### PR TITLE
added `orbit_representatives_and_stabilizers`

### DIFF
--- a/src/Groups/matrices/matrix_manipulation.jl
+++ b/src/Groups/matrices/matrix_manipulation.jl
@@ -245,6 +245,11 @@ Base.:*(x::MatrixGroupElem{T}, u::Vector{T}) where T <: RingElem = matrix(x)*u
 # (`^` is the natural action in GAP)
 Base.:^(v::AbstractAlgebra.Generic.FreeModuleElem{T},x::MatrixGroupElem{T}) where T <: RingElem = v.parent(v.v*matrix(x))
 
+# action of matrix group elements on subspaces of a vector space
+function Base.:^(V::AbstractAlgebra.Generic.Submodule{T}, x::MatrixGroupElem{T}) where T <: RingElem
+  return sub(V.m, [v^x for v in V.gens])[1]
+end
+
 # evaluation of the form x into the vectors v and u
 Base.:*(v::AbstractAlgebra.Generic.FreeModuleElem{T},x::MatrixGroupElem{T},u::AbstractAlgebra.Generic.FreeModuleElem{T}) where T <: RingElem = (v.v*matrix(x)*transpose(u.v))[1]
 

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -268,3 +268,35 @@ end
   @test ! rep[1]
 
 end
+
+@testset "orbits of matrix groups over finite fields" begin
+
+  @testset for F in [ GF(2), GF(3), GF(2,2) ]
+    for n in 2:4
+      q = order(F)
+      V = VectorSpace(F, n)
+      GL = general_linear_group(n, F)
+      S = sylow_subgroup(GL, 2)[1]
+      for G in [GL, S]
+#       for k in 0:n   # k = 0 is a problem in GAP 4.12.0
+        for k in 1:n
+          res = orbit_representatives_and_stabilizers(G, k)
+          total = ZZ(0)
+          for (U, stab) in res
+            total = total + index(G, stab)
+            @test length(orbit(stab, U)) == 1
+          end
+          num = ZZ(1)
+          for i in 0:(k-1)
+            num = num * (q^n - q^i)
+          end
+          for i in 0:(k-1)
+            num = divexact(num, q^k - q^i)
+          end
+          @test total == num
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
@simonbrandhorst had asked for this functionality:
Compute orbit representatives of the action of a matrix group over a finite field on k-dimensional subspaces of the natural vector space on which the group acts, and compute also the stabilizers of these representatives.
The current function is very simpleminded, it just delegates the task to GAP. For larger examples, we will have to use other ideas, depending also on the concrete questions. (For example, if one knows that there are only few orbits and that the orbits are long then trying random subspaces is reasonable.) 