### PR TITLE
fix conjugation of perm. groups by permutations

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -498,6 +498,18 @@ function conjugate_subgroup(G::T, x::GAPGroupElem) where T<:GAPGroup
   return T(GAP.Globals.ConjugateSubgroup(G.X,x.X))
 end
 
+# We want to preserve the degree of the permutation action.
+# (Analogous methods are needed for other group types.
+# The above generic methods are not correct,
+# but for the moment we have no better solution.)
+Base.:^(G::PermGroup, x::PermGroupElem) = conjugate_subgroup(G, x)
+
+function conjugate_subgroup(G::PermGroup, x::PermGroupElem)
+  P = parent(x)
+  H = degree(P) <= degree(G) ? G : P
+  return _as_subgroup_bare(P, GAP.Globals.ConjugateSubgroup(G.X,x.X))
+end
+
 """
     isconjugate(G::GAPGroup, H::GAPGroup, K::GAPGroup)
 


### PR DESCRIPTION
This fixes the second problem mentioned in issue #894,
that is, conjugating a group by an element preserves the degree.

(The fix works only for permutation groups,
I do not see how to formulate a generic method.
Eventually we have to define what compatibility means
for several groups and group elements,
perhaps via a function `iscompatible` that returns a group
w.r.t. which one can then use as the first argument of `_as_subgroup_bare`?)