### PR TITLE
changed `transitivity`

### DIFF
--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -809,8 +809,12 @@ end
 """
     transitivity(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
 
-Return the maximum `k` such that the action of `G` on `L` is
-`k`-transitive. The output is `0` if `G` is not transitive on `L`.
+Return the maximum `k` such that `G` acts `k`-transitively on `L`,
+that is, every `k`-tuple of points in `L` can be mapped simultaneously
+to every other `k`-tuple by an element of `G`.
+
+The output is `0` if `G` acts intransitively on `L`,
+and an exception is thrown if `G` does not act on `L`.
 
 # Examples
 ```jldoctest
@@ -820,14 +824,33 @@ julia> transitivity(mathieu_group(24))
 julia> transitivity(symmetric_group(6))
 6
 
+julia> transitivity(symmetric_group(6), 1:7)
+0
+
+julia> transitivity(symmetric_group(6), 1:5)
+ERROR: ArgumentError: the group does not act
 ```
 """
-transitivity(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAP.Globals.Transitivity(G.X, GapObj(L))::Int
+function transitivity(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
+  gL = GapObj(L)
+  res = GAP.Globals.Transitivity(G.X, gL)::Int
+  res === GAP.Globals.fail && throw(ArgumentError("the group does not act"))
+  # If the result is `0` then it may be that `G` does not act on `L`,
+  # and in this case we want to throw an exception.
+  if res == 0 && length(L) > 0
+    orbs = GAP.Globals.Orbits(G.X, gL)
+    if sum([length(x) for x in orbs]) != length(L)
+      throw(ArgumentError("the group does not act"))
+    end
+  end
+  return res
+end
 
 """
     is_transitive(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
 
-Return whether the action of `G` on `L` is transitive.
+Return whether `G` acts transitively on `L`, that is,
+`L` is an orbit of `G`.
 
 # Examples
 ```jldoctest

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -838,8 +838,9 @@ function transitivity(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
   # If the result is `0` then it may be that `G` does not act on `L`,
   # and in this case we want to throw an exception.
   if res == 0 && length(L) > 0
-    orbs = GAP.Globals.Orbits(G.X, gL)
-    if sum([length(x) for x in orbs]) != length(L)
+    lens = GAP.Globals.OrbitLengths(G.X, gL)
+#TODO: Compute the orbit lengths more efficiently than GAP does.
+    if sum(lens) != length(L)
       throw(ArgumentError("the group does not act"))
     end
   end

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -192,7 +192,7 @@ end
   # transitivity
   @test transitivity(G8) == 1
   @test transitivity(S4) == 4
-  @test transitivity(S4, 1:3) == 0
+  @test_throws ArgumentError transitivity(S4, 1:3)
   @test transitivity(S4, 1:4) == 4
   @test transitivity(S4, 1:5) == 0
 

--- a/test/Groups/libraries.jl
+++ b/test/Groups/libraries.jl
@@ -58,10 +58,14 @@ end
    H4 = sub(G,[G([3,4,1,2]), G([2,1,4,3])])[1]  # Klein subgroup
    L = [G,H1,H2,H3,H4]
 
-   # FIXME: the following two tests are fishy. The first couple calls
-   # really should result in errors ?!?
-   @test [transitivity(G,1:i) for i in 1:5]==[0,0,0,4,0]
-   @test [transitivity(L[5],1:i) for i in 1:5]==[0,0,0,1,0]
+   @test transitivity(G) == 4
+   @test transitivity(G, 1:4) == 4
+   @test_throws ArgumentError transitivity(G, 1:3)
+   @test transitivity(G, 1:5) == 0
+   @test transitivity(H4) == 1
+   @test transitivity(H4, 1:4) == 1
+   @test_throws ArgumentError transitivity(H4, 1:3)
+   @test transitivity(H4, 1:5) == 0
 
    @test is_transitive(G)
    H = sub(G,[G([2,3,1,4])])[1]


### PR DESCRIPTION
`transitivity` now throws an exception if the group does not act on the given set.

The problem was observed and discussed in pull request  #1671.