### PR TITLE
Fix import statement for julia 1.3

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1,6 +1,6 @@
 # further possible functions: similar, literal_pow, parent_type
 
-import Base.:^, Base.Vector
+import Base: ^, Base.Vector
 
 export GroupConjClass
 

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -34,8 +34,7 @@ The following ones are commonly used.
 ##  on `GAP.GapObj` objects to the corresponding GAP action,
 ##  and to implement the action on native Julia objects case by case.
 
-import Base.:^
-import Base.:*
+import Base: ^, *
 
 export on_tuples, on_sets, on_indeterminates, permuted
 


### PR DESCRIPTION
On 1.3 this gives the following error (and it is not clear why the `.` should be there at all).
```
julia> import Base.:^
ERROR: syntax: invalid "import" statement: expected identifier
Stacktrace:
 [1] top-level scope at none:0
```
