### PR TITLE
Agnostic saturated_ideal and related user facing adjustments

### DIFF
--- a/experimental/Schemes/AffineSchemes.jl
+++ b/experimental/Schemes/AffineSchemes.jl
@@ -44,6 +44,7 @@ polynomial ring ``P = 𝕜[x₁,…,xₙ]`` with natural coercion
 ring ``S`` and any homomorphism ``φ : R → S`` there is a morphism 
 ``ψ : P → S`` factoring through ``φ`` and such that ``φ`` 
 is uniquely determined by ``ψ``.
+For simplicity of use, ambient_ring(R) also returns ambient_ring(Spec(R)).
 """
 function ambient_ring(X::AbsSpec)
   return ambient_ring(underlying_scheme(X))::MPolyRing
@@ -202,7 +203,10 @@ ambient_ring(X::Spec{<:Any, <:MPolyQuo}) = base_ring(OO(X))
 ambient_ring(X::Spec{<:Any, <:MPolyLocalizedRing}) = base_ring(OO(X))
 ambient_ring(X::Spec{<:Any, <:MPolyQuoLocalizedRing}) = base_ring(OO(X))
 ambient_ring(X::Spec{T, T}) where {T<:Field} = base_ring(X)
-
+ambient_ring(R::MPolyRing) = R
+ambient_ring(R::MPolyQuo) = base_ring(R)
+ambient_ring(R::MPolyLocalizedRing) = base_ring(R)
+ambient_ring(R::MPolyQuoLocalizedRing) = base_ring(R)
 
 @attr String function name(X::Spec)
   return "unnamed affine variety"

--- a/experimental/Schemes/AffineSchemes.jl
+++ b/experimental/Schemes/AffineSchemes.jl
@@ -1,7 +1,7 @@
 import AbstractAlgebra.Ring
 import Base: intersect
 
-export OO, defining_ideal, ambient_ring
+export OO, defining_ideal, ambient_ring, ideal_in_ambient_ring
 export spec_type, ring_type
 export base_ring_type, base_ring_elem_type, poly_type, poly_ring_type, mult_set_type, ring_type
 export affine_space, empty_spec
@@ -207,6 +207,7 @@ ambient_ring(R::MPolyRing) = R
 ambient_ring(R::MPolyQuo) = base_ring(R)
 ambient_ring(R::MPolyLocalizedRing) = base_ring(R)
 ambient_ring(R::MPolyQuoLocalizedRing) = base_ring(R)
+ideal_in_ambient_ring(X::AbsSpec) = saturated_ideal(modulus(OO(X)))
 
 @attr String function name(X::Spec)
   return "unnamed affine variety"

--- a/experimental/Schemes/singular_locus.jl
+++ b/experimental/Schemes/singular_locus.jl
@@ -3,12 +3,12 @@ export singular_locus, singular_locus_reduced
 export reduced_scheme
 export is_smooth
 
-MPAnyQuoRing = Union{MPolyQuoLocalizedRing, 
-                MPolyQuo
-               }
-
-MPAnyNonQuoRing = Union{MPolyRing, MPolyLocalizedRing
-                  }
+#MPAnyQuoRing = Union{MPolyQuoLocalizedRing, 
+#                MPolyQuo
+#               }
+#
+#MPAnyNonQuoRing = Union{MPolyRing, MPolyLocalizedRing
+#                  }
 
 ### TODO: The following two functions need to be made type-sensitive 
 ###       and reduced=true needs to be set automatically for varieties 

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -35,6 +35,8 @@ Base.getindex(Q::MPolyQuo, i::Int) = Q(Q.R[i])
 base_ring(W::MPolyQuo) = W.R
 coefficient_ring(W::MPolyQuo) = coefficient_ring(base_ring(W))
 modulus(W::MPolyQuo) = W.I
+# for convenience of the scripting user make modulus agnostic
+modulus(W::MPAnyNonQuoRing) = ideal(W,[zero(W)])
 
 default_ordering(Q::MPolyQuo) = default_ordering(base_ring(Q))
 

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -36,7 +36,7 @@ base_ring(W::MPolyQuo) = W.R
 coefficient_ring(W::MPolyQuo) = coefficient_ring(base_ring(W))
 modulus(W::MPolyQuo) = W.I
 # for convenience of the scripting user make modulus agnostic
-modulus(W::MPAnyNonQuoRing) = ideal(W,[zero(W)])
+modulus(W::MPolyRing) = ideal(W,[zero(W)])
 
 default_ordering(Q::MPolyQuo) = default_ordering(base_ring(Q))
 

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -35,8 +35,6 @@ Base.getindex(Q::MPolyQuo, i::Int) = Q(Q.R[i])
 base_ring(W::MPolyQuo) = W.R
 coefficient_ring(W::MPolyQuo) = coefficient_ring(base_ring(W))
 modulus(W::MPolyQuo) = W.I
-# for convenience of the scripting user make modulus agnostic
-modulus(W::MPolyRing) = ideal(W,[zero(W)])
 
 default_ordering(Q::MPolyQuo) = default_ordering(base_ring(Q))
 

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -1575,11 +1575,11 @@ function saturated_ideal(
     L = base_ring(I)
     R = base_ring(base_ring(I))
     result=ideal(R,[one(R)])
-    if !all(x->iszero(evaluate(x, point_coordinates(inverted_set(L)))), gens(I)) 
+    J = pre_saturated_ideal(I)
+    if !all(x->iszero(evaluate(x, point_coordinates(inverted_set(L)))), gens(J))
       I.saturated_ideal = result
       return result
     end
-    J = pre_saturated_ideal(I)
     pdec = primary_decomposition(J)
     for (Q, P) in pdec
       if all(x->iszero(evaluate(x, point_coordinates(inverted_set(L)))), gens(P))
@@ -1604,7 +1604,7 @@ function saturated_ideal(
     R = base_ring(L)
     result = ideal(R, [one(R)])
     U = inverted_set(base_ring(I))
-    if !issubset(I,L(prime_ideal(U)))
+    if one(L) in I+L(prime_ideal(U))
       I.saturated_ideal = result
       return result
     end

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -162,10 +162,6 @@ function modulus(L::MPolyQuoLocalizedRing)
   return get_attribute(L, :modulus)::ideal_type(localized_ring_type(L))
 end
 
-### for compatibility -- also provide modulus in the trivial case
-modulus(R::MPolyLocalizedRing)=ideal(R,[zero(R)])
-
-
 @Markdown.doc """
     quotient_ring(L::MPolyQuoLocalizedRing)
 

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -1402,6 +1402,8 @@ function saturated_ideal(I::MPolyQuoLocalizedIdeal)
   return saturated_ideal(pre_image_ideal(I))
 end
 
+# for convenience of the scripting user
+saturated_ideal(I::MPolyQuoIdeal) = pre_image_ideal(I)
 
 ### Conversion of ideals in the original ring to localized ideals
 function (W::MPolyQuoLocalizedRing{BRT, BRET, RT, RET, MST})(I::MPolyIdeal{RET}) where {BRT, BRET, RT, RET, MST}

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -121,6 +121,14 @@ multiplicative set ``S ⊂ P`` of type `MultSetType`.
   end
 end
 
+### for convenience of later use
+MPAnyQuoRing = Union{MPolyQuoLocalizedRing, 
+                MPolyQuo
+               }
+
+MPAnyNonQuoRing = Union{MPolyRing, MPolyLocalizedRing
+                  }
+
 ### type getters 
 coefficient_ring_type(::Type{MPolyQuoLocalizedRing{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST} = BRT
 coefficient_ring_type(L::MPolyQuoLocalizedRing{BRT, BRET, RT, RET, MST}) where {BRT, BRET, RT, RET, MST} = coefficient_ring_type(typeof(L))
@@ -161,6 +169,8 @@ function modulus(L::MPolyQuoLocalizedRing)
   end
   return get_attribute(L, :modulus)::ideal_type(localized_ring_type(L))
 end
+# for convenience of the scripting user make modulus agnostic
+modulus(W::MPAnyNonQuoRing) = ideal(W,[zero(W)])
 
 @Markdown.doc """
     quotient_ring(L::MPolyQuoLocalizedRing)

--- a/test/Rings/MPolyQuo_test.jl
+++ b/test/Rings/MPolyQuo_test.jl
@@ -124,3 +124,29 @@ end
   J2 = ideal(A, [A(z*y)])
   @test !is_prime(J2)
 end
+
+@testset "modulus - MPAnyQuoRing MPAnyNonQuoRing" begin
+  R, (x,y,z) = QQ["x", "y", "z"]
+  I = ideal(R, [x+y+z])
+  A, _ = quo(R,I)
+  @test modulus(R) == ideal(R,[zero(R)])
+  @test modulus(A) == I
+  U=MPolyComplementOfKPointIdeal(R,[0,0,0])
+  Rl,_ = Localization(R,U)
+  Il = Rl(I)
+  Al, _ = quo(Rl, Il)
+  @test modulus(Rl) == ideal(Rl,[zero(Rl)])
+  @test modulus(Al) == Il
+  U2=MPolyComplementOfPrimeIdeal(ideal(R,[x^2+1,y^2+1,z]))
+  Rl2,_ = Localization(R,U2)
+  Il2 = Rl2(I)
+  Al2,_ = quo(Rl2,Il2)
+  @test modulus(Rl2) == ideal(Rl2,[zero(Rl2)])
+  @test modulus(Al2) == Il2
+  U3=MPolyPowersOfElement(x+y)
+  Rl3,_ = Localization(R,U3)
+  Il3 = Rl3(I)
+  Al3,_ = quo(Rl3,Il3)
+  @test modulus(Rl3) == ideal(Rl3,[zero(Rl3)])
+  @test modulus(Al3) == Il3
+end

--- a/test/Rings/mpoly-localizations.jl
+++ b/test/Rings/mpoly-localizations.jl
@@ -314,6 +314,8 @@ end
   J_sat = ideal(R,[(x^2+(y^2+1)^2)])
   @test saturated_ideal(J) == J_sat
   @test_throws ErrorException("no transition matrix available using local orderings") saturated_ideal(L(J_sat); with_generator_transition=true)
+  JJ = ideal(R, [y*(x^2+(y^2+1)^2)])
+  @test saturated_ideal(JJ) == JJ
 end
 
 @testset "zero divisors" begin
@@ -340,8 +342,8 @@ end
   Z4x, (x, y) = Z4["x", "y"]
   f = 2*x
   @test is_zero_divisor(Z4(2))
-  @test is_zero_divisor(Z4x(2))
-  @test is_zero_divisor(f)
+  @test_broken is_zero_divisor(Z4x(2))
+  @test_broken is_zero_divisor(f)
   # At the moment, the Singular backend complains when the modulus of the coefficient 
   # ring is not a prime. So we leave the following tests out for the time being. 
 #  L, _ = localization(Z4x, Z4x(x))

--- a/test/Rings/mpoly-localizations.jl
+++ b/test/Rings/mpoly-localizations.jl
@@ -351,7 +351,8 @@ end
   @test is_zero_divisor(2*L(x))
   @test is_zero_divisor(zero(L))
   # At the moment, the Singular backend complains when the modulus of the coefficient 
-  # ring is not a prime. So we leave the following tests out for the time being. #  I = ideal(Z4x, x*y)
+  # ring is not a prime. So we leave the following tests out for the time being. 
+#  I = ideal(Z4x, x*y)
 #  A, _ = quo(Z4x, I)
 #  @test !is_zero_divisor(A(x+y))
 #  @test is_zero_divisor(2*A(x+y))

--- a/test/Rings/mpoly-localizations.jl
+++ b/test/Rings/mpoly-localizations.jl
@@ -342,17 +342,16 @@ end
   Z4x, (x, y) = Z4["x", "y"]
   f = 2*x
   @test is_zero_divisor(Z4(2))
-  @test_broken is_zero_divisor(Z4x(2))
-  @test_broken is_zero_divisor(f)
+  @test is_zero_divisor(Z4x(2))
+  @test is_zero_divisor(f)
+  L, _ = localization(Z4x, Z4x(x))
+  @test !is_zero_divisor(L(5))
+  @test is_zero_divisor(L(2))
+  @test !is_zero_divisor(L(x))
+  @test is_zero_divisor(2*L(x))
+  @test is_zero_divisor(zero(L))
   # At the moment, the Singular backend complains when the modulus of the coefficient 
-  # ring is not a prime. So we leave the following tests out for the time being. 
-#  L, _ = localization(Z4x, Z4x(x))
-#  @test !is_zero_divisor(L(5))
-#  @test is_zero_divisor(L(2))
-#  @test !is_zero_divisor(L(x))
-#  @test is_zero_divisor(2*L(x))
-#  @test is_zero_divisor(zero(L))
-#  I = ideal(Z4x, x*y)
+  # ring is not a prime. So we leave the following tests out for the time being. #  I = ideal(Z4x, x*y)
 #  A, _ = quo(Z4x, I)
 #  @test !is_zero_divisor(A(x+y))
 #  @test is_zero_divisor(2*A(x+y))

--- a/test/Schemes/AffineSchemes.jl
+++ b/test/Schemes/AffineSchemes.jl
@@ -161,7 +161,7 @@ end
 
 @testset "ambient_ring -- case test" begin
   R, (x,y,z) = QQ["x", "y", "z"]
-  I = ideal(R, [x+y+z])
+  I = ideal(R, [x^2-y^2+z])
   A, _ = quo(R,I)
   U=MPolyComplementOfKPointIdeal(R,[0,0,0])
   Rl,_ = Localization(R,U)
@@ -179,16 +179,24 @@ end
   @test ambient_ring(Spec(R)) == R
   @test ambient_ring(A) == R
   @test ambient_ring(Spec(A)) == R
+  @test ideal_in_ambient_ring(Spec(R)) == ideal(R,[zero(R)])
+  @test ideal_in_ambient_ring(Spec(A)) == I
   @test ambient_ring(Rl) == R
   @test ambient_ring(Spec(Rl)) == R
   @test ambient_ring(Al) == R
   @test ambient_ring(Spec(Al)) == R
+  @test ideal_in_ambient_ring(Spec(Rl)) == ideal(R,[zero(R)])
+  @test ideal_in_ambient_ring(Spec(Al)) == I
   @test ambient_ring(Rl2) == R
   @test ambient_ring(Spec(Rl2)) == R
   @test ambient_ring(Al2) == R
   @test ambient_ring(Spec(Al2)) == R
+  @test ideal_in_ambient_ring(Spec(Rl2)) == ideal(R,[zero(R)])
+  @test ideal_in_ambient_ring(Spec(Al2)) == I
   @test ambient_ring(Rl3) == R
   @test ambient_ring(Spec(Rl3)) == R
   @test ambient_ring(Al3) == R
   @test ambient_ring(Spec(Al3)) == R
+  @test ideal_in_ambient_ring(Spec(Rl3)) == ideal(R,[zero(R)])
+  @test ideal_in_ambient_ring(Spec(Al3)) == I
 end

--- a/test/Schemes/AffineSchemes.jl
+++ b/test/Schemes/AffineSchemes.jl
@@ -158,3 +158,37 @@ end
   fib = subscheme(Spec(A), ideal(A, [a[2]-a[4]]))
   @test fib==Z
 end
+
+@testset "ambient_ring -- case test" begin
+  R, (x,y,z) = QQ["x", "y", "z"]
+  I = ideal(R, [x+y+z])
+  A, _ = quo(R,I)
+  U=MPolyComplementOfKPointIdeal(R,[0,0,0])
+  Rl,_ = Localization(R,U)
+  Il = Rl(I)
+  Al, _ = quo(Rl, Il)
+  U2=MPolyComplementOfPrimeIdeal(ideal(R,[x^2+1,y^2+1,z]))
+  Rl2,_ = Localization(R,U2)
+  Il2 = Rl2(I)
+  Al2,_ = quo(Rl2,Il2)
+  U3=MPolyPowersOfElement(x+y)
+  Rl3,_ = Localization(R,U3)
+  Il3 = Rl3(I)
+  Al3,_ = quo(Rl3,Il3)
+  @test ambient_ring(R) == R
+  @test ambient_ring(Spec(R)) == R
+  @test ambient_ring(A) == R
+  @test ambient_ring(Spec(A)) == R
+  @test ambient_ring(Rl) == R
+  @test ambient_ring(Spec(Rl)) == R
+  @test ambient_ring(Al) == R
+  @test ambient_ring(Spec(Al)) == R
+  @test ambient_ring(Rl2) == R
+  @test ambient_ring(Spec(Rl2)) == R
+  @test ambient_ring(Al2) == R
+  @test ambient_ring(Spec(Al2)) == R
+  @test ambient_ring(Rl3) == R
+  @test ambient_ring(Spec(Rl3)) == R
+  @test ambient_ring(Al3) == R
+  @test ambient_ring(Spec(Al3)) == R
+end


### PR DESCRIPTION
For the convenience of the scripting user:
- modulus returns zero ideal instead of throwing an error for non-quo rings
- ambient_ring also works for rings, not just Specs (and ambient_ring of a polynomial ring is the ring itself, not the coefficient field)
- saturated_ideal returns the ideal itself for non-localized rings instead of throwing an error
- ideal_in_ambient_ring introduced 