### PR TITLE
Require GAP 0.7.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ msolve_jll = "6d01cc9a-e8f6-580e-8c54-544227e08205"
 [compat]
 AbstractAlgebra = "0.23.0"
 DocStringExtensions = "0.8"
-GAP = "0.7.2"
+GAP = "0.7.3"
 Hecke = "0.10.27"
 Nemo = "0.28.0"
 Polymake = "0.6.2"


### PR DESCRIPTION
... which fixes an issue with recent Julia nightly builds
