### PR TITLE
a few fixes and suggestions concerning groups

### DIFF
--- a/docs/src/Groups/groups.md
+++ b/docs/src/Groups/groups.md
@@ -59,9 +59,9 @@ Oscar supports the following operations and functions on group elements.
 * `*` = multiplication between two elements in a group.
 * `inv(x)` = ``x^{-1}`` the inverse of `x`.
 * `x/y` = the element ``xy^{-1}``.
-* `x^n` = the ``n``-th power of `x`. If ``n = 0``, the identity of the group is returned; if ``n < 0 ``, the ``n``-th power of the inverse of `x` is returned.
+* `x^n` = the ``n``-th power of `x`. If ``n = 0``, the identity of the group is returned; if ``n < 0 ``, the ``-n``-th power of the inverse of `x` is returned.
 * `isone(x)`: returns whether `x` is the identity of the group.
-* `conj(x,y)` = `x^y` = the conjugate of `x` by `y`, i.e. the element ``x^{-1}yx``.
+* `conj(x,y)` = `x^y` = the conjugate of `x` by `y`, i.e. the element ``y^{-1}xy``.
 * `comm(x,y)` = the commutator of `x` and `y`, i.e. the element ``x^{-1}y^{-1}xy``.
 
 !!! note

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -142,7 +142,7 @@ function _maxgroup(x::T, y::T) where T <: GAPGroup
    # but GAP's `IsSubset` check is not as cheap as one wants;
    # there is an `IsSubset` method that checks for identity,
    # but it is not always the first choice.
-   if GAP.Globals.IsIdenticalObj(x.X, y.X)
+   if x.X === y.X
      return x
    elseif GAP.Globals.IsSubset(x.X, y.X)
      return x
@@ -610,7 +610,7 @@ normal_closure(G::T, H::T) where T<:GAPGroup = _as_subgroup(G, GAP.Globals.Norma
 Return `C,f`, where `C` is the `p`-core (i.e. the largest normal `p`-subgroup) of `G` and `f` is the embedding morphism of `C` into `G`.
 """
 function pcore(G::GAPGroup, p::Int64)
-   if !GAP.Globals.IsPrimeInt(p)
+   if !isprime(p)
       throw(ArgumentError("p is not a prime"))
    end
    return _as_subgroup(G, GAP.Globals.PCore(G.X,p))
@@ -663,7 +663,7 @@ socle(G::GAPGroup) = _as_subgroup(G, GAP.Globals.Socle(G.X))
 Return a Sylow `p`-subgroup of `G`.
 """
 function sylow_subgroup(G::GAPGroup, p::Int64)
-   if !GAP.Globals.IsPrime(p)
+   if !isprime(p)
       throw(ArgumentError("p is not a prime"))
    end
    return _as_subgroup(G,GAP.Globals.SylowSubgroup(G.X,p))
@@ -676,7 +676,7 @@ Return a Hall `P`-subgroup of `G`. It works only if `G` is solvable.
 function hall_subgroup(G::GAPGroup, P::AbstractVector{<:Base.Integer})
    P = unique(P)
    for p in P
-      if !GAP.Globals.IsPrime(p)
+      if !isprime(p)
          throw(ArgumentError("The integers must be prime"))
       end
    end

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -239,11 +239,13 @@ end
 
 """
     cokernel(f::GAPGroupHomomorphism)
-Return the cokernel of `f`.
+Return the cokernel of `f`, that is, the quotient of the codomain of `f`
+by the normal closure of the image.
 """
 function cokernel(f::GAPGroupHomomorphism)
   K, mK = image(f)
-  return quo(codomain(f), K)
+  C = codomain(f)
+  return quo(C, normal_closure(C, K))
 end
 
 """

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -245,7 +245,7 @@ by the normal closure of the image.
 function cokernel(f::GAPGroupHomomorphism)
   K, mK = image(f)
   C = codomain(f)
-  return quo(C, normal_closure(C, K))
+  return quo(C, normal_closure(C, K)[1])
 end
 
 """

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -35,6 +35,7 @@ import Hecke:
     mul,
     mul!,
     ngens,
+    normal_closure,
     one!,
     order,
     perm,


### PR DESCRIPTION
- fixed two errors in the documentation

- fixed `cokernel` (needs `normal_closure`)

- fixed the `show` method for conjugacy classes

- inserted an `IsIdenticalObj` check in `_maxgroup`
  (perhaps this is rather a GAP problem, but for the moment,
  the change seems to make sense)

- added `normal_closure` for two groups,
  under the assumption that the "small" group is a subgroup of the "big" one;
  GAP does *not* assume this, thus we have a problem here:
  The assumption should be checked, but this can be expensive;
  thus a user should at least have a chance to omit the check.
  And in order to get the flexibility of GAP's `NormalClosure`,
  something such as GAP's `ClosureGroup` can be introduced
  --I think we will need this anyhow, sooner or later.

- call `GAP.Globals.IsPrimeInt` instead of `GAP.Globals.IsPrime`,
  this avoids some overhead on the GAP side;
  since we know that the number in question is an `Int64`,
  a perhaps better alternative would be to call Nemo's `isprime`.