### PR TITLE
Remove illegal == for QabField

### DIFF
--- a/experimental/Rings/QabAndPChars.jl
+++ b/experimental/Rings/QabAndPChars.jl
@@ -24,6 +24,8 @@ export QabField, QabElem, QabAutomorphism, isconductor, root_of_unity, PartialCh
 mutable struct QabField <: Nemo.Field # union of cyclotomic fields
 end
 
+const Qab = QabField()
+
 function Base.show(io::IO, a::QabField)
   print(io, "Abelian closure of Q")
 end
@@ -108,8 +110,6 @@ import Nemo.mul!, Nemo.addeq!, Nemo.divexact, Nemo.iszero, Nemo.isunit
 Oscar.show_minus_one(::Type{QabElem}) = false
 Oscar.needs_parentheses(a::QabElem) = Oscar.needs_parentheses(a.data)
 Oscar.displayed_with_minus_in_front(a::QabElem) = Oscar.displayed_with_minus_in_front(a.data)
-
-==(::QabField, ::QabField) = true
 
 isunit(a::QabElem) = !iszero(a)
 
@@ -237,9 +237,9 @@ function Base.deepcopy(a::QabElem, b::QabElem)
   return QabElem(a.data//b.data, a.c)
 end
 
-Base.parent(::QabElem) = QabField()
-Base.one(::QabField) = QabField()(1)
-Base.one(::QabElem) = QabField()(1)
+Base.parent(::QabElem) = Qab
+Base.one(::QabField) = Qab(1)
+Base.one(::QabElem) = Qab(1)
 
 Oscar.isnegative(::QabElem) = false
 
@@ -284,7 +284,7 @@ end
 function Oscar.root(a::QabElem, n::Int)
  o = Oscar.order(a)
  l = o*n
- mu = root_of_unity2(QabField(), Int(l))
+ mu = root_of_unity2(Qab, Int(l))
  return mu
 end
 
@@ -295,7 +295,7 @@ function allroot(a::QabElem, n::Int)
 	#root_of_unity constructs the field Q(z_10))
 	o = order(a)
   l = o*n
-  mu = root_of_unity(QabField(), Int(l))
+  mu = root_of_unity(Qab, Int(l))
 	A = QabElem[]
 	if l==1 && mu==a
 		push!(A, mu)

--- a/src/Rings/binomial_ideals.jl
+++ b/src/Rings/binomial_ideals.jl
@@ -421,7 +421,7 @@ function partial_character_from_ideal(I::MPolyIdeal, R::MPolyRing)
 
   Delta = cell[2]   #cell variables
   if isempty(Delta)
-    return QabModule.partial_character(zero_matrix(FlintZZ, 1, nvars(R)), [one(QabModule.QabField())], Set{Int64}())
+    return QabModule.partial_character(zero_matrix(FlintZZ, 1, nvars(R)), [one(QabModule.Qab)], Set{Int64}())
   end
 
   #now consider the case where Delta is not empty
@@ -436,14 +436,14 @@ function partial_character_from_ideal(I::MPolyIdeal, R::MPolyRing)
     J = eliminate(I, to_eliminate)
   end
   if iszero(J)
-    return QabModule.partial_character(zero_matrix(FlintZZ, 1, nvars(R)), [one(QabModule.QabField())], Set{Int64}())
+    return QabModule.partial_character(zero_matrix(FlintZZ, 1, nvars(R)), [one(QabModule.Qab)], Set{Int64}())
   end
   #now case if J \neq 0
   #let ts be a list of minimal binomial generators for J
   gb = groebner_basis(J, complete_reduction = true)
   vs = zero_matrix(FlintZZ, 0, nvars(R))
   images = QabModule.QabElem[]
-  Qabcl = QabModule.QabField()
+  Qabcl = QabModule.Qab
   for t in gb
     #TODO: Once tail will be available, use it.
     lm = leading_monomial(t)
@@ -595,7 +595,7 @@ end
 
 Given a cellular binomial ideal `I`, return the associated primes of `I`.
 """
-function cellular_associated_primes(I::MPolyIdeal{fmpq_mpoly}, RQab::MPolyRing = PolynomialRing(QabModule.QabField(), nvars(base_ring(I)))[1])
+function cellular_associated_primes(I::MPolyIdeal{fmpq_mpoly}, RQab::MPolyRing = PolynomialRing(QabModule.Qab, nvars(base_ring(I)))[1])
   #input: cellular binomial ideal
   #output: the set of associated primes of I
 
@@ -667,7 +667,7 @@ function cellular_minimal_associated_primes(I::MPolyIdeal{fmpq_mpoly})
   end
   R = base_ring(I)
   P = partial_character_from_ideal(I, R)
-  RQab = PolynomialRing(QabModule.QabField(), nvars(R))[1]
+  RQab = PolynomialRing(QabModule.Qab, nvars(R))[1]
   PSat = QabModule.saturations(P)
   minimal_associated = Vector{MPolyIdeal{Generic.MPoly{QabModule.QabElem}}}() #this will hold the set of minimal associated primes
 
@@ -712,7 +712,7 @@ end
 
 Given a cellular binomial ideal `I`, return a binomial primary decomposition of `I`.
 """
-function cellular_primary_decomposition(I::MPolyIdeal, RQab::MPolyRing = PolynomialRing(QabModule.QabField(), nvars(base_ring(I)))[1])
+function cellular_primary_decomposition(I::MPolyIdeal, RQab::MPolyRing = PolynomialRing(QabModule.Qab, nvars(base_ring(I)))[1])
   #algorithm from macaulay2
   #input: unital cellular binomial ideal in k[x]
   #output: binomial primary ideals which form a minimal primary decomposition of I 
@@ -773,7 +773,7 @@ function binomial_primary_decomposition(I::MPolyIdeal)
   T = MPolyIdeal{Generic.MPoly{QabModule.QabElem}}
   res = Vector{Tuple{T, T}}() #This will hold the set of primary components
   #now compute a primary decomposition of each cellular component
-  Qab = QabModule.QabField()
+  Qab = QabModule.Qab
   RQab = PolynomialRing(Qab, nvars(base_ring(I)))[1]
   for J in cell_comps
     resJ = cellular_primary_decomposition(J, RQab)


### PR DESCRIPTION
The code was creating new fields via `QabField()` all over the place,  but the definition of `==` was incompatible with hashing. I decided to introduce a global `QabField` object, called `Qab` (similar to `ZZ` and `QQ`). 

Closes #491  

CC: @fieker 
