### PR TITLE
Fix syntax error in the documentation

### DIFF
--- a/docs/src/AlgebraicGeometry/standard_constructions.md
+++ b/docs/src/AlgebraicGeometry/standard_constructions.md
@@ -17,6 +17,6 @@ available in Oscar.
 
 ## Grassman Plücker Ideal
 ```@docs
-grassman_pluecker_ideal([ring::MPolyRing,] subspace_dimension::Int, ambient_dimension::Int)
+grassman_pluecker_ideal
 ```
 


### PR DESCRIPTION
One can leave off the parameter list, this will then include all docstrings for methods matching that name -- but since there is only one such method right now, this is fine