### PR TITLE
Add Oscar back to docs/Project.toml

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,7 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 DocumenterMarkdown = "997ab1e6-3595-5248-9280-8efb232c3433"
+Oscar = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
 
 [compat]
 DocumenterCitations = "0.2.5"


### PR DESCRIPTION
This was useful for me to be able to run doctests conveniently. But it breaks CI, and I don't quite understand why... so I reverted it on master (lesson once again reinforced: don't push to master, even for "obviously harmless changes". Perhaps I'll even learn it)