### PR TITLE
properly fix typo in nrows(subarray)

### DIFF
--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -43,7 +43,7 @@ linear_matrix_for_polymake(x::Union{Oscar.fmpz_mat, Oscar.fmpq_mat, AbstractMatr
 
 matrix_for_polymake(x::Union{Oscar.fmpz_mat, Oscar.fmpq_mat, AbstractMatrix}) = assure_matrix_polymake(x)
 
-nrows(x::SubArray{T, U, V, W}) where {T, U, V, W} = size(x, 1)
+nrows(x::SubArray{T, 2, U, V, W}) where {T, U, V, W} = size(x, 1)
 
 function Polymake.Matrix{Polymake.Rational}(x::Union{Oscar.fmpq_mat,AbstractMatrix{Oscar.fmpq}})
     res = Polymake.Matrix{Polymake.Rational}(size(x)...)


### PR DESCRIPTION
the second type parameter should be fixed to 2 for the number of dimensions, and there are indeed 5 total type parameters for subarrays.

cc: @lkastner @thofma @alexej-jordan 

fixes #1709 