### PR TITLE
better error message for `right_transversal`

### DIFF
--- a/docs/src/Groups/subgroups.md
+++ b/docs/src/Groups/subgroups.md
@@ -109,10 +109,10 @@ is_left(c::GroupCoset)
 is_bicoset(C::GroupCoset)
 acting_domain(C::GroupCoset)
 representative(C::GroupCoset)
-right_cosets(G::GAPGroup, H::GAPGroup)
-left_cosets(G::GAPGroup, H::GAPGroup)
-right_transversal(G::T, H::T) where T<: GAPGroup
-left_transversal(G::T, H::T) where T<: GAPGroup
+right_cosets(G::T, H::T; check::Bool=true) where T<: GAPGroup
+left_cosets(G::T, H::T; check::Bool=true) where T<: GAPGroup
+right_transversal(G::T, H::T; check::Bool=true) where T<: GAPGroup
+left_transversal(G::T, H::T; check::Bool=true) where T<: GAPGroup
 GroupDoubleCoset{T <: GAPGroup, S <: GAPGroupElem}
 double_coset(G::T, g::GAPGroupElem{T}, H::T) where T<: GAPGroup
 double_cosets(G::T, H::T, K::T; check::Bool) where T<: GAPGroup

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -154,6 +154,8 @@ end
    @test order(C) == length(collect(C))
   
    @test length(right_transversal(G, H)) == index(G, H)
+   @test_throws ArgumentError right_transversal(H, G)
+   @test_throws ArgumentError left_transversal(H, G)
 
    @testset "set comparison for cosets in PermGroup" begin
       G=symmetric_group(5)
@@ -207,6 +209,7 @@ end
 
    H = sub(G, [cperm(G,[1,2,3]), cperm(G,[2,3,4])])[1]
    L = right_cosets(G,H)
+   @test_throws ArgumentError right_cosets(H, G)
    T = right_transversal(G,H)
    @test length(L)==10
    @test length(T)==10
@@ -219,6 +222,7 @@ end
    @test representative(rc1) != representative(rc)
    @test rc1 == rc
    L = left_cosets(G,H)
+   @test_throws ArgumentError left_cosets(H, G)
    T = left_transversal(G,H)
    @test length(L)==10
    @test length(T)==10


### PR DESCRIPTION
Now `right_transversal`, `left_transversal`, `right_cosets`, and `left_cosets` check by default whether the second argument is a subgroup of the first; the check can be switched off.
(Apparently it would be complicated to change the GAP code such that it shows meaningful error messages.)

@fieker had noticed that up to now one got just an error message from GAP if this condition is not satisfied.