### PR TITLE
Clarify groebner assure

### DIFF
--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -235,6 +235,7 @@ end
 function singular_ring(Rx::MPolyQuo; keep_ordering::Bool = true)
   if !isdefined(Rx, :SQR)
     groebner_assure(Rx.I)
+    singular_assure(Rx.I.gb)
     Rx.SQR = Singular.create_ring_from_singular_ring(
                       Singular.libSingular.rQuotientRing(Rx.I.gb.S.ptr,
                                              base_ring(Rx.I.gb.S).ptr))

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -8,6 +8,9 @@ export  groebner_basis, groebner_basis_with_transformation_matrix, leading_ideal
 
 Given an ideal `I` in a multivariate polynomial ring this function assures that a
 Groebner basis w.r.t. the given monomial ordering is attached to `I` in `I.gb`.
+It *currently* also ensures that the basis is defined on the Singular side in
+`I.gb.S`, but this should not be relied upon: use `singular_assure(I.gb)` before
+accessing `I.gb.S`.
 
 # Examples
 ```jldoctest

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -759,9 +759,7 @@ false
 ```
 """
 function Base.:(==)(I::MPolyIdeal, J::MPolyIdeal)
-  singular_assure(I)
-  singular_assure(J)
-  return Singular.equal(I.gens.S, J.gens.S)
+  return issubset(I, J) && issubset(J, I)
 end
 
 ### todo: wenn schon GB's  bekannt ...
@@ -788,9 +786,11 @@ true
 ```
 """
 function Base.issubset(I::MPolyIdeal, J::MPolyIdeal)
+  # avoid Singular.contains as it does not save the gb it might compute
   singular_assure(I)
-  singular_assure(J)
-  return Singular.contains(J.gens.S, I.gens.S)
+  groebner_assure(J)
+  singular_assure(J.gb)
+  return Singular.iszero(Singular.reduce(I.gens.S, J.gb.S))
 end
 
 ### todo: wenn schon GB's  bekannt ...

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -825,6 +825,7 @@ false
 """
 function ideal_membership(f::T, I::MPolyIdeal) where T <: MPolyElem
   groebner_assure(I)
+  singular_assure(I.gb)
   Sx = base_ring(I.gb.S)
   return Singular.iszero(reduce(Sx(f), I.gb.S))
 end
@@ -1001,7 +1002,7 @@ function dim(I::MPolyIdeal)
     return I.dim
   end
   groebner_assure(I)
-  singular_assure(I)
+  singular_assure(I.gb)
   I.dim = Singular.dimension(I.gb.S)
   return I.dim
 end


### PR DESCRIPTION
@wdecker I went through the ideals code, and it looks like the only inefficiencies were in `issubset` and `==`, so it wasn't too bad.