### PR TITLE
Gröbner Bases: Changes normal form to take a monomial ordering kwarg

### DIFF
--- a/src/Rings/MPolyMap/AffineAlgebras.jl
+++ b/src/Rings/MPolyMap/AffineAlgebras.jl
@@ -79,7 +79,9 @@ function _groebner_data(F::AffAlgHom, ord::Symbol)
     (S, I, W, _) = _ring_helper(s, zero(s), _images(F))
     # Build auxiliary objects
     (T, inc, J) = _containment_helper(S, n, m, I, W, ord)
-    D = normal_form([gen(T, i) for i in 1:m], J)
+    # make sure to compute the NF with respect to the correct ordering  
+    D = normal_form([gen(T, i) for i in 1:m], J,
+                    ordering = first(collect(keys(J.gb))))
     A = [zero(r) for i in 1:m]
     B = [gen(r, i) for i in 1:n]
     pr = hom(T, r, vcat(A, B))
@@ -232,7 +234,7 @@ function preimage_with_kernel(F::AffAlgHom, f::Union{MPolyElem, MPolyQuoElem})
 
   (S, _, _, g) = _ring_helper(s, f, [zero(s)])
   (T, inc, pr, J, o) = _groebner_data(F, :degrevlex)
-  D = normal_form([inc(g)], J)
+  D = normal_form([inc(g)], J, ordering = first(collect(keys(J.gb))))
   !(leading_monomial(D[1]) < gen(T, m)) && error("Element not contained in image")
   return (pr(D[1]), kernel(F))
 end

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -846,6 +846,8 @@ function sparse_matrix(R::MPolyRing, M::Singular.Module)
   for g = 1:Singular.ngens(M)
     push!(S, sparse_row(R, M[g]))
   end
+  S.r = ngens(M)
+  S.c = rank(M)
   return S
 end
 

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -450,7 +450,7 @@ are zero.
 
 Return an element which is `f` reduced by the underlying generators
 of `F` w.r.t. the monomial ordering `ordering`. `F` need not be a
-Groebner basis. The returned
+Groebner basis. 
 
 	reduce(F::Vector{T}, G::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(F[1]))) where {T <: MPolyElem}
 
@@ -512,7 +512,7 @@ function reduce(F::Vector{T}, G::Vector{T}; ordering::MonomialOrdering = default
 end
 
 @doc Markdown.doc"""
-    reduce_with_quotients_and_units(I::IdealGens, J::IdealGens; ordering::MonomialOrdering = default_ordering(base_ring(J)))
+        reduce_with_quotients_and_units(I::IdealGens, J::IdealGens; ordering::MonomialOrdering = default_ordering(base_ring(J)))
 
 Return a `Tuple` consisting of a `Generic.MatSpaceElem` `M`, a
 `Vector` `res` whose elements are the underlying elements of `I`
@@ -603,7 +603,7 @@ end
 
 
 @doc Markdown.doc"""
-    reduce_with_quotients(I::IdealGens, J::IdealGens; ordering::MonomialOrdering = default_ordering(base_ring(J)))
+        reduce_with_quotients(I::IdealGens, J::IdealGens; ordering::MonomialOrdering = default_ordering(base_ring(J)))
 
 Return a `Tuple` consisting of a `Generic.MatSpaceElem` `M` and a
 `Vector` `res` whose elements are the underlying elements of `I`

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -460,10 +460,10 @@ julia> normal_form(-1+c+b+a^3, J)
 a^3
 ```
 """
-function normal_form(f::T, J::MPolyIdeal) where { T <: MPolyElem }
+function normal_form(f::T, J::MPolyIdeal, o=default_ordering(base_ring(J))::MonomialOrdering) where { T <: MPolyElem }
     singular_assure(J)
     I = Singular.Ideal(J.gens.Sx, J.gens.Sx(f))
-    N = normal_form_internal(I, J)
+    N = normal_form_internal(I, J, o)
     return N[1]
 end
 
@@ -502,16 +502,8 @@ julia> normal_form(A, J)
  4*a - 2*c^2 - c + 5
 ```
 """
-function normal_form(A::Vector{T}, J::MPolyIdeal) where { T <: MPolyElem }
+function normal_form(A::Vector{T}, J::MPolyIdeal, o=default_ordering(base_ring(J))::MonomialOrdering) where { T <: MPolyElem }
     singular_assure(J)
     I = Singular.Ideal(J.gens.Sx, [J.gens.Sx(x) for x in A])
-    normal_form_internal(I, J)
-end
-
-function normal_form(f::MPolyElem, J::MPolyIdeal, o::MonomialOrdering)
-  stdJ = standard_basis(J, ordering=o, complete_reduction=false)
-  Sx = stdJ.Sx
-  Ox = parent(f)
-  I = Singular.Ideal(Sx, Sx(f))
-  return Ox(gens(Singular.reduce(I, stdJ.S))[1])
+    normal_form_internal(I, J, o)
 end

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -461,7 +461,7 @@ julia> normal_form(-1+c+b+a^3, J)
 a^3
 ```
 """
-function normal_form(f::T, J::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I))) where { T <: MPolyElem }
+function normal_form(f::T, J::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(J))) where { T <: MPolyElem }
     singular_assure(J, ordering)
     I = Singular.Ideal(J.gens.Sx, J.gens.Sx(f))
     N = normal_form_internal(I, J, ordering)

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -426,9 +426,9 @@ julia> Oscar.normal_form_internal(I,J)
  4*a - 2*c^2 - c + 5
 ```
 """
-function normal_form_internal(I::Singular.sideal, J::MPolyIdeal)
-  groebner_assure(J)
-  G = collect(values(J.gb))[1]
+function normal_form_internal(I::Singular.sideal, J::MPolyIdeal, o::MonomialOrdering)
+  groebner_assure(J, o)
+  G = J.gb[o]  
   singular_assure(G)
   K = ideal(base_ring(J), reduce(I, G.S))
   return [J.gens.Ox(x) for x = gens(K.gens.S)]

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -446,17 +446,17 @@ ordering `ordering`. `J` need not be a Groebner basis. The returned
 `Vector` will have the same number of elements as `I`, even if they
 are zero.
 
-	reduce(F::Vector{T}, G::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(F[1]))) where {T <: MPolyElem}
-
-Return a `Vector` whose elements are the elements of `F`
-reduced by the elements of `G` w.r.t. the monomial
-ordering `ordering`. `G` need not be a Groebner basis.
-
 	reduce(f::T, F::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(f))) where {T <: MPolyElem}
 
 Return an element which is `f` reduced by the underlying generators
 of `F` w.r.t. the monomial ordering `ordering`. `F` need not be a
 Groebner basis. The returned
+
+	reduce(F::Vector{T}, G::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(F[1]))) where {T <: MPolyElem}
+
+Return a `Vector` whose elements are the elements of `F`
+reduced by the elements of `G` w.r.t. the monomial
+ordering `ordering`. `G` need not be a Groebner basis.
 
 # Examples
 ```jldoctest
@@ -482,7 +482,7 @@ julia> reduce(y^3, [x^2, x*y-y^3], ordering=lex(R))
 y^3
 
 julia> reduce([y^3], [x^2, x*y-y^3], ordering=lex(R))
-1-element Vector{fmpq_mpoly}:
+1-element Vector{gfp_mpoly}:
  y^3
 ```
 """

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -523,6 +523,27 @@ gens(J) + res == units * gens(I)`. If `ordering` is global then
 `reduce_with_quotients`. `J` need not be a Groebner basis. `res` will
 have the same number of elements as `I`, even if they are zero.
 
+	reduce_with_quotients_and_units(F::Vector{T}, G::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(F[1]))) where {T <: MPolyElem}
+
+Return a `Tuple` consisting of a `Generic.MatSpaceElem` `M`, a
+`Vector` `res` whose elements are the underlying elements of `F`
+reduced by the underlying generators of `G` w.r.t. the monomial
+ordering `ordering` and a diagonal matrix `units` such that `M *
+G + res == units * F`. If `ordering` is global then
+`units` will always be the identity matrix, see also
+`reduce_with_quotients`. `G` need not be a Groebner basis. `res` will
+have the same number of elements as `F`, even if they are zero.
+
+	reduce_with_quotients_and_units(f::T, F::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(F[1]))) where {T <: MPolyElem}
+
+Return a `Tuple` consisting of a `Generic.MatSpaceElem` `M`, an
+`MPolyElem` `res` which represents `f`
+reduced by the underlying generators of `F` w.r.t. the monomial
+ordering `ordering` and a diagonal matrix `units` such that `M *
+F + res == units * f`. If `ordering` is global then
+`units` will always be the identity matrix, see also
+`reduce_with_quotients`. `G` need not be a Groebner basis.
+
 # Examples
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(GF(11), ["x", "y"]);
@@ -539,6 +560,23 @@ julia> M, res, units = reduce_with_quotients_and_units(I.gens, J.gens, ordering 
 ([x], gfp_mpoly[0], [x+1])
 
 julia> M * gens(J) + res == units * gens(I)
+true
+
+julia> f = x^3*y^2-y^4-10
+x^3*y^2 + 10*y^4 + 1
+
+julia> F = [x^2*y-y^3, x^3-y^4]
+2-element Vector{gfp_mpoly}:
+ x^2*y + 10*y^3
+ x^3 + 10*y^4
+
+julia> reduce_with_quotients_and_units(f,F)
+([x*y 10*x+1], x^4 + 10*x^3 + 1, [1])
+
+julia> M, res, units = reduce_with_quotients_and_units(f,F, ordering=lex(R))
+([0 y^2], y^6 + 10*y^4 + 1, [1])
+
+julia> M * F + [res] == units * [f]
 true
 ```
 """

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -430,7 +430,7 @@ julia> Oscar.normal_form_internal(I,J,default_ordering(base_ring(J)))
 function normal_form_internal(I::Singular.sideal, J::MPolyIdeal, o::MonomialOrdering)
   groebner_assure(J, o)
   G = J.gb[o]  
-  singular_assure(G)
+  singular_assure(G, o)
   K = ideal(base_ring(J), reduce(I, G.S))
   return [J.gens.Ox(x) for x = gens(K.gens.S)]
 end
@@ -462,7 +462,7 @@ a^3
 ```
 """
 function normal_form(f::T, J::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I))) where { T <: MPolyElem }
-    singular_assure(J)
+    singular_assure(J, ordering)
     I = Singular.Ideal(J.gens.Sx, J.gens.Sx(f))
     N = normal_form_internal(I, J, ordering)
     return N[1]
@@ -504,7 +504,7 @@ julia> normal_form(A, J)
 ```
 """
 function normal_form(A::Vector{T}, J::MPolyIdeal; ordering::MonomialOrdering=default_ordering(base_ring(J))) where { T <: MPolyElem }
-    singular_assure(J)
+    singular_assure(J, ordering)
     I = Singular.Ideal(J.gens.Sx, [J.gens.Sx(x) for x in A])
     normal_form_internal(I, J, ordering)
 end

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1,4 +1,6 @@
-export  f4, standard_basis, groebner_basis, groebner_basis_with_transformation_matrix, leading_ideal, syzygy_generators
+export  reduce, reduce_with_quotients, reduce_with_quotients_and_units, f4,
+		standard_basis, groebner_basis, groebner_basis_with_transformation_matrix,
+		leading_ideal, syzygy_generators
 
 # groebner stuff #######################################################
 @doc Markdown.doc"""
@@ -433,6 +435,31 @@ function normal_form_internal(I::Singular.sideal, J::MPolyIdeal, o::MonomialOrde
   singular_assure(G, o)
   K = ideal(base_ring(J), reduce(I, G.S))
   return [J.gens.Ox(x) for x = gens(K.gens.S)]
+end
+
+function reduce(I::IdealGens, J::IdealGens; ordering::MonomialOrdering = default_ordering(base_ring(J)))
+	@assert base_ring(J) == base_ring(I)
+	singular_assure(I, ordering)
+	singular_assure(J, ordering)
+	res = reduce(I.gens.S, J.gens.S)
+	return [J.gens.Ox(x) for x = gens(res)]
+end
+
+function reduce_with_quotients_and_units(I::IdealGens, J::IdealGens; ordering::MonomialOrdering = default_ordering(base_ring(J)))
+	return _reduce_with_quotients_and_units(I, J, ordering)
+end
+
+function reduce_with_quotients(I::IdealGens, J::IdealGens; ordering::MonomialOrdering = default_ordering(base_ring(J)))
+	q, r, _ = _reduce_with_quotients_and_units(I, J, ordering)
+	return q, r
+end
+
+function _reduce_with_quotients_and_units(I::IdealGens, J::IdealGens, ordering::MonomialOrdering = default_ordering(base_ring(J)))
+	@assert base_ring(J) == base_ring(I)
+	singular_assure(I, ordering)
+	singular_assure(J, ordering)
+	res = Singular.division(I.gens.S, J.gens.S)
+	return matrix(base_ring(I), res[1]), [J.gens.Ox(x) for x = gens(res[2])], matrix(base_ring(I), res[3])
 end
 
 @doc Markdown.doc"""

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -570,10 +570,10 @@ julia> F = [x^2*y-y^3, x^3-y^4]
  x^2*y + 10*y^3
  x^3 + 10*y^4
 
-julia> reduce_with_quotients_and_units(f,F)
+julia> reduce_with_quotients_and_units(f, F)
 ([x*y 10*x+1], x^4 + 10*x^3 + 1, [1])
 
-julia> M, res, units = reduce_with_quotients_and_units(f,F, ordering=lex(R))
+julia> M, res, units = reduce_with_quotients_and_units(f, F, ordering=lex(R))
 ([0 y^2], y^6 + 10*y^4 + 1, [1])
 
 julia> M * F + [res] == units * [f]
@@ -664,13 +664,13 @@ julia> F = [x^2*y-y^3, x^3-y^4]
  x^2*y + 10*y^3
  x^3 + 10*y^4
 
-julia> reduce_with_quotients_and_units(f,F)
-([x*y 10*x+1], x^4 + 10*x^3 + 1)
+julia> reduce_with_quotients_and_units(f, F)
+([x*y 10*x+1], x^4 + 10*x^3 + 1, [1])
 
-julia> M, res, units = reduce_with_quotients_and_units(f,F, ordering=lex(R))
-([0 y^2], y^6 + 10*y^4 + 1)
+julia> M, res, units = reduce_with_quotients_and_units(f, F, ordering=lex(R))
+([0 y^2], y^6 + 10*y^4 + 1, [1])
 
-julia> M * F + [res] == [f]
+julia> M * F + [res] == units * [f]
 true
 ```
 """

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -438,13 +438,25 @@ function normal_form_internal(I::Singular.sideal, J::MPolyIdeal, o::MonomialOrde
 end
 
 @doc Markdown.doc"""
-    reduce(I::IdealGens, J::IdealGens; ordering::MonomialOrdering = default_ordering(base_ring(J)))
+	reduce(I::IdealGens, J::IdealGens; ordering::MonomialOrdering = default_ordering(base_ring(J)))
 
 Return a `Vector` whose elements are the underlying elements of `I`
 reduced by the underlying generators of `J` w.r.t. the monomial
 ordering `ordering`. `J` need not be a Groebner basis. The returned
 `Vector` will have the same number of elements as `I`, even if they
 are zero.
+
+	reduce(F::Vector{T}, G::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(F[1]))) where {T <: MPolyElem}
+
+Return a `Vector` whose elements are the elements of `F`
+reduced by the elements of `G` w.r.t. the monomial
+ordering `ordering`. `G` need not be a Groebner basis.
+
+	reduce(f::T, F::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(f))) where {T <: MPolyElem}
+
+Return an element which is `f` reduced by the underlying generators
+of `F` w.r.t. the monomial ordering `ordering`. `F` need not be a
+Groebner basis. The returned
 
 # Examples
 ```jldoctest
@@ -462,6 +474,16 @@ julia> reduce(J.gens, I.gens)
 julia> reduce(J.gens, groebner_basis(I))
 1-element Vector{gfp_mpoly}:
  0
+
+julia> reduce(y^3, [x^2, x*y-y^3])
+x*y
+
+julia> reduce(y^3, [x^2, x*y-y^3], ordering=lex(R))
+y^3
+
+julia> reduce([y^3], [x^2, x*y-y^3], ordering=lex(R))
+1-element Vector{fmpq_mpoly}:
+ y^3
 ```
 """
 function reduce(I::IdealGens, J::IdealGens; ordering::MonomialOrdering = default_ordering(base_ring(J)))
@@ -470,6 +492,23 @@ function reduce(I::IdealGens, J::IdealGens; ordering::MonomialOrdering = default
 	singular_assure(J, ordering)
 	res = reduce(I.gens.S, J.gens.S)
 	return [J.gens.Ox(x) for x = gens(res)]
+end
+
+function reduce(f::T, F::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(f))) where {T <: MPolyElem}
+	@assert parent(f) == parent(F[1])
+	R = parent(f)
+	I = IdealGens(R, [f], ordering)
+	J = IdealGens(R, F, ordering)
+	redv = reduce(I, J, ordering=ordering)
+	return redv[1]
+end
+
+function reduce(F::Vector{T}, G::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(F[1]))) where {T <: MPolyElem}
+	@assert parent(F[1]) == parent(G[1])
+	R = parent(F[1])
+	I = IdealGens(R, F, ordering)
+	J = IdealGens(R, G, ordering)
+	return reduce(I, J, ordering=ordering)
 end
 
 @doc Markdown.doc"""

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -787,9 +787,9 @@ function is_standard_basis(F::IdealGens; ordering::MonomialOrdering=default_orde
 		# Try to reduce all possible s-polynomials, i.e. Buchberger's criterion
 		R = base_ring(F)
 		for i in 1:length(F)
-			lt_i = leading_term(F[i], ordering)
+			lt_i = leading_term(F[i], ordering=ordering)
 			for j in i+1:length(F)
-				lt_j = leading_term(F[j], ordering)
+				lt_j = leading_term(F[j], ordering=ordering)
 				lcm_ij  = lcm(lt_i, lt_j)
 				sp_ij = div(lcm_ij, lt_i) * F[i] - div(lcm_ij, lt_j) * F[j]
 				if reduce(IdealGens([sp_ij], ordering), F, ordering=ordering) != [R(0)]

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -390,15 +390,16 @@ function leading_ideal(I::MPolyIdeal; ordering::MonomialOrdering)
 end
 
 @doc Markdown.doc"""
-    normal_form_internal(I::Singular.sideal, J::MPolyIdeal)
+    normal_form_internal(I::Singular.sideal, J::MPolyIdeal, o::MonomialOrdering)
 
 **Note**: Internal function, subject to change, do not use.
 
 Compute the normal form of the generators `gens(I)` of the ideal `I` w.r.t. a
-Groebner basis of `J`.
+Groebner basis of `J` and the monomial ordering `o`.
 
-CAVEAT: This computation needs a Groebner basis of `J`. If this Groebner basis
-is not available, one is computed automatically. This may take some time.
+CAVEAT: This computation needs a Groebner basis of `J` and the monomial ordering
+`o`. If this Groebner basis is not available, one is computed automatically.
+This may take some time.
 
 # Examples
 ```jldoctest
@@ -419,7 +420,7 @@ Singular Polynomial Ring (QQ),(a,b,c),(dp(3),C)
 julia> I = Singular.Ideal(SR,[SR(-1+c+b+a^3),SR(-1+b+c*a+2*a^3),SR(5+c*b+c^2*a)])
 Singular ideal over Singular Polynomial Ring (QQ),(a,b,c),(dp(3),C) with generators (a^3 + b + c - 1, 2*a^3 + a*c + b - 1, a*c^2 + b*c + 5)
 
-julia> Oscar.normal_form_internal(I,J)
+julia> Oscar.normal_form_internal(I,J,default_ordering(base_ring(J)))
 3-element Vector{fmpq_mpoly}:
  a^3
  2*a^3 + 2*a - 2*c
@@ -435,13 +436,13 @@ function normal_form_internal(I::Singular.sideal, J::MPolyIdeal, o::MonomialOrde
 end
 
 @doc Markdown.doc"""
-    normal_form(f::T, J::MPolyIdeal) where { T <: MPolyElem }
+    normal_form(f::T, J::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I))) where { T <: MPolyElem }
 
 Compute the normal form of the polynomial `f` w.r.t. a
-Groebner basis of `J`.
+Groebner basis of `J` and the monomial ordering `o`.
 
-CAVEAT: This computation needs a Groebner basis of `J`. If this Groebner basis
-is not available, one is computed automatically. This may take some time.
+CAVEAT: This computation needs a Groebner basis of `J` and `o`. If this Groebner
+basis is not available, one is computed automatically. This may take some time.
 
 # Examples
 ```jldoctest
@@ -460,21 +461,21 @@ julia> normal_form(-1+c+b+a^3, J)
 a^3
 ```
 """
-function normal_form(f::T, J::MPolyIdeal, o=default_ordering(base_ring(J))::MonomialOrdering) where { T <: MPolyElem }
+function normal_form(f::T, J::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I))) where { T <: MPolyElem }
     singular_assure(J)
     I = Singular.Ideal(J.gens.Sx, J.gens.Sx(f))
-    N = normal_form_internal(I, J, o)
+    N = normal_form_internal(I, J, ordering)
     return N[1]
 end
 
 @doc Markdown.doc"""
-    normal_form(A::Vector{T}, J::MPolyIdeal) where { T <: MPolyElem }
+    normal_form(A::Vector{T}, J::MPolyIdeal; ordering::MonomialOrdering=default_ordering(base_ring(J))) where { T <: MPolyElem }
 
 Compute the normal form of the elements of the array `A` w.r.t. a
-Groebner basis of `J`.
+Groebner basis of `J` and the monomial ordering `o`.
 
-CAVEAT: This computation needs a Groebner basis of `J`. If this Groebner basis
-is not available, one is computed automatically. This may take some time.
+CAVEAT: This computation needs a Groebner basis of `J` and `o`. If this Groebner
+basis is not available, one is computed automatically. This may take some time.
 
 # Examples
 ```jldoctest
@@ -502,8 +503,8 @@ julia> normal_form(A, J)
  4*a - 2*c^2 - c + 5
 ```
 """
-function normal_form(A::Vector{T}, J::MPolyIdeal, o=default_ordering(base_ring(J))::MonomialOrdering) where { T <: MPolyElem }
+function normal_form(A::Vector{T}, J::MPolyIdeal; ordering::MonomialOrdering=default_ordering(base_ring(J))) where { T <: MPolyElem }
     singular_assure(J)
     I = Singular.Ideal(J.gens.Sx, [J.gens.Sx(x) for x in A])
-    normal_form_internal(I, J, o)
+    normal_form_internal(I, J, ordering)
 end

--- a/test/Rings/groebner-test.jl
+++ b/test/Rings/groebner-test.jl
@@ -18,7 +18,23 @@
     @test reduce(y^3, [y^2 - x, x^3 - 2*y^2]) == x*y
     @test reduce([y^3], [y^2 - x, x^3 - 2*y^2]) == [x*y]
     @test reduce([y^3], [y^2 - x, x^3 - 2*y^2], ordering=lex(R)) == [y^3]
-    I = ideal(R,[y^2 - x, x^3 - 2*y^2])
+    f = x*y^3-y^4
+	F = [x*y^2-x,x^3-2*x*y^2]
+	q, r = reduce_with_quotients(f, F)
+	@test q * F + [r] == [f]
+	q, r = reduce_with_quotients([f], F)
+	@test q * F + r == [f]
+	q, r, u = reduce_with_quotients_and_units(f, F)
+	@test q * F + [r] == u * [f]
+	q, r, u = reduce_with_quotients_and_units([f], F)
+	@test q * F + r == u * [f]
+	f = x
+	F = [1-x]
+	q, r = reduce_with_quotients(f, F, ordering=neglex(R))
+	@test q * F + [r] != [f]
+	q, r, u = reduce_with_quotients_and_units(f, F, ordering=neglex(R))
+	@test q * F + [r] == u * [f]
+	I = ideal(R,[y^2 - x, x^3 - 2*y^2])
     @test is_groebner_basis(I.gens, ordering=degrevlex(R)) == true
     @test is_groebner_basis(I.gens, ordering=lex(R)) == false
     @test_throws ErrorException is_groebner_basis(I.gens, ordering=neglex(R))

--- a/test/Rings/groebner-test.jl
+++ b/test/Rings/groebner-test.jl
@@ -50,6 +50,9 @@ end
   o = negdegrevlex(gens(R))
   G = standard_basis(I, ordering=o)
   @test normal_form(x^5-5, I, ordering=o) == -5
+  J = ideal(R, [x^5-5])
+  matr, res, units = reduce_with_quotients_and_units(J.gens, G)
+  @test matr * gens(G) + res == units * gens(J)
   u = negdegrevlex([x])*negdegrevlex([y])
   @test ideal_membership(x^4, I, ordering=u)
 end

--- a/test/Rings/groebner-test.jl
+++ b/test/Rings/groebner-test.jl
@@ -7,6 +7,12 @@
     I = ideal(R, [x])
     gb = f4(I)
     @test normal_form(y, I) == y
+    I = ideal(R,[y^2 - x, x^3 - 2*y^2])
+    @test is_groebner_basis(I.gens, ordering=degrevlex(R)) == true
+    @test is_groebner_basis(I.gens, ordering=lex(R)) == false
+    @test_throws ErrorException is_groebner_basis(I.gens, ordering=neglex(R))
+    @test is_standard_basis(I.gens, ordering=degrevlex(R)) == true
+    @test is_standard_basis(I.gens, ordering=neglex(R)) == false
 end
 
 @testset "groebner leading ideal" begin

--- a/test/Rings/groebner-test.jl
+++ b/test/Rings/groebner-test.jl
@@ -49,7 +49,7 @@ end
   I = ideal(R, [x^2*(x-1)-y^2, y^3*(x+y-6)])
   o = negdegrevlex(gens(R))
   G = standard_basis(I, ordering=o)
-  @test normal_form(x^5-5, I, o) == -5
+  @test normal_form(x^5-5, I, ordering=o) == -5
   u = negdegrevlex([x])*negdegrevlex([y])
   @test ideal_membership(x^4, I, ordering=u)
 end

--- a/test/Rings/groebner-test.jl
+++ b/test/Rings/groebner-test.jl
@@ -7,6 +7,12 @@
     I = ideal(R, [x])
     gb = f4(I)
     @test normal_form(y, I) == y
+    G = groebner_basis(I)
+    J = ideal(R, y)
+    @test reduce(J.gens, G) == [y]
+    J = ideal(R, x*y^2)
+    matrix, res = reduce_with_quotients(J.gens, G)
+    @test matrix * gens(G) + res == gens(J)
     I = ideal(R,[y^2 - x, x^3 - 2*y^2])
     @test is_groebner_basis(I.gens, ordering=degrevlex(R)) == true
     @test is_groebner_basis(I.gens, ordering=lex(R)) == false

--- a/test/Rings/groebner-test.jl
+++ b/test/Rings/groebner-test.jl
@@ -13,6 +13,11 @@
     J = ideal(R, x*y^2)
     matrix, res = reduce_with_quotients(J.gens, G)
     @test matrix * gens(G) + res == gens(J)
+    quots, res, units = reduce_with_quotients_and_units(J.gens, G)
+    @test matrix * gens(G) + res == units * gens(J)
+    @test reduce(y^3, [y^2 - x, x^3 - 2*y^2]) == x*y
+    @test reduce([y^3], [y^2 - x, x^3 - 2*y^2]) == [x*y]
+    @test reduce([y^3], [y^2 - x, x^3 - 2*y^2], ordering=lex(R)) == [y^3]
     I = ideal(R,[y^2 - x, x^3 - 2*y^2])
     @test is_groebner_basis(I.gens, ordering=degrevlex(R)) == true
     @test is_groebner_basis(I.gens, ordering=lex(R)) == false


### PR DESCRIPTION
As discussed with @ederc, this changes the normal form methods in `Rings/groebner.jl` to accept a monomial ordering keyword argument.