### PR TITLE
Add {characteristic,minimal}_polynomial aliases

### DIFF
--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -912,7 +912,6 @@ function characteristic_polynomial(M::Matroid)
     R, q = polynomial_ring(ZZ, 'q')
     return (-1)^M.pm_matroid.RANK*tutte_polynomial(M)(1-q,0)
 end
-charpoly(M::Matroid) = characteristic_polynomial(M)
 
 @doc Markdown.doc"""
     reduced_characteristic_polynomial(M::Matroid)

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -276,7 +276,6 @@ export character_lattice
 export character_parameters
 export character_table
 export character_to_rational_function
-export characteristic_polynomial
 export characteristic_subgroups, has_characteristic_subgroups, set_characteristic_subgroups
 export charpoly
 export chip_firing_move

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -396,6 +396,10 @@ end
 
 include("Exports.jl")
 
+# HACK/FIXME: remove these aliases once we have them in AA/Nemo/Hecke
+@alias characteristic_polynomial charpoly  # FIXME
+@alias minimal_polynomial minpoly  # FIXME
+
 include("printing.jl")
 include("fallbacks.jl")
 


### PR DESCRIPTION
This resolves some confusion: there was a single `characteristic_polynomial` method, with a docstring that gave no hint about `charpoly`. It also prepares us for a potential future renaming of these functions.

As a natural extension also add `minimal_polynomial` as alias for `minpoly`.

Resolve #2026.