### PR TITLE
ToricVarieties: Bugfix in is_empty for closed subvarieties

### DIFF
--- a/src/ToricVarieties/Subvarieties/properties.jl
+++ b/src/ToricVarieties/Subvarieties/properties.jl
@@ -29,9 +29,6 @@ true
 """
 @attr Bool function is_empty(c::ClosedSubvarietyOfToricVariety)
     B = irrelevant_ideal(toric_variety(c))
-    if (is_one(defining_ideal(c)) || is_one(saturation(defining_ideal(c), B)))
-      return true
-    end
-    return false
+    return (is_one(defining_ideal(c)) || is_one(saturation(defining_ideal(c), B)))
 end
 export is_empty

--- a/src/ToricVarieties/Subvarieties/properties.jl
+++ b/src/ToricVarieties/Subvarieties/properties.jl
@@ -19,10 +19,19 @@ A closed subvariety of a normal toric variety
 
 julia> is_empty(c)
 false
+
+julia> c2 = ClosedSubvarietyOfToricVariety(f2, [x1,x2])
+A closed subvariety of a normal toric variety
+
+julia> is_empty(c2)
+true
 ```
 """
 @attr Bool function is_empty(c::ClosedSubvarietyOfToricVariety)
     B = irrelevant_ideal(toric_variety(c))
-    return intersect(radical(c), B) == B
+    if (is_one(defining_ideal(c)) || is_one(saturation(defining_ideal(c), B)))
+      return true
+    end
+    return false
 end
 export is_empty


### PR DESCRIPTION
A closed subvariety of a toric variety, defined by an ideal `I`, is empty iff B^l subseteq I for a suitable non-negative integer l.

After discussion with @tthsqe12 , I have modified the code so that (at least to the best of my knowledge) it truly checks this criterion.