### PR TITLE
Update URLs to www.oscar-system.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ julia> using Oscar
 
 However, some of OSCAR's components have additional requirements.
 For more detailed information, please consult the [installation
-instructions](https://oscar.computeralgebra.de/install/) on our website.
+instructions](https://www.oscar-system.org/install/) on our website.
 
 ## Contributing to OSCAR
 
@@ -129,7 +129,7 @@ PropertyValue wrapping pm::Array<polymake::topaz::HomologyGroup<pm::Integer>>
 If you have used OSCAR in the preparation of a paper please cite it as described below:
 
     [OSCAR]
-        OSCAR -- Open Source Computer Algebra Research system, Version 0.12.0-DEV The OSCAR Team, 2023. (https://oscar.computeralgebra.de)
+        OSCAR -- Open Source Computer Algebra Research system, Version 0.12.0-DEV The OSCAR Team, 2023. (https://www.oscar-system.org)
     [OSCAR-book]
         Christian Eder, Wolfram Decker, Claus Fieker, Max Horn, Michael Joswig, The OSCAR book, 2024.
 
@@ -141,7 +141,7 @@ If you are using BibTeX, you can use the following BibTeX entries:
       title        = {OSCAR -- Open Source Computer Algebra Research system,
                       Version 0.12.0-DEV},
       year         = {2023},
-      url          = {https://oscar.computeralgebra.de},
+      url          = {https://www.oscar-system.org},
       }
 
     @Book{OSCAR-book,

--- a/docs/src/AlgebraicGeometry/Curves/para_rational_curves.md
+++ b/docs/src/AlgebraicGeometry/Curves/para_rational_curves.md
@@ -95,6 +95,6 @@ Please direct questions about this part of OSCAR to the following people:
 * [Janko Böhm](https://www.mathematik.uni-kl.de/~boehm/),
 * [Wolfram Decker](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-wolfram-decker/seite).
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/AlgebraicGeometry/Schemes/intro.md
+++ b/docs/src/AlgebraicGeometry/Schemes/intro.md
@@ -30,6 +30,6 @@ Please direct questions about this part of OSCAR to the following people:
 * [Anne Frühbis-Krüger](https://uol.de/anne-fruehbis-krueger),
 * [Matthias Zach](https://www.mathematik.uni-kl.de/en/agag/people/members),
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/AlgebraicGeometry/StandardConstructions/standard_constructions.md
+++ b/docs/src/AlgebraicGeometry/StandardConstructions/standard_constructions.md
@@ -26,6 +26,6 @@ grassmann_pluecker_ideal
 Please direct questions about this part of OSCAR to the following people:
 * [Wolfram Decker](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-wolfram-decker).
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/AlgebraicGeometry/Surfaces/K3Surfaces.md
+++ b/docs/src/AlgebraicGeometry/Surfaces/K3Surfaces.md
@@ -47,6 +47,6 @@ Please direct questions about this part of OSCAR to the following people:
 * [Simon Brandhorst](https://www.math.uni-sb.de/ag/brandhorst/index.php?lang=en).
 * [Matthias Zach](https://www.mathematik.uni-kl.de/en/agag/people/members),
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/Combinatorics/intro.md
+++ b/docs/src/Combinatorics/intro.md
@@ -22,6 +22,6 @@ Please direct questions about this part of OSCAR to the following people:
     * [Benjamin Schröter](https://www.math.uni-frankfurt.de/~schroete/)
     * [Lukas Kühne](https://www.math.uni-bielefeld.de/~lkuehne/).
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/CommutativeAlgebra/intro.md
+++ b/docs/src/CommutativeAlgebra/intro.md
@@ -54,6 +54,6 @@ General textbooks offering details on theory and algorithms include:
 Please direct questions about this part of OSCAR to the following people:
 * [Wolfram Decker](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-wolfram-decker).
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/DeveloperDocumentation/new_developers.md
+++ b/docs/src/DeveloperDocumentation/new_developers.md
@@ -22,8 +22,8 @@ on these things online.
      problems you might encounter and whether we can mitigate these by making
      changes to OSCAR.
    - Feel free to contact us on
-     [Slack](https://join.slack.com/t/oscar-system/shared_invite/zt-thtcv97k-2678bKQ~RpR~5gZszDcISw).
-   - Have a look at [our community page](https://oscar.computeralgebra.de/community/).
+     [Slack](https://oscar-system.org/slack).
+   - Have a look at [our community page](https://www.oscar-system.org/community/).
 4. Please also read our page on [Documenting OSCAR code](@ref).
 5. Look at existing code that does similar things to your project to get an
    idea of what OSCAR code should look like. Try to look at multiple examples.
@@ -137,7 +137,7 @@ using Revise, Oscar
 ```
 whenever you are using OSCAR in Julia.
 
-### Ask OSCAR Related Questions in the [OSCAR Slack](https://join.slack.com/t/oscar-system/shared_invite/zt-thtcv97k-2678bKQ~RpR~5gZszDcISw).
+### Ask OSCAR Related Questions in the [OSCAR Slack](https://oscar-system.org/slack).
 
 ### Use `]up`
 Working with the development version also entails that the packages `Oscar`

--- a/docs/src/Experimental/ToricSchemes/intro.md
+++ b/docs/src/Experimental/ToricSchemes/intro.md
@@ -42,6 +42,6 @@ Please direct questions about this part of OSCAR to the following people:
 * [Martin Bies](https://martinbies.github.io/),
 * [Matthias Zach](https://www.mathematik.uni-kl.de/en/agag/people/members/seite).
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/Fields/intro.md
+++ b/docs/src/Fields/intro.md
@@ -38,6 +38,6 @@ Please direct questions about this part of OSCAR to the following people:
 * [Tommy Hofmann](https://www.thofma.com/),
 * [Max Horn](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-max-horn).
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/General/architecture.md
+++ b/docs/src/General/architecture.md
@@ -17,7 +17,7 @@ Pages = ["architecture.md"]
 
 This page aims to give a short technical overview of the architecture of OSCAR.
 A more in-depth overview of the various components of OSCAR is given
-[on the OSCAR homepage](https://oscar.computeralgebra.de/about/).
+[on the OSCAR homepage](https://www.oscar-system.org/about/).
 
 ## Julia packages
 

--- a/docs/src/General/faq.md
+++ b/docs/src/General/faq.md
@@ -9,7 +9,7 @@ Pages = ["faq.md"]
 
 **Q: How do I install OSCAR?**
 
-You can find our installation instructions [here](https://oscar.computeralgebra.de/install/).
+You can find our installation instructions [here](https://www.oscar-system.org/install/).
 
 ---
 
@@ -135,7 +135,7 @@ background. Please read our page on [Complex Algorithms in OSCAR].
 
 **Q: How can I install OSCAR on Windows?**
 
-Please follow [the install instructions on our website](https://oscar.computeralgebra.de/install/).
+Please follow [the install instructions on our website](https://www.oscar-system.org/install/).
 
 ---
 

--- a/docs/src/Groups/intro.md
+++ b/docs/src/Groups/intro.md
@@ -34,6 +34,6 @@ Please direct questions about this part of OSCAR to the following people:
 * [Thomas Breuer](https://www.math.rwth-aachen.de/homes/Thomas.Breuer/),
 * [Max Horn](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-max-horn).
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/InvariantTheory/intro.md
+++ b/docs/src/InvariantTheory/intro.md
@@ -74,6 +74,6 @@ Please direct questions about this part of OSCAR to the following people:
 * [Max Horn](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-max-horn),
 * [Johannes Schmitt](https://joschmitt.eu/).
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/LinearAlgebra/intro.md
+++ b/docs/src/LinearAlgebra/intro.md
@@ -31,6 +31,6 @@ Please direct questions about this part of OSCAR to the following people:
 * [Claus Fieker](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-claus-fieker),
 * [Tommy Hofmann](https://www.thofma.com/).
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/NoncommutativeAlgebra/intro.md
+++ b/docs/src/NoncommutativeAlgebra/intro.md
@@ -39,6 +39,6 @@ offer details on theory and algorithms.
 Please direct questions about this part of OSCAR to the following people:
 * [Wolfram Decker](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-wolfram-decker).
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/NumberTheory/intro.md
+++ b/docs/src/NumberTheory/intro.md
@@ -29,6 +29,6 @@ Please direct questions about this part of OSCAR to the following people:
 * [Claus Fieker](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-claus-fieker),
 * [Tommy Hofmann](https://www.thofma.com/).
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/PolyhedralGeometry/intro.md
+++ b/docs/src/PolyhedralGeometry/intro.md
@@ -143,6 +143,6 @@ Please direct questions about this part of OSCAR to the following people:
 * [Lars Kastner](https://lkastner.github.io/),
 * Benjamin Lorenz.
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/Rings/intro.md
+++ b/docs/src/Rings/intro.md
@@ -32,6 +32,6 @@ Please direct questions about this part of OSCAR to the following people:
 * [Claus Fieker](https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-claus-fieker),
 * [Tommy Hofmann](https://www.thofma.com/).
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/StraightLinePrograms/intro.md
+++ b/docs/src/StraightLinePrograms/intro.md
@@ -211,6 +211,6 @@ Please direct questions about this part of OSCAR to the following people:
 * [Thomas Breuer](https://www.math.rwth-aachen.de/homes/Thomas.Breuer/),
 * [Raphael Fourquet](https://github.com/rfourquet).
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/ToricVarieties/intro.md
+++ b/docs/src/ToricVarieties/intro.md
@@ -46,6 +46,6 @@ Please direct questions about this part of OSCAR to the following people:
 * [Martin Bies](https://martinbies.github.io/),
 * [Lars Kastner](https://lkastner.github.io/).
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/docs/src/TropicalGeometry/intro.md
+++ b/docs/src/TropicalGeometry/intro.md
@@ -19,9 +19,9 @@ Please direct questions about this part of OSCAR to the following people:
 * [Marta Panizzut](https://martapanizzut.github.io/),
 * [Yue Ren](https://www.yueren.de/).
 
-You can ask questions in the [OSCAR Slack](https://oscar.computeralgebra.de/community/#slack).
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
-Alternatively, you can [raise an issue on github](https://oscar.computeralgebra.de/community/#how-to-report-issues).
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).
 
 
 ## Tropical semirings

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,13 +6,12 @@ algebraic and polyhedral geometry, and more. It is built upon several well
 established systems for mathematical research joined via the Julia programming
 language. Have a look at our [Architecture](@ref) page for a detailed overview
 and at our [installation
-instructions](https://oscar.computeralgebra.de/install/) for installing OSCAR.
+instructions](https://www.oscar-system.org/install/) for installing OSCAR.
 
 If you have questions about OSCAR, please have a look at our [Frequently Asked
 Questions](@ref) and feel free to contact us under the channels mentioned on
-[our community page](https://oscar.computeralgebra.de/community/). Our main
-communication channels are
-[Slack](https://join.slack.com/t/oscar-system/shared_invite/zt-thtcv97k-2678bKQ~RpR~5gZszDcISw)
+[our community page](https://www.oscar-system.org/community/). Our main
+communication channels are [Slack](https://oscar-system.org/slack)
 and [Github](https://github.com/oscar-system/Oscar.jl).
 
 If you are a new developer or interested in developing OSCAR, have a look at

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -13,7 +13,7 @@ into a comprehensive tool for computational algebra.
 
   For more information please visit
 
-  `https://oscar.computeralgebra.de`
+  `https://www.oscar-system.org`
 
 OSCAR is licensed under the GPL v3+ (see LICENSE.md).
 """
@@ -126,7 +126,7 @@ windows_error() = error("""
 
     This package unfortunately does not run natively under Windows.
     Please install Julia using Windows subsystem for Linux and try again.
-    See also https://oscar.computeralgebra.de/install/.
+    See also https://www.oscar-system.org/install/.
     """)
 
 if Sys.iswindows()


### PR DESCRIPTION
This is our new primary website. The old will keep working as a redirect (it may take some time for http://oscar.computeralgebra.de to redirect due to DNS caches and whatnot)

Also replace hardcoded Slack Join links by https://oscar-system.org/slack so that we only have to update the join URL in one place. Also, this URL is reasonably easy to remember and give to others.

Resolves #1792