### PR TITLE
Fix nmod ring

### DIFF
--- a/experimental/ModStd/ModStdQ.jl
+++ b/experimental/ModStd/ModStdQ.jl
@@ -9,7 +9,7 @@ function __init__()
   Hecke.add_verbose_scope(:ModStdQ)
 end
 
-function (R::AbstractAlgebra.Generic.MPolyRing{Nemo.gfp_elem})(f::fmpq_mpoly)
+function (R::GFPMPolyRing)(f::fmpq_mpoly)
   g  = MPolyBuildCtx(R)
   S = base_ring(R)
   for (c, v) in zip(coefficients(f), exponent_vectors(f))
@@ -18,7 +18,7 @@ function (R::AbstractAlgebra.Generic.MPolyRing{Nemo.gfp_elem})(f::fmpq_mpoly)
   return finish(g)
 end
 
-function (S::Nemo.NmodRing)(a::fmpq)
+function (S::Union{Nemo.NmodRing, Nemo.GaloisField})(a::fmpq)
   return S(numerator(a))//S(denominator(a))
 end
 
@@ -138,7 +138,7 @@ function Oscar.groebner_basis_with_transform(I::MPolyIdeal{fmpq_mpoly}; ordering
     p = iterate(ps, p)[1]
     @vprint :ModStdQ 2 "Main loop: using $p\n"
 #    nbits(d) > 1700 && error("too long")
-    R = ResidueRing(ZZ, Int(p))
+    R = GF(p)
     Rt, t = PolynomialRing(R, [string(s) for s = symbols(Qt)], cached = false)
     @vtime :ModStdQ 3 Ip = Oscar.BiPolyArray([Rt(x) for x = gI], keep_ordering = false)
     Gp, Tp = Oscar.groebner_basis_with_transform(Ip, ord = ordering, complete_reduction = complete_reduction)
@@ -204,7 +204,7 @@ function Oscar.groebner_basis_with_transform(I::MPolyIdeal{fmpq_mpoly}; ordering
 end
 
 
-function Oscar.lift(R::Nemo.Ring, f::nmod_mpoly)
+function Oscar.lift(R::Nemo.Ring, f::Union{gfp_mpoly, nmod_mpoly})
   g = MPolyBuildCtx(R)
   for (c, v) in zip(coefficients(f), exponent_vectors(f))
     push_term!(g, lift(c), v)

--- a/src/Rings/binomial_ideals.jl
+++ b/src/Rings/binomial_ideals.jl
@@ -63,17 +63,6 @@ function iscellular(I::MPolyIdeal)
   end
 end
 
-function isone_easy(I::MPolyIdeal)
-  p = next_prime(2^28)
-  fl = false
-  Qt = base_ring(I)
-  R = ResidueRing(ZZ, Int(p)) #gfp_mpoly missing...
-  Rt, t = PolynomialRing(R, nvars(Qt), cached = false)
-  Ip = Oscar.BiPolyArray([Rt(x) for x in gens(I)], keep_ordering = false)
-  Gp = Oscar.groebner_basis(Ip, ordering = :degrevlex, complete_reduction = true)
-  return any(isone, Gp)
-end
-
 function _iscellular(I::MPolyIdeal)
   #input: binomial ideal in a polynomial ring
   #output: the decision true/false whether I is cellular or not

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -594,8 +594,14 @@ end
 #Note: Singular crashes if it gets Nemo.ZZ instead of Singular.ZZ ((Coeffs(17)) instead of (ZZ))
 singular_ring(::Nemo.FlintIntegerRing) = Singular.Integers()
 singular_ring(::Nemo.FlintRationalField) = Singular.Rationals()
+
+# if the characteristic overflows an Int, Singular doesn't support it anyways
 singular_ring(F::Nemo.GaloisField) = Singular.Fp(Int(characteristic(F)))
-singular_ring(F::Nemo.NmodRing) = Singular.Fp(Int(characteristic(F)))
+
+function singular_ring(F::Union{Nemo.NmodRing, Nemo.FmpzModRing})
+  return Singular.ResidueRing(Singular.Integers(), BigInt(modulus(F)))
+end
+
 singular_ring(R::Singular.PolyRing; keep_ordering::Bool = true) = R
 
 function singular_ring(Rx::MPolyRing{T}; keep_ordering::Bool = true) where {T <: RingElem}

--- a/test/Rings/mpoly-graded-test.jl
+++ b/test/Rings/mpoly-graded-test.jl
@@ -48,6 +48,7 @@ end
     NFx = PolynomialRing(k1, ["x", "y", "z"])[1]
     k2 = Nemo.GF(23)
     GFx = PolynomialRing(k2, ["x", "y", "z"])[1]
+    # TODO explain why test fails if Nemo.ResidueRing(ZZ,17) => Nemo.GF(17)
     RNmodx=PolynomialRing(Nemo.ResidueRing(ZZ,17), :x => 1:2)[1]
     Rings= [Qx, NFx, GFx, RNmodx]
 

--- a/test/Rings/mpoly-test.jl
+++ b/test/Rings/mpoly-test.jl
@@ -227,7 +227,13 @@ end
   @test groebner_basis(I,ordering=:lex) == [y^2 - y*z - z - 3, x + y*z + 5*z - 2]
   @test groebner_basis(I,ordering=:degrevlex, complete_reduction = true) == [x + y*z + 5*z - 2, x + y^2 + 4*z - 5, x*y - x*z - 5*x - 2*y - 4*z^2 - 20*z + 10, x^2 + x*z^2 + 10*x*z - 4*x + 4*z^3 + 20*z^2 - 20*z + 4]
 
-
+  # test coefficient "rings" that are actually fields for safety
+  for Zn in [ResidueRing(ZZ, 11), ResidueRing(ZZ, fmpz(10)^50+151)]
+    R, (x, y) = PolynomialRing(Zn, ["x", "y"], ordering = :degrevlex)
+    l = [x*y+x^3+1, x*y^2+x^2+1]
+    g = groebner_basis(ideal(R, l), ordering = :degrevlex)
+    @assert iszero(divrem(l[1] + l[2], g)[2])
+  end
 end
 
 @testset "Primary decomposition" begin


### PR DESCRIPTION
Will eventually fix #444 
This is a bit difficult because a proper solution requires singular's multiprecision Z/nZ coeffs.
@wdecker @hannes14  I noticed singular's gb engine crashing with (integer, 269484097) coeffs instead of the usual F_269484097 coeffs. Not sure whose fault it is at this point.
Also, @thofma there is a strange hecke bug in the test code that I added.
here is MWE
```julia
using Oscar
R,(x,y) = PolynomialRing(ResidueRing(ZZ, ZZ(10)^50+151), ["x", "y"])
divrem(x+y,y)
```