### PR TITLE
New properties and attributes for toric line bundles

### DIFF
--- a/docs/src/ToricVarieties/ToricDivisors.md
+++ b/docs/src/ToricVarieties/ToricDivisors.md
@@ -43,5 +43,5 @@ is_very_ample(td::ToricDivisor)
 ```@docs
 coefficients(td::ToricDivisor)
 polyhedron(td::ToricDivisor)
-toricvariety(td::ToricDivisor)
+toric_variety(td::ToricDivisor)
 ```

--- a/docs/src/ToricVarieties/ToricLineBundles.md
+++ b/docs/src/ToricVarieties/ToricLineBundles.md
@@ -20,6 +20,7 @@ ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{Int})
 ## Attributes
 
 ```@docs
+toric_divisor(l::ToricLineBundle)
 divisor_class(l::ToricLineBundle)
 variety(l::ToricLineBundle)
 ```

--- a/docs/src/ToricVarieties/ToricLineBundles.md
+++ b/docs/src/ToricVarieties/ToricLineBundles.md
@@ -17,6 +17,17 @@ ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{fmpz})
 ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{Int})
 ```
 
+
+## Properties
+
+```@docs
+istrivial(l::ToricLineBundle)
+is_basepoint_free(l::ToricLineBundle)
+isample(l::ToricLineBundle)
+is_very_ample(l::ToricLineBundle)
+```
+
+
 ## Attributes
 
 ```@docs

--- a/docs/src/ToricVarieties/ToricLineBundles.md
+++ b/docs/src/ToricVarieties/ToricLineBundles.md
@@ -20,7 +20,8 @@ ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{Int})
 ## Attributes
 
 ```@docs
-toric_divisor(l::ToricLineBundle)
+degree(l::ToricLineBundle)
 divisor_class(l::ToricLineBundle)
+toric_divisor(l::ToricLineBundle)
 variety(l::ToricLineBundle)
 ```

--- a/src/ToricVarieties/JToric.jl
+++ b/src/ToricVarieties/JToric.jl
@@ -11,4 +11,6 @@ include("ToricDivisors/properties.jl")
 include("ToricDivisors/attributes.jl")
 
 include("LineBundles/constructors.jl")
+include("LineBundles/properties.jl")
 include("LineBundles/attributes.jl")
+

--- a/src/ToricVarieties/LineBundles/attributes.jl
+++ b/src/ToricVarieties/LineBundles/attributes.jl
@@ -12,6 +12,7 @@ function divisor_class(l::ToricLineBundle)
 end
 export divisor_class
 
+
 @doc Markdown.doc"""
     variety(l::ToricLineBundle)
 
@@ -21,3 +22,23 @@ function variety(l::ToricLineBundle)
     return l.variety
 end
 export variety
+
+
+@doc Markdown.doc"""
+    toric_divisor(l::ToricLineBundle)
+
+Returns a divisor corresponding to the toric line bundle `l`.
+"""
+function toric_divisor(l::ToricLineBundle)
+    return get_attribute!(l, :toric_divisor) do
+        class = divisor_class(l)
+        map1 = map_from_cartier_divisor_group_to_picard_group(variety(l))
+        map2 = map = map_from_cartier_divisor_group_to_torus_invariant_divisor_group(variety(l))
+        image = map2(preimage(map1, class)).coeff
+        coeffs = vec([fmpz(x) for x in image])
+        td = ToricDivisor(variety(l), coeffs)
+        set_attribute!(td, :iscartier, true)
+        return td
+    end
+end
+export divisor

--- a/src/ToricVarieties/LineBundles/attributes.jl
+++ b/src/ToricVarieties/LineBundles/attributes.jl
@@ -42,3 +42,16 @@ function toric_divisor(l::ToricLineBundle)
     end
 end
 export divisor
+
+
+@doc Markdown.doc"""
+    degree(l::ToricLineBundle)
+
+Returns the degree of the toric line bundle `l`.
+"""
+function degree(l::ToricLineBundle)
+    return get_attribute!(l, :degree) do
+        return sum(coefficients(toric_divisor(l)))::fmpz
+    end
+end
+export degree

--- a/src/ToricVarieties/LineBundles/constructors.jl
+++ b/src/ToricVarieties/LineBundles/constructors.jl
@@ -4,7 +4,7 @@
 
 abstract type ToricCoherentSheaf end
 
-struct ToricLineBundle <: ToricCoherentSheaf
+@attributes mutable struct ToricLineBundle <: ToricCoherentSheaf
     variety::AbstractNormalToricVariety
     divisor_class::GrpAbFinGenElem
 end
@@ -23,7 +23,7 @@ Construct the line bundle on the abstract normal toric variety `v` with class `c
 """
 function ToricLineBundle(v::AbstractNormalToricVariety, input_class::Vector{fmpz})
     class = picard_group(v)(input_class)
-    return ToricLineBundle(v, class)
+    return ToricLineBundle(v, class, Dict())
 end
 
 @doc Markdown.doc"""
@@ -42,7 +42,7 @@ A line bundle on a normal toric variety corresponding to a polyhedral fan in amb
 """
 function ToricLineBundle(v::AbstractNormalToricVariety, input_class::Vector{Int})
     class = picard_group(v)(input_class)
-    return ToricLineBundle(v, class)
+    return ToricLineBundle(v, class, Dict())
 end
 
 

--- a/src/ToricVarieties/LineBundles/constructors.jl
+++ b/src/ToricVarieties/LineBundles/constructors.jl
@@ -7,6 +7,7 @@ abstract type ToricCoherentSheaf end
 @attributes mutable struct ToricLineBundle <: ToricCoherentSheaf
     variety::AbstractNormalToricVariety
     divisor_class::GrpAbFinGenElem
+    ToricLineBundle(variety::AbstractNormalToricVariety, divisor_class::GrpAbFinGenElem) = new(variety, divisor_class)
 end
 export ToricLineBundle
 
@@ -23,7 +24,7 @@ Construct the line bundle on the abstract normal toric variety `v` with class `c
 """
 function ToricLineBundle(v::AbstractNormalToricVariety, input_class::Vector{fmpz})
     class = picard_group(v)(input_class)
-    return ToricLineBundle(v, class, Dict())
+    return ToricLineBundle(v, class)
 end
 
 @doc Markdown.doc"""
@@ -42,7 +43,7 @@ A line bundle on a normal toric variety corresponding to a polyhedral fan in amb
 """
 function ToricLineBundle(v::AbstractNormalToricVariety, input_class::Vector{Int})
     class = picard_group(v)(input_class)
-    return ToricLineBundle(v, class, Dict())
+    return ToricLineBundle(v, class)
 end
 
 

--- a/src/ToricVarieties/LineBundles/properties.jl
+++ b/src/ToricVarieties/LineBundles/properties.jl
@@ -1,0 +1,73 @@
+@doc Markdown.doc"""
+    istrivial(l::ToricLineBundle)
+
+Returns "true" if the toric line bundle `l` is trivial and "false" otherwise.
+
+# Examples
+```jldoctest
+julia> H = hirzebruch_surface(4)
+A normal, non-affine, smooth, projective, gorenstein, q-gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+
+julia> istrivial(ToricLineBundle(H, [1,0]))
+false
+
+julia> istrivial(ToricLineBundle(H, [0,0]))
+true
+```
+"""
+istrivial(l::ToricLineBundle) = isprincipal(toric_divisor(l))
+export istrivial
+
+
+@doc Markdown.doc"""
+    is_basepoint_free(l::ToricLineBundle)
+
+Returns "true" if the toric line bundle `l` is basepoint free and "false" otherwise.
+
+# Examples
+```jldoctest
+julia> H = hirzebruch_surface(4)
+A normal, non-affine, smooth, projective, gorenstein, q-gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+
+julia> is_basepoint_free(ToricLineBundle(H, [1,0]))
+true
+```
+"""
+is_basepoint_free(l::ToricLineBundle) = is_basepoint_free(toric_divisor(l))
+export is_basepoint_free
+
+
+@doc Markdown.doc"""
+    isample(l::ToricLineBundle)
+
+Returns "true" if the toric line bundle `l` is ample and "false" otherwise.
+
+# Examples
+```jldoctest
+julia> H = hirzebruch_surface(4)
+A normal, non-affine, smooth, projective, gorenstein, q-gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+
+julia> isample(ToricLineBundle(H, [1,0]))
+false
+```
+"""
+isample(l::ToricLineBundle) = isample(toric_divisor(l))
+export isample
+
+
+@doc Markdown.doc"""
+    is_very_ample(l::ToricLineBundle)
+
+Returns "true" if the toric line bundle `l` is very ample and "false" otherwise.
+
+# Examples
+```jldoctest
+julia> H = hirzebruch_surface(4)
+A normal, non-affine, smooth, projective, gorenstein, q-gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+
+julia> is_very_ample(ToricLineBundle(H, [1,0]))
+false
+```
+"""
+is_very_ample(l::ToricLineBundle) = is_very_ample(toric_divisor(l))
+export is_very_ample

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -5,11 +5,13 @@ abstract type AbstractNormalToricVariety end
 
 @attributes mutable struct NormalToricVariety <: AbstractNormalToricVariety
            polymakeNTV::Polymake.BigObject
+           NormalToricVariety(polymakeNTV::Polymake.BigObject) = new(polymakeNTV)
 end
 export NormalToricVariety
 
 @attributes mutable struct AffineNormalToricVariety <: AbstractNormalToricVariety
            polymakeNTV::Polymake.BigObject
+           AffineNormalToricVariety(polymakeNTV::Polymake.BigObject) = new(polymakeNTV)
 end
 export AffineNormalToricVariety
 
@@ -42,7 +44,7 @@ function AffineNormalToricVariety(C::Cone)
     # construct the variety
     fan = PolyhedralFan(C)
     pmntv = Polymake.fulton.NormalToricVariety(Oscar.pm_object(fan))
-    variety = AffineNormalToricVariety(pmntv, Dict())
+    variety = AffineNormalToricVariety(pmntv)
     
     # set known attributes
     set_attribute!(variety, :cone, C)
@@ -76,7 +78,7 @@ function NormalToricVariety(C::Cone)
     # construct the variety
     fan = PolyhedralFan(C)
     pmntv = Polymake.fulton.NormalToricVariety(Oscar.pm_object(fan))
-    variety = NormalToricVariety(pmntv, Dict())
+    variety = NormalToricVariety(pmntv)
     
     # set known attributes
     set_attribute!(variety, :fan, fan)
@@ -112,7 +114,7 @@ function NormalToricVariety(PF::PolyhedralFan)
     # construct the variety    
     fan = Oscar.pm_object(PF)
     pmntv = Polymake.fulton.NormalToricVariety(fan)
-    variety = NormalToricVariety(pmntv, Dict())
+    variety = NormalToricVariety(pmntv)
     
     # set attributes
     set_attribute!(variety, :fan, PF)
@@ -170,7 +172,7 @@ function AffineNormalToricVariety(v::NormalToricVariety)
     isaffine(v) || error("Cannot construct affine toric variety from non-affine input")
     
     # set variety
-    variety = AffineNormalToricVariety(pm_object(v), Dict())
+    variety = AffineNormalToricVariety(pm_object(v))
     
     # set properties of variety
     set_attribute!(variety, :isaffine, true)
@@ -209,7 +211,7 @@ function toric_affine_space(d::Int)
     # construct the variety
     fan = PolyhedralFan(C)
     pmntv = Polymake.fulton.NormalToricVariety(Oscar.pm_object(fan))
-    variety = NormalToricVariety(pmntv, Dict())
+    variety = NormalToricVariety(pmntv)
     
     # set known properties
     set_attribute!(variety, :isaffine, true)
@@ -243,7 +245,7 @@ function toric_projective_space(d::Int)
     # construct the variety
     f = normal_fan(Oscar.simplex(d))
     pm_object = Polymake.fulton.NormalToricVariety(Oscar.pm_object(f))
-    variety = NormalToricVariety(pm_object, Dict())
+    variety = NormalToricVariety(pm_object)
     
     # set properties
     set_attribute!(variety, :isaffine, false)

--- a/src/ToricVarieties/ToricDivisors/attributes.jl
+++ b/src/ToricVarieties/ToricDivisors/attributes.jl
@@ -59,7 +59,7 @@ julia> D = ToricDivisor(H, [1,2,3,4])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> coefficients(D)
-4-element Vector{Int64}:
+4-element Vector{fmpz}:
  1
  2
  3

--- a/src/ToricVarieties/ToricDivisors/attributes.jl
+++ b/src/ToricVarieties/ToricDivisors/attributes.jl
@@ -73,11 +73,11 @@ export coefficients
 
 
 @doc Markdown.doc"""
-    toricvariety(td::ToricDivisor)
+    toric_variety(td::ToricDivisor)
 
 Return the toric variety of a torus-invariant Weil divisor.
 """
-function toricvariety(td::ToricDivisor)
-    return td.toricvariety
+function toric_variety(td::ToricDivisor)
+    return td.toric_variety
 end
-export toricvariety
+export toric_variety

--- a/src/ToricVarieties/ToricDivisors/constructors.jl
+++ b/src/ToricVarieties/ToricDivisors/constructors.jl
@@ -6,9 +6,9 @@
            polymake_divisor::Polymake.BigObject
            toricvariety::AbstractNormalToricVariety
            coeffs::Vector{fmpz}
+           ToricDivisor(polymake_divisor::Polymake.BigObject, toricvariety::AbstractNormalToricVariety, coeffs::Vector{fmpz}) = new(polymake_divisor, toricvariety, coeffs)
 end
 export ToricDivisor
-
 
 function pm_tdivisor(td::ToricDivisor)
     return td.polymake_divisor
@@ -40,7 +40,7 @@ function ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{fmpz})
     # construct the divisor
     ptd = Polymake.fulton.TDivisor(COEFFICIENTS=Polymake.Vector{Polymake.Integer}(coeffs))
     Polymake.add(pm_object(v), "DIVISOR", ptd)
-    td = ToricDivisor(ptd, v, coeffs, Dict())
+    td = ToricDivisor(ptd, v, coeffs)
     
     # set attributes
     if sum(coeffs) != 1

--- a/src/ToricVarieties/ToricDivisors/constructors.jl
+++ b/src/ToricVarieties/ToricDivisors/constructors.jl
@@ -4,9 +4,9 @@
 
 @attributes mutable struct ToricDivisor
            polymake_divisor::Polymake.BigObject
-           toricvariety::AbstractNormalToricVariety
+           toric_variety::AbstractNormalToricVariety
            coeffs::Vector{fmpz}
-           ToricDivisor(polymake_divisor::Polymake.BigObject, toricvariety::AbstractNormalToricVariety, coeffs::Vector{fmpz}) = new(polymake_divisor, toricvariety, coeffs)
+           ToricDivisor(polymake_divisor::Polymake.BigObject, toric_variety::AbstractNormalToricVariety, coeffs::Vector{fmpz}) = new(polymake_divisor, toric_variety, coeffs)
 end
 export ToricDivisor
 

--- a/src/ToricVarieties/ToricDivisors/constructors.jl
+++ b/src/ToricVarieties/ToricDivisors/constructors.jl
@@ -5,7 +5,7 @@
 @attributes mutable struct ToricDivisor
            polymake_divisor::Polymake.BigObject
            toricvariety::AbstractNormalToricVariety
-           coeffs::Vector{Int}
+           coeffs::Vector{fmpz}
 end
 export ToricDivisor
 
@@ -29,14 +29,16 @@ julia> ToricDivisor(toric_projective_space(2), [1,1,2])
 A torus-invariant, non-prime divisor on a normal toric variety
 ```
 """
-function ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{Int})
+ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{Int}) = ToricDivisor(v, [fmpz(k) for k in coeffs])
+
+function ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{fmpz})
     # check input
     if length(coeffs) != pm_object(v).N_RAYS
         throw(ArgumentError("Number of coefficients needs to match number of prime divisors!"))
     end
     
     # construct the divisor
-    ptd = Polymake.fulton.TDivisor(COEFFICIENTS=coeffs)
+    ptd = Polymake.fulton.TDivisor(COEFFICIENTS=Polymake.Vector{Polymake.Integer}(coeffs))
     Polymake.add(pm_object(v), "DIVISOR", ptd)
     td = ToricDivisor(ptd, v, coeffs, Dict())
     
@@ -74,7 +76,7 @@ function DivisorOfCharacter(v::AbstractNormalToricVariety, character::Vector{Int
     end
     f = map_from_character_to_principal_divisors(v)
     char = sum(character .* gens(domain(f)))
-    coeffs = [Int(x) for x in transpose(f(char).coeff)][:,1]
+    coeffs = [fmpz(x) for x in transpose(f(char).coeff)][:,1]
     return ToricDivisor(v, coeffs)
 end
 export DivisorOfCharacter

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -195,7 +195,7 @@ D=ToricDivisor(H5, [0,0,0,0])
 D2 = DivisorOfCharacter(H5, [1,2])
 
 @testset "Divisors" begin
-    @test dim(toricvariety(D)) == 2
+    @test dim(toric_variety(D)) == 2
     @test is_prime_divisor(D) == false
     @test iscartier(D) == true
     @test isprincipal(D) == true

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -229,7 +229,7 @@ end
 line_bundle = ToricLineBundle(dP3, [1,2,3,4])
 
 @testset "Toric line bundles" begin
-    @test sum(coefficients(toric_divisor(line_bundle))) == 10
+    @test degree(line_bundle) == 10
     @test divisor_class(line_bundle).coeff == AbstractAlgebra.matrix(ZZ, [1 2 3 4])
     @test dim(variety(line_bundle)) == 2
 end

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -229,6 +229,7 @@ end
 line_bundle = ToricLineBundle(dP3, [1,2,3,4])
 
 @testset "Toric line bundles" begin
+    @test sum(coefficients(toric_divisor(line_bundle))) == 10
     @test divisor_class(line_bundle).coeff == AbstractAlgebra.matrix(ZZ, [1 2 3 4])
     @test dim(variety(line_bundle)) == 2
 end

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -232,4 +232,8 @@ line_bundle = ToricLineBundle(dP3, [1,2,3,4])
     @test degree(line_bundle) == 10
     @test divisor_class(line_bundle).coeff == AbstractAlgebra.matrix(ZZ, [1 2 3 4])
     @test dim(variety(line_bundle)) == 2
+    @test istrivial(line_bundle) == false
+    @test is_basepoint_free(line_bundle) == false
+    @test isample(line_bundle) == false
+    @test is_very_ample(line_bundle) == false
 end


### PR DESCRIPTION
- Activate caching for `ToricLineBundles,`
- Add divisor of `ToricLineBundle,`
- Add degree of `ToricLineBundle,`
- Derive several properties of `ToricLineBundles` from its (a) divisor.

This PR contains the changes of https://github.com/oscar-system/Oscar.jl/pull/940 and https://github.com/oscar-system/Oscar.jl/pull/929 to simplify a possible rebase.