### PR TITLE
Add the minimal_degree option for irreducible representations

### DIFF
--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -22,8 +22,10 @@ function __init__()
 
   add_assert_scope(:MinField)
   set_assert_level(:MinField, 0)
-end
 
+  add_verbose_scope(:MinField)
+  set_verbose_level(:MinField, 0)
+end
 
 function irreducible_modules(G::Oscar.GAPGroup)
   im = GAP.Globals.IrreducibleRepresentations(G.X)
@@ -87,7 +89,7 @@ function Oscar.conductor(a::QabElem)
   return conductor(data(a))
 end
 
-function irreducible_modules(::Type{AnticNumberField}, G::Oscar.GAPGroup)
+function irreducible_modules(::Type{AnticNumberField}, G::Oscar.GAPGroup; minimal_degree::Bool = false)
   z = irreducible_modules(G)
   Z = GModule[]
   for m in z
@@ -95,12 +97,33 @@ function irreducible_modules(::Type{AnticNumberField}, G::Oscar.GAPGroup)
     k, mk = Hecke.subfield(base_ring(a), vec(collect(vcat(map(mat, a.ac)...))))
     if k != base_ring(a)
       F = free_module(k, dim(m))
-      push!(Z, gmodule(group(m), [hom(F, F, map_entries(inv(mk), mat(x))) for x = a.ac]))
+      push!(Z, gmodule(group(m), [hom(F, F, map_entries(pseudo_inv(mk), mat(x))) for x = a.ac]))
     else
       push!(Z, a)
     end
   end
-  return Z
+
+  if !minimal_degree
+    return Z
+  else
+    res = GModule[]
+    for V in Z
+      k, m = _character_field(V)
+      chi = character(V)
+      #if schur_index(chi) != 1
+      #  error("Not implemented for non-trivial Schur indicies yet")
+      #end
+      if degree(k) == degree(base_ring(V))
+        push!(res, V)
+      else
+        @info("Going from $(degree(base_ring(V))) to $(degree(k))")
+        Vmin = gmodule_over(m, V)
+        push!(res, Vmin)
+      end
+    end
+    @assert length(res) == length(z)
+    return res
+  end
 end
 
 function irreducible_modules(::typeof(CyclotomicField), G::Oscar.GAPGroup)
@@ -197,26 +220,32 @@ function _character(C::GModule{<:Any, <:Generic.FreeModule{<:Union{nf_elem, fmpq
   return chr
 end
 
-character_field(C::GModule{<:Any, <:Generic.FreeModule{fmpq}}) = QQ
+Oscar.character_field(C::GModule{<:Any, <:Generic.FreeModule{fmpq}}) = QQ
 
-function character_field(C::GModule{<:Any, <:Generic.FreeModule{nf_elem}})
+function _character_field(C::GModule{<:Any, <:Generic.FreeModule{nf_elem}})
   val = _character(C)
   k, mkK = Hecke.subfield(base_ring(C), [x[2] for x = val])
-  return k
+  return k, mkK
 end
 
-function character(C::GModule{<:Any, <:Generic.FreeModule{nf_elem}})
+function Oscar.character_field(C::GModule{<:Any, <:Generic.FreeModule{nf_elem}})
+  return _character_field(C)[1]
+end
+
+function Oscar.character(C::GModule{<:Any, <:Generic.FreeModule{nf_elem}})
   chr = _character(C)
   k, mkK = Hecke.subfield(base_ring(C), [x[2] for x = chr])
   A = maximal_abelian_subfield(ClassField, k)
   c = Hecke.norm(conductor(A)[1])
-  K = cyclotomic_field(Int(c))[1]
+  Qab = abelian_closure(QQ)[1]
+  K = cyclotomic_field(Qab, Int(c))[1]
   fl, em = issubfield(k, K)
-  return [(x[1], em(preimage(mkK, x[2]))) for x = chr]
+  return Oscar.group_class_function(group(C), [Qab(em(preimage(mkK, x[2]))) for x = chr])
 end
 
-function character(C::GModule{<:Any, <:Generic.FreeModule{fmpq}})
-  return _character(C)
+function Oscar.character(C::GModule{<:Any, <:Generic.FreeModule{fmpq}})
+  Qab = abelian_closure(QQ)[1]
+  return Oscar.group_class_function(group(C), [Qab(x[2]) for x = _character(C)])
 end
 
 function gmodule(k::Nemo.GaloisField, C::GModule{<:Any, <:Generic.FreeModule{<:FinFieldElem}})
@@ -303,7 +332,7 @@ function gmodule_over(k::FinField, C::GModule{<:Any, <:Generic.FreeModule{<:FinF
 end
 
 #...now the same for number fields - and non-cyclic fields.
-function gmodule_over(em::Map{AnticNumberField, AnticNumberField}, C::GModule{<:Any, <:Generic.FreeModule{nf_elem}}; do_error::Bool = false)
+function gmodule_over(em::Map{AnticNumberField, AnticNumberField}, C::GModule{<:Any, <:Generic.FreeModule{nf_elem}}; do_error::Bool = true)
   K = base_ring(C)
   k = domain(em)
   @assert codomain(em) == K
@@ -312,14 +341,28 @@ function gmodule_over(em::Map{AnticNumberField, AnticNumberField}, C::GModule{<:
   A, mA = automorphism_group(PermGroup, K)
   s, ms = sub(A, [a for a = A if mA(a)(gk) == gk])
   ac =  _two_cocycle(ms*mA, C, do_error = do_error)  
+  if ac === nothing 
+    if do_error
+      error("cannot do over this field")
+    else
+      return nothing
+    end
+  end
   F = free_module(k, dim(C))
   return gmodule(F, group(C), [hom(F, F, map_entries(t->preimage(em, t), x)) for x = ac])
 end
 
-function gmodule_over(::FlintRationalField, C::GModule{<:Any, <:Generic.FreeModule{nf_elem}}; do_error::Bool = false)
+function gmodule_over(::FlintRationalField, C::GModule{<:Any, <:Generic.FreeModule{nf_elem}}; do_error::Bool = true)
   K = base_ring(C)
   A, mA = automorphism_group(PermGroup, K)
   ac = _two_cocycle(mA, C, do_error = do_error)  
+  if ac === nothing 
+    if do_error
+      error("cannot do over this field")
+    else
+      return nothing
+    end
+  end
   F = free_module(QQ, dim(C))
   return gmodule(F, group(C), [hom(F, F, map_entries(QQ, x)) for x = ac])
 end
@@ -345,7 +388,7 @@ function Oscar.content_ideal(M::MatElem{nf_elem})
   return C
 end
 
-function _two_cocycle(mA::Map, C::GModule{<:Any, <:Generic.FreeModule{nf_elem}}; do_error::Bool = false)
+function _two_cocycle(mA::Map, C::GModule{<:Any, <:Generic.FreeModule{nf_elem}}; do_error::Bool = true)
   G = domain(mA)
   K = base_ring(C)
 
@@ -353,7 +396,8 @@ function _two_cocycle(mA::Map, C::GModule{<:Any, <:Generic.FreeModule{nf_elem}};
   @vprint :MinField 1 "Gathering Galois images of the generators...\n"
   for g = gens(G)
     @vprint :MinField 2 "gen: $g\n"
-    @vtime :MinField 2 hb = hom_base(C, C^mA(g))
+    @vtime :MinField 2 hb = hom_base(C^mA(g), C)
+    #C^g * hb == hb * C
     if length(hb) == 0
       do_error && return nothing
       error("field too small")
@@ -375,10 +419,10 @@ function _two_cocycle(mA::Map, C::GModule{<:Any, <:Generic.FreeModule{nf_elem}};
   I = identity_matrix(K, dim(C))
 
   @vprint :MinField 1 "computing un-normalised 1-chain (of matrices)\n"
-  # pairs: (g, X_g) with operation (g, X_g)(h, X_h) = (gh, X_h*X_g^h)
+  # pairs: (g, X_g) with operation (g, X_g)(h, X_h) = (gh, X_g^h * X_h)
   @vtime :MinField 2 
     c = closure([(gen(G, i), homs[i]) for i=1:ngens(G)], 
-              (a, b) -> (a[1]*b[1], b[2]*map_entries(mA(b[1]), a[2])),
+              (a, b) -> (a[1]*b[1], map_entries(mA(b[1]), a[2])*b[2]),
               (one(G), I),
               eq = (a,b) -> a[1] == b[1])
   X = Dict(x[1] => x[2] for x = c)
@@ -389,32 +433,42 @@ function _two_cocycle(mA::Map, C::GModule{<:Any, <:Generic.FreeModule{nf_elem}};
 
   @vprint :MinField 1 "now the 2-cocycle (scalars)\n"
   MK = MultGrp(K)
-  sigma = Dict{Tuple{PermGroupElem, PermGroupElem}, MultGrpElem{nf_elem}}()
+  sigma = Dict{Tuple{PermGroupElem, PermGroupElem}, nf_elem}()
   for g = G
     for h = G
       if isone(g)
-        sigma[(g, h)] = MK(one(K))
+        sigma[(g, h)] = (one(K))
       elseif isone(h)
-        sigma[(g, h)] = MK(one(K))
+        sigma[(g, h)] = (one(K))
       else
         lf = findfirst(x->!iszero(x), X[g*h])
-        sigma[(g, h)] = MK(X[g*h][lf]//(X[h]*map_entries(mA(h), X[g]))[lf])
+        sigma[(g, h)] = (X[g*h][lf]//(map_entries(mA(h), X[g])*X[h])[lf])
+#        sigma[(g, h)] = MK(X[g*h][lf]//(X[h]*map_entries(mA(h), X[g]))[lf])
       end
     end
   end
+  istwo_cocycle(sigma, mA)
 
   @vprint :MinField 1 "test for co-boundary\n"
   D = gmodule(G, [hom(MK, MK, mA(x)) for x = gens(G)])
-  Sigma = Oscar.GrpCoh.CoChain{2,PermGroupElem, MultGrpElem{nf_elem}}(D, sigma)
+  Sigma = Oscar.GrpCoh.CoChain{2,PermGroupElem, MultGrpElem{nf_elem}}(D, Dict(k=>MK(v) for (k,v) = sigma))
   @vtime :MinField 2 fl, cb = Oscar.GrpCoh.iscoboundary(Sigma)
+
+  cc = Dict(k => cb(k).data for k = G)
+  for g = G
+    for h = G
+      @assert mA(h)(cc[g])*cc[h] == sigma[(g, h)]*cc[g*h]
+    end
+  end
 
   if !fl
     do_error || return nothing
     error("field too small")
   end
   for g = G
-    X[g] *= inv(cb(g).data)
+    X[g] *= (cb(g).data)
   end
+  isone_cochain(X, mA)
 
   #now X should be in H^1(G, Gl(n, K)) which is trivial
   #hence a Hilbert-90 should find A s.th. A^(1-g) = X[g] for all g
@@ -427,8 +481,39 @@ function _two_cocycle(mA::Map, C::GModule{<:Any, <:Generic.FreeModule{nf_elem}};
   Ai *= inv(d)
 
   @vprint :MinField 1 "conjugating the generators\n"
-  @vtime :MinField 2 r = [Ai*mat(x)*A for x = C.ac]
+  @vtime :MinField 2 r = [A*mat(x)*Ai for x = C.ac]
   return r
+end
+
+function isone_cochain(X::Dict{<:GAPGroupElem, <:MatElem{nf_elem}}, mA)
+  G = domain(mA)
+  for g = G
+    for h = G
+      @assert X[g*h] == map_entries(mA(h), X[g])*X[h]
+    end
+  end
+end
+
+function isone_cochain(X::Dict{<:GAPGroupElem, nf_elem}, mA)
+  @show X
+  G = domain(mA)
+  for g = G
+    for h = G
+      @assert X[g*h] == mA(h)(X[g])*X[h]
+    end
+  end
+end
+
+
+function istwo_cocycle(X::Dict, mA)
+  G = domain(mA)
+  for g = G
+    for h = G
+      for k = G
+        @assert X[(g*h, k)] == X[(g, h*k)]//mA(k)(X[(g, h)])*X[(h, k)]
+      end
+    end
+  end
 end
 
 """
@@ -460,7 +545,7 @@ function hilbert90_generic(X::Dict, mA)
       cnt += 1
       if cnt > 10 error("s.th. wiered") end
     end
-    S = sum(v*map_entries(mA(g), Y) for (g,v) = X)
+    S = sum(map_entries(mA(g), Y)*v for (g,v) = X)
     fl, Si = isinvertible_with_inverse(S)
     fl && return S, Si
   end
@@ -1168,71 +1253,6 @@ function Nemo._hnf_with_transform(x::fmpz_mat)
   return Nemo.__hnf_with_transform(x) # ist die original Nemo flint hnf
 end
 
-
-function extend(C::GModule, m::Map)
-  #N acts and is normal in <h, N> 
-  #m injects N into <h, N>  (at least h, maybe more)
-  #h = gen(domain(m), 1)
-  #h has order p in <h, N>/N
-  #Satz 10 in Brueckner, Chap 1.2.3
-  #TODO: should be used above in reps!
-
-  F = Module(C)
-  N = group(C)
-  Nh = codomain(m)
-  @assert ngens(N) + 1 == ngens(Nh)
-  @assert all(x->m(gen(N, i)) == gen(Nh, i+1), 1:ngens(N))
-
-  h = gen(Nh, 1)
-  p = divexact(order(Nh), order(N))
-  @assert isprime(p)
-
-  F = C.M
-  K = base_ring(F)
-  Ch = gmodule(N, [action(C, preimage(m, m(x)^h)) for x = gens(N)])
-  l = Oscar.GModuleFromGap.hom_base(C, Ch)
-  @assert length(l) <= 1
-  nr = []
-  Y = mat(action(C, preimage(m, h^p)))
-  if length(l) == 1
-    X = l[1]
-    Xp = X^p
-    #Brueckner: C*Xp == Y for some scalar C
-    i = findfirst(x->!iszero(x), Xp)
-    @assert !iszero(Y[i])
-    C = divexact(Y[i], Xp[i])
-    @assert C*Xp == Y
-    # I think they should always be roots of one here.
-    rt = roots(C, p)
-    Y = r.ac
-    for x = rt
-      nw = gmodule(F, Nh,  vcat([hom(F, F, x*X)], Y))
-      push!(nr, nw)
-    end
-  else #need to extend dim
-    n = dim(r)
-    F = free_module(K, dim(r)*p)
-    z = zero_matrix(K, dim(F), dim(F))
-    #TODO: see above in reps, this is wrong.
-    #TODO: fuse
-    z[(p-1)*n+1:end, 1:n] = Y
-    for i=1:p-1
-      z[(i-1)*n+1:i*n, i*n+1:(i+1)*n] = identity_matrix(K, n)
-    end
-    md = [hom(F, F, z)]
-    for g = gens(s)
-      z = zero_matrix(K, dim(F), dim(F))
-      for j=1:p
-        Y = action(r, g)
-        z[(j-1)*n+1:j*n, (j-1)*n+1:j*n] = mat(Y)
-        g = preimage(m, g^h)
-      end
-      push!(md, hom(F, F, z))
-    end
-    push!(nr, gmodule(F, Nh, md))
-  end
-  return nr
-end
 
 """
 Brueckner Chap 1.3.1

--- a/test/Experimental/gmodule-test.jl
+++ b/test/Experimental/gmodule-test.jl
@@ -10,5 +10,16 @@
   z = irreducible_modules(ZZ, G)
   @test length(z) == 5
 
+  l = irreducible_modules(AnticNumberField, small_group(48, 17), minimal_degree = true)
+  ds = degree.(base_ring.(l))
+  @test length(l) == 12
+  @test count(isequal(1), ds) == 8
+  @test count(isequal(2), ds) == 4
+
+  l = irreducible_modules(AnticNumberField, small_group(48, 29), minimal_degree = true)
+  ds = degree.(base_ring.(l))
+  @test length(l) == 8
+  @test count(isequal(1), ds) == 6
+  @test count(isequal(2), ds) == 2
 end
 


### PR DESCRIPTION
@fieker The test is crashing with:
```julia
julia> G = small_group(48, 17)

julia> irreducible_modules(AnticNumberField, G, minimal_degree = true)
[ Info: Going from 2 to 1
[ Info: Going from 2 to 1
[ Info: Going from 4 to 2
[ Info: Going from 4 to 2
[ Info: Going from 4 to 1
(:sparse_t, size(x)) = (:sparse_t, (24, 18))
(:sparse, size(x)) = (:sparse, (19, 19))
(:sparse, size(x)) = (:sparse, (15, 13))
(:sparse_t, size(x)) = (:sparse_t, (19, 6))
ERROR: MethodError: no method matching length(::Nothing)
Closest candidates are:
  length(::Union{Base.KeySet, Base.ValueIterator}) at ~/repositories/julia/usr/share/julia/base/abstractdict.jl:58
  length(::Union{LinearAlgebra.Adjoint{T, S}, LinearAlgebra.Transpose{T, S}} where {T, S}) at ~/repositories/julia/usr/share/julia/stdlib/v1.8/LinearAlgebra/src/adjtrans.jl:172
  length(::Union{AbstractAlgebra.Generic.UnivPolyCoeffs, AbstractAlgebra.Generic.UnivPolyExponentVectors, AbstractAlgebra.Generic.UnivPolyMonomials, AbstractAlgebra.Generic.UnivPolyTerms}) at ~/.julia/packages/AbstractAlgebra/ypjon/src/generic/UnivPoly.jl:464
  ...
Stacktrace:
 [1] length(g::Base.Generator{Nothing, Oscar.GModuleFromGap.var"#429#432"{NfToNfMor, AbstractAlgebra.Generic.FreeModule{nf_elem}}})
   @ Base ./generator.jl:50
 [2] _similar_shape(itr::Base.Generator{Nothing, Oscar.GModuleFromGap.var"#429#432"{NfToNfMor, AbstractAlgebra.Generic.FreeModule{nf_elem}}}, #unused#::Base.HasLength)
   @ Base ./array.jl:660
 [3] collect(itr::Base.Generator{Nothing, Oscar.GModuleFromGap.var"#429#432"{NfToNfMor, AbstractAlgebra.Generic.FreeModule{nf_elem}}})
   @ Base ./array.jl:783
 [4] gmodule_over(em::NfToNfMor, C::GModule{PcGroup, AbstractAlgebra.Generic.FreeModule{nf_elem}}; do_error::Bool)
   @ Oscar.GModuleFromGap ~/.julia/dev/Oscar/experimental/GModule/GModule.jl:344
 [5] gmodule_over(em::NfToNfMor, C::GModule{PcGroup, AbstractAlgebra.Generic.FreeModule{nf_elem}})
   @ Oscar.GModuleFromGap ~/.julia/dev/Oscar/experimental/GModule/GModule.jl:335
 [6] irreducible_modules(::Type{AnticNumberField}, G::PcGroup; minimal_degree::Bool)
   @ Oscar.GModuleFromGap ~/.julia/dev/Oscar/experimental/GModule/GModule.jl:121
 [7] top-level scope
```
Maybe I am using it wrong?

P.S.: Here is my list of test groups (all have trivial Schur indicies)
<details><summary>Click to expand</summary>
<p>

```julia
[ (2 1), (3 1), (4 1), (4 2), (5 1), (6 1), (6 2), (7 1), (8 1), (8 2), (8 3), (8 5), (9 1), (9 2), (10 1), (10 2), (11 1), (12 2), (12 3), (12 4), (12 5), (13 1), (14 1), (14 2), (15 1), (16 1), (16 2), (16 3), (16 5), (16 6), (16 7), (16 8), (16 10), (16 11), (16 13), (16 14), (17 1), (18 1), (18 2), (18 3), (18 4), (18 5), (19 1), (20 2), (20 3), (20 4), (20 5), (21 1), (21 2), (22 1), (22 2), (23 1), (24 2), (24 5), (24 6), (24 8), (24 9), (24 10), (24 12), (24 13), (24 14), (24 15), (25 1), (25 2), (26 1), (26 2), (27 1), (27 2), (27 3), (27 4), (27 5), (28 2), (28 3), (28 4), (29 1), (30 1), (30 2), (30 3), (30 4), (31 1), (32 1), (32 3), (32 4), (32 5), (32 6), (32 7), (32 9), (32 11), (32 16), (32 17), (32 18), (32 19), (32 21), (32 22), (32 24), (32 25), (32 27), (32 28), (32 30), (32 31), (32 33), (32 34), (32 36), (32 37), (32 38), (32 39), (32 40), (32 42), (32 43), (32 45), (32 46), (32 48), (32 49), (32 51), (33 1), (34 1), (34 2), (35 1), (36 2), (36 3), (36 4), (36 5), (36 8), (36 9), (36 10), (36 11), (36 12), (36 13), (36 14), (37 1), (38 1), (38 2), (39 1), (39 2), (40 2), (40 5), (40 6), (40 8), (40 9), (40 10), (40 12), (40 13), (40 14), (41 1), (42 1), (42 2), (42 3), (42 4), (42 5), (42 6), (43 1), (44 2), (44 3), (44 4), (45 1), (45 2), (46 1), (46 2), (47 1), (48 2), (48 3), (48 4), (48 5), (48 6), (48 7), (48 14), (48 17), (48 20), (48 21), (48 23), (48 24), (48 25), (48 26), (48 29), (48 31), (48 33), (48 35), (48 36), (48 37), (48 38), (48 43), (48 44), (48 45), (48 47), (48 48), (48 49), (48 50), (48 51), (48 52), (49 1), (49 2), (50 1), (50 2), (50 3), (50 4), (50 5), (51 1), (52 2), (52 3), (52 4), (52 5), (53 1), (54 1), (54 2), (54 3), (54 4), (54 5), (54 6), (54 7), (54 8), (54 9), (54 10), (54 11), (54 12), (54 13), (54 14), (54 15), (55 1), (55 2), (56 2), (56 4), (56 5), (56 7), (56 8), (56 9), (56 11), (56 12), (56 13), (57 1), (57 2), (58 1), (58 2), (59 1), (60 4), (60 5), (60 6), (60 8), (60 9), (60 10), (60 11), (60 12), (60 13), (61 1), (62 1), (62 2), (63 2), (63 3), (63 4), (64 1), (64 2), (64 3), (64 4), (64 6), (64 8), (64 10), (64 12), (64 26), (64 27), (64 28), (64 29), (64 30), (64 31), (64 32), (64 33), (64 34), (64 35), (64 36), (64 38), (64 40), (64 41), (64 42), (64 50), (64 51), (64 52), (64 53), (64 55), (64 57), (64 58), (64 60), (64 62), (64 64), (64 67), (64 69), (64 71), (64 73), (64 75), (64 78), (64 82), (64 83), (64 84), (64 85), (64 86), (64 87), (64 88), (64 89), (64 90), (64 91), (64 92), (64 94), (64 95), (64 97), (64 99), (64 101), (64 102), (64 112), (64 113), (64 114), (64 115), (64 116), (64 117), (64 118), (64 119), (64 123), (64 124), (64 125), (64 128), (64 130), (64 131), (64 134), (64 135), (64 136), (64 138), (64 139), (64 140), (64 141), (64 144), (64 146), (64 147), (64 150), (64 152), (64 153), (64 162), (64 163), (64 167), (64 169), (64 171), (64 173), (64 174), (64 176), (64 177), (64 183), (64 184), (64 185), (64 186), (64 187), (64 189), (64 190), (64 192), (64 193), (64 195), (64 196), (64 198), (64 199), (64 202), (64 203), (64 205), (64 206), (64 207), (64 209), (64 210), (64 211), (64 213), (64 215), (64 216), (64 219), (64 221), (64 226), (64 227), (64 231), (64 232), (64 234), (64 236), (64 240), (64 241), (64 242), (64 246), (64 247), (64 248), (64 249), (64 250), (64 251), (64 253), (64 254), (64 256), (64 257), (64 258), (64 260), (64 261), (64 263), (64 264), (64 266), (64 267), (65 1), (66 1), (66 2), (66 3), (66 4), (67 1), (68 2), (68 3), (68 4), (68 5), (69 1), (70 1), (70 2), (70 3), (70 4), (71 1), (72 2), (72 5), (72 6), (72 8), (72 9), (72 10), (72 14), (72 15), (72 16), (72 17), (72 18), (72 21), (72 23), (72 27), (72 28), (72 30), (72 32), (72 33), (72 35), (72 36), (72 37), (72 39), (72 40), (72 42), (72 43), (72 44), (72 45), (72 46), (72 47), (72 48), (72 49), (72 50), (73 1), (74 1), (74 2), (75 1), (75 2), (75 3), (76 2), (76 3), (76 4), (77 1), (78 1), (78 2), (78 3), (78 4), (78 5), (78 6), (79 1), (80 2), (80 4), (80 5), (80 6), (80 7), (80 14), (80 20), (80 21), (80 23), (80 24), (80 25), (80 26), (80 29), (80 30), (80 34), (80 36), (80 37), (80 38), (80 39), (80 42), (80 44), (80 45), (80 46), (80 48), (80 49), (80 50), (80 51), (80 52), (81 1), (81 2), (81 3), (81 4), (81 5), (81 6), (81 7), (81 8), (81 9), (81 10), (81 11), (81 12), (81 13), (81 14), (81 15), (82 1), (82 2), (83 1), (84 2), (84 6), (84 7), (84 8), (84 9), (84 10), (84 11), (84 12), (84 13), (84 14), (84 15), (85 1), (86 1), (86 2), (87 1), (88 2), (88 4), (88 5), (88 7), (88 8), (88 9), (88 11), (88 12), (89 1), (90 1), (90 2), (90 3), (90 4), (90 5), (90 6), (90 7), (90 8), (90 9), (90 10), (91 1), (92 2), (92 3), (92 4), (93 1), (93 2), (94 1), (94 2), (95 1), (96 2), (96 4), (96 5), (96 6), (96 7), (96 12), (96 13), (96 27), (96 28), (96 30), (96 32), (96 46), (96 47), (96 48), (96 49), (96 50), (96 52), (96 54), (96 59), (96 60), (96 61), (96 62), (96 64), (96 68), (96 70), (96 71), (96 72), (96 73), (96 74), (96 78), (96 79), (96 80), (96 81), (96 82), (96 83), (96 87), (96 89), (96 91), (96 106), (96 107), (96 108), (96 109), (96 110), (96 111), (96 113), (96 114), (96 115), (96 117), (96 118), (96 120), (96 121), (96 126), (96 134), (96 135), (96 136), (96 137), (96 139), (96 144), (96 147), (96 148), (96 156), (96 157), (96 160), (96 161), (96 162), (96 164), (96 165), (96 167), (96 168), (96 170), (96 171), (96 173), (96 174), (96 176), (96 177), (96 178), (96 179), (96 180), (96 182), (96 183), (96 186), (96 187), (96 189), (96 192), (96 193), (96 195), (96 196), (96 197), (96 200), (96 201), (96 204), (96 206), (96 207), (96 208), (96 209), (96 211), (96 215), (96 216), (96 219), (96 220), (96 221), (96 223), (96 224), (96 226), (96 227), (96 228), (96 229), (96 230), (96 231), (97 1), (98 1), (98 2), (98 3), (98 4), (98 5), (99 1), (99 2), (100 2), (100 3), (100 4), (100 5), (100 8), (100 9), (100 11), (100 12), (100 13), (100 14), (100 15), (100 16) ]
```
</p>
</details>