### PR TITLE
Polyhedral geometry/non redundant

### DIFF
--- a/src/PolyhedralGeometry/PolyhedralComplex/constructors.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/constructors.jl
@@ -58,7 +58,8 @@ function PolyhedralComplex{T}(
                 vr::Union{SubObjectIterator{<:Union{PointVector,PointVector}}, Oscar.MatElem, AbstractMatrix}, 
                 far_vertices::Union{Vector{Int}, Nothing} = nothing, 
                 L::Union{SubObjectIterator{<:RayVector}, 
-                Oscar.MatElem, AbstractMatrix, Nothing} = nothing
+                Oscar.MatElem, AbstractMatrix, Nothing} = nothing;
+                non_redundant::Bool = false
             ) where T<:scalar_types
     LM = isnothing(L) || isempty(L) ? Polymake.Matrix{scalar_type_to_polymake[T]}(undef, 0, size(vr, 2)) : L
 
@@ -72,11 +73,19 @@ function PolyhedralComplex{T}(
     # Lineality is homogenized
     lineality = homogenize(LM, 0)
 
-    PolyhedralComplex{T}(Polymake.fan.PolyhedralComplex{scalar_type_to_polymake[T]}(
-        POINTS = points,
-        INPUT_LINEALITY = lineality,
-        INPUT_CONES = polyhedra,
-    ))
+    if non_redundant
+        return PolyhedralComplex{T}(Polymake.fan.PolyhedralComplex{scalar_type_to_polymake[T]}(
+            VERTICES = points,
+            LINEALITY_SPACE = lineality,
+            MAXIMAL_CONES = polyhedra,
+        ))
+    else
+        return PolyhedralComplex{T}(Polymake.fan.PolyhedralComplex{scalar_type_to_polymake[T]}(
+            POINTS = points,
+            INPUT_LINEALITY = lineality,
+            INPUT_CONES = polyhedra,
+        ))
+    end
 end
 
 # TODO: Only works for this specific case; implement generalization using `iter.Acc`

--- a/src/PolyhedralGeometry/PolyhedralFan/constructors.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/constructors.jl
@@ -75,18 +75,33 @@ julia> PF=PolyhedralFan(R,IM)
 A polyhedral fan in ambient dimension 2
 ```
 """
-function PolyhedralFan{T}(Rays::Union{SubObjectIterator{<:RayVector}, Oscar.MatElem,AbstractMatrix}, Incidence::IncidenceMatrix) where T<:scalar_types
-   PolyhedralFan{T}(Polymake.fan.PolyhedralFan{scalar_type_to_polymake[T]}(
-      INPUT_RAYS = Rays,
-      INPUT_CONES = Incidence,
-   ))
+function PolyhedralFan{T}(Rays::Union{SubObjectIterator{<:RayVector}, Oscar.MatElem,AbstractMatrix}, Incidence::IncidenceMatrix; non_redundant::Bool = false) where T<:scalar_types
+   if non_redundant
+      return PolyhedralFan{T}(Polymake.fan.PolyhedralFan{scalar_type_to_polymake[T]}(
+         RAYS = Rays,
+         MAXIMAL_CONES = Incidence,
+      ))
+   else
+      return PolyhedralFan{T}(Polymake.fan.PolyhedralFan{scalar_type_to_polymake[T]}(
+         INPUT_RAYS = Rays,
+         INPUT_CONES = Incidence,
+      ))
+   end
 end
-function PolyhedralFan{T}(Rays::Union{SubObjectIterator{<:RayVector}, Oscar.MatElem,AbstractMatrix}, LS::Union{SubObjectIterator{<:RayVector}, Oscar.MatElem,AbstractMatrix}, Incidence::IncidenceMatrix) where T<:scalar_types
-   PolyhedralFan{T}(Polymake.fan.PolyhedralFan{scalar_type_to_polymake[T]}(
-      INPUT_RAYS = Rays,
-      INPUT_LINEALITY = LS,
-      INPUT_CONES = Incidence,
-   ))
+function PolyhedralFan{T}(Rays::Union{SubObjectIterator{<:RayVector}, Oscar.MatElem,AbstractMatrix}, LS::Union{SubObjectIterator{<:RayVector}, Oscar.MatElem,AbstractMatrix}, Incidence::IncidenceMatrix; non_redundant::Bool = false) where T<:scalar_types
+   if non_redundant
+      return PolyhedralFan{T}(Polymake.fan.PolyhedralFan{scalar_type_to_polymake[T]}(
+         RAYS = Rays,
+         LINEALITY_SPACE = LS,
+         MAXIMAL_CONES = Incidence,
+      ))
+   else
+      return PolyhedralFan{T}(Polymake.fan.PolyhedralFan{scalar_type_to_polymake[T]}(
+         INPUT_RAYS = Rays,
+         INPUT_LINEALITY = LS,
+         INPUT_CONES = Incidence,
+      ))
+   end
 end
 
 """

--- a/src/PolyhedralGeometry/PolyhedralFan/constructors.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/constructors.jl
@@ -47,7 +47,7 @@ struct PolyhedralFan{T} <:_FanLikeType{T}
 end
 
 # default scalar type: `fmpq`
-PolyhedralFan(x...) = PolyhedralFan{fmpq}(x...)
+PolyhedralFan(x...; non_redundant::Bool = false) = PolyhedralFan{fmpq}(x...; non_redundant = non_redundant)
 
 # Automatic detection of corresponding OSCAR scalar type;
 # Avoid, if possible, to increase type stability

--- a/src/ToricVarieties/CohomologyClasses/attributes.jl
+++ b/src/ToricVarieties/CohomologyClasses/attributes.jl
@@ -16,7 +16,7 @@ julia> d = ToricDivisor(dP2, [1,2,3,4,5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> cc = CohomologyClass(d)
-A cohomology class on a normal toric variety given by 2*x2 + 5*e2 + 7*x3
+A cohomology class on a normal toric variety given by 6*x3 + e1 + 7*e2
 
 julia> toric_variety(cc)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety over QQ without torusfactor
@@ -40,12 +40,12 @@ julia> d = ToricDivisor(dP2, [1,2,3,4,5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> cc = CohomologyClass(d)
-A cohomology class on a normal toric variety given by 2*x2 + 5*e2 + 7*x3
+A cohomology class on a normal toric variety given by 6*x3 + e1 + 7*e2
 
 julia> coefficients(cc)
 3-element Vector{fmpq}:
- 2
- 5
+ 6
+ 1
  7
 ```
 """
@@ -67,7 +67,7 @@ julia> d = ToricDivisor(dP2, [1,2,3,4,5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> cc = CohomologyClass(d)
-A cohomology class on a normal toric variety given by 2*x2 + 5*e2 + 7*x3
+A cohomology class on a normal toric variety given by 6*x3 + e1 + 7*e2
 
 julia> exponents(cc)
 [0   0   1   0   0]
@@ -94,10 +94,10 @@ julia> d = ToricDivisor(dP2, [1,2,3,4,5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> cc = CohomologyClass(d)
-A cohomology class on a normal toric variety given by 2*x2 + 5*e2 + 7*x3
+A cohomology class on a normal toric variety given by 6*x3 + e1 + 7*e2
 
 julia> polynomial(cc)
-2*x2 + 5*e2 + 7*x3
+6*x3 + e1 + 7*e2
 ```
 """
 polynomial(c::CohomologyClass) = polynomial(c, cohomology_ring(toric_variety(c)))
@@ -119,7 +119,7 @@ julia> d = ToricDivisor(dP2, [1,2,3,4,5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> cc = CohomologyClass(d)
-A cohomology class on a normal toric variety given by 2*x2 + 5*e2 + 7*x3
+A cohomology class on a normal toric variety given by 6*x3 + e1 + 7*e2
 
 julia> R, _ = PolynomialRing(QQ, 5)
 (Multivariate Polynomial Ring in x1, x2, x3, x4, x5 over Rational Field, fmpq_mpoly[x1, x2, x3, x4, x5])
@@ -139,7 +139,7 @@ julia> R_quo = quo(R, sr_and_linear_relation_ideal)[1]
 Quotient of Multivariate Polynomial Ring in x1, x2, x3, x4, x5 over Rational Field by ideal(x1*x3, x1*x5, x2*x4, x2*x5, x3*x4, x1 + x2 - x5, x2 + x3 - x4 - x5)
 
 julia> polynomial(cc, R_quo)
-2*x3 + 5*x4 + 7*x5
+6*x3 + x4 + 7*x5
 ```
 """
 function polynomial(c::CohomologyClass, ring::MPolyQuo)

--- a/src/ToricVarieties/CohomologyClasses/methods.jl
+++ b/src/ToricVarieties/CohomologyClasses/methods.jl
@@ -9,14 +9,14 @@ toric variety `toric_variety(c)`.
 julia> dP3 = del_pezzo(3)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> (x1,x2,x3,e3,e2,e1) = gens(cohomology_ring(dP3))
+julia> (x1,x2,x3,e1,e2,e3) = gens(cohomology_ring(dP3))
 6-element Vector{MPolyQuoElem{MPolyElem_dec{fmpq, fmpq_mpoly}}}:
  x1
  x2
  x3
- e3
- e2
  e1
+ e2
+ e3
 
 julia> c = CohomologyClass(dP3, e3*e3 + e3)
 A cohomology class on a normal toric variety given by e3 + e1^2

--- a/src/ToricVarieties/CohomologyClasses/methods.jl
+++ b/src/ToricVarieties/CohomologyClasses/methods.jl
@@ -19,7 +19,7 @@ julia> (x1,x2,x3,e1,e2,e3) = gens(cohomology_ring(dP3))
  e3
 
 julia> c = CohomologyClass(dP3, e3*e3 + e3)
-A cohomology class on a normal toric variety given by e3 + e1^2
+A cohomology class on a normal toric variety given by e3^2 + e3
 
 julia> integrate(c)
 -1

--- a/src/ToricVarieties/CohomologyClasses/methods.jl
+++ b/src/ToricVarieties/CohomologyClasses/methods.jl
@@ -9,17 +9,17 @@ toric variety `toric_variety(c)`.
 julia> dP3 = del_pezzo(3)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> (x1,e1,x2,e2,x3,e3) = gens(cohomology_ring(dP3))
+julia> (x1,x2,x3,e3,e2,e1) = gens(cohomology_ring(dP3))
 6-element Vector{MPolyQuoElem{MPolyElem_dec{fmpq, fmpq_mpoly}}}:
  x1
- e1
  x2
- e2
  x3
  e3
+ e2
+ e1
 
 julia> c = CohomologyClass(dP3, e3*e3 + e3)
-A cohomology class on a normal toric variety given by e3^2 + e3
+A cohomology class on a normal toric variety given by e3 + e1^2
 
 julia> integrate(c)
 -1

--- a/src/ToricVarieties/CohomologyClasses/special_attributes.jl
+++ b/src/ToricVarieties/CohomologyClasses/special_attributes.jl
@@ -41,7 +41,7 @@ julia> polynomial(volume_form(projective_space(NormalToricVariety, 2)))
 x3^2
 
 julia> polynomial(volume_form(del_pezzo(3)))
--e3^2
+-e1^2
 
 julia> polynomial(volume_form(hirzebruch_surface(5)))
 1//5*x2^2

--- a/src/ToricVarieties/CohomologyClasses/special_attributes.jl
+++ b/src/ToricVarieties/CohomologyClasses/special_attributes.jl
@@ -41,7 +41,7 @@ julia> polynomial(volume_form(projective_space(NormalToricVariety, 2)))
 x3^2
 
 julia> polynomial(volume_form(del_pezzo(3)))
--e1^2
+-e3^2
 
 julia> polynomial(volume_form(hirzebruch_surface(5)))
 1//5*x2^2

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -349,12 +349,7 @@ function hirzebruch_surface(r::Int)
     end
     
     # assign meaningful variables according to the rays
-    vars_dict = Dict()
-    vars_dict[matrix(ZZ,[1 0])] = "t1"
-    vars_dict[matrix(ZZ,[0 1])] = "x1"
-    vars_dict[matrix(ZZ,[-1 r])] = "t2"
-    vars_dict[matrix(ZZ,[0 -1])] = "x2"
-    vars = [vars_dict[new_rays[i,:]] for i in 1:nrows(new_rays)]
+    vars = ["t1", "x1", "t2", "x2"]
     set_coordinate_names(variety, vars)
     
     # set attributes
@@ -368,12 +363,7 @@ function hirzebruch_surface(r::Int)
     set_attribute!(variety, :class_group, free_abelian_group(2))
     
     # find weights of the Cox ring
-    weight_dict = Dict()
-    weight_dict[matrix(ZZ,[1 0])] = [0, 1]
-    weight_dict[matrix(ZZ,[0 1])] = [1, 0]
-    weight_dict[matrix(ZZ,[-1 r])] = [0, 1]
-    weight_dict[matrix(ZZ,[0 -1])] = [1, 2]
-    weights = matrix(ZZ, [weight_dict[new_rays[i,:]] for i in 1:nrows(new_rays)])
+    weights = matrix(ZZ, [0 1; 1 0; 0 1; 1 2])
     
     # set map from torusinvariant weil divisors to class group
     set_attribute!(variety, :map_from_torusinvariant_weil_divisor_group_to_class_group, hom(torusinvariant_weil_divisor_group(variety), class_group(variety), weights))

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -328,7 +328,7 @@ function hirzebruch_surface(r::Int)
     # construct the variety
     fan_rays = [1 0; 0 1; -1 r; 0 -1]
     cones = IncidenceMatrix([[1,2],[2,3],[3,4],[4,1]])
-    variety = NormalToricVariety(PolyhedralFan(fan_rays, cones))
+    variety = NormalToricVariety(PolyhedralFan(fan_rays, cones; non_redundant = true))
     new_rays = matrix(ZZ, Oscar.rays(variety))
     
     # set properties
@@ -431,7 +431,7 @@ function del_pezzo(b::Int)
         fan_rays = [1 0; 0 1; -1 -1; 1 1; 0 -1; -1 0]
         cones = IncidenceMatrix([[1,4],[2,4],[1,5],[5,3],[2,6],[6,3]])
     end
-    variety = NormalToricVariety(PolyhedralFan(fan_rays, cones))
+    variety = NormalToricVariety(PolyhedralFan(fan_rays, cones); non_redundant = true)
     new_rays = matrix(ZZ, Oscar.rays(variety))
     
     # set properties
@@ -656,7 +656,7 @@ function NormalToricVarietiesFromStarTriangulations(P::Polyhedron)
     max_cones = [IncidenceMatrix([[c[i]-1 for i in 2:length(c)] for c in t]) for t in max_cones]
     
     # construct the varieties
-    return [NormalToricVariety(PolyhedralFan(integral_rays, cones)) for cones in max_cones]
+    return [NormalToricVariety(PolyhedralFan(integral_rays, cones; non_redundant = true)) for cones in max_cones]
 end
 export NormalToricVarietiesFromStarTriangulations
 

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -448,15 +448,8 @@ function del_pezzo(b::Int)
     set_attribute!(variety, :isfano, true)
     
     # assign meaningful variables according to the rays
-    vars_dict = Dict()
-    vars_dict[matrix(ZZ,[1 0])] = "x1"
-    vars_dict[matrix(ZZ,[0 1])] = "x2"
-    vars_dict[matrix(ZZ,[-1 -1])] = "x3"
-    vars_dict[matrix(ZZ,[1 1])] = "e1"
-    vars_dict[matrix(ZZ,[0 -1])] = "e2"
-    vars_dict[matrix(ZZ,[-1 0])] = "e3"
-    vars = [vars_dict[new_rays[i,:]] for i in 1:nrows(new_rays)]
-    set_coordinate_names(variety, vars)
+    vars = ["x1", "x2", "x3", "e1", "e2", "e3"]
+    set_coordinate_names(variety, vars[1:(3 + b)])
     
     # set attributes
     set_attribute!(variety, :dim, 2)
@@ -469,12 +462,7 @@ function del_pezzo(b::Int)
         set_attribute!(variety, :betti_number, [fmpz(1),fmpz(2),fmpz(1)])
         
         # determine weights of the Cox ring
-        weight_dict = Dict()
-        weight_dict[matrix(ZZ,[1 0])] = [1, 1]
-        weight_dict[matrix(ZZ,[0 1])] = [1, 1]
-        weight_dict[matrix(ZZ,[-1 -1])] = [1, 0]
-        weight_dict[matrix(ZZ,[1 1])] = [0, -1]
-        weights = matrix(ZZ, [weight_dict[new_rays[i,:]] for i in 1:nrows(new_rays)])
+        weights = matrix(ZZ, [1 1; 1 1; 1 0; 0 -1])
         
         # use it to set more attributes
         set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(4))
@@ -490,13 +478,7 @@ function del_pezzo(b::Int)
         set_attribute!(variety, :betti_number, [fmpz(1),fmpz(3),fmpz(1)])
         
         # determine weights of the Cox ring
-        weight_dict = Dict()
-        weight_dict[matrix(ZZ,[1 0])] = [1, 1, 1]
-        weight_dict[matrix(ZZ,[0 1])] = [1, 1, 0]
-        weight_dict[matrix(ZZ,[-1 -1])] = [1, 0, 1]
-        weight_dict[matrix(ZZ,[1 1])] = [0, -1, 0]
-        weight_dict[matrix(ZZ,[0 -1])] = [0, 0, -1]
-        weights = matrix(ZZ, [weight_dict[new_rays[i,:]] for i in 1:nrows(new_rays)])
+        weights = matrix(ZZ, [1 1 1; 1 1 0; 1 0 1; 0 -1 0; 0 0 -1])
         
         # use it to set more attributes
         set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(5))
@@ -512,14 +494,7 @@ function del_pezzo(b::Int)
         set_attribute!(variety, :betti_number, [fmpz(1),fmpz(4),fmpz(1)])
         
         # determine weights of the Cox ring
-        weight_dict = Dict()
-        weight_dict[matrix(ZZ,[1 0])] = [1, 1, 1, 0]
-        weight_dict[matrix(ZZ,[0 1])] = [1, 1, 0, 1]
-        weight_dict[matrix(ZZ,[-1 -1])] = [1, 0, 1, 1]
-        weight_dict[matrix(ZZ,[1 1])] = [0, -1, 0, 0]
-        weight_dict[matrix(ZZ,[0 -1])] = [0, 0, -1, 0]
-        weight_dict[matrix(ZZ,[-1 0])] = [0, 0, 0, -1]
-        weights = matrix(ZZ, [weight_dict[new_rays[i,:]] for i in 1:nrows(new_rays)])
+        weights = matrix(ZZ, [1 1 1 0; 1 1 0 1; 1 0 1 1; 0 -1 0 0; 0 0 -1 0; 0 0 0 -1])
         
         # use it to set more attributes
         set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(6))

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -431,7 +431,7 @@ function del_pezzo(b::Int)
         fan_rays = [1 0; 0 1; -1 -1; 1 1; 0 -1; -1 0]
         cones = IncidenceMatrix([[1,4],[2,4],[1,5],[5,3],[2,6],[6,3]])
     end
-    variety = NormalToricVariety(PolyhedralFan(fan_rays, cones); non_redundant = true)
+    variety = NormalToricVariety(PolyhedralFan(fan_rays, cones; non_redundant = true))
     new_rays = matrix(ZZ, Oscar.rays(variety))
     
     # set properties

--- a/test/PolyhedralGeometry/PolyhedralComplex.jl
+++ b/test/PolyhedralGeometry/PolyhedralComplex.jl
@@ -11,6 +11,7 @@
         @test PolyhedralComplex{T}(I, P) isa PolyhedralComplex{T}
         @test PolyhedralComplex{T}(I, P, F) isa PolyhedralComplex{T}
         @test PolyhedralComplex{T}(I, P2, F, L) isa PolyhedralComplex{T}
+        @test PolyhedralComplex{T}(I, P2, F, L; non_redundant = true) isa PolyhedralComplex{T}
         @test PolyhedralComplex{T}(I, P2, nothing, L) isa PolyhedralComplex{T}
         
     end
@@ -18,6 +19,7 @@
      PC = PolyhedralComplex{T}(I, P)
      PCF = PolyhedralComplex{T}(I, -P, F)
      PCFL = PolyhedralComplex{T}(I, P2, F, L)
+     PCFLN = PolyhedralComplex{T}(I, P2, F, L; non_redundant = true)
      PCL = PolyhedralComplex{T}(I, P2, nothing, L)
      
      @test common_refinement(PC, PCF) isa PolyhedralComplex{T}
@@ -87,6 +89,12 @@
          @test npolyhedra(PCL) == 9
          @test codim(PCF) == 0
          @test isembedded(PC)
+         
+         @test vertices(PCFLN) == [P2[i, :] for i in 1:3]
+         @test rays(PCFLN) == [P2[4, :]]
+         @test lineality_space(PCFLN) == [L[1, :]]
+         # TODO: include when index methods have been been implemented
+         # @test vertex_and_ray_indices(maximal_polyhedra(PCFLN)) == I
          
      end
     

--- a/test/PolyhedralGeometry/PolyhedralFan.jl
+++ b/test/PolyhedralGeometry/PolyhedralFan.jl
@@ -1,17 +1,23 @@
 @testset "PolyhedralFan{$T}" for T in [fmpq, nf_elem]
     C0 = cube(T, 2)
+    @test normal_fan(C0) isa PolyhedralFan{T}
     NFsquare = normal_fan(C0)
     R = [1 0 0; 0 0 1]
     L = [0 1 0]
     Cone4 = positive_hull(T, R)
     Cone5 = positive_hull(T, [1 0 0; 0 1 0])
 
+    @test PolyhedralFan([Cone4, Cone5]) isa PolyhedralFan{T}
     F0 = PolyhedralFan([Cone4, Cone5])
     I3 = [1 0 0; 0 1 0; 0 0 1]
     incidence1 = IncidenceMatrix([[1,2],[2,3]])
     incidence2 = IncidenceMatrix([[1,2]])
+    @test PolyhedralFan{T}(I3, incidence1) isa PolyhedralFan{T}
     F1 = PolyhedralFan{T}(I3, incidence1)
+    F1NR = PolyhedralFan{T}(I3, incidence1; non_redundant = true)
+    @test PolyhedralFan{T}(I3, incidence1) isa PolyhedralFan{T}
     F2 = PolyhedralFan{T}(R, L, incidence2)
+    F2NR = PolyhedralFan{T}(R, L, incidence2; non_redundant = true)
 
     @testset "core functionality" begin
         if T == fmpq
@@ -60,6 +66,11 @@
             @test !issmooth(FF0)
         end
         @test f_vector(NFsquare) == [4, 4]
+        @test rays(F1NR) == collect(eachrow(I3))
+        @test ray_indices(maximal_cones(F1NR)) == incidence1
+        @test rays(F2NR) == collect(eachrow(R))
+        @test lineality_space(F2NR) == collect(eachrow(L))
+        @test ray_indices(maximal_cones(F2NR)) == incidence2
     end
 
 end


### PR DESCRIPTION
When constructing certain polymake `BigObject`s (e.g. a `PolyhedralFan`), we can use the specific input properties like `INPUT_RAYS` to pass the information required to identify our object. The big advantage of these input properties is that it is allowed to be redundant, so polymake sorts out the rest.
But it is also possible to directly set the value `RAYS` instead of `INPUT_RAYS`. Given that our input is not faulty, this allows us to skip unnecessary redundancy checks. Further, this information will not be altered, meaning that it preserves the exact state of the input, for example the order of the rays or the choice of generators.

This PR contains some small adjustments to `PolyhedralFan`, `PolyhedralComplex` and `NormalToricVarieties` so we can transfer these capabilities to Oscar. Similar to the constructor of `Cone` or the function `convex_hull` there now is an additional `non_redundant::Bool = false` keyword argument for `PolyhedralFan` and `PolyhedralComplex`. If it is set to `true`, the entire input is expected to be non-redundant.

Tagging @HereAround because this should help with #1208 (and thus #1258 ).