### PR TITLE
Remove duplicate method for `iszero(I::MPolyIdeal)`

### DIFF
--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -52,19 +52,6 @@ end
 
 # elementary operations #######################################################
 @doc Markdown.doc"""
-    :iszero(I::MPolyIdeal)
-
-Return `true` if `I` the zero ideal.
-"""
-function iszero(I::MPolyIdeal)
-  if isdefined(I.gens, :S)
-    return iszero(I.gens.S)
-  else
-    return all(iszero, I.gens.O)
-  end
-end
-
-@doc Markdown.doc"""
     :^(I::MPolyIdeal, m::Int)
 
 Return the m-th power of `I`. 


### PR DESCRIPTION
Fixes #417 

I chose to delete this one because the other method seems newer, has a much better documentation and arguably the cleaner implementation. Here it is for reference:
````julia
@doc Markdown.doc"""
    iszero(I::MPolyIdeal)

Returns true whether `I` is the zero ideal, false otherwise.
# Examples
```jldoctest
julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
(Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])

julia> I = ideal(R, y-x^2)
ideal generated by: -x^2 + y

julia> iszero(I)
false
```
"""
function iszero(I::MPolyIdeal)
  lg = gens(I)
  return isempty(lg) || all(iszero, lg)
end
````

