### PR TITLE
Enable attribute storing for group products

### DIFF
--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -264,7 +264,7 @@ where `f` is a group homomorphism from `H` to the automorphism group of `N`.
 """
 function semidirect_product(N::S, f::GAPGroupHomomorphism{T,AutomorphismGroup{S}}, H::T) where S <: GAPGroup where T <: GAPGroup
    sdp=GAP.Globals.SemidirectProduct(H.X,f.map,N.X)
-   return SemidirectProductGroup(sdp,N,H,f,sdp,true)
+   return SemidirectProductGroup{S,T}(sdp,N,H,f,sdp,true)
 end
 
 # return the element (a,b) in G
@@ -338,7 +338,7 @@ end
 
 function _as_subgroup_bare(G::SemidirectProductGroup{S,T}, H::GapObj) where { S , T }
 #  t = G.X==H
-  return SemidirectProductGroup(H, G.N, G.H, G.f, G.X, false)
+  return SemidirectProductGroup{S,T}(H, G.N, G.H, G.f, G.X, false)
 end
 
 function Base.show(io::IO, x::SemidirectProductGroup)

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -257,11 +257,15 @@ end
 
 Either direct product of two or more groups of any type, or subgroup of a direct product of groups.
 """
-struct DirectProductGroup <: GAPGroup
+@attributes mutable struct DirectProductGroup <: GAPGroup
   X::GapObj
   L::Vector{<:GAPGroup}   # list of groups
   Xfull::GapObj      # direct product of the GAP groups of L
   isfull::Bool     # true if G is direct product of the groups of L, false if it is a proper subgroup
+
+  function DirectProductGroup(X::GapObj, L::Vector{<:GAPGroup}, Xfull::GapObj, isfull::Bool)
+    return new(X, L, Xfull, isfull)
+  end
 end
 
 
@@ -271,13 +275,17 @@ end
 Semidirect product of two groups of type `S` and `T` respectively, or
 subgroup of a semidirect product of groups.
 """
-struct SemidirectProductGroup{S<:GAPGroup, T<:GAPGroup} <: GAPGroup 
+@attributes mutable struct SemidirectProductGroup{S<:GAPGroup, T<:GAPGroup} <: GAPGroup
   X::GapObj
   N::S              # normal subgroup
   H::T              # group acting on N
   f::GAPGroupHomomorphism{T,AutomorphismGroup{S}}        # action of H on N
-  Xfull::GapObj         # full semidirect product: X is a subgroup of Xfull. 
+  Xfull::GapObj         # full semidirect product: X is a subgroup of Xfull.
   isfull::Bool     # true if X==Xfull
+
+  function SemidirectProductGroup{S, T}(X::GapObj, N::S, H::T, f::GAPGroupHomomorphism{T,AutomorphismGroup{S}}, Xfull::GapObj, isfull::Bool) where {S<:GAPGroup, T<:GAPGroup}
+    return new{S, T}(X, N, H, f, Xfull, isfull)
+  end
 end
 
 """
@@ -287,13 +295,17 @@ Wreath product of a group `G` and a group of permutations `H`, or a generic
 group `H` together with the homomorphism `a` from `H` to a permutation
 group.
 """
-struct WreathProductGroup <: GAPGroup
+@attributes mutable struct WreathProductGroup <: GAPGroup
   X::GapObj
   G::GAPGroup
   H::GAPGroup
   a::GAPGroupHomomorphism   # morphism from H to the permutation group
   Xfull::GapObj            # if H does not move all the points, this is the wreath product of (G, Sym(degree(H))
   isfull::Bool             # true if Xfull == X
+
+  function WreathProductGroup(X::GapObj, G::GAPGroup, H::GAPGroup, a::GAPGroupHomomorphism, Xfull::GapObj, isfull::Bool)
+    return new(X, G, H, a, Xfull, isfull)
+  end
 end
 
 

--- a/test/Groups/directproducts.jl
+++ b/test/Groups/directproducts.jl
@@ -6,12 +6,13 @@
    @test G isa DirectProductGroup
    @test order(G)==order(S)*order(C)
    @test exponent(G)==lcm(exponent(S),exponent(C))
-   @test typeof(rand(G))==elem_type(DirectProductGroup)
+   @test rand(G) isa elem_type(DirectProductGroup)
    @test factor_of_direct_product(G,1)==S
    @test factor_of_direct_product(G,2)==C
    @test_throws ArgumentError factor_of_direct_product(G,3)
    @test number_of_factors(G)==2
    @test isfull_direct_product(G)
+   @test PermGroup(G) isa PermGroup
 
    G,emb,proj = direct_product(S,C; morphisms=true)
    @test G==direct_product(S,C)
@@ -112,6 +113,7 @@
       @test isabelian(G)
       @test factor_of_direct_product(G,5)==C
       @test isisomorphic(G,abelian_group(PcGroup,[3,3,3,3,3]))
+      @test PermGroup(G) isa PermGroup
       x1 = G(C[1],one(C),one(C),one(C),one(C))
       x2 = G(one(C),C[1],one(C),one(C),one(C))
       x3 = G(one(C),one(C),C[1],one(C),one(C))
@@ -139,6 +141,7 @@ end
    @test homomorphism_of_semidirect_product(G)==f
    @test order(G)==16
    @test isfull_semidirect_product(G)
+   @test PermGroup(G) isa PermGroup
    x = G(Q[1]*Q[2],C[1])
    @test parent(x)==G
    H = sub(G,[x])[1]
@@ -172,14 +175,15 @@ end
    @test order(W)==48
    @test isfull_wreath_product(W)
    @test W==sub(W,gens(W))[1]
+   @test PermGroup(W) isa PermGroup
 
    H = sub(cperm([1,2,4]))[1]
    W = wreath_product(C,H)
 
-   @test typeof(W)==WreathProductGroup
+   @test W isa WreathProductGroup
    @test order(W)==2^4*3
    @test !isabelian(W)
-   @test typeof(rand(W))==elem_type(WreathProductGroup)
+   @test rand(W) isa elem_type(WreathProductGroup)
    f1 = C[1]
    x = W(f1,one(C),f1,one(C),cperm([1,4,2]))
    @test embedding(W,1)(f1)==W(f1,one(C),one(C),one(C),one(H))
@@ -194,7 +198,7 @@ end
    K = sub(W,[x])[1]
    @test K==sub(x)[1]
    @test K==sub(x)[1]
-   @test typeof(K)==WreathProductGroup
+   @test K isa WreathProductGroup
    @test order(K)==6
    @test iscyclic(K)
    @test index(W,K)==8


### PR DESCRIPTION
The new test failed before because the isomorphisms couldn't be stored