### PR TITLE
Remove transitive_identification

### DIFF
--- a/experimental/GaloisGrp/Qt.jl
+++ b/experimental/GaloisGrp/Qt.jl
@@ -171,7 +171,7 @@ function galois_group(FF::Generic.FunctionField{fmpq}; overC::Bool = false)
     @vprint :GaloisGroup 1 "specialising at t = $tStart, computing over Q\n"
     Gal, S = galois_group(K, prime = p)
 
-    @vprint :GaloisGroup 1 "after specialisation, group is: $(transitive_identification(Gal))\n"
+    @vprint :GaloisGroup 1 "after specialisation, group is: $(transitive_group_identification(Gal))\n"
 
 #    @show S.start, S.chn
 

--- a/src/Groups/libraries/transitivegroups.jl
+++ b/src/Groups/libraries/transitivegroups.jl
@@ -156,8 +156,6 @@ function transitive_group_identification(G::PermGroup)
   return deg, res
 end
 
-@deprecate transitive_identification(x) transitive_group_identification(x)[1]
-
 """
     all_transitive_groups(L...)
 


### PR DESCRIPTION
It was deprecated, and wrong (the `[1]` should have been `[2]`).
Instead of fixing this (and adding a test, etc.), let's just remove it.
