### PR TITLE
WIP -- install GAP packages at runtime only if necessary

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 AbstractAlgebra = "^0.9.1, 0.10"
 DocStringExtensions = "0.8"
-GAP = "0.4"
+GAP = "0.4.5"
 Hecke = "^0.8.0"
 Nemo = "^0.18.0"
 Polymake = "^0.4, ^0.5"

--- a/examples/GaloisGrp.jl
+++ b/examples/GaloisGrp.jl
@@ -10,8 +10,7 @@ export galois_group, transitive_group_identification, slpoly_ring
 
 
 function __init__()
-  GAP.Packages.install("ferret")
-  GAP.Packages.load("ferret")
+  GAP.Packages.load("ferret", install = true)
 
   Hecke.add_verbose_scope(:GaloisGroup)
   Hecke.add_verbose_scope(:GaloisInvariant)


### PR DESCRIPTION
as soon as GAP.jl supports this (from version 0.4.5 on), see oscar-system/GAP.jl/pull/555