### PR TITLE
add argument checks for `iso_oscar_gap`, `iso_gap_oscar`

### DIFF
--- a/src/GAP/iso_gap_oscar.jl
+++ b/src/GAP/iso_gap_oscar.jl
@@ -1,11 +1,26 @@
 # Basically the same as the usual preimage function but without a type check
 # since we don't have elem_type(D) in this case
-function preimage(M::Map{D, C}, a) where {D <: GapObj, C}
+function preimage(M::Map{D, C}, a; check::Bool = true) where {D <: GapObj, C}
+  parent(a) === codomain(M) || error("the element is not in the map's codomain")
   if isdefined(M.header, :preimage)
     p = M.header.preimage(a)
     return p
   end
   error("No preimage function known")
+end
+
+# needed in order to do a generic argument check on the GAP side
+function image(M::Map{D, C}, a; check::Bool = true) where {D <: GapObj, C}
+  check && (a in domain(M) || error("the element is not in the map's domain"))
+  if isdefined(M, :header)
+    if isdefined(M.header, :image)
+      return M.header.image(a)::elem_type(C)
+    else
+      error("No image function known")
+    end
+  else
+    return M(a)
+  end
 end
 
 ################################################################################
@@ -55,12 +70,18 @@ function _iso_gap_oscar_field_finite(FG::GAP.GapObj)
    return MapFromFunc(f, finv, FG, FO)
 end
 
-function _iso_gap_oscar_field_rationals(F::GAP.GapObj)
-   return MapFromFunc(x -> fmpq(x), x -> GAP.Obj(x), F, QQ)
+function _iso_gap_oscar_field_rationals(FG::GAP.GapObj)
+   FO = QQ
+   finv, f = _iso_oscar_gap_field_rationals_functions(FO, FG)
+
+   return MapFromFunc(f, finv, FG, FO)
 end
 
-function _iso_gap_oscar_ring_integers(F::GAP.GapObj)
-   return MapFromFunc(x -> fmpz(x), x -> GAP.Obj(x), F, ZZ)
+function _iso_gap_oscar_ring_integers(FG::GAP.GapObj)
+   FO = ZZ
+   finv, f = _iso_oscar_gap_ring_integers_functions(FO, FG)
+
+   return MapFromFunc(f, finv, FG, FO)
 end
 
 function _iso_gap_oscar_field_cyclotomic(FG::GAP.GapObj)

--- a/test/GAP/iso_gap_oscar.jl
+++ b/test/GAP/iso_gap_oscar.jl
@@ -16,6 +16,10 @@
       @test oxi == ox^i
       @test oxi + oy == iso(xi + y)
     end
+    p2 = next_prime(p)
+    @test_throws ErrorException iso(GAP.Globals.Z(GAP.Obj(p2)))
+    @test_throws ErrorException image(iso, GAP.Globals.Z(GAP.Obj(p2)))
+    @test_throws ErrorException preimage(iso, GF(p2)(1))
   end
 end
 
@@ -44,6 +48,11 @@ end
         @test oxi == ox^i
         @test oxi + oy == iso(xi + y)
       end
+      p2 = next_prime(p)
+      o = GAP.Globals.One(GAP.Globals.GF(GAP.Obj(p2)))
+      @test_throws ErrorException iso(o)
+      @test_throws ErrorException image(iso, o)
+      @test_throws ErrorException preimage(iso, GF(p2)(1))
     end
   end
 end
@@ -62,6 +71,10 @@ end
       @test oxi == ox^i
       @test oxi + oy == iso(xi + y)
     end
+    @test_throws ErrorException preimage(iso, 1)
+    @test_throws ErrorException iso(GAP.Globals.Z(2))
+    @test_throws ErrorException image(iso, GAP.Globals.Z(2))
+    @test_throws ErrorException preimage(iso, GF(2)(1))
   end
 end
 
@@ -80,6 +93,9 @@ end
       @test oxi == ox^i
       @test oxi + oy == iso(xi + y)
     end
+    @test_throws ErrorException iso(GAP.Globals.Z(2))
+    @test_throws ErrorException image(iso, GAP.Globals.Z(2))
+    @test_throws ErrorException preimage(iso, CyclotomicField(2)[2])
   end
 end
 
@@ -97,5 +113,8 @@ end
          img = iso(pol)
          @test preimage(iso, img) == pol
       end
+      @test_throws ErrorException iso(GAP.Globals.Z(2))
+      @test_throws ErrorException image(iso, GAP.Globals.Z(2))
+      @test_throws ErrorException preimage(iso, PolynomialRing(QQ, "y")[1]())
    end
 end

--- a/test/GAP/iso_oscar_gap.jl
+++ b/test/GAP/iso_oscar_gap.jl
@@ -8,6 +8,17 @@
                @test f(a-b) == f(a)-f(b)
             end
          end
+         C = codomain(f)
+         for a in C
+            for b in C
+               @test preimage(f, a*b) == preimage(f, a)*preimage(f, b)
+               @test preimage(f, a-b) == preimage(f, a)-preimage(f, b)
+            end
+         end
+         p2 = next_prime(p)
+         @test_throws ErrorException f(GF(p2)(1))
+         @test_throws ErrorException image(f, GF(p2)(1))
+         @test_throws ErrorException preimage(f, GAP.Globals.Z(GAP.Obj(p2)))
       end
    end
 
@@ -21,6 +32,13 @@
                @test f(a-b) == f(a)-f(b)
             end
          end
+         C = codomain(f)
+         for a in C
+            for b in C
+               @test preimage(f, a*b) == preimage(f, a)*preimage(f, b)
+               @test preimage(f, a-b) == preimage(f, a)-preimage(f, b)
+            end
+         end
          G = GL(4,F)
          for a in gens(G)
             for b in gens(G)
@@ -28,6 +46,10 @@
                @test g(a.elm-b.elm) == g(a.elm)-g(b.elm)
             end
          end
+         p2 = next_prime(p)
+         @test_throws ErrorException f(GF(p2)(1))
+         @test_throws ErrorException image(f, GF(p2)(1))
+         @test_throws ErrorException preimage(f, GAP.Globals.Z(GAP.Obj(p2)))
       end
    end
 end
@@ -46,6 +68,10 @@ end
    @test GAP.Globals.DefiningPolynomial(codomain(f)) ==
          GAP.Globals.ConwayPolynomial(p, 2)
    @test F.is_conway == 0
+   p2 = next_prime(p)
+   @test_throws ErrorException f(GF(p2)(1))
+   @test_throws ErrorException image(f, GF(p2)(1))
+   @test_throws ErrorException preimage(f, GAP.Globals.Z(GAP.Obj(p2)))
 end
 
 @testset "another large non-prime field (FqNmodFiniteField)" begin
@@ -65,6 +91,10 @@ end
       a = f(x)
       @test preimage(f, a) == x
    end
+   p2 = next_prime(p)
+   @test_throws ErrorException f(GF(p2)(1))
+   @test_throws ErrorException image(f, GF(p2)(1))
+   @test_throws ErrorException preimage(f, GAP.Globals.Z(GAP.Obj(p2)))
 end
 
 @testset "field of rationals, ring of integers" begin
@@ -79,6 +109,11 @@ end
       @test oxi == ox^i
       @test oxi + oy == iso(xi + y)
     end
+    @test_throws ErrorException iso(1)
+    @test_throws ErrorException image(iso, 1)
+    @test_throws ErrorException iso(GF(2)(1))
+    @test_throws ErrorException image(iso, GF(2)(1))
+    @test_throws ErrorException preimage(iso, GAP.Globals.Z(2))
   end
 end
 
@@ -101,6 +136,9 @@ end
             @test f(a - b) == f(a) - f(b)
          end
       end
+      @test_throws ErrorException f(CyclotomicField(2)[2])
+      @test_throws ErrorException image(f, CyclotomicField(2)[2])
+      @test_throws ErrorException preimage(f, GAP.Globals.Z(2))
    end
 end
 
@@ -121,5 +159,8 @@ end
       end
       m = matrix([x x; x x])
       @test map_entries(inv(iso), map_entries(iso, m)) == m
+      @test_throws ErrorException iso(PolynomialRing(R, "y")[1]())
+      @test_throws ErrorException image(iso, PolynomialRing(R, "y")[1]())
+      @test_throws ErrorException preimage(iso, GAP.Globals.Z(2))
    end
 end

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -69,7 +69,7 @@ end
 
 @testset "Oscar-GAP relationship for cyclotomic fields" begin
    fields = Any[CyclotomicField(n) for n in [1, 3, 4, 5, 8, 15, 45]]
-   push!(fields, (QQ, 1))
+   push!(fields, (QQ, QQ(1)))
 
    @testset for (F, z) in fields
       f = Oscar.iso_oscar_gap(F)


### PR DESCRIPTION
This pull request tries to address issue #1066.

The request was that attempts to call `image(map, elm)` for `parent(elm)` different from `domain(map)` or to call `preimage(map, elm)` for `parent(elm)` different from `codomain(map)` shall throw an error, where the `parent` check must be replaced by a membership test with `in` on the GAP side.

The idea is that the tests get added to the `image` and `preimage` methods in question, not to the individual functions from which the `MapFromFunction` objects get created.
Note that this requires two `image` methods and two `preimage` methods each with domain or codomain being a `GAP.GapObj`. Two of them had already been necessary because of the type checks in the generic methods from Hecke, which do not work for GAP objects. The other two methods are introduced now because of the checks on the GAP side.

The membership tests on the GAP side can be expensive, therefore they can be switched off using a keyword argument.

Remarks:
- Calls of the form `map(elm)` are delegated to `image(map, elm)`, thus no methods for `map(elm)` had to be changed.
  If we want to support `map(elm; check = false)` then the right places for this would be the generic methods in Hecke.
- The generic `preimage(map, elm)` method in Hecke does not check whether the parent of `elm` is `codomain(map)` but whether the parent of the preimage computed by the given function is `domain(map)`. Is this intended?
  (Checking the parent of the argument means to catch user errors, checking the parent of the result catches erroneous functions used in the construction of the map. Do we perhaps want to check both?
  And the check in the Hecke method is done via `@assert`, which we wanted to avoid, as far as I understood.)