### PR TITLE
Rewrite docu as template for cleaning up `orderings.jl`

### DIFF
--- a/docs/doc.main
+++ b/docs/doc.main
@@ -117,6 +117,7 @@
   "Commutative Algebra" => [
      "CommutativeAlgebra/intro.md",
      "CommutativeAlgebra/rings.md",
+     "CommutativeAlgebra/orderings.md",
      "CommutativeAlgebra/ideals.md",
      "Modules Over Multivariate Rings" => [
         "CommutativeAlgebra/ModulesOverMultivariateRings/intro.md",

--- a/docs/src/CommutativeAlgebra/ideals.md
+++ b/docs/src/CommutativeAlgebra/ideals.md
@@ -34,225 +34,6 @@ polynomials is needed.
 !!! note
     The performance of Buchberger's algorithm and the resulting Gröbner basis depend crucially on the choice of monomial ordering.
 
-
-### Monomial Orderings
-
-Given a ring $R$, we write $R[x]=R[x_1, \ldots, x_n]$ for the polynomial ring
-over $R$ in the set of variables $x=\{x_1, \ldots, x_n\}$. Monomials in
-$x=\{x_1, \ldots, x_n\}$ are written using multi--indices:
-If $\alpha=(\alpha_1, \ldots, \alpha_n)\in \N^n$, set
-$x^\alpha=x_1^{\alpha_1}\cdots x_n^{\alpha_n}$ and 
-
-$\text{Mon}_n(x) :=  \text{Mon}_n(x_1, \ldots, x_n) := \{x^\alpha \mid \alpha \in \N^n\}.$
-
-A *monomial ordering* on $\text{Mon}_n(x)$  is a total  ordering $>$ on $\text{Mon}_n(x)$ such that
-
-$x^\alpha > x^\beta \Longrightarrow x^\gamma x^\alpha > x^\gamma  x^\beta,
-\; \text{ for all }\; \alpha, \beta, \gamma \in \mathbb N^n.$
-
-A monomial ordering $>$ on $\text{Mon}_n(x)$ is called
-- *global* if $x^\alpha > 1$ for all $\alpha \not = (0, \dots, 0)$,
-- *local* if  $x^\alpha < 1$ for all $\alpha \not = (0, \dots, 0)$, and
-- *mixed* if it is neither global nor local.
-
-We then also say that $>$ is a *global* , *local*, or *mixed* *monomial ordering* on $R[x]$.
-
-!!! note
-    - A monomial ordering on $\text{Mon}_n(x)$ is global iff it is a well-ordering.
-    - To give a monomial ordering on $\text{Mon}_n(x)$ means to give a total ordering $>$ on $ \N^n$ such that
-	   $\alpha > \beta$ implies $ \gamma + \alpha > \gamma  + \beta$ for all $\alpha , \beta, \gamma \in \N^n.$
-       Rather than speaking of a monomial ordering on $\text{Mon}_n(x)$, we may, thus, also speak of a
-	   (global, local, mixed) monomial ordering on $\N^n$.
-	
-Some monomial orderings are predefined in OSCAR.
-
-#### Predefined Global Orderings
-
-##### The Lexicographical Ordering
-
-The *lexicographical ordering* `lex` is defined by setting
-
-$x^\alpha > x^\beta \;  \Leftrightarrow \;\exists \; 1 \leq i \leq n: \alpha_1 = \beta_1, \dots, \alpha_{i-1} = \beta_{i-1}, \alpha_i > \beta_i.$
-
-##### The Degree Lexicographical Ordering
-
-The *degree lexicographical ordering* `deglex` is defined by setting $\;\deg(x^\alpha) = \alpha_1 + \cdots + \alpha_n\;$ and
-
-$x^\alpha > x^\beta \;  \Leftrightarrow \;  \deg(x^\alpha) > \deg(x^\beta)  \;\text{ or }\; \exists \; 1 \leq i \leq n: \alpha_1 = \beta_1, \dots, \alpha_{i-1} = \beta_{i-1}, \alpha_i > \beta_i.$
-
-##### The Reverse Lexicographical Ordering
-
-The *reverse lexicographical ordering* `revlex` is defined by setting
-
-$x^\alpha > x^\beta \;  \Leftrightarrow \;\exists \; 1 \leq i \leq n: \alpha_n = \beta_n, \dots, \alpha_{i+1} = \beta_{i+1}, \alpha_i  > \beta_i.$
-
-
-##### The Degree Reverse Lexicographical Ordering
-
-The *degree reverse lexicographical ordering* `degrevlex` is defined by setting $\;\deg(x^\alpha) = \alpha_1 + \cdots + \alpha_n\;$ and
-
-$x^\alpha > x^\beta \;  \Leftrightarrow \; \deg(x^\alpha) > \deg(x^\beta)  \;\text{ or }\;\exists \; 1 \leq i \leq n: \alpha_n = \beta_n, \dots, \alpha_{i+1} = \beta_{i+1}, \alpha_i < \beta_i.$
-
-
-##### Weighted Lexicographical Orderings
-
-If `W` is a vector of positive integers  $w_1, \dots, w_n$, the *weighted lexicographical ordering* `wdeglex(W)`  is defined by setting
-$\;\text{wdeg}(x^\alpha) = w_1\alpha_1 + \cdots + w_n\alpha_n\;$ and
-
-$x^\alpha > x^\beta \;  \Leftrightarrow \;  \text{wdeg}(x^\alpha) > \text{wdeg}(x^\beta)  \;\text{ or }\; \exists \; 1 \leq i \leq n: \alpha_1 = \beta_1, \dots, \alpha_{i-1} = \beta_{i-1}, \alpha_i > \beta_i.$
-
-
-##### Weighted Reverse Lexicographical Orderings
-
-If `W` is a vector of positive integers  $w_1, \dots, w_n$, the *weighted reverse lexicographical ordering* `wdegrevlex(W)`  is defined by setting
-$\;\text{wdeg}(x^\alpha) = w_1\alpha_1 + \cdots + w_n\alpha_n\;$ and
-
-$x^\alpha > x^\beta \;  \Leftrightarrow \; \text{wdeg}(x^\alpha) > \text{wdeg}(x^\beta)  \;\text{ or }\;\exists \; 1 \leq i \leq n: \alpha_n = \beta_n, \dots, \alpha_{i+1} = \beta_{i+1}, \alpha_i < \beta_i.$
-
-#### Predefined Local Orderings
-
-##### The Negative Lexicographical Ordering
-
-The *negative lexicographical ordering* `neglex` is defined by setting
-
-$x^\alpha > x^\beta \;  \Leftrightarrow \;\exists \; 1 \leq i \leq n: \alpha_1 = \beta_1, \dots, \alpha_{i-1} = \beta_{i-1}, \alpha_i < \beta_i.$
-
-##### The Negative Degree Lexicographical Ordering
-
-The *negative degree lexicographical ordering* `negdeglex` is defined by setting $\;\deg(x^\alpha) = \alpha_1 + \cdots + \alpha_n\;$ and
-
-$x^\alpha > x^\beta \;  \Leftrightarrow \;  \deg(x^\alpha) < \deg(x^\beta)  \;\text{ or }\; \exists \; 1 \leq i \leq n: \alpha_1 = \beta_1, \dots, \alpha_{i-1} = \beta_{i-1}, \alpha_i > \beta_i.$
-
-##### The Negative Reverse Lexicographical Ordering
-
-The *negative reverse lexicographical ordering* `negrevlex` is defined by setting
-
-$x^\alpha > x^\beta \;  \Leftrightarrow \;\exists \; 1 \leq i \leq n: \alpha_n = \beta_n, \dots, \alpha_{i+1} = \beta_{i+1}, \alpha_i  < \beta_i.$
-
-
-##### The Negative Degree Reverse Lexicographical Ordering
-
-The *negative degree reverse lexicographical ordering* `negdegrevlex` is defined by setting $\;\deg(x^\alpha) = \alpha_1 + \cdots + \alpha_n\;$ and
-
-$x^\alpha > x^\beta \;  \Leftrightarrow \; \deg(x^\alpha) < \deg(x^\beta)  \;\text{ or }\;\exists \; 1 \leq i \leq n: \alpha_n = \beta_n, \dots, \alpha_{i+1} = \beta_{i+1}, \alpha_i < \beta_i.$
-
-
-
-##### Negative Weighted Lexicographical Orderings
-
-If `W` is a vector of positive integers  $w_1, \dots, w_n$, the *negative weighted lexicographical ordering* `negwdeglex(W)`  is defined by setting
-$\;\text{wdeg}(x^\alpha) = w_1\alpha_1 + \cdots + w_n\alpha_n\;$ and
-
-$x^\alpha > x^\beta \;  \Leftrightarrow \;  \text{wdeg}(x^\alpha) < \text{wdeg}(x^\beta)  \;\text{ or }\; \exists \; 1 \leq i \leq n: \alpha_1 = \beta_1, \dots, \alpha_{i-1} = \beta_{i-1}, \alpha_i > \beta_i.$
-
-
-##### Negative Weighted Reverse Lexicographical Orderings
-
-If `W` is a vector of positive integers  $w_1, \dots, w_n$, the *negative weighted reverse lexicographical ordering* `negwdegrevlex(W)`  is defined by setting
-$\;\text{wdeg}(x^\alpha) = w_1\alpha_1 + \cdots + w_n\alpha_n\;$ and
-
-$x^\alpha > x^\beta \;  \Leftrightarrow \; \text{wdeg}(x^\alpha) < \text{wdeg}(x^\beta)  \;\text{ or }\;\exists \; 1 \leq i \leq n: \alpha_n = \beta_n, \dots, \alpha_{i+1} = \beta_{i+1}, \alpha_i < \beta_i.$
-
-
-#### Creating Block Orderings
-
-The concept of block orderings allows one to construct new monomial orderings from already given ones: If $>_1$ and $>_2$ are monomial orderings on $\text{Mon}_s(x_1, \ldots, x_s)$ and $\text{Mon}_{n-s}(x_{s+1}, \ldots, x_n)$, respectively, then the *block ordering*
-$>=(>_1, >_2)$ on $\text{Mon}_n(x)=\text{Mon}_n(x_1, \ldots, x_n)$ is defined by setting
-          
-$x^\alpha>x^\beta  \;\Leftrightarrow\;  x_1^{\alpha_1}\cdots x_s^{\alpha_s} >_1 x_1^{\beta_1}\cdots x_s^{\beta_s} \;\text{ or }\;
-\bigl(x_1^{\alpha_1}\cdots x_s^{\alpha_s} = x_1^{\beta_1}\cdots x_s^{\beta_s} \text{ and }  x_{s+1}^{\alpha_{s+1}}\cdots x_n^{\alpha_n} >_2
-x_{s+1}^{\beta_{s+1}}\cdots x_n^{\beta_n}\bigr).$
-          
-Note that $>=(>_1, >_2)$ is global (local) iff both $>_1$ and $>_2$ are global (local). Mixed orderings arise by choosing
-one of $>_1$ and $>_2$ global and the other one local.
-		  
-#### Creating Matrix Orderings
-
-Given a matrix $M\in \text{GL}(n,\mathbb R)$, with rows $m_1,\dots,m_n$, the *matrix ordering*
-defined by $M$ is obtained by setting
-         
-$x^\alpha>_M x^\beta  \Leftrightarrow  \;\exists\; 1\leq i\leq n:  m_1\alpha=m_1\beta,\ldots, 
-m_{i-1}\alpha\ =m_{i-1}\beta,\ m_i\alpha>m_i\beta$
-
-(here, $\alpha$ and $\beta$ are regarded as column vectors).
-
-!!! note
-    By a theorem of Robbiano, every monomial ordering arises as a matrix ordering as above.
-    
-
-To create matrix orderings, OSCAR allows for matrices with integer coefficients as input matrices.
-
-#### Functions for creating orderings
-
-When computing Gröbner bases an ordering must be supplied. Standard Singular
-orderings, including block orderings, weighted orderings and local orderings
-are available.
-
-The basic orderings are `:lex`, `:revlex`, `:deglex`, `:degrevlex`,
-`:neglex`, `:negrevlex`, `:negdeglex`, `:negdegrevlex`, `:wdeglex`,
-`:wdegrevlex`, `:negwdeglex` and `:negwdegrevlex`.
-
-The orderings starting with `w` are weighted orderings.
-
-The following functions exist for creating orderings:
-
-```@docs
-lex(::AbstractVector{<:MPolyElem})
-revlex(::AbstractVector{<:MPolyElem})
-deglex(::AbstractVector{<:MPolyElem})
-degrevlex(::AbstractVector{<:MPolyElem})
-neglex(::AbstractVector{<:MPolyElem})
-negrevlex(::AbstractVector{<:MPolyElem})
-negdeglex(::AbstractVector{<:MPolyElem})
-negdegrevlex(::AbstractVector{<:MPolyElem})
-monomial_ordering(v::AbstractVector{<:MPolyElem}, s::Symbol)
-```
-
-```@docs
-wdeglex(::AbstractVector{<:MPolyElem}, ::Vector{Int})
-wdegrevlex(::AbstractVector{<:MPolyElem}, ::Vector{Int})
-negwdeglex(::AbstractVector{<:MPolyElem}, ::Vector{Int})
-negwdegrevlex(::AbstractVector{<:MPolyElem}, ::Vector{Int})
-monomial_ordering(v::AbstractVector{<:MPolyElem}, s::Symbol, w::Vector{Int})
-matrix_ordering(::AbstractVector{<:MPolyElem}, ::fmpz_mat)
-weighted_ordering(::AbstractVector{<:MPolyElem}, ::Vector{Int})
-```
-
-Block orderings can be obtained by concatening monomial orderings using the `*`
-operator. The following function can be used to convert Singular.jl orderings:
-
-```@docs
-monomial_ordering(R::MPolyRing, ord::Singular.sordering)
-```
-
-Term over position and position over term module orderings are also available.
-These are also specified byy concatenation using the `*` operator. One creates
-the requisite module ordering (`lex` or `revlex`) for the generators of the
-free module.
-
-Term over position is specified by appending the module ordering to the
-monomial ordering and position over term by prepending the module ordering.
-
-###### Examples
-
-```@repl oscar
-R, (x, y, s, t, u) = PolynomialRing(QQ, ["x", "y", "s", "t", "u"])
-O1 = degrevlex(gens(R))
-O2 = lex([x, y])*deglex([s, t, u])
-O3 = wdeglex(gens(R), [2, 3, 5, 7, 3])
-O4 = monomial_ordering(R, Singular.ordering_a([1,2,3,4,5])*Singular.ordering_rs(5))
-
-K = FreeModule(R, 3)
-O5 = revlex(gens(K))*degrevlex(gens(R))
-```
-
-## Normal Forms
-
-```@docs
-normal_form(f::T, J::MPolyIdeal) where { T <: MPolyElem }
-normal_form(A::Vector{T}, J::MPolyIdeal) where { T <: MPolyElem }
-```
-
 ### Computing Gröbner Bases
 
 ```@docs
@@ -284,14 +65,6 @@ groebner_basis_with_transformation_matrix(I::MPolyIdeal; ordering::Symbol = :deg
 f4( I::MPolyIdeal; initial_hts::Int=17, nr_thrds::Int=1, max_nr_pairs::Int=0, la_option::Int=2, reduce_gb::Int=1, info_level::Int=0)
 ```
 
-
-#### Leading Ideals
-
-```@docs
-leading_ideal(g::Vector{T}; ordering::MonomialOrdering) where { T <: MPolyElem }
-leading_ideal(I::MPolyIdeal; ordering::MonomialOrdering)
-```
-
 #### Gröbner Bases over the integers
 
 Over the integers the coefficients of the polynomials 
@@ -308,9 +81,22 @@ R, (x,y) = PolynomialRing(ZZ, ["x","y"])
 I = ideal(R, [2x,3x,4y])
 H = groebner_basis(I)
 ```
-### Syzygies
 
-#### Generators of syzygies
+### Leading Ideals
+
+```@docs
+leading_ideal(g::Vector{T}; ordering::MonomialOrdering) where { T <: MPolyElem }
+leading_ideal(I::MPolyIdeal; ordering::MonomialOrdering)
+```
+
+### Normal Forms
+
+```@docs
+normal_form(f::T, J::MPolyIdeal) where { T <: MPolyElem }
+normal_form(A::Vector{T}, J::MPolyIdeal) where { T <: MPolyElem }
+```
+
+### Syzygies
 
 ```@docs
 syzygy_generators(a::Vector{<:MPolyElem})

--- a/docs/src/CommutativeAlgebra/orderings.md
+++ b/docs/src/CommutativeAlgebra/orderings.md
@@ -1,0 +1,265 @@
+```@meta
+CurrentModule = Oscar
+```
+
+```@setup oscar
+using Oscar
+```
+
+```@contents
+Pages = ["orderings.md"]
+```
+
+# Monomial Orderings
+
+Given a coefficient ring $C$ as in the previous section, we write $C[x]=C[x_1, \ldots, x_n]$
+for the polynomial ring over $R$ in the set of variables $x=\{x_1, \ldots, x_n\}$. Monomials
+in $x=\{x_1, \ldots, x_n\}$ are written using multi--indices: If $\alpha=(\alpha_1, \ldots, \alpha_n)\in \N^n$,
+set $x^\alpha=x_1^{\alpha_1}\cdots x_n^{\alpha_n}$ and
+
+$\text{Mon}_n(x) :=  \text{Mon}(x_1, \ldots, x_n) := \{x^\alpha \mid \alpha \in \N^n\}.$
+
+A *monomial ordering* on $\text{Mon}_n(x)$ is a total  ordering $>$ on $\text{Mon}_n(x)$ such that
+
+$x^\alpha > x^\beta \Longrightarrow x^\gamma x^\alpha > x^\gamma  x^\beta,
+\; \text{ for all }\; \alpha, \beta, \gamma \in \mathbb N^n.$
+
+A monomial ordering $>$ on $\text{Mon}_n(x)$ is called
+- *global* if $x^\alpha > 1$ for all $\alpha \not = (0, \dots, 0)$,
+- *local* if  $x^\alpha < 1$ for all $\alpha \not = (0, \dots, 0)$, and
+- *mixed* if it is neither global nor local.
+
+!!! note
+    - A monomial ordering on $\text{Mon}_n(x)$ is global iff it is a well-ordering.
+    - To give a monomial ordering on $\text{Mon}_n(x)$ means to give a total ordering $>$ on $ \N^n$ such that
+	   $\alpha > \beta$ implies $ \gamma + \alpha > \gamma  + \beta$ for all $\alpha , \beta, \gamma \in \N^n.$
+       Rather than speaking of a monomial ordering on $\text{Mon}_n(x)$, we may, thus, also speak of a
+	   (global, local, mixed) monomial ordering on $\N^n$.
+	
+Some monomial orderings are predefined in OSCAR. In this section, we fix our notation with respect to  these orderings
+and illustrate their creation using several explicit examples. We then discuss block and matrix orderings.
+
+## Predefined Global Orderings
+
+#### The Lexicographical Ordering
+
+The *lexicographical ordering* `lex` is defined by setting
+
+$x^\alpha > x^\beta \;  \Leftrightarrow \;\exists \; 1 \leq i \leq n: \alpha_1 = \beta_1, \dots, \alpha_{i-1} = \beta_{i-1}, \alpha_i > \beta_i.$
+
+```@docs
+lex(V::AbstractVector{<:MPolyElem})
+```
+
+#### The Degree Lexicographical Ordering
+
+The *degree lexicographical ordering* `deglex` is defined by setting $\;\deg(x^\alpha) = \alpha_1 + \cdots + \alpha_n\;$ and
+
+$x^\alpha > x^\beta \;  \Leftrightarrow \;  \deg(x^\alpha) > \deg(x^\beta)  \;\text{ or }\; \exists \; 1 \leq i \leq n: \alpha_1 = \beta_1, \dots, \alpha_{i-1} = \beta_{i-1}, \alpha_i > \beta_i.$
+
+```@docs
+deglex(V::AbstractVector{<:MPolyElem})
+```
+
+#### The Reverse Lexicographical Ordering
+
+The *reverse lexicographical ordering* `revlex` is defined by setting
+
+$x^\alpha > x^\beta \;  \Leftrightarrow \;\exists \; 1 \leq i \leq n: \alpha_n = \beta_n, \dots, \alpha_{i+1} = \beta_{i+1}, \alpha_i  > \beta_i.$
+
+```@docs
+revlex(V::AbstractVector{<:MPolyElem})
+```
+
+#### The Degree Reverse Lexicographical Ordering
+
+The *degree reverse lexicographical ordering* `degrevlex` is defined by setting $\;\deg(x^\alpha) = \alpha_1 + \cdots + \alpha_n\;$ and
+
+$x^\alpha > x^\beta \;  \Leftrightarrow \; \deg(x^\alpha) > \deg(x^\beta)  \;\text{ or }\;\exists \; 1 \leq i \leq n: \alpha_n = \beta_n, \dots, \alpha_{i+1} = \beta_{i+1}, \alpha_i < \beta_i.$
+
+```@docs
+degrevlex(V::AbstractVector{<:MPolyElem})
+```
+
+#### Weighted Lexicographical Orderings
+
+If `W` is a vector of positive integers  $w_1, \dots, w_n$, the corresponding *weighted lexicographical ordering*
+`wdeglex(W)`  is defined by setting $\;\text{wdeg}(x^\alpha) = w_1\alpha_1 + \cdots + w_n\alpha_n\;$ and
+
+$x^\alpha > x^\beta \;  \Leftrightarrow \;  \text{wdeg}(x^\alpha) > \text{wdeg}(x^\beta)  \;\text{ or }\;\\
+(\text{wdeg}(x^\alpha) = \text{wdeg}(x^\beta)  \;\text{ and }\; \exists \; 1 \leq i \leq n: \alpha_1 = \beta_1, \dots, \alpha_{i-1} = \beta_{i-1}, \alpha_i > \beta_i).$
+
+```@docs
+wdeglex(V::AbstractVector{<:MPolyElem}, W::Vector{Int})
+```
+
+#### Weighted Reverse Lexicographical Orderings
+
+If `W` is a vector of positive integers  $w_1, \dots, w_n$, the corresponding *weighted reverse lexicographical ordering*
+`wdegrevlex`  is defined by setting $\;\text{wdeg}(x^\alpha) = w_1\alpha_1 + \cdots + w_n\alpha_n\;$ and
+
+$x^\alpha > x^\beta \;  \Leftrightarrow \; \text{wdeg}(x^\alpha) > \text{wdeg}(x^\beta)  \;\text{ or }\;\\
+(\text{wdeg}(x^\alpha) = \text{wdeg}(x^\beta)  \;\text{ and }\; \exists \; 1 \leq i \leq n: \alpha_n = \beta_n, \dots, \alpha_{i+1} = \beta_{i+1}, \alpha_i < \beta_i).$
+
+```@docs
+wdegrevlex(V::AbstractVector{<:MPolyElem}, W::Vector{Int})
+```
+
+## Predefined Local Orderings
+
+#### The Negative Lexicographical Ordering
+
+The *negative lexicographical ordering* `neglex` is defined by setting
+
+$x^\alpha > x^\beta \;  \Leftrightarrow \;\exists \; 1 \leq i \leq n: \alpha_1 = \beta_1, \dots, \alpha_{i-1} = \beta_{i-1}, \alpha_i < \beta_i.$
+
+```@docs
+neglex(V::AbstractVector{<:MPolyElem})
+```
+
+#### The Negative Degree Lexicographical Ordering
+
+The *negative degree lexicographical ordering* `negdeglex` is defined by setting $\;\deg(x^\alpha) = \alpha_1 + \cdots + \alpha_n\;$ and
+
+$x^\alpha > x^\beta \;  \Leftrightarrow \;  \deg(x^\alpha) < \deg(x^\beta)  \;\text{ or }\; \exists \; 1 \leq i \leq n: \alpha_1 = \beta_1, \dots, \alpha_{i-1} = \beta_{i-1}, \alpha_i > \beta_i.$
+
+```@docs
+negdeglex(V::AbstractVector{<:MPolyElem})
+```
+
+#### The Negative Reverse Lexicographical Ordering
+
+The *negative reverse lexicographical ordering* `negrevlex` is defined by setting
+
+$x^\alpha > x^\beta \;  \Leftrightarrow \;\exists \; 1 \leq i \leq n: \alpha_n = \beta_n, \dots, \alpha_{i+1} = \beta_{i+1}, \alpha_i  < \beta_i.$
+
+```@docs
+negrevlex(V::AbstractVector{<:MPolyElem})
+```
+
+#### The Negative Degree Reverse Lexicographical Ordering
+
+The *negative degree reverse lexicographical ordering* `negdegrevlex` is defined by setting $\;\deg(x^\alpha) = \alpha_1 + \cdots + \alpha_n\;$ and
+
+$x^\alpha > x^\beta \;  \Leftrightarrow \; \deg(x^\alpha) < \deg(x^\beta)  \;\text{ or }\;\exists \; 1 \leq i \leq n: \alpha_n = \beta_n, \dots, \alpha_{i+1} = \beta_{i+1}, \alpha_i < \beta_i.$
+
+```@docs
+negdegrevlex(V::AbstractVector{<:MPolyElem})
+```
+
+#### Negative Weighted Lexicographical Orderings
+
+If `W` is a vector of positive integers  $w_1, \dots, w_n$, the corresponding *negative weighted lexicographical ordering*
+`negwdeglex(W)`  is defined by setting $\;\text{wdeg}(x^\alpha) = w_1\alpha_1 + \cdots + w_n\alpha_n\;$ and
+
+$x^\alpha > x^\beta \;  \Leftrightarrow \;  \text{wdeg}(x^\alpha) < \text{wdeg}(x^\beta)  \;\text{ or }\;\\
+(\text{wdeg}(x^\alpha) = \text{wdeg}(x^\beta)  \;\text{ and }\; \exists \; 1 \leq i \leq n: \alpha_1 = \beta_1, \dots, \alpha_{i-1} = \beta_{i-1}, \alpha_i > \beta_i).$
+
+```@docs
+negwdeglex(V::AbstractVector{<:MPolyElem}, W::Vector{Int})
+```
+
+#### Negative Weighted Reverse Lexicographical Orderings
+
+If `W` is a vector of positive integers  $w_1, \dots, w_n$, the corresponding *negative weighted reverse lexicographical ordering*
+`negwdegrevlex(W)`  is defined by setting $\;\text{wdeg}(x^\alpha) = w_1\alpha_1 + \cdots + w_n\alpha_n\;$ and
+
+$x^\alpha > x^\beta \;  \Leftrightarrow \; \text{wdeg}(x^\alpha) < \text{wdeg}(x^\beta)  \;\text{ or }\;\\
+(\text{wdeg}(x^\alpha) = \text{wdeg}(x^\beta)  \;\text{ and }\; \exists \; 1 \leq i \leq n: \alpha_n = \beta_n, \dots, \alpha_{i+1} = \beta_{i+1}, \alpha_i < \beta_i).$
+
+```@docs
+negwdegrevlex(V::AbstractVector{<:MPolyElem}, W::Vector{Int})
+```
+
+## Block Orderings
+
+The concept of block orderings allows one to construct new monomial orderings from already given ones: If $>_1$ and $>_2$ are monomial orderings on $\text{Mon}_s(x_1, \ldots, x_s)$ and $\text{Mon}_{n-s}(x_{s+1}, \ldots, x_n)$, respectively, then the *block ordering*
+$>=(>_1, >_2)$ on $\text{Mon}_n(x)=\text{Mon}_n(x_1, \ldots, x_n)$ is defined by setting
+          
+$x^\alpha>x^\beta  \;\Leftrightarrow\;  x_1^{\alpha_1}\cdots x_s^{\alpha_s} >_1 x_1^{\beta_1}\cdots x_s^{\beta_s} \;\text{ or }\;
+\bigl(x_1^{\alpha_1}\cdots x_s^{\alpha_s} = x_1^{\beta_1}\cdots x_s^{\beta_s} \text{ and }  x_{s+1}^{\alpha_{s+1}}\cdots x_n^{\alpha_n} >_2
+x_{s+1}^{\beta_{s+1}}\cdots x_n^{\beta_n}\bigr).$
+          
+Note that $>=(>_1, >_2)$ is global (local) iff both $>_1$ and $>_2$ are global (local). Mixed orderings arise by choosing
+one of $>_1$ and $>_2$ global and the other one local.
+
+In Oscar, block orderings are obtained by the concatination of individually given orderings using the `*` operator.
+
+##### Examples
+
+```@repl oscar
+R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+o = degrevlex([w, x])*degrevlex([y, z])
+```
+
+## Matrix Orderings
+
+Given a matrix $M\in \text{Mat}(k\times n,\mathbb R)$ of rank $n$, with rows $m_1,\dots,m_k$,
+the *matrix ordering* defined by $M$ is obtained by setting
+         
+$x^\alpha>_M x^\beta  \Leftrightarrow  \;\exists\; 1\leq i\leq k:  m_1\alpha=m_1\beta,\ldots, 
+m_{i-1}\alpha\ =m_{i-1}\beta,\ m_i\alpha>m_i\beta$
+
+(here, $\alpha$ and $\beta$ are regarded as column vectors).
+
+!!! note
+    By a theorem of Robbiano, every monomial ordering arises as a matrix ordering as above with $M\in \text{GL}(n,\mathbb R)$.
+    
+To create matrix orderings, OSCAR allows for matrices with integer coefficients as input matrices.
+
+```@docs
+matrix_ordering(V::AbstractVector{<:MPolyElem}, M::Union{Matrix{T}, MatElem{T}}) where T
+```
+
+```@julia
+matrix(ord::MonomialOrdering)
+```
+
+Return an invertible matrix such that the matrix ordering defined by this matrix is equal to the given ordering `ord`.
+
+##### Example
+
+```@julia
+R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+o = degrevlex(R)
+matrix(o)
+```
+
+## Weight Orderings
+
+If $W$ is a vector of integers  $w_1, \dots, w_n$, and $>$ is a monomial ordering on $\text{Mon}_n(x)$,
+the corresponding *weight ordering* is defined by setting $\;\text{wdeg}(x^\alpha) = w_1\alpha_1 + \cdots + w_n\alpha_n\;$ and
+
+$x^\alpha >_{W} x^\beta \;  \Leftrightarrow \; \text{wdeg}(x^\alpha) > \text{wdeg}(x^\beta)  \;\text{ or }\;
+(\text{wdeg}(x^\alpha) = \text{wdeg}(x^\beta)  \;\text{ and }\; x^\alpha > x^\beta).$
+
+
+```@julia
+weight_ordering(W::Vector{Int}, ord::MonomialOrdering)
+```
+
+```@julia
+R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"]);
+W = [1, 0, -1];
+o = degrevlex(R)
+matrix(o)
+oW = weight_ordering(W, o)
+matrix(oW)
+```
+
+## Tests on Monomial Orderings
+
+```@docs
+is_global(ord::MonomialOrdering)
+```
+
+```@docs
+is_local(ord::MonomialOrdering)
+```
+
+```@docs
+is_mixed(ord::MonomialOrdering)
+```
+
+
+

--- a/docs/src/NoncommutativeAlgebra/PBWAlgebras/quotients.md
+++ b/docs/src/NoncommutativeAlgebra/PBWAlgebras/quotients.md
@@ -15,6 +15,10 @@ Pages = ["quotients.md"]
 In analogy to the affine algebras section in the commutative algebra chapter, we describe OSCAR
 functionality for dealing with quotients of PBW-algebras modulo two-sided ideals.
 
+!!! note
+    Quotients of PBW-algebras modulo two-sided ideals are also known as *GR-algebras* (here, *GR*
+    stands for *Gröbner-Ready*; see [Lev05](@cite)).
+
 **Example.** ``\;`` The *$n$-th exterior algebra over $K$* is the quotient of the PBW-algebra
 
 $A=K \langle e_1,\dots, e_n \mid e_ie_j = - e_je_i \ \text { for }\ i\neq j\rangle$

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -576,13 +576,13 @@ julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
 (Multivariate Polynomial Ring in w, x, y, z over Rational Field, fmpq_mpoly[w, x, y, z])
 
 julia> o1 = negdeglex([w, x])
-negdegrevlex([w, x])
+negdeglex([w, x])
 
 julia> o2 = negdeglex(gens(R)[3:4])
-negdegrevlex([y, z])
+negdeglex([y, z])
 
 julia> o3 = negdeglex(R)
-negdegrevlex([w, x, y, z])
+negdeglex([w, x, y, z])
 ```
 """
 function negdeglex(v::AbstractVector{<:MPolyElem})
@@ -805,7 +805,7 @@ negwdeglex([w, x], [1, 2])
 julia> o2 = negwdeglex(gens(R)[3:4], [3, 4])
 negwdeglex([y, z], [3, 4])
 
-julia> o3 = newwdeglex(R, [1, 2, 3, 4])
+julia> o3 = negwdeglex(R, [1, 2, 3, 4])
 negwdeglex([w, x, y, z], [1, 2, 3, 4])
 ```
 """

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -133,10 +133,28 @@ end
 #### lex ####
 
 @doc Markdown.doc"""
-    lex(v::AbstractVector{<:MPolyElem}) -> MonomialOrdering
+    lex(V::AbstractVector{<:MPolyElem}) -> MonomialOrdering
+
+Given a vector `V` of variables, return the lexicographical ordering on the set of monomials in these variables.
+
     lex(R::MPolyRing) -> MonomialOrdering
 
-Defines the `lex` (lexicographic) ordering on the variables given.
+Return the lexicographical ordering on the set of monomials in the variables of `R`.
+
+# Examples
+```jldoctest
+julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+(Multivariate Polynomial Ring in w, x, y, z over Rational Field, fmpq_mpoly[w, x, y, z])
+
+julia> o1 = lex([w, x])
+lex([w, x])
+
+julia> o2 = lex(gens(R)[3:4])
+lex([y, z])
+
+julia> o3 = lex(R)
+lex([w, x, y, z])
+```
 """
 function lex(v::AbstractVector{<:MPolyElem})
   i = _unique_var_indices(v)
@@ -173,10 +191,28 @@ end
 #### deglex ####
 
 @doc Markdown.doc"""
-    deglex(v::AbstractVector{<:MPolyElem}) -> MonomialOrdering
+    deglex(V::AbstractVector{<:MPolyElem}) -> MonomialOrdering
+    
+Given a vector `V` of variables, return the degree lexicographical ordering on the set of monomials in these variables.
+
     deglex(R::MPolyRing) -> MonomialOrdering
 
-Defines the `deglex` ordering on the variables given.
+Return the degree lexicographical ordering on the set of monomials in the variables of `R`.
+
+# Examples
+```jldoctest
+julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+(Multivariate Polynomial Ring in w, x, y, z over Rational Field, fmpq_mpoly[w, x, y, z])
+
+julia> o1 = deglex([w, x])
+deglex([w, x])
+
+julia> o2 = deglex(gens(R)[3:4])
+deglex([y, z])
+
+julia> o3 = deglex(R)
+deglex([w, x, y, z])
+```
 """
 function deglex(v::AbstractVector{<:MPolyElem})
   i = _unique_var_indices(v)
@@ -221,10 +257,27 @@ end
 #### degrevlex ####
 
 @doc Markdown.doc"""
-    degrevlex(v::AbstractVector{<:MPolyElem}) -> MonomialOrdering
+    degrevlex(V::AbstractVector{<:MPolyElem}) -> MonomialOrdering
+
+Given a vector `V` of variables, return the degree reverse lexicographical ordering on the set of monomials in these variables
     degrevlex(R::MPolyRing) -> MonomialOrdering
 
-Defines the `degrevlex` ordering on the variables given.
+Return the degree reverse lexicographical ordering on the set of monomials in the variables of `R`.
+
+# Examples
+```jldoctest
+julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+(Multivariate Polynomial Ring in w, x, y, z over Rational Field, fmpq_mpoly[w, x, y, z])
+
+julia> o1 = degrevlex([w, x])
+degrevlex([w, x])
+
+julia> o2 = degrevlex(gens(R)[3:4])
+degrevlex([y, z])
+
+julia> o3 = degrevlex(R)
+degrevlex([w, x, y, z])
+```
 """
 function degrevlex(v::AbstractVector{<:MPolyElem})
   i = _unique_var_indices(v)
@@ -269,10 +322,28 @@ end
 #### revlex ####
 
 @doc Markdown.doc"""
-    revlex(v::AbstractVector{<:MPolyElem}) -> MonomialOrdering
+    revlex(V::AbstractVector{<:MPolyElem}) -> MonomialOrdering
+
+Given a vector `V` of variables, return the reverse lexicographical ordering on the set of monomials in these variables.
+
     revlex(R::MPolyRing) -> MonomialOrdering
 
-Defines the `revlex` ordering on the variables given.
+Return the reverse lexicographical ordering on the set of monomials in the variables of `R`.
+
+# Examples
+```jldoctest
+julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+(Multivariate Polynomial Ring in w, x, y, z over Rational Field, fmpq_mpoly[w, x, y, z])
+
+julia> o1 = revlex([w, x])
+revlex([w, x])
+
+julia> o2 = revlex(gens(R)[3:4])
+revlex([y, z])
+
+julia> o3 = revlex(R)
+revlex([w, x, y, z])
+```
 """
 function revlex(v::AbstractVector{<:MPolyElem})
   i = _unique_var_indices(v)
@@ -309,10 +380,28 @@ end
 #### neglex ####
 
 @doc Markdown.doc"""
-    neglex(v::AbstractVector{<:MPolyElem}) -> MonomialOrdering
+    neglex(V::AbstractVector{<:MPolyElem}) -> MonomialOrdering
+
+Given a vector `V` of variables, return the negative lexicographical ordering on the set of monomials in these variables.
+
     neglex(R::MPolyRing) -> MonomialOrdering
 
-Defines the `neglex` ordering on the variables given.
+Return the negative lexicographical ordering on the set of monomials in the variables of `R`.
+
+# Examples
+```jldoctest
+julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+(Multivariate Polynomial Ring in w, x, y, z over Rational Field, fmpq_mpoly[w, x, y, z])
+
+julia> o1 = neglex([w, x])
+neglex([w, x])
+
+julia> o2 = neglex(gens(R)[3:4])
+neglex([y, z])
+
+julia> o3 = neglex(R)
+neglex([w, x, y, z])
+```
 """
 function neglex(v::AbstractVector{<:MPolyElem})
   i = _unique_var_indices(v)
@@ -349,10 +438,28 @@ end
 #### negrevlex ####
 
 @doc Markdown.doc"""
-    negrevlex(v::AbstractVector{<:MPolyElem}) -> MonomialOrdering
+    negrevlex(V::AbstractVector{<:MPolyElem}) -> MonomialOrdering
+
+Given a vector `V` of variables, return the negative reverse lexicographical ordering on the set of monomials in these variables.
+
     negrevlex(R::MPolyRing) -> MonomialOrdering
 
-Defines the `negrevlex` ordering on the variables given.
+Return the negative reverse lexicographical ordering  on the set of monomials in the variables of `R`.
+
+# Examples
+```jldoctest
+julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+(Multivariate Polynomial Ring in w, x, y, z over Rational Field, fmpq_mpoly[w, x, y, z])
+
+julia> o1 = negrevlex([w, x])
+negrevlex([w, x])
+
+julia> o2 = negrevlex(gens(R)[3:4])
+negrevlex([y, z])
+
+julia> o3 = negrevlex(R)
+negrevlex([w, x, y, z])
+```
 """
 function negrevlex(v::AbstractVector{<:MPolyElem})
   i = _unique_var_indices(v)
@@ -389,10 +496,28 @@ end
 #### negdegrevlex ####
 
 @doc Markdown.doc"""
-    negdegrevlex(v::AbstractVector{<:MPolyElem}) -> MonomialOrdering
+    negdegrevlex(V::AbstractVector{<:MPolyElem}) -> MonomialOrdering
+
+Given a vector `V` of variables, return the negative degree reverse lexicographical ordering on the set of monomials in these variables.
+
     negdegrevlex(R::MPolyRing) -> MonomialOrdering
 
-Defines the `negdegrevlex` ordering on the variables given.
+Return the negative degree reverse lexicographical ordering on the set of monomials in the variables of `R`.
+
+# Examples
+```jldoctest
+julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+(Multivariate Polynomial Ring in w, x, y, z over Rational Field, fmpq_mpoly[w, x, y, z])
+
+julia> o1 = negdegrevlex([w, x])
+negdegrevlex([w, x])
+
+julia> o2 = negdegrevlex(gens(R)[3:4])
+negdegrevlex([y, z])
+
+julia> o3 = negdegrevlex(R)
+negdegrevlex([w, x, y, z])
+```
 """
 function negdegrevlex(v::AbstractVector{<:MPolyElem})
   i = _unique_var_indices(v)
@@ -437,10 +562,28 @@ end
 #### negdeglex ####
 
 @doc Markdown.doc"""
-    negdeglex(v::AbstractVector{<:MPolyElem}) -> MonomialOrdering
+    negdeglex(V::AbstractVector{<:MPolyElem}) -> MonomialOrdering    
+
+Given a vector `V` of variables, return the negative degree lexicographical ordering on the set of monomials in these variables.
+
     negdeglex(R::MPolyRing) -> MonomialOrdering
 
-Defines the `negdeglex` ordering on the variables given.
+Return the negative degree lexicographical ordering on the set of monomials in the variables of `R`.
+
+# Examples
+```jldoctest
+julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+(Multivariate Polynomial Ring in w, x, y, z over Rational Field, fmpq_mpoly[w, x, y, z])
+
+julia> o1 = negdeglex([w, x])
+negdegrevlex([w, x])
+
+julia> o2 = negdeglex(gens(R)[3:4])
+negdegrevlex([y, z])
+
+julia> o3 = negdeglex(R)
+negdegrevlex([w, x, y, z])
+```
 """
 function negdeglex(v::AbstractVector{<:MPolyElem})
   i = _unique_var_indices(v)
@@ -515,10 +658,30 @@ end
 #### wdeglex, Wp ####
 
 @doc Markdown.doc"""
-    wdeglex(v::AbstractVector{<:MPolyElem}, w::Vector{Int}) -> MonomialOrdering
-    wdeglex(R, w::Vector{Int}) -> MonomialOrdering
+    wdeglex(V::AbstractVector{<:MPolyElem}, W::Vector{Int}) -> MonomialOrdering
+    
+Given a vector `V` of variables and a vector `W` of positive integers, return the corresponding weighted 
+lexicographical ordering on the set of monomials in the given variables.
 
-Defines the `wdeglex` ordering on the variables given with the weights `w`.
+    wdeglex(R, W::Vector{Int}) -> MonomialOrdering
+
+If `W` is a vector of positive integers, return the corresponding weighted 
+lexicographical ordering on the set of monomials in the variables of `R`.
+
+# Examples
+```jldoctest
+julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+(Multivariate Polynomial Ring in w, x, y, z over Rational Field, fmpq_mpoly[w, x, y, z])
+
+julia> o1 = wdeglex([w, x], [1, 2])
+wdeglex([w, x], [1, 2])
+
+julia> o2 = wdeglex(gens(R)[3:4], [3, 4])
+wdeglex([y, z], [3, 4])
+
+julia> o3 = wdeglex(R, [1, 2, 3, 4])
+wdeglex([w, x, y, z], [1, 2, 3, 4])
+```
 """
 function wdeglex(v::AbstractVector{<:MPolyElem}, w::Vector{Int})
   i = _unique_var_indices(v)
@@ -558,10 +721,30 @@ end
 #### wdegrevlex, wp ####
 
 @doc Markdown.doc"""
-    wdegrevlex(v::AbstractVector{<:MPolyElem}, w::Vector{Int}) -> MonomialOrdering
-    wdegrevlex(R::MPolyRing, w::Vector{Int}) -> MonomialOrdering
+    wdegrevlex(V::AbstractVector{<:MPolyElem}, W::Vector{Int}) -> MonomialOrdering
 
-Defines the `wdegrevlex` ordering on the variables given with the weights `w`.
+Given a vector `V` of variables and a vector `W` of positive integers, return the corresponding weighted reverse 
+lexicographical ordering on the set of monomials in the given variables.
+
+    wdegrevlex(R::MPolyRing, W::Vector{Int}) -> MonomialOrdering
+
+If `W` is a vector of positive integers, return the corresponding weighted reverse 
+lexicographical ordering on the set of monomials in the variables of `R`.
+
+# Examples
+```jldoctest
+julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+(Multivariate Polynomial Ring in w, x, y, z over Rational Field, fmpq_mpoly[w, x, y, z])
+
+julia> o1 = wdegrevlex([w, x], [1, 2])
+wdegrevlex([w, x], [1, 2])
+
+julia> o2 = wdegrevlex(gens(R)[3:4], [3, 4])
+wdegrevlex([y, z], [3, 4])
+
+julia> o3 = wdegrevlex(R, [1, 2, 3, 4])
+wdegrevlex([w, x, y, z], [1, 2, 3, 4])
+```
 """
 function wdegrevlex(v::AbstractVector{<:MPolyElem}, w::Vector{Int})
   i = _unique_var_indices(v)
@@ -601,10 +784,30 @@ end
 #### negwdeglex, Ws ####
 
 @doc Markdown.doc"""
-    negwdeglex(v::AbstractVector{<:MPolyElem}, w::Vector{Int}) -> MonomialOrdering
-    negwdeglex(R::MPolyRing, w::Vector{Int}) -> MonomialOrdering
+    negwdeglex(V::AbstractVector{<:MPolyElem}, W::Vector{Int}) -> MonomialOrdering
+    
+Given a vector `V` of variables and a vector `W` of positive integers, return the corresponding
+negative weighted lexicographical ordering on the set of monomials in the given variables.
 
-Defines the `negwdeglex` ordering on the variables given with the weights `w`.
+    negwdeglex(R::MPolyRing, W::Vector{Int}) -> MonomialOrdering
+
+If `W` is a vector of positive integers, return the corresponding negative weighted 
+lexicographical ordering on the set of monomials in the variables of `R`.
+
+# Examples
+```jldoctest
+julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+(Multivariate Polynomial Ring in w, x, y, z over Rational Field, fmpq_mpoly[w, x, y, z])
+
+julia> o1 = negwdeglex([w, x], [1, 2])
+negwdeglex([w, x], [1, 2])
+
+julia> o2 = negwdeglex(gens(R)[3:4], [3, 4])
+negwdeglex([y, z], [3, 4])
+
+julia> o3 = newwdeglex(R, [1, 2, 3, 4])
+negwdeglex([w, x, y, z], [1, 2, 3, 4])
+```
 """
 function negwdeglex(v::AbstractVector{<:MPolyElem}, w::Vector{Int})
   i = _unique_var_indices(v)
@@ -645,9 +848,29 @@ end
 
 @doc Markdown.doc"""
     negwdegrevlex(v::AbstractVector{<:MPolyElem}, w::Vector{Int}) -> MonomialOrdering
+    
+Given a vector `V` of variables and a vector `W` of positive integers, return the corresponding negative
+weighted reverse lexicographical ordering on the set of monomials in the given variables.
+
     negwdegrevlex(R::MPolyRing, w::Vector{Int}) -> MonomialOrdering
 
-Defines the `negwdegrevlex` ordering on the variables given with the weights `w`.
+If `W` is a vector of positive integers, return the corresponding negative weighted
+reverse lexicographical ordering on the set of monomials in the variables of `R`.
+
+# Examples
+```jldoctest
+julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+(Multivariate Polynomial Ring in w, x, y, z over Rational Field, fmpq_mpoly[w, x, y, z])
+
+julia> o1 = negwdegrevlex([w, x], [1, 2])
+negwdegrevlex([w, x], [1, 2])
+
+julia> o2 = negwdegrevlex(gens(R)[3:4], [3, 4])
+negwdegrevlex([y, z], [3, 4])
+
+julia> o3 = negwdegrevlex(R, [1, 2, 3, 4])
+negwdegrevlex([w, x, y, z], [1, 2, 3, 4])
+```
 """
 function negwdegrevlex(v::AbstractVector{<:MPolyElem}, w::Vector{Int})
   i = _unique_var_indices(v)
@@ -687,12 +910,35 @@ end
 #### matrix, M ####
 
 @doc Markdown.doc"""
-    matrix_ordering(v::AbstractVector{<:MPolyElem}, M::Union{Matrix{T}, MatElem{T}}) -> MonomialOrdering
+    matrix_ordering(V::AbstractVector{<:MPolyElem}, M::Union{Matrix{T}, MatElem{T}}) where T -> MonomialOrdering
+
+Given a vector `V` of variables and an integer matrix `M` such that `length(V) = ncols(M) = rank(M)`, 
+return the corresponding matrix ordering on the set of monomials in the given variables. 
+
     matrix_ordering(R::MPolyRing, M::Union{Matrix{T}, MatElem{T}}) -> MonomialOrdering
 
-Defines the matrix ordering on the variables given with the matrix `M`. The
-matrix need not be square nor have full row rank, thus the resulting ordering
-may be only a partial ordering on the given variables.
+Given an integer matrix `M` such that `nvars(R) = ncols(M) = rank(M)`, 
+return the matrix ordering on the set of variables of `R` which is defined by `M`.
+
+!!! note
+    The matrix `M` need not be square.
+
+# Examples
+```jldoctest
+julia> R, (x,y,z) = QQ["x", "y", "z"];
+
+julia> M =[1 1 1; 0 0 -1; 0 -1 0]
+3×3 Matrix{Int64}:
+ 1   1   1
+ 0   0  -1
+ 0  -1   0
+
+julia> o = matrix_ordering(R, M)
+matrix_ordering([x, y, z], [1 1 1; 0 0 -1; 0 -1 0])
+
+julia> o == degrevlex(R)
+true
+```
 """
 function matrix_ordering(v::AbstractVector{<:MPolyElem}, M::Union{Matrix{T}, MatElem{T}}) where T
   i = _unique_var_indices(v)
@@ -843,10 +1089,22 @@ function _global_and_local_vars(M::MonomialOrdering)
 end
 
 @doc Markdown.doc"""
-    is_global(M::MonomialOrdering)
+    is_global(ord::MonomialOrdering)
 
-Return `true` if the given ordering is global, i.e. if $1 < x$ for
-each variable $x$ in the ring `M.R` for which `M` is defined.
+Return `true` if `ord` is global, `false` otherwise.
+
+# Examples
+```jldoctest
+julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"]);
+
+julia> M = [1 1; 0 -1];
+
+julia> o = matrix_ordering(R, M)
+matrix_ordering([x, y], [1 1; 0 -1])
+
+julia> is_global(o)
+true
+```
 """
 function is_global(M::MonomialOrdering)
   globals, locals = _global_and_local_vars(M)
@@ -854,10 +1112,22 @@ function is_global(M::MonomialOrdering)
 end
 
 @doc Markdown.doc"""
-    is_local(M::MonomialOrdering)
+    is_local(ord::MonomialOrdering)
 
-Return `true` if the given ordering is local, i.e. if $1 > x$ for
-each variable $x$ in the ring `M.R` for which `M` is defined.
+Return `true` if `ord` is local, `false` otherwise.
+
+# Examples
+```jldoctest
+julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"]);
+
+julia> M = [-1 -1; 0 -1];
+
+julia> o = matrix_ordering(R, M)
+matrix_ordering([x, y], [-1 -1; 0 -1])
+
+julia> is_local(o)
+true
+```
 """
 function is_local(M::MonomialOrdering)
   globals, locals = _global_and_local_vars(M)
@@ -865,11 +1135,22 @@ function is_local(M::MonomialOrdering)
 end
 
 @doc Markdown.doc"""
-    is_mixed(M::MonomialOrdering)
+    is_mixed(ord::MonomialOrdering)
 
-Return `true` if the given ordering is mixed, i.e. if $1 < x_i$ for
-a variable $x_i$ and $1 > x_j$ for another variable $x_j$ in the ring `M.R`
-for which `M` is defined.
+Return `true` if `ord` is mixed, `false` otherwise. 
+
+# Examples
+```jldoctest
+julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"]);
+
+julia> M = [1 -1; 0 -1];
+
+julia> o = matrix_ordering(R, M)
+matrix_ordering([x, y], [1 -1; 0 -1])
+
+julia> is_mixed(o)
+true
+```
 """
 function is_mixed(M::MonomialOrdering)
   globals, locals = _global_and_local_vars(M)

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -847,12 +847,12 @@ end
 #### negwdegrevlex, ws ####
 
 @doc Markdown.doc"""
-    negwdegrevlex(v::AbstractVector{<:MPolyElem}, w::Vector{Int}) -> MonomialOrdering
+    negwdegrevlex(V::AbstractVector{<:MPolyElem}, W::Vector{Int}) -> MonomialOrdering
     
 Given a vector `V` of variables and a vector `W` of positive integers, return the corresponding negative
 weighted reverse lexicographical ordering on the set of monomials in the given variables.
 
-    negwdegrevlex(R::MPolyRing, w::Vector{Int}) -> MonomialOrdering
+    negwdegrevlex(R::MPolyRing, W::Vector{Int}) -> MonomialOrdering
 
 If `W` is a vector of positive integers, return the corresponding negative weighted
 reverse lexicographical ordering on the set of monomials in the variables of `R`.


### PR DESCRIPTION
@tthsqe12 Please:
- `wdeglex`, `wdegrevlex`, `negwdeglex`, `negwdegrevlex`: Assert entries of `W` are positive.
- `matrix_ordering(V::AbstractVector{<:MPolyElem}, M::Union{Matrix{T}, MatElem{T}})`, `matrix_ordering(R::MPolyRing, M::Union{Matrix{T}, MatElem{T}})`: Assert matrix has rank `ncols(M)` which in turn must agree with `length(V)` and `nvars(R)`, respectively.
- Introduce a function `matrix(ord::MonomialOrdering)` as described in the docu. I believe, this is what `canonical_weight_matrix(M::MonomialOrdering)` does.
- Introduce a function `weight_ordering(W::Vector{Int}, ord::MonomialOrdering)` as described in the docu. Replace the old function `weight_ordering` by the new one.
- Adjust `is_global`, `is_local`, `is_mixed` as discussed.
