### PR TITLE
Adapted groebner_basis command

### DIFF
--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -537,9 +537,10 @@ function groebner_basis(I::MPolyIdeal)
   return collect(I.gb)
 end
 
-function groebner_basis(I::MPolyIdeal, ord::Symbol)
+function groebner_basis(I::MPolyIdeal, ord::Symbol; complete_reduction::Bool=false)
   R = singular_ring(base_ring(I), ord)
-  i = Singular.std(Singular.Ideal(R, [convert(R, x) for x = gens(I)]))
+  !Oscar.Singular.has_global_ordering(R) && error("The ordering has to be a global ordering.")
+  i = Singular.std(Singular.Ideal(R, [convert(R, x) for x = gens(I)]), complete_reduction = complete_reduction)
   return collect(BiPolyArray(base_ring(I), i))
 end
 

--- a/test/Rings/mpoly-test.jl
+++ b/test/Rings/mpoly-test.jl
@@ -54,3 +54,11 @@ end
   @test jacobi_matrix(f) == matrix(R, 2, 1, [2*x, 2*y])
   @test jacobi_matrix(I) == matrix(R, 2, 2, [2*x, 4*x^3*y-y^3, 2*y, x^4-3*x*y^2])
 end
+
+@testset "Groebner" begin
+  R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+  I = ideal([2*x+3*y+4*z-5,3*x+4*y+5*z-2])
+  @test groebner_basis(I,:degrevlex) == [y+2*z-11, 3*x+4*y+5*z-2]
+  @test groebner_basis(I,:degrevlex, complete_reduction = true) == [y+2*z-11, x-z+14]
+  
+end


### PR DESCRIPTION
Changed groebner_basis command, such that it accepts "complete_reduction" as a boolean input in order to compute a reduced groebner basis.
Also added a check to exclude non global orderings.
Tests added.