### PR TITLE
Abstract types for varieties

### DIFF
--- a/experimental/Schemes/Types.jl
+++ b/experimental/Schemes/Types.jl
@@ -11,11 +11,6 @@ export VarietyFunctionFieldElem
 
 
 ########################################################################
-# Abstract projective schemes                                          #
-########################################################################
-abstract type AbsProjectiveScheme{BaseRingType, RingType} <: Scheme{BaseRingType} end
-
-########################################################################
 # Concrete type for projective schemes                                 #
 ########################################################################
 @Markdown.doc """

--- a/src/AlgebraicGeometry/Schemes/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/Types.jl
@@ -41,3 +41,10 @@ struct EmptyScheme{BaseRingType}<:Scheme{BaseRingType}
     return new{BaseRingType}(k)
   end
 end
+
+
+
+########################################################################
+# Abstract projective schemes                                          #
+########################################################################
+abstract type AbsProjectiveScheme{BaseRingType, RingType} <: Scheme{BaseRingType} end

--- a/src/AlgebraicGeometry/Schemes/Varieties/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/Varieties/Types.jl
@@ -1,0 +1,78 @@
+################################################################################
+#
+# Abstract types for varieties
+#
+################################################################################
+
+@doc Markdown.doc"""
+    AbsAffineVariety <: AbsSpec{<:Field}
+
+An affine, geometrically integral scheme of finite type over a field.
+"""
+abstract type AbsAffineVariety{BaseField<:Field, RingType} <:AbsSpec{BaseField, RingType}# where {BaseField <:Field, RingType}
+end
+
+@doc Markdown.doc"""
+    AbsProjectiveVariety <: AbsProjectiveScheme{<:Field}
+
+A projective variety over a field.
+
+That is a projective, geometrically integral scheme over a field.
+"""
+abstract type AbsProjectiveVariety{BaseField<:Field, GradedRingType<:Ring} <: AbsProjectiveScheme{BaseField, GradedRingType} end
+
+@doc Markdown.doc"""
+    AbsCoveredVariety <: Scheme{<:Field}
+
+A separated, geometrically integral scheme of finite type over a field.
+
+Note that we allow reducible varieties.
+"""
+abstract type AbsCoveredVariety{BaseField<:Field} <: AbsCoveredScheme{BaseField} end
+
+################################################################################
+#
+# Abstract types for curves
+#
+################################################################################
+
+@doc Markdown.doc"""
+    AbsAffineCurve <: AbsAffineVariety
+
+A curve in affine space.
+
+An affine curve is an affine variety of dimension one.
+"""
+abstract type AbsAffineCurve{BaseField<:Field, RingType<:Ring} <: AbsAffineVariety{BaseField, RingType} end
+
+@doc Markdown.doc"""
+    AbsProjectiveCurve <: AbsProjectiveVariety
+
+A projective curve embedded in an ambient projective space.
+"""
+abstract type AbsProjectiveCurve{BaseField<:Field, RingType<:Ring} <: AbsProjectiveVariety{BaseField, RingType} end
+
+
+@doc Markdown.doc"""
+    AbsCoveredCurve
+
+A curve represented in terms of a covering.
+
+A curve is a geometrically integral scheme of finite type over a field which is
+of dimension one.
+"""
+abstract type AbsCoveredCurve{BaseField} <: Scheme{BaseField} end
+
+#=
+################################################################################
+# Plane curves
+################################################################################
+@doc Markdown.doc"""
+    ProjectivePlaneCurve
+
+A plane projective curve embedded in an ambient projective space.
+"""
+mutable struct PlaneProjectiveCurve{BaseField<:Field, GradedRingType<:Ring} <: AbsProjectiveCurve{BaseField, GradedRingType}
+  X::ProjectiveScheme{BaseField, GradedRingType}
+end
+=#

--- a/src/AlgebraicGeometry/Schemes/Varieties/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/Varieties/Types.jl
@@ -1,3 +1,19 @@
+@doc Markdown.doc"""
+    AbsAffineAlgebraicSet <: AbsSpec
+
+An affine, geometrically reduced scheme of finite type over a field.
+"""
+abstract type AbsAffineAlgebraicSet{BaseField<:Field, RingType} <:AbsSpec{BaseField, RingType}# where {BaseField <:Field, RingType}
+end
+
+@doc Markdown.doc"""
+    AbsProjectiveAlgebraicSet <: AbsProjectiveScheme
+
+An affine, geometrically reduced scheme of finite type over a field.
+"""
+abstract type AbsProjectiveAlgebraicSet{BaseField<:Field, RingType} <:AbsProjectiveScheme{BaseField, RingType}# where {BaseField <:Field, RingType}
+end
+
 ################################################################################
 #
 # Abstract types for varieties
@@ -5,24 +21,24 @@
 ################################################################################
 
 @doc Markdown.doc"""
-    AbsAffineVariety <: AbsSpec{<:Field}
+    AbsAffineVariety <: AbsAffineAlgebraicSet
 
 An affine, geometrically integral scheme of finite type over a field.
 """
-abstract type AbsAffineVariety{BaseField<:Field, RingType} <:AbsSpec{BaseField, RingType}# where {BaseField <:Field, RingType}
+abstract type AbsAffineVariety{BaseField<:Field, RingType} <:AbsAffineAlgebraicSet{BaseField, RingType}# where {BaseField <:Field, RingType}
 end
 
 @doc Markdown.doc"""
-    AbsProjectiveVariety <: AbsProjectiveScheme{<:Field}
+    AbsProjectiveVariety <: AbsProjectiveAlgebraicSet
 
 A projective variety over a field.
 
 That is a projective, geometrically integral scheme over a field.
 """
-abstract type AbsProjectiveVariety{BaseField<:Field, GradedRingType<:Ring} <: AbsProjectiveScheme{BaseField, GradedRingType} end
+abstract type AbsProjectiveVariety{BaseField<:Field, GradedRingType<:Ring} <: AbsProjectiveAlgebraicSet{BaseField, GradedRingType} end
 
 @doc Markdown.doc"""
-    AbsCoveredVariety <: Scheme{<:Field}
+    AbsCoveredVariety <: Scheme
 
 A separated, geometrically integral scheme of finite type over a field.
 

--- a/src/AlgebraicGeometry/Schemes/Varieties/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/Varieties/Types.jl
@@ -3,16 +3,14 @@
 
 An affine, geometrically reduced scheme of finite type over a field.
 """
-abstract type AbsAffineAlgebraicSet{BaseField<:Field, RingType} <:AbsSpec{BaseField, RingType}# where {BaseField <:Field, RingType}
-end
+abstract type AbsAffineAlgebraicSet{BaseField<:Field, RingType} <:AbsSpec{BaseField, RingType} end
 
 @doc Markdown.doc"""
     AbsProjectiveAlgebraicSet <: AbsProjectiveScheme
 
-An affine, geometrically reduced scheme of finite type over a field.
+A projective, geometrically reduced scheme of finite type over a field.
 """
-abstract type AbsProjectiveAlgebraicSet{BaseField<:Field, RingType} <:AbsProjectiveScheme{BaseField, RingType}# where {BaseField <:Field, RingType}
-end
+abstract type AbsProjectiveAlgebraicSet{BaseField<:Field, RingType} <:AbsProjectiveScheme{BaseField, RingType} end
 
 ################################################################################
 #
@@ -25,8 +23,7 @@ end
 
 An affine, geometrically integral scheme of finite type over a field.
 """
-abstract type AbsAffineVariety{BaseField<:Field, RingType} <:AbsAffineAlgebraicSet{BaseField, RingType}# where {BaseField <:Field, RingType}
-end
+abstract type AbsAffineVariety{BaseField<:Field, RingType} <:AbsAffineAlgebraicSet{BaseField, RingType} end
 
 @doc Markdown.doc"""
     AbsProjectiveVariety <: AbsProjectiveAlgebraicSet
@@ -41,8 +38,6 @@ abstract type AbsProjectiveVariety{BaseField<:Field, GradedRingType<:Ring} <: Ab
     AbsCoveredVariety <: Scheme
 
 A separated, geometrically integral scheme of finite type over a field.
-
-Note that we allow reducible varieties.
 """
 abstract type AbsCoveredVariety{BaseField<:Field} <: AbsCoveredScheme{BaseField} end
 
@@ -68,14 +63,12 @@ A projective curve embedded in an ambient projective space.
 """
 abstract type AbsProjectiveCurve{BaseField<:Field, RingType<:Ring} <: AbsProjectiveVariety{BaseField, RingType} end
 
-
 @doc Markdown.doc"""
     AbsCoveredCurve
 
 A curve represented in terms of a covering.
 
-A curve is a geometrically integral scheme of finite type over a field which is
-of dimension one.
+A curve is a geometrically integral scheme of dimension 1 of finite type over a field.
 """
 abstract type AbsCoveredCurve{BaseField} <: Scheme{BaseField} end
 
@@ -84,7 +77,7 @@ abstract type AbsCoveredCurve{BaseField} <: Scheme{BaseField} end
 # Plane curves
 ################################################################################
 @doc Markdown.doc"""
-    ProjectivePlaneCurve
+    PlaneProjectiveCurve
 
 A plane projective curve embedded in an ambient projective space.
 """

--- a/src/AlgebraicGeometry/Schemes/main.jl
+++ b/src/AlgebraicGeometry/Schemes/main.jl
@@ -95,3 +95,9 @@ include("CoveredSchemes/Objects/Methods.jl")
 include("CoveredSchemes/Morphisms/Constructors.jl")
 include("CoveredSchemes/Morphisms/Attributes.jl")
 include("CoveredSchemes/Morphisms/Methods.jl")
+
+########################################################################
+# Varieties                                                            #
+########################################################################
+include("Varieties/Types.jl")
+


### PR DESCRIPTION
We fix our terminology.

In a nutshell:
Affine[/Projective]AlgebraicSet :=  affine [projective] scheme which is geometrically reduced and of finite type over a field
Affine[/Projective / Covered]Variety:= (affine/projective/separated) geometrically integral scheme of finite type over a field 

Curves, Surfaces, Threefolds and ToricVarieties are varieties. 

The plane curves should be integrated into this framework.
There should also be enough room for elliptic curves. @fieker 

@afkafkafk13, @wdecker 
Once we migrate AbsProjectiveScheme out of experimental more will follow. 
