### PR TITLE
changes in argument orders of functions

### DIFF
--- a/docs/src/Groups/subgroups.md
+++ b/docs/src/Groups/subgroups.md
@@ -19,11 +19,14 @@ The following functions are available in OSCAR for subgroup properties:
 
 ```@docs
 sub(G::GAPGroup, gens::AbstractVector{<:GAPGroupElem}; check::Bool = true)
-is_subgroup
-embedding(G::T, H::T) where T <: GAPGroup
+is_subset(H::T, G::T) where T <: GAPGroup
+is_subgroup(H::T, G::T) where T <: GAPGroup
+embedding(H::T, G::T) where T <: GAPGroup
 index(G::T, H::T) where T <: GAPGroup
-is_normal(G::T, H::T) where T <: GAPGroup
-is_characteristic(G::T, H::T) where T <: GAPGroup
+is_maximal_subgroup(H::T, G::T) where T <: GAPGroup
+is_normalized_by(H::T, G::T) where T <: GAPGroup
+is_normal_subgroup(H::T, G::T) where T <: GAPGroup
+is_characteristic_subgroup(H::T, G::T) where T <: GAPGroup
 ```
 
 ## Standard subgroups

--- a/experimental/GModule/Cohomology.jl
+++ b/experimental/GModule/Cohomology.jl
@@ -385,8 +385,7 @@ end
    - make sure that image/ kernel are consistent
    - preimage 
    - issubset yields (for GrpAb) only true/ false, not the map
-   - is_subgroup has the "wrong" order of arguments (and cannot apply
-     to modules)
+   - is_subgroup cannot apply to modules
    - quo does ONLY work if B is a direct submodule of A (Z-modules)
    - mat or matrix is used to get "the matrix" from a hom
    - zero_hom/ zero_obj/ identity_hom is missing
@@ -2118,7 +2117,7 @@ Sort:
 # - a magic(?) function to get idel-aproximations in and out?
 
 function restrict(C::GModule, U::Oscar.GAPGroup)
-  fl, m = is_subgroup(C.G, U)
+  fl, m = is_subgroup(U, C.G)
   @assert fl
   return gmodule(U, [action(C, m(g)) for g = gens(U)])
 end

--- a/experimental/GaloisGrp/GaloisGrp.jl
+++ b/experimental/GaloisGrp/GaloisGrp.jl
@@ -949,7 +949,7 @@ function invariant(G::PermGroup, H::PermGroup)
       hH = image(h, H)[1]
       if order(hG) > order(hH)
         @vprint :GaloisInvariant 2 "differ on action on $o, recursing\n"
-        @hassert :GaloisInvariant 0 is_maximal(hG, hH)
+        @hassert :GaloisInvariant 0 is_maximal_subgroup(hH, hG)
         I = invariant(hG, hH)
         return evaluate(I, g[collect(o)])
       end
@@ -1595,21 +1595,21 @@ function starting_group(GC::GaloisCtx, K::T; useSubfields::Bool = true) where T 
         G = intersect(G, ar)[1]
       else
         let ar = ar 
-          push!(F, x->!is_subgroup(ar, x)[1], "subfield is even/odd")
+          push!(F, x->!is_subset(x, ar), "subfield is even/odd")
         end
       end
     end
     if in_br
       #G = intersect(G, br)[1] #already done above
     else
-      #push!(F, x->!is_subgroup(br, x)[1]) #already done above
+      #push!(F, x->!is_subset(x, br)) #already done above
     end
     if can_use_wr
       if in_cr
         G = intersect(G, cr)[1]
       else
         let cr = cr
-          push!(F, x->!is_subgroup(cr, x)[1], "third subgroup of wreath product")
+          push!(F, x->!is_subset(x, cr), "third subgroup of wreath product")
         end
       end
     end

--- a/experimental/GaloisGrp/Group.jl
+++ b/experimental/GaloisGrp/Group.jl
@@ -8,7 +8,7 @@ function maximal_subgroup_chain(G::PermGroup, U::PermGroup)
   l = [G]
   while order(l[end]) > order(U)
     m = maximal_subgroups(l[end])
-    push!(l, m[findfirst(x -> is_subgroup(x, U)[1], m)])
+    push!(l, m[findfirst(x -> is_subset(U, x), m)])
   end
   return reverse(l)
 

--- a/experimental/GaloisGrp/Solve.jl
+++ b/experimental/GaloisGrp/Solve.jl
@@ -168,7 +168,7 @@ original roots
 max_prec can be given to limit the internal precision
 """
 function _fixed_field(C::GaloisCtx, S::SubField, U::PermGroup; invar=nothing, max_prec::Int = typemax(Int))
-  @hassert :SolveRadical 1 is_subgroup(S.grp, U)[1]
+  @hassert :SolveRadical 1 is_subset(U, S.grp)
   t = right_transversal(S.grp, U)
   @assert isone(t[1])
   if invar !== nothing

--- a/experimental/SymmetricIntersections/Representations.jl
+++ b/experimental/SymmetricIntersections/Representations.jl
@@ -378,7 +378,7 @@ function center_of_character(chi::Oscar.GAPGroupClassFunction)
   E = chi.table.GAPGroup
   _H = GG.CenterOfCharacter(chi.values)::GAP.GapObj
   H = typeof(E)(_H)
-  ok, j = is_subgroup(E, H)
+  ok, j = is_subgroup(H, E)
   @assert ok
   return H, j
 end
@@ -514,7 +514,7 @@ This is equivalent to ask that the center of `chi` contains the kernel of `p`.
 """
 function is_projective(chi::Oscar.GAPGroupClassFunction, p::GAPGroupHomomorphism)
   @req chi.table.GAPGroup === domain(p) "Incompatible representation ring of rep and domain of the cover p"
-  return is_subgroup(center_of_character(chi)[1], kernel(p)[1])[1]
+  return is_subset(kernel(p)[1], center_of_character(chi)[1])
 end
 
 is_projective(rep::LinRep, p::GAPGroupHomomorphism) = is_projective(character_representation(rep), p)

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -895,7 +895,7 @@ function is_conjugate_subgroup(G::T, U::T, V::T) where T <: GAPGroup
   end
   s = short_right_transversal(G, U, sigma)
   for t = s
-    if is_subgroup(U, V^inv(t))[1]
+    if is_subset(V^inv(t), U)
       return true, inv(t)
     end
   end

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -471,8 +471,8 @@ function double_cosets(G::T, H::T, K::T; check::Bool=true) where T<: GAPGroup
    if !check
       dcs = GAP.Globals.DoubleCosetsNC(G.X,H.X,K.X)
    else
-      @assert is_subgroup(G,H)[1] "H is not a subgroup of G"
-      @assert is_subgroup(G,K)[1] "K is not a subgroup of G"
+      @assert is_subset(H, G) "H is not a subgroup of G"
+      @assert is_subset(K, G) "K is not a subgroup of G"
       dcs = GAP.Globals.DoubleCosets(G.X,H.X,K.X)
    end
    res = Vector{GroupDoubleCoset{T,elem_type(T)}}(undef, length(dcs))

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -275,7 +275,7 @@ function restrict_homomorphism(f::GAPGroupHomomorphism, H::GAPGroup)
   # (The GAP documentation does not claim anything about the result
   # in the case that `H` is not a subgroup of `f.domain`,
   # and in fact just the given map may be returned.)
-  @assert is_subgroup(domain(f), H)[1] "Not a subgroup!"
+  @assert is_subset(H, domain(f)) "Not a subgroup!"
   return GAPGroupHomomorphism(H, f.codomain, GAP.Globals.RestrictedMapping(f.map,H.X)::GapObj)
 end
 

--- a/src/Groups/matrices/linear_centralizer.jl
+++ b/src/Groups/matrices/linear_centralizer.jl
@@ -443,7 +443,7 @@ end
 
 Return (`C`,`f`), where `C` is the centralizer of `x` in `C` and `f` is the embedding of `C` into `G`.
 If `G` = `GL(n,F)` or `SL(n,F)`, then `f` = `nothing`. In this case, to get the embedding homomorphism of `C` into `G`, use
-> `is_subgroup(G,C)[2]`
+> `is_subgroup(C, G)[2]`
 """
 function centralizer(G::MatrixGroup{T}, x::MatrixGroupElem{T}) where T <: FinFieldElem
    if isdefined(G,:descr) && (G.descr==:GL || G.descr==:SL)

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -6,8 +6,8 @@ export derived_subgroup, has_derived_subgroup, set_derived_subgroup
 export embedding
 export epimorphism_from_free_group
 export index
-export is_characteristic_subgroup,
-export is_maximal_subgroup,
+export is_characteristic_subgroup
+export is_maximal_subgroup
 export is_nilpotent, has_is_nilpotent, set_is_nilpotent
 export is_normal_subgroup
 export is_normalized_by

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -6,9 +6,11 @@ export derived_subgroup, has_derived_subgroup, set_derived_subgroup
 export embedding
 export epimorphism_from_free_group
 export index
-export is_characteristic
-export is_maximal
+export is_characteristic_subgroup,
+export is_maximal_subgroup,
 export is_nilpotent, has_is_nilpotent, set_is_nilpotent
+export is_normal_subgroup
+export is_normalized_by
 export is_solvable, has_is_solvable, set_is_solvable
 export is_supersolvable, has_is_supersolvable, set_is_supersolvable
 export maximal_abelian_quotient, has_maximal_abelian_quotient, set_maximal_abelian_quotient
@@ -71,13 +73,36 @@ function sub(gens::GAPGroupElem...)
 end
 
 """
-    is_subgroup(G::T, H::T) where T <: GAPGroup
+    is_subset(H::T, G::T) where T <: GAPGroup
+
+Return `true` if `H` is a subset of `G`, otherwise return `false`.
+
+# Examples
+```jldoctest
+julia> g = symmetric_group(300); h = derived_subgroup(g)[1];
+
+julia> is_subset(h, g)
+true
+
+julia> is_subset(g, h)
+false
+```
+"""
+function is_subset(H::T, G::T) where T <: GAPGroup
+   return all(h -> h in G, gens(H))
+end
+
+"""
+    is_subgroup(H::T, G::T) where T <: GAPGroup
 
 Return (`true`,`f`) if `H` is a subgroup of `G`, where `f` is the embedding
 homomorphism of `H` into `G`, otherwise return (`false`,`nothing`).
+
+If you do not need the embedding then better call
+[`is_subset(H::T, G::T) where T <: GAPGroup`](@ref).
 """
-function is_subgroup(G::T, H::T) where T <: GAPGroup
-   if !all(h -> h in G, gens(H))
+function is_subgroup(H::T, G::T) where T <: GAPGroup
+   if !is_subset(H, G)
       return (false, nothing)
    else
       return (true, _as_subgroup(G, H.X)[2])
@@ -85,13 +110,13 @@ function is_subgroup(G::T, H::T) where T <: GAPGroup
 end
 
 """
-    embedding(G::T, H::T) where T <: GAPGroup
+    embedding(H::T, G::T) where T <: GAPGroup
 
 Return the embedding morphism of `H` into `G`.
 An exception is thrown if `H` is not a subgroup of `G`.
 """
-function embedding(G::T, H::T) where T <: GAPGroup
-   a, f = is_subgroup(G,H)
+function embedding(H::T, G::T) where T <: GAPGroup
+   a, f = is_subgroup(H, G)
    a || throw(ArgumentError("H is not a subgroup of G"))
    return f
 end
@@ -233,31 +258,43 @@ const centraliser = centralizer
 
 ################################################################################
 #
-#  IsNormal, IsCharacteristic, IsSolvable, IsNilpotent
+#  is_normal_subgroup, is_characteristic_subgroup, is_solvable, is_nilpotent
 #
 ################################################################################
 
 """
-    is_maximal(G::T, H::T) where T <: GAPGroup
+    is_maximal_subgroup(H::T, G::T; check::Bool = true) where T <: GAPGroup
 
 Return whether `H` is a maximal subgroup of `G`, i. e.,
 whether `H` is a proper subgroup of `G` and there is no proper subgroup of `G`
 that properly contains `H`.
 
+If `check` is set to `false` then it is not checked
+whether `H` is a subgroup of `G`.
+If `check` is not set to `false` then an exception is thrown
+if `H` is not a subgroup of `G`.
+
 # Examples
 ```jldoctest
 julia> G = symmetric_group(4);
 
-julia> is_maximal(G, sylow_subgroup(G, 2)[1])
+julia> is_maximal_subgroup(sylow_subgroup(G, 2)[1], G)
 true
 
-julia> is_maximal(G, sylow_subgroup(G, 3)[1])
+julia> is_maximal_subgroup(sylow_subgroup(G, 3)[1], G)
 false
 
+julia> is_maximal_subgroup(sylow_subgroup(G, 3)[1], sylow_subgroup(G, 2)[1])
+ERROR: ArgumentError: H is not a subgroup of G
 ```
 """
-function is_maximal(G::T, H::T) where T <: GAPGroup
-  is_subgroup(G, H)[1] || return false
+function is_maximal_subgroup(H::T, G::T; check::Bool = true) where T <: GAPGroup
+  # In earlier times, `is_maximal` returned `false` if `H` was not a subgroup
+  # if `G`, but at that time `G` was the first argument.
+  # In order to avoid wrong results due to the reordering of arguments,
+  # we throw an exception if `H` is not a subgroup of `G`.
+  # (Just in case that you think about removing this exception.)
+  check && !is_subset(H, G) && throw(ArgumentError("H is not a subgroup of G"))
   if order(G) // order(H) < 100
     t = right_transversal(G, H)[2:end] #drop the identity
     return all(x -> order(sub(G, vcat(gens(H), [x]))[1]) == order(G), t)
@@ -265,29 +302,99 @@ function is_maximal(G::T, H::T) where T <: GAPGroup
   return any(M -> is_conjugate(G, M, H), maximal_subgroup_reps(G))
 end
 
+# `is_maximal` had the wrong order of arguments,
+# see https://github.com/oscar-system/Oscar.jl/issues/1793
+@deprecate is_maximal(G::T, H::T) where T <: GAPGroup is_maximal_subgroup(H, G)
+
 """
-    is_normal(G::T, H::T) where T <: GAPGroup
+    is_normalized_by(H::T, G::T) where T <: GAPGroup
 
 Return whether the group `H` is normalized by `G`, i.e.,
 whether `H` is invariant under conjugation with elements of `G`.
 
-!!! note
-    To test whether `H` is a normal subgroup, use `is_normal(G, H) && issubset(H, G)`
+Note that `H` need not be a subgroup of `G`.
+To test whether `H` is a normal subgroup of `G`,
+use [`is_normal_subgroup`](@ref).
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(4);
+
+julia> is_normalized_by(sylow_subgroup(G, 2)[1], G)
+false
+
+julia> is_normalized_by(derived_subgroup(G)[1], G)
+true
+
+julia> is_normalized_by(derived_subgroup(G)[1], sylow_subgroup(G, 2)[1])
+true
+```
 """
-is_normal(G::T, H::T) where T <: GAPGroup = GAPWrap.IsNormal(G.X, H.X)
+is_normalized_by(H::T, G::T) where T <: GAPGroup = GAPWrap.IsNormal(G.X, H.X)
+
+# `is_normal` had the wrong order of arguments,
+# see https://github.com/oscar-system/Oscar.jl/issues/1793
+@deprecate is_normal(G::T, H::T) where T <: GAPGroup is_normalized_by(H, G)
 
 """
-    is_characteristic(G::T, H::T) where T <: GAPGroup
+    is_normal_subgroup(H::T, G::T) where T <: GAPGroup
 
-Return whether the subgroup `H` is characteristic in `G`,
+Return whether the group `H` is a normal subgroup of `G`, i.e., whether `H`
+is a subgroup of `G` that is invariant under conjugation with elements of `G`.
+
+(See [`is_normalized_by`](@ref) for an invariance check only.)
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(4);
+
+julia> is_normal_subgroup(sylow_subgroup(G, 2)[1], G)
+false
+
+julia> is_normal_subgroup(derived_subgroup(G)[1], G)
+true
+
+julia> is_normal_subgroup(derived_subgroup(G)[1], sylow_subgroup(G, 2)[1])
+false
+```
+"""
+function is_normal_subgroup(H::T, G::T) where T <: GAPGroup
+  return is_subset(H, G) && is_normalized_by(H, G)
+end
+
+"""
+    is_characteristic_subgroup(H::T, G::T; check::Bool = true) where T <: GAPGroup
+
+Return whether the subgroup `H` of `G` is characteristic in `G`,
 i.e., `H` is invariant under all automorphisms of `G`.
 
-!!! note
-    To test whether `H` is a characteristic subgroup, use `is_characteristic(G, H) && issubset(H, G)`
+If `check` is set to `false` then it is not checked
+whether `H` is a subgroup of `G`.
+If `check` is not set to `false` then an exception is thrown
+if `H` is not a subgroup of `G`.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(4);
+
+julia> is_characteristic_subgroup(derived_subgroup(G)[1], G)
+true
+
+julia> is_characteristic_subgroup(sylow_subgroup(G, 3)[1], G)
+false
+
+julia> is_characteristic_subgroup(sylow_subgroup(G, 3)[1], sylow_subgroup(G, 2)[1])
+ERROR: ArgumentError: H is not a subgroup of G
+```
 """
-function is_characteristic(G::T, H::T) where T <: GAPGroup
+function is_characteristic_subgroup(H::T, G::T; check::Bool = true) where T <: GAPGroup
+  check && !is_subset(H, G)[1] && throw(ArgumentError("H is not a subgroup of G"))
   return GAPWrap.IsCharacteristicSubgroup(G.X, H.X)
 end
+
+# `is_characteristic` had the wrong order of arguments,
+# see https://github.com/oscar-system/Oscar.jl/issues/1793
+@deprecate is_characteristic(G::T, H::T) where T <: GAPGroup is_characteristic_subgroup(H, G)
 
 """
     is_solvable(G::GAPGroup)

--- a/test/Experimental/SymmetricIntersections-test.jl
+++ b/test/Experimental/SymmetricIntersections-test.jl
@@ -59,7 +59,7 @@ end
     chidt = exterior_power(chid, 3)
     @test all(nu -> is_constituent(chidt, determinant(nu)), cs)
     Z, _ = center_of_character(chid)
-    @test is_subgroup(E, Z)[1]
+    @test is_subset(Z, E)
 
     rep = @inferred affording_representation(RR, chi)
     @test representation_ring(rep) === RR

--- a/test/Groups/directproducts.jl
+++ b/test/Groups/directproducts.jl
@@ -147,7 +147,7 @@ end
    H = sub(G,[x])[1]
    @test H(Q[1]*Q[2],C[1])==x
    @test_throws ArgumentError H(Q[1],C[1])
-   @test is_subgroup(G,H)[1]
+   @test is_subset(H, G)
    @test index(G,H)==4
    @test !is_full_semidirect_product(H)
    @test projection(G)(x)==projection(H)(x)

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -537,7 +537,7 @@ TestKernels = function(G,H,f)
       @test (i*f)(K[j])==one(H)
       @test index(G,K)==order(Im)
    end
-   if is_normal(H,Im) 
+   if is_normalized_by(Im, H)
       C,p = cokernel(f)
         @test is_surjective(p)
       for j in 1:ngens(G)
@@ -609,7 +609,8 @@ end
    AA,phi = sub(A,[g1,g2])
    @test is_isomorphic(AA,alt)
    @test index(A,AA)==2
-   @test is_normal(A,AA)
+   @test is_normal_subgroup(AA, A)
+   @test is_normalized_by(AA, A)
    @test phi(AA[1])==AA[1]
    @test phi(AA[2])==AA[2]
    @test order(quo(A,AA)[1])==2

--- a/test/Groups/libraries.jl
+++ b/test/Groups/libraries.jl
@@ -228,7 +228,7 @@ end
    G = atlas_group("M11")
    H, emb = atlas_subgroup(G, 1)
    @test order(H) == 720
-   @test is_subgroup(G, H)[1]
+   @test is_subset(H, G)
    @test domain(emb) == H
    @test codomain(emb) == G
    # the group was not created with `atlas_group`

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -487,7 +487,7 @@ end
    O = GO(1,2,F)
    H = intersect(S,O)[1]
    @test H==SO(1,2,F)
-   @test is_normal(O,H)
+   @test is_normal_subgroup(H, O)
    @test index(O,H)==2
 #   @test index(GO(0,3,3), omega_group(0,3,3))==4
    @test index(GO(1,2,8), omega_group(1,2,8))==2

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -12,16 +12,16 @@
    @test codomain(f)==G
    @test [f(x) for x in gens(H)]==gens(H)
    @test (H,f)==(K,g)
-   @test is_subgroup(G,K)[1]
-   @test g==is_subgroup(G,K)[2]
-   @test g==embedding(G,K)
-   @test is_normal(G,H)
+   @test is_subset(K, G)
+   @test g == is_subgroup(K, G)[2]
+   @test g == embedding(K, G)
+   @test is_normal_subgroup(H, G)
    H,f=sub(G,[x,z])
    @test H==G
    @test f==id_hom(G)
 
-   @test !is_subgroup(G,symmetric_group(8))[1]
-   @test_throws ArgumentError embedding(G,symmetric_group(8))
+   @test !is_subset(symmetric_group(8), G)
+   @test_throws ArgumentError embedding(symmetric_group(8), G)
 
    H=sub(G,[G([2,3,1]),G([2,1])])[1]
    @test H != symmetric_group(3)
@@ -34,7 +34,7 @@
    L = subgroups(G)
    @test length(L)==30
    @test L[1] isa PermGroup
-   L1 = [x for x in L if is_normal(G,x)]
+   L1 = [x for x in L if is_normal_subgroup(x, G)]
    K = normal_subgroups(G)
    @test length(K)==4
    for H in L1
@@ -47,7 +47,7 @@
    @test minimal_normal_subgroups(G)==[H]
    @test length(characteristic_subgroups(G))==4
    @test H in characteristic_subgroups(G)
-   @test is_characteristic(G,H)
+   @test is_characteristic_subgroup(H, G)
 
    H1,h1 = sub(G, gens(symmetric_group(3)))
    H2,h2 = sub(G, gens(alternating_group(4)))
@@ -100,8 +100,8 @@ end
 
    Nx = normalizer(G,Cx)[1]
    Ny = normalizer(G,Cy)[1]
-   @test is_normal(Nx,Cx)
-   @test is_normal(Ny,Cy)
+   @test is_normal_subgroup(Cx, Nx)
+   @test is_normal_subgroup(Cy, Ny)
    notx = setdiff(G,Nx)
    noty = setdiff(G,Ny)
    @testset for i in 1:3
@@ -131,12 +131,12 @@ end
    Q=quaternion_group(16)
    H=sub(Q,[Q[1]])[1]
    C=core(Q,H)[1]
-   @test is_normal(Q,C)
+   @test is_normal_subgroup(C, Q)
    @test order(C)==2
    S=symmetric_group(4)
    P2=pcore(S,2)[1]
    @test order(P2)==4
-   @test is_normal(S,P2)
+   @test is_normal_subgroup(P2, S)
    P3=pcore(S,3)[1]
    @test order(P3)==1
    @test_throws ArgumentError pcore(S,4)
@@ -321,7 +321,7 @@ end
    @test [is_prime(is_power(l)[2]) for l in Lo] == [1 for i in 1:length(L)]
 
    L = hall_system(symmetric_group(4))
-   @test is_subgroup(symmetric_group(4),L[1])[1]
+   @test is_subset(L[1], symmetric_group(4))
    @test Set(order(H) for H in L)==Set(ZZRingElem[1,3,8,24])
    @test_throws ArgumentError hall_system(symmetric_group(5))
    

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -362,7 +362,7 @@ end
    @test frattini_subgroup(S)==sub(S,[one(S)])
    @test frattini_subgroup(G)[1]==intersect(maximal_subgroups(G))[1]
    @test frattini_subgroup(G)==center(G)
-   @test is_characteristic(G,center(G)[1])
+   @test is_characteristic_subgroup(center(G)[1], G)
    @test socle(G)==frattini_subgroup(G)
    @test socle(S)==fitting_subgroup(S)   
    @test radical_subgroup(S)[1]==S


### PR DESCRIPTION
Resolves #1793 and resolves #163.

- `is_subgroup(H::T, G::T) where T <: GAPGroup`:
  Swap the argument order such that the it is checked whether `H` is a subgroup of `G` (unlike in GAP). Note that this is already the definition of `is_subgroup` for the abelian groups that come from Hecke. And this definition fits to that of `is_subset`. This is of course a *breaking change*.
- `embedding(H::T, G::T) where T <: GAPGroup`:
  This is analogous to `is_subgroup`, except that there are no other methods for two groups.
  This is of course a *breaking change*.
- `is_maximal(...)`:
  This is now deprecated, and calls the newly introduced `is_maximal_subgroup(H::T, G::T) where T <: GAPGroup`. This is a *breaking change* in the sense that up to now, `is_maximal` returned `false` in the situation that `H` is not a subgroup of `G`, and from now on, an exception is thrown instead.
- `is_normal(G::T, H::T) where T <: GAPGroup`:
  This is now deprecated, and calls the newly introduced `is_normalized_by(H::T, G::T) where T <: GAPGroup`; the behaviour of `is_normal(G::T, H::T) where T <: GAPGroup` does not change. Note that the two functions do not require `H` to be a subgroup of `G`; in addition, there is a new function `is_normal_subgroup(H::T, G::T) where T <: GAPGroup`.
- `is_characteristic(G::T, H::T) where T <: GAPGroup`:
  This is now deprecated, and calls the newly introduced `is_characteristic_subgroup(H::T, G::T) where T <: GAPGroup`. Note that we define this function only for the case that `H` is a subgroup of `G`, and from now on an exception will be thrown if this is not the case. GAP does not (yet) document this condition, but it may run into an error if this condition is not satisfied. In this sense, this is a *breaking change* for `is_characteristic(G::T, H::T) where T <: GAPGroup`, it will throw an exception in certain situations where `H` is not a subgroup of `G` (and where the underlying GAP function may or may not run into an error).

The Oscar code, tests, and documentation have been adjusted to these changes. (The `is_subgroup` calls where the arguments are not in `GAPGroup` have not been changed.)

Calls of the kind `is_subgroup(G, H)[1]` have been replaced by `is_subset(H, G)`, and a generic `is_subset` method for this situation (based on membership tests for the generators of `H`) has been installed.