### PR TITLE
ToricVarieties: Line bundle cohomologies with cohomcalg

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RandomExtensions = "fb686558-2515-59ef-acaa-46db3789a887"
 Singular = "bcd08a7b-43d2-5ff7-b6d4-c458787f915c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+cohomCalg_jll = "5558cf25-a90e-53b0-b813-cadaa3ae7ade"
 msolve_jll = "6d01cc9a-e8f6-580e-8c54-544227e08205"
 
 [compat]

--- a/docs/src/ToricVarieties/ToricLineBundles.md
+++ b/docs/src/ToricVarieties/ToricLineBundles.md
@@ -36,3 +36,13 @@ divisor_class(l::ToricLineBundle)
 toric_divisor(l::ToricLineBundle)
 variety(l::ToricLineBundle)
 ```
+
+## Method
+
+We use [cohomCalg](https://github.com/BenjaminJurke/cohomCalg)
+to compute line bundle cohomologies. This is achieved with the following methods.
+
+```@docs
+all_cohomologies(l::ToricLineBundle)
+cohomology(l::ToricLineBundle, i::Int)
+```

--- a/src/ToricVarieties/JToric.jl
+++ b/src/ToricVarieties/JToric.jl
@@ -50,3 +50,4 @@ include("ToricLineBundles/constructors.jl")
 include("ToricLineBundles/properties.jl")
 include("ToricLineBundles/attributes.jl")
 
+include("cohomCalg.jl")

--- a/src/ToricVarieties/cohomCalg.jl
+++ b/src/ToricVarieties/cohomCalg.jl
@@ -1,0 +1,186 @@
+############################
+# Line bundle cohomologies with cohomCalg
+############################
+
+
+function command_string(v::AbstractNormalToricVariety, c::Vector{fmpz})
+    # Initialize a list of strings, which we will eventually join to form the command string
+    string_list = Vector{String}()
+    
+    # Define helper function
+    joincomma(list) = join([string(x) for x in list], ",")
+    
+    # create dictionary from "our" variables to safe variable for use in cohomCalg
+    coordinate_names = [string(x) for x in Hecke.gens(cox_ring(v))]
+    coordinate_dictionary = Dict(coordinate_names[i] => "x$i" for i = 1:length(coordinate_names))
+    
+    # Add information about grading of Cox ring to string_list
+    divisors = gens(torusinvariant_divisor_group(v))
+    for i in 1:length(coordinate_names)
+        tmp = joincomma(map_from_weil_divisors_to_class_group(v)(divisors[i]).coeff)
+        push!(string_list, "vertex $(coordinate_dictionary[coordinate_names[i]])|GLSM:($(tmp))")
+    end
+    
+    # Add information about the Stanley-Reisner ideal to string_list
+    generators = [string(g) for g in gens(stanley_reisner_ideal(v))]
+    for i in 1:length(generators)
+        new_g = generators[i]
+        for (key, value) in coordinate_dictionary
+            new_g = replace(new_g, key => value)
+        end
+        generators[i] = new_g
+    end
+    push!(string_list, "srideal [" * joincomma(generators) * "]")
+    
+    # Add line bundle information to string_list
+    push!(string_list, "ambientcohom O(" * joincomma(c) * ");")
+    
+    # Join and return
+    return join(string_list, ";")
+end
+
+
+@doc Markdown.doc"""
+    all_cohomologies(l::ToricLineBundle)
+
+Computes the dimension of all sheaf cohomologies of the toric line bundle `l`.
+
+# Examples
+```jldoctest
+julia> dP3 = del_pezzo(3)
+A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
+
+julia> all_cohomologies(ToricLineBundle(dP3, [1,2,3,4]))
+3-element Vector{fmpz}:
+ 11
+ 0
+ 0
+```
+"""
+function all_cohomologies(l::ToricLineBundle)
+    # check if we can apply cohomCalg
+    v = variety(l)
+    if !((issmooth(v) && iscomplete(v)) || (issimplicial(v) && isprojective(v)))
+        throw(ArgumentError("cohomCalg only applies to toric varieties that are either smooth, complete or simplicial, projective."))
+    end
+    
+    # extract vector of currently-known cohomology dimensions (or create it if necessary)
+    return get_attribute!(l, :all_cohomologies) do
+        
+        # Minimal example:
+        #
+        # The following lines provide an interface to cohomCalg. This is easiest explained with an example.
+        # 
+        # Example: Compute the cohomologies of the structure sheaf of the 2-dimensional projective space.
+        #
+        # Step 1: We trigger the following command so that cohomCalg computes these cohomologies for us:
+        #
+        # ./cohomCalg "vertex x1 | GLSM: ( 1 ); vertex x2 | GLSM: ( 1 ); vertex x3 | GLSM: ( 1 ); srideal [x1*x2*x3]; ambientcohom O(0 );"
+        #
+        # The notation GLSM is for generalized linear sigma model.
+        # This is a physics model which famously triggered interest in toric geometry for physics applications.
+        # The cohomCalg algorithm relies only on the grading of the Cox ring and the Stanley-Reisner ideal.
+        # <-> Those two pieces of information are (more or less) the defining data of a GLSM.
+        #
+        # Step 2: We receive the following return value from cohomCalg:
+        #
+        # "{True,{{1,0,0},{{0,1*1}}}}"
+        #
+        # The "True" tells us that the run was successful. Otherwise, we would find "False".
+        # 
+        # Whenever we encounter "False", this most likely indicates wrong input data. This could be any of the following:
+        # (a) wrong variable names: cohomCalg accepts "x1, x2, ..." (and also "y1, y2, ..."), but "_x1, _x2" or "x[1]", "x[2]" will cause errors.
+        # (b) an inconsistent grading of the Cox ring: This could e.g. lead to infinitely many monoms of a fixed degree.
+        # (c) an inconsistent Stanley-Reisner ideal.
+        # 
+        # For sake of simplicity, our implementation creates a dictionary that maps "our" variable names to "x1, x2,...".
+        # The latter are then passed to cohomCalg.
+        # 
+        # After this boolean, the above return value contains the line bundle cohomologies and some intermediate results.
+        # The first argument in the { }-brackets are the line bundle cohomologies in question. Here: {1,0,0}.
+        # 
+        # By the cohomCalg algorithm, the line bundle cohomologies are given by certain rationoms, that is fractions of 
+        # monoms in the Cox ring of the variety. Behind the scenes, cohomCalg reads-off monomials which contribute
+        # to the denominators of these rationoms. For sake of simplicity, let us refer to these monomials as "partial-denominators".
+        # 
+        # Crucially: These partial-denominators are read-off from the Stanley-Reisner ideal. Hence, they encode information about
+        # the toric space and are not specific to a certain line bundle. In https://arxiv.org/abs/1802.08860, this is used to infer
+        # refined vanishing sets of line bundle cohomologies on toric spaces. Implementations of which are currently available in
+        # https://github.com/homalg-project/ToricVarieties_project and will be migrated to OSCAR soon.
+        # 
+        # To make contact with a line bundle in question, pick a partial-denominator and look for all rationoms with multi-degree
+        # matching that of the line bundle in question. In particular, under the assumptions that the variety in question be either
+        # smooth, complete or alternatively simplicial, projective, one finds a finite number of such rationoms for each partial-denominator.
+        # 
+        # Once these rationoms are identified, two questions remain:
+        # (1) To which line bundle cohomology do they contribute?
+        # (2) Could they encode more than a one-dimensional linear subspace of these cohomology spaces?
+        # 
+        # The answers to both questions are involved and described in detail in the original work https://arxiv.org/pdf/1003.5217.pdf
+        # and the proofs of this algorithm in https://arxiv.org/abs/1006.2392, https://arxiv.org/abs/1006.0780. In particular note that
+        # the answer to (2) involved the evaluation of certain "remnant cohomologies", so that a single rationom may indeed encode
+        # a vector space of line bundle cohomologies which is strictly larger than 1.
+        # 
+        # Let us now return to the above return value {{0,1*1}}. The fact that this list contains only a single sub-list states that only 
+        # a single partial-denominator was identified. The first value tells to which cohomology group it contributes. Here we find 0,
+        # so it contributes to H^0. The second value is, in the following order, the product of the multiplicity (as in response to 
+        # (2) above) and the exact form of the partial-denominator. So here the multiplicity is 1 and the partial-denominator is 1.
+        # For other examples, we could for example find "2 * x2 * x3 * x5", which would mean that the multiplicity is 2
+        # and the partial denominator in question is "x2 * x3 * x5".
+        # 
+        # For more details, please refer to the cohomCalg manual: https://arxiv.org/pdf/1003.5217.pdf.
+        # 
+        # Step 3: Extract "True" (or "False") and the first argument of the following "{ }" by suitable parsing.
+        #
+        # -> Hooray! We found the line bundle cohomologies in question.
+        
+        # obtain the command string
+        class = vec([fmpz(x) for x in divisor_class(l).coeff])
+        command = command_string(v, class)
+        
+        # execute cohomCalg
+        out = Pipe()
+        err = Pipe()
+        process = run(pipeline(ignorestatus(`$(cohomCalg_jll.cohomcalg()) --integrated --in=$(command)`), stdout=out, stderr=err))
+        close(out.in)
+        close(err.in)
+        
+        # was there an error?
+        stderr = String(read(err))
+        code = process.exitcode
+        if code != 0
+            error("cohomCalg encountered the error " * stderr)
+        end
+        
+        # read out the result
+        stdout = String(read(out))
+        result = [fmpz(parse(Int,c)) for c in split(chop(chop(split(stdout, "{" )[4])), ",")]
+        
+        # consistency check
+        if length(result) != dim(v)+1
+            error("cohomCalg should return list of length $(dim(v)+1) but returned list of length $(length(result))")
+        end
+        
+        # return result
+        return result
+    end
+end
+export all_cohomologies
+
+
+@doc Markdown.doc"""
+    cohomology(l::ToricLineBundle, i::Int)
+
+Computes the dimension of the i-th sheaf cohomology of the toric line bundle `l`.
+
+# Examples
+```jldoctest
+julia> dP3 = del_pezzo(3)
+A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
+
+julia> cohomology(ToricLineBundle(dP3, [1,2,3,4]), 0)
+11
+```
+"""
+cohomology(l::ToricLineBundle, i::Int) = all_cohomologies(l)[i+1]
+export cohomology

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -226,3 +226,5 @@ import Hecke:
     TorQuadModMor,
     tr,
     trace
+
+import cohomCalg_jll

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -253,4 +253,6 @@ line_bundle = ToricLineBundle(dP3, [1,2,3,4])
     @test is_basepoint_free(line_bundle) == false
     @test isample(line_bundle) == false
     @test is_very_ample(line_bundle) == false
+    @test all_cohomologies(line_bundle) == [11,0,0]
+    @test cohomology(line_bundle,0) == 11
 end


### PR DESCRIPTION
As anticipated since last year... line bundle cohomologies via `cohomCalg`.

