### PR TITLE
Allow more graded ops

### DIFF
--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -463,7 +463,7 @@ function primary_decomposition(I::MPolyIdeal; alg=:GTZ)
 end
 ########################################################
 @doc Markdown.doc"""
-    absolute_primary_decomposition(I::MPolyIdeal{fmpq_mpoly})
+    absolute_primary_decomposition(I::MPolyIdeal{<:MPolyElem{fmpq}})
 
 If `I` is an ideal in a multivariate polynomial ring over the rationals, return an absolute minimal primary decomposition of `I`. 
 
@@ -517,7 +517,7 @@ julia> minpoly(a)
 x^2 + 1
 ```
 """
-function absolute_primary_decomposition(I::MPolyIdeal{fmpq_mpoly})
+function absolute_primary_decomposition(I::MPolyIdeal{<:MPolyElem{fmpq}})
   R = base_ring(I)
   singular_assure(I)
   (S, d) = Singular.LibPrimdec.absPrimdecGTZ(I.gens.Sx, I.gens.S)

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -536,7 +536,6 @@ end
 function _map_to_ext(Qx::MPolyRing, I::Oscar.Singular.sideal)
   Qxa = base_ring(I)
   @assert nvars(Qxa) == nvars(Qx) + 1
-  # TODO AbstractAlgebra's coefficients_of_univariate is still broken
   p = I[1]
   minpoly = zero(Hecke.Globals.Qx)
   for (c, e) in zip(coefficients(p), exponent_vectors(p))

--- a/test/Rings/mpoly-test.jl
+++ b/test/Rings/mpoly-test.jl
@@ -219,6 +219,11 @@ end
                             MPolyIdeal{fmpq_mpoly},
                             MPolyIdeal{AbstractAlgebra.Generic.MPoly{nf_elem}},
                             Int}})
+
+  R,(x,y,z) = GradedPolynomialRing(QQ, ["x", "y", "z"])
+  I = ideal(R, [(z+y)*(z^2+y^2)*(z^3+2*y^3)^2, x^3-y*z^2])
+  d = absolute_primary_decomposition(I)
+  @test length(d) == 5
 end
 
 @testset "Groebner" begin

--- a/test/Rings/mpoly-test.jl
+++ b/test/Rings/mpoly-test.jl
@@ -215,10 +215,6 @@ end
   I = ideal(R, [(z+1)*(z^2+1)*(z^3+2)^2, x-y*z^2])
   d = absolute_primary_decomposition(I)
   @test length(d) == 3
-  @test isa(d, Vector{Tuple{MPolyIdeal{fmpq_mpoly},
-                            MPolyIdeal{fmpq_mpoly},
-                            MPolyIdeal{AbstractAlgebra.Generic.MPoly{nf_elem}},
-                            Int}})
 
   R,(x,y,z) = GradedPolynomialRing(QQ, ["x", "y", "z"])
   I = ideal(R, [(z+y)*(z^2+y^2)*(z^3+2*y^3)^2, x^3-y*z^2])


### PR DESCRIPTION
@wdecker  You can cover more types by changing `::MPolyIdeal{fmpq_mpoly})` to `::MPolyIdeal{<:MPolyElem{fmpq}}` in the signature.