### PR TITLE
ToricVarieties: More improvements

### DIFF
--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -33,7 +33,7 @@ AffineNormalToricVariety(v::NormalToricVariety)
 ### Normal Toric Varieties
 
 ```@docs
-NormalToricVariety(rays::Vector{Vector{Int64}}, max_cones::Vector{Vector{Int64}})
+NormalToricVariety(rays::Vector{Vector{Int64}}, max_cones::Vector{Vector{Int64}}; non_redundant::Bool = true)
 NormalToricVariety(PF::PolyhedralFan)
 NormalToricVariety(P::Polyhedron)
 ```

--- a/docs/src/ToricVarieties/ToricMorphisms.md
+++ b/docs/src/ToricVarieties/ToricMorphisms.md
@@ -74,6 +74,6 @@ of $\mathbb{R}^N$ and the maximal cones are one to one to the maximal cones of
 the fan of $v$.
 
 ```@docs
-morphism_on_cartier_divisor_group(tm::ToricMorphism)
+morphism_on_torusinvariant_cartier_divisor_group(tm::ToricMorphism)
 morphism_from_cox_variety(variety::AbstractNormalToricVariety)
 ```

--- a/src/ToricVarieties/JToric.jl
+++ b/src/ToricVarieties/JToric.jl
@@ -91,3 +91,4 @@ include("ToricMorphisms/special_attributes.jl")
 @deprecate cartier_divisor_group(v::AbstractNormalToricVariety) torusinvariant_cartier_divisor_group(v)
 @deprecate torusinvariant_divisor_group(v::AbstractNormalToricVariety) torusinvariant_weil_divisor_group(v)
 @deprecate StructureSheaf(v::AbstractNormalToricVariety) structure_sheaf
+@deprecate morphism_on_cartier_divisor_group(tm::ToricMorphism) morphism_on_torusinvariant_cartier_divisor_group(tm)

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -98,7 +98,12 @@ end
     NormalToricVariety(rays::Vector{Vector{Int64}}, max_cones::Vector{Vector{Int64}})
 
 Construct a normal toric variety $X$ by providing the rays and maximal cones
-as vector of vectors.
+as vector of vectors. By default, this method assumes that the input is not
+non-redundant (e.g. that a ray was entered twice by accident). If the user
+is certain that no redundancy exists in the entered information, one can
+pass `non_redundant = true` as third argument. This will bypass these consistency
+checks. In addition, this will ensure that the order of the rays is not
+altered by the constructor.
 
 # Examples
 ```jldoctest
@@ -118,10 +123,13 @@ julia> max_cones = [[1,2],[2,3],[3,4],[4,1]]
 
 julia> NormalToricVariety(ray_generators, max_cones)
 A normal toric variety
+
+julia> NormalToricVariety(ray_generators, max_cones, non_redundant = true)
+A normal toric variety
 ```
 """
-function NormalToricVariety(rays::Vector{Vector{Int64}}, max_cones::Vector{Vector{Int64}})
-    fan = PolyhedralFan(transpose(hcat(rays...)), IncidenceMatrix(max_cones))
+function NormalToricVariety(rays::Vector{Vector{Int64}}, max_cones::Vector{Vector{Int64}}; non_redundant::Bool = false)
+    fan = PolyhedralFan(transpose(hcat(rays...)), IncidenceMatrix(max_cones); non_redundant = non_redundant)
     return NormalToricVariety(fan)
 end
 

--- a/src/ToricVarieties/ToricMorphisms/attributes.jl
+++ b/src/ToricVarieties/ToricMorphisms/attributes.jl
@@ -134,11 +134,11 @@ Codomain:
 Abelian group with structure: Z^4
 ```
 """
-@attr GrpAbFinGenMap function morphism_on_cartier_divisor_group(tm::ToricMorphism)
+@attr GrpAbFinGenMap function morphism_on_torusinvariant_cartier_divisor_group(tm::ToricMorphism)
     domain_variety = domain(tm)
     codomain_variety = codomain(tm)
-    source_embedding = map_from_cartier_divisor_group_to_torusinvariant_divisor_group(domain_variety)
+    source_embedding = map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group(domain_variety)
     morphism_of_weil_divisors = morphism_on_torusinvariant_weil_divisor_group(tm)
     return restrict_codomain(source_embedding * morphism_of_weil_divisors)
 end
-export morphism_on_cartier_divisor_group
+export morphism_on_torusinvariant_cartier_divisor_group

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -667,7 +667,7 @@ end
     @test codomain(tm1) == domain(tm2)
     @test matrix(grid_morphism(tm2)) == matrix(ZZ,[[1,0],[0,1]])
     @test morphism_on_torusinvariant_weil_divisor_group(tm2).map == identity_matrix(ZZ,4)
-    @test morphism_on_cartier_divisor_group(tm2).map == identity_matrix(ZZ,4)
+    @test morphism_on_torusinvariant_cartier_divisor_group(tm2).map == identity_matrix(ZZ,4)
     @test grid_morphism(morphism_from_cox_variety(source)).map == matrix(ZZ, [[1], [-1]])
     @test is_affine(cox_variety(source)) == false
 end


### PR DESCRIPTION
- Do not use deprecated method.
- Allow user to bypass consistency checks (and keep the order of the rays) if desired. This should close https://github.com/oscar-system/Oscar.jl/issues/1208.