### PR TITLE
Reynolds operator and bases of invariant rings

### DIFF
--- a/experimental/InvariantTheory/InvariantTheory.jl
+++ b/experimental/InvariantTheory/InvariantTheory.jl
@@ -1,1 +1,2 @@
+include("types.jl")
 include("invariant_rings.jl")

--- a/experimental/InvariantTheory/InvariantTheory.jl
+++ b/experimental/InvariantTheory/InvariantTheory.jl
@@ -1,2 +1,3 @@
 include("types.jl")
 include("invariant_rings.jl")
+include("iterators.jl")

--- a/experimental/InvariantTheory/invariant_rings.jl
+++ b/experimental/InvariantTheory/invariant_rings.jl
@@ -706,8 +706,11 @@ julia> molien_series(IR)
 ```
 """
 function molien_series(I::InvRing)
-  S, t = PolynomialRing(QQ, "t", cached = false)
-  return molien_series(S, I)
+  if !isdefined(I, :molien_series)
+    S, t = PolynomialRing(QQ, "t", cached = false)
+    I.molien_series = molien_series(S, I)
+  end
+  return I.molien_series
 end
 
 

--- a/experimental/InvariantTheory/invariant_rings.jl
+++ b/experimental/InvariantTheory/invariant_rings.jl
@@ -89,7 +89,7 @@ function right_action(R::MPolyRing{T}, M::MatrixElem{T}) where T
     end
   end
 
-  right_action_by_M(f::MPolyElem{T}) = evaluate(f, vars)
+  right_action_by_M = (f::MPolyElem{T}) -> evaluate(f, vars)
 
   return MapFromFunc(right_action_by_M, R, R)
 end

--- a/experimental/InvariantTheory/invariant_rings.jl
+++ b/experimental/InvariantTheory/invariant_rings.jl
@@ -367,10 +367,10 @@ AbstractAlgebra.Generic.MatSpaceElem{nf_elem}[[0 0 1; 1 0 0; 0 1 0], [1 0 0; 0 a
 
 julia> basis(IR, 6)
 4-element Vector{MPolyElem_dec{nf_elem, AbstractAlgebra.Generic.MPoly{nf_elem}}}:
- x[1]^2*x[2]^2*x[3]^2
- x[1]^3*x[2]^3 + x[1]^3*x[3]^3 + x[2]^3*x[3]^3
- x[1]^4*x[2]*x[3] + x[1]*x[2]^4*x[3] + x[1]*x[2]*x[3]^4
  x[1]^6 + x[2]^6 + x[3]^6
+ x[1]^4*x[2]*x[3] + x[1]*x[2]^4*x[3] + x[1]*x[2]*x[3]^4
+ x[1]^3*x[2]^3 + x[1]^3*x[3]^3 + x[2]^3*x[3]^3
+ x[1]^2*x[2]^2*x[3]^2
 ```
 ```
 julia> M = matrix(GF(3), [0 1 0; -1 0 0; 0 0 -1])
@@ -389,24 +389,16 @@ gfp_mat[[0 1 0; 2 0 0; 0 0 2]]
 
 julia> basis(IR, 2)
 2-element Vector{MPolyElem_dec{gfp_elem, gfp_mpoly}}:
- x[3]^2
  x[1]^2 + x[2]^2
+ x[3]^2
 
 julia> basis(IR, 3)
 2-element Vector{MPolyElem_dec{gfp_elem, gfp_mpoly}}:
- x[1]*x[2]*x[3]
  x[1]^2*x[3] + 2*x[2]^2*x[3]
+ x[1]*x[2]*x[3]
 ```
 """
-function basis(IR::InvRing, d::Int)
-  # TODO: Fine tune this: Depending on d and the group order it is better
-  # to use "via_linear_algebra" also in the non-modular case.
-  if ismodular(IR)
-    return basis_via_linear_algebra(IR, d)
-  else
-    return basis_via_reynolds(IR, d)
-  end
-end
+basis(IR::InvRing, d::Int, algo = :default) = collect(iterate_basis(IR, d, algo))
 
 function primary_invariants_via_singular(IR::InvRing)
   if !isdefined(IR, :primary_singular)

--- a/experimental/InvariantTheory/iterators.jl
+++ b/experimental/InvariantTheory/iterators.jl
@@ -66,7 +66,7 @@ function Base.iterate(AM::AllMonomials, s::Vector{Int})
 end
 
 function Base.show(io::IO, AM::AllMonomials)
-  print(io, "Iterator over the monomials of degree $(AM.d) of\n")
+  println(io, "Iterator over the monomials of degree $(AM.d) of")
   print(io, AM.R)
 end
 
@@ -181,7 +181,7 @@ Base.eltype(BI::InvRingBasisIterator) = elem_type(polynomial_ring(BI.R))
 Base.length(BI::InvRingBasisIterator) = BI.dim
 
 function Base.show(io::IO, BI::InvRingBasisIterator)
-  print(io, "Iterator over a basis of the component of degree $(BI.degree) of\n")
+  println(io, "Iterator over a basis of the component of degree $(BI.degree) of")
   print(io, BI.R)
 end
 

--- a/experimental/InvariantTheory/iterators.jl
+++ b/experimental/InvariantTheory/iterators.jl
@@ -1,0 +1,192 @@
+# Iterate over all vectors in Z_{\geq 0}^n of weight (sum of the entries d)
+WeightedIntegerVectors(n::T, d::T) where T = WeightedIntegerVectors{T}(n, d)
+
+Base.eltype(WIV::WeightedIntegerVectors{T}) where T = Vector{T}
+
+# We are basically doing d-multicombinations of n here and those are "the same"
+# as d-combinations of n + d - 1 (according to Knuth).
+function Base.length(WIV::WeightedIntegerVectors{T}) where T
+  if iszero(WIV.d)
+    return 0
+  end
+  return binomial(Int(WIV.n + WIV.d - 1), Int(WIV.d))
+end
+
+function Base.iterate(WIV::WeightedIntegerVectors{T}, state::Nothing = nothing) where T
+  if WIV.n == 0 || WIV.d == 0
+    return nothing
+  end
+
+  c = zeros(T, WIV.n)
+  c[1] = WIV.d
+  s = zeros(T, WIV.n)
+  if isone(WIV.n)
+    s[1] = WIV.d + 1
+    return (c, s)
+  end
+
+  s[1] = WIV.d - 1
+  s[2] = T(1)
+  return (c, s)
+end
+
+function Base.iterate(WIV::WeightedIntegerVectors{T}, s::Vector{T}) where T
+  n = WIV.n
+  d = WIV.d
+  if s[n] == d + 1
+    return nothing
+  end
+  c = copy(s)
+  if s[n] == d
+    s[n] += 1
+    return (c, s)
+  end
+
+  for i = n - 1:-1:1
+    if !iszero(s[i])
+      s[i] -= 1
+      if i + 1 == n
+        s[n] += 1
+      else
+        s[i + 1] = 1
+        if !iszero(s[n])
+          s[i + 1] += s[n]
+          s[n] = 0
+        end
+      end
+      return (c, s)
+    end
+  end
+end
+
+# Returns an iterator over all monomials of R of degree d
+function all_monomials(R::MPolyRing, d::Int)
+  @assert d >= 0
+  oneR = elem_type(base_ring(R))[ one(base_ring(R)) ]
+  exps = Vector{Int}[ zeros(Int, nvars(R)) ]
+
+  function new_elt(w::Vector{Int})
+    exps[1] = w
+    return R(oneR, exps)
+  end
+  return ( new_elt(w) for w in WeightedIntegerVectors(nvars(R), d))
+end
+
+# Iterate over the basis of the degree d component of an invariant ring.
+# algo can be either :default, :reynolds or :linear_algebra.
+function InvRingBasisIterator(R::InvRing{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT}, d::Int, algo::Symbol = :default) where {FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT}
+  @assert d >= 0 "Degree must be non-negativ"
+
+  Qt, t = PowerSeriesRing(QQ, d + 1, "t")
+  F = molien_series(R)
+  k = coeff(numerator(F)(t)*inv(denominator(F)(t)), d) # Dimension of the d-th component
+  @assert isintegral(k)
+  k = Int(numerator(k))
+  reynolds = false
+  if algo == :reynolds
+    reynolds = true
+  elseif algo == :linear_algebra
+    reynolds = false
+  elseif algo == :default
+    # TODO: Fine tune this: Depending on d and the group order it is better
+    # to use "via_linear_algebra" also in the non-modular case.
+    if ismodular(R)
+      reynolds = false
+    else
+      reynolds = true
+    end
+  else
+    error("Unsupported argument :$(algo) for algo.")
+  end
+
+  monomials = all_monomials(polynomial_ring(R), d)
+  return InvRingBasisIterator{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT, typeof(monomials)}(R, d, k, reynolds, monomials)
+end
+
+Base.eltype(BI::InvRingBasisIterator{FldT, GrpT, PolyElemT}) where {FldT, GrpT, PolyElemT} = PolyElemT
+
+Base.length(BI::InvRingBasisIterator) = BI.dim
+
+function Base.iterate(BI::InvRingBasisIterator)
+  if BI.dim == 0
+    return nothing
+  end
+
+  @assert BI.reynolds "Not implemented (yet)"
+
+  K = base_ring(polynomial_ring(BI.R))
+
+  monomial_to_basis = Dict{elem_type(polynomial_ring(BI.R)), Int}()
+
+  if BI.degree == 0
+    M = zero_matrix(K, 1, 0)
+    state = 1 # Just a dummy
+    return one(polynomial_ring(BI.R)), InvRingBasisIteratorState{typeof(M), elem_type(polynomial_ring(BI.R)), Int}(M, monomial_to_basis, state)
+  end
+
+  state = nothing
+  while true
+    fstate = iterate(BI.monomials, state)
+    if fstate === nothing
+      error("No monomials left")
+    end
+    f = fstate[1]
+    state = fstate[2]
+
+    g = reynolds_operator(BI.R, f)
+    if iszero(g)
+      continue
+    end
+    M = zero_matrix(K, 1, length(g))
+    i = 1
+    for (c, m) in zip(coefficients(g), monomials(g))
+      monomial_to_basis[m] = i
+      M[1, i] = c
+      i += 1
+    end
+    return g, InvRingBasisIteratorState{typeof(M), typeof(g), typeof(state)}(M, monomial_to_basis, state)
+  end
+end
+
+function Base.iterate(BI::InvRingBasisIterator, state::InvRingBasisIteratorState)
+  @assert BI.reynolds "Not implemented (yet)"
+
+  if nrows(state.M) == BI.dim
+    return nothing
+  end
+
+  K = base_ring(polynomial_ring(BI.R))
+
+  M = state.M
+  monomial_state = state.monomial_iter_state
+  while true
+    fmonomial_state = iterate(BI.monomials, monomial_state)
+    if fmonomial_state === nothing
+      error("No monomials left")
+    end
+    f = fmonomial_state[1]
+    monomial_state = fmonomial_state[2]
+
+    g = reynolds_operator(BI.R, f)
+    if iszero(g)
+      continue
+    end
+    N = vcat(M, zero_matrix(K, 1, ncols(M)))
+    new_basis_mon = false
+    for (c, m) in zip(coefficients(g), monomials(g))
+      if !haskey(state.monomial_to_basis, m)
+        new_basis_mon = true
+        state.monomial_to_basis[m] = ncols(N) + 1
+        N = hcat(N, zero_matrix(K, nrows(N), 1))
+      end
+      col = state.monomial_to_basis[m]
+      N[nrows(N), col] = c
+    end
+    if new_basis_mon || rref!(N) == nrows(M) + 1
+      return g, InvRingBasisIteratorState{typeof(N), typeof(g), typeof(monomial_state)}(N, state.monomial_to_basis, monomial_state)
+    end
+  end
+end
+
+iterate_basis(IR::InvRing, d::Int, algo::Symbol = :default) = InvRingBasisIterator(IR, d, algo)
+

--- a/experimental/InvariantTheory/iterators.jl
+++ b/experimental/InvariantTheory/iterators.jl
@@ -65,6 +65,11 @@ function Base.iterate(AM::AllMonomials, s::Vector{Int})
   end
 end
 
+function Base.show(io::IO, AM::AllMonomials)
+  print(io, "Iterator over the monomials of degree $(AM.d) of\n")
+  print(io, AM.R)
+end
+
 ################################################################################
 #
 #  Bases of Invariant Rings
@@ -174,6 +179,11 @@ end
 Base.eltype(BI::InvRingBasisIterator) = elem_type(polynomial_ring(BI.R))
 
 Base.length(BI::InvRingBasisIterator) = BI.dim
+
+function Base.show(io::IO, BI::InvRingBasisIterator)
+  print(io, "Iterator over a basis of the component of degree $(BI.degree) of\n")
+  print(io, BI.R)
+end
 
 function Base.iterate(BI::InvRingBasisIterator)
   if BI.reynolds

--- a/experimental/InvariantTheory/types.jl
+++ b/experimental/InvariantTheory/types.jl
@@ -49,44 +49,23 @@ mutable struct InvRing{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularAction
   end
 end
 
-struct WeightedIntegerVectors{T}
-  n::T
-  d::T
+struct AllMonomials{PolyRingT}
+  R::PolyRingT
+  d::Int
 
-  function WeightedIntegerVectors{T}(n::T, d::T) where {T <: Union{Integer, fmpz}}
-    @assert n >= 0 && d >= 0
-    return new{T}(n, d)
+  function AllMonomials{PolyRingT}(R::PolyRingT, d::Int) where PolyRingT
+    @assert d >= 0
+    return new{PolyRingT}(R, d)
   end
 end
 
-struct InvRingBasisIterator{InvRingT, IteratorT, MatrixT}
+struct InvRingBasisIterator{InvRingT, IteratorT, PolyElemT, MatrixT}
   R::InvRingT
   degree::Int
   dim::Int
   reynolds::Bool
 
   monomials::IteratorT
+  monomials_collected::Vector{PolyElemT}
   kernel::MatrixT # used iff reynolds == false
-end
-
-mutable struct InvRingBasisIteratorState{MatrixT, PolyElemT, MonIterStateT}
-  M::MatrixT
-  monomial_to_basis::Dict{PolyElemT, Int}
-  monomial_iter_state::MonIterStateT
-
-  i::Int # used iff reynolds == false
-
-  function InvRingBasisIteratorState{MatrixT, PolyElemT, MonIterStateT}(M::MatrixT, monomial_to_basis::Dict{PolyElemT, Int}, monomial_iter_state::MonIterStateT) where {MatrixT, PolyElemT, MonIterStateT}
-    z = new{MatrixT, PolyElemT, MonIterStateT}()
-    z.M = M
-    z.monomial_to_basis = monomial_to_basis
-    z.monomial_iter_state = monomial_iter_state
-    return z
-  end
-
-  function InvRingBasisIteratorState{MatrixT, PolyElemT, MonIterStateT}(i::Int) where {MatrixT, PolyElemT, MonIterStateT}
-    z = new{MatrixT, PolyElemT, MonIterStateT}()
-    z.i = i
-    return z
-  end
 end

--- a/experimental/InvariantTheory/types.jl
+++ b/experimental/InvariantTheory/types.jl
@@ -48,3 +48,27 @@ mutable struct InvRing{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularAction
     return z
   end
 end
+
+struct WeightedIntegerVectors{T}
+  n::T
+  d::T
+
+  function WeightedIntegerVectors{T}(n::T, d::T) where {T <: Union{Integer, fmpz}}
+    @assert n >= 0 && d >= 0
+    return new{T}(n, d)
+  end
+end
+
+struct InvRingBasisIterator{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT, IteratorT}
+  R::InvRing{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT}
+  degree::Int
+  dim::Int
+  reynolds::Bool
+  monomials::IteratorT
+end
+
+struct InvRingBasisIteratorState{MatrixT, PolyElemT, MonIterStateT}
+  M::MatrixT
+  monomial_to_basis::Dict{PolyElemT, Int}
+  monomial_iter_state::MonIterStateT
+end

--- a/experimental/InvariantTheory/types.jl
+++ b/experimental/InvariantTheory/types.jl
@@ -59,16 +59,34 @@ struct WeightedIntegerVectors{T}
   end
 end
 
-struct InvRingBasisIterator{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT, IteratorT}
-  R::InvRing{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT}
+struct InvRingBasisIterator{InvRingT, IteratorT, MatrixT}
+  R::InvRingT
   degree::Int
   dim::Int
   reynolds::Bool
+
   monomials::IteratorT
+  kernel::MatrixT # used iff reynolds == false
 end
 
-struct InvRingBasisIteratorState{MatrixT, PolyElemT, MonIterStateT}
+mutable struct InvRingBasisIteratorState{MatrixT, PolyElemT, MonIterStateT}
   M::MatrixT
   monomial_to_basis::Dict{PolyElemT, Int}
   monomial_iter_state::MonIterStateT
+
+  i::Int # used iff reynolds == false
+
+  function InvRingBasisIteratorState{MatrixT, PolyElemT, MonIterStateT}(M::MatrixT, monomial_to_basis::Dict{PolyElemT, Int}, monomial_iter_state::MonIterStateT) where {MatrixT, PolyElemT, MonIterStateT}
+    z = new{MatrixT, PolyElemT, MonIterStateT}()
+    z.M = M
+    z.monomial_to_basis = monomial_to_basis
+    z.monomial_iter_state = monomial_iter_state
+    return z
+  end
+
+  function InvRingBasisIteratorState{MatrixT, PolyElemT, MonIterStateT}(i::Int) where {MatrixT, PolyElemT, MonIterStateT}
+    z = new{MatrixT, PolyElemT, MonIterStateT}()
+    z.i = i
+    return z
+  end
 end

--- a/experimental/InvariantTheory/types.jl
+++ b/experimental/InvariantTheory/types.jl
@@ -1,0 +1,50 @@
+mutable struct InvRing{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT}
+  field::FldT
+  poly_ring::PolyRingT
+
+  group::GrpT
+  action::Vector{ActionT}
+  action_singular::Vector{SingularActionT}
+
+  modular::Bool
+
+  primary::Vector{PolyElemT}
+  secondary::Vector{PolyElemT}
+  irreducible_secondary::Vector{PolyElemT}
+  fundamental::Vector{PolyElemT}
+
+  reynolds_operator::MapFromFunc{PolyRingT, PolyRingT}
+
+  molien_series::Generic.Frac{fmpq_poly}
+
+  # Cache some stuff on the Singular side
+  # (possibly removed at some point)
+  reynolds_singular::Singular.smatrix
+  molien_singular::Singular.smatrix
+  primary_singular # the type is different depending on the characteristic...
+
+  function InvRing(K::FldT, G::GrpT, action::Vector{ActionT}) where {FldT <: Field, GrpT <: AbstractAlgebra.Group, ActionT}
+    n = degree(G)
+    R, = grade(PolynomialRing(K, "x" => 1:n, cached = false)[1], ones(Int, n))
+    R_sing = singular_ring(R)
+    action_singular = identity.([change_base_ring(R_sing, g) for g in action])
+    PolyRingT = typeof(R)
+    PolyElemT = elem_type(R)
+    SingularActionT = eltype(action_singular)
+    z = new{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT}()
+    z.field = K
+    z.poly_ring = R
+    z.group = G
+    z.action = action
+    z.action_singular = action_singular
+    z.modular = true
+    if iszero(characteristic(K))
+      z.modular = false
+    else
+      if !iszero(mod(order(G), characteristic(K)))
+        z.modular = false
+      end
+    end
+    return z
+  end
+end

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -199,12 +199,8 @@ function (W::MPolyRing_dec)(f::MPolyElem)
   return MPolyElem_dec(f, W)
 end
 
-function (W::MPolyRing_dec)(a)
-  return W(W.R(a))
-end
-
-function (W::MPolyRing_dec)(a, b)
-  return W(W.R(a, b))
+function (W::MPolyRing_dec)(a...)
+  return W(W.R(a...))
 end
 
 (W::MPolyRing_dec)(g::MPolyElem_dec) = MPolyElem_dec(g.f, W)

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -203,6 +203,10 @@ function (W::MPolyRing_dec)(a)
   return W(W.R(a))
 end
 
+function (W::MPolyRing_dec)(a, b)
+  return W(W.R(a, b))
+end
+
 (W::MPolyRing_dec)(g::MPolyElem_dec) = MPolyElem_dec(g.f, W)
 one(W::MPolyRing_dec) = MPolyElem_dec(one(W.R), W)
 zero(W::MPolyRing_dec) = MPolyElem_dec(zero(W.R), W)

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -161,7 +161,7 @@ function grade(R::MPolyRing, v::Vector{GrpAbFinGenElem})
   return S, map(S, gens(R))
 end
 
-struct MPolyElem_dec{T, S} <: MPolyElem{T}
+mutable struct MPolyElem_dec{T, S} <: MPolyElem{T}
   f::S
   parent
   function MPolyElem_dec(f::S, p) where {S}
@@ -330,6 +330,11 @@ function push_term!(M::MPolyBuildCtx{<:MPolyElem_dec{T, S}}, c::T, expv::Vector{
   set_exponent_vector!(M.poly.f, len, expv)
   setcoeff!(M.poly.f, len, c)
   return M
+end
+
+function set_exponent_vector!(f::MPolyElem_dec, i::Int, exps::Vector{Int})
+  f.f = set_exponent_vector!(f.f, i, exps)
+  return f
 end
 
 function finish(M::MPolyBuildCtx{<:MPolyElem_dec})

--- a/test/InvariantTheory/invariant_rings-test.jl
+++ b/test/InvariantTheory/invariant_rings-test.jl
@@ -16,7 +16,11 @@
   @test mol == (-t^6 - t^3 - 1)//(t^12 - 2t^9 + 2t^3 - 1)
 
   @test length(basis(RG, 1)) == 0
+  @test length(basis(RG, 1, :reynolds)) == 0
+  @test length(basis(RG, 1, :linear_algebra)) == 0
   @test length(basis(RG, 3)) == 3
+  @test length(basis(RG, 3, :reynolds)) == 3
+  @test length(basis(RG, 3, :linear_algebra)) == 3
 
   primaries = primary_invariants(RG)
   @test dim(ideal(R, primaries)) == 0
@@ -50,7 +54,11 @@
   @test mol == (-t^4 - 1)//(t^8 - 2t^6 + 2t^2 - 1)
 
   @test length(basis(RG, 1)) == 0
+  @test length(basis(RG, 1, :reynolds)) == 0
+  @test length(basis(RG, 1, :linear_algebra)) == 0
   @test length(basis(RG, 2)) == 2
+  @test length(basis(RG, 2, :reynolds)) == 2
+  @test length(basis(RG, 2, :linear_algebra)) == 2
 
   primaries = primary_invariants(RG)
   @test dim(ideal(R, primaries)) == 0


### PR DESCRIPTION
I implemented the Reynolds operator and functions to compute the basis of a homogeneous component of an invariant ring directly in Oscar.
There is now a function `iterate_basis` which gives an iterator of the basis. If one uses the "linear algebra method" this doesn't change a lot, but when using the Reynolds operator it does as one only needs to compute exactly as many invariants as one wants.