### PR TITLE
PolyhedralGeometry: set one-based ray labels for visualization

### DIFF
--- a/src/PolyhedralGeometry/Visualization.jl
+++ b/src/PolyhedralGeometry/Visualization.jl
@@ -8,14 +8,19 @@ Four-dimensional polytopes are visualized as a Schlegel diagram, which is a proj
 In higher dimensions there is no standard method; use projections to lower dimensions or try ideas from [GJRW10](@cite).
 """
 function visualize(P::Union{Polyhedron, Cone, PolyhedralFan, PolyhedralComplex})
-    d = ambient_dim(P)
-    b = P isa Polyhedron
-    if d < 4 || (d == 4 && b && dim(P) == 4)
-        pmo = pm_object(P)
-        Polymake.visual(pmo)
-    else
-        d == 4 && b && throw(ArgumentError(string("Can only visualize full-dimensional ", typeof(P), " of ambient dimension ", d, ".")))
-        throw(ArgumentError(string("Can not visualize ", typeof(P), " of ambient dimension ", d, ". Supported range: 1 <= d <= ", 3 + b)))
+  d = ambient_dim(P)
+  b = P isa Polyhedron
+  if d < 4 || (d == 4 && b && dim(P) == 4)
+    # polymake will by default use 0:n-1 as ray labels so we assign labels
+    # starting from 1 here if there are no labels yet
+    # (note: labels are mutable, i.e. they can be changed again later)
+    if !Polymake.exists(pm_object(P), "RAY_LABELS")
+      pm_object(P).RAY_LABELS = string.(1:Oscar.pm_object(P).N_RAYS)
     end
+    pmo = pm_object(P)
+    Polymake.visual(pmo)
+  else
+    d == 4 && b && throw(ArgumentError(string("Can only visualize full-dimensional ", typeof(P), " of ambient dimension ", d, ".")))
+    throw(ArgumentError(string("Can not visualize ", typeof(P), " of ambient dimension ", d, ". Supported range: 1 <= d <= ", 3 + b)))
+  end
 end
-


### PR DESCRIPTION
`ray` here is in the sense of polymake, i.e. including vertices of polytopes / complexes.

fixes #2068 