### PR TITLE
ToricVarieties: Rational functionscharacters, basis of line bundle cohomology and construction of toric varieties from triangulations

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -1,4 +1,13 @@
 
+@Misc{cohomCalg:Implementation,
+  title         = {cohomCalg package},
+  howpublished  = {Download link},
+  url           = {https://github.com/BenjaminJurke/cohomCalg},
+  note          = {High-performance line bundle cohomology computation based
+                  on \cite{Blumenhagen:2010pv}},
+  year          = {2010}
+}
+
 @Book{AL94,
   title         = {An Introduction to Gröbner Bases},
   author        = {Adams, William W. and Loustaunau, Philippe},
@@ -74,6 +83,36 @@
   publisher     = {Cambridge University Press, Cambridge},
   year          = {2009},
   note          = {2nd edition}
+}
+
+@Article{BJRR10,
+  title         = {Cohomology of line bundles: A computational algorithm},
+  volume        = {51},
+  url           = {https://doi.org/10.1063/1.3501132},
+  doi           = {10.1063/1.3501132},
+  number        = {10},
+  journal       = {Journal of Mathematical Physics},
+  publisher     = {AIP Publishing},
+  author        = {Blumenhagen, Ralph and Jurke, Benjamin and Rahn, Thorsten
+                  and Roschy, Helmut},
+  year          = {2010},
+  month         = {Oct},
+  pages         = {103525}
+}
+
+@Article{BJRR12,
+  title         = {Cohomology of line bundles: Applications},
+  volume        = {53},
+  url           = {https://doi.org/10.1063/1.3677646},
+  doi           = {10.1063/1.3677646},
+  number        = {1},
+  journal       = {Journal of Mathematical Physics},
+  publisher     = {AIP Publishing},
+  author        = {Blumenhagen, Ralph and Jurke, Benjamin and Rahn, Thorsten
+                  and Roschy, Helmut},
+  year          = {2012},
+  month         = {Jan},
+  pages         = {012302}
 }
 
 @Article{BKR20,
@@ -180,7 +219,7 @@
   title         = {Centralizers and conjugacy classes in finite classical
                   groups},
   howpublished  = {arXiv:2008.12651},
-  url           = {http://export.arxiv.org/abs/2008.12651},
+  url           = {https://export.arxiv.org/abs/2008.12651},
   bibkey        = {{DF20}},
   year          = 2020
 }
@@ -367,6 +406,20 @@
   url           = {https://doi.org/10.1215/S0012-7094-96-08401-X}
 }
 
+@Article{FJR17,
+  title         = {A mathematical theory of the gauged linear sigma model},
+  volume        = {22},
+  url           = {https://doi.org/10.2140/gt.2018.22.235},
+  doi           = {10.2140/gt.2018.22.235},
+  number        = {1},
+  journal       = {Geometry & Topology},
+  publisher     = {Mathematical Sciences Publishers},
+  author        = {Fan, Huijun and Jarvis, Tyler and Ruan, Yongbin},
+  year          = {2017},
+  month         = {Oct},
+  pages         = {235–303}
+}
+
 @Article{Fau99,
   title         = {A new efficient algorithm for computing Gröbner bases
                   (F4)},
@@ -546,6 +599,21 @@
   pages         = {x+250},
   doi           = {10.1007/978-1-4471-4817-3},
   url           = {https://doi.org/10.1007/978-1-4471-4817-3}
+}
+
+@Article{Jow11,
+  title         = {Cohomology of toric line bundles via simplicial Alexander
+                  duality},
+  volume        = {52},
+  url           = {https://doi.org/10.1063/1.3562523},
+  doi           = {10.1063/1.3562523},
+  number        = {3},
+  journal       = {Journal of Mathematical Physics},
+  publisher     = {AIP Publishing},
+  author        = {Jow, Shin-Yao},
+  year          = {2011},
+  month         = {Mar},
+  pages         = {033506}
 }
 
 @InCollection{KL91,
@@ -754,19 +822,19 @@
   pages         = {xiv+499}
 }
 
-@article{Shim2018,
-author = {Ichiro Shimada},
-title = {{Connected Components of the Moduli of Elliptic $K3$ Surfaces}},
-volume = {67},
-journal = {Michigan Mathematical Journal},
-number = {3},
-publisher = {University of Michigan, Department of Mathematics},
-pages = {511 -- 559},
-year = {2018},
-doi = {10.1307/mmj/1528941621},
-URL = {https://doi.org/10.1307/mmj/1528941621}
+@Article{RR10,
+  title         = {Cohomology of line bundles: Proof of the algorithm},
+  volume        = {51},
+  url           = {https://doi.org/10.1063/1.3501135},
+  doi           = {10.1063/1.3501135},
+  number        = {10},
+  journal       = {Journal of Mathematical Physics},
+  publisher     = {AIP Publishing},
+  author        = {Roschy, Helmut and Rahn, Thorsten},
+  year          = {2010},
+  month         = {Oct},
+  pages         = {103520}
 }
-
 
 @Article{SY96,
   author        = {Shimoyama, Takeshi and Yokoyama, Kazuhiro},
@@ -780,6 +848,20 @@ URL = {https://doi.org/10.1307/mmj/1528941621}
   pages         = {247--277},
   doi           = {10.1006/jsco.1996.0052},
   url           = {https://doi.org/10.1006/jsco.1996.0052}
+}
+
+@Article{Shi18,
+  author        = {Ichiro Shimada},
+  title         = {{Connected Components of the Moduli of Elliptic $K3$
+                  Surfaces}},
+  volume        = {67},
+  journal       = {Michigan Mathematical Journal},
+  number        = {3},
+  publisher     = {University of Michigan, Department of Mathematics},
+  pages         = {511 -- 559},
+  year          = {2018},
+  doi           = {10.1307/mmj/1528941621},
+  url           = {https://doi.org/10.1307/mmj/1528941621}
 }
 
 @InCollection{Ste91,
@@ -842,6 +924,17 @@ URL = {https://doi.org/10.1307/mmj/1528941621}
   pages         = {4573--4583},
   doi           = {10.1016/j.laa.2013.02.026},
   url           = {https://doi.org/10.1016/j.laa.2013.02.026}
+}
+
+@Article{Wit88,
+  author        = {Witten, Edward},
+  title         = {Topological Sigma Models},
+  reportnumber  = {IASSNS-HEP-88/7},
+  doi           = {10.1007/BF01466725},
+  journal       = {Commun. Math. Phys.},
+  volume        = {118},
+  pages         = {411},
+  year          = {1988}
 }
 
 @Book{Zie95,

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -119,27 +119,23 @@ We support the Cox ring (also termed the "total coordinate ring" in [CLS11](@cit
 - `irrelevant ideal`,
 - `Stanley-Reisner ideal`
 For their computation, names for the indeterminates of the Cox ring must be chosen.
-The user is free to change these until the Cox ring is computed for the first time.
+The default value is `[x1, x2, ... ]`. the user can overwrite this at any time.
 
 ```@docs
 coordinate_names(v::AbstractNormalToricVariety)
 set_coordinate_names(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
 ```
 
-Likewise, a coefficient ring for the Cox ring must be chosen. The user can change 
-it until either the Cox ring or the toric ideal is computed for the first time.
+Likewise, a coefficient ring for the Cox ring must be chosen. The default value is 
+the field of rational numbers. The user can overwrite this at any time.
 
 ```@docs
 coefficient_ring(v::AbstractNormalToricVariety)
 set_coefficient_ring(v::AbstractNormalToricVariety, coefficient_ring::AbstractAlgebra.Ring)
 ```
 
-If no choice is made, we invoke the following default values:
-- `coefficient_ring` is chosen as the field of rational numbers,
-- `coordinate_names` is chosen as `[x1, x2, ... ]`.
-
-Similarly, for the computation of the coordinate ring of the torus, coordinate names have to be chosen.
-The default value is `[x1, x2, ... ]`. The user can overwrite this default value.
+Similarly, the computation of the coordinate ring of the torus requires coordinate names.
+Again, the default value is `[x1, x2, ... ]` and be overwritten at any time.
 
 ```@docs
 coordinate_names_of_torus(v::AbstractNormalToricVariety)

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -157,7 +157,9 @@ stanley_reisner_ideal(R::MPolyRing, v::AbstractNormalToricVariety)
 toric_ideal(antv::AffineNormalToricVariety)
 toric_ideal(R::MPolyRing, antv::AffineNormalToricVariety)
 coordinate_ring_of_torus(v::AbstractNormalToricVariety)
+coordinate_ring_of_torus(R::MPolyRing, v::AbstractNormalToricVariety)
 character_to_rational_function(v::AbstractNormalToricVariety, character::Vector{fmpz})
+character_to_rational_function(R::MPolyRing, v::AbstractNormalToricVariety, character::Vector{fmpz})
 ```
 
 ### Sheaves

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -155,6 +155,7 @@ stanley_reisner_ideal(R::MPolyRing, v::AbstractNormalToricVariety)
 toric_ideal(antv::AffineNormalToricVariety)
 toric_ideal(R::MPolyRing, antv::AffineNormalToricVariety)
 coordinate_ring_of_torus(v::AbstractNormalToricVariety)
+character_to_rational_function(v::AbstractNormalToricVariety, character::Vector{fmpz})
 ```
 
 ### Sheaves

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -51,6 +51,7 @@ projective_space(::Type{NormalToricVariety}, d::Int)
 ```@docs
 blowup_on_ith_minimal_torus_orbit(v::AbstractNormalToricVariety, n::Int, coordinate_name::String)
 Base.:*(v::AbstractNormalToricVariety, w::AbstractNormalToricVariety)
+NormalToricVarietyFromTriangulation(P::Polyhedron)
 ```
 
 

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -138,6 +138,14 @@ If no choice is made, we invoke the following default values:
 - `coefficient_ring` is chosen as the field of rational numbers,
 - `coordinate_names` is chosen as `[x1, x2, ... ]`.
 
+Similarly, for the computation of the coordinate ring of the torus, coordinate names have to be chosen.
+The default value is `[x1, x2, ... ]`. The user can overwrite this default value.
+
+```@docs
+coordinate_names_of_torus(v::AbstractNormalToricVariety)
+set_coordinate_names_of_torus(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
+```
+
 
 ### Rings and ideals
 
@@ -150,6 +158,7 @@ stanley_reisner_ideal(v::AbstractNormalToricVariety)
 stanley_reisner_ideal(R::MPolyRing, v::AbstractNormalToricVariety)
 toric_ideal(antv::AffineNormalToricVariety)
 toric_ideal(R::MPolyRing, antv::AffineNormalToricVariety)
+coordinate_ring_of_torus(v::AbstractNormalToricVariety)
 ```
 
 ### Sheaves

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -52,6 +52,7 @@ projective_space(::Type{NormalToricVariety}, d::Int)
 blowup_on_ith_minimal_torus_orbit(v::AbstractNormalToricVariety, n::Int, coordinate_name::String)
 Base.:*(v::AbstractNormalToricVariety, w::AbstractNormalToricVariety)
 NormalToricVarietyFromTriangulation(P::Polyhedron)
+NormalToricVarietyFromGLSM(charges::fmpz_mat)
 ```
 
 

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -51,7 +51,7 @@ projective_space(::Type{NormalToricVariety}, d::Int)
 ```@docs
 blowup_on_ith_minimal_torus_orbit(v::AbstractNormalToricVariety, n::Int, coordinate_name::String)
 Base.:*(v::AbstractNormalToricVariety, w::AbstractNormalToricVariety)
-NormalToricVarietyFromTriangulation(P::Polyhedron)
+NormalToricVarietiesFromStarTriangulations(P::Polyhedron)
 NormalToricVarietyFromGLSM(charges::fmpz_mat)
 ```
 

--- a/docs/src/ToricVarieties/ToricLineBundles.md
+++ b/docs/src/ToricVarieties/ToricLineBundles.md
@@ -64,9 +64,9 @@ all_cohomologies(l::ToricLineBundle)
 cohomology(l::ToricLineBundle, i::Int)
 ```
 
-In addition, we can also compute a basis of the global sections
-from characters.
+We can also compute a basis of the global sections.
 
 ```@docs
-basis_of_global_sections(l::ToricLineBundle)
+basis_of_global_sections_via_rational_functions(l::ToricLineBundle)
+basis_of_global_sections_via_homogeneous_component(l::ToricLineBundle)
 ```

--- a/docs/src/ToricVarieties/ToricLineBundles.md
+++ b/docs/src/ToricVarieties/ToricLineBundles.md
@@ -57,9 +57,16 @@ toric_variety(l::ToricLineBundle)
 ## Method
 
 We use [cohomCalg](https://github.com/BenjaminJurke/cohomCalg)
-to compute line bundle cohomologies. This is achieved with the following methods.
+to compute the dimension of line bundle cohomologies. This is achieved with the following methods.
 
 ```@docs
 all_cohomologies(l::ToricLineBundle)
 cohomology(l::ToricLineBundle, i::Int)
+```
+
+In addition, we can also compute a basis of the global sections
+from characters.
+
+```@docs
+basis_of_global_sections(l::ToricLineBundle)
 ```

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -89,7 +89,10 @@ export set_coordinate_names
 This method returns the names of the homogeneous coordinates of 
 the normal toric variety `v`. The default is `x1,...,xn`.
 """
-coordinate_names(v::AbstractNormalToricVariety) = get_attribute!(v, :coordinate_names, ["x$(i)" for i in 1:rank(torusinvariant_weil_divisor_group(v))])
+@attr Vector{String} function coordinate_names(v::AbstractNormalToricVariety)
+    return ["x$(i)" for i in 1:rank(torusinvariant_weil_divisor_group(v))]
+end
+export coordinate_names
 
 
 function _cox_ring_weights(v::AbstractNormalToricVariety)
@@ -337,7 +340,9 @@ export set_coordinate_names_of_torus
 This method returns the names of the coordinates of the torus of
 the normal toric variety `v`. The default is `x1,...,xn`.
 """
-coordinate_names_of_torus(v::AbstractNormalToricVariety) = get_attribute!(v, :coordinate_names_of_torus, ["x$(i)" for i in 1:ambient_dim(v)])
+@attr Vector{String} function coordinate_names_of_torus(v::AbstractNormalToricVariety)
+    return ["x$(i)" for i in 1:ambient_dim(v)]
+end
 export coordinate_names_of_torus
 
 

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -370,7 +370,8 @@ Computes the coordinate ring of the torus of the normal toric variety `v`
 in the given polynomial ring `R`.
 """
 function coordinate_ring_of_torus(R::MPolyRing, v::AbstractNormalToricVariety)
-    if length(gens(R)) < 2 * length(coordinate_names_of_torus(v))
+    n = length(coordinate_names_of_torus(v))
+    if length(gens(R)) < 2 * n
         throw(ArgumentError("The given ring must have at least $(length( coordinate_names_of_torus(v))) indeterminates."))
     end
     relations = [gens(R)[i] * gens(R)[i+length(coordinate_names_of_torus(v))] - one(coefficient_ring(R)) for i in 1:length(coordinate_names_of_torus(v))]
@@ -422,9 +423,9 @@ function character_to_rational_function(R::MPolyRing, v::AbstractNormalToricVari
     rational_function = one(coefficient_ring(R))
     for i in 1:length(character)
         if character[i] < 0
-            rational_function = rational_function * generators[i+ambient_dim(v)]^(-1*character[i])
+            rational_function *= generators[i+ambient_dim(v)]^(-1*character[i])
         else
-            rational_function = rational_function * generators[i]^(character[i])
+            rational_function *= generators[i]^(character[i])
         end
     end
     return rational_function

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -364,6 +364,38 @@ end
 export coordinate_ring_of_torus
 
 
+@doc Markdown.doc"""
+    character_to_rational_function(v::AbstractNormalToricVariety, character::Vector{fmpz})
+
+Computes the rational function corresponding to a character of the normal toric variety `v`.
+
+# Examples
+```jldoctest
+julia> p2 = projective_space(NormalToricVariety, 2);
+
+julia> character_to_rational_function(p2, [-1,2])
+x2^2*x1_
+```
+"""
+function character_to_rational_function(v::AbstractNormalToricVariety, character::Vector{fmpz})
+    if ambient_dim(v) != length(character)
+        throw(ArgumentError("A character consist of as many integers as the ambient dimension of the variety."))
+    end
+    generators = gens(coordinate_ring_of_torus(v))
+    rational_function = one(coefficient_ring(v))
+    for i in 1:length(character)
+        if character[i] < 0
+            rational_function = rational_function * generators[i+ambient_dim(v)]^(-1*character[i])
+        else
+            rational_function = rational_function * generators[i]^(character[i])
+        end
+    end
+    return rational_function
+end
+character_to_rational_function(v::AbstractNormalToricVariety, character::Vector{Int}) = character_to_rational_function(v, [fmpz(k) for k in character])
+export character_to_rational_function
+
+
 ############################
 # Characters, Weil divisor and the class group
 ############################

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -317,6 +317,53 @@ end
 export toric_ideal
 
 
+@doc Markdown.doc"""
+    set_coordinate_names_of_torus(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
+
+Allows to set the names of the coordinates of the torus.
+"""
+function set_coordinate_names_of_torus(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
+    if length(coordinate_names) != ambient_dim(v)
+        throw(ArgumentError("The provided list of coordinate names must match the ambient dimension of the fan."))
+    end
+    set_attribute!(v, :coordinate_names_of_torus, coordinate_names)
+end
+export set_coordinate_names_of_torus
+
+
+@doc Markdown.doc"""
+    coordinate_names_of_torus(v::AbstractNormalToricVariety)
+
+This method returns the names of the coordinates of the torus of
+the normal toric variety `v`. The default is `x1,...,xn`.
+"""
+coordinate_names_of_torus(v::AbstractNormalToricVariety) = get_attribute!(v, :coordinate_names_of_torus, ["x$(i)" for i in 1:ambient_dim(v)])
+export coordinate_names_of_torus
+
+
+@doc Markdown.doc"""
+    coordinate_ring_of_torus(v::AbstractNormalToricVariety)
+
+Computes the coordinate ring of the torus of the normal toric variety `v`.
+
+# Examples
+```jldoctest
+julia> p2 = projective_space(NormalToricVariety, 2);
+
+julia> set_coordinate_names_of_torus(p2, ["y1", "y2"])
+
+julia> coordinate_ring_of_torus(p2)
+Quotient of Multivariate Polynomial Ring in y1, y2, y1_, y2_ over Rational Field by ideal(y1*y1_ - 1, y2*y2_ - 1)
+```
+"""
+function coordinate_ring_of_torus(v::AbstractNormalToricVariety)
+    S, _ = PolynomialRing(coefficient_ring(v), vcat(coordinate_names_of_torus(v), [x*"_" for x in coordinate_names_of_torus(v)]), cached=false)
+    relations = [gens(S)[i] * gens(S)[i+length(coordinate_names_of_torus(v))] - one(coefficient_ring(v)) for i in 1:length(coordinate_names_of_torus(v))]
+    return quo(S, ideal(relations))[1]
+end
+export coordinate_ring_of_torus
+
+
 ############################
 # Characters, Weil divisor and the class group
 ############################

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -495,7 +495,53 @@ end
 
 
 ############################
-### 5: Display
+# 5: Toric varieties from triangulations
+############################
+
+@doc Markdown.doc"""
+    NormalToricVarietyFromTriangulation(P::Polyhedron)
+
+Returns the list of toric varieties obtained from fine regular
+star triangulations of the polyhedron P.
+
+# Examples
+```jldoctest
+julia> P = convex_hull([0 0 0; 0 0 1; 1 0 1; 1 1 1; 0 1 1])
+A polyhedron in ambient dimension 3
+
+julia> NormalToricVarietyFromTriangulation(P::Polyhedron)
+2-element Vector{NormalToricVariety}:
+ A normal toric variety
+ A normal toric variety
+```
+"""
+function NormalToricVarietyFromTriangulation(P::Polyhedron)
+    # triangulate the polyhedron
+    trias = star_triangulations(P)
+    
+    # Currently, the rays in trias[1]
+    # (a) are encoded as fmpq_mat (fmpz expected)
+    # (b) contain the origin as first element (not a rays, so to be removed)
+    rays = trias[1]
+    integral_rays = zeros(ZZ, nrows(rays)-1, ncols(rays))
+    for i in 2:nrows(rays)
+        integral_rays[i-1, 1:ncols(rays)] = [ZZ(c) for c in rays[i,1:ncols(rays)]]
+    end
+    
+    # trias[2] contains the max_cones as list of lists
+    # (a) needs to be converted to incidence matrix
+    # (b) one has to remove origin from list of indices (as removed above)
+    max_cones = trias[2]
+    max_cones = [IncidenceMatrix([[c[i]-1 for i in 2:length(c)] for c in t]) for t in max_cones]
+    
+    # construct the varieties
+    return [NormalToricVariety(PolyhedralFan(integral_rays, cones)) for cones in max_cones]
+end
+export NormalToricVarietyFromTriangulation
+
+
+############################
+### 6: Display
 ############################
 function Base.show(io::IO, v::AbstractNormalToricVariety)
     # initiate properties string

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -547,15 +547,19 @@ export NormalToricVarietiesFromStarTriangulations
 @doc Markdown.doc"""
     NormalToricVarietyFromGLSM(charges::fmpz_mat)
 
-Generalized-Sigma models (GLSM) originally sparked interest
-in the physics community in toric varieties. On a mathematical
-level, this establishes a construction of toric varieties for which a
-Z^n grading of the Cox ring is provided. This implies that the
-map from the group of torus invariant Weil divisors to the 
-class group is known. Under the assumption that the variety
-in question has no torus factor, we can then identify the map
-from the lattice to the group of torus invariant Weil divisors as
-the kernel of the map from the torus invariant Weil divisor to the
+Witten's Generalized-Sigma models (GLSM) [Wit88](@cite)
+originally sparked interest in the physics community in toric varieties.
+On a mathematical level, this establishes a construction of toric 
+varieties for  which a Z^n grading of the Cox ring is provided. See 
+for example [FJR17](@cite), which describes this as GIT 
+construction [CLS11](@cite).
+
+Explicitly, given the grading of the Cox ring, the map from
+the group of torus invariant Weil divisors to the class group
+is known. Under the assumption that the variety in question
+has no torus factor, we can then identify the map from the 
+lattice to the group of torus invariant Weil divisors as the 
+kernel of the map from the torus invariant Weil divisor to the
 class group. The latter is a map between free Abelian groups, i.e.
 is provided by an integer valued matrix. The rows of this matrix
 are nothing but the ray generators of the fan of the toric variety.

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -499,7 +499,7 @@ end
 ############################
 
 @doc Markdown.doc"""
-    NormalToricVarietyFromTriangulation(P::Polyhedron)
+    NormalToricVarietiesFromStarTriangulations(P::Polyhedron)
 
 Returns the list of toric varieties obtained from fine regular
 star triangulations of the polyhedron P.
@@ -509,13 +509,13 @@ star triangulations of the polyhedron P.
 julia> P = convex_hull([0 0 0; 0 0 1; 1 0 1; 1 1 1; 0 1 1])
 A polyhedron in ambient dimension 3
 
-julia> NormalToricVarietyFromTriangulation(P::Polyhedron)
+julia> NormalToricVarietiesFromStarTriangulations(P::Polyhedron)
 2-element Vector{NormalToricVariety}:
  A normal toric variety
  A normal toric variety
 ```
 """
-function NormalToricVarietyFromTriangulation(P::Polyhedron)
+function NormalToricVarietiesFromStarTriangulations(P::Polyhedron)
     # triangulate the polyhedron
     trias = star_triangulations(P)
     
@@ -537,7 +537,7 @@ function NormalToricVarietyFromTriangulation(P::Polyhedron)
     # construct the varieties
     return [NormalToricVariety(PolyhedralFan(integral_rays, cones)) for cones in max_cones]
 end
-export NormalToricVarietyFromTriangulation
+export NormalToricVarietiesFromStarTriangulations
 
 
 ############################
@@ -601,7 +601,7 @@ function NormalToricVarietyFromGLSM(charges::fmpz_mat)
 
     # construct polyhedron
     p = convex_hull(pts)
-    return NormalToricVarietyFromTriangulation(p)
+    return NormalToricVarietiesFromStarTriangulations(p)
 end
 NormalToricVarietyFromGLSM(charges::Vector{Vector{Int}}) = NormalToricVarietyFromGLSM(matrix(ZZ,charges))
 NormalToricVarietyFromGLSM(charges::Vector{Vector{fmpz}}) = NormalToricVarietyFromGLSM(matrix(ZZ,charges))

--- a/src/ToricVarieties/ToricLineBundles/attributes.jl
+++ b/src/ToricVarieties/ToricLineBundles/attributes.jl
@@ -58,12 +58,26 @@ export degree
 #####################
 
 @doc Markdown.doc"""
-    basis_of_global_sections(l::ToricLineBundle)
+    basis_of_global_sections_via_rational_functions(l::ToricLineBundle)
 
 Returns a basis of the global sections of the toric line bundle `l`.
 """
-@attr function basis_of_global_sections(l::ToricLineBundle)
+@attr function basis_of_global_sections_via_rational_functions(l::ToricLineBundle)
     characters = matrix(ZZ, lattice_points(polyhedron(toric_divisor(l))))
     return [character_to_rational_function(toric_variety(l), vec([fmpz(c) for c in characters[i,:]])) for i in 1:nrows(characters)]
 end
-export basis_of_global_sections
+export basis_of_global_sections_via_rational_functions
+
+
+@doc Markdown.doc"""
+    basis_of_global_sections_via_homogeneous_component(l::ToricLineBundle)
+
+Returns a basis of the global sections of the toric line bundle `l`,
+which is computed from a homogeneous component of the cox ring.
+"""
+@attr function basis_of_global_sections_via_homogeneous_component(l::ToricLineBundle)
+    hc = homogeneous_component(cox_ring(toric_variety(l)), divisor_class(l))
+    generators = gens(hc[1])
+    return [hc[2](x) for x in generators]
+end
+export basis_of_global_sections_via_homogeneous_component

--- a/src/ToricVarieties/ToricLineBundles/attributes.jl
+++ b/src/ToricVarieties/ToricLineBundles/attributes.jl
@@ -51,3 +51,19 @@ Returns the degree of the toric line bundle `l`.
     return sum(coefficients(toric_divisor(l)))
 end
 export degree
+
+
+#####################
+# 2. Basis of global sections
+#####################
+
+@doc Markdown.doc"""
+    basis_of_global_sections(l::ToricLineBundle)
+
+Returns a basis of the global sections of the toric line bundle `l`.
+"""
+@attr function basis_of_global_sections(l::ToricLineBundle)
+    characters = matrix(ZZ, lattice_points(polyhedron(toric_divisor(l))))
+    return [character_to_rational_function(toric_variety(l), vec([fmpz(c) for c in characters[i,:]])) for i in 1:nrows(characters)]
+end
+export basis_of_global_sections

--- a/src/ToricVarieties/cohomCalg.jl
+++ b/src/ToricVarieties/cohomCalg.jl
@@ -43,7 +43,13 @@ end
 @doc Markdown.doc"""
     all_cohomologies(l::ToricLineBundle)
 
-Computes the dimension of all sheaf cohomologies of the toric line bundle `l`.
+Computes the dimension of all sheaf cohomologies of the 
+toric line bundle `l` by use of the cohomCalg algorithm 
+[BJRR10](@cite),
+[cohomCalg:Implementation(@cite),
+[RR10](@cite),
+[Jow11](@cite),
+[BJRR12](@cite).
 
 # Examples
 ```jldoctest
@@ -171,7 +177,13 @@ export all_cohomologies
 @doc Markdown.doc"""
     cohomology(l::ToricLineBundle, i::Int)
 
-Computes the dimension of the i-th sheaf cohomology of the toric line bundle `l`.
+Computes the dimension of the i-th sheaf cohomology of the
+toric line bundle `l` by use of the cohomCalg algorithm
+[BJRR10](@cite),
+[cohomCalg:Implementation(@cite),
+[RR10](@cite),
+[Jow11](@cite),
+[BJRR12](@cite).
 
 # Examples
 ```jldoctest

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -284,3 +284,9 @@ torus_coordinate_ring = coordinate_ring_of_torus(dP3)
     @test length(basis_of_global_sections_via_rational_functions(line_bundle2)) == 1
     @test length(basis_of_global_sections_via_rational_functions(line_bundle2^2)) == length(basis_of_global_sections_via_homogeneous_component(line_bundle2^2))
 end
+
+P = convex_hull([0 0 0; 0 0 1; 1 0 1; 1 1 1; 0 1 1])
+
+@testset "ToricVarieties from triangulations and GLSMs" begin
+    @test length(NormalToricVarietyFromTriangulation(P)) == 2
+end

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -292,6 +292,6 @@ charges[1,2] = 1;
 charges[1,3] = 1;
 
 @testset "ToricVarieties from triangulations and GLSMs" begin
-    @test length(NormalToricVarietyFromTriangulation(P)) == 2
+    @test length(NormalToricVarietiesFromStarTriangulations(P)) == 2
     @test length(NormalToricVarietyFromGLSM(charges)) == 1
 end

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -286,7 +286,12 @@ torus_coordinate_ring = coordinate_ring_of_torus(dP3)
 end
 
 P = convex_hull([0 0 0; 0 0 1; 1 0 1; 1 1 1; 0 1 1])
+charges = zero_matrix(ZZ, 1, 3);
+charges[1,1] = 1;
+charges[1,2] = 1;
+charges[1,3] = 1;
 
 @testset "ToricVarieties from triangulations and GLSMs" begin
     @test length(NormalToricVarietyFromTriangulation(P)) == 2
+    @test length(NormalToricVarietyFromGLSM(charges)) == 1
 end

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -278,8 +278,9 @@ end
 
 torus_coordinate_ring = coordinate_ring_of_torus(dP3)
 
-@testset "Characters and rational functions" begin
+@testset "Characters, rational functions and global sections" begin
     @test ngens(torus_coordinate_ring.I) == 2
-    @test length(basis_of_global_sections(line_bundle)) == 11
-    @test length(basis_of_global_sections(line_bundle2)) == 1
+    @test length(basis_of_global_sections_via_rational_functions(line_bundle)) == 11
+    @test length(basis_of_global_sections_via_rational_functions(line_bundle2)) == 1
+    @test length(basis_of_global_sections_via_rational_functions(line_bundle2^2)) == length(basis_of_global_sections_via_homogeneous_component(line_bundle2^2))
 end

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -280,4 +280,6 @@ torus_coordinate_ring = coordinate_ring_of_torus(dP3)
 
 @testset "Characters and rational functions" begin
     @test ngens(torus_coordinate_ring.I) == 2
+    @test length(basis_of_global_sections(line_bundle)) == 11
+    @test length(basis_of_global_sections(line_bundle2)) == 1
 end

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -275,3 +275,9 @@ line_bundle2 = ToricLineBundle(D2)
     @test all_cohomologies(line_bundle) == [11,0,0]
     @test cohomology(line_bundle,0) == 11
 end
+
+torus_coordinate_ring = coordinate_ring_of_torus(dP3)
+
+@testset "Characters and rational functions" begin
+    @test ngens(torus_coordinate_ring.I) == 2
+end


### PR DESCRIPTION
- coordinate ring of torus
- update documentation: coordinate names and coefficient ring can by now be changed at any time
- convert character to a rational function
- find a basis of the global sections of a toric line bundle in terms of rational functions
- find a basis of the global sections of a toric line bundle in terms of homogeneous component of the Cox ring
- construct toric varieties from triangulations
- construct toric variety from GLSM charges
- added references on GLSMs and cohomCalg