### PR TITLE
added a new `hom` method

### DIFF
--- a/docs/src/Groups/grouphom.md
+++ b/docs/src/Groups/grouphom.md
@@ -52,6 +52,7 @@ true
 hom(G::GAPGroup, H::GAPGroup, img::Function)
 hom(G::GAPGroup, H::GAPGroup, gensG::Vector, imgs::Vector)
 image(f::GAPGroupHomomorphism, x::GAPGroupElem)
+preimage(f::GAPGroupHomomorphism, x::GAPGroupElem)
 restrict_homomorphism(f::GAPGroupHomomorphism, H::GAPGroup)
 ```
 

--- a/experimental/GModule/Cohomology.jl
+++ b/experimental/GModule/Cohomology.jl
@@ -498,12 +498,6 @@ function confluent_fp_group(G::Oscar.GAPGroup)
   return Fp, GAPGroupHomomorphism(Fp, G, GAP.Globals.InverseGeneralMapping(C.fphom)), ru
 end
 
-function Oscar.preimage(f::GAPGroupHomomorphism, x::GAPGroupElem) 
-  fl, p = haspreimage(f, x)
-  @assert fl
-  return p
-end
-
 
 #############################
 #

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -31,7 +31,7 @@ end
 
 function _as_subgroup(G::GAPGroup, H::GapObj)
   H1 = _as_subgroup_bare(G, H)
-  return H1, hom(H1, G, x -> group_element(G, x.X))
+  return H1, hom(H1, G, x -> group_element(G, x.X), x -> group_element(H1, x.X); is_known_to_be_bijective = false)
 end
 
 """

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -1,3 +1,12 @@
+@testset "embeddings" begin
+   @testset for G in [symmetric_group(5), small_group(24, 12), general_linear_group(2, 3)]
+     G = symmetric_group(5)
+     H, emb = sylow_subgroup(G, 2)
+     x = gen(H, 1)
+     y = image(emb, x)
+     @test preimage(emb, y) == x
+   end
+end
 
 n = 6
 @testset "Homomorphism in Sym($n)" begin


### PR DESCRIPTION
- moved `preimage(f::GAPGroupHomomorphism, x::GAPGroupElem)` from
  `experimental/GModule/Cohomology.jl` to `src/Groups/homomorphisms.jl`
- added `hom(G::GAPGroup, H::GAPGroup, img::Function, preimg::Function; is_known_to_be_bijective::Bool = false)`,
  which admits the computation of preimages for more types of groups
- use this `hom` variant in `_as_subgroup`

Effects of the last change:

- We can now compute `Oscar.RepPc.reps(CyclotomicField(24)[1], special_linear_group(2,3))`; up to now, a matrix group as the second argument was not allowed.
- Those group embeddings that are the identity on the GAP side are now cheaper. (We can still improve this situation by avoiding several steps of wrapping/unwrapping group elements.)