### PR TITLE
Revert "let `iso_gap_oscar` choose `Nemo._GF` (#2008)"

### DIFF
--- a/src/GAP/iso_gap_oscar.jl
+++ b/src/GAP/iso_gap_oscar.jl
@@ -76,7 +76,16 @@ function _iso_gap_oscar_residue_ring(RG::GAP.GapObj)
 end
 
 function _iso_gap_oscar_field_finite(FG::GAP.GapObj)
-   FO = Nemo._GF(characteristic(FG), GAPWrap.DegreeOverPrimeField(FG))
+   p = characteristic(FG)  # of type `ZZRingElem`
+   d = GAPWrap.DegreeOverPrimeField(FG)
+   if d == 1
+     if p < ZZRingElem(2)^64
+       p = UInt64(p)
+     end
+     FO = GF(p)
+   else
+     FO = GF(p, d)
+   end
 
    finv, f = _iso_oscar_gap_field_finite_functions(FO, FG)
 

--- a/src/GAP/iso_oscar_gap.jl
+++ b/src/GAP/iso_oscar_gap.jl
@@ -74,16 +74,14 @@ function _iso_oscar_gap_field_finite_functions(FO::Union{FqPolyRepField, FqField
    p = characteristic(FO)
    d = degree(FO)
 
-   if degree(FO) != absolute_degree(FO) ||
-      ! GAPWrap.IsPrimeField(GAPWrap.LeftActingDomain(FG))
-     # The Oscar field or the GAP field is not an extension of the prime field.
+   # Compute the canonical basis of `FG`.
+   if ! GAPWrap.IsPrimeField(GAPWrap.LeftActingDomain(FG))
+     # The GAP field is not an extension of the prime field.
      # What is a reasonable way to compute (on the GAP side) a polynomial
      # w.r.t. the prime field, and to decompose field elements w.r.t.
      # the corresponding basis?
      error("extensions of extension fields are not supported")
    end
-
-   # Compute the canonical basis of `FG`.
    basis_FG = GAPWrap.Basis(FG)
    # Test that we do not run into the problem from
    # https://github.com/gap-system/gap/issues/4694.

--- a/src/Groups/libraries/atlasgroups.jl
+++ b/src/Groups/libraries/atlasgroups.jl
@@ -22,7 +22,7 @@ julia> atlas_group("A5")  # alternating group A5
 Group([ (1,2)(3,4), (1,3,5) ])
 
 julia> atlas_group(MatrixGroup, "A5")
-Matrix group of degree 4 over Finite field of degree 1 over F_2
+Matrix group of degree 4 over Galois field with characteristic 2
 
 julia> atlas_group("M11")  # Mathieu group M11
 Group([ (2,10)(4,11)(5,7)(8,9), (1,4,3,8)(2,5,6,9) ])
@@ -125,7 +125,7 @@ julia> h2, emb = atlas_subgroup("M11", 1);  h2
 Group([ (1,4)(2,10)(3,7)(6,9), (1,6,10,7,11,3,9,2)(4,5) ])
 
 julia> h3, emb = atlas_subgroup(MatrixGroup, "M11", 1 );  h3
-Matrix group of degree 10 over Finite field of degree 1 over F_2
+Matrix group of degree 10 over Galois field with characteristic 2
 
 julia> info = all_atlas_group_infos("M11", degree => 11);
 
@@ -199,7 +199,7 @@ julia> info = all_atlas_group_infos("A5", dim => 4, characteristic => 3)
  Dict(:dim => 4, :repname => "A5G1-f3r4B0", :name => "A5")
 
 julia> atlas_group(info[1])
-Matrix group of degree 4 over Finite field of degree 1 over F_3
+Matrix group of degree 4 over Galois field with characteristic 3
 
 ```
 """

--- a/test/GAP/gap_to_oscar.jl
+++ b/test/GAP/gap_to_oscar.jl
@@ -218,6 +218,7 @@ end
 
     @test_throws ArgumentError Oscar.matrices_over_cyclotomic_field(GAP.Globals.E(4))
     @test_throws ArgumentError Oscar.matrices_over_cyclotomic_field(GAP.evalstr("[]"))
+    @test_throws MethodError Oscar.matrices_over_cyclotomic_field(GAP.evalstr("[ [ [ Z(2) ] ] ]"))
 
     F, z = quadratic_field(5)
     @test_throws ArgumentError matrix(F, GAP.evalstr("[ [ Sqrt(5) ] ]"))


### PR DESCRIPTION
This reverts commit e2134dc4a22bd6c987fdef58bdd2a1e9a17a8445 from PR #2008.

I've chosen to revert this instead of reverting PR #1988 because...
- it is much smaller, thus removing it has less impact, and adding it back again later should be easier
- it was an experiment to begin with
- I want to verify that it is really the combination of these two PRs that causes the breakage, and not something else

Assuming this works and is merged, I'll open a new PR which adds these changes back so that we can take our time to analyze the problem.

Hopefully fixes #2027