### PR TITLE
Minor tweaks for perm groups / cycle types

### DIFF
--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -523,7 +523,7 @@ julia> cycle_structure(ans)
 ```
 """
 function cycle_structure(g::PermGroupElem)
-    c = GAP.Globals.CycleStructurePerm(GAP.GapObj(g))
+    c = GAP.Globals.CycleStructurePerm(GAP.GapObj(g))::GAP.GapObj
     # TODO: use SortedDict from DataStructures.jl ?
     ct = Pair{Int, Int}[ i+1 => c[i] for i in 1:length(c) if GAP.Globals.ISB_LIST(c, i) ]
     s = degree(CycleType(ct, sorted = true))

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -448,9 +448,6 @@ struct CycleType <: AbstractVector{Pair{Int64, Int64}}
     sort!(s, by = x -> x[1])
     return new(s)
   end
-  function CycleType()
-    return new(Pair{Int, Int}[])
-  end
   function CycleType(v::Vector{Pair{Int, Int}}; sorted::Bool = false)
     sorted && return new(v)
     return new(sort(v, by = x -> x[1]))

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -497,6 +497,9 @@ function order(c::CycleType)
   return reduce(lcm, map(x->fmpz(x[1]), c.s), init = fmpz(1))
 end
 
+degree(c::CycleType) = mapreduce(x->x[1]*x[2], +, c.s, init = 0)
+
+
 """
     cycle_structure(g::PermGroupElem)
 
@@ -527,7 +530,7 @@ function cycle_structure(g::PermGroupElem)
     c = GAP.Globals.CycleStructurePerm(GAP.GapObj(g))
     # TODO: use SortedDict from DataStructures.jl ?
     ct = Pair{Int, Int}[ i+1 => c[i] for i in 1:length(c) if GAP.Globals.ISB_LIST(c, i) ]
-    s = mapreduce(x->x[1]*x[2], +, ct, init = Int(0))
+    s = degree(CycleType(ct, sorted = true))
     if s < degree(g)
       @assert length(c) == 0 || ct[1][1] > 1
       insert!(ct, 1, 1=>degree(g)-s)

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -62,8 +62,8 @@ Return the degree of the parent of `g`. This value is always greater or equal nu
 degree(g::PermGroupElem) = degree(parent(g))
 
 """
-    moved_points(x::PermGroupElem)
-    moved_points(G::PermGroup)
+    moved_points(x::PermGroupElem) -> Vector{Int}
+    moved_points(G::PermGroup) -> Vector{Int}
 
 Return the vector of those points in `1:degree(x)` or `1:degree(G)`,
 respectively, that are not mapped to themselves under the action `^`.
@@ -360,7 +360,7 @@ Base.Vector(x::PermGroupElem, n::Int = x.parent.deg) = Vector{Int}(x,n)
 
 
 """
-    sign(g::PermGroupElem)
+    sign(g::PermGroupElem) -> Int
 
 Return the sign of the permutation `g`.
 
@@ -497,7 +497,7 @@ degree(c::CycleType) = mapreduce(x->x[1]*x[2], +, c.s, init = 0)
 
 
 """
-    cycle_structure(g::PermGroupElem)
+    cycle_structure(g::PermGroupElem) -> CycleType
 
 Return the cycle structure of the permutation `g` as a cycle type.
 A cycle type behaves similar to a vector of pairs `k => n`

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -6,7 +6,7 @@ Base.isfinite(G::PermGroup) = true
 
 ==(x::PermGroup, y::PermGroup) = x.deg == y.deg && x.X == y.X
 
-==(x::PermGroupElem, y::PermGroupElem) = degree(parent(x)) == degree(parent(y)) && x.X == y.X
+==(x::PermGroupElem, y::PermGroupElem) = degree(x) == degree(y) && x.X == y.X
 
 Base.:<(x::PermGroupElem, y::PermGroupElem) = x.X < y.X
 
@@ -52,6 +52,14 @@ julia> show(Vector(gen(symmetric_group(5), 2)))
 ```
 """
 degree(x::PermGroup) = x.deg
+
+"""
+    degree(g::PermGroupElem) -> Int
+
+Return the degree of the parent of `g`. This value is always greater or equal number_moved_points
+
+"""
+degree(g::PermGroupElem) = degree(parent(g))
 
 """
     moved_points(x::PermGroupElem)
@@ -206,7 +214,7 @@ julia> cperm([1,2],[2,3])
 julia> p = cperm([1,2,3],[7])
 (1,2,3)
 
-julia> degree(parent(p))
+julia> degree(p)
 7
 ```
 
@@ -520,9 +528,9 @@ function cycle_structure(g::PermGroupElem)
     # TODO: use SortedDict from DataStructures.jl ?
     ct = Pair{Int, Int}[ i+1 => c[i] for i in 1:length(c) if GAP.Globals.ISB_LIST(c, i) ]
     s = mapreduce(x->x[1]*x[2], +, ct, init = Int(0))
-    if s < degree(parent(g))
+    if s < degree(g)
       @assert length(c) == 0 || ct[1][1] > 1
-      insert!(ct, 1, 1=>degree(parent(g))-s)
+      insert!(ct, 1, 1=>degree(g)-s)
     end
     return CycleType(ct, sorted = true)
 end

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -75,12 +75,11 @@ julia> length(moved_points(gen(s, 1)))
 @gapattribute moved_points(x::Union{PermGroupElem,PermGroup}) = Vector{Int}(GAP.Globals.MovedPoints(x.X))
 
 """
-    number_moved_points(::Type{T} = fmpz, x::PermGroupElem) where T <: IntegerUnion
-    number_moved_points(::Type{T} = fmpz, G::PermGroup) where T <: IntegerUnion
+    number_moved_points(x::PermGroupElem) -> Int
+    number_moved_points(G::PermGroup) -> Int
 
 Return the number of those points in `1:degree(x)` or `1:degree(G)`,
-respectively, that are not mapped to themselves under the action `^`,
-as an instance of `T`.
+respectively, that are moved (i.e., not fixed) under the action `^`.
 
 # Examples
 ```jldoctest
@@ -89,17 +88,12 @@ julia> g = symmetric_group(4);  s = sylow_subgroup(g, 3)[1];
 julia> number_moved_points(s)
 3
 
-julia> number_moved_points(Int, s)
-3
-
 julia> number_moved_points(gen(s, 1))
 3
 
 ```
 """
-@gapattribute number_moved_points(x::Union{PermGroupElem,PermGroup}) = fmpz(GAP.Globals.NrMovedPoints(x.X))::fmpz
-
-number_moved_points(::Type{T}, x::Union{PermGroupElem,PermGroup}) where T <: IntegerUnion = T(GAP.Globals.NrMovedPoints(x.X))::T
+@gapattribute number_moved_points(x::Union{PermGroupElem,PermGroup}) = GAP.Globals.NrMovedPoints(x.X)::Int
 
 @doc Markdown.doc"""
     perm(L::AbstractVector{<:IntegerUnion})

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -493,9 +493,8 @@ function ^(c::CycleType, e::Int)
   return CycleType(t; sorted=true)
 end
 
-function order(c::CycleType)
-  return reduce(lcm, map(x->fmpz(x[1]), c.s), init = fmpz(1))
-end
+order(::Type{T}, c::CycleType) where T = mapreduce(x->T(x[1]), lcm, c.s, init = T(1))
+order(c::CycleType) = order(fmpz, c)
 
 degree(c::CycleType) = mapreduce(x->x[1]*x[2], +, c.s, init = 0)
 

--- a/test/Groups/Permutations.jl
+++ b/test/Groups/Permutations.jl
@@ -44,3 +44,17 @@
 end
 
 
+@testset "CycleType" begin
+  @testset "degree and order" begin
+    g = cperm(1:3, 4:5, 6:7, 8:10, 11:15)
+    c = cycle_structure(g)
+    @test degree(g) == degree(c)
+    @test order(g) == order(c)
+
+    for g in symmetric_group(6)
+      c = cycle_structure(g)
+      @test degree(g) == degree(c)
+      @test order(g) == order(c)
+    end
+  end
+end

--- a/test/Groups/Permutations.jl
+++ b/test/Groups/Permutations.jl
@@ -50,11 +50,13 @@ end
     c = cycle_structure(g)
     @test degree(g) == degree(c)
     @test order(g) == order(c)
+    @test order(Int, g) == order(Int, c)
 
     for g in symmetric_group(6)
       c = cycle_structure(g)
       @test degree(g) == degree(c)
       @test order(g) == order(c)
+      @test order(Int, g) == order(Int, c)
     end
   end
 end

--- a/test/Groups/constructors.jl
+++ b/test/Groups/constructors.jl
@@ -11,10 +11,7 @@
     @test length(moved_points(G)) == n
     nmp = number_moved_points(G)
     @test nmp == n
-    @test nmp isa fmpz
-    nmp = number_moved_points(Int64, G)
-    @test nmp == n
-    @test nmp isa Int64
+    @test nmp isa Int
 
     @test isfinite(G)
 


### PR DESCRIPTION
- Remove optional return type argument from number_moved_points
- Add degree(g::PermGroupElem)
- Add degree(c::CycleType)
- order(c::CycleType): allow specifying return type
- Remove CycleType() constructor
