### PR TITLE
allow for custom path in build_doc

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -158,9 +158,9 @@ function open_doc()
     end
 end
 
-function build_doc(; doctest=false, strict=false)
+function build_doc(; doctest=false, strict=false, path=mktempdir())
   if !isdefined(Main, :BuildDoc)
-    doc_init()
+    doc_init(path=path)
   end
   Pkg.activate(docsproject) do
     Base.invokelatest(Main.BuildDoc.doit, Oscar; strict=strict, local_build=true, doctest=doctest)


### PR DESCRIPTION
In the following situation, one has no choice but to edit `src/Oscar.jl`. The hope is now that one can do `Oscar.build.doc(path="/my/writable/tmp")`.
```
julia> Oscar.build_doc()
   Resolving package versions...
ERROR: SystemError: opening file "/tmp/jl_xcWLRT/Project.toml": Permission denied
```