### PR TITLE
import only defined names from Hecke

### DIFF
--- a/src/imports.jl
+++ b/src/imports.jl
@@ -157,7 +157,7 @@ exclude = [:Nemo, :AbstractAlgebra, :Rational, :change_uniformizer,
     :exponents, :monomials, :leading_monomial, :terms, :leading_term, :tail]
 
 for i in names(Hecke)
-  i in exclude && continue
+  (i in exclude || !isdefined(Hecke, i)) && continue
   eval(Meta.parse("import Hecke." * string(i)))
   eval(Expr(:export, i))
 end


### PR DESCRIPTION
`names(Hecke)` may contain names that are exported but are actually not defined