### PR TITLE
Speed up primary invariants test

### DIFF
--- a/experimental/InvariantTheory/invariant_rings.jl
+++ b/experimental/InvariantTheory/invariant_rings.jl
@@ -184,6 +184,7 @@ end
 
 function reynolds_operator_via_oscar(IR::InvRing{FldT, GrpT, T}, f::T) where {FldT, GrpT, T <: MPolyElem}
   @assert !ismodular(IR)
+  @assert parent(f) === polynomial_ring(IR)
 
   if !isdefined(IR, :reynolds_operator)
     _prepare_reynolds_operator(IR)

--- a/experimental/InvariantTheory/iterators.jl
+++ b/experimental/InvariantTheory/iterators.jl
@@ -317,7 +317,10 @@ function iterate_linear_algebra(BI::InvRingBasisIterator)
     end
     f += N[i, 1]*BI.monomials_collected[i]
   end
-  return f, 2
+  # Have to (should...) divide by the leading coefficient again:
+  # The matrix was in echelon form, but the columns were not necessarily sorted
+  # w.r.t. the monomial ordering.
+  return inv(leading_coefficient(f))*f, 2
 end
 
 function iterate_linear_algebra(BI::InvRingBasisIterator, state::Int)
@@ -334,7 +337,7 @@ function iterate_linear_algebra(BI::InvRingBasisIterator, state::Int)
     end
     f += N[i, state]*BI.monomials_collected[i]
   end
-  return f, state + 1
+  return inv(leading_coefficient(f))*f, state + 1
 end
 
 ################################################################################

--- a/test/InvariantTheory/primary_invariants-test.jl
+++ b/test/InvariantTheory/primary_invariants-test.jl
@@ -17,12 +17,12 @@
   @test sort([ total_degree(f.f) for f in invars ]) == [ 3, 5, 9 ]
   @test dim(ideal(polynomial_ring(RG), invars)) == 0
 
-  # Kem99, p. 183: S_3^4
-  M1 = diagonal_matrix([ matrix(QQ, 3, 3, [ 0, 1, 0, 1, 0, 0, 0, 0, 1 ]) for i = 1:4 ])
-  M2 = diagonal_matrix([ matrix(QQ, 3, 3, [ 0, 1, 0, 0, 0, 1, 1, 0, 0 ]) for i = 1:4 ])
+  # Kem99, p. 183: S_3^3
+  M1 = diagonal_matrix([ matrix(QQ, 3, 3, [ 0, 1, 0, 1, 0, 0, 0, 0, 1 ]) for i = 1:3 ])
+  M2 = diagonal_matrix([ matrix(QQ, 3, 3, [ 0, 1, 0, 0, 0, 1, 1, 0, 0 ]) for i = 1:3 ])
   RG = invariant_ring(M1, M2)
   invars = Oscar.primary_invariants_via_optimal_hsop(RG)
-  @test length(invars) == 12
-  @test sort([ total_degree(f.f) for f in invars ]) == [ 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3 ]
+  @test length(invars) == 9
+  @test sort([ total_degree(f.f) for f in invars ]) == [ 1, 1, 1, 2, 2, 2, 3, 3, 3 ]
   @test dim(ideal(polynomial_ring(RG), invars)) == 0
 end


### PR DESCRIPTION
This speeds up the primary invariants tests (#851) without making them less thorough.
I can't really reproduce the timings from #851, but the `Primary invariants` test suite is now about 10 times faster.
(I also added two minor unrelated things.)