### PR TITLE
[CI] add julia 1.8, remove nightly on macos

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,18 +24,17 @@ jobs:
         julia-version:
           - '1.6'
           - '~1.7.0-0'
+          - '~1.8.0-0'
           - 'nightly'
         julia-arch:
           - x64
         os:
           - ubuntu-latest
           - macOS-latest
-        #exclude:
-        #  # Reduce the number of macOS jobs, as fewer can be run in parallel
-        #  - os: macos-latest
-        #    julia-version: '1.3'
-        #  - os: macos-latest
-        #    julia-version: '1.4'
+        exclude:
+          # disable nightly tests due to https://github.com/JuliaLang/julia/issues/44800
+          - os: macos-latest
+            julia-version: 'nightly'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Currently https://github.com/JuliaLang/julia/issues/44800 is blocking the macos workers for 5 hours per job.
We can enable nightly again once this is solved.

cc: @fingolfin @thofma 