### PR TITLE
provide `iso_oscar_gap` and `iso_gap_oscar` for number fields

### DIFF
--- a/src/GAP/gap_to_oscar.jl
+++ b/src/GAP/gap_to_oscar.jl
@@ -44,7 +44,7 @@ function (F::FinField)(x::GAP.FFE)
         # FFE in GAP only exist for "small" characteristic, so we know the int
         # value fits into an Int; telling Julia about this via a type assertion
         # results in slightly better code
-        val = GAPWrap.INT_FFE_DEFAULT(x)::Int
+        val = GAPWrap.INT_FFE_DEFAULT(x)
         return F(val)
     end
 

--- a/src/GAP/iso_gap_oscar.jl
+++ b/src/GAP/iso_gap_oscar.jl
@@ -41,9 +41,13 @@ function _iso_gap_oscar(F::GAP.GapObj)
        elseif GAPWrap.IsCyclotomicCollection(F)
          if GAPWrap.IsCyclotomicField(F)
            return _iso_gap_oscar_field_cyclotomic(F)
+         elseif GAPWrap.IsNumberField(F)
+           return _iso_gap_oscar_number_field(F)
          elseif F === GAP.Globals.Cyclotomics
            return _iso_gap_oscar_abelian_closure(F)
          end
+       elseif GAPWrap.IsAlgebraicExtension(F)
+         return _iso_gap_oscar_number_field(F)
        end
      end
    elseif GAPWrap.IsZmodnZObjNonprimeCollection(F)
@@ -73,7 +77,7 @@ end
 
 function _iso_gap_oscar_field_finite(FG::GAP.GapObj)
    p = characteristic(FG)  # of type `ZZRingElem`
-   d = GAP.Globals.DegreeOverPrimeField(FG)
+   d = GAPWrap.DegreeOverPrimeField(FG)
    if d == 1
      if p < ZZRingElem(2)^64
        p = UInt64(p)
@@ -103,8 +107,59 @@ function _iso_gap_oscar_ring_integers(FG::GAP.GapObj)
 end
 
 function _iso_gap_oscar_field_cyclotomic(FG::GAP.GapObj)
-   FO = CyclotomicField(GAPWrap.Conductor(FG))[1]
+   FO = cyclotomic_field(GAPWrap.Conductor(FG))[1]
    finv, f = _iso_oscar_gap_field_cyclotomic_functions(FO, FG)
+
+   return MapFromFunc(f, finv, FG, FO)
+end
+
+# If `FG` is a number field that is not cyclotomic then
+# it can be in `IsAlgebraicExtension` or in `IsCyclotomicCollection`.
+function _iso_gap_oscar_number_field(FG::GapObj)
+   if GAPWrap.IsCyclotomicCollection(FG)
+     # The abelian number fields of GAP store one generator.
+     gensFG = GAPWrap.GeneratorsOfField(FG)
+     length(gensFG) == 1 || error("do not know how to handle FG")
+     z = gensFG[1]
+     pol = GAPWrap.MinimalPolynomial(GAP.Globals.Rationals::GapObj, z)
+     N = GAPWrap.DegreeOfLaurentPolynomial(pol)
+     cfs = GAPWrap.CoefficientsOfUnivariatePolynomial(pol)
+     R, x = polynomial_ring(QQ, "x")
+     polFO = R(Vector{QQFieldElem}(cfs))
+     FO, _ = number_field(polFO, "z")
+     powers = GapObj([z^i for i in 0:(N-1)])::GapObj
+     B = GAPWrap.Basis(FG, powers)
+
+     finv = function(x::Nemo.nf_elem)
+        coeffs = GAP.GapObj(coefficients(x), recursive = true)::GapObj
+        return (coeffs * powers)::GAP.Obj
+     end
+
+     f = function(x::GAP.Obj)
+        coeffs = Vector{QQFieldElem}(GAPWrap.Coefficients(B, x))
+        return FO(coeffs)
+     end
+   elseif GAPWrap.IsAlgebraicExtension(FG)
+     # This is the analogon of `_iso_oscar_gap(FO::AnticNumberField)`.
+     pol = GAPWrap.DefiningPolynomial(FG)
+     cfs = GAPWrap.CoefficientsOfUnivariatePolynomial(pol)
+     R, x = polynomial_ring(QQ, "x")
+     polFO = R(Vector{QQFieldElem}(cfs))
+     FO, _ = number_field(polFO, "z")
+     fam = GAPWrap.ElementsFamily(GAP.Globals.FamilyObj(FG))
+
+     finv = function(x::Nemo.nf_elem)
+        coeffs = GAP.GapObj(coefficients(x), recursive = true)::GapObj
+        return GAPWrap.ObjByExtRep(fam, coeffs)
+     end
+
+     f = function(x::GAP.Obj)
+        coeffs = Vector{QQFieldElem}(GAPWrap.ExtRepOfObj(x))
+        return FO(coeffs)
+     end
+   else
+     error("do not know how to handle FG")
+   end
 
    return MapFromFunc(f, finv, FG, FO)
 end
@@ -117,7 +172,7 @@ function _iso_gap_oscar_abelian_closure(FG::GAP.GapObj)
 end
 
 function _iso_gap_oscar_univariate_polynomial_ring(RG::GAP.GapObj)
-   coeffs_iso = iso_gap_oscar(GAP.Globals.LeftActingDomain(RG))
+   coeffs_iso = iso_gap_oscar(GAPWrap.LeftActingDomain(RG))
    RO, x = polynomial_ring(codomain(coeffs_iso), "x")
    finv, f = _iso_oscar_gap_polynomial_ring_functions(RO, RG, inv(coeffs_iso))
 
@@ -125,8 +180,8 @@ function _iso_gap_oscar_univariate_polynomial_ring(RG::GAP.GapObj)
 end
 
 function _iso_gap_oscar_multivariate_polynomial_ring(RG::GAP.GapObj)
-   coeffs_iso = iso_gap_oscar(GAP.Globals.LeftActingDomain(RG))
-   nams = [string(x) for x in GAP.Globals.IndeterminatesOfPolynomialRing(RG)]
+   coeffs_iso = iso_gap_oscar(GAPWrap.LeftActingDomain(RG))
+   nams = [string(x) for x in GAPWrap.IndeterminatesOfPolynomialRing(RG)]
    RO, x = polynomial_ring(codomain(coeffs_iso), nams)
    finv, f = _iso_oscar_gap_polynomial_ring_functions(RO, RG, inv(coeffs_iso))
 
@@ -144,9 +199,73 @@ function __init_IsoGapOscar()
     end
 
     GAP.Globals.BindGlobal(GapObj("_OSCAR_GroupElem"), AbstractAlgebra.GroupElem)
-    GAP.Globals.Read(GapObj(joinpath(Oscar.oscardir, "gap", "misc.g")))
+    GAP.Globals.Read(GapObj(joinpath(oscardir, "gap", "misc.g")))
 end
 
+"""
+    Oscar.iso_gap_oscar(R) -> Map{GAP.GapObj, T}
+
+Return an isomorphism `f` with `domain` the GAP object `R`
+and `codomain` an Oscar object `S`.
+
+Elements `x` of `R` are mapped to `S` via `f(x)`,
+and elements `y` of `S` are mapped to `R` via `preimage(f, y)`.
+
+Matrices `m` over `R` are mapped to matrices over `S` via
+`map_entries(f, m)`,
+and matrices `n` over `S` are mapped to matrices over `R` via
+`Oscar.preimage_matrix(f, n)`.
+
+Admissible values of `R` and the corresponding `S` are currently as follows.
+
+| `S` (in `GAP.Globals`)             | `R`                        |
+|:---------------------------------- |:-------------------------- |
+| `Integers`                         | `ZZ`                       |
+| `Rationals`                        | `QQ`                       |
+| `mod(Integers, n)`                 | `residue_ring(ZZ, n)`      |
+| `GF(p, d)`                         | `FiniteField(p, d)[1]`     |
+| `CF(n)`                            | `cyclotomic_field(n)[1]`   |
+| `AlgebraicExtension(Rationals, f)` | `number_field(g)[1]`       |
+| `Cyclotomics`                      | `abelian_closure(QQ)[1]`   |
+| `PolynomialRing(F)`                | `polynomial_ring(G)[1]`    |
+| `PolynomialRing(F, n)`             | `polynomial_ring(G, n)[1]` |
+
+(Here `g` is the polynomial over `QQ` that corresponds to the polynomial `f`,
+and `G` is equal to `Oscar.iso_gap_oscar(F)`.)
+
+# Examples
+```jldoctest
+julia> f = Oscar.iso_gap_oscar(GAP.Globals.Integers);
+
+julia> x = ZZ(2)^100;  y = preimage(f, x)
+GAP: 1267650600228229401496703205376
+
+julia> f(y) == x
+true
+
+julia> m = matrix(ZZ, 2, 3, [1, 2, 3, 4, 5, 6]);
+
+julia> n = Oscar.preimage_matrix(f, m)
+GAP: [ [ 1, 2, 3 ], [ 4, 5, 6 ] ]
+
+julia> map_entries(f, n) == m
+true
+
+julia> R = GAP.Globals.PolynomialRing(GAP.Globals.Rationals);
+
+julia> f = Oscar.iso_gap_oscar(R);
+
+julia> x = gen(codomain(f));
+
+julia> pol = x^2 + x + 1;
+
+julia> y = preimage(f, pol)
+GAP: x_1^2+x_1+1
+
+julia> f(y) == pol
+true
+```
+"""
 iso_gap_oscar(F::GAP.GapObj) = GAP.Globals.IsoGapOscar(F)
 
 

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -12,24 +12,37 @@ module GAPWrap
 
 using GAP
 
+GAP.@wrap AlgebraicExtension(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap AsList(x::GapObj)::GapObj
 GAP.@wrap AsSet(x::GapObj)::GapObj
+GAP.@wrap Basis(x::GapObj)::GapObj
+GAP.@wrap Basis(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap CF(x::Any, y::Any)::GapObj
 GAP.@wrap CF(x::Any)::GapObj
 GAP.@wrap CHAR_FFE_DEFAULT(x::Any)::GapInt
 GAP.@wrap Characteristic(x::Any)::GapInt
 GAP.@wrap Coefficients(x::Any, y::Any)::GapObj
+GAP.@wrap CoeffsCyc(x::GAP.Obj, y::Int)::GapObj
+GAP.@wrap CoefficientsOfUnivariatePolynomial(x::GapObj)::GapObj
 GAP.@wrap Conductor(x::Any)::GapInt
 GAP.@wrap CycList(x::GapObj)::GapInt
+GAP.@wrap CyclotomicPol(x::Int)::GapObj
+GAP.@wrap DefiningPolynomial(x::GapObj)::GapObj
 GAP.@wrap DegreeFFE(x::Any)::Int
+GAP.@wrap DegreeOfLaurentPolynomial(x::GapObj)::GapInt
+GAP.@wrap DegreeOverPrimeField(x::GapObj)::Int
 GAP.@wrap DenominatorCyc(x::Any)::GapInt
 GAP.@wrap DenominatorRat(x::Any)::GapInt
 GAP.@wrap E(x::Any)::GapInt
 GAP.@wrap Elements(x::GapObj)::GapObj
+GAP.@wrap ElementsFamily(x::GapObj)::GapObj
 GAP.@wrap ExtRepOfObj(x::GapObj)::GapObj
+GAP.@wrap ExtRepPolynomialRatFun(x::GapObj)::GapObj
+GAP.@wrap FamilyObj(x::GAP.Obj)::GapObj
 GAP.@wrap FreeAbelianGroup(x::Int)::GapObj
 GAP.@wrap FreeGeneratorsOfFpGroup(x::GapObj)::GapObj
 GAP.@wrap FreeGroupOfFpGroup(x::GapObj)::GapObj
+GAP.@wrap GeneratorsOfField(x::GapObj)::GapObj
 GAP.@wrap GeneratorsOfGroup(x::GapObj)::GapObj
 GAP.@wrap GF(x::Any, y::Any)::GapObj
 GAP.@wrap GF(x::Any)::GapObj
@@ -38,7 +51,10 @@ GAP.@wrap GroupHomomorphismByFunction(x1, x2, x3, x4)::GapObj
 GAP.@wrap GroupHomomorphismByFunction(x1, x2, x3, x4, x5)::GapObj
 GAP.@wrap Image(x::Any, y::Any)::GapObj
 GAP.@wrap Image(x::Any)::GapObj
+GAP.@wrap ImmutableMatrix(x::GapObj, y::GapObj, z::Bool)::GapObj
 GAP.@wrap IndependentGeneratorExponents(x::Any, y::Any)::GapObj
+GAP.@wrap IndeterminateNumberOfUnivariateRationalFunction(x::GapObj)::Int
+GAP.@wrap IndeterminatesOfPolynomialRing(x::GapObj)::GapObj
 GAP.@wrap Inverse(x::GapObj)::GapObj
 GAP.@wrap INT_FFE_DEFAULT(x::Any)::GapInt
 GAP.@wrap IntFFE(x::Any)::GapInt
@@ -52,6 +68,7 @@ GAP.@wrap IsAssocWord(x::Any)::Bool
 GAP.@wrap IsBiCoset(x::Any)::Bool
 GAP.@wrap IsBijective(x::Any)::Bool
 GAP.@wrap IsBool(x::Any)::Bool
+GAP.@wrap IsCanonicalBasisAlgebraicExtension(x::GapObj)::Bool
 GAP.@wrap IsChar(x::Any)::Bool
 GAP.@wrap IsCharacteristicSubgroup(x::Any, y::Any)::Bool
 GAP.@wrap IsCheapConwayPolynomial(x::Any, y::Any)::Bool
@@ -66,6 +83,7 @@ GAP.@wrap IsCyclotomicCollCollColl(x::Any)::Bool
 GAP.@wrap IsCyclotomicCollection(x::Any)::Bool
 GAP.@wrap IsCyclotomicField(x::Any)::Bool
 GAP.@wrap IsDihedralGroup(x::Any)::Bool
+GAP.@wrap IsDomain(x::Any)::Bool
 GAP.@wrap IsDoneIterator(x::Any)::Bool
 GAP.@wrap IsDuplicateTable(x::Any)::Bool
 GAP.@wrap IsElementaryAbelian(x::Any)::Bool
@@ -96,6 +114,7 @@ GAP.@wrap IsNaturalAlternatingGroup(x::Any)::Bool
 GAP.@wrap IsNaturalSymmetricGroup(x::Any)::Bool
 GAP.@wrap IsNilpotentGroup(x::Any)::Bool
 GAP.@wrap IsNormal(x::Any, y::Any)::Bool
+GAP.@wrap IsNumberField(x::Any)::Bool
 GAP.@wrap IsOne(x::Any)::Bool
 GAP.@wrap IsPcGroup(x::Any)::Bool
 GAP.@wrap IsPerfectGroup(x::Any)::Bool
@@ -136,6 +155,9 @@ GAP.@wrap IsZmodnZObj(x::Any)::Bool
 GAP.@wrap IsZmodnZObjNonprimeCollection(x::Any)::Bool
 GAP.@wrap Iterator(x::Any)::GapObj
 GAP.@wrap LargestMovedPoint(x::Any)::Int
+GAP.@wrap LeftActingDomain(x::GapObj)::GapObj
+GAP.@wrap MinimalPolynomial(x::GapObj, y::GAP.Obj)::GapObj
+GAP.@wrap mod(x::Any, y::Any)::GAP.Obj
 GAP.@wrap NextIterator(x::GapObj)::Any
 GAP.@wrap NrCols(x::GapObj)::Int
 GAP.@wrap NrConjugacyClasses(x::Any)::GapInt
@@ -146,13 +168,18 @@ GAP.@wrap NumeratorRat(x::Any)::GapInt
 GAP.@wrap ObjByExtRep(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap One(x::Any)::GAP.Obj
 GAP.@wrap Order(x::Any)::GapInt
+GAP.@wrap PolynomialByExtRep(x::GapObj, y::GapObj)::GapObj
+GAP.@wrap PolynomialRing(x::GapObj)::GapObj
+GAP.@wrap PolynomialRing(x::GapObj, y::Int)::GapObj
 GAP.@wrap PrimePGroup(x::GapObj)::GapInt
 GAP.@wrap Range(x::GapObj)::GapObj
+GAP.@wrap ReduceCoeffs(x::GapObj, y::GapObj)
 GAP.@wrap RelatorsOfFpGroup(x::GapObj)::GapObj
 GAP.@wrap Size(x::Any)::GapInt
 GAP.@wrap Source(x::GapObj)::GapObj
 GAP.@wrap StringViewObj(x::Any)::GapObj
 GAP.@wrap UnderlyingElement(x::GapObj)::GapObj
+GAP.@wrap UnivariatePolynomialByCoefficients(x::GapObj, y::GapObj, z::Int)::GapObj
 GAP.@wrap Z(x::Any)::GAP.Obj
 GAP.@wrap Zero(x::Any)::GAP.Obj
 


### PR DESCRIPTION
- provide `iso_oscar_gap` and `iso_gap_oscar` for number fields that are not of cyclotomic type (addresses the problem from #1930, but does not address the questions raised in its discussion)

- provide docstrings for `Oscar.iso_oscar_gap` and `Oscar.iso_gap_oscar` (had been suggested by Meinolf; it is not clear to me where in the manual these docstrins should appear)

- removed a workaround for certain finite fields, since the problem on the GAP side has been fixed (a test and an assertion make sure that the problem will not come up again)

- extended the tests

- replaced `GAP.Globals` access by `Oscar.GAPWrap` access