### PR TITLE
CI: limit concurrency for PR builds but not for master

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,6 +65,3 @@ jobs:
       - name: "Upload coverage data to Codecov"
         continue-on-error: true
         uses: codecov/codecov-action@v1
-
-    # don't run ci twice on own PRs
-    if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,9 +5,10 @@ on:
   - pull_request
 
 concurrency:
-  # Skip intermediate builds: always.
-  # Cancel intermediate builds: only if it is a pull request build.
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:

--- a/.github/workflows/Docu.yml
+++ b/.github/workflows/Docu.yml
@@ -8,9 +8,10 @@ on:
   pull_request:
 
 concurrency:
-  # Skip intermediate builds: always.
-  # Cancel intermediate builds: only if it is a pull request build.
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:

--- a/.github/workflows/Docu.yml
+++ b/.github/workflows/Docu.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
-  build:
+  deploy_docs:
     #runs-on: self-hosted
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The previous change which limited the number of concurrent builds
for PRs to 1 also caused builds on the master branch to become
sequential, which is not what we want. This patch fixes this.

Right now, the fix is only applied to master -- so if people work on branches directly here, then these still will be build sequentially (but only the currently running build, plus the most recent one, are being run). I think that's fine -- the one reason we want `master` to build all commits is to allow us to pinpoint which merge introduce a regression, if any.

CC @thofma @benlorenz @fieker 