### PR TITLE
Fix Oscar.build()

### DIFF
--- a/system/Build.jl
+++ b/system/Build.jl
@@ -1,3 +1,7 @@
+if VERSION < v"1.9.0-DEV"
+  error("Julia >= 1.9 required")
+end
+
 using Pkg
 Pkg.add("PackageCompiler")
 Pkg.add("Libdl")

--- a/system/precompile.jl
+++ b/system/precompile.jl
@@ -1,3 +1,8 @@
+import Pkg
+Pkg.add("Documenter")
+Pkg.add("PrettyTables")
+Pkg.add("Printf")
+
 include(joinpath(pkgdir(Oscar), "test", "runtests.jl"))
 Hecke.system("precompile.jl")
 

--- a/test/Rings/nmod-localizations.jl
+++ b/test/Rings/nmod-localizations.jl
@@ -5,7 +5,7 @@
 using Oscar
 using Markdown
 
-import Nemo.zzModRing
+import Oscar.Nemo.zzModRing
 import Oscar: base_ring, inverted_set, ambient_ring, Localization, parent, numerator, denominator, one, zero
 import Oscar.AbstractAlgebra: elem_type, parent_type
 

--- a/test/StraightLinePrograms/setup.jl
+++ b/test/StraightLinePrograms/setup.jl
@@ -1,6 +1,6 @@
 using Oscar.StraightLinePrograms
 
-using AbstractAlgebra: AbstractAlgebra, Perm, SymmetricGroup, order, @perm_str
+using Oscar.AbstractAlgebra: AbstractAlgebra, Perm, SymmetricGroup, order, @perm_str
 
 using Oscar.StraightLinePrograms: Const, Exp, Gen, Minus, Plus, LazyRec,
     Times, UniMinus, Call, pushconst!, pushop!,


### PR DESCRIPTION
It requires Julia 1.9, which the code now enforces.

Resolves #1400

Draft because the tests on my system are still running (but I did not want to wait for them before submitting this, lest I forget about it)