### PR TITLE
support `GrpAbFinGen` groups in group functions

### DIFF
--- a/docs/src/Groups/basics.md
+++ b/docs/src/Groups/basics.md
@@ -74,7 +74,7 @@ comm(x::GAPGroupElem, y::GAPGroupElem)
 ## Properties of groups
 
 ```@docs
-Base.isfinite(G::GAPGroup)
+is_finite(G::GAPGroup)
 is_trivial(G::GAPGroup)
 is_abelian(G::GAPGroup)
 is_elementary_abelian

--- a/docs/src/Groups/basics.md
+++ b/docs/src/Groups/basics.md
@@ -75,6 +75,7 @@ comm(x::GAPGroupElem, y::GAPGroupElem)
 
 ```@docs
 Base.isfinite(G::GAPGroup)
+is_trivial(G::GAPGroup)
 is_abelian(G::GAPGroup)
 is_elementary_abelian
 is_pgroup

--- a/docs/src/Groups/quotients.md
+++ b/docs/src/Groups/quotients.md
@@ -36,7 +36,7 @@ julia> (f1,f2)=gens(F);
 
 julia> G,_=quo(F,[f1^2,f2^3,(f1*f2)^2]);
 
-julia> isfinite(G)
+julia> is_finite(G)
 true
 
 julia> is_isomorphic(G,symmetric_group(3))

--- a/docs/src/Groups/subgroups.md
+++ b/docs/src/Groups/subgroups.md
@@ -42,8 +42,8 @@ sylow_subgroup(G::GAPGroup, p::IntegerUnion)
 derived_subgroup
 fitting_subgroup
 frattini_subgroup
-radical_subgroup
 socle
+solvable_radical
 pcore(G::GAPGroup, p::IntegerUnion)
 intersect(V::T...) where T<:GAPGroup
 ```

--- a/experimental/GModule/Cohomology.jl
+++ b/experimental/GModule/Cohomology.jl
@@ -837,7 +837,7 @@ function H_two(C::GModule)
   i, mi = image(CC)
 #  @show intersect(i, E)
   H2, mH2 = quo(E, i)
-  if isfinite(G) && isa(H2, GrpAbFinGen)
+  if is_finite(G) && isa(H2, GrpAbFinGen)
     H2.exponent = order(G)
   end
   #we know |G| is an exponent - this might help
@@ -1054,7 +1054,7 @@ Together with the abstract module, a map is provided that will
 function cohomology_group(C::GModule{PermGroup,GrpAbFinGen}, i::Int; Tate::Bool = false)
   #should also allow modules...
   if Tate
-    @assert isfinite(group(C))
+    @assert is_finite(group(C))
   end
   if i==0
     if Tate
@@ -1142,7 +1142,7 @@ If `refine` is false, then the relative orders are just used from the hnf
 of the relation matrix.
 """
 function pc_group(M::GrpAbFinGen; refine::Bool = true)
-  @assert isfinite(M)
+  @assert is_finite(M)
   R = rels(M)
   h = hnf(R)
   if nrows(h) > ncols(h)

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -1252,7 +1252,7 @@ Note: the field is NOT extended - but it throws an error if it was too small.
 Implements: Brueckner, Chap 1.2.3
 """
 function reps(K, G::Oscar.GAPGroup)
-  isfinite(G) || error("the group is not finite")
+  @req is_finite(G) "the group is not finite"
   if order(G) == 1
     F = free_module(K, 1)
     h = hom(F, F, [F[1]])

--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -1,4 +1,4 @@
-@alias has_is_finite has_isfinite
+@alias has_isfinite has_is_finite
 @alias SymmetricGroup symmetric_group
 
 # make some Julia names compatible with our naming conventions
@@ -6,6 +6,7 @@
 @alias is_valid isvalid
 
 # for backwards compatibility
+@alias hall_subgroups_representatives hall_subgroup_reps
 @alias hasrelshp has_relshp
 @alias hastorusfactor has_torusfactor
 @alias inner_automorphisms_group inner_automorphism_group

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -209,3 +209,19 @@ function ToricMorphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAbF
 end
 
 @deprecate ToricIdentityMorphism(v::AbstractNormalToricVariety) toric_identity_morphism(v)
+
+@deprecate radical_subgroup solvable_radical
+@deprecate has_radical_subgroup has_solvable_radical
+@deprecate set_radical_subgroup set_solvable_radical
+
+# `is_characteristic` had the wrong order of arguments,
+# see https://github.com/oscar-system/Oscar.jl/issues/1793
+@deprecate is_characteristic(G::T, H::T) where T <: GAPGroup is_characteristic_subgroup(H, G)
+
+# `is_maximal` had the wrong order of arguments,
+# see https://github.com/oscar-system/Oscar.jl/issues/1793
+@deprecate is_maximal(G::T, H::T) where T <: GAPGroup is_maximal_subgroup(H, G)
+
+# `is_normal` had the wrong order of arguments,
+# see https://github.com/oscar-system/Oscar.jl/issues/1793
+@deprecate is_normal(G::T, H::T) where T <: GAPGroup is_normalized_by(H, G)

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -1047,7 +1047,6 @@ export quo
 export quotient
 export radical
 export radical_membership
-export radical_subgroup, has_radical_subgroup, set_radical_subgroup
 export rand
 export rand_pseudo
 export rand_spherical_polytope
@@ -1163,6 +1162,7 @@ export small_generating_set, has_small_generating_set, set_small_generating_set
 export small_group
 export small_group_identification, has_small_group_identification
 export socle, has_socle, set_socle
+export solvable_radical, has_solvable_radical, set_solvable_radical
 export solve_ineq
 export solve_lp
 export solve_milp

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -45,6 +45,7 @@ export FreeModuleHom
 export FreeModuleHom_dec
 export FreeResolution
 export GAP
+export GAPGroupConjClass
 export GAPGroupElem
 export GAPGroupHomomorphism
 export GL

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -542,7 +542,7 @@ function Base.rand(C::GroupConjClass{S,T}) where S where T<:GAPGroupElem
    return Base.rand(Random.GLOBAL_RNG, C)
 end
 
-function Base.rand(rng::Random.AbstractRNG, C::GroupConjClass{S,T}) where S where T<:GAPGroupElem
+function Base.rand(rng::Random.AbstractRNG, C::GAPGroupConjClass{S,T}) where S where T<:GAPGroupElem
    return group_element(C.X, GAP.Globals.Random(GAP.wrap_rng(rng), C.CC)::GapObj)
 end
 
@@ -607,7 +607,7 @@ end
 Return the subgroup conjugacy class `cc` of `H` in `G`, where `H` = `representative`(`cc`).
 """
 function conjugacy_class(G::T, g::T) where T<:GAPGroup
-   return GroupConjClass(G, g, GAP.Globals.ConjugacyClassSubgroups(G.X,g.X)::GapObj)
+   return GAPGroupConjClass(G, g, GAP.Globals.ConjugacyClassSubgroups(G.X,g.X)::GapObj)
 end
 
 function Base.rand(C::GroupConjClass{S,T}) where S where T<:GAPGroup
@@ -629,7 +629,7 @@ julia> G = symmetric_group(3)
 Sym( [ 1 .. 3 ] )
 
 julia> conjugacy_classes_subgroups(G)
-4-element Vector{GroupConjClass{PermGroup, PermGroup}}:
+4-element Vector{GAPGroupConjClass{PermGroup, PermGroup}}:
  Group(()) ^ Sym( [ 1 .. 3 ] )
  Group([ (2,3) ]) ^ Sym( [ 1 .. 3 ] )
  Group([ (1,2,3) ]) ^ Sym( [ 1 .. 3 ] )
@@ -684,7 +684,7 @@ Return the vector of all conjugacy classes of maximal subgroups of G.
 julia> G = symmetric_group(3);
 
 julia> conjugacy_classes_maximal_subgroups(G)
-2-element Vector{GroupConjClass{PermGroup, PermGroup}}:
+2-element Vector{GAPGroupConjClass{PermGroup, PermGroup}}:
  Group([ (1,2,3) ]) ^ Sym( [ 1 .. 3 ] )
  Group([ (2,3) ]) ^ Sym( [ 1 .. 3 ] )
 
@@ -692,7 +692,7 @@ julia> conjugacy_classes_maximal_subgroups(G)
 """
 function conjugacy_classes_maximal_subgroups(G::GAPGroup)
   L = Vector{GapObj}(GAP.Globals.ConjugacyClassesMaximalSubgroups(G.X)::GapObj)
-  return [GroupConjClass(G, _as_subgroup_bare(G, GAP.Globals.Representative(cc)), cc) for cc in L]
+  return [GAPGroupConjClass(G, _as_subgroup_bare(G, GAP.Globals.Representative(cc)), cc) for cc in L]
 end
 
 """
@@ -935,7 +935,7 @@ end
 
 
 # START iterator
-Base.IteratorSize(::Type{<:GroupConjClass}) = Base.SizeUnknown()
+Base.IteratorSize(::Type{<:GAPGroupConjClass}) = Base.SizeUnknown()
 
 Base.iterate(cc::GAPGroupConjClass) = iterate(cc, GAPWrap.Iterator(cc.CC))
 

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1408,10 +1408,10 @@ julia> prime_of_pgroup(UInt16, quaternion_group(8))
 0x0002
 
 julia> prime_of_pgroup(symmetric_group(1))
-ERROR: only supported for non-trivial p-groups
+ERROR: ArgumentError: only supported for non-trivial p-groups
 
 julia> prime_of_pgroup(symmetric_group(3))
-ERROR: only supported for non-trivial p-groups
+ERROR: ArgumentError: only supported for non-trivial p-groups
 
 ```
 """

--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -30,6 +30,10 @@ end
 
 # order(x::GrpAbFinGenElem) = order(ZZRingElem, x) # see Hecke.jl/src/GrpAb/Elem.jl
 
+function order(::Type{T}, G::GrpAbFinGen) where T <: IntegerUnion
+   return T(order(G))
+end
+
 #TODO: do we need `one`? (Hecke defines `is_one(x::GrpAbFinGen)`.)
 # one(x::GrpAbFinGen) == zero(x)
 # one(x::GrpAbFinGenElem) == zero(x)

--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -108,14 +108,6 @@ end
 
 conjugacy_class(G::T, H::T) where T <: GrpAbFinGen = GrpAbFinGenConjClass(G, H)
 
-# function Base.rand(C::GroupConjClass{S,T}) where S <: GrpAbFinGen where T <: GrpAbFinGen
-#    return C.repr
-# end
-
-# function Base.rand(rng::Random.AbstractRNG, C::GroupConjClass{S,T}) where S <: GrpAbFinGen where T <: GrpAbFinGen
-#    return C.repr
-# end
-
 function conjugacy_classes_subgroups(G::GrpAbFinGen)
    return [conjugacy_class(G, H) for (H, mp) in subgroups(G)]
 end

--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -90,9 +90,9 @@ Base.rand(C::GrpAbFinGenConjClass) = representative(C)
 
 Base.rand(rng::Random.AbstractRNG, C::GrpAbFinGenConjClass) = representative(C)
 
-number_conjugacy_classes(G::GrpAbFinGen) = ZZRingElem(order(G))
+number_conjugacy_classes(G::GrpAbFinGen) = order(ZZRingElem, G)
 
-number_conjugacy_classes(::Type{T}, G::GrpAbFinGen) where T <: IntegerUnion = T(order(G))
+number_conjugacy_classes(::Type{T}, G::GrpAbFinGen) where T <: IntegerUnion = order(T, G)
 
 conjugacy_classes(G::GrpAbFinGen) = [GrpAbFinGenConjClass(G, x) for x in G]
 
@@ -155,11 +155,8 @@ conjugate_group(G::GrpAbFinGen, x::GrpAbFinGenElem) = G
 Base.:^(G::GrpAbFinGen, x::GrpAbFinGenElem) = G
 
 function is_conjugate(G::GrpAbFinGen, H::GrpAbFinGen, K::GrpAbFinGen)
-   if is_subgroup(H, K)[1] && is_subgroup(K, H)[1]
-     return true
-   else
-     return false
-   end
+   return is_subgroup(H, G)[1] && is_subgroup(K, G)[1] &&
+          is_subgroup(H, K)[1] && is_subgroup(K, H)[1]
 end
 
 function representative_action(G::GrpAbFinGen, H::GrpAbFinGen, K::GrpAbFinGen)

--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -1,4 +1,4 @@
-# Something additional functions for abelian groups
+# additional functions for abelian groups (type `GrpAbFinGen`)
 
 # Restrict a morphism f : G -> H to the surjective morphism g : G -> im(G)
 function restrict_codomain(f::GrpAbFinGenMap)
@@ -12,3 +12,356 @@ function restrict_codomain(f::GrpAbFinGenMap)
   end
   return hom(G, H, imgs)
 end
+
+
+# Compute whether `x` is contained in `G`, modulo natural embeddings.
+# (This is analogous to `issubset`.)
+is_element(x::GrpAbFinGenElem, G::GrpAbFinGen) = issubset(sub([x])[1], G)
+
+function is_finiteorder(a::GrpAbFinGenElem)
+  G, m = snf(a.parent)
+  b = preimage(m, a)
+  return any(i -> iszero(G.snf[i]) && !iszero(b[i]), 1:ngens(G))
+end
+
+function order(::Type{T}, a::GrpAbFinGenElem) where T <: IntegerUnion
+   return T(order(a))
+end
+
+# order(x::GrpAbFinGenElem) = order(ZZRingElem, x) # see Hecke.jl/src/GrpAb/Elem.jl
+
+#TODO: do we need `one`? (Hecke defines `is_one(x::GrpAbFinGen)`.)
+# one(x::GrpAbFinGen) == zero(x)
+# one(x::GrpAbFinGenElem) == zero(x)
+# Base.inv(x::GrpAbFinGenElem) = -x
+# x^n for GrpAbFinGenElem -> n*x
+
+function comm(x::GrpAbFinGenElem, y::GrpAbFinGenElem)
+  x.parent == y.parent || error("Elements must belong to the same group")
+  zero(parent(x))
+end
+
+has_gens(G::GrpAbFinGen) = true
+
+#TODO: improve?
+small_generating_set(G::GrpAbFinGen) = gens(G)
+
+
+################################################################################
+#
+#   Conjugacy Classes in GrpAbFinGen groups: just wrap elements
+#
+################################################################################
+
+struct GrpAbFinGenConjClass{T<:GrpAbFinGen, S<:Union{GrpAbFinGenElem,GrpAbFinGen}} <: GroupConjClass{T, S}
+   X::T
+   repr::S
+end
+
+function Base.hash(C::GrpAbFinGenConjClass, h::UInt)
+  return Base.hash(Representative(C), h)
+end
+
+function Base.show(io::IO, C::GrpAbFinGenConjClass)
+  print(io, string(representative(C)), " ^ ", string(C.X))
+end
+
+==(a::GrpAbFinGenConjClass, b::GrpAbFinGenConjClass) = representative(a) == representative(b)
+
+Base.length(::Type{T}, C::GrpAbFinGenConjClass) where T <: IntegerUnion = T(1)
+
+Base.length(C::GrpAbFinGenConjClass) = ZZRingElem(1)
+
+
+################################################################################
+#
+#   Conjugacy classes of elements
+#
+################################################################################
+
+conjugacy_class(G::GrpAbFinGen, g::GrpAbFinGenElem) = GrpAbFinGenConjClass(G, g)
+
+Base.eltype(::Type{GrpAbFinGenConjClass{T,S}}) where {T,S} = S
+
+Base.rand(C::GrpAbFinGenConjClass) = representative(C)
+
+Base.rand(rng::Random.AbstractRNG, C::GrpAbFinGenConjClass) = representative(C)
+
+number_conjugacy_classes(G::GrpAbFinGen) = ZZRingElem(order(G))
+
+number_conjugacy_classes(::Type{T}, G::GrpAbFinGen) where T <: IntegerUnion = T(order(G))
+
+conjugacy_classes(G::GrpAbFinGen) = [GrpAbFinGenConjClass(G, x) for x in G]
+
+is_conjugate(G::GrpAbFinGen, x::GrpAbFinGenElem, y::GrpAbFinGenElem) = (x == y)
+
+function representative_action(G::GrpAbFinGen, x::GrpAbFinGenElem, y::GrpAbFinGenElem)
+   x == y ? (true, zero(G)) : (false, nothing)
+end
+
+
+################################################################################
+#
+#   Conjugacy classes of subgroups
+#
+################################################################################
+
+conjugacy_class(G::T, H::T) where T <: GrpAbFinGen = GrpAbFinGenConjClass(G, H)
+
+# function Base.rand(C::GroupConjClass{S,T}) where S <: GrpAbFinGen where T <: GrpAbFinGen
+#    return C.repr
+# end
+
+# function Base.rand(rng::Random.AbstractRNG, C::GroupConjClass{S,T}) where S <: GrpAbFinGen where T <: GrpAbFinGen
+#    return C.repr
+# end
+
+function conjugacy_classes_subgroups(G::GrpAbFinGen)
+   return [conjugacy_class(G, H) for (H, mp) in subgroups(G)]
+end
+
+#TODO: Does Hecke provide the following?
+# subgroup_reps(G::GrpAbFinGen; order::ZZRingElem = ZZRingElem(-1))
+# conjugacy_classes_maximal_subgroups(G::GrpAbFinGen)
+# maximal_subgroup_reps(G::GrpAbFinGen)
+# low_index_subgroup_reps(G::GrpAbFinGen, n::Int)
+
+conjugate_group(G::GrpAbFinGen, x::GrpAbFinGenElem) = G
+
+Base.:^(G::GrpAbFinGen, x::GrpAbFinGenElem) = G
+
+function is_conjugate(G::GrpAbFinGen, H::GrpAbFinGen, K::GrpAbFinGen)
+   if is_subgroup(H, K)[1] && is_subgroup(K, H)[1]
+     return true
+   else
+     return false
+   end
+end
+
+function representative_action(G::GrpAbFinGen, H::GrpAbFinGen, K::GrpAbFinGen)
+   if is_subgroup(H, K)[1] && is_subgroup(K, H)[1]
+     return true, zero(G)
+   else
+     return false, nothing
+   end
+end
+
+is_conjugate_subgroup(G::T, U::T, V::T) where T <: GrpAbFinGen = is_subgroup(V, U)[1]
+
+
+Base.IteratorSize(::Type{<:GrpAbFinGenConjClass}) = Base.HasLength()
+
+Base.iterate(C::GrpAbFinGenConjClass) = iterate(C, 0)
+
+function Base.iterate(C::GrpAbFinGenConjClass, state::Int)
+  if state == 0
+    return representative(C), 1
+  else
+    return nothing
+  end
+end
+
+
+################################################################################
+#
+# Normal Structure
+#
+################################################################################
+
+function core(G::GrpAbFinGen, H::GrpAbFinGen)
+  flag, emb = is_subgroup(H, G)
+  flag || error("H  must be a subgroup of G")
+  return (H, emb)
+end
+
+function normalizer(G::GrpAbFinGen, H::GrpAbFinGen)
+  is_subgroup(H, G)[1] || error("H  must be a subgroup of G")
+  return (G, identity_map(G))
+end
+
+function normalizer(G::GrpAbFinGen, x::GrpAbFinGenElem)
+  is_element(x, G) || throw(ArgumentError("x does not lie in G"))
+  return (G, identity_map(G))
+end
+
+function normal_closure(G::GrpAbFinGen, H::GrpAbFinGen)
+  flag, emb = is_subgroup(H, G)
+  flag || error("H  must be a subgroup of G")
+  return (H, emb)
+end
+
+pcore(G::GrpAbFinGen, p::IntegerUnion) = sylow_subgroup(G, p)
+
+
+################################################################################
+#
+# Specific Subgroups
+#
+################################################################################
+
+fitting_subgroup(G::GrpAbFinGen) = (G, identity_map(G))
+
+function frattini_subgroup(G::GrpAbFinGen)
+   is_finite(G) || throw(ArgumentError("G is not finite"))
+   subgens = GrpAbFinGenElem[]
+   for x in gens(G)
+     for (p, e) in collect(factor(order(x)))
+       x = p*x
+     end
+     if !is_zero(x)
+       push!(subgens, x)
+     end
+   end
+   return sub(G, subgens)
+end
+
+function socle(G::GrpAbFinGen)
+   is_finite(G) || throw(ArgumentError("G is not finite"))
+   subgens = GrpAbFinGenElem[]
+   for x in gens(G)
+     n = 1
+     ord = order(x)
+     for (p, e) in collect(factor(ord))
+       n = p*n
+     end
+     x = divexact(ord, n)*x
+     if !is_zero(x)
+       push!(subgens, x)
+     end
+   end
+   return sub(G, subgens)
+end
+
+solvable_radical(G::GrpAbFinGen) = (G, identity_map(G))
+
+
+################################################################################
+#
+# Sylow & Hall Subgroups
+#
+################################################################################
+
+#TODO: how to compute complements?
+# complement_class_reps(G::T, N::T) where T <: GrpAbFinGen
+# complement_system(G::GrpAbFinGen)
+
+function sylow_subgroup(G::GrpAbFinGen, p::IntegerUnion)
+   is_finite(G) || throw(ArgumentError("G is not finite"))
+   is_prime(p) || throw(ArgumentError("p is not a prime"))
+   subgens = GrpAbFinGenElem[]
+   for x in gens(G)
+     ord = order(x)
+     while mod(ord, p) == 0
+       ord = divexact(ord, p)
+     end
+     x = ord*x
+     if !is_zero(x)
+       push!(subgens, x)
+     end
+   end
+   return sub(G, subgens)
+end
+
+function sylow_system(G::GrpAbFinGen)
+   is_finite(G) || throw(ArgumentError("G is not finite"))
+   result = GrpAbFinGen[]
+   for (p, e) in collect(factor(order(G)))
+     push!(result, sylow_subgroup(G, p)[1])
+   end
+   return result
+end
+
+# no longer documented, better use `hall_subgroup_reps`
+hall_subgroup(G::GrpAbFinGen, P::AbstractVector{<:IntegerUnion}) = hall_subgroup_reps(G, P)[1]
+
+function hall_subgroup_reps(G::GrpAbFinGen, P::AbstractVector{<:IntegerUnion})
+   is_finite(G) || throw(ArgumentError("G is not finite"))
+   P = unique(P)
+   all(is_prime, P) || throw(ArgumentError("The integers must be prime"))
+   subgens = GrpAbFinGenElem[]
+   for x in gens(G)
+     ord = order(x)
+     for p in P
+       ordp = ord
+       while mod(ordp, p) == 0
+         ordp = divexact(ordp, p)
+       end
+       px = ordp*x
+       if !is_zero(px)
+         push!(subgens, px)
+       end
+     end
+   end
+   return [sub(G, subgens)[1]]
+end
+
+function hall_system(G::GrpAbFinGen)
+   is_solvable(G) || error("G must be solvable")
+   primes = [p for (p, e) in factor(order(G))]
+   result = GrpAbFinGen[]
+   for P in subsets(Set(primes))
+     push!(result, hall_subgroup_reps(G, collect(P))[1])
+   end
+   return result
+end
+
+################################################################################
+#
+#   Properties
+#
+################################################################################
+
+is_almostsimple(G::GrpAbFinGen) = false
+
+is_finitelygenerated(G::GrpAbFinGen) = true
+
+is_perfect(G::GrpAbFinGen) = is_trivial(G)
+
+is_pgroup(G::GrpAbFinGen) = is_pgroup_with_prime(G)[1]
+
+is_quasisimple(G::GrpAbFinGen) = false
+
+is_simple(G::GrpAbFinGen) = is_finite(G) && is_prime(order(G))
+
+is_solvable(G::GrpAbFinGen) = true
+
+is_sporadic_simple(G::GrpAbFinGen) = false
+
+function is_pgroup_with_prime(::Type{T}, G::GrpAbFinGen) where T <: IntegerUnion
+  is_trivial(G) && return true, nothing
+  is_finite(G) || return false, nothing
+  flag, p, e = is_prime_power_with_data(order(G))
+  flag && return true, T(p)
+  return false, nothing
+end
+
+is_pgroup_with_prime(G::GrpAbFinGen) = is_pgroup_with_prime(ZZRingElem, G)
+
+nilpotency_class(G::GrpAbFinGen) = (order(G) == 1 ? 0 : 1)
+
+# helper for prime_of_pgroup: this helper is efficient thanks to
+# @gapattribute, but we also want prime_of_pgroup to accept an optional
+# type argument; so we cannot use @gapattribute directly. Instead we set
+# up this auxiliary _prime_of_pgroup which then is called by the real
+# prime_of_pgroup.
+# TODO: enhance @gapattribute so this is not necessary
+function _prime_of_pgroup(G::GrpAbFinGen)
+  flag, p, e = is_prime_power_with_data(order(G))
+  if !flag
+    error("only supported for non-trivial p-groups")
+  end
+  return p
+end
+
+function prime_of_pgroup(::Type{T}, G::GrpAbFinGen) where T <: IntegerUnion
+  return ZZRingElem(_prime_of_pgroup(G))
+end
+
+prime_of_pgroup(G::GrpAbFinGen) = prime_of_pgroup(ZZRingElem, G)
+
+#TODO There is no underlying GAP attribute, we do not store the prime.
+#   has_prime_of_pgroup(G::GrpAbFinGen) = false
+#   function set_prime_of_pgroup(G::GrpAbFinGen, p::IntegerUnion)
+#     # do nothing
+#   end
+# The same holds for `fitting_subgroup`, `frattini_subgroup`, `socle`, ...

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -47,9 +47,7 @@ Sym( [ 1 .. 3 ] )
 """
 function right_coset(H::GAPGroup, g::GAPGroupElem)
    @assert elem_type(H) == typeof(g)
-   if !GAPWrap.IsSubset(parent(g).X, H.X)
-      throw(ArgumentError("H is not a subgroup of parent(g)"))
-   end
+   @req GAPWrap.IsSubset(parent(g).X, H.X) "H is not a subgroup of parent(g)"
    return _group_coset(parent(g), H, g, :right, GAP.Globals.RightCoset(H.X,g.X))
 end
 
@@ -76,9 +74,7 @@ Left coset   (1,3)(2,4,5) * Sym( [ 1 .. 3 ] )
 """
 function left_coset(H::GAPGroup, g::GAPGroupElem)
    @assert elem_type(H) == typeof(g)
-   if !GAPWrap.IsSubset(parent(g).X, H.X)
-      throw(ArgumentError("H is not a subgroup of parent(g)"))
-   end
+   @req GAPWrap.IsSubset(parent(g).X, H.X) "H is not a subgroup of parent(g)"
    return _group_coset(parent(g), H, g, :left, GAP.Globals.RightCoset(GAP.Globals.ConjugateSubgroup(H.X,GAP.Globals.Inverse(g.X)),g.X))
 end
 
@@ -129,9 +125,7 @@ function Base.:*(y::GAPGroupElem, c::GroupCoset)
 end
 
 function Base.:*(c::GroupCoset, d::GroupCoset)
-   if c.side != :right || d.side != :left
-      throw(ArgumentError("Wrong input"))
-   end
+   @req (c.side == :right && d.side == :left) "Wrong input"
    return double_coset(c.H, c.repr*d.repr, d.H)
 end
 
@@ -302,9 +296,7 @@ julia> right_transversal(G,H)
 ```
 """
 function right_transversal(G::T, H::T; check::Bool=true) where T<: GAPGroup
-   if check && ! GAPWrap.IsSubset(G.X, H.X)
-     throw(ArgumentError("H is not a subgroup of G"))
-   end
+   @req (!check || GAPWrap.IsSubset(G.X, H.X)) "H is not a subgroup of G"
    L = GAP.Globals.RightTransversal(G.X,H.X)
 #TODO: The object returned by GAP tries to avoid the overhead of explicitly
 #      listing all elements.
@@ -414,12 +406,8 @@ Sym( [ 1 .. 3 ] ) * (1,3,5,2,4) * Sym( [ 1 .. 2 ] )
 ```
 """
 function double_coset(G::T, g::GAPGroupElem{T}, H::T) where T<: GAPGroup
-   if !GAPWrap.IsSubset(parent(g).X,G.X)
-      throw(ArgumentError("G is not a subgroup of parent(g)"))
-   end
-   if !GAPWrap.IsSubset(parent(g).X,H.X)
-      throw(ArgumentError("H is not a subgroup of parent(g)"))
-   end
+   @req GAPWrap.IsSubset(parent(g).X,G.X) "G is not a subgroup of parent(g)"
+   @req GAPWrap.IsSubset(parent(g).X,H.X) "H is not a subgroup of parent(g)"
    return GroupDoubleCoset(parent(g),G,H,g,GAP.Globals.DoubleCoset(G.X,g.X,H.X))
 end
 

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -773,7 +773,7 @@ ERROR: ArgumentError: the group is not transitive
 """
 function rank_action(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
    @req is_transitive(G, L) "the group is not transitive"
-   length(L) == 0 && throw(ArgumentError("the action domain is empty"))
+   @req length(L) != 0 "the action domain is empty"
    H = stabilizer(G, L[1])[1]
    return length(orbits(gset(H, L, closed = true)))
 end
@@ -806,15 +806,13 @@ ERROR: ArgumentError: the group does not act
 function transitivity(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
   gL = GapObj(L)
   res = GAP.Globals.Transitivity(G.X, gL)::Int
-  res === GAP.Globals.fail && throw(ArgumentError("the group does not act"))
+  @req res !== GAP.Globals.fail "the group does not act"
   # If the result is `0` then it may be that `G` does not act on `L`,
   # and in this case we want to throw an exception.
   if res == 0 && length(L) > 0
     lens = GAP.Globals.OrbitLengths(G.X, gL)
 #TODO: Compute the orbit lengths more efficiently than GAP does.
-    if sum(lens) != length(L)
-      throw(ArgumentError("the group does not act"))
-    end
+    @req sum(lens) == length(L) "the group does not act"
   end
   return res
 end

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -646,6 +646,20 @@ is_bijective(f::GroupIsomorphismFromFunc) = true
 
 kernel(f::GroupIsomorphismFromFunc) = trivial_subgroup(domain(f))
 
+function images(f::GroupIsomorphismFromFunc{R, T}, G::R) where R where T
+  D = domain(f)
+  C = codomain(f)
+  imgs = eltype(typeof(C))[]
+  for x in gens(G)
+    if parent(x) === D
+      push!(imgs, f(x))
+    else
+      push!(imgs, f(D(x)))
+    end
+  end
+  return sub(codomain(f), imgs)
+end
+
 ####
 
 # compute the kernel of a composition of maps, with domain a `GAPGroup`,

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -116,7 +116,7 @@ function hom(G::GAPGroup, H::GAPGroup, gensG::Vector, imgs::Vector; check::Bool 
   else
     mp = GAP.Globals.GroupHomomorphismByImagesNC(G.X, H.X, vgens, vimgs)
   end
-  if mp == GAP.Globals.fail throw(ArgumentError("Invalid input")) end
+  @req mp !== GAP.Globals.fail "Invalid input"
   return GAPGroupHomomorphism(G, H, mp)
 end
 
@@ -441,7 +441,7 @@ to
 """
 function isomorphism(G::GAPGroup, H::GAPGroup)
   mp = GAP.Globals.IsomorphismGroups(G.X, H.X)::GapObj
-  mp === GAP.Globals.fail && throw(ArgumentError("the groups are not isomorphic"))
+  @req mp !== GAP.Globals.fail "the groups are not isomorphic"
   return GAPGroupHomomorphism(G, H, mp)
 end
 
@@ -449,7 +449,7 @@ function isomorphism(G::GAPGroup, H::GrpGen)
   HtoP = isomorphism(PermGroup, H)
   P = codomain(HtoP)
   fl, GtoP = is_isomorphic_with_map(G, P)
-  !fl && throw(ArgumentError("the groups are not isomorphic"))
+  @req fl "the groups are not isomorphic"
   return GtoP * inv(HtoP)
 end
 
@@ -457,7 +457,7 @@ function isomorphism(G::GrpGen, H::GAPGroup)
   GtoP = isomorphism(PermGroup, G)
   P = codomain(GtoP)
   fl, PtoH = is_isomorphic_with_map(P, H)
-  !fl && throw(ArgumentError("the groups are not isomorphic"))
+  @req fl "the groups are not isomorphic"
   return GtoP * PtoH
 end
 
@@ -507,7 +507,7 @@ function isomorphism(::Type{T}, G::GAPGroup) where T <: Union{FPGroup, PcGroup, 
    return get!(isos, T) do
      fun = _get_iso_function(T)
      f = fun(G.X)::GapObj
-     f == GAP.Globals.fail && throw(ArgumentError("Could not convert group into a group of type $T"))
+     @req f !== GAP.Globals.fail "Could not convert group into a group of type $T"
      H = T(GAP.Globals.ImagesSource(f)::GapObj)
      return GAPGroupHomomorphism(G, H, f)
    end::GAPGroupHomomorphism{typeof(G), T}
@@ -525,7 +525,7 @@ function isomorphism(::Type{GrpAbFinGen}, G::GAPGroup)
    isos = get_attribute!(Dict{Type, Any}, G, :isomorphisms)::Dict{Type, Any}
    return get!(isos, GrpAbFinGen) do
      @req is_abelian(G) "the group is not abelian"
-     @req isfinite(G) "the group is not finite"
+     @req is_finite(G) "the group is not finite"
 #T this restriction is not nice
 
      indep = GAP.Globals.IndependentGeneratorsOfAbelianGroup(G.X)::GapObj

--- a/src/Groups/libraries/atlasgroups.jl
+++ b/src/Groups/libraries/atlasgroups.jl
@@ -22,7 +22,7 @@ julia> atlas_group("M11")  # Mathieu group M11
 Group([ (2,10)(4,11)(5,7)(8,9), (1,4,3,8)(2,5,6,9) ])
 
 julia> atlas_group("M")  # Monster group M
-ERROR: the group atlas does not provide a representation for M
+ERROR: ArgumentError: the group atlas does not provide a representation for M
 ```
 """
 function atlas_group(name::String)

--- a/src/Groups/libraries/atlasgroups.jl
+++ b/src/Groups/libraries/atlasgroups.jl
@@ -27,7 +27,7 @@ ERROR: the group atlas does not provide a representation for M
 """
 function atlas_group(name::String)
   G = GAP.Globals.AtlasGroup(GapObj(name))
-  G === GAP.Globals.fail && error("the group atlas does not provide a representation for $name")
+  @req (G !== GAP.Globals.fail) "the group atlas does not provide a representation for $name"
   T = _get_type(G)
   return T(G)
 end
@@ -38,7 +38,7 @@ function atlas_group(::Type{T}, name::String) where T <: Union{PermGroup, Matrix
   else
     G = GAP.Globals.AtlasGroup(GapObj(name), GAP.Globals.IsMatrixGroup, true)::GapObj
   end
-  G === GAP.Globals.fail && error("the group atlas does not provide a representation of type $T for $name")
+  @req (G !== GAP.Globals.fail) "the group atlas does not provide a representation of type $T for $name"
   TT = _get_type(G)
   return TT(G)
 end
@@ -66,9 +66,9 @@ function atlas_group(info::Dict)
   gapname = info[:name]
   l = GAP.Globals.AGR.MergedTableOfContents(GapObj("all"), GapObj(gapname))::GapObj
   pos = findfirst(r -> String(r.repname) == info[:repname], Vector{GAP.GapObj}(l))
-  pos === nothing && error("no Atlas group for $info")
+  @req (pos !== nothing) "no Atlas group for $info"
   G = GAP.Globals.AtlasGroup(l[pos])
-  G === GAP.Globals.fail && error("the group atlas does not provide a representation for $info")
+  @req (G !== GAP.Globals.fail) "the group atlas does not provide a representation for $info"
 
   if haskey(info, :base_ring_iso)
     # make sure that the given ring is used
@@ -128,9 +128,9 @@ Group([ (1,4)(2,10)(3,7)(6,9), (1,6,10,7,11,3,9,2)(4,5) ])
 ```
 """
 function atlas_subgroup(G::GAPGroup, nr::Int)
-  GAP.Globals.HasAtlasRepInfoRecord(G.X) || error("$G was not constructed with atlas_group")
+  @req GAP.Globals.HasAtlasRepInfoRecord(G.X) "$G was not constructed with atlas_group"
   info = GAP.Globals.AtlasRepInfoRecord(G.X)
-  info.groupname == info.identifier[1] || error("$G was not constructed with atlas_group")
+  @req (info.groupname == info.identifier[1]) "$G was not constructed with atlas_group"
   H = GAP.Globals.AtlasSubgroup(G.X, nr)
   if H === GAP.Globals.fail
     name = string(info.groupname)

--- a/src/Groups/libraries/perfectgroups.jl
+++ b/src/Groups/libraries/perfectgroups.jl
@@ -151,9 +151,9 @@ julia> perfect_group_identification(SL(2,7))
 ```
 """
 function perfect_group_identification(G::GAPGroup)
-   is_perfect(G) || error("group is not perfect")
+   @req is_perfect(G) "group is not perfect"
    res = GAP.Globals.PerfectIdentification(G.X)
-   res !== GAP.Globals.fail || error("identification is not available for groups of order $(order(G))")
+   @req (res !== GAP.Globals.fail) "identification is not available for groups of order $(order(G))"
    return Tuple{Int,Int}(res)
 end
 
@@ -174,7 +174,7 @@ julia> number_perfect_groups(1966080)
 function number_perfect_groups(n::IntegerUnion)
    @req n >= 1 "group order must be positive, not $n"
    res = GAP.Globals.NumberPerfectGroups(GAP.Obj(n))
-   res !== GAP.Globals.fail || error("the number of perfect groups of order $n is not available")
+   @req (res !== GAP.Globals.fail) "the number of perfect groups of order $n is not available"
    return res::Int
 end
 

--- a/src/Groups/libraries/primitivegroups.jl
+++ b/src/Groups/libraries/primitivegroups.jl
@@ -134,12 +134,12 @@ julia> order(primitive_group(m...)) == order(S)
 true
 
 julia> primitive_group_identification(symmetric_group(4096))
-ERROR: identification of primitive permutation groups of degree 4096 is not available
+ERROR: ArgumentError: identification of primitive permutation groups of degree 4096 is not available
 
 julia> S = sub(G, [perm([1,3,4,5,2,7,6])])[1];
 
 julia> primitive_group_identification(S)
-ERROR: group is not primitive on its moved points
+ERROR: ArgumentError: group is not primitive on its moved points
 ```
 """
 function primitive_group_identification(G::PermGroup)

--- a/src/Groups/libraries/primitivegroups.jl
+++ b/src/Groups/libraries/primitivegroups.jl
@@ -144,9 +144,9 @@ ERROR: group is not primitive on its moved points
 """
 function primitive_group_identification(G::PermGroup)
   moved = moved_points(G)
-  is_primitive(G, moved) || error("group is not primitive on its moved points")
+  @req is_primitive(G, moved) "group is not primitive on its moved points"
   deg = length(moved)
-  has_primitive_groups(deg) || error("identification of primitive permutation groups of degree $(deg) is not available")
+  @req has_primitive_groups(deg) "identification of primitive permutation groups of degree $(deg) is not available"
   res = GAP.Globals.PrimitiveIdentification(G.X)::Int
   return deg, res
 end

--- a/src/Groups/libraries/smallgroups.jl
+++ b/src/Groups/libraries/smallgroups.jl
@@ -115,8 +115,8 @@ ERROR: identification is not available for groups of order 2432902008176640000
 ```
 """
 function small_group_identification(G::GAPGroup)
-   isfinite(G) || error("group is not finite")
-   has_small_group_identification(order(G)) || error("identification is not available for groups of order $(order(G))")
+   @req is_finite(G) "group is not finite"
+   @req has_small_group_identification(order(G)) "identification is not available for groups of order $(order(G))"
    res = GAP.Globals.IdGroup(G.X)
    return Tuple{ZZRingElem,ZZRingElem}(res)
 end
@@ -140,7 +140,7 @@ julia> number_small_groups(next_prime(ZZRingElem(2)^64))
 ```
 """
 function number_small_groups(n::IntegerUnion)
-  has_number_small_groups(n) || error("the number of groups of order $n is not available")
+  @req has_number_small_groups(n) "the number of groups of order $n is not available"
   return ZZRingElem(GAP.Globals.NumberSmallGroups(GAP.Obj(n))::GapInt)
 end
 

--- a/src/Groups/libraries/smallgroups.jl
+++ b/src/Groups/libraries/smallgroups.jl
@@ -111,7 +111,7 @@ julia> small_group_identification(alternating_group(5))
 (60, 5)
 
 julia> small_group_identification(symmetric_group(20))
-ERROR: identification is not available for groups of order 2432902008176640000
+ERROR: ArgumentError: identification is not available for groups of order 2432902008176640000
 ```
 """
 function small_group_identification(G::GAPGroup)
@@ -133,7 +133,7 @@ julia> number_small_groups(8)
 5
 
 julia> number_small_groups(4096)
-ERROR: the number of groups of order 4096 is not available
+ERROR: ArgumentError: the number of groups of order 4096 is not available
 
 julia> number_small_groups(next_prime(ZZRingElem(2)^64))
 1

--- a/src/Groups/libraries/transitivegroups.jl
+++ b/src/Groups/libraries/transitivegroups.jl
@@ -130,12 +130,12 @@ julia> order(transitive_group(m...)) == order(S)
 true
 
 julia> transitive_group_identification(symmetric_group(64))
-ERROR: identification of transitive groups of degree 64 are not available
+ERROR: ArgumentError: identification of transitive groups of degree 64 are not available
 
 julia> S = sub(G, [perm([1,3,4,5,2,7,6])])[1];
 
 julia> transitive_group_identification(S)
-ERROR: group is not transitive on its moved points
+ERROR: ArgumentError: group is not transitive on its moved points
 ```
 """
 function transitive_group_identification(G::PermGroup)

--- a/src/Groups/libraries/transitivegroups.jl
+++ b/src/Groups/libraries/transitivegroups.jl
@@ -140,9 +140,9 @@ ERROR: group is not transitive on its moved points
 """
 function transitive_group_identification(G::PermGroup)
   moved = moved_points(G)
-  is_transitive(G, moved) || error("group is not transitive on its moved points")
+  @req is_transitive(G, moved) "group is not transitive on its moved points"
   deg = length(moved)
-  has_transitive_groups(deg) || error("identification of transitive groups of degree $(deg) are not available")
+  @req has_transitive_groups(deg) "identification of transitive groups of degree $(deg) are not available"
   res = GAP.Globals.TransitiveIdentification(G.X)::Int
   return deg, res
 end

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -163,21 +163,17 @@ true
 """
 function perm(g::PermGroup, L::AbstractVector{<:IntegerUnion})
    x = GAP.Globals.PermList(GAP.GapObj(L;recursive=true))
-   x == GAP.Globals.fail && throw(ArgumentError("the list does not describe a permutation"))
-   if length(L) <= degree(g) && x in g.X
-     return PermGroupElem(g, x)
-   end
-   throw(ArgumentError("the element does not embed in the group"))
+   @req x !== GAP.Globals.fail "the list does not describe a permutation"
+   @req (length(L) <= degree(g) && x in g.X) "the element does not embed in the group"
+   return PermGroupElem(g, x)
 end
 
 perm(g::PermGroup, L::AbstractVector{<:ZZRingElem}) = perm(g, [Int(y) for y in L])
 
 function (g::PermGroup)(L::AbstractVector{<:IntegerUnion})
    x = GAP.Globals.PermList(GAP.GapObj(L;recursive=true))
-   if length(L) <= degree(g) && x in g.X
-     return PermGroupElem(g, x)
-   end
-   throw(ArgumentError("the element does not embed in the group"))
+   @req (length(L) <= degree(g) && x in g.X) "the element does not embed in the group"
+   return PermGroupElem(g, x)
 end
 
 (g::PermGroup)(L::AbstractVector{<:ZZRingElem}) = g([Int(y) for y in L])
@@ -300,11 +296,8 @@ function cperm(g::PermGroup,L::AbstractVector{T}...) where T <: IntegerUnion
       return one(g)
    else
       x=prod(y -> GAP.Globals.CycleFromList(GAP.Obj([Int(k) for k in y])), L)
-      if length(L) <= degree(g) && x in g.X
-         return PermGroupElem(g, x)
-      else
-         throw(ArgumentError("the element does not embed in the group"))
-      end
+      @req (length(L) <= degree(g) && x in g.X) "the element does not embed in the group"
+      return PermGroupElem(g, x)
    end
 end
 

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -123,9 +123,7 @@ index(G::T, H::T) where T <: GAPGroup = index(ZZRingElem, G, H)
 
 function index(::Type{I}, G::T, H::T) where I <: IntegerUnion where T <: GAPGroup
    i = GAP.Globals.Index(G.X, H.X)::GapInt
-   if i === GAP.Globals.infinity
-      error("index() not supported for subgroup of infinite index, use isfinite()")
-   end
+   @req (i !== GAP.Globals.infinity) "index() not supported for subgroup of infinite index, use is_finite()"
    return I(i)
 end
 
@@ -282,10 +280,6 @@ function is_maximal_subgroup(H::T, G::T; check::Bool = true) where T <: GAPGroup
   return any(M -> is_conjugate(G, M, H), maximal_subgroup_reps(G))
 end
 
-# `is_maximal` had the wrong order of arguments,
-# see https://github.com/oscar-system/Oscar.jl/issues/1793
-@deprecate is_maximal(G::T, H::T) where T <: GAPGroup is_maximal_subgroup(H, G)
-
 """
     is_normalized_by(H::T, G::T) where T <: GAPGroup
 
@@ -311,10 +305,6 @@ true
 ```
 """
 is_normalized_by(H::T, G::T) where T <: GAPGroup = GAPWrap.IsNormal(G.X, H.X)
-
-# `is_normal` had the wrong order of arguments,
-# see https://github.com/oscar-system/Oscar.jl/issues/1793
-@deprecate is_normal(G::T, H::T) where T <: GAPGroup is_normalized_by(H, G)
 
 """
     is_normal_subgroup(H::T, G::T) where T <: GAPGroup
@@ -373,10 +363,6 @@ function is_characteristic_subgroup(H::T, G::T; check::Bool = true) where T <: G
   end
   return GAPWrap.IsCharacteristicSubgroup(G.X, H.X)
 end
-
-# `is_characteristic` had the wrong order of arguments,
-# see https://github.com/oscar-system/Oscar.jl/issues/1793
-@deprecate is_characteristic(G::T, H::T) where T <: GAPGroup is_characteristic_subgroup(H, G)
 
 """
     is_solvable(G::GAPGroup)

--- a/test/Groups/GrpAb.jl
+++ b/test/Groups/GrpAb.jl
@@ -61,6 +61,9 @@ end
     if is_pgroup(G1) && order(G1) != 1
       @test prime_of_pgroup(G1) == prime_of_pgroup(G2)
     end
+    sg1 = small_generating_set(G1)
+    @test order(sub(G1, sg1)[1]) == order(G1)
+    @test length(sg1) <= length(para)
 
     # conjugacy classes of elements
     cc = conjugacy_classes(G1)
@@ -99,6 +102,22 @@ end
     for H in C
       @test H == representative(C)
     end
+    S1 = subgroup_reps(G1)
+    S2 = subgroup_reps(G2)
+    @test sort!([length(x) for x in S1]) == sort!([length(x) for x in S2])
+    for n in 2:4
+      S1 = subgroup_reps(G1, order = ZZ(n))
+      S2 = subgroup_reps(G2, order = ZZ(n))
+      @test length(S1) == length(S2)
+    end
+    for n in 1:4
+      S1 = low_index_subgroup_reps(G1, n)
+      S2 = low_index_subgroup_reps(G2, n)
+      @test length(S1) == length(S2)
+    end
+    S1 = conjugacy_classes_maximal_subgroups(G1)
+    S2 = conjugacy_classes_maximal_subgroups(G2)
+    @test sort!([length(x) for x in S1]) == sort!([length(x) for x in S2])
 
     # operations
     x = representative(rand(cc))

--- a/test/Groups/GrpAb.jl
+++ b/test/Groups/GrpAb.jl
@@ -23,3 +23,104 @@ end
   @test describe(abelian_group(GrpAbFinGen, Int[0, 2, 4])) == "Z/2 + Z/4 + Z"
   @test describe(abelian_group(GrpAbFinGen, Int[0, 0, 2, 4])) == "Z/2 + Z/4 + Z^2"
 end
+
+@testset "group functions for finite GrpAbFinGen" begin
+  @testset for para in [ [2, 3, 4], Int[], [2, 4] ]
+    G1 = abelian_group(GrpAbFinGen, para)
+    iso = isomorphism(PcGroup, G1)
+    G2 = codomain(iso)
+    primes = [p for (p, e) in collect(factor(order(G1)))]
+
+    # elements
+    @test [order(iso(x)) for x in gens(G1)] == [order(x) for x in gens(G1)]
+    for x in gens(G1), y in gens(G1)
+      @test is_one(comm(x, y))
+    end
+
+    # properties
+    @test is_abelian(G1) == is_abelian(G2)
+    @test is_finite(G1) == is_finite(G2)
+    @test is_finitelygenerated(G1) == is_finitelygenerated(G2)
+    @test is_perfect(G1) == is_perfect(G2)
+    @test is_pgroup(G1) == is_pgroup(G2)
+    @test is_quasisimple(G1) == is_quasisimple(G2)
+    @test is_simple(G1) == is_simple(G2)
+    @test is_solvable(G1) == is_solvable(G2)
+    @test is_sporadic_simple(G1) == is_sporadic_simple(G2)
+
+    # attributes
+    @test images(iso, fitting_subgroup(G1)[1]) == fitting_subgroup(G2)
+    @test images(iso, frattini_subgroup(G1)[1]) == frattini_subgroup(G2)
+    @test is_pgroup_with_prime(G1) == is_pgroup_with_prime(G2)
+    @test nilpotency_class(G1) == nilpotency_class(G2)
+    @test number_conjugacy_classes(G1) == order(G1)
+    @test number_conjugacy_classes(Int, G1) isa Int
+    @test order(G1) == order(G2)
+    @test images(iso, socle(G1)[1]) == socle(G2)
+    @test images(iso, solvable_radical(G1)[1]) == solvable_radical(G2)
+    if is_pgroup(G1) && order(G1) != 1
+      @test prime_of_pgroup(G1) == prime_of_pgroup(G2)
+    end
+
+    # conjugacy classes of elements
+    cc = conjugacy_classes(G1)
+    @test length(cc) == order(G1)
+    @test all(C -> length(C) == 1, cc)
+    @test rand(cc[1]) == representative(cc[1])
+    @test acting_group(cc[1]) == G1
+    for x in gens(G1), y in gens(G1)
+      @test is_conjugate(G1, x, y) == (x == y)
+      @test representative_action(G1, x, y)[1] == (x == y)
+    end
+    C = cc[1]
+    for H in C
+      @test H == representative(C)
+    end
+
+    # conjugacy classes of subgroups
+    CC = conjugacy_classes_subgroups(G1)
+    @test length(CC) == length(conjugacy_classes_subgroups(G2))
+    @test all(C -> length(C) == 1, CC)
+    @test rand(CC[1]) == representative(CC[1])
+    @test acting_group(CC[1]) == G1
+    for C1 in CC, x in gens(G1)
+      H = representative(C1)
+      @test conjugate_group(H, x) == H
+      @test H^x == H
+    end
+    for C1 in CC, C2 in CC
+      H = representative(C1)
+      K = representative(C2)
+      @test is_conjugate(G1, H, K) == (H == K)
+      @test representative_action(G1, H, K)[1] == (H == K)
+      @test is_conjugate_subgroup(G1, H, K) == is_subgroup(K, H)[1]
+    end
+    C = CC[1]
+    for H in C
+      @test H == representative(C)
+    end
+
+    # operations
+    x = representative(rand(cc))
+    H = representative(rand(CC))
+    @test images(iso, core(G1, H)[1]) == core(G2, images(iso, H)[1])
+    @test images(iso, normalizer(G1, x)[1]) == normalizer(G2, iso(x))
+    @test images(iso, normalizer(G1, H)[1]) == normalizer(G2, images(iso, H)[1])
+    @test images(iso, normal_closure(G1, H)[1]) == normal_closure(G2, images(iso, H)[1])
+
+    # operations depending on primes
+    for p in primes
+      @test images(iso, pcore(G1, p)[1]) == pcore(G2, p)
+      @test images(iso, sylow_subgroup(G1, p)[1]) == sylow_subgroup(G2, p)
+    end
+
+    # operations depending on sets of primes
+    for P in subsets(Set(primes))
+      @test [images(iso, S)[1] for S in hall_subgroup_reps(G1, collect(P))] ==
+            hall_subgroup_reps(G2, collect(P))
+    end
+    @test sort!([order(images(iso, S)[1]) for S in hall_system(G1)]) ==
+          sort!([order(S) for S in hall_system(G2)])
+    @test [images(iso, S)[1] for S in sylow_system(G1)] == sylow_system(G2)
+  end
+end

--- a/test/Groups/conformance.jl
+++ b/test/Groups/conformance.jl
@@ -26,13 +26,13 @@ import Oscar.AbstractAlgebra.GroupsCore
       @test one(G) isa typeof(g)
       @test one(G)==one(g)==one(h)
 
-      @test isfinite(G) isa Bool
+      @test is_finite(G) isa Bool
 #      @test hasorder(G) isa Bool
 #      @test hasgens(G) isa Bool
       @test ngens(G) isa Int
       @test gens(G) isa Vector{typeof(g)}
 
-      if isfinite(G)
+      if is_finite(G)
          @test order(G) isa ZZRingElem
          @test order(G) > 0
          @test is_trivial(G) == (order(G) == 1)

--- a/test/Groups/constructors.jl
+++ b/test/Groups/constructors.jl
@@ -13,7 +13,7 @@
     @test nmp == n
     @test nmp isa Int
 
-    @test isfinite(G)
+    @test is_finite(G)
 
     @test order(G) isa ZZRingElem
     @test order(G) == factorial(n)
@@ -111,7 +111,7 @@ end
 # FIXME: a function `free_abelian_group` is not defined in GAPGroups, since it is already defined in Hecke
 #=
   H = free_abelian_group(2)
-  @test !isfinite(H)
+  @test !is_finite(H)
   @test is_abelian(H)
 =#
   
@@ -127,17 +127,17 @@ end
   F = free_group("x","y")
   @test F isa FPGroup
   @test_throws GroupsCore.InfiniteOrder{FPGroup} order(F)
-  @test_throws ErrorException index(F, trivial_subgroup(F)[1])
+  @test_throws ArgumentError index(F, trivial_subgroup(F)[1])
   @test_throws MethodError degree(F)
-  @test !isfinite(F)
+  @test !is_finite(F)
   @test !is_abelian(F)
 
   F = free_group(:x,:y)
   @test F isa FPGroup
   @test_throws GroupsCore.InfiniteOrder{FPGroup} order(F)
-  @test_throws ErrorException index(F, trivial_subgroup(F)[1])
+  @test_throws ArgumentError index(F, trivial_subgroup(F)[1])
   @test_throws MethodError degree(F)
-  @test !isfinite(F)
+  @test !is_finite(F)
   @test !is_abelian(F)
 
   F = free_group("x",:y)

--- a/test/Groups/libraries.jl
+++ b/test/Groups/libraries.jl
@@ -102,12 +102,12 @@ end
    @test [number_perfect_groups(i) for i in 2:59]==[0 for i in 1:58]
    x = perfect_group_identification(alternating_group(5))
    @test is_isomorphic(perfect_group(x[1],x[2]),alternating_group(5))
-   @test_throws ErrorException perfect_group_identification(symmetric_group(5))
+   @test_throws ArgumentError perfect_group_identification(symmetric_group(5))
 
    @test sum(number_perfect_groups, 1:59) == 1
    @test number_perfect_groups(ZZRingElem(60)^3) == 1
    @test_throws ArgumentError number_perfect_groups(0) # invalid argument
-   @test_throws ErrorException number_perfect_groups(ZZRingElem(60)^10)  # result not known
+   @test_throws ArgumentError number_perfect_groups(ZZRingElem(60)^10)  # result not known
 end
 
 @testset "Small groups" begin
@@ -139,7 +139,7 @@ end
    # `atlas_group` for type and group name
    @test order(atlas_group(PermGroup, "A5")) == 60
    @test order(atlas_group(MatrixGroup, "A5")) == 60
-   @test_throws ErrorException atlas_group(PermGroup, "B")
+   @test_throws ArgumentError atlas_group(PermGroup, "B")
 
    # prescribe permutation degree
    info1 = all_atlas_group_infos("A5", degree => 5)
@@ -220,7 +220,7 @@ end
    H, emb = atlas_subgroup(MatrixGroup, "M11", 1)
    @test order(H) == 720
    # no representation of the group
-   @test_throws ErrorException atlas_subgroup(PermGroup, "B", 1)
+   @test_throws ArgumentError atlas_subgroup(PermGroup, "B", 1)
    # no restriction to the subgroup
    @test_throws ErrorException atlas_subgroup("M11", 100)
 
@@ -232,8 +232,8 @@ end
    @test domain(emb) == H
    @test codomain(emb) == G
    # the group was not created with `atlas_group`
-   @test_throws ErrorException atlas_subgroup(symmetric_group(5), 1)
-   @test_throws ErrorException atlas_subgroup(H, 1)
+   @test_throws ArgumentError atlas_subgroup(symmetric_group(5), 1)
+   @test_throws ArgumentError atlas_subgroup(H, 1)
    # no restriction to the subgroup
    @test_throws ErrorException atlas_subgroup(G, 100)
 

--- a/test/Groups/quotients.jl
+++ b/test/Groups/quotients.jl
@@ -2,10 +2,10 @@
    @testset for G in [symmetric_group(4), special_linear_group(2, 3), special_linear_group(2, 4), free_group(1), abelian_group(PcGroup, [2, 3, 4])]
       subgens = elem_type(G)[]
       F, epi = quo(G, subgens)
-      if isfinite(G)
+      if is_finite(G)
         @test order(F) == order(G)
       else
-        @test ! isfinite(F)
+        @test ! is_finite(F)
       end
    end
 end
@@ -81,7 +81,7 @@ end
    
    n=5
    G,f = quo(F, [x^2,y^n,(x*y)^2] )           # dihedral group D(2n)
-   @test isfinite(G)
+   @test is_finite(G)
    @test order(G) == 2*n
    @test !is_abelian(G)
    @test is_isomorphic(G, dihedral_group(2*n))
@@ -95,7 +95,7 @@ end
    end
    
    G,f = quo(F, [x^n,y^n,comm(x,y)])          # group C(n) x C(n)
-   @test isfinite(G)
+   @test is_finite(G)
    @test order(G) == n^2
    @test is_abelian(G)
    @test !is_injective(f)

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -365,7 +365,7 @@ end
    @test is_characteristic_subgroup(center(G)[1], G)
    @test socle(G)==frattini_subgroup(G)
    @test socle(S)==fitting_subgroup(S)   
-   @test radical_subgroup(S)[1]==S
+   @test solvable_radical(S)[1]==S
    S = symmetric_group(5)
-   @test radical_subgroup(S)==sub(S,[one(S)])
+   @test solvable_radical(S)==sub(S,[one(S)])
 end


### PR DESCRIPTION
- added "group function" methods for `GrpAbFinGen` groups (I am not sure how much of this should better be moved to Hecke)

- changed `GroupConjClass` to be an abstract type, defined `GAPGroupConjClass` and `GrpAbFinGenConjClass`

- renamed `radical_subgroup` to `solvable_radical` (the name has meanwhile been corrected in GAP)

- support prescribed type of integer for the return value of `is_pgroup_with_prime`, `length(::GroupConjClass)`, `number_conjugacy_classes`

- fixed `hall_subgroup_reps`

- added `images` to compute the image of a subgroup under a homomorphism

- added some doctests, improved docstrings