### PR TITLE
Improvements toric varieties

### DIFF
--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -227,7 +227,7 @@ function toric_projective_space(d::Int)
     set_attribute!(variety, :map_from_cartier_divisor_group_to_picard_group, map_from_weil_divisors_to_class_group(variety))
     set_attribute!(variety, :stanley_reisner_ideal, ideal([prod(Hecke.gens(cox_ring(variety)))]))
     set_attribute!(variety, :irrelevant_ideal, ideal(Hecke.gens(cox_ring(variety))))
-    betti_numbers = [if iseven(i) fmpz(1) else fmpz(0) end for i in 0:2*d]
+    betti_numbers = [fmpz(1) for i in 0:d]
     set_attribute!(variety, :betti_number, betti_numbers)
     
     # return the variety
@@ -281,7 +281,7 @@ function hirzebruch_surface(r::Int)
     gens = Hecke.gens(cox_ring(variety))
     set_attribute!(variety, :stanley_reisner_ideal, ideal([gens[1]*gens[3],gens[2]*gens[4]]))
     set_attribute!(variety, :irrelevant_ideal, ideal([gens[1]*gens[2], gens[3]*gens[2], gens[1]*gens[4], gens[3]*gens[4]]))
-    set_attribute!(variety, :betti_number, [fmpz(1),fmpz(0),fmpz(2),fmpz(0),fmpz(1)])
+    set_attribute!(variety, :betti_number, [fmpz(1),fmpz(2),fmpz(1)])
     
     # return the result
     return variety
@@ -352,7 +352,7 @@ function del_pezzo(b::Int)
         set_attribute!(variety, :cox_ring, grade(ring,weights)[1])
         set_attribute!(variety, :stanley_reisner_ideal, ideal([gens[1]*gens[3], gens[2]*gens[4]]))
         set_attribute!(variety, :irrelevant_ideal, ideal([gens[3]*gens[4], gens[1]*gens[4], gens[1]*gens[2], gens[3]*gens[2]]))
-        set_attribute!(variety, :betti_number, [fmpz(1),fmpz(0),fmpz(2),fmpz(0),fmpz(1)])
+        set_attribute!(variety, :betti_number, [fmpz(1),fmpz(2),fmpz(1)])
     end
     if b == 2
         set_attribute!(variety, :euler_characteristic, 5)
@@ -365,7 +365,7 @@ function del_pezzo(b::Int)
                                                                                           gens[2]*gens[4], gens[2]*gens[5], gens[3]*gens[5]]))
         set_attribute!(variety, :irrelevant_ideal, ideal([gens[3]*gens[4]*gens[5], gens[1]*gens[4]*gens[5], 
                                                                                  gens[1]*gens[2]*gens[5], gens[1]*gens[2]*gens[3], gens[2]*gens[3]*gens[4]]))
-        set_attribute!(variety, :betti_number, [fmpz(1),fmpz(0),fmpz(3),fmpz(0),fmpz(1)])
+        set_attribute!(variety, :betti_number, [fmpz(1),fmpz(3),fmpz(1)])
     end
     if b == 3
         set_attribute!(variety, :euler_characteristic, 6)
@@ -379,7 +379,7 @@ function del_pezzo(b::Int)
         set_attribute!(variety, :irrelevant_ideal, ideal([gens[3]*gens[4] *gens[5]*gens[6], gens[1]*gens[4] *gens[5]*gens[6],
                                                                                  gens[1]*gens[2] *gens[5]*gens[6], gens[1]*gens[2] *gens[3]*gens[6],
                                                                                  gens[1]*gens[2] *gens[3]*gens[4], gens[2]*gens[3] *gens[4]*gens[5]]))
-        set_attribute!(variety, :betti_number, [fmpz(1),fmpz(0),fmpz(4),fmpz(0),fmpz(1)])
+        set_attribute!(variety, :betti_number, [fmpz(1),fmpz(4),fmpz(1)])
     end
     
     # set further attributes

--- a/src/ToricVarieties/NormalToricVarieties/methods.jl
+++ b/src/ToricVarieties/NormalToricVarieties/methods.jl
@@ -34,6 +34,6 @@ function betti_number(v::AbstractNormalToricVariety, i::Int)
     end
     
     # return result
-    return get_attribute(v, :betti_number)[i+1]
+    return betti_numbers[i+1]
 end
 export betti_number

--- a/src/ToricVarieties/NormalToricVarieties/methods.jl
+++ b/src/ToricVarieties/NormalToricVarieties/methods.jl
@@ -5,35 +5,27 @@
 @doc Markdown.doc"""
     betti_number(v::AbstractNormalToricVariety, i::Int)
 
-Compute the i-th Betti number of the normal toric variety `v`.
+Compute the `i`-th Betti number of the normal toric variety `v`.
 """
 function betti_number(v::AbstractNormalToricVariety, i::Int)
     # check input
-    if i > 2*dim(v) || i < 0
-        return 0
+    d = dim(v)::Int
+    if i > 2*d || i < 0 || isodd(i)
+        return fmpz(0)
     end
-    
+
     # extract vector of currently-known Betti numbers (or create it if necessary)
-    if !has_attribute(v, :betti_number)
-        betti_numbers = fill(fmpz(-1),2*dim(v)+1)
-    else
-        betti_numbers = get_attribute(v, :betti_number)::Vector{fmpz}
-    end
-    
+    betti_numbers = get_attribute!(() -> fill(fmpz(-1),d+1), v, :betti_number)::Vector{fmpz}
+
     # compute the Betti number if needed
-    if betti_numbers[i+1] == -1
-        if isodd(i)
-            betti_numbers[i+1] = fmpz(0)
-        else
-            k = div(i, 2)
-            f_vector = Vector{Int}(pm_object(v).F_VECTOR)
-            pushfirst!(f_vector, 1)
-            betti_numbers[i+1] = fmpz(sum((-1)^(i-k) * binomial(i,k) * f_vector[dim(v) - i + 1] for i=k:dim(v)))
-        end
-        set_attribute!(v, :betti_number, betti_numbers)
+    k = i >> 1 # i is even, so divide by two and use that as index
+    if betti_numbers[k+1] == -1
+        f_vector::Vector{Int} = pm_object(v).F_VECTOR
+        pushfirst!(f_vector, 1)
+        betti_numbers[k+1] = fmpz(sum((-1)^(i-k) * binomial(i,k) * f_vector[d - i + 1] for i=k:d))
     end
     
     # return result
-    return betti_numbers[i+1]
+    return betti_numbers[k+1]
 end
 export betti_number

--- a/src/ToricVarieties/ToricDivisors/attributes.jl
+++ b/src/ToricVarieties/ToricDivisors/attributes.jl
@@ -67,9 +67,7 @@ julia> coefficients(D)
 ```
 """
 function coefficients(td::ToricDivisor)
-    return get_attribute!(td, :coefficients) do
-        return Vector{Int}(Polymake.common.primitive(pm_tdivisor(td).COEFFICIENTS))
-    end
+    return td.coeffs
 end
 export coefficients
 
@@ -80,6 +78,6 @@ export coefficients
 Return the toric variety of a torus-invariant Weil divisor.
 """
 function toricvariety(td::ToricDivisor)
-    return get_attribute(td, :toricvariety)
+    return td.toricvariety
 end
 export toricvariety

--- a/src/ToricVarieties/ToricDivisors/constructors.jl
+++ b/src/ToricVarieties/ToricDivisors/constructors.jl
@@ -4,6 +4,8 @@
 
 @attributes mutable struct ToricDivisor
            polymake_divisor::Polymake.BigObject
+           toricvariety::AbstractNormalToricVariety
+           coeffs::Vector{Int}
 end
 export ToricDivisor
 
@@ -36,11 +38,9 @@ function ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{Int})
     # construct the divisor
     ptd = Polymake.fulton.TDivisor(COEFFICIENTS=coeffs)
     Polymake.add(pm_object(v), "DIVISOR", ptd)
-    td = ToricDivisor(ptd, Dict())
+    td = ToricDivisor(ptd, v, coeffs, Dict())
     
     # set attributes
-    set_attribute!(td, :coefficients, coeffs)
-    set_attribute!(td, :toricvariety, v)
     if sum(coeffs) != 1
         set_attribute!(td, :isprime_divisor, false)
     else


### PR DESCRIPTION
@fingolfin As discussed in https://github.com/oscar-system/Oscar.jl/pull/839, a few minor improvements:
- `coeffs` and `toricvariety` are now (ordinary) struct fields for toric divisors
- Rename the method `betti_number` to `betti_numbers`.

I am not sure how to rewrite the method `betti_numbers` to use the (standard?) syntax for cached properties. This is a prototype that I expect to repeat for line/vector bundle cohomologies very soon. So it would seem worth to think more about this.

1. The user can provide any integer `i` and thereby ask for i-th Betti number with `i<0` or `i>2 * dimension(variety)`. In this case, one could either raise an error ("this Betti number is not defined") or return `0`. Currently, the latter is implemented, but on second thought, I would think it is more reasonable to opt for the error.
Irrespective, this test should probably be conducted before checking if the attribute `betti_numbers` is known and has a properly initialized value at position `i+1`.
2. Next, check if `betti_numbers` has a meaningful/initialized value at position `i+1`. If `yes`, return it and otherwise compute it.
3. Currently, I initialize the vector `betti_numbers` with values `-1`. Since this number is never a Betti number (as Betti numbers are dimensions of a vector spaces), I can then proceed as follows:
> `if (betti_numbers[i+1] == -1) ... #compute it...`

In summary, I am unsure how to adjust 
> `return get_attribute!(v, :betti_numbers) do ...`

such that it returns **only** the `i+1`st element of the vector `betti_numbers` **if this `i+1`st element has been initialized** (i.e. is not `-1` in the current implementation).

Feedback/suggestions very much appreciated.