### PR TITLE
Removed convert function from mpoly.jl

### DIFF
--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -136,14 +136,14 @@ end
 
 function Base.getindex(A::BiPolyArray, ::Val{:S}, i::Int)
   if !isdefined(A, :S)
-    A.S = Singular.Ideal(A.Sx, [convert(A.Sx, x) for x = A.O])
+    A.S = Singular.Ideal(A.Sx, [A.Sx(x) for x = A.O])
   end
   return A.S[i]
 end
 
 function Base.getindex(A::BiPolyArray, ::Val{:O}, i::Int)
   if !isassigned(A.O, i)
-    A.O[i] = convert(A.Ox, A.S[i])
+    A.O[i] = A.Ox(A.S[i])
   end
   return A.O[i]
 end
@@ -178,7 +178,16 @@ Base.eltype(::BiPolyArray{S}) where S = S
 # singular_ring(Nemo-Ring) tries to create the appropriate Ring
 #
 
-function Base.convert(Ox::MPolyRing, f::MPolyElem) 
+function (Sx::Singular.PolyRing{S})(f::T) where {S<:RingElem, T<:MPolyElem}
+  O = base_ring(Sx)
+  g = MPolyBuildCtx(Sx)
+  for (c, e) = Base.Iterators.zip(MPolyCoeffs(f), MPolyExponentVectors(f))
+    push_term!(g, O(c), e)
+  end
+  return finish(g)
+end
+
+function (Ox::MPolyRing)(f::MPolyElem) 
   O = base_ring(Ox)
   g = MPolyBuildCtx(Ox)
   for (c, e) = Base.Iterators.zip(MPolyCoeffs(f), MPolyExponentVectors(f))
@@ -192,7 +201,6 @@ function (S::Singular.Rationals)(a::fmpq)
   return S(b)
 end
 
-(Ox::MPolyRing)(f::MPolyElem) = convert(Ox, f)
 (F::Singular.N_ZpField)(a::Nemo.gfp_elem) = F(lift(a))
 (F::Singular.N_ZpField)(a::Nemo.nmod) = F(lift(a))
 (F::Nemo.GaloisField)(a::Singular.n_Zp) = F(Int(a))
@@ -370,14 +378,14 @@ end
 
 function singular_assure(I::BiPolyArray)
   if !isdefined(I, :S)
-    I.S = Singular.Ideal(I.Sx, [convert(I.Sx, x) for x = I.O])
+    I.S = Singular.Ideal(I.Sx, [I.Sx(x) for x = I.O])
   end
 end
 
 
 function oscar_assure(I::MPolyIdeal)
   if !isdefined(I.gens, :O)
-    I.gens.O = [convert(I.gens.Ox, x) for x = gens(I.gens.S)]
+    I.gens.O = [I.gens.Ox(x) for x = gens(I.gens.S)]
   end
 end
 
@@ -457,13 +465,13 @@ end
 function groebner_basis(B::BiPolyArray; ord::Symbol = :degrevlex, complete_reduction::Bool = false)
   if ord != :degrevlex
     R = singular_ring(B.Ox, ord)
-    i = Singular.Ideal(R, [convert(R, x) for x = B])
+    i = Singular.Ideal(R, [R(x) for x = B])
 #    @show "std on", i, B
     i = Singular.std(i, complete_reduction = complete_reduction)
     return BiPolyArray(B.Ox, i)
   end
   if !isdefined(B, :S)
-    B.S = Singular.Ideal(B.Sx, [convert(B.Sx, x) for x = B.O])
+    B.S = Singular.Ideal(B.Sx, [B.Sx(x) for x = B.O])
   end
 #  @show "dtd", B.S
   return BiPolyArray(B.Ox, Singular.std(B.S, complete_reduction = complete_reduction))
@@ -472,18 +480,18 @@ end
 function groebner_basis_with_transform(B::BiPolyArray; ord::Symbol = :degrevlex, complete_reduction::Bool = false)
   if ord != :degrevlex
     R = singular_ring(B.Ox, ord)
-    i = Singular.Ideal(R, [convert(R, x) for x = B])
+    i = Singular.Ideal(R, [R(x) for x = B])
 #    @show "std on", i, B
     i, m = Singular.lift_std(i, complete_reduction = complete_reduction)
-    return BiPolyArray(B.Ox, i), map_entries(x->convert(B.Ox, x), m)
+    return BiPolyArray(B.Ox, i), map_entries(x->B.Ox(x), m)
   end
   if !isdefined(B, :S)
-    B.S = Singular.Ideal(B.Sx, [convert(B.Sx, x) for x = B.O])
+    B.S = Singular.Ideal(B.Sx, [B.Sx(x) for x = B.O])
   end
 #  @show "dtd", B.S
 
   i, m = Singular.lift_std(B.S, complete_reduction = complete_reduction)
-  return BiPolyArray(B.Ox, i), map_entries(x->convert(B.Ox, x), m)
+  return BiPolyArray(B.Ox, i), map_entries(x->B.Ox(x), m)
 end
 
 function map_entries(R, M::Singular.smatrix)
@@ -498,7 +506,7 @@ function syzygy_module(a::Array{MPolyElem, 1})
 end
 
 
-function convert(F::Generic.FreeModule, s::Singular.svector)
+function (F::Generic.FreeModule)(s::Singular.svector)
   pv = Tuple{Int, elem_type(base_ring(F))}[]
   pos = Int[]
   values = []
@@ -527,7 +535,7 @@ function syzygy_generators(a::Array{<:MPolyElem, 1})
   s = Singular.syz(I.gens.S)
   F = free_module(parent(a[1]), length(a))
   @assert rank(s) == length(a)
-  return [convert(F, s[i]) for i=1:Singular.ngens(s)]
+  return [F(s[i]) for i=1:Singular.ngens(s)]
 end
 
 function dim(I::MPolyIdeal)
@@ -542,7 +550,7 @@ end
 function Base.in(f::MPolyElem, I::MPolyIdeal)
   groebner_assure(I)
   Sx = base_ring(I.gb.S)
-  return Singular.iszero(reduce(convert(Sx, f), I.gb.S))
+  return Singular.iszero(reduce(Sx(f), I.gb.S))
 end
 
 function base_ring(I::MPolyIdeal)
@@ -557,7 +565,7 @@ end
 function groebner_basis(I::MPolyIdeal, ord::Symbol; complete_reduction::Bool=false)
   R = singular_ring(base_ring(I), ord)
   !Oscar.Singular.has_global_ordering(R) && error("The ordering has to be a global ordering.")
-  i = Singular.std(Singular.Ideal(R, [convert(R, x) for x = gens(I)]), complete_reduction = complete_reduction)
+  i = Singular.std(Singular.Ideal(R, [R(x) for x = gens(I)]), complete_reduction = complete_reduction)
   return collect(BiPolyArray(base_ring(I), i))
 end
 
@@ -702,7 +710,7 @@ function coordinates(a::Array{<:MPolyElem, 1}, b::Array{<:MPolyElem, 1})
   singular_assure(ib)
   c = _lift(ia.gens.S, ib.gens.S)
   F = free_module(parent(a[1]), length(a))
-  return [convert(F, c[x]) for x = 1:Singular.ngens(c)]
+  return [F(c[x]) for x = 1:Singular.ngens(c)]
 end
 
 function coordinates(a::Array{<:MPolyElem, 1}, b::MPolyElem)
@@ -727,9 +735,9 @@ mutable struct MPolyHom_alg{T1, T2}  <: Map{T1, T2, Hecke.HeckeMap, MPolyHom_var
   end
 
   function im_func(r, a::MPolyElem)
-    A = convert(singular_ring(r.header.domain, keep_ordering = false), a)
+    A = singular_ring(r.header.domain, keep_ordering = false)(a)
     B = Singular.map_poly(r.f, A)
-    return convert(r.header.codomain, B)
+    return r.header.codomain(B)
   end
 
   function im_func(r, a::MPolyIdeal)
@@ -742,7 +750,7 @@ mutable struct MPolyHom_alg{T1, T2}  <: Map{T1, T2, Hecke.HeckeMap, MPolyHom_var
 #    ib = ideal(codomain(r), [b])
 #    singular_assure(ib)
 #    A = Singular.preimage(r.f, ib.gens.S)
-#    return convert(r.header.domain, gens(A)[1])
+#    return r.header.domain(gens(A)[1])
 #  end
 
   function pr_func(r, b::MPolyIdeal)
@@ -787,7 +795,7 @@ function eliminate(I::MPolyIdeal, l::Array{<:MPolyElem, 1})
   singular_assure(I)
   B = BiPolyArray(l)
   S = base_ring(I.gens.S)
-  s = Singular.eliminate(I.gens.S, [convert(S, x) for x = l]...)
+  s = Singular.eliminate(I.gens.S, [S(x) for x = l]...)
   return MPolyIdeal(base_ring(I), s)
 end
 
@@ -1139,7 +1147,7 @@ function factor(f::MPolyElem)
   I = ideal(parent(f), [f])
   fS = Singular.factor(I.gens[Val(:S), 1])
   R = parent(f)
-  return Nemo.Fac(convert(R, fS.unit), Dict(convert(R, k) =>v for (k,v) = fS.fac))
+  return Nemo.Fac(R(fS.unit), Dict(R(k) =>v for (k,v) = fS.fac))
 end
 =#
 
@@ -1224,7 +1232,7 @@ function simplify!(a::MPolyQuoElem)
   Sx = base_ring(I.gb.S)
   I.gb.S.isGB = true
   f = a.f
-  a.f = convert(I.gens.Ox, reduce(convert(Sx, f), I.gb.S))
+  a.f = I.gens.Ox(reduce(Sx(f), I.gb.S))
   return a
 end
 
@@ -1261,7 +1269,7 @@ function _kbase(Q::MPolyQuo)
   if iszero(s)
     error("ideal was no zero-dimensional")
   end
-  return [convert(Q.R, x) for x = gens(s)]
+  return [Q.R(x) for x = gens(s)]
 end
 
 #TODO: the reverse map...

--- a/test/Rings/mpoly-test.jl
+++ b/test/Rings/mpoly-test.jl
@@ -52,11 +52,16 @@ end
   I = [f, g]
   S, (a, b, c) = PolynomialRing(QQ, ["a", "b", "c"])
   J = ideal(S, [(c^2+1)*(c^3+2)^2, b-c^2])
+  r1 = c^2-b
+  r2 = b^2*c+c^3+2*c^2+2
+  L = gens(radical(J))
 
   @test jacobi_ideal(f) == ideal(R, [2*x, 2*y])
   @test jacobi_matrix(f) == matrix(R, 2, 1, [2*x, 2*y])
   @test jacobi_matrix(I) == matrix(R, 2, 2, [2*x, 4*x^3*y-y^3, 2*y, x^4-3*x*y^2])
-  @test gens(radical(J)) == [c^2-b, b^2*c+c^3+2*c^2+2]
+  @test length(L) == 2
+  @test length(findall(x->x==r1, L)) == 1
+  @test length(findall(x->x==r2, L)) == 1
 end
 
 @testset "Groebner" begin

--- a/test/Rings/mpoly-test.jl
+++ b/test/Rings/mpoly-test.jl
@@ -50,9 +50,13 @@ end
   f = x^2 + y^2
   g = x^4*y - x*y^3
   I = [f, g]
+  S, (a, b, c) = PolynomialRing(QQ, ["a", "b", "c"])
+  J = ideal(S, [(c^2+1)*(c^3+2)^2, b-c^2])
+
   @test jacobi_ideal(f) == ideal(R, [2*x, 2*y])
   @test jacobi_matrix(f) == matrix(R, 2, 1, [2*x, 2*y])
   @test jacobi_matrix(I) == matrix(R, 2, 2, [2*x, 4*x^3*y-y^3, 2*y, x^4-3*x*y^2])
+  @test gens(radical(J)) == [c^2-b, b^2*c+c^3+2*c^2+2]
 end
 
 @testset "Groebner" begin


### PR DESCRIPTION
Removed convert function and changed it to be of type R(x) instead of convert(R, x).
This PR is based on PR #227 .

There is an issue with the test in mpoly-graded.jl related to a conversion, but this one is independent of my change.