### PR TITLE
Tag 0.7.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oscar"
 uuid = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
 authors = ["Claus Fieker <fieker@mathematik.uni-kl.de>", "Giovanni De Franceschi <franceschi@mathematik.uni-kl.de>", "Johannes Schmitt <schmitt@mathematik.uni-kl.de>", "Max Horn <horn@mathematik.uni-kl.de>", "William Hart <goodwillhart@googlemail.com>", "Taylor Brysiewicz <taylor.brysiewicz@mis.mpg.de>", "Michael Joswig <joswig@math.tu-berlin.de>", "Marek Kaluba <kalmar@amu.edu.pl>", "Sascha Timme <sascha.timme@googlemail.com>", "Sebastian Gutsche <gutsche@momo.math.rwth-aachen.de>"]
-version = "0.7.1-DEV"
+version = "0.7.1"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ julia> using Oscar
  -----    -----    -----   -     -  -     -
 
 ...combining (and extending) ANTIC, GAP, Polymake and Singular
-Version 0.7.1-DEV ...
+Version 0.7.1 ...
 ... which comes with absolutely no warranty whatsoever
 Type: '?Oscar' for more information
 (c) 2019-2021 by The Oscar Development Team


### PR DESCRIPTION
The doctests are failing on 0.7.0, which is a bit annoying when we test Oscar upstream (with the changes introduced in https://github.com/oscar-system/OscarDevTools.jl/pull/18). Since the doctest is fixed on master, I propose we make a quick 0.7.1 tag.