### PR TITLE
support `check` for group homom. by images

### DIFF
--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -71,21 +71,17 @@ end
 Return the identity homomorphism on the group `G`.
 """
 function id_hom(G::GAPGroup)
-  return hom(G, G, x -> x)
+  return GAPGroupHomomorphism(G, G, GAP.Globals.IdentityMapping(G.X))
 end
 
 """
-    trivial_morphism(G::GAPGroup, H::GAPGroup)
+    trivial_morphism(G::GAPGroup, H::GAPGroup = G)
 
 Return the homomorphism from `G` to `H` sending every element of `G` into the
-identity of `H`. If `H` is not specified, it is taken equal to `G`.
+identity of `H`.
 """
-function trivial_morphism(G::GAPGroup, H::GAPGroup)
+function trivial_morphism(G::GAPGroup, H::GAPGroup = G)
   return hom(G, H, x -> one(H))
-end
-
-function trivial_morphism(G::GAPGroup)
-  return hom(G, G, x -> one(G))
 end
 
 """
@@ -108,7 +104,7 @@ function hom(G::GAPGroup, H::GAPGroup, img::Function)
 end
 
 """
-    hom(G::GAPGroup, H::GAPGroup, gensG::Vector, imgs::Vector; check::Bool = true)
+    hom(G::GAPGroup, H::GAPGroup, gensG::Vector = gens(G), imgs::Vector; check::Bool = true)
 
 Return the group homomorphism defined by `gensG`[`i`] -> `imgs`[`i`] for every
 `i`. In order to work, the elements of `gensG` must generate `G`.
@@ -126,6 +122,10 @@ function hom(G::GAPGroup, H::GAPGroup, gensG::Vector, imgs::Vector; check::Bool 
   end
   if mp == GAP.Globals.fail throw(ArgumentError("Invalid input")) end
   return GAPGroupHomomorphism(G, H, mp)
+end
+
+function hom(G::GAPGroup, H::GAPGroup, imgs::Vector; check::Bool = true)
+  return hom(G, H, gens(G), imgs; check)
 end
 
 function domain(f::GAPGroupHomomorphism)

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -108,15 +108,22 @@ function hom(G::GAPGroup, H::GAPGroup, img::Function)
 end
 
 """
-    hom(G::GAPGroup, H::GAPGroup, gensG::Vector, imgs::Vector)
+    hom(G::GAPGroup, H::GAPGroup, gensG::Vector, imgs::Vector; check::Bool = true)
 
 Return the group homomorphism defined by `gensG`[`i`] -> `imgs`[`i`] for every
 `i`. In order to work, the elements of `gensG` must generate `G`.
+
+If `check` is set to `false` then it is not checked whether the mapping
+defines a group homomorphism.
 """
-function hom(G::GAPGroup, H::GAPGroup, gensG::Vector, imgs::Vector)
+function hom(G::GAPGroup, H::GAPGroup, gensG::Vector, imgs::Vector; check::Bool = true)
   vgens = GapObj([x.X for x in gensG])
   vimgs = GapObj([x.X for x in imgs])
-  mp = GAP.Globals.GroupHomomorphismByImages(G.X, H.X, vgens, vimgs)
+  if check
+    mp = GAP.Globals.GroupHomomorphismByImages(G.X, H.X, vgens, vimgs)
+  else
+    mp = GAP.Globals.GroupHomomorphismByImagesNC(G.X, H.X, vgens, vimgs)
+  end
   if mp == GAP.Globals.fail throw(ArgumentError("Invalid input")) end
   return GAPGroupHomomorphism(G, H, mp)
 end
@@ -495,7 +502,7 @@ An exception is thrown if `H` is not invariant under `f`.
 """
 function restrict_automorphism(f::GAPGroupElem{AutomorphismGroup{T}}, H::T, A=automorphism_group(H)) where T <: GAPGroup
   @assert isinvariant(f,H) "H is not invariant under f!"
-  fh = hom(H,H,gens(H), [f(x) for x in gens(H)])
+  fh = hom(H, H, gens(H), [f(x) for x in gens(H)], check = false)
   return A(fh)
 end
 

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -5,6 +5,9 @@ n = 6
    x = G(vcat(2:n-1, [1]))
 
    g = hom(G, G, gens(G), [y^x for y in gens(G)])
+   @test g == hom(G, G, gens(G), [y^x for y in gens(G)], check = false)
+   @test g == hom(G, G, [y^x for y in gens(G)])
+   @test g == hom(G, G, [y^x for y in gens(G)], check = false)
    @test typeof(g) == Oscar.GAPGroupHomomorphism{PermGroup, PermGroup}
    @test domain(g) == G
    @test codomain(g) == G


### PR DESCRIPTION
This change addresses #1098.

Concerning the hint that group inclusion morphisms should always be created with `check = false`, currently there are in fact no checks. The point is that these inclusions (as well as many other group homomorphisms) are created using a function and `GAP.Globals.GroupHomomorphismByFunction`, which does not perform checks.