### PR TITLE
Curves: add missing parametric constructors, remove _assure_has_components

### DIFF
--- a/examples/AffinePlaneCurve.jl
+++ b/examples/AffinePlaneCurve.jl
@@ -165,13 +165,13 @@ end
 Return the reduced singular locus of `C` as a list whose first element is the affine plane curve consisting of the singular components of `C` (if any), and the second element is the list of the isolated singular points (which may be contained in the singular component). The singular component might not contain any point over the considered field.
 """
 function curve_singular_locus(C::AffinePlaneCurve)
-   _assure_has_components(C)
+   comp = curve_components(C)
    D = reduction(C)
    Pts = Array{Point, 1}()
    CC = Array{AffinePlaneCurve, 1}()
    # The components with multiplicity > 1 are singular
    f = []
-   for (h, c) in C.components
+   for (h, c) in comp
       if c != 1
          push!(f, h.eq)
       end

--- a/examples/DivisorCurve.jl
+++ b/examples/DivisorCurve.jl
@@ -16,7 +16,7 @@ struct AffineCurveDivisor{S <: FieldElem} <: CurveDivisor
     C::AffinePlaneCurve{S}
     divisor::Dict{Point{S}, Int}
     degree::Int
-    function AffineCurveDivisor(C::AffinePlaneCurve{S}, D::Dict{Point{S}, Int}) where S <: FieldElem
+    function AffineCurveDivisor{S}(C::AffinePlaneCurve{S}, D::Dict{Point{S}, Int}) where S <: FieldElem
         for (P, m) in D
             P in C || error("The point ", P.coord, " is not on the curve")
             if m == 0
@@ -27,8 +27,16 @@ struct AffineCurveDivisor{S <: FieldElem} <: CurveDivisor
     end
 end
 
+function AffineCurveDivisor(C::AffinePlaneCurve{S}) where S <: FieldElem
+    return AffineCurveDivisor{S}(C, Dict{Point{S}, Int}())
+end
+
+function AffineCurveDivisor(C::AffinePlaneCurve{S}, D::Dict{Point{S}, Int}) where S <: FieldElem
+    return AffineCurveDivisor{S}(C, D)
+end
+
 function AffineCurveDivisor(C::AffinePlaneCurve{S}, P::Point{S}, m::Int=1) where S <: FieldElem
-    return AffineCurveDivisor(C, Dict(P => m))
+    return AffineCurveDivisor{S}(C, Dict(P => m))
 end
 
 ################################################################################
@@ -42,7 +50,7 @@ struct ProjCurveDivisor{S <: FieldElem} <: CurveDivisor
     C::ProjPlaneCurve{S}
     divisor::Dict{Oscar.Geometry.ProjSpcElem{S}, Int}
     degree::Int
-    function ProjCurveDivisor(C::ProjPlaneCurve{S}, D::Dict{Oscar.Geometry.ProjSpcElem{S}, Int}) where S <: FieldElem
+    function ProjCurveDivisor{S}(C::ProjPlaneCurve{S}, D::Dict{Oscar.Geometry.ProjSpcElem{S}, Int}) where S <: FieldElem
         for (P, m) in D
             P in C || error("The point ", P, " is not on the curve")
             if m == 0
@@ -53,8 +61,16 @@ struct ProjCurveDivisor{S <: FieldElem} <: CurveDivisor
     end
 end
 
+function ProjCurveDivisor(C::ProjPlaneCurve{S}) where S <: FieldElem
+    return ProjCurveDivisor{S}(C, Dict{Oscar.Geometry.ProjSpcElem{S}, Int}())
+end
+
+function ProjCurveDivisor(C::ProjPlaneCurve{S}, D::Dict{Oscar.Geometry.ProjSpcElem{S}, Int}) where S <: FieldElem
+    return ProjCurveDivisor{S}(C, D)
+end
+
 function ProjCurveDivisor(C::ProjPlaneCurve{S}, P::Oscar.Geometry.ProjSpcElem{S}, m::Int=1) where S <: FieldElem
-    return ProjCurveDivisor(C, Dict(P => m))
+    return ProjCurveDivisor{S}(C, Dict(P => m))
 end
 
 ################################################################################
@@ -116,14 +132,9 @@ end
 ################################################################################
 # Sum of two divisors
 
-function Base.:+(D::AffineCurveDivisor, E::AffineCurveDivisor)
+function Base.:+(D::T, E::T) where T <: CurveDivisor
     _check_same_curve(D, E)
-    return AffineCurveDivisor(D.C, merge(+, D.divisor, E.divisor))
-end
-
-function Base.:+(D::ProjCurveDivisor, E::ProjCurveDivisor)
-    _check_same_curve(D, E)
-    return ProjCurveDivisor(D.C, merge(+, D.divisor, E.divisor))
+    return T(D.C, merge(+, D.divisor, E.divisor))
 end
 
 ################################################################################
@@ -141,35 +152,17 @@ function _help_minus(D::CurveDivisor, E::CurveDivisor)
     return F
 end
 
-function Base.:-(D::AffineCurveDivisor, E::AffineCurveDivisor)
-    return AffineCurveDivisor(D.C, _help_minus(D, E))
-end
-
-function Base.:-(D::ProjCurveDivisor, E::ProjCurveDivisor)
-    return ProjCurveDivisor(D.C, _help_minus(D, E))
+function Base.:-(D::T, E::T) where T <: CurveDivisor
+    return T(D.C, _help_minus(D, E))
 end
 
 ################################################################################
 ################################################################################
 
-function Base.:*(k::Int, D::AffineCurveDivisor{S}) where S <: FieldElem
-    if k == 0
-        return AffineCurveDivisor(D.C, Dict{Point{S}, Int}())
-    elseif k == 1
-        return D
-    else
-        return AffineCurveDivisor(D.C, Dict((P, k*m) for (P, m) in D.divisor))
-    end
-end
-
-function Base.:*(k::Int, D::ProjCurveDivisor{S}) where S <: FieldElem
-    if k == 0
-        return ProjCurveDivisor(D.C, Dict{Oscar.Geometry.ProjSpcElem{S}, Int}())
-    elseif k == 1
-        return D
-    else
-        return ProjCurveDivisor(D.C, Dict((P, k*m) for (P, m) in D.divisor))
-    end
+function Base.:*(k::Int, D::T) where T <: CurveDivisor
+    k == 0 && return T(D.C)
+    k == 1 && return D
+    return T(D.C, Dict((P, k*m) for (P, m) in D.divisor))
 end
 
 ################################################################################

--- a/examples/PlaneCurve.jl
+++ b/examples/PlaneCurve.jl
@@ -224,17 +224,6 @@ function Oscar.jacobi_ideal(C::PlaneCurve)
 end
 
 ################################################################################
-# Helping function
-
-function _assure_has_components(C::PlaneCurve)
-  if isempty(C.components)
-    T = typeof(C)
-    D = factor(C.eq)
-    C.components = Dict(T(x) => D.fac[x] for x in keys(D.fac))
-  end
-end
-
-################################################################################
 # Components of the curve
 
 @doc Markdown.doc"""
@@ -243,7 +232,11 @@ end
 Return a dictionary containing the irreducible components of `C` and their multiplicity.
 """
 function curve_components(C::PlaneCurve)
-  _assure_has_components(C)
+  if isempty(C.components)
+    T = typeof(C)
+    D = factor(C.eq)
+    C.components = Dict(T(x) => D.fac[x] for x in keys(D.fac))
+  end
   return C.components
 end
 
@@ -257,8 +250,8 @@ end
 Return `true` if `C` is irreducible, and `false` otherwise.
 """
 function Oscar.isirreducible(C::PlaneCurve)
-  _assure_has_components(C)
-   return length(C.components) == 1 && all(isone, values(C.components))
+   comp = curve_components(C)
+   return length(comp) == 1 && all(isone, values(comp))
 end
 
 ################################################################################
@@ -302,10 +295,10 @@ function reduction(C::AffinePlaneCurve)
 end
 
 function reduction(C::ProjPlaneCurve)
-  _assure_has_components(C)
-  F = prod(D -> D.eq, keys(C.components))
+  comp = curve_components(C)
+  F = prod(D -> D.eq, keys(comp))
   rC = ProjPlaneCurve(F)
-  rC.components = Dict(ProjPlaneCurve(D.eq) => 1 for D in keys(C.components))
+  rC.components = Dict(ProjPlaneCurve(D.eq) => 1 for D in keys(comp))
   return rC
 end
 


### PR DESCRIPTION
For parametric types, one should provide parametric constructors (and then perhaps, as in this case, non-parametric ones for convenience).

This allows us to avoid some code duplication.

Also, try hard to not access `C.components` directly, instead use `curve_components(C)` -- this allows us to get rid of `_assure_has_components`