### PR TITLE
added optional argument `check` to `haspreimage`, improved an error message

### DIFF
--- a/docs/src/Groups/grouphom.md
+++ b/docs/src/Groups/grouphom.md
@@ -88,7 +88,7 @@ julia> x^f
 
 A sort of "inverse" of the evaluation is the following
 ```@docs
-haspreimage(f::GAPGroupHomomorphism, x::GAPGroupElem)
+haspreimage(f::GAPGroupHomomorphism, x::GAPGroupElem; check::Bool = true)
 ```
   **Example:**
 ```jldoctest

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -146,6 +146,7 @@ julia> perm(symmetric_group(6),[2,4,6,1,3,5])
 """
 function perm(g::PermGroup, L::AbstractVector{<:IntegerUnion})
    x = GAP.Globals.PermList(GAP.GapObj(L;recursive=true))
+   x == GAP.Globals.fail && throw(ArgumentError("the list does not describe a permutation"))
    if length(L) <= degree(g) && x in g.X
      return PermGroupElem(g, x)
    end

--- a/test/Groups/elements.jl
+++ b/test/Groups/elements.jl
@@ -48,6 +48,7 @@
   @test_throws ArgumentError G([2,3,1,4,6,5,7])
   @test G(gap_perm([2,3,1,4,6,5,7]))==gap_perm([2,3,1,4,6,5])
   @test_throws ArgumentError perm(G,[2,3,4,5,6,7,1])
+  @test_throws ArgumentError perm(G, [1,1])
   @test one(G)==cperm(G,Int64[])
 end
 

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -5,6 +5,7 @@
      x = gen(H, 1)
      y = image(emb, x)
      @test preimage(emb, y) == x
+     @test any(g -> ! haspreimage(emb, g)[1], gens(G))
    end
 end
 


### PR DESCRIPTION
- Concerning `haspreimage`: Due to a GAP bug (see gap-system/gap/issues/4809), we have to check for membership in the image not in the codomain.
- Concerning the error message: `perm` now says that the given list of images does not describe a permutation if this is the case.