### PR TITLE
Make `elements` even faster

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -112,9 +112,14 @@ check_parent(G::PermGroup, g::PermGroupElem) = (degree(G) == degree(parent(g)))
 # (This cannot be defined here because `MatrixGroup` is not yet defined.)
 
 
-function elements(G::T) where T <: GAPGroup
+# TODO: ideally the `elements` method below would be turned into a method for
+# `collect`, as it is much faster than plain `collect`. Unfortunately, though,
+# for some groups (e.g. permutation groups) the order of elements computed
+# by this function may differ from that computed by an iterator over G. So
+# this is not an option right now.
+function elements(G::GAPGroup)
   els = GAP.Globals.Elements(G.X)::GapObj
-  return [group_element(G, x) for x in els]
+  return [group_element(G, x::GapObj) for x in els]
 end
 
 function parent(x::GAPGroupElem)

--- a/src/PolyhedralGeometry/Groups.jl
+++ b/src/PolyhedralGeometry/Groups.jl
@@ -59,13 +59,13 @@ A polyhedron in ambient dimension 2
 julia> G = combinatorial_symmetries(quad)
 Group([ (2,4), (1,2)(3,4) ])
 
-julia> length(elements(G))
+julia> order(G)
 8
 
 julia> G = linear_symmetries(quad)
 Group([ (2,4) ])
 
-julia> length(elements(G))
+julia> order(G)
 2
 ```
 """
@@ -90,7 +90,7 @@ A polyhedron in ambient dimension 3
 julia> G = linear_symmetries(c)
 Group([ (3,5)(4,6), (2,3)(6,7), (1,2)(3,4)(5,6)(7,8) ])
 
-julia> length(elements(G))
+julia> order(G)
 48
 ```
 
@@ -103,7 +103,7 @@ A polyhedron in ambient dimension 2
 julia> G = linear_symmetries(quad)
 Group([ (2,4) ])
 
-julia> length(elements(G))
+julia> order(G)
 2
 ```
 """


### PR DESCRIPTION
Also change some doctest examples to use `order(G)` instead of `length(elements(G))`

CC @SyxP 