### PR TITLE
More GAP -> Oscar conversions

### DIFF
--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -165,7 +165,7 @@ function Hecke.modular_proj(C::GModule{T, Generic.FreeModule{nf_elem}}, me::Heck
   return R
 end
 
-function Gap(C::GModule{<:Any, <:Generic.FreeModule{<:FinFieldElem}}, h=Oscar.ring_iso_oscar_gap(base_ring(C)))
+function Gap(C::GModule{<:Any, <:Generic.FreeModule{<:FinFieldElem}}, h=Oscar.iso_oscar_gap(base_ring(C)))
   z = get_attribute(C, :Gap)
   if z !== nothing
     return z
@@ -206,7 +206,7 @@ end
 
 function hom_base(C::T, D::T) where T <: GModule{<:Any, <:Generic.FreeModule{<:FinFieldElem}}
   @assert base_ring(C) == base_ring(D)
-  h = Oscar.ring_iso_oscar_gap(base_ring(C))
+  h = Oscar.iso_oscar_gap(base_ring(C))
   hb = GAP.Globals.MTX.BasisModuleHomomorphisms(Gap(C, h), Gap(D, h))
   n = length(hb)
   b = map(x->matrix(map(y->preimage(h, y), Oscar.GAP.gap_to_julia(Matrix{Any}, x))), hb)
@@ -490,7 +490,7 @@ end
 if isdefined(Hecke, :stub_composition_factors)
   function Hecke.stub_composition_factors(x::Vector{T}) where {T}
     F = base_ring(x[1])
-    h = Oscar.ring_iso_oscar_gap(F)
+    h = Oscar.iso_oscar_gap(F)
     V = _to_gap(h, x)
     Vcf = GAP.Globals.MTX.CompositionFactors(V)
     res = Vector{T}[]
@@ -504,7 +504,7 @@ end
 if isdefined(Hecke, :stub_basis_hom_space)
   function Hecke.stub_basis_hom_space(x::Vector, y::Vector)
     F = base_ring(x[1])
-    h = Oscar.ring_iso_oscar_gap(F)
+    h = Oscar.iso_oscar_gap(F)
     @assert base_ring(x[1]) == base_ring(y[1])
     @assert length(x) == length(y)
     hb = GAP.Globals.MTX.BasisModuleHomomorphisms(_to_gap(h, x), _to_gap(h, y))

--- a/src/GAP/gap_to_oscar.jl
+++ b/src/GAP/gap_to_oscar.jl
@@ -48,7 +48,9 @@ function (F::FinField)(x::GAP.FFE)
         return F(val)
     end
 
-    error("TODO: add support for FFE outside the prime field")
+    # HACK: use `iso_oscar_gap` for now, until `iso_gap_oscar` becomes available
+    iso = iso_oscar_gap(F)
+    return preimage(iso, x)
 end
 
 # test code for producing a gap finite field element not stored as FFE:  `GAP.Globals.Z(65537)`
@@ -62,11 +64,9 @@ function (F::FinField)(x::GapObj)
         return F(val)
     end
 
-    # TODO: conversion of elements from extension field; code for this
-    # already exists in `src/Groups/matrices/iso_oscar_gap.jl` but it may require
-    # precomputations, which we should cache
-
-    error("TODO: add support for FFE outside the prime field")
+    # HACK: use `iso_oscar_gap` for now, until `iso_gap_oscar` becomes available
+    iso = iso_oscar_gap(F)
+    return preimage(iso, x)
 end
 
 ##

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -201,7 +201,7 @@ function Base.getproperty(G::MatrixGroup, sym::Symbol)
    isdefined(G,sym) && return getfield(G,sym)
 
    if sym === :ring_iso
-      G.ring_iso = ring_iso_oscar_gap(G.ring)
+      G.ring_iso = iso_oscar_gap(G.ring)
 
    elseif sym === :X
       if isdefined(G,:descr)

--- a/src/Groups/matrices/forms.jl
+++ b/src/Groups/matrices/forms.jl
@@ -306,7 +306,7 @@ function Base.getproperty(f::SesquilinearForm, sym::Symbol)
    if isdefined(f,sym) return getfield(f,sym) end
 
    if sym === :ring_iso
-      f.ring_iso = ring_iso_oscar_gap(base_ring(f))
+      f.ring_iso = iso_oscar_gap(base_ring(f))
 
    elseif sym == :X
       if !isdefined(f, :X)

--- a/src/Groups/matrices/iso_oscar_gap.jl
+++ b/src/Groups/matrices/iso_oscar_gap.jl
@@ -19,7 +19,7 @@ end
 ################################################################################
 
 # computes the isomorphism between the Oscar field F and the corresponding GAP field
-function ring_iso_oscar_gap(F::Union{Nemo.GaloisField, Nemo.GaloisFmpzField})
+function iso_oscar_gap(F::Union{Nemo.GaloisField, Nemo.GaloisFmpzField})
    p = characteristic(F)
    G = GAPWrap.GF(GAP.Obj(p))
    e = GAPWrap.One(G)
@@ -30,7 +30,7 @@ function ring_iso_oscar_gap(F::Union{Nemo.GaloisField, Nemo.GaloisFmpzField})
    return MapFromFunc(f, finv, F, G)
 end
 
-function ring_iso_oscar_gap(F::Union{Nemo.FqNmodFiniteField, Nemo.FqFiniteField})
+function iso_oscar_gap(F::Union{Nemo.FqNmodFiniteField, Nemo.FqFiniteField})
    p = characteristic(F)
    d = degree(F)
    p_gap = GAP.Obj(p)
@@ -96,7 +96,7 @@ function ring_iso_oscar_gap(F::Union{Nemo.FqNmodFiniteField, Nemo.FqFiniteField}
    return MapFromFunc(f, finv, F, G)
 end
 
-function ring_iso_oscar_gap(F::FlintRationalField)
+function iso_oscar_gap(F::FlintRationalField)
    return MapFromFunc(x -> GAP.Obj(x), x -> fmpq(x), F, GAP.Globals.Rationals)
 end
 
@@ -104,7 +104,7 @@ end
 # General number fields will require caching,
 # in order to achieve that Oscar matrix groups over the same number field
 # are mapped to GAP matrix groups over the same `AlgebraicExtension` field.
-function ring_iso_oscar_gap(F::AnticNumberField)
+function iso_oscar_gap(F::AnticNumberField)
 
    flag, N = Hecke.iscyclotomic_type(F)
    flag || error("$F is not a cyclotomic field")
@@ -134,7 +134,7 @@ function ring_iso_oscar_gap(F::AnticNumberField)
    return MapFromFunc(f, finv, F, G)
 end
 
-#TODO function ring_iso_oscar_gap(F::T) where T <: QabField
+#TODO function iso_oscar_gap(F::T) where T <: QabField
 
 
 ################################################################################

--- a/src/Groups/matrices/iso_oscar_gap.jl
+++ b/src/Groups/matrices/iso_oscar_gap.jl
@@ -25,7 +25,10 @@ function iso_oscar_gap(F::Union{Nemo.GaloisField, Nemo.GaloisFmpzField})
    e = GAPWrap.One(G)
 
    f(x::Union{Nemo.gfp_elem, Nemo.gfp_fmpz_elem}) = GAP.Obj(lift(x))*e
-   finv(x) = F(fmpz(GAPWrap.IntFFE(x)))
+   function finv(x::GAP.Obj)
+      y = GAPWrap.IntFFE(x)
+      return y isa Int ? F(y) : F(fmpz(y))
+   end
 
    return MapFromFunc(f, finv, F, G)
 end
@@ -40,7 +43,10 @@ function iso_oscar_gap(F::Union{Nemo.FqNmodFiniteField, Nemo.FqFiniteField})
    # prime fields are easy and efficient to deal with, handle them separately
    if d == 1
       f1(x::Union{Nemo.fq_nmod, Nemo.fq}) = GAP.Obj(coeff(x, 0))*e
-      finv1(x) = F(fmpz(GAPWrap.IntFFE(x)))
+      function finv1(x::GAP.Obj)
+         y = GAPWrap.IntFFE(x)
+         return y isa Int ? F(y) : F(fmpz(y))
+      end
       return MapFromFunc(f1, finv1, F, Fp_gap)
    end
 
@@ -87,7 +93,7 @@ function iso_oscar_gap(F::Union{Nemo.FqNmodFiniteField, Nemo.FqFiniteField})
    end
 
    # For "small" primes x should be an FFE, but for bigger ones it's GAP_jll.Mptr (?)
-   function finv(x)
+   function finv(x::GAP.Obj)
       v = GAPWrap.Coefficients(Basis_G, x)
       v_int = [ fmpz(GAPWrap.IntFFE(v[i])) for i = 1:length(v) ]
       return sum([ v_int[i]*Basis_F[i] for i = 1:d ])
@@ -118,7 +124,7 @@ function iso_oscar_gap(F::AnticNumberField)
       return GAPWrap.CycList(GAP.GapObj(coeffs; recursive=true))
    end
 
-   function finv(x)
+   function finv(x::GAP.Obj)
       GAPWrap.IsCyc(x) || error("$x is not a GAP cyclotomic")
       denom = GAPWrap.DenominatorCyc(x)
       n = GAPWrap.Conductor(x)

--- a/src/Groups/matrices/iso_oscar_gap.jl
+++ b/src/Groups/matrices/iso_oscar_gap.jl
@@ -19,7 +19,7 @@ end
 ################################################################################
 
 # computes the isomorphism between the Oscar field F and the corresponding GAP field
-function iso_oscar_gap(F::Union{Nemo.GaloisField, Nemo.GaloisFmpzField})
+function _iso_oscar_gap(F::Union{Nemo.GaloisField, Nemo.GaloisFmpzField})
    p = characteristic(F)
    G = GAPWrap.GF(GAP.Obj(p))
    e = GAPWrap.One(G)
@@ -33,7 +33,7 @@ function iso_oscar_gap(F::Union{Nemo.GaloisField, Nemo.GaloisFmpzField})
    return MapFromFunc(f, finv, F, G)
 end
 
-function iso_oscar_gap(F::Union{Nemo.FqNmodFiniteField, Nemo.FqFiniteField})
+function _iso_oscar_gap(F::Union{Nemo.FqNmodFiniteField, Nemo.FqFiniteField})
    p = characteristic(F)
    d = degree(F)
    p_gap = GAP.Obj(p)
@@ -102,7 +102,8 @@ function iso_oscar_gap(F::Union{Nemo.FqNmodFiniteField, Nemo.FqFiniteField})
    return MapFromFunc(f, finv, F, G)
 end
 
-function iso_oscar_gap(F::FlintRationalField)
+@attributes FlintRationalField # TODO: port this to Nemo
+function _iso_oscar_gap(F::FlintRationalField)
    return MapFromFunc(x -> GAP.Obj(x), x -> fmpq(x), F, GAP.Globals.Rationals)
 end
 
@@ -110,7 +111,7 @@ end
 # General number fields will require caching,
 # in order to achieve that Oscar matrix groups over the same number field
 # are mapped to GAP matrix groups over the same `AlgebraicExtension` field.
-function iso_oscar_gap(F::AnticNumberField)
+function _iso_oscar_gap(F::AnticNumberField)
 
    flag, N = Hecke.iscyclotomic_type(F)
    flag || error("$F is not a cyclotomic field")
@@ -138,6 +139,12 @@ function iso_oscar_gap(F::AnticNumberField)
    end
 
    return MapFromFunc(f, finv, F, G)
+end
+
+function iso_oscar_gap(F)
+   return get_attribute!(F, :iso_oscar_gap) do
+      return _iso_oscar_gap(F)
+   end
 end
 
 #TODO function iso_oscar_gap(F::T) where T <: QabField

--- a/test/GAP/gap_to_oscar.jl
+++ b/test/GAP/gap_to_oscar.jl
@@ -115,9 +115,31 @@ end
     @test_throws GAP.ConversionError GAP.gap_to_julia(fmpq_mat, val)
 end
 
+@testset "finite field elements" begin
+  @testset "with characteristic $p" for p in [ 5, fmpz(5), 65537, fmpz(65537) ]
+    @testset "with finite field $F" for F in [ GF(p), GF(p,1), GF(p,2) ]
+        x = F(2)
+        q = order(F)
+
+        # GAP large integers
+        val = GAP.evalstr( "2+$p*2^65" )
+        @test F(val) == x
+
+        # finite field elements from prime field
+        z_gap = GAP.evalstr( "Z($p)" )
+        @test F(z_gap)^2 == F(z_gap^2)
+
+        # finite field elements from full field
+        # FIXME: this is not yet implemented in general
+        #z_gap = GAP.evalstr( "Z($q)" )
+        #@test F(z_gap)^2 == F(z_gap^2)
+    end
+  end
+end
+
 @testset "finite field matrix" begin
   @testset "with characteristic $p" for p in [ 5, fmpz(5), 65537, fmpz(65537) ]
-    @testset "with finite field $F" for F in [ GF(p), FiniteField(p,1,"a")[1], FiniteField(p,2,"a")[1] ]
+    @testset "with finite field $F" for F in [ GF(p), GF(p,1), GF(p,2) ]
         x = F[1 2; 3 4]
 
         # matrix of small (GAP) integers

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -2,7 +2,7 @@
 
    @testset for (p,d) in [(2,1),(5,1),(2,4),(3,3),(2,8)]
       F = GF(p,d)
-      f = Oscar.ring_iso_oscar_gap(F)
+      f = Oscar.iso_oscar_gap(F)
       g = elm -> map_entries(f, elm)
       for a in F
          for b in F
@@ -23,7 +23,7 @@
    # (Oscar chooses a polynomial that is not a Conway polynomial.)
    p = next_prime(10^6)
    F = GF(p, 2)
-   f = Oscar.ring_iso_oscar_gap(F)
+   f = Oscar.iso_oscar_gap(F)
    for x in [ F(3), gen(F) ]
       a = f(x)
       @test preimage(f, a) == x
@@ -109,7 +109,7 @@ end
    push!(fields, (QQ, 1))
 
    @testset for (F, z) in fields
-      f = Oscar.ring_iso_oscar_gap(F)
+      f = Oscar.iso_oscar_gap(F)
       g = elm -> map_entries(f, elm)
       for i in 1:10
          a = my_rand_bits(F, 5)


### PR DESCRIPTION
TODO: remove old code, compare performance before/after, tweak performance, fix test failure:
```
with finite field Finite field of degree 2 over F_65537: Error During Test at /Users/mhorn/Projekte/OSCAR/Oscar.spielwiese/test/GAP/gap_to_oscar.jl:130
  Test threw exception
  Expression: F(z_gap) ^ 2 == F(z_gap ^ 2)
  Error thrown by GAP: Error, no method found! For debugging hints type ?Recovery from NoMethodFound
  Error, no 2nd choice method found for `Coefficients' on 2 arguments at /Users/mhorn/.julia/artifacts/1ae5d8f1898d9dcbe8dc3d93f56369c864a8e717/share/gap/lib/methsel2.g:249 called from
  <function "HANDLE_METHOD_NOT_FOUND">( <arguments> )
   called from read-eval loop at *defin*:0

  Stacktrace:
    [1] error(s::String)
      @ Base ./error.jl:33
    [2] ThrowObserver(depth::Int32)
      @ GAP ~/.julia/packages/GAP/h4tDv/src/GAP.jl:51
    [3] _call_gap_func(func::GapObj, a1::GapObj, a2::GapObj)
      @ GAP ~/.julia/packages/GAP/h4tDv/src/ccalls.jl:270
    [4] macro expansion
      @ ~/Projekte/OSCAR/Oscar.spielwiese/src/GAP/wrappers.jl:19 [inlined]
    [5] Coefficients(x::GapObj, y::GapObj)
      @ Oscar.GAPWrap ~/Projekte/OSCAR/Oscar.spielwiese/src/GAP/wrappers.jl:19
    [6] (::Oscar.var"#finv#229"{Vector{fq}, Int64})(x::GapObj)
      @ Oscar ~/Projekte/OSCAR/Oscar.spielwiese/src/Groups/matrices/iso_oscar_gap.jl:98
    [7] (::FqFiniteField)(x::GapObj)
      @ Oscar ~/Projekte/OSCAR/Oscar.spielwiese/src/GAP/gap_to_oscar.jl:64
    [8] macro expansion
      @ ~/Projekte/OSCAR/Oscar.spielwiese/test/GAP/gap_to_oscar.jl:130 [inlined]
...
```