### PR TITLE
Adjust AbstractAlgebra doc refs after recent rearrangement.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Singular = "bcd08a7b-43d2-5ff7-b6d4-c458787f915c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-AbstractAlgebra = "0.19.0"
+AbstractAlgebra = "0.20.0"
 DocStringExtensions = "0.8"
 GAP = "0.5"
 Hecke = "0.10.12"

--- a/docs/doc.main
+++ b/docs/doc.main
@@ -19,14 +19,12 @@
 
   "Rings" => [
      "Rings/intro.md",
-     "AbstractAlgebra/rings.md",
+     "AbstractAlgebra/ring.md",
      "Rings/integer.md",
      "Univariate Polynomials" => [
-        "AbstractAlgebra/polynomial_rings.md",
         "AbstractAlgebra/polynomial.md",
      ],
      "Multivariate Polynomials" => [
-        "AbstractAlgebra/mpolynomial_rings.md",
         "AbstractAlgebra/mpolynomial.md",
      ],
      "Orders" => [
@@ -37,7 +35,6 @@
         "Hecke/orders/frac_ideals.md",
      ],
      "Series Rings" => [
-        "AbstractAlgebra/series_rings.md",
         "AbstractAlgebra/series.md",
         "AbstractAlgebra/puiseux.md",
         "Nemo/series.md",
@@ -47,7 +44,7 @@
 
   "Fields" => [
      "Fields/intro.md",
-     "AbstractAlgebra/fields.md",
+     "AbstractAlgebra/field.md",
      "Rings/rational.md",
      "Number Fields" => [
         "Hecke/number_fields/intro.md",
@@ -56,7 +53,6 @@
      ],
      "Hecke/FacElem.md",
      "Hecke/class_fields/intro.md",
-     "AbstractAlgebra/fraction_fields.md",
      "AbstractAlgebra/fraction.md",
      "Local Fields" => [
         "Nemo/padic.md",
@@ -68,7 +64,6 @@
   "Linear Algebra" => [
      "LinearAlgebra/intro.md",
      "Hecke/sparse/intro.md",
-     "AbstractAlgebra/matrix_spaces.md",
      "AbstractAlgebra/matrix.md",
      "AbstractAlgebra/matrix_algebras.md",
      "Modules" => [


### PR DESCRIPTION
This is the Oscar counterpart to https://github.com/Nemocas/AbstractAlgebra.jl/pull/930 which needs to be merged before this PR.

It's slightly strange that matrix algebras are described in linear algebra instead of rings.

I also didn't try to slurp in any of the new AbstractAlgebra introduction sections. That's up to maintainers of Oscar.jl.