### PR TITLE
Tweak Hilbert series code

### DIFF
--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -2020,21 +2020,18 @@ function _hilbert_numerator_bayer_stillman(
 
   # initialize the result 
   h = oneS - _expvec_to_poly(S, t, weight_matrix, a[1])
+  linear_mons = Vector{Int}()
   for i in 2:length(a)
     J = _divide_by(a[1:i-1], a[i])
-    J1 = Vector{Vector{Int}}()
-    linear_mons = Vector{Int}()
-    for m in J
-      if sum(m) > 1
-        push!(J1, m)
-      else
-        for k in 1:length(m)
-          if m[k] > 0 
-            push!(linear_mons, k)
-            break
-          end
-        end
+    empty!(linear_mons)
+    J1 = filter!(J) do m
+      k = findfirst(!iszero, m)
+      k === nothing && return false # filter out zero vector
+      if m[k] == 1 && findnext(!iszero, m, k + 1) === nothing
+        push!(linear_mons, k)
+        return false
       end
+      return true
     end
     q = _hilbert_numerator_bayer_stillman(J1, weight_matrix, S, t, oneS)
     for k in linear_mons

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -1653,11 +1653,10 @@ function _divide_by(a::Vector{Vector{Int}}, pivot::Vector{Int})
   good = sizehint!(Vector{Vector{Int}}(), length(a))
   bad = sizehint!(Vector{Vector{Int}}(), length(a))
   for e in a
-    next = e-pivot
-    if all(x -> x >= 0, next) # tuned version of divides(e, pivot)
-      push!(good, next)
+    if _divides(e, pivot)
+      push!(good, e - pivot)
     else
-      push!(bad, next)
+      push!(bad, e)
     end
   end
 
@@ -1667,7 +1666,7 @@ function _divide_by(a::Vector{Vector{Int}}, pivot::Vector{Int})
     # the next line computers   m = [k < 0 ? 0 : k for k in e]
     # but without allocations
     for i in 1:length(e)
-      m[i] = e[i] >= 0 ? e[i] : 0
+      m[i] = max(e[i] - pivot[i], 0)
     end
 
     # check whether the new monomial m is already in the span 

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -1650,8 +1650,8 @@ function _divide_by(a::Vector{Vector{Int}}, pivot::Vector{Int})
   # generator which is collected in `bad` a priori. It is checked 
   # whether they become superfluous and if not, they are added to 
   # the good ones.
-  good = similar(a, 0)
-  bad = similar(a, 0)
+  good = sizehint!(Vector{Vector{Int}}(), length(a))
+  bad = sizehint!(Vector{Vector{Int}}(), length(a))
   for e in a
     next = e-pivot
     if all(x -> x >= 0, next) # tuned version of divides(e, pivot)

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -2016,7 +2016,7 @@ function _hilbert_numerator_bayer_stillman(
   ret !== nothing && return ret
 
   # make sure we have lexicographically ordered monomials
-  sort!(a)
+  sort!(a, alg=QuickSort)
 
   # initialize the result 
   h = oneS - _expvec_to_poly(S, t, weight_matrix, a[1])

--- a/test/Rings/mpoly-graded-test.jl
+++ b/test/Rings/mpoly-graded-test.jl
@@ -250,13 +250,12 @@ end
 
 @testset "Hilbert series" begin
   n = 5
-  AbstractAlgebra.divides(a::Vector{Int}, b::Vector{Int}) = all(x->(x>=0), a-b)
 
   g = Vector{Vector{Int}}()
   for i in 1:50
     e = [rand(20:50) for i in 1:n]
-    if all(v->!divides(e, v), g)
-      g = [v for v in g if !divides(v, e)]
+    if all(v->!Oscar._divides(e, v), g)
+      filter!(v -> !Oscar._divides(v, e), g)
       push!(g, e)
     end
   end


### PR DESCRIPTION
This PR speeds up the new Hilbert series code by @HechtiDerLachs .

I went to town and used the Julia memory profiler (new in 1.8), combined with the `PProf` package; basically doing this:
```
Profile.Allocs.@profile sample_rate=0.001 hilb_with_oscar(g)
PProf.Allocs.pprof()
Profile.Allocs.clear()
```

The result was super helpful for tracking down allocations which in turn resulted in a lot of speed up. Some numbers for comparison: I used a modified version of @HechtiDerLachs's test code; of course different examples give different results; for the purpose of giving numbers here, I am using a fixed RNG seed, like so:
```julia
using BenchmarkTools
using Random
Random.seed!(3)

n = 10
g = Vector{Vector{Int}}()
for i in 1:100
  e = [rand(20:50) for i in 1:n]
  if all(v->!Oscar._divides(e, v), g)
    filter!(v -> !Oscar._divides(v, e), g)
    push!(g, e)
  end
end

function hilb_with_sing(g)
  R, x = PolynomialRing(QQ, ["x$i" for i in 1:length(g[1])])
  P, _ = grade(R)
  I = ideal(P, [prod([x[i]^e[i] for i in 1:length(x)]) for e in g])
  Q, _ = quo(P, I)
  return hilbert_series(Q)[1]
end

function hilb_with_oscar(g)
  W = ones(Int, 1, length(g[1]))
  Oscar._hilbert_numerator_from_leading_exponents(g, W, ZZ[:t][1], :BayerStillmanA)
end
```

Before this PR, Singular is ~40% faster. And the memory usage is insane in the Julia version. To be fair, I think "plain" Singular might be even faster; our Singular in Julia is not using `omalloc` after all.
```
julia> @btime hilb_with_sing(g);
  253.109 ms (30479 allocations: 1.07 MiB)

julia> @btime hilb_with_oscar(g);
  362.275 ms (5290463 allocations: 427.12 MiB)
```

After this PR, the timings for singular of course remain similar, but now the Julia version is 23% faster. The number of allocations also went down from ~5.3 million to "just" ~3 million (of course Singular only has 30479...)
```
julia> @btime hilb_with_sing(g);
  245.023 ms (30479 allocations: 1.07 MiB)

julia> @btime hilb_with_oscar(g);
  199.230 ms (3027723 allocations: 260.76 MiB)
```

Mind you, it is not always faster (yet?). Here's a couple runs of the above code, but with the `Random.seed!` call removed, and `n = rand(3:15)`:
```
# n = 5
  245.023 ms (30479 allocations: 1.07 MiB)
  199.230 ms (3027723 allocations: 260.76 MiB)

# n = 8
  25.304 ms (22715 allocations: 805.34 KiB)
  18.833 ms (276985 allocations: 24.04 MiB)

# n = 4
  275.292 μs (5116 allocations: 179.65 KiB)
  232.041 μs (2477 allocations: 282.48 KiB)

# n = 6
  936.291 μs (11335 allocations: 401.80 KiB)
  1.376 ms (15978 allocations: 1.64 MiB)

# n = 4
  265.958 μs (5285 allocations: 179.41 KiB)
  173.500 μs (1761 allocations: 203.89 KiB)

# n = 10
  1.658 s (31345 allocations: 1.07 MiB)
  374.490 ms (4754077 allocations: 386.11 MiB)
```
Note how in the final example we are actually 5 times faster than Singular.
And in some of the smaller examples we actually allocate less than Singular...

Of course the above is far from a comprehensive study. It is absolutely possible that someone can construct examples were Singular crushes the Julia code. But one thing is clear: this PR makes the Julia code competitive in at least *some* cases.

The main things we still allocate can be discovered with the help of the memory profiler I mentioned at the start... E.g. in the final `n = 10` example I am seeing...
- ~52% of all allocations are in `_divide_by`, all for `Vector` allocations
  - this directly contributes to ~62% of all allocations coming from `jl_gc_alloc`
  - of those, ~16% are for `Vector{Vector{Int}}`
  - and ~26% are for `Vector{Int}`
  - finally ~19% for.. "Profile Allocs BufferType" (?)
- the remaining 38% of allocations are spent allocating `fmpz_poly`

Note that for `fmpz_poly` it hurts us that creating a polynomial of the form `1 - monomial` is relatively expensive, even with an `MPolyBuildCtx`. THe problem is that we have to allocate exponent vectors and coefficients, and then the `fmpz_poly` construct copies them,  We waste at least 2-3 allocations for each `fmpz_poly` we create. 