### PR TITLE
Tweak the "cancel" workflow

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -3,7 +3,7 @@
 name: Cancel
 on:
   workflow_run:
-    workflows: ["Run tests", "Documentation"]
+    workflows: ["Run tests"]
     types:
       - requested
 jobs:


### PR DESCRIPTION
The old version triggered twice for each PR, this should only trigger once.
