### PR TITLE
Bump to 0.11.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oscar"
 uuid = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
 authors = ["The OSCAR Team <oscar@mathematik.uni-kl.de>"]
-version = "0.11.1-DEV"
+version = "0.11.1"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ julia> using Oscar
  -----    -----    -----   -     -  -     -
 
 ...combining (and extending) ANTIC, GAP, Polymake and Singular
-Version 0.11.1-DEV ...
+Version 0.11.1 ...
 ... which comes with absolutely no warranty whatsoever
 Type: '?Oscar' for more information
 (c) 2019-2022 by The OSCAR Development Team
@@ -129,7 +129,7 @@ PropertyValue wrapping pm::Array<polymake::topaz::HomologyGroup<pm::Integer>>
 If you have used OSCAR in the preparation of a paper please cite it as described below:
 
     [OSCAR]
-        OSCAR -- Open Source Computer Algebra Research system, Version 0.11.1-DEV The OSCAR Team, 2022. (https://oscar.computeralgebra.de)
+        OSCAR -- Open Source Computer Algebra Research system, Version 0.11.1 The OSCAR Team, 2022. (https://oscar.computeralgebra.de)
     [OSCAR-book]
         Christian Eder, Wolfram Decker, Claus Fieker, Max Horn, Michael Joswig, The OSCAR book, 2024.
 
@@ -139,7 +139,7 @@ If you are using BibTeX, you can use the following BibTeX entries:
       key          = {OSCAR},
       organization = {The OSCAR Team},
       title        = {OSCAR -- Open Source Computer Algebra Research system,
-                      Version 0.11.1-DEV},
+                      Version 0.11.1},
       year         = {2022},
       url          = {https://oscar.computeralgebra.de},
       }

--- a/docs/src/PolyhedralGeometry/Polyhedra/serialization.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/serialization.md
@@ -22,8 +22,7 @@ following way:
 julia> square = cube(2)
 A polyhedron in ambient dimension 2
 
-julia> save("square.poly", square)
-739
+julia> save("square.poly", square);
 
 julia> s = load("square.poly")
 A polyhedron in ambient dimension 2

--- a/docs/src/PolyhedralGeometry/cones.md
+++ b/docs/src/PolyhedralGeometry/cones.md
@@ -48,8 +48,7 @@ following way:
 julia> C = positive_hull([1 0; 0 1])
 A polyhedral cone in ambient dimension 2
 
-julia> save("C.cone", C)
-434
+julia> save("C.cone", C);
 
 julia> CC = load("C.cone")
 A polyhedral cone in ambient dimension 2

--- a/docs/src/PolyhedralGeometry/fans.md
+++ b/docs/src/PolyhedralGeometry/fans.md
@@ -52,8 +52,7 @@ A polyhedron in ambient dimension 2
 julia> fan = normal_fan(square)
 A polyhedral fan in ambient dimension 2
 
-julia> save("F.fan", fan)
-610
+julia> save("F.fan", fan);
 
 julia> f = load("F.fan")
 A polyhedral fan in ambient dimension 2

--- a/docs/src/PolyhedralGeometry/linear_programs.md
+++ b/docs/src/PolyhedralGeometry/linear_programs.md
@@ -130,8 +130,7 @@ where P is a Polyhedron{fmpq} and
    c=Polymake.Rational[1 2 -3]
    k=0
 
-julia> save("lp.poly", LP)
-1185
+julia> save("lp.poly", LP);
 
 julia> LP0 = load("lp.poly")
 The linear program


### PR DESCRIPTION
Since OSCAR 0.11, there has been a version bump in Hecke from 0.15 to 0.16. So I would like to release OSCAR 0.11.1 to make it not lag behind.