### PR TITLE
Improve documentation of toric varieties

### DIFF
--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -22,103 +22,14 @@ the affine and non-affine case:
 
 ## Constructors
 
+### Affine toric varieties
+
 ```@docs
 AffineNormalToricVariety(C::Cone)
-CyclicQuotientSingularity
 NormalToricVariety(C::Cone)
-NormalToricVariety(PF::PolyhedralFan)
-NormalToricVariety(P::Polyhedron)
-toric_projective_space
-hirzebruch_surface
-del_pezzo
 ```
 
-
-## Properties of toric varieties
-
-```@docs
-hastorusfactor
-isaffine
-iscomplete
-isfano
-isgorenstein
-issimplicial
-issmooth
-isnormal
-isorbifold
-isprojective
-isq_gorenstein
-```
-
-
-## Operations for toric varieties
-
-### Dimensions
-
-```@docs
-dim
-dim_of_torusfactor
-ith_betti_number(v::AbstractNormalToricVariety, i::Int)
-euler_characteristic
-```
-
-### Rings and ideals
-
-```@docs
-cox_ring
-stanley_reisner_ideal
-irrelevant_ideal
-```
-
-### Characters, Weil divisor and the class group
-
-```@docs
-character_lattice
-torusinvariant_divisor_group
-class_group
-map_from_character_to_principal_divisors
-map_from_weil_divisors_to_class_group
-torusinvariant_prime_divisors
-```
-
-### Cones and fans
-
-```@docs
-fan_of_variety
-fan
-nef_cone
-mori_cone
-```
-
-### Affine covering
-
-```@docs
-affine_open_covering( v::AbstractNormalToricVariety )
-```
-
-### Toric ideal
-
-```@docs
-binomial_exponents_to_ideal(binoms::Union{AbstractMatrix, fmpz_mat})
-toric_ideal(pts::Union{AbstractMatrix, fmpz_mat})
-toric_ideal(antv::AffineNormalToricVariety)
-```
-
-### Advanced constructions
-
-```@docs
-blowup_on_ith_minimal_torus_orbit(v::AbstractNormalToricVariety, n::Int)
-Base.:*(v::AbstractNormalToricVariety, w::AbstractNormalToricVariety)
-```
-
-### Comparison
-
-```@docs
-isprojective_space(v::AbstractNormalToricVariety)
-```
-
-
-## Cyclic Quotient Singularities
+### Cyclic Quotient Singularities
 
 Cyclic quotient singularities are quotients of $\mathbb{C}^2$ by the action of
 $\mathbb{Z}/n\mathbb{Z}$ acting via 
@@ -132,8 +43,103 @@ For the notation we rely on [Chr91](@cite) and [Ste91](@cite).
     commonly known continued fraction.
 
 ```@docs
+CyclicQuotientSingularity(n::fmpz, q::fmpz)
 continued_fraction_hirzebruch_jung(cqs::CyclicQuotientSingularity)
 continued_fraction_hirzebruch_jung_to_rational(v::Vector{fmpz})
 dual_continued_fraction_hirzebruch_jung(cqs::CyclicQuotientSingularity)
 rational_to_continued_fraction_hirzebruch_jung(r::fmpq)
+```
+
+### Normal toric varieties
+
+```@docs
+NormalToricVariety(PF::PolyhedralFan)
+NormalToricVariety(P::Polyhedron)
+```
+
+### Famous toric vareties
+
+```@docs
+del_pezzo(b::Int)
+hirzebruch_surface(r::Int)
+toric_projective_space(d::Int)
+```
+
+### Further constructions
+
+```@docs
+blowup_on_ith_minimal_torus_orbit(v::AbstractNormalToricVariety, n::Int)
+Base.:*(v::AbstractNormalToricVariety, w::AbstractNormalToricVariety)
+```
+
+
+## Properties of toric varieties
+
+```@docs
+hastorusfactor(v::AbstractNormalToricVariety)
+isaffine(v::AbstractNormalToricVariety)
+iscomplete(v::AbstractNormalToricVariety)
+isfano(v::AbstractNormalToricVariety)
+isgorenstein(v::AbstractNormalToricVariety)
+issimplicial(v::AbstractNormalToricVariety)
+issmooth(v::AbstractNormalToricVariety)
+isnormal(v::AbstractNormalToricVariety)
+isorbifold(v::AbstractNormalToricVariety)
+isprojective(v::AbstractNormalToricVariety)
+isprojective_space(v::AbstractNormalToricVariety)
+isq_gorenstein(v::AbstractNormalToricVariety)
+```
+
+
+## Operations for toric varieties
+
+### Affine open covering
+
+```@docs
+affine_open_covering( v::AbstractNormalToricVariety )
+```
+
+### Characters, Weil divisors and the class group
+
+```@docs
+character_lattice(v::AbstractNormalToricVariety)
+class_group(v::AbstractNormalToricVariety)
+map_from_character_to_principal_divisors(v::AbstractNormalToricVariety)
+map_from_weil_divisors_to_class_group(v::AbstractNormalToricVariety)
+torusinvariant_divisor_group(v::AbstractNormalToricVariety)
+torusinvariant_prime_divisors(v::AbstractNormalToricVariety)
+```
+
+### Cones and fans
+
+```@docs
+fan_of_variety(v::NormalToricVariety)
+fan(v::NormalToricVariety)
+mori_cone(v::NormalToricVariety)
+nef_cone(v::NormalToricVariety)
+```
+
+### Dimensions
+
+```@docs
+dim(v::AbstractNormalToricVariety)
+dim_of_torusfactor(v::AbstractNormalToricVariety)
+euler_characteristic(v::AbstractNormalToricVariety)
+ith_betti_number(v::AbstractNormalToricVariety, i::Int)
+```
+
+### Rings and ideals
+
+```@docs
+cox_ring(v::AbstractNormalToricVariety)
+irrelevant_ideal(v::AbstractNormalToricVariety)
+stanley_reisner_ideal(v::AbstractNormalToricVariety)
+```
+
+### Toric ideals
+
+```@docs
+binomial_exponents_to_ideal(binoms::Union{AbstractMatrix, fmpz_mat})
+toric_ideal(pts::Union{AbstractMatrix, fmpz_mat})
+toric_ideal(antv::AffineNormalToricVariety)
 ```

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -35,7 +35,7 @@ AffineNormalToricVariety(v::NormalToricVariety)
 Cyclic quotient singularities are quotients of $\mathbb{C}^2$ by the action of
 $\mathbb{Z}/n\mathbb{Z}$ acting via 
 $$\left(\begin{array}{cc}\xi & 0\\0 & \xi^q\end{array}\right)$$,
-where $\xi$ is a $n$-th root of unity, and $0<q<n$ are two coprime integers.
+where $\xi$ is a $n$-th root of unity, and $q$ and $n$ are integers, such that $q$ is coprime with $n$, and $0<q<n$.
 
 For the notation we rely on [Chr91](@cite) and [Ste91](@cite).
 

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -40,8 +40,8 @@ where $\xi$ is a $n$-th root of unity, and $q$ and $n$ are integers, such that $
 For the notation we rely on [Chr91](@cite) and [Ste91](@cite).
 
 !!! warning
-    Note that the notion of Hirzebruch-Jung continued fraction differs from the
-    commonly known continued fraction.
+    Note that [Chr91](@cite) and [Ste91](@cite) use Hirzebruch-Jung continued fraction, which differ from the
+    commonly known continued fraction from literature and used in the rest of OSCAR.
 
 ```@docs
 CyclicQuotientSingularity(n::fmpz, q::fmpz)

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -27,6 +27,7 @@ the affine and non-affine case:
 ```@docs
 AffineNormalToricVariety(C::Cone)
 NormalToricVariety(C::Cone)
+AffineNormalToricVariety(v::NormalToricVariety)
 ```
 
 ### Cyclic Quotient Singularities

--- a/docs/src/ToricVarieties/ToricDivisors.md
+++ b/docs/src/ToricVarieties/ToricDivisors.md
@@ -19,28 +19,28 @@ correspond to the rays of the underlying fan.
 ## Constructors
 
 ```@docs
-ToricDivisor( v::AbstractNormalToricVariety, coeffs::Vector{Int} )
-DivisorOfCharacter( v::AbstractNormalToricVariety, character::Vector{Int} )
+DivisorOfCharacter(v::AbstractNormalToricVariety, character::Vector{Int})
+ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{Int})
 ```
 
 ## Properties of toric divisors
 
 ```@docs
-isample
-isbasepoint_free
-iscartier
+isample(td::ToricDivisor)
+isbasepoint_free(td::ToricDivisor)
+iscartier(td::ToricDivisor)
 iseffective(td::ToricDivisor)
-isintegral(td::ToricDivisor) 
-isnef
-isprime_divisor
-isprincipal
-isq_cartier
-isvery_ample
+isintegral(td::ToricDivisor)
+isnef(td::ToricDivisor)
+isprime_divisor(td::ToricDivisor)
+isprincipal(td::ToricDivisor)
+isq_cartier(td::ToricDivisor)
+isvery_ample(td::ToricDivisor)
 ```
 
 ## Operations for toric divisors
 
 ```@docs
-polyhedron(td::ToricDivisor)
 coefficients(td::ToricDivisor)
+polyhedron(td::ToricDivisor)
 ```

--- a/src/ToricVarieties/AttributesAndMethods.jl
+++ b/src/ToricVarieties/AttributesAndMethods.jl
@@ -93,7 +93,7 @@ export cox_ring
 
 
 @doc Markdown.doc"""
-    stanley_reisner_ideal(v::NormalToricVariety)
+    stanley_reisner_ideal(v::AbstractNormalToricVariety)
 
 Computes the Stanley-Reisner ideal of a normal toric variety `v`.
 
@@ -116,7 +116,7 @@ export stanley_reisner_ideal
 
 
 @doc Markdown.doc"""
-    irrelevant_ideal(v::NormalToricVariety)
+    irrelevant_ideal(v::AbstractNormalToricVariety)
 
 Computes the irrelevant ideal of a normal toric variety `v`.
 
@@ -129,7 +129,7 @@ julia> length(irrelevant_ideal(p2).gens)
 1
 ```
 """
-function irrelevant_ideal(v::NormalToricVariety)
+function irrelevant_ideal(v::AbstractNormalToricVariety)
     # prepare maximal cone presentation
     max_cones = [findall(x->x!=0, l) for l in eachrow(pm_object(v).MAXIMAL_CONES)]
     n_ray = size(pm_object(v).RAYS, 1)
@@ -183,7 +183,7 @@ export character_lattice
 
 
 @doc Markdown.doc"""
-    torusinvariant_divisor_group(v::NormalToricVariety)
+    torusinvariant_divisor_group(v::AbstractNormalToricVariety)
 
 Computes the torusinvariant divisor group of a normal toric variety `v`.
 

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -169,7 +169,7 @@ export hirzebruch_surface
 
 
 @doc Markdown.doc"""
-    delPezzo(b::Int)
+    del_pezzo(b::Int)
 
 Constructs the delPezzo surface with b blowups for b at most 3.
 

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -119,6 +119,23 @@ end
 
 export NormalToricVariety
 
+@doc Markdown.doc"""
+    AffineNormalToricVariety(v::NormalToricVariety)
+
+For internal design, we make a strict distinction between
+normal toric varieties and affine toric varieties.
+Given an affine, normal toric variety `v`,
+this method turns it into an affine toric variety.
+
+# Examples
+```jldoctest
+julia> v = NormalToricVariety(positive_hull([1 0; 0 1]))
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> affineVariety = AffineNormalToricVariety(v)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+```
+"""
 function AffineNormalToricVariety(v::NormalToricVariety)
     isaffine(v) || error("Cannot construct affine toric variety from non-affine input")
     return AffineNormalToricVariety(pm_object(v))

--- a/src/ToricVarieties/ToricDivisors.jl
+++ b/src/ToricVarieties/ToricDivisors.jl
@@ -71,9 +71,9 @@ export DivisorOfCharacter
 ######################
 
 @doc Markdown.doc"""
-    iscartier(d::ToricDivisor)
+    iscartier(td::ToricDivisor)
 
-Checks if the divisor `d` is Cartier.
+Checks if the divisor `td` is Cartier.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
- Restructure content (in particular the constructors for toric varieties).
- Provide more information to filter the docstring, as currently documentation for many other methods is displayed.