### PR TITLE
Optimize some calls into GAP

### DIFF
--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -1,0 +1,25 @@
+# Use the @wrap macro to set up optimized versions of a bunch of frequently
+# used GAP functions. So instead of writing e.g. GAP.Globals.DenominatorRat(x)
+# you'd write GAPWrap.DenominatorRat(x). The former always performs a variable
+# lookup in the GAP kernel and is not type stable. The latter accesses the
+# underlying GAP function object directly and also has information about the
+# return type.
+#
+# Note that the macro GAP.@wrap has a similar purpose as @gapwrap and @gappatribute
+# have, but works on a much lower level on purpose. We may actually phase out
+# use of @gapwrap and @gappatribute in the future.
+module GAPWrap
+
+using GAP
+
+GAP.@wrap Coefficients(x::GapObj, y::GapObj)::GapObj
+GAP.@wrap DenominatorRat(x::Any)::GapInt
+GAP.@wrap IsDoneIterator(x::Any)::Bool
+GAP.@wrap IsList(x::Any)::Bool
+GAP.@wrap IN(x::Any, y::Any)::Bool
+GAP.@wrap NextIterator(x::GapObj)::Any
+GAP.@wrap NumberColumns(x::GapObj)::GapInt
+GAP.@wrap NumberRows(x::GapObj)::GapInt
+GAP.@wrap NumeratorRat(x::Any)::GapInt
+
+end

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -270,15 +270,15 @@ Base.IteratorSize(::Type{PermGroup}) = Base.HasLength()
 
 function Base.iterate(G::GAPGroup)
   L=GAP.Globals.Iterator(G.X)
-  i = GAP.Globals.NextIterator(L)
+  i = GAPWrap.NextIterator(L)
   return group_element(G, i), L
 end
 
 function Base.iterate(G::GAPGroup, state)
-  if GAP.Globals.IsDoneIterator(state)
+  if GAPWrap.IsDoneIterator(state)
     return nothing
   end
-  i = GAP.Globals.NextIterator(state)
+  i = GAPWrap.NextIterator(state)
   return group_element(G, i), state
 end
 
@@ -529,10 +529,10 @@ Base.IteratorSize(::Type{<:GroupConjClass}) = Base.SizeUnknown()
 Base.iterate(cc::GroupConjClass) = iterate(cc, GAP.Globals.Iterator(cc.CC))
 
 function Base.iterate(cc::GroupConjClass{S,T}, state::GapObj) where {S,T}
-  if GAP.Globals.IsDoneIterator(state)
+  if GAPWrap.IsDoneIterator(state)
     return nothing
   end
-  i = GAP.Globals.NextIterator(state)
+  i = GAPWrap.NextIterator(state)
   if T <: GAPGroupElem
      return group_element(cc.X, i), state
   else

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -213,10 +213,10 @@ Base.IteratorSize(::Type{<:GroupCoset}) = Base.SizeUnknown()
 Base.iterate(G::GroupCoset) = iterate(G, GAP.Globals.Iterator(G.X))
 
 function Base.iterate(G::GroupCoset, state)
-  if GAP.Globals.IsDoneIterator(state)
+  if GAPWrap.IsDoneIterator(state)
     return nothing
   end
-  i = GAP.Globals.NextIterator(state)
+  i = GAPWrap.NextIterator(state)
   return group_element(G.G, i), state
 end
 
@@ -347,10 +347,10 @@ Base.IteratorSize(::Type{<:GroupDoubleCoset}) = Base.SizeUnknown()
 Base.iterate(G::GroupDoubleCoset) = iterate(G, GAP.Globals.Iterator(G.X))
 
 function Base.iterate(G::GroupDoubleCoset, state)
-  if GAP.Globals.IsDoneIterator(state)
+  if GAPWrap.IsDoneIterator(state)
     return nothing
   end
-  i = GAP.Globals.NextIterator(state)
+  i = GAPWrap.NextIterator(state)
   return group_element(G.G, i), state
 end
 

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -417,7 +417,7 @@ function apply_automorphism(f::GAPGroupElem{AutomorphismGroup{T}}, x::GAPGroupEl
   A = parent(f)
   G = parent(x)
   if check
-    @assert A.G == G || GAP.Globals.IN(x.X, A.G.X) "Not in the domain of f!"      #TODO Do we really need the IN check?
+    @assert A.G == G || GAPWrap.IN(x.X, A.G.X) "Not in the domain of f!"      #TODO Do we really need the IN check?
   end
   return typeof(x)(G, GAP.Globals.Image(f.X,x.X))
 end

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -240,16 +240,16 @@ Base.IteratorSize(::Type{<:MatrixGroup}) = Base.SizeUnknown()
 
 function Base.iterate(G::MatrixGroup)
   L=GAP.Globals.Iterator(G.X)
-  @assert ! GAP.Globals.IsDoneIterator(L)
-  i = GAP.Globals.NextIterator(L)
+  @assert ! GAPWrap.IsDoneIterator(L)
+  i = GAPWrap.NextIterator(L)
   return MatrixGroupElem(G, i), L
 end
 
 function Base.iterate(G::MatrixGroup, state::GapObj)
-  if GAP.Globals.IsDoneIterator(state)
+  if GAPWrap.IsDoneIterator(state)
     return nothing
   end
-  i = GAP.Globals.NextIterator(state)
+  i = GAPWrap.NextIterator(state)
   return MatrixGroupElem(G, i), state
 end
 

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -146,7 +146,7 @@ julia> perm(symmetric_group(6),[2,4,6,1,3,5])
 """
 function perm(g::PermGroup, L::AbstractVector{<:IntegerUnion})
    x = GAP.Globals.PermList(GAP.GapObj(L;recursive=true))
-   if length(L) <= degree(g) && GAP.Globals.IN(x,g.X) 
+   if length(L) <= degree(g) && GAPWrap.IN(x,g.X) 
      return PermGroupElem(g, x)
    end
    throw(ArgumentError("the element does not embed in the group"))
@@ -156,7 +156,7 @@ perm(g::PermGroup, L::AbstractVector{<:fmpz}) = perm(g, [Int(y) for y in L])
 
 function (g::PermGroup)(L::AbstractVector{<:IntegerUnion})
    x = GAP.Globals.PermList(GAP.GapObj(L;recursive=true))
-   if length(L) <= degree(g) && GAP.Globals.IN(x,g.X)
+   if length(L) <= degree(g) && GAPWrap.IN(x,g.X)
      return PermGroupElem(g, x)
    end
    throw(ArgumentError("the element does not embed in the group"))
@@ -227,7 +227,7 @@ function cperm(g::PermGroup,L::AbstractVector{T}...) where T <: IntegerUnion
       return one(g)
    else
       x=prod(y -> GAP.Globals.CycleFromList(GAP.julia_to_gap([Int(k) for k in y])), L)
-      if length(L) <= degree(g) && GAP.Globals.IN(x,g.X)
+      if length(L) <= degree(g) && GAPWrap.IN(x,g.X)
          return PermGroupElem(g, x)
       else
          throw(ArgumentError("the element does not embed in the group"))
@@ -274,20 +274,16 @@ Base.Vector(x::PermGroupElem, n::Int = x.parent.deg) = Vector{Int}(x,n)
 
 #embedding of a permutation in permutation group
 function (G::PermGroup)(x::PermGroupElem)
-   if !GAP.Globals.IN(x.X,G.X)
+   if !GAPWrap.IN(x.X,G.X)
       throw(ArgumentError("the element does not embed in the group"))
    end
    return group_element(G, x.X)
 end
 
 #evaluation function
-function (x::PermGroupElem)(n::T) where T <: IntegerUnion
-   return T(GAP.Globals.OnPoints(GAP.Obj(n), x.X))
-end
+(x::PermGroupElem)(n::IntegerUnion) = n^x
 
-(x::PermGroupElem)(n::Int) = GAP.Globals.OnPoints(n,x.X)
-
-^(n::T, x::PermGroupElem) where T <: IntegerUnion = T(GAP.Globals.OnPoints(GAP.Obj(n), x.X))
+^(n::T, x::PermGroupElem) where T <: IntegerUnion = T(GAP.Obj(n)^x.X)
 
 ^(n::Int, x::PermGroupElem) = (n^x.X)::Int
 

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -229,6 +229,7 @@ include("Rings/Hecke.jl") #does all the importing from Hecke - to define names
 include("printing.jl")
 
 include("GAP/GAP.jl")
+include("GAP/wrappers.jl")
 include("GAP/gap_to_oscar.jl")
 include("GAP/oscar_to_gap.jl")
 


### PR DESCRIPTION
... by setting up "wrappers" for certain functions

We could convert more GAP.Globals.* functions, but it's not strictly necessary to do this for all; for now I focused on a few frequently used ones; clearly it's easy to "adapt" more. But with this PR, at least we have the "foot in the door", adding more is now rather straight forward.