### PR TITLE
Refactor some GAP<->Julia conversions

### DIFF
--- a/src/GAP/gap_to_oscar.jl
+++ b/src/GAP/gap_to_oscar.jl
@@ -3,61 +3,70 @@
 ## `src/constructors.jl`, where low level Julia objects are treated)
 
 import GAP: gap_to_julia
+import GAP: GapObj, GapInt
 import Nemo: FlintIntegerRing, FlintRationalField, MatrixSpace, fmpz, fmpq, fmpz_mat, fmpq_mat
 import Oscar.AbelianClosure: QabElem
 
+##
 ## GAP integer to `fmpz`
-GAP.gap_to_julia(::Type{fmpz}, obj::Int64) = fmpz(obj)
-function GAP.gap_to_julia(::Type{fmpz}, obj::GAP.GapObj)
+##
+function fmpz(obj::GapObj)
     GAP.GAP_IS_INT(obj) || throw(GAP.ConversionError(obj, fmpz))
     GC.@preserve obj fmpz(GAP.ADDR_OBJ(obj), div(GAP.SIZE_OBJ(obj), sizeof(Int)))
 end
 
-fmpz(obj::GAP.GapObj) = gap_to_julia(fmpz, obj)
+GAP.gap_to_julia(::Type{fmpz}, obj::GapInt) = fmpz(obj)
+(::FlintIntegerRing)(obj::GapObj) = gap_to_julia(fmpz, obj)
 
-(::FlintIntegerRing)(obj::GAP.GapObj) = gap_to_julia(fmpz, obj)
-
+##
 ## large GAP rational or integer to `fmpq`
-GAP.gap_to_julia(::Type{fmpq}, obj::Int64) = fmpq(obj)
-function GAP.gap_to_julia(::Type{fmpq}, obj::GAP.GapObj)
+##
+function fmpq(obj::GapObj)
     GAP.GAP_IS_INT(obj) && return fmpq(fmpz(obj))
     GAP.GAP_IS_RAT(obj) || throw(GAP.ConversionError(obj, fmpq))
     return fmpq(fmpz(GAP.Globals.NumeratorRat(obj)), fmpz(GAP.Globals.DenominatorRat(obj)))
 end
 
-fmpq(obj::GAP.GapObj) = gap_to_julia(fmpq, obj)
+GAP.gap_to_julia(::Type{fmpq}, obj::GapInt) = fmpq(obj)
+(::FlintRationalField)(obj::GapObj) = gap_to_julia(fmpq, obj)
 
-(::FlintRationalField)(obj::GAP.GapObj) = gap_to_julia(fmpq, obj)
-
+##
 ## matrix of GAP integers to `fmpz_mat`
-function GAP.gap_to_julia(::Type{fmpz_mat}, obj::GAP.GapObj)
-    m = GAP.gap_to_julia(Matrix{fmpz}, obj)
-    return fmpz_mat(size(m, 1), size(m, 2), m)
+##
+function fmpz_mat(obj::GapObj)
+    m = Matrix{fmpz}(obj)
+    return matrix(ZZ, m)
 end
 
-fmpz_mat(obj::GAP.GAP.GapObj) = gap_to_julia(fmpz_mat, obj)
+GAP.gap_to_julia(::Type{fmpz_mat}, obj::GapObj) = fmpz_mat(obj)
+matrix(R::FlintIntegerRing, obj::GapObj) = fmpz_mat(obj)
 
+##
 ## matrix of GAP rationals or integers to `fmpq_mat`
-function GAP.gap_to_julia(::Type{fmpq_mat}, obj::GAP.GapObj)
-    m = GAP.gap_to_julia(Matrix{fmpq}, obj)
-    return matrix(FlintQQ, m)
+##
+function fmpq_mat(obj::GapObj)
+    m = Matrix{fmpq}(obj)
+    return matrix(QQ, m)
 end
 
-fmpq_mat(obj::GAP.GAP.GapObj) = gap_to_julia(fmpq_mat, obj)
+GAP.gap_to_julia(::Type{fmpq_mat}, obj::GapObj) = fmpq_mat(obj)
+matrix(R::FlintRationalField, obj::GapObj) = fmpq_mat(obj)
 
+##
 ## cache default bases of GAP's cyclotomic fields
-const default_bases_GAP_cyclotomic_fields = AbstractAlgebra.WeakValueDict{Int64, GAP.GapObj}()
+##
+const default_bases_GAP_cyclotomic_fields = AbstractAlgebra.WeakValueDict{Int64, GapObj}()
 
-function default_basis_GAP_cyclotomic_field(N::Int64, F::GAP.GapObj = GAP.Globals.CyclotomicField(N))
+function default_basis_GAP_cyclotomic_field(N::Int64, F::GapObj = GAP.Globals.CyclotomicField(N))
     get!(default_bases_GAP_cyclotomic_fields, N) do
       root = GAP.Globals.E(N)
       elms = [root^i for i in 0:(euler_phi(N)-1)]
-      return GAP.Globals.Basis(F, GAP.GapObj(elms))
+      return GAP.Globals.Basis(F, GapObj(elms))
     end
 end
 
 ## single GAP cyclotomic to element of cyclotomic field
-function (F::AnticNumberField)(obj::GAP.GapObj)
+function (F::AnticNumberField)(obj::GapObj)
     Nemo.iscyclo_type(F) || throw(ArgumentError("F is not a cyclotomic field"))
     GAP.Globals.IsCyclotomic(obj) || throw(ArgumentError("input is not a GAP cyclotomic"))
     N = Oscar.get_special(F, :cyclo)
@@ -86,7 +95,7 @@ function QabElem(cyc::GapInt)
 end
 
 ## nonempty list of GAP matrices over the same cyclotomic field
-function matrices_over_cyclotomic_field(gapmats::GAP.GapObj)
+function matrices_over_cyclotomic_field(gapmats::GapObj)
     GAPWrap.IsList(gapmats) || throw(ArgumentError("gapmats is not a GAP list"))
     GAP.Globals.IsEmpty(gapmats) && throw(ArgumentError("gapmats is empty"))
     GAP.Globals.ForAll(gapmats, GAP.Globals.IsCyclotomicCollColl) ||
@@ -110,7 +119,7 @@ function matrices_over_cyclotomic_field(gapmats::GAP.GapObj)
 end
 
 ## single GAP matrix of cyclotomics
-function matrix(F::AnticNumberField, mat::GAP.GapObj)
+function matrix(F::AnticNumberField, mat::GapObj)
     Nemo.iscyclo_type(F) || throw(ArgumentError("F is not a cyclotomic field"))
     (GAP.Globals.IsCyclotomicCollColl(mat) && GAP.Globals.IsMatrixOrMatrixObj(mat)) || throw(ArgumentError("mat is not a GAP matrix of cyclotomics"))
     N = Oscar.get_special(F, :cyclo)

--- a/test/GAP/gap_to_oscar.jl
+++ b/test/GAP/gap_to_oscar.jl
@@ -58,12 +58,14 @@ end
     val = GAP.evalstr( "[ [ 1, 2 ], [ 3, 4 ] ]" )
     @test GAP.gap_to_julia(fmpz_mat, val) == x
     @test fmpz_mat(val) == x
+    @test matrix(ZZ, val) == x
 
     # matrix containing small and large integers
     x = Nemo.ZZ[1 BigInt(2)^65; 3 4]
     val = GAP.evalstr( "[ [ 1, 2^65 ], [ 3, 4 ] ]" )
     @test GAP.gap_to_julia(fmpz_mat, val) == x
     @test fmpz_mat(val) == x
+    @test matrix(ZZ, val) == x
 
     # matrix containing non-integers
     val = GAP.evalstr( "[ [ 1/2, 2 ], [ 3, 4 ] ]" )
@@ -76,24 +78,28 @@ end
     val = GAP.evalstr( "[ [ 1, 2 ], [ 3, 4 ] ]" )
     @test GAP.gap_to_julia(fmpq_mat, val) == x
     @test fmpq_mat(val) == x
+    @test matrix(QQ, val) == x
 
     # matrix containing small and large integers
     x = Nemo.QQ[1 BigInt(2)^65; 3 4]
     val = GAP.evalstr( "[ [ 1, 2^65 ], [ 3, 4 ] ]" )
     @test GAP.gap_to_julia(fmpq_mat, val) == x
     @test fmpq_mat(val) == x
+    @test matrix(QQ, val) == x
 
     # matrix containing non-integer rationals, small numerator and denominator
     x = Nemo.QQ[fmpq(1, 2) 2; 3 4]
     val = GAP.evalstr( "[ [ 1/2, 2 ], [ 3, 4 ] ]" )
     @test GAP.gap_to_julia(fmpq_mat, val) == x
     @test fmpq_mat(val) == x
+    @test matrix(QQ, val) == x
 
     # matrix containing non-integer rationals, large numerator and denominator
     x = Nemo.QQ[fmpq(fmpz(2)^65, fmpz(3)^40) 2; 3 4]
     val = GAP.evalstr( "[ [ 2^65/3^40, 2 ], [ 3, 4 ] ]" )
     @test GAP.gap_to_julia(fmpq_mat, val) == x
     @test fmpq_mat(val) == x
+    @test matrix(QQ, val) == x
 
     # matrix containing non-rationals
     val = GAP.evalstr( "[ [ E(4), 2 ], [ 3, 4 ] ]" )


### PR DESCRIPTION
The central implementations now are all in type constructors, and
gap_to_julia invokes them.

Also implement `matrix(ZZ, gapobj)` and `matrix(QQ, gapobj)`, so this works:

    julia> gapobj = GAP.@gap [[1,2],[3,4]]
    GAP: [ [ 1, 2 ], [ 3, 4 ] ]

    julia> matrix(QQ, gapobj)
    [1   2]
    [3   4]

    julia> typeof(ans)
    fmpq_mat

Note that already before you could do `fmpq_mat(gapobj)`.


Next thing to do: support `matrix(GF(p), gapobj)` and `gfp_mat(gapobj)` etc. etc.
