### PR TITLE
Change default for Qab to use ζ

### DIFF
--- a/src/Rings/AbelianClosure.jl
+++ b/src/Rings/AbelianClosure.jl
@@ -50,7 +50,7 @@ mutable struct QabField <: Nemo.Field # union of cyclotomic fields
   fields::Dict{Int, AnticNumberField} # Cache for the cyclotomic fields
 end
 
-const _Qab = QabField("z", Dict{Int, AnticNumberField}())
+const _Qab = QabField("ζ", Dict{Int, AnticNumberField}())
 
 mutable struct QabElem <: Nemo.FieldElem
   data::nf_elem                       # Element in cyclotomic field

--- a/src/Rings/binomial_ideals.jl
+++ b/src/Rings/binomial_ideals.jl
@@ -832,8 +832,8 @@ ideal(x - y, x^3 - 1, y^2*z - z)
 
 julia> binomial_primary_decomposition(I)
 3-element Vector{Tuple{MPolyIdeal{AbstractAlgebra.Generic.MPoly{QabElem}}, MPolyIdeal{AbstractAlgebra.Generic.MPoly{QabElem}}}}:
- (ideal(x - y, x^3 - 1, y^2*z - z, z, y - z(3), x - z(3)), ideal(x*y^2 - 1, y - z(3), z))
- (ideal(x - y, x^3 - 1, y^2*z - z, z, y + z(3) + 1, x + z(3) + 1), ideal(x*y^2 - 1, y + z(3) + 1, z))
+ (ideal(x - y, x^3 - 1, y^2*z - z, z, y - ζ(3), x - ζ(3)), ideal(x*y^2 - 1, y - ζ(3), z))
+ (ideal(x - y, x^3 - 1, y^2*z - z, z, y + ζ(3) + 1, x + ζ(3) + 1), ideal(x*y^2 - 1, y + ζ(3) + 1, z))
  (ideal(y - 1, x - 1, x*y - 1), ideal(y - 1, x - 1, x*y - 1))
 ```
 """

--- a/test/Rings/AbelianClosure.jl
+++ b/test/Rings/AbelianClosure.jl
@@ -50,18 +50,18 @@
   @testset "Printing" begin
     K, z = abelian_closure(QQ)
     @test sprint(show, "text/plain", K) == "Abelian closure of Q"
-    @test get_variable(K) == "z"
+    @test get_variable(K) == "ζ"
     s = sprint(show, "text/plain", z)
 
     a = z(1)
     sprint(show, "text/plain", a) == "1"
     a = z(4)
-    sprint(show, "text/plain", a) == "z(4)"
-
-    t = set_variable!(K, "ζ")
-    @test t == "z"
-    @test get_variable(K) == "ζ"
     sprint(show, "text/plain", a) == "ζ(4)"
+
+    t = set_variable!(K, "z")
+    @test t == "ζ"
+    @test get_variable(K) == "z"
+    sprint(show, "text/plain", a) == "z(4)"
 
     zz = gen(K, "ω")
     @test get_variable(K) == "ω"


### PR DESCRIPTION
This changes the default printing for the "generator" to be `ζ` instead of `z` (as requested by @wdecker).

I am happy with this change. Maybe @fieker could check if this prints correctly for him?

