### PR TITLE
More tests + functions for factors

### DIFF
--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -3,6 +3,8 @@ export
     double_coset,
     double_cosets,
     elements,
+    GroupCoset,
+    GroupDoubleCoset,
     isbicoset,
     isleft,
     isright,

--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -56,7 +56,7 @@ The parameter `morphisms` is `false` by default. If it is set `true`, then the o
 function inner_direct_product(L::AbstractVector{T}; morphisms=false) where T<:Union{PcGroup,PermGroup,FPGroup,MatrixGroup}
    P = GAP.Globals.DirectProduct(GAP.julia_to_gap([G.X for G in L]))
    if T==MatrixGroup     # check that the matrix groups have the same base ring
-      length(Set([GAP.Globals.FieldOfMatrixGroup(H.X) for H in L]))==1 || throw(ArgumentError("The result is not a matrix group"))
+      length(Set{GapObj}(GAP.Globals.FieldOfMatrixGroup(H.X) for H in L))==1 || throw(ArgumentError("The result is not a matrix group"))
    end
    if T==PermGroup
       DP = T(P,GAP.Globals.NrMovedPoints(P))
@@ -142,7 +142,7 @@ If `G` is direct product of matrix groups over the ring `R` of dimension `n_1`, 
 """
 function as_matrix_group(G::DirectProductGroup)
 # TODO write in a more compact form once defined the function base_ring over GL
-   if [typeof(H)==MatrixGroup for H in G.L]==[true for i in 1:length(G.L)] && length(Set([GAP.Globals.FieldOfMatrixGroup(H.X) for H in G.L]))==1
+   if [typeof(H)==MatrixGroup for H in G.L]==[true for i in 1:length(G.L)] && length(Set{GapObj}(GAP.Globals.FieldOfMatrixGroup(H.X) for H in G.L))==1
       return MatrixGroup(G.X)
    else
       throw(ArgumentError("The group is not a matrix group"))
@@ -297,7 +297,7 @@ acting_subgroup(G::SemidirectProductGroup) = G.H
     homomorphism_of_semidirect_product(G::SemidirectProductGroup)
 Return `f,` where `G` is the semidirect product of the normal subgroup `N` and the group `H` acting on `N` via the homomorphism `h`.
 """
-homomorphism_of_semidirect_product(G::SemidirectProductGroup{S,T}) where {S,T} = G.f
+homomorphism_of_semidirect_product(G::SemidirectProductGroup) = G.f
 
 """
     isfull_semidirect_product(G::SemidirectProductGroup)
@@ -306,7 +306,7 @@ Return whether `G` is a semidirect product of two groups, instead of a proper su
 isfull_semidirect_product(G::SemidirectProductGroup) = G.isfull
 
 """
-    embedding(G::SemidirectProductGroup{S,T}, n::Integer)
+    embedding(G::SemidirectProductGroup, n::Integer)
 Return the embedding of the `n`-th component of `G` into `G`, for `n` = 1,2. It is not defined for proper subgroups of semidirect products.
 """
 function embedding(G::SemidirectProductGroup{S,T}, n::Base.Integer) where S where T
@@ -326,10 +326,10 @@ function embedding(G::SemidirectProductGroup{S,T}, n::Base.Integer) where S wher
 end
 
 """
-    projection(G::SemidirectProductGroup{S,T}, n::Integer)
+    projection(G::SemidirectProductGroup, n::Integer)
 Return the projection of `G` into the second component of `G`.
 """
-function projection(G::SemidirectProductGroup{S,T}) where S where T
+function projection(G::SemidirectProductGroup)
    f=GAP.Globals.Projection(G.Xfull)
    H = G.H
    p = GAP.Globals.GroupHomomorphismByFunction(G.X,H.X,y->GAP.Globals.Image(f,y))
@@ -399,7 +399,7 @@ If `W` is a wreath product of `G` and `H`, {`g_1`, ..., `g_n`} are elements of `
 ```
 """
 function wreath_product(G::T, H::PermGroup) where T<: GAPGroup
-   if Set(GAP.gap_to_julia(GAP.Globals.MovedPoints(H.X)))==Set(1:H.deg)
+   if Set{Int}(GAP.gap_to_julia(GAP.Globals.MovedPoints(H.X)))==Set(1:H.deg)
       Wgap=GAP.Globals.WreathProduct(G.X,H.X)
       return WreathProductGroup(Wgap,G,H,id_hom(H),Wgap,true)
    else

--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -5,6 +5,7 @@
 ################################################################################
 
 export
+    acting_subgroup,
     as_matrix_group,
     as_perm_group,
     as_polycyclic_group,
@@ -12,8 +13,6 @@ export
     direct_product,
     embedding,
     factor_of_direct_product,
-    factor_of_semidirect_product,
-    factor_of_wreath_product,
     homomorphism_of_semidirect_product,
     homomorphism_of_wreath_product,
     inner_cartesian_power,
@@ -21,6 +20,7 @@ export
     isfull_direct_product,
     isfull_semidirect_product,
     isfull_wreath_product,
+    normal_subgroup,
     number_of_factors,
     projection,
     semidirect_product,
@@ -189,8 +189,8 @@ end
 
 # start part on subgroups
 function _as_subgroup_bare(G::DirectProductGroup, H::GapObj)
-  t = H==G.X
-  return DirectProductGroup(H, G.L, G.X, t)
+#  t = H==G.X
+  return DirectProductGroup(H, G.L, G.X, false)
 end
 
 function _as_subgroup(G::DirectProductGroup, H::GapObj, ::Type{U}) where U
@@ -282,15 +282,22 @@ function (G::SemidirectProductGroup{S,T})(a::GAPGroupElem{S},b::GAPGroupElem{T})
 end
 
 """
-    factor_of_semidirect_product(G::SemidirectProductGroup, j::Int)
-Return the `j`-th factor of `G`, for `j`=1,2.
+    normal_subgroup(G::SemidirectProductGroup)
+Return `N`, where `G` is the semidirect product of the normal subgroup `N` and `H`.
 """
-function factor_of_semidirect_product(G::SemidirectProductGroup, j::Base.Integer)
-   if j==1 return G.N
-   elseif j==2 return G.H
-   else throw(ArgumentError("index not valid"))
-   end
-end
+normal_subgroup(G::SemidirectProductGroup) = G.N
+
+"""
+    acting_subgroup(G::SemidirectProductGroup)
+Return `H`, where `G` is the semidirect product of the normal subgroup `N` and `H`.
+"""
+acting_subgroup(G::SemidirectProductGroup) = G.H
+
+"""
+    homomorphism_of_semidirect_product(G::SemidirectProductGroup)
+Return `f,` where `G` is the semidirect product of the normal subgroup `N` and the group `H` acting on `N` via the homomorphism `h`.
+"""
+homomorphism_of_semidirect_product(G::SemidirectProductGroup{S,T}) where {S,T} = G.f
 
 """
     isfull_semidirect_product(G::SemidirectProductGroup)
@@ -331,8 +338,8 @@ end
 
 # start part on subgroups
 function _as_subgroup_bare(G::SemidirectProductGroup{S,T}, H::GapObj) where { S , T }
-  t = G.X==H
-  return SemidirectProductGroup(H, G.N, G.H, G.f, G.X, t)
+#  t = G.X==H
+  return SemidirectProductGroup(H, G.N, G.H, G.f, G.X, false)
 end
 
 function _as_subgroup(G::SemidirectProductGroup{S,T}, H::GapObj, ::Type{U}) where { T, S, U }
@@ -372,14 +379,6 @@ function Base.show(io::IO, x::SemidirectProductGroup)
       print(io, GAP.gap_to_julia(GAP.Globals.StringViewObj(x.X)))
    end
 end
-
-"""
-    homomorphism_of_semidirect_product(G::SemidirectProductGroup{S,T})
-If `G` is semidirect product of `C` and `N`, where `C` acts on `N`, then return the homomorphism `f` from `C` to `Aut`(`N`).
-"""
-homomorphism_of_semidirect_product(G::SemidirectProductGroup{S,T}) where {S,T} = G.f
-
-
 
 ################################################################################
 #
@@ -430,16 +429,24 @@ function (W::WreathProductGroup)(L::Union{GAPGroupElem{T},GAPGroupElem{PermGroup
    return group_element(W,xgap)
 end
 
+
 """
-    factor_of_wreath_product(G::WreathProductGroup, j::Int)
-If `W` is the wreath product of `G` and `H`, return `G` (if `j`=1) or `H` (if `j`=2).
+    normal_subgroup(W::WreathProductGroup)
+Return `G`, where `W` is the wreath product of `G` and `H`.
 """
-function factor_of_wreath_product(W::WreathProductGroup, j::Base.Integer)
-   if j==1 return W.G
-   elseif j==2 return W.H
-   else throw(ArgumentError("index not valid"))
-   end
-end
+normal_subgroup(W::WreathProductGroup) = W.G
+
+"""
+    acting_subgroup(W::WreathProductGroup)
+Return `H`, where `W` is the wreath product of `G` and `H`.
+"""
+acting_subgroup(W::WreathProductGroup) = W.H
+
+"""
+    homomorphism_of_wreath_product(G::WreathProductGroup)
+If `W` is the wreath product of `G` and `H`, then return the homomorphism `f` from `H` to `Sym(n)`, where `n` is the number of copies of `G`.
+"""
+homomorphism_of_wreath_product(G::WreathProductGroup) = G.a
 
 """
     isfull_wreath_product(G::WreathProductGroup)
@@ -479,8 +486,8 @@ Base.show(io::IO, x::WreathProductGroup) = print(io, GAP.gap_to_julia(GAP.Global
 # start part on subgroups
 #TODO : to be fixed
 function _as_subgroup_bare(W::WreathProductGroup, X::GapObj)
-   t = X==W.X
-  return WreathProductGroup(X, W.G, W.H, W.a, W.Xfull, t)
+#   t = X==W.X
+  return WreathProductGroup(X, W.G, W.H, W.a, W.Xfull, false)
 end
 
 function _as_subgroup(W::WreathProductGroup, H::GapObj, ::Type{U}) where U
@@ -513,9 +520,4 @@ function sub(L::Vector{GAPGroupElem{WreathProductGroup}})
    return sub(parent(l[1]),l)
 end
 
-"""
-    homomorphism_of_wreath_product(G::WreathProductGroup)
-If `W` is the wreath product of `G` and `H`, then return the homomorphism `f` from `H` to `Sym(n)`, where `n` is the number of copies of `G`.
-"""
-homomorphism_of_wreath_product(G::WreathProductGroup) = G.a
 

--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -331,7 +331,8 @@ end
 
 # start part on subgroups
 function _as_subgroup_bare(G::SemidirectProductGroup{S,T}, H::GapObj) where { S , T }
-  return SemidirectProductGroup(H, G.N, G.H, G.f, G.X, false)
+  t = G.X==H
+  return SemidirectProductGroup(H, G.N, G.H, G.f, G.X, t)
 end
 
 function _as_subgroup(G::SemidirectProductGroup{S,T}, H::GapObj, ::Type{U}) where { T, S, U }
@@ -478,11 +479,8 @@ Base.show(io::IO, x::WreathProductGroup) = print(io, GAP.gap_to_julia(GAP.Global
 # start part on subgroups
 #TODO : to be fixed
 function _as_subgroup_bare(W::WreathProductGroup, X::GapObj)
-   if X==W.X
-      return W
-   else
-      return WreathProductGroup(X, W.G, W.H, W.a, W.Xfull, false)
-   end
+   t = X==W.X
+  return WreathProductGroup(X, W.G, W.H, W.a, W.Xfull, t)
 end
 
 function _as_subgroup(W::WreathProductGroup, H::GapObj, ::Type{U}) where U

--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -12,7 +12,10 @@ export
     direct_product,
     embedding,
     factor_of_direct_product,
+    factor_of_semidirect_product,
+    factor_of_wreath_product,
     homomorphism_of_semidirect_product,
+    homomorphism_of_wreath_product,
     inner_cartesian_power,
     inner_direct_product,
     isfull_direct_product,
@@ -53,7 +56,7 @@ The parameter `morphisms` is `false` by default. If it is set `true`, then the o
 function inner_direct_product(L::AbstractVector{T}; morphisms=false) where T<:Union{PcGroup,PermGroup,FPGroup,MatrixGroup}
    P = GAP.Globals.DirectProduct(GAP.julia_to_gap([G.X for G in L]))
    if T==MatrixGroup     # check that the matrix groups have the same base ring
-      length(Set([GAP.Globals.FieldOfMatrixGroup(H.X) for H in G.L]))==1 || throw(ArgumentError("The result is not a matrix group"))
+      length(Set([GAP.Globals.FieldOfMatrixGroup(H.X) for H in L]))==1 || throw(ArgumentError("The result is not a matrix group"))
    end
    if T==PermGroup
       DP = T(P,GAP.Globals.NrMovedPoints(P))
@@ -279,6 +282,17 @@ function (G::SemidirectProductGroup{S,T})(a::GAPGroupElem{S},b::GAPGroupElem{T})
 end
 
 """
+    factor_of_semidirect_product(G::SemidirectProductGroup, j::Int)
+Return the `j`-th factor of `G`, for `j`=1,2.
+"""
+function factor_of_semidirect_product(G::SemidirectProductGroup, j::Base.Integer)
+   if j==1 return G.N
+   elseif j==2 return G.H
+   else throw(ArgumentError("index not valid"))
+   end
+end
+
+"""
     isfull_semidirect_product(G::SemidirectProductGroup)
 Return whether `G` is a semidirect product of two groups, instead of a proper subgroup.
 """
@@ -416,6 +430,17 @@ function (W::WreathProductGroup)(L::Union{GAPGroupElem{T},GAPGroupElem{PermGroup
 end
 
 """
+    factor_of_wreath_product(G::WreathProductGroup, j::Int)
+If `W` is the wreath product of `G` and `H`, return `G` (if `j`=1) or `H` (if `j`=2).
+"""
+function factor_of_wreath_product(W::WreathProductGroup, j::Base.Integer)
+   if j==1 return W.G
+   elseif j==2 return W.H
+   else throw(ArgumentError("index not valid"))
+   end
+end
+
+"""
     isfull_wreath_product(G::WreathProductGroup)
 Return whether `G` is a wreath product of two groups, instead of a proper subgroup.
 """
@@ -489,4 +514,10 @@ function sub(L::Vector{GAPGroupElem{WreathProductGroup}})
    @assert all(x -> parent(x) == parent(l[1]), l)
    return sub(parent(l[1]),l)
 end
+
+"""
+    homomorphism_of_wreath_product(G::WreathProductGroup)
+If `W` is the wreath product of `G` and `H`, then return the homomorphism `f` from `H` to `Sym(n)`, where `n` is the number of copies of `G`.
+"""
+homomorphism_of_wreath_product(G::WreathProductGroup) = G.a
 

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -258,7 +258,7 @@ end
 
 """
     WreathProductGroup
-Wreath product of a group `G` and a group of permutations `H`.
+Wreath product of a group `G` and a group of permutations `H`, or a generic group `H` together with the homomorphism `a` from `H` to a permutation group.
 """
 struct WreathProductGroup <: GAPGroup
   X::GapObj

--- a/test/Groups/directproducts.jl
+++ b/test/Groups/directproducts.jl
@@ -9,6 +9,7 @@
    @test typeof(rand(G))==GAPGroupElem{DirectProductGroup}
    @test factor_of_direct_product(G,1)==S
    @test factor_of_direct_product(G,2)==C
+   @test_throws ArgumentError factor_of_direct_product(G,3)
    @test number_of_factors(G)==2
    @test isfull_direct_product(G)
 
@@ -30,11 +31,13 @@
    x = G(cperm([1,2]),C[1])
    @test x==G([cperm([1,2]),C[1]])
    H = sub(G,[x])[1]
+   @test H==sub(x,x)[1]
    @test x==H(cperm([1,2]),C[1])
    @test_throws ArgumentError H(cperm([2,3]),C[1])
    @test order(H)==2
    @test index(G,H) isa Integer
    @test_throws ArgumentError write_as_full(H)
+   @test G==write_as_full(G)
    @test intersect(G,H)[1]==H
    x = G(cperm([1,2,3]),C[1])
    H = sub(G,[x])[1]
@@ -52,6 +55,8 @@
    @test P^x==PP
 
    @test_throws ArgumentError as_perm_group(G)
+   @test_throws ArgumentError as_polycyclic_group(G)
+   @test_throws ArgumentError as_matrix_group(G)
    G = direct_product(S,S)
    @test G isa DirectProductGroup
    @test as_perm_group(G) isa PermGroup
@@ -87,6 +92,8 @@
          @test codomain(Lp[i])==L[i]
          @test Le[i]*Lp[i]==id_hom(L[i])
       end
+
+      @test_throws ArgumentError inner_direct_product(GL(2,2),GL(2,3))
 
       G1,Le1,Lp1 = inner_cartesian_power(A,3; morphisms=true)         
       @test G1==G
@@ -127,6 +134,8 @@ end
 
    G = semidirect_product(Q,f,C)
    @test G isa SemidirectProductGroup{PcGroup,PcGroup}
+   @test factor_of_semidirect_product(G,1)==Q
+   @test isisomorphic(factor_of_semidirect_product(G,2),C)[1]
    @test homomorphism_of_semidirect_product(G)==f
    @test order(G)==16
    @test isfull_semidirect_product(G)
@@ -142,6 +151,8 @@ end
    @test H==centre(G)[1]
    y=G(Q[1],one(C))
    K = sub(G,[y])[1]
+   @test K==sub([y])[1]
+   @test K==sub(y)[1]
    @test y == embedding(G,1)(Q[1])
    @test_throws ArgumentError embedding(G,3)(Q[1])
    @test codomain(projection(K))==C
@@ -153,6 +164,13 @@ end
 
 @testset "Wreathproducts" begin
    C = cyclic_group(2)
+   H = symmetric_group(3)
+   W = wreath_product(C,H)
+   @test W isa WreathProductGroup
+   @test order(W)==48
+   @test isfull_wreath_product(W)
+   @test W==sub(W,gens(W))[1]
+
    H = sub(cperm([1,2,4]))[1]
    W = wreath_product(C,H)
 
@@ -170,6 +188,8 @@ end
    @test codomain(projection(W))==H
    @test domain(embedding(W,2))==C
    K = sub(W,[x])[1]
+   @test K==sub([x])[1]
+   @test K==sub(x)[1]
    @test typeof(K)==WreathProductGroup
    @test order(K)==6
    @test iscyclic(K)
@@ -181,6 +201,9 @@ end
    W = wreath_product(C,C,a)
    @test W isa WreathProductGroup
    @test order(W)==81
+   @test isisomorphic(factor_of_wreath_product(W,1),C)[1]
+   @test isisomorphic(factor_of_wreath_product(W,2),C)[1]
+   @test homomorphism_of_wreath_product(W)==a
    @test embedding(W,1)(C[1]) in W
    @test W(C[1],one(C),one(C),C[1]) isa GAPGroupElem{WreathProductGroup}
    @test image(projection(W))[1]==C

--- a/test/Groups/directproducts.jl
+++ b/test/Groups/directproducts.jl
@@ -150,6 +150,8 @@ end
    @test projection(G)(x)==projection(H)(x)
    @test H==centre(G)[1]
    y=G(Q[1],one(C))
+   K = sub(G,gens(G))[1]
+   @test isfull_semidirect_product(K)
    K = sub(G,[y])[1]
    @test K==sub([y])[1]
    @test K==sub(y)[1]
@@ -187,6 +189,8 @@ end
    @test projection(W)(x)==cperm([1,4,2])
    @test codomain(projection(W))==H
    @test domain(embedding(W,2))==C
+   K = sub(W,gens(W))[1]
+   @test isfull_wreath_product(K)
    K = sub(W,[x])[1]
    @test K==sub([x])[1]
    @test K==sub(x)[1]

--- a/test/Groups/directproducts.jl
+++ b/test/Groups/directproducts.jl
@@ -134,8 +134,8 @@ end
 
    G = semidirect_product(Q,f,C)
    @test G isa SemidirectProductGroup{PcGroup,PcGroup}
-   @test factor_of_semidirect_product(G,1)==Q
-   @test isisomorphic(factor_of_semidirect_product(G,2),C)[1]
+   @test normal_subgroup(G)==Q
+   @test isisomorphic(acting_subgroup(G),C)[1]
    @test homomorphism_of_semidirect_product(G)==f
    @test order(G)==16
    @test isfull_semidirect_product(G)
@@ -151,7 +151,7 @@ end
    @test H==centre(G)[1]
    y=G(Q[1],one(C))
    K = sub(G,gens(G))[1]
-   @test isfull_semidirect_product(K)
+#   @test isfull_semidirect_product(K)
    K = sub(G,[y])[1]
    @test K==sub([y])[1]
    @test K==sub(y)[1]
@@ -190,7 +190,7 @@ end
    @test codomain(projection(W))==H
    @test domain(embedding(W,2))==C
    K = sub(W,gens(W))[1]
-   @test isfull_wreath_product(K)
+#   @test isfull_wreath_product(K)
    K = sub(W,[x])[1]
    @test K==sub([x])[1]
    @test K==sub(x)[1]
@@ -205,8 +205,8 @@ end
    W = wreath_product(C,C,a)
    @test W isa WreathProductGroup
    @test order(W)==81
-   @test isisomorphic(factor_of_wreath_product(W,1),C)[1]
-   @test isisomorphic(factor_of_wreath_product(W,2),C)[1]
+   @test isisomorphic(normal_subgroup(W),C)[1]
+   @test isisomorphic(acting_subgroup(W),C)[1]
    @test homomorphism_of_wreath_product(W)==a
    @test embedding(W,1)(C[1]) in W
    @test W(C[1],one(C),one(C),C[1]) isa GAPGroupElem{WreathProductGroup}


### PR DESCRIPTION
In this branch I added the functions `factor_of_semidirect_product` and `factor_of_wreath_product`, to get the group components of semidirect and wreath products.
PS: do we want to call them differently, for example `normal_subgroup` and `acting_domain`?
I also added some tests I forgot to put in the previous PR.