### PR TITLE
added `character_field`

### DIFF
--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -21,6 +21,7 @@ import Oscar.AbelianClosure: QabElem, QabAutomorphism
 import Nemo: degree
 
 export
+    character_field,
     character_table,
     decomposition_matrix,
     scalar_product,
@@ -653,4 +654,69 @@ function(chi::GAPGroupClassFunction)(g::BasicGAPGroupElem)
       end
     end
     error("$g is not an element in the underlying group")
+end
+
+@doc Markdown.doc"""
+    character_field(chi::GAPGroupClassFunction)
+
+Return the pair `(F, phi)` where `F` is a number field that is generated
+by the character values of `chi`, and `phi` is the embedding of `F` into
+`abelian_closure(QQ)`.
+"""
+function character_field(chi::GAPGroupClassFunction)
+    values = chi.values  # a list of GAP cyclotomics
+    gapfield = GAP.Globals.Field(values)
+    N = GAP.Globals.Conductor(gapfield)
+    FF, = abelian_closure(QQ)
+    if GAP.Globals.IsCyclotomicField(gapfield)
+      # In this case, the want to return a field that knows to be cyclotomic
+      # (and the embedding is easy).
+      F, z = Oscar.AbelianClosure.cyclotomic_field(FF, N)
+      f = x::nf_elem -> QabElem(x, N)
+      finv = function(x::QabElem)
+        g = gcd(x.c, N)
+        K, = Oscar.AbelianClosure.cyclotomic_field(FF, g)
+        x = Hecke.force_coerce_cyclo(K, x.data)
+        x = Hecke.force_coerce_cyclo(F, x)
+        return x
+      end
+    else
+      # In the general case, we have to work for the embedding.
+      gapgens = GAP.Globals.GeneratorsOfField(gapfield)
+      @assert length(gapgens) == 1
+      gappol = GAP.Globals.MinimalPolynomial(GAP.Globals.Rationals, gapgens[1])
+      gapcoeffs = GAP.Globals.CoefficientsOfUnivariatePolynomial(gappol)
+      coeffscyc = Vector{fmpq}(GAP.Globals.COEFFS_CYC(gapgens[1]))
+      v = Vector{fmpq}(gapcoeffs)
+      R, = PolynomialRing(QQ, "x")
+      f = R(v)
+      F, z = NumberField(f, "z"; cached = true, check = false)
+      K, zz = Oscar.AbelianClosure.cyclotomic_field(FF, N)
+
+      nfelm = QabElem(gapgens[1]).data
+
+      # Compute the expression of powers of `z` as sums of roots of unity (once).
+      powers = [coefficients(Hecke.force_coerce_cyclo(K, nfelm^i)) for i in 0:length(v)-2]
+      c = matrix(QQ, powers)'
+
+      f = function(x::nf_elem)
+        return QabElem(evaluate(R(x), nfelm), N)
+      end
+
+      finv = function(x::QabElem)
+        # Write `x` w.r.t. the N-th cyclotomic field ...
+        g = gcd(x.c, N)
+        Kg, = Oscar.AbelianClosure.cyclotomic_field(FF, g)
+        x = Hecke.force_coerce_cyclo(Kg, x.data)
+        x = Hecke.force_coerce_cyclo(K, x)
+
+        # ... and then w.r.t. `F`
+        a = coefficients(x)
+        b = solve(c, matrix(QQ,length(a),1,a))'
+        b = [b[i] for i in 1:length(b)]
+        return F(b)
+      end
+    end
+
+    return F, MapFromFunc(f, finv, F, FF)
 end

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -406,3 +406,17 @@ end
   t = character_table(g)
   @test mod(t, 2) == nothing
 end
+
+@testset "character fields" begin
+  for id in [ "C5", "A5" ]   # cyclotomic and non-cyclotomic number fields
+    for chi in character_table(id)
+      F, phi = character_field(chi)
+      for i in 1:length(chi)
+        x = chi[i]
+        xF = preimage(phi, x)
+        @test parent(xF) == F
+        @test phi(xF) == x
+      end
+    end
+  end
+end


### PR DESCRIPTION
@fieker and I had a discussion on this topic last week.

In which direction do we want to go,
change the name of the function (`number_field(chi)`?) or introduce the call `QQ(chi)`,
change the code to be applicable in the more general setup of arrays of `QabElem`s (which would also make it easier to write better tests) and move it to another file?
And should the number fields in question always be cached?

Currently there is one problem with `Hecke.force_coerce_cyclo`:
```
julia> F, z = CyclotomicField(15)
(Cyclotomic field of order 15, z_15)

julia> K, = CyclotomicField(9)
(Cyclotomic field of order 9, z_9)

julia> Hecke.force_coerce_cyclo(K, z^5)
ERROR: no coercion possible
[...]

julia> K3, = CyclotomicField(3)
(Cyclotomic field of order 3, z_3)

julia> Hecke.force_coerce_cyclo(K3, z^5)
z_3

julia> Hecke.force_coerce_cyclo(K, ans)
z_9^3
```
(A comment in the code mentions this problem.)

And what is the intended relation between `Hecke.force_coerce_cyclo` and `Oscar.AbelianClosure.coerce_up`, `Oscar.AbelianClosure.coerce_down`?
(`Hecke.force_coerce_cyclo` can replace the latter two.)
