### PR TITLE
in (membership test) for groups

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -239,6 +239,8 @@ end
 # need this function just for the iterator
 Base.length(x::GAPGroup)::Int = order(x)
 
+Base.in(g::GAPGroupElem, G::GAPGroup) = GAP.Globals.in(g.X, G.X)
+
 # FIXME: clashes with AbstractAlgebra.perm method
 #function perm(L::AbstractVector{<:Base.Integer})
 #   return PermGroupElem(symmetric_group(length(L)), GAP.Globals.PermList(GAP.julia_to_gap(L)))

--- a/test/Groups/operations.jl
+++ b/test/Groups/operations.jl
@@ -18,7 +18,7 @@
 
       @test x isa PermGroupElem
       @test ox isa Int64
-#      @test inv(x) in G                        this takes a lot of time
+      @test inv(x) in G
       @test mul(x,y) == x*y
       @test mul!(x,x,y) == x*y
       @test inv(x)==x^-1


### PR DESCRIPTION
Added an `in` method for a group element and a group, which delegates to GAP's `in`;
note that Julia's default method uses the iterator for the group to run over the elements.