### PR TITLE
Change `isisomorphic` to only return a `Bool`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oscar"
 uuid = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
 authors = ["The OSCAR Team <oscar@mathematik.uni-kl.de>"]
-version = "0.8.3-DEV"
+version = "0.9.0-DEV"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/docs/src/Groups/grouphom.md
+++ b/docs/src/Groups/grouphom.md
@@ -105,11 +105,6 @@ julia> haspreimage(f,x)
 !!! warning
     Do not confuse `haspreimage` with the function `has_preimage`, which works on variable of type `GrpGenToGrpGenMor`.
 
-A further function that produces isomorphisms is `isisomorphic`:
-```@docs
-isisomorphic(G::GAPGroup, H::GAPGroup)
-```
-
 ## Operations on homomorphisms
 
 Oscar supports the following operations on homomorphisms.
@@ -164,7 +159,13 @@ cokernel(f::GAPGroupHomomorphism)
 preimage(f::GAPGroupHomomorphism{S, T}, H::T) where S <: GAPGroup where T <: GAPGroup
 ```
 
-## Groups created by isomorphisms
+## Group isomorphisms
+
+```@docs
+isisomorphic(G::GAPGroup, H::GAPGroup)
+isisomorphic_with_map(G::GAPGroup, H::GAPGroup)
+isomorphism(G::GAPGroup, H::GAPGroup)
+```
 
 ```@docs
 isomorphism(::Type{T}, G::GAPGroup) where T <: Union{FPGroup, PcGroup, PermGroup}

--- a/docs/src/Groups/quotients.md
+++ b/docs/src/Groups/quotients.md
@@ -39,7 +39,7 @@ julia> G,_=quo(F,[f1^2,f2^3,(f1*f2)^2]);
 julia> isfinite(G)
 true
 
-julia> isisomorphic(G,symmetric_group(3))[1]
+julia> isisomorphic(G,symmetric_group(3))
 true
 ```
 Similarly to the subgroups, the output consists of a pair (`Q`,`p`), where `Q` is the quotient group and `p` is the projection homomorphism of `G` into `Q`.

--- a/experimental/GModule/Cohomology.jl
+++ b/experimental/GModule/Cohomology.jl
@@ -1177,7 +1177,7 @@ function pc_group(M::GrpAbFinGen; refine::Bool = true)
     return M(z)
   end
 
-  @assert isisomorphic(B, fp_group(M)[1])[1]
+  @assert isisomorphic(B, fp_group(M)[1])
 
   return B, MapFromFunc(
     x->image(mM, gap_to_julia(x.X)),

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -1503,7 +1503,7 @@ function lift(C::GModule, mp::Map)
     GG, GGinj, GGpro, GMtoGG = Oscar.GrpCoh.extension(PcGroup, z(chn))
     if get_assert_level(:BruecknerSQ) > 1
       _GG, _ = Oscar.GrpCoh.extension(z(chn))
-      @assert isisomorphic(GG, _GG)[1]
+      @assert isisomorphic(GG, _GG)
     end
 
     function reduce(g) #in G

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -16,6 +16,7 @@ export
     isinvariant,
     isinvertible,
     isisomorphic,
+    isisomorphic_with_map,
     isomorphic_fp_group,
     isomorphic_pc_group,
     isomorphic_perm_group,
@@ -356,19 +357,65 @@ end
 ################################################################################
 
 """
-    isisomorphic(G::Group, H::Group)
+    isisomorphic_with_map(G::Group, H::Group)
 
 Return (`true`,`f`) if `G` and `H` are isomorphic groups, where `f` is a group
 isomorphism. Otherwise, return (`false`,`f`), where `f` is the trivial
 homomorphism.
+
+# Examples
+```jldoctest
+julia> isisomorphic_with_map(symmetric_group(3), dihedral_group(6))
+(true, Group homomorphism from
+Sym( [ 1 .. 3 ] )
+to
+<pc group of size 6 with 2 generators>)
+```
 """
-function isisomorphic(G::GAPGroup, H::GAPGroup)
+function isisomorphic_with_map(G::GAPGroup, H::GAPGroup)
   mp = GAP.Globals.IsomorphismGroups(G.X, H.X)::GapObj
-  if mp == GAP.Globals.fail
+  if mp === GAP.Globals.fail
     return false, trivial_morphism(G, H)
   else
     return true, GAPGroupHomomorphism(G, H, mp)
   end
+end
+
+"""
+    isisomorphic(G::Group, H::Group)
+
+Return `true` if `G` and `H` are isomorphic groups, and `false` otherwise.
+
+# Examples
+```jldoctest
+julia> isisomorphic(symmetric_group(3), dihedral_group(6))
+true
+```
+"""
+function isisomorphic(G::GAPGroup, H::GAPGroup)
+  mp = GAP.Globals.IsomorphismGroups(G.X, H.X)::GapObj
+  return mp !== GAP.Globals.fail
+end
+
+"""
+    isomorphism(G::Group, H::Group)
+
+Return a group isomorphism between `G` and `H` if they are isomorphic groups.
+Otherwise throw an exception.
+
+# Examples
+```jldoctest
+julia> isomorphism(symmetric_group(3), dihedral_group(6))
+Group homomorphism from
+Sym( [ 1 .. 3 ] )
+to
+<pc group of size 6 with 2 generators>
+```
+"""
+function isomorphism(G::GAPGroup, H::GAPGroup)
+  mp = GAP.Globals.IsomorphismGroups(G.X, H.X)::GapObj
+  mp === GAP.Globals.fail && throw(ArgumentError("the groups are not isomorphic"))
+  return GAPGroupHomomorphism(G, H, mp)
 end
 
 

--- a/test/Combinatorics/SimplicialComplexes.jl
+++ b/test/Combinatorics/SimplicialComplexes.jl
@@ -20,7 +20,7 @@
         @test minimal_nonfaces(sphere) == [Set{Int}([1, 2, 3, 4])]
         R, _ = PolynomialRing(ZZ, ["a", "x", "i_7", "n"])
         @test stanley_reisner_ideal(R, sphere) == ideal([R([1], [[1, 1, 1, 1]])])
-        @test isisomorphic(fundamental_group(sphere), free_group())[1]
+        @test isisomorphic(fundamental_group(sphere), free_group())
         
     end
     

--- a/test/Groups/constructors.jl
+++ b/test/Groups/constructors.jl
@@ -69,7 +69,7 @@ end
   
   @test isa(alternating_group(PcGroup,3), PcGroup)
   @test isa(symmetric_group(PcGroup,3), PcGroup)
-  @test isisomorphic(symmetric_group(4), symmetric_group(PcGroup,4))[1]
+  @test isisomorphic(symmetric_group(4), symmetric_group(PcGroup,4))
 
   @test isquaternion_group(small_group(8, 4))
   @test small_group_identification(small_group(8, 4)) == (8, 4)
@@ -85,7 +85,7 @@ end
   @test isa(G, PcGroup)
   @test iscyclic(G)
   G1 = abelian_group(PermGroup, [2, 3])
-  @test isisomorphic(G, G1)[1]
+  @test isisomorphic(G, G1)
   G = abelian_group(PcGroup, [ZZ(2)^70])
 
 # FIXME: a function `free_abelian_group` is not defined in GAPGroups, since it is already defined in Hecke

--- a/test/Groups/directproducts.jl
+++ b/test/Groups/directproducts.jl
@@ -31,9 +31,9 @@
    S1 = image(embedding(G,1))[1]
    C1 = image(embedding(G,2))[1]
    @test intersect(G,S1)[1]==S1
-   @test isisomorphic(S1,S)[1]
-   @test isisomorphic(quo(G,S1)[1],C)[1]
-   @test isisomorphic(quo(G,C1)[1],S1)[1]
+   @test isisomorphic(S1,S)
+   @test isisomorphic(quo(G,S1)[1],C)
+   @test isisomorphic(quo(G,C1)[1],S1)
 
    x = G(cperm([1,2]),C[1])
    @test x==G([cperm([1,2]),C[1]])
@@ -74,7 +74,7 @@
       C3 = cyclic_group(3)
       G = inner_direct_product(C2,C2,C3,C3)
       @test G isa PcGroup
-      @test isisomorphic(G,direct_product(C2,C2,C3,C3))[1]
+      @test isisomorphic(G,direct_product(C2,C2,C3,C3))
       A = alternating_group(3)
       G = inner_direct_product(A,A,A)
       @test G isa PermGroup
@@ -111,7 +111,7 @@
       @test number_of_factors(G)==5
       @test isabelian(G)
       @test factor_of_direct_product(G,5)==C
-      @test isisomorphic(G,abelian_group(PcGroup,[3,3,3,3,3]))[1]
+      @test isisomorphic(G,abelian_group(PcGroup,[3,3,3,3,3]))
       x1 = G(C[1],one(C),one(C),one(C),one(C))
       x2 = G(one(C),C[1],one(C),one(C),one(C))
       x3 = G(one(C),one(C),C[1],one(C),one(C))
@@ -135,7 +135,7 @@ end
    G = semidirect_product(Q,f,C)
    @test G isa SemidirectProductGroup{PcGroup,PcGroup}
    @test normal_subgroup(G)==Q
-   @test isisomorphic(acting_subgroup(G),C)[1]
+   @test isisomorphic(acting_subgroup(G),C)
    @test homomorphism_of_semidirect_product(G)==f
    @test order(G)==16
    @test isfull_semidirect_product(G)
@@ -205,8 +205,8 @@ end
    W = wreath_product(C,C,a)
    @test W isa WreathProductGroup
    @test order(W)==81
-   @test isisomorphic(normal_subgroup(W),C)[1]
-   @test isisomorphic(acting_subgroup(W),C)[1]
+   @test isisomorphic(normal_subgroup(W),C)
+   @test isisomorphic(acting_subgroup(W),C)
    @test homomorphism_of_wreath_product(W)==a
    @test embedding(W,1)(C[1]) in W
    @test W(C[1],one(C),one(C),C[1]) isa elem_type(WreathProductGroup)

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -38,7 +38,7 @@ n = 6
    @test g^(og+1) == g
    @test g^(1-og) == g
 
-   @test !isisomorphic(symmetric_group(4), symmetric_group(3))[1]
+   @test !isisomorphic(symmetric_group(4), symmetric_group(3))
 
    A = alternating_group(n)
    x = cperm(G,[1,2,3])
@@ -245,10 +245,10 @@ TestDirectProds=function(G1,G2)
    end
    q1=p1*f1
    q2=p2*f2
-   @test isisomorphic(kernel(q1)[1],G2)[1]
-   @test isisomorphic(image(q1)[1],G1)[1]
-   @test isisomorphic(kernel(q2)[1],G1)[1]
-   @test isisomorphic(image(q2)[1],G2)[1]
+   @test isisomorphic(kernel(q1)[1],G2)
+   @test isisomorphic(image(q1)[1],G1)
+   @test isisomorphic(kernel(q2)[1],G1)
+   @test isisomorphic(image(q2)[1],G2)
 end
 
 @testset "Direct product" begin
@@ -331,7 +331,7 @@ end
    @test A isa AutomorphismGroup
    @test A isa AutomorphismGroup{PermGroup}
    @test A.G == G
-   @test isisomorphic(G,A)[1]
+   @test isisomorphic(G,A)
    @test order(A) == 24
    @test A==inner_automorphisms_group(A)[1]
 
@@ -366,7 +366,7 @@ end
    @test g1 in A
    g2 = A(inner_automorphism(G(alt[2])))
    AA,phi = sub(A,[g1,g2])
-   @test isisomorphic(AA,alt)[1]
+   @test isisomorphic(AA,alt)
    @test index(A,AA)==2
    @test isnormal(A,AA)
    @test phi(AA[1])==AA[1]
@@ -393,7 +393,7 @@ end
    G = direct_product(C,C)
    A = automorphism_group(G)
 
-   @test isisomorphic(A,GL(2,3))[1]
+   @test isisomorphic(A,GL(2,3))
    @test order(inner_automorphisms_group(A)[1])==1
 end
 

--- a/test/Groups/libraries.jl
+++ b/test/Groups/libraries.jl
@@ -9,7 +9,7 @@
    H4 = sub(G,[G([3,4,1,2]), G([2,1,4,3])])[1]         #Klein subgroup
    L = [G,H1,H2,H3,H4]
    for i in 1:5
-      @test sum([isisomorphic(transitive_group(4,i),l)[1] for l in L])==1
+      @test sum([isisomorphic(transitive_group(4,i),l) for l in L])==1
    end
    @test Set([transitive_identification(l) for l in L])==Set(1:5)
    @test Set(L)==Set(all_transitive_groups(degree,4))
@@ -45,10 +45,10 @@ end
    @test perfect_group(FPGroup,120,1) isa FPGroup
    @test_throws ArgumentError perfect_group(MatrixGroup,120,1)
 
-   @test isisomorphic(perfect_group(60,1),G)[1]
+   @test isisomorphic(perfect_group(60,1),G)
    @test [number_perfect_groups(i) for i in 2:59]==[0 for i in 1:58]
    x = perfect_identification(alternating_group(5))
-   @test isisomorphic(perfect_group(x[1],x[2]),alternating_group(5))[1]
+   @test isisomorphic(perfect_group(x[1],x[2]),alternating_group(5))
 
    @test_throws AssertionError perfect_group(60, 2)
 end
@@ -58,7 +58,7 @@ end
    LG = [abelian_group(PcGroup,[2,4]), abelian_group(PcGroup,[2,2,2]), cyclic_group(8), quaternion_group(8), dihedral_group(8)]
    @test length(L)==5
    @testset for G in LG
-      arr = [i for i in 1:5 if isisomorphic(L[i],G)[1]]
+      arr = [i for i in 1:5 if isisomorphic(L[i],G)]
       @test length(arr)==1
       @test small_group_identification(G)==(8,arr[1])
    end

--- a/test/Groups/quotients.jl
+++ b/test/Groups/quotients.jl
@@ -79,7 +79,7 @@ end
    @test isfinite(G)
    @test order(G) == 2*n
    @test !isabelian(G)
-   @test isisomorphic(G, dihedral_group(2*n))[1]
+   @test isisomorphic(G, dihedral_group(2*n))
    @test !isinjective(f)
    @test issurjective(f)
    @test exponent(G) == 2*n

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -25,8 +25,7 @@
 
    H=sub(G,[G([2,3,1]),G([2,1])])[1]
    @test H != symmetric_group(3)
-   @test isisomorphic(H, symmetric_group(3))[1]
-   @test isisomorphic(H, symmetric_group(3))[2]==id_hom(H)       # TODO: this in future may change to false.
+   @test isisomorphic(H, symmetric_group(3))
    @test Vector(H[1])==[2,3,1,4,5,6,7]
    @test Vector(symmetric_group(3)(H[1]))==[2,3,1]
 
@@ -92,8 +91,8 @@ end
    end
    @test x in Cx
    @test one(G) in Cx
-   @test isisomorphic(Cx, direct_product(symmetric_group(2),symmetric_group(4)))[1]
-   @test isisomorphic(Cy, direct_product(sub(G,[y])[1], symmetric_group(2)))[1]
+   @test isisomorphic(Cx, direct_product(symmetric_group(2),symmetric_group(4)))
+   @test isisomorphic(Cy, direct_product(sub(G,[y])[1], symmetric_group(2)))
 
    Nx = normalizer(G,Cx)[1]
    Ny = normalizer(G,Cy)[1]
@@ -278,7 +277,7 @@ end
 
    P = sylow_subgroup(G,2)[1]
    @test order(P)==8
-   @test isisomorphic(P,dihedral_group(8))[1]
+   @test isisomorphic(P,dihedral_group(8))
    P = sylow_subgroup(G,3)[1]
    @test order(P)==3
    @test representative_action(G, P, sub(G, [cperm(1:3)])[1])[1]


### PR DESCRIPTION
To get an actual isomorphism, one may instead use the new method `isomorphism(G::Group, H::Group)`.

Since this is definitely a breaking change, I've increased the Oscar version to 0.9.0-DEV.


This has a trivial conflict with PR #1243, in `docs/src/Groups/grouphom.md` but this should be easy to resolve no matter which one we merge first. 

(There is also a conflict with my PR #1169, but that, too, will be no problem)