### PR TITLE
Use sparse matrices in the pre_saturation_data.

### DIFF
--- a/src/Modules/Posur.jl
+++ b/src/Modules/Posur.jl
@@ -19,11 +19,13 @@ function clear_denominators(A::MatrixType) where {T<:AbsLocalizedRingElem, Matri
   n = ncols(A)
   S = base_ring(A)
   R = base_ring(S)
-  D = zero(MatrixSpace(R, m, m))
+  D = sparse_matrix(R)
+  #D = zero(MatrixSpace(R, m, m))
   B = zero(MatrixSpace(R, m, n))
   for i in 1:m
     d = lcm(vec(denominator.(A[i,:])))
-    D[i,i] = d
+    push!(D, sparse_row(R, [(i, d)]))
+    #D[i,i] = d
     for j in 1:n
       B[i, j] = numerator(A[i,j])*divexact(d, denominator(A[i,j]))
     end
@@ -96,7 +98,7 @@ free modules given by ``A``.
 function syz(A::MatrixElem{<:AbsLocalizedRingElem})
   B, D = clear_denominators(A)
   L = syz(B)
-  return L*D
+  return transpose(mul(transpose(D), transpose(L)))
 end
 
 # The annihilator of b as an element of a free module modulo the cokernel of A
@@ -179,7 +181,7 @@ function has_solution(
   # We have B = D⋅A and c = u ⋅ b as matrices. 
   # Now y⋅B = v⋅c ⇔ y⋅D ⋅A = v ⋅ u ⋅ b ⇔ v⁻¹ ⋅ u⁻¹ ⋅ y ⋅ D ⋅ A = b.
   # Take v⁻¹ ⋅ u⁻¹ ⋅ y ⋅ D to be the solution x of x ⋅ A = b.
-  return (success, S(one(R), v*u[1,1])*change_base_ring(S, y*D))
+  return (success, S(one(R), v*u[1,1])*change_base_ring(S, transpose(mul(transpose(D), transpose(y)))))
 end
 
 # This second version solves over the base ring and checks compatibility with 
@@ -279,7 +281,7 @@ function pre_saturation_data_gens(M::SubQuo{T}) where {T<:AbsLocalizedRingElem}
   if !has_attribute(M, :pre_saturation_data_gens)
     pre_saturated_module(M)
   end
-  return get_attribute(M, :pre_saturation_data_gens)::dense_matrix_type(T)
+  return get_attribute(M, :pre_saturation_data_gens)::SMat{elem_type(base_ring(M))}
 end
 
 # For a SubQuo M over a localized ring S = R[U⁻¹] and its current 
@@ -292,7 +294,7 @@ function pre_saturation_data_rels(M::SubQuo{T}) where {T<:AbsLocalizedRingElem}
   if !has_attribute(M, :pre_saturation_data_rels)
     pre_saturated_module(M)
   end
-  return get_attribute(M, :pre_saturation_data_rels)::dense_matrix_type(T)
+  return get_attribute(M, :pre_saturation_data_rels)::SMat{elem_type(base_ring(M))}
 end
 
 base_ring_module_map_type(::Type{FreeMod{T}}) where {T<:AbsLocalizedRingElem} = morphism_type(base_ring_module_type(FreeMod{T}), FreeMod{T})
@@ -422,7 +424,8 @@ function kernel(
   fb = hom(Fb, Gb, B)
   Kb, incb = kernel(fb)
   Cb = representing_matrix(incb)
-  C = change_base_ring(S, Cb*D)
+  C = change_base_ring(S, transpose(mul(transpose(D), transpose(Cb))))
+  #C = change_base_ring(S, Cb*D)
   K, inc = sub(domain(f), C)
   return K, inc
 end
@@ -457,13 +460,15 @@ function coordinates(u::FreeModElem{T}, M::SubQuo{T}) where {T<:AbsLocalizedRing
   (u_clear, d_u) = clear_denominators(u)
   Mb = pre_saturated_module(M)
   if represents_element(u_clear, Mb)
-    yc = as_matrix(coordinates(u_clear, Mb), ngens(Mb))
-    Tr = pre_saturation_data_gens(M)
-    # We have yc ⋅ A' ≡ uc with A' = Tr ⋅ generator_matrix(M) and d_u ⋅ u = uc.
-    # Then (1//d_u) ⋅ yc ⋅ T are the coordinates of u in the original generators 
-    # generator_matrix(M).
-    result = S(one(R), d_u)*(yc*Tr) 
-    return sparse_row(result)
+    # yc = as_matrix(coordinates(u_clear, Mb), ngens(Mb))
+    # Tr = pre_saturation_data_gens(M)
+    # # We have yc ⋅ A' ≡ uc with A' = Tr ⋅ generator_matrix(M) and d_u ⋅ u = uc.
+    # # Then (1//d_u) ⋅ yc ⋅ T are the coordinates of u in the original generators 
+    # # generator_matrix(M).
+    # result = S(one(R), d_u)*(yc*Tr) 
+    # return sparse_row(result)
+    return S(one(R), d_u)*mul(change_base_ring(S, coordinates(u_clear, Mb)), 
+                                               pre_saturation_data_gens(M))
   end
 
   # If u_clear was not yet found in the presaturated module, do the full search.
@@ -501,11 +506,13 @@ function coordinates(u::FreeModElem{T}, M::SubQuo{T}) where {T<:AbsLocalizedRing
   # For the extended set of generators in the pre-saturation, we 
   # need to extend this matrix by one more row given by d_v ⋅ y.
   set_attribute!(M, :pre_saturation_data_gens, 
-                 vcat(Tr, d_v*y)
+                 #vcat(Tr, d_v*y)
+                 push!(Tr, sparse_row(d_v*y))
                 )
   Tr = pre_saturation_data_rels(M)
   set_attribute!(M, :pre_saturation_data_rels, 
-                 vcat(Tr, d_w*z)
+                 #vcat(Tr, d_w*z)
+                 push!(Tr, sparse_row(d_w*z))
                 )
   set_attribute!(M, :pre_saturated_module, Mbext)
   # finally, return the computed coordinates
@@ -587,11 +594,13 @@ function represents_element(u::FreeModElem{T}, M::SubQuo{T}) where {T<:AbsLocali
   # For the extended set of generators in the pre-saturation, we 
   # need to extend this matrix by one more row given by d_v ⋅ y.
   set_attribute!(M, :pre_saturation_data_gens, 
-                 vcat(Tr, d_v*y)
+                 #vcat(Tr, d_v*y)
+                 push!(Tr, sparse_row(mul(change_base_ring(base_ring(M), d_v), y)))
                 )
   Tr = pre_saturation_data_rels(M)
   set_attribute!(M, :pre_saturation_data_rels, 
-                 vcat(Tr, d_w*z)
+                 #vcat(Tr, d_w*z)
+                 push!(Tr, sparse_row(mul(change_base_ring(base_ring(M), d_w), z)))
                 )
   set_attribute!(M, :pre_saturated_module, Mbext)
 
@@ -688,7 +697,8 @@ function iszero(v::SubQuoElem{<:AbsLocalizedRingElem})
   # need to extend this matrix by one more row given by d ⋅ y.
   Tr = pre_saturation_data_rels(M)
   set_attribute!(M, :pre_saturation_data_rels, 
-                 vcat(Tr, d*y)
+                 #vcat(Tr, d*y)
+                 push!(Tr, sparse_row(d*y))
                 )
   set_attribute!(M, :pre_saturated_module, Mbext)
   return true

--- a/src/Modules/Posur.jl
+++ b/src/Modules/Posur.jl
@@ -19,7 +19,7 @@ function clear_denominators(A::MatrixType) where {T<:AbsLocalizedRingElem, Matri
   n = ncols(A)
   S = base_ring(A)
   R = base_ring(S)
-  D = sparse_matrix(R)
+  D = zero_matrix(SMat, R, 0, m)
   #D = zero(MatrixSpace(R, m, m))
   B = zero(MatrixSpace(R, m, n))
   for i in 1:m

--- a/src/Modules/mpoly-localizations.jl
+++ b/src/Modules/mpoly-localizations.jl
@@ -75,7 +75,8 @@ function has_nonempty_intersection(U::MPolyProductOfMultSets, I::MPolyIdeal; che
     return false, zero(R), zero(MatrixSpace(R, 1, ngens(I)))
   end
   T = pre_saturation_data(Iloc)
-  Bext = A*T
+  Bext = transpose(mul(T, transpose(B)))
+  #Bext = A*T
   u = lcm(vec(denominator.(Bext)))
   B = map_entries(x->preimage(map_from_base_ring(Iloc), x), u*Bext)
   return true, u*g, B

--- a/src/Modules/mpolyquo-localizations.jl
+++ b/src/Modules/mpolyquo-localizations.jl
@@ -36,7 +36,7 @@ end
 function syz(A::MatrixElem{<:MPolyQuoLocalizedRingElem})
   B, D = clear_denominators(A)
   L = syz(vcat(B, modulus_matrix(base_ring(A), ncols(B))))
-  return map_entries(base_ring(A), L[:,1:nrows(D)]*D)
+  return map_entries(base_ring(A), transpose(mul(transpose(D), transpose(L[:,1:nrows(D)]))))
 end
 
 function ann(b::MatrixType, A::MatrixType) where {T<:MPolyQuoLocalizedRingElem, MatrixType<:MatrixElem{T}}
@@ -65,7 +65,8 @@ function has_solution(A::MatrixType, b::MatrixType) where {T<:MPolyQuoLocalizedR
   # Now [y z]⋅B = v⋅c ⇔ [y z]⋅D ⋅Aext = v ⋅ u ⋅ b ⇔ v⁻¹ ⋅ u⁻¹ ⋅ [y z] ⋅ D ⋅ Aext = b.
   # Take v⁻¹ ⋅ u⁻¹ ⋅ [y z] ⋅ D to be the solution x of x ⋅ Aext = b. 
   # Then for the first m components x' of x we have x' ⋅ A ≡ b mod I
-  x = S(one(R), v*u[1,1])*map_entries(S, y*D)
+  x = S(one(R), v*u[1,1])*map_entries(S, transpose(mul(transpose(D), transpose(y))))
+  #x = S(one(R), v*u[1,1])*map_entries(S, y*D)
   xpart = zero(MatrixSpace(S, 1, nrows(A)))
   for i in 1:nrows(A)
     xpart[1, i] = x[1, i]
@@ -83,7 +84,10 @@ function pre_saturated_module(M::SubQuo{T}) where {T<:MPolyQuoLocalizedRingElem}
     (B, E) = clear_denominators(relM)
     mod_mat = modulus_matrix(S, ncols(B))
     B = vcat(B, mod_mat)
-    E = vcat(E, zero(MatrixSpace(R, nrows(mod_mat), ncols(E))))
+    #E = vcat(E, zero(MatrixSpace(R, nrows(mod_mat), ncols(E))))
+    for i in 1:nrows(mod_mat)
+      push!(E, sparse_row(base_ring(E)))
+    end
     F = ambient_free_module(M)
     Fb = base_ring_module(F)
     Mb = SubQuo(Fb, A, B)

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -1351,8 +1351,19 @@ Ideals in localizations of polynomial rings.
   # fields for caching 
   map_from_base_ring::Hecke.Map
 
+  # The pre_saturated_ideal can be any ideal I in the `base_ring` of W
+  # such that W(I) is this ideal
   pre_saturated_ideal::MPolyIdeal
-  pre_saturation_data::MatrixElem
+  # The following field contains a matrix A such that the *transpose* 
+  # of A can be used to compute coordinates v of elements a w.r.t the 
+  # generators of the pre_saturated_ideal to the coordinates w 
+  # of W(a) w.r.t the generators of this ideal: 
+  #   
+  #     v*A^T = w, or equivalently (A*v^T)^T = w.
+  #
+  # In the code below we will often use the latter, because multiplication 
+  # with sparse matrices is only implemented from the left. 
+  pre_saturation_data::SMat
 
   is_saturated::Bool
   saturated_ideal::MPolyIdeal
@@ -1439,12 +1450,14 @@ function coordinates(a::RingElem, I::MPolyLocalizedIdeal; check::Bool=true)
     q = denominator(a)
     # caching has been done during the call of `in`, so the following will work
     x = coordinates(p, pre_saturated_ideal(I))
-    return L(one(q), q, check=false)*change_base_ring(L, x)*pre_saturation_data(I)
+    # multiplications sparse*dense have to be carried out this way round.
+    return transpose(mul(pre_saturation_data(I), transpose(L(one(q), q, check=false)*change_base_ring(L, x))))
   else
     (success, x, u) = has_solution(generator_matrix(J), MatrixSpace(R, 1, 1)([p]), inverted_set(L), check=false)
     !success && error("check for membership was disabled, but element is not in the ideal")
     # cache the intermediate result
-    result = L(one(R), u*denominator(a), check=false)*change_base_ring(L, x)*pre_saturation_data(I)
+    #result = L(one(R), u*denominator(a), check=false)*change_base_ring(L, x)*pre_saturation_data(I)
+    result = transpose(mul(pre_saturation_data(I), transpose(L(one(R), u*denominator(a), check=false)*change_base_ring(L, x))))
     extend_pre_saturated_ideal!(I, p, x, u, check=false)
     return result
   end
@@ -1465,7 +1478,7 @@ function coordinates(
   p = numerator(a)
   x = coordinates(p, J)
   q = denominator(a)
-  return L(one(q), q, check=false)*change_base_ring(L, x)*pre_saturation_data(I)
+  return transpose(mul(pre_saturation_data(I), transpose(L(one(q), q, check=false)*change_base_ring(L, x))))
 end
 
 generator_matrix(J::MPolyIdeal) = MatrixSpace(base_ring(J), ngens(J), 1)(gens(J))
@@ -1519,9 +1532,11 @@ function pre_saturated_ideal(I::MPolyLocalizedIdeal)
     W = base_ring(I)
     I.pre_saturated_ideal = ideal(base_ring(W), numerator.(gens(I)))
     r = length(gens(I))
-    A = zero(MatrixSpace(W, r, r))
+    A = sparse_matrix(W)
+    #A = zero(MatrixSpace(W, r, r))
     for i in 1:r
-      A[i, i] = denominator(gens(I)[i])
+      push!(A, sparse_row(W, [(i, W(denominator(gens(I)[i])))]))
+      #A[i, i] = denominator(gens(I)[i])
     end
     I.pre_saturation_data = A
   end
@@ -1548,7 +1563,12 @@ function extend_pre_saturated_ideal!(
   end
   J_ext = ideal(R, vcat(gens(J), [f]))
   T = pre_saturation_data(I)
-  T_ext = vcat(T, L(one(u), u, check=false)*change_base_ring(L, x)*T)
+  y = mul(T, transpose(L(one(u), u, check=false)*change_base_ring(L, x)))
+  T_ext = sparse_matrix(L)
+  for i in 1:length(y)
+    push!(T_ext, T[i] + sparse_row(L, [(ncols(T) + 1, y[i, 1])]))
+  end
+  #T_ext = vcat(T, L(one(u), u, check=false)*change_base_ring(L, x)*T)
   I.pre_saturated_ideal = J_ext
   I.pre_saturation_data = T_ext
   return I
@@ -1570,13 +1590,30 @@ function extend_pre_saturated_ideal!(
   end
   J_ext = ideal(R, vcat(gens(J), f))
   T = pre_saturation_data(I)
-  T_ext = vcat(T, 
-               diagonal_matrix([L(one(v), v, check=false) for v in u])*
-               change_base_ring(L, x)*T
-              )
+  #T_ext = vcat(T, 
+  #             diagonal_matrix([L(one(v), v, check=false) for v in u])*
+  #             change_base_ring(L, x)*T
+  #            )
+  #y = T * transpose(L(one(u), u, check=false)*change_base_ring(L, x))
+  y = mul(T, transpose(change_base_ring(L, x)))
+  for i in 1:ncols(y)
+    y[i, 1] = y[i, 1]*L(one(u[i]), u[i], check=false) 
+  end
+  T_ext = sparse_matrix(L)
+  for i in 1:length(y)
+    push!(T_ext, T[i] + sparse_row(L, [(ncols(T) + 1, y[i, 1])]))
+  end
   I.pre_saturated_ideal = J_ext
   I.pre_saturation_data = T_ext
   return I
+end
+
+function _diagonal_sparse_matrix(L::Ring, v::Vector{T}) where {T<:RingElem}
+  A = sparse_matrix(L)
+  for i in 1:length(v)
+    push!(A, sparse_row(L, [(i, v[i])]))
+  end
+  return A
 end
 
 function coordinate_shift(
@@ -1680,16 +1717,29 @@ function saturated_ideal(
             (k, dttk) = Oscar._minimal_power_such_that(d, p->(p*g in pre_saturated_ideal(I)))
             if k > 0
               push!(cache, (g, coordinates(dttk*g, pre_saturated_ideal(I)), dttk))
+            else
+              # We hit the unit ideal. Now we could simply return that; but we don't for 
+              # the moment.
+              push!(cache, (g, coordinates(dttk*g, pre_saturated_ideal(I)), dttk))
             end
           end
           if length(cache) > 0
-            A = zero(MatrixSpace(L, ngens(Jsat), ngens(I)))
+            #A = zero(MatrixSpace(L, ngens(Jsat), ngens(I)))
 
+            #for i in 1:length(cache)
+            #  (g, a, dttk) = cache[i]
+            #  A[i, :] = L(one(dttk), dttk, check=false)*change_base_ring(L, a)*pre_saturation_data(I)
+            #end
+            cols = Vector()
             for i in 1:length(cache)
               (g, a, dttk) = cache[i]
-              A[i, :] = L(one(dttk), dttk, check=false)*change_base_ring(L, a)*pre_saturation_data(I)
+              push!(cols, mul(pre_saturation_data(I), transpose(L(one(dttk), dttk, check=false)*change_base_ring(L, a))))
             end
-            I.pre_saturated_ideal = Jsat
+            A = sparse_matrix(L)
+            for i in 1:ngens(I)
+              push!(A, sparse_row(L, [(j, cols[j][i, 1]) for j in 1:length(cols)]))
+            end
+            I.pre_saturated_ideal = ideal(R, gens(Jsat))
             I.pre_saturation_data = A
 #            extend_pre_saturated_ideal!(I, 
 #                                        elem_type(R)[g for (g, x, u) in cache],
@@ -1719,10 +1769,19 @@ function saturated_ideal(
         if length(cache) > 0
           # We completely overwrite the pre_saturated_ideal with the generators 
           # of the saturated ideal
-          A = zero(MatrixSpace(L, ngens(Jsat), ngens(I)))
+          #A = zero(MatrixSpace(L, ngens(Jsat), ngens(I)))
+          #for i in 1:length(cache)
+          #  (g, a, dttk) = cache[i]
+          #  A[i, :] = L(one(dttk), dttk, check=false)*change_base_ring(L, a)*pre_saturation_data(I)
+          #end
+          cols = Vector()
           for i in 1:length(cache)
             (g, a, dttk) = cache[i]
-            A[i, :] = L(one(dttk), dttk, check=false)*change_base_ring(L, a)*pre_saturation_data(I)
+            push!(cols, mul(pre_saturation_data(I), transpose(L(one(dttk), dttk, check=false)*change_base_ring(L, a))))
+          end
+          A = sparse_matrix(L)
+          for i in 1:ngens(I)
+            push!(A, sparse_row(L, [(j, cols[j][i, 1]) for j in 1:length(cols)]))
           end
           I.pre_saturated_ideal = Jsat
           I.pre_saturation_data = A
@@ -1942,7 +2001,8 @@ function coordinates(
   o = negdegrevlex(gens(R))
   x, u = Oscar.lift(p, J, o)
   T = pre_saturation_data(I)
-  return L(one(base_ring(L)), tfihs(u)*denominator(a), check=false)*change_base_ring(L, map_entries(tfihs,x))*T
+  return transpose(mul(T, transpose(L(one(base_ring(L)), tfihs(u)*denominator(a), check=false)*change_base_ring(L, map_entries(tfihs,x)))))
+  #return L(one(base_ring(L)), tfihs(u)*denominator(a), check=false)*change_base_ring(L, map_entries(tfihs,x))*T
 end
 
 ########################################################################
@@ -1979,10 +2039,13 @@ function coordinates(
       set_attribute!(I, :popped_ideal, popped_ideal)
     end
     popped_ideal = get_attribute(I, :popped_ideal)
-    return L(one(R), denominator(a), check=false)*map_entries(x->L(x, check=false), coordinates(numerator(a), popped_ideal))*pre_saturation_data(I)
+    return transpose(mul(pre_saturation_data(I), transpose(L(one(R), denominator(a), check=false)*map_entries(x->L(x, check=false), coordinates(numerator(a), popped_ideal)))))
+    #return L(one(R), denominator(a), check=false)*map_entries(x->L(x, check=false), coordinates(numerator(a), popped_ideal))*pre_saturation_data(I)
   end
 
-  numerator(a) in pre_saturated_ideal(I) && return L(one(R), denominator(a), check=false)*map_entries(L, coordinates(numerator(a), pre_saturated_ideal(I)))*pre_saturation_data(I)
+  if numerator(a) in pre_saturated_ideal(I) 
+    return transpose(mul(T, transpose(L(one(R), denominator(a), check=false)*map_entries(L, coordinates(numerator(a), pre_saturated_ideal(I))))))
+  end
 
   i = findfirst(x->(typeof(x)<:MPolyPowersOfElement), U)
   if !isnothing(i)
@@ -1999,7 +2062,9 @@ function coordinates(
     popped_ideal = get_attribute(I, :popped_ideal)
     next_ideal = get_attribute(I, :next_ideal)
     y = coordinates(numerator(a), next_ideal)
-    x = map_entries(x->L(x, check=false), y)*map_entries(x->L(x, check=false), pre_saturation_data(popped_ideal))
+    x = transpose(mul(map_entries(x->L(x, check=false), pre_saturation_data(popped_ideal)), 
+                      transpose(map_entries(x->L(x, check=false), y))))
+    #x = map_entries(x->L(x, check=false), y)*map_entries(x->L(x, check=false), pre_saturation_data(popped_ideal))
     return L(one(R), denominator(a), check=false)*x
   else
     if !has_attribute(I, :popped_ideal)
@@ -2015,7 +2080,9 @@ function coordinates(
     popped_ideal = get_attribute(I, :popped_ideal)
     next_ideal = get_attribute(I, :next_ideal)
     y = coordinates(numerator(a), next_ideal)
-    x = map_entries(x->L(x, check=false), y)*map_entries(x->L(x, check=false), pre_saturation_data(popped_ideal))
+    x = transpose(mul(map_entries(x->L(x, check=false), pre_saturation_data(popped_ideal)), 
+                      transpose(map_entries(x->L(x, check=false), y))))
+    #x = map_entries(x->L(x, check=false), y)*map_entries(x->L(x, check=false), pre_saturation_data(popped_ideal))
     return L(one(R), denominator(a), check=false)*x
   end
 end
@@ -2102,7 +2169,8 @@ function coordinates(
   o = ordering(inverted_set(parent(a)))
   x, u = Oscar.lift(p, J, o)
   T = pre_saturation_data(I)
-  return L(one(base_ring(L)), u*denominator(a), check=false)*change_base_ring(L, x)*T
+  return transpose(mul(T, transpose(L(one(base_ring(L)), u*denominator(a), check=false)*
+                                    change_base_ring(L, x))))
 end
 
 @Markdown.doc """

--- a/test/Modules/module-localizations.jl
+++ b/test/Modules/module-localizations.jl
@@ -34,7 +34,7 @@ end
   Fb = base_ring_module(F)
   A = S[x//(x+y); y//(x+y)^2]
   B, D = Oscar.clear_denominators(A)
-  @test D*A == B
+  @test mul(change_base_ring(S, D), A) == B
 
   b = MatrixSpace(S, 1, 1)((x+y)*x + 5*y//(x+y)^10)
   (success, v) = Oscar.has_solution(A, b)

--- a/test/Rings/mpoly-localizations.jl
+++ b/test/Rings/mpoly-localizations.jl
@@ -1,7 +1,7 @@
 @testset "mpoly-localizations" begin
-  R, var = ZZ["x", "y"]
-  x = var[1]
-  y = var[2] 
+  R, variab = ZZ["x", "y"]
+  x = variab[1]
+  y = variab[2] 
   f = x^2 + y^2 -1
   m = ideal(R, [x, y])
   I = ideal(R, f)
@@ -11,9 +11,9 @@
   W, _ = Localization(T)
   
   k = QQ
-  R, var = k["x", "y"]
-  x = var[1]
-  y = var[2] 
+  R, variab = k["x", "y"]
+  x = variab[1]
+  y = variab[2] 
   p = 123
   q = -49
   f = x^2 + y^2 - p^2 - q^2
@@ -116,18 +116,18 @@
 end
 
 @testset "mpoly-localizations PowersOfElements" begin
-  R, var = ZZ["x", "y"]
-  x = var[1]
-  y = var[2] 
+  R, variab = ZZ["x", "y"]
+  x = variab[1]
+  y = variab[2] 
   f = x^2 + y^2 -1
   S = MPolyPowersOfElement(R, [x, y, f])
   @test f in S
   # 5 is not a unit in R
   @test !(5*f in S)
 
-  R, vars = QQ["x","y"]
-  x = vars[1]
-  y = vars[2]
+  R, variabs = QQ["x","y"]
+  x = variabs[1]
+  y = variabs[2]
   f = x^2 + y^4-120
   S = MPolyPowersOfElement(R, [x, y, f])
   @test f in S
@@ -148,9 +148,9 @@ end
 end
 
 @testset "mpoly-localization homomorphisms" begin
-  R, var = ZZ["x", "y"]
-  x = var[1]
-  y = var[2] 
+  R, variab = ZZ["x", "y"]
+  x = variab[1]
+  y = variab[2] 
   f = x^2 + y^2 -1
   S = MPolyPowersOfElement(R, [x, y, f])
   @test f in S


### PR DESCRIPTION
It turned out that for huge generating sets of ideals, the internal data to translate from one side to the other was eating up memory very badly: I had been using dense matrices for that.

Now I switched to sparse matrices. Unfortunately, due to the restricted functionality for the latter, I had to modify the code to an almost unreadable form. 

If anyone has better ideas on how to solve this, let me know! Otherwise, this should do the job for the time being. 