### PR TITLE
Mat elim

### DIFF
--- a/src/Groups/matrices/form_group.jl
+++ b/src/Groups/matrices/form_group.jl
@@ -47,7 +47,7 @@ function invariant_bilinear_forms(G::MatrixGroup{S,T}) where {S,T}
       push!(M,MM)
    end
 
-   r,K = nullspace(block_matrix(length(M),1,M))
+   r,K = nullspace(vcat(M))
    
    return [matrix(F,n,n,[K[i,j] for i in 1:n^2]) for j in 1:r]
 end
@@ -76,7 +76,7 @@ function invariant_sesquilinear_forms(G::MatrixGroup{S,T}) where {S,T}
       push!(M,MM)
    end
 
-   r,K = nullspace(block_matrix(length(M),1,M))
+   r,K = nullspace(vcat(M))
    
    return [matrix(F,n,n,[K[i,j] for i in 1:n^2]) for j in 1:r]
 end
@@ -109,7 +109,7 @@ function invariant_quadratic_forms(G::MatrixGroup{S,T}) where {S,T}
       push!(M,MM)
    end
 
-   r,K = nullspace(block_matrix(length(M),1,M))
+   r,K = nullspace(vcat(M))
    M = T[]
    for i in 1:r
       push!(M,upper_triangular_matrix(K[1:div(n*(n+1),2),i]))
@@ -163,7 +163,7 @@ function invariant_alternating_forms(G::MatrixGroup{S,T}) where {S,T}
       push!(M,MM)
    end
 
-   r,K = nullspace(block_matrix(length(M),1,M))
+   r,K = nullspace(vcat(M))
 
    L = T[]
    for j in 1:r
@@ -379,7 +379,7 @@ function invariant_hermitian_forms(G::MatrixGroup{S,T}) where {S,T}
       end
    end
 
-   n_gens,K = nullspace(block_matrix(length(M),1,M))
+   n_gens,K = nullspace(vcat(M))
    N = div(n*(n-1),2)
    L = T[]
 

--- a/src/Groups/matrices/form_group.jl
+++ b/src/Groups/matrices/form_group.jl
@@ -168,7 +168,7 @@ function invariant_alternating_forms(G::MatrixGroup{S,T}) where {S,T}
    L = T[]
    for j in 1:r
       B = zero_matrix(F,n,n)
-      _copy_matrix_into_matrix(B,1,2,upper_triangular_matrix(K[1:div(n*(n-1),2),j]))
+      B[1:n-1,2:n] = upper_triangular_matrix(K[1:div(n*(n-1),2),j])
 #=      for i in 1:n, j in 1:i-1
          B[i,j]=-B[j,i]
       end  =#
@@ -610,12 +610,12 @@ function isometry_group(f::SesquilinearForm{T}) where T
       L = dense_matrix_type(elem_type(F))[]
       for i in 1:ngens(G)
          temp = deepcopy(Idn)
-         _copy_matrix_into_matrix(temp,1,1,Xfn*(G[i].elm)*Xf)
+         temp[1:r,1:r] = Xfn*(G[i].elm)*Xf
          push!(L, An*temp*A)
       end
       for g in _gens_for_GL(n-r,F)
          temp = deepcopy(Idn)
-         _copy_matrix_into_matrix(temp,r+1,r+1,g)
+         temp[r+1:n, r+1:n] = g
          push!(L, An*temp*A)
       end
 # TODO: not quite sure whether the last element (the one with i=r) is sufficient to generate the whole top-right block

--- a/src/Groups/matrices/form_group.jl
+++ b/src/Groups/matrices/form_group.jl
@@ -573,7 +573,7 @@ function isometry_group(f::SesquilinearForm{T}) where T
    end
 
    if r<n
-      fn = SesquilinearForm(submatrix(C,1,1,r,r),f.descr)
+      fn = SesquilinearForm(C[1:r, 1:r],f.descr)
    else
       fn = f
    end

--- a/src/Groups/matrices/form_group.jl
+++ b/src/Groups/matrices/form_group.jl
@@ -167,8 +167,8 @@ function invariant_alternating_forms(G::MatrixGroup{S,T}) where {S,T}
 
    L = T[]
    for j in 1:r
-      B = upper_triangular_matrix(K[1:div(n*(n-1),2),j])
-      B = insert_block(zero_matrix(F,n,n),B,1,2)
+      B = zero_matrix(F,n,n)
+      _copy_matrix_into_matrix(B,1,2,upper_triangular_matrix(K[1:div(n*(n-1),2),j]))
 #=      for i in 1:n, j in 1:i-1
          B[i,j]=-B[j,i]
       end  =#
@@ -609,10 +609,14 @@ function isometry_group(f::SesquilinearForm{T}) where T
       Idn = identity_matrix(F,n)
       L = dense_matrix_type(elem_type(F))[]
       for i in 1:ngens(G)
-         push!(L, An*insert_block(Idn,Xfn*(G[i].elm)*Xf,1,1)*A)
+         temp = deepcopy(Idn)
+         _copy_matrix_into_matrix(temp,1,1,Xfn*(G[i].elm)*Xf)
+         push!(L, An*temp*A)
       end
       for g in _gens_for_GL(n-r,F)
-         push!(L, An*insert_block(Idn,g,r+1,r+1)*A)
+         temp = deepcopy(Idn)
+         _copy_matrix_into_matrix(temp,r+1,r+1,g)
+         push!(L, An*temp*A)
       end
 # TODO: not quite sure whether the last element (the one with i=r) is sufficient to generate the whole top-right block
       for i in 1:r

--- a/src/Groups/matrices/linear_centralizer.jl
+++ b/src/Groups/matrices/linear_centralizer.jl
@@ -70,9 +70,9 @@ function _gens_for_GL_matrix(f::PolyElem, n::Int, F::FinField; D::Int=1)
    CP = _centralizer(f)(C)            # matrix of maximal order in the centralizer of the companion matrix
    Df = degree(f)*D
 
-   if n==1 return [diagonal_join([CP for i in 1:D])] end
+   if n==1 return [cat([CP for i in 1:D]..., dims=(1,2))] end
    h1 = identity_matrix(F,n*Df)
-   insert_block!(h1,diagonal_join([CP for i in 1:D]),1,1)
+   insert_block!(h1,cat([CP for i in 1:D]..., dims=(1,2)),1,1)
    h2 = zero_matrix(F,n*degree(f)*D,n*Df)
    for i in 1:(n-1)*Df
       h2[i+Df,i]=-1
@@ -325,8 +325,8 @@ function _gens_for_SL_matrix(f::PolyElem, n::Int, F::FinField; D::Int=1)
 
    n != 1 || return dense_matrix_type(F)[]
    h1 = identity_matrix(F,n*Df)
-   insert_block!(h1,diagonal_join([CP for i in 1:D]),1,1)
-   insert_block!(h1,diagonal_join([CPi for i in 1:D]),Df+1,Df+1)
+   insert_block!(h1,cat([CP for i in 1:D]..., dims=(1,2)),1,1)
+   insert_block!(h1,cat([CPi for i in 1:D]..., dims=(1,2)),Df+1,Df+1)
    h2 = zero_matrix(F,n*Df,n*Df)
    for i in 1:(n-1)*Df
       h2[i+Df,i]=-1
@@ -340,7 +340,7 @@ function _gens_for_SL_matrix(f::PolyElem, n::Int, F::FinField; D::Int=1)
    # TODO: if in future we find out how to generate intermediate groups between GL and SL with only 2 elements,
    # then we can reduce the number of generators here from 3 to 2
    h3 = identity_matrix(F,n*Df)
-   insert_block!(h3,diagonal_join([CP^(order(F)-1) for i in 1:D]),1,1)
+   insert_block!(h3,cat([CP^(order(F)-1) for i in 1:D]..., dims=(1,2)),1,1)
    return [h1,h2,h3]
 end
 
@@ -409,6 +409,7 @@ function _centralizer_SL(x::MatElem)
       pos = 1
       for i in 1:length(block_dim)
          insert_block!(z,diagonal_join([block_dim[i][3]^Int(g(k)[i]) for j in 1:block_dim[i][1]]),pos,pos)
+         insert_block!(z,cat([block_dim[i][3]^Int(g(k)[i]) for j in 1:block_dim[i][1]]..., dims=(1,2)),pos,pos)
          pos += block_dim[i][1]*block_dim[i][2]*nrows(block_dim[i][3])
       end
       push!(listgens, am*z*a)

--- a/src/Groups/matrices/linear_centralizer.jl
+++ b/src/Groups/matrices/linear_centralizer.jl
@@ -111,7 +111,8 @@ function _centr_unipotent(F::FinField, V::AbstractVector{Int}; isSL=false)
       idN = identity_matrix(F,n)
       v_g = isSL ? _gens_for_SL(l[2],F) : _gens_for_GL(l[2],F)
       for x in v_g
-         z = block_matrix(l[2],l[2],[x[i,j]*identity_matrix(F,l[1]) for i in 1:l[2] for j in 1:l[2]])
+#         z = block_matrix(l[2],l[2],[x[i,j]*identity_matrix(F,l[1]) for i in 1:l[2] for j in 1:l[2]])
+         z = vcat([hcat([x[i,j]*identity_matrix(F,l[1]) for j in 1:l[2]]) for i in 1:l[2]])
          _copy_matrix_into_matrix(idN,pos,pos,z)
          push!(listgens,idN)
       end

--- a/src/Groups/matrices/linear_centralizer.jl
+++ b/src/Groups/matrices/linear_centralizer.jl
@@ -111,9 +111,7 @@ function _centr_unipotent(F::FinField, V::AbstractVector{Int}; isSL=false)
       idN = identity_matrix(F,n)
       v_g = isSL ? _gens_for_SL(l[2],F) : _gens_for_GL(l[2],F)
       for x in v_g
-#         z = block_matrix(l[2],l[2],[x[i,j]*identity_matrix(F,l[1]) for i in 1:l[2] for j in 1:l[2]])
          z = hvcat(l[2], [x[i,j]*identity_matrix(F,l[1]) for j in 1:l[2] for i in 1:l[2]]...)
-#         z = vcat([hcat([x[i,j]*identity_matrix(F,l[1]) for j in 1:l[2]]) for i in 1:l[2]])
          idN[pos:pos+l[1]*l[2]-1,pos:pos+l[1]*l[2]-1] = z
          push!(listgens,idN)
       end

--- a/src/Groups/matrices/linear_centralizer.jl
+++ b/src/Groups/matrices/linear_centralizer.jl
@@ -112,7 +112,8 @@ function _centr_unipotent(F::FinField, V::AbstractVector{Int}; isSL=false)
       v_g = isSL ? _gens_for_SL(l[2],F) : _gens_for_GL(l[2],F)
       for x in v_g
 #         z = block_matrix(l[2],l[2],[x[i,j]*identity_matrix(F,l[1]) for i in 1:l[2] for j in 1:l[2]])
-         z = vcat([hcat([x[i,j]*identity_matrix(F,l[1]) for j in 1:l[2]]) for i in 1:l[2]])
+         z = hvcat(l[2], [x[i,j]*identity_matrix(F,l[1]) for j in 1:l[2] for i in 1:l[2]]...)
+#         z = vcat([hcat([x[i,j]*identity_matrix(F,l[1]) for j in 1:l[2]]) for i in 1:l[2]])
          idN[pos:pos+l[1]*l[2]-1,pos:pos+l[1]*l[2]-1] = z
          push!(listgens,idN)
       end

--- a/src/Groups/matrices/linear_centralizer.jl
+++ b/src/Groups/matrices/linear_centralizer.jl
@@ -415,7 +415,7 @@ function _centralizer_SL(x::MatElem)
       z = deepcopy(idN)
       pos = 1
       for i in 1:length(block_dim)
-         t1 = diagonal_join([block_dim[i][3]^Int(g(k)[i]) for j in 1:block_dim[i][1]])
+         t1 = cat([block_dim[i][3]^Int(g(k)[i]) for j in 1:block_dim[i][1]]..., dims=(1,2))
          z[pos:pos-1+nrows(t1), pos:pos-1+ncols(t1)] = t1
          t1 = cat([block_dim[i][3]^Int(g(k)[i]) for j in 1:block_dim[i][1]]..., dims=(1,2))
          z[pos:pos-1+nrows(t1), pos:pos-1+ncols(t1)] = t1

--- a/src/Groups/matrices/linear_isconjugate.jl
+++ b/src/Groups/matrices/linear_isconjugate.jl
@@ -115,7 +115,7 @@ function generalized_jordan_block(f::T, n::Int) where T<:PolyElem
    JB = cat([companion_matrix(f) for i in 1:n]..., dims=(1,2))
    pos = 1
    for i in 1:n-1
-      _copy_matrix_into_matrix(JB, pos,pos+degree(f),identity_matrix(base_ring(f),degree(f)))
+      JB[pos:pos-1+degree(f), pos+degree(f):pos-1+2*degree(f)] = identity_matrix(base_ring(f),degree(f))
       pos += degree(f)
    end
    return JB

--- a/src/Groups/matrices/linear_isconjugate.jl
+++ b/src/Groups/matrices/linear_isconjugate.jl
@@ -112,7 +112,7 @@ Return the Jordan block of dimension `n` corresponding to the polynomial `f`.
 """
 function generalized_jordan_block(f::T, n::Int) where T<:PolyElem
    d = degree(f)
-   JB = diagonal_join([companion_matrix(f) for i in 1:n])
+   JB = cat([companion_matrix(f) for i in 1:n]..., dims=(1,2))
    pos = 1
    for i in 1:n-1
       insert_block!(JB, identity_matrix(base_ring(f),degree(f)),pos,pos+degree(f))
@@ -129,7 +129,7 @@ Return (`J`,`Z`), where `Z^-1*J*Z = A` and `J` is a diagonal join of Jordan bloc
 """
 function generalized_jordan_form(A::MatElem{T}; with_pol=false) where T
    V = pol_elementary_divisors(A)
-   GJ = diagonal_join([generalized_jordan_block(v[1],v[2]) for v in V])
+   GJ = cat([generalized_jordan_block(v[1],v[2]) for v in V]..., dims=(1,2))
    a = rational_canonical_form(A)[2]
    gj = rational_canonical_form(GJ)[2]
    if with_pol return GJ, gj^-1*a, V

--- a/src/Groups/matrices/linear_isconjugate.jl
+++ b/src/Groups/matrices/linear_isconjugate.jl
@@ -115,7 +115,7 @@ function generalized_jordan_block(f::T, n::Int) where T<:PolyElem
    JB = cat([companion_matrix(f) for i in 1:n]..., dims=(1,2))
    pos = 1
    for i in 1:n-1
-      insert_block!(JB, identity_matrix(base_ring(f),degree(f)),pos,pos+degree(f))
+      _copy_matrix_into_matrix(JB, pos,pos+degree(f),identity_matrix(base_ring(f),degree(f)))
       pos += degree(f)
    end
    return JB

--- a/src/Groups/matrices/matrix_manipulation.jl
+++ b/src/Groups/matrices/matrix_manipulation.jl
@@ -10,18 +10,13 @@ import AbstractAlgebra: FieldElem, map, Ring
 import Hecke: _copy_matrix_into_matrix, multiplicative_jordan_decomposition, PolyElem, _rational_canonical_form_setup, refine_for_jordan
 
 export
-    block_matrix,
     complement,
     conjugate_transpose,
-    diagonal_join,
-    insert_block,
-    insert_block!,
     isconjugate_gl,
     ishermitian_matrix,
     isskewsymmetric_matrix,
     lower_triangular_matrix,
     permutation_matrix,
-    submatrix,
     upper_triangular_matrix
 
 
@@ -32,83 +27,6 @@ export
 #
 ########################################################################
 
-"""
-    submatrix(A::MatElem{T}, i::Int, j::Int, m::Int, n::Int)
-
-Return the `m x n` submatrix of `A` rooted at `(i,j)`
-"""
-# TODO: eliminate this function again
-function submatrix(A::MatElem, i::Int, j::Int, nr::Int, nc::Int)
-   return A[i:i+nr-1, j:j+nc-1]
-end
-
-# exists already in Hecke _copy_matrix_into_matrix
-"""
-    insert_block(A::MatElem, B::MatElem, i,j)
-
-Return the matrix `A` with the block `B` inserted at the position `(i,j)`.
-"""
-# TODO: eliminate this function again
-function insert_block(A::MatElem{T}, B::MatElem{T}, i::Int, j::Int) where T <: RingElem
-   C = deepcopy(A)
-   return insert_block!(C,B,i,j)
-end
-
-"""
-    insert_block!(A::MatElem, B::MatElem, i,j)
-
-Insert the block `B` in the matrix `A` at the position `(i,j)`.
-"""
-# TODO: eliminate this function again
-function insert_block!(A::MatElem{T}, B::MatElem{T}, i::Int, j::Int) where T <: RingElem
-   A[i:i+nrows(B)-1, j:j+ncols(B)-1] = B
-   return A
-end
-
-"""
-    diagonal_join(V::AbstractVector{<:MatElem})
-    diagonal_join(V::T...) where T <: MatElem
-
-Return the diagonal join of the matrices in `V`.
-"""
-# TODO: eliminate this function again, use cat instead
-function diagonal_join(V::AbstractVector{T}) where T <: MatElem
-   return cat(V...; dims=(1,2))
-end
-
-diagonal_join(V::T...) where T <: MatElem = diagonal_join(collect(V))
-
-"""
-    block_matrix(m::Int, n::Int, V::AbstractVector{T}) where T <: MatElem
-
-Given a sequence `V` of matrices, return the `m x n` block matrix,
-where the `(i,j)`-block is the `((i-1)*n+j)`-th element of `V`.
-The sequence `V` must have length `mn` and the dimensions of the matrices of `V` must be compatible with the above construction.
-"""
-# TODO: eliminate this function again, use cat/hcat/vcat/... instead
-function block_matrix(m::Int, n::Int, V::AbstractVector{T}) where T <: MatElem
-   length(V)==m*n || throw(ArgumentError("Wrong number of inserted blocks"))
-   n_rows=0
-   for i in 1:m
-      for j in 1:n
-         nrows(V[n*(i-1)+j])==nrows(V[n*(i-1)+1]) || throw(ArgumentError("Invalid matrix dimension"))
-         ncols(V[n*(i-1)+j])==ncols(V[j]) || throw(ArgumentError("Invalid matrix dimension"))
-      end
-      n_rows += nrows(V[n*(i-1)+1])
-   end
-   n_cols = sum(ncols(V[j]) for j in 1:n)
-   B = zero_matrix(base_ring(V[1]), n_rows, n_cols)
-   pos_i=1
-   for i in 1:m
-      pos_j=1
-      for j in 1:n
-         _copy_matrix_into_matrix(B,pos_i,pos_j,V[n*(i-1)+j])
-         pos_j += ncols(V[n*(i-1)+j])
-      end
-      pos_i += nrows(V[n*(i-1)+1])
-   end
-   return B
-end
 
 """
     matrix(A::Array{AbstractAlgebra.Generic.FreeModuleElem{T},1})

--- a/src/Groups/matrices/matrix_manipulation.jl
+++ b/src/Groups/matrices/matrix_manipulation.jl
@@ -7,7 +7,7 @@
 # TODO: when this happens, files mentioned above need to be modified too.
 
 import AbstractAlgebra: FieldElem, map, Ring
-import Hecke: _copy_matrix_into_matrix, multiplicative_jordan_decomposition, PolyElem, _rational_canonical_form_setup, refine_for_jordan
+import Hecke: multiplicative_jordan_decomposition, PolyElem, _rational_canonical_form_setup, refine_for_jordan
 
 export
     complement,

--- a/src/Groups/matrices/matrix_manipulation.jl
+++ b/src/Groups/matrices/matrix_manipulation.jl
@@ -7,7 +7,7 @@
 # TODO: when this happens, files mentioned above need to be modified too.
 
 import AbstractAlgebra: FieldElem, map, Ring
-import Hecke: multiplicative_jordan_decomposition, PolyElem, _rational_canonical_form_setup, refine_for_jordan
+import Hecke: _copy_matrix_into_matrix, multiplicative_jordan_decomposition, PolyElem, _rational_canonical_form_setup, refine_for_jordan
 
 export
     block_matrix,
@@ -102,7 +102,7 @@ function block_matrix(m::Int, n::Int, V::AbstractVector{T}) where T <: MatElem
    for i in 1:m
       pos_j=1
       for j in 1:n
-         insert_block!(B,V[n*(i-1)+j],pos_i,pos_j)
+         _copy_matrix_into_matrix(B,pos_i,pos_j,V[n*(i-1)+j])
          pos_j += ncols(V[n*(i-1)+j])
       end
       pos_i += nrows(V[n*(i-1)+1])

--- a/src/Groups/matrices/transform_form.jl
+++ b/src/Groups/matrices/transform_form.jl
@@ -120,8 +120,8 @@ function _block_anisotropic_elim(B::MatElem{T}, _type::Symbol; isotr=false, f=0)
          end
       end
       B0,A0 = _block_anisotropic_elim(Bprime,_type)
-      B1 = diagonal_join(Barray)
-      B1 = diagonal_join(B1,B0)
+      B1 = cat(Barray..., dims=(1,2))
+      B1 = cat(B1,B0,dims=(1,2))
       C = C^-1
       Temp = vcat(C,-TR*C)
       Temp = vcat(Temp,-Y*C)
@@ -131,8 +131,8 @@ function _block_anisotropic_elim(B::MatElem{T}, _type::Symbol; isotr=false, f=0)
          P[2*i-1,i] = 1
          P[2*i,i+f] = 1
       end
-      A1 = diagonal_join(Aarray)*P
-      A1 = diagonal_join(A1,A0)
+      A1 = cat(Aarray..., dims=(1,2))*P
+      A1 = cat(A1,A0, dims=(1,2))
       return B1, A1*Temp
    else
       c,f = Int(ceil(d/2)), Int(floor(d/2))
@@ -159,7 +159,7 @@ function _block_anisotropic_elim(B::MatElem{T}, _type::Symbol; isotr=false, f=0)
       Temp = vcat(A0,Temp)
       Temp = insert_block(identity_matrix(F,d),Temp,1,1)
 
-      return diagonal_join(D1,D2), diagonal_join(A1,A2)*Temp
+      return cat(D1,D2, dims=(1,2)), cat(A1,A2, dims=(1,2))*Temp
    end
 end
 
@@ -260,7 +260,7 @@ function _to_standard_form(B::MatElem{T}, _type::Symbol)  where T <: FinFieldEle
       if div(n-NOZ,2)==0
          S = zero_matrix(F,0,0)
       else
-         S = diagonal_join([S for i in 1:div(n-NOZ,2)])
+         S = cat([S for i in 1:div(n-NOZ,2)]..., dims=(1,2))
       end
       # turn into standard GAP form
       sec_perm = Int[]

--- a/src/Groups/matrices/transform_form.jl
+++ b/src/Groups/matrices/transform_form.jl
@@ -33,7 +33,7 @@ end
 
 
 
-# if _is_symmetric, returns C,A,d where A*B*transpose(frobenius(A,e)) = C, C = block_matrix(2,2,[C,0,0,0]) and d = rank(C)
+# if _is_symmetric, returns C,A,d where A*B*transpose(frobenius(A,e)) = C, C = [C 0; 0 0] and d = rank(C)
 # else returns C,A,d where B*A = C, C = [C 0] and d = rank(C)
 # Assumption: if _is_symmetric==true, then nr=nc always
 # Assumption: e = deg(F)/2 in the hermitian case, e=0 otherwise

--- a/src/Groups/matrices/transform_form.jl
+++ b/src/Groups/matrices/transform_form.jl
@@ -147,9 +147,9 @@ function _block_anisotropic_elim(B::MatElem{T}, _type::Symbol; isotr=false, f=0)
       Z = V-s*U1*B1^-1*star(U1)
       D1,A1 = _block_anisotropic_elim(B1,_type)
       Temp = zero_matrix(F,d-e,d-e)
-      _copy_matrix_into_matrix(Temp,1,c-e+1,s*star(U2))
-      _copy_matrix_into_matrix(Temp,c-e+1,1,U2)
-      _copy_matrix_into_matrix(Temp,c-e+1,c-e+1,Z)
+      Temp[1:c-e, c-e+1:c-e+f] = s*star(U2)
+      Temp[c-e+1:c-e+f, 1:c-e] = U2
+      Temp[c-e+1:c-e+f, c-e+1:c-e+f] = Z
       if c-e==0
          D2,A2 = _block_anisotropic_elim(Temp,_type)
       else
@@ -158,7 +158,7 @@ function _block_anisotropic_elim(B::MatElem{T}, _type::Symbol; isotr=false, f=0)
       Temp = hcat(-U1*B1^-1, zero_matrix(F,f,c-e))*A0
       Temp = vcat(A0,Temp)
       Temp1 = identity_matrix(F,d)
-      _copy_matrix_into_matrix(Temp1,1,1,Temp)
+      Temp1[1:nrows(Temp), 1:ncols(Temp)] = Temp
 
       return cat(D1,D2, dims=(1,2)), cat(A1,A2, dims=(1,2))*Temp1
    end
@@ -269,10 +269,10 @@ function _to_standard_form(B::MatElem{T}, _type::Symbol)  where T <: FinFieldEle
          sec_perm = vcat([i,n+1-i],sec_perm)
       end
       if isodd(n)
-         _copy_matrix_into_matrix(Z,2,2,S)
+         Z[2:1+nrows(S), 2:1+ncols(S)] = S
          sec_perm = vcat([div(n+1,2)],sec_perm)
       else
-         _copy_matrix_into_matrix(Z,1,1,S)
+         Z[1:nrows(S), 1:ncols(S)] = S
       end
       D = transpose(permutation_matrix(F,sec_perm))*Z*D
    end
@@ -304,7 +304,7 @@ function _elim_hyp_lines(A::MatElem{T}) where T <: FinFieldElem
          A[i,i+1]=0
          A[i+1,i]=0
          A[i+1,i+1]=-2
-         _copy_matrix_into_matrix(Z,i,i,b)
+         Z[i:i+1, i:i+1] = b
          i+=2
       else
          i+=1
@@ -409,7 +409,7 @@ function iscongruent(f::SesquilinearForm{T}, g::SesquilinearForm{T}) where T <: 
          _is_true, Z = _change_basis_forms( Cf[1:d, 1:d], Cg[1:d, 1:d], f.descr)
          _is_true || return false, nothing
          Z1 = identity_matrix(F,n)
-         _copy_matrix_into_matrix(Z1,1,1,Z)
+         Z1[1:nrows(Z), 1:ncols(Z)] = Z
          return true, Af^-1*Z1*Ag
       else
          return _change_basis_forms(gram_matrix(f), gram_matrix(g), f.descr)

--- a/src/Groups/matrices/transform_form.jl
+++ b/src/Groups/matrices/transform_form.jl
@@ -147,9 +147,9 @@ function _block_anisotropic_elim(B::MatElem{T}, _type::Symbol; isotr=false, f=0)
       Z = V-s*U1*B1^-1*star(U1)
       D1,A1 = _block_anisotropic_elim(B1,_type)
       Temp = zero_matrix(F,d-e,d-e)
-      insert_block!(Temp,s*star(U2),1,c-e+1)
-      insert_block!(Temp,U2,c-e+1,1)
-      insert_block!(Temp,Z,c-e+1,c-e+1)
+      _copy_matrix_into_matrix(Temp,1,c-e+1,s*star(U2))
+      _copy_matrix_into_matrix(Temp,c-e+1,1,U2)
+      _copy_matrix_into_matrix(Temp,c-e+1,c-e+1,Z)
       if c-e==0
          D2,A2 = _block_anisotropic_elim(Temp,_type)
       else
@@ -157,9 +157,10 @@ function _block_anisotropic_elim(B::MatElem{T}, _type::Symbol; isotr=false, f=0)
       end
       Temp = hcat(-U1*B1^-1, zero_matrix(F,f,c-e))*A0
       Temp = vcat(A0,Temp)
-      Temp = insert_block(identity_matrix(F,d),Temp,1,1)
+      Temp1 = identity_matrix(F,d)
+      _copy_matrix_into_matrix(Temp1,1,1,Temp)
 
-      return cat(D1,D2, dims=(1,2)), cat(A1,A2, dims=(1,2))*Temp
+      return cat(D1,D2, dims=(1,2)), cat(A1,A2, dims=(1,2))*Temp1
    end
 end
 
@@ -268,10 +269,10 @@ function _to_standard_form(B::MatElem{T}, _type::Symbol)  where T <: FinFieldEle
          sec_perm = vcat([i,n+1-i],sec_perm)
       end
       if isodd(n)
-         insert_block!(Z,S,2,2)
+         _copy_matrix_into_matrix(Z,2,2,S)
          sec_perm = vcat([div(n+1,2)],sec_perm)
       else
-         insert_block!(Z,S,1,1)
+         _copy_matrix_into_matrix(Z,1,1,S)
       end
       D = transpose(permutation_matrix(F,sec_perm))*Z*D
    end
@@ -303,7 +304,7 @@ function _elim_hyp_lines(A::MatElem{T}) where T <: FinFieldElem
          A[i,i+1]=0
          A[i+1,i]=0
          A[i+1,i+1]=-2
-         insert_block!(Z,b,i,i)
+         _copy_matrix_into_matrix(Z,i,i,b)
          i+=2
       else
          i+=1
@@ -407,8 +408,9 @@ function iscongruent(f::SesquilinearForm{T}, g::SesquilinearForm{T}) where T <: 
          Cg,Ag,_ = _find_radical(gram_matrix(g),F,n,n; e=degF, _is_symmetric=true)
          _is_true, Z = _change_basis_forms( Cf[1:d, 1:d], Cg[1:d, 1:d], f.descr)
          _is_true || return false, nothing
-         Z = insert_block(identity_matrix(F,n), Z, 1,1)
-         return true, Af^-1*Z*Ag
+         Z1 = identity_matrix(F,n)
+         _copy_matrix_into_matrix(Z1,1,1,Z)
+         return true, Af^-1*Z1*Ag
       else
          return _change_basis_forms(gram_matrix(f), gram_matrix(g), f.descr)
       end

--- a/src/Groups/matrices/transform_form.jl
+++ b/src/Groups/matrices/transform_form.jl
@@ -92,15 +92,15 @@ function _block_anisotropic_elim(B::MatElem{T}, _type::Symbol; isotr=false, f=0)
    if isotr
       q = characteristic(F)^degF
       g = d-f
-      U = submatrix(B,1,f+1,f,g)
-      V = submatrix(B,f+1,f+1,g,g)
+      U = B[1:f, f+1:f+g]
+      V = B[f+1:f+g, f+1:f+g]
       C,A,e = _find_radical(U,F,f,g)
       # I expect C always to be of rank f
-      C = submatrix(C,1,1,f,f)                     
+      C = C[1:f, 1:f]
       Vprime = star(A)*V*A
-      Z = submatrix(Vprime, 1,1,f,f)
-      Y = submatrix(Vprime,f+1,1,g-f,f)
-      Bprime = submatrix(Vprime,f+1,f+1,g-f,g-f)
+      Z = Vprime[1:f, 1:f]
+      Y = Vprime[f+1:g, 1:f]
+      Bprime = Vprime[f+1:g, f+1:g]
       TR = zero_matrix(F,f,f)
       D = zero_matrix(F,f,f)
       for i in 1:f
@@ -136,14 +136,14 @@ function _block_anisotropic_elim(B::MatElem{T}, _type::Symbol; isotr=false, f=0)
       return B1, A1*Temp
    else
       c,f = Int(ceil(d/2)), Int(floor(d/2))
-      B0 = submatrix(B,1,1,c,c)
-      U = submatrix(B,c+1,1,f,c)
-      V = submatrix(B,c+1,c+1,f,f)
+      B0 = B[1:c,1:c]
+      U = B[c+1:c+f, 1:c]
+      V = B[c+1:c+f, c+1:c+f]
       B1,A0,e = _find_radical(B0,F,c,c; e=degF, _is_symmetric=true)
-      B1 = submatrix(B1,1,1,e,e)
+      B1 = B1[1:e, 1:e]
       U = U*star(A0)
-      U1 = submatrix(U,1,1,f,e)
-      U2 = submatrix(U,1,e+1,f,c-e)
+      U1 = U[1:f, 1:e]
+      U2 = U[1:f, e+1:c]
       Z = V-s*U1*B1^-1*star(U1)
       D1,A1 = _block_anisotropic_elim(B1,_type)
       Temp = zero_matrix(F,d-e,d-e)
@@ -180,7 +180,7 @@ function _block_herm_elim(B::MatElem{T}, _type) where T <: FinFieldElem
    end
 
    c = Int(ceil(d/2))
-   B2 = submatrix(B,1,1,c,c)
+   B2 = B[1:c, 1:c]
    if B2==0
       D,A = _block_anisotropic_elim(B,_type; isotr=true, f=c)
    else
@@ -405,7 +405,7 @@ function iscongruent(f::SesquilinearForm{T}, g::SesquilinearForm{T}) where T <: 
          if f.descr==:hermitian degF=div(degree(F),2) end
          Cf,Af,d = _find_radical(gram_matrix(f),F,n,n; e=degF, _is_symmetric=true)
          Cg,Ag,_ = _find_radical(gram_matrix(g),F,n,n; e=degF, _is_symmetric=true)
-         _is_true, Z = _change_basis_forms( submatrix(Cf,1,1,d,d), submatrix(Cg,1,1,d,d), f.descr)
+         _is_true, Z = _change_basis_forms( Cf[1:d, 1:d], Cg[1:d, 1:d], f.descr)
          _is_true || return false, nothing
          Z = insert_block(identity_matrix(F,n), Z, 1,1)
          return true, Af^-1*Z*Ag

--- a/test/Groups/conjugation.jl
+++ b/test/Groups/conjugation.jl
@@ -156,7 +156,7 @@ end
    G = GL(8,5)
    S = SL(8,5)
    R,t = PolynomialRing(base_ring(G),"t")
-   x = diagonal_join(generalized_jordan_block(t-1,4), generalized_jordan_block(t-1,2), identity_matrix(base_ring(G),2))
+   x = cat(generalized_jordan_block(t-1,4), generalized_jordan_block(t-1,2), identity_matrix(base_ring(G),2), dims=(1,2))
    C = centralizer(G,G(x))[1]
    @test order(C) == order(GL(2,5))*4^2*5^16
    @testset for y in gens(C)
@@ -167,7 +167,7 @@ end
    @testset for y in gens(Cs)
       @test x*y==y*x
    end
-   x = diagonal_join( [generalized_jordan_block(t-1,2) for i in 1:4] )
+   x = cat( [generalized_jordan_block(t-1,2) for i in 1:4]..., dims=(1,2) )
    C = centralizer(G,G(x))[1]
    @test order(C) == order(GL(4,5))*5^16
    @testset for y in gens(C)
@@ -175,7 +175,7 @@ end
    end
    Cs = centralizer(S,S(x))[1]
    @test order(Cs) == div(order(GL(4,5))*5^16,2)
-   x = diagonal_join( [generalized_jordan_block(t-1,4) for i in 1:2] )
+   x = cat( [generalized_jordan_block(t-1,4) for i in 1:2]..., dims=(1,2) )
    C = centralizer(G,G(x))[1]
    @test order(C) == order(GL(2,5))*5^12
    Cs = centralizer(S,S(x))[1]
@@ -189,7 +189,7 @@ end
       @test x*y==y*x
    end
 
-   x = diagonal_join(companion_matrix((t^2+3)^2), companion_matrix(t^3+3*t+2), companion_matrix(t-3))
+   x = cat(companion_matrix((t^2+3)^2), companion_matrix(t^3+3*t+2), companion_matrix(t-3), dims=(1,2))
    C = centralizer(G,G(x))[1]
    @test order(C)==24*124*4*25
    @testset for y in gens(C)

--- a/test/Groups/forms.jl
+++ b/test/Groups/forms.jl
@@ -338,7 +338,7 @@ end
       @test f^x==f
    end
    @test order(H)==order(Op)
-   insert_block!(B,identity_matrix(F,2),3,3)
+   Hecke._copy_matrix_into_matrix(B,3,3,identity_matrix(F,2))
    f = symmetric_form(B)
    H = isometry_group(f)
    @testset for x in gens(H)

--- a/test/Groups/forms.jl
+++ b/test/Groups/forms.jl
@@ -338,7 +338,7 @@ end
       @test f^x==f
    end
    @test order(H)==order(Op)
-   Hecke._copy_matrix_into_matrix(B,3,3,identity_matrix(F,2))
+   B[3:4,3:4] = identity_matrix(F,2)
    f = symmetric_form(B)
    H = isometry_group(f)
    @testset for x in gens(H)

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -498,7 +498,7 @@ end
         [(t-2,9)]
        ]
    @testset for L in L_big
-      x = diagonal_join([generalized_jordan_block(a...) for a in L])
+      x = cat([generalized_jordan_block(a...) for a in L]..., dims=(1,2))
    # TODO: the change_base_ring is necessary, otherwise the equality between polynomials does not work
       @test MSet([(change_base_ring(F,f[1]),f[2]) for f in pol_elementary_divisors(x) ])==MSet([(change_base_ring(F,f[1]),f[2]) for f in L])
       @test MSet([(change_base_ring(F,f[1]),f[2]) for f in pol_elementary_divisors(G(x)) ])==MSet([(change_base_ring(F,f[1]),f[2]) for f in L])
@@ -565,7 +565,7 @@ end
       @test L[1]^8==1
       @test L[2]^3==1
       @test order(matrix_group(L...))==div(order(GL(2,9)),2)
-      x = diagonal_join([generalized_jordan_block(f,n) for n in [1,1,1,2,2,3]])
+      x = cat([generalized_jordan_block(f,n) for n in [1,1,1,2,2,3]]..., dims=(1,2))
       L,c = Oscar._centr_block_unipotent(f,GF(3,1)[1],[1,1,1,2,2,3])
       @testset for l in L
          @test l*x==x*l

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -529,7 +529,7 @@ end
    R,t = PolynomialRing(F,"t")
    f = t^3+t*z+1
    x = generalized_jordan_block(f,2)
-   @test generalized_jordan_block(f,2)==block_matrix(2,2,[companion_matrix(f),identity_matrix(F,3),zero_matrix(F,3,3),companion_matrix(f)])
+   @test generalized_jordan_block(f,2)==hvcat((2,2),companion_matrix(f),identity_matrix(F,3),zero_matrix(F,3,3),companion_matrix(f))
    @testset for i in [2,4,42,62]
       y = Oscar._elem_given_det(G(x),z^i)
       @test x*y==y*x

--- a/test/Groups/operations.jl
+++ b/test/Groups/operations.jl
@@ -57,9 +57,10 @@ end
    
    I = identity_matrix(F,6)
    x = matrix(F,2,2,[2,3,4,0])
-   I1 = insert_block(I,x,3,3)
+   I1 = deepcopy(I)
+   Hecke._copy_matrix_into_matrix(I1,3,3,x)
    @test I==identity_matrix(F,6)
-   insert_block!(I,x,3,3)
+   Hecke._copy_matrix_into_matrix(I,3,3,x)
    @test I==I1
    @test I[3:4,3:4]==x
    Y = block_matrix(2,1,[block_matrix(1,2,[x,x^2]), block_matrix(1,2,[-x,x])])

--- a/test/Groups/operations.jl
+++ b/test/Groups/operations.jl
@@ -65,8 +65,7 @@ end
    Y = block_matrix(2,1,[block_matrix(1,2,[x,x^2]), block_matrix(1,2,[-x,x])])
    @test Y==block_matrix(2,2,[x,x^2,-x,x])
    z = zero_matrix(F,2,2)
-   @test diagonal_join([x,x,x])==block_matrix(3,3,[x,z,z,z,x,z,z,z,x])
-   @test diagonal_join(x,x,zero_matrix(F,4,4))==diagonal_join([x,x,zero_matrix(F,4,4)])
+   @test cat(x,x,x, dims=(1,2))==block_matrix(3,3,[x,z,z,z,x,z,z,z,x])
    V = VectorSpace(F,6)
    @test matrix([V[i] for i in 1:6])==identity_matrix(F,6)
    L = [1,4,6,2,3,5]

--- a/test/Groups/operations.jl
+++ b/test/Groups/operations.jl
@@ -58,9 +58,9 @@ end
    I = identity_matrix(F,6)
    x = matrix(F,2,2,[2,3,4,0])
    I1 = deepcopy(I)
-   Hecke._copy_matrix_into_matrix(I1,3,3,x)
+   I1[3:4,3:4] = x
    @test I==identity_matrix(F,6)
-   Hecke._copy_matrix_into_matrix(I,3,3,x)
+   I[3:4,3:4] = x
    @test I==I1
    @test I[3:4,3:4]==x
 #   Y = block_matrix(2,1,[block_matrix(1,2,[x,x^2]), block_matrix(1,2,[-x,x])])

--- a/test/Groups/operations.jl
+++ b/test/Groups/operations.jl
@@ -63,10 +63,10 @@ end
    Hecke._copy_matrix_into_matrix(I,3,3,x)
    @test I==I1
    @test I[3:4,3:4]==x
-   Y = block_matrix(2,1,[block_matrix(1,2,[x,x^2]), block_matrix(1,2,[-x,x])])
-   @test Y==block_matrix(2,2,[x,x^2,-x,x])
-   z = zero_matrix(F,2,2)
-   @test cat(x,x,x, dims=(1,2))==block_matrix(3,3,[x,z,z,z,x,z,z,z,x])
+#   Y = block_matrix(2,1,[block_matrix(1,2,[x,x^2]), block_matrix(1,2,[-x,x])])
+#   @test Y==block_matrix(2,2,[x,x^2,-x,x])
+#   z = zero_matrix(F,2,2)
+#   @test cat(x,x,x, dims=(1,2))==block_matrix(3,3,[x,z,z,z,x,z,z,z,x])
    V = VectorSpace(F,6)
    @test matrix([V[i] for i in 1:6])==identity_matrix(F,6)
    L = [1,4,6,2,3,5]

--- a/test/Groups/operations.jl
+++ b/test/Groups/operations.jl
@@ -61,7 +61,7 @@ end
    @test I==identity_matrix(F,6)
    insert_block!(I,x,3,3)
    @test I==I1
-   @test submatrix(I,3,3,2,2)==x
+   @test I[3:4,3:4]==x
    Y = block_matrix(2,1,[block_matrix(1,2,[x,x^2]), block_matrix(1,2,[-x,x])])
    @test Y==block_matrix(2,2,[x,x^2,-x,x])
    z = zero_matrix(F,2,2)

--- a/test/Groups/operations.jl
+++ b/test/Groups/operations.jl
@@ -63,10 +63,6 @@ end
    I[3:4,3:4] = x
    @test I==I1
    @test I[3:4,3:4]==x
-#   Y = block_matrix(2,1,[block_matrix(1,2,[x,x^2]), block_matrix(1,2,[-x,x])])
-#   @test Y==block_matrix(2,2,[x,x^2,-x,x])
-#   z = zero_matrix(F,2,2)
-#   @test cat(x,x,x, dims=(1,2))==block_matrix(3,3,[x,z,z,z,x,z,z,z,x])
    V = VectorSpace(F,6)
    @test matrix([V[i] for i in 1:6])==identity_matrix(F,6)
    L = [1,4,6,2,3,5]


### PR DESCRIPTION
Suggestions from issue #407 are employed here.

The following functions have been defined in the file src/Groups/matrices/matrix_manipulation.jl: `submatrix`, `insert_block`, `insert_block!`, `diagonal_join` and `block_matrix`. Those functions are just doubles of already existing methods, so in this branch all the instances have been deleted and replaced with the already existing methods.