### PR TITLE
Sanitize input for triangulation computation.

### DIFF
--- a/src/PolyhedralGeometry/triangulations.jl
+++ b/src/PolyhedralGeometry/triangulations.jl
@@ -64,6 +64,7 @@ julia> all_triangulations(V)
 function all_triangulations(pts::Union{SubObjectIterator{<:PointVector}, AbstractMatrix, Oscar.MatElem}; full::Bool=false)
     input = homogenized_matrix(pts, 1)
     PC = Polymake.polytope.PointConfiguration(POINTS=input)
+    PC.FULL_DIM::Bool || error("Input points must have full rank.")
     triangs = Polymake.polytope.topcom_all_triangulations(PC)
     result = [[[e for e in simplex] for simplex in triang] for triang in triangs]
     return _postprocess(result, nrows(input), full)
@@ -74,7 +75,8 @@ end
     all_triangulations(P::Polyhedron)
 
 Compute all triangulations that can be formed using the vertices of the given
-polytope `P`.
+bounded and full-dimensional polytope `P`.
+
 The return type is a `Vector{Vector{Vector{Int}}}` where each
 `Vector{Vector{Int}}` encodes a triangulation, in which a `Vector{Int}` encodes
 a simplex as the set of indices of the vertices of the simplex. I.e. the
@@ -92,7 +94,11 @@ julia> all_triangulations(c)
  [[1, 2, 4], [1, 3, 4]]
 ```
 """
-all_triangulations(P::Polyhedron) = all_triangulations(vertices(P); full=false)
+function all_triangulations(P::Polyhedron)
+    isfulldimensional(P) || error("Input polytope must be full-dimensional.")
+    isbounded(P) || error("Input polytope must be bounded.")
+    return all_triangulations(vertices(P); full=false)
+end
 
 
 @doc Markdown.doc"""
@@ -120,10 +126,10 @@ end
 @doc Markdown.doc"""
     star_triangulations(P::Polyhedron; full::Bool=false, regular::Bool=false)
 
-Return all star triangulations of the given polyhedron, i.e. all simplices are
-required to contain the origin. If the origin is not among the vertices of the
-polyhedron, it is added. Optionally only select the `regular` or `full`
-triangulations.
+Return all star triangulations of the given bounded and full-dimensional
+polyhedron, i.e. all simplices are required to contain the origin. If the
+origin is not among the vertices of the polyhedron, it is added. Optionally
+only select the `regular` or `full` triangulations.
 
 The output is a pair
 - The first entry contains the points of the point configuration as their order
@@ -160,6 +166,8 @@ julia> star_triangulations(P)
 ```
 """    
 function star_triangulations(P::Polyhedron; full::Bool=false, regular::Bool=false)
+    isfulldimensional(P) || error("Input polytope must be full-dimensional.")
+    isbounded(P) || error("Input polytope must be bounded.")
     zero = [0 for i in 1:ambient_dim(P)]
     contains(P, zero) || throw(ArgumentError("Input polyhedron must contain origin."))
     V = vertices(P)
@@ -209,6 +217,7 @@ julia> regular_triangulations(V)
 function regular_triangulations(pts::Union{SubObjectIterator{<:PointVector}, AbstractMatrix, Oscar.MatElem}; full::Bool=false)
     input = homogenized_matrix(pts, 1)
     PC = Polymake.polytope.PointConfiguration(POINTS=input)
+    PC.FULL_DIM::Bool || error("Input points must have full rank.")
     triangs = Polymake.polytope.topcom_regular_triangulations(PC)
     result = [[[e for e in simplex] for simplex in triang] for triang in triangs]
     return _postprocess(result, nrows(input), full)
@@ -219,7 +228,7 @@ end
     regular_triangulations(P::Polyhedron)
 
 Compute all regular triangulations that can be formed using the vertices of the
-given polytope `P`.
+given bounded and full-dimensional polytope `P`.
 
 A triangulation is regular if it can be induced by weights, i.e. attach a
 weight to every point, take the convex hull of these new vectors and then take
@@ -243,7 +252,11 @@ julia> regular_triangulations(c)
  [[1, 3, 4], [1, 2, 4]]
 ```
 """
-regular_triangulations(P::Polyhedron) = regular_triangulations(vertices(P); full=false)
+function regular_triangulations(P::Polyhedron)
+    isfulldimensional(P) || error("Input polytope must be full-dimensional.")
+    isbounded(P) || error("Input polytope must be bounded.")
+    return regular_triangulations(vertices(P); full=false)
+end
 
 
 @doc Markdown.doc"""


### PR DESCRIPTION
Input polytopes must be bounded and full-dimensional. Equivalently, if points are given, then they must span the whole space, i.e. have full rank.

In the long run we will need a decision on how many of the input errors we want to catch.