### PR TITLE
CI: don't cache Julia artifacts

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,17 +40,6 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
-      - name: Cache artifacts
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
       - name: "Build package"
         uses: julia-actions/julia-buildpkg@latest
       - name: "Run tests"


### PR DESCRIPTION
The caching step seems to take ~50 seconds recently. I wonder if it really saves us any time vs. just installing all packages and artifacts fresh. With this PR, we can hopefully find out, and then decide whether to keep the caching step or not.