### PR TITLE
Serialization: remove eval fallback in decodeType

### DIFF
--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -68,18 +68,7 @@ function encodeType(::Type{T}) where T
 end
 
 function decodeType(input::String)
-    if haskey(reverseTypeMap, input)
-        return reverseTypeMap[input]
-    else
-        # As a default, parse the type from the string.
-        #
-        # WARNING: Never deserialize data from an untrusted source, as this
-        # parsing is insecure and potentially malicious code could be
-        # entered here. (also computationally expensive)
-        # Standard Oscar tests should never pass this line
-        @warn "Serialization: Generic Decoding of type $input"
-        eval(Meta.parse(input))
-
+    get(reverseTypeMap, input) do
         error("unsupported type '$input' for decoding")
     end
 end


### PR DESCRIPTION
This is a security nightmare. It also should not be necessary anymore.

Or maybe it *is* still necessary for something, then this will help us
find out for what, and then we can get rid of that, until this PR here
can be merged.
