### PR TITLE
docs: fix incorrect `Pages` entries in @contents blocks

### DIFF
--- a/docs/src/CommutativeAlgebra/affine_algebras.md
+++ b/docs/src/CommutativeAlgebra/affine_algebras.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["ca_affine_algebras.md"]
+Pages = ["affine_algebras.md"]
 ```
 
 # Affine Algebras

--- a/docs/src/CommutativeAlgebra/binomial_ideals.md
+++ b/docs/src/CommutativeAlgebra/binomial_ideals.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["ca_binomial_ideals.md"]
+Pages = ["binomial_ideals.md"]
 ```
 
 # Binomial Primary Decomposition

--- a/docs/src/CommutativeAlgebra/ideals.md
+++ b/docs/src/CommutativeAlgebra/ideals.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["ca_ideals.md"]
+Pages = ["ideals.md"]
 ```
 
 # Ideals in Polynomial Rings

--- a/docs/src/CommutativeAlgebra/intro.md
+++ b/docs/src/CommutativeAlgebra/intro.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["ca.md"]
+Pages = ["intro.md"]
 ```
 
 # Introduction

--- a/docs/src/CommutativeAlgebra/modules.md
+++ b/docs/src/CommutativeAlgebra/modules.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["ca_modules.md"]
+Pages = ["modules.md"]
 ```
 
 # Modules Over Polynomial Rings

--- a/docs/src/CommutativeAlgebra/quotient_rings.md
+++ b/docs/src/CommutativeAlgebra/quotient_rings.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["ca_quotient_rings.md"]
+Pages = ["quotient_rings.md"]
 ```
 
 # Quotient Rings of Polynomial Rings

--- a/docs/src/CommutativeAlgebra/rings.md
+++ b/docs/src/CommutativeAlgebra/rings.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["ca_rings.md"]
+Pages = ["rings.md"]
 ```
 
 # Creating Polynomial Rings

--- a/docs/src/InvariantTheory/finite_groups.md
+++ b/docs/src/InvariantTheory/finite_groups.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["it_fg.md"]
+Pages = ["finite_groups.md"]
 ```
 
 # Invariants of Finite Groups

--- a/docs/src/InvariantTheory/intro.md
+++ b/docs/src/InvariantTheory/intro.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["it.md"]
+Pages = ["intro.md"]
 ```
 
 # Introduction

--- a/docs/src/PolyhedralGeometry/Polyhedra/auxiliary.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/auxiliary.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["pg_polyhedra_auxiliary.md"]
+Pages = ["auxiliary.md"]
 ```
 
 

--- a/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["pg_polyhedra_constructions.md"]
+Pages = ["constructions.md"]
 ```
 
 # Constructions

--- a/docs/src/PolyhedralGeometry/Polyhedra/intro.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/intro.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["pg_polyhedra_intro.md"]
+Pages = ["intro.md"]
 ```
 
 # Introduction

--- a/docs/src/PolyhedralGeometry/Polyhedra/polymake.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/polymake.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["pg_polyhedra_polymake.md"]
+Pages = ["polymake.md"]
 ```
 
 

--- a/docs/src/PolyhedralGeometry/Polyhedra/serialization.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/serialization.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["pg_polyhedra_serialization.md"]
+Pages = ["serialization.md"]
 ```
 
 

--- a/docs/src/PolyhedralGeometry/cones.md
+++ b/docs/src/PolyhedralGeometry/cones.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["pg_cones.md"]
+Pages = ["cones.md"]
 ```
 
 # Cones

--- a/docs/src/PolyhedralGeometry/fans.md
+++ b/docs/src/PolyhedralGeometry/fans.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["pg_fans.md"]
+Pages = ["fans.md"]
 ```
 
 # Polyhedral Fans

--- a/docs/src/PolyhedralGeometry/graphs.md
+++ b/docs/src/PolyhedralGeometry/graphs.md
@@ -8,7 +8,7 @@ using Oscar.Graphs
 ```
 
 ```@contents
-Pages = ["pg_graphs.md"]
+Pages = ["graphs.md"]
 ```
 
 # Graphs

--- a/docs/src/PolyhedralGeometry/intro.md
+++ b/docs/src/PolyhedralGeometry/intro.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["pg.md"]
+Pages = ["intro.md"]
 ```
 
 # Introduction

--- a/docs/src/PolyhedralGeometry/linear_programs.md
+++ b/docs/src/PolyhedralGeometry/linear_programs.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["pg_linear_programs.md"]
+Pages = ["linear_programs.md"]
 ```
 
 # Linear Programs

--- a/docs/src/PolyhedralGeometry/subdivisions_of_points.md
+++ b/docs/src/PolyhedralGeometry/subdivisions_of_points.md
@@ -7,7 +7,7 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["pg_subdivision_of_points.md"]
+Pages = ["subdivision_of_points.md"]
 ```
 
 # Subdivisions of Points


### PR DESCRIPTION
When I renamed the files in docs/src for consistency, I missed these
