### PR TITLE
Tweak `alternating_group` and `symmetric_group`

### DIFF
--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -33,16 +33,23 @@ _gap_filter(::Type{FPGroup}) = GAP.Globals.IsFpGroup
 # `_gap_filter(::Type{MatrixGroup})` is on the file `matrices/MatGrp.jl`
 
 """
-    symmetric_group(::Type{T} = PermGroup, n::Int)
+    symmetric_group(n::Int)
 
-Return the full symmetric group on the set `{1, 2, ..., n}`,
-as an instance of `T`, where `T` is in {`PermGroup`, `PcGroup`}.
+Return the full symmetric group on the set `{1, 2, ..., n}`.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(5)
+Sym( [ 1 .. 5 ] )
+
+julia> order(G)
+120
+
+```
 """
-symmetric_group(n::Int) = symmetric_group(PermGroup, n)
-
-function symmetric_group(::Type{T}, n::Int) where T <: GAPGroup
+function symmetric_group(n::Int)
   n >= 1 || throw(ArgumentError("n must be a positive integer"))
-  return T(GAP.Globals.SymmetricGroup(_gap_filter(T), n)::GapObj)
+  return PermGroup(GAP.Globals.SymmetricGroup(n)::GapObj)
 end
 
 """
@@ -62,16 +69,23 @@ and `false` otherwise.
 @gapattribute is_isomorphic_with_symmetric_group(G::GAPGroup) = GAP.Globals.IsSymmetricGroup(G.X)::Bool
 
 """
-    alternating_group(::Type{T} = PermGroup, n::Int)
+    alternating_group(n::Int)
 
-Return the full alternating group on the set `{1, 2, ..., n}`,
-as an instance of `T`, where `T` is in {`PermGroup`, `PcGroup`}.
+Return the full alternating group on the set `{1, 2, ..., n}`..
+
+# Examples
+```jldoctest
+julia> G = alternating_group(5)
+Alt( [ 1 .. 5 ] )
+
+julia> order(G)
+60
+
+```
 """
-alternating_group(n::Int) = alternating_group(PermGroup, n)
-
-function alternating_group(::Type{T}, n::Int) where T <: GAPGroup
+function alternating_group(n::Int)
   n >= 1 || throw(ArgumentError("n must be a positive integer"))
-  return T(GAP.Globals.AlternatingGroup(_gap_filter(T), n)::GapObj)
+  return PermGroup(GAP.Globals.AlternatingGroup(n)::GapObj)
 end
 
 """

--- a/test/Groups/constructors.jl
+++ b/test/Groups/constructors.jl
@@ -52,9 +52,9 @@
   @test !is_isomorphic_with_alternating_group(symmetric_group(4))
 
   @test is_natural_symmetric_group(symmetric_group(4))
-  @test ! is_natural_symmetric_group(symmetric_group(PcGroup,4))
+  @test ! is_natural_symmetric_group(PcGroup(symmetric_group(4)))
   @test is_isomorphic_with_symmetric_group(symmetric_group(4))
-  @test is_isomorphic_with_symmetric_group(symmetric_group(PcGroup,4))
+  @test is_isomorphic_with_symmetric_group(PcGroup(symmetric_group(4)))
   @test !is_isomorphic_with_symmetric_group(alternating_group(4))
 end
 
@@ -66,10 +66,6 @@ end
     
   @test isa(dihedral_group(6), PcGroup)
   @test isa(dihedral_group(PermGroup, 6), PermGroup)
-  
-  @test isa(alternating_group(PcGroup,3), PcGroup)
-  @test isa(symmetric_group(PcGroup,3), PcGroup)
-  @test is_isomorphic(symmetric_group(4), symmetric_group(PcGroup,4))
 
   @test is_quaternion_group(small_group(8, 4))
   @test small_group_identification(small_group(8, 4)) == (8, 4)


### PR DESCRIPTION
- improve the docstrings, add examples
- remove obscure ability to request a `PcGroup` instead of a `PermGroup`, which only worked with degrees <= 4 anyway; if one needs these groups one can easily get them via e.g. `PcGroup(alternating_group(4))` which to me is conceptually much clearer (and performance does not matter as this is only for interactive toy code anyway)