### PR TITLE
Refactor parts of the groups code

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,3 +20,13 @@ recommend the following steps:
 4. To rebuild the documentation, just repeat the same command as in step 4,
    without exiting Julia. Thanks to the Revise package, any runs after
    the first will be much faster.
+
+
+## Updating the bibliography
+
+When editing `docs/oscar_references.bib` please follow the style of the
+existing entries. An easy way to do that is to add your new BibTeX entry,
+then run [bibtool](http://www.gerd-neugebauer.de/software/TeX/BibTool/en/)
+by invoking it as follows from the root directory of the Oscar.jl repository:
+
+    bibtool docs/oscar_references.bib -o docs/oscar_references.bib

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -26,6 +26,18 @@
   pdf           = {https://hal.inria.fr/hal-02912148/file/07.pdf}
 }
 
+@Book{Cam99,
+  author        = {Cameron, Peter J.},
+  title         = {Permutation groups},
+  series        = {London Mathematical Society Student Texts},
+  volume        = {45},
+  publisher     = {Cambridge University Press, Cambridge},
+  year          = {1999},
+  pages         = {x+220},
+  doi           = {10.1017/CBO9780511623677},
+  url           = {https://doi.org/10.1017/CBO9780511623677}
+}
+
 @Book{Coh00,
   author        = {Cohen, Henri},
   title         = {Advanced topics in computational number theory},

--- a/docs/src/Groups/permgroup.md
+++ b/docs/src/Groups/permgroup.md
@@ -81,6 +81,15 @@ The function `Vector{T}` works in the opposite way with respect to `perm`:
 Vector(x::PermGroupElem, n::Int = x.parent.deg)
 ```
 
+## Operations on permutations
+
+```@docs
+sign(g::PermGroupElem)
+isodd(g::PermGroupElem)
+iseven(g::PermGroupElem)
+cycle_structure(g::PermGroupElem)
+```
+
 
 ## Permutations as functions
 A permutation can be viewed as a function on the set `{1,...,n}`, hence it can be evaluated on integers.

--- a/experimental/GaloisGrp/Group.jl
+++ b/experimental/GaloisGrp/Group.jl
@@ -133,11 +133,6 @@ function action_on_blocks(G::PermGroup, B::Vector{Int})
   return Oscar._hom_from_gap_map(G, H, act)
 end
 
-Base.sign(G::PermGroup) = GAP.Globals.SignPermGroup(G.X)
-
-Base.isodd(G::PermGroup) = sign(G) == -1
-Base.iseven(n::PermGroup) = !isodd(n)
-
 @doc Markdown.doc"""
     short_right_transversal(G::PermGroup, H::PermGroup, s::PermGroupElem) ->
 
@@ -146,11 +141,11 @@ Determines representatives `g` for all right-cosets of `G` modulo `H`
 """
 function short_right_transversal(G::PermGroup, H::PermGroup, s::PermGroupElem)
   C = conjugacy_classes(H)
-  cs = GAP.Globals.CycleStructurePerm(s.X)
+  cs = cycle_structure(s)
   can = PermGroupElem[]
   for c in C
     r = representative(c)
-    if cs == GAP.Globals.CycleStructurePerm(r.X)
+    if cs == cycle_structure(r)
       push!(can, r)
     end
   end

--- a/src/GAP/GAP.jl
+++ b/src/GAP/GAP.jl
@@ -1,0 +1,5 @@
+import GAP:
+    @gapattribute,
+    @gapwrap,
+    FFE,
+    GapObj

--- a/src/GAP/oscar_to_gap.jl
+++ b/src/GAP/oscar_to_gap.jl
@@ -25,9 +25,5 @@ GAP.julia_to_gap(obj::fmpq_mat) = GAP.julia_to_gap(Matrix(obj), recursive = true
 ## `GapGroup` to GAP group
 GAP.GapObj(obj::GAPGroup) = return obj.X
 
-convert(::Type{GAP.GapObj}, obj::GAPGroup) = GAP.GapObj(obj)
-
 ## `GapGroupElem` to GAP group element
 GAP.GapObj(obj::GAPGroupElem) = return obj.X
-
-convert(::Type{GAP.GapObj}, obj::GAPGroupElem) = GAP.GapObj(obj)

--- a/src/GAP/oscar_to_gap.jl
+++ b/src/GAP/oscar_to_gap.jl
@@ -21,9 +21,3 @@ GAP.julia_to_gap(obj::fmpz_mat) = GAP.julia_to_gap(Matrix(obj), recursive = true
 
 ## `fmpq_mat` to matrix of GAP rationals or integers
 GAP.julia_to_gap(obj::fmpq_mat) = GAP.julia_to_gap(Matrix(obj), recursive = true)
-
-## `GapGroup` to GAP group
-GAP.GapObj(obj::GAPGroup) = return obj.X
-
-## `GapGroupElem` to GAP group element
-GAP.GapObj(obj::GAPGroupElem) = return obj.X

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -104,8 +104,6 @@ false
 ```
 """ isfinite(G::GAPGroup)
 
-Base.isfinite(G::PermGroup) = true
-
 Base.isfinite(G::PcGroup) = true
 
 """
@@ -124,96 +122,6 @@ false
 ```
 """
 isfinite_order(x::GAPGroupElem) = GAP.Globals.IsInt(GAP.Globals.Order(x.X))::Bool
-
-"""
-    degree(G::PermGroup) -> Int
-
-Return the degree of `G` as a permutation group, that is,
-an integer `n` that is stored in `G`, with the following meaning.
-
-- `G` embeds into `symmetric_group(n)`.
-- Two permutation groups of different degrees are regarded as not equal,
-  even if they contain the same permutations.
-- Subgroups constructed with `derived_subgroup`, `sylow_subgroup`, etc.,
-  get the same degree as the given group.
-- The range `1:degree(G)` is used as the default set of points on which
-  `G` and its element acts.
-
-!!! note
-    The degree of a group of permutations is not necessarily equal to the largest moved point of the group `G`. For example, the trivial subgroup of `symmetric_group(n)` has degree `n` even though it fixes `n`.
-
-# Examples
-```jldoctest
-julia> degree(symmetric_group(4))
-4
-
-julia> t4 = trivial_subgroup(symmetric_group(4))[1];
-
-julia> degree(t4)
-4
-
-julia> t4 == trivial_subgroup(symmetric_group(5))[1]
-false
-
-julia> show(Vector(gen(symmetric_group(4), 2)))
-[2, 1, 3, 4]
-julia> show(Vector(gen(symmetric_group(5), 2)))
-[2, 1, 3, 4, 5]
-```
-"""
-degree(x::PermGroup) = x.deg
-
-@gapattribute moved_points(x::Union{PermGroupElem,PermGroup}) = [y for y in GAP.gap_to_julia(GAP.Globals.MovedPoints(x.X))]
-# This is more efficient than `Vector{Int}(GAP.Globals.MovedPoints(x.X))`.
-# (And note that `GAP.gap_to_julia(GAP.Globals.MovedPoints(G.X))` may return
-# a range.)
-"""
-    moved_points(x::PermGroupElem)
-    moved_points(G::PermGroup)
-
-Return the vector of those points in `1:degree(x)` or `1:degree(G)`,
-respectively, that are not mapped to themselves under the action `^`.
-
-# Examples
-```jldoctest
-julia> g = symmetric_group(4);  s = sylow_subgroup(g, 3)[1];
-
-julia> length(moved_points(s))
-3
-
-julia> length(moved_points(gen(s, 1)))
-3
-
-```
-""" moved_points
-
-@gapattribute number_moved_points(x::Union{PermGroupElem,PermGroup}) = fmpz(GAP.Globals.NrMovedPoints(x.X))::fmpz
-"""
-    number_moved_points(::Type{T} = fmpz, x::PermGroupElem) where T <: IntegerUnion
-    number_moved_points(::Type{T} = fmpz, G::PermGroup) where T <: IntegerUnion
-
-Return the number of those points in `1:degree(x)` or `1:degree(G)`,
-respectively, that are not mapped to themselves under the action `^`,
-as an instance of `T`.
-
-# Examples
-```jldoctest
-julia> g = symmetric_group(4);  s = sylow_subgroup(g, 3)[1];
-
-julia> number_moved_points(s)
-3
-
-julia> number_moved_points(Int, s)
-3
-
-julia> number_moved_points(gen(s, 1))
-3
-
-```
-""" number_moved_points
-
-number_moved_points(::Type{T}, x::Union{PermGroupElem,PermGroup}) where T <: IntegerUnion = T(GAP.Globals.NrMovedPoints(x.X))::T
-
 
 """
     order(::Type{T} = fmpz, x::Union{GAPGroupElem, GAPGroup}) where T <: IntegerUnion
@@ -301,11 +209,7 @@ end
 
 Base.:*(x::GAPGroupElem, y::GAPGroupElem) = _prod(x, y)
 
-==(x::PermGroup, y::PermGroup) = x.deg == y.deg && x.X == y.X
-
 ==(x::GAPGroup, y::GAPGroup) = x.X == y.X
-
-==(x::PermGroupElem, y::PermGroupElem) = degree(parent(x)) == degree(parent(y)) && x.X == y.X
 
 ==(x::T, y::T) where T <: BasicGAPGroupElem = x.X == y.X
 
@@ -336,8 +240,6 @@ inv!(out::GAPGroupElem, x::GAPGroupElem) = inv(x)  #if needed later
 Base.:^(x::GAPGroupElem, y::Int) = group_element(parent(x), x.X ^ y)
 
 Base.:^(x::GAPGroupElem, y::fmpz) = Hecke._generic_power(x, y) # TODO: perhaps  let GAP handle this; also handle arbitrary Integer subtypes?
-
-Base.:<(x::PermGroupElem, y::PermGroupElem) = x.X < y.X
 
 Base.:/(x::GAPGroupElem, y::GAPGroupElem) = x*y^-1
 
@@ -389,177 +291,6 @@ Return whether `g` is an element of `G`.
 The parent of `g` need not be equal to `G`.
 """
 Base.in(g::GAPGroupElem, G::GAPGroup) = GAP.Globals.in(g.X, G.X)::Bool
-
-# FIXME: clashes with AbstractAlgebra.perm method
-#function perm(L::AbstractVector{<:Base.Integer})
-#   return PermGroupElem(symmetric_group(length(L)), GAP.Globals.PermList(GAP.GapObj(L;recursive=true)))
-#end
-# FIXME: use name gap_perm for now
-@doc Markdown.doc"""
-    gap_perm(L::AbstractVector{<:Base.Integer})
-
-Return the permutation $x$ which maps every $i$ from `1` to $n$` = length(L)`
-to `L`$[i]$.
-The parent of $x$ is set to [`symmetric_group`](@ref)$(n)$.
-An exception is thrown if `L` does not contain every integer from 1 to $n$
-exactly once.
-
-# Examples
-```jldoctest
-julia> gap_perm([2,4,6,1,3,5])
-(1,2,4)(3,6,5)
-```
-"""
-function gap_perm(L::AbstractVector{<:IntegerUnion})
-  return PermGroupElem(symmetric_group(length(L)), GAP.Globals.PermList(GAP.GapObj(L;recursive=true)))
-end
-
-@doc Markdown.doc"""
-    perm(G::PermGroup, L::AbstractVector{<:Integer})
-    (G::PermGroup)(L::AbstractVector{<:Integer})
-
-Return the permutation $x$ which maps every `i` from 1 to $n$` = length(L)`
-to `L`$[i]$.
-The parent of $x$ is `G`.
-An exception is thrown if $x$ is not contained in `G`
-or `L` does not contain every integer from 1 to $n$ exactly once.
-
-For [`gap_perm`](@ref),
-the parent group of $x$ is set to [`symmetric_group`](@ref)$(n)$.
-
-# Examples
-```jldoctest
-julia> perm(symmetric_group(6),[2,4,6,1,3,5])
-(1,2,4)(3,6,5)
-```
-"""
-function perm(g::PermGroup, L::AbstractVector{<:Base.Integer})
-   x = GAP.Globals.PermList(GAP.GapObj(L;recursive=true))
-   if length(L) <= degree(g) && GAP.Globals.IN(x,g.X) 
-     return PermGroupElem(g, x)
-   end
-   throw(ArgumentError("the element does not embed in the group"))
-end
-
-perm(g::PermGroup, L::AbstractVector{<:fmpz}) = perm(g, [Int(y) for y in L])
-
-function (g::PermGroup)(L::AbstractVector{<:Base.Integer})
-   x = GAP.Globals.PermList(GAP.GapObj(L;recursive=true))
-   if length(L) <= degree(g) && GAP.Globals.IN(x,g.X)
-     return PermGroupElem(g, x)
-   end
-   throw(ArgumentError("the element does not embed in the group"))
-end
-
-(g::PermGroup)(L::AbstractVector{<:fmpz}) = g([Int(y) for y in L])
-
-# cperm stays for "cycle permutation", but we can change name if we want
-# takes as input a list of vectors (not necessarly disjoint)
-@doc Markdown.doc"""
-    cperm(L::AbstractVector{<:T}...) where T <: IntegerUnion
-    cperm(G::PermGroup, L::AbstractVector{<:T}...)
-
-For given lists $[a_1, a_2, \ldots, a_n], [b_1, b_2, \ldots , b_m], \ldots$
-of positive integers, return the
-permutation $x = (a_1, a_2, \ldots, a_n) * (b_1, b_2, \ldots, b_m) * \ldots$.
-Arrays of the form `[n, n+1, ..., n+k]` can be replaced by `n:n+k`.
-
-The parent of $x$ is `G`.
-If `G` is not specified then the parent of $x$ is set to
-[`symmetric_group`](@ref)$(n)$,
-where $n$ is the largest integer that occurs in an entry of `L`.
-
-An exception is thrown if $x$ is not contained in `G`
-or one of the given vectors is empty or contains duplicates.
-
-# Examples
-```jldoctest
-julia> cperm([1,2,3],4:7)
-(1,2,3)(4,5,6,7)
-
-julia> cperm([1,2],[2,3])
-(1,3,2)
-
-julia> p = cperm([1,2,3],[7])
-(1,2,3)
-
-julia> degree(parent(p))
-7
-
-```
-
-At the moment, the input vectors of the function `cperm` need not be disjoint.
-
-!!! warning
-    If the function `perm` is evaluated in a vector of integers
-    without specifying the group `G`,
-    then the returned value is an element of the AbstractAlgebra.jl type
-    `Perm{Int}`.
-    For this reason, if one wants a permutation of type
-    `GAPGroupElem{PermGroup}` without specifying a parent,
-    one has to use the function `gap_perm`.
-"""
-function cperm(L::AbstractVector{T}...) where T <: IntegerUnion
-   if length(L)==0
-      return one(symmetric_group(1))
-   else
-      return prod([PermGroupElem(symmetric_group(maximum(y)), GAP.Globals.CycleFromList(GAP.julia_to_gap([Int(k) for k in y]))) for y in L])
-#TODO: better create the product of GAP permutations?
-   end
-end
-
-# cperm stays for "cycle permutation", but we can change name if we want
-# takes as input a list of vectors (not necessarly disjoint)
-# WARNING: we allow e.g. PermList([2,3,1,4,5,6]) in Sym(3)
-function cperm(g::PermGroup,L::AbstractVector{T}...) where T <: IntegerUnion
-   if length(L)==0
-      return one(g)
-   else
-      x=prod(y -> GAP.Globals.CycleFromList(GAP.julia_to_gap([Int(k) for k in y])), L)
-      if length(L) <= degree(g) && GAP.Globals.IN(x,g.X)
-         return PermGroupElem(g, x)
-      else
-         throw(ArgumentError("the element does not embed in the group"))
-      end
-   end
-end
-
-@deprecate listperm(x::PermGroupElem) Vector(x)
-
-"""
-    Vector{T}(x::PermGroupElem, n::Int = x.parent.deg) where T <: IntegerUnion
-    Vector(x::PermGroupElem, n::Int = x.parent.deg)
-
-Return the list of length `n` that contains `x(i)` at position `i`. If not specified, `T` is set as `Int`.
-
-# Examples
-```jldoctest
-julia> pi = cperm(1:3)
-(1,2,3)
-julia> Vector(pi)
-3-element Vector{Int64}:
- 2
- 3
- 1
-julia> Vector(pi, 2)
-2-element Vector{Int64}:
- 2
- 3
-julia> Vector(pi, 4)
-4-element Vector{Int64}:
- 2
- 3
- 1
- 4
-julia> Vector{fmpz}(pi, 2)
-2-element Vector{fmpz}:
- 2
- 3
-
-```
-"""
-Base.Vector{T}(x::PermGroupElem, n::Int = x.parent.deg) where T <: IntegerUnion = T[x(i) for i in 1:n]
-Base.Vector(x::PermGroupElem, n::Int = x.parent.deg) = Vector{Int}(x,n)
 
 """
     gens(G::Group)
@@ -619,29 +350,6 @@ Return the length of the vector [`gens`](@ref)`(G)`.
 """
 ngens(G::GAPGroup) = length(GAP.Globals.GeneratorsOfGroup(G.X))
 
-
-Base.sign(x::PermGroupElem) = GAP.Globals.SignPerm(x.X)::Int
-
-Base.isless(x::PermGroupElem, y::PermGroupElem) = x<y
-
-#embedding of a permutation in permutation group
-function (G::PermGroup)(x::PermGroupElem)
-   if !GAP.Globals.IN(x.X,G.X)
-      throw(ArgumentError("the element does not embed in the group"))
-   end
-   return group_element(G, x.X)
-end
-
-#evaluation function
-function (x::PermGroupElem)(n::T) where T <: IntegerUnion
-   return T(GAP.Globals.OnPoints(GAP.GapObj(n), x.X))
-end
-
-(x::PermGroupElem)(n::Int) = GAP.Globals.OnPoints(n,x.X)
-
-^(n::T, x::PermGroupElem) where T <: IntegerUnion = T(GAP.Globals.OnPoints(GAP.GapObj(n), x.X))
-
-^(n::Int, x::PermGroupElem) = GAP.Globals.OnPoints(n,x.X)
 
 ################################################################################
 #

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -17,6 +17,7 @@ export
     core,
     coset_decomposition,
     cperm,
+    cycle_structure,
     degree,
     describe,
     div_left,

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -23,7 +23,10 @@ export
 """
     GroupCoset{T<: Group, S <: GAPGroupElem}
 
-Type of group cosets. It is displayed as `H * x` (right cosets) or `x * H` (left cosets), where `H` is a subgroup of a group `G` and `x` is an element of `G`. Two cosets are equal if, and only if, they are both left (resp. right) and they contain the same elements.
+Type of group cosets. It is displayed as `H * x` (right cosets) or `x * H`
+(left cosets), where `H` is a subgroup of a group `G` and `x` is an element of
+`G`. Two cosets are equal if, and only if, they are both left (resp. right)
+and they contain the same elements.
 """
 struct GroupCoset{T<: GAPGroup, S <: GAPGroupElem} 
    G::T                    # big group containing the subgroup and the element
@@ -65,7 +68,8 @@ end
 
 Return the coset `gH`.
 !!! note
-    Since GAP supports right cosets only, the underlying GAP object of `left_coset(H,g)` is the right coset `H^(g^-1) * g`.
+    Since GAP supports right cosets only, the underlying GAP object of
+    `left_coset(H,g)` is the right coset `H^(g^-1) * g`.
 """
 function left_coset(H::GAPGroup, g::GAPGroupElem)
    @assert elem_type(H) == typeof(g)
@@ -221,7 +225,9 @@ end
 """
     GroupDoubleCoset{T<: Group, S <: GAPGroupElem}
 
-Group double coset. It is displayed as `H * x * K`, where `H` and `K` are subgroups of a group `G` and `x` is an element of `G`. Two double cosets are equal if, and only if, they contain the same elements.
+Group double coset. It is displayed as `H * x * K`, where `H` and `K` are
+subgroups of a group `G` and `x` is an element of `G`. Two double cosets are
+equal if, and only if, they contain the same elements.
 """
 struct GroupDoubleCoset{T <: GAPGroup, S <: GAPGroupElem}
 # T=type of the group, S=type of the element

--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -34,7 +34,9 @@ export
 
 Return the direct product of the groups in the collection `L`.
 
-The parameter `morphisms` is `false` by default. If it is set `true`, then the output is a triple (`G`, `emb`, `proj`), where `emb` and `proj` are the vectors of the embeddings (resp. projections) of the direct product `G`.
+The parameter `morphisms` is `false` by default. If it is set `true`, then
+the output is a triple (`G`, `emb`, `proj`), where `emb` and `proj` are the
+vectors of the embeddings (resp. projections) of the direct product `G`.
 """
 function direct_product(L::AbstractVector{<:GAPGroup}; morphisms=false)
    X = GAP.Globals.DirectProduct(GAP.julia_to_gap([G.X for G in L]))
@@ -56,10 +58,13 @@ end
     inner_direct_product(L::AbstractVector{T}; morphisms)
     inner_direct_product(L::T...)
 
-Return a direct product of groups of the same type `T` as a group of type `T`. It works for `T` of the following types:
+Return a direct product of groups of the same type `T` as a group of type
+`T`. It works for `T` of the following types:
 - `PermGroup`, `PcGroup`, `FPGroup`.
 
-The parameter `morphisms` is `false` by default. If it is set `true`, then the output is a triple (`G`, `emb`, `proj`), where `emb` and `proj` are the vectors of the embeddings (resp. projections) of the direct product `G`.
+The parameter `morphisms` is `false` by default. If it is set `true`, then
+the output is a triple (`G`, `emb`, `proj`), where `emb` and `proj` are the
+vectors of the embeddings (resp. projections) of the direct product `G`.
 """
 function inner_direct_product(L::AbstractVector{T}; morphisms=false) where T<:Union{PcGroup,PermGroup,FPGroup}
    P = GAP.Globals.DirectProduct(GAP.julia_to_gap([G.X for G in L]))
@@ -103,7 +108,9 @@ end
 
 Return the direct product of `n` copies of `G` as group of type `T`.
 
-The parameter `morphisms` is `false` by default. If it is set `true`, then the output is a triple (`G`, `emb`, `proj`), where `emb` and `proj` are the vectors of the embeddings (resp. projections) of the direct product `G`.
+The parameter `morphisms` is `false` by default. If it is set `true`, then
+the output is a triple (`G`, `emb`, `proj`), where `emb` and `proj` are the
+vectors of the embeddings (resp. projections) of the direct product `G`.
 """
 function inner_cartesian_power(G::T, n::Base.Integer; morphisms=false) where T <: GAPGroup
    L = [G for i in 1:n]
@@ -276,7 +283,8 @@ acting_subgroup(G::SemidirectProductGroup) = G.H
 """
     homomorphism_of_semidirect_product(G::SemidirectProductGroup)
 
-Return `f,` where `G` is the semidirect product of the normal subgroup `N` and the group `H` acting on `N` via the homomorphism `h`.
+Return `f,` where `G` is the semidirect product of the normal subgroup `N` and
+the group `H` acting on `N` via the homomorphism `h`.
 """
 homomorphism_of_semidirect_product(G::SemidirectProductGroup) = G.f
 
@@ -290,7 +298,8 @@ isfull_semidirect_product(G::SemidirectProductGroup) = G.isfull
 """
     embedding(G::SemidirectProductGroup, n::Integer)
 
-Return the embedding of the `n`-th component of `G` into `G`, for `n` = 1,2. It is not defined for proper subgroups of semidirect products.
+Return the embedding of the `n`-th component of `G` into `G`, for `n` = 1,2.
+It is not defined for proper subgroups of semidirect products.
 """
 function embedding(G::SemidirectProductGroup{S,T}, n::Base.Integer) where S where T
    @assert G.isfull "Embedding not defined for proper subgroups of semidirect products"
@@ -327,7 +336,8 @@ end
 
 function Base.show(io::IO, x::SemidirectProductGroup)
    if x.isfull
-      print(io, "SemidirectProduct( ", GAP.gap_to_julia(GAP.Globals.StringViewObj(x.N.X)), " , ", GAP.gap_to_julia(GAP.Globals.StringView(x.H.X))," )")
+      print(io, "SemidirectProduct( ", GAP.gap_to_julia(GAP.Globals.StringViewObj(x.N.X)),
+                " , ", GAP.gap_to_julia(GAP.Globals.StringView(x.H.X))," )")
    else
       print(io, GAP.gap_to_julia(GAP.Globals.StringViewObj(x.X)))
    end
@@ -343,11 +353,16 @@ end
     wreath_product(G::T, H::S, a::GAPGroupHomomorphism{S,PermGroup})
     wreath_product(G::T, H::PermGroup) where T<: Group
 
-Return the wreath product of the group `G` and the group `H`, where `H` acts on `n` copies of `G` through the homomorphism `a` from `H` to a permutation group, and `n` is the number of moved points of `Image(a)`.
+Return the wreath product of the group `G` and the group `H`, where `H` acts
+on `n` copies of `G` through the homomorphism `a` from `H` to a permutation
+group, and `n` is the number of moved points of `Image(a)`.
 
-If `a` is not specified, then `H` must be a group of permutations. In this case, `n` is NOT the number of moved points, but the degree of `H`.
+If `a` is not specified, then `H` must be a group of permutations. In this
+case, `n` is NOT the number of moved points, but the degree of `H`.
 
-If `W` is a wreath product of `G` and `H`, {`g_1`, ..., `g_n`} are elements of `G` and `h` in `H`, the element `(g_1, ..., h)` of `W` can be obtained by typing
+If `W` is a wreath product of `G` and `H`, {`g_1`, ..., `g_n`} are elements of
+`G` and `h` in `H`, the element `(g_1, ..., h)` of `W` can be obtained by
+typing
 ```
     W(g_1,...,g_n, h).
 ```
@@ -401,7 +416,8 @@ acting_subgroup(W::WreathProductGroup) = W.H
 """
     homomorphism_of_wreath_product(G::WreathProductGroup)
 
-If `W` is the wreath product of `G` and `H`, then return the homomorphism `f` from `H` to `Sym(n)`, where `n` is the number of copies of `G`.
+If `W` is the wreath product of `G` and `H`, then return the homomorphism `f`
+from `H` to `Sym(n)`, where `n` is the number of copies of `G`.
 """
 homomorphism_of_wreath_product(G::WreathProductGroup) = G.a
 

--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -4,9 +4,6 @@
 #  
 ################################################################################
 
-import GAP.@gapattribute
-import GAP.@gapwrap
-
 export
     abelian_group,
     alternating_group,

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -77,7 +77,8 @@ end
 """
     trivial_morphism(G::GAPGroup, H::GAPGroup)
 
-Return the homomorphism from `G` to `H` sending every element of `G` into the identity of `H`. If `H` is not specified, it is taken equal to `G`.
+Return the homomorphism from `G` to `H` sending every element of `G` into the
+identity of `H`. If `H` is not specified, it is taken equal to `G`.
 """
 function trivial_morphism(G::GAPGroup, H::GAPGroup)
   return hom(G, H, x -> one(H))
@@ -113,7 +114,8 @@ end
 """
     hom(G::GAPGroup, H::GAPGroup, gensG::Vector, imgs::Vector)
 
-Return the group homomorphism defined by `gensG`[`i`] -> `imgs`[`i`] for every `i`. In order to work, the elements of `gensG` must generate `G`.
+Return the group homomorphism defined by `gensG`[`i`] -> `imgs`[`i`] for every
+`i`. In order to work, the elements of `gensG` must generate `G`.
 """
 function hom(G::GAPGroup, H::GAPGroup, gensG::Vector, imgs::Vector)
   vgens = GAP.julia_to_gap(GapObj[x.X for x in gensG])
@@ -290,7 +292,8 @@ end
 """
     preimage(f::GAPGroupHomomorphism{S, T}, H::T) where S <: GAPGroup where T <: GAPGroup
 
-If `H` is a subgroup of the codomain of `f`, return the subgroup `f^-1(H)`, together with its embedding homomorphism into the domain of `f`.
+If `H` is a subgroup of the codomain of `f`, return the subgroup `f^-1(H)`,
+together with its embedding homomorphism into the domain of `f`.
 """
 function preimage(f::GAPGroupHomomorphism{S, T}, H::T) where S <: GAPGroup where T <: GAPGroup
   H1 = GAP.Globals.PreImage(f.map, H.X)
@@ -307,7 +310,9 @@ end
 """
     isisomorphic(G::Group, H::Group)
 
-Return (`true`,`f`) if `G` and `H` are isomorphic groups, where `f` is a group isomorphism. Otherwise, return (`false`,`f`), where `f` is the trivial homomorphism.
+Return (`true`,`f`) if `G` and `H` are isomorphic groups, where `f` is a group
+isomorphism. Otherwise, return (`false`,`f`), where `f` is the trivial
+homomorphism.
 """
 function isisomorphic(G::GAPGroup, H::GAPGroup)
   mp = GAP.Globals.IsomorphismGroups(G.X, H.X)
@@ -370,7 +375,9 @@ end
 """
     automorphism_group(G::Group) -> A::AutomorphismGroup{T}
 
-Return the full automorphism group of `G`. If `f` is an object of type `GAPGroupHomomorphism` and it is bijective from `G` to itself, then `A(f)` return the embedding of `f` in `A`.
+Return the full automorphism group of `G`. If `f` is an object of type
+`GAPGroupHomomorphism` and it is bijective from `G` to itself, then `A(f)`
+return the embedding of `f` in `A`.
 
 Elements of `A` can be multiplied with other elements of `A` or by elements
 of type `GAPGroupHomomorphism`; in this last case, the result has type
@@ -466,7 +473,10 @@ end
     induced_automorphism(f::GAPGroupHomomorphism, g::GAPGroupHomomorphism)
     induced_automorphism(f::GAPGroupHomomorphism, g::GAPGroupElem{AutomorphismGroup{T}})
 
-Return the automorphism `h` of the image of `f` such that `h`(`f`) == `f`(`g`), where `g` is an automorphism of a group `G` and `f` is a group homomorphism defined over `G` such that the kernel of `f` is invariant under `g`
+Return the automorphism `h` of the image of `f` such that `h`(`f`) ==
+`f`(`g`), where `g` is an automorphism of a group `G` and `f` is a group
+homomorphism defined over `G` such that the kernel of `f` is invariant under
+`g`
 """
 function induced_automorphism(f::GAPGroupHomomorphism, mH::GAPGroupHomomorphism)
   @assert isinvariant(mH, kernel(f)[1]) "The kernel is not invariant under g!"

--- a/src/Groups/libraries/smallgroups.jl
+++ b/src/Groups/libraries/smallgroups.jl
@@ -47,7 +47,12 @@ number_small_groups(n::Int) = GAP.Globals.NumberSmallGroups(n)
 """
     all_small_groups(n::Int, L...)
 
-Return the list of all groups (up to isomorphism) of order `n` and satisfying the conditions in `L`. Here, `L` is a vector whose arguments are organized as `L` = [ `func1`, `arg1`, `func2`, `arg2`, ... ], and the function returns all the groups `G` satisfying the conditions `func1`(`G`) = `arg1`, `func2`(`G`) = `arg2`, etc. An argument can be omitted if it corresponds to the boolean value ``true``.
+Return the list of all groups (up to isomorphism) of order `n` and satisfying
+the conditions in `L`. Here, `L` is a vector whose arguments are organized as
+`L` = [ `func1`, `arg1`, `func2`, `arg2`, ... ], and the function returns all
+the groups `G` satisfying the conditions `func1`(`G`) = `arg1`, `func2`(`G`) =
+`arg2`, etc. An argument can be omitted if it corresponds to the boolean value
+``true``.
 
 # Examples
 ```

--- a/src/Groups/libraries/transitivegroups.jl
+++ b/src/Groups/libraries/transitivegroups.jl
@@ -39,7 +39,10 @@ transitive_identification(G::PermGroup) = GAP.Globals.TransitiveIdentification(G
 
 Return the list of all transitive groups (up to permutation isomorphism)
 satisfying the conditions in `L`.
-Here, `L` is a vector whose arguments are organized as `L` = [ `func1`, `arg1`, `func2`, `arg2`, ... ], and the function returns all the groups `G` satisfying the conditions `func1`(`G`) = `arg1`, `func2`(`G`) = `arg2`, etc. An argument can be omitted if it corresponds to the boolean value `true`.
+Here, `L` is a vector whose arguments are organized as `L` = [ `func1`,
+`arg1`, `func2`, `arg2`, ... ], and the function returns all the groups `G`
+satisfying the conditions `func1`(`G`) = `arg1`, `func2`(`G`) = `arg2`, etc.
+An argument can be omitted if it corresponds to the boolean value `true`.
 
 # Examples
 ```jldoctest

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -559,7 +559,8 @@ end
     symplectic_group(n::Int, F::FqNmodFiniteField)
     Sp = symplectic_group
 
-Return the symplectic group of dimension `n` either over the field `F` or the field `GF(q)`. The dimension `n` must be even.
+Return the symplectic group of dimension `n` either over the field `F` or the
+field `GF(q)`. The dimension `n` must be even.
 """
 function symplectic_group(n::Int, F::Ring)
    iseven(n) || throw(ArgumentError("The dimension must be even"))
@@ -579,7 +580,9 @@ end
     orthogonal_group(e::Int, n::Int, q::Int)
     GO = orthogonal_group
 
-Return the orthogonal group of dimension `n` either over the field `F` or the field `GF(q)` of type `e`, where `e` in {`+1`,`-1`} for `n` even and `e`=`0` for `n` odd. If `n` is odd, `e` can be omitted.
+Return the orthogonal group of dimension `n` either over the field `F` or the
+field `GF(q)` of type `e`, where `e` in {`+1`,`-1`} for `n` even and `e`=`0`
+for `n` odd. If `n` is odd, `e` can be omitted.
 """
 function orthogonal_group(e::Int, n::Int, F::Ring)
    if e==1
@@ -614,7 +617,9 @@ orthogonal_group(n::Int, q::Int) = orthogonal_group(0,n,q)
     special_orthogonal_group(e::Int, n::Int, q::Int)
     SO = special_orthogonal_group
 
-Return the special orthogonal group of dimension `n` either over the field `F` or the field `GF(q)` of type `e`, where `e` in {`+1`,`-1`} for `n` even and `e`=`0` for `n` odd. If `n` is odd, `e` can be omitted.
+Return the special orthogonal group of dimension `n` either over the field `F`
+or the field `GF(q)` of type `e`, where `e` in {`+1`,`-1`} for `n` even and
+`e`=`0` for `n` odd. If `n` is odd, `e` can be omitted.
 """
 function special_orthogonal_group(e::Int, n::Int, F::Ring)
    iseven(order(F)) && return GO(e,n,F)
@@ -649,7 +654,9 @@ special_orthogonal_group(n::Int, q::Int) = special_orthogonal_group(0,n,q)
     omega_group(e::Int, n::Int, F::Ring)
     omega_group(e::Int, n::Int, q::Int)
 
-Return the Omega group of dimension `n` over the field `GF(q)` of type `e`, where `e` in {`+1`,`-1`} for `n` even and `e`=`0` for `n` odd. If `n` is odd, `e` can be omitted.
+Return the Omega group of dimension `n` over the field `GF(q)` of type `e`,
+where `e` in {`+1`,`-1`} for `n` even and `e`=`0` for `n` odd. If `n` is odd,
+`e` can be omitted.
 """
 function omega_group(e::Int, n::Int, F::Ring)
    n==1 && return SO(e,n,F)

--- a/src/Groups/matrices/forms.jl
+++ b/src/Groups/matrices/forms.jl
@@ -61,7 +61,7 @@ mutable struct SesquilinearForm{T<:RingElem}
 
    function SesquilinearForm{T}(f::MPolyElem{T},sym) where T
       @assert sym==:quadratic "Only quadratic forms are described by polynomials"
-      @assert Set([total_degree(x) for x in monomials(f)])==Set(2) "The polynomials is not homoneneous of degree 2"
+      @assert Set([total_degree(x) for x in monomials(f)])==Set(2) "The polynomials is not homogeneous of degree 2"
       r = new{T}()
       r.pol = f
       r.descr = :quadratic
@@ -169,7 +169,7 @@ quadratic_form(f::MPolyElem{T}) where T <: FieldElem = SesquilinearForm(f, :quad
 
 # just to allow quadratic forms over vector fields of dimension 1, so defined over polynomials in 1 variable
 function quadratic_form(f::PolyElem{T}) where T <: FieldElem
-   @assert degree(f)==2 && coefficients(f)[0]==0 && coefficients(f)[1]==0 "The polynomials is not homoneneous of degree 2"
+   @assert degree(f)==2 && coefficients(f)[0]==0 && coefficients(f)[1]==0 "The polynomials is not homogeneous of degree 2"
    R1 = PolynomialRing(base_ring(f), [string(parent(f).S)])[1]
 
    return SesquilinearForm(R1[1]^2*coefficients(f)[2], :quadratic)
@@ -406,7 +406,8 @@ end
 """
     radical(f::SesquilinearForm{T})
 
-Return the radical of the sesquilinear form `f`, i.e. the subspace of all `v` such that `f(u,v)=0` for all `u`.
+Return the radical of the sesquilinear form `f`, i.e. the subspace of all `v`
+such that `f(u,v)=0` for all `u`.
 The radical of a quadratic form `Q` is the set of vectors `v` such that `Q(v)=0`
  and `v` lies in the radical of the corresponding bilinear form.
 """
@@ -433,7 +434,8 @@ witt_index(f::SesquilinearForm{T}) where T = GAP.Globals.WittIndex(f.X)
 """
     isdegenerate(f::SesquilinearForm{T})
 
-Return whether `f` is degenerate, i.e. `f` has nonzero radical. A quadratic form is degenerate if the corresponding bilinear form is.
+Return whether `f` is degenerate, i.e. `f` has nonzero radical. A quadratic
+form is degenerate if the corresponding bilinear form is.
 """
 function isdegenerate(f::SesquilinearForm{T}) where T
    f.descr != :quadratic && return det(gram_matrix(f))==0

--- a/src/Groups/matrices/linear_isconjugate.jl
+++ b/src/Groups/matrices/linear_isconjugate.jl
@@ -24,7 +24,8 @@ export
 """
     multiplicative_jordan_decomposition(M::MatrixGroupElem)
 
-Return `S` and `U` in the group `G = parent(M)` such that `S` is semisimple, `U` is unipotent and  `M = SU = US`.
+Return `S` and `U` in the group `G = parent(M)` such that `S` is semisimple,
+`U` is unipotent and  `M = SU = US`.
 !!! warning "WARNING:" 
     this is *NOT*, in general, the same output returned when `M` has type `MatElem`.
 """
@@ -81,7 +82,9 @@ end
     pol_elementary_divisors(x::MatElem)
     pol_elementary_divisors(x::MatrixGroupElem)
 
-Return a list of pairs `(f_i,m_i)`, for irreducible polynomials `f_i` and positive integers `m_i`, where the `f_i^m_i` are the elementary divisors of `x`.
+Return a list of pairs `(f_i,m_i)`, for irreducible polynomials `f_i` and
+positive integers `m_i`, where the `f_i^m_i` are the elementary divisors of
+`x`.
 """
 function pol_elementary_divisors(A::MatElem{T}) where T
    a,_,c = _rational_canonical_form_setup(A)
@@ -125,7 +128,8 @@ end
 """
     generalized_jordan_form(A::MatElem{T}; with_pol=false) where T
 
-Return (`J`,`Z`), where `Z^-1*J*Z = A` and `J` is a diagonal join of Jordan blocks (corresponding to irreducible polynomials).
+Return (`J`,`Z`), where `Z^-1*J*Z = A` and `J` is a diagonal join of Jordan
+blocks (corresponding to irreducible polynomials).
 """
 function generalized_jordan_form(A::MatElem{T}; with_pol=false) where T
    V = pol_elementary_divisors(A)

--- a/src/Groups/matrices/transform_form.jl
+++ b/src/Groups/matrices/transform_form.jl
@@ -376,8 +376,15 @@ end
 """
     iscongruent(f::SesquilinearForm{T}, g::SesquilinearForm{T}) where T <: RingElem
 
-If `f` and `g` are sesquilinear forms, return (`true`, `C`) if there exists a matrix `C` such that `f^C = g`, or equivalently, `CBC* = A`, where `A` and `B` are the Gram matrices of `f` and `g` respectively, and `C*` is the transpose-conjugate matrix of `C`. If such `C` does not exist, then return (`false`, `nothing`).
-If `f` and `g` are quadratic forms, return (`true`, `C`) if there exists a matrix `C` such that `f^A = ag` for some scalar `a`. If such `C` does not exist, then return (`false`, `nothing`).
+If `f` and `g` are sesquilinear forms, return (`true`, `C`) if there exists a
+matrix `C` such that `f^C = g`, or equivalently, `CBC* = A`, where `A` and `B`
+are the Gram matrices of `f` and `g` respectively, and `C*` is the
+transpose-conjugate matrix of `C`. If such `C` does not exist, then return
+(`false`, `nothing`).
+
+If `f` and `g` are quadratic forms, return (`true`, `C`) if there exists a
+matrix `C` such that `f^A = ag` for some scalar `a`. If such `C` does not
+exist, then return (`false`, `nothing`).
 """
 function iscongruent(f::SesquilinearForm{T}, g::SesquilinearForm{T}) where T <: RingElem
 

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -28,7 +28,9 @@ an integer `n` that is stored in `G`, with the following meaning.
   `G` and its element acts.
 
 !!! note
-    The degree of a group of permutations is not necessarily equal to the largest moved point of the group `G`. For example, the trivial subgroup of `symmetric_group(n)` has degree `n` even though it fixes `n`.
+    The degree of a group of permutations is not necessarily equal to the
+    largest moved point of the group `G`. For example, the trivial subgroup of
+    `symmetric_group(n)` has degree `n` even though it fixes `n`.
 
 # Examples
 ```jldoctest

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -1,0 +1,295 @@
+#
+#
+#
+
+Base.isfinite(G::PermGroup) = true
+
+==(x::PermGroup, y::PermGroup) = x.deg == y.deg && x.X == y.X
+
+==(x::PermGroupElem, y::PermGroupElem) = degree(parent(x)) == degree(parent(y)) && x.X == y.X
+
+Base.:<(x::PermGroupElem, y::PermGroupElem) = x.X < y.X
+
+Base.isless(x::PermGroupElem, y::PermGroupElem) = x<y
+
+
+"""
+    degree(G::PermGroup) -> Int
+
+Return the degree of `G` as a permutation group, that is,
+an integer `n` that is stored in `G`, with the following meaning.
+
+- `G` embeds into `symmetric_group(n)`.
+- Two permutation groups of different degrees are regarded as not equal,
+  even if they contain the same permutations.
+- Subgroups constructed with `derived_subgroup`, `sylow_subgroup`, etc.,
+  get the same degree as the given group.
+- The range `1:degree(G)` is used as the default set of points on which
+  `G` and its element acts.
+
+!!! note
+    The degree of a group of permutations is not necessarily equal to the largest moved point of the group `G`. For example, the trivial subgroup of `symmetric_group(n)` has degree `n` even though it fixes `n`.
+
+# Examples
+```jldoctest
+julia> degree(symmetric_group(4))
+4
+
+julia> t4 = trivial_subgroup(symmetric_group(4))[1];
+
+julia> degree(t4)
+4
+
+julia> t4 == trivial_subgroup(symmetric_group(5))[1]
+false
+
+julia> show(Vector(gen(symmetric_group(4), 2)))
+[2, 1, 3, 4]
+julia> show(Vector(gen(symmetric_group(5), 2)))
+[2, 1, 3, 4, 5]
+```
+"""
+degree(x::PermGroup) = x.deg
+
+@gapattribute moved_points(x::Union{PermGroupElem,PermGroup}) = [y for y in GAP.gap_to_julia(GAP.Globals.MovedPoints(x.X))]
+# This is more efficient than `Vector{Int}(GAP.Globals.MovedPoints(x.X))`.
+# (And note that `GAP.gap_to_julia(GAP.Globals.MovedPoints(G.X))` may return
+# a range.)
+"""
+    moved_points(x::PermGroupElem)
+    moved_points(G::PermGroup)
+
+Return the vector of those points in `1:degree(x)` or `1:degree(G)`,
+respectively, that are not mapped to themselves under the action `^`.
+
+# Examples
+```jldoctest
+julia> g = symmetric_group(4);  s = sylow_subgroup(g, 3)[1];
+
+julia> length(moved_points(s))
+3
+
+julia> length(moved_points(gen(s, 1)))
+3
+
+```
+""" moved_points
+
+@gapattribute number_moved_points(x::Union{PermGroupElem,PermGroup}) = fmpz(GAP.Globals.NrMovedPoints(x.X))::fmpz
+"""
+    number_moved_points(::Type{T} = fmpz, x::PermGroupElem) where T <: IntegerUnion
+    number_moved_points(::Type{T} = fmpz, G::PermGroup) where T <: IntegerUnion
+
+Return the number of those points in `1:degree(x)` or `1:degree(G)`,
+respectively, that are not mapped to themselves under the action `^`,
+as an instance of `T`.
+
+# Examples
+```jldoctest
+julia> g = symmetric_group(4);  s = sylow_subgroup(g, 3)[1];
+
+julia> number_moved_points(s)
+3
+
+julia> number_moved_points(Int, s)
+3
+
+julia> number_moved_points(gen(s, 1))
+3
+
+```
+""" number_moved_points
+
+number_moved_points(::Type{T}, x::Union{PermGroupElem,PermGroup}) where T <: IntegerUnion = T(GAP.Globals.NrMovedPoints(x.X))::T
+
+# FIXME: clashes with AbstractAlgebra.perm method
+#function perm(L::AbstractVector{<:Base.Integer})
+#   return PermGroupElem(symmetric_group(length(L)), GAP.Globals.PermList(GAP.GapObj(L;recursive=true)))
+#end
+# FIXME: use name gap_perm for now
+@doc Markdown.doc"""
+    gap_perm(L::AbstractVector{<:Base.Integer})
+
+Return the permutation $x$ which maps every $i$ from `1` to $n$` = length(L)`
+to `L`$[i]$.
+The parent of $x$ is set to [`symmetric_group`](@ref)$(n)$.
+An exception is thrown if `L` does not contain every integer from 1 to $n$
+exactly once.
+
+# Examples
+```jldoctest
+julia> gap_perm([2,4,6,1,3,5])
+(1,2,4)(3,6,5)
+```
+"""
+function gap_perm(L::AbstractVector{<:IntegerUnion})
+  return PermGroupElem(symmetric_group(length(L)), GAP.Globals.PermList(GAP.GapObj(L;recursive=true)))
+end
+
+@doc Markdown.doc"""
+    perm(G::PermGroup, L::AbstractVector{<:Integer})
+    (G::PermGroup)(L::AbstractVector{<:Integer})
+
+Return the permutation $x$ which maps every `i` from 1 to $n$` = length(L)`
+to `L`$[i]$.
+The parent of $x$ is `G`.
+An exception is thrown if $x$ is not contained in `G`
+or `L` does not contain every integer from 1 to $n$ exactly once.
+
+For [`gap_perm`](@ref),
+the parent group of $x$ is set to [`symmetric_group`](@ref)$(n)$.
+
+# Examples
+```jldoctest
+julia> perm(symmetric_group(6),[2,4,6,1,3,5])
+(1,2,4)(3,6,5)
+```
+"""
+function perm(g::PermGroup, L::AbstractVector{<:Base.Integer})
+   x = GAP.Globals.PermList(GAP.GapObj(L;recursive=true))
+   if length(L) <= degree(g) && GAP.Globals.IN(x,g.X) 
+     return PermGroupElem(g, x)
+   end
+   throw(ArgumentError("the element does not embed in the group"))
+end
+
+perm(g::PermGroup, L::AbstractVector{<:fmpz}) = perm(g, [Int(y) for y in L])
+
+function (g::PermGroup)(L::AbstractVector{<:Base.Integer})
+   x = GAP.Globals.PermList(GAP.GapObj(L;recursive=true))
+   if length(L) <= degree(g) && GAP.Globals.IN(x,g.X)
+     return PermGroupElem(g, x)
+   end
+   throw(ArgumentError("the element does not embed in the group"))
+end
+
+(g::PermGroup)(L::AbstractVector{<:fmpz}) = g([Int(y) for y in L])
+
+# cperm stays for "cycle permutation", but we can change name if we want
+# takes as input a list of vectors (not necessarly disjoint)
+@doc Markdown.doc"""
+    cperm(L::AbstractVector{<:T}...) where T <: IntegerUnion
+    cperm(G::PermGroup, L::AbstractVector{<:T}...)
+
+For given lists $[a_1, a_2, \ldots, a_n], [b_1, b_2, \ldots , b_m], \ldots$
+of positive integers, return the
+permutation $x = (a_1, a_2, \ldots, a_n) * (b_1, b_2, \ldots, b_m) * \ldots$.
+Arrays of the form `[n, n+1, ..., n+k]` can be replaced by `n:n+k`.
+
+The parent of $x$ is `G`.
+If `G` is not specified then the parent of $x$ is set to
+[`symmetric_group`](@ref)$(n)$,
+where $n$ is the largest integer that occurs in an entry of `L`.
+
+An exception is thrown if $x$ is not contained in `G`
+or one of the given vectors is empty or contains duplicates.
+
+# Examples
+```jldoctest
+julia> cperm([1,2,3],4:7)
+(1,2,3)(4,5,6,7)
+
+julia> cperm([1,2],[2,3])
+(1,3,2)
+
+julia> p = cperm([1,2,3],[7])
+(1,2,3)
+
+julia> degree(parent(p))
+7
+
+```
+
+At the moment, the input vectors of the function `cperm` need not be disjoint.
+
+!!! warning
+    If the function `perm` is evaluated in a vector of integers
+    without specifying the group `G`,
+    then the returned value is an element of the AbstractAlgebra.jl type
+    `Perm{Int}`.
+    For this reason, if one wants a permutation of type
+    `GAPGroupElem{PermGroup}` without specifying a parent,
+    one has to use the function `gap_perm`.
+"""
+function cperm(L::AbstractVector{T}...) where T <: IntegerUnion
+   if length(L)==0
+      return one(symmetric_group(1))
+   else
+      return prod([PermGroupElem(symmetric_group(maximum(y)), GAP.Globals.CycleFromList(GAP.julia_to_gap([Int(k) for k in y]))) for y in L])
+#TODO: better create the product of GAP permutations?
+   end
+end
+
+# cperm stays for "cycle permutation", but we can change name if we want
+# takes as input a list of vectors (not necessarly disjoint)
+# WARNING: we allow e.g. PermList([2,3,1,4,5,6]) in Sym(3)
+function cperm(g::PermGroup,L::AbstractVector{T}...) where T <: IntegerUnion
+   if length(L)==0
+      return one(g)
+   else
+      x=prod(y -> GAP.Globals.CycleFromList(GAP.julia_to_gap([Int(k) for k in y])), L)
+      if length(L) <= degree(g) && GAP.Globals.IN(x,g.X)
+         return PermGroupElem(g, x)
+      else
+         throw(ArgumentError("the element does not embed in the group"))
+      end
+   end
+end
+
+@deprecate listperm(x::PermGroupElem) Vector(x)
+
+"""
+    Vector{T}(x::PermGroupElem, n::Int = x.parent.deg) where T <: IntegerUnion
+    Vector(x::PermGroupElem, n::Int = x.parent.deg)
+
+Return the list of length `n` that contains `x(i)` at position `i`. If not specified, `T` is set as `Int`.
+
+# Examples
+```jldoctest
+julia> pi = cperm(1:3)
+(1,2,3)
+julia> Vector(pi)
+3-element Vector{Int64}:
+ 2
+ 3
+ 1
+julia> Vector(pi, 2)
+2-element Vector{Int64}:
+ 2
+ 3
+julia> Vector(pi, 4)
+4-element Vector{Int64}:
+ 2
+ 3
+ 1
+ 4
+julia> Vector{fmpz}(pi, 2)
+2-element Vector{fmpz}:
+ 2
+ 3
+
+```
+"""
+Base.Vector{T}(x::PermGroupElem, n::Int = x.parent.deg) where T <: IntegerUnion = T[x(i) for i in 1:n]
+Base.Vector(x::PermGroupElem, n::Int = x.parent.deg) = Vector{Int}(x,n)
+
+Base.sign(x::PermGroupElem) = GAP.Globals.SignPerm(x.X)::Int
+
+#embedding of a permutation in permutation group
+function (G::PermGroup)(x::PermGroupElem)
+   if !GAP.Globals.IN(x.X,G.X)
+      throw(ArgumentError("the element does not embed in the group"))
+   end
+   return group_element(G, x.X)
+end
+
+#evaluation function
+function (x::PermGroupElem)(n::T) where T <: IntegerUnion
+   return T(GAP.Globals.OnPoints(GAP.GapObj(n), x.X))
+end
+
+(x::PermGroupElem)(n::Int) = GAP.Globals.OnPoints(n,x.X)
+
+^(n::T, x::PermGroupElem) where T <: IntegerUnion = T(GAP.Globals.OnPoints(GAP.GapObj(n), x.X))
+
+^(n::Int, x::PermGroupElem) = GAP.Globals.OnPoints(n,x.X)

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -67,7 +67,8 @@ end
 """
     issubgroup(G::T, H::T) where T <: GAPGroup
 
-Return (`true`,`f`) if `H` is a subgroup of `G`, where `f` is the embedding homomorphism of `H` into `G`, otherwise return (`false`,`nothing`).
+Return (`true`,`f`) if `H` is a subgroup of `G`, where `f` is the embedding
+homomorphism of `H` into `G`, otherwise return (`false`,`nothing`).
 """
 function issubgroup(G::T, H::T) where T <: GAPGroup
    if !all(h -> h in G, gens(H))
@@ -295,7 +296,9 @@ end
 """
     quo(G::T, elements::Vector{S})
 
-Return the quotient group `G/H` of type `FPGroup` (if `T`=`FPGroup`), `PcGroup` (if the quotient group is solvable) or `PermGroup` (otherwise), where `H` is the normal closure of `elements` in `G`.
+Return the quotient group `G/H` of type `FPGroup` (if `T`=`FPGroup`),
+`PcGroup` (if the quotient group is solvable) or `PermGroup` (otherwise),
+where `H` is the normal closure of `elements` in `G`.
 """
 function quo(G::T, elements::Vector{S}) where T <: GAPGroup where S <: GAPGroupElem
   @assert elem_type(G) == S
@@ -310,7 +313,9 @@ end
 """
     quo(G::T, H::T)
 
-Return the quotient group `G/H` of type `PcGroup` (if the quotient group is solvable) or `PermGroup` (otherwise), together with the projection `G` -> `G/H`.
+Return the quotient group `G/H` of type `PcGroup` (if the quotient group is
+solvable) or `PermGroup` (otherwise), together with the projection `G` ->
+`G/H`.
 """
 function quo(G::T, H::T) where T <: GAPGroup
   mp = GAP.Globals.NaturalHomomorphismByNormalSubgroup(G.X, H.X)

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -1,5 +1,4 @@
 import Base.intersect
-import GAP.@gapattribute
 
 export
     centralizer,

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -275,7 +275,8 @@ end
 """
     SemidirectProductGroup{S,T}
 
-Semidirect product of two groups of type `S` and `T` respectively, or subgroup of a semidirect product of groups.
+Semidirect product of two groups of type `S` and `T` respectively, or
+subgroup of a semidirect product of groups.
 """
 struct SemidirectProductGroup{S<:GAPGroup, T<:GAPGroup} <: GAPGroup 
   X::GapObj
@@ -289,7 +290,9 @@ end
 """
     WreathProductGroup
 
-Wreath product of a group `G` and a group of permutations `H`, or a generic group `H` together with the homomorphism `a` from `H` to a permutation group.
+Wreath product of a group `G` and a group of permutations `H`, or a generic
+group `H` together with the homomorphism `a` from `H` to a permutation
+group.
 """
 struct WreathProductGroup <: GAPGroup
   X::GapObj

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -89,6 +89,9 @@ and `MatrixGroup`.
 """
 abstract type GAPGroup <: AbstractAlgebra.Group end
 
+## `GapGroup` to GAP group
+GAP.GapObj(obj::GAPGroup) = return obj.X
+
 @doc Markdown.doc"""
     GAPGroupElem <: AbstractAlgebra.GroupElem
 
@@ -100,6 +103,9 @@ For expert usage, you can extract the underlying GAP object via `GapObj`,
 i.e., if `g` is a `GAPGroupElem`, then `GapObj(g)` is the `GapObj` underlying `g`.
 """
 abstract type GAPGroupElem{T<:GAPGroup} <: AbstractAlgebra.GroupElem end
+
+## `GapGroupElem` to GAP group element
+GAP.GapObj(obj::GAPGroupElem) = return obj.X
 
 @doc Markdown.doc"""
     BasicGAPGroupElem{T<:GAPGroup} <: GAPGroupElem{T}

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -326,7 +326,7 @@ parent_type(::T) where T<:BasicGAPGroupElem{S} where S = S
 # Julia type such as `PermGroup`.
 #
  
-const _gap_group_types = []
+const _gap_group_types = Tuple{GAP.GapObj, Type}[]
 
 function _get_type(G::GapObj)
   for pair in _gap_group_types
@@ -336,4 +336,3 @@ function _get_type(G::GapObj)
   end
   error("Not a known type of group")
 end
-

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -236,6 +236,7 @@ include("GAP/gap_to_oscar.jl")
 include("GAP/oscar_to_gap.jl")
 
 include("Groups/types.jl")
+include("Groups/perm.jl")
 include("Groups/group_constructors.jl")
 include("Groups/sub.jl")
 include("Groups/homomorphisms.jl")

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -227,15 +227,15 @@ end
 
 function weights end
 
-include("Groups/types.jl")
-
 include("Rings/Hecke.jl") #does all the importing from Hecke - to define names
 
 include("printing.jl")
 
+include("GAP/GAP.jl")
 include("GAP/gap_to_oscar.jl")
 include("GAP/oscar_to_gap.jl")
 
+include("Groups/types.jl")
 include("Groups/group_constructors.jl")
 include("Groups/sub.jl")
 include("Groups/homomorphisms.jl")

--- a/test/GAP/oscar_to_gap.jl
+++ b/test/GAP/oscar_to_gap.jl
@@ -3,14 +3,12 @@
     x = fmpz(17)
     val = 17
     @test GAP.julia_to_gap(x) == val
-    @test convert(GAP.GapObj, x) == val
     @test GAP.GapObj(x) == val
 
     # large GAP integer
     x = fmpz(2)^65
     val = GAP.evalstr("2^65")
     @test GAP.julia_to_gap(x) == val
-    @test convert(GAP.GapObj, x) == val
     @test GAP.GapObj(x) == val
 end
 
@@ -19,28 +17,24 @@ end
     x = fmpz(17)
     val = 17
     @test GAP.julia_to_gap(x) == val
-    @test convert(GAP.GapObj, x) == val
     @test GAP.GapObj(x) == val
 
     # large GAP integer
     x = fmpz(2)^65
     val = GAP.evalstr("2^65")
     @test GAP.julia_to_gap(x) == val
-    @test convert(GAP.GapObj, x) == val
     @test GAP.GapObj(x) == val
 
     # non-integer rational, small numerator and denominator
     x = fmpq(2, 3)
     val = GAP.evalstr("2/3")
     @test GAP.julia_to_gap(x) == val
-    @test convert(GAP.GapObj, x) == val
     @test GAP.GapObj(x) == val
 
     # non-integer rational, large numerator and denominator
     x = fmpq(fmpz(2)^65, fmpz(3)^40)
     val = GAP.evalstr("2^65/3^40")
     @test GAP.julia_to_gap(x) == val
-    @test convert(GAP.GapObj, x) == val
     @test GAP.GapObj(x) == val
 end
 
@@ -49,14 +43,12 @@ end
     x = Nemo.ZZ[1 2; 3 4]
     val = GAP.evalstr( "[ [ 1, 2 ], [ 3, 4 ] ]" )
     @test GAP.julia_to_gap(x) == val
-    @test convert(GAP.GapObj, x) == val
     @test GAP.GapObj(x) == val
 
     # matrix containing small and large integers
     x = Nemo.ZZ[1 BigInt(2)^65; 3 4]
     val = GAP.evalstr( "[ [ 1, 2^65 ], [ 3, 4 ] ]" )
     @test GAP.julia_to_gap(x) == val
-    @test convert(GAP.GapObj, x) == val
     @test GAP.GapObj(x) == val
 end
 
@@ -65,28 +57,24 @@ end
     x = Nemo.QQ[1 2; 3 4]
     val = GAP.evalstr( "[ [ 1, 2 ], [ 3, 4 ] ]" )
     @test GAP.julia_to_gap(x) == val
-    @test convert(GAP.GapObj, x) == val
     @test GAP.GapObj(x) == val
 
     # matrix containing small and large integers
     x = Nemo.QQ[1 BigInt(2)^65; 3 4]
     val = GAP.evalstr( "[ [ 1, 2^65 ], [ 3, 4 ] ]" )
     @test GAP.julia_to_gap(x) == val
-    @test convert(GAP.GapObj, x) == val
     @test GAP.GapObj(x) == val
 
     # matrix containing non-integer rationals, small numerator and denominator
     x = Nemo.QQ[fmpq(1, 2) 2; 3 4]
     val = GAP.evalstr( "[ [ 1/2, 2 ], [ 3, 4 ] ]" )
     @test GAP.julia_to_gap(x) == val
-    @test convert(GAP.GapObj, x) == val
     @test GAP.GapObj(x) == val
 
     # matrix containing non-integer rationals, large numerator and denominator
     x = Nemo.QQ[fmpq(fmpz(2)^65, fmpz(3)^40) 2; 3 4]
     val = GAP.evalstr( "[ [ 2^65/3^40, 2 ], [ 3, 4 ] ]" )
     @test GAP.julia_to_gap(x) == val
-    @test convert(GAP.GapObj, x) == val
     @test GAP.GapObj(x) == val
 end
 
@@ -95,17 +83,9 @@ end
     G = symmetric_group(5)
     val = GAP.evalstr("SymmetricGroup(5)")
     @test GAP.GapObj(G) == val
-    @test convert(GAP.GapObj, G) == val
 
     # `GapGroupElem` to GAP group element, Perm
     g = perm(G, [2,3,1,5,4])
     val = GAP.evalstr("(1,2,3)(4,5)")
     @test GAP.GapObj(g) == val
-    @test convert(GAP.GapObj, g) == val
-
-    # test implicit conversion
-    V = GAP.GapObj[]
-    push!(V, G) # convert GAPGroup to GapObj implicitly
-    push!(V, g) # convert GAPGroupElem to GapObj implicitly
-    @test V == [GAP.GapObj(G), GAP.GapObj(g)]
 end


### PR DESCRIPTION
- Remove convert(:GapObj,...) methods
- Add src/GAP/GAP.jl and move some stuff there
- Move two GapObj constructors next to struct defs
- bib: add 'Permutation Groups' by Peter Cameron
- Move some permutations code to new file src/Groups/perm.jl
- Set specific type for Oscar._gap_group_types
- Wrap some overly long lines
- Add iseven(g::PermGroupElem), cycle_structure(g::PermGroupElem)
