### PR TITLE
support empty lists of group generators

### DIFF
--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -212,8 +212,8 @@ function Base.getproperty(G::MatrixGroup, sym::Symbol)
       if isdefined(G,:descr)
          assign_from_description(G)
       elseif isdefined(G,:gens)
-         V = GAP.julia_to_gap([g.X for g in gens(G)])
-         G.X=GAP.Globals.Group(V)
+         V = GAP.GapObj([g.X for g in gens(G)])
+         G.X = isempty(V) ? GAP.Globals.Group(V, one(G).X) : GAP.Globals.Group(V)
       else
          error("Cannot determine underlying GAP object")
       end

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -266,6 +266,12 @@ end
    @test K==matrix_group(x.elm, (x^2).elm, y.elm)
    @test K==matrix_group([x.elm, (x^2).elm, y.elm])
 
+   n = nrows(x)
+   matgens = typeof(x)[]   # empty list of generators
+   G = MatrixGroup(n, F)
+   G.gens = [MatrixGroupElem(G, mat) for mat in matgens]
+   G.X
+   @test one(G) == one(x)
 
    G = GL(3,F)
    x = G([1,z,0,0,z,0,0,0,z+1])

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -266,10 +266,8 @@ end
    @test K==matrix_group(x.elm, (x^2).elm, y.elm)
    @test K==matrix_group([x.elm, (x^2).elm, y.elm])
 
-   n = nrows(x)
-   matgens = typeof(x)[]   # empty list of generators
-   G = MatrixGroup(n, F)
-   G.gens = [MatrixGroupElem(G, mat) for mat in matgens]
+   G = MatrixGroup(nrows(x), F)
+   G.gens = typeof(x)[]   # empty list of generators
    G.X
    @test one(G) == one(x)
 


### PR DESCRIPTION
when computing `G.X` (from given Oscar generators) for a matrix group `G`