### PR TITLE
Version 0.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oscar"
 uuid = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
 authors = ["William Hart <goodwillhart@googlemail.com>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ julia> using Oscar
  -----    -----    -----   -     -  -     -  
 
 ...combining (and extending) GAP, Hecke, Nemo, Polymake and Singular
-Version 0.2.0 ... 
+Version 0.3.0 ... 
  ... which comes with absolutely no warranty whatsoever
 Type: '?Oscar' for more information
 (c) 2019-2020 by The Oscar Development Team


### PR DESCRIPTION
@fieker please merge & register if you agree.

I would have preferred to have a new GAP.jl ready, too, but that won't work out as of right now.

So I suggest we get this out now, so that the segfaults people get when installing are fixed. Then hopefully later this week we can get out 0.3.1 with a newer GAP or so.

Why 0.3.0 and not 0.2.1? Good question; I thought it might be a good idea because of the new major versions of Singular.jl and Polymake.jl, and because GAP is now in the mix. But writing this now, I am not so sure... I am also fine if this is called 0.2.1 instead. Your call (for now); I'll be back in the afternoon.