### PR TITLE
Fixes #795

### DIFF
--- a/experimental/ModStd/ModStdQ.jl
+++ b/experimental/ModStd/ModStdQ.jl
@@ -115,7 +115,7 @@ end
 function Oscar.groebner_basis_with_transform(I::MPolyIdeal{fmpq_mpoly}; ordering::Symbol = :degrevlex, complete_reduction::Bool = true, use_hilbert::Bool = false)
 
   if iszero(I)
-    I.gb = BiPolyArray(base_ring(I), fmpq_mpoly[], isGB = true)
+    I.gb = BiPolyArray(base_ring(I), fmpq_mpoly[], isGB = true, keep_ordering = false)
     singular_assure(I.gb)
     return fmpq_mpoly[], matrix(base_ring(I), ngens(I), 0, fmpq_mpoly[])
   end

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -804,6 +804,7 @@ false
 ```
 """
 function Base.:(==)(I::MPolyIdeal, J::MPolyIdeal)
+  I === J && return true
   return issubset(I, J) && issubset(J, I)
 end
 

--- a/test/Rings/mpoly-test.jl
+++ b/test/Rings/mpoly-test.jl
@@ -260,3 +260,10 @@ end
   end
   @test Q == I
 end
+
+@testset "#795" begin
+  R, = QQ["x", "y"]
+  I = ideal(R, zero(R))
+  @test issubset(I, I)
+  @test I == I
+end


### PR DESCRIPTION
The shortcut for zero-ideals used the wrong order.
