### PR TITLE
rearrange/extend G-set related code

### DIFF
--- a/docs/src/Groups/action.md
+++ b/docs/src/Groups/action.md
@@ -63,6 +63,7 @@ see [`action_homomorphism(Omega::GSetByElements{T}) where T<:GAPGroup`](@ref).
 
 ```@docs
 gset(G::GAPGroup, fun::Function, Omega)
+permutation
 action_homomorphism(Omega::GSetByElements{T}) where T<:GAPGroup
 orbit(Omega::GSetByElements{<:GAPGroup}, omega::T) where T
 orbit(G::PermGroup, omega)

--- a/docs/src/Groups/action.md
+++ b/docs/src/Groups/action.md
@@ -51,6 +51,25 @@ permuted
 on_indeterminates
 ```
 
+
+## G-Sets
+
+The idea behind G-sets is to have objects that encode the permutation action
+induced by a group (that need not be a permutation group) on a given set.
+A G-set provides an explicit bijection between the elements of the set and
+the corresponding set of positive integers on which the induced permutation
+group acts,
+see [`action_homomorphism(Omega::GSetByElements{T}) where T<:GAPGroup`](@ref).
+
+```@docs
+gset(G::GAPGroup, fun::Function, Omega)
+action_homomorphism(Omega::GSetByElements{T}) where T<:GAPGroup
+orbit(Omega::GSetByElements{<:GAPGroup}, omega::T) where T
+orbit(G::PermGroup, omega)
+orbits(Omega::T) where T <: GSetByElements{TG} where TG <: GAPGroup
+```
+
+
 ## Stabilizers
 
 ```@docs

--- a/docs/src/Groups/permgroup.md
+++ b/docs/src/Groups/permgroup.md
@@ -117,6 +117,6 @@ isregular(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
 issemiregular(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
 blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
 maximal_blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
-representatives_minimal_blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
+minimal_block_reps(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
 all_blocks(G::PermGroup)
 ```

--- a/docs/src/Groups/subgroups.md
+++ b/docs/src/Groups/subgroups.md
@@ -56,7 +56,7 @@ minimal_normal_subgroups
 characteristic_subgroups
 derived_series
 sylow_system
-hall_subgroups_representatives
+hall_subgroup_reps
 hall_system
 complement_system
 ```

--- a/experimental/GaloisGrp/GaloisGrp.jl
+++ b/experimental/GaloisGrp/GaloisGrp.jl
@@ -754,7 +754,7 @@ function set_orbit(G::PermGroup, H::PermGroup)
   #    http://dblp.uni-trier.de/db/journals/jsc/jsc79.html#Elsenhans17
   # https://doi.org/10.1016/j.jsc.2016.02.005
 
-  l = low_index_subgroups(H, 2*degree(G)^2)
+  l = low_index_subgroup_reps(H, 2*degree(G)^2)
   S, g = slpoly_ring(ZZ, degree(G), cached = false)
 
   sort!(l, lt = (a,b) -> isless(order(b), order(a)))
@@ -762,7 +762,7 @@ function set_orbit(G::PermGroup, H::PermGroup)
     O = orbits(U)
     for o in O
       #TODO: should use orbits of Set(o)...
-      f = sum(g[elements(o)])
+      f = sum(g[collect(o)])
       oH = probable_orbit(H, f)
       oG = probable_orbit(G, f, limit = length(oH)+5)
       if length(oH) < length(oG)
@@ -774,7 +774,7 @@ function set_orbit(G::PermGroup, H::PermGroup)
             return true, I
           end
         end
-        f = prod(g[elements(o)])
+        f = prod(g[collect(o)])
         oH = probable_orbit(H, f)
         I = sum(oH)
         if isprobably_invariant(I, H) &&
@@ -809,8 +809,8 @@ function invariant(G::PermGroup, H::PermGroup)
 
   if !istransitive(G) 
     @vprint :GaloisInvariant 2 "both groups are intransitive\n"
-    OG = [sort(elements(x)) for x = orbits(G)]
-    OH = [sort(elements(x)) for x = orbits(H)]
+    OG = [sort(collect(x)) for x = orbits(G)]
+    OH = [sort(collect(x)) for x = orbits(H)]
     d = setdiff(OH, OG)
     if length(d) > 0
       @vprint :GaloisInvariant 2 "groups have different orbits\n"
@@ -825,7 +825,7 @@ function invariant(G::PermGroup, H::PermGroup)
         @vprint :GaloisInvariant 2 "differ on action on $o, recursing\n"
         @hassert :GaloisInvariant 0 ismaximal(hG, hH)
         I = invariant(hG, hH)
-        return evaluate(I, g[elements(o)])
+        return evaluate(I, g[collect(o)])
       end
     end
     @vprint :GaloisInvariant 2 "going transitive...\n"
@@ -840,7 +840,7 @@ function invariant(G::PermGroup, H::PermGroup)
     I = invariant(GG, HH)
     ex = 1
     while true
-      J = evaluate(I, [sum(g[o])^ex for o = elements(os)])
+      J = evaluate(I, [sum(g[o])^ex for o = collect(os)])
       if !isprobably_invariant(J, G)
         I = J
         break
@@ -866,8 +866,6 @@ function invariant(G::PermGroup, H::PermGroup)
   bH = all_blocks(H)
 
   d = setdiff(bH, bG)
-#T GAP's AllBlocks: compatible for G and H?
-#T                  ("representatives" or "smallest representatives"?)
   @vprint :GaloisInvariant 2 "Have block systems, they differ at $d\n"
   if length(d) > 0
     @vprint :GaloisInvariant 3  "using F-invar\n"

--- a/experimental/GaloisGrp/GaloisGrp.jl
+++ b/experimental/GaloisGrp/GaloisGrp.jl
@@ -762,7 +762,7 @@ function set_orbit(G::PermGroup, H::PermGroup)
     O = orbits(U)
     for o in O
       #TODO: should use orbits of Set(o)...
-      f = sum(g[o])
+      f = sum(g[elements(o)])
       oH = probable_orbit(H, f)
       oG = probable_orbit(G, f, limit = length(oH)+5)
       if length(oH) < length(oG)
@@ -774,7 +774,7 @@ function set_orbit(G::PermGroup, H::PermGroup)
             return true, I
           end
         end
-        f = prod(g[o])
+        f = prod(g[elements(o)])
         oH = probable_orbit(H, f)
         I = sum(oH)
         if isprobably_invariant(I, H) &&
@@ -809,8 +809,8 @@ function invariant(G::PermGroup, H::PermGroup)
 
   if !istransitive(G) 
     @vprint :GaloisInvariant 2 "both groups are intransitive\n"
-    OG = [sort(x) for x = orbits(G)]
-    OH = [sort(x) for x = orbits(H)]
+    OG = [sort(elements(x)) for x = orbits(G)]
+    OH = [sort(elements(x)) for x = orbits(H)]
     d = setdiff(OH, OG)
     if length(d) > 0
       @vprint :GaloisInvariant 2 "groups have different orbits\n"
@@ -825,7 +825,7 @@ function invariant(G::PermGroup, H::PermGroup)
         @vprint :GaloisInvariant 2 "differ on action on $o, recursing\n"
         @hassert :GaloisInvariant 0 ismaximal(hG, hH)
         I = invariant(hG, hH)
-        return evaluate(I, g[o])
+        return evaluate(I, g[elements(o)])
       end
     end
     @vprint :GaloisInvariant 2 "going transitive...\n"
@@ -866,6 +866,8 @@ function invariant(G::PermGroup, H::PermGroup)
   bH = all_blocks(H)
 
   d = setdiff(bH, bG)
+#T GAP's AllBlocks: compatible for G and H?
+#T                  ("representatives" or "smallest representatives"?)
   @vprint :GaloisInvariant 2 "Have block systems, they differ at $d\n"
   if length(d) > 0
     @vprint :GaloisInvariant 3  "using F-invar\n"

--- a/experimental/GaloisGrp/Group.jl
+++ b/experimental/GaloisGrp/Group.jl
@@ -1,59 +1,3 @@
-"""
-Tests if `U` is a maximal subgroup of `G`. Suboptimal algorithm...
-  Missing in GAP
-"""
-function ismaximal(G::Oscar.PermGroup, U::Oscar.PermGroup)
-  if !issubgroup(G, U)[1]
-    return false
-  end
-  if order(G)//order(U) < 100
-    t = right_transversal(G, U)[2:end] #drop the identity
-    if any(x->order(sub(G, vcat(gens(U), [x]))[1]) < order(G), t)
-      return false
-    end
-    return true
-  end
-  S = maximal_subgroup_reps(G) 
-  error("not done yet")
-  if any(x->x == U, S)
-    return true
-  end
-  return false
-end
-
-"""
-Tests if a conjugate of `V` by some element in `G` is a subgroup of `U`.
-  Missing from GAP
-"""
-function isconjugate_subgroup(G::Oscar.PermGroup, U::Oscar.PermGroup, V::Oscar.PermGroup)
-  if order(V) == 1
-    return true, one(U)
-  end
-  local sigma
-  while true
-    sigma = rand(V)
-    if order(sigma) > 1
-      break
-    end
-  end
-  s = short_right_transversal(G, U, sigma)
-  for t = s
-    if issubgroup(U, V^inv(t))[1]
-      return true, inv(t)
-    end
-  end
-  return false, one(U)
-end
-
-export maximal_subgroup_reps
-function maximal_subgroup_reps(G::Oscar.GAPGroup)
-  return Oscar._as_subgroups(G, GAP.Globals.MaximalSubgroupClassReps(G.X))
-end
-
-function low_index_subgroups(G::PermGroup, n::Int)
-  ll = GAP.Globals.LowIndexSubgroups(G.X, n)
-  return [Oscar._as_subgroup(G, x)[1] for x = ll]
-end
 
 """
 An ascending chain of minimal supergroups linking `U` and `G`.
@@ -74,108 +18,18 @@ function maximal_subgroup_chain(G::PermGroup, U::PermGroup)
   return [Oscar._as_subgroup(G, x)[1] for x = ll]
 end
 
-# TODO: add a GSet Julia type which does something similar Magma's,
-# or also to GAP's ExternalSet (but don't use ExternalSet, to avoid the overhead)
-
-# TODO: add type BlockSystem
-
-# TODO: add lots of more orbit related stuff
-
-#provided by Thomas Breuer:
-
-Hecke.orbit(G::PermGroup, i::Int) = Vector{Int}(GAP.Globals.Orbit(G.X, GAP.Obj(i)))
-orbits(G::PermGroup) = Vector{Vector{Int}}(GAP.Globals.Orbits(G.X, GAP.GapObj(1:degree(G))))
-
-function action_homomorphism(G::PermGroup, omega::AbstractVector{Int})
-  mp = GAP.Globals.ActionHomomorphism(G.X, GAP.GapObj(omega))
-  if mp == GAP.Globals.fail throw(ArgumentError("Invalid input")) end
-  H = PermGroup(GAP.Globals.Range(mp))
-  return GAPGroupHomomorphism(G, H, mp)
-end
-
 function block_system(G::PermGroup, B::Vector{Int})
-  orb = GAP.Globals.Orbit(G.X, GAP.GapObj(B), GAP.Globals.OnSets)
-  return Vector{Vector{Int}}(orb)
+  return elements(orbit(G, on_sets, B))
 end
 
 # given a perm group G and a block B, compute a homomorphism into Sym(B^G)
 function action_on_blocks(G::PermGroup, B::Vector{Int})
-  orb = GAP.Globals.Orbit(G.X, GAP.GapObj(B), GAP.Globals.OnSets)
-  act = GAP.Globals.ActionHomomorphism(G.X, orb, GAP.Globals.OnSets)
-  H = GAPWrap.Image(act)
-  T = Oscar._get_type(H)
-  H = T(H)
-  return Oscar.GAPGroupHomomorphism(G, H, act)
+  Omega = gset(G, [B])
+  return action_homomorphism(Omega)
 end
 
 function action_on_block_system(G::PermGroup, B::Vector{Vector{Int}})
-  orb = GAP.GapObj(B, recursive = true)
-  act = GAP.Globals.ActionHomomorphism(G.X, orb, GAP.Globals.OnSets)
-  H = GAPWrap.Image(act)
-  T = Oscar._get_type(H)
-  H = T(H)
-  return Oscar.GAPGroupHomomorphism(G, H, act)
-end
-
-
-@doc Markdown.doc"""
-    short_right_transversal(G::PermGroup, H::PermGroup, s::PermGroupElem) ->
-
-Determines representatives `g` for all right-cosets of `G` modulo `H`
-  such that `H^g` contains the element `s`.
-"""
-function short_right_transversal(G::PermGroup, H::PermGroup, s::PermGroupElem)
-  C = conjugacy_classes(H)
-  cs = cycle_structure(s)
-  can = PermGroupElem[]
-  for c in C
-    r = representative(c)
-    if cs == cycle_structure(r)
-      push!(can, r)
-    end
-  end
-
-  R = PermGroupElem[]
-  for c in can
-    success, d = representative_action(G, c, s)
-    if success
-      push!(R, d)
-      @assert c^R[end] == s
-    end
-  end
-
-  S = PermGroupElem[]
-  C = centralizer(G, s)[1]
-  for r in R
-    CH = centralizer(H^r, s)[1]
-    for t = right_transversal(C, CH)
-      push!(S, r*t)
-    end
-  end
-
-  return S
-end
-
-"""
-Computes representatives (under conjugation) for all subgroups of
-the given group. If geven, only subgroups of a certain order
-are returned.
-"""
-function subgroup_reps(G::PermGroup; order::fmpz = fmpz(-1))
-  C = GAP.Globals.ConjugacyClassesSubgroups(G.X)
-  C = map(GAP.Globals.Representative, C)
-  if order != -1
-    C = [x for x = C if GAP.Globals.Order(x) == order]
-  end
-  return [Oscar._as_subgroup(G, x)[1] for x = C]
-end
-
-"""
-Computes the action of G on the right cosets
-"""
-function right_coset_action(G::PermGroup, U::PermGroup)
-  mp = GAP.Globals.FactorCosetAction(G.X, U.X)
-  if mp == GAP.Globals.fail throw(ArgumentError("Invalid input")) end
-  H = PermGroup(GAP.Globals.Range(mp))
-  return GAPGroupHomomorphism(G, H, mp)
+  Omega = gset(G, B)
+  set_attribute!(Omega, :elements => Omega.seeds)
+  return action_homomorphism(Omega)
 end

--- a/experimental/GaloisGrp/Group.jl
+++ b/experimental/GaloisGrp/Group.jl
@@ -19,7 +19,7 @@ function maximal_subgroup_chain(G::PermGroup, U::PermGroup)
 end
 
 function block_system(G::PermGroup, B::Vector{Int})
-  return elements(orbit(G, on_sets, B))
+  return collect(orbit(G, on_sets, B))
 end
 
 # given a perm group G and a block B, compute a homomorphism into Sym(B^G)

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -28,7 +28,7 @@ export
     gen,
     gens, has_gens,
     hall_subgroup,
-    hall_subgroups_representatives,
+    hall_subgroup_reps,
     hall_system, has_hall_system, set_hall_system,
     inv!,
     isalmostsimple, has_isalmostsimple, set_isalmostsimple,
@@ -42,7 +42,7 @@ export
     is_quasisimple, hasis_quasisimple, setis_quasisimple,
     issimple, has_issimple, set_issimple,
     is_sporadic_simple, hasis_sporadic_simple, setis_sporadic_simple,
-    low_index_subgroups,
+    low_index_subgroup_reps,
     maximal_subgroup_reps,
     moved_points, has_moved_points, set_moved_points,
     mul,
@@ -483,6 +483,7 @@ julia> C = conjugacy_class(G, G([2, 1, 3, 4]))
 julia> representative(C)
 (1,2)
 
+```
 """
 representative(C::GroupConjClass) = C.repr
 
@@ -501,6 +502,7 @@ julia> C = conjugacy_class(G, G([2, 1, 3, 4]))
 julia> acting_group(C) === G
 true
 
+```
 """
 acting_group(C::GroupConjClass) = C.X
 
@@ -518,6 +520,7 @@ julia> G = symmetric_group(4);
 julia> C = conjugacy_class(G, G([2, 1, 3, 4]))
 (1,2) ^ Sym( [ 1 .. 4 ] )
 
+```
 """
 function conjugacy_class(G::GAPGroup, g::GAPGroupElem)
    return GroupConjClass(G, g, GAP.Globals.ConjugacyClass(G.X,g.X)::GapObj)
@@ -613,6 +616,7 @@ julia> conjugacy_classes_subgroups(G)
  Group([ (1,2,3) ]) ^ Sym( [ 1 .. 3 ] )
  Group([ (1,2,3), (2,3) ]) ^ Sym( [ 1 .. 3 ] )
 
+```
 """
 function conjugacy_classes_subgroups(G::GAPGroup)
   L = Vector{GapObj}(GAP.Globals.ConjugacyClassesSubgroups(G.X)::GapObj)
@@ -640,6 +644,7 @@ julia> subgroup_reps(G, order = fmpz(2))
 1-element Vector{PermGroup}:
  Group([ (2,3) ])
 
+```
 """
 function subgroup_reps(G::GAPGroup; order::fmpz = fmpz(-1))
   C = GAP.Globals.ConjugacyClassesSubgroups(G.X)
@@ -657,7 +662,14 @@ Return the vector of all conjugacy classes of maximal subgroups of G.
 
 # Examples
 ```jldoctest
+julia> G = symmetric_group(3);
 
+julia> conjugacy_classes_maximal_subgroups(G)
+2-element Vector{GroupConjClass{PermGroup, PermGroup}}:
+ Group([ (1,2,3) ]) ^ Sym( [ 1 .. 3 ] )
+ Group([ (2,3) ]) ^ Sym( [ 1 .. 3 ] )
+
+```
 """
 function conjugacy_classes_maximal_subgroups(G::GAPGroup)
   L = Vector{GapObj}(GAP.Globals.ConjugacyClassesMaximalSubgroups(G.X)::GapObj)
@@ -678,13 +690,14 @@ julia> maximal_subgroup_reps(symmetric_group(4))
  Group([ (3,4), (1,4)(2,3), (1,3)(2,4) ])
  Group([ (3,4), (2,4,3) ])
 
+```
 """
 function maximal_subgroup_reps(G::GAPGroup)
   return Oscar._as_subgroups(G, GAP.Globals.MaximalSubgroupClassReps(G.X))
 end
 
 """
-    low_index_subgroups(G::GAPGroup, n::Int)
+    low_index_subgroup_reps(G::GAPGroup, n::Int)
 
 Return a vector of representatives (under conjugation) for all subgroups
 of index at most `n` in `G`.
@@ -693,14 +706,15 @@ of index at most `n` in `G`.
 ```jldoctest
 julia> G = symmetric_group(5);
 
-julia> low_index_subgroups(G, 5)
+julia> low_index_subgroup_reps(G, 5)
 3-element Vector{PermGroup}:
  Sym( [ 1 .. 5 ] )
  Alt( [ 1 .. 5 ] )
  Sym( [ 1 .. 4 ] )
 
+```
 """
-function low_index_subgroups(G::PermGroup, n::Int)
+function low_index_subgroup_reps(G::PermGroup, n::Int)
   ll = GAP.Globals.LowIndexSubgroups(G.X, n)
   return [Oscar._as_subgroup(G, x)[1] for x = ll]
 end
@@ -720,6 +734,7 @@ Group([ (1,2,3) ])
 julia> conjugate_group(H, gen(G, 1))
 Group([ (2,3,4) ])
 
+```
 """
 function conjugate_group(G::T, x::GAPGroupElem) where T <: GAPGroup
   check_parent(G, x) || error("G and x are not compatible")
@@ -757,6 +772,7 @@ Group([ (1,2)(3,4) ])
 julia> isconjugate(G, H, K)
 false
 
+```
 """
 isconjugate(G::GAPGroup, H::GAPGroup, K::GAPGroup) = GAPWrap.IsConjugate(G.X,H.X,K.X)
 
@@ -1061,7 +1077,7 @@ function sylow_subgroup(G::GAPGroup, p::IntegerUnion)
    return _as_subgroup(G,GAP.Globals.SylowSubgroup(G.X,GAP.Obj(p)))
 end
 
-# no longer documented, better use `hall_subgroups_representatives`
+# no longer documented, better use `hall_subgroup_reps`
 function hall_subgroup(G::GAPGroup, P::AbstractVector{<:IntegerUnion})
    P = unique(P)
    all(isprime, P) || throw(ArgumentError("The integers must be prime"))
@@ -1070,7 +1086,7 @@ function hall_subgroup(G::GAPGroup, P::AbstractVector{<:IntegerUnion})
 end
 
 """
-    hall_subgroups_representatives(G::Group, P::AbstractVector{<:IntegerUnion})
+    hall_subgroup_reps(G::Group, P::AbstractVector{<:IntegerUnion})
 
 Return a vector that contains representatives of conjugacy classes of
 Hall `P`-subgroups of the finite group `G`, for a vector `P` of primes.
@@ -1085,7 +1101,7 @@ up to conjugacy.
 ```jldoctest
 julia> g = dihedral_group(30);
 
-julia> h = hall_subgroups_representatives(g, [2, 3]);
+julia> h = hall_subgroup_reps(g, [2, 3]);
 
 julia> (length(h), order(h[1]))
 (1, 6)
@@ -1093,17 +1109,17 @@ julia> (length(h), order(h[1]))
 julia> g = GL(3, 2)
 GL(3,2)
 
-julia> h = hall_subgroups_representatives(g, [2, 3]);
+julia> h = hall_subgroup_reps(g, [2, 3]);
 
 julia> (length(h), order(h[1]))
 (2, 24)
 
-julia> h = hall_subgroups_representatives(g, [2, 7]); length(h)
+julia> h = hall_subgroup_reps(g, [2, 7]); length(h)
 0
 
 ```
 """
-function hall_subgroups_representatives(G::GAPGroup, P::AbstractVector{<:IntegerUnion})
+function hall_subgroup_reps(G::GAPGroup, P::AbstractVector{<:IntegerUnion})
    P = unique(P)
    all(isprime, P) || throw(ArgumentError("The integers must be prime"))
    res_gap = GAP.Globals.HallSubgroup(G.X, GAP.julia_to_gap(P))::GapObj
@@ -1115,6 +1131,9 @@ function hall_subgroups_representatives(G::GAPGroup, P::AbstractVector{<:Integer
      return [_as_subgroup_bare(G, res_gap)]
    end
 end
+
+hall_subgroups_representatives(G::GAPGroup, P::AbstractVector{<:IntegerUnion}) = hall_subgroup_reps(G,P)
+# use @alias?
 
 @doc Markdown.doc"""
     sylow_system(G::Group)

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -1,3 +1,10 @@
+export on_indeterminates,
+       on_sets,
+       on_sets_sets,
+       on_tuples,
+       permuted,
+       right_coset_action
+
 """
 A *group action* of a group G on a set Ω (from the right) is defined by
 a map μ: Ω × G → Ω that satisfies the compatibility conditions
@@ -33,8 +40,6 @@ The following ones are commonly used.
 ##  The idea is to delegate the action of `GAPGroupElem` objects
 ##  on `GAP.GapObj` objects to the corresponding GAP action,
 ##  and to implement the action on native Julia objects case by case.
-
-export on_tuples, on_sets, on_sets_sets, on_indeterminates, permuted
 
 """
 We try to avoid introducing `on_points` and `on_right`.
@@ -393,3 +398,33 @@ stabilizer(G::MatrixGroup{ET,MT}, pnt::AbstractAlgebra.Generic.FreeModuleElem{ET
 stabilizer(G::MatrixGroup{ET,MT}, pnt::Vector{AbstractAlgebra.Generic.FreeModuleElem{ET}}) where {ET,MT} = stabilizer(G, pnt, on_tuples)
 
 stabilizer(G::MatrixGroup{ET,MT}, pnt::AbstractSet{AbstractAlgebra.Generic.FreeModuleElem{ET}}) where {ET,MT} = stabilizer(G, pnt, on_sets)
+
+
+"""
+    right_coset_action(G::T, U::T) where T <: GAPGroup
+
+Compute the action of `G` on the right cosets of its subgroup `U`.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(6);
+
+julia> H = sylow_subgroup(G, 2)[1]
+Group([ (1,2), (3,4), (1,3)(2,4), (5,6) ])
+
+julia> index(G, H)
+45
+
+julia> act = right_coset_action(G, H);
+
+julia> degree(codomain(act)) == index(G, H)
+true
+
+```
+"""
+function right_coset_action(G::T, U::T) where T <: GAPGroup
+  mp = GAP.Globals.FactorCosetAction(G.X, U.X)
+  mp == GAP.Globals.fail && throw(ArgumentError("Invalid input"))
+  H = PermGroup(GAP.Globals.Range(mp))
+  return GAPGroupHomomorphism(G, H, mp)
+end

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -4,6 +4,8 @@
 # but that local replacements by pure Julia code (independent of GAP)
 # are welcome.
 
+import Hecke.orbit
+
 export
     all_blocks,
     blocks,
@@ -65,6 +67,35 @@ acting_group(gset::GSetByElements) = gset.group
 ##
 ##  general method with explicit action function
 
+"""
+    gset(G::GAPGroup[, fun::Function], Omega)
+
+Return the G-set that consists of the closure of the seeds `Omega`
+under the action of `G` defined by `fun`.
+
+This means that the result contains all elements `fun(omega, g)`
+for `omega` in `Omega` and `g` in `G`.
+
+`fun` can be omitted if the element type of `Omega` implies
+a reasonable default,
+for example, if `G` is a `PermGroup` and `Omega` is a `Vector{T}` where
+`T` is one of `Int`, `Set{Int}`, `Vector{Int}`.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(4);
+
+julia> length(gset(G, [[1]]))  # natural action
+4
+
+julia> length(gset(G, [[1, 2]]))  # action on ordered pairs
+12
+
+julia> length(gset(G, on_sets, [[1, 2]]))  # action on unordered pairs
+6
+
+```
+"""
 gset(G::GAPGroup, fun::Function, Omega) = GSetByElements(G, fun, Omega)
 
 
@@ -153,7 +184,7 @@ end
 
 Base.in(omega::ElementOfGSet, Omega::GSet) = Base.in(omega.obj, Omega)
 
-Hecke.orbit(omega::ElementOfGSet) = Hecke.orbit(omega.gset, omega.obj)
+orbit(omega::ElementOfGSet) = orbit(omega.gset, omega.obj)
 
 
 unwrap(omega::Any) = omega
@@ -165,21 +196,72 @@ unwrap(omega::ElementOfGSet) = omega.obj
 ##
 ##  `:orbit`
 
-function Hecke.orbit(Omega::GSetByElements{<:GAPGroup}, omega)
+"""
+    orbit(G::PermGroup[, fun::Function], omega)
+
+Return the G-set that consists of the images of `omega`
+under the action of `G` defined by `fun`.
+
+This means that the result contains all elements `fun(omega, g)`
+for `g` in `G`.
+
+`fun` can be omitted if the type of `Omega` implies a reasonable default,
+for example, if `G` is a `PermGroup` and `omega` is
+one of `Int`, `Set{Int}`, `Vector{Int}`.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(4);
+
+julia> length(orbit(G, 1))
+4
+
+julia> length(orbit(G, [1, 2]))
+12
+
+julia> length(orbit(G, on_sets, [1, 2]))
+6
+
+```
+"""
+orbit(G::PermGroup, omega) = gset_by_type(G, [omega], typeof(omega))
+
+orbit(G::PermGroup, fun::Function, omega) = GSetByElements(G, fun, [omega])
+
+"""
+    orbit(Omega::GSet, omega::T) where T
+
+Return the G-set that consists of the elements `fun(omega, g)` where
+`g` is in the group of `Omega` and `fun` is the underlying action of `Omega`.
+
+# Examples
+```jldoctest
+julia> G = sylow_subgroup(symmetric_group(6), 2)[1]
+Group([ (1,2), (3,4), (1,3)(2,4), (5,6) ])
+
+julia> Omega = gset(G, [1, 5]);
+
+julia> length(orbit(Omega, 1))
+4
+
+```
+"""
+function orbit(Omega::GSetByElements{<:GAPGroup}, omega::T) where T
     G = Omega.group
-    acts = GAP.julia_to_gap(gens(G))
-    gfun = GAP.julia_to_gap(Omega.action_function)
+    acts = GapObj(gens(G))
+    gfun = GapObj(Omega.action_function)
 
     # The following works only because GAP does not check
     # whether the given (dummy) group 'G.X' fits to the given generators,
     # or whether the elements of 'acts' are group elements.
-    orb = GAP.gap_to_julia(GAP.Globals.Orbit(G.X, omega, acts, acts, gfun))
+    orb = Vector{T}(GAP.Globals.Orbit(G.X, omega, acts, acts, gfun)::GapObj)
 
     res = as_gset(Omega.group, Omega.action_function, orb)
     # We know that this G-set is transitive.
     set_attribute!(res, :orbits => [orb])
     return res
 end
+#T check whether omega lies in Omega?
 
 # simpleminded alternative directly in Julia
 # In fact, '<:GAPGroup' is not used at all in this function.
@@ -205,28 +287,60 @@ function orbit_via_Julia(Omega::GSetByElements{<:GAPGroup}, omega)
 end
 
 
-#TODO: - Currently this conflicts with a method in
-#        `experimental/GaloisGrp/Group.jl`
-#      - Provide more convenience methods for "natural" actions",
-#        as for `gset`?
-# Hecke.orbit(G::PermGroup, pt::T) where {T<:IntegerUnion} = GSetByElements(G, [pt])
-
-
 #############################################################################
 ##
 ##  `:orbits` a vector of G-sets
 
-@attr Vector{Any} function orbits(Omega::GSetByElements{<:GAPGroup})
+"""
+    orbits(Omega::GSet)
+
+Return the vector of transitive G-sets in `Omega`.
+
+# Examples
+```jldoctest
+julia> G = sylow_subgroup(symmetric_group(6), 2)[1]
+Group([ (1,2), (3,4), (1,3)(2,4), (5,6) ])
+
+julia> orbs = orbits(gset(G));
+
+julia> map(elements, orbs)
+2-element Vector{Vector{Int64}}:
+ [1, 2, 3, 4]
+ [5, 6]
+
+```
+"""
+@attr Vector{GSetByElements{TG}} function orbits(Omega::T) where T <: GSetByElements{TG} where TG <: GAPGroup
   G = Omega.group
-  # TODO: tighten the return type
-  orbs = []
+  orbs = T[]
   for p in Omega.seeds
     if all(o -> !(p in o), orbs)
-      push!(orbs, Hecke.orbit(Omega, p))
+      push!(orbs, orbit(Omega, p))
     end
   end
   return orbs
 end
+
+"""
+    orbits(G::PermGroup)
+
+Return the orbits of the natural G-set of `G`.
+
+# Examples
+```jldoctest
+julia> G = sylow_subgroup(symmetric_group(6), 2)[1]
+Group([ (1,2), (3,4), (1,3)(2,4), (5,6) ])
+
+julia> orbs = orbits(G);
+
+julia> map(length, orbs)
+2-element Vector{Int64}:
+ 4
+ 2
+
+```
+"""
+@attr Vector{GSetByElements{PermGroup}} orbits(G::PermGroup) = orbits(gset(G))
 
 
 #############################################################################
@@ -263,8 +377,9 @@ end
 ##
 ##  action homomorphisms
 
-# The following must be executed at runtime.
-# (Eventually put it into some `__init__`.)
+# Use a GAP attribute for caching the mapping.
+# The following must be executed at runtime,
+# the function gets called in Oscar's `__init__`.
 function __init_JuliaData()
     if ! hasproperty(GAP.Globals, :JuliaData)
       GAP.evalstr("""
@@ -280,6 +395,44 @@ end );
     end
 end
 
+"""
+    action_homomorphism(Omega::GSetByElements{T}) where T<:GAPGroup
+
+Return the group homomorphism `act` with domain `G = Omega.group`
+and codomain `symmetric_group(n)` that describes the action of `G` on `Omega`,
+where `Omega` has `n` elements.
+
+This means that if an element `g` in `G` maps `elements(Omega)[i]` to
+`elements(Omega)[j]` then `act(g)` maps `i` to `j`.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(6);
+
+julia> Omega = gset(G, [Set([1, 2])]);  # action on unordered pairs
+
+julia> acthom = action_homomorphism(Omega)
+Group homomorphism from 
+Sym( [ 1 .. 6 ] )
+to
+Sym( [ 1 .. 15 ] )
+
+julia> g = gens(G)[1]
+(1,2,3,4,5,6)
+
+julia> elms = elements(Omega);
+
+julia> actg = acthom(g)
+(1,2,3,5,7,10)(4,6,8,11,14,13)(9,12,15)
+
+julia> elms[1]^g == elms[2]
+true
+
+julia> 1^actg == 2
+true
+
+```
+"""
 @attr GAPGroupHomomorphism{T, PermGroup} function action_homomorphism(Omega::GSetByElements{T}) where T<:GAPGroup
   G = Omega.group
   omega_list = GAP.julia_to_gap(elements(Omega))
@@ -304,7 +457,6 @@ end
   # (Yes, this is also overhead.
   # The alternative would be to create a new type of Oscar homomorphism,
   # which uses `permutation` or something better for mapping elements.)
-  __init_JuliaData()
   GAP.Globals.SetJuliaData(acthom, GAP.julia_to_gap([Omega, G]))
 
   sym = get_attribute!(Omega, :action_range) do
@@ -313,12 +465,36 @@ end
   return GAPGroupHomomorphism(G, sym, acthom)
 end
 
+# for convenience: create the G-set on the fly
+function action_homomorphism(G::PermGroup, Omega)
+  return action_homomorphism(gset_by_type(G, Omega, eltype(Omega)))
+end
+
+function action_homomorphism(G::PermGroup, fun::Function, Omega)
+  return action_homomorphism(GSetByElements(G, fun, Omega))
+end
+
 
 """
     isconjugate(Omega::GSet, omega1, omega2)
 
 Return `true` if `omega1`, `omega2` are in the same orbit of `Omega`,
 and `false` otherwise.
+
+# Examples
+```jldoctest
+julia> G = sylow_subgroup(symmetric_group(6), 2)[1]
+Group([ (1,2), (3,4), (1,3)(2,4), (5,6) ])
+
+julia> Omega = gset(G);
+
+julia> isconjugate(Omega, 1, 2)
+true
+
+julia> isconjugate(Omega, 1, 5)
+false
+
+```
 """
 isconjugate(Omega::GSet, omega1, omega2) = omega2 in orbit(Omega, omega1)
 
@@ -330,6 +506,21 @@ Determine whether `omega1`, `omega2` are in the same orbit of `Omega`.
 If yes, return `true, g` where `g` is an element in the group `G` of
 `Omega` that maps `omega1` to `omega2`.
 If not, return `false, nothing`.
+
+# Examples
+```jldoctest
+julia> G = sylow_subgroup(symmetric_group(6), 2)[1]
+Group([ (1,2), (3,4), (1,3)(2,4), (5,6) ])
+
+julia> Omega = gset(G);
+
+julia> representative_action(Omega, 1, 2)
+(true, (1,2))
+
+julia> representative_action(Omega, 1, 5)
+(false, ())
+
+```
 """
 function representative_action(Omega::GSet, omega1, omega2)
     # We do not call GAP's 'RepresentativeAction' with points, generators,
@@ -362,6 +553,8 @@ representative(Omega::GSet) = first(Omega.seeds)
 
 acting_domain(Omega::GSet) = Omega.group
 
+Base.getindex(Omega::GSet, i::Int) = elements(Omega)[i]
+
 # TODO:
 # - Base.iterate
 
@@ -389,43 +582,72 @@ isprimitive(G::GSet) = error("not implemented")
 """
     blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
 
-Return a block system for the action of `G` on `L`, i.e.,
-a non-trivial partition of `L` preserved by the action of `G`.
+Return a G-set that is a block system for the action of `G` on `L`,
+i.e., a non-trivial partition of `L` preserved by the action of `G`.
 
 Here, `L` must be a subvector of `1:degree(G)` on which `G` acts transitively.
 `G` may move points outside `L`, in this case the restriction of the action
 of the set stabilizer of `L` in `G` to `L` is considered.
 
 An exception is thrown if this action is not transitive.
+
+# Examples
+```jldoctest
+julia> g = sylow_subgroup(symmetric_group(4), 2)[1]
+Group([ (1,2), (3,4), (1,3)(2,4) ])
+
+julia> elements(blocks(g))
+2-element Vector{Vector{Int64}}:
+ [1, 2]
+ [3, 4]
+
+```
 """
 function blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
    @assert istransitive(G, L) "The group action is not transitive"
-   return Vector{Vector{Int}}(GAP.Globals.Blocks(G.X, GAP.GapObj(L)))
+   bl = Vector{Vector{Int}}(GAP.Globals.Blocks(G.X, GapObj(L))::GapObj)
+   omega = gset(G, bl)
+   set_attribute!(omega, :elements => omega.seeds)
+   return omega
 end
-
 
 """
     maximal_blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
 
-Return a maximal block system for the action of `G` on `L`, i.e.,
-a maximal non-trivial partition of `L` preserved by the action of `G`.
+Return a G-set that is a maximal block system for the action of `G` on `L`,
+i.e., a maximal non-trivial partition of `L` preserved by the action of `G`.
 
 Here, `L` must be a subvector of `1:degree(G)` on which `G` acts transitively.
 `G` may move points outside `L`, in this case the restriction of the action
 of the set stabilizer of `L` in `G` to `L` is considered.
 
 An exception is thrown if this action is not transitive.
+
+# Examples
+```jldoctest
+julia> G = transitive_group(8, 2)
+4[x]2
+
+julia> elements(maximal_blocks(G))
+2-element Vector{Vector{Int64}}:
+ [1, 2, 3, 8]
+ [4, 5, 6, 7]
+
+```
 """
 function maximal_blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
    @assert istransitive(G, L) "The group action is not transitive"
-   return Vector{Vector{Int}}(GAP.Globals.MaximalBlocks(G.X, GAP.GapObj(L)))
+   bl = Vector{Vector{Int}}(GAP.Globals.MaximalBlocks(G.X, GapObj(L))::GapObj)
+   omega = gset(G, bl)
+   set_attribute!(omega, :elements => omega.seeds)
+   return omega
 end
 
 
 """
     representatives_minimal_blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
 
-Return a list of block representatives for all minimal non-trivial block
+Return a vector of block representatives for all minimal non-trivial block
 systems for the action of `G` on `L`.
 
 Here, `L` must be a subvector of `1:degree(G)` on which `G` acts transitively.
@@ -433,18 +655,47 @@ Here, `L` must be a subvector of `1:degree(G)` on which `G` acts transitively.
 of the set stabilizer of `L` in `G` to `L` is considered.
 
 An exception is thrown if this action is not transitive.
+
+# Examples
+```jldoctest
+julia> G = transitive_group(8, 2)
+4[x]2
+
+julia> representatives_minimal_blocks(G)
+3-element Vector{Vector{Int64}}:
+ [1, 3]
+ [1, 5]
+ [1, 7]
+
+```
 """
 function representatives_minimal_blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
    @assert istransitive(G, L) "The group action is not transitive"
-   return Vector{Vector{Int}}(GAP.Globals.RepresentativesMinimalBlocks(G.X, GAP.GapObj(L)))
+   return Vector{Vector{Int}}(GAP.Globals.RepresentativesMinimalBlocks(G.X, GapObj(L))::GapObj)
 end
 
 
 """
     all_blocks(G::PermGroup)
 
-Return a list of representatives of all block systems for the action of
+Return a vector of representatives of all block systems for the action of
 `G` on the set of moved points of `G`.
+
+# Examples
+```jldoctest
+julia> G = transitive_group(8, 2)
+4[x]2
+
+julia> all_blocks(G)
+6-element Vector{Vector{Int64}}:
+ [1, 2, 3, 8]
+ [1, 5]
+ [1, 3, 5, 7]
+ [1, 3]
+ [1, 3, 4, 6]
+ [1, 7]
+
+```
 """
 all_blocks(G::PermGroup) = Vector{Vector{Int}}(GAP.Globals.AllBlocks(G.X))
 #TODO: Do we really want to act on the set of moved points?
@@ -455,15 +706,37 @@ all_blocks(G::PermGroup) = Vector{Vector{Int}}(GAP.Globals.AllBlocks(G.X))
 
 Return the maximum `k` such that the action of `G` on `L` is
 `k`-transitive. The output is `0` if `G` is not transitive on `L`.
+
+# Examples
+```jldoctest
+julia> transitivity(mathieu_group(24))
+5
+
+julia> transitivity(symmetric_group(6))
+6
+
+```
 """
-transitivity(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAP.Globals.Transitivity(G.X, GAP.GapObj(L))
+transitivity(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAP.Globals.Transitivity(G.X, GapObj(L))::Int
 
 """
     istransitive(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
 
 Return whether the action of `G` on `L` is transitive.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(6);
+
+julia> istransitive(G)
+true
+
+julia> istransitive(sylow_subgroup(G, 2)[1])
+false
+
+```
 """
-istransitive(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAPWrap.IsTransitive(G.X, GAP.GapObj(L))
+istransitive(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAPWrap.IsTransitive(G.X, GapObj(L))
 # Note that this definition does not coincide with that of the
 # property `GAP.Globals.IsTransitive`, for which the default domain
 # of the action is the set of moved points.
@@ -474,8 +747,26 @@ istransitive(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAPWrap.IsTra
 
 Return whether the action of `G` on `L` is primitive, that is,
 the action is transitive and the point stabilizers are maximal in `G`.
+
+# Examples
+```jldoctest
+julia> G = alternating_group(6);
+
+julia> mx = filter(istransitive, maximal_subgroup_reps(G))
+3-element Vector{PermGroup}:
+ Group([ (1,2)(3,4), (1,2)(5,6), (1,3,5)(2,4,6), (1,3)(2,4) ])
+ Group([ (1,2,3), (4,5,6), (1,2)(4,5), (1,5,2,4)(3,6) ])
+ PSL(2,5)
+
+julia> [(order(H), isprimitive(H)) for H in mx]
+3-element Vector{Tuple{fmpz, Bool}}:
+ (24, 0)
+ (36, 0)
+ (60, 1)
+
+```
 """
-isprimitive(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAPWrap.IsPrimitive(G.X, GAP.GapObj(L))
+isprimitive(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAPWrap.IsPrimitive(G.X, GapObj(L))
 
 
 """
@@ -483,8 +774,23 @@ isprimitive(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAPWrap.IsPrim
 
 Return whether the action of `G` on `L` is regular
 (i.e., transitive and semiregular).
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(6);
+
+julia> H = sub(G, [G([2, 3, 4, 5, 6, 1])])[1]
+Group([ (1,2,3,4,5,6) ])
+
+julia> isregular(H)
+true
+
+julia> isregular(G)
+false
+
+```
 """
-isregular(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAPWrap.IsRegular(G.X, GAP.GapObj(L))
+isregular(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAPWrap.IsRegular(G.X, GapObj(L))
 
 
 """
@@ -492,5 +798,20 @@ isregular(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAPWrap.IsRegula
 
 Return whether the action of `G` on `L` is semiregular
 (i.e., the stabilizer of each point is the identity).
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(6);
+
+julia> H = sub(G, [G([2, 3, 1, 5, 6, 4])])[1]
+Group([ (1,2,3)(4,5,6) ])
+
+julia> issemiregular(H)
+true
+
+julia> isregular(H)
+false
+
+```
 """
-issemiregular(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAPWrap.IsSemiRegular(G.X, GAP.GapObj(L))
+issemiregular(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAPWrap.IsSemiRegular(G.X, GapObj(L))

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -7,6 +7,7 @@ export
     embedding,
     index,
     ischaracteristic,
+    ismaximal,
     isnilpotent, has_isnilpotent, set_isnilpotent,
     issolvable, has_issolvable, set_issolvable,
     issupersolvable, has_issupersolvable, set_issupersolvable,
@@ -231,6 +232,34 @@ const centraliser = centralizer
 #  IsNormal, IsCharacteristic, IsSolvable, IsNilpotent
 #
 ################################################################################
+
+"""
+    ismaximal(G::T, H::T) where T <: GAPGroup
+
+Return whether `H` is a maximal subgroup of `G`, i. e.,
+whether `H` is a proper subgroup of `G` and there is no proper subgroup of `G`
+that properly contains `H`.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(4);
+
+julia> ismaximal(G, sylow_subgroup(G, 2)[1])
+true
+
+julia> ismaximal(G, sylow_subgroup(G, 3)[1])
+false
+
+```
+"""
+function ismaximal(G::T, H::T) where T <: GAPGroup
+  issubgroup(G, H)[1] || return false
+  if order(G) // order(H) < 100
+    t = right_transversal(G, H)[2:end] #drop the identity
+    return all(x -> order(sub(G, vcat(gens(H), [x]))[1]) == order(G), t)
+  end
+  return any(M -> isconjugate(G, M, H), maximal_subgroup_reps(G))
+end
 
 """
     isnormal(G::T, H::T) where T <: GAPGroup

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -140,6 +140,7 @@ function __init__()
     GAP.Packages.load("forms")
     __init_IsoGapOscar()
     __init_group_libraries()
+    __init_JuliaData()
     __GAP_info_messages_off()
 end
 

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -151,8 +151,8 @@ end
 
   # blocks
   bl = blocks(G8)
-  @test bl == [[1, 8], [2, 3], [4, 5], [6, 7]]
-  @test bl == blocks(G8, 1:degree(G8))
+  @test elements(bl) == [[1, 8], [2, 3], [4, 5], [6, 7]]
+  @test elements(bl) == elements(blocks(G8, 1:degree(G8)))
 
   # isprimitive
   @test ! isprimitive(G8)
@@ -176,9 +176,9 @@ end
 
   # maximal_blocks
   bl = maximal_blocks(G8)
-  @test bl == [[1, 2, 3, 8], [4, 5, 6, 7]]
-  @test bl == maximal_blocks(G8, 1:degree(G8))
-  @test maximal_blocks(S4) == [[1, 2, 3, 4]]
+  @test elements(bl) == [[1, 2, 3, 8], [4, 5, 6, 7]]
+  @test elements(bl) == elements(maximal_blocks(G8, 1:degree(G8)))
+  @test elements(maximal_blocks(S4)) == [[1, 2, 3, 4]]
 
   # representatives_minimal_blocks
   bl = representatives_minimal_blocks(G8)

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -180,11 +180,11 @@ end
   @test elements(bl) == elements(maximal_blocks(G8, 1:degree(G8)))
   @test elements(maximal_blocks(S4)) == [[1, 2, 3, 4]]
 
-  # representatives_minimal_blocks
-  bl = representatives_minimal_blocks(G8)
+  # minimal_block_reps
+  bl = minimal_block_reps(G8)
   @test bl == [[1,i] for i in 2:8]
-  @test bl == representatives_minimal_blocks(G8, 1:degree(G8))
-  @test representatives_minimal_blocks(S4) == [[1, 2, 3, 4]]
+  @test bl == minimal_block_reps(G8, 1:degree(G8))
+  @test minimal_block_reps(S4) == [[1, 2, 3, 4]]
 
   # transitivity
   @test transitivity(G8) == 1

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -292,15 +292,15 @@ end
    end
    L = [[2],[3],[5],[7],[2,3],[2,5],[2,7],[3,5],[3,7],[5,7],[2,3,5],[2,3,7],[2,5,7],[3,5,7],[2,3,5,7]]
    @testset for l in L
-      h = hall_subgroups_representatives(G, l)
+      h = hall_subgroup_reps(G, l)
       @test length(h) == 1
       @test h[1] == sub(G,[g^(210÷lcm(l))])[1]
    end
-   h = hall_subgroups_representatives(G, Int64[])
+   h = hall_subgroup_reps(G, Int64[])
    @test length(h) == 1
    @test h[1] == sub(G, [one(G)])[1]
-   @test length(hall_subgroups_representatives(symmetric_group(5), [2, 5])) == 0
-   @test_throws ArgumentError hall_subgroups_representatives(G, [4])
+   @test length(hall_subgroup_reps(symmetric_group(5), [2, 5])) == 0
+   @test_throws ArgumentError hall_subgroup_reps(G, [4])
 
    L = sylow_system(G)
    Lo = [order(l) for l in L]


### PR DESCRIPTION
- moved `ismaximal`, `isconjugate_subgroup`, `maximal_subgroup_reps`,
  `low_index_subgroups`, `short_right_transversal`, `subgroup_reps`,
  `right_coset_action`
  from `experimental/GaloisGrp/Group.jl` to
  `src/Groups/GAPGroups.jl`

- extended `action_homomorphism` in `src/Groups/gsets.jl` to cover the
  situation of `action_homomorphism` in `experimental/GaloisGrp/Group.jl`

- added documentation for G-sets related functions

- changed `blocks` and `maximal_blocks` to return G-sets not lists

- moved the call of `__init_JuliaData` to Oscar's `__init__`

TODO:
- Provide G-set functionality for matrix groups
- Now orbits and action homomorphisms are computed by giving Julia objects and Julia functions to GAP, which makes everything slower than before, when the objects and functions were translated to GAP. In the "special cases" (which are the most interesting cases) where we can translate the objects/functions, we should either do this or instead do everything without GAP.
