### PR TITLE
ToricVarieties: Toric morphisms

### DIFF
--- a/docs/doc.main
+++ b/docs/doc.main
@@ -166,6 +166,7 @@
         "ToricVarieties/CohomologyClasses.md",
         "ToricVarieties/Subvarieties.md",
         "ToricVarieties/AlgebraicCycles.md",
+        "ToricVarieties/ToricMorphisms.md",
      ],
      "Schemes" => [
         "AlgebraicGeometry/AffineSchemes.md",

--- a/docs/src/ToricVarieties/ToricMorphisms.md
+++ b/docs/src/ToricVarieties/ToricMorphisms.md
@@ -1,0 +1,61 @@
+```@meta
+CurrentModule = Oscar
+```
+
+```@contents
+Pages = ["ToricMorphisms.md"]
+```
+
+# ToricMorphisms
+
+A class of morphisms among toric varieties are described by certain lattice morphisms.
+Let $N_1$ and $N_2$ be lattices and $\Sigma_1$, $\Sigma_2$ fans in $N_1$ and $N_2$
+respectively. A $\mathbb{Z}$-linear map
+
+$$\overline{\phi} \colon N_1 \to N_2$$
+
+is said to be compatible with the fans $\Sigma_1$ and $\Sigma_2$ if for every cone
+$\sigma_1 \in \Sigma_1$, there exists a cone $\sigma_2 \in \Sigma_2$ such that
+$\overline{\phi}_{\mathbb{R}}(\sigma_1) \subseteq \sigma_2$.
+
+By theorem 3.3.4 [CLS11](@cite), such a map $\overline{\phi}$ induces a morphism
+$\phi \colon X_{\Sigma_1} \to X_{\Sigma_2}$ of the toric varieties, and those
+morphisms are exactly the toric morphisms.
+
+
+## Constructors
+
+### Generic constructors without specified codomain
+
+```@docs
+ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Vector{Vector{T}}) where {T <: IntegerUnion}
+ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Matrix{T}) where {T <: IntegerUnion}
+ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::fmpz_mat)
+ToricMorphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap)
+```
+
+### Generic constructors with specified codomain
+
+```@docs
+ToricMorphism(v1::AbstractNormalToricVariety, mapping_matrix::Vector{Vector{T}}, v2::AbstractNormalToricVariety) where {T <: IntegerUnion}
+ToricMorphism(v1::AbstractNormalToricVariety, mapping_matrix::Matrix{T}, v2::AbstractNormalToricVariety) where {T <: IntegerUnion}
+ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::fmpz_mat, codomain::AbstractNormalToricVariety)
+ToricMorphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap, codomain::AbstractNormalToricVariety)
+```
+
+### Special constructors
+
+```@docs
+ToricIdentityMorphism(variety::AbstractNormalToricVariety)
+```
+
+## Attributes of Toric Morhpisms
+
+```@docs
+domain(tm::ToricMorphism)
+image(tm::ToricMorphism)
+codomain(tm::ToricMorphism)
+grid_morphism(tm::ToricMorphism)
+```
+
+## Properties of Toric Morhpisms

--- a/docs/src/ToricVarieties/ToricMorphisms.md
+++ b/docs/src/ToricVarieties/ToricMorphisms.md
@@ -49,7 +49,10 @@ ToricMorphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap,
 ToricIdentityMorphism(variety::AbstractNormalToricVariety)
 ```
 
+
 ## Attributes of Toric Morhpisms
+
+### General attributes
 
 ```@docs
 domain(tm::ToricMorphism)
@@ -57,7 +60,20 @@ image(tm::ToricMorphism)
 codomain(tm::ToricMorphism)
 grid_morphism(tm::ToricMorphism)
 morphism_on_torusinvariant_weil_divisor_group(tm::ToricMorphism)
-morphism_on_cartier_divisor_group(tm::ToricMorphism)
 ```
 
-## Properties of Toric Morhpisms
+### Special attributes of toric varieties
+
+To every toric variety $v$ we can associate a special toric variety, the
+Cox variety. By definition, the Cox variety is such that the mapping matrix of
+the toric morphism from the Cox variety to the variety $v$ is simply
+given by the ray generators of the variety $v$. Put differently,
+if there are exactly $N$ ray generators for the fan of $v$, then the
+Cox variety of $v$ has a fan for which the ray generators are the standard basis
+of $\mathbb{R}^N$ and the maximal cones are one to one to the maximal cones of
+the fan of $v$.
+
+```@docs
+morphism_on_cartier_divisor_group(tm::ToricMorphism)
+morphism_from_cox_variety(variety::AbstractNormalToricVariety)
+```

--- a/docs/src/ToricVarieties/ToricMorphisms.md
+++ b/docs/src/ToricVarieties/ToricMorphisms.md
@@ -56,6 +56,8 @@ domain(tm::ToricMorphism)
 image(tm::ToricMorphism)
 codomain(tm::ToricMorphism)
 grid_morphism(tm::ToricMorphism)
+morphism_on_torusinvariant_weil_divisor_group(tm::ToricMorphism)
+morphism_on_cartier_divisor_group(tm::ToricMorphism)
 ```
 
 ## Properties of Toric Morhpisms

--- a/src/ToricVarieties/JToric.jl
+++ b/src/ToricVarieties/JToric.jl
@@ -79,6 +79,11 @@ include("AlgebraicCycles/properties.jl")
 include("AlgebraicCycles/attributes.jl")
 include("AlgebraicCycles/special_attributes.jl")
 
+include("ToricMorphisms/constructors.jl")
+#include("ToricMorphisms/properties.jl")
+include("ToricMorphisms/attributes.jl")
+#include("ToricMorphisms/special_attributes.jl")
+
 # deprecated functions
 @deprecate map_from_character_to_principal_divisors(v::AbstractNormalToricVariety) map_from_character_lattice_to_torusinvariant_weil_divisor_group(v)
 @deprecate map_from_weil_divisors_to_class_group(v::AbstractNormalToricVariety) map_from_torusinvariant_weil_divisor_group_to_class_group(v)

--- a/src/ToricVarieties/JToric.jl
+++ b/src/ToricVarieties/JToric.jl
@@ -80,9 +80,8 @@ include("AlgebraicCycles/attributes.jl")
 include("AlgebraicCycles/special_attributes.jl")
 
 include("ToricMorphisms/constructors.jl")
-#include("ToricMorphisms/properties.jl")
 include("ToricMorphisms/attributes.jl")
-#include("ToricMorphisms/special_attributes.jl")
+include("ToricMorphisms/special_attributes.jl")
 
 # deprecated functions
 @deprecate map_from_character_to_principal_divisors(v::AbstractNormalToricVariety) map_from_character_lattice_to_torusinvariant_weil_divisor_group(v)

--- a/src/ToricVarieties/ToricMorphisms/attributes.jl
+++ b/src/ToricVarieties/ToricMorphisms/attributes.jl
@@ -1,0 +1,76 @@
+@doc Markdown.doc"""
+    domain(tm::ToricMorphism)
+
+Return the domain of the toric morphism `tm`.
+
+# Examples
+```jldoctest
+julia> F4 = hirzebruch_surface(4)
+A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+
+julia> domain(ToricIdentityMorphism(F4))
+A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+```
+"""
+domain(tm::ToricMorphism) = tm.domain
+export domain
+
+
+@doc Markdown.doc"""
+    codomain(tm::ToricMorphism)
+
+Return the codomain of the toric morphism `tm`.
+
+# Examples
+```jldoctest
+julia> F4 = hirzebruch_surface(4)
+A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+
+julia> codomain(ToricIdentityMorphism(F4))
+A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+```
+"""
+codomain(tm::ToricMorphism) = tm.codomain
+export codomain
+
+
+@doc Markdown.doc"""
+    image(tm::ToricMorphism)
+
+Return the image of the toric morphism `tm`.
+
+# Examples
+```jldoctest
+julia> F4 = hirzebruch_surface(4)
+A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+
+julia> image(ToricIdentityMorphism(F4))
+A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+```
+"""
+image(tm::ToricMorphism) = tm.image
+export image
+
+
+@doc Markdown.doc"""
+    grid_morphism(tm::ToricMorphism)
+
+Return the underlying grid morphism of the toric morphism `tm`.
+
+# Examples
+```jldoctest
+julia> F4 = hirzebruch_surface(4)
+A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+
+julia> grid_morphism(ToricIdentityMorphism(F4))
+Map with following data
+Domain:
+=======
+Abelian group with structure: Z^2
+Codomain:
+=========
+Abelian group with structure: Z^2
+```
+"""
+grid_morphism(tm::ToricMorphism) = tm.grid_morphism
+export grid_morphism

--- a/src/ToricVarieties/ToricMorphisms/attributes.jl
+++ b/src/ToricVarieties/ToricMorphisms/attributes.jl
@@ -74,3 +74,71 @@ Abelian group with structure: Z^2
 """
 grid_morphism(tm::ToricMorphism) = tm.grid_morphism
 export grid_morphism
+
+
+@doc Markdown.doc"""
+    morphism_on_torusinvariant_weil_divisor_group(tm::ToricMorphism)
+
+For a given toric morphism `tm`, this method computes the corresponding
+map of the torusinvariant Weil divisors.
+
+# Examples
+```jldoctest
+julia> F4 = hirzebruch_surface(4)
+A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+
+julia> morphism_on_torusinvariant_weil_divisor_group(ToricIdentityMorphism(F4))
+Map with following data
+Domain:
+=======
+Abelian group with structure: Z^4
+Codomain:
+=========
+Abelian group with structure: Z^4
+```
+"""
+@attr GrpAbFinGenMap function morphism_on_torusinvariant_weil_divisor_group(tm::ToricMorphism)
+    d = domain(tm)
+    cod = codomain(tm)
+    cod_rays = matrix(ZZ,rays(cod))
+    images = matrix(ZZ, rays(d)) * matrix(grid_morphism(tm))
+    mapping_matrix = matrix(ZZ, zeros(ZZ, rank(torusinvariant_weil_divisor_group(d)), 0))
+    for i in 1:nrows(images)
+      j = findfirst(x -> x == true, [contains(maximal_cones(cod)[j], [images[i,k] for k in 1:ncols(images)]) for j in 1:n_maximal_cones(cod)])
+      m = vcat([Int(ray_indices(maximal_cones(cod))[j,k]) * cod_rays[k,:] for k in 1:nrays(cod)])
+      mapping_matrix = hcat(mapping_matrix, solve(transpose(m), transpose(images[i,:])))
+    end
+    return hom(torusinvariant_weil_divisor_group(d), torusinvariant_weil_divisor_group(cod), mapping_matrix)
+end
+export morphism_on_torusinvariant_weil_divisor_group
+
+
+@doc Markdown.doc"""
+    morphism_on_cartier_divisor_group(tm::ToricMorphism)
+
+For a given toric morphism `tm`, this method computes the corresponding
+map of the Cartier divisors.
+
+# Examples
+```jldoctest
+julia> F4 = hirzebruch_surface(4)
+A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+
+julia> morphism_on_cartier_divisor_group(ToricIdentityMorphism(F4))
+Map with following data
+Domain:
+=======
+Abelian group with structure: Z^4
+Codomain:
+=========
+Abelian group with structure: Z^4
+```
+"""
+@attr GrpAbFinGenMap function morphism_on_cartier_divisor_group(tm::ToricMorphism)
+    domain_variety = domain(tm)
+    codomain_variety = codomain(tm)
+    source_embedding = map_from_cartier_divisor_group_to_torusinvariant_divisor_group(domain_variety)
+    morphism_of_weil_divisors = morphism_on_torusinvariant_weil_divisor_group(tm)
+    return restrict_codomain(source_embedding * morphism_of_weil_divisors)
+end
+export morphism_on_cartier_divisor_group

--- a/src/ToricVarieties/ToricMorphisms/constructors.jl
+++ b/src/ToricVarieties/ToricMorphisms/constructors.jl
@@ -1,0 +1,254 @@
+####################################################
+# 1: The Julia type for ToricMorphisms
+####################################################
+
+@attributes mutable struct ToricMorphism
+    domain::AbstractNormalToricVariety
+    grid_morphism::GrpAbFinGenMap
+    image::AbstractNormalToricVariety
+    codomain::AbstractNormalToricVariety
+    ToricMorphism(domain, grid_morphism, image, codomain) = new(domain, grid_morphism, image, codomain)
+end
+export ToricMorphism
+
+
+####################################################
+# 2: Generic constructors
+####################################################
+
+
+@doc Markdown.doc"""
+    ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Vector{Vector{T}}, codomain::T2=nothing) where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}
+
+Construct the toric morphism with given domain and associated to the lattice morphism given by the `mapping_matrix`.
+As optional argument, the codomain of the morphism can be specified.
+
+# Examples
+```jldoctest
+julia> domain = projective_space(NormalToricVariety,1)
+A normal, non-affine, smooth, projective, gorenstein, fano, 1-dimensional toric variety without torusfactor
+
+julia> mapping_matrix = [[0, 1]]
+1-element Vector{Vector{Int64}}:
+ [0, 1]
+
+julia> ToricMorphism(domain, mapping_matrix)
+A toric morphism
+```
+"""
+function ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Vector{Vector{T}}, codomain::T2=nothing) where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}
+    (length(mapping_matrix) > 0 && length(mapping_matrix[1]) > 0) || throw(ArgumentError("The mapping matrix must not be empty"))
+    if codomain == nothing
+      return ToricMorphism(domain, hom(character_lattice(domain), free_abelian_group(length(mapping_matrix[1])), matrix(ZZ,mapping_matrix)), codomain)
+    else
+      return ToricMorphism(domain, hom(character_lattice(domain), character_lattice(codomain), matrix(ZZ,mapping_matrix)), codomain)
+    end
+end
+export ToricMorphism
+
+
+@doc Markdown.doc"""
+    ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Matrix{T}, codomain::T2=nothing) where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}
+
+Construct the toric morphism with given domain and associated to the lattice morphism given by the `mapping_matrix`.
+
+# Examples
+```jldoctest
+julia> domain = projective_space(NormalToricVariety,1)
+A normal, non-affine, smooth, projective, gorenstein, fano, 1-dimensional toric variety without torusfactor
+
+julia> mapping_matrix = [0 1]
+1×2 Matrix{Int64}:
+ 0  1
+
+julia> ToricMorphism(domain, mapping_matrix)
+A toric morphism
+```
+"""
+function ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Matrix{T}, codomain::T2=nothing) where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}
+    (nrows(mapping_matrix) > 0 && ncols(mapping_matrix) > 0) || throw(ArgumentError("The mapping matrix must not be empty"))
+    if codomain == nothing
+      return ToricMorphism(domain, hom(character_lattice(domain), free_abelian_group(ncols(mapping_matrix)), matrix(ZZ,mapping_matrix)), codomain)
+    else
+      return ToricMorphism(domain, hom(character_lattice(domain), character_lattice(codomain), matrix(ZZ,mapping_matrix)), codomain)
+    end
+end
+export ToricMorphism
+
+
+@doc Markdown.doc"""
+    ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::fmpz_mat, codomain::T=nothing) where {T <: Union{AbstractNormalToricVariety, Nothing}}
+
+Construct the toric morphism with given domain and associated to the lattice morphism given by the `mapping_matrix`.
+
+# Examples
+```jldoctest
+julia> domain = projective_space(NormalToricVariety,1)
+A normal, non-affine, smooth, projective, gorenstein, fano, 1-dimensional toric variety without torusfactor
+
+julia> codomain = hirzebruch_surface(2)
+A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+
+julia> mapping_matrix = matrix(ZZ,[0 1])
+[0   1]
+
+julia> ToricMorphism(domain, mapping_matrix, codomain)
+A toric morphism
+```
+"""
+function ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::fmpz_mat, codomain::T=nothing) where {T <: Union{AbstractNormalToricVariety, Nothing}}
+    (nrows(mapping_matrix) > 0 && ncols(mapping_matrix) > 0) || throw(ArgumentError("The mapping matrix must not be empty"))
+    if codomain == nothing
+      return ToricMorphism(domain, hom(character_lattice(domain), free_abelian_group(ncols(mapping_matrix)), mapping_matrix), codomain)
+    else
+      return ToricMorphism(domain, hom(character_lattice(domain), character_lattice(codomain), mapping_matrix), codomain)
+    end
+end
+export ToricMorphism
+
+
+@doc Markdown.doc"""
+    function ToricMorphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap, codomain::T=nothing) where {T <: Union{AbstractNormalToricVariety, Nothing}}
+
+Construct the toric morphism from the `domain` to the `codomain` with map given by the `grid_morphism`.
+
+# Examples
+```jldoctest
+julia> domain = projective_space(NormalToricVariety,1)
+A normal, non-affine, smooth, projective, gorenstein, fano, 1-dimensional toric variety without torusfactor
+
+julia> codomain = hirzebruch_surface(2)
+A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+
+julia> mapping_matrix = matrix(ZZ,[[0, 1]])
+[0   1]
+
+julia> grid_morphism = hom(character_lattice(domain), character_lattice(codomain), mapping_matrix)
+Map with following data
+Domain:
+=======
+Abelian group with structure: Z
+Codomain:
+=========
+Abelian group with structure: Z^2
+
+julia> ToricMorphism(domain, grid_morphism, codomain)
+A toric morphism
+```
+"""
+function ToricMorphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap, codomain::T=nothing) where {T <: Union{AbstractNormalToricVariety, Nothing}}
+    # avoid empty mapping
+    (nrows(matrix(grid_morphism)) > 0 && ncols(matrix(grid_morphism)) > 0) || throw(ArgumentError("The mapping matrix must not be empty"))
+
+    # check for a well-defined map
+    if nrows(matrix(grid_morphism)) !== rank(character_lattice(domain))
+      throw(ArgumentError("The number of rows of the mapping matrix must match the rank of the character lattice of the domain toric variety"))
+    end
+
+    # compute the image
+    image_rays = matrix(ZZ, rays(domain)) * matrix(grid_morphism)
+    image_rays = hcat([[Int(image_rays[i, j]) for i in 1:nrows(image_rays)] for j in 1:ncols(image_rays)]...)
+    image = NormalToricVariety(PolyhedralFan(image_rays, ray_indices(maximal_cones(domain))))
+
+    # compute the morphism
+    if codomain == nothing
+      return ToricMorphism(domain, grid_morphism, image, image)
+    else
+      if ncols(matrix(grid_morphism)) !== rank(character_lattice(codomain))
+        throw(ArgumentError("The number of columns of the mapping matrix must match the rank of the character lattice of the codomain toric variety"))
+      end
+      codomain_cones = maximal_cones(codomain)
+      image_cones = [positive_hull(matrix(ZZ,rays(c)) * matrix(grid_morphism)) for c in maximal_cones(domain)]
+      for c in image_cones
+        any([intersect(c, ic) == c for ic in image_cones]) || throw(ArgumentError("Toric morphism not well-defined"))
+      end
+      return ToricMorphism(domain, grid_morphism, image, codomain)
+    end
+end
+export ToricMorphism
+
+
+####################################################
+# 3: Special constructors
+####################################################
+
+@doc Markdown.doc"""
+    ToricIdentityMorphism(variety::AbstractNormalToricVariety)
+
+Construct the toric identity morphism from `variety` to `variety`.
+
+# Examples
+```jldoctest
+julia> ToricIdentityMorphism(hirzebruch_surface(2))
+A toric morphism
+```
+"""
+function ToricIdentityMorphism(variety::AbstractNormalToricVariety)
+    r = rank(character_lattice(variety))
+    identity_matrix = matrix(ZZ,[[if i==j 1 else 0 end for j in 1:r] for i in 1:r])
+    grid_morphism = hom(character_lattice(variety), character_lattice(variety), identity_matrix)
+    return ToricMorphism(variety, grid_morphism, variety, variety)
+end
+export ToricIdentityMorphism
+
+
+####################################################
+# 4: Addition and scalar multiplication of morphisms
+####################################################
+
+function Base.:+(tm1::ToricMorphism, tm2::ToricMorphism)
+    if domain(tm1) !== domain(tm2)
+        throw(ArgumentError("The toric morphism must be defined with identically the same domain"))
+    end
+    if codomain(tm1) !== codomain(tm2)
+        throw(ArgumentError("The toric morphism must be defined with identically the same codomain"))
+    end
+    return ToricMorphism(domain(tm1), grid_morphism(tm1) + grid_morphism(tm2), codomain(tm1))
+end
+
+
+function Base.:-(tm1::ToricMorphism, tm2::ToricMorphism)
+    if domain(tm1) !== domain(tm2)
+        throw(ArgumentError("The toric morphism must be defined with identically the same domain"))
+    end
+    if codomain(tm1) !== codomain(tm2)
+        throw(ArgumentError("The toric morphism must be defined with identically the same codomain"))
+    end
+    return ToricMorphism(domain(tm1), grid_morphism(tm1) - grid_morphism(tm2), codomain(tm1))
+end
+
+
+function Base.:*(c::T, tm::ToricMorphism) where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}
+  new_grid_morphism = hom(domain(grid_morphism(tm)), codomain(grid_morphism(tm)), c * matrix(grid_morphism(tm)))
+  return ToricMorphism(domain(tm), new_grid_morphism, codomain(tm))
+end
+
+
+####################################################
+# 5: Composition of toric morphisms
+####################################################
+
+function Base.:*(tm1::ToricMorphism, tm2::ToricMorphism)
+    if codomain(tm1) !== domain(tm2)
+        throw(ArgumentError("The codomain of the first toric morphism must be identically the same as the domain of the second morphism"))
+    end
+    return ToricMorphism(domain(tm1), grid_morphism(tm1) * grid_morphism(tm2), codomain(tm2))
+end
+
+
+####################################################
+# 6: Equality of toric morphisms
+####################################################
+
+function Base.:(==)(tm1::ToricMorphism, tm2::ToricMorphism)
+    return domain(tm1) == domain(tm2) && codomain(tm1) == codomain(tm2) && grid_morphism(tm1) == grid_morphism(tm2)
+end
+
+
+######################
+# 6: Display
+######################
+
+function Base.show(io::IO, tm::ToricMorphism)
+    join(io, "A toric morphism")
+end

--- a/src/ToricVarieties/ToricMorphisms/special_attributes.jl
+++ b/src/ToricVarieties/ToricMorphisms/special_attributes.jl
@@ -1,0 +1,42 @@
+@doc Markdown.doc"""
+    morphism_from_cox_variety(variety::AbstractNormalToricVariety)
+
+This method returns the quotient morphism from the Cox variety to the toric variety in question.
+
+# Examples
+```jldoctest
+julia> F4 = hirzebruch_surface(4)
+A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+
+julia> morphism_from_cox_variety(F4)
+A toric morphism
+```
+"""
+@attr ToricMorphism function morphism_from_cox_variety(variety::AbstractNormalToricVariety)
+    mapping_matrix = matrix(ZZ, rays(fan(variety)))
+    max_cones_for_cox_variety = ray_indices(maximal_cones(variety))
+    rays_for_cox_variety = matrix(ZZ,[[if i==j 1 else 0 end for j in 1:nrays(variety)] for i in 1:nrays(variety)])
+    cox_variety = NormalToricVariety(PolyhedralFan(rays_for_cox_variety, max_cones_for_cox_variety))
+    return ToricMorphism(cox_variety, mapping_matrix, variety)
+end
+export morphism_from_cox_variety
+
+
+@doc Markdown.doc"""
+    cox_variety(variety::AbstractNormalToricVariety)
+
+This method returns the Cox variety of the toric variety in question.
+
+# Examples
+```jldoctest
+julia> F4 = hirzebruch_surface(4)
+A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
+
+julia> cox_variety(F4)
+A normal toric variety
+```
+"""
+@attr AbstractNormalToricVariety function cox_variety(variety::AbstractNormalToricVariety)
+    return domain(morphism_from_cox_variety(variety))
+end
+export cox_variety

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -637,3 +637,33 @@ end
     @test is_trivial(ac2*ac2) == false
     @test is_trivial(ac2*ac2*ac2) == true
 end
+
+
+
+
+
+#########################
+# (16) ToricMorphisms
+#########################
+
+source = projective_space(NormalToricVariety,1)
+target = hirzebruch_surface(2)
+tm1 = ToricMorphism(source, matrix(ZZ, [[0, 1]]), target)
+tm2 = ToricIdentityMorphism(target)
+
+@testset "Argument errors for toric morphisms" begin
+    @test_throws ArgumentError tm1 * tm1
+end
+
+@testset "Arithmetics of toric morphisms" begin
+    @test (tm1 == tm2) == false
+    @test (tm2 + tm2 == 2*tm2) == true
+    @test (tm2 + tm2 == fmpz(2)*tm2) == true
+    @test (tm2 * tm2 == tm2) == true
+end
+
+@testset "Attributes of toric morphisms" begin
+    @test (image(tm1) == codomain(tm1)) == false
+    @test codomain(tm1) == domain(tm2)
+    @test matrix(grid_morphism(tm2)) == matrix(ZZ,[[1,0],[0,1]])
+end

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -668,4 +668,6 @@ end
     @test matrix(grid_morphism(tm2)) == matrix(ZZ,[[1,0],[0,1]])
     @test morphism_on_torusinvariant_weil_divisor_group(tm2).map == identity_matrix(ZZ,4)
     @test morphism_on_cartier_divisor_group(tm2).map == identity_matrix(ZZ,4)
+    @test grid_morphism(morphism_from_cox_variety(source)).map == matrix(ZZ, [[1], [-1]])
+    @test is_affine(cox_variety(source)) == false
 end

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -666,4 +666,6 @@ end
     @test (image(tm1) == codomain(tm1)) == false
     @test codomain(tm1) == domain(tm2)
     @test matrix(grid_morphism(tm2)) == matrix(ZZ,[[1,0],[0,1]])
+    @test morphism_on_torusinvariant_weil_divisor_group(tm2).map == identity_matrix(ZZ,4)
+    @test morphism_on_cartier_divisor_group(tm2).map == identity_matrix(ZZ,4)
 end


### PR DESCRIPTION
This PR achieves the following:
1. Implement basic functionality for toric morphisms.
2. For a given toric morphism, it computes the induced maps on the torusinvariant Weil divisors and the Cartier divisors.
3. It implements the Cox variety and the quotient morphism from the Cox variety to the toric variety in question.