### PR TITLE
Lazy toric schemes

### DIFF
--- a/experimental/Schemes/ToricSchemes/AffineToricSchemes/Attributes.jl
+++ b/experimental/Schemes/ToricSchemes/AffineToricSchemes/Attributes.jl
@@ -34,7 +34,6 @@ function underlying_scheme(X::ToricSpec)
   end
   return X.X
 end
-export underlying_scheme
 
 
 @doc Markdown.doc"""
@@ -59,7 +58,6 @@ Normal, affine toric variety
 ```
 """
 affine_normal_toric_variety(X::ToricSpec) = X.antv
-export affine_normal_toric_variety
 
 
 @doc Markdown.doc"""
@@ -84,7 +82,6 @@ Polyhedral cone in ambient dimension 2
 ```
 """
 cone(X::ToricSpec) = cone(affine_normal_toric_variety(X))
-export cone
 
 
 @doc Markdown.doc"""
@@ -117,7 +114,6 @@ function dual_cone(X::ToricSpec)
   end
   return X.dual_cone
 end
-export dual_cone
 
 
 @doc Markdown.doc"""
@@ -158,5 +154,4 @@ function hilbert_basis(X::ToricSpec)
   end
   return X.hb
 end
-export hilbert_basis
 

--- a/experimental/Schemes/ToricSchemes/AffineToricSchemes/Attributes.jl
+++ b/experimental/Schemes/ToricSchemes/AffineToricSchemes/Attributes.jl
@@ -18,7 +18,7 @@ julia> affine_toric_scheme = ToricSpec(antv)
 Spec of an affine toric variety with cone spanned by RayVector{QQFieldElem}[[1, 0], [0, 1]]
 
 julia> underlying_scheme(affine_toric_scheme)
-Spec of Quotient of Multivariate Polynomial Ring in x1, x2 over Rational Field by ideal()
+Spec of Quotient of Multivariate Polynomial Ring in x1, x2 over Rational Field by ideal(0)
 ```
 """
 function underlying_scheme(X::ToricSpec)

--- a/experimental/Schemes/ToricSchemes/AffineToricSchemes/Attributes.jl
+++ b/experimental/Schemes/ToricSchemes/AffineToricSchemes/Attributes.jl
@@ -21,7 +21,19 @@ julia> underlying_scheme(affine_toric_scheme)
 Spec of Quotient of Multivariate Polynomial Ring in x1, x2 over Rational Field by ideal()
 ```
 """
-underlying_scheme(X::ToricSpec) = X.X
+function underlying_scheme(X::ToricSpec)
+  if !isdefined(X, :X)
+    if length(X.var_names) == 0
+      I = toric_ideal(affine_normal_toric_variety(X))
+      X.X = Spec(base_ring(I), I)
+    else
+      R, _ = polynomial_ring(QQ, X.var_names)
+      I = toric_ideal(R, hilbert_basis(X))
+      X.X = Spec(R, I)
+    end
+  end
+  return X.X
+end
 export underlying_scheme
 
 
@@ -99,7 +111,12 @@ julia> polarize(cone(affine_toric_scheme)) == dual_cone(affine_toric_scheme)
 true
 ```
 """
-dual_cone(X::ToricSpec) = X.dual_cone
+function dual_cone(X::ToricSpec) 
+  if !isdefined(X, :dual_cone)
+    X.dual_cone = polarize(cone(X))
+  end
+  return X.dual_cone
+end
 export dual_cone
 
 
@@ -135,5 +152,11 @@ julia> hilbert_basis(affine_toric_scheme)
 [ 0   1]
 ```
 """
-hilbert_basis(X::ToricSpec) = X.hb
+function hilbert_basis(X::ToricSpec)
+  if !isdefined(X, :hb)
+    X.hb = matrix(ZZ, hilbert_basis(dual_cone(X)))
+  end
+  return X.hb
+end
 export hilbert_basis
+

--- a/experimental/Schemes/ToricSchemes/AffineToricSchemes/Properties.jl
+++ b/experimental/Schemes/ToricSchemes/AffineToricSchemes/Properties.jl
@@ -33,7 +33,6 @@ false
 ```
 """
 is_smooth(X::ToricSpec) = is_smooth(affine_normal_toric_variety(X))
-export is_smooth
 
 
 @doc Markdown.doc"""
@@ -65,4 +64,4 @@ true
 ```
 """
 is_simplicial(X::ToricSpec) = is_simplicial(affine_normal_toric_variety(X))
-export is_simplicial
+

--- a/experimental/Schemes/ToricSchemes/AffineToricSchemes/Type.jl
+++ b/experimental/Schemes/ToricSchemes/AffineToricSchemes/Type.jl
@@ -1,16 +1,20 @@
 export ToricSpec
 
-@attributes mutable struct ToricSpec{BRT, RT, SpecType<:Spec} <: AbsSpec{BRT, RT}
-  X::SpecType
+@attributes mutable struct ToricSpec{BRT, RT} <: AbsSpec{BRT, RT}
   antv::AffineNormalToricVariety
+  var_names::Vector{Symbol}
+  X::Spec
   dual_cone::Cone
   hb::ZZMatrix
-  function ToricSpec(antv::AffineNormalToricVariety; R::MPolyRing=base_ring(toric_ideal(antv)))
-    Cdual = polarize(cone(antv))
-    hb = matrix(ZZ, hilbert_basis(Cdual))
-    I = toric_ideal(R, hb)
-    X = Spec(R, I)
-    return new{typeof(base_ring(X)), typeof(OO(X)), typeof(X)}(X, antv, Cdual, hb)
+  function ToricSpec(antv::AffineNormalToricVariety; 
+      var_names::Vector{Symbol} = Vector{Symbol}()
+    )
+    # R = polynomial_ring(QQ, var_names)
+    # Cdual = polarize(cone(antv))
+    # hb = matrix(ZZ, hilbert_basis(Cdual))
+    # I = toric_ideal(R, hb)
+    # X = Spec(R, I)
+    return new{typeof(QQ), MPolyQuoRing}(antv, var_names)
   end
 end
 

--- a/experimental/Schemes/ToricSchemes/AffineToricSchemes/Type.jl
+++ b/experimental/Schemes/ToricSchemes/AffineToricSchemes/Type.jl
@@ -1,5 +1,3 @@
-export ToricSpec
-
 @attributes mutable struct ToricSpec{BRT, RT} <: AbsSpec{BRT, RT}
   antv::AffineNormalToricVariety
   var_names::Vector{Symbol}
@@ -21,3 +19,4 @@ end
 function Base.show(io::IO, X::ToricSpec) 
   print(io, "Spec of an affine toric variety with cone spanned by $(rays(affine_normal_toric_variety(X)))")
 end
+

--- a/experimental/Schemes/ToricSchemes/NormalToricSchemes/Attributes.jl
+++ b/experimental/Schemes/ToricSchemes/NormalToricSchemes/Attributes.jl
@@ -18,7 +18,112 @@ julia> underlying_scheme(toric_scheme)
 covered scheme with 3 affine patches in its default covering
 ```
 """
-underlying_scheme(X::ToricCoveredScheme) = X.X
+function underlying_scheme(Z::ToricCoveredScheme)
+  if !isdefined(Z, :X)
+    F = fan(normal_toric_variety(Z))
+    C = maximal_cones(F)
+
+    antv = affine_open_covering(normal_toric_variety(Z))
+    var_names = [Symbol.(["x_$(i)_$(k)" for i in 1:ngens(base_ring(toric_ideal(antv[k])))]) for k in 1:length(antv)]
+    #rings = [polynomial_ring(coefficient_ring(antv[k]), ["x_$(i)_$(k)" for i in 1:ngens(base_ring(toric_ideal(antv[k])))], cached=false)[1] for k in 1:length(antv)]
+    patch_list = [ToricSpec(U, var_names=n) for (U, n) in zip(antv, var_names)]
+    cov = Covering(patch_list)
+
+    for i in 1:(length(patch_list)-1)
+      X = patch_list[i]
+      CX = cone(X)
+      CXdual = dual_cone(X)
+      for j in i+1:length(patch_list)
+        Y = patch_list[j]
+        CY = cone(Y)
+        CYdual = dual_cone(Y)
+
+        # Now glue X and Y
+        
+        # Step 1: Find the cone of the intersection of X and Y.
+        facet = intersect(CX, CY)
+        # harvest the dual cone
+        dual_facet = polarize(facet)
+        if !(dim(facet) == dim(CX) - 1)
+          continue
+        end
+
+        # Step 2: Extract the candidates for the localization element.
+        candidates = dual_facet.pm_cone.HILBERT_BASIS_GENERATORS[2]
+        v = candidates[1,:]
+        for j in 1:nrows(candidates)
+          v = candidates[j,:]
+          if contains(CXdual, v) && contains(CYdual, -v)
+            break
+          elseif contains(CXdual, -v) && contains(CYdual, v)
+            v = -v
+            break
+          end
+        end
+        (contains(CXdual, v) && contains(CYdual, -v)) || error("no element found for localization")
+        
+        # Step 3: We express the loclization element (it is v, resp. -v) in the Hilbert basis of the two patches.
+        # -> Then localize at this element.
+        vmat = matrix(ZZ.(collect(v)))
+        
+        AX = transpose(hilbert_basis(X))
+        Id = identity_matrix(ZZ, ncols(AX))
+        sol = solve_mixed(AX, vmat, Id, zero(vmat))
+        fX = prod([x^k for (x, k) in zip(gens(ambient_coordinate_ring(X)), sol)])
+        U = PrincipalOpenSubset(X, OO(X)(fX))
+        
+        AY = transpose(hilbert_basis(Y))
+        Id = identity_matrix(ZZ, ncols(AY))
+        sol = solve_mixed(AY, -vmat, Id, zero(vmat))
+        fY = prod([x^(k>0 ? 1 : 0) for (x, k) in zip(gens(ambient_coordinate_ring(Y)), sol)])
+        V = PrincipalOpenSubset(Y, OO(Y)(fY))
+        
+        # Step 4: Set up the glueing isomorphisms.
+        # (Assumption: v is part of the Hilbert basis.)
+        l = 0
+        for j in 1:ncols(AX)
+          if vmat == AX[:, j] 
+            l = j
+            break
+          end
+        end
+        Idext = identity_matrix(ZZ, ncols(AX))
+        Idext[l,l] = 0
+        img_gens = [solve_mixed(AX, AY[:, k], Idext, zero(matrix_space(ZZ, ncols(Idext), 1))) for k in 1:ncols(AY)]
+        fres = hom(OO(V), OO(U), [prod([(k >= 0 ? x^k : inv(x)^(-k)) for (x, k) in zip(gens(OO(U)), w)]) for w in img_gens])
+        
+        l = 0
+        for j in 1:ncols(AY)
+          if -vmat == AY[:, j] 
+            l = j
+            break
+          end
+        end
+        Idext = identity_matrix(ZZ, ncols(AY))
+        Idext[l,l] = 0
+        img_gens = [solve_mixed(AY, AX[:, k], Idext, zero(matrix_space(ZZ, ncols(Idext), 1))) for k in 1:ncols(AX)]
+        gres = hom(OO(U), OO(V), [prod([(k >= 0 ? x^k : inv(x)^(-k)) for (x, k) in zip(gens(OO(V)), w)]) for w in img_gens])
+        
+        set_attribute!(gres, :inverse, fres)
+        set_attribute!(fres, :inverse, gres)
+        f = SpecMor(U, V, fres)
+        g = SpecMor(V, U, gres)
+        set_attribute!(g, :inverse, f)
+        set_attribute!(f, :inverse, g)
+        
+        G = SimpleGlueing(X, Y, f, g)
+        add_glueing!(cov, G)
+      end
+    end
+    
+    # TODO: Improve the gluing (lazy gluing) or try to use the Hasse diagram.
+    # TODO: For now, we conjecture, that the composition of the computed glueings is sufficient to deduce all glueings.
+    fill_transitions!(cov)
+    X = CoveredScheme(cov)
+    Z.X = X
+  end
+  return Z.X
+end
 export underlying_scheme
 
 

--- a/experimental/Schemes/ToricSchemes/NormalToricSchemes/Attributes.jl
+++ b/experimental/Schemes/ToricSchemes/NormalToricSchemes/Attributes.jl
@@ -124,7 +124,6 @@ function underlying_scheme(Z::ToricCoveredScheme)
   end
   return Z.X
 end
-export underlying_scheme
 
 
 @doc Markdown.doc"""
@@ -146,7 +145,6 @@ Normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric va
 ```
 """
 normal_toric_variety(X::ToricCoveredScheme) = X.ntv
-export normal_toric_variety
 
 
 @doc Markdown.doc"""
@@ -168,4 +166,4 @@ Polyhedral fan in ambient dimension 2
 ```
 """
 fan(X::ToricCoveredScheme) = fan(normal_toric_variety(X))
-export fan
+

--- a/experimental/Schemes/ToricSchemes/NormalToricSchemes/Properties.jl
+++ b/experimental/Schemes/ToricSchemes/NormalToricSchemes/Properties.jl
@@ -17,4 +17,4 @@ true
 ```
 """
 is_smooth(X::ToricCoveredScheme) = is_smooth(normal_toric_variety(X))
-export is_smooth
+

--- a/experimental/Schemes/ToricSchemes/NormalToricSchemes/Type.jl
+++ b/experimental/Schemes/ToricSchemes/NormalToricSchemes/Type.jl
@@ -1,6 +1,3 @@
-export ToricCoveredScheme
-
-
 @attributes mutable struct ToricCoveredScheme{BRT} <: AbsCoveredScheme{BRT}
   ntv::NormalToricVariety
   X::CoveredScheme
@@ -13,3 +10,4 @@ end
 function Base.show(io::IO, X::ToricCoveredScheme)
   print(io, "Scheme of a toric variety with fan spanned by $(rays(fan(X)))")
 end
+

--- a/experimental/Schemes/ToricSchemes/NormalToricSchemes/Type.jl
+++ b/experimental/Schemes/ToricSchemes/NormalToricSchemes/Type.jl
@@ -10,8 +10,9 @@ export ToricCoveredScheme
     C = maximal_cones(F)
 
     antv = affine_open_covering(ntv)
-    rings = [polynomial_ring(coefficient_ring(antv[k]), ["x_$(i)_$(k)" for i in 1:ngens(base_ring(toric_ideal(antv[k])))], cached=false)[1] for k in 1:length(antv)]
-    patch_list = [ToricSpec(U, R=R) for (U, R) in zip(antv, rings)]
+    var_names = [Symbol.(["x_$(i)_$(k)" for i in 1:ngens(base_ring(toric_ideal(antv[k])))]) for k in 1:length(antv)]
+    #rings = [polynomial_ring(coefficient_ring(antv[k]), ["x_$(i)_$(k)" for i in 1:ngens(base_ring(toric_ideal(antv[k])))], cached=false)[1] for k in 1:length(antv)]
+    patch_list = [ToricSpec(U, var_names=n) for (U, n) in zip(antv, var_names)]
     cov = Covering(patch_list)
 
     for i in 1:(length(patch_list)-1)

--- a/experimental/Schemes/ToricSchemes/NormalToricSchemes/Type.jl
+++ b/experimental/Schemes/ToricSchemes/NormalToricSchemes/Type.jl
@@ -1,112 +1,12 @@
 export ToricCoveredScheme
 
 
-@attributes mutable struct ToricCoveredScheme{BRT, CoveredSchemeType<:CoveredScheme} <: AbsCoveredScheme{BRT}
-  X::CoveredSchemeType
+@attributes mutable struct ToricCoveredScheme{BRT} <: AbsCoveredScheme{BRT}
   ntv::NormalToricVariety
+  X::CoveredScheme
 
   function ToricCoveredScheme(ntv::NormalToricVariety)
-    F = fan(ntv)
-    C = maximal_cones(F)
-
-    antv = affine_open_covering(ntv)
-    var_names = [Symbol.(["x_$(i)_$(k)" for i in 1:ngens(base_ring(toric_ideal(antv[k])))]) for k in 1:length(antv)]
-    #rings = [polynomial_ring(coefficient_ring(antv[k]), ["x_$(i)_$(k)" for i in 1:ngens(base_ring(toric_ideal(antv[k])))], cached=false)[1] for k in 1:length(antv)]
-    patch_list = [ToricSpec(U, var_names=n) for (U, n) in zip(antv, var_names)]
-    cov = Covering(patch_list)
-
-    for i in 1:(length(patch_list)-1)
-      X = patch_list[i]
-      CX = cone(X)
-      CXdual = dual_cone(X)
-      for j in i+1:length(patch_list)
-        Y = patch_list[j]
-        CY = cone(Y)
-        CYdual = dual_cone(Y)
-
-        # Now glue X and Y
-        
-        # Step 1: Find the cone of the intersection of X and Y.
-        facet = intersect(CX, CY)
-        # harvest the dual cone
-        dual_facet = polarize(facet)
-        if !(dim(facet) == dim(CX) - 1)
-          continue
-        end
-
-        # Step 2: Extract the candidates for the localization element.
-        candidates = dual_facet.pm_cone.HILBERT_BASIS_GENERATORS[2]
-        v = candidates[1,:]
-        for j in 1:nrows(candidates)
-          v = candidates[j,:]
-          if contains(CXdual, v) && contains(CYdual, -v)
-            break
-          elseif contains(CXdual, -v) && contains(CYdual, v)
-            v = -v
-            break
-          end
-        end
-        (contains(CXdual, v) && contains(CYdual, -v)) || error("no element found for localization")
-        
-        # Step 3: We express the loclization element (it is v, resp. -v) in the Hilbert basis of the two patches.
-        # -> Then localize at this element.
-        vmat = matrix(ZZ.(collect(v)))
-        
-        AX = transpose(hilbert_basis(X))
-        Id = identity_matrix(ZZ, ncols(AX))
-        sol = solve_mixed(AX, vmat, Id, zero(vmat))
-        fX = prod([x^k for (x, k) in zip(gens(ambient_coordinate_ring(X)), sol)])
-        U = PrincipalOpenSubset(X, OO(X)(fX))
-        
-        AY = transpose(hilbert_basis(Y))
-        Id = identity_matrix(ZZ, ncols(AY))
-        sol = solve_mixed(AY, -vmat, Id, zero(vmat))
-        fY = prod([x^(k>0 ? 1 : 0) for (x, k) in zip(gens(ambient_coordinate_ring(Y)), sol)])
-        V = PrincipalOpenSubset(Y, OO(Y)(fY))
-        
-        # Step 4: Set up the glueing isomorphisms.
-        # (Assumption: v is part of the Hilbert basis.)
-        l = 0
-        for j in 1:ncols(AX)
-          if vmat == AX[:, j] 
-            l = j
-            break
-          end
-        end
-        Idext = identity_matrix(ZZ, ncols(AX))
-        Idext[l,l] = 0
-        img_gens = [solve_mixed(AX, AY[:, k], Idext, zero_matrix(ZZ, ncols(Idext), 1)) for k in 1:ncols(AY)]
-        fres = hom(OO(V), OO(U), [prod([(k >= 0 ? x^k : inv(x)^(-k)) for (x, k) in zip(gens(OO(U)), w)]) for w in img_gens])
-        
-        l = 0
-        for j in 1:ncols(AY)
-          if -vmat == AY[:, j] 
-            l = j
-            break
-          end
-        end
-        Idext = identity_matrix(ZZ, ncols(AY))
-        Idext[l,l] = 0
-        img_gens = [solve_mixed(AY, AX[:, k], Idext, zero_matrix(ZZ, ncols(Idext), 1)) for k in 1:ncols(AX)]
-        gres = hom(OO(U), OO(V), [prod([(k >= 0 ? x^k : inv(x)^(-k)) for (x, k) in zip(gens(OO(V)), w)]) for w in img_gens])
-        
-        set_attribute!(gres, :inverse, fres)
-        set_attribute!(fres, :inverse, gres)
-        f = SpecMor(U, V, fres)
-        g = SpecMor(V, U, gres)
-        set_attribute!(g, :inverse, f)
-        set_attribute!(f, :inverse, g)
-        
-        G = SimpleGlueing(X, Y, f, g)
-        add_glueing!(cov, G)
-      end
-    end
-    
-    # TODO: Improve the gluing (lazy gluing) or try to use the Hasse diagram.
-    # TODO: For now, we conjecture, that the composition of the computed glueings is sufficient to deduce all glueings.
-    fill_transitions!(cov)
-    X = CoveredScheme(cov)
-    return new{typeof(base_ring(X)), typeof(X)}(X, ntv)
+    return new{typeof(QQ)}(ntv)
   end
 end
 

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -28,6 +28,7 @@ export AffineHalfspace
 export AffineHyperplane
 export AffineNormalToricVariety
 export AffineVariety
+export affine_normal_toric_variety
 export affine_variety
 export affine_algebraic_set
 export AutomorphismGroup
@@ -160,11 +161,13 @@ export SubQuoHom
 export SubdivisionOfPoints
 export SubquoModule
 export SubquoModuleElem
+export ToricCoveredScheme
 export ToricDivisor
 export ToricDivisorClass
 export ToricLineBundle
 export ToricMorphism
 export ToricVanishingSet
+export ToricSpec
 export TropicalCurve
 export TropicalHypersurface
 export TropicalLinearSpace
@@ -431,6 +434,7 @@ export domain_type
 export double_coset
 export double_cosets
 export dst
+export dual_cone
 export dual_continued_fraction_hirzebruch_jung
 export dual_matroid
 export dual_subdivision


### PR DESCRIPTION
If our marriage of toric stuff with the general schemes is to compete in any way to the purely toric world, we need to postpone creating the algebraic objects until needed. This is a first step towards this end. 