### PR TITLE
New isometry groups

### DIFF
--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -159,8 +159,12 @@ function assign_from_description(G::MatrixGroup)
    elseif G.descr==Symbol("GO+") G.X=GAP.Globals.GO(1,G.deg,G.mat_iso.fr.codomain)
    elseif G.descr==Symbol("SO+") G.X=GAP.Globals.SO(1,G.deg,G.mat_iso.fr.codomain)
    elseif G.descr==Symbol("Omega+")
+      # FIXME/TODO: Work around GAP issue <https://github.com/gap-system/gap/issues/500>
+      # using the following inefficient code. In the future, we should use appropriate
+      # generators for Omega (e.g. by applying a form change matrix to the Omega
+      # generators returned by GAP).
+      L = GAP.Globals.SubgroupsOfIndexTwo(GAP.Globals.SO(1,G.deg,G.mat_iso.fr.codomain))
       if G.deg==4 && order(G.ring)==2  # this is the only case SO(n,q) has more than one subgroup of index 2
-         L = GAP.Globals.SubgroupsOfIndexTwo(GAP.Globals.SO(1,G.deg,G.mat_iso.fr.codomain))
          for y in L
             _ranks = [GAP.Globals.Rank(u) for u in GAP.Globals.GeneratorsOfGroup(y)]
             if all(r->iseven(r),_ranks)
@@ -169,7 +173,8 @@ function assign_from_description(G::MatrixGroup)
             end
          end
       else
-         G.X=GAP.Globals.SubgroupsOfIndexTwo(GAP.Globals.SO(1,G.deg,G.mat_iso.fr.codomain))[1]
+         @assert length(L) == 1
+         G.X=L[1]
       end
    elseif G.descr==Symbol("GO-") G.X=GAP.Globals.GO(-1,G.deg,G.mat_iso.fr.codomain)
    elseif G.descr==Symbol("SO-") G.X=GAP.Globals.SO(-1,G.deg,G.mat_iso.fr.codomain)

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -162,9 +162,24 @@ function assign_from_description(G::MatrixGroup)
    elseif G.descr==Symbol("GO-") G.X=GAP.Globals.GO(-1,G.deg,G.mat_iso.fr.codomain)
    elseif G.descr==Symbol("SO-") G.X=GAP.Globals.SO(-1,G.deg,G.mat_iso.fr.codomain)
    elseif G.descr==Symbol("Omega-") G.X=GAP.Globals.Omega(-1,G.deg,Int(order(G.ring)))
-   elseif G.descr==:GO G.X=GAP.Globals.GO(0,G.deg,G.mat_iso.fr.codomain)
-   elseif G.descr==:SO G.X=GAP.Globals.SO(0,G.deg,G.mat_iso.fr.codomain)
-   elseif G.descr==:Omega G.X=GAP.Globals.Omega(0,G.deg,Int(order(G.ring)))
+   elseif G.descr==:GO
+      if G.deg==1
+         G.X=GAP.Globals.Group(GapObj([GapObj([-GAP.Globals.One(G.mat_iso.f.riso.codomain)])]))
+      else
+         G.X=GAP.Globals.GO(0,G.deg,G.mat_iso.fr.codomain)
+      end
+   elseif G.descr==:SO
+      if G.deg==1
+         G.X=GAP.Globals.Group(GapObj([GapObj([GAP.Globals.One(G.mat_iso.f.riso.codomain)])]))
+      else
+         G.X=GAP.Globals.SO(0,G.deg,G.mat_iso.fr.codomain)
+      end
+   elseif G.descr==:Omega
+      if G.deg==1
+         G.X=GAP.Globals.Group(GapObj([GapObj([GAP.Globals.One(G.mat_iso.f.riso.codomain)])]))
+      else
+         G.X=GAP.Globals.Omega(0,G.deg,Int(order(G.ring)))
+      end
    elseif G.descr==:GU G.X=GAP.Globals.GU(G.deg,Int(characteristic(G.ring)^(div(degree(G.ring),2) ) ))
    elseif G.descr==:SU G.X=GAP.Globals.SU(G.deg,Int(characteristic(G.ring)^(div(degree(G.ring),2) ) ))
    else error("unsupported description")

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -163,6 +163,7 @@ function assign_from_description(G::MatrixGroup)
       # using the following inefficient code. In the future, we should use appropriate
       # generators for Omega (e.g. by applying a form change matrix to the Omega
       # generators returned by GAP).
+      # This also compensates for the fact that Omega(-1,2,q) is not supported in GAP.
       L = GAP.Globals.SubgroupsOfIndexTwo(GAP.Globals.SO(1,G.deg,G.mat_iso.fr.codomain))
       if G.deg==4 && order(G.ring)==2  # this is the only case SO(n,q) has more than one subgroup of index 2
          for y in L
@@ -179,6 +180,8 @@ function assign_from_description(G::MatrixGroup)
    elseif G.descr==Symbol("GO-") G.X=GAP.Globals.GO(-1,G.deg,G.mat_iso.fr.codomain)
    elseif G.descr==Symbol("SO-") G.X=GAP.Globals.SO(-1,G.deg,G.mat_iso.fr.codomain)
    elseif G.descr==Symbol("Omega-") G.X=GAP.Globals.SubgroupsOfIndexTwo(GAP.Globals.SO(-1,G.deg,G.mat_iso.fr.codomain))[1]
+   # TODO : we define explicitly orthogonal groups in dimension 1, since GAP does not support them
+   # GO(1,q) = { +1, -1 } and SO(1,q)=Omega(1,q) = { +1 }.
    elseif G.descr==:GO
       if G.deg==1
          G.X=GAP.Globals.Group(GapObj([GapObj([-GAP.Globals.One(G.mat_iso.f.riso.codomain)])]))

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -218,17 +218,17 @@ end
          @testset for e in [+1,-1]
             G = GO(e,n,F)
             S = SO(e,n,F)
+            O = omega_group(e,n,F)
             @test G==GO(e,n,q)
             @test G==orthogonal_group(e,n,F)
             @test G==orthogonal_group(e,n,q)
             @test S==SO(e,n,q)
             @test S==special_orthogonal_group(e,n,F)
             @test S==special_orthogonal_group(e,n,q)
+            @test O==omega_group(e,n,q)
+            @test index(S,O)==2
             if isodd(q)
                @test index(G,S)==2
-               @test order(S)==2*order(omega_group(e,n,q))
-            else
-               @test order(G)==2*order(omega_group(e,n,q))
             end
          end
       end
@@ -236,14 +236,16 @@ end
          if isodd(q)
             G = GO(n,F)
             S = SO(n,F)
+            O = omega_group(n,F)
             @test G==GO(n,q)
             @test G==orthogonal_group(n,F)
             @test G==orthogonal_group(n,q)
             @test S==SO(n,q)
             @test S==special_orthogonal_group(n,F)
             @test S==special_orthogonal_group(n,q)
+            @test O==omega_group(n,q)
             @test index(G,S)==2
-            @test order(S)==2*order(omega_group(n,q))
+            @test index(S,O)==2
          end
       end
    end
@@ -255,8 +257,13 @@ end
    @test_throws ArgumentError SO(+2,2,5)
    @test_throws ArgumentError omega_group(-2,4,3)
 
-   G = GL(4,3)
-   
+   @test omega_group(1,5)==SO(1,5)
+   @test index(GO(1,7),omega_group(1,7))==2
+   @test order(omega_group(1,5))==1
+   G = omega_group(1,4,2)
+   @testset for x in gens(G)
+       @test iseven(rank(x.elm-1))
+   end
 end
 
 


### PR DESCRIPTION
There are two novelties in this PR, both in the file `MatGrp.jl`.
1) Orthogonal groups (so `GO`, `SO` and `omega_group`) can be defined of dimension 1. E.g. `GO(1,3)` or `omega_group(1,5)`. Here, `GO(1,q)` contains only the matrices `+1` and `-1`, while `SO(1,q)` and `omega_group(1,q)` contain only the identity matrix. This definition could be useful in further branches like `transform-form`.
2) In GAP, the forms fixed by `GO` and `omega_group` are different, so `omega_group(n,q)` is not a subgroup of `GO(n,q)`. Here, I define `omega_group` as the only subgroup of `SO(n,q)` of index 2, using the GAP function `SubgroupsOfIndexTwo`.
Tests are also added.
If we do not agree with these changes, we can also keep just one of them.