### PR TITLE
support invariant rings of permutation groups

### DIFF
--- a/experimental/InvariantTheory/types.jl
+++ b/experimental/InvariantTheory/types.jl
@@ -53,7 +53,12 @@ mutable struct InvRing{FldT, GrpT, PolyElemT, PolyRingT, ActionT, SingularAction
     n = degree(G)
     R, = grade(PolynomialRing(K, "x" => 1:n, cached = false)[1], ones(Int, n))
     R_sing = singular_poly_ring(R)
-    action_singular = identity.([change_base_ring(R_sing, g) for g in action])
+    if ActionT <: PermGroupElem
+      m_action = [permutation_matrix(K, p) for p in action]
+      action_singular = identity.([change_base_ring(R_sing, g) for g in m_action])
+    else
+      action_singular = identity.([change_base_ring(R_sing, g) for g in action])
+    end
     PolyRingT = typeof(R)
     PolyElemT = elem_type(R)
     SingularActionT = eltype(action_singular)

--- a/test/InvariantTheory/invariant_rings-test.jl
+++ b/test/InvariantTheory/invariant_rings-test.jl
@@ -1,4 +1,4 @@
-@testset "InvariantRings" begin
+@testset "InvariantRings of matrix groups" begin
   K, a = CyclotomicField(3, "a")
   M1 = matrix(K, 3, 3, [ 0, 1, 0, 1, 0, 0, 0, 0, 1 ])
   M2 = matrix(K, 3, 3, [ 1, 0, 0, 0, a, 0, 0, 0, -a - 1 ])
@@ -79,7 +79,7 @@
     @test reynolds_operator(RGp, f) == f
   end
 
-  # S4
+  # S5 (deleted permutation module)
   G = matrix_group(matrix(QQ, [-1 1 0 0;
                                -1 0 1 0;
                                -1 0 0 1;
@@ -93,6 +93,7 @@
   m = @inferred molien_series(S, I)
   @test m == 1//((1 - t^2)*(1 - t^3)*(1 - t^4)*(1 - t^5))
 
+  # S4 (natural permutation module in characteristic 5)
   gl = general_linear_group(4, 5)
   gapmats = [GAP.Globals.PermutationMat(elm.X, 4, GAP.Globals.GF(5))
              for elm in gens(symmetric_group(4))]
@@ -105,4 +106,90 @@
   I = invariant_ring(-identity_matrix(F, 2))
   m = @inferred molien_series(S, I)
   @test m == (t^2 + 1)//(t^4 - 2*t^2 + 1)
+end
+
+@testset "InvariantRings of permutation groups" begin
+  G = symmetric_group(3)
+  RGQ = invariant_ring(G)   # char. 0, over QQ
+
+  K, a = CyclotomicField(3, "a")
+  RGK = invariant_ring(K, G)   # char. 0, over K
+
+  F5 = GF(5)
+  RGF = invariant_ring(F5, G) # char p, non-modular
+
+  F3 = GF(3)
+  RGM = invariant_ring(F3, G)  # char. p, modular
+
+  @test coefficient_ring(RGQ) == QQ
+  @test coefficient_ring(RGK) == K
+  @test coefficient_ring(RGF) == F5
+  @test coefficient_ring(RGM) == F3
+
+  @test !is_modular(RGQ)
+  @test !is_modular(RGK)
+  @test !is_modular(RGF)
+  @test is_modular(RGM)
+
+  RQ = polynomial_ring(RGQ)
+  RK = polynomial_ring(RGK)
+  RF = polynomial_ring(RGF)
+  RM = polynomial_ring(RGM)
+
+  @test reynolds_operator(RGK, gen(RK, 1)^2) == sum(x -> x^2, gens(RK))//3
+  @test reynolds_operator(RGK, gen(RK, 1) - gen(RK, 2)) == zero(RK)
+
+  @test reynolds_operator(RGF, gen(RF, 1)^2) == sum(x -> x^2, gens(RF))//3
+  @test reynolds_operator(RGF, gen(RF, 1) - gen(RF, 2)) == zero(RF)
+
+  @test_throws AssertionError reynolds_operator(RGM, gen(RM, 1))
+
+  @test length(basis(RGK, 1)) == 1
+  @test length(basis(RGK, 1, :reynolds)) == 1
+  @test length(basis(RGK, 1, :linear_algebra)) == 1
+  @test length(basis(RGK, 3)) == 3
+  @test length(basis(RGK, 3, :reynolds)) == 3
+  @test length(basis(RGK, 3, :linear_algebra)) == 3
+
+  @test length(basis(RGF, 1)) == 1
+  @test length(basis(RGF, 1, :reynolds)) == 1
+  @test length(basis(RGF, 1, :linear_algebra)) == 1
+  @test length(basis(RGF, 3)) == 3
+  @test length(basis(RGF, 3, :reynolds)) == 3
+  @test length(basis(RGF, 3, :linear_algebra)) == 3
+
+  @test length(basis(RGM, 1)) == 1
+  @test length(basis(RGM, 1, :linear_algebra)) == 1
+  @test_throws AssertionError basis(RGM, 1, :reynolds)
+
+  mol = molien_series(RGK)
+  F = parent(mol)
+  t = gens(base_ring(F))[1]
+  @test mol == 1//((1-t^3)*(1-t^2)*(1-t))
+
+  mol = molien_series(RGF)
+  F = parent(mol)
+  t = gens(base_ring(F))[1]
+  @test mol == 1//((1-t^3)*(1-t^2)*(1-t))
+
+  fund_invars = fundamental_invariants(RGK)
+  for f in fund_invars
+    @test reynolds_operator(RGK, f) == f
+  end
+  fund_invars2 = Oscar.fundamental_invariants_via_minimal_subalgebra(RGK)
+  for f in fund_invars2
+    @test reynolds_operator(RGK, f) == f
+  end
+
+  fund_invars = fundamental_invariants(RGF)
+  for f in fund_invars
+    @test reynolds_operator(RGF, f) == f
+  end
+
+  # S4 (natural permutation module in characteristic 5)
+  s4 = symmetric_group(4)
+  S, t = QQ["t"]
+  I = invariant_ring(GF(5), s4)
+  m = @inferred molien_series(S, I)
+  @test m == 1//((1 - t)*(1 - t^2)*(1 - t^3)*(1 - t^4))
 end

--- a/test/InvariantTheory/secondary_invariants-test.jl
+++ b/test/InvariantTheory/secondary_invariants-test.jl
@@ -1,4 +1,4 @@
-@testset "Secondary invariants" begin
+@testset "Secondary invariants (for matrix groups)" begin
   K, a = CyclotomicField(3, "a")
   M1 = matrix(K, 3, 3, [ 0, 1, 0, 1, 0, 0, 0, 0, 1 ])
   M2 = matrix(K, 3, 3, [ 1, 0, 0, 0, a, 0, 0, 0, -a - 1 ])
@@ -116,6 +116,121 @@
   gens, exps = Oscar.generators_for_given_degree!(C, [ x[3] ], 3, true)
   @test Set(gens) == Set([ x[1]^2*x[3], x[1]*x[2]*x[3], x[2]^2*x[3] ])
   for m in gens
+    @test haskey(exps, m)
+    @test set_exponent_vector!(one(R), 1, exps[m]) == m
+  end
+end
+
+@testset "Secondary invariants (for permutation groups)" begin
+  G = sylow_subgroup(symmetric_group(6), 2)[1]
+  RG0 = invariant_ring(G)     # char. 0
+
+  F7 = GF(7)
+  RGp = invariant_ring(F7, G) # char. p, non-modular
+
+  F9 = GF(3, 2)
+  RGm = invariant_ring(F9, G) # char. p, modular
+
+  for RG in [ RG0, RGp ]
+    s_invars = secondary_invariants(RG)
+    m = molien_series(RG)
+    S = base_ring(parent(m))
+    t = gen(S)
+    n = S()
+    for f in s_invars
+      @test reynolds_operator(RG, f) == f
+      n += t^total_degree(f.f)
+    end
+    d = prod( 1 - t^total_degree(f.f) for f in primary_invariants(RG) )
+    @test m == n//d
+
+    # The secondary invariants have to be a module basis. Let's test this for
+    # the degree 9 homogeneous component.
+    R = polynomial_ring(RG).R
+    C = Oscar.PowerProductCache(R, [ f.f for f in primary_invariants(RG) ])
+    b1, _ = Oscar.generators_for_given_degree!(C, [ f.f for f in secondary_invariants(RG) ], 9, false)
+    b2 = [ f.f for f in basis(RG, 9) ]
+    B = Oscar.BasisOfPolynomials(R, b1)
+    for f in b2
+      @test !Oscar.add_to_basis!(B, f)
+    end
+  end
+
+  s_invars = secondary_invariants(RGm)
+  actions = [Oscar.right_action(polynomial_ring(RGm), x) for x in gens(G)]
+  for f in s_invars
+    @test all(act -> act(f) == f, actions)
+  end
+  @test length(s_invars) == 2
+  # The secondary invariants have to be a module basis. Let's test this for
+  # the degree 9 homogeneous component.
+  R = polynomial_ring(RGm).R
+  C = Oscar.PowerProductCache(R, [ f.f for f in primary_invariants(RGm) ])
+  b1, _ = Oscar.generators_for_given_degree!(C, [ f.f for f in secondary_invariants(RGm) ], 9, false)
+  b2 = [ f.f for f in basis(RGm, 9) ]
+  B = Oscar.BasisOfPolynomials(R, b1)
+  for f in b2
+    @test !Oscar.add_to_basis!(B, f)
+  end
+
+  for RG in [ RG0, RGp ]
+    is_invars = irreducible_secondary_invariants(RG)
+    @test issubset(is_invars, secondary_invariants(RG))
+    @test length(is_invars) == 1
+
+    # The irreducible secondary invariants have to be algebra generators. Let's
+    # test this for the degree 9 homogeneous component.
+    R = polynomial_ring(RG).R
+    C = Oscar.PowerProductCache(R, append!([ f.f for f in primary_invariants(RG) ], [ f.f for f in is_invars ]))
+    b1 = Oscar.all_power_products_of_degree!(C, 9, false)
+    b2 = [ f.f for f in basis(RG, 9) ]
+    B = Oscar.BasisOfPolynomials(R, b1)
+    for f in b2
+      @test !Oscar.add_to_basis!(B, f)
+    end
+  end
+
+  is_invars = irreducible_secondary_invariants(RGm)
+  @test issubset(is_invars, secondary_invariants(RGm))
+  @test length(is_invars) == 1
+  # The irreducible secondary invariants have to be algebra generators. Let's
+  # test this for the degree 9 homogeneous component.
+  R = polynomial_ring(RGm).R
+  C = Oscar.PowerProductCache(R, append!([ f.f for f in primary_invariants(RGm) ], [ f.f for f in is_invars ]))
+  b1 = Oscar.all_power_products_of_degree!(C, 6, false)
+  b2 = [ f.f for f in basis(RGm, 6) ]
+  B = Oscar.BasisOfPolynomials(R, b1)
+  for f in b2
+    @test !Oscar.add_to_basis!(B, f)
+  end
+
+  for RG in [ RG0, RGp, RGm ]
+    is_invars = irreducible_secondary_invariants(RG)
+    for i = 1:length(RG.secondary.invars)
+      f = RG.secondary.invars[i]
+      @test in(f, is_invars) == RG.secondary.is_irreducible[i]
+      t = one(polynomial_ring(RG))
+      for j = 1:length(is_invars)
+        t *= is_invars[j]^RG.secondary.sec_in_irred[i][j]
+      end
+      @test f == t
+    end
+  end
+
+  R, x = PolynomialRing(QQ, "x" => 1:3)
+  C = Oscar.PowerProductCache(R, x)
+  @test Set(Oscar.all_power_products_of_degree!(C, 3, false)) == Set(collect(Oscar.all_monomials(R, 3)))
+  mons = Oscar.all_power_products_of_degree!(C, 3, true)
+  @test Set(mons) == Set(collect(Oscar.all_monomials(R, 3)))
+  for m in mons
+    @test haskey(C.exponent_vectors, m)
+    @test set_exponent_vector!(one(R), 1, C.exponent_vectors[m]) == m
+  end
+
+  C = Oscar.PowerProductCache(R, [ x[1], x[2] ])
+  ggens, exps = Oscar.generators_for_given_degree!(C, [ x[3] ], 3, true)
+  @test Set(ggens) == Set([ x[1]^2*x[3], x[1]*x[2]*x[3], x[2]^2*x[3] ])
+  for m in ggens
     @test haskey(exps, m)
     @test set_exponent_vector!(one(R), 1, exps[m]) == m
   end


### PR DESCRIPTION
This resolves #1346

- added `right_action` for `PermGroupElem`
- in `_molien_series_char0`, call `isomorphic_group_over_finite_field`   only if this function is applicable,
  i.e., the given group is a `MatrixGroup` over `Union{fmpq, fmpz, nf_elem}`
- in `_molien_series_char0`, call `charpoly` for the corresponding permutation matrix if the group element is a `PermGroupElem`
  (we could define a `charpoly` method for `PermGroupElem` that returns the product of the polynomials `x^m-1`, taken over the cycles of length `m` with their multiplicities, i.e., avoid creating the permutation matrix and the "generic" characteristic polynomial computation)
- in the `InvRing` constructor, set `action_singular` to the array of permutation matrices corresponding to the given group generators in case they are `PermGroupElem`s
  (this way, Singular can work as expected; in the future, Singular will not be needed here)
- support `PermGroup`s in `_molien_series_charp_nonmodular_via_gap`
- extended the tests accordingly