### PR TITLE
Small fixes for Polyhedral Geometry (Float64, IncidenceMatrix)

### DIFF
--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -1,5 +1,8 @@
 import Polymake: IncidenceMatrix
 
+nrows(i::IncidenceMatrix) = Polymake.nrows(i)
+ncols(i::IncidenceMatrix) = Polymake.ncols(i)
+
 const nf_scalar = Union{nf_elem, QQFieldElem}
 
 function assure_matrix_polymake(m::Union{AbstractMatrix{Any}, AbstractMatrix{FieldElem}})
@@ -32,7 +35,7 @@ end
 
 assure_vector_polymake(v::AbstractVector{nf_scalar}) = Polymake.Vector{Polymake.QuadraticExtension{Polymake.Rational}}(v)
 
-assure_vector_polymake(v::AbstractVector{<:Union{QQFieldElem, ZZRingElem, nf_elem, Base.Integer, Base.Rational, Polymake.Rational, Polymake.QuadraticExtension}}) = v
+assure_vector_polymake(v::AbstractVector{<:Union{QQFieldElem, ZZRingElem, nf_elem, Base.Integer, Base.Rational, Polymake.Rational, Polymake.QuadraticExtension, Float64}}) = v
 
 affine_matrix_for_polymake(x::Tuple{<:AnyVecOrMat, <:AbstractVector}) = augment(unhomogenized_matrix(x[1]), -Vector(assure_vector_polymake(x[2])))
 affine_matrix_for_polymake(x::Tuple{<:AnyVecOrMat, <:Any}) = homogenized_matrix(x[1], -x[2])

--- a/test/PolyhedralGeometry/extended.jl
+++ b/test/PolyhedralGeometry/extended.jl
@@ -145,6 +145,10 @@
         @test Polyhedron(matrix(ZZ, [-1 0 0; 0 -1 0; 0 0 -1]), [0, 0, 0]) == Pos_poly
         @test Polyhedron(matrix(QQ, [-1 0 0; 0 -1 0; 0 0 -1]), [0, 0, 0]) == Pos_poly
         
+        # testing different input types
+        @test Polyhedron([-1 0 0; 0 -1 0; 0 0 -1], Float64[0, 0, 0]) == Pos_poly
+        @test Polyhedron(Float64[-1 0 0; 0 -1 0; 0 0 -1], [0, 0, 0]) == Pos_poly
+        
         let y = convex_hull([0, 0, 0], [1, 0, 0], [[0, 1, 0], [0, 0, 1]])
             @test Polyhedron([-1 0 0], [0]) == y
             @test Polyhedron([-1 0 0], 0) == y

--- a/test/PolyhedralGeometry/types.jl
+++ b/test/PolyhedralGeometry/types.jl
@@ -1,5 +1,13 @@
 @testset "types" begin
     
+    @testset "IncidenceMatrix" begin
+        
+        im = IncidenceMatrix([[1,2,3],[4,5,6]])
+        @test nrows(im) == 2
+        @test ncols(im) == 6
+        
+    end
+    
     @testset "nf_scalar" begin
         
         qe = Polymake.QuadraticExtension{Polymake.Rational}(123, 456, 789)


### PR DESCRIPTION
Fix #1617 and make `nrows`/`ncols` available to `OSCAR`.