### PR TITLE
add `Oscar.test_experimental_module`

### DIFF
--- a/docs/src/DeveloperDocumentation/new_developers.md
+++ b/docs/src/DeveloperDocumentation/new_developers.md
@@ -99,7 +99,7 @@ random values.  The code may also directly create and use such a random source.
 The current seed will be printed at the beginning of the testsuite, it is fixed
 to 42 in the CI. It can be changed by setting `ENV["OSCAR_RANDOM_SEED"]` (for
 the testsuite running in a separate process) or by using `Oscar.set_seed!` (for
-the current session, e.g. `Oscar.test_module("something.jl", false)`).
+the current session, e.g. `Oscar.test_module("something", new=false)`).
 
 ```@docs
 Oscar.test_module

--- a/docs/src/Experimental/intro.md
+++ b/docs/src/Experimental/intro.md
@@ -48,6 +48,12 @@ have any documentation yet.
     introduction of this structure. Thus we mentioned `FTheoryTools` and
     `PlaneCurve` as projects having adopted to the new standard.
 
+### Useful functions for development
+Apart from the hints in the [Introduction for new developers](@ref), there are some more specialized functions for the structure of the `experimental` folder.
+```@docs
+Oscar.test_experimental_module
+```
+
 ## Procedure for adding a new feature
 Ideally we envision the procedure to follow along the following lines.
 


### PR DESCRIPTION
While changing my experimental module to the structure from #2146, I noticed that `Oscar.test_module` feels kind of weird to use due to the fixed prefix `test/`. Thus I attempted to add an alternative `Oscar.test_experimental_module` and put it in the new experimental docs as well.

cc @lkastner 