### PR TITLE
First implementations for line bundles on toric varieties

### DIFF
--- a/docs/doc.main
+++ b/docs/doc.main
@@ -134,6 +134,7 @@
         "ToricVarieties/NormalToricVarieties.md",
         "ToricVarieties/CyclicQuotientSingularities.md",
         "ToricVarieties/ToricDivisors.md",
+        "ToricVarieties/ToricLineBundles.md",
      ],
   ],
 

--- a/docs/src/ToricVarieties/ToricLineBundles.md
+++ b/docs/src/ToricVarieties/ToricLineBundles.md
@@ -16,3 +16,10 @@ Pages = ["ToricLineBundles.md"]
 ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{fmpz})
 ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{Int})
 ```
+
+## Attributes
+
+```@docs
+divisor_class(l::ToricLineBundle)
+variety(l::ToricLineBundle)
+```

--- a/docs/src/ToricVarieties/ToricLineBundles.md
+++ b/docs/src/ToricVarieties/ToricLineBundles.md
@@ -1,0 +1,18 @@
+```@meta
+CurrentModule = Oscar
+```
+
+```@contents
+Pages = ["ToricLineBundles.md"]
+```
+
+
+# Toric Line Bundles
+
+
+## Constructors
+
+```@docs
+ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{fmpz})
+ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{Int})
+```

--- a/src/ToricVarieties/JToric.jl
+++ b/src/ToricVarieties/JToric.jl
@@ -10,3 +10,4 @@ include("ToricDivisors/constructors.jl")
 include("ToricDivisors/properties.jl")
 
 include("LineBundles/constructors.jl")
+include("LineBundles/attributes.jl")

--- a/src/ToricVarieties/JToric.jl
+++ b/src/ToricVarieties/JToric.jl
@@ -8,3 +8,5 @@ include("CyclicQuotientSingularities/CyclicQuotientSingularities.jl")
 
 include("ToricDivisors/constructors.jl")
 include("ToricDivisors/properties.jl")
+
+include("LineBundles/constructors.jl")

--- a/src/ToricVarieties/LineBundles/attributes.jl
+++ b/src/ToricVarieties/LineBundles/attributes.jl
@@ -1,0 +1,23 @@
+#####################
+# 1. Defining data of a line bundle
+#####################
+
+@doc Markdown.doc"""
+    divisor_class(l::ToricLineBundle)
+
+Returns the divisor class which defines the toric line bundle `l`.
+"""
+function divisor_class(l::ToricLineBundle)
+    return l.divisor_class
+end
+export divisor_class
+
+@doc Markdown.doc"""
+    variety(l::ToricLineBundle)
+
+Returns the toric variety over which the toric line bundle `l` is defined.
+"""
+function variety(l::ToricLineBundle)
+    return l.variety
+end
+export variety

--- a/src/ToricVarieties/LineBundles/constructors.jl
+++ b/src/ToricVarieties/LineBundles/constructors.jl
@@ -1,0 +1,57 @@
+########################
+# 1: The Julia type for toric line bundles
+########################
+
+abstract type ToricCoherentSheaf end
+
+struct ToricLineBundle <: ToricCoherentSheaf
+    variety::AbstractNormalToricVariety
+    divisor_class::GrpAbFinGenElem
+end
+export ToricLineBundle
+
+
+########################
+# 2: Generic constructors
+########################
+
+
+@doc Markdown.doc"""
+    ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{fmpz})
+
+Construct the line bundle on the abstract normal toric variety `v` with class `c`.
+```
+"""
+function ToricLineBundle(v::AbstractNormalToricVariety, input_class::Vector{fmpz})
+    class = picard_group(v)(input_class)
+    return ToricLineBundle(v, class)
+end
+
+@doc Markdown.doc"""
+    ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{Int})
+
+Convenience method for ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{fmpz}).
+
+# Examples
+```jldoctest
+julia> v = toric_projective_space(2)
+A normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+
+julia> l = ToricLineBundle( v, [ 2 ] )
+A line bundle on a normal toric variety corresponding to a polyhedral fan in ambient dimension 2
+```
+"""
+function ToricLineBundle(v::AbstractNormalToricVariety, input_class::Vector{Int})
+    class = picard_group(v)(input_class)
+    return ToricLineBundle(v, class)
+end
+
+
+########################
+# 3: Display
+########################
+
+function Base.show(io::IO, line_bundle::ToricLineBundle)
+    ambdim = pm_object(line_bundle.variety).FAN_AMBIENT_DIM
+    print(io, "A line bundle on a normal toric variety corresponding to a polyhedral fan in ambient dimension $(ambdim)")
+end

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -513,6 +513,7 @@ Returns the cone of the affine normal toric variety `v`.
 ```jdoctest
 julia> cone(AffineNormalToricVariety(Oscar.positive_hull([1 1; -1 1])))
 A polyhedral cone in ambient dimension 2
+```
 """
 function cone(v::AffineNormalToricVariety)
     return maximal_cones(fan(v))[1]

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -386,13 +386,12 @@ function map_from_cartier_divisor_group_to_torus_invariant_divisor_group(v::Abst
     target = abelian_group(zeros(Int, ncols(mapping_matrix)))
     total_map = hom(source, target, mapping_matrix)
     
-    # identify the cartier_data_group and its embedding
+    # identify the embedding of the cartier_data_group
     ker = kernel(total_map)
-    cartier_data_group = snf(ker[1])[1]
-    cartier_data_group_embedding = hom(cartier_data_group, source, ker[1].snf_map.map * ker[2].map)
+    embedding = snf(ker[1])[2] * ker[2] * hom(codomain(ker[2]), torusinvariant_divisor_group(v), map_to_weil_divisors)
     
-    # construct the embedding of the Cartier divisor group into the group of torusinvariant divisors
-    return cartier_divisor_group_embedding = image(hom(cartier_data_group, torusinvariant_divisor_group(v), cartier_data_group_embedding.map * map_to_weil_divisors))[2]
+    # return the image of this embedding
+    return image(embedding)[2]
 end
 export map_from_cartier_divisor_group_to_torus_invariant_divisor_group
 

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -112,15 +112,16 @@ H5 = hirzebruch_surface(5)
     @test length(irrelevant_ideal(H5).gens) == 4
 end
 
+dP0 = del_pezzo(0)
+dP1 = del_pezzo(1)
+dP2 = del_pezzo(2)
+dP3 = del_pezzo(3)
+
 @testset "delPezzo surfaces" begin
     @test_throws ArgumentError del_pezzo(-1)
-    dP0 = del_pezzo(0)
     @test length(torusinvariant_prime_divisors(dP0)) == 3
-    dP1 = del_pezzo(1)
     @test length(torusinvariant_prime_divisors(dP1)) == 4
-    dP2 = del_pezzo(2)
     @test length(torusinvariant_prime_divisors(dP2)) == 5
-    dP3 = del_pezzo(3)
     @test rank(cartier_divisor_group(dP3)) == 6
     @test length(torusinvariant_prime_divisors(dP3)) == 6
     @test_throws ArgumentError del_pezzo(4)

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -213,7 +213,9 @@ p = polyhedron(D)
     @test ambient_dim(p) == 2
 end
 
+line_bundle = ToricLineBundle(dP3, [1,2,3,4])
+
 @testset "Toric line bundles" begin
-    line_bundle = ToricLineBundle(dP3, [ 1,2,3,4 ])
-    @test line_bundle.divisor_class.coeff == AbstractAlgebra.matrix(ZZ, [ 1 2 3 4 ])
+    @test divisor_class(line_bundle).coeff == AbstractAlgebra.matrix(ZZ, [1 2 3 4])
+    @test dim(variety(line_bundle)) == 2
 end

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -212,3 +212,8 @@ p = polyhedron(D)
     @test dim(p) == 0
     @test ambient_dim(p) == 2
 end
+
+@testset "Toric line bundles" begin
+    line_bundle = ToricLineBundle(dP3, [ 1,2,3,4 ])
+    @test line_bundle.divisor_class.coeff == AbstractAlgebra.matrix(ZZ, [ 1 2 3 4 ])
+end


### PR DESCRIPTION
- Minor code improvements (construct delPezzos outside of @test, concatenate maps in computation of toric Cartier divisors),
- Implement type, constructor and show method for toric line bundles,
- Support defining attributes of toric line bundles,
- Add page to document functionality of toric line bundles.