### PR TITLE
Fix a problem with MappedWord

### DIFF
--- a/src/Groups/matrices/iso_nf_fq.jl
+++ b/src/Groups/matrices/iso_nf_fq.jl
@@ -21,8 +21,12 @@ function _isomorphic_group_over_finite_field(matrices::Vector{T}) where T <: Mat
    F = GAP.Globals.Range(G_to_fin_pres)
    rels = GAP.Globals.RelatorsOfFpGroup(F)
 
+   gens_and_invsF = [ g for g in GAP.Globals.FreeGeneratorsOfFpGroup(F) ]
+   append!(gens_and_invsF, [ inv(g) for g in GAP.Globals.FreeGeneratorsOfFpGroup(F) ])
+   matrices_and_invs = copy(matrices)
+   append!(matrices_and_invs, [ inv(M) for M in matrices ])
    for i = 1:length(rels)
-      M = GAP.Globals.MappedWord(rels[i], GAP.Globals.FreeGeneratorsOfFpGroup(F), GapObj(matrices))
+      M = GAP.Globals.MappedWord(rels[i], GapObj(gens_and_invsF), GapObj(matrices_and_invs))
       if !isone(M)
          error("Group is not finite")
       end

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -114,6 +114,17 @@
    H = GAP.Globals.Group(GAP.julia_to_gap([ GAP.Globals.E(5) 0; 0 GAP.Globals.E(5) ]))
    f = GAP.Globals.GroupHomomorphismByImages(G.X, H)
    @test GAP.Globals.IsBijective(f)
+
+   K, a = CyclotomicField(3, "a")
+   M1 = matrix(K, 2, 2, [ a, 0, -a - 1, 1 ])
+   M2 = matrix(K, 2, 2, [ 1, a + 1, 0, a ])
+   G, g = Oscar.isomorphic_group_over_finite_field(matrix_group([ M1, M2 ]))
+   @test order(G) == 24
+   for i in 1:10
+     x, y = rand(G), rand(G)
+     @test (g\x) * (g\y) == g\(x * y)
+     @test g(g\x) == x
+   end
 end
 
 @testset "Type operations" begin


### PR DESCRIPTION
There is a problem with GAP's `MappedWord` called on AbstractAlgebra matrices because there is no `/` for those. This fix was suggested by @thofma .
I added the (previously failing) example to the tests.