### PR TITLE
SLPolyRing: A couple fixes to make it more usable 

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -40,7 +40,7 @@ using Markdown, Test, Requires
 export Nemo, Hecke, Singular, Polymake, AbstractAlgebra, GAP
 
 import AbstractAlgebra: @show_name, @show_special, elem_type, force_coerce, force_op,
-                        parent_type
+                        parent_type, expressify
 
 function __init__()
   if isinteractive()

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -40,7 +40,7 @@ using Markdown, Test, Requires
 export Nemo, Hecke, Singular, Polymake, AbstractAlgebra, GAP
 
 import AbstractAlgebra: @show_name, @show_special, elem_type, force_coerce, force_op,
-                        parent_type, expressify
+                        parent_type, expressify, canonical_unit
 
 function __init__()
   if isinteractive()

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -39,7 +39,8 @@ using Markdown, Test, Requires
 # possibly all should add a doc string to the module?
 export Nemo, Hecke, Singular, Polymake, AbstractAlgebra, GAP
 
-import AbstractAlgebra: @show_name, @show_special, force_coerce, force_op
+import AbstractAlgebra: @show_name, @show_special, elem_type, force_coerce, force_op,
+                        parent_type
 
 function __init__()
   if isinteractive()

--- a/src/Rings/lazypolys.jl
+++ b/src/Rings/lazypolys.jl
@@ -1,7 +1,7 @@
 using .StraightLinePrograms: SLProgram
 const SLP = StraightLinePrograms
 
-using AbstractAlgebra: AbstractAlgebra, Ring, RingElement, RingElem, MPolyRing, MPolyElem, elem_type, Generic
+using AbstractAlgebra: AbstractAlgebra, Ring, RingElement, RingElem, MPolyRing, MPolyElem, Generic
 
 import AbstractAlgebra: base_ring, gen, gens, ngens, nvars, symbols, evaluate, addeq!
 

--- a/src/Rings/slpolys.jl
+++ b/src/Rings/slpolys.jl
@@ -133,6 +133,11 @@ end
 Base.zero(p::SLPoly) = zero(parent(p))
 Base.one(p::SLPoly) = one(parent(p))
 
+# we don't know easily, in general, whether an SLPoly is zero or one, so assume it isn't
+# TODO: handle correctly simple cases (e.g. empty underlying sl-program)
+Base.iszero(p::SLPoly) = false
+Base.isone(p::SLPoly) = false
+
 function Base.copy!(p::SLPoly{T}, q::SLPoly{T}) where {T}
     check_parent(p, q)
     copy!(p.slprogram, q.slprogram)

--- a/src/Rings/slpolys.jl
+++ b/src/Rings/slpolys.jl
@@ -20,6 +20,8 @@ SLPolyRing(r::Ring, v::Pair{<:Union{String,Symbol},
 
 base_ring(S::SLPolyRing) = S.base_ring
 
+elem_type(::Type{S}) where {T,S<:SLPolyRing{T}} = SLPoly{T,S}
+
 symbols(S::SLPolyRing) = S.S
 
 # have to constrain T <: RingElement so that this is more specific than the second
@@ -114,6 +116,8 @@ function assert_valid(p::SLPoly)
 end
 
 parent(p::SLPoly) = p.parent
+
+parent_type(::Type{SLPoly{T,SLPR}}) where {T,SLPR} = SLPR
 
 function check_parent(p::SLPoly, q::SLPoly)
     p.parent === q.parent ||

--- a/src/Rings/slpolys.jl
+++ b/src/Rings/slpolys.jl
@@ -152,10 +152,12 @@ SLP.nsteps(p::SLPoly) = SLP.nsteps(p.slprogram)
 
 ## show
 
-function Base.show(io::IO, p::SLPoly)
+function Base.show(io::IO, ::MIME"text/plain", p::SLPoly)
     io = IOContext(io, :SLPsymbols => symbols(parent(p)))
     show(io, p.slprogram)
 end
+
+Base.show(io::IO, p::SLPoly) = show(io, "text/plain", p)
 
 
 ## mutating ops

--- a/src/Rings/slpolys.jl
+++ b/src/Rings/slpolys.jl
@@ -134,6 +134,13 @@ Base.zero(p::SLPoly) = zero(parent(p))
 Base.one(p::SLPoly) = one(parent(p))
 canonical_unit(p::SLPoly) = one(p) # required by AA's Rings interface
 
+# TODO: could be optimized by not creating an intermediate SLProgram
+function zero!(p::SLPoly)
+    z = zero(p)
+    copy!(p.slprogram, z.slprogram)
+    p
+end
+
 # we don't know easily, in general, whether an SLPoly is zero or one, so assume it isn't
 # TODO: handle correctly simple cases (e.g. empty underlying sl-program)
 Base.iszero(p::SLPoly) = false

--- a/src/Rings/slpolys.jl
+++ b/src/Rings/slpolys.jl
@@ -230,6 +230,12 @@ end
 
 addeq!(p::SLPoly{T}, q::SLPoly{T}) where {T} = SLP.combine!(SLP.plus, p, q)
 
+function add!(r::SLPoly{T}, p::SLPoly{T}, q::SLPoly{T}) where {T}
+    copy!(r.slprogram, p.slprogram)
+    addeq!(r, q)
+    r
+end
+
 SLP.subeq!(p::SLPoly{T}, q::SLPoly{T}) where {T} = SLP.combine!(SLP.minus, p, q)
 
 function SLP.subeq!(p::SLPoly)
@@ -238,6 +244,12 @@ function SLP.subeq!(p::SLPoly)
 end
 
 SLP.muleq!(p::SLPoly{T}, q::SLPoly{T}) where {T} = SLP.combine!(SLP.times, p, q)
+
+function mul!(r::SLPoly{T}, p::SLPoly{T}, q::SLPoly{T}) where {T}
+    copy!(r.slprogram, p.slprogram)
+    SLP.muleq!(r, q)
+    r
+end
 
 function SLP.expeq!(p::SLPoly, e::Base.Integer)
     SLP.combine!(SLP.exponentiate, p.slprogram, e)

--- a/src/Rings/slpolys.jl
+++ b/src/Rings/slpolys.jl
@@ -132,6 +132,7 @@ end
 
 Base.zero(p::SLPoly) = zero(parent(p))
 Base.one(p::SLPoly) = one(parent(p))
+canonical_unit(p::SLPoly) = one(p) # required by AA's Rings interface
 
 # we don't know easily, in general, whether an SLPoly is zero or one, so assume it isn't
 # TODO: handle correctly simple cases (e.g. empty underlying sl-program)

--- a/test/Rings/slpolys-test.jl
+++ b/test/Rings/slpolys-test.jl
@@ -125,6 +125,9 @@ end
     p = SLPoly(S, SLP.SLProgram{Int}())
     @test p isa SLPoly{Int,typeof(S)} <: MPolyElem{Int}
     @test parent(p) === S
+    @test parent_type(p) == parent_type(typeof(p)) == typeof(S)
+    @test elem_type(S) == elem_type(typeof(S)) == typeof(p)
+
     p = SLPoly(S)
     @test p isa SLPoly{Int,typeof(S)} <: MPolyElem{Int}
     @test parent(p) === S

--- a/test/Rings/slpolys-test.jl
+++ b/test/Rings/slpolys-test.jl
@@ -190,7 +190,7 @@ end
     l7 = SLP.pushop!(p, SLP.exponentiate, l5, SLP.Arg(2)) # ((1+x)y)^2
     l8 = SLP.pushop!(p, SLP.minus, l6, l7) # xy - ((1+x)y)^2
     SLP.pushfinalize!(p, l8)
-    @test string(p) == "((x*y) - ((1 + x)*y)^2)"
+    @test string(p) == "x*y - ((1 + x)*y)^2"
     @test SLP.evaluate!(Int[], p, [2, 3]) == -75
     @test SLP.evaluate!(Int[], p, [-2, -1]) == 1
 
@@ -343,4 +343,17 @@ end
     # we just want to test that this works and looks correct
     @test p ==  0 + 1*(1*X^1*Y^0) + 1*(1*X^0*Y^1)
     =#
+
+    @testset "SLPolyRing is a proper Ring" begin
+    S, (x1, x2) = Oscar.SLPolynomialRing(QQ, 2)
+    St, t = PolynomialRing(S, "t")
+
+        @testset "show" begin
+            @test string(x1) == "x1"
+            @test string(-x1*QQ(2, 3)*x2^3) == "-x1*2//3*x2^3"
+            @test string(x1-x2+x1) == "x1 - x2 + x1"
+            @test string(2-x2) == "2 - x2"
+            @test string(2t+3) == "2*t + 3"
+        end
+    end
 end

--- a/test/Rings/slpolys-test.jl
+++ b/test/Rings/slpolys-test.jl
@@ -337,12 +337,10 @@ end
     R, (x, y) = PolynomialRing(AbstractAlgebra.zz, ["x", "y"])
     S = SLPolyRing(AbstractAlgebra.zz, [:x, :y])
     X, Y = gens(S)
-    #= TODO: make it pass, fail due to AA upgrade
     p = evaluate(x+y, [X, Y])
     # this is bad to hardcode exactly how evaluation of `x+y` happens,
     # we just want to test that this works and looks correct
-    @test p ==  0 + 1*(1*X^1*Y^0) + 1*(1*X^0*Y^1)
-    =#
+    @test p ==  0 + 1*(1*X^1) + 1*(1*Y^1)
 
     @testset "SLPolyRing is a proper Ring" begin
         S, (x1, x2) = Oscar.SLPolynomialRing(QQ, 2)
@@ -364,5 +362,8 @@ end
         @test string(q) == "x1*x2"
         @test q === add!(q, x1, x2)
         @test string(q) == "x1 + x2"
+
+        r = prod(t-y for y = gens(S))
+        @test string(r) == "t^2 + (-x2 - x1)*t + x1*x2"
     end
 end

--- a/test/Rings/slpolys-test.jl
+++ b/test/Rings/slpolys-test.jl
@@ -139,6 +139,9 @@ end
     @test one(p) == one(S)
     @test one(p) isa SLPoly{Int}
 
+    @test !isone(p)
+    @test !iszero(p)
+
     # copy
     q = SLPoly(S)
     # TODO: do smthg more interesting with q

--- a/test/Rings/slpolys-test.jl
+++ b/test/Rings/slpolys-test.jl
@@ -99,11 +99,10 @@ end
     @test nvars(S) == 2
     @test string(x0) == "x"
     @test string(y0) == "y"
-    # TODO: make replstr pass, fail to AA upgrade
-#    @test replstr(x0) == "x"
-#    @test replstr(y0) == "y"
+    @test replstr(x0) == "x"
+    @test replstr(y0) == "y"
     @test string(S(2)) == "2"
-#    @test replstr(S(2)) == "2"
+    @test replstr(S(2)) == "2"
 
     for x in (gen(S, 1), x0)
         @test string(x) == "x"

--- a/test/Rings/slpolys-test.jl
+++ b/test/Rings/slpolys-test.jl
@@ -345,8 +345,8 @@ end
     =#
 
     @testset "SLPolyRing is a proper Ring" begin
-    S, (x1, x2) = Oscar.SLPolynomialRing(QQ, 2)
-    St, t = PolynomialRing(S, "t")
+        S, (x1, x2) = Oscar.SLPolynomialRing(QQ, 2)
+        St, t = PolynomialRing(S, "t")
 
         @testset "show" begin
             @test string(x1) == "x1"
@@ -355,5 +355,9 @@ end
             @test string(2-x2) == "2 - x2"
             @test string(2t+3) == "2*t + 3"
         end
+
+        q = x1+x2
+        @test q === zero!(q)
+        @test string(q) == "0" # can't test with iszero, which currently always return false
     end
 end

--- a/test/Rings/slpolys-test.jl
+++ b/test/Rings/slpolys-test.jl
@@ -359,5 +359,10 @@ end
         q = x1+x2
         @test q === zero!(q)
         @test string(q) == "0" # can't test with iszero, which currently always return false
+
+        @test q === mul!(q, x1, x2)
+        @test string(q) == "x1*x2"
+        @test q === add!(q, x1, x2)
+        @test string(q) == "x1 + x2"
     end
 end


### PR DESCRIPTION
Fix #195, #196. cc @fieker 

@tthsqe12: I actually had no choice but to implement `expressify` when `SLPolyRing` is used as the base ring of another polynomial ring. I hadn't looked closely until now, but the `expressify` system looks quite nice! Is there a simple test I can add to make sure that I got correctly the handling of the `context` keyword argument?