### PR TITLE
More cleanup for ProjectiveScheme

### DIFF
--- a/experimental/Schemes/CartierDivisor.jl
+++ b/experimental/Schemes/CartierDivisor.jl
@@ -158,12 +158,12 @@ end
 
 
 function effective_cartier_divisor(IP::AbsProjectiveScheme, f::Union{MPolyDecRingElem, MPolyQuoRingElem})
-  parent(f) === graded_coordinate_ring(IP) || error("element does not belong to the correct ring")
+  parent(f) === homogeneous_coordinate_ring(IP) || error("element does not belong to the correct ring")
   d = degree(f)
   X = covered_scheme(IP)
   triv_dict = IdDict{AbsSpec, RingElem}()
   for U in affine_charts(X)
-    triv_dict[U] = dehomogenize(IP, U)(f)
+    triv_dict[U] = dehomogenization_map(IP, U)(f)
   end
   C = EffectiveCartierDivisor(X, triv_dict, trivializing_covering=default_covering(X))
   return C

--- a/experimental/Schemes/CoherentSheaves.jl
+++ b/experimental/Schemes/CoherentSheaves.jl
@@ -677,7 +677,7 @@ function twisting_sheaf(IP::ProjectiveScheme{<:Field}, d::Int)
 
   X = covered_scheme(IP)
   MD = IdDict{AbsSpec, ModuleFP}()
-  S = graded_coordinate_ring(IP)
+  S = homogeneous_coordinate_ring(IP)
   n = ngens(S)-1
   for i in 1:n+1
     U = affine_charts(X)[i]
@@ -763,7 +763,7 @@ end
   R = OO(X)
   P = base_ring(R)
   F = FreeMod(R, ["d$(x)" for x in symbols(P)])
-  rels, _ = sub(F, transpose(change_base_ring(R, jacobi_matrix(gens(modulus(R))))))
+  rels, _ = sub(F, transpose(change_base_ring(R, jacobi_matrix(base_ring(modulus(R)), gens(modulus(R))))))
   M, _ = quo(F, rels)
   return M
 end
@@ -772,7 +772,7 @@ end
   R = OO(X)
   P = base_ring(R)
   F = FreeMod(R, ["d$(x)" for x in symbols(P)])
-  rels, _ = sub(F, transpose(change_base_ring(R, jacobi_matrix(gens(modulus(R))))))
+  rels, _ = sub(F, transpose(change_base_ring(R, jacobi_matrix(base_ring(modulus(R)), gens(modulus(R))))))
   M, _ = quo(F, rels)
   return M
 end
@@ -1623,9 +1623,9 @@ function projectivization(E::AbsCoherentSheaf;
   # prepare for the projective glueings
   for (U, V) in keys(glueings(C))
     P = on_patches[U]
-    SP = graded_coordinate_ring(P)
+    SP = homogeneous_coordinate_ring(P)
     Q = on_patches[V]
-    SQ = graded_coordinate_ring(Q)
+    SQ = homogeneous_coordinate_ring(Q)
     G = C[U, V]
     UV, VU = glueing_domains(G)
     f, g = glueing_morphisms(G)
@@ -1659,8 +1659,8 @@ function projectivization(E::AbsCoherentSheaf;
     B = [coordinates(E(V, UV)(w)) for w in gens(E(V))]
     #A = [coordinates(OX(U, VU)(f), I(VU)) for f in gens(I(U))] # A[i][j] = aᵢⱼ
     #B = [coordinates(OX(V, UV)(g), I(UV)) for g in gens(I(V))] # B[j][i] = bⱼᵢ
-    SQVU = graded_coordinate_ring(QVU)
-    SPUV = graded_coordinate_ring(PUV)
+    SQVU = homogeneous_coordinate_ring(QVU)
+    SPUV = homogeneous_coordinate_ring(PUV)
     # the induced map is ℙ(UV) → ℙ(VU), tⱼ ↦ ∑ᵢ bⱼᵢ ⋅ sᵢ 
     # and ℙ(VU) → ℙ(UV), sᵢ ↦ ∑ⱼ aᵢⱼ ⋅ tⱼ 
     fup = ProjectiveSchemeMor(PUV, QVU, hom(SQVU, SPUV, pullback(f), [sum([B[j][i]*SPUV[i] for i in 1:ngens(SPUV)]) for j in 1:length(B)]))

--- a/experimental/Schemes/CoveredProjectiveSchemes.jl
+++ b/experimental/Schemes/CoveredProjectiveSchemes.jl
@@ -144,8 +144,8 @@ mutable struct ProjectiveGlueing{
     (PU, QV) = (domain(incP), domain(incQ))
     (base_scheme(PX) == X && base_scheme(QY) == Y) || error("base glueing is incompatible with the projective schemes")
     domain(f) == codomain(g) == PU && domain(g) == codomain(f) == QV || error("maps are not compatible")
-    SPU = graded_coordinate_ring(domain(f))
-    SQV = graded_coordinate_ring(codomain(f))
+    SPU = homogeneous_coordinate_ring(domain(f))
+    SQV = homogeneous_coordinate_ring(codomain(f))
     if check
       # check the commutativity of the pullbacks
       all(y->(pullback(f)(SQV(OO(V)(y))) == SPU(pullback(fb)(OO(V)(y)))), gens(base_ring(OO(Y)))) || error("maps do not commute")
@@ -272,7 +272,7 @@ function blow_up_chart(W::AbsSpec{<:Field, <:MPolyRing}, I::MPolyIdeal;
   r = ngens(I) - 1
   g = gens(I)
   IPW = projective_space(W, r, var_name=var_name)
-  S = graded_coordinate_ring(IPW)
+  S = homogeneous_coordinate_ring(IPW)
   t = gens(S)
   if is_regular_sequence(gens(I))
     # construct the blowup manually
@@ -305,7 +305,7 @@ function blow_up_chart(W::AbsSpec{<:Field, <:MPolyRing}, I::MPolyIdeal;
     phi = hom(OO(CIPW), A, vcat([inc(g[i])*t for i in 1:r+1], x_ext[1:end-1], )) # the homogeneous variables come first
     J = kernel(phi)
     pb = inverse(pullback_to_cone)
-    Jh = ideal(graded_coordinate_ring(IPW), pb.(lifted_numerator.(gens(J))))
+    Jh = ideal(homogeneous_coordinate_ring(IPW), pb.(lifted_numerator.(gens(J))))
     IPY = subscheme(IPW, Jh)
     # Compute the IdealSheaf for the exceptional divisor
     ID = IdDict{AbsSpec, RingElem}()
@@ -550,8 +550,8 @@ function _compute_projective_glueing(gd::CoveredProjectiveGlueingData)
   X = scheme(I)
   OX = StructureSheafOfRings(X)
 
-  SP = graded_coordinate_ring(P)
-  SQ = graded_coordinate_ring(Q)
+  SP = homogeneous_coordinate_ring(P)
+  SQ = homogeneous_coordinate_ring(Q)
   UV, VU = glueing_domains(G)
   f, g = glueing_morphisms(G)
 
@@ -582,8 +582,8 @@ function _compute_projective_glueing(gd::CoveredProjectiveGlueingData)
   # tⱼ the variables for the homogenesous ring over V
   A = [coordinates(OX(U, VU)(f), I(VU)) for f in gens(I(U))] # A[i][j] = aᵢⱼ
   B = [coordinates(OX(V, UV)(g), I(UV)) for g in gens(I(V))] # B[j][i] = bⱼᵢ
-  SQVU = graded_coordinate_ring(QVU)
-  SPUV = graded_coordinate_ring(PUV)
+  SQVU = homogeneous_coordinate_ring(QVU)
+  SPUV = homogeneous_coordinate_ring(PUV)
   # the induced map is ℙ(UV) → ℙ(VU), tⱼ ↦ ∑ᵢ bⱼᵢ ⋅ sᵢ 
   # and ℙ(VU) → ℙ(UV), sᵢ ↦ ∑ⱼ aᵢⱼ ⋅ tⱼ 
   fup = ProjectiveSchemeMor(PUV, QVU, hom(SQVU, SPUV, pullback(f), [sum([B[j][i]*SPUV[i] for i in 1:ngens(SPUV)]) for j in 1:length(B)], check=false), check=false)
@@ -699,8 +699,8 @@ function _compute_glueing(gd::ProjectiveGlueingData)
   (UD, VD) = glueing_domains(P[U, V])
   (fup, gup) = glueing_morphisms(P[U, V])
   (incU, incV) = inclusion_maps(P[U, V])
-  S = graded_coordinate_ring(P[U])
-  T = graded_coordinate_ring(P[V])
+  S = homogeneous_coordinate_ring(P[U])
+  T = homogeneous_coordinate_ring(P[V])
   i = P[U][UW][2]
   j = P[V][VW][2]
   s_i = gens(S)[i]
@@ -708,8 +708,8 @@ function _compute_glueing(gd::ProjectiveGlueingData)
   AW = affine_charts(Oscar.covered_scheme(UD))[i]
   BW = affine_charts(Oscar.covered_scheme(VD))[j]
 
-  hU = dehomogenize(UD, AW)(pullback(fup)(pullback(incV)(t_j)))
-  hV = dehomogenize(VD, BW)(pullback(gup)(pullback(incU)(s_i)))
+  hU = dehomogenization_map(UD, AW)(pullback(fup)(pullback(incV)(t_j)))
+  hV = dehomogenization_map(VD, BW)(pullback(gup)(pullback(incU)(s_i)))
 
   # We need to construct the glueing 
   #
@@ -738,14 +738,14 @@ function _compute_glueing(gd::ProjectiveGlueingData)
   x = gens(ambient_coordinate_ring(AAW))
   y = gens(ambient_coordinate_ring(BBW))
 
-  xh = homogenize(UD, AW).(OO(AW).(x))
-  yh = homogenize(VD, BW).(OO(BW).(y))
+  xh = homogenization_map(UD, AW).(OO(AW).(x))
+  yh = homogenization_map(VD, BW).(OO(BW).(y))
 
   xhh = [(pullback(gup)(pp), pullback(gup)(qq)) for (pp, qq) in xh]
   yhh = [(pullback(fup)(pp), pullback(fup)(qq)) for (pp, qq) in yh]
 
-  phi = dehomogenize(VD, BW)
-  psi = dehomogenize(UD, AW) 
+  phi = dehomogenization_map(VD, BW)
+  psi = dehomogenization_map(UD, AW) 
   yimgs = [OO(AAW)(psi(pp))*inv(OO(AAW)(psi(qq))) for (pp, qq) in yhh]
   ximgs = [OO(BBW)(phi(pp))*inv(OO(BBW)(phi(qq))) for (pp, qq) in xhh]
   ff = SpecMor(AAW, BBW, hom(OO(BBW), OO(AAW), yimgs, check=false), check=false)

--- a/experimental/Schemes/IdealSheaves.jl
+++ b/experimental/Schemes/IdealSheaves.jl
@@ -31,28 +31,28 @@ convert ``ℐ`` into a `CoherentSheaf` on ``Y``, first.
 """
 function IdealSheaf(X::ProjectiveScheme, I::MPolyIdeal) 
   S = base_ring(I)
-  S === graded_coordinate_ring(X) || error("ideal does not live in the graded coordinate ring of the scheme")
+  S === homogeneous_coordinate_ring(X) || error("ideal does not live in the graded coordinate ring of the scheme")
   g = gens(I)
   X_covered = covered_scheme(X)
   C = default_covering(X_covered)
   r = relative_ambient_dimension(X)
   I = IdDict{AbsSpec, Ideal}()
   for i in 0:r
-    I[C[i+1]] = ideal(OO(C[i+1]), dehomogenize(X, i).(g))
+    I[C[i+1]] = ideal(OO(C[i+1]), dehomogenization_map(X, i).(g))
   end
   return IdealSheaf(X_covered, I, check=true)
 end
 
 function IdealSheaf(X::ProjectiveScheme, I::MPolyQuoIdeal) 
   S = base_ring(I)
-  S === graded_coordinate_ring(X) || error("ideal does not live in the graded coordinate ring of the scheme")
+  S === homogeneous_coordinate_ring(X) || error("ideal does not live in the graded coordinate ring of the scheme")
   g = gens(I)
   X_covered = covered_scheme(X)
   C = default_covering(X_covered)
   r = relative_ambient_dimension(X)
   I = IdDict{AbsSpec, Ideal}()
   for i in 0:r
-    I[C[i+1]] = ideal(OO(C[i+1]), dehomogenize(X, i).(g))
+    I[C[i+1]] = ideal(OO(C[i+1]), dehomogenization_map(X, i).(g))
   end
   return IdealSheaf(X_covered, I, check=true)
 end
@@ -86,7 +86,7 @@ function IdealSheaf(
   I = IdDict{AbsSpec, Ideal}()
   U = basic_patches(default_covering(X_covered))
   for i in 1:length(U)
-    I[U[i]] = ideal(OO(U[i]), dehomogenize(X, i-1).(g))
+    I[U[i]] = ideal(OO(U[i]), dehomogenization_map(X, i-1).(g))
   end
   return IdealSheaf(X_covered, I, check=false)
 end
@@ -100,7 +100,7 @@ function IdealSheaf(
   I = IdDict{AbsSpec, Ideal}()
   U = basic_patches(default_covering(X_covered))
   for i in 1:length(U)
-    I[U[i]] = ideal(OO(U[i]), dehomogenize(X, i-1).(g))
+    I[U[i]] = ideal(OO(U[i]), dehomogenization_map(X, i-1).(g))
   end
   return IdealSheaf(X_covered, I, check=false)
 end

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
@@ -1,8 +1,3 @@
-
-
-
-
-
 ########################################################################
 # (1) Attributes of AbsSpec
 #     coordinate ring and ambient space related methods
@@ -47,6 +42,14 @@ function OO(X::AbsSpec{BRT, RT}) where {BRT, RT}
   OO(underlying_scheme(X))::RT
 end
 
+@doc Markdown.doc"""
+    total_ring_of_fractions(X::AbsSpec)
+
+Return the total ring of fractions of the coordinate ring of `X`.
+"""
+@attr function total_ring_of_fractions(X::AbsSpec)
+  return total_ring_of_fractions(OO(X))
+end
 
 @doc Markdown.doc"""
     ambient_space(X::AbsSpec)

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Attributes.jl
@@ -43,7 +43,7 @@ Return the default covering for ``X``.
 ```jldoctest
 julia> P = projective_space(QQ, 2);
 
-julia> S = graded_coordinate_ring(P);
+julia> S = homogeneous_coordinate_ring(P);
 
 julia> I = ideal(S, [S[1]*S[2]-S[3]^2]);
 
@@ -77,7 +77,7 @@ Return the affine charts in the `default_covering` of ``X``.
 ```jldoctest
 julia> P = projective_space(QQ, 2);
 
-julia> S = graded_coordinate_ring(P);
+julia> S = homogeneous_coordinate_ring(P);
 
 julia> I = ideal(S, [S[1]*S[2]-S[3]^2]);
 

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Attributes.jl
@@ -95,7 +95,7 @@ function map_on_affine_cones(
     pb_phi = pullback(phi)
     C_dom, flat_dom = affine_cone(domain(phi))
     C_cod, flat_cod = affine_cone(codomain(phi))
-    pb_res = hom(OO(C_cod), OO(C_dom), flat_dom.(pb_phi.(gens(graded_coordinate_ring(codomain(phi))))), check=false)
+    pb_res = hom(OO(C_cod), OO(C_dom), flat_dom.(pb_phi.(gens(homogeneous_coordinate_ring(codomain(phi))))), check=false)
     phi.map_on_affine_cones = SpecMor(C_dom, C_cod, pb_res)
   end
   return phi.map_on_affine_cones::AbsSpecMor

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Constructors.jl
@@ -5,9 +5,9 @@ function ProjectiveSchemeMor(
     a::Vector{<:RingElem}
   )
   base_ring(X) === base_ring(Y) || error("projective schemes must be defined over the same base ring")
-  Q = graded_coordinate_ring(X)
+  Q = homogeneous_coordinate_ring(X)
   all(x->parent(x)===Q, a) || return ProjectiveSchemeMor(X, Y, Q.(a))
-  P = graded_coordinate_ring(Y)
+  P = homogeneous_coordinate_ring(Y)
   return ProjectiveSchemeMor(X, Y, hom(P, Q, a))
 end
 
@@ -25,10 +25,10 @@ function fiber_product(f::Hecke.Map{DomType, CodType}, P::ProjectiveScheme{DomTy
   Qambient = projective_space(Rnew, symbols(S))
   Snew = ambient_coordinate_ring(Qambient)
   phi = hom(S, Snew, f, gens(Snew))
-  Q = subscheme(Qambient, ideal(graded_coordinate_ring(Qambient), phi.(gens(defining_ideal(P)))))
-  return Q, ProjectiveSchemeMor(Q, P, hom(graded_coordinate_ring(P), 
-                                          graded_coordinate_ring(Q), 
-                                          f, gens(graded_coordinate_ring(Q))))
+  Q = subscheme(Qambient, ideal(homogeneous_coordinate_ring(Qambient), phi.(gens(defining_ideal(P)))))
+  return Q, ProjectiveSchemeMor(Q, P, hom(homogeneous_coordinate_ring(P), 
+                                          homogeneous_coordinate_ring(Q), 
+                                          f, gens(homogeneous_coordinate_ring(Q))))
 end
 
 function fiber_product(
@@ -44,14 +44,14 @@ function fiber_product(
                  pullback(f),
                  gens(ambient_coordinate_ring(Q_ambient))
                 )
-  SQ = graded_coordinate_ring(Q_ambient)
+  SQ = homogeneous_coordinate_ring(Q_ambient)
   I = ideal(SQ, SQ.(help_map.(gens(defining_ideal(P)))))
   Q = subscheme(Q_ambient, I)
   return Q, ProjectiveSchemeMor(Q, P, 
-                                hom(graded_coordinate_ring(P),
-                                    graded_coordinate_ring(Q),
+                                hom(homogeneous_coordinate_ring(P),
+                                    homogeneous_coordinate_ring(Q),
                                     pullback(f),
-                                    gens(graded_coordinate_ring(Q)), 
+                                    gens(homogeneous_coordinate_ring(Q)), 
                                     check=false
                                    )
                                )
@@ -77,10 +77,10 @@ function inclusion_morphism(
   Y = base_scheme(Q)
   f = inclusion_morphism(X, Y) # will throw if X and Y are not compatible
   return ProjectiveSchemeMor(P, Q, 
-                             hom(graded_coordinate_ring(Q),
-                                 graded_coordinate_ring(P),
+                             hom(homogeneous_coordinate_ring(Q),
+                                 homogeneous_coordinate_ring(P),
                                  pullback(f), 
-                                 gens(graded_coordinate_ring(P))
+                                 gens(homogeneous_coordinate_ring(P))
                                 )
                             )
 end
@@ -90,17 +90,17 @@ function inclusion_morphism(P::T, Q::T) where {T<:AbsProjectiveScheme{<:Abstract
   B = base_ring(P)
   A === B || error("can not compare schemes for non-equal base rings") # TODO: Extend by check for canonical maps, once they are available
   return ProjectiveSchemeMor(P, Q, 
-                             hom(graded_coordinate_ring(Q),
-                                 graded_coordinate_ring(P),
-                                 gens(graded_coordinate_ring(P))
+                             hom(homogeneous_coordinate_ring(Q),
+                                 homogeneous_coordinate_ring(P),
+                                 gens(homogeneous_coordinate_ring(P))
                                 )
                             )
 end
 
 identity_map(P::ProjectiveScheme) = ProjectiveSchemeMor(P, P, 
-                                                        hom(graded_coordinate_ring(P),
-                                                            graded_coordinate_ring(P),
-                                                            gens(graded_coordinate_ring(P))
+                                                        hom(homogeneous_coordinate_ring(P),
+                                                            homogeneous_coordinate_ring(P),
+                                                            gens(homogeneous_coordinate_ring(P))
                                                            )
                                                        )
 

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Methods.jl
@@ -2,7 +2,7 @@
 function ==(f::ProjectiveSchemeMor, g::ProjectiveSchemeMor) 
   domain(f) === domain(g) || return false
   codomain(f) === codomain(g) || return false
-  for s in gens(graded_coordinate_ring(codomain(f)))
+  for s in gens(homogeneous_coordinate_ring(codomain(f)))
     iszero(pullback(f)(s) - pullback(g)(s)) || return false
   end
   return true
@@ -36,7 +36,7 @@ of ``X`` and ``Y``, respectively.
   U = affine_charts(X)
   for i in 1:ngens(SX)
     U_i = U[i]
-    dehom = dehomogenize(PX, U_i) # the dehomogenization map SX → 𝒪(Uᵢ)
+    dehom = dehomogenization_map(PX, U_i) # the dehomogenization map SX → 𝒪(Uᵢ)
     for j in 1:ngens(SY)
       y = gens(SY, j)
       denom = dehom(pbf(y))

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Types.jl
@@ -51,8 +51,8 @@ space over the same ring with the identity on the base.
              CodomainType<:ProjectiveScheme, 
              PullbackType<:Map
             }
-    T = graded_coordinate_ring(P)
-    S = graded_coordinate_ring(Q)
+    T = homogeneous_coordinate_ring(P)
+    S = homogeneous_coordinate_ring(Q)
     (S === domain(f) && T === codomain(f)) || error("pullback map incompatible")
     if check
       #TODO: Check map on ideals (not available yet)
@@ -70,8 +70,8 @@ space over the same ring with the identity on the base.
              CodomainType<:ProjectiveScheme, 
              PullbackType<:MPolyAnyMap{<:Any, <:Any, <:Map}
             }
-    T = graded_coordinate_ring(P)
-    S = graded_coordinate_ring(Q)
+    T = homogeneous_coordinate_ring(P)
+    S = homogeneous_coordinate_ring(Q)
     (S === domain(f) && T === codomain(f)) || error("pullback map incompatible")
     if check
       #TODO: Check map on ideals (not available yet)
@@ -92,8 +92,8 @@ space over the same ring with the identity on the base.
              PullbackType<:Map,
              BaseMorType<:SchemeMor
             }
-    T = graded_coordinate_ring(P)
-    S = graded_coordinate_ring(Q)
+    T = homogeneous_coordinate_ring(P)
+    S = homogeneous_coordinate_ring(Q)
     (S === domain(f) && T === codomain(f)) || error("pullback map incompatible")
     pbh = pullback(h)
     OO(domain(h)) == coefficient_ring(T) || error("base scheme map not compatible")

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl
@@ -1,4 +1,4 @@
-export graded_coordinate_ring
+export homogeneous_coordinate_ring
 
 ########################################################################
 # Interface for abstract projective schemes                            #
@@ -20,13 +20,13 @@ function ambient_coordinate_ring(P::AbsProjectiveScheme)
 end
 
 @doc Markdown.doc"""
-    graded_coordinate_ring(P::AbsProjectiveScheme)
+    homogeneous_coordinate_ring(P::AbsProjectiveScheme)
 
 On a projective scheme ``P = Proj(S)`` for a standard 
 graded finitely generated algebra ``S`` this returns ``S``.
 """
-function graded_coordinate_ring(P::AbsProjectiveScheme)
-  return graded_coordinate_ring(underlying_scheme(P))
+function homogeneous_coordinate_ring(P::AbsProjectiveScheme)
+  return homogeneous_coordinate_ring(underlying_scheme(P))
 end
 
 @attr AbsSpec function base_scheme(P::AbsProjectiveScheme)
@@ -38,12 +38,12 @@ end
 
 On ``X = Proj(S) ⊂ ℙʳ_𝕜`` this returns a pair `(C, f)` where ``C = C(X) ⊂ 𝕜ʳ⁺¹`` 
 is the affine cone of ``X`` and ``f : S → 𝒪(C)`` is the morphism of rings 
-from the `graded_coordinate_ring` to the `coordinate_ring` of the affine cone.
+from the `homogeneous_coordinate_ring` to the `coordinate_ring` of the affine cone.
 """
 @attr function affine_cone(
     P::AbsProjectiveScheme{RT}
   ) where {RT<:Union{MPolyRing, MPolyQuoRing, MPolyQuoLocRing, MPolyLocRing}}
-  S = graded_coordinate_ring(P)
+  S = homogeneous_coordinate_ring(P)
   phi = RingFlattening(S)
   A = codomain(phi)
   C = Spec(A)
@@ -55,7 +55,7 @@ end
 @attr function affine_cone(
     P::AbsProjectiveScheme{RT, <:MPolyQuoRing}
   ) where {RT<:Field}
-  S = graded_coordinate_ring(P)
+  S = homogeneous_coordinate_ring(P)
   PS = base_ring(S)
   PP = forget_grading(PS) # the ungraded polynomial ring
   I = modulus(S)
@@ -69,7 +69,7 @@ end
 @attr function affine_cone(
     P::AbsProjectiveScheme{RT, <:MPolyDecRing}
   ) where {RT<:Field}
-  S = graded_coordinate_ring(P)
+  S = homogeneous_coordinate_ring(P)
   PP = forget_grading(S) # the ungraded polynomial ring
   phi = hom(S, PP, gens(PP))
   C = Spec(PP)
@@ -83,7 +83,7 @@ end
 @doc Markdown.doc"""
     base_ring(X::ProjectiveScheme)
 
-On ``X ⊂ ℙʳ(A)`` this returns ``A``.
+On ``X ⊂ ℙʳ_A`` this returns ``A``.
 """
 base_ring(P::ProjectiveScheme) = P.A
 
@@ -123,46 +123,55 @@ end
 @doc Markdown.doc"""
     relative_ambient_dimension(X::ProjectiveScheme)
 
-On ``X ⊂ ℙʳ(A)`` this returns ``r``.
+On ``X ⊂ ℙʳ_A`` this returns ``r``.
 """
 relative_ambient_dimension(P::ProjectiveScheme) = P.r
 
 @doc Markdown.doc"""
-    graded_coordinate_ring(X::ProjectiveScheme)
+    homogeneous_coordinate_ring(X::ProjectiveScheme)
 
-On ``X ⊂ ℙʳ(A)`` this returns ``A[s₀,…,sᵣ]``.
+On ``X ⊂ ℙʳ_A`` this returns ``A[s₀,…,sᵣ]``.
 """
-graded_coordinate_ring(P::ProjectiveScheme) = P.S
+homogeneous_coordinate_ring(P::ProjectiveScheme) = P.S
 
-ambient_coordinate_ring(P::ProjectiveScheme{<:Any, <:Any, <:MPolyQuoRing}) = base_ring(graded_coordinate_ring(P))
-ambient_coordinate_ring(P::ProjectiveScheme{<:Any, <:Any, <:MPolyDecRing}) = graded_coordinate_ring(P)
+ambient_coordinate_ring(P::ProjectiveScheme{<:Any, <:Any, <:MPolyQuoRing}) = base_ring(homogeneous_coordinate_ring(P))
+ambient_coordinate_ring(P::ProjectiveScheme{<:Any, <:Any, <:MPolyDecRing}) = homogeneous_coordinate_ring(P)
 
-### TODO: Replace by the map of generators.
 @doc Markdown.doc"""
     homogeneous_coordinates(X::ProjectiveScheme)
 
-On ``X ⊂ ℙʳ(A)`` this returns a vector with the homogeneous 
+Return the generators of the homogeneous coordinate ring of ``X``.
+"""
+function homogeneous_coordinates(X::ProjectiveScheme)
+  return gens(homogeneous_coordinate_ring(X))
+end
+
+### TODO: Replace by the map of generators.
+@doc Markdown.doc"""
+    homogeneous_coordinates_on_affine_cone(X::ProjectiveScheme)
+
+On ``X ⊂ ℙʳ_A`` this returns a vector with the homogeneous
 coordinates ``[s₀,…,sᵣ]`` as entries where each one of the 
 ``sᵢ`` is a function on the `affine cone` of ``X``.
 """
-function homogeneous_coordinates(P::ProjectiveScheme)
+function homogeneous_coordinates_on_affine_cone(P::ProjectiveScheme)
   if !isdefined(P, :homog_coord)
     C, f = affine_cone(P)
-    P.homog_coord = f.(gens(graded_coordinate_ring(P)))
+    P.homog_coord = f.(gens(homogeneous_coordinate_ring(P)))
   end
   return P.homog_coord
 end
 
-homogeneous_coordinate(P::ProjectiveScheme, i::Int) = homogeneous_coordinates(P)[i]
+homogeneous_coordinate_on_affine_cone(P::ProjectiveScheme, i::Int) = homogeneous_coordinates_on_affine_cone(P)[i]
 
 @doc Markdown.doc"""
     defining_ideal(X::AbsProjectiveScheme)
 
-On ``X ⊂ ℙʳ(A)`` this returns the homogeneous 
+On ``X ⊂ ℙʳ_A`` this returns the homogeneous
 ideal ``I ⊂ A[s₀,…,sᵣ]`` defining ``X``.
 """
-defining_ideal(X::AbsProjectiveScheme{<:Any, <:MPolyDecRing}) = ideal(graded_coordinate_ring(X), Vector{elem_type(graded_coordinate_ring(X))}())
-defining_ideal(X::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}) = modulus(graded_coordinate_ring(X))
+defining_ideal(X::AbsProjectiveScheme{<:Any, <:MPolyDecRing}) = ideal(homogeneous_coordinate_ring(X), Vector{elem_type(homogeneous_coordinate_ring(X))}())
+defining_ideal(X::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}) = modulus(homogeneous_coordinate_ring(X))
 
 ### type getters 
 projective_scheme_type(A::T) where {T<:AbstractAlgebra.Ring} = projective_scheme_type(typeof(A))
@@ -181,64 +190,11 @@ ring_type(::Type{ProjectiveScheme{S, T, U, V}}) where {S, T, U, V} = U
 projective_scheme_type(X::AbsSpec) = projective_scheme_type(typeof(X))
 projective_scheme_type(::Type{T}) where {T<:AbsSpec} = projective_scheme_type(ring_type(T))
 
-#function affine_cone(X::ProjectiveScheme{CRT, CRET, RT, RET}) where {CRT<:Union{MPolyRing, MPolyQuoRing, MPolyLocRing, MPolyQuoLocRing}, CRET, RT, RET}
-#  if !isdefined(X, :C)
-#    Y = base_scheme(X)
-#    A = OO(Y)
-#    kk = base_ring(A)
-#    F = affine_space(kk, symbols(ambient_coordinate_ring(X)))
-#    C, pr_fiber, pr_base = product(F, Y)
-#    X.homog_coord = lift.([pullback(pr_fiber)(u) for u in gens(OO(F))])
-#
-#    S = ambient_coordinate_ring(X)
-#    # use the new mapping types for polynomial rings.
-#    inner_help_map = hom(A, OO(C), [pullback(pr_base)(x) for x in gens(OO(Y))])
-#    help_map = hom(S, OO(C), inner_help_map, [pullback(pr_fiber)(y) for y in gens(OO(F))])
-#
-#    # use the map to convert ideals:
-#    #I = ideal(OO(C), [help_map(g) for g in gens(defining_ideal(X))])
-#    I = help_map(defining_ideal(X))
-#    CX = subscheme(C, I)
-#    set_attribute!(X, :affine_cone, CX) # TODO: Why this doubling?
-#    X.C = get_attribute(X, :affine_cone)
-#    pr_base_res = restrict(pr_base, CX, Y, check=false)
-#    pr_fiber_res = restrict(pr_fiber, CX, F, check=false)
-#
-#    # store the various conversion maps
-#    set_attribute!(X, :homog_to_frac, 
-#                    hom(S, OO(CX), 
-#                          hom(A, OO(CX), [pullback(pr_base_res)(x) for x in gens(OO(Y))]),
-#                          [pullback(pr_fiber_res)(y) for y in gens(OO(F))]
-#                       )
-#                  )
-#    pth = hom(ambient_coordinate_ring(CX), S, vcat(gens(S), S.(gens(A))))
-#    set_attribute!(X, :poly_to_homog, pth)
-##    set_attribute!(X, :frac_to_homog_pair, (f -> (pth(lifted_numerator(OO(CX)(f))), pth(lifted_denominator(OO(CX)(f))))))
-#    X.projection_to_base = pr_base_res
-#  end
-#  return X.C
-#end
+@doc Markdown.doc"""
+    affine_cone(X::AbsProjectiveScheme) -> AbsSpec
 
-#function affine_cone(X::ProjectiveScheme{CRT, CRET, RT, RET}) where {CRT<:AbstractAlgebra.Ring, CRET, RT, RET}
-#  if !isdefined(X, :C)
-#    kk = base_ring(X)
-#    C = affine_space(kk, symbols(ambient_coordinate_ring(X)))
-#    X.homog_coord = gens(OO(C))
-#    S = ambient_coordinate_ring(X)
-#    help_map = hom(S, OO(C), gens(OO(C)))
-#    I = help_map(defining_ideal(X))
-#    CX = subscheme(C, I)
-#
-#    # store the various conversion maps
-#    set_attribute!(X, :homog_to_frac, hom(S, OO(CX), gens(OO(CX))))
-#    pth = hom(base_ring(OO(CX)), S, gens(S))
-#    set_attribute!(X, :poly_to_homog, pth)
-#    set_attribute!(X, :frac_to_homog_pair, (f -> (pth(lift(f)), one(S))))
-#    X.C = CX
-#  end
-#  return X.C
-#end
-
+Return the affine cone of `X`.
+"""
 @attr function affine_cone(
     X::AbsProjectiveScheme{CRT, RT}
   ) where {
@@ -266,6 +222,13 @@ projective_scheme_type(::Type{T}) where {T<:AbsSpec} = projective_scheme_type(ri
   return X.C, psi 
 end
 
+@doc Markdown.doc"""
+    affine_cone(X::AbsProjectiveScheme{<:SpecOpenRing}) -> SpecOpen
+
+Return the affine_cone of `X`.
+
+Note that if the base scheme is not affine, then the affine cone is not affine.
+"""
 @attr function affine_cone(
     X::AbsProjectiveScheme{CRT, RT}
   ) where {
@@ -273,7 +236,7 @@ end
            RT<:MPolyQuoRing
           }
   P = ambient_coordinate_ring(X)
-  S = graded_coordinate_ring(X)
+  S = homogeneous_coordinate_ring(X)
   B = coefficient_ring(P)
   Y = scheme(B)
   U = domain(B)
@@ -305,11 +268,11 @@ end
 end
 
 @attr QQPolyRingElem function hilbert_polynomial(P::AbsProjectiveScheme{<:Field})
-  return hilbert_polynomial(graded_coordinate_ring(P))
+  return hilbert_polynomial(homogeneous_coordinate_ring(P))
 end
 
 @attr ZZRingElem function degree(P::AbsProjectiveScheme{<:Field})
-  return degree(graded_coordinate_ring(P))
+  return degree(homogeneous_coordinate_ring(P))
 end
 
 @attr QQFieldElem function arithmetic_genus(P::AbsProjectiveScheme{<:Field})
@@ -326,8 +289,8 @@ end
     
 Return a `CoveredScheme` ``X`` isomorphic to `P` with standard affine charts given by dehomogenization. 
 
-Use `dehomogenize(P, U)` with `U` one of the `affine_charts` of ``X`` to 
-obtain the dehomogenization map from the `graded_coordinate_ring` of `P` 
+Use [`dehomogenization_map(::ProjectiveScheme, ::AbsSpec)`](@ref) with `U` one of the `affine_charts` of ``X`` to
+obtain the dehomogenization map from the `homogeneous_coordinate_ring` of `P`
 to the `coordinate_ring` of `U`.
 
 # Examples

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl
@@ -289,7 +289,7 @@ end
     
 Return a `CoveredScheme` ``X`` isomorphic to `P` with standard affine charts given by dehomogenization. 
 
-Use [`dehomogenization_map(::ProjectiveScheme, ::AbsSpec)`](@ref) with `U` one of the `affine_charts` of ``X`` to
+Use `dehomogenization_map` with `U` one of the `affine_charts` of ``X`` to
 obtain the dehomogenization map from the `homogeneous_coordinate_ring` of `P`
 to the `coordinate_ring` of `U`.
 

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Constructors.jl
@@ -1,6 +1,6 @@
 
 function subscheme(P::AbsProjectiveScheme, f::RingElem)
-  S = graded_coordinate_ring(P)
+  S = homogeneous_coordinate_ring(P)
   parent(f) === S || return subscheme(P, S(f))
   Q, _ = quo(S, ideal(S, [f]))
   result = ProjectiveScheme(Q)
@@ -15,7 +15,7 @@ function subscheme(
     f::Vector{T}
   ) where {T<:RingElem}
   length(f) == 0 && return P #TODO: Replace P by an honest copy!
-  S = graded_coordinate_ring(P)
+  S = homogeneous_coordinate_ring(P)
   for i in 1:length(f)
     parent(f[i]) === S || return subscheme(P, S.(f))
   end
@@ -30,7 +30,7 @@ end
 function subscheme(P::AbsProjectiveScheme, 
     I::Ideal{T}
   ) where {T<:RingElem}
-  S = graded_coordinate_ring(P)
+  S = homogeneous_coordinate_ring(P)
   base_ring(I) === S || error("ideal does not belong to the correct ring")
   Q, _ = quo(S, I)
   result = ProjectiveScheme(Q)

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
@@ -7,16 +7,15 @@ function dehomogenization_map(
     X::AbsProjectiveScheme{<:Ring}, 
     U::AbsSpec
   )
-  charts = affine_charts(covered_scheme(X))
-  any(x->(x===U), charts) || error("second argument is not an affine chart of the first")
-  # TODO move the previous check after the cache look up as soon as we have WeakKeyIdDict
   if !isdefined(X, :dehomogenization_cache)
-    X.dehomogenization_cache = WeakKeyDict()
+    X.dehomogenization_cache = IdDict()
   end
   cache = X.dehomogenization_cache
   if haskey(cache, U)
     return cache[U]
   end
+  charts = affine_charts(covered_scheme(X))
+  any(x->(x===U), charts) || error("second argument is not an affine chart of the first")
   i = findfirst(k->(charts[k] === U), 1:relative_ambient_dimension(X)+1) - 1
   S = homogeneous_coordinate_ring(X)
   C = default_covering(covered_scheme(X))
@@ -39,7 +38,7 @@ function dehomogenization_map(
     CRT<:Union{MPolyQuoLocRing, MPolyLocRing, MPolyRing, MPolyQuoRing}
   }
   if !isdefined(X, :dehomogenization_cache)
-    X.dehomogenization_cache = WeakKeyDict()
+    X.dehomogenization_cache = IdDict()
   end
   i in 0:relative_ambient_dimension(X) || error("the given integer is not in the admissible range")
   S = homogeneous_coordinate_ring(X)
@@ -72,17 +71,17 @@ function dehomogenization_map(
   ) where {
     CRT<:AbstractAlgebra.Ring
   }
-  i in 0:relative_ambient_dimension(X) || error("the given integer is not in the admissible range")
-  S = homogeneous_coordinate_ring(X)
-  C = default_covering(covered_scheme(X))
-  U = C[i+1]
   if !isdefined(X, :dehomogenization_cache)
-    X.dehomogenization_cache = WeakKeyDict()
+    X.dehomogenization_cache = IdDict()
   end
   cache = X.dehomogenization_cache
   if haskey(cache, U)
     return cache[U]
   end
+  i in 0:relative_ambient_dimension(X) || error("the given integer is not in the admissible range")
+  S = homogeneous_coordinate_ring(X)
+  C = default_covering(covered_scheme(X))
+  U = C[i+1]
   s = vcat(gens(OO(U))[1:i], [one(OO(U))], gens(OO(U))[i+1:relative_ambient_dimension(X)])
   phi = hom(S, OO(U), s)
   cache[U] = phi
@@ -110,25 +109,18 @@ is not a mathematical morphism and, hence, in particular
 not an instance of `Hecke.Map`.
 """
 function homogenization_map(P::AbsProjectiveScheme{<:Any, <:MPolyDecRing}, U::AbsSpec)
-  # TODO: Ideally, one needs to provide this function 
-  # only once for every pair (P, U), so we should think of 
-  # some internal way for caching. The @attr macro is not 
-  # suitable for this, because it is not sensitive for 
-  # which U is put in. 
-  # Find the chart where a belongs to
-  X = covered_scheme(P)
-  i = findfirst(V->(U===V), affine_charts(X))
-  i === nothing && error("the given affine scheme is not one of the standard affine charts")
-  # TODO move the previous check after the cache look up as soon as we have WeakKeyIdDict
   if !isdefined(P, :homogenization_cache)
-    P.homogenization_cache = WeakKeyDict()
+    P.homogenization_cache = IdDict()
   end
   cache = P.homogenization_cache
   if haskey(cache, U)
     return cache[U]
   end
+  # Find the chart where U belongs to
+  X = covered_scheme(P)
+  i = findfirst(V->(U===V), affine_charts(X))
+  i === nothing && error("the given affine scheme is not one of the standard affine charts")
 
-  
   # Determine those variables which come from the homogeneous 
   # coordinates
   S = homogeneous_coordinate_ring(P)
@@ -175,23 +167,17 @@ function homogenization_map(P::AbsProjectiveScheme{<:Any, <:MPolyDecRing}, U::Ab
 end
 
 function homogenization_map(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}, U::AbsSpec)
-  # TODO: Ideally, one needs to provide this function 
-  # only once for every pair (P, U), so we should think of 
-  # some internal way for caching. The @attr macro is not 
-  # suitable for this, because it is not sensitive for 
-  # which U is put in. 
-  # Find the chart where a belongs to
-  X = covered_scheme(P)
-  i = findfirst(V->(U===V), affine_charts(X))
-  i === nothing && error("the given affine scheme is not one of the standard affine charts")
-  # TODO move the previous check after the cache look up as soon as we have WeakKeyIdDict
   if !isdefined(P, :homogenization_cache)
-    P.homogenization_cache = WeakKeyDict()
+    P.homogenization_cache = IdDict()
   end
   cache = P.homogenization_cache
   if haskey(cache, U)
     return cache[U]
   end
+  # Find the chart where U belongs to
+  X = covered_scheme(P)
+  i = findfirst(V->(U===V), affine_charts(X))
+  i === nothing && error("the given affine scheme is not one of the standard affine charts")
   
   # Determine those variables which come from the homogeneous 
   # coordinates

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
@@ -71,6 +71,10 @@ function dehomogenization_map(
   ) where {
     CRT<:AbstractAlgebra.Ring
   }
+  i in 0:relative_ambient_dimension(X) || error("the given integer is not in the admissible range")
+  S = homogeneous_coordinate_ring(X)
+  C = default_covering(covered_scheme(X))
+  U = C[i+1]
   if !isdefined(X, :dehomogenization_cache)
     X.dehomogenization_cache = IdDict()
   end
@@ -78,10 +82,6 @@ function dehomogenization_map(
   if haskey(cache, U)
     return cache[U]
   end
-  i in 0:relative_ambient_dimension(X) || error("the given integer is not in the admissible range")
-  S = homogeneous_coordinate_ring(X)
-  C = default_covering(covered_scheme(X))
-  U = C[i+1]
   s = vcat(gens(OO(U))[1:i], [one(OO(U))], gens(OO(U))[i+1:relative_ambient_dimension(X)])
   phi = hom(S, OO(U), s)
   cache[U] = phi

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
@@ -7,13 +7,22 @@ function dehomogenization_map(
     X::AbsProjectiveScheme{<:Ring}, 
     U::AbsSpec
   )
+  if !isdefined(X, :dehomogenization_cache)
+    X.dehomogenization_cache = WeakKeyDict()
+  end
+  cache = X.dehomogenization_cache
+  if haskey(cache, U)
+    return cache[U]
+  end
   charts = affine_charts(covered_scheme(X))
   any(x->(x===U), charts) || error("second argument is not an affine chart of the first")
   i = findfirst(k->(charts[k] === U), 1:relative_ambient_dimension(X)+1) - 1
   S = homogeneous_coordinate_ring(X)
   C = default_covering(covered_scheme(X))
   s = vcat(gens(OO(U))[1:i], [one(OO(U))], gens(OO(U))[i+1:relative_ambient_dimension(X)])
-  return hom(S, OO(U), s)
+  phi = hom(S, OO(U), s)
+  cache[U] = phi
+  return phi
 end
 
 @doc Markdown.doc"""
@@ -28,13 +37,22 @@ function dehomogenization_map(
   ) where {
     CRT<:Union{MPolyQuoLocRing, MPolyLocRing, MPolyRing, MPolyQuoRing}
   }
+  if !isdefined(X, :dehomogenization_cache)
+    X.dehomogenization_cache = WeakKeyDict()
+  end
   i in 0:relative_ambient_dimension(X) || error("the given integer is not in the admissible range")
   S = homogeneous_coordinate_ring(X)
   C = standard_covering(X)
   U = C[i+1]
+  cache = X.dehomogenization_cache
+  if haskey(cache, U)
+    return cache[U]
+  end
   p = covered_projection_to_base(X)
   s = vcat(gens(OO(U))[1:i], [one(OO(U))], gens(OO(U))[i+1:relative_ambient_dimension(X)])
-  return hom(S, OO(U), pullback(p[U]), s)
+  phi = hom(S, OO(U), pullback(p[U]), s)
+  cache[U] = phi
+  return phi
 end
 
 
@@ -57,8 +75,17 @@ function dehomogenization_map(
   S = homogeneous_coordinate_ring(X)
   C = default_covering(covered_scheme(X))
   U = C[i+1]
+  if !isdefined(X, :dehomogenization_cache)
+    X.dehomogenization_cache = WeakKeyDict()
+  end
+  cache = X.dehomogenization_cache
+  if haskey(cache, U)
+    return cache[U]
+  end
   s = vcat(gens(OO(U))[1:i], [one(OO(U))], gens(OO(U))[i+1:relative_ambient_dimension(X)])
-  return hom(S, OO(U), s)
+  phi = hom(S, OO(U), s)
+  cache[U] = phi
+  return phi
 end
 
 
@@ -87,6 +114,13 @@ function homogenization_map(P::AbsProjectiveScheme{<:Any, <:MPolyDecRing}, U::Ab
   # some internal way for caching. The @attr macro is not 
   # suitable for this, because it is not sensitive for 
   # which U is put in. 
+  if !isdefined(P, :homogenization_cache)
+    P.homogenization_cache = WeakKeyDict()
+  end
+  cache = P.homogenization_cache
+  if haskey(cache, U)
+    return cache[U]
+  end
 
   # Find the chart where a belongs to
   X = covered_scheme(P)
@@ -134,6 +168,7 @@ function homogenization_map(P::AbsProjectiveScheme{<:Any, <:MPolyDecRing}, U::Ab
     end
     return (pp, qq)
   end
+  cache[U] = my_dehom
   return my_dehom
 end
 
@@ -143,7 +178,13 @@ function homogenization_map(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}, U::Ab
   # some internal way for caching. The @attr macro is not 
   # suitable for this, because it is not sensitive for 
   # which U is put in. 
-
+  if !isdefined(P, :homogenization_cache)
+    P.homogenization_cache = WeakKeyDict()
+  end
+  cache = P.homogenization_cache
+  if haskey(cache, U)
+    return cache[U]
+  end
   # Find the chart where a belongs to
   X = covered_scheme(P)
   i = findfirst(V->(U===V), affine_charts(X))
@@ -190,6 +231,7 @@ function homogenization_map(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}, U::Ab
     end
     return (pp, qq)
   end
+  cache[U] = my_dehom
   return my_dehom
 end
 

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
@@ -1,24 +1,35 @@
-function dehomogenize(
+@doc Markdown.doc"""
+    dehomogenization_map(X::AbsProjectiveScheme, U::AbsSpec)
+
+Return the restriction morphism from the graded coordinate ring of ``X`` to `𝒪(U)`.
+"""
+function dehomogenization_map(
     X::AbsProjectiveScheme{<:Ring}, 
     U::AbsSpec
   )
   charts = affine_charts(covered_scheme(X))
   any(x->(x===U), charts) || error("second argument is not an affine chart of the first")
   i = findfirst(k->(charts[k] === U), 1:relative_ambient_dimension(X)+1) - 1
-  S = graded_coordinate_ring(X)
+  S = homogeneous_coordinate_ring(X)
   C = default_covering(covered_scheme(X))
   s = vcat(gens(OO(U))[1:i], [one(OO(U))], gens(OO(U))[i+1:relative_ambient_dimension(X)])
   return hom(S, OO(U), s)
 end
 
-function dehomogenize(
+@doc Markdown.doc"""
+    dehomogenization_map(X::AbsProjectiveScheme, i::AbsSpec)
+
+Return the restriction morphism from the graded coordinate ring of ``X`` to `𝒪(Uᵢ)`.
+Where `Uᵢ` is the `i`-th affine chart of `X`.
+"""
+function dehomogenization_map(
     X::AbsProjectiveScheme{CRT}, 
     i::Int
   ) where {
     CRT<:Union{MPolyQuoLocRing, MPolyLocRing, MPolyRing, MPolyQuoRing}
   }
   i in 0:relative_ambient_dimension(X) || error("the given integer is not in the admissible range")
-  S = graded_coordinate_ring(X)
+  S = homogeneous_coordinate_ring(X)
   C = standard_covering(X)
   U = C[i+1]
   p = covered_projection_to_base(X)
@@ -26,23 +37,24 @@ function dehomogenize(
   return hom(S, OO(U), pullback(p[U]), s)
 end
 
-function dehomogenize(
+
+function dehomogenization_map(
     X::AbsProjectiveScheme{CRT}, 
     U::AbsSpec
   ) where {
     CRT<:Union{MPolyQuoLocRing, MPolyLocRing, MPolyRing, MPolyQuoRing}
   }
-  return dehomogenize(X, X[U][2]-1)
+  return dehomogenization_map(X, X[U][2]-1)
 end
 
-function dehomogenize(
+function dehomogenization_map(
     X::AbsProjectiveScheme{CRT},
     i::Int
   ) where {
     CRT<:AbstractAlgebra.Ring
   }
   i in 0:relative_ambient_dimension(X) || error("the given integer is not in the admissible range")
-  S = graded_coordinate_ring(X)
+  S = homogeneous_coordinate_ring(X)
   C = default_covering(covered_scheme(X))
   U = C[i+1]
   s = vcat(gens(OO(U))[1:i], [one(OO(U))], gens(OO(U))[i+1:relative_ambient_dimension(X)])
@@ -51,15 +63,15 @@ end
 
 
 @doc Markdown.doc"""
-    homogenize(P::AbsProjectiveScheme, U::AbsSpec)
+    homogenization_map(P::AbsProjectiveScheme, U::AbsSpec) -> function
 
 Given an affine chart ``U ⊂ P`` of an `AbsProjectiveScheme` 
 ``P``, return a method ``h`` for the homogenization of elements 
-``a ∈ 𝒪(U)``. 
+``a ∈ 𝒪(U)``.
 
-That means ``h(a)`` returns a pair ``(p, q)`` representing a fraction 
-``p/q ∈ S`` of the `ambient_coordinate_ring` of ``P`` such 
-that ``a`` is the dehomogenization of ``p/q``.
+This means ``h(a)`` returns a fraction ``p/q`` of the
+`homogeneous_coordinate_ring` ``S`` of ``P`` such that ``a`` is the dehomogenization
+of ``p/q``.
 
 **Note:** For the time being, this only works for affine 
 charts which are of the standard form ``sᵢ ≠ 0`` for ``sᵢ∈ S``
@@ -68,12 +80,8 @@ one of the homogeneous coordinates of ``P``.
 **Note:** Since this map returns representatives only, it 
 is not a mathematical morphism and, hence, in particular 
 not an instance of `Hecke.Map`.
-
-**Note:** Since `fraction_field` relies on some implementation 
-of division for the elements, we can not return the fraction 
-directly. 
 """
-function homogenize(P::AbsProjectiveScheme{<:Any, <:MPolyDecRing}, U::AbsSpec)
+function homogenization_map(P::AbsProjectiveScheme{<:Any, <:MPolyDecRing}, U::AbsSpec)
   # TODO: Ideally, one needs to provide this function 
   # only once for every pair (P, U), so we should think of 
   # some internal way for caching. The @attr macro is not 
@@ -87,7 +95,7 @@ function homogenize(P::AbsProjectiveScheme{<:Any, <:MPolyDecRing}, U::AbsSpec)
   
   # Determine those variables which come from the homogeneous 
   # coordinates
-  S = graded_coordinate_ring(P)
+  S = homogeneous_coordinate_ring(P)
   n = ngens(S)
   R = ambient_coordinate_ring(U)
   x = gens(R)
@@ -122,14 +130,14 @@ function homogenize(P::AbsProjectiveScheme{<:Any, <:MPolyDecRing}, U::AbsSpec)
     if deg_a > 0
       return (pp, qq*ss^deg_a)
     elseif deg_a <0
-      return (pp * ss^(-deg_a), qq)
+      return F(pp * ss^(-deg_a), qq)
     end
     return (pp, qq)
   end
   return my_dehom
 end
 
-function homogenize(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}, U::AbsSpec)
+function homogenization_map(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}, U::AbsSpec)
   # TODO: Ideally, one needs to provide this function 
   # only once for every pair (P, U), so we should think of 
   # some internal way for caching. The @attr macro is not 
@@ -143,7 +151,7 @@ function homogenize(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}, U::AbsSpec)
   
   # Determine those variables which come from the homogeneous 
   # coordinates
-  S = graded_coordinate_ring(P)
+  S = homogeneous_coordinate_ring(P)
   n = ngens(S)
   R = ambient_coordinate_ring(U)
   x = gens(R)
@@ -197,32 +205,4 @@ function getindex(X::ProjectiveScheme, U::AbsSpec)
   return nothing, 0
 end
 
-#function dehomogenize(
-#    X::ProjectiveScheme{CRT}, 
-#    U::AbsSpec
-#  ) where {
-#    CRT<:MPolyQuoLocRing
-#  }
-#  # look up U in the coverings of X
-#  cover_of_U, index_of_U = X[U]
-#  Xcov = covered_scheme(X)
-#  S = graded_coordinate_ring(X)
-# 
-#  s = Vector{elem_type(OO(U))}()
-#  if cover_of_U === standard_covering(X)
-#    S = ambient_coordinate_ring(X)
-#    C = standard_covering(X)
-#    p = covered_projection_to_base(X)
-#    s = vcat(gens(OO(U))[1:index_of_U-1], [one(OO(U))], gens(OO(U))[index_of_U:relative_ambient_dimension(X)])
-#    return hom(S, OO(U), pullback(p[U]), s)
-#  else
-#    ref = Xcov[cover_of_U, standard_covering(X)]
-#    V = codomain(ref[U])
-#    index_of_V = standard_covering(X)[V]
-#    t = vcat(gens(OO(V))[1:index_of_V-1], [one(OO(V))], gens(OO(V))[index_of_V:relative_ambient_dimension(X)])
-#    s = pullback(ref[U]).(t)
-#    pb = compose(ref[U], covered_projection_to_base(X)[V])
-#    return hom(S, OO(U), pullback(pb), s)
-#  end
-#end
 

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
@@ -69,9 +69,9 @@ Given an affine chart ``U ⊂ P`` of an `AbsProjectiveScheme`
 ``P``, return a method ``h`` for the homogenization of elements 
 ``a ∈ 𝒪(U)``.
 
-This means ``h(a)`` returns a fraction ``p/q`` of the
-`homogeneous_coordinate_ring` ``S`` of ``P`` such that ``a`` is the dehomogenization
-of ``p/q``.
+This means that ``h(a)`` returns a pair ``(p, q)`` representing a fraction
+``p/q ∈ S`` of the `ambient_coordinate_ring` of ``P`` such
+that ``a`` is the dehomogenization of ``p/q``.
 
 **Note:** For the time being, this only works for affine 
 charts which are of the standard form ``sᵢ ≠ 0`` for ``sᵢ∈ S``
@@ -130,7 +130,7 @@ function homogenization_map(P::AbsProjectiveScheme{<:Any, <:MPolyDecRing}, U::Ab
     if deg_a > 0
       return (pp, qq*ss^deg_a)
     elseif deg_a <0
-      return F(pp * ss^(-deg_a), qq)
+      return (pp * ss^(-deg_a), qq)
     end
     return (pp, qq)
   end

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
@@ -7,6 +7,9 @@ function dehomogenization_map(
     X::AbsProjectiveScheme{<:Ring}, 
     U::AbsSpec
   )
+  charts = affine_charts(covered_scheme(X))
+  any(x->(x===U), charts) || error("second argument is not an affine chart of the first")
+  # TODO move the previous check after the cache look up as soon as we have WeakKeyIdDict
   if !isdefined(X, :dehomogenization_cache)
     X.dehomogenization_cache = WeakKeyDict()
   end
@@ -14,8 +17,6 @@ function dehomogenization_map(
   if haskey(cache, U)
     return cache[U]
   end
-  charts = affine_charts(covered_scheme(X))
-  any(x->(x===U), charts) || error("second argument is not an affine chart of the first")
   i = findfirst(k->(charts[k] === U), 1:relative_ambient_dimension(X)+1) - 1
   S = homogeneous_coordinate_ring(X)
   C = default_covering(covered_scheme(X))
@@ -114,6 +115,11 @@ function homogenization_map(P::AbsProjectiveScheme{<:Any, <:MPolyDecRing}, U::Ab
   # some internal way for caching. The @attr macro is not 
   # suitable for this, because it is not sensitive for 
   # which U is put in. 
+  # Find the chart where a belongs to
+  X = covered_scheme(P)
+  i = findfirst(V->(U===V), affine_charts(X))
+  i === nothing && error("the given affine scheme is not one of the standard affine charts")
+  # TODO move the previous check after the cache look up as soon as we have WeakKeyIdDict
   if !isdefined(P, :homogenization_cache)
     P.homogenization_cache = WeakKeyDict()
   end
@@ -122,10 +128,6 @@ function homogenization_map(P::AbsProjectiveScheme{<:Any, <:MPolyDecRing}, U::Ab
     return cache[U]
   end
 
-  # Find the chart where a belongs to
-  X = covered_scheme(P)
-  i = findfirst(V->(U===V), affine_charts(X))
-  i === nothing && error("the given affine scheme is not one of the standard affine charts")
   
   # Determine those variables which come from the homogeneous 
   # coordinates
@@ -178,6 +180,11 @@ function homogenization_map(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}, U::Ab
   # some internal way for caching. The @attr macro is not 
   # suitable for this, because it is not sensitive for 
   # which U is put in. 
+  # Find the chart where a belongs to
+  X = covered_scheme(P)
+  i = findfirst(V->(U===V), affine_charts(X))
+  i === nothing && error("the given affine scheme is not one of the standard affine charts")
+  # TODO move the previous check after the cache look up as soon as we have WeakKeyIdDict
   if !isdefined(P, :homogenization_cache)
     P.homogenization_cache = WeakKeyDict()
   end
@@ -185,10 +192,6 @@ function homogenization_map(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}, U::Ab
   if haskey(cache, U)
     return cache[U]
   end
-  # Find the chart where a belongs to
-  X = covered_scheme(P)
-  i = findfirst(V->(U===V), affine_charts(X))
-  i === nothing && error("the given affine scheme is not one of the standard affine charts")
   
   # Determine those variables which come from the homogeneous 
   # coordinates

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Types.jl
@@ -20,8 +20,8 @@ ideal ``I`` in the graded ring ``A[s₀,…,sᵣ]`` and the latter is of type
   Y::Scheme # the base scheme
   projection_to_base::SchemeMor
   homog_coord::Vector # the homogeneous coordinates as functions on the affine cone
-  homogenization_cache::WeakKeyDict
-  dehomogenization_cache::WeakKeyDict
+  homogenization_cache::IdDict # TODO make it a WeakIdDict once available
+  dehomogenization_cache::IdDict
 
   function ProjectiveScheme(S::MPolyDecRing)
     all(x->(total_degree(x) == 1), gens(S)) || error("ring is not standard graded")

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Types.jl
@@ -20,6 +20,8 @@ ideal ``I`` in the graded ring ``A[s₀,…,sᵣ]`` and the latter is of type
   Y::Scheme # the base scheme
   projection_to_base::SchemeMor
   homog_coord::Vector # the homogeneous coordinates as functions on the affine cone
+  homogenization_cache::WeakKeyDict
+  dehomogenization_cache::WeakKeyDict
 
   function ProjectiveScheme(S::MPolyDecRing)
     all(x->(total_degree(x) == 1), gens(S)) || error("ring is not standard graded")

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -405,7 +405,6 @@ export deglex
 export degree
 export degrevlex
 export dehomogenization
-export dehomogenize
 export dehomogenization_map
 export del_pezzo_polytope
 export del_pezzo_surface

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -406,6 +406,7 @@ export degree
 export degrevlex
 export dehomogenization
 export dehomogenize
+export dehomogenization_map
 export del_pezzo_polytope
 export del_pezzo_surface
 export deletion

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -742,15 +742,20 @@ function jacobi_ideal(f::MPolyRingElem)
 end
 
 @doc Markdown.doc"""
-    jacobi_matrix(g::Vector{<:MPolyRingElem})
+    jacobi_matrix([R::MPolyRing,] g::Vector{<:MPolyRingElem})
 
-Given an array ``g=[f_1,...,f_m]`` of polynomials over the same base ring,
+Given an array ``g=[f_1,...,f_m]`` of polynomials over the same base ring `R`,
 this function returns the Jacobian matrix ``J=(\partial_{x_i}f_j)_{i,j}`` of ``g``.
 """
 function jacobi_matrix(g::Vector{<:MPolyRingElem})
+  @req length(g) > 0 "specify the common parent as first argument"
   R = parent(g[1])
+  return jacobi_matrix(R, g)
+end
+
+function jacobi_matrix(R::MPolyRing, g::Vector{<:MPolyRingElem})
   n = nvars(R)
-  @assert all(x->parent(x) == R, g)
+  @req all(x->parent(x) === R, g) "polynomials must be elements of R"
   return matrix(R, n, length(g), [derivative(x, i) for i=1:n for x = g])
 end
 

--- a/test/AlgebraicGeometry/Schemes/CartierDivisor.jl
+++ b/test/AlgebraicGeometry/Schemes/CartierDivisor.jl
@@ -1,6 +1,6 @@
 @testset "pullbacks of Cartier divisors" begin 
   P = projective_space(QQ, 2)
-  SP = graded_coordinate_ring(P)
+  SP = homogeneous_coordinate_ring(P)
   (x, y, z) = gens(SP)
 
   A = [1 2 4; 1 3 9; 1 5 25]
@@ -14,7 +14,7 @@
   D = IdDict{AbsSpec, RingElem}()
   H = x^2 + y^2 + z^2
   for U in affine_charts(X)
-    D[U] = dehomogenize(P, U)(H)
+    D[U] = dehomogenization_map(P, U)(H)
   end
 
   C = oscar.EffectiveCartierDivisor(X, D)
@@ -43,10 +43,10 @@ end
 
 @testset "Arithmetic of CartierDivisors" begin
   IP = projective_space(QQ, 3)
-  (x,y,z,w) = gens(graded_coordinate_ring(IP))
+  (x,y,z,w) = gens(homogeneous_coordinate_ring(IP))
   f = x^4 + y^4 + z^4 + w^4
   IPX = subscheme(IP, f)
-  S = graded_coordinate_ring(IPX)
+  S = homogeneous_coordinate_ring(IPX)
   (x, y, z, w) = gens(S)
   X = covered_scheme(IPX)
   h = (x+y+z+w)^3
@@ -60,7 +60,7 @@ end
 
 @testset "conversion of Cartier to Weil divisors" begin
   IP2 = projective_space(QQ, ["x", "y", "z"])
-  S = graded_coordinate_ring(IP2)
+  S = homogeneous_coordinate_ring(IP2)
   (x,y,z) = gens(S)
   I = ideal(S, x^2*y^3*(x+y+z))
   C = oscar.effective_cartier_divisor(IP2, gens(I)[1])

--- a/test/AlgebraicGeometry/Schemes/CoherentSheaves.jl
+++ b/test/AlgebraicGeometry/Schemes/CoherentSheaves.jl
@@ -45,7 +45,7 @@ end
 
 @testset "Pushforward of modules" begin
   IP = projective_space(QQ, ["x", "y", "z"])
-  S = graded_coordinate_ring(IP)
+  S = homogeneous_coordinate_ring(IP)
   (x,y,z) = gens(S)
   f = z^2 - x*y
   I = ideal(S, f)
@@ -66,15 +66,15 @@ end
   TC1 = incTC(U[1])
   @test TC1 === incTC(U[1])
   @test incTC(U[1]) isa SubquoModule
-  U21 = PrincipalOpenSubset(U[2], dehomogenize(IP, 1)(x))
-  U321 = PrincipalOpenSubset(U[3], dehomogenize(IP, 2)(x*y))
+  U21 = PrincipalOpenSubset(U[2], dehomogenization_map(IP, 1)(x))
+  U321 = PrincipalOpenSubset(U[3], dehomogenization_map(IP, 2)(x*y))
   @test incTC(U[1], U321)(TC1[1]) == incTC(U21, U321)(incTC(U[1], U21)(TC1[1]))
 end
 
 @testset "pullbacks of modules" begin
   # Note: The PullbackSheafs are not yet fully functional!!!
   IP = projective_space(QQ, 2)
-  S = graded_coordinate_ring(IP)
+  S = homogeneous_coordinate_ring(IP)
   X = covered_scheme(IP)
   (x,y,z) = gens(S)
   f = x^3 + y^3 + z^3
@@ -120,7 +120,7 @@ end
 
 @testset "projectivization of vector bundles" begin
   IP = projective_space(QQ, ["x", "y", "z", "w"])
-  S = graded_coordinate_ring(IP)
+  S = homogeneous_coordinate_ring(IP)
   (x,y,z,w) = gens(S)
   f = x^4 + y^4 + z^4 + w^4
   IPC = subscheme(IP, f)
@@ -156,7 +156,7 @@ end
 
 @testset "direct sums of sheaves" begin
   IP = projective_space(QQ, ["x", "y", "z", "w"])
-  S = graded_coordinate_ring(IP)
+  S = homogeneous_coordinate_ring(IP)
   (x, y, z, w) = gens(S)
   f = x^4 + y^4 + z^4 + w^4
   IPX = subscheme(IP, f)

--- a/test/AlgebraicGeometry/Schemes/CoveredProjectiveSchemes.jl
+++ b/test/AlgebraicGeometry/Schemes/CoveredProjectiveSchemes.jl
@@ -1,7 +1,7 @@
 @testset "blowups" begin
   P = projective_space(QQ, ["x", "y", "z", "w"])
   X = covered_scheme(P)
-  S = graded_coordinate_ring(P)
+  S = homogeneous_coordinate_ring(P)
   (x, y, z, w) = gens(S)
   M = S[x y z; y z w]
   I = ideal(S, minors(M, 2))

--- a/test/AlgebraicGeometry/Schemes/CoveredScheme.jl
+++ b/test/AlgebraicGeometry/Schemes/CoveredScheme.jl
@@ -2,7 +2,7 @@
   R, (x,y) = polynomial_ring(QQ, ["x", "y"])
   X = subscheme(Spec(R), [x^2+y^2])
   P = projective_space(X, 3)
-  S = graded_coordinate_ring(P)
+  S = homogeneous_coordinate_ring(P)
   (u, v) = gens(S)[1], gens(S)[2]
   h = u^3 
   h = u^3 + u^2
@@ -10,14 +10,14 @@
   h = u^3 + u^2*v - OO(X)(x)*v^3
   Z = subscheme(P, h)
   C = standard_covering(Z)
-  f = dehomogenize(Z, 1)
+  f = dehomogenization_map(Z, 1)
   @test f(u) == gens(OO(C[2]))[1]
 end
 
 @testset "Covered schemes 2" begin
   P = projective_space(QQ, ["x", "y", "z", "w"])
   Pc = covered_scheme(P)
-  S = graded_coordinate_ring(P)
+  S = homogeneous_coordinate_ring(P)
   (x,y,z,w) = gens(S)
   X = subscheme(P, [x*w - y*z])
   @test dim(Pc)==3
@@ -41,7 +41,7 @@ end
 
 @testset "covered schemes 3" begin
   IP2 = projective_space(QQ, 2, var_name="u")
-  S = graded_coordinate_ring(IP2)
+  S = homogeneous_coordinate_ring(IP2)
   u0, u1, u2 = gens(S)
   C = subscheme(IP2, u0^2 - u1*u2)
 
@@ -118,7 +118,7 @@ end
 
 @testset "closed embeddings and singular loci" begin
   IP2 = projective_space(QQ, ["x", "y", "z"])
-  S = graded_coordinate_ring(IP2)
+  S = homogeneous_coordinate_ring(IP2)
   (x, y, z) = gens(S)
   f = x^2*z + y^3 - y^2*z
   C = subscheme(IP2, ideal(S, f))
@@ -134,7 +134,7 @@ end
 @testset "is_integral" begin
   P = projective_space(QQ, 2)
 
-  S = graded_coordinate_ring(P)
+  S = homogeneous_coordinate_ring(P)
   u, v, w = gens(S)
   I = ideal(S, [u*(v^2 + w^2 + u^2)])
 
@@ -187,13 +187,13 @@ end
 
 @testset "conversion of morphisms" begin
   P = projective_space(QQ, 2)
-  SP = graded_coordinate_ring(P)
+  SP = homogeneous_coordinate_ring(P)
   (x, y, z) = gens(SP)
   m = ideal(SP, gens(SP))
   m3 = m^3
   n = ngens(m3)
   Q = projective_space(QQ, n-1)
-  SQ = graded_coordinate_ring(Q)
+  SQ = homogeneous_coordinate_ring(Q)
   phi = hom(SQ, SP, gens(m3))
   f = ProjectiveSchemeMor(P, Q, phi)
   f_cov = covered_scheme_morphism(f)

--- a/test/AlgebraicGeometry/Schemes/FunctionFields.jl
+++ b/test/AlgebraicGeometry/Schemes/FunctionFields.jl
@@ -7,7 +7,7 @@
   @test !is_irreducible(Spec(R, ideal(R, x*y), units_of(R)))
 
   P = projective_space(QQ, 2)
-  S = graded_coordinate_ring(P)
+  S = homogeneous_coordinate_ring(P)
   C = subscheme(P, ideal(S, S[1]*S[2]-S[3]^2))
   Ccov = covered_scheme(C)
 
@@ -110,7 +110,7 @@ end
   @test K(h) == (f+2*g-5)//g
 
   P2 = projective_space(QQ,2)
-  S = graded_coordinate_ring(P2)
+  S = homogeneous_coordinate_ring(P2)
   s0 = gens(S)[1]
   X = subscheme(P2, ideal(S, s0))
   Xc = covered_scheme(X)

--- a/test/AlgebraicGeometry/Schemes/IdealSheaves.jl
+++ b/test/AlgebraicGeometry/Schemes/IdealSheaves.jl
@@ -53,7 +53,7 @@ end
 @testset "ideal sheaves II" begin
   IP2 = projective_space(QQ, 2)
   X = covered_scheme(IP2)
-  S = graded_coordinate_ring(IP2)
+  S = homogeneous_coordinate_ring(IP2)
   (u,v,w) = gens(S)
   Ihom = ideal(S, u^2 - v*w)
   I = IdealSheaf(IP2, Ihom)
@@ -85,13 +85,13 @@ end
 
 @testset "pullbacks of ideal sheaves" begin
   P = projective_space(QQ, 2)
-  SP = graded_coordinate_ring(P)
+  SP = homogeneous_coordinate_ring(P)
   (x, y, z) = gens(SP)
   m = ideal(SP, gens(SP))
   m3 = m^3
   n = ngens(m3)
   Q = projective_space(QQ, n-1)
-  SQ = graded_coordinate_ring(Q)
+  SQ = homogeneous_coordinate_ring(Q)
   phi = hom(SQ, SP, gens(m3))
   f = ProjectiveSchemeMor(P, Q, phi)
   f_cov = covered_scheme_morphism(f)
@@ -114,7 +114,7 @@ end
 
 @testset "primary decomposition of ideal sheaves" begin
   IP2 = projective_space(QQ, ["x", "y", "z"])
-  S = graded_coordinate_ring(IP2)
+  S = homogeneous_coordinate_ring(IP2)
   (x,y,z) = gens(S)
   I = ideal(S, x^2*y^3*(x+y+z))
   II = IdealSheaf(IP2, I)

--- a/test/AlgebraicGeometry/Schemes/ProjectiveSchemes.jl
+++ b/test/AlgebraicGeometry/Schemes/ProjectiveSchemes.jl
@@ -8,8 +8,8 @@
   X = ProjectiveScheme(S, I)
   CX, id = affine_cone(X)
   p = covered_projection_to_base(X)
-  @test OO(CX).(homogeneous_coordinates(X)) == [id(g) for g in gens(S)]
-  hc = homogeneous_coordinates(X)
+  @test OO(CX).(Oscar.homogeneous_coordinates_on_affine_cone(X)) == [id(g) for g in gens(S)]
+  hc = Oscar.homogeneous_coordinates_on_affine_cone(X)
 
   phi = ProjectiveSchemeMor(X, X, [-u, -v])
 
@@ -23,8 +23,8 @@
   I = ideal(S, [u])
   X = ProjectiveScheme(S, I)
   CX, id = affine_cone(X)
-  @test OO(CX).(homogeneous_coordinates(X)) == [id(g) for g in gens(S)]
-  hc = homogeneous_coordinates(X)
+  @test OO(CX).(Oscar.homogeneous_coordinates_on_affine_cone(X)) == [id(g) for g in gens(S)]
+  hc = Oscar.homogeneous_coordinates_on_affine_cone(X)
 
   phi = ProjectiveSchemeMor(X, X, [u^2, v^2])
 
@@ -52,7 +52,7 @@ end
   X = Spec(R, I)
   U = SpecOpen(X, [x, y])
   P = projective_space(OO(U), 1)
-  S = graded_coordinate_ring(P)
+  S = homogeneous_coordinate_ring(P)
   Y = subscheme(P, [OO(U)(x)*S[1]- OO(U)(y)*S[2], OO(U)(z)*S[1] - OO(U)(x)*S[2]]) # Coercion needs to be carried out manually.
   C, phi = affine_cone(Y)
   s1 = phi(S[2])
@@ -65,7 +65,7 @@ end
 
 @testset "projective schemes as covered schemes" begin
   P3 = projective_space(QQ,3)
-  S = graded_coordinate_ring(P3)
+  S = homogeneous_coordinate_ring(P3)
   F = subscheme(P3,ideal(S,S[1]^4+S[2]^4+S[3]^4+S[4]^4))
   Fc = covered_scheme(F)
   U = patches(Fc)[1]
@@ -76,13 +76,13 @@ end
 @testset "Fermat lines" begin
   K,a = cyclotomic_field(8)
   P3 = projective_space(K,3)
-  S = graded_coordinate_ring(P3)
+  S = homogeneous_coordinate_ring(P3)
   F = subscheme(P3, ideal(S, S[1]^4 + S[2]^4 + S[3]^4 + S[4]^4))
   Fc = covered_scheme(F)
   U = patches(Fc)[1]
   V = patches(Fc)[2]
   oscar.intersect_in_covering(U,V,Fc[1]);
-  SF = graded_coordinate_ring(F)
+  SF = homogeneous_coordinate_ring(F)
   line = subscheme(F, ideal(SF, [SF[1]+a*SF[2],SF[3]+a*SF[4]]))
   groebner_basis(defining_ideal(line))
 end
@@ -150,10 +150,10 @@ end
 #  @test base_ring_type(IP2_U) == typeof(OO(U))
 #  @test base_ring_type(IP2_UY) == typeof(OO(UY))
 # 
-#  @test ring_type(IP2_X) == typeof(graded_coordinate_ring(IP2_X))
-#  @test ring_type(IP2_Y) == typeof(graded_coordinate_ring(IP2_Y))
-#  @test ring_type(IP2_U) == typeof(graded_coordinate_ring(IP2_U))
-#  @test ring_type(IP2_UY) == typeof(graded_coordinate_ring(IP2_UY))
+#  @test ring_type(IP2_X) == typeof(homogeneous_coordinate_ring(IP2_X))
+#  @test ring_type(IP2_Y) == typeof(homogeneous_coordinate_ring(IP2_Y))
+#  @test ring_type(IP2_U) == typeof(homogeneous_coordinate_ring(IP2_U))
+#  @test ring_type(IP2_UY) == typeof(homogeneous_coordinate_ring(IP2_UY))
 
   CX, _ = affine_cone(IP2_X)
   CY, _ = affine_cone(IP2_Y)
@@ -192,61 +192,61 @@ end
 
   map_on_affine_cones(map)
 
-  IP2_Xh = subscheme(IP2_X, gens(graded_coordinate_ring(IP2_X))[1])
-  ProjectiveSchemeMor(IP2_Xh, IP2_X, gens(graded_coordinate_ring(IP2_Xh)))
-  IP2_Yh = subscheme(IP2_Y, gens(graded_coordinate_ring(IP2_Y))[1])
-  ProjectiveSchemeMor(IP2_Yh, IP2_Y, gens(graded_coordinate_ring(IP2_Yh)))
-  IP2_Uh = subscheme(IP2_U, gens(graded_coordinate_ring(IP2_U))[1])
-  ProjectiveSchemeMor(IP2_Uh, IP2_U, gens(graded_coordinate_ring(IP2_Uh)))
-  IP2_UYh = subscheme(IP2_UY, gens(graded_coordinate_ring(IP2_UY))[1])
-  ProjectiveSchemeMor(IP2_UYh, IP2_UY, gens(graded_coordinate_ring(IP2_UYh)))
-  IP2_Wh = subscheme(IP2_W, gens(graded_coordinate_ring(IP2_W))[1])
-  ProjectiveSchemeMor(IP2_Wh, IP2_W, gens(graded_coordinate_ring(IP2_Wh)))
+  IP2_Xh = subscheme(IP2_X, gens(homogeneous_coordinate_ring(IP2_X))[1])
+  ProjectiveSchemeMor(IP2_Xh, IP2_X, gens(homogeneous_coordinate_ring(IP2_Xh)))
+  IP2_Yh = subscheme(IP2_Y, gens(homogeneous_coordinate_ring(IP2_Y))[1])
+  ProjectiveSchemeMor(IP2_Yh, IP2_Y, gens(homogeneous_coordinate_ring(IP2_Yh)))
+  IP2_Uh = subscheme(IP2_U, gens(homogeneous_coordinate_ring(IP2_U))[1])
+  ProjectiveSchemeMor(IP2_Uh, IP2_U, gens(homogeneous_coordinate_ring(IP2_Uh)))
+  IP2_UYh = subscheme(IP2_UY, gens(homogeneous_coordinate_ring(IP2_UY))[1])
+  ProjectiveSchemeMor(IP2_UYh, IP2_UY, gens(homogeneous_coordinate_ring(IP2_UYh)))
+  IP2_Wh = subscheme(IP2_W, gens(homogeneous_coordinate_ring(IP2_W))[1])
+  ProjectiveSchemeMor(IP2_Wh, IP2_W, gens(homogeneous_coordinate_ring(IP2_Wh)))
 
   incYtoX = inclusion_morphism(Y, X)
-  h = hom(graded_coordinate_ring(IP2_X), graded_coordinate_ring(IP2_Y), pullback(incYtoX), gens(graded_coordinate_ring(IP2_Y)))
+  h = hom(homogeneous_coordinate_ring(IP2_X), homogeneous_coordinate_ring(IP2_Y), pullback(incYtoX), gens(homogeneous_coordinate_ring(IP2_Y)))
   YtoX = ProjectiveSchemeMor(IP2_Y, IP2_X, 
                              h, 
                              incYtoX
                             );
   @test YtoX == inclusion_morphism(IP2_Y, IP2_X)
   IP2_Y2, map = fiber_product(incYtoX, IP2_X)
-  h2 = hom(graded_coordinate_ring(IP2_Y2), graded_coordinate_ring(IP2_Y), gens(graded_coordinate_ring(IP2_Y)))
+  h2 = hom(homogeneous_coordinate_ring(IP2_Y2), homogeneous_coordinate_ring(IP2_Y), gens(homogeneous_coordinate_ring(IP2_Y)))
   YtoY2 = ProjectiveSchemeMor(IP2_Y, IP2_Y2, h2)
   @test compose(YtoY2, map) == YtoX
 
   incUtoX = inclusion_morphism(U, X)
-  h = hom(graded_coordinate_ring(IP2_X), graded_coordinate_ring(IP2_U), pullback(incUtoX), gens(graded_coordinate_ring(IP2_U)))
+  h = hom(homogeneous_coordinate_ring(IP2_X), homogeneous_coordinate_ring(IP2_U), pullback(incUtoX), gens(homogeneous_coordinate_ring(IP2_U)))
   UtoX = ProjectiveSchemeMor(IP2_U, IP2_X, 
                              h, 
                              incUtoX
                             );
   @test UtoX == inclusion_morphism(IP2_U, IP2_X)
   IP2_U2, map = fiber_product(incUtoX, IP2_X)
-  h2 = hom(graded_coordinate_ring(IP2_U2), graded_coordinate_ring(IP2_U), gens(graded_coordinate_ring(IP2_U)))
+  h2 = hom(homogeneous_coordinate_ring(IP2_U2), homogeneous_coordinate_ring(IP2_U), gens(homogeneous_coordinate_ring(IP2_U)))
   UtoU2 = ProjectiveSchemeMor(IP2_U, IP2_U2, h2)
   @test compose(UtoU2, map) == UtoX
 
   incUYtoY = inclusion_morphism(UY, Y)
-  h = hom(graded_coordinate_ring(IP2_Y), graded_coordinate_ring(IP2_UY), pullback(incUYtoY), gens(graded_coordinate_ring(IP2_UY)))
+  h = hom(homogeneous_coordinate_ring(IP2_Y), homogeneous_coordinate_ring(IP2_UY), pullback(incUYtoY), gens(homogeneous_coordinate_ring(IP2_UY)))
   UYtoY = ProjectiveSchemeMor(IP2_UY, IP2_Y, 
                               h, 
                               incUYtoY
                              );
   @test UYtoY == inclusion_morphism(IP2_UY, IP2_Y)
   IP2_UY2, map = fiber_product(incUYtoY, IP2_Y)
-  h2 = hom(graded_coordinate_ring(IP2_UY2), graded_coordinate_ring(IP2_UY), gens(graded_coordinate_ring(IP2_UY)))
+  h2 = hom(homogeneous_coordinate_ring(IP2_UY2), homogeneous_coordinate_ring(IP2_UY), gens(homogeneous_coordinate_ring(IP2_UY)))
   UYtoUY2 = ProjectiveSchemeMor(IP2_UY, IP2_UY2, h2)
   @test compose(UYtoUY2, map) == UYtoY
 
   incUYtoX = inclusion_morphism(UY, X)
-  h = hom(graded_coordinate_ring(IP2_X), graded_coordinate_ring(IP2_UY), pullback(incUYtoX), gens(graded_coordinate_ring(IP2_UY)))
+  h = hom(homogeneous_coordinate_ring(IP2_X), homogeneous_coordinate_ring(IP2_UY), pullback(incUYtoX), gens(homogeneous_coordinate_ring(IP2_UY)))
   UYtoX = ProjectiveSchemeMor(IP2_UY, IP2_X, 
                               h, 
                               incUYtoX
                              );
   IP2_UY2, map = fiber_product(incUYtoX, IP2_X)
-  h2 = hom(graded_coordinate_ring(IP2_UY2), graded_coordinate_ring(IP2_UY), gens(graded_coordinate_ring(IP2_UY)))
+  h2 = hom(homogeneous_coordinate_ring(IP2_UY2), homogeneous_coordinate_ring(IP2_UY), gens(homogeneous_coordinate_ring(IP2_UY)))
   UYtoUY2 = ProjectiveSchemeMor(IP2_UY, IP2_UY2, h2)
   @test compose(UYtoUY2, map) == UYtoX
 
@@ -271,7 +271,7 @@ end
   I = ideal(S, x^2 - y*z)
   Q, _ = quo(S, I)
   C = ProjectiveScheme(Q)
-  @test graded_coordinate_ring(C) === Q
+  @test homogeneous_coordinate_ring(C) === Q
   @test dim(C) == 1
   @test degree(C) == 2
   @test is_smooth(C)
@@ -282,7 +282,7 @@ end
   I = ideal(S, [x^4 + y^4 + z^4 + w^4])
   Q, _ = quo(S, I)
   Y = ProjectiveScheme(Q)
-  @test graded_coordinate_ring(Y) === Q
+  @test homogeneous_coordinate_ring(Y) === Q
   @test dim(Y) == 2
   @test degree(Y) == 4
   @test is_smooth(Y)

--- a/test/AlgebraicGeometry/Schemes/VectorBundles.jl
+++ b/test/AlgebraicGeometry/Schemes/VectorBundles.jl
@@ -1,6 +1,6 @@
 @testset "trivializations of coherent sheaves" begin
   IP2 = projective_space(QQ, 2)
-  S = graded_coordinate_ring(IP2)
+  S = homogeneous_coordinate_ring(IP2)
   (x,y,z) = gens(S)
   f = x^2 + y*z
   IPC = subscheme(IP2, f)
@@ -20,7 +20,7 @@
   @test oscar.trivializing_covering(TC) isa Covering
 
   IP4 = projective_space(QQ, 4)
-  S = graded_coordinate_ring(IP4)
+  S = homogeneous_coordinate_ring(IP4)
   (x,y,z,u,v) = gens(S)
   A = S[x y z; u v x]
   I = ideal(S, minors(A, 2))

--- a/test/AlgebraicGeometry/Schemes/WeilDivisor.jl
+++ b/test/AlgebraicGeometry/Schemes/WeilDivisor.jl
@@ -107,7 +107,7 @@ end
 
 @testset "linear systems" begin
   P2 = projective_space(QQ, 2)
-  S = graded_coordinate_ring(P2)
+  S = homogeneous_coordinate_ring(P2)
   X = covered_scheme(P2)
   I = IdealSheaf(P2, [S[1]])
   D = WeilDivisor(I)
@@ -131,11 +131,11 @@ end
 
 @testset "WeilDivisor" begin
   P2 = projective_space(QQ, 2)
-  S = graded_coordinate_ring(P2)
+  S = homogeneous_coordinate_ring(P2)
   (x, y, z) = gens(S)
   I = ideal(S, x^3 + y^3 + z^3)
   C = subscheme(P2, I)
-  SC = graded_coordinate_ring(C)
+  SC = homogeneous_coordinate_ring(C)
   (x, y, z) = gens(SC)
   X = covered_scheme(C)
   H = ideal(SC, SC.([x, y+z]))


### PR DESCRIPTION
`graded_coordinate_ring` is now called `homogeneous_coordinate_ring` 
and some further renamings. Further cleanup will come in later in other pull requests.