### PR TITLE
Remove `trace(::MatrixGroupElem)`

### DIFF
--- a/docs/src/Groups/matgroup.md
+++ b/docs/src/Groups/matgroup.md
@@ -30,7 +30,7 @@ matrix(x::MatrixGroupElem)
 base_ring(x::MatrixGroupElem)
 nrows(x::MatrixGroupElem)
 det(x::MatrixGroupElem)
-trace(x::MatrixGroupElem)
+tr(x::MatrixGroupElem)
 multiplicative_jordan_decomposition(x::MatrixGroupElem)
 is_semisimple(x::MatrixGroupElem{T}) where T <: FinFieldElem
 is_unipotent(x::MatrixGroupElem{T}) where T <: FinFieldElem

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -483,13 +483,11 @@ Return the number of rows of the given matrix.
 nrows(x::MatrixGroupElem) = x.parent.deg
 
 """
-    trace(x::MatrixGroupElem)
     tr(x::MatrixGroupElem)
 
-Return the trace of `x`.
+Return the trace of the underlying matrix of `x`.
 """
-trace(x::MatrixGroupElem) = trace(x.elm)
-tr(x::MatrixGroupElem) = tr(x.elm)
+tr(x::MatrixGroupElem) = tr(matrix(x))
 
 #FIXME for the following functions, the output may not belong to the parent group of x
 #=

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -444,7 +444,7 @@ end
    @test !isone(x)
    @test det(x)==1
    @test det(y)==z+2
-   @test trace(x)==2
+   @test tr(x)==2
    @test tr(y)==z
    @test order(x)==3
    @test order(y)==8


### PR DESCRIPTION
Everything else uses `tr`, no need to be a special snowflake.
If we want `trace` as an alias, we should do this globally.
