### PR TITLE
Adjust localizations to proper types for monomial orderings

### DIFF
--- a/experimental/PlaneCurve/AffinePlaneCurve.jl
+++ b/experimental/PlaneCurve/AffinePlaneCurve.jl
@@ -432,7 +432,7 @@ function intersection_multiplicity(C::AffinePlaneCurve{S}, D::AffinePlaneCurve{S
   m = ideal_point(R, P)
   r = Localization(R, m)
   I = ideal(r, [C.eq, D.eq])
-  G = groebner_assure(I)
+  G = Oscar.groebner_assure(I)
   return Singular.vdim(G.S)
 end
 

--- a/experimental/PlaneCurve/ProjPlaneCurve.jl
+++ b/experimental/PlaneCurve/ProjPlaneCurve.jl
@@ -275,7 +275,7 @@ function curve_singular_locus(PP::Oscar.Geometry.ProjSpc{S}, C::ProjectivePlaneC
   pY = phi(FY.f)
   pZ = phi(FZ.f)
   I = ideal([pF, pX, pY, pZ])
-  g = collect(groebner_assure(I, lex(gens(rr)), true))
+  g = collect(Oscar.groebner_assure(I, lex(gens(rr)), true))
   f = factor(g[1])
   ro = []
   for h in keys(f.fac)

--- a/experimental/Schemes/AffineSchemes.jl
+++ b/experimental/Schemes/AffineSchemes.jl
@@ -237,7 +237,7 @@ function hypersurface_complement(X::Spec{BRT, BRET, RT, RET, MST}, f::RET; keep_
         if issubset(Jsat, saturated_ideal(IX))
           for o in keys(DIX)
             gb = DIX[o]
-            groebner_bases(J)[o] = LocalizedBiPolyArray(localized_ring(W), singular_gens(gb), shift(gb), true)
+            groebner_bases(J)[o] = LocalizedBiPolyArray(localized_ring(W), singular_gens(gb), shift(gb), o.o, true)
           end
         end
         set_attribute!(W, :localized_modulus, J)

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -1367,6 +1367,23 @@ function to_oscar_side(
   return [psi(R(numerator(a)))//psi(R(denominator(a))) for a in f]
 end
 
+function Base.length(lbpa::LocalizedBiPolyArray)
+  if isdefined(lbpa, :oscar_gens)
+    return length(lbpa.oscar_gens)
+  else
+    return Singular.ngens(lbpa.singular_gens)
+  end
+end
+
+function Base.iterate(lbpa::LocalizedBiPolyArray, s::Int = 1)
+  if s > length(lbpa)
+    return nothing
+  end
+  return lbpa.oscar_gens[s], s + 1
+end
+
+Base.eltype(lbpa::LocalizedBiPolyArray{BRT, BRET, RT, RET, MST}) where {BRT, BRET, RT, RET, MST} = MPolyLocalizedRingElem{BRT, BRET, RT, RET, MST}
+
 ########################################################################
 # Ideals in localizations of multivariate polynomial rings             #
 ########################################################################

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -1752,10 +1752,10 @@ function groebner_basis(
   if haskey(D, ordering)
     return D[ordering]
   end
-  # if not, set up a LocalizedBiPolyArray
-  lbpa = LocalizedBiPolyArray(base_ring(I), gens(I), point_coordinates(inverted_set(base_ring(I))), ordering.o)
   # Check whether this ordering is admissible
-  !Singular.has_local_ordering(singular_poly_ring(lbpa)) && error("The ordering has to be a local ordering.")
+  !islocal(ordering) && error("The ordering has to be a local ordering.")
+  # set up a LocalizedBiPolyArray
+  lbpa = LocalizedBiPolyArray(base_ring(I), gens(I), point_coordinates(inverted_set(base_ring(I))), ordering.o)
   # compute the standard basis and cache the result.
   # No saturation is necessary in this case. 
   D[ordering] = _compute_standard_basis(lbpa, ordering)
@@ -1806,6 +1806,8 @@ function groebner_basis(I::MPolyLocalizedIdeal{BRT, BRET, RT, RET, MPolyLeadingM
   if haskey(D, ordering)
     return D[ordering]
   end
+
+  Orderings._global_and_local_vars(ordering) != Orderings._global_and_local_vars(default_ordering(I)) && error("The localization does not correspond to the given ordering")
 
   W = base_ring(I)
   lbpa = LocalizedBiPolyArray(W, gens(I), default_shift(W), ordering.o)

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -15,7 +15,7 @@ export Localization, ideal
 export bring_to_common_denominator, write_as_linear_combination
 
 export LocalizedBiPolyArray
-export oscar_gens, oscar_ring, singular_ring, singular_gens, ordering, shift, shift_hom, inv_shift_hom, to_singular_side, to_oscar_side
+export oscar_gens, oscar_ring, singular_gens, ordering, shift, shift_hom, inv_shift_hom, to_singular_side, to_oscar_side
 export groebner_basis
 
 export MPolyLocalizedRingHom
@@ -1267,7 +1267,7 @@ function singular_assure(lbpa::LocalizedBiPolyArray, ordering::MonomialOrdering)
   else
     if !isdefined(lbpa, :ordering)
       lbpa.ordering = ordering.o
-      SR = singular_ring(lbpa.oscar_ring, ordering.o)
+      SR = singular_poly_ring(lbpa.oscar_ring, ordering.o)
       f = Singular.AlgebraHomomorphism(lbpa.singular_ring, SR, gens(SR))
       lbpa.singular_gens = Singular.map_ideal(f, lbpa.singular_gens)
       lbpa.singular_ring = SR

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -136,7 +136,8 @@ end
 using .Orderings
 export lex, deglex, degrevlex, revlex, neglex, negrevlex, negdeglex,
        negdegrevlex, wdeglex, wdegrevlex, negwdeglex, negwdegrevlex,
-       matrix_ordering, weights, MonomialOrdering, singular
+       matrix_ordering, weights, MonomialOrdering, singular,
+       isglobal, islocal, ismixed
 
 
 ##############################################################################

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -973,6 +973,12 @@ function _cmp_monomials(f::MPolyElem, k::Int, l::Int, o::Oscar.Orderings.GenOrde
            return 1
          end
        end
+   elseif o.ord == :weight
+     if _isless_matrix(f, k, l, o.wgt)
+       return -1
+     elseif _isless_matrix(f, l, k, o.wgt)
+       return 1
+     end
    else
       dk = weighted_degree(f, k, o.vars, o.w)
       dl = weighted_degree(f, l, o.vars, o.w)

--- a/test/Rings/mpoly-localizations.jl
+++ b/test/Rings/mpoly-localizations.jl
@@ -52,12 +52,12 @@
   
   J = ideal(W, [W(x-3), W(y-4)])
   lbpa = groebner_basis(J)
-  @test ordering(lbpa) == :negdegrevlex
+  @test MonomialOrdering(R, ordering(lbpa)) == negdegrevlex(gens(base_ring(W)))
   @test oscar_gens(lbpa)[1] == W(1)
 
   J = ideal(W, [f, y-q])
   lbpa = groebner_basis(J)
-  @test ordering(lbpa) == :negdegrevlex
+  @test MonomialOrdering(R, ordering(lbpa)) == negdegrevlex(gens(base_ring(W)))
   @test oscar_gens(lbpa) == W.([x-p, y-q])
 
   @test I_loc + J isa MPolyLocalizedIdeal

--- a/test/Rings/mpoly-localizations.jl
+++ b/test/Rings/mpoly-localizations.jl
@@ -87,6 +87,14 @@
   @test f in U
   @test (f*(x-1) in U)
   @test !(f*x in U)
+
+  R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+  o = degrevlex([x, y])*negdegrevlex([z])
+  S = Localization(R, o)
+  @test z + 1 in inverted_set(S)
+  @test !(x + 1 in inverted_set(S))
+  I = ideal(S, [x + y + z, x^2 + y^2 + z^3])
+  @test collect(groebner_basis(I)) == [ S(x + y + z), S(-x*z + 2*y^2 + y*z + z^3) ]
 end
 
 @testset "mpoly-localizations PowersOfElements" begin

--- a/test/Rings/orderings-test.jl
+++ b/test/Rings/orderings-test.jl
@@ -146,4 +146,7 @@ end
    f = sum(M)
    o = negdegrevlex(gens(R))
    @test collect(monomials(f, o)) == M
+
+   o = matrix_ordering(gens(R), matrix(ZZ, [ 1 1 1 1; 0 0 0 -1; 0 0 -1 0; 0 -1 0 0 ]))
+   @test collect(monomials(f, o)) == collect(monomials(f, degrevlex(gens(R))))
  end

--- a/test/Rings/orderings-test.jl
+++ b/test/Rings/orderings-test.jl
@@ -46,6 +46,16 @@
  
    M = [ 1 1 1; 1 0 0; 0 1 0 ]
    @test collect(monomials(f, M)) == collect(monomials(f, :deglex))
+
+   @test isglobal(lex([x, y]))
+   @test !islocal(lex([x, y]))
+   @test !ismixed(lex([x, y]))
+   @test !isglobal(neglex([y, z]))
+   @test islocal(neglex([y, z]))
+   @test !ismixed(neglex([y, z]))
+   @test !isglobal(lex([x, y])*neglex([z]))
+   @test !islocal(lex([x, y])*neglex([z]))
+   @test ismixed(lex([x, y])*neglex([z]))
 end
 
 @testset "Polynomial Orderings terms, monomials and coefficients" begin


### PR DESCRIPTION
I adjusted the code in `mpoly-localizations.jl` to use `MonomialOrdering` and friends instead of symbols.
This also introduces a new type of localization for the ring associated with a monomial ordering, so that one can now (mathematically meaningful) compute with non-global and in particular mixed orderings like e.g. `deglex([x, y])*negdeglex([z])`.
Two questions:
1. I noticed that in some cases the ideal needs to be saturated w.r.t. ... something for the Groebner basis computation in the localization. I don't think this needs to be the case here? But honestly, I'm not really sure about this and couldn't find anything in the literature.
2. Should one only allow to compute Groebner bases w.r.t. the ordering associated with the localization? I don't like such restrictions and don't dare to judge what is meaningful and what isn't.