### PR TITLE
Tests: create github action summary with run-times and compile-times per test-file

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,6 +60,8 @@ jobs:
         run: echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
       - name: "Run tests"
         uses: julia-actions/julia-runtest@latest
+        with:
+          coverage: ${{ matrix.julia-version == '1.6' }}
       - name: "Process code coverage"
         uses: julia-actions/julia-processcoverage@v1
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -41,7 +41,9 @@ julia = "1.6"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Documenter"]
+test = ["Test", "Documenter", "PrettyTables", "Printf"]

--- a/test/Rings/mpoly-localizations.jl
+++ b/test/Rings/mpoly-localizations.jl
@@ -176,8 +176,6 @@ function test_elem(W::MPolyLocalizedRing)
 end
 
 @testset "Ring interface for localized polynomial rings" begin
-  include(joinpath(pathof(AbstractAlgebra), "..", "..", "test", "Rings-conformance-tests.jl"))
-#
 # kk = QQ
 # R, v = kk["x", "y"]
 # x = v[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,7 +54,9 @@ function include(str::String)
     compile_elapsedtimes = Base.cumulative_compile_time_ns()
   end
   stats = @timed Base.include(identity, Main, str)
-  if innermost[]
+  # skip files which just include other files and ignore
+  # files outside of the oscar folder
+  if innermost[] && !isabspath(str)
     @static if compiletimes
       compile_elapsedtimes = Base.cumulative_compile_time_ns() .- compile_elapsedtimes
       compile_elapsedtimes = compile_elapsedtimes ./ 10^9

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -143,10 +143,10 @@ else
   @info "Not running doctests (Julia version must be 1.6)"
 end
 
-if haskey(ENV, "GITHUB_STEP_SUMMARY")
+if haskey(ENV, "GITHUB_STEP_SUMMARY") && compiletimes
   open(ENV["GITHUB_STEP_SUMMARY"], "a") do io
     print_stats(io, fmt=PrettyTables.tf_markdown)
   end
 else
-  print_stats(stdout)
+  print_stats(stdout; max=10)
 end


### PR DESCRIPTION
The code to for the compile time is inspired by `base/timing.jl` since @timed doesn't return those values and uses several internal functions, currently works for julia 1.9 and nightly.

I changed code-coverage to run only for julia 1.6, I think this makes sense as this is where the doctests run as well. Not sure if there is any reason to run code-coverage for other versions as well.
The reason is that enabling code-coverage breaks the compilation time stats on julia 1.9 (and probably nightly as well).

Currently this sorts by run-time and prints the top 50 files, the compilation and recompilation times are printed separately; In contrast to julia printing total time + percentages in `@time`. This can of course be adjusted.
_Edit:_ GC-time is currently still included in the main run-time, but that could be changed easily.

To make this work I created a custom `include` function that replaces the `Base.include` and takes all the measurements, it also ignores any file that itself includes other files like `PolyhedralGeometry/runtests.jl` which just pulls in more files. (This heuristic is not really perfect but does work fine currently)

Tables in the github actions summary are currently generated only for 1.9 and nightly (because for older versions there would just be one timing).

And if you want to have a look at the timings for one test file just search through the test-log, the times are printed after each include block.