### PR TITLE
introduce `is_full_fp_group` ...

### DIFF
--- a/docs/src/Groups/fpgroup.md
+++ b/docs/src/Groups/fpgroup.md
@@ -19,6 +19,7 @@ Pages = ["fpgroup.md"]
 FPGroup
 FPGroupElem
 free_group(n::Int)
+is_full_fp_group(G::FPGroup)
 relators(G::FPGroup)
 length(g::FPGroupElem)
 map_word

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -76,6 +76,7 @@ GAP.@wrap IsField(x::Any)::Bool
 GAP.@wrap IsFinite(x::Any)::Bool
 GAP.@wrap IsFinitelyGeneratedGroup(x::Any)::Bool
 GAP.@wrap IsFreeGroup(x::Any)::Bool
+GAP.@wrap IsFpGroup(x::Any)::Bool
 GAP.@wrap IsGroupOfAutomorphisms(x::Any)::Bool
 GAP.@wrap IsHandledByNiceMonomorphism(x::Any)::Bool
 GAP.@wrap IsHermitianForm(x::Any)::Bool

--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -229,12 +229,16 @@ end
 ################################################################################
 
 """
-    free_group(n::Int, s::Union{String, Symbol} = "f") -> FPGroup
+    free_group(n::Int, s::Union{String, Symbol} = "f"; eltype::Symbol = :letter) -> FPGroup
     free_group(L::Vector{<:Union{String, Symbol}}) -> FPGroup
     free_group(L::Union{String, Symbol}...) -> FPGroup
 
 The first form returns the free group of rank `n`, where the generators are
 printed as `s1`, `s2`, ..., the default being `f1`, `f2`, ...
+If `eltype` has the value `:syllable` then each element in the free group is
+internally represented by a vector of syllables,
+whereas a representation by a vector of integers is chosen in the default case
+of `eltype == :letter`.
 
 The second form, if `L` has length `n`, returns the free group of rank `n`,
 where the `i`-th generator is printed as `L[i]`.

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -622,7 +622,7 @@ function isomorphism(::Type{FPGroup}, A::GrpAbFinGen)
    # Known isomorphisms are cached in the attribute `:isomorphisms`.
    isos = get_attribute!(Dict{Type, Any}, A, :isomorphisms)::Dict{Type, Any}
    return get!(isos, FPGroup) do
-      G = free_group(ngens(A))
+      G = free_group(ngens(A); eltype = :syllable)
       R = rels(A)
       s = vcat(elem_type(G)[i*j*inv(i)*inv(j) for i = gens(G) for j = gens(G) if i != j],
            elem_type(G)[prod([gen(G, i)^R[j,i] for i=1:ngens(A) if !iszero(R[j,i])], init = one(G)) for j=1:nrows(R)])
@@ -630,11 +630,9 @@ function isomorphism(::Type{FPGroup}, A::GrpAbFinGen)
       @hassert is_finite(A) == is_finite(F)
       is_finite(A) && @hassert order(A) == order(F)
       return MapFromFunc(
-        y->mF(prod([gen(G, i)^y[i] for i=1:ngens(A)], init = one(G))),
-        x->sum([sign(w)*gen(A, abs(w)) for w = letters(x)], init = zero(A)),
+        y->F([i => y[i] for i=1:ngens(A)]),
+        x->sum([w.second*gen(A, w.first) for w = syllables(x)], init = zero(A)),
         A, F)
-#TODO: As soon as #1822 is merged, choose elements in `G.X` represented by
-#T     products of syllables and improve the map from `F` to `A`.
    end::MapFromFunc{GrpAbFinGen, FPGroup}
 end
 

--- a/test/Groups/quotients.jl
+++ b/test/Groups/quotients.jl
@@ -73,6 +73,11 @@ end
    x,y = gens(F)
    @test x == F[1]
    @test y == F[2]
+   @test is_full_fp_group(F)
+   @test relators(F) == FPGroupElem[]
+   S = sub(F, [gen(F, 1)])[1]
+   @test ! is_full_fp_group(S)
+   @test_throws ArgumentError relators(S)
    
    n=5
    G,f = quo(F, [x^2,y^n,(x*y)^2] )           # dihedral group D(2n)
@@ -97,7 +102,14 @@ end
    @test is_surjective(f)
    @test exponent(G) == n
    @test isone(G[1]^n)
+   @test is_full_fp_group(G)
    @test relators(G)==[x^n,y^n,comm(x,y)]
+   S = sub(G, [gen(G, 1)])[1]
+   @test ! is_full_fp_group(S)
+   @test_throws ArgumentError relators(S)
+
+   @test G([1 => 2, 2 => -3]) == G[1]^2 * G[2]^-3
+   @test_throws ArgumentError S([1 => 2])
 
    S = symmetric_group(4)
    G,f = quo(S, [cperm(S,[1,3,2])])


### PR DESCRIPTION
... in order to deal safely with groups of type `FPGroup`

- add `is_full_fp_group`
- restrict `relators` to groups with `is_full_fp_group`
- improve `(G::FPGroup)(pairs::AbstractVector{Pair{T, S}})`: restrict it to groups with `is_full_fp_group`, support it for full free groups and full quotients of free groups
- document the `eltype` argument of `free_group` (values `:letter` or `:syllable`)
- use `free_group(ngens(A); eltype = :syllable)` in `isomorphism(::Type{FPGroup}, A::GrpAbFinGen)` and improve the function that maps to `FPGroup`