### PR TITLE
first conversions between GAP and Nemo

### DIFF
--- a/src/GAP/gap_to_oscar.jl
+++ b/src/GAP/gap_to_oscar.jl
@@ -1,0 +1,41 @@
+## conversions of GAP objects to Oscar objects
+## (extends the conversions from GAP.jl's `src/gap_to_julia.jl` and
+## `src/constructors.jl`, where low level Julia objects are treated)
+
+import GAP: gap_to_julia
+import Nemo: FlintIntegerRing, FlintRationalField, MatrixSpace, fmpz, fmpq, fmpz_mat, fmpq_mat
+
+## GAP integer to `fmpz`
+GAP.gap_to_julia(::Type{fmpz}, obj::Union{GAP.GapObj, Int64}) = fmpz(BigInt(obj))
+
+fmpz(obj::GAP.GapObj) = gap_to_julia(fmpz, obj)
+
+(::FlintIntegerRing)(obj::GAP.GapObj) = gap_to_julia(fmpz, obj)
+
+## large GAP rational or integer to `fmpq`
+function GAP.gap_to_julia(::Type{fmpq}, obj::Union{GAP.GapObj, Int64})
+    GAP.Globals.IsRat(obj) || throw(GAP.ConversionError(obj, fmpq))
+    return fmpq(BigInt(GAP.Globals.NumeratorRat(obj)), BigInt(GAP.Globals.DenominatorRat(obj)))
+end
+
+fmpq(obj::GAP.GapObj) = gap_to_julia(fmpq, obj)
+
+(::FlintRationalField)(obj::GAP.GapObj) = gap_to_julia(fmpq, obj)
+
+## matrix of GAP integers to `fmpz_mat`
+function GAP.gap_to_julia(::Type{fmpz_mat}, obj::GAP.GapObj)
+    m = GAP.gap_to_julia(Matrix{fmpz}, obj)
+    return fmpz_mat(size(m, 1), size(m, 2), m)
+end
+
+fmpz_mat(obj::GAP.GAP.GapObj) = gap_to_julia(fmpz_mat, obj)
+
+## matrix of GAP rationals or integers to `fmpq_mat`
+function GAP.gap_to_julia(::Type{fmpq_mat}, obj::GAP.GapObj)
+    m = GAP.gap_to_julia(Matrix{fmpq}, obj)
+#   return fmpq_mat(size(m, 1), size(m, 2), m) # corrupted object!
+    S = MatrixSpace(FlintRationalField(), size(m, 1), size(m, 2))
+    return S(m)
+end
+
+fmpq_mat(obj::GAP.GAP.GapObj) = gap_to_julia(fmpq_mat, obj)

--- a/src/GAP/gap_to_oscar.jl
+++ b/src/GAP/gap_to_oscar.jl
@@ -6,16 +6,18 @@ import GAP: gap_to_julia
 import Nemo: FlintIntegerRing, FlintRationalField, MatrixSpace, fmpz, fmpq, fmpz_mat, fmpq_mat
 
 ## GAP integer to `fmpz`
-GAP.gap_to_julia(::Type{fmpz}, obj::Union{GAP.GapObj, Int64}) = fmpz(BigInt(obj))
+GAP.gap_to_julia(::Type{fmpz}, obj::GAP.GapObj) = fmpz(BigInt(obj))
+GAP.gap_to_julia(::Type{fmpz}, obj::Int64) = fmpz(obj)
 
 fmpz(obj::GAP.GapObj) = gap_to_julia(fmpz, obj)
 
 (::FlintIntegerRing)(obj::GAP.GapObj) = gap_to_julia(fmpz, obj)
 
 ## large GAP rational or integer to `fmpq`
-function GAP.gap_to_julia(::Type{fmpq}, obj::Union{GAP.GapObj, Int64})
+GAP.gap_to_julia(::Type{fmpq}, obj::Int64) = fmpq(obj)
+function GAP.gap_to_julia(::Type{fmpq}, obj::GAP.GapObj)
     GAP.Globals.IsRat(obj) || throw(GAP.ConversionError(obj, fmpq))
-    return fmpq(BigInt(GAP.Globals.NumeratorRat(obj)), BigInt(GAP.Globals.DenominatorRat(obj)))
+    return fmpq(fmpz(GAP.Globals.NumeratorRat(obj)), fmpz(GAP.Globals.DenominatorRat(obj)))
 end
 
 fmpq(obj::GAP.GapObj) = gap_to_julia(fmpq, obj)
@@ -34,8 +36,7 @@ fmpz_mat(obj::GAP.GAP.GapObj) = gap_to_julia(fmpz_mat, obj)
 function GAP.gap_to_julia(::Type{fmpq_mat}, obj::GAP.GapObj)
     m = GAP.gap_to_julia(Matrix{fmpq}, obj)
 #   return fmpq_mat(size(m, 1), size(m, 2), m) # corrupted object!
-    S = MatrixSpace(FlintRationalField(), size(m, 1), size(m, 2))
-    return S(m)
+    return matrix(FlintQQ, m)
 end
 
 fmpq_mat(obj::GAP.GAP.GapObj) = gap_to_julia(fmpq_mat, obj)

--- a/src/GAP/oscar_to_gap.jl
+++ b/src/GAP/oscar_to_gap.jl
@@ -4,6 +4,10 @@
 
 import GAP: julia_to_gap
 
+## WORKAROUND: the following method is also defined in GAP.jl, but apparently
+## we need to redefine it here, otherwise it doesn't work
+GAP.julia_to_gap(obj::Any; recursive::Bool) = GAP.julia_to_gap(obj)
+
 ## `fmpz` to GAP integer
 GAP.julia_to_gap(obj::fmpz) = GAP.julia_to_gap(BigInt(obj))
 

--- a/src/GAP/oscar_to_gap.jl
+++ b/src/GAP/oscar_to_gap.jl
@@ -1,0 +1,17 @@
+## conversions of Oscar objects to GAP objects
+## (extends the conversions from GAP.jl's `src/julia_to_gap.jl`,
+## where low level Julia objects are treated)
+
+import GAP: julia_to_gap
+
+## `fmpz` to GAP integer
+GAP.julia_to_gap(obj::fmpz) = GAP.julia_to_gap(BigInt(obj))
+
+## `fmpq` to GAP rational
+GAP.julia_to_gap(obj::fmpq) = GAP.Globals.QUO(GAP.julia_to_gap(numerator(obj)), GAP.julia_to_gap(denominator(obj)))
+
+## `fmpz_mat` to matrix of GAP integers
+GAP.julia_to_gap(obj::fmpz_mat) = GAP.julia_to_gap(Matrix(obj), recursive = true)
+
+## `fmpq_mat` to matrix of GAP rationals or integers
+GAP.julia_to_gap(obj::fmpq_mat) = GAP.julia_to_gap(Matrix(obj), recursive = true)

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -172,6 +172,10 @@ end
 include("OscarTypes.jl")
 
 include("Groups/types.jl")
+
+include("GAP/gap_to_oscar.jl")
+include("GAP/oscar_to_gap.jl")
+
 include("Groups/group_constructors.jl")
 include("Groups/sub.jl")
 include("Groups/homomorphisms.jl")

--- a/test/GAP/gap_to_oscar.jl
+++ b/test/GAP/gap_to_oscar.jl
@@ -1,0 +1,113 @@
+@testset "fmpz" begin
+    # small (GAP) integer
+    x = fmpz(17)
+    val = 17
+    @test GAP.gap_to_julia(fmpz, val) == x
+    @test convert(fmpz, val) == x
+    @test fmpz(val) == x
+    @test ZZ(val) == x
+
+    # large GAP integer
+    x = fmpz(2)^65
+    val = GAP.evalstr("2^65")
+    @test GAP.gap_to_julia(fmpz, val) == x
+    @test convert(fmpz, val) == x
+    @test fmpz(val) == x
+    @test ZZ(val) == x
+
+    # non-integer
+    val = GAP.evalstr("1/2")
+    @test_throws GAP.ConversionError GAP.gap_to_julia(fmpz, val)
+end
+
+@testset "fmpq" begin
+    # small (GAP) integer
+    x = fmpq(17)
+    val = 17
+    @test GAP.gap_to_julia(fmpq, val) == x
+    @test convert(fmpq, val) == x
+    @test fmpq(val) == x
+    @test QQ(val) == x
+
+    # large GAP integer
+    x = fmpq(2)^65
+    val = GAP.evalstr("2^65")
+    @test GAP.gap_to_julia(fmpq, val) == x
+    @test convert(fmpq, val) == x
+    @test fmpq(val) == x
+    @test QQ(val) == x
+
+    # non-integer rational, small numerator and denominator
+    x = fmpq(2, 3)
+    val = GAP.evalstr("2/3")
+    @test GAP.gap_to_julia(fmpq, val) == x
+    @test convert(fmpq, val) == x
+    @test fmpq(val) == x
+    @test QQ(val) == x
+
+    # non-integer rational, large numerator and denominator
+    x = fmpq(fmpz(2)^65, fmpz(3)^40)
+    val = GAP.evalstr("2^65/3^40")
+    @test GAP.gap_to_julia(fmpq, val) == x
+    @test convert(fmpq, val) == x
+    @test fmpq(val) == x
+    @test QQ(val) == x
+
+    # non-rational
+    val = GAP.evalstr("()")
+    @test_throws GAP.ConversionError GAP.gap_to_julia(fmpq, val)
+end
+
+@testset "fmpz_mat" begin
+    # matrix of small (GAP) integers
+    x = Nemo.ZZ[1 2; 3 4]
+    val = GAP.evalstr( "[ [ 1, 2 ], [ 3, 4 ] ]" )
+    @test GAP.gap_to_julia(fmpz_mat, val) == x
+    @test convert(fmpz_mat, val) == x
+    @test fmpz_mat(val) == x
+
+    # matrix containing small and large integers
+    x = Nemo.ZZ[1 BigInt(2)^65; 3 4]
+    val = GAP.evalstr( "[ [ 1, 2^65 ], [ 3, 4 ] ]" )
+    @test GAP.gap_to_julia(fmpz_mat, val) == x
+    @test convert(fmpz_mat, val) == x
+    @test fmpz_mat(val) == x
+
+    # matrix containing non-integers
+    val = GAP.evalstr( "[ [ 1/2, 2 ], [ 3, 4 ] ]" )
+    @test_throws GAP.ConversionError GAP.gap_to_julia(fmpz_mat, val)
+end
+
+@testset "fmpq_mat" begin
+    # matrix of small (GAP) integers
+    x = Nemo.QQ[1 2; 3 4]
+    val = GAP.evalstr( "[ [ 1, 2 ], [ 3, 4 ] ]" )
+    @test GAP.gap_to_julia(fmpq_mat, val) == x
+    @test convert(fmpq_mat, val) == x
+    @test fmpq_mat(val) == x
+
+    # matrix containing small and large integers
+    x = Nemo.QQ[1 BigInt(2)^65; 3 4]
+    val = GAP.evalstr( "[ [ 1, 2^65 ], [ 3, 4 ] ]" )
+    @test GAP.gap_to_julia(fmpq_mat, val) == x
+    @test convert(fmpq_mat, val) == x
+    @test fmpq_mat(val) == x
+
+    # matrix containing non-integer rationals, small numerator and denominator
+    x = Nemo.QQ[fmpq(1, 2) 2; 3 4]
+    val = GAP.evalstr( "[ [ 1/2, 2 ], [ 3, 4 ] ]" )
+    @test GAP.gap_to_julia(fmpq_mat, val) == x
+    @test convert(fmpq_mat, val) == x
+    @test fmpq_mat(val) == x
+
+    # matrix containing non-integer rationals, large numerator and denominator
+    x = Nemo.QQ[fmpq(fmpz(2)^65, fmpz(3)^40) 2; 3 4]
+    val = GAP.evalstr( "[ [ 2^65/3^40, 2 ], [ 3, 4 ] ]" )
+    @test GAP.gap_to_julia(fmpq_mat, val) == x
+    @test convert(fmpq_mat, val) == x
+    @test fmpq_mat(val) == x
+
+    # matrix containing non-rationals
+    val = GAP.evalstr( "[ [ E(4), 2 ], [ 3, 4 ] ]" )
+    @test_throws GAP.ConversionError GAP.gap_to_julia(fmpq_mat, val)
+end

--- a/test/GAP/oscar_to_gap.jl
+++ b/test/GAP/oscar_to_gap.jl
@@ -1,0 +1,91 @@
+@testset "fmpz" begin
+    # small (GAP) integer
+    x = fmpz(17)
+    val = 17
+    @test GAP.julia_to_gap(x) == val
+    @test convert(GAP.GapObj, x) == val
+    @test GAP.GapObj(x) == val
+
+    # large GAP integer
+    x = fmpz(2)^65
+    val = GAP.evalstr("2^65")
+    @test GAP.julia_to_gap(x) == val
+    @test convert(GAP.GapObj, x) == val
+    @test GAP.GapObj(x) == val
+end
+
+@testset "fmpq" begin
+    # small (GAP) integer
+    x = fmpz(17)
+    val = 17
+    @test GAP.julia_to_gap(x) == val
+    @test convert(GAP.GapObj, x) == val
+    @test GAP.GapObj(x) == val
+
+    # large GAP integer
+    x = fmpz(2)^65
+    val = GAP.evalstr("2^65")
+    @test GAP.julia_to_gap(x) == val
+    @test convert(GAP.GapObj, x) == val
+    @test GAP.GapObj(x) == val
+
+    # non-integer rational, small numerator and denominator
+    x = fmpq(2, 3)
+    val = GAP.evalstr("2/3")
+    @test GAP.julia_to_gap(x) == val
+    @test convert(GAP.GapObj, x) == val
+    @test GAP.GapObj(x) == val
+
+    # non-integer rational, large numerator and denominator
+    x = fmpq(fmpz(2)^65, fmpz(3)^40)
+    val = GAP.evalstr("2^65/3^40")
+    @test GAP.julia_to_gap(x) == val
+    @test convert(GAP.GapObj, x) == val
+    @test GAP.GapObj(x) == val
+end
+
+@testset "fmpz_mat" begin
+    # matrix of small (GAP) integers
+    x = Nemo.ZZ[1 2; 3 4]
+    val = GAP.evalstr( "[ [ 1, 2 ], [ 3, 4 ] ]" )
+    @test GAP.julia_to_gap(x) == val
+    @test convert(GAP.GapObj, x) == val
+    @test GAP.GapObj(x) == val
+
+    # matrix containing small and large integers
+    x = Nemo.ZZ[1 BigInt(2)^65; 3 4]
+    val = GAP.evalstr( "[ [ 1, 2^65 ], [ 3, 4 ] ]" )
+    @test GAP.julia_to_gap(x) == val
+    @test convert(GAP.GapObj, x) == val
+    @test GAP.GapObj(x) == val
+end
+
+@testset "fmpq_mat" begin
+    # matrix of small (GAP) integers
+    x = Nemo.QQ[1 2; 3 4]
+    val = GAP.evalstr( "[ [ 1, 2 ], [ 3, 4 ] ]" )
+    @test GAP.julia_to_gap(x) == val
+    @test convert(GAP.GapObj, x) == val
+    @test GAP.GapObj(x) == val
+
+    # matrix containing small and large integers
+    x = Nemo.QQ[1 BigInt(2)^65; 3 4]
+    val = GAP.evalstr( "[ [ 1, 2^65 ], [ 3, 4 ] ]" )
+    @test GAP.julia_to_gap(x) == val
+    @test convert(GAP.GapObj, x) == val
+    @test GAP.GapObj(x) == val
+
+    # matrix containing non-integer rationals, small numerator and denominator
+    x = Nemo.QQ[fmpq(1, 2) 2; 3 4]
+    val = GAP.evalstr( "[ [ 1/2, 2 ], [ 3, 4 ] ]" )
+    @test GAP.julia_to_gap(x) == val
+    @test convert(GAP.GapObj, x) == val
+    @test GAP.GapObj(x) == val
+
+    # matrix containing non-integer rationals, large numerator and denominator
+    x = Nemo.QQ[fmpq(fmpz(2)^65, fmpz(3)^40) 2; 3 4]
+    val = GAP.evalstr( "[ [ 2^65/3^40, 2 ], [ 3, 4 ] ]" )
+    @test GAP.julia_to_gap(x) == val
+    @test convert(GAP.GapObj, x) == val
+    @test GAP.GapObj(x) == val
+end

--- a/test/GAP/runtests.jl
+++ b/test/GAP/runtests.jl
@@ -1,0 +1,5 @@
+using Oscar
+using Test
+
+include("gap_to_oscar.jl")
+include("oscar_to_gap.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using Oscar
 using Test
 
+include("GAP/runtests.jl")
+
 include("Rings/integer-test.jl")
 include("Rings/rational-test.jl")
 include("Rings/mpoly-test.jl")


### PR DESCRIPTION
- conversions (in both directions) via `julia_to_gap`, `gap_to_julia`, `convert`, and the relevant constructors,
  between `fmpz`, `fmpq`, `fmpz_mat`, `fmpq_mat` on the one side, and the corresponding GAP objects on the other side
- some tests for these conversions

The idea is to collect useful conversions between GAP objects and those Oscar objects that are not known to the plain GAP.jl into the `src/GAP` directory of Oscar.jl.

This is a first attempt to support such conversions.
I am not sure which constructors are really relevant here, thus I am expecting feedback from the Nemo experts.
For example, calling `fmpz` etc. on GAP objects looks natural, but `fmpz` etc. are not documented;
and `fmpq_mat` is definitely not intended to be called by a user, since its output is not valid.