### PR TITLE
move some code from `experimental/GaloisGrp`

### DIFF
--- a/docs/src/Groups/permgroup.md
+++ b/docs/src/Groups/permgroup.md
@@ -90,7 +90,6 @@ iseven(g::PermGroupElem)
 cycle_structure(g::PermGroupElem)
 ```
 
-
 ## Permutations as functions
 A permutation can be viewed as a function on the set `{1,...,n}`, hence it can be evaluated on integers.
 
@@ -106,4 +105,18 @@ julia> x(2)
 
 julia> x(6)
 6
+```
+
+## Operations for permutation groups
+
+```@docs
+istransitive(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
+transitivity(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
+isprimitive(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
+isregular(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
+issemiregular(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
+blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
+maximal_blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
+representatives_minimal_blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
+all_blocks(G::PermGroup)
 ```

--- a/experimental/GaloisGrp/GaloisGrp.jl
+++ b/experimental/GaloisGrp/GaloisGrp.jl
@@ -5,7 +5,7 @@ import Base: ^, +, -, *, ==
 import Oscar: Hecke, AbstractAlgebra, GAP
 using Oscar: SLPolyRing, SLPoly, SLPolynomialRing
 
-export galois_group, transitive_group_identification, slpoly_ring, elementary_symmetric,
+export galois_group, slpoly_ring, elementary_symmetric,
        power_sum, to_elementary_symmetric, cauchy_ideal, galois_ideal, fixed_field,
        extension_field
 
@@ -876,8 +876,8 @@ function invariant(G::PermGroup, H::PermGroup)
         return E
       end
 
-      sG = set_stabilizer(G, BB)[1]
-      sH = set_stabilizer(H, BB)[1]
+      sG = stabilizer(G, BB, on_sets)[1]
+      sH = stabilizer(H, BB, on_sets)[1]
       hG = action_homomorphism(sG, BB)
       ssG = image(hG, sG)[1]
       ssH = image(hG, sH)[1]
@@ -1196,7 +1196,7 @@ function starting_group(GC::GaloisCtx, K::AnticNumberField; useSubfields::Bool =
 
     #TODO: wrap this properly
     G = Oscar._as_subgroup(G, GAP.Globals.Solve(GAP.julia_to_gap(vcat(GAP.Globals.ConInGroup(G.X), [GAP.Globals.ConStabilize(GAP.julia_to_gap(sort(o), Val(true)), GAP.Globals.OnSetsSets) for o in O]))))[1]
-    #@show G = intersect([stabilizer(G, GAP.julia_to_gap(sort(o), Val(true)), GAP.Globals.OnSetsSets)[1] for o=O]...)[1]
+    #@show G = intersect([stabilizer(G, sort(o), on_sets_sets)[1] for o=O]...)[1]
   end
 
   si = G(si)
@@ -1324,7 +1324,7 @@ function galois_group(K::AnticNumberField, extra::Int = 5; useSubfields::Bool = 
 end
 
 @doc Markdown.doc"""
-    descent(GC::GaloisCtx, G::PermGroup, F::GroupFilter, si::PermGroupElem; grp_id = transitive_group_identification, extra::Int = 5)
+    descent(GC::GaloisCtx, G::PermGroup, F::GroupFilter, si::PermGroupElem; grp_id = transitive_identification, extra::Int = 5)
 
 Performs a generic Stauduhar descent: starting with the group `G` that needs to be a 
 supergroup of the Galois group, operating on the roots in `GC`, the context object.
@@ -1332,7 +1332,7 @@ supergroup of the Galois group, operating on the roots in `GC`, the context obje
 The groups are filtered by `F` and the result needs to contain the permutation `si`.
 For verbose output, the groups are printed through `grp_id`.
 """
-function descent(GC::GaloisCtx, G::PermGroup, F::GroupFilter, si::PermGroupElem; grp_id = transitive_group_identification, extra::Int = 5)
+function descent(GC::GaloisCtx, G::PermGroup, F::GroupFilter, si::PermGroupElem; grp_id = transitive_identification, extra::Int = 5)
   @vprint :GaloisGroup 2 "Have starting group with id $(grp_id(G))\n"
 
   p = GC.C.p
@@ -1803,7 +1803,7 @@ include("Qt.jl")
 end
 
 using .GaloisGrp
-export galois_group, transitive_group_identification, slpoly_ring, elementary_symmetric,
+export galois_group, slpoly_ring, elementary_symmetric,
        power_sum, to_elementary_symmetric, cauchy_ideal, galois_ideal, fixed_field, 
        maximal_subgroup_reps, extension_field
        

--- a/experimental/GaloisGrp/Group.jl
+++ b/experimental/GaloisGrp/Group.jl
@@ -56,7 +56,7 @@ function low_index_subgroups(G::PermGroup, n::Int)
 end
 
 """
-An ascending chain of minimual supergroups linking `U` and `G`.
+An ascending chain of minimal supergroups linking `U` and `G`.
 Not a good algorithm, but Max' version `RefinedChain` does not produce
 minimal supergroups, ie. it fails in ``C_4``.
 """
@@ -74,35 +74,10 @@ function maximal_subgroup_chain(G::PermGroup, U::PermGroup)
   return [Oscar._as_subgroup(G, x)[1] for x = ll]
 end
 
-function transitive_group_identification(G::PermGroup)
-  if degree(G) > 31
-    return -1
-  end
-  return GAP.Globals.TransitiveIdentification(G.X)
-end
-
 # TODO: add a GSet Julia type which does something similar Magma's,
 # or also to GAP's ExternalSet (but don't use ExternalSet, to avoid the overhead)
 
-function all_blocks(G::PermGroup)
-  # TODO: this returns an array of arrays;
-  # TODO: AllBlocks assumes that we act on MovedPoints(G), which
-  # may NOT be what we want...
-  return GAP.gap_to_julia(Vector{Vector{Int}}, GAP.Globals.AllBlocks(G.X))
-end
-
-# TODO: update stabilizer to use GSet
-# TODO: allow specifying actions other than the default
-function stabilizer(G::Oscar.GAPGroup, seed, act)
-    return Oscar._as_subgroup(G, GAP.Globals.Stabilizer(G.X, GAP.julia_to_gap(seed), act))
-end
-
 # TODO: add type BlockSystem
-
-# TODO: perhaps get rid of set_stabilizer again, once we have proper Gsets
-function set_stabilizer(G::Oscar.GAPGroup, seed::Vector{Int})
-    return stabilizer(G, GAP.julia_to_gap(seed), GAP.Globals.OnSets)
-end
 
 # TODO: add lots of more orbit related stuff
 

--- a/experimental/GaloisGrp/Qt.jl
+++ b/experimental/GaloisGrp/Qt.jl
@@ -177,7 +177,7 @@ function galois_group(FF::Generic.FunctionField{fmpq})
     @vprint :GaloisGroup 1 "specialising at t = $tStart, computing over Q\n"
     Gal, S = galois_group(K, prime = p)
 
-    @vprint :GaloisGroup 1 "after specialisation, group is: $(transitive_group_identification(Gal))\n"
+    @vprint :GaloisGroup 1 "after specialisation, group is: $(transitive_identification(Gal))\n"
 
 #    @show S.start, S.chn
 

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -36,7 +36,7 @@ The following ones are commonly used.
 
 import Base: ^, *
 
-export on_tuples, on_sets, on_indeterminates, permuted
+export on_tuples, on_sets, on_sets_sets, on_indeterminates, permuted
 
 """
 We try to avoid introducing `on_points` and `on_right`.
@@ -167,6 +167,58 @@ function on_sets(set::T, x::GAPGroupElem) where T <: Tuple
 end
 
 ^(set::T, x::GAPGroupElem) where T <: Set = on_sets(set, x)
+
+"""
+    on_sets_sets(set::GAP.GapObj, x::GAPGroupElem)
+    on_sets_sets(set::Vector{T}, x::GAPGroupElem) where T
+    on_sets_sets(set::T, x::GAPGroupElem) where T <: Union{Tuple, Set}
+
+Return the image of `set` under `x`,
+where the action is given by applying `on_sets` to the entries
+of `set`, and then turning the result into a sorted vector/tuple or a set,
+respectively.
+
+# Examples
+```jldoctest
+julia> g = symmetric_group(3);  g[1]
+(1,2,3)
+
+julia> l = GAP.julia_to_gap([[1, 2], [3, 4]], recursive = true)
+GAP: [ [ 1, 2 ], [ 3, 4 ] ]
+
+julia> on_sets_sets(l, g[1])
+GAP: [ [ 1, 4 ], [ 2, 3 ] ]
+
+julia> on_sets_sets([[1, 2], [3, 4]], g[1])
+2-element Vector{Vector{Int64}}:
+ [1, 4]
+ [2, 3]
+
+julia> on_sets_sets(((1,2), (3,4)), g[1])
+((1, 4), (2, 3))
+
+julia> on_sets_sets(Set([[1, 2], [3, 4]]), g[1])
+Set{Vector{Int64}} with 2 elements:
+  [1, 4]
+  [2, 3]
+
+```
+"""
+on_sets_sets(set::GAP.GapObj, x::GAPGroupElem) = GAP.Globals.OnSetsSets(set, x.X)
+
+function on_sets_sets(set::Vector{T}, x::GAPGroupElem) where T
+    res = T[on_sets(pnt, x) for pnt in set]
+    sort!(res)
+    return res
+end
+
+on_sets_sets(set::T, x::GAPGroupElem) where T <: Set = T([on_sets(pnt, x) for pnt in set])
+
+function on_sets_sets(set::T, x::GAPGroupElem) where T <: Tuple
+    res = [on_sets(pnt, x) for pnt in set]
+    sort!(res)
+    return T(res)
+end
 
 
 """

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -12,6 +12,7 @@ if isdefined(Hecke, :isprimitive)
 end
 
 export
+    all_blocks,
     blocks,
     isprimitive,
     isregular,
@@ -389,7 +390,7 @@ acting_domain(Omega::GSet) = Omega.group
 blocks(G::GSet) = error("not implemented")
 maximal_blocks(G::GSet) = error("not implemented")
 representatives_minimal_blocks(G::GSet) = error("not implemented")
-allblocks(G::GSet) = error("not implemented")
+all_blocks(G::GSet) = error("not implemented")
 
 function istransitive(Omega::GSet)
     length(Omega.seeds) == 1 && return true
@@ -409,115 +410,108 @@ isprimitive(G::GSet) = error("not implemented")
 """
     blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
 
-Return a block system for the action of `G` over `L`, i.e. a minimal
-non-trivial partition of `L` preserved by the action of `G`. Here, `L`
-must be a subvector of [1..degree(`G`)] and it is considered only the
-action of `H` on `L`, where `H` is the subgroup of `G` that moves only
-points in `L`.
+Return a block system for the action of `G` on `L`, i.e.,
+a non-trivial partition of `L` preserved by the action of `G`.
+
+Here, `L` must be a subvector of `1:degree(G)` on which `G` acts transitively.
+`G` may move points outside `L`, in this case the restriction of the action
+of the set stabilizer of `L` in `G` to `L` is considered.
 
 An exception is thrown if this action is not transitive.
 """
-function blocks(G::PermGroup, L::AbstractVector{Int})
-   @assert istransitive(G,L) "The group action is not transitive"
-   l = GAP.gap_to_julia(GAP.Globals.Blocks(G.X, GAP.julia_to_gap(L)))
-   return [ [y for y in l1] for l1 in l]              # to return a vector of integers
+function blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
+   @assert istransitive(G, L) "The group action is not transitive"
+   return Vector{Vector{Int}}(GAP.Globals.Blocks(G.X, GAP.GapObj(L)))
 end
 
-blocks(G::PermGroup) = blocks(G,[i for i in GAP.gap_to_julia(GAP.Globals.MovedPoints(G.X))])
 
 """
     maximal_blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
 
-Return a maximal block system for the action of `G` over `L`, i.e. a
-maximal non-trivial partition of `L` preserved by the action of `G`.
-Here, `L` must be a subvector of [1..degree(`G`)] and it is considered only
-the action of `H` on `L`, where `H` is the subgroup of `G` that moves
-only points in `L`.
+Return a maximal block system for the action of `G` on `L`, i.e.,
+a maximal non-trivial partition of `L` preserved by the action of `G`.
+
+Here, `L` must be a subvector of `1:degree(G)` on which `G` acts transitively.
+`G` may move points outside `L`, in this case the restriction of the action
+of the set stabilizer of `L` in `G` to `L` is considered.
 
 An exception is thrown if this action is not transitive.
 """
-function maximal_blocks(G::PermGroup, L::AbstractVector{Int})
-   @assert istransitive(G,L) "The group action is not transitive"
-   l = GAP.gap_to_julia(GAP.Globals.MaximalBlocks(G.X, GAP.julia_to_gap(L)))
-   return [ [y for y in l1] for l1 in l]              # to return a vector of integers
+function maximal_blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
+   @assert istransitive(G, L) "The group action is not transitive"
+   return Vector{Vector{Int}}(GAP.Globals.MaximalBlocks(G.X, GAP.GapObj(L)))
 end
 
-maximal_blocks(G::PermGroup) = maximal_blocks(G,[i for i in GAP.gap_to_julia(GAP.Globals.MovedPoints(G.X))])
 
 """
     representatives_minimal_blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
 
 Return a list of block representatives for all minimal non-trivial block
-systems for the action of `G` over `L`. Here, `L` must be a subvector of
-[1..degree(`G`)] and it is considered only the action of `H` on `L`, where
-`H` is the subgroup of `G` that moves only points in `L`.
+systems for the action of `G` on `L`.
+
+Here, `L` must be a subvector of `1:degree(G)` on which `G` acts transitively.
+`G` may move points outside `L`, in this case the restriction of the action
+of the set stabilizer of `L` in `G` to `L` is considered.
 
 An exception is thrown if this action is not transitive.
 """
-function representatives_minimal_blocks(G::PermGroup, L::AbstractVector{Int})
-   @assert istransitive(G,L) "The group action is not transitive"
-   l = GAP.gap_to_julia(GAP.Globals.RepresentativesMinimalBlocks(G.X, GAP.julia_to_gap(L)))
-   return [ [y for y in l1] for l1 in l]              # to return a vector of integers
+function representatives_minimal_blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
+   @assert istransitive(G, L) "The group action is not transitive"
+   return Vector{Vector{Int}}(GAP.Globals.RepresentativesMinimalBlocks(G.X, GAP.GapObj(L)))
 end
 
-representatives_minimal_blocks(G::PermGroup) = minimal_blocks(G,[i for i in GAP.gap_to_julia(GAP.Globals.MovedPoints(G.X))])
 
 """
-    allblocks(G::PermGroup)
+    all_blocks(G::PermGroup)
 
 Return a list of representatives of all block systems for the action of
 `G` on the set of moved points of `G`.
 """
-function allblocks(G::PermGroup)
-   l = GAP.gap_to_julia(GAP.Globals.AllBlocks(G.X))
-   return [ [y for y in l1] for l1 in l]              # to return a vector of integers
-end
+all_blocks(G::PermGroup) = Vector{Vector{Int}}(GAP.Globals.AllBlocks(G.X))
+#TODO: Do we really want to act on the set of moved points?
+
 
 """
-    transitivity(G::PermGroup, L::AbstractVector{Int})
+    transitivity(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
 
-Return the maximum `k` such that the action of `G` over `L` is
-`k`-transitive. The output is `0` if `G` is not transitive. If `L` is
-not specified, then `L` is taken as [1,...,degree(`G`)].
+Return the maximum `k` such that the action of `G` on `L` is
+`k`-transitive. The output is `0` if `G` is not transitive on `L`.
 """
-transitivity(G::PermGroup, L::AbstractVector{Int}) = GAP.Globals.Transitivity(G.X, GAP.julia_to_gap(L))
-transitivity(G::PermGroup) = GAP.Globals.Transitivity(G.X, GAP.julia_to_gap(1:G.deg))
+transitivity(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAP.Globals.Transitivity(G.X, GAP.GapObj(L))
 
 """
-    istransitive(G::PermGroup, L::AbstractVector{Int})
+    istransitive(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
 
-Return whether the action of the group `G` on `L` is transitive. If `L`
-is not specified, then `L` is taken as [1,...,degree(`G`)].
+Return whether the action of `G` on `L` is transitive.
 """
-istransitive(G::PermGroup, L::AbstractVector{Int}) = GAP.Globals.IsTransitive(G.X, GAP.julia_to_gap(L))
-istransitive(G::PermGroup) = GAP.Globals.IsTransitive(G.X, GAP.julia_to_gap(1:G.deg))
+istransitive(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAP.Globals.IsTransitive(G.X, GAP.GapObj(L))
+# Note that this definition does not coincide with that of the
+# property `GAP.Globals.IsTransitive`, for which the default domain
+# of the action is the set of moved points.
 
-"""
-    isprimitive(G::PermGroup, L::AbstractVector{Int})
-
-Return whether the action of the group `G` on `L` is primitive. If `L`
-is not specified, then `L` is taken as [1,...,degree(`G`)].
-"""
-isprimitive(G::PermGroup, L::AbstractVector{Int}) = GAP.Globals.IsPrimitive(G.X, GAP.julia_to_gap(L))
-isprimitive(G::PermGroup) = GAP.Globals.IsPrimitive(G.X, GAP.julia_to_gap(1:G.deg))
 
 """
-    isregular(G::PermGroup, L::AbstractVector{Int})
+    isprimitive(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
 
-Return whether the action of the group `G` on `L` is regular (i.e.
-transitive and semiregular). If `L` is not specified, then `L` is taken
-as [1,...,degree(`G`)].
+Return whether the action of `G` on `L` is primitive, that is,
+the action is transitive and the point stabilizers are maximal in `G`.
 """
-isregular(G::PermGroup, L::AbstractVector{Int}) = GAP.Globals.IsRegular(G.X, GAP.julia_to_gap(L))
-isregular(G::PermGroup) = GAP.Globals.IsRegular(G.X, GAP.julia_to_gap(1:G.deg))
+isprimitive(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAP.Globals.IsPrimitive(G.X, GAP.GapObj(L))
+
 
 """
-    issemiregular(G::PermGroup, L::AbstractVector{Int})
+    isregular(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
 
-Return whether the action of the group `G` on `L` is semiregular (i.e.
-the stabilizer of each point is the identity). If `L` is not specified,
-then `L` is taken as [1,...,degree(`G`)].
+Return whether the action of `G` on `L` is regular
+(i.e., transitive and semiregular).
 """
-issemiregular(G::PermGroup, L::AbstractVector{Int}) = GAP.Globals.IsSemiRegular(G.X, GAP.julia_to_gap(L))
-issemiregular(G::PermGroup) = GAP.Globals.IsSemiRegular(G.X, GAP.julia_to_gap(1:G.deg))
+isregular(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAP.Globals.IsRegular(G.X, GAP.GapObj(L))
 
+
+"""
+    issemiregular(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
+
+Return whether the action of `G` on `L` is semiregular
+(i.e., the stabilizer of each point is the identity).
+"""
+issemiregular(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAP.Globals.IsSemiRegular(G.X, GAP.GapObj(L))

--- a/src/Groups/libraries/transitivegroups.jl
+++ b/src/Groups/libraries/transitivegroups.jl
@@ -29,10 +29,55 @@ end
 """
     transitive_identification(G::PermGroup)
 
-Return `(deg, m)` such that `G` is permutation isomorphic with
-`transitive_group(deg, m)`.
+Return `m` such that `G` is permutation isomorphic with
+`transitive_group(d, m)`, where `G` is transitive on `d` points,
+with `d < 32`.
+
+If `G` moves more than 31 points then `-1` is returned.
+Otherwise, if `G` is not transitive on its moved points then `0` is returned,
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(7);  m = transitive_identification(G)
+7
+
+julia> order(transitive_group(7, m)) == order(G)
+true
+
+julia> S = sub(G, [gap_perm([1, 3, 4, 5, 2])])[1]
+Group([ (2,3,4,5) ])
+
+julia> istransitive(S)
+false
+
+julia> istransitive(S, moved_points(S))
+true
+
+julia> m = transitive_identification(S)
+1
+
+julia> order(transitive_group(4, m)) == order(S)
+true
+
+julia> transitive_identification(symmetric_group(32))
+-1
+
+julia> S = sub(G, [gap_perm([1,3,4,5,2,7,6])])[1];
+
+julia> istransitive(S, moved_points(S))
+false
+
+julia> transitive_identification(S)
+0
+```
 """
-transitive_identification(G::PermGroup) = GAP.Globals.TransitiveIdentification(G.X)
+function transitive_identification(G::PermGroup)
+  moved = moved_points(G)
+  length(moved) < 32 || return -1
+  istransitive(G, moved) || return 0
+  return GAP.Globals.TransitiveIdentification(G.X)
+end
+
 
 """
     all_transitive_groups(L...)

--- a/test/Examples/galois-test.jl
+++ b/test/Examples/galois-test.jl
@@ -3,12 +3,10 @@
   Zx, x = ZZ["x"]
   k, a = number_field(x^5-2)
   G, C = galois_group(k)
-  @test transitive_group_identification(G) == 3
+  @test transitive_identification(G) == 3
 
   U = trivial_subgroup(G)[1]
   L = fixed_field(C, U)
   @test degree(L) == order(G)
   @test length(roots(k.pol, L)) == 5
 end
-
-

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -136,3 +136,60 @@
   @test ! rep[1]
 
 end
+
+@testset "natural action of permutation groups" begin
+
+  G8 = transitive_group(8, 3)
+  S4 = symmetric_group(4)
+  @test order(G8) == 8
+
+  # all_blocks
+  bl = all_blocks(G8)
+  @test length(bl) == 14
+  @test [1, 2] in bl
+  @test length(all_blocks(S4)) == 0
+
+  # blocks
+  bl = blocks(G8)
+  @test bl == [[1, 8], [2, 3], [4, 5], [6, 7]]
+  @test bl == blocks(G8, 1:degree(G8))
+
+  # isprimitive
+  @test ! isprimitive(G8)
+  @test ! isprimitive(G8, 1:degree(G8))
+  @test isprimitive(S4)
+  @test isprimitive(S4, 1:3)
+
+  # isregular
+  @test isregular(G8)
+  @test ! isregular(G8, 1:9)
+  @test ! isregular(S4)
+
+  # issemiregular
+  @test issemiregular(G8)
+  @test ! issemiregular(G8, 1:9)
+  @test ! issemiregular(S4)
+
+  # istransitive
+  @test istransitive(G8)
+  @test ! istransitive(G8, 1:9)
+
+  # maximal_blocks
+  bl = maximal_blocks(G8)
+  @test bl == [[1, 2, 3, 8], [4, 5, 6, 7]]
+  @test bl == maximal_blocks(G8, 1:degree(G8))
+  @test maximal_blocks(S4) == [[1, 2, 3, 4]]
+
+  # representatives_minimal_blocks
+  bl = representatives_minimal_blocks(G8)
+  @test bl == [[1,i] for i in 2:8]
+  @test bl == representatives_minimal_blocks(G8, 1:degree(G8))
+  @test representatives_minimal_blocks(S4) == [[1, 2, 3, 4]]
+
+  # transitivity
+  @test transitivity(G8) == 1
+  @test transitivity(S4) == 4
+  @test transitivity(S4, 1:3) == 3
+  @test transitivity(S4, 1:5) == 0
+
+end


### PR DESCRIPTION
- moved `all_blocks` and `transitive_identification` from `experimental/GaloisGrp` to `src/Groups`
  (and removed `allblocks`)
- adjusted `experimental/GaloisGrp` to the availability of `stabilizer`
- added `on_sets_sets`
- corrected the documentation and simplified the code for `transitive_identification` and functions related to blocks, transitivity, primitivity etc.
- added the docstrings for these functions to the manual
- extended some tests

### Conceptual question:

Function calls like `istransitive(G)` need a default for the domain of the action.

Currently we define `1:degree(G)` as the default for `istransitive`, `transitivity`, `isprimitive`, `isregular`, `issemiregular`.
And we define `moved_points(G)` as the default for `blocks`, `maximal_blocks`, `representatives_minimal_blocks`.
I think we should use a consistent default. (GAP uses the set of moved points in all cases.)

In all these cases, it is just the question about a default, one can always specify the domain via an optional argument.
`all_blocks` is different, it does not admit such an optional argument, probably because already `GAP.Globals.AllBlocks` supports only one argument. (And I do not know why this is the case.)