### PR TITLE
Fix coxring gradings & renaming some constructors

### DIFF
--- a/docs/src/Experimental/ToricSchemes/AffineToricSchemes.md
+++ b/docs/src/Experimental/ToricSchemes/AffineToricSchemes.md
@@ -20,7 +20,7 @@ We can construct an affine toric scheme as follows:
 julia> C = positive_hull([1 0; 0 1])
 A polyhedral cone in ambient dimension 2
 
-julia> antv = AffineNormalToricVariety(C)
+julia> antv = affine_normal_toric_variety(C)
 A normal, affine toric variety
 
 julia> affine_toric_scheme = ToricSpec(antv)

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -35,16 +35,16 @@ passing `set_attributes = false` as last argument. Note however, that the constr
 
 ```@docs
 affine_normal_toric_variety(C::Cone; set_attributes::Bool = true)
-NormalToricVariety(C::Cone; set_attributes::Bool = true)
+normal_toric_variety(C::Cone; set_attributes::Bool = true)
 affine_normal_toric_variety(v::NormalToricVariety; set_attributes::Bool = true)
 ```
 
 ### Normal Toric Varieties
 
 ```@docs
-NormalToricVariety(rays::Vector{Vector{Int64}}, max_cones::Vector{Vector{Int64}}; non_redundant::Bool = false, set_attributes::Bool = true)
-NormalToricVariety(PF::PolyhedralFan; set_attributes::Bool = true)
-NormalToricVariety(P::Polyhedron; set_attributes::Bool = true)
+normal_toric_variety(rays::Vector{Vector{Int64}}, max_cones::Vector{Vector{Int64}}; non_redundant::Bool = false, set_attributes::Bool = true)
+normal_toric_variety(PF::PolyhedralFan; set_attributes::Bool = true)
+normal_toric_variety(P::Polyhedron; set_attributes::Bool = true)
 ```
 
 ### Famous Toric Vareties

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -12,8 +12,8 @@ Pages = ["NormalToricVarieties.md"]
 
 We introduce two main types of normal toric varieties, distinguishing between
 the affine and non-affine case:
-- `AffineNormalToricVariety` is the toric variety associated to a cone $\sigma$, denoted by $U_{\sigma}$ in [CLS11](@cite)
-- `NormalToricVariety` is the toric variety associated to a polyhedral fan $\Sigma$, denoted by $X_{\Sigma}$ in [CLS11](@cite)
+- `AffineNormalToricVariety` is the type for toric varieties associated to a cone $\sigma$, denoted by $U_{\sigma}$ in [CLS11](@cite)
+- `NormalToricVariety` is the type for toric varieties associated to a polyhedral fan $\Sigma$, denoted by $X_{\Sigma}$ in [CLS11](@cite)
 
 !!! warning
     The lattice is always assumed to be the standard lattice $\mathbb{Z}^n$.
@@ -34,9 +34,9 @@ passing `set_attributes = false` as last argument. Note however, that the constr
 ### Affine Toric Varieties
 
 ```@docs
-AffineNormalToricVariety(C::Cone; set_attributes::Bool = true)
+affine_normal_toric_variety(C::Cone; set_attributes::Bool = true)
 NormalToricVariety(C::Cone; set_attributes::Bool = true)
-AffineNormalToricVariety(v::NormalToricVariety; set_attributes::Bool = true)
+affine_normal_toric_variety(v::NormalToricVariety; set_attributes::Bool = true)
 ```
 
 ### Normal Toric Varieties

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -27,7 +27,8 @@ sets attributes for the constructed variety. The benefit of such setters is incr
 a price. In the case at hand, it might lead to possible inconsistencies, despite our best efforts to prevent this from happening.
 
 The default is `set_attributes = true`, that is our constructors set attributes upon construction. If not desired, it can be switched off by
-passing `set_attributes = false` as last argument.
+passing `set_attributes = false` as last argument. Note however, that the constructors of `del_pezzo_surface`, `hirzebruch_surface`,
+`projective_space` and `weighted_projective_space ` *always* make a default/standard choice for the grading of the Cox ring.
 
 
 ### Affine Toric Varieties

--- a/experimental/Schemes/ToricSchemes/AffineToricSchemes/Attributes.jl
+++ b/experimental/Schemes/ToricSchemes/AffineToricSchemes/Attributes.jl
@@ -11,7 +11,7 @@ its toric origin.
 julia> C = positive_hull([1 0; 0 1])
 A polyhedral cone in ambient dimension 2
 
-julia> antv = AffineNormalToricVariety(C)
+julia> antv = affine_normal_toric_variety(C)
 A normal, affine toric variety
 
 julia> affine_toric_scheme = ToricSpec(antv)
@@ -36,7 +36,7 @@ the underlying affine toric variety.
 julia> C = positive_hull([1 0; 0 1])
 A polyhedral cone in ambient dimension 2
 
-julia> antv = AffineNormalToricVariety(C)
+julia> antv = affine_normal_toric_variety(C)
 A normal, affine toric variety
 
 julia> affine_toric_scheme = ToricSpec(antv)
@@ -61,7 +61,7 @@ the cone of the underlying affine toric variety.
 julia> C = positive_hull([1 0; 0 1])
 A polyhedral cone in ambient dimension 2
 
-julia> antv = AffineNormalToricVariety(C)
+julia> antv = affine_normal_toric_variety(C)
 A normal, affine toric variety
 
 julia> affine_toric_scheme = ToricSpec(antv)
@@ -86,7 +86,7 @@ of the cone of the underlying affine toric variety.
 julia> C = positive_hull([1 0; 0 1])
 A polyhedral cone in ambient dimension 2
 
-julia> antv = AffineNormalToricVariety(C)
+julia> antv = affine_normal_toric_variety(C)
 A normal, affine toric variety
 
 julia> affine_toric_scheme = ToricSpec(antv)
@@ -115,7 +115,7 @@ affine toric variety.
 julia> C = positive_hull([-1 1; 1 1])
 A polyhedral cone in ambient dimension 2
 
-julia> antv = AffineNormalToricVariety(C)
+julia> antv = affine_normal_toric_variety(C)
 A normal, affine toric variety
 
 julia> affine_toric_scheme = ToricSpec(antv)

--- a/experimental/Schemes/ToricSchemes/AffineToricSchemes/Properties.jl
+++ b/experimental/Schemes/ToricSchemes/AffineToricSchemes/Properties.jl
@@ -10,7 +10,7 @@ If so, the function returns `true` and otherwise
 julia> C = positive_hull([1 0; 0 1])
 A polyhedral cone in ambient dimension 2
 
-julia> antv = AffineNormalToricVariety(C)
+julia> antv = affine_normal_toric_variety(C)
 A normal, affine toric variety
 
 julia> affine_toric_scheme = ToricSpec(antv)
@@ -22,7 +22,7 @@ true
 julia> C2 = positive_hull([-1 1; 1 1])
 A polyhedral cone in ambient dimension 2
 
-julia> antv2 = AffineNormalToricVariety(C2)
+julia> antv2 = affine_normal_toric_variety(C2)
 A normal, affine toric variety
 
 julia> affine_toric_scheme2 = ToricSpec(antv2)
@@ -48,7 +48,7 @@ If so, the function returns `true` and otherwise
 julia> C = positive_hull([-1 1; 1 1])
 A polyhedral cone in ambient dimension 2
 
-julia> antv = AffineNormalToricVariety(C)
+julia> antv = affine_normal_toric_variety(C)
 A normal, affine toric variety
 
 julia> affine_toric_scheme = ToricSpec(antv)

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -35,3 +35,29 @@ function AffineNormalToricVariety(v::NormalToricVariety; set_attributes::Bool = 
     "'affine_normal_toric_variety(v::NormalToricVariety; set_attributes::Bool = true)' instead.", :AffineNormalToricVariety)
     affine_normal_toric_variety(v; set_attributes = set_attributes)
 end
+
+function NormalToricVariety(C::Cone; set_attributes::Bool = true)
+    Base.depwarn("'NormalToricVariety(C::Cone; set_attributes::Bool = true)' is deprecated, use "*
+    "'normal_toric_variety(C::Cone; set_attributes::Bool = true)' instead.", :NormalToricVariety)
+    normal_toric_variety(C; set_attributes = set_attributes)
+end
+
+function NormalToricVariety(rays::Vector{Vector{Int64}}, max_cones::Vector{Vector{Int64}}; non_redundant::Bool = false, set_attributes::Bool = true)
+    Base.depwarn("'NormalToricVariety(rays::Vector{Vector{Int64}}, max_cones::Vector{Vector{Int64}}; "*
+    "non_redundant::Bool = false, set_attributes::Bool = true)' is deprecated, use "*
+    "'normal_toric_variety(rays::Vector{Vector{Int64}}, max_cones::Vector{Vector{Int64}}; "*
+    "non_redundant::Bool = false, set_attributes::Bool = true)' instead.", :NormalToricVariety)
+    normal_toric_variety(rays, max_cones; non_redundant = non_redundant, set_attributes = set_attributes)
+end
+
+function NormalToricVariety(PF::PolyhedralFan; set_attributes::Bool = true)
+    Base.depwarn("'NormalToricVariety(PF::PolyhedralFan; set_attributes::Bool = true)' is deprecated, use"*
+    "'normal_toric_variety(PF::PolyhedralFan; set_attributes::Bool = true)' instead.", :NormalToricVariety)
+    normal_toric_variety(PF; set_attributes = set_attributes)
+end
+
+function NormalToricVariety(P::Polyhedron; set_attributes::Bool = true)
+    Base.depwarn("'NormalToricVariety(P::Polyhedron; set_attributes::Bool = true)' is deprecated, use"*
+    "'normal_toric_variety(P::Polyhedron; set_attributes::Bool = true)' instead.", :NormalToricVariety)
+    normal_toric_variety(P; set_attributes = set_attributes)
+end

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -21,3 +21,17 @@
 @deprecate birkhoff(n::Integer; even::Bool = false) birkhoff_polytope(n; even=even)
 @deprecate cross(args...) cross_polytope(args...)
 @deprecate gelfand_tsetlin(lambda::AbstractVector) gelfand_tsetlin_polytope(lambda)
+
+
+# Deprecate after 0.11.4
+function AffineNormalToricVariety(C::Cone; set_attributes::Bool = true)
+    Base.depwarn("'AffineNormalToricVariety(C::Cone; set_attributes::Bool = true)' is deprecated, use "*
+    "'affine_normal_toric_variety(C::Cone; set_attributes::Bool = true)' instead.", :AffineNormalToricVariety)
+    affine_normal_toric_variety(C; set_attributes = set_attributes)
+end
+
+function AffineNormalToricVariety(v::NormalToricVariety; set_attributes::Bool = true)
+    Base.depwarn("'AffineNormalToricVariety(v::NormalToricVariety; set_attributes::Bool = true)' is deprecated, use "*
+    "'affine_normal_toric_variety(v::NormalToricVariety; set_attributes::Bool = true)' instead.", :AffineNormalToricVariety)
+    affine_normal_toric_variety(v; set_attributes = set_attributes)
+end

--- a/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
+++ b/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
@@ -905,7 +905,7 @@ The normal toric variety associated with its face fan is smooth.
 julia> S = fano_simplex(3)
 A polyhedron in ambient dimension 3
 
-julia> X = NormalToricVariety(face_fan(S))
+julia> X = normal_toric_variety(face_fan(S))
 A normal toric variety
 
 julia> is_smooth(X)

--- a/src/ToricVarieties/AlgebraicCycles/attributes.jl
+++ b/src/ToricVarieties/AlgebraicCycles/attributes.jl
@@ -52,7 +52,7 @@ julia> polynomial(ac)
 ```
 """
 polynomial(ac::RationalEquivalenceClass) = ac.p
-export p
+export polynomial
 
 
 @doc Markdown.doc"""

--- a/src/ToricVarieties/AlgebraicCycles/constructors.jl
+++ b/src/ToricVarieties/AlgebraicCycles/constructors.jl
@@ -149,7 +149,7 @@ cycles of a closed subvariety of a normal toric variety.
 
 # Examples
 ```jldoctest
-julia> ntv = NormalToricVariety(Oscar.normal_fan(Oscar.cube(2)))
+julia> ntv = normal_toric_variety(Oscar.normal_fan(Oscar.cube(2)))
 A normal toric variety
 
 julia> set_coordinate_names(ntv, ["x1", "x2", "y1", "y2"]);

--- a/src/ToricVarieties/AlgebraicCycles/special_attributes.jl
+++ b/src/ToricVarieties/AlgebraicCycles/special_attributes.jl
@@ -27,7 +27,7 @@ true
 julia> ngens(chow_ring(p2))
 3
 
-julia> v = NormalToricVariety([[1, 0], [0, 1], [-1, -1]], [[1], [2], [3]])
+julia> v = normal_toric_variety([[1, 0], [0, 1], [-1, -1]], [[1], [2], [3]])
 A normal toric variety
 
 julia> is_complete(v)

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -12,7 +12,7 @@ Return the dimension of the normal toric variety `v`.
 ```jldoctest
 julia> C = Oscar.positive_hull([1 0]);
 
-julia> antv = AffineNormalToricVariety(C);
+julia> antv = affine_normal_toric_variety(C);
 
 julia> dim(antv)
 1
@@ -33,7 +33,7 @@ Return the dimension of the torus factor of the normal toric variety `v`.
 ```jldoctest
 julia> C = Oscar.positive_hull([1 0]);
 
-julia> antv = AffineNormalToricVariety(C);
+julia> antv = affine_normal_toric_variety(C);
 
 julia> dim_of_torusfactor(antv)
 1
@@ -59,7 +59,7 @@ Return the Euler characteristic of the normal toric variety `v`.
 ```jldoctest
 julia> C = Oscar.positive_hull([1 0]);
 
-julia> antv = AffineNormalToricVariety(C);
+julia> antv = affine_normal_toric_variety(C);
 
 julia> euler_characteristic(antv)
 1
@@ -118,7 +118,7 @@ question is not yet finalized (cf. [`is_finalized(v::AbstractNormalToricVariety)
 ```jldoctest
 julia> C = Oscar.positive_hull([1 0]);
 
-julia> antv = AffineNormalToricVariety(C);
+julia> antv = affine_normal_toric_variety(C);
 
 julia> set_coordinate_names(antv, ["u"])
 
@@ -181,7 +181,7 @@ This method returns the coefficient_ring `QQ` of the normal toric variety `v`.
 ```jldoctest
 julia> C = Oscar.positive_hull([1 0]);
 
-julia> antv = AffineNormalToricVariety(C);
+julia> antv = affine_normal_toric_variety(C);
 
 julia> coefficient_ring(antv) == QQ
 true
@@ -200,7 +200,7 @@ the normal toric variety `v`. The default is `x1, ..., xn`.
 ```jldoctest
 julia> C = Oscar.positive_hull([1 0]);
 
-julia> antv = AffineNormalToricVariety(C);
+julia> antv = affine_normal_toric_variety(C);
 
 julia> coordinate_names(antv)
 1-element Vector{String}:
@@ -463,7 +463,7 @@ ideal comes from the dual cone.
 julia> C = positive_hull([1 0 0; 1 1 0; 1 0 1; 1 1 1])
 A polyhedral cone in ambient dimension 3
 
-julia> antv = AffineNormalToricVariety(C)
+julia> antv = affine_normal_toric_variety(C)
 A normal, affine toric variety
 
 julia> R, _ = PolynomialRing(QQ, 4);
@@ -493,7 +493,7 @@ ideal comes from the dual cone.
 julia> C = positive_hull([1 0 0; 1 1 0; 1 0 1; 1 1 1])
 A polyhedral cone in ambient dimension 3
 
-julia> antv = AffineNormalToricVariety(C)
+julia> antv = affine_normal_toric_variety(C)
 A normal, affine toric variety
 
 julia> toric_ideal(antv)
@@ -510,7 +510,7 @@ end
 
 @attr MPolyIdeal function toric_ideal(ntv::NormalToricVariety)
     is_affine(ntv) || error("Cannot construct affine toric variety from non-affine input")
-    return toric_ideal(AffineNormalToricVariety(ntv))
+    return toric_ideal(affine_normal_toric_variety(ntv))
 end
 export toric_ideal
 
@@ -1007,7 +1007,7 @@ Return the cone of the affine normal toric variety `v`.
 
 # Examples
 ```jldoctest
-julia> cone(AffineNormalToricVariety(Oscar.positive_hull([1 1; -1 1])))
+julia> cone(affine_normal_toric_variety(Oscar.positive_hull([1 1; -1 1])))
 A polyhedral cone in ambient dimension 2
 ```
 """
@@ -1042,7 +1042,7 @@ julia> affine_open_covering(p2)
 @attr Vector{AffineNormalToricVariety} function affine_open_covering(v::AbstractNormalToricVariety)
     charts = Vector{AffineNormalToricVariety}(undef, pm_object(v).N_MAXIMAL_CONES)
     for i in 1:pm_object(v).N_MAXIMAL_CONES
-        charts[i] = AffineNormalToricVariety(Cone(Polymake.fan.cone(pm_object(v), i-1)))
+        charts[i] = affine_normal_toric_variety(Cone(Polymake.fan.cone(pm_object(v), i-1)))
     end
     return charts
 end

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -274,6 +274,16 @@ function projective_space(::Type{NormalToricVariety}, d::Int; set_attributes::Bo
     pm_object = Polymake.fulton.NormalToricVariety(Oscar.pm_object(f))
     variety = NormalToricVariety(pm_object)
     
+    # make standard choice for weights of the cox ring
+    set_attribute!(variety, :torusinvariant_cartier_divisor_group, free_abelian_group(d+1))
+    set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(d+1))
+    set_attribute!(variety, :class_group, free_abelian_group(1))
+    set_attribute!(variety, :picard_group, free_abelian_group(1))
+    weights = matrix(ZZ,hcat([1 for i in 1:d+1]))
+    set_attribute!(variety, :map_from_torusinvariant_weil_divisor_group_to_class_group, hom(torusinvariant_weil_divisor_group(variety), class_group(variety), weights))
+    set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_picard_group, hom(torusinvariant_cartier_divisor_group(variety), picard_group(variety), weights))
+    set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group, hom(torusinvariant_cartier_divisor_group(variety), torusinvariant_weil_divisor_group(variety), identity_matrix(ZZ,d+1)))
+    
     if set_attributes
         set_attribute!(variety, :is_affine, false)
         set_attribute!(variety, :is_projective, true)
@@ -291,14 +301,6 @@ function projective_space(::Type{NormalToricVariety}, d::Int; set_attributes::Bo
         set_attribute!(variety, :euler_characteristic, d+1)
         set_attribute!(variety, :betti_number, fill(fmpz(1), d+1))
         set_attribute!(variety, :character_lattice, free_abelian_group(d))
-        set_attribute!(variety, :torusinvariant_cartier_divisor_group, free_abelian_group(d+1))
-        set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(d+1))
-        set_attribute!(variety, :class_group, free_abelian_group(1))
-        set_attribute!(variety, :picard_group, free_abelian_group(1))
-        weights = matrix(ZZ,hcat([1 for i in 1:d+1]))
-        set_attribute!(variety, :map_from_torusinvariant_weil_divisor_group_to_class_group, hom(torusinvariant_weil_divisor_group(variety), class_group(variety), weights))
-        set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_picard_group, hom(torusinvariant_cartier_divisor_group(variety), picard_group(variety), weights))
-        set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group, hom(torusinvariant_cartier_divisor_group(variety), torusinvariant_weil_divisor_group(variety), identity_matrix(ZZ,d+1)))
     end
     
     return variety
@@ -349,6 +351,12 @@ function weighted_projective_space(::Type{NormalToricVariety}, w::Vector{T}; set
     mc = IncidenceMatrix(subsets(Vector{Int}(1:length(w)), length(w)-1))
     variety = NormalToricVariety(PolyhedralFan(ray_gens, mc; non_redundant=true ))
     
+    # make standard choice for the weights of the cox ring
+    set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(length(w)))
+    set_attribute!(variety, :class_group, free_abelian_group(1))
+    weights = matrix(ZZ,hcat([w[i] for i in 1:length(w)]))
+    set_attribute!(variety, :map_from_torusinvariant_weil_divisor_group_to_class_group, hom(torusinvariant_weil_divisor_group(variety), class_group(variety), weights))
+    
     if set_attributes
         set_attribute!(variety, :has_torusfactor, false)
         set_attribute!(variety, :is_affine, false)
@@ -359,7 +367,6 @@ function weighted_projective_space(::Type{NormalToricVariety}, w::Vector{T}; set
         set_attribute!(variety, :is_simplicial, true)
         set_attribute!(variety, :dim, length(w)-1)
         set_attribute!(variety, :character_lattice, free_abelian_group(length(w)-1))
-        set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(length(w)))
         set_attribute!(variety, :dim_of_torusfactor, 0)
     end
     
@@ -384,6 +391,16 @@ function hirzebruch_surface(r::Int; set_attributes::Bool = true)
     cones = IncidenceMatrix([[1, 2], [2, 3], [3, 4], [4, 1]])
     variety = NormalToricVariety(PolyhedralFan(fan_rays, cones; non_redundant = true))
     
+    # make standard choice for the weights of the cox ring
+    set_attribute!(variety, :torusinvariant_cartier_divisor_group, free_abelian_group(4))
+    set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(4))
+    set_attribute!(variety, :class_group, free_abelian_group(2))
+    set_attribute!(variety, :picard_group, free_abelian_group(2))
+    weights = matrix(ZZ, [1 0; 0 1; 1 0; r 1])
+    set_attribute!(variety, :map_from_torusinvariant_weil_divisor_group_to_class_group, hom(torusinvariant_weil_divisor_group(variety), class_group(variety), weights))
+    set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_picard_group, hom(torusinvariant_cartier_divisor_group(variety), picard_group(variety), weights))
+    set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group, hom(torusinvariant_cartier_divisor_group(variety), torusinvariant_weil_divisor_group(variety), identity_matrix(ZZ,4)))
+    
     if set_attributes
         set_attribute!(variety, :is_affine, false)
         set_attribute!(variety, :is_projective, true)
@@ -407,15 +424,7 @@ function hirzebruch_surface(r::Int; set_attributes::Bool = true)
         set_attribute!(variety, :euler_characteristic, 4)
         set_attribute!(variety, :betti_number, [fmpz(1), fmpz(2), fmpz(1)])
         set_attribute!(variety, :character_lattice, free_abelian_group(2))
-        set_attribute!(variety, :torusinvariant_cartier_divisor_group, free_abelian_group(4))
-        set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(4))
-        set_attribute!(variety, :class_group, free_abelian_group(2))
-        set_attribute!(variety, :picard_group, free_abelian_group(2))
-        weights = matrix(ZZ, [1 0; 0 1; 1 0; r 1])
-        set_attribute!(variety, :map_from_torusinvariant_weil_divisor_group_to_class_group, hom(torusinvariant_weil_divisor_group(variety), class_group(variety), weights))
-        set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_picard_group, hom(torusinvariant_cartier_divisor_group(variety), picard_group(variety), weights))
         set_attribute!(variety, :map_from_character_lattice_to_torusinvariant_weil_divisor_group, hom(character_lattice(variety), torusinvariant_weil_divisor_group(variety), transpose(matrix(ZZ, fan_rays))))
-        set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group, hom(torusinvariant_cartier_divisor_group(variety), torusinvariant_weil_divisor_group(variety), identity_matrix(ZZ,4)))
     end
     
     return variety
@@ -463,6 +472,38 @@ function del_pezzo_surface(b::Int; set_attributes::Bool = true)
     end
     variety = NormalToricVariety(PolyhedralFan(fan_rays, cones; non_redundant = true))
     
+    # make standard choice for weights of the cox ring
+    if b == 1
+        set_attribute!(variety, :torusinvariant_cartier_divisor_group, free_abelian_group(4))
+        set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(4))
+        set_attribute!(variety, :class_group, free_abelian_group(2))
+        set_attribute!(variety, :picard_group, free_abelian_group(2))
+        weights = matrix(ZZ, [1 1; 1 1; 1 0; 0 -1])
+        set_attribute!(variety, :map_from_torusinvariant_weil_divisor_group_to_class_group, hom(torusinvariant_weil_divisor_group(variety), class_group(variety), weights))
+        set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_picard_group, hom(torusinvariant_cartier_divisor_group(variety), picard_group(variety), weights))
+        set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group, hom(torusinvariant_cartier_divisor_group(variety), torusinvariant_weil_divisor_group(variety), identity_matrix(ZZ,4)))
+    end
+    if b == 2
+        set_attribute!(variety, :torusinvariant_cartier_divisor_group, free_abelian_group(5))
+        set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(5))
+        set_attribute!(variety, :class_group, free_abelian_group(3))
+        set_attribute!(variety, :picard_group, free_abelian_group(3))
+        weights = matrix(ZZ, [1 1 1; 1 1 0; 1 0 1; 0 -1 0; 0 0 -1])
+        set_attribute!(variety, :map_from_torusinvariant_weil_divisor_group_to_class_group, hom(torusinvariant_weil_divisor_group(variety), class_group(variety), weights))
+        set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_picard_group, hom(torusinvariant_cartier_divisor_group(variety), picard_group(variety), weights))
+        set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group, hom(torusinvariant_cartier_divisor_group(variety), torusinvariant_weil_divisor_group(variety), identity_matrix(ZZ,5)))
+    end
+    if b == 3
+        set_attribute!(variety, :torusinvariant_cartier_divisor_group, free_abelian_group(6))
+        set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(6))
+        set_attribute!(variety, :class_group, free_abelian_group(4))
+        set_attribute!(variety, :picard_group, free_abelian_group(4))
+        weights = matrix(ZZ, [1 1 1 0; 1 1 0 1; 1 0 1 1; 0 -1 0 0; 0 0 -1 0; 0 0 0 -1])
+        set_attribute!(variety, :map_from_torusinvariant_weil_divisor_group_to_class_group, hom(torusinvariant_weil_divisor_group(variety), class_group(variety), weights))
+        set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_picard_group, hom(torusinvariant_cartier_divisor_group(variety), picard_group(variety), weights))
+        set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group, hom(torusinvariant_cartier_divisor_group(variety), torusinvariant_weil_divisor_group(variety), identity_matrix(ZZ,6)))
+    end
+    
     if set_attributes
         set_attribute!(variety, :is_affine, false)
         set_attribute!(variety, :is_projective, true)
@@ -483,43 +524,19 @@ function del_pezzo_surface(b::Int; set_attributes::Bool = true)
             set_attribute!(variety, :euler_characteristic, 4)
             set_attribute!(variety, :betti_number, [fmpz(1), fmpz(2), fmpz(1)])
             set_attribute!(variety, :character_lattice, free_abelian_group(2))
-            set_attribute!(variety, :torusinvariant_cartier_divisor_group, free_abelian_group(4))
-            set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(4))
-            set_attribute!(variety, :class_group, free_abelian_group(2))
-            set_attribute!(variety, :picard_group, free_abelian_group(2))
-            weights = matrix(ZZ, [1 1; 1 1; 1 0; 0 -1])
-            set_attribute!(variety, :map_from_torusinvariant_weil_divisor_group_to_class_group, hom(torusinvariant_weil_divisor_group(variety), class_group(variety), weights))
-            set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_picard_group, hom(torusinvariant_cartier_divisor_group(variety), picard_group(variety), weights))
             set_attribute!(variety, :map_from_character_lattice_to_torusinvariant_weil_divisor_group, hom(character_lattice(variety), torusinvariant_weil_divisor_group(variety), transpose(matrix(ZZ, fan_rays))))
-            set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group, hom(torusinvariant_cartier_divisor_group(variety), torusinvariant_weil_divisor_group(variety), identity_matrix(ZZ,4)))
         end
         if b == 2
             set_attribute!(variety, :euler_characteristic, 5)
             set_attribute!(variety, :betti_number, [fmpz(1), fmpz(3), fmpz(1)])
             set_attribute!(variety, :character_lattice, free_abelian_group(2))
-            set_attribute!(variety, :torusinvariant_cartier_divisor_group, free_abelian_group(5))
-            set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(5))
-            set_attribute!(variety, :class_group, free_abelian_group(3))
-            set_attribute!(variety, :picard_group, free_abelian_group(3))
-            weights = matrix(ZZ, [1 1 1; 1 1 0; 1 0 1; 0 -1 0; 0 0 -1])
-            set_attribute!(variety, :map_from_torusinvariant_weil_divisor_group_to_class_group, hom(torusinvariant_weil_divisor_group(variety), class_group(variety), weights))
-            set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_picard_group, hom(torusinvariant_cartier_divisor_group(variety), picard_group(variety), weights))
             set_attribute!(variety, :map_from_character_lattice_to_torusinvariant_weil_divisor_group, hom(character_lattice(variety), torusinvariant_weil_divisor_group(variety), transpose(matrix(ZZ, fan_rays))))
-            set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group, hom(torusinvariant_cartier_divisor_group(variety), torusinvariant_weil_divisor_group(variety), identity_matrix(ZZ,5)))
         end
         if b == 3
             set_attribute!(variety, :euler_characteristic, 6)
             set_attribute!(variety, :betti_number, [fmpz(1), fmpz(4), fmpz(1)])
             set_attribute!(variety, :character_lattice, free_abelian_group(2))
-            set_attribute!(variety, :torusinvariant_cartier_divisor_group, free_abelian_group(6))
-            set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(6))
-            set_attribute!(variety, :class_group, free_abelian_group(4))
-            set_attribute!(variety, :picard_group, free_abelian_group(4))
-            weights = matrix(ZZ, [1 1 1 0; 1 1 0 1; 1 0 1 1; 0 -1 0 0; 0 0 -1 0; 0 0 0 -1])
-            set_attribute!(variety, :map_from_torusinvariant_weil_divisor_group_to_class_group, hom(torusinvariant_weil_divisor_group(variety), class_group(variety), weights))
-            set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_picard_group, hom(torusinvariant_cartier_divisor_group(variety), picard_group(variety), weights))
             set_attribute!(variety, :map_from_character_lattice_to_torusinvariant_weil_divisor_group, hom(character_lattice(variety), torusinvariant_weil_divisor_group(variety), transpose(matrix(ZZ, fan_rays))))
-            set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group, hom(torusinvariant_cartier_divisor_group(variety), torusinvariant_weil_divisor_group(variety), identity_matrix(ZZ,6)))
         end
     end
     

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -280,7 +280,7 @@ function projective_space(::Type{NormalToricVariety}, d::Int; set_attributes::Bo
     set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(d+1))
     set_attribute!(variety, :class_group, free_abelian_group(1))
     set_attribute!(variety, :picard_group, free_abelian_group(1))
-    weights = matrix(ZZ,hcat([1 for i in 1:d+1]))
+    weights = matrix(ZZ,ones(Int,d+1,1))
     set_attribute!(variety, :map_from_torusinvariant_weil_divisor_group_to_class_group, hom(torusinvariant_weil_divisor_group(variety), class_group(variety), weights))
     set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_picard_group, hom(torusinvariant_cartier_divisor_group(variety), picard_group(variety), weights))
     set_attribute!(variety, :map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group, hom(torusinvariant_cartier_divisor_group(variety), torusinvariant_weil_divisor_group(variety), identity_matrix(ZZ,d+1)))

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -23,9 +23,8 @@ end
 # 2: Generic constructors
 ######################
 
-
 @doc Markdown.doc"""
-    AffineNormalToricVariety(C::Cone; set_attributes::Bool = true)
+    affine_normal_toric_variety(C::Cone; set_attributes::Bool = true)
 
 Construct the affine normal toric variety $U_{C}$ corresponding to a polyhedral
 cone `C`.
@@ -36,11 +35,11 @@ Set `C` to be the positive orthant in two dimensions.
 julia> C = positive_hull([1 0; 0 1])
 A polyhedral cone in ambient dimension 2
 
-julia> antv = AffineNormalToricVariety(C)
+julia> antv = affine_normal_toric_variety(C)
 A normal, affine toric variety
 ```
 """
-function AffineNormalToricVariety(C::Cone; set_attributes::Bool = true)
+function affine_normal_toric_variety(C::Cone; set_attributes::Bool = true)
     fan = PolyhedralFan(C)
     pmntv = Polymake.fulton.NormalToricVariety(Oscar.pm_object(fan))
     variety = AffineNormalToricVariety(pmntv)
@@ -57,6 +56,7 @@ function AffineNormalToricVariety(C::Cone; set_attributes::Bool = true)
     
     return variety
 end
+export affine_normal_toric_variety
 
 
 @doc Markdown.doc"""
@@ -191,7 +191,7 @@ end
 
 
 @doc Markdown.doc"""
-    AffineNormalToricVariety(v::NormalToricVariety; set_attributes::Bool = true)
+    affine_normal_toric_variety(v::NormalToricVariety; set_attributes::Bool = true)
 
 For internal design, we make a strict distinction between
 normal toric varieties and affine toric varieties.
@@ -203,11 +203,11 @@ this method turns it into an affine toric variety.
 julia> v = NormalToricVariety(positive_hull([1 0; 0 1]))
 A normal, affine toric variety
 
-julia> affineVariety = AffineNormalToricVariety(v)
+julia> affineVariety = affine_normal_toric_variety(v)
 A normal, affine toric variety
 ```
 """
-function AffineNormalToricVariety(v::NormalToricVariety; set_attributes::Bool = true)
+function affine_normal_toric_variety(v::NormalToricVariety; set_attributes::Bool = true)
     is_affine(v) || error("Cannot construct affine toric variety from non-affine input")
     variety = AffineNormalToricVariety(pm_object(v))
     

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -60,7 +60,7 @@ export affine_normal_toric_variety
 
 
 @doc Markdown.doc"""
-    NormalToricVariety(C::Cone; set_attributes::Bool = true)
+    normal_toric_variety(C::Cone; set_attributes::Bool = true)
 
 Construct the (affine) normal toric variety $X_{\Sigma}$ corresponding to a
 polyhedral fan $\Sigma = C$ consisting only of the cone `C`.
@@ -71,11 +71,11 @@ Set `C` to be the positive orthant in two dimensions.
 julia> C = positive_hull([1 0; 0 1])
 A polyhedral cone in ambient dimension 2
 
-julia> ntv = NormalToricVariety(C)
+julia> ntv = normal_toric_variety(C)
 A normal, affine toric variety
 ```
 """
-function NormalToricVariety(C::Cone; set_attributes::Bool = true)
+function normal_toric_variety(C::Cone; set_attributes::Bool = true)
     fan = PolyhedralFan(C)
     pmntv = Polymake.fulton.NormalToricVariety(Oscar.pm_object(fan))
     variety = NormalToricVariety(pmntv)
@@ -91,10 +91,11 @@ function NormalToricVariety(C::Cone; set_attributes::Bool = true)
     
     return variety
 end
+export normal_toric_variety
 
 
 @doc Markdown.doc"""
-NormalToricVariety(rays::Vector{Vector{Int64}}, max_cones::Vector{Vector{Int64}}; non_redundant::Bool = false, set_attributes::Bool = true)
+    normal_toric_variety(rays::Vector{Vector{Int64}}, max_cones::Vector{Vector{Int64}}; non_redundant::Bool = false, set_attributes::Bool = true)
 
 Construct a normal toric variety $X$ by providing the rays and maximal cones
 as vector of vectors. By default, this method assumes that the input is not
@@ -120,21 +121,21 @@ julia> max_cones = [[1, 2], [2, 3], [3, 4], [4, 1]]
  [3, 4]
  [4, 1]
 
-julia> NormalToricVariety(ray_generators, max_cones)
+julia> normal_toric_variety(ray_generators, max_cones)
 A normal toric variety
 
-julia> NormalToricVariety(ray_generators, max_cones, non_redundant = true)
+julia> normal_toric_variety(ray_generators, max_cones; non_redundant = true)
 A normal toric variety
 ```
 """
-function NormalToricVariety(rays::Vector{Vector{Int64}}, max_cones::Vector{Vector{Int64}}; non_redundant::Bool = false, set_attributes::Bool = true)
+function normal_toric_variety(rays::Vector{Vector{Int64}}, max_cones::Vector{Vector{Int64}}; non_redundant::Bool = false, set_attributes::Bool = true)
     fan = PolyhedralFan(transpose(hcat(rays...)), IncidenceMatrix(max_cones); non_redundant = non_redundant)
-    return NormalToricVariety(fan; set_attributes = set_attributes)
+    return normal_toric_variety(fan; set_attributes = set_attributes)
 end
 
 
 @doc Markdown.doc"""
-    NormalToricVariety(PF::PolyhedralFan; set_attributes::Bool = true)
+    normal_toric_variety(PF::PolyhedralFan; set_attributes::Bool = true)
 
 Construct the normal toric variety $X_{PF}$ corresponding to a polyhedral fan `PF`.
 
@@ -147,11 +148,11 @@ A polyhedron in ambient dimension 2
 julia> nf = normal_fan(square)
 A polyhedral fan in ambient dimension 2
 
-julia> ntv = NormalToricVariety(nf)
+julia> ntv = normal_toric_variety(nf)
 A normal toric variety
 ```
 """
-function NormalToricVariety(PF::PolyhedralFan; set_attributes::Bool = true)
+function normal_toric_variety(PF::PolyhedralFan; set_attributes::Bool = true)
     fan = Oscar.pm_object(PF)
     pmntv = Polymake.fulton.NormalToricVariety(fan)
     variety = NormalToricVariety(pmntv)
@@ -177,12 +178,12 @@ Set `P` to be a square.
 julia> square = cube(2)
 A polyhedron in ambient dimension 2
 
-julia> ntv = NormalToricVariety(square)
+julia> ntv = normal_toric_variety(square)
 A normal toric variety
 ```
 """
-function NormalToricVariety(P::Polyhedron; set_attributes::Bool = true)
-    variety = NormalToricVariety(normal_fan(P))
+function normal_toric_variety(P::Polyhedron; set_attributes::Bool = true)
+    variety = normal_toric_variety(normal_fan(P))
     if set_attributes
         set_attribute!(variety, :polyhedron, P)
     end
@@ -200,7 +201,7 @@ this method turns it into an affine toric variety.
 
 # Examples
 ```jldoctest
-julia> v = NormalToricVariety(positive_hull([1 0; 0 1]))
+julia> v = normal_toric_variety(positive_hull([1 0; 0 1]))
 A normal, affine toric variety
 
 julia> affineVariety = affine_normal_toric_variety(v)
@@ -349,7 +350,7 @@ function weighted_projective_space(::Type{NormalToricVariety}, w::Vector{T}; set
     tr,_ = pseudo_inv(lattice_gens)
     ray_gens = ray_gens * transpose(tr)
     mc = IncidenceMatrix(subsets(Vector{Int}(1:length(w)), length(w)-1))
-    variety = NormalToricVariety(PolyhedralFan(ray_gens, mc; non_redundant=true ))
+    variety = normal_toric_variety(PolyhedralFan(ray_gens, mc; non_redundant=true ))
     
     # make standard choice for the weights of the cox ring
     set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(length(w)))
@@ -389,7 +390,7 @@ A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional to
 function hirzebruch_surface(r::Int; set_attributes::Bool = true)
     fan_rays = [1 0; 0 1; -1 r; 0 -1]
     cones = IncidenceMatrix([[1, 2], [2, 3], [3, 4], [4, 1]])
-    variety = NormalToricVariety(PolyhedralFan(fan_rays, cones; non_redundant = true))
+    variety = normal_toric_variety(PolyhedralFan(fan_rays, cones; non_redundant = true))
     
     # make standard choice for the weights of the cox ring
     set_attribute!(variety, :torusinvariant_cartier_divisor_group, free_abelian_group(4))
@@ -470,7 +471,7 @@ function del_pezzo_surface(b::Int; set_attributes::Bool = true)
         fan_rays = [1 0; 0 1; -1 -1; 1 1; 0 -1; -1 0]
         cones = IncidenceMatrix([[1, 4], [2, 4], [1, 5], [5, 3], [2, 6], [6, 3]])
     end
-    variety = NormalToricVariety(PolyhedralFan(fan_rays, cones; non_redundant = true))
+    variety = normal_toric_variety(PolyhedralFan(fan_rays, cones; non_redundant = true))
     
     # make standard choice for weights of the cox ring
     if b == 1
@@ -573,7 +574,7 @@ Multivariate Polynomial Ring in x2, x3, x1, e over Rational Field graded by
 function blowup_on_ith_minimal_torus_orbit(v::AbstractNormalToricVariety, n::Int, coordinate_name::String; set_attributes::Bool = true)
     # compute the blow-up variety
     new_fan = starsubdivision(fan(v), n)
-    new_variety = NormalToricVariety(new_fan; set_attributes = set_attributes)
+    new_variety = normal_toric_variety(new_fan; set_attributes = set_attributes)
     
     # extract the old and new rays
     # the new cones are in general given by first (in general) permuting the old rays and then adding a new ray (not necessarily at the last position)
@@ -649,7 +650,7 @@ Multivariate Polynomial Ring in 6 variables x1, x2, x3, y1, ..., y3 over Rationa
 ```
 """
 function Base.:*(v::AbstractNormalToricVariety, w::AbstractNormalToricVariety; set_attributes::Bool = true)
-    product = NormalToricVariety(fan(v)*fan(w); set_attributes = set_attributes)
+    product = normal_toric_variety(fan(v)*fan(w); set_attributes = set_attributes)
     set_coordinate_names(product, vcat(["x$(i)" for i in coordinate_names(v)], ["y$(i)" for i in coordinate_names(w)]))
     return product
 end
@@ -703,7 +704,7 @@ function NormalToricVarietiesFromStarTriangulations(P::Polyhedron; set_attribute
     max_cones = [IncidenceMatrix([[c[i]-1 for i in 2:length(c)] for c in t]) for t in max_cones]
     
     # construct the varieties
-    return [NormalToricVariety(PolyhedralFan(integral_rays, cones; non_redundant = true), set_attributes = set_attributes) for cones in max_cones]
+    return [normal_toric_variety(PolyhedralFan(integral_rays, cones; non_redundant = true), set_attributes = set_attributes) for cones in max_cones]
 end
 export NormalToricVarietiesFromStarTriangulations
 

--- a/src/ToricVarieties/ToricMorphisms/constructors.jl
+++ b/src/ToricVarieties/ToricMorphisms/constructors.jl
@@ -148,7 +148,7 @@ function ToricMorphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbF
     # compute the image
     image_rays = matrix(ZZ, rays(domain)) * matrix(grid_morphism)
     image_rays = hcat([[Int(image_rays[i, j]) for i in 1:nrows(image_rays)] for j in 1:ncols(image_rays)]...)
-    image = NormalToricVariety(PolyhedralFan(image_rays, ray_indices(maximal_cones(domain))))
+    image = normal_toric_variety(PolyhedralFan(image_rays, ray_indices(maximal_cones(domain))))
 
     # compute the morphism
     if codomain == nothing

--- a/src/ToricVarieties/ToricMorphisms/special_attributes.jl
+++ b/src/ToricVarieties/ToricMorphisms/special_attributes.jl
@@ -16,7 +16,7 @@ A toric morphism
     mapping_matrix = matrix(ZZ, rays(fan(variety)))
     max_cones_for_cox_variety = ray_indices(maximal_cones(variety))
     rays_for_cox_variety = matrix(ZZ, [[if i==j 1 else 0 end for j in 1:nrays(variety)] for i in 1:nrays(variety)])
-    cox_variety = NormalToricVariety(PolyhedralFan(rays_for_cox_variety, max_cones_for_cox_variety))
+    cox_variety = normal_toric_variety(PolyhedralFan(rays_for_cox_variety, max_cones_for_cox_variety))
     return ToricMorphism(cox_variety, mapping_matrix, variety)
 end
 export morphism_from_cox_variety

--- a/test/Schemes/ToricSchemes.jl
+++ b/test/Schemes/ToricSchemes.jl
@@ -4,7 +4,7 @@ using Test
 @testset "Toric schemes" begin
   
   C = positive_hull([-1 1; 1 1])
-  antv = AffineNormalToricVariety(C)
+  antv = affine_normal_toric_variety(C)
   affine_toric_scheme = ToricSpec(antv)
   
   @testset "A simplicial (and not smooth) affine toric scheme" begin

--- a/test/ToricVarieties/affine_normal_varieties.jl
+++ b/test/ToricVarieties/affine_normal_varieties.jl
@@ -4,11 +4,11 @@ using Test
 @testset "Affine normal toric varieties (set_attributes = $set_attributes)" for set_attributes in [true, false]
     
     antv = affine_normal_toric_variety(Oscar.positive_hull([1 1; -1 1]); set_attributes)
-    antv2 = NormalToricVariety(Oscar.positive_hull([1 1; -1 1]); set_attributes)
+    antv2 = normal_toric_variety(Oscar.positive_hull([1 1; -1 1]); set_attributes)
     antv3 = affine_normal_toric_variety(antv2; set_attributes)
     antv4 = affine_normal_toric_variety(Oscar.positive_hull([1 0]); set_attributes)
     antv5 = affine_space(NormalToricVariety, 2; set_attributes)
-    antv6 = NormalToricVariety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]]; set_attributes)
+    antv6 = normal_toric_variety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]]; set_attributes)
     
     @testset "Basic properties" begin
         @test is_smooth(antv) == false

--- a/test/ToricVarieties/affine_normal_varieties.jl
+++ b/test/ToricVarieties/affine_normal_varieties.jl
@@ -3,10 +3,10 @@ using Test
 
 @testset "Affine normal toric varieties (set_attributes = $set_attributes)" for set_attributes in [true, false]
     
-    antv = AffineNormalToricVariety(Oscar.positive_hull([1 1; -1 1]); set_attributes)
+    antv = affine_normal_toric_variety(Oscar.positive_hull([1 1; -1 1]); set_attributes)
     antv2 = NormalToricVariety(Oscar.positive_hull([1 1; -1 1]); set_attributes)
-    antv3 = AffineNormalToricVariety(antv2; set_attributes)
-    antv4 = AffineNormalToricVariety(Oscar.positive_hull([1 0]); set_attributes)
+    antv3 = affine_normal_toric_variety(antv2; set_attributes)
+    antv4 = affine_normal_toric_variety(Oscar.positive_hull([1 0]); set_attributes)
     antv5 = affine_space(NormalToricVariety, 2; set_attributes)
     antv6 = NormalToricVariety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]]; set_attributes)
     

--- a/test/ToricVarieties/algebraic_cycles.jl
+++ b/test/ToricVarieties/algebraic_cycles.jl
@@ -3,7 +3,7 @@ using Test
 
 @testset "Algebraic cycles (set_attributes = $set_attributes)" for set_attributes in [true, false]
     
-    antv = AffineNormalToricVariety(Oscar.positive_hull([1 1; -1 1]))
+    antv = affine_normal_toric_variety(Oscar.positive_hull([1 1; -1 1]))
     
     P3 = projective_space(NormalToricVariety, 3; set_attributes)
     sv0 = ClosedSubvarietyOfToricVariety(P3, [gens(cox_ring(P3))[1]^2])

--- a/test/ToricVarieties/algebraic_cycles.jl
+++ b/test/ToricVarieties/algebraic_cycles.jl
@@ -8,7 +8,7 @@ using Test
     P3 = projective_space(NormalToricVariety, 3; set_attributes)
     sv0 = ClosedSubvarietyOfToricVariety(P3, [gens(cox_ring(P3))[1]^2])
     
-    ntv = NormalToricVariety(Oscar.normal_fan(Oscar.cube(2)))
+    ntv = normal_toric_variety(Oscar.normal_fan(Oscar.cube(2)))
     (xx1, xx2, yy1, yy2) = gens(cox_ring(ntv));
     sv1 = ClosedSubvarietyOfToricVariety(ntv, [xx1])
     sv2 = ClosedSubvarietyOfToricVariety(ntv, [xx1^2+xx1*xx2+xx2^2, yy2])

--- a/test/ToricVarieties/direct_products.jl
+++ b/test/ToricVarieties/direct_products.jl
@@ -3,8 +3,8 @@ using Test
 
 @testset "Direct products (set_attributes = $set_attributes)" for set_attributes in [true, false]
     
-    F5 = NormalToricVariety([[1, 0], [0, 1], [-1, 5], [0, -1]], [[1, 2], [2, 3], [3, 4], [4, 1]]; set_attributes)
-    P2 = NormalToricVariety(normal_fan(Oscar.simplex(2)); set_attributes)
+    F5 = normal_toric_variety([[1, 0], [0, 1], [-1, 5], [0, -1]], [[1, 2], [2, 3], [3, 4], [4, 1]]; set_attributes)
+    P2 = normal_toric_variety(normal_fan(Oscar.simplex(2)); set_attributes)
     variety = F5 * P2
     
     @testset "Properties of a direct product of two toric varieties" begin

--- a/test/ToricVarieties/intersection_numbers.jl
+++ b/test/ToricVarieties/intersection_numbers.jl
@@ -3,10 +3,10 @@ using Test
 
 @testset "Topological intersection numbers (set_attributes = $set_attributes)" for set_attributes in [true, false]
     
-    antv = AffineNormalToricVariety(Oscar.positive_hull([1 1; -1 1]); set_attributes)
-
+    antv = affine_normal_toric_variety(Oscar.positive_hull([1 1; -1 1]); set_attributes)
+    
     antv2 = NormalToricVariety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]]; set_attributes)
-
+    
     v = NormalToricVariety([[1, 0], [0, 1], [-1, -1]], [[1], [2], [3]]; set_attributes)
     
     dP1 = del_pezzo_surface(1; set_attributes)

--- a/test/ToricVarieties/intersection_numbers.jl
+++ b/test/ToricVarieties/intersection_numbers.jl
@@ -5,9 +5,9 @@ using Test
     
     antv = affine_normal_toric_variety(Oscar.positive_hull([1 1; -1 1]); set_attributes)
     
-    antv2 = NormalToricVariety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]]; set_attributes)
+    antv2 = normal_toric_variety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]]; set_attributes)
     
-    v = NormalToricVariety([[1, 0], [0, 1], [-1, -1]], [[1], [2], [3]]; set_attributes)
+    v = normal_toric_variety([[1, 0], [0, 1], [-1, -1]], [[1], [2], [3]]; set_attributes)
     
     dP1 = del_pezzo_surface(1; set_attributes)
     c0 = CohomologyClass(dP1, gens(cohomology_ring(dP1))[1])

--- a/test/ToricVarieties/line_bundle_cohomologies.jl
+++ b/test/ToricVarieties/line_bundle_cohomologies.jl
@@ -16,13 +16,8 @@ using Test
     R,_ = PolynomialRing(QQ, 3)
     
     @testset "Cohomology with cohomCalg on dP3" begin
-        if set_attributes
-            @test cohomology(l, 0) == 0
-            @test all_cohomologies(l) == [0, 16, 0]
-        else
-            @test cohomology(l, 0) == 6
-            @test all_cohomologies(l) == [6, 3, 0]
-        end
+        @test cohomology(l, 0) == 0
+        @test all_cohomologies(l) == [0, 16, 0]
     end
     
     @testset "Cohomology with cohomCalg on F5" begin
@@ -37,15 +32,9 @@ using Test
         @test contains(vs[1], structure_sheaf(dP3)) == false
         @test contains(vs[2], structure_sheaf(dP3)) == true
         @test contains(vs[3], structure_sheaf(dP3)) == true
-        if set_attributes
-            @test contains(vs[1], l) == true
-            @test contains(vs[2], l) == false
-            @test contains(vs[3], l) == true
-        else
-            @test contains(vs[1], l) == false
-            @test contains(vs[2], l) == false
-            @test contains(vs[3], l) == true
-        end
+        @test contains(vs[1], l) == true
+        @test contains(vs[2], l) == false
+        @test contains(vs[3], l) == true
     end
     
     @testset "Toric vanishing sets of P2" begin
@@ -71,12 +60,7 @@ using Test
         @test length(basis_of_global_sections(anticanonical_bundle(dP3)^2)) == 19
         @test length(basis_of_global_sections_via_rational_functions(canonical_bundle(dP3))) == 0
         @test length(basis_of_global_sections(canonical_bundle(dP3))) == 0
-        if set_attributes
-            @test length(basis_of_global_sections_via_rational_functions(l)) == 0
-            @test length(basis_of_global_sections(l)) == 0
-        else
-            @test length(basis_of_global_sections_via_rational_functions(l)) == 6
-            @test length(basis_of_global_sections(l)) == 6
-        end
+        @test length(basis_of_global_sections_via_rational_functions(l)) == 0
+        @test length(basis_of_global_sections(l)) == 0
     end
 end

--- a/test/ToricVarieties/line_bundles.jl
+++ b/test/ToricVarieties/line_bundles.jl
@@ -24,15 +24,9 @@ using Test
     end
     
     @testset "Basic attributes" begin
-        if set_attributes
-            @test degree(l) == -6
-            @test degree(l^(-1)) == 6
-            @test degree(l*l) == -12
-        else
-            @test degree(l) == 10
-            @test degree(l^(-1)) == -10
-            @test degree(l*l) == 20
-        end
+        @test degree(l) == -6
+        @test degree(l^(-1)) == 6
+        @test degree(l*l) == -12
         @test divisor_class(l).coeff == AbstractAlgebra.matrix(ZZ, [1 2 3 4])
         @test dim(toric_variety(l)) == 2
     end

--- a/test/ToricVarieties/normal_toric_varieties.jl
+++ b/test/ToricVarieties/normal_toric_varieties.jl
@@ -3,12 +3,12 @@ using Test
 
 @testset "Normal toric varieties (set_attributes = $set_attributes)" for set_attributes in [true, false]
     
-    ntv = NormalToricVariety(Oscar.normal_fan(Oscar.cube(2)); set_attributes)
+    ntv = normal_toric_variety(Oscar.normal_fan(Oscar.cube(2)); set_attributes)
     set_coordinate_names(ntv, ["x1", "x2", "y1", "y2"])
-    ntv2 = NormalToricVariety(Oscar.cube(2); set_attributes)
+    ntv2 = normal_toric_variety(Oscar.cube(2); set_attributes)
     ntv3 = NormalToricVarietyFromGLSM(matrix(ZZ, [[1, 1, 1]]); set_attributes)
     ntv4 = NormalToricVarietiesFromStarTriangulations(convex_hull([0 0 0; 0 0 1; 1 0 1; 1 1 1; 0 1 1]); set_attributes)
-    ntv5 = NormalToricVariety(polarize(Polyhedron(Polymake.polytope.rand_sphere(5, 60; seed=42))); set_attributes)
+    ntv5 = normal_toric_variety(polarize(Polyhedron(Polymake.polytope.rand_sphere(5, 60; seed=42))); set_attributes)
     
     @testset "Basic properties" begin
         @test is_complete(ntv) == true

--- a/test/ToricVarieties/subvarieties.jl
+++ b/test/ToricVarieties/subvarieties.jl
@@ -3,9 +3,9 @@ using Test
 
 @testset "Closed subvarieties (set_attributes = $set_attributes)" for set_attributes in [true, false]
     
-    antv = NormalToricVariety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]]; set_attributes)
+    antv = normal_toric_variety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]]; set_attributes)
     
-    ntv = NormalToricVariety(Oscar.normal_fan(Oscar.cube(2)); set_attributes)
+    ntv = normal_toric_variety(Oscar.normal_fan(Oscar.cube(2)); set_attributes)
     (x1, x2, y1, y2) = gens(cox_ring(ntv));
     sv1 = ClosedSubvarietyOfToricVariety(ntv, [x1])
     sv2 = ClosedSubvarietyOfToricVariety(ntv, [x1^2+x1*x2+x2^2, y2])


### PR DESCRIPTION
@lkastner Here is a proposal to streamline the attribute setting.

This works by always (= for Hirzebruch surfaces, del Pezzo surfaces and (weighted) projective spaces) fixing a grading of the Cox ring. As a consequence, many of the if/else statements that I recently introduced in the tests for the toric functionality could be removed.

@fingolfin In addition, this renames the following constructors:
* `AffineNormalToricVariety` -> `affine_normal_toric_variety`,
* `NormalToricVariety` -> `normal_toric_variety`.

As @fingolfin pointed out: For algebraic cycles, we currently issue `export p`. This should be `export polynomial` and is fixed in https://github.com/oscar-system/Oscar.jl/pull/1958/commits/7342b2109e12d9fc54c60b9f3e9af04e2db35d9f.