### PR TITLE
[RFC] Add function to retrieve degrees of generators

### DIFF
--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -848,6 +848,14 @@ end
 #
 ################################################################################
 
+function degree_generators(R::MPolyQuo)
+  if R.R isa MPolyRing_dec
+    return R.R.d
+  else
+    error("Must be quotient ring of graded polynomial ring")
+  end
+end
+
 function degree(a::MPolyQuoElem{<:MPolyElem_dec})
   simplify!(a)
   return degree(a.f)

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -26,6 +26,8 @@ mutable struct MPolyRing_dec{T, S} <: AbstractAlgebra.MPolyRing{T}
   end
 end
 
+degree_generators(R::MPolyRing_dec) = R.d
+
 isgraded(W::MPolyRing_dec) = !isdefined(W, :lt)
 isfiltered(W::MPolyRing_dec) = isdefined(W, :lt)
 


### PR DESCRIPTION
@8d1h was asking for function to retrieve the degrees of the generators. At the moment this information can be accessed by `R.d` and `R.R.d` respectively. But we need a uniform interface to write generic code.

I picked `degree_generators`, but I am not married to the name. I am happy to change it to whatever we want. (Other options would be `generators_degree`/`generators_degrees`/`degrees_generators`/...).

@wdecker 