### PR TITLE
added `map_word`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ msolve_jll = "6d01cc9a-e8f6-580e-8c54-544227e08205"
 [compat]
 AbstractAlgebra = "0.26.0"
 DocStringExtensions = "0.8"
-GAP = "0.8.0"
+GAP = "0.8.1"
 Hecke = "0.14.4"
 JSON = "^0.20, ^0.21"
 Nemo = "0.31.0"

--- a/docs/src/Groups/fpgroup.md
+++ b/docs/src/Groups/fpgroup.md
@@ -20,4 +20,5 @@ FPGroup
 FPGroupElem
 free_group(n::Int)
 relators(G::FPGroup)
+map_word
 ```

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1407,9 +1407,7 @@ function map_word(g::FPGroupElem, genimgs::Vector; genimgs_inv::Vector = Vector(
     # element of a f.p. group
     gX = GAP.Globals.UnderlyingElement(gX)
   end
-  _names = GAP.evalstr("x -> x!.names")
-  @assert length(_names(GAP.Globals.FamilyObj(gX))) == length(genimgs)
-#TODO: use the feature from oscar-system/GAP.jl/pull/816 when it becomes available
+  @assert length(GAP.getbangproperty(GAP.Globals.FamilyObj(gX), :names)) == length(genimgs)
   @assert GAP.Globals.IsAssocWord(gX)
   if GAP.Globals.IsLetterAssocWordRep(gX)
     # `GAP.Globals.ExtRepOfObj` would create a syllable representation,

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1409,16 +1409,16 @@ function map_word(g::FPGroupElem, genimgs::Vector; genimgs_inv::Vector = Vector(
   end
   _names = GAP.evalstr("x -> x!.names")
   @assert length(_names(GAP.Globals.FamilyObj(gX))) == length(genimgs)
-#TODO: improve this, see https://github.com/oscar-system/GAP.jl/issues/771
+#TODO: use the feature from oscar-system/GAP.jl/pull/816 when it becomes available
   @assert GAP.Globals.IsAssocWord(gX)
   if GAP.Globals.IsLetterAssocWordRep(gX)
-    ll = Vector{Int}(GAP.Globals.LetterRepAssocWord(gX))
+    # `GAP.Globals.ExtRepOfObj` would create a syllable representation,
+    # which is unnecessary.
+    ll = Vector{Int}(GAP.Globals.LetterRepAssocWord(gX)::GAP.GapObj)
   elseif GAP.Globals.IsSyllableAssocWordRep(gX)
-    l = ExtRepOfObj(gX)
-    ll = Pairs{Int, Int}[]
-    for i in 1:2:length(l)
-      push!(ll, l[i] => l[i+1])
-    end
+    # Here we take the available syllable representation.
+    l = GAP.Globals.ExtRepOfObj(gX)::GAP.GapObj
+    ll = Pair{Int, Int}[l[i] => l[i+1] for i in 1:2:length(l)]
   else
     error("do not know the type of the element $gX")
   end

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -108,15 +108,13 @@ end
    @test GAP.Globals.IsLetterWordsFamily(
            GAP.Globals.ElementsFamily(GAP.Globals.FamilyObj(FL.X)))
    for F in [FL, FS]
-     F1 = gen(F, 1)
-     F2 = gen(F, 2)
+     F1, F2 = gens(F)
      rels = [F1^2, F2^2, comm(F1, F2)]
      FP = quo(F, rels)[1]
 
      # map an element of a free group or a f.p. group ...
      for f in [F, FP]
-       f1 = gen(f, 1)
-       f2 = gen(f, 2)
+       f1, f2 = gens(f)
        of = one(f)
 
        # ... to an element of a permutation group or to a rational number


### PR DESCRIPTION
(suggested by @thofma)

The main idea is that one can map an element of a free group to a product of the entries of a given array or of their inverses.

The same is defined for elements of f. p. groups, by delegating to a representative in the underlying free group. This is because in Oscar, these elements have the same type as elements in free groups (and because the same definition is used also in GAP).

The same is defined for a description of elements in free groups by vectors of generator numbers and their negatives ("letter representation") or by vectors of pairs `i => e` denoting the `e`-th power of the `i`-th generator ("syllable representation").

Note:
- GAP allows one to specify in the construction of a free group whether its elements will be represented via letters or syllables. Up to now, there is no such choice in Oscar.
- The GAP function `MappedWord` is optimized for the (common?) situation that the given images are themselves elements of the free group. This case is ignored in the current pull request.
- The syntax of `MappedWord` is affected by this perspective in the sense that in GAP, the identity of the free group on 0 generators is mapped to itself if one prescribes an empty list of images for the empty list of generators. Here I propose a different solution, using an optional argument `init` for this situation.
- In order to avoid computing the inverses of generators over and over again, `map_word` supports an array containing (some) inverses of the given images, and if new inverses are needed then they will be stored in this array, in order to be available in the next calls of `map_word` for the same images. This seems to be more flexible than the GAP syntax of `MappedWord`, where one has to enter also the list of generators, and where it is allowed to extend this list as well as the list of images by inverses.