### PR TITLE
[CI] re-enable macos nightly test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,10 +32,6 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
-        exclude:
-          # disable nightly tests due to https://github.com/JuliaLang/julia/issues/44800
-          - os: macos-latest
-            julia-version: 'nightly'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The nightly tests will still fail until everything was rebuilt for the recent `libjulia_jll` 1.9 update.