### PR TITLE
test/PolyhedralGeometry/timings on macos: restrict openmp threads and allow more time

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,6 +53,10 @@ jobs:
           arch: ${{ matrix.julia-arch }}
       - name: "Build package"
         uses: julia-actions/julia-buildpkg@latest
+      - name: "limit OpenMP threads"
+        if: runner.os == 'macOS'
+        # restrict number of openMP threads on macOS due to oversubscription
+        run: echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
       - name: "Run tests"
         uses: julia-actions/julia-runtest@latest
       - name: "Run doctests"

--- a/test/PolyhedralGeometry/timing.jl
+++ b/test/PolyhedralGeometry/timing.jl
@@ -7,6 +7,8 @@
     using Oscar
     using Oscar.Graphs
 
+    # macos on github actions is very slow
+    factor = Sys.isapple() && haskey(ENV,"GITHUB_ACTIONS") ? 5.0 : 1.0
 
     lp_provide = ["FACETS", "VERTICES", "VERTICES_IN_FACETS", "LATTICE", "BOUNDED"]
 
@@ -106,8 +108,10 @@
             for i in 1:repeat
                 copy = deepcopy(poly)
                 result = min(@elapsed fun(copy), result)
-                if result <= bound
+                if result <= bound*factor
                     return true
+                else
+                    @warn "timing $(Polymake.getname(Oscar.pm_object(poly))) with $pref too slow: $result > $(bound*factor)"
                 end
             end
             return false


### PR DESCRIPTION
The poor Github runners for macOS only have three cores and we do not want to disturb those important Spotlight processes running in parallel that need to index all the files ...
So we restrict OpenMP to only use one thread on the macOS runners, and we also add an extra factor to allow more time to finish the timing-tests.

```
Processes: 349 total, 5 running, 344 sleeping, 1212 threads 
Load Avg: 17.16, 14.30, 9.28 
CPU usage: 49.30% user, 32.59% sys, 18.10% idle 

PID    COMMAND         %CPU TIME     #TH   #WQ #PORTS MEM    PURG CMPRS PGRP  PPID  STATE    BOOSTS %CPU_ME  %CPU_OTHRS UID
267    mds_stores      41.7 01:48.88 11/3  9/3 97-    374M-  25M+ 0B    267   1     running  *0[1]  0.00000  41.10942   0  
83     mds             24.6 01:48.48 11/1  8/1 262+   12M-   0B   0B    83    1     running  *0[1]  2.95321  22.40077   0  
27406  mdworker_shared 18.4 00:01.70 4     1   50     984K-  0B   0B    27406 1     sleeping *0[1]  0.66546  0.00000    501
27491  mdworker_shared 13.5 00:01.02 4     1   48     948K-  0B   0B    27491 1     sleeping *0[1]  9.63756  0.00000    501
27796  top             13.4 00:00.30 1/1   0   28+    1264K+ 0B   0B    391   17106 running  *0[1]  0.04178  0.00000    0  
27353  mdworker_shared 12.9 00:02.61 4     1   48     948K-  0B   0B    27353 1     sleeping *0[1]  15.83480 0.00000    501
27403  mdworker_shared 12.8 00:01.57 4     1   50     976K-  0B   0B    27403 1     sleeping *0[1]  14.89349 0.00000    501
27404  mdworker_shared 12.6 00:01.78 4     1   50     988K-  0B   0B    27404 1     sleeping *0[1]  0.49264  0.00000    501
27447  mdworker_shared 11.9 00:01.18 4     1   48     956K-  0B   0B    27447 1     sleeping *0[1]  0.60271  0.00000    501
0      kernel_task     3.4  00:39.14 154/3 0   0      772K+  0B   0B    0     0     running   0[0]  0.00000  0.00000    0  
```

cc: @lkastner @thofma 