### PR TITLE
ToricVarieties: Rename more constructors - Part 2

### DIFF
--- a/docs/src/ToricVarieties/ToricDivisorClasses.md
+++ b/docs/src/ToricVarieties/ToricDivisorClasses.md
@@ -19,7 +19,9 @@ Toric divisor classes are equivalence classes of Weil divisors modulo linear equ
 ### General constructors
 
 ```@docs
-ToricDivisorClass(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
+toric_divisor_class(v::AbstractNormalToricVariety, class::GrpAbFinGenElem)
+toric_divisor_class(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
+toric_divisor_class(td::ToricDivisor)
 ```
 
 ### Addition, subtraction and scalar multiplication

--- a/docs/src/ToricVarieties/ToricDivisors.md
+++ b/docs/src/ToricVarieties/ToricDivisors.md
@@ -21,7 +21,7 @@ correspond to the rays of the underlying fan.
 ### General constructors
 
 ```@docs
-DivisorOfCharacter(v::AbstractNormalToricVariety, character::Vector{T}) where {T <: IntegerUnion}
+divisor_of_character(v::AbstractNormalToricVariety, character::Vector{T}) where {T <: IntegerUnion}
 toric_divisor(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
 ```
 

--- a/docs/src/ToricVarieties/ToricDivisors.md
+++ b/docs/src/ToricVarieties/ToricDivisors.md
@@ -22,7 +22,7 @@ correspond to the rays of the underlying fan.
 
 ```@docs
 DivisorOfCharacter(v::AbstractNormalToricVariety, character::Vector{T}) where {T <: IntegerUnion}
-ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
+toric_divisor(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
 ```
 
 ### Addition, subtraction and scalar multiplication

--- a/docs/src/ToricVarieties/ToricLineBundles.md
+++ b/docs/src/ToricVarieties/ToricLineBundles.md
@@ -15,8 +15,10 @@ Pages = ["ToricLineBundles.md"]
 ### Generic constructors
 
 ```@docs
-ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{T}) where {T <: IntegerUnion}
-ToricLineBundle(v::AbstractNormalToricVariety, d::ToricDivisor)
+toric_line_bundle(v::AbstractNormalToricVariety, class::GrpAbFinGenElem)
+toric_line_bundle(v::AbstractNormalToricVariety, c::Vector{T}) where {T <: IntegerUnion}
+toric_line_bundle(v::AbstractNormalToricVariety, d::ToricDivisor)
+toric_line_bundle(d::ToricDivisor)
 ```
 
 ### Tensor products

--- a/docs/src/ToricVarieties/ToricMorphisms.md
+++ b/docs/src/ToricVarieties/ToricMorphisms.md
@@ -28,19 +28,19 @@ morphisms are exactly the toric morphisms.
 ### Generic constructors without specified codomain
 
 ```@docs
-ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Vector{Vector{T}}) where {T <: IntegerUnion}
-ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Matrix{T}) where {T <: IntegerUnion}
-ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::fmpz_mat)
-ToricMorphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap)
+toric_morphism(domain::AbstractNormalToricVariety, mapping_matrix::Vector{Vector{T}}) where {T <: IntegerUnion}
+toric_morphism(domain::AbstractNormalToricVariety, mapping_matrix::Matrix{T}) where {T <: IntegerUnion}
+toric_morphism(domain::AbstractNormalToricVariety, mapping_matrix::fmpz_mat)
+toric_morphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap)
 ```
 
 ### Generic constructors with specified codomain
 
 ```@docs
-ToricMorphism(v1::AbstractNormalToricVariety, mapping_matrix::Vector{Vector{T}}, v2::AbstractNormalToricVariety) where {T <: IntegerUnion}
-ToricMorphism(v1::AbstractNormalToricVariety, mapping_matrix::Matrix{T}, v2::AbstractNormalToricVariety) where {T <: IntegerUnion}
-ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::fmpz_mat, codomain::AbstractNormalToricVariety)
-ToricMorphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap, codomain::AbstractNormalToricVariety)
+toric_morphism(v1::AbstractNormalToricVariety, mapping_matrix::Vector{Vector{T}}, v2::AbstractNormalToricVariety) where {T <: IntegerUnion}
+toric_morphism(v1::AbstractNormalToricVariety, mapping_matrix::Matrix{T}, v2::AbstractNormalToricVariety) where {T <: IntegerUnion}
+toric_morphism(domain::AbstractNormalToricVariety, mapping_matrix::fmpz_mat, codomain::AbstractNormalToricVariety)
+toric_morphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap, codomain::AbstractNormalToricVariety)
 ```
 
 ### Special constructors

--- a/docs/src/ToricVarieties/ToricMorphisms.md
+++ b/docs/src/ToricVarieties/ToricMorphisms.md
@@ -46,7 +46,7 @@ toric_morphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap
 ### Special constructors
 
 ```@docs
-ToricIdentityMorphism(variety::AbstractNormalToricVariety)
+toric_identity_morphism(variety::AbstractNormalToricVariety)
 ```
 
 

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -142,3 +142,16 @@ function ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T
 end
 
 @deprecate DivisorOfCharacter(v::AbstractNormalToricVariety, character::Vector{T}) where {T <: IntegerUnion} divisor_of_character(v, character)
+
+function ToricDivisorClass(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
+    Base.depwarn("'ToricDivisorClass(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}' "*
+    "is deprecated, use 'toric_divisor_class(v::AbstractNormalToricVariety, coeffs::Vector{T}) "*
+    "where {T <: IntegerUnion}' instead.", :ToricDivisorClass)
+    toric_divisor_class(v, coeffs)
+end
+
+function ToricDivisorClass(td::ToricDivisor)
+    Base.depwarn("'ToricDivisorClass(td::ToricDivisor)' is deprecated, use "*
+    "'toric_divisor_class(td::ToricDivisor) instead.", :ToricDivisorClass)
+    toric_divisor_class(td)
+end

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -140,3 +140,5 @@ function ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T
     "where {T <: IntegerUnion}' instead.", :ToricDivisor)
     toric_divisor(v, coeffs)
 end
+
+@deprecate DivisorOfCharacter(v::AbstractNormalToricVariety, character::Vector{T}) where {T <: IntegerUnion} divisor_of_character(v, character)

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -175,3 +175,35 @@ function ToricLineBundle(d::ToricDivisor)
     " is deprecated, use 'toric_line_bundle(d::ToricDivisor)' instead", :ToricLineBundle)
     toric_line_bundle(d)
 end
+
+function ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Vector{Vector{T}}, codomain::T2=nothing) where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}
+    Base.depwarn("'ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Vector{Vector{T}}, codomain::T2=nothing) "*
+    "where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}' is depcreated, use "*
+    "'ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Vector{Vector{T}}, codomain::T2=nothing) "*
+    "where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}})' instead", :ToricMorphism)
+    toric_morphism(domain, mapping_matrix, codomain = codomain)
+end
+
+function ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Matrix{T}, codomain::T2=nothing) where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}
+    Base.depwarn("'ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Matrix{T}, codomain::T2=nothing) "*
+    "where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}' is deprecated, use "*
+    "'ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Matrix{T}, codomain::T2=nothing) "*
+    "where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}' instead", :ToricMorphism)
+    toric_morphism(domain, mapping_matrix, codomain = codomain)
+end
+
+function ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::fmpz_mat, codomain::T=nothing) where {T <: Union{AbstractNormalToricVariety, Nothing}}
+    Base.depwarn("'ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::fmpz_mat, codomain::T=nothing) "*
+    "where {T <: Union{AbstractNormalToricVariety, Nothing}}' is deprecated, use "*
+    "'ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::fmpz_mat, codomain::T=nothing) "*
+    "where {T <: Union{AbstractNormalToricVariety, Nothing}}' instead", :ToricMorphism)
+    toric_morphism(domain, mapping_matrix, codomain = codomain)
+end
+
+function ToricMorphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap, codomain::T=nothing) where {T <: Union{AbstractNormalToricVariety, Nothing}}
+    Base.depwarn("'ToricMorphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap, codomain::T=nothing) "*
+    "where {T <: Union{AbstractNormalToricVariety, Nothing}}' is deprecated, use "*
+    "'ToricMorphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap, codomain::T=nothing) "*
+    "where {T <: Union{AbstractNormalToricVariety, Nothing}}' instead", :ToricMorphism)
+    toric_morphism(domain, grid_morphism, codomain = codomain)
+end

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -132,4 +132,11 @@ function ClosedSubvarietyOfToricVariety(toric_variety::AbstractNormalToricVariet
     "'closed_subvariety_of_toric_variety(toric_variety::AbstractNormalToricVariety, "*
     "defining_polynomials::Vector{MPolyDecRingElem{fmpq, fmpq_mpoly}})' instead.", :ClosedSubvarietyOfToricVariety)
     closed_subvariety_of_toric_variety(toric_variety, defining_polynomials)
-  end
+end
+
+function ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
+    Base.depwarn("'ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}' "*
+    "is deprecated, use 'toric_divisor(v::AbstractNormalToricVariety, coeffs::Vector{T}) "*
+    "where {T <: IntegerUnion}' instead.", :ToricDivisor)
+    toric_divisor(v, coeffs)
+end

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -207,3 +207,5 @@ function ToricMorphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbF
     "where {T <: Union{AbstractNormalToricVariety, Nothing}}' instead", :ToricMorphism)
     toric_morphism(domain, grid_morphism, codomain = codomain)
 end
+
+@deprecate ToricIdentityMorphism(v::AbstractNormalToricVariety) toric_identity_morphism(v)

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -155,3 +155,23 @@ function ToricDivisorClass(td::ToricDivisor)
     "'toric_divisor_class(td::ToricDivisor) instead.", :ToricDivisorClass)
     toric_divisor_class(td)
 end
+
+function ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{T}) where {T <: IntegerUnion}
+    Base.depwarn("'ToricLineBundle(v::AbstractNormalToricVariety, c::Vector{T}) where {T <: IntegerUnion}'"*
+    " is deprecated, use 'toric_line_bundle(v::AbstractNormalToricVariety, c::Vector{T}) where {T <: IntegerUnion}' "*
+    "instead.", :ToricLineBundle)
+    toric_line_bundle(v, c)
+end
+
+function ToricLineBundle(v::AbstractNormalToricVariety, d::ToricDivisor)
+    Base.depwarn("'ToricLineBundle(v::AbstractNormalToricVariety, d::ToricDivisor)'"*
+    " is deprecated, use 'toric_line_bundle(v::AbstractNormalToricVariety, d::ToricDivisor)' "*
+    "instead.", :ToricLineBundle)
+    toric_line_bundle(v, d)
+end
+
+function ToricLineBundle(d::ToricDivisor)
+    Base.depwarn("'ToricLineBundle(d::ToricDivisor)'"*
+    " is deprecated, use 'toric_line_bundle(d::ToricDivisor)' instead", :ToricLineBundle)
+    toric_line_bundle(d)
+end

--- a/src/ToricVarieties/AlgebraicCycles/attributes.jl
+++ b/src/ToricVarieties/AlgebraicCycles/attributes.jl
@@ -14,7 +14,7 @@ equivalence class of algebraic cycles.
 julia> dP2 = del_pezzo_surface(2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
+julia> d = toric_divisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> ac = rational_equivalence_class(d)
@@ -41,7 +41,7 @@ rational equivalence class of algebraic cycles.
 julia> dP2 = del_pezzo_surface(2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
+julia> d = toric_divisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> ac = rational_equivalence_class(d)
@@ -71,7 +71,7 @@ ring if desired.
 julia> dP2 = del_pezzo_surface(2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
+julia> d = toric_divisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> ac = rational_equivalence_class(d)
@@ -127,7 +127,7 @@ Return a polynomial in the Cox ring mapping to `polynomial(ac)`.
 julia> dP2 = del_pezzo_surface(2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
+julia> d = toric_divisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> ac = rational_equivalence_class(d)
@@ -161,7 +161,7 @@ Return the coefficients of `polynomial(ac)`.
 julia> dP2 = del_pezzo_surface(2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
+julia> d = toric_divisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> ac = rational_equivalence_class(d)
@@ -197,7 +197,7 @@ class is identical to the one given to this method.
 julia> dP2 = del_pezzo_surface(2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
+julia> d = toric_divisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> ac = rational_equivalence_class(d)
@@ -236,7 +236,7 @@ equilvalence class of algebraic cycles.
 julia> dP2 = del_pezzo_surface(2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
+julia> d = toric_divisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> ac = rational_equivalence_class(d)

--- a/src/ToricVarieties/AlgebraicCycles/constructors.jl
+++ b/src/ToricVarieties/AlgebraicCycles/constructors.jl
@@ -103,7 +103,7 @@ Construct the toric algebraic cycle corresponding to the toric line bundle `l`.
 julia> P2 = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> l = ToricLineBundle(P2, [2])
+julia> l = toric_line_bundle(P2, [2])
 A toric line bundle on a normal toric variety
 
 julia> polynomial(rational_equivalence_class(l))

--- a/src/ToricVarieties/AlgebraicCycles/constructors.jl
+++ b/src/ToricVarieties/AlgebraicCycles/constructors.jl
@@ -83,7 +83,7 @@ Construct the algebraic cycle corresponding to the toric divisor class `c`.
 julia> P2 = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> tdc = ToricDivisorClass(P2, [2])
+julia> tdc = toric_divisor_class(P2, [2])
 A divisor class on a normal toric variety
 
 julia> rational_equivalence_class(tdc)

--- a/src/ToricVarieties/AlgebraicCycles/constructors.jl
+++ b/src/ToricVarieties/AlgebraicCycles/constructors.jl
@@ -55,7 +55,7 @@ Construct the rational equivalence class of algebraic cycles corresponding to th
 julia> P2 = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> d = ToricDivisor(P2, [1, 2, 3])
+julia> d = toric_divisor(P2, [1, 2, 3])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> rational_equivalence_class(d)

--- a/src/ToricVarieties/CohomologyClasses/attributes.jl
+++ b/src/ToricVarieties/CohomologyClasses/attributes.jl
@@ -12,7 +12,7 @@ Return the normal toric variety of the cohomology class `c`.
 julia> dP2 = del_pezzo_surface(2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
+julia> d = toric_divisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> cc = cohomology_class(d)
@@ -36,7 +36,7 @@ Return the coefficients of the cohomology class `c`.
 julia> dP2 = del_pezzo_surface(2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
+julia> d = toric_divisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> cc = cohomology_class(d)
@@ -63,7 +63,7 @@ Return the exponents of the cohomology class `c`.
 julia> dP2 = del_pezzo_surface(2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
+julia> d = toric_divisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> cc = cohomology_class(d)
@@ -90,7 +90,7 @@ toric variety `toric_variety(c)` which corresponds to `c`.
 julia> dP2 = del_pezzo_surface(2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
+julia> d = toric_divisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> cc = cohomology_class(d)
@@ -115,7 +115,7 @@ to the cohomology class `c`.
 julia> dP2 = del_pezzo_surface(2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> d = ToricDivisor(dP2, [1, 2, 3, 4, 5])
+julia> d = toric_divisor(dP2, [1, 2, 3, 4, 5])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> cc = cohomology_class(d)

--- a/src/ToricVarieties/CohomologyClasses/constructors.jl
+++ b/src/ToricVarieties/CohomologyClasses/constructors.jl
@@ -51,7 +51,7 @@ corresponding to the toric divisor `d`.
 julia> P2 = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> d = ToricDivisor(P2, [1, 2, 3])
+julia> d = toric_divisor(P2, [1, 2, 3])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> cohomology_class(d)

--- a/src/ToricVarieties/CohomologyClasses/constructors.jl
+++ b/src/ToricVarieties/CohomologyClasses/constructors.jl
@@ -98,7 +98,7 @@ corresponding to the toric line bundle `l`.
 julia> P2 = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> l = ToricLineBundle(P2, [2])
+julia> l = toric_line_bundle(P2, [2])
 A toric line bundle on a normal toric variety
 
 julia> polynomial(cohomology_class(l))

--- a/src/ToricVarieties/CohomologyClasses/constructors.jl
+++ b/src/ToricVarieties/CohomologyClasses/constructors.jl
@@ -77,7 +77,7 @@ corresponding to the toric divisor class `c`.
 julia> P2 = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> tdc = ToricDivisorClass(P2, [2])
+julia> tdc = toric_divisor_class(P2, [2])
 A divisor class on a normal toric variety
 
 julia> cohomology_class(tdc)

--- a/src/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -719,7 +719,7 @@ julia> torusinvariant_prime_divisors(p2)
     for i in 1:rank(ti_divisors)
         coeffs = zeros(Int, rank(ti_divisors))
         coeffs[i] = 1
-        push!(prime_divisors, ToricDivisor(v, coeffs))
+        push!(prime_divisors, toric_divisor(v, coeffs))
     end
     return prime_divisors
 end

--- a/src/ToricVarieties/ToricDivisorClasses/attributes.jl
+++ b/src/ToricVarieties/ToricDivisorClasses/attributes.jl
@@ -8,7 +8,7 @@ Return the element of the class group corresponding to the toric divisor class `
 julia> P2 = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> tdc = ToricDivisorClass(P2, class_group(P2)([1]))
+julia> tdc = toric_divisor_class(P2, class_group(P2)([1]))
 A divisor class on a normal toric variety
 
 julia> divisor_class(tdc)
@@ -31,7 +31,7 @@ Return the toric variety on which the toric divisor class `tdc` is defined.
 julia> P2 = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> tdc = ToricDivisorClass(P2, class_group(P2)([1]))
+julia> tdc = toric_divisor_class(P2, class_group(P2)([1]))
 A divisor class on a normal toric variety
 
 julia> toric_variety(tdc)
@@ -52,7 +52,7 @@ Constructs a toric divisor corresponding to the toric divisor class  `tdc`.
 julia> P2 = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> tdc = ToricDivisorClass(P2, class_group(P2)([1]))
+julia> tdc = toric_divisor_class(P2, class_group(P2)([1]))
 A divisor class on a normal toric variety
 
 julia> toric_divisor(tdc)

--- a/src/ToricVarieties/ToricDivisorClasses/attributes.jl
+++ b/src/ToricVarieties/ToricDivisorClasses/attributes.jl
@@ -62,6 +62,6 @@ A torus-invariant, prime divisor on a normal toric variety
 @attr ToricDivisor function toric_divisor(tdc::ToricDivisorClass)
     f = map_from_torusinvariant_weil_divisor_group_to_class_group(toric_variety(tdc))
     coeffs = vec([fmpz(x) for x in preimage(f, divisor_class(tdc)).coeff])
-    return ToricDivisor(toric_variety(tdc), coeffs)
+    return toric_divisor(toric_variety(tdc), coeffs)
 end
 export toric_divisor

--- a/src/ToricVarieties/ToricDivisorClasses/constructors.jl
+++ b/src/ToricVarieties/ToricDivisorClasses/constructors.jl
@@ -20,20 +20,40 @@ export ToricDivisorClass
 ######################
 
 @doc Markdown.doc"""
-    ToricDivisorClass(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
+    toric_divisor_class(v::AbstractNormalToricVariety, class::GrpAbFinGenElem)
 
-Construct the toric divisor class associated to a list of integers which specify an element of the class group of the normal toric variety `v`.
+Construct the toric divisor class associated to a group
+element of the class group of the normal toric variety `v`.
 
 # Examples
 ```jldoctest
 julia> P2 = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> tdc = ToricDivisorClass(P2, class_group(P2)([fmpz(1)]))
+julia> tdc = toric_divisor_class(P2, class_group(P2)([1]))
 A divisor class on a normal toric variety
 ```
 """
-ToricDivisorClass(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion} = ToricDivisorClass(v, class_group(v)([fmpz(c) for c in coeffs]))
+toric_divisor_class(v::AbstractNormalToricVariety, class::GrpAbFinGenElem) = ToricDivisorClass(v, class)
+export toric_divisor_class
+
+
+@doc Markdown.doc"""
+    toric_divisor_class(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
+
+Construct the toric divisor class associated to a list of integers which
+specify an element of the class group of the normal toric variety `v`.
+
+# Examples
+```jldoctest
+julia> P2 = projective_space(NormalToricVariety, 2)
+A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
+
+julia> tdc = toric_divisor_class(P2, class_group(P2)([fmpz(1)]))
+A divisor class on a normal toric variety
+```
+"""
+toric_divisor_class(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion} = ToricDivisorClass(v, class_group(v)([fmpz(c) for c in coeffs]))
 
 
 ######################
@@ -41,7 +61,7 @@ ToricDivisorClass(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: 
 ######################
 
 @doc Markdown.doc"""
-    ToricDivisorClass(td::ToricDivisor)
+    toric_divisor_class(td::ToricDivisor)
 
 Construct the toric divisor class associated to the element ... of the class group of the normal toric variety `v`.
 
@@ -53,14 +73,14 @@ A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric 
 julia> td = toric_divisor(P2, [1, 2, 3])
 A torus-invariant, non-prime divisor on a normal toric variety
 
-julia> tdc = ToricDivisorClass(td)
+julia> tdc = toric_divisor_class(td)
 A divisor class on a normal toric variety
 ```
 """
-function ToricDivisorClass(td::ToricDivisor)
+function toric_divisor_class(td::ToricDivisor)
     f = map_from_torusinvariant_weil_divisor_group_to_class_group(toric_variety(td))
     class = f(sum(coefficients(td) .* gens(domain(f))))
-    return ToricDivisorClass(toric_variety(td), class)
+    return toric_divisor_class(toric_variety(td), class)
 end
 
 
@@ -72,7 +92,7 @@ function Base.:+(tdc1::ToricDivisorClass, tdc2::ToricDivisorClass)
     if toric_variety(tdc1) !== toric_variety(tdc2)
         throw(ArgumentError("The divisor classes must be defined on the same toric variety, i.e. the same OSCAR variable"))
     end
-    return ToricDivisorClass(toric_variety(tdc1), divisor_class(tdc1) + divisor_class(tdc2))
+    return toric_divisor_class(toric_variety(tdc1), divisor_class(tdc1) + divisor_class(tdc2))
 end
 
 
@@ -80,11 +100,11 @@ function Base.:-(tdc1::ToricDivisorClass, tdc2::ToricDivisorClass)
     if toric_variety(tdc1) !== toric_variety(tdc2)
         throw(ArgumentError("The divisor classes must be defined on the same toric variety, i.e. the same OSCAR variable"))
     end
-    return ToricDivisorClass(toric_variety(tdc1), divisor_class(tdc1) - divisor_class(tdc2))
+    return toric_divisor_class(toric_variety(tdc1), divisor_class(tdc1) - divisor_class(tdc2))
 end
 
 
-Base.:*(c::T, tdc::ToricDivisorClass) where {T <: IntegerUnion} = ToricDivisorClass(toric_variety(tdc), fmpz(c) * divisor_class(tdc))
+Base.:*(c::T, tdc::ToricDivisorClass) where {T <: IntegerUnion} = toric_divisor_class(toric_variety(tdc), fmpz(c) * divisor_class(tdc))
 
 
 ########################

--- a/src/ToricVarieties/ToricDivisorClasses/constructors.jl
+++ b/src/ToricVarieties/ToricDivisorClasses/constructors.jl
@@ -50,7 +50,7 @@ Construct the toric divisor class associated to the element ... of the class gro
 julia> P2 = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> td = ToricDivisor(P2, [1, 2, 3])
+julia> td = toric_divisor(P2, [1, 2, 3])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> tdc = ToricDivisorClass(td)

--- a/src/ToricVarieties/ToricDivisorClasses/properties.jl
+++ b/src/ToricVarieties/ToricDivisorClasses/properties.jl
@@ -13,13 +13,13 @@ in this divisor class is linearly equivalent to an effective toric divisor.
 julia> P2 = projective_space(NormalToricVariety,2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> tdc = ToricDivisorClass(P2, [1])
+julia> tdc = toric_divisor_class(P2, [1])
 A divisor class on a normal toric variety
 
 julia> is_effective(tdc)
 true
 
-julia> tdc2 = ToricDivisorClass(P2, [-1])
+julia> tdc2 = toric_divisor_class(P2, [-1])
 A divisor class on a normal toric variety
 
 julia> is_effective(tdc2)

--- a/src/ToricVarieties/ToricDivisorClasses/special_attributes.jl
+++ b/src/ToricVarieties/ToricDivisorClasses/special_attributes.jl
@@ -16,7 +16,7 @@ julia> trivial_divisor_class(v)
 A divisor class on a normal toric variety
 ```
 """
-@attr ToricDivisorClass trivial_divisor_class(v::AbstractNormalToricVariety) = ToricDivisorClass(trivial_divisor(v))
+@attr ToricDivisorClass trivial_divisor_class(v::AbstractNormalToricVariety) = toric_divisor_class(trivial_divisor(v))
 export trivial_divisor_class
 
 
@@ -34,7 +34,7 @@ julia> anticanonical_divisor_class(v)
 A divisor class on a normal toric variety
 ```
 """
-@attr ToricDivisorClass anticanonical_divisor_class(v::AbstractNormalToricVariety) = ToricDivisorClass(anticanonical_divisor(v))
+@attr ToricDivisorClass anticanonical_divisor_class(v::AbstractNormalToricVariety) = toric_divisor_class(anticanonical_divisor(v))
 export anticanonical_divisor_class
 
 
@@ -52,5 +52,5 @@ julia> canonical_divisor_class(v)
 A divisor class on a normal toric variety
 ```
 """
-@attr ToricDivisorClass canonical_divisor_class(v::AbstractNormalToricVariety) = ToricDivisorClass(canonical_divisor(v))
+@attr ToricDivisorClass canonical_divisor_class(v::AbstractNormalToricVariety) = toric_divisor_class(canonical_divisor(v))
 export canonical_divisor_class

--- a/src/ToricVarieties/ToricDivisors/attributes.jl
+++ b/src/ToricVarieties/ToricDivisors/attributes.jl
@@ -15,7 +15,7 @@ anymore and the polyhedron becomes empty.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> td0 = ToricDivisor(F4, [0,0,0,0])
+julia> td0 = toric_divisor(F4, [0,0,0,0])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> is_feasible(polyhedron(td0))
@@ -24,13 +24,13 @@ true
 julia> dim(polyhedron(td0))
 0
 
-julia> td1 = ToricDivisor(F4, [1,0,0,0])
+julia> td1 = toric_divisor(F4, [1,0,0,0])
 A torus-invariant, prime divisor on a normal toric variety
 
 julia> is_feasible(polyhedron(td1))
 true
 
-julia> td2 = ToricDivisor(F4, [-1,0,0,0])
+julia> td2 = toric_divisor(F4, [-1,0,0,0])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> is_feasible(polyhedron(td2))
@@ -51,7 +51,7 @@ Identify the coefficients of a toric divisor in the group of torus invariant Wei
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> D = ToricDivisor(F4, [1, 2, 3, 4])
+julia> D = toric_divisor(F4, [1, 2, 3, 4])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> coefficients(D)
@@ -77,7 +77,7 @@ Return the toric variety of a torus-invariant Weil divisor.
 ```jldoctest
 julia> F4 = hirzebruch_surface(4);
 
-julia> D = ToricDivisor(F4, [1, 2, 3, 4]);
+julia> D = toric_divisor(F4, [1, 2, 3, 4]);
 
 julia> toric_variety(D)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor

--- a/src/ToricVarieties/ToricDivisors/constructors.jl
+++ b/src/ToricVarieties/ToricDivisors/constructors.jl
@@ -63,17 +63,17 @@ export toric_divisor
 ######################
 
 @doc Markdown.doc"""
-    DivisorOfCharacter(v::AbstractNormalToricVariety, character::Vector{T}) where {T <: IntegerUnion}
+    divisor_of_character(v::AbstractNormalToricVariety, character::Vector{T}) where {T <: IntegerUnion}
 
 Construct the torus invariant divisor associated to a character of the normal toric variety `v`.
 
 # Examples
 ```jldoctest
-julia> DivisorOfCharacter(projective_space(NormalToricVariety, 2), [1, 2])
+julia> divisor_of_character(projective_space(NormalToricVariety, 2), [1, 2])
 A torus-invariant, non-prime divisor on a normal toric variety
 ```
 """
-function DivisorOfCharacter(v::AbstractNormalToricVariety, character::Vector{T}) where {T <: IntegerUnion}
+function divisor_of_character(v::AbstractNormalToricVariety, character::Vector{T}) where {T <: IntegerUnion}
     if length(character) != rank(character_lattice(v))
         throw(ArgumentError("Character must consist of $(rank(character_lattice(v))) integers"))
     end
@@ -82,7 +82,7 @@ function DivisorOfCharacter(v::AbstractNormalToricVariety, character::Vector{T})
     coeffs = [fmpz(x) for x in transpose(f(char).coeff)][:, 1]
     return toric_divisor(v, coeffs)
 end
-export DivisorOfCharacter
+export divisor_of_character
 
 
 ########################

--- a/src/ToricVarieties/ToricDivisors/constructors.jl
+++ b/src/ToricVarieties/ToricDivisors/constructors.jl
@@ -22,7 +22,7 @@ end
 ######################
 
 @doc Markdown.doc"""
-    ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
+    toric_divisor(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
 
 Construct the torus invariant divisor on the normal toric variety `v` as linear
  combination of the torus invariant prime divisors of `v`. The coefficients of this
@@ -30,11 +30,11 @@ Construct the torus invariant divisor on the normal toric variety `v` as linear
 
 # Examples
 ```jldoctest
-julia> ToricDivisor(projective_space(NormalToricVariety, 2), [1, 1, 2])
+julia> toric_divisor(projective_space(NormalToricVariety, 2), [1, 1, 2])
 A torus-invariant, non-prime divisor on a normal toric variety
 ```
 """
-function ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
+function toric_divisor(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T <: IntegerUnion}
     # check input
     if length(coeffs) != pm_object(v).N_RAYS
         throw(ArgumentError("Number of coefficients needs to match number of prime divisors"))
@@ -55,7 +55,7 @@ function ToricDivisor(v::AbstractNormalToricVariety, coeffs::Vector{T}) where {T
     # return the result
     return td
 end
-export ToricDivisor
+export toric_divisor
 
 
 ######################
@@ -80,7 +80,7 @@ function DivisorOfCharacter(v::AbstractNormalToricVariety, character::Vector{T})
     f = map_from_character_lattice_to_torusinvariant_weil_divisor_group(v)
     char = sum(character .* gens(domain(f)))
     coeffs = [fmpz(x) for x in transpose(f(char).coeff)][:, 1]
-    return ToricDivisor(v, coeffs)
+    return toric_divisor(v, coeffs)
 end
 export DivisorOfCharacter
 
@@ -94,7 +94,7 @@ function Base.:+(td1::ToricDivisor, td2::ToricDivisor)
         throw(ArgumentError("The toric divisors must be defined on the same toric variety, i.e. the same OSCAR variable"))
     end
     new_coeffiicients = coefficients(td1) + coefficients(td2)
-    return ToricDivisor(toric_variety(td1), new_coeffiicients)
+    return toric_divisor(toric_variety(td1), new_coeffiicients)
 end
 
 
@@ -103,11 +103,11 @@ function Base.:-(td1::ToricDivisor, td2::ToricDivisor)
         throw(ArgumentError("The toric divisors must be defined on the same toric variety, i.e. the same OSCAR variable"))
     end
     new_coeffiicients = coefficients(td1) - coefficients(td2)
-    return ToricDivisor(toric_variety(td1), new_coeffiicients)
+    return toric_divisor(toric_variety(td1), new_coeffiicients)
 end
 
 
-Base.:*(c::T, td::ToricDivisor) where {T <: IntegerUnion} = ToricDivisor(toric_variety(td), [fmpz(c)*x for x in coefficients(td)])
+Base.:*(c::T, td::ToricDivisor) where {T <: IntegerUnion} = toric_divisor(toric_variety(td), [fmpz(c)*x for x in coefficients(td)])
 
 
 ######################

--- a/src/ToricVarieties/ToricDivisors/properties.jl
+++ b/src/ToricVarieties/ToricDivisors/properties.jl
@@ -8,7 +8,7 @@ Checks if the divisor `td` is Cartier.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> td = ToricDivisor(F4, [1,0,0,0])
+julia> td = toric_divisor(F4, [1,0,0,0])
 A torus-invariant, prime divisor on a normal toric variety
 
 julia> is_cartier(td)
@@ -29,7 +29,7 @@ Determine whether the toric divisor `td` is principal.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> td = ToricDivisor(F4, [1,0,0,0])
+julia> td = toric_divisor(F4, [1,0,0,0])
 A torus-invariant, prime divisor on a normal toric variety
 
 julia> is_principal(td)
@@ -53,7 +53,7 @@ Determine whether the toric divisor `td` is basepoint free.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> td = ToricDivisor(F4, [1,0,0,0])
+julia> td = toric_divisor(F4, [1,0,0,0])
 A torus-invariant, prime divisor on a normal toric variety
 
 julia> is_basepoint_free(td)
@@ -75,13 +75,13 @@ i.e. if all of its coefficients are non-negative.
 julia> P2 = projective_space(NormalToricVariety,2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> td = ToricDivisor(P2, [1,-1,0])
+julia> td = toric_divisor(P2, [1,-1,0])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> is_effective(td)
 false
 
-julia> td2 = ToricDivisor(P2, [1,2,3])
+julia> td2 = toric_divisor(P2, [1,2,3])
 A torus-invariant, non-prime divisor on a normal toric variety
 
 julia> is_effective(td2)
@@ -101,7 +101,7 @@ Determine whether the toric divisor `td` is integral.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> td = ToricDivisor(F4, [1,0,0,0])
+julia> td = toric_divisor(F4, [1,0,0,0])
 A torus-invariant, prime divisor on a normal toric variety
 
 julia> is_integral(td)
@@ -121,7 +121,7 @@ Determine whether the toric divisor `td` is ample.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> td = ToricDivisor(F4, [1,0,0,0])
+julia> td = toric_divisor(F4, [1,0,0,0])
 A torus-invariant, prime divisor on a normal toric variety
 
 julia> is_ample(td)
@@ -141,7 +141,7 @@ Determine whether the toric divisor `td` is very ample.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> td = ToricDivisor(F4, [1,0,0,0])
+julia> td = toric_divisor(F4, [1,0,0,0])
 A torus-invariant, prime divisor on a normal toric variety
 
 julia> is_very_ample(td)
@@ -161,7 +161,7 @@ Determine whether the toric divisor `td` is nef.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> td = ToricDivisor(F4, [1,0,0,0])
+julia> td = toric_divisor(F4, [1,0,0,0])
 A torus-invariant, prime divisor on a normal toric variety
 
 julia> is_nef(td)
@@ -181,7 +181,7 @@ Determine whether the toric divisor `td` is Q-Cartier.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> td = ToricDivisor(F4, [1,0,0,0])
+julia> td = toric_divisor(F4, [1,0,0,0])
 A torus-invariant, prime divisor on a normal toric variety
 
 julia> is_q_cartier(td)
@@ -202,7 +202,7 @@ Determine whether the toric divisor `td` is a prime divisor.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> td = ToricDivisor(F4, [1,0,0,0])
+julia> td = toric_divisor(F4, [1,0,0,0])
 A torus-invariant, prime divisor on a normal toric variety
 
 julia> is_prime(td)

--- a/src/ToricVarieties/ToricDivisors/special_attributes.jl
+++ b/src/ToricVarieties/ToricDivisors/special_attributes.jl
@@ -16,7 +16,7 @@ julia> trivial_divisor(v)
 A torus-invariant, non-prime divisor on a normal toric variety
 ```
 """
-@attr ToricDivisor trivial_divisor(v::AbstractNormalToricVariety) = ToricDivisor(v, zeros(fmpz, nrays(v)))
+@attr ToricDivisor trivial_divisor(v::AbstractNormalToricVariety) = toric_divisor(v, zeros(fmpz, nrays(v)))
 export trivial_divisor
 
 
@@ -34,7 +34,7 @@ julia> anticanonical_divisor(v)
 A torus-invariant, non-prime divisor on a normal toric variety
 ```
 """
-@attr ToricDivisor anticanonical_divisor(v::AbstractNormalToricVariety) = ToricDivisor(v, fill(fmpz(1), nrays(v)))
+@attr ToricDivisor anticanonical_divisor(v::AbstractNormalToricVariety) = toric_divisor(v, fill(fmpz(1), nrays(v)))
 export anticanonical_divisor
 
 
@@ -52,5 +52,5 @@ julia> canonical_divisor(v)
 A torus-invariant, non-prime divisor on a normal toric variety
 ```
 """
-@attr ToricDivisor canonical_divisor(v::AbstractNormalToricVariety) = ToricDivisor(v, fill(fmpz(-1), nrays(v)))
+@attr ToricDivisor canonical_divisor(v::AbstractNormalToricVariety) = toric_divisor(v, fill(fmpz(-1), nrays(v)))
 export canonical_divisor

--- a/src/ToricVarieties/ToricLineBundles/attributes.jl
+++ b/src/ToricVarieties/ToricLineBundles/attributes.jl
@@ -76,7 +76,7 @@ true
     map2 = map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group(toric_variety(l))
     image = map2(preimage(map1, class)).coeff
     coeffs = vec([fmpz(x) for x in image])
-    td = ToricDivisor(toric_variety(l), coeffs)
+    td = toric_divisor(toric_variety(l), coeffs)
     set_attribute!(td, :is_cartier, true)
     return td
 end

--- a/src/ToricVarieties/ToricLineBundles/attributes.jl
+++ b/src/ToricVarieties/ToricLineBundles/attributes.jl
@@ -12,7 +12,7 @@ Return the divisor class which defines the toric line bundle `l`.
 julia> v = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> l = ToricLineBundle(v, [fmpz(2)])
+julia> l = toric_line_bundle(v, [fmpz(2)])
 A toric line bundle on a normal toric variety
 
 julia> divisor_class(l)
@@ -37,7 +37,7 @@ Return the toric variety over which the toric line bundle `l` is defined.
 julia> v = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> l = ToricLineBundle(v, [fmpz(2)])
+julia> l = toric_line_bundle(v, [fmpz(2)])
 A toric line bundle on a normal toric variety
 
 julia> toric_variety(l)
@@ -60,7 +60,7 @@ Return a divisor corresponding to the toric line bundle `l`.
 julia> v = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> l = ToricLineBundle(v, [fmpz(2)])
+julia> l = toric_line_bundle(v, [fmpz(2)])
 A toric line bundle on a normal toric variety
 
 julia> toric_divisor(l)
@@ -93,7 +93,7 @@ Return the degree of the toric line bundle `l`.
 julia> v = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> l = ToricLineBundle(v, [fmpz(2)])
+julia> l = toric_line_bundle(v, [fmpz(2)])
 A toric line bundle on a normal toric variety
 
 julia> degree(l)
@@ -120,7 +120,7 @@ Return a basis of the global sections of the toric line bundle `l` in terms of r
 julia> v = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> l = ToricLineBundle(v, [fmpz(2)])
+julia> l = toric_line_bundle(v, [fmpz(2)])
 A toric line bundle on a normal toric variety
 
 julia> basis_of_global_sections_via_rational_functions(l)
@@ -159,7 +159,7 @@ For convenience, this method can also be called via
 julia> v = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> l = ToricLineBundle(v, [fmpz(2)])
+julia> l = toric_line_bundle(v, [fmpz(2)])
 A toric line bundle on a normal toric variety
 
 julia> basis_of_global_sections_via_homogeneous_component(l)

--- a/src/ToricVarieties/ToricLineBundles/constructors.jl
+++ b/src/ToricVarieties/ToricLineBundles/constructors.jl
@@ -50,7 +50,7 @@ Construct the toric variety associated to a (Cartier) torus-invariant divisor `d
 julia> v = projective_space(NormalToricVariety, 2)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> l = ToricLineBundle(v, ToricDivisor(v, [1, 2, 3]))
+julia> l = ToricLineBundle(v, toric_divisor(v, [1, 2, 3]))
 A toric line bundle on a normal toric variety
 ```
 """

--- a/src/ToricVarieties/ToricLineBundles/properties.jl
+++ b/src/ToricVarieties/ToricLineBundles/properties.jl
@@ -12,7 +12,7 @@ Return `true` if the toric line bundle `l` is basepoint free and `false` otherwi
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> is_basepoint_free(ToricLineBundle(F4, [1, 0]))
+julia> is_basepoint_free(toric_line_bundle(F4, [1, 0]))
 true
 ```
 """
@@ -30,7 +30,7 @@ Return `true` if the toric line bundle `l` is ample and `false` otherwise.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> is_ample(ToricLineBundle(F4, [1,0]))
+julia> is_ample(toric_line_bundle(F4, [1,0]))
 false
 ```
 """
@@ -48,7 +48,7 @@ Return `true` if the toric line bundle `l` is very ample and `false` otherwise.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> is_very_ample(ToricLineBundle(F4, [1,0]))
+julia> is_very_ample(toric_line_bundle(F4, [1,0]))
 false
 ```
 """

--- a/src/ToricVarieties/ToricLineBundles/special_attributes.jl
+++ b/src/ToricVarieties/ToricLineBundles/special_attributes.jl
@@ -17,7 +17,7 @@ julia> structure_sheaf(v)
 A toric line bundle on a normal toric variety
 ```
 """
-@attr ToricLineBundle structure_sheaf(v::AbstractNormalToricVariety) = ToricLineBundle(v, zero(picard_group(v)))
+@attr ToricLineBundle structure_sheaf(v::AbstractNormalToricVariety) = toric_line_bundle(v, zero(picard_group(v)))
 export structure_sheaf
 
 
@@ -36,7 +36,7 @@ julia> anticanonical_bundle(v)
 A toric line bundle on a normal toric variety
 ```
 """
-@attr ToricLineBundle anticanonical_bundle(v::AbstractNormalToricVariety) = prod(ToricLineBundle(v, d) for d in torusinvariant_prime_divisors(v))
+@attr ToricLineBundle anticanonical_bundle(v::AbstractNormalToricVariety) = prod(toric_line_bundle(v, d) for d in torusinvariant_prime_divisors(v))
 export anticanonical_bundle
 
 

--- a/src/ToricVarieties/ToricMorphisms/attributes.jl
+++ b/src/ToricVarieties/ToricMorphisms/attributes.jl
@@ -8,7 +8,7 @@ Return the domain of the toric morphism `tm`.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> domain(ToricIdentityMorphism(F4))
+julia> domain(toric_identity_morphism(F4))
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 ```
 """
@@ -26,7 +26,7 @@ Return the codomain of the toric morphism `tm`.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> codomain(ToricIdentityMorphism(F4))
+julia> codomain(toric_identity_morphism(F4))
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 ```
 """
@@ -44,7 +44,7 @@ Return the image of the toric morphism `tm`.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> image(ToricIdentityMorphism(F4))
+julia> image(toric_identity_morphism(F4))
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 ```
 """
@@ -62,7 +62,7 @@ Return the underlying grid morphism of the toric morphism `tm`.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> grid_morphism(ToricIdentityMorphism(F4))
+julia> grid_morphism(toric_identity_morphism(F4))
 Map with following data
 Domain:
 =======
@@ -87,7 +87,7 @@ map of the torusinvariant Weil divisors.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> morphism_on_torusinvariant_weil_divisor_group(ToricIdentityMorphism(F4))
+julia> morphism_on_torusinvariant_weil_divisor_group(toric_identity_morphism(F4))
 Map with following data
 Domain:
 =======
@@ -124,7 +124,7 @@ map of the Cartier divisors.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> morphism_on_torusinvariant_cartier_divisor_group(ToricIdentityMorphism(F4))
+julia> morphism_on_torusinvariant_cartier_divisor_group(toric_identity_morphism(F4))
 Map with following data
 Domain:
 =======
@@ -156,7 +156,7 @@ map of the Class groups.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> morphism_on_class_group(ToricIdentityMorphism(F4))
+julia> morphism_on_class_group(toric_identity_morphism(F4))
 Map with following data
 Domain:
 =======
@@ -188,7 +188,7 @@ map of the Picard groups.
 julia> F4 = hirzebruch_surface(4)
 A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor
 
-julia> morphism_on_picard_group(ToricIdentityMorphism(F4))
+julia> morphism_on_picard_group(toric_identity_morphism(F4))
 Map with following data
 Domain:
 =======

--- a/src/ToricVarieties/ToricMorphisms/constructors.jl
+++ b/src/ToricVarieties/ToricMorphisms/constructors.jl
@@ -174,23 +174,23 @@ end
 ####################################################
 
 @doc Markdown.doc"""
-    ToricIdentityMorphism(variety::AbstractNormalToricVariety)
+    toric_identity_morphism(variety::AbstractNormalToricVariety)
 
 Construct the toric identity morphism from `variety` to `variety`.
 
 # Examples
 ```jldoctest
-julia> ToricIdentityMorphism(hirzebruch_surface(2))
+julia> toric_identity_morphism(hirzebruch_surface(2))
 A toric morphism
 ```
 """
-function ToricIdentityMorphism(variety::AbstractNormalToricVariety)
+function toric_identity_morphism(variety::AbstractNormalToricVariety)
     r = rank(character_lattice(variety))
     identity_matrix = matrix(ZZ, [[if i==j 1 else 0 end for j in 1:r] for i in 1:r])
     grid_morphism = hom(character_lattice(variety), character_lattice(variety), identity_matrix)
     return ToricMorphism(variety, grid_morphism, variety, variety)
 end
-export ToricIdentityMorphism
+export toric_identity_morphism
 
 
 ####################################################

--- a/src/ToricVarieties/ToricMorphisms/constructors.jl
+++ b/src/ToricVarieties/ToricMorphisms/constructors.jl
@@ -18,7 +18,7 @@ export ToricMorphism
 
 
 @doc Markdown.doc"""
-    ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Vector{Vector{T}}, codomain::T2=nothing) where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}
+    toric_morphism(domain::AbstractNormalToricVariety, mapping_matrix::Vector{Vector{T}}, codomain::T2=nothing) where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}
 
 Construct the toric morphism with given domain and associated to the lattice morphism given by the `mapping_matrix`.
 As optional argument, the codomain of the morphism can be specified.
@@ -32,25 +32,26 @@ julia> mapping_matrix = [[0, 1]]
 1-element Vector{Vector{Int64}}:
  [0, 1]
 
-julia> ToricMorphism(domain, mapping_matrix)
+julia> toric_morphism(domain, mapping_matrix)
 A toric morphism
 ```
 """
-function ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Vector{Vector{T}}, codomain::T2=nothing) where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}
+function toric_morphism(domain::AbstractNormalToricVariety, mapping_matrix::Vector{Vector{T}}, codomain::T2=nothing) where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}
     (length(mapping_matrix) > 0 && length(mapping_matrix[1]) > 0) || throw(ArgumentError("The mapping matrix must not be empty"))
     if codomain == nothing
-      return ToricMorphism(domain, hom(character_lattice(domain), free_abelian_group(length(mapping_matrix[1])), matrix(ZZ, mapping_matrix)), codomain)
+      return toric_morphism(domain, hom(character_lattice(domain), free_abelian_group(length(mapping_matrix[1])), matrix(ZZ, mapping_matrix)), codomain)
     else
-      return ToricMorphism(domain, hom(character_lattice(domain), character_lattice(codomain), matrix(ZZ, mapping_matrix)), codomain)
+      return toric_morphism(domain, hom(character_lattice(domain), character_lattice(codomain), matrix(ZZ, mapping_matrix)), codomain)
     end
 end
-export ToricMorphism
+export toric_morphism
 
 
 @doc Markdown.doc"""
-    ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Matrix{T}, codomain::T2=nothing) where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}
+    toric_morphism(domain::AbstractNormalToricVariety, mapping_matrix::Matrix{T}, codomain::T2=nothing) where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}
 
 Construct the toric morphism with given domain and associated to the lattice morphism given by the `mapping_matrix`.
+As optional argument, the codomain of the morphism can be specified.
 
 # Examples
 ```jldoctest
@@ -61,25 +62,25 @@ julia> mapping_matrix = [0 1]
 1×2 Matrix{Int64}:
  0  1
 
-julia> ToricMorphism(domain, mapping_matrix)
+julia> toric_morphism(domain, mapping_matrix)
 A toric morphism
 ```
 """
-function ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::Matrix{T}, codomain::T2=nothing) where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}
+function toric_morphism(domain::AbstractNormalToricVariety, mapping_matrix::Matrix{T}, codomain::T2=nothing) where {T <: IntegerUnion, T2 <: Union{AbstractNormalToricVariety, Nothing}}
     (nrows(mapping_matrix) > 0 && ncols(mapping_matrix) > 0) || throw(ArgumentError("The mapping matrix must not be empty"))
     if codomain == nothing
-      return ToricMorphism(domain, hom(character_lattice(domain), free_abelian_group(ncols(mapping_matrix)), matrix(ZZ, mapping_matrix)), codomain)
+      return toric_morphism(domain, hom(character_lattice(domain), free_abelian_group(ncols(mapping_matrix)), matrix(ZZ, mapping_matrix)), codomain)
     else
-      return ToricMorphism(domain, hom(character_lattice(domain), character_lattice(codomain), matrix(ZZ, mapping_matrix)), codomain)
+      return toric_morphism(domain, hom(character_lattice(domain), character_lattice(codomain), matrix(ZZ, mapping_matrix)), codomain)
     end
 end
-export ToricMorphism
 
 
 @doc Markdown.doc"""
-    ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::fmpz_mat, codomain::T=nothing) where {T <: Union{AbstractNormalToricVariety, Nothing}}
+    toric_morphism(domain::AbstractNormalToricVariety, mapping_matrix::fmpz_mat, codomain::T=nothing) where {T <: Union{AbstractNormalToricVariety, Nothing}}
 
 Construct the toric morphism with given domain and associated to the lattice morphism given by the `mapping_matrix`.
+As optional argument, the codomain of the morphism can be specified.
 
 # Examples
 ```jldoctest
@@ -92,25 +93,26 @@ A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional to
 julia> mapping_matrix = matrix(ZZ, [0 1])
 [0   1]
 
-julia> ToricMorphism(domain, mapping_matrix, codomain)
+julia> toric_morphism(domain, mapping_matrix, codomain)
 A toric morphism
 ```
 """
-function ToricMorphism(domain::AbstractNormalToricVariety, mapping_matrix::fmpz_mat, codomain::T=nothing) where {T <: Union{AbstractNormalToricVariety, Nothing}}
+function toric_morphism(domain::AbstractNormalToricVariety, mapping_matrix::fmpz_mat, codomain::T=nothing) where {T <: Union{AbstractNormalToricVariety, Nothing}}
     (nrows(mapping_matrix) > 0 && ncols(mapping_matrix) > 0) || throw(ArgumentError("The mapping matrix must not be empty"))
     if codomain == nothing
-      return ToricMorphism(domain, hom(character_lattice(domain), free_abelian_group(ncols(mapping_matrix)), mapping_matrix), codomain)
+      return toric_morphism(domain, hom(character_lattice(domain), free_abelian_group(ncols(mapping_matrix)), mapping_matrix), codomain)
     else
-      return ToricMorphism(domain, hom(character_lattice(domain), character_lattice(codomain), mapping_matrix), codomain)
+      return toric_morphism(domain, hom(character_lattice(domain), character_lattice(codomain), mapping_matrix), codomain)
     end
 end
-export ToricMorphism
+export toric_morphism
 
 
 @doc Markdown.doc"""
-    function ToricMorphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap, codomain::T=nothing) where {T <: Union{AbstractNormalToricVariety, Nothing}}
+    function toric_morphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap, codomain::T=nothing) where {T <: Union{AbstractNormalToricVariety, Nothing}}
 
 Construct the toric morphism from the `domain` to the `codomain` with map given by the `grid_morphism`.
+As optional argument, the codomain of the morphism can be specified.
 
 # Examples
 ```jldoctest
@@ -132,11 +134,11 @@ Codomain:
 =========
 Abelian group with structure: Z^2
 
-julia> ToricMorphism(domain, grid_morphism, codomain)
+julia> toric_morphism(domain, grid_morphism, codomain)
 A toric morphism
 ```
 """
-function ToricMorphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap, codomain::T=nothing) where {T <: Union{AbstractNormalToricVariety, Nothing}}
+function toric_morphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbFinGenMap, codomain::T=nothing) where {T <: Union{AbstractNormalToricVariety, Nothing}}
     # avoid empty mapping
     (nrows(matrix(grid_morphism)) > 0 && ncols(matrix(grid_morphism)) > 0) || throw(ArgumentError("The mapping matrix must not be empty"))
 
@@ -165,7 +167,6 @@ function ToricMorphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbF
       return ToricMorphism(domain, grid_morphism, image, codomain)
     end
 end
-export ToricMorphism
 
 
 ####################################################
@@ -203,7 +204,7 @@ function Base.:+(tm1::ToricMorphism, tm2::ToricMorphism)
     if codomain(tm1) !== codomain(tm2)
         throw(ArgumentError("The toric morphism must be defined with identically the same codomain"))
     end
-    return ToricMorphism(domain(tm1), grid_morphism(tm1) + grid_morphism(tm2), codomain(tm1))
+    return toric_morphism(domain(tm1), grid_morphism(tm1) + grid_morphism(tm2), codomain(tm1))
 end
 
 
@@ -214,13 +215,13 @@ function Base.:-(tm1::ToricMorphism, tm2::ToricMorphism)
     if codomain(tm1) !== codomain(tm2)
         throw(ArgumentError("The toric morphism must be defined with identically the same codomain"))
     end
-    return ToricMorphism(domain(tm1), grid_morphism(tm1) - grid_morphism(tm2), codomain(tm1))
+    return toric_morphism(domain(tm1), grid_morphism(tm1) - grid_morphism(tm2), codomain(tm1))
 end
 
 
 function Base.:*(c::T, tm::ToricMorphism) where T <: IntegerUnion
   new_grid_morphism = hom(domain(grid_morphism(tm)), codomain(grid_morphism(tm)), c * matrix(grid_morphism(tm)))
-  return ToricMorphism(domain(tm), new_grid_morphism, codomain(tm))
+  return toric_morphism(domain(tm), new_grid_morphism, codomain(tm))
 end
 
 
@@ -232,7 +233,7 @@ function Base.:*(tm1::ToricMorphism, tm2::ToricMorphism)
     if codomain(tm1) !== domain(tm2)
         throw(ArgumentError("The codomain of the first toric morphism must be identically the same as the domain of the second morphism"))
     end
-    return ToricMorphism(domain(tm1), grid_morphism(tm1) * grid_morphism(tm2), codomain(tm2))
+    return toric_morphism(domain(tm1), grid_morphism(tm1) * grid_morphism(tm2), codomain(tm2))
 end
 
 

--- a/src/ToricVarieties/ToricMorphisms/special_attributes.jl
+++ b/src/ToricVarieties/ToricMorphisms/special_attributes.jl
@@ -17,7 +17,7 @@ A toric morphism
     max_cones_for_cox_variety = ray_indices(maximal_cones(variety))
     rays_for_cox_variety = matrix(ZZ, [[if i==j 1 else 0 end for j in 1:nrays(variety)] for i in 1:nrays(variety)])
     cox_variety = normal_toric_variety(PolyhedralFan(rays_for_cox_variety, max_cones_for_cox_variety))
-    return ToricMorphism(cox_variety, mapping_matrix, variety)
+    return toric_morphism(cox_variety, mapping_matrix, variety)
 end
 export morphism_from_cox_variety
 

--- a/src/ToricVarieties/cohomCalg/VanishingSets/constructors.jl
+++ b/src/ToricVarieties/cohomCalg/VanishingSets/constructors.jl
@@ -18,6 +18,9 @@
 end
 export ToricVanishingSet
 
+toric_vanishing_set(v::AbstractNormalToricVariety, ps::Vector{Polyhedron{fmpq}}, i::Int) = ToricVanishingSet(v, ps)
+export toric_vanishing_set
+
 
 ######################
 # 2: Display

--- a/src/ToricVarieties/cohomCalg/VanishingSets/methods.jl
+++ b/src/ToricVarieties/cohomCalg/VanishingSets/methods.jl
@@ -8,7 +8,7 @@ Checks if the toric line bundle `l` is contained in the toric vanishing set `tvs
 julia> dP1 = del_pezzo_surface(1)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> l = ToricLineBundle(dP1, [3, 2])
+julia> l = toric_line_bundle(dP1, [3, 2])
 A toric line bundle on a normal toric variety
 
 julia> all_cohomologies(l)

--- a/src/ToricVarieties/cohomCalg/special_attributes.jl
+++ b/src/ToricVarieties/cohomCalg/special_attributes.jl
@@ -39,7 +39,7 @@ toric line bundle `l` by use of the cohomCalg algorithm
 julia> dP3 = del_pezzo_surface(3)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> all_cohomologies(ToricLineBundle(dP3, [1, 2, 3, 4]))
+julia> all_cohomologies(toric_line_bundle(dP3, [1, 2, 3, 4]))
 3-element Vector{fmpz}:
  0
  16
@@ -173,7 +173,7 @@ toric line bundle `l` by use of the cohomCalg algorithm
 julia> dP3 = del_pezzo_surface(3)
 A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> cohomology(ToricLineBundle(dP3, [4, 1, 1, 1]), 0)
+julia> cohomology(toric_line_bundle(dP3, [4, 1, 1, 1]), 0)
 12
 ```
 """

--- a/test/Serialization/ToricGeometry.jl
+++ b/test/Serialization/ToricGeometry.jl
@@ -11,8 +11,8 @@
 
         @testset "ToricDivisor" begin
             pp = projective_space(NormalToricVariety, 2)
-            td0 = ToricDivisor(pp, [1,1,2])
-            td1 = ToricDivisor(pp, [1,1,3])
+            td0 = toric_divisor(pp, [1,1,2])
+            td1 = toric_divisor(pp, [1,1,3])
             vtd = [td0, td1]
             test_save_load_roundtrip(path, vtd) do loaded
               @test coefficients(td0) == coefficients(loaded[1])

--- a/test/ToricVarieties/algebraic_cycles.jl
+++ b/test/ToricVarieties/algebraic_cycles.jl
@@ -12,7 +12,7 @@ using Test
     (xx1, xx2, yy1, yy2) = gens(cox_ring(ntv));
     sv1 = closed_subvariety_of_toric_variety(ntv, [xx1])
     sv2 = closed_subvariety_of_toric_variety(ntv, [xx1^2+xx1*xx2+xx2^2, yy2])
-    ac0 = rational_equivalence_class(ToricLineBundle(ntv, [1, 1]))
+    ac0 = rational_equivalence_class(toric_line_bundle(ntv, [1, 1]))
     
     F5 = hirzebruch_surface(5; set_attributes)
     ac1 = rational_equivalence_class(divisor_of_character(F5, [1, 2]))

--- a/test/ToricVarieties/algebraic_cycles.jl
+++ b/test/ToricVarieties/algebraic_cycles.jl
@@ -15,7 +15,7 @@ using Test
     ac0 = rational_equivalence_class(ToricLineBundle(ntv, [1, 1]))
     
     F5 = hirzebruch_surface(5; set_attributes)
-    ac1 = rational_equivalence_class(DivisorOfCharacter(F5, [1, 2]))
+    ac1 = rational_equivalence_class(divisor_of_character(F5, [1, 2]))
     
     dP1 = del_pezzo_surface(1; set_attributes)
     (u1, u2, u3, u4) = gens(cohomology_ring(dP1))

--- a/test/ToricVarieties/algebraic_cycles.jl
+++ b/test/ToricVarieties/algebraic_cycles.jl
@@ -24,7 +24,7 @@ using Test
     dP3 = del_pezzo_surface(3; set_attributes)
     (x1, e1, x2, e3, x3, e2) = gens(cohomology_ring(dP3))
     ac3 = rational_equivalence_class(canonical_bundle(dP3))
-    ac4 = rational_equivalence_class(ToricDivisorClass(dP3, [4, 3, 2, 1]))
+    ac4 = rational_equivalence_class(toric_divisor_class(dP3, [4, 3, 2, 1]))
     
     @testset "Should fail" begin
         @test_throws ArgumentError rational_equivalence_class(antv, [1, 2, 3])

--- a/test/ToricVarieties/line_bundle_cohomologies.jl
+++ b/test/ToricVarieties/line_bundle_cohomologies.jl
@@ -7,9 +7,9 @@ using Test
     dP3 = del_pezzo_surface(3; set_attributes)
     F5 = hirzebruch_surface(5; set_attributes)
     
-    l = ToricLineBundle(dP3, [1, 2, 3, 4])
-    l2 = ToricLineBundle(divisor_of_character(F5, [1, 2]))
-    l3 = ToricLineBundle(P2, [1])
+    l = toric_line_bundle(dP3, [1, 2, 3, 4])
+    l2 = toric_line_bundle(divisor_of_character(F5, [1, 2]))
+    l3 = toric_line_bundle(P2, [1])
     
     vs = vanishing_sets(dP3)
     vs2 = vanishing_sets(P2)

--- a/test/ToricVarieties/line_bundle_cohomologies.jl
+++ b/test/ToricVarieties/line_bundle_cohomologies.jl
@@ -8,7 +8,7 @@ using Test
     F5 = hirzebruch_surface(5; set_attributes)
     
     l = ToricLineBundle(dP3, [1, 2, 3, 4])
-    l2 = ToricLineBundle(DivisorOfCharacter(F5, [1, 2]))
+    l2 = ToricLineBundle(divisor_of_character(F5, [1, 2]))
     l3 = ToricLineBundle(P2, [1])
     
     vs = vanishing_sets(dP3)

--- a/test/ToricVarieties/line_bundles.jl
+++ b/test/ToricVarieties/line_bundles.jl
@@ -6,11 +6,11 @@ using Test
     dP1 = del_pezzo_surface(1; set_attributes)
     dP3 = del_pezzo_surface(3; set_attributes)
     
-    l = ToricLineBundle(dP3, [1, 2, 3, 4])
+    l = toric_line_bundle(dP3, [1, 2, 3, 4])
     l2 = canonical_bundle(dP3)
     l3 = anticanonical_bundle(dP3)
-    l4 = ToricLineBundle(dP3, trivial_divisor(dP3))
-    l5 = ToricLineBundle(dP1, [fmpz(1), fmpz(2)])
+    l4 = toric_line_bundle(dP3, trivial_divisor(dP3))
+    l5 = toric_line_bundle(dP1, [fmpz(1), fmpz(2)])
     
     @testset "Should fail" begin
         @test_throws ArgumentError l * l5

--- a/test/ToricVarieties/toric_divisor_classes.jl
+++ b/test/ToricVarieties/toric_divisor_classes.jl
@@ -7,14 +7,14 @@ using Test
     dP3 = del_pezzo_surface(3; set_attributes)
     P2 = projective_space(NormalToricVariety, 2; set_attributes)
     
-    DC = ToricDivisorClass(F5, [fmpz(0), fmpz(0)])
-    DC2 = ToricDivisorClass(F5, [1, 2])
-    DC3 = ToricDivisorClass(dP3, [4, 3, 2, 1])
+    DC = toric_divisor_class(F5, [fmpz(0), fmpz(0)])
+    DC2 = toric_divisor_class(F5, [1, 2])
+    DC3 = toric_divisor_class(dP3, [4, 3, 2, 1])
     DC4 = canonical_divisor_class(dP3)
     DC5 = anticanonical_divisor_class(dP3)
     DC6 = trivial_divisor_class(dP3)
-    DC7 = ToricDivisorClass(P2, [1])
-    DC8 = ToricDivisorClass(P2, [-1])
+    DC7 = toric_divisor_class(P2, [1])
+    DC8 = toric_divisor_class(P2, [-1])
     
     @testset "Basic properties" begin
         @test is_trivial(toric_divisor(DC2)) == false

--- a/test/ToricVarieties/toric_divisors.jl
+++ b/test/ToricVarieties/toric_divisors.jl
@@ -7,18 +7,18 @@ using Test
     dP3 = del_pezzo_surface(3; set_attributes)
     P2 = projective_space(NormalToricVariety, 2; set_attributes)
     
-    D=ToricDivisor(F5, [0, 0, 0, 0])
+    D=toric_divisor(F5, [0, 0, 0, 0])
     D2 = DivisorOfCharacter(F5, [1, 2])
-    D3 = ToricDivisor(dP3, [1, 0, 0, 0, 0, 0])
+    D3 = toric_divisor(dP3, [1, 0, 0, 0, 0, 0])
     D4 = canonical_divisor(dP3)
     D5 = anticanonical_divisor(dP3)
     D6 = trivial_divisor(dP3)
-    D7 = ToricDivisor(P2, [1,1,0])
-    D8 = ToricDivisor(P2, [1,-1,0])
-    D9 = ToricDivisor(P2, [0,-1,0])
+    D7 = toric_divisor(P2, [1,1,0])
+    D8 = toric_divisor(P2, [1,-1,0])
+    D9 = toric_divisor(P2, [0,-1,0])
     
     @testset "Should fail" begin
-        @test_throws ArgumentError ToricDivisor(F5, [0, 0, 0])
+        @test_throws ArgumentError toric_divisor(F5, [0, 0, 0])
         @test_throws ArgumentError D+D3
         @test_throws ArgumentError D-D3
     end

--- a/test/ToricVarieties/toric_divisors.jl
+++ b/test/ToricVarieties/toric_divisors.jl
@@ -8,7 +8,7 @@ using Test
     P2 = projective_space(NormalToricVariety, 2; set_attributes)
     
     D=toric_divisor(F5, [0, 0, 0, 0])
-    D2 = DivisorOfCharacter(F5, [1, 2])
+    D2 = divisor_of_character(F5, [1, 2])
     D3 = toric_divisor(dP3, [1, 0, 0, 0, 0, 0])
     D4 = canonical_divisor(dP3)
     D5 = anticanonical_divisor(dP3)

--- a/test/ToricVarieties/toric_morphisms.jl
+++ b/test/ToricVarieties/toric_morphisms.jl
@@ -5,7 +5,7 @@ using Test
     
     source = projective_space(NormalToricVariety, 1; set_attributes)
     target = hirzebruch_surface(2; set_attributes)
-    tm1 = ToricMorphism(source, matrix(ZZ, [[0, 1]]), target)
+    tm1 = toric_morphism(source, matrix(ZZ, [[0, 1]]), target)
     tm2 = ToricIdentityMorphism(target)
     tm3 = ToricIdentityMorphism(hirzebruch_surface(4; set_attributes))
     

--- a/test/ToricVarieties/toric_morphisms.jl
+++ b/test/ToricVarieties/toric_morphisms.jl
@@ -6,8 +6,8 @@ using Test
     source = projective_space(NormalToricVariety, 1; set_attributes)
     target = hirzebruch_surface(2; set_attributes)
     tm1 = toric_morphism(source, matrix(ZZ, [[0, 1]]), target)
-    tm2 = ToricIdentityMorphism(target)
-    tm3 = ToricIdentityMorphism(hirzebruch_surface(4; set_attributes))
+    tm2 = toric_identity_morphism(target)
+    tm3 = toric_identity_morphism(hirzebruch_surface(4; set_attributes))
     
     @testset "Argument errors for toric morphisms" begin
         @test_throws ArgumentError tm1 * tm1


### PR DESCRIPTION
This PR aims at completing the conversion from `CamelCase` to `snake_case` constructors for the toric varieties. Here, we change the following constructors:
* `ToricDivisor` -> `toric_divsior`,
* `DivisorOfCharacter` -> `divisor_of_character`,
* `ToricDivisorClass` -> `toric_divisor_class`,
* `ToricLineBundle` -> `toric_line_bundle`,
* `ToricMorphism` -> `toric_moprhism`,
* `ToricIdentityMorphism` -> `toric_identity_morphism`.

I also add a constructor `toric_vanishing _set`.