### PR TITLE
Rework of Hilbert-driven GB computation

### DIFF
--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1265,23 +1265,21 @@ function _compute_groebner_basis_using_fglm(I::MPolyIdeal,
 end
 
 @doc Markdown.doc"""
-    groebner_basis_hilbert_driven(I::MPolyIdeal{P};
-                                  ordering::MonomialOrdering,
-                                  complete_reduction::Bool = false,
-                                  weights::Vector{Int} = ones(ngens(base_ring(I)))) where {P <: MPolyElem}
+         groebner_basis_hilbert_driven(I::MPolyIdeal{P};
+                                       ordering::MonomialOrdering,
+                                       complete_reduction::Bool = false,
+                                       weights::Vector{Int} = ones(Int, ngens(base_ring(I))),
+                                       hilbert_numerator::Union{Nothing, fmpz_poly} = nothing) where {P <: MPolyElem}
 
 
-Compute a Gröbner basis of `I` with respect to `ordering` using a
-Hilbert Series driven method as follows: If a Gröbner basis for `I` is
-present, compute the Hilbert series of `I` (w.r.t. `weights`) and use
-it to optimize the Gröbner basis computation for `I`
-w.r.t. `ordering`. If no Gröbner basis for `I` is present compute the
-Hilbert series for `I` if the base field of `I` has positive
-characteristic, otherwise compute the Hilbert series for `I` modulo a
-randomly chosen prime. Use the resulting Hilbert series to optimize
-the Gröbner basis computation for `I` w.r.t. `ordering`.
+Compute a Gröbner basis of `I` with respect to `ordering` using the
+Hilbert series of `I` to optimize the computation. If the numerator of
+the hilbert series of `I` is not passed by the user, it is computed
+internally.
 
-`I` must be given by generators homogeneous w.r.t. `weights`.
+`I` must be given by generators homogeneous w.r.t. `weights` and
+`hilbert_numerator` must be either `nothing` or the numerator of the
+hilbert series of `I` w.r.t.  weights computed by Oscar.
 
 # Examples
 ```jldoctest

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1393,6 +1393,7 @@ function _find_weights(F::Vector{P}) where {P <: MPolyElem}
     pos_vec += K*(v.p)
   end
   ret = (Int).(lcm((denominator).(pos_vec)) .* pos_vec)
+  ret = (x -> div(x, gcd(ret))).(ret) 
   @assert iszero(mat_space(exp_diffs) * ret)
   return ret
 end

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1406,13 +1406,13 @@ end
 function _find_weights(F::Vector{P}) where {P <: MPolyElem}
   nrows = sum((length).(F)) - length(F)
   ncols = ngens(parent(first(F)))
-  mat_space = MatrixSpace(ZZ, nrows, ncols)
+  mat_space = MatrixSpace(QQ, nrows, ncols)
 
   exp_diffs = permutedims(reduce(hcat, [e[i] - e[1] for e in
                                           (collect).((exponents).(F))
                                           for i in 2:length(e)]))
   K = kernel(mat_space(exp_diffs))[2]
-
+  isempty(K) && return zeros(Int, ncols)
   # Here we try to find a vector with strictly positive entries in K
   # this method to find such a vector is taken from
   # https://mathoverflow.net/questions/363181/intersection-of-a-vector-subspace-with-a-cone
@@ -1420,7 +1420,7 @@ function _find_weights(F::Vector{P}) where {P <: MPolyElem}
   !is_feasible(Pol) && return zeros(Int, ncols)
   pos_vec = zeros(Int, ncols)
   for i in 1:ncols
-    ei = [j == i ? 1 : 0 for j in 1:ncols]
+    ei = [j == i ? one(QQ) : zero(QQ) for j in 1:ncols]
     obj_func = ei * K
     L = LinearProgram(Pol, obj_func)
     m, v = solve_lp(L)

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1434,6 +1434,6 @@ function _find_weights(F::Vector{P}) where {P <: MPolyElem}
   end
   ret = (Int).(lcm((denominator).(pos_vec)) .* pos_vec)
   ret = (x -> div(x, gcd(ret))).(ret) 
-  @assert iszero(mat_space(exp_diffs) * ret)
-  return ret
+  # assure that the weights fit in Int32 for singular
+  all(ret .< 2^32) ? return ret : return zeros(Int,ncols)
 end

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -268,7 +268,7 @@ julia> G = groebner_basis(I, ordering = o, algorithm = :hilbert);
 julia> length(G)
 296
 
-julia> total_degree(G[296])
+julia> total_degree(G[49])
 30
 ```
 ```jldoctest
@@ -1435,5 +1435,5 @@ function _find_weights(F::Vector{P}) where {P <: MPolyElem}
   ret = (Int).(lcm((denominator).(pos_vec)) .* pos_vec)
   ret = (x -> div(x, gcd(ret))).(ret) 
   # assure that the weights fit in Int32 for singular
-  all(ret .< 2^32) ? return ret : return zeros(Int,ncols)
+  return all(ret .< 2^32) ? ret : zeros(Int,ncols)
 end


### PR DESCRIPTION
As discussed with @ederc and @wdecker this is a rework of the hilbert driven GB computation to

1. First try to find weights w.r.t. which the input ideal is homogeneous in `standard_basis` before homogenizing.
2. Let the user pass weights themselves into `groebner_basis_hilbert_driven`