### PR TITLE
Improve type stability

### DIFF
--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -93,8 +93,7 @@ julia> nfacets(C)
 4
 ```
 """
-nfacets(C::Cone) = pm_object(C).N_FACETS
-
+nfacets(C::Cone) = pm_object(C).N_FACETS::Int
 
 @doc Markdown.doc"""
     nrays(C::Cone)
@@ -112,7 +111,7 @@ julia> nrays(PO)
 2
 ```
 """
-nrays(C::Cone) = pm_object(C).N_RAYS
+nrays(C::Cone) = pm_object(C).N_RAYS::Int
 
 @doc Markdown.doc"""
     dim(C::Cone)
@@ -128,7 +127,7 @@ julia> dim(C)
 2
 ```
 """
-dim(C::Cone) = pm_object(C).CONE_DIM
+dim(C::Cone) = pm_object(C).CONE_DIM::Int
 
 @doc Markdown.doc"""
     ambient_dim(C::Cone)
@@ -144,7 +143,7 @@ julia> ambient_dim(C)
 3
 ```
 """
-ambient_dim(C::Cone) = pm_object(C).CONE_AMBIENT_DIM
+ambient_dim(C::Cone) = pm_object(C).CONE_AMBIENT_DIM::Int
 
 @doc Markdown.doc"""
     codim(C::Cone)
@@ -224,7 +223,7 @@ julia> lineality_dim(C1)
 1
 ```
 """
-lineality_dim(C::Cone) = pm_object(C).LINEALITY_DIM
+lineality_dim(C::Cone) = pm_object(C).LINEALITY_DIM::Int
 
 
 
@@ -250,7 +249,7 @@ julia> ispointed(C)
 true
 ```
 """
-ispointed(C::Cone) = pm_object(C).POINTED
+ispointed(C::Cone) = pm_object(C).POINTED::Bool
 
 @doc Markdown.doc"""
     isfulldimensional(C::Cone)
@@ -266,7 +265,7 @@ julia> isfulldimensional(C)
 false
 ```
 """
-isfulldimensional(C::Cone) = pm_object(C).FULL_DIM
+isfulldimensional(C::Cone) = pm_object(C).FULL_DIM::Bool
 
 ###############################################################################
 ## Points properties

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -174,7 +174,7 @@ julia> nvertices(C)
 8
 ```
 """
-nvertices(P::Polyhedron) = pm_object(P).N_VERTICES - nrays(P)
+nvertices(P::Polyhedron) = pm_object(P).N_VERTICES::Int - nrays(P)
 
 
 @doc Markdown.doc"""
@@ -241,7 +241,10 @@ julia> nfacets(cross(5))
 32
 ```
 """
-nfacets(P::Polyhedron) = pm_object(P).N_FACETS - (_facet_at_infinity(pm_object(P)) != pm_object(P).N_FACETS + 1)
+function nfacets(P::Polyhedron)
+    n = pm_object(P).N_FACETS::Int
+    return n - (_facet_at_infinity(pm_object(P)) != n + 1)
+end
 
 @doc Markdown.doc"""
     facets(as::Type{T} = AffineHalfspace, P::Polyhedron)
@@ -349,7 +352,7 @@ function _facet_at_infinity(P::Polymake.BigObject)
         fai = Int64(isnothing(i) ? P.N_FACETS + 1 : i)
         Polymake.attach(P, "_facet_at_infinity", fai)
     end
-    return fai
+    return fai::Int64
 end
 
 _is_facet_at_infinity(v::AbstractVector) = v[1] >= 0 && iszero(v[2:end])
@@ -381,7 +384,7 @@ julia> lineality_dim(C)
 1
 ```
 """
-lineality_dim(P::Polyhedron) = pm_object(P).LINEALITY_DIM
+lineality_dim(P::Polyhedron) = pm_object(P).LINEALITY_DIM::Int
 
 
 @doc Markdown.doc"""
@@ -413,7 +416,7 @@ julia> lattice_volume(C)
 8
 ```
 """
-lattice_volume(P::Polyhedron) = (pm_object(P)).LATTICE_VOLUME
+lattice_volume(P::Polyhedron)::fmpz = (pm_object(P)).LATTICE_VOLUME
 
 
 @doc Markdown.doc"""
@@ -446,7 +449,7 @@ julia> dim(P)
 2
 ```
 """
-dim(P::Polyhedron) = Polymake.polytope.dim(pm_object(P))
+dim(P::Polyhedron) = Polymake.polytope.dim(pm_object(P))::Int
 
 
 @doc Markdown.doc"""
@@ -553,7 +556,7 @@ julia> ambient_dim(P)
 3
 ```
 """
-ambient_dim(P::Polyhedron) = Polymake.polytope.ambient_dim(pm_object(P))
+ambient_dim(P::Polyhedron) = Polymake.polytope.ambient_dim(pm_object(P))::Int
 
 @doc Markdown.doc"""
     codim(P::Polyhedron)


### PR DESCRIPTION
Add type assertions to queries for pm_object properties/attributes. This may
help optimize code calling these methods. For example, before this patch:

    julia> Base.return_types(nfacets)
    2-element Vector{Any}:
     Any
     Any

After this patch:

    julia> Base.return_types(nfacets)
    2-element Vector{Any}:
     Int64
     Int64

Someone should double check that the type assertion I suggest really make sense; e.g. I assumed that all (co)dimensions, volumes etc. always are of type `Int` but perhaps that's not always true (e.g. perhaps volumes can be too big to fit into an `Int`?