### PR TITLE
compute the Schur index via a GAP function

### DIFF
--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -1523,6 +1523,11 @@ function schur_index(chi::GAPGroupClassFunction, recurse::Bool = true)
       end
     end
 
+    if isdefined(tbl, :GAPGroup) && hasproperty(GAP.Globals, :SchurIndexByCharacter)
+      g = tbl.GAPGroup
+      return GAP.Globals.SchurIndexByCharacter(GAP.Globals.Rationals, g.X, values)
+    end
+
     # For the moment, we do not have more character theoretic criteria.
     error("cannot determine the Schur index with the currently used criteria")
 end

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -166,6 +166,7 @@ function __init__()
     GAP.Packages.load("browse"; install=true) # needed for all_character_table_names doctest
     GAP.Packages.load("ctbllib")
     GAP.Packages.load("forms")
+    GAP.Packages.load("wedderga") # provides a function to compute Schur indices
     __init_IsoGapOscar()
     __init_group_libraries()
     __init_JuliaData()

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -801,12 +801,30 @@ end
   t = character_table("2.A5")
   @test map(schur_index, collect(t)) == [1,1,1,1,1,2,2,2,2]
 
+  # Test a character table with group.
   g = small_group(192, 1022)
   h = derived_subgroup(g)[1];
   s = character_table(h);
   t = character_table(g);
   trivial_character(s)^t;  # side-effect: stores a class fusion
   @test length(names_of_fusion_sources(t)) > 0
+  if hasproperty(GAP.Globals, :SchurIndexByCharacter)
+    # We can compute the values.
+    @test sort!(map(schur_index, collect(t))) == append!(repeat([1],15), repeat([2],4))
+  else
+    # We can fail.
+    for chi in t
+      try
+        schur_index(chi)
+      catch(e)
+        msg = sprint(showerror, e)
+        @test msg == "cannot determine the Schur index with the currently used criteria"
+      end
+    end
+  end
+
+  # For a character table without group, we can fail.
+  t = character_table("S6")
   for chi in t
     try
       schur_index(chi)


### PR DESCRIPTION
GAP's wedderga package provides a function `SchurIndexByCharacter`, which works for not too large groups.