### PR TITLE
fixed `is_conjugate` for matrix groups

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -600,7 +600,12 @@ end
 Return whether `x` and `y` are conjugate elements in `G`,
 i.e., there is an element $z$ in `G` such that `x^`$z$ equals `y`.
 """
-is_conjugate(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem) = GAPWrap.IsConjugate(G.X,x.X,y.X)
+function is_conjugate(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)
+   if isdefined(G,:descr) && (G.descr == :GL || G.descr == :SL)
+     return representative_action_in_gl_or_sl(G, x, y)[1]
+   end
+   return GAPWrap.IsConjugate(G.X, x.X, y.X)
+end
 
 """
     representative_action(G::Group, x::GAPGroupElem, y::GAPGroupElem)
@@ -610,6 +615,9 @@ return `(true, z)`, where `x^z == y` holds;
 otherwise, return `(false, nothing)`.
 """
 function representative_action(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)
+   if isdefined(G,:descr) && (G.descr == :GL || G.descr == :SL)
+     return representative_action_in_gl_or_sl(G, x, y)
+   end
    conj = GAP.Globals.RepresentativeAction(G.X, x.X, y.X)::GapObj
    if conj != GAP.Globals.fail
       return true, group_element(G, conj)

--- a/src/Groups/matrices/linear_isconjugate.jl
+++ b/src/Groups/matrices/linear_isconjugate.jl
@@ -142,24 +142,23 @@ function generalized_jordan_form(A::MatElem{T}; with_pol::Bool=false) where T
 end
 
 
-function is_conjugate(G::MatrixGroup, x::MatrixGroupElem, y::MatrixGroupElem)
-   isdefined(G,:descr) || throw(ArgumentError("Group must be general or special linear group"))
-   if G.descr==:GL || G.descr==:SL
-      Jx,ax = jordan_normal_form(x.elm)
-      Jy,ay = jordan_normal_form(y.elm)
-      if Jx != Jy return false, nothing end
-      z = inv(ax)*ay
-      if G.descr==:GL return true, G(z) end
-      ED = pol_elementary_divisors(x.elm)
-      l = gcd([k[2] for k in ED])
-      l = gcd(l, order(G.ring)-1)
-      d = det(z)
-      if isone(d^( div(order(G.ring)-1,l)))
-         corr = _elem_given_det(x, d^-1)
-         return true, G(corr*z)
-      else return false, nothing
-      end
+function representative_action_in_gl_or_sl(G::MatrixGroup, x::MatrixGroupElem, y::MatrixGroupElem)
+   (isdefined(G,:descr) && (G.descr == :GL || G.descr == :SL)) ||
+   throw(ArgumentError("Group must be general or special linear group"))
+
+   Jx,ax = jordan_normal_form(x.elm)
+   Jy,ay = jordan_normal_form(y.elm)
+   if Jx != Jy return false, nothing end
+   z = inv(ax)*ay
+   if G.descr==:GL return true, G(z) end
+   ED = pol_elementary_divisors(x.elm)
+   l = gcd([k[2] for k in ED])
+   l = gcd(l, order(G.ring)-1)
+   d = det(z)
+   if isone(d^( div(order(G.ring)-1,l)))
+      corr = _elem_given_det(x, d^-1)
+      return true, G(corr*z)
    else
-      return is_conjugate(G,x,y)
+      return false, nothing
    end
 end

--- a/test/Groups/conjugation.jl
+++ b/test/Groups/conjugation.jl
@@ -149,6 +149,19 @@ end
    TestConjCentr(G,x)
 end
 
+@testset "Conjugation in matrix group (different from GL and SL)" begin
+   G = sylow_subgroup(general_linear_group(2, 3), 2)[1]
+   M = G(matrix(G.ring, 2, 2, [0, 1, 2, 0]))
+   @test order(M) == 4
+   @test is_conjugate(G, M, inv(M))
+   @test ! is_conjugate(G, M, M^2)
+   flag, N = representative_action(G, M, inv(M))
+   @test flag
+   @test M^N == inv(M)
+   flag, _ = representative_action(G, M, M^2)
+   @test ! flag
+end
+
 @testset "Conjugation and centralizers for GL and SL" begin
    G = GL(8,25)
    S = SL(8,25)
@@ -159,14 +172,14 @@ end
    y = generalized_jordan_block(t-1,8)
    x[7,8]=l
    x=S(x); y=S(y);
-   vero, z = is_conjugate(G,x,y)
+   vero, z = representative_action(G, x, y)
    @test vero
    @test z in G
    @test x^z==y
-   vero, z = is_conjugate(S,x,y)
+   vero, z = representative_action(S, x, y)
    @test !vero
    x.elm[7,8]=l^8
-   vero, z = is_conjugate(S,x,y)
+   vero, z = representative_action(S, x, y)
    @test z in S
    @test x^z==y
 

--- a/test/Groups/forms.jl
+++ b/test/Groups/forms.jl
@@ -356,21 +356,21 @@ end
    @testset for x in gens(H)
       @test f^x==f
    end
-   @test is_conjugate(G,H,Op)[1]
+   @test is_conjugate(G, H, Op)
    B[2,2]=1; B[3,3]=1;
    f = quadratic_form(B)
    H = isometry_group(f)
    @testset for x in gens(H)
       @test f^x==f
    end
-   @test is_conjugate(G,H,Om)[1]
+   @test is_conjugate( G, H, Om)
    Q = f
    f = corresponding_bilinear_form(Q)
    H = isometry_group(f)
    @testset for x in gens(H)
       @test f^x==f
    end
-   @test is_conjugate(G,H,Sp(4,2))[1]
+   @test is_conjugate(G, H, Sp(4,2))
 
    G = GL(5,9)
    F = base_ring(G)


### PR DESCRIPTION
This addresses issue #1974.

- renamed the `is_conjugate` method for matrix groups, which is applicable only to groups that know to be a GL or SL and which returns also a conjugating element if it exists, to  `representative_action_in_gl_or_sl`

- in `is_conjugate` and `representative_action`, check whether the group in question knows that it is a GL or SL, and if yes then delegate to `representative_action_in_gl_or_sl`

- extended and adjusted the tests