### PR TITLE
ToricVarieties: Cache rings and ideals

### DIFF
--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -116,54 +116,64 @@ euler_characteristic(v::AbstractNormalToricVariety)
 betti_number(v::AbstractNormalToricVariety, i::Int)
 ```
 
-### Coefficient ring and coordinate names
+### Rings and ideals
 
-We support the Cox ring (also termed the "total coordinate ring" in [CLS11](@cite)) and the following ideals:
-- `irrelevant ideal`,
-- `Stanley-Reisner ideal`
-For their computation, names for the indeterminates of the Cox ring must be chosen.
-The default value is `[x1, x2, ... ]`. the user can overwrite this at any time.
-
+We support the following rings and ideals for toric varieties:
+- Cox ring (also termed the "total coordinate ring" in [CLS11](@cite)),
+- coordinate ring of torus,
+- cohomology_ring,
+- Chow ring,
+- irrelevant ideal,
+- Stanley-Reisner ideal,
+- ideal of linear relations,
+- toric ideal.
+Of course, for any of these coordinate names and the coefficient ring
+have to be chosen. We provide the following setter and getter functions:
 ```@docs
 coordinate_names(v::AbstractNormalToricVariety)
 set_coordinate_names(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
-```
-
-Likewise, a coefficient ring for the Cox ring must be chosen. The default value is
-the field of rational numbers. The user can overwrite this at any time.
-
-```@docs
 coefficient_ring(v::AbstractNormalToricVariety)
 set_coefficient_ring(v::AbstractNormalToricVariety, coefficient_ring::AbstractAlgebra.Ring)
-```
-
-Similarly, the computation of the coordinate ring of the torus requires coordinate names.
-Again, the default value is `[x1, x2, ... ]` and be overwritten at any time.
-
-```@docs
 coordinate_names_of_torus(v::AbstractNormalToricVariety)
 set_coordinate_names_of_torus(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
 ```
-
-
-### Rings and ideals
-
+In order to efficiently construct algebraic cycles (elements of the Chox ring),
+cohomology classes (elements of the cohomology ring), or in order to compare ideals,
+it is imperative to fix the choices of coordinates and coefficient rings. This happens
+once any of the above rings is computed for the variety. One can check the status as follows:
+```@docs
+is_finalized(v::AbstractNormalToricVariety)
+```
+The default value for coordinate names is `[x1, x2, ... ]`. The default for the coefficient
+ring is the field of rational numbers. The following methods provide access to the above rings
+and ideals:
 ```@docs
 cox_ring(v::AbstractNormalToricVariety)
-cox_ring(R::MPolyRing, v::AbstractNormalToricVariety)
 irrelevant_ideal(v::AbstractNormalToricVariety)
-irrelevant_ideal(R::MPolyRing, v::AbstractNormalToricVariety)
 ideal_of_linear_relations(v::AbstractNormalToricVariety)
-ideal_of_linear_relations(R::MPolyRing, v::AbstractNormalToricVariety)
 stanley_reisner_ideal(v::AbstractNormalToricVariety)
-stanley_reisner_ideal(R::MPolyRing, v::AbstractNormalToricVariety)
 toric_ideal(antv::AffineNormalToricVariety)
-toric_ideal(R::MPolyRing, antv::AffineNormalToricVariety)
 coordinate_ring_of_torus(v::AbstractNormalToricVariety)
+```
+After the variety finalized, one can enforce obtain the above ideals in different rings.
+Also, one can opt to compute the above rings with a different choice of coordinate names
+or a different coefficient ring. To this end, once provides a custom ring (which
+reflects the desired choice of coordinate names and coefficient ring) as first argument.
+However, note that the cached ideals and rings are *not* altered.
+```@docs
+cox_ring(R::MPolyRing, v::AbstractNormalToricVariety)
+irrelevant_ideal(R::MPolyRing, v::AbstractNormalToricVariety)
+ideal_of_linear_relations(R::MPolyRing, v::AbstractNormalToricVariety)
+stanley_reisner_ideal(R::MPolyRing, v::AbstractNormalToricVariety)
+toric_ideal(R::MPolyRing, antv::AffineNormalToricVariety)
 coordinate_ring_of_torus(R::MPolyRing, v::AbstractNormalToricVariety)
+```
+Along the same lines, characters can be turned into rational functions:
+```@docs
 character_to_rational_function(v::AbstractNormalToricVariety, character::Vector{fmpz})
 character_to_rational_function(R::MPolyRing, v::AbstractNormalToricVariety, character::Vector{fmpz})
 ```
+
 
 ## Auxillary Methods
 

--- a/src/ToricVarieties/AlgebraicCycles/special_attributes.jl
+++ b/src/ToricVarieties/AlgebraicCycles/special_attributes.jl
@@ -15,7 +15,7 @@ julia> ngens(chow_ring(p2))
 3
 ```
 """
-function chow_ring(v::AbstractNormalToricVariety)
+@attr MPolyQuo function chow_ring(v::AbstractNormalToricVariety)
     if !issimplicial(v) || !iscomplete(v)
         throw(ArgumentError("The Chow ring is (currently) only supported for simplicial and complete toric varieties."))
     end

--- a/src/ToricVarieties/CohomologyClasses/special_attributes.jl
+++ b/src/ToricVarieties/CohomologyClasses/special_attributes.jl
@@ -15,7 +15,7 @@ julia> ngens(cohomology_ring(p2))
 3
 ```
 """
-function cohomology_ring(v::AbstractNormalToricVariety)
+@attr MPolyQuo function cohomology_ring(v::AbstractNormalToricVariety)
     if !issimplicial(v) || !iscomplete(v)
         throw(ArgumentError("The cohomology ring is (currently) only supported for simplicial and complete toric varieties."))
     end

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -72,9 +72,38 @@ end
 export euler_characteristic
 
 
-############################
-# Rings and ideals
-############################
+###############################
+# Setters for rings and ideals
+###############################
+
+
+@doc Markdown.doc"""
+    is_finalized(v::AbstractNormalToricVariety)
+
+Checks if the Cox ring, the coordinate ring of the torus,
+the cohomology_ring, the Chow ring, the Stanley-Reisner ideal,
+the irrelevant ideal, the ideal of linear relations
+or the toric ideal has been cached. If any of these has been
+cached, then this function returns `true` and otherwise `false`.
+
+# Examples
+```jldoctest
+julia> is_finalized(del_pezzo(3))
+false
+```
+"""
+function is_finalized(v::AbstractNormalToricVariety)
+    properties = [has_attribute(v, :cox_ring),
+                    has_attribute(v, :coordinate_ring_of_torus),
+                    has_attribute(v, :cohomology_ring),
+                    has_attribute(v, :chow_ring),
+                    has_attribute(v, :stanley_reisner_ideal),
+                    has_attribute(v, :irrelevant_ideal),
+                    has_attribute(v, :ideal_of_linear_relations),
+                    has_attribute(v, :toric_ideal)]
+    return any(properties)
+end
+export is_finalized
 
 
 @doc Markdown.doc"""
@@ -97,9 +126,77 @@ true
 ```
 """
 function set_coefficient_ring(v::AbstractNormalToricVariety, coefficient_ring::AbstractAlgebra.Ring)
+    if is_finalized(v)
+        error("The coefficient ring cannot be modified since the toric variety is finalized.")
+    end
     set_attribute!(v, :coefficient_ring, coefficient_ring)
 end
 export set_coefficient_ring
+
+
+@doc Markdown.doc"""
+    set_coordinate_names(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
+
+Allows to set the names of the homogeneous coordinates.
+
+# Examples
+```jldoctest
+julia> C = Oscar.positive_hull([1 0]);
+
+julia> antv = AffineNormalToricVariety(C);
+
+julia> set_coordinate_names(antv,["u"])
+
+julia> coordinate_names(antv)
+1-element Vector{String}:
+ "u"
+```
+"""
+function set_coordinate_names(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
+    if is_finalized(v)
+        error("The coordinate names cannot be modified since the toric variety is finalized.")
+    end
+    if length(coordinate_names) != nrays(v)
+        throw(ArgumentError("The provided list of coordinate names must match the number of rays in the fan."))
+    end
+    set_attribute!(v, :coordinate_names, coordinate_names)
+end
+export set_coordinate_names
+
+
+@doc Markdown.doc"""
+    set_coordinate_names_of_torus(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
+
+Allows to set the names of the coordinates of the torus.
+
+# Examples
+```jldoctest
+julia> F3 = hirzebruch_surface(3);
+
+julia> set_coordinate_names_of_torus(F3,["u","v"])
+
+julia> coordinate_names_of_torus(F3)
+2-element Vector{String}:
+ "u"
+ "v"
+```
+"""
+function set_coordinate_names_of_torus(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
+    if is_finalized(v)
+        error("The coordinate names of the torus cannot be modified since the toric variety is finalized.")
+    end
+    if length(coordinate_names) != ambient_dim(v)
+        throw(ArgumentError("The provided list of coordinate names must match the ambient dimension of the fan."))
+    end
+    set_attribute!(v, :coordinate_names_of_torus, coordinate_names)
+end
+export set_coordinate_names_of_torus
+
+
+
+########################################
+# Cox ring
+########################################
 
 
 @doc Markdown.doc"""
@@ -119,33 +216,6 @@ true
 ```
 """
 coefficient_ring(v::AbstractNormalToricVariety) = get_attribute!(v, :coefficient_ring, QQ)
-
-
-@doc Markdown.doc"""
-    set_coordinate_names(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
-
-Allows to set the names of the homogeneous coordinates.
-
-# Examples
-```jldoctest
-julia> C = Oscar.positive_hull([1 0]);
-
-julia> antv = AffineNormalToricVariety(C);
-
-julia> set_coordinate_names(antv, ["u"])
-
-julia> coordinate_names(antv)
-1-element Vector{String}:
- "u"
-```
-"""
-function set_coordinate_names(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
-    if length(coordinate_names) != nrays(v)
-        throw(ArgumentError("The provided list of coordinate names must match the number of rays in the fan."))
-    end
-    set_attribute!(v, :coordinate_names, coordinate_names)
-end
-export set_coordinate_names
 
 
 @doc Markdown.doc"""
@@ -179,33 +249,6 @@ end
 
 
 @doc Markdown.doc"""
-    cox_ring(v::AbstractNormalToricVariety)
-
-Computes the Cox ring of the normal toric variety `v`.
-Note that [CLS11](@cite) refers to this ring as the "total coordinate ring".
-
-# Examples
-```jldoctest
-julia> p2 = projective_space(NormalToricVariety, 2);
-
-julia> set_coordinate_names(p2, ["y1", "y2", "y3"])
-
-julia> set_coefficient_ring(p2, ZZ)
-
-julia> cox_ring(p2)
-Multivariate Polynomial Ring in y1, y2, y3 over Integer Ring graded by 
-  y1 -> [1]
-  y2 -> [1]
-  y3 -> [1]
-```
-"""
-function cox_ring(v::AbstractNormalToricVariety)
-    S, _ = PolynomialRing(coefficient_ring(v), coordinate_names(v), cached=false)
-    return cox_ring(S, v)
-end
-
-
-@doc Markdown.doc"""
     cox_ring(R::MPolyRing, v::AbstractNormalToricVariety)
 
 Computes the Cox ring of the normal toric variety `v`, in this case by adding
@@ -230,7 +273,39 @@ function cox_ring(R::MPolyRing, v::AbstractNormalToricVariety)
     length(weights) == nvars(R) || throw(ArgumentError("Wrong number of variables"))
     return grade(R, weights)[1]
 end
+
+
+@doc Markdown.doc"""
+    cox_ring(v::AbstractNormalToricVariety)
+
+Computes the Cox ring of the normal toric variety `v`.
+Note that [CLS11](@cite) refers to this ring as the "total coordinate ring".
+
+# Examples
+```jldoctest
+julia> p2 = projective_space(NormalToricVariety, 2);
+
+julia> set_coordinate_names(p2, ["y1", "y2", "y3"])
+
+julia> set_coefficient_ring(p2, ZZ)
+
+julia> cox_ring(p2)
+Multivariate Polynomial Ring in y1, y2, y3 over Integer Ring graded by 
+  y1 -> [1]
+  y2 -> [1]
+  y3 -> [1]
+```
+"""
+@attr MPolyRing function cox_ring(v::AbstractNormalToricVariety)
+    S, _ = PolynomialRing(coefficient_ring(v), coordinate_names(v), cached=false)
+    return cox_ring(S, v)
+end
 export cox_ring
+
+
+########################################
+# Stanley-Reisner ideal
+########################################
 
 
 @attr Polymake.IncidenceMatrixAllocated{Polymake.NonSymmetric} function _minimal_nonfaces(v::AbstractNormalToricVariety)
@@ -277,8 +352,15 @@ julia> ngens(stanley_reisner_ideal(p2))
 1
 ```
 """
-stanley_reisner_ideal(v::AbstractNormalToricVariety) = stanley_reisner_ideal(cox_ring(v), v)
+@attr MPolyIdeal function stanley_reisner_ideal(v::AbstractNormalToricVariety)
+    return stanley_reisner_ideal(cox_ring(v), v)
+end
 export stanley_reisner_ideal
+
+
+########################################
+# Irrelevant ideal
+########################################
 
 
 @attr Vector{Vector{Int}} function _irrelevant_ideal_monomials(v::AbstractNormalToricVariety)
@@ -289,25 +371,6 @@ export stanley_reisner_ideal
         push!(result, onesv - Vector{Int}(mc[i,:]))
     end
     return result
-end
-
-
-@doc Markdown.doc"""
-    irrelevant_ideal(v::AbstractNormalToricVariety)
-
-Return the irrelevant ideal of a normal toric variety `v`.
-
-# Examples
-```jldoctest
-julia> p2 = projective_space(NormalToricVariety, 2);
-
-julia> length(gens(irrelevant_ideal(p2)))
-3
-```
-"""
-function irrelevant_ideal(v::AbstractNormalToricVariety)
-    R = cox_ring(v)
-    return irrelevant_ideal(R, v)
 end
 
 
@@ -331,32 +394,35 @@ function irrelevant_ideal(R::MPolyRing, v::AbstractNormalToricVariety)
     nvars(R) == nrays(v) || throw(ArgumentError("Wrong number of variables in polynomial ring."))
     return ideal([R([1], [x]) for x in monoms])
 end
-export irrelevant_ideal
 
 
 @doc Markdown.doc"""
-    ideal_of_linear_relations(v::AbstractNormalToricVariety)
+    irrelevant_ideal(v::AbstractNormalToricVariety)
 
-Return the ideal of linear relations of the simplicial and complete toric variety `v`.
+Return the irrelevant ideal of a normal toric variety `v`.
 
 # Examples
 ```jldoctest
 julia> p2 = projective_space(NormalToricVariety, 2);
 
-julia> ngens(ideal_of_linear_relations(p2))
-2
+julia> length(gens(irrelevant_ideal(p2)))
+3
 ```
 """
-function ideal_of_linear_relations(v::AbstractNormalToricVariety)
-    R, _ = PolynomialRing(coefficient_ring(v), coordinate_names(v))
-    weights = [1 for i in 1:ngens(R)]
-    grade(R, weights)
-    return ideal_of_linear_relations(R, v)
+@attr MPolyIdeal function irrelevant_ideal(v::AbstractNormalToricVariety)
+    R = cox_ring(v)
+    return irrelevant_ideal(R, v)
 end
+export irrelevant_ideal
+
+
+########################################
+# Ideal of linear relations
+########################################
 
 
 @doc Markdown.doc"""
-    ideal_of_linear_relations(v::AbstractNormalToricVariety)
+    ideal_of_linear_relations(R::MPolyRing, v::AbstractNormalToricVariety)
 
 Return the ideal of linear relations of the simplicial and complete toric variety `v` in the ring R.
 
@@ -382,36 +448,33 @@ function ideal_of_linear_relations(R::MPolyRing, v::AbstractNormalToricVariety)
     generators = [sum([rays(v)[j][i] * indeterminates[j] for j in 1:nrays(v)]) for i in 1:d]
     return ideal(generators)
 end
-export ideal_of_linear_relations
 
 
 @doc Markdown.doc"""
-    toric_ideal(antv::AffineNormalToricVariety)
+    ideal_of_linear_relations(v::AbstractNormalToricVariety)
 
-Return the toric ideal defining the affine normal toric variety.
+Return the ideal of linear relations of the simplicial and complete toric variety `v`.
 
 # Examples
-Take the cone over the square at height one. The resulting toric variety has
-one defining equation. In projective space this corresponds to
-$\mathbb{P}^1\times\mathbb{P}^1$. Note that this cone is self-dual, the toric
-ideal comes from the dual cone.
 ```jldoctest
-julia> C = positive_hull([1 0 0; 1 1 0; 1 0 1; 1 1 1])
-A polyhedral cone in ambient dimension 3
+julia> p2 = projective_space(NormalToricVariety, 2);
 
-julia> antv = AffineNormalToricVariety(C)
-A normal, affine toric variety
-
-julia> toric_ideal(antv)
-ideal(-x1*x2 + x3*x4)
+julia> ngens(ideal_of_linear_relations(p2))
+2
 ```
 """
-function toric_ideal(antv::AffineNormalToricVariety)
-    cone = Cone(pm_object(antv).WEIGHT_CONE)
-    n = length(hilbert_basis(cone))
-    R,_ = PolynomialRing(coefficient_ring(antv), n, cached=false)
-    return toric_ideal(R, antv)
+@attr MPolyIdeal function ideal_of_linear_relations(v::AbstractNormalToricVariety)
+    R, _ = PolynomialRing(coefficient_ring(v), coordinate_names(v))
+    weights = [1 for i in 1:ngens(R)]
+    grade(R, weights)
+    return ideal_of_linear_relations(R, v)
 end
+export ideal_of_linear_relations
+
+
+########################################
+# Toric ideal
+########################################
 
 
 @doc Markdown.doc"""
@@ -444,30 +507,50 @@ function toric_ideal(R::MPolyRing, antv::AffineNormalToricVariety)
     return binomial_exponents_to_ideal(R, gens)
 end
 
-function toric_ideal(ntv::NormalToricVariety)
+
+@doc Markdown.doc"""
+    toric_ideal(antv::AffineNormalToricVariety)
+
+Return the toric ideal defining the affine normal toric variety.
+
+# Examples
+Take the cone over the square at height one. The resulting toric variety has
+one defining equation. In projective space this corresponds to
+$\mathbb{P}^1\times\mathbb{P}^1$. Note that this cone is self-dual, the toric
+ideal comes from the dual cone.
+```jldoctest
+julia> C = positive_hull([1 0 0; 1 1 0; 1 0 1; 1 1 1])
+A polyhedral cone in ambient dimension 3
+
+julia> antv = AffineNormalToricVariety(C)
+A normal, affine toric variety
+
+julia> toric_ideal(antv)
+ideal(-x1*x2 + x3*x4)
+```
+"""
+@attr MPolyIdeal function toric_ideal(antv::AffineNormalToricVariety)
+    cone = Cone(pm_object(antv).WEIGHT_CONE)
+    n = length(hilbert_basis(cone))
+    R,_ = PolynomialRing(coefficient_ring(antv), n, cached=false)
+    return toric_ideal(R, antv)
+end
+
+
+@attr MPolyIdeal function toric_ideal(ntv::NormalToricVariety)
     isaffine(ntv) || error("Cannot construct affine toric variety from non-affine input")
     return toric_ideal(AffineNormalToricVariety(ntv))
 end
 export toric_ideal
 
 
-@doc Markdown.doc"""
-    set_coordinate_names_of_torus(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
-
-Allows to set the names of the coordinates of the torus.
-"""
-function set_coordinate_names_of_torus(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
-    if length(coordinate_names) != ambient_dim(v)
-        throw(ArgumentError("The provided list of coordinate names must match the ambient dimension of the fan."))
-    end
-    set_attribute!(v, :coordinate_names_of_torus, coordinate_names)
-end
-export set_coordinate_names_of_torus
+########################################
+# Coordinate ring of torus
+########################################
 
 
 @doc Markdown.doc"""
     coordinate_names_of_torus(v::AbstractNormalToricVariety)
-
 This method returns the names of the coordinates of the torus of
 the normal toric variety `v`. The default is `x1,...,xn`.
 """
@@ -475,6 +558,22 @@ the normal toric variety `v`. The default is `x1,...,xn`.
     return ["x$(i)" for i in 1:ambient_dim(v)]
 end
 export coordinate_names_of_torus
+
+
+@doc Markdown.doc"""
+    coordinate_ring_of_torus(R::MPolyRing, v::AbstractNormalToricVariety)
+
+Computes the coordinate ring of the torus of the normal toric variety `v`
+in the given polynomial ring `R`.
+"""
+function coordinate_ring_of_torus(R::MPolyRing, v::AbstractNormalToricVariety)
+    n = length(coordinate_names_of_torus(v))
+    if length(gens(R)) < 2 * n
+        throw(ArgumentError("The given ring must have at least $(length( coordinate_names_of_torus(v))) indeterminates."))
+    end
+    relations = [gens(R)[i] * gens(R)[i+length(coordinate_names_of_torus(v))] - one(coefficient_ring(R)) for i in 1:length(coordinate_names_of_torus(v))]
+    return quo(R, ideal(relations))[1]
+end
 
 
 @doc Markdown.doc"""
@@ -492,28 +591,16 @@ julia> coordinate_ring_of_torus(p2)
 Quotient of Multivariate Polynomial Ring in y1, y2, y1_, y2_ over Rational Field by ideal(y1*y1_ - 1, y2*y2_ - 1)
 ```
 """
-function coordinate_ring_of_torus(v::AbstractNormalToricVariety)
+@attr MPolyQuo function coordinate_ring_of_torus(v::AbstractNormalToricVariety)
     S, _ = PolynomialRing(coefficient_ring(v), vcat(coordinate_names_of_torus(v), [x*"_" for x in coordinate_names_of_torus(v)]), cached=false)
     return coordinate_ring_of_torus(S, v)
 end
 export coordinate_ring_of_torus
 
 
-@doc Markdown.doc"""
-    coordinate_ring_of_torus(R::MPolyRing, v::AbstractNormalToricVariety)
-
-Computes the coordinate ring of the torus of the normal toric variety `v`
-in the given polynomial ring `R`.
-"""
-function coordinate_ring_of_torus(R::MPolyRing, v::AbstractNormalToricVariety)
-    n = length(coordinate_names_of_torus(v))
-    if length(gens(R)) < 2 * n
-        throw(ArgumentError("The given ring must have at least $(length( coordinate_names_of_torus(v))) indeterminates."))
-    end
-    relations = [gens(R)[i] * gens(R)[i+length(coordinate_names_of_torus(v))] - one(coefficient_ring(R)) for i in 1:length(coordinate_names_of_torus(v))]
-    return quo(R, ideal(relations))[1]
-end
-export coordinate_ring_of_torus
+#########################################
+# Turn characters into rational functions
+#########################################
 
 
 @doc Markdown.doc"""
@@ -570,9 +657,9 @@ character_to_rational_function(R::MPolyRing, v::AbstractNormalToricVariety, char
 export character_to_rational_function
 
 
-############################
+##############################################
 # Characters, Weil divisor and the class group
-############################
+##############################################
 
 
 @doc Markdown.doc"""

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -93,15 +93,17 @@ false
 ```
 """
 function is_finalized(v::AbstractNormalToricVariety)
-    properties = [has_attribute(v, :cox_ring),
-                    has_attribute(v, :coordinate_ring_of_torus),
-                    has_attribute(v, :cohomology_ring),
-                    has_attribute(v, :chow_ring),
-                    has_attribute(v, :stanley_reisner_ideal),
-                    has_attribute(v, :irrelevant_ideal),
-                    has_attribute(v, :ideal_of_linear_relations),
-                    has_attribute(v, :toric_ideal)]
-    return any(properties)
+    properties = [
+        :cox_ring,
+        :coordinate_ring_of_torus,
+        :cohomology_ring,
+        :chow_ring,
+        :stanley_reisner_ideal,
+        :irrelevant_ideal,
+        :ideal_of_linear_relations,
+        :toric_ideal,
+    ]
+    return any(p -> has_attribute(v, p), properties)
 end
 export is_finalized
 

--- a/src/ToricVarieties/cohomCalg/auxilliary.jl
+++ b/src/ToricVarieties/cohomCalg/auxilliary.jl
@@ -19,10 +19,9 @@ function command_string(v::AbstractNormalToricVariety, c::Vector{fmpz})
     # Add information about the Stanley-Reisner ideal to string_list
     current_coordinate_names = [string(x) for x in Hecke.gens(cox_ring(v))]
     new_coordinate_names = ["x$i" for i = 1:length(current_coordinate_names)]
-    set_coordinate_names(v, new_coordinate_names)
-    generators = [string(g) for g in gens(stanley_reisner_ideal(v))]
+    new_ring, _ = PolynomialRing(coefficient_ring(v), new_coordinate_names, cached=false)
+    generators = [string(g) for g in gens(stanley_reisner_ideal(new_ring,v))]
     push!(string_list, "srideal [" * joincomma(generators) * "]")
-    set_coordinate_names(v, current_coordinate_names)
     
     # Add line bundle information to string_list
     push!(string_list, "ambientcohom O(" * joincomma(c) * ");")

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -13,6 +13,8 @@ antv5 = AffineNormalToricVariety(Oscar.positive_hull([1 0; 0 1]))
 antv6 = NormalToricVariety([[1,0,0], [1,0,1], [1,1,1], [1,1,0]], [[1,2,3,4]])
 
 set_coefficient_ring(antv4, ZZ)
+set_coordinate_names(antv4, ["u"])
+set_coordinate_names_of_torus(antv4, ["u1","u2"])
 
 @testset "Affine toric varieties" begin
     @test issmooth(antv) == false
@@ -40,12 +42,20 @@ end
 
 @testset "Affine toric varieties with torusfactor" begin
     @test_throws ArgumentError set_coordinate_names(antv4, ["u1", "u2"])
-    @test_throws ArgumentError ideal_of_linear_relations(antv4)
     @test_throws ArgumentError set_coordinate_names_of_torus(antv4, ["u"])
+    @test_throws ArgumentError ideal_of_linear_relations(antv4)
     @test_throws ArgumentError map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group(antv4)
     @test_throws ArgumentError map_from_torusinvariant_cartier_divisor_group_to_picard_group(antv4)
     @test_throws ArgumentError betti_number(antv4, 0)
     @test dim_of_torusfactor(antv4) == 1
+end
+
+@testset "Errors from changes to coordinates and coefficients are variety is finalized" begin
+    @test ngens(cox_ring(antv4)) == 1
+    @test is_finalized(antv4) == true
+    @test_throws ErrorException set_coordinate_names(antv4, ["u"])
+    @test_throws ErrorException set_coordinate_names_of_torus(antv4, ["u1", "u2"])
+    @test_throws ErrorException set_coefficient_ring(antv4, ZZ)
 end
 
 @testset "Affine toric varieties with trivial toric ideal" begin
@@ -429,7 +439,7 @@ end
     @test dim(toric_variety(l)) == 2
 end
 
-@testset "Arithmetics of torlc line bundles" begin
+@testset "Arithmetics of toric line bundles" begin
     @test (l == l3) == false
     @test (l4 * l5 == l7) == true
     @test (l * l6 * inv(l) == l7) == true


### PR DESCRIPTION
This aims towards closing https://github.com/oscar-system/Oscar.jl/issues/1257. As of now, the following are included:

1. Fix coordinate names/coefficient ring once an associated ring or ideal is computed.
2. Cache associated rings and ideals.
3. Continue support for custom ring as first argument.
4. Update documentation accordingly. Also, slightly restructure code for improved readability.

This is a first step towards https://github.com/oscar-system/Oscar.jl/issues/1257 and should fix the failures in https://github.com/oscar-system/Oscar.jl/pull/1274.