### PR TITLE
CI: update codecov/codecov-action to v2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,4 +67,4 @@ jobs:
         uses: julia-actions/julia-processcoverage@v1
       - name: "Upload coverage data to Codecov"
         continue-on-error: true
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2


### PR DESCRIPTION
v1 will be disabled February 1, 2022; see https://github.com/codecov/codecov-action
