### PR TITLE
Minor additions and fixes

### DIFF
--- a/docs/src/DeveloperDocumentation/styleguide.md
+++ b/docs/src/DeveloperDocumentation/styleguide.md
@@ -25,13 +25,13 @@ Here is a summary of the naming convention followed in Oscar:
   Similarly for `matrix_to_points`. Of course it is fine to use them internally, where
   useful.
 - Follow the mathematics. If your function needs a list of points, you should
-  create a point-type (or use the one already ehre) and then use this.
+  create a point-type (or use the one already there) and then use this.
   For user-facing functions, please do not use re-purposed lists, arrays,
   matrices...
 - If already existing types in Oscar are almost what you need, consider
   improving them instead of writing your own. While it might be
   tempting to create a new polynomial ring type for the new application because
-  some feature is missing, it causes a lot of work and compability issues: Will the new type support
+  some feature is missing, it causes a lot of work and compatibility issues: Will the new type support
   - normal functions (gcd, factor),
   - quotient fields,
   - modules and residue rings,

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -487,7 +487,7 @@ function isomorphism(::Type{GrpAbFinGen}, G::GAPGroup)
 #T this restriction is not nice
 
      indep = GAP.Globals.IndependentGeneratorsOfAbelianGroup(G.X)::GapObj
-     orders = [GAPWrap.Order(x) for x in indep]
+     orders = fmpz[GAPWrap.Order(x) for x in indep]
      n = length(indep)
      A = abelian_group(GrpAbFinGen, orders)
 

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -455,28 +455,20 @@ function simplify(a::MPolyQuoIdeal)
    J = R.I
    GJ = groebner_assure(J)
    singular_assure(GJ)
-   oscar_assure(a)
    singular_assure(a.I)
    red  = reduce(a.I.gens.S, GJ.S)
    SR   = singular_poly_ring(R)
-   si   = Singular.Ideal(SR, gens(red))
+   si   = Singular.Ideal(SR, unique!(gens(red)))
    red  = MPolyQuoIdeal(R, si)
    return red
 end
+
 function simplify!(a::MPolyQuoIdeal)
-    R   = base_ring(a)
-    oscar_assure(a)
-    RI  = base_ring(a.I)
-    J = R.I
-    GJ = groebner_assure(J)
-    singular_assure(GJ)
-    oscar_assure(a)
-    singular_assure(a.I)
-    red  = reduce(a.I.gens.S, GJ.S)
-    SR   = singular_poly_ring(R)
-    a.SI = Singular.Ideal(SR, gens(red))
-    a.I  = ideal(RI, RI.(gens(a.SI)))
-    return a
+  b = simplify(a)
+  a.SI = b.SI
+  RI = base_ring(a.I)
+  a.I = ideal(RI, RI.(gens(a.SI)))
+  return a
 end
 
 @doc Markdown.doc"""

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -298,11 +298,9 @@ julia> Oscar.normal_form_internal(I,J)
 ```
 """
 function normal_form_internal(I::Singular.sideal, J::MPolyIdeal)
-    if !isdefined(J, :gb)
-        groebner_assure(J)
-    end
-    K = ideal(base_ring(J), reduce(I, collect(values(J.gb))[1].S))
-    return [J.gens.Ox(x) for x = gens(K.gens.S)]
+  groebner_assure(J)
+  K = ideal(base_ring(J), reduce(I, collect(values(J.gb))[1].S))
+  return [J.gens.Ox(x) for x = gens(K.gens.S)]
 end
 
 @doc Markdown.doc"""

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -675,7 +675,6 @@ function factor(x::Oscar.MPolyElem_dec)
   #end
 end
 
-
 function gcd(x::Oscar.MPolyElem_dec, y::Oscar.MPolyElem_dec)
   R = parent(x)
   return R(gcd(x.f, y.f))
@@ -684,6 +683,12 @@ end
 function div(x::Oscar.MPolyElem_dec, y::Oscar.MPolyElem_dec)
   R = parent(x)
   return R(div(x.f, y.f))
+end
+
+function divrem(x::MPolyElem_dec, y::MPolyElem_dec)
+  R = parent(x)
+  q, r = divrem(x.f, y.f)
+  return R(q), R(r)
 end
 
 ################################################################################

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -107,7 +107,7 @@ end
    end
 
    @testset "Finite abelian GAPGroup to GrpAbFinGen" begin
-      for invs in [[2, 3, 4], [6, 8, 9, 15]]
+      for invs in [[1], [2, 3, 4], [6, 8, 9, 15]]
          for T in [PermGroup, PcGroup, FPGroup]
             G = abelian_group(T, invs)
             iso = @inferred isomorphism(GrpAbFinGen, G)

--- a/test/Rings/mpoly-graded-test.jl
+++ b/test/Rings/mpoly-graded-test.jl
@@ -206,6 +206,14 @@ end
   @test minimal_generating_set(ideal(R, [ R() ])) == elem_type(R)[]
 end
 
+@testset "Division" begin
+  R, (x, y) = GradedPolynomialRing(QQ, [ "x", "y" ], [ 1, 2 ])
+  f = x^2 + y
+  g = x^2
+  @test div(f, g) == one(R)
+  @test divrem(f, g) == (one(R), y)
+end
+
 # Conversion bug
 
 begin


### PR DESCRIPTION
Here are some minor additions and fixes:
- I put `unique!` around the generators one gets when simplifying a `MPolyQuoIdeal`. I encountered the case that all generators of the ideal are actually trivial in the quotient ring and then `simplify` returns an ideal with as many generators - which are all zero.
- Adds a trivial fix to allow the trivial group in `isomorphism(GrpAbFinGen, ::GAPGroup)`
- Removes `isdefined(..., :gb)` around a `groebner_assure`
- Adds `divrem` for `MPolyElem_dec`
- Fixes two typos in the styleguide.