### PR TITLE
Tropical Geometry documentation improvement

### DIFF
--- a/docs/src/DeveloperDocumentation/styleguide.md
+++ b/docs/src/DeveloperDocumentation/styleguide.md
@@ -49,7 +49,7 @@ to a minimum. Here is a general principle:
 > Do not use Unicode characters inside functions. See below for the exception
 > concerning printing.
 
-Per default output should be ANSI only (no Unicode). Implementors of 
+Per default output should be ANSI only (no Unicode). Implementors of
 `Base.show` and related functions can branch on the output of
 `Oscar.is_unicode_allowed()` to display objects using non-ASCII characters.
 This will then be used for users which enabled Unicode using
@@ -167,5 +167,8 @@ However, as always, rules sometimes should be broken.
 
 ## Documentation
 
-In general we try to follow the list of recommendations in the
-[Documentation section of the Julia manual](https://docs.julialang.org/en/v1/manual/documentation/).
+ - In general we try to follow the list of recommendations in the
+   [Documentation section of the Julia manual](https://docs.julialang.org/en/v1/manual/documentation/).
+
+ - Via the MathJax integration it is possible to use LaTeX code, and this is the
+   preferred way to denote the mathematical symbols in the docstrings.

--- a/src/TropicalGeometry/hypersurface.jl
+++ b/src/TropicalGeometry/hypersurface.jl
@@ -204,7 +204,7 @@ end
 Return the dual subdivision of `TH` if it is embedded. Otherwise an error is thrown.
 
 # Examples
-A tropical hypersurface in RR^n is always of dimension n-1.
+A tropical hypersurface in $\mathbb{R}^n$ is always of dimension n-1.
 ```jldoctest
 julia> T = TropicalSemiring(min);
 

--- a/src/TropicalGeometry/variety_supertype.jl
+++ b/src/TropicalGeometry/variety_supertype.jl
@@ -85,7 +85,7 @@ export intersect_stably
 Return the ambient dimension of `T` if it is embedded. Otherwise an error is thrown.
 
 # Examples
-A tropical hypersurface in RR^n is of ambient dimension n
+A tropical hypersurface in $\mathbb{R}^n$ is of ambient dimension n
 ```jldoctest
 julia> RR = TropicalSemiring(min);
 
@@ -118,7 +118,7 @@ end
 Return the codimension of `T`.
 
 # Examples
-A tropical hypersurface in RR^n is always of dimension n-1
+A tropical hypersurface in $\mathbb{R}^n$ is always of dimension n-1
 ```jldoctest
 julia> RR = TropicalSemiring(min);
 
@@ -147,7 +147,7 @@ end
 Return the dimension of `T`.
 
 # Examples
-A tropical hypersurface in RR^n is always of dimension n-1
+A tropical hypersurface in $\mathbb{R}^n$ is always of dimension n-1
 ```jldoctest
 julia> RR = TropicalSemiring(min);
 
@@ -176,7 +176,7 @@ end
 Return the f-Vector of `T`.
 
 # Examples
-A tropical hypersurface in RR^n is of lineality dimension n
+A tropical hypersurface in $\mathbb{R}^n$ is of lineality dimension n
 ```jldoctest
 julia> RR = TropicalSemiring(min);
 
@@ -207,7 +207,7 @@ end
 Return the dimension of the lineality space of `T` if it is embedded. Otherwise an error is thrown.
 
 # Examples
-A tropical hypersurface in RR^n is of lineality dimension n
+A tropical hypersurface in $\mathbb{R}^n$ is of lineality dimension n
 ```jldoctest
 julia> RR = TropicalSemiring(min);
 
@@ -240,7 +240,7 @@ end
 Return the lineality space of `T` if it is embedded. Otherwise an error is thrown.
 
 # Examples
-A tropical hypersurface in RR^n is of lineality spaceension n
+A tropical hypersurface in $\mathbb{R}^n$ is of lineality spaceension n
 ```jldoctest
 julia> RR = TropicalSemiring(min);
 
@@ -274,7 +274,7 @@ end
 Return the maximal polyhedra of `T`.
 
 # Examples
-A tropical hypersurface in RR^n is of lineality dimension n
+A tropical hypersurface in $\mathbb{R}^n$ is of lineality dimension n
 ```jldoctest
 julia> RR = TropicalSemiring(min);
 
@@ -307,7 +307,7 @@ end
 Return the number of maximal polyhedra of `T`.
 
 # Examples
-A tropical hypersurface in RR^n is of lineality dimension n
+A tropical hypersurface in $\mathbb{R}^n$ is of lineality dimension n
 ```jldoctest
 julia> RR = TropicalSemiring(min);
 
@@ -337,7 +337,7 @@ end
 Return the number of polyhedra of `T`.
 
 # Examples
-A tropical hypersurface in RR^n is of lineality dimension n
+A tropical hypersurface in $\mathbb{R}^n$ is of lineality dimension n
 ```jldoctest
 julia> RR = TropicalSemiring(min);
 
@@ -367,7 +367,7 @@ end
 Return the number of vertices of `T`.
 
 # Examples
-A tropical hypersurface in RR^n is of lineality dimension n
+A tropical hypersurface in $\mathbb{R}^n$ is of lineality dimension n
 ```jldoctest
 julia> RR = TropicalSemiring(min);
 
@@ -397,7 +397,7 @@ end
 Return true if `T` is a pure polyhedral complex, false otherwise.
 
 # Examples
-A tropical hypersurface in RR^n is of lineality dimension n
+A tropical hypersurface in $\mathbb{R}^n$ is of lineality dimension n
 ```jldoctest
 julia> RR = TropicalSemiring(min);
 
@@ -426,7 +426,7 @@ end
 Return true if `T` is a simplicial polyhedral complex, false otherwise.
 
 # Examples
-A tropical hypersurface in RR^n is of lineality dimension n
+A tropical hypersurface in $\mathbb{R}^n$ is of lineality dimension n
 ```jldoctest
 julia> RR = TropicalSemiring(min);
 
@@ -506,7 +506,7 @@ end
 Return the weights of `T`.
 
 # Examples
-A tropical hypersurface in RR^n is of lineality dimension n
+A tropical hypersurface in $\mathbb{R}^n$ is of lineality dimension n
 ```jldoctest
 julia> RR = TropicalSemiring(min);
 


### PR DESCRIPTION
I changed RR^n into \mathbb{R}^n in the documenations of the tropical geometry implementations.