### PR TITLE
Finitely Presented Algebras, not 'Represented'

### DIFF
--- a/docs/doc.main
+++ b/docs/doc.main
@@ -179,7 +179,7 @@
      ]
   ],
 
- "Finitely Represented Algebras" => [
+ "Finitely Presented Algebras" => [
     "NoncommutativeAlgebra/intro.md",
     "PBW-Algebras" => [
     "NoncommutativeAlgebra/PBWAlgebras/intro.md",


### PR DESCRIPTION
I think this is a typo, but am not 100% sure, so I hope @wdecker can clarify either way...

As it is, isn't the idea to talk in this chapter about finitely *presented* algebras (so given as a quotient of a finitely generated free associative algebra by a finitely generated ideal). While "represented", at least to me, would suggest something about a matrix representation (?!) which doesn't seem relevant here? But perhaps there is some other meaning here I am just not aware? (Google didn't reveal anything that seemed to be relevant, but that doesn't mean much)