### PR TITLE
Prototype for standard basis for ideals and modules in Oscar

### DIFF
--- a/experimental/Experimental.jl
+++ b/experimental/Experimental.jl
@@ -6,4 +6,4 @@ include("InvariantTheory.jl")
 include("GITFans.jl")
 include("GModule.jl")
 
-include("experimental/LibSingWrapper.jl")
+include("LibSingWrapper.jl")

--- a/experimental/Experimental.jl
+++ b/experimental/Experimental.jl
@@ -5,3 +5,5 @@ include("PlaneCurve.jl")
 include("InvariantTheory.jl")
 include("GITFans.jl")
 include("GModule.jl")
+
+include("experimental/LibSingWrapper.jl")

--- a/experimental/LibSingWrapper.jl
+++ b/experimental/LibSingWrapper.jl
@@ -207,3 +207,38 @@ function milnor(f::Vector{T}; point::Vector{E}=Vector{elem_type(base_ring(parent
   end
   return sum(summands)
 end
+
+#function tjurina(f::Vector{T}; 
+#    point::Vector{E}=[zero(base_ring(parent(f[1]))) for i in 1:ngens(base_ring(parent(f[1])))]
+#  ) where {T<:MPolyElem, E}
+#  length(f) == 0 && error("not an ICIS")
+#  R = parent(f[1])
+#  k = length(f)
+#  all((x-> (parent(f[x]) == R)), 2:k) || error("elements do not have the same parent")
+#  n = ngens(R)
+#
+#  kk = coefficient_ring(R)
+#  all((x->(parent(x) == kk)), point) || return milnor(f, point=kk.(point))
+#
+#  W = Localization(MPolyComplementOfKPointIdeal(R, k_point))
+##  I = ideal(R, f)
+#  IW = W(I)
+#  # N = SubQuo(F, IF)
+#  N = Hom(IW, SubQuo(W, W, IW))
+#  F = ambient_free_module(N)
+#  Df = jacobi_matrix(f)
+#  Tj = N//SubQuo(F, Df)
+#  std_Tj = std(Tj) # Compute a relative standard basis; 
+#                   # adapted from standard basis in localized rings 
+#                   # from Greuel-Pfister, Def. 2.3.2.
+#  kbase(Tj)
+#end
+#
+#function kbase(Q::MPolyQuoLocalizedRing{<:Field, <:FieldElem, <:MPolyRing, <:MPolyElem, MST}) where {MST<:Union{MPolyComplementOfKPointIdeal}}
+#  # Sei Q = S/I, S = R[U⁻¹], R ein Polynomring, U das 
+#  # Komplement von einem K-Punkt.
+#  # Sei L(I) das Leitideal vom modulus von Q in R
+#  # Schaue, ob der Quotient R/L(I) endlich ist und 
+#  # gebe das Komplement von L(I) in der Menge der 
+#  # Monome von R zurueck. 
+#end

--- a/experimental/LibSingWrapper.jl
+++ b/experimental/LibSingWrapper.jl
@@ -14,12 +14,11 @@ for the Milnor algebra.
 
 The default argument for `point` is the origin.
 """
-function milnor(f::MPolyElem; point::Vector=[])
+function milnor(f::MPolyElem; point::Vector{T}=Vector{elem_type(base_ring(parent(f)))}()) where {T}
   iszero(f) && error("polynomial is zero")
   R = parent(f)
   kk = coefficient_ring(f)
-  # check whether we are working over a field of coefficients
-  typeof(kk)<:AbstractAlgebra.Field || error("coefficient domain is not a field")
+  all((x->(parent(x) == kk)), point) || return milnor(f, point=kk.(point))
 
   # We can not provide a full default vector of zeroes in the 
   # signature of the function, because we would need a full 
@@ -61,18 +60,17 @@ end
     tjurina(f::MPolyElem; point::Vector=[])
 
 For an isolated hypersurface singularity `f` at a point `point`,
-compute the triple `(gb,\tau,g)` where `gb` is a standard basis for the
-Tjurina ideal. `\tau` is the Tjurina number, and `g` is a ``k``-base of the
+compute the triple `(gb,τ,g)` where `gb` is a standard basis for the
+Tjurina ideal. `τ` is the Tjurina number, and `g` is a ``k``-base of the
 Tjurina algebra.
 
 The default argument for `point` is the origin.
 """
-function tjurina(f::MPolyElem; point::Vector=[])
+function tjurina(f::MPolyElem; point::Vector{T}=Vector{elem_type(base_ring(parent(f)))}()) where {T}
   iszero(f) && error("input polynomial is zero")
   R = parent(f)
   kk = coefficient_ring(f)
-  # make sure that kk is a field
-  typeof(kk)<:AbstractAlgebra.Field || error("coefficient domain is not a field")
+  all((x->(parent(x) == kk)), point) || return tjurina(f, point=kk.(point))
 
   # Set sanity check on point or creation of vector of point, if default point 
   k_point = kk.(point)
@@ -109,12 +107,10 @@ end
 Computes the global Milnor number of the affine hypersurface 
 defined by `f` with at most isolated singularities.
 """
-function global_milnor_number(f::MPolyElem)
+function global_milnor_number(f::MPolyElem{T}) where {T<:FieldElem}
   iszero(f) && error("polynomial is zero")
   R = parent(f)
   kk = coefficient_ring(f)
-  # check whether we are working over a field of coefficients
-  typeof(kk)<:AbstractAlgebra.Field || error("coefficient domain is not a field")
 
   # set up Singular-ring, because we need it later on
   RS=Oscar.singular_ring(R)
@@ -138,12 +134,10 @@ end
 Computes the global Tjurina number of the affine hypersurface
 defined by `f` with at most isolated singularities
 """
-function global_tjurina_number(f::MPolyElem)
+function global_tjurina_number(f::MPolyElem{T}) where {T<:FieldElem}
   iszero(f) && error("polynomial is zero")
   R = parent(f)
   kk = coefficient_ring(f)
-  # check whether we are working over a field of coefficients
-  typeof(kk)<:AbstractAlgebra.Field || error("coefficient domain is not a field")
 
   # set up Singular-ring, because we need it later on
   RS=Oscar.singular_ring(R)
@@ -168,7 +162,7 @@ For an isolated complete intersection singularity given by
 the regular sequence ``f₁,…,fₖ`` compute the Milnor number 
 at `point` by means of the Le-Greuel-formula.
 """
-function milnor(f::Vector{T}; point::Vector=[]) where {T<:MPolyElem}
+function milnor(f::Vector{T}; point::Vector{E}=Vector{elem_type(base_ring(parent(f[1])))}()) where {T<:MPolyElem, E}
   length(f) == 0 && error("not an ICIS")
   R = parent(f[1])
   k = length(f)
@@ -178,8 +172,7 @@ function milnor(f::Vector{T}; point::Vector=[]) where {T<:MPolyElem}
   n = ngens(R)
 
   kk = coefficient_ring(R)
-  # check whether we are working of a field of coefficients
-  typeof(kk)<:AbstractAlgebra.Field || error("coefficient domain is not a field")
+  all((x->(parent(x) == kk)), point) || return milnor(f, point=kk.(point))
 
   # We can not provide a full default vector of zeroes in the 
   # signature of the function, because we would need a full 
@@ -194,7 +187,7 @@ function milnor(f::Vector{T}; point::Vector=[]) where {T<:MPolyElem}
     k_point = elem_type(kk)[zero(kk) for i in 1:ngens(R)]
   end
 
-  rem_f = f
+  rem_f = copy(f)
   summands = Int[]
   W = Localization(MPolyComplementOfKPointIdeal(R, k_point))
   sign = 1

--- a/experimental/LibSingWrapper.jl
+++ b/experimental/LibSingWrapper.jl
@@ -118,15 +118,17 @@ function global_milnor_number(f::MPolyElem)
 
   # compute groebner basis of the jacobian ideal
   Df = jacobi_matrix(f)::AbstractAlgebra.Generic.MatSpaceElem{typeof(f)}
-  I = ideal(R, [Df[i, 1] for i in 1:nrows(Df)])
+  #I = ideal(R, [Df[i, 1] for i in 1:nrows(Df)])
 
-# NEE, das muss auf der Singular Seite passieren -- SingularRing machen, Ideal rüberziehen, std...
-  stdI = groebner_basis(I)
+  RS=Oscar.singular_ring(R)
+  # I needs to be passed to RS where we can make a Singular Standard basis..
+  Ising = Singular.Ideal(RS, [RS(Df[i, 1]) for i in 1:nrows(Df)])
+  stdI = Singular.std(Ising)
 
   # set up the resulting data
-  Singular.dimension(singular_gens(stdI)) == 0 || error("non-isolated singularities detected")
-  milnor_number = Singular.vdim(singular_gens(stdI)) 
-  return (stdI, milnor_number)
+  Singular.dimension(stdI) == 0 || error("non-isolated singularities detected")
+  milnor_number = Singular.vdim(stdI) 
+  return (milnor_number)
 end
 
 @Markdown.doc """

--- a/experimental/LibSingWrapper.jl
+++ b/experimental/LibSingWrapper.jl
@@ -1,6 +1,6 @@
 import Singular.LibSing: *
 
-export milnor
+export milnor, tjurina
 
 ### The Milnor algebra of an isolated hypersurface singularity f
 
@@ -18,7 +18,7 @@ function milnor(f::MPolyElem; point::Vector=[])
   iszero(f) && error("polynomial is zero")
   R = parent(f)
   kk = coefficient_ring(f)
-  # check whether we are working of a field of coefficients
+  # check whether we are working over a field of coefficients
   typeof(kk)<:AbstractAlgebra.Field || error("coefficient domain is not a field")
 
   # We can not provide a full default vector of zeroes in the 
@@ -56,14 +56,76 @@ function milnor(f::MPolyElem; point::Vector=[])
   return (stdI, milnor_number, milnor_kbase)
 end
 
+### The Tjurina algebra  of an isolated hypersurface singularity f
+@Markdown.doc """
+    tjurina(f::MPolyElem; point::Vector=[])
+
+For an isolated hypersurface singularity `f` at a point `point`,
+compute the triple `(gb,\tau,g)` where `gb` is a standard basis for the
+Tjurina ideal. `\tau` is the Tjurina number, and `g` is a ``k``-base of the
+Tjurina algebra.
+
+The default argument for `point` is the origin.
+""
+function tjurina(f::MPolyElem; point::Vector=[])
+  iszero(f) && error("input polynomial is zero")
+  R = parent(f)
+  kk = coefficient_ring(f)
+  # make sure that kk is a field
+  typeof(kk)<:AbstractAlgebra.Field || error("coefficient domain is not a field")
+
+  # Set sanity check on point or creation of vector of point, if default point 
+  k_point = kk.(point)
+  if length(point) != 0
+     # right number of coordinates?
+     length(k_point) == ngens(R) || error("vector does not have correct length")
+  else
+     # default case, need to set up point for origin
+     k_point = elem_type(kk)[zero(kk) for i in 1:ngens(R)]
+  end
+
+  # localize at point (setting up stage for Singular)
+  RL = Localization(MPolyComplementOfKPointIdeal(R,k_point))  
+
+  # compute the jacobian and tjurina ideals
+  Jf = jacobi_matrix(f)::AbstractAlgebra.Generic.MatSpaceElem{typeof(f)}
+  I=ideal(R,[Df[i,1] for i i n1:nrows(Df)]) + ideal(R,[f])
+  # now move to localization RL of R and do standard basis there
+  IL=RL(I)
+  stdIL = groebner_basis(IL)
+  
+  # now fill in the return values
+    Singular.dimension(singular_gens(stdI)) == 0 || error("singularity is not isolated")
+  tjurina_number = Singular.vdim(singular_gens(stdIL)) 
+  # make the conversion to the Oscar side 
+  tjurina_kbase = [to_oscar_side(stdIL, g) for g in gens(Singular.kbase(singular_gens(stdIL)))]
+  return (stdIL, tjurina_number, tjurina_kbase)
+end
+
 @Markdown.doc """
     global_milnor_number(f::MPolyElem)
 
-Computes the global Milnor number of a hypersurface `f` with 
+Computes the global Milnor number of an affine hypersurface `f` with 
 at most isolated singularities.
 """
 function global_milnor_number(f::MPolyElem)
-  error("not implemented")
+  iszero(f) && error("polynomial is zero")
+  R = parent(f)
+  kk = coefficient_ring(f)
+  # check whether we are working over a field of coefficients
+  typeof(kk)<:AbstractAlgebra.Field || error("coefficient domain is not a field")
+
+  # compute groebner basis of the jacobian ideal
+  Df = jacobi_matrix(f)::AbstractAlgebra.Generic.MatSpaceElem{typeof(f)}
+  I = ideal(R, [Df[i, 1] for i in 1:nrows(Df)])
+  stdI = groebner_basis(I)
+
+  # set up the resulting data
+  Singular.dimension(singular_gens(stdI)) == 0 || error("non-isolated singularities detected")
+    milnor_number = Singular.vdim(singular_gens(stdI)) 
+  # make the conversion to the Oscar side 
+  milnor_kbase = [to_oscar_side(stdI, g) for g in gens(Singular.kbase(singular_gens(stdI)))]
+  return (stdI, milnor_number, milnor_kbase)
 end
 
 @Markdown.doc """

--- a/experimental/LibSingWrapper.jl
+++ b/experimental/LibSingWrapper.jl
@@ -1,0 +1,121 @@
+import Singular.LibSing: *
+
+export milnor
+
+### The Milnor algebra of an isolated hypersurface singularity f
+
+@Markdown.doc """
+    milnor(f::MPolyElem; point::Vector=[])
+
+For an isolated hypersurface singularity `f` at a point `point`, 
+compute the triple `(gb, μ, g)` where `gb` is a standard basis for 
+the jacobian ideal, `μ` is the Milnor number, and `g` is a ``𝕜``-base 
+for the Milnor algebra.
+
+The default argument for `point` is the origin.
+"""
+function milnor(f::MPolyElem; point::Vector=[])
+  iszero(f) && error("polynomial is zero")
+  R = parent(f)
+  kk = coefficient_ring(f)
+  # check whether we are working of a field of coefficients
+  typeof(kk)<:AbstractAlgebra.Field || error("coefficient domain is not a field")
+
+  # We can not provide a full default vector of zeroes in the 
+  # signature of the function, because we would need a full 
+  # instance of the field at that point. Hence, we have to 
+  # do that at a later point here.
+  k_point = kk.(point)
+  if length(point) != 0
+    # check for the right number of coordinates
+    length(k_point) == ngens(R) || error("vector does not have the correct length")
+  else
+    # fill up the default otherwise
+    k_point = elem_type(kk)[zero(kk) for i in 1:ngens(R)]
+  end
+
+  # Set up the localization at `point` so that we have 
+  # the local orderings at our disposal
+  W = Localization(MPolyComplementOfKPointIdeal(R, k_point))
+
+  # compute the jacobian ideal
+  Df = jacobi_matrix(f)::AbstractAlgebra.Generic.MatSpaceElem{typeof(f)}
+  I = ideal(R, [Df[i, 1] for i in 1:nrows(Df)])
+  
+  # transfer to the localized ring since otherwise we could not work with 
+  # local orderings
+  WI = W(I)
+  # compute a standard basis w.r.t a local ordering 
+  stdI = groebner_basis(WI)
+
+  # carry out the computations on the Singular side
+  Singular.dimension(singular_gens(stdI)) == 0 || error("singularity is not isolated")
+  milnor_number = Singular.vdim(singular_gens(stdI)) 
+  # make the conversion to the Oscar side 
+  milnor_kbase = [to_oscar_side(stdI, g) for g in gens(Singular.kbase(singular_gens(stdI)))]
+  return (stdI, milnor_number, milnor_kbase)
+end
+
+@Markdown.doc """
+    global_milnor_number(f::MPolyElem)
+
+Computes the global Milnor number of a hypersurface `f` with 
+at most isolated singularities.
+"""
+function global_milnor_number(f::MPolyElem)
+  error("not implemented")
+end
+
+@Markdown.doc """
+    milnor(f::Vector{T}) where {T<:MPolyElem}
+
+For an isolated complete intersection singularity given by 
+the regular sequence ``f₁,…,fₖ`` compute the Milnor number 
+at `point` by means of the Le-Greuel-formula.
+"""
+function milnor(f::Vector{T}; point::Vector=[]) where {T<:MPolyElem}
+  length(f) == 0 && error("not an ICIS")
+  R = parent(f[1])
+  k = length(f)
+  for i in 2:k
+    parent(f[i]) == R || error("elements do not have the same parent")
+  end
+  n = ngens(R)
+
+  kk = coefficient_ring(R)
+  # check whether we are working of a field of coefficients
+  typeof(kk)<:AbstractAlgebra.Field || error("coefficient domain is not a field")
+
+  # We can not provide a full default vector of zeroes in the 
+  # signature of the function, because we would need a full 
+  # instance of the field at that point. Hence, we have to 
+  # do that at a later point here.
+  k_point = kk.(point)
+  if length(point) != 0
+    # check for the right number of coordinates
+    length(k_point) == ngens(R) || error("vector does not have the correct length")
+  else
+    # fill up the default otherwise
+    k_point = elem_type(kk)[zero(kk) for i in 1:ngens(R)]
+  end
+
+  rem_f = f
+  summands = Int[]
+  W = Localization(MPolyComplementOfKPointIdeal(R, k_point))
+  sign = 1
+  for i in k:-1:1
+    Df_rem = jacobi_matrix(rem_f)
+    Df_min = minors(Df_rem, i)
+    pop!(rem_f)
+    Df_min_ext = vcat(Df_min, rem_f)
+    I = ideal(R, Df_min_ext)
+    WI = W(I)
+    stdI = groebner_basis(WI)
+    Singular.dimension(singular_gens(stdI)) == 0 || error("not an ICIS or not in general position")
+    b = Singular.vdim(singular_gens(stdI))
+    #b >= 0 || error("not an ICIS or not in general position")
+    push!(summands, sign*b)
+    sign = -sign
+  end
+  return sum(summands)
+end

--- a/experimental/LibSingWrapper.jl
+++ b/experimental/LibSingWrapper.jl
@@ -1,6 +1,6 @@
 import Singular.LibSing: *
 
-export milnor, tjurina
+export milnor, tjurina, global_milnor_number
 
 ### The Milnor algebra of an isolated hypersurface singularity f
 
@@ -56,7 +56,7 @@ function milnor(f::MPolyElem; point::Vector=[])
   return (stdI, milnor_number, milnor_kbase)
 end
 
-### The Tjurina algebra  of an isolated hypersurface singularity f
+### The Tjurina number  of an isolated hypersurface singularity f
 @Markdown.doc """
     tjurina(f::MPolyElem; point::Vector=[])
 
@@ -66,7 +66,7 @@ Tjurina ideal. `\tau` is the Tjurina number, and `g` is a ``k``-base of the
 Tjurina algebra.
 
 The default argument for `point` is the origin.
-""
+"""
 function tjurina(f::MPolyElem; point::Vector=[])
   iszero(f) && error("input polynomial is zero")
   R = parent(f)
@@ -89,24 +89,25 @@ function tjurina(f::MPolyElem; point::Vector=[])
 
   # compute the jacobian and tjurina ideals
   Jf = jacobi_matrix(f)::AbstractAlgebra.Generic.MatSpaceElem{typeof(f)}
-  I=ideal(R,[Df[i,1] for i i n1:nrows(Df)]) + ideal(R,[f])
+  I=ideal(R,[Jf[i,1] for i in 1:nrows(Jf)]) + ideal(R,[f])
   # now move to localization RL of R and do standard basis there
   IL=RL(I)
   stdIL = groebner_basis(IL)
   
   # now fill in the return values
-    Singular.dimension(singular_gens(stdI)) == 0 || error("singularity is not isolated")
+  Singular.dimension(singular_gens(stdIL)) == 0 || error("singularity is not isolated")
   tjurina_number = Singular.vdim(singular_gens(stdIL)) 
   # make the conversion to the Oscar side 
   tjurina_kbase = [to_oscar_side(stdIL, g) for g in gens(Singular.kbase(singular_gens(stdIL)))]
   return (stdIL, tjurina_number, tjurina_kbase)
 end
 
+### The global Milnor number of a hypersurface with at most isolated singularities
 @Markdown.doc """
     global_milnor_number(f::MPolyElem)
 
-Computes the global Milnor number of an affine hypersurface `f` with 
-at most isolated singularities.
+Computes the global Milnor number of the affine hypersurface 
+defined by `f` with at most isolated singularities.
 """
 function global_milnor_number(f::MPolyElem)
   iszero(f) && error("polynomial is zero")
@@ -118,14 +119,14 @@ function global_milnor_number(f::MPolyElem)
   # compute groebner basis of the jacobian ideal
   Df = jacobi_matrix(f)::AbstractAlgebra.Generic.MatSpaceElem{typeof(f)}
   I = ideal(R, [Df[i, 1] for i in 1:nrows(Df)])
+
+# NEE, das muss auf der Singular Seite passieren -- SingularRing machen, Ideal rüberziehen, std...
   stdI = groebner_basis(I)
 
   # set up the resulting data
   Singular.dimension(singular_gens(stdI)) == 0 || error("non-isolated singularities detected")
-    milnor_number = Singular.vdim(singular_gens(stdI)) 
-  # make the conversion to the Oscar side 
-  milnor_kbase = [to_oscar_side(stdI, g) for g in gens(Singular.kbase(singular_gens(stdI)))]
-  return (stdI, milnor_number, milnor_kbase)
+  milnor_number = Singular.vdim(singular_gens(stdI)) 
+  return (stdI, milnor_number)
 end
 
 @Markdown.doc """

--- a/experimental/singular_standard_basis.jl
+++ b/experimental/singular_standard_basis.jl
@@ -1,0 +1,73 @@
+mutable struct SingularStandardBasis{
+    RingElemType<:MPolyElem,
+    FreeModType<:FreeMod,
+    SubModType<:ModuleFP,
+    ModElemType<:FreeModElem, 
+    OrderingType<:Oscar.Ordering.ModOrdering
+   } <: AbsModuleStdBasis{MPolyElem}
+  F::FreeModType
+  M::SubModType
+  o::OrderingType
+  gens::Vector{ModElemType}
+
+  # fields for caching
+  elements::Vector{ModElemType}
+  quotient_module::ModuleFP
+  quotient_projection::Hecke.Map
+
+  g::Oscar.ModuleGens
+
+  function SingularStandardBasis(
+      F::FreeMod,
+      v::Vector{ModElemType},
+      o::OrderingType; 
+      generated_submodule::Oscar.SubModuleOfFreeModule=Oscar.SubModuleFreeModule(F, v),
+      check::Bool=true
+    ) where {
+      ModElemType<:FreeModElem, 
+      OrderingType<:Oscar.Ordering.ModOrdering
+    }
+    all(x->(parent(x) == F), v) || error("module elements do not have the correct parent")
+    ambient_free_module(generated_submodule) == F || error("submodule does not have the correct ambient module")
+    if check
+      # Full membership does not make sense here, because its implementation will eventually 
+      # be based on this code.
+      all(x->(v in gens(generated_submodule)), v) || error("can not check whether the given module elements belong to the given submodule") 
+    end
+    R = base_ring(F)
+    return new{elem_type(R), typeof(F), typeof(generated_submodule), ModElemType, typeof(o)}(F, generated_submodule, o, v)
+  end
+end
+
+ordering(G::SingularStandardBasis) = G.o
+ambient_free_module(G::SingularStandardBasis) = G.F
+
+function sub(G::SingularStandardBasis; cached::Bool=true) 
+  cached && return G.M, inclusion_map(M)
+  return sub(G.M, G.F)
+end
+    
+function sub(G::SingularStandardBasis; cached::Bool=true) 
+  if cached 
+    if isdefined(G, :quotient_module) 
+      return G.quotient_module, G.quotient_projection
+    end
+    N, p = quo(ambient_free_module(G), G.M)
+    G.quotient_module = N
+    G.quotient_projection = p
+    return N, p
+  end
+  return sub(G.M, G.F)
+end
+
+function elements(G::SingularStandardBasis)
+  if !isdefined(G. :elements) 
+    mg = Oscar.ModuleGens(gens(G))
+    singular_assure(mg) # How can we pass on the ordering???
+    mgstd = Oscar.ModuleGens(ambient_free_module(G), Singular.std(mg.S))
+    G.g = mgstd
+    G.elements = mgstd.O
+  end
+  return G.elements
+end
+

--- a/experimental/standard_basis.jl
+++ b/experimental/standard_basis.jl
@@ -1,0 +1,108 @@
+export AbsModuleStdBasis, AbsIdealStdBasis
+export odering
+
+abstract type AbsModuleStdBasis{RingElemType} end
+
+abstract type AbsIdealStdBasis{RingElemType} end
+
+### Essential getters #################################################
+#
+### return the ordering with respect to which the standard 
+# basis had been computed
+function ordering(G::AbsModuleStdBasis)
+end
+
+function ordering(G::AbsIdealStdBasis)
+end
+  
+### return the ambient free module F which contains the elements of G
+function ambient_free_module(G::AbsModuleStdBasis)
+end
+
+### return the submodule M ⊂ F ≅ Rⁿ of which G is a standard basis, 
+# together with its inclusion M ↪ F.
+function sub(G::AbsModuleStdBasis; cached::Bool=true)
+end
+
+### return the quotient F/M for the submodule M ⊂ F ≅ Rⁿ of which G 
+#is a standard basis, together with its projection F →  F/M.
+function quo(G::AbsModuleStdBasis; cached::Bool=true)
+end
+
+### return a vector of the module elements in the standard basis
+function elements(G::AbsModuleStdBasis)
+end
+
+### return the leading monomials of `elements(G)`
+function leading_monomials(G::AbsModuleStdBasis)
+end
+
+
+### Essential functionality ###########################################
+
+function normal_form(v::FreeModElem, G::AbsModuleStdBasis)
+end
+
+### In the case of a finite dimensional quotient F/G with F ≅ Rⁿ 
+# a free module over a polynomial ring R = 𝕜[x₁,…,xₙ] with an ordering <, 
+# and 𝕜 a field, return a list of elements v₁,…,vᵣ ∈ F which reduce 
+# to a 𝕜-basis of F/G.
+function k_base(G::AbsModuleStdBasis)
+end
+
+### 
+# Suppose G is a standard basis for M ⊂ F ≅ Rⁿ for some polynomial ring 
+# R = 𝕜[x₁,…,xₙ] over a field 𝕜. Set N = F/M.
+#
+# Check whether the given weight is compatible with the ordering; if not, complain.
+#
+# Return a 𝕜-base for the d-th graded slice of N.
+function graded_slice(G::AbsModuleStdBasis, d::Int; w::Vector{T}=Vector{Int}()) where {T<:Integer}
+end
+
+
+### Generic functions #################################################
+
+base_ring(G::AbsModuleStdBasis) = base_ring(ambient_free_module(G))
+
+### return the leading module of G
+function leading_module(G::AbsModuleStdBasis)
+  # can be implemented generically
+end
+
+### return the dimension of the support of the module
+function dim(G::AbsModuleStdBasis)
+end
+
+function is_finite_dimensional(G::AbsModuleStdBasis) 
+end
+
+function as_vector_space(G::AbsModuleStdBasis)
+  v = k_base(G)
+  F = ambient_free_module(G)
+  R = base_ring(F)
+  kk = coefficient_ring(R) 
+  r = length(v)
+  V = vector_space(kk, r)
+  VectorType = elem_type(V)
+  N, p = quo(G)
+  ModuleType = elem_type(N)
+  function im_func(w::VectorType) 
+    return sum([w[i]*v[i] for i in 1:length(w)])
+  end
+  function pr_func(w::ModuleType)
+    w_norm = normal_form(lift(w), G)
+    result = zero(V)
+    for (c, m) in zip(coefficients(w_norm), monomials(w_norm))
+      for i in 1:length(v)
+        if m == v[i] 
+          result = result + c*V[i]
+          break
+        end
+      end
+    end
+    return result
+  end
+  f = MapFromFunc(im_func, pr_func, V, N)
+  return V, f
+end

--- a/test/LibSingWrapper.jl
+++ b/test/LibSingWrapper.jl
@@ -1,0 +1,31 @@
+@testset "LibSing wrapper" begin
+  R, (x,y) = QQ["x","y"]
+  f = x^5 + y^5 + x^3*y^3
+  shift = hom(R, R, [x-1, y-2])
+  (gb, mu, g) = milnor(f)
+  shift_f = shift(f)
+  (gbs, mus, gs) = milnor(shift_f, point=[1, 2])
+  @test mu == mus
+  @test mu == 16
+
+  (gb, tau, g) = tjurina(f)
+  (gbs, taus, gs) = tjurina(shift_f, point=[1, 2])
+  @test tau == 15
+  @test tau == taus
+
+  h = (y-x^2)*(y+x^2-2)
+  @test global_milnor_number(h) == 3
+  @test global_tjurina_number(h) == 2
+
+  g = y^3 - (x-1)^2*(x+1)^2
+  @test global_milnor_number(g) == 6
+  @test global_tjurina_number(g) == 4
+
+  f = f*(y-2)
+  @test global_milnor_number(f) == 30
+  @test global_tjurina_number(f) == 20
+
+  R, (x,y,z) = QQ["x", "y", "z"]
+  f = [x^2 + y^2 + z^2, x*y]
+  @test milnor(f) == 5
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,3 +54,5 @@ include("ToricVarieties/runtests.jl")
 
 include("Schemes/AffineSchemes.jl")
 include("Schemes/SpecOpen.jl")
+
+include("LibSingWrapper.jl")


### PR DESCRIPTION
Whether or not a proper new type for standard basis of ideals and modules should be introduced in Oscar is an ongoing debate. With this PR we would like to contribute to that discussion by exposing our specific demands and suggestions for solutions.

Let me first explain, why @afkafkafk13 and I are interested in a standard-basis functionality. This July, we would like to give a course on computational aspects of singularity theory at the [Sao Carlos workshop](http://www.worksing.icmc.usp.br/main_site/2022/) which is one of the major international conferences in singularity theory. Two years ago, we would have given the course based on Singular, but this year, we would very much like to use and promote Oscar; especially for the upcoming generation of singularity theorists. 

### An example problem we would like to address
Now we are facing the following challenges. The compuational aspects of singularity theory rely heavily on the theory of standard basis and monomial orderings. As a central example, let us consider the Kodaira spencer map `K : T_0 B -> T^1_{X,0}`. For a given singularity `(X, 0)` and a deformation of it `(Z, 0) -> (B,0)` over some base germ `(B,0)` it takes a tangent vector `v` in the tangent space at `0` of the base `B` to its corresponding infinitesimal deformation of the singularity. The space `N := T^1_{X,0}` will be probably be a `SubQuo`, but certainly a finitely presented module over a polynomial ring `R`, which has finite dimension over the field `k` of coefficients of `R`. For simplicity, let us assume for the moment that `N = F/M` for some free module `F = R^n` and a submodule `M` of `F`.

In order to write down `K`, we need a so-called `k`-base of `N` with respect to a local ordering. This is a finite list of representatives `v_1,...,v_r` in `F` of elements of `N` which reduce to a basis for `N` as a vector space over `k`. On the mathematical side, this is achieved by 

 1) Choosing a (local) monomial ordering `<` for `F`;
 2) computing a standard basis `G` for `M` w.r.t. `<` and
 3) collecting the monomials (in the module sense) which are not contained in the leading module of `G`.

 This is one of the things we would like to explain to the students and accompany this with a presentation of the corresponding commands and computations in Oscar. 

### Why not use Singular?
The methods for all the above exist since many years in Singular and they are available through the calls to the libraries via `Singular.jl`. But when teaching a course, there is no point in using Oscar, only to tell the students that, essentially, we will be working with Singular, including the use of the singular syntax etc. What we would like to have, are the Oscar versions of commands like `k`-base, etc., meaning we use Oscar rings and modules and the return value of `k_base` is not only a list of elements, but an honest `Oscar` vector space `V` together with a `Hecke.Map` taking a basis of `V` to the corresponding representatives of the quotient `N = F/M`. 

### What could standard bases look like in Oscar?
Our point of view is the following: Groebner- and standard basis are not only concrete objects in `Singular`, but honest mathematical objects with a mathematical theory of its own right. We think, this should be reflected in Oscar by introducing the corresponding abstract types and interfaces; a prototype of this can be found in this PR in `experimental/standard_basis.jl`. 

In particular, a standard basis `G` is more than just a list of elements; for instance, the ordering with respect to which a basis had been computed needs to be associated to `G`. Furthermore, having an abstract and concrete types for standard bases allows us to write methods like e.g. `normal_form` which take an instance  `<:AbsStandardBasis` as input rather than simply a `Vector{T}` where `{T<:MPolyElem}`. Just to compare: For factorizations of polynomials, we have a type of its own for the return value of `factor(f)`, namely `AbstractAlgebra.Fac`. So why not have a type for standard basis?

### User facing vs. programmer facing functionality, code organization
Introducing a type for standard bases should also help us to improve the organization of our code.  In the end, we want to be able to not only use Singular as a backend for standard basis computations, but also any other potential and upcoming Groebner-basis engines. Having an abstract interface allows us to embed and organize the concrete implementations of standard bases for different backends. 

Keep in mind that Groebner- and standard bases should not be user-facing for the average user, in the end. But we believe that they should be 'programmer facing' in the sense that there should be a second layer below the surface, to which a programmer can refer and this would be the layer, we would like to expose to our students in the course. At this point, this second layer is concretely given by objects like `BiPolyArray` or `ModuleGens`, accompanied with their methods `singular_assure` and `oscar_assure`. But this is more a technical and practical solution to allow for things like ideal membership tests to be carried out for Oscar rings. It is **not** the solution, we would like to present to students in a course! In a course, we introduce the mathematical theory of testing ideal membership via standard basis methods and then show how to do that in Oscar. If showing the latter means introducing the students to `BiPolyArrays` and `singular_assure`, something is fundamentally wrong with the course! 


### Conclusion
For the preparation of the course, @afkafkafk13 and I need to have a reliable decision on the design of these matters within Oscar and, I'm afraid, we need that rather soon. 

Should we reach the conclusion that Oscar should feature standard basis as mathematical objects of their own right, then we will be happy to contribute to their development.

Should we decide that we stick with the practical solution via `BiPolyArrays`, then it seems that Oscar is not a suitable software for this course. But that would entail that we miss the opportunity to promote it at this conference.


Please, share your thoughts, comments, suggestions, complaints, ideas and objections.

CC: @wdecker , @ederc , @jankoboehm , @AlexD97 , @fingolfin 