### PR TITLE
fix renaming artifacts

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -1256,7 +1256,7 @@
   title         = {An algorithm to compute automorphism groups of {$K3$}
                   surfaces and an application to singular {$K3$} surfaces},
   mrnumber      = {3456710},
-  journal       = {Int. Math. ResidueRingElem. Not. IMRN},
+  journal       = {Int. Math. Res. Not. IMRN},
   fjournal      = {International Mathematics Research Notices. IMRN},
   number        = {22},
   pages         = {11961--12014},

--- a/docs/src/General/faq.md
+++ b/docs/src/General/faq.md
@@ -13,13 +13,6 @@ You can find our installation instructions [here](https://oscar.computeralgebra.
 
 ---
 
-**Q: Why do some of your types have funny names like `ZZRingElem` or `QQMatrix`?**
-
-This has historical reasons. We plan to rename these types before OSCAR 1.0
-(the old names will still work indefinitely, though).
-
----
-
 **Q: Can I find all methods that apply to a given object?**
 
 Yes, Julia provides the function [methodswith](https://docs.julialang.org/en/v1/stdlib/InteractiveUtils/#InteractiveUtils.methodswith) for this very purpose.


### PR DESCRIPTION
In #1982, some artifacts arose by automatically renaming stuff.
Things done: 
* fix bib entry (https://github.com/oscar-system/Oscar.jl/pull/1982#discussion_r1118680565)
* remove faq entry for old names (https://github.com/oscar-system/Oscar.jl/pull/1982#discussion_r1120100319)

@fieker 