### PR TITLE
provide random number generator with fixed seed, seed mpoly-localizations tests

### DIFF
--- a/docs/src/DeveloperDocumentation/new_developers.md
+++ b/docs/src/DeveloperDocumentation/new_developers.md
@@ -91,8 +91,17 @@ There are two ways to add tests:
     folder. The main file there is `test/runtests.jl` which then includes other
     testfiles. 
 
+Tests that rely on random values should use `Oscar.get_seeded_rng`, which will
+return a seeded random number source, and pass this to any functions that need
+random values.  The code may also directly create and use such a random source.
+The current seed will be printed at the beginning of the testsuite, it is fixed
+to 42 in the CI. It can be changed by setting `ENV["OSCAR_RANDOM_SEED"]` (for
+the testsuite running in a separate process) or by using `Oscar.set_seed!` (for
+the current session, e.g. `Oscar.test_module("something.jl", false)`).
+
 ```@docs
 Oscar.test_module
+Oscar.get_seeded_rng
 ```
 
 ### Adding documentation

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -133,12 +133,49 @@ if Sys.iswindows()
   windows_error()
 end
 
-const RNG = MersenneTwister()
+# global seed value for oscar to allow creating deterministic random number
+# generators
+# we initialize this here with a random value as well to allow use during
+# precompilation
+const rng_seed = Ref{UInt32}(rand(UInt32))
+
+@doc Markdown.doc"""
+    get_seed()
+
+Return the current random seed that is used for calls to `Oscar.get_seeded_rng`.
+"""
+get_seed() = return rng_seed[]
+
+@doc Markdown.doc"""
+    set_seed!(s::Integer)
+
+Set a new global seed for all subsequent calls to `Oscar.get_seeded_rng`.
+"""
+function set_seed!(s::Integer)
+  rng_seed[] = convert(UInt32, s)
+end
+
+@doc Markdown.doc"""
+    get_seeded_rng()
+
+Return a new random number generator object of type MersenneTwister which is
+seeded with the global seed value `Oscar.rng_seed`. This can be used for
+the testsuite to get more stable output and running times. Using a separate RNG
+object for each testset (or file) makes sure previous uses don't affect later
+testcases. It could also be useful for some randomized algorithms.
+The seed will be initialized with a random value during OSCAR startup but can
+be set to a fixed value with `Oscar.set_seed!` as it is done in `runtests.jl`.
+"""
+get_seeded_rng() = return MersenneTwister([get_seed()])
+
 
 function __init__()
   if Sys.iswindows()
     windows_error()
   end
+
+  # initialize random seed
+  set_seed!(rand(UInt32))
 
   if isinteractive() && Base.JLOptions().banner != 0
     println(" -----    -----    -----      -      -----   ")
@@ -157,9 +194,6 @@ function __init__()
     println("Type: '?Oscar' for more information")
     println("(c) 2019-2023 by The OSCAR Development Team")
   end
-
-  # re-seed at startup
-  Random.seed!(RNG)
 
   append!(_gap_group_types,
     [

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -133,6 +133,8 @@ if Sys.iswindows()
   windows_error()
 end
 
+const RNG = MersenneTwister()
+
 function __init__()
   if Sys.iswindows()
     windows_error()
@@ -155,6 +157,9 @@ function __init__()
     println("Type: '?Oscar' for more information")
     println("(c) 2019-2023 by The OSCAR Development Team")
   end
+
+  # re-seed at startup
+  Random.seed!(RNG)
 
   append!(_gap_group_types,
     [
@@ -198,7 +203,6 @@ const oscardir = Base.pkgdir(Oscar)
 const aadir = Base.pkgdir(AbstractAlgebra)
 const nemodir = Base.pkgdir(Nemo)
 const heckedir = Base.pkgdir(Hecke)
-
 
 function example(s::String)
   Base.include(Main, joinpath(oscardir, "examples", s))

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -121,12 +121,12 @@ end
 ### generation of random elements 
 function rand(S::MPolyPowersOfElement, v1::UnitRange{Int}, v2::UnitRange{Int}, v3::UnitRange{Int})
   R = ambient_ring(S)
-  return prod(f^rand(0:5) for f in denominators(S); init = one(R))::elem_type(R)
+  return prod(f^rand(0:4) for f in denominators(S); init = one(R))::elem_type(R)
 end
 
 function rand(rng::Random.AbstractRNG, S::MPolyPowersOfElement, v1::UnitRange{Int}, v2::UnitRange{Int}, v3::UnitRange{Int})
   R = ambient_ring(S)
-  return prod(f^rand(rng, 0:9) for f in denominators(S); init = one(R))::elem_type(R)
+  return prod(f^rand(rng, 0:4) for f in denominators(S); init = one(R))::elem_type(R)
 end
 
 ### simplification. 

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -124,6 +124,11 @@ function rand(S::MPolyPowersOfElement, v1::UnitRange{Int}, v2::UnitRange{Int}, v
   return prod(f^rand(0:5) for f in denominators(S); init = one(R))::elem_type(R)
 end
 
+function rand(rng::Random.AbstractRNG, S::MPolyPowersOfElement, v1::UnitRange{Int}, v2::UnitRange{Int}, v3::UnitRange{Int})
+  R = ambient_ring(S)
+  return prod(f^rand(rng, 0:9) for f in denominators(S); init = one(R))::elem_type(R)
+end
+
 ### simplification. 
 # Replaces each element d by its list of square free prime divisors.
 function simplify!(S::MPolyPowersOfElement)
@@ -212,6 +217,14 @@ function rand(S::MPolyComplementOfPrimeIdeal, v1::UnitRange{Int}, v2::UnitRange{
   f = rand(ambient_ring(S), v1, v2, v3)
   if f in prime_ideal(S)
     return rand(S, v1, v2, v3)
+  end
+  return f
+end
+
+function rand(rng::Random.AbstractRNG, S::MPolyComplementOfPrimeIdeal, v1::UnitRange{Int}, v2::UnitRange{Int}, v3::UnitRange{Int})
+  f = rand(rng, ambient_ring(S), v1, v2, v3)
+  if f in prime_ideal(S)
+    return rand(rng, S, v1, v2, v3)
   end
   return f
 end
@@ -347,6 +360,13 @@ function rand(S::MPolyComplementOfKPointIdeal, v1::UnitRange{Int}, v2::UnitRange
   end
   return f
 end
+function rand(rng::Random.AbstractRNG, S::MPolyComplementOfKPointIdeal, v1::UnitRange{Int}, v2::UnitRange{Int}, v3::UnitRange{Int})
+  f = rand(rng, ambient_ring(S), v1, v2, v3)
+  if !(f in S)
+    return rand(rng, S, v1, v2, v3)
+  end
+  return f
+end
 
 
 @Markdown.doc """
@@ -434,6 +454,9 @@ end
 ### generation of random elements 
 function rand(S::MPolyProductOfMultSets, v1::UnitRange{Int}, v2::UnitRange{Int}, v3::UnitRange{Int})
   return prod([rand(s, v1, v2, v3) for s in sets(S)])::elem_type(ambient_ring(S))
+end
+function rand(rng::Random.AbstractRNG, S::MPolyProductOfMultSets, v1::UnitRange{Int}, v2::UnitRange{Int}, v3::UnitRange{Int})
+  return prod([rand(rng, s, v1, v2, v3) for s in sets(S)])::elem_type(ambient_ring(S))
 end
 
 ########################################################################
@@ -1038,6 +1061,10 @@ end
 ### generation of random elements 
 function rand(W::MPolyLocalizedRing, v1::UnitRange{Int}, v2::UnitRange{Int}, v3::UnitRange{Int})
   return W(rand(base_ring(W), v1, v2, v3), rand(inverted_set(W), v1, v2, v3))
+end
+
+function rand(rng::Random.AbstractRNG, W::MPolyLocalizedRing, v1::UnitRange{Int}, v2::UnitRange{Int}, v3::UnitRange{Int})
+  return W(rand(rng, base_ring(W), v1, v2, v3), rand(rng, inverted_set(W), v1, v2, v3))
 end
 
 

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -121,12 +121,12 @@ end
 ### generation of random elements 
 function rand(S::MPolyPowersOfElement, v1::UnitRange{Int}, v2::UnitRange{Int}, v3::UnitRange{Int})
   R = ambient_ring(S)
-  return prod(f^rand(0:4) for f in denominators(S); init = one(R))::elem_type(R)
+  return prod(f^rand(0:2) for f in denominators(S); init = one(R))::elem_type(R)
 end
 
 function rand(rng::Random.AbstractRNG, S::MPolyPowersOfElement, v1::UnitRange{Int}, v2::UnitRange{Int}, v3::UnitRange{Int})
   R = ambient_ring(S)
-  return prod(f^rand(rng, 0:4) for f in denominators(S); init = one(R))::elem_type(R)
+  return prod(f^rand(rng, 0:2) for f in denominators(S); init = one(R))::elem_type(R)
 end
 
 ### simplification. 

--- a/test/Rings/mpoly-localizations.jl
+++ b/test/Rings/mpoly-localizations.jl
@@ -1,3 +1,17 @@
+import Random
+
+if haskey(ENV, "JULIA_PKGEVAL") ||
+    get(ENV, "CI", "") == "true" ||
+    haskey(ENV, "OSCAR_RANDOM_SEED")
+  seed = parse(UInt32, get(ENV, "OSCAR_RANDOM_SEED", "42"))
+  @info string(@__FILE__)*" -- fixed SEED $seed"
+else
+  seed = rand(UInt32)
+  @info string(@__FILE__)*" -- SEED $seed"
+end
+rng = Random.MersenneTwister(seed)
+
+
 @testset "mpoly-localizations" begin
   R, variab = ZZ["x", "y"]
   x = variab[1]

--- a/test/Rings/mpoly-localizations.jl
+++ b/test/Rings/mpoly-localizations.jl
@@ -206,9 +206,10 @@ end
 # test_Ring_interface_recursive(Localization(S)[1])
 # test_Ring_interface_recursive(Localization(T)[1])
 # test_Ring_interface_recursive(Localization(U)[1])
-  
-  AbstractAlgebra.promote_rule(::Type{gfp_mpoly}, ::Type{fmpz}) = gfp_mpoly
-  AbstractAlgebra.promote_rule(::Type{gfp_elem}, ::Type{fmpz}) = gfp_elem
+
+# should be unnecessary: https://github.com/oscar-system/Oscar.jl/pull/1459#issuecomment-1230185617
+#  AbstractAlgebra.promote_rule(::Type{gfp_mpoly}, ::Type{fmpz}) = gfp_mpoly
+#  AbstractAlgebra.promote_rule(::Type{gfp_elem}, ::Type{fmpz}) = gfp_elem
 
   kk = GF(7) 
   R, v = kk["x", "y"]

--- a/test/Rings/mpoly-localizations.jl
+++ b/test/Rings/mpoly-localizations.jl
@@ -1,16 +1,4 @@
-import Random
-
-if haskey(ENV, "JULIA_PKGEVAL") ||
-    get(ENV, "CI", "") == "true" ||
-    haskey(ENV, "OSCAR_RANDOM_SEED")
-  seed = parse(UInt32, get(ENV, "OSCAR_RANDOM_SEED", "42"))
-  @info string(@__FILE__)*" -- fixed SEED $seed"
-else
-  seed = rand(UInt32)
-  @info string(@__FILE__)*" -- SEED $seed"
-end
-rng = Random.MersenneTwister(seed)
-
+const rng = Oscar.RNG
 
 @testset "mpoly-localizations" begin
   R, variab = ZZ["x", "y"]

--- a/test/Rings/mpoly-localizations.jl
+++ b/test/Rings/mpoly-localizations.jl
@@ -183,7 +183,7 @@ end
 end
 
 function test_elem(W::MPolyLocalizedRing) 
-  f = rand(W, 0:3, 0:4, 0:3)
+  f = rand(rng, W, 0:3, 0:4, 0:3)
   return f
 end
 
@@ -218,8 +218,8 @@ end
   I = ideal(R, f)
 
   d = Vector{elem_type(R)}()
-  for i in 0:(abs(rand(Int))%3+1)
-    f = rand(R, 1:3, 0:3, 1:10)::elem_type(R)
+  for i in 0:(abs(rand(rng, Int))%3+1)
+    f = rand(rng, R, 1:3, 0:3, 1:10)::elem_type(R)
     iszero(f) || push!(d, f)
   end
   S = MPolyPowersOfElement(R, d)

--- a/test/Rings/mpoly-localizations.jl
+++ b/test/Rings/mpoly-localizations.jl
@@ -1,4 +1,4 @@
-const rng = Oscar.RNG
+const rng = Oscar.get_seeded_rng()
 
 @testset "mpoly-localizations" begin
   R, variab = ZZ["x", "y"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,8 +13,7 @@ else
   seed = rand(UInt32)
   @info string(@__FILE__)*" -- SEED $seed"
 end
-
-Random.seed!(Oscar.RNG, seed)
+Oscar.set_seed!(seed)
 
 import Oscar.Nemo.AbstractAlgebra
 include(joinpath(pathof(AbstractAlgebra), "..", "..", "test", "Rings-conformance-tests.jl"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,19 @@ using Oscar
 using Test
 using Documenter
 
+import Random
+
+if haskey(ENV, "JULIA_PKGEVAL") ||
+    get(ENV, "CI", "") == "true" ||
+    haskey(ENV, "OSCAR_RANDOM_SEED")
+  seed = parse(UInt32, get(ENV, "OSCAR_RANDOM_SEED", "42"))
+  @info string(@__FILE__)*" -- fixed SEED $seed"
+else
+  seed = rand(UInt32)
+  @info string(@__FILE__)*" -- SEED $seed"
+end
+
+Random.seed!(Oscar.RNG, seed)
 
 import Oscar.Nemo.AbstractAlgebra
 include(joinpath(pathof(AbstractAlgebra), "..", "..", "test", "Rings-conformance-tests.jl"))


### PR DESCRIPTION
I have added a few seeded versions of `Base.rand` functions, added a fixed random number generator at the beginning of that test file and used this RNG in the testgroup.

We could also move the RNG creation to the beginning of the whole Oscar testsuite and use it in other testgroups as well but for now I just added this for the localized polynomial rings.

- Without any environment variables it will generate (and print) a new random seed every run.
- If `ENV["CI"]=="true"` or if `JULIA_PKGEVAL` is set it will use the default value which is currently 42.
- And if `OSCAR_RANDOM_SEED` is set to something that can be used as a `UInt32` that will be used as a seed.



This does not make it fully stable but it seems a lot better like this, at least for some seed values. The rings should be stable now but the checks from the AbstractAlgebra - Rings-conformance-tests.jl file might still use some non-seeded random data.

I had the following timings with the default seed 42 and 59 iterations:
```
  Ring interface for localized polynomial rings: 
    median  41.8 - max    48.6
```

With seed 2863916321 I do get longer and also more inconsistent timings:
```
Ring interface for localized polynomial rings | 18804  18804  1m31.9s
Ring interface for localized polynomial rings | 18792  18792  2m06.7s
Ring interface for localized polynomial rings | 18786  18786  6m19.7s
Ring interface for localized polynomial rings | 18744  18744  1m34.0s
Ring interface for localized polynomial rings | 18846  18846  1m18.6s
Ring interface for localized polynomial rings | 18810  18810  1m35.6s
Ring interface for localized polynomial rings | 18786  18786  6m11.1s
```

With the seed value it should also be possible to recreate these rings and to try to find out why some are a lot slower than others.


This is just a draft for now to get some opinions on this.
cc: @HechtiDerLachs @fingolfin @thofma 
x-ref: #851 