### PR TITLE
cohomCalg: Improve the bibtex entry for its implementation

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -149,6 +149,14 @@
   url           = {https://doi.org/10.1063/1.3501132}
 }
 
+@Misc{BJRR10*1,
+  author        = {Blumenhagen, Ralph and Jurke, Benjamin and Rahn, Thorsten and Roschy, Helmut},
+  title         = {cohomCalg package},
+  note          = {High-performance line bundle cohomology computation based on BJRR10},
+  year          = {2010},
+  url           = {https://github.com/BenjaminJurke/cohomCalg}
+}
+
 @Article{BJRR12,
   author        = {Blumenhagen, Ralph and Jurke, Benjamin and Rahn, Thorsten and Roschy, Helmut},
   title         = {Cohomology of line bundles: Applications},
@@ -1444,12 +1452,4 @@
   year          = {1995},
   doi           = {10.1007/978-1-4613-8431-1},
   url           = {https://doi.org/10.1007/978-1-4613-8431-1}
-}
-
-@Misc{cohomCalg:Implementation,
-  bibkey        = {cohomCalg:Implementation},
-  title         = {cohomCalg package},
-  note          = {High-performance line bundle cohomology computation based on BJRR10},
-  year          = {2010},
-  url           = {https://github.com/BenjaminJurke/cohomCalg}
 }

--- a/docs/src/AlgebraicGeometry/ToricVarieties/cohomCalg.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/cohomCalg.md
@@ -9,7 +9,7 @@ Pages = ["CohomCalg.md"]
 
 # Line bundle cohomology with cohomCalg
 
-We employ the cohomCalg algorithm [cohomCalg:Implementation](@cite)
+We employ the cohomCalg algorithm [BJRR10*1](@cite)
 to compute the dimension of line bundle cohomologies as well as vanishing sets.
 
 
@@ -23,7 +23,7 @@ cohomology(l::ToricLineBundle, i::Int)
 ## Toric vanishing sets
 
 Vanishing sets describe subsets of the Picard group of toric varieties.
-Their computations is based on [cohomCalg:Implementation](@cite), i.e.
+Their computations is based on [BJRR10*1](@cite), i.e.
 this functionality is only available if the toric variety in question is
 either smooth and complete or alternatively, simplicial and projective.
 This approach to identify vanishing sets on toric varieties was originally

--- a/docs/src/AlgebraicGeometry/ToricVarieties/intro.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/intro.md
@@ -16,7 +16,7 @@ and objects from commutative algebra and polyhedral geometry derived thereof. In
 we provide support for the following:
 - torus-invariant divisor (classes),
 - line bundles,
-- line bundle cohomology via `cohomCalg` (cf. [cohomCalg:Implementation](@cite)),
+- line bundle cohomology via `cohomCalg` (cf. [BJRR10*1](@cite)),
 - vanishing sets of line bundle cohomology (cf. `Appendix B` of [Bie18](@cite)),
 - cohomology ring and cohomology classes,
 - Chow ring, algebraic cycles and intersection theory,

--- a/src/AlgebraicGeometry/ToricVarieties/cohomCalg/special_attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/cohomCalg/special_attributes.jl
@@ -27,11 +27,8 @@ end
 
 Computes the dimension of all sheaf cohomologies of the 
 toric line bundle `l` by use of the cohomCalg algorithm 
-[BJRR10](@cite),
-[cohomCalg:Implementation(@cite),
-[RR10](@cite),
-[Jow11](@cite),
-[BJRR12](@cite).
+[BJRR10](@cite), [BJRR10*1](@cite) (see also [RR10](@cite),
+[Jow11](@cite) and [BJRR12](@cite)).
 
 # Examples
 ```jldoctest
@@ -160,11 +157,8 @@ end
 
 Computes the dimension of the i-th sheaf cohomology of the
 toric line bundle `l` by use of the cohomCalg algorithm
-[BJRR10](@cite),
-[cohomCalg:Implementation(@cite),
-[RR10](@cite),
-[Jow11](@cite),
-[BJRR12](@cite).
+[BJRR10](@cite), [BJRR10*1](@cite) (see also [RR10](@cite),
+[Jow11](@cite) and [BJRR12](@cite)).
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
The bib-tex entry for `cohomCalg:Implementation` was taken from https://github.com/BenjaminJurke/cohomCalg, but sadly looks bad at the OSCAR website https://docs.oscar-system.org/stable/references/. This PR modifies this bibtex entry, so that it looks (hopefully) great on the OSCAR website, while giving proper credit to the people involved.

cc @fingolfin 