### PR TITLE
ToricVarieties: Move docs under Algebraic Geometry, minor improvements

### DIFF
--- a/docs/doc.main
+++ b/docs/doc.main
@@ -128,13 +128,13 @@
 #        "Experimental/elliptic_curves.md",
 #        "Experimental/non_plane_curves.md",
 #     ],
+     "Toric Varieties" => [
+        "ToricVarieties/intro.md",
+        "ToricVarieties/NormalToricVarieties.md",
+        "ToricVarieties/ToricDivisors.md",
+     ],
   ],
 
-  "Toric Varieties" => [
-     "ToricVarieties/intro.md",
-     "ToricVarieties/NormalToricVarieties.md",
-     "ToricVarieties/ToricDivisors.md",
-  ],
 
   "General" => [
      "General/styleguide.md",

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -88,7 +88,6 @@ fan_of_variety
 fan
 nef_cone
 mori_cone
-toric_ideal
 ```
 
 ### Affine covering
@@ -99,7 +98,12 @@ affine_open_covering( v::AbstractNormalToricVariety )
 
 ### Toric ideal
 
-To come very soon.
+```@docs
+toric_ideal_binomial_generators(pts::Union{AbstractMatrix, fmpz_mat})
+toric_ideal_binomial_generators(antv::AffineNormalToricVariety)
+toric_ideal(pts::Union{AbstractMatrix, fmpz_mat})
+toric_ideal(antv::AffineNormalToricVariety)
+```
 
 ### Advanced constructions
 

--- a/src/ToricVarieties/ToricIdeals.jl
+++ b/src/ToricVarieties/ToricIdeals.jl
@@ -1,5 +1,5 @@
 @doc Markdown.doc"""
-    toric_ideal_binomial_generators(pts::Matrix{Int})
+    toric_ideal_binomial_generators(pts::Union{AbstractMatrix, fmpz_mat})
 
 Get the exponent vectors corresponding to the generators of the toric ideal
 coming from the linear integer relations between the rows of `pts`. The result
@@ -23,7 +23,7 @@ julia> toric_ideal_binomial_generators(H)
 [1   -3   0   1]
 ```
 """
-function toric_ideal_binomial_generators(pts::AbstractMatrix)
+function toric_ideal_binomial_generators(pts::Union{AbstractMatrix, fmpz_mat})
     result = kernel(matrix(ZZ, pts), side=:left)
     return result[2]
 end
@@ -84,6 +84,9 @@ ideal(x[1]^2*x[3] - x[2]^5, x[1]*x[4] - x[2]^3)
 function binomial_exponents_to_ideal(binoms::Union{AbstractMatrix, fmpz_mat})
     nvars = ncols(binoms)
     R::FmpqMPolyRing, x = PolynomialRing(QQ, "x" => 1:nvars, cached=false)
+    if nrows(binoms) == 0
+        return ideal([zero(R)])
+    end
     terms = Vector{fmpq_mpoly}(undef, nrows(binoms))
     for i in 1:nrows(binoms)
         binom = binoms[i, :]


### PR DESCRIPTION
- Move toric variety docs under algebraic geometry
- Fix boundary bug in `toric_variety`, if the ideal is zero
- Add `toric_ideal` and related entries to docs