### PR TITLE
ToricVarieties: Coordinate names in direct product & overhaul of introduction

### DIFF
--- a/docs/src/ToricVarieties/intro.md
+++ b/docs/src/ToricVarieties/intro.md
@@ -9,12 +9,34 @@ Pages = ["intro.md"]
 
 # Introduction
 
-The toric geometry part of OSCAR comprises algorithms addressing
-- normal toric varieties
-- torus-invariant divisors and line bundles on normal toric varieties
-- objects from commutative algebra and polyhedral geometry derived thereof.
+## Content
+
+The toric geometry part of OSCAR comprises algorithms addressing normal toric varieties
+and objects from commutative algebra and polyhedral geometry derived thereof. In particular,
+we provide support for the following:
+- torus-invariant divisor (classes),
+- line bundles,
+- line bundle cohomology via `cohomCalg` (cf. [cohomCalg:Implementation](@cite)),
+- vanishing sets of line bundle cohomology (cf. `Appendix B` of [Bie18](@cite)),
+- cohomology ring and cohomology classes,
+- Chow ring, algebraic cycles and intersection theory,
+- elementary support for closed subvarieties.
 
 
-We follow [CLS11](@cite).
-Our goal is to ensure that one can perform all computations of `Appendix B`.
-Currently, this project is work-in-progress.
+## Status
+
+This project is work-in-progress.
+
+
+## Long term goals
+
+We follow [CLS11](@cite). Our long term goals include the following:
+- Ensure that one can perform all computations of `Appendix B` in [CLS11](@cite).
+- Provide support for coherent sheaves and their sheaf cohomologies. In particular, the existing algorithms in [ToricVarieties_project](https://github.com/homalg-project/ToricVarieties_project) (based on [Bie18](@cite)) should eventually be available in OSCAR.
+
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Martin Bies](https://martinbies.github.io/),
+* [Lars Kastner](https://lkastner.github.io/).

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -111,7 +111,8 @@ export is_finalized
 @doc Markdown.doc"""
     set_coordinate_names(v::AbstractNormalToricVariety, coordinate_names::Vector{String})
 
-Allows to set the names of the homogeneous coordinates.
+Allows to set the names of the homogeneous coordinates as long as the toric variety in
+question is not yet finalized (cf. [`is_finalized(v::AbstractNormalToricVariety)`](@ref)).
 
 # Examples
 ```jldoctest

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -608,7 +608,10 @@ Return the Cartesian/direct product of two normal toric varieties `v` and `w`.
 By default, we prepend an "x" to all homogeneous coordinate names of the first factor
 `v` and a "y" to all homogeneous coordinate names of the second factor `w`. This default
 can be overwritten by invoking `set_coordinate_names` after creating the variety
-(cf. [`set_coordinate_names`](@ref)).
+(cf. [`set_coordinate_names(v::AbstractNormalToricVariety, coordinate_names::Vector{String})`](@ref)).
+
+*Important*: Recall that the coordinate names can only be changed as long as the toric
+variety in question is not finalized (cf. [`is_finalized(v::AbstractNormalToricVariety)`](@ref)).
 
 Crucially, the order of the homogeneous coordinates is not shuffled. To be more
 specific, assume that `v` has ``n_1`` and `w` has ``n_2`` homogeneous coordinates. Then

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -605,17 +605,54 @@ export blowup_on_ith_minimal_torus_orbit
 
 Return the Cartesian/direct product of two normal toric varieties `v` and `w`.
 
+By default, we prepend an "x" to all homogeneous coordinate names of the first factor
+`v` and a "y" to all homogeneous coordinate names of the second factor `w`. This default
+can be overwritten by invoking `set_coordinate_names` after creating the variety
+(cf. [`set_coordinate_names`](@ref)).
+
+Crucially, the order of the homogeneous coordinates is not shuffled. To be more
+specific, assume that `v` has ``n_1`` and `w` has ``n_2`` homogeneous coordinates. Then
+`v * w` has ``n_1 + n_2`` homogeneous coordinates. The first ``n_1`` of these coordinates
+are those of `v` and appear in the very same order as they do for `v`. The remaining
+``n_2`` homogeneous coordinates are those of `w` and appear in the very same order as they
+do for `w`.
+
 # Examples
 ```jldoctest
 julia> P2 = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> P2 * P2
+julia> v1 = P2 * P2
 A normal toric variety
+
+julia> cox_ring(v1)
+Multivariate Polynomial Ring in 6 variables xx1, xx2, xx3, yx1, ..., yx3 over Rational Field graded by
+  xx1 -> [1 0]
+  xx2 -> [1 0]
+  xx3 -> [1 0]
+  yx1 -> [0 1]
+  yx2 -> [0 1]
+  yx3 -> [0 1]
+
+julia> v2 = P2 * P2
+A normal toric variety
+
+julia> set_coordinate_names(v2, ["x1", "x2", "x3", "y1", "y2", "y3"])
+
+julia> cox_ring(v2)
+Multivariate Polynomial Ring in 6 variables x1, x2, x3, y1, ..., y3 over Rational Field graded by
+  x1 -> [1 0]
+  x2 -> [1 0]
+  x3 -> [1 0]
+  y1 -> [0 1]
+  y2 -> [0 1]
+  y3 -> [0 1]
 ```
 """
 function Base.:*(v::AbstractNormalToricVariety, w::AbstractNormalToricVariety)
-    return NormalToricVariety(fan(v)*fan(w))
+    product = NormalToricVariety(fan(v)*fan(w))
+    set_coordinate_names(product, vcat(["x$(i)" for i in coordinate_names(v)], ["y$(i)" for i in coordinate_names(w)]))
+    return product
 end
 
 


### PR DESCRIPTION
- For direct products, by default "x" is prepended to the homogeneous coordinates of the first factor and "y" to those of the second factor. This can be overwritten by set_coordinate_names (ideally immediately) after creating the direct product.
- Overhaul of the introduction to toric varieties (more details on the content, goals and listed who is responsible for the toric varieties, so that user know who to contact).
- Mention in documentation that the coordinate names can only be changed as long as the toric variety in question is not yet finalized.