### PR TITLE
Heisenbug factoring

### DIFF
--- a/experimental/ModStd/ModStdQt.jl
+++ b/experimental/ModStd/ModStdQt.jl
@@ -694,6 +694,9 @@ function afact(g::fmpq_mpoly, a::Vector{Int}; int::Bool = false)
 
       @vtime :ModStdQt 2 MM = g(v...)
       fg = factor_absolute(MM)
+      if length(fg) > 2
+        return nothing #bad evaluation
+      end
       @assert length(fg) == 2
       if isa(base_ring(fg[2][1][1]), FlintRationalField)
         return nothing


### PR DESCRIPTION
can be repoduced, possibly in 1.9 with
```
S, (a, b) = PolynomialRing(QQ, ["a", "b"]);
S = parent(a//b)
St, (u, v) = PolynomialRing(S, ["u", "v"])
Random.seed!(0x00125f822eb19745)
f = factor_absolute(u^2+v^2*a)
```
a modular algo picked bad eval. point. good chancde that for you the seed has to be different.
I found this by running the test in  a loop and seeding to time_ns() everytime (in the test)...