### PR TITLE
Ideal membership

### DIFF
--- a/docs/src/CommutativeAlgebra/ideals.md
+++ b/docs/src/CommutativeAlgebra/ideals.md
@@ -167,7 +167,7 @@ is_subset(I::MPolyIdeal{T}, J::MPolyIdeal{T}) where T
 ### Ideal Membership
 
 ```@docs
-ideal_membership(f::T, I::MPolyIdeal{T}) where T
+ideal_membership(f::T, I::MPolyIdeal{T}; ordering::MonomialOrdering = default_ordering(base_ring(I))) where T
 ```
 
 ### Radical Membership

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -910,7 +910,7 @@ end
     ideal_membership(f::T, I::MPolyIdeal{T}; ordering::MonomialOrdering = default_ordering(base_ring(I))) where T
 
 Return `true` if `f` is contained in `I`, `false` otherwise. Uses a cached Gröbner basis for `I` or, if no such cached
-Gröbner basis exists, computes first a Gröbner basis for `I` w.r.t. the monomial ordering `ordering.
+Gröbner basis exists, computes first a Gröbner basis for `I` w.r.t. the monomial ordering `ordering`.
 Alternatively, use `f in I`.
 
 # Examples

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -907,9 +907,11 @@ end
 #######################################################
 
 @doc Markdown.doc"""
-    ideal_membership(f::T, I::MPolyIdeal{T}) where T
+    ideal_membership(f::T, I::MPolyIdeal{T}; ordering::MonomialOrdering = default_ordering(base_ring(I))) where T
 
-Return `true` if `f` is contained in `I`, `false` otherwise. Alternatively, use `f in I`.
+Return `true` if `f` is contained in `I`, `false` otherwise. Uses a cached Gröbner basis for `I` or, if no such cached
+Gröbner basis exists, computes first a Gröbner basis for `I` w.r.t. the monomial ordering `ordering.
+Alternatively, use `f in I`.
 
 # Examples
 ```jldoctest
@@ -933,7 +935,11 @@ false
 ```
 """
 function ideal_membership(f::T, I::MPolyIdeal{T}; ordering::MonomialOrdering = default_ordering(base_ring(I))) where T
-  GI = standard_basis(I, ordering=ordering, complete_reduction=false)
+  if isempty(I.gb)
+    GI = standard_basis(I, ordering=ordering, complete_reduction=false)
+  else
+    GI = first(I.gb)[2]
+  end
   singular_assure(GI)
   Sx = base_ring(GI.S)
   return Singular.iszero(Singular.reduce(Sx(f), GI.S))

--- a/test/Rings/groebner-test.jl
+++ b/test/Rings/groebner-test.jl
@@ -120,7 +120,7 @@ end
   G = standard_basis(I, ordering=o)
   @test normal_form(x^5-5, I, ordering=o) == -5
   J = ideal(R, [x^5-5])
-  units, matr, res = reduce_with_quotients_and_unit(J.gens, G)
+  units, matr, res = reduce_with_quotients_and_unit(J.gens, G, ordering=o)
   @test matr * gens(G) + res == units * gens(J)
   u = negdegrevlex([x])*negdegrevlex([y])
   @test ideal_membership(x^4, I, ordering=u)


### PR DESCRIPTION
This is a part of a fix for #2099: `ideal_membership` now uses the first cached Gröbner basis for an ideal, otherwise it first computes a Gröbner basis w.r.t. the given monomial ordering.