### PR TITLE
Rings/mpoly-ideals.jl: ==(I::MPolyIdeal, J::MPolyIdeal), added check for generators before GB computation

### DIFF
--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -848,6 +848,7 @@ false
 """
 function ==(I::MPolyIdeal{T}, J::MPolyIdeal{T}) where T
   I === J && return true
+  gens(I) == gens(J) && return true
   return issubset(I, J) && issubset(J, I)
 end
 


### PR DESCRIPTION
When the users asks for equality of two multivariate polynomial ideals, I suggest we first check equality of their generators before starting any GB computation. (I stumbled upon the issue when I had to compare two (equal) ideals for whom the GB computation did not finish.)