### PR TITLE
Add `coefficient_ring(::MPolyQuo)`; avoid typeof

### DIFF
--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -359,7 +359,7 @@ Return a vector containing all elements belonging to all groups and cosets
 in `V`.
 """
 function intersect(V::AbstractVector{Union{T, GroupCoset, GroupDoubleCoset}}) where T <: GAPGroup
-   if typeof(V[1]) <: GAPGroup
+   if V[1] isa GAPGroup
       G = V[1]
    else
       G = V[1].G

--- a/src/Groups/matrices/form_group.jl
+++ b/src/Groups/matrices/form_group.jl
@@ -67,7 +67,7 @@ over its prime subfield.
 """
 function invariant_sesquilinear_forms(G::MatrixGroup{S,T}) where {S,T}
    F = base_ring(G)
-   @assert typeof(F)<:FinField "At the moment, only finite fields are considered"
+   @assert F isa FinField "At the moment, only finite fields are considered"
    @assert iseven(degree(F)) "Base ring has no even degree"
    n = degree(G)
    M = T[]
@@ -202,7 +202,7 @@ over its prime subfield.
 """
 function invariant_hermitian_forms(G::MatrixGroup{S,T}) where {S,T}
    F = base_ring(G)
-   @assert typeof(F)<:FinField "At the moment, only finite fields are considered"
+   @assert F isa FinField "At the moment, only finite fields are considered"
    n = degree(G)
    M = T[]
 

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -33,6 +33,7 @@ ngens(Q::MPolyQuo) = ngens(Q.R)
 gen(Q::MPolyQuo, i::Int) = Q(gen(Q.R, i))
 Base.getindex(Q::MPolyQuo, i::Int) = Q(Q.R[i])
 base_ring(W::MPolyQuo) = W.R
+coefficient_ring(W::MPolyQuo) = coefficient_ring(base_ring(W))
 modulus(W::MPolyQuo) = W.I
 
 default_ordering(Q::MPolyQuo) = default_ordering(base_ring(Q))
@@ -1215,7 +1216,7 @@ function minimal_generating_set(I::MPolyQuoIdeal{<:MPolyElem_dec}; ordering::Mon
 
   @assert isgraded(Q)
   
-  if !(base_ring(base_ring(Q)) isa AbstractAlgebra.Field)
+  if !(coefficient_ring(Q) isa AbstractAlgebra.Field)
        throw(ArgumentError("The coefficient ring must be a field."))
   end
   

--- a/src/Rings/mpoly-affine-algebras.jl
+++ b/src/Rings/mpoly-affine-algebras.jl
@@ -376,10 +376,10 @@ julia> multi_hilbert_series(A)
 function multi_hilbert_series(A::MPolyQuo)
    R = A.R
    I = A.I
-   if !(typeof(base_ring(R)) <: AbstractAlgebra.Field)
-       throw(ArgumentError("The coefficient ring of the base ring must be a field."))
+   if !(coefficient_ring(R) isa AbstractAlgebra.Field)
+       throw(ArgumentError("The coefficient ring must be a field."))
    end
-   if !(typeof(R) <: MPolyRing_dec && isgraded(R) && is_positively_graded(R))
+   if !(R isa MPolyRing_dec && isgraded(R) && is_positively_graded(R))
        throw(ArgumentError("The base ring must be positively graded."))
    end
    if !(is_zm_graded(R))
@@ -567,8 +567,8 @@ julia> multi_hilbert_function(A, 7*g)
 """
 function multi_hilbert_function(A::MPolyQuo, g::GrpAbFinGenElem)
     R = A.R
-    if !(typeof(base_ring(R)) <: AbstractAlgebra.Field)
-       throw(ArgumentError("The coefficient ring of the base ring must be a field."))
+    if !(coefficient_ring(R) isa AbstractAlgebra.Field)
+       throw(ArgumentError("The coefficient ring of must be a field."))
     end
     LI = leading_ideal(A.I, ordering=degrevlex(gens(R)))
     ### TODO: Decide whether we should check whether a GB with respect
@@ -720,14 +720,8 @@ julia> subalgebra_membership(f, V)
 """
 function subalgebra_membership(f::S, v::Vector{S}) where S <: Union{MPolyElem, MPolyQuoElem}
    r = parent(f)
-   if r isa MPolyRing
-      if !(base_ring(r) isa AbstractAlgebra.Field)
-          throw(ArgumentError("The coefficient ring must be a field."))
-      end
-   else
-      if !(base_ring(r.R) isa AbstractAlgebra.Field)
-         throw(ArgumentError("The coefficient ring of the base ring must be a field."))
-      end
+   if !(coefficient_ring(r) isa AbstractAlgebra.Field)
+       throw(ArgumentError("The coefficient ring must be a field."))
    end
    @assert !isempty(v)
    @assert all(x->parent(x) == r, v)
@@ -789,23 +783,17 @@ julia> minimal_subalgebra_generators(V)
 function minimal_subalgebra_generators(V::Vector{T}) where T <: Union{MPolyElem, MPolyQuoElem}
   p = parent(V[1])
   @assert all(x->parent(x) == p, V)
-  if p isa MPolyRing
-       if !(base_ring(p) isa AbstractAlgebra.Field)
-          throw(ArgumentError("The coefficient ring must be a field."))
-      end
-      p isa MPolyRing_dec && is_positively_graded(p) || throw(ArgumentError("The base ring must be positively graded"))
-      all(ishomogeneous, V) || throw(ArgumentError("The input data is not homogeneous"))
-      # iterate over the generators, starting with those in lowest degree, then work up
-      W = sort(V, by = x -> degree(x)[1])
-  else
-      if !(base_ring(p.R) isa AbstractAlgebra.Field)
-         throw(ArgumentError("The coefficient ring of the base ring must be a field."))
-      end
-      p.R isa MPolyRing_dec && isgraded(p.R) || throw(ArgumentError("The base ring must be graded"))
-      all(ishomogeneous, V) || throw(ArgumentError("The input data is not homogeneous"))
-      # iterate over the generators, starting with those in lowest degree, then work up
-      W = sort(V, by = x -> degree(x.f)[1])
+  if !(coefficient_ring(p) isa AbstractAlgebra.Field)
+     throw(ArgumentError("The coefficient ring must be a field."))
   end
+  if p isa MPolyRing
+      p isa MPolyRing_dec && is_positively_graded(p) || throw(ArgumentError("The base ring must be positively graded"))
+  else
+      p.R isa MPolyRing_dec && isgraded(p.R) || throw(ArgumentError("The base ring must be graded"))
+  end
+  all(ishomogeneous, V) || throw(ArgumentError("The input data is not homogeneous"))
+  # iterate over the generators, starting with those in lowest degree, then work up
+  W = sort(V, by = x -> degree(x)[1])
   result = [ W[1] ]
   for elm in W
     if !subalgebra_membership(elm, result)[1]
@@ -913,10 +901,10 @@ julia> LL[1][3]
 ```
 """
 function normalization(A::MPolyQuo; alg=:equidimDec)
-  if !(typeof(base_ring(A.R)) <: AbstractAlgebra.Field)
-       throw(ArgumentError("The coefficient ring of the base ring must be a field."))
+  if !(coefficient_ring(A) isa AbstractAlgebra.Field)
+       throw(ArgumentError("The coefficient ring must be a field."))
   end
-  if typeof(A.R) <: MPolyRing_dec
+  if A.R isa MPolyRing_dec
     throw(ArgumentError("Not implemented for quotients of decorated rings."))
   end
   I = A.I
@@ -980,10 +968,10 @@ Quotient of Multivariate Polynomial Ring in T(1), T(2), x, y, z over Rational Fi
 ```
 """
 function normalization_with_delta(A::MPolyQuo; alg=:equidimDec)
-  if !(typeof(base_ring(A.R)) <: AbstractAlgebra.Field)
-       throw(ArgumentError("The coefficient ring of the base ring must be a field."))
+  if !(coefficient_ring(A) isa AbstractAlgebra.Field)
+       throw(ArgumentError("The coefficient ring must be a field."))
   end
-  if typeof(A.R) <: MPolyRing_dec
+  if A.R isa MPolyRing_dec
     throw(ArgumentError("Not implemented for quotients of decorated rings."))
   end
   I = A.I
@@ -1014,10 +1002,10 @@ $l_i$ to the the last $d$ variables of $R$; and $G = F^{-1}$.
 
 """
 function noether_normalization(A::MPolyQuo)
- if !(typeof(base_ring(A.R)) <: AbstractAlgebra.Field)
-     throw(ArgumentError("The coefficient ring of the base ring must be a field."))
+ if !(coefficient_ring(A) isa AbstractAlgebra.Field)
+     throw(ArgumentError("The coefficient ring must be a field."))
  end
- if typeof(A.R) <: MPolyRing_dec && !(is_standard_graded(A.R))
+ if A.R isa MPolyRing_dec && !(is_standard_graded(A.R))
    throw(ArgumentError("If the base ring is decorated, it must be standard graded."))
  end
  I = A.I
@@ -1079,11 +1067,11 @@ julia> integral_basis(f, 2)
 function integral_basis(f::MPolyElem, i::Int)
   R = parent(f)
 
-  if typeof(R) <: MPolyRing_dec
+  if R isa MPolyRing_dec
     throw(ArgumentError("Not implemented for decorated rings."))
   end
   
-  if !(nvars(R) == 2)
+  if nvars(R) != 2
     throw(ArgumentError("The parent ring must be a polynomial ring in two variables."))
   end
 

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -452,7 +452,7 @@ julia> S, (t, x, y) = grade(R, [-gen(G, 1), gen(G, 1), gen(G, 1)])
 julia> typeof(S)
 MPolyRing_dec{fmpq, FmpqMPolyRing}
 
-julia> typeof(S) <: MPolyRing
+julia> S isa MPolyRing
 true
 
 julia> typeof(x)
@@ -1315,8 +1315,8 @@ function homogeneous_component(W::MPolyRing_dec, d::GrpAbFinGenElem)
   #      aparently it is possible to get the number of points faster than the points
   #TODO: in the presence of torsion, this is wrong. The component
   #      would be a module over the deg-0-sub ring.
-  if !(typeof(base_ring(W)) <: AbstractAlgebra.Field)
-       throw(ArgumentError("The coefficient ring of the base ring must be a field."))
+  if !(coefficient_ring(W) isa AbstractAlgebra.Field)
+       throw(ArgumentError("The coefficient ring must be a field."))
   end
   D = W.D
   isfree(D) || error("Grading group must be torsion-free")
@@ -1465,11 +1465,11 @@ mutable struct HilbertData
        throw(ArgumentError("The weights must be positive."))
     end
     
-    if !(typeof(base_ring(R)) <: AbstractAlgebra.Field)
-       throw(ArgumentError("The coefficient ring of the base ring must be a field."))
+    if !(coefficient_ring(R) isa AbstractAlgebra.Field)
+       throw(ArgumentError("The coefficient ring must be a field."))
     end
 
-    if !((typeof(R) <: Oscar.MPolyRing_dec) && (isgraded(R)))
+    if !((R isa Oscar.MPolyRing_dec) && (isgraded(R)))
        throw(ArgumentError("The base ring must be graded."))
     end
     

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -1276,7 +1276,7 @@ function minimal_generating_set(I::MPolyIdeal{<:MPolyElem_dec}; ordering::Monomi
 
   @assert isgraded(R)
   
-  if !(base_ring(R) isa AbstractAlgebra.Field)
+  if !(coefficient_ring(R) isa AbstractAlgebra.Field)
      throw(ArgumentError("The coefficient ring must be a field."))
   end
   

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -172,7 +172,7 @@ function weights(a::AbsOrdering)
   aa = flat(a)
   m = matrix(ZZ, 0, 0, [])
   for o = aa
-    if typeof(o) <: GenOrdering
+    if o isa GenOrdering
       w = weights(o)
       if maximum(o.vars) > ncols(m)
         m = hcat(m, zero_matrix(ZZ, nrows(m), maximum(o.vars) - ncols(m)))


### PR DESCRIPTION
- add `coefficient_ring(::MPolyQuo)` so that one can
  treat MPolyRing and MPolyQuo identically in certain code
- adapt a bunch of code to use `coefficient_ring`
- replace several 'typeof(A) <: T` checks by `a isa T`
- unify some error messages
