### PR TITLE
Bib: add some missing DOIs, minor tweaks

### DIFF
--- a/.bibtoolrsc
+++ b/.bibtoolrsc
@@ -16,10 +16,8 @@ delete.field = { isbn }
 delete.field = { issn }
 delete.field = { keywords }
 delete.field = { mrclass }
-delete.field = { mrnumber }
 delete.field = { mrreviewer }
 delete.field = { msc2010 }
-delete.field = { zbl }
 
 fmt.name.name = { }
 fmt.inter.name = { x }

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -4,7 +4,7 @@
   author        = {Adams, William W. and Loustaunau, Philippe},
   series        = {Graduate studies in mathematics},
   doi           = {10.1090/gsm/003},
-  url           = {http://dx.doi.org/10.1090/gsm/003},
+  url           = {https://doi.org/10.1090/gsm/003},
   year          = {1994},
   publisher     = {American Mathematical Society}
 }
@@ -32,7 +32,9 @@
                   and number theory},
   pages         = {51--96},
   publisher     = {Springer, Cham},
-  year          = {2017}
+  year          = {2017},
+  doi           = {10.1007/978-3-319-70566-8_3},
+  url           = {https://doi.org/10.1007/978-3-319-70566-8_3}
 }
 
 @InProceedings{BDLP19,
@@ -66,7 +68,8 @@
 
 @Article{BKR20,
   author        = {Böhm, Janko and Keicher, Simon and Ren, Yue},
-  title         = {Computing {GIT}-fans with symmetry and the {M}ori chamber decomposition of {$\overline{M}_{0,6}$}},
+  title         = {Computing {GIT}-fans with symmetry and the Mori chamber
+                  decomposition of $\overline{M}_{0,6}$},
   journal       = {Math. Comp.},
   fjournal      = {Mathematics of Computation},
   volume        = {89},
@@ -90,10 +93,12 @@
   title         = {Toric varieties},
   series        = {Graduate Studies in Mathematics},
   volume        = {124},
-  pages         = {xxiv + 841},
+  pages         = {xxiv+841},
   year          = {2011},
   publisher     = {Providence, RI: American Mathematical Society (AMS)},
-  url           = {https://bookstore.ams.org/gsm-124}
+  mrnumber      = {2810322},
+  doi           = {10.1090/gsm/124},
+  url           = {https://doi.org/10.1090/gsm/124}
 }
 
 @Book{Cam99,
@@ -112,7 +117,7 @@
   author        = {Christophersen, Jan Arthur},
   title         = {On the components and discriminant of the versal base
                   space of cyclic quotient singularities},
-  booktitle     = {Singularity theory and its applications, {P}art {I}
+  booktitle     = {Singularity theory and its applications, Part {I}
                   ({C}oventry, 1988/1989)},
   series        = {Lecture Notes in Math.},
   volume        = {1462},
@@ -193,7 +198,10 @@
   volume        = {251},
   pages         = {61--89},
   publisher     = {Cambridge Univ. Press, Cambridge},
-  year          = {1998}
+  year          = {1998},
+  doi           = {10.1017/CBO9780511565847.005},
+  url           = {https://doi.org/10.1017/CBO9780511565847.005},
+  mrnumber      = {1699814}
 }
 
 @Book{DK15,
@@ -221,21 +229,25 @@
   publisher     = {Springer-Verlag, Berlin; Hindustan Book Agency, New
                   Delhi},
   year          = {2006},
-  pages         = {xvi+327}
+  pages         = {xvi+327},
+  doi           = {10.1007/3-540-28993-3},
+  url           = {https://doi.org/10.1007/3-540-28993-3}
 }
 
 @Book{DLRS10,
   author        = {De Loera, Jesús A. and Rambau, Jörg and Santos,
                   Francisco},
-  title         = {Triangulations},
+  title         = {Triangulations. Structures for algorithms and
+                  applications},
   series        = {Algorithms and Computation in Mathematics},
   volume        = {25},
-  note          = {Structures for algorithms and applications},
   publisher     = {Springer-Verlag},
   address       = {Berlin},
   year          = {2010},
   bibkey        = {DLRS10},
-  pages         = {xiv+535}
+  pages         = {xiv+535},
+  doi           = {10.1007/978-3-642-12971-1},
+  zbl           = {1207.52002}
 }
 
 @Book{DP13,
@@ -333,8 +345,7 @@
 
 @Book{Ful69,
   author        = {Fulton, William},
-  title         = {Algebraic curves. {A}n introduction to algebraic
-                  geometry},
+  title         = {Algebraic curves. An introduction to algebraic geometry},
   series        = {Mathematics Lecture Note Series},
   note          = {Notes written with the collaboration of Richard Weiss},
   publisher     = {W. A. Benjamin, Inc., New York-Amsterdam},
@@ -343,18 +354,15 @@
 }
 
 @InProceedings{GHJ16,
-  author        = "Gawrilow, Ewgenij and Hampe, Simon and Joswig, Michael",
-  editor        = "Greuel, Gert-Martin and Koch, Thorsten and Paule, Peter
-                  and Sommese, Andrew",
-  title         = "The polymake XML File Format",
-  booktitle     = "Mathematical Software -- ICMS 2016",
-  year          = "2016",
-  publisher     = "Springer International Publishing",
-  address       = "Cham",
-  pages         = "403--410",
-  abstract      = "We describe an XML file format for storing data from
-                  computations in algebra and geometry. We also present a
-                  formal specification based on a RELAX-NG schema."
+  author        = {Gawrilow, Ewgenij and Hampe, Simon and Joswig, Michael},
+  editor        = {Greuel, Gert-Martin and Koch, Thorsten and Paule, Peter
+                  and Sommese, Andrew},
+  title         = {The polymake XML File Format},
+  booktitle     = {Mathematical Software -- ICMS 2016},
+  year          = {2016},
+  publisher     = {Springer International Publishing},
+  address       = {Cham},
+  pages         = {403--410}
 }
 
 @InCollection{GJ00,
@@ -375,7 +383,9 @@
   series        = {Springer Monographs in Mathematics},
   publisher     = {Springer-Verlag, Berlin},
   year          = {2007},
-  pages         = {xii+471}
+  pages         = {xii+471},
+  doi           = {10.1007/3-540-28419-2},
+  mrnumber      = {2290112}
 }
 
 @Article{GLS10,
@@ -401,7 +411,8 @@
   publisher     = {Springer, Berlin},
   year          = {2008},
   pages         = {xx+689},
-  url           = {http://link.springer.com/book/10.1007%2F978-3-540-73542-7}
+  doi           = {10.1007/978-3-540-73542-7},
+  url           = {https://doi.org/10.1007/978-3-540-73542-7}
 }
 
 @InCollection{GTZ88,
@@ -443,17 +454,21 @@
   series        = {Graduate Texts in Mathematics},
   publisher     = {Springer-Verlag, New York},
   year          = {1977},
-  pages         = {xvi+496}
+  pages         = {xvi+496},
+  doi           = {10.1007/978-1-4757-3849-0},
+  url           = {https://doi.org/10.1007/978-1-4757-3849-0}
 }
 
 @Book{Hup67,
   author        = {Huppert, B.},
   title         = {Endliche Gruppen. I},
-  series        = {Die Grundlehren der mathematischen Wissenschaften, Band
-                  134},
+  series        = {Die Grundlehren der mathematischen Wissenschaften},
+  volume        = {134},
   publisher     = {Springer-Verlag, Berlin-New York},
   year          = {1967},
-  pages         = {xii+793}
+  pages         = {xii+793},
+  doi           = {10.1007/978-3-642-64981-3},
+  url           = {https://doi.org/10.1007/978-3-642-64981-3}
 }
 
 @Book{JP00,
@@ -462,7 +477,9 @@
   series        = {Advanced Lectures in Mathematics},
   publisher     = {Vieweg+Teubner Verlag},
   year          = {2000},
-  pages         = {xi+384}
+  pages         = {xi+384},
+  doi           = {10.1007/978-3-322-90159-0},
+  url           = {https://doi.org/10.1007/978-3-322-90159-0}
 }
 
 @Book{JT13,
@@ -490,7 +507,7 @@
   pages         = {195--205},
   publisher     = {Springer, Berlin},
   year          = {1991},
-  doi           = {10.1007/3-540-54522-0\_108},
+  doi           = {10.1007/3-540-54522-0_108},
   url           = {https://doi.org/10.1007/3-540-54522-0_108}
 }
 
@@ -504,6 +521,7 @@
   publisher     = {Springer International Publishing},
   address       = {Cham},
   pages         = {377--385},
+  doi           = {10.1007/978-3-030-52200-1_37},
   url           = {https://doi.org/10.1007/978-3-030-52200-1_37}
 }
 
@@ -515,7 +533,7 @@
   series        = {Progr. Math.},
   volume        = {173},
   pages         = {267--285},
-  publisher     = {Birkh\"{a}user, Basel},
+  publisher     = {Birkhäuser, Basel},
   year          = {1999}
 }
 
@@ -684,7 +702,8 @@
   journal       = {The Cayley Bulletin},
   volume        = {3},
   year          = {1987},
-  pages         = {76--85}
+  pages         = {76--85},
+  url           = {https://www.maths.usyd.edu.au/u/don/papers/genAC.pdf}
 }
 
 @Book{Was08,

--- a/src/Groups/matrices/linear_centralizer.jl
+++ b/src/Groups/matrices/linear_centralizer.jl
@@ -35,8 +35,7 @@ _SL_order(n::Int, F::Ring) = _SL_order(n, order(F))
 ########################################################################
 
 # Compute a generating set for GL(n,q) and SL(n,q)
-# generators for GL(n,q) and SL(n,q) are described in: 
-# Taylor, D. E., Pairs of Generators for Matrix Groups. I, The Cayley Bulletin, 3 (1987)
+# generators for GL(n,q) and SL(n,q) are described in [Tay87]
 
 # returns elements of type MatElem{T}
 # returns a generating set for GL(n,F) of at most two elements
@@ -291,8 +290,7 @@ end
 #
 ########################################################################
 
-# generators for GL(n,q) and SL(n,q) are described in:
-# Taylor, D. E., Pairs of Generators for Matrix Groups. I, The Cayley Bulletin, 3 (1987)
+# generators for GL(n,q) and SL(n,q) are described in [Tay87]
 
 # returns elements of type MatElem{T}
 # returns a generating set for SL(n,F) of at most two elements


### PR DESCRIPTION
- add a bunch of missing DOIs
- instruct bibtool to retain MathSciNet / Zentralblatt refs
- fix a few DOIs and URLs by not "quoting" `_` to `\_`
- some other minor cleanup
