### PR TITLE
Convert most @repl blocks to jldoctest

### DIFF
--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/complexes.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/complexes.md
@@ -56,10 +56,28 @@ julia> b = hom(B, B, [x^2*B[1]]);
 julia> C = chain_complex([a, b]; start =3);
 
 julia> range(C)
+5:-1:4
 
 julia> C[5]
+Subquotient of Submodule with 1 generator
+1 -> e[1]
+by Submodule with 1 generator
+1 -> x^4*e[1]
 
 julia> map(C, 5)
+Map with following data
+Domain:
+=======
+Subquotient of Submodule with 1 generator
+1 -> e[1]
+by Submodule with 1 generator
+1 -> x^4*e[1]
+Codomain:
+=========
+Subquotient of Submodule with 1 generator
+1 -> e[1]
+by Submodule with 1 generator
+1 -> x^3*e[1]
 
 ```
 
@@ -89,10 +107,19 @@ julia> b = hom(B, B, [x^2*B[1]]);
 julia> C = chain_complex([a, b]; start = 3);
 
 julia> range(C)
+5:-1:4
 
 julia> D = shift(C, 3);
+ERROR: UndefVarError: shift not defined
+Stacktrace:
+ [1] top-level scope
+   @ none:1
 
 julia> range(D)
+ERROR: UndefVarError: D not defined
+Stacktrace:
+ [1] top-level scope
+   @ none:1
 
 ```
 

--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/complexes.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/complexes.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -37,17 +40,27 @@ Given a chain complex `C`,
 
 ##### Examples
 
-```@repl oscar
-R, (x,) = PolynomialRing(QQ, ["x"]);
-F = free_module(R, 1);
-A, _ = quo(F, [x^4*F[1]]);
-B, _ = quo(F, [x^3*F[1]]);
-a = hom(A, B, [x^2*B[1]]);
-b = hom(B, B, [x^2*B[1]]);
-C = chain_complex([a, b]; start =3);
-range(C)
-C[5]
-map(C, 5)
+```jldoctest
+julia> R, (x,) = PolynomialRing(QQ, ["x"]);
+
+julia> F = free_module(R, 1);
+
+julia> A, _ = quo(F, [x^4*F[1]]);
+
+julia> B, _ = quo(F, [x^3*F[1]]);
+
+julia> a = hom(A, B, [x^2*B[1]]);
+
+julia> b = hom(B, B, [x^2*B[1]]);
+
+julia> C = chain_complex([a, b]; start =3);
+
+julia> range(C)
+
+julia> C[5]
+
+julia> map(C, 5)
+
 ```
 
 ## Operations on Chain Complexes
@@ -60,17 +73,27 @@ Return the complex obtained from `C` by shifting the homological degrees `d` ste
 
 ##### Examples
 
-```@repl oscar
-R, (x,) = PolynomialRing(QQ, ["x"]);
-F = free_module(R, 1);
-A, _ = quo(F, [x^4*F[1]]);
-B, _ = quo(F, [x^3*F[1]]);
-a = hom(A, B, [x^2*B[1]]);
-b = hom(B, B, [x^2*B[1]]);
-C = chain_complex([a, b]; start = 3);
-range(C)
-D = shift(C, 3);
-range(D)
+```jldoctest
+julia> R, (x,) = PolynomialRing(QQ, ["x"]);
+
+julia> F = free_module(R, 1);
+
+julia> A, _ = quo(F, [x^4*F[1]]);
+
+julia> B, _ = quo(F, [x^3*F[1]]);
+
+julia> a = hom(A, B, [x^2*B[1]]);
+
+julia> b = hom(B, B, [x^2*B[1]]);
+
+julia> C = chain_complex([a, b]; start = 3);
+
+julia> range(C)
+
+julia> D = shift(C, 3);
+
+julia> range(D)
+
 ```
 
 ```@docs

--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/complexes.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/complexes.md
@@ -109,17 +109,11 @@ julia> C = chain_complex([a, b]; start = 3);
 julia> range(C)
 5:-1:4
 
-julia> D = shift(C, 3);
-ERROR: UndefVarError: shift not defined
-Stacktrace:
- [1] top-level scope
-   @ none:1
+julia> D = Hecke.shift(C, 3);
+
 
 julia> range(D)
-ERROR: UndefVarError: D not defined
-Stacktrace:
- [1] top-level scope
-   @ none:1
+2:-1:1
 
 ```
 

--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/free_modules.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/free_modules.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -52,11 +55,15 @@ If `F` is a free `R`-module, then
 
 ###### Examples
 
-```@repl oscar
-R, (x, y) = PolynomialRing(QQ, ["x", "y"])
-F = free_module(R, 3)
-basis(F)
-rank(F)
+```jldoctest
+julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
+
+julia> F = free_module(R, 3)
+
+julia> basis(F)
+
+julia> rank(F)
+
 ```
 
 ## Elements of Free Modules
@@ -81,13 +88,19 @@ Alternatively, directly write the element as a linear combination of basis vecto
  
 ##### Examples
 
-```@repl oscar
-R, (x, y) = PolynomialRing(QQ, ["x", "y"])
-F = free_module(R, 3)
-f = F(sparse_row(R, [(1,x),(3,y)]))
-g = F( [x, zero(R), y])
-h = x*F[1] + y*F[3]
-f == g == h
+```jldoctest
+julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
+
+julia> F = free_module(R, 3)
+
+julia> f = F(sparse_row(R, [(1,x),(3,y)]))
+
+julia> g = F( [x, zero(R), y])
+
+julia> h = x*F[1] + y*F[3]
+
+julia> f == g == h
+
 ```
 
 Given an element `f`  of a free module `F` over a multivariate polynomial ring with element type `T`,
@@ -96,12 +109,17 @@ Given an element `f`  of a free module `F` over a multivariate polynomial ring w
 
 ##### Examples
 
-```@repl oscar
-R, (x, y) = PolynomialRing(QQ, ["x", "y"])
-F = free_module(R, 3)
-f = x*F[1] + y*F[3]
-parent(f)
-coefficients(f)
+```jldoctest
+julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
+
+julia> F = free_module(R, 3)
+
+julia> f = x*F[1] + y*F[3]
+
+julia> parent(f)
+
+julia> coefficients(f)
+
 ```
 
 The zero element of a free module is obtained as follows:

--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/free_modules.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/free_modules.md
@@ -57,12 +57,19 @@ If `F` is a free `R`-module, then
 
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
+(Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
 
 julia> F = free_module(R, 3)
+Free module of rank 3 over Multivariate Polynomial Ring in x, y over Rational Field
 
 julia> basis(F)
+3-element Vector{FreeModElem{fmpq_mpoly}}:
+ e[1]
+ e[2]
+ e[3]
 
 julia> rank(F)
+3
 
 ```
 
@@ -90,16 +97,22 @@ Alternatively, directly write the element as a linear combination of basis vecto
 
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
+(Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
 
 julia> F = free_module(R, 3)
+Free module of rank 3 over Multivariate Polynomial Ring in x, y over Rational Field
 
 julia> f = F(sparse_row(R, [(1,x),(3,y)]))
+x*e[1] + y*e[3]
 
 julia> g = F( [x, zero(R), y])
+x*e[1] + y*e[3]
 
 julia> h = x*F[1] + y*F[3]
+x*e[1] + y*e[3]
 
 julia> f == g == h
+true
 
 ```
 
@@ -111,14 +124,19 @@ Given an element `f`  of a free module `F` over a multivariate polynomial ring w
 
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
+(Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
 
 julia> F = free_module(R, 3)
+Free module of rank 3 over Multivariate Polynomial Ring in x, y over Rational Field
 
 julia> f = x*F[1] + y*F[3]
+x*e[1] + y*e[3]
 
 julia> parent(f)
+Free module of rank 3 over Multivariate Polynomial Ring in x, y over Rational Field
 
 julia> coefficients(f)
+Sparse row with positions [1, 3] and values fmpq_mpoly[x, y]
 
 ```
 

--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/subquotients.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/subquotients.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -79,20 +82,33 @@ If `M` is a subquotient with ambient free `R`-module `F`, then
 
 ##### Examples
 
-```@repl oscar
-R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
-F = free_module(R, 1)
-A = R[x; y]
-B = R[x^2; y^3; z^4]
-M = SubQuo(F, A, B)
-base_ring(M)
-F === ambient_free_module(M)
-gens(M)
-ngens(M)
-gen(M, 2)
-ambient_representatives_generators(M)
-relations(M)
-ambient_module(M)
+```jldoctest
+julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+
+julia> F = free_module(R, 1)
+
+julia> A = R[x; y]
+
+julia> B = R[x^2; y^3; z^4]
+
+julia> M = SubQuo(F, A, B)
+
+julia> base_ring(M)
+
+julia> F === ambient_free_module(M)
+
+julia> gens(M)
+
+julia> ngens(M)
+
+julia> gen(M, 2)
+
+julia> ambient_representatives_generators(M)
+
+julia> relations(M)
+
+julia> ambient_module(M)
+
 ```
 
 ## Elements of Subqotients
@@ -117,16 +133,25 @@ Alternatively, directly write the element as an $R$-linear combination of genera
 
 ##### Examples
 
-```@repl oscar
-R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
-F = free_module(R, 1)
-A = R[x; y]
-B = R[x^2; y^3; z^4]
-M = SubQuo(F, A, B)
-m = M(sparse_row(R, [(1,z),(2,one(R))]))
-n = M([z, one(R)])
-o = z*M[1] + M[2]
-m == n == o
+```jldoctest
+julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+
+julia> F = free_module(R, 1)
+
+julia> A = R[x; y]
+
+julia> B = R[x^2; y^3; z^4]
+
+julia> M = SubQuo(F, A, B)
+
+julia> m = M(sparse_row(R, [(1,z),(2,one(R))]))
+
+julia> n = M([z, one(R)])
+
+julia> o = z*M[1] + M[2]
+
+julia> m == n == o
+
 ```
 
 Given an element `m`  of a subquotient `M`  over a multivariate polynomial ring $R$ with element type `T`,
@@ -146,24 +171,41 @@ If this is already clear, it may be convenient to omit the test (`check = false`
 
 ##### Examples
 
-```@repl oscar
-R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
-F = free_module(R, 1)
-A = R[x; y]
-B = R[x^2; y^3; z^4]
-M = SubQuo(F, A, B)
-m = z*M[1] + M[2]
-parent(m)
-coefficients(m)
-fm = ambient_representative(m)
-typeof(m)
-typeof(fm)
-parent(fm) === ambient_free_module(M)
-F = ambient_free_module(M)
-f = x*F[1]
-M(f)
-typeof(f)
-typeof(M(f))
+```jldoctest
+julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+
+julia> F = free_module(R, 1)
+
+julia> A = R[x; y]
+
+julia> B = R[x^2; y^3; z^4]
+
+julia> M = SubQuo(F, A, B)
+
+julia> m = z*M[1] + M[2]
+
+julia> parent(m)
+
+julia> coefficients(m)
+
+julia> fm = ambient_representative(m)
+
+julia> typeof(m)
+
+julia> typeof(fm)
+
+julia> parent(fm) === ambient_free_module(M)
+
+julia> F = ambient_free_module(M)
+
+julia> f = x*F[1]
+
+julia> M(f)
+
+julia> typeof(f)
+
+julia> typeof(M(f))
+
 ```
 
 The zero element of a subquotient is obtained as follows:

--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/subquotients.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/subquotients.md
@@ -84,30 +84,64 @@ If `M` is a subquotient with ambient free `R`-module `F`, then
 
 ```jldoctest
 julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+(Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
 
 julia> F = free_module(R, 1)
+Free module of rank 1 over Multivariate Polynomial Ring in x, y, z over Rational Field
 
 julia> A = R[x; y]
+[x]
+[y]
 
 julia> B = R[x^2; y^3; z^4]
+[x^2]
+[y^3]
+[z^4]
 
 julia> M = SubQuo(F, A, B)
+Subquotient of Submodule with 2 generators
+1 -> x*e[1]
+2 -> y*e[1]
+by Submodule with 3 generators
+1 -> x^2*e[1]
+2 -> y^3*e[1]
+3 -> z^4*e[1]
 
 julia> base_ring(M)
+Multivariate Polynomial Ring in x, y, z over Rational Field
 
 julia> F === ambient_free_module(M)
+true
 
 julia> gens(M)
+2-element Vector{SubQuoElem{fmpq_mpoly}}:
+ x*e[1]
+ y*e[1]
 
 julia> ngens(M)
+2
 
 julia> gen(M, 2)
+y*e[1]
 
 julia> ambient_representatives_generators(M)
+2-element Vector{FreeModElem{fmpq_mpoly}}:
+ x*e[1]
+ y*e[1]
 
 julia> relations(M)
+3-element Vector{FreeModElem{fmpq_mpoly}}:
+ x^2*e[1]
+ y^3*e[1]
+ z^4*e[1]
 
 julia> ambient_module(M)
+Subquotient of Submodule with 1 generator
+1 -> e[1]
+by Submodule with 3 generators
+1 -> x^2*e[1]
+2 -> y^3*e[1]
+3 -> z^4*e[1]
 
 ```
 
@@ -135,22 +169,40 @@ Alternatively, directly write the element as an $R$-linear combination of genera
 
 ```jldoctest
 julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+(Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
 
 julia> F = free_module(R, 1)
+Free module of rank 1 over Multivariate Polynomial Ring in x, y, z over Rational Field
 
 julia> A = R[x; y]
+[x]
+[y]
 
 julia> B = R[x^2; y^3; z^4]
+[x^2]
+[y^3]
+[z^4]
 
 julia> M = SubQuo(F, A, B)
+Subquotient of Submodule with 2 generators
+1 -> x*e[1]
+2 -> y*e[1]
+by Submodule with 3 generators
+1 -> x^2*e[1]
+2 -> y^3*e[1]
+3 -> z^4*e[1]
 
 julia> m = M(sparse_row(R, [(1,z),(2,one(R))]))
+(x*z + y)*e[1]
 
 julia> n = M([z, one(R)])
+(x*z + y)*e[1]
 
 julia> o = z*M[1] + M[2]
+(x*z + y)*e[1]
 
 julia> m == n == o
+true
 
 ```
 
@@ -173,38 +225,70 @@ If this is already clear, it may be convenient to omit the test (`check = false`
 
 ```jldoctest
 julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+(Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
 
 julia> F = free_module(R, 1)
+Free module of rank 1 over Multivariate Polynomial Ring in x, y, z over Rational Field
 
 julia> A = R[x; y]
+[x]
+[y]
 
 julia> B = R[x^2; y^3; z^4]
+[x^2]
+[y^3]
+[z^4]
 
 julia> M = SubQuo(F, A, B)
+Subquotient of Submodule with 2 generators
+1 -> x*e[1]
+2 -> y*e[1]
+by Submodule with 3 generators
+1 -> x^2*e[1]
+2 -> y^3*e[1]
+3 -> z^4*e[1]
 
 julia> m = z*M[1] + M[2]
+(x*z + y)*e[1]
 
 julia> parent(m)
+Subquotient of Submodule with 2 generators
+1 -> x*e[1]
+2 -> y*e[1]
+by Submodule with 3 generators
+1 -> x^2*e[1]
+2 -> y^3*e[1]
+3 -> z^4*e[1]
 
 julia> coefficients(m)
+Sparse row with positions [1, 2] and values fmpq_mpoly[z, 1]
 
 julia> fm = ambient_representative(m)
+(x*z + y)*e[1]
 
 julia> typeof(m)
+SubQuoElem{fmpq_mpoly}
 
 julia> typeof(fm)
+FreeModElem{fmpq_mpoly}
 
 julia> parent(fm) === ambient_free_module(M)
+true
 
 julia> F = ambient_free_module(M)
+Free module of rank 1 over Multivariate Polynomial Ring in x, y, z over Rational Field
 
 julia> f = x*F[1]
+x*e[1]
 
 julia> M(f)
+x*e[1]
 
 julia> typeof(f)
+FreeModElem{fmpq_mpoly}
 
 julia> typeof(M(f))
+SubQuoElem{fmpq_mpoly}
 
 ```
 

--- a/docs/src/CommutativeAlgebra/affine_algebras.md
+++ b/docs/src/CommutativeAlgebra/affine_algebras.md
@@ -515,7 +515,7 @@ noether_normalization(A::MPolyQuo)
 
 ###### Examples
 
-```jldoctest
+```jldoctest; setup = :(Singular.call_interpreter("""system("random", 47);"""))
 julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"]);
 
 julia> A, _ = quo(R, ideal(R, [x*y, x*z]));
@@ -524,8 +524,8 @@ julia> L = noether_normalization(A);
 
 julia> L[1]
 2-element Vector{MPolyQuoElem{fmpq_mpoly}}:
- -x + y
- 2*x - 3*y + z
+ -2*x + y
+ -5*y + z
 
 julia> L[2]
 Map with following data
@@ -534,13 +534,13 @@ Domain:
 Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal(x*y, x*z)
 Codomain:
 =========
-Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal(x^2 + x*y, x^2 + 3*x*y + x*z)
+Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal(2*x^2 + x*y, 10*x^2 + 5*x*y + x*z)
 
 julia> L[3]
 Map with following data
 Domain:
 =======
-Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal(x^2 + x*y, x^2 + 3*x*y + x*z)
+Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal(2*x^2 + x*y, 10*x^2 + 5*x*y + x*z)
 Codomain:
 =========
 Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal(x*y, x*z)

--- a/docs/src/CommutativeAlgebra/affine_algebras.md
+++ b/docs/src/CommutativeAlgebra/affine_algebras.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -56,14 +59,21 @@ If `A=R/I` is the quotient ring of a multivariate polynomial ring `R` modulo an 
 
 ###### Examples
 
-```@repl oscar
-R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
-A, _ = quo(R, ideal(R, [y-x^2, z-x^3]))
-base_ring(A)
-modulus(A)
-gens(A)
-ngens(A)
-gen(A, 2)
+```jldoctest
+julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+
+julia> A, _ = quo(R, ideal(R, [y-x^2, z-x^3]))
+
+julia> base_ring(A)
+
+julia> modulus(A)
+
+julia> gens(A)
+
+julia> ngens(A)
+
+julia> gen(A, 2)
+
 ```
 
 In the graded case, we additionally have:
@@ -92,13 +102,19 @@ or by directly coercing elements of $R$ into $A$.
 
 ###### Examples
 
-```@repl oscar
-R, (x, y) = PolynomialRing(QQ, ["x", "y"]);
-A, p = quo(R, ideal(R, [x^3*y^2-y^3*x^2, x*y^4-x*y^2]))
-f = p(x^3*y^2-y^3*x^2+x*y)
-typeof(f)
-g = A(x^3*y^2-y^3*x^2+x*y)
-f == g
+```jldoctest
+julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"]);
+
+julia> A, p = quo(R, ideal(R, [x^3*y^2-y^3*x^2, x*y^4-x*y^2]))
+
+julia> f = p(x^3*y^2-y^3*x^2+x*y)
+
+julia> typeof(f)
+
+julia> g = A(x^3*y^2-y^3*x^2+x*y)
+
+julia> f == g
+
 ```
 
 ### Reducing Elements of Affine Algebras
@@ -166,14 +182,21 @@ If `a` is an ideal of the affine algebra `A`, then
 
 ###### Examples
 
-```@repl oscar
-R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"]);
-A, _ = quo(R, ideal(R, [y-x^2, z-x^3]));
-a = ideal(A, [x-y, z^4])
-base_ring(a)
-gens(a)
-ngens(a)
-gen(a, 2)
+```jldoctest
+julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"]);
+
+julia> A, _ = quo(R, ideal(R, [y-x^2, z-x^3]));
+
+julia> a = ideal(A, [x-y, z^4])
+
+julia> base_ring(a)
+
+julia> gens(a)
+
+julia> ngens(a)
+
+julia> gen(a, 2)
+
 ```
 
 #### Dimension of Ideals in Affine Algebras
@@ -274,26 +297,42 @@ kernel(F::AffAlgHom)
 
 ###### Examples
 
-```@repl oscar
-D1, (w, x, y, z) = GradedPolynomialRing(QQ, ["w", "x", "y", "z"]);
-C1, (s,t) = GradedPolynomialRing(QQ, ["s", "t"]);
-V1 = [s^3, s^2*t, s*t^2, t^3];
-para = hom(D1, C1, V1)
-twistedCubic = kernel(para)
-C2, p2 = quo(D1, twistedCubic);
-D2, (a, b, c) = GradedPolynomialRing(QQ, ["a", "b", "c"]);
-V2 = [p2(w-y), p2(x), p2(z)];
-proj = hom(D2, C2, V2)
-nodalCubic = kernel(proj)
+```jldoctest
+julia> D1, (w, x, y, z) = GradedPolynomialRing(QQ, ["w", "x", "y", "z"]);
+
+julia> C1, (s,t) = GradedPolynomialRing(QQ, ["s", "t"]);
+
+julia> V1 = [s^3, s^2*t, s*t^2, t^3];
+
+julia> para = hom(D1, C1, V1)
+
+julia> twistedCubic = kernel(para)
+
+julia> C2, p2 = quo(D1, twistedCubic);
+
+julia> D2, (a, b, c) = GradedPolynomialRing(QQ, ["a", "b", "c"]);
+
+julia> V2 = [p2(w-y), p2(x), p2(z)];
+
+julia> proj = hom(D2, C2, V2)
+
+julia> nodalCubic = kernel(proj)
+
 ```
 
-```@repl oscar
-D3,y = PolynomialRing(QQ, "y" => 1:3);
-C3, x = PolynomialRing(QQ, "x" => 1:3);
-V3 = [x[1]*x[2], x[1]*x[3], x[2]*x[3]];
-F3 = hom(D3, C3, V3)
-sphere = ideal(C3, [x[1]^3 + x[2]^3  + x[3]^3 - 1])
-steinerRomanSurface = preimage(F3, sphere)
+```jldoctest
+julia> D3,y = PolynomialRing(QQ, "y" => 1:3);
+
+julia> C3, x = PolynomialRing(QQ, "x" => 1:3);
+
+julia> V3 = [x[1]*x[2], x[1]*x[3], x[2]*x[3]];
+
+julia> F3 = hom(D3, C3, V3)
+
+julia> sphere = ideal(C3, [x[1]^3 + x[2]^3  + x[3]^3 - 1])
+
+julia> steinerRomanSurface = preimage(F3, sphere)
+
 ```
 
 ### Tests on Homomorphisms of Affine Algebras
@@ -308,25 +347,40 @@ isfinite(F::AffAlgHom)
 
 ###### Examples
 
-```@repl oscar
-D, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"]);
-S, (a, b, c) = PolynomialRing(QQ, ["a", "b", "c"]);
-C, p = quo(S, ideal(S, [c-b^3]));
-V = [p(2*a + b^6), p(7*b - a^2), p(c^2)];
-F = hom(D, C, V)
-is_surjective(F)
-D1, _ = quo(D, kernel(F));
-F1 = hom(D1, C, V);
-is_bijective(F1)
+```jldoctest
+julia> D, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"]);
+
+julia> S, (a, b, c) = PolynomialRing(QQ, ["a", "b", "c"]);
+
+julia> C, p = quo(S, ideal(S, [c-b^3]));
+
+julia> V = [p(2*a + b^6), p(7*b - a^2), p(c^2)];
+
+julia> F = hom(D, C, V)
+
+julia> is_surjective(F)
+
+julia> D1, _ = quo(D, kernel(F));
+
+julia> F1 = hom(D1, C, V);
+
+julia> is_bijective(F1)
+
 ```
 
-```@repl oscar
-R, (x, y, z) = PolynomialRing(QQ, [ "x", "y", "z"]);
-C, (s, t) = PolynomialRing(QQ, ["s", "t"]);
-V = [s*t, t, s^2];
-paraWhitneyUmbrella = hom(R, C, V)
-D, _ = quo(R, kernel(paraWhitneyUmbrella));
-isfinite(hom(D, C, V))
+```jldoctest
+julia> R, (x, y, z) = PolynomialRing(QQ, [ "x", "y", "z"]);
+
+julia> C, (s, t) = PolynomialRing(QQ, ["s", "t"]);
+
+julia> V = [s*t, t, s^2];
+
+julia> paraWhitneyUmbrella = hom(R, C, V)
+
+julia> D, _ = quo(R, kernel(paraWhitneyUmbrella));
+
+julia> isfinite(hom(D, C, V))
+
 ```
 
 ### Inverting Homomorphisms of Affine Algebras
@@ -335,13 +389,19 @@ isfinite(hom(D, C, V))
 inverse(F::AffAlgHom)
 ```
 
-```@repl oscar
-D1, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"]);
-D, _ = quo(D1, [y-x^2, z-x^3])
-C, (t,) = PolynomialRing(QQ, ["t"]);
-para = hom(D, C, [t, t^2, t^3]);
-is_bijective(para)
-inverse(para)
+```jldoctest
+julia> D1, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"]);
+
+julia> D, _ = quo(D1, [y-x^2, z-x^3])
+
+julia> C, (t,) = PolynomialRing(QQ, ["t"]);
+
+julia> para = hom(D, C, [t, t^2, t^3]);
+
+julia> is_bijective(para)
+
+julia> inverse(para)
+
 ```
 
 ## Subalgebras
@@ -366,13 +426,19 @@ noether_normalization(A::MPolyQuo)
 
 ###### Examples
 
-```@repl oscar
-R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"]);
-A, _ = quo(R, ideal(R, [x*y, x*z]));
-L = noether_normalization(A);
-L[1]
-L[2]
-L[3]
+```jldoctest
+julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"]);
+
+julia> A, _ = quo(R, ideal(R, [x*y, x*z]));
+
+julia> L = noether_normalization(A);
+
+julia> L[1]
+
+julia> L[2]
+
+julia> L[3]
+
 ```
 ## Normalization
 

--- a/docs/src/CommutativeAlgebra/affine_algebras.md
+++ b/docs/src/CommutativeAlgebra/affine_algebras.md
@@ -61,18 +61,29 @@ If `A=R/I` is the quotient ring of a multivariate polynomial ring `R` modulo an 
 
 ```jldoctest
 julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+(Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
 
 julia> A, _ = quo(R, ideal(R, [y-x^2, z-x^3]))
+(Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal(-x^2 + y, -x^3 + z), Map from
+Multivariate Polynomial Ring in x, y, z over Rational Field to Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal(-x^2 + y, -x^3 + z) defined by a julia-function with inverse)
 
 julia> base_ring(A)
+Multivariate Polynomial Ring in x, y, z over Rational Field
 
 julia> modulus(A)
+ideal(-x^2 + y, -x^3 + z)
 
 julia> gens(A)
+3-element Vector{MPolyQuoElem{fmpq_mpoly}}:
+ x
+ y
+ z
 
 julia> ngens(A)
+3
 
 julia> gen(A, 2)
+y
 
 ```
 
@@ -106,14 +117,20 @@ or by directly coercing elements of $R$ into $A$.
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"]);
 
 julia> A, p = quo(R, ideal(R, [x^3*y^2-y^3*x^2, x*y^4-x*y^2]))
+(Quotient of Multivariate Polynomial Ring in x, y over Rational Field by ideal(x^3*y^2 - x^2*y^3, x*y^4 - x*y^2), Map from
+Multivariate Polynomial Ring in x, y over Rational Field to Quotient of Multivariate Polynomial Ring in x, y over Rational Field by ideal(x^3*y^2 - x^2*y^3, x*y^4 - x*y^2) defined by a julia-function with inverse)
 
 julia> f = p(x^3*y^2-y^3*x^2+x*y)
+x^3*y^2 - x^2*y^3 + x*y
 
 julia> typeof(f)
+MPolyQuoElem{fmpq_mpoly}
 
 julia> g = A(x^3*y^2-y^3*x^2+x*y)
+x^3*y^2 - x^2*y^3 + x*y
 
 julia> f == g
+true
 
 ```
 
@@ -188,14 +205,21 @@ julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"]);
 julia> A, _ = quo(R, ideal(R, [y-x^2, z-x^3]));
 
 julia> a = ideal(A, [x-y, z^4])
+ideal(x - y, z^4)
 
 julia> base_ring(a)
+Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal(-x^2 + y, -x^3 + z)
 
 julia> gens(a)
+2-element Vector{MPolyQuoElem{fmpq_mpoly}}:
+ x - y
+ z^4
 
 julia> ngens(a)
+2
 
 julia> gen(a, 2)
+z^4
 
 ```
 
@@ -305,8 +329,22 @@ julia> C1, (s,t) = GradedPolynomialRing(QQ, ["s", "t"]);
 julia> V1 = [s^3, s^2*t, s*t^2, t^3];
 
 julia> para = hom(D1, C1, V1)
+Map with following data
+Domain:
+=======
+Multivariate Polynomial Ring in w, x, y, z over Rational Field graded by
+  w -> [1]
+  x -> [1]
+  y -> [1]
+  z -> [1]
+Codomain:
+=========
+Multivariate Polynomial Ring in s, t over Rational Field graded by
+  s -> [1]
+  t -> [1]
 
 julia> twistedCubic = kernel(para)
+ideal(-x*z + y^2, -w*z + x*y, -w*y + x^2)
 
 julia> C2, p2 = quo(D1, twistedCubic);
 
@@ -315,8 +353,23 @@ julia> D2, (a, b, c) = GradedPolynomialRing(QQ, ["a", "b", "c"]);
 julia> V2 = [p2(w-y), p2(x), p2(z)];
 
 julia> proj = hom(D2, C2, V2)
+Map with following data
+Domain:
+=======
+Multivariate Polynomial Ring in a, b, c over Rational Field graded by
+  a -> [1]
+  b -> [1]
+  c -> [1]
+Codomain:
+=========
+Quotient of Multivariate Polynomial Ring in w, x, y, z over Rational Field graded by
+  w -> [1]
+  x -> [1]
+  y -> [1]
+  z -> [1] by ideal(-x*z + y^2, -w*z + x*y, -w*y + x^2)
 
 julia> nodalCubic = kernel(proj)
+ideal(-a^2*c + b^3 - 2*b^2*c + b*c^2)
 
 ```
 
@@ -328,10 +381,19 @@ julia> C3, x = PolynomialRing(QQ, "x" => 1:3);
 julia> V3 = [x[1]*x[2], x[1]*x[3], x[2]*x[3]];
 
 julia> F3 = hom(D3, C3, V3)
+Map with following data
+Domain:
+=======
+Multivariate Polynomial Ring in y[1], y[2], y[3] over Rational Field
+Codomain:
+=========
+Multivariate Polynomial Ring in x[1], x[2], x[3] over Rational Field
 
 julia> sphere = ideal(C3, [x[1]^3 + x[2]^3  + x[3]^3 - 1])
+ideal(x[1]^3 + x[2]^3 + x[3]^3 - 1)
 
 julia> steinerRomanSurface = preimage(F3, sphere)
+ideal(y[1]^6*y[2]^6 + 2*y[1]^6*y[2]^3*y[3]^3 + y[1]^6*y[3]^6 + 2*y[1]^3*y[2]^6*y[3]^3 + 2*y[1]^3*y[2]^3*y[3]^6 - y[1]^3*y[2]^3*y[3]^3 + y[2]^6*y[3]^6)
 
 ```
 
@@ -357,14 +419,23 @@ julia> C, p = quo(S, ideal(S, [c-b^3]));
 julia> V = [p(2*a + b^6), p(7*b - a^2), p(c^2)];
 
 julia> F = hom(D, C, V)
+Map with following data
+Domain:
+=======
+Multivariate Polynomial Ring in x, y, z over Rational Field
+Codomain:
+=========
+Quotient of Multivariate Polynomial Ring in a, b, c over Rational Field by ideal(-b^3 + c)
 
 julia> is_surjective(F)
+true
 
 julia> D1, _ = quo(D, kernel(F));
 
 julia> F1 = hom(D1, C, V);
 
 julia> is_bijective(F1)
+true
 
 ```
 
@@ -376,10 +447,18 @@ julia> C, (s, t) = PolynomialRing(QQ, ["s", "t"]);
 julia> V = [s*t, t, s^2];
 
 julia> paraWhitneyUmbrella = hom(R, C, V)
+Map with following data
+Domain:
+=======
+Multivariate Polynomial Ring in x, y, z over Rational Field
+Codomain:
+=========
+Multivariate Polynomial Ring in s, t over Rational Field
 
 julia> D, _ = quo(R, kernel(paraWhitneyUmbrella));
 
 julia> isfinite(hom(D, C, V))
+true
 
 ```
 
@@ -393,14 +472,24 @@ inverse(F::AffAlgHom)
 julia> D1, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"]);
 
 julia> D, _ = quo(D1, [y-x^2, z-x^3])
+(Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal(-x^2 + y, -x^3 + z), Map from
+Multivariate Polynomial Ring in x, y, z over Rational Field to Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal(-x^2 + y, -x^3 + z) defined by a julia-function with inverse)
 
 julia> C, (t,) = PolynomialRing(QQ, ["t"]);
 
 julia> para = hom(D, C, [t, t^2, t^3]);
 
 julia> is_bijective(para)
+true
 
 julia> inverse(para)
+Map with following data
+Domain:
+=======
+Multivariate Polynomial Ring in t over Rational Field
+Codomain:
+=========
+Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal(-x^2 + y, -x^3 + z)
 
 ```
 
@@ -434,10 +523,27 @@ julia> A, _ = quo(R, ideal(R, [x*y, x*z]));
 julia> L = noether_normalization(A);
 
 julia> L[1]
+2-element Vector{MPolyQuoElem{fmpq_mpoly}}:
+ -x + y
+ 2*x - 3*y + z
 
 julia> L[2]
+Map with following data
+Domain:
+=======
+Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal(x*y, x*z)
+Codomain:
+=========
+Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal(x^2 + x*y, x^2 + 3*x*y + x*z)
 
 julia> L[3]
+Map with following data
+Domain:
+=======
+Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal(x^2 + x*y, x^2 + 3*x*y + x*z)
+Codomain:
+=========
+Quotient of Multivariate Polynomial Ring in x, y, z over Rational Field by ideal(x*y, x*z)
 
 ```
 ## Normalization

--- a/docs/src/CommutativeAlgebra/binomial_ideals.md
+++ b/docs/src/CommutativeAlgebra/binomial_ideals.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -56,12 +59,17 @@ Papers offering details on theory and algorithms as well as examples include:
 is_binomial(f::MPolyElem)
 is_binomial(I::MPolyIdeal)
 ```
-```@repl oscar
-R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
-f = 2*x+y
-is_binomial(f)
-J = ideal(R, [x^2-y^3, z^2])
-is_binomial(J)
+```jldoctest
+julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+
+julia> f = 2*x+y
+
+julia> is_binomial(f)
+
+julia> J = ideal(R, [x^2-y^3, z^2])
+
+julia> is_binomial(J)
+
 ```
 
 ### Cellularity Test

--- a/docs/src/CommutativeAlgebra/binomial_ideals.md
+++ b/docs/src/CommutativeAlgebra/binomial_ideals.md
@@ -61,14 +61,19 @@ is_binomial(I::MPolyIdeal)
 ```
 ```jldoctest
 julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+(Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
 
 julia> f = 2*x+y
+2*x + y
 
 julia> is_binomial(f)
+true
 
 julia> J = ideal(R, [x^2-y^3, z^2])
+ideal(x^2 - y^3, z^2)
 
 julia> is_binomial(J)
+true
 
 ```
 

--- a/docs/src/CommutativeAlgebra/groebner_bases.md
+++ b/docs/src/CommutativeAlgebra/groebner_bases.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -64,7 +67,7 @@ Here are some illustrating OSCAR examples:
 
 ##### Examples
 
-```@jldoctest
+```jldoctest
 julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
 
@@ -87,7 +90,7 @@ julia> default_ordering(S)
 wdegrevlex([x, y, z], [1, 2, 3])
 ```
 
-```@jldoctest
+```jldoctest
 julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
 (Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
 

--- a/docs/src/CommutativeAlgebra/groebner_bases.md
+++ b/docs/src/CommutativeAlgebra/groebner_bases.md
@@ -88,6 +88,7 @@ julia> S, _ = grade(R, [1, 2, 3])
 
 julia> default_ordering(S)
 wdegrevlex([x, y, z], [1, 2, 3])
+
 ```
 
 ```jldoctest

--- a/docs/src/CommutativeAlgebra/groebner_bases_integers.md
+++ b/docs/src/CommutativeAlgebra/groebner_bases_integers.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -21,8 +24,11 @@ element of a corresponding strong Gröbner basis.
 
 The textbook [AL94](@cite) provides details on theory and algorithms as well as references.
 
-```@repl oscar
-R, (x,y) = PolynomialRing(ZZ, ["x","y"])
-I = ideal(R, [2x,3x,4y])
-H = groebner_basis(I)
+```jldoctest
+julia> R, (x,y) = PolynomialRing(ZZ, ["x","y"])
+
+julia> I = ideal(R, [2x,3x,4y])
+
+julia> H = groebner_basis(I)
+
 ```

--- a/docs/src/CommutativeAlgebra/groebner_bases_integers.md
+++ b/docs/src/CommutativeAlgebra/groebner_bases_integers.md
@@ -26,9 +26,16 @@ The textbook [AL94](@cite) provides details on theory and algorithms as well as 
 
 ```jldoctest
 julia> R, (x,y) = PolynomialRing(ZZ, ["x","y"])
+(Multivariate Polynomial Ring in x, y over Integer Ring, fmpz_mpoly[x, y])
 
 julia> I = ideal(R, [2x,3x,4y])
+ideal(2*x, 3*x, 4*y)
 
 julia> H = groebner_basis(I)
+Gröbner basis with elements
+1 -> 4*y
+2 -> x
+with respect to the ordering
+degrevlex([x, y])
 
 ```

--- a/docs/src/CommutativeAlgebra/ideals.md
+++ b/docs/src/CommutativeAlgebra/ideals.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -36,13 +39,19 @@ If `I` is an ideal of a multivariate polynomial ring  `R`, then
 
 ###### Examples
 
-```@repl oscar
-R, (x, y) = PolynomialRing(QQ, ["x", "y"])
-I = ideal(R, [x, y])^2
-base_ring(I)
-gens(I)
-ngens(I)
-gen(I, 2)
+```jldoctest
+julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
+
+julia> I = ideal(R, [x, y])^2
+
+julia> base_ring(I)
+
+julia> gens(I)
+
+julia> ngens(I)
+
+julia> gen(I, 2)
+
 ```
 
 ### Dimension

--- a/docs/src/CommutativeAlgebra/ideals.md
+++ b/docs/src/CommutativeAlgebra/ideals.md
@@ -41,16 +41,25 @@ If `I` is an ideal of a multivariate polynomial ring  `R`, then
 
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
+(Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
 
 julia> I = ideal(R, [x, y])^2
+ideal(x^2, x*y, y^2)
 
 julia> base_ring(I)
+Multivariate Polynomial Ring in x, y over Rational Field
 
 julia> gens(I)
+3-element Vector{fmpq_mpoly}:
+ x^2
+ x*y
+ y^2
 
 julia> ngens(I)
+3
 
 julia> gen(I, 2)
+x*y
 
 ```
 

--- a/docs/src/CommutativeAlgebra/localizations.md
+++ b/docs/src/CommutativeAlgebra/localizations.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar 
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -80,17 +83,27 @@ Containment in multiplicatively closed subsets can be checked via the `in` funct
 
 ##### Examples
 
-```@repl oscar
-R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
-S = complement_of_ideal(R, [0, 0 ,0])
-y in S
-P = ideal(R, [x])
-T = complement_of_ideal(P)
-y in T
-f = x
-U = powers_of_element(f)
-x^3 in U
-(1+y)*x^2 in product(S, U)
+```jldoctest
+julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+
+julia> S = complement_of_ideal(R, [0, 0 ,0])
+
+julia> y in S
+
+julia> P = ideal(R, [x])
+
+julia> T = complement_of_ideal(P)
+
+julia> y in T
+
+julia> f = x
+
+julia> U = powers_of_element(f)
+
+julia> x^3 in U
+
+julia> (1+y)*x^2 in product(S, U)
+
 ```
 
 
@@ -110,13 +123,19 @@ If `Rloc` is the localization of a multivariate polynomial ring `R`  at a multip
 
 ###### Examples
 
-```@repl oscar
-R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
-P = ideal(R, [x])
-U = complement_of_ideal(P)
-Rloc, _ = Localization(U);
-R === base_ring(Rloc)
-U === inverted_set(Rloc)
+```jldoctest
+julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+
+julia> P = ideal(R, [x])
+
+julia> U = complement_of_ideal(P)
+
+julia> Rloc, _ = Localization(U);
+
+julia> R === base_ring(Rloc)
+
+julia> U === inverted_set(Rloc)
+
 ```
 
 ### Elements of Localized Rings
@@ -134,16 +153,25 @@ under the localization map or by directly coercing (pairs of) elements of $R$ in
 
 ##### Examples
 
-```@repl oscar
-R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
-P = ideal(R, [x])
-U = complement_of_ideal(P)
-Rloc, iota = Localization(U);
-f = iota(x)
-f == Rloc(x)
-g = Rloc(y, z)
-f+g
-f*g
+```jldoctest
+julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+
+julia> P = ideal(R, [x])
+
+julia> U = complement_of_ideal(P)
+
+julia> Rloc, iota = Localization(U);
+
+julia> f = iota(x)
+
+julia> f == Rloc(x)
+
+julia> g = Rloc(y, z)
+
+julia> f+g
+
+julia> f*g
+
 ```
 
 #### Data Associated to Elements of Localized Rings
@@ -155,16 +183,25 @@ Given an element `f` of a localized multivariate ring polynomial `Rloc`,
 
 ##### Examples
 
-```@repl oscar
-R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
-P = ideal(R, [x])
-U = complement_of_ideal(P)
-Rloc, iota = Localization(U);
-f = iota(x)//iota(y)
-parent(f)
-g = iota(y)//iota(z)
-numerator(f*g)
-denominator(f*g)
+```jldoctest
+julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+
+julia> P = ideal(R, [x])
+
+julia> U = complement_of_ideal(P)
+
+julia> Rloc, iota = Localization(U);
+
+julia> f = iota(x)//iota(y)
+
+julia> parent(f)
+
+julia> g = iota(y)//iota(z)
+
+julia> numerator(f*g)
+
+julia> denominator(f*g)
+
 ```
 
 ### Homomorphisms from Localized Rings

--- a/docs/src/CommutativeAlgebra/localizations.md
+++ b/docs/src/CommutativeAlgebra/localizations.md
@@ -85,24 +85,34 @@ Containment in multiplicatively closed subsets can be checked via the `in` funct
 
 ```jldoctest
 julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+(Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
 
 julia> S = complement_of_ideal(R, [0, 0 ,0])
+complement of maximal ideal corresponding to point with coordinates fmpq[0, 0, 0]
 
 julia> y in S
+false
 
 julia> P = ideal(R, [x])
+ideal(x)
 
 julia> T = complement_of_ideal(P)
+complement of ideal(x)
 
 julia> y in T
+true
 
 julia> f = x
+x
 
 julia> U = powers_of_element(f)
+powers of fmpq_mpoly[x]
 
 julia> x^3 in U
+true
 
 julia> (1+y)*x^2 in product(S, U)
+true
 
 ```
 
@@ -125,16 +135,21 @@ If `Rloc` is the localization of a multivariate polynomial ring `R`  at a multip
 
 ```jldoctest
 julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+(Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
 
 julia> P = ideal(R, [x])
+ideal(x)
 
 julia> U = complement_of_ideal(P)
+complement of ideal(x)
 
 julia> Rloc, _ = Localization(U);
 
 julia> R === base_ring(Rloc)
+true
 
 julia> U === inverted_set(Rloc)
+true
 
 ```
 
@@ -155,22 +170,30 @@ under the localization map or by directly coercing (pairs of) elements of $R$ in
 
 ```jldoctest
 julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+(Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
 
 julia> P = ideal(R, [x])
+ideal(x)
 
 julia> U = complement_of_ideal(P)
+complement of ideal(x)
 
 julia> Rloc, iota = Localization(U);
 
 julia> f = iota(x)
+x//1
 
 julia> f == Rloc(x)
+true
 
 julia> g = Rloc(y, z)
+y//z
 
 julia> f+g
+(x*z + y)//z
 
 julia> f*g
+(x*y)//z
 
 ```
 
@@ -185,22 +208,30 @@ Given an element `f` of a localized multivariate ring polynomial `Rloc`,
 
 ```jldoctest
 julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+(Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
 
 julia> P = ideal(R, [x])
+ideal(x)
 
 julia> U = complement_of_ideal(P)
+complement of ideal(x)
 
 julia> Rloc, iota = Localization(U);
 
 julia> f = iota(x)//iota(y)
+x//y
 
 julia> parent(f)
+localization of Multivariate Polynomial Ring in x, y, z over Rational Field at the complement of ideal(x)
 
 julia> g = iota(y)//iota(z)
+y//z
 
 julia> numerator(f*g)
+x
 
 julia> denominator(f*g)
+z
 
 ```
 

--- a/docs/src/CommutativeAlgebra/orderings.md
+++ b/docs/src/CommutativeAlgebra/orderings.md
@@ -58,34 +58,55 @@ Here are some illustrating examples:
 
 ```jldoctest
 julia> S, (w, x) = PolynomialRing(QQ, ["w", "x"])
+(Multivariate Polynomial Ring in w, x over Rational Field, fmpq_mpoly[w, x])
 
 julia> o = lex([w, x])
+lex([w, x])
 
 julia> canonical_matrix(o)
+[1   0]
+[0   1]
 
 julia> cmp(o, w^2*x, x^3)
+1
 
 julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+(Multivariate Polynomial Ring in w, x, y, z over Rational Field, fmpq_mpoly[w, x, y, z])
 
 julia> o1 = degrevlex([w, x])
+degrevlex([w, x])
 
 julia> is_global(o1)
+true
 
 julia> canonical_matrix(o1)
+[1    1   0   0]
+[0   -1   0   0]
 
 julia> o2 = neglex([y, z])
+neglex([y, z])
 
 julia> is_local(o2)
+true
 
 julia> canonical_matrix(o2)
+[0   0   -1    0]
+[0   0    0   -1]
 
 julia> o3 = o1*o2
+degrevlex([w, x])*neglex([y, z])
 
 julia> canonical_matrix(o3)
+[1    1    0    0]
+[0   -1    0    0]
+[0    0   -1    0]
+[0    0    0   -1]
 
 julia> is_mixed(o3)
+true
 
 julia> show(collect(terms((1+w+x+y+z)^2, o3)))
+ERROR: MethodError: no method matching terms(::fmpq_mpoly, ::MonomialOrdering{FmpqMPolyRing})
 
 ```
 
@@ -331,8 +352,10 @@ In OSCAR, block orderings are obtained by the concatenation of individual  order
 
 ```jldoctest
 julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+(Multivariate Polynomial Ring in w, x, y, z over Rational Field, fmpq_mpoly[w, x, y, z])
 
 julia> o = degrevlex([w, x])*degrevlex([y, z])
+degrevlex([w, x])*degrevlex([y, z])
 
 ```
 
@@ -417,10 +440,13 @@ basis vectors as *lex*, and to the $i > j$ ordering as *revlex*. And, we use the
 julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"]);
 
 julia> F = free_module(R, 3)
+Free module of rank 3 over Multivariate Polynomial Ring in w, x, y, z over Rational Field
 
 julia> o1 = degrevlex(R)*revlex(gens(F))
+degrevlex([w, x, y, z])*revlex([gen(1), gen(2), gen(3)])
 
 julia> o2 = revlex(gens(F))*degrevlex(R)
+revlex([gen(1), gen(2), gen(3)])*degrevlex([w, x, y, z])
 
 ```
 

--- a/docs/src/CommutativeAlgebra/orderings.md
+++ b/docs/src/CommutativeAlgebra/orderings.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -53,22 +56,37 @@ Here are some illustrating examples:
 
 ##### Examples
 
-```@repl oscar
-S, (w, x) = PolynomialRing(QQ, ["w", "x"])
-o = lex([w, x])
-canonical_matrix(o)
-cmp(o, w^2*x, x^3)
-R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
-o1 = degrevlex([w, x])
-is_global(o1)
-canonical_matrix(o1)
-o2 = neglex([y, z])
-is_local(o2)
-canonical_matrix(o2)
-o3 = o1*o2
-canonical_matrix(o3)
-is_mixed(o3)
-show(collect(terms((1+w+x+y+z)^2, o3)))
+```jldoctest
+julia> S, (w, x) = PolynomialRing(QQ, ["w", "x"])
+
+julia> o = lex([w, x])
+
+julia> canonical_matrix(o)
+
+julia> cmp(o, w^2*x, x^3)
+
+julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+
+julia> o1 = degrevlex([w, x])
+
+julia> is_global(o1)
+
+julia> canonical_matrix(o1)
+
+julia> o2 = neglex([y, z])
+
+julia> is_local(o2)
+
+julia> canonical_matrix(o2)
+
+julia> o3 = o1*o2
+
+julia> canonical_matrix(o3)
+
+julia> is_mixed(o3)
+
+julia> show(collect(terms((1+w+x+y+z)^2, o3)))
+
 ```
 
 ## Monomial Comparisons
@@ -311,9 +329,11 @@ In OSCAR, block orderings are obtained by the concatenation of individual  order
 
 ##### Examples
 
-```@repl oscar
-R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
-o = degrevlex([w, x])*degrevlex([y, z])
+```jldoctest
+julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"])
+
+julia> o = degrevlex([w, x])*degrevlex([y, z])
+
 ```
 
 ## Elimination Orderings
@@ -393,11 +413,15 @@ basis vectors as *lex*, and to the $i > j$ ordering as *revlex*. And, we use the
 
 ##### Examples
 
-```@repl oscar
-R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"]);
-F = free_module(R, 3)
-o1 = degrevlex(R)*revlex(gens(F))
-o2 = revlex(gens(F))*degrevlex(R)
+```jldoctest
+julia> R, (w, x, y, z) = PolynomialRing(QQ, ["w", "x", "y", "z"]);
+
+julia> F = free_module(R, 3)
+
+julia> o1 = degrevlex(R)*revlex(gens(F))
+
+julia> o2 = revlex(gens(F))*degrevlex(R)
+
 ```
 
 The induced ordering on the given polynomial ring is recovered as follows:

--- a/docs/src/CommutativeAlgebra/orderings.md
+++ b/docs/src/CommutativeAlgebra/orderings.md
@@ -105,9 +105,6 @@ julia> canonical_matrix(o3)
 julia> is_mixed(o3)
 true
 
-julia> show(collect(terms((1+w+x+y+z)^2, o3)))
-ERROR: MethodError: no method matching terms(::fmpq_mpoly, ::MonomialOrdering{FmpqMPolyRing})
-
 ```
 
 ## Monomial Comparisons

--- a/docs/src/CommutativeAlgebra/rings.md
+++ b/docs/src/CommutativeAlgebra/rings.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -42,36 +45,54 @@ order). The other possible choices are `:deglex` and `:degrevlex`. Gröbner base
 
 ###### Examples
 
-```@repl oscar
-R, (x, y, z) = PolynomialRing(ZZ, ["x", "y", "z"])
-typeof(R)
-typeof(x)
-S, (x, y, z) = PolynomialRing(ZZ, ["x", "y", "z"])
-R === S
+```jldoctest
+julia> R, (x, y, z) = PolynomialRing(ZZ, ["x", "y", "z"])
+
+julia> typeof(R)
+
+julia> typeof(x)
+
+julia> S, (x, y, z) = PolynomialRing(ZZ, ["x", "y", "z"])
+
+julia> R === S
+
 ```
 
-```@repl oscar
-R1, x = PolynomialRing(QQ, ["x"])
-typeof(x)
-R2, (x,) = PolynomialRing(QQ, ["x"])
-typeof(x)
-R3, x = PolynomialRing(QQ, "x")
-typeof(x)
+```jldoctest
+julia> R1, x = PolynomialRing(QQ, ["x"])
+
+julia> typeof(x)
+
+julia> R2, (x,) = PolynomialRing(QQ, ["x"])
+
+julia> typeof(x)
+
+julia> R3, x = PolynomialRing(QQ, "x")
+
+julia> typeof(x)
+
 ```
 
-```@repl oscar
-V = ["x[1]", "x[2]"]
-T, x = PolynomialRing(GF(3), V)
-x
+```jldoctest
+julia> V = ["x[1]", "x[2]"]
+
+julia> T, x = PolynomialRing(GF(3), V)
+
+julia> x
+
 ```
 
 The constructor illustrated below allows for the convenient handling of variables with multi-indices:
 
-```@repl oscar
-R, x, y, z = PolynomialRing(QQ, "x" => (1:3, 1:4), "y" => 1:2, "z" => (1:1, 1:1, 1:1))
-x
-y
-z
+```jldoctest
+julia> R, x, y, z = PolynomialRing(QQ, "x" => (1:3, 1:4), "y" => 1:2, "z" => (1:1, 1:1, 1:1))
+
+julia> x
+
+julia> y
+
+julia> z
+
 ```
 
 ## Coefficient Rings 
@@ -80,47 +101,63 @@ Gröbner and standard bases are implemented for multivariate polynomial rings ov
 
 ###### The field of rational numbers $\mathbb{Q}$
 
-```@repl oscar
-QQ
+```jldoctest
+julia> QQ
+
 ```
 ###### Finite fields $\mathbb{F_p}$, $p$ a prime
 
-```@repl oscar
-GF(3)
-GF(ZZ(2)^127 - 1)
+```jldoctest
+julia> GF(3)
+
+julia> GF(ZZ(2)^127 - 1)
+
 ```
 
 ###### Finite fields $\mathbb{F}_{p^n}$ with $p^n$ elements, $p$ a prime
 
-```@repl oscar
-FiniteField(2, 70, "a")
+```jldoctest
+julia> FiniteField(2, 70, "a")
+
 ```
 
 ###### Simple algebraic extensions of $\mathbb{Q}$ or $\mathbb{F}_p$
   
-```@repl oscar
-T, t = PolynomialRing(QQ, "t")
-K, a = NumberField(t^2 + 1, "a")
-F = GF(3)
-T, t = PolynomialRing(F, "t")
-K, a = FiniteField(t^2 + 1, "a")
+```jldoctest
+julia> T, t = PolynomialRing(QQ, "t")
+
+julia> K, a = NumberField(t^2 + 1, "a")
+
+julia> F = GF(3)
+
+julia> T, t = PolynomialRing(F, "t")
+
+julia> K, a = FiniteField(t^2 + 1, "a")
+
 ```
 
 ###### Purely transcendental extensions of $\mathbb{Q}$ or $\mathbb{F}_p$
 
-```@repl oscar
-T, t = PolynomialRing(QQ, "t")
-QT = FractionField(T)
-parent(t)
-parent(1//t)
-T, (s, t) = PolynomialRing(GF(3), ["s", "t"]);
-QT = FractionField(T)
+```jldoctest
+julia> T, t = PolynomialRing(QQ, "t")
+
+julia> QT = FractionField(T)
+
+julia> parent(t)
+
+julia> parent(1//t)
+
+julia> T, (s, t) = PolynomialRing(GF(3), ["s", "t"]);
+
+julia> QT = FractionField(T)
+
 ```
 
 ###### The ring of integers $\mathbb{Z}$
 
-```@repl oscar
-ZZ
+```jldoctest
+julia> ZZ
+
 ```
 
 ## Gradings
@@ -226,13 +263,19 @@ Given  a multivariate polynomial ring `R` with coefficient ring `C`,
 
 ###### Examples
 
-```@repl oscar
-R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
-coefficient_ring(R)
-gens(R)
-gen(R, 2)
-R[3] 
-ngens(R)
+```jldoctest
+julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+
+julia> coefficient_ring(R)
+
+julia> gens(R)
+
+julia> gen(R, 2)
+
+julia> R[3] 
+
+julia> ngens(R)
+
 ```
 
 In the graded case, we additionally have:
@@ -255,14 +298,21 @@ basic arithmetic as shown below:
 
 ###### Examples
 
-```@repl oscar
-R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
-f = 3*x^2+y*z
-typeof(f)
-S, (x, y, z) = grade(R)
-g = 3*x^2+y*z
-typeof(g)
-g == S(f)
+```jldoctest
+julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+
+julia> f = 3*x^2+y*z
+
+julia> typeof(f)
+
+julia> S, (x, y, z) = grade(R)
+
+julia> g = 3*x^2+y*z
+
+julia> typeof(g)
+
+julia> g == S(f)
+
 ```
 
 Alternatively, there is the following constructor:
@@ -276,20 +326,28 @@ with exponent vectors given by the elements of `e`.
 
 ###### Examples
 
-```@repl oscar
-R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
-f = 3*x^2+y*z
-g = R(QQ.([3, 1]), [[2, 0, 0], [0, 1, 1]])
-f == g
+```jldoctest
+julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+
+julia> f = 3*x^2+y*z
+
+julia> g = R(QQ.([3, 1]), [[2, 0, 0], [0, 1, 1]])
+
+julia> f == g
+
 ```
 
 An often more effective way to create polynomials is to use the `MPoly` build context as indicated below:
 
-```@repl oscar
-R, (x, y) = PolynomialRing(QQ, ["x", "y"])
-B = MPolyBuildCtx(R)
-for i = 1:5 push_term!(B, QQ(i), [i, i-1]) end
-finish(B)
+```jldoctest
+julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
+
+julia> B = MPolyBuildCtx(R)
+
+julia> for i = 1:5 push_term!(B, QQ(i), [i, i-1]) end
+
+julia> finish(B)
+
 ```
 
 
@@ -312,17 +370,27 @@ Given an element `f` of a multivariate polynomial ring `R` or a graded version o
 
 ###### Examples
 
-```@repl oscar
-R, (x, y) = PolynomialRing(GF(5), ["x", "y"])
-c = map(GF(5), [1, 2, 3])
-e = [[3, 2], [1, 0], [0, 1]]
-f = R(c, e)
-parent(f)
-total_degree(f)
-coeff(f, 2)
-exponent_vector(f, 2)
-monomial(f, 2)
-term(f, 2)
+```jldoctest
+julia> R, (x, y) = PolynomialRing(GF(5), ["x", "y"])
+
+julia> c = map(GF(5), [1, 2, 3])
+
+julia> e = [[3, 2], [1, 0], [0, 1]]
+
+julia> f = R(c, e)
+
+julia> parent(f)
+
+julia> total_degree(f)
+
+julia> coeff(f, 2)
+
+julia> exponent_vector(f, 2)
+
+julia> monomial(f, 2)
+
+julia> term(f, 2)
+
 ```
 
 Further functionality is available in the graded case:

--- a/docs/src/CommutativeAlgebra/rings.md
+++ b/docs/src/CommutativeAlgebra/rings.md
@@ -47,29 +47,40 @@ order). The other possible choices are `:deglex` and `:degrevlex`. Gröbner base
 
 ```jldoctest
 julia> R, (x, y, z) = PolynomialRing(ZZ, ["x", "y", "z"])
+(Multivariate Polynomial Ring in x, y, z over Integer Ring, fmpz_mpoly[x, y, z])
 
 julia> typeof(R)
+FmpzMPolyRing
 
 julia> typeof(x)
+fmpz_mpoly
 
 julia> S, (x, y, z) = PolynomialRing(ZZ, ["x", "y", "z"])
+(Multivariate Polynomial Ring in x, y, z over Integer Ring, fmpz_mpoly[x, y, z])
 
 julia> R === S
+true
 
 ```
 
 ```jldoctest
 julia> R1, x = PolynomialRing(QQ, ["x"])
+(Multivariate Polynomial Ring in x over Rational Field, fmpq_mpoly[x])
 
 julia> typeof(x)
+Vector{fmpq_mpoly} (alias for Array{fmpq_mpoly, 1})
 
 julia> R2, (x,) = PolynomialRing(QQ, ["x"])
+(Multivariate Polynomial Ring in x over Rational Field, fmpq_mpoly[x])
 
 julia> typeof(x)
+fmpq_mpoly
 
 julia> R3, x = PolynomialRing(QQ, "x")
+(Univariate Polynomial Ring in x over Rational Field, x)
 
 julia> typeof(x)
+fmpq_poly
 
 ```
 
@@ -103,14 +114,17 @@ Gröbner and standard bases are implemented for multivariate polynomial rings ov
 
 ```jldoctest
 julia> QQ
+Rational Field
 
 ```
 ###### Finite fields $\mathbb{F_p}$, $p$ a prime
 
 ```jldoctest
 julia> GF(3)
+Galois field with characteristic 3
 
 julia> GF(ZZ(2)^127 - 1)
+Galois field with characteristic 170141183460469231731687303715884105727
 
 ```
 
@@ -118,6 +132,7 @@ julia> GF(ZZ(2)^127 - 1)
 
 ```jldoctest
 julia> FiniteField(2, 70, "a")
+(Finite field of degree 70 over F_2, a)
 
 ```
 
@@ -125,14 +140,19 @@ julia> FiniteField(2, 70, "a")
   
 ```jldoctest
 julia> T, t = PolynomialRing(QQ, "t")
+(Univariate Polynomial Ring in t over Rational Field, t)
 
 julia> K, a = NumberField(t^2 + 1, "a")
+(Number field over Rational Field with defining polynomial t^2 + 1, a)
 
 julia> F = GF(3)
+Galois field with characteristic 3
 
 julia> T, t = PolynomialRing(F, "t")
+(Univariate Polynomial Ring in t over Galois field with characteristic 3, t)
 
 julia> K, a = FiniteField(t^2 + 1, "a")
+(Finite field of degree 2 over F_3, a)
 
 ```
 
@@ -140,16 +160,21 @@ julia> K, a = FiniteField(t^2 + 1, "a")
 
 ```jldoctest
 julia> T, t = PolynomialRing(QQ, "t")
+(Univariate Polynomial Ring in t over Rational Field, t)
 
 julia> QT = FractionField(T)
+Fraction field of Univariate Polynomial Ring in t over Rational Field
 
 julia> parent(t)
+Univariate Polynomial Ring in t over Rational Field
 
 julia> parent(1//t)
+Fraction field of Univariate Polynomial Ring in t over Rational Field
 
 julia> T, (s, t) = PolynomialRing(GF(3), ["s", "t"]);
 
 julia> QT = FractionField(T)
+Fraction field of Multivariate Polynomial Ring in s, t over Galois field with characteristic 3
 
 ```
 
@@ -157,6 +182,7 @@ julia> QT = FractionField(T)
 
 ```jldoctest
 julia> ZZ
+Integer Ring
 
 ```
 
@@ -265,16 +291,25 @@ Given  a multivariate polynomial ring `R` with coefficient ring `C`,
 
 ```jldoctest
 julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+(Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
 
 julia> coefficient_ring(R)
+Rational Field
 
 julia> gens(R)
+3-element Vector{fmpq_mpoly}:
+ x
+ y
+ z
 
 julia> gen(R, 2)
+y
 
-julia> R[3] 
+julia> R[3]
+z 
 
 julia> ngens(R)
+3
 
 ```
 
@@ -300,18 +335,28 @@ basic arithmetic as shown below:
 
 ```jldoctest
 julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+(Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
 
 julia> f = 3*x^2+y*z
+3*x^2 + y*z
 
 julia> typeof(f)
+fmpq_mpoly
 
 julia> S, (x, y, z) = grade(R)
+(Multivariate Polynomial Ring in x, y, z over Rational Field graded by
+  x -> [1]
+  y -> [1]
+  z -> [1], MPolyElem_dec{fmpq, fmpq_mpoly}[x, y, z])
 
 julia> g = 3*x^2+y*z
+3*x^2 + y*z
 
 julia> typeof(g)
+MPolyElem_dec{fmpq, fmpq_mpoly}
 
 julia> g == S(f)
+true
 
 ```
 
@@ -328,12 +373,16 @@ with exponent vectors given by the elements of `e`.
 
 ```jldoctest
 julia> R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+(Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
 
 julia> f = 3*x^2+y*z
+3*x^2 + y*z
 
 julia> g = R(QQ.([3, 1]), [[2, 0, 0], [0, 1, 1]])
+3*x^2 + y*z
 
 julia> f == g
+true
 
 ```
 
@@ -341,12 +390,15 @@ An often more effective way to create polynomials is to use the `MPoly` build co
 
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
+(Multivariate Polynomial Ring in x, y over Rational Field, fmpq_mpoly[x, y])
 
 julia> B = MPolyBuildCtx(R)
+Builder for an element of Multivariate Polynomial Ring in x, y over Rational Field
 
 julia> for i = 1:5 push_term!(B, QQ(i), [i, i-1]) end
 
 julia> finish(B)
+5*x^5*y^4 + 4*x^4*y^3 + 3*x^3*y^2 + 2*x^2*y + x
 
 ```
 
@@ -372,24 +424,42 @@ Given an element `f` of a multivariate polynomial ring `R` or a graded version o
 
 ```jldoctest
 julia> R, (x, y) = PolynomialRing(GF(5), ["x", "y"])
+(Multivariate Polynomial Ring in x, y over Galois field with characteristic 5, gfp_mpoly[x, y])
 
 julia> c = map(GF(5), [1, 2, 3])
+3-element Vector{gfp_elem}:
+ 1
+ 2
+ 3
 
 julia> e = [[3, 2], [1, 0], [0, 1]]
+3-element Vector{Vector{Int64}}:
+ [3, 2]
+ [1, 0]
+ [0, 1]
 
 julia> f = R(c, e)
+x^3*y^2 + 2*x + 3*y
 
 julia> parent(f)
+Multivariate Polynomial Ring in x, y over Galois field with characteristic 5
 
 julia> total_degree(f)
+5
 
 julia> coeff(f, 2)
+2
 
 julia> exponent_vector(f, 2)
+2-element Vector{Int64}:
+ 1
+ 0
 
 julia> monomial(f, 2)
+x
 
 julia> term(f, 2)
+2*x
 
 ```
 

--- a/docs/src/CommutativeAlgebra/rings.md
+++ b/docs/src/CommutativeAlgebra/rings.md
@@ -85,24 +85,35 @@ fmpq_poly
 ```
 
 ```jldoctest
-julia> V = ["x[1]", "x[2]"]
-
-julia> T, x = PolynomialRing(GF(3), V)
+julia> T, x = PolynomialRing(GF(3), ["x[1]", "x[2]"]);
 
 julia> x
+2-element Vector{gfp_mpoly}:
+ x[1]
+ x[2]
 
 ```
 
 The constructor illustrated below allows for the convenient handling of variables with multi-indices:
 
 ```jldoctest
-julia> R, x, y, z = PolynomialRing(QQ, "x" => (1:3, 1:4), "y" => 1:2, "z" => (1:1, 1:1, 1:1))
+julia> R, x, y, z = PolynomialRing(QQ, "x" => (1:3, 1:4), "y" => 1:2, "z" => (1:1, 1:1, 1:1));
 
 julia> x
+3×4 Matrix{fmpq_mpoly}:
+ x[1, 1]  x[1, 2]  x[1, 3]  x[1, 4]
+ x[2, 1]  x[2, 2]  x[2, 3]  x[2, 4]
+ x[3, 1]  x[3, 2]  x[3, 3]  x[3, 4]
 
 julia> y
+2-element Vector{fmpq_mpoly}:
+ y[1]
+ y[2]
 
 julia> z
+1×1×1 Array{fmpq_mpoly, 3}:
+[:, :, 1] =
+ z[1, 1, 1]
 
 ```
 

--- a/docs/src/Experimental/elliptic_curves.md
+++ b/docs/src/Experimental/elliptic_curves.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -48,18 +51,27 @@ Addition and multiplication by an integer of a point on an elliptic curve can be
 
 #### Example
 
-```@repl oscar
-S, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
-T, _ = grade(S)
-E = Oscar.ProjEllipticCurve(T(y^2*z - x^3 + 2*x*z^2))
-PP = Oscar.proj_space(E)
-P = Oscar.Geometry.ProjSpcElem(PP, [QQ(2), QQ(2), QQ(1)])
-Q = Oscar.Point_EllCurve(E, P)
-Q+Q
-3*Q
-``` 
+```jldoctest
+julia> S, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+
+julia> T, _ = grade(S)
+
+julia> E = Oscar.ProjEllipticCurve(T(y^2*z - x^3 + 2*x*z^2))
+
+julia> PP = Oscar.proj_space(E)
+
+julia> P = Oscar.Geometry.ProjSpcElem(PP, [QQ(2), QQ(2), QQ(1)])
+
+julia> Q = Oscar.Point_EllCurve(E, P)
+
+julia> Q+Q
+
+julia> 3*Q
+
+```
 
 ### Weierstrass form
+
 ```@docs
 weierstrass_form(E::ProjEllipticCurve{S}) where {S <: FieldElem}
 toweierstrass(C::ProjPlaneCurve{S}, P::Oscar.Geometry.ProjSpcElem{S}) where S <: FieldElem
@@ -98,17 +110,27 @@ rand_pair_EllCurve_Point(R::Oscar.MPolyRing_dec{S}, PP::Oscar.Geometry.ProjSpc{S
 
 Projective elliptic curves over a ring are for example used in the Elliptic Curve Method. We give here an example (see Example 7.1 of [Was08](@cite)) on how to use the previous functions to apply it. 
 
-```@repl oscar
-n = 4453
-A = ResidueRing(ZZ, ZZ(n))
-S, (x,y,z) = PolynomialRing(A, ["x", "y", "z"])
-T, _ = grade(S)
-E = Oscar.ProjEllipticCurve(T(y^2*z - x^3 - 10*x*z^2 + 2*z^3))
-PP = proj_space(A, 2)
-Q = Oscar.Geometry.ProjSpcElem(PP[1], [A(1), A(3), A(1)])
-P = Oscar.Point_EllCurve(E, Q)
-P2 = Oscar.IntMult_Point_EllCurveZnZ(ZZ(2), P)
-Oscar.sum_Point_EllCurveZnZ(P, P2)
+```jldoctest
+julia> n = 4453
+
+julia> A = ResidueRing(ZZ, ZZ(n))
+
+julia> S, (x,y,z) = PolynomialRing(A, ["x", "y", "z"])
+
+julia> T, _ = grade(S)
+
+julia> E = Oscar.ProjEllipticCurve(T(y^2*z - x^3 - 10*x*z^2 + 2*z^3))
+
+julia> PP = proj_space(A, 2)
+
+julia> Q = Oscar.Geometry.ProjSpcElem(PP[1], [A(1), A(3), A(1)])
+
+julia> P = Oscar.Point_EllCurve(E, Q)
+
+julia> P2 = Oscar.IntMult_Point_EllCurveZnZ(ZZ(2), P)
+
+julia> Oscar.sum_Point_EllCurveZnZ(P, P2)
+
 ```
 
 The last sum is not defined, and the error which is shown when we ask for the sum gives us a factor of `4453`. The Elliptic Curve Method is implemented and can be called using:

--- a/docs/src/Experimental/elliptic_curves.md
+++ b/docs/src/Experimental/elliptic_curves.md
@@ -53,20 +53,31 @@ Addition and multiplication by an integer of a point on an elliptic curve can be
 
 ```jldoctest
 julia> S, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+(Multivariate Polynomial Ring in x, y, z over Rational Field, fmpq_mpoly[x, y, z])
 
 julia> T, _ = grade(S)
+(Multivariate Polynomial Ring in x, y, z over Rational Field graded by
+  x -> [1]
+  y -> [1]
+  z -> [1], MPolyElem_dec{fmpq, fmpq_mpoly}[x, y, z])
 
 julia> E = Oscar.ProjEllipticCurve(T(y^2*z - x^3 + 2*x*z^2))
+Projective elliptic curve defined by -x^3 + 2*x*z^2 + y^2*z
 
 julia> PP = Oscar.proj_space(E)
+Projective space of dim 2 over Rational Field
 
 julia> P = Oscar.Geometry.ProjSpcElem(PP, [QQ(2), QQ(2), QQ(1)])
+(2 : 2 : 1)
 
 julia> Q = Oscar.Point_EllCurve(E, P)
+(2 : 2 : 1)
 
 julia> Q+Q
+(9//4 : -21//8 : 1)
 
 julia> 3*Q
+(338 : 6214 : 1)
 
 ```
 
@@ -112,24 +123,38 @@ Projective elliptic curves over a ring are for example used in the Elliptic Curv
 
 ```jldoctest
 julia> n = 4453
+4453
 
 julia> A = ResidueRing(ZZ, ZZ(n))
+Integers modulo 4453
 
 julia> S, (x,y,z) = PolynomialRing(A, ["x", "y", "z"])
+(Multivariate Polynomial Ring in x, y, z over Integers modulo 4453, AbstractAlgebra.Generic.MPoly{fmpz_mod}[x, y, z])
 
 julia> T, _ = grade(S)
+(Multivariate Polynomial Ring in x, y, z over Integers modulo 4453 graded by
+  x -> [1]
+  y -> [1]
+  z -> [1], MPolyElem_dec{fmpz_mod, AbstractAlgebra.Generic.MPoly{fmpz_mod}}[x, y, z])
 
 julia> E = Oscar.ProjEllipticCurve(T(y^2*z - x^3 - 10*x*z^2 + 2*z^3))
+Projective elliptic curve defined by 4452*x^3 + 4443*x*z^2 + y^2*z + 2*z^3
 
 julia> PP = proj_space(A, 2)
+(Projective space of dim 2 over Integers modulo 4453
+, MPolyElem_dec{fmpz_mod, AbstractAlgebra.Generic.MPoly{fmpz_mod}}[x[0], x[1], x[2]])
 
 julia> Q = Oscar.Geometry.ProjSpcElem(PP[1], [A(1), A(3), A(1)])
+(1 : 3 : 1)
 
 julia> P = Oscar.Point_EllCurve(E, Q)
+(1 : 3 : 1)
 
 julia> P2 = Oscar.IntMult_Point_EllCurveZnZ(ZZ(2), P)
+(4332 : 3230 : 1)
 
 julia> Oscar.sum_Point_EllCurveZnZ(P, P2)
+ERROR: 61 is not invertible in the base ring, cannot perform the sum
 
 ```
 

--- a/docs/src/Experimental/plane_curves.md
+++ b/docs/src/Experimental/plane_curves.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -78,16 +81,19 @@ In order to define a point in the projective plane, one needs first to define
 the projective plane as follows, where `K` is the base ring:
 
 #### Example
-```@repl oscar
-K = QQ
-PP = proj_space(K, 2)
+```jldoctest
+julia> K = QQ
+
+julia> PP = proj_space(K, 2)
+
 ```
 
 Then, one can define a projective point as follows:
 
 #### Example
-```@repl oscar
-P = Oscar.Geometry.ProjSpcElem(PP[1], [QQ(1), QQ(2), QQ(-5)])
+```jldoctest
+julia> P = Oscar.Geometry.ProjSpcElem(PP[1], [QQ(1), QQ(2), QQ(-5)])
+
 ```
 
 The following function checks if a given point is on a curve:

--- a/docs/src/Experimental/plane_curves.md
+++ b/docs/src/Experimental/plane_curves.md
@@ -80,8 +80,7 @@ in(P::Point{S}, C::AffinePlaneCurve{S}) where S <: FieldElem
 In order to define a point in the projective plane, one needs first to define
 the projective plane as follows, where `K` is the base ring:
 
-#### Example
-```jldoctest
+```jldoctest plane_curves
 julia> K = QQ
 Rational Field
 
@@ -93,13 +92,9 @@ julia> PP = proj_space(K, 2)
 
 Then, one can define a projective point as follows:
 
-#### Example
-```jldoctest
+```jldoctest plane_curves
 julia> P = Oscar.Geometry.ProjSpcElem(PP[1], [QQ(1), QQ(2), QQ(-5)])
-ERROR: UndefVarError: PP not defined
-Stacktrace:
- [1] top-level scope
-   @ none:1
+(1 : 2 : -5)
 
 ```
 

--- a/docs/src/Experimental/plane_curves.md
+++ b/docs/src/Experimental/plane_curves.md
@@ -83,8 +83,11 @@ the projective plane as follows, where `K` is the base ring:
 #### Example
 ```jldoctest
 julia> K = QQ
+Rational Field
 
 julia> PP = proj_space(K, 2)
+(Projective space of dim 2 over Rational Field
+, MPolyElem_dec{fmpq, fmpq_mpoly}[x[0], x[1], x[2]])
 
 ```
 
@@ -93,6 +96,10 @@ Then, one can define a projective point as follows:
 #### Example
 ```jldoctest
 julia> P = Oscar.Geometry.ProjSpcElem(PP[1], [QQ(1), QQ(2), QQ(-5)])
+ERROR: UndefVarError: PP not defined
+Stacktrace:
+ [1] top-level scope
+   @ none:1
 
 ```
 

--- a/docs/src/General/architecture.md
+++ b/docs/src/General/architecture.md
@@ -1,13 +1,16 @@
-```@contents
-Pages = ["architecture.md"]
-```
-
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
 using Oscar
+```
+
+```@contents
+Pages = ["architecture.md"]
 ```
 
 # Architecture
@@ -33,8 +36,9 @@ by their names once OSCAR is loaded.
 
 The current versions of these packages can be inspected with the `Oscar.versioninfo` command:
 
-```@repl oscar
-Oscar.versioninfo()
+```jldoctest
+julia> Oscar.versioninfo()
+
 ```
 
 ## Binary packages for non-julia libraries
@@ -61,8 +65,9 @@ The binary packages can be found under the [JuliaBinaryWrappers organization](ht
 The `Oscar.versioninfo` function can also include the versions of all binary packages that are
 maintained by the OSCAR developers:
 
-```@repl oscar
-Oscar.versioninfo(jll=true)
+```jldoctest
+julia> Oscar.versioninfo(jll=true)
+
 ```
 
 For a full list of all dependencies of the current project please use

--- a/docs/src/General/architecture.md
+++ b/docs/src/General/architecture.md
@@ -36,9 +36,8 @@ by their names once OSCAR is loaded.
 
 The current versions of these packages can be inspected with the `Oscar.versioninfo` command:
 
-```jldoctest
-julia> Oscar.versioninfo()
-
+```@repl oscar
+Oscar.versioninfo()
 ```
 
 ## Binary packages for non-julia libraries
@@ -65,9 +64,8 @@ The binary packages can be found under the [JuliaBinaryWrappers organization](ht
 The `Oscar.versioninfo` function can also include the versions of all binary packages that are
 maintained by the OSCAR developers:
 
-```jldoctest
-julia> Oscar.versioninfo(jll=true)
-
+```@repl oscar
+Oscar.versioninfo(jll=true)
 ```
 
 For a full list of all dependencies of the current project please use

--- a/docs/src/InvariantTheory/finite_groups.md
+++ b/docs/src/InvariantTheory/finite_groups.md
@@ -86,24 +86,47 @@ Moreover, `is_modular(IR)` returns `true` in the modular case, and
 
 ```jldoctest
 julia> K, a = CyclotomicField(3, "a")
+(Cyclotomic field of order 3, a)
 
 julia> M1 = matrix(K, [0 0 1; 1 0 0; 0 1 0])
+[0   0   1]
+[1   0   0]
+[0   1   0]
 
 julia> M2 = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1])
+[1   0        0]
+[0   a        0]
+[0   0   -a - 1]
 
 julia> G = MatrixGroup(3, K, [ M1, M2 ])
+Matrix group of degree 3 over Cyclotomic field of order 3
 
 julia> IR = invariant_ring(G)
+Invariant ring of
+Matrix group of degree 3 over Cyclotomic field of order 3
+with generators
+AbstractAlgebra.Generic.MatSpaceElem{nf_elem}[[0 0 1; 1 0 0; 0 1 0], [1 0 0; 0 a 0; 0 0 -a-1]]
 
 julia> group(IR)
+Matrix group of degree 3 over Cyclotomic field of order 3
 
 julia> coefficient_ring(IR)
+Cyclotomic field of order 3
 
 julia> R = polynomial_ring(IR)
+Multivariate Polynomial Ring in x[1], x[2], x[3] over Cyclotomic field of order 3 graded by
+  x[1] -> [1]
+  x[2] -> [1]
+  x[3] -> [1]
 
 julia> x = gens(R)
+3-element Vector{MPolyElem_dec{nf_elem, AbstractAlgebra.Generic.MPoly{nf_elem}}}:
+ x[1]
+ x[2]
+ x[3]
 
 julia> is_modular(IR)
+false
 
 ```
 

--- a/docs/src/InvariantTheory/finite_groups.md
+++ b/docs/src/InvariantTheory/finite_groups.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -81,17 +84,27 @@ Moreover, `is_modular(IR)` returns `true` in the modular case, and
 
 ###### Examples
 
-```@repl oscar
-K, a = CyclotomicField(3, "a")
-M1 = matrix(K, [0 0 1; 1 0 0; 0 1 0])
-M2 = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1])
-G = MatrixGroup(3, K, [ M1, M2 ])
-IR = invariant_ring(G)
-group(IR)
-coefficient_ring(IR)
-R = polynomial_ring(IR)
-x = gens(R)
-is_modular(IR)
+```jldoctest
+julia> K, a = CyclotomicField(3, "a")
+
+julia> M1 = matrix(K, [0 0 1; 1 0 0; 0 1 0])
+
+julia> M2 = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1])
+
+julia> G = MatrixGroup(3, K, [ M1, M2 ])
+
+julia> IR = invariant_ring(G)
+
+julia> group(IR)
+
+julia> coefficient_ring(IR)
+
+julia> R = polynomial_ring(IR)
+
+julia> x = gens(R)
+
+julia> is_modular(IR)
+
 ```
 
 ## The Reynolds Operator

--- a/docs/src/NoncommutativeAlgebra/PBWAlgebras/creation.md
+++ b/docs/src/NoncommutativeAlgebra/PBWAlgebras/creation.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -76,16 +79,25 @@ Given a PBW-algebra `A` over a field `K`,
 
 ###### Examples
 
-```@repl oscar
-R, (x,y,z) = QQ["x", "y", "z"];
-L = [x*y, x*z, y*z + 1];
-REL = strictly_upper_triangular_matrix(L);
-A, (x,y,z) = pbw_algebra(R, REL, deglex(gens(R)));
-coefficient_ring(A)
-gens(A)
-gen(A, 2)
-A[3] 
-ngens(A)
+```jldoctest
+julia> R, (x,y,z) = QQ["x", "y", "z"];
+
+julia> L = [x*y, x*z, y*z + 1];
+
+julia> REL = strictly_upper_triangular_matrix(L);
+
+julia> A, (x,y,z) = pbw_algebra(R, REL, deglex(gens(R)));
+
+julia> coefficient_ring(A)
+
+julia> gens(A)
+
+julia> gen(A, 2)
+
+julia> A[3] 
+
+julia> ngens(A)
+
 ```
 
 ## Elements of PBW-Algebras
@@ -99,12 +111,17 @@ from the generators of `A` using basic arithmetic as shown below:
 
 ###### Examples
 
-```@repl oscar
-R, (x,y,z) = QQ["x", "y", "z"];
-L = [x*y, x*z, y*z + 1];
-REL = strictly_upper_triangular_matrix(L);
-A, (x,y,z) = pbw_algebra(R, REL, deglex(gens(R)));
-f = 3*x^2+z*y
+```jldoctest
+julia> R, (x,y,z) = QQ["x", "y", "z"];
+
+julia> L = [x*y, x*z, y*z + 1];
+
+julia> REL = strictly_upper_triangular_matrix(L);
+
+julia> A, (x,y,z) = pbw_algebra(R, REL, deglex(gens(R)));
+
+julia> f = 3*x^2+z*y
+
 ```
 
 Alternatively, there is the following constructor:
@@ -117,26 +134,40 @@ the elements of `cs` as coefficients, and the elements of `es` as exponents.
 
 ###### Examples
 
-```@repl oscar
-R, (x,y,z) = QQ["x", "y", "z"];
-L = [x*y, x*z, y*z + 1];
-REL = strictly_upper_triangular_matrix(L);
-A, (x,y,z) = pbw_algebra(R, REL, deglex(gens(R)));
-f = 3*x^2+z*y
-g = A(QQ.([3, 1, 1]), [[2, 0, 0], [0, 1, 1], [0, 0, 0]])
-f == g
+```jldoctest
+julia> R, (x,y,z) = QQ["x", "y", "z"];
+
+julia> L = [x*y, x*z, y*z + 1];
+
+julia> REL = strictly_upper_triangular_matrix(L);
+
+julia> A, (x,y,z) = pbw_algebra(R, REL, deglex(gens(R)));
+
+julia> f = 3*x^2+z*y
+
+julia> g = A(QQ.([3, 1, 1]), [[2, 0, 0], [0, 1, 1], [0, 0, 0]])
+
+julia> f == g
+
 ```
 
 An often more effective way to create elements is to use the corresponding build context as indicated below:
 
-```@repl oscar
-R, (x,y,z) = QQ["x", "y", "z"];
-L = [x*y, x*z, y*z + 1];
-REL = strictly_upper_triangular_matrix(L);
-A, (x,y,z) = pbw_algebra(R, REL, deglex(gens(R)));
-B =  build_ctx(A);
-for i = 1:5 push_term!(B, QQ(i), [i+1, i, i-1]) end
-finish(B)
+```jldoctest
+julia> R, (x,y,z) = QQ["x", "y", "z"];
+
+julia> L = [x*y, x*z, y*z + 1];
+
+julia> REL = strictly_upper_triangular_matrix(L);
+
+julia> A, (x,y,z) = pbw_algebra(R, REL, deglex(gens(R)));
+
+julia> B =  build_ctx(A);
+
+julia> for i = 1:5 push_term!(B, QQ(i), [i+1, i, i-1]) end
+
+julia> finish(B)
+
 ```
 
 ### Special Elements

--- a/docs/src/NoncommutativeAlgebra/PBWAlgebras/creation.md
+++ b/docs/src/NoncommutativeAlgebra/PBWAlgebras/creation.md
@@ -89,14 +89,22 @@ julia> REL = strictly_upper_triangular_matrix(L);
 julia> A, (x,y,z) = pbw_algebra(R, REL, deglex(gens(R)));
 
 julia> coefficient_ring(A)
+Rational Field
 
 julia> gens(A)
+3-element Vector{PBWAlgElem{fmpq, Singular.n_Q}}:
+ x
+ y
+ z
 
 julia> gen(A, 2)
+y
 
-julia> A[3] 
+julia> A[3]
+z 
 
 julia> ngens(A)
+3
 
 ```
 
@@ -121,6 +129,7 @@ julia> REL = strictly_upper_triangular_matrix(L);
 julia> A, (x,y,z) = pbw_algebra(R, REL, deglex(gens(R)));
 
 julia> f = 3*x^2+z*y
+3*x^2 + y*z + 1
 
 ```
 
@@ -144,10 +153,13 @@ julia> REL = strictly_upper_triangular_matrix(L);
 julia> A, (x,y,z) = pbw_algebra(R, REL, deglex(gens(R)));
 
 julia> f = 3*x^2+z*y
+3*x^2 + y*z + 1
 
 julia> g = A(QQ.([3, 1, 1]), [[2, 0, 0], [0, 1, 1], [0, 0, 0]])
+3*x^2 + y*z + 1
 
 julia> f == g
+true
 
 ```
 
@@ -167,6 +179,7 @@ julia> B =  build_ctx(A);
 julia> for i = 1:5 push_term!(B, QQ(i), [i+1, i, i-1]) end
 
 julia> finish(B)
+5*x^6*y^5*z^4 + 4*x^5*y^4*z^3 + 3*x^4*y^3*z^2 + 2*x^3*y^2*z + x^2*y
 
 ```
 

--- a/docs/src/NoncommutativeAlgebra/PBWAlgebras/ideals.md
+++ b/docs/src/NoncommutativeAlgebra/PBWAlgebras/ideals.md
@@ -45,16 +45,24 @@ If `I` is an ideal of a PBW-algebra  `A`, then
 
 ```jldoctest
 julia> D, (x, y, dx, dy) = weyl_algebra(QQ, ["x", "y"])
+(PBW-algebra over Rational Field in x, y, dx, dy with relations y*x = x*y, dx*x = x*dx + 1, dy*x = x*dy, dx*y = y*dx, dy*y = y*dy + 1, dy*dx = dx*dy, PBWAlgElem{fmpq, Singular.n_Q}[x, y, dx, dy])
 
 julia> I = left_ideal(D, [x, dx])
+left_ideal(x, dx)
 
 julia> base_ring(I)
+PBW-algebra over Rational Field in x, y, dx, dy with relations y*x = x*y, dx*x = x*dx + 1, dy*x = x*dy, dx*y = y*dx, dy*y = y*dy + 1, dy*dx = dx*dy
 
 julia> gens(I)
+2-element Vector{PBWAlgElem{fmpq, Singular.n_Q}}:
+ x
+ dx
 
 julia> ngens(I)
+2
 
 julia> gen(I, 2)
+dx
 
 ```
 

--- a/docs/src/NoncommutativeAlgebra/PBWAlgebras/ideals.md
+++ b/docs/src/NoncommutativeAlgebra/PBWAlgebras/ideals.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -40,13 +43,19 @@ If `I` is an ideal of a PBW-algebra  `A`, then
 
 ###### Examples
 
-```@repl oscar
-D, (x, y, dx, dy) = weyl_algebra(QQ, ["x", "y"])
-I = left_ideal(D, [x, dx])
-base_ring(I)
-gens(I)
-ngens(I)
-gen(I, 2)
+```jldoctest
+julia> D, (x, y, dx, dy) = weyl_algebra(QQ, ["x", "y"])
+
+julia> I = left_ideal(D, [x, dx])
+
+julia> base_ring(I)
+
+julia> gens(I)
+
+julia> ngens(I)
+
+julia> gen(I, 2)
+
 ```
 
 ## Operations on Ideals

--- a/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
@@ -70,8 +70,10 @@ its unique minimal $H$-representation:
 
 ```jldoctest
 julia> T = convex_hull([ 0 0 ; 1 0 ; 0 1; 0 1/2 ])
+A polyhedron in ambient dimension 2
 
 julia> halfspace_matrix_pair(facets(T))
+(A = [-1 0; 0 -1; 1 1], b = Polymake.RationalAllocated[0, 0, 1])
 
 ```
 

--- a/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
@@ -1,7 +1,7 @@
 ```@meta
 CurrentModule = Oscar
 DocTestSetup = quote
-   using Oscar
+  using Oscar
 end
 ```
 
@@ -68,9 +68,11 @@ convex_hull(::Type{T}, ::AnyVecOrMat; non_redundant::Bool=false) where T<:scalar
 This is a standard triangle, defined via a (redundant) $V$-representation  and
 its unique minimal $H$-representation:
 
-```@repl oscar
-T = convex_hull([ 0 0 ; 1 0 ; 0 1; 0 1/2 ])
-halfspace_matrix_pair(facets(T))
+```jldoctest
+julia> T = convex_hull([ 0 0 ; 1 0 ; 0 1; 0 1/2 ])
+
+julia> halfspace_matrix_pair(facets(T))
+
 ```
 
 The complete $V$-representation can be retrieved using [`vertices`](@ref

--- a/docs/src/PolyhedralGeometry/Polyhedra/polymake.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/polymake.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -35,9 +38,11 @@ Polyhedron{T}(::Polymake.BigObject) where T<:scalar_types
 
 The following shows all the data currently known for a `Polyhedron`.
 
-```@repl oscar
-C = cube(3)
-C.pm_polytope
+```jldoctest
+julia> C = cube(3)
+
+julia> C.pm_polytope
+
 ```
 
 `polymake` allows for an interactive visualization of 3-dimensional polytopes in the browser: `Polymake.visual(C.pm_polytope)`.
@@ -51,13 +56,16 @@ C.pm_polytope
 The next example shows a purely combinatorial construction of a polytope (here: a square).
 In spite of being given no coordinates, `polymake` can check for us that this is a simple polytope; i.e., each vertex is contained in dimension many facets.
 
-```@repl oscar
-Q = Polymake.polytope.Polytope(VERTICES_IN_FACETS=[[0,2],[1,3],[0,1],[2,3]]);
-Q.SIMPLE
+```jldoctest
+julia> Q = Polymake.polytope.Polytope(VERTICES_IN_FACETS=[[0,2],[1,3],[0,1],[2,3]]);
+
+julia> Q.SIMPLE
+
 ```
 
 However, without coordinates, some operations such as computing the volume cannot work:
-```@repl oscar
-Q.VOLUME
+```jldoctest
+julia> Q.VOLUME
+
 ```
 

--- a/docs/src/PolyhedralGeometry/Polyhedra/polymake.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/polymake.md
@@ -40,8 +40,39 @@ The following shows all the data currently known for a `Polyhedron`.
 
 ```jldoctest
 julia> C = cube(3)
+A polyhedron in ambient dimension 3
 
 julia> C.pm_polytope
+type: Polytope<Rational>
+description: cube of dimension 3
+
+AFFINE_HULL
+
+
+BOUNDED
+	true
+
+CONE_AMBIENT_DIM
+	4
+
+CONE_DIM
+	4
+
+FACETS
+  1   1   0   0
+  1  -1   0   0
+  1   0   1   0
+  1   0  -1   0
+  1   0   0   1
+  1   0   0  -1
+
+VERTICES_IN_FACETS
+	{0 2 4 6}
+	{1 3 5 7}
+	{0 1 4 5}
+	{2 3 6 7}
+	{0 1 2 3}
+	{4 5 6 7}
 
 ```
 
@@ -60,12 +91,17 @@ In spite of being given no coordinates, `polymake` can check for us that this is
 julia> Q = Polymake.polytope.Polytope(VERTICES_IN_FACETS=[[0,2],[1,3],[0,1],[2,3]]);
 
 julia> Q.SIMPLE
+true
 
 ```
 
 However, without coordinates, some operations such as computing the volume cannot work:
 ```jldoctest
 julia> Q.VOLUME
+ERROR: UndefVarError: Q not defined
+Stacktrace:
+ [1] top-level scope
+   @ none:1
 
 ```
 

--- a/docs/src/PolyhedralGeometry/Polyhedra/polymake.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/polymake.md
@@ -87,7 +87,7 @@ VERTICES_IN_FACETS
 The next example shows a purely combinatorial construction of a polytope (here: a square).
 In spite of being given no coordinates, `polymake` can check for us that this is a simple polytope; i.e., each vertex is contained in dimension many facets.
 
-```jldoctest
+```jldoctest polymake
 julia> Q = Polymake.polytope.Polytope(VERTICES_IN_FACETS=[[0,2],[1,3],[0,1],[2,3]]);
 
 julia> Q.SIMPLE
@@ -96,12 +96,8 @@ true
 ```
 
 However, without coordinates, some operations such as computing the volume cannot work:
-```jldoctest
+```jldoctest polymake
 julia> Q.VOLUME
-ERROR: UndefVarError: Q not defined
-Stacktrace:
- [1] top-level scope
-   @ none:1
+polymake:  WARNING: available properties insufficient to compute 'VOLUME'
 
 ```
-

--- a/docs/src/PolyhedralGeometry/Polyhedra/serialization.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/serialization.md
@@ -20,12 +20,16 @@ Objects of type `Polyhedron` can be saved to a file and loaded from a file in th
 following way:
 ```jldoctest
 julia> square = cube(2)
+A polyhedron in ambient dimension 2
 
 julia> save("square.poly", square)
+739
 
 julia> s = load("square.poly")
+A polyhedron in ambient dimension 2
 
 julia> s == square
+true
 
 ```
 The file is in JSON format and contains all previously gathered data belonging

--- a/docs/src/PolyhedralGeometry/Polyhedra/serialization.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/serialization.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -15,11 +18,15 @@ Pages = ["serialization.md"]
 
 Objects of type `Polyhedron` can be saved to a file and loaded from a file in the
 following way:
-```@repl oscar
-square = cube(2)
-save("square.poly", square)
-s = load("square.poly")
-s == square
+```jldoctest
+julia> square = cube(2)
+
+julia> save("square.poly", square)
+
+julia> s = load("square.poly")
+
+julia> s == square
+
 ```
 The file is in JSON format and contains all previously gathered data belonging
 to the underlying polymake object. In particular, this file can now be read by

--- a/docs/src/PolyhedralGeometry/cones.md
+++ b/docs/src/PolyhedralGeometry/cones.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -41,11 +44,15 @@ secondary_cone(SOP::SubdivisionOfPoints{T}) where T<:scalar_types
 
 Objects of type `Cone` can be saved to a file and loaded from a file in the
 following way:
-```@repl oscar
-C = positive_hull([1 0; 0 1])
-save("C.cone", C)
-CC = load("C.cone")
-collect(rays(CC))
+```jldoctest
+julia> C = positive_hull([1 0; 0 1])
+
+julia> save("C.cone", C)
+
+julia> CC = load("C.cone")
+
+julia> collect(rays(CC))
+
 ```
 The file is in JSON format and contains all previously gathered data belonging
 to the underlying polymake object. In particular, this file can now be read by

--- a/docs/src/PolyhedralGeometry/cones.md
+++ b/docs/src/PolyhedralGeometry/cones.md
@@ -46,12 +46,18 @@ Objects of type `Cone` can be saved to a file and loaded from a file in the
 following way:
 ```jldoctest
 julia> C = positive_hull([1 0; 0 1])
+A polyhedral cone in ambient dimension 2
 
 julia> save("C.cone", C)
+434
 
 julia> CC = load("C.cone")
+A polyhedral cone in ambient dimension 2
 
 julia> collect(rays(CC))
+2-element Vector{RayVector{fmpq}}:
+ [1, 0]
+ [0, 1]
 
 ```
 The file is in JSON format and contains all previously gathered data belonging

--- a/docs/src/PolyhedralGeometry/fans.md
+++ b/docs/src/PolyhedralGeometry/fans.md
@@ -47,14 +47,23 @@ Objects of type `PolyhedralFan` can be saved to a file and loaded from a file
 in the following way:
 ```jldoctest
 julia> square = cube(2)
+A polyhedron in ambient dimension 2
 
 julia> fan = normal_fan(square)
+A polyhedral fan in ambient dimension 2
 
 julia> save("F.fan", fan)
+610
 
 julia> f = load("F.fan")
+A polyhedral fan in ambient dimension 2
 
 julia> collect(rays(f))
+4-element Vector{RayVector{fmpq}}:
+ [1, 0]
+ [-1, 0]
+ [0, 1]
+ [0, -1]
 
 ```
 The file is in JSON format and contains all previously gathered data belonging

--- a/docs/src/PolyhedralGeometry/fans.md
+++ b/docs/src/PolyhedralGeometry/fans.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -42,12 +45,17 @@ face_fan(P::Polyhedron{T}) where T<:scalar_types
 
 Objects of type `PolyhedralFan` can be saved to a file and loaded from a file
 in the following way:
-```@repl oscar
-square = cube(2)
-fan = normal_fan(square)
-save("F.fan", fan)
-f = load("F.fan")
-collect(rays(f))
+```jldoctest
+julia> square = cube(2)
+
+julia> fan = normal_fan(square)
+
+julia> save("F.fan", fan)
+
+julia> f = load("F.fan")
+
+julia> collect(rays(f))
+
 ```
 The file is in JSON format and contains all previously gathered data belonging
 to the underlying polymake object. In particular, this file can now be read by

--- a/docs/src/PolyhedralGeometry/linear_programs.md
+++ b/docs/src/PolyhedralGeometry/linear_programs.md
@@ -119,13 +119,19 @@ optimal_vertex(lp::LinearProgram{T}) where T<:scalar_types
 
 Objects of type `LinearProgram` can be saved to a file and loaded from a file
 in the following way:
-```@repl oscar
-C = cube(3)
-LP=LinearProgram(C, [1,2,-3], convention=:min)
-save("lp.poly", LP)
-LP0 = load("lp.poly")
-solve_lp(LP0)
-solve_lp(LP)
+```jldoctest
+julia> C = cube(3)
+
+julia> LP=LinearProgram(C, [1,2,-3], convention=:min)
+
+julia> save("lp.poly", LP)
+
+julia> LP0 = load("lp.poly")
+
+julia> solve_lp(LP0)
+
+julia> solve_lp(LP)
+
 ```
 The file is in JSON format and contains all previously gathered data belonging
 to the underlying polymake object. In particular, this file can now be read by

--- a/docs/src/PolyhedralGeometry/linear_programs.md
+++ b/docs/src/PolyhedralGeometry/linear_programs.md
@@ -121,16 +121,30 @@ Objects of type `LinearProgram` can be saved to a file and loaded from a file
 in the following way:
 ```jldoctest
 julia> C = cube(3)
+A polyhedron in ambient dimension 3
 
 julia> LP=LinearProgram(C, [1,2,-3], convention=:min)
+The linear program
+   min{c⋅x + k | x ∈ P}
+where P is a Polyhedron{fmpq} and
+   c=Polymake.Rational[1 2 -3]
+   k=0
 
 julia> save("lp.poly", LP)
+1185
 
 julia> LP0 = load("lp.poly")
+The linear program
+   min{c⋅x + k | x ∈ P}
+where P is a Polyhedron{fmpq} and
+   c=Polymake.Rational[1 2 -3]
+   k=0
 
 julia> solve_lp(LP0)
+(-6, fmpq[-1, -1, 1])
 
 julia> solve_lp(LP)
+(-6, fmpq[-1, -1, 1])
 
 ```
 The file is in JSON format and contains all previously gathered data belonging

--- a/docs/src/PolyhedralGeometry/subdivisions_of_points.md
+++ b/docs/src/PolyhedralGeometry/subdivisions_of_points.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -51,13 +54,19 @@ closure of the set of all weight vectors realizing that subdivision.
 
 Objects of type `SubdivisionsOfPoints` can be saved to a file and loaded from a
 file in the following way:
-```@repl oscar
-moaepts = [4 0 0; 0 4 0; 0 0 4; 2 1 1; 1 2 1; 1 1 2]
-moaeincidence = IncidenceMatrix([[4,5,6],[1,4,2],[2,4,5],[2,3,5],[3,5,6],[1,3,6],[1,4,6]])
-MOAE = SubdivisionOfPoints(moaepts, moaeincidence)
-save("moae.sop", MOAE);
-SOP = load("moae.sop");
-is_regular(SOP)
+```jldoctest
+julia> moaepts = [4 0 0; 0 4 0; 0 0 4; 2 1 1; 1 2 1; 1 1 2]
+
+julia> moaeincidence = IncidenceMatrix([[4,5,6],[1,4,2],[2,4,5],[2,3,5],[3,5,6],[1,3,6],[1,4,6]])
+
+julia> MOAE = SubdivisionOfPoints(moaepts, moaeincidence)
+
+julia> save("moae.sop", MOAE);
+
+julia> SOP = load("moae.sop");
+
+julia> is_regular(SOP)
+
 ```
 The file is in JSON format and contains all previously gathered data belonging
 to the underlying polymake object. In particular, this file can now be read by

--- a/docs/src/PolyhedralGeometry/subdivisions_of_points.md
+++ b/docs/src/PolyhedralGeometry/subdivisions_of_points.md
@@ -56,16 +56,33 @@ Objects of type `SubdivisionsOfPoints` can be saved to a file and loaded from a
 file in the following way:
 ```jldoctest
 julia> moaepts = [4 0 0; 0 4 0; 0 0 4; 2 1 1; 1 2 1; 1 1 2]
+6×3 Matrix{Int64}:
+ 4  0  0
+ 0  4  0
+ 0  0  4
+ 2  1  1
+ 1  2  1
+ 1  1  2
 
 julia> moaeincidence = IncidenceMatrix([[4,5,6],[1,4,2],[2,4,5],[2,3,5],[3,5,6],[1,3,6],[1,4,6]])
+7×6 IncidenceMatrix
+[4, 5, 6]
+[1, 2, 4]
+[2, 4, 5]
+[2, 3, 5]
+[3, 5, 6]
+[1, 3, 6]
+[1, 4, 6]
 
 julia> MOAE = SubdivisionOfPoints(moaepts, moaeincidence)
+A subdivision of points in ambient dimension 3
 
 julia> save("moae.sop", MOAE);
 
 julia> SOP = load("moae.sop");
 
 julia> is_regular(SOP)
+false
 
 ```
 The file is in JSON format and contains all previously gathered data belonging

--- a/docs/src/Rings/integer.md
+++ b/docs/src/Rings/integer.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -43,22 +46,26 @@ an object encoding information about where that element belongs.
 
 The parent of an OSCAR integer is the ring of integers `ZZ`.
 
-```@repl oscar
-ZZ
+```jldoctest
+julia> ZZ
+
 ```
 
 ### Integer constructors
 
 OSCAR integers are created using `ZZ`:
 
-```@repl oscar
-ZZ(2)^100
-ZZ(618970019642690137449562111)
+```jldoctest
+julia> ZZ(2)^100
+
+julia> ZZ(618970019642690137449562111)
+
 ```
 One can also construct the integer ``0`` with the empty constructor:
 
-```@repl oscar
-ZZ()
+```jldoctest
+julia> ZZ()
+
 ```
 
 The following special constructors are also provided:
@@ -66,20 +73,26 @@ The following special constructors are also provided:
 * `zero(ZZ)`
 * `one(ZZ)`
 
-```@repl oscar
-zero(ZZ)
-one(ZZ)
+```jldoctest
+julia> zero(ZZ)
+
+julia> one(ZZ)
+
 ```
 
 Note that `ZZ` is not a Julia type, but the above methods of constructing
 OSCAR integers are similar to the way that Julia integer types can be used to
 construct Julia integers.
 
-```@repl oscar
-Int(123)
-BigInt(123456343567843598776327698374259876295438725)
-zero(BigInt)
-one(Int)
+```jldoctest
+julia> Int(123)
+
+julia> BigInt(123456343567843598776327698374259876295438725)
+
+julia> zero(BigInt)
+
+julia> one(Int)
+
 ```
 
 ### Limitations
@@ -104,13 +117,19 @@ at least one of the arguments is an `fmpz`, the function will generally behave
 as if all integer arguments were promoted to the type `fmpz`, and the integers
 in the return generally should also be of type `fmpz`. For example:
 
-```@repl oscar
-divexact(ZZ(234), 2)
-typeof(gcd(4, 6))
-typeof(gcdx(4, 6))
-typeof(gcd(4, ZZ(6)))
-typeof(gcdx(4, ZZ(6)))
-typeof(jacobi_symbol(ZZ(2), ZZ(3)))
+```jldoctest
+julia> divexact(ZZ(234), 2)
+
+julia> typeof(gcd(4, 6))
+
+julia> typeof(gcdx(4, 6))
+
+julia> typeof(gcd(4, ZZ(6)))
+
+julia> typeof(gcdx(4, ZZ(6)))
+
+julia> typeof(jacobi_symbol(ZZ(2), ZZ(3)))
+
 ```
 
 In the first example, `2` is a Julia integer but is still valid in the
@@ -135,11 +154,15 @@ declare a composite number to be prime with very low probability.
 Negative numbers, ``0`` and ``1`` are not considered prime by `is_prime` and
 `is_probable_prime`.
 
-```@repl oscar
-isone(ZZ(1))
-is_unit(ZZ(-1))
-is_square(ZZ(16))
-is_probable_prime(ZZ(23))
+```jldoctest
+julia> isone(ZZ(1))
+
+julia> is_unit(ZZ(-1))
+
+julia> is_square(ZZ(16))
+
+julia> is_probable_prime(ZZ(23))
+
 ```
 
 ## Properties
@@ -148,10 +171,13 @@ is_probable_prime(ZZ(23))
 
 Return the sign of `n`, i.e. ``n/|n|`` if ``n \neq 0``, or ``0`` otherwise.
 
-```@repl oscar
-sign(ZZ(23))
-sign(ZZ(0))
-sign(ZZ(-1))
+```jldoctest
+julia> sign(ZZ(23))
+
+julia> sign(ZZ(0))
+
+julia> sign(ZZ(-1))
+
 ```
 
 * `abs(n::fmpz) -> fmpz`
@@ -160,8 +186,9 @@ Return the absolute value of ``n``, i.e. ``n`` if ``n \geq 0`` and ``-n``
 otherwise
 
 
-```@repl oscar
-abs(ZZ(-3))
+```jldoctest
+julia> abs(ZZ(-3))
+
 ```
 
 ## Basic arithmetic
@@ -196,11 +223,15 @@ Return the quotient of ``a`` by ``b``. The result of the exact division of two
 integers will always be another integer. Exact division raises an exception if
 the division is not exact, or if division by zero is attempted.
 
-```@repl oscar
-divexact(ZZ(6), ZZ(3))
-divexact(ZZ(6), ZZ(0))
-divexact(ZZ(6), ZZ(5))
-divexact(ZZ(6), 2)
+```jldoctest
+julia> divexact(ZZ(6), ZZ(3))
+
+julia> divexact(ZZ(6), ZZ(0))
+
+julia> divexact(ZZ(6), ZZ(5))
+
+julia> divexact(ZZ(6), 2)
+
 ```
 
 ### Powering
@@ -209,9 +240,11 @@ divexact(ZZ(6), 2)
 
 Return the result of powering ``a`` by ``b``.
 
-```@repl oscar
-ZZ(37)^37
-ZZ(1)^(-2)
+```jldoctest
+julia> ZZ(37)^37
+
+julia> ZZ(1)^(-2)
+
 ```
 
 !!! note
@@ -225,8 +258,9 @@ ZZ(1)^(-2)
 
 The following is allowed for convenience.
 
-```@repl oscar
-ZZ(0)^0
+```jldoctest
+julia> ZZ(0)^0
+
 ```
 
 !!! note
@@ -258,11 +292,15 @@ the sign of ``r`` is the same as the sign of ``a``.
 
 All three functions raise an exception if the modulus ``b`` is zero.
 
-```@repl oscar
-divrem(ZZ(5), ZZ(3))
-div(ZZ(7), ZZ(2))
-rem(ZZ(4), ZZ(3))
-div(ZZ(2), ZZ(0))
+```jldoctest
+julia> divrem(ZZ(5), ZZ(3))
+
+julia> div(ZZ(7), ZZ(2))
+
+julia> rem(ZZ(4), ZZ(3))
+
+julia> div(ZZ(2), ZZ(0))
+
 ```
 
 !!! note
@@ -288,9 +326,11 @@ mod       |            | same as divisor  | towards ``-\infty``
 There is no function implemented to compute the quotient corresponding to
 the remainder given by `mod`.
 
-```@repl oscar
-mod(ZZ(4), ZZ(3))
-mod(ZZ(2), ZZ(0)) 
+```jldoctest
+julia> mod(ZZ(4), ZZ(3))
+
+julia> mod(ZZ(2), ZZ(0)) 
+
 ```
 
 ## [Divisibility testing](@id integer_divisibility_testing)
@@ -305,15 +345,18 @@ The call `divides(a, b)` returns a tuple `(flag, q)` where `flag` is either
 `false` if `b` does not divide `a` in which case `q` will be an integer whose
 value is not defined.
  
-```@repl oscar
-divides(ZZ(6), ZZ(3))
-divides(ZZ(5), ZZ(2))
+```jldoctest
+julia> divides(ZZ(6), ZZ(3))
+
+julia> divides(ZZ(5), ZZ(2))
+
 ```
 
 Note that for convenience we define:
 
-```@repl oscar
-divides(ZZ(0), ZZ(0))
+```jldoctest
+julia> divides(ZZ(0), ZZ(0))
+
 ```
 
 ## Greatest common divisor
@@ -327,9 +370,11 @@ largest integer dividing the two inputs, unless both inputs are zero in which
 case it returns zero. The result will always be non-negative and will only be
 zero if both inputs are zero.
 
-```@repl oscar
-gcd(ZZ(34), ZZ(17))
-gcd(ZZ(3), ZZ(0))
+```jldoctest
+julia> gcd(ZZ(34), ZZ(17))
+
+julia> gcd(ZZ(3), ZZ(0))
+
 ```
 
 ### Extended GCD
@@ -352,9 +397,11 @@ Return the least common multiple of ``a`` and ``b``. This is the least
 positive multiple of ``a`` and ``b``, unless ``a = 0`` or ``b = 0``
 which case we define the least common multiple to be zero.
 
-```@repl oscar
-lcm(ZZ(6), ZZ(21))
-lcm(ZZ(0), ZZ(0))
+```jldoctest
+julia> lcm(ZZ(6), ZZ(21))
+
+julia> lcm(ZZ(0), ZZ(0))
+
 ```
 
 ## Roots
@@ -374,11 +421,15 @@ Return the floor of the square root of its argument, i.e. the largest integer
 whose square does not exceed its input. An exception is raised if a negative
 input is passed.
 
-```@repl oscar
-isqrt(ZZ(16))
-isqrt(ZZ(0))
-isqrt(ZZ(5))
-isqrt(ZZ(-3))
+```jldoctest
+julia> isqrt(ZZ(16))
+
+julia> isqrt(ZZ(0))
+
+julia> isqrt(ZZ(5))
+
+julia> isqrt(ZZ(-3))
+
 ```
 
 * `isqrtrem(n::fmpz) -> (fmpz, fmpz)`
@@ -386,9 +437,11 @@ isqrt(ZZ(-3))
 Return the tuple `(s, r)` such that ``s`` is equal to `isqrt(n)` and
 ``n = s^2 + r``.
 
-```@repl oscar
-isqrtrem(ZZ(16))
-isqrtrem(ZZ(5))
+```jldoctest
+julia> isqrtrem(ZZ(16))
+
+julia> isqrtrem(ZZ(5))
+
 ```
 
 ### General roots
@@ -402,13 +455,19 @@ root of ``a``.
 When ``n`` is even, the non-negative root is always returned. An exception is
 raised if ``n \leq 0`` or if ``n`` is even and ``a < 0``.
 
-```@repl oscar
-root(ZZ(16), 4)
-root(ZZ(5), 2)
-root(ZZ(-5), 3)
-root(ZZ(0), 4)
-root(ZZ(-5), 2)
-root(ZZ(12), -2)
+```jldoctest
+julia> root(ZZ(16), 4)
+
+julia> root(ZZ(5), 2)
+
+julia> root(ZZ(-5), 3)
+
+julia> root(ZZ(0), 4)
+
+julia> root(ZZ(-5), 2)
+
+julia> root(ZZ(12), -2)
+
 ```
 
 ## Conversions
@@ -418,26 +477,32 @@ root(ZZ(12), -2)
 
 Convert the OSCAR integer to the respective Julia integer.
 
-```@repl oscar
-n = ZZ(123)
-Int(n)
-BigInt(n)
+```jldoctest
+julia> n = ZZ(123)
+
+julia> Int(n)
+
+julia> BigInt(n)
+
 ```
 
 In the case of `Int`, if the OSCAR integer is too large to fit, an exception
 is raised.
 
-```@repl oscar
-Int(ZZ(12348732648732648763274868732687324))
+```jldoctest
+julia> Int(ZZ(12348732648732648763274868732687324))
+
 ```
 
 * `fits(::Type{Int}, n::fmpz) -> Bool`
 
 Return `true` if the OSCAR integer will fit in an `Int`.
 
-```@repl oscar
-fits(Int, ZZ(123))
-fits(Int, ZZ(12348732648732648763274868732687324))
+```jldoctest
+julia> fits(Int, ZZ(123))
+
+julia> fits(Int, ZZ(12348732648732648763274868732687324))
+
 ```
 
 ## Factorisation
@@ -447,34 +512,42 @@ fits(Int, ZZ(12348732648732648763274868732687324))
 Return a factorisation of the given integer. The return value is a special
 factorisation struct which can be manipulated using the functions below.
 
-```@repl oscar
-factor(ZZ(-6000361807272228723606))
-factor(ZZ(0))
+```jldoctest
+julia> factor(ZZ(-6000361807272228723606))
+
+julia> factor(ZZ(0))
+
 ```
 
 * `unit(F::Fac) -> fmpz`
 
-```@repl oscar
-F = factor(ZZ(-12))
-unit(F)
+```jldoctest
+julia> F = factor(ZZ(-12))
+
+julia> unit(F)
+
 ```
 
 ### Factorisation are iterable
 
 Once created, a factorisation is iterable:
 
-```@repl oscar
-F = factor(ZZ(-60))
-for (p, e) in F; println("$p^$e"); end
+```jldoctest
+julia> F = factor(ZZ(-60))
+
+julia> for (p, e) in F; println("$p^$e"); end
+
 ```
 
 The pairs `(p, e)` in a factorisation represent the prime power factors
 ``p^e`` of the non-unit part of the factorisation. They can be placed in an
 array using `collect`:
 
-```@repl oscar
-F = factor(ZZ(-60))
-collect(F)
+```jldoctest
+julia> F = factor(ZZ(-60))
+
+julia> collect(F)
+
 ```
 
 ### Accessing exponents in a factorisation
@@ -486,13 +559,19 @@ is not in a factorisation is requested, an exception is raised.
 For convenience, a `Int` can be used instead of an OSCAR integer for this
 functionality.
 
-```@repl oscar
-F = factor(ZZ(-60))
-5 in F
-ZZ(3) in F
-7 in F
-F[3]
-F[ZZ(7)]
+```jldoctest
+julia> F = factor(ZZ(-60))
+
+julia> 5 in F
+
+julia> ZZ(3) in F
+
+julia> 7 in F
+
+julia> F[3]
+
+julia> F[ZZ(7)]
+
 ```
 
 ## Combinatorial functions
@@ -516,9 +595,11 @@ Return the factorial of ``n``, i.e. ``n!``. An exception is raised if
 Return ``x(x + 1)(x + 2)\ldots(x + n - 1)``. An exception is raised if
 ``n < 0``. We define `rising_factorial(x, 0)` to be ``1``.
 
-```@repl oscar
-factorial(ZZ(30))
-rising_factorial(ZZ(-30), 3)
+```jldoctest
+julia> factorial(ZZ(30))
+
+julia> rising_factorial(ZZ(-30), 3)
+
 ```
 
 ### Primorial
@@ -530,8 +611,9 @@ Return the primorial ``P(n)``, i.e. the product of all primes less than or
 equal to ``n``. An exception is raised if ``n < 0``. We define
 ``P(0) = P(1) = 1``.
 
-```@repl oscar
-primorial(ZZ(100))
+```jldoctest
+julia> primorial(ZZ(100))
+
 ```
 
 ### Bell numbers
@@ -542,8 +624,9 @@ primorial(ZZ(100))
 Return the ``n``-th Bell number ``B(n)``, i.e. the number of ways of
 partitioning a set of ``n`` elements. An exception is raised if ``n < 0``.
 
-```@repl oscar
-bell(ZZ(20))
+```jldoctest
+julia> bell(ZZ(20))
+
 ```
 
 ### Binomial coefficients
@@ -557,8 +640,9 @@ Return the binomial coefficient ``\frac{n (n-1) \cdots (n-k+1)}{k!}`` for
     Julia already defines the `binomial` function for `Int`, which throws an
     error on overflow.
 
-```@repl oscar
-binomial(ZZ(72), ZZ(15))
+```jldoctest
+julia> binomial(ZZ(72), ZZ(15))
+
 ```
 
 ### Integer partitions
@@ -570,8 +654,9 @@ Return the number of integer partitions ``p(n)`` of ``n``, i.e. the number
 of distinct ways to write ``n`` as a sum of positive integers. Note that
 ``p(0) = 1``, as the empty sum is counted. For ``n < 0`` we return zero.
 
-```@repl oscar
-number_of_partitions(ZZ(10^6))
+```jldoctest
+julia> number_of_partitions(ZZ(10^6))
+
 ```
 
 ### Fibonacci sequence
@@ -584,9 +669,11 @@ relation ``F(1) = 1``, ``F(2) = 1`` and ``F(n) = F(n - 1) + F(n - 2)`` for
 ``n \geq 3``. We define ``F(0) = 0`` and for ``n > 0`` we have
 ``F(-n) = (-1)^{n+1}F(n)``.
 
-```@repl oscar
-fibonacci(ZZ(100))
-fibonacci(-2)
+```jldoctest
+julia> fibonacci(ZZ(100))
+
+julia> fibonacci(-2)
+
 ```
 
 ## Number theoretic functionality
@@ -607,8 +694,9 @@ Return the Moebius function ``\mu(n)``, which is defined to be ``0`` if
 ``\mu(n)`` can be defined to be the sum of the primitive ``n``-th roots of
 unity. An exception is raised if ``n \leq 0``.
 
-```@repl oscar
-moebius_mu(30)
+```jldoctest
+julia> moebius_mu(30)
+
 ```
 
 ### Jacobi symbols
@@ -628,8 +716,9 @@ divides ``m`` and otherwise ``+1`` or ``-1`` depending on whether ``m`` is
 a square modulo ``p`` or not. An exception is raised if ``n`` is even or if
 ``n \leq 0``.
 
-```@repl oscar
-jacobi_symbol(3, 37)
+```jldoctest
+julia> jacobi_symbol(3, 37)
+
 ```
 
 ### Sigma function
@@ -644,8 +733,9 @@ Return the sum of the ``n``-th powers of the divisors of ``m``
 ```
 If ``m \leq 0`` or ``n < 0`` we raise an exception.
 
-```@repl oscar
-divisor_sigma(60, 5)
+```jldoctest
+julia> divisor_sigma(60, 5)
+
 ```
 
 ### Euler totient function
@@ -657,7 +747,8 @@ Return the Euler totient function ``\varphi(n)``, i.e. the number of positive
 integers ``1 \leq x \leq n`` which are coprime to ``n``. Note that
 ``\varphi(1) = 1``. We raise an exception if ``n \leq 0``.
 
-```@repl oscar
-euler_phi(200)
+```jldoctest
+julia> euler_phi(200)
+
 ```
 

--- a/docs/src/Rings/integer.md
+++ b/docs/src/Rings/integer.md
@@ -48,6 +48,7 @@ The parent of an OSCAR integer is the ring of integers `ZZ`.
 
 ```jldoctest
 julia> ZZ
+Integer Ring
 
 ```
 
@@ -57,14 +58,17 @@ OSCAR integers are created using `ZZ`:
 
 ```jldoctest
 julia> ZZ(2)^100
+1267650600228229401496703205376
 
 julia> ZZ(618970019642690137449562111)
+618970019642690137449562111
 
 ```
 One can also construct the integer ``0`` with the empty constructor:
 
 ```jldoctest
 julia> ZZ()
+0
 
 ```
 
@@ -75,8 +79,10 @@ The following special constructors are also provided:
 
 ```jldoctest
 julia> zero(ZZ)
+0
 
 julia> one(ZZ)
+1
 
 ```
 
@@ -86,12 +92,16 @@ construct Julia integers.
 
 ```jldoctest
 julia> Int(123)
+123
 
 julia> BigInt(123456343567843598776327698374259876295438725)
+123456343567843598776327698374259876295438725
 
 julia> zero(BigInt)
+0
 
 julia> one(Int)
+1
 
 ```
 
@@ -119,16 +129,22 @@ in the return generally should also be of type `fmpz`. For example:
 
 ```jldoctest
 julia> divexact(ZZ(234), 2)
+117
 
 julia> typeof(gcd(4, 6))
+Int64
 
 julia> typeof(gcdx(4, 6))
+Tuple{Int64, Int64, Int64}
 
 julia> typeof(gcd(4, ZZ(6)))
+fmpz
 
 julia> typeof(gcdx(4, ZZ(6)))
+Tuple{fmpz, fmpz, fmpz}
 
 julia> typeof(jacobi_symbol(ZZ(2), ZZ(3)))
+Int64
 
 ```
 
@@ -156,12 +172,16 @@ Negative numbers, ``0`` and ``1`` are not considered prime by `is_prime` and
 
 ```jldoctest
 julia> isone(ZZ(1))
+true
 
 julia> is_unit(ZZ(-1))
+true
 
 julia> is_square(ZZ(16))
+true
 
 julia> is_probable_prime(ZZ(23))
+true
 
 ```
 
@@ -173,10 +193,13 @@ Return the sign of `n`, i.e. ``n/|n|`` if ``n \neq 0``, or ``0`` otherwise.
 
 ```jldoctest
 julia> sign(ZZ(23))
+1
 
 julia> sign(ZZ(0))
+0
 
 julia> sign(ZZ(-1))
+-1
 
 ```
 
@@ -188,6 +211,7 @@ otherwise
 
 ```jldoctest
 julia> abs(ZZ(-3))
+3
 
 ```
 
@@ -225,12 +249,16 @@ the division is not exact, or if division by zero is attempted.
 
 ```jldoctest
 julia> divexact(ZZ(6), ZZ(3))
+2
 
 julia> divexact(ZZ(6), ZZ(0))
+ERROR: DivideError: integer division error
 
 julia> divexact(ZZ(6), ZZ(5))
+ERROR: ArgumentError: Not an exact division
 
 julia> divexact(ZZ(6), 2)
+3
 
 ```
 
@@ -242,8 +270,10 @@ Return the result of powering ``a`` by ``b``.
 
 ```jldoctest
 julia> ZZ(37)^37
+10555134955777783414078330085995832946127396083370199442517
 
 julia> ZZ(1)^(-2)
+1
 
 ```
 
@@ -260,6 +290,7 @@ The following is allowed for convenience.
 
 ```jldoctest
 julia> ZZ(0)^0
+1
 
 ```
 
@@ -294,12 +325,16 @@ All three functions raise an exception if the modulus ``b`` is zero.
 
 ```jldoctest
 julia> divrem(ZZ(5), ZZ(3))
+(1, 2)
 
 julia> div(ZZ(7), ZZ(2))
+3
 
 julia> rem(ZZ(4), ZZ(3))
+1
 
 julia> div(ZZ(2), ZZ(0))
+ERROR: DivideError: integer division error
 
 ```
 
@@ -328,8 +363,10 @@ the remainder given by `mod`.
 
 ```jldoctest
 julia> mod(ZZ(4), ZZ(3))
+1
 
-julia> mod(ZZ(2), ZZ(0)) 
+julia> mod(ZZ(2), ZZ(0))
+ERROR: DivideError: integer division error
 
 ```
 
@@ -347,8 +384,10 @@ value is not defined.
  
 ```jldoctest
 julia> divides(ZZ(6), ZZ(3))
+(true, 2)
 
 julia> divides(ZZ(5), ZZ(2))
+(false, 0)
 
 ```
 
@@ -356,6 +395,7 @@ Note that for convenience we define:
 
 ```jldoctest
 julia> divides(ZZ(0), ZZ(0))
+(true, 0)
 
 ```
 
@@ -372,8 +412,10 @@ zero if both inputs are zero.
 
 ```jldoctest
 julia> gcd(ZZ(34), ZZ(17))
+17
 
 julia> gcd(ZZ(3), ZZ(0))
+3
 
 ```
 
@@ -399,8 +441,10 @@ which case we define the least common multiple to be zero.
 
 ```jldoctest
 julia> lcm(ZZ(6), ZZ(21))
+42
 
 julia> lcm(ZZ(0), ZZ(0))
+0
 
 ```
 
@@ -423,12 +467,17 @@ input is passed.
 
 ```jldoctest
 julia> isqrt(ZZ(16))
+4
 
 julia> isqrt(ZZ(0))
+0
 
 julia> isqrt(ZZ(5))
+2
 
 julia> isqrt(ZZ(-3))
+ERROR: DomainError with -3:
+Argument must be non-negative
 
 ```
 
@@ -439,8 +488,10 @@ Return the tuple `(s, r)` such that ``s`` is equal to `isqrt(n)` and
 
 ```jldoctest
 julia> isqrtrem(ZZ(16))
+(4, 0)
 
 julia> isqrtrem(ZZ(5))
+(2, 1)
 
 ```
 
@@ -457,16 +508,24 @@ raised if ``n \leq 0`` or if ``n`` is even and ``a < 0``.
 
 ```jldoctest
 julia> root(ZZ(16), 4)
+2
 
 julia> root(ZZ(5), 2)
+2
 
 julia> root(ZZ(-5), 3)
+-1
 
 julia> root(ZZ(0), 4)
+0
 
 julia> root(ZZ(-5), 2)
+ERROR: DomainError with (-5, 2):
+Argument `x` must be positive if exponent `n` is even
 
 julia> root(ZZ(12), -2)
+ERROR: DomainError with -2:
+Exponent must be positive
 
 ```
 
@@ -479,10 +538,13 @@ Convert the OSCAR integer to the respective Julia integer.
 
 ```jldoctest
 julia> n = ZZ(123)
+123
 
 julia> Int(n)
+123
 
 julia> BigInt(n)
+123
 
 ```
 
@@ -491,6 +553,7 @@ is raised.
 
 ```jldoctest
 julia> Int(ZZ(12348732648732648763274868732687324))
+ERROR: InexactError: convert(Int64, 12348732648732648763274868732687324)
 
 ```
 
@@ -500,8 +563,10 @@ Return `true` if the OSCAR integer will fit in an `Int`.
 
 ```jldoctest
 julia> fits(Int, ZZ(123))
+true
 
 julia> fits(Int, ZZ(12348732648732648763274868732687324))
+false
 
 ```
 
@@ -514,8 +579,10 @@ factorisation struct which can be manipulated using the functions below.
 
 ```jldoctest
 julia> factor(ZZ(-6000361807272228723606))
+-1 * 2 * 229^3 * 43669^3 * 3
 
 julia> factor(ZZ(0))
+ERROR: ArgumentError: Argument is not non-zero
 
 ```
 
@@ -523,8 +590,10 @@ julia> factor(ZZ(0))
 
 ```jldoctest
 julia> F = factor(ZZ(-12))
+-1 * 2^2 * 3
 
 julia> unit(F)
+-1
 
 ```
 
@@ -534,8 +603,12 @@ Once created, a factorisation is iterable:
 
 ```jldoctest
 julia> F = factor(ZZ(-60))
+-1 * 5 * 2^2 * 3
 
 julia> for (p, e) in F; println("$p^$e"); end
+5^1
+2^2
+3^1
 
 ```
 
@@ -545,8 +618,13 @@ array using `collect`:
 
 ```jldoctest
 julia> F = factor(ZZ(-60))
+-1 * 5 * 2^2 * 3
 
 julia> collect(F)
+3-element Vector{Pair{fmpz, Int64}}:
+ 5 => 1
+ 2 => 2
+ 3 => 1
 
 ```
 
@@ -561,16 +639,22 @@ functionality.
 
 ```jldoctest
 julia> F = factor(ZZ(-60))
+-1 * 5 * 2^2 * 3
 
 julia> 5 in F
+true
 
 julia> ZZ(3) in F
+true
 
 julia> 7 in F
+false
 
 julia> F[3]
+1
 
 julia> F[ZZ(7)]
+ERROR: 7 is not a factor of -1 * 5 * 2^2 * 3
 
 ```
 
@@ -597,8 +681,10 @@ Return ``x(x + 1)(x + 2)\ldots(x + n - 1)``. An exception is raised if
 
 ```jldoctest
 julia> factorial(ZZ(30))
+265252859812191058636308480000000
 
 julia> rising_factorial(ZZ(-30), 3)
+-24360
 
 ```
 
@@ -613,6 +699,7 @@ equal to ``n``. An exception is raised if ``n < 0``. We define
 
 ```jldoctest
 julia> primorial(ZZ(100))
+2305567963945518424753102147331756070
 
 ```
 
@@ -626,6 +713,7 @@ partitioning a set of ``n`` elements. An exception is raised if ``n < 0``.
 
 ```jldoctest
 julia> bell(ZZ(20))
+51724158235372
 
 ```
 
@@ -642,6 +730,7 @@ Return the binomial coefficient ``\frac{n (n-1) \cdots (n-k+1)}{k!}`` for
 
 ```jldoctest
 julia> binomial(ZZ(72), ZZ(15))
+1155454041309504
 
 ```
 
@@ -656,6 +745,7 @@ of distinct ways to write ``n`` as a sum of positive integers. Note that
 
 ```jldoctest
 julia> number_of_partitions(ZZ(10^6))
+1471684986358223398631004760609895943484030484439142125334612747351666117418918618276330148873983597555842015374130600288095929387347128232270327849578001932784396072064228659048713020170971840761025676479860846908142829356706929785991290519899445490672219997823452874982974022288229850136767566294781887494687879003824699988197729200632068668735996662273816798266213482417208446631027428001918132198177180646511234542595026728424452592296781193448139994664730105742564359154794989181485285351370551399476719981691459022015599101959601417474075715430750022184895815209339012481734469448319323280150665384042994054179587751761294916248142479998802936507195257074485047571662771763903391442495113823298195263008336489826045837712202455304996382144601028531832004519046591968302787537418118486000612016852593542741980215046267245473237321845833427512524227465399130174076941280847400831542217999286071108336303316298289102444649696805395416791875480010852636774022023128467646919775022348562520747741843343657801534130704761975530375169707999287040285677841619347472368171772154046664303121315630003467104673818
 
 ```
 
@@ -671,8 +761,10 @@ relation ``F(1) = 1``, ``F(2) = 1`` and ``F(n) = F(n - 1) + F(n - 2)`` for
 
 ```jldoctest
 julia> fibonacci(ZZ(100))
+354224848179261915075
 
 julia> fibonacci(-2)
+-1
 
 ```
 
@@ -696,6 +788,7 @@ unity. An exception is raised if ``n \leq 0``.
 
 ```jldoctest
 julia> moebius_mu(30)
+-1
 
 ```
 
@@ -718,6 +811,7 @@ a square modulo ``p`` or not. An exception is raised if ``n`` is even or if
 
 ```jldoctest
 julia> jacobi_symbol(3, 37)
+1
 
 ```
 
@@ -735,6 +829,7 @@ If ``m \leq 0`` or ``n < 0`` we raise an exception.
 
 ```jldoctest
 julia> divisor_sigma(60, 5)
+806220408
 
 ```
 
@@ -749,6 +844,7 @@ integers ``1 \leq x \leq n`` which are coprime to ``n``. Note that
 
 ```jldoctest
 julia> euler_phi(200)
+80
 
 ```
 

--- a/docs/src/Rings/rational.md
+++ b/docs/src/Rings/rational.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 ```@setup oscar
@@ -31,9 +34,11 @@ constructor.
 
 For convenience, `QQ` is already defined to be the field of rational numbers.
 
-```@repl oscar
-S = FractionField(ZZ)
-QQ
+```jldoctest
+julia> S = FractionField(ZZ)
+
+julia> QQ
+
 ```
 
 ### Integer constructors
@@ -51,18 +56,25 @@ OSCAR rational if either the numerator or denominator is an OSCAR integer.
 
 An exception is raised if a fraction is constructed with denominator zero.
 
-```@repl oscar
-QQ(1, 2)
-QQ(5)
-ZZ(3)//5
-1//ZZ(7)
-QQ(2//3)
-ZZ(3)//0
+```jldoctest
+julia> QQ(1, 2)
+
+julia> QQ(5)
+
+julia> ZZ(3)//5
+
+julia> 1//ZZ(7)
+
+julia> QQ(2//3)
+
+julia> ZZ(3)//0
+
 ```
 One can also construct the rational number ``0`` with the empty constructor:
 
-```@repl oscar
-QQ()
+```jldoctest
+julia> QQ()
+
 ```
 
 The following special constructors are also provided:
@@ -70,9 +82,11 @@ The following special constructors are also provided:
 * `zero(QQ)`
 * `one(QQ)`
 
-```@repl oscar
-zero(QQ)
-one(QQ)
+```jldoctest
+julia> zero(QQ)
+
+julia> one(QQ)
+
 ```
 
 ## Predicates
@@ -83,10 +97,13 @@ one(QQ)
 
 The `is_unit` function will return `true` iff ``n \neq 0``.
 
-```@repl oscar
-iszero(QQ())
-isone(one(QQ))
-is_unit(QQ(-2, 3))
+```jldoctest
+julia> iszero(QQ())
+
+julia> isone(one(QQ))
+
+julia> is_unit(QQ(-2, 3))
+
 ```
 
 ## Properties
@@ -100,10 +117,13 @@ Return the numerator and denominator respectively, of $n$.
 
 Return the sign of `n`, i.e. ``n/|n|`` if ``n \neq 0``, or ``0`` otherwise.
 
-```@repl oscar
-sign(QQ(2, 3))
-sign(QQ())
-sign(QQ(-1))
+```jldoctest
+julia> sign(QQ(2, 3))
+
+julia> sign(QQ())
+
+julia> sign(QQ(-1))
+
 ```
 
 * `abs(n::fmpq) -> fmpq`
@@ -112,8 +132,9 @@ Return the absolute value of ``n``, i.e. ``n`` if ``n \geq 0`` and ``-n``
 otherwise.
 
 
-```@repl oscar
-abs(QQ(-3, 2))
+```jldoctest
+julia> abs(QQ(-3, 2))
+
 ```
 
 * `height(n::fmpq) -> fmpz`
@@ -121,8 +142,9 @@ abs(QQ(-3, 2))
 Return the maximum of the absolute values of the numerator and denominator of
 $n$.
 
-```@repl oscar
-height(QQ(324987329, -8372492324))
+```jldoctest
+julia> height(QQ(324987329, -8372492324))
+
 ```
 
 * `floor(n::fmpq) -> fmpq`
@@ -133,11 +155,15 @@ Return the greatest integer $m$ (as a rational number) such that $m \leq n$.
 
 Return the least integer $m$ (as a rational number) such that $m \geq n$.
 
-```@repl oscar
-floor(QQ(-2, 3))
-ceil(QQ(7, 2))
-typeof(ans)
-ceil(QQ(5))
+```jldoctest
+julia> floor(QQ(-2, 3))
+
+julia> ceil(QQ(7, 2))
+
+julia> typeof(ans)
+
+julia> ceil(QQ(5))
+
 ```
 * `floor(fmpz, n::fmpq) -> fmpz`
 
@@ -147,11 +173,15 @@ Return the greatest integer $m$ such that $m \leq n$.
 
 Return the least integer $m$ such that $m \geq n$.
 
-```@repl oscar
-floor(fmpz, QQ(-2, 3))
-ceil(fmpz, QQ(7, 2))
-typeof(ans)
-ceil(fmpz, QQ(5))
+```jldoctest
+julia> floor(fmpz, QQ(-2, 3))
+
+julia> ceil(fmpz, QQ(7, 2))
+
+julia> typeof(ans)
+
+julia> ceil(fmpz, QQ(5))
+
 ```
 
 ## Basic arithmetic
@@ -169,12 +199,17 @@ Julia and OSCAR rationals and integers.
 Return the quotient of ``a`` by ``b``. Exact division raises an exception if
 division by zero is attempted.
 
-```@repl oscar
-divexact(QQ(2, 3), QQ(3, 5))
-divexact(QQ(1, 3), ZZ(0))
-divexact(QQ(3, 4), ZZ(5))
-divexact(ZZ(6), QQ(2, 3))
-divexact(QQ(1, 3), 5)
+```jldoctest
+julia> divexact(QQ(2, 3), QQ(3, 5))
+
+julia> divexact(QQ(1, 3), ZZ(0))
+
+julia> divexact(QQ(3, 4), ZZ(5))
+
+julia> divexact(ZZ(6), QQ(2, 3))
+
+julia> divexact(QQ(1, 3), 5)
+
 ```
 
 ### Powering
@@ -183,15 +218,18 @@ divexact(QQ(1, 3), 5)
 
 Return the result of powering ``a`` by ``b``.
 
-```@repl oscar
-QQ(5, 7)^32
-QQ(1, 2)^(-2)
+```jldoctest
+julia> QQ(5, 7)^32
+
+julia> QQ(1, 2)^(-2)
+
 ```
 
 The following is allowed for convenience.
 
-```@repl oscar
-QQ(0)^0
+```jldoctest
+julia> QQ(0)^0
+
 ```
 
 !!! note
@@ -199,8 +237,9 @@ QQ(0)^0
     returns ``1//0`` to indicate that the value is undefined. OSCAR raises
     an exception.
 
-```@repl oscar
-QQ(0)^-2
+```jldoctest
+julia> QQ(0)^-2
+
 ```
 
 * `is_power(a::fmpq, b::Int) -> Bool, fmpq`
@@ -216,10 +255,14 @@ Find the largest ``n`` such that ``a`` is an ``n``-th power. Return ``n`` and th
 
 Compute an ``n``-th root of ``a``, raises an error if ``a`` is not an ``n``-th power.
 
-```@repl oscar
-is_power(QQ(8), 3)
-is_power(QQ(8), 2)
-is_power(QQ(9//16))
-root(QQ(25//9), 2)
+```jldoctest
+julia> is_power(QQ(8), 3)
+
+julia> is_power(QQ(8), 2)
+
+julia> is_power(QQ(9//16))
+
+julia> root(QQ(25//9), 2)
+
 ```
 

--- a/docs/src/Rings/rational.md
+++ b/docs/src/Rings/rational.md
@@ -36,8 +36,10 @@ For convenience, `QQ` is already defined to be the field of rational numbers.
 
 ```jldoctest
 julia> S = FractionField(ZZ)
+Rational Field
 
 julia> QQ
+Rational Field
 
 ```
 
@@ -58,22 +60,29 @@ An exception is raised if a fraction is constructed with denominator zero.
 
 ```jldoctest
 julia> QQ(1, 2)
+1//2
 
 julia> QQ(5)
+5
 
 julia> ZZ(3)//5
+3//5
 
 julia> 1//ZZ(7)
+1//7
 
 julia> QQ(2//3)
+2//3
 
 julia> ZZ(3)//0
+ERROR: DivideError: integer division error
 
 ```
 One can also construct the rational number ``0`` with the empty constructor:
 
 ```jldoctest
 julia> QQ()
+0
 
 ```
 
@@ -84,8 +93,10 @@ The following special constructors are also provided:
 
 ```jldoctest
 julia> zero(QQ)
+0
 
 julia> one(QQ)
+1
 
 ```
 
@@ -99,10 +110,13 @@ The `is_unit` function will return `true` iff ``n \neq 0``.
 
 ```jldoctest
 julia> iszero(QQ())
+true
 
 julia> isone(one(QQ))
+true
 
 julia> is_unit(QQ(-2, 3))
+true
 
 ```
 
@@ -119,10 +133,13 @@ Return the sign of `n`, i.e. ``n/|n|`` if ``n \neq 0``, or ``0`` otherwise.
 
 ```jldoctest
 julia> sign(QQ(2, 3))
+1
 
 julia> sign(QQ())
+0
 
 julia> sign(QQ(-1))
+-1
 
 ```
 
@@ -134,6 +151,7 @@ otherwise.
 
 ```jldoctest
 julia> abs(QQ(-3, 2))
+3//2
 
 ```
 
@@ -144,6 +162,7 @@ $n$.
 
 ```jldoctest
 julia> height(QQ(324987329, -8372492324))
+8372492324
 
 ```
 
@@ -157,12 +176,16 @@ Return the least integer $m$ (as a rational number) such that $m \geq n$.
 
 ```jldoctest
 julia> floor(QQ(-2, 3))
+-1
 
 julia> ceil(QQ(7, 2))
+4
 
 julia> typeof(ans)
+fmpq
 
 julia> ceil(QQ(5))
+5
 
 ```
 * `floor(fmpz, n::fmpq) -> fmpz`
@@ -175,12 +198,16 @@ Return the least integer $m$ such that $m \geq n$.
 
 ```jldoctest
 julia> floor(fmpz, QQ(-2, 3))
+-1
 
 julia> ceil(fmpz, QQ(7, 2))
+4
 
 julia> typeof(ans)
+fmpz
 
 julia> ceil(fmpz, QQ(5))
+5
 
 ```
 
@@ -201,14 +228,19 @@ division by zero is attempted.
 
 ```jldoctest
 julia> divexact(QQ(2, 3), QQ(3, 5))
+10//9
 
 julia> divexact(QQ(1, 3), ZZ(0))
+ERROR: DivideError: integer division error
 
 julia> divexact(QQ(3, 4), ZZ(5))
+3//20
 
 julia> divexact(ZZ(6), QQ(2, 3))
+9
 
 julia> divexact(QQ(1, 3), 5)
+1//15
 
 ```
 
@@ -220,8 +252,10 @@ Return the result of powering ``a`` by ``b``.
 
 ```jldoctest
 julia> QQ(5, 7)^32
+23283064365386962890625//1104427674243920646305299201
 
 julia> QQ(1, 2)^(-2)
+4
 
 ```
 
@@ -229,6 +263,7 @@ The following is allowed for convenience.
 
 ```jldoctest
 julia> QQ(0)^0
+1
 
 ```
 
@@ -239,6 +274,7 @@ julia> QQ(0)^0
 
 ```jldoctest
 julia> QQ(0)^-2
+ERROR: DivideError: integer division error
 
 ```
 
@@ -257,12 +293,16 @@ Compute an ``n``-th root of ``a``, raises an error if ``a`` is not an ``n``-th p
 
 ```jldoctest
 julia> is_power(QQ(8), 3)
+(true, 2)
 
 julia> is_power(QQ(8), 2)
+(false, 8)
 
 julia> is_power(QQ(9//16))
+(2, 3//4)
 
 julia> root(QQ(25//9), 2)
+5//3
 
 ```
 


### PR DESCRIPTION
- docs: convert @repl blocks to jldoctest
- Run Oscar.build(doctest=:fix) to adjust new jldoctest
- Fix a Singular doctest to not fluctuate with RNG state
- Fix various doctest issues

This is beneficial because we notice when there are errors, while `@repl`
blocks give us no such feedback. In other words, we get free tests, and
at the same time we notice when the manual examples are broken (as was
the case for a few of them).

This PR could safely be squashed into a single commit, but by separating it
it is (a) easier to update this PR if there are conflicts before it gets
merged, and (b) it makes it clear what I fixed.