### PR TITLE
Minor adjustment of ideals

### DIFF
--- a/docs/src/CommutativeAlgebra/ideals.md
+++ b/docs/src/CommutativeAlgebra/ideals.md
@@ -23,7 +23,7 @@ The OSCAR type for ideals in multivariate polynomial rings is of parametrized fo
 ## Constructors
 
 ```@docs
-ideal(g::Vector{T}) where {T <: MPolyElem}
+ideal(R::MPolyRing, g::Vector)
 ```
 
 ## Data Associated to Ideals

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -821,7 +821,7 @@ function ideal(g::Vector{T}) where {T <: MPolyElem_dec}
        throw(ArgumentError("The generators of the ideal must be homogeneous."))
      end
   end
-  return MPolyIdeal(g)
+  return MPolyIdeal(parent(g[1]), g)
 end
 
 function jacobi_matrix(f::MPolyElem_dec)

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -48,10 +48,12 @@ julia> typeof(J)
 MPolyIdeal{MPolyElem_dec{fmpq, fmpq_mpoly}}
 ```
 """
-function ideal(g::Vector{T}) where {T <: MPolyElem}
-  @assert length(g) > 0
-  @assert all(x->parent(x) == parent(g[1]), g)
-  return MPolyIdeal(g)
+function ideal(R::MPolyRing, g::Vector)
+  h = elem_type(R)[R(f) for f = g]
+  #if isempty(g)
+  #  push!(h, R())
+  #end
+  return MPolyIdeal(R, h)
 end
 
 function ideal(I::IdealGens{T}) where {T <: MPolyElem}
@@ -60,17 +62,16 @@ end
 
 # TODO: Can we make this the default?
 # (Or maybe remove ideal(...) without a ring completely?)
-function ideal(R::MPolyRing, g::Vector)
-  h = elem_type(R)[R(f) for f = g]
-  if isempty(g)
-    push!(h, R())
-  end
-  return ideal(h)
-end
 
 function ideal(Qxy::MPolyRing{T}, x::MPolyElem{T}) where T <: RingElem
   return ideal(Qxy, [x])
 end
+
+function ideal(g::Vector{T}) where {T <: MPolyElem}
+  @req length(g) > 0 "List of elements must be non-empty"
+  return ideal(parent(g[1]), g)
+end
+
 
 
 # elementary operations #######################################################
@@ -83,18 +84,6 @@ function check_base_rings(I::MPolyIdeal{T}, J::MPolyIdeal{T}) where T
   if !isequal(base_ring(I), base_ring(J))
     error("Base rings must coincide.")
   end
-end
-
-@doc Markdown.doc"""
-    remove_zeroes!(I::MPolyIdeal)
-
-Removes zero generators from ideal `I` if `I` is not the zero ideal.
-"""
-function remove_zeroes!(I::MPolyIdeal{T}) where T
-    if !iszero(I)
-      filter!(!iszero, I.gens.O)
-    end
-    return I
 end
 
 @doc Markdown.doc"""
@@ -143,7 +132,8 @@ function Base.:+(I::MPolyIdeal{T}, J::MPolyIdeal{T}) where T
   oscar_assure(I)
   oscar_assure(J)
   check_base_rings(I, J)
-  return remove_zeroes!(MPolyIdeal(unique!(vcat(I.gens.O,J.gens.O))))
+  newgens = filter!(!iszero, unique!(vcat(I.gens.O,J.gens.O)))
+  return ideal(base_ring(I), newgens)
 end
 Base.:-(I::MPolyIdeal, J::MPolyIdeal) = I+J
 
@@ -171,7 +161,16 @@ function Base.:*(I::MPolyIdeal{T}, J::MPolyIdeal{T}) where T
   oscar_assure(I)
   oscar_assure(J)
   check_base_rings(I, J)
-  return remove_zeroes!(MPolyIdeal(unique!(vcat([broadcast(*, g, J.gens.O) for g in I.gens.O]...))))
+  newgens = elem_type(base_ring(I))[]
+  for g in I.gens.O
+    for h in J.gens.O
+      gh = g * h
+      if !iszero(gh)
+        push!(newgens, gh)
+      end
+    end
+  end
+  return ideal(base_ring(I), unique!(newgens))
 end
 
 #######################################################

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -576,8 +576,8 @@ mutable struct MPolyIdeal{S} <: Ideal{S}
   gb::Dict{MonomialOrdering, IdealGens{S}}
   dim::Int
 
-  function MPolyIdeal(g::Vector{T}) where {T <: MPolyElem}
-    return MPolyIdeal(IdealGens(g, keep_ordering = false))
+  function MPolyIdeal(R::Ring, g::Vector{T}) where {T <: MPolyElem}
+    return MPolyIdeal(IdealGens(R, g, keep_ordering = false))
   end
 
   function MPolyIdeal(Ox::T, s::Singular.sideal) where {T <: MPolyRing}

--- a/test/Rings/mpoly-test.jl
+++ b/test/Rings/mpoly-test.jl
@@ -75,12 +75,6 @@ end
 
 @testset "Ideal operations" begin
   R, (x, y) = PolynomialRing(QQ, ["x", "y"])
-  I = ideal(R, [0, x^2, 0])
-  Oscar.remove_zeroes!(I)
-  @test I == ideal(R, [x^2])
-  I = ideal(R, [0])
-  Oscar.remove_zeroes!(I)
-  @test I == ideal(R, [0])
   I = ideal(R, [x^2, y^2])
   J = ideal(R, [x*y^2, x^2])
   S = ideal(R, [x^2, y^2, x*y^2])


### PR DESCRIPTION
- Make `ideals(R, elements)` the primary method
- Do not modify the generators

Should fix #1778.