### PR TITLE
ToricVarieties: Extend conifold-transition example

### DIFF
--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -557,17 +557,24 @@ end
     NormalToricVarietiesFromStarTriangulations(P::Polyhedron)
 
 Returns the list of toric varieties obtained from fine regular
-star triangulations of the polyhedron P.
+star triangulations of the polyhedron P. With this we can
+compute the two phases of the famous conifold transition.
 
 # Examples
 ```jldoctest
 julia> P = convex_hull([0 0 0; 0 0 1; 1 0 1; 1 1 1; 0 1 1])
 A polyhedron in ambient dimension 3
 
-julia> NormalToricVarietiesFromStarTriangulations(P::Polyhedron)
+julia> (v1,v2) = NormalToricVarietiesFromStarTriangulations(P::Polyhedron)
 2-element Vector{NormalToricVariety}:
  A normal toric variety
  A normal toric variety
+
+julia> stanley_reisner_ideal(v1)
+ideal(x2*x4)
+
+julia> stanley_reisner_ideal(v2)
+ideal(x1*x3)
 ```
 """
 function NormalToricVarietiesFromStarTriangulations(P::Polyhedron)


### PR DESCRIPTION
This should extend the documentation and detect https://github.com/oscar-system/Oscar.jl/issues/1440 in the future.