### PR TITLE
init: add terminfo dirs when installing GAPs browse

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -164,7 +164,9 @@ function __init__()
         (GAP.Globals.IsSubgroupFpGroup, FPGroup),
     ])
     __GAP_info_messages_off()
-    GAP.Packages.load("browse"; install=true) # needed for all_character_table_names doctest
+    withenv("TERMINFO_DIRS" => joinpath(GAP.GAP_jll.Readline_jll.Ncurses_jll.find_artifact_dir(), "share", "terminfo")) do
+      GAP.Packages.load("browse"; install=true) # needed for all_character_table_names doctest
+    end
     GAP.Packages.load("ctbllib")
     GAP.Packages.load("forms")
     GAP.Packages.load("wedderga") # provides a function to compute Schur indices


### PR DESCRIPTION
I got hit by this error in the CI for `libpolymake_julia` [here](https://github.com/oscar-system/libpolymake-julia/actions/runs/4039048910/jobs/6943476730) with the following error:
```
     Testing Running tests...
Error opening terminal: dumb.
ERROR: Package Oscar errored during testing
```

After various experiments I was able to reproduce this locally, but only when the Browse package does not already exist in `~/.julia/gaproot/v4.12/pkg/Browse-1.8.20` (either running `make clean` in the folder or removing it might help). The first try to start Oscar then fails with the above error, retrying it a second time works fine, the reason is probably that once it is installed the Browse package is loaded during `initialize` via `GAP.jl` which does use the same `withenv` that I am adding here, see [here](https://github.com/oscar-system/GAP.jl/blob/master/src/GAP.jl#L297-L299).

I still don't understand why this only appeared now when trying to update `polymake_jll` as this should always be required when loading Browse (i.e. `Ncurses_jll`).

On a different machine I was unable to reproduce this because Browse failed to install because it couldn't find `panel.h`, it does seem to only search in the system include and library directories when building it according, e.g.:
```
cc -g -O2 -fPIC -o /tmp/gac5PlmKrk/1327_ncurses.o -I/home/datastore/lorenz/software/julia/depot/artifacts/a7a51f050ae9f280687f459aa628ab00b6907075/include/gap -I/home/datastore/lorenz/software/julia/depot/scratchspaces/c863536a-3901-11e9-33e7-d5cd0df7b904/gap_11666353854719087970_1.8 -DUSE_JULIA_GC=1 -c src/ncurses.c
src/ncurses.c:27:17: fatal error: panel.h: No such file or directory
#include        <panel.h>
^~~~~~~~~
compilation terminated.
gmake: *** [Makefile:16: bin/x86_64-pc-linux-gnu-julia1.8-64-kv8/ncurses.so] Error 1

WARNING: Failed to build Browse-1.8.20
```

Once Oscar is running one can see that the system-ncurses library seems to get pulled in addition to the jll version:
```
julia> showall(dllist())
...
"/home/lorenz/.julia/artifacts/d56f6bc8675ad021bf8070a7bce573e3fbe2e737/lib/libncursesw.so.6"
"/home/lorenz/.julia/artifacts/d56f6bc8675ad021bf8070a7bce573e3fbe2e737/lib/libmenu.so"
"/home/lorenz/.julia/artifacts/d56f6bc8675ad021bf8070a7bce573e3fbe2e737/lib/libpanel.so"
...
...
"/home/lorenz/.julia/artifacts/a7a51f050ae9f280687f459aa628ab00b6907075/lib/libgap.so"
 "/lib64/libutil.so.1"
"/home/lorenz/.julia/artifacts/3178f2673dfbca96a1b950d66be9d4b60f1268f6/lib/gap/JuliaInterface.so"
 "/home/lorenz/.julia/gaproot/v4.12/pkg/Browse-1.8.20/bin/x86_64-pc-linux-gnu-julia1.8-64-kv8/ncurses.so"
 "/usr/lib64/libpanel.so.6"
 "/lib64/libncurses.so.6"
 "/lib64/libtinfo.so.6"
...
```
This probably contributes to this not being a more widespread problem.

And I guess all this will be irrelevant once we finally get a jll for Browse.

cc: @fingolfin 

PS: <del>I also need this branch (with this name) to check whether this change fixes the CI mentioned at the beginning.</del> _Tests done._

_Edit: Tests are [successful](https://github.com/oscar-system/libpolymake-julia/actions/runs/4039048910/jobs/6959866995) now for libpolymake_julia when using this downstream branch._