### PR TITLE
support `iso_gap_oscar` for multivariate pol. rings

### DIFF
--- a/src/GAP/iso_gap_oscar.jl
+++ b/src/GAP/iso_gap_oscar.jl
@@ -52,6 +52,8 @@ function _iso_gap_oscar(F::GAP.GapObj)
      return _iso_gap_oscar_ring_integers(F)
    elseif GAPWrap.IsUnivariatePolynomialRing(F)
      return _iso_gap_oscar_univariate_polynomial_ring(F)
+   elseif GAPWrap.IsPolynomialRing(F)
+     return _iso_gap_oscar_multivariate_polynomial_ring(F)
    end
 
    error("no method found")
@@ -122,6 +124,14 @@ function _iso_gap_oscar_univariate_polynomial_ring(RG::GAP.GapObj)
    return MapFromFunc(f, finv, RG, RO)
 end
 
+function _iso_gap_oscar_multivariate_polynomial_ring(RG::GAP.GapObj)
+   coeffs_iso = iso_gap_oscar(GAP.Globals.LeftActingDomain(RG))
+   nams = [string(x) for x in GAP.Globals.IndeterminatesOfPolynomialRing(RG)]
+   RO, x = PolynomialRing(codomain(coeffs_iso), nams)
+   finv, f = _iso_oscar_gap_polynomial_ring_functions(RO, RG, inv(coeffs_iso))
+
+   return MapFromFunc(f, finv, RG, RO)
+end
 
 # Use a GAP attribute for caching the mapping.
 # The following must be executed at runtime,

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -102,6 +102,7 @@ GAP.@wrap IsPerfectGroup(x::Any)::Bool
 GAP.@wrap IsPermGroup(x::Any)::Bool
 GAP.@wrap IsPGroup(x::Any)::Bool
 GAP.@wrap IsPolynomial(x::Any)::Bool
+GAP.@wrap IsPolynomialRing(x::Any)::Bool
 GAP.@wrap IsPrimeField(x::Any)::Bool
 GAP.@wrap IsPrimitive(x::Any, y::Any)::Bool
 GAP.@wrap IsPrimitive(x::Any)::Bool

--- a/test/GAP/iso_gap_oscar.jl
+++ b/test/GAP/iso_gap_oscar.jl
@@ -155,3 +155,23 @@ end
       @test_throws ErrorException preimage(iso, PolynomialRing(QQ, "y")[1]())
    end
 end
+
+@testset "multivariate polynomial rings" begin
+   baserings = [GAP.Globals.Rationals,
+                GAP.Globals.Integers,
+                GAP.Globals.GF(2),
+                GAP.Globals.GF(2, 3),
+               ]
+   @testset for R in baserings
+      PR = GAP.Globals.PolynomialRing(R, 3)
+      x, y, z = GAP.Globals.GeneratorsOfAlgebraWithOne(PR)
+      iso = Oscar.iso_gap_oscar(PR)
+      for pol in [zero(x), one(x), x, x^3+x+1, x*y+z+1]
+         img = iso(pol)
+         @test preimage(iso, img) == pol
+      end
+      @test_throws ErrorException iso(GAP.Globals.Z(2))
+      @test_throws ErrorException image(iso, GAP.Globals.Z(2))
+      @test_throws ErrorException preimage(iso, PolynomialRing(QQ, "y")[1]())
+   end
+end

--- a/test/GAP/iso_oscar_gap.jl
+++ b/test/GAP/iso_oscar_gap.jl
@@ -196,9 +196,7 @@ end
    baserings = [QQ,                           # yields `FmpqPolyRing`
                 ZZ,                           # yields `FmpzPolyRing`
                 GF(2,2),                      # yields `FqNmodPolyRing`
-#               FqDefaultFiniteField(fmpz(2),3,:x), # yields `FqDefaultPolyRing`
-#TODO: This case fails due to a problem in AA/Nemo,
-#      see https://github.com/Nemocas/Nemo.jl/issues/1307
+                FqDefaultFiniteField(fmpz(2),3,:x), # yields `FqDefaultPolyRing`
                 FqFiniteField(fmpz(2),2,:z),  # yields `FqPolyRing`
                 GF(fmpz(2)),                  # yields `GFPFmpzPolyRing`
                 GF(2),                        # yields `GFPPolyRing`


### PR DESCRIPTION
(Meinolf had asked for this)

(also added one test for `iso_oscar_gap` that did not work some time ago)