### PR TITLE
Two issues fixed.

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -294,7 +294,7 @@ julia> perm(symmetric_group(6),[2,4,6,1,3,5])
 """
 function perm(g::PermGroup, L::AbstractVector{<:Base.Integer})
    x = GAP.Globals.PermList(GAP.julia_to_gap(L))
-   if GAP.Globals.IN(x,g.X) 
+   if length(L) <= degree(g) && GAP.Globals.IN(x,g.X) 
      return PermGroupElem(g, x)
    end
    throw(ArgumentError("the element does not embed in the group"))
@@ -304,7 +304,7 @@ perm(g::PermGroup, L::AbstractVector{<:fmpz}) = perm(g, [Int(y) for y in L])
 
 function (g::PermGroup)(L::AbstractVector{<:Base.Integer})
    x = GAP.Globals.PermList(GAP.julia_to_gap(L))
-   if GAP.Globals.IN(x,g.X) 
+   if length(L) <= degree(g) && GAP.Globals.IN(x,g.X) 
      return PermGroupElem(g, x)
    end
    throw(ArgumentError("the element does not embed in the group"))
@@ -347,8 +347,10 @@ function cperm(g::PermGroup,L::AbstractVector{T}...) where T <: Union{Base.Integ
       return one(g)
    else
       x=prod(y -> GAP.Globals.CycleFromList(GAP.julia_to_gap([Int(k) for k in y])), L)
-      if GAP.Globals.IN(x,g.X) return PermGroupElem(g, x)
-      else throw(ArgumentError("the element does not embed in the group"))
+      if length(L) <= degree(g) && GAP.Globals.IN(x,g.X)
+         return PermGroupElem(g, x)
+      else
+         throw(ArgumentError("the element does not embed in the group"))
       end
    end
 end

--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -29,18 +29,27 @@ export
 
 
 """
-    direct_product(L::AbstractVector{<:GAPGroup})
+    direct_product(L::AbstractVector{<:GAPGroup}; morphisms)
     direct_product(L::GAPGroup...)
 
 Return the direct product of the groups in the collection `L`.
+
+The parameter `morphisms` is `false` by default. If it is set `true`, then the output is a triple (`G`, `emb`, `proj`), where `emb` and `proj` are the vectors of the embeddings (resp. projections) of the direct product `G`.
 """
-function direct_product(L::AbstractVector{<:GAPGroup})
+function direct_product(L::AbstractVector{<:GAPGroup}; morphisms=false)
    X = GAP.Globals.DirectProduct(GAP.julia_to_gap([G.X for G in L]))
-   return DirectProductGroup(X,L,X,true)
+   DP = DirectProductGroup(X,L,X,true)
+   if morphisms
+      emb = [_hom_from_gap_map(L[i],DP,GAP.Globals.Embedding(X,i)) for i in 1:length(L)]
+      proj = [_hom_from_gap_map(DP,L[i],GAP.Globals.Projection(X,i)) for i in 1:length(L)]
+      return DP, emb, proj
+   else
+      return DP
+   end
 end
 
-function direct_product(L::GAPGroup...)
-   return direct_product([x for x in L])
+function direct_product(L::GAPGroup...; morphisms=false)
+   return direct_product([x for x in L]; morphisms=morphisms)
 end
 
 """

--- a/test/Groups/directproducts.jl
+++ b/test/Groups/directproducts.jl
@@ -13,6 +13,13 @@
    @test number_of_factors(G)==2
    @test isfull_direct_product(G)
 
+   G,emb,proj = direct_product(S,C; morphisms=true)
+   @test G==direct_product(S,C)
+   @test emb[1]==embedding(G,1)
+   @test emb[2]==embedding(G,2)
+   @test proj[1]==projection(G,1)
+   @test proj[2]==projection(G,2)
+
    x = rand(G)
    @test x in G
    @test projection(G,1)(x) in S

--- a/test/Groups/elements.jl
+++ b/test/Groups/elements.jl
@@ -41,6 +41,8 @@
   @test x==cperm(G,[1,2,3,4,5,6])
   @test one(G)==gap_perm(1:6)
   @test_throws ArgumentError G(gap_perm([2,3,4,5,6,7,1]))
+  @test_throws ArgumentError G([2,3,1,4,6,5,7])
+  @test G(gap_perm([2,3,1,4,6,5,7]))==gap_perm([2,3,1,4,6,5])
   @test_throws ArgumentError perm(G,[2,3,4,5,6,7,1])
   @test one(G)==cperm(G,Int64[])
 end


### PR DESCRIPTION
Here I fixed issues:
fixes #371 : now if `G` is a matrix group of degree `n` and `L` is a vector of length `>n`, then the coercion `G(L)` returns an error, even if the permutation described by `L` embeds into `G`.

fixes #372: a parameter `morphisms` has been set for function `direct_group`. If the parameter is true, then `direct_product(C1,C2,C3,...)` returns a triple `(D,e,p)`, where `D` is the direct product of the `Ci`, `e` is the vector of embeddings and `p` is the vector of projections. This is analogous to what already works for `inner_direct_product`.

The tests for these methods have been added too.

Still open is the issue #369: what do we do when some trivial groups occur in the list defining a direct product? GAP ignores trivial factors, but maybe we want a different behavior.