### PR TITLE
fixed code using `names_of_fusion_sources`

### DIFF
--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -1445,12 +1445,10 @@ end
 @doc Markdown.doc"""
     schur_index(chi::GAPGroupClassFunction)
 
-Return either the minimal integer `m` such that the character `m * chi`
+Return the minimal integer `m` such that the character `m * chi`
 is afforded by a representation over the character field of `chi`,
-or `nothing`.
-
-The latter happens if character theoretic criteria do not suffice for
-computing `m`.
+or throw an exception if the currently used character theoretic criteria
+do not suffice for computing `m`.
 """
 function schur_index(chi::GAPGroupClassFunction, recurse::Bool = true)
     deg = numerator(degree(chi))
@@ -1517,7 +1515,7 @@ function schur_index(chi::GAPGroupClassFunction, recurse::Bool = true)
     end
 
     # For the moment, we do not have more character theoretic criteria.
-    return nothing
+    error("cannot determine the Schur index with the currently used criteria")
 end
 
 function character_table_complex_reflection_group(m::Int, p::Int, n::Int)

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -1493,12 +1493,14 @@ function schur_index(chi::GAPGroupClassFunction, recurse::Bool = true)
     # - Consider characters induced from other known subgroups.
     for name in names_of_fusion_sources(tbl)
       s = character_table(name)
-      known, fus = known_class_fusion(s, tbl)
-      @assert known "the class fusion is not stored"
-      if length(class_positions_of_kernel(fus)) == 1
-        psi = trivial_character(s)^(tbl)
-        bound = gcd(bound, scalar_product(fmpz, chi, psi))
-        bound == 1 && return 1
+      if s !== nothing
+        known, fus = known_class_fusion(s, tbl)
+        @assert known "the class fusion is not stored"
+        if length(class_positions_of_kernel(fus)) == 1
+          psi = trivial_character(s)^(tbl)
+          bound = gcd(bound, scalar_product(fmpz, chi, psi))
+          bound == 1 && return 1
+        end
       end
     end
 

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -718,6 +718,14 @@ end
 @testset "Schur index" begin
   t = character_table("2.A5")
   @test map(schur_index, collect(t)) == [1,1,1,1,1,2,2,2,2]
+
+  g = small_group(192, 1022)
+  h = derived_subgroup(g)[1];
+  s = character_table(h);
+  t = character_table(g);
+  trivial_character(s)^t;  # side-effect: stores a class fusion
+  @test length(names_of_fusion_sources(t)) > 0
+  [schur_index(chi) for chi in t]
 end
 
 @testset "specialized generic tables" begin

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -725,7 +725,14 @@ end
   t = character_table(g);
   trivial_character(s)^t;  # side-effect: stores a class fusion
   @test length(names_of_fusion_sources(t)) > 0
-  [schur_index(chi) for chi in t]
+  for chi in t
+    try
+      schur_index(chi)
+    catch(e)
+      msg = sprint(showerror, e)
+      @test msg == "cannot determine the Schur index with the currently used criteria"
+    end
+  end
 end
 
 @testset "specialized generic tables" begin


### PR DESCRIPTION
Some entries may belong to tables computed directly from groups, thus they cannot be accessed via their names.