### PR TITLE
Serialize Symbols; add some tests, minor cleanup

### DIFF
--- a/src/Serialization/basic_types.jl
+++ b/src/Serialization/basic_types.jl
@@ -1,11 +1,11 @@
 ################################################################################
 # fmpz
-function load_internal(s::DeserializerState, ::Type{fmpz}, str::String)
-    return fmpz(str)
-end
-
 function save_internal(s::SerializerState, z::fmpz)
     return string(z)
+end
+
+function load_internal(s::DeserializerState, ::Type{fmpz}, str::String)
+    return fmpz(str)
 end
 
 

--- a/src/Serialization/basic_types.jl
+++ b/src/Serialization/basic_types.jl
@@ -29,3 +29,14 @@ end
 function load_internal(s::DeserializerState, ::Type{String}, str::String)
     return str
 end
+
+
+################################################################################
+# Symbol
+function save_internal(s::SerializerState, sym::Symbol)
+   return string(sym)
+end
+
+function load_internal(s::DeserializerState, ::Type{Symbol}, str::String)
+   return Symbol(str)
+end

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -101,7 +101,7 @@ end
 ################################################################################
 # High level
 function save_type_dispatch(s::SerializerState, obj::T) where T
-    if !isprimitivetype(T) && !Base.issingletontype(T)
+    if !isprimitivetype(T) && !Base.issingletontype(T) && T !== Symbol
         # if obj is already serialzed, just output
         # a backref
         ref = get(s.objmap, obj, nothing)

--- a/test/Serialization/basic_types.jl
+++ b/test/Serialization/basic_types.jl
@@ -23,5 +23,14 @@
             @test loaded isa String
             @test loaded == original
         end
+
+        @testset "Symbol" begin
+            original = :original
+            filename = joinpath(path, "original.json")
+            save(original, filename)
+            loaded = load(filename)
+            @test loaded isa Symbol
+            @test loaded == original
+        end
     end
 end

--- a/test/Serialization/basic_types.jl
+++ b/test/Serialization/basic_types.jl
@@ -3,9 +3,11 @@
     mktempdir() do path
         @testset "Testing (de)serialization of $(T)" for T in 
             (
-                UInt, UInt128, UInt16, UInt32, UInt64, UInt8,
-                Int, Int128, Int16, Int32, Int64, Int8,
-                Float16, Float32, Float64
+                UInt, UInt8, UInt16, UInt32, UInt64, UInt128,
+                Int, Int8, Int16, Int32, Int64, Int128,
+                Float16, Float32, Float64,
+                BigInt,
+                fmpz,
             )
             original = T(1)
             filename = joinpath(path, string(T)*".json")


### PR DESCRIPTION
Resolves #1325.

This slightly overlaps @antonydellavecchia PR #1291 which also adds code for serializing `Symbol` but with backrefs. Since @antonydellavecchia asked about how to avoid that, here it is.