### PR TITLE
Avoid needs_parentheses

### DIFF
--- a/experimental/PlaneCurve/DivisorCurve.jl
+++ b/experimental/PlaneCurve/DivisorCurve.jl
@@ -124,30 +124,21 @@ function ProjCurveDivisor(C::ProjPlaneCurve{S}, P::Oscar.Geometry.ProjSpcElem{S}
 end
 
 ################################################################################
-# To get a nice output for the divisors. The needs_parentheses is needed since
-# expressify wants to know if parentheses are needed.
-
-function AbstractAlgebra.needs_parentheses(A::Vector{T}) where T <: RingElem
-    return false
-end
+# To get a nice output for the divisors.
 
 function AbstractAlgebra.expressify(@nospecialize(a::AffineCurveDivisor); context = nothing)
    prod = Expr(:call, :+)
    for (P, m) in a.divisor
-      ep = AbstractAlgebra.expressify(P.coord, context = context)
+      ep = sprint(print, P.coord; context = context)::String
       push!(prod.args, Expr(:call, :*, m, ep))
    end
    return prod
 end
 
-function AbstractAlgebra.needs_parentheses(A::Oscar.Geometry.ProjSpcElem{T}) where T <: RingElem
-    return false
-end
-
 function AbstractAlgebra.expressify(@nospecialize(a::ProjCurveDivisor); context = nothing)
    prod = Expr(:call, :+)
    for (P, m) in a.divisor
-      ep = AbstractAlgebra.expressify(P, context = context)
+      ep = sprint(print, P; context = context)::String
       push!(prod.args, Expr(:call, :*, m, ep))
    end
    return prod

--- a/experimental/PlaneCurve/DivisorCurve.jl
+++ b/experimental/PlaneCurve/DivisorCurve.jl
@@ -129,7 +129,7 @@ end
 function AbstractAlgebra.expressify(@nospecialize(a::AffineCurveDivisor); context = nothing)
    prod = Expr(:call, :+)
    for (P, m) in a.divisor
-      ep = sprint(print, P.coord; context = context)::String
+      ep = AbstractAlgebra.expressify(P.coord; context = context)::String
       push!(prod.args, Expr(:call, :*, m, ep))
    end
    return prod
@@ -138,7 +138,7 @@ end
 function AbstractAlgebra.expressify(@nospecialize(a::ProjCurveDivisor); context = nothing)
    prod = Expr(:call, :+)
    for (P, m) in a.divisor
-      ep = sprint(print, P; context = context)::String
+      ep = AbstractAlgebra.expressify(P; context = context)
       push!(prod.args, Expr(:call, :*, m, ep))
    end
    return prod


### PR DESCRIPTION
There are a few more uses of `needs_parentheses` left in
`src/Rings/localization_interface.jl`, but I hope @HechtiDerLachs will
take care of these.