### PR TITLE
Semi-invariants / relative invariants

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -714,6 +714,19 @@
   url           = {https://www.mathematik.uni-kl.de/~gathmann/en/curves.php}
 }
 
+@Article{Gat96,
+  author        = {Gatermann, Karin},
+  title         = {Semi-invariants, equivariants and algorithms},
+  journal       = {Appl. Algebra Engrg. Comm. Comput.},
+  fjournal      = {Applicable Algebra in Engineering, Communication and
+                  Computing},
+  volume        = {7},
+  number        = {2},
+  pages         = {105--124},
+  year          = {1996},
+  url           = {https://doi.org/10.1007/BF01191379}
+}
+
 @Book{HEO05,
   author        = {Holt, Derek F. and Eick, Bettina and O'Brien, Eamonn A.},
   title         = {Handbook of computational group theory},
@@ -1210,6 +1223,18 @@
   year          = {2018},
   doi           = {10.1307/mmj/1528941621},
   url           = {https://doi.org/10.1307/mmj/1528941621}
+}
+
+@Article{Sta79,
+  author        = {Stanley, Richard P.},
+  title         = {Invariants of finite groups and their applications to
+                  combinatorics},
+  journal       = {Bull. Amer. Math. Soc. (N.S.)},
+  fjournal      = {American Mathematical Society. Bulletin. New Series},
+  volume        = {1},
+  number        = {3},
+  pages         = {475--511},
+  year          = {1979}
 }
 
 @InCollection{Ste91,

--- a/docs/src/InvariantTheory/finite_groups.md
+++ b/docs/src/InvariantTheory/finite_groups.md
@@ -185,3 +185,8 @@ fundamental_invariants(IR::InvRing, algo::Symbol = :default; beta::Int = 0)
 ```@docs
 affine_algebra(IR::InvRing)
 ```
+
+## Semi-invariants / relative invariants
+```@docs
+semi_invariants(IR::InvRing, chi::GAPGroupClassFunction)
+```

--- a/docs/src/InvariantTheory/finite_groups.md
+++ b/docs/src/InvariantTheory/finite_groups.md
@@ -134,22 +134,28 @@ false
 
 ```@docs
 reynolds_operator(IR::InvRing{FldT, GrpT, T}, f::T) where {FldT, GrpT, T <: MPolyElem}
+
+reynolds_operator(IR::InvRing{FldT, GrpT, T}, f::T, chi::GAPGroupClassFunction) where {FldT, GrpT, T <: MPolyElem}
 ```
 
 ## Invariants of a Given Degree
 
 ```@docs
 basis(IR::InvRing, d::Int, algo::Symbol = :default)
+
+basis(IR::InvRing, d::Int, chi::GAPGroupClassFunction)
 ```
 
 ```@docs
 iterate_basis(IR::InvRing, d::Int, algo::Symbol = :default)
+
+iterate_basis(IR::InvRing, d::Int, chi::GAPGroupClassFunction)
 ```
 
 ## The Molien Series
 
 ```@docs
- molien_series([S::PolyRing], I::InvRing)
+ molien_series([S::PolyRing], I::InvRing, [chi::GAPGroupClassFunction])
 ```
 
 ## Primary Invariants

--- a/src/InvariantTheory/invariant_rings.jl
+++ b/src/InvariantTheory/invariant_rings.jl
@@ -612,17 +612,17 @@ function molien_series(S::PolyRing, I::InvRing, chi::Union{GAPGroupClassFunction
   end
 end
 
-function molien_series(I::InvRing)
-  if !isdefined(I, :molien_series)
+function molien_series(I::InvRing, chi::Union{GAPGroupClassFunction, Nothing} = nothing)
+  if chi === nothing
+    if !isdefined(I, :molien_series)
+      S, t = PolynomialRing(QQ, "t", cached = false)
+      I.molien_series = molien_series(S, I)
+    end
+    return I.molien_series
+  else
     S, t = PolynomialRing(QQ, "t", cached = false)
-    I.molien_series = molien_series(S, I)
+    return molien_series(S, I, chi)
   end
-  return I.molien_series
-end
-
-function molien_series(I::InvRing, chi::GAPGroupClassFunction)
-  S, t = PolynomialRing(QQ, "t", cached = false)
-  return molien_series(S, I, chi)
 end
 
 # There are some situations where one needs to know whether one can ask for the

--- a/src/InvariantTheory/invariant_rings.jl
+++ b/src/InvariantTheory/invariant_rings.jl
@@ -285,7 +285,7 @@ In case `chi` is a linear character, the returned polynomial, say `h`, fulfils
 `h^g = chi(g)h` for all `g` in `group(IR)` (possibly `h` is zero).
 
 !!! note
-    It is implicitly assumed that `coefficient_ring(IR)` contains all character values of `chi`.
+    If `coefficient_ring(IR)` does not contain all character values of `chi`, an error is raised.
 
 # Examples
 ```jldoctest
@@ -421,7 +421,7 @@ with respect to `chi`.
 This function is only implemented in the case of characteristic zero.
 
 !!! note
-    It is implicitly assumed that `coefficient_ring(IR)` contains all character values of `chi`.
+    If `coefficient_ring(IR)` does not contain all character values of `chi`, an error is raised.
 
 See also [`iterate_basis`](@ref).
 

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -87,11 +87,7 @@ function dimension_via_molien_series(::Type{T}, R::InvRing, d::Int, chi::Union{G
   end
 
   Qt, t = PowerSeriesRing(QQ, d + 1, "t")
-  if chi !== nothing
-    F = molien_series(R, chi)
-  else
-    F = molien_series(R)
-  end
+  F = molien_series(R, chi)
   k = coeff(numerator(F)(t)*inv(denominator(F)(t)), d)
   @assert is_integral(k)
   return T(numerator(k))::T

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -222,7 +222,7 @@ in degree `d` with respect to `chi`.
 This function is only implemented in the case of characteristic zero.
 
 !!! note
-    It is implicitly assumed that `coefficient_ring(IR)` contains all character values of `chi`.
+    If `coefficient_ring(IR)` does not contain all character values of `chi`, an error is raised.
 
 See also [`basis`](@ref).
 

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -81,13 +81,17 @@ end
 # Return the dimension of the graded component of degree d.
 # If we cannot compute the Molien series (so far in the modular case), we return
 # -1.
-function dimension_via_molien_series(::Type{T}, R::InvRing, d::Int) where T <: IntegerUnion
+function dimension_via_molien_series(::Type{T}, R::InvRing, d::Int, chi::Union{GAPGroupClassFunction, Nothing} = nothing) where T <: IntegerUnion
   if !is_molien_series_implemented(R)
     return -1
   end
 
   Qt, t = PowerSeriesRing(QQ, d + 1, "t")
-  F = molien_series(R)
+  if chi !== nothing
+    F = molien_series(R, chi)
+  else
+    F = molien_series(R)
+  end
   k = coeff(numerator(F)(t)*inv(denominator(F)(t)), d)
   @assert is_integral(k)
   return T(numerator(k))::T
@@ -212,17 +216,93 @@ function iterate_basis(R::InvRing, d::Int, algo::Symbol = :default)
   end
 end
 
-function iterate_basis_reynolds(R::InvRing, d::Int)
+@doc Markdown.doc"""
+    iterate_basis(IR::InvRing, d::Int, chi::GAPGroupClassFunction)
+
+Given an invariant ring `IR`, an integer `d` and an irreducible character `chi`,
+return an iterator over a basis for the semi-invariants (or relative invariants)
+in degree `d` with respect to `chi`.
+
+This function is only implemented in the case of characteristic zero.
+
+!!! note
+    It is implicitly assumed that `coefficient_ring(IR)` contains all character values of `chi`.
+
+See also [`basis`](@ref).
+
+# Examples
+```
+julia> K, a = CyclotomicField(3, "a");
+
+julia> M1 = matrix(K, [0 0 1; 1 0 0; 0 1 0]);
+
+julia> M2 = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1]);
+
+julia> G = MatrixGroup(3, K, [ M1, M2 ]);
+
+julia> IR = invariant_ring(G);
+
+julia> B = iterate_basis(IR, 6, trivial_character(G))
+Iterator over a basis of the component of degree 6 of
+Invariant ring of
+Matrix group of degree 3 over Cyclotomic field of order 3
+with generators
+AbstractAlgebra.Generic.MatSpaceElem{nf_elem}[[0 0 1; 1 0 0; 0 1 0], [1 0 0; 0 a 0; 0 0 -a-1]]
+relative to a character
+
+julia> collect(B)
+4-element Vector{MPolyElem_dec{nf_elem, AbstractAlgebra.Generic.MPoly{nf_elem}}}:
+ x[1]^6 + x[2]^6 + x[3]^6
+ x[1]^4*x[2]*x[3] + x[1]*x[2]^4*x[3] + x[1]*x[2]*x[3]^4
+ x[1]^3*x[2]^3 + x[1]^3*x[3]^3 + x[2]^3*x[3]^3
+ x[1]^2*x[2]^2*x[3]^2
+
+julia> S2 = symmetric_group(2);
+
+julia> R = invariant_ring(QQ, S2);
+
+julia> F = abelian_closure(QQ)[1];
+
+julia> chi = Oscar.group_class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
+group_class_function(character_table(Sym( [ 1 .. 2 ] )), QQAbElem{nf_elem}[1, -1])
+
+julia> B = iterate_basis(R, 3, chi)
+Iterator over a basis of the component of degree 3 of
+Invariant ring of
+Sym( [ 1 .. 2 ] )
+with generators
+PermGroupElem[(1,2)]
+relative to a character
+
+julia> collect(B)
+2-element Vector{MPolyElem_dec{fmpq, fmpq_mpoly}}:
+ x[1]^3 - x[2]^3
+ x[1]^2*x[2] - x[1]*x[2]^2
+
+```
+"""
+iterate_basis(R::InvRing, d::Int, chi::GAPGroupClassFunction) = iterate_basis_reynolds(R, d, chi)
+
+function iterate_basis_reynolds(R::InvRing, d::Int, chi::Union{GAPGroupClassFunction, Nothing} = nothing)
   @assert !is_modular(R)
   @assert d >= 0 "Degree must be non-negative"
+  if chi !== nothing
+    @assert is_zero(characteristic(coefficient_ring(R)))
+    @assert is_irreducible(chi)
+
+    reynolds = reynolds_operator(R, chi)
+  else
+    reynolds = nothing
+  end
 
   monomials = all_monomials(polynomial_ring(R), d)
 
-  k = dimension_via_molien_series(Int, R, d)
+  k = dimension_via_molien_series(Int, R, d, chi)
   @assert k != -1
 
   N = zero_matrix(base_ring(polynomial_ring(R)), 0, 0)
-  return InvRingBasisIterator{typeof(R), typeof(monomials), eltype(monomials), typeof(N)}(R, d, k, true, monomials, Vector{eltype(monomials)}(), N)
+
+  return InvRingBasisIterator{typeof(R), typeof(reynolds), typeof(monomials), eltype(monomials), typeof(N)}(R, d, k, true, reynolds, monomials, Vector{eltype(monomials)}(), N)
 end
 
 # Sadly, we can't really do much iteratively here.
@@ -236,7 +316,7 @@ function iterate_basis_linear_algebra(IR::InvRing, d::Int)
     N = zero_matrix(base_ring(R), 0, 0)
     mons = elem_type(R)[]
     dummy_mons = all_monomials(R, 0)
-    return InvRingBasisIterator{typeof(IR), typeof(dummy_mons), eltype(mons), typeof(N)}(IR, d, k, false, dummy_mons, mons, N)
+    return InvRingBasisIterator{typeof(IR), Nothing, typeof(dummy_mons), eltype(mons), typeof(N)}(IR, d, k, false, nothing, dummy_mons, mons, N)
   end
 
   mons_iterator = all_monomials(R, d)
@@ -244,7 +324,7 @@ function iterate_basis_linear_algebra(IR::InvRing, d::Int)
   if d == 0
     N = identity_matrix(base_ring(R), 1)
     dummy_mons = all_monomials(R, 0)
-    return InvRingBasisIterator{typeof(IR), typeof(mons_iterator), eltype(mons), typeof(N)}(IR, d, k, false, mons_iterator, mons, N)
+    return InvRingBasisIterator{typeof(IR), Nothing, typeof(mons_iterator), eltype(mons), typeof(N)}(IR, d, k, false, nothing, mons_iterator, mons, N)
   end
 
   mons_to_rows = Dict{elem_type(R), Int}(mons .=> 1:length(mons))
@@ -276,7 +356,7 @@ function iterate_basis_linear_algebra(IR::InvRing, d::Int)
   end
   n, N = right_kernel(M)
 
-  return InvRingBasisIterator{typeof(IR), typeof(mons_iterator), eltype(mons), typeof(N)}(IR, d, n, false, mons_iterator, mons, N)
+  return InvRingBasisIterator{typeof(IR), Nothing, typeof(mons_iterator), eltype(mons), typeof(N)}(IR, d, n, false, nothing, mons_iterator, mons, N)
 end
 
 Base.eltype(BI::InvRingBasisIterator) = elem_type(polynomial_ring(BI.R))
@@ -286,6 +366,10 @@ Base.length(BI::InvRingBasisIterator) = BI.dim
 function Base.show(io::IO, BI::InvRingBasisIterator)
   println(io, "Iterator over a basis of the component of degree $(BI.degree) of")
   print(io, BI.R)
+  if BI.reynolds_operator !== nothing
+    # We don't save the character in the iterator unfortunately
+    print(io, "\nrelative to a character")
+  end
 end
 
 function Base.iterate(BI::InvRingBasisIterator)
@@ -317,7 +401,11 @@ function iterate_reynolds(BI::InvRingBasisIterator)
     f = fstate[1]
     state = fstate[2]
 
-    g = reynolds_operator(BI.R, f)
+    if !isnothing(BI.reynolds_operator)
+      g = BI.reynolds_operator(f)
+    else
+      g = reynolds_operator(BI.R, f)
+    end
     if iszero(g)
       continue
     end
@@ -344,7 +432,11 @@ function iterate_reynolds(BI::InvRingBasisIterator, state)
     f = fmonomial_state[1]
     monomial_state = fmonomial_state[2]
 
-    g = reynolds_operator(BI.R, f)
+    if !isnothing(BI.reynolds_operator)
+      g = BI.reynolds_operator(f)
+    else
+      g = reynolds_operator(BI.R, f)
+    end
     if iszero(g)
       continue
     end

--- a/src/InvariantTheory/primary_invariants.jl
+++ b/src/InvariantTheory/primary_invariants.jl
@@ -21,14 +21,14 @@ function test_primary_degrees_via_hilbert_series(R::InvRing, degrees::Vector{Int
   return true
 end
 
-function reduce_hilbert_series_by_primary_degrees(R::InvRing)
-  fl, h = _reduce_hilbert_series_by_primary_degrees(R, [ total_degree(f.f) for f in primary_invariants(R) ])
+function reduce_hilbert_series_by_primary_degrees(R::InvRing, chi::Union{GAPGroupClassFunction, Nothing} = nothing)
+  fl, h = _reduce_hilbert_series_by_primary_degrees(R, [ total_degree(f.f) for f in primary_invariants(R) ], chi)
   @assert fl
   return h
 end
 
-function _reduce_hilbert_series_by_primary_degrees(R::InvRing, degrees::Vector{Int})
-  mol = molien_series(R)
+function _reduce_hilbert_series_by_primary_degrees(R::InvRing, degrees::Vector{Int}, chi::Union{GAPGroupClassFunction, Nothing} = nothing)
+  mol = molien_series(R, chi)
   f = numerator(mol)
   g = denominator(mol)
   for d in degrees

--- a/src/InvariantTheory/secondary_invariants.jl
+++ b/src/InvariantTheory/secondary_invariants.jl
@@ -405,7 +405,7 @@ by primary invariants for `IR`.
 See also [Gat96](@cite) and [Sta79](@cite).
 
 !!! note
-    It is implicitly assumed that `coefficient_ring(IR)` contains all character values of `chi`.
+    If `coefficient_ring(IR)` does not contain all character values of `chi`, an error is raised.
 
 This function is so far only implemented in the case of characteristic zero.
 

--- a/src/InvariantTheory/types.jl
+++ b/src/InvariantTheory/types.jl
@@ -103,11 +103,15 @@ struct AllMonomials{PolyRingT}
   end
 end
 
-struct InvRingBasisIterator{InvRingT, IteratorT, PolyElemT, MatrixT}
+struct InvRingBasisIterator{InvRingT, ReynoldsT, IteratorT, PolyElemT, MatrixT}
   R::InvRingT
   degree::Int
   dim::Int
   reynolds::Bool
+
+  # If we compute the basis twisted by a character, we cache the operator here
+  # instead of in the invariant ring. Otherwise this is `nothing`.
+  reynolds_operator::ReynoldsT
 
   monomials::IteratorT
   monomials_collected::Vector{PolyElemT}

--- a/test/InvariantTheory/invariant_rings-test.jl
+++ b/test/InvariantTheory/invariant_rings-test.jl
@@ -32,6 +32,9 @@
   @test reynolds_operator(RG0, gens(R0)[3]^3) == gens(R0)[3]^3
   @test reynolds_operator(RG0, gens(R0)[1]) == zero(R0)
 
+  @test reynolds_operator(RG0, gens(R0)[3]^3) == reynolds_operator(RG0, gens(R0)[3]^3, trivial_character(group(RG0)))
+  @test reynolds_operator(RG0, gens(R0)[1]) == reynolds_operator(RG0, gens(R0)[1], trivial_character(group(RG0)))
+
   @test reynolds_operator(RGp, gens(Rp)[3]^2) == gens(Rp)[3]^2
   @test reynolds_operator(RGp, gens(Rp)[1]) == zero(Rp)
 
@@ -40,9 +43,11 @@
   @test length(basis(RG0, 1)) == 0
   @test length(basis(RG0, 1, :reynolds)) == 0
   @test length(basis(RG0, 1, :linear_algebra)) == 0
+  @test length(basis(RG0, 1, trivial_character(group(RG0)))) == 0
   @test length(basis(RG0, 3)) == 3
   @test length(basis(RG0, 3, :reynolds)) == 3
   @test length(basis(RG0, 3, :linear_algebra)) == 3
+  @test length(basis(RG0, 3, trivial_character(group(RG0)))) == 3
 
   @test length(basis(RGp, 1)) == 0
   @test length(basis(RGp, 1, :reynolds)) == 0
@@ -59,6 +64,7 @@
   F = parent(mol)
   t = gens(base_ring(F))[1]
   @test mol == (-t^6 - t^3 - 1)//(t^12 - 2t^9 + 2t^3 - 1)
+  @test molien_series(base_ring(F), RG0, trivial_character(group(RG0))) == mol
 
   mol = molien_series(RGp)
   F = parent(mol)
@@ -164,4 +170,21 @@ end
   I = invariant_ring(GF(5), s4)
   m = @inferred molien_series(S, I)
   @test m == 1//((1 - t)*(1 - t^2)*(1 - t^3)*(1 - t^4))
+
+  S2 = symmetric_group(2)
+  RS2 = invariant_ring(S2)
+  R = polynomial_ring(RS2)
+  x = gens(R)
+  F = abelian_closure(QQ)[1]
+  chi = Oscar.group_class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
+  @test reynolds_operator(RS2, x[1] - x[2], chi) == x[1] - x[2]
+  @test reynolds_operator(RS2, x[1] + x[2], chi) == zero(R)
+
+  mol = molien_series(RS2)
+  F = parent(mol)
+  t = gens(base_ring(F))[1]
+  @test mol == 1//(t^3 - t^2 - t + 1)
+  @test molien_series(base_ring(F), RS2, chi) == t*mol
+
+  @test length(basis(RS2, 1, chi)) == 1
 end

--- a/test/InvariantTheory/secondary_invariants-test.jl
+++ b/test/InvariantTheory/secondary_invariants-test.jl
@@ -124,6 +124,30 @@
     @test haskey(exps, m)
     @test set_exponent_vector!(one(R), 1, exps[m]) == m
   end
+
+  chi = trivial_character(group(RG0))
+  semi_invars = semi_invariants(RG0, chi)
+  m = molien_series(RG0, chi)
+  S = base_ring(parent(m))
+  t = gen(S)
+  n = S()
+  for f in semi_invars
+    @test reynolds_operator(RG0, f, chi) == f
+    n += t^total_degree(f.f)
+  end
+  d = prod( 1 - t^total_degree(f.f) for f in primary_invariants(RG0) )
+  @test m == n//d
+
+  # The semi-invariants have to be a module basis. Let's test this for
+  # the degree 9 homogeneous component.
+  R = polynomial_ring(RG0).R
+  C = Oscar.PowerProductCache(R, [ f.f for f in primary_invariants(RG0) ])
+  b1, _ = Oscar.generators_for_given_degree!(C, [ f.f for f in semi_invars ], 9, false)
+  b2 = [ f.f for f in basis(RG0, 9, chi) ]
+  B = Oscar.BasisOfPolynomials(R, b1)
+  for f in b2
+    @test !Oscar.add_to_basis!(B, f)
+  end
 end
 
 @testset "Secondary invariants (for permutation groups)" begin


### PR DESCRIPTION
Add basic functionality to compute generators of semi-invariants / relative invariants with respect to a character as module over the algebra generated by the primary invariants.

Some caveats:
* I don't need this; I implemented it because Ulrich Thiel was asked whether we have it. That means I don't really know what one wants to do with it. @fieker: I remember you asking me about something in this direction once. Can you use this?
* I barely found literature on this. Basically the only references are Sta79 for some theory and Gat96 for algorithms. I assume that much of this is folklore for the experts. In particular, I find it weird that the semi-invariants are computed over the primary invariants and not the whole invariant ring. However, I don't really have time to think about this in detail right now (or probably for the next months, they want me to write a thesis...). If anybody knows another reference, please say so!
* There is some potential for confusing names here: I followed Sta79 and call generators of the isotypic component of the polynomial ring with respect to a character semi-invariants or relative invariants. If the character is linear, so a representation by itself, this coincides with what is called equivariants. This has nothing to do with co(in)variants as far as I can see.