### PR TITLE
create Oscar groups with context

### DIFF
--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -69,7 +69,9 @@ vectors of the embeddings (resp. projections) of the direct product `G`.
 function inner_direct_product(L::AbstractVector{T}; morphisms=false) where T<:Union{PcGroup,PermGroup,FPGroup}
    P = GAP.Globals.DirectProduct(GapObj([G.X for G in L]))
    if T==PermGroup
-      DP = T(P,GAP.Globals.NrMovedPoints(P))
+      # Make sure that the degree of the direct product
+      # is the sum of the degrees of its factors.
+      DP = T(P, sum([degree(G) for G in L], init = 0))
    else
       DP = T(P)
    end

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -74,6 +74,30 @@ end
 
 MatrixGroup(m::Int, F::Ring, V::AbstractVector{T}) where T<:Union{MatElem,AbstractMatrixGroupElem} = MatrixGroup{elem_type(F), dense_matrix_type(elem_type(F))}(m,F,V)
 
+
+# `MatrixGroup`: compare types, dimensions, and coefficient rings
+function check_parent(G::T, g::GAPGroupElem) where T <: MatrixGroup
+  P = g.parent
+  return T === typeof(P) && G.deg == P.deg && G.ring == P.ring
+end
+
+# `MatrixGroup`: set dimension and ring of `G`
+function _oscar_group(obj::GapObj, G::MatrixGroup)
+  d = GAP.Globals.DimensionOfMatrixGroup(obj)
+  d == G.deg || error("requested dimension of matrices ($(G.deg)) does not match the given matrix dimension ($d)")
+
+  R = G.ring
+  iso = G.ring_iso
+  GAP.Globals.IsSubset(codomain(iso), GAP.Globals.FieldOfMatrixGroup(obj)) || error("matrix entries are not in the requested ring ($(codomain(iso)))")
+
+  M = MatrixGroup(d, R)
+  M.X = obj
+  M.ring = R
+  M.ring_iso = iso
+  return M
+end
+
+
 function _as_subgroup_bare(G::T, H::GapObj) where {T <: MatrixGroup}
   H1 = T(G.deg,G.ring)
   H1.ring_iso = G.ring_iso

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -25,12 +25,8 @@ export
 #
 ################################################################################
 
-function _as_subgroup_bare(G::T, H::GapObj) where T
-  return T(H)
-end
-
-function _as_subgroup_bare(G::PermGroup, H::GapObj)
-  return PermGroup(H, G.deg)
+function _as_subgroup_bare(G::T, H::GapObj) where T <: GAPGroup
+  return _oscar_group(H, G)
 end
 
 function _as_subgroup(G::GAPGroup, H::GapObj)

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -169,6 +169,34 @@ TODO: document this
 """
 const FPGroupElem = BasicGAPGroupElem{FPGroup}
 
+
+################################################################################
+#
+# Construct an Oscar group wrapping the GAP group `obj`
+# *and* compatible with a given Oscar group `G`.
+
+# default: ignore `G`
+_oscar_group(obj::GapObj, G::T) where T <: GAPGroup = T(obj)
+
+# `PermGroup`: set the degree of `G`
+function _oscar_group(obj::GapObj, G::PermGroup)
+  n = GAP.Globals.LargestMovedPoint(obj)
+  N = degree(G)
+  n <= N || error("requested degree ($N) is smaller than the largest moved point ($n)")
+  return PermGroup(obj, N)
+end
+
+# `MatrixGroup`: set dimension and ring of `G`
+# (This cannot be defined here because `MatrixGroup` is not yet defined.)
+
+
+################################################################################
+#
+# "Coerce" an Oscar group `G` to one that is compatible with
+# the given Oscar group `S`.
+compatible_group(G::T, S::T) where T <: GAPGroup = _oscar_group(G.X, S)
+
+
 ################################################################################
 #
 #  Group Homomorphism

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -102,7 +102,7 @@ Every group of this type is the subgroup of Sym(n) for some n.
    end
    
    function PermGroup(G::GapObj, deg::Int)
-     @assert GAPWrap.IsPermGroup(G)
+     @assert GAPWrap.IsPermGroup(G) && deg > 0 && deg >= GAPWrap.LargestMovedPoint(G)::Int
      z = new(G, deg)
      return z
    end


### PR DESCRIPTION
(This addresses issue #894.)

Several types of Oscar groups need context information besides the underlying GAP object:
`PermGroup` needs the degree, `MatrixGroup` needs the dimension and the ring of the matrix entries.
This context was not used in certain situations.

Now the recommended way to construct groups with context is via `oscar_group(gapobj, G)` where `gapobj` is a GAP group and `G` is an Oscar group that provides the context.
(Up to now we had `T(gapobj)`, where `T` is the type of `G`, but this does not work in general. It would be tempting to use `T(gapobj, G)`, but this syntax cannot be used in general because `AutomorphismGroup` uses it for something different.)

(More methods should get restricted to situations where the contexts of the arguments are equal. This will be the next step.)