### PR TITLE
fixed `orbits` for `PermGroup`

### DIFF
--- a/experimental/GaloisGrp/Group.jl
+++ b/experimental/GaloisGrp/Group.jl
@@ -108,7 +108,7 @@ end
 #provided by Thomas Breuer:
 
 Hecke.orbit(G::PermGroup, i::Int) = GAP.gap_to_julia(GAP.Globals.Orbit(G.X, GAP.julia_to_gap(i)))
-orbits(G::PermGroup) = GAP.gap_to_julia(GAP.Globals.Orbits(G.X))
+orbits(G::PermGroup) = Array{Array{Int,1},1}(GAP.Globals.Orbits(G.X, GAP.GapObj(1:degree(G))))
 
 function action_homomorphism(G::PermGroup, omega::AbstractVector{Int})
   mp = GAP.Globals.ActionHomomorphism(G.X, GAP.julia_to_gap(omega))


### PR DESCRIPTION
- the type of the result is `Array{Array{Int,1},1}`
- the (default) set of points is `1:degree(G)` not the set of moved points