### PR TITLE
Miscellaneous changes to the groups code

### DIFF
--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -351,7 +351,7 @@ end
 
 # embedding an element of type MatElem into a group G
 # if check=false, there are no checks on the condition `x in G`
-function (G::MatrixGroup)(x::MatElem; check=true)
+function (G::MatrixGroup)(x::MatElem; check::Bool=true)
    if check
       _is_true, x_gap = lies_in(x,G,nothing)
       _is_true || throw(ArgumentError("Element not in the group"))
@@ -362,7 +362,7 @@ end
 
 # embedding an element of type MatrixGroupElem into a group G
 # if check=false, there are no checks on the condition `x in G`
-function (G::MatrixGroup)(x::MatrixGroupElem; check=true)
+function (G::MatrixGroup)(x::MatrixGroupElem; check::Bool=true)
    if !check
       z = x
       z.parent = G
@@ -386,8 +386,8 @@ function (G::MatrixGroup)(x::MatrixGroupElem; check=true)
    end
 end
 
-# embedding a nxn array into a group G
-function (G::MatrixGroup)(L::AbstractVecOrMat; check=true)
+# embedding a n x n array into a group G
+function (G::MatrixGroup)(L::AbstractVecOrMat; check::Bool=true)
    x = matrix(G.ring, G.deg, G.deg, L)
    return G(x; check=check)
 end
@@ -453,14 +453,14 @@ comm(x::MatrixGroupElem, y::MatrixGroupElem) = inv(x)*conj(x,y)
 """
     det(x::MatrixGroupElem)
     
-Return the determinant of `x`.
+Return the determinant of the underlying matrix of `x`.
 """
-det(x::MatrixGroupElem) = det(x.elm)
+det(x::MatrixGroupElem) = det(matrix(x))
 
 """
     base_ring(x::MatrixGroupElem)
 
-Return the base ring of `x`.
+Return the base ring of the underlying matrix of `x`.
 """
 base_ring(x::MatrixGroupElem) = x.parent.ring
 
@@ -469,7 +469,7 @@ parent(x::MatrixGroupElem) = x.parent
 """
     matrix(x::MatrixGroupElem)
 
-Return the underlying `AbstractAlgebra` matrix of `x`.
+Return the underlying matrix of `x`.
 """
 matrix(x::MatrixGroupElem) = x.elm
 
@@ -478,9 +478,17 @@ Base.getindex(x::MatrixGroupElem, i::Int, j::Int) = x.elm[i,j]
 """
     nrows(x::MatrixGroupElem)
 
-Return the number of rows of the given matrix.
+Return the number of rows of the underlying matrix of `x`.
 """
-nrows(x::MatrixGroupElem) = x.parent.deg
+nrows(x::MatrixGroupElem) = nrows(matrix(x))
+
+"""
+    ncols(x::MatrixGroupElem)
+
+Return the number of columns of the underlying matrix of `x`.
+"""
+ncols(x::MatrixGroupElem) = ncols(matrix(x))
+
 
 """
     trace(x::MatrixGroupElem)


### PR DESCRIPTION
- add some type annotations
- improve some docstrings
- replace some low-level access by use of accessor functions
- add `ncols(::MatrixGroupElem)` to complement `nrows(::MatrixGroupElem)`
  (they will always return the same value, but it seems natural to offer
  both, and will potentially prevent some confusion for some poor sod
  down the line)
