### PR TITLE
SimplicialComplexes: Propose fix for (co-)homology

### DIFF
--- a/docs/src/DeveloperDocumentation/documentation.md
+++ b/docs/src/DeveloperDocumentation/documentation.md
@@ -90,3 +90,27 @@ then run [bibtool](http://www.gerd-neugebauer.de/software/TeX/BibTool/en/)
 by invoking it as follows from the root directory of the Oscar.jl repository:
 
     bibtool docs/oscar_references.bib -o docs/oscar_references.bib
+
+
+## Automatically repairing `jldoctest`s
+
+It is possible to have julia fix the output of all `jldoctest`s when your
+changes to the code entail changes to the output. Just run the following
+command:
+```
+build_doc(doctest = :fix)
+```
+!!! danger
+    Please use this command carefully:
+    - Make sure to only commit the changes to the doctests originating from
+      your changes to the code.
+    - The doctests also serve as actual tests, so make absolutely sure that the
+      output is still mathematically correct.
+
+!!! tip
+    If this command fails with an error message indicating lacking permissions
+    to change `AbtractAlgebra.jl` related docs, it may help to run the
+    following command:
+    ```
+    ]dev AbstractAlgebra
+    ```

--- a/docs/src/General/other.md
+++ b/docs/src/General/other.md
@@ -21,6 +21,10 @@
   from `0` like polymake. For most properties we have taken care of the
   translation but be aware that it might pop up at some point and generate
   confusion.
+
+  For convenience, `Polymake.jl` provides `Polymake.to_one_based_indexing` and
+  `Polymake.to_zero_based_indexing`.
+
 - Polyhedra and polyhedral complexes in OSCAR are represented inhomogeneously,
   i.e. without the leading `1` for vertices or `0` for rays. Hence constructors
   take points, rays, and lineality generators separately.

--- a/src/Combinatorics/SimplicialComplexes.jl
+++ b/src/Combinatorics/SimplicialComplexes.jl
@@ -228,8 +228,7 @@ Return `i`-th reduced integral cohomology group of `K`.
 julia> K = SimplicialComplex([[0,1],[1,2],[0,2]]);
 
 julia> cohomology(K,1)
-(General) abelian group with relation matrix
-[1]
+GrpAb: Z
 ```
 """
 cohomology(K::SimplicialComplex, i::Int) = _convert_finitely_generated_abelian_group(pm_object(K).COHOMOLOGY[i+1]) # index shift

--- a/src/Combinatorics/SimplicialComplexes.jl
+++ b/src/Combinatorics/SimplicialComplexes.jl
@@ -82,18 +82,14 @@ end
 ##  Auxiliary
 ################################################################################
 
-function _vertexindices(K::Polymake.BigObject)
-    if Polymake.exists(K,"VERTEX_INDICES")
-        return Vector{Int}(K.VERTEX_INDICES)
+function vertexindices(K::SimplicialComplex) 
+    bigobject = pm_object(K)
+    if Polymake.exists(bigobject,"VERTEX_INDICES")
+        return Vector{Int}(bigobject.VERTEX_INDICES)
     else
-        return Vector{Int}(1:K.N_VERTICES)
+        return Vector{Int}(1:bigobject.N_VERTICES)
     end
 end
-
-vertexindices(K::SimplicialComplex) = _vertexindices(pm_object(K))
-
-# currently unused
-_reindexset(M::Set{Int}, ind::Vector{Int}) = [ ind[x] for x in M ]
 
 function _convert_finitely_generated_abelian_group(A::Polymake.HomologyGroupAllocated{Polymake.Integer})
     vec = zeros(Int, Polymake.betti_number(A))

--- a/src/Combinatorics/SimplicialComplexes.jl
+++ b/src/Combinatorics/SimplicialComplexes.jl
@@ -96,12 +96,12 @@ vertexindices(K::SimplicialComplex) = _vertexindices(pm_object(K))
 _reindexset(M::Set{Int}, ind::Vector{Int}) = [ ind[x] for x in M ]
 
 function _convert_finitely_generated_abelian_group(A::Polymake.HomologyGroupAllocated{Polymake.Integer})
-    vec = ones(Int, Polymake.betti_number(A))
+    vec = zeros(Int, Polymake.betti_number(A))
     torsion_i = Polymake.torsion(A)
     for (p,k) in torsion_i
         append!(vec, fill(p,k))
     end
-    return vec
+    return abelian_group(vec)
 end
 
 ################################################################################
@@ -216,7 +216,7 @@ julia> [ homology(real_projective_plane(), i) for i in [0,1,2] ]
  GrpAb: Z/1
 ```
 """
-homology(K::SimplicialComplex, i::Int) = abelian_group(_convert_finitely_generated_abelian_group(pm_object(K).HOMOLOGY[i+1])) # index shift
+homology(K::SimplicialComplex, i::Int) = _convert_finitely_generated_abelian_group(pm_object(K).HOMOLOGY[i+1]) # index shift
 
 @doc Markdown.doc"""
     cohomology(K::SimplicialComplex, i::Int)
@@ -232,7 +232,7 @@ julia> cohomology(K,1)
 [1]
 ```
 """
-cohomology(K::SimplicialComplex, i::Int) = abelian_group(_convert_finitely_generated_abelian_group(pm_object(K).COHOMOLOGY[i+1])) # index shift
+cohomology(K::SimplicialComplex, i::Int) = _convert_finitely_generated_abelian_group(pm_object(K).COHOMOLOGY[i+1]) # index shift
 
 @doc Markdown.doc"""
     minimal_nonfaces(K::SimplicialComplex)

--- a/test/Combinatorics/SimplicialComplexes.jl
+++ b/test/Combinatorics/SimplicialComplexes.jl
@@ -38,5 +38,18 @@
         end
         
     end
+
+    @testset "torus homology" begin
+        T = torus()
+        H0 = homology(T, 0)
+        H1 = homology(T, 1)
+        H2 = homology(T, 2)
+        @test istrivial(H0)
+        @test !istrivial(H1)
+        @test !istrivial(H2)
+        @test rank(H0) == 0
+        @test rank(H1) == 2
+        @test rank(H2) == 1
+    end
     
 end


### PR DESCRIPTION
The free part of the (co-)homology is missing, since in
```
function _convert_finitely_generated_abelian_group(A::Polymake.HomologyGroupAllocated{Polymake.Integer})
    vec = ones(Int, Polymake.betti_number(A))
    torsion_i = Polymake.torsion(A)
    for (p,k) in torsion_i
        append!(vec, fill(p,k))
    end
    return vec
end
```
it is given by ones instead of zeros. Here I propose a fix by writing the resulting group as a `direct_product`. Instead `vec` could also just be initialized with zeros. Let me know which solution you prefer.