### PR TITLE
move QabElem <-> GAP cyclotomics conversion

### DIFF
--- a/src/GAP/oscar_to_gap.jl
+++ b/src/GAP/oscar_to_gap.jl
@@ -33,6 +33,12 @@ function GAP.julia_to_gap(obj::nf_elem)
     return GAP.Globals.CycList(GAP.julia_to_gap(v, recursive = true))
 end
 
+## `QabElem` to GAP cyclotomic
+function GAP.julia_to_gap(elm::QabElem)
+    coeffs = [Nemo.coeff(elm.data, i) for i in 0:(elm.c-1)]  # fmpq
+    return GAP.Globals.CycList(GAP.GapObj(coeffs; recursive=true))
+end
+
 ## matrix of elements of cyclotomic field to GAP matrix of cyclotomics
 function GAP.julia_to_gap(obj::AbstractAlgebra.Generic.MatSpaceElem{nf_elem})
     F = base_ring(obj)

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -27,32 +27,6 @@ export
     trivial_character
 
 
-#############################################################################
-##
-##  conversion between Julia's QabElem and GAP's cyclotomics
-##
-function QabElem(cyc::GapInt)
-    GAP.Globals.IsCyc(cyc) || error("cyc must be a GAP cyclotomic")
-    denom = GAP.Globals.DenominatorCyc(cyc)
-    n = GAP.Globals.Conductor(cyc)
-    coeffs = GAP.Globals.ExtRepOfObj(cyc * denom)
-    cycpol = GAP.Globals.CyclotomicPol(n)
-    dim = length(cycpol)-1
-    GAP.Globals.ReduceCoeffs(coeffs, cycpol)
-    coeffs = Vector{fmpz}(coeffs)
-    coeffs = coeffs[1:dim]
-    denom = fmpz(denom)
-    FF = abelian_closure(QQ)[1]
-    F, z = Oscar.AbelianClosure.cyclotomic_field(FF, n)
-    val = Nemo.elem_from_mat_row(F, Nemo.matrix(Nemo.ZZ, 1, dim, coeffs), 1, denom)
-    return QabElem(val, n)
-end
-
-function gap_cyclotomic(elm::QabElem)
-    coeffs = [Nemo.coeff(elm.data, i) for i in 0:(elm.c-1)]  # fmpq
-    return GAP.Globals.CycList(GAP.GapObj(coeffs; recursive=true))
-end
-
 complex_conjugate(elm::QabElem) = elm^QabAutomorphism(-1)
 
 
@@ -567,7 +541,7 @@ function group_class_function(tbl::GAPGroupCharacterTable, values::GAP.GapObj)
 end
 
 function group_class_function(tbl::GAPGroupCharacterTable, values::Vector{QabElem})
-    gapvalues = GAP.GapObj([gap_cyclotomic(x) for x in values])
+    gapvalues = GAP.GapObj([GAP.Obj(x) for x in values])
     return GAPGroupClassFunction(tbl, GAP.Globals.ClassFunction(tbl.GAPTable, gapvalues))
 end
 

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -230,8 +230,6 @@ include("printing.jl")
 
 include("GAP/GAP.jl")
 include("GAP/wrappers.jl")
-include("GAP/gap_to_oscar.jl")
-include("GAP/oscar_to_gap.jl")
 
 include("Groups/types.jl")
 include("Groups/perm.jl")
@@ -269,6 +267,9 @@ include("Rings/FinField.jl")
 include("Rings/NumberField.jl")
 include("Rings/FunctionField.jl")
 include("Rings/AbelianClosure.jl")
+
+include("GAP/gap_to_oscar.jl")
+include("GAP/oscar_to_gap.jl")
 
 include("Groups/group_characters.jl")  # needs some Rings functionality
 

--- a/test/GAP/gap_to_oscar.jl
+++ b/test/GAP/gap_to_oscar.jl
@@ -101,6 +101,7 @@ end
 end
 
 @testset "single cyclotomics" begin
+    # to cyclotomic fields
     F, z = CyclotomicField(1)
     @test F(GAP.evalstr("2^64")) == F(2)^64
 
@@ -111,6 +112,15 @@ end
     @test F(GAP.Globals.E(5)) == z^3
     @test F(GAP.Globals.E(3)) == z^5
 
+    # to `QabElem`
+    x = QabElem(GAP.evalstr("2^64"))
+    @test x == fmpz(2)^64
+
+    F, z = abelian_closure(QQ)
+    x = QabElem(GAP.evalstr("EB(5)"))
+    @test x == z(5) + z(5)^4
+
+    # not supported conversions
     F, z = quadratic_field(5)
     @test_throws ArgumentError F(GAP.Globals.Sqrt(5))
 
@@ -123,6 +133,8 @@ end
     gapF = GAP.Globals.AlgebraicExtension(GAP.Globals.Rationals, pol)
     a = GAP.Globals.PrimitiveElement(gapF)
     @test_throws ArgumentError F(a)
+
+    @test_throws ErrorException QabElem(GAP.evalstr("[ E(3) ]"))
 end
 
 @testset "matrices over a cyclotomic field" begin

--- a/test/GAP/oscar_to_gap.jl
+++ b/test/GAP/oscar_to_gap.jl
@@ -79,10 +79,16 @@ end
 end
 
 @testset "single cyclotomics" begin
+    # from cyclotomic fields
     F, z = CyclotomicField(5)
     e5 = GAP.Globals.E(5)
     @test GAP.Obj(z^2+z+1) == e5^2 + e5 + 1
 
+    # from `QabElem`
+    F, z = abelian_closure(QQ)
+    @test GAP.Obj(z(5) + z(5)^4) == e5 + e5^4
+
+    # not supported conversions
     F, z = quadratic_field(5)
     @test_throws ArgumentError GAP.Obj(z)
 end


### PR DESCRIPTION
Now the conversion (both directions) is in `src/GAP/gap_to_oscar.jl` and `src/GAP/oscar_to_gap.jl`, as suggested in the discussion of PR #840.

For that, the ordering of `include` statements in `src/Oscar.jl` had to be changed.