### PR TITLE
Toric variety structs

### DIFF
--- a/src/Polytopes/PolyhedralFan/constructors.jl
+++ b/src/Polytopes/PolyhedralFan/constructors.jl
@@ -105,6 +105,12 @@ function PolyhedralFan(Rays::Union{Oscar.MatElem,AbstractMatrix}, Incidence::Mat
    PolyhedralFan(Rays,IncidenceMatrix(Polymake.IncidenceMatrix(Incidence)))
 end
 
+
+function PolyhedralFan(C::Cone)
+    pmfan = Polymake.fan.check_fan_objects(pm_cone(C))
+    return PolyhedralFan(pmfan)
+end
+
 ###############################################################################
 ###############################################################################
 ### Display

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -40,17 +40,18 @@ A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
 ```
 """
 function AffineNormalToricVariety(C::Cone)
-    pmc = Oscar.pm_cone(C)
-    fan = Polymake.fan.check_fan_objects(pmc)
-    pmntv = Polymake.fulton.NormalToricVariety(fan)
+    fan = PolyhedralFan(C)
+    pmntv = Polymake.fulton.NormalToricVariety(Oscar.pm_fan(fan))
     return AffineNormalToricVariety(pmntv)
 end
 
 
 @doc Markdown.doc"""
     NormalToricVariety(C::Cone)
+
 Construct the (affine) normal toric variety $X_{\Sigma}$ corresponding to a
 polyhedral fan $\Sigma = C$ consisting only of the cone `C`.
+
 # Examples
 Set `C` to be the positive orthant in two dimensions.
 ```jldoctest
@@ -61,7 +62,9 @@ A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
 ```
 """
 function NormalToricVariety(C::Cone)
-    return AffineNormalToricVariety(C)
+    fan = PolyhedralFan(C)
+    pmntv = Polymake.fulton.NormalToricVariety(Oscar.pm_fan(fan))
+    return NormalToricVariety(pmntv)
 end
 
 
@@ -86,9 +89,6 @@ A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
 function NormalToricVariety(PF::PolyhedralFan)
     fan = Oscar.pm_fan(PF)
     pmntv = Polymake.fulton.NormalToricVariety(fan)
-    if fan.N_MAXIMAL_CONES == 1
-        return AffineNormalToricVariety( pmntv )
-    end
     return NormalToricVariety(pmntv)
 end
 
@@ -131,18 +131,19 @@ A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
 """
 function NormalToricVariety( rays::Matrix{Int}, cones::Vector{Vector{Int}} )
     Incidence = Oscar.IncidenceMatrix(cones)
-    # arr = Polymake.@convert_to Array{Set{Int}} Polymake.common.rows(Incidence.pm_incidencematrix)
     pmntv = Polymake.fulton.NormalToricVariety(
         RAYS = Oscar.matrix_for_polymake(rays),
         MAXIMAL_CONES = Incidence,
     )
-    if length( cones ) == 1
-        return AffineNormalToricVariety( pmntv )
-    end    
-    return NormalToricVariety( pmntv )
+    return NormalToricVariety(pmntv)
 end
 
 export NormalToricVariety
+
+function AffineNormalToricVariety(v::NormalToricVariety)
+    isaffine(v) || error("Cannot construct affine toric variety from non-affine input")
+    return AffineNormalToricVariety(pm_ntv(v))
+end
 
 
 


### PR DESCRIPTION
This is another suggestion to the issue with the `NormalToricVariety` constructor not always returning a `NormalToricVariety`. In this PR
- `NormalToricVariety` always returns a `NormalToricVariety`
- A constructor `AffineNormalToricVariety(NormalToricVariety)` has been introduced, for conversion in case something is affine. It will error if the input turns out not to be affine.
- As an example I put `toric_ideal` here. @HereAround said that if `X` has `isaffine(X)`, then you ought to be able to feed it to e.g. `toric_ideal`, even if it is not of type `AffineNormalToricVariety`. This is solved by using the above constructor.

I thought using a PR might be better to discuss actual code, @thofma .

Also note that @benlorenz said there is some work that needs to be done to make 4ti2 work with `Polymake.jl`, so `toric_ideal` will not work in the ci (it does for me though).