### PR TITLE
test/ToricVarieties: fix+improve test for Stanley Reisner ideal

### DIFF
--- a/src/Combinatorics/SimplicialComplexes.jl
+++ b/src/Combinatorics/SimplicialComplexes.jl
@@ -249,10 +249,14 @@ julia> minimal_nonfaces(K)
 """
 minimal_nonfaces(K::SimplicialComplex) = minimal_nonfaces(Vector{Set{Int}}, K)
 function minimal_nonfaces(::Type{Vector{Set{Int}}}, K::SimplicialComplex)
-    I = pm_object(K).MINIMAL_NON_FACES
+    I = minimal_nonfaces(IncidenceMatrix, K)
     return Vector{Set{Int}}([Polymake.row(I,i) for i in 1:Polymake.nrows(I)])
 end
-minimal_nonfaces(::Type{IncidenceMatrix}, K::SimplicialComplex) = pm_object(K).MINIMAL_NON_FACES
+function minimal_nonfaces(::Type{IncidenceMatrix}, K::SimplicialComplex)
+    # the following line must stay to ensure polymake uses the correct algorithm for the non-faces
+    nvertices(K)
+    return pm_object(K).MINIMAL_NON_FACES
+end
 
 @doc Markdown.doc"""
     alexander_dual(K::SimplicialComplex)

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -201,11 +201,13 @@ end
 
 P = polarize(Polyhedron(Polymake.polytope.rand_sphere(5,60; seed=42)))
 big_variety = NormalToricVariety(P)
-big_variety2 = NormalToricVariety(P)
-set_coefficient_ring(big_variety2, GF(13))
+set_coefficient_ring(big_variety, GF(13))
 
 @testset "Additional test for Stanley-Reisner ideal" begin
-    @test ngens(stanley_reisner_ideal(big_variety)) == ngens(stanley_reisner_ideal(big_variety2))
+    # this should run in a few seconds at most
+    duration = @elapsed stanley_reisner_ideal(big_variety)
+    @test duration < 10
+    @test ngens(stanley_reisner_ideal(big_variety)) == 1648
 end
 
 D=ToricDivisor(H5, [0,0,0,0])


### PR DESCRIPTION
@HereAround
cc: @lkastner 

Currently:
Linux CI (nightly):
```
Test Summary:                             | Pass  Total     Time
Additional test for Stanley-Reisner ideal |    1      1  2m37.9s
```
macOS CI (nightly):
```
Test Summary:                             | Pass  Total     Time
Additional test for Stanley-Reisner ideal |    1      1  5m13.4s
```
This PR should bring that down to probably a few seconds.

Also I don't really understand the point of this testcase, especially why is it running the the (fully deterministic) algorithm twice on the same input? The same wrong result would also be accepted by that test, maybe there is some other invariant of the ideal that could be precomputed and used for the test, maybe for some simpler example?
https://github.com/oscar-system/Oscar.jl/blob/92298048a3fa72ac69b4487c5bbd5edc563fd944/test/ToricVarieties/runtests.jl#L202-L209


_Edit:_ With this PR:
Linux:
```
Test Summary:                             | Pass  Total  Time
Additional test for Stanley-Reisner ideal |    1      1  1.3s
```
macOS:
```
Test Summary:                             | Pass  Total  Time
Additional test for Stanley-Reisner ideal |    1      1  2.9s
```