### PR TITLE
Polytopes: support fmpz_mat, fmpq_mat in convex_hull

### DIFF
--- a/src/Polytopes/Polyhedron.jl
+++ b/src/Polytopes/Polyhedron.jl
@@ -271,6 +271,8 @@ recession_cone(P::Polyhedron) = Cone(Polymake.polytope.recession_cone(pm_polytop
 ###############################################################################
 ###############################################################################
 
+const AnyVecOrMat = Union{MatElem, AbstractVecOrMat}
+
 @doc Markdown.doc"""
     convex_hull(V [, R [, L]])
 
@@ -278,17 +280,18 @@ The polytope given as the convex hull of the columns of V. Optionally, rays (R)
 and generators of the lineality space (L) can be given as well.
 
 see Def. 2.11 and Def. 3.1.
-""" function convex_hull(V::AbstractVecOrMat)
+"""
+function convex_hull(V::AnyVecOrMat)
     pm_polytope =
         Polymake.polytope.Polytope{Polymake.Rational}(POINTS = matrix_for_polymake(homogenize(V, 1)))
     return Polyhedron(pm_polytope)
 end
-function convex_hull(V::AbstractVecOrMat, R::AbstractVecOrMat)
+function convex_hull(V::AnyVecOrMat, R::AnyVecOrMat)
     points = stack(homogenize(V, 1), homogenize(R, 0))
     pm_polytope = Polymake.polytope.Polytope{Polymake.Rational}(POINTS = matrix_for_polymake(points))
     return Polyhedron(pm_polytope)
 end
-function convex_hull(V::AbstractVecOrMat, R::AbstractVecOrMat, L::AbstractVecOrMat)
+function convex_hull(V::AnyVecOrMat, R::AnyVecOrMat, L::AnyVecOrMat)
     points = stack(homogenize(V, 1), homogenize(R, 0))
     lineality = homogenize(L, 0)
     pm_polytope = Polymake.polytope.Polytope{Polymake.Rational}(

--- a/src/Polytopes/helpers.jl
+++ b/src/Polytopes/helpers.jl
@@ -25,6 +25,7 @@ end
 
 homogenize(vec::AbstractVector, val::Number = 0) = augment(vec, val)
 homogenize(mat::AbstractMatrix, val::Number = 1) = augment(mat, fill(val, size(mat, 1)))
+homogenize(mat::MatElem, val::Number = 1) = homogenize(Matrix(mat), val)
 
 dehomogenize(vec::AbstractVector) = vec[2:end]
 dehomogenize(mat::AbstractMatrix) = mat[:, 2:end]

--- a/test/Polytopes/runtests.jl
+++ b/test/Polytopes/runtests.jl
@@ -105,4 +105,15 @@ const pm = Polymake
         @test lhs == [1 0; 0 4; 0 0]
         @test rhs == [1, -3, 1]
     end
+
+    @testset "Polytope From Group Orbit" begin
+        G = symmetric_group(4)
+        x = [0,1,2,3]
+        M = matrix(ZZ, [permuted(x,g) for g in G])
+        P = convex_hull(M)
+        @test ambient_dim(P) == 4
+
+        F = facets(P; as = :polyhedra)
+        @test n_vertices.(F) == [6, 6, 4, 6, 4, 4, 6, 4, 6, 6, 4, 6, 6, 4]
+    end
 end # of @testset "OscarPolytope"


### PR DESCRIPTION
... and also in homogenize.

This further simplifies the example in @micjoswig's ICERM talk.

CC @tbrysiewicz 