### PR TITLE
Kemper's algorithm for primary invariants of minimal degree

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -657,3 +657,43 @@
   doi           = {10.1007/978-1-4613-8431-1},
   url           = {https://doi.org/10.1007/978-1-4613-8431-1}
 }
+
+@Book{GLS07,
+  author        = {Greuel, G.-M. and Lossen, C. and Shustin, E.},
+  title         = {Introduction to Singularities and Deformations},
+  series        = {Springer Monographs in Mathematics},
+  publisher     = {Springer-Verlag, Berlin},
+  year          = {2007},
+  pages         = {xii+471}
+}
+
+@Book{dJP00,
+  author        = {de Jong, Theo and Pfister, Gerhard},
+  title         = {Local Analytic Geometry},
+  series        = {Advanced Lectures in Mathematics},
+  publisher     = {Vieweg+Teubner Verlag},
+  year          = {2000},
+  pages         = {xi+384}
+}
+
+@Book{Har77,
+  author        = {Hartshorne, Robin},
+  title         = {Algebraic Geometry},
+  series        = {Graduate Texts in Mathematics},
+  publisher     = {Springer-Verlag, New York},
+  year          = {1977},
+  pages         = {xvi+496}
+}
+
+@Article{Kem99,
+  author        = {Kemper, Gregor},
+  title         = {An algorithm to calculate optimal homogeneous systems of parameters},
+  journal       = {J. Symbolic Comput.},
+  fjournal      = {Journal of Symbolic Computation},
+  volume        = {27},
+  year          = {1999},
+  number        = {2},
+  pages         = {171--184},
+  doi           = {10.1006/jsco.1998.0247},
+  url           = {https://doi.org/10.1006/jsco.1998.0247},
+}

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -545,6 +545,15 @@
   doi           = {10.1016/j.jsc.2012.05.002}
 }
 
+@Book{Knu11,
+  author        = {Knuth, Donald E.},
+  title         = {The art of computer programming. {V}ol. 4{A}.
+                  {C}ombinatorial algorithms. {P}art 1},
+  publisher     = {Addison-Wesley, Upper Saddle River, NJ},
+  year          = {2011},
+  pages         = {xv+883}
+}
+
 @Book{LN97,
   author        = {Lidl, Rudolf and Niederreiter, Harald},
   title         = {Finite fields},

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -502,6 +502,23 @@
   url           = {https://doi.org/10.1006/jsco.2002.0560}
 }
 
+<<<<<<< HEAD
+=======
+@Article{Kem99,
+  author        = {Kemper, Gregor},
+  title         = {An algorithm to calculate optimal homogeneous systems of
+                  parameters},
+  journal       = {J. Symbolic Comput.},
+  fjournal      = {Journal of Symbolic Computation},
+  volume        = {27},
+  year          = {1999},
+  number        = {2},
+  pages         = {171--184},
+  doi           = {10.1006/jsco.1998.0247},
+  url           = {https://doi.org/10.1006/jsco.1998.0247}
+}
+
+>>>>>>> 0e211ab1d... Minor changes
 @Article{Kin13,
   author        = {King, Simon},
   title         = {Minimal generating sets of non-modular invariant rings of

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -475,6 +475,18 @@
   url           = {https://doi.org/10.1007/978-3-030-52200-1_37}
 }
 
+@InCollection{KS99,
+  author        = {Kemper, Gregor and Steel, Allan},
+  title         = {Some algorithms in invariant theory of finite groups},
+  booktitle     = {Computational methods for representations of groups and
+                  algebras ({E}ssen, 1997)},
+  series        = {Progr. Math.},
+  volume        = {173},
+  pages         = {267--285},
+  publisher     = {Birkh\"{a}user, Basel},
+  year          = {1999}
+}
+
 @Article{Kah10,
   author        = {Kahle, Thomas},
   title         = {Decompositions of binomial ideals},

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -528,20 +528,6 @@
   url           = {https://doi.org/10.1006/jsco.1998.0247}
 }
 
-@Article{Kem99*1,
-  author        = {Kemper, Gregor},
-  title         = {An algorithm to calculate optimal homogeneous systems of
-                  parameters},
-  journal       = {J. Symbolic Comput.},
-  fjournal      = {Journal of Symbolic Computation},
-  volume        = {27},
-  year          = {1999},
-  number        = {2},
-  pages         = {171--184},
-  doi           = {10.1006/jsco.1998.0247},
-  url           = {https://doi.org/10.1006/jsco.1998.0247}
-}
-
 @Article{Kin13,
   author        = {King, Simon},
   title         = {Minimal generating sets of non-modular invariant rings of

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -514,8 +514,6 @@
   url           = {https://doi.org/10.1006/jsco.2002.0560}
 }
 
-<<<<<<< HEAD
-=======
 @Article{Kem99,
   author        = {Kemper, Gregor},
   title         = {An algorithm to calculate optimal homogeneous systems of
@@ -530,7 +528,20 @@
   url           = {https://doi.org/10.1006/jsco.1998.0247}
 }
 
->>>>>>> 0e211ab1d... Minor changes
+@Article{Kem99*1,
+  author        = {Kemper, Gregor},
+  title         = {An algorithm to calculate optimal homogeneous systems of
+                  parameters},
+  journal       = {J. Symbolic Comput.},
+  fjournal      = {Journal of Symbolic Computation},
+  volume        = {27},
+  year          = {1999},
+  number        = {2},
+  pages         = {171--184},
+  doi           = {10.1006/jsco.1998.0247},
+  url           = {https://doi.org/10.1006/jsco.1998.0247}
+}
+
 @Article{Kin13,
   author        = {King, Simon},
   title         = {Minimal generating sets of non-modular invariant rings of
@@ -694,44 +705,4 @@
   pages         = {x+370},
   doi           = {10.1007/978-1-4613-8431-1},
   url           = {https://doi.org/10.1007/978-1-4613-8431-1}
-}
-
-@Book{GLS07,
-  author        = {Greuel, G.-M. and Lossen, C. and Shustin, E.},
-  title         = {Introduction to Singularities and Deformations},
-  series        = {Springer Monographs in Mathematics},
-  publisher     = {Springer-Verlag, Berlin},
-  year          = {2007},
-  pages         = {xii+471}
-}
-
-@Book{dJP00,
-  author        = {de Jong, Theo and Pfister, Gerhard},
-  title         = {Local Analytic Geometry},
-  series        = {Advanced Lectures in Mathematics},
-  publisher     = {Vieweg+Teubner Verlag},
-  year          = {2000},
-  pages         = {xi+384}
-}
-
-@Book{Har77,
-  author        = {Hartshorne, Robin},
-  title         = {Algebraic Geometry},
-  series        = {Graduate Texts in Mathematics},
-  publisher     = {Springer-Verlag, New York},
-  year          = {1977},
-  pages         = {xvi+496}
-}
-
-@Article{Kem99,
-  author        = {Kemper, Gregor},
-  title         = {An algorithm to calculate optimal homogeneous systems of parameters},
-  journal       = {J. Symbolic Comput.},
-  fjournal      = {Journal of Symbolic Computation},
-  volume        = {27},
-  year          = {1999},
-  number        = {2},
-  pages         = {171--184},
-  doi           = {10.1006/jsco.1998.0247},
-  url           = {https://doi.org/10.1006/jsco.1998.0247},
 }

--- a/experimental/InvariantTheory/InvariantTheory.jl
+++ b/experimental/InvariantTheory/InvariantTheory.jl
@@ -1,3 +1,4 @@
 include("types.jl")
 include("invariant_rings.jl")
 include("iterators.jl")
+include("primary_invariants.jl")

--- a/experimental/InvariantTheory/invariant_rings.jl
+++ b/experimental/InvariantTheory/invariant_rings.jl
@@ -400,8 +400,13 @@ julia> basis(IR, 3)
 """
 basis(IR::InvRing, d::Int, algo = :default) = collect(iterate_basis(IR, d, algo))
 
+# It's nice to have this for fmpz too (I think), but Singular can't handle them.
+# Not that it were a good idea to call this function with something that does not
+# fit into an Int.
+basis(IR::InvRing, d::fmpz) = basis(IR, Int(d))
+
 function primary_invariants_via_singular(IR::InvRing)
-  if !isdefined(IR, :primary_singular)
+  #if !isdefined(IR, :primary_singular)
     IR.primary_singular = Singular.LibFinvar.primary_invariants(_action_singular(IR)...)
     P = IR.primary_singular[1]
     R = polynomial_ring(IR)
@@ -410,7 +415,7 @@ function primary_invariants_via_singular(IR::InvRing)
       push!(p, R(P[1, i]))
     end
     IR.primary = p
-  end
+  #end
   return IR.primary
 end
 

--- a/experimental/InvariantTheory/invariant_rings.jl
+++ b/experimental/InvariantTheory/invariant_rings.jl
@@ -406,7 +406,7 @@ basis(IR::InvRing, d::Int, algo = :default) = collect(iterate_basis(IR, d, algo)
 basis(IR::InvRing, d::fmpz) = basis(IR, Int(d))
 
 function primary_invariants_via_singular(IR::InvRing)
-  #if !isdefined(IR, :primary_singular)
+  if !isdefined(IR, :primary_singular)
     IR.primary_singular = Singular.LibFinvar.primary_invariants(_action_singular(IR)...)
     P = IR.primary_singular[1]
     R = polynomial_ring(IR)
@@ -415,7 +415,7 @@ function primary_invariants_via_singular(IR::InvRing)
       push!(p, R(P[1, i]))
     end
     IR.primary = p
-  #end
+  end
   return IR.primary
 end
 

--- a/experimental/InvariantTheory/iterators.jl
+++ b/experimental/InvariantTheory/iterators.jl
@@ -79,7 +79,7 @@ end
 # Returns the dimension of the graded component of degree d.
 # If we cannot compute the Molien series (so far in the modular case), we return
 # -1.
-function dimension_via_molien_series(R::InvRing, d::Int)
+function dimension_via_molien_series(::Type{T}, R::InvRing, d::Int) where T <: IntegerUnion
   if ismodular(R)
     return -1
   end
@@ -88,8 +88,7 @@ function dimension_via_molien_series(R::InvRing, d::Int)
   F = molien_series(R)
   k = coeff(numerator(F)(t)*inv(denominator(F)(t)), d)
   @assert isintegral(k)
-  k = Int(numerator(k))
-  return k
+  return T(numerator(k))::T
 end
 
 # Iterate over the basis of the degree d component of an invariant ring.
@@ -136,7 +135,7 @@ function iterate_basis_reynolds(R::InvRing, d::Int)
 
   monomials = all_monomials(polynomial_ring(R), d)
 
-  k = dimension_via_molien_series(R, d)
+  k = dimension_via_molien_series(Int, R, d)
   @assert k != -1
 
   N = zero_matrix(base_ring(polynomial_ring(R)), 0, 0)
@@ -149,7 +148,7 @@ function iterate_basis_linear_algebra(IR::InvRing, d::Int)
 
   R = polynomial_ring(IR)
 
-  k = dimension_via_molien_series(IR, d)
+  k = dimension_via_molien_series(Int, IR, d)
   if k == 0
     N = zero_matrix(base_ring(R), 0, 0)
     mons = elem_type(R)[]

--- a/experimental/InvariantTheory/iterators.jl
+++ b/experimental/InvariantTheory/iterators.jl
@@ -105,15 +105,16 @@ function iterate_basis(R::InvRing, d::Int, algo::Symbol = :default)
       # We use the "worst case" estimate, so 2d|G|/s instead of sqrt(2d|G|/s)
       # for the reynolds operator since we have to assume that the user really
       # wants to iterate the whole basis.
-      # Other than that we just use the bound from the paper. It probably also
-      # depends on the type of the field etc., so one could fine-tune here...
-      # But it should be a good heuristic anyways and the users can always
-      # choose for themselves :)
+      # "Experience" showed that one should drop the 2 in the bound.
+      # It probably also depends on the type of the field etc., so one could
+      # fine-tune here...
+      # But this should be a good heuristic anyways and the users can
+      # always choose for themselves :)
       s = length(action(R))
       g = order(Int, group(R))
       n = degree(group(R))
       k = binomial(n + d - 1, n - 1)
-      if k > 2*d*g/s
+      if k > d*g/s
         algo = :reynolds
       else
         algo = :linear_algebra

--- a/experimental/InvariantTheory/iterators.jl
+++ b/experimental/InvariantTheory/iterators.jl
@@ -338,7 +338,7 @@ function _iterate(VSI::VectorSpaceIterator)
     b = VSI.basis_collected[1]
   else
     b, s = iterate(VSI.basis_iterator)
-    VSI.basis_collected = typeof(b)[ b ]
+    VSI.basis_collected = [ b ]
     VSI.basis_iterator_state = s
   end
   phase = length(VSI.basis_iterator) != 1 ? 1 : 3
@@ -354,7 +354,7 @@ function Base.iterate(VSI::VectorSpaceIteratorFiniteField)
 
   b, state = _iterate(VSI)
   e, s = iterate(VSI.field)
-  elts = [ e for i = 1:length(VSI.basis_iterator) ]
+  elts = fill(e, length(VSI.basis_iterator))
   states = [ deepcopy(s) for i = 1:length(VSI.basis_iterator) ]
 
   return b, (state..., elts, states)

--- a/experimental/InvariantTheory/primary_invariants.jl
+++ b/experimental/InvariantTheory/primary_invariants.jl
@@ -47,11 +47,11 @@ function candidates_primary_degrees(R::InvRing, k::Int)
 
   # Find all possible tuples (d_1, ..., d_n), such that d_1 \cdots d_n = k*order(group(R))
   n = degree(group(R))
-  parts = Vector{Any}()
+  parts = Vector{Vector{Vector{Int}}}()
   for i = 1:n
     # Actually, we want multiset partitions here (as the factors may show
     # up more than once). But GAP doesn't have this as far as I'm aware.
-    append!(parts, GAP.gap_to_julia(GAP.Globals.PartitionsSet(GAP.Globals.Set(GAP.julia_to_gap(1:length(factors))), i)))
+    append!(parts, Vector{Vector{Vector{Int}}}(GAP.Globals.PartitionsSet(GAP.Obj(1:length(factors)), i)))
   end
 
   sorted_degrees = Vector{Tuple{fmpz, Vector{fmpz}}}()
@@ -107,7 +107,7 @@ function check_primary_degrees(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vect
       end
       I = I + ideal(R, collect_basis(iter))
     end
-    numbersInds = sum(Int[ deg_dict[e] for e in degs ])
+    numbersInds = !isempty(degs) ? sum(deg_dict[e] for e in degs) : 0
     if dim(I) > n - length(invars) - numbersInds
       return false
     end
@@ -183,6 +183,3 @@ function primary_invariants_via_optimal_hsop!(RG::InvRing{FldT, GrpT, PolyElemT}
   end
   return false, k
 end
-
-# Shouldn't be here and shouldn't be like this
-order(G::MatrixGroup{T}) where {T <: Union{nf_elem, fmpq}} = order(isomorphic_group_over_finite_field(G)[1])

--- a/experimental/InvariantTheory/primary_invariants.jl
+++ b/experimental/InvariantTheory/primary_invariants.jl
@@ -1,107 +1,6 @@
-mutable struct PrimaryInvarsCache{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT}
-  R::InvRing{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT}
-  bases::Dict{fmpz, Vector{PolyElemT}}
-
-  function PrimaryInvarsCache(R::InvRing{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT}) where {FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT}
-    C = new{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT}()
-    C.R = R
-    C.bases = Dict{fmpz, Vector{PolyElemT}}()
-    return C
-  end
-end
-
-mutable struct VectorSpaceIterator{IteratorT}
-  basis_iterator::IteratorT
-  rand_bound::Int
-
-  function VectorSpaceIterator(basis_iterator::IteratorT, bound::Int = 10^5) where {IteratorT}
-    VSI = new{IteratorT}()
-    VSI.basis_iterator = basis_iterator
-    VSI.rand_bound = bound
-    return VSI
-  end
-end
-
-function Base.iterate(VSI::VectorSpaceIterator)
-  if isempty(VSI.basis_iterator)
-    return nothing
-  end
-
-  b, s = iterate(VSI.basis_iterator)
-  basis_collected = typeof(b)[ b ]
-  return b, (s, Int[ length(VSI.basis_iterator) ], basis_collected, 1)
-end
-
-# We "iterate" the vector space in 3 phases:
-# 1) iterate the basis using VSI.basis_iterator, so return one basis element at
-#    a time
-# 2) iterate all possible sums of basis elements
-# 3) return random linear combinations of the basis elements
-#
-# state is supposed to be a tuple of length 4 containing:
-# - the state of VSI.basis_iterator
-# - a Vector{Int} being the state for "phase 2"
-# - a Vector containing the (so far) collected basis
-# - an Int: the number of the phase
-function Base.iterate(VSI::VectorSpaceIterator, state)
-  phase = state[4]
-
-  if phase == 1
-    bs = iterate(VSI.basis_iterator, state[1])
-    if bs == nothing
-      phase = 2
-    else
-      b = bs[1]
-      s = bs[2]
-      push!(state[3], b)
-      return b, (s, state[2], state[3], state[4])
-    end
-  end
-
-  if phase == 2
-    expand = true
-    s = state[2]
-    if s[end] < length(state[3])
-      s[end] += 1
-      expand = false
-    else
-      for i = length(s) - 1:-1:1
-        if s[i] + 1 < s[i + 1]
-          s[i] += 1
-          for j = i + 1:length(s)
-            s[j] = s[j - 1] + 1
-          end
-          expand = false
-          break
-        end
-      end
-    end
-
-    if expand
-      if length(s) < length(state[3])
-        s = collect(1:length(s) + 1)
-      else
-        phase = 3
-      end
-    end
-    if phase != 3
-      return sum([ state[3][i] for i in s ]), (state[1], s, state[3], 2)
-    end
-  end
-
-  coeffs = rand(-VSI.rand_bound:VSI.rand_bound, length(state[3]))
-  return sum([ coeffs[i]*state[3][i] for i = 1:length(state[3]) ]), (state[1], state[2], state[3], 3)
-end
-
-function basis(C::PrimaryInvarsCache, d::fmpz)
-  return get!(C.bases, d) do
-    basis(C.R, d)
-  end
-end
-
 # If d_1, ..., d_n are degrees of primary invariants, then the Hilbert series
 # must be f(t)/\prod_i (1 - t^{d_i}) where f is a polynomial with non-negative
-# integer coefficients.
+# integer coefficients (non-negativity only holds in the non-modular case!).
 # See Derksen, Kemper "Computational Invariant Theory", pp. 94, 95.
 function test_primary_degrees_via_hilbert_series(R::InvRing, degrees::Vector{fmpz})
   @assert !ismodular(R)
@@ -122,9 +21,6 @@ function test_primary_degrees_via_hilbert_series(R::InvRing, degrees::Vector{fmp
     if !isinteger(c)
       return false
     end
-    if !(c isa fmpq)
-      c = coeff(c, 0)
-    end
     if c < 0
       return false
     end
@@ -136,10 +32,11 @@ end
 # d_1 \cdots d_n == k*|G|, where G = group(R).
 # TODO: Possibly include checks involving earlier runs of the search, see Kemper, p. 181
 function candidates_primary_degrees(R::InvRing, k::Int)
-  # If we can't factor the group order in reasonable time, we might as well
-  # give up.
+
   factors = Vector{fmpz}()
   for n in [ k, order(group(R)) ]
+    # If we can't factor the group order in reasonable time, we might as well
+    # give up.
     fac = factor(n) # TODO: cache this!
     for (p, e) in fac
       for i = 1:e
@@ -148,16 +45,14 @@ function candidates_primary_degrees(R::InvRing, k::Int)
     end
   end
 
+  # Find all possible tuples (d_1, ..., d_n), such that d_1 \cdots d_n = k*order(group(R))
   n = degree(group(R))
   parts = Vector{Any}()
   for i = 1:n
-    # Actually, we want to multiset partitions here (as the factors may show
+    # Actually, we want multiset partitions here (as the factors may show
     # up more than once). But GAP doesn't have this as far as I'm aware.
-    # It's in JuLie.jl though.
     append!(parts, GAP.gap_to_julia(GAP.Globals.PartitionsSet(GAP.Globals.Set(GAP.julia_to_gap(1:length(factors))), i)))
   end
-
-  #expG = exponent(group(R))
 
   sorted_degrees = Vector{Tuple{fmpz, Vector{fmpz}}}()
   for part in parts
@@ -167,9 +62,6 @@ function candidates_primary_degrees(R::InvRing, k::Int)
        ds[i + n - length(part)] *= factors[j]
       end
     end
-    #if !iszero(mod(lcm(ds), expG))
-    #  continue
-    #end
     sort!(ds) # To avoid duplicates
     s = sum(ds)
     sds = (s, ds)
@@ -190,7 +82,12 @@ function candidates_primary_degrees(R::InvRing, k::Int)
   return degrees
 end
 
-function check_primary_degrees(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vector{fmpz}, invars::Vector{PolyElemT}, k::Int, C::PrimaryInvarsCache) where {FldT, GrpT, PolyElemT}
+# Checks whether there exist homogeneous f_1, ..., f_k in RG of degrees
+# degrees[length(invars) + 1:length(invars) + k] such that
+# RG/< invars, f_1, ..., f_k > has Krull dimension n - k, where n == length(invars).
+# If the base field is finite, the answer "true" might be wrong (for theoretical reasons).
+# See Kemper, Theorem 2.
+function check_primary_degrees(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vector{fmpz}, invars::Vector{PolyElemT}, k::Int, iters::Dict{Int, <: VectorSpaceIterator}) where {FldT, GrpT, PolyElemT}
   R = polynomial_ring(RG)
   n = length(degrees)
 
@@ -205,7 +102,10 @@ function check_primary_degrees(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vect
       I = ideal(R, invars)
     end
     for e in degs
-      I = I + ideal(R, basis(C, e))
+      iter = get!(iters, Int(e)) do
+        VectorSpaceIterator(coefficient_ring(RG), iterate_basis(RG, Int(e)))
+      end
+      I = I + ideal(R, collect_basis(iter))
     end
     numbersInds = sum(Int[ deg_dict[e] for e in degs ])
     if dim(I) > n - length(invars) - numbersInds
@@ -216,14 +116,13 @@ function check_primary_degrees(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vect
 end
 
 function primary_invariants_via_optimal_hsop(RG::InvRing)
-  C = PrimaryInvarsCache(RG)
+  iters = Dict{Int, VectorSpaceIterator}()
   k = 1
   while true
     degrees = candidates_primary_degrees(RG, k)
     for ds in degrees
-    #@info "Checking k = $k"
       invars = elem_type(polynomial_ring(RG))[]
-      b, _ = primary_invariants_via_optimal_hsop!(RG, ds, invars, C)
+      b, _ = primary_invariants_via_optimal_hsop!(RG, ds, invars, iters)
       b && return invars
     end
     k += 1
@@ -235,51 +134,44 @@ end
 # b == true iff primary invariants of the given degrees exist. In this case
 # invars will contain those invariants.
 # k is only needed for recursive calls of the function.
-function primary_invariants_via_optimal_hsop!(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vector{fmpz}, invars::Vector{PolyElemT}, C::PrimaryInvarsCache) where {FldT, GrpT, PolyElemT}
+function primary_invariants_via_optimal_hsop!(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vector{fmpz}, invars::Vector{PolyElemT}, iters::Dict{Int, <: VectorSpaceIterator}) where {FldT, GrpT, PolyElemT}
   k = 0
   n = length(degrees) - length(invars)
   R = polynomial_ring(RG)
 
-  B = Vector{PolyElemT}()
   if length(invars) != length(degrees)
     d = degrees[length(invars) + 1]
-    #@time B = basis(C, d)
-    B = iterate_basis(RG, Int(d))
-  end
 
-  for f in VectorSpaceIterator(B)
-    if iszero(f) || f in invars
-      continue
+    iter = get!(iters, Int(d)) do
+      VectorSpaceIterator(coefficient_ring(RG), iterate_basis(RG, Int(d)))
     end
-    push!(invars, f)
-    if k > 0
-      #@info "Test needed 1"
-      if !check_primary_degrees(RG, degrees, invars, k - 1, C)
-        pop!(invars)
-        #@info "Test failed"
+
+    for f in iter
+      if f in invars
         continue
       end
-      #@info "Test succeeded"
-    end
-    b, kk = primary_invariants_via_optimal_hsop!(RG, degrees, invars, C)
-    if b
-      return true, 0
-    end
-    pop!(invars)
-    if kk >= k
-      k = kk + 1
-      #@info "Test needed 2"
-      if !check_primary_degrees(RG, degrees, invars, k, C)
-        #@info "Test failed"
-        break
-        #return false, 0
+      push!(invars, f)
+      if k > 0
+        if !check_primary_degrees(RG, degrees, invars, k - 1, iters)
+          pop!(invars)
+          continue
+        end
       end
-      #@info "Test succeeded"
+      b, kk = primary_invariants_via_optimal_hsop!(RG, degrees, invars, iters)
+      if b
+        return true, 0
+      end
+      pop!(invars)
+      if kk >= k
+        k = kk + 1
+        if !check_primary_degrees(RG, degrees, invars, k, iters)
+          break
+        end
+      end
     end
   end
 
   if k <= 1
-    #@info "Compute GB"
     if !isempty(invars) && dim(ideal(polynomial_ring(RG), invars)) > n
       k = 0
     else
@@ -292,7 +184,7 @@ function primary_invariants_via_optimal_hsop!(RG::InvRing{FldT, GrpT, PolyElemT}
   return false, k
 end
 
-# Shouldn't be here and should be like this
+# Shouldn't be here and shouldn't be like this
 order(G::MatrixGroup{T}) where {T <: Union{nf_elem, fmpq}} = order(isomorphic_group_over_finite_field(G)[1])
 exponent(G::MatrixGroup{T}) where {T <: Union{nf_elem, fmpq}} = exponent(isomorphic_group_over_finite_field(G)[1])
 

--- a/experimental/InvariantTheory/primary_invariants.jl
+++ b/experimental/InvariantTheory/primary_invariants.jl
@@ -1,7 +1,7 @@
 # If d_1, ..., d_n are degrees of primary invariants, then the Hilbert series
 # must be f(t)/\prod_i (1 - t^{d_i}) where f is a polynomial with non-negative
 # integer coefficients (non-negativity only holds in the non-modular case!).
-# See Derksen, Kemper "Computational Invariant Theory", pp. 94, 95.
+# See DK15, pp. 94, 95.
 function test_primary_degrees_via_hilbert_series(R::InvRing, degrees::Vector{fmpz})
   @assert !ismodular(R)
 
@@ -86,7 +86,7 @@ end
 # degrees[length(invars) + 1:length(invars) + k] such that
 # RG/< invars, f_1, ..., f_k > has Krull dimension n - k, where n == length(invars).
 # If the base field is finite, the answer "true" might be wrong (for theoretical reasons).
-# See Kemper, Theorem 2.
+# See Kem99, Theorem 2.
 function check_primary_degrees(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vector{fmpz}, invars::Vector{PolyElemT}, k::Int, iters::Dict{Int, <: VectorSpaceIterator}) where {FldT, GrpT, PolyElemT}
   R = polynomial_ring(RG)
   n = length(degrees)
@@ -103,7 +103,7 @@ function check_primary_degrees(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vect
     end
     for e in degs
       iter = get!(iters, Int(e)) do
-        VectorSpaceIterator(coefficient_ring(RG), iterate_basis(RG, Int(e)))
+        vector_space_iterator(coefficient_ring(RG), iterate_basis(RG, Int(e)))
       end
       I = I + ideal(R, collect_basis(iter))
     end
@@ -129,7 +129,7 @@ function primary_invariants_via_optimal_hsop(RG::InvRing)
   end
 end
 
-# Kemper "An Algorithm to Calculate Optimal Homogeneous Systems of Parameters", 1999
+# Kemper "An Algorithm to Calculate Optimal Homogeneous Systems of Parameters", 1999, [Kem99]
 # Returns a bool b and an integer k.
 # b == true iff primary invariants of the given degrees exist. In this case
 # invars will contain those invariants.
@@ -143,7 +143,7 @@ function primary_invariants_via_optimal_hsop!(RG::InvRing{FldT, GrpT, PolyElemT}
     d = degrees[length(invars) + 1]
 
     iter = get!(iters, Int(d)) do
-      VectorSpaceIterator(coefficient_ring(RG), iterate_basis(RG, Int(d)))
+      vector_space_iterator(coefficient_ring(RG), iterate_basis(RG, Int(d)))
     end
 
     for f in iter
@@ -186,19 +186,3 @@ end
 
 # Shouldn't be here and shouldn't be like this
 order(G::MatrixGroup{T}) where {T <: Union{nf_elem, fmpq}} = order(isomorphic_group_over_finite_field(G)[1])
-exponent(G::MatrixGroup{T}) where {T <: Union{nf_elem, fmpq}} = exponent(isomorphic_group_over_finite_field(G)[1])
-
-function symmetric_matrix_group(n::Int)
-  @assert n >= 2
-  M = identity_matrix(FlintQQ, n)
-  matrices = Vector{typeof(M)}(undef, n - 1)
-  for i = 1:n - 1
-    M[i, i] = zero(FlintQQ)
-    M[i + 1, i + 1] = zero(FlintQQ)
-    M[i + 1, i] = one(FlintQQ)
-    M[i, i + 1] = one(FlintQQ)
-    matrices[i] = M
-    M = identity_matrix(FlintQQ, n)
-  end
-  return matrix_group(matrices)
-end

--- a/experimental/InvariantTheory/primary_invariants.jl
+++ b/experimental/InvariantTheory/primary_invariants.jl
@@ -2,16 +2,15 @@
 # must be f(t)/\prod_i (1 - t^{d_i}) where f is a polynomial with non-negative
 # integer coefficients (non-negativity only holds in the non-modular case!).
 # See DK15, pp. 94, 95.
-function test_primary_degrees_via_hilbert_series(R::InvRing, degrees::Vector{fmpz})
+function test_primary_degrees_via_hilbert_series(R::InvRing, degrees::Vector{Int})
   @assert !ismodular(R)
 
   mol = molien_series(R)
   f = numerator(mol)
   g = denominator(mol)
-  S = parent(f)
-  t = gen(S)
   for d in degrees
-    f *= (1 - t^d)
+    # multiply f by 1 - t^d
+    f -= shift_left(f, d)
   end
   if !iszero(mod(f, g))
     return false
@@ -30,16 +29,16 @@ end
 
 # Returns possible degrees of primary invariants d_1, ..., d_n with
 # d_1 \cdots d_n == k*|G|, where G = group(R).
-function candidates_primary_degrees(R::InvRing, k::Int, bad_prefixes::Vector{Vector{fmpz}} = Vector{Vector{fmpz}}())
+function candidates_primary_degrees(R::InvRing, k::Int, bad_prefixes::Vector{Vector{Int}} = Vector{Vector{Int}}())
 
-  factors = MSet{fmpz}()
+  factors = MSet{Int}()
   for n in [ k, order(group(R)) ]
     # If we can't factor the group order in reasonable time, we might as well
     # give up.
-    fac = factor(n) # TODO: cache this!
+    fac = factor(n)
     for (p, e) in fac
       for i = 1:e
-        push!(factors, p)
+        push!(factors, Int(p))
       end
     end
   end
@@ -47,13 +46,13 @@ function candidates_primary_degrees(R::InvRing, k::Int, bad_prefixes::Vector{Vec
   n = degree(group(R))
 
   # Find all possible tuples (d_1, ..., d_n), such that d_1 \cdots d_n = k*order(group(R))
-  degrees = Vector{Vector{fmpz}}()
+  degrees = Vector{Vector{Int}}()
   for part in iterate_partitions(factors)
     # We actually only need the multiset partitions with at most n parts.
     if length(part) > n
       continue
     end
-    ds = ones(fmpz, n)
+    ds = ones(Int, n)
     for i = 1:length(part)
       for (p, e) in part[i].dict
        ds[i + n - length(part)] *= p^e
@@ -65,6 +64,15 @@ function candidates_primary_degrees(R::InvRing, k::Int, bad_prefixes::Vector{Vec
     skip = false
     for prefix in bad_prefixes
       if ds[1:length(prefix)] == prefix
+        skip = true
+        break
+      end
+    end
+    skip ? continue : nothing
+
+    for d in ds
+      # Check whether there exist invariants of this degree.
+      if dimension_via_molien_series(fmpz, R, d) == 0
         skip = true
         break
       end
@@ -85,7 +93,7 @@ end
 # RG/< invars, f_1, ..., f_k > has Krull dimension n - k, where n == length(invars).
 # If the base field is finite, the answer "true" might be wrong (for theoretical reasons).
 # See Kem99, Theorem 2.
-function check_primary_degrees(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vector{fmpz}, invars::Vector{PolyElemT}, k::Int, iters::Dict{Int, <: VectorSpaceIterator}, ideals::Dict{Set{PolyElemT}, Int}) where {FldT, GrpT, PolyElemT}
+function check_primary_degrees(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vector{Int}, invars::Vector{PolyElemT}, k::Int, iters::Dict{Int, <: VectorSpaceIterator}, ideals::Dict{Set{PolyElemT}, Int}) where {FldT, GrpT, PolyElemT}
   R = polynomial_ring(RG)
   n = length(degrees)
 
@@ -102,9 +110,6 @@ function check_primary_degrees(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vect
       union!(gens_ideal, collect_basis(iter))
     end
     numbersInds = !isempty(degs) ? sum(deg_dict[e] for e in degs) : 0
-    if isempty(gens_ideal)
-      push!(gens_ideal, R())
-    end
     dimI = get!(ideals, gens_ideal) do
       dim(ideal(R, collect(gens_ideal)))
     end
@@ -115,16 +120,16 @@ function check_primary_degrees(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vect
   return true
 end
 
-function primary_invariants_via_optimal_hsop(RG::InvRing)
+function primary_invariants_via_optimal_hsop(RG::InvRing, ensure_minimality::Int = 0)
   iters = Dict{Int, VectorSpaceIterator}()
   ideals = Dict{Set{elem_type(polynomial_ring(RG))}, Int}()
-  bad_prefixes = Vector{Vector{fmpz}}()
+  bad_prefixes = Vector{Vector{Int}}()
   l = 1
   while true
     degrees = candidates_primary_degrees(RG, l, bad_prefixes)
     for ds in degrees
       invars = elem_type(polynomial_ring(RG))[]
-      b, k = primary_invariants_via_optimal_hsop!(RG, ds, invars, iters, ideals)
+      b, k = primary_invariants_via_optimal_hsop!(RG, ds, invars, iters, ideals, ensure_minimality, 0)
       b && return invars
       push!(bad_prefixes, ds[1:k])
     end
@@ -137,7 +142,7 @@ end
 # b == true iff primary invariants of the given degrees exist. In this case
 # invars will contain those invariants.
 # k is only needed for recursive calls of the function.
-function primary_invariants_via_optimal_hsop!(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vector{fmpz}, invars::Vector{PolyElemT}, iters::Dict{Int, <: VectorSpaceIterator}, ideals::Dict{Set{PolyElemT}, Int}, k::Int = 0) where {FldT, GrpT, PolyElemT}
+function primary_invariants_via_optimal_hsop!(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vector{Int}, invars::Vector{PolyElemT}, iters::Dict{Int, <: VectorSpaceIterator}, ideals::Dict{Set{PolyElemT}, Int}, ensure_minimality::Int = 0, k::Int = 0) where {FldT, GrpT, PolyElemT}
 
   n = length(degrees) - length(invars)
   R = polynomial_ring(RG)
@@ -149,10 +154,15 @@ function primary_invariants_via_optimal_hsop!(RG::InvRing{FldT, GrpT, PolyElemT}
       vector_space_iterator(coefficient_ring(RG), iterate_basis(RG, Int(d)))
     end
 
+    attempts = 1
     for f in iter
       if f in invars
         continue
       end
+      if ensure_minimality > 0 && attempts > ensure_minimality
+        break
+      end
+      attempts += 1
       push!(invars, f)
       if k > 0
         if !check_primary_degrees(RG, degrees, invars, k - 1, iters, ideals)
@@ -160,7 +170,7 @@ function primary_invariants_via_optimal_hsop!(RG::InvRing{FldT, GrpT, PolyElemT}
           continue
         end
       end
-      b, kk = primary_invariants_via_optimal_hsop!(RG, degrees, invars, iters, ideals, k - 1)
+      b, kk = primary_invariants_via_optimal_hsop!(RG, degrees, invars, iters, ideals, ensure_minimality, k - 1)
       if b
         return true, 0
       end
@@ -176,13 +186,11 @@ function primary_invariants_via_optimal_hsop!(RG::InvRing{FldT, GrpT, PolyElemT}
 
   if k <= 1
     k = 1
-    if !isempty(invars) # Work around https://github.com/oscar-system/Oscar.jl/issues/784
-      dimI = get!(ideals, Set(invars)) do
-        dim(ideal(polynomial_ring(RG), invars))
-      end
-      if dimI > n
-        k = 0
-      end
+    dimI = get!(ideals, Set(invars)) do
+      dim(ideal(polynomial_ring(RG), invars))
+    end
+    if dimI > n
+      k = 0
     end
   end
   if iszero(n) && isone(k)

--- a/experimental/InvariantTheory/primary_invariants.jl
+++ b/experimental/InvariantTheory/primary_invariants.jl
@@ -1,0 +1,292 @@
+mutable struct PrimaryInvarsCache{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT}
+  R::InvRing{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT}
+  bases::Dict{fmpz, Vector{PolyElemT}}
+
+  function PrimaryInvarsCache(R::InvRing{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT}) where {FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT}
+    C = new{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularActionT}()
+    C.R = R
+    C.bases = Dict{fmpz, Vector{PolyElemT}}()
+    return C
+  end
+end
+
+mutable struct VectorSpaceIterator{EltT}
+  basis::Vector{EltT}
+  iters::Vector{Vector{Int}}
+  rand_bound::Int
+
+  function VectorSpaceIterator(basis::Vector{EltT}, bound::Int = 10^5) where {EltT}
+    VSI = new{EltT}()
+    VSI.basis = basis
+    VSI.iters = make_iterators(length(basis), length(basis))
+    VSI.rand_bound = bound
+    return VSI
+  end
+end
+
+function Base.iterate(VSI::VectorSpaceIterator)
+  if isempty(VSI.basis)
+    return nothing
+  end
+
+  return VSI.basis[1], 2
+end
+
+function Base.iterate(VSI::VectorSpaceIterator, state::Int)
+  if state > length(VSI.iters)
+    coeffs = rand(-VSI.rand_bound:VSI.rand_bound, length(VSI.basis))
+    return sum([ coeffs[i]*VSI.basis[i] for i = 1:length(VSI.basis) ]), state + 1
+  end
+  return sum([ VSI.basis[i] for i in VSI.iters[state] ]), state + 1
+end
+
+function basis(C::PrimaryInvarsCache, d::fmpz)
+  return get!(C.bases, d) do
+    basis(C.R, d)
+  end
+end
+
+function make_iterators(n::Int, k::Int)
+  function fill_next_layer()
+    res2 = copy(res)
+    for v in res
+      for i = v[end] + 1:n
+        w = copy(v)
+        push!(w, i)
+        push!(res2, w)
+      end
+    end
+    res = res2
+    return res
+  end
+
+  @assert k <= n
+  res = Vector{Vector{Int}}(undef, n)
+  for i = 1:n
+    res[i] = [ i ]
+  end
+  for j = 2:k
+    res = fill_next_layer()
+  end
+  return res
+end
+
+# If d_1, ..., d_n are degrees of primary invariants, then the Hilbert series
+# must be f(t)/\prod_i (1 - t^{d_i}) where f is a polynomial with non-negative
+# integer coefficients.
+# See Derksen, Kemper "Computational Invariant Theory", pp. 94, 95.
+function test_primary_degrees_via_hilbert_series(R::InvRing, degrees::Vector{fmpz})
+  @assert !ismodular(R)
+
+  mol = molien_series(R)
+  f = numerator(mol)
+  g = denominator(mol)
+  S = parent(f)
+  t = gen(S)
+  for d in degrees
+    f *= (1 - t^d)
+  end
+  if !iszero(mod(f, g))
+    return false
+  end
+  h = div(f, g)
+  for c in coefficients(h)
+    if !isinteger(c)
+      return false
+    end
+    if !(c isa fmpq)
+      c = coeff(c, 0)
+    end
+    if c < 0
+      return false
+    end
+  end
+  return true
+end
+
+# Returns possible degrees of primary invariants d_1, ..., d_n with
+# d_1 \cdots d_n == k*|G|, where G = group(R).
+# TODO: Possibly include checks involving earlier runs of the search, see Kemper, p. 181
+function candidates_primary_degrees(R::InvRing, k::Int)
+  # If we can't factor the group order in reasonable time, we might as well
+  # give up.
+  factors = Vector{fmpz}()
+  for n in [ k, order(group(R)) ]
+    fac = factor(n) # TODO: cache this!
+    for (p, e) in fac
+      for i = 1:e
+        push!(factors, p)
+      end
+    end
+  end
+
+  n = degree(group(R))
+  parts = Vector{Any}()
+  for i = 1:n
+    # Actually, we want to multiset partitions here (as the factors may show
+    # up more than once). But GAP doesn't have this as far as I'm aware.
+    # It's in JuLie.jl though.
+    append!(parts, GAP.gap_to_julia(GAP.Globals.PartitionsSet(GAP.Globals.Set(GAP.julia_to_gap(1:length(factors))), i)))
+  end
+
+  #expG = exponent(group(R))
+
+  sorted_degrees = Vector{Tuple{fmpz, Vector{fmpz}}}()
+  for part in parts
+    ds = ones(fmpz, n)
+    for i = 1:length(part)
+      for j in part[i]
+       ds[i + n - length(part)] *= factors[j]
+      end
+    end
+    #if !iszero(mod(lcm(ds), expG))
+    #  continue
+    #end
+    sort!(ds) # To avoid duplicates
+    s = sum(ds)
+    sds = (s, ds)
+    l = searchsortedfirst(sorted_degrees, sds)
+    # If we used multiset partitions there shouldn't be duplicates (I think)
+    if l <= length(sorted_degrees) && sorted_degrees[l] == sds
+      continue
+    end
+    insert!(sorted_degrees, l, sds)
+  end
+
+  degrees = Vector{Vector{fmpz}}()
+  for (s, ds) in sorted_degrees
+    if test_primary_degrees_via_hilbert_series(R, ds)
+      push!(degrees, ds)
+    end
+  end
+  return degrees
+end
+
+function check_primary_degrees(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vector{fmpz}, invars::Vector{PolyElemT}, k::Int, C::PrimaryInvarsCache) where {FldT, GrpT, PolyElemT}
+  R = polynomial_ring(RG)
+  n = length(degrees)
+
+  deg_dict = Dict{fmpz, Int}()
+  for e in degrees[length(invars) + 1:length(invars) + k]
+    deg_dict[e] = get(deg_dict, e, 0) + 1
+  end
+  for degs in Hecke.subsets(Set(keys(deg_dict)))
+    if isempty(invars)
+      I = ideal(R, R())
+    else
+      I = ideal(R, invars)
+    end
+    for e in degs
+      I = I + ideal(R, basis(C, e))
+    end
+    numbersInds = sum(Int[ deg_dict[e] for e in degs ])
+    if dim(I) > n - length(invars) - numbersInds
+      return false
+    end
+  end
+  return true
+end
+
+function primary_invariants_via_optimal_hsop(RG::InvRing)
+  C = PrimaryInvarsCache(RG)
+  k = 1
+  while true
+    degrees = candidates_primary_degrees(RG, k)
+    for ds in degrees
+    #@info "Checking k = $k"
+      invars = elem_type(polynomial_ring(RG))[]
+      b, _ = primary_invariants_via_optimal_hsop!(RG, ds, invars, C)
+      b && return invars
+    end
+    k += 1
+  end
+end
+
+# Kemper "An Algorithm to Calculate Optimal Homogeneous Systems of Parameters", 1999
+# Returns a bool b and an integer k.
+# b == true iff primary invariants of the given degrees exist. In this case
+# invars will contain those invariants.
+# k is only needed for recursive calls of the function.
+function primary_invariants_via_optimal_hsop!(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vector{fmpz}, invars::Vector{PolyElemT}, C::PrimaryInvarsCache) where {FldT, GrpT, PolyElemT}
+  k = 0
+  n = length(degrees) - length(invars)
+  R = polynomial_ring(RG)
+
+  B = Vector{PolyElemT}()
+  if length(invars) != length(degrees)
+    d = degrees[length(invars) + 1]
+    @time B = basis(C, d)
+  end
+
+  #coeff_bound = 1
+  #for coeffs in Iterators.product([ 0:coeff_bound for i = 1:length(B) ]...)
+  for f in VectorSpaceIterator(B)
+  #for i = 1:length(B)
+    #coeffs = rand(-coeff_bound:coeff_bound, length(B))
+    #f = sum([ coeffs[i]*B[i] for i = 1:length(B) ])
+    #f = B[i]
+    if iszero(f) || f in invars
+      continue
+    end
+    push!(invars, f)
+    if k > 0
+      #@info "Test needed 1"
+      if !check_primary_degrees(RG, degrees, invars, k - 1, C)
+        pop!(invars)
+        #@info "Test failed"
+        continue
+      end
+      #@info "Test succeeded"
+    end
+    b, kk = primary_invariants_via_optimal_hsop!(RG, degrees, invars, C)
+    if b
+      return true, 0
+    end
+    pop!(invars)
+    if kk >= k
+      k = kk + 1
+      #@info "Test needed 2"
+      if !check_primary_degrees(RG, degrees, invars, k, C)
+        #@info "Test failed"
+        break
+        #return false, 0
+      end
+      #@info "Test succeeded"
+    end
+    #if i == length(B)
+    #  @info "loop terminated"
+    #end
+  end
+
+  if k <= 1
+    #@info "Compute GB"
+    if !isempty(invars) && dim(ideal(polynomial_ring(RG), invars)) > n
+      k = 0
+    else
+      k = 1
+    end
+  end
+  if iszero(n) && isone(k)
+    return true, k
+  end
+  return false, k
+end
+
+# Shouldn't be here and should be like this
+order(G::MatrixGroup{T}) where {T <: Union{nf_elem, fmpq}} = order(isomorphic_group_over_finite_field(G)[1])
+exponent(G::MatrixGroup{T}) where {T <: Union{nf_elem, fmpq}} = exponent(isomorphic_group_over_finite_field(G)[1])
+
+function symmetric_matrix_group(n::Int)
+  @assert n >= 2
+  M = identity_matrix(FlintQQ, n)
+  matrices = Vector{typeof(M)}(undef, n - 1)
+  for i = 1:n - 1
+    M[i, i] = zero(FlintQQ)
+    M[i + 1, i + 1] = zero(FlintQQ)
+    M[i + 1, i] = one(FlintQQ)
+    M[i, i + 1] = one(FlintQQ)
+    matrices[i] = M
+    M = identity_matrix(FlintQQ, n)
+  end
+  return matrix_group(matrices)
+end

--- a/experimental/InvariantTheory/types.jl
+++ b/experimental/InvariantTheory/types.jl
@@ -72,7 +72,7 @@ end
 
 abstract type VectorSpaceIterator{FieldT, IteratorT, ElemT} end
 
-# This takes a basis of a vector space as an interator and then "iterates" the
+# This takes a basis of a vector space as an iterator and then "iterates" the
 # space in three "phases":
 # 1) iterate the basis using basis_iterator, so return one basis element at
 #    a time
@@ -89,7 +89,7 @@ mutable struct VectorSpaceIteratorRand{FieldT, IteratorT, ElemT} <: VectorSpaceI
   field::FieldT
   basis_iterator::IteratorT
   basis_collected::Vector{ElemT}
-  basis_iterator_state # I don't know the type of this and I don't think there
+  basis_iterator_state::Any # I don't know the type of this and I don't think there
                        # is a "type-stable" way of finding it out
   rand_bound::Int
 
@@ -110,7 +110,7 @@ mutable struct VectorSpaceIteratorFiniteField{FieldT, IteratorT, ElemT} <: Vecto
   field::FieldT
   basis_iterator::IteratorT
   basis_collected::Vector{ElemT}
-  basis_iterator_state # I don't know the type of this and I don't think there
+  basis_iterator_state::Any # I don't know the type of this and I don't think there
                        # is a "type-stable" way of finding it out
 
   function VectorSpaceIteratorFiniteField(K::FieldT, basis_iterator::IteratorT) where {FieldT <: Union{Nemo.GaloisField, Nemo.GaloisFmpzField, FqNmodFiniteField, FqFiniteField}, IteratorT}

--- a/experimental/InvariantTheory/types.jl
+++ b/experimental/InvariantTheory/types.jl
@@ -69,3 +69,55 @@ struct InvRingBasisIterator{InvRingT, IteratorT, PolyElemT, MatrixT}
   monomials_collected::Vector{PolyElemT}
   kernel::MatrixT # used iff reynolds == false
 end
+
+abstract type VectorSpaceIterator{FieldT, IteratorT, ElemT} end
+
+# This takes a basis of a vector space as an interator and then "iterates" the
+# space in three "phases":
+# 1) iterate the basis using basis_iterator, so return one basis element at
+#    a time
+# 2) iterate all possible sums of basis elements
+# 3) return random linear combinations of the basis elements (with integer
+#    coefficients bounded by rand_bound)
+#
+# We collect the basis while iterating it, so that multiple iteration over the
+# same VectorSpaceIterator do not need to recompute it. basis_iterator_state
+# must always be a state of basis_iterator, so that
+# iterate(basis_iterator, basis_iterator_state) returns the next element in the
+# basis coming after basis_collected[end].
+mutable struct VectorSpaceIteratorRand{FieldT, IteratorT, ElemT} <: VectorSpaceIterator{FieldT, IteratorT, ElemT}
+  field::FieldT
+  basis_iterator::IteratorT
+  basis_collected::Vector{ElemT}
+  basis_iterator_state # I don't know the type of this and I don't think there
+                       # is a "type-stable" way of finding it out
+  rand_bound::Int
+
+  function VectorSpaceIteratorRand(K::FieldT, basis_iterator::IteratorT, bound::Int = 10^5) where {FieldT, IteratorT}
+    VSI = new{FieldT, IteratorT, eltype(basis_iterator)}()
+    VSI.field = K
+    VSI.basis_iterator = basis_iterator
+    VSI.basis_collected = eltype(basis_iterator)[]
+    VSI.rand_bound = bound
+    return VSI
+  end
+end
+
+# The same things as for VectorSpaceIteratorRand apply besides that in "phase 3"
+# all elements of the vector space are iterated in deterministic order (it is
+# supposed to be finite after all).
+mutable struct VectorSpaceIteratorFiniteField{FieldT, IteratorT, ElemT} <: VectorSpaceIterator{FieldT, IteratorT, ElemT}
+  field::FieldT
+  basis_iterator::IteratorT
+  basis_collected::Vector{ElemT}
+  basis_iterator_state # I don't know the type of this and I don't think there
+                       # is a "type-stable" way of finding it out
+
+  function VectorSpaceIteratorFiniteField(K::FieldT, basis_iterator::IteratorT) where {FieldT <: Union{Nemo.GaloisField, Nemo.GaloisFmpzField, FqNmodFiniteField, FqFiniteField}, IteratorT}
+    VSI = new{FieldT, IteratorT, eltype(basis_iterator)}()
+    VSI.field = K
+    VSI.basis_iterator = basis_iterator
+    VSI.basis_collected = eltype(basis_iterator)[]
+    return VSI
+  end
+end

--- a/experimental/InvariantTheory/types.jl
+++ b/experimental/InvariantTheory/types.jl
@@ -121,3 +121,50 @@ mutable struct VectorSpaceIteratorFiniteField{FieldT, IteratorT, ElemT} <: Vecto
     return VSI
   end
 end
+
+struct MSetPartitions{T}
+  M::MSet{T}
+  num_to_key::Vector{Int}
+  key_to_num::Dict{T, Int}
+
+  function MSetPartitions(M::MSet{T}) where T
+    num_to_key = collect(keys(M.dict))
+    key_to_num = Dict{T, Int}()
+    for i = 1:length(num_to_key)
+      key_to_num[num_to_key[i]] = i
+    end
+    return new{T}(M, num_to_key, key_to_num)
+  end
+end
+
+mutable struct MSetPartitionsState
+  f::Vector{Int}
+  c::Vector{Int}
+  u::Vector{Int}
+  v::Vector{Int}
+  a::Int
+  b::Int
+  l::Int
+
+  function MSetPartitionsState(MSP::MSetPartitions)
+    m = length(MSP.num_to_key)
+    n = length(MSP.M)
+    f = zeros(Int, n + 1)
+    c = zeros(Int, n*m + 1)
+    u = zeros(Int, n*m + 1)
+    v = zeros(Int, n*m + 1)
+
+    for j = 1:m
+      c[j] = j
+      u[j] = MSP.M.dict[MSP.num_to_key[j]]
+      v[j] = MSP.M.dict[MSP.num_to_key[j]]
+    end
+    f[1] = 1
+    f[2] = m + 1
+    a = 1
+    b = m + 1
+    l = 1
+
+    return new(f, c, u, v, a, b, l)
+  end
+end

--- a/src/Groups/matrices/iso_nf_fq.jl
+++ b/src/Groups/matrices/iso_nf_fq.jl
@@ -53,7 +53,7 @@ function _reduce(M::MatrixElem{fmpq}, Fp)
   return map_entries(Fp, M)
 end
 
-function isomorphic_group_over_finite_field(G::MatrixGroup{T}) where T <: Union{fmpq, nf_elem}
+function _isomorphic_group_over_finite_field(G::MatrixGroup{T}) where T <: Union{fmpq, nf_elem}
    matrices = map(x -> x.elm, gens(G))
 
    Gp, GptoF, F, OtoFq = _isomorphic_group_over_finite_field(matrices)
@@ -71,6 +71,15 @@ function isomorphic_group_over_finite_field(G::MatrixGroup{T}) where T <: Union{
    end
 
    return Gp, MapFromFunc(img, preimg, G, Gp)
+end
+
+function isomorphic_group_over_finite_field(G::MatrixGroup{T}) where T <: Union{fmpq, nf_elem}
+   res = get_special(G, :isomorphic_group_over_fq)
+   if res == nothing
+      res = _isomorphic_group_over_finite_field(G)
+      set_special(G, :isomorphic_group_over_fq => res)
+   end
+   return res
 end
 
 # Detinko, Flannery, O'Brien "Recognizing finite matrix  groups over infinite

--- a/test/InvariantTheory/primary_invariants-test.jl
+++ b/test/InvariantTheory/primary_invariants-test.jl
@@ -1,0 +1,28 @@
+@testset "Primary invariants" begin
+  # Kem99, Example 1
+  K, a = CyclotomicField(9, "a")
+  M = matrix(K, 2, 2, [ a, 0, 0, -a^3 ])
+  RG = invariant_ring(M)
+  invars = Oscar.primary_invariants_via_optimal_hsop(RG)
+  @test length(invars) == 2
+  @test sort([ total_degree(f.f) for f in invars ]) == [ 6, 9 ]
+  @test dim(ideal(polynomial_ring(RG), invars)) == 0
+
+  # Kem99, Example 2
+  K, a = CyclotomicField(9, "a")
+  M = matrix(K, 3, 3, [ a, 0, 0, 0, a^2, 0, 0, 0, a^6 ])
+  RG = invariant_ring(M)
+  invars = Oscar.primary_invariants_via_optimal_hsop(RG)
+  @test length(invars) == 3
+  @test sort([ total_degree(f.f) for f in invars ]) == [ 3, 5, 9 ]
+  @test dim(ideal(polynomial_ring(RG), invars)) == 0
+
+  # Kem99, p. 183: S_3^4
+  M1 = diagonal_matrix([ matrix(QQ, 3, 3, [ 0, 1, 0, 1, 0, 0, 0, 0, 1 ]) for i = 1:4 ])
+  M2 = diagonal_matrix([ matrix(QQ, 3, 3, [ 0, 1, 0, 0, 0, 1, 1, 0, 0 ]) for i = 1:4 ])
+  RG = invariant_ring(M1, M2)
+  invars = Oscar.primary_invariants_via_optimal_hsop(RG)
+  @test length(invars) == 12
+  @test sort([ total_degree(f.f) for f in invars ]) == [ 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3 ]
+  @test dim(ideal(polynomial_ring(RG), invars)) == 0
+end

--- a/test/InvariantTheory/runtests.jl
+++ b/test/InvariantTheory/runtests.jl
@@ -1,0 +1,5 @@
+using Oscar
+using Test
+
+include("invariant_rings-test.jl")
+include("primary_invariants-test.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,5 +39,6 @@ include("Examples/ModStdNF-test.jl")
 include("Modules/UngradedModules.jl")
 
 include("InvariantTheory/invariant_rings-test.jl")
+include("InvariantTheory/primary_invariants-test.jl")
 
 include("ToricVarieties/runtests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,6 @@ include("Examples/ModStdNF-test.jl")
 
 include("Modules/UngradedModules.jl")
 
-include("InvariantTheory/invariant_rings-test.jl")
-include("InvariantTheory/primary_invariants-test.jl")
+include("InvariantTheory/runtests.jl")
 
 include("ToricVarieties/runtests.jl")


### PR DESCRIPTION
Here is a first implementation of Kemper's algorithm for primary invariants of optimal degree.
It's not faster than Singular (at least not always) and much slower than Magma.
However, my impression is that the biggest bottleneck is at the moment the conversion of the characteristic 0 group to characteristic p, especially the lack of any caching: whenever I ask for the order of the group, the isomorphism needs to be computed again. **Is anybody working on or having concrete plans to work on a better interface for this?**
It does not make sense for me to optimize my implementation when about 80% of the runtime go into the recomputation of the group isomorphism.