### PR TITLE
PolyhedralGeometry: improve compatibility with fmpz and fmpq types

### DIFF
--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -127,5 +127,5 @@ toric_ideal(antv::AffineNormalToricVariety)
 
 ```@docs
 binomial_exponents_to_ideal(binoms::Union{AbstractMatrix, fmpz_mat})
-toric_ideal(pts::Union{AbstractMatrix, fmpz_mat})
+toric_ideal(pts::fmpz_mat)
 ```

--- a/src/PolyhedralGeometry/Cone/constructors.jl
+++ b/src/PolyhedralGeometry/Cone/constructors.jl
@@ -36,13 +36,14 @@ A polyhedral cone in ambient dimension 2
 ```
 """
 function Cone(R::Union{SubObjectIterator{<:RayVector}, Oscar.MatElem, AbstractMatrix}, L::Union{SubObjectIterator{<:RayVector}, Oscar.MatElem, AbstractMatrix, Nothing} = nothing; non_redundant::Bool = false)
-    RM = matrix_for_polymake(R)
-    LM = isnothing(L) || isempty(L) ? Polymake.Matrix{Polymake.Rational}(undef, 0, size(RM, 2)) : matrix_for_polymake(L)
+    if isnothing(L) || isempty(L)
+        L = Polymake.Matrix{Polymake.Rational}(undef, 0, size(R, 2))
+    end
 
     if non_redundant
-        return Cone(Polymake.polytope.Cone{Polymake.Rational}(RAYS = RM, LINEALITY_SPACE = LM,))
+        return Cone(Polymake.polytope.Cone{Polymake.Rational}(RAYS = R, LINEALITY_SPACE = L,))
     else
-        return Cone(Polymake.polytope.Cone{Polymake.Rational}(INPUT_RAYS = RM, INPUT_LINEALITY = LM,))
+        return Cone(Polymake.polytope.Cone{Polymake.Rational}(INPUT_RAYS = R, INPUT_LINEALITY = L,))
     end
 end
 
@@ -74,9 +75,8 @@ A polyhedral cone in ambient dimension 2
 ```
 """
 function positive_hull(R::Union{SubObjectIterator{<:RayVector}, Oscar.MatElem, AbstractMatrix})
-    # TODO: Filter out zero rows
     C=Polymake.polytope.Cone{Polymake.Rational}(INPUT_RAYS =
-      matrix_for_polymake(remove_zero_rows(R)))
+      remove_zero_rows(R))
     Cone(C)
 end
 

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -8,7 +8,7 @@ rays(as::Type{RayVector{T}}, C::Cone) where T = SubObjectIterator{as}(pm_object(
 
 _ray_cone(::Type{T}, C::Polymake.BigObject, i::Base.Integer) where T = T(C.RAYS[i, :])
 
-_vector_matrix(::Val{_ray_cone}, C::Polymake.BigObject) = C.RAYS
+_vector_matrix(::Val{_ray_cone}, C::Polymake.BigObject; homogenized=false) = C.RAYS
 
 _matrix_for_polymake(::Val{_ray_cone}) = _vector_matrix
 
@@ -334,7 +334,7 @@ lineality_space(C::Cone) = SubObjectIterator{RayVector{Polymake.Rational}}(pm_ob
 
 _lineality_cone(::Type{RayVector{Polymake.Rational}}, C::Polymake.BigObject, i::Base.Integer) = RayVector(C.LINEALITY_SPACE[i, :])
 
-_generator_matrix(::Val{_lineality_cone}, C::Polymake.BigObject) = C.LINEALITY_SPACE
+_generator_matrix(::Val{_lineality_cone}, C::Polymake.BigObject; homogenized=false) = C.LINEALITY_SPACE
 
 _matrix_for_polymake(::Val{_lineality_cone}) = _generator_matrix
 
@@ -392,6 +392,6 @@ end
 
 _hilbert_generator(::Type{PointVector{Polymake.Integer}}, C::Polymake.BigObject, i::Base.Integer) = PointVector{Polymake.Integer}(C.HILBERT_BASIS_GENERATORS[1][i, :])
 
-_generator_matrix(::Val{_hilbert_generator}, C::Polymake.BigObject) = C.HILBERT_BASIS_GENERATORS[1]
+_generator_matrix(::Val{_hilbert_generator}, C::Polymake.BigObject; homogenized=false) = C.HILBERT_BASIS_GENERATORS[1]
 
 _matrix_for_polymake(::Val{_hilbert_generator}) = _generator_matrix

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -375,11 +375,11 @@ This (non-smooth) cone in the plane has a hilbert basis with three elements.
 julia> C = Cone([1 0; 1 2])
 A polyhedral cone in ambient dimension 2
 
-julia> hilbert_basis(C)
-pm::Matrix<pm::Integer>
-1 0
-1 1
-1 2
+julia> matrix(ZZ, hilbert_basis(C))
+[1   0]
+[1   2]
+[1   1]
+
 ```
 """
 function hilbert_basis(C::Cone)

--- a/src/PolyhedralGeometry/PolyhedralFan/constructors.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/constructors.jl
@@ -64,14 +64,14 @@ A polyhedral fan in ambient dimension 2
 """
 function PolyhedralFan(Rays::Union{SubObjectIterator{<:RayVector}, Oscar.MatElem,AbstractMatrix}, Incidence::IncidenceMatrix)
    PolyhedralFan(Polymake.fan.PolyhedralFan{Polymake.Rational}(
-      INPUT_RAYS = matrix_for_polymake(Rays),
+      INPUT_RAYS = Rays,
       INPUT_CONES = Incidence,
    ))
 end
 function PolyhedralFan(Rays::Union{SubObjectIterator{<:RayVector}, Oscar.MatElem,AbstractMatrix}, LS::Union{SubObjectIterator{<:RayVector}, Oscar.MatElem,AbstractMatrix}, Incidence::IncidenceMatrix)
    PolyhedralFan(Polymake.fan.PolyhedralFan{Polymake.Rational}(
-      INPUT_RAYS = matrix_for_polymake(Rays),
-      INPUT_LINEALITY = matrix_for_polymake(LS),
+      INPUT_RAYS = Rays,
+      INPUT_LINEALITY = LS,
       INPUT_CONES = Incidence,
    ))
 end

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -31,7 +31,7 @@ rays(PF::PolyhedralFan) = SubObjectIterator{RayVector{Polymake.Rational}}(pm_obj
 
 _ray_fan(::Type{RayVector{Polymake.Rational}}, PF::Polymake.BigObject, i::Base.Integer) = RayVector(PF.RAYS[i, :])
 
-_vector_matrix(::Val{_ray_fan}, PF::Polymake.BigObject) = PF.RAYS
+_vector_matrix(::Val{_ray_fan}, PF::Polymake.BigObject; homogenized=false) = PF.RAYS
 
 _matrix_for_polymake(::Val{_ray_fan}) = _vector_matrix
 
@@ -268,7 +268,7 @@ lineality_space(PF::PolyhedralFan) = SubObjectIterator{RayVector{Polymake.Ration
 
 _lineality_fan(::Type{RayVector{Polymake.Rational}}, PF::Polymake.BigObject, i::Base.Integer) = RayVector(PF.LINEALITY_SPACE[i, :])
 
-_generator_matrix(::Val{_lineality_fan}, PF::Polymake.BigObject) = PF.LINEALITY_SPACE
+_generator_matrix(::Val{_lineality_fan}, PF::Polymake.BigObject; homogenized=false) = PF.LINEALITY_SPACE
 
 _matrix_for_polymake(::Val{_lineality_fan}) = _generator_matrix
 

--- a/src/PolyhedralGeometry/Polyhedron/constructors.jl
+++ b/src/PolyhedralGeometry/Polyhedron/constructors.jl
@@ -140,15 +140,10 @@ A polyhedron in ambient dimension 2
 ```
 """
 function convex_hull(V::Union{SubObjectIterator{PointVector}, AnyVecOrMat, Oscar.MatElem}, R::Union{SubObjectIterator{RayVector}, AnyVecOrMat, Oscar.MatElem, Nothing} = nothing, L::Union{SubObjectIterator{RayVector}, AnyVecOrMat, Oscar.MatElem, Nothing} = nothing; non_redundant::Bool = false)
-    # we access the matrices which polymake can work with.
-    VM = matrix_for_polymake(V)
-    RM = isnothing(R) || isempty(R) ? Polymake.Matrix{Polymake.Rational}(undef, 0, size(VM, 2)) : matrix_for_polymake(R)
-    LM = isnothing(L) || isempty(L) ? Polymake.Matrix{Polymake.Rational}(undef, 0, size(VM, 2)) : matrix_for_polymake(L)
-
     # Rays and Points are homogenized and combined and
     # Lineality is homogenized
-    points = stack(homogenize(VM, 1), homogenize(RM, 0))
-    lineality = homogenize(LM, 0)
+    points = stack(homogenized_matrix(V, 1), homogenized_matrix(R, 0))
+    lineality = isnothing(L) || isempty(L) ? zero_matrix(QQ, 0, size(points,2)) : homogenized_matrix(L, 0)
 
     # These matrices are in the right format for polymake.
     # given non_redundant can avoid unnecessary redundancy checks

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -115,7 +115,7 @@ vertices(as::Type{PointVector{T}}, P::Polyhedron) where T = SubObjectIterator{as
 
 _vertex_polyhedron(::Type{PointVector{T}}, P::Polymake.BigObject, i::Base.Integer) where T = PointVector{T}(P.VERTICES[_vertex_indices(P)[i], 2:end])
 
-_point_matrix(::Val{_vertex_polyhedron}, P::Polymake.BigObject) = P.VERTICES[_vertex_indices(P), 2:end]
+_point_matrix(::Val{_vertex_polyhedron}, P::Polymake.BigObject; homogenized=false) = P.VERTICES[_vertex_indices(P), (homogenized ? 1 : 2):end]
 
 _matrix_for_polymake(::Val{_vertex_polyhedron}) = _point_matrix
 
@@ -202,7 +202,7 @@ rays(as::Type{RayVector{T}}, P::Polyhedron) where T = SubObjectIterator{as}(pm_o
 
 _ray_polyhedron(::Type{RayVector{T}}, P::Polymake.BigObject, i::Base.Integer) where T = RayVector{T}(P.VERTICES[_ray_indices(P)[i], 2:end])
 
-_vector_matrix(::Val{_ray_polyhedron}, P::Polymake.BigObject) = P.VERTICES[_ray_indices(P), 2:end]
+_vector_matrix(::Val{_ray_polyhedron}, P::Polymake.BigObject; homogenized=false) = P.VERTICES[_ray_indices(P), (homogenized ? 1 : 2):end]
 
 _matrix_for_polymake(::Val{_ray_polyhedron}) = _vector_matrix
 
@@ -478,7 +478,7 @@ end
 
 _lattice_point(::Type{PointVector{Polymake.Integer}}, P::Polymake.BigObject, i::Base.Integer) = PointVector{Polymake.Integer}(P.LATTICE_POINTS_GENERATORS[1][i, 2:end])
 
-_point_matrix(::Val{_lattice_point}, P::Polymake.BigObject) = P.LATTICE_POINTS_GENERATORS[1][:, 2:end]
+_point_matrix(::Val{_lattice_point}, P::Polymake.BigObject; homogenized=false) = P.LATTICE_POINTS_GENERATORS[1][:, (homogenized ? 1 : 2):end]
 
 _matrix_for_polymake(::Val{_lattice_point}) = _point_matrix
 
@@ -505,7 +505,7 @@ end
 
 _interior_lattice_point(::Type{PointVector{Polymake.Integer}}, P::Polymake.BigObject, i::Base.Integer) = PointVector{Polymake.Integer}(P.INTERIOR_LATTICE_POINTS[i, 2:end])
 
-_point_matrix(::Val{_interior_lattice_point}, P::Polymake.BigObject) = P.INTERIOR_LATTICE_POINTS[:, 2:end]
+_point_matrix(::Val{_interior_lattice_point}, P::Polymake.BigObject; homogenized=false) = P.INTERIOR_LATTICE_POINTS[:, (homogenized ? 1 : 2):end]
 
 _matrix_for_polymake(::Val{_interior_lattice_point}) = _point_matrix
 
@@ -537,7 +537,7 @@ end
 
 _boundary_lattice_point(::Type{PointVector{Polymake.Integer}}, P::Polymake.BigObject, i::Base.Integer) = PointVector{Polymake.Integer}(P.BOUNDARY_LATTICE_POINTS[i, 2:end])
 
-_point_matrix(::Val{_boundary_lattice_point}, P::Polymake.BigObject) = P.BOUNDARY_LATTICE_POINTS[:, 2:end]
+_point_matrix(::Val{_boundary_lattice_point}, P::Polymake.BigObject; homogenized=false) = P.BOUNDARY_LATTICE_POINTS[:, (homogenized ? 1 : 2):end]
 
 _matrix_for_polymake(::Val{_boundary_lattice_point}) = _point_matrix
 
@@ -603,7 +603,7 @@ lineality_space(P::Polyhedron) = SubObjectIterator{RayVector{Polymake.Rational}}
 
 _lineality_polyhedron(::Type{RayVector{Polymake.Rational}}, P::Polymake.BigObject, i::Base.Integer) = RayVector(P.LINEALITY_SPACE[i, 2:end])
 
-_generator_matrix(::Val{_lineality_polyhedron}, P::Polymake.BigObject) = P.LINEALITY_SPACE[:, 2:end]
+_generator_matrix(::Val{_lineality_polyhedron}, P::Polymake.BigObject; homogenized=false) = P.LINEALITY_SPACE[:, (homogenized ? 1 : 2):end]
 
 _matrix_for_polymake(::Val{_lineality_polyhedron}) = _generator_matrix
 

--- a/src/PolyhedralGeometry/SubdivisionOfPoints/constructors.jl
+++ b/src/PolyhedralGeometry/SubdivisionOfPoints/constructors.jl
@@ -37,7 +37,7 @@ A subdivision of points in ambient dimension 3
 function SubdivisionOfPoints(Points::Union{Oscar.MatElem,AbstractMatrix}, Incidence::IncidenceMatrix)
    arr = @Polymake.convert_to Array{Set{Int}} Polymake.common.rows(Incidence)
    SubdivisionOfPoints(Polymake.fan.SubdivisionOfPoints{Polymake.Rational}(
-      POINTS = matrix_for_polymake(homogenize(Points,1)),
+      POINTS = homogenize(Points,1),
       MAXIMAL_CELLS = arr,
    ))
 end
@@ -68,7 +68,7 @@ julia> nmaximal_cells(SOP)
 """
 function SubdivisionOfPoints(Points::Union{Oscar.MatElem,AbstractMatrix}, Weights::AbstractVector)
    SubdivisionOfPoints(Polymake.fan.SubdivisionOfPoints{Polymake.Rational}(
-      POINTS = matrix_for_polymake(homogenize(Points,1)),
+      POINTS = homogenize(Points,1),
       WEIGHTS = Weights,
    ))
 end

--- a/src/PolyhedralGeometry/iterators.jl
+++ b/src/PolyhedralGeometry/iterators.jl
@@ -224,12 +224,12 @@ function matrix_for_polymake(iter::SubObjectIterator; homogenized=false)
 end
 
 # primitive generators only for ray based iterators
-matrix(::FlintIntegerRing, iter::SubObjectIterator{RayVector{Polymake.Rational}}) =
-    matrix(ZZ, Polymake.common.primitive(matrix_for_polymake(iter)))
-matrix(::FlintIntegerRing, iter::SubObjectIterator{<:Union{RayVector{Polymake.Integer},PointVector{Polymake.Integer}}}) =
-    matrix(ZZ, matrix_for_polymake(iter))
-matrix(::FlintRationalField, iter::SubObjectIterator{<:Union{RayVector,PointVector}}) =
-    matrix(QQ, Matrix{fmpq}(matrix_for_polymake(iter)))
+matrix(R::FlintIntegerRing, iter::SubObjectIterator{RayVector{Polymake.Rational}}) =
+    matrix(R, Polymake.common.primitive(matrix_for_polymake(iter)))
+matrix(R::FlintIntegerRing, iter::SubObjectIterator{<:Union{RayVector{Polymake.Integer},PointVector{Polymake.Integer}}}) =
+    matrix(R, matrix_for_polymake(iter))
+matrix(R::FlintRationalField, iter::SubObjectIterator{<:Union{RayVector,PointVector}}) =
+    matrix(R, Matrix{fmpq}(matrix_for_polymake(iter)))
 
 function linear_matrix_for_polymake(iter::SubObjectIterator)
     if hasmethod(_linear_matrix_for_polymake, Tuple{Val{iter.Acc}})

--- a/src/PolyhedralGeometry/iterators.jl
+++ b/src/PolyhedralGeometry/iterators.jl
@@ -215,13 +215,21 @@ for (sym, name) in (("point_matrix", "Point Matrix"), ("vector_matrix", "Vector 
     end
 end
 
-function matrix_for_polymake(iter::SubObjectIterator)
+function matrix_for_polymake(iter::SubObjectIterator; homogenized=false)
     if hasmethod(_matrix_for_polymake, Tuple{Val{iter.Acc}})
-        return _matrix_for_polymake(Val(iter.Acc))(Val(iter.Acc), iter.Obj; iter.options...)
+        return _matrix_for_polymake(Val(iter.Acc))(Val(iter.Acc), iter.Obj; homogenized=homogenized, iter.options...)
     else
         throw(ArgumentError("Matrix for Polymake not defined in this context."))
     end
 end
+
+# primitive generators only for ray based iterators
+matrix(::FlintIntegerRing, iter::SubObjectIterator{RayVector{Polymake.Rational}}) =
+    matrix(ZZ, Polymake.common.primitive(matrix_for_polymake(iter)))
+matrix(::FlintIntegerRing, iter::SubObjectIterator{<:Union{RayVector{Polymake.Integer},PointVector{Polymake.Integer}}}) =
+    matrix(ZZ, matrix_for_polymake(iter))
+matrix(::FlintRationalField, iter::SubObjectIterator{<:Union{RayVector,PointVector}}) =
+    matrix(QQ, Matrix{fmpq}(matrix_for_polymake(iter)))
 
 function linear_matrix_for_polymake(iter::SubObjectIterator)
     if hasmethod(_linear_matrix_for_polymake, Tuple{Val{iter.Acc}})
@@ -250,4 +258,17 @@ function halfspace_matrix_pair(iter::SubObjectIterator)
     catch e
         throw(ArgumentError("Halfspace-Matrix-Pair not defined in this context."))
     end
+end
+
+Polymake.convert_to_pm_type(::Type{SubObjectIterator{RayVector{T}}}) where T = Polymake.Matrix{T}
+Polymake.convert_to_pm_type(::Type{SubObjectIterator{PointVector{T}}}) where T = Polymake.Matrix{T}
+Base.convert(::Type{<:Polymake.Matrix}, iter::SubObjectIterator) = matrix_for_polymake(iter; homogenized=true)
+
+function homogenized_matrix(x::SubObjectIterator{<:PointVector}, v::Number = 1)
+    @assert v == 1
+    return matrix_for_polymake(x; homogenized=true)
+end
+function homogenized_matrix(x::SubObjectIterator{<:RayVector}, v::Number = 0)
+    @assert v == 0
+    return matrix_for_polymake(x; homogenized=true)
 end

--- a/src/PolyhedralGeometry/iterators.jl
+++ b/src/PolyhedralGeometry/iterators.jl
@@ -265,10 +265,14 @@ Polymake.convert_to_pm_type(::Type{SubObjectIterator{PointVector{T}}}) where T =
 Base.convert(::Type{<:Polymake.Matrix}, iter::SubObjectIterator) = matrix_for_polymake(iter; homogenized=true)
 
 function homogenized_matrix(x::SubObjectIterator{<:PointVector}, v::Number = 1)
-    @assert v == 1
+    if v != 1
+        throw(ArgumentError("PointVectors can only be (re-)homogenized with parameter 1, please convert to a matrix first."))
+    end
     return matrix_for_polymake(x; homogenized=true)
 end
 function homogenized_matrix(x::SubObjectIterator{<:RayVector}, v::Number = 0)
-    @assert v == 0
+    if v != 0
+        throw(ArgumentError("RayVectors can only be (re-)homogenized with parameter 0, please convert to a matrix first."))
+    end
     return matrix_for_polymake(x; homogenized=true)
 end

--- a/src/ToricVarieties/NormalToricVarieties/auxilliary.jl
+++ b/src/ToricVarieties/NormalToricVarieties/auxilliary.jl
@@ -63,12 +63,12 @@ julia> toric_ideal(H)
 ideal(x[2]*x[3] - x[4]^2, -x[1]*x[3] + x[2]^2*x[4], -x[1]*x[4] + x[2]^3, -x[1]*x[3]^2 + x[2]*x[4]^3, -x[1]*x[3]^3 + x[4]^5)
 ```
 """
-function toric_ideal(pts::Union{AbstractMatrix, fmpz_mat})
-    intkernel = kernel(matrix(ZZ, pts), side=:left)
+function toric_ideal(pts::fmpz_mat)
+    intkernel = kernel(pts, side=:left)
     intkernel = intkernel[2]
     presat = binomial_exponents_to_ideal(intkernel)
     J = ideal([prod(gens(base_ring(presat)))])
     return saturation(presat, J)
 end
 
-toric_ideal(pts::SubObjectIterator) = toric_ideal(matrix_for_polymake(pts))
+toric_ideal(pts::Union{AbstractMatrix,SubObjectIterator}) = toric_ideal(matrix(ZZ, pts))

--- a/test/PolyhedralGeometry/Cone.jl
+++ b/test/PolyhedralGeometry/Cone.jl
@@ -10,6 +10,7 @@ const pm = Polymake
     Cone3 = Cone(R, L; non_redundant=true)
     Cone4 = positive_hull(R)
     Cone5 = positive_hull([1 0 0; 1 1 0; 1 1 1; 1 0 1])
+    Cone6 = positive_hull([1//3 1//2; 4//5 2])
 
     @testset "core functionality" begin
         @test ispointed(Cone1)
@@ -24,7 +25,8 @@ const pm = Polymake
         @test rays(Cone1) isa SubObjectIterator{RayVector{Polymake.Rational}}
         @test rays(RayVector, Cone1) isa SubObjectIterator{RayVector{Polymake.Rational}}
         @test vector_matrix(rays(Cone1)) == matrix(QQ, [1 0; 0 1])
-        @test Oscar.matrix_for_polymake(rays(Cone1)) == [1 0; 0 1]
+        @test matrix(QQ,rays(Cone1)) == matrix(QQ, [1 0; 0 1])
+        @test matrix(ZZ,rays(Cone6)) == matrix(ZZ, [2 3; 2 5])
         @test length(rays(Cone1)) == 2
         @test rays(Cone1)[1] == RayVector([1, 0])
         @test rays(Cone1)[2] == RayVector([0, 1])
@@ -61,7 +63,8 @@ const pm = Polymake
         @test ambient_dim(Cone2) == 3
         @test lineality_space(Cone2) isa SubObjectIterator{RayVector{Polymake.Rational}}
         @test generator_matrix(lineality_space(Cone2)) == matrix(QQ, L)
-        @test Oscar.matrix_for_polymake(lineality_space(Cone2)) == L
+        @test matrix(QQ, lineality_space(Cone2)) == matrix(QQ, L)
+        @test matrix(ZZ, lineality_space(Cone2)) == matrix(ZZ, L)
         @test length(lineality_space(Cone2)) == 1
         @test lineality_space(Cone2)[] == RayVector(L[1, :])
         @test vector_matrix(rays(Cone4)) == matrix(QQ, R)

--- a/test/PolyhedralGeometry/PolyhedralFan.jl
+++ b/test/PolyhedralGeometry/PolyhedralFan.jl
@@ -38,7 +38,7 @@
         @test generator_matrix(lineality_space(F2)) == matrix(QQ, L)
         @test length(lineality_space(F2)) == 1
         @test lineality_space(F2)[] == RayVector(L[:])
-        @test Oscar.matrix_for_polymake(lineality_space(F2)) == L
+        @test matrix(QQ, lineality_space(F2)) == matrix(QQ, L)
         @test cones(F2, 2) isa SubObjectIterator{Cone}
         @test size(cones(F2, 2)) == (2,)
         @test generator_matrix(lineality_space(cones(F2, 2)[1])) == matrix(QQ, [0 1 0])

--- a/test/PolyhedralGeometry/Polyhedron.jl
+++ b/test/PolyhedralGeometry/Polyhedron.jl
@@ -20,19 +20,18 @@
         @test nvertices.(faces(Q0,1)) == [2,2,2]
         @test lattice_points(Q0) isa SubObjectIterator{PointVector{Polymake.Integer}}
         @test point_matrix(lattice_points(Q0)) == matrix(QQ, [0 0; 0 1; 1 0])
-        @test Oscar.matrix_for_polymake(lattice_points(Q0)) == [0 0; 0 1; 1 0]
+        @test matrix(ZZ, lattice_points(Q0)) == matrix(ZZ, [0 0; 0 1; 1 0])
         @test length(lattice_points(Q0)) == 3
         @test lattice_points(Q0)[1] == PointVector{Polymake.Integer}([0, 0])
         @test lattice_points(Q0)[2] == PointVector{Polymake.Integer}([0, 1])
         @test lattice_points(Q0)[3] == PointVector{Polymake.Integer}([1, 0])
         @test interior_lattice_points(square) isa SubObjectIterator{PointVector{Polymake.Integer}}
-        @test point_matrix(interior_lattice_points(square)) == matrix(QQ, [0 0])
-        @test Oscar.matrix_for_polymake(interior_lattice_points(square)) == [0 0]
+        @test point_matrix(interior_lattice_points(square)) == matrix(ZZ, [0 0])
+        @test matrix(ZZ, interior_lattice_points(square)) == matrix(ZZ,[0 0])
         @test length(interior_lattice_points(square)) == 1
         @test interior_lattice_points(square)[] == PointVector{Polymake.Integer}([0, 0])
         @test boundary_lattice_points(square) isa SubObjectIterator{PointVector{Polymake.Integer}}
-        @test point_matrix(boundary_lattice_points(square)) == matrix(QQ, [-1 -1; -1 0; -1 1; 0 -1; 0 1; 1 -1; 1 0; 1 1])
-        @test Oscar.matrix_for_polymake(boundary_lattice_points(square)) == [-1 -1; -1 0; -1 1; 0 -1; 0 1; 1 -1; 1 0; 1 1]
+        @test point_matrix(boundary_lattice_points(square)) == matrix(ZZ, [-1 -1; -1 0; -1 1; 0 -1; 0 1; 1 -1; 1 0; 1 1])
         @test length(boundary_lattice_points(square)) == 8
         @test boundary_lattice_points(square)[1] == PointVector{Polymake.Integer}([-1, -1])
         @test boundary_lattice_points(square)[2] == PointVector{Polymake.Integer}([-1, 0])
@@ -71,7 +70,7 @@
         @test rays(Pos)[3] == RayVector([0, 0, 1])
         @test lineality_space(L) isa SubObjectIterator{RayVector{Polymake.Rational}}
         @test generator_matrix(lineality_space(L)) == matrix(QQ, [0 0 1])
-        @test Oscar.matrix_for_polymake(lineality_space(L)) == [0 0 1]
+        @test matrix(ZZ, lineality_space(L)) == matrix(ZZ, [0 0 1])
         @test length(lineality_space(L)) == 1
         @test lineality_space(L)[] == RayVector([0, 0, 1])
         @test faces(square, 1) isa SubObjectIterator{Polyhedron}


### PR DESCRIPTION
- This injects a conversion from fmpz/fmpq types (both `fmpX_mat` and `Matrix{fmpX}`) into the polymake constructors, allowing something like `Polymake.fulton.TDivisor(COEFFICIENTS=[fmpz(1), fmpz(2)])`.
- Adds overloads for `matrix(ZZ, ...)` and `matrix(QQ, ...)` for `SubobjectIterator` which among a few other variants allows conversion of ray generators to primitive integral generators, e.g. `matrix(ZZ, rays(positive_hull([1//3 1//2; 4//5 2])))`
- remove most `matrix_for_polymake` calls to simplify constructors and better pass-through of already homogenized polymake matrices inside `SubObjectIterator`

cc: @alexej-jordan @lkastner @HereAround 