### PR TITLE
make the Rubik's cube example run in Oscar

### DIFF
--- a/docs/src/Groups/basics.md
+++ b/docs/src/Groups/basics.md
@@ -75,6 +75,7 @@ comm(x::GAPGroupElem, y::GAPGroupElem)
 ```@docs
 Base.isfinite(G::GAPGroup)
 is_abelian(G::GAPGroup)
+is_elementary_abelian
 is_pgroup
 is_pgroup_with_prime
 is_nilpotent

--- a/docs/src/Groups/fpgroup.md
+++ b/docs/src/Groups/fpgroup.md
@@ -20,5 +20,6 @@ FPGroup
 FPGroupElem
 free_group(n::Int)
 relators(G::FPGroup)
+length(g::FPGroupElem)
 map_word
 ```

--- a/docs/src/Groups/subgroups.md
+++ b/docs/src/Groups/subgroups.md
@@ -58,6 +58,7 @@ derived_series
 sylow_system
 hall_subgroup_reps
 hall_system
+complement_class_reps
 complement_system
 ```
 

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -4,6 +4,7 @@ export
     acting_group,
     comm,
     comm!,
+    complement_class_reps, has_complement_class_reps, set_complement_class_reps,
     complement_system, has_complement_system, set_complement_system,
     conjugacy_class,
     conjugacy_classes_maximal_subgroups,
@@ -1159,9 +1160,39 @@ an exception is thrown if `G` is not solvable.
 end
 
 @doc Markdown.doc"""
+    complement_class_reps(G::T, N::T) where T <: GAPGroup
+
+Return a vector of representatives of the conjugacy classes of complements
+of the normal subgroup `N` in `G`.
+This function may throws an error exception if both `N` and `G/N` are
+nonsolvable.
+
+A complement is a subgroup of `G` which intersects trivially with `N` and
+together with `N` generates `G`.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(3);
+
+julia> complement_class_reps(G, derived_subgroup(G)[1])
+1-element Vector{PermGroup}:
+ Group([ (2,3) ])
+
+julia> G = dihedral_group(8)
+<pc group of size 8 with 3 generators>
+
+julia> complement_class_reps(G, center(G)[1])
+PcGroup[]
+```
+"""
+function complement_class_reps(G::T, N::T) where T <: GAPGroup
+   return _as_subgroups(G, GAP.Globals.ComplementClassesRepresentatives(G.X, N.X))
+end
+
+@doc Markdown.doc"""
     complement_system(G::Group)
 
-Return a vector of $p'$-Hall subgroups of the finite group `G`,
+Return a vector of Hall $p'$-subgroups of the finite group `G`,
 where $p$ runs over the prime factors of the order of `G`.
 
 Complement systems exist only for solvable groups,
@@ -1556,6 +1587,33 @@ function _map_word_syllable(vi::Pair{Int, Int}, genimgs::Vector, genimgs_inv::Ve
   genimgs_inv[x] = res
   e == -1 && return res
   return res^-e
+end
+
+
+@doc Markdown.doc"""
+    length(g::FPGroupElem)
+
+Return the length of `g` as a word in terms of the generators of its group
+if `g` is an element of a free group, otherwise a exception is thrown.
+
+# Examples
+```jldoctest
+julia> F = free_group(2);  F1 = gen(F, 1);  F2 = gen(F, 2);
+
+julia> length(F1*F2^-2)
+3
+
+julia> length(one(F))
+0
+
+julia> length(one(quo(F, [F1])[1]))
+ERROR: ArgumentError: the element does not lie in a free group
+```
+"""
+function length(g::FPGroupElem)
+  gX = g.X
+  GAP.Globals.IsAssocWord(gX) || throw(ArgumentError("the element does not lie in a free group"))
+  return length(gX)
 end
 
 

--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -14,6 +14,7 @@ export
     is_abelian, has_is_abelian, set_is_abelian,
     is_cyclic, has_is_cyclic, set_is_cyclic,
     is_dihedral_group, has_is_dihedral_group, set_is_dihedral_group,
+    is_elementary_abelian, has_is_elementary_abelian, set_is_elementary_abelian,
     is_isomorphic_with_alternating_group, has_is_isomorphic_with_alternating_group, set_is_isomorphic_with_alternating_group,
     is_isomorphic_with_symmetric_group, has_is_isomorphic_with_symmetric_group, set_is_isomorphic_with_symmetric_group,
     is_natural_alternating_group, has_is_natural_alternating_group, set_is_natural_alternating_group,
@@ -179,6 +180,28 @@ Return `true` if `G` is abelian (commutative),
 that is, $x*y = y*x$ holds for all elements $x, y$ in `G`.
 """
 @gapattribute is_abelian(G::GAPGroup) = GAP.Globals.IsAbelian(G.X)::Bool
+
+@doc Markdown.doc"""
+    is_elementary_abelian(G::Group)
+
+Return `true` if `G` is a abelian (see [`is_abelian`](@ref))
+and if there is a prime `p` such that the order of each element in `G`
+divides `p`.
+
+# Examples
+```jldoctest
+julia> g = alternating_group(5);
+
+julia> is_elementary_abelian(sylow_subgroup(g, 2)[1])
+true
+
+julia> g = alternating_group(6);
+
+julia> is_elementary_abelian(sylow_subgroup(g, 2)[1])
+false
+```
+"""
+@gapattribute is_elementary_abelian(G::GAPGroup) = GAP.Globals.IsElementaryAbelian(G.X)::Bool
 
 function mathieu_group(n::Int)
   9 <= n <= 12 || 21 <= n <= 24 || throw(ArgumentError("n must be a 9-12 or 21-24"))

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -449,12 +449,30 @@ function __init_JuliaData()
     if ! hasproperty(GAP.Globals, :JuliaData)
       GAP.evalstr("""
 DeclareAttribute( "JuliaData", IsObject );
+
 InstallOtherMethod( ImagesRepresentative,
 [ IsActionHomomorphism and HasJuliaData, IsMultiplicativeElementWithInverse ],
 function( hom, elm )
 local data;
 data:= JuliaData( hom );
 return Julia.Oscar.permutation(data[1], Julia.Oscar.group_element(data[2], elm)).X;
+end );
+
+InstallMethod( RestrictedMapping,
+CollFamSourceEqFamElms,
+[ IsActionHomomorphism and HasJuliaData, IsGroup ],
+function( hom, H )
+local data, OscarG, xset, Omega, Hgens, Hacts, OscarH, res;
+data:= JuliaData( hom ); # the Oscar G-set and the acting Oscar group G
+OscarG:= data[2]; # the acting Oscar group G
+xset:= UnderlyingExternalSet( hom );
+Omega:= HomeEnumerator( xset ); # the set of Oscar objects
+Hgens:= GeneratorsOfGroup( H ); # GAP generators of H
+Hacts:= List( Hgens, x -> Julia.Oscar.group_element( OscarG, x ) ); # corresponding Oscar generators of H
+OscarH:= Julia.Oscar._as_subgroup_bare( OscarG, H );
+res:= ActionHomomorphism( H, Omega, Hgens, Hacts, FunctionAction( xset ) );
+SetJuliaData( res, [ data[1], OscarH ] );
+return res;
 end );
 """)
     end
@@ -676,7 +694,7 @@ julia> collect(blocks(g))
 function blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
    @assert is_transitive(G, L) "The group action is not transitive"
    bl = Vector{Vector{Int}}(GAP.Globals.Blocks(G.X, GapObj(L))::GapObj)
-   return gset(G, bl; closed = true)
+   return gset(G, on_sets, bl; closed = true)
 end
 
 """

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -122,6 +122,8 @@
   @test pi == g^acthom
   @test haspreimage(acthom, pi)[1]
   @test order(image(acthom)[1]) == 720
+  rest = restrict_homomorphism(acthom, derived_subgroup(G)[1])
+  @test ! is_bijective(rest)
 
   # is_conjugate
   G = symmetric_group(6)
@@ -156,6 +158,10 @@ end
   bl = blocks(G8)
   @test elements(bl) == [[1, 8], [2, 3], [4, 5], [6, 7]]
   @test elements(bl) == elements(blocks(G8, 1:degree(G8)))
+
+  # block homomorphism
+  blhom = action_homomorphism(bl)
+  @test ! is_bijective(blhom)
 
   # is_primitive
   @test ! is_primitive(G8)


### PR DESCRIPTION
- added `length` for elements of free groups
- added `complement_class_reps` for groups
- added `is_elementary_abelian`
- fixed a bug in the construction of blocks homomorphisms (act with `on_sets`)
- fixed `restrict_homomorphism` for action homomorphisms: When GAP gets a map that is controlled by Oscar data then it must create a map that is also controlled by Oscar data. (We install a special GAP method for `GAP.Globals.RestrictedMapping`. Extending `restrict_homomorphism` would have been simpler, but would not have covered all situations where GAP deals with the maps that rely on Oscar data.)