### PR TITLE
add `isomorphism`

### DIFF
--- a/docs/src/Groups/grouphom.md
+++ b/docs/src/Groups/grouphom.md
@@ -167,8 +167,7 @@ preimage(f::GAPGroupHomomorphism{S, T}, H::T) where S <: GAPGroup where T <: GAP
 ## Groups created by isomorphisms
 
 ```@docs
-isomorphic_perm_group(G::GAPGroup)
-isomorphic_pc_group(G::GAPGroup)
-isomorphic_fp_group(G::GAPGroup)
+isomorphism(::Type{T}, G::GAPGroup) where T <: Union{FPGroup, PcGroup, PermGroup}
+isomorphism(::Type{GrpAbFinGen}, G::GAPGroup)
 simplified_fp_group(G::FPGroup)
 ```

--- a/experimental/GaloisGrp/GaloisGrp.jl
+++ b/experimental/GaloisGrp/GaloisGrp.jl
@@ -1378,7 +1378,7 @@ function starting_group(GC::GaloisCtx, K::T; useSubfields::Bool = true) where T 
     # and the product then is one for the 3rd case.
     s = S(vcat(b...))
 
-    wr = codomain(isomorphism(PermGroup, wreath_product(symmetric_group(length(b[1])), symmetric_group(length(b)))))
+    wr = PermGroup(wreath_product(symmetric_group(length(b[1])), symmetric_group(length(b))))
     br = intersect(wr, alternating_group(degree(K)))[1]
     wr = wr^s
     br = br^s
@@ -1389,7 +1389,7 @@ function starting_group(GC::GaloisCtx, K::T; useSubfields::Bool = true) where T 
     #for length(b) == 2, the bottom field is quadratic and thus always S2
     #the wreath product would not be transitive here
     if can_use_wr
-      ar = codomain(isomorphism(PermGroup, wreath_product(symmetric_group(length(b[1])), alternating_group(length(b)))))
+      ar = PermGroup(wreath_product(symmetric_group(length(b[1])), alternating_group(length(b))))
       ar = ar^s
       cr = index2sum(wr, ar, br)
     end

--- a/experimental/GaloisGrp/GaloisGrp.jl
+++ b/experimental/GaloisGrp/GaloisGrp.jl
@@ -1378,7 +1378,7 @@ function starting_group(GC::GaloisCtx, K::T; useSubfields::Bool = true) where T 
     # and the product then is one for the 3rd case.
     s = S(vcat(b...))
 
-    wr = isomorphic_perm_group(wreath_product(symmetric_group(length(b[1])), symmetric_group(length(b))))[1]
+    wr = codomain(isomorphism(PermGroup, wreath_product(symmetric_group(length(b[1])), symmetric_group(length(b)))))
     br = intersect(wr, alternating_group(degree(K)))[1]
     wr = wr^s
     br = br^s
@@ -1389,7 +1389,7 @@ function starting_group(GC::GaloisCtx, K::T; useSubfields::Bool = true) where T 
     #for length(b) == 2, the bottom field is quadratic and thus always S2
     #the wreath product would not be transitive here
     if can_use_wr
-      ar = isomorphic_perm_group(wreath_product(symmetric_group(length(b[1])), alternating_group(length(b))))[1]
+      ar = codomain(isomorphism(PermGroup, wreath_product(symmetric_group(length(b[1])), alternating_group(length(b)))))
       ar = ar^s
       cr = index2sum(wr, ar, br)
     end

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1121,7 +1121,7 @@ function describe(G::FPGroup)
       iso = GAP.Globals.IsomorphismPermGroupOrFailFpGroup(G.X, 100000)::GapObj
       iso != GAP.Globals.fail && return describe(PermGroup(GAP.Globals.Range(iso)))
    elseif isfinite(G)
-      return describe(codomain(isomorphism(PermGroup, G)))
+      return describe(PermGroup(G))
    else
       extra *= " infinite"
    end

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1121,7 +1121,7 @@ function describe(G::FPGroup)
       iso = GAP.Globals.IsomorphismPermGroupOrFailFpGroup(G.X, 100000)::GapObj
       iso != GAP.Globals.fail && return describe(PermGroup(GAP.Globals.Range(iso)))
    elseif isfinite(G)
-      return describe(isomorphic_perm_group(G)[1])
+      return describe(codomain(isomorphism(PermGroup, G)))
    else
       extra *= " infinite"
    end

--- a/src/Groups/abelian_aut.jl
+++ b/src/Groups/abelian_aut.jl
@@ -7,59 +7,8 @@ AutGrpAbTorElem = Union{AutomorphismGroupElem{GrpAbFinGen},AutomorphismGroupElem
 AbTorElem = Union{GrpAbFinGenElem,TorQuadModElem}
 
 function _isomorphic_gap_group(A::GrpAbFinGen; T=PcGroup)
-  # find independent generators
-  if isdiagonal(rels(A))
-    exponents = diagonal(rels(A))
-    A2 = A
-    A2_to_A = identity_map(A)
-    A_to_A2 = identity_map(A)
-  else
-    exponents = elementary_divisors(A)
-    A2, A2_to_A = snf(A)
-    A_to_A2 = inv(A2_to_A)
-  end
-  # the isomorphic gap group
-  Agap = abelian_group(T, exponents)
-  G = GAP.Globals
-  # the gap IndependentGenerators may differ from
-  # the generators even if the generators are independent
-  gensindep = G.IndependentGeneratorsOfAbelianGroup(Agap.X)
-  Aindep = abelian_group(fmpz[G.Order(g) for g in gensindep])
-
-  imgs = [Vector{fmpz}(G.IndependentGeneratorExponents(Agap.X, a.X)) for a in gens(Agap)]
-  A2_to_Aindep = hom(A2, Aindep, elem_type(Aindep)[Aindep(e) for e in imgs])
-  Aindep_to_A2 = inv(A2_to_Aindep)
-  Aindep_to_A = compose(Aindep_to_A2, A2_to_A)
-
-  function Agap_to_A(a)
-      return Aindep_to_A(_gap_to_oscar(a, Aindep))
-  end
-
-  function A_to_Agap(a)
-      return _oscar_to_gap(A_to_A2(a), Agap)
-  end
-
-  to_gap = Hecke.map_from_func(A_to_Agap, A, Agap)
-  to_oscar = Hecke.map_from_func(Agap_to_A, Agap, A)
-
-  return Agap, to_gap, to_oscar
-end
-
-function _oscar_to_gap(a::GrpAbFinGenElem, B::GAPGroup)
-  gensB = gens(B)
-  n = length(a.coeff)
-  @assert length(gensB) == n
-  img = one(B)
-  for i in 1:n
-    img *= gensB[i]^a[i]
-  end
-  return img
-end
-
-function _gap_to_oscar(a::Oscar.BasicGAPGroupElem, B::GrpAbFinGen)
-  A = parent(a)
-  exp = Vector{fmpz}(GAP.Globals.IndependentGeneratorExponents(A.X, a.X))
-  return B(exp)
+  iso = isomorphism(T, A)
+  return codomain(iso), iso, inv(iso)
 end
 
 """

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -324,7 +324,8 @@ end
 function quo(::Type{Q}, G::T, elements::Vector{S}) where {Q <: GAPGroup, T <: GAPGroup, S <: GAPGroupElem}
   F, epi = quo(G, elements)
   if !(F isa Q)
-    F, map = isomorphic_group(Q, F)
+    map = isomorphism(Q, F)
+    F = codomain(map)
     epi = compose(epi, map)
   end
   return F, epi
@@ -373,7 +374,8 @@ end
 function quo(::Type{Q}, G::T, N::T) where {Q <: GAPGroup, T <: GAPGroup}
   F, epi = quo(G, N)
   if !(F isa Q)
-    F, map = isomorphic_group(Q, F)
+    map = isomorphism(Q, F)
+    F = codomain(map)
     epi = compose(epi, map)
   end
   return F, epi
@@ -426,7 +428,8 @@ end
 function maximal_abelian_quotient(::Type{Q}, G::GAPGroup) where Q <: GAPGroup
   F, epi = maximal_abelian_quotient(G)
   if !(F isa Q)
-    F, map = isomorphic_group(Q, F)
+    map = isomorphism(Q, F)
+    F = codomain(map)
     epi = compose(epi, map)
   end
   return F, epi
@@ -500,22 +503,3 @@ function intersect(V::AbstractVector{T}) where T<:GAPGroup
    return Arr
 end
 #T why duplicate this code?
-
-
-################################################################################
-#
-#  Conversions between types
-#
-################################################################################
-
-_get_iso_function(::Type{PermGroup}) = GAP.Globals.IsomorphismPermGroup
-_get_iso_function(::Type{FPGroup}) = GAP.Globals.IsomorphismFpGroup
-_get_iso_function(::Type{PcGroup}) = GAP.Globals.IsomorphismPcGroup
-
-function isomorphic_group(::Type{T}, G::GAPGroup) where T <: GAPGroup
-  f = _get_iso_function(T)
-  mp = f(G.X)::GapObj
-  G1 = T(GAP.Globals.ImagesSource(mp)::GapObj)
-  fmap = GAPGroupHomomorphism(G, G1, mp)
-  return G1, fmap
-end

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -121,6 +121,41 @@ end
       end
    end
 
+   @testset "Finite GrpAbFinGen to GAPGroup" begin
+      @testset for Agens in [[2, 4, 8], [2, 3, 4], [ 2, 12 ],
+                             [1, 6], matrix(ZZ, 2, 2, [2, 3, 2, 6])]
+         A = abelian_group(Agens)
+         for T in [FPGroup, PcGroup, PermGroup]
+            iso = isomorphism(T, A)
+            for x in gens(A)
+               for y in gens(A)
+                  z = x+y
+                  @test iso(x) * iso(y) == iso(z)
+                  @test all(a -> preimage(iso, iso(a)) == a, [x, y, z])
+               end
+            end
+         end
+      end
+   end
+
+   @testset "Group types as constructors" begin
+      G = symmetric_group(4)
+      for T in [FPGroup, PcGroup, PermGroup]
+        H = T(G)
+        @test H isa T
+        @test isisomorphic(G, H)[1]
+      end
+
+      G = cyclic_group(5)
+      T = GrpAbFinGen
+      H = T(G)
+      @test H isa T
+      @test order(H) == order(G)
+      K = PermGroup(H)
+      @test K isa PermGroup
+      @test order(K) == order(H)
+   end
+
    @testset "Abelian_as_permutation" for n in 15:20
       G = symmetric_group(n)
       for j in 2:n-2
@@ -135,31 +170,45 @@ end
 
    @testset "Change type" begin
        S = symmetric_group(4)
-       (S1,f)=isomorphic_perm_group(S)
-       @test S1==S
-       (G,f)=isomorphic_pc_group(S)
+       f = isomorphism(PermGroup, S)
+       @test codomain(f) == S
+
+       f = isomorphism(PcGroup, S)
+       G = codomain(f)
        @test G isa PcGroup
-       @test domain(f)==S
-       @test codomain(f)==G
+       @test domain(f) == S
        @test isinjective(f)
        @test issurjective(f)
 
-       (S,g)=isomorphic_pc_group(G)
-       @test S isa PcGroup
-       @test domain(g)==G
-       @test codomain(g)==S
-       @test isinjective(g)
-       @test issurjective(g)
+       f = isomorphism(PcGroup, G)
+       @test codomain(f) isa PcGroup
+       @test domain(f) == G
+       @test isinjective(f)
+       @test issurjective(f)
 
-       (F,g)=isomorphic_fp_group(G)
-       @test F isa FPGroup
-       @test domain(g)==G
-       @test codomain(g)==F
-       @test isinjective(g)
-       @test issurjective(g)
+       f = isomorphism(FPGroup, G)
+       @test codomain(f) isa FPGroup
+       @test domain(f) == G
+       @test isinjective(f)
+       @test issurjective(f)
 
-       @test_throws ArgumentError isomorphic_pc_group(symmetric_group(5))   
-   end   
+       G = abelian_group(PermGroup, [2, 2])
+       f = isomorphism(GrpAbFinGen, G)
+       @test codomain(f) isa GrpAbFinGen
+       @test domain(f) == G
+     # @test isinjective(f)
+     # @test issurjective(f)
+
+       @test_throws ArgumentError isomorphism(GrpAbFinGen, symmetric_group(5))
+       @test_throws ArgumentError isomorphism(PcGroup, symmetric_group(5))
+       @test_throws ArgumentError isomorphism(PermGroup, free_group(1))
+
+       G = symmetric_group(4)
+       @test PermGroup(G) isa PermGroup
+       @test PcGroup(G) isa PcGroup
+       @test FPGroup(G) isa FPGroup
+       @test_throws ArgumentError GrpAbFinGen(G)
+   end
 end
 
 TestDirectProds=function(G1,G2)

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -395,7 +395,7 @@ end
 @testset "Composition of mappings" begin
    g = symmetric_group(4)
    q, epi = quo(g, pcore(g, 2)[1])
-   F, iso = isomorphic_perm_group(q)
+   iso = isomorphism(PermGroup, q)
    comp = compose(epi, iso)
    @test domain(comp) == domain(epi)
    @test codomain(comp) == codomain(iso)

--- a/test/Groups/quotients.jl
+++ b/test/Groups/quotients.jl
@@ -32,13 +32,13 @@ end
    for subgens in [N, gens(N)]
       @test quo(G, subgens)[1] isa PermGroup
       @test quo(FPGroup, G, subgens)[1] isa FPGroup
-      @test_throws ErrorException quo(PcGroup, G, subgens)
+      @test_throws ArgumentError quo(PcGroup, G, subgens)
    end
    N = trivial_subgroup(G)[1]
    for subgens in [N, gens(N)]
       @test quo(G, subgens)[1] isa MatrixGroup
       @test quo(PermGroup, G, subgens)[1] isa PermGroup
-      @test_throws ErrorException quo(PcGroup, G, subgens)
+      @test_throws ArgumentError quo(PcGroup, G, subgens)
    end
 
    # - `maximal_abelian_quotient` without prescribed type:


### PR DESCRIPTION
This is a follow-up to #1182.

- deprecate
  `isomorphic_fp_group(G::GAPGroup)`,
  `isomorphic_pc_group(G::GAPGroup)`,
  `isomorphic_perm_group(G::GAPGroup)`
  in favour of
  `isomorphism(::Type{FPGroup}, G::GAPGroup)`
  `isomorphism(::Type{PcGroup}, G::GAPGroup)`
  `isomorphism(::Type{PermGroup}, G::GAPGroup)`

- deprecate also (the undocumented) `isomorphic_group(::Type{T}, G::GAPGroup)`
  (does not occur in tests) in favour of `isomorphism`

- added
  `isomorphism(::Type{FPGroup}, A::GrpAbFinGen)`
  `isomorphism(::Type{PcGroup}, A::GrpAbFinGen)`
  `isomorphism(::Type{PermGroup}, A::GrpAbFinGen)`

- moved `_get_iso_function` and `isomorphic_group`
  from `sub.jl` to `homomorphisms.jl`

- added tests for new conversions

- adjusted tests to use `isomorphism` instead of the deprecated versions

- added (::Type{T})(G::GAPGroup)