### PR TITLE
Don't use generic serialization automatically, add a test

### DIFF
--- a/src/Serialization/PolyhedralGeometry.jl
+++ b/src/Serialization/PolyhedralGeometry.jl
@@ -44,4 +44,18 @@ function load_internal(s::DeserializerState, ::Type{LinearProgram{T}}, dict::Dic
     return LinearProgram{T}(fr, lp, Symbol(conv))
 end
 
+# use generic serialization for the other types:
+save_internal(s::SerializerState, obj::Cone) = save_internal_generic(s, obj)
+load_internal(s::DeserializerState, ::Type{T}, dict::Dict) where T <: Cone = load_internal_generic(s, T, dict)
 
+save_internal(s::SerializerState, obj::PolyhedralComplex) = save_internal_generic(s, obj)
+load_internal(s::DeserializerState, ::Type{T}, dict::Dict) where T <: PolyhedralComplex = load_internal_generic(s, T, dict)
+
+save_internal(s::SerializerState, obj::Polyhedron) = save_internal_generic(s, obj)
+load_internal(s::DeserializerState, ::Type{T}, dict::Dict) where T <: Polyhedron = load_internal_generic(s, T, dict)
+
+save_internal(s::SerializerState, obj::PolyhedralFan) = save_internal_generic(s, obj)
+load_internal(s::DeserializerState, ::Type{T}, dict::Dict) where T <: PolyhedralFan = load_internal_generic(s, T, dict)
+
+save_internal(s::SerializerState, obj::SubdivisionOfPoints) = save_internal_generic(s, obj)
+load_internal(s::DeserializerState, ::Type{T}, dict::Dict) where T <: SubdivisionOfPoints = load_internal_generic(s, T, dict)

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -166,7 +166,7 @@ end
 
 ################################################################################
 # Default generic save_internal, load_internal
-function save_internal(s::SerializerState, obj::T) where T
+function save_internal_generic(s::SerializerState, obj::T) where T
     result = Dict{Symbol, Any}()
     for n in fieldnames(T)
         if n != :__attrs
@@ -176,7 +176,7 @@ function save_internal(s::SerializerState, obj::T) where T
     return result
 end
 
-function load_internal(s::DeserializerState, ::Type{T}, dict::Dict) where T
+function load_internal_generic(s::DeserializerState, ::Type{T}, dict::Dict) where T
     fields = []
     for (n,t) in zip(fieldnames(T), fieldtypes(T))
         if n!= :__attrs

--- a/test/Serialization/PolyhedralGeometry.jl
+++ b/test/Serialization/PolyhedralGeometry.jl
@@ -32,7 +32,20 @@
             @test dim(square) == dim(loaded)
             @test square == loaded
         end
-        
+
+        @testset "PolyhedralComplex" begin
+            IM = IncidenceMatrix([[1,2,3],[1,3,4]])
+            vr = [0 0; 1 0; 1 1; 0 1]
+            PC = PolyhedralComplex(IM, vr)
+            save(PC, joinpath(path, "docu.pc"))
+            loaded = load(joinpath(path, "docu.pc"))
+            @test loaded isa PolyhedralComplex
+            @test Base.propertynames(PC) == Base.propertynames(loaded)
+            @test nrays(PC) == nrays(loaded)
+            @test n_maximal_polyhedra(PC) == n_maximal_polyhedra(loaded)
+            @test dim(PC) == dim(loaded)
+        end
+
         @testset "PolyhedralFan" begin
             nfsquare = normal_fan(cube(2))
             save(nfsquare, joinpath(path, "nfsquare.fan"))
@@ -43,7 +56,7 @@
             @test n_maximal_cones(nfsquare) == n_maximal_cones(loaded)
             @test dim(nfsquare) == dim(loaded)
         end
-        
+
         @testset "LinearProgram" begin
             P = cube(3)
             LP = LinearProgram(P,[3,-2,4];k=2,convention = :min)


### PR DESCRIPTION
For some types (e.g. from Nemo, Singular) it can produce nonsense,
even corrupt objects and ultimately crashes.

Instead, allow types to opt-in to this generic handling. This
could be made even nicer with a macro if so desired. So that one could write, say
```julia
@serialize_generic PolyhedralComplex
```
instead of
```
save_internal(s::SerializerState, obj::PolyhedralComplex) = save_internal_generic(s, obj)
load_internal(s::DeserializerState, ::Type{T}, dict::Dict) where T <: PolyhedralComplex = load_internal_generic(s, T, dict)
```
I'd be happy to write such a macro, but before doing that, I'd rather first find out what others think of this PR :-)