### PR TITLE
Decrease allocations in elements

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -113,12 +113,8 @@ check_parent(G::PermGroup, g::PermGroupElem) = (degree(G) == degree(parent(g)))
 
 
 function elements(G::T) where T <: GAPGroup
-  els = Vector{GapObj}(GAP.Globals.Elements(G.X)::GapObj)
-  elems = Vector{elem_type(G)}(undef, length(els))
-  for i in 1:length(els)
-    elems[i] = group_element(G, els[i])
-  end
-  return elems
+  els = GAP.Globals.Elements(G.X)::GapObj
+  return [group_element(G, x) for x in els]
 end
 
 function parent(x::GAPGroupElem)


### PR DESCRIPTION
This changes the function `elements(G::T)` to allocate less by bypassing `gap_to_julia(::Type{Vector{T}}, ...)`. This results in a speedup, most noticeable in `PermGroups`.

```julia
julia> @btime length(elements(symmetric_group(10)))
  2.490 s (14516261 allocations: 857.95 MiB)
3628800

julia> @btime length(Oscar.old_elements(symmetric_group(10)))
  10.269 s (18144569 allocations: 1010.96 MiB)
3628800

# Doesn't improve as much for matrix groups, but still an improvement. 
# Majority of the time is spend allocating for matrices.

julia> @btime length(elements(GL(3,4)))
  3.266 s (10745950 allocations: 638.01 MiB)
181440

julia> @btime length(Oscar.old_elements(GL(3,4)))
  3.544 s (11108337 allocations: 650.26 MiB)
181440

# Sanity Check: Preserves order and is equal

julia> let G = alternating_group(8)
           elements(G) == Oscar.old_elements(G)
       end
true

julia> let G = Sp(4,3)
           elements(G) == Oscar.old_elements(G)
       end
true
```

