### PR TITLE
Improve perfect groups library

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -559,6 +559,18 @@
   url           = {https://doi.org/10.1201/9781420035216}
 }
 
+@Book{HP89,
+  author        = {Holt, Derek F. and Plesken, W.},
+  title         = {Perfect groups},
+  series        = {Oxford Mathematical Monographs},
+  note          = {With an appendix by W. Hanrath, Oxford Science
+                  Publications},
+  publisher     = {The Clarendon Press, Oxford University Press, New York},
+  year          = {1989},
+  pages         = {xii+364},
+  mrnumber      = {1025760}
+}
+
 @Book{Har77,
   author        = {Hartshorne, Robin},
   title         = {Algebraic Geometry},

--- a/docs/src/Groups/grouplib.md
+++ b/docs/src/Groups/grouplib.md
@@ -34,10 +34,35 @@ all_primitive_groups
 
 ## Perfect groups of small order
 
+The functions in this section are wrappers for the GAP library of finite perfect
+groups which provides, up to isomorphism, a list of all perfect groups whose
+sizes are less than $2\cdot 10^6$. The groups of most orders up to $10^6$ have been
+enumerated by Derek Holt and Wilhelm Plesken, see [HP89](@cite). For orders
+$n = 86016$, 368640, or 737280 this work only counted the groups (but did not
+explicitly list them), the groups of orders $n = 61440$, 122880, 172032,
+245760, 344064, 491520, 688128, or 983040 were omitted.
+
+Several additional groups omitted from the book [HP89](@cite) have also
+been included. Two groups -- one of order 450000 with a factor group of
+type $A_6$ and the one of order 962280 -- were found by Jack Schmidt in
+2005. Two groups of order 243000 and one each of orders 729000, 871200, 878460
+were found in 2020 by Alexander Hulpke.
+
+The perfect groups of size less than $2\cdot 10^6$ which had not been
+classified in the work of Holt and Plesken have been enumerated by Alexander
+Hulpke. They are stored directly and provide less construction information
+in their names.
+
+As all groups are stored by presentations, a permutation representation
+is obtained by coset enumeration. Note that some of the library groups do
+not have a faithful permutation representation of small degree.
+Computations in these groups may be rather time consuming.
+
 ```@docs
+orders_perfect_groups
 number_perfect_groups
 perfect_group
-perfect_identification
+perfect_group_identification
 ```
 
 ## Groups of small order

--- a/src/Groups/libraries/perfectgroups.jl
+++ b/src/Groups/libraries/perfectgroups.jl
@@ -1,27 +1,76 @@
 export
+    orders_perfect_groups,
     number_perfect_groups,
     perfect_group,
-    perfect_identification
-    
+    perfect_group_identification
+
 
 ###################################################################
 # Perfect groups
 ###################################################################
 
-"""
-    perfect_group(::Type{T} = FPGroup, n::Int, i::Int)
 
-Return the `i`-th group of order `n` and type `T` in the catalogue of
+@doc Markdown.doc"""
+    orders_perfect_groups()
+
+Returns a sorted vector of all numbers to $2 \cdot 10^6$ that occur as orders
+of perfect groups.
+
+# Examples
+```jldoctest
+julia> orders_perfect_groups()[1:10]
+10-element Vector{Int64}:
+   1
+  60
+ 120
+ 168
+ 336
+ 360
+ 504
+ 660
+ 720
+ 960
+```
+"""
+function orders_perfect_groups()
+    return Vector{Int}(GAP.Globals.SizesPerfectGroups())
+end
+
+"""
+    perfect_group(::Type{T} = PermGroup, n::IntegerUnion, k::IntegerUnion)
+
+Return the `k`-th group of order `n` and type `T` in the catalogue of
 perfect groups in GAP's Perfect Groups Library.
 The type `T` can be either `PermGroup` or `FPGroup`.
+
+# Examples
+```jldoctest
+julia> perfect_group(60, 1)
+A5
+
+julia> gens(ans)
+2-element Vector{PermGroupElem}:
+ (1,2)(4,5)
+ (2,3,4)
+
+julia> perfect_group(FPGroup, 60, 1)
+A5
+
+julia> gens(ans)
+2-element Vector{FPGroupElem}:
+ a
+ b
+```
 """
-function perfect_group(::Type{T}, n::Int, m::Int) where T <: GAPGroup
+function perfect_group(::Type{T}, n::IntegerUnion, k::IntegerUnion) where T <: GAPGroup
+   n >= 1 || throw(ArgumentError("group order must be positive, not $n"))
+   k >= 1 || throw(ArgumentError("group index must be positive, not $k"))
    N = number_perfect_groups(n)
-   @assert m <= N "There are only $N perfect groups of order $n, up to isomorphism."
-   if T==PermGroup
-      G = T(GAP.Globals.PerfectGroup(GAP.Globals.IsPermGroup,n,m))
-   elseif T==FPGroup
-      G = T(GAP.Globals.PerfectGroup(GAP.Globals.IsSubgroupFpGroup,n,m))
+   k <= N || throw(ArgumentError("There are only $N perfect groups of order $n, up to isomorphism"))
+   if T == PermGroup
+      G = T(GAP.Globals.PerfectGroup(GAP.Globals.IsPermGroup, GAP.Obj(n), GAP.Obj(k)))
+   elseif T == FPGroup
+      G = T(GAP.Globals.PerfectGroup(GAP.Globals.IsSubgroupFpGroup, GAP.Obj(n), GAP.Obj(k)))
    else
       throw(ArgumentError("Wrong type"))
    end
@@ -29,18 +78,46 @@ function perfect_group(::Type{T}, n::Int, m::Int) where T <: GAPGroup
    return G
 end
 
-perfect_group(n::Int, m::Int) = perfect_group(PermGroup,n,m)
+perfect_group(n::IntegerUnion, m::IntegerUnion) = perfect_group(PermGroup, n, m)
 
 """
-    perfect_identification(G::GAPGroup)
+    perfect_group_identification(G::GAPGroup)
 
 Return `(n, m)` such that `G` is isomorphic with `perfect_group(n, m)`.
+
+# Examples
+```jldoctest
+julia> perfect_group_identification(alternating_group(5))
+(60, 1)
+
+julia> perfect_group_identification(SL(2,7))
+(336, 1)
+```
 """
-perfect_identification(G::GAPGroup) = Tuple{Int,Int}(GAP.Globals.PerfectIdentification(G.X))
+function perfect_group_identification(G::GAPGroup)
+   isperfect(G) || error("group is not perfect")
+   res = GAP.Globals.PerfectIdentification(G.X)
+   res !== GAP.Globals.fail || error("identification is not available for groups of order $(order(G))")
+   return Tuple{Int,Int}(res)
+end
 
 """
-    number_perfect_groups(n::Int)
+    number_perfect_groups(n::IntegerUnion)
 
 Return the number of perfect groups of order `n`, up to isomorphism.
+
+# Examples
+```jldoctest
+julia> number_perfect_groups(60)
+1
+
+julia> number_perfect_groups(1966080)
+7344
+```
 """
-number_perfect_groups(n::Int) = GAP.Globals.NumberPerfectGroups(n)
+function number_perfect_groups(n::IntegerUnion)
+   n >= 1 || throw(ArgumentError("group order must be positive, not $n"))
+   res = GAP.Globals.NumberPerfectGroups(GAP.Obj(n))
+   res !== GAP.Globals.fail || error("the number of perfect groups of order $n is not in the library")
+   return res::Int
+end

--- a/test/Groups/libraries.jl
+++ b/test/Groups/libraries.jl
@@ -42,15 +42,25 @@ end
    @test !isperfect(symmetric_group(5))
 
    @test perfect_group(120,1) isa PermGroup
+   @test perfect_group(PermGroup,120,1) isa PermGroup
    @test perfect_group(FPGroup,120,1) isa FPGroup
    @test_throws ArgumentError perfect_group(MatrixGroup,120,1)
 
+   @test_throws ArgumentError perfect_group(17, 0)
+   @test_throws ArgumentError perfect_group(17, 1)
+   @test_throws ArgumentError perfect_group(60, 0)
+   @test_throws ArgumentError perfect_group(60, 2)
+
    @test isisomorphic(perfect_group(60,1),G)
    @test [number_perfect_groups(i) for i in 2:59]==[0 for i in 1:58]
-   x = perfect_identification(alternating_group(5))
+   x = perfect_group_identification(alternating_group(5))
    @test isisomorphic(perfect_group(x[1],x[2]),alternating_group(5))
+   @test_throws ErrorException perfect_group_identification(symmetric_group(5))
 
-   @test_throws AssertionError perfect_group(60, 2)
+   @test sum(number_perfect_groups, 1:59) == 1
+   @test number_perfect_groups(fmpz(60)^3) == 1
+   @test_throws ArgumentError number_perfect_groups(0) # invalid argument
+   @test_throws ErrorException number_perfect_groups(fmpz(60)^10)  # result not known
 end
 
 @testset "Small groups" begin


### PR DESCRIPTION
- add `orders_perfect_groups()`
- replace `Int` by `IntegerUnion` for various arguments
- `perfect_group`: fix docstring to correctly indicate that by default it returns `PermGroup` instances (not `FPGroup` as it said before)
- `perfect_group`: improve argument validation
- `perfect_identification`: rename to `perfect_group_identification`; reject groups that are not perfect, handle failures
- `number_perfect_groups`: validate arguments, deal with orders for which the result is not known

(parts based on previous work in PR #1169; includes PR #1246 which should be merged first)