### PR TITLE
ToricVarieties: Computation of Betti numbers limited to complete, simplicial varieties

### DIFF
--- a/src/ToricVarieties/NormalToricVarieties/methods.jl
+++ b/src/ToricVarieties/NormalToricVarieties/methods.jl
@@ -5,9 +5,18 @@
 @doc Markdown.doc"""
     betti_number(v::AbstractNormalToricVariety, i::Int)
 
-Compute the `i`-th Betti number of the normal toric variety `v`.
+Compute the `i`-th Betti number of the normal toric variety `v`. 
+Specifically, this method returns the dimension of the i-th 
+simplicial homology group (with rational coefficients) of `v`. 
+The employed algorithm is derived from theorem 12.3.12 in 
+[CLS11](@cite). Note that this theorem requires that the normal 
+toric variety `v` is both complete and simplicial.
 """
 function betti_number(v::AbstractNormalToricVariety, i::Int)
+    if (!iscomplete(v) || !issimplicial(v))
+        throw(ArgumentError("Currently, the computation of Betti numbers is limited to complete and simplicial toric varieties."))
+    end
+    
     # check input
     d = dim(v)::Int
     if i > 2*d || i < 0 || isodd(i)


### PR DESCRIPTION
This PR aims towards closing https://github.com/oscar-system/Oscar.jl/issues/1023.

Specifically:
- The current algorithms for Betti numbers of toric varieties are limited to complete simplicial varieties.
- Check this in the implementation and raise and error if the input variety does not satisfy these conditions.
- Explain this limitation in the documentation.