### PR TITLE
improvements/extensions for G-sets

### DIFF
--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -1342,7 +1342,7 @@ function coimage(h::Map)
   return quo(domain(h), kernel(h)[1])
 end
 
-function Base.iterate(M::Generic.Submodule{<:FinFieldElem})
+function Base.iterate(M::Union{Generic.FreeModule{T}, Generic.Submodule{T}}) where T <: FinFieldElem
   k = base_ring(M)
   if dim(M) == 0
     return zero(M), iterate([1])
@@ -1352,16 +1352,24 @@ function Base.iterate(M::Generic.Submodule{<:FinFieldElem})
   return M(elem_type(k)[f[1][i] for i=1:dim(M)]), (f[2], p)
 end
 
-function Base.iterate(::AbstractAlgebra.Generic.Submodule{fq_nmod}, ::Tuple{Int64, Int64})
+function Base.iterate(::Union{Generic.FreeModule{fq_nmod}, Generic.Submodule{fq_nmod}}, ::Tuple{Int64, Int64})
   return nothing
 end
 
-function Base.iterate(M::Generic.Submodule{<:FinFieldElem}, st::Tuple{<:Tuple, <:Base.Iterators.ProductIterator})
+function Base.iterate(M::Union{Generic.FreeModule{T}, Generic.Submodule{T}}, st::Tuple{<:Tuple, <:Base.Iterators.ProductIterator}) where T <: FinFieldElem
   n = iterate(st[2], st[1])
   if n === nothing
     return n
   end
   return M(elem_type(base_ring(M))[n[1][i] for i=1:dim(M)]), (n[2], st[2])
+end
+
+function Base.length(M::Union{Generic.FreeModule{T}, Generic.Submodule{T}}) where T <: FinFieldElem
+  return Int(order(base_ring(M))^dim(M))
+end
+
+function Base.eltype(M::Union{Generic.FreeModule{T}, Generic.Submodule{T}}) where T <: FinFieldElem
+  return elem_type(M)
 end
 
 """

--- a/experimental/GaloisGrp/Group.jl
+++ b/experimental/GaloisGrp/Group.jl
@@ -29,7 +29,5 @@ function action_on_blocks(G::PermGroup, B::Vector{Int})
 end
 
 function action_on_block_system(G::PermGroup, B::Vector{Vector{Int}})
-  Omega = gset(G, on_sets, B)
-  set_attribute!(Omega, :elements => Omega.seeds)
-  return action_homomorphism(Omega)
+  return action_homomorphism(gset(G, on_sets, B; closed = true))
 end

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -52,15 +52,18 @@ abstract type GSet{T} end
     action_function::Function
     seeds
 
-    function GSetByElements(G::T, fun::Function, seeds) where T<:GAPGroup
+    function GSetByElements(G::T, fun::Function, seeds; closed::Bool = false) where T<:GAPGroup
         @assert ! isempty(seeds)
-        return new{T}(G, fun, seeds, Dict{Symbol,Any}())
+        Omega = new{T}(G, fun, seeds, Dict{Symbol,Any}())
+        closed && set_attribute!(Omega, :elements => collect(seeds))
+        return Omega
     end
 end
 #TODO: How can I specify that `seeds` should be an iterable object?
 
-# TODO: document `acting_group` and GSets in general
-acting_group(gset::GSetByElements) = gset.group
+# TODO: document `acting_group`, `action_function`
+acting_group(Omega::GSetByElements) = Omega.group
+action_function(Omega::GSetByElements) = Omega.action_function
 
 
 #############################################################################
@@ -68,18 +71,25 @@ acting_group(gset::GSetByElements) = gset.group
 ##  general method with explicit action function
 
 """
-    gset(G::GAPGroup[, fun::Function], Omega)
+    gset(G::GAPGroup[, fun::Function], seeds, closed::Bool = false)
 
-Return the G-set that consists of the closure of the seeds `Omega`
+Return the G-set `Omega` that consists of the closure of the seeds `seeds`
 under the action of `G` defined by `fun`.
 
-This means that the result contains all elements `fun(omega, g)`
-for `omega` in `Omega` and `g` in `G`.
+This means that `Omega` contains all elements `fun(omega, g)`
+for `omega` in `seeds` and `g` in `G`.
 
-`fun` can be omitted if the element type of `Omega` implies
+`fun` can be omitted if the element type of `seeds` implies
 a reasonable default,
-for example, if `G` is a `PermGroup` and `Omega` is a `Vector{T}` where
-`T` is one of `Int`, `Set{Int}`, `Vector{Int}`.
+for example, if `G` is a `PermGroup` and `seeds` is a `Vector{T}`
+where `T` is one of `Int`, `Set{Int}`, `Vector{Int}`.
+
+If `closed` is set to `true` then `seeds` is assumed to be closed
+under the action of `G`.
+In this case, `collect(Omega)` is guaranteed to be equal to `collect(seeds)`;
+in particular, the ordering of points in `seeds` (if applicable) is kept.
+Note that the indexing of points in `Omega` is used by
+[`action_homomorphism`](@ref).
 
 # Examples
 ```jldoctest
@@ -96,7 +106,9 @@ julia> length(gset(G, on_sets, [[1, 2]]))  # action on unordered pairs
 
 ```
 """
-gset(G::GAPGroup, fun::Function, Omega) = GSetByElements(G, fun, Omega)
+function gset(G::GAPGroup, fun::Function, seeds; closed::Bool = false)
+  return GSetByElements(G, fun, seeds; closed = closed)
+end
 
 
 #############################################################################
@@ -104,31 +116,56 @@ gset(G::GAPGroup, fun::Function, Omega) = GSetByElements(G, fun, Omega)
 ##  G-sets where the action function can be omitted
 ##
 ##  (We use an indirection via `gset_by_type`, in order to admit specifying
-##  a default action depending on the element type of `Omega` (which can be
+##  a default action depending on the element type of `seeds` (which can be
 ##  any iterable collection.)
 
-gset(G::T, Omega) where T<:GAPGroup = gset_by_type(G, Omega, eltype(Omega))
+gset(G::T, seeds; closed::Bool = false) where T<:GAPGroup = gset_by_type(G, seeds, eltype(seeds); closed = closed)
 
 
 ## natural action of permutations on positive integers
-gset_by_type(G::PermGroup, Omega, ::Type{T}) where T<:IntegerUnion = GSetByElements(G, ^, Omega)
+function gset_by_type(G::PermGroup, Omega, ::Type{T}; closed::Bool = false) where T<:IntegerUnion
+  return GSetByElements(G, ^, Omega; closed = closed)
+end
 
 ## action of permutations on sets of positive integers
-gset_by_type(G::PermGroup, Omega, ::Type{T}) where T<:Set{T2} where T2<:IntegerUnion = GSetByElements(G, on_sets, Omega)
+function gset_by_type(G::PermGroup, Omega, ::Type{T}; closed::Bool = false) where T<:Set{T2} where T2<:IntegerUnion
+  return GSetByElements(G, on_sets, Omega; closed = closed)
+end
 
 ## action of permutations on vectors of positive integers
-gset_by_type(G::PermGroup, Omega, ::Type{T}) where T<:Vector{T2} where T2<:IntegerUnion = GSetByElements(G, on_tuples, Omega)
+function gset_by_type(G::PermGroup, Omega, ::Type{T}; closed::Bool = false) where T<:Vector{T2} where T2<:IntegerUnion
+  return GSetByElements(G, on_tuples, Omega; closed = closed)
+end
 
 ## action of permutations on tuples of positive integers
-gset_by_type(G::PermGroup, Omega, ::Type{T}) where T<:Tuple{Vararg{T2}} where T2<:IntegerUnion = GSetByElements(G, on_tuples, Omega)
+function gset_by_type(G::PermGroup, Omega, ::Type{T}; closed::Bool = false) where T<:Tuple{Vararg{T2}} where T2<:IntegerUnion
+  return GSetByElements(G, on_tuples, Omega; closed = closed)
+end
+
+## action of matrices on vectors via right multiplication
+function gset_by_type(G::MatrixGroup{E, M}, Omega, ::Type{AbstractAlgebra.Generic.FreeModuleElem{E}}; closed::Bool = false) where E where M
+  return GSetByElements(G, *, Omega; closed = closed)
+end
+
+## action of matrices on sets of vectors via right multiplication
+function gset_by_type(G::MatrixGroup{E, M}, Omega, ::Type{T}; closed::Bool = false) where T <: Set{AbstractAlgebra.Generic.FreeModuleElem{E}} where E where M
+  return GSetByElements(G, on_sets, Omega; closed = closed)
+end
+
+## action of matrices on vectors of vectors via right multiplication
+function gset_by_type(G::MatrixGroup{E, M}, Omega, ::Type{T}; closed::Bool = false) where T <: Vector{AbstractAlgebra.Generic.FreeModuleElem{E}} where E where M
+  return GSetByElements(G, on_tuples, Omega; closed = closed)
+end
 
 ## (add more such actions: on sets of sets, on sets of tuples, ...)
 
 ## natural action of a permutation group on the integers 1, ..., degree
-function gset(G::PermGroup)
-    omega = gset(G, 1:G.deg)
-    set_attribute!(omega, :elements => omega.seeds)
-    return omega
+gset(G::PermGroup) = gset(G, 1:G.deg; closed = true)
+
+## natural action of a matrix group over a finite field on vectors
+function gset(G::MatrixGroup{T, MT}) where T <: FinFieldElem where MT
+    V = free_module(base_ring(G), degree(G))
+    return gset(G, collect(V); closed = true)
 end
 
 
@@ -148,9 +185,7 @@ end
 ##  G-sets given by the complete set
 
 function as_gset(G::T, fun::Function, Omega) where T<:GAPGroup
-    omega = GSetByElements(G, fun, Omega)
-    set_attribute!(omega, :elements => omega.seeds)
-    return omega
+    return GSetByElements(G, fun, Omega; closed = true)
 end
 
 as_gset(G::T, Omega) where T<:GAPGroup = as_gset(G, ^, Omega)
@@ -177,7 +212,8 @@ end
 
 function ^(omega::ElementOfGSet, g::T) where {T<:AbstractAlgebra.GroupElem}
     Omega = omega.gset
-    return ElementOfGSet(Omega, Omega.action_function(omega.obj, g))
+    fun = action_function(Omega)
+    return ElementOfGSet(Omega, fun(omega.obj, g))
 end
 
 ==(omega1::ElementOfGSet, omega2::ElementOfGSet) = ((omega1.gset == omega2.gset) && (omega1.obj == omega2.obj))
@@ -197,7 +233,7 @@ unwrap(omega::ElementOfGSet) = omega.obj
 ##  `:orbit`
 
 """
-    orbit(G::PermGroup[, fun::Function], omega)
+    orbit(G::GAPGroup[, fun::Function], omega)
 
 Return the G-set that consists of the images of `omega`
 under the action of `G` defined by `fun`.
@@ -224,9 +260,9 @@ julia> length(orbit(G, on_sets, [1, 2]))
 
 ```
 """
-orbit(G::PermGroup, omega) = gset_by_type(G, [omega], typeof(omega))
+orbit(G::GAPGroup, omega) = gset_by_type(G, [omega], typeof(omega))
 
-orbit(G::PermGroup, fun::Function, omega) = GSetByElements(G, fun, [omega])
+orbit(G::GAPGroup, fun::Function, omega) = GSetByElements(G, fun, [omega])
 
 """
     orbit(Omega::GSet, omega::T) where T
@@ -247,16 +283,16 @@ julia> length(orbit(Omega, 1))
 ```
 """
 function orbit(Omega::GSetByElements{<:GAPGroup}, omega::T) where T
-    G = Omega.group
+    G = acting_group(Omega)
     acts = GapObj(gens(G))
-    gfun = GapObj(Omega.action_function)
+    gfun = GapObj(action_function(Omega))
 
     # The following works only because GAP does not check
     # whether the given (dummy) group 'G.X' fits to the given generators,
     # or whether the elements of 'acts' are group elements.
     orb = Vector{T}(GAP.Globals.Orbit(G.X, omega, acts, acts, gfun)::GapObj)
 
-    res = as_gset(Omega.group, Omega.action_function, orb)
+    res = as_gset(acting_group(Omega), action_function(Omega), orb)
     # We know that this G-set is transitive.
     set_attribute!(res, :orbits => [orb])
     return res
@@ -266,10 +302,10 @@ end
 # simpleminded alternative directly in Julia
 # In fact, '<:GAPGroup' is not used at all in this function.
 function orbit_via_Julia(Omega::GSetByElements{<:GAPGroup}, omega)
-    acts = gens(Omega.group)
+    acts = gens(acting_group(Omega))
     orbarray = [omega]
     orb = Set(orbarray)
-    fun = Omega.action_function
+    fun = action_function(Omega)
     for p in orbarray
       for g in acts
         img = fun(p, g)
@@ -280,7 +316,7 @@ function orbit_via_Julia(Omega::GSetByElements{<:GAPGroup}, omega)
       end
     end
 
-    res = as_gset(Omega.group, Omega.action_function, orbarray)
+    res = as_gset(acting_group(Omega), action_function(Omega), orbarray)
     # We know that this G-set is transitive.
     set_attribute!(res, :orbits => [orbarray])
     return res
@@ -311,7 +347,7 @@ julia> map(collect, orbs)
 ```
 """
 @attr Vector{GSetByElements{TG}} function orbits(Omega::T) where T <: GSetByElements{TG} where TG <: GAPGroup
-  G = Omega.group
+  G = acting_group(Omega)
   orbs = T[]
   for p in Omega.seeds
     if all(o -> !(p in o), orbs)
@@ -345,12 +381,13 @@ julia> map(length, orbs)
 
 #############################################################################
 ##
-##  `:elements` a vector of points
+##  `:elements` a vector of points;
+##  if `:seeds` is known to be closed under the action then
+##  keep its ordering of points
 
 @attr Any function elements(Omega::GSetByElements)
   orbs = orbits(Omega)
-  elms = union(map(collect, orbs)...)
-  return elms
+  return union(map(collect, orbs)...)
 end
 
 
@@ -379,9 +416,9 @@ julia> permutation(Omega, x)
 
 ```
 """
-function permutation(Omega::GSetByElements{T}, g::BasicGAPGroupElem{T}) where T<:GAPGroup
+function permutation(Omega::GSetByElements{T}, g::GAPGroupElem) where T<:GAPGroup
     omega_list = GAP.julia_to_gap(elements(Omega))
-    gfun = GAP.julia_to_gap(Omega.action_function)
+    gfun = GAP.julia_to_gap(action_function(Omega))
 
     # The following works only because GAP does not check
     # whether the given group element 'g' is a group element.
@@ -419,9 +456,9 @@ end
 """
     action_homomorphism(Omega::GSetByElements{T}) where T<:GAPGroup
 
-Return the group homomorphism `act` with domain `G = Omega.group`
-and codomain `symmetric_group(n)` that describes the action of `G` on `Omega`,
-where `Omega` has `n` elements.
+Return the group homomorphism `act` with domain `G = acting_group(Omega)`
+and codomain `symmetric_group(n)` that describes the permutation action
+of `G` on `Omega`, where `Omega` has `n` elements.
 
 This means that if an element `g` in `G` maps `collect(Omega)[i]` to
 `collect(Omega)[j]` then `act(g)` maps `i` to `j`.
@@ -455,10 +492,10 @@ true
 ```
 """
 @attr GAPGroupHomomorphism{T, PermGroup} function action_homomorphism(Omega::GSetByElements{T}) where T<:GAPGroup
-  G = Omega.group
+  G = acting_group(Omega)
   omega_list = GAP.julia_to_gap(collect(Omega))
   gap_gens = map(x -> x.X, gens(G))
-  gfun = GAP.julia_to_gap(Omega.action_function)
+  gfun = GAP.julia_to_gap(action_function(Omega))
 
   # The following works only because GAP does not check
   # whether the given generators in GAP and Julia fit together.
@@ -551,7 +588,7 @@ function representative_action(Omega::GSet, omega1, omega2)
     # Instead, we delegate to the image of the action homomorphism.
     # (For that, we write down the elements of the G-set.
     # Computing the orbit of `omega1` or `omega2` would in principle suffice.)
-    G = Omega.group
+    G = acting_group(Omega)
     acthom = action_homomorphism(Omega)
     elms = collect(Omega)
     pos1 = findfirst(isequal(omega1), elms)
@@ -572,7 +609,7 @@ Base.length(Omega::GSet) = length(elements(Omega))
 
 representative(Omega::GSet) = first(Omega.seeds)
 
-acting_domain(Omega::GSet) = Omega.group
+acting_domain(Omega::GSet) = acting_group(Omega)
 
 function Base.iterate(Omega::GSet, state = 1)
   elms = elements(Omega)
@@ -594,10 +631,10 @@ function is_transitive(Omega::GSet)
     return length(orbits(Omega)) == 1
 end
 
-is_regular(Omega::GSet) = is_transitive(Omega) && length(Omega) == order(Omega.group)
+is_regular(Omega::GSet) = is_transitive(Omega) && length(Omega) == order(acting_group(Omega))
 
 function is_semiregular(Omega::GSet)
-    ord = order(Omega.group)
+    ord = order(acting_group(Omega))
     return all(orb -> length(orb) == ord, orbits(Omega))
 end
 
@@ -631,9 +668,7 @@ julia> collect(blocks(g))
 function blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
    @assert is_transitive(G, L) "The group action is not transitive"
    bl = Vector{Vector{Int}}(GAP.Globals.Blocks(G.X, GapObj(L))::GapObj)
-   omega = gset(G, bl)
-   set_attribute!(omega, :elements => omega.seeds)
-   return omega
+   return gset(G, bl; closed = true)
 end
 
 """
@@ -663,9 +698,7 @@ julia> collect(maximal_blocks(G))
 function maximal_blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
    @assert is_transitive(G, L) "The group action is not transitive"
    bl = Vector{Vector{Int}}(GAP.Globals.MaximalBlocks(G.X, GapObj(L))::GapObj)
-   omega = gset(G, bl)
-   set_attribute!(omega, :elements => omega.seeds)
-   return omega
+   return gset(G, bl; closed = true)
 end
 
 

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -524,12 +524,13 @@ true
 end
 
 # for convenience: create the G-set on the fly
+# (Here we assume that `Omega` is closed, this is dangerous.)
 function action_homomorphism(G::PermGroup, Omega)
-  return action_homomorphism(gset_by_type(G, Omega, eltype(Omega)))
+  return action_homomorphism(gset_by_type(G, Omega, eltype(Omega); closed = true))
 end
 
 function action_homomorphism(G::PermGroup, fun::Function, Omega)
-  return action_homomorphism(GSetByElements(G, fun, Omega))
+  return action_homomorphism(GSetByElements(G, fun, Omega, closed = true))
 end
 
 

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -421,7 +421,7 @@ function _prod(x::T,y::T) where {T <: MatrixGroupElem}
    # if the underlying GAP matrices are both defined, but not both Oscar matrices,
    # then use the GAP matrices.
    # Otherwise, use the Oscar matrices, which if necessary are implicitly computed
-   # by the Base.getproperty(::MatrixGroupElem, ::Symbil) method .
+   # by the Base.getproperty(::MatrixGroupElem, ::Symbol) method .
    if isdefined(x,:X) && isdefined(y,:X) && !(isdefined(x,:elm) && isdefined(y,:elm))
       return T(G, x.X*y.X)
    else
@@ -429,8 +429,8 @@ function _prod(x::T,y::T) where {T <: MatrixGroupElem}
    end
 end
 
-Base.:*(x::MatrixGroupElem, y::fq_nmod_mat) = x.elm*y
-Base.:*(x::fq_nmod_mat, y::MatrixGroupElem) = x*y.elm
+Base.:*(x::MatrixGroupElem{RE, T}, y::T) where RE where T = x.elm*y
+Base.:*(x::T, y::MatrixGroupElem{RE, T}) where RE where T = x*y.elm
 
 Base.:^(x::MatrixGroupElem, n::Int) = MatrixGroupElem(x.parent, x.elm^n)
 

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -9,6 +9,7 @@
   @test is_transitive(Omega)
   @test ! is_regular(Omega)
   @test ! is_semiregular(Omega)
+  @test collect(Omega) == 1:6  # ordering is kept
 
   Omega = gset(G, [Set([1, 2])])  # action on unordered pairs
   @test isa(Omega, GSet)
@@ -93,11 +94,13 @@
 
   # construction from a known set
   G = sylow_subgroup(symmetric_group(4), 3)[1]
-  Omega = as_gset(G, Set(1:4))
+  given = 1:4
+  Omega = as_gset(G, given)
   @test length(Omega) == 4
   @test length(orbits(Omega)) == 2
   @test isa(Omega, GSet)
   @test isa(orbit(Omega, 1), GSet)
+  @test collect(Omega) == given  # ordering is kept
 
   # orbit
   G = symmetric_group(6)
@@ -191,5 +194,77 @@ end
   @test transitivity(S4) == 4
   @test transitivity(S4, 1:3) == 3
   @test transitivity(S4, 1:5) == 0
+
+end
+
+@testset "G-sets of matrix groups over finite fields" begin
+
+  # natural constructions (determined by the types of the seeds)
+  G = general_linear_group(2, 3)
+  V = free_module(base_ring(G), degree(G))
+  Omega = gset(G)
+  @test isa(Omega, GSet)
+  @test length(Omega) == 9
+  @test length(orbits(Omega)) == 2
+  @test ! is_transitive(Omega)
+  @test ! is_regular(Omega)
+  @test ! is_semiregular(Omega)
+  @test collect(Omega) == collect(V)  # ordering is kept
+
+  Omega = orbit(G, gen(V, 1))
+  @test isa(Omega, GSet)
+  @test length(Omega) == 8
+  @test length(orbits(Omega)) == 1
+  @test is_transitive(Omega)
+  @test ! is_regular(Omega)
+  @test ! is_semiregular(Omega)
+
+  Omega = gset(G, [Set(gens(V))])  # action on unordered pairs of vectors
+  @test isa(Omega, GSet)
+  @test length(Omega) == 24
+  @test length(orbits(Omega)) == 1
+  @test is_transitive(Omega)
+  @test ! is_regular(Omega)
+  @test ! is_semiregular(Omega)
+
+  Omega = gset(G, [gens(V)])  # action on ordered pairs of vectors
+  @test isa(Omega, GSet)
+  @test length(Omega) == 48
+  @test length(orbits(Omega)) == 1
+  @test is_transitive(Omega)
+  @test is_regular(Omega)
+  @test is_semiregular(Omega)
+
+  # orbit
+  Omega = gset(G)
+  v = gen(V, 1)
+  @test length(orbit(Omega, v)) == length(Oscar.orbit_via_Julia(Omega, v))
+
+  # permutation
+  Omega = gset(G)
+  g = gens(G)[1]
+  pi = permutation(Omega, g)
+  @test order(pi) == order(g)
+  @test degree(parent(pi)) == length(Omega)
+
+  # action homomorphism
+  Omega = gset(G)
+  acthom = action_homomorphism(Omega)
+  @test pi == g^acthom
+  @test haspreimage(acthom, pi)[1]
+  @test order(image(acthom)[1]) == 48
+
+  # isconjugate
+  Omega = gset(G)
+  @test isconjugate(Omega, gen(V, 1), gen(V, 2))
+  @test ! isconjugate(Omega, zero(V), gen(V, 1))
+
+  # representative_action
+  Omega = gset(G)
+  rep = representative_action(Omega, gens(V)...)
+  @test rep[1]
+  @test gen(V, 1) * rep[2] == gen(V, 2)
+  rep = representative_action(Omega, zero(V), gen(V, 1))
+  @test ! rep[1]
 
 end


### PR DESCRIPTION
- added keyword argument `closed` in the construction of G-sets,
  which indicates whether the given seeds are known to be closed
  under the group action;
  in this situation, we store the seeds *in the given ordering*
  (we call `collect(seeds)` in order to get an indexed collection)

  (When the given seeds are *not* closed under the group action,
  one might still be interested in keeping their ordering inside the
  closure, but currently we do not promise anything in this direction.)

- fixed the signatures in the `*` methods for a matrix and a `MatrixGroupElem`

- added support for G-sets of matrix groups; for that,

  - added iteration for `Generic.FreeModule{<:FinFieldElem}`,
    using the code available for `Generic.Submodule{<:FinFieldElem}`

  - added `Base.length(M::Union{Generic.FreeModule{T}, Generic.Submodule{T}}) where T <: FinFieldElem`
    and `Base.eltype(M::Union{Generic.FreeModule{T}, Generic.Submodule{T}}) where T <: FinFieldElem`,
    in order to admit `collect` for these modules