### PR TITLE
Make doctests part of Pkg.test("Oscar")

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,17 +60,6 @@ jobs:
         run: echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
       - name: "Run tests"
         uses: julia-actions/julia-runtest@latest
-      - name: "Run doctests"
-        if: ${{ matrix.julia-version == '1.6' }}
-        run: |
-          julia --project=docs --color=yes --code-coverage -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()
-            using Documenter
-            using Oscar
-            DocMeta.setdocmeta!(Oscar, :DocTestSetup, :(using Oscar, Oscar.Graphs); recursive = true)
-            doctest(Oscar)'
       - name: "Process code coverage"
         uses: julia-actions/julia-processcoverage@v1
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -38,3 +38,10 @@ RandomExtensions = "0.4.3"
 RecipesBase = "1.2.1"
 Singular = "0.14.0"
 julia = "1.6"
+
+[extras]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "Documenter"]

--- a/experimental/GaloisGrp/GaloisGrp.jl
+++ b/experimental/GaloisGrp/GaloisGrp.jl
@@ -1517,7 +1517,7 @@ function starting_group(GC::GaloisCtx, K::T; useSubfields::Bool = true) where T 
         # the re-ordering is easy: W^s for s = vcat(bs)
         bs = map(x->findall(isequal(x), d), r)
         @assert all(x->length(x) == length(bs[1]), bs)
-        W = isomorphic_perm_group(wreath_product(symmetric_group(length(bs[2])), g))[1]
+        W = PermGroup(wreath_product(symmetric_group(length(bs[2])), g))
         #should have the block system as above..
         W = W^symmetric_group(degree(W))(vcat(bs...))
         G = intersect(G, W)[1]
@@ -2401,7 +2401,7 @@ function galois_ideal(C::GaloisCtx, extra::Int = 5)
   if C.start[1] == 1 # start with intersection of wreath products
     _, g = slpoly_ring(ZZ, n)
     for bs = C.start[2]
-      W = isomorphic_perm_group(wreath_product(symmetric_group(length(bs[1])), symmetric_group(length(bs))))[1]
+      W = PermGroup(wreath_product(symmetric_group(length(bs[1])), symmetric_group(length(bs))))
       W = W^symmetric_group(n)(vcat(bs...))
       G = intersect(G, W)[1]
       #each subfield causes, possibly, several invariants...

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -17,9 +17,6 @@ export
     is_invertible,
     is_isomorphic,
     is_isomorphic_with_map,
-    isomorphic_fp_group,
-    isomorphic_pc_group,
-    isomorphic_perm_group,
     isomorphism,
     is_surjective,
     kernel,
@@ -695,38 +692,6 @@ end
 function (::Type{T})(G::GrpGen) where T <: GAPGroup
    return codomain(isomorphism(T, G))
 end
-
-################################################################################
-#
-# provide and deprecate the old syntax
-#
-function _isomorphic_perm_group(G::GAPGroup)
-   f = isomorphism(PermGroup, G)
-   return codomain(f), f
-end
-
-@deprecate isomorphic_perm_group(G::GAPGroup) _isomorphic_perm_group(G)
-
-function _isomorphic_pc_group(G::GAPGroup)
-   f = isomorphism(PcGroup, G)
-   return codomain(f), f
-end
-
-@deprecate isomorphic_pc_group(G::GAPGroup) _isomorphic_pc_group(G)
-
-function _isomorphic_fp_group(G::GAPGroup)
-   f = isomorphism(FPGroup, G)
-   return codomain(f), f
-end
-
-@deprecate isomorphic_fp_group(G::GAPGroup) _isomorphic_fp_group(G)
-
-function _isomorphic_group(::Type{T}, G::GAPGroup) where T <: GAPGroup
-  fmap = isomorphism(T, G)
-  return codomain(fmap), fmap
-end
-
-@deprecate isomorphic_group(::Type{T}, G::GAPGroup) where T <: GAPGroup _isomorphic_group(T, G)
 
 
 """

--- a/src/ToricVarieties/ToricMorphisms/attributes.jl
+++ b/src/ToricVarieties/ToricMorphisms/attributes.jl
@@ -114,7 +114,7 @@ export morphism_on_torusinvariant_weil_divisor_group
 
 
 @doc Markdown.doc"""
-    morphism_on_cartier_divisor_group(tm::ToricMorphism)
+    morphism_on_torusinvariant_cartier_divisor_group(tm::ToricMorphism)
 
 For a given toric morphism `tm`, this method computes the corresponding
 map of the Cartier divisors.
@@ -124,7 +124,7 @@ map of the Cartier divisors.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> morphism_on_cartier_divisor_group(ToricIdentityMorphism(F4))
+julia> morphism_on_torusinvariant_cartier_divisor_group(ToricIdentityMorphism(F4))
 Map with following data
 Domain:
 =======

--- a/test/Rings/AbelianClosure.jl
+++ b/test/Rings/AbelianClosure.jl
@@ -79,6 +79,9 @@ end
 
     a = @inferred root_of_unity(K, 4)
     @test isone(a^4) && !isone(a) && !isone(a^2)
+
+    # reset variable for any subsequent (doc-)tests
+    set_variable!(K, "ζ")
   end
 
   @testset "Coercion" begin

--- a/test/StraightLinePrograms/runtests.jl
+++ b/test/StraightLinePrograms/runtests.jl
@@ -1,4 +1,12 @@
+# avoid polluting the main namespace to to preserve proper printing in doctests
+module SLPTest
+using ..Test
+using ..Oscar
+using ..Oscar: SLP
+
 include("setup.jl")
 include("straightline.jl")
 include("gap.jl")
 include("atlas.jl")
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,16 +2,6 @@ using Oscar
 using Test
 using Documenter
 
-# We want to avoid running the doctests twice so we skip them when
-# "oscar_run_doctests" is set by OscarDevTools.jl
-if v"1.6.0" <= VERSION < v"1.7.0" && !haskey(ENV,"oscar_run_doctests")
-  @info "Running doctests (Julia version is 1.6)"
-  DocMeta.setdocmeta!(Oscar, :DocTestSetup, :(using Oscar, Oscar.Graphs); recursive = true)
-  doctest(Oscar)
-else
-  @info "Not running doctests (Julia version must be 1.6)"
-end
-
 
 import Oscar.Nemo.AbstractAlgebra
 include(joinpath(pathof(AbstractAlgebra), "..", "..", "test", "Rings-conformance-tests.jl"))
@@ -57,3 +47,15 @@ include("TropicalGeometry/runtests.jl")
 include("Serialization/runtests.jl")
 
 include("StraightLinePrograms/runtests.jl")
+
+# Doctests
+
+# We want to avoid running the doctests twice so we skip them when
+# "oscar_run_doctests" is set by OscarDevTools.jl
+if v"1.6.0" <= VERSION < v"1.7.0" && !haskey(ENV,"oscar_run_doctests")
+  @info "Running doctests (Julia version is 1.6)"
+  DocMeta.setdocmeta!(Oscar, :DocTestSetup, :(using Oscar, Oscar.Graphs); recursive = true)
+  doctest(Oscar)
+else
+  @info "Not running doctests (Julia version must be 1.6)"
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,9 @@ using Oscar
 using Test
 using Documenter
 
-if v"1.6.0" <= VERSION < v"1.7.0"
+# We want to avoid running the doctests twice so we skip them when
+# "oscar_run_doctests" is set by OscarDevTools.jl
+if v"1.6.0" <= VERSION < v"1.7.0" && !haskey(ENV,"oscar_run_doctests")
   @info "Running doctests (version 1.6)"
   DocMeta.setdocmeta!(Oscar, :DocTestSetup, :(using Oscar, Oscar.Graphs); recursive = true)
   doctest(Oscar)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,11 +5,11 @@ using Documenter
 # We want to avoid running the doctests twice so we skip them when
 # "oscar_run_doctests" is set by OscarDevTools.jl
 if v"1.6.0" <= VERSION < v"1.7.0" && !haskey(ENV,"oscar_run_doctests")
-  @info "Running doctests (version 1.6)"
+  @info "Running doctests (Julia version is 1.6)"
   DocMeta.setdocmeta!(Oscar, :DocTestSetup, :(using Oscar, Oscar.Graphs); recursive = true)
   doctest(Oscar)
 else
-  @info "Not running doctests (version must be 1.6)"
+  @info "Not running doctests (Julia version must be 1.6)"
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,15 @@
 using Oscar
 using Test
+using Documenter
+
+if v"1.6.0" <= VERSION < v"1.7.0"
+  @info "Running doctests (version 1.6)"
+  DocMeta.setdocmeta!(Oscar, :DocTestSetup, :(using Oscar, Oscar.Graphs); recursive = true)
+  doctest(Oscar)
+else
+  @info "Not running doctests (version must be 1.6)"
+end
+
 
 import Oscar.Nemo.AbstractAlgebra
 include(joinpath(pathof(AbstractAlgebra), "..", "..", "test", "Rings-conformance-tests.jl"))


### PR DESCRIPTION
This allows for the downstream testing in our upstream packages GAP, Hecke, Polymake, etc., to also run the doctests by default (the downstream tests are run by default on julia version 1.6, so we are good in this regard).

A minor disadvantage is that the default julia version for https://github.com/oscar-system/OscarDevTools.jl and the Oscar 
doctest julia version need to be kept in lockstep.

(In an ideal world, we would make the doctests julia version agnostic and then these remarks about versions would all be unnecessary.)

CC: @fingolfin @benlorenz 