### PR TITLE
basic function field support

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -232,6 +232,7 @@ include("Rings/mpoly-affine-algebras.jl")
 include("Rings/mpoly-local.jl")
 include("Rings/FinField.jl")
 include("Rings/NumberField.jl")
+include("Rings/FunctionField.jl")
 
 include("Modules/FreeModules-graded.jl")
 

--- a/src/Rings/FunctionField.jl
+++ b/src/Rings/FunctionField.jl
@@ -1,0 +1,42 @@
+# conversion between Singular and AbstractAlgebra function fields
+function Oscar.singular_ring(F::AbstractAlgebra.Generic.RationalFunctionField{T}) where T <: FieldElem
+  return Singular.FunctionField(singular_ring(base_ring(F)), [string(F.S)])[1]
+end
+
+function (F::Singular.N_FField)(x::AbstractAlgebra.Generic.Rat{T}) where T <: FieldElem
+  @assert Singular.transcendence_degree(F) == 1
+  a = Singular.transcendence_basis(F)[1]
+  numerator(x)(a) // denominator(x)(a)
+end
+
+function (F::AbstractAlgebra.Generic.RationalFunctionField{T})(x::Singular.n_transExt) where T <: FieldElem
+  @assert Singular.transcendence_degree(parent(x)) == 1
+  n, d = Singular.n_transExt_to_spoly.([numerator(x), denominator(x)])
+  F(n) // F(d)
+end
+
+function (F::FlintRationalField)(x::AbstractAlgebra.Generic.Rat{fmpq})
+  num = numerator(x)
+  cst_num = constant_coefficient(num)
+  denom = denominator(x)
+  cst_denom = constant_coefficient(denom)
+  if (num != cst_num || denom != cst_denom) throw(InexactError) end
+  F(cst_num) // F(cst_denom)
+end
+
+function (F::Singular.N_FField)(x::gfp_elem)
+  @assert characteristic(F) == characteristic(parent(x))
+  F(lift(x))
+end
+
+# These should probably be put in Singular.jl
+function (F::Singular.N_FField)(x::fmpq)
+  @assert characteristic(F) == 0
+  F(numerator(x)) // F(denominator(x))
+end
+
+function (Ox::PolyRing)(f::Singular.spoly)
+  O = base_ring(Ox)
+  @assert ngens(parent(f)) == 1
+  Ox(O.(coefficients_of_univariate(f)))
+end

--- a/src/Rings/FunctionField.jl
+++ b/src/Rings/FunctionField.jl
@@ -1,37 +1,70 @@
-# conversion between Singular and AbstractAlgebra function fields
-function Oscar.singular_ring(F::AbstractAlgebra.Generic.RationalFunctionField{T}) where T <: FieldElem
-  return Singular.FunctionField(singular_ring(base_ring(F)), [string(F.S)])[1]
+function check_char(A::Ring, B::Ring)
+  characteristic(A) == characteristic(B) || throw(ArgumentError("wrong characteristic"))
 end
 
-function (F::Singular.N_FField)(x::AbstractAlgebra.Generic.Rat{T}) where T <: FieldElem
-  @assert Singular.transcendence_degree(F) == 1
+# conversion between FractionField and Singular function field
+# univariate
+function Oscar.singular_ring(F::AbstractAlgebra.Generic.FracField{T}) where T <: Union{fmpq_poly, gfp_poly}
+  R = base_ring(F)
+  return Singular.FunctionField(singular_ring(base_ring(R)), [string(R.S)])[1]
+end
+
+function (F::Singular.N_FField)(x::AbstractAlgebra.Generic.Frac{T}) where T <: Union{fmpq_poly, gfp_poly}
+  check_char(F, parent(x))
+  Singular.transcendence_degree(F) == 1 || throw(ArgumentError("wrong number of generators"))
   a = Singular.transcendence_basis(F)[1]
   numerator(x)(a) // denominator(x)(a)
 end
 
-function (F::AbstractAlgebra.Generic.RationalFunctionField{T})(x::Singular.n_transExt) where T <: FieldElem
-  @assert Singular.transcendence_degree(parent(x)) == 1
+function (F::AbstractAlgebra.Generic.FracField{T})(x::Singular.n_transExt) where T <: Union{fmpq_poly, gfp_poly}
+  check_char(F, parent(x))
+  Singular.transcendence_degree(parent(x)) == 1 || throw(ArgumentError("wrong number of generators"))
   n, d = Singular.n_transExt_to_spoly.([numerator(x), denominator(x)])
   F(n) // F(d)
 end
 
-function (F::FlintRationalField)(x::AbstractAlgebra.Generic.Rat{fmpq})
-  num = numerator(x)
-  cst_num = constant_coefficient(num)
-  denom = denominator(x)
-  cst_denom = constant_coefficient(denom)
-  if (num != cst_num || denom != cst_denom) throw(InexactError) end
-  F(cst_num) // F(cst_denom)
+# multivariate
+function Oscar.singular_ring(F::AbstractAlgebra.Generic.FracField{T}) where T <: Union{fmpq_mpoly, gfp_mpoly}
+  R = base_ring(F)
+  return Singular.FunctionField(singular_ring(base_ring(R)), string.(R.S))[1]
 end
 
+function (F::Singular.N_FField)(x::AbstractAlgebra.Generic.Frac{T}) where T <: Union{fmpq_mpoly, gfp_mpoly}
+  check_char(F, parent(x))
+  Singular.transcendence_degree(F) == ngens(base_ring(parent(x))) || throw(ArgumentError("wrong number of generators"))
+  a = Singular.transcendence_basis(F)
+  numerator(x)(a...) // denominator(x)(a...)
+end
+
+function (F::AbstractAlgebra.Generic.FracField{T})(x::Singular.n_transExt) where T <: Union{fmpq_mpoly, gfp_mpoly}
+  check_char(F, parent(x))
+  ngens(base_ring(F)) == Singular.transcendence_degree(parent(x)) || throw(ArgumentError("wrong number of generators"))
+  n, d = Singular.n_transExt_to_spoly.([numerator(x), denominator(x)])
+  F(n) // F(d)
+end
+
+# conversion between Singular and AbstractAlgebra function fields
+function Oscar.singular_ring(F::AbstractAlgebra.Generic.RationalFunctionField{T}) where T <: FieldElem
+  return singular_ring(F.fraction_field)
+end
+
+function (F::Singular.N_FField)(x::AbstractAlgebra.Generic.Rat{T}) where T <: FieldElem
+  return F(x.d)
+end
+
+function (F::AbstractAlgebra.Generic.RationalFunctionField{T})(x::Singular.n_transExt) where T <: FieldElem
+  return F(F.fraction_field(x))
+end
+
+# constants
 function (F::Singular.N_FField)(x::gfp_elem)
-  @assert characteristic(F) == characteristic(parent(x))
+  check_char(F, parent(x))
   F(lift(x))
 end
 
 # These should probably be put in Singular.jl
 function (F::Singular.N_FField)(x::fmpq)
-  @assert characteristic(F) == 0
+  check_char(F, parent(x))
   F(numerator(x)) // F(denominator(x))
 end
 
@@ -39,4 +72,31 @@ function (Ox::PolyRing)(f::Singular.spoly)
   O = base_ring(Ox)
   @assert ngens(parent(f)) == 1
   Ox(O.(coefficients_of_univariate(f)))
+end
+
+# coercion
+function (F::FlintRationalField)(x::AbstractAlgebra.Generic.Frac{T}) where T <: Union{fmpq_poly, fmpq_mpoly}
+  num = numerator(x)
+  cst_num = constant_coefficient(num)
+  denom = denominator(x)
+  cst_denom = constant_coefficient(denom)
+  if (num != cst_num || denom != cst_denom) throw(InexactError(:fmpq, fmpq, x)) end
+  F(cst_num) // F(cst_denom)
+end
+
+function (F::FlintRationalField)(x::AbstractAlgebra.Generic.Rat{fmpq})
+  return F(x.d)
+end
+
+function (F::Nemo.GaloisField)(x::AbstractAlgebra.Generic.Frac{T}) where T <: Union{gfp_poly, gfp_mpoly}
+  num = numerator(x)
+  cst_num = constant_coefficient(num)
+  denom = denominator(x)
+  cst_denom = constant_coefficient(denom)
+  if (num != cst_num || denom != cst_denom) throw(InexactError(:gfp_elem, gfp_elem, x)) end
+  F(cst_num) // F(cst_denom)
+end
+
+function (F::Nemo.GaloisField)(x::AbstractAlgebra.Generic.Rat{gfp_elem})
+  return F(x.d)
 end

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -567,7 +567,8 @@ Base.eltype(::BiPolyArray{S}) where S = S
 # singular_ring(Nemo-Ring) tries to create the appropriate Ring
 #
 
-function (Ox::MPolyRing)(f::Singular.spoly)
+for T in [:MPolyRing, :(AbstractAlgebra.Generic.MPolyRing)]
+@eval function (Ox::$T)(f::Singular.spoly)
   O = base_ring(Ox)
   Sx = parent(f)
   @assert ngens(Sx) == ngens(Ox)
@@ -576,6 +577,7 @@ function (Ox::MPolyRing)(f::Singular.spoly)
     push_term!(g, O(c), e)
   end
   return finish(g)
+end
 end
 
 

--- a/test/Rings/FunctionField-test.jl
+++ b/test/Rings/FunctionField-test.jl
@@ -1,0 +1,41 @@
+@testset "FunctionField" begin
+  for (k, kk) in [(QQ, Singular.QQ), (GF(3), Singular.Fp(3))]
+    tests = []
+    
+    # RationalFunctionField
+    F, a = RationalFunctionField(k, "a")
+    push!(tests, (F, a, ["a"]))
+    
+    # univariate FractionField
+    F = FractionField(k["a"][1])
+    a = F(gen(base_ring(F)))
+    push!(tests, (F, a, ["a"]))
+    
+    # multivariate FractionField
+    F = FractionField(k["a1", "a2"][1])
+    a = F(base_ring(F)[1])
+    push!(tests, (F, a, ["a1", "a2"]))
+    
+    for (F, a, symb) in tests
+      F1, (a1,) = Singular.FunctionField(kk, symb)
+      F2, (a2,) = Singular.FunctionField(kk, vcat(symb, ["b"])) # one more gen
+      F3, (a3,) = Singular.FunctionField(Singular.Fp(5), symb) # different char
+      
+      @test singular_ring(F) === F1
+      @test F(a1) == a
+      @test F1(a) == a1
+      
+      @test_throws ArgumentError F(a2) # wrong ngens
+      @test_throws ArgumentError F2(a) # wrong ngens
+      
+      @test_throws ArgumentError F(a3) # wrong char
+      @test_throws ArgumentError F3(a) # wrong char
+      
+      R, (x, y) = PolynomialRing(F, ["x", "y"])
+      @test singular_ring(R) isa Singular.PolyRing{Singular.n_transExt}
+
+      @test k(F(1)) isa elem_type(k)
+      @test_throws InexactError k(a)
+    end
+  end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ include("Rings/slpolys-test.jl")
 include("Polymake/nmbthy-test.jl")
 include("Groups/runtests.jl")
 include("Rings/NumberField.jl")
+include("Rings/FunctionField-test.jl")
 
 # if Oscar.is_dev
 #   include("Examples/PlaneCurve-test.jl")


### PR DESCRIPTION
The idea is to be able to use parameters in coefficients and still compute Gröbner basis using Singular. For now `AbstractAlgebra.RationalFunctionField` only supports one parameter.
```julia
julia> F, a = RationalFunctionField(QQ, "a");

julia> R, (x,y) = PolynomialRing(F, ["x", "y"]);

julia> singular_ring(R)
Singular Polynomial Ring (0,a),(x,y),(lp(2),C)

julia> I = ideal([x^3+a*y, x+(a+1)*y]); groebner_basis(I)
2-element Vector{AbstractAlgebra.Generic.MPoly{AbstractAlgebra.Generic.Rat{fmpq}}}:
 x + (a + 1)*y
 (a^3 + 3*a^2 + 3*a + 1)*y^3 - a*y
```

There is an annoying ambiguity issue with `(::MPolyRing)(::spoly)` so I just duplicated the code.