### PR TITLE
fix for `ring_iso_oscar_gap`

### DIFF
--- a/src/Groups/matrices/iso_oscar_gap.jl
+++ b/src/Groups/matrices/iso_oscar_gap.jl
@@ -56,7 +56,20 @@ function ring_iso_oscar_gap(F::T) where T <: Union{Nemo.FqNmodFiniteField, Nemo.
    G = GAP.Globals.GF(Fp_gap, f_gap)
 
    # compute matching bases of both fields
-   Basis_G = GAP.Globals.Basis(G)
+   if GAP.Globals.IsAlgebraicExtension(G)
+#FIXME:
+# As soon as the problem from https://github.com/gap-system/gap/issues/4694
+# is fixed, go back to `Basis_G = GAP.Globals.Basis(G)` also in this case.
+# Note that the above `GF` call delegates to `FieldExtension`,
+# and we want a basis in the filter `IsCanonicalBasisAlgebraicExtension`.
+      Basis_G = GAP.Globals.Objectify(GAP.Globals.NewType(
+                GAP.Globals.FamilyObj(G),
+                GAP.Globals.IsCanonicalBasisAlgebraicExtension),
+                GAP.NewPrecord(0))
+      GAP.Globals.SetUnderlyingLeftModule(Basis_G, G)
+   else
+      Basis_G = GAP.Globals.Basis(G)
+   end
    Basis_F = Vector{elem_type(F)}(undef, d)
    Basis_F[1] = F(1)
    for i = 2:d

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -19,6 +19,14 @@
       end
    end
 
+   # Test a large non-prime field.
+   F, _ = GF(next_prime(10^6), 2)
+   f = Oscar.ring_iso_oscar_gap(F)
+   for x in [ F(3), gen(F) ]
+      a = f(x)
+      @test preimage(f, a) == x
+   end
+
    F = GF(29,1)[1]
    z = F(2)
    G = GL(3,F)


### PR DESCRIPTION
... for certain finite fields.
The changes are just a workaround for a GAP bug,
see gap-system/gap/issues/4694.