### PR TITLE
docs: workflow to cleanup doc preview after closing PR

### DIFF
--- a/.github/workflows/CleanupDocPreview.yml
+++ b/.github/workflows/CleanupDocPreview.yml
@@ -1,0 +1,29 @@
+name: Cleanup Doc Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup-doc-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+      - name: Delete preview
+        run: |
+            if [ -d "previews/PR$PRNUM" ]; then
+              git config user.name "Documenter.jl"
+              git config user.email "documenter@juliadocs.github.io"
+              git rm -rf "previews/PR$PRNUM"
+              git commit -m "delete preview for $PRNUM"
+              git push origin gh-pages:gh-pages
+            fi
+        env:
+            PRNUM: ${{ github.event.number }}
+
+# adapted from here:
+# https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#gh-pages-Branch
+# without history cleanup


### PR DESCRIPTION
Alternative to #777, code from here: https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#gh-pages-Branch but history is kept (it does compresses very well).