### PR TITLE
exhibit a problem with Documenter.jl -- do not merge!

### DIFF
--- a/docs/src/Groups/basics.md
+++ b/docs/src/Groups/basics.md
@@ -82,5 +82,6 @@ isalmostsimple
 ## Attributes of groups
 
 ```@docs
+order(::Type{T}, x::Union{GAPGroupElem, GAPGroup}) where T
 Base.exponent(x::GAPGroup)
 ```

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -104,8 +104,19 @@ function degree(x::PermGroup)
    return x.deg
 end
 
-order(x::Union{GAPGroupElem, GAPGroup}) = order(fmpz, x)
+"""
+    order([::Type{T}, ]x::Union{GAPGroupElem, GAPGroup}) where T
 
+Return the order of `x`, as an instance of `T`.
+The default for `T` is `fmpz`.
+
+For a group element `x` in the group `G`, the order of `x` is the smallest
+positive integer `n` such that `x^n` is the identity of `G`.
+For a group `x`, the order of `x` is the number of elements in `x`.
+
+An exception is raised if the order of `x` is infinite,
+use `isfinite` in order to check for finiteness.
+"""
 function order(::Type{T}, x::Union{GAPGroupElem, GAPGroup}) where T
    ord = GAP.Globals.Order(x.X)
    if ord === GAP.Globals.infinity
@@ -113,6 +124,8 @@ function order(::Type{T}, x::Union{GAPGroupElem, GAPGroup}) where T
    end
    return T(ord)
 end
+
+order(x::Union{GAPGroupElem, GAPGroup}) = order(fmpz, x)
 
 """
     exponent(G::Group)


### PR DESCRIPTION
This PR adds documentation for a *method* for `order` for group elements and groups.
When I build the Oscar documentation in this situation, I get the following.

- The documentation page for Groups/Basics shows a documentation entry for the new method, as expected.
- The documentation page for Rings/Orders/'Fractional ideals' shows a documentation entry for *two* methods, the new one and one for `order(a::NfAbsOrdFracIdl)`; the `@docs` block in the source file `orders/frac_ideals.md` of Hecke specifies the latter one.

Why does the group related method appear in the page about Fractional ideals?