### PR TITLE
Change perfect_group to return permutation groups by default

### DIFF
--- a/src/Groups/libraries/perfectgroups.jl
+++ b/src/Groups/libraries/perfectgroups.jl
@@ -28,7 +28,7 @@ function perfect_group(::Type{T}, n::Int, m::Int) where T <: GAPGroup
    return G
 end
 
-perfect_group(n::Int, m::Int) = perfect_group(FPGroup,n,m)
+perfect_group(n::Int, m::Int) = perfect_group(PermGroup,n,m)
 
 """
     perfect_identification(G::GAPGroup)

--- a/test/Groups/libraries.jl
+++ b/test/Groups/libraries.jl
@@ -39,8 +39,8 @@ end
    @test isperfect(G)
    @test !isperfect(symmetric_group(5))
 
-   @test perfect_group(120,1) isa FPGroup
-   @test perfect_group(PermGroup,120,1) isa PermGroup
+   @test perfect_group(120,1) isa PermGroup
+   @test perfect_group(FPGroup,120,1) isa FPGroup
    @test_throws ArgumentError perfect_group(MatrixGroup,120,1)
 
    @test isisomorphic(perfect_group(60,1),G)[1]


### PR DESCRIPTION
This resolves #774 for now. The underlying issue is a regression in GAP itself ([see here](https://github.com/gap-system/gap/issues/4688)), but in the meantime, this change here avoids it, and at the same time is an improvement anyway.