### PR TITLE
Fix performance regression

### DIFF
--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -40,8 +40,8 @@ function groebner_assure(I::MPolyIdeal; complete_reduction::Bool = false)
     else
       I.gb = BiPolyArray(base_ring(I), Singular.std(I.gens.S))
     end
+    I.gb.O = [I.gb.Ox(x) for x = gens(I.gb.S)]
   end
-  I.gb.O = [I.gb.Ox(x) for x = gens(I.gb.S)]
 end
 
 @doc Markdown.doc"""


### PR DESCRIPTION
This was introduced by accident in #647.

Set `I.gb.O` once and for all. Conversions are expensive and this slows downs everything.

CC: @ederc, @8d1h 
