### PR TITLE
improve `ring_iso_oscar_gap` for finite fields

### DIFF
--- a/src/Groups/matrices/iso_oscar_gap.jl
+++ b/src/Groups/matrices/iso_oscar_gap.jl
@@ -36,7 +36,8 @@ end
 function ring_iso_oscar_gap(F::T) where T <: Union{Nemo.FqNmodFiniteField, Nemo.FqFiniteField}
    p = characteristic(F)
    d = degree(F)
-   Fp_gap = GAP.Globals.GF(GAP.Obj(p)) # the prime field in GAP
+   p_gap = GAP.Obj(p)
+   Fp_gap = GAP.Globals.GF(p_gap) # the prime field in GAP
    e = GAP.Globals.One(Fp_gap)
 
    # prime fields are easy and efficient to deal with, handle them seperately
@@ -53,7 +54,14 @@ function ring_iso_oscar_gap(F::T) where T <: Union{Nemo.FqNmodFiniteField, Nemo.
    f_gap = GAP.Globals.UnivariatePolynomial(Fp_gap, L_gap)
 
    # ... and compute a GAP field G defined via this polynomial
-   G = GAP.Globals.GF(Fp_gap, f_gap)
+   # (If the given polynomial is a Conway polynomial then we may call
+   # GAP's `GF(p, d)`, which avoids GAP's `AlgebraicExtension`.)
+   if GAP.Globals.IsCheapConwayPolynomial(p_gap, d) &&
+      f_gap == GAP.Globals.ConwayPolynomial(p_gap, d)
+      G = GAP.Globals.GF(p_gap, d)
+   else
+      G = GAP.Globals.GF(Fp_gap, f_gap)
+   end
 
    # compute matching bases of both fields
    if GAP.Globals.IsAlgebraicExtension(G)

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -20,12 +20,17 @@
    end
 
    # Test a large non-prime field.
-   F, _ = GF(next_prime(10^6), 2)
+   # (Oscar chooses a polynomial that is not a Conway polynomial.)
+   p = next_prime(10^6)
+   F, _ = GF(p, 2)
    f = Oscar.ring_iso_oscar_gap(F)
    for x in [ F(3), gen(F) ]
       a = f(x)
       @test preimage(f, a) == x
    end
+   @test GAP.Globals.DefiningPolynomial(codomain(f)) !=
+         GAP.Globals.ConwayPolynomial(p, 2)
+   @test GAP.Globals.IsAlgebraicExtension(codomain(f))
 
    F = GF(29,1)[1]
    z = F(2)


### PR DESCRIPTION
As suggested by @fingolfin in a comment to #799:
On the GAP side, choose a field that is not in `GAP.Globals.IsAlgebraicExtension` if the given field is defined by a Conway polynomial.