### PR TITLE
Fix for silent changes of monomial ordering

### DIFF
--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -1153,6 +1153,7 @@ export simulate_valuation
 export singular
 export singular_assure
 export singular_coeff_ring
+export singular_ideal
 export singular_locus
 export singular_locus_reduced
 export singular_poly_ring

--- a/src/InvariantTheory/fundamental_invariants.jl
+++ b/src/InvariantTheory/fundamental_invariants.jl
@@ -30,8 +30,8 @@ function fundamental_invariants_via_king(RG::InvRing, beta::Int = 0)
   ordR = degrevlex(gens(R))
 
   S = elem_type(R)[]
-  G = IdealGens(R, elem_type(R)[])
-  singular_assure(G, ordR)
+  G = IdealGens(R, elem_type(R)[], ordR)
+  singular_assure(G)
   GO = elem_type(R)[]
 
   g = order(Int, group(RG))

--- a/src/InvariantTheory/fundamental_invariants.jl
+++ b/src/InvariantTheory/fundamental_invariants.jl
@@ -9,9 +9,9 @@
 # TODO: This should not be in this file and integrated in the general groebner_basis
 # functionality
 function _groebner_basis(I::MPolyIdeal, d::Int; ordering::MonomialOrdering = default_ordering(base_ring(I)))
-  singular_assure(I, ordering)
-  R = I.gens.Sx
-  J = Singular.Ideal(R, gens(I.gens.S)...)
+  sI = singular_ideal(I.gens, ordering)
+  R = base_ring(sI)
+  J = Singular.Ideal(R, gens(sI)...)
   G = Singular.with_degBound(d) do
         return Singular.std(J)
       end

--- a/src/Rings/MPolyMap/AffineAlgebras.jl
+++ b/src/Rings/MPolyMap/AffineAlgebras.jl
@@ -78,10 +78,11 @@ function _groebner_data(F::AffAlgHom, ord::Symbol)
   return get_attribute!(F, ord) do
     (S, I, W, _) = _ring_helper(s, zero(s), _images(F))
     # Build auxiliary objects
-    (T, inc, J) = _containment_helper(S, n, m, I, W, ord)
-    # make sure to compute the NF with respect to the correct ordering  
-    D = normal_form([gen(T, i) for i in 1:m], J,
-                    ordering = first(collect(keys(J.gb))))
+    (T, inc, J, O) = _containment_helper(S, n, m, I, W, ord)
+    # make sure to compute the NF with respect to the correct ordering
+    R1 = base_ring(J)
+    D = normal_form([gen(R1, i) for i in 1:m], J,
+                    ordering = O)
     A = [zero(r) for i in 1:m]
     B = [gen(r, i) for i in 1:n]
     pr = hom(T, r, vcat(A, B))

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1349,9 +1349,9 @@ function groebner_basis_hilbert_driven(I::MPolyIdeal{P};
     h = (Int32).([coeff(hilbert_numerator, i) for i in 0:degree(hilbert_numerator)+1])
   end
 
-  singular_assure(I.gens, ordering)
-  singular_ring = I.gens.Sx
-  J  = Singular.Ideal(singular_ring, gens(I.gens.S)...)
+  singular_I_gens = singular_ideal(I.gens, ordering)
+  singular_ring = base_ring(singular_I_gens)
+  J = Singular.Ideal(singular_ring, gens(singular_I_gens)...)
   i  = Singular.std_hilbert(J, h, (Int32).(weights),
                             complete_reduction = complete_reduction)
   GB = IdealGens(I.gens.Ox, i, complete_reduction)

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -975,8 +975,9 @@ julia> normal_form(A, J)
 ```
 """
 function normal_form(f::T, J::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(J))) where { T <: MPolyRingElem }
-    singular_assure(J, ordering)
-    I = Singular.Ideal(J.gens.Sx, J.gens.Sx(f))
+    sJ = singular_ideal(J.gens, ordering)
+    S = base_ring(sJ)
+    I = Singular.Ideal(S, S(f))
     N = normal_form_internal(I, J, ordering)
     return N[1]
 end

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -566,9 +566,13 @@ julia> Oscar.normal_form_internal(I,J,default_ordering(base_ring(J)))
 """
 function normal_form_internal(I::Singular.sideal, J::MPolyIdeal, o::MonomialOrdering)
   groebner_assure(J, o)
-  G = J.gb[o]  
-  singular_assure(G)
-  K = ideal(base_ring(J), reduce(I, G.S))
+  G = J.gb[o]
+  R = base_ring(J)
+  SR = singular_poly_ring(R, o)
+  f = Singular.AlgebraHomomorphism(base_ring(I), SR, gens(SR))
+  IS = Singular.map_ideal(f, I)
+  GS = singular_ideal(G, o)
+  K = ideal(base_ring(J), reduce(IS, GS))
   return [J.gens.Ox(x) for x = gens(K.gens.S)]
 end
 

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -567,7 +567,7 @@ julia> Oscar.normal_form_internal(I,J,default_ordering(base_ring(J)))
 function normal_form_internal(I::Singular.sideal, J::MPolyIdeal, o::MonomialOrdering)
   groebner_assure(J, o)
   G = J.gb[o]  
-  singular_assure(G, o)
+  singular_assure(G)
   K = ideal(base_ring(J), reduce(I, G.S))
   return [J.gens.Ox(x) for x = gens(K.gens.S)]
 end

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -342,7 +342,7 @@ function groebner_basis_f4(
 end
 
 @doc Markdown.doc"""
-    _compute_standard_basis_with_transform(B::BiPolyArray, ordering::MonomialOrdering, complete_reduction::Bool = false)
+    _compute_standard_basis_with_transform(B::IdealGens, ordering::MonomialOrdering, complete_reduction::Bool = false)
 
 **Note**: Internal function, subject to change, do not use.
 
@@ -369,21 +369,8 @@ julia> B,m = Oscar._compute_standard_basis_with_transform(A, degrevlex(R))
 ```
 """
 function _compute_standard_basis_with_transform(B::IdealGens, ordering::MonomialOrdering, complete_reduction::Bool = false)
-   if !isdefined(B, :ordering)
-      singular_assure(B, ordering)
-   elseif ordering != B.ordering
-     R = singular_poly_ring(B.Ox, ordering)
-     i = Singular.Ideal(R, [R(x) for x = B])
-     i, m = Singular.lift_std(i, complete_reduction = complete_reduction)
-     return IdealGens(B.Ox, i), map_entries(x->B.Ox(x), m)
-   end
-
-   if !isdefined(B, :S)
-     B.S = Singular.Ideal(B.Sx, [B.Sx(x) for x = B.O])
-   end
-
-   i, m = Singular.lift_std(B.S, complete_reduction = complete_reduction)
-   return IdealGens(B.Ox, i), map_entries(x->B.Ox(x), m)
+  istd, m = Singular.lift_std(singular_ideal(B, ordering), complete_reduction = complete_reduction)
+  return IdealGens(B.Ox, istd), map_entries(x -> B.Ox(x), m)
 end
 
 @doc Markdown.doc"""

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -979,6 +979,7 @@ julia> normal_form(A, J)
 ```
 """
 function normal_form(f::T, J::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(J))) where { T <: MPolyRingElem }
+    singular_assure(J)
     SR = J.gens.Sx
     I = Singular.Ideal(SR, SR(f))
     N = normal_form_internal(I, J, ordering)
@@ -986,6 +987,7 @@ function normal_form(f::T, J::MPolyIdeal; ordering::MonomialOrdering = default_o
 end
 
 function normal_form(A::Vector{T}, J::MPolyIdeal; ordering::MonomialOrdering=default_ordering(base_ring(J))) where { T <: MPolyElem }
+  singular_assure(J)
   SR = J.gens.Sx
   I = Singular.Ideal(SR, [SR(x) for x in A])
   normal_form_internal(I, J, ordering)

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -85,17 +85,15 @@ degrevlex([x, y])
 ```
 """
 function _compute_standard_basis(B::IdealGens, ordering::MonomialOrdering, complete_reduction::Bool = false)
-	singular_assure(B, ordering)
-	R = B.Sx
-	I  = Singular.Ideal(R, gens(B.S)...)
-	i  = Singular.std(I, complete_reduction = complete_reduction)
-	BA = IdealGens(B.Ox, i, complete_reduction)
-	BA.isGB = true
-	BA.ord = ordering
-	if isdefined(BA, :S)
-	   BA.S.isGB  = true
-	end
-	return BA
+    gensSord = singular_ideal(B, ordering)
+    i = Singular.std(gensSord, complete_reduction = complete_reduction)
+    BA = IdealGens(B.Ox, i, complete_reduction)
+    BA.isGB = true
+    BA.ord = ordering
+    if isdefined(BA, :S)
+        BA.S.isGB = true
+    end
+    return BA
 end
 
 # standard basis for non-global orderings #############################

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -917,9 +917,9 @@ end
 
 function _reduce_with_quotients_and_unit(I::IdealGens, J::IdealGens, ordering::MonomialOrdering = default_ordering(base_ring(J)))
 	@assert base_ring(J) == base_ring(I)
-	singular_assure(I, ordering)
-	singular_assure(J, ordering)
-	res = Singular.division(I.gens.S, J.gens.S)
+	sI = singular_ideal(I, ordering)
+  sJ = singular_ideal(J, ordering)
+  res = Singular.division(sI, sJ)
 	return matrix(base_ring(I), res[3]), matrix(base_ring(I), res[1]), [J.gens.Ox(x) for x = gens(res[2])]
 end
 

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -975,17 +975,16 @@ julia> normal_form(A, J)
 ```
 """
 function normal_form(f::T, J::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(J))) where { T <: MPolyRingElem }
-    sJ = singular_ideal(J.gens, ordering)
-    S = base_ring(sJ)
-    I = Singular.Ideal(S, S(f))
+    SR = J.gens.Sx
+    I = Singular.Ideal(SR, SR(f))
     N = normal_form_internal(I, J, ordering)
     return N[1]
 end
 
-function normal_form(A::Vector{T}, J::MPolyIdeal; ordering::MonomialOrdering=default_ordering(base_ring(J))) where { T <: MPolyRingElem }
-    singular_assure(J, ordering)
-    I = Singular.Ideal(J.gens.Sx, [J.gens.Sx(x) for x in A])
-    normal_form_internal(I, J, ordering)
+function normal_form(A::Vector{T}, J::MPolyIdeal; ordering::MonomialOrdering=default_ordering(base_ring(J))) where { T <: MPolyElem }
+  SR = J.gens.Sx
+  I = Singular.Ideal(SR, [SR(x) for x in A])
+  normal_form_internal(I, J, ordering)
 end
 
 @doc Markdown.doc"""

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -611,11 +611,11 @@ julia> reduce([y^3], [x^2, x*y-y^3], ordering=lex(R))
 ```
 """
 function reduce(I::IdealGens, J::IdealGens; ordering::MonomialOrdering = default_ordering(base_ring(J)))
-	@assert base_ring(J) == base_ring(I)
-	singular_assure(I, ordering)
-	singular_assure(J, ordering)
-	res = reduce(I.gens.S, J.gens.S)
-	return [J.gens.Ox(x) for x = gens(res)]
+  @assert base_ring(J) == base_ring(I)
+  Is = singular_ideal(I, ordering)
+  Js = singular_ideal(J, ordering)
+  res = reduce(Is, Js)
+  return [J.Ox(x) for x = gens(res)]
 end
 
 @doc Markdown.doc"""

--- a/src/Rings/mpoly-affine-algebras.jl
+++ b/src/Rings/mpoly-affine-algebras.jl
@@ -848,7 +848,7 @@ function _containment_helper(R::MPolyRing, N::Int, M::Int, I::MPolyIdeal, W::Vec
       O = degrevlex(GG[1:M])*degrevlex(GG[M+1:M+N])
    end
    groebner_assure(J, O, true)
-   return (T, phi, J)
+   return (T, phi, J, O)
 end
 
 # helper function to obtain information about qring status and 
@@ -903,7 +903,7 @@ function subalgebra_membership(f::S, v::Vector{S}) where S <: Union{MPolyRingEle
    m = ngens(R)
 
    # Build auxiliary objects
-   (T, phi, J) = _containment_helper(R, n, m, I, W, :degrevlex)
+   (T, phi, J, _) = _containment_helper(R, n, m, I, W, :degrevlex)
    TT, _ = polynomial_ring(base_ring(T), ["t_$i" for i in 1:n], ordering = :lex)
    
    # Check containment

--- a/src/Rings/mpoly-affine-algebras.jl
+++ b/src/Rings/mpoly-affine-algebras.jl
@@ -816,8 +816,8 @@ function is_cohen_macaulay(A::MPolyQuoRing)
  if !((R isa Oscar.MPolyDecRing) && is_standard_graded(R))
     throw(ArgumentError("The base ring must be standard ZZ-graded."))
  end
- singular_assure(I, negdegrevlex(gens(R)))
- res = Singular.LibHomolog.isCM(I.gens.gens.S)
+ sI = singular_ideal(I.gens, negdegrevlex(gens(R)))
+ res = Singular.LibHomolog.isCM(sI)
  if res == 1 return true end
  return false
 end

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -1298,9 +1298,8 @@ function minimal_generating_set(I::MPolyIdeal{<:MPolyDecRingElem}; ordering::Mon
 
   @req coefficient_ring(R) isa AbstractAlgebra.Field "The coefficient ring must be a field"
 
-  singular_assure(I, ordering)
-  IS = I.gens.S
-  RS = I.gens.Sx
+  IS = singular_ideal(I.gens, ordering)
+  RS = base_ring(IS)
   GC.@preserve IS RS begin
     ptr = Singular.libSingular.idMinBase(IS.ptr, RS.ptr)
     gensS = gens(typeof(IS)(RS, ptr))

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -381,6 +381,19 @@ function elements(I::IdealGens)
   return collect(I)
 end
 
+function singular_ideal(B::IdealGens, ordering::MonomialOrdering)
+  singular_assure(B)
+  isdefined(B, :ord) && B.ord == ordering && return B.gens.S
+  SR = singular_poly_ring(B.Ox, ordering)
+  f = Singular.AlgebraHomomorphism(B.Sx, SR, gens(SR))
+  return Singular.map_ideal(f, B.gens.S)
+end
+
+function singular_ideal(B::IdealGens)
+  singular_assure(B)
+  return B.gens.S
+end
+
 ##############################################################################
 #
 # Conversion to and from Singular: in particular, some Rings are

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -653,10 +653,12 @@ function singular_assure(I::IdealGens)
   end
 end
 
+# will be removed TODO
 function singular_assure(I::MPolyIdeal, ordering::MonomialOrdering)
    singular_assure(I.gens, ordering)
 end
 
+# will be removed TODO
 function singular_assure(I::IdealGens, ordering::MonomialOrdering)
   if !isdefined(I.gens, :S)
       I.ord = ordering

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -381,10 +381,15 @@ function elements(I::IdealGens)
   return collect(I)
 end
 
-function singular_ideal(B::IdealGens, ordering::MonomialOrdering)
+# Note: the check 
+# B.ord == monomial_ordering(B.Ox, ordering(base_ring(B.S)))
+# in the following function should not be necessary, 
+# but the constructor does not keep those consistent always. Trap, fix.
+
+function singular_ideal(B::IdealGens, monorder::MonomialOrdering)
   singular_assure(B)
-  isdefined(B, :ord) && B.ord == ordering && return B.gens.S
-  SR = singular_poly_ring(B.Ox, ordering)
+  isdefined(B, :ord) && B.ord == monorder && monomial_ordering(B.Ox, ordering(base_ring(B.S))) == B.ord && return B.gens.S
+  SR = singular_poly_ring(B.Ox, monorder)
   f = Singular.AlgebraHomomorphism(B.Sx, SR, gens(SR))
   return Singular.map_ideal(f, B.gens.S)
 end


### PR DESCRIPTION
This aims to fix the use of a wrong function signature of singular_assure for IdealGens and a monomial ordering which results in a change of the input object (silently changing the monomial ordering) when doing a computation. This problem was first observed in the standard_basis command and this hence also aims to fix #1914, but the issue is occures at various places (normal_form and friends, reduce and friends, is_cohen_macaulay, hilbert driven buchberger, invariant theory). The wrong signature of singular_assure is still in, but is eliminated at those places found. It should be deleted eventually. This changes code of a couple of people, so I hope it does not create new issues.