### PR TITLE
Rename 'Example' section to 'Examples'

### DIFF
--- a/experimental/PlaneCurve/AffinePlaneCurve.jl
+++ b/experimental/PlaneCurve/AffinePlaneCurve.jl
@@ -19,7 +19,7 @@ export issmooth, tangent, common_components, curve_intersect, intersect,
 
 Throw an error if `P` is not a point of `C`, return `false` if `P` is a singular point of `C`, and `true` if `P` is a smooth point of `C`.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -53,7 +53,7 @@ end
 
 Return the tangent of `C` at `P` when `P` is a smooth point of `C`, and throw an error otherwise.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -92,7 +92,7 @@ end
 
 Return the affine plane curve consisting of the common component of `C` and `D`, or an empty vector if they do not have a common component.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -128,7 +128,7 @@ end
 
 Return a list whose first element is the affine plane curve defined by the gcd of `C.eq` and `D.eq`, the second element is the list of the remaining intersection points when the common components are removed from `C` and `D`.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -221,7 +221,7 @@ end
 
 Return the reduced singular locus of `C` as a list whose first element is the affine plane curve consisting of the singular components of `C` (if any), and the second element is the list of the isolated singular points (which may be contained in the singular component). The singular component might not contain any point over the considered field.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -307,7 +307,7 @@ end
 
 Return the multiplicity of `C` at `P`.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -343,7 +343,7 @@ end
 
 Return the tangent lines at `P` to `C` with their multiplicity.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -408,7 +408,7 @@ end
 
 Return the intersection multiplicity of `C` and `D` at `P`.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -444,7 +444,7 @@ end
 
 Return `true` if `C` and `D` intersect transversally at `P` and `false` otherwise.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -480,7 +480,7 @@ end
 
 Return `true` if `C` has no singular point, and `false` otherwise.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -525,7 +525,7 @@ end
 
 Return the geometric genus of the projective closure of `C`.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(GF(7), ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Galois field with characteristic 7, gfp_mpoly[x, y])

--- a/experimental/PlaneCurve/DivisorCurve.jl
+++ b/experimental/PlaneCurve/DivisorCurve.jl
@@ -15,7 +15,7 @@ abstract type CurveDivisor end
 
 Given a curve `C` which is assumed to be smooth and irreducible, return the divisor on the curve `C` defined by `D`.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x,y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -67,7 +67,7 @@ end
 
 Given a curve `C` which is assumed to be smooth and irreducible, return the divisor on the curve `C` defined by `D`.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x,y,z) = PolynomialRing(QQ, ["x", "y", "z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
@@ -248,7 +248,7 @@ end
 
 Return `true` if `D` is an effective divisor, `false` otherwise.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x,y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -288,7 +288,7 @@ end
 
 Return the multiplicity of the rational function `phi` on the curve `C` at the point `P`.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x,y,z) = PolynomialRing(QQ, ["x", "y", "z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
@@ -435,7 +435,7 @@ end
 
 Return the divisor defined by the rational function `phi` on the curve `C`.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x,y,z) = PolynomialRing(QQ, ["x", "y", "z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
@@ -582,7 +582,7 @@ end
 
 Return a set of generators of the global sections of the sheaf associated to the divisor `D` of a smooth and irreducible projective curve.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
@@ -681,7 +681,7 @@ end
 Return `true` if the divisors `D` and `E` are linearly equivalent, and `false`
 otherwise
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
@@ -725,7 +725,7 @@ end
 
 Return `true` if the divisor `D` is principal, and `false` otherwise
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
@@ -767,7 +767,7 @@ end
 If the divisor `D` is principal, return a rational function `phi` such that `D`
 is linearly equivalent to the divisor defined by `phi`.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])

--- a/experimental/PlaneCurve/ParaPlaneCurves.jl
+++ b/experimental/PlaneCurve/ParaPlaneCurves.jl
@@ -36,7 +36,7 @@ end
 
 Return a rational parametrization of  `C`. 
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x,y,z) = GradedPolynomialRing(QQ, ["x", "y", "z"]);
 
@@ -65,7 +65,7 @@ end
 
 Return the Gorenstein adjoint ideal of `C`. 
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x,y,z) = GradedPolynomialRing(QQ, ["x", "y", "z"]);
 
@@ -90,7 +90,7 @@ end
 If the conic `D` contains a rational point, return the homogeneous coordinates of such a point.
 If no such point exists, return a point on `D` defined over a quadratic field extension of $\mathbb Q$.
  
-# Example
+# Examples
 ```jldoctest
 julia> R, (x,y,z) = GradedPolynomialRing(QQ, ["x", "y", "z"]);
 
@@ -145,7 +145,7 @@ end
 
 Return a rational normal curve of degree $\deg C-2$ which `C` is mapped.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x,y,z) = GradedPolynomialRing(QQ, ["x", "y", "z"]);
 
@@ -176,7 +176,7 @@ Return a vector `V` defining the anticanonical map `C --> PP^(n-2)`. Note that t
 entries of `V` should be considered as representatives of elements in R/I,
 where R is the basering.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (v, w, x, y, z) = GradedPolynomialRing(QQ, ["v", "w", "x", "y", "z"])
 (Multivariate Polynomial Ring in v, w, x, y, z over Rational Field graded by 
@@ -225,7 +225,7 @@ Return a vector `PHI` defining an isomorphic projection of `C` to `PP^1`.
 Note that the entries of `PHI` should be considered as
 representatives of elements in `R/I`, where `R` is the basering.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (w, x, y, z) = GradedPolynomialRing(QQ, ["w", "x", "y", "z"]);
 
@@ -278,7 +278,7 @@ Return a vector `PHI` defining an isomorphic projection of `C` to `PP^1`.
 Note that the entries of `PHI` should be considered as
 representatives of elements in `R/I`, where `R` is the basering.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (v, w, x, y, z) = GradedPolynomialRing(QQ, ["v", "w", "x", "y", "z"]);
 

--- a/experimental/PlaneCurve/PlaneCurve.jl
+++ b/experimental/PlaneCurve/PlaneCurve.jl
@@ -64,7 +64,7 @@ end
 
 Return the maximal ideal associated to the point `P` in the ring `R`.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -130,7 +130,7 @@ end
 
 Return the Projective Plane Curve defined by the homogeneous polynomial in three variables `eq`.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x,y,z) = PolynomialRing(QQ, ["x", "y", "z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
@@ -265,7 +265,7 @@ end
 
 Return the Jacobian ideal of the defining polynomial of `C`.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -289,7 +289,7 @@ end
 
 Return a dictionary containing the irreducible components of `C` and their multiplicity.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -321,7 +321,7 @@ end
 
 Return `true` if `C` is irreducible, and `false` otherwise.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -351,7 +351,7 @@ end
 
 Return `true` if `C` is reduced, and `false` otherwise.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -387,7 +387,7 @@ end
 
 Return the plane curve defined by the squarefree part of the equation of `C`.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -429,7 +429,7 @@ end
 
 Return the union of `C` and `D` (with multiplicity).
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
@@ -454,7 +454,7 @@ Base.union(C::T, D::T) where T <: PlaneCurve = T(C.eq*D.eq)
 
 Return the coordinate ring of the curve `C`.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])

--- a/experimental/PlaneCurve/ProjCurve.jl
+++ b/experimental/PlaneCurve/ProjCurve.jl
@@ -72,7 +72,7 @@ end
 
 Return `true` if the point `P` is on the curve `C`, and `false` otherwise.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x, y, z, t) = PolynomialRing(QQ, ["x", "y", "z", "t"])
 (Multivariate Polynomial Ring in x, y, z, t over Rational Field, fmpq_mpoly[x, y, z, t])
@@ -132,7 +132,7 @@ end
 
 Return `true` if `C` is irreducible, and `false` otherwise.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x, y, z, t) = PolynomialRing(QQ, ["x", "y", "z", "t"])
 (Multivariate Polynomial Ring in x, y, z, t over Rational Field, fmpq_mpoly[x, y, z, t])
@@ -166,7 +166,7 @@ end
 
 Return the projective curve defined by the radical of the defining ideal of `C`.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x, y, z, t) = PolynomialRing(QQ, ["x", "y", "z", "t"])
 (Multivariate Polynomial Ring in x, y, z, t over Rational Field, fmpq_mpoly[x, y, z, t])
@@ -200,7 +200,7 @@ end
 
 Return the Jacobian ideal of the defining ideal of `C`.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x, y, z, t) = PolynomialRing(QQ, ["x", "y", "z", "t"])
 (Multivariate Polynomial Ring in x, y, z, t over Rational Field, fmpq_mpoly[x, y, z, t])

--- a/experimental/PlaneCurve/ProjEllipticCurve.jl
+++ b/experimental/PlaneCurve/ProjEllipticCurve.jl
@@ -141,7 +141,7 @@ Return the Projective Elliptic Curve defined by the equation `eq`, with `P` as
 infinity point. If no point is specified it is expected that `eq` is in
 Weierstrass form, and the infinity point is `(0:1:0)`.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
@@ -260,7 +260,7 @@ end
 Return the equation of a projective elliptic curve defined by an equation in
 Weierstrass form and which is linearly equivalent to `E`.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
@@ -343,7 +343,7 @@ end
 
 Create the point `P` on the elliptic curve `E`.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
@@ -553,7 +553,7 @@ Given a smooth plane cubic projective curve `C` and a point `P` on the curve,
 return an elliptic curve birationally equivalent to `C` given by an equation in
 long Weierstrass form.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])

--- a/experimental/PlaneCurve/ProjPlaneCurve.jl
+++ b/experimental/PlaneCurve/ProjPlaneCurve.jl
@@ -18,7 +18,7 @@ export issmooth, tangent, common_components, curve_intersect,
 
 Throw an error if `P` is not a point of `C`, return `false` if `P` is a singular point of `C`, and `true` if `P` is a smooth point of `C`.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
@@ -63,7 +63,7 @@ end
 
 Return the tangent of `C` at `P` when `P` is a smooth point of `C`, and throw an error otherwise.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x, y, z) = PolynomialRing(QQ, ["x", "y","z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
@@ -144,7 +144,7 @@ end
 
 Return a list whose first element is the projective plane curve defined by the gcd of `C.eq` and `D.eq`, the second element is the list of the remaining intersection points when the common components are removed from `C` and `D` (the points are in `PP` if specified, or in a new projective space otherwise).
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x, y, z) = PolynomialRing(QQ, ["x", "y","z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
@@ -450,7 +450,7 @@ end
 
 Return the arithmetic genus of `C`.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
@@ -484,7 +484,7 @@ end
 
 Return the geometric genus of `C`.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x,y,z) = GradedPolynomialRing(QQ, ["x", "y", "z"]);
 

--- a/src/Combinatorics/Matroids/ChowRings.jl
+++ b/src/Combinatorics/Matroids/ChowRings.jl
@@ -139,7 +139,7 @@ end
 
 Return an augmented Chow ring of a matroid. As described in [BHMPW20](@cite). 
 
-# Example
+# Examples
 ```jldoctest
 julia> M = fano_matroid();
 

--- a/src/Combinatorics/Matroids/matroids.jl
+++ b/src/Combinatorics/Matroids/matroids.jl
@@ -409,7 +409,7 @@ dual_matroid(M::Matroid) = Matroid(M.pm_matroid.DUAL,M.groundset,M.gs2num)
 The ground set `E` of a matroid `M`.
 
 To obtain the ground set of the Fano matroid write:
-# Example
+# Examples
 ```jldoctest
 julia> matroid_groundset(fano_matroid())
 7-element Vector{Int64}:
@@ -432,14 +432,14 @@ Optionally one can also pass a vector of matroids.
 See Section 4.2 of [Oxl11](@cite).
 
 To obtain the direct sum of the Fano and a uniform matroid type:
-# Example
+# Examples
 ```jldoctest
 julia> direct_sum(fano_matroid(), uniform_matroid(2,4))
 Matroid of rank 5 on 11 elements
 ```
 
 To take the sum of three uniform matroids use:
-# Example
+# Examples
 ```jldoctest
 julia> matroids = Vector([uniform_matroid(2,4), uniform_matroid(1,3), uniform_matroid(3,4)]);
 
@@ -472,7 +472,7 @@ The `deletion M\S` of an element `e` or a subset `S` of the ground set `E` of th
 
 See Section 3 of [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> M = matroid_from_bases([[1,2],[1,'i'],[1,'j'],[2,'i'],[2,'j']],[1,2,'i','j']);
 
@@ -480,7 +480,7 @@ julia> N = deletion(M,'i')
 Matroid of rank 2 on 3 elements
 ```
 
-# Example
+# Examples
 ```jldoctest
 julia> M = matroid_from_bases([[1,2],[1,'i'],[1,'j'],[2,'i'],[2,'j']],[1,2,'i','j']);
 
@@ -528,7 +528,7 @@ The `restriction M|S` on a subset `S` of the ground set `E` of the matroid `M`.
 
 See Section 3 of [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> M = matroid_from_bases([[1,2],[1,'i'],[1,'j'],[2,'i'],[2,'j']],[1,2,'i','j']);
 
@@ -558,7 +558,7 @@ The `contraction M/S` of an element or a subset `S` of the ground set `E` of the
 
 See Section 3 of [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> M = matroid_from_bases([[1,2],[1,'i'],[1,'j'],[2,'i'],[2,'j']],[1,2,'i','j']);
 
@@ -566,7 +566,7 @@ julia> N = contraction(M,'i')
 Matroid of rank 1 on 3 elements
 ```
 
-# Example
+# Examples
 ```jldoctest
 julia> M = matroid_from_bases([[1,2],[1,'i'],[1,'j'],[2,'i'],[2,'j']],[1,2,'i','j']);
 
@@ -593,7 +593,7 @@ The `minor M\S/T` of disjoint subsets  `S` and `T` of the ground set `E` of the 
 
 See also `contraction` and `deletion`. You can find more in Section 3 of [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> M = fano_matroid();
 
@@ -619,7 +619,7 @@ The `principal extension M +_F e` of a matroid `M` where the element `e` is free
 
 See Section 7.2 of [Oxl11](@cite).
 
-# Example
+# Examples
 To add `5` freely to the flat `{1,2}` of the uniform matroid `U_{3,4}` do
 ```jldoctest
 julia> M = uniform_matroid(3,4);
@@ -643,7 +643,7 @@ The `free extension M +_E e` of a matroid `M` where the element `e`.
 
 See ``principal_extension`` and Section 7.2 of [Oxl11](@cite).
 
-# Example
+# Examples
 To add `5` freely to the uniform matroid `U_{3,4}` do
 ```jldoctest
 julia> M = uniform_matroid(3,4);
@@ -661,7 +661,7 @@ The `series extension` of a matroid `M` where the element `e` is added in series
 
 This is actually a coextension see also Section 7.2 of [Oxl11](@cite).
 
-# Example
+# Examples
 To add `e` in series to `1` in the uniform matroid U_{3,4} do
 ```jldoctest
 julia> M = uniform_matroid(1,4);
@@ -687,7 +687,7 @@ The `parallel extension M +_{f} e` of a matroid `M` where the element `e` is add
 
 See Section 7.2 of [Oxl11](@cite).
 
-# Example
+# Examples
 To add `e` parallel to `1` in the uniform matroid `U_{3,4}` do
 ```jldoctest
 julia> M = uniform_matroid(3,4);
@@ -773,7 +773,7 @@ Note that this only works for prime numbers `q` for now.
 
 See Section 6.1 of [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> M = projective_plane(3)
 Matroid of rank 3 on 13 elements
@@ -797,7 +797,7 @@ Note that this only works for prime numbers `q` for now.
 See Section 6.1 of [Oxl11](@cite).
 Warning: Following the book of Oxley, the rank of the resulting matroid is `r+1`.
 
-# Example
+# Examples
 ```jldoctest
 julia> M = projective_geometry(2, 3)
 Matroid of rank 3 on 13 elements
@@ -834,7 +834,7 @@ Note that this only works for prime numbers `q` for now.
 See Section 6.1 of [Oxl11](@cite).
 Warning: Following the book of Oxley, the rank of the resulting matroid is `r+1`.
 
-# Example
+# Examples
 ```jldoctest
 julia> M = affine_geometry(2, 3)
 Matroid of rank 3 on 9 elements

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -24,7 +24,7 @@ export
 
 Return a matroid isomorphic to `M` on the groundset `gs`.
 
-# Example
+# Examples
 ```jldoctest
 julia> isomorphic_matroid(fano_matroid(), [2,3,4,1,5,6,7])
 Matroid of rank 3 on 7 elements
@@ -44,7 +44,7 @@ end
 
 Return the size of the ground set of the matroid `M`.
 
-# Example
+# Examples
 ```jldoctest
 julia> length(fano_matroid())
 7
@@ -58,7 +58,7 @@ length(M::Matroid) = length(M.groundset)
 
 Return the list of bases of the matroid `M`.
 
-# Example
+# Examples
 ```jldoctest
 julia> bases(uniform_matroid(2, 3))
 3-element Vector{Vector{Int64}}:
@@ -74,7 +74,7 @@ bases(M::Matroid) = [[M.groundset[i+1] for i in sort(collect(C))] for C in Vecto
 
 Return the list of nonbases of the matroid `M`.
 
-# Example
+# Examples
 ```jldoctest
 julia> nonbases(fano_matroid())
 7-element Vector{Vector{Int64}}:
@@ -95,7 +95,7 @@ nonbases(M::Matroid) = [[M.groundset[i+1] for i in N] for N in M.pm_matroid.NON_
 
 Return the list of circuits of the matroid `M`.
 
-# Example
+# Examples
 ```jldoctest
 julia> circuits(uniform_matroid(2, 4))
 4-element Vector{Vector{Int64}}:
@@ -112,7 +112,7 @@ circuits(M::Matroid) = [[M.groundset[i+1] for i in sort(collect(C))] for C in Ve
 
 Return the list of hyperplanes of the matroid `M`.
 
-# Example
+# Examples
 ```jldoctest
 julia> hyperplanes(fano_matroid())
 7-element Vector{Vector{Int64}}:
@@ -135,7 +135,7 @@ Return the list of flats of the matroid `M`.
 By default all flats are returned.
 One may specify a rank `r` as the second parameter in which case only the flats of rank `r` are returned.
 
-# Example
+# Examples
 ```jldoctest
 julia> M = fano_matroid()
 Matroid of rank 3 on 7 elements
@@ -199,7 +199,7 @@ By default all cylic flats are returned.
 One may specify a rank `r` as the second parameter.
 In this case only the cylic flats of this rank are returned.
 
-# Example
+# Examples
 ```jldoctest
 julia> M = fano_matroid()
 Matroid of rank 3 on 7 elements
@@ -234,7 +234,7 @@ cyclic_flats(M::Matroid, r::Union{Int,Nothing}=nothing) = flats_impl(M::Matroid,
 
 Return the closure of `set` in the matroid `M`.
 
-# Example
+# Examples
 ```jldoctest
 julia> closure(fano_matroid(), [1,2])
 3-element Vector{Int64}:
@@ -258,7 +258,7 @@ end
 
 Return the rank of the matroid `M`.
 
-# Example
+# Examples
 ```jldoctest
 julia> rank(fano_matroid())
 3
@@ -271,7 +271,7 @@ rank(M::Matroid) = M.pm_matroid.RANK::Int
 
 Return the rank of `set` in the matroid `M`.
 
-# Example
+# Examples
 ```jldoctest
 julia> M = fano_matroid();
 
@@ -293,7 +293,7 @@ end
 Return the nullity of `set` in the matroid `M`.
 This is defined to be `|set| - rk(set)`.
 
-# Example
+# Examples
 ```jldoctest
 julia> M = fano_matroid();
 
@@ -312,7 +312,7 @@ See Section 1.2 of [Oxl11](@cite).
 Note that `elem` needs to be in the complement of the `basis` in this case.
 
 
-# Example
+# Examples
 ```jldoctest
 julia> M = fano_matroid();
 
@@ -351,7 +351,7 @@ See Section 2.1 of [Oxl11](@cite).
 Note that `elem` needs to be an element of the `basis` in this case.
 
 
-# Example
+# Examples
 ```jldoctest
 julia> fundamental_cocircuit(fano_matroid(), [1,2,4], 4)
 4-element Vector{Int64}:
@@ -369,7 +369,7 @@ fundamental_cocircuit(M::Matroid, basis::GroundsetType, elem::ElementType) = fun
 Return the list of independent sets of the matroid `M`.
 These are all subsets of the bases.
 
-# Example
+# Examples
 ```jldoctest
 julia> independent_sets(uniform_matroid(2, 3))
 7-element Vector{Vector{Integer}}:
@@ -407,7 +407,7 @@ end
 Return the list of spanning sets of the matroid `M`.
 These are all sets containing a basis.
 
-# Example
+# Examples
 ```jldoctest
 julia> spanning_sets(uniform_matroid(2, 3))
 4-element Vector{Vector{Integer}}:
@@ -430,7 +430,7 @@ end
 Return the bases of the dual matroid of `M`.
 See Section 2 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> cobases(uniform_matroid(2, 3))
 3-element Vector{Vector{Int64}}:
@@ -447,7 +447,7 @@ cobases(M::Matroid) = bases(dual_matroid(M))
 Return the circuits of the dual matroid of `M`.
 See Section 2 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> cocircuits(uniform_matroid(2, 5))
 5-element Vector{Vector{Int64}}:
@@ -466,7 +466,7 @@ cocircuits(M::Matroid) = circuits(dual_matroid(M))
 Return the hyperplanes of the dual matroid of `M`.
 See Section 2 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> cohyperplanes(fano_matroid())
 14-element Vector{Vector{Int64}}:
@@ -493,7 +493,7 @@ cohyperplanes(M::Matroid) = hyperplanes(dual_matroid(M))
 
 Return the rank of `set` in the dual matroid of `M`.
 
-# Example
+# Examples
 ```jldoctest
 julia> corank(fano_matroid(), [1,2,3])
 3
@@ -508,7 +508,7 @@ Checks if the collection of subsets `sets` is a clutter.
 A collection of subsets is a clutter if none of the sets is a proper subset of another.
 See Section 2.1 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> is_clutter([[1,2], [1,2,3]])
 false
@@ -534,7 +534,7 @@ end
 Checks if the matroid `M` is regular, that is representable over every field.
 See Section 6.6 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> is_regular(uniform_matroid(2, 3))
 true
@@ -557,7 +557,7 @@ end
 Checks if the matroid `M` is binary, that is representable over the finite field `F_2`.
 See Section 6.5 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> is_binary(uniform_matroid(2, 4))
 false
@@ -574,7 +574,7 @@ is_binary(M::Matroid) = M.pm_matroid.BINARY
 Checks if the matroid `M` is ternary, that is representable over the finite field `F_3`.
 See Section 4.1 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> is_ternary(uniform_matroid(2, 4))
 true
@@ -597,7 +597,7 @@ end
 Return the number of connected components of `M`.
 See Section 4.1 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> n_connected_components(fano_matroid())
 1
@@ -614,7 +614,7 @@ n_connected_components(M::Matroid) = length(M.pm_matroid.CONNECTED_COMPONENTS)
 Return the connected components of `M`. The function returns a partition of the ground set where each part corresponds to one connected component. 
 See Section 4.1 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> connected_components(fano_matroid())
 1-element Vector{Vector{Int64}}:
@@ -635,7 +635,7 @@ connected_components(M::Matroid) = [[M.groundset[i+1] for i in comp] for comp in
 Check if the matroid `M` is connected, that is has one connected component
 See Section 4.1 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> is_connected(fano_matroid())
 true
@@ -651,7 +651,7 @@ is_connected(M::Matroid) = M.pm_matroid.CONNECTED
 
 Return the loops of `M`. A loop is an element of the ground set that is not contained in any basis.
 
-# Example
+# Examples
 ```jldoctest
 julia> loops(matroid_from_bases([[1,2]], 4))
 2-element Vector{Int64}:
@@ -669,7 +669,7 @@ loops(M::Matroid) = [M.groundset[i+1] for i in M.pm_matroid.LOOPS]
 
 Return the coloops of `M`. A coloop is an element of the ground set that is contained in every basis.
 
-# Example
+# Examples
 ```jldoctest
 julia> coloops(matroid_from_bases([[1,2]], 4))
 2-element Vector{Int64}:
@@ -688,7 +688,7 @@ coloops(M::Matroid) = [M.groundset[i+1] for i in M.pm_matroid.DUAL.LOOPS]
 Check if `M` has a loop. Return `true` if `M` does not have a loop.
 See also `loops`.
 
-# Example
+# Examples
 ```jldoctest
 julia> is_loopless(matroid_from_bases([[1,2]], 4))
 false
@@ -705,7 +705,7 @@ is_loopless(M::Matroid) = length(M.pm_matroid.LOOPS)==0 ? true : false
 Check if `M` has a coloop. Return `true` if `M` does not have a coloop.
 See also `coloops`.
 
-# Example
+# Examples
 ```jldoctest
 julia> is_coloopless(matroid_from_bases([[1,2]], 4))
 false
@@ -723,7 +723,7 @@ Check if `M` has is simple. A matroid is simple if it doesn't have loops and doe
 Return `true` if `M` is simple.
 See also `loops`.
 
-# Example
+# Examples
 ```jldoctest
 julia> is_simple(matroid_from_bases([[1,2]], 4))
 false
@@ -740,7 +740,7 @@ is_simple(M::Matroid) = M.pm_matroid.SIMPLE
 Return the connected components of `M` as a list of matroids.
 See Section 4.1 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> direct_sum_components(fano_matroid())
 1-element Vector{Matroid}:
@@ -767,7 +767,7 @@ end
 Return the value of the connectivity function of `set` in the matroid `M`.
 See Section 8.1 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> connectivity_function(fano_matroid(), [1,2,4])
 3
@@ -784,7 +784,7 @@ end
 Check if `set` together with its complement defines a `k` separation in `M`
 See Section 8.6 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> is_vertical_k_separation(fano_matroid(), 2, [1,2,4])
 false
@@ -801,7 +801,7 @@ end
 Check if `set` together with its complement defines a `k` separation in `M`
 See Section 8.1 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> is_k_separation(fano_matroid(), 2, [1,2,4])
 false
@@ -818,7 +818,7 @@ end
 If 'M' has two disjoint cocircuits, its vertical connectivity is defined to be least positive integer k such that `M` has a vertical k separation.
 Otherwise its vertical connectivity is defined to be the rank of `M`.
 See Section 8.6 in [Oxl11](@cite).
-# Example
+# Examples
 ```jldoctest
 julia> vertical_connectivity(fano_matroid())
 3
@@ -850,7 +850,7 @@ Return the girth of `set` in the matroid `M`.
 This is the size of the smalles circuit contained in `set` and infintie otherwise.
 See Section 8.6 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> girth(fano_matroid(), [1,2,3,4])
 3
@@ -865,7 +865,7 @@ girth(M::Matroid, set::GroundsetType=M.groundset) = minimum([inf; [issubset(C,se
 The Tutte connectivity of `M` is the least integer k such that `M` has a k separation. It can be infinte if no k separation exists.
 See Section 8.6 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> tutte_connectivity(fano_matroid())
 3
@@ -897,7 +897,7 @@ end
 Return the Tutte polynomial of `M`. This is polynomial in the variables x and y with integral coefficients.
 See Section 15.3 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> tutte_polynomial(fano_matroid())
 x^3 + 4*x^2 + 7*x*y + 3*x + y^4 + 3*y^3 + 6*y^2 + 3*y
@@ -918,7 +918,7 @@ Return the characteristic polynomial of `M`. This is polynomial in the variable 
 It is computed as an evaluation of the Tutte polynmomial.
 See Section 15.2 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> characteristic_polynomial(fano_matroid())
 q^3 - 7*q^2 + 14*q - 8
@@ -937,7 +937,7 @@ charpoly(M::Matroid) = characteristic_polynomial(M)
 Return the reduced characteristic polynomial of `M`. This is the quotient of the characteristic polynomial by (q-1).
 See Section 15.2 in [Oxl11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> reduced_characteristic_polynomial(fano_matroid())
 q^2 - 6*q + 8
@@ -1023,7 +1023,7 @@ end
 
 Checks if the matroid `M1` is isomorphic to the matroid `M2` under the action of the symmetric group that acts on their groundsets.
 
-# Example
+# Examples
 To compare two matrods write:
 ```jldoctest
 julia> H = [[1,2,4],[2,3,5],[1,3,6],[3,4,7],[1,5,7],[2,6,7],[4,5,6]];


### PR DESCRIPTION
Using '# Examples' is the convention suggested by the Julia style guide
