### PR TITLE
Groups: a few small suggestions

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -137,9 +137,7 @@ end
 
 
 function _maxgroup(x::T, y::T) where T <: GAPGroup
-   if x == y
-     return x
-   elseif GAP.Globals.IsSubset(x.X, y.X)
+   if GAP.Globals.IsSubset(x.X, y.X)
      return x
    elseif GAP.Globals.IsSubset(y.X, x.X)
      return y
@@ -185,8 +183,8 @@ Return the one element of the parent of x.
 Base.one(x::GAPGroupElem) = one(parent(x))
 one!(x::GAPGroupElem) = one(parent(x))
 
-Base.show(io::IO, x::GAPGroupElem) =  print(io, GAP.gap_to_julia(GAP.Globals.StringView(x.X)))
-Base.show(io::IO, x::GAPGroup) = print(io, GAP.gap_to_julia(GAP.Globals.StringView(x.X)))
+Base.show(io::IO, x::GAPGroupElem) =  print(io, GAP.gap_to_julia(GAP.Globals.StringViewObj(x.X)))
+Base.show(io::IO, x::GAPGroup) = print(io, GAP.gap_to_julia(GAP.Globals.StringViewObj(x.X)))
 
 Base.isone(x::GAPGroupElem) = x == one(parent(x))
 
@@ -406,9 +404,9 @@ end
 Base.hash(x::GroupConjClass) = 0 # FIXME
 
 function Base.show(io::IO, x::GroupConjClass)
-  print(io, GAP.gap_to_julia(GAP.Globals.StringView(x.repr)),
+  print(io, GAP.gap_to_julia(GAP.Globals.StringViewObj(x.repr)),
             " ^ ",
-            GAP.gap_to_julia(GAP.Globals.StringView(x.X)))
+            GAP.gap_to_julia(GAP.Globals.StringViewObj(x.X)))
 end
 
 function _conjugacy_class(G, g, cc::GapObj)         # function for assignment
@@ -473,8 +471,9 @@ false, nothing
 ```
 """
 function isconjugate(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)
-   if GAP.Globals.IsConjugate(G.X, x.X, y.X)
-      return true, group_element(G,GAP.Globals.RepresentativeAction(G.X, x.X, y.X))
+   conj = GAP.Globals.RepresentativeAction(G.X, x.X, y.X)
+   if conj != GAP.Globals.fail
+      return true, group_element(G, conj)
    else
       return false, nothing
    end
@@ -535,8 +534,9 @@ false, nothing
 ```
 """
 function isconjugate(G::GAPGroup, H::GAPGroup, K::GAPGroup)
-   if GAP.Globals.IsConjugate(G.X, H.X, K.X)
-      return true, group_element(G,GAP.Globals.RepresentativeAction(G.X, H.X, K.X))
+   conj = GAP.Globals.RepresentativeAction(G.X, H.X, K.X)
+   if conj != GAP.Globals.fail
+      return true, group_element(G, conj)
    else
       return false, nothing
    end
@@ -713,10 +713,12 @@ Return (``true``,``p``) if |`G`| is a non-trivial ``p``-power, (``false``,nothin
 """
 function ispgroup(G::GAPGroup)
    if GAP.Globals.IsPGroup(G.X)
-      return true, GAP.Globals.PrimePGroup(G.X)
-   else
-      return false, nothing
+      p = GAP.Globals.PrimePGroup(G.X)
+      if p != GAP.Globals.fail
+         return true, p
+      end
    end
+   return false, nothing
 end
 
 function relators(G::FPGroup)

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -62,8 +62,8 @@ function left_coset(H::GAPGroup, g::GAPGroupElem)
 end
 
 function show(io::IO, x::GroupCoset)
-   a = GAP.gap_to_julia(GAP.Globals.StringView(x.H.X))
-   b = GAP.gap_to_julia(GAP.Globals.StringView(x.repr.X))
+   a = GAP.gap_to_julia(GAP.Globals.StringViewObj(x.H.X))
+   b = GAP.gap_to_julia(GAP.Globals.StringViewObj(x.repr.X))
    if x.side == :right
       print(io, a, " * ", b)
    else
@@ -188,11 +188,11 @@ function ==(x::GroupDoubleCoset, y::GroupDoubleCoset)
 end
 
 function Base.show(io::IO, x::GroupDoubleCoset)
-  print(io, GAP.gap_to_julia(GAP.Globals.StringView(x.H.X)),
+  print(io, GAP.gap_to_julia(GAP.Globals.StringViewObj(x.H.X)),
             " * ",
-            GAP.gap_to_julia(GAP.Globals.StringView(x.repr.X)),
+            GAP.gap_to_julia(GAP.Globals.StringViewObj(x.repr.X)),
             " * ",
-            GAP.gap_to_julia(GAP.Globals.StringView(x.K.X)))
+            GAP.gap_to_julia(GAP.Globals.StringViewObj(x.K.X)))
 end
 
 """

--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -56,6 +56,8 @@ end
 
 function issymmetric_group(G::GAPGroup)
   return GAP.Globals.IsSymmetricGroup(G.X)
+#T perhaps rather GAP.Globals.IsNaturalSymmetricGroup(G.X),
+#T or even something else?
 end
 
 """
@@ -74,6 +76,8 @@ end
 
 function isalternating_group(G::GAPGroup)
   return GAP.Globals.IsAlternatingGroup(G.X)
+#T perhaps rather GAP.Globals.IsNaturalAlternatingGroup(G.X),
+#T or even something else?
 end
 
 cyclic_group(n::Int) = cyclic_group(PcGroup, n)


### PR DESCRIPTION
- `ispgroup` does not behave as documented if the argument is a trivial group:
  In GAP, trivial groups are regarded as p-groups, thus the result of `GAP.Globals.IsPGroup` is `true`) but `GAP.Globals.PrimePGroup` returns `fail`.
  According to the documentation in Oscar, the result should be `false, nothing`.
  Of course, we could also change the definition such that `true, nothing` is returned for trivial groups.

- In `isconjugate` (two methods), calling first `GAP.Globals.IsConjugate` and then `GAP.Globals.RepresentativeAction` means to do the work twice.
  Instead, one should call `GAP.Globals.RepresentativeAction` directly.

- The `==` check in `maxgroup` is unnecessary, it checks more than the subset relation.
  (If one thinks it is a usual case that the two arguments are identical then one could check this with `===`.)

- I propose to use `GAP.Globals.StringViewObj` instead of `GAP.Globals.StringView`.
  Both are intended to return a string that looks exactly like GAP's `ViewObj` output, but the latter runs into errors for some GAP objects.

- Open question:
  Concerning `issymmetric_group` and `isalternating_group`, there is no documentation that tells what the result shall be, and the functions are not used in the code.
  Currently these functions delegate to `GAP.Globals.IsSymmetricGroup` and `GAP.Globals.IsAlternatingGroup`, respectively, which means that `true` shall be returned if the group in question is isomorphic to a symmetric or alternating group.
  I guess that `GAP.Globals.IsNaturalSymmetricGroup` and `GAP.Globals.IsNaturalAlternatingGroup` would be more appropriate; their results express whether the group is a permutation group that acts on its moved points as a symmetric/alternating group.
  Even that may be too general if one wants to test whether the group is a symmetric/alternating group on the points from 1 to some n; note that `symmetric_group` admits only the degree as an argument, not a set of moved points.