### PR TITLE
Allow save to / load from IOStream, and other serialization tweaks

### DIFF
--- a/src/Serialization/Fields.jl
+++ b/src/Serialization/Fields.jl
@@ -62,7 +62,6 @@ function load_internal(s::DeserializerState, ::Type{<: SimpleNumField}, dict::Di
     def_pol = load_unknown_type(s, dict[:def_pol])
     var = load_type_dispatch(s, Symbol, dict[:var])
     K, _ = NumberField(def_pol, var, cached=false)
-
     return K
 end
 
@@ -77,7 +76,6 @@ end
 function load_internal(s::DeserializerState, ::Type{FqNmodFiniteField}, dict::Dict)
     def_pol = load_unknown_type(s, dict[:def_pol])
     K, _ = FiniteField(def_pol, cached=false)
-
     return K
 end
 
@@ -85,10 +83,9 @@ end
 function save_internal(s::SerializerState, k::Union{nf_elem, fq_nmod, Hecke.NfRelElem})
     K = parent(k)
     polynomial = parent(defining_polynomial(K))(k)
-    K_dict = save_type_dispatch(s, K)
 
     return Dict(
-        :parent => K_dict,
+        :parent => save_type_dispatch(s, K),
         :polynomial => save_type_dispatch(s, polynomial)
     )
 end
@@ -125,9 +122,8 @@ function save_internal(s::SerializerState, k::Union{NfAbsNSElem, Hecke.NfRelNSEl
     K = parent(k)
     polynomial = Oscar.Hecke.data(k)
     polynomial_parent = parent(polynomial)
-    K_dict = save_type_dispatch(s, K)
     return Dict(
-        :parent_field => K_dict,
+        :parent_field => save_type_dispatch(s, K),
         :polynomial => save_type_dispatch(s, polynomial),
         :polynomial_parent => save_type_dispatch(s, polynomial_parent)
     )
@@ -162,9 +158,8 @@ end
 
 # elements
 function save_internal(s::SerializerState, f::FracElem)
-    parent_dict = save_type_dispatch(s, parent(f))
     return Dict(
-        :parent => parent_dict,
+        :parent => save_type_dispatch(s, parent(f)),
         :den => save_type_dispatch(s, denominator(f)),
         :num => save_type_dispatch(s, numerator(f))
     )

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -252,6 +252,9 @@ function load_type_dispatch(s::DeserializerState, ::Type{T}, dict::Dict) where T
     end
 
     encodeType(T) == dict[:type] || throw(ErrorException("Type in file doesn't match target type: $(dict[:type]) != $T"))
+
+    Base.issingletontype(T) && return T()
+
     result = load_internal(s, T, dict[:data])
     if haskey(dict, :id)
         s.objs[UUID(dict[:id])] = result

--- a/test/Serialization/basic_types.jl
+++ b/test/Serialization/basic_types.jl
@@ -5,6 +5,22 @@ function test_save_load_roundtrip(func, path, original::T) where T
   loaded = load(filename)
   @test loaded isa T
   func(loaded)
+
+  # save and load from an IO buffer
+  io = IOBuffer()
+  save(io, original)
+  seekstart(io)
+  loaded = load(io)
+  @test loaded isa T
+  func(loaded)
+
+  # save and load from an IO buffer, with prescribed type
+  io = IOBuffer()
+  save(io, original)
+  seekstart(io)
+  loaded = load(io, T)
+  @test loaded isa T
+  func(loaded)
 end
 
 @testset "basic_types" begin


### PR DESCRIPTION
- Fix load_type_dispatch with type for singletons
- Add save/load method taking an io object, and add `load` variants with specified type

Resolves #1319

<s>
For the new `save` method, I chose to order the arguments so that the IO stream comes first, the object second -- I chose this to match the order used by Julia's own serialization method, and because in virtual all cases IO streams are listed first. This leads to an ambiguity case with the existing `save`, which has the object first, the filename second. The last commit hacks around that, but I think it would be nicer to employ another solution:
1. swap the argument order of the existing `save` method
2. swap the argument order of the new `save` method
3. rename the existing save/load to savefile/loadfile
4. do 1 and 3 together

Personally I'd prefer 1 or 4. 
</s>

UPDATE: We resolved the above via option 1 in a prior PR