### PR TITLE
Add conversion from oscar `GapGroup` and `GapGroupElem` to `GAP.GapObj`.

### DIFF
--- a/src/GAP/oscar_to_gap.jl
+++ b/src/GAP/oscar_to_gap.jl
@@ -21,3 +21,13 @@ GAP.julia_to_gap(obj::fmpz_mat) = GAP.julia_to_gap(Matrix(obj), recursive = true
 
 ## `fmpq_mat` to matrix of GAP rationals or integers
 GAP.julia_to_gap(obj::fmpq_mat) = GAP.julia_to_gap(Matrix(obj), recursive = true)
+
+## `GapGroup` to GAP group
+GAP.GapObj(obj::GAPGroup) = return obj.X
+
+convert(::Type{GAP.GapObj}, obj::GAPGroup) = GAP.GapObj(obj)
+
+## `GapGroupElem` to GAP group element
+GAP.GapObj(obj::GAPGroupElem) = return obj.X
+
+convert(::Type{GAP.GapObj}, obj::GAPGroupElem) = GAP.GapObj(obj)

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -77,21 +77,35 @@ export
 @doc Markdown.doc"""
     GAPGroup <: AbstractAlgebra.Group
 
-The idea is that each object of the abstract type `GAPGroup` stores
-a group object from the GAP system,
-and thus can delegate questions about this group to GAP.
+Each object of the abstract type `GAPGroup` stores a group object from
+the GAP system,
+and thus can delegate questions about this object to GAP.
+
+For expert usage, you can extract the underlying GAP object via `GapObj`,
+i.e., if `G` is a `GAPGroup`, then `GapObj(G)` is the `GapObj` underlying `G`.
 
 Concrete subtypes of `GAPGroup` are `PermGroup`, `FPGroup`, `PcGroup`,
 and `MatrixGroup`.
 """
 abstract type GAPGroup <: AbstractAlgebra.Group end
+
+@doc Markdown.doc"""
+    GAPGroupElem <: AbstractAlgebra.GroupElem
+
+Each object of the abstract type `GAPGroupElem` stores a group element
+object from the GAP system,
+and thus can delegate questions about this object to GAP.
+
+For expert usage, you can extract the underlying GAP object via `GapObj`,
+i.e., if `g` is a `GAPGroupElem`, then `GapObj(g)` is the `GapObj` underlying `g`.
+"""
 abstract type GAPGroupElem{T<:GAPGroup} <: AbstractAlgebra.GroupElem end
 
 @doc Markdown.doc"""
-    BasicGAPGroupElem{T<:GAPGroup}
+    BasicGAPGroupElem{T<:GAPGroup} <: GAPGroupElem{T}
 
 The type `BasicGAPGroupElem` gathers all types of group elements
-described only by an underlying GAP object.
+described *only* by an underlying GAP object.
 
 If $x$ is an element of the group `G` of type `T`,
 then the type of $x$ is `BasicGAPGroupElem{T}`.

--- a/test/GAP/oscar_to_gap.jl
+++ b/test/GAP/oscar_to_gap.jl
@@ -89,3 +89,17 @@ end
     @test convert(GAP.GapObj, x) == val
     @test GAP.GapObj(x) == val
 end
+
+@testset "GapGroup and GapGroupElem" begin
+    # `GapGroup` to GAP group, Perm
+    G = symmetric_group(5)
+    val = GAP.evalstr("SymmetricGroup(5)")
+    @test GAP.GapObj(G) == val
+    @test convert(GAP.GapObj, G) == val
+
+    # `GapGroupElem` to GAP group element, Perm
+    g = perm(G, [2,3,1,5,4])
+    val = GAP.evalstr("(1,2,3)(4,5)")
+    @test GAP.GapObj(g) == val
+    @test convert(GAP.GapObj, g) == val
+end

--- a/test/GAP/oscar_to_gap.jl
+++ b/test/GAP/oscar_to_gap.jl
@@ -102,4 +102,10 @@ end
     val = GAP.evalstr("(1,2,3)(4,5)")
     @test GAP.GapObj(g) == val
     @test convert(GAP.GapObj, g) == val
+
+    # test implicit conversion
+    V = GAP.GapObj[]
+    push!(V, G) # convert GAPGroup to GapObj implicitly
+    push!(V, g) # convert GAPGroupElem to GapObj implicitly
+    @test V == [GAP.GapObj(G), GAP.GapObj(g)]
 end


### PR DESCRIPTION
- Add `GAP.GapObj` constructors for above types
- Add `convert` methods for above types