### PR TITLE
versioninfo: add commit + commit-date

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,11 +24,11 @@ the bug is of mathematical nature we will need the mathematical context. If
 applicable please provide references to relevant papers.
 
 **System (please complete the following information):**
-Please paste the output of `Oscar.versioninfo(jll=true,julia=true)` below. If
-this does not work, please paste the output of Julia's `versioninfo()` and your
-Oscar version.
+Please paste the output of `Oscar.versioninfo(full=true)` below. If this does
+not work, please paste the output of Julia's `versioninfo()` and your Oscar
+version.
 ```
-julia> Oscar.versioninfo(jll=true,julia=true)
+julia> Oscar.versioninfo(full=true)
 OSCAR version 0.8.3-DEV
 ...
 ```

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -70,14 +70,16 @@ function _print_dependency_versions(io::IO, deps::AbstractArray{<:AbstractString
 end
 
 @doc Markdown.doc"""
-    Oscar.versioninfo(io::IO=stdout; branch=false, jll=false, julia=false)
+    Oscar.versioninfo(io::IO=stdout; branch=false, jll=false, julia=false, commit=false, full=false)
 
 Print the versions of all Oscar-related dependencies.
 
 # Arguments
 - `branch::Bool=false`: include git branch name in the output
+- `commit::Bool=false`: include git commit hash and date where applicable
 - `jll::Bool=false`   : include binary packages (jll) in the output
 - `julia::Bool=false` : include julia `versioninfo` output
+- `full::Bool=false`  : include all of the above
 """
 function versioninfo(io::IO=stdout; branch=false, jll=false, julia=false, commit=false, full=false)
    if full

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -33,6 +33,11 @@ const jll_deps = String["Antic_jll", "Arb_jll", "Calcium_jll", "FLINT_jll", "GAP
                         "libpolymake_julia_jll", "libsingular_julia_jll", "msolve_jll",
                         "polymake_jll", "Singular_jll"];
 
+# When a specific branch is loaded via `]add Package#branch` julia will only
+# create a checkout and keep a bare git repo in a separate directory.
+# In a bare repo HEAD will not point to the correct commit so we use the git
+# tree-hash that Pkg.jl provides and manually map this to a corresponding
+# commit.
 function _lookup_commit_from_cache(url::AbstractString, tree::AbstractString)
    if Sys.which("git") != nothing
       try

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -33,36 +33,39 @@ const jll_deps = String["Antic_jll", "Arb_jll", "Calcium_jll", "FLINT_jll", "GAP
                         "libpolymake_julia_jll", "libsingular_julia_jll", "msolve_jll",
                         "polymake_jll", "Singular_jll"];
 
-function _lookup_git_branch(dir::AbstractString)
+function _lookup_git_branch(dir::AbstractString; commit=false)
+   info = ""
    if length(Sys.which("git")) != nothing &&
          isdir(joinpath(dir,".git"))
       try
-         ref = cd(dir) do
-            readchomp(`git rev-parse --abbrev-ref HEAD`)
+         ref = readchomp(`git -C $dir rev-parse --abbrev-ref HEAD`)
+         info = " - #$(ref)"
+         if commit
+            c = readchomp(`git -C $dir show -s --format="%h -- %ci" HEAD`)
+            info = "$info, $c"
          end
-         return " - branch #$(ref)"
       catch
       end
    end
-   return ""
+   return info
 end
 
-function _deps_git_info(dep::Pkg.API.PackageInfo)
+function _deps_git_info(dep::Pkg.API.PackageInfo; commit=false)
    if dep.is_tracking_repo
-      return " - branch #$(dep.git_revision)"
+      return " - #$(dep.git_revision)"
    elseif dep.is_tracking_path
-      return _lookup_git_branch(dep.source)
+      return _lookup_git_branch(dep.source; commit=commit)
    end
    return ""
 end
 
-function _print_dependency_versions(io::IO, deps::AbstractArray{<:AbstractString}; padding="    ", suffix="", branch=false)
+function _print_dependency_versions(io::IO, deps::AbstractArray{<:AbstractString}; padding="    ", suffix="", branch=false, commit=false)
    width = maximum(length.(deps))+length(suffix)+2
    deps = filter(d->d.name in deps, collect(values(Pkg.dependencies())))
    deps = sort!(deps; by=x->x.name)
    for dep in deps
       print(io, "$(padding)$(rpad(dep.name*suffix, width, ' ')) v$(dep.version)")
-      println(io, branch ? _deps_git_info(dep) : "")
+      println(io, branch ? _deps_git_info(dep; commit=commit) : "")
    end
 end
 
@@ -76,14 +79,17 @@ Print the versions of all Oscar-related dependencies.
 - `jll::Bool=false`   : include binary packages (jll) in the output
 - `julia::Bool=false` : include julia `versioninfo` output
 """
-function versioninfo(io::IO=stdout; branch=false, jll=false, julia=false)
+function versioninfo(io::IO=stdout; branch=false, jll=false, julia=false, commit=false, full=false)
+   if full
+      branch = jll = julia = commit = true
+   end
    print(io, "OSCAR version $(VERSION_NUMBER)")
-   println(io, branch ? _lookup_git_branch(dirname(@__DIR__)) : "")
+   println(io, branch ? _lookup_git_branch(dirname(@__DIR__); commit=commit) : "")
    println(io, "  combining:")
-   _print_dependency_versions(io, cornerstones; suffix=".jl", branch=branch)
+   _print_dependency_versions(io, cornerstones; suffix=".jl", branch=branch, commit=commit)
    if jll
       println(io, "  building on:")
-      _print_dependency_versions(io, jll_deps; branch=branch)
+      _print_dependency_versions(io, jll_deps; branch=branch, commit=commit)
       println(io, "See `]st -m` for a full list of dependencies.")
    end
    if julia


### PR DESCRIPTION
commit and commit-date ~~will only work when the package is used from a git clone.~~ now works even with Pkg.jl clones using the cached repo.

add `full` option to enable all output and use it in the issue template.

full output looks like this:
```julia
julia> Oscar.versioninfo(full=true)
OSCAR version 0.9.0-DEV - #bl/versioninfo, 3abd56b310 -- 2022-05-12 23:36:56 +0200
  combining:
    AbstractAlgebra.jl   v0.25.3
    GAP.jl               v0.8.0-DEV - #bl/sigchld, 6e62777 -- 2022-04-14 13:20:04 +0200
    Hecke.jl             v0.13.4
    Nemo.jl              v0.30.0
    Polymake.jl          v0.7.2 - #master, 9242f08 -- 2022-04-23 23:39:19 +0200
    Singular.jl          v0.10.1
  building on:
    Antic_jll               v0.200.501+0
    Arb_jll                 v200.2200.0+0
    Calcium_jll             v0.400.102+0
    FLINT_jll               v200.800.500+0
    GAP_jll                 v400.1192.2+1
    Singular_jll            v403.1.300+0
    libpolymake_julia_jll   v0.8.0+2
    libsingular_julia_jll   v0.23.1+0
    msolve_jll              v0.2.3+1
    polymake_jll            v400.600.0+0
See `]st -m` for a full list of dependencies.

Julia Version 1.8.0-beta3
Commit 3e092a2521 (2022-03-29 15:42 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: 8 × 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-13.0.1 (ORCJIT, tigerlake)
  Threads: 1 on 8 virtual cores
Environment:
  JULIA_CXX_RTTI = 1
  JULIA_CPU_TARGET = native
Official https://julialang.org/ release
```
(Oscar is using a git directory, GAP as well, for Polymake.jl I did `]add Polymake#master`.