### PR TITLE
changed the `rand` methods for groups and cosets ...

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -4,6 +4,8 @@ import Base: ^, Base.Vector
 import GAP.@gapattribute
 import GAP.@gapwrap
 
+using Random
+
 export GroupConjClass
 
 export
@@ -130,14 +132,16 @@ Return the exponent of `G`, i.e. the smallest positive integer `e` such that `g`
 """ exponent
 
 """
-    rand(G::Group)
+    rand(rng::Random.AbstractRNG = Random.GLOBAL_RNG, G::Group)
 
-Return a random element of the group `G`.
+Return a random element of `G`, using the random number generator `rng`.
 """
-function Base.rand(x::GAPGroup)
-   s = GAP.Globals.Random(x.X)
-   return group_element(x, s)
+function Base.rand(rng::Random.AbstractRNG, G::GAPGroup)
+   s = GAP.Globals.Random(GAP.wrap_rng(rng), G.X)
+   return group_element(G, s)
 end
+
+Base.rand(G::GAPGroup) = Base.rand(Random.GLOBAL_RNG, G)
 
 """
     rand_pseudo(G::Group)

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -1,3 +1,5 @@
+using Random
+
 export
     acting_domain,
     double_coset,
@@ -300,11 +302,17 @@ order(C::Union{GroupCoset,GroupDoubleCoset}) = GAP.Globals.Size(C.X)
 Base.length(C::Union{GroupCoset,GroupDoubleCoset}) = GAP.Globals.Size(C.X)
 
 """
-    rand(C::Union{GroupCoset,GroupDoubleCoset})
+    rand(rng::Random.AbstractRNG = Random.GLOBAL_RNG, C::Union{GroupCoset,GroupDoubleCoset})
 
-Return a random element of the (double) coset `C`.
+Return a random element of the (double) coset `C`,
+using the random number generator `rng`.
 """
-Base.rand(C::Union{GroupCoset,GroupDoubleCoset}) = group_element(C.G, GAP.Globals.Random(C.X))
+function Base.rand(rng::Random.AbstractRNG, C::Union{GroupCoset,GroupDoubleCoset})
+  s = GAP.Globals.Random(GAP.wrap_rng(rng), C.X)
+  return group_element(C.G, s)
+end
+
+Base.rand(C::Union{GroupCoset,GroupDoubleCoset}) = Base.rand(Random.GLOBAL_RNG, C)
 
 """
     representative(C::GroupDoubleCoset)

--- a/test/Groups/forms.jl
+++ b/test/Groups/forms.jl
@@ -25,7 +25,7 @@
    @test gram_matrix(f)==B
    @test ishermitian_form(f)
    @test f.mat_iso isa MapFromFunc
-   @test f.X isa GapObj
+   @test f.X isa GAP.GapObj
    @test_throws AssertionError f = symmetric_form(B)
    @test_throws AssertionError f = alternating_form(B)
    @test_throws ArgumentError corresponding_quadratic_form(f)

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -22,11 +22,11 @@
    F = GF(29,1)[1]
    z = F(2)
    G = GL(3,F)
-   @test G.X isa GapObj
+   @test G.X isa GAP.GapObj
    @test isdefined(G,:X)
    @test isdefined(G, :ring_iso)
    @test isdefined(G, :mat_iso)
-   @test G.ring_iso(z) isa FFE
+   @test G.ring_iso(z) isa GAP.FFE
    Z = G.ring_iso(z)
    @test GAP.Globals.IN(Z,codomain(G.ring_iso))
    @test preimage(G.ring_iso, Z)==z
@@ -39,14 +39,14 @@
    @test isone(preimage(G.ring_iso, GAP.Globals.One(codomain(G.ring_iso))))
    
    xo = matrix(F,3,3,[1,z,0,0,1,2*z+1,0,0,z+2])
-#   xg = Vector{GapObj}(undef, 3)
+#   xg = Vector{GAP.GapObj}(undef, 3)
 #   for i in 1:3
-#      xg[i] = GapObj([preimage(G.ring_iso, xo[i,j]) for j in 1:3])
+#      xg[i] = GAP.GapObj([preimage(G.ring_iso, xo[i,j]) for j in 1:3])
 #   end
 #   xg=GAP.julia_to_gap(xg)
 
-   xg = GapObj([[G.ring_iso(xo[i,j]) for j in 1:3] for i in 1:3]; recursive=true)
-   @test G.mat_iso(xo) isa GapObj
+   xg = GAP.GapObj([[G.ring_iso(xo[i,j]) for j in 1:3] for i in 1:3]; recursive=true)
+   @test G.mat_iso(xo) isa GAP.GapObj
    @test G.mat_iso(xo)==xg
    @test preimage(G.mat_iso, xg)==xo
    @test preimage(G.mat_iso, GAP.Globals.One(GAP.Globals.GL(3,codomain(G.ring_iso))))==one(G).elm
@@ -55,11 +55,11 @@
    T,t = PolynomialRing(GF(3),"t")
    F,z = FiniteField(t^2+1,"z")
    G = GL(3,F)
-   @test G.X isa GapObj
+   @test G.X isa GAP.GapObj
    @test isdefined(G,:X)
    @test isdefined(G, :ring_iso)
    @test isdefined(G, :mat_iso)
-   @test G.ring_iso(z) isa FFE
+   @test G.ring_iso(z) isa GAP.FFE
    Z = G.ring_iso(z)
    @testset for a in F
       for b in F
@@ -79,7 +79,7 @@
    @test isone(preimage(G.ring_iso, GAP.Globals.One(codomain(G.ring_iso))))
    
    xo = matrix(F,3,3,[1,z,0,0,1,2*z+1,0,0,z+2])
-   xg = Vector{GapObj}(undef, 3)
+   xg = Vector{GAP.GapObj}(undef, 3)
    for i in 1:3
       xg[i] = GAP.julia_to_gap([G.ring_iso(xo[i,j]) for j in 1:3])
    end
@@ -142,7 +142,7 @@ end
    x = matrix(F,2,2,[1,0,0,1])
    x = G(x)
    @test !isdefined(x,:X)
-   @test x.X isa GapObj
+   @test x.X isa GAP.GapObj
    x = G[1].elm
    x = G(x)
    @test !isdefined(x,:X)
@@ -164,7 +164,7 @@ end
    @test parent(f(H[1]))==G
 
    K1 = matrix_group(x,y,x*y)
-   @test K1.X isa GapObj
+   @test K1.X isa GAP.GapObj
    @test K1.X==H.X
 
    K = matrix_group(x,x^2,y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using Oscar
 using Test
-using GAP
 
 include("Polytopes/runtests.jl")
 


### PR DESCRIPTION
... such that a (Julia) random number generator can be given as the first argument.
(This feature relies on the recent release of GAP.jl 0.6.)

The default rng is `Random.GLOBAL_RNG`.
Note that this is not GAP's default rng, thus the same group related computations in Oscar and GAP will yield different results if random elements are involved.

I have also changed `GapObj` and `FFE` to `GAP.GapObj` and `GAP.FFE` in a few tests; up to now, I got test failures when I ran the Groups tests without calling `using GAP` in advance.