### PR TITLE
Bugfix in doctest of PlaneCurve.jl

### DIFF
--- a/experimental/PlaneCurve/PlaneCurve.jl
+++ b/experimental/PlaneCurve/PlaneCurve.jl
@@ -278,11 +278,8 @@ julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 julia> C = Oscar.AffinePlaneCurve(y^3*x^6 - y^6*x^2)
 Affine plane curve defined by x^6*y^3 - x^2*y^6
 
-julia> Oscar.curve_components(C)
-Dict{Oscar.PlaneCurveModule.AffinePlaneCurve{fmpq}, Int64} with 3 entries:
-  x^4 - y^3 => 1
-  y         => 3
-  x         => 2
+julia> length(Oscar.curve_components(C))
+3
 ```
 """
 function curve_components(C::PlaneCurve{S}) where S <: FieldElem


### PR DESCRIPTION
The doctests of the current master fail (or me):

> Error: doctest failure in ~/Oscar.jl/experimental/PlaneCurve/PlaneCurve.jl:274-286
│ 
│ ```jldoctest
│ julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
│ (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
│ 
│ julia> C = Oscar.AffinePlaneCurve(y^3*x^6 - y^6*x^2)
│ Affine plane curve defined by x^6*y^3 - x^2*y^6
│ 
│ julia> Oscar.curve_components(C)
│ Dict{Oscar.PlaneCurveModule.AffinePlaneCurve{fmpq}, Int64} with 3 entries:
│   x^4 - y^3 => 1
│   y         => 3
│   x         => 2
│ ```
│ 
│ Subexpression:
│ 
│ Oscar.curve_components(C)
│ 
│ Evaluated output:
│ 
│ Dict{Oscar.PlaneCurveModule.AffinePlaneCurve{fmpq}, Int64} with 3 entries:
│   y         => 3
│   x         => 2
│   x^4 - y^3 => 1
│ 
│ Expected output:
│ 
│ Dict{Oscar.PlaneCurveModule.AffinePlaneCurve{fmpq}, Int64} with 3 entries:
│   x^4 - y^3 => 1
│   y         => 3
│   x         => 2
│ 
│   diff =
│    Dict{Oscar.PlaneCurveModule.AffinePlaneCurve{fmpq}, Int64} with 3 entries:
│      x^4 - y^3 => 1
│      y         => 3
│      x         => 22
│      x^4 - y^3 => 1
└ @ Documenter.DocTests ~/Oscar.jl/experimental/PlaneCurve/PlaneCurve.jl:274

The issue seems to be that the components of this curve are printed is an order different from the expected counterpart.

This order could depend on the operating system, Julia version and many more things. From past experience, I therefore try to tests "invariants", i.e. quantities that are not changed among operating systems, versions etc. In the case at hand, the number of components of this plane curve is a natural candidate. This is therefore my suggested fix.

@fingolfin git blame tells me that you last modified this code. Are you ok with this change?