### PR TITLE
Use the coefficient map in `_check_imgs_quo`

### DIFF
--- a/src/Rings/MPolyMap/MPolyQuo.jl
+++ b/src/Rings/MPolyMap/MPolyQuo.jl
@@ -4,23 +4,31 @@
 #
 ################################################################################
 
-function _check_imgs_quo(R, S::NCRing, imgs)
+function _check_imgs_quo(R, S::NCRing, imgs, coeff_map = nothing)
   n = length(imgs)
   for i in 1:n, j in 1:(i - 1)
     @req imgs[i] * imgs[j] == imgs[j] * imgs[i] "Images $i and $j do not commute"
   end
   gensI = gens(modulus(R))
   for g in gensI
-    @req iszero(evaluate(g, imgs)) "Morphism is not well-defined"
+    if coeff_map !== nothing
+      @req is_zero(evaluate(map_coefficients(coeff_map, g), imgs)) "Morphism is not well-defined"
+    else
+      @req iszero(evaluate(g, imgs)) "Morphism is not well-defined"
+    end
   end
   return nothing
 end
 
 # no check for commutative codomains
-function _check_imgs_quo(R, S::Ring, imgs) 
+function _check_imgs_quo(R, S::Ring, imgs, coeff_map = nothing)
   gensI = gens(modulus(R))
   for g in gensI
-    @req iszero(evaluate(g, imgs)) "Morphism is not well-defined"
+    if coeff_map !== nothing
+      @req is_zero(evaluate(map_coefficients(coeff_map, g), imgs)) "Morphism is not well-defined"
+    else
+      @req iszero(evaluate(g, imgs)) "Morphism is not well-defined"
+    end
   end
 end
 
@@ -28,7 +36,7 @@ end
     hom(A::MPolyQuo, S::NCRing, coeff_map, images::Vector; check::Bool = true)
 
     hom(A::MPolyQuo, S::NCRing, images::Vector; check::Bool = true)
-    
+
 Given a homomorphism `coeff_map` from `C` to `S`, where `C` is the 
 coefficient ring of the base ring of `A`, and given a vector `images` of `ngens(A)` 
 elements of `S`, return the homomorphism `A` $\to$ `S` whose restriction 
@@ -73,7 +81,7 @@ function hom(R::MPolyQuo, S::NCRing, coeff_map, images::Vector; check::Bool = tr
   # Now coerce into S or throw an error if not possible
   imgs = _coerce(S, images)
   if check
-    _check_imgs_quo(R, S, imgs)
+    _check_imgs_quo(R, S, imgs, coeff_map)
     _check_homo(S, imgs)
   end
 

--- a/test/Rings/MPolyAnyMap/MPolyQuo.jl
+++ b/test/Rings/MPolyAnyMap/MPolyQuo.jl
@@ -180,4 +180,17 @@
   f = hom(Qix, Qi, x -> x, [i, 0])
   @test fh(x) == h(f(x)) 
   f = hom(Qix, Qi, x -> x, [i, 0])
+
+  # Construct stacked domain
+  R, (x, y) = PolynomialRing(QQ, ["x", "y"])
+  S, (u, v) = PolynomialRing(QQ, ["u", "v"])
+  I = ideal(S, [ u - v^2 ])
+  Q, StoQ = quo(S, I)
+  QtoR = hom(Q, R, [ x^2, x ])
+  T, (a, b, c) = PolynomialRing(Q, [ "a", "b", "c" ])
+  J = ideal(T, [ a*b - c^2 ])
+  A, TtoA = quo(T, J)
+  # The test is whether the following two lines work at all
+  AtoR = @inferred hom(A, R, QtoR, [ x^2, y^2, x*y ])
+  @test isone(AtoR(A(1)))
 end


### PR DESCRIPTION
Fixes this:
```
julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"]);

julia> S, (u, v) = PolynomialRing(QQ, ["u", "v"]);

julia> T, (a, b, c) = PolynomialRing(S, [ "a", "b", "c" ]);

julia> StoR = hom(S, R, [ x^2, x ]);

julia> J = ideal(T, [ a*b - c^2 ]);

julia> A, TtoA = quo(T, J);

julia> AtoR = hom(A, R, StoR, [ x^2, y^2, x*y ])
ERROR: Incompatible polynomial rings in polynomial operation
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] check_parent
    @ ~/.julia/packages/Nemo/pzCmt/src/flint/fmpq_mpoly.jl:31 [inlined]
  [3] *(a::fmpq_mpoly, b::fmpq_mpoly)
    @ Nemo ~/.julia/packages/Nemo/pzCmt/src/flint/fmpq_mpoly.jl:354
  [4] *(a::AbstractAlgebra.Generic.MPoly{fmpq_mpoly}, n::fmpq_mpoly)
    @ AbstractAlgebra.Generic ~/.julia/packages/AbstractAlgebra/mgYkc/src/generic/MPoly.jl:1976
  [5] evaluate(a::AbstractAlgebra.Generic.SparsePoly{AbstractAlgebra.Generic.MPoly{fmpq_mpoly}}, b::fmpq_mpoly)
    @ AbstractAlgebra.Generic ~/.julia/packages/AbstractAlgebra/mgYkc/src/generic/SparsePoly.jl:1349
  [6] evaluate(a::AbstractAlgebra.Generic.MPoly{fmpq_mpoly}, A::Vector{fmpq_mpoly})
    @ AbstractAlgebra.Generic ~/.julia/packages/AbstractAlgebra/mgYkc/src/generic/MPoly.jl:3351
  [7] macro expansion
    @ ~/.julia/dev/Hecke/src/Assertions.jl:235 [inlined]
  [8] _check_imgs_quo(R::MPolyQuo{AbstractAlgebra.Generic.MPoly{fmpq_mpoly}}, S::FmpqMPolyRing, imgs::Vector{fmpq_mpoly})
    @ Oscar ~/.julia/dev/Oscar/src/Rings/MPolyMap/MPolyQuo.jl:23
  [9] hom(R::MPolyQuo{AbstractAlgebra.Generic.MPoly{fmpq_mpoly}}, S::FmpqMPolyRing, coeff_map::Oscar.MPolyAnyMap{FmpqMPolyRing, FmpqMPolyRing, Nothing, fmpq_mpoly}, images::Vector{fmpq_mpoly}; check::Bool)
    @ Oscar ~/.julia/dev/Oscar/src/Rings/MPolyMap/MPolyQuo.jl:76
 [10] hom(R::MPolyQuo{AbstractAlgebra.Generic.MPoly{fmpq_mpoly}}, S::FmpqMPolyRing, coeff_map::Oscar.MPolyAnyMap{FmpqMPolyRing, FmpqMPolyRing, Nothing, fmpq_mpoly}, images::Vector{fmpq_mpoly})
    @ Oscar ~/.julia/dev/Oscar/src/Rings/MPolyMap/MPolyQuo.jl:70
 [11] top-level scope
    @ REPL[8]:1
```
Also I noticed that there are functions `_evaluate_help` defined in this context, but they are never used anywhere?