### PR TITLE
save: don't return number of bytes written

### DIFF
--- a/docs/src/PolyhedralGeometry/Polyhedra/serialization.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/serialization.md
@@ -22,7 +22,7 @@ following way:
 julia> square = cube(2)
 A polyhedron in ambient dimension 2
 
-julia> save("square.poly", square);
+julia> save("square.poly", square)
 
 julia> s = load("square.poly")
 A polyhedron in ambient dimension 2

--- a/docs/src/PolyhedralGeometry/cones.md
+++ b/docs/src/PolyhedralGeometry/cones.md
@@ -48,7 +48,7 @@ following way:
 julia> C = positive_hull([1 0; 0 1])
 A polyhedral cone in ambient dimension 2
 
-julia> save("C.cone", C);
+julia> save("C.cone", C)
 
 julia> CC = load("C.cone")
 A polyhedral cone in ambient dimension 2

--- a/docs/src/PolyhedralGeometry/fans.md
+++ b/docs/src/PolyhedralGeometry/fans.md
@@ -52,7 +52,7 @@ A polyhedron in ambient dimension 2
 julia> fan = normal_fan(square)
 A polyhedral fan in ambient dimension 2
 
-julia> save("F.fan", fan);
+julia> save("F.fan", fan)
 
 julia> f = load("F.fan")
 A polyhedral fan in ambient dimension 2

--- a/docs/src/PolyhedralGeometry/linear_programs.md
+++ b/docs/src/PolyhedralGeometry/linear_programs.md
@@ -130,7 +130,7 @@ where P is a Polyhedron{fmpq} and
    c=Polymake.Rational[1 2 -3]
    k=0
 
-julia> save("lp.poly", LP);
+julia> save("lp.poly", LP)
 
 julia> LP0 = load("lp.poly")
 The linear program

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -231,6 +231,7 @@ function save(io::IO, obj::Any)
     jsoncompatible = save_type_dispatch(state, obj)
     jsonstr = json(jsoncompatible)
     write(io, jsonstr)
+    return nothing
 end
 
 function save(filename::String, obj::Any)


### PR DESCRIPTION
@antonydellavecchia
I don't think anyone needs this and it mostly causes confusion (or CI issues, see #1775).
It is also not documented and probably not really intended but just an automatic forwarding of the return of `write`.

cc @thofma @lkastner 

PS: Technically I guess this is a breaking change?