### PR TITLE
some more docu for invariant theory

### DIFF
--- a/docs/src/InvariantTheory/it.md
+++ b/docs/src/InvariantTheory/it.md
@@ -19,15 +19,15 @@ $x = \{x_1, \dots, x_n\}\subset V^*$ denotes a fixed set of cooordinates.
 
 The action of $G$ on $V$ defines an action of  $G$ on $V^\ast$,
 
-$(\pi f)(v)=f(\rho(\pi^{-1}) v).$
+$(\pi \;\!  . f)(v)=f(\rho(\pi^{-1}) \;\!  . v),$
 
-This extends naturally to an action of $G$ on the graded symmetric algebra
+which extends to an action of $G$ on the graded symmetric algebra
 
 $K[x] = K[x_1, \dots, x_n] \cong K[V]:=S(V^*)=\bigoplus_{d\geq 0} S^d V^*.$
 
 The *invariants* of $G$ are the fixed points of this action, its *ring of invariants* is the graded subalgebra
 
-$K[x]^G = K[x_1, \dots, x_n]^G\cong  K[V]^G=\{f\in K[V] \mid \pi f=f {\text { for any }} \pi\in G\}\subset K[V].$
+$K[x]^G = K[x_1, \dots, x_n]^G\cong  K[V]^G=\{f\in K[V] \mid \pi  \;\!  . f=f {\text { for any }} \pi\in G\}\subset K[V].$
 
 Clearly, $K[V]^G$ depends only on the image $\rho(G)\subset \text{GL}(V)$.
 

--- a/docs/src/InvariantTheory/it.md
+++ b/docs/src/InvariantTheory/it.md
@@ -12,38 +12,35 @@ Pages = ["it.md"]
 
 # Introduction
 
-Our basic setting in invariant theory consists of a group $G$, a field $K$, 
-a vector space $V$ over $K$ of finite dimension $n,$  and a representation $\rho: G \to \text{GL}(V)$
-of $G$ on $V$. We write $V^\ast$ for the dual vector space of $V$ and suppose that a fixed set of
-cooordinates $x = \{x_1, \dots, x_n\}\in V^*$ is chosen.
+The basic setting in this chapter consists of a group $G$, a field $K$, a vector space
+$V$ over $K$ of finite dimension $n,$  and a representation $\rho: G \to \text{GL}(V)$
+of $G$ on $V$. Furthermore, $V^\ast$ denotes the dual vector space of $V$ and 
+$x = \{x_1, \dots, x_n\}\subset V^*$ denotes a fixed set of cooordinates.
 
-
-The action of $G$ on $V$ induces an action of  $G$ on $V^\ast$: Set
+The action of $G$ on $V$ defines an action of  $G$ on $V^\ast$,
 
 $(\pi f)(v)=f(\rho(\pi^{-1}) v).$
 
-This, in turn, defines an action of $G$ on the graded symmetric algebra
+This extends naturally to an action of $G$ on the graded symmetric algebra
 
-$K[x] = K[x_1, \dots, x_n] \cong  K[V]=S(V^*)=\bigoplus_{d\geq 0} S^d V^*.$
+$K[x] = K[x_1, \dots, x_n] \cong K[V]:=S(V^*)=\bigoplus_{d\geq 0} S^d V^*.$
 
 The *invariants* of $G$ are the fixed points of this action, its *ring of invariants* is the graded subalgebra
 
-$K[x]^G\cong K[V]^G=\{f\in K[V] \mid \pi f=f {\text { for any }} \pi\in G\}\subset K[V].$
+$K[x]^G = K[x_1, \dots, x_n]^G\cong  K[V]^G=\{f\in K[V] \mid \pi f=f {\text { for any }} \pi\in G\}\subset K[V].$
 
-Clearly, this ring depends only on the image $\rho(G)\subset \text{GL}(V)$.
+Clearly, $K[V]^G$ depends only on the image $\rho(G)\subset \text{GL}(V)$.
 
 !!! note
-    If not mentioned otherwise, we will be in the favourable situation where $G$ is a linear reductive group which acts rationally on $V$. This has several important consequences:
+    If $K[V]^G$ is finitely generated as a $K$-algebra, then any minimal system of homogeneous generators is called a *fundamental system of invariants* of $K[V]^G$. By Nakayama's lemma, the number of elements in such a system is uniquely determined as the embedding dimension of $K[V]^G$. Similarly, the degrees of these elements are uniquely determined.
+
+!!! note
+     If $K[V]^G$ is finitely generated as a $K$-algebra, then $K[V]^G$ admits a graded Noether normalization, that is, a Noether normalization $K[p_1, \dots, p_m] \subset K[V]^G$ with $p_1, \dots, p_m$ homogeneous. Given any such Noether normalization, $p_1, \dots, p_m$ is called a system of *primary invariants* of $K[V]^G$, and  any minimal system $s_0=1, s_1,\dots, s_l$ of homogeneous generators of $K[V]^G$ as a $K[p_1, \dots, p_m]$-module is called a system of *secondary invariants* of $K[V]^G$ with respect to $p_1, \dots, p_m$.
+
+!!! note
+    In all situations considered in this chapter, theoretical results will guarantee that $K[V]^G$ is finitely generated as a $K$-algebra. In addition, if not mentioned otherwise, the following will hold:
     - There exists a Reynolds operator $\mathcal R: K[V] \to K[V]$. That is, $\mathcal R$ is a $K$-linear graded map which projects $K[V]$ onto $K[V]^G$, and which is a $K[V]^G$-module homomorphism.
-    - By Hilbert's finiteness theorem, $K[V]^G$ is finitely generated as a $K$-algebra.
-    - By a result of Hochster and Roberts, $K[V]^G$ is Cohen-Macaulay. Equivalently, $K[V]^G$ is a free module (of finite rank) over any of its Noether normalizations.
-
-!!! note
-    If $k[V]^G$ is finitely generated as a $K$-algebra, then any minimal system of homogeneous generators is called a *fundamental system of invariants* of $k[V]^G$. By Nakayama's lemma, the number of elements in such a system is uniquely determined as the embedding dimension of $K[V]^G$. Similarly, the degrees of these elements are uniquely determined.
-
-!!! note
-    If $K[V]^G$ is finitely generated as a $K$-algebra, and $K[p_1, \dots, p_m] \subset K[V]^G$ is any Noether normalization, then $p_1, \dots, p_m$ is called a system of *primary invariants*. Given such a system $p_1, \dots, p_m$, we call any minimal system $s_0=1, s_1,\dots, s_l$ of homogeneous generators of $K[V]^G$ as a $K[p_1, \dots, p_m]$-module a system of *secondary invariants*.
-
+    - The ring $K[V]^G$ is Cohen-Macaulay. Equivalently, $K[V]^G$ is a free module (of finite rank) over any of its graded Noether normalizations.
 
 The textbook
 

--- a/docs/src/InvariantTheory/it.md
+++ b/docs/src/InvariantTheory/it.md
@@ -17,13 +17,14 @@ $V$ over $K$ of finite dimension $n,$  and a representation $\rho: G \to \text{G
 of $G$ on $V$. Furthermore, $V^\ast$ denotes the dual vector space of $V$ and 
 $x = \{x_1, \dots, x_n\}\subset V^*$ denotes a fixed set of cooordinates.
 
-The action of $G$ on $V$ defines an action of  $G$ on $V^\ast$,
+The action of $G$ on $V$ defines an action of  $G$ on the graded symmetric algebra
 
-$(\pi \;\!  . f)(v)=f(\rho(\pi^{-1}) \;\!  . v),$
+$K[x] = K[x_1, \dots, x_n] \cong K[V]:=S(V^*)=\bigoplus_{d\geq 0} S^d V^*$
 
-which extends to an action of $G$ on the graded symmetric algebra
+by linear substitution: Identify $\text{GL}_n(K)\cong \text{GL}(V)$ and set
 
-$K[x] = K[x_1, \dots, x_n] \cong K[V]:=S(V^*)=\bigoplus_{d\geq 0} S^d V^*.$
+$(\pi \;\!  .f) \;\! (x_1, \dots, x_n)  = f(\rho(\pi^{-1}) \cdot (x_1, \dots, x_n)^T) \text{ for all } \pi\in G.$
+
 
 The *invariants* of $G$ are the fixed points of this action, its *ring of invariants* is the graded subalgebra
 

--- a/docs/src/InvariantTheory/it_fg.md
+++ b/docs/src/InvariantTheory/it_fg.md
@@ -12,24 +12,58 @@ Pages = ["it_fg.md"]
 
 # Invariants of Finite Groups
 
-Using the notation from the introductory section, we now suppose that $\rho: G\to V$ is the representation
-of a *finite* group $G$ on $V$. Recall that we identify $K[V]\cong K[x] $ via a fixed set of cooordinates $x_1, \dots, x_n\in V^*$.
+Using the notation from the introductory section to this chapter, we now suppose that $G$ is a *finite* group.
 
 !!! note
-    - By Emmy Noether's finiteneness theorem, $K[V]^G$ is a finitely generated $K$-algebra of dimension $\dim K[V]^G = \dim K[V] = n$.
-    - If the group order $|G|$ is invertible in $K$, then $K[V]^G$ is Cohen-Macaulay. In fact, in this case, $G$ is a linearly reductive group with explicitly given Reynolds operator
+     - By a result of Emmy Noether, $K[V]$ is integral over $K[V]^G$. In particular,
 
-       $\mathcal R: K[V] \to K[V], f(x)\to \sum_{\pi\in G}(\pi f(x))$.
+          $\dim K[V]^G = \dim K[V] = n.$
+         
+         Moreover, $K[V]^G$ is finitely generated as a $K$-algebra.
+		   
+    - If the group order $|G|$ is invertible in $K$, then we have the explicit Reynolds operator
+
+         $\mathcal R: K[V] \to K[V], f\to \frac{1}{|G|}\sum_{\pi\in G}(\pi f).$
+
+    - Using  Emmy Noether's result and the Reynolds operator, it is not too difficult to show that $K[V]^G$ is a free module (of finite rank) over any of its graded Noether normalizations. That is, $K[V]^G$ is Cohen-Macaulay.
+
 
 !!! note
     We speak of *non-modular* invariant theory if $|G|$ is invertible in $K$, and of *modular* invariant theory otherwise.
 
 !!! note
-    In the non-modular case, the Hilbert series of $K[V]^G$ is explicitly given as the Molien series of $G$, see [DK15](@cite) or [DJ98](@cite).
+    In the non-modular case, the Hilbert series of $K[V]^G$ can be precomputed via Molien's theorem. See [DK15](@cite) or [DJ98](@cite) for explicit formulas.
 
-The algorithms for computing generators of invariant rings of finite groups proceed in two steps. First, compute a system of primary invariants. Then, compute a corresponding system of secondary invariants.
+The algorithms for computing generators of invariant rings of finite groups proceed in two steps.
+- First, compute a system of primary invariants.
+- Then, compute a corresponding system of secondary invariants.
+
+## Creating Invariant Rings
+
+```@docs
+invariant_ring(G::MatrixGroup)
+```
+
+## Basic Data Associated to Invariant Rings
+
+## The Reynolds Operator
+
+## Invariants of a Given Degree
+
+## The Molien Series
+
 ## Primary Invariants
+
+```@docs
+primary_invariants(IR::InvRing)
+```
 
 ## Secondary Invariants
 
-## Invariant Rings and Fundamental Invariants
+```@docs
+secondary_invariants(IR::InvRing)
+```
+
+## Fundamental Systems of Invariants
+
+## Invariant Rings as Affine Algebras

--- a/docs/src/InvariantTheory/it_fg.md
+++ b/docs/src/InvariantTheory/it_fg.md
@@ -12,7 +12,7 @@ Pages = ["it_fg.md"]
 
 # Invariants of Finite Groups
 
-Using the notation from the introductory section to this chapter, we now suppose that $G$ is a *finite* group.
+In this section, with notation as in the introduction to this chapter, $G$ will always be a *finite* group.
 
 !!! note
      - By a result of Emmy Noether, $K[V]$ is integral over $K[V]^G$. In particular,
@@ -43,7 +43,7 @@ In the non-modular case, the Molien series allows one to precompute the number o
 
 ## Creating Invariant Rings
 
-The invariant theory module of OSCAR  distinguishes two ways of how  finite groups and their actions on $K[x_1, \dots, x_n]\cong K[V]$ are given.
+The invariant theory module of OSCAR  distinguishes two ways of how  finite groups and their actions on $K[x_1, \dots, x_n]\cong K[V]$ are specified.
 
 ### Matrix Groups
 

--- a/docs/src/InvariantTheory/it_fg.md
+++ b/docs/src/InvariantTheory/it_fg.md
@@ -25,11 +25,11 @@ Using the notation from the introductory section to this chapter, we now suppose
 
          $\mathcal R: K[V] \to K[V], f\to \frac{1}{|G|}\sum_{\pi\in G}(\pi f).$
 
-    - Using  Emmy Noether's result and the Reynolds operator, it is not too difficult to show that $K[V]^G$ is a free module (of finite rank) over any of its graded Noether normalizations. That is, $K[V]^G$ is Cohen-Macaulay.
-
-
 !!! note
     We speak of *non-modular* invariant theory if $|G|$ is invertible in $K$, and of *modular* invariant theory otherwise.
+
+!!! note
+    In the non-modular case, using  Emmy Noether's result and the Reynolds operator, it is not too difficult to show that $K[V]^G$ is a free module over any of its graded Noether normalizations. That is, $K[V]^G$ is Cohen-Macaulay.
 
 !!! note
     In the non-modular case, the Hilbert series of $K[V]^G$ can be precomputed via Molien's theorem. See [DK15](@cite) or [DJ98](@cite) for explicit formulas.

--- a/docs/src/InvariantTheory/it_fg.md
+++ b/docs/src/InvariantTheory/it_fg.md
@@ -23,7 +23,7 @@ Using the notation from the introductory section to this chapter, we now suppose
 		   
     - If the group order $|G|$ is invertible in $K$, then we have the explicit Reynolds operator
 
-         $\mathcal R: K[V] \to K[V], f\to \frac{1}{|G|}\sum_{\pi\in G}(\pi f).$
+       $\mathcal R: K[V] \to K[V], f\to \frac{1}{|G|}\sum_{\pi\in G}(\pi \;\!  . f).$
 
 !!! note
     We speak of *non-modular* invariant theory if $|G|$ is invertible in $K$, and of *modular* invariant theory otherwise.
@@ -34,15 +34,30 @@ Using the notation from the introductory section to this chapter, we now suppose
 !!! note
     In the non-modular case, the Hilbert series of $K[V]^G$ can be precomputed via Molien's theorem. See [DK15](@cite) or [DJ98](@cite) for explicit formulas.
 
-The algorithms for computing generators of invariant rings of finite groups proceed in two steps.
-- First, compute a system of primary invariants.
-- Then, compute a corresponding system of secondary invariants.
+Having means to compute a $K$-basis for the invariants of each given degree, the algorithms for computing generators of invariant rings of finite groups proceed in two steps:
+
+- First, compute a system of primary invariants $p_1,\dots, p_n$.
+- Then, compute a system of secondary invariants with respect to $p_1,\dots, p_n$.
+
+In the non-modular case, the Molien series allows one to precompute the number of $K$-linearly independent invariants for each given degree,
 
 ## Creating Invariant Rings
+
+The invariant theory module of OSCAR  distinguishes two ways of how  finite groups and their actions on $K[x_1, \dots, x_n]\cong K[V]$ are given.
+
+### Matrix Groups
+
+Here, $G$ will be explicitly given as a matrix group $G\subset \text{GL}_n(K)\cong \text{GL}(V) $ by (finitely many) generating matrices, acting on $K[x_1, \dots, x_n]\cong K[V]$ by linear substitution:
+
+$(\pi \;\!  .f) \;\! (x_1, \dots, x_n)  = f(\pi^{-1} \cdot (x_1, \dots, x_n)^T) \text{ for all } \pi\in G.$
+
 
 ```@docs
 invariant_ring(G::MatrixGroup)
 ```
+
+### Permutation Groups
+
 
 ## Basic Data Associated to Invariant Rings
 

--- a/docs/src/InvariantTheory/it_lrg.md
+++ b/docs/src/InvariantTheory/it_lrg.md
@@ -12,14 +12,43 @@ Pages = ["it_lrg.md"]
 
 # Invariants of Linearly Reductive Groups
 
-Using the notation from the introductory section to this chapter, we now suppose that $\rho: G\to V$ is a *rational* representation
-of a *linearly reductive* group $G$ on $V$. 
+In this section, with notation as in the introduction to this chapter, $G$ will always be a *linearly algebraic group* over an algebraically closed field $K$, and ``\rho: G \to \text{GL}(V)`` will be a *rational* representation of $G$. As in the previous sections, ``G`` will act on $K[x_1, \dots, x_n]\cong K[V]$ by linear substitution:
+
+$(\pi \;\!  .f) \;\! (x_1, \dots, x_n)  = f(\rho(\pi^{-1}) \cdot (x_1, \dots, x_n)^T) \text{ for all } \pi\in G.$
 
 !!! note
     
-    - By the very definition of linear reductivity, there exists a Reynolds operator $\mathcal R: K[V] \to K[V]$. 
+    - By the very definition of linear reductivity, there is a Reynolds operator $\mathcal R: K[V] \to K[V]$. 
     - By Hilbert's celebrated finiteness theorem, $K[V]^G$ is finitely generated as a $K$-algebra.
-    - As shown by Hochster and Roberts, $K[V]^G$ is Cohen-Macaulay. 
+    - By a result of Hochster and Roberts, $K[V]^G$ is Cohen-Macaulay. 
+
+## Creating Invariant Rings
+
+The invariant theory module of OSCAR handles linearly algebraic groups which are defined over an exact subfield $k$ of $K$ which is supported by OSCAR. That is:
+
+- ``G`` is  specified as an algebraic subgroup of $\text{GL}_t(K)$ by polynomial equations over $k$,  for some $t$.
+- ``\rho: G \to \text{GL}_n(K)\cong \text{GL}(V)`` is a *rational* representation of $G$ given by polynomials over $k$.
+
+!!! note
+    There are no exact means to handle algebraically closed fields on the computer. In the above setting, we do not deal with explicit elements of ``G``.
 
 
-Omega-process, Derksen's algorithm
+## Basic Data Associated to Invariant Rings
+
+## The Reynolds Operator
+
+Omega-process
+
+## Generators of the Null-Cone
+
+## Generators of the Invariant Ring
+
+## Fundamental Systems of Invariants
+
+## Invariant Rings as Affine Algebras
+
+
+
+
+
+

--- a/docs/src/InvariantTheory/it_lrg.md
+++ b/docs/src/InvariantTheory/it_lrg.md
@@ -12,4 +12,14 @@ Pages = ["it_lrg.md"]
 
 # Invariants of Linearly Reductive Groups
 
+Using the notation from the introductory section to this chapter, we now suppose that $\rho: G\to V$ is a *rational* representation
+of a *linearly reductive* group $G$ on $V$. 
+
+!!! note
+    
+    - By the very definition of linear reductivity, there exists a Reynolds operator $\mathcal R: K[V] \to K[V]$. 
+    - By Hilbert's celebrated finiteness theorem, $K[V]^G$ is finitely generated as a $K$-algebra.
+    - As shown by Hochster and Roberts, $K[V]^G$ is Cohen-Macaulay. 
+
+
 Omega-process, Derksen's algorithm

--- a/src/InvariantTheory/invariant_rings.jl
+++ b/src/InvariantTheory/invariant_rings.jl
@@ -80,7 +80,7 @@ end
 @doc Markdown.doc"""
     invariant_ring(G::MatrixGroup)
 
-Return the invariant ring $K[V]^G$ of the finite matrix group `G`.
+Return the invariant ring of the finite matrix group `G`.
     
 CAVEAT: The creation of invariant rings is lazy in the sense that no explicit computations are done until specifically invoked (for example by the `primary_invariants` function).
 


### PR DESCRIPTION
This is very much WIP, but can be merged so that @joschmitt can add more of the Singular functionality: Please implement the following functions:

reynolds_operator(f::MPolyElem)
molien_series(IR::InvRing)  as rational function 
hilbert_series(IR::InvRing)  = molien_series(IR)
invariant_basis(d::Int)

Do we have an expand function for rational functions?