### PR TITLE
Prefer setting struct fields by passing them to `new`

### DIFF
--- a/experimental/PlaneCurve/Variety.jl
+++ b/experimental/PlaneCurve/Variety.jl
@@ -8,9 +8,7 @@ mutable struct Variety
   I::Oscar.MPolyIdeal
 
   function Variety(I::Oscar.MPolyIdeal{<:MPolyElem{<:FieldElem}})
-    r = new()
-    r.I = I
-    return r
+    return new(I)
   end
 end
 

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -104,24 +104,17 @@ in an ordinary table, and to store the corresponding ordinary table
 in a `p`-modular table.
 """
 @attributes mutable struct GAPGroupCharacterTable <: GroupCharacterTable
-    GAPGroup::GAPGroup    # the underlying group, if any
     GAPTable::GAP.GapObj  # the character table object
     characteristic::Int
+    GAPGroup::GAPGroup    # the underlying group, if any
 
     function GAPGroupCharacterTable(G::GAPGroup, tab::GAP.GapObj, char::Int)
-      ct = new()
-      ct.GAPGroup = G
-      ct.GAPTable = tab
-      ct.characteristic = char
-      return ct
+      return new(tab, char, G)
     end
 
     function GAPGroupCharacterTable(tab::GAP.GapObj, char::Int)
-      ct = new()
-      #ct.GAPGroup is left undefined
-      ct.GAPTable = tab
-      ct.characteristic = char
-      return ct
+      #GAPGroup is left undefined
+      return new(tab, char)
     end
 end
 


### PR DESCRIPTION
Some people prefer writing constructors as e.g.

    mutable struct Foo
      coeffs::Vector{Int}
      exps::Vector{Int}
      optional::Vector{Int}
      function Foo(x::Vector{Int}, y::Vector{Int})
        f = new()
        f.coeffs = x
        f.exps = y
        return f
      end
    end

instead of

    mutable struct Foo
      coeffs::Vector{Int}
      exps::Vector{Int}
      optional::Vector{Int}
      function Foo(x::Vector{Int}, y::Vector{Int})
        return new(x, y)
      end
    end

The primary arguments are readability and safety: this way it is immediately
clear which expression is assigned to which field (you don't need to count the
arguments to `new` to determine this). And this then reduces the risk of
mistakes where one accidentally assigns a constructor argument to the wrong
fields (if the types match, otherwise of course a runtime error will be thrown
anyway).

However, this also has performance ramifications: consider a simple helper function

    bar(foo::Foo) = length(foo.coeffs)

In the second example, Julia is able to deduce that `foo.coeffs` will always
be initialized, and generates optimal code machine code (edited slightly for
readability):

    julia> foo = Foo([1,2],[3,4]); @code_native bar(foo)
        .section	__TEXT,__text,regular,pure_instructions
        movq	(%rdi), %rax
        movq	8(%rax), %rax
        retq

But in the former case, Julia is not able to do that, and thus generates code
which is far less efficient:

    julia> foo = Foo([1,2],[3,4]); @code_native bar(foo)
        .section	__TEXT,__text,regular,pure_instructions
        pushq	%rax
        movq	(%rdi), %rax
        testq	%rax, %rax
        je	L15
        popq	%rcx
        retq
    L15:
        movabsq	$jl_throw, %rax
        movabsq	$jl_system_image_data, %rdi
        callq	*%rax
        nopw	%cs:(%rax,%rax)

The difference does not matter if access is rare, but it can accumulate
quickly if one e.g. pays it for access to entries of a matrix and then
performs it millions of times.

This patch thus changes some uses of `new` to try and set fields by
passing them as arguments directly. To get at least somewhat better
readability, we ensure that the names of the arguments passed to `new`
match the field names. So to continue the initial example, it is better
to write

    mutable struct Foo
      coeffs::Vector{Int}
      exps::Vector{Int}
      optional::Vector{Int}
      function Foo(coeffs::Vector{Int}, exps::Vector{Int})
        return new(coeffs, exps)
      end
    end

For even more safety, one can also use the Base.@kwdef macro and then
reimplement existing inner constructors using the keyword-args based
constructor provided by the macro. Note that this does not allow for undefined
fields, but one can replace fields `x::T` which currently can be `undef` by
`x::Union{Nothing,T} = nothing` for a similar but safer effect:

    Base.@kwdef mutable struct Foo
      coeffs::Vector{Int}
      exps::Vector{Int}
      optional::Union{Nothing,Vector{Int}} = nothing
    end
    function Foo(coeffs::Vector{Int}, exps::Vector{Int})
      return Foo(; coeffs, exps)
    end
