### PR TITLE
ToricVarieties: Bugfix in vanishing sets

### DIFF
--- a/src/ToricVarieties/AlgebraicCycles/methods.jl
+++ b/src/ToricVarieties/AlgebraicCycles/methods.jl
@@ -2,24 +2,6 @@
 # 1: Intersections involving closed subvarieties
 ################################################
 
-@doc Markdown.doc"""
-    RationalEquivalenceClass(v::AbstractNormalToricVariety, coefficients::Vector{T}) where {T <: IntegerUnion}
-
-Construct the rational equivalence class of algebraic cycles corresponding to a linear combination of cones.
-
-# Examples
-```jldoctest
-julia> P2 = projective_space(NormalToricVariety, 2)
-A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
-
-julia> d = ToricDivisor(P2, [1, 2, 3])
-A torus-invariant, non-prime divisor on a normal toric variety
-
-julia> RationalEquivalenceClass(d)
-A rational equivalence class on a normal toric variety represented by 6V(x3)
-```
-"""
-
 function Base.:*(ac::RationalEquivalenceClass, sv::ClosedSubvarietyOfToricVariety)
     if toric_variety(ac) !== toric_variety(sv)
         throw(ArgumentError("The rational equivalence class and the closed subvariety must be defined on the same toric variety, i.e. the same OSCAR variable"))

--- a/src/ToricVarieties/cohomCalg/auxiliary.jl
+++ b/src/ToricVarieties/cohomCalg/auxiliary.jl
@@ -95,14 +95,14 @@ function contributing_denominators(variety::AbstractNormalToricVariety)
     # we execute cohomCalg with homogeneous variable names "x1", "x2" and so on
     # -> translate back into actually chosen variable names
     gens = Hecke.gens(cox_ring(variety))
-    for i in 1:length(contributing_monomials)
-        if contributing_monomials[i] == [""]
-            contributing_monomials[i] = String[]
+    for cm in contributing_monomials
+        if cm == [""]
+            empty!(cm)
         else
-            for j in 1:length(contributing_monomials[i])
-                m = contributing_monomials[i][j]
+            for j in 1:length(cm)
+                m = cm[j]
                 present_variables = [occursin("x$k", m) for k in 1:ngens(cox_ring(variety))]
-                contributing_monomials[i][j] = string(prod(gens[k]^present_variables[k] for k in 1:ngens(cox_ring(variety))))
+                cm[j] = string(prod(gens[k]^present_variables[k] for k in 1:ngens(cox_ring(variety))))
             end
         end
     end

--- a/src/ToricVarieties/cohomCalg/auxiliary.jl
+++ b/src/ToricVarieties/cohomCalg/auxiliary.jl
@@ -96,10 +96,14 @@ function contributing_denominators(variety::AbstractNormalToricVariety)
     # -> translate back into actually chosen variable names
     gens = Hecke.gens(cox_ring(variety))
     for i in 1:length(contributing_monomials)
-        for j in 1:length(contributing_monomials[i])
-            m = contributing_monomials[i][j]
-            present_variables = [occursin("x$k", m) for k in 1:ngens(cox_ring(variety))]
-            contributing_monomials[i][j] = string(prod(gens[k]^present_variables[k] for k in 1:ngens(cox_ring(variety))))
+        if contributing_monomials[i] == [""]
+            contributing_monomials[i] = String[]
+        else
+            for j in 1:length(contributing_monomials[i])
+                m = contributing_monomials[i][j]
+                present_variables = [occursin("x$k", m) for k in 1:ngens(cox_ring(variety))]
+                contributing_monomials[i][j] = string(prod(gens[k]^present_variables[k] for k in 1:ngens(cox_ring(variety))))
+            end
         end
     end
     

--- a/src/ToricVarieties/cohomCalg/special_attributes.jl
+++ b/src/ToricVarieties/cohomCalg/special_attributes.jl
@@ -11,7 +11,7 @@ Compute the vanishing sets of an abstract toric variety `v` by use of the cohomC
     denominator_contributions = contributing_denominators(variety)
     vs = ToricVanishingSet[]
     for i in 1:length(denominator_contributions)
-        list_of_polyhedra = [turn_denominator_into_polyhedron(variety, m) for m in denominator_contributions[i]]
+        list_of_polyhedra = Polyhedron{fmpq}[turn_denominator_into_polyhedron(variety, m) for m in denominator_contributions[i]]
         push!(vs, ToricVanishingSet(variety, list_of_polyhedra, i-1))
     end
     return vs::Vector{ToricVanishingSet}

--- a/test/ToricVarieties/line_bundle_cohomology.jl
+++ b/test/ToricVarieties/line_bundle_cohomology.jl
@@ -1,15 +1,20 @@
+using Test
+
 @testset "Line bundle cohomologies and vanishing sets" begin
+    P2 = projective_space(NormalToricVariety,2)
     dP3 = NormalToricVariety([[1, 0], [1, 1], [0, 1], [-1, 0], [-1, -1], [0, -1]], [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 1]])
     F5 = NormalToricVariety([[1, 0], [0, 1], [-1, 5], [0, -1]], [[1, 2], [2, 3], [3, 4], [4, 1]])
     D2 = DivisorOfCharacter(F5, [1, 2])
 
     l = ToricLineBundle(dP3, [1, 2, 3, 4])
     l2 = ToricLineBundle(D2)
+    l3 = ToricLineBundle(P2, [1])
     l4 = canonical_bundle(dP3)
     l5 = anticanonical_bundle(dP3)
-    l7 = structure_sheaf(dP3)
+    l6 = structure_sheaf(dP3)
 
     vs = vanishing_sets(dP3)
+    vs2 = vanishing_sets(P2)
     R,_ = PolynomialRing(QQ, 3)
 
     @testset "Cohomology with cohomCalg" begin
@@ -19,17 +24,23 @@
         @test all_cohomologies(l2) == [1, 0, 0]
     end
 
-    @testset "Toric vanishingSets of dP3" begin
+    @testset "Toric vanishing sets of dP3" begin
         @test is_projective_space(toric_variety(vs[1])) == false
         @test contains(vs[1], l) == false
         @test contains(vs[1], l2) == false
         @test contains(vs[2], l) == true
         @test contains(vs[3], l) == true
-        @test contains(vs[1], l7) == false
-        @test contains(vs[2], l7) == true
-        @test contains(vs[3], l7) == true
+        @test contains(vs[1], l6) == false
+        @test contains(vs[2], l6) == true
+        @test contains(vs[3], l6) == true
         @test length(polyhedra(vs[1])) == 1
         @test cohomology_index(vs[1]) == 0
+    end
+
+    @testset "Toric vanishing sets of P2" begin
+        @test contains(vs2[1], l3) == false
+        @test contains(vs2[2], l3) == true
+        @test contains(vs2[3], l3) == true
     end
 
     @testset "Should fail" begin


### PR DESCRIPTION
It holds $h^1(P^2, L ) = 0$ for every line bundle $L$ on the projective space $P^2$. This extreme case that for every line bundle the cohomology in question vanishes, was not yet handeled correctly when computing vanishing sets in OSCAR. I provide a bug fix and have added a test that will detect this failure in the future.

(I also noticed a docstring, which appears in vacuum. I.e. the corresponding method does not exist in that particular file but was (?) moved to another file in the past. This obselete docstring should have no effect and so - presumably - can be removed. I have done so.)