### PR TITLE
CI: run automatically only for master and PRs, add workflow_dispatch for manual CI runs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,11 @@
 name: Run tests
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
   # group by workflow and ref; the last slightly strange component ensures that for pull


### PR DESCRIPTION
We still get quite some backlog, so I think it would be better to run the tests only for master + PRs and not for the branches. This should free up some of the runners, especially for macos.
Anyone who needs to run the tests on his branch can either create a Draft PR or run them manually with the [workflow_dispatch](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).

cc: @thofma @fingolfin 

PS: This PR should only trigger the tests once instead of twice.