### PR TITLE
split singular_ring into singular_coeff_ring and singular_poly_ring

### DIFF
--- a/experimental/InvariantTheory/types.jl
+++ b/experimental/InvariantTheory/types.jl
@@ -52,7 +52,7 @@ mutable struct InvRing{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularAction
   function InvRing(K::FldT, G::GrpT, action::Vector{ActionT}) where {FldT <: Field, GrpT <: AbstractAlgebra.Group, ActionT}
     n = degree(G)
     R, = grade(PolynomialRing(K, "x" => 1:n, cached = false)[1], ones(Int, n))
-    R_sing = singular_ring(R)
+    R_sing = singular_poly_ring(R)
     action_singular = identity.([change_base_ring(R_sing, g) for g in action])
     PolyRingT = typeof(R)
     PolyElemT = elem_type(R)

--- a/experimental/ModStd/ModStdNF.jl
+++ b/experimental/ModStd/ModStdNF.jl
@@ -28,7 +28,7 @@ end
 
 function exp_groebner_basis(B::BiPolyArray{nmod_mpoly}, h::HilbertData; ord::Symbol = :degrevlex, complete_reduction::Bool = false)
   if ord != :degrevlex
-    R = Oscar.singular_ring(B.Ox, ord)
+    R = Oscar.singular_poly_ring(B.Ox, ord)
     i = stdhilb(Singular.Ideal(R, [convert(R, x) for x = B]), h.data, complete_reduction = complete_reduction)
     return BiPolyArray(B.Ox, i)
   end

--- a/experimental/PlaneCurve/ParaPlaneCurves.jl
+++ b/experimental/PlaneCurve/ParaPlaneCurves.jl
@@ -8,7 +8,7 @@ export parametrization_plane_curve, adjoint_ideal, rational_point_conic,
 function _tosingular(C::ProjPlaneCurve{fmpq})
     F = C.eq
     T = parent(F)
-    Tx = singular_ring(T)
+    Tx = singular_poly_ring(T)
     return Tx(F)
 end
 

--- a/src/Modules/FreeModules-graded.jl
+++ b/src/Modules/FreeModules-graded.jl
@@ -343,7 +343,7 @@ end
 getindex(F::BiModArray, i::Int) = getindex(F, Val(:O), i)
 
 function singular_module(F::FreeModule_dec)
-  Sx = singular_ring(base_ring(F).R)
+  Sx = singular_poly_ring(base_ring(F).R)
   return Singular.FreeModule(Sx, dim(F))
 end
 

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -547,8 +547,8 @@ are computed, given the OSCAR side.
 function singular_assure(F::ModuleGens)
   if !isdefined(F, :S)
     if length(F) == 0
-      singular_ring = base_ring(F.SF)
-      F.S = Singular.Module(singular_ring, Singular.vector(singular_ring, singular_ring(0)))
+      sr = base_ring(F.SF)
+      F.S = Singular.Module(sr, Singular.vector(sr, sr(0)))
       return 
     end
     F.S = Singular.Module(base_ring(F.SF), [F.SF(x) for x = oscar_generators(F)]...)
@@ -566,7 +566,7 @@ getindex(F::ModuleGens, i::Int) = getindex(F, Val(:O), i)
 Create a Singular module from an OSCAR free module.
 """
 function singular_module(F::FreeMod)
-  Sx = singular_ring(base_ring(F), keep_ordering=false)
+  Sx = singular_poly_ring(base_ring(F), keep_ordering=false)
   return Singular.FreeModule(Sx, dim(F))
 end
 

--- a/src/Rings/AbelianClosure.jl
+++ b/src/Rings/AbelianClosure.jl
@@ -304,7 +304,7 @@ Oscar.@enable_all_show_via_expressify QabElem
 #
 ################################################################################
 
-function Oscar.singular_ring(F::QabField)
+function Oscar.singular_coeff_ring(F::QabField)
   return Singular.CoefficientRing(F)
 end
 

--- a/src/Rings/FunctionField.jl
+++ b/src/Rings/FunctionField.jl
@@ -4,9 +4,9 @@ end
 
 # conversion between FractionField and Singular function field
 # univariate
-function Oscar.singular_ring(F::AbstractAlgebra.Generic.FracField{T}) where T <: Union{fmpq_poly, gfp_poly}
+function Oscar.singular_coeff_ring(F::AbstractAlgebra.Generic.FracField{T}) where T <: Union{fmpq_poly, gfp_poly}
   R = base_ring(F)
-  return Singular.FunctionField(singular_ring(base_ring(R)), [string(R.S)])[1]
+  return Singular.FunctionField(singular_coeff_ring(base_ring(R)), [string(R.S)])[1]
 end
 
 function (F::Singular.N_FField)(x::AbstractAlgebra.Generic.Frac{T}) where T <: Union{fmpq_poly, gfp_poly}
@@ -24,9 +24,9 @@ function (F::AbstractAlgebra.Generic.FracField{T})(x::Singular.n_transExt) where
 end
 
 # multivariate
-function Oscar.singular_ring(F::AbstractAlgebra.Generic.FracField{T}) where T <: Union{fmpq_mpoly, gfp_mpoly}
+function Oscar.singular_coeff_ring(F::AbstractAlgebra.Generic.FracField{T}) where T <: Union{fmpq_mpoly, gfp_mpoly}
   R = base_ring(F)
-  return Singular.FunctionField(singular_ring(base_ring(R)), string.(R.S))[1]
+  return Singular.FunctionField(singular_coeff_ring(base_ring(R)), string.(R.S))[1]
 end
 
 function (F::Singular.N_FField)(x::AbstractAlgebra.Generic.Frac{T}) where T <: Union{fmpq_mpoly, gfp_mpoly}
@@ -44,8 +44,8 @@ function (F::AbstractAlgebra.Generic.FracField{T})(x::Singular.n_transExt) where
 end
 
 # conversion between Singular and AbstractAlgebra function fields
-function Oscar.singular_ring(F::AbstractAlgebra.Generic.RationalFunctionField{T}) where T <: FieldElem
-  return singular_ring(F.fraction_field)
+function Oscar.singular_coeff_ring(F::AbstractAlgebra.Generic.RationalFunctionField{T}) where T <: FieldElem
+  return singular_coeff_ring(F.fraction_field) # TODO: this is not correct
 end
 
 function (F::Singular.N_FField)(x::AbstractAlgebra.Generic.Rat{T}) where T <: FieldElem

--- a/src/Rings/MPolyMap/AffineAlgebras.jl
+++ b/src/Rings/MPolyMap/AffineAlgebras.jl
@@ -75,9 +75,9 @@ affine_algebra_morphism_type(R::S, U::T) where {S <: Ring, T} = affine_algebra_m
 #
 ################################################################################
 
-@attr Any _singular_ring_domain(f::MPolyAnyMap) = singular_ring(domain(f))
+@attr Any _singular_ring_domain(f::MPolyAnyMap) = singular_poly_ring(domain(f))
 
-@attr Any _singular_ring_codomain(f::MPolyAnyMap) = singular_ring(codomain(f))
+@attr Any _singular_ring_codomain(f::MPolyAnyMap) = singular_poly_ring(codomain(f))
 
 @attr Any function _singular_algebra_morphism(f::MPolyAnyMap)
   DS = _singular_ring_domain(f)

--- a/src/Rings/affine-algebra-homs.jl
+++ b/src/Rings/affine-algebra-homs.jl
@@ -18,7 +18,7 @@ struct IdAlgHom{T} <: AbstractAlgebra.Map{Ring, Ring,
 
    function IdAlgHom{T}(R::U) where U <: Union{MPolyRing{T}, MPolyQuo{T}} where T
       V = gens(R)
-      Sx = Oscar.singular_ring(R)
+      Sx = Oscar.singular_poly_ring(R)
       ty = typeof(base_ring(Sx))
       z = new(R, V, Singular.IdentityAlgebraHomomorphism(Sx), ideal(R, [zero(R)]))
       return z
@@ -112,8 +112,8 @@ mutable struct AlgHom{T} <: AbstractAlgebra.Map{Ring, Ring,
          all(ishomogeneous, V) || error("Array needs to contain homogeneous elements")
       end
 
-      Dx = singular_ring(D)
-      Cx = singular_ring(C)
+      Dx = singular_poly_ring(D)
+      Cx = singular_poly_ring(C)
       
       z = new(D, C, V, MapFromFunc(x->evaluate(x, V), D, C), Singular.AlgebraHomomorphism(Dx, Cx, Cx.(V)))
       return z
@@ -127,8 +127,8 @@ mutable struct AlgHom{T} <: AbstractAlgebra.Map{Ring, Ring,
          all(ishomogeneous, V) || error("Array needs to contain homogeneous elements")
       end
 
-      Dx = singular_ring(D)
-      Cx = singular_ring(C)
+      Dx = singular_poly_ring(D)
+      Cx = singular_poly_ring(C)
       z = new(D, C, V, MapFromFunc(x->evaluate(x, V), base_ring(D), C), Singular.AlgebraHomomorphism(Dx, Cx, Cx.(V)))
       return z
    end
@@ -141,8 +141,8 @@ mutable struct AlgHom{T} <: AbstractAlgebra.Map{Ring, Ring,
          all(ishomogeneous, V) || error("Array needs to contain homogeneous elements")
       end
 
-      Dx = singular_ring(D)
-      Cx = singular_ring(C)
+      Dx = singular_poly_ring(D)
+      Cx = singular_poly_ring(C)
       z = new(D, C, V, MapFromFunc(x->evaluate(x, V), D.R, C), Singular.AlgebraHomomorphism(Dx, Cx, Cx.(V)))
       return z
    end

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -133,7 +133,7 @@ function groebner_basis_with_transform(B::BiPolyArray, ordering::MonomialOrderin
    if !isdefined(B, :ordering)
       singular_assure(B, ordering)
    elseif ordering != B.ordering
-     R = singular_ring(B.Ox, ordering)
+     R = singular_poly_ring(B.Ox, ordering)
      i = Singular.Ideal(R, [R(x) for x = B])
      i, m = Singular.lift_std(i, complete_reduction = complete_reduction)
      return BiPolyArray(B.Ox, i), map_entries(x->B.Ox(x), m)
@@ -311,7 +311,7 @@ julia> groebner_basis(J)
  b + c - 1
  a*c - 2*a + c
 
-julia> SR = singular_ring(base_ring(J))
+julia> SR = singular_poly_ring(base_ring(J))
 Singular Polynomial Ring (QQ),(a,b,c),(dp(3),C)
 
 julia> I = Singular.Ideal(SR,[SR(-1+c+b+a^3),SR(-1+b+c*a+2*a^3),SR(5+c*b+c^2*a)])

--- a/src/Rings/mpoly-affine-algebras.jl
+++ b/src/Rings/mpoly-affine-algebras.jl
@@ -972,7 +972,7 @@ function integral_basis(f::MPolyElem, i::Int)
     throw(ArgumentError("The input polynomial must be irreducible"))
   end
 
-  SR = singular_ring(R)
+  SR = singular_poly_ring(R)
   l = Singular.LibIntegralbasis.integralBasis(SR(f), i, "isIrred")
   A, p = quo(R, ideal(R, [f]))
   ###return (R(l[2]), R.(gens(l[1])))

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -749,8 +749,8 @@ coeff(a::MPolyElem_dec, i::Int) = coeff(a.f, i)
 term(a::MPolyElem_dec, i::Int) = parent(a)(term(a.f, i))
 exponent_vector(a::MPolyElem_dec, i::Int) = exponent_vector(a.f, i)
 
-function singular_ring(R::MPolyRing_dec; keep_ordering::Bool = false)
-  return singular_ring(R.R, keep_ordering = keep_ordering)
+function singular_poly_ring(R::MPolyRing_dec; keep_ordering::Bool = false)
+  return singular_poly_ring(R.R, keep_ordering = keep_ordering)
 end
 
 MPolyCoeffs(f::MPolyElem_dec) = MPolyCoeffs(f.f)

--- a/src/Rings/mpoly-local.jl
+++ b/src/Rings/mpoly-local.jl
@@ -193,7 +193,7 @@ Sets up the singular ring in the backend to perform, for instance, standard basi
 in `R`.
 """
 function singular_ring_loc(R::MPolyRingLoc{T}; ord::Symbol = :negdegrevlex) where T
-  return Singular.PolynomialRing(Oscar.singular_ring(base_ring(R.base_ring)),
+  return Singular.PolynomialRing(Oscar.singular_coeff_ring(base_ring(R.base_ring)),
               [string(x) for x = Nemo.symbols(R)],
               ordering = ord,
               cached = false)[1]

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -234,8 +234,23 @@ Base.eltype(::BiPolyArray{S}) where S = S
 # Needs convert(Target(Ring), elem)
 # Ring(s.th.)
 #
-# singular_ring(Nemo-Ring) tries to create the appropriate Ring
+# Singular's polynomial rings are not recursive:
+# 1. singular_poly_ring(R::Ring) tries to create a Singular.PolyRing (with
+#    elements of type Singular.spoly) isomorphic to R 
+# 2. singular_coeff_ring(R::Ring) tries to create a ring isomorphic to R that is
+#    acceptable to Singular.jl as 'coefficients'
 #
+# a real native Singular polynomial ring with Singular's native QQ as coefficients:
+#  singular_poly_ring(QQ[t]) => Singular.PolyRing{Singular.n_Q}
+#
+# Singular's native Fp(5):
+#  singular_coeff_ring(GF(5)) => Singular.N_ZpField
+#
+# Singular wrapper of the Oscar type fmpq_poly:
+#  singular_coeff_ring(QQ[t]) => Singular.N_Ring{fmpq_poly}
+#
+# even more wrappings of the immutable Oscar type gfp_fmpz_elem:
+#  singular_coeff_ring(GF(fmpz(5))) => Singular.N_Field{Singular.FieldElemWrapper{GaloisFmpzField, gfp_fmpz_elem}}
 
 for T in [:MPolyRing, :(AbstractAlgebra.Generic.MPolyRing)]
 @eval function (Ox::$T)(f::Singular.spoly)
@@ -262,22 +277,22 @@ end
 (F::Nemo.NmodRing)(a::Singular.n_Zp) = F(Int(a))
 
 #Note: Singular crashes if it gets Nemo.ZZ instead of Singular.ZZ ((Coeffs(17)) instead of (ZZ))
-singular_ring(::Nemo.FlintIntegerRing) = Singular.Integers()
-singular_ring(::Nemo.FlintRationalField) = Singular.Rationals()
+singular_coeff_ring(::Nemo.FlintIntegerRing) = Singular.Integers()
+singular_coeff_ring(::Nemo.FlintRationalField) = Singular.Rationals()
 
 # if the characteristic overflows an Int, Singular doesn't support it anyways
-singular_ring(F::Nemo.GaloisField) = Singular.Fp(Int(characteristic(F)))
+singular_coeff_ring(F::Nemo.GaloisField) = Singular.Fp(Int(characteristic(F)))
 
-function singular_ring(F::Union{Nemo.NmodRing, Nemo.FmpzModRing})
+function singular_coeff_ring(F::Union{Nemo.NmodRing, Nemo.FmpzModRing})
   return Singular.ResidueRing(Singular.Integers(), BigInt(modulus(F)))
 end
 
-singular_ring(R::Singular.PolyRing; keep_ordering::Bool = true) = R
+singular_poly_ring(R::Singular.PolyRing; keep_ordering::Bool = true) = R
 
 # Note: Several Singular functions crash if they get the catch-all
 # Singular.CoefficientRing(F) instead of the native Singular equivalent as
 # conversions to/from factory are not implemented.
-function singular_ring(K::AnticNumberField)
+function singular_coeff_ring(K::AnticNumberField)
   minpoly = defining_polynomial(K)
   Qa = parent(minpoly)
   a = gen(Qa)
@@ -290,7 +305,7 @@ function singular_ring(K::AnticNumberField)
   return SK
 end
 
-function singular_ring(F::FqNmodFiniteField)
+function singular_coeff_ring(F::FqNmodFiniteField)
   # TODO: the Fp(Int(char)) can throw
   minpoly = modulus(F)
   Fa = parent(minpoly)
@@ -335,21 +350,21 @@ function (SF::Singular.N_AlgExtField)(a::fq_nmod)
 end
 #### end stuff to move to singular.jl
 
-function singular_ring(Rx::MPolyRing{T}; keep_ordering::Bool = false) where {T <: RingElem}
+function singular_poly_ring(Rx::MPolyRing{T}; keep_ordering::Bool = false) where {T <: RingElem}
   if keep_ordering
-    return Singular.PolynomialRing(singular_ring(base_ring(Rx)),
+    return Singular.PolynomialRing(singular_coeff_ring(base_ring(Rx)),
               [string(x) for x = Nemo.symbols(Rx)],
               ordering = ordering(Rx),
               cached = false)[1]
   else
-    return Singular.PolynomialRing(singular_ring(base_ring(Rx)),
+    return Singular.PolynomialRing(singular_coeff_ring(base_ring(Rx)),
               [string(x) for x = Nemo.symbols(Rx)],
               cached = false)[1]
   end
 end
 
-function singular_ring(Rx::MPolyRing{T}, ord::Symbol) where {T <: RingElem}
-  return Singular.PolynomialRing(singular_ring(base_ring(Rx)),
+function singular_poly_ring(Rx::MPolyRing{T}, ord::Symbol) where {T <: RingElem}
+  return Singular.PolynomialRing(singular_coeff_ring(base_ring(Rx)),
               [string(x) for x = Nemo.symbols(Rx)],
               ordering = ord,
               cached = false)[1]
@@ -398,7 +413,7 @@ function singular(o::Orderings.ModOrdering)
    end
 end
 
-function singular_ring(Rx::MPolyRing{T}, ord::Orderings.AbsOrdering) where {T <: RingElem}
+function singular_poly_ring(Rx::MPolyRing{T}, ord::Orderings.AbsOrdering) where {T <: RingElem}
   #test if it can be mapped directly to singular:
   # - consecutive, non-overlapping variables
   # - covering everything
@@ -425,7 +440,7 @@ function singular_ring(Rx::MPolyRing{T}, ord::Orderings.AbsOrdering) where {T <:
     o = Singular.ordering_M(Orderings.simplify_weight_matrix(ord))
   end
 
-  return Singular.PolynomialRing(singular_ring(base_ring(Rx)),
+  return Singular.PolynomialRing(singular_coeff_ring(base_ring(Rx)),
               [string(x) for x = Nemo.symbols(Rx)],
               ordering = o,
               cached = false)[1]
@@ -433,7 +448,7 @@ end
 
 
 #catch all for generic nemo rings
-function Oscar.singular_ring(F::AbstractAlgebra.Ring)
+function Oscar.singular_coeff_ring(F::AbstractAlgebra.Ring)
   return Singular.CoefficientRing(F)
 end
 
@@ -514,7 +529,7 @@ end
 
 function singular_assure(I::BiPolyArray)
   if !isdefined(I, :S)
-    I.Sx = singular_ring(I.Ox, keep_ordering=I.keep_ordering)
+    I.Sx = singular_poly_ring(I.Ox, keep_ordering=I.keep_ordering)
     I.S = Singular.Ideal(I.Sx, elem_type(I.Sx)[I.Sx(x) for x = I.O])
   end
   if I.isGB
@@ -529,7 +544,7 @@ end
 function singular_assure(I::BiPolyArray, ordering::MonomialOrdering)
     if !isdefined(I, :S) 
         I.ord = ordering.o
-        I.Sx = singular_ring(I.Ox, ordering.o)
+        I.Sx = singular_poly_ring(I.Ox, ordering.o)
         I.S = Singular.Ideal(I.Sx, elem_type(I.Sx)[I.Sx(x) for x = I.O])
         if I.isGB
             I.S.isGB = true
@@ -539,7 +554,7 @@ function singular_assure(I::BiPolyArray, ordering::MonomialOrdering)
          = attached, thus we have to create a new singular ring and map the ideal. =#
         if !isdefined(I, :ord) || I.ord != ordering.o
             I.ord = ordering.o
-            SR    = singular_ring(I.Ox, ordering.o)
+            SR    = singular_poly_ring(I.Ox, ordering.o)
             f     = Singular.AlgebraHomomorphism(I.Sx, SR, gens(SR))
             I.S   = Singular.map_ideal(f, I.S)
             I.Sx  = SR

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -743,7 +743,7 @@ function write_as_linear_combination(
   lbpa = LocalizedBiPolyArray(W.(h))
   p = a[1]*lifted_numerator(f)
   p_sing = to_singular_side(lbpa, p)
-  S = singular_ring(lbpa)
+  S = singular_poly_ring(lbpa)
   I = modulus(L)
   SI = to_singular_side(lbpa, gens(I))
   
@@ -771,7 +771,7 @@ function write_as_linear_combination(
   hg = [a[i+1]*lifted_numerator(g[i]) for i in 1:n]
   hf = lifted_numerator(f)*a[1]
   A, I, q, phi, theta = as_affine_algebra(L)
-  SA, _ = Singular.PolynomialRing(Oscar.singular_ring(base_ring(A)), 
+  SA, _ = Singular.PolynomialRing(Oscar.singular_coeff_ring(base_ring(A)), 
 				  String.(symbols(A)),  
 				  ordering=Singular.ordering_dp(1)
 				  *Singular.ordering_dp(nvars(A)-1))
@@ -797,7 +797,7 @@ function write_as_linear_combination(f::T, g::Vector{T}) where {T<:MPolyQuoElem}
   for b in g
     parent(b) == Q || error("elements do not belong to the same ring")
   end
-  SR, _ = Singular.PolynomialRing(Oscar.singular_ring(base_ring(R)), 
+  SR, _ = Singular.PolynomialRing(Oscar.singular_coeff_ring(base_ring(R)), 
 				  String.(symbols(R)),  
 				  ordering=Singular.ordering_dp(ngens(R)))
   Sg_ext = SR.(vcat(lift.(g), gens(I)))
@@ -1156,7 +1156,7 @@ function is_isomorphism(
   C, j1, B_vars = _add_variables_first(A, String.(symbols(B)))
   j2 = hom(B, C, B_vars)
   G = ideal(C, [j1(gens(A)[i]) - j2(imagesB[i]) for i in (1:length(gens(A)))]) + ideal(C, j2.(gens(J))) + ideal(C, j1.(gens(I)))
-  singC, _ = Singular.PolynomialRing(Oscar.singular_ring(base_ring(C)), 
+  singC, _ = Singular.PolynomialRing(Oscar.singular_coeff_ring(base_ring(C)), 
 				  String.(symbols(C)),  
 				  ordering=Singular.ordering_dp(1)
 				  *Singular.ordering_dp(nvars(B)-1)

--- a/test/Rings/AbelianClosure.jl
+++ b/test/Rings/AbelianClosure.jl
@@ -239,7 +239,7 @@
 
   @testset "Singular ring" begin
     K, z = abelian_closure(QQ)
-    L = Oscar.singular_ring(K)
+    L = Oscar.singular_coeff_ring(K)
     a = z(4)
     @test K(L(a)) == a
   end

--- a/test/Rings/FunctionField-test.jl
+++ b/test/Rings/FunctionField-test.jl
@@ -21,7 +21,7 @@
       F2, (a2,) = Singular.FunctionField(kk, vcat(symb, ["b"])) # one more gen
       F3, (a3,) = Singular.FunctionField(Singular.Fp(5), symb) # different char
       
-      @test singular_ring(F) === F1
+      @test singular_coeff_ring(F) === F1
       @test F(a1) == a
       @test F1(a) == a1
       
@@ -32,7 +32,7 @@
       @test_throws ArgumentError F3(a) # wrong char
       
       R, (x, y) = PolynomialRing(F, ["x", "y"])
-      @test singular_ring(R) isa Singular.PolyRing{Singular.n_transExt}
+      @test singular_poly_ring(R) isa Singular.PolyRing{Singular.n_transExt}
 
       @test k(F(1)) isa elem_type(k)
       @test_throws InexactError k(a)

--- a/test/Rings/MPolyQuo_test.jl
+++ b/test/Rings/MPolyQuo_test.jl
@@ -75,7 +75,8 @@ end
 
   I = ideal(Q, [x^2*y-x+y,y+1])
   simplify!(I)
-  @test I.SI[1] == singular_ring(Q)(-x+y) && I.SI[2] == singular_ring(Q)(y+1)
+  SQ = singular_poly_ring(Q)
+  @test I.SI[1] == SQ(-x+y) && I.SI[2] == SQ(y+1)
   J = ideal(Q, [x+y+1,y+1])
   @test issubset(J, I) == true
   @test issubset(I, J) == false

--- a/test/Rings/mpoly-test.jl
+++ b/test/Rings/mpoly-test.jl
@@ -236,3 +236,10 @@ end
   @test issubset(I, I)
   @test I == I
 end
+
+@testset "#975" begin
+  A, t = PolynomialRing(QQ, ["t"])
+  R, (x,y,z) = PolynomialRing(A, ["x", "y", "z"])
+  I = ideal(R, [x])
+  @test x in I
+end


### PR DESCRIPTION
This is the first step in working towards iso_oscar_singular_{poly|coeff}_... .
Since this seems like an invasive change, I wanted to do it bit by bit and not have a large pr sit and bitrot.
Here I have just clarified why kind of ring the user is requesting. This is not just pointless mind reading and code refactoring, it actually does solve the first problem on #975. However, I wouldn't say the issue is resolved.