### PR TITLE
Resolve #1195

### DIFF
--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -113,6 +113,25 @@ function Base.getindex(R::MPolyRing, i::Int)
   return gen(R, i)
 end
 
+ngens(F::AbstractAlgebra.Generic.FracField{T}) where {T <: MPolyElem} = ngens(base_ring(F))
+
+function gen(F::AbstractAlgebra.Generic.FracField{T}) where {T <: PolyElem}
+  return F(gen(base_ring(F)))
+end
+
+function gen(F::AbstractAlgebra.Generic.FracField{T}, i::Int) where {T <: MPolyElem}
+  return F(gen(base_ring(F), i))
+end
+
+function gens(F::AbstractAlgebra.Generic.FracField{T}) where {T <: Union{PolyElem, MPolyElem}}
+  return map(F, gens(base_ring(F)))
+end
+
+function Base.getindex(F::AbstractAlgebra.Generic.FracField{T}, i::Int) where {T <: MPolyElem}
+  i == 0 && return zero(F)
+  return gen(F, i)
+end
+
 ######################################################################
 # pretty printing for iJulia notebooks..
 #

--- a/test/Rings/mpoly-test.jl
+++ b/test/Rings/mpoly-test.jl
@@ -243,3 +243,18 @@ end
   I = ideal(R, [x])
   @test x in I
 end
+
+@testset "Fraction fields over polynomial rings" begin
+  R, x = PolynomialRing(QQ, "x")
+  F = FractionField(R)
+  @test gen(F) == F(x)
+  @test gens(F) == elem_type(F)[ F(x) ]
+
+  R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+  F = FractionField(R)
+  @test ngens(F) == 3
+  @test gen(F, 2) == F(y)
+  @test gens(F) == elem_type(F)[ F(x), F(y), F(z) ]
+  @test F[1] == F(x)
+  @test F[0] == zero(F)
+end


### PR DESCRIPTION
Adds `gens`, `gen`, etc. for fraction fields over polynomial rings as requested in #1195 .
I'm actually wondering whether this should be restricted to polynomial rings. If `R` is a ring of a type for which `gens` is implemented then `gens(FractionField(R))` could just work generically. (And otherwise there will be an error either way.)