### PR TITLE
fix a bug in creating perm. group elements

### DIFF
--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -156,7 +156,7 @@ perm(g::PermGroup, L::AbstractVector{<:fmpz}) = perm(g, [Int(y) for y in L])
 
 function (g::PermGroup)(L::AbstractVector{<:IntegerUnion})
    x = GAP.Globals.PermList(GAP.GapObj(L;recursive=true))
-   if length(L) <= degree(g) && GAPWrap.IN(x,g.X)
+   if GAP.Globals.LargestMovedPoint(x) <= degree(g) && GAPWrap.IN(x, g.X)
      return PermGroupElem(g, x)
    end
    throw(ArgumentError("the element does not embed in the group"))


### PR DESCRIPTION
The length of the list of images is irrelevant for the moved points of the result.
(This provides a workaround for the second problem mentioned in issue #894.
It does not fix the underlying conceptual problem.)