### PR TITLE
Force push when deploying docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,6 +11,6 @@ deploydocs(
    target = "build",
    push_preview = true,
 #  make = () -> run(`mkdocs build`),
-   make = nothing
+   make = nothing,
    forcepush = true
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,4 +12,5 @@ deploydocs(
    push_preview = true,
 #  make = () -> run(`mkdocs build`),
    make = nothing
+   forcepush = true
 )


### PR DESCRIPTION
To not bloat the Oscar repository (it is already at 400 MB for a fresh clone).