### PR TITLE
Combine incidencematrix

### DIFF
--- a/src/Polytopes/PolyhedralFan/constructors.jl
+++ b/src/Polytopes/PolyhedralFan/constructors.jl
@@ -63,14 +63,14 @@ A polyhedral fan in ambient dimension 2
 ```
 """
 function PolyhedralFan(Rays::Union{Oscar.MatElem,AbstractMatrix}, Incidence::IncidenceMatrix)
-   arr = @Polymake.convert_to Array{Set{Int}} Polymake.common.rows(Incidence.pm_incidencematrix)
+   arr = @Polymake.convert_to Array{Set{Int}} Polymake.common.rows(Incidence)
    PolyhedralFan(Polymake.fan.PolyhedralFan{Polymake.Rational}(
       INPUT_RAYS = matrix_for_polymake(Rays),
       INPUT_CONES = arr,
    ))
 end
 function PolyhedralFan(Rays::Union{Oscar.MatElem,AbstractMatrix}, LS::Union{Oscar.MatElem,AbstractMatrix}, Incidence::IncidenceMatrix)
-   arr = @Polymake.convert_to Array{Set{Int}} Polymake.common.rows(Incidence.pm_incidencematrix)
+   arr = @Polymake.convert_to Array{Set{Int}} Polymake.common.rows(Incidence)
    PolyhedralFan(Polymake.fan.PolyhedralFan{Polymake.Rational}(
       INPUT_RAYS = matrix_for_polymake(Rays),
       INPUT_LINEALITY = matrix_for_polymake(LS),

--- a/src/Polytopes/PolyhedralFan/properties.jl
+++ b/src/Polytopes/PolyhedralFan/properties.jl
@@ -211,10 +211,10 @@ julia> rays(PF)
 
 julia> maximal_cones_as_incidence_matrix(PF)
 4×4 IncidenceMatrix
-(1) - 1, 3
-(2) - 2, 3
-(3) - 1, 4
-(4) - 2, 4
+[1, 3]
+[2, 3]
+[1, 4]
+[2, 4]
 ```
 """
 function maximal_cones_as_incidence_matrix(PF::PolyhedralFan)

--- a/src/Polytopes/PolyhedralFan/properties.jl
+++ b/src/Polytopes/PolyhedralFan/properties.jl
@@ -210,11 +210,11 @@ julia> rays(PF)
  [0, -1]
 
 julia> maximal_cones_as_incidence_matrix(PF)
-4×4 Matrix{Bool}:
- 1  0  1  0
- 0  1  1  0
- 1  0  0  1
- 0  1  0  1
+4×4 IncidenceMatrix
+(1) - 1, 3
+(2) - 2, 3
+(3) - 1, 4
+(4) - 2, 4
 ```
 """
 function maximal_cones_as_incidence_matrix(PF::PolyhedralFan)

--- a/src/Polytopes/SubdivisionOfPoints/constructors.jl
+++ b/src/Polytopes/SubdivisionOfPoints/constructors.jl
@@ -35,7 +35,7 @@ A subdivision of points in ambient dimension 3
 ```
 """
 function SubdivisionOfPoints(Points::Union{Oscar.MatElem,AbstractMatrix}, Incidence::IncidenceMatrix)
-   arr = @Polymake.convert_to Array{Set{Int}} Polymake.common.rows(Incidence.pm_incidencematrix)
+   arr = @Polymake.convert_to Array{Set{Int}} Polymake.common.rows(Incidence)
    SubdivisionOfPoints(Polymake.fan.SubdivisionOfPoints{Polymake.Rational}(
       POINTS = matrix_for_polymake(homogenize(Points,1)),
       MAXIMAL_CELLS = arr,

--- a/src/Polytopes/SubdivisionOfPoints/properties.jl
+++ b/src/Polytopes/SubdivisionOfPoints/properties.jl
@@ -179,7 +179,7 @@ A subdivision of points in ambient dimension 3
 
 julia> maximal_cells_as_incidence_matrix(SOP)
 1×6 IncidenceMatrix
-(1) - 1, 2, 3, 4, 5, 6
+[1, 2, 3, 4, 5, 6]
 ```
 """
 function maximal_cells_as_incidence_matrix(SOP::SubdivisionOfPoints)

--- a/src/Polytopes/SubdivisionOfPoints/properties.jl
+++ b/src/Polytopes/SubdivisionOfPoints/properties.jl
@@ -178,8 +178,8 @@ julia> SOP = SubdivisionOfPoints(moaepts, [1,1,1,1,1,1])
 A subdivision of points in ambient dimension 3
 
 julia> maximal_cells_as_incidence_matrix(SOP)
-1×6 Matrix{Bool}:
- 1  1  1  1  1  1
+1×6 IncidenceMatrix
+(1) - 1, 2, 3, 4, 5, 6
 ```
 """
 function maximal_cells_as_incidence_matrix(SOP::SubdivisionOfPoints)
@@ -215,4 +215,3 @@ true
 ```
 """
 isregular(SOP::SubdivisionOfPoints) = pm_subdivision(SOP).REGULAR
-

--- a/src/Polytopes/helpers.jl
+++ b/src/Polytopes/helpers.jl
@@ -1,3 +1,8 @@
+import Polymake: IncidenceMatrix
+
+import Base: convert
+
+
 matrix_for_polymake(x::Union{Oscar.fmpz_mat,AbstractMatrix{Oscar.fmpz}}) = Matrix{BigInt}(x)
 matrix_for_polymake(x::Union{Oscar.fmpq_mat,AbstractMatrix{Oscar.fmpq}}) =
     Polymake.Matrix{Polymake.Rational}(x)
@@ -10,8 +15,6 @@ function Polymake.Matrix{Polymake.Rational}(x::Union{Oscar.fmpq_mat,AbstractMatr
     end
     return res
 end
-
-import Base: convert
 
 Base.convert(::Type{Polymake.Integer}, x::fmpz) = Polymake.Integer(BigInt(x))
 Base.convert(::Type{Polymake.Rational}, x::fmpz) = Polymake.Rational(convert(Polymake.Integer, x), convert(Polymake.Integer, 1))
@@ -130,34 +133,7 @@ function decompose_hdata(A)
     (A = -A[:, 2:end], b = A[:, 1])
 end
 
-
-# This is a specific polymake data structure supporting fast functions
-#  for rows->sets, rows containing col_i==true, etc.
-struct IncidenceMatrix
-   pm_incidencematrix::Polymake.IncidenceMatrix
-end
-
-function IncidenceMatrix(TrueIndices::Vector{Vector{Int64}})
-   nrows = length(TrueIndices)
-   ncols = maximum([maximum(set) for set in TrueIndices])
-   IM = Polymake.IncidenceMatrix(nrows, ncols)
-   i = 1
-   for set in TrueIndices
-      for j in set
-         IM[i,j] = 1
-      end
-      i = i+1
-  end
-   return IncidenceMatrix(IM)
-end
-
-
-
-#TODO: change how incidence matrices are shown (not zero base but maybe bool?)
-function Base.show(io::IO, I::IncidenceMatrix)
-    show(io,"text/plain", (Matrix{Bool}(I.pm_incidencematrix)))
-end
-
-import Base: convert
-
 Base.convert(::Type{fmpq}, q::Polymake.Rational) = fmpq(Polymake.numerator(q), Polymake.denominator(q))
+
+# TODO: different printing within oscar? if yes, implement the following method
+# Base.show(io::IO, ::MIME"text/plain", I::IncidenceMatrix) = show(io, "text/plain", Matrix{Bool}(I))

--- a/test/Polytopes/SubdivisionOfPoints.jl
+++ b/test/Polytopes/SubdivisionOfPoints.jl
@@ -21,7 +21,7 @@
         @test min_weights(SOP1) == [0,0,0,1,1,1]
         @test dim(C1) == 6
         @test dim(CMOAE) == 4
-        @test moaeimnonreg0.pm_incidencematrix == maximal_cells_as_incidence_matrix(MOAE).pm_incidencematrix
+        @test moaeimnonreg0 == maximal_cells_as_incidence_matrix(MOAE)
     end
 
 end


### PR DESCRIPTION
move functionality of `IncidenceMatrix` to polymake and access functionality from there.

within Oscar, importing `IncidenceMatrix` from polymake and then exporting it removes the necessity to re-invent the wheel and re-define the required functionality again in Oscar.