### PR TITLE
changed `compose` in `src/Groups` ...

### DIFF
--- a/docs/src/Groups/grouphom.md
+++ b/docs/src/Groups/grouphom.md
@@ -118,7 +118,7 @@ Oscar supports the following operations on homomorphisms.
 * `f^n` = the homomorphism `f` composed `n` times with itself.
   An exception is thrown if the domain and the codomain of `f` do not coincide
   (unless `n=1`). If `n` is negative, the result is the inverse of `f` composed `n` times with itself.
-* `compose(g,f)` = composition of `g` and `f`. This works only if the codomain of `g` coincide with the domain of `f`. Shorter equivalent expressions are `g*f` and `f(g)`.
+* `compose(f, g)` = composition of `f` and `g`. This works only if the codomain of `f` coincides with the domain of `g`. Shorter equivalent expressions are `f*g` and `g(f)`.
 
   **Example:**
 ```jldoctest

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -37,7 +37,7 @@ function ==(f::GAPGroupHomomorphism{S,T}, g::GAPGroupHomomorphism{S,T}) where S 
    return f.map == g.map
 end
 
-Base.:*(f::GAPGroupHomomorphism{S, T}, g::GAPGroupHomomorphism{T, U}) where S where T where U = compose(g, f)
+Base.:*(f::GAPGroupHomomorphism{S, T}, g::GAPGroupHomomorphism{T, U}) where S where T where U = compose(f, g)
 
 function Base.inv(f::GAPGroupHomomorphism{S,T}) where S where T
    @assert GAPWrap.IsBijective(f.map) "f is not bijective"
@@ -55,7 +55,7 @@ function Base.:^(f::GAPGroupHomomorphism{S,T}, n::Int64) where S where T
    end
 end
 
-function compose(g::GAPGroupHomomorphism{T, U}, f::GAPGroupHomomorphism{S, T}) where S where T where U
+function compose(f::GAPGroupHomomorphism{S, T}, g::GAPGroupHomomorphism{T, U}) where {S, T, U}
   dom = domain(f)
   cod = codomain(g)
   @assert codomain(f) == domain(g)
@@ -63,7 +63,7 @@ function compose(g::GAPGroupHomomorphism{T, U}, f::GAPGroupHomomorphism{S, T}) w
   return GAPGroupHomomorphism(dom, cod, mp)
 end
 
-#(g::GAPGroupHomomorphism{T, U})(f::GAPGroupHomomorphism{S, T}) where {S,T,U} = compose(g,f)
+#(g::GAPGroupHomomorphism{T, U})(f::GAPGroupHomomorphism{S, T}) where {S,T,U} = compose(f,g)
 
 """
     id_hom(G::GAPGroup)

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -324,7 +324,7 @@ function quo(::Type{Q}, G::T, elements::Vector{S}) where {Q <: GAPGroup, T <: GA
   F, epi = quo(G, elements)
   if !(F isa Q)
     F, map = isomorphic_group(Q, F)
-    epi = compose(map, epi)
+    epi = compose(epi, map)
   end
   return F, epi
 end
@@ -373,7 +373,7 @@ function quo(::Type{Q}, G::T, N::T) where {Q <: GAPGroup, T <: GAPGroup}
   F, epi = quo(G, N)
   if !(F isa Q)
     F, map = isomorphic_group(Q, F)
-    epi = compose(map, epi)
+    epi = compose(epi, map)
   end
   return F, epi
 end
@@ -426,7 +426,7 @@ function maximal_abelian_quotient(::Type{Q}, G::GAPGroup) where Q <: GAPGroup
   F, epi = maximal_abelian_quotient(G)
   if !(F isa Q)
     F, map = isomorphic_group(Q, F)
-    epi = compose(map, epi)
+    epi = compose(epi, map)
   end
   return F, epi
 end

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -314,3 +314,12 @@ end
    @test isisomorphic(A,GL(2,3))[1]
    @test order(inner_automorphisms_group(A)[1])==1
 end
+
+@testset "Composition of mappings" begin
+   g = symmetric_group(4)
+   q, epi = quo(g, pcore(g, 2)[1])
+   F, iso = isomorphic_perm_group(q)
+   comp = compose(epi, iso)
+   @test domain(comp) == domain(epi)
+   @test codomain(comp) == codomain(iso)
+end


### PR DESCRIPTION
... such that `compose(f, g)` maps `x` to `g(f(x))`.

As is stated in the discussion of issue #690, the definition from [the AbstractAlgebra manual section for the Map interface](https://oscar-system.github.io/Oscar.jl/dev/AbstractAlgebra/map_interface/#Composition-of-maps) should be used consistently.