### PR TITLE
Clean up printing

### DIFF
--- a/src/Rings/localization_interface.jl
+++ b/src/Rings/localization_interface.jl
@@ -277,7 +277,10 @@ function parent(f::AbsLocalizedRingElem)
   error("`parent` is not implemented for the type $(typeof(f))")
 end
 
-expressify(f::AbsLocalizedRingElem; context=nothing) = Expr(:call, ://, expressify(numerator(f), context=context), expressify(denominator(f), context=context))
+function expressify(f::AbsLocalizedRingElem; context=nothing) 
+  isone(denominator(f)) && expressify(numerator(f), context=context)
+  return Expr(:call, ://, expressify(numerator(f), context=context), expressify(denominator(f), context=context))
+end
 
 @enable_all_show_via_expressify AbsLocalizedRingElem
 
@@ -405,15 +408,6 @@ function Base.show(io::IO, W::AbsLocalizedRing)
   print(io, base_ring(W))
   print(io, " at the ")
   print(io, inverted_set(W))
-end
-
-function Base.show(io::IO, a::AbsLocalizedRingElem) 
-  if isone(denominator(a))
-    print(io, numerator(a))
-  else
-    print(io, "$(numerator(a))//$(denominator(a))")
-  end
-  return
 end
 
 function zero!(a::AbsLocalizedRingElem) 


### PR DESCRIPTION
In this morning's merge I had made a mess with printing of elements of localized rings. This should make the warning go away when starting up Oscar.

@tthsqe12 : Thanks for explaining the expressify stuff (again)! 