### PR TITLE
Fix saturated ideal for quotient rings.

### DIFF
--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -1,6 +1,7 @@
 export singular_poly_ring, singular_coeff_ring, MPolyQuo, MPolyQuoElem, MPolyQuoIdeal
 export quo, base_ring, modulus, gens, ngens, dim, simplify!, default_ordering
 export issubset
+export is_prime, pre_image_ideal
 ##############################################################################
 #
 # quotient rings
@@ -307,10 +308,16 @@ end
 
 # TODO: replace by a more efficient method!
 @attr function is_prime(I::MPolyQuoIdeal)
+  return is_prime(pre_image_ideal(I))
+end
+
+# TODO: Clean this up eventually!
+@attr function pre_image_ideal(I::MPolyQuoIdeal)
   R = base_ring(base_ring(I))
   J = ideal(R, lift.(gens(I))) + modulus(base_ring(I))
-  return is_prime(J)
+  return J
 end
+
 
 @doc Markdown.doc"""
     iszero(a::MPolyQuoIdeal)

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -1,7 +1,7 @@
 export singular_poly_ring, singular_coeff_ring, MPolyQuo, MPolyQuoElem, MPolyQuoIdeal
 export quo, base_ring, modulus, gens, ngens, dim, simplify!, default_ordering
 export issubset
-export is_prime, pre_image_ideal
+export saturated_ideal
 ##############################################################################
 #
 # quotient rings
@@ -308,11 +308,16 @@ end
 
 # TODO: replace by a more efficient method!
 @attr function is_prime(I::MPolyQuoIdeal)
-  return is_prime(pre_image_ideal(I))
+  return is_prime(saturated_ideal(I))
 end
 
-# TODO: Clean this up eventually!
-@attr function pre_image_ideal(I::MPolyQuoIdeal)
+# The following is to streamline the programmer's 
+# interface for the use of the four standard rings 
+# for the schemes `MPolyRing`, `MPolyQuo`, `MPolyLocalizedRing`, 
+# and `MPolyQuoLocalizedRing` together with their ideals. 
+# We return the preimage of the given ideal under the 
+# canonical map from the underlying free polynomial ring.
+@attr function saturated_ideal(I::MPolyQuoIdeal)
   R = base_ring(base_ring(I))
   J = ideal(R, lift.(gens(I))) + modulus(base_ring(I))
   return J

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -1406,11 +1406,6 @@ function saturated_ideal(I::MPolyQuoLocalizedIdeal)
   return saturated_ideal(pre_image_ideal(I))
 end
 
-# for convenience of the scripting user allow I::MPolyQuoIdeal as 
-# input to saturated_ideal and return the preimage of I in 
-# under the canonical quotient map 
-saturated_ideal(I::MPolyQuoIdeal) = pre_image_ideal(I)
-
 ### Conversion of ideals in the original ring to localized ideals
 function (W::MPolyQuoLocalizedRing{BRT, BRET, RT, RET, MST})(I::MPolyIdeal{RET}) where {BRT, BRET, RT, RET, MST}
   return MPolyQuoLocalizedIdeal(W, W.(gens(I)))

--- a/test/Rings/MPolyQuo_test.jl
+++ b/test/Rings/MPolyQuo_test.jl
@@ -151,3 +151,11 @@ end
   @test modulus(Al3) == Il3
 end
 
+@testset "saturated ideal compatibility" begin
+  R, (x,y,z) = QQ["x", "y", "z"]
+  I = ideal(R, [x+y+z])
+  A, _ = quo(R,I)
+  J = ideal(A, [x, y])
+  @test z in saturated_ideal(J)
+end
+


### PR DESCRIPTION
We decided earlier that `saturated_ideal` should run also for `MPolyQuoIdeal`s for compatibility reasons. However, this did not yet seem to work and this should fix it. 