### PR TITLE
Remove invalid root test

### DIFF
--- a/test/Rings/integer-test.jl
+++ b/test/Rings/integer-test.jl
@@ -482,7 +482,6 @@ end
    @test_throws DomainError isqrtrem(ZZ(-4))
 
    @test root(ZZ(16), 2) == 4
-   @test root(ZZ(5), 3) == 1
    @test root(ZZ(-8), 3) == -2
    @test root(ZZ(0), 2) == 0
    @test root(ZZ(0), 3) == 0


### PR DESCRIPTION
The function `root` is for computing exact roots, and by default throws an
exception if the input is not a perfect power (except that this was
disabled in Nemo for some time, and has only been re-enabled in the most
recent version).

For integer truncated roots, use `iroot`.
