### PR TITLE
Fix "Replacing docs" precompilation warnings

### DIFF
--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -178,15 +178,15 @@ end
 @doc Markdown.doc"""
     FreeModElem_dec(c::SRow{T}, parent::FreeMod_dec{T}) where T
 
-Return the element of `F` whose coefficients with respect to the basis of 
+Return the element of `F` whose coefficients with respect to the basis of
 standard unit vectors of `F` are given by the entries of `c`.
 """
 FreeModElem_dec(c::SRow{T}, parent::FreeMod_dec{T}) where T = FreeModElem_dec{T}(c, parent)
 
 @doc Markdown.doc"""
     FreeModElem_dec(c::Vector{T}, parent::FreeMod_dec{T}) where T
-    
-Return the element of `F` whose coefficients with respect to the basis of 
+
+Return the element of `F` whose coefficients with respect to the basis of
 standard unit vectors of `F` are given by the entries of `c`.
 """
 function FreeModElem_dec(c::Vector{T}, parent::FreeMod_dec{T}) where T
@@ -195,22 +195,22 @@ function FreeModElem_dec(c::Vector{T}, parent::FreeMod_dec{T}) where T
   return FreeModElem_dec{T}(sparse_coords,parent)
 end
 
-@doc Markdown.doc"""
-    (F::FreeMod_dec{T})(c::SRow{T}) where T
-    
-Return the element of `F` whose coefficients with respect to the basis of 
-standard unit vectors of `F` are given by the entries of `c`.
-"""
+#@doc Markdown.doc"""
+#    (F::FreeMod_dec{T})(c::SRow{T}) where T
+#
+#Return the element of `F` whose coefficients with respect to the basis of
+#standard unit vectors of `F` are given by the entries of `c`.
+#"""
 function (F::FreeMod_dec{T})(c::SRow{T}) where T
   return FreeModElem_dec(c, F)
 end
 
-@doc Markdown.doc"""
-    (F::FreeMod_dec{T})(c::Vector{T}) where T
-
-Return the element of `F` whose coefficients with respect to the basis of 
-standard unit vectors of `F` are given by the entries of `c`.
-"""
+#@doc Markdown.doc"""
+#    (F::FreeMod_dec{T})(c::Vector{T}) where T
+#
+#Return the element of `F` whose coefficients with respect to the basis of
+#standard unit vectors of `F` are given by the entries of `c`.
+#"""
 function (F::FreeMod_dec{T})(c::Vector{T}) where T 
   return FreeModElem_dec(c, F)
 end

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -120,15 +120,15 @@ end
 @doc Markdown.doc"""
     FreeModElem(c::SRow{T}, parent::FreeMod{T}) where T
 
-Return the element of  `F`  whose coefficients with respect to the basis of 
+Return the element of `F` whose coefficients with respect to the basis of
 standard unit vectors of `F` are given by the entries of `c`.
 """
 FreeModElem(c::SRow{T}, parent::FreeMod{T}) where T = FreeModElem{T}(c, parent)
 
 @doc Markdown.doc"""
     FreeModElem(c::Vector{T}, parent::FreeMod{T}) where T
-    
-Return the element of  `F`  whose coefficients with respect to the basis of 
+
+Return the element of `F` whose coefficients with respect to the basis of
 standard unit vectors of `F` are given by the entries of `c`.
 """
 function FreeModElem(c::Vector{T}, parent::FreeMod{T}) where T
@@ -137,40 +137,40 @@ function FreeModElem(c::Vector{T}, parent::FreeMod{T}) where T
   return FreeModElem{T}(sparse_coords,parent)
 end
 
-@doc Markdown.doc"""
-    (F::FreeMod{T})(c::SRow{T}) where T
-    
-Return the element of  `F`  whose coefficients with respect to the basis of 
-standard unit vectors of `F` are given by the entries of `c`.
-"""
+#@doc Markdown.doc"""
+#    (F::FreeMod{T})(c::SRow{T}) where T
+#
+#Return the element of `F` whose coefficients with respect to the basis of
+#standard unit vectors of `F` are given by the entries of `c`.
+#"""
 function (F::FreeMod{T})(c::SRow{T}) where T
   return FreeModElem(c, F)
 end
 
-@doc Markdown.doc"""
-    (F::FreeMod{T})(c::Vector{T}) where T
-
-Return the element of  `F`  whose coefficients with respect to the basis of 
-standard unit vectors of `F` are given by the entries of `c`.
-
-# Examples
-```jldoctest
-julia> R, (x,y) = PolynomialRing(QQ, ["x", "y"])
-(Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
-
-julia> F = FreeMod(R,3)
-Free module of rank 3 over Multivariate Polynomial Ring in x, y over Rational Field
-
-julia> V = [x, zero(R), y]
-3-element Vector{fmpq_mpoly}:
- x
- 0
- y
-
-julia> f = F(V)
-x*e[1] + y*e[3]
-```
-"""
+#@doc Markdown.doc"""
+#    (F::FreeMod{T})(c::Vector{T}) where T
+#
+#Return the element of `F` whose coefficients with respect to the basis of
+#standard unit vectors of `F` are given by the entries of `c`.
+#
+## Examples
+#```jldoctest
+#julia> R, (x,y) = PolynomialRing(QQ, ["x", "y"])
+#(Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
+#
+#julia> F = FreeMod(R,3)
+#Free module of rank 3 over Multivariate Polynomial Ring in x, y over Rational Field
+#
+#julia> V = [x, zero(R), y]
+#3-element Vector{fmpq_mpoly}:
+# x
+# 0
+# y
+#
+#julia> f = F(V)
+#x*e[1] + y*e[3]
+#```
+#"""
 function (F::FreeMod{T})(c::Vector{T}) where T 
  return FreeModElem(c, F)
 end


### PR DESCRIPTION
Fix the following shown while precompiling Oscar:

    ┌ Warning: Replacing docs for `Oscar.F :: Union{Tuple{Hecke.SRow{T}}, Tuple{T}} where T` in module `Oscar`
    └ @ Base.Docs docs/Docs.jl:240
    ┌ Warning: Replacing docs for `Oscar.F :: Union{Tuple{Vector{T}}, Tuple{T}} where T` in module `Oscar`
    └ @ Base.Docs docs/Docs.jl:240

Resolves #1061