### PR TITLE
Fix README.md badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Forschungsgemeinschaft DFG within the
 [docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
 [docs-stable-url]: https://oscar-system.github.io/Oscar.jl/stable/
 
-[ga-image]: https://github.com/oscar-system/Oscar.jl/workflows/Run%20tests/badge.svg
+[ga-img]: https://github.com/oscar-system/Oscar.jl/workflows/Run%20tests/badge.svg
 [ga-url]: https://github.com/oscar-system/Oscar.jl/actions?query=workflow%3A%22Run+tests%22
 
 [codecov-img]: https://codecov.io/gh/oscar-system/Oscar.jl/branch/master/graph/badge.svg


### PR DESCRIPTION
Oops, seems I merged PR #181 too soon.

Anyway, that new badge now is permanently red, because the tests with Julia nightly fails (Polymake.jl resp. its JLLs need changes to work with Julia master again, @benlorenz already knows about that).

Perhaps we can split the `CI.yml` file into two, one which has the expected-pass tests, and one which has the expected-fail; then I assume they'll get separate badges?