### PR TITLE
added `describe` for `GrpAbFinGen`

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -915,6 +915,16 @@ An exception is thrown if `G` is not nilpotent.
    return GAP.Globals.NilpotencyClassOfGroup(G.X)::Int
 end
 
+
+function describe(G::GrpAbFinGen)
+   l = elementary_divisors(G)
+   length(l) == 0 && return "0"   # trivial group
+   l_tor = filter(x -> x != 0, l)
+   free = length(l) - length(l_tor)
+   res = length(l_tor) == 0 ? "" : "Z/" * join([string(x) for x in l_tor], " + Z/")
+   return free == 0 ? res : ( res == "" ? ( free == 1 ? "Z" : "Z^$free" ) : ( free == 1 ? "$res + Z" : "$res + Z^$free" ) )
+end
+
 @doc Markdown.doc"""
     describe(G::GAPGroup)
 

--- a/test/Groups/GrpAb.jl
+++ b/test/Groups/GrpAb.jl
@@ -11,3 +11,15 @@
   @test issurjective(g)
   @test order(codomain(g)) == 2
 end
+
+@testset "describe for GrpAbFinGen" begin
+  @test describe(abelian_group(GrpAbFinGen, Int[])) == "0"
+  @test describe(abelian_group(GrpAbFinGen, Int[0])) == "Z"
+  @test describe(abelian_group(GrpAbFinGen, Int[0, 0])) == "Z^2"
+  @test describe(abelian_group(GrpAbFinGen, Int[2])) == "Z/2"
+  @test describe(abelian_group(GrpAbFinGen, Int[0, 2])) == "Z/2 + Z"
+  @test describe(abelian_group(GrpAbFinGen, Int[0, 0, 2])) == "Z/2 + Z^2"
+  @test describe(abelian_group(GrpAbFinGen, Int[2, 4])) == "Z/2 + Z/4"
+  @test describe(abelian_group(GrpAbFinGen, Int[0, 2, 4])) == "Z/2 + Z/4 + Z"
+  @test describe(abelian_group(GrpAbFinGen, Int[0, 0, 2, 4])) == "Z/2 + Z/4 + Z^2"
+end


### PR DESCRIPTION
resolves #1132

The proposed notation is an additive one.
For abelian groups of type `GAPGroup`, `describe` returns a description as a multiplicative group.
(Perhaps we should add an optional argument `additive::Bool = false` that allows one to specify which notation one wants for abelian groups.)