### PR TITLE
SubQuo: add type annotation to fix crash with julia 1.7 and nightly

### DIFF
--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -1734,7 +1734,7 @@ Return the `i`th generator of `F`.
 """
 function gen(F::SubQuo{T}, i::Int) where T
   R = base_ring(F)
-  v = sparse_row(R)
+  v::SRow{T} = sparse_row(R)
   v.pos = [i]
   v.values = [R(1)]
   return SubQuoElem{T}(v, F)


### PR DESCRIPTION
fixes #735, similar to the [fix](https://github.com/oscar-system/Oscar.jl/commit/b6ad35b2edd0ff767c699b00457e9d9255d1902d) on the #731 branch.

to reproduce the original crash after the fix:
```julia
using Oscar
R, (x, y) = PolynomialRing(QQ, ["x", "y"])
I = ideal(R, [zero(R)])
Q, q = quo(R,I)
f = q(x*y)
b = divides(one(Q), f) == (false, one(Q))
A1 = R[x y;
      2*x^2 3*y^2]
B = R[4*x*y^3 (2*x+y)]
F2 = FreeMod(R,2)
M1 = SubQuo(F2, A1, B)
M = M1
N = M1
M_quo = M.quo
N_quo = N.quo
R = base_ring(M)
F1 = FreeMod(R, ngens(M.sub) + ngens(N.sub) + ngens(M_quo))
F2 = free_module(M)
phi = FreeModuleHom(F1,F2,vcat(gens(M.sub),gens(N.sub),gens(M_quo)))
K,i = kernel(phi)
function mygen(F::SubQuo{T}, i::Int) where T
  R = base_ring(F)
  v = sparse_row(R)
  v.pos = [i]
  v.values = [R(1)]
  return SubQuoElem{T}(v, F)
end
mygen(K,1)
```