### PR TITLE
Wrap Singular function `minbase` for homogeneous ideals

### DIFF
--- a/experimental/InvariantTheory/secondary_invariants.jl
+++ b/experimental/InvariantTheory/secondary_invariants.jl
@@ -308,7 +308,7 @@ function secondary_invariants_nonmodular(RG::InvRing)
   @assert !ismodular(RG)
   p_invars = primary_invariants(RG)
   I = ideal_of_primary_invariants(RG)
-  LI = leading_ideal(I, ordering=degrevlex(gens(base_ring(I))))
+  LI = leading_ideal(I, ordering = default_ordering(base_ring(I)))
 
   fg = molien_series(RG)
   f = numerator(fg)

--- a/experimental/ModStd/ModStdQ.jl
+++ b/experimental/ModStd/ModStdQ.jl
@@ -217,7 +217,7 @@ end
  =    return groebner_basis_with_transform_inner(I, ord; complete_reduction=complete_reduction, use_hilbert=use_hilbert)
  = end
  =  =#
- function Oscar.groebner_basis_with_transform(I::MPolyIdeal{fmpq_mpoly}, ord::MonomialOrdering=degrevlex(gens(base_ring(I))); complete_reduction::Bool = true, use_hilbert::Bool = false)
+ function Oscar.groebner_basis_with_transform(I::MPolyIdeal{fmpq_mpoly}, ord::MonomialOrdering=default_ordering(base_ring(I)); complete_reduction::Bool = true, use_hilbert::Bool = false)
    return groebner_basis_with_transform_inner(I, ord; complete_reduction=complete_reduction, use_hilbert=use_hilbert)
 end
 

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -1195,6 +1195,15 @@ function minimal_generating_set(I::MPolyQuoIdeal{<:MPolyElem_dec}; ordering::Mon
     gensS = gens(typeof(IS)(QS, ptr))
   end
 
+  i = 1
+  while i <= length(gensS)
+    if iszero(gensS[i])
+      deleteat!(gensS, i)
+    else
+      i += 1
+    end
+  end
+
   return elem_type(Q)[ Q(f) for f in gensS ]
 end
 

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -35,6 +35,8 @@ Base.getindex(Q::MPolyQuo, i::Int) = Q(Q.R[i])
 base_ring(W::MPolyQuo) = W.R
 modulus(W::MPolyQuo) = W.I
 
+default_ordering(Q::MPolyQuo) = default_ordering(base_ring(Q))
+
 ##############################################################################
 #
 # Quotient ring elements
@@ -358,7 +360,7 @@ end
 
 ##################################################################
 
-function singular_poly_ring(Rx::MPolyQuo, ordering::MonomialOrdering = degrevlex(gens(Rx.R)); keep_ordering::Bool = true)
+function singular_poly_ring(Rx::MPolyQuo, ordering::MonomialOrdering = default_ordering(Rx); keep_ordering::Bool = true)
   if !isdefined(Rx, :SQR)
     groebner_assure(Rx.I, ordering)
     singular_assure(Rx.I.gb[ordering], ordering)
@@ -1178,7 +1180,7 @@ end
 ##################################
 #######################################################
 
-function minimal_generating_set(I::MPolyQuoIdeal{<:MPolyElem_dec}; ordering::MonomialOrdering = weighted_ordering(base_ring(base_ring(I))))
+function minimal_generating_set(I::MPolyQuoIdeal{<:MPolyElem_dec}; ordering::MonomialOrdering = default_ordering(base_ring(base_ring(I))))
   # This only works / makes sense for homogeneous ideals. So far ideals in an
   # MPolyRing_dec are forced to be homogeneous though.
 

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -1178,6 +1178,23 @@ end
 ##################################
 #######################################################
 
+function minimal_generating_set(I::MPolyQuoIdeal{<:MPolyElem_dec}; ordering::MonomialOrdering = weighted_ordering(base_ring(base_ring(I))))
+  # This only works / makes sense for homogeneous ideals. So far ideals in an
+  # MPolyRing_dec are forced to be homogeneous though.
+
+  Q = base_ring(I)
+
+  QS = singular_poly_ring(Q, ordering)
+  singular_assure(I)
+
+  IS = I.SI
+  GC.@preserve IS QS begin
+    ptr = Singular.libSingular.idMinBase(IS.ptr, QS.ptr)
+    gensS = gens(typeof(IS)(QS, ptr))
+  end
+
+  return elem_type(Q)[ Q(f) for f in gensS ]
+end
 
 ################################################################################
 #

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -30,7 +30,7 @@ Oscar.BiPolyArray{fmpq_mpoly}(Multivariate Polynomial Ring in x, y over Rational
 """
 function groebner_assure(I::MPolyIdeal, complete_reduction::Bool = false)
     if isempty(I.gb)
-        drl = degrevlex(gens(base_ring(I)))
+        drl = default_ordering(base_ring(I))
         I.gb[drl] = groebner_assure(I, drl, complete_reduction)
         G = I.gb[drl]
     else
@@ -87,7 +87,7 @@ end
 
 @doc Markdown.doc"""
     function groebner_basis(I::MPolyIdeal;
-      ordering::MonomialOrdering = degrevlex(gens(base_ring(I))),
+      ordering::MonomialOrdering = default_ordering(base_ring(I)),
       complete_reduction::Bool = false, enforce_global_ordering::Bool = true)
 
 Given an ideal `I` and optional parameters monomial ordering `ordering` and `complete_reduction`,
@@ -110,7 +110,7 @@ julia> H = groebner_basis(I, ordering=lex(gens(R)))
  6*x^2 - y^3
 ```
 """
-function groebner_basis(I::MPolyIdeal; ordering::MonomialOrdering = degrevlex(gens(base_ring(I))), complete_reduction::Bool=false, enforce_global_ordering::Bool = true)
+function groebner_basis(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool=false, enforce_global_ordering::Bool = true)
     groebner_assure(I, ordering, complete_reduction, enforce_global_ordering)
     return collect(I.gb[ordering])
 end
@@ -155,7 +155,7 @@ function groebner_basis_with_transform(B::BiPolyArray, ordering::MonomialOrderin
  end
 
 @doc Markdown.doc"""
-    groebner_basis_with_transformation_matrix(I::MPolyIdeal; ordering::MonomialOrdering=degrevlex(gens(base_ring(I))), complete_reduction::Bool=false)
+    groebner_basis_with_transformation_matrix(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool=false)
 
 Return a pair `G, m` where `G` is a Groebner basis of the ideal `I` with respect to the
 monomial ordering `ordering` (as default degree reverse lexicographical), and `m` is a transformation matrix from
@@ -177,7 +177,7 @@ true
 
 ```
 """
-function groebner_basis_with_transformation_matrix(I::MPolyIdeal; ordering::MonomialOrdering=degrevlex(gens(base_ring(I))), complete_reduction::Bool=false)
+function groebner_basis_with_transformation_matrix(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool = false)
    G, m = groebner_basis_with_transform(I.gens, ordering, complete_reduction)
    I.gb[ordering]  = G
    return collect(G), m

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -1268,5 +1268,14 @@ function minimal_generating_set(I::MPolyIdeal{<:MPolyElem_dec}; ordering::Monomi
     gensS = gens(typeof(IS)(RS, ptr))
   end
 
+  i = 1
+  while i <= length(gensS)
+    if iszero(gensS[i])
+      deleteat!(gensS, i)
+    else
+      i += 1
+    end
+  end
+
   return elem_type(R)[ R(f) for f in gensS ]
 end

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -911,7 +911,7 @@ julia> g in I
 false
 ```
 """
-function ideal_membership(f::T, I::MPolyIdeal{T}; ordering::MonomialOrdering = degrevlex(gens(base_ring(I)))) where T
+function ideal_membership(f::T, I::MPolyIdeal{T}; ordering::MonomialOrdering = default_ordering(base_ring(I))) where T
   groebner_assure(I, ordering)
   GI = I.gb[ordering]
   singular_assure(GI)
@@ -1254,7 +1254,7 @@ Given a homogeneous ideal $I$ in graded ring $R$ such that the grading gives ris
 to a weighted monomial ordering, return an array containing a minimal set of
 generators of $I$.
 """
-function minimal_generating_set(I::MPolyIdeal{<:MPolyElem_dec}; ordering::MonomialOrdering = weighted_ordering(base_ring(I)))
+function minimal_generating_set(I::MPolyIdeal{<:MPolyElem_dec}; ordering::MonomialOrdering = default_ordering(base_ring(I)))
   # This only works / makes sense for homogeneous ideals. So far ideals in an
   # MPolyRing_dec are forced to be homogeneous though.
 

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -5,6 +5,7 @@ export radical, primary_decomposition, minimal_primes, equidimensional_decomposi
 export absolute_primary_decomposition
 export iszero, isone, issubset, ideal_membership, radical_membership, inradical, isprime, isprimary
 export ngens, gens
+export minimal_generating_set
 
 # constructors #######################################################
 
@@ -1238,3 +1239,34 @@ function ismonomial(I::MPolyIdeal)
   end
   return false
 end 
+
+################################################################################
+#
+# Minimal generating set
+#
+################################################################################
+
+@doc Markdown.doc"""
+    minimal_generating_set(I::MPolyIdeal{<:MPolyElem_dec})
+    minimal_generating_set(I::MPolyQuoIdeal{<:MPolyElem_dec})
+
+Given a homogeneous ideal $I$ in graded ring $R$ such that the grading gives rise
+to a weighted monomial ordering, return an array containing a minimal set of
+generators of $I$.
+"""
+function minimal_generating_set(I::MPolyIdeal{<:MPolyElem_dec}; ordering::MonomialOrdering = weighted_ordering(base_ring(I)))
+  # This only works / makes sense for homogeneous ideals. So far ideals in an
+  # MPolyRing_dec are forced to be homogeneous though.
+
+  R = base_ring(I)
+
+  singular_assure(I, ordering)
+  IS = I.gens.S
+  RS = I.gens.Sx
+  GC.@preserve IS RS begin
+    ptr = Singular.libSingular.idMinBase(IS.ptr, RS.ptr)
+    gensS = gens(typeof(IS)(RS, ptr))
+  end
+
+  return elem_type(R)[ R(f) for f in gensS ]
+end

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -159,6 +159,8 @@ export lex, deglex, degrevlex, revlex, neglex, negrevlex, negdeglex,
 #type for orderings, use this...
 #in general: all algos here needs revision: do they benefit from gb or not?
 
+default_ordering(R::MPolyRing) = degrevlex(gens(R))
+
 mutable struct BiPolyArray{S}
   Ox::MPolyRing #Oscar Poly Ring
   O::Vector{S}

--- a/test/Rings/MPolyQuo_test.jl
+++ b/test/Rings/MPolyQuo_test.jl
@@ -83,4 +83,10 @@ end
   @test (I == J) == false
   @test dim(J)  == 1
   @test dim(J)  == J.dim  # test case if dim(J) is already set
+
+  R, (x, y) = grade(PolynomialRing(QQ, [ "x", "y"])[1], [ 1, 2 ])
+  I = ideal(R, [ x*y ])
+  Q, RtoQ = quo(R, I)
+  J = ideal(Q, [ x^3 + x*y, y, x^2 + y ])
+  @test minimal_generating_set(J) == [ Q(y), Q(x^2 + y) ]
 end

--- a/test/Rings/MPolyQuo_test.jl
+++ b/test/Rings/MPolyQuo_test.jl
@@ -89,4 +89,5 @@ end
   Q, RtoQ = quo(R, I)
   J = ideal(Q, [ x^3 + x*y, y, x^2 + y ])
   @test minimal_generating_set(J) == [ Q(y), Q(x^2 + y) ]
+  @test minimal_generating_set(ideal(Q, [ Q() ])) == elem_type(Q)[]
 end

--- a/test/Rings/mpoly-graded-test.jl
+++ b/test/Rings/mpoly-graded-test.jl
@@ -199,6 +199,12 @@ end
   @test isisomorphic(D, abelian_group([0]))
 end
 
+@testset "Minimal generating set" begin
+  R, (x, y) = grade(PolynomialRing(QQ, [ "x", "y"])[1], [ 1, 2 ])
+  I = ideal(R, [ x^2, y, x^2 + y ])
+  @test minimal_generating_set(I) == [ y, x^2 ]
+end
+
 # Conversion bug
 
 begin

--- a/test/Rings/mpoly-graded-test.jl
+++ b/test/Rings/mpoly-graded-test.jl
@@ -203,6 +203,7 @@ end
   R, (x, y) = grade(PolynomialRing(QQ, [ "x", "y"])[1], [ 1, 2 ])
   I = ideal(R, [ x^2, y, x^2 + y ])
   @test minimal_generating_set(I) == [ y, x^2 ]
+  @test minimal_generating_set(ideal(R, [ R() ])) == elem_type(R)[]
 end
 
 # Conversion bug


### PR DESCRIPTION
This introduces `minimal_generating_set` for homogeneous ideals using Singular's `minbase`.
Also makes sure that the `singular_poly_ring` constructed from a `MPolyRing_dec` is given a weighted monomial ordering corresponding to the grading if the grading is given by positive (or negative) weights.
Resolves #886 as far as I'm concerned.
Note that `minbase` is also wrapped in Singular.jl, but only for local orderings.