### PR TITLE
fixed `orthogonal_sign`

### DIFF
--- a/src/Groups/matrices/form_group.jl
+++ b/src/Groups/matrices/form_group.jl
@@ -545,14 +545,16 @@ function orthogonal_sign(G::MatrixGroup)
     M = GAP.Globals.GModuleByMats(GAP.Globals.GeneratorsOfGroup(G.X),
                                   codomain(iso_oscar_gap(R)))
     sign = GAP.Globals.MTX.OrthogonalSign(M)
-    sign == GAP.Globals.fail && return nothing
+    sign === GAP.Globals.fail && return nothing
     # If the characteristic is odd and there is an invariant
     # antisymmetric bilinear form then `GAP.Globals.MTX.OrthogonalSign`
     # does *not* return `fail`,
     # see https://github.com/gap-system/gap/issues/4936.
     if isodd(characteristic(R))
       Q = GAP.Globals.MTX.InvariantQuadraticForm(M)
-      Q == - GAP.Globals.TransposedMat(Q) && return nothing
+      if Q === GAP.Globals.fail || Q == - GAP.Globals.TransposedMat(Q)
+        return nothing
+      end
     end
     return sign
 end

--- a/src/Groups/matrices/form_group.jl
+++ b/src/Groups/matrices/form_group.jl
@@ -546,6 +546,14 @@ function orthogonal_sign(G::MatrixGroup)
                                   codomain(iso_oscar_gap(R)))
     sign = GAP.Globals.MTX.OrthogonalSign(M)
     sign == GAP.Globals.fail && return nothing
+    # If the characteristic is odd and there is an invariant
+    # antisymmetric bilinear form then `GAP.Globals.MTX.OrthogonalSign`
+    # does *not* return `fail`,
+    # see https://github.com/gap-system/gap/issues/4936.
+    if isodd(characteristic(R))
+      Q = GAP.Globals.MTX.InvariantQuadraticForm(M)
+      Q == - GAP.Globals.TransposedMat(Q) && return nothing
+    end
     return sign
 end
 

--- a/test/Groups/forms.jl
+++ b/test/Groups/forms.jl
@@ -610,5 +610,16 @@ end
       # Odd dimensional orthogonal groups in char. 2 are not irreducible.
       @test_throws ErrorException orthogonal_sign(orthogonal_group(0, 5, 2))
       @test orthogonal_sign(general_linear_group(4, 2)) == nothing
+      # If the abs. irred. module preserves an antisymmetric invariant
+      # bilinear form then there is no nondegenerate quadratic form.
+      F = GF(7)
+      G = MatrixGroup(6, F)
+      mats = [matrix(F, [0 1 0 0 0 0; 1 0 0 0 0 0; 0 0 0 1 0 0;
+                         0 0 1 0 0 0; 5 5 2 2 6 0; 3 3 4 4 0 6]),
+              matrix(F, [4 0 0 0 0 0; 0 0 1 0 0 0; 0 6 1 0 0 0;
+                         0 0 0 0 1 0; 0 0 0 0 0 1; 6 0 0 2 4 3])]
+      G.gens = [MatrixGroupElem(G, m) for m in mats]
+      @test describe(G) == "PSU(3,3)"
+      @test orthogonal_sign(G) == nothing
    end
 end


### PR DESCRIPTION
Note that `GAP.Globals.MTX.OrthogonalSign` is not aware of the fact
that `GAP.Globals.MTX.InvariantQuadraticForm` may return a matrix
of the zero form in certain situations,
see https://github.com/gap-system/gap/issues/4936.