### PR TITLE
Adjust to recent Hecke changes

### DIFF
--- a/src/Groups/abelian_aut.jl
+++ b/src/Groups/abelian_aut.jl
@@ -262,11 +262,15 @@ Return the full orthogonal group of this torsion quadratic module.
 function orthogonal_group(T::TorQuadMod)
   !isdegenerate(T) || error("T must be non-degenerate to compute the full orthogonal group")
   return get_attribute!(T, :orthogonal_group) do
-    N,i = normal_form(T)
+    N, i = normal_form(T)
     j = inv(i)
     gensOT = _compute_gens(N)
     gensOT = [hom(N, N, g) for g in gensOT]
-    gensOT = [compose(compose(j,g),i).map_ab.map for g in gensOT]
+    if isdefined(Hecke, :pkg_version) && Hecke.pkg_version > v"0.10.28"
+      gensOT = [compose(compose(i,g),j).map_ab.map for g in gensOT]
+    else
+      gensOT = [compose(compose(j,g),i).map_ab.map for g in gensOT]
+    end
     return _orthogonal_group(T, gensOT, check=false)
   end
 end


### PR DESCRIPTION
`normal_form` now returns a projection instead of an injection.
