### PR TITLE
provide a `hash` method for `QabElem`

### DIFF
--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -50,56 +50,6 @@ function irreducible_modules(G::Oscar.GAPGroup)
   return IM
 end
 
-function minimize(::typeof(CyclotomicField), a::AbstractArray{nf_elem})
-  fl, c = Hecke.iscyclotomic_type(parent(a[1]))
-  @assert all(x->parent(x) == parent(a[1]), a)
-  @assert fl
-  for p = keys(factor(c).fac)
-    while c % p == 0
-      K, _ = cyclotomic_field(Int(div(c, p)), cached = false)
-      b = similar(a)
-      OK = true
-      for x = eachindex(a)
-        y = Hecke.force_coerce_cyclo(K, a[x], Val{false})
-        if y === nothing 
-          OK = false
-        else
-          b[x] = y
-        end
-      end
-      if OK
-        a = b
-        c = div(c, p)
-      else
-        break
-      end
-    end
-  end
-  return a
-end
-
-function minimize(::typeof(CyclotomicField), a::MatElem{nf_elem})
-  return matrix(minimize(CyclotomicField, a.entries))
-end
-
-function minimize(::typeof(CyclotomicField), a::nf_elem)
-  return minimize(CyclotomicField, [a])[1]
-end
-
-function Oscar.conductor(a::nf_elem)
-  return conductor(parent(minimize(CyclotomicField, a)))
-end
-
-function Oscar.conductor(k::AnticNumberField)
-  f, c = Hecke.iscyclotomic_type(k)
-  f || error("field is not of cyclotomic type")
-  return c
-end
-
-function Oscar.conductor(a::QabElem)
-  return conductor(data(a))
-end
-
 function irreducible_modules(::Type{AnticNumberField}, G::Oscar.GAPGroup; minimal_degree::Bool = false)
   z = irreducible_modules(G)
   Z = GModule[]

--- a/src/Rings/AbelianClosure.jl
+++ b/src/Rings/AbelianClosure.jl
@@ -25,7 +25,7 @@ module AbelianClosure
 
 using ..Oscar
 
-import Base: +, *, -, //, ==, zero, one, ^, div, isone, iszero, deepcopy_internal
+import Base: +, *, -, //, ==, zero, one, ^, div, isone, iszero, deepcopy_internal, hash
 
 #import ..Oscar.AbstractAlgebra: promote_rule
 
@@ -33,7 +33,7 @@ import ..Oscar: addeq!, isunit, parent_type, elem_type, gen, root_of_unity,
                 root, divexact, mul!, roots, isroot_of_unity, promote_rule,
                 AbstractAlgebra
 using Hecke
-import Hecke: data
+import Hecke: conductor, data
 
 ################################################################################
 #
@@ -353,6 +353,54 @@ function make_compatible(a::QabElem, b::QabElem)
   return coerce_up(K, d, a), coerce_up(K, d, b)
 end
 
+
+function minimize(::typeof(CyclotomicField), a::AbstractArray{nf_elem})
+  fl, c = Hecke.iscyclotomic_type(parent(a[1]))
+  @assert all(x->parent(x) == parent(a[1]), a)
+  @assert fl
+  for p = keys(factor(c).fac)
+    while c % p == 0
+      K, _ = cyclotomic_field(Int(div(c, p)), cached = false)
+      b = similar(a)
+      OK = true
+      for x = eachindex(a)
+        y = Hecke.force_coerce_cyclo(K, a[x], Val{false})
+        if y === nothing
+          OK = false
+        else
+          b[x] = y
+        end
+      end
+      if OK
+        a = b
+        c = div(c, p)
+      else
+        break
+      end
+    end
+  end
+  return a
+end
+
+function minimize(::typeof(CyclotomicField), a::MatElem{nf_elem})
+  return matrix(minimize(CyclotomicField, a.entries))
+end
+
+function minimize(::typeof(CyclotomicField), a::nf_elem)
+  return minimize(CyclotomicField, [a])[1]
+end
+
+conductor(a::nf_elem) = conductor(parent(minimize(CyclotomicField, a)))
+
+function conductor(k::AnticNumberField)
+  f, c = Hecke.iscyclotomic_type(k)
+  f || error("field is not of cyclotomic type")
+  return c
+end
+
+conductor(a::QabElem) = conductor(data(a))
+
+
 ################################################################################
 #
 #  Ring interface functions
@@ -518,6 +566,8 @@ end
 function ==(a::Union{fmpz, fmpq, Integer, Rational}, b::QabElem)
   return b == a
 end
+
+hash(a::QabElem, h::UInt) = hash(minimize(CyclotomicField, a.data), h)
 
 ################################################################################
 #

--- a/test/Rings/AbelianClosure.jl
+++ b/test/Rings/AbelianClosure.jl
@@ -174,6 +174,11 @@
       @test @inferred b == T(-1)
       @test @inferred T(-1) == b
     end
+
+    a = z(5)
+    b = z(15)^3
+    @test @inferred a == b
+    @test hash(a, zero(UInt)) == hash(b, zero(UInt))
   end
 
   @testset "Roots" begin


### PR DESCRIPTION
- moved `minimize` and `conductor` from `experimental/GModule/GModule.jl` to `src/Rings/AbelianClosure.jl`
- added `hash(a::QabElem, h::UInt)`

resolves #1287