### PR TITLE
Forms

### DIFF
--- a/src/Groups/matrices/forms.jl
+++ b/src/Groups/matrices/forms.jl
@@ -295,15 +295,16 @@ function gram_matrix(f::SesquilinearForm)
    V = collect(exponent_vectors(f.pol))
    C = collect(coeffs(f.pol))
    for i in 1:length(V)
+      x = y = 0
       for j in 1:d
          if V[i][j] !=0
-            global x = j
+            x = j
             break
          end
       end
       for j in 1:d
          if V[i][d+1-j] !=0
-            global y = d+1-j
+            y = d+1-j
             break
          end
       end

--- a/src/Groups/matrices/forms.jl
+++ b/src/Groups/matrices/forms.jl
@@ -316,8 +316,8 @@ end
 
 
 function assign_from_description(f::SesquilinearForm)
-   if f.descr==:quadratic f.X=GAP.Globals.QuadraticFormByMatrix(f.mat_iso(gram_matrix(f)))
-   elseif f.descr==:symmetric || f.descr==:alternating f.X=GAP.Globals.BilinearFormByMatrix(f.mat_iso(gram_matrix(f)))
+   if f.descr==:quadratic f.X=GAP.Globals.QuadraticFormByMatrix(f.mat_iso(gram_matrix(f)),f.mat_iso.fr.codomain)
+   elseif f.descr==:symmetric || f.descr==:alternating f.X=GAP.Globals.BilinearFormByMatrix(f.mat_iso(gram_matrix(f)),f.mat_iso.fr.codomain)
    elseif f.descr==:hermitian f.X=GAP.Globals.HermitianFormByMatrix(f.mat_iso(gram_matrix(f)),f.mat_iso.fr.codomain)
    else error("unsupported description")
    end
@@ -329,12 +329,12 @@ function Base.getproperty(f::SesquilinearForm, sym::Symbol)
    if isdefined(f,sym) return getfield(f,sym) end
 
    if sym === :mat_iso
-      f.mat_iso = gen_mat_iso(nrows(gram_matrix(f)), base_ring(gram_matrix(f)))
+      f.mat_iso = gen_mat_iso(nrows(gram_matrix(f)), base_ring(f))
 
    elseif sym == :X
       if !isdefined(f, :X)
          if !isdefined(f,:mat_iso)
-            f.mat_iso = gen_mat_iso(nrows(gram_matrix(f)), base_ring(gram_matrix(f)))
+            f.mat_iso = gen_mat_iso(nrows(gram_matrix(f)), base_ring(f))
          end
          assign_from_description(f)
       end

--- a/src/Groups/matrices/forms.jl
+++ b/src/Groups/matrices/forms.jl
@@ -26,6 +26,7 @@ export
 # NOTE: the fields ring_iso and mat_iso are always defined if the field X is
 """
     SesquilinearForm{T<:RingElem}
+
 Type of groups `G` of `n x n` matrices over the ring `R`, where `n = degree(G)` and `R = base_ring(G)`.
 At the moment, only rings of type `FqNmodFiniteField` are supported.
 """
@@ -78,30 +79,35 @@ SesquilinearForm(f::MPolyElem{T},sym) where T = SesquilinearForm{T}(f,sym)
 
 """
     isalternating_form(f::SesquilinearForm)
+
 Return whether the form `f` is an alternating form.
 """
 isalternating_form(f::SesquilinearForm) = f.descr==:alternating
 
 """
     ishermitian_form(f::SesquilinearForm)
+
 Return whether the form `f` is a hermitian form.
 """
 ishermitian_form(f::SesquilinearForm) = f.descr==:hermitian
 
 """
     isquadratic_form(f::SesquilinearForm)
+
 Return whether the form `f` is a quadratic form.
 """
 isquadratic_form(f::SesquilinearForm) = f.descr==:quadratic
 
 """
     issymmetric_form(f::SesquilinearForm)
+
 Return whether the form `f` is a symmetric form.
 """
 issymmetric_form(f::SesquilinearForm) = f.descr==:symmetric
 
 """
     preserved_quadratic_forms(G::MatrixGroup)
+
 Return a generating set for the vector space of quadratic forms preserved by `G`.
 !!! warning "Note:"
     The process involves random procedures, so the function may return different outputs every time.
@@ -113,6 +119,7 @@ end
 
 """
     preserved_sesquilinear_forms(G::MatrixGroup)
+
 Return a generating set for the vector space of sesquilinear forms preserved by `G`.
 !!! warning "Note:"
     The process involves random procedures, so the function may return different outputs every time.
@@ -134,18 +141,21 @@ end
 
 """
     alternating_form(B::MatElem{T})
+
 Return the alternating form with Gram matrix `B`.
 """
 alternating_form(B::MatElem{T}) where T <: FieldElem = SesquilinearForm(B, :alternating)
 
 """
     symmetric_form(B::MatElem{T})
+
 Return the symmetric form with Gram matrix `B`.
 """
 symmetric_form(B::MatElem{T}) where T <: FieldElem = SesquilinearForm(B, :symmetric)
 
 """
     hermitian_form(B::MatElem{T})
+
 Return the hermitian form with Gram matrix `B`.
 """
 hermitian_form(B::MatElem{T}) where T <: FieldElem = SesquilinearForm(B, :hermitian)
@@ -154,23 +164,23 @@ hermitian_form(B::MatElem{T}) where T <: FieldElem = SesquilinearForm(B, :hermit
 # (two matrices A,B represent the same quadratic form iff A-B is skew-symmetric)
 function _upper_triangular_version(C::MatElem)
    B = deepcopy(C)
-   for i in 1:nrows(B)
-   for j in i+1:nrows(B)
+   for i in 1:nrows(B), j in i+1:nrows(B)
       B[i,j]+=B[j,i]
       B[j,i]=0
-   end
    end
    return B
 end
 
 """
     quadratic_form(B::MatElem{T})
+
 Return the quadratic form with Gram matrix `B`.
 """
 quadratic_form(B::MatElem{T}) where T <: FieldElem = SesquilinearForm(B, :quadratic)
 
 """
     quadratic_form(f::MPolyElem{T}; check=true)
+
 Return the quadratic form described by the polynomial `f`. Here, `f` must be a homogeneous polynomial of degree 2. If `check` is set as `false`, it does not check whether the polynomial is homogeneous of degree 2.
 To define quadratic forms of dimension 1, `f` can also have type `PolyElem{T}`.
 """
@@ -228,6 +238,7 @@ end
 
 """
     corresponding_bilinear_form(Q::SesquilinearForm)
+
 Given a quadratic form `Q`, return the bilinear form `B` defined by `B(u,v) = Q(u+v)-Q(u)-Q(v)`.
 """
 function corresponding_bilinear_form(B::SesquilinearForm)
@@ -240,6 +251,7 @@ end
 
 """
     corresponding_quadratic_form(Q::SesquilinearForm)
+
 Given a symmetric form `f`, returns the quadratic form `Q` defined by `Q(v) = f(v,v)/2`. It is defined only in odd characteristic.
 """
 function corresponding_quadratic_form(B::SesquilinearForm)
@@ -266,6 +278,7 @@ end
 
 """
     gram_matrix(B::SesquilinearForm)
+
 Return the Gram matrix of a sesquilinear or quadratic form `B`.
 """
 function gram_matrix(f::SesquilinearForm)
@@ -297,6 +310,7 @@ end
 
 """
     defining_polynomial(f::SesquilinearForm)
+
 Return the polynomial that defines the quadratic form `f`.
 """
 function defining_polynomial(f::SesquilinearForm)
@@ -305,10 +319,8 @@ function defining_polynomial(f::SesquilinearForm)
    @assert f.descr == :quadratic "Polynomial defined only for quadratic forms"
    R = PolynomialRing(base_ring(f.matrix), nrows(f.matrix) )[1]
    p = zero(R)
-   for i in 1:nrows(f.matrix)
-   for j in i:nrows(f.matrix)
+   for i in 1:nrows(f.matrix), j in i:nrows(f.matrix)
       p += f.matrix[i,j] * R[i]*R[j]
-   end
    end
    f.pol = p
    return p
@@ -408,6 +420,7 @@ end
 
 """
     radical(f::SesquilinearForm{T})
+
 Return the radical of the sesquilinear form `f`, i.e. the subspace of all `v` such that `f(u,v)=0` for all `u`. The radical of a quadratic form `Q` is the set of vectors `v` such that `Q(v)=0` and `v` lies in the radical of the corresponding bilinear form.
 """
 function radical(f::SesquilinearForm{T}) where T
@@ -424,12 +437,14 @@ end
 
 """
     witt_index(f::SesquilinearForm{T})
+
 Return the Witt index of the form induced by `f` on `V/Rad(f)`. The Witt Index is the dimension of a maximal totally isotropic (singular for quadratic forms) subspace.
 """
 witt_index(f::SesquilinearForm{T}) where T = GAP.Globals.WittIndex(f.X)
 
 """
     isdegenerate(f::SesquilinearForm{T})
+
 Return whether `f` is degenerate, i.e. `f` has nonzero radical. A quadratic form is degenerate if the corresponding bilinear form is.
 """
 function isdegenerate(f::SesquilinearForm{T}) where T
@@ -439,6 +454,7 @@ end
 
 """
     issingular(Q::SesquilinearForm{T})
+
 For a quadratic form `Q`, return whether `Q` is singular, i.e. `Q` has nonzero radical.
 """
 function issingular(f::SesquilinearForm{T}) where T

--- a/src/Groups/matrices/forms.jl
+++ b/src/Groups/matrices/forms.jl
@@ -1,0 +1,461 @@
+import AbstractAlgebra: FieldElem, PolyElem, MPolyElem
+import Hecke: base_ring, defining_polynomial, gram_matrix, radical
+
+export
+    alternating_form,
+    corresponding_bilinear_form,
+    corresponding_quadratic_form,
+    hermitian_form,
+    isalternating_form,
+    isdegenerate,
+    ishermitian_form,
+    isquadratic_form,
+    issingular,
+    issymmetric_form,
+    preserved_quadratic_forms,
+    preserved_sesquilinear_forms,
+    quadratic_form,
+    SesquilinearForm,
+    symmetric_form,
+    witt_index
+
+
+
+# descr is always defined
+# matrix is always defined except when descr="quadratic"; in such a case, at least one of matrix and pol is defined
+# NOTE: the fields ring_iso and mat_iso are always defined if the field X is
+"""
+    SesquilinearForm{T<:RingElem}
+Type of groups `G` of `n x n` matrices over the ring `R`, where `n = degree(G)` and `R = base_ring(G)`.
+At the moment, only rings of type `FqNmodFiniteField` are supported.
+"""
+mutable struct SesquilinearForm{T<:RingElem}
+   matrix::MatElem{T}
+   descr::Symbol       # quadratic, symmetric, alternating or hermitian
+   pol::MPolyElem{T}     # only for quadratic forms
+   X::GapObj
+   mat_iso::GenMatIso
+
+   SesquilinearForm(B::MatElem{T},sym) where T = new{T}(B,sym)
+
+   function SesquilinearForm(f::MPolyElem{T},sym) where T
+      @assert sym==:quadratic "Only quadratic forms are described by polynomials"
+      r = new{T}()
+      r.pol = f
+      r.descr = :quadratic
+      return r
+   end
+end
+
+
+
+
+
+########################################################################
+#
+# Properties
+#
+########################################################################
+
+
+"""
+    isalternating_form(f::SesquilinearForm)
+Return whether the form `f` is an alternating form.
+"""
+isalternating_form(f::SesquilinearForm) = f.descr==:alternating
+
+"""
+    ishermitian_form(f::SesquilinearForm)
+Return whether the form `f` is a hermitian form.
+"""
+ishermitian_form(f::SesquilinearForm) = f.descr==:hermitian
+
+"""
+    isquadratic_form(f::SesquilinearForm)
+Return whether the form `f` is a quadratic form.
+"""
+isquadratic_form(f::SesquilinearForm) = f.descr==:quadratic
+
+"""
+    issymmetric_form(f::SesquilinearForm)
+Return whether the form `f` is a symmetric form.
+"""
+issymmetric_form(f::SesquilinearForm) = f.descr==:symmetric
+
+"""
+    preserved_quadratic_forms(G::MatrixGroup)
+Return a generating set for the vector space of quadratic forms preserved by `G`.
+!!! warning "Note:"
+    The process involves random procedures, so the function may return different outputs every time.
+"""
+function preserved_quadratic_forms(G::MatrixGroup)
+   L = GAP.Globals.PreservedQuadraticForms(G.X)
+   return [G.mat_iso(GAP.Globals.GramMatrix(L[i])) for i in 1:length(L)]
+end
+
+"""
+    preserved_sesquilinear_forms(G::MatrixGroup)
+Return a generating set for the vector space of sesquilinear forms preserved by `G`.
+!!! warning "Note:"
+    The process involves random procedures, so the function may return different outputs every time.
+"""
+function preserved_sesquilinear_forms(G::MatrixGroup)
+   L = GAP.Globals.PreservedSesquilinearForms(G.X)
+   return [G.mat_iso(GAP.Globals.GramMatrix(L[i])) for i in 1:length(L)]
+end
+
+
+
+
+########################################################################
+#
+# Constructors
+#
+########################################################################
+
+
+"""
+    alternating_form(B::MatElem{T}; check=true)
+Return the alternating form with Gram matrix `B`. If `check` is set as `false`, it does not check whether the matrix is skew-symmetric.
+"""
+function alternating_form(B::MatElem{T}; check=true) where T <: FieldElem
+   if check
+      @assert isskewsymmetric_matrix(B) "The matrix is not skew-symmetric"
+   end
+   f = SesquilinearForm(B, :alternating)
+   return f
+end
+
+"""
+    symmetric_form(B::MatElem{T}; check=true)
+Return the symmetric form with Gram matrix `B`. If `check` is set as `false`, it does not check whether the matrix is symmetric.
+"""
+function symmetric_form(B::MatElem{T}; check=true) where T <: FieldElem
+   if check
+      @assert issymmetric(B) "The matrix is not symmetric"
+   end
+   f = SesquilinearForm(B, :symmetric)
+   return f
+end
+
+"""
+    hermitian_form(B::MatElem{T}; check=true)
+Return the hermitian form with Gram matrix `B`. If `check` is set as `false`, it does not check whether the matrix is hermitian.
+"""
+function hermitian_form(B::MatElem{T}; check=true) where T <: FieldElem
+   if check
+      @assert ishermitian_matrix(B) "The matrix is not hermitian"
+   end
+   f = SesquilinearForm(B, :hermitian)
+   return f
+end
+
+# turns the matrix of a quadratic form into an upper triangular matrix of the same form
+# (two matrices A,B represent the same quadratic form iff A-B is skew-symmetric)
+function _upper_triangular_version(C::MatElem)
+   B = deepcopy(C)
+   for i in 1:nrows(B)
+   for j in i+1:nrows(B)
+      B[i,j]+=B[j,i]
+      B[j,i]=0
+   end
+   end
+   return B
+end
+
+"""
+    quadratic_form(B::MatElem{T})
+Return the quadratic form with Gram matrix `B`.
+"""
+function quadratic_form(B::MatElem{T}; check=true) where T <: FieldElem
+   f = SesquilinearForm(_upper_triangular_version(B), :quadratic)
+   return f
+end
+
+"""
+    quadratic_form(f::MPolyElem{T}; check=true)
+Return the quadratic form described by the polynomial `f`. Here, `f` must be a homogeneous polynomial of degree 2. If `check` is set as `false`, it does not check whether the polynomial is homogeneous of degree 2.
+To define quadratic forms of dimension 1, `f` can also have type `PolyElem{T}`.
+"""
+function quadratic_form(f::MPolyElem{T}; check=true) where T <: FieldElem
+# TODO : neither ishomogeneous or ishomogenous works for variables of type MPolyElem{T}
+   if check
+      @assert Set([total_degree(x) for x in monomials(f)])==Set(2) "The polynomials is not homoneneous of degree 2"
+#   @assert total_degree(f)==2 "The polynomial must have degree 2"
+#   @assert ishomogenous(f) "The polynomial is not homogeneous"
+   end
+
+   f = SesquilinearForm(f, :quadratic)
+   return f
+end
+
+# just to allow quadratic forms over vector fields of dimension 1, so defined over polynomials in 1 variable
+function quadratic_form(f::PolyElem{T}; check=true) where T <: FieldElem
+   if check
+      @assert degree(f)==2 && coefficients(f)[0]==0 && coefficients(f)[1]==0 "The polynomials is not homoneneous of degree 2"
+   end
+   R1 = PolynomialRing(base_ring(f), [string(parent(f).S)])[1]
+
+   return SesquilinearForm(R1[1]*coefficients(f)[2], :quadratic)
+end
+
+########################################################################
+#
+# Show
+#
+########################################################################
+
+
+function _assign_description(sym::Symbol)
+   if sym== :alternating print("Alternating")
+   elseif sym== :hermitian print("Hermitian")
+   elseif sym== :symmetric print("Symmetric")
+   elseif sym== :quadratic print("Quadratic")
+   else error("unsupported description")
+   end
+end
+
+
+function Base.show(io::IO, f::SesquilinearForm)
+   _assign_description(f.descr)
+   println(" form with Gram matrix ")
+   show(io, "text/plain", gram_matrix(f))
+end
+
+
+
+
+########################################################################
+#
+# Basic
+#
+########################################################################
+
+#TODO: checking whether two quadratic forms coincide by checking their polynomials is not possible yet.
+==(B::SesquilinearForm, C::SesquilinearForm) = gram_matrix(B)==gram_matrix(C) && B.descr==C.descr
+
+function base_ring(B::SesquilinearForm)
+   if isdefined(B,:matrix) return base_ring(gram_matrix(B))
+   else return base_ring(B.pol)
+   end
+end
+
+"""
+    corresponding_bilinear_form(Q::SesquilinearForm)
+Given a quadratic form `Q`, return the bilinear form `B` defined by `B(u,v) = Q(u+v)-Q(u)-Q(v)`.
+"""
+function corresponding_bilinear_form(B::SesquilinearForm)
+   B.descr==:quadratic || throw(ArgumentError("The form must be a quadratic form"))
+   M = gram_matrix(B)+transpose(gram_matrix(B))
+   if characteristic(base_ring(B))==2 return alternating_form(M)
+   else return symmetric_form(M)
+   end
+end
+
+"""
+    corresponding_quadratic_form(Q::SesquilinearForm)
+Given a symmetric form `f`, returns the quadratic form `Q` defined by `Q(v) = f(v,v)/2`. It is defined only in odd characteristic.
+"""
+function corresponding_quadratic_form(B::SesquilinearForm)
+   B.descr==:symmetric || throw(ArgumentError("The form must be a symmetric form"))
+   characteristic(base_ring(B))!=2 || throw(ArgumentError("Corresponding quadratic form not uniquely determined"))
+   M = deepcopy(gram_matrix(B))
+   l = inv(base_ring(B)(2))
+   for i in 1:nrows(M)
+      for j in i+1:nrows(M)
+         M[j,i]=0
+      end
+      M[i,i]*=l
+   end
+   return quadratic_form(M)
+end
+
+
+
+########################################################################
+#
+# Fields of the variable
+#
+########################################################################
+
+"""
+    gram_matrix(B::SesquilinearForm)
+Return the Gram matrix of a sesquilinear or quadratic form `B`.
+"""
+function gram_matrix(f::SesquilinearForm)
+   isdefined(f,:matrix) && return f.matrix
+
+   @assert f.descr==:quadratic && isdefined(f,:pol) "Cannot determine Gram matrix"
+   d = nvars(parent(f.pol))
+   B = zero_matrix( base_ring(f.pol), d, d )
+   V = collect(exponent_vectors(f.pol))
+   C = collect(coeffs(f.pol))
+   for i in 1:length(V)
+      for j in 1:d
+         if V[i][j] !=0
+            global x = j
+            break
+         end
+      end
+      for j in 1:d
+         if V[i][d+1-j] !=0
+            global y = d+1-j
+            break
+         end
+      end
+      B[x,y] = C[i]
+   end
+   f.matrix = B
+   return B
+end
+
+"""
+    defining_polynomial(f::SesquilinearForm)
+Return the polynomial that defines the quadratic form `f`.
+"""
+function defining_polynomial(f::SesquilinearForm)
+   isdefined(f,:pol) && return f.pol
+
+   @assert f.descr == :quadratic "Polynomial defined only for quadratic forms"
+   R = PolynomialRing(base_ring(f.matrix), nrows(f.matrix) )[1]
+   p = zero(R)
+   for i in 1:nrows(f.matrix)
+   for j in i:nrows(f.matrix)
+      p += f.matrix[i,j] * R[i]*R[j]
+   end
+   end
+   f.pol = p
+   return p
+end
+
+
+function assign_from_description(f::SesquilinearForm)
+   if f.descr==:quadratic f.X=GAP.Globals.QuadraticFormByMatrix(f.mat_iso(gram_matrix(f)))
+   elseif f.descr==:symmetric || f.descr==:alternating f.X=GAP.Globals.BilinearFormByMatrix(f.mat_iso(gram_matrix(f)))
+   elseif f.descr==:hermitian f.X=GAP.Globals.HermitianFormByMatrix(f.mat_iso(gram_matrix(f)),f.mat_iso.fr.codomain)
+   else error("unsupported description")
+   end
+end
+
+
+function Base.getproperty(f::SesquilinearForm, sym::Symbol)
+
+   if isdefined(f,sym) return getfield(f,sym) end
+
+   if sym === :mat_iso
+      f.mat_iso = gen_mat_iso(nrows(gram_matrix(f)), base_ring(gram_matrix(f)))
+
+   elseif sym == :X
+      if !isdefined(f, :X)
+         if !isdefined(f,:mat_iso)
+            f.mat_iso = gen_mat_iso(nrows(gram_matrix(f)), base_ring(gram_matrix(f)))
+         end
+         assign_from_description(f)
+      end
+
+   end
+
+   return getfield(f, sym)
+
+end
+
+
+
+########################################################################
+#
+# Operations
+#
+########################################################################
+
+function Base.:*(f::SesquilinearForm, l::FieldElem)
+   l !=0 || throw(ArgumentError("Zero is not admitted"))
+   parent(l)==base_ring(f) || throw(ArgumentError("The scalar does not belong to the base ring of the form"))
+   if !isdefined(f,:matrix)
+      return SesquilinearForm(l*f.pol, f.descr)
+   else
+      g = SesquilinearForm(l*gram_matrix(f), f.descr)
+      if isdefined(f,:pol) g.pol=f.pol end
+      return g
+   end
+end
+
+Base.:*(l::FieldElem, f::SesquilinearForm) = f*l
+
+function Base.:^(f::SesquilinearForm{T}, x::MatElem{T}; check=false) where T <: RingElem
+   @assert base_ring(f)==base_ring(x) "Incompatible base rings"
+   @assert nrows(gram_matrix(f))==nrows(x) "Incompatible dimensions"
+
+   if check @assert rank(x)==nrows(x) "Matrix not invertible" end
+   if f.descr==:hermitian
+      m = x^-1*gram_matrix(f)*conjugate_transpose(x^-1)
+   else
+      m = x^-1*gram_matrix(f)*transpose(x^-1)
+   end
+   return SesquilinearForm(m, f.descr)
+end
+
+Base.:^(f::SesquilinearForm{T}, x::MatrixGroupElem{T}; check=false) where T <: RingElem = f^x.elm
+
+function (f::SesquilinearForm{T})(v::AbstractAlgebra.Generic.FreeModuleElem{T},w::AbstractAlgebra.Generic.FreeModuleElem{T}) where T <: RingElem
+   @assert f.descr!=:quadratic "Quadratic forms requires only one argument"
+
+   if f.descr==:hermitian
+      return v*gram_matrix(f)*map( y->frobenius(y,div(degree(base_ring(w)),2)),w)
+   else
+      return v*gram_matrix(f)*w
+   end
+end
+
+function (f::SesquilinearForm{T})(v::AbstractAlgebra.Generic.FreeModuleElem{T}) where T <: RingElem
+   @assert f.descr==:quadratic "Sesquilinear forms requires two arguments"
+   return v*gram_matrix(f)*v
+end
+
+
+
+
+########################################################################
+#
+# Functionalities
+#
+########################################################################
+
+"""
+    radical(f::SesquilinearForm{T})
+Return the radical of the sesquilinear form `f`, i.e. the subspace of all `v` such that `f(u,v)=0` for all `u`. The radical of a quadratic form `Q` is the set of vectors `v` such that `Q(v)=0` and `v` lies in the radical of the corresponding bilinear form.
+"""
+function radical(f::SesquilinearForm{T}) where T
+   V = VectorSpace(base_ring(f), nrows(gram_matrix(f)) )
+   R = GAP.Globals.RadicalOfForm(f.X)
+   GAP.Globals.Dimension(R)==0 && return sub(V,[])
+   L = AbstractAlgebra.Generic.FreeModuleElem{T}[]
+   for l in GAP.Globals.GeneratorsOfVectorSpace(R)
+      v = V([f.mat_iso.fr(t) for t in l])
+      push!(L,v)
+   end
+   return sub(V,L)
+end
+
+"""
+    witt_index(f::SesquilinearForm{T})
+Return the Witt index of the form induced by `f` on `V/Rad(f)`. The Witt Index is the dimension of a maximal totally isotropic (singular for quadratic forms) subspace.
+"""
+witt_index(f::SesquilinearForm{T}) where T = GAP.Globals.WittIndex(f.X)
+
+"""
+    isdegenerate(f::SesquilinearForm{T})
+Return whether `f` is degenerate, i.e. `f` has nonzero radical. A quadratic form is degenerate if the corresponding bilinear form is.
+"""
+function isdegenerate(f::SesquilinearForm{T}) where T
+   f.descr != :quadratic && return det(gram_matrix(f))==0
+   return det(gram_matrix(f)+transpose(gram_matrix(f)))==0
+end
+
+"""
+    issingular(Q::SesquilinearForm{T})
+For a quadratic form `Q`, return whether `Q` is singular, i.e. `Q` has nonzero radical.
+"""
+function issingular(f::SesquilinearForm{T}) where T
+   f.descr != :quadratic && throw(ArgumentError("The form is not quadratic"))
+   return GAP.Globals.IsSingularForm(f.X)
+end

--- a/src/Groups/matrices/forms.jl
+++ b/src/Groups/matrices/forms.jl
@@ -1,3 +1,8 @@
+# TODO: in this file are used many methods TEMPORARILY defined in files matrix_manipulation.jl and stuff_field_gen.jl
+# once methods in those files will be deleted / replaced / modified, this file need to be modified too
+
+
+
 import AbstractAlgebra: FieldElem, PolyElem, MPolyElem
 import Hecke: base_ring, defining_polynomial, gram_matrix, radical
 

--- a/src/Groups/matrices/matrices.jl
+++ b/src/Groups/matrices/matrices.jl
@@ -4,3 +4,4 @@ include("stuff_field_gen.jl")
 include("matrix_manipulation.jl")
 include("linear_centralizer.jl")
 include("linear_isconjugate.jl")
+

--- a/src/Groups/matrices/matrices.jl
+++ b/src/Groups/matrices/matrices.jl
@@ -4,4 +4,4 @@ include("stuff_field_gen.jl")
 include("matrix_manipulation.jl")
 include("linear_centralizer.jl")
 include("linear_isconjugate.jl")
-
+include("forms.jl")

--- a/src/Groups/matrices/matrix_manipulation.jl
+++ b/src/Groups/matrices/matrix_manipulation.jl
@@ -219,7 +219,7 @@ function isskewsymmetric_matrix(B::MatElem{T}) where T <: RingElem
 end
 
 """
-    ishermitian_matrix(B::MatElem{T}) where T <: Ring
+    ishermitian_matrix(B::MatElem{T}) where T <: FinFieldElem
 
 Return whether the matrix `B` is hermitian, i.e. `B = conjugate_transpose(B)`. Returns `false` if `B` is not a square matrix, or the field has not even degree.
 """

--- a/src/Groups/matrices/matrix_manipulation.jl
+++ b/src/Groups/matrices/matrix_manipulation.jl
@@ -59,7 +59,6 @@ function insert_block!(A::MatElem{T}, B::MatElem{T}, i::Int, j::Int) where T <: 
    for s in 1:nrows(B), t in 1:ncols(B)
       A[i+s-1,j+t-1] = B[s,t]
    end
-
    return A
 end
 
@@ -73,7 +72,6 @@ Return the diagonal join of the matrices in `V`.
 function diagonal_join(V::AbstractVector{T}) where T <: MatElem
    nr = sum(nrows, V)
    nc = sum(ncols, V)
-
    B = zero_matrix(base_ring(V[1]), nr,nc)
    pos_i=1
    pos_j=1

--- a/src/Groups/matrices/stuff_field_gen.jl
+++ b/src/Groups/matrices/stuff_field_gen.jl
@@ -6,7 +6,7 @@
 # functions in this file are to be removed / moved / replaced
 # TODO: when this happens, files mentioned above need to be modified too.
 
-import Hecke: evaluate, field_extension, FinField, FinFieldElem, PolyElem
+import Hecke: evaluate, field_extension, FinField, FinFieldElem, PolyElem, primitive_element
 
 
 # changes the base ring of a polynomial ring into fq_nmod

--- a/src/Groups/matrices/stuff_field_gen.jl
+++ b/src/Groups/matrices/stuff_field_gen.jl
@@ -9,6 +9,7 @@
 
 import Hecke: evaluate, field_extension, FinField, FinFieldElem, PolyElem, primitive_element
 
+
 # changes the base ring of a polynomial ring into fq_nmod
 function _change_type(f::PolyElem{T}) where T <: FinFieldElem
    e,p = ispower(order(base_ring(f)))
@@ -17,8 +18,10 @@ function _change_type(f::PolyElem{T}) where T <: FinFieldElem
    return sum([t^i*F(lift(coeff(f,i))) for i in 0:degree(f)])
 end
 
+
 # if f in F[x] and z is a root of f in the splitting field of f over F,
 # then return a polynomial g such that g(z) is a generator for the unit group of F(z)
+# return a generator for the unit group of F = K[X] / (f), where K = base_ring(f)
 function _centralizer(f::PolyElem{T}) where T <: FinFieldElem
   if typeof(f)!=fq_nmod_poly && typeof(f)!=fq_poly
      f = _change_type(f)
@@ -30,6 +33,7 @@ function _centralizer(f::PolyElem{T}) where T <: FinFieldElem
 end
 
 # TODO very bold discrete log, waiting for a better one. Don't try with large fields!!
+
 # return g such that a^g = b
 function _disc_log(a,b)
    for g in 0:order(parent(a))

--- a/src/Groups/matrices/stuff_field_gen.jl
+++ b/src/Groups/matrices/stuff_field_gen.jl
@@ -6,8 +6,7 @@
 # functions in this file are to be removed / moved / replaced
 # TODO: when this happens, files mentioned above need to be modified too.
 
-
-import Hecke: evaluate, field_extension, FinField, FinFieldElem, PolyElem, primitive_element
+import Hecke: evaluate, field_extension, FinField, FinFieldElem, PolyElem
 
 
 # changes the base ring of a polynomial ring into fq_nmod
@@ -33,7 +32,6 @@ function _centralizer(f::PolyElem{T}) where T <: FinFieldElem
 end
 
 # TODO very bold discrete log, waiting for a better one. Don't try with large fields!!
-
 # return g such that a^g = b
 function _disc_log(a,b)
    for g in 0:order(parent(a))

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -84,6 +84,7 @@ function __init__()
         (GAP.Globals.IsMatrixGroup, MatrixGroup),
         (GAP.Globals.IsFpGroup, FPGroup),
     ])
+    GAP.Packages.load("forms")
 end
 
 # pkgdir was added in Julia 1.4

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -193,7 +193,10 @@ include("Groups/libraries/libraries.jl")
 include("Groups/GAPGroups.jl")
 include("Groups/directproducts.jl")
 include("Groups/action.jl")
+<<<<<<< HEAD
 include("Groups/gsets.jl")
+=======
+>>>>>>> GAP: deal with matrices, vectors, finite field elements
 include("Groups/matrices/matrices.jl")
 
 include("Rings/integer.jl")

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -194,10 +194,7 @@ include("Groups/libraries/libraries.jl")
 include("Groups/GAPGroups.jl")
 include("Groups/directproducts.jl")
 include("Groups/action.jl")
-<<<<<<< HEAD
 include("Groups/gsets.jl")
-=======
->>>>>>> GAP: deal with matrices, vectors, finite field elements
 include("Groups/matrices/matrices.jl")
 
 include("Rings/integer.jl")

--- a/test/Groups/forms.jl
+++ b/test/Groups/forms.jl
@@ -1,0 +1,155 @@
+@testset "Definition forms" begin
+   T,t = PolynomialRing(FiniteField(3),"t")
+   F,z = FiniteField(t^2+1,"z")
+
+   B = matrix(F,4,4,[0 1 0 0; 2 0 0 0; 0 0 0 z+2; 0 0 1-z 0])
+   @test isskewsymmetric_matrix(B)
+   f = alternating_form(B)
+   @test f isa SesquilinearForm
+   @test gram_matrix(f)==B
+   @test f==alternating_form(gram_matrix(f))
+   @test base_ring(B)==F
+   @test !issymmetric(B)
+   @test !ishermitian_matrix(B)
+   @test isalternating_form(f)
+   @test !isquadratic_form(f)
+   @test !issymmetric_form(f)
+   @test !ishermitian_form(f)
+   @test_throws AssertionError f = symmetric_form(B)
+   @test_throws AssertionError f = hermitian_form(B)
+   @test hermitian_form(B; check=false) isa SesquilinearForm
+
+   B = matrix(F,4,4,[0 1 0 0; 1 0 0 0; 0 0 0 z+2; 0 0 -1-z 0])
+   @test ishermitian_matrix(B)
+   f = hermitian_form(B)
+   @test f isa SesquilinearForm
+   @test gram_matrix(f)==B
+   @test ishermitian_form(f)
+   @test f.mat_iso isa Oscar.GenMatIso
+   @test f.X isa GapObj
+   @test_throws AssertionError f = symmetric_form(B)
+   @test_throws AssertionError f = alternating_form(B)
+   @test_throws ArgumentError corresponding_quadratic_form(f)
+   f = SesquilinearForm(B,:unitary)
+   @test_throws ErrorException f.X
+
+   B = matrix(F,4,4,[0 1 0 0; 1 0 0 0; 0 0 0 z+2; 0 0 z+2 0])
+   @test issymmetric(B)
+   f = symmetric_form(B)
+   @test f isa SesquilinearForm
+   @test gram_matrix(f)==B
+   @test issymmetric_form(f)
+   @test !ishermitian_form(f)
+   @test_throws AssertionError f = alternating_form(B)
+   Qf = corresponding_quadratic_form(f)
+   R = PolynomialRing(F,4)[1]
+   p = R[1]*R[2]+(z+2)*R[3]*R[4]
+   Q = quadratic_form(p)
+   @test Q==Qf
+   @test corresponding_quadratic_form(corresponding_bilinear_form(Q))==Q
+   @test corresponding_bilinear_form(Q)==f
+   B1 = matrix(F,4,4,[0 0 0 0; 1 0 0 0; 0 0 0 0; 0 0 z+2 0])
+   Q1 = quadratic_form(B1)
+   @test Q1==Q
+   @test gram_matrix(Q1)!=B1
+   @test defining_polynomial(Q1) isa AbstractAlgebra.Generic.MPolyElem
+   pf = defining_polynomial(Q1)
+   @test defining_polynomial(Q1)==parent(pf)[1]*parent(pf)[2]+(z+2)*parent(pf)[3]*parent(pf)[4]
+# I can't test simply pf==p, because it returns FALSE. The line
+ #      PolynomialRing(F,4)[1]==PolynomialRing(F,4)[1]
+# returns FALSE.
+   @test_throws ArgumentError corresponding_quadratic_form(Q)
+   @test_throws ArgumentError corresponding_bilinear_form(f)
+
+   R,x = PolynomialRing(F,"x")
+   p = x^2*z
+   Q = quadratic_form(p)
+   @test isquadratic_form(Q)
+   f = corresponding_bilinear_form(Q)
+   @test issymmetric_form(f)
+   @test gram_matrix(f)==matrix(F,1,1,[-z])
+
+   T,t = PolynomialRing(FiniteField(2),"t")
+   F,z = FiniteField(t^2+t+1,"z")
+   R = PolynomialRing(F,4)[1]
+   p = R[1]*R[2]+z*R[3]*R[4]
+   Q = quadratic_form(p)
+   @test isquadratic_form(Q)
+   @test gram_matrix(Q)==matrix(F,4,4,[0 1 0 0; 0 0 0 0; 0 0 0 z; 0 0 0 0])
+   f = corresponding_bilinear_form(Q)
+   @test isalternating_form(f)
+   @test gram_matrix(f)==matrix(F,4,4,[0 1 0 0; 1 0 0 0; 0 0 0 z; 0 0 z 0])
+   @test_throws ArgumentError corresponding_quadratic_form(f)
+
+
+end
+
+@testset "Evaluating forms" begin
+   F,z=GF(3,2,"z")
+   V=VectorSpace(F,6)
+
+   x = matrix(F,6,6,[1,0,0,0,z+1,0,0,0,0,2,1+2*z,1,0,0,1,0,0,z,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,1])
+   f = alternating_form(x-transpose(x))
+   for i in 1:6
+   for j in i:6
+      @test f(V[i],V[j])==f.matrix[i,j]
+   end
+   end
+
+   f = hermitian_form(x+conjugate_transpose(x))
+   for i in 1:6
+   for j in i:6
+      @test f(V[i],V[j])==f(V[j],V[i])^3         # x -> x^3 is the field automorphism
+   end
+   end
+
+   Q = quadratic_form(x)
+   f = corresponding_bilinear_form(Q)
+   @test f.matrix==x+transpose(x)
+   for i in 1:6
+   for j in i:6
+      @test f(V[i],V[j])==Q(V[i]+V[j])-Q(V[i])-Q(V[j])
+   end
+   end
+
+   @test_throws AssertionError Q(V[1],V[5])
+   @test_throws AssertionError f(V[2])
+
+   g = rand(GL(6,F))
+   v = rand(V)
+   w = rand(V)
+   @test (f^g)(v,w)==f(v*g^-1,w*g^-1)
+   @test (Q^g)(v)==Q(v*g^-1)
+end
+
+@testset "Methods with forms" begin
+   F = GF(5,1)[1]
+   V = VectorSpace(F,6)
+   x = zero_matrix(F,6,6)
+   f = symmetric_form(x)
+   @test radical(f)[1]==sub(V,gens(V))[1]
+   x[3,5]=1; x[4,6]=1;
+   f = symmetric_form(x+transpose(x))
+   @test radical(f)[1]==sub(V,[V[1],V[2]])[1]
+   @test f*F(3)==F(3)*f;
+   @test issymmetric_form(f*F(3))
+   @test gram_matrix(f*F(3))==F(3)*(x+transpose(x))
+   @test isdegenerate(f)
+   x[1,2]=1;
+
+   f = symmetric_form(x+transpose(x))
+   @test radical(f)[1]==sub(V,[])[1]
+   Q = corresponding_quadratic_form(f)
+   @test radical(Q)[1]==radical(f)[1]
+   @test witt_index(f)==3
+   @test witt_index(Q)==3
+   @test !isdegenerate(f)
+
+   F = GF(2,1)[1]
+   x = matrix(F,2,2,[1,0,0,0])
+   Q = quadratic_form(x)
+   @test dim(radical(Q)[1])==1
+   f = corresponding_bilinear_form(Q)
+   @test dim(radical(f)[1])==2
+
+end

--- a/test/Groups/forms.jl
+++ b/test/Groups/forms.jl
@@ -17,7 +17,6 @@
    @test !ishermitian_form(f)
    @test_throws AssertionError f = symmetric_form(B)
    @test_throws AssertionError f = hermitian_form(B)
-   @test hermitian_form(B; check=false) isa SesquilinearForm
 
    B = matrix(F,4,4,[0 1 0 0; 1 0 0 0; 0 0 0 z+2; 0 0 -1-z 0])
    @test ishermitian_matrix(B)
@@ -30,8 +29,7 @@
    @test_throws AssertionError f = symmetric_form(B)
    @test_throws AssertionError f = alternating_form(B)
    @test_throws ArgumentError corresponding_quadratic_form(f)
-   f = SesquilinearForm(B,:unitary)
-   @test_throws ErrorException f.X
+   @test_throws ErrorException f = SesquilinearForm(B,:unitary)
 
    B = matrix(F,4,4,[0 1 0 0; 1 0 0 0; 0 0 0 z+2; 0 0 z+2 0])
    @test issymmetric(B)

--- a/test/Groups/operations.jl
+++ b/test/Groups/operations.jl
@@ -146,3 +146,4 @@ end
    @test Oscar._disc_log(F(16),F(1))==0
    @test_throws ErrorException Oscar._disc_log(b,F(0))
 end
+

--- a/test/Groups/operations.jl
+++ b/test/Groups/operations.jl
@@ -146,4 +146,3 @@ end
    @test Oscar._disc_log(F(16),F(1))==0
    @test_throws ErrorException Oscar._disc_log(b,F(0))
 end
-

--- a/test/Groups/runtests.jl
+++ b/test/Groups/runtests.jl
@@ -13,4 +13,4 @@ include("libraries.jl")
 include("directproducts.jl")
 include("matrixgroups.jl")
 include("gsets.jl")
-
+include("forms.jl")


### PR DESCRIPTION
This branch is rebased on `VectSpaces`. Here, there is the definition of the type `SesquilinearForm`, that includes symmetric, alternating, hermitian and quadratic forms. Could be the case to consider quadratic forms as a separate type?
All the content is in the file `src/Groups/forms.jl`. There is the definition of the type and some functionalities, most of them imported from the GAP library "forms".