### PR TITLE
Serialize singletons; avoid redundant backref ids

### DIFF
--- a/test/Serialization/basic_types.jl
+++ b/test/Serialization/basic_types.jl
@@ -34,5 +34,16 @@
             @test loaded isa Symbol
             @test loaded == original
         end
+
+        @testset "Singleton types" begin
+            original = [ZZ, QQ]
+            filename = joinpath(path, "original.json")
+            save(original, filename)
+            loaded = load(filename)
+            @test loaded[1] isa FlintIntegerRing
+            @test loaded[1] === ZZ
+            @test loaded[2] isa FlintRationalField
+            @test loaded[2] === QQ
+        end
     end
 end


### PR DESCRIPTION
This fixes at least one of the CI errors in PR #1342