### PR TITLE
add build scripts.

### DIFF
--- a/system/build_antic.jl
+++ b/system/build_antic.jl
@@ -5,12 +5,14 @@ using LoadFlint.FLINT_jll
 using Pkg.Artifacts
 
 # TODO: use ARGS to specify custom build dir?
-function gmp_artifact_dir()
-    artifacts_toml = joinpath(dirname(dirname(Base.pathof(GMP_jll))), "StdlibArtifacts.toml")
+function jll_artifact_dir(the_jll::Module)
+    artifacts_toml = joinpath(dirname(dirname(Base.pathof(the_jll))), "StdlibArtifacts.toml")
 
     # If this file exists, it's a stdlib JLL and we must download the artifact ourselves
     if isfile(artifacts_toml)
-        meta = artifact_meta("GMP", artifacts_toml)
+        # the artifact name is always equal to the module name minus the "_jll" suffix
+        name = replace(string(nameof(the_jll)), "_jll" => "")
+        meta = artifact_meta(name, artifacts_toml)
         hash = Base.SHA1(meta["git-tree-sha1"])
         if !artifact_exists(hash)
             dl_info = first(meta["download"])
@@ -20,49 +22,12 @@ function gmp_artifact_dir()
     end
 
     # Otherwise, we can just use the artifact directory given to us by GMP_jll
-    return GMP_jll.find_artifact_dir()
+    return the_jll.find_artifact_dir()
 end
 
-function mpfr_artifact_dir()
-    artifacts_toml = joinpath(dirname(dirname(Base.pathof(MPFR_jll))), "StdlibArtifacts.toml")
-
-    # If this file exists, it's a stdlib JLL and we must download the artifact ourselves
-    if isfile(artifacts_toml)
-        meta = artifact_meta("MPFR", artifacts_toml)
-        hash = Base.SHA1(meta["git-tree-sha1"])
-        if !artifact_exists(hash)
-            dl_info = first(meta["download"])
-            download_artifact(hash, dl_info["url"], dl_info["sha256"])
-        end
-        return artifact_path(hash)
-    end
-
-    # Otherwise, we can just use the artifact directory given to us by GMP_jll
-    return MPFR_jll.find_artifact_dir()
-end
-
-function flint_artifact_dir()
-    artifacts_toml = joinpath(dirname(dirname(Base.pathof(FLINT_jll))), "StdlibArtifacts.toml")
-
-    # If this file exists, it's a stdlib JLL and we must download the artifact ourselves
-    if isfile(artifacts_toml)
-        meta = artifact_meta("FLINT", artifacts_toml)
-        hash = Base.SHA1(meta["git-tree-sha1"])
-        if !artifact_exists(hash)
-            dl_info = first(meta["download"])
-            download_artifact(hash, dl_info["url"], dl_info["sha256"])
-        end
-        return artifact_path(hash)
-    end
-
-    # Otherwise, we can just use the artifact directory given to us by GMP_jll
-    return FLINT_jll.find_artifact_dir()
-end
-
-
-const gmp_prefix = gmp_artifact_dir()
-const mpfr_prefix = mpfr_artifact_dir()
-const flint_prefix = flint_artifact_dir()
+const gmp_prefix = jll_artifact_dir(GMP_jll)
+const mpfr_prefix = jll_artifact_dir(MPFR_jll)
+const flint_prefix = jll_artifact_dir(FLINT_jll)
 
 
 cd("antic")

--- a/system/build_antic.jl
+++ b/system/build_antic.jl
@@ -1,0 +1,89 @@
+import LoadFlint
+using LoadFlint.GMP_jll
+using LoadFlint.MPFR_jll
+using LoadFlint.FLINT_jll
+using Pkg.Artifacts
+
+# TODO: use ARGS to specify custom build dir?
+function gmp_artifact_dir()
+    artifacts_toml = joinpath(dirname(dirname(Base.pathof(GMP_jll))), "StdlibArtifacts.toml")
+
+    # If this file exists, it's a stdlib JLL and we must download the artifact ourselves
+    if isfile(artifacts_toml)
+        meta = artifact_meta("GMP", artifacts_toml)
+        hash = Base.SHA1(meta["git-tree-sha1"])
+        if !artifact_exists(hash)
+            dl_info = first(meta["download"])
+            download_artifact(hash, dl_info["url"], dl_info["sha256"])
+        end
+        return artifact_path(hash)
+    end
+
+    # Otherwise, we can just use the artifact directory given to us by GMP_jll
+    return GMP_jll.find_artifact_dir()
+end
+
+function mpfr_artifact_dir()
+    artifacts_toml = joinpath(dirname(dirname(Base.pathof(MPFR_jll))), "StdlibArtifacts.toml")
+
+    # If this file exists, it's a stdlib JLL and we must download the artifact ourselves
+    if isfile(artifacts_toml)
+        meta = artifact_meta("MPFR", artifacts_toml)
+        hash = Base.SHA1(meta["git-tree-sha1"])
+        if !artifact_exists(hash)
+            dl_info = first(meta["download"])
+            download_artifact(hash, dl_info["url"], dl_info["sha256"])
+        end
+        return artifact_path(hash)
+    end
+
+    # Otherwise, we can just use the artifact directory given to us by GMP_jll
+    return MPFR_jll.find_artifact_dir()
+end
+
+function flint_artifact_dir()
+    artifacts_toml = joinpath(dirname(dirname(Base.pathof(FLINT_jll))), "StdlibArtifacts.toml")
+
+    # If this file exists, it's a stdlib JLL and we must download the artifact ourselves
+    if isfile(artifacts_toml)
+        meta = artifact_meta("FLINT", artifacts_toml)
+        hash = Base.SHA1(meta["git-tree-sha1"])
+        if !artifact_exists(hash)
+            dl_info = first(meta["download"])
+            download_artifact(hash, dl_info["url"], dl_info["sha256"])
+        end
+        return artifact_path(hash)
+    end
+
+    # Otherwise, we can just use the artifact directory given to us by GMP_jll
+    return FLINT_jll.find_artifact_dir()
+end
+
+
+const gmp_prefix = gmp_artifact_dir()
+const mpfr_prefix = mpfr_artifact_dir()
+const flint_prefix = flint_artifact_dir()
+
+
+cd("antic")
+run(`./configure
+    --with-gmp=$(gmp_prefix)
+    --with-mpfr=$(mpfr_prefix)
+    --with-flint=$(flint_prefix)
+    --prefix=/tmp/antic
+`)
+
+run(`make install -j$(Sys.CPU_THREADS)`)
+
+println(
+"""
+
+
+Add the following lines to your .julia/artifacts/Overrides.toml
+
+[e21ec000-9f72-519e-ba6d-10061e575a27]
+Antic = "/tmp/antic"
+
+and restart julia
+
+""")

--- a/system/build_flint.jl
+++ b/system/build_flint.jl
@@ -4,12 +4,14 @@ using LoadFlint.MPFR_jll
 using Pkg.Artifacts
 
 # TODO: use ARGS to specify custom build dir?
-function gmp_artifact_dir()
-    artifacts_toml = joinpath(dirname(dirname(Base.pathof(GMP_jll))), "StdlibArtifacts.toml")
+function jll_artifact_dir(the_jll::Module)
+    artifacts_toml = joinpath(dirname(dirname(Base.pathof(the_jll))), "StdlibArtifacts.toml")
 
     # If this file exists, it's a stdlib JLL and we must download the artifact ourselves
     if isfile(artifacts_toml)
-        meta = artifact_meta("GMP", artifacts_toml)
+        # the artifact name is always equal to the module name minus the "_jll" suffix
+        name = replace(string(nameof(the_jll)), "_jll" => "")
+        meta = artifact_meta(name, artifacts_toml)
         hash = Base.SHA1(meta["git-tree-sha1"])
         if !artifact_exists(hash)
             dl_info = first(meta["download"])
@@ -19,29 +21,11 @@ function gmp_artifact_dir()
     end
 
     # Otherwise, we can just use the artifact directory given to us by GMP_jll
-    return GMP_jll.find_artifact_dir()
+    return the_jll.find_artifact_dir()
 end
 
-function mpfr_artifact_dir()
-    artifacts_toml = joinpath(dirname(dirname(Base.pathof(MPFR_jll))), "StdlibArtifacts.toml")
-
-    # If this file exists, it's a stdlib JLL and we must download the artifact ourselves
-    if isfile(artifacts_toml)
-        meta = artifact_meta("MPFR", artifacts_toml)
-        hash = Base.SHA1(meta["git-tree-sha1"])
-        if !artifact_exists(hash)
-            dl_info = first(meta["download"])
-            download_artifact(hash, dl_info["url"], dl_info["sha256"])
-        end
-        return artifact_path(hash)
-    end
-
-    # Otherwise, we can just use the artifact directory given to us by GMP_jll
-    return MPFR_jll.find_artifact_dir()
-end
-
-const gmp_prefix = gmp_artifact_dir()
-const mpfr_prefix = mpfr_artifact_dir()
+const gmp_prefix = gmp_artifact_dir(GMP_jll)
+const mpfr_prefix = mpfr_artifact_dir(MPFR_jll)
 
 
 cd("flint2")

--- a/system/build_flint.jl
+++ b/system/build_flint.jl
@@ -1,0 +1,68 @@
+import LoadFlint
+using LoadFlint.GMP_jll
+using LoadFlint.MPFR_jll
+using Pkg.Artifacts
+
+# TODO: use ARGS to specify custom build dir?
+function gmp_artifact_dir()
+    artifacts_toml = joinpath(dirname(dirname(Base.pathof(GMP_jll))), "StdlibArtifacts.toml")
+
+    # If this file exists, it's a stdlib JLL and we must download the artifact ourselves
+    if isfile(artifacts_toml)
+        meta = artifact_meta("GMP", artifacts_toml)
+        hash = Base.SHA1(meta["git-tree-sha1"])
+        if !artifact_exists(hash)
+            dl_info = first(meta["download"])
+            download_artifact(hash, dl_info["url"], dl_info["sha256"])
+        end
+        return artifact_path(hash)
+    end
+
+    # Otherwise, we can just use the artifact directory given to us by GMP_jll
+    return GMP_jll.find_artifact_dir()
+end
+
+function mpfr_artifact_dir()
+    artifacts_toml = joinpath(dirname(dirname(Base.pathof(MPFR_jll))), "StdlibArtifacts.toml")
+
+    # If this file exists, it's a stdlib JLL and we must download the artifact ourselves
+    if isfile(artifacts_toml)
+        meta = artifact_meta("MPFR", artifacts_toml)
+        hash = Base.SHA1(meta["git-tree-sha1"])
+        if !artifact_exists(hash)
+            dl_info = first(meta["download"])
+            download_artifact(hash, dl_info["url"], dl_info["sha256"])
+        end
+        return artifact_path(hash)
+    end
+
+    # Otherwise, we can just use the artifact directory given to us by GMP_jll
+    return MPFR_jll.find_artifact_dir()
+end
+
+const gmp_prefix = gmp_artifact_dir()
+const mpfr_prefix = mpfr_artifact_dir()
+
+
+cd("flint2")
+run(`./configure
+    --with-gmp=$(gmp_prefix)
+    --with-mpfr=$(mpfr_prefix)
+    --prefix=/tmp/flint
+`)
+
+run(`make install -j$(Sys.CPU_THREADS)`)
+
+println(
+"""
+
+
+Add the following lines to your .julia/artifacts/Overrides.toml
+
+[e134572f-a0d5-539d-bddf-3cad8db41a82]
+FLINT = "/tmp/flint"
+
+and restart julia
+
+""")
+


### PR DESCRIPTION
I'd prefer them to be IN the packages, but maybe in Oscar is actually
better. This is WIP, missing
 - clone the flint/antic repo
 - or pass in a location
 - maybe don't install into /tmp - but into a passed in location
 - deal with the Override better
 - add Singular, Polymake and Gap
 - or provide a generic common one...