### PR TITLE
smaller powers in random loc elems

### DIFF
--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -120,7 +120,7 @@ end
 ### generation of random elements 
 function rand(S::MPolyPowersOfElement, v1::UnitRange{Int}, v2::UnitRange{Int}, v3::UnitRange{Int})
   R = ambient_ring(S)
-  return prod(f^rand(0:9) for f in denominators(S); init = one(R))::elem_type(R)
+  return prod(f^rand(0:5) for f in denominators(S); init = one(R))::elem_type(R)
 end
 
 ### simplification. 


### PR DESCRIPTION
for 
```
include("Rings/mpoly-localizations.jl")
include("Rings/mpolyquo-localizations.jl")
include("Rings/integer-localizations.jl")
include("Rings/nmod-localizations.jl")
```

old:
```
 87.708311 seconds (210.43 M allocations: 21.406 GiB, 2.03% gc time, 67.67% compilation time)
```

new:
```
 72.770121 seconds (233.91 M allocations: 11.959 GiB, 4.45% gc time, 80.79% compilation time)
```

At least now we can put more of the blame on the compiler.