### PR TITLE
renamed `centre` to `center`

### DIFF
--- a/docs/src/Groups/subgroups.md
+++ b/docs/src/Groups/subgroups.md
@@ -34,7 +34,7 @@ of the same type of `G` and `f` is the embedding homomorphism of `H` into `G`.
 
 ```@docs
 trivial_subgroup
-centre
+center(G::GAPGroup)
 sylow_subgroup(G::GAPGroup, p::IntegerUnion)
 derived_subgroup
 fitting_subgroup

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -866,7 +866,7 @@ For other groups, the function tries to decompose `G` as a direct product
 or a semidirect product,
 and if this is not possible as a non-splitting extension of
 a normal subgroup $N$ with the factor group `G`$/N$,
-where $N$ is the centre or the derived subgroup or the Frattini subgroup
+where $N$ is the center or the derived subgroup or the Frattini subgroup
 of `G`.
 
 Note that

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -1,6 +1,6 @@
 export
     centralizer,
-    centre, hascentre, setcentre,
+    center, hascenter, setcenter,
     characteristic_subgroups, hascharacteristic_subgroups, setcharacteristic_subgroups,
     derived_series, hasderived_series, setderived_series,
     derived_subgroup, hasderived_subgroup, setderived_subgroup,
@@ -207,13 +207,13 @@ i.e., those subgroups that are invariant under all automorphisms of `G`.
   _as_subgroups(G, GAP.Globals.CharacteristicSubgroups(G.X))
 
 @doc Markdown.doc"""
-    centre(G::Group)
+    center(G::Group)
 
-Return the centre of `G`, i.e.,
+Return the center of `G`, i.e.,
 the subgroup of all $x$ in `G` such that $x y$ equals $y x$ for every $y$
 in `G`, together with its embedding morphism into `G`.
 """
-@gapattribute centre(G::GAPGroup) = _as_subgroup(G, GAP.Globals.Centre(G.X))
+@gapattribute center(G::GAPGroup) = _as_subgroup(G, GAP.Globals.Centre(G.X))
 
 @doc Markdown.doc"""
     centralizer(G::Group, H::Group)

--- a/test/Groups/directproducts.jl
+++ b/test/Groups/directproducts.jl
@@ -148,7 +148,7 @@ end
    @test index(G,H)==4
    @test !isfull_semidirect_product(H)
    @test projection(G)(x)==projection(H)(x)
-   @test H==centre(G)[1]
+   @test H==center(G)[1]
    y=G(Q[1],one(C))
    K = sub(G,gens(G))[1]
 #   @test isfull_semidirect_product(K)

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -146,7 +146,7 @@ end
 @testset "Cosets" begin
   
    G = dihedral_group(8)
-   H, mH = centre(G)
+   H, mH = center(G)
   
    @test index(G, H) == 4
   
@@ -250,7 +250,7 @@ end
 @testset "Predicates for groups" begin
    @test !issimple(alternating_group(4))
    @test issimple(alternating_group(5))
-   @test issimple(quo(SL(4,3), centre(SL(4,3))[1])[1])
+   @test issimple(quo(SL(4,3), center(SL(4,3))[1])[1])
 
    @test isalmostsimple(symmetric_group(5))
    @test !issimple(symmetric_group(5))
@@ -329,8 +329,8 @@ end
    @test fitting_subgroup(S)==sub(S,[S([3,4,1,2]), S([4,3,2,1])])
    @test frattini_subgroup(S)==sub(S,[one(S)])
    @test frattini_subgroup(G)[1]==intersect(maximal_subgroups(G))[1]
-   @test frattini_subgroup(G)==centre(G)
-   @test ischaracteristic(G,centre(G)[1])
+   @test frattini_subgroup(G)==center(G)
+   @test ischaracteristic(G,center(G)[1])
    @test socle(G)==frattini_subgroup(G)
    @test socle(S)==fitting_subgroup(S)   
    @test radical_subgroup(S)[1]==S


### PR DESCRIPTION
There was already `center` in Hecke.
Up to now, the groups code had introduced `centre` (and `hascentre`, `setcentre`).

Should we reintroduce `centre` as an alias for `center`?
If yes then where is the appropriate place for such aliases?