### PR TITLE
ToricVarieties: Extend Chow ring to non-complete varieties

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -1283,7 +1283,7 @@
   bibkey        = {cohomCalg:Implementation},
   title         = {cohomCalg package},
   note          = {High-performance line bundle cohomology computation based
-                  on \cite{BJRR10}},
+                  on BJRR10},
   year          = {2010},
   url           = {https://github.com/BenjaminJurke/cohomCalg}
 }

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -579,6 +579,20 @@
   url           = {https://doi.org/10.2140/gt.2018.22.235}
 }
 
+@Article{FY04,
+  author        = {Eva Maria Feichtner and Sergey Yuzvinsky},
+  title         = {Chow rings of toric varieties defined by atomic lattices},
+  journal       = {Inventiones Mathematicae},
+  volume        = {155},
+  number        = {3},
+  publisher     = {Springer Science and Business Media {LLC}},
+  pages         = {515--536},
+  year          = 2004,
+  month         = {mar},
+  doi           = {10.1007/s00222-003-0327-2},
+  url           = {https://doi.org/10.1007%2Fs00222-003-0327-2}
+}
+
 @Article{Fau99,
   author        = {Faugère, Jean-Charles},
   title         = {A new efficient algorithm for computing Gröbner bases
@@ -1078,6 +1092,17 @@
   publisher     = {Cambridge University Press, Cambridge},
   pages         = {xiv+499},
   year          = {1997}
+}
+
+@MastersThesis{Peg14,
+  author        = {Christoph Pegel},
+  title         = {Chow Rings of Toric Varieties},
+  note          = {Refereed by Prof. Dr. Eva Maria Feichtner and Dr. Emanuele
+                  Delucchi},
+  address       = {Faculty of Mathematics},
+  year          = 2014,
+  month         = 9,
+  school        = {University of Bremen}
 }
 
 @Article{Pos18,

--- a/src/ToricVarieties/AlgebraicCycles/special_attributes.jl
+++ b/src/ToricVarieties/AlgebraicCycles/special_attributes.jl
@@ -5,19 +5,49 @@
 @doc Markdown.doc"""
     chow_ring(v::AbstractNormalToricVariety)
 
-Return the Chow ring of the simplicial and complete toric variety `v`.
+Return the Chow ring of the simplicial toric variety `v`.
+
+While [CLS11](@cite) focus on simplicial and complete varieties to
+define the Chow ring, it was described in [Peg14](@cite) that this
+notion can also be extended to non-complete varieties. We explicitly
+support the Chow ring also for non-complete varieties.
+
+This is demonstrated by the following example. Note that the computation
+for the non-complete variety leads to a Chow ring which is identical to
+the Chow ring of a certain matroid. This observation can be anticipated
+by e.g. the results in [FY04](@cite).
 
 # Examples
 ```jldoctest
 julia> p2 = projective_space(NormalToricVariety, 2);
 
+julia> is_complete(p2)
+true
+
 julia> ngens(chow_ring(p2))
 3
+
+julia> v = NormalToricVariety([[1, 0], [0, 1], [-1, -1]], [[1], [2], [3]])
+A normal toric variety
+
+julia> is_complete(v)
+false
+
+julia> set_coordinate_names(v, ["x_{1}", "x_{2}", "x_{3}"])
+
+julia> chow_ring(v)
+Quotient of Multivariate Polynomial Ring in x_{1}, x_{2}, x_{3} over Rational Field by ideal(x_{1} - x_{3}, x_{2} - x_{3}, x_{1}*x_{2}, x_{1}*x_{3}, x_{2}*x_{3})
+
+julia> M = cycle_matroid(Graphs.complete_graph(3))
+Matroid of rank 2 on 3 elements
+
+julia> chow_ring(M)
+Quotient of Multivariate Polynomial Ring in x_{1}, x_{2}, x_{3} over Rational Field by ideal(x_{1} - x_{2}, x_{1} - x_{3}, x_{1}*x_{2}, x_{1}*x_{3}, x_{2}*x_{3})
 ```
 """
 @attr MPolyQuo function chow_ring(v::AbstractNormalToricVariety)
-    if !is_simplicial(v) || !is_complete(v)
-        throw(ArgumentError("The Chow ring is (currently) only supported for simplicial and complete toric varieties"))
+    if !is_simplicial(v)
+      throw(ArgumentError("The combinatorial Chow ring is (currently) only supported for simplicial toric varieties"))
     end
     R, _ = PolynomialRing(coefficient_ring(v), coordinate_names(v), cached = false)
     linear_relations = ideal_of_linear_relations(R, v)

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -304,6 +304,7 @@ function stanley_reisner_ideal(R::MPolyRing, v::AbstractNormalToricVariety)
     n = nrays(v)
     n == nvars(R) || throw(ArgumentError("Wrong number of variables"))
     mnf = _minimal_nonfaces(v)
+    Polymake.nrows(mnf) > 0 || return ideal([zero(R)])
     return ideal([ R([1], [Vector{Int}(mnf[i, :])]) for i in 1:Polymake.nrows(mnf) ])
 end
 
@@ -406,8 +407,8 @@ julia> ngens(ideal_of_linear_relations(R, p2))
 ```
 """
 function ideal_of_linear_relations(R::MPolyRing, v::AbstractNormalToricVariety)
-    if !(is_complete(v) && is_simplicial(v))
-        throw(ArgumentError("The variety must be both complete and simplicial for the computation of the ideal of linear relations"))
+    if !is_simplicial(v)
+        throw(ArgumentError("The ideal of linear relations is only supported for simplicial toric varieties"))
     end
     if ngens(R) != nrays(v)
         throw(ArgumentError("The given polynomial ring must have exactly as many indeterminates as rays for the toric variety"))

--- a/test/ToricVarieties/affine.jl
+++ b/test/ToricVarieties/affine.jl
@@ -42,7 +42,7 @@
     @testset "Torusfactor" begin
         @test_throws ArgumentError set_coordinate_names(antv4, ["u1",  "u2"])
         @test_throws ArgumentError set_coordinate_names_of_torus(antv4, ["u"])
-        @test_throws ArgumentError ideal_of_linear_relations(antv4)
+        @test_throws ArgumentError ideal_of_linear_relations(antv6)
         @test_throws ArgumentError map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group(antv4)
         @test_throws ArgumentError map_from_torusinvariant_cartier_divisor_group_to_picard_group(antv4)
         @test_throws ArgumentError betti_number(antv4, 0)

--- a/test/ToricVarieties/intersection_numbers.jl
+++ b/test/ToricVarieties/intersection_numbers.jl
@@ -5,18 +5,20 @@
     P2 = NormalToricVariety(normal_fan(Oscar.simplex(2)))
     ntv6 = F5 * P2
     antv = AffineNormalToricVariety(Oscar.positive_hull([1 1; -1 1]))
+    antv2 = NormalToricVariety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]])
+    v = NormalToricVariety([[1, 0], [0, 1], [-1, -1]], [[1], [2], [3]])
 
     (u1, u2, u3, u4) = gens(cohomology_ring(dP1))
     (x1, e1, x2, e3, x3, e2) = gens(cohomology_ring(dP3))
     c = CohomologyClass(dP3, x1)
     c2 = CohomologyClass(dP3, e1)
     c3 = CohomologyClass(dP1, u1)
-
+    combi_chow = chow_ring(v)
 
     @testset "Should fail" begin
         R,_ = PolynomialRing(QQ, 3)
         @test_throws ArgumentError cohomology_ring(antv)
-        @test_throws ArgumentError chow_ring(antv)
+        @test_throws ArgumentError chow_ring(antv2)
         @test_throws ArgumentError is_trivial(c - c3)
         @test_throws ArgumentError is_trivial(c + c3)
         @test_throws ArgumentError ideal_of_linear_relations(R, dP3)
@@ -26,6 +28,12 @@
         @test ngens(ideal_of_linear_relations(ntv6)) == 4
         @test ngens(chow_ring(ntv6).I) == 7
         @test is_trivial(volume_form(ntv6)) == false
+    end
+
+    @testset "Chow ring for non-complete but simplicial varieties" begin
+        @test is_simplicial(v) == true
+        @test is_complete(v) == false
+        @test length(gens(combi_chow.I)) == 5
     end
 
     @testset "Properties, attributes and arithmetics of cohomology classes" begin

--- a/test/ToricVarieties/runtests.jl
+++ b/test/ToricVarieties/runtests.jl
@@ -16,4 +16,3 @@ include("intersection_numbers.jl")
 include("subvarieties.jl")
 include("algebraic_cycles.jl")
 include("morphism.jl")
-


### PR DESCRIPTION
The Chow ring can also be computed for toric varieties that are merely simplicial (and not complete). This opens an avenue for examples of toric varieties whose Chow ring is identical to that of certain matroids. The corresponding functionality (respectively, extending the computability of Chow rings to non-complete but simplicial toric varieties) has been added for @bschroter.

~~For my convenience, this includes the changes in https://github.com/oscar-system/Oscar.jl/pull/1650.~~