### PR TITLE
Towards Migrating projective schemes out of experimental

### DIFF
--- a/src/Rings/MPolyMap/flattenings.jl
+++ b/src/Rings/MPolyMap/flattenings.jl
@@ -8,8 +8,8 @@
 # To the outside, this is primarily the map identifying S with its 
 # flattened version.
 ########################################################################
-mutable struct RingFlattening{TowerRingType<:MPolyRing, FlatRingType<:Ring, 
-                              CoeffRingType<:Ring
+mutable struct RingFlattening{TowerRingType<:Union{MPolyRing, MPolyQuoRing}, 
+                              FlatRingType<:Ring, CoeffRingType<:Ring
                              } <: Hecke.Map{TowerRingType, FlatRingType, 
                                             SetMap, RingFlattening
                                            }
@@ -121,6 +121,132 @@ mutable struct RingFlattening{TowerRingType<:MPolyRing, FlatRingType<:Ring,
                                                      L_to_S_flat
                                                     )
   end
+
+  function RingFlattening(
+      S::MPolyQuoRing{RingElemType}
+    ) where {RingElemType <: MPolyRingElem{<:MPolyRingElem}}
+    P = base_ring(S) # the free polynomial ring
+    P_flattening = flatten(P)
+    R = base_ring(P) # the coefficient ring of S
+    kk = coefficient_ring(R)
+
+    P_flat = codomain(P_flattening)
+    S_flat, _ = quo(P_flat, P_flattening(modulus(S)))
+
+    R_to_S_flat = hom(R, S_flat, gens(S_flat)[ngens(S)+1:end])
+    S_to_S_flat = hom(S, S_flat, R_to_S_flat, gens(S_flat)[1:ngens(S)])
+    S_flat_to_S = hom(S_flat, S, vcat(gens(S), S.(gens(R))))
+    return new{typeof(S), typeof(S_flat), typeof(R)}(S, S_flat, R, 
+                                                     S_to_S_flat, S_flat_to_S,
+                                                     R_to_S_flat
+                                                    )
+  end
+
+  function RingFlattening(
+      S::MPolyQuoRing{RingElemType}
+    ) where {RingElemType <: MPolyRingElem{<:MPolyQuoRingElem}}
+    P = base_ring(S)::MPolyRing # the polynomial ring behind S
+    A = base_ring(P)::MPolyQuoRing # the coefficient ring of S
+    R = base_ring(A)::MPolyRing # the polynomial ring behind the coefficient ring of S
+    I = modulus(A)::MPolyIdeal # the modulus of the coefficient ring of S
+    kk = coefficient_ring(R)::Field
+
+    P_flattening = flatten(P)
+    P_flat = codomain(P_flattening)
+    mod_flat = P_flattening(modulus(S))
+    S_flat, _ = quo(P_flat, mod_flat)
+
+    A_to_S_flat = hom(A, S_flat, gens(S_flat)[ngens(S)+1:end])
+
+    S_to_S_flat = hom(S, S_flat, A_to_S_flat, gens(S_flat)[1:ngens(S)])
+    S_flat_to_S = hom(S_flat, S, vcat(gens(S), S.(P.(gens(A)))))
+
+    return new{typeof(S), typeof(S_flat), typeof(A)}(S, S_flat, A, 
+                                                     S_to_S_flat, S_flat_to_S,
+                                                     A_to_S_flat
+                                                    )
+  end
+
+  function RingFlattening(
+      S::MPolyQuoRing{RingElemType}
+    ) where {RingElemType <: MPolyRingElem{<:MPolyQuoLocRingElem}}
+    P = base_ring(S)::MPolyRing
+    Q = base_ring(P)::MPolyQuoLocRing
+    R = base_ring(Q)::MPolyRing
+    L = localized_ring(Q)::MPolyLocRing
+    A = underlying_quotient(Q)::MPolyQuoRing
+    U = inverted_set(Q)::AbsMultSet
+    I = modulus(Q)::MPolyLocalizedIdeal
+    kk = coefficient_ring(R)::Field
+
+    P_flattening = flatten(P)
+    P_flat = codomain(P_flattening)
+    mod_flat = P_flattening(modulus(S))
+    S_flat, _ = quo(P_flat, mod_flat)
+
+    Q_to_S_flat = hom(Q, S_flat, gens(S_flat)[ngens(S)+1:end])
+    S_to_S_flat = hom(S, S_flat, Q_to_S_flat, gens(S_flat)[1:ngens(S)])
+
+    # The common type of homomorphisms from a localization to S
+    # involves computation of the inverse of elements in S. 
+    # This has no computational backend. Hence, we need to cheat here. 
+    B = base_ring(S_flat)
+    psi = hom(B, S, vcat(gens(S), S.(gens(Q))))
+    v = vcat([zero(Q) for i in 1:ngens(S)], gens(Q))
+    function my_map(a::RingElem) 
+      p = lifted_numerator(a)
+      q = lifted_denominator(a)
+      pp = psi(p)
+      qq = S(P(inv(evaluate(q, v)))) # We know that all admissible representatives of denominators must come from elements in L.
+      return pp*qq
+    end
+
+    #S_flat_to_S = hom(S_flat, S, vcat(gens(S), S.(gens(Q))))
+    S_flat_to_S = MapFromFunc(my_map, S_flat, S)
+
+    return new{typeof(S), typeof(S_flat), typeof(Q)}(S, S_flat, Q, 
+                                                     S_to_S_flat, S_flat_to_S,
+                                                     Q_to_S_flat
+                                                    )
+  end
+
+  function RingFlattening(
+      S::MPolyQuoRing{RingElemType}
+    ) where {RingElemType <: MPolyRingElem{<:MPolyLocRingElem}}
+    P = base_ring(S)::MPolyRing
+    L = base_ring(P)::MPolyLocRing
+    R = base_ring(L)::MPolyRing
+    U = inverted_set(L)::AbsMultSet
+    kk = coefficient_ring(R)::Field
+
+    P_flattening = flatten(P)
+    P_flat = codomain(P_flattening)
+    mod_flat = P_flattening(modulus(S))
+    S_flat, _ = quo(P_flat, mod_flat)
+
+    L_to_S_flat = hom(L, S_flat, gens(S_flat)[ngens(S)+1:end])
+    S_to_S_flat = hom(S, S_flat, L_to_S_flat, gens(S_flat)[1:ngens(S)])
+
+    # The common type of homomorphisms from a localization to S
+    # involves computation of the inverse of elements in S. 
+    # This has no computational backend. Hence, we need to cheat here. 
+    B = base_ring(S_flat)
+    psi = hom(B, S, vcat(gens(S), S.(gens(L))))
+    v = vcat([zero(L) for i in 1:ngens(S)], gens(L))
+    function my_map(a::RingElem) 
+      p = lifted_numerator(a)
+      q = lifted_denominator(a)
+      pp = psi(p)
+      qq = S(P(inv(evaluate(q, v)))) # We know that all admissible representatives of denominators must come from elements in L.
+      return pp*qq
+    end
+
+    S_flat_to_S = MapFromFunc(my_map, S_flat, S)
+    return new{typeof(S), typeof(S_flat), typeof(L)}(S, S_flat, L, 
+                                                     S_to_S_flat, S_flat_to_S,
+                                                     L_to_S_flat
+                                                    )
+  end
 end
 
 ### Getters 
@@ -146,6 +272,10 @@ end
 
 ### Some basic functionality
 @attr RingFlattening function flatten(R::MPolyRing)
+  return RingFlattening(R)
+end
+
+@attr RingFlattening function flatten(R::MPolyQuoRing)
   return RingFlattening(R)
 end
 
@@ -293,5 +423,32 @@ function saturation(
   phi = flatten(S)
   pre_res = saturation(phi(I), phi(J))
   return ideal(S, inverse(phi).(gens(pre_res)))
+end
+
+### transferred functionality for quotient rings
+function is_invertible_with_inverse(
+    a::MPolyQuoRingElem{<:MPolyRingElem{<:Union{MPolyRingElem, MPolyQuoRingElem, 
+                                            MPolyQuoLocRingElem, MPolyLocRingElem}
+                                   }})
+  phi = flatten(parent(a))
+  a_flat = phi(a)
+  is_unit(a_flat) || return false, a
+  return true, inverse(phi)(inv(a_flat))
+end
+
+function is_unit(
+    a::MPolyQuoRingElem{<:MPolyRingElem{<:Union{MPolyRingElem, MPolyQuoRingElem, 
+                                            MPolyQuoLocRingElem, MPolyLocRingElem}
+                                   }})
+  return is_unit(flatten(parent(a))(a))
+end
+
+function inv(
+    a::MPolyQuoRingElem{<:MPolyRingElem{<:Union{MPolyRingElem, MPolyQuoRingElem, 
+                                            MPolyQuoLocRingElem, MPolyLocRingElem}
+                                   }})
+  phi = flatten(parent(a))
+  a_flat = phi(a)
+  return inverse(phi)(inv(a_flat))
 end
 

--- a/src/Rings/MPolyMap/flattenings.jl
+++ b/src/Rings/MPolyMap/flattenings.jl
@@ -122,6 +122,7 @@ mutable struct RingFlattening{TowerRingType<:Union{MPolyRing, MPolyQuoRing},
                                                     )
   end
 
+  # Flattenings of quotient rings of the form (𝕜[x][u])/J
   function RingFlattening(
       S::MPolyQuoRing{RingElemType}
     ) where {RingElemType <: MPolyRingElem{<:MPolyRingElem}}
@@ -142,14 +143,12 @@ mutable struct RingFlattening{TowerRingType<:Union{MPolyRing, MPolyQuoRing},
                                                     )
   end
 
+  # Flattenings of quotient rings of the form ((𝕜[x]/I)[u])/J
   function RingFlattening(
       S::MPolyQuoRing{RingElemType}
     ) where {RingElemType <: MPolyRingElem{<:MPolyQuoRingElem}}
     P = base_ring(S)::MPolyRing # the polynomial ring behind S
     A = base_ring(P)::MPolyQuoRing # the coefficient ring of S
-    R = base_ring(A)::MPolyRing # the polynomial ring behind the coefficient ring of S
-    I = modulus(A)::MPolyIdeal # the modulus of the coefficient ring of S
-    kk = coefficient_ring(R)::Field
 
     P_flattening = flatten(P)
     P_flat = codomain(P_flattening)
@@ -167,17 +166,13 @@ mutable struct RingFlattening{TowerRingType<:Union{MPolyRing, MPolyQuoRing},
                                                     )
   end
 
+  # Flattenings of quotient rings of the form (((𝕜[x]/I)[U⁻¹])[u])/J
   function RingFlattening(
       S::MPolyQuoRing{RingElemType}
     ) where {RingElemType <: MPolyRingElem{<:MPolyQuoLocRingElem}}
     P = base_ring(S)::MPolyRing
     Q = base_ring(P)::MPolyQuoLocRing
     R = base_ring(Q)::MPolyRing
-    L = localized_ring(Q)::MPolyLocRing
-    A = underlying_quotient(Q)::MPolyQuoRing
-    U = inverted_set(Q)::AbsMultSet
-    I = modulus(Q)::MPolyLocalizedIdeal
-    kk = coefficient_ring(R)::Field
 
     P_flattening = flatten(P)
     P_flat = codomain(P_flattening)
@@ -210,14 +205,12 @@ mutable struct RingFlattening{TowerRingType<:Union{MPolyRing, MPolyQuoRing},
                                                     )
   end
 
+  # Flattenings of quotient rings of the form ((𝕜[x][U⁻¹])[u])/J
   function RingFlattening(
       S::MPolyQuoRing{RingElemType}
     ) where {RingElemType <: MPolyRingElem{<:MPolyLocRingElem}}
     P = base_ring(S)::MPolyRing
     L = base_ring(P)::MPolyLocRing
-    R = base_ring(L)::MPolyRing
-    U = inverted_set(L)::AbsMultSet
-    kk = coefficient_ring(R)::Field
 
     P_flattening = flatten(P)
     P_flat = codomain(P_flattening)

--- a/test/Rings/MPolyAnyMap/flattenings.jl
+++ b/test/Rings/MPolyAnyMap/flattenings.jl
@@ -80,3 +80,40 @@ end
   @test s-y in kernel(h)
   @test S(x-z) in kernel(h)
 end
+
+@testset "flattenings of quotient rings" begin
+  R, (x,y,z) = QQ["x", "y", "z"]
+
+  S, _ = polynomial_ring(R, ["s", "t"])
+  Q, _ = quo(S, ideal(S, S[1]))
+  phi = oscar.flatten(Q)
+  @test vcat(phi.(gens(Q)), oscar.map_from_coefficient_ring_to_flattening(phi).(gens(coefficient_ring(Q)))) == gens(codomain(phi))
+  @test gens(S) == inverse(phi).(phi.(gens(S)))
+  @test oscar.map_from_coefficient_ring_to_flattening(phi).(gens(R)) == phi.(Q.(gens(R)))
+
+  U = powers_of_element(x)
+  L, _ = localization(R, U)
+  S, _ = polynomial_ring(L, ["s", "t"])
+  Q, _ = quo(S, ideal(S, S[1]))
+  phi = oscar.flatten(Q);
+  @test vcat(phi.(gens(Q)), oscar.map_from_coefficient_ring_to_flattening(phi).(gens(coefficient_ring(Q)))) == gens(codomain(phi))
+  @test gens(S) == inverse(phi).(phi.(gens(S)))
+  @test oscar.map_from_coefficient_ring_to_flattening(phi).(gens(R)) == phi.(Q.(S.(gens(R))))
+  
+  A, _ = quo(R, ideal(R, y))
+  S, _ = polynomial_ring(A, ["s", "t"])
+  Q, _ = quo(S, ideal(S, S[1]))
+  phi = oscar.flatten(Q);
+  @test vcat(phi.(gens(Q)), oscar.map_from_coefficient_ring_to_flattening(phi).(gens(coefficient_ring(Q)))) == gens(codomain(phi))
+  @test gens(S) == inverse(phi).(phi.(gens(S)))
+  @test oscar.map_from_coefficient_ring_to_flattening(phi).(gens(R)) == phi.(Q.(S.(gens(R))))
+
+  LA, _ = localization(A, U)
+  S, _ = polynomial_ring(LA, ["s", "t"])
+  Q, _ = quo(S, ideal(S, S[1]))
+  phi = oscar.flatten(Q);
+  @test vcat(phi.(gens(Q)), oscar.map_from_coefficient_ring_to_flattening(phi).(gens(coefficient_ring(Q)))) == gens(codomain(phi))
+  @test gens(S) == inverse(phi).(phi.(gens(S)))
+  @test oscar.map_from_coefficient_ring_to_flattening(phi).(gens(R)) == phi.(Q.(S.(gens(R))))
+end
+


### PR DESCRIPTION
In particular, we can finally create quotient rings of polynomial rings over arbitrary base rings (thanks to the changes entailed by #1876). That allows for a significant maturation of the projective schemes. 