### PR TITLE
Remove tail for spolys in favour of a version implemented in AbstractAlgebra.

### DIFF
--- a/examples/ZeroDec.jl
+++ b/examples/ZeroDec.jl
@@ -186,11 +186,6 @@ function primaryTest(I::Singular.sideal, usefglm::Bool = false)
 ###################################################### helpprocs PrimaryTest ############################################################################
 
 
-  #Calculates the tail of a polynomial
-  function tail(f::Singular.spoly)
-    return f - leading_term(f)
-  end
-  
    # adds a generator to an ideal
   function addGenerator(I::Singular.sideal, f::Singular.spoly)
     G = Singular.gens(I);


### PR DESCRIPTION
This is the Oscar.jl counterpart to https://github.com/Nemocas/AbstractAlgebra.jl/issues/815 and https://github.com/oscar-system/Singular.jl/pull/405

Those must be merged first before this PR is applied.