### PR TITLE
Add /docs/fourtitwo.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /docs/src/Hecke/
 /docs/src/Nemo/
 Manifest.toml
+/docs/fourtitwo.json


### PR DESCRIPTION
For some time now, I notice a dynamically created file, which is not tracked by `OSCAR`. Specifically `/docs/fourtitwo.json` is create either upon building `OSCAR` or executing the doctests. This is a bit annoying when working on PRs (which should contain all changes, and not leave untracked files). So I suggest to extend `.gitignore` accordingly.
