### PR TITLE
PolyhedralGeometry: automorphism_group fixed for trivial case

### DIFF
--- a/src/Combinatorics/Graphs.jl
+++ b/src/Combinatorics/Graphs.jl
@@ -605,7 +605,7 @@ julia> automorphism_group_generators(g)
 function automorphism_group_generators(g::Graph{T}) where {T <: Union{Directed, Undirected}}
     pmg = pm_object(g);
     result = Polymake.graph.automorphisms(pmg)
-    return _pm_arr_arr_to_group_generators(result)
+    return _pm_arr_arr_to_group_generators(result, nv(g))
 end
 
 

--- a/test/PolyhedralGeometry/Group.jl
+++ b/test/PolyhedralGeometry/Group.jl
@@ -42,4 +42,17 @@
         P = Polyhedron([-1 0 0; 0 -1 0; 0 0 -1],[0,0,0])
         @test_throws ArgumentError combinatorial_symmetries(P)
     end
+
+    @testset "trivial automorphism_group" begin
+        M = matroid_from_nonbases([[1,2,3,4],[1,2,5,6],[1,3,5,7],[3,4,6,8]],8)
+        GM = automorphism_group(M)
+        @test is_trivial(GM)
+        IM = IncidenceMatrix(bases(M))
+        GIM = automorphism_group(IM)
+        @test length(GIM) == 2
+        @test haskey(GIM, :on_cols)
+        @test haskey(GIM, :on_rows)
+        @test is_trivial(GIM[:on_cols])
+        @test is_trivial(GIM[:on_rows])
+    end
 end


### PR DESCRIPTION
When there is no automorphism, except for the identity, it can be hard to determine the degree and the usual methods did not work. This should be fixed now.