### PR TITLE
ToricVarieties: Implement weighted projective space

### DIFF
--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -45,6 +45,7 @@ affine_space(::Type{NormalToricVariety}, d::Int)
 del_pezzo_surface(b::Int)
 hirzebruch_surface(r::Int)
 projective_space(::Type{NormalToricVariety}, d::Int)
+weighted_projective_space(::Type{NormalToricVariety}, w::Vector{T}) where {T <: IntegerUnion}
 ```
 
 ### Further Constructions

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -291,6 +291,48 @@ export projective_space
 
 
 @doc Markdown.doc"""
+    weighted_projective_space(::Type{NormalToricVariety}, w::Vector{T}) where {T <: IntegerUnion}
+
+Construct the weighted projective space corresponding to the weights `w`.
+
+# Examples
+```jldoctest
+julia> weighted_projective_space(NormalToricVariety, [2,3,1])
+A normal, non-affine, simplicial, projective, 2-dimensional toric variety without torusfactor
+```
+"""
+function weighted_projective_space(::Type{NormalToricVariety}, w::Vector{T}) where {T <: IntegerUnion}
+    # build projective space
+    if all(a -> isone(a), w)
+      return projective_space(NormalToricVariety, length(w)-1)
+    end
+
+    # construct the weighted projective space
+    pmntv = Polymake.fulton.weighted_projective_space(w)
+    variety = NormalToricVariety(pmntv)
+
+    # set properties
+    set_attribute!(variety, :has_torusfactor, false)
+    set_attribute!(variety, :is_affine, false)
+    set_attribute!(variety, :is_projective, true)
+    set_attribute!(variety, :is_projective_space, false)
+    set_attribute!(variety, :is_complete, true)
+    set_attribute!(variety, :is_orbifold, true)
+    set_attribute!(variety, :is_simplicial, true)
+
+    # set attributes
+    set_attribute!(variety, :dim, length(w)-1)
+    set_attribute!(variety, :character_lattice, free_abelian_group(length(w)-1))
+    set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(length(w)))
+    set_attribute!(variety, :dim_of_torusfactor, 0)
+
+    # return the variety
+    return variety
+end
+export weighted_projective_space
+
+
+@doc Markdown.doc"""
     hirzebruch_surface(r::Int)
 
 Constructs the r-th Hirzebruch surface.

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -348,7 +348,6 @@ function hirzebruch_surface(r::Int)
     fan_rays = [1 0; 0 1; -1 r; 0 -1]
     cones = IncidenceMatrix([[1,2],[2,3],[3,4],[4,1]])
     variety = NormalToricVariety(PolyhedralFan(fan_rays, cones; non_redundant = true))
-    new_rays = matrix(ZZ, Oscar.rays(variety))
     
     # set properties
     set_attribute!(variety, :is_affine, false)
@@ -438,7 +437,6 @@ function del_pezzo_surface(b::Int)
         cones = IncidenceMatrix([[1,4],[2,4],[1,5],[5,3],[2,6],[6,3]])
     end
     variety = NormalToricVariety(PolyhedralFan(fan_rays, cones; non_redundant = true))
-    new_rays = matrix(ZZ, Oscar.rays(variety))
     
     # set properties
     set_attribute!(variety, :is_affine, false)

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -118,12 +118,13 @@ end
 
 
 ##################################################
-# (4) Projective space
+# (4) (Weighted) projective space
 ##################################################
 
 P2 = NormalToricVariety(normal_fan(Oscar.simplex(2)))
 P2v2 = projective_space(NormalToricVariety,2)
 P3 = projective_space(NormalToricVariety,3)
+WPS = weighted_projective_space(NormalToricVariety,[2,3,1])
 
 @testset "Projective space P2" begin
     @test is_normal(P2) == true
@@ -144,10 +145,16 @@ P3 = projective_space(NormalToricVariety,3)
     @test length(irrelevant_ideal(P2).gens) == 3
 end
 
-@testset "Test constructor for Hirzebruch surfaces" begin
+@testset "Test weighted projective space" begin
+  @test is_smooth(WPS) == false
+  @test ngens(cox_ring(WPS)) == 3
+end
+
+@testset "Test standard constructor for projective space" begin
   @test vcat([map_from_torusinvariant_weil_divisor_group_to_class_group(P2v2)(x).coeff for x in gens(torusinvariant_weil_divisor_group(P2v2))]) == matrix(ZZ, [[1],[1],[1]])
   @test coordinate_names(P2v2) == ["x1","x2","x3"]
 end
+
 
 
 


### PR DESCRIPTION
This PR achieves:
1. Implementation of the weighted projective space as a toric variety.
2. Minor code improvement by removing obsolete lines in some constructors of toric varieties.

Cf. https://github.com/oscar-system/Oscar.jl/issues/1644, cc @HechtiDerLachs 