### PR TITLE
Tiny allocations

### DIFF
--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -89,13 +89,7 @@ end
 
 Base.convert(T::Type{<:Polymake.Matrix}, x::Union{fmpz_mat,fmpq_mat}) = Base.convert(T, Matrix(x))
 
-function Base.convert(::Type{<:Polymake.Integer}, x::fmpz)
-    if Nemo._fmpz_is_small(x)
-        return Polymake.Integer(x.d)
-    else
-        GC.@preserve x return Polymake._integer_from_ptr64(x.d << 2)
-    end
-end
+Base.convert(::Type{<:Polymake.Integer}, x::fmpz) = GC.@preserve x return Polymake.new_integer_from_fmpz(x)
 
 Base.convert(::Type{<:Polymake.Rational}, x::fmpq) = GC.@preserve x return Polymake.new_rational_from_fmpq(x)
 

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -91,8 +91,28 @@ Base.convert(::Type{<:Polymake.Rational}, x::fmpq) = GC.@preserve x return Polym
 
 Base.convert(::Type{<:Polymake.Rational}, x::fmpz) = GC.@preserve x return Polymake.new_rational_from_fmpz(x)
 
+Base.convert(::Type{<:Polymake.Integer}, x::fmpq) = GC.@preserve x return Polymake.new_integer_from_fmpq(x)
+
 function Base.convert(::Type{fmpz}, x::Polymake.Integer)
     GC.@preserve x np = Polymake.new_fmpz_from_integer(x)
+    rp = Ptr{fmpz}(np)
+    return unsafe_load(rp)
+end
+
+function Base.convert(::Type{fmpq}, x::Polymake.Rational)
+    GC.@preserve x np = Polymake.new_fmpq_from_rational(x)
+    rp = Ptr{fmpq}(np)
+    return unsafe_load(rp)
+end
+
+function Base.convert(::Type{fmpq}, x::Polymake.Integer)
+    GC.@preserve x np = Polymake.new_fmpq_from_integer(x)
+    rp = Ptr{fmpq}(np)
+    return unsafe_load(rp)
+end
+
+function Base.convert(::Type{fmpz}, x::Polymake.Rational)
+    GC.@preserve x np = Polymake.new_fmpz_from_rational(x)
     rp = Ptr{fmpz}(np)
     return unsafe_load(rp)
 end
@@ -232,10 +252,6 @@ end
 function decompose_hdata(A)
     (A = -A[:, 2:end], b = A[:, 1])
 end
-
-Base.convert(::Type{fmpq}, q::Polymake.Rational) = fmpq(Polymake.numerator(q), Polymake.denominator(q))
-
-Base.convert(::Type{fmpz}, q::Polymake.Rational) = convert(fmpz, convert(Polymake.Integer, q))
 
 # TODO: different printing within oscar? if yes, implement the following method
 # Base.show(io::IO, ::MIME"text/plain", I::IncidenceMatrix) = show(io, "text/plain", Matrix{Bool}(I))

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -53,7 +53,7 @@ _isempty_halfspace(x::Pair{<:Union{Oscar.MatElem, AbstractMatrix}, Any}) = isemp
 _isempty_halfspace(x) = isempty(x)
 
 # Base.convert(::Type{Polymake.Integer}, x::fmpz) = Polymake.Integer(BigInt(x))
-Base.convert(::Type{Polymake.Rational}, x::fmpz) = Polymake.Rational(convert(Polymake.Integer, x), convert(Polymake.Integer, 1))
+# Base.convert(::Type{Polymake.Rational}, x::fmpz) = Polymake.Rational(convert(Polymake.Integer, x), convert(Polymake.Integer, 1))
 # Base.convert(::Type{Polymake.Rational}, x::fmpq) = Polymake.Rational(convert(Polymake.Integer, numerator(x)), convert(Polymake.Integer, denominator(x)))
 
 # export nf_scalar
@@ -92,6 +92,8 @@ Base.convert(T::Type{<:Polymake.Matrix}, x::Union{fmpz_mat,fmpq_mat}) = Base.con
 Base.convert(::Type{<:Polymake.Integer}, x::fmpz) = GC.@preserve x return Polymake.new_integer_from_fmpz(x)
 
 Base.convert(::Type{<:Polymake.Rational}, x::fmpq) = GC.@preserve x return Polymake.new_rational_from_fmpq(x)
+
+Base.convert(::Type{<:Polymake.Rational}, x::fmpz) = GC.@preserve x return Polymake.new_rational_from_fmpz(x)
 
 Polymake.convert_to_pm_type(::Type{Oscar.fmpz_mat}) = Polymake.Matrix{Polymake.Integer}
 Polymake.convert_to_pm_type(::Type{Oscar.fmpq_mat}) = Polymake.Matrix{Polymake.Rational}

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -94,31 +94,27 @@ Base.convert(::Type{<:Polymake.Rational}, x::fmpz) = GC.@preserve x return Polym
 Base.convert(::Type{<:Polymake.Integer}, x::fmpq) = GC.@preserve x return Polymake.new_integer_from_fmpq(x)
 
 function Base.convert(::Type{fmpz}, x::Polymake.Integer)
-    res = pointer_from_objref(fmpz())
-    GC.@preserve x Polymake.new_fmpz_from_integer(x, res)
-    rp = Ptr{fmpz}(res)
-    return unsafe_load(rp)
+    res = fmpz()
+    GC.@preserve x Polymake.new_fmpz_from_integer(x, pointer_from_objref(res))
+    return res
 end
 
 function Base.convert(::Type{fmpq}, x::Polymake.Rational)
-    res = pointer_from_objref(fmpq())
-    GC.@preserve x Polymake.new_fmpq_from_rational(x, res)
-    rp = Ptr{fmpq}(res)
-    return unsafe_load(rp)
+    res = fmpq()
+    GC.@preserve x Polymake.new_fmpq_from_rational(x, pointer_from_objref(res))
+    return res
 end
 
 function Base.convert(::Type{fmpq}, x::Polymake.Integer)
-    res = pointer_from_objref(fmpq())
-    GC.@preserve x Polymake.new_fmpq_from_integer(x, res)
-    rp = Ptr{fmpq}(res)
-    return unsafe_load(rp)
+    res = fmpq()
+    GC.@preserve x Polymake.new_fmpq_from_integer(x, pointer_from_objref(res))
+    return res
 end
 
 function Base.convert(::Type{fmpz}, x::Polymake.Rational)
-    res = pointer_from_objref(fmpz())
-    GC.@preserve x Polymake.new_fmpz_from_rational(x, res)
-    rp = Ptr{fmpz}(res)
-    return unsafe_load(rp)
+    res = fmpz()
+    GC.@preserve x Polymake.new_fmpz_from_rational(x, pointer_from_objref(res))
+    return res
 end
 
 Polymake.convert_to_pm_type(::Type{Oscar.fmpz_mat}) = Polymake.Matrix{Polymake.Integer}

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -52,10 +52,6 @@ end
 _isempty_halfspace(x::Pair{<:Union{Oscar.MatElem, AbstractMatrix}, Any}) = isempty(x[1])
 _isempty_halfspace(x) = isempty(x)
 
-# Base.convert(::Type{Polymake.Integer}, x::fmpz) = Polymake.Integer(BigInt(x))
-# Base.convert(::Type{Polymake.Rational}, x::fmpz) = Polymake.Rational(convert(Polymake.Integer, x), convert(Polymake.Integer, 1))
-# Base.convert(::Type{Polymake.Rational}, x::fmpq) = Polymake.Rational(convert(Polymake.Integer, numerator(x)), convert(Polymake.Integer, denominator(x)))
-
 # export nf_scalar
 
 Base.zero(::Type{nf_scalar}) = fmpq()

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -97,11 +97,7 @@ function Base.convert(::Type{<:Polymake.Integer}, x::fmpz)
     end
 end
 
-function Base.convert(::Type{<:Polymake.Rational}, x::fmpq)
-    GC.@preserve x begin
-        return Polymake.new_rational_from_fmpq(x)
-    end
-end
+Base.convert(::Type{<:Polymake.Rational}, x::fmpq) = GC.@preserve x return Polymake.new_rational_from_fmpq(x)
 
 Polymake.convert_to_pm_type(::Type{Oscar.fmpz_mat}) = Polymake.Matrix{Polymake.Integer}
 Polymake.convert_to_pm_type(::Type{Oscar.fmpq_mat}) = Polymake.Matrix{Polymake.Rational}

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -94,26 +94,30 @@ Base.convert(::Type{<:Polymake.Rational}, x::fmpz) = GC.@preserve x return Polym
 Base.convert(::Type{<:Polymake.Integer}, x::fmpq) = GC.@preserve x return Polymake.new_integer_from_fmpq(x)
 
 function Base.convert(::Type{fmpz}, x::Polymake.Integer)
-    GC.@preserve x np = Polymake.new_fmpz_from_integer(x)
-    rp = Ptr{fmpz}(np)
+    res = pointer_from_objref(fmpz())
+    GC.@preserve x Polymake.new_fmpz_from_integer(x, res)
+    rp = Ptr{fmpz}(res)
     return unsafe_load(rp)
 end
 
 function Base.convert(::Type{fmpq}, x::Polymake.Rational)
-    GC.@preserve x np = Polymake.new_fmpq_from_rational(x)
-    rp = Ptr{fmpq}(np)
+    res = pointer_from_objref(fmpq())
+    GC.@preserve x Polymake.new_fmpq_from_rational(x, res)
+    rp = Ptr{fmpq}(res)
     return unsafe_load(rp)
 end
 
 function Base.convert(::Type{fmpq}, x::Polymake.Integer)
-    GC.@preserve x np = Polymake.new_fmpq_from_integer(x)
-    rp = Ptr{fmpq}(np)
+    res = pointer_from_objref(fmpq())
+    GC.@preserve x Polymake.new_fmpq_from_integer(x, res)
+    rp = Ptr{fmpq}(res)
     return unsafe_load(rp)
 end
 
 function Base.convert(::Type{fmpz}, x::Polymake.Rational)
-    GC.@preserve x np = Polymake.new_fmpz_from_rational(x)
-    rp = Ptr{fmpz}(np)
+    res = pointer_from_objref(fmpz())
+    GC.@preserve x Polymake.new_fmpz_from_rational(x, res)
+    rp = Ptr{fmpz}(res)
     return unsafe_load(rp)
 end
 

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -91,6 +91,12 @@ Base.convert(::Type{<:Polymake.Rational}, x::fmpq) = GC.@preserve x return Polym
 
 Base.convert(::Type{<:Polymake.Rational}, x::fmpz) = GC.@preserve x return Polymake.new_rational_from_fmpz(x)
 
+function Base.convert(::Type{fmpz}, x::Polymake.Integer)
+    GC.@preserve x np = Polymake.new_fmpz_from_integer(x)
+    rp = Ptr{fmpz}(np)
+    return unsafe_load(rp)
+end
+
 Polymake.convert_to_pm_type(::Type{Oscar.fmpz_mat}) = Polymake.Matrix{Polymake.Integer}
 Polymake.convert_to_pm_type(::Type{Oscar.fmpq_mat}) = Polymake.Matrix{Polymake.Rational}
 Polymake.convert_to_pm_type(::Type{Oscar.fmpz}) = Polymake.Integer

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -89,6 +89,18 @@ end
 
 Base.convert(T::Type{<:Polymake.Matrix}, x::Union{fmpz_mat,fmpq_mat}) = Base.convert(T, Matrix(x))
 
+function Base.convert(::Type{<:Polymake.Integer}, x::fmpz)
+    if Nemo._fmpz_is_small(x)
+        return Polymake.Integer(x.d)
+    else
+        GC.@preserve x begin
+            bi = Nemo._as_bigint(x)
+            p = pointer_from_objref(bi)
+            return _integer_from_fmpz(p)
+        end
+    end
+end
+
 Polymake.convert_to_pm_type(::Type{Oscar.fmpz_mat}) = Polymake.Matrix{Polymake.Integer}
 Polymake.convert_to_pm_type(::Type{Oscar.fmpq_mat}) = Polymake.Matrix{Polymake.Rational}
 Polymake.convert_to_pm_type(::Type{Oscar.fmpz}) = Polymake.Integer

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -52,9 +52,9 @@ end
 _isempty_halfspace(x::Pair{<:Union{Oscar.MatElem, AbstractMatrix}, Any}) = isempty(x[1])
 _isempty_halfspace(x) = isempty(x)
 
-Base.convert(::Type{Polymake.Integer}, x::fmpz) = Polymake.Integer(BigInt(x))
+# Base.convert(::Type{Polymake.Integer}, x::fmpz) = Polymake.Integer(BigInt(x))
 Base.convert(::Type{Polymake.Rational}, x::fmpz) = Polymake.Rational(convert(Polymake.Integer, x), convert(Polymake.Integer, 1))
-Base.convert(::Type{Polymake.Rational}, x::fmpq) = Polymake.Rational(convert(Polymake.Integer, numerator(x)), convert(Polymake.Integer, denominator(x)))
+# Base.convert(::Type{Polymake.Rational}, x::fmpq) = Polymake.Rational(convert(Polymake.Integer, numerator(x)), convert(Polymake.Integer, denominator(x)))
 
 # export nf_scalar
 
@@ -93,11 +93,13 @@ function Base.convert(::Type{<:Polymake.Integer}, x::fmpz)
     if Nemo._fmpz_is_small(x)
         return Polymake.Integer(x.d)
     else
-        GC.@preserve x begin
-            bi = Nemo._as_bigint(x)
-            p = pointer_from_objref(bi)
-            return _integer_from_fmpz(p)
-        end
+        GC.@preserve x return Polymake._integer_from_ptr64(x.d << 2)
+    end
+end
+
+function Base.convert(::Type{<:Polymake.Rational}, x::fmpq)
+    GC.@preserve x begin
+        return Polymake.new_rational_from_fmpq(x)
     end
 end
 


### PR DESCRIPTION
Avoid frequent tiny allocations by implementing specific C++ functionality. This mainly focuses on conversion between `Polymake` native types (`Integer` and `Rational`) and `Oscar` native types (`fmpz` and `fmpq`), as well as the access of properties of `BigObject`s.

Requires changes from same-named branch on `Polymake.jl` and `libpolymake-julia`.