### PR TITLE
CI: update to v3 of actions/checkout

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,7 @@ jobs:
             os: macOS-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # For Codecov, we must also fetch the parent of the HEAD commit to
           # be able to properly deal with PRs / merges

--- a/.github/workflows/Docu.yml
+++ b/.github/workflows/Docu.yml
@@ -19,7 +19,7 @@ jobs:
     #runs-on: self-hosted
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.6'


### PR DESCRIPTION
This silences warnings in the actions web interface:

> Node.js 12 actions are deprecated. For more information see:
> https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
> Please update the following actions to use Node.js 16: actions/checkout, actions/checkout
