### PR TITLE
Combinatorics: Add sanity check to add_edge!(Graph)

### DIFF
--- a/src/Combinatorics/Graphs.jl
+++ b/src/Combinatorics/Graphs.jl
@@ -77,9 +77,7 @@ function Graph{T}(nverts::Int64) where {T <: Union{Directed, Undirected}}
     return Graph{T}(pmg)
 end
 
-function _has_node(G::Graph, node::Int64)
-    return 0<node && node<=nv(G)
-end
+_has_node(G::Graph, node::Int64) = 0 < node <= nv(G)
 
 @doc Markdown.doc"""
     add_edge!(g::Graph{T}, s::Int64, t::Int64) where {T <: Union{Directed, Undirected}}

--- a/src/Combinatorics/Graphs.jl
+++ b/src/Combinatorics/Graphs.jl
@@ -77,6 +77,9 @@ function Graph{T}(nverts::Int64) where {T <: Union{Directed, Undirected}}
     return Graph{T}(pmg)
 end
 
+function _has_node(G::Graph, node::Int64)
+    return 0<node && node<=nv(G)
+end
 
 @doc Markdown.doc"""
     add_edge!(g::Graph{T}, s::Int64, t::Int64) where {T <: Union{Directed, Undirected}}
@@ -94,6 +97,7 @@ julia> ne(g)
 ```
 """
 function add_edge!(g::Graph{T}, source::Int64, target::Int64) where {T <: Union{Directed, Undirected}}
+    (_has_node(g, source) && _has_node(g, target)) || throw(ArgumentError("Nodes must be between 1 and $(nv(g)), but edge given is $source -- $target"))
     Polymake._add_edge(pm_object(g), source-1, target-1)
 end
 

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -112,4 +112,9 @@
         @test length(connected_components(g)) == 1
         @test diameter(g) == 3
     end
+
+    @testset "errors" begin
+        g = graph{Undirected}(1)
+        @test_throws ArgumentError add_edge!(g,1,2)
+    end
 end

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -114,7 +114,7 @@
     end
 
     @testset "errors" begin
-        g = graph{Undirected}(1)
+        g = Graph{Undirected}(1)
         @test_throws ArgumentError add_edge!(g,1,2)
     end
 end


### PR DESCRIPTION
Previously we would get a crash from polymake, if the source or target of the edge to be added did not exist. Now we just throw an Oscar error.