### PR TITLE
minimal_nonfaces: fix column number of IncidenceMatrix

### DIFF
--- a/src/Combinatorics/SimplicialComplexes.jl
+++ b/src/Combinatorics/SimplicialComplexes.jl
@@ -250,8 +250,13 @@ function minimal_nonfaces(::Type{Vector{Set{Int}}}, K::SimplicialComplex)
 end
 function minimal_nonfaces(::Type{IncidenceMatrix}, K::SimplicialComplex)
     # the following line must stay to ensure polymake uses the correct algorithm for the non-faces
-    nvertices(K)
-    return pm_object(K).MINIMAL_NON_FACES
+    nv = nvertices(K)
+    m = pm_object(K).MINIMAL_NON_FACES
+    # fix column number (see #1440) until this is fixed in polymake
+    if size(m, 2) < nv
+      resize!(m, size(m, 1), nv)
+    end
+    return m
 end
 
 @doc Markdown.doc"""

--- a/test/Combinatorics/SimplicialComplexes.jl
+++ b/test/Combinatorics/SimplicialComplexes.jl
@@ -21,7 +21,10 @@
         R, _ = PolynomialRing(ZZ, ["a", "x", "i_7", "n"])
         @test stanley_reisner_ideal(R, sphere) == ideal([R([1], [[1, 1, 1, 1]])])
         @test is_isomorphic(fundamental_group(sphere), free_group())
-        
+
+        # from #1440, make sure empty columns at the end are kept
+        sc = SimplicialComplex([[1, 2, 4], [2, 3, 4]])
+        @test size(minimal_nonfaces(IncidenceMatrix, sc)) == (1, 4)
     end
     
     @testset "standard examples" begin


### PR DESCRIPTION
this is a workaround until that is fixed in polymake
add testcase
fixes #1440

```julia
julia> P = convex_hull([0 0 0; 0 0 1; 1 0 1; 1 1 1; 0 1 1]);
julia> (v1,v2) = NormalToricVarietiesFromStarTriangulations(P);
julia> stanley_reisner_ideal(v2)
ideal(x1*x3)

julia> stanley_reisner_ideal(v1)
ideal(x2*x4)
```

cc @HereAround @lkastner 