### PR TITLE
Add contact section to introduction page of all specialized chapters in OSCAR

### DIFF
--- a/docs/src/AlgebraicGeometry/Curves/para_rational_curves.md
+++ b/docs/src/AlgebraicGeometry/Curves/para_rational_curves.md
@@ -89,7 +89,12 @@ rational_point_conic(D::ProjPlaneCurve{fmpq})
 ```
 
 
+## Contact
 
+Please direct questions about this part of OSCAR to the following people:
+* [Janko Böhm](https://www.mathematik.uni-kl.de/~boehm/),
+* [Wolfram Decker](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-wolfram-decker/seite).
 
+You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
 
-
+Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).

--- a/docs/src/AlgebraicGeometry/Schemes/intro.md
+++ b/docs/src/AlgebraicGeometry/Schemes/intro.md
@@ -1,0 +1,35 @@
+```@meta
+CurrentModule = Oscar
+```
+
+```@setup oscar
+using Oscar
+```
+
+```@contents
+Pages = ["intro.md"]
+```
+
+# Introduction
+
+## Content
+
+The schemes part of OSCAR comprises algorithms addressing affine schemes. More functionality
+(e.g. for general covered schemes and toric schemes) exists in experimental state.
+
+
+## Status
+
+This project is work-in-progress.
+
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Simon Brandhorst](https://www.math.uni-sb.de/ag/brandhorst/index.php?lang=en).
+* [Anne Frühbis-Krüger](https://uol.de/anne-fruehbis-krueger),
+* [Matthias Zach](https://www.mathematik.uni-kl.de/en/agag/people/members),
+
+You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).

--- a/docs/src/AlgebraicGeometry/Surfaces/K3Surfaces.md
+++ b/docs/src/AlgebraicGeometry/Surfaces/K3Surfaces.md
@@ -40,3 +40,13 @@ adjacent_chamber(D::K3Chamber, v::fmpz_mat)
 separating_hyperplanes(S::ZLat, v::fmpq_mat, h::fmpq_mat, d)
 has_zero_entropy
 ```
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Simon Brandhorst](https://www.math.uni-sb.de/ag/brandhorst/index.php?lang=en).
+* [Matthias Zach](https://www.mathematik.uni-kl.de/en/agag/people/members),
+
+You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).

--- a/docs/src/AlgebraicGeometry/intro.md
+++ b/docs/src/AlgebraicGeometry/intro.md
@@ -12,10 +12,10 @@ Pages = ["intro.md"]
 
 # Introduction
 
-In this chapter, we introduce structures and functionality for dealing with varieties, sheaves, and schemes.
+In this chapter, we introduce structures and functionality for algebraic geometry. Among others, we support:
+* schemes,
+* toric varieties,
+* toric schemes,
+* tropical geometry.
 
-This part of OSCAR is at the very beginning of its development.
-
-We refer to the individual sections for references which provide details on theory and algorithms.
-
-
+We refer to the individual sections for more details.

--- a/docs/src/Combinatorics/intro.md
+++ b/docs/src/Combinatorics/intro.md
@@ -7,24 +7,20 @@ using Oscar
 ```
 
 ```@contents
-Pages = ["standard_constructions.md"]
+Pages = ["intro.md"]
 ```
 
-# Standard Constructions in Algebraic Geometry
-
-This page documents a collection of standard constructions in algebraic geometry
-available in OSCAR.
-
-## Grassmann Plücker Ideal
-```@docs
-grassmann_pluecker_ideal
-```
+# Introduction
 
 
 ## Contact
 
 Please direct questions about this part of OSCAR to the following people:
-* [Wolfram Decker](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-wolfram-decker).
+* Simplicial complexes: [Michael Joswig](https://page.math.tu-berlin.de/~joswig/),
+* Graphs: [Lars Kastner](https://lkastner.github.io/),
+* Matroids:
+    * [Benjamin Schröter](https://www.math.uni-frankfurt.de/~schroete/)
+    * [Lukas Kühne](https://www.math.uni-bielefeld.de/~lkuehne/).
 
 You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
 

--- a/docs/src/CommutativeAlgebra/intro.md
+++ b/docs/src/CommutativeAlgebra/intro.md
@@ -48,3 +48,12 @@ General textbooks offering details on theory and algorithms include:
 - [DL06](@cite)
 - [DP13](@cite)
 
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Wolfram Decker](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-wolfram-decker).
+
+You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).

--- a/docs/src/Experimental/ToricSchemes/intro.md
+++ b/docs/src/Experimental/ToricSchemes/intro.md
@@ -41,3 +41,7 @@ We aim for a robust interface between toric varieties and schemes.
 Please direct questions about this part of OSCAR to the following people:
 * [Martin Bies](https://martinbies.github.io/),
 * [Matthias Zach](https://www.mathematik.uni-kl.de/en/agag/people/members/seite).
+
+You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).

--- a/docs/src/Fields/intro.md
+++ b/docs/src/Fields/intro.md
@@ -29,3 +29,15 @@ General textbooks offering details on theory and algorithms include:
 - [LN97](@cite)
 - [Mar18](@cite)
 - [PZ97](@cite)
+
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Claus Fieker](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-claus-fieker),
+* [Tommy Hofmann](https://www.thofma.com/),
+* [Max Horn](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-max-horn).
+
+You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).

--- a/docs/src/Groups/intro.md
+++ b/docs/src/Groups/intro.md
@@ -26,3 +26,14 @@ The groups part of OSCAR provides functionality for handling
 General textbooks offering details on theory and algorithms include:
 - [Hup67](@cite)
 - [HEO05](@cite)
+
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Thomas Breuer](https://www.math.rwth-aachen.de/homes/Thomas.Breuer/),
+* [Max Horn](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-max-horn).
+
+You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).

--- a/docs/src/InvariantTheory/intro.md
+++ b/docs/src/InvariantTheory/intro.md
@@ -65,3 +65,15 @@ and the survey article
 - [DJ98](@cite)
 
 provide details on theory and algorithms as well as references.
+
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Wolfram Decker](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-wolfram-decker),
+* [Max Horn](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-max-horn),
+* [Johannes Schmitt](https://joschmitt.eu/).
+
+You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).

--- a/docs/src/LinearAlgebra/intro.md
+++ b/docs/src/LinearAlgebra/intro.md
@@ -23,3 +23,14 @@ The linear algebra part of OSCAR provides functionality for handling
 
 General textbooks offering details on theory and algorithms include:
 - ...
+
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Claus Fieker](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-claus-fieker),
+* [Tommy Hofmann](https://www.thofma.com/).
+
+You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).

--- a/docs/src/NoncommutativeAlgebra/intro.md
+++ b/docs/src/NoncommutativeAlgebra/intro.md
@@ -32,3 +32,13 @@ The textbooks
 and the thesis
 - [Lev05](@cite)
 offer details on theory and algorithms.
+
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Wolfram Decker](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-wolfram-decker).
+
+You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).

--- a/docs/src/NumberTheory/intro.md
+++ b/docs/src/NumberTheory/intro.md
@@ -21,3 +21,14 @@ General textbooks offering details on theory and algorithms include:
 - [Coh00](@cite)
 - [Mar18](@cite)
 - [PZ97](@cite)
+
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Claus Fieker](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-claus-fieker),
+* [Tommy Hofmann](https://www.thofma.com/).
+
+You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).

--- a/docs/src/PolyhedralGeometry/intro.md
+++ b/docs/src/PolyhedralGeometry/intro.md
@@ -133,3 +133,16 @@ can find details of the specification
 More details on the serialization, albeit concerning the older XML format, can be
 found in [GHJ16](@cite). Even though the underlying format changed to JSON, the
 abstract mathematical structure of the data files is still the same.
+
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Taylor Brysiewicz](https://sites.google.com/view/taylorbrysiewicz/home),
+* [Michael Joswig](https://page.math.tu-berlin.de/~joswig/),
+* [Lars Kastner](https://lkastner.github.io/),
+* Benjamin Lorenz.
+
+You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).

--- a/docs/src/Rings/intro.md
+++ b/docs/src/Rings/intro.md
@@ -24,3 +24,14 @@ various kinds of rings:
 
 General textbooks offering details on theory and algorithms include:
 - ...
+
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Claus Fieker](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-claus-fieker),
+* [Tommy Hofmann](https://www.thofma.com/).
+
+You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).

--- a/docs/src/StraightLinePrograms/intro.md
+++ b/docs/src/StraightLinePrograms/intro.md
@@ -205,3 +205,12 @@ false
 ```
 
 
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Thomas Breuer](https://www.math.rwth-aachen.de/homes/Thomas.Breuer/),
+* [Raphael Fourquet](https://github.com/rfourquet).
+
+You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).

--- a/docs/src/ToricVarieties/intro.md
+++ b/docs/src/ToricVarieties/intro.md
@@ -45,3 +45,7 @@ We follow [CLS11](@cite). Our long term goals include the following:
 Please direct questions about this part of OSCAR to the following people:
 * [Martin Bies](https://martinbies.github.io/),
 * [Lars Kastner](https://lkastner.github.io/).
+
+You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).

--- a/docs/src/TropicalGeometry/intro.md
+++ b/docs/src/TropicalGeometry/intro.md
@@ -11,6 +11,19 @@ Pages = ["intro.md"]
 
 This page lists the OSCAR features for tropical geometry, which are still at the very beginning of their development. For notation we refer to [MS15](@cite) and [Jos21](@cite).
 
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Lars Kastner](https://lkastner.github.io/),
+* [Marta Panizzut](https://martapanizzut.github.io/),
+* [Yue Ren](https://www.yueren.de/).
+
+You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+
+
 ## Tropical semirings
 
 ```@docs


### PR DESCRIPTION
Goal: Make it easy for users to get in touch with people that can provide support for specialized areas in OSCAR.

Note however, that this is *not* meant as credit system.

This PR aims to close https://github.com/oscar-system/Oscar.jl/issues/1938.

cc @fingolfin @fieker @wdecker @micjoswig 