### PR TITLE
convenience methods for `Vector * MatGroupElem`

### DIFF
--- a/docs/src/Groups/matgroup.md
+++ b/docs/src/Groups/matgroup.md
@@ -84,7 +84,7 @@ orthogonal_sign(G::MatrixGroup)
 pol_elementary_divisors(A::MatElem{T}) where T
 generalized_jordan_block(f::T, n::Int) where T<:PolyElem
 generalized_jordan_form(A::MatElem{T}; with_pol=false) where T
-matrix(A::Vector{AbstractAlgebra.Generic.FreeModuleElem{T}}) where T<: FieldElem
+matrix(A::Vector{AbstractAlgebra.Generic.FreeModuleElem{T}}) where T <: RingElem
 upper_triangular_matrix(L)
 lower_triangular_matrix(L)
 conjugate_transpose(x::MatElem{T}) where T <: FinFieldElem

--- a/src/Groups/matrices/matrix_manipulation.jl
+++ b/src/Groups/matrices/matrix_manipulation.jl
@@ -25,12 +25,12 @@ export
 
 
 """
-    matrix(A::Vector{AbstractAlgebra.Generic.FreeModuleElem{T}})
+    matrix(A::Vector{AbstractAlgebra.Generic.FreeModuleElem})
 
 Return the matrix whose rows are the vectors in `A`.
 All vectors in `A` must have the same length and the same base ring.
 """
-function matrix(A::Vector{AbstractAlgebra.Generic.FreeModuleElem{T}}) where T <: FieldElem
+function matrix(A::Vector{AbstractAlgebra.Generic.FreeModuleElem{T}}) where T <: RingElem
    c = length(A[1].v)
    @assert all(x -> length(x.v)==c, A) "Vectors must have the same length"
    X = zero_matrix(base_ring(A[1]), length(A), c)
@@ -102,7 +102,7 @@ end
 
 # computes a complement for W in V (i.e. a subspace U of V such that V is direct sum of U and W)
 """
-    complement(V::AbstractAlgebra.Generic.FreeModule{T}, W::AbstractAlgebra.Generic.Submodule{T})
+    complement(V::AbstractAlgebra.Generic.FreeModule{T}, W::AbstractAlgebra.Generic.Submodule{T}) where T <: FieldElem
 
 Return a complement for `W` in `V`, i.e. a subspace `U` of `V` such that `V` is direct sum of `U` and `W`.
 """
@@ -227,23 +227,29 @@ end
 Base.getindex(V::AbstractAlgebra.Generic.FreeModule, i::Int) = gen(V, i)
 
 # scalar product
-Base.:*(v::AbstractAlgebra.Generic.FreeModuleElem{T},u::AbstractAlgebra.Generic.FreeModuleElem{T}) where T <: FieldElem = (v.v*transpose(u.v))[1]
+Base.:*(v::AbstractAlgebra.Generic.FreeModuleElem{T},u::AbstractAlgebra.Generic.FreeModuleElem{T}) where T <: RingElem = (v.v*transpose(u.v))[1]
+#T do we want this at all? (type piracy?)
 
-Base.:*(v::AbstractAlgebra.Generic.FreeModuleElem{T},x::MatElem{T}) where T <: FieldElem = v.parent(v.v*x)
-Base.:*(x::MatElem{T},u::AbstractAlgebra.Generic.FreeModuleElem{T}) where T <: FieldElem = x*transpose(u.v)
+
+Base.:*(v::AbstractAlgebra.Generic.FreeModuleElem{T},x::MatElem{T}) where T <: RingElem = v.parent(v.v*x)
+Base.:*(x::MatElem{T},u::AbstractAlgebra.Generic.FreeModuleElem{T}) where T <: RingElem = x*transpose(u.v)
 
 # evaluation of the form x into the vectors v and u
-Base.:*(v::AbstractAlgebra.Generic.FreeModuleElem{T},x::MatElem{T},u::AbstractAlgebra.Generic.FreeModuleElem{T}) where T <: FieldElem = (v.v*x*transpose(u.v))[1]
+Base.:*(v::AbstractAlgebra.Generic.FreeModuleElem{T},x::MatElem{T},u::AbstractAlgebra.Generic.FreeModuleElem{T}) where T <: RingElem = (v.v*x*transpose(u.v))[1]
 
 
-Base.:*(v::AbstractAlgebra.Generic.FreeModuleElem{T},x::MatrixGroupElem{T}) where T <: FieldElem = v.parent(v.v*x.elm)
-Base.:*(x::MatrixGroupElem{T},u::AbstractAlgebra.Generic.FreeModuleElem{T}) where T <: FieldElem = x.elm*transpose(u.v)
+Base.:*(v::AbstractAlgebra.Generic.FreeModuleElem{T},x::MatrixGroupElem{T}) where T <: RingElem = v.parent(v.v*matrix(x))
+Base.:*(x::MatrixGroupElem{T},u::AbstractAlgebra.Generic.FreeModuleElem{T}) where T <: RingElem = matrix(x)*transpose(u.v)
+
+
+Base.:*(v::Vector{T}, x::MatrixGroupElem{T}) where T <: RingElem = v*matrix(x)
+Base.:*(x::MatrixGroupElem{T}, u::Vector{T}) where T <: RingElem = matrix(x)*u
 
 # `on_tuples` and `on_sets` delegate to an action via `^` on the subobjects
 # (`^` is the natural action in GAP)
-Base.:^(v::AbstractAlgebra.Generic.FreeModuleElem{T},x::MatrixGroupElem{T}) where T <: FieldElem = v.parent(v.v*x.elm)
+Base.:^(v::AbstractAlgebra.Generic.FreeModuleElem{T},x::MatrixGroupElem{T}) where T <: RingElem = v.parent(v.v*matrix(x))
 
 # evaluation of the form x into the vectors v and u
-Base.:*(v::AbstractAlgebra.Generic.FreeModuleElem{T},x::MatrixGroupElem{T},u::AbstractAlgebra.Generic.FreeModuleElem{T}) where T <: FieldElem = (v.v*x.elm*transpose(u.v))[1]
+Base.:*(v::AbstractAlgebra.Generic.FreeModuleElem{T},x::MatrixGroupElem{T},u::AbstractAlgebra.Generic.FreeModuleElem{T}) where T <: RingElem = (v.v*matrix(x)*transpose(u.v))[1]
 
-map(f::Function, v::AbstractAlgebra.Generic.FreeModuleElem{T}) where T <: FieldElem = v.parent(map(f,v.v))
+map(f::Function, v::AbstractAlgebra.Generic.FreeModuleElem{T}) where T <: RingElem = v.parent(map(f,v.v))


### PR DESCRIPTION
This addresses issue #872.

- admit `RingElem` instead of `FieldElem` in the context of matrix group elements,
  *except* in those cases where either `FinFieldElem` is required or the matrices describe forms (in which case the documentation says that only in fact only rings of the type `FqNmodFiniteField` are supported)
- support the multiplication of Julia `Vector`s with Oscar matrix group elements from the left and from the right
- replaced `x.elm` by `matrix(x)` for matrix group elements `x`
- added tests