### PR TITLE
admit result `GrpAbFinGen` for `maximal_abelian_quotient`

### DIFF
--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -382,7 +382,7 @@ function quo(::Type{Q}, G::T, N::T) where {Q <: GAPGroup, T <: GAPGroup}
 end
 
 """
-    maximal_abelian_quotient([::Type{Q}, ]G::GAPGroup)
+    maximal_abelian_quotient([::Type{Q}, ]G::GAPGroup) where Q <: Union{GAPGroup, GrpAbFinGen}
 
 Return `F, epi` such that `F` is the largest abelian factor group of `G`
 and `epi` is an epimorphism from `G` to `F`.
@@ -425,7 +425,7 @@ function maximal_abelian_quotient(G::GAPGroup)
   return F, GAPGroupHomomorphism(G, F, map)
 end
 
-function maximal_abelian_quotient(::Type{Q}, G::GAPGroup) where Q <: GAPGroup
+function maximal_abelian_quotient(::Type{Q}, G::GAPGroup) where Q <: Union{GAPGroup, GrpAbFinGen}
   F, epi = maximal_abelian_quotient(G)
   if !(F isa Q)
     map = isomorphism(Q, F)

--- a/test/Groups/quotients.jl
+++ b/test/Groups/quotients.jl
@@ -55,6 +55,7 @@ end
    G = abelian_group(T, [2, 3, 4])
    @test maximal_abelian_quotient(G)[1] isa PcGroup
    @test maximal_abelian_quotient(PermGroup, G)[1] isa PermGroup
+   @test maximal_abelian_quotient(GrpAbFinGen, G)[1] isa GrpAbFinGen
    G = symmetric_group(4)
    @test maximal_abelian_quotient(G)[1] isa PcGroup
    @test maximal_abelian_quotient(PermGroup, G)[1] isa PermGroup


### PR DESCRIPTION
We will have the idea to cache the results of `maximal_abelian_quotient`, parametrized by their types.
Then the question arises how to deal with the unary version, where up to now the result of the GAP function determines the type of the result in Oscar.
One natural solution would be to take any cached result if there is one, which would make the description of the result type even more complicated.