### PR TITLE
ToricVarieties: More CamelCase constructors to snake_case

### DIFF
--- a/docs/src/ToricVarieties/AlgebraicCycles.md
+++ b/docs/src/ToricVarieties/AlgebraicCycles.md
@@ -61,17 +61,17 @@ the cones in the fan of the toric variety.
 ### General constructors
 
 ```@docs
-RationalEquivalenceClass(v::AbstractNormalToricVariety, coefficients::Vector{T}) where {T <: IntegerUnion}
+rational_equivalence_class(v::AbstractNormalToricVariety, coefficients::Vector{T}) where {T <: IntegerUnion}
 ```
 
 ### Special constructors
 
 ```@docs
-RationalEquivalenceClass(d::ToricDivisor)
-RationalEquivalenceClass(c::ToricDivisorClass)
-RationalEquivalenceClass(l::ToricLineBundle)
-RationalEquivalenceClass(cc::CohomologyClass)
-RationalEquivalenceClass(cc::ClosedSubvarietyOfToricVariety)
+rational_equivalence_class(d::ToricDivisor)
+rational_equivalence_class(c::ToricDivisorClass)
+rational_equivalence_class(l::ToricLineBundle)
+rational_equivalence_class(cc::CohomologyClass)
+rational_equivalence_class(sv::ClosedSubvarietyOfToricVariety)
 ```
 
 ### Addition, subtraction and scalar multiplication

--- a/docs/src/ToricVarieties/CohomologyClasses.md
+++ b/docs/src/ToricVarieties/CohomologyClasses.md
@@ -15,9 +15,10 @@ Pages = ["CohomologyClasses.md"]
 ### General constructors
 
 ```@docs
-CohomologyClass(d::ToricDivisor)
-CohomologyClass(c::ToricDivisorClass)
-CohomologyClass(l::ToricLineBundle)
+cohomology_class(v::AbstractNormalToricVariety, p::MPolyQuoElem)
+cohomology_class(d::ToricDivisor)
+cohomology_class(c::ToricDivisorClass)
+cohomology_class(l::ToricLineBundle)
 ```
 
 ### Addition, subtraction and scalar multiplication

--- a/docs/src/ToricVarieties/CyclicQuotientSingularities.md
+++ b/docs/src/ToricVarieties/CyclicQuotientSingularities.md
@@ -25,7 +25,7 @@ For the notation we rely on [Chr91](@cite) and [Ste91](@cite).
 ## Constructors
 
 ```@docs
-CyclicQuotientSingularity(n::fmpz, q::fmpz)
+cyclic_quotient_singularity(n::T, q::T) where {T <: IntegerUnion}
 ```
 
 

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -63,7 +63,7 @@ weighted_projective_space(::Type{NormalToricVariety}, w::Vector{T}; set_attribut
 blowup_on_ith_minimal_torus_orbit(v::AbstractNormalToricVariety, n::Int, coordinate_name::String; set_attributes::Bool = true)
 Base.:*(v::AbstractNormalToricVariety, w::AbstractNormalToricVariety; set_attributes::Bool = true)
 normal_toric_varieties_from_star_triangulations(P::Polyhedron; set_attributes::Bool = true)
-NormalToricVarietyFromGLSM(charges::fmpz_mat; set_attributes::Bool = true)
+normal_toric_varieties_from_glsm(charges::fmpz_mat; set_attributes::Bool = true)
 ```
 
 

--- a/docs/src/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/ToricVarieties/NormalToricVarieties.md
@@ -62,7 +62,7 @@ weighted_projective_space(::Type{NormalToricVariety}, w::Vector{T}; set_attribut
 ```@docs
 blowup_on_ith_minimal_torus_orbit(v::AbstractNormalToricVariety, n::Int, coordinate_name::String; set_attributes::Bool = true)
 Base.:*(v::AbstractNormalToricVariety, w::AbstractNormalToricVariety; set_attributes::Bool = true)
-NormalToricVarietiesFromStarTriangulations(P::Polyhedron; set_attributes::Bool = true)
+normal_toric_varieties_from_star_triangulations(P::Polyhedron; set_attributes::Bool = true)
 NormalToricVarietyFromGLSM(charges::fmpz_mat; set_attributes::Bool = true)
 ```
 

--- a/docs/src/ToricVarieties/Subvarieties.md
+++ b/docs/src/ToricVarieties/Subvarieties.md
@@ -25,7 +25,8 @@ varieties.
 ### General constructors
 
 ```@docs
-ClosedSubvarietyOfToricVariety(toric_variety::AbstractNormalToricVariety, defining_polynomials::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}})
+closed_subvariety_of_toric_variety(toric_variety::AbstractNormalToricVariety, defining_polynomials::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}})
+closed_subvariety_of_toric_variety(toric_variety::AbstractNormalToricVariety, defining_ideal::MPolyIdeal)
 ```
 
 

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -64,3 +64,40 @@ end
 
 @deprecate NormalToricVarietiesFromStarTriangulations(P::Polyhedron; set_attributes::Bool = true) normal_toric_varieties_from_star_triangulations(P; set_attributes = set_attributes)
 @deprecate NormalToricVarietyFromGLSM(charges::fmpz_mat; set_attributes::Bool = true) normal_toric_varieties_from_glsm(charges; set_attributes = set_attributes)
+
+function RationalEquivalenceClass(v::AbstractNormalToricVariety, coefficients::Vector{T}) where {T <: IntegerUnion}
+    Base.depwarn("'RationalEquivalenceClass(v::AbstractNormalToricVariety, coefficients::Vector{T}) where {T <: IntegerUnion}'"*
+    " is deprecated, use 'rational_equivalence_class(v::AbstractNormalToricVariety, coefficients::Vector{T}) "*
+    "where {T <: IntegerUnion}' instead.", RationalEquivalenceClass)
+    rational_equivalence_class(v, coefficients)
+end
+
+function RationalEquivalenceClass(d::ToricDivisor)
+    Base.depwarn("'RationalEquivalenceClass(d::ToricDivisor)' is deprecated, use "*
+    "'rational_equivalence_class(d::ToricDivisor)' instead.", :RationalEquivalenceClass)
+    rational_equivalence_class(d)
+end
+
+function RationalEquivalenceClass(c::ToricDivisorClass)
+    Base.depwarn("'RationalEquivalenceClass(c::ToricDivisorClass)' is deprecated, use "*
+    "'rational_equivalence_class(c::ToricDivisorClass)' instead.", :RationalEquivalenceClass)
+    rational_equivalence_class(c)
+end
+
+function RationalEquivalenceClass(l::ToricLineBundle)
+    Base.depwarn("'RationalEquivalenceClass(l::ToricLineBundle)' is deprecated, use "*
+    "'rational_equivalence_class(l::ToricLineBundle)' instead.", :RationalEquivalenceClass)
+    rational_equivalence_class(l)
+end
+
+function RationalEquivalenceClass(cc::CohomologyClass)
+    Base.depwarn("'RationalEquivalenceClass(cc::CohomologyClass)' is deprecated, use "*
+    "'rational_equivalence_class(cc::CohomologyClass)' instead.", :RationalEquivalenceClass)
+    rational_equivalence_class(cc)
+end
+
+function RationalEquivalenceClass(sv::ClosedSubvarietyOfToricVariety)
+    Base.depwarn("'RationalEquivalenceClass(sv::ClosedSubvarietyOfToricVariety)' is deprecated, use "*
+    "'rational_equivalence_class(sv::ClosedSubvarietyOfToricVariety)' instead.", :RationalEquivalenceClass)
+    rational_equivalence_class(sv)
+end

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -125,3 +125,11 @@ function CyclicQuotientSingularity(n::T, q::T) where {T <: IntegerUnion}
     "'cyclic_quotient_singularity(n::fmpz, q::fmpz)' instead.", :CyclicQuotientSingularity)
     cyclic_quotient_singularity(n, q)
 end
+
+function ClosedSubvarietyOfToricVariety(toric_variety::AbstractNormalToricVariety, defining_polynomials::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}})
+    Base.depwarn("ClosedSubvarietyOfToricVariety(toric_variety::AbstractNormalToricVariety, "*
+    "defining_polynomials::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}}) is deprecated, use "*
+    "'closed_subvariety_of_toric_variety(toric_variety::AbstractNormalToricVariety, "*
+    "defining_polynomials::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}})' instead.", :ClosedSubvarietyOfToricVariety)
+    closed_subvariety_of_toric_variety(toric_variety, defining_polynomials)
+  end

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -119,3 +119,9 @@ function CohomologyClass(l::ToricLineBundle)
     "'cohomology_class(l::ToricLineBundle)' instead.", :CohomologyClass)
     cohomology_class(l)
 end
+
+function CyclicQuotientSingularity(n::T, q::T) where {T <: IntegerUnion}
+    Base.depwarn("'CyclicQuotientSingularity(n::fmpz, q::fmpz)' is deprecated, use "*
+    "'cyclic_quotient_singularity(n::fmpz, q::fmpz)' instead.", :CyclicQuotientSingularity)
+    cyclic_quotient_singularity(n, q)
+end

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -63,3 +63,4 @@ function NormalToricVariety(P::Polyhedron; set_attributes::Bool = true)
 end
 
 @deprecate NormalToricVarietiesFromStarTriangulations(P::Polyhedron; set_attributes::Bool = true) normal_toric_varieties_from_star_triangulations(P; set_attributes = set_attributes)
+@deprecate NormalToricVarietyFromGLSM(charges::fmpz_mat; set_attributes::Bool = true) normal_toric_varieties_from_glsm(charges; set_attributes = set_attributes)

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -101,3 +101,21 @@ function RationalEquivalenceClass(sv::ClosedSubvarietyOfToricVariety)
     "'rational_equivalence_class(sv::ClosedSubvarietyOfToricVariety)' instead.", :RationalEquivalenceClass)
     rational_equivalence_class(sv)
 end
+
+function CohomologyClass(d::ToricDivisor)
+    Base.depwarn("'CohomologyClass(d::ToricDivisor)' is deprecated, use "*
+    "'cohomology_class(d::ToricDivisor)' instead.", :CohomologyClass)
+    cohomology_class(d)
+end
+
+function CohomologyClass(c::ToricDivisorClass)
+    Base.depwarn("'CohomologyClass(c::ToricDivisorClass)' is deprecated, use "*
+    "'cohomology_class(c::ToricDivisorClass)' instead.", :CohomologyClass)
+    cohomology_class(c)
+end
+
+function CohomologyClass(l::ToricLineBundle)
+    Base.depwarn("'CohomologyClass(l::ToricLineBundle)' is deprecated, use "*
+    "'cohomology_class(l::ToricLineBundle)' instead.", :CohomologyClass)
+    cohomology_class(l)
+end

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -61,3 +61,5 @@ function NormalToricVariety(P::Polyhedron; set_attributes::Bool = true)
     "'normal_toric_variety(P::Polyhedron; set_attributes::Bool = true)' instead.", :NormalToricVariety)
     normal_toric_variety(P; set_attributes = set_attributes)
 end
+
+@deprecate NormalToricVarietiesFromStarTriangulations(P::Polyhedron; set_attributes::Bool = true) normal_toric_varieties_from_star_triangulations(P; set_attributes = set_attributes)

--- a/src/ToricVarieties/AlgebraicCycles/attributes.jl
+++ b/src/ToricVarieties/AlgebraicCycles/attributes.jl
@@ -17,7 +17,7 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
-julia> ac = RationalEquivalenceClass(d)
+julia> ac = rational_equivalence_class(d)
 A rational equivalence class on a normal toric variety represented by 6V(x3)+V(e1)+7V(e2)
 
 julia> toric_variety(ac)
@@ -44,7 +44,7 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
-julia> ac = RationalEquivalenceClass(d)
+julia> ac = rational_equivalence_class(d)
 A rational equivalence class on a normal toric variety represented by 6V(x3)+V(e1)+7V(e2)
 
 julia> polynomial(ac)
@@ -74,7 +74,7 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
-julia> ac = RationalEquivalenceClass(d)
+julia> ac = rational_equivalence_class(d)
 A rational equivalence class on a normal toric variety represented by 6V(x3)+V(e1)+7V(e2)
 
 julia> R, _ = PolynomialRing(QQ, 5)
@@ -130,7 +130,7 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
-julia> ac = RationalEquivalenceClass(d)
+julia> ac = rational_equivalence_class(d)
 A rational equivalence class on a normal toric variety represented by 6V(x3)+V(e1)+7V(e2)
 
 julia> ac*ac
@@ -164,7 +164,7 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
-julia> ac = RationalEquivalenceClass(d)
+julia> ac = rational_equivalence_class(d)
 A rational equivalence class on a normal toric variety represented by 6V(x3)+V(e1)+7V(e2)
 
 julia> coefficients(ac*ac)
@@ -200,7 +200,7 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
-julia> ac = RationalEquivalenceClass(d)
+julia> ac = rational_equivalence_class(d)
 A rational equivalence class on a normal toric variety represented by 6V(x3)+V(e1)+7V(e2)
 
 julia> length(components(ac*ac))
@@ -239,7 +239,7 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
-julia> ac = RationalEquivalenceClass(d)
+julia> ac = rational_equivalence_class(d)
 A rational equivalence class on a normal toric variety represented by 6V(x3)+V(e1)+7V(e2)
 
 julia> cohomology_class(ac)

--- a/src/ToricVarieties/AlgebraicCycles/attributes.jl
+++ b/src/ToricVarieties/AlgebraicCycles/attributes.jl
@@ -215,7 +215,7 @@ julia> length(components(ac*ac))
     gs = gens(cox_ring(toric_variety(ac)))
     mons = [m for m in monomials(representative(ac))]
     expos = [[e for e in AbstractAlgebra.exponent_vectors(m)][1] for m in mons]
-    return [ClosedSubvarietyOfToricVariety(variety, [gs[k] for k in findall(!iszero, exps)]) for exps in expos]
+    return [closed_subvariety_of_toric_variety(variety, [gs[k] for k in findall(!iszero, exps)]) for exps in expos]
 end
 export components
 

--- a/src/ToricVarieties/AlgebraicCycles/constructors.jl
+++ b/src/ToricVarieties/AlgebraicCycles/constructors.jl
@@ -15,7 +15,7 @@ export RationalEquivalenceClass
 ####################################################
 
 @doc Markdown.doc"""
-    RationalEquivalenceClass(v::AbstractNormalToricVariety, coefficients::Vector{T}) where {T <: IntegerUnion}
+    rational_equivalence_class(v::AbstractNormalToricVariety, coefficients::Vector{T}) where {T <: IntegerUnion}
 
 Construct the rational equivalence class of algebraic cycles corresponding to a linear combination of cones.
 
@@ -24,14 +24,11 @@ Construct the rational equivalence class of algebraic cycles corresponding to a 
 julia> P2 = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> d = ToricDivisor(P2, [1, 2, 3])
-A torus-invariant, non-prime divisor on a normal toric variety
-
-julia> RationalEquivalenceClass(d)
-A rational equivalence class on a normal toric variety represented by 6V(x3)
+julia> rational_equivalence_class(P2, [1, 2, 3, 4, 5, 6])
+A rational equivalence class on a normal toric variety represented by 15V(x1,x3)+6V(x3)
 ```
 """
-function RationalEquivalenceClass(v::AbstractNormalToricVariety, coefficients::Vector{T}) where {T <: IntegerUnion}
+function rational_equivalence_class(v::AbstractNormalToricVariety, coefficients::Vector{T}) where {T <: IntegerUnion}
     if !(is_complete(v) && is_simplicial(v))
         throw(ArgumentError("Currently, the Chow ring is only supported for toric varieties that are both complete and simplicial"))
     end
@@ -41,6 +38,7 @@ function RationalEquivalenceClass(v::AbstractNormalToricVariety, coefficients::V
     mons = gens_of_rational_equivalence_classes(v)
     return RationalEquivalenceClass(v, sum(coefficients[i]*mons[i] for i in 1:length(coefficients)))
 end
+export rational_equivalence_class
 
 
 ####################################################
@@ -48,7 +46,7 @@ end
 ####################################################
 
 @doc Markdown.doc"""
-    RationalEquivalenceClass(d::ToricDivisor)
+    rational_equivalence_class(d::ToricDivisor)
 
 Construct the rational equivalence class of algebraic cycles corresponding to the toric divisor `d`.
 
@@ -60,11 +58,11 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> d = ToricDivisor(P2, [1, 2, 3])
 A torus-invariant, non-prime divisor on a normal toric variety
 
-julia> RationalEquivalenceClass(d)
+julia> rational_equivalence_class(d)
 A rational equivalence class on a normal toric variety represented by 6V(x3)
 ```
 """
-function RationalEquivalenceClass(d::ToricDivisor)
+function rational_equivalence_class(d::ToricDivisor)
     v = toric_variety(d)
     if is_trivial(d)
         return RationalEquivalenceClass(v, zero(chow_ring(v)))
@@ -76,7 +74,7 @@ end
 
 
 @doc Markdown.doc"""
-    RationalEquivalenceClass(c::ToricDivisorClass)
+    rational_equivalence_class(c::ToricDivisorClass)
 
 Construct the algebraic cycle corresponding to the toric divisor class `c`.
 
@@ -88,11 +86,11 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> tdc = ToricDivisorClass(P2, [2])
 A divisor class on a normal toric variety
 
-julia> RationalEquivalenceClass(tdc)
+julia> rational_equivalence_class(tdc)
 A rational equivalence class on a normal toric variety represented by 2V(x3)
 ```
 """
-RationalEquivalenceClass(c::ToricDivisorClass) = RationalEquivalenceClass(toric_divisor(c))
+rational_equivalence_class(c::ToricDivisorClass) = rational_equivalence_class(toric_divisor(c))
 
 
 @doc Markdown.doc"""
@@ -108,15 +106,15 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> l = ToricLineBundle(P2, [2])
 A toric line bundle on a normal toric variety
 
-julia> polynomial(RationalEquivalenceClass(l))
+julia> polynomial(rational_equivalence_class(l))
 2*x3
 ```
 """
-RationalEquivalenceClass(l::ToricLineBundle) = RationalEquivalenceClass(toric_divisor(l))
+rational_equivalence_class(l::ToricLineBundle) = rational_equivalence_class(toric_divisor(l))
 
 
 @doc Markdown.doc"""
-    RationalEquivalenceClass(cc::CohomologyClass)
+    rational_equivalence_class(cc::CohomologyClass)
 
 Construct the toric algebraic cycle corresponding to the cohomology class `cc`.
 
@@ -134,15 +132,15 @@ julia> (x1, x2, x3) = gens(cohomology_ring(P2))
 julia> cc = CohomologyClass(P2, x1+x2)
 A cohomology class on a normal toric variety given by x1 + x2
 
-julia> RationalEquivalenceClass(cc)
+julia> rational_equivalence_class(cc)
 A rational equivalence class on a normal toric variety represented by 2V(x3)
 ```
 """
-RationalEquivalenceClass(cc::CohomologyClass) = RationalEquivalenceClass(toric_variety(cc), polynomial(chow_ring(toric_variety(cc)), cc))
+rational_equivalence_class(cc::CohomologyClass) = RationalEquivalenceClass(toric_variety(cc), polynomial(chow_ring(toric_variety(cc)), cc))
 
 
 @doc Markdown.doc"""
-    RationalEquivalenceClass(cc::ClosedSubvarietyOfToricVariety)
+    rational_equivalence_class(sv::ClosedSubvarietyOfToricVariety)
 
 Construct the rational equivalence class of algebraic
 cycles of a closed subvariety of a normal toric variety.
@@ -164,11 +162,11 @@ julia> (x1, x2, y1, y2) = gens(cox_ring(ntv))
 julia> sv = ClosedSubvarietyOfToricVariety(ntv, [x1^2+x1*x2+x2^2, y2])
 A closed subvariety of a normal toric variety
 
-julia> RationalEquivalenceClass(sv)
+julia> rational_equivalence_class(sv)
 A rational equivalence class on a normal toric variety represented by 2V(x2,y2)
 ```
 """
-function RationalEquivalenceClass(sv::ClosedSubvarietyOfToricVariety)
+function rational_equivalence_class(sv::ClosedSubvarietyOfToricVariety)
     v = toric_variety(sv)
     indets = gens(chow_ring(v))
     mons = [[m for m in monomials(p)][1] for p in gens(defining_ideal(sv))]
@@ -188,6 +186,7 @@ function RationalEquivalenceClass(sv::ClosedSubvarietyOfToricVariety)
     classes = [coeffs[k]*RationalEquivalenceClass(v, new_mons[k]) for k in 1:length(mons)]
     return prod(classes)
 end
+
 
 ####################################################
 # 4: Addition, subtraction and scalar multiplication
@@ -233,7 +232,7 @@ function Base.:*(ac::RationalEquivalenceClass, sv::ClosedSubvarietyOfToricVariet
     if toric_variety(ac) !== toric_variety(sv)
         throw(ArgumentError("The rational equivalence class and the closed subvariety must be defined on the same toric variety, i.e. the same OSCAR variable"))
     end
-    return ac * RationalEquivalenceClass(sv)
+    return ac * rational_equivalence_class(sv)
 end
 
 
@@ -241,7 +240,7 @@ function Base.:*(sv::ClosedSubvarietyOfToricVariety, ac::RationalEquivalenceClas
     if toric_variety(ac) !== toric_variety(sv)
         throw(ArgumentError("The rational equivalence class and the closed subvariety must be defined on the same toric variety, i.e. the same OSCAR variable"))
     end
-    return ac * RationalEquivalenceClass(sv)
+    return ac * rational_equivalence_class(sv)
 end
 
 
@@ -249,7 +248,7 @@ function Base.:*(sv1::ClosedSubvarietyOfToricVariety, sv2::ClosedSubvarietyOfTor
     if toric_variety(sv1) !== toric_variety(sv2)
         throw(ArgumentError("The closed subvarieties must be defined on the same toric variety, i.e. the same OSCAR variable"))
     end
-    return RationalEquivalenceClass(sv1) * RationalEquivalenceClass(sv2)
+    return rational_equivalence_class(sv1) * rational_equivalence_class(sv2)
 end
 
 

--- a/src/ToricVarieties/AlgebraicCycles/constructors.jl
+++ b/src/ToricVarieties/AlgebraicCycles/constructors.jl
@@ -159,7 +159,7 @@ julia> (x1, x2, y1, y2) = gens(cox_ring(ntv))
  y1
  y2
 
-julia> sv = ClosedSubvarietyOfToricVariety(ntv, [x1^2+x1*x2+x2^2, y2])
+julia> sv = closed_subvariety_of_toric_variety(ntv, [x1^2+x1*x2+x2^2, y2])
 A closed subvariety of a normal toric variety
 
 julia> rational_equivalence_class(sv)

--- a/src/ToricVarieties/AlgebraicCycles/methods.jl
+++ b/src/ToricVarieties/AlgebraicCycles/methods.jl
@@ -6,7 +6,7 @@ function Base.:*(ac::RationalEquivalenceClass, sv::ClosedSubvarietyOfToricVariet
     if toric_variety(ac) !== toric_variety(sv)
         throw(ArgumentError("The rational equivalence class and the closed subvariety must be defined on the same toric variety, i.e. the same OSCAR variable"))
     end
-    return ac * RationalEquivalenceClass(sv)
+    return ac * rational_equivalence_class(sv)
 end
 
 
@@ -14,5 +14,5 @@ function Base.:*(sv::ClosedSubvarietyOfToricVariety, ac::RationalEquivalenceClas
     if toric_variety(ac) !== toric_variety(sv)
         throw(ArgumentError("The rational equivalence class and the closed subvariety must be defined on the same toric variety, i.e. the same OSCAR variable"))
     end
-    return ac * RationalEquivalenceClass(sv)
+    return ac * rational_equivalence_class(sv)
 end

--- a/src/ToricVarieties/CohomologyClasses/attributes.jl
+++ b/src/ToricVarieties/CohomologyClasses/attributes.jl
@@ -15,7 +15,7 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
-julia> cc = CohomologyClass(d)
+julia> cc = cohomology_class(d)
 A cohomology class on a normal toric variety given by 6*x3 + e1 + 7*e2
 
 julia> toric_variety(cc)
@@ -39,7 +39,7 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
-julia> cc = CohomologyClass(d)
+julia> cc = cohomology_class(d)
 A cohomology class on a normal toric variety given by 6*x3 + e1 + 7*e2
 
 julia> coefficients(cc)
@@ -66,7 +66,7 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
-julia> cc = CohomologyClass(d)
+julia> cc = cohomology_class(d)
 A cohomology class on a normal toric variety given by 6*x3 + e1 + 7*e2
 
 julia> exponents(cc)
@@ -93,7 +93,7 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
-julia> cc = CohomologyClass(d)
+julia> cc = cohomology_class(d)
 A cohomology class on a normal toric variety given by 6*x3 + e1 + 7*e2
 
 julia> polynomial(cc)
@@ -118,7 +118,7 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
-julia> cc = CohomologyClass(d)
+julia> cc = cohomology_class(d)
 A cohomology class on a normal toric variety given by 6*x3 + e1 + 7*e2
 
 julia> R, _ = PolynomialRing(QQ, 5)

--- a/src/ToricVarieties/CohomologyClasses/constructors.jl
+++ b/src/ToricVarieties/CohomologyClasses/constructors.jl
@@ -20,7 +20,28 @@ export CohomologyClass
 ######################
 
 @doc Markdown.doc"""
-    CohomologyClass(d::ToricDivisor)
+    cohomology_class(v::AbstractNormalToricVariety, p::MPolyQuoElem)
+
+Construct the toric cohomology class
+on the toric variety `v` corresponding
+to the polynomial `p`. Note that `p` must
+reside in the cohomology ring of `v`.
+
+# Examples
+```jldoctest
+julia> P2 = projective_space(NormalToricVariety, 2)
+A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
+
+julia> c = cohomology_class(P2, gens(cohomology_ring(P2))[1])
+A cohomology class on a normal toric variety given by x1
+```
+"""
+cohomology_class(v::AbstractNormalToricVariety, p::MPolyQuoElem) = CohomologyClass(v, p)
+export cohomology_class
+
+
+@doc Markdown.doc"""
+    cohomology_class(d::ToricDivisor)
 
 Construct the toric cohomology class
 corresponding to the toric divisor `d`.
@@ -33,11 +54,11 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> d = ToricDivisor(P2, [1, 2, 3])
 A torus-invariant, non-prime divisor on a normal toric variety
 
-julia> CohomologyClass(d)
+julia> cohomology_class(d)
 A cohomology class on a normal toric variety given by 6*x3
 ```
 """
-function CohomologyClass(d::ToricDivisor)
+function cohomology_class(d::ToricDivisor)
     indets = gens(cohomology_ring(toric_variety(d)))
     coeff_ring = coefficient_ring(toric_variety(d))
     poly = sum(coeff_ring(coefficients(d)[k]) * indets[k] for k in 1:length(indets))
@@ -46,7 +67,7 @@ end
 
 
 @doc Markdown.doc"""
-    CohomologyClass(c::ToricDivisorClass)
+    cohomology_class(c::ToricDivisorClass)
 
 Construct the toric cohomology class
 corresponding to the toric divisor class `c`.
@@ -59,15 +80,15 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> tdc = ToricDivisorClass(P2, [2])
 A divisor class on a normal toric variety
 
-julia> CohomologyClass(tdc)
+julia> cohomology_class(tdc)
 A cohomology class on a normal toric variety given by 2*x3
 ```
 """
-CohomologyClass(c::ToricDivisorClass) = CohomologyClass(toric_divisor(c))
+cohomology_class(c::ToricDivisorClass) = cohomology_class(toric_divisor(c))
 
 
 @doc Markdown.doc"""
-    CohomologyClass(l::ToricLineBundle)
+    cohomology_class(l::ToricLineBundle)
 
 Construct the toric cohomology class
 corresponding to the toric line bundle `l`.
@@ -80,11 +101,11 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> l = ToricLineBundle(P2, [2])
 A toric line bundle on a normal toric variety
 
-julia> polynomial(CohomologyClass(l))
+julia> polynomial(cohomology_class(l))
 2*x3
 ```
 """
-CohomologyClass(l::ToricLineBundle) = CohomologyClass(toric_divisor(l))
+cohomology_class(l::ToricLineBundle) = cohomology_class(toric_divisor(l))
 
 
 #################################

--- a/src/ToricVarieties/CohomologyClasses/methods.jl
+++ b/src/ToricVarieties/CohomologyClasses/methods.jl
@@ -18,7 +18,7 @@ julia> (x1, x2, x3, e1, e2, e3) = gens(cohomology_ring(dP3))
  e2
  e3
 
-julia> c = CohomologyClass(dP3, e3*e3 + e3)
+julia> c = cohomology_class(dP3, e3*e3 + e3)
 A cohomology class on a normal toric variety given by e3^2 + e3
 
 julia> integrate(c)
@@ -34,7 +34,7 @@ julia> (x1, x2, x3, x4) = gens(cohomology_ring(F3))
  t2
  x2
 
-julia> c = CohomologyClass(F3, x1*x2 + x3*x4)
+julia> c = cohomology_class(F3, x1*x2 + x3*x4)
 A cohomology class on a normal toric variety given by 2//3*x2^2
 
 julia> integrate(c)

--- a/src/ToricVarieties/CohomologyClasses/special_attributes.jl
+++ b/src/ToricVarieties/CohomologyClasses/special_attributes.jl
@@ -62,7 +62,7 @@ export volume_form
 
 @attr function _intersection_form_via_exponents(v::NormalToricVariety)
     # extract the cohomology classes corresponding to the torus-invariant prime divisors
-    generators = [CohomologyClass(d) for d in torusinvariant_prime_divisors(v)]
+    generators = [cohomology_class(d) for d in torusinvariant_prime_divisors(v)]
     
     # find combinations of those classes that we have to integrate
     S, _ = PolynomialRing(QQ, ["g$(i)" for i in 1:length(generators)], cached=false)

--- a/src/ToricVarieties/CyclicQuotientSingularities/CyclicQuotientSingularities.jl
+++ b/src/ToricVarieties/CyclicQuotientSingularities/CyclicQuotientSingularities.jl
@@ -24,14 +24,14 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    CyclicQuotientSingularity(n::fmpz, q::fmpz)
+    cyclic_quotient_singularity(n::fmpz, q::fmpz)
 
 Return the cyclic quotient singularity for the parameters $n$ and $q$, with
 $0<q<n$ and $q, n$ coprime.
 
 # Examples
 ```jldoctest
-julia> cqs = CyclicQuotientSingularity(7, 5)
+julia> cqs = cyclic_quotient_singularity(7, 5)
 The cyclic quotient singularity Y(7, 5)
 
 julia> is_affine(cqs)
@@ -41,7 +41,7 @@ julia> is_smooth(cqs)
 false
 ```
 """
-function CyclicQuotientSingularity(n::fmpz, q::fmpz)
+function cyclic_quotient_singularity(n::T, q::T) where {T <: IntegerUnion}
     n > 0 || error("n (=$(n)) must be positive")
     q > 0 || error("q (=$(q)) must be positive")
     q < n || error("q must be smaller than n (q=$(q) >= n=$(n))")
@@ -49,7 +49,7 @@ function CyclicQuotientSingularity(n::fmpz, q::fmpz)
     pmntv = Polymake.fulton.CyclicQuotient(N=convert(Polymake.Integer, n), Q=convert(Polymake.Integer, q))
     return CyclicQuotientSingularity(pmntv, Dict())
 end
-CyclicQuotientSingularity(n::Int64, q::Int64) = CyclicQuotientSingularity(fmpz(n), fmpz(q))
+export cyclic_quotient_singularity
 
 
 @doc Markdown.doc"""
@@ -66,7 +66,7 @@ differs in sign from what is commonly known as continued fraction.
 
 # Examples
 ```jldoctest
-julia> cqs = CyclicQuotientSingularity(7, 5)
+julia> cqs = cyclic_quotient_singularity(7, 5)
 The cyclic quotient singularity Y(7, 5)
 
 julia> cf = continued_fraction_hirzebruch_jung(cqs)
@@ -99,7 +99,7 @@ differs in sign from what is commonly known as continued fraction.
 
 # Examples
 ```jldoctest
-julia> cqs = CyclicQuotientSingularity(7, 5)
+julia> cqs = cyclic_quotient_singularity(7, 5)
 The cyclic quotient singularity Y(7, 5)
 
 julia> dcf = dual_continued_fraction_hirzebruch_jung(cqs)
@@ -130,7 +130,7 @@ differs in sign from what is commonly known as continued fraction.
 
 # Examples
 ```jldoctest
-julia> cqs = CyclicQuotientSingularity(7, 5)
+julia> cqs = cyclic_quotient_singularity(7, 5)
 The cyclic quotient singularity Y(7, 5)
 
 julia> v = continued_fraction_hirzebruch_jung(cqs)

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -714,7 +714,7 @@ export normal_toric_varieties_from_star_triangulations
 ############################
 
 @doc Markdown.doc"""
-    NormalToricVarietyFromGLSM(charges::fmpz_mat; set_attributes::Bool = true)
+    normal_toric_varieties_from_glsm(charges::fmpz_mat; set_attributes::Bool = true)
 
 Witten's Generalized-Sigma models (GLSM) [Wit88](@cite)
 originally sparked interest in the physics community in toric varieties.
@@ -742,16 +742,16 @@ julia> charges = [[1, 1, 1]]
 1-element Vector{Vector{Int64}}:
  [1, 1, 1]
 
-julia> NormalToricVarietyFromGLSM(charges)
+julia> normal_toric_varieties_from_glsm(charges)
 1-element Vector{NormalToricVariety}:
  A normal toric variety
 ```
 
 For convenience, we also support:
-- NormalToricVarietyFromGLSM(charges::Vector{Vector{Int}})
-- NormalToricVarietyFromGLSM(charges::Vector{Vector{fmpz}})
+- normal_toric_varieties_from_glsm(charges::Vector{Vector{Int}})
+- normal_toric_varieties_from_glsm(charges::Vector{Vector{fmpz}})
 """
-function NormalToricVarietyFromGLSM(charges::fmpz_mat; set_attributes::Bool = true)
+function normal_toric_varieties_from_glsm(charges::fmpz_mat; set_attributes::Bool = true)
     # compute the map from Div_T -> Cl
     source = free_abelian_group(ncols(charges))
     range = free_abelian_group(nrows(charges))
@@ -776,8 +776,8 @@ function NormalToricVarietyFromGLSM(charges::fmpz_mat; set_attributes::Bool = tr
     p = convex_hull(pts)
     return normal_toric_varieties_from_star_triangulations(p; set_attributes = set_attributes)
 end
-NormalToricVarietyFromGLSM(charges::Vector{Vector{T}}; set_attributes::Bool = true) where {T <: IntegerUnion} = NormalToricVarietyFromGLSM(matrix(ZZ, charges); set_attributes = set_attributes)
-export NormalToricVarietyFromGLSM
+normal_toric_varieties_from_glsm(charges::Vector{Vector{T}}; set_attributes::Bool = true) where {T <: IntegerUnion} = normal_toric_varieties_from_glsm(matrix(ZZ, charges); set_attributes = set_attributes)
+export normal_toric_varieties_from_glsm
 
 
 ############################

--- a/src/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -661,7 +661,7 @@ end
 ############################
 
 @doc Markdown.doc"""
-    NormalToricVarietiesFromStarTriangulations(P::Polyhedron; set_attributes::Bool = true)
+    normal_toric_varieties_from_star_triangulations(P::Polyhedron; set_attributes::Bool = true)
 
 Returns the list of toric varieties obtained from fine regular
 star triangulations of the polyhedron P. With this we can
@@ -672,7 +672,7 @@ compute the two phases of the famous conifold transition.
 julia> P = convex_hull([0 0 0; 0 0 1; 1 0 1; 1 1 1; 0 1 1])
 A polyhedron in ambient dimension 3
 
-julia> (v1, v2) = NormalToricVarietiesFromStarTriangulations(P::Polyhedron)
+julia> (v1, v2) = normal_toric_varieties_from_star_triangulations(P::Polyhedron)
 2-element Vector{NormalToricVariety}:
  A normal toric variety
  A normal toric variety
@@ -684,7 +684,7 @@ julia> stanley_reisner_ideal(v2)
 ideal(x1*x3)
 ```
 """
-function NormalToricVarietiesFromStarTriangulations(P::Polyhedron; set_attributes::Bool = true)
+function normal_toric_varieties_from_star_triangulations(P::Polyhedron; set_attributes::Bool = true)
     # triangulate the polyhedron
     trias = star_triangulations(P)
     
@@ -706,7 +706,7 @@ function NormalToricVarietiesFromStarTriangulations(P::Polyhedron; set_attribute
     # construct the varieties
     return [normal_toric_variety(PolyhedralFan(integral_rays, cones; non_redundant = true), set_attributes = set_attributes) for cones in max_cones]
 end
-export NormalToricVarietiesFromStarTriangulations
+export normal_toric_varieties_from_star_triangulations
 
 
 ############################
@@ -774,7 +774,7 @@ function NormalToricVarietyFromGLSM(charges::fmpz_mat; set_attributes::Bool = tr
     
     # construct polyhedron
     p = convex_hull(pts)
-    return NormalToricVarietiesFromStarTriangulations(p; set_attributes = set_attributes)
+    return normal_toric_varieties_from_star_triangulations(p; set_attributes = set_attributes)
 end
 NormalToricVarietyFromGLSM(charges::Vector{Vector{T}}; set_attributes::Bool = true) where {T <: IntegerUnion} = NormalToricVarietyFromGLSM(matrix(ZZ, charges); set_attributes = set_attributes)
 export NormalToricVarietyFromGLSM

--- a/src/ToricVarieties/Subvarieties/attributes.jl
+++ b/src/ToricVarieties/Subvarieties/attributes.jl
@@ -18,7 +18,7 @@ julia> f2 = hirzebruch_surface(2);
 
 julia> (t1, x1, t2, x2) = gens(cox_ring(f2));
 
-julia> c = ClosedSubvarietyOfToricVariety(f2, [t1])
+julia> c = closed_subvariety_of_toric_variety(f2, [t1])
 A closed subvariety of a normal toric variety
 
 julia> toric_variety(c) == f2
@@ -44,7 +44,7 @@ julia> f2 = hirzebruch_surface(2);
 
 julia> (t1, x1, t2, x2) = gens(cox_ring(f2));
 
-julia> c = ClosedSubvarietyOfToricVariety(f2, [t1])
+julia> c = closed_subvariety_of_toric_variety(f2, [t1])
 A closed subvariety of a normal toric variety
 
 julia> defining_ideal(c) == ideal([t1])
@@ -71,7 +71,7 @@ julia> f2 = hirzebruch_surface(2);
 
 julia> (t1, x1, t2, x2) = gens(cox_ring(f2));
 
-julia> c = ClosedSubvarietyOfToricVariety(f2, [t1])
+julia> c = closed_subvariety_of_toric_variety(f2, [t1])
 A closed subvariety of a normal toric variety
 
 julia> radical(c) == ideal([t1])

--- a/src/ToricVarieties/Subvarieties/constructors.jl
+++ b/src/ToricVarieties/Subvarieties/constructors.jl
@@ -23,7 +23,7 @@ export ClosedSubvarietyOfToricVariety
 ##############################################################
 
 @doc Markdown.doc"""
-    ClosedSubvarietyOfToricVariety(toric_variety::AbstractNormalToricVariety, defining_polynomials::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}})
+    closed_subvariety_of_toric_variety(toric_variety::AbstractNormalToricVariety, defining_polynomials::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}})
 
 Construct the closed subvariety of a simplicial normal toric variety.
 The defining data for the closed subvariety is a list of homogeneous
@@ -39,12 +39,35 @@ julia> f2 = hirzebruch_surface(2);
 
 julia> (t1, x1, t2, x2) = gens(cox_ring(f2));
 
-julia> ClosedSubvarietyOfToricVariety(f2, [t1])
+julia> closed_subvariety_of_toric_variety(f2, [t1])
 A closed subvariety of a normal toric variety
 ```
 """
-ClosedSubvarietyOfToricVariety(toric_variety::AbstractNormalToricVariety, defining_polynomials::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}}) = ClosedSubvarietyOfToricVariety(toric_variety, ideal(defining_polynomials))
-export ClosedSubvarietyOfToricVariety
+closed_subvariety_of_toric_variety(toric_variety::AbstractNormalToricVariety, defining_polynomials::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}}) = ClosedSubvarietyOfToricVariety(toric_variety, ideal(defining_polynomials))
+export closed_subvariety_of_toric_variety
+
+
+@doc Markdown.doc"""
+    closed_subvariety_of_toric_variety(toric_variety::AbstractNormalToricVariety, defining_ideal::MPolyIdeal)
+
+Construct the closed subvariety of a simplicial normal toric variety.
+The defining data for the closed subvariety is an ideal of the Cox ring of the
+toric variety in question. By proposition 5.2.4 in
+[CLS11](@cite) every closed subvariety of a simplicial toric variety
+arises in this way.
+
+# Examples
+```jldoctest
+julia> f2 = hirzebruch_surface(2);
+
+julia> (t1, x1, t2, x2) = gens(cox_ring(f2));
+
+julia> closed_subvariety_of_toric_variety(f2, ideal([t1]))
+A closed subvariety of a normal toric variety
+```
+"""
+closed_subvariety_of_toric_variety(toric_variety::AbstractNormalToricVariety, defining_ideal::MPolyIdeal) = ClosedSubvarietyOfToricVariety(toric_variety, defining_ideal)
+export closed_subvariety_of_toric_variety
 
 
 ######################

--- a/src/ToricVarieties/Subvarieties/properties.jl
+++ b/src/ToricVarieties/Subvarieties/properties.jl
@@ -14,13 +14,13 @@ julia> f2 = hirzebruch_surface(2);
 
 julia> (t1, x1, t2, x2) = gens(cox_ring(f2));
 
-julia> c = ClosedSubvarietyOfToricVariety(f2, [t1])
+julia> c = closed_subvariety_of_toric_variety(f2, [t1])
 A closed subvariety of a normal toric variety
 
 julia> is_empty(c)
 false
 
-julia> c2 = ClosedSubvarietyOfToricVariety(f2, [x1,x2])
+julia> c2 = closed_subvariety_of_toric_variety(f2, [x1,x2])
 A closed subvariety of a normal toric variety
 
 julia> is_empty(c2)

--- a/test/ToricVarieties/algebraic_cycles.jl
+++ b/test/ToricVarieties/algebraic_cycles.jl
@@ -19,7 +19,7 @@ using Test
     
     dP1 = del_pezzo_surface(1; set_attributes)
     (u1, u2, u3, u4) = gens(cohomology_ring(dP1))
-    ac2 = rational_equivalence_class(CohomologyClass(dP1, u1))
+    ac2 = rational_equivalence_class(cohomology_class(dP1, u1))
     
     dP3 = del_pezzo_surface(3; set_attributes)
     (x1, e1, x2, e3, x3, e2) = gens(cohomology_ring(dP3))

--- a/test/ToricVarieties/algebraic_cycles.jl
+++ b/test/ToricVarieties/algebraic_cycles.jl
@@ -12,23 +12,23 @@ using Test
     (xx1, xx2, yy1, yy2) = gens(cox_ring(ntv));
     sv1 = ClosedSubvarietyOfToricVariety(ntv, [xx1])
     sv2 = ClosedSubvarietyOfToricVariety(ntv, [xx1^2+xx1*xx2+xx2^2, yy2])
-    ac0 = RationalEquivalenceClass(ToricLineBundle(ntv, [1, 1]))
+    ac0 = rational_equivalence_class(ToricLineBundle(ntv, [1, 1]))
     
     F5 = hirzebruch_surface(5; set_attributes)
-    ac1 = RationalEquivalenceClass(DivisorOfCharacter(F5, [1, 2]))
+    ac1 = rational_equivalence_class(DivisorOfCharacter(F5, [1, 2]))
     
     dP1 = del_pezzo_surface(1; set_attributes)
     (u1, u2, u3, u4) = gens(cohomology_ring(dP1))
-    ac2 = RationalEquivalenceClass(CohomologyClass(dP1, u1))
+    ac2 = rational_equivalence_class(CohomologyClass(dP1, u1))
     
     dP3 = del_pezzo_surface(3; set_attributes)
     (x1, e1, x2, e3, x3, e2) = gens(cohomology_ring(dP3))
-    ac3 = RationalEquivalenceClass(canonical_bundle(dP3))
-    ac4 = RationalEquivalenceClass(ToricDivisorClass(dP3, [4, 3, 2, 1]))
+    ac3 = rational_equivalence_class(canonical_bundle(dP3))
+    ac4 = rational_equivalence_class(ToricDivisorClass(dP3, [4, 3, 2, 1]))
     
     @testset "Should fail" begin
-        @test_throws ArgumentError RationalEquivalenceClass(antv, [1, 2, 3])
-        @test_throws ArgumentError RationalEquivalenceClass(toric_variety(ac1), [1, 2, 3])
+        @test_throws ArgumentError rational_equivalence_class(antv, [1, 2, 3])
+        @test_throws ArgumentError rational_equivalence_class(toric_variety(ac1), [1, 2, 3])
         @test_throws ArgumentError ac1 + ac3
         @test_throws ArgumentError ac1 - ac3
         @test_throws ArgumentError ac1 * ac3
@@ -48,7 +48,7 @@ using Test
         @test polynomial(ac1) == 0
         @test parent(representative(ac1)) == cox_ring(toric_variety(ac1))
         @test is_trivial(cohomology_class(3*ac2)) == false
-        @test is_trivial(RationalEquivalenceClass(sv2)) == false
+        @test is_trivial(rational_equivalence_class(sv2)) == false
         @test length(coefficients(ac1)) == 0
         @test length(components(ac4-ac3)) == 4
         @test is_trivial(ac0*sv1) == false

--- a/test/ToricVarieties/algebraic_cycles.jl
+++ b/test/ToricVarieties/algebraic_cycles.jl
@@ -6,12 +6,12 @@ using Test
     antv = affine_normal_toric_variety(Oscar.positive_hull([1 1; -1 1]))
     
     P3 = projective_space(NormalToricVariety, 3; set_attributes)
-    sv0 = ClosedSubvarietyOfToricVariety(P3, [gens(cox_ring(P3))[1]^2])
+    sv0 = closed_subvariety_of_toric_variety(P3, [gens(cox_ring(P3))[1]^2])
     
     ntv = normal_toric_variety(Oscar.normal_fan(Oscar.cube(2)))
     (xx1, xx2, yy1, yy2) = gens(cox_ring(ntv));
-    sv1 = ClosedSubvarietyOfToricVariety(ntv, [xx1])
-    sv2 = ClosedSubvarietyOfToricVariety(ntv, [xx1^2+xx1*xx2+xx2^2, yy2])
+    sv1 = closed_subvariety_of_toric_variety(ntv, [xx1])
+    sv2 = closed_subvariety_of_toric_variety(ntv, [xx1^2+xx1*xx2+xx2^2, yy2])
     ac0 = rational_equivalence_class(ToricLineBundle(ntv, [1, 1]))
     
     F5 = hirzebruch_surface(5; set_attributes)

--- a/test/ToricVarieties/cyclic_quotient_singularities.jl
+++ b/test/ToricVarieties/cyclic_quotient_singularities.jl
@@ -3,7 +3,7 @@ using Test
 
 @testset "Cyclic Quotient Singularities" begin
     
-    cyc = CyclicQuotientSingularity(2, 1)
+    cyc = cyclic_quotient_singularity(2, 1)
     
     @testset "Basic properties" begin
         @test is_affine(cyc) == true

--- a/test/ToricVarieties/intersection_numbers.jl
+++ b/test/ToricVarieties/intersection_numbers.jl
@@ -10,12 +10,12 @@ using Test
     v = normal_toric_variety([[1, 0], [0, 1], [-1, -1]], [[1], [2], [3]]; set_attributes)
     
     dP1 = del_pezzo_surface(1; set_attributes)
-    c0 = CohomologyClass(dP1, gens(cohomology_ring(dP1))[1])
+    c0 = cohomology_class(dP1, gens(cohomology_ring(dP1))[1])
     
     dP3 = del_pezzo_surface(3; set_attributes)
     (x1, e1, x2, e3, x3, e2) = gens(cohomology_ring(dP3))
-    c1 = CohomologyClass(dP3, x1)
-    c2 = CohomologyClass(dP3, e1)
+    c1 = cohomology_class(dP3, x1)
+    c2 = cohomology_class(dP3, e1)
     
     product_space = hirzebruch_surface(5; set_attributes) * projective_space(NormalToricVariety, 2; set_attributes)
     
@@ -50,12 +50,12 @@ using Test
     end
     
     @testset "Intersection numbers on dP3" begin
-        @test integrate(CohomologyClass(dP3, e1*e1)) == -1
-        @test integrate(CohomologyClass(dP3, e2*e2)) == -1
-        @test integrate(CohomologyClass(dP3, e3*e3)) == -1
-        @test integrate(CohomologyClass(dP3, x1*x1)) == -1
-        @test integrate(CohomologyClass(dP3, x2*x2)) == -1
-        @test integrate(CohomologyClass(dP3, x3*x3)) == -1
+        @test integrate(cohomology_class(dP3, e1*e1)) == -1
+        @test integrate(cohomology_class(dP3, e2*e2)) == -1
+        @test integrate(cohomology_class(dP3, e3*e3)) == -1
+        @test integrate(cohomology_class(dP3, x1*x1)) == -1
+        @test integrate(cohomology_class(dP3, x2*x2)) == -1
+        @test integrate(cohomology_class(dP3, x3*x3)) == -1
         @test integrate(c1) == 0
         @test integrate(c1^2+c1-3//4*c1*c1) == -1//4
         @test length(intersection_form(dP3)) == 21

--- a/test/ToricVarieties/normal_toric_varieties.jl
+++ b/test/ToricVarieties/normal_toric_varieties.jl
@@ -7,7 +7,7 @@ using Test
     set_coordinate_names(ntv, ["x1", "x2", "y1", "y2"])
     ntv2 = normal_toric_variety(Oscar.cube(2); set_attributes)
     ntv3 = NormalToricVarietyFromGLSM(matrix(ZZ, [[1, 1, 1]]); set_attributes)
-    ntv4 = NormalToricVarietiesFromStarTriangulations(convex_hull([0 0 0; 0 0 1; 1 0 1; 1 1 1; 0 1 1]); set_attributes)
+    ntv4 = normal_toric_varieties_from_star_triangulations(convex_hull([0 0 0; 0 0 1; 1 0 1; 1 1 1; 0 1 1]); set_attributes)
     ntv5 = normal_toric_variety(polarize(Polyhedron(Polymake.polytope.rand_sphere(5, 60; seed=42))); set_attributes)
     
     @testset "Basic properties" begin

--- a/test/ToricVarieties/normal_toric_varieties.jl
+++ b/test/ToricVarieties/normal_toric_varieties.jl
@@ -6,7 +6,7 @@ using Test
     ntv = normal_toric_variety(Oscar.normal_fan(Oscar.cube(2)); set_attributes)
     set_coordinate_names(ntv, ["x1", "x2", "y1", "y2"])
     ntv2 = normal_toric_variety(Oscar.cube(2); set_attributes)
-    ntv3 = NormalToricVarietyFromGLSM(matrix(ZZ, [[1, 1, 1]]); set_attributes)
+    ntv3 = normal_toric_varieties_from_glsm(matrix(ZZ, [[1, 1, 1]]); set_attributes)
     ntv4 = normal_toric_varieties_from_star_triangulations(convex_hull([0 0 0; 0 0 1; 1 0 1; 1 1 1; 0 1 1]); set_attributes)
     ntv5 = normal_toric_variety(polarize(Polyhedron(Polymake.polytope.rand_sphere(5, 60; seed=42))); set_attributes)
     

--- a/test/ToricVarieties/subvarieties.jl
+++ b/test/ToricVarieties/subvarieties.jl
@@ -7,15 +7,15 @@ using Test
     
     ntv = normal_toric_variety(Oscar.normal_fan(Oscar.cube(2)); set_attributes)
     (x1, x2, y1, y2) = gens(cox_ring(ntv));
-    sv1 = ClosedSubvarietyOfToricVariety(ntv, [x1])
-    sv2 = ClosedSubvarietyOfToricVariety(ntv, [x1^2+x1*x2+x2^2, y2])
+    sv1 = closed_subvariety_of_toric_variety(ntv, [x1])
+    sv2 = closed_subvariety_of_toric_variety(ntv, [x1^2+x1*x2+x2^2, y2])
     
     P3 = projective_space(NormalToricVariety, 3; set_attributes)
-    sv3 = ClosedSubvarietyOfToricVariety(P3, [gens(cox_ring(P3))[1]^2])
+    sv3 = closed_subvariety_of_toric_variety(P3, [gens(cox_ring(P3))[1]^2])
     
     @testset "Should fail" begin
-        @test_throws ArgumentError ClosedSubvarietyOfToricVariety(ntv, [x1 - y1])
-        @test_throws ArgumentError ClosedSubvarietyOfToricVariety(antv, [gens(cox_ring(antv))[1]])
+        @test_throws ArgumentError closed_subvariety_of_toric_variety(ntv, [x1 - y1])
+        @test_throws ArgumentError closed_subvariety_of_toric_variety(antv, [gens(cox_ring(antv))[1]])
     end
     
     @testset "Basic properties" begin


### PR DESCRIPTION
For my convenience, this includes https://github.com/oscar-system/Oscar.jl/pull/1958. This other PR should be merged first.

The following are renamed:
* `NormalToricVarietiesFromStarTriangulations` -> `normal_toric_varieties_from_star_triangulations`,
* `NormalToricVarietyFromGLSM` -> `normal_toric_varieties_from_glsm`,
* `RationalEquivalenceClass` -> `rational_equivalence_class`,
* `CohomologyClass` -> `cohomology_class`,
* `CyclicQuotientSingularity` -> `cyclic_quotient_singularity`,
* `ClosedSubvarietiesOfToricVarieties` -> `closed_subvarieties_of_toric_varieties`.

This is ~~still work in progress~~ ready for review.