### PR TITLE
Disable docs previews for PRs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,5 @@ deploydocs(
 #  deps = Deps.pip("pymdown-extensions", "pygments", "mkdocs", "python-markdown-math", "mkdocs-material", "mkdocs-cinder"),
    deps = nothing,
    target = "build",
-   push_preview = true,
-#  make = () -> run(`mkdocs build`),
    make = nothing
 )


### PR DESCRIPTION
While a nice feature in theory, I am (a) not sure anybody used it in
practice, and (b) it caused checkouts of gh-pages to grow to ~900 MB
