### PR TITLE
Add naive version for rational solutions of zero/one-dimensional ideals

### DIFF
--- a/test/Rings/mpoly-graded-test.jl
+++ b/test/Rings/mpoly-graded-test.jl
@@ -248,10 +248,10 @@ begin
   @assert parent(t) == R
 end
 
-@testset "Alheydis" begin
+@testset "Rational solutions" begin
   Q, x = proj_space(QQ, 2)
   i = ideal([x[1]-2*x[3], x[2]-3*x[3]])
-  @test length(Oscar.rational_points_naive(i)) == 1
+  @test length(rational_solutions(i)) == 1
 end
 
 @testset "Hilbert series" begin
@@ -295,3 +295,15 @@ end
   bayer = Oscar._hilbert_numerator_from_leading_exponents(g, W, S, :BayerStillmanA)
   @test custom == gcd == generator == cocoa == indeterminate
 end
+
+@testset "Rand" begin
+  for K in [ZZ, GF(3), QQ]
+    R, = K["x", "y", "z"]
+    S, = grade(R)
+    for i in 1:100
+      f = rand(R, 5:10, 1:10, 1:100)
+      @test parent(f) === R
+    end
+  end
+end
+

--- a/test/Rings/mpoly-graded-test.jl
+++ b/test/Rings/mpoly-graded-test.jl
@@ -248,6 +248,12 @@ begin
   @assert parent(t) == R
 end
 
+@testset "Alheydis" begin
+  Q, x = proj_space(QQ, 2)
+  i = ideal([x[1]-2*x[3], x[2]-3*x[3]])
+  @test length(Oscar.rational_points_naive(i)) == 1
+end
+
 @testset "Hilbert series" begin
   n = 5
 

--- a/test/Rings/mpoly-test.jl
+++ b/test/Rings/mpoly-test.jl
@@ -283,3 +283,12 @@ end
     test_ideal = ideal([x[1, 2]*x[2, 2] + 6*x[2, 1]*x[1, 3] + x[1, 1]*x[2, 3]])
     @test grassmann_pluecker_ideal(R, 2, 4) == test_ideal
 end
+
+@testset "Rational solutions" begin
+  R, (x, y) = QQ["x", "y"]
+  I = ideal([x - 1, y - 1])
+  J = ideal([x - 2, y - 3])
+  pts = rational_solutions(I * J)
+  @test length(pts) == 2
+  @test issetequal(pts, Vector{fmpq}[[1, 1], [2, 3]])
+end


### PR DESCRIPTION
Make the following work:
```
julia> R, (x, y, z, w) = GradedPolynomialRing(QQ, ["x", "y", "z", "w"]);

julia> f = x*y*z+w*rand(R, 2:4, 2:2, -10:10)
x*y*z + 9//5*y^2*w - 3*z^2*w

julia> g = (x+2*y+3*z)^2+w*rand(R, 2:4, 1:1, -10:10)
x^2 + 4*x*y + 6*x*z - x*w + 4*y^2 + 12*y*z + y*w + 9*z^2 + z*w

julia> I = ideal([f,g, w])
ideal(x*y*z + 9//5*y^2*w - 3*z^2*w, x^2 + 4*x*y + 6*x*z - x*w + 4*y^2 + 12*y*z + y*w + 9*z^2 + z*w, w)

julia> p = primary_decomposition(I);
julia> rp = []
julia> for i = p 
         append!(rp, Oscar.rational_points_naive(i[1]))
         end

julia> rp
3-element Vector{Any}:
 (1 : -1//2 : 0 : 0)
 (0 : 1 : -2//3 : 0)
 (1 : 0 : -1//3 : 0)
 ```
 
 as a "translation" from M2-Code:
 ```R = QQ[x,y,z,w];
f = x*y*z+w*random(2,R)
g = (x+2*y+3*z)^2+w*random(1,R)
I = ideal(f,g,w);
p = primaryDecomposition(I);
ratPts={};
for i in p do
(
    for j from i to degree(i) do
(
        ratPts = ratPts | rationalPoints(i,Projective => true);
)
```

this is not perfect - or intelligent, but as far as I can push it.
 