### PR TITLE
Cleanup code in docs/make_work.jl

### DIFF
--- a/docs/make_local.jl
+++ b/docs/make_local.jl
@@ -1,10 +1,10 @@
 module BuildDoc
 using Oscar
 
-include(normpath(joinpath(Oscar.oscardir, "docs", "make_work.jl")))
+include(normpath(Oscar.oscardir, "docs", "make_work.jl"))
 
 function open_doc()
-    filename = normpath(joinpath(dirname(pathof(Oscar)), "..", "docs", "build", "index.html"))
+    filename = normpath(Oscar.oscardir, "docs", "build", "index.html")
     @static if Sys.isapple()
         run(`open $(filename)`; wait = false)
     elseif Sys.islinux() || Sys.isbsd()


### PR DESCRIPTION
Using `Meta.eval` was wrong: that's just the `eval` function of the `Meta`
module, i.e., it evaluated the parse tree within the `Meta` module, which is
not what we want. Instead, call `eval` to evaluate in the current module; this
way, `aa`, `hecke`, `nemo` are accessible and interpolated for us