### PR TITLE
Allow coercion of group elements to new parents

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -124,6 +124,12 @@ function parent(x::GAPGroupElem)
   return x.parent
 end
 
+# coercion embeds a group element into a different parent
+function (G::GAPGroup)(x::BasicGAPGroupElem{T}) where T<:GAPGroup
+   x.X in G.X && return group_element(G, x.X)
+   throw(ArgumentError("the element does not embed in the group"))
+end
+
 """
     isfinite(G::GAPGroup) -> Bool
 

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -350,12 +350,6 @@ julia> Vector{fmpz}(pi, 2)
 Base.Vector{T}(x::PermGroupElem, n::Int = x.parent.deg) where T <: IntegerUnion = T[x(i) for i in 1:n]
 Base.Vector(x::PermGroupElem, n::Int = x.parent.deg) = Vector{Int}(x,n)
 
-#embedding of a permutation in permutation group
-function (G::PermGroup)(x::PermGroupElem)
-   x.X in G.X && return group_element(G, x.X)
-   throw(ArgumentError("the element does not embed in the group"))
-end
-
 #evaluation function
 (x::PermGroupElem)(n::IntegerUnion) = n^x
 

--- a/test/Groups/elements.jl
+++ b/test/Groups/elements.jl
@@ -73,6 +73,19 @@ end
 
     @test cperm(K,Int64[]) == one(K)
   end
+
+  for G in [
+            PermGroup(small_group(2, 1))
+            PcGroup(small_group(2, 1))
+            FPGroup(small_group(2, 1))
+            GL(2,2)
+           ]
+    H = first(subgroups(G))
+    @test parent(one(H)) === H
+    @test parent(G(one(H))) === G
+  end
+
+
 end
 
 @testset "Eltypes" begin


### PR DESCRIPTION
Previously we only implemented this for permutation groups.

Resolves #1599