### PR TITLE
changed `show` for `MatrixGroupElem` ...

### DIFF
--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -145,13 +145,7 @@ function Base.show(io::IO, x::MatrixGroup)
    end
 end
 
-function Base.show(io::IO, x::MatrixGroupElem)
-   if isdefined(x, :elm)
-      show(io, "text/plain", x.elm)
-   else
-      print(io, String(GAP.Globals.StringViewObj(x.X)))
-   end
-end
+Base.show(io::IO, x::MatrixGroupElem) = show(io, "text/plain", x.elm)
 
 group_element(G::MatrixGroup, x::GapObj) = MatrixGroupElem(G,x)
 

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -145,7 +145,8 @@ function Base.show(io::IO, x::MatrixGroup)
    end
 end
 
-Base.show(io::IO, x::MatrixGroupElem) = show(io, "text/plain", x.elm)
+Base.show(io::IO, x::MatrixGroupElem) = show(io, x.elm)
+Base.show(io::IO, mi::MIME"text/plain", x::MatrixGroupElem) = show(io, mi, x.elm)
 
 group_element(G::MatrixGroup, x::GapObj) = MatrixGroupElem(G,x)
 


### PR DESCRIPTION
... such that always the Oscar matrix is shown; for that, the computation of the `elm` field is triggered by `show` if missing.

I found it very irritating that certain matrix group elements were shown in "GAP style" if their `elm` field was not (yet) known.
Here is an example.

Before the change:
```julia
julia> g = general_linear_group(2, 5);  x = gen(g, 1)
[2   0]
[0   1]

julia> y = MatrixGroupElem(g, x.X);   # create an element from a GAP matrix, without the corresponding Oscar matrix

julia> isdefined(y, :elm)
false

julia> y    # the `show` method does not compute `y.elm`, and shows the GAP matrix
[ [ Z(5), 0*Z(5) ], [ 0*Z(5), Z(5)^0 ] ]

julia> y.elm   # compute the Oscar matrix and store it
[2   0]
[0   1]

julia> y    # now the Oscar matrix is shown by `show`
[2   0]
[0   1]
```
After the change:
```julia
julia> g = general_linear_group(2, 5);  x = gen(g, 1)
[2   0]
[0   1]

julia> y = MatrixGroupElem(g, x.X);    # create an element from a GAP matrix, without the corresponding Oscar matrix

julia> isdefined(y, :elm)
false

julia> y    # the show method computes `y.elm`
[2   0]
[0   1]

julia> isdefined(y, :elm)
true
```