### PR TITLE
docs: rework docs-project, allow doctest option

### DIFF
--- a/.github/workflows/Docu.yml
+++ b/.github/workflows/Docu.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           version: '1.6'
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: julia --project=. -e 'using Oscar; Oscar.doc_init(; path="docs/")'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/.github/workflows/Docu.yml
+++ b/.github/workflows/Docu.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.6'
+      - name: Build package
+        uses: julia-actions/julia-buildpkg@latest
       - name: Install dependencies
         run: julia --project=. -e 'using Oscar; Oscar.doc_init(; path="docs/")'
       - name: Build and deploy

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,13 +1,7 @@
 [deps]
-AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 DocumenterMarkdown = "997ab1e6-3595-5248-9280-8efb232c3433"
-Hecke = "3e1990a7-5d81-5526-99ce-9ba3ff248f21"
-Kroki = "b3565e16-c1f2-4fe9-b4ab-221c88942068"
-Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
-Oscar = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
 
 [compat]
-AbstractAlgebra = "= 0.21.0"
 DocumenterCitations = "0.2.5"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, Oscar
 
 include(normpath(joinpath(Oscar.oscardir, "docs", "make_work.jl")))
 
-BuildDoc.doit(Oscar, true, false)
+BuildDoc.doit(Oscar; strict=true, local_build=false, doctest=true)
 
 deploydocs(
    repo   = "github.com/oscar-system/Oscar.jl.git",

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -24,7 +24,7 @@ using Documenter, DocumenterMarkdown, DocumenterCitations
 # Remove the module prefix
 Base.print(io::IO, b::Base.Docs.Binding) = print(io, b.var)
 
-function doit(Oscar::Module, strict::Bool = true, local_build::Bool = false)
+function doit(Oscar::Module; strict::Bool = true, local_build::Bool = false, doctest::Bool = true)
 
   # include the list of pages, performing substitutions
   s = read(joinpath(Oscar.oscardir, "docs", "doc.main"), String)
@@ -72,7 +72,7 @@ function doit(Oscar::Module, strict::Bool = true, local_build::Bool = false)
            sitename = "Oscar.jl",
            modules = [Oscar, Oscar.Hecke, Oscar.Nemo, Oscar.AbstractAlgebra, Oscar.Singular],
            clean = true,
-           doctest = true,
+           doctest = doctest,
            strict = strict,
            checkdocs = :none,
            pages    = doc)

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -159,7 +159,7 @@ function open_doc()
     end
 end
 
-function build_doc(; doctest=true)
+function build_doc(; doctest=false)
   if !isdefined(Main, :BuildDoc)
     doc_init()
   end

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -159,12 +159,12 @@ function open_doc()
     end
 end
 
-function build_doc()
+function build_doc(; doctest=true)
   if !isdefined(Main, :BuildDoc)
     doc_init()
   end
   Pkg.activate(docsproject) do
-    Base.invokelatest(Main.BuildDoc.doit, Oscar, false, true)
+    Base.invokelatest(Main.BuildDoc.doit, Oscar; strict=false, local_build=true, doctest=doctest)
   end
   open_doc()
 end

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -159,12 +159,12 @@ function open_doc()
     end
 end
 
-function build_doc(; doctest=false)
+function build_doc(; doctest=false, strict=false)
   if !isdefined(Main, :BuildDoc)
     doc_init()
   end
   Pkg.activate(docsproject) do
-    Base.invokelatest(Main.BuildDoc.doit, Oscar; strict=false, local_build=true, doctest=doctest)
+    Base.invokelatest(Main.BuildDoc.doit, Oscar; strict=strict, local_build=true, doctest=doctest)
   end
   open_doc()
 end


### PR DESCRIPTION
To make the `build_doc()` process a little more robust I have removed everything except for `Documenter*` from `docs/Project.toml`. (Also Kroki, i.e. this obsoletes #603)
These entries caused various issues because without a corresponding Manifest.toml telling julia to use the Oscar-dev-dir the Pkg resolver failed in some cases. But keeping a manifest in that place can cause other issues, because people tend to forget to explicitly update that project.

The docs building process works like this in the background:
- When `build_doc` is called a new environment with a copy of this `docs/Project.toml` is created in `/tmp/jl_something`
- All packages required for the doctests are added via `Pkg.develop` with the currently active path in `doc_init` (called automatically from `build_doc`)
  This also makes sure that the doctests and the docbuild are run with the correct versions of Oscar, Hecke, Nemo, AbstractAlgebra (e.g. if one uses a dev'd version of one of these).
- this temporary project is then instantiated and used for running the build+test

All the resulting docs and temporary files are still in the `docs` subdirectory. (Only Project.toml and Manifest.toml are in that temporary directory)

I have also added `doctest` and `strict` flags to `build_doc()` which default to `false`. (fixes #604)
Except for these flags there are no user-facing changes here.

For the CI I have added a keyword argument to `doc_init` to use a custom path for the docs-project now used in `.github/workflows/Docu.yml` to make sure that directory is still alive for the next github actions steps.