### PR TITLE
Faster conversion GAP <-> fmpz

### DIFF
--- a/src/GAP/gap_to_oscar.jl
+++ b/src/GAP/gap_to_oscar.jl
@@ -6,8 +6,11 @@ import GAP: gap_to_julia
 import Nemo: FlintIntegerRing, FlintRationalField, MatrixSpace, fmpz, fmpq, fmpz_mat, fmpq_mat
 
 ## GAP integer to `fmpz`
-GAP.gap_to_julia(::Type{fmpz}, obj::GAP.GapObj) = fmpz(BigInt(obj))
 GAP.gap_to_julia(::Type{fmpz}, obj::Int64) = fmpz(obj)
+function GAP.gap_to_julia(::Type{fmpz}, obj::GAP.GapObj)
+    GAP.Globals.IsInt(obj) || throw(GAP.ConversionError(obj, fmpz))
+    GC.@preserve obj fmpz(GAP.ADDR_OBJ(obj), div(GAP.SIZE_OBJ(obj), sizeof(Int)))
+end
 
 fmpz(obj::GAP.GapObj) = gap_to_julia(fmpz, obj)
 

--- a/src/GAP/oscar_to_gap.jl
+++ b/src/GAP/oscar_to_gap.jl
@@ -5,7 +5,13 @@
 import GAP: julia_to_gap
 
 ## `fmpz` to GAP integer
-GAP.julia_to_gap(obj::fmpz) = GAP.julia_to_gap(BigInt(obj))
+function GAP.julia_to_gap(obj::fmpz)
+  Nemo._fmpz_is_small(obj) && return GAP.julia_to_gap(Int(obj))
+  GC.@preserve obj begin
+    x = Nemo._as_bigint(obj)
+    return ccall(:MakeObjInt, GapObj, (Ptr{UInt64}, Cint), x.d, x.size)
+  end
+end
 
 ## `fmpq` to GAP rational
 GAP.julia_to_gap(obj::fmpq) = GAP.Globals.QUO(GAP.julia_to_gap(numerator(obj)), GAP.julia_to_gap(denominator(obj)))


### PR DESCRIPTION
This is a draft because we can not yet switch to the newer Nemo.jl required by this PR; see PR #218 for the state of that.

Suppose the development version of Oscar.jl was loaded and the following assignments were made:

    x = @gap 5^200;
    y = fmpz(5)^200;

Before this patch:

    julia> @btime GAP.gap_to_julia(fmpz, x);
      254.204 ns (4 allocations: 112 bytes)

    julia> @btime GAP.julia_to_gap(y);
      215.226 ns (5 allocations: 192 bytes)

After this patch:

    julia> @btime GAP.gap_to_julia(fmpz, x);
      83.054 ns (1 allocation: 16 bytes)

    julia> @btime GAP.julia_to_gap(y);
      41.068 ns (2 allocations: 96 bytes)

Resolves #202 