### PR TITLE
ToricVarieties: More improvements

### DIFF
--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -128,25 +128,24 @@ We support the following rings and ideals for toric varieties:
 - ideal of linear relations,
 - toric ideal.
 Of course, for any of these coordinate names and the coefficient ring
-have to be chosen. We provide the following setter and getter functions:
+have to be chosen. The coefficient ring is fixed to `Q`. Therefore, the
+method `coefficient_ring(v::AbstractNormalToricVariety)` always return
+the field of rational numbers. For the coordinate names, we provide the
+following setter functions:
+```@docs
+set_coordinate_names(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
+set_coordinate_names_of_torus(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
+```
+The following methods allow to etract the chosen coordinates:
 ```@docs
 coordinate_names(v::AbstractNormalToricVariety)
-set_coordinate_names(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
-coefficient_ring(v::AbstractNormalToricVariety)
-set_coefficient_ring(v::AbstractNormalToricVariety, coefficient_ring::AbstractAlgebra.Ring)
 coordinate_names_of_torus(v::AbstractNormalToricVariety)
-set_coordinate_names_of_torus(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
 ```
 In order to efficiently construct algebraic cycles (elements of the Chox ring),
 cohomology classes (elements of the cohomology ring), or in order to compare ideals,
-it is imperative to fix the choices of coordinates and coefficient rings. This happens
-once any of the above rings is computed for the variety. One can check the status as follows:
-```@docs
-is_finalized(v::AbstractNormalToricVariety)
-```
-The default value for coordinate names is `[x1, x2, ... ]`. The default for the coefficient
-ring is the field of rational numbers. The following methods provide access to the above rings
-and ideals:
+it is imperative to fix choices of the coordinate names. The default value for
+coordinate names is `[x1, x2, ... ]`. The choice of coordinate names is fixed,
+once one of the above-mentioned rings is computed via one the following methods:
 ```@docs
 cox_ring(v::AbstractNormalToricVariety)
 irrelevant_ideal(v::AbstractNormalToricVariety)
@@ -155,9 +154,13 @@ stanley_reisner_ideal(v::AbstractNormalToricVariety)
 toric_ideal(antv::AffineNormalToricVariety)
 coordinate_ring_of_torus(v::AbstractNormalToricVariety)
 ```
-After the variety finalized, one can enforce obtain the above ideals in different rings.
+One can check the status as follows:
+```@docs
+is_finalized(v::AbstractNormalToricVariety)
+```
+After the variety finalized, one can enforce to obtain the above ideals in different rings.
 Also, one can opt to compute the above rings with a different choice of coordinate names
-or a different coefficient ring. To this end, once provides a custom ring (which
+and different coefficient ring. To this end, onc provides a custom ring (which
 reflects the desired choice of coordinate names and coefficient ring) as first argument.
 However, note that the cached ideals and rings are *not* altered.
 ```@docs

--- a/docs/src/ToricVarieties/ToricDivisorClasses.md
+++ b/docs/src/ToricVarieties/ToricDivisorClasses.md
@@ -19,8 +19,7 @@ Toric divisor classes are equivalence classes of Weil divisors modulo linear equ
 ### General constructors
 
 ```@docs
-ToricDivisorClass(v::AbstractNormalToricVariety, coeffs::Vector{fmpz})
-ToricDivisorClass(v::AbstractNormalToricVariety, coeffs::Vector{Int})
+ToricDivisorClass(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
 ```
 
 ### Special constructors

--- a/docs/src/ToricVarieties/ToricDivisors.md
+++ b/docs/src/ToricVarieties/ToricDivisors.md
@@ -21,8 +21,8 @@ correspond to the rays of the underlying fan.
 ### General constructors
 
 ```@docs
-DivisorOfCharacter(v::AbstractNormalToricVariety, character::Vector{Int})
-ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{Int})
+DivisorOfCharacter(v::AbstractNormalToricVariety, character::Vector{T}) where {T <: IntegerUnion}
+ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
 ```
 
 ### Special constructors

--- a/docs/src/ToricVarieties/ToricLineBundles.md
+++ b/docs/src/ToricVarieties/ToricLineBundles.md
@@ -15,8 +15,7 @@ Pages = ["ToricLineBundles.md"]
 ### Generic constructors
 
 ```@docs
-ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{fmpz})
-ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{Int})
+ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{T}) where {T <: IntegerUnion}
 ToricLineBundle(v::AbstractNormalToricVariety, d::ToricDivisor)
 ```
 

--- a/src/ToricVarieties/CohomologyClasses/attributes.jl
+++ b/src/ToricVarieties/CohomologyClasses/attributes.jl
@@ -22,7 +22,7 @@ julia> toric_variety(cc)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety over QQ without torusfactor
 ```
 """
-toric_variety(c::CohomologyClass) = c.toric_variety
+toric_variety(c::CohomologyClass) = c.v
 export toric_variety
 
 
@@ -49,7 +49,7 @@ julia> coefficients(cc)
  7
 ```
 """
-coefficients(c::CohomologyClass) = [coefficient_ring(toric_variety(c))(k) for k in c.coeffs]
+coefficients(c::CohomologyClass) = [coefficient_ring(toric_variety(c))(k) for k in coefficients(polynomial(c).f)]
 export coefficients
 
 
@@ -75,7 +75,7 @@ julia> exponents(cc)
 [0   0   0   0   1]
 ```
 """
-exponents(c::CohomologyClass) = c.exponents
+exponents(c::CohomologyClass) = matrix(ZZ,[k for k in exponent_vectors(polynomial(c).f)])
 export exponents
 
 
@@ -100,7 +100,7 @@ julia> polynomial(cc)
 6*x3 + e1 + 7*e2
 ```
 """
-polynomial(c::CohomologyClass) = polynomial(c, cohomology_ring(toric_variety(c)))
+polynomial(c::CohomologyClass) = c.p
 export polynomial
 
 
@@ -143,11 +143,12 @@ julia> polynomial(cc, R_quo)
 ```
 """
 function polynomial(c::CohomologyClass, ring::MPolyQuo)
-    coeffs = coefficients(c)
-    if length(coeffs) == 0
+    p = polynomial(c)
+    if iszero(p)
         return zero(ring)
     end
-    expos = exponents(c)
+    coeffs = [k for k in coefficients(p.f)]
+    expos = matrix(ZZ,[k for k in exponent_vectors(p.f)])
     indets = gens(ring)
     monoms = [prod(indets[j]^expos[k,j] for j in 1:ncols(expos)) for k in 1:nrows(expos)]
     return sum(coeffs[k]*monoms[k] for k in 1:length(monoms))

--- a/src/ToricVarieties/CohomologyClasses/attributes.jl
+++ b/src/ToricVarieties/CohomologyClasses/attributes.jl
@@ -19,7 +19,7 @@ julia> cc = CohomologyClass(d)
 A cohomology class on a normal toric variety given by 6*x3 + e1 + 7*e2
 
 julia> toric_variety(cc)
-A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety over QQ without torusfactor
+A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 ```
 """
 toric_variety(c::CohomologyClass) = c.v

--- a/src/ToricVarieties/CohomologyClasses/constructors.jl
+++ b/src/ToricVarieties/CohomologyClasses/constructors.jl
@@ -3,27 +3,13 @@
 #############################
 
 @attributes mutable struct CohomologyClass
-    toric_variety::AbstractNormalToricVariety
-    coeffs::Vector
-    exponents::fmpz_mat
+    v::AbstractNormalToricVariety
+    p::MPolyQuoElem
     function CohomologyClass(v::AbstractNormalToricVariety, p::MPolyQuoElem)
-        if length(coordinate_names(v)) != ngens(parent(p))
+        if parent(p) != cohomology_ring(v)
             throw(ArgumentError("The polynomial must reside in the cohomology ring of the toric variety."))
         end
-        for k in 1:length(coordinate_names(v))
-            if string(gens(parent(p))[k]) !== coordinate_names(v)[k]
-                throw(ArgumentError("The names of the indeterminates must match the names of the homogeneous coordinates of the toric variety."))
-            end
-        end
-        coeffs = [k for k in coefficients(p.f)]
-        expos = matrix(ZZ,[k for k in exponent_vectors(p.f)])
-        if nrows(expos) != length(coeffs)
-            throw(ArgumentError("There must be as many exponents as coefficients."))
-        end
-        if !iszero(p) && ncols(expos) != ngens(cohomology_ring(v))
-            throw(ArgumentError("Each exponent must consist of as many numbers as generators of the cohomology ring of the toric variety."))
-        end
-        return new(v, coeffs, expos)
+        return new(v, p)
     end
 end
 export CohomologyClass

--- a/src/ToricVarieties/CohomologyClasses/constructors.jl
+++ b/src/ToricVarieties/CohomologyClasses/constructors.jl
@@ -113,8 +113,7 @@ end
 
 Base.:*(c::fmpq, cc::CohomologyClass) = CohomologyClass(toric_variety(cc), coefficient_ring(toric_variety(cc))(c) * polynomial(cc))
 Base.:*(c::Rational{Int64}, cc::CohomologyClass) = CohomologyClass(toric_variety(cc), coefficient_ring(toric_variety(cc))(c) * polynomial(cc))
-Base.:*(c::fmpz, cc::CohomologyClass) = CohomologyClass(toric_variety(cc), coefficient_ring(toric_variety(cc))(c) * polynomial(cc))
-Base.:*(c::Int, cc::CohomologyClass) = CohomologyClass(toric_variety(cc), coefficient_ring(toric_variety(cc))(c) * polynomial(cc))
+Base.:*(c::T, cc::CohomologyClass) where {T <: IntegerUnion} = CohomologyClass(toric_variety(cc), coefficient_ring(toric_variety(cc))(c) * polynomial(cc))
 
 
 #################################
@@ -131,15 +130,7 @@ function Base.:*(cc1::CohomologyClass, cc2::CohomologyClass)
 end
 
 
-function Base.:^(cc::CohomologyClass, p::fmpz)
-    ring = cohomology_ring(toric_variety(cc))
-    if p == 0
-        return CohomologyClass(toric_variety(cc), one(ring))
-    end
-    poly = prod(polynomial(cc, ring) for i in 1:p)
-    return CohomologyClass(toric_variety(cc), poly)
-end
-Base.:^(cc::CohomologyClass, p::Int) = cc^fmpz(p)
+Base.:^(cc::CohomologyClass, p::T) where {T <: IntegerUnion} = CohomologyClass(toric_variety(cc), polynomial(cc)^p)
 
 
 ########################

--- a/src/ToricVarieties/CohomologyClasses/special_attributes.jl
+++ b/src/ToricVarieties/CohomologyClasses/special_attributes.jl
@@ -51,7 +51,7 @@ julia> polynomial(volume_form(hirzebruch_surface(5)))
     mc = ray_indices(maximal_cones(v))
     exponents = [fmpz(mc[1,i]) for i in 1:length(mc[1,:])]
     indets = gens(cohomology_ring(v))
-    poly = fmpz(1) * prod(indets[k]^exponents[k] for k in 1:length(exponents))
+    poly = prod(indets[k]^exponents[k] for k in 1:length(exponents))
     if iszero(poly) || degree(poly)[1] != dim(v)
         throw(ArgumentError("The volume class does not exist."))
     end

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -109,34 +109,6 @@ export is_finalized
 
 
 @doc Markdown.doc"""
-    set_coefficient_ring(v::AbstractNormalToricVariety, coefficient_ring::AbstractAlgebra.Ring)
-
-Allows to set the coefficient_ring. If the Cox ring of the variety has
-already been computed, we do not allow this to be changed.
-In this case an error is triggered.
-
-# Examples
-```jldoctest
-julia> C = Oscar.positive_hull([1 0]);
-
-julia> antv = AffineNormalToricVariety(C);
-
-julia> set_coefficient_ring(antv, ZZ)
-
-julia> coefficient_ring(antv) == ZZ
-true
-```
-"""
-function set_coefficient_ring(v::AbstractNormalToricVariety, coefficient_ring::AbstractAlgebra.Ring)
-    if is_finalized(v)
-        error("The coefficient ring cannot be modified since the toric variety is finalized.")
-    end
-    set_attribute!(v, :coefficient_ring, coefficient_ring)
-end
-export set_coefficient_ring
-
-
-@doc Markdown.doc"""
     set_coordinate_names(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
 
 Allows to set the names of the homogeneous coordinates.
@@ -203,10 +175,7 @@ export set_coordinate_names_of_torus
 
 @doc Markdown.doc"""
     coefficient_ring(v::AbstractNormalToricVariety)
-
-This method returns the coefficient_ring of the normal toric variety `v`.
-The default is the ring `QQ`.
-
+This method returns the coefficient_ring `QQ` of the normal toric variety `v`.
 # Examples
 ```jldoctest
 julia> C = Oscar.positive_hull([1 0]);
@@ -217,7 +186,7 @@ julia> coefficient_ring(antv) == QQ
 true
 ```
 """
-coefficient_ring(v::AbstractNormalToricVariety) = get_attribute!(v, :coefficient_ring, QQ)
+coefficient_ring(v::AbstractNormalToricVariety) = QQ
 
 
 @doc Markdown.doc"""
@@ -289,10 +258,8 @@ julia> p2 = projective_space(NormalToricVariety, 2);
 
 julia> set_coordinate_names(p2, ["y1", "y2", "y3"])
 
-julia> set_coefficient_ring(p2, ZZ)
-
 julia> cox_ring(p2)
-Multivariate Polynomial Ring in y1, y2, y3 over Integer Ring graded by 
+Multivariate Polynomial Ring in y1, y2, y3 over Rational Field graded by
   y1 -> [1]
   y2 -> [1]
   y3 -> [1]

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -92,7 +92,6 @@ function NormalToricVariety(C::Cone)
     set_attribute!(variety, :is_projective_space, false)
     set_attribute!(variety, :picard_group, free_abelian_group(0))
     
-    # return
     return variety
 end
 
@@ -148,15 +147,10 @@ A normal toric variety
 ```
 """
 function NormalToricVariety(PF::PolyhedralFan)
-    # construct the variety
     fan = Oscar.pm_object(PF)
     pmntv = Polymake.fulton.NormalToricVariety(fan)
     variety = NormalToricVariety(pmntv)
-    
-    # set attributes
     set_attribute!(variety, :fan, PF)
-    
-    # return
     return variety
 end
 
@@ -181,13 +175,8 @@ A normal toric variety
 ```
 """
 function NormalToricVariety(P::Polyhedron)
-    #construct the variety
     variety = NormalToricVariety(normal_fan(P))
-    
-    # set attributes
     set_attribute!(variety, :polyhedron, P)
-    
-    # return
     return variety
 end
 
@@ -244,26 +233,21 @@ A normal, affine, 2-dimensional toric variety
 ```
 """
 function affine_space(::Type{NormalToricVariety}, d::Int)
-    # construct the cone of the variety
-    C = positive_hull(identity_matrix(ZZ, d))
-    
     # construct the variety
+    C = positive_hull(identity_matrix(ZZ, d))
     fan = PolyhedralFan(C)
     pmntv = Polymake.fulton.NormalToricVariety(Oscar.pm_object(fan))
     variety = NormalToricVariety(pmntv)
     
-    # set known properties
+    # set known properties and attributes
     set_attribute!(variety, :isaffine, true)
     set_attribute!(variety, :iscomplete, false)
     set_attribute!(variety, :isprojective, false)
     set_attribute!(variety, :isprojective_space, false)
-    
-    # set attributes
     set_attribute!(variety, :fan, fan)
     set_attribute!(variety, :dim, d)
     set_attribute!(variety, :dim_of_torusfactor, 0)
     
-    # return the variety
     return variety
 end
 export affine_space
@@ -281,12 +265,9 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 ```
 """
 function projective_space(::Type{NormalToricVariety}, d::Int)
-    # construct the variety
     f = normal_fan(Oscar.simplex(d))
     pm_object = Polymake.fulton.NormalToricVariety(Oscar.pm_object(f))
     variety = NormalToricVariety(pm_object)
-    
-    # set properties
     set_attribute!(variety, :isaffine, false)
     set_attribute!(variety, :isprojective, true)
     set_attribute!(variety, :is_projective_space, true)
@@ -298,20 +279,14 @@ function projective_space(::Type{NormalToricVariety}, d::Int)
     set_attribute!(variety, :isgorenstein, true)
     set_attribute!(variety, :is_q_gorenstein, true)
     set_attribute!(variety, :isfano, true)
-    
-    # set general attributes
     set_attribute!(variety, :dim, d)
     set_attribute!(variety, :dim_of_torusfactor, 0)
     set_attribute!(variety, :euler_characteristic, d+1)
     set_attribute!(variety, :betti_number, fill(fmpz(1), d+1))
-    
-    # set groups and mappings
     set_attribute!(variety, :character_lattice, free_abelian_group(d))
     set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(d+1))
     set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group, identity_map(torusinvariant_weil_divisor_group(variety)))
     set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_picard_group, map_from_torusinvariant_weil_divisor_group_to_class_group(variety))
-    
-    # return the variety
     return variety
 end
 export projective_space
@@ -352,7 +327,7 @@ function hirzebruch_surface(r::Int)
         set_attribute!(variety, :isfano, false)
     end
     
-    # assign meaningful variables according to the rays
+    # assign *meaningful* variables
     vars = ["t1", "x1", "t2", "x2"]
     set_coordinate_names(variety, vars)
     
@@ -361,8 +336,6 @@ function hirzebruch_surface(r::Int)
     set_attribute!(variety, :dim_of_torusfactor, 0)
     set_attribute!(variety, :euler_characteristic, 4)
     set_attribute!(variety, :betti_number, [fmpz(1),fmpz(2),fmpz(1)])
-    
-    # set class and torusinvariant weil divisor group
     set_attribute!(variety, :torusinvariant_divisor_group, free_abelian_group(4))
     set_attribute!(variety, :class_group, free_abelian_group(2))
     
@@ -381,7 +354,6 @@ function hirzebruch_surface(r::Int)
     set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group, identity_map(torusinvariant_divisor_group(variety)))
     set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_picard_group, map_from_torusinvariant_weil_divisor_group_to_class_group(variety))
     
-    # return the result
     return variety
 end
 export hirzebruch_surface
@@ -504,7 +476,6 @@ function del_pezzo(b::Int)
     set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group, identity_map(torusinvariant_weil_divisor_group(variety)))
     set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_picard_group, map_from_torusinvariant_weil_divisor_group_to_class_group(variety))
     
-    # return the result
     return variety
 end
 export del_pezzo
@@ -556,7 +527,6 @@ function blowup_on_ith_minimal_torus_orbit(v::AbstractNormalToricVariety, n::Int
     weights = [map_from_torusinvariant_weil_divisor_group_to_class_group(new_variety)(x) for x in gens(torusinvariant_weil_divisor_group(new_variety))]
     set_attribute!(new_variety, :cox_ring_weights, weights)
     
-    # return variety
     return new_variety
 end
 export blowup_on_ith_minimal_torus_orbit

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -693,8 +693,7 @@ function NormalToricVarietyFromGLSM(charges::fmpz_mat)
     p = convex_hull(pts)
     return NormalToricVarietiesFromStarTriangulations(p)
 end
-NormalToricVarietyFromGLSM(charges::Vector{Vector{Int}}) = NormalToricVarietyFromGLSM(matrix(ZZ,charges))
-NormalToricVarietyFromGLSM(charges::Vector{Vector{fmpz}}) = NormalToricVarietyFromGLSM(matrix(ZZ,charges))
+NormalToricVarietyFromGLSM(charges::Vector{Vector{T}}) where {T <: IntegerUnion} = NormalToricVarietyFromGLSM(matrix(ZZ,charges))
 export NormalToricVarietyFromGLSM
 
 

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -181,9 +181,13 @@ A normal toric variety
 ```
 """
 function NormalToricVariety(P::Polyhedron)
-    fan = normal_fan(P)
-    variety = NormalToricVariety(fan)
+    #construct the variety
+    variety = NormalToricVariety(normal_fan(P))
+    
+    # set attributes
     set_attribute!(variety, :polyhedron, P)
+    
+    # return
     return variety
 end
 
@@ -521,7 +525,7 @@ julia> P2 = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
 julia> bP2 = blowup_on_ith_minimal_torus_orbit(P2,1,"e")
-A normal toric variety over QQ
+A normal toric variety
 
 julia> cox_ring(bP2)
 Multivariate Polynomial Ring in x2, x3, x1, e over Rational Field graded by
@@ -551,9 +555,6 @@ function blowup_on_ith_minimal_torus_orbit(v::AbstractNormalToricVariety, n::Int
     set_attribute!(new_variety, :coordinate_names, new_vars)
     weights = [map_from_torusinvariant_weil_divisor_group_to_class_group(new_variety)(x) for x in gens(torusinvariant_weil_divisor_group(new_variety))]
     set_attribute!(new_variety, :cox_ring_weights, weights)
-    if has_attribute(v, :coefficient_ring)
-        set_attribute!(new_variety, :coefficient_ring, coefficient_ring(v))
-    end
     
     # return variety
     return new_variety
@@ -720,28 +721,14 @@ function Base.show(io::IO, v::AbstractNormalToricVariety)
     
     push_attribute_if_exists!(properties_string, v, :isfano, "fano")
     
-    # dimension?
     if has_attribute(v, :dim)
         push!(properties_string, string(dim(v))*"-dimensional")
     end
     
-    # join with ","
     properties_string = [join(properties_string, ", ")]
+    push!(properties_string, "toric variety")
     
-    # add coefficient ring and torusfactor
-    if has_attribute(v, :coefficient_ring)
-        if coefficient_ring(v) == QQ
-            push!(properties_string, "toric variety over QQ")
-        elseif coefficient_ring(v) == ZZ
-            push!(properties_string, "toric variety over ZZ")
-        else
-            push!(properties_string, "toric variety over coefficient_ring(variety)")
-        end
-    else
-        push!(properties_string, "toric variety")
-    end
     push_attribute_if_exists!(properties_string, v, :hastorusfactor, "with torusfactor", "without torusfactor")
     
-    # print string
     join(io, properties_string, " ")
 end

--- a/src/ToricVarieties/ToricDivisorClasses/constructors.jl
+++ b/src/ToricVarieties/ToricDivisorClasses/constructors.jl
@@ -20,7 +20,7 @@ export ToricDivisorClass
 ######################
 
 @doc Markdown.doc"""
-    ToricDivisorClass(v::AbstractNormalToricVariety, coeffs::Vector{fmpz})
+    ToricDivisorClass(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
 
 Construct the toric divisor class associated to a list of integers which specify an element of the class group of the normal toric variety `v`.
 
@@ -33,23 +33,7 @@ julia> tdc = ToricDivisorClass(P2, class_group(P2)([fmpz(1)]))
 A divisor class on a normal toric variety
 ```
 """
-ToricDivisorClass(v::AbstractNormalToricVariety, coeffs::Vector{fmpz}) = ToricDivisorClass(v, class_group(v)(coeffs))
-
-@doc Markdown.doc"""
-    ToricDivisorClass(v::AbstractNormalToricVariety, coeffs::Vector{Int})
-
-Construct the toric divisor class associated to a list of integers which specify an element of the class group of the normal toric variety `v`.
-
-# Examples
-```jldoctest
-julia> P2 = projective_space(NormalToricVariety, 2)
-A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
-
-julia> tdc = ToricDivisorClass(P2, class_group(P2)([1]))
-A divisor class on a normal toric variety
-```
-"""
-ToricDivisorClass(v::AbstractNormalToricVariety, coeffs::Vector{Int}) = ToricDivisorClass(v, class_group(v)([fmpz(c) for c in coeffs]))
+ToricDivisorClass(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion} = ToricDivisorClass(v, class_group(v)([fmpz(c) for c in coeffs]))
 
 
 ######################
@@ -100,8 +84,7 @@ function Base.:-(tdc1::ToricDivisorClass, tdc2::ToricDivisorClass)
 end
 
 
-Base.:*(c::fmpz, tdc::ToricDivisorClass) = ToricDivisorClass(toric_variety(tdc), c * divisor_class(tdc))
-Base.:*(c::Int, tdc::ToricDivisorClass) = ToricDivisorClass(toric_variety(tdc), fmpz(c) * divisor_class(tdc))
+Base.:*(c::T, tdc::ToricDivisorClass) where {T <: IntegerUnion} = ToricDivisorClass(toric_variety(tdc), fmpz(c) * divisor_class(tdc))
 
 
 ########################

--- a/src/ToricVarieties/ToricDivisors/constructors.jl
+++ b/src/ToricVarieties/ToricDivisors/constructors.jl
@@ -6,7 +6,9 @@
            polymake_divisor::Polymake.BigObject
            toric_variety::AbstractNormalToricVariety
            coeffs::Vector{fmpz}
-           ToricDivisor(polymake_divisor::Polymake.BigObject, toric_variety::AbstractNormalToricVariety, coeffs::Vector{fmpz}) = new(polymake_divisor, toric_variety, coeffs)
+           ToricDivisor(polymake_divisor::Polymake.BigObject,
+                        toric_variety::AbstractNormalToricVariety,
+                        coeffs::Vector{T}) where {T <: IntegerUnion} = new(polymake_divisor, toric_variety, [fmpz(c) for c in coeffs])
 end
 export ToricDivisor
 
@@ -20,9 +22,11 @@ end
 ######################
 
 @doc Markdown.doc"""
-    ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{Int})
+    ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
 
-Construct the torus invariant divisor on the normal toric variety `v` as linear combination of the torus invariant prime divisors of `v`. The coefficients of thi linear combination are passed as list of integers as first argument.
+Construct the torus invariant divisor on the normal toric variety `v` as linear
+ combination of the torus invariant prime divisors of `v`. The coefficients of this
+ linear combination are passed as list of integers as first argument.
 
 # Examples
 ```jldoctest
@@ -30,9 +34,7 @@ julia> ToricDivisor(projective_space(NormalToricVariety, 2), [1,1,2])
 A torus-invariant, non-prime divisor on a normal toric variety
 ```
 """
-ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{Int}) = ToricDivisor(v, [fmpz(k) for k in coeffs])
-
-function ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{fmpz})
+function ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
     # check input
     if length(coeffs) != pm_object(v).N_RAYS
         throw(ArgumentError("Number of coefficients needs to match number of prime divisors!"))
@@ -61,7 +63,7 @@ export ToricDivisor
 ######################
 
 @doc Markdown.doc"""
-    DivisorOfCharacter(v::AbstractNormalToricVariety, character::Vector{Int})
+    DivisorOfCharacter(v::AbstractNormalToricVariety, character::Vector{T}) where {T <: IntegerUnion}
 
 Construct the torus invariant divisor associated to a character of the normal toric variety `v`.
 
@@ -71,7 +73,7 @@ julia> DivisorOfCharacter(projective_space(NormalToricVariety, 2), [1,2])
 A torus-invariant, non-prime divisor on a normal toric variety
 ```
 """
-function DivisorOfCharacter(v::AbstractNormalToricVariety, character::Vector{Int})
+function DivisorOfCharacter(v::AbstractNormalToricVariety, character::Vector{T}) where {T <: IntegerUnion}
     if length(character) != rank(character_lattice(v))
         throw(ArgumentError("Character must consist of $(rank(character_lattice(v))) integers!"))
     end
@@ -105,8 +107,7 @@ function Base.:-(td1::ToricDivisor, td2::ToricDivisor)
 end
 
 
-Base.:*(c::fmpz, td::ToricDivisor) = ToricDivisor(toric_variety(td), [c*x for x in coefficients(td)])
-Base.:*(c::Int, td::ToricDivisor) = ToricDivisor(toric_variety(td), [fmpz(c)*x for x in coefficients(td)])
+Base.:*(c::T, td::ToricDivisor) where {T <: IntegerUnion} = ToricDivisor(toric_variety(td), [fmpz(c)*x for x in coefficients(td)])
 
 
 ######################

--- a/src/ToricVarieties/ToricLineBundles/attributes.jl
+++ b/src/ToricVarieties/ToricLineBundles/attributes.jl
@@ -133,15 +133,15 @@ julia> basis_of_global_sections_via_rational_functions(l)
  1
 ```
 """
-@attr Vector function basis_of_global_sections_via_rational_functions(l::ToricLineBundle)
+@attr Vector{MPolyQuoElem{fmpq_mpoly}} function basis_of_global_sections_via_rational_functions(l::ToricLineBundle)
     if has_attribute(toric_variety(l), :vanishing_sets)
         tvs = vanishing_sets(toric_variety(l))[1]
         if contains(tvs, l)
-            return []
+            return MPolyQuoElem{fmpq_mpoly}[]
         end
     end
     characters = matrix(ZZ, lattice_points(polyhedron(toric_divisor(l))))
-    return [character_to_rational_function(toric_variety(l), vec([fmpz(c) for c in characters[i,:]])) for i in 1:nrows(characters)]
+    return MPolyQuoElem{fmpq_mpoly}[character_to_rational_function(toric_variety(l), vec([fmpz(c) for c in characters[i,:]])) for i in 1:nrows(characters)]
 end
 export basis_of_global_sections_via_rational_functions
 
@@ -181,16 +181,16 @@ julia> basis_of_global_sections(l)
  x1^2
 ```
 """
-@attr Vector function basis_of_global_sections_via_homogeneous_component(l::ToricLineBundle)
+@attr Vector{MPolyElem_dec{fmpq, fmpq_mpoly}} function basis_of_global_sections_via_homogeneous_component(l::ToricLineBundle)
     if has_attribute(toric_variety(l), :vanishing_sets)
         tvs = vanishing_sets(toric_variety(l))[1]
         if contains(tvs, l)
-            return []
+            return MPolyElem_dec{fmpq, fmpq_mpoly}[]
         end
     end
     hc = homogeneous_component(cox_ring(toric_variety(l)), divisor_class(l))
     generators = gens(hc[1])
-    return [hc[2](x) for x in generators]
+    return MPolyElem_dec{fmpq, fmpq_mpoly}[hc[2](x) for x in generators]
 end
 basis_of_global_sections(l::ToricLineBundle) = basis_of_global_sections_via_homogeneous_component(l)
 export basis_of_global_sections_via_homogeneous_component, basis_of_global_sections

--- a/src/ToricVarieties/ToricLineBundles/constructors.jl
+++ b/src/ToricVarieties/ToricLineBundles/constructors.jl
@@ -17,7 +17,7 @@ export ToricLineBundle
 ########################
 
 @doc Markdown.doc"""
-    ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{fmpz})
+    ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{T}) where {T <: IntegerUnion}
 
 Construct the line bundle on the abstract normal toric variety `v` with class `c`.
 
@@ -30,26 +30,7 @@ julia> l = ToricLineBundle(v, [fmpz(2)])
 A toric line bundle on a normal toric variety
 ```
 """
-function ToricLineBundle(v::AbstractNormalToricVariety, input_class::Vector{fmpz})
-    class = picard_group(v)(input_class)
-    return ToricLineBundle(v, class)
-end
-
-@doc Markdown.doc"""
-    ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{Int})
-
-Convenience method for ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{fmpz}).
-
-# Examples
-```jldoctest
-julia> v = projective_space(NormalToricVariety, 2)
-A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
-
-julia> l = ToricLineBundle(v, [2])
-A toric line bundle on a normal toric variety
-```
-"""
-function ToricLineBundle(v::AbstractNormalToricVariety, input_class::Vector{Int})
+function ToricLineBundle(v::AbstractNormalToricVariety, input_class::Vector{T}) where {T <: IntegerUnion}
     class = picard_group(v)(input_class)
     return ToricLineBundle(v, class)
 end

--- a/src/ToricVarieties/cohomCalg/VanishingSets/attributes.jl
+++ b/src/ToricVarieties/cohomCalg/VanishingSets/attributes.jl
@@ -19,7 +19,7 @@ julia> vs = vanishing_sets(dP1)
  A toric vanishing set for cohomology index 2
 
 julia> toric_variety(vs[3])
-A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety over QQ without torusfactor
+A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 ```
 """
 function toric_variety(tvs::ToricVanishingSet)

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -207,6 +207,7 @@ dP0 = NormalToricVariety(normal_fan(Oscar.simplex(2)))
 dP1 = NormalToricVariety([[1,0], [0,1], [-1,0], [-1,-1]], [[1,2],[2,3],[3,4],[4,1]])
 dP2 = NormalToricVariety([[1,0], [0,1], [-1,0], [-1,-1], [0,-1]], [[1,2],[2,3],[3,4],[4,5],[5,1]])
 dP3 = NormalToricVariety([[1,0], [1,1], [0,1], [-1,0], [-1,-1], [0,-1]], [[1,2],[2,3],[3,4],[4,5],[5,6],[6,1]])
+set_coordinate_names(dP3,["x1","e1","x2","e3","x3","e2"])
 
 @testset "Argument errors for del Pezzo surfaces" begin
     @test_throws ArgumentError del_pezzo(-1)
@@ -522,8 +523,8 @@ end
 
 @testset "Properties, attributes and arithmetics of cohomology classes" begin
     @test istrivial(c) == false
-    @test nrows(exponents(c)) == 1
-    @test length(coefficients(c)) == 1
+    @test nrows(exponents(c)) == 3
+    @test length(coefficients(c)) == 3
     @test fmpq(3) * c == fmpz(3) * c
     @test 2 * c != fmpz(3) * c2
     @test (c == c3) == false

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -12,7 +12,6 @@ antv4 = AffineNormalToricVariety(Oscar.positive_hull([1 0]))
 antv5 = AffineNormalToricVariety(Oscar.positive_hull([1 0; 0 1]))
 antv6 = NormalToricVariety([[1,0,0], [1,0,1], [1,1,1], [1,1,0]], [[1,2,3,4]])
 
-set_coefficient_ring(antv4, ZZ)
 set_coordinate_names(antv4, ["u"])
 set_coordinate_names_of_torus(antv4, ["u1","u2"])
 
@@ -55,7 +54,6 @@ end
     @test is_finalized(antv4) == true
     @test_throws ErrorException set_coordinate_names(antv4, ["u"])
     @test_throws ErrorException set_coordinate_names_of_torus(antv4, ["u1", "u2"])
-    @test_throws ErrorException set_coefficient_ring(antv4, ZZ)
 end
 
 @testset "Affine toric varieties with trivial toric ideal" begin
@@ -97,8 +95,6 @@ ntv2 = NormalToricVariety(Oscar.cube(2))
 ntv3 = NormalToricVarietyFromGLSM(matrix(ZZ, [[1,1,1]]))
 ntv4 = NormalToricVarietiesFromStarTriangulations(convex_hull([0 0 0; 0 0 1; 1 0 1; 1 1 1; 0 1 1]))
 ntv5 = NormalToricVariety(polarize(Polyhedron(Polymake.polytope.rand_sphere(5,60; seed=42))))
-
-set_coefficient_ring(ntv5, GF(13))
 
 @testset "Normal toric varieties from fans, triangulations and GLSMs" begin
     @test iscomplete(ntv) == true


### PR DESCRIPTION
- Cohomology classes defined by (equ. class of) polynomial.
- Fix coefficient ring to `Q`. (Method which accept ring as first argument, and thereby allow different coefficient rings/variable names are and will be supported in the future.)
- Type stable return value for basis of line bundle sections.
- Use `IntegerUnion` to simplify the code.

This PR contains the changes in https://github.com/oscar-system/Oscar.jl/pull/1279, which should be merged first. Once this is done, the changes in this very PR should close https://github.com/oscar-system/Oscar.jl/issues/1280 and https://github.com/oscar-system/Oscar.jl/issues/1257.