### PR TITLE
ToricVarieties/PolyhedralGeometry: Introduce FanLikeType

### DIFF
--- a/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
@@ -284,7 +284,7 @@ end
 
 lineality_space(PC::PolyhedralComplex) = SubObjectIterator{RayVector{Polymake.Rational}}(pm_object(PC), _lineality_polyhedron, lineality_dim(PC))
 
-lineality_dim(PC::PolyhedralComplex) = pm_object(PC).LINEALITY_DIM
+lineality_dim(PC::PolyhedralComplex) = pm_object(PC).LINEALITY_DIM::Int
 
 
 @doc Markdown.doc"""

--- a/src/PolyhedralGeometry/PolyhedralFan/constructors.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/constructors.jl
@@ -4,6 +4,12 @@
 ###############################################################################
 ###############################################################################
 
+# We introduce this abstract (hidden) type to allow for other objects to be
+# used like polyhedral fans without duplicating too much code, concretely we
+# want to be able to directly access rays, maximal_cones, etc for
+# NormalToricVariety's.
+abstract type _FanLikeType end
+
 @doc Markdown.doc"""
     PolyhedralFan(Rays::Union{Oscar.MatElem, AbstractMatrix, SubObjectIterator}, [LS::Union{Oscar.MatElem, AbstractMatrix, SubObjectIterator},] Cones::IncidenceMatrix)
 
@@ -33,7 +39,7 @@ A polyhedral fan in ambient dimension 2
 julia> iscomplete(PF)
 true
 """
-struct PolyhedralFan
+struct PolyhedralFan <: _FanLikeType
    pm_fan::Polymake.BigObject
    function PolyhedralFan(pm::Polymake.BigObject)
       return new(pm)

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -126,7 +126,7 @@ julia> dim(PF)
 2
 ```
 """
-dim(PF::_FanLikeType) = pm_object(PF).FAN_DIM
+dim(PF::_FanLikeType) = pm_object(PF).FAN_DIM::Int
 
 @doc Markdown.doc"""
     n_maximal_cones(PF::PolyhedralFan)
@@ -143,7 +143,7 @@ julia> n_maximal_cones(PF)
 2
 ```
 """
-n_maximal_cones(PF::_FanLikeType) = pm_object(PF).N_MAXIMAL_CONES
+n_maximal_cones(PF::_FanLikeType) = pm_object(PF).N_MAXIMAL_CONES::Int
 
 @doc Markdown.doc"""
     ambient_dim(PF::PolyhedralFan)
@@ -161,7 +161,7 @@ julia> ambient_dim(normal_fan(cube(4)))
 4
 ```
 """
-ambient_dim(PF::_FanLikeType) = pm_object(PF).FAN_AMBIENT_DIM
+ambient_dim(PF::_FanLikeType) = pm_object(PF).FAN_AMBIENT_DIM::Int
 
 @doc Markdown.doc"""
     nrays(PF::PolyhedralFan)
@@ -175,7 +175,7 @@ julia> nrays(face_fan(cube(3)))
 8
 ```
 """
-nrays(PF::_FanLikeType) = pm_object(PF).N_RAYS
+nrays(PF::_FanLikeType) = pm_object(PF).N_RAYS::Int
 
 
 @doc Markdown.doc"""
@@ -239,7 +239,7 @@ julia> lineality_dim(nf)
 1
 ```
 """
-lineality_dim(PF::_FanLikeType) = pm_object(PF).LINEALITY_DIM
+lineality_dim(PF::_FanLikeType) = pm_object(PF).LINEALITY_DIM::Int
 
 ###############################################################################
 ## Points properties

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -27,7 +27,7 @@ julia> rays(NF)
  [0, 0, -1]
 ```
 """
-rays(PF::PolyhedralFan) = SubObjectIterator{RayVector{Polymake.Rational}}(pm_object(PF), _ray_fan, pm_object(PF).N_RAYS)
+rays(PF::_FanLikeType) = SubObjectIterator{RayVector{Polymake.Rational}}(pm_object(PF), _ray_fan, pm_object(PF).N_RAYS)
 
 _ray_fan(::Type{RayVector{Polymake.Rational}}, PF::Polymake.BigObject, i::Base.Integer) = RayVector(PF.RAYS[i, :])
 
@@ -59,7 +59,7 @@ julia> for c in maximal_cones(PF)
 4
 ```
 """
-maximal_cones(PF::PolyhedralFan) = SubObjectIterator{Cone}(pm_object(PF), _maximal_cone, n_maximal_cones(PF))
+maximal_cones(PF::_FanLikeType) = SubObjectIterator{Cone}(pm_object(PF), _maximal_cone, n_maximal_cones(PF))
 
 _ray_indices(::Val{_maximal_cone}, obj::Polymake.BigObject) = obj.MAXIMAL_CONES
 
@@ -89,7 +89,7 @@ julia> cones(PF, 2)
  A polyhedral cone in ambient dimension 3
 ```
 """
-function cones(PF::PolyhedralFan, cone_dim::Int)
+function cones(PF::_FanLikeType, cone_dim::Int)
     l = cone_dim  - length(lineality_space(PF))
     l < 1 && return nothing
     return SubObjectIterator{Cone}(pm_object(PF), _cone_of_dim, size(Polymake.fan.cones_of_dim(pm_object(PF), l), 1), (c_dim = l,))
@@ -126,7 +126,7 @@ julia> dim(PF)
 2
 ```
 """
-dim(PF::PolyhedralFan) = pm_object(PF).FAN_DIM
+dim(PF::_FanLikeType) = pm_object(PF).FAN_DIM
 
 @doc Markdown.doc"""
     n_maximal_cones(PF::PolyhedralFan)
@@ -143,7 +143,7 @@ julia> n_maximal_cones(PF)
 2
 ```
 """
-n_maximal_cones(PF::PolyhedralFan) = pm_object(PF).N_MAXIMAL_CONES
+n_maximal_cones(PF::_FanLikeType) = pm_object(PF).N_MAXIMAL_CONES
 
 @doc Markdown.doc"""
     ambient_dim(PF::PolyhedralFan)
@@ -161,7 +161,7 @@ julia> ambient_dim(normal_fan(cube(4)))
 4
 ```
 """
-ambient_dim(PF::PolyhedralFan) = pm_object(PF).FAN_AMBIENT_DIM
+ambient_dim(PF::_FanLikeType) = pm_object(PF).FAN_AMBIENT_DIM
 
 @doc Markdown.doc"""
     nrays(PF::PolyhedralFan)
@@ -175,7 +175,7 @@ julia> nrays(face_fan(cube(3)))
 8
 ```
 """
-nrays(PF::PolyhedralFan) = pm_object(PF).N_RAYS
+nrays(PF::_FanLikeType) = pm_object(PF).N_RAYS
 
 
 @doc Markdown.doc"""
@@ -207,7 +207,7 @@ julia> f_vector(nfc)
   8
 ```
 """
-function f_vector(PF::PolyhedralFan)
+function f_vector(PF::_FanLikeType)
     pmf = pm_object(PF)
     ldim = pmf.LINEALITY_DIM
     return vcat(fill(0,ldim),pmf.F_VECTOR)
@@ -239,7 +239,7 @@ julia> lineality_dim(nf)
 1
 ```
 """
-lineality_dim(PF::PolyhedralFan) = pm_object(PF).LINEALITY_DIM
+lineality_dim(PF::_FanLikeType) = pm_object(PF).LINEALITY_DIM
 
 ###############################################################################
 ## Points properties
@@ -264,7 +264,7 @@ julia> lineality_space(PF)
  [1, 0]
 ```
 """
-lineality_space(PF::PolyhedralFan) = SubObjectIterator{RayVector{Polymake.Rational}}(pm_object(PF), _lineality_fan, lineality_dim(PF))
+lineality_space(PF::_FanLikeType) = SubObjectIterator{RayVector{Polymake.Rational}}(pm_object(PF), _lineality_fan, lineality_dim(PF))
 
 _lineality_fan(::Type{RayVector{Polymake.Rational}}, PF::Polymake.BigObject, i::Base.Integer) = RayVector(PF.LINEALITY_SPACE[i, :])
 
@@ -299,7 +299,7 @@ julia> lineality_dim(nf)
 1
 ```
 """
-ispointed(PF::PolyhedralFan) = pm_object(PF).POINTED::Bool
+ispointed(PF::_FanLikeType) = pm_object(PF).POINTED::Bool
 
 
 @doc Markdown.doc"""
@@ -317,7 +317,7 @@ julia> issmooth(PF)
 false
 ```
 """
-issmooth(PF::PolyhedralFan) = pm_object(PF).SMOOTH_FAN::Bool
+issmooth(PF::_FanLikeType) = pm_object(PF).SMOOTH_FAN::Bool
 
 @doc Markdown.doc"""
     isregular(PF::PolyhedralFan)
@@ -333,7 +333,7 @@ julia> isregular(PF)
 false
 ```
 """
-isregular(PF::PolyhedralFan) = pm_object(PF).REGULAR::Bool
+isregular(PF::_FanLikeType) = pm_object(PF).REGULAR::Bool
 
 @doc Markdown.doc"""
     iscomplete(PF::PolyhedralFan)
@@ -348,7 +348,7 @@ julia> iscomplete(normal_fan(cube(3)))
 true
 ```
 """
-iscomplete(PF::PolyhedralFan) = pm_object(PF).COMPLETE::Bool
+iscomplete(PF::_FanLikeType) = pm_object(PF).COMPLETE::Bool
 
 
 @doc Markdown.doc"""
@@ -367,7 +367,7 @@ julia> issimplicial(face_fan(cube(3)))
 false
 ```
 """
-issimplicial(PF::PolyhedralFan) = pm_object(PF).SIMPLICIAL::Bool
+issimplicial(PF::_FanLikeType) = pm_object(PF).SIMPLICIAL::Bool
 
 
 ###############################################################################
@@ -386,7 +386,7 @@ julia> primitive_collections(normal_fan(simplex(3)))
  Set([4, 2, 3, 1])
 ```
 """
-function primitive_collections(PF::PolyhedralFan)
+function primitive_collections(PF::_FanLikeType)
     issimplicial(PF) || throw(ArgumentError("PolyhedralFan must be simplicial."))
     I = ray_indices(maximal_cones(PF))
     K = SimplicialComplex(I)
@@ -426,7 +426,7 @@ julia> ray_indices(maximal_cones(star))
 [1, 4, 5]
 ```
 """
-function starsubdivision(PF::PolyhedralFan, n::Int)
+function starsubdivision(PF::_FanLikeType, n::Int)
     # extract defining information on the fan
     maxcones = IncidenceMatrix(pm_object(PF).MAXIMAL_CONES)
     R = Polymake.common.primitive(pm_object(PF).RAYS)

--- a/src/PolyhedralGeometry/SubdivisionOfPoints/properties.jl
+++ b/src/PolyhedralGeometry/SubdivisionOfPoints/properties.jl
@@ -122,7 +122,7 @@ julia> ambient_dim(SOP)
 3
 ```
 """
-ambient_dim(SOP::SubdivisionOfPoints) = pm_object(SOP).VECTOR_AMBIENT_DIM - 1
+ambient_dim(SOP::SubdivisionOfPoints) = pm_object(SOP).VECTOR_AMBIENT_DIM::Int - 1
 
 
 @doc Markdown.doc"""
@@ -140,7 +140,7 @@ julia> npoints(SOP)
 6
 ```
 """
-npoints(SOP::SubdivisionOfPoints) = pm_object(SOP).N_POINTS
+npoints(SOP::SubdivisionOfPoints) = pm_object(SOP).N_POINTS::Int
 
 
 
@@ -232,4 +232,4 @@ julia> isregular(SOP)
 true
 ```
 """
-isregular(SOP::SubdivisionOfPoints) = pm_object(SOP).REGULAR
+isregular(SOP::SubdivisionOfPoints) = pm_object(SOP).REGULAR::Bool

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -87,7 +87,7 @@ function set_coordinate_names(v::AbstractNormalToricVariety, coordinate_names::V
     if has_attribute(v, :cox_ring)
         error("Cox ring already constructed. Coordinate names cannot be changed anymore.")
     end
-    if length(coordinate_names) != nrays(fan(v))
+    if length(coordinate_names) != nrays(v)
         throw(ArgumentError("The provided list of coordinate names must match the number of rays in the fan."))
     end
     set_attribute!(v, :coordinate_names, coordinate_names)
@@ -173,7 +173,7 @@ export cox_ring
 
 function _minimal_nonfaces(v::AbstractNormalToricVariety)
     return get_attribute(v, :minimal_nonfaces) do
-        I = ray_indices(maximal_cones(fan(v)))
+        I = ray_indices(maximal_cones(v))
         K = SimplicialComplex(I)
         return minimal_nonfaces(IncidenceMatrix, K)
     end
@@ -196,7 +196,7 @@ julia> ngens(stanley_reisner_ideal(R, p2))
 ```
 """
 function stanley_reisner_ideal(R::MPolyRing, v::AbstractNormalToricVariety)
-    n = nrays(fan(v))
+    n = nrays(v)
     n == nvars(R) || throw(ArgumentError("Wrong number of variables"))
     mnf = _minimal_nonfaces(v)
     return ideal([ R([1], [Vector{Int}(mnf[i,:])]) for i in 1:Polymake.nrows(mnf) ])
@@ -222,7 +222,7 @@ export stanley_reisner_ideal
 
 function _irrelevant_ideal_monomials(v::AbstractNormalToricVariety)
     return get_attribute!(v, :irrelevant_ideal_monomials) do
-        mc = ray_indices(maximal_cones(fan(v)))
+        mc = ray_indices(maximal_cones(v))
         result = Vector{Vector{Int}}()
         onesv = ones(Int, Polymake.ncols(mc))
         for i in 1:Polymake.nrows(mc)
@@ -268,7 +268,7 @@ julia> length(gens(irrelevant_ideal(R, p2)))
 """
 function irrelevant_ideal(R::MPolyRing, v::AbstractNormalToricVariety)
     monoms = _irrelevant_ideal_monomials(v)
-    nvars(R) == nrays(fan(v)) || throw(ArgumentError("Wrong number of variables in polynomial ring."))
+    nvars(R) == nrays(v) || throw(ArgumentError("Wrong number of variables in polynomial ring."))
     return ideal([R([1], [x]) for x in monoms])
 end
 export irrelevant_ideal
@@ -359,7 +359,7 @@ GrpAb: Z^2
 ```
 """
 @attr GrpAbFinGen function character_lattice(v::AbstractNormalToricVariety)
-    return free_abelian_group(ambient_dim(fan(v)))
+    return free_abelian_group(ambient_dim(v))
 end
 export character_lattice
 
@@ -378,7 +378,7 @@ GrpAb: Z^3
 ```
 """
 @attr GrpAbFinGen function torusinvariant_divisor_group(v::AbstractNormalToricVariety)
-    return free_abelian_group(nrays(fan(v)))
+    return free_abelian_group(nrays(v))
 end
 export torusinvariant_divisor_group
 
@@ -403,7 +403,7 @@ Abelian group with structure: Z^3
 ```
 """
 @attr GrpAbFinGenMap function map_from_character_to_principal_divisors(v::AbstractNormalToricVariety)
-    mat = transpose(matrix(ZZ, rays(fan(v))))
+    mat = transpose(matrix(ZZ, rays(v)))
     return hom(character_lattice(v), torusinvariant_divisor_group(v), mat)
 end
 export map_from_character_to_principal_divisors
@@ -510,8 +510,8 @@ GrpAb: Z^3
     end
 
     # identify fan_rays and cones
-    fan_rays = transpose(matrix(ZZ, rays(fan(v))))
-    max_cones = ray_indices(maximal_cones(fan(v)))
+    fan_rays = transpose(matrix(ZZ, rays(v)))
+    max_cones = ray_indices(maximal_cones(v))
     number_of_rays = ncols(fan_rays)
     number_of_cones = size(max_cones)[1]
 
@@ -722,7 +722,7 @@ A polyhedral cone in ambient dimension 2
 ```
 """
 @attr Cone function cone(v::AffineNormalToricVariety)
-    return maximal_cones(fan(v))[1]
+    return maximal_cones(v)[1]
 end
 export cone
 

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -64,29 +64,17 @@ export set_coefficient_ring
     coefficient_ring(v::AbstractNormalToricVariety)
 
 This method returns the coefficient_ring of the normal toric variety `v`.
-An error is triggered if it is not yet set.
+The default is the ring `QQ`.
 """
-function coefficient_ring(v::AbstractNormalToricVariety)
-    if !has_attribute(v, :coefficient_ring)
-        set_attribute!(v, :coefficient_ring, QQ)
-    end
-    return get_attribute(v, :coefficient_ring)
-end
-export coefficient_ring
+coefficient_ring(v::AbstractNormalToricVariety) = get_attribute!(v, :coefficient_ring, QQ)
 
 
 @doc Markdown.doc"""
     set_coordinate_names(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
 
-Allows to set the names of the homogeneous coordinates. If
-the Cox ring of the variety has already been computed, we do
-not allow changes of the coordinate names. In this case, an error
-is triggered.
+Allows to set the names of the homogeneous coordinates.
 """
 function set_coordinate_names(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
-    if has_attribute(v, :cox_ring)
-        error("Cox ring already constructed. Coordinate names cannot be changed anymore.")
-    end
     if length(coordinate_names) != nrays(v)
         throw(ArgumentError("The provided list of coordinate names must match the number of rays in the fan."))
     end
@@ -98,16 +86,10 @@ export set_coordinate_names
 @doc Markdown.doc"""
     coordinate_names(v::AbstractNormalToricVariety)
 
-This method returns the names of the homogeneous coordinates of
-the normal toric variety `v`. If they are not yet set an error is returned.
+This method returns the names of the homogeneous coordinates of 
+the normal toric variety `v`. The default is `x1,...,xn`.
 """
-function coordinate_names(v::AbstractNormalToricVariety)
-    if !has_attribute(v, :coordinate_names)
-        set_attribute!(v, :coordinate_names, ["x" * string(i) for i in 1:rank(torusinvariant_divisor_group(v))])
-    end
-    return get_attribute(v, :coordinate_names)
-end
-export coordinate_names
+coordinate_names(v::AbstractNormalToricVariety) = get_attribute!(v, :coordinate_names, ["x$(i)" for i in 1:rank(torusinvariant_divisor_group(v))])
 
 
 function _cox_ring_weights(v::AbstractNormalToricVariety)

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -3,7 +3,7 @@ import Oscar.projective_space
 ######################
 # 1: The Julia type for ToricVarieties
 ######################
-abstract type AbstractNormalToricVariety end
+abstract type AbstractNormalToricVariety <: _FanLikeType end
 
 @attributes mutable struct NormalToricVariety <: AbstractNormalToricVariety
            polymakeNTV::Polymake.BigObject

--- a/src/ToricVarieties/NormalToricVarieties/properties.jl
+++ b/src/ToricVarieties/NormalToricVarieties/properties.jl
@@ -132,7 +132,7 @@ julia> hastorusfactor(projective_space(NormalToricVariety, 2))
 false
 ```
 """
-@attr Bool hastorusfactor(v::AbstractNormalToricVariety) = Polymake.common.rank(rays(fan(v))) < ambient_dim(fan(v))
+@attr Bool hastorusfactor(v::AbstractNormalToricVariety) = Polymake.common.rank(rays(v)) < ambient_dim(v)
 export hastorusfactor
 
 


### PR DESCRIPTION
Introduce an abstract type such that NormalToricVariety can be used more like a polyhedral fan directly, instead of having to cast to fan.

I also resolved #1070 here.