### PR TITLE
Some tweak for matrix groups code

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -234,7 +234,7 @@ function rand_pseudo(G::FPGroup; radius::Int)
   return group_element(G, GAP.Globals.PseudoRandom(G.X, radius = radius))
 end
 
-function _maxgroup(x::T, y::T) where T <: GAPGroup
+function _common_parent_group(x::T, y::T) where T <: GAPGroup
    # A typical situation should be that the two groups are identical,
    # but GAP's `IsSubset` check is not as cheap as one wants;
    # there is an `IsSubset` method that checks for identity,
@@ -252,7 +252,7 @@ end
 
 #We need a lattice of groups to implement this properly
 function _prod(x::T, y::T) where T <: GAPGroupElem
-  G = _maxgroup(parent(x), parent(y))
+  G = _common_parent_group(parent(x), parent(y))
   return group_element(G, x.X*y.X)
 end
 
@@ -496,7 +496,7 @@ function conjugacy_classes(G::GAPGroup)
    return [GroupConjClass(G, group_element(G,GAP.Globals.Representative(cc)::GapObj),cc) for cc in L]
 end
 
-Base.:^(x::T, y::T) where T <: GAPGroupElem = group_element(_maxgroup(parent(x), parent(y)), x.X ^ y.X)
+Base.:^(x::T, y::T) where T <: GAPGroupElem = group_element(_common_parent_group(parent(x), parent(y)), x.X ^ y.X)
 
 @doc Markdown.doc"""
     isconjugate(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)

--- a/src/Groups/matrices/linear_isconjugate.jl
+++ b/src/Groups/matrices/linear_isconjugate.jl
@@ -44,14 +44,14 @@ end
 
 Return whether `x` is semisimple, i.e. has order coprime with the characteristic of its base ring.
 """
-issemisimple(x::MatrixGroupElem{T}) where T <: FinFieldElem = iscoprime(Int(order(x)::fmpz), Int(characteristic(x.parent.ring)))
+issemisimple(x::MatrixGroupElem{T}) where T <: FinFieldElem = iscoprime(order(Int, x), Int(characteristic(x.parent.ring)))
 
 """
     isunipotent(x::MatrixGroupElem{T}) where T <: FinFieldElem
 
 Return whether `x` is unipotent, i.e. its order is a power of the characteristic of its base ring.
 """
-isunipotent(x::MatrixGroupElem{T}) where T <: FinFieldElem = isone(x) || ispower(Int(order(x)))[2]==Int(characteristic(x.parent.ring))
+isunipotent(x::MatrixGroupElem{T}) where T <: FinFieldElem = isone(x) || ispower(order(Int, x))[2]==Int(characteristic(x.parent.ring))
 
 
 
@@ -126,12 +126,12 @@ end
 
 # TODO is there a way to accelerate the process? pol_elementary_divisors and generalized_jordan_block repeat parts of the same code.
 """
-    generalized_jordan_form(A::MatElem{T}; with_pol=false) where T
+    generalized_jordan_form(A::MatElem{T}; with_pol::Bool=false) where T
 
 Return (`J`,`Z`), where `Z^-1*J*Z = A` and `J` is a diagonal join of Jordan
 blocks (corresponding to irreducible polynomials).
 """
-function generalized_jordan_form(A::MatElem{T}; with_pol=false) where T
+function generalized_jordan_form(A::MatElem{T}; with_pol::Bool=false) where T
    V = pol_elementary_divisors(A)
    GJ = cat([generalized_jordan_block(v[1],v[2]) for v in V]..., dims=(1,2))
    a = rational_canonical_form(A)[2]


### PR DESCRIPTION
- Refactor examples/benchmark_matrices.jl
- Improve GL(n.p) and friends to use GF(p) instead of GF(p,1)
- Fix type stability for MatrixGroupElem products
