### PR TITLE
Tidy up invariant theory code

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -182,6 +182,19 @@
   url           = {https://doi.org/10.1007/978-3-642-59932-3}
 }
 
+@Article{DHS98,
+  author        = {Decker, Wolfram and Heydtmann, Agnes Eileen and Schreyer,
+                  Frank-Olaf},
+  title         = {Generating a {N}oetherian normalization of the invariant
+                  ring of a finite group},
+  journal       = {J. Symbolic Comput.},
+  fjournal      = {Journal of Symbolic Computation},
+  volume        = {25},
+  year          = {1998},
+  number        = {6},
+  pages         = {727--731}
+}
+
 @InCollection{DJ98,
   author        = {Decker, Wolfram and de Jong, Theo},
   title         = {Gröbner bases and invariant theory},

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -678,6 +678,15 @@
   url           = {https://doi.org/10.1007/BFb0086390}
 }
 
+@Book{Stu93,
+  author        = {Sturmfels, Bernd},
+  title         = {Algorithms in invariant theory},
+  series        = {Texts and Monographs in Symbolic Computation},
+  publisher     = {Springer-Verlag, Vienna},
+  year          = {1993},
+  pages         = {vi+197}
+}
+
 @Article{Tay87,
   author        = {Taylor, D. E.},
   title         = {Pairs of Generators for Matrix Groups. I},

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -192,7 +192,9 @@
   volume        = {25},
   year          = {1998},
   number        = {6},
-  pages         = {727--731}
+  pages         = {727--731},
+  doi           = {10.1006/jsco.1997.0196},
+  url           = {https://doi.org/10.1006/jsco.1997.0196}
 }
 
 @InCollection{DJ98,
@@ -697,7 +699,9 @@
   series        = {Texts and Monographs in Symbolic Computation},
   publisher     = {Springer-Verlag, Vienna},
   year          = {1993},
-  pages         = {vi+197}
+  pages         = {vi+197},
+  doi           = {10.1007/978-3-7091-4368-1},
+  url           = {https://doi.org/10.1007/978-3-7091-4368-1}
 }
 
 @Article{Tay87,

--- a/docs/src/General/styleguide.md
+++ b/docs/src/General/styleguide.md
@@ -21,7 +21,7 @@ quite some of them; but in general we strive to reduce these)
   `point_from_matrix` as the from part is clear by the type of the argument.
   It should be called `points(T::Matrix)` in some variation.
   Similar: `matrix_to_points`. It is fine to use them internally, where
-  useful, however, internally.
+  useful.
 - follow the mathematics. If your function needs a list of points, you should
   create a point-type and then use this. For user-facing functions, please do not
   use re-purposed lists, arrays, matrices...
@@ -117,11 +117,11 @@ end
 
 - Functions should not have too many arguments.
   If you need a bunch arguments, chances are that introducing a new object
-  makes it more readable)
+  makes it more readable.
 
 - Functions should not be too long; very long functions are in general harder
   to understand; it is also more difficult to see all the code at once. Consider
-  splitting the function into multiple, if it is sensibly possible.
+  splitting the function into multiple ones, if it is sensibly possible.
 
 However, as always, rules sometimes should be broken.
 

--- a/docs/src/InvariantTheory/finite_groups.md
+++ b/docs/src/InvariantTheory/finite_groups.md
@@ -103,7 +103,11 @@ reynolds_operator(IR::InvRing{FldT, GrpT, T}, f::T) where {FldT, GrpT, T <: MPol
 ## Invariants of a Given Degree
 
 ```@docs
-basis(IR::InvRing, d::Int)
+basis(IR::InvRing, d::Int, algo::Symbol = :default)
+```
+
+```@docs
+iterate_basis(IR::InvRing, d::Int, algo::Symbol = :default)
 ```
 
 ## The Molien Series
@@ -115,7 +119,15 @@ basis(IR::InvRing, d::Int)
 ## Primary Invariants
 
 ```@docs
-primary_invariants(IR::InvRing)
+primary_invariants(IR::InvRing, algo::Symbol = :optimal_hsop)
+```
+
+```@docs
+primary_invariants_via_optimal_hsop(IR::InvRing)
+```
+
+```@docs
+primary_invariants_via_successive_algo(IR::InvRing)
 ```
 
 ## Secondary Invariants

--- a/experimental/InvariantTheory/invariant_rings.jl
+++ b/experimental/InvariantTheory/invariant_rings.jl
@@ -353,7 +353,7 @@ basis(IR::InvRing, d::Int, algo = :default) = collect(iterate_basis(IR, d, algo)
 function secondary_invariants_via_singular(IR::InvRing)
   if !isdefined(IR, :secondary)
     rey, mol = reynolds_molien_via_singular(IR)
-    primary_invariants_via_radical_containment(IR)
+    primary_invariants_via_successive_algo(IR)
     P = IR.primary_singular
     if iszero(characteristic(coefficient_ring(IR)))
       S, IS = Singular.LibFinvar.secondary_char0(P[1], rey, mol)

--- a/experimental/InvariantTheory/invariant_rings.jl
+++ b/experimental/InvariantTheory/invariant_rings.jl
@@ -35,8 +35,10 @@ end
     invariant_ring(G::MatrixGroup)
 
 Return the invariant ring of the finite matrix group `G`.
-    
-CAVEAT: The creation of invariant rings is lazy in the sense that no explicit computations are done until specifically invoked (for example, by the `primary_invariants` function).
+
+CAVEAT: The creation of invariant rings is lazy in the sense that no explicit
+computations are done until specifically invoked (for example, by the
+`primary_invariants` function).
 
 # Examples
 ```jldoctest
@@ -164,7 +166,8 @@ end
 @doc Markdown.doc"""
      reynolds_operator(IR::InvRing{FldT, GrpT, T}, f::T) where {FldT, GrpT, T <: MPolyElem}
 
-In the non-modular case, return the image of `f` under the Reynolds operator projecting onto `IR`.
+In the non-modular case, return the image of `f` under the Reynolds operator
+projecting onto `IR`.
 
 # Examples
 ```jldoctest
@@ -207,8 +210,7 @@ x[1]^3
 
 julia> reynolds_operator(IR, f)
 1//3*x[1]^3 + 1//3*x[2]^3 + 1//3*x[3]^3
-```
-```jldoctest
+
 julia> M = matrix(GF(3), [0 1 0; -1 0 0; 0 0 -1])
 [0   1   0]
 [2   0   0]
@@ -272,13 +274,17 @@ end
 @doc Markdown.doc"""
      basis(IR::InvRing, d::Int, algo::Symbol = :default)
 
-Given an invariant ring `IR` and an integer `d`, return a basis for the invariants in degree `d`.
-The used algorithm can be specified using the optional argument `algo`. Possible values are `:reynolds` which uses the reynolds operator to construct the basis (only available in the non-modular case) and `:linear_algebra` which uses plain linear algebra. With the default value `:default` the heuristically best algorithm is selected.
+Given an invariant ring `IR` and an integer `d`, return a basis for the invariants
+in degree `d`. The used algorithm can be specified using the optional argument
+`algo`. Possible values are `:reynolds` which uses the reynolds operator to
+construct the basis (only available in the non-modular case) and `:linear_algebra`
+which uses plain linear algebra. With the default value `:default` the
+heuristically best algorithm is selected.
 
-See also `iterate_basis`.
+See also [`iterate_basis`](@ref).
 
 # Examples
-```
+```jldoctest
 julia> K, a = CyclotomicField(3, "a")
 (Cyclotomic field of order 3, a)
 
@@ -303,12 +309,11 @@ AbstractAlgebra.Generic.MatSpaceElem{nf_elem}[[0 0 1; 1 0 0; 0 1 0], [1 0 0; 0 a
 
 julia> basis(IR, 6)
 4-element Vector{MPolyElem_dec{nf_elem, AbstractAlgebra.Generic.MPoly{nf_elem}}}:
- x[1]^6 + x[2]^6 + x[3]^6
+ x[1]^2*x[2]^2*x[3]^2
  x[1]^4*x[2]*x[3] + x[1]*x[2]^4*x[3] + x[1]*x[2]*x[3]^4
  x[1]^3*x[2]^3 + x[1]^3*x[3]^3 + x[2]^3*x[3]^3
- x[1]^2*x[2]^2*x[3]^2
-```
-```
+ x[1]^6 + x[2]^6 + x[3]^6
+
 julia> M = matrix(GF(3), [0 1 0; -1 0 0; 0 0 -1])
 [0   1   0]
 [2   0   0]
@@ -330,8 +335,8 @@ julia> basis(IR, 2)
 
 julia> basis(IR, 3)
 2-element Vector{MPolyElem_dec{gfp_elem, gfp_mpoly}}:
- x[1]^2*x[3] + 2*x[2]^2*x[3]
  x[1]*x[2]*x[3]
+ x[1]^2*x[3] + 2*x[2]^2*x[3]
 ```
 """
 basis(IR::InvRing, d::Int, algo = :default) = collect(iterate_basis(IR, d, algo))
@@ -378,10 +383,11 @@ end
 @doc Markdown.doc"""
     secondary_invariants(IR::InvRing)
 
-Return a system of secondary invariants for `IR` with respect to the currently cached system of primary invariants for `IR`
-(if no system of primary invariants for `IR` is cached, compute and cache such a system first).
+Return a system of secondary invariants for `IR` with respect to the currently
+cached system of primary invariants for `IR` (if no system of primary invariants
+for `IR` is cached, compute and cache such a system first).
 
-If a system of secondary invariants is already cached, return the cached system. 
+If a system of secondary invariants is already cached, return the cached system.
 Otherwise, compute and cache such a system first.
 
 NOTE: The secondary invariants are sorted by increasing degree.
@@ -403,7 +409,7 @@ julia> secondary_invariants(IR)
  1
  x[1]^6*x[3]^3 + x[1]^3*x[2]^6 + x[2]^3*x[3]^6
 ```
-"""    
+"""
 function secondary_invariants(IR::InvRing)
   if !isdefined(IR, :secondary)
     secondary_invariants_via_singular(IR)
@@ -414,16 +420,18 @@ end
 @doc Markdown.doc"""
     irreducible_secondary_invariants(IR::InvRing)
 
-Return a system of irreducible secondary invariants for `IR` with respect to the currently cached system of primary invariants for `IR`
-(if no system of primary invariants for `IR` is cached, compute and cache such a system first).
+Return a system of irreducible secondary invariants for `IR` with respect to the
+currently cached system of primary invariants for `IR` (if no system of primary
+invariants for `IR` is cached, compute and cache such a system first).
 
-If a system of irreducible secondary invariants is already cached, return the cached system. 
+If a system of irreducible secondary invariants is already cached, return the
+cached system.
 Otherwise, compute and cache such a system first.
 
 NOTE: The irreducible secondary invariants are sorted by increasing degree.
 
 # Examples
-```
+```jldoctest
 julia> M = matrix(QQ, [0 -1 0 0 0; 1 -1 0 0 0; 0 0 0 0 1; 0 0 1 0 0; 0 0 0 1 0]);
 
 julia> G = MatrixGroup(5, QQ, [M]);
@@ -437,7 +445,7 @@ julia> secondary_invariants(IR)
  x[1]^2 - x[1]*x[2] + x[2]^2
  x[3]^2*x[5] + x[3]*x[4]^2 + x[4]*x[5]^2
  x[3]^3 + x[4]^3 + x[5]^3
- x[1]*x[3]*x[4] - x[1]*x[3]*x[5] - x[2]*x[3]*x[4] + x[2]*x[4]*x[5]
+ x[1]*x[3]^2 - x[1]*x[5]^2 - x[2]*x[3]^2 + x[2]*x[4]^2
  x[1]*x[3]^2 - x[1]*x[4]^2 + x[2]*x[4]^2 - x[2]*x[5]^2
  x[1]^2*x[3] + x[1]^2*x[5] - 2*x[1]*x[2]*x[3] + x[2]^2*x[3] + x[2]^2*x[4]
  x[1]^2*x[3] - x[1]*x[2]*x[3] - x[1]*x[2]*x[4] + x[1]*x[2]*x[5] + x[2]^2*x[4]
@@ -451,7 +459,7 @@ julia> irreducible_secondary_invariants(IR)
  x[1]^2 - x[1]*x[2] + x[2]^2
  x[3]^2*x[5] + x[3]*x[4]^2 + x[4]*x[5]^2
  x[3]^3 + x[4]^3 + x[5]^3
- x[1]*x[3]*x[4] - x[1]*x[3]*x[5] - x[2]*x[3]*x[4] + x[2]*x[4]*x[5]
+ x[1]*x[3]^2 - x[1]*x[5]^2 - x[2]*x[3]^2 + x[2]*x[4]^2
  x[1]*x[3]^2 - x[1]*x[4]^2 + x[2]*x[4]^2 - x[2]*x[5]^2
  x[1]^2*x[3] + x[1]^2*x[5] - 2*x[1]*x[2]*x[3] + x[2]^2*x[3] + x[2]^2*x[4]
  x[1]^2*x[3] - x[1]*x[2]*x[3] - x[1]*x[2]*x[4] + x[1]*x[2]*x[5] + x[2]^2*x[4]
@@ -507,10 +515,11 @@ end
 @doc Markdown.doc"""
     molien_series([S::PolyRing], I::InvRing)
 
-In the non-modular case, return the Molien series of `I` as a rational function. 
+In the non-modular case, return the Molien series of `I` as a rational function.
 
-If a univariate polynomial ring with rational coefficients is specified by the optional argument `S::PolyRing`, 
-then the Molien series is returned as an element of the fraction field of that ring.
+If a univariate polynomial ring with rational coefficients is specified by the
+optional argument `S::PolyRing`, then the Molien series is returned as an element
+of the fraction field of that ring.
 
 # Examples
 ```jldoctest
@@ -573,17 +582,17 @@ ismolien_series_implemented(I::InvRing) = !ismodular(I)
 
 Return a system of fundamental invariants for `IR`.
 
-If a system of fundamental invariants is already cached, return the cached system. 
+If a system of fundamental invariants is already cached, return the cached system.
 Otherwise, compute and cache such a system first.
 
 # Implemented Algorithms
 
-By default, the function relies on King's algorithm which finds a system of 
-fundamental invariants directly, without computing primary and secondary invariants. 
+By default, the function relies on King's algorithm which finds a system of
+fundamental invariants directly, without computing primary and secondary invariants.
 
 Alternatively, if specified by `algo = :minimal_subalgebra`, the function computes
-fundamental invariants from a collection of primary and irreducible secondary invariants using
-the function `minimal_subalgebra_generators`.
+fundamental invariants from a collection of primary and irreducible secondary
+invariants using the function `minimal_subalgebra_generators`.
 
 NOTE: The fundamental invariants are sorted by increasing degree.
 
@@ -653,17 +662,18 @@ end
     affine_algebra(IR::InvRing)
 
 Given an invariant ring `IR` with underlying graded polynomial ring, say `R`,
-return a graded affine algebra, say `A`, together with a graded algebra homomomorphism 
-$A\rightarrow R$ which maps `A` isomorphically onto `IR`.
+return a graded affine algebra, say `A`, together with a graded algebra
+homomomorphism $A\rightarrow R$ which maps `A` isomorphically onto `IR`.
 
-NOTE: If a system of fundamental invariants for `IR` is already cached, the function makes use of that system. 
-Otherwise, such a system is computed and cached first. The algebra `A` is graded according to the 
-degrees of the fundamental invariants, the modulus of `A` is generated by the algebra relations
-on these invariants, and the algebra homomomorphism $A\rightarrow R$ is defined by sending the
-$i$th generator of `A` to the $i$th fundamental invariant.
+NOTE: If a system of fundamental invariants for `IR` is already cached, the
+function makes use of that system. Otherwise, such a system is computed and
+cached first. The algebra `A` is graded according to the degrees of the
+fundamental invariants, the modulus of `A` is generated by the algebra relations
+on these invariants, and the algebra homomomorphism $A\rightarrow R$ is defined
+by sending the $i$th generator of `A` to the $i$th fundamental invariant.
 
-# Examples 
-```jldoctest 
+# Examples
+```jldoctest
 julia> K, a = CyclotomicField(3, "a")
 (Cyclotomic field of order 3, a)
 

--- a/experimental/InvariantTheory/iterators.jl
+++ b/experimental/InvariantTheory/iterators.jl
@@ -96,11 +96,19 @@ end
 @doc Markdown.doc"""
      iterate_basis(IR::InvRing, d::Int, algo::Symbol = :default)
 
-Given an invariant ring `IR` and an integer `d`, return an iterator over a basis for the invariants in degree `d`.
-The used algorithm can be specified using the optional argument `algo`. Possible values are `:reynolds` which uses the reynolds operator to construct the basis (only available in the non-modular case) and `:linear_algebra` which uses plain linear algebra. With the default value `:default` the heuristically best algorithm is selected.
-When using the reynolds operator the basis is constructed element-by-element. With linear algebra this is not possible and the whole basis will be constructed directly when calling the function.
+Given an invariant ring `IR` and an integer `d`, return an iterator over a basis
+for the invariants in degree `d`.
+The used algorithm can be specified using the optional argument `algo`. Possible
+values are `:reynolds` which uses the reynolds operator to construct the basis
+(only available in the non-modular case) and `:linear_algebra` which uses plain
+linear algebra. With the default value `:default` the heuristically best algorithm
+is selected.
 
-See also `basis`.
+When using the reynolds operator the basis is constructed element-by-element.
+With linear algebra this is not possible and the whole basis will be constructed
+directly when calling the function.
+
+See also [`basis`](@ref).
 
 # Examples
 ```
@@ -139,8 +147,7 @@ julia> collect(B)
  x[1]^4*x[2]*x[3] + x[1]*x[2]^4*x[3] + x[1]*x[2]*x[3]^4
  x[1]^3*x[2]^3 + x[1]^3*x[3]^3 + x[2]^3*x[3]^3
  x[1]^6 + x[2]^6 + x[3]^6
-```
-```
+
 julia> M = matrix(GF(3), [0 1 0; -1 0 0; 0 0 -1])
 [0   1   0]
 [2   0   0]

--- a/experimental/InvariantTheory/iterators.jl
+++ b/experimental/InvariantTheory/iterators.jl
@@ -1,3 +1,5 @@
+export iterate_basis
+
 ################################################################################
 #
 #  All Monomials
@@ -80,7 +82,7 @@ end
 # If we cannot compute the Molien series (so far in the modular case), we return
 # -1.
 function dimension_via_molien_series(::Type{T}, R::InvRing, d::Int) where T <: IntegerUnion
-  if ismodular(R)
+  if !ismolien_series_implemented(R)
     return -1
   end
 
@@ -91,8 +93,81 @@ function dimension_via_molien_series(::Type{T}, R::InvRing, d::Int) where T <: I
   return T(numerator(k))::T
 end
 
-# Iterate over the basis of the degree d component of an invariant ring.
-# algo can be either :default, :reynolds or :linear_algebra.
+@doc Markdown.doc"""
+     iterate_basis(IR::InvRing, d::Int, algo::Symbol = :default)
+
+Given an invariant ring `IR` and an integer `d`, return an iterator over a basis for the invariants in degree `d`.
+The used algorithm can be specified using the optional argument `algo`. Possible values are `:reynolds` which uses the reynolds operator to construct the basis (only available in the non-modular case) and `:linear_algebra` which uses plain linear algebra. With the default value `:default` the heuristically best algorithm is selected.
+When using the reynolds operator the basis is constructed element-by-element. With linear algebra this is not possible and the whole basis will be constructed directly when calling the function.
+
+See also `basis`.
+
+# Examples
+```
+julia> K, a = CyclotomicField(3, "a")
+(Cyclotomic field of order 3, a)
+
+julia> M1 = matrix(K, [0 0 1; 1 0 0; 0 1 0])
+[0   0   1]
+[1   0   0]
+[0   1   0]
+
+julia> M2 = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1])
+[1   0        0]
+[0   a        0]
+[0   0   -a - 1]
+
+julia> G = MatrixGroup(3, K, [ M1, M2 ])
+Matrix group of degree 3 over Cyclotomic field of order 3
+
+julia> IR = invariant_ring(G)
+Invariant ring of
+Matrix group of degree 3 over Cyclotomic field of order 3
+with generators
+AbstractAlgebra.Generic.MatSpaceElem{nf_elem}[[0 0 1; 1 0 0; 0 1 0], [1 0 0; 0 a 0; 0 0 -a-1]]
+
+julia> B = iterate_basis(IR, 6)
+Iterator over a basis of the component of degree 6 of
+Invariant ring of
+Matrix group of degree 3 over Cyclotomic field of order 3
+with generators
+AbstractAlgebra.Generic.MatSpaceElem{nf_elem}[[0 0 1; 1 0 0; 0 1 0], [1 0 0; 0 a 0; 0 0 -a-1]]
+
+julia> collect(B)
+4-element Vector{MPolyElem_dec{nf_elem, AbstractAlgebra.Generic.MPoly{nf_elem}}}:
+ x[1]^2*x[2]^2*x[3]^2
+ x[1]^4*x[2]*x[3] + x[1]*x[2]^4*x[3] + x[1]*x[2]*x[3]^4
+ x[1]^3*x[2]^3 + x[1]^3*x[3]^3 + x[2]^3*x[3]^3
+ x[1]^6 + x[2]^6 + x[3]^6
+```
+```
+julia> M = matrix(GF(3), [0 1 0; -1 0 0; 0 0 -1])
+[0   1   0]
+[2   0   0]
+[0   0   2]
+
+julia> G = MatrixGroup(3, GF(3), [M])
+Matrix group of degree 3 over Galois field with characteristic 3
+
+julia> IR = invariant_ring(G)
+Invariant ring of
+Matrix group of degree 3 over Galois field with characteristic 3
+with generators
+gfp_mat[[0 1 0; 2 0 0; 0 0 2]]
+
+julia> B = iterate_basis(IR, 2)
+Iterator over a basis of the component of degree 2 of
+Invariant ring of
+Matrix group of degree 3 over Galois field with characteristic 3
+with generators
+gfp_mat[[0 1 0; 2 0 0; 0 0 2]]
+
+julia> collect(B)
+2-element Vector{MPolyElem_dec{gfp_elem, gfp_mpoly}}:
+ x[1]^2 + x[2]^2
+ x[3]^2
+```
+"""
 function iterate_basis(R::InvRing, d::Int, algo::Symbol = :default)
   @assert d >= 0 "Degree must be non-negativ"
 
@@ -131,6 +206,7 @@ function iterate_basis(R::InvRing, d::Int, algo::Symbol = :default)
 end
 
 function iterate_basis_reynolds(R::InvRing, d::Int)
+  @assert !ismodular(R)
   @assert d >= 0 "Degree must be non-negativ"
 
   monomials = all_monomials(polynomial_ring(R), d)

--- a/experimental/InvariantTheory/primary_invariants.jl
+++ b/experimental/InvariantTheory/primary_invariants.jl
@@ -141,7 +141,7 @@ The product of the degrees $d_1,\dots, d_n$ of the returned primary invariants i
 The following keyword agruments can be used to speed up the computation.
 If degrees $d_1,\dots, d_n$ of primary invariants are known, those can be specified by `primary_degrees = [d_1, ..., d_n]`. Note that an error is raised if in fact no primary invariants of the given degrees exist.
 If a number $l \geq 1$ with $d_1\cdots d_n \geq l |G|$, where $G$ is the underlying group, is known, this can be specified by `degree_bound = l`. The default value is `degree_bound = 1`.
-In some situations the runtime of the algorithm might be improved by assigning `ensure_minimality` a positive integer. This leads to an early cancellation of loops in the algorithm and the described minimality of the degrees is not guaranteed anymore. The default value is `ensure_minimality = 0` corresponding to no cancellation.
+In some situations the runtime of the algorithm might be improved by assigning `ensure_minimality` a positive integer. This leads to an early cancellation of loops in the algorithm and the described minimality of the degrees is not guaranteed anymore. A smaller (positive) value of `ensure_minimality` corresponds to an earlier cancellation. However, the default value `ensure_minimality = 0` corresponds to no cancellation.
 
 # Examples
 ```jldoctest

--- a/experimental/InvariantTheory/primary_invariants.jl
+++ b/experimental/InvariantTheory/primary_invariants.jl
@@ -1,4 +1,4 @@
-export primary_invariants, primary_invariants_via_optimal_hsop, primary_invariants_via_radical_containment
+export primary_invariants, primary_invariants_via_optimal_hsop, primary_invariants_via_successive_algo
 
 # If d_1, ..., d_n are degrees of primary invariants, then the Hilbert series
 # must be f(t)/\prod_i (1 - t^{d_i}) where f is a polynomial with integer
@@ -260,9 +260,9 @@ function primary_invariants_via_optimal_hsop!(RG::InvRing{FldT, GrpT, PolyElemT}
 end
 
 @doc Markdown.doc"""
-    primary_invariants_via_radical_containment(IR::InvRing)
+    primary_invariants_via_successive_algo(IR::InvRing)
 
-Return a system of primary invariants for `IR` using the algorithm in Stu93.
+Return a system of primary invariants for `IR` using the algorithm in DHS98.
 
 # Examples
 ```jldoctest
@@ -276,14 +276,14 @@ julia> G = MatrixGroup(3, K, [M1, M2]);
 
 julia> IR = invariant_ring(G);
 
-julia> primary_invariants_via_radical_containment(IR)
+julia> primary_invariants_via_successive_algo(IR)
 3-element Vector{MPolyElem_dec{nf_elem, AbstractAlgebra.Generic.MPoly{nf_elem}}}:
  x[1]*x[2]*x[3]
  x[1]^3 + x[2]^3 + x[3]^3
  x[1]^3*x[2]^3 + x[1]^3*x[3]^3 + x[2]^3*x[3]^3
 ```
 """
-function primary_invariants_via_radical_containment(IR::InvRing)
+function primary_invariants_via_successive_algo(IR::InvRing)
   IR.primary_singular = Singular.LibFinvar.primary_invariants(_action_singular(IR)...)
   if ismodular(IR)
     P = IR.primary_singular
@@ -308,12 +308,12 @@ If a system of primary invariants for `IR` is already cached, return the cached 
 Otherwise, compute and cache such a system first.
 
 The used algorithm can be specified with the optional argument `algo`. Possible values
-are `:optimal_hsop` which uses the algorithm in Kem99 or `:radical_containment` which uses the algorithm from Stu93.
+are `:optimal_hsop` which uses the algorithm in Kem99 or `:successive_algo` which uses the algorithm from DHS98.
 The default option is `:optimal_hsop` which is in general expected to be the faster algorithm.
 
 NOTE: The primary invariants are sorted by increasing degree.
 
-See also `primary_invariants_via_optimal_hsop` and `primary_invariants_via_radical_containment` for more options.
+See also `primary_invariants_via_optimal_hsop` and `primary_invariants_via_successive_algo` for more options.
 
 # Examples
 ```jldoctest
@@ -338,8 +338,8 @@ function primary_invariants(IR::InvRing, algo::Symbol = :optimal_hsop)
   if !isdefined(IR, :primary)
     if algo == :optimal_hsop
       IR.primary = primary_invariants_via_optimal_hsop(IR)
-    elseif algo == :radical_containment
-      IR.primary = primary_invariants_via_radical_containment(IR)
+    elseif algo == :successive_algo
+      IR.primary = primary_invariants_via_successive_algo(IR)
     else
       error("Unsupported argument :$(algo) for algo.")
     end

--- a/experimental/InvariantTheory/primary_invariants.jl
+++ b/experimental/InvariantTheory/primary_invariants.jl
@@ -132,16 +132,27 @@ end
 
 @doc Markdown.doc"""
     primary_invariants_via_optimal_hsop(IR::InvRing;
-      ensure_minimality::Int = 0, degree_bound::Int = 1, primary_degrees::Vector{Int} = Int[])
+      ensure_minimality::Int = 0, degree_bound::Int = 1,
+      primary_degrees::Vector{Int} = Int[])
 
 Return a system of primary invariants for `IR` using the algorithm in Kem99.
 
-The product of the degrees $d_1,\dots, d_n$ of the returned primary invariants is guaranteed to be minimal among all possible sets of primary invariants.
+The product of the degrees $d_1,\dots, d_n$ of the returned primary invariants
+is guaranteed to be minimal among all possible sets of primary invariants.
 
 The following keyword agruments can be used to speed up the computation.
-If degrees $d_1,\dots, d_n$ of primary invariants are known, those can be specified by `primary_degrees = [d_1, ..., d_n]`. Note that an error is raised if in fact no primary invariants of the given degrees exist.
-If a number $l \geq 1$ with $d_1\cdots d_n \geq l |G|$, where $G$ is the underlying group, is known, this can be specified by `degree_bound = l`. The default value is `degree_bound = 1`.
-In some situations the runtime of the algorithm might be improved by assigning `ensure_minimality` a positive integer. This leads to an early cancellation of loops in the algorithm and the described minimality of the degrees is not guaranteed anymore. A smaller (positive) value of `ensure_minimality` corresponds to an earlier cancellation. However, the default value `ensure_minimality = 0` corresponds to no cancellation.
+If degrees $d_1,\dots, d_n$ of primary invariants are known, those can be specified
+by `primary_degrees = [d_1, ..., d_n]`. Note that an error is raised if in fact
+no primary invariants of the given degrees exist.
+If a number $l \geq 1$ with $d_1\cdots d_n \geq l |G|$, where $G$ is the underlying
+group, is known, this can be specified by `degree_bound = l`. The default value is
+`degree_bound = 1`.
+In some situations the runtime of the algorithm might be improved by assigning
+`ensure_minimality` a positive integer. This leads to an early cancellation of
+loops in the algorithm and the described minimality of the degrees is not
+guaranteed anymore. A smaller (positive) value of `ensure_minimality` corresponds
+to an earlier cancellation. However, the default value `ensure_minimality = 0`
+corresponds to no cancellation.
 
 # Examples
 ```jldoctest
@@ -302,18 +313,17 @@ end
 @doc Markdown.doc"""
     primary_invariants(IR::InvRing, algo::Symbol = :optimal_hsop)
 
-Return a system of primary invariants for `IR`.
+Return a system of primary invariants for `IR` as a `Vector` sorted by increasing
+degree. The result is cached, so calling this function again will be fast and
+give the same result.
 
-If a system of primary invariants for `IR` is already cached, return the cached system.
-Otherwise, compute and cache such a system first.
+The used algorithm can be specified with the optional argument `algo`. Possible
+values are `:optimal_hsop` which uses the algorithm in Kem99 or `:successive_algo`
+which uses the algorithm from DHS98. The default option is `:optimal_hsop` which
+is in general expected to be the faster algorithm.
 
-The used algorithm can be specified with the optional argument `algo`. Possible values
-are `:optimal_hsop` which uses the algorithm in Kem99 or `:successive_algo` which uses the algorithm from DHS98.
-The default option is `:optimal_hsop` which is in general expected to be the faster algorithm.
-
-NOTE: The primary invariants are sorted by increasing degree.
-
-See also `primary_invariants_via_optimal_hsop` and `primary_invariants_via_successive_algo` for more options.
+See also [`primary_invariants_via_optimal_hsop`](@ref) and
+[`primary_invariants_via_successive_algo`](@ref) for more options.
 
 # Examples
 ```jldoctest

--- a/experimental/InvariantTheory/primary_invariants.jl
+++ b/experimental/InvariantTheory/primary_invariants.jl
@@ -1,10 +1,11 @@
+export primary_invariants, primary_invariants_via_optimal_hsop, primary_invariants_via_radical_containment
+
 # If d_1, ..., d_n are degrees of primary invariants, then the Hilbert series
-# must be f(t)/\prod_i (1 - t^{d_i}) where f is a polynomial with non-negative
-# integer coefficients (non-negativity only holds in the non-modular case!).
+# must be f(t)/\prod_i (1 - t^{d_i}) where f is a polynomial with integer
+# coefficients respectively non-negative integer coefficients in the non-modular
+# case.
 # See DK15, pp. 94, 95.
 function test_primary_degrees_via_hilbert_series(R::InvRing, degrees::Vector{Int})
-  @assert !ismodular(R)
-
   mol = molien_series(R)
   f = numerator(mol)
   g = denominator(mol)
@@ -20,7 +21,7 @@ function test_primary_degrees_via_hilbert_series(R::InvRing, degrees::Vector{Int
     if !isinteger(c)
       return false
     end
-    if c < 0
+    if !ismodular(R) && c < 0
       return false
     end
   end
@@ -29,6 +30,7 @@ end
 
 # Returns possible degrees of primary invariants d_1, ..., d_n with
 # d_1 \cdots d_n == k*|G|, where G = group(R).
+# (Note that |G| must divide d_1 \cdots d_n, see DK15, Prop. 3.5.5.)
 function candidates_primary_degrees(R::InvRing, k::Int, bad_prefixes::Vector{Vector{Int}} = Vector{Vector{Int}}())
 
   factors = MSet{Int}()
@@ -70,6 +72,10 @@ function candidates_primary_degrees(R::InvRing, k::Int, bad_prefixes::Vector{Vec
     end
     skip ? continue : nothing
 
+    if mod(lcm(ds), exponent(group(R))) != 0
+      continue
+    end
+
     for d in ds
       # Check whether there exist invariants of this degree.
       if dimension_via_molien_series(fmpz, R, d) == 0
@@ -79,9 +85,13 @@ function candidates_primary_degrees(R::InvRing, k::Int, bad_prefixes::Vector{Vec
     end
     skip ? continue : nothing
 
-    if test_primary_degrees_via_hilbert_series(R, ds)
-      push!(degrees, ds)
+    if ismolien_series_implemented(R)
+      if !test_primary_degrees_via_hilbert_series(R, ds)
+        continue
+      end
     end
+
+    push!(degrees, ds)
   end
 
   sort!(degrees, lt = (x, y) -> sum(x) < sum(y) || x < y)
@@ -120,11 +130,61 @@ function check_primary_degrees(RG::InvRing{FldT, GrpT, PolyElemT}, degrees::Vect
   return true
 end
 
-function primary_invariants_via_optimal_hsop(RG::InvRing, ensure_minimality::Int = 0)
+@doc Markdown.doc"""
+    primary_invariants_via_optimal_hsop(IR::InvRing;
+      ensure_minimality::Int = 0, degree_bound::Int = 1, primary_degrees::Vector{Int} = Int[])
+
+Return a system of primary invariants for `IR` using the algorithm in Kem99.
+
+The product of the degrees $d_1,\dots, d_n$ of the returned primary invariants is guaranteed to be minimal among all possible sets of primary invariants.
+
+The following keyword agruments can be used to speed up the computation.
+If degrees $d_1,\dots, d_n$ of primary invariants are known, those can be specified by `primary_degrees = [d_1, ..., d_n]`. Note that an error is raised if in fact no primary invariants of the given degrees exist.
+If a number $l \geq 1$ with $d_1\cdots d_n \geq l |G|$, where $G$ is the underlying group, is known, this can be specified by `degree_bound = l`. The default value is `degree_bound = 1`.
+In some situations the runtime of the algorithm might be improved by assigning `ensure_minimality` a positive integer. This leads to an early cancellation of loops in the algorithm and the described minimality of the degrees is not guaranteed anymore. The default value is `ensure_minimality = 0` corresponding to no cancellation.
+
+# Examples
+```jldoctest
+julia> K, a = CyclotomicField(3, "a");
+
+julia> M1 = matrix(K, [0 0 1; 1 0 0; 0 1 0]);
+
+julia> M2 = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1]);
+
+julia> G = MatrixGroup(3, K, [M1, M2]);
+
+julia> IR = invariant_ring(G);
+
+julia> primary_invariants_via_optimal_hsop(IR)
+3-element Vector{MPolyElem_dec{nf_elem, AbstractAlgebra.Generic.MPoly{nf_elem}}}:
+ x[1]*x[2]*x[3]
+ x[1]^3 + x[2]^3 + x[3]^3
+ x[1]^3*x[2]^3 + x[1]^3*x[3]^3 + x[2]^3*x[3]^3
+
+julia> primary_invariants_via_optimal_hsop(IR, primary_degrees = [ 3, 6, 6 ])
+3-element Vector{MPolyElem_dec{nf_elem, AbstractAlgebra.Generic.MPoly{nf_elem}}}:
+ x[1]*x[2]*x[3]
+ x[1]^3*x[2]^3 + x[1]^3*x[3]^3 + x[2]^3*x[3]^3
+ x[1]^6 + x[2]^6 + x[3]^6
+
+```
+"""
+function primary_invariants_via_optimal_hsop(RG::InvRing; ensure_minimality::Int = 0, degree_bound::Int = 1, primary_degrees::Vector{Int} = Int[])
   iters = Dict{Int, VectorSpaceIterator}()
   ideals = Dict{Set{elem_type(polynomial_ring(RG))}, Int}()
+
+  if !isempty(primary_degrees)
+    @assert length(primary_degrees) == degree(group(RG))
+    invars = elem_type(polynomial_ring(RG))[]
+    b, k = primary_invariants_via_optimal_hsop!(RG, primary_degrees, invars, iters, ideals, ensure_minimality, 0)
+    if !b
+      error("No primary invariants of the given degrees exist")
+    end
+    return invars
+  end
+
   bad_prefixes = Vector{Vector{Int}}()
-  l = 1
+  l = degree_bound
   while true
     degrees = candidates_primary_degrees(RG, l, bad_prefixes)
     for ds in degrees
@@ -197,4 +257,92 @@ function primary_invariants_via_optimal_hsop!(RG::InvRing{FldT, GrpT, PolyElemT}
     return true, k
   end
   return false, k
+end
+
+@doc Markdown.doc"""
+    primary_invariants_via_radical_containment(IR::InvRing)
+
+Return a system of primary invariants for `IR` using the algorithm in Stu93.
+
+# Examples
+```jldoctest
+julia> K, a = CyclotomicField(3, "a");
+
+julia> M1 = matrix(K, [0 0 1; 1 0 0; 0 1 0]);
+
+julia> M2 = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1]);
+
+julia> G = MatrixGroup(3, K, [M1, M2]);
+
+julia> IR = invariant_ring(G);
+
+julia> primary_invariants_via_radical_containment(IR)
+3-element Vector{MPolyElem_dec{nf_elem, AbstractAlgebra.Generic.MPoly{nf_elem}}}:
+ x[1]*x[2]*x[3]
+ x[1]^3 + x[2]^3 + x[3]^3
+ x[1]^3*x[2]^3 + x[1]^3*x[3]^3 + x[2]^3*x[3]^3
+```
+"""
+function primary_invariants_via_radical_containment(IR::InvRing)
+  IR.primary_singular = Singular.LibFinvar.primary_invariants(_action_singular(IR)...)
+  if ismodular(IR)
+    P = IR.primary_singular
+  else
+    P = IR.primary_singular[1]
+  end
+  R = polynomial_ring(IR)
+  p = Vector{elem_type(R)}()
+  for i = 1:ncols(P)
+    push!(p, R(P[1, i]))
+  end
+  IR.primary = p
+  return IR.primary
+end
+
+@doc Markdown.doc"""
+    primary_invariants(IR::InvRing, algo::Symbol = :optimal_hsop)
+
+Return a system of primary invariants for `IR`.
+
+If a system of primary invariants for `IR` is already cached, return the cached system.
+Otherwise, compute and cache such a system first.
+
+The used algorithm can be specified with the optional argument `algo`. Possible values
+are `:optimal_hsop` which uses the algorithm in Kem99 or `:radical_containment` which uses the algorithm from Stu93.
+The default option is `:optimal_hsop` which is in general expected to be the faster algorithm.
+
+NOTE: The primary invariants are sorted by increasing degree.
+
+See also `primary_invariants_via_optimal_hsop` and `primary_invariants_via_radical_containment` for more options.
+
+# Examples
+```jldoctest
+julia> K, a = CyclotomicField(3, "a");
+
+julia> M1 = matrix(K, [0 0 1; 1 0 0; 0 1 0]);
+
+julia> M2 = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1]);
+
+julia> G = MatrixGroup(3, K, [M1, M2]);
+
+julia> IR = invariant_ring(G);
+
+julia> primary_invariants(IR)
+3-element Vector{MPolyElem_dec{nf_elem, AbstractAlgebra.Generic.MPoly{nf_elem}}}:
+ x[1]*x[2]*x[3]
+ x[1]^3 + x[2]^3 + x[3]^3
+ x[1]^3*x[2]^3 + x[1]^3*x[3]^3 + x[2]^3*x[3]^3
+```
+"""
+function primary_invariants(IR::InvRing, algo::Symbol = :optimal_hsop)
+  if !isdefined(IR, :primary)
+    if algo == :optimal_hsop
+      IR.primary = primary_invariants_via_optimal_hsop(IR)
+    elseif algo == :radical_containment
+      IR.primary = primary_invariants_via_radical_containment(IR)
+    else
+      error("Unsupported argument :$(algo) for algo.")
+    end
+  end
+  return copy(IR.primary)
 end

--- a/test/InvariantTheory/invariant_rings-test.jl
+++ b/test/InvariantTheory/invariant_rings-test.jl
@@ -2,77 +2,99 @@
   K, a = CyclotomicField(3, "a")
   M1 = matrix(K, 3, 3, [ 0, 1, 0, 1, 0, 0, 0, 0, 1 ])
   M2 = matrix(K, 3, 3, [ 1, 0, 0, 0, a, 0, 0, 0, -a - 1 ])
+  RG0 = invariant_ring(M1, M2)
 
-  RG = invariant_ring(M1, M2)
-  @test coefficient_ring(RG) == K
-  @test !ismodular(RG)
+  # Explicitely call the other constructors
+  invariant_ring([ M1, M2 ])
+  invariant_ring(K, [ M1, M2 ])
+  invariant_ring(matrix_group([ M1, M2 ]))
 
-  R = Oscar.polynomial_ring(RG)
-  @test Oscar.reynolds_operator(RG, gens(R)[3]^3) == gens(R)[3]^3
-  @test Oscar.reynolds_operator(RG, gens(R)[1]) == zero(R)
-  mol = Oscar.molien_series(RG)
+  F = GF(3)
+  N1 = matrix(F, 3, 3, [ 0, 1, 0, 2, 0, 0, 0, 0, 2 ])
+  N2 = matrix(F, 3, 3, [ 2, 0, 0, 0, 2, 0, 0, 0, 2 ])
+  RGp = invariant_ring(N1, N2) # char p, non-modular
+
+  N3 = matrix(F, 2, 2, [ 1, 1, 0, 1 ])
+  RGm = invariant_ring(N3) # charp, modular
+
+  @test coefficient_ring(RG0) == K
+  @test coefficient_ring(RGp) == F
+  @test coefficient_ring(RGm) == F
+
+  @test !ismodular(RG0)
+  @test !ismodular(RGp)
+  @test ismodular(RGm)
+
+  R0 = polynomial_ring(RG0)
+  Rp = polynomial_ring(RGp)
+  Rm = polynomial_ring(RGm)
+
+  @test reynolds_operator(RG0, gens(R0)[3]^3) == gens(R0)[3]^3
+  @test reynolds_operator(RG0, gens(R0)[1]) == zero(R0)
+
+  @test reynolds_operator(RGp, gens(Rp)[3]^2) == gens(Rp)[3]^2
+  @test reynolds_operator(RGp, gens(Rp)[1]) == zero(Rp)
+
+  @test_throws AssertionError reynolds_operator(RGm, gens(Rm)[1])
+
+  @test length(basis(RG0, 1)) == 0
+  @test length(basis(RG0, 1, :reynolds)) == 0
+  @test length(basis(RG0, 1, :linear_algebra)) == 0
+  @test length(basis(RG0, 3)) == 3
+  @test length(basis(RG0, 3, :reynolds)) == 3
+  @test length(basis(RG0, 3, :linear_algebra)) == 3
+
+  @test length(basis(RGp, 1)) == 0
+  @test length(basis(RGp, 1, :reynolds)) == 0
+  @test length(basis(RGp, 1, :linear_algebra)) == 0
+  @test length(basis(RGp, 2)) == 2
+  @test length(basis(RGp, 2, :reynolds)) == 2
+  @test length(basis(RGp, 2, :linear_algebra)) == 2
+
+  @test length(basis(RGm, 1)) == 1
+  @test length(basis(RGm, 1, :linear_algebra)) == 1
+  @test_throws AssertionError basis(RGm, 1, :reynolds)
+
+  secondaries = secondary_invariants(RG0)
+  for f in secondaries
+    @test reynolds_operator(RG0, f) == f
+  end
+  irrs = irreducible_secondary_invariants(RG0)
+  for f in irrs
+    @test reynolds_operator(RG0, f) == f
+  end
+
+  secondaries = secondary_invariants(RGp)
+  for f in secondaries
+    @test reynolds_operator(RGp, f) == f
+  end
+  irrs = irreducible_secondary_invariants(RGp)
+  for f in irrs
+    @test reynolds_operator(RGp, f) == f
+  end
+
+  mol = molien_series(RG0)
   F = parent(mol)
   t = gens(base_ring(F))[1]
   @test mol == (-t^6 - t^3 - 1)//(t^12 - 2t^9 + 2t^3 - 1)
 
-  @test length(basis(RG, 1)) == 0
-  @test length(basis(RG, 1, :reynolds)) == 0
-  @test length(basis(RG, 1, :linear_algebra)) == 0
-  @test length(basis(RG, 3)) == 3
-  @test length(basis(RG, 3, :reynolds)) == 3
-  @test length(basis(RG, 3, :linear_algebra)) == 3
-
-  primaries = primary_invariants(RG)
-  @test dim(ideal(R, primaries)) == 0
-  for f in primaries
-    @test Oscar.reynolds_operator(RG, f) == f
-  end
-
-  secondaries = secondary_invariants(RG)
-  for f in secondaries
-    @test Oscar.reynolds_operator(RG, f) == f
-  end
-  irrs = Oscar.irreducible_secondary_invariants(RG)
-  for f in irrs
-    @test Oscar.reynolds_operator(RG, f) == f
-  end
-
-  K = GF(3)
-  M1 = matrix(K, 3, 3, [ 0, 1, 0, 2, 0, 0, 0, 0, 2 ])
-  M2 = matrix(K, 3, 3, [ 2, 0, 0, 0, 2, 0, 0, 0, 2 ])
-
-  RG = invariant_ring(M1, M2)
-  @test coefficient_ring(RG) == K
-  @test !ismodular(RG)
-
-  R = Oscar.polynomial_ring(RG)
-  @test Oscar.reynolds_operator(RG, gens(R)[3]^2) == gens(R)[3]^2
-  @test Oscar.reynolds_operator(RG, gens(R)[1]) == zero(R)
-  mol = Oscar.molien_series(RG)
+  mol = molien_series(RGp)
   F = parent(mol)
   t = gens(base_ring(F))[1]
   @test mol == (-t^4 - 1)//(t^8 - 2t^6 + 2t^2 - 1)
 
-  @test length(basis(RG, 1)) == 0
-  @test length(basis(RG, 1, :reynolds)) == 0
-  @test length(basis(RG, 1, :linear_algebra)) == 0
-  @test length(basis(RG, 2)) == 2
-  @test length(basis(RG, 2, :reynolds)) == 2
-  @test length(basis(RG, 2, :linear_algebra)) == 2
-
-  primaries = primary_invariants(RG)
-  @test dim(ideal(R, primaries)) == 0
-  for f in primaries
-    @test Oscar.reynolds_operator(RG, f) == f
+  fund_invars = fundamental_invariants(RG0)
+  for f in fund_invars
+    @test reynolds_operator(RG0, f) == f
+  end
+  fund_invars2 = Oscar.fundamental_invariants_via_minimal_subalgebra(RG0)
+  for f in fund_invars2
+    @test reynolds_operator(RG0, f) == f
   end
 
-  secondaries = secondary_invariants(RG)
-  for f in secondaries
-    @test Oscar.reynolds_operator(RG, f) == f
-  end
-  irrs = Oscar.irreducible_secondary_invariants(RG)
-  for f in irrs
-    @test Oscar.reynolds_operator(RG, f) == f
+  fund_invars = fundamental_invariants(RGp)
+  for f in fund_invars
+    @test reynolds_operator(RGp, f) == f
   end
 
   # S4

--- a/test/InvariantTheory/invariant_rings-test.jl
+++ b/test/InvariantTheory/invariant_rings-test.jl
@@ -110,7 +110,6 @@
   S, t = QQ["t"]
   m = @inferred molien_series(S, I)
   @test m == 1//((1 - t^2)*(1 - t^3)*(1 - t^4)*(1 - t^5))
-  @test m == Oscar._molien_series_via_singular(S, I)
 
   gl = general_linear_group(4, 5)
   gapmats = [GAP.Globals.PermutationMat(elm.X, 4, GAP.Globals.GF(5))
@@ -124,5 +123,4 @@
   I = invariant_ring(-identity_matrix(F, 2))
   m = @inferred molien_series(S, I)
   @test m == (t^2 + 1)//(t^4 - 2*t^2 + 1)
-  @test m == Oscar._molien_series_via_singular(S, I)
 end

--- a/test/InvariantTheory/primary_invariants-test.jl
+++ b/test/InvariantTheory/primary_invariants-test.jl
@@ -1,9 +1,41 @@
 @testset "Primary invariants" begin
+  K, a = CyclotomicField(3, "a")
+  M1 = matrix(K, 3, 3, [ 0, 1, 0, 1, 0, 0, 0, 0, 1 ])
+  M2 = matrix(K, 3, 3, [ 1, 0, 0, 0, a, 0, 0, 0, -a - 1 ])
+  RG0 = invariant_ring(M1, M2)
+
+  F = GF(3)
+  N1 = matrix(F, 3, 3, [ 0, 1, 0, 2, 0, 0, 0, 0, 2 ])
+  N2 = matrix(F, 3, 3, [ 2, 0, 0, 0, 2, 0, 0, 0, 2 ])
+  RGp = invariant_ring(N1, N2) # char p, non-modular
+
+  N3 = matrix(F, 2, 2, [ 1, 1, 0, 1 ])
+  RGm = invariant_ring(N3) # char p, modular
+
+  for RG in [ RG0, RGp ]
+    for algo in [ :optimal_hsop, :radical_containment ]
+      invars = primary_invariants(RG, algo)
+      @test dim(ideal(polynomial_ring(RG), invars)) == 0
+      for f in invars
+        @test reynolds_operator(RG, f) == f
+      end
+    end
+  end
+
+  for algo in [ :optimal_hsop, :radical_containment ]
+    invars = primary_invariants(RGm, algo)
+    @test dim(ideal(polynomial_ring(RGm), invars)) == 0
+    actionN3 = Oscar.right_action(polynomial_ring(RGm), N3)
+    for f in invars
+      @test actionN3(f) == f
+    end
+  end
+
   # Kem99, Example 1
   K, a = CyclotomicField(9, "a")
   M = matrix(K, 2, 2, [ a, 0, 0, -a^3 ])
   RG = invariant_ring(M)
-  invars = Oscar.primary_invariants_via_optimal_hsop(RG)
+  invars = primary_invariants_via_optimal_hsop(RG)
   @test length(invars) == 2
   @test sort([ total_degree(f.f) for f in invars ]) == [ 6, 9 ]
   @test dim(ideal(polynomial_ring(RG), invars)) == 0
@@ -12,7 +44,7 @@
   K, a = CyclotomicField(9, "a")
   M = matrix(K, 3, 3, [ a, 0, 0, 0, a^2, 0, 0, 0, a^6 ])
   RG = invariant_ring(M)
-  invars = Oscar.primary_invariants_via_optimal_hsop(RG)
+  invars = primary_invariants_via_optimal_hsop(RG)
   @test length(invars) == 3
   @test sort([ total_degree(f.f) for f in invars ]) == [ 3, 5, 9 ]
   @test dim(ideal(polynomial_ring(RG), invars)) == 0
@@ -21,7 +53,7 @@
   M1 = diagonal_matrix([ matrix(QQ, 3, 3, [ 0, 1, 0, 1, 0, 0, 0, 0, 1 ]) for i = 1:3 ])
   M2 = diagonal_matrix([ matrix(QQ, 3, 3, [ 0, 1, 0, 0, 0, 1, 1, 0, 0 ]) for i = 1:3 ])
   RG = invariant_ring(M1, M2)
-  invars = Oscar.primary_invariants_via_optimal_hsop(RG)
+  invars = primary_invariants_via_optimal_hsop(RG)
   @test length(invars) == 9
   @test sort([ total_degree(f.f) for f in invars ]) == [ 1, 1, 1, 2, 2, 2, 3, 3, 3 ]
   @test dim(ideal(polynomial_ring(RG), invars)) == 0

--- a/test/InvariantTheory/primary_invariants-test.jl
+++ b/test/InvariantTheory/primary_invariants-test.jl
@@ -13,7 +13,7 @@
   RGm = invariant_ring(N3) # char p, modular
 
   for RG in [ RG0, RGp ]
-    for algo in [ :optimal_hsop, :radical_containment ]
+    for algo in [ :optimal_hsop, :successive_algo ]
       invars = primary_invariants(RG, algo)
       @test dim(ideal(polynomial_ring(RG), invars)) == 0
       for f in invars
@@ -22,7 +22,7 @@
     end
   end
 
-  for algo in [ :optimal_hsop, :radical_containment ]
+  for algo in [ :optimal_hsop, :successive_algo ]
     invars = primary_invariants(RGm, algo)
     @test dim(ideal(polynomial_ring(RGm), invars)) == 0
     actionN3 = Oscar.right_action(polynomial_ring(RGm), N3)


### PR DESCRIPTION
I restructured the invariant theory code a little and wrote some more tests and documentation.
In the second commit I removed a few functions which called Singular because we by now have functions providing the same functionality directly in Oscar/Julia, which are faster and/or apply to more general situations. I don't know what our policy is regarding this; if you want to keep these functions I can remove the commit. The only exception is the function for primary invariants because Singular has a different algorithm implemented.