### PR TITLE
Disable trim_trailing_whitespace in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ charset = utf-8
 end_of_line = lf
 indent_style = space
 insert_final_newline = true
-trim_trailing_whitespace = true
+#trim_trailing_whitespace = true  # as long as we don't enforce this, this option causes more trouble than it helps
 
 [*.jl]
 indent_size = 2


### PR DESCRIPTION
As long as people keep adding files with lots of trailing spaces, this option
hurts more than it helps, as at least in my editor it will strip all trailing
spaces in files I edit, leading to lots of unwanted diffs.

*If* we wanted to get rid of these completely, the only realistic way IMHO would be to remove them once everywhere (and adding that commit to a `.git-blame-ignore-revs` file), then adding a GH action that flags this in PRs (either requiring authors to change it, or else automatically reformatting them as needed). But definitely not today