### PR TITLE
Fix `stabilizer` for "large" permutation groups

### DIFF
--- a/gap/misc.g
+++ b/gap/misc.g
@@ -1,0 +1,10 @@
+# the following code ensures that `GAP.Globals.Group` accepts a GAP list
+# of Oscar group elements, as there is a GAP `OrbitStabilizerAlgorithm` method
+# which sometimes does that when called by our `stabilize` method.
+BindGlobal("JuliaObjectCollectionsFamily", CollectionsFamily(JuliaObjectFamily));
+InstallMethod( IsGeneratorsOfMagmaWithInverses,
+    "for a list or collection of Julia objects",
+    f -> f= JuliaObjectCollectionsFamily,
+    [ IsListOrCollection ],
+    gens -> IsCollection( gens ) and
+       ForAll( gens, x -> Julia.isa(x, _OSCAR_GroupElem) ) );

--- a/src/GAP/iso_gap_oscar.jl
+++ b/src/GAP/iso_gap_oscar.jl
@@ -123,6 +123,9 @@ function __init_IsoGapOscar()
       GAP.Globals.InstallMethod(GAP.Globals.IsoGapOscar,
         GAP.Obj([GAP.Globals.IsDomain]), GAP.GapObj(_iso_gap_oscar));
     end
+
+    GAP.Globals.BindGlobal(GapObj("_OSCAR_GroupElem"), AbstractAlgebra.GroupElem)
+    GAP.Globals.Read(GapObj(joinpath(Oscar.oscardir, "gap", "misc.g")))
 end
 
 iso_gap_oscar(F::GAP.GapObj) = GAP.Globals.IsoGapOscar(F)

--- a/test/Groups/action.jl
+++ b/test/Groups/action.jl
@@ -15,6 +15,20 @@
   S = stabilizer(G, l, permuted)
   @test order(S[1]) == 4
 
+  # a more complex example
+  G = symmetric_group(14)
+  gens = [ cperm([1,10], [2,12,13,7,8,14], [3,4,9,6,5,11]),
+           cperm([1,11,6,13,12,10,2,8,4,3]) ]
+  H = sub(G, gens)[1]
+
+  # stabilizer should work
+  K = stabilizer(H, 1)[1]
+  @test order(K) == 46080
+
+  # bugfix test: stabilizer should still work after group size is known
+  @test order(H) == 645120
+  @test K == stabilizer(H, 1)[1]
+
 end
 
 @testset "natural stabilizers in matrix groups" begin


### PR DESCRIPTION
In some cases, computing a stabilizer in a GAP group, e.g. via
`stabilizer(G,1)`, could result in an error inside GAP. This only
happened when the permutation group already knew its size. That could
lead to confusing situations where at first `stabilizer` works, but
subsequent ones fail (because as a side effect of the first stabilizer
computation, the group order was calculated and stored). This patch
fixes this, and adds some tests to verify the fix works as intended.
