### PR TITLE
Fix warning about coordinate_ring

### DIFF
--- a/src/AlgebraicGeometry/Miscellaneous/basics.jl
+++ b/src/AlgebraicGeometry/Miscellaneous/basics.jl
@@ -9,7 +9,7 @@ import Oscar: weights
 import AbstractAlgebra, Nemo
 import Base: ==, show, hash
 
-export proj_space, normalize!, coordinate_ring
+export proj_space, normalize!
 
 struct ProjSpc{T}  <: Oscar.ProjSpc{T}
   R::AbstractAlgebra.Ring


### PR DESCRIPTION
Fixes this warning:

    WARNING: using Geometry.coordinate_ring in module Oscar conflicts
    with an existing identifier.
