### PR TITLE
Fix overwritten constructors

### DIFF
--- a/docs/src/PolyhedralGeometry/Polyhedra/polymake.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/polymake.md
@@ -30,7 +30,7 @@ functions allow extracting the underlying `Polymake.jl` object from a
 polyhedron into a high-level `Polyhedron` object.
 
 ```@docs
-Polyhedron(::Polymake.BigObject)
+Polyhedron{T}(::Polymake.BigObject) where T<:scalar_types
 ```
 
 The following shows all the data currently known for a `Polyhedron`.

--- a/src/PolyhedralGeometry/Polyhedron/constructors.jl
+++ b/src/PolyhedralGeometry/Polyhedron/constructors.jl
@@ -4,11 +4,17 @@
 ###############################################################################
 ###############################################################################
 
-struct Polyhedron{T} #a real polymake polyhedron
+struct Polyhedron{T<:scalar_types} #a real polymake polyhedron
     pm_polytope::Polymake.BigObject
-    
+
     # only allowing scalar_types;
     # can be improved by testing if the template type of the `BigObject` corresponds to `T`
+
+    """
+        Polyhedron{T}(P::Polymake.BigObject) where T<:scalar_types
+
+    Construct a `Polyhedron` corresponding to a `Polymake.BigObject` of type `Polytope`.
+    """
     Polyhedron{T}(p::Polymake.BigObject) where T<:scalar_types = new{T}(p)
 end
 
@@ -20,17 +26,6 @@ Polyhedron(x...) = Polyhedron{fmpq}(x...)
 Polyhedron(p::Polymake.BigObject) = Polyhedron{detect_scalar_type(Polyhedron, p)}(p)
 
 @doc Markdown.doc"""
-
-    Polyhedron{T}(P::Polymake.BigObject) where T<:scalar_types
-
-Construct a `Polyhedron` corresponding to a `Polymake.BigObject` of type `Polytope`.
-"""
-function Polyhedron{T}(pm_polytope::Polymake.BigObject) where T<:scalar_types
-    Polyhedron{T}(pm_polytope, :unknown)
-end
-
-@doc Markdown.doc"""
-
     Polyhedron{T}(A::Union{Oscar.MatElem,AbstractMatrix}, b) where T<:scalar_types
 
 The (convex) polyhedron defined by

--- a/src/PolyhedralGeometry/Polyhedron/constructors.jl
+++ b/src/PolyhedralGeometry/Polyhedron/constructors.jl
@@ -10,10 +10,11 @@ struct Polyhedron{T<:scalar_types} #a real polymake polyhedron
     # only allowing scalar_types;
     # can be improved by testing if the template type of the `BigObject` corresponds to `T`
 
-    """
+    @doc Markdown.doc"""
         Polyhedron{T}(P::Polymake.BigObject) where T<:scalar_types
 
     Construct a `Polyhedron` corresponding to a `Polymake.BigObject` of type `Polytope`.
+    The type parameter `T` is optional but recommended for type stability.
     """
     Polyhedron{T}(p::Polymake.BigObject) where T<:scalar_types = new{T}(p)
 end


### PR DESCRIPTION
This fixes the following precompilation warning:

    WARNING: Method definition (::Type{Oscar.Polyhedron{T}})(Polymake.BigObject)
    where {T<:Union{Float64, Nemo.fmpq, Nemo.nf_elem}} in module Oscar at
    .../Oscar.jl/src/PolyhedralGeometry/Polyhedron/constructors.jl:12 overwritten
    at .../Oscar.jl/src/PolyhedralGeometry/Polyhedron/constructors.jl:28.
      ** incremental compilation may be fatally broken for this module **
