### PR TITLE
homogenous -> homogeneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ defined on the Singular side
 julia> D = decoration(H)
 GrpAb: Z
 
-julia> homogenous_component(H, D[0])
+julia> homogeneous_component(H, D[0])
 (H_[0] of dim 2, Map from
 H_[0] of dim 2 to H defined by a julia-function with inverse
 )

--- a/experimental/PlaneCurve/AffinePlaneCurve.jl
+++ b/experimental/PlaneCurve/AffinePlaneCurve.jl
@@ -236,7 +236,7 @@ function multiplicity(C::AffinePlaneCurve{S}, P::Point{S}) where S <: FieldElem
   G = D.eq
   R = parent(G)
   A = grade(R)[1]
-  HC = homogenous_components(A(G))
+  HC = homogeneous_components(A(G))
   L = collect(keys(HC))
   M = sort(L, by=_sort_helper_multiplicity)
   return M[1].coeff[1, 1]
@@ -258,7 +258,7 @@ function tangent_lines(C::AffinePlaneCurve{S}, P::Point{S}) where S <: FieldElem
   R = parent(G)
   V = gens(R)
   A = grade(R)[1]
-  HC = homogenous_components(A(G))
+  HC = homogeneous_components(A(G))
   L = collect(keys(HC))
   M = sort(L, by=_sort_helper_multiplicity)
   Gm = HC[M[1]]

--- a/experimental/PlaneCurve/PlaneCurve.jl
+++ b/experimental/PlaneCurve/PlaneCurve.jl
@@ -95,7 +95,7 @@ mutable struct ProjPlaneCurve{S} <: ProjectivePlaneCurve{S}
   function ProjPlaneCurve{S}(eq::Oscar.MPolyElem_dec{S}) where {S <: FieldElem}
     nvars(parent(eq)) == 3 || error("The defining equation must belong to a ring with three variables")
     !isconstant(eq) || error("The defining equation must be non constant")
-    ishomogenous(eq) || error("The defining equation is not homogeneous")
+    ishomogeneous(eq) || error("The defining equation is not homogeneous")
     new{S}(eq,
            -1,                   # -1 when it is not computed yet
             Dict{ProjPlaneCurve{S}, Int}())

--- a/experimental/PlaneCurve/ProjEllipticCurve.jl
+++ b/experimental/PlaneCurve/ProjEllipticCurve.jl
@@ -128,7 +128,7 @@ mutable struct ProjEllipticCurve{S} <: ProjectivePlaneCurve{S}
   function ProjEllipticCurve{S}(eq::Oscar.MPolyElem_dec{S}) where {S <: FieldElem}
     nvars(parent(eq)) == 3 || error("The defining equation must belong to a ring with three variables")
     !isconstant(eq) || error("The defining equation must be non constant")
-    ishomogenous(eq) || error("The defining equation is not homogeneous")
+    ishomogeneous(eq) || error("The defining equation is not homogeneous")
     _iselliptic(eq) || error("Not an elliptic curve")
     isweierstrass_form(eq.f) || error("Not in Weierstrass form")
     v = shortformtest(eq.f)
@@ -143,7 +143,7 @@ mutable struct ProjEllipticCurve{S} <: ProjectivePlaneCurve{S}
      nvars(parent(eq)) == 3 || error("The defining equation must belong to a ring with three variables")
      iszero(evaluate(eq, P.v)) || error("The point is not on the curve")
      !isconstant(eq) || error("The defining equation must be non constant")
-     ishomogenous(eq) || error("The defining equation is not homogeneous")
+     ishomogeneous(eq) || error("The defining equation is not homogeneous")
      isinflection(eq, P) || error("Not an inflection point -- structure implemented only with an inflection point as base point.")
      _iselliptic(eq) || error("Not an elliptic curve")
      T = parent(eq)

--- a/src/Groups/matrices/forms.jl
+++ b/src/Groups/matrices/forms.jl
@@ -164,7 +164,7 @@ If `check` is set as `false`, it does not check whether the polynomial is homoge
 To define quadratic forms of dimension 1, `f` can also have type `PolyElem{T}`.
 """
 quadratic_form(f::MPolyElem{T}) where T <: FieldElem = SesquilinearForm(f, :quadratic)
-# TODO : neither ishomogeneous or ishomogenous works for variables of type MPolyElem{T}
+# TODO : neither ishomogeneous or ishomogeneous works for variables of type MPolyElem{T}
 
 # just to allow quadratic forms over vector fields of dimension 1, so defined over polynomials in 1 variable
 function quadratic_form(f::PolyElem{T}) where T <: FieldElem

--- a/src/Modules/FreeModules-graded.jl
+++ b/src/Modules/FreeModules-graded.jl
@@ -207,7 +207,7 @@ function degree(a::FreeModuleElem_dec)
       first = false
     elseif isgraded(W)
       if ww != w
-        error("elem not homogenous")
+        error("elem not homogeneous")
       end
     else
       if W.lt(ww, w) 
@@ -218,11 +218,11 @@ function degree(a::FreeModuleElem_dec)
   return w
 end
 
-function homogenous_components(a::FreeModuleElem_dec)
+function homogeneous_components(a::FreeModuleElem_dec)
   res = Dict{GrpAbFinGenElem, FreeModuleElem_dec}()
   F = parent(a)
   for (p,v) = a.r
-    c = homogenous_components(v)
+    c = homogeneous_components(v)
     for (pp, vv) = c
       w = pp + F.d[p]
       if haskey(res, w)
@@ -235,16 +235,16 @@ function homogenous_components(a::FreeModuleElem_dec)
   return res
 end
 
-function homogenous_component(a::FreeModuleElem_dec, g::GrpAbFinGenElem)
+function homogeneous_component(a::FreeModuleElem_dec, g::GrpAbFinGenElem)
   F = parent(a)
   x = zero(F)
   for (p,v) = a.r
-    x += homogenous_component(v, g-F.d[p])*gen(F, p)
+    x += homogeneous_component(v, g-F.d[p])*gen(F, p)
   end
   return x
 end
 
-function ishomogenous(a::FreeModuleElem_dec)
+function ishomogeneous(a::FreeModuleElem_dec)
   if iszero(a)
     return true
   end
@@ -252,7 +252,7 @@ function ishomogenous(a::FreeModuleElem_dec)
   first = true
   local d::GrpAbFinGenElem
   for (p,v) = a.r
-    ishomogenous(v) || return false
+    ishomogeneous(v) || return false
     if first
       d = F.d[p] + degree(v)
       first = false
@@ -392,8 +392,8 @@ mutable struct FreeModuleHom_dec{T1, T2} <: Map_dec{T1, T2}
   Hecke.@declare_other
 
   function FreeModuleHom_dec(F::FreeModule_dec{T}, G::S, a::Array{<:Any, 1}) where {T, S}
-#    @assert isfiltered(F) || all(ishomogenous, a) #neccessary and suffient according to Hans XXX
-#same as non-homogenous elements are required, this too must not be enforced
+#    @assert isfiltered(F) || all(ishomogeneous, a) #neccessary and suffient according to Hans XXX
+#same as non-homogeneous elements are required, this too must not be enforced
     @assert all(x->parent(x) == G, a)
     @assert length(a) == ngens(F)
     #for filtrations, all is legal...
@@ -428,7 +428,7 @@ function identity_map(M::ModuleFP_dec)
   return hom(M, M, gens(M))
 end
 
-function ishomogenous(h::T) where {T <: Map_dec}
+function ishomogeneous(h::T) where {T <: Map_dec}
   first = true
   local d::GrpAbFinGenElem
   for i = gens(domain(h))
@@ -462,7 +462,7 @@ function degree(h::T) where {T <: Map_dec}
         d = dd
       end
     else
-      d == dd || error("hom is not homogenous")
+      d == dd || error("hom is not homogeneous")
     end
   end
   if first
@@ -471,7 +471,7 @@ function degree(h::T) where {T <: Map_dec}
   return d
 end
 
-function homogenous_components(h::T) where {T <: Map_dec}
+function homogeneous_components(h::T) where {T <: Map_dec}
   c = Dict{GrpAbFinGenElem, typeof(h)}()
   d = Dict{GrpAbFinGenElem, Array{Int, 1}}()
   F = domain(h)
@@ -620,12 +620,12 @@ end
 ==(a::SubQuoElem_dec, b::SubQuoElem_dec) = iszero(a-b)
 
 function sub(F::FreeModule_dec, O::Array{<:FreeModuleElem_dec, 1})
-  all(ishomogenous, O) || error("generators have to be homogenous")
+  all(ishomogeneous, O) || error("generators have to be homogeneous")
   s = SubQuo_dec(F, O)
 end
 
 function sub(F::FreeModule_dec, O::Array{<:SubQuoElem_dec, 1})
-  all(ishomogenous, O) || error("generators have to be homogenous")
+  all(ishomogeneous, O) || error("generators have to be homogeneous")
   return SubQuo_dec(F, [x.a for x = O])
 end
 
@@ -654,7 +654,7 @@ function quo(F::FreeModule_dec, O::Array{<:SubQuoElem_dec, 1})
 end
 
 function quo(F::SubQuo_dec, O::Array{<:FreeModuleElem_dec, 1})
-  all(ishomogenous, O) || error("generators have to be homogenous")
+  all(ishomogeneous, O) || error("generators have to be homogeneous")
   @assert parent(O[1]) == F.F
   if isdefined(F, :quo)
     F.sub[Val(:S), 1]
@@ -925,17 +925,17 @@ function degree(a::FreeModuleElem_dec, C::SubQuo_dec)
   return degree(convert(C.F, x))
 end
 
-function ishomogenous(a::SubQuoElem_dec)
+function ishomogeneous(a::SubQuoElem_dec)
   C = parent(a)
   if !isdefined(C, :quo)
-    return ishomogenous(a.a)
+    return ishomogeneous(a.a)
   end
   if !isdefined(C, :std_quo)
     singular_assure(C.quo)
     C.std_quo = BiModArray(C.quo.F, Singular.std(C.quo.S))
   end
   x = _reduce(convert(C.quo.SF, a.a), C.std_quo.S)
-  return ishomogenous(convert(C.F, x))
+  return ishomogeneous(convert(C.F, x))
 end
 
 function iszero(a::SubQuoElem_dec)
@@ -1359,7 +1359,7 @@ end
 #################################################
 #
 #################################################
-function homogenous_component(F::T, d::GrpAbFinGenElem) where {T <: Union{FreeModule_dec, SubQuo_dec, MPolyIdeal{<:MPolyElem_dec}}}
+function homogeneous_component(F::T, d::GrpAbFinGenElem) where {T <: Union{FreeModule_dec, SubQuo_dec, MPolyIdeal{<:MPolyElem_dec}}}
 
   #TODO: lazy: ie. no enumeration of points
   #      aparently it is possible to get the number of points faster than the points
@@ -1374,7 +1374,7 @@ function homogenous_component(F::T, d::GrpAbFinGenElem) where {T <: Union{FreeMo
     if iszero(g)
       continue
     end
-    Md, mMd = homogenous_component(W, d - degree(g))
+    Md, mMd = homogeneous_component(W, d - degree(g))
     #TODO careful <0> is 0-dim but non empty...
     if dim(Md) > 0
       push!(all, (g, mMd))

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -583,19 +583,19 @@ end
 isfiltered(q::MPolyQuo) = isfiltered(q.R)
 isgraded(q::MPolyQuo) = isgraded(q.R)
 
-function homogenous_component(a::MPolyQuoElem{<:MPolyElem_dec}, d::GrpAbFinGenElem)
+function homogeneous_component(a::MPolyQuoElem{<:MPolyElem_dec}, d::GrpAbFinGenElem)
   simplify!(a)
-  return homogenous_component(a.f, d)
+  return homogeneous_component(a.f, d)
 end
 
-function homogenous_components(a::MPolyQuoElem{<:MPolyElem_dec})
+function homogeneous_components(a::MPolyQuoElem{<:MPolyElem_dec})
   simplify!(a)
-  return homogenous_components(a.f)
+  return homogeneous_components(a.f)
 end
 
-function ishomogenous(a::MPolyQuoElem{<:MPolyElem_dec})
+function ishomogeneous(a::MPolyQuoElem{<:MPolyElem_dec})
   simplify!(a)
-  return ishomogenous(a.f)
+  return ishomogeneous(a.f)
 end
 
 decoration(q::MPolyQuo{<:MPolyElem_dec}) = decoration(q.R)
@@ -605,7 +605,7 @@ function hash(w::MPolyQuoElem, u::UInt)
   return hash(w.f, u)
 end
 
-function homogenous_component(W::MPolyQuo{<:MPolyElem_dec}, d::GrpAbFinGenElem)
+function homogeneous_component(W::MPolyQuo{<:MPolyElem_dec}, d::GrpAbFinGenElem)
   #TODO: lazy: ie. no enumeration of points
   #      aparently it is possible to get the number of points faster than the points
   D = parent(d)
@@ -613,7 +613,7 @@ function homogenous_component(W::MPolyQuo{<:MPolyElem_dec}, d::GrpAbFinGenElem)
   R = base_ring(W)
   I = modulus(W)
 
-  H, mH = homogenous_component(R, d)
+  H, mH = homogeneous_component(R, d)
   B = Set{elem_type(W)}()
   for h = basis(H)
     b = W(mH(h))

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -1,5 +1,5 @@
-export weight, decorate, ishomogenous, homogenous_components, filtrate,
-grade, GradedPolynomialRing, homogenous_component, jacobi_matrix, jacobi_ideal,
+export weight, decorate, ishomogeneous, homogeneous_components, filtrate,
+grade, GradedPolynomialRing, homogeneous_component, jacobi_matrix, jacobi_ideal,
 HilbertData, hilbert_series, hilbert_series_reduced, hilbert_series_expanded, hilbert_function, hilbert_polynomial,
 homogenization, dehomogenization
 export MPolyRing_dec, MPolyElem_dec
@@ -156,8 +156,8 @@ struct MPolyElem_dec{T, S} <: MPolyElem{T}
   function MPolyElem_dec(f::S, p) where {S}
     r = new{elem_type(base_ring(f)), S}(f, p)
 #    if isgraded(p) && length(r) > 1
-#      if !ishomogenous(r)
-#        error("element not homogenous")
+#      if !ishomogeneous(r)
+#        error("element not homogeneous")
 #      end
 #both wrong and undesired.
 #    end
@@ -316,7 +316,7 @@ function ideal(g::Vector{T}) where {T <: MPolyElem_dec}
   @assert length(g) > 0
   @assert all(x->parent(x) == parent(g[1]), g)
   if isgraded(parent(g[1]))
-     if !(all(ishomogenous, g))
+     if !(all(ishomogeneous, g))
        throw(ArgumentError("The generators of the ideal must be homogeneous."))
      end
   end
@@ -358,13 +358,13 @@ function degree(a::MPolyElem_dec)
       first = false
       w = u
     else
-      w == u || error("element not homogenous")
+      w == u || error("element not homogeneous")
     end
   end
   return w
 end
 
-function ishomogenous(a::MPolyElem_dec)
+function ishomogeneous(a::MPolyElem_dec)
   D = parent(a).D
   d = parent(a).d
   S = Set{elem_type(D)}()
@@ -381,13 +381,13 @@ function ishomogenous(a::MPolyElem_dec)
   return true
 end
 
-function homogenous_components(a::MPolyElem_dec{T, S}) where {T, S}
+function homogeneous_components(a::MPolyElem_dec{T, S}) where {T, S}
   D = parent(a).D
   d = parent(a).d
   h = Dict{elem_type(D), typeof(a)}()
   W = parent(a)
   R = W.R
-  # First assemble the homogenous components into the build contexts.
+  # First assemble the homogeneous components into the build contexts.
   # Afterwards compute the polynomials.
   hh = Dict{elem_type(D), MPolyBuildCtx{S, DataType}}()
   dmat = vcat([d[i].coeff for i in 1:length(d)])
@@ -420,7 +420,7 @@ function homogenous_components(a::MPolyElem_dec{T, S}) where {T, S}
   return hhh
 end
 
-function homogenous_component(a::MPolyElem_dec, g::GrpAbFinGenElem)
+function homogeneous_component(a::MPolyElem_dec, g::GrpAbFinGenElem)
   R = parent(a).R
   r = R(0)
   d = parent(a).d
@@ -454,11 +454,11 @@ function show_homo_comp(io::IO, M)
   if n != nothing
     print(io, "$(n)_$(d.coeff) of dim $(dim(M))")
   else
-    println(io, "homogenous component of $W of degree $d")
+    println(io, "homogeneous component of $W of degree $d")
   end
 end
 
-function homogenous_component(W::MPolyRing_dec, d::GrpAbFinGenElem)
+function homogeneous_component(W::MPolyRing_dec, d::GrpAbFinGenElem)
   #TODO: lazy: ie. no enumeration of points
   #      aparently it is possible to get the number of points faster than the points
   D = W.D
@@ -604,7 +604,7 @@ mutable struct HilbertData
        throw(ArgumentError("The base ring must be graded."))
     end
     
-    if !(all(ishomogenous, gens(I)))
+    if !(all(ishomogeneous, gens(I)))
        throw(ArgumentError("The generators of the ideal must be homogeneous."))
     end
     

--- a/test/Modules/FreeModules-graded-test.jl
+++ b/test/Modules/FreeModules-graded-test.jl
@@ -105,7 +105,7 @@ end
         Hom_FreeModElemst = []
         len = Dict{GrpAbFinGenElem, Int64}()
         for c = 1:6
-          for k in keys(homogenous_components(FreeModElems[c]))
+          for k in keys(homogeneous_components(FreeModElems[c]))
             if haskey(len, k)
               len[k] += 1
             else
@@ -125,7 +125,7 @@ end
           len[temp] = 0
           comp = zero(F)
           for l = 1:6
-            comp += homogenous_component(FreeModElems[l], temp)
+            comp += homogeneous_component(FreeModElems[l], temp)
           end
           push!(Hom_FreeModElemst, comp)
         end
@@ -140,8 +140,8 @@ end
         for p = 1:6
           push!(Hom_FreeModElems, Hom_FreeModElemst[order_new[p]])
         end
-        hom_keys = [collect(keys(homogenous_components(F.R(polys[s]))))[1] for s = 1:6]
-        hom_pols = [homogenous_component(F.R(polys[s]), hom_keys[s]) for s = 1:6]
+        hom_keys = [collect(keys(homogeneous_components(F.R(polys[s]))))[1] for s = 1:6]
+        hom_pols = [homogeneous_component(F.R(polys[s]), hom_keys[s]) for s = 1:6]
         SubQuos = [sub(F, [Hom_FreeModElems[e] for e = 1:3]), quo(F, [Hom_FreeModElems[2*e-1] for e = 1:3])]
         Hom_SubQuoElems = [[SubQuos[1](SubQuos[1](hom_pols[e] * Hom_FreeModElems[e])) for e = 1:3], [SubQuos[2](Hom_FreeModElems[2*e]) for e = 1:3]]
         @test parent_type(Hom_SubQuoElems[1][1]) == typeof(SubQuos[1])
@@ -258,13 +258,13 @@ end
         @test iszero(k[2](gen(k[1], 1)))
         im = image(f)
         @test _eq(im[1], sub(codomain(f), [im[2](x.a) for x = gens(im[1])]))
-        D = homogenous_components(f)
+        D = homogeneous_components(f)
         first = true
         res = 0
         t = gen(domain(f), 1)
         for deg in keys(D)
           gm = D[deg]
-          @test ishomogenous(gm)
+          @test ishomogeneous(gm)
           @test degree(gm) == deg
           if first
             res = gm(t)
@@ -295,10 +295,10 @@ end
 
         for f in FHoms
           @test _eq(image(f + f)[1], image(f)[1])
-          D = homogenous_components(f)
+          D = homogeneous_components(f)
           for deg in keys(D)
             gm = D[deg]
-            @test ishomogenous(gm)
+            @test ishomogeneous(gm)
             @test degree(gm) == deg
             @test _eq(kernel(gm + gm)[1], kernel(gm)[1])
           end
@@ -309,11 +309,11 @@ end
           Ob = [F, SubQuos[3], I]
           El = [gen(F, rand(1:3)), Hom_SubQuoElems[3][rand(1:3)], hom_pols[rand(1:3)]]
           for t = 1:2
-            comp = homogenous_component(Ob[t], g)[2]
+            comp = homogeneous_component(Ob[t], g)[2]
 
             #=
             if j < 4
-              temp = homogenous_component(El[t], g)
+              temp = homogeneous_component(El[t], g)
               comp.header.image(comp.header.preimage(temp)) == temp
             end
             =#

--- a/test/Modules/GradedModules.jl
+++ b/test/Modules/GradedModules.jl
@@ -10,9 +10,9 @@
 
   @test length([h(g) for g = basis(F)]) == dim(F)
 
-  @test !Oscar.ishomogenous(h)
+  @test !Oscar.ishomogeneous(h)
 
-  c = homogenous_components(h)
+  c = homogeneous_components(h)
   @test length(c) == 3
 
   for g = keys(c)
@@ -27,7 +27,7 @@
 
   free_resolution(H)
 
-  homogenous_component(H, Oscar.decoration(F)[0])
+  homogeneous_component(H, Oscar.decoration(F)[0])
 end
 
 @testset "Graded Modules 2" begin

--- a/test/Rings/mpoly-graded-test.jl
+++ b/test/Rings/mpoly-graded-test.jl
@@ -16,12 +16,12 @@ function _random_poly(RR, n)
   return pols
 end
 
-function _homogenous_polys(polys::Vector{<:MPolyElem})
+function _homogeneous_polys(polys::Vector{<:MPolyElem})
   R = parent(polys[1])
   D = []
   _monomials = [zero(R)]
   for i = 1:4
-    push!(D, homogenous_components(polys[i]))
+    push!(D, homogeneous_components(polys[i]))
     _monomials = append!(_monomials, monomials(polys[i]))
   end
   hom_polys = []
@@ -30,11 +30,11 @@ function _homogenous_polys(polys::Vector{<:MPolyElem})
     for i = 1:4
       if haskey(D[i], deg)
         temp = get(D[i], deg, 'x')
-        @test homogenous_component(polys[i], deg) == temp
+        @test homogeneous_component(polys[i], deg) == temp
         g += temp
       end
     end
-    @test ishomogenous(g)
+    @test ishomogeneous(g)
     push!(hom_polys, g)
   end
   return hom_polys
@@ -87,7 +87,7 @@ end
 
       dims = IdDict(zip(decorated_rings, [15, 12, 6, 1, 1]))
 
-      # In RR, we take the quotient by the homogenous component corresponding to d_Elems[RR]
+      # In RR, we take the quotient by the homogeneous component corresponding to d_Elems[RR]
       # The dimension should be dims[RR]
 
       for RR in decorated_rings
@@ -115,17 +115,17 @@ end
                 finish(push_term!(MPolyBuildCtx(RR), collect(Oscar.MPolyCoeffs(polys[4]))[k], collect(Oscar.MPolyExponentVectors(polys[4]))[k]))
         end
 
-        hom_polys = _homogenous_polys(polys)
+        hom_polys = _homogeneous_polys(polys)
         I = ideal(hom_polys)
         R_quo = Oscar.MPolyQuo(RR, I)
         @test base_ring(R_quo) == RR
         @test modulus(R_quo) == I
         f = R_quo(polys[2])
-        D = homogenous_components(f)
+        D = homogeneous_components(f)
         for deg in [degree(R_quo(mon)) for mon  = Oscar.monomials(f.f)]
           h = get(D, deg, 'x')
-          @test ishomogenous(R_quo(h))
-          @test h == homogenous_component(f, deg)
+          @test ishomogeneous(R_quo(h))
+          @test h == homogeneous_component(f, deg)
         end
 
         @test Oscar.isfiltered(R_quo) == Oscar.isfiltered(RR)
@@ -139,7 +139,7 @@ end
 
         if base_ring(R) isa AbstractAlgebra.Field
           grp_elem = d_Elem
-          H = homogenous_component(RR, grp_elem)
+          H = homogeneous_component(RR, grp_elem)
           @test Oscar.hasrelshp(H[1], RR) !== nothing
           for g in gens(H[1])
             @test degree(H[2](g)) == grp_elem
@@ -147,7 +147,7 @@ end
           end
           @test dim(H[1]) == dim_test # j
         end
-        #H_quo = homogenous_component(R_quo, grp_elem)
+        #H_quo = homogeneous_component(R_quo, grp_elem)
         #Oscar.hasrelshp(H_quo[1], R_quo) !== nothing
         #for g in gens(H_quo[1])
         #    degree(H_quo[2](g)) == grp_elem


### PR DESCRIPTION
Both are allowed spellings; but elsewhere in Oscar.jl, Hecke.jl
and AbstractAlgebra.jl, we use the more common "homogeneous", so
let's also use it here.

Motived by [a comment](https://github.com/oscar-system/Oscar.jl/issues/426#issuecomment-832554695) made by @8d1h.

We could of course also provide synonyms for both spellings but this has downsides, too. Similar for `center` vs `centre`, or `normalizer` vs. `normaliser` and more.