### PR TITLE
Adjust doctest for describe(G::GAPGroup)

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1054,10 +1054,8 @@ julia> describe(sylow_subgroup(g,2)[1])
 julia> describe(sylow_subgroup(g, 3)[1])
 "C3 x C3"
 
-julia> g = symmetric_group(10);
-
-julia> describe(sylow_subgroup(g,2)[1])
-"C2 x ((((C2 x C2 x C2 x C2) : C2) : C2) : C2)"
+julia> describe(free_group(3))
+"a free group of rank 3"
 
 ```
 """


### PR DESCRIPTION
The output of `describe` is in general not unique and depends on the
state of a random number generator. The previous doctest used an
example that was affected by this, which we remove.

Also add an example involving a free group, just to show this other
flavor of the function.