### PR TITLE
Don't run doctest of upstream packages

### DIFF
--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -163,7 +163,7 @@ makedocs(bib,
 #         format   = Documenter.HTML(),
 #         format   = Markdown(),
          sitename = "Oscar.jl",
-         modules = [Oscar, Hecke, Nemo, AbstractAlgebra],
+         modules = [Oscar],
          clean = true,
          doctest = true,
          pages    = [


### PR DESCRIPTION
I don't see the point of running them.

If we really want to run them (again), the "dosc/make_work.jl" file needs to be adjusted to make the documentation build again.
