### PR TITLE
Require GAP 0.7.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ msolve_jll = "6d01cc9a-e8f6-580e-8c54-544227e08205"
 [compat]
 AbstractAlgebra = "0.22.2"
 DocStringExtensions = "0.8"
-GAP = "0.7"
+GAP = "0.7.2"
 Hecke = "0.10.24"
 Nemo = "0.27.0"
 Polymake = "0.6.0"


### PR DESCRIPTION
While not strictly necessary, it is useful to 'force' users to have the latest
version with all those bug fixes and little improvements
