### PR TITLE
When computing matrix group orders, inform GAP about the result

### DIFF
--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -545,7 +545,7 @@ gen(G::MatrixGroup, i::Int) = gens(G)[i]
 ngens(G::MatrixGroup) = length(gens(G))
 
 
-compute_order(G::GAPGroup) = fmpz(GAPWrap.Order(G.X))
+compute_order(G::GAPGroup) = fmpz(GAPWrap.Size(G.X))
 
 function compute_order(G::MatrixGroup{T}) where {T <: Union{nf_elem, fmpq}}
   #=
@@ -561,9 +561,11 @@ function compute_order(G::MatrixGroup{T}) where {T <: Union{nf_elem, fmpq}}
     # The call to `IsHandledByNiceMonomorphism` triggers an expensive
     # computation of `IsFinite` which we avoid by checking
     # `HasIsHandledByNiceMonomorphism` first.
-    return fmpz(GAPWrap.Order(G.X))
+    return fmpz(GAPWrap.Size(G.X))
   else
-    order(isomorphic_group_over_finite_field(G)[1])
+    n = order(isomorphic_group_over_finite_field(G)[1])
+    GAP.Globals.SetSize(G.X, GAP.Obj(n))
+    return n
   end
 end
 

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -129,11 +129,17 @@ end
    @testset "... over ring $(base_ring(mats[1]))" for mats in inputs
      G0 = matrix_group(mats)
      G, g = Oscar.isomorphic_group_over_finite_field(G0)
+
+     @test !has_order(G0)
+     order(G0)
+     @test has_order(G0)
+
      for i in 1:10
        x, y = rand(G), rand(G)
        @test (g\x) * (g\y) == g\(x * y)
        @test g(g\x) == x
      end
+
      H = GAP.Globals.Group(GAP.Obj(gens(G0); recursive=true))
      f = GAP.Globals.GroupHomomorphismByImages(G.X, H)
      @test GAP.Globals.IsBijective(f)


### PR DESCRIPTION
Resolves part of #1779, but more should be done