### PR TITLE
added `maximal_abelian_quotient`

### DIFF
--- a/docs/src/Groups/quotients.md
+++ b/docs/src/Groups/quotients.md
@@ -43,3 +43,7 @@ julia> isisomorphic(G,symmetric_group(3))[1]
 true
 ```
 Similarly to the subgroups, the output consists of a pair (`Q`,`p`), where `Q` is the quotient group and `p` is the projection homomorphism of `G` into `Q`.
+
+```@docs
+maximal_abelian_quotient
+```

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -372,8 +372,20 @@ function maximal_abelian_quotient(G::GAPGroup)
   map = GAP.Globals.MaximalAbelianQuotient(G.X)
   F = GAP.Globals.Range(map)
   if GAP.Globals.IsFinite(F)
+    # force `PcGroup`
+    if !GAP.Globals.IsPcGroup(F)
+      map2 = GAP.Globals.IsomorphismPcGroup(F)
+      F = GAP.Globals.Range(map2)
+      map = GAP.Globals.CompositionMapping(map2, map)
+    end
     F = PcGroup(F)
   else
+    if !GAP.Globals.IsFpGroup(F)
+      map2 = GAP.Globals.IsomorphismFpGroup(F)
+#TODO: This does not work for example for infinite cyclic matrix groups.
+      F = GAP.Globals.Range(map2)
+      map = GAP.Globals.CompositionMapping(map2, map)
+    end
     F = FPGroup(F)
   end
   return F, _hom_from_gap_map(G, F, map)

--- a/test/Groups/quotients.jl
+++ b/test/Groups/quotients.jl
@@ -1,3 +1,72 @@
+@testset "quo for trivial kernel" begin
+   @testset for G in [symmetric_group(4), special_linear_group(2, 3), special_linear_group(2, 4), free_group(1), abelian_group(PcGroup, [2, 3, 4])]
+      subgens = elem_type(G)[]
+      F, epi = quo(G, subgens)
+      if isfinite(G)
+        @test order(F) == order(G)
+      else
+        @test ! isfinite(F)
+      end
+   end
+end
+
+@testset "types of factor groups" begin
+   # - `quo` without prescribed type:
+   #   same type as the input type if the kernel is trivial,
+   #   otherwise `PcGroup` if solvable, `PermGroup` if not
+   # - `quo` with prescribed type:
+   #    return a group of this type if possible
+   G = symmetric_group(4)
+   N = pcore(G, 2)[1]
+   for subgens in [N, gens(N)]
+      @test quo(G, subgens)[1] isa PcGroup
+      @test quo(PermGroup, G, subgens)[1] isa PermGroup
+   end
+   N = trivial_subgroup(G)[1]
+   for subgens in [N, gens(N)]
+      @test quo(G, subgens)[1] isa PermGroup
+      @test quo(PcGroup, G, subgens)[1] isa PcGroup
+   end
+   G = special_linear_group(2, 5)
+   N = centre(G)[1]
+   for subgens in [N, gens(N)]
+      @test quo(G, subgens)[1] isa PermGroup
+      @test quo(FPGroup, G, subgens)[1] isa FPGroup
+      @test_throws ErrorException quo(PcGroup, G, subgens)
+   end
+   N = trivial_subgroup(G)[1]
+   for subgens in [N, gens(N)]
+      @test quo(G, subgens)[1] isa MatrixGroup
+      @test quo(PermGroup, G, subgens)[1] isa PermGroup
+      @test_throws ErrorException quo(PcGroup, G, subgens)
+   end
+
+   # - `maximal_abelian_quotient` without prescribed type:
+   #   same type as the input type if abelian,
+   #   otherwise `PcGroup` if finite, `FPGroup` if not
+   # - `maximal_abelian_quotient` with prescribed type:
+   #    return a group of this type if possible
+   for T in [ PermGroup, PcGroup ]
+      G = abelian_group(T, [2, 3, 4])
+      @test maximal_abelian_quotient(G)[1] isa T
+      @test maximal_abelian_quotient(PermGroup, G)[1] isa PermGroup
+   end
+   T = FPGroup
+   G = abelian_group(T, [2, 3, 4])
+   @test maximal_abelian_quotient(G)[1] isa PcGroup
+   @test maximal_abelian_quotient(PermGroup, G)[1] isa PermGroup
+   G = symmetric_group(4)
+   @test maximal_abelian_quotient(G)[1] isa PcGroup
+   @test maximal_abelian_quotient(PermGroup, G)[1] isa PermGroup
+   G = special_linear_group(2, 3)
+   @test maximal_abelian_quotient(G)[1] isa PcGroup
+   @test maximal_abelian_quotient(PermGroup, G)[1] isa PermGroup
+   G = free_group(1)
+   @test maximal_abelian_quotient(G)[1] isa FPGroup
+   @test maximal_abelian_quotient(FPGroup, G)[1] isa FPGroup
+   @test_throws MethodError quo(PcGroup, G)
+end
+
 @testset "Finitely presented groups" begin
    F = free_group(2)
    x,y = gens(F)


### PR DESCRIPTION
@fieker had mentioned that this function is missing in Oscar.
Although the function is trivial, I have a conceptual question concerning the caching of known attribute values.

On the GAP side, functions return only one object, and if the GAP function is an attribute then this object can be cached; in this example, `MaximalAbelianQuotient( G )` returns the epimorphism from `G` to an abelian group.
On the Oscar side, it is common to have several return values. The general `quo(G, N)` returns a pair `(F, epi)`, where `epi` is the epimorphism and `F` is its image, and the same format is used also for `F, epi = maximal_abelian_quotient(G)`.
Caching on the GAP side means that the GAP map (`epi.map`) is stored in `G`, and `hasmaximal_abelian_quotient(G)` returns `true`.
(Currently we are not caching the value on the Oscar side, thus each call `maximal_abelian_quotient(G)` constructs a new object `epi` around the known GAP map.)
The idea behind setters, here `setmaximal_abelian_quotient(G, val)`, is that one can avoid the computation if one knows the value, for example because `quo(G, derived_subgroup(G))` has been computed before.
What should be the format of `val`? In this pull request, I have assumed that `val` is the pair `(F, epi)`. If this is the rule then we have to change other pieces of code (such as `setderived_subgroup`), and `@gapattribute` cannot proceed as it does.