### PR TITLE
Standard basis fixes

### DIFF
--- a/docs/src/CommutativeAlgebra/groebner_bases.md
+++ b/docs/src/CommutativeAlgebra/groebner_bases.md
@@ -15,17 +15,23 @@ Pages = ["groebner_bases.md"]
 ## Computing Gröbner Bases
 
 ```@docs
-groebner_basis(I::MPolyIdeal; ordering::Symbol = :degrevlex, complete_reduction::Bool = false)
+groebner_basis(I::MPolyIdeal;
+	ordering::MonomialOrdering = default_ordering(base_ring(I)),
+	complete_reduction::Bool = false)
 ```
 ```@docs
-std_basis(I::MPolyIdeal, o::MonomialOrdering)
+standard_basis(I::MPolyIdeal,
+	ordering::MonomialOrdering = default_ordering(base_ring(I)),
+	complete_reduction::Bool = false)
 ```
 See e.g. [GP08](@cite) for the theoretical background on Gröbner- and standard bases.
 
 ### Gröbner Bases with transformation matrix
 
 ```@docs
-groebner_basis_with_transformation_matrix(I::MPolyIdeal; ordering::Symbol = :degrevlex, complete_reduction::Bool=false)
+groebner_basis_with_transformation_matrix(I::MPolyIdeal;
+	ordering::MonomialOrdering = default_ordering(base_ring(I)),
+	complete_reduction::Bool=false)
 ```
 
     fglm

--- a/docs/src/CommutativeAlgebra/groebner_bases.md
+++ b/docs/src/CommutativeAlgebra/groebner_bases.md
@@ -20,7 +20,7 @@ groebner_basis(I::MPolyIdeal;
 	complete_reduction::Bool = false)
 ```
 ```@docs
-standard_basis(I::MPolyIdeal,
+standard_basis(I::MPolyIdeal;
 	ordering::MonomialOrdering = default_ordering(base_ring(I)),
 	complete_reduction::Bool = false)
 ```

--- a/src/Modules/ModuleTypes.jl
+++ b/src/Modules/ModuleTypes.jl
@@ -186,7 +186,7 @@ end
 
 Data structure for submodules of free modules. `SubModuleOfFreeModule` shouldn't be
 used by the end user.
-When computed, a standard basis (computed via `std_basis()`) and generating matrix (that is the rows of the matrix
+When computed, a standard basis (computed via `standard_basis()`) and generating matrix (that is the rows of the matrix
 generate the submodule) (computed via `generator_matrix()`) are cached.
 """
 mutable struct SubModuleOfFreeModule{T} <: ModuleFP{T}

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -1,6 +1,6 @@
 export presentation, coords, coeffs, repres, cokernel, index_of_gen, sub,
       quo, presentation, present_as_cokernel, is_equal_with_morphism, 
-      std_basis, groebner_basis, reduced_groebner_basis, leading_module, 
+      standard_basis, groebner_basis, reduced_groebner_basis, leading_module, 
       reduce, hom_tensor, hom_product, coordinates, 
       represents_element, free_resolution, free_resolution_via_kernels,
       element_to_homomorphism, homomorphism_to_element, generator_matrix, 
@@ -1063,14 +1063,14 @@ function set_default_ordering!(M::SubModuleOfFreeModule, ord::ModuleOrdering)
 end
 
 @doc Markdown.doc"""
-    std_basis(submod::SubModuleOfFreeModule, ordering::ModuleOrdering = default_ordering(submod))
+    standard_basis(submod::SubModuleOfFreeModule, ordering::ModuleOrdering = default_ordering(submod))
 
 Compute a standard basis of `submod` with respect to the given `odering``.
 The return type is `ModuleGens`.
 """
-function std_basis(submod::SubModuleOfFreeModule, ordering::ModuleOrdering = default_ordering(submod))
+function standard_basis(submod::SubModuleOfFreeModule, ordering::ModuleOrdering = default_ordering(submod))
   gb = get!(submod.groebner_basis, ordering) do
-    return compute_std_basis(submod, ordering)
+    return compute_standard_basis(submod, ordering)
   end::ModuleGens
   return gb
 end
@@ -1083,7 +1083,7 @@ The ordering must be global. The return type is `ModuleGens`.
 """
 function groebner_basis(submod::SubModuleOfFreeModule, ordering::ModuleOrdering = default_ordering(submod))
   @assert is_global(ordering)
-  return std_basis(submod, ordering)
+  return standard_basis(submod, ordering)
 end
 
 @doc Markdown.doc"""
@@ -1095,32 +1095,32 @@ function reduced_groebner_basis(submod::SubModuleOfFreeModule, ordering::ModuleO
   @assert is_global(ordering)
 
   gb = get!(submod.groebner_basis, ordering) do
-    return compute_std_basis(submod, ordering, true)
+    return compute_standard_basis(submod, ordering, true)
   end::ModuleGens
   gb.is_reduced && return gb
   return get_attribute!(gb, :reduced_groebner_basis) do
-    return compute_std_basis(submod, ordering, true)
+    return compute_standard_basis(submod, ordering, true)
   end::ModuleGens
 end
 
 function leading_module(submod::SubModuleOfFreeModule, ordering::ModuleOrdering = default_ordering(submod))
-  gb = std_basis(submod, ordering)
+  gb = standard_basis(submod, ordering)
   return SubModuleOfFreeModule(submod.F, leading_monomials(gb))
 end
 
 @doc Markdown.doc"""
-    compute_std_basis(submod::SubModuleOfFreeModule, ordering::ModuleOrdering = default_ordering(submod), reduced::Bool=false)
+    compute_standard_basis(submod::SubModuleOfFreeModule, ordering::ModuleOrdering = default_ordering(submod), reduced::Bool=false)
 
 Compute a standard basis of `submod` with respect to the given ordering.
 Allowed orderings are those that are allowed as orderings for Singular polynomial rings.
 In case `reduced` is `true` and the ordering is global, a reduced Gröbner basis is computed.
 """
-function compute_std_basis(submod::SubModuleOfFreeModule, ordering::ModuleOrdering = default_ordering(submod), reduced::Bool=false)
+function compute_standard_basis(submod::SubModuleOfFreeModule, ordering::ModuleOrdering = default_ordering(submod), reduced::Bool=false)
   if reduced
     @assert is_global(ordering)
   end
   mg = ModuleGens(oscar_generators(submod.gens), submod.F , ordering)
-  gb = std_basis(mg, reduced)
+  gb = standard_basis(mg, reduced)
   oscar_assure(gb)
   gb.isGB = true
   gb.S.isGB = true
@@ -1718,12 +1718,12 @@ function set_default_ordering!(M::SubQuo, ord::ModuleOrdering)
   set_default_ordering!(M.sum, ord)
 end
 
-function std_basis(M::SubQuo, ord::ModuleOrdering = default_ordering(M))
+function standard_basis(M::SubQuo, ord::ModuleOrdering = default_ordering(M))
   if !haskey(M.groebner_basis, ord)
     if isdefined(M, :quo)
-      quo_gb = std_basis(M.quo, ord)
+      quo_gb = standard_basis(M.quo, ord)
       sub_union_gb_of_quo = SubModuleOfFreeModule(M.F, ModuleGens(vcat(M.sub.gens.O, quo_gb.O), M.F))
-      gb = compute_std_basis(sub_union_gb_of_quo, ord)
+      gb = compute_standard_basis(sub_union_gb_of_quo, ord)
       rel_gb_list = Vector{elem_type(ambient_free_module(M))}()
 
       for i in 1:length(gb.O)
@@ -1739,7 +1739,7 @@ function std_basis(M::SubQuo, ord::ModuleOrdering = default_ordering(M))
       rel_gb_ModuleGens.quo_GB = quo_gb
       M.groebner_basis[ord] = rel_gb_ModuleGens
     else
-      M.groebner_basis[ord] = std_basis(M.sub, ord)
+      M.groebner_basis[ord] = standard_basis(M.sub, ord)
     end
   end
   return M.groebner_basis[ord]
@@ -1747,7 +1747,7 @@ end
 
 function groebner_basis(M::SubQuo, ord::ModuleOrdering = default_ordering(M))
   @assert is_global(ord)
-  return std_basis(M, ord)
+  return standard_basis(M, ord)
 end
 
 function reduced_groebner_basis(M::SubQuo, ord::ModuleOrdering = default_ordering(M))
@@ -2436,13 +2436,13 @@ function Vector(v::SubQuoElem)
 end
 
 @doc Markdown.doc"""
-    std_basis(F::ModuleGens{T}, reduced::Bool=false) where {T <: MPolyElem}
+    standard_basis(F::ModuleGens{T}, reduced::Bool=false) where {T <: MPolyElem}
 
 Return a standard basis of `F` as an object of type `ModuleGens`.
 If `reduced` is set to `true` and the ordering of the underlying ring is global, 
 a reduced Gröbner basis is computed.
 """
-function std_basis(F::ModuleGens{T}, reduced::Bool=false) where {T <: MPolyElem}
+function standard_basis(F::ModuleGens{T}, reduced::Bool=false) where {T <: MPolyElem}
   singular_assure(F)
   if reduced
     @assert Singular.has_global_ordering(base_ring(F.SF))
@@ -3758,7 +3758,7 @@ Check if `a` is an element of `M`.
 """
 function in(a::FreeModElem, M::SubModuleOfFreeModule)
   F = ambient_free_module(M)
-  return iszero(reduce(a, std_basis(M, default_ordering(F))))
+  return iszero(reduce(a, standard_basis(M, default_ordering(F))))
 end
 
 @doc Markdown.doc"""
@@ -3860,7 +3860,7 @@ end
 function normal_form(M::SubModuleOfFreeModule{T}, N::SubModuleOfFreeModule{T}) where {T <: MPolyElem}
   @assert is_global(default_ordering(N))
   # TODO reduced flag to be implemented in Singular.jl
-  #return SubModuleOfFreeModule(M.F, normal_form(M.gens, std_basis(N), reduced = true))
+  #return SubModuleOfFreeModule(M.F, normal_form(M.gens, standard_basis(N), reduced = true))
   error("Not yet implemented")
 end
 

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -1095,11 +1095,11 @@ function reduced_groebner_basis(submod::SubModuleOfFreeModule, ordering::ModuleO
   @assert is_global(ordering)
 
   gb = get!(submod.groebner_basis, ordering) do
-    return compute_standard_basis(submod, ordering=ordering, true)
+    return compute_standard_basis(submod, ordering, true)
   end::ModuleGens
   gb.is_reduced && return gb
   return get_attribute!(gb, :reduced_groebner_basis) do
-    return compute_standard_basis(submod, ordering=ordering, true)
+    return compute_standard_basis(submod, ordering, true)
   end::ModuleGens
 end
 
@@ -1723,7 +1723,7 @@ function standard_basis(M::SubQuo; ordering::ModuleOrdering = default_ordering(M
     if isdefined(M, :quo)
       quo_gb = standard_basis(M.quo, ordering=ordering)
       sub_union_gb_of_quo = SubModuleOfFreeModule(M.F, ModuleGens(vcat(M.sub.gens.O, quo_gb.O), M.F))
-      gb = compute_standard_basis(sub_union_gb_of_quo, ordering=ordering)
+      gb = compute_standard_basis(sub_union_gb_of_quo, ordering)
       rel_gb_list = Vector{elem_type(ambient_free_module(M))}()
 
       for i in 1:length(gb.O)

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -1063,12 +1063,12 @@ function set_default_ordering!(M::SubModuleOfFreeModule, ord::ModuleOrdering)
 end
 
 @doc Markdown.doc"""
-    standard_basis(submod::SubModuleOfFreeModule, ordering::ModuleOrdering = default_ordering(submod))
+    standard_basis(submod::SubModuleOfFreeModule; ordering::ModuleOrdering = default_ordering(submod))
 
 Compute a standard basis of `submod` with respect to the given `odering``.
 The return type is `ModuleGens`.
 """
-function standard_basis(submod::SubModuleOfFreeModule, ordering::ModuleOrdering = default_ordering(submod))
+function standard_basis(submod::SubModuleOfFreeModule; ordering::ModuleOrdering = default_ordering(submod))
   gb = get!(submod.groebner_basis, ordering) do
     return compute_standard_basis(submod, ordering)
   end::ModuleGens
@@ -1076,14 +1076,14 @@ function standard_basis(submod::SubModuleOfFreeModule, ordering::ModuleOrdering 
 end
 
 @doc Markdown.doc"""
-    groebner_basis(submod::SubModuleOfFreeModule, ordering::ModuleOrdering = default_ordering(submod))
+    groebner_basis(submod::SubModuleOfFreeModule; ordering::ModuleOrdering = default_ordering(submod))
 
 Compute a Gröbner of `submod` with respect to the given `ordering`.
 The ordering must be global. The return type is `ModuleGens`.
 """
 function groebner_basis(submod::SubModuleOfFreeModule, ordering::ModuleOrdering = default_ordering(submod))
   @assert is_global(ordering)
-  return standard_basis(submod, ordering)
+  return standard_basis(submod, ordering=ordering)
 end
 
 @doc Markdown.doc"""
@@ -1095,16 +1095,16 @@ function reduced_groebner_basis(submod::SubModuleOfFreeModule, ordering::ModuleO
   @assert is_global(ordering)
 
   gb = get!(submod.groebner_basis, ordering) do
-    return compute_standard_basis(submod, ordering, true)
+    return compute_standard_basis(submod, ordering=ordering, true)
   end::ModuleGens
   gb.is_reduced && return gb
   return get_attribute!(gb, :reduced_groebner_basis) do
-    return compute_standard_basis(submod, ordering, true)
+    return compute_standard_basis(submod, ordering=ordering, true)
   end::ModuleGens
 end
 
 function leading_module(submod::SubModuleOfFreeModule, ordering::ModuleOrdering = default_ordering(submod))
-  gb = standard_basis(submod, ordering)
+  gb = standard_basis(submod, ordering=ordering)
   return SubModuleOfFreeModule(submod.F, leading_monomials(gb))
 end
 
@@ -1718,12 +1718,12 @@ function set_default_ordering!(M::SubQuo, ord::ModuleOrdering)
   set_default_ordering!(M.sum, ord)
 end
 
-function standard_basis(M::SubQuo, ord::ModuleOrdering = default_ordering(M))
-  if !haskey(M.groebner_basis, ord)
+function standard_basis(M::SubQuo; ordering::ModuleOrdering = default_ordering(M))
+  if !haskey(M.groebner_basis, ordering)
     if isdefined(M, :quo)
-      quo_gb = standard_basis(M.quo, ord)
+      quo_gb = standard_basis(M.quo, ordering=ordering)
       sub_union_gb_of_quo = SubModuleOfFreeModule(M.F, ModuleGens(vcat(M.sub.gens.O, quo_gb.O), M.F))
-      gb = compute_standard_basis(sub_union_gb_of_quo, ord)
+      gb = compute_standard_basis(sub_union_gb_of_quo, ordering=ordering)
       rel_gb_list = Vector{elem_type(ambient_free_module(M))}()
 
       for i in 1:length(gb.O)
@@ -1735,19 +1735,19 @@ function standard_basis(M::SubQuo, ord::ModuleOrdering = default_ordering(M))
 
       rel_gb_ModuleGens = ModuleGens(rel_gb_list, M.F)
       rel_gb_ModuleGens.isGB = true
-      rel_gb_ModuleGens.ordering = ord
+      rel_gb_ModuleGens.ordering = ordering
       rel_gb_ModuleGens.quo_GB = quo_gb
-      M.groebner_basis[ord] = rel_gb_ModuleGens
+      M.groebner_basis[ordering] = rel_gb_ModuleGens
     else
-      M.groebner_basis[ord] = standard_basis(M.sub, ord)
+      M.groebner_basis[ordering] = standard_basis(M.sub, ordering=ordering)
     end
   end
-  return M.groebner_basis[ord]
+  return M.groebner_basis[ordering]
 end
 
-function groebner_basis(M::SubQuo, ord::ModuleOrdering = default_ordering(M))
+function groebner_basis(M::SubQuo; ordering::ModuleOrdering = default_ordering(M))
   @assert is_global(ord)
-  return standard_basis(M, ord)
+  return standard_basis(M, ordering=ordering)
 end
 
 function reduced_groebner_basis(M::SubQuo, ord::ModuleOrdering = default_ordering(M))

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -3758,7 +3758,7 @@ Check if `a` is an element of `M`.
 """
 function in(a::FreeModElem, M::SubModuleOfFreeModule)
   F = ambient_free_module(M)
-  return iszero(reduce(a, standard_basis(M, default_ordering(F))))
+  return iszero(reduce(a, standard_basis(M, ordering=default_ordering(F))))
 end
 
 @doc Markdown.doc"""

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -1746,7 +1746,7 @@ function standard_basis(M::SubQuo; ordering::ModuleOrdering = default_ordering(M
 end
 
 function groebner_basis(M::SubQuo; ordering::ModuleOrdering = default_ordering(M))
-  @assert is_global(ord)
+  @assert is_global(ordering)
   return standard_basis(M, ordering=ordering)
 end
 

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -509,7 +509,7 @@ function normal_form(A::Vector{T}, J::MPolyIdeal) where { T <: MPolyElem }
 end
 
 function normal_form(f::MPolyElem, J::MPolyIdeal, o::MonomialOrdering)
-  stdJ = standard_basis(J, o, false)
+  stdJ = standard_basis(J, ordering=o, complete_reduction=false)
   Sx = stdJ.Sx
   Ox = parent(f)
   I = Singular.Ideal(Sx, Sx(f))

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -50,7 +50,7 @@ function groebner_assure(I::MPolyIdeal, ordering::MonomialOrdering, complete_red
 end
 
 @doc Markdown.doc"""
-    _compute_standard_basis(B::IdealGens, ordering::MonomialOrdering,
+    _compute_standard_basis(B::IdealGens; ordering::MonomialOrdering,
                             complete_reduction::Bool = false)
 
 **Note**: Internal function, subject to change, do not use.
@@ -96,7 +96,7 @@ end
 
 # standard basis for non-global orderings #############################
 @doc Markdown.doc"""
-    standard_basis(I::MPolyIdeal,
+    standard_basis(I::MPolyIdeal;
       ordering::MonomialOrdering = default_ordering(base_ring(I)),
       complete_reduction::Bool = false)
 
@@ -114,7 +114,7 @@ julia> R,(x,y) = PolynomialRing(QQ, ["x","y"])
 julia> I = ideal([x*(x+1), x^2-y^2+(x-2)*y])
 ideal(x^2 + x, x^2 + x*y - y^2 - 2*y)
 
-julia> standard_basis(I, negdegrevlex(gens(R)))
+julia> standard_basis(I, ordering=negdegrevlex(gens(R)))
 Standard basis with elements
 1 -> x
 2 -> y
@@ -122,7 +122,7 @@ with respect to the ordering
 negdegrevlex([x, y])
 ```
 """
-function standard_basis(I::MPolyIdeal, ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool = false)
+function standard_basis(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool = false)
   complete_reduction && @assert is_global(ordering)
   if !haskey(I.gb, ordering)
     I.gb[ordering] = _compute_standard_basis(I.gens, ordering, complete_reduction)
@@ -158,7 +158,7 @@ lex([x, y])
 """
 function groebner_basis(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool=false)
     is_global(ordering) || error("Ordering must be global")
-    return standard_basis(I, ordering, complete_reduction)
+    return standard_basis(I, ordering=ordering, complete_reduction=complete_reduction)
 end
 
 @doc Markdown.doc"""

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -21,9 +21,9 @@ julia> R,(x,y) = PolynomialRing(QQ, ["x","y"])
 julia> I = ideal([x*y-3*x,y^3-2*x^2*y])
 ideal(x*y - 3*x, -2*x^2*y + y^3)
 
-julia> Oscar.groebner_assure(I, degrevlex(gens(R)));
+julia> Oscar.groebner_assure(I, degrevlex(R));
 
-julia> I.gb[degrevlex(gens(R))]
+julia> I.gb[degrevlex(R)]
 Gröbner basis with elements
 1 -> x*y - 3*x
 2 -> y^3 - 6*x^2
@@ -70,7 +70,7 @@ Ideal generating system with elements
 1 -> x*y - 3*x
 2 -> -2*x^2*y + y^3
 
-julia> B = Oscar._compute_standard_basis(A, degrevlex(gens(R)))
+julia> B = Oscar._compute_standard_basis(A, degrevlex(R))
 Gröbner basis with elements
 1 -> x*y - 3*x
 2 -> y^3 - 6*x^2
@@ -114,7 +114,7 @@ julia> R,(x,y) = PolynomialRing(QQ, ["x","y"])
 julia> I = ideal([x*(x+1), x^2-y^2+(x-2)*y])
 ideal(x^2 + x, x^2 + x*y - y^2 - 2*y)
 
-julia> standard_basis(I, ordering=negdegrevlex(gens(R)))
+julia> standard_basis(I, ordering=negdegrevlex(R))
 Standard basis with elements
 1 -> x
 2 -> y
@@ -147,7 +147,7 @@ julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 julia> I = ideal([x*y-3*x,y^3-2*x^2*y])
 ideal(x*y - 3*x, -2*x^2*y + y^3)
 
-julia> H = groebner_basis(I, ordering=lex(gens(R)))
+julia> H = groebner_basis(I, ordering=lex(R))
 Gröbner basis with elements
 1 -> y^4 - 3*y^3
 2 -> x*y - 3*x
@@ -248,7 +248,7 @@ Ideal generating system with elements
 1 -> x*y - 3*x
 2 -> -2*x^2*y + y^3
 
-julia> B,m = Oscar.groebner_basis_with_transform(A, degrevlex(gens(R)))
+julia> B,m = Oscar.groebner_basis_with_transform(A, degrevlex(R))
 (Ideal generating system with elements
 1 -> x*y - 3*x
 2 -> -6*x^2 + y^3
@@ -343,10 +343,10 @@ w.r.t. the given monomial ordering.
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
 
-julia> L = leading_ideal([x*y^2-3*x, x^3-14*y^5], ordering=degrevlex(gens(R)))
+julia> L = leading_ideal([x*y^2-3*x, x^3-14*y^5], ordering=degrevlex(R))
 ideal(x*y^2, y^5)
 
-julia> L = leading_ideal([x*y^2-3*x, x^3-14*y^5], ordering=lex(gens(R)))
+julia> L = leading_ideal([x*y^2-3*x, x^3-14*y^5], ordering=lex(R))
 ideal(x*y^2, x^3)
 ```
 """
@@ -377,10 +377,10 @@ julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
 julia> I = ideal(R,[x*y^2-3*x, x^3-14*y^5])
 ideal(x*y^2 - 3*x, x^3 - 14*y^5)
 
-julia> L = leading_ideal(I, ordering=degrevlex(gens(R)))
+julia> L = leading_ideal(I, ordering=degrevlex(R))
 ideal(x*y^2, x^4, y^5)
 
-julia> L = leading_ideal(I, ordering=lex(gens(R)))
+julia> L = leading_ideal(I, ordering=lex(R))
 ideal(y^7, x*y^2, x^3)
 ```
 """

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -947,7 +947,7 @@ false
 ```
 """
 function ideal_membership(f::T, I::MPolyIdeal{T}; ordering::MonomialOrdering = default_ordering(base_ring(I))) where T
-  GI = std_basis(I, ordering, false)
+  GI = standard_basis(I, ordering, false)
   singular_assure(GI)
   Sx = base_ring(GI.S)
   return Singular.iszero(Singular.reduce(Sx(f), GI.S))

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -947,7 +947,7 @@ false
 ```
 """
 function ideal_membership(f::T, I::MPolyIdeal{T}; ordering::MonomialOrdering = default_ordering(base_ring(I))) where T
-  GI = standard_basis(I, ordering, false)
+  GI = standard_basis(I, ordering=ordering, complete_reduction=false)
   singular_assure(GI)
   Sx = base_ring(GI.S)
   return Singular.iszero(Singular.reduce(Sx(f), GI.S))

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -1788,7 +1788,7 @@ function Base.in(
   # We have to call for that groebner basis once manually. 
   # Otherwise the ideal membership will complain about the ordering not being global.
   o = negdegrevlex(gens(R))
-  standard_basis(Is, o)
+  standard_basis(Is, ordering=o)
   return ideal_membership(shift(numerator(a)), Is, ordering=o)
 end
 
@@ -1950,7 +1950,7 @@ function Base.in(
   o = ordering(inverted_set(parent(a)))
   # We have to call for that groebner basis once manually. 
   # Otherwise the ideal membership will complain about the ordering not being global.
-  standard_basis(J, o)
+  standard_basis(J, ordering=o)
   return ideal_membership(p, J, ordering=o)
 end
 

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -1788,7 +1788,7 @@ function Base.in(
   # We have to call for that groebner basis once manually. 
   # Otherwise the ideal membership will complain about the ordering not being global.
   o = negdegrevlex(gens(R))
-  std_basis(Is, o)
+  standard_basis(Is, o)
   return ideal_membership(shift(numerator(a)), Is, ordering=o)
 end
 
@@ -1950,7 +1950,7 @@ function Base.in(
   o = ordering(inverted_set(parent(a)))
   # We have to call for that groebner basis once manually. 
   # Otherwise the ideal membership will complain about the ordering not being global.
-  std_basis(J, o)
+  standard_basis(J, o)
   return ideal_membership(p, J, ordering=o)
 end
 

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -300,8 +300,8 @@ end
 	lp = lex(gens(base_ring(F)))*lex(gens(F))
 
 	J = SubQuo(F, [(x[1]+x[2]+R(1))*F[1], (x[1]+x[2]+2*x[3]+2*x[4]+1)*F[1],(x[1]+x[2]+x[3]+x[4]+1)*F[1]])
-	@test reduced_groebner_basis(J, ordering=lp).O == Oscar.ModuleGens([(x[3]+x[4])*F[1], (x[1]+x[2]+1)*F[1]], F).O
-	@test haskey(J.groebner_basis, ordering=lp)
+	@test reduced_groebner_basis(J, lp).O == Oscar.ModuleGens([(x[3]+x[4])*F[1], (x[1]+x[2]+1)*F[1]], F).O
+	@test haskey(J.groebner_basis, lp)
 
 	R, (x,y) = PolynomialRing(QQ, ["x", "y"])
 	F = FreeMod(R, 1)

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -300,8 +300,8 @@ end
 	lp = lex(gens(base_ring(F)))*lex(gens(F))
 
 	J = SubQuo(F, [(x[1]+x[2]+R(1))*F[1], (x[1]+x[2]+2*x[3]+2*x[4]+1)*F[1],(x[1]+x[2]+x[3]+x[4]+1)*F[1]])
-	@test reduced_groebner_basis(J, lp).O == Oscar.ModuleGens([(x[3]+x[4])*F[1], (x[1]+x[2]+1)*F[1]], F).O
-	@test haskey(J.groebner_basis, lp)
+	@test reduced_groebner_basis(J, ordering=lp).O == Oscar.ModuleGens([(x[3]+x[4])*F[1], (x[1]+x[2]+1)*F[1]], F).O
+	@test haskey(J.groebner_basis, ordering=lp)
 
 	R, (x,y) = PolynomialRing(QQ, ["x", "y"])
 	F = FreeMod(R, 1)

--- a/test/Rings/groebner-test.jl
+++ b/test/Rings/groebner-test.jl
@@ -35,7 +35,7 @@ end
    M = matrix_ordering([x, y, z], [1 1 1; 0 1 0; 1 0 0])
    @test gens(groebner_basis(I, ordering = M)) == [ x + y + z, 2*x^2 + 2*x*z + z^3 + z^2 ]
    @test_throws ErrorException groebner_basis(I, ordering = negdeglex([x, y, z]))
-   @test gens(standard_basis(I, negdeglex([x, y, z]))) == [ x + y + z, 2*y^2 + 2*y*z + z^3 + z^2 ]
+   @test gens(standard_basis(I, ordering=negdeglex([x, y, z]))) == [ x + y + z, 2*y^2 + 2*y*z + z^3 + z^2 ]
 
    @test groebner_basis_with_transformation_matrix(I, ordering=lex([x])*lex([y,z])) == groebner_basis_with_transformation_matrix(I, ordering=lex([x, y, z]))
    @test groebner_basis_with_transformation_matrix(I, ordering=lex([z])*lex([y])*lex([x])) == groebner_basis_with_transformation_matrix(I, ordering=revlex([x, y, z]))

--- a/test/Rings/groebner-test.jl
+++ b/test/Rings/groebner-test.jl
@@ -35,7 +35,7 @@ end
    M = matrix_ordering([x, y, z], [1 1 1; 0 1 0; 1 0 0])
    @test gens(groebner_basis(I, ordering = M)) == [ x + y + z, 2*x^2 + 2*x*z + z^3 + z^2 ]
    @test_throws ErrorException groebner_basis(I, ordering = negdeglex([x, y, z]))
-   @test gens(std_basis(I, negdeglex([x, y, z]))) == [ x + y + z, 2*y^2 + 2*y*z + z^3 + z^2 ]
+   @test gens(standard_basis(I, negdeglex([x, y, z]))) == [ x + y + z, 2*y^2 + 2*y*z + z^3 + z^2 ]
 
    @test groebner_basis_with_transformation_matrix(I, ordering=lex([x])*lex([y,z])) == groebner_basis_with_transformation_matrix(I, ordering=lex([x, y, z]))
    @test groebner_basis_with_transformation_matrix(I, ordering=lex([z])*lex([y])*lex([x])) == groebner_basis_with_transformation_matrix(I, ordering=revlex([x, y, z]))
@@ -48,7 +48,7 @@ end
   R, (x, y) = QQ["x", "y"]
   I = ideal(R, [x^2*(x-1)-y^2, y^3*(x+y-6)])
   o = negdegrevlex(gens(R))
-  G = std_basis(I, o)
+  G = standard_basis(I, o)
   @test normal_form(x^5-5, I, o) == -5
   u = negdegrevlex([x])*negdegrevlex([y])
   @test ideal_membership(x^4, I, ordering=u)

--- a/test/Rings/groebner-test.jl
+++ b/test/Rings/groebner-test.jl
@@ -48,7 +48,7 @@ end
   R, (x, y) = QQ["x", "y"]
   I = ideal(R, [x^2*(x-1)-y^2, y^3*(x+y-6)])
   o = negdegrevlex(gens(R))
-  G = standard_basis(I, o)
+  G = standard_basis(I, ordering=o)
   @test normal_form(x^5-5, I, o) == -5
   u = negdegrevlex([x])*negdegrevlex([y])
   @test ideal_membership(x^4, I, ordering=u)


### PR DESCRIPTION
1. Renames `std_basis` to `standard_basis`.
2. Adds `ordering` and `complete_reduction` as kwargs to `standard_basis` in order to conform with the conventions for monomial ordering dependent user functions.