### PR TITLE
get rid of the `mat_iso` field in matrix groups

### DIFF
--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -23,7 +23,6 @@ export
 abstract type AbstractMatrixGroupElem <: GAPGroupElem{GAPGroup} end
 
 # NOTE: always defined are deg, ring and at least one between { X, gens, descr }
-# NOTE: the field mat_iso are always defined if the field X is
 """
     MatrixGroup{RE<:RingElem, T<:MatElem{RE}} <: GAPGroup
 Type of groups `G` of `n x n` matrices over the ring `R`, where `n = degree(G)` and `R = base_ring(G)`.
@@ -37,7 +36,6 @@ mutable struct MatrixGroup{RE<:RingElem, T<:MatElem{RE}} <: GAPGroup
    gens::Vector{<:AbstractMatrixGroupElem}
    descr::Symbol                       # e.g. GL, SL, symbols for isometry groups
    ring_iso::MapFromFunc # Isomorphism from the Oscar base ring to the GAP base ring
-   mat_iso::MapFromFunc # Isomorphism from the Oscar matrix space to the GAP one
 #   order::fmpz
    AbstractAlgebra.@declare_other
 
@@ -91,7 +89,7 @@ Elements of a group of type `MatrixGroup{RE<:RingElem, T<:MatElem{RE}}`
 mutable struct MatrixGroupElem{RE<:RingElem, T<:MatElem{RE}} <: AbstractMatrixGroupElem
    parent::MatrixGroup{RE, T}
    elm::T                         # Oscar matrix
-   X::GapObj                     # GAP matrix. If x isa MatrixGroupElem, then x.X = x.parent.mat_iso(x.elm)
+   X::GapObj                     # GAP matrix. If x isa MatrixGroupElem, then x.X = map_entries(x.parent.ring_iso, x.elm)
 
    # full constructor
    MatrixGroupElem{RE,T}(G::MatrixGroup{RE,T}, x::T, x_gap::GapObj) where {RE, T} = new{RE,T}(G, x, x_gap)
@@ -151,7 +149,6 @@ end
 function Base.show(io::IO, x::MatrixGroupElem)
    if isdefined(x, :elm)
       show(io, "text/plain", x.elm)
-#      print(io, x.elm)
    else
       print(io, String(GAP.Globals.StringViewObj(x.X)))
    end
@@ -210,7 +207,6 @@ function assign_from_description(G::MatrixGroup)
 end
 
 # return the G.sym if isdefined(G, :sym); otherwise, the field :sym is computed and set using information from other defined fields
-# NOTE: if G.X has to be set, then also the field G.mat_iso is set
 function Base.getproperty(G::MatrixGroup, sym::Symbol)
 
    isdefined(G,sym) && return getfield(G,sym)
@@ -218,19 +214,10 @@ function Base.getproperty(G::MatrixGroup, sym::Symbol)
    if sym === :ring_iso
       G.ring_iso = ring_iso_oscar_gap(G.ring)
 
-   elseif sym === :mat_iso
-      G.mat_iso = mat_iso_oscar_gap(G.ring, G.deg, G.ring_iso)
-
    elseif sym === :X
       if isdefined(G,:descr)
-         if !isdefined(G,:mat_iso)
-            G.mat_iso = mat_iso_oscar_gap(G.ring, G.deg, G.ring_iso)
-         end
          assign_from_description(G)
       elseif isdefined(G,:gens)
-         if !isdefined(G,:mat_iso)
-            G.mat_iso = mat_iso_oscar_gap(G.ring, G.deg, G.ring_iso)
-         end
          V = GAP.julia_to_gap([g.X for g in gens(G)])
          G.X=GAP.Globals.Group(V)
       else
@@ -248,9 +235,9 @@ function Base.getproperty(x::MatrixGroupElem, sym::Symbol)
    isdefined(x,sym) && return getfield(x,sym)
 
    if sym === :X
-      x.X = x.parent.mat_iso(x.elm)
+      x.X = map_entries(x.parent.ring_iso, x.elm)
    elseif sym == :elm
-      x.elm = preimage(x.parent.mat_iso, x.X)
+      x.elm = preimage_matrix(x.parent.ring_iso, x.X)
    end
    return getfield(x,sym)
 end
@@ -261,7 +248,7 @@ function Base.iterate(G::MatrixGroup)
   L=GAP.Globals.Iterator(G.X)
   @assert ! GAP.Globals.IsDoneIterator(L)
   i = GAP.Globals.NextIterator(L)
-  return MatrixGroupElem(G, preimage(G.mat_iso, i),i), L
+  return MatrixGroupElem(G, i), L
 end
 
 function Base.iterate(G::MatrixGroup, state::GapObj)
@@ -269,7 +256,7 @@ function Base.iterate(G::MatrixGroup, state::GapObj)
     return nothing
   end
   i = GAP.Globals.NextIterator(state)
-  return MatrixGroupElem(G, preimage(G.mat_iso, i),i), state
+  return MatrixGroupElem(G, i), state
 end
 
 ########################################################################
@@ -309,8 +296,8 @@ function lies_in(x::MatElem, G::MatrixGroup, x_gap)
    elseif isdefined(G,:descr) && G.descr==:SL
       return det(x)==1, x_gap
    else
-      if x_gap==nothing x_gap = G.mat_iso(x) end
-     # x_gap !=nothing || x_gap = G.mat_iso(x)
+      if x_gap==nothing x_gap = map_entries(G.ring_iso, x) end
+     # x_gap !=nothing || x_gap = map_entries(G.ring_iso, x)
       return GAP.Globals.in(x_gap,G.X), x_gap
    end
 end
@@ -486,14 +473,13 @@ Base.one(G::MatrixGroup) = MatrixGroupElem(G, identity_matrix(G.ring, G.deg))
 
 function Base.rand(rng::Random.AbstractRNG, G::MatrixGroup)
    x_gap = GAP.Globals.Random(GAP.wrap_rng(rng), G.X)
-   x_oscar = preimage(G.mat_iso, x_gap)
-   return MatrixGroupElem(G,x_oscar,x_gap)
+   return MatrixGroupElem(G, x_gap)
 end
 
 function gens(G::MatrixGroup)
    if !isdefined(G,:gens)
       L = GAP.Globals.GeneratorsOfGroup(G.X)
-      G.gens=[MatrixGroupElem(G,preimage(G.mat_iso, a),a) for a in L]
+      G.gens = [MatrixGroupElem(G, a) for a in L]
    end
    return G.gens
 end
@@ -806,7 +792,6 @@ function conjugacy_classes_subgroups(G::MatrixGroup)
    V = Vector{GroupConjClass{typeof(G), typeof(G)}}(undef, length(L))
    for i in 1:length(L)
       y = MatrixGroup(G.deg,G.ring)
-      y.mat_iso = G.mat_iso
       y.X = GAP.Globals.Representative(L[i])
       V[i] = _conjugacy_class(G,y,L[i])
    end
@@ -819,7 +804,6 @@ function conjugacy_classes_maximal_subgroups(G::MatrixGroup)
    V = Vector{GroupConjClass{typeof(G), typeof(G)}}(undef, length(L))
    for i in 1:length(L)
       y = MatrixGroup(G.deg,G.ring)
-      y.mat_iso = G.mat_iso
       y.X = GAP.Globals.Representative(L[i])
       V[i] = _conjugacy_class(G,y,L[i])
    end
@@ -829,7 +813,6 @@ end
 
 function Base.rand(rng::Random.AbstractRNG, C::GroupConjClass{S,T}) where S<:MatrixGroup where T<:MatrixGroup
    H = MatrixGroup(C.X.deg,C.X.ring)
-   H.mat_iso = C.X.mat_iso
    H.X = GAP.Globals.Random(GAP.wrap_rng(rng), C.CC)
    return H
 end

--- a/src/Groups/matrices/form_group.jl
+++ b/src/Groups/matrices/form_group.jl
@@ -490,7 +490,6 @@ function preserved_quadratic_forms(G::MatrixGroup{S,T}) where {S,T}
       f = quadratic_form(preimage_matrix(G.ring_iso, GAP.Globals.GramMatrix(f_gap)))
       f.X = f_gap
       f.ring_iso = G.ring_iso
-      f.mat_iso = G.mat_iso
       push!(R,f)
    end
    return R
@@ -518,7 +517,6 @@ function preserved_sesquilinear_forms(G::MatrixGroup{S,T}) where {S,T}
          error("Invalid form")
       end
       f.X = f_gap
-      f.mat_iso = G.mat_iso
       push!(R,f)
    end
    return R

--- a/src/Groups/matrices/form_group.jl
+++ b/src/Groups/matrices/form_group.jl
@@ -429,7 +429,7 @@ is not absolutely irreducible.
 function invariant_bilinear_form(G::MatrixGroup)
    V = GAP.Globals.GModuleByMats(GAP.Globals.GeneratorsOfGroup(G.X), codomain(G.ring_iso))
    B = GAP.Globals.MTX.InvariantBilinearForm(V)
-   return preimage(G.mat_iso, B)
+   return preimage_matrix(G.ring_iso, B)
 end
 
 """
@@ -445,7 +445,7 @@ is not absolutely irreducible.
 function invariant_sesquilinear_form(G::MatrixGroup)
    V = GAP.Globals.GModuleByMats(GAP.Globals.GeneratorsOfGroup(G.X), codomain(G.ring_iso))
    B = GAP.Globals.MTX.InvariantSesquilinearForm(V)
-   return preimage(G.mat_iso, B)
+   return preimage_matrix(G.ring_iso, B)
 end
 
 """
@@ -462,7 +462,7 @@ function invariant_quadratic_form(G::MatrixGroup)
    if iseven(characteristic(base_ring(G)))
       V = GAP.Globals.GModuleByMats(GAP.Globals.GeneratorsOfGroup(G.X), codomain(G.ring_iso))
       B = GAP.Globals.MTX.InvariantQuadraticForm(V)
-      return _upper_triangular_version(preimage(G.mat_iso, B))
+      return _upper_triangular_version(preimage_matrix(G.ring_iso, B))
    else
       m = invariant_bilinear_form(G)
       for i in 1:degree(G), j in i+1:degree(G)
@@ -487,7 +487,7 @@ function preserved_quadratic_forms(G::MatrixGroup{S,T}) where {S,T}
    L = GAP.Globals.PreservedQuadraticForms(G.X)
    R = SesquilinearForm{S}[]
    for f_gap in L
-      f = quadratic_form(preimage(G.mat_iso, GAP.Globals.GramMatrix(f_gap)))
+      f = quadratic_form(preimage_matrix(G.ring_iso, GAP.Globals.GramMatrix(f_gap)))
       f.X = f_gap
       f.ring_iso = G.ring_iso
       f.mat_iso = G.mat_iso
@@ -509,11 +509,11 @@ function preserved_sesquilinear_forms(G::MatrixGroup{S,T}) where {S,T}
    R = SesquilinearForm{S}[]
    for f_gap in L
       if GAP.Globals.IsHermitianForm(f_gap)
-         f = hermitian_form(preimage(G.mat_iso, GAP.Globals.GramMatrix(f_gap)))
+         f = hermitian_form(preimage_matrix(G.ring_iso, GAP.Globals.GramMatrix(f_gap)))
       elseif GAP.Globals.IsSymmetricForm(f_gap)
-         f = symmetric_form(preimage(G.mat_iso, GAP.Globals.GramMatrix(f_gap)))
+         f = symmetric_form(preimage_matrix(G.ring_iso, GAP.Globals.GramMatrix(f_gap)))
       elseif GAP.Globals.IsAlternatingForm(f_gap)
-         f = alternating_form(preimage(G.mat_iso, GAP.Globals.GramMatrix(f_gap)))
+         f = alternating_form(preimage_matrix(G.ring_iso, GAP.Globals.GramMatrix(f_gap)))
       else
          error("Invalid form")
       end
@@ -598,11 +598,11 @@ function isometry_group(f::SesquilinearForm{T}) where T
          e = -1
       end
    end
-   Xf = iscongruent(SesquilinearForm( preimage(fn.mat_iso, _standard_form(fn.descr,e,r,F)), fn.descr),fn)[2]
+   Xf = iscongruent(SesquilinearForm(preimage_matrix(fn.ring_iso, _standard_form(fn.descr, e, r, F)), fn.descr), fn)[2]
 # if dimension is odd, fn may be congruent to a scalar multiple of the standard form
 # TODO: I don't really need a primitive_element(F); I just need a non-square in F. Is there a faster way to get it?
    if Xf==nothing && isodd(r)
-      Xf = iscongruent(SesquilinearForm( primitive_element(F)*preimage(fn.mat_iso, _standard_form(fn.descr,e,r,F)), fn.descr),fn)[2]
+      Xf = iscongruent(SesquilinearForm(primitive_element(F)*preimage_matrix(fn.ring_iso, _standard_form(fn.descr, e, r, F)), fn.descr), fn)[2]
    end
 
 

--- a/src/Groups/matrices/forms.jl
+++ b/src/Groups/matrices/forms.jl
@@ -26,7 +26,7 @@ export
 
 # descr is always defined
 # matrix is always defined except when descr="quadratic"; in such a case, at least one of matrix and pol is defined
-# NOTE: the fields ring_iso and mat_iso are always defined if the field X is
+# NOTE: the field ring_iso is always defined if the field X is
 """
     SesquilinearForm{T<:RingElem}
 
@@ -39,7 +39,6 @@ mutable struct SesquilinearForm{T<:RingElem}
    pol::MPolyElem{T}     # only for quadratic forms
    X::GapObj
    ring_iso::MapFromFunc
-   mat_iso::MapFromFunc
 
    function SesquilinearForm{T}(B::MatElem{T},sym) where T
       if sym==:hermitian

--- a/src/Groups/matrices/forms.jl
+++ b/src/Groups/matrices/forms.jl
@@ -310,9 +310,9 @@ end
 
 
 function assign_from_description(f::SesquilinearForm)
-   if f.descr==:quadratic f.X=GAP.Globals.QuadraticFormByMatrix(f.mat_iso(gram_matrix(f)),codomain(f.ring_iso))
-   elseif f.descr==:symmetric || f.descr==:alternating f.X=GAP.Globals.BilinearFormByMatrix(f.mat_iso(gram_matrix(f)),codomain(f.ring_iso))
-   elseif f.descr==:hermitian f.X=GAP.Globals.HermitianFormByMatrix(f.mat_iso(gram_matrix(f)),codomain(f.ring_iso))
+   if f.descr == :quadratic f.X = GAP.Globals.QuadraticFormByMatrix(map_entries(f.ring_iso, gram_matrix(f)), codomain(f.ring_iso))
+   elseif f.descr == :symmetric || f.descr == :alternating f.X = GAP.Globals.BilinearFormByMatrix(map_entries(f.ring_iso, gram_matrix(f)), codomain(f.ring_iso))
+   elseif f.descr == :hermitian f.X = GAP.Globals.HermitianFormByMatrix(map_entries(f.ring_iso, gram_matrix(f)), codomain(f.ring_iso))
    else error("unsupported description")
    end
 end
@@ -325,14 +325,8 @@ function Base.getproperty(f::SesquilinearForm, sym::Symbol)
    if sym === :ring_iso
       f.ring_iso = ring_iso_oscar_gap(base_ring(f))
 
-   elseif sym === :mat_iso
-      f.mat_iso = mat_iso_oscar_gap(base_ring(f), nrows(gram_matrix(f)), f.ring_iso)
-
    elseif sym == :X
       if !isdefined(f, :X)
-         if !isdefined(f,:mat_iso)
-            f.mat_iso = mat_iso_oscar_gap(base_ring(f), nrows(gram_matrix(f)), f.ring_iso)
-         end
          assign_from_description(f)
       end
 

--- a/src/Groups/matrices/iso_nf_fq.jl
+++ b/src/Groups/matrices/iso_nf_fq.jl
@@ -65,7 +65,7 @@ function isomorphic_group_over_finite_field(G::MatrixGroup{T}) where T <: Union{
    gen = gens(G)
 
    preimg = function(y)
-     return GAP.Globals.MappedWord(GAP.Globals.UnderlyingElement(GAP.Globals.Image(GptoF, Gp.mat_iso(y.elm))),
+     return GAP.Globals.MappedWord(GAP.Globals.UnderlyingElement(GAP.Globals.Image(GptoF, map_entries(Gp.ring_iso, y.elm))),
                                    GAP.Globals.FreeGeneratorsOfFpGroup(F),
                                    GAP.GapObj(gen))
    end

--- a/src/Groups/matrices/iso_oscar_gap.jl
+++ b/src/Groups/matrices/iso_oscar_gap.jl
@@ -39,7 +39,7 @@ function ring_iso_oscar_gap(F::T) where T <: Union{Nemo.FqNmodFiniteField, Nemo.
    Fp_gap = GAP.Globals.GF(GAP.Obj(p)) # the prime field in GAP
    e = GAP.Globals.One(Fp_gap)
 
-   # prime fields are easy and efficient to deal with, handle them seperately
+   # prime fields are easy and efficient to deal with, handle them separately
    if d == 1
       f1(x::Union{Nemo.fq_nmod, Nemo.fq}) = GAP.Obj(coeff(x, 0))*e
       finv1(x) = F(GAP.gap_to_julia(GAP.Globals.IntFFE(x)))
@@ -123,30 +123,29 @@ end
 #
 #  Matrix space isomorphism
 #
+#  Using the known ring isomorphism from an Oscar ring to a GAP ring,
+#  we can map matrices from Oscar to GAP using `map_entries`.
+#  (The generic `map_entries` method cannot be used because the concepts of
+#  `parent`and `_change_base_ring` do not fit to the situation in GAP.)
+#  For the direction from GAP to Oscar, we introduce a generic function
+#  `preimage_matrix` that takes the `ring_iso` and a GAP matrix.
+#
 ################################################################################
 
-# computes the isomorphism between the Oscar matrix space of dimension deg over
-# F and the corresponding GAP matrix space
-
-mat_iso_oscar_gap(F::Union{Nemo.GaloisField, Nemo.GaloisFmpzField, Nemo.FqNmodFiniteField, Nemo.FqFiniteField, Nemo.FlintRationalField, Nemo.AnticNumberField}, deg) = mat_iso_oscar_gap(F, deg, ring_iso_oscar_gap(F))
-
-function mat_iso_oscar_gap(F::T, deg::Int, FtoGAP::MapFromFunc{T, S}) where {T <: Union{Nemo.GaloisField, Nemo.GaloisFmpzField, Nemo.FqNmodFiniteField, Nemo.FqFiniteField, Nemo.FlintRationalField, Nemo.AnticNumberField}, S}
-   function f(x::MatElem)
-      @assert base_ring(x) === domain(FtoGAP)
-      rows = Vector{GapObj}(undef, nrows(x))
-      for i in 1:nrows(x)
-         rows[i] = GapObj([ FtoGAP(x[i, j]) for j in 1:ncols(x) ])
-      end
-      return GAP.Globals.ImmutableMatrix(codomain(FtoGAP), GapObj(rows), true)
+function AbstractAlgebra.map_entries(f::Map{T, GapObj}, a::MatElem) where T
+   isempty(a) && error("empty matrices are not supported by GAP")
+   @assert base_ring(a) === domain(f)
+   rows = Vector{GapObj}(undef, nrows(a))
+   for i in 1:nrows(a)
+      rows[i] = GapObj([f(a[i, j]) for j in 1:ncols(a)])
    end
+   return GAP.Globals.ImmutableMatrix(codomain(f), GapObj(rows), true)
+end
 
-   function finv(x::GapObj)
-      m = GAP.Globals.NrRows(x)
-      n = GAP.Globals.NrCols(x)
-      L = [ preimage(FtoGAP, x[i, j]) for i in 1:m for j in 1:n]
-      return matrix(domain(FtoGAP), m, n, L)
-   end
-
-   M = MatrixSpace(F, deg, deg)
-   return MapFromFunc(f, finv, M, GAP.Globals.MatrixAlgebra(codomain(FtoGAP), deg))
+function preimage_matrix(f::Map{T, GapObj}, a::GapObj) where T
+   isdefined(f.header, :preimage) || error("No preimage function known")
+   m = GAP.Wrappers.NumberRows(a)
+   n = GAP.Wrappers.NumberColumns(a)
+   L = [f.header.preimage(a[i, j]) for i in 1:m for j in 1:n]
+   return matrix(domain(f), m, n, L)
 end

--- a/src/Groups/matrices/transform_form.jl
+++ b/src/Groups/matrices/transform_form.jl
@@ -396,8 +396,9 @@ function iscongruent(f::SesquilinearForm{T}, g::SesquilinearForm{T}) where T <: 
    
    if f.descr==:quadratic
       if iseven(characteristic(F))            # in this case we use the GAP algorithms
-         Bg = preimage(g.mat_iso, GAP.Globals.BaseChangeToCanonical(g.X))
-         Bf = preimage(f.mat_iso, GAP.Globals.BaseChangeToCanonical(f.X))
+         Bg = preimage_matrix(g.ring_iso, GAP.Globals.BaseChangeToCanonical(g.X))
+         Bf = preimage_matrix(f.ring_iso, GAP.Globals.BaseChangeToCanonical(f.X))
+
          UTf = _upper_triangular_version(Bf*gram_matrix(f)*transpose(Bf))
          UTg = _upper_triangular_version(Bg*gram_matrix(g)*transpose(Bg))
          if _is_scalar_multiple_mat(UTf, UTg)[1]

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -32,7 +32,6 @@ function _as_subgroup_bare(G::T, H::GapObj) where T
   elseif T<:MatrixGroup
     H1 = MatrixGroup(G.deg,G.ring)
     H1.ring_iso = G.ring_iso
-    H1.mat_iso = G.mat_iso
     H1.X = H
   else
     H1 = T(H)

--- a/test/Groups/forms.jl
+++ b/test/Groups/forms.jl
@@ -24,7 +24,6 @@
    @test f isa SesquilinearForm
    @test gram_matrix(f)==B
    @test ishermitian_form(f)
-   @test f.mat_iso isa MapFromFunc
    @test f.X isa GAP.GapObj
    @test_throws AssertionError f = symmetric_form(B)
    @test_throws AssertionError f = alternating_form(B)

--- a/test/InvariantTheory/invariant_rings-test.jl
+++ b/test/InvariantTheory/invariant_rings-test.jl
@@ -93,7 +93,7 @@
   gl = general_linear_group(4, 5)
   gapmats = [GAP.Globals.PermutationMat(elm.X, 4, GAP.Globals.GF(5))
              for elm in gens(symmetric_group(4))]
-  s4 = sub(gl, [MatrixGroupElem(gl, preimage(gl.mat_iso, x), x) for x in gapmats])[1]
+  s4 = sub(gl, [MatrixGroupElem(gl, x) for x in gapmats])[1]
   I = invariant_ring(s4)
   m = @inferred molien_series(S, I)
   @test m == 1//((1 - t)*(1 - t^2)*(1 - t^3)*(1 - t^4))


### PR DESCRIPTION
@fieker had observed that an individual `mat_iso` field is not needed in matrix groups and forms.
What we need is the possibility to translate matrices from Oscar to GAP and back,
and this can be done generically via the known `ring_iso` that translates matrix entries.
The recommended user function for the direction from Oscar to GAP is `map_entries`.
(We cannot use the available `map_entries` method because `parent`and `_change_base_ring` do not fit to the situation in GAP.)
For the direction from GAP to Oscar, we introduce `preimage_matrix`:
The former calls of the form `preimage(G.mat_iso, x)` got replaced by `preimage_matrix(G.ring_iso, x)`.

In fact, the direction from GAP to Oscar seems to be needed only in few places.
When one constructs a matrix group element from a GAP matrix,
one can create the Oscar matrix (field `elm`) only on demand.
This feature had not really been used up to now.
With the current changes, the computations via `preimage_matrix` get delayed until someone accesses the `elm` field.