### PR TITLE
Implement group of torusinvariant Cartier divisors and the Picard group

### DIFF
--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -79,11 +79,13 @@ isq_gorenstein(v::AbstractNormalToricVariety)
 affine_open_covering( v::AbstractNormalToricVariety )
 ```
 
-### Characters, Weil Divisors and the Class Group
+### Characters, Weil Divisors, Cartier divisors and the Class Group
 
 ```@docs
+cartier_divisor_group(v::AbstractNormalToricVariety)
 character_lattice(v::AbstractNormalToricVariety)
 class_group(v::AbstractNormalToricVariety)
+map_from_cartier_divisor_group_to_torus_invariant_divisor_group(v::AbstractNormalToricVariety)
 map_from_character_to_principal_divisors(v::AbstractNormalToricVariety)
 map_from_weil_divisors_to_class_group(v::AbstractNormalToricVariety)
 torusinvariant_divisor_group(v::AbstractNormalToricVariety)

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -79,7 +79,7 @@ isq_gorenstein(v::AbstractNormalToricVariety)
 affine_open_covering( v::AbstractNormalToricVariety )
 ```
 
-### Characters, Weil Divisors, Cartier divisors and the Class Group
+### Characters, Weil Divisors, Cartier Divisors, Class Group and Picard Group
 
 ```@docs
 cartier_divisor_group(v::AbstractNormalToricVariety)
@@ -88,6 +88,7 @@ class_group(v::AbstractNormalToricVariety)
 map_from_cartier_divisor_group_to_torus_invariant_divisor_group(v::AbstractNormalToricVariety)
 map_from_character_to_principal_divisors(v::AbstractNormalToricVariety)
 map_from_weil_divisors_to_class_group(v::AbstractNormalToricVariety)
+picard_group(v::AbstractNormalToricVariety)
 torusinvariant_divisor_group(v::AbstractNormalToricVariety)
 torusinvariant_prime_divisors(v::AbstractNormalToricVariety)
 ```

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -368,7 +368,7 @@ function map_from_cartier_divisor_group_to_torus_invariant_divisor_group(v::Abst
     col = 1
     for i in 1:number_of_rays
         ncol = number_ray_is_part_of_max_cones[i]-1
-        map_for_difference_of_elements[row, col:(col+ncol-1)] = [fmpz(1) for c in 1:ncol]
+        map_for_difference_of_elements[row, col:(col+ncol-1)] = fill(fmpz(1), ncol)
         map_for_difference_of_elements[(row+1):(row+ncol), col:(col+ncol-1)] = -identity_matrix(ZZ, ncol)
         row += ncol + 1
         col += ncol

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -233,8 +233,8 @@ Abelian group with structure: Z^3
 ```
 """
 function map_from_character_to_principal_divisors(v::AbstractNormalToricVariety)
-    mat = Matrix{Int}(Polymake.common.primitive(pm_object(v).RAYS))
-    matrix = AbstractAlgebra.matrix(ZZ, size(mat,2), size(mat,1), vec(mat))
+    mat = transpose(Matrix{Int}(Polymake.common.primitive(pm_object(v).RAYS)))
+    matrix = AbstractAlgebra.matrix(ZZ, mat)
     return hom(character_lattice(v), torusinvariant_divisor_group(v), matrix)
 end
 export map_from_character_to_principal_divisors
@@ -367,12 +367,11 @@ function map_from_cartier_divisor_group_to_torus_invariant_divisor_group(v::Abst
     row = 1
     col = 1
     for i in 1:number_of_rays
-        for j in 1:(number_ray_is_part_of_max_cones[i]-1)
-            map_for_difference_of_elements[row,col] = 1
-            map_for_difference_of_elements[row+j,col] = -1
-            col += 1
-        end
-        row = row + number_ray_is_part_of_max_cones[i]
+        ncol = number_ray_is_part_of_max_cones[i]-1
+        map_for_difference_of_elements[row, col:(col+ncol-1)] = [fmpz(1) for c in 1:ncol]
+        map_for_difference_of_elements[(row+1):(row+ncol), col:(col+ncol-1)] = -identity_matrix(ZZ, ncol)
+        row = row + ncol + 1
+        col = col + ncol
     end
     
     # compute the matrix for mapping to torusinvariant Weil divisors

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -370,8 +370,8 @@ function map_from_cartier_divisor_group_to_torus_invariant_divisor_group(v::Abst
         ncol = number_ray_is_part_of_max_cones[i]-1
         map_for_difference_of_elements[row, col:(col+ncol-1)] = [fmpz(1) for c in 1:ncol]
         map_for_difference_of_elements[(row+1):(row+ncol), col:(col+ncol-1)] = -identity_matrix(ZZ, ncol)
-        row = row + ncol + 1
-        col = col + ncol
+        row += ncol + 1
+        col += ncol
     end
     
     # compute the matrix for mapping to torusinvariant Weil divisors

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -417,6 +417,28 @@ end
 export cartier_divisor_group
 
 
+@doc Markdown.doc"""
+    picard_group(v::AbstractNormalToricVariety)
+
+Computes the Picard group of an abstract normal toric variety `v`.
+
+# Examples
+```jdoctest
+julia> p2 = toric_projective_space(2)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> picard_group(p2)
+GrpAb: Z
+```
+"""
+function picard_group(v::AbstractNormalToricVariety)
+    map1 = map_from_cartier_divisor_group_to_torus_invariant_divisor_group(v)
+    map2 = map_from_weil_divisors_to_class_group(v)
+    return snf(image(hom(domain(map1), codomain(map2), map1.map * map2.map))[1])[1]
+end
+export picard_group
+
+
 ############################
 # Cones and fans
 ############################

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -48,6 +48,8 @@ ntv3 = NormalToricVariety(square)
 @testset "Toric varieties from polyhedral fans" begin
     @test iscomplete(ntv2) == true
     @test iscomplete(ntv3) == true
+    @test rank(cartier_divisor_group(ntv2)) == 4
+    @test rank(domain(map_from_cartier_divisor_group_to_torus_invariant_divisor_group(ntv2))) == 4
 end
 
 P2 = toric_projective_space(2)
@@ -119,6 +121,7 @@ end
     dP2 = del_pezzo(2)
     @test length(torusinvariant_prime_divisors(dP2)) == 5
     dP3 = del_pezzo(3)
+    @test rank(cartier_divisor_group(dP3)) == 6
     @test length(torusinvariant_prime_divisors(dP3)) == 6
     @test_throws ArgumentError del_pezzo(4)
 end

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -124,6 +124,7 @@ end
     @test rank(cartier_divisor_group(dP3)) == 6
     @test length(torusinvariant_prime_divisors(dP3)) == 6
     @test_throws ArgumentError del_pezzo(4)
+    @test rank(picard_group(dP3)) == 4
 end
 
 blowup_variety = blowup_on_ith_minimal_torus_orbit(P2, 1)
@@ -143,6 +144,7 @@ blowup_variety = blowup_on_ith_minimal_torus_orbit(P2, 1)
     @test ith_betti_number(blowup_variety, 3) == 0
     @test ith_betti_number(blowup_variety, 4) == 1
     @test euler_characteristic(blowup_variety) == 4
+    @test rank(picard_group(blowup_variety)) == 2
 end
 
 v = H5 * P2


### PR DESCRIPTION
This contains the following:
- implement `cartier_divisor_group` (a.k.a. the group of torusinvariant Cartier divisors),
- implement `picard_group`,
- export `pm_object` (for convenience),
- make use of `AbstractAlgebra.matrix` more robust (one instance).