### PR TITLE
Raise CI timeout from 120 to 150 minutes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 120
+    timeout-minutes: 150
     continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Of course we want to make our tests faster again, but in the meantime
it's a nuisance if CI tests randomly fail after being 95% complete. So
let's be pragmatic and raise this limit, at least for the time being
