### PR TITLE
improvements/fixes for `iso_oscar_gap`

### DIFF
--- a/src/GAP/iso_oscar_gap.jl
+++ b/src/GAP/iso_oscar_gap.jl
@@ -99,7 +99,7 @@ function _iso_oscar_gap_field_finite_functions(FO::Union{FqFiniteField, FqDefaul
    end
 
    # Check whether the two fields have compatible polynomials.
-   polFO = defining_polynomial(FO)
+   polFO = modulus(FO)
    coeffsFO = collect(coefficients(polFO))
 
    polFG = GAP.Globals.DefiningPolynomial(FG)::GapObj
@@ -174,7 +174,7 @@ function _iso_oscar_gap(FO::FinField)
      FG = GAPWrap.GF(p, d)
    else
      # Calling `GAPWrap.GF(p, d)` would throw a GAP error.
-     polFO = defining_polynomial(FO)
+     polFO = modulus(FO)
      coeffsFO = collect(coefficients(polFO))
 
      e = one(GAP.Globals.Z(p)::GAP.Obj)
@@ -278,17 +278,6 @@ end
 #
 # Univariate polynomial rings
 #
-@attributes FmpqPolyRing # TODO: port this to Nemo
-@attributes FmpzPolyRing # TODO: port this to Nemo
-@attributes FqNmodPolyRing # TODO: port this to Nemo
-@attributes FqPolyRing # TODO: port this to Nemo
-@attributes GFPFmpzPolyRing # TODO: port this to Nemo
-@attributes GFPPolyRing # TODO: port this to Nemo
-#TODO: support
-# `NmodPolyRing` (from `Nemo.NmodRing(UInt64(6))`)
-# `FmpzModPolyRing` (from `Nemo.FmpzModRing(fmpz(2))`)
-# `FqDefaultPolyRing` (from `FqDefaultFiniteField(fmpz(2), 3, :x)`)
-
 function _iso_oscar_gap_polynomial_ring_functions(RO::PolyRing{T}, RG::GAP.GapObj, coeffs_iso::MapFromFunc) where T
    fam = GAP.Globals.ElementsFamily(GAP.Globals.FamilyObj(codomain(coeffs_iso)))::GapObj
    ind = GAP.Globals.IndeterminateNumberOfUnivariateRationalFunction(
@@ -301,7 +290,7 @@ function _iso_oscar_gap_polynomial_ring_functions(RO::PolyRing{T}, RG::GAP.GapOb
 
    finv = function(x)
       GAP.Globals.IsPolynomial(x)::Bool || error("$x is not a GAP polynomial")
-      cfs = Vector{Any}(GAP.Globals.CoefficientsOfUnivariatePolynomial(x)::GapObj)
+      cfs = Vector{GAP.Obj}(GAP.Globals.CoefficientsOfUnivariatePolynomial(x)::GapObj)
       return RO([preimage(coeffs_iso, c) for c in cfs])
    end
 
@@ -311,6 +300,62 @@ end
 function _iso_oscar_gap(RO::PolyRing{T}) where T
    coeffs_iso = iso_oscar_gap(base_ring(RO))
    RG = GAP.Globals.PolynomialRing(codomain(coeffs_iso))::GapObj
+
+   f, finv = _iso_oscar_gap_polynomial_ring_functions(RO, RG, coeffs_iso)
+
+   return MapFromFunc(f, finv, RO, RG)
+end
+
+
+################################################################################
+#
+# Multivariate polynomial rings
+#
+@attributes AbstractAlgebra.Generic.MPolyRing # TODO: port this to AA
+
+function _iso_oscar_gap_polynomial_ring_functions(RO::MPolyRing{T}, RG::GAP.GapObj, coeffs_iso::MapFromFunc) where T
+   fam = GAP.Globals.ElementsFamily(GAP.Globals.FamilyObj(RG))::GapObj
+   n = nvars(RO)
+   indets = GAP.Globals.IndeterminatesOfPolynomialRing(RG)::GapObj
+   ind = [GAP.Globals.IndeterminateNumberOfUnivariateRationalFunction(x)
+          for x in indets]::Vector{Int}
+
+   f = function(x::MPolyElem{T})
+      extrep = []
+      for (c, l) in zip(coefficients(x), exponent_vectors(x))
+        v = []
+        for i in 1:n
+          if l[i] != 0
+            append!(v, [i, l[i]])
+          end
+        end
+        push!(extrep, GAP.GapObj(v))
+        push!(extrep, coeffs_iso(c))
+      end
+      return GAP.Globals.PolynomialByExtRep(fam, GAP.GapObj(extrep))::GapObj
+   end
+
+   finv = function(x)
+      GAP.Globals.IsPolynomial(x)::Bool || error("$x is not a GAP polynomial")
+      extrep = Vector{GAP.Obj}(GAP.Globals.ExtRepPolynomialRatFun(x)::GapObj)
+      M = Generic.MPolyBuildCtx(RO)
+      for i in 1:2:length(extrep)
+        v = fill(0, n)
+        l = extrep[i]
+        for j in 1:2:length(l)
+          v[l[j]] = l[j+1]
+        end
+        push_term!(M, preimage(coeffs_iso, extrep[i+1]), v)
+      end
+      return finish(M)
+   end
+
+   return (f, finv)
+end
+
+function _iso_oscar_gap(RO::MPolyRing{T}) where T
+   coeffs_iso = iso_oscar_gap(base_ring(RO))
+   RG = GAP.Globals.PolynomialRing(codomain(coeffs_iso), nvars(RO))::GapObj
 
    f, finv = _iso_oscar_gap_polynomial_ring_functions(RO, RG, coeffs_iso)
 

--- a/test/GAP/iso_oscar_gap.jl
+++ b/test/GAP/iso_oscar_gap.jl
@@ -56,7 +56,7 @@ end
    end
 
    @testset for (p,d) in [(2, 1), (5, 1), (2, 4), (3, 3)]
-      for F in [FqFiniteField(fmpz(p),d,:z), FqFiniteField(fmpz(p),d,:z)]
+      for F in [FqFiniteField(fmpz(p),d,:z), FqDefaultFiniteField(fmpz(p),d,:z)]
          f = Oscar.iso_oscar_gap(F)
          g = elm -> map_entries(f, elm)
          for a in F
@@ -196,10 +196,16 @@ end
    baserings = [QQ,                           # yields `FmpqPolyRing`
                 ZZ,                           # yields `FmpzPolyRing`
                 GF(2,2),                      # yields `FqNmodPolyRing`
+#               FqDefaultFiniteField(fmpz(2),3,:x), # yields `FqDefaultPolyRing`
+#TODO: This case fails due to a problem in AA/Nemo,
+#      see https://github.com/Nemocas/Nemo.jl/issues/1307
                 FqFiniteField(fmpz(2),2,:z),  # yields `FqPolyRing`
                 GF(fmpz(2)),                  # yields `GFPFmpzPolyRing`
                 GF(2),                        # yields `GFPPolyRing`
+                Nemo.NmodRing(UInt64(6)),     # yields `NmodPolyRing`
+                Nemo.FmpzModRing(fmpz(6)),    # yields `FmpzModPolyRing`
                ]
+#TODO: How to get `AbstractAlgebra.Generic.PolyRing`?
    @testset for R in baserings
       PR, x = PolynomialRing(R, "x")
       iso = Oscar.iso_oscar_gap(PR)
@@ -211,6 +217,30 @@ end
       @test map_entries(inv(iso), map_entries(iso, m)) == m
       @test_throws ErrorException iso(PolynomialRing(R, "y")[1]())
       @test_throws ErrorException image(iso, PolynomialRing(R, "y")[1]())
+      @test_throws ErrorException preimage(iso, GAP.Globals.Z(2))
+   end
+end
+
+@testset "multivariate polynomial rings" begin
+   baserings = [QQ,                           # yields `FmpqMPolyRing`
+                ZZ,                           # yields `FmpzMPolyRing`
+                GF(2,2),                      # yields `FqNmodMPolyRing`
+                GF(fmpz(2)),                  # yields `AbstractAlgebra.Generic.MPolyRing{gfp_fmpz_elem}`
+                GF(2),                        # yields `GFPMPolyRing`
+                Nemo.NmodRing(UInt64(6)),     # yields `NmodMPolyRing`
+               ]
+#TODO: How to get `GFPFmpzMPolyRing`, `FqDefaultMPolyRing`?
+   @testset for R in baserings
+      PR, (x,y,z) = PolynomialRing(R, 3)
+      iso = Oscar.iso_oscar_gap(PR)
+      for pol in [zero(x), one(x), x, x^2*y + y*z^3 + x*y*z + 1]
+         img = iso(pol)
+         @test preimage(iso, img) == pol
+      end
+      m = matrix([x x; y z])
+      @test map_entries(inv(iso), map_entries(iso, m)) == m
+      @test_throws ErrorException iso(PolynomialRing(R, ["y"])[1]())
+      @test_throws ErrorException image(iso, PolynomialRing(R, ["y"])[1]())
       @test_throws ErrorException preimage(iso, GAP.Globals.Z(2))
    end
 end


### PR DESCRIPTION
- use `modulus` instead of `defining_polynomial` for field extensions
  (The former is documented, the latter not;
  the former works for `FqDefaultFiniteField`, the latter not.)
  Still I would prefer the name `defining_polynomial`.)
- fixed a type from `Vector{Any}` to `Vector{GAP.Obj}`
  (The former tries to convert entries from GAP to Julia, which may fail.)
- added `iso_oscar_gap` for multivariate polynomial rings
- extended the tests for `iso_oscar_gap` for polynomial rings
- removed some `@attributes` calls that are no longer necessary