### PR TITLE
construct subgroups compatible with the given group

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -478,7 +478,8 @@ Return the vector of all conjugacy classes of subgroups of G.
 """
 function conjugacy_classes_subgroups(G::GAPGroup)
    L=Vector{GapObj}(GAP.Globals.ConjugacyClassesSubgroups(G.X))
-   return GroupConjClass{typeof(G), typeof(G)}[ _conjugacy_class(G,typeof(G)(GAP.Globals.Representative(cc)),cc) for cc in L]
+   return GroupConjClass{typeof(G), typeof(G)}[_conjugacy_class(G, _as_subgroup_bare(G, GAP.Globals.Representative(cc)),cc) for cc in L]
+
 end
 
 """
@@ -488,7 +489,7 @@ Return the vector of all conjugacy classes of maximal subgroups of G.
 """
 function conjugacy_classes_maximal_subgroups(G::GAPGroup)
   L = Vector{GapObj}(GAP.Globals.ConjugacyClassesMaximalSubgroups(G.X))
-   return GroupConjClass{typeof(G), typeof(G)}[ _conjugacy_class(G,typeof(G)(GAP.Globals.Representative(cc)),cc) for cc in L]
+   return GroupConjClass{typeof(G), typeof(G)}[_conjugacy_class(G, _as_subgroup_bare(G, GAP.Globals.Representative(cc)),cc) for cc in L]
 end
 
 Base.:^(H::GAPGroup, y::GAPGroupElem) = typeof(H)(H.X ^ y.X)

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -141,6 +141,12 @@ Every group of this type is the subgroup of Sym(n) for some n.
    function PermGroup(G::GapObj)
      @assert GAPWrap.IsPermGroup(G)
      n = GAPWrap.LargestMovedPoint(G)::Int
+     if n == 0
+       # We support only positive degrees.
+       # (`symmetric_group(0)` yields an error,
+       # and `symmetric_group(1)` yields a GAP group with `n == 0`.)
+       n = 1
+     end
      z = new(G, n)
      return z
    end

--- a/test/Groups/conjugation.jl
+++ b/test/Groups/conjugation.jl
@@ -64,9 +64,10 @@
 
   CC = conjugacy_classes_subgroups(G)
   @test length(CC)==11
-  @testset for i in 1:length(CC)
-     @test CC[i] == conjugacy_class(G,representative(CC[i]))
-     @test length(CC[i]) == index(G, normalizer(G,representative(CC[i]))[1])
+  @testset for C in CC
+     @test C == conjugacy_class(G, representative(C))
+     @test length(C) == index(G, normalizer(G, representative(C))[1])
+     @test degree(representative(C)) == degree(G)
   end
   H=rand(subgroups(G))
   @test sum([length(c) for c in CC]) == length(subgroups(G))
@@ -91,6 +92,10 @@
   x = G(cperm([1,2,3,4]))
   H = sub(G,[x])[1]
   @test normalizer(G,H)==normalizer(G,x)
+
+  G = symmetric_group(5)
+  CC = conjugacy_classes_maximal_subgroups(G)
+  all(H -> degree(H) == degree(G), map(representative, CC))
 
   G = symmetric_group(10)
   x = rand(G)


### PR DESCRIPTION
(This addresses one item from #894.)

Calls of the form `T(gapobj)`, for a type `T`, are not suitable when the result shall be compatible with a given group.
In order to set the correct degree (in case of a permutation group) or the correct base ring information (in case of a matrix group), one can call `_as_subgroup_bare`.