### PR TITLE
Run doctests in Julia >= 1.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,14 +32,19 @@ jobs:
           - x64
         os:
           - ubuntu-latest
+        doctest:
+          - 'no'
+          - 'only'
         include:
           # Add a few macOS jobs (not too many, the number we can run in parallel is limited)
           - julia-version: '1.8'
             julia-arch: x64
             os: macOS-latest
+            doctest: 'yes'
           - julia-version: 'nightly'
             julia-arch: x64
             os: macOS-latest
+            doctest: 'yes'
 
     steps:
       - uses: actions/checkout@v3
@@ -59,10 +64,23 @@ jobs:
         # restrict number of openMP threads on macOS due to oversubscription
         run: echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
       - name: "Run tests"
+        if: matrix.doctest != 'only'
         uses: julia-actions/julia-runtest@latest
         with:
+          annotate: ${{ matrix.julia-version == '1.8' }}
           coverage: ${{ matrix.julia-version == '1.8' }}
           depwarn: error
+      - name: "Run doctests"
+        if: matrix.doctest != 'no'
+        run: |
+          julia --project=docs --color=yes -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()
+            using Documenter
+            using Oscar
+            DocMeta.setdocmeta!(Oscar, :DocTestSetup, :(using Oscar); recursive = true)
+            doctest(Oscar)'
       - name: "Process code coverage"
         if: matrix.julia-version == '1.8'
         uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,14 +27,11 @@ jobs:
           - '1.8'
           - '~1.9.0-0'
           - 'nightly'
-        julia-arch:
-          - x64
         os:
           - ubuntu-latest
         include:
           # Add a few macOS jobs (not too many, the number we can run in parallel is limited)
           - julia-version: 'nightly'
-            julia-arch: x64
             os: macOS-latest
 
     steps:
@@ -47,7 +44,6 @@ jobs:
         uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
-          arch: ${{ matrix.julia-arch }}
       - name: "Build package"
         uses: julia-actions/julia-buildpkg@latest
       - name: "limit OpenMP threads"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,8 +24,8 @@ jobs:
       matrix:
         julia-version:
           - '1.6'
-          - '~1.7.0-0'
-          - '~1.8.0-0'
+          - '1.7'
+          - '1.8'
           - '~1.9.0-0'
           - 'nightly'
         julia-arch:
@@ -34,7 +34,7 @@ jobs:
           - ubuntu-latest
         include:
           # Add a few macOS jobs (not too many, the number we can run in parallel is limited)
-          - julia-version: '1.6'
+          - julia-version: '1.8'
             julia-arch: x64
             os: macOS-latest
           - julia-version: 'nightly'
@@ -61,12 +61,14 @@ jobs:
       - name: "Run tests"
         uses: julia-actions/julia-runtest@latest
         with:
-          coverage: ${{ matrix.julia-version == '1.6' }}
+          coverage: ${{ matrix.julia-version == '1.8' }}
           depwarn: error
       - name: "Process code coverage"
+        if: matrix.julia-version == '1.8'
         uses: julia-actions/julia-processcoverage@v1
         with:
           directories: src,experimental
       - name: "Upload coverage data to Codecov"
+        if: matrix.julia-version == '1.8'
         continue-on-error: true
         uses: codecov/codecov-action@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,9 +33,6 @@ jobs:
           - ubuntu-latest
         include:
           # Add a few macOS jobs (not too many, the number we can run in parallel is limited)
-          - julia-version: '1.8'
-            julia-arch: x64
-            os: macOS-latest
           - julia-version: 'nightly'
             julia-arch: x64
             os: macOS-latest
@@ -86,6 +83,10 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
+        include:
+          # Add macOS jobs (not too many, the number we can run in parallel is limited)
+          - julia-version: '1.8'
+            os: macOS-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -99,6 +100,19 @@ jobs:
           version: ${{ matrix.julia-version }}
       - name: "Build package"
         uses: julia-actions/julia-buildpkg@latest
+      - name: "limit OpenMP threads"
+        if: runner.os == 'macOS'
+        # restrict number of openMP threads on macOS due to oversubscription
+        run: echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
+      - name: "Run tests"
+        # HACK: since macOS runners are so expensive, we reuse this one to run
+        # both regular tests and doctests
+        if: runner.os == 'macOS'
+        uses: julia-actions/julia-runtest@latest
+        with:
+          annotate: ${{ matrix.julia-version == '1.8' }}
+          coverage: ${{ matrix.julia-version == '1.8' }}
+          depwarn: error
       - name: "Setup package"
         run: |
           julia --project=docs --color=yes -e '

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,6 @@ jobs:
       matrix:
         julia-version:
           - '1.6'
-          - '1.7'
           - '1.8'
           - '~1.9.0-0'
           - 'nightly'
@@ -82,7 +81,6 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.7'
           - '1.8'
           - '~1.9.0-0'
           - 'nightly'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,19 +32,14 @@ jobs:
           - x64
         os:
           - ubuntu-latest
-        doctest:
-          - 'no'
-          - 'only'
         include:
           # Add a few macOS jobs (not too many, the number we can run in parallel is limited)
           - julia-version: '1.8'
             julia-arch: x64
             os: macOS-latest
-            doctest: 'yes'
           - julia-version: 'nightly'
             julia-arch: x64
             os: macOS-latest
-            doctest: 'yes'
 
     steps:
       - uses: actions/checkout@v3
@@ -64,19 +59,57 @@ jobs:
         # restrict number of openMP threads on macOS due to oversubscription
         run: echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
       - name: "Run tests"
-        if: matrix.doctest != 'only'
         uses: julia-actions/julia-runtest@latest
         with:
           annotate: ${{ matrix.julia-version == '1.8' }}
           coverage: ${{ matrix.julia-version == '1.8' }}
           depwarn: error
-      - name: "Run doctests"
-        if: matrix.doctest != 'no'
+      - name: "Process code coverage"
+        if: matrix.julia-version == '1.8'
+        uses: julia-actions/julia-processcoverage@v1
+        with:
+          directories: src,experimental
+      - name: "Upload coverage data to Codecov"
+        if: matrix.julia-version == '1.8'
+        continue-on-error: true
+        uses: codecov/codecov-action@v3
+
+  doctest:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 150
+    continue-on-error: ${{ matrix.julia-version == 'nightly' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version:
+          - '1.7'
+          - '1.8'
+          - '~1.9.0-0'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # For Codecov, we must also fetch the parent of the HEAD commit to
+          # be able to properly deal with PRs / merges
+          fetch-depth: 2
+      - name: "Set up Julia"
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: "Build package"
+        uses: julia-actions/julia-buildpkg@latest
+      - name: "Setup package"
         run: |
           julia --project=docs --color=yes -e '
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()
+            Pkg.instantiate()'
+      - name: "Run doctests"
+        run: |
+          julia --project=docs --color=yes -e '
             using Documenter
             using Oscar
             DocMeta.setdocmeta!(Oscar, :DocTestSetup, :(using Oscar); recursive = true)

--- a/.github/workflows/Docu.yml
+++ b/.github/workflows/Docu.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.6'
+          version: '1.8'
       - name: Build package
         uses: julia-actions/julia-buildpkg@latest
       - name: Install dependencies

--- a/experimental/PlaneCurve/src/AffinePlaneCurve.jl
+++ b/experimental/PlaneCurve/src/AffinePlaneCurve.jl
@@ -149,7 +149,7 @@ julia> D = Oscar.AffinePlaneCurve((x-y)*(x-2))
 Affine plane curve defined by x^2 - x*y - 2*x + 2*y
 
 julia> Oscar.curve_intersect(C, D)
-2-element Vector{Vector{T} where T}:
+2-element Vector{Vector}:
  AffinePlaneCurve[]
  Point{QQFieldElem}[Point with coordinates QQFieldElem[0, 0], Point with coordinates QQFieldElem[2, -2]]
 ```
@@ -239,7 +239,7 @@ julia> C = Oscar.AffinePlaneCurve(x^2*(x+y)*(y^3-x^2))
 Affine plane curve defined by -x^5 - x^4*y + x^3*y^3 + x^2*y^4
 
 julia> Oscar.curve_singular_locus(C)
-2-element Vector{Vector{T} where T}:
+2-element Vector{Vector}:
  AffinePlaneCurve[Affine plane curve defined by x]
  Point[Point with coordinates QQFieldElem[-1, 1], Point with coordinates QQFieldElem[0, 0]]
 ```

--- a/experimental/PlaneCurve/src/DivisorCurve.jl
+++ b/experimental/PlaneCurve/src/DivisorCurve.jl
@@ -41,7 +41,7 @@ julia> Q = Oscar.Point([QQ(0), QQ(-1)])
 Point with coordinates QQFieldElem[0, -1]
 
 julia> Oscar.AffineCurveDivisor(C, Dict(P => 3, Q => -2))
-3*QQFieldElem[0, 0] - 2*QQFieldElem[0, -1]
+-2*QQFieldElem[0, -1] + 3*QQFieldElem[0, 0]
 ```
 """
 struct AffineCurveDivisor{S <: FieldElem} <: CurveDivisor
@@ -103,7 +103,7 @@ julia> Q = Oscar.Geometry.ProjSpcElem(PP[1], [QQ(0), QQ(-1), QQ(1)])
 (0 : -1 : 1)
 
 julia> D = Oscar.ProjCurveDivisor(C, Dict(P => 3, Q => -2))
-3*(0 : 0 : 1) - 2*(0 : 1 : -1)
+-2*(0 : 1 : -1) + 3*(0 : 0 : 1)
 ```
 """
 mutable struct ProjCurveDivisor{S <: FieldElem} <: CurveDivisor
@@ -274,7 +274,7 @@ julia> Q = Oscar.Point([QQ(0), QQ(-1)])
 Point with coordinates QQFieldElem[0, -1]
 
 julia> D = Oscar.AffineCurveDivisor(C, Dict(P => 3, Q => -2))
-3*QQFieldElem[0, 0] - 2*QQFieldElem[0, -1]
+-2*QQFieldElem[0, -1] + 3*QQFieldElem[0, 0]
 
 julia> Oscar.is_effective(D)
 false
@@ -468,7 +468,7 @@ julia> phi = T(x)//T(y)
 x//y
 
 julia> Oscar.divisor(PP[1], C, phi)
--(0 : 0 : 1) + (0 : 1 : -1)
+(0 : 1 : -1) - (0 : 0 : 1)
 ```
 """
 function divisor(PP::Oscar.Geometry.ProjSpc{S}, C::ProjPlaneCurve{S}, phi::AbstractAlgebra.Generic.Frac{T})  where {S <: FieldElem, T <: Oscar.MPolyDecRingElem{S}}
@@ -811,7 +811,7 @@ julia> F = Oscar.ProjCurveDivisor(C, R, 2)
 2*(0 : 0 : 1)
 
 julia> G = 2*E - 2*F
--4*(0 : 0 : 1) + 4*(0 : 1 : 0)
+4*(0 : 1 : 0) - 4*(0 : 0 : 1)
 
 julia> Oscar.principal_divisor(G)
 x^2//z^2

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -124,7 +124,7 @@ julia> M = fano_matroid()
 Matroid of rank 3 on 7 elements
 
 julia> flats(M)
-16-element Vector{Vector{T} where T}:
+16-element Vector{Vector}:
  Any[]
  [1]
  [2]
@@ -143,7 +143,7 @@ julia> flats(M)
  [1, 2, 3, 4, 5, 6, 7]
 
 julia> flats(M, 2)
-7-element Vector{Vector{T} where T}:
+7-element Vector{Vector}:
  [1, 2, 3]
  [1, 4, 5]
  [1, 6, 7]
@@ -187,7 +187,7 @@ julia> M = fano_matroid()
 Matroid of rank 3 on 7 elements
 
 julia> cyclic_flats(M)
-9-element Vector{Vector{T} where T}:
+9-element Vector{Vector}:
  Any[]
  [1, 2, 3]
  [1, 4, 5]
@@ -199,7 +199,7 @@ julia> cyclic_flats(M)
  [1, 2, 3, 4, 5, 6, 7]
 
 julia> cyclic_flats(M, 2)
-7-element Vector{Vector{T} where T}:
+7-element Vector{Vector}:
  [1, 2, 3]
  [1, 4, 5]
  [1, 6, 7]

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -205,8 +205,8 @@ julia> on_sets_sets(((1,2), (3,4)), g[1])
 
 julia> on_sets_sets(Set([[1, 2], [3, 4]]), g[1])
 Set{Vector{Int64}} with 2 elements:
-  [1, 4]
   [2, 3]
+  [1, 4]
 
 julia> setset = Set([BitSet([1, 2]), BitSet([3, 4])]);
 

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -331,8 +331,8 @@ The optional parameter `doctest` can take three values:
   - `:fix`: Run the doctests and replace the output in the manual with
     the output produced by Oscar. Please use this option carefully.
 
-In github actions the Julia version used for building the manual and
-running the doctests is 1.6. Using a different Julia version will produce
+In GitHub Actions the Julia version used for building the manual is 1.8 and
+doctests are run with >= 1.7. Using a different Julia version may produce
 errors in some parts of Oscar, so please be careful, especially when setting
 `doctest=:fix`.
 
@@ -356,9 +356,9 @@ The first run of `build_doc` will take the usual few minutes, subsequently runs
 will be significantly faster.
 """
 function build_doc(; doctest=false, strict=false, open_browser=true)
-  versioncheck = (VERSION.major == 1) && (VERSION.minor == 6)
+  versioncheck = (VERSION.major == 1) && (VERSION.minor >= 7)
   versionwarn = 
-"The Julia reference version for the doctests is 1.6, but you are using
+"The Julia reference version for the doctests is 1.7 or later, but you are using
 $(VERSION). Running the doctests will produce errors that you do not expect."
   if doctest != false && !versioncheck
     @warn versionwarn

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -135,12 +135,12 @@ end
 
 # We want to avoid running the doctests twice so we skip them when
 # "oscar_run_doctests" is set by OscarDevTools.jl
-if v"1.6.0" <= VERSION < v"1.7.0" && !haskey(ENV,"oscar_run_doctests")
-  @info "Running doctests (Julia version is 1.6)"
+if VERSION >= v"1.7.0" && !haskey(ENV,"oscar_run_doctests")
+  @info "Running doctests (Julia version is >= 1.7)"
   DocMeta.setdocmeta!(Oscar, :DocTestSetup, :(using Oscar); recursive = true)
   doctest(Oscar)
 else
-  @info "Not running doctests (Julia version must be 1.6)"
+  @info "Not running doctests (Julia version must be >= 1.7)"
 end
 
 if haskey(ENV, "GITHUB_STEP_SUMMARY") && compiletimes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,18 +131,6 @@ include("StraightLinePrograms/runtests.jl")
   Base.cumulative_compile_timing(false);
 end
 
-# Doctests
-
-# We want to avoid running the doctests twice so we skip them when
-# "oscar_run_doctests" is set by OscarDevTools.jl
-if VERSION >= v"1.7.0" && !haskey(ENV,"oscar_run_doctests")
-  @info "Running doctests (Julia version is >= 1.7)"
-  DocMeta.setdocmeta!(Oscar, :DocTestSetup, :(using Oscar); recursive = true)
-  doctest(Oscar)
-else
-  @info "Not running doctests (Julia version must be >= 1.7)"
-end
-
 if haskey(ENV, "GITHUB_STEP_SUMMARY") && compiletimes
   open(ENV["GITHUB_STEP_SUMMARY"], "a") do io
     print_stats(io, fmt=PrettyTables.tf_markdown)


### PR DESCRIPTION
It seems that with the minor adjustments in this PR, doctests pass
in Julia 1.7, 1.8 and 1.9 (but not anymore in 1.6).

If this works, and also with Julia nightly, that may be a good way
to address the problem that currently doctests are run only in Julia
1.6 and thus cannot catch regressions caused by new Julia versions.

The downside is that this means all CI tests will be even slower...