### PR TITLE
Simplify matrix_manipulation.jl, add cleanup TODOs

### DIFF
--- a/src/Groups/matrices/matrix_manipulation.jl
+++ b/src/Groups/matrices/matrix_manipulation.jl
@@ -35,8 +35,9 @@ export
 
 Return the `m x n` submatrix of `A` rooted at `(i,j)`
 """
+# TODO: eliminate this function again
 function submatrix(A::MatElem, i::Int, j::Int, nr::Int, nc::Int)
-   return matrix(base_ring(A),nr,nc, [A[s,t] for s in i:nr+i-1 for t in j:nc+j-1])
+   return A[i:i+nr-1, j:j+nr-1]
 end
 
 # exists already in Hecke _copy_matrix_into_matrix
@@ -45,6 +46,7 @@ end
 
 Return the matrix `A` with the block `B` inserted at the position `(i,j)`.
 """
+# TODO: eliminate this function again
 function insert_block(A::MatElem{T}, B::MatElem{T}, i::Int, j::Int) where T <: RingElem
    C = deepcopy(A)
    return insert_block!(C,B,i,j)
@@ -55,32 +57,21 @@ end
 
 Insert the block `B` in the matrix `A` at the position `(i,j)`.
 """
+# TODO: eliminate this function again
 function insert_block!(A::MatElem{T}, B::MatElem{T}, i::Int, j::Int) where T <: RingElem
-   for s in 1:nrows(B), t in 1:ncols(B)
-      A[i+s-1,j+t-1] = B[s,t]
-   end
+   A[i:i+nrows(B)-1, j:j+ncols(B)-1] = B
    return A
 end
 
-# exists already in Hecke cat(V...; dims=(1,2))
 """
     diagonal_join(V::AbstractVector{<:MatElem})
     diagonal_join(V::T...) where T <: MatElem
 
 Return the diagonal join of the matrices in `V`.
 """
+# TODO: eliminate this function again, use cat instead
 function diagonal_join(V::AbstractVector{T}) where T <: MatElem
-   nr = sum(nrows, V)
-   nc = sum(ncols, V)
-   B = zero_matrix(base_ring(V[1]), nr,nc)
-   pos_i=1
-   pos_j=1
-   for k in 1:length(V)
-      insert_block!(B,V[k],pos_i,pos_j)
-      pos_i += nrows(V[k])
-      pos_j += ncols(V[k])
-   end
-   return B
+   return cat(V...; dims=(1,2))
 end
 
 diagonal_join(V::T...) where T <: MatElem = diagonal_join(collect(V))
@@ -90,6 +81,7 @@ diagonal_join(V::T...) where T <: MatElem = diagonal_join(collect(V))
 
 Given a sequence `V` of matrices, return the `m x n` block matrix, where the `(i,j)`-block is the `((i-1)*n+j)`-th element of `V`. The sequence `V` must have length `mn` and the dimensions of the matrices of `V` must be compatible with the above construction.
 """
+# TODO: eliminate this function again, use cat/hcat/vcat/... instead
 function block_matrix(m::Int, n::Int, V::AbstractVector{T}) where T <: MatElem
    length(V)==m*n || throw(ArgumentError("Wrong number of inserted blocks"))
    n_rows=0


### PR DESCRIPTION
We should eliminate these functions eventually; for now I simply changed them to use implementations more akin to what the replacements would look like.