### PR TITLE
initial step towards matrix groups in char. zero (DRAFT)

### DIFF
--- a/src/Groups/matrices/iso_oscar_gap.jl
+++ b/src/Groups/matrices/iso_oscar_gap.jl
@@ -78,6 +78,47 @@ function ring_iso_oscar_gap(F::T) where T <: Union{Nemo.FqNmodFiniteField, Nemo.
    return MapFromFunc(f, finv, F, G)
 end
 
+function ring_iso_oscar_gap(F::T) where T <: FlintRationalField
+   return MapFromFunc(x -> GAP.Obj(x), x -> fmpq(x), F, GAP.Globals.Rationals)
+end
+
+# For the moment, support only cyclotomic fields.
+# General number fields will require caching,
+# in order to achieve that Oscar matrix groups over the same number field
+# are mapped to GAP matrix groups over the same `AlgebraicExtension` field.
+function ring_iso_oscar_gap(F::T) where T <: AnticNumberField
+
+   flag, N = Hecke.iscyclotomic_type(F)
+   flag || error("$F is not a cyclotomic field")
+
+   G = GAP.Globals.CF(GAP.Obj(N))
+
+   function f(x::Nemo.nf_elem)
+      coeffs = [Nemo.coeff(x, i) for i in 0:(N-1)]
+      return GAP.Globals.CycList(GAP.GapObj(coeffs; recursive=true))
+   end
+
+   function finv(x)
+      GAP.Globals.IsCyc(x) || error("$x is not a GAP cyclotomic")
+      denom = GAP.Globals.DenominatorCyc(x)
+      n = GAP.Globals.Conductor(x)
+      mod(N, n) == 0 || error("$x does not lie in the $N-th cyclotomic field")
+      coeffs = GAP.Globals.CoeffsCyc(x * denom, N)
+      cycpol = GAP.Globals.CyclotomicPol(N)
+      dim = length(cycpol)-1
+      GAP.Globals.ReduceCoeffs(coeffs, cycpol)
+      coeffs = Vector{fmpz}(coeffs)
+      coeffs = coeffs[1:dim]
+      denom = fmpz(denom)
+      return F(coeffs) // denom
+   end
+
+   return MapFromFunc(f, finv, F, G)
+end
+
+#TODO function ring_iso_oscar_gap(F::T) where T <: QabField
+
+
 ################################################################################
 #
 #  Matrix space isomorphism
@@ -87,16 +128,15 @@ end
 # computes the isomorphism between the Oscar matrix space of dimension deg over
 # F and the corresponding GAP matrix space
 
-mat_iso_oscar_gap(F::Union{Nemo.GaloisField, Nemo.GaloisFmpzField, Nemo.FqNmodFiniteField, Nemo.FqFiniteField}, deg) = mat_iso_oscar_gap(F, deg, ring_iso_oscar_gap(F))
+mat_iso_oscar_gap(F::Union{Nemo.GaloisField, Nemo.GaloisFmpzField, Nemo.FqNmodFiniteField, Nemo.FqFiniteField, Nemo.FlintRationalField, Nemo.AnticNumberField}, deg) = mat_iso_oscar_gap(F, deg, ring_iso_oscar_gap(F))
 
-function mat_iso_oscar_gap(F::T, deg::Int, FtoGAP::MapFromFunc{T, S}) where {T <: Union{Nemo.GaloisField, Nemo.GaloisFmpzField, Nemo.FqNmodFiniteField, Nemo.FqFiniteField}, S}
+function mat_iso_oscar_gap(F::T, deg::Int, FtoGAP::MapFromFunc{T, S}) where {T <: Union{Nemo.GaloisField, Nemo.GaloisFmpzField, Nemo.FqNmodFiniteField, Nemo.FqFiniteField, Nemo.FlintRationalField, Nemo.AnticNumberField}, S}
    function f(x::MatElem)
       @assert base_ring(x) === domain(FtoGAP)
       rows = Vector{GapObj}(undef, nrows(x))
       for i in 1:nrows(x)
          rows[i] = GapObj([ FtoGAP(x[i, j]) for j in 1:ncols(x) ])
       end
-
       return GAP.Globals.ImmutableMatrix(codomain(FtoGAP), GapObj(rows), true)
    end
 
@@ -104,7 +144,6 @@ function mat_iso_oscar_gap(F::T, deg::Int, FtoGAP::MapFromFunc{T, S}) where {T <
       m = GAP.Globals.NrRows(x)
       n = GAP.Globals.NrCols(x)
       L = [ preimage(FtoGAP, x[i, j]) for i in 1:m for j in 1:n]
-
       return matrix(domain(FtoGAP), m, n, L)
    end
 


### PR DESCRIPTION
Support matrix groups over `QQ` or cyclotomic fields.
With these changes, the following works already.
```
g = symmetric_group(4)
homs = GAP.Globals.IrreducibleRepresentations(g.X)
hom = homs[3]

rng = GAP.Globals.Range(hom)
N = GAP.Globals.Conductor(GAP.Globals.FieldOfMatrixGroup(rng))
F, z = CyclotomicField(N)
d = GAP.Globals.DimensionOfMatrixGroup(rng)
G = MatrixGroup(d, F)
cod = GAP.Globals.Range(hom)
ggens = GAP.Globals.GeneratorsOfGroup(cod)
G.gens = [MatrixGroupElem(G, G.mat_iso.g(x), x) for x in ggens]
```
and then
```
julia> order(G)
6

julia> rep = GAPGroupHomomorphism{typeof(g),typeof(G)}(g, G, hom)
Group homomorphism from 
Sym( [ 1 .. 4 ] )
to
G

julia> y = rep(gen(g, 1))
[ [ 0, E(3)^2 ], [ E(3), 0 ] ]

julia> y.elm
[  0   -z_3 - 1]
[z_3          0]
```
(The fact that `y` is first printed "in GAP style" is due to the `show` method that apparently wants to avoid computing `.elm` values that are not yet known.)


