### PR TITLE
Speed up PolyhedralGeometry tests

### DIFF
--- a/src/PolyhedralGeometry/Cone/constructors.jl
+++ b/src/PolyhedralGeometry/Cone/constructors.jl
@@ -47,11 +47,10 @@ function Cone(R::Union{SubObjectIterator{<:RayVector}, Oscar.MatElem, AbstractMa
 end
 
 function ==(C0::Cone, C1::Cone)
-    # TODO: Remove the following 4 lines, see #758
-    facets(C0)
-    facets(C1)
-    rays(C0)
-    rays(C1)
+    # TODO: Remove the following 3 lines, see #758
+    for pair in Iterators.product([C0, C1], ["RAYS", "FACETS"])
+        Polymake.give(pm_object(pair[1]),pair[2])
+    end
     return Polymake.polytope.equal_polyhedra(pm_object(C0), pm_object(C1))
 end
 

--- a/src/PolyhedralGeometry/Polyhedron/constructors.jl
+++ b/src/PolyhedralGeometry/Polyhedron/constructors.jl
@@ -70,11 +70,10 @@ Get the underlying polymake `Polytope`.
 pm_object(P::Polyhedron) = P.pm_polytope
 
 function ==(P0::Polyhedron, P1::Polyhedron)
-    # TODO: Remove the following 4 lines, see #758
-    facets(P0)
-    vertices(P0)
-    facets(P1)
-    vertices(P1)
+    # TODO: Remove the following 3 lines, see #758
+    for pair in Iterators.product([P0, P1], ["RAYS", "FACETS"])
+        Polymake.give(pm_object(pair[1]),pair[2])
+    end
     Polymake.polytope.equal_polyhedra(pm_object(P0), pm_object(P1))
 end
 


### PR DESCRIPTION
`PolyhedralGeometry/Group.jl` was taking way too long now because the speedup of precomputing a double description for `Base.==({Cone,Polyhedron})` was lost when the iterators were turned lazy. Now we enforce the corresponding polymake properties instead.

x-ref: #851 