### PR TITLE
FGLM Gröbner conversion algorithm

### DIFF
--- a/docs/src/CommutativeAlgebra/groebner_bases.md
+++ b/docs/src/CommutativeAlgebra/groebner_bases.md
@@ -244,12 +244,12 @@ computed basis can be retrieved by using the `elements` function or and its alia
 ```@docs
 groebner_basis(I::MPolyIdeal;
 	ord::MonomialOrdering = default_ordering(base_ring(I)),
-	complete_reduction::Bool = false)
+	complete_reduction::Bool = false, algorithm::Symbol = :buchberger)
 ```
 ```@docs
 standard_basis(I::MPolyIdeal;
 	ord::MonomialOrdering = default_ordering(base_ring(I)),
-	complete_reduction::Bool = false)
+	complete_reduction::Bool = false, algorithm::Symbol = :buchberger)
 ```
 	
 ### Gröbner Bases with transformation matrix
@@ -265,8 +265,11 @@ standard_basis_with_transformation_matrix(I::MPolyIdeal;
 	complete_reduction::Bool=false)
 ```
 
-    fglm
+### Gröbner Basis Conversions
 
+```@docs
+fglm(G::IdealGens; ordering::MonomialOrdering)
+```
     Gröbner walks
 
     Hilbert-driven

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -134,7 +134,7 @@ function standard_basis(I::MPolyIdeal; ordering::MonomialOrdering = default_orde
 	elseif algorithm == :fglm
 		_compute_groebner_basis_using_fglm(I, ordering, default_ordering(base_ring(I)))
 	elseif algorithm == :f4
-		_compute_groebner_basis_using_f4(I, complete_reduction=complete_reduction)
+		f4(I, complete_reduction=complete_reduction)
 	end
 	return I.gb[ordering]
 end
@@ -203,7 +203,7 @@ function groebner_basis(I::MPolyIdeal; ordering::MonomialOrdering = default_orde
 end
 
 @doc Markdown.doc"""
-    f4(I::MPolyIdeal, <keyword arguments>)
+	f4(I::MPolyIdeal, <keyword arguments>)
 
 Compute a Gröbner basis of `I` with respect to `degrevlex` using Faugère's F4 algorithm.
 See [Fau99](@cite) for more information.
@@ -241,7 +241,7 @@ julia> isdefined(I, :gb)
 true
 ```
 """
-function _compute_groebner_basis_using_f4(
+function f4(
         I::MPolyIdeal;
         initial_hts::Int=17,
         nr_thrds::Int=1,

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1,4 +1,4 @@
-export  reduce, reduce_with_quotients, reduce_with_quotients_and_unit, f4, fglm
+export  reduce, reduce_with_quotients, reduce_with_quotients_and_unit, f4, fglm,
 		standard_basis, groebner_basis, standard_basis_with_transformation_matrix,
 		groebner_basis_with_transformation_matrix,
 		leading_ideal, syzygy_generators, is_standard_basis, is_groebner_basis
@@ -1038,9 +1038,9 @@ lex([x1, x2, x3, x4])
 ```
 """
 function fglm(G::IdealGens; ordering::MonomialOrdering)
-	@assert G.isGB == true 
-	@assert G.isReduced == true
+	(G.isGB == true && G.isReduced == true) || error("Input must be a reduced Gröbner basis.") 
 	singular_assure(G)
+	Singular.dimension(G.S) == 0 || error("Dimesion of corresponding ideal must be zero.")
 	SR_destination, = Singular.PolynomialRing(base_ring(G.Sx),["$i" for i in gens(G.Sx)]; ordering = Singular.ordering_as_symbol(singular(ordering)))
 
 	ptr = Singular.libSingular.fglmzero(G.S.ptr, G.Sx.ptr, SR_destination.ptr)
@@ -1050,13 +1050,13 @@ end
 function _compute_groebner_basis_using_fglm(I::MPolyIdeal,
 	destination_ordering::MonomialOrdering, start_ordering::MonomialOrdering = default_ordering(base_ring(I)))
 	haskey(I.gb, destination_ordering) && return I.gb[destination_ordering]
-	@assert is_global(start_ordering) && is_global(destination_ordering)
+	(is_global(start_ordering) && is_global(destination_ordering)) || error("Start and destination ordering must be global.")
 	if start_ordering == degrevlex(base_ring(I)) && typeof(coefficient_ring(base_ring(I))) == Nemo.GaloisField
 		standard_basis(I, ordering=start_ordering, complete_reduction=true, algorithm=:f4)
 	else
 		standard_basis(I, ordering=start_ordering, complete_reduction=true)
 	end
-	@assert dim(I) == 0
+	dim(I) == 0 || error("Dimesion of ideal must be zero.")
 	I.gb[destination_ordering] = fglm(I.gb[start_ordering], ordering=destination_ordering)
 end
 

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -48,7 +48,7 @@ function groebner_assure(I::MPolyIdeal, complete_reduction::Bool = false, need_g
 		end
 	end
 	ord = default_ordering(base_ring(I))
-	(need_global && is_global(ord)) || error("Monomial ordering must be global.")
+	(need_global <= is_global(ord)) || error("Monomial ordering must be global.")
 	I.gb[ord] = groebner_assure(I, ord, complete_reduction)
 	return I.gb[ord]
 end

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -142,7 +142,7 @@ function standard_basis(I::MPolyIdeal; ordering::MonomialOrdering = default_orde
 			I.gb[ordering] = _compute_standard_basis(I.gb[ordering], ordering, complete_reduction)
 		end
 	elseif algorithm == :fglm
-		_compute_groebner_basis_using_fglm(I, ordering, default_ordering(base_ring(I)))
+		_compute_groebner_basis_using_fglm(I, ordering)
 	elseif algorithm == :f4
 		f4(I, complete_reduction=complete_reduction)
 	end
@@ -1055,15 +1055,12 @@ function fglm(G::IdealGens; ordering::MonomialOrdering)
 end
 
 function _compute_groebner_basis_using_fglm(I::MPolyIdeal,
-	destination_ordering::MonomialOrdering, start_ordering::MonomialOrdering = default_ordering(base_ring(I)))
+	destination_ordering::MonomialOrdering)
 	haskey(I.gb, destination_ordering) && return I.gb[destination_ordering]
-	(is_global(start_ordering) && is_global(destination_ordering)) || error("Start and destination ordering must be global.")
-	if start_ordering == degrevlex(base_ring(I)) && typeof(coefficient_ring(base_ring(I))) == Nemo.GaloisField
-		standard_basis(I, ordering=start_ordering, complete_reduction=true, algorithm=:f4)
-	else
-		standard_basis(I, ordering=start_ordering, complete_reduction=true)
-	end
+	is_global(destination_ordering) || error("Destination ordering must be global.")
+	G = groebner_assure(I, true, true)
+	start_ordering = G.ord
 	dim(I) == 0 || error("Dimesion of ideal must be zero.")
-	I.gb[destination_ordering] = fglm(I.gb[start_ordering], ordering=destination_ordering)
+	I.gb[destination_ordering] = fglm(G, ordering=destination_ordering)
 end
 

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -124,11 +124,13 @@ negdegrevlex([x, y])
 function standard_basis(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)),
 	complete_reduction::Bool = false, algorithm::Symbol = :direct)
 	complete_reduction && @assert is_global(ordering)
+	if haskey(I.gb, ordering) && (complete_reduction == false || I.gb[ordering].isReduced == true)
+		return I.gb[ordering]
+	end
 	if algorithm == :direct
 		if !haskey(I.gb, ordering)
 			I.gb[ordering] = _compute_standard_basis(I.gens, ordering, complete_reduction)
-		end
-		if !I.gb[ordering].isReduced
+		elseif complete_reduction == true
 			I.gb[ordering] = _compute_standard_basis(I.gb[ordering].gens, ordering, complete_reduction)
 		end
 	elseif algorithm == :fglm

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -152,7 +152,7 @@ end
 @doc Markdown.doc"""
     groebner_basis(I::MPolyIdeal;
       ordering::MonomialOrdering = default_ordering(base_ring(I)),
-      complete_reduction::Bool = false, algorithm::Symbol = :singular)
+      complete_reduction::Bool = false, algorithm::Symbol = :buchberger)
 
 If `ordering` is global, return a Gröbner basis of `I` with respect to `ordering`.
 `algorithm` can be set to `:buchberger` (Singular's Buchberger algorithm), `:fglm` (compute first via a "good" monomial ordering, then convert to the chosen ordering via the FGLM algorithm), `:f4` (msolve's implementation of Faugère's F4 algorithm).

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -100,9 +100,10 @@ end
 @doc Markdown.doc"""
     standard_basis(I::MPolyIdeal;
       ordering::MonomialOrdering = default_ordering(base_ring(I)),
-      complete_reduction::Bool = false)
+      complete_reduction::Bool = false, algorithm::Symbol = :singular)
 
 Return a standard basis of `I` with respect to `ordering`. 
+`algorithm` can be set to `:singular` (Singular's Buchberger algorithm), `:fglm` (compute first via a "good" monomial ordering, then convert to the chosen ordering via the FGLM algorithm), `:f4` (msolve's implementation of Faugère's F4 algorithm).
 
 !!! note
     The returned standard basis is reduced if `ordering` is `global` and `complete_reduction = true`.
@@ -122,12 +123,12 @@ negdegrevlex([x, y])
 ```
 """
 function standard_basis(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)),
-	complete_reduction::Bool = false, algorithm::Symbol = :direct)
+	complete_reduction::Bool = false, algorithm::Symbol = :singular)
 	complete_reduction && @assert is_global(ordering)
 	if haskey(I.gb, ordering) && (complete_reduction == false || I.gb[ordering].isReduced == true)
 		return I.gb[ordering]
 	end
-	if algorithm == :direct
+	if algorithm == :singular
 		if !haskey(I.gb, ordering)
 			I.gb[ordering] = _compute_standard_basis(I.gens, ordering, complete_reduction)
 		elseif complete_reduction == true
@@ -144,9 +145,10 @@ end
 @doc Markdown.doc"""
     groebner_basis(I::MPolyIdeal;
       ordering::MonomialOrdering = default_ordering(base_ring(I)),
-      complete_reduction::Bool = false)
+      complete_reduction::Bool = false, algorithm::Symbol = :singular)
 
 If `ordering` is global, return a Gröbner basis of `I` with respect to `ordering`.
+`algorithm` can be set to `:singular` (Singular's Buchberger algorithm), `:fglm` (compute first via a "good" monomial ordering, then convert to the chosen ordering via the FGLM algorithm), `:f4` (msolve's implementation of Faugère's F4 algorithm).
 
 !!! note
     The returned Gröbner basis is reduced if `complete_reduction = true`.
@@ -199,7 +201,7 @@ wdegrevlex([x, y], [1, 3])
 ```
 """
 function groebner_basis(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool=false,
-	algorithm::Symbol = :direct)
+	algorithm::Symbol = :singular)
     is_global(ordering) || error("Ordering must be global")
     return standard_basis(I, ordering=ordering, complete_reduction=complete_reduction, algorithm=algorithm)
 end

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1,4 +1,4 @@
-export  reduce, reduce_with_quotients, reduce_with_quotients_and_unit, f4,
+export  reduce, reduce_with_quotients, reduce_with_quotients_and_unit, f4, fglm
 		standard_basis, groebner_basis, standard_basis_with_transformation_matrix,
 		groebner_basis_with_transformation_matrix,
 		leading_ideal, syzygy_generators, is_standard_basis, is_groebner_basis

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -131,7 +131,7 @@ function standard_basis(I::MPolyIdeal; ordering::MonomialOrdering = default_orde
 		if !haskey(I.gb, ordering)
 			I.gb[ordering] = _compute_standard_basis(I.gens, ordering, complete_reduction)
 		elseif complete_reduction == true
-			I.gb[ordering] = _compute_standard_basis(I.gb[ordering].gens, ordering, complete_reduction)
+			I.gb[ordering] = _compute_standard_basis(I.gb[ordering], ordering, complete_reduction)
 		end
 	elseif algorithm == :fglm
 		_compute_groebner_basis_using_fglm(I, ordering, default_ordering(base_ring(I)))

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -107,10 +107,10 @@ end
 @doc Markdown.doc"""
     standard_basis(I::MPolyIdeal;
       ordering::MonomialOrdering = default_ordering(base_ring(I)),
-      complete_reduction::Bool = false, algorithm::Symbol = :singular)
+      complete_reduction::Bool = false, algorithm::Symbol = :buchberger)
 
 Return a standard basis of `I` with respect to `ordering`. 
-`algorithm` can be set to `:singular` (Singular's Buchberger algorithm), `:fglm` (compute first via a "good" monomial ordering, then convert to the chosen ordering via the FGLM algorithm), `:f4` (msolve's implementation of Faugère's F4 algorithm).
+`algorithm` can be set to `:singular` (Singular's Buchberger (resp. Mora) algorithm), `:fglm` (compute first via a "good" monomial ordering, then convert to the chosen ordering via the FGLM algorithm), `:f4` (msolve's implementation of Faugère's F4 algorithm).
 
 !!! note
     The returned standard basis is reduced if `ordering` is `global` and `complete_reduction = true`.
@@ -130,12 +130,12 @@ negdegrevlex([x, y])
 ```
 """
 function standard_basis(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)),
-	complete_reduction::Bool = false, algorithm::Symbol = :singular)
+	complete_reduction::Bool = false, algorithm::Symbol = :buchberger)
 	complete_reduction && @assert is_global(ordering)
 	if haskey(I.gb, ordering) && (complete_reduction == false || I.gb[ordering].isReduced == true)
 		return I.gb[ordering]
 	end
-	if algorithm == :singular
+	if algorithm == :buchberger
 		if !haskey(I.gb, ordering)
 			I.gb[ordering] = _compute_standard_basis(I.gens, ordering, complete_reduction)
 		elseif complete_reduction == true
@@ -155,7 +155,7 @@ end
       complete_reduction::Bool = false, algorithm::Symbol = :singular)
 
 If `ordering` is global, return a Gröbner basis of `I` with respect to `ordering`.
-`algorithm` can be set to `:singular` (Singular's Buchberger algorithm), `:fglm` (compute first via a "good" monomial ordering, then convert to the chosen ordering via the FGLM algorithm), `:f4` (msolve's implementation of Faugère's F4 algorithm).
+`algorithm` can be set to `:buchberger` (Singular's Buchberger algorithm), `:fglm` (compute first via a "good" monomial ordering, then convert to the chosen ordering via the FGLM algorithm), `:f4` (msolve's implementation of Faugère's F4 algorithm).
 
 !!! note
     The returned Gröbner basis is reduced if `complete_reduction = true`.
@@ -208,7 +208,7 @@ wdegrevlex([x, y], [1, 3])
 ```
 """
 function groebner_basis(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool=false,
-	algorithm::Symbol = :singular)
+	algorithm::Symbol = :buchberger)
     is_global(ordering) || error("Ordering must be global")
     return standard_basis(I, ordering=ordering, complete_reduction=complete_reduction, algorithm=algorithm)
 end

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -1133,7 +1133,7 @@ function dim(I::MPolyIdeal)
   if I.dim > -1
     return I.dim
   end
-  G = groebner_assure(I)
+  G = groebner_assure(I, false, true)
   singular_assure(G)
   I.dim = Singular.dimension(G.S)
   return I.dim

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -213,6 +213,7 @@ end
 mutable struct IdealGens{S}
   gens::BiPolyArray{S}
   isGB::Bool
+  isReduced::Bool
   ord::Orderings.MonomialOrdering
   keep_ordering::Bool
 
@@ -224,11 +225,12 @@ mutable struct IdealGens{S}
     return IdealGens(parent(O[1]), O, ordering; keep_ordering = keep_ordering, isGB)
   end
 
-  function IdealGens(Ox::NCRing, O::Vector{T}, ordering::Orderings.MonomialOrdering; keep_ordering::Bool = true, isGB::Bool = false) where {T <: NCRingElem}
+  function IdealGens(Ox::NCRing, O::Vector{T}, ordering::Orderings.MonomialOrdering; keep_ordering::Bool = true, isGB::Bool = false, isReduced::Bool = false) where {T <: NCRingElem}
     r = new{T}()
     r.gens = BiPolyArray(Ox, O)
     r.ord = ordering
     r.isGB = isGB
+	r.isReduced = isReduced
     r.keep_ordering = keep_ordering
     return r
   end
@@ -243,10 +245,11 @@ mutable struct IdealGens{S}
     return r
   end
 
-  function IdealGens(Ox::T, S::Singular.sideal) where {T <: NCRing}
+  function IdealGens(Ox::T, S::Singular.sideal, isReduced::Bool = false) where {T <: NCRing}
     r = new{elem_type(T)}()
-    r.gens = BiPolyArray(Ox, S)
-    r.isGB = S.isGB
+    r.gens		= BiPolyArray(Ox, S)
+    r.isGB		= S.isGB
+	r.isReduced = isReduced
     if T <: Union{MPolyRing, MPolyRingLoc, MPolyQuo}
       r.ord = monomial_ordering(Ox, ordering(base_ring(S)))
     end
@@ -269,6 +272,8 @@ function Base.getproperty(idealgens::IdealGens, name::Symbol)
     return getfield(idealgens, name)
   elseif name == :isGB
     return getfield(idealgens, name)
+  elseif name == :isReduced
+    return getfield(idealgens, name)
   elseif name == :ord
     return getfield(idealgens, name)
   elseif name == :keep_ordering
@@ -281,7 +286,7 @@ end
 function Base.setproperty!(idealgens::IdealGens, name::Symbol, x)
   if name == :Ox || name == :O || name == :Sx || name == :S
     setfield!(idealgens.gens, name, x)
-  elseif name == :gens || name == :isGB || name == :ord || name == :keep_ordering
+  elseif name == :gens || name == :isGB || name == :isReduced|| name == :ord || name == :keep_ordering
     setfield!(idealgens, name, x)
   else
     error("undefined property: ", string(name))

--- a/test/Rings/groebner-test.jl
+++ b/test/Rings/groebner-test.jl
@@ -6,7 +6,7 @@
     @test leading_ideal(I, ordering=lex(gens(R))) == ideal(R,[y^7, x*y^2, x^3])
     R, (x, y) = PolynomialRing(GF(5), ["x", "y"])
     I = ideal(R, [x])
-    gb = f4(I)
+    gb = Oscar._compute_groebner_basis_using_f4(I)
     @test normal_form(y, I) == y
     G = groebner_basis(I)
     J = ideal(R, y)
@@ -110,7 +110,7 @@ end
             x1^2+2*x2^2+2*x3^2+2*x4^2-x1,
             2*x1*x2+2*x2*x3+2*x3*x4-x2,
             x2^2+2*x1*x3+2*x2*x4-x3])
-    H = f4(I);
+    H = Oscar._compute_groebner_basis_using_f4(I);
     G = gfp_mpoly[x1 + 2*x2 + 2*x3 + 2*x4 + 268435458
                   x3^2 + 2*x2*x4 + 76695850*x3*x4 + 115043772*x4^2 + 115043768*x2 + 191739613*x3 + 230087535*x4
                   x2*x3 + 268435457*x2*x4 + 230087533*x3*x4 + 76695842*x4^2 + 210913575*x2 + 38347923*x3 + 153391692*x4
@@ -121,7 +121,7 @@ end
     @test elements(H) == G
     @test isdefined(I, :gb)
     @test I.gb[degrevlex(gens(base_ring(I)))].O == G
-    H = f4(I, eliminate=2);
+    H = Oscar._compute_groebner_basis_using_f4(I, eliminate=2);
     G = gfp_mpoly[x3^2*x4 + 73209671*x3*x4^2 + 260301051*x4^3 + 188447115*x3^2 + 167207272*x3*x4 + 120660383*x4^2 + 210590781*x3 + 109814506*x4
                   x3^3 + 156877866*x3*x4^2 + 59264971*x4^3 + 224858274*x3^2 + 183605206*x3*x4 + 130731555*x4^2 + 110395535*x3 + 158620953*x4
                   x4^4 + 167618101*x3*x4^2 + 102789335*x4^3 + 193931678*x3^2 + 156155981*x3*x4 + 60823186*x4^2 + 239040667*x3 + 127377432*x4

--- a/test/Rings/groebner-test.jl
+++ b/test/Rings/groebner-test.jl
@@ -6,7 +6,7 @@
     @test leading_ideal(I, ordering=lex(gens(R))) == ideal(R,[y^7, x*y^2, x^3])
     R, (x, y) = PolynomialRing(GF(5), ["x", "y"])
     I = ideal(R, [x])
-    gb = Oscar._compute_groebner_basis_using_f4(I)
+    gb = f4(I)
     @test normal_form(y, I) == y
     G = groebner_basis(I)
     J = ideal(R, y)
@@ -110,7 +110,7 @@ end
             x1^2+2*x2^2+2*x3^2+2*x4^2-x1,
             2*x1*x2+2*x2*x3+2*x3*x4-x2,
             x2^2+2*x1*x3+2*x2*x4-x3])
-    H = Oscar._compute_groebner_basis_using_f4(I);
+    H = f4(I);
     G = gfp_mpoly[x1 + 2*x2 + 2*x3 + 2*x4 + 268435458
                   x3^2 + 2*x2*x4 + 76695850*x3*x4 + 115043772*x4^2 + 115043768*x2 + 191739613*x3 + 230087535*x4
                   x2*x3 + 268435457*x2*x4 + 230087533*x3*x4 + 76695842*x4^2 + 210913575*x2 + 38347923*x3 + 153391692*x4
@@ -121,7 +121,7 @@ end
     @test elements(H) == G
     @test isdefined(I, :gb)
     @test I.gb[degrevlex(gens(base_ring(I)))].O == G
-    H = Oscar._compute_groebner_basis_using_f4(I, eliminate=2);
+    H = f4(I, eliminate=2);
     G = gfp_mpoly[x3^2*x4 + 73209671*x3*x4^2 + 260301051*x4^3 + 188447115*x3^2 + 167207272*x3*x4 + 120660383*x4^2 + 210590781*x3 + 109814506*x4
                   x3^3 + 156877866*x3*x4^2 + 59264971*x4^3 + 224858274*x3^2 + 183605206*x3*x4 + 130731555*x4^2 + 110395535*x3 + 158620953*x4
                   x4^4 + 167618101*x3*x4^2 + 102789335*x4^3 + 193931678*x3^2 + 156155981*x3*x4 + 60823186*x4^2 + 239040667*x3 + 127377432*x4

--- a/test/Rings/groebner-test.jl
+++ b/test/Rings/groebner-test.jl
@@ -54,8 +54,15 @@
        2*x1*x2+2*x2*x3+2*x3*x4-x2,
        x2^2+2*x1*x3+2*x2*x4-x3])
 	standard_basis(J, ordering=neglex(R))
-	groebner_assure(J, true, true)
+	Oscar.groebner_assure(J, true, true)
 	@test J.gb[degrevlex(R)].isReduced == true 
+	@test_throws ErrorException standard_basis(J, ordering=negdeglex(R), algorithm=:fglm)
+	standard_basis(J, ordering=lex(R), algorithm=:fglm)
+	H = fmpq_mpoly[128304*x4^8 - 93312*x4^7 + 15552*x4^6 + 3144*x4^5 - 1120*x4^4 + 36*x4^3 + 15*x4^2 - x4,
+		5913075*x3 + 371438283744*x4^7 - 237550027104*x4^6 + 22645939824*x4^5 + 11520686172*x4^4 - 2024910556*x4^3 - 132524276*x4^2 + 30947828*x4,
+		1971025*x2 - 97197721632*x4^7 + 73975630752*x4^6 - 12121915032*x4^5 - 2760941496*x4^4 + 814792828*x4^3 - 1678512*x4^2 - 9158924*x4,
+		5913075*x1 - 159690237696*x4^7 + 31246269696*x4^6 + 27439610544*x4^5 - 6475723368*x4^4 - 838935856*x4^3 + 275119624*x4^2 + 4884038*x4 - 5913075]
+	@test elements(J.gb[lex(R)]) == H
 end
 
 @testset "groebner leading ideal" begin

--- a/test/Rings/groebner-test.jl
+++ b/test/Rings/groebner-test.jl
@@ -48,6 +48,14 @@
     @test_throws ErrorException is_groebner_basis(I.gens, ordering=neglex(R))
     @test is_standard_basis(I.gens, ordering=degrevlex(R)) == true
     @test is_standard_basis(I.gens, ordering=neglex(R)) == false
+	R, (x1, x2, x3, x4) = PolynomialRing(QQ, ["x1", "x2", "x3", "x4"])
+	J = ideal(R, [x1+2*x2+2*x3+2*x4-1,
+       x1^2+2*x2^2+2*x3^2+2*x4^2-x1,
+       2*x1*x2+2*x2*x3+2*x3*x4-x2,
+       x2^2+2*x1*x3+2*x2*x4-x3])
+	standard_basis(J, ordering=neglex(R))
+	groebner_assure(J, true, true)
+	@test J.gb[degrevlex(R)].isReduced == true 
 end
 
 @testset "groebner leading ideal" begin

--- a/test/Rings/groebner-test.jl
+++ b/test/Rings/groebner-test.jl
@@ -1,6 +1,13 @@
 @testset "groebner" begin
     R, (x, y) = PolynomialRing(QQ, ["x", "y"])
     I = ideal(R,[x*y^2 - x, x^3 - 2*y^5])
+    groebner_basis(I, ordering=lex(R), algorithm=:fglm)
+    @test gens(I.gb[lex(R)]) == fmpq_mpoly[y^7 - y^5, x*y^2 - x, x^3 - 2*y^5]
+    groebner_basis(I, ordering=degrevlex(R))
+    @test gens(I.gb[degrevlex(R)]) == fmpq_mpoly[x*y^2 - x, x^4 - 2*x*y, -x^3 + 2*y^5]
+    @test_throws ErrorException groebner_basis(I, ordering=neglex(R))
+    standard_basis(I, ordering=neglex(R))
+    @test gens(I.gb[neglex(R)]) == fmpq_mpoly[-x^3 + 2*y^5, x]
     @test leading_ideal(I, ordering=degrevlex(gens(R))) == ideal(R,[x*y^2, x^4, y^5])
     @test leading_ideal(I) == ideal(R,[x*y^2, x^4, y^5])
     @test leading_ideal(I, ordering=lex(gens(R))) == ideal(R,[y^7, x*y^2, x^3])
@@ -128,4 +135,18 @@ end
                   x3*x4^3 + 99215126*x3*x4^2 + 261328123*x4^3 + 132228634*x3^2 + 93598185*x3*x4 + 85654356*x4^2 + 3613010*x3 + 240673711*x4]
     @test elements(H) == G
     @test I.gb[degrevlex(gens(base_ring(I))[3:end])].O == G
+end
+
+@testset "fglm" begin
+	R, (x, y) = PolynomialRing(QQ, ["x", "y"])
+	A = Oscar.IdealGens(R, [x*y-1, x^2+y^2])
+	@test_throws ErrorException fglm(A, ordering = lex(R))
+	I = ideal(R, gens(A))
+	groebner_basis(I)
+	@test_throws ErrorException fglm(I.gb[degrevlex([x, y])], ordering=lex(R))
+	groebner_basis(I, complete_reduction=true)
+	G = fglm(I.gb[degrevlex([x, y])], ordering=lex(R))
+	@test gens(G) == fmpq_mpoly[y^4 + 1, x + y^3]
+	J = ideal(R, [x])
+	@test_throws ErrorException groebner_basis(J, algorithm=:fglm)
 end


### PR DESCRIPTION
Adds the FGLM algorithm to

1. directly convert Gröbner bases for different monomial orderings, and
2. use the FGLM-method to compute Gröbner bases.

For this `IdealGens` includes a new flag `isReduced` which tracks if the Gröbner basis is reduced or not. Corresponding adjustments for `groebner_assure()` have been applied.