### PR TITLE
Add eltype + tests

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -492,12 +492,7 @@ function Base.rand(C::GroupConjClass{S,T}) where S where T<:GAPGroupElem
    return group_element(C.X, GAP.Globals.Random(C.CC))
 end
 
-"""
-    elements(C::GroupConjClass)
-
-Return the array of the elements in C.
-"""
-elements(C::GroupConjClass) = collect(C)
+@deprecate elements(C::GroupConjClass) collect(C)
 
 """
     conjugacy_classes(G::Group)
@@ -614,9 +609,9 @@ end
 # START iterator
 Base.IteratorSize(::Type{<:GroupConjClass}) = Base.SizeUnknown()
 
-Base.iterate(cc::GroupConjClass) = iterate(CC, GAP.Globals.Iterator(cc.CC))
+Base.iterate(cc::GroupConjClass) = iterate(cc, GAP.Globals.Iterator(cc.CC))
 
-function Base.iterate(cc::GroupConjClass, state::GapObj)
+function Base.iterate(cc::GroupConjClass{S,T}, state::GapObj) where {S,T}
   if GAP.Globals.IsDoneIterator(state)
     return nothing
   end

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -457,7 +457,6 @@ struct GroupConjClass{T<:GAPGroup, S<:Union{GAPGroupElem,GAPGroup}}
 end
 
 Base.eltype(::Type{GroupConjClass{T,S}}) where {T,S} = S
-Base.eltype(::Type{GroupConjClass}) = GAPGroupElem
 Base.hash(x::GroupConjClass, h::UInt) = h # FIXME
 
 function Base.show(io::IO, x::GroupConjClass)
@@ -498,7 +497,7 @@ end
 
 Return the array of the elements in C.
 """
-elements(C::GroupConjClass{S, T}) where {S,T} = collect(C)
+elements(C::GroupConjClass) = collect(C)
 
 """
     conjugacy_classes(G::Group)
@@ -615,20 +614,9 @@ end
 # START iterator
 Base.IteratorSize(::Type{<:GroupConjClass}) = Base.SizeUnknown()
 
-function Base.iterate(cc::GroupConjClass{S,T}) where {S,T}
-  L=GAP.Globals.Iterator(cc.CC)
-  if GAP.Globals.IsDoneIterator(L)
-    return nothing
-  end
-  i = GAP.Globals.NextIterator(L)
-  if T <: GAPGroupElem
-     return group_element(cc.X, i), L
-  else
-     return _as_subgroup(cc.X, i)[1], L
-  end
-end
+Base.iterate(cc::GroupConjClass) = iterate(CC, GAP.Globals.Iterator(cc.CC))
 
-function Base.iterate(cc::GroupConjClass{S,T}, state) where {S,T}
+function Base.iterate(cc::GroupConjClass, state::GapObj)
   if GAP.Globals.IsDoneIterator(state)
     return nothing
   end

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -456,6 +456,8 @@ struct GroupConjClass{T<:GAPGroup, S<:Union{GAPGroupElem,GAPGroup}}
    CC::GapObj
 end
 
+Base.eltype(::Type{GroupConjClass{T,S}}) where {T,S} = S
+Base.eltype(::Type{GroupConjClass}) = GAPGroupElem
 Base.hash(x::GroupConjClass, h::UInt) = h # FIXME
 
 function Base.show(io::IO, x::GroupConjClass)

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -2,7 +2,6 @@ export
     acting_domain,
     double_coset,
     double_cosets,
-#    elements,
     GroupCoset,
     GroupDoubleCoset,
     isbicoset,

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -2,7 +2,7 @@ export
     acting_domain,
     double_coset,
     double_cosets,
-    elements,
+#    elements,
     GroupCoset,
     GroupDoubleCoset,
     isbicoset,
@@ -141,12 +141,7 @@ If `C` = `Hx` or `xH`, return `x`.
 """
 representative(C::GroupCoset) = C.repr
 
-"""
-    elements(C::GroupCoset)
-
-Return the array of all elements of the coset `C`.
-"""
-elements(C::GroupCoset) = collect(C)
+@deprecate elements(C::GroupCoset) collect(C)
 
 """
     isbicoset(C::GroupCoset)
@@ -209,14 +204,7 @@ function left_transversal(G::T, H::T) where T<: GAPGroup
    return [x^-1 for x in right_transversal(G,H)]
 end
 
-function Base.iterate(G::GroupCoset)
-  L=GAP.Globals.Iterator(G.X)
-  if GAP.Globals.IsDoneIterator(L)
-    return nothing
-  end
-  i = GAP.Globals.NextIterator(L)
-  return group_element(G.G, i), L
-end
+Base.iterate(G::GroupCoset) = iterate(G, GAP.Globals.Iterator(G.X))
 
 function Base.iterate(G::GroupCoset, state)
   if GAP.Globals.IsDoneIterator(state)
@@ -301,12 +289,7 @@ function double_cosets(G::T, H::T, K::T; NC=false) where T<: GAPGroup
    #return [GroupDoubleCoset(G,H,K,group_element(G.X,GAP.Globals.Representative(dc)),dc) for dc in dcs]
 end
 
-"""
-    elements(C::GroupDoubleCoset)
-
-Return the array of all elements of the double coset `C`.
-"""
-elements(C::GroupDoubleCoset) = collect(C)
+@deprecate elements(C::GroupDoubleCoset) collect(C)
 
 """
     order(C::Union{GroupCoset,GroupDoubleCoset})

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -142,14 +142,12 @@ If `C` = `Hx` or `xH`, return `x`.
 """
 representative(C::GroupCoset) = C.repr
 
-function elements(C::GroupCoset)
-  L = GAP.Globals.AsList(C.X)
-  l = Vector{elem_type(C.G)}(undef, length(L))
-  for i = 1:length(l)
-    l[i] = group_element(C.G, L[i])
-  end
-  return l
-end
+"""
+    elements(C::GroupCoset)
+
+Return the array of all elements of the coset `C`.
+"""
+elements(C::GroupCoset) = collect(C)
 
 """
     isbicoset(C::GroupCoset)
@@ -310,14 +308,7 @@ end
 
 Return the array of all elements of the double coset `C`.
 """
-function elements(C::GroupDoubleCoset)
-  L = GAP.Globals.AsList(C.X)
-  l = Vector{elem_type(C.G)}(undef, length(L))
-  for i = 1:length(l)
-    l[i] = group_element(C.G, L[i])
-  end
-  return l
-end
+elements(C::GroupDoubleCoset) = collect(C)
 
 """
     order(C::Union{GroupCoset,GroupDoubleCoset})

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -204,6 +204,7 @@ function left_transversal(G::T, H::T) where T<: GAPGroup
    return [x^-1 for x in right_transversal(G,H)]
 end
 
+Base.IteratorSize(::Type{<:GroupCoset}) = Base.SizeUnknown()
 Base.iterate(G::GroupCoset) = iterate(G, GAP.Globals.Iterator(G.X))
 
 function Base.iterate(G::GroupCoset, state)
@@ -327,14 +328,9 @@ if `C` = `HxK`, returns `K`
 """
 right_acting_group(C::GroupDoubleCoset) = C.K
 
-function Base.iterate(G::GroupDoubleCoset)
-  L=GAP.Globals.Iterator(G.X)
-  if GAP.Globals.IsDoneIterator(L)
-    return nothing
-  end
-  i = GAP.Globals.NextIterator(L)
-  return group_element(G.G, i), L
-end
+Base.IteratorSize(::Type{<:GroupDoubleCoset}) = Base.SizeUnknown()
+
+Base.iterate(G::GroupDoubleCoset) = iterate(G, GAP.Globals.Iterator(G.X))
 
 function Base.iterate(G::GroupDoubleCoset, state)
   if GAP.Globals.IsDoneIterator(state)

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -33,6 +33,8 @@ struct GroupCoset{T<: GAPGroup, S <: GAPGroupElem}
 end
 
 Base.hash(x::GroupCoset, h::UInt) = h # FIXME
+Base.eltype(::Type{GroupCoset{T,S}}) where {T,S} = S
+Base.eltype(::Type{GroupCoset}) = GAPGroupElem
 
 function _group_coset(G::GAPGroup, H::GAPGroup, repr::GAPGroupElem, side::Symbol, X::GapObj)
   return GroupCoset{typeof(G), typeof(repr)}(G, H, repr, side, X)
@@ -244,6 +246,8 @@ struct GroupDoubleCoset{T <: GAPGroup, S <: GAPGroupElem}
 end
 
 Base.hash(x::GroupDoubleCoset, h::UInt) = h # FIXME
+Base.eltype(::Type{GroupDoubleCoset{T,S}}) where {T,S} = S
+Base.eltype(::Type{GroupDoubleCoset}) = GAPGroupElem
 
 function ==(x::GroupDoubleCoset, y::GroupDoubleCoset)
    return x.X == y.X

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -34,7 +34,6 @@ end
 
 Base.hash(x::GroupCoset, h::UInt) = h # FIXME
 Base.eltype(::Type{GroupCoset{T,S}}) where {T,S} = S
-Base.eltype(::Type{GroupCoset}) = GAPGroupElem
 
 function _group_coset(G::GAPGroup, H::GAPGroup, repr::GAPGroupElem, side::Symbol, X::GapObj)
   return GroupCoset{typeof(G), typeof(repr)}(G, H, repr, side, X)
@@ -245,7 +244,6 @@ end
 
 Base.hash(x::GroupDoubleCoset, h::UInt) = h # FIXME
 Base.eltype(::Type{GroupDoubleCoset{T,S}}) where {T,S} = S
-Base.eltype(::Type{GroupDoubleCoset}) = GAPGroupElem
 
 function ==(x::GroupDoubleCoset, y::GroupDoubleCoset)
    return x.X == y.X

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -117,6 +117,9 @@ mat_elem_type(::Type{MatrixGroup{S,T}}) where {S,T} = T
 _gap_filter(::Type{<:MatrixGroup}) = GAP.Globals.IsMatrixGroup
 
 elem_type(::Type{MatrixGroup{S,T}}) where {S,T} = MatrixGroupElem{S,T}
+elem_type(::Type{MatrixGroup}) = MatrixGroupElem
+Base.eltype(::Type{MatrixGroup{S,T}}) where {S,T} = MatrixGroupElem{S,T}
+Base.eltype(::Type{MatrixGroup}) = MatrixGroupElem
 
 
 ########################################################################

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -117,9 +117,8 @@ mat_elem_type(::Type{MatrixGroup{S,T}}) where {S,T} = T
 _gap_filter(::Type{<:MatrixGroup}) = GAP.Globals.IsMatrixGroup
 
 elem_type(::Type{MatrixGroup{S,T}}) where {S,T} = MatrixGroupElem{S,T}
-elem_type(::Type{MatrixGroup}) = MatrixGroupElem
+elem_type(::MatrixGroup{S,T}) where {S,T} = MatrixGroupElem{S,T}
 Base.eltype(::Type{MatrixGroup{S,T}}) where {S,T} = MatrixGroupElem{S,T}
-Base.eltype(::Type{MatrixGroup}) = MatrixGroupElem
 
 
 ########################################################################

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -267,6 +267,8 @@ might also be needed.
 
 elem_type(::Type{T}) where T <: GAPGroup = BasicGAPGroupElem{T}
 
+Base.eltype(::Type{T}) where T <: GAPGroup = BasicGAPGroupElem{T}
+
 
 
 #

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -266,6 +266,7 @@ might also be needed.
 """
 
 elem_type(::Type{T}) where T <: GAPGroup = BasicGAPGroupElem{T}
+elem_type(::T) where T <: GAPGroup = BasicGAPGroupElem{T}
 
 Base.eltype(::Type{T}) where T <: GAPGroup = BasicGAPGroupElem{T}
 
@@ -287,5 +288,4 @@ function _get_type(G::GapObj)
   end
   error("Not a known type of group")
 end
-
 

--- a/test/Groups/conjugation.jl
+++ b/test/Groups/conjugation.jl
@@ -33,7 +33,7 @@
   cc = conjugacy_class(G,x)
 
   @test length(cc) == 3
-  @test Set(collect(cc)) == Set([x^y for y in G])
+  @test Set(collect(cc)) == Set(x^y for y in G)
   y = rand(cc)
   @test y in collect(cc)
   @test order(y) == 2

--- a/test/Groups/conjugation.jl
+++ b/test/Groups/conjugation.jl
@@ -41,11 +41,11 @@
   C = conjugacy_classes(G)
   @test length(C) == 5
   @test cc in C
-  @test sum([length(c) for c in C]) == order(G)
-  @test sum([x in collect(c) for c in C]) == 1          # x belongs to a unique conjugacy class
-  @test count(c -> y in c, C) == 1          # x belongs to a unique conjugacy class
+  @test sum(length, C) == order(G)
+  @test count(c -> x in c, C) == 1          # x belongs to a unique conjugacy class
+  @test count(c -> y in c, C) == 1          # y belongs to a unique conjugacy class
   z = rand(G)
-  @test sum([z in collect(c) for c in C]) == 1          # x belongs to a unique conjugacy class
+  @test count(c -> z in c, C) == 1          # z belongs to a unique conjugacy class
   @testset for i in 1:5
      c = C[i]
      x = rand(c)
@@ -67,7 +67,7 @@
   end
   H=rand(subgroups(G))
   @test sum([length(c) for c in CC]) == length(subgroups(G))
-  @test sum([H in collect(c) for c in CC]) == 1         # H belongs to a unique conjugacy class
+  @test count(c -> H in c, CC) == 1          # H belongs to a unique conjugacy class
   @testset for i in 1:length(CC)
      c = CC[i]
      x = rand(c)
@@ -104,8 +104,8 @@ function TestConjCentr(G,x)
    cc = conjugacy_class(G,x)
    @test index(G,Cx)==length(cc)
    T=right_transversal(G,Cx)
-   @testset for y in collect(cc)
-       @test sum([y==x^t for t in T])==1
+   @testset for y in cc
+       @test count(t -> y==x^t, T) == 1
    end
    
    cs = conjugacy_class(G,Cx)

--- a/test/Groups/conjugation.jl
+++ b/test/Groups/conjugation.jl
@@ -9,7 +9,7 @@
   
   ccid = conjugacy_class(G,one(G))
   @test length(ccid)==1
-  @test elements(ccid) == [one(G)]
+  @test collect(ccid) == [one(G)]
   
   x = perm(G,vcat(2:n,[1]))
   cc = conjugacy_class(G,x)
@@ -33,19 +33,19 @@
   cc = conjugacy_class(G,x)
 
   @test length(cc) == 3
-  @test Set(elements(cc)) == Set([x^y for y in G])
+  @test Set(collect(cc)) == Set([x^y for y in G])
   y = rand(cc)
-  @test y in elements(cc)
+  @test y in collect(cc)
   @test order(y) == 2
 
   C = conjugacy_classes(G)
   @test length(C) == 5
   @test cc in C
   @test sum([length(c) for c in C]) == order(G)
-  @test sum([x in elements(c) for c in C]) == 1          # x belongs to a unique conjugacy class
-  @test sum([y in elements(c) for c in C]) == 1          # x belongs to a unique conjugacy class
+  @test sum([x in collect(c) for c in C]) == 1          # x belongs to a unique conjugacy class
+  @test sum([y in collect(c) for c in C]) == 1          # x belongs to a unique conjugacy class
   z = rand(G)
-  @test sum([z in elements(c) for c in C]) == 1          # x belongs to a unique conjugacy class
+  @test sum([z in collect(c) for c in C]) == 1          # x belongs to a unique conjugacy class
   @testset for i in 1:5
      c = C[i]
      x = rand(c)
@@ -67,7 +67,7 @@
   end
   H=rand(subgroups(G))
   @test sum([length(c) for c in CC]) == length(subgroups(G))
-  @test sum([H in elements(c) for c in CC]) == 1         # H belongs to a unique conjugacy class
+  @test sum([H in collect(c) for c in CC]) == 1         # H belongs to a unique conjugacy class
   @testset for i in 1:length(CC)
      c = CC[i]
      x = rand(c)
@@ -104,7 +104,7 @@ function TestConjCentr(G,x)
    cc = conjugacy_class(G,x)
    @test index(G,Cx)==length(cc)
    T=right_transversal(G,Cx)
-   @testset for y in elements(cc)
+   @testset for y in collect(cc)
        @test sum([y==x^t for t in T])==1
    end
    
@@ -112,8 +112,8 @@ function TestConjCentr(G,x)
    Nx = normalizer(G,Cx)[1]
    @test index(G,Nx)==length(cs)
    T=right_transversal(G,Nx)
-   # Set([Cx^t for t in T]) == Set(elements(cs)) does not work
-   @testset for H in elements(cs)
+   # Set([Cx^t for t in T]) == Set(collect(cs)) does not work
+   @testset for H in collect(cs)
        @test sum([H==Cx^t for t in T])==1
    end
 end

--- a/test/Groups/conjugation.jl
+++ b/test/Groups/conjugation.jl
@@ -43,7 +43,7 @@
   @test cc in C
   @test sum([length(c) for c in C]) == order(G)
   @test sum([x in collect(c) for c in C]) == 1          # x belongs to a unique conjugacy class
-  @test sum([y in collect(c) for c in C]) == 1          # x belongs to a unique conjugacy class
+  @test count(c -> y in c, C) == 1          # x belongs to a unique conjugacy class
   z = rand(G)
   @test sum([z in collect(c) for c in C]) == 1          # x belongs to a unique conjugacy class
   @testset for i in 1:5

--- a/test/Groups/elements.jl
+++ b/test/Groups/elements.jl
@@ -74,10 +74,10 @@ end
    @test eltype(FPGroup)==FPGroupElem
    @test eltype(MatrixGroup)==MatrixGroupElem
    @test eltype(GL(2,3))==MatrixGroupElem{fq_nmod,fq_nmod_mat}
-   @test eltype(DirectProductGroup)==BasicGAPGroupElem{DirectProductGroup}
-   @test eltype(direct_product(symmetric_group(3),cyclic_group(2)))==BasicGAPGroupElem{DirectProductGroup}
-   @test eltype(SemidirectProductGroup)==BasicGAPGroupElem{SemidirectProductGroup}
-   @test eltype(WreathProductGroup)==BasicGAPGroupElem{WreathProductGroup}
+   @test eltype(DirectProductGroup)==Oscar.BasicGAPGroupElem{DirectProductGroup}
+   @test eltype(direct_product(symmetric_group(3),cyclic_group(2)))==Oscar.BasicGAPGroupElem{DirectProductGroup}
+   @test eltype(SemidirectProductGroup)==Oscar.BasicGAPGroupElem{SemidirectProductGroup}
+   @test eltype(WreathProductGroup)==Oscar.BasicGAPGroupElem{WreathProductGroup}
    @test eltype(AutomorphismGroup)==Oscar.BasicGAPGroupElem{AutomorphismGroup}
    @test eltype(AutomorphismGroup{PcGroup})==Oscar.BasicGAPGroupElem{AutomorphismGroup{PcGroup}}
    @test eltype(GroupConjClass)==GAPGroupElem

--- a/test/Groups/elements.jl
+++ b/test/Groups/elements.jl
@@ -68,6 +68,26 @@ end
   end
 end
 
+@testset "Eltypes" begin
+   @test eltype(PermGroup)==PermGroupElem
+   @test eltype(PcGroup)==PcGroupElem
+   @test eltype(FPGroup)==FPGroupElem
+   @test eltype(MatrixGroup)==MatrixGroupElem
+   @test eltype(GL(2,3))==MatrixGroupElem{fq_nmod,fq_nmod_mat}
+   @test eltype(DirectProductGroup)==BasicGAPGroupElem{DirectProductGroup}
+   @test eltype(direct_product(symmetric_group(3),cyclic_group(2)))==BasicGAPGroupElem{DirectProductGroup}
+   @test eltype(SemidirectProductGroup)==BasicGAPGroupElem{SemidirectProductGroup}
+   @test eltype(WreathProductGroup)==BasicGAPGroupElem{WreathProductGroup}
+   @test eltype(AutomorphismGroup)==Oscar.BasicGAPGroupElem{AutomorphismGroup}
+   @test eltype(AutomorphismGroup{PcGroup})==Oscar.BasicGAPGroupElem{AutomorphismGroup{PcGroup}}
+   @test eltype(GroupConjClass)==GAPGroupElem
+   @test eltype(GroupConjClass{PermGroup,PermGroupElem})==PermGroupElem
+   @test eltype(GroupConjClass{PcGroup,PcGroup})==PcGroup
+   @test eltype(GroupCoset)==GAPGroupElem
+   @test eltype(GroupCoset{PermGroup,PermGroupElem})==PermGroupElem
+   @test eltype(GroupDoubleCoset{PcGroup,PcGroupElem})==PcGroupElem
+end
+
 @testset "Generators" begin
    L=[symmetric_group(4), cyclic_group(5), free_group(3), symplectic_group(4,3)]
    for G in L

--- a/test/Groups/elements.jl
+++ b/test/Groups/elements.jl
@@ -86,11 +86,15 @@ end
    y = cperm(G,[2,3,4])
    cc = conjugacy_class(G,y)
    cs = conjugacy_class(G,H)
-   ls = x*H
+   lc = x*H
    @test [z for z in G] == @inferred collect(G)
    @test [z for z in cc] == @inferred collect(cc)
    @test [z for z in cs] == @inferred collect(cs)
-   @test [z for z in lc] == @inferred collect(lc)
+   @test [z for z in lc] == collect(lc)
+   @test typeof(collect(G))==Vector{typeof(x)}
+   @test typeof(collect(lc))==Vector{typeof(x)}
+   @test typeof(collect(cc))==Vector{typeof(x)}
+   @test typeof(collect(cs))==Vector{typeof(H)}
    @test eltype(cc)==typeof(y)
    @test eltype(cs)==typeof(H)
    @test eltype(lc)==typeof(y)

--- a/test/Groups/elements.jl
+++ b/test/Groups/elements.jl
@@ -92,8 +92,8 @@ end
    @test [z for z in G] == @inferred collect(G)
    @test [z for z in cc] == @inferred collect(cc)
    @test [z for z in cs] == @inferred collect(cs)
-   @test [z for z in lc] == collect(lc)
-   @test [z for z in dc] == collect(dc)
+   @test [z for z in lc] == @inferred collect(lc)
+   @test [z for z in dc] == @inferred collect(dc)
    @test typeof(collect(G))==Vector{typeof(x)}
    @test typeof(collect(lc))==Vector{typeof(x)}
    @test typeof(collect(cc))==Vector{typeof(x)}

--- a/test/Groups/elements.jl
+++ b/test/Groups/elements.jl
@@ -72,7 +72,6 @@ end
    @test eltype(PermGroup)==PermGroupElem
    @test eltype(PcGroup)==PcGroupElem
    @test eltype(FPGroup)==FPGroupElem
-   @test eltype(MatrixGroup)==MatrixGroupElem
    @test eltype(GL(2,3))==MatrixGroupElem{fq_nmod,fq_nmod_mat}
    @test eltype(DirectProductGroup)==Oscar.BasicGAPGroupElem{DirectProductGroup}
    @test eltype(direct_product(symmetric_group(3),cyclic_group(2)))==Oscar.BasicGAPGroupElem{DirectProductGroup}
@@ -84,13 +83,17 @@ end
    x = cperm([1,4,2,5])
    H = sub(G,[x])[1]
    y = cperm(G,[2,3,4])
+   w = cperm(G,[1,4])
+   K = sub(G,[w])[1]
    cc = conjugacy_class(G,y)
    cs = conjugacy_class(G,H)
    lc = x*H
+   dc = K*x*H
    @test [z for z in G] == @inferred collect(G)
    @test [z for z in cc] == @inferred collect(cc)
    @test [z for z in cs] == @inferred collect(cs)
    @test [z for z in lc] == collect(lc)
+   @test [z for z in dc] == collect(dc)
    @test typeof(collect(G))==Vector{typeof(x)}
    @test typeof(collect(lc))==Vector{typeof(x)}
    @test typeof(collect(cc))==Vector{typeof(x)}
@@ -98,7 +101,6 @@ end
    @test eltype(cc)==typeof(y)
    @test eltype(cs)==typeof(H)
    @test eltype(lc)==typeof(y)
-   @test eltype(GroupDoubleCoset{PcGroup,PcGroupElem})==PcGroupElem
 end
 
 @testset "Generators" begin

--- a/test/Groups/elements.jl
+++ b/test/Groups/elements.jl
@@ -78,13 +78,22 @@ end
    @test eltype(direct_product(symmetric_group(3),cyclic_group(2)))==Oscar.BasicGAPGroupElem{DirectProductGroup}
    @test eltype(SemidirectProductGroup)==Oscar.BasicGAPGroupElem{SemidirectProductGroup}
    @test eltype(WreathProductGroup)==Oscar.BasicGAPGroupElem{WreathProductGroup}
-   @test eltype(AutomorphismGroup)==Oscar.BasicGAPGroupElem{AutomorphismGroup}
    @test eltype(AutomorphismGroup{PcGroup})==Oscar.BasicGAPGroupElem{AutomorphismGroup{PcGroup}}
-   @test eltype(GroupConjClass)==GAPGroupElem
-   @test eltype(GroupConjClass{PermGroup,PermGroupElem})==PermGroupElem
-   @test eltype(GroupConjClass{PcGroup,PcGroup})==PcGroup
-   @test eltype(GroupCoset)==GAPGroupElem
-   @test eltype(GroupCoset{PermGroup,PermGroupElem})==PermGroupElem
+
+   G = symmetric_group(5)
+   x = cperm([1,4,2,5])
+   H = sub(G,[x])[1]
+   y = cperm(G,[2,3,4])
+   cc = conjugacy_class(G,y)
+   cs = conjugacy_class(G,H)
+   ls = x*H
+   @test [z for z in G] == @inferred collect(G)
+   @test [z for z in cc] == @inferred collect(cc)
+   @test [z for z in cs] == @inferred collect(cs)
+   @test [z for z in lc] == @inferred collect(lc)
+   @test eltype(cc)==typeof(y)
+   @test eltype(cs)==typeof(H)
+   @test eltype(lc)==typeof(y)
    @test eltype(GroupDoubleCoset{PcGroup,PcGroupElem})==PcGroupElem
 end
 

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -313,7 +313,7 @@ end
    end
    @test N==99
 
-   @test Set(elements(G))==Set([x for x in G])
+   @test Set(collect(G))==Set([x for x in G])
 end
 
 @testset "Membership" begin
@@ -454,16 +454,16 @@ end
    @test order(C)==64
 
    cc = conjugacy_class(G,x)
-   @test x^G[2] in elements(cc)
+   @test x^G[2] in collect(cc)
    @test representative(cc)==x
    @test parent(representative(cc))==G
    @test length(cc)==index(G,C)
 
    cc = conjugacy_class(G,H)
-   @test H^G[2] in elements(cc)
+   @test H^G[2] in collect(cc)
    @test representative(cc)==H
    @test length(cc)==index(G,normalizer(G,H)[1])
-   @test rand(cc) in elements(cc)
+   @test rand(cc) in collect(cc)
 
    x = G([1,z,0,1])
    y = G([1,0,0,z+1])

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -181,7 +181,7 @@ end
       @test representative(rc) == x
       @test representative(lc) == x
       @test representative(dc) == x
-      @test Set(collect(rc)) == Set(z for z in rc)          # test iterator
+      @test length(collect(rc)) == length(rc)
       @test Set(collect(rc)) == Set(h*x for h in H)
       @test Set(collect(lc)) == Set(x*h for h in H)
       @test Set(h for h in dc) == Set(h*x*k for h in H for k in K)

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -242,7 +242,7 @@ end
    @test left_acting_group(L[1])==H
    @test Set([G([4,5,1,2,3]), G([3,4,5,1,2]), G([2,3,4,5,1])])==Set(intersect(dc, sub(G,[x])[1]) )
    lc = left_coset(H,one(G))
-   @test Set(intersect(lc,H))==Set(collect(H))
+   @test Set(intersect(lc,H))==Set(H)
    lc = left_coset(H,x)
    @test intersect(lc,H)==[]
 end

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -152,7 +152,7 @@ end
   
    C = right_coset(H, G[1])
    @test isright(C)
-   @test order(C) == length(elements(C))
+   @test order(C) == length(collect(C))
   
    @test length(right_transversal(G, H)) == index(G, H)
 
@@ -181,9 +181,9 @@ end
       @test representative(rc) == x
       @test representative(lc) == x
       @test representative(dc) == x
-      @test Set(elements(rc)) == Set(z for z in rc)          # test iterator
-      @test Set(elements(rc)) == Set(h*x for h in H)
-      @test Set(elements(lc)) == Set(x*h for h in H)
+      @test Set(collect(rc)) == Set(z for z in rc)          # test iterator
+      @test Set(collect(rc)) == Set(h*x for h in H)
+      @test Set(collect(lc)) == Set(x*h for h in H)
       @test Set(h for h in dc) == Set(h*x*k for h in H for k in K)
       @test order(rc) == 3
       @test order(dc) == 6
@@ -242,7 +242,7 @@ end
    @test left_acting_group(L[1])==H
    @test Set([G([4,5,1,2,3]), G([3,4,5,1,2]), G([2,3,4,5,1])])==Set(intersect(dc, sub(G,[x])[1]) )
    lc = left_coset(H,one(G))
-   @test Set(intersect(lc,H))==Set(elements(H))
+   @test Set(intersect(lc,H))==Set(collect(H))
    lc = left_coset(H,x)
    @test intersect(lc,H)==[]
 end


### PR DESCRIPTION
I added `Base.eltype` for all types for those it makes sense: group types, conjugacy classes, cosets.
This method is still not defined for gsets.