### PR TITLE
Temporarily pin Hecke version in the doc build

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,8 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 DocumenterMarkdown = "997ab1e6-3595-5248-9280-8efb232c3433"
+Hecke = "3e1990a7-5d81-5526-99ce-9ba3ff248f21"
 
 [compat]
 DocumenterCitations = "0.2.5"
+Hecke = "= 0.10.17"


### PR DESCRIPTION
To fix #642, but I only want to do a patch release of Hecke.