### PR TITLE
CI: Fail on deprecation warning

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,6 +62,7 @@ jobs:
         uses: julia-actions/julia-runtest@latest
         with:
           coverage: ${{ matrix.julia-version == '1.6' }}
+          depwarn: error
       - name: "Process code coverage"
         uses: julia-actions/julia-processcoverage@v1
         with:


### PR DESCRIPTION
Currently, there are deprecation warnings when running the tests. (I am to blame for this).

I made a minor change to our CI. If I did it correctly, then the CI should now fail because of the deprecation warnings.