### PR TITLE
small additions concerning irrationalities

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -98,6 +98,19 @@
   year          = {1999}
 }
 
+@Book{CCNPW85,
+  author        = {Conway, J. H. and Curtis, R. T. and Norton, S. P. and
+                  Parker, R. A. and Wilson, R. A.},
+  title         = {Atlas of finite groups},
+  publisher     = {Oxford University Press},
+  address       = {Eynsham},
+  year          = {1985},
+  pages         = {xxxiv+252},
+  note          = {Maximal subgroups and ordinary characters for simple
+                  groups, With computational assistance from J. G. Thackray},
+  mrnumber      = {827219 (88g:20025)}
+}
+
 @Book{CLS11,
   author        = {Cox, David A. and Little, John B. and Schenck, Henry K.},
   title         = {Toric varieties},

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -7,21 +7,6 @@ import Oscar:gmodule, GAPWrap
 import AbstractAlgebra: Group, Module
 import Base: parent
 
-function GAP.gap_to_julia(::Type{QabElem}, a::GAP.GapObj) #which should be a Cyclotomic
-  c = GAPWrap.Conductor(a)
-  E = abelian_closure(QQ)[2](c)
-  z = parent(E)(0)
-  co = GAP.Globals.CoeffsCyc(a, c)
-  for i=1:c
-    if !iszero(co[i])
-      z += fmpq(co[i])*E^(i-1)
-    end
-  end
-  return z
-end
-
-(::QabField)(a::GAP.GapObj) = GAP.gap_to_julia(QabElem, a)
-
 function irreducible_modules(G::Oscar.GAPGroup)
   im = GAP.Globals.IrreducibleRepresentations(G.X)
   IM = GModule[] 

--- a/test/GAP/gap_to_oscar.jl
+++ b/test/GAP/gap_to_oscar.jl
@@ -178,8 +178,11 @@ end
     @test x == fmpz(2)^64
 
     F, z = abelian_closure(QQ)
-    x = QabElem(GAP.evalstr("EB(5)"))
+    val = GAP.evalstr("EB(5)")
+    x = QabElem(val)
     @test x == z(5) + z(5)^4
+    @test F(val) == x
+    @test GAP.gap_to_julia(QabElem, val) == x
 
     # not supported conversions
     F, z = quadratic_field(5)
@@ -195,7 +198,7 @@ end
     a = GAP.Globals.PrimitiveElement(gapF)
     @test_throws ArgumentError F(a)
 
-    @test_throws ErrorException QabElem(GAP.evalstr("[ E(3) ]"))
+    @test_throws GAP.ConversionError QabElem(GAP.evalstr("[ E(3) ]"))
 end
 
 @testset "matrices over a cyclotomic field" begin

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -407,6 +407,32 @@ end
   @test mod(t, 2) == nothing
 end
 
+@testset "natural characters" begin
+  G = symmetric_group(4)
+  chi = Oscar.natural_character(G)
+  @test degree(chi) == 4
+  psi = chi
+  @test scalar_product(chi, psi) == 2
+  @test scalar_product(chi, chi) == 2
+  @test scalar_product(chi, trivial_character(G)) == 1
+
+  K, a = CyclotomicField(5, "a")
+  L, b = CyclotomicField(3, "b")
+
+  inputs = [
+    #[ matrix(ZZ, [0 1 0; -1 0 0; 0 0 -1]) ],
+    [ matrix(QQ, [0 1 0; -1 0 0; 0 0 -1]) ],
+    [ matrix(K, [a 0; 0 a]) ],
+    [ matrix(L, 2, 2, [b, 0, -b - 1, 1]), matrix(L, 2, 2, [1, b + 1, 0, b]) ],
+  ]
+
+  @testset "... over ring $(base_ring(mats[1]))" for mats in inputs
+    G = matrix_group(mats)
+    chi = Oscar.natural_character(G)
+    @test degree(chi) == degree(G)
+  end
+end
+
 @testset "character fields" begin
   for id in [ "C5", "A5" ]   # cyclotomic and non-cyclotomic number fields
     for chi in character_table(id)


### PR DESCRIPTION
- added `atlas_irrationality`
- added `natural_character`
- moved the `QabElem` constructions for GAP cyclotomics from `experimental/GModule.jl` to `src/GAP` (this code is apparently better than the `QabElem` method that was already available in `src/GAP/gap_to_oscar.jl`)