### PR TITLE
More work on GAP -> Oscar matrix conversion

### DIFF
--- a/src/GAP/gap_to_oscar.jl
+++ b/src/GAP/gap_to_oscar.jl
@@ -25,27 +25,115 @@ end
 GAP.gap_to_julia(::Type{fmpq}, obj::GapInt) = fmpq(obj)
 (::FlintRationalField)(obj::GapObj) = fmpq(obj)
 
+###
+### GAP finite field elements to Oscar (generically)
+###
+
+# TODO: the following could be made faster for GAP.FFE by extracting the
+# characteristic directly from the GAP FFE
+characteristic(x::GAP.FFE) = fmpz(GAPWrap.CHAR_FFE_DEFAULT(x))
+characteristic(x::GapObj) = fmpz(GAPWrap.Characteristic(x))
+
+# test code for producing an FFE:  `GAP.Globals.Z(5)`
+function (F::FinField)(x::GAP.FFE)
+    characteristic(x) == characteristic(F) || error("characteristic does not match")
+
+    if GAPWrap.DegreeFFE(x) == 1
+        # FFE in GAP only exist for "small" characteristic, so we know the int
+        # value fits into an Int; telling Julia about this via a type assertion
+        # results in slightly better code
+        val = GAPWrap.INT_FFE_DEFAULT(x)::Int
+        return F(val)
+    end
+
+    error("TODO: add support for FFE outside the prime field")
+end
+
+# test code for producing a gap finite field element not stored as FFE:  `GAP.Globals.Z(65537)`
+function (F::FinField)(x::GapObj)
+    GAP.GAP_IS_INT(x) && return F(fmpz(x))
+    GAPWrap.IsFFE(x) || error("<x> must be a GAP large integer or a GAP finite field element")
+    characteristic(x) == characteristic(F) || error("characteristic does not match")
+
+    if GAPWrap.DegreeFFE(x) == 1
+        val = GAPWrap.IntFFE(x)
+        return F(val)
+    end
+
+    # TODO: conversion of elements from extension field; code for this
+    # already exists in `src/Groups/matrices/iso_oscar_gap.jl` but it may require
+    # precomputations, which we should cache
+
+    error("TODO: add support for FFE outside the prime field")
+end
+
+##
+## matrix conversion
+##
+
+function __ensure_gap_matrix(obj::GapObj)
+    GAPWrap.IsMatrixOrMatrixObj(obj) || throw(ArgumentError("<obj> is not a GAP matrix"))
+end
+
 ##
 ## matrix of GAP integers to `fmpz_mat`
 ##
 function fmpz_mat(obj::GapObj)
-    m = Matrix{fmpz}(obj)
-    return matrix(ZZ, m)
+    __ensure_gap_matrix(obj)
+    nrows = GAPWrap.NrRows(obj)
+    ncols = GAPWrap.NrCols(obj)
+    m = zero_matrix(ZZ, nrows, ncols)
+    for i in 1:nrows, j in 1:ncols
+        x = obj[i,j]
+        @inbounds m[i,j] = x isa Int ? x : fmpz(x::GapObj)
+    end
+    return m
 end
 
-GAP.gap_to_julia(::Type{fmpz_mat}, obj::GapObj) = fmpz_mat(obj)
-matrix(R::FlintIntegerRing, obj::GapObj) = fmpz_mat(obj)
+GAP.gap_to_julia(::Type{fmpz_mat}, obj::GapObj) = fmpz_mat(obj) # TODO: deprecate/remove this
 
 ##
 ## matrix of GAP rationals or integers to `fmpq_mat`
 ##
 function fmpq_mat(obj::GapObj)
-    m = Matrix{fmpq}(obj)
-    return matrix(QQ, m)
+    __ensure_gap_matrix(obj)
+    nrows = GAPWrap.NrRows(obj)
+    ncols = GAPWrap.NrCols(obj)
+    m = zero_matrix(QQ, nrows, ncols)
+    for i in 1:nrows, j in 1:ncols
+        x = obj[i,j]
+        @inbounds m[i,j] = x isa Int ? x : fmpq(x::GapObj)
+    end
+    return m
 end
 
-GAP.gap_to_julia(::Type{fmpq_mat}, obj::GapObj) = fmpq_mat(obj)
-matrix(R::FlintRationalField, obj::GapObj) = fmpq_mat(obj)
+GAP.gap_to_julia(::Type{fmpq_mat}, obj::GapObj) = fmpq_mat(obj) # TODO: deprecate/remove this
+
+##
+## generic matrix() method for GAP matrices which converts each element on its
+## own: this is inefficient but almost always works, so we use it as our base
+## case
+##
+function matrix(R::Ring, obj::GapObj)
+    # TODO: add special code for compressed matrices, resp. MatrixObj, so that
+    # we can perform the characteristic check once, instead of nrows*ncols
+    # times
+    __ensure_gap_matrix(obj)
+    nrows = GAPWrap.NrRows(obj)
+    ncols = GAPWrap.NrCols(obj)
+    m = zero_matrix(R, nrows, ncols)
+    for i in 1:nrows, j in 1:ncols
+        x = obj[i,j]::Union{Int,GapObj,GAP.FFE} # type annotation so Julia generates better code
+        @inbounds m[i,j] = x isa Int ? x : R(x)
+    end
+    return m
+end
+
+# also allow map_entries to make Claus happy ;-)
+map_entries(R::Ring, obj::GapObj) = matrix(R, obj)
+
+# TODO: cache conversion tables
+
 
 ##
 ## cache default bases of GAP's cyclotomic fields

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -14,6 +14,7 @@ using GAP
 
 GAP.@wrap CF(x::Any, y::Any)::GapObj
 GAP.@wrap CF(x::Any)::GapObj
+GAP.@wrap CHAR_FFE_DEFAULT(x::Any)::GapInt
 GAP.@wrap Characteristic(x::Any)::GapInt
 GAP.@wrap Coefficients(x::Any, y::Any)::GapObj
 GAP.@wrap Conductor(x::Any)::GapInt

--- a/src/Groups/matrices/iso_oscar_gap.jl
+++ b/src/Groups/matrices/iso_oscar_gap.jl
@@ -19,7 +19,7 @@ end
 ################################################################################
 
 # computes the isomorphism between the Oscar field F and the corresponding GAP field
-function ring_iso_oscar_gap(F::T) where T <: Union{Nemo.GaloisField, Nemo.GaloisFmpzField}
+function ring_iso_oscar_gap(F::Union{Nemo.GaloisField, Nemo.GaloisFmpzField})
    p = characteristic(F)
    G = GAPWrap.GF(GAP.Obj(p))
    e = GAPWrap.One(G)
@@ -30,7 +30,7 @@ function ring_iso_oscar_gap(F::T) where T <: Union{Nemo.GaloisField, Nemo.Galois
    return MapFromFunc(f, finv, F, G)
 end
 
-function ring_iso_oscar_gap(F::T) where T <: Union{Nemo.FqNmodFiniteField, Nemo.FqFiniteField}
+function ring_iso_oscar_gap(F::Union{Nemo.FqNmodFiniteField, Nemo.FqFiniteField})
    p = characteristic(F)
    d = degree(F)
    p_gap = GAP.Obj(p)
@@ -96,7 +96,7 @@ function ring_iso_oscar_gap(F::T) where T <: Union{Nemo.FqNmodFiniteField, Nemo.
    return MapFromFunc(f, finv, F, G)
 end
 
-function ring_iso_oscar_gap(F::T) where T <: FlintRationalField
+function ring_iso_oscar_gap(F::FlintRationalField)
    return MapFromFunc(x -> GAP.Obj(x), x -> fmpq(x), F, GAP.Globals.Rationals)
 end
 
@@ -104,12 +104,14 @@ end
 # General number fields will require caching,
 # in order to achieve that Oscar matrix groups over the same number field
 # are mapped to GAP matrix groups over the same `AlgebraicExtension` field.
-function ring_iso_oscar_gap(F::T) where T <: AnticNumberField
+function ring_iso_oscar_gap(F::AnticNumberField)
 
    flag, N = Hecke.iscyclotomic_type(F)
    flag || error("$F is not a cyclotomic field")
 
    G = GAPWrap.CF(GAP.Obj(N))
+   cycpol = GAP.Globals.CyclotomicPol(N)
+   dim = length(cycpol)-1
 
    function f(x::Nemo.nf_elem)
       coeffs = [Nemo.coeff(x, i) for i in 0:(N-1)]
@@ -122,8 +124,6 @@ function ring_iso_oscar_gap(F::T) where T <: AnticNumberField
       n = GAPWrap.Conductor(x)
       mod(N, n) == 0 || error("$x does not lie in the $N-th cyclotomic field")
       coeffs = GAP.Globals.CoeffsCyc(x * denom, N)
-      cycpol = GAP.Globals.CyclotomicPol(N)
-      dim = length(cycpol)-1
       GAP.Globals.ReduceCoeffs(coeffs, cycpol)
       coeffs = Vector{fmpz}(coeffs)
       coeffs = coeffs[1:dim]

--- a/test/GAP/gap_to_oscar.jl
+++ b/test/GAP/gap_to_oscar.jl
@@ -106,6 +106,30 @@ end
     @test_throws GAP.ConversionError GAP.gap_to_julia(fmpq_mat, val)
 end
 
+@testset "finite field matrix" begin
+  @testset "with characteristic $p" for p in [ 5, fmpz(5), 65537, fmpz(65537) ]
+    @testset "with finite field $F" for F in [ GF(p), FiniteField(p,1,"a")[1], FiniteField(p,2,"a")[1] ]
+        x = F[1 2; 3 4]
+
+        # matrix of small (GAP) integers
+        val = GAP.evalstr( "[ [ 1, 2 ], [ 3, 4 ] ]" )
+        @test matrix(F, val) == x
+
+        # matrix containing small and large integers
+        val = GAP.evalstr( "[ [ 1, 2+$p*2^65 ], [ 3, 4 ] ]" )
+        @test matrix(F, val) == x
+
+        # matrix of finite field elements
+        val = GAP.evalstr( "Z($p)^0 * [ [ 1, 2 ], [ 3, 4 ] ]" )
+        @test matrix(F, val) == x
+
+        # possible compressed matrix of finite field elements
+        GAP.Globals.ConvertToMatrixRep(val)
+        @test matrix(F, val) == x
+    end
+  end
+end
+
 @testset "single cyclotomics" begin
     # to cyclotomic fields
     F, z = CyclotomicField(1)


### PR DESCRIPTION
- better error message if the input is not a GAP matrix
- implement conversion to matrices over finite fields of degree 1
- optimize some conversion functions

For example, before this patch:

    julia> gapobj = GAP.@gap [[1,2^100],[3,4]];

    julia> @btime matrix(QQ, gapobj);
      2.439 μs (22 allocations: 1.11 KiB)

After this patch:

    julia> gapobj = GAP.@gap [[1,2^100],[3,4]];

    julia> @btime matrix(QQ, gapobj);
      1.178 μs (6 allocations: 240 bytes)


---

This code was already done a month ago, but then I want to connect the
existing code dealing with non-prime finite fields, which lead me to work on
the whole `get_attribute` machinery... now that is done, so I could use it,
but I figured I should get this in *now* before waiting even longer 