### PR TITLE
Code formatting defaults

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,7 @@
+style = "blue"
+
+always_use_return = false
+annotate_untyped_fields_with_any = true
+import_to_using = false
+indent = 2
+short_to_long_function_def = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.jl]
+indent_size = 2
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
We have no official code formatting guidelines. But for those of us who wish
to align themselves to some common coding conventions, it is useful to have
`.JuliaFormatter.toml` and `.editorconfig` files in the repository to provide
some consistent default for editor settings and for JuliaFormatter. It can also
be useful for helping new contributors who *want* to know how they ought to
format their code.

I tried to come up with some "reasonable" defaults. I used a tab width of 2 because empirically that seems to be what @thofma, @fieker and @ThomasBreuer prefer, and I am fine with it, too.

To be clear, this is not intended to force a single formatting standard, although personally I wouldn't mind one, simply because it'd reduce the burden on my mind: I'd just format my code whatever why while writing, then at the end I'd run JuliaFormatter over it once and be done with it :-)