### PR TITLE
Replace arbitrary 'authors' list by a generic entry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oscar"
 uuid = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
-authors = ["Claus Fieker <fieker@mathematik.uni-kl.de>", "Giovanni De Franceschi <franceschi@mathematik.uni-kl.de>", "Johannes Schmitt <schmitt@mathematik.uni-kl.de>", "Max Horn <horn@mathematik.uni-kl.de>", "William Hart <goodwillhart@googlemail.com>", "Taylor Brysiewicz <taylor.brysiewicz@mis.mpg.de>", "Michael Joswig <joswig@math.tu-berlin.de>", "Marek Kaluba <kalmar@amu.edu.pl>", "Sascha Timme <sascha.timme@googlemail.com>", "Sebastian Gutsche <gutsche@momo.math.rwth-aachen.de>"]
+authors = ["The OSCAR Team <oscar@mathematik.uni-kl.de>"]
 version = "0.8.0-DEV"
 
 [deps]


### PR DESCRIPTION
To find contributors, one may consult the git history, or our website:
<https://oscar.computeralgebra.de/contributors/>
