### PR TITLE
Fix typo in __init_JuliaData, simplify code

### DIFF
--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -279,9 +279,9 @@ end
 # The following must be executed at runtime.
 # (Eventually put it into some `__init__`.)
 function __init_JuliaData()
-    if ! GAP.Globals.ISB_GVAR(GAP.julia_to_gap("JuliaData"))
+    if ! hasproperty(GAP.Globals, :JuliaData)
       GAP.evalstr("""
-DeclareAttribute( "JuliaData", IsObject );");
+DeclareAttribute( "JuliaData", IsObject );
 InstallOtherMethod( ImagesRepresentative,
 [ IsActionHomomorphism and HasJuliaData, IsMultiplicativeElementWithInverse ],
 function( hom, elm )


### PR DESCRIPTION
In GAP.jl 0.6, evalstr is more strict and reported the syntax error
