### PR TITLE
`iso_oscar_gap` for `quadratic_field`

### DIFF
--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -5,18 +5,20 @@
 # underlying GAP function object directly and also has information about the
 # return type.
 #
-# Note that the macro GAP.@wrap has a similar purpose as @gappatribute
-# have, but works on a much lower level on purpose. We may actually phase out
-# use of @gappatribute in the future.
+# Note that the macro GAP.@wrap has a similar purpose as @gapattribute has,
+# but works on a much lower level on purpose. We may actually phase out
+# use of @gapattribute in the future.
 module GAPWrap
 
 using GAP
 
+GAP.@wrap AlgExtElm(x::GapObj, y::GAP.Obj)::GapObj
 GAP.@wrap AlgebraicExtension(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap AsList(x::GapObj)::GapObj
 GAP.@wrap AsSet(x::GapObj)::GapObj
 GAP.@wrap Basis(x::GapObj)::GapObj
 GAP.@wrap Basis(x::GapObj, y::GapObj)::GapObj
+GAP.@wrap BasisNC(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap CF(x::Any, y::Any)::GapObj
 GAP.@wrap CF(x::Any)::GapObj
 GAP.@wrap CHAR_FFE_DEFAULT(x::Any)::GapInt
@@ -39,6 +41,7 @@ GAP.@wrap ElementsFamily(x::GapObj)::GapObj
 GAP.@wrap ExtRepOfObj(x::GapObj)::GapObj
 GAP.@wrap ExtRepPolynomialRatFun(x::GapObj)::GapObj
 GAP.@wrap FamilyObj(x::GAP.Obj)::GapObj
+GAP.@wrap Field(x::Any)::GapObj
 GAP.@wrap FreeAbelianGroup(x::Int)::GapObj
 GAP.@wrap FreeGeneratorsOfFpGroup(x::GapObj)::GapObj
 GAP.@wrap FreeGroupOfFpGroup(x::GapObj)::GapObj
@@ -181,6 +184,7 @@ GAP.@wrap SetMaximalAbelianQuotient(x::Any, y::Any)::Nothing
 GAP.@wrap SetSize(x::Any, y::Any)::Nothing
 GAP.@wrap Size(x::Any)::GapInt
 GAP.@wrap Source(x::GapObj)::GapObj
+GAP.@wrap Sqrt(x::Int64)::GAP.Obj
 GAP.@wrap StringViewObj(x::Any)::GapObj
 GAP.@wrap UnderlyingElement(x::GapObj)::GapObj
 GAP.@wrap UnivariatePolynomialByCoefficients(x::GapObj, y::GapObj, z::Int)::GapObj

--- a/test/GAP/iso_gap_oscar.jl
+++ b/test/GAP/iso_gap_oscar.jl
@@ -133,10 +133,13 @@ end
   end
 end
 
-@testset "number fields" begin
+@testset "number fields" begin  # includes quadratic fields
    @testset "subfield $F of a cyclotomic field" for F in
      [ GAP.evalstr( "Field( [ Sqrt(5) ] )" ),
-       GAP.evalstr( "Field( [ EC(19) ] )" ) ]
+       GAP.evalstr( "Field( [ Sqrt(-1) ] )" ),
+       GAP.evalstr( "Field( [ Sqrt(6) ] )" ),
+       GAP.evalstr( "Field( [ Sqrt(-6) ] )" ),
+       GAP.evalstr( "Field( [ EC(19) ] )" ) ]  # not a quadratic field
 
      x = GAP.Globals.GeneratorsOfField(F)[1]
      y = GAP.Globals.One(F)

--- a/test/GAP/iso_oscar_gap.jl
+++ b/test/GAP/iso_oscar_gap.jl
@@ -180,6 +180,29 @@ end
    @test phi(-a^3 + a^2 + 1) == GAP.evalstr("-E(5)^2-E(5)^3")
 end
 
+@testset "quadratic number fields" begin
+   # for computing random elements of the fields in question
+   my_rand_bits(F::QQField, b::Int) = rand_bits(F, b)
+   my_rand_bits(F::AnticNumberField, b::Int) = F([rand_bits(QQ, b) for i in 1:degree(F)])
+
+   @testset for N in [ 5, -3, 12, -8 ]
+      F, z = quadratic_field(N)
+      f = Oscar.iso_oscar_gap(F)
+      @test f === Oscar.iso_oscar_gap(F)  # test that everything gets cached
+      for i in 1:10
+         a = my_rand_bits(F, 5)
+         for j in 1:10
+            b = my_rand_bits(F, 5)
+            @test f(a*b) == f(a)*f(b)
+            @test f(a - b) == f(a) - f(b)
+         end
+      end
+
+      m = matrix([z z; z z])
+      @test map_entries(inv(f), map_entries(f, m)) == m
+   end
+end
+
 @testset "number fields" begin
    # for computing random elements of the fields in question
    my_rand_bits(F::QQField, b::Int) = rand_bits(F, b)


### PR DESCRIPTION
This addresses issue #2049.

`iso_oscar_gap` maps a `quadratic_field` to a field of cyclotomics in GAP (not to an `AlgebraicExtension`),
and `iso_gap_oscar` maps a quadratic field of cyclotomics to a `quadratic_field` in Oscar (not to a general `number_field`).

Resolves #2049.