### PR TITLE
allow the singular function to convert oscar orderings

### DIFF
--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -370,6 +370,7 @@ function singular_poly_ring(Rx::MPolyRing{T}, ord::Symbol) where {T <: RingElem}
               cached = false)[1]
 end
 
+# convert only a basic block of an ordering
 function singular(o::Orderings.GenOrdering)
   v = o.vars
   @assert minimum(v)+length(v) == maximum(v)+1
@@ -402,6 +403,7 @@ function singular(o::Orderings.GenOrdering)
   end
 end
 
+# converts only a basic block of an ordering
 function singular(o::Orderings.ModOrdering)
    v = o.gens
    if o.ord == :lex
@@ -413,7 +415,8 @@ function singular(o::Orderings.ModOrdering)
    end
 end
 
-function singular_poly_ring(Rx::MPolyRing{T}, ord::Orderings.AbsOrdering) where {T <: RingElem}
+# convert a whole ordering, which may be a product
+function singular(ord::Orderings.AbsOrdering)
   #test if it can be mapped directly to singular:
   # - consecutive, non-overlapping variables
   # - covering everything
@@ -439,10 +442,17 @@ function singular_poly_ring(Rx::MPolyRing{T}, ord::Orderings.AbsOrdering) where 
   else
     o = Singular.ordering_M(Orderings.simplify_weight_matrix(ord))
   end
+  return o
+end
 
+# MonomialOrdering{T} and ModuleOrdering{T} are the user-facing types
+singular(ord::MonomialOrdering) = singular(ord.o)
+singular(ord::ModuleOrdering) = singular(ord.o)
+
+function singular_poly_ring(Rx::MPolyRing{T}, ord::Orderings.AbsOrdering) where {T <: RingElem}
   return Singular.PolynomialRing(singular_coeff_ring(base_ring(Rx)),
               [string(x) for x = Nemo.symbols(Rx)],
-              ordering = o,
+              ordering = singular(ord),
               cached = false)[1]
 end
 

--- a/test/Rings/orderings-test.jl
+++ b/test/Rings/orderings-test.jl
@@ -137,3 +137,27 @@ end
    o = negdegrevlex(gens(R))
    @test collect(monomials(f, o)) == M
  end
+
+@testset "Polynomial Ordering internal conversion to Singular" begin
+   R, (x, y, s, t, u) = PolynomialRing(QQ, ["x", "y", "s", "t", "u"])
+
+   O1 = degrevlex(gens(R))
+   @test string(singular(O1)) == "ordering_dp(5)"
+
+   O2 = lex([x, y])*deglex([s, t, u])
+   @test string(singular(O2)) == "ordering_lp(2) * ordering_Dp(3)"
+
+   O3 = wdeglex(gens(R), [2, 3, 5, 7, 3])
+   @test string(singular(O3)) == "ordering_Wp([2, 3, 5, 7, 3])"
+
+   O4 = deglex([x, y, t]) * deglex([y, s, u])
+   @test string(singular(O4)) == "ordering_M([1 1 0 1 0; 0 -1 0 -1 0; 0 0 0 -1 0; 0 0 1 0 1; 0 0 0 0 -1])"
+
+   K = FreeModule(R, 3)
+
+   O5 = revlex(gens(K))*degrevlex(gens(R))
+   @test string(singular(O5)) == "ordering_c() * ordering_dp(5)"
+
+   O6 = matrix_ordering([x, y], matrix(ZZ, 2, 2, [1 2; 3 4])) * lex(gens(K)) * wdeglex([s, t, u], [1, 2, 3])
+   @test string(singular(O6)) == "ordering_M([1 2; 3 4]) * ordering_C() * ordering_Wp([1, 2, 3])"
+end


### PR DESCRIPTION
@jankoboehm @AlexD97 You should now be able to call the `singular` function on the user-facing oscar orderings and get some kind of `Singular.sordering` out. The test code here has some examples from the documentation pasted in to make sure it works.