### PR TITLE
add normalise(::MPolyQuo)

### DIFF
--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -14,7 +14,7 @@ import Hecke: MapHeader, math_html
 
 export PolynomialRing, total_degree, degree, MPolyElem, ordering, ideal,
        groebner_basis, eliminate, syzygy_generators, coordinates, 
-       jacobi_matrix, jacobi_ideal, radical
+       jacobi_matrix, jacobi_ideal, radical, normalize, AlgebraHomomorphism
 
 ##############################################################################
 #
@@ -203,6 +203,8 @@ end
 singular_ring(::Nemo.FlintRationalField) = Singular.Rationals()
 singular_ring(F::Nemo.GaloisField) = Singular.Fp(Int(characteristic(F)))
 singular_ring(F::Nemo.NmodRing) = Singular.Fp(Int(characteristic(F)))
+
+singular_ring(R::Singular.PolyRing; keep_ordering::Bool = true) = R
 
 function singular_ring(Rx::MPolyRing{T}; keep_ordering::Bool = true) where {T <: RingElem}
   if keep_ordering

--- a/test/Rings/MPolyQuo.jl
+++ b/test/Rings/MPolyQuo.jl
@@ -14,3 +14,13 @@
   b = inv(Q(x))
   @test isone(b*Q(x))
 end
+
+@testset "MPolyQuo.normalize" begin
+  R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+  Q, _ = quo(R, ideal(R, [z - x^4, z - y^6]))
+  for (S, M, FI) in normalize(Q)
+    @test parent(FI[1]) == Q
+    @test isa(FI[2], Oscar.Ideal)
+    @test parent(M(Q(x+y))) == S
+  end
+end


### PR DESCRIPTION
The code is terrible and will have to go through many revisions in the near future. This is just a demonstration of getting the data out of singular and ocsarifying it. The printing of the fractional ideal FI will be fixed soon in Singular.jl.
```
julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
julia> Q, _ = quo(R, ideal(R, [z - x^4, z - y^6]))
julia> for (S, M, FI) in normalize(Q)
         @show S
         @show M
         @show FI
         @show typeof(Q(x))
         @show (typeof(M(Q(x+y))), M(Q(x+y)))
       end

S = Quotient of Singular Polynomial Ring (QQ),(T(1),T(2),T(3),x,y,z),(dp(3),dp(3),C) by ideal generated by: -T(3)*y+x, T(1)*x-T(2)*y, -T(2)*x+y^2, T(1)*y^2-T(3)*x, T(2)*y^3-T(3)*x^2, -T(2)*x^2+T(3)*y^3, -T(1)*z+T(2)*x^3*y, T(3)*x^3*y-z, T(1)^2-1, T(1)*T(2)-T(3), T(2)^2-T(1)*y, T(1)*T(3)-T(2), T(2)*T(3)-y, T(3)^2-T(1)*y, x^4-z, y^6-z
M = AlgebraHomomorphism(Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal generated by: -x^4 + z, -y^6 + z => Quotient of Singular Polynomial Ring (QQ),(T(1),T(2),T(3),x,y,z),(dp(3),dp(3),C) by ideal generated by: -T(3)*y+x, T(1)*x-T(2)*y, -T(2)*x+y^2, T(1)*y^2-T(3)*x, T(2)*y^3-T(3)*x^2, -T(2)*x^2+T(3)*y^3, -T(1)*z+T(2)*x^3*y, T(3)*x^3*y-z, T(1)^2-1, T(1)*T(2)-T(3), T(2)^2-T(1)*y, T(1)*T(3)-T(2), T(2)*T(3)-y, T(3)^2-T(1)*y, x^4-z, y^6-z, Singular.spoly{Singular.n_Q}[x, y, z])
FI = (z, MPolyQuoIdeal(x2y3, x3y2, xy5, z))
typeof(Q(x)) = Oscar.MPolyQuoElem{fmpq_mpoly}
(typeof(M(Q(x + y))), M(Q(x + y))) = (Oscar.MPolyQuoElem{Singular.spoly{Singular.n_Q}}, x + y)
```