### PR TITLE
CI: don't run timing tests when JULIA_PKGEVAL is set

### DIFF
--- a/test/PolyhedralGeometry/timing.jl
+++ b/test/PolyhedralGeometry/timing.jl
@@ -1,4 +1,9 @@
 @testset "Timing" begin
+
+    # the pkgeval / nanosoldier tests are quite resource-constrained
+    # to avoid unnecessary failures we skip the timing tests
+    haskey(ENV, "JULIA_PKGEVAL") && return
+
     using Oscar
     using Oscar.Graphs
 


### PR DESCRIPTION
to avoid failures on nanosoldier like this:
https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_date/2022-05/24/Oscar.primary.log

That machine is probably under a lot of load when running tests for all julia packages ...