### PR TITLE
[CI] reduce job timeout to 2 hours

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
     continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
As [requested](https://github.com/oscar-system/Oscar.jl/issues/1218#issuecomment-1083613991), to avoid jobs accidentally blocking the workers for a long time.

Currently tests on macos with julia 1.6 including doctests take about 1 hour, so this should be a reasonable limit.