### PR TITLE
support `Oscar.is_unicode_allowed` in matrix display

### DIFF
--- a/src/Groups/MatrixDisplay.jl
+++ b/src/Groups/MatrixDisplay.jl
@@ -119,8 +119,6 @@ The following attributes of `io` are supported.
 
 ## Examples
 ```jldoctest
-julia> old_allow_unicode = Oscar.allow_unicode(true);
-
 julia> m = 3; n = 4;  mat = Array{String}(undef, m, n);
 
 julia> for i in 1:m for j in 1:n mat[i,j] = string( (i,j) ); end; end
@@ -142,7 +140,9 @@ julia> ioc = IOContext(io,
               :footer => ["", "with footer"],
              );
 
-julia> labelled_matrix_formatted(ioc, mat)
+julia> Oscar.with_unicode() do
+         labelled_matrix_formatted(ioc, mat)
+       end;
 
 julia> print(String(take!(io)))
 
@@ -165,7 +165,9 @@ julia> ioc = IOContext(io,
               :portions_col => [2,2],
              );
 
-julia> labelled_matrix_formatted(ioc, mat)
+julia> Oscar.with_unicode() do
+         labelled_matrix_formatted(ioc, mat)
+       end;
 
 julia> print(String(take!(io)))
  │     1      2
@@ -185,8 +187,6 @@ julia> print(String(take!(io)))
  │     3      4
 ─┼─────────────
 3│(3, 3) (3, 4)
-
-julia> Oscar.allow_unicode(old_allow_unicode);
 
 ```
 """

--- a/src/Groups/MatrixDisplay.jl
+++ b/src/Groups/MatrixDisplay.jl
@@ -118,7 +118,9 @@ The following attributes of `io` are supported.
   and to create portions according to the screen width otherwise,
 
 ## Examples
-```jldoctest; setup = :(Oscar.allow_unicode(true))
+```jldoctest
+julia> old_allow_unicode = Oscar.allow_unicode(true);
+
 julia> m = 3; n = 4;  mat = Array{String}(undef, m, n);
 
 julia> for i in 1:m for j in 1:n mat[i,j] = string( (i,j) ); end; end
@@ -183,6 +185,8 @@ julia> print(String(take!(io)))
  │     3      4
 ─┼─────────────
 3│(3, 3) (3, 4)
+
+julia> Oscar.allow_unicode(old_allow_unicode);
 
 ```
 """

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -43,7 +43,7 @@ if `F` is not given then the result has type `QabElem`.
 `description` is assumed to have the format defined in
 [CCNPW85](@cite), Chapter 6, Section 10.
 
-```jldoctest
+```jldoctest; setup = :(Oscar.allow_unicode(true))
 julia> atlas_irrationality("r5")
 -2*ζ(5)^3 - 2*ζ(5)^2 - 1
 
@@ -126,7 +126,7 @@ If the `p`-modular character table of `G` cannot be computed by GAP
 then `nothing` is returned.
 
 # Examples
-```jldoctest
+```jldoctest; setup = :(Oscar.allow_unicode(true))
 julia> character_table( symmetric_group(3) )
 Sym( [ 1 .. 3 ] )
 

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -45,26 +45,26 @@ if `F` is not given then the result has type `QabElem`.
 
 ```jldoctest
 julia> Oscar.with_unicode() do
-         show(atlas_irrationality("r5"))
-       end;
+         atlas_irrationality("r5"))
+       end
 -2*ζ(5)^3 - 2*ζ(5)^2 - 1
 
 julia> atlas_irrationality(CyclotomicField(5)[1], "r5")
 -2*z_5^3 - 2*z_5^2 - 1
 
 julia> Oscar.with_unicode() do
-         show(atlas_irrationality("i"))
-       end;
+         atlas_irrationality("i")
+       end
 ζ(4)
 
 julia> Oscar.with_unicode() do
-         show(atlas_irrationality("b7*3"))
-       end;
+         atlas_irrationality("b7*3")
+       end
 -ζ(7)^4 - ζ(7)^2 - ζ(7) - 1
 
 julia> Oscar.with_unicode() do
-         show(atlas_irrationality("3y'''24*13-2&5"))
-       end;
+         atlas_irrationality("3y'''24*13-2&5")
+       end
 -5*ζ(24)^7 - 2*ζ(24)^5 + 2*ζ(24)^3 - 3*ζ(24)
 
 ```
@@ -136,8 +136,8 @@ then `nothing` is returned.
 # Examples
 ```jldoctest
 julia> Oscar.with_unicode() do
-         show(character_table(symmetric_group(3)))
-       end;
+         character_table(symmetric_group(3))
+       end
 Sym( [ 1 .. 3 ] )
 
  2  1  1  .
@@ -152,8 +152,8 @@ Sym( [ 1 .. 3 ] )
 χ₃  1  1  1
 
 julia> Oscar.with_unicode() do
-         show(character_table(symmetric_group(3), 2))
-       end;
+         character_table(symmetric_group(3), 2)
+       end
 Sym( [ 1 .. 3 ] ) mod 2
 
  2  1  .

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -43,7 +43,9 @@ if `F` is not given then the result has type `QabElem`.
 `description` is assumed to have the format defined in
 [CCNPW85](@cite), Chapter 6, Section 10.
 
-```jldoctest; setup = :(Oscar.allow_unicode(true))
+```jldoctest
+julia> old_allow_unicode = Oscar.allow_unicode(true);
+
 julia> atlas_irrationality("r5")
 -2*ζ(5)^3 - 2*ζ(5)^2 - 1
 
@@ -58,6 +60,8 @@ julia> atlas_irrationality("b7*3")
 
 julia> atlas_irrationality("3y'''24*13-2&5")
 -5*ζ(24)^7 - 2*ζ(24)^5 + 2*ζ(24)^3 - 3*ζ(24)
+
+julia> Oscar.allow_unicode(old_allow_unicode);
 
 ```
 """
@@ -126,7 +130,9 @@ If the `p`-modular character table of `G` cannot be computed by GAP
 then `nothing` is returned.
 
 # Examples
-```jldoctest; setup = :(Oscar.allow_unicode(true))
+```jldoctest
+julia> old_allow_unicode = Oscar.allow_unicode(true);
+
 julia> character_table( symmetric_group(3) )
 Sym( [ 1 .. 3 ] )
 
@@ -155,6 +161,8 @@ Sym( [ 1 .. 3 ] ) mod 2
 χ₁  1  1
 χ₂  2 -1
 
+
+julia> Oscar.allow_unicode(old_allow_unicode);
 
 ```
 """

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -44,24 +44,28 @@ if `F` is not given then the result has type `QabElem`.
 [CCNPW85](@cite), Chapter 6, Section 10.
 
 ```jldoctest
-julia> old_allow_unicode = Oscar.allow_unicode(true);
-
-julia> atlas_irrationality("r5")
+julia> Oscar.with_unicode() do
+         show(atlas_irrationality("r5"))
+       end;
 -2*ζ(5)^3 - 2*ζ(5)^2 - 1
 
 julia> atlas_irrationality(CyclotomicField(5)[1], "r5")
 -2*z_5^3 - 2*z_5^2 - 1
 
-julia> atlas_irrationality("i")
+julia> Oscar.with_unicode() do
+         show(atlas_irrationality("i"))
+       end;
 ζ(4)
 
-julia> atlas_irrationality("b7*3")
+julia> Oscar.with_unicode() do
+         show(atlas_irrationality("b7*3"))
+       end;
 -ζ(7)^4 - ζ(7)^2 - ζ(7) - 1
 
-julia> atlas_irrationality("3y'''24*13-2&5")
+julia> Oscar.with_unicode() do
+         show(atlas_irrationality("3y'''24*13-2&5"))
+       end;
 -5*ζ(24)^7 - 2*ζ(24)^5 + 2*ζ(24)^3 - 3*ζ(24)
-
-julia> Oscar.allow_unicode(old_allow_unicode);
 
 ```
 """
@@ -131,9 +135,9 @@ then `nothing` is returned.
 
 # Examples
 ```jldoctest
-julia> old_allow_unicode = Oscar.allow_unicode(true);
-
-julia> character_table( symmetric_group(3) )
+julia> Oscar.with_unicode() do
+         show(character_table(symmetric_group(3)))
+       end;
 Sym( [ 1 .. 3 ] )
 
  2  1  1  .
@@ -147,8 +151,9 @@ Sym( [ 1 .. 3 ] )
 χ₂  2  . -1
 χ₃  1  1  1
 
-
-julia> character_table( symmetric_group(3), 2 )
+julia> Oscar.with_unicode() do
+         show(character_table(symmetric_group(3), 2))
+       end;
 Sym( [ 1 .. 3 ] ) mod 2
 
  2  1  .
@@ -160,9 +165,6 @@ Sym( [ 1 .. 3 ] ) mod 2
         
 χ₁  1  1
 χ₂  2 -1
-
-
-julia> Oscar.allow_unicode(old_allow_unicode);
 
 ```
 """

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -45,26 +45,26 @@ if `F` is not given then the result has type `QabElem`.
 
 ```jldoctest
 julia> Oscar.with_unicode() do
-         atlas_irrationality("r5"))
-       end
+         show(atlas_irrationality("r5"))
+       end;
 -2*ζ(5)^3 - 2*ζ(5)^2 - 1
 
 julia> atlas_irrationality(CyclotomicField(5)[1], "r5")
 -2*z_5^3 - 2*z_5^2 - 1
 
 julia> Oscar.with_unicode() do
-         atlas_irrationality("i")
-       end
+         show(atlas_irrationality("i"))
+       end;
 ζ(4)
 
 julia> Oscar.with_unicode() do
-         atlas_irrationality("b7*3")
-       end
+         show(atlas_irrationality("b7*3"))
+       end;
 -ζ(7)^4 - ζ(7)^2 - ζ(7) - 1
 
 julia> Oscar.with_unicode() do
-         atlas_irrationality("3y'''24*13-2&5")
-       end
+         show(atlas_irrationality("3y'''24*13-2&5"))
+       end;
 -5*ζ(24)^7 - 2*ζ(24)^5 + 2*ζ(24)^3 - 3*ζ(24)
 
 ```
@@ -136,8 +136,8 @@ then `nothing` is returned.
 # Examples
 ```jldoctest
 julia> Oscar.with_unicode() do
-         character_table(symmetric_group(3))
-       end
+         show(character_table(symmetric_group(3)))
+       end;
 Sym( [ 1 .. 3 ] )
 
  2  1  1  .
@@ -152,8 +152,8 @@ Sym( [ 1 .. 3 ] )
 χ₃  1  1  1
 
 julia> Oscar.with_unicode() do
-         character_table(symmetric_group(3), 2)
-       end
+         show(character_table(symmetric_group(3), 2))
+       end;
 Sym( [ 1 .. 3 ] ) mod 2
 
  2  1  .

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -43,8 +43,7 @@ function is_unicode_allowed()
 end
 
 function with_unicode(f::Function)
-  old_allow_unicode = allow_unicode(true)
-  result = f()
-  allow_unicode(old_allow_unicode)
-  return result
+  old_allow_unicode = allow_unicode(true);
+  f()
+  allow_unicode(old_allow_unicode);
 end

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -41,3 +41,9 @@ export allow_unicode
 function is_unicode_allowed()
   return @load_preference("unicode", default = false)
 end
+
+function with_unicode(f::Function)
+  old_allow_unicode = allow_unicode(true);
+  f()
+  allow_unicode(old_allow_unicode);
+end

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -43,7 +43,8 @@ function is_unicode_allowed()
 end
 
 function with_unicode(f::Function)
-  old_allow_unicode = allow_unicode(true);
-  f()
-  allow_unicode(old_allow_unicode);
+  old_allow_unicode = allow_unicode(true)
+  result = f()
+  allow_unicode(old_allow_unicode)
+  return result
 end

--- a/test/Groups/MatrixDisplay.jl
+++ b/test/Groups/MatrixDisplay.jl
@@ -2,8 +2,6 @@
   m = 2; n = 2;  mat = Array{String}(undef, m, n);
   for i in 1:m for j in 1:n mat[i,j] = string(i)*"/"*string(j); end; end
 
-  old_allow = Oscar.is_unicode_allowed()
-
   io = IOBuffer();
 
   # no labels
@@ -102,10 +100,10 @@
   ioc = IOContext(io,
           :separators_row => [0, 1, 2],
         );
-  Oscar.allow_unicode(true)
-  labelled_matrix_formatted(ioc, mat)
+  Oscar.with_unicode() do
+    labelled_matrix_formatted(ioc, mat)
+  end
   @test String(take!(io)) == "───────\n1/1 1/2\n───────\n2/1 2/2\n───────\n"
-  Oscar.allow_unicode(false)
   labelled_matrix_formatted(ioc, mat)
   @test String(take!(io)) == "-------\n1/1 1/2\n-------\n2/1 2/2\n-------\n"
 
@@ -114,10 +112,10 @@
           :labels_col => [string(j) for j in 1:n],
           :separators_row => [0,1,2],
         );
-  Oscar.allow_unicode(true)
-  labelled_matrix_formatted(ioc, mat)
+  Oscar.with_unicode() do
+    labelled_matrix_formatted(ioc, mat)
+  end
   @test String(take!(io)) == "  1   2\n───────\n1/1 1/2\n───────\n2/1 2/2\n───────\n"
-  Oscar.allow_unicode(false)
   labelled_matrix_formatted(ioc, mat)
   @test String(take!(io)) == "  1   2\n-------\n1/1 1/2\n-------\n2/1 2/2\n-------\n"
 
@@ -125,10 +123,10 @@
   ioc = IOContext(io,
           :separators_col => [0, 1, 2],
         );
-  Oscar.allow_unicode(true)
-  labelled_matrix_formatted(ioc, mat)
+  Oscar.with_unicode() do
+    labelled_matrix_formatted(ioc, mat)
+  end
   @test String(take!(io)) == "│1/1│1/2│\n│2/1│2/2│\n"
-  Oscar.allow_unicode(false)
   labelled_matrix_formatted(ioc, mat)
   @test String(take!(io)) == "|1/1|1/2|\n|2/1|2/2|\n"
 
@@ -137,10 +135,10 @@
           :labels_row => [string(i)*":" for i in 1:m],
           :separators_col => [0, 1, 2],
         );
-  Oscar.allow_unicode(true)
-  labelled_matrix_formatted(ioc, mat)
+  Oscar.with_unicode() do
+    labelled_matrix_formatted(ioc, mat)
+  end
   @test String(take!(io)) == "1:│1/1│1/2│\n2:│2/1│2/2│\n"
-  Oscar.allow_unicode(false)
   labelled_matrix_formatted(ioc, mat)
   @test String(take!(io)) == "1:|1/1|1/2|\n2:|2/1|2/2|\n"
 
@@ -151,10 +149,10 @@
           :separators_row => [0, 1, 2],
           :separators_col => [0, 1, 2],
         );
-  Oscar.allow_unicode(true)
-  labelled_matrix_formatted(ioc, mat)
+  Oscar.with_unicode() do
+    labelled_matrix_formatted(ioc, mat)
+  end
   @test String(take!(io)) == "  │  1│  2│\n──┼───┼───┼\n1:│1/1│1/2│\n──┼───┼───┼\n2:│2/1│2/2│\n──┼───┼───┼\n"
-  Oscar.allow_unicode(false)
   labelled_matrix_formatted(ioc, mat)
   @test String(take!(io)) == "  |  1|  2|\n--+---+---+\n1:|1/1|1/2|\n--+---+---+\n2:|2/1|2/2|\n--+---+---+\n"
 
@@ -167,14 +165,12 @@
           :portions_row => [1,1],
           :portions_col => [1,1],
         );
-  Oscar.allow_unicode(true)
-  labelled_matrix_formatted(ioc, mat)
+  Oscar.with_unicode() do
+    labelled_matrix_formatted(ioc, mat)
+  end
   @test String(take!(io)) == "  │  1\n──┼───\n1:│1/1\n\n  │  1\n──┼───\n2:│2/1\n\n  │  2\n──┼───\n1:│1/2\n\n  │  2\n──┼───\n2:│2/2\n"
-  Oscar.allow_unicode(false)
   labelled_matrix_formatted(ioc, mat)
   @test String(take!(io)) == "  |  1\n--+---\n1:|1/1\n\n  |  1\n--+---\n2:|2/1\n\n  |  2\n--+---\n1:|1/2\n\n  |  2\n--+---\n2:|2/2\n"
-
-  Oscar.allow_unicode(old_allow)
 end
 
 @testset "labelled_matrix_formatted, LaTeX format" begin

--- a/test/Groups/MatrixDisplay.jl
+++ b/test/Groups/MatrixDisplay.jl
@@ -2,6 +2,8 @@
   m = 2; n = 2;  mat = Array{String}(undef, m, n);
   for i in 1:m for j in 1:n mat[i,j] = string(i)*"/"*string(j); end; end
 
+  old_allow = Oscar.is_unicode_allowed()
+
   io = IOBuffer();
 
   # no labels
@@ -100,31 +102,47 @@
   ioc = IOContext(io,
           :separators_row => [0, 1, 2],
         );
+  Oscar.allow_unicode(true)
   labelled_matrix_formatted(ioc, mat)
   @test String(take!(io)) == "───────\n1/1 1/2\n───────\n2/1 2/2\n───────\n"
+  Oscar.allow_unicode(false)
+  labelled_matrix_formatted(ioc, mat)
+  @test String(take!(io)) == "-------\n1/1 1/2\n-------\n2/1 2/2\n-------\n"
 
   # with row separators and column labels
   ioc = IOContext(io,
           :labels_col => [string(j) for j in 1:n],
           :separators_row => [0,1,2],
         );
+  Oscar.allow_unicode(true)
   labelled_matrix_formatted(ioc, mat)
   @test String(take!(io)) == "  1   2\n───────\n1/1 1/2\n───────\n2/1 2/2\n───────\n"
+  Oscar.allow_unicode(false)
+  labelled_matrix_formatted(ioc, mat)
+  @test String(take!(io)) == "  1   2\n-------\n1/1 1/2\n-------\n2/1 2/2\n-------\n"
 
   # with column separators but without row labels
   ioc = IOContext(io,
           :separators_col => [0, 1, 2],
         );
+  Oscar.allow_unicode(true)
   labelled_matrix_formatted(ioc, mat)
   @test String(take!(io)) == "│1/1│1/2│\n│2/1│2/2│\n"
+  Oscar.allow_unicode(false)
+  labelled_matrix_formatted(ioc, mat)
+  @test String(take!(io)) == "|1/1|1/2|\n|2/1|2/2|\n"
 
   # with column separators and row labels
   ioc = IOContext(io,
           :labels_row => [string(i)*":" for i in 1:m],
           :separators_col => [0, 1, 2],
         );
+  Oscar.allow_unicode(true)
   labelled_matrix_formatted(ioc, mat)
   @test String(take!(io)) == "1:│1/1│1/2│\n2:│2/1│2/2│\n"
+  Oscar.allow_unicode(false)
+  labelled_matrix_formatted(ioc, mat)
+  @test String(take!(io)) == "1:|1/1|1/2|\n2:|2/1|2/2|\n"
 
   # with row and column labels and separators
   ioc = IOContext(io,
@@ -133,8 +151,12 @@
           :separators_row => [0, 1, 2],
           :separators_col => [0, 1, 2],
         );
+  Oscar.allow_unicode(true)
   labelled_matrix_formatted(ioc, mat)
   @test String(take!(io)) == "  │  1│  2│\n──┼───┼───┼\n1:│1/1│1/2│\n──┼───┼───┼\n2:│2/1│2/2│\n──┼───┼───┼\n"
+  Oscar.allow_unicode(false)
+  labelled_matrix_formatted(ioc, mat)
+  @test String(take!(io)) == "  |  1|  2|\n--+---+---+\n1:|1/1|1/2|\n--+---+---+\n2:|2/1|2/2|\n--+---+---+\n"
 
   # with row and column portions
   ioc = IOContext(io,
@@ -145,8 +167,14 @@
           :portions_row => [1,1],
           :portions_col => [1,1],
         );
+  Oscar.allow_unicode(true)
   labelled_matrix_formatted(ioc, mat)
   @test String(take!(io)) == "  │  1\n──┼───\n1:│1/1\n\n  │  1\n──┼───\n2:│2/1\n\n  │  2\n──┼───\n1:│1/2\n\n  │  2\n──┼───\n2:│2/2\n"
+  Oscar.allow_unicode(false)
+  labelled_matrix_formatted(ioc, mat)
+  @test String(take!(io)) == "  |  1\n--+---\n1:|1/1\n\n  |  1\n--+---\n2:|2/1\n\n  |  2\n--+---\n1:|1/2\n\n  |  2\n--+---\n2:|2/2\n"
+
+  Oscar.allow_unicode(old_allow)
 end
 
 @testset "labelled_matrix_formatted, LaTeX format" begin

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -1,8 +1,6 @@
 @testset "show and print character tables" begin
   io = IOBuffer();
 
-  old_allow = Oscar.is_unicode_allowed()
-
   t_a4 = character_table(alternating_group(4))
   t_a5 = character_table("A5")
 
@@ -11,8 +9,9 @@
   @test String(take!(io)) == "character_table(Alt( [ 1 .. 4 ] ))"
 
   # default `show`
-  Oscar.allow_unicode(true)
-  show(io, t_a4)
+  Oscar.with_unicode() do
+    show(io, t_a4)
+  end
   @test String(take!(io)) ==
   """
   Alt( [ 1 .. 4 ] )
@@ -30,7 +29,6 @@
   χ₄  3 -1       .       .
   """
 
-  Oscar.allow_unicode(false)
   show(io, t_a4)
   @test String(take!(io)) ==
   """
@@ -72,8 +70,9 @@
 
   # show a legend of irrationalities instead of self-explanatory values,
   # in the screen format ...
-  Oscar.allow_unicode(true)
-  show(IOContext(io, :with_legend => true), t_a4)
+  Oscar.with_unicode() do
+    show(IOContext(io, :with_legend => true), t_a4)
+  end
   @test String(take!(io)) ==
   """
   Alt( [ 1 .. 4 ] )
@@ -94,7 +93,6 @@
   A̅ = ζ₃
   """
 
-  Oscar.allow_unicode(false)
   show(IOContext(io, :with_legend => true), t_a4)
   @test String(take!(io)) ==
   """
@@ -141,8 +139,9 @@
   \$"""
 
   # show the screen format for a table with real and non-real irrationalities
-  Oscar.allow_unicode(true)
-  show(IOContext(io, :with_legend => true), character_table("L2(11)"))
+  Oscar.with_unicode() do
+    show(IOContext(io, :with_legend => true), character_table("L2(11)"))
+  end
   @test String(take!(io)) ==
   """
   L2(11)
@@ -173,7 +172,6 @@
   B̅ = -ζ₁₁⁹ - ζ₁₁⁵ - ζ₁₁⁴ - ζ₁₁³ - ζ₁₁ - 1
   """
 
-  Oscar.allow_unicode(false)
   show(IOContext(io, :with_legend => true), character_table("L2(11)"))
   @test String(take!(io)) ==
   """
@@ -206,9 +204,10 @@
   """
 
   # show some separating lines, in the screen format ...
-  Oscar.allow_unicode(true)
-  show(IOContext(io, :separators_col => [0,5],
-                     :separators_row => [0,5]), t_a5)
+  Oscar.with_unicode() do
+    show(IOContext(io, :separators_col => [0,5],
+                       :separators_row => [0,5]), t_a5)
+  end
   @test String(take!(io)) ==
   """
   A5
@@ -231,7 +230,6 @@
   ──┼────────────────────────────────────┼
   """
 
-  Oscar.allow_unicode(false)
   show(IOContext(io, :separators_col => [0,5],
                      :separators_row => [0,5]), t_a5)
   @test String(take!(io)) ==
@@ -285,10 +283,11 @@
   \$"""
 
   # distribute the table into column portions, in the screen format ...
-  Oscar.allow_unicode(true)
-  show(IOContext(io, :separators_col => [0],
-                     :separators_row => [0],
-                     :portions_col => [2,3]), t_a5)
+  Oscar.with_unicode() do
+    show(IOContext(io, :separators_col => [0],
+                       :separators_row => [0],
+                       :portions_col => [2,3]), t_a5)
+  end
   @test String(take!(io)) ==
   """
   A5
@@ -326,7 +325,6 @@
   χ₅│-1             .             .
   """
 
-  Oscar.allow_unicode(false)
   show(IOContext(io, :separators_col => [0],
                      :separators_row => [0],
                      :portions_col => [2,3]), t_a5)
@@ -414,10 +412,11 @@
 
   # distribute the table into row portions,
   # in the screen format (perhaps not relevant) ...
-  Oscar.allow_unicode(true)
-  show(IOContext(io, :separators_col => [0],
-                     :separators_row => [0],
-                     :portions_row => [2,3]), t_a5)
+  Oscar.with_unicode() do
+    show(IOContext(io, :separators_col => [0],
+                       :separators_row => [0],
+                       :portions_row => [2,3]), t_a5)
+  end
   @test String(take!(io)) ==
   """
   A5
@@ -450,7 +449,6 @@
   χ₅│ 5  1 -1             .             .
   """
 
-  Oscar.allow_unicode(false)
   show(IOContext(io, :separators_col => [0],
                      :separators_row => [0],
                      :portions_row => [2,3]), t_a5)
@@ -485,8 +483,6 @@
   X_4| 4  .  1                -1                -1
   X_5| 5  1 -1                 .                 .
   """
-
-  Oscar.allow_unicode(old_allow)
 
   # ... and in LaTeX format (may be interesting)
   show(IOContext(io, :separators_col => [0],

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -1,5 +1,8 @@
 @testset "show and print character tables" begin
   io = IOBuffer();
+
+  old_allow = Oscar.is_unicode_allowed()
+
   t_a4 = character_table(alternating_group(4))
   t_a5 = character_table("A5")
 
@@ -8,6 +11,7 @@
   @test String(take!(io)) == "character_table(Alt( [ 1 .. 4 ] ))"
 
   # default `show`
+  Oscar.allow_unicode(true)
   show(io, t_a4)
   @test String(take!(io)) ==
   """
@@ -24,6 +28,25 @@
   χ₂  1  1 -ζ₃ - 1      ζ₃
   χ₃  1  1      ζ₃ -ζ₃ - 1
   χ₄  3 -1       .       .
+  """
+
+  Oscar.allow_unicode(false)
+  show(io, t_a4)
+  @test String(take!(io)) ==
+  """
+  Alt( [ 1 .. 4 ] )
+  
+    2  2  2        .        .
+    3  1  .        1        1
+                             
+      1a 2a       3a       3b
+   2P 1a 1a       3b       3a
+   3P 1a 2a       1a       1a
+                             
+  X_1  1  1        1        1
+  X_2  1  1 -z_3 - 1      z_3
+  X_3  1  1      z_3 -z_3 - 1
+  X_4  3 -1        .        .
   """
 
   # LaTeX format
@@ -49,6 +72,7 @@
 
   # show a legend of irrationalities instead of self-explanatory values,
   # in the screen format ...
+  Oscar.allow_unicode(true)
   show(IOContext(io, :with_legend => true), t_a4)
   @test String(take!(io)) ==
   """
@@ -68,6 +92,28 @@
 
   A = -ζ₃ - 1
   A̅ = ζ₃
+  """
+
+  Oscar.allow_unicode(false)
+  show(IOContext(io, :with_legend => true), t_a4)
+  @test String(take!(io)) ==
+  """
+  Alt( [ 1 .. 4 ] )
+  
+    2  2  2  .  .
+    3  1  .  1  1
+                 
+      1a 2a 3a 3b
+   2P 1a 1a 3b 3a
+   3P 1a 2a 1a 1a
+                 
+  X_1  1  1  1  1
+  X_2  1  1  A /A
+  X_3  1  1 /A  A
+  X_4  3 -1  .  .
+  
+  A = -z_3 - 1
+  /A = z_3
   """
 
   # ... and in LaTeX format
@@ -95,6 +141,7 @@
   \$"""
 
   # show the screen format for a table with real and non-real irrationalities
+  Oscar.allow_unicode(true)
   show(IOContext(io, :with_legend => true), character_table("L2(11)"))
   @test String(take!(io)) ==
   """
@@ -126,7 +173,40 @@
   B̅ = -ζ₁₁⁹ - ζ₁₁⁵ - ζ₁₁⁴ - ζ₁₁³ - ζ₁₁ - 1
   """
 
+  Oscar.allow_unicode(false)
+  show(IOContext(io, :with_legend => true), character_table("L2(11)"))
+  @test String(take!(io)) ==
+  """
+  L2(11)
+  
+    2  2  2  1  .  .  1   .   .
+    3  1  1  1  .  .  1   .   .
+    5  1  .  .  1  1  .   .   .
+   11  1  .  .  .  .  .   1   1
+                               
+      1a 2a 3a 5a 5b 6a 11a 11b
+   2P 1a 1a 3a 5b 5a 3a 11b 11a
+   3P 1a 2a 1a 5b 5a 2a 11a 11b
+   5P 1a 2a 3a 1a 1a 6a 11a 11b
+  11P 1a 2a 3a 5a 5b 6a  1a  1a
+                               
+  X_1  1  1  1  1  1  1   1   1
+  X_2  5  1 -1  .  .  1   B  /B
+  X_3  5  1 -1  .  .  1  /B   B
+  X_4 10 -2  1  .  .  1  -1  -1
+  X_5 10  2  1  .  . -1  -1  -1
+  X_6 11 -1 -1  1  1 -1   .   .
+  X_7 12  .  .  A A*  .   1   1
+  X_8 12  .  . A*  A  .   1   1
+  
+  A = -z_5^3 - z_5^2 - 1
+  A* = z_5^3 + z_5^2
+  B = z_11^9 + z_11^5 + z_11^4 + z_11^3 + z_11
+  /B = -z_11^9 - z_11^5 - z_11^4 - z_11^3 - z_11 - 1
+  """
+
   # show some separating lines, in the screen format ...
+  Oscar.allow_unicode(true)
   show(IOContext(io, :separators_col => [0,5],
                      :separators_row => [0,5]), t_a5)
   @test String(take!(io)) ==
@@ -149,6 +229,31 @@
   χ₄│ 4  .  1            -1            -1│
   χ₅│ 5  1 -1             .             .│
   ──┼────────────────────────────────────┼
+  """
+
+  Oscar.allow_unicode(false)
+  show(IOContext(io, :separators_col => [0,5],
+                     :separators_row => [0,5]), t_a5)
+  @test String(take!(io)) ==
+  """
+  A5
+  
+    2| 2  2  .                 .                 .|
+    3| 1  .  1                 .                 .|
+    5| 1  .  .                 1                 1|
+     |                                            |
+     |1a 2a 3a                5a                5b|
+   2P|1a 1a 3a                5b                5a|
+   3P|1a 2a 1a                5b                5a|
+   5P|1a 2a 3a                1a                1a|
+     |                                            |
+  ---+--------------------------------------------+
+  X_1| 1  1  1                 1                 1|
+  X_2| 3 -1  . z_5^3 + z_5^2 + 1    -z_5^3 - z_5^2|
+  X_3| 3 -1  .    -z_5^3 - z_5^2 z_5^3 + z_5^2 + 1|
+  X_4| 4  .  1                -1                -1|
+  X_5| 5  1 -1                 .                 .|
+  ---+--------------------------------------------+
   """
 
   # ... and in LaTeX format
@@ -180,6 +285,7 @@
   \$"""
 
   # distribute the table into column portions, in the screen format ...
+  Oscar.allow_unicode(true)
   show(IOContext(io, :separators_col => [0],
                      :separators_row => [0],
                      :portions_col => [2,3]), t_a5)
@@ -218,6 +324,47 @@
   χ₃│ .    -ζ₅³ - ζ₅² ζ₅³ + ζ₅² + 1
   χ₄│ 1            -1            -1
   χ₅│-1             .             .
+  """
+
+  Oscar.allow_unicode(false)
+  show(IOContext(io, :separators_col => [0],
+                     :separators_row => [0],
+                     :portions_col => [2,3]), t_a5)
+  @test String(take!(io)) ==
+  """
+  A5
+  
+    2| 2  2
+    3| 1  .
+    5| 1  .
+     |     
+     |1a 2a
+   2P|1a 1a
+   3P|1a 2a
+   5P|1a 2a
+     |     
+  ---+-----
+  X_1| 1  1
+  X_2| 3 -1
+  X_3| 3 -1
+  X_4| 4  .
+  X_5| 5  1
+  
+    2| .                 .                 .
+    3| 1                 .                 .
+    5| .                 1                 1
+     |                                      
+     |3a                5a                5b
+   2P|3a                5b                5a
+   3P|1a                5b                5a
+   5P|3a                1a                1a
+     |                                      
+  ---+--------------------------------------
+  X_1| 1                 1                 1
+  X_2| . z_5^3 + z_5^2 + 1    -z_5^3 - z_5^2
+  X_3| .    -z_5^3 - z_5^2 z_5^3 + z_5^2 + 1
+  X_4| 1                -1                -1
+  X_5|-1                 .                 .
   """
 
   # ... and in LaTeX format
@@ -267,11 +414,13 @@
 
   # distribute the table into row portions,
   # in the screen format (perhaps not relevant) ...
+  Oscar.allow_unicode(true)
   show(IOContext(io, :separators_col => [0],
                      :separators_row => [0],
                      :portions_row => [2,3]), t_a5)
   @test String(take!(io)) ==
-  """A5
+  """
+  A5
 
    2│ 2  2  .             .             .
    3│ 1  .  1             .             .
@@ -300,6 +449,44 @@
   χ₄│ 4  .  1            -1            -1
   χ₅│ 5  1 -1             .             .
   """
+
+  Oscar.allow_unicode(false)
+  show(IOContext(io, :separators_col => [0],
+                     :separators_row => [0],
+                     :portions_row => [2,3]), t_a5)
+  @test String(take!(io)) ==
+  """
+  A5
+  
+    2| 2  2  .                 .                 .
+    3| 1  .  1                 .                 .
+    5| 1  .  .                 1                 1
+     |                                            
+     |1a 2a 3a                5a                5b
+   2P|1a 1a 3a                5b                5a
+   3P|1a 2a 1a                5b                5a
+   5P|1a 2a 3a                1a                1a
+     |                                            
+  ---+--------------------------------------------
+  X_1| 1  1  1                 1                 1
+  X_2| 3 -1  . z_5^3 + z_5^2 + 1    -z_5^3 - z_5^2
+  
+    2| 2  2  .                 .                 .
+    3| 1  .  1                 .                 .
+    5| 1  .  .                 1                 1
+     |                                            
+     |1a 2a 3a                5a                5b
+   2P|1a 1a 3a                5b                5a
+   3P|1a 2a 1a                5b                5a
+   5P|1a 2a 3a                1a                1a
+     |                                            
+  ---+--------------------------------------------
+  X_3| 3 -1  .    -z_5^3 - z_5^2 z_5^3 + z_5^2 + 1
+  X_4| 4  .  1                -1                -1
+  X_5| 5  1 -1                 .                 .
+  """
+
+  Oscar.allow_unicode(old_allow)
 
   # ... and in LaTeX format (may be interesting)
   show(IOContext(io, :separators_col => [0],


### PR DESCRIPTION
- provide ASCII and unicode variants of `labelled_matrix_formatted`,
  depending on `Oscar.is_unicode_allowed()`
- added tests for the two variants
- mark the doctests in question such that the unicode variant is used
  (in order to show this variant in the manual)