### PR TITLE
added `parent_type` methods for group elements

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1,4 +1,4 @@
-# further possible functions: similar, literal_pow, parent_type
+# further possible functions: similar, literal_pow
 
 import Base: ^, Base.Vector
 

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -120,6 +120,10 @@ elem_type(::Type{MatrixGroup{S,T}}) where {S,T} = MatrixGroupElem{S,T}
 elem_type(::MatrixGroup{S,T}) where {S,T} = MatrixGroupElem{S,T}
 Base.eltype(::Type{MatrixGroup{S,T}}) where {S,T} = MatrixGroupElem{S,T}
 
+# `parent_type` is defined and documented in AbstractAlgebra.
+parent_type(::Type{T}) where T<:MatrixGroupElem{RE,S} where {RE,S} = MatrixGroup{RE,S}
+parent_type(::T) where T<:MatrixGroupElem{RE,S} where {RE,S} = MatrixGroup{RE,S}
+
 
 ########################################################################
 #

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -271,7 +271,9 @@ elem_type(::T) where T <: GAPGroup = BasicGAPGroupElem{T}
 
 Base.eltype(::Type{T}) where T <: GAPGroup = BasicGAPGroupElem{T}
 
-
+# `parent_type` is defined and documented in AbstractAlgebra.
+parent_type(::Type{T}) where T<:BasicGAPGroupElem{S} where S = S
+parent_type(::T) where T<:BasicGAPGroupElem{S} where S = S
 
 #
 # The array _gap_group_types contains pairs (X,Y) where

--- a/test/Groups/testing.jl
+++ b/test/Groups/testing.jl
@@ -11,7 +11,10 @@ L = [ alternating_group(5), cyclic_group(18), SL(3,3), free_group(0), free_group
    @test parent(h) == G
 
    @testset "Parent methods" begin
+      @test elem_type(typeof(G)) == typeof(g)
       @test elem_type(G) == typeof(g)
+      @test parent_type(typeof(g)) == typeof(G)
+      @test parent_type(g) == typeof(G)
       @test one(G) isa typeof(g)
       @test one(G)==one(g)==one(h)
 


### PR DESCRIPTION
(Apparently the conformance tests in GroupsCore.jl are the first place where `parent_type` is needed in this context.)