### PR TITLE
provide `character_table` functionality for `GrpAbFinGen`

### DIFF
--- a/docs/src/Groups/group_characters.md
+++ b/docs/src/Groups/group_characters.md
@@ -173,7 +173,8 @@ arithmetic operations:
 
 ```@docs
 scalar_product
-induced_class_function
+induce(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable)
+restrict(chi::GAPGroupClassFunction, subtbl::GAPGroupCharacterTable)
 ```
 
 ## Symmetrizations of group characters

--- a/docs/src/Groups/subgroups.md
+++ b/docs/src/Groups/subgroups.md
@@ -22,7 +22,7 @@ sub(G::GAPGroup, gens::AbstractVector{<:GAPGroupElem}; check::Bool = true)
 is_subset(H::T, G::T) where T <: GAPGroup
 is_subgroup(H::T, G::T) where T <: GAPGroup
 embedding(H::T, G::T) where T <: GAPGroup
-index(G::T, H::T) where T <: GAPGroup
+index(G::T, H::T) where T <: Union{GAPGroup, GrpAbFinGen}
 is_maximal_subgroup(H::T, G::T) where T <: GAPGroup
 is_normalized_by(H::T, G::T) where T <: GAPGroup
 is_normal_subgroup(H::T, G::T) where T <: GAPGroup

--- a/experimental/GModule/Cohomology.jl
+++ b/experimental/GModule/Cohomology.jl
@@ -2,6 +2,7 @@ module GrpCoh
 
 using Oscar
 import Oscar:action
+import Oscar:induce
 import Oscar:GAPWrap, pc_group, direct_product, direct_sum
 import AbstractAlgebra: Group, Module
 import Base: parent

--- a/experimental/GModule/Cohomology.jl
+++ b/experimental/GModule/Cohomology.jl
@@ -1,9 +1,9 @@
 module GrpCoh
 
 using Oscar
-import Oscar:action
-import Oscar:induce
-import Oscar:GAPWrap, pc_group, direct_product, direct_sum
+import Oscar: action
+import Oscar: induce
+import Oscar: GAPWrap, pc_group, direct_product, direct_sum
 import AbstractAlgebra: Group, Module
 import Base: parent
 

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -23,7 +23,7 @@
 @deprecate gelfand_tsetlin(lambda::AbstractVector) gelfand_tsetlin_polytope(lambda)
 
 
-# Deprecate after 0.11.4
+# Deprecated after 0.11.4
 function AffineNormalToricVariety(C::Cone; set_attributes::Bool = true)
     Base.depwarn("'AffineNormalToricVariety(C::Cone; set_attributes::Bool = true)' is deprecated, use "*
     "'affine_normal_toric_variety(C::Cone; set_attributes::Bool = true)' instead.", :AffineNormalToricVariety)
@@ -210,6 +210,7 @@ end
 
 @deprecate ToricIdentityMorphism(v::AbstractNormalToricVariety) toric_identity_morphism(v)
 
+@deprecate induced_class_function induce
 @deprecate radical_subgroup solvable_radical
 @deprecate has_radical_subgroup has_solvable_radical
 @deprecate set_radical_subgroup set_solvable_radical

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -619,7 +619,7 @@ export index_of_gen
 export index_of_leading_term
 export indicator
 export induced_automorphism
-export induced_class_function
+export induce
 export induced_cyclic
 export induced_ring_ordering
 export initial

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -181,6 +181,7 @@ GAP.@wrap PrimePGroup(x::GapObj)::GapInt
 GAP.@wrap Range(x::GapObj)::GapObj
 GAP.@wrap ReduceCoeffs(x::GapObj, y::GapObj)
 GAP.@wrap RelatorsOfFpGroup(x::GapObj)::GapObj
+GAP.@wrap Representative(x::GapObj)::GAP.Obj
 GAP.@wrap SetMaximalAbelianQuotient(x::Any, y::Any)::Nothing
 GAP.@wrap SetSize(x::Any, y::Any)::Nothing
 GAP.@wrap Size(x::Any)::GapInt

--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -40,6 +40,8 @@ end
 # Base.inv(x::GrpAbFinGenElem) = -x
 # x^n for GrpAbFinGenElem -> n*x
 
+Base.:^(g::GrpAbFinGenElem, x::GrpAbFinGenElem) = g
+
 function comm(x::GrpAbFinGenElem, y::GrpAbFinGenElem)
   @req (x.parent == y.parent) "elements must belong to the same group"
   return zero(parent(x))
@@ -51,6 +53,13 @@ function small_generating_set(G::GrpAbFinGen)
    is_snf(G) && return gens(G)
    S, mp = snf(G)
    return [mp(x) for x in gens(S)]
+end
+
+function index(::Type{I}, G::T, H::T) where I <: IntegerUnion where T <: GrpAbFinGen
+   @req is_subgroup(H, G)[1] "H must be a subgroup of G"
+   f = count(x -> x == 0, snf(G)[1].snf) - count(x -> x == 0, snf(H)[1].snf)
+   @req f == 0 "index is supported only for subgroups of finite index"
+   return I(divexact(order(torsion_subgroup(G)[1]), order(torsion_subgroup(H)[1]), check = false))
 end
 
 
@@ -256,6 +265,8 @@ function socle(G::GrpAbFinGen)
    end
    return sub(G, subgens)
 end
+
+trivial_subgroup(G::GrpAbFinGen) = sub(G, GrpAbFinGenElem[])
 
 solvable_radical(G::GrpAbFinGen) = (G, identity_map(G))
 

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -78,11 +78,12 @@ This is the type of (ordinary or Brauer) character tables that can delegate
 tasks to an underlying character table object in the GAP system
 (field `GAPTable`).
 
-An object of type `GAPGroup` can (but need not) be stored
-in the field `GAPGroup`.
-
 The value of the field `characteristic` determines whether the table
 is an ordinary one (value `0`) or a `p`-modular one (value `p`).
+
+A group can (but need not) be stored in the field `group`.
+If it is available then also the field `isomorphism` is available,
+its value is a bijective map from the `group` value to a group in GAP.
 
 Objects of type `GAPGroupCharacterTable` support [`get_attribute`](@ref),
 for example in order to store the already computed `p`-modular tables
@@ -90,19 +91,97 @@ in an ordinary table, and to store the corresponding ordinary table
 in a `p`-modular table.
 """
 @attributes mutable struct GAPGroupCharacterTable <: GroupCharacterTable
-    GAPTable::GapObj  # the character table object
+    GAPTable::GapObj  # the GAP character table object
     characteristic::Int
-    GAPGroup::GAPGroup    # the underlying group, if any
+    group::Union{GAPGroup, GrpAbFinGen}    # the underlying group, if any
+    isomorphism::Map  # isomorphism from `group` to a group in GAP
 
-    function GAPGroupCharacterTable(G::GAPGroup, tab::GapObj, char::Int)
-      return new(tab, char, G)
+    function GAPGroupCharacterTable(G::Union{GAPGroup, GrpAbFinGen}, tab::GapObj, iso::Map, char::Int)
+      return new(tab, char, G, iso)
     end
 
     function GAPGroupCharacterTable(tab::GapObj, char::Int)
-      #GAPGroup is left undefined
+      #group is left undefined
       return new(tab, char)
     end
 end
+
+# access to field values via functions
+GAPTable(tbl::GAPGroupCharacterTable) = tbl.GAPTable
+group(tbl::GAPGroupCharacterTable) = tbl.group
+characteristic(tbl::GAPGroupCharacterTable) = tbl.characteristic
+
+# backwards compatibility:
+# return `tbl.group` when one accesses `tbl.GAPGroup`
+function Base.getproperty(tbl::GAPGroupCharacterTable, sym::Symbol)
+   sym === :GAPGroup && return tbl.group
+   return getfield(tbl, sym)
+end
+
+
+# If the character table stores an Oscar group `G` then
+# an isomorphism from `G` to a GAP group is stored in the field `isomorphism`.
+# Different kinds of isomorphisms can be stored,
+# depending on the type of the stored group.
+#
+# - For `GAPGroup`, we compute images and preimages by unwrapping and
+#   wrapping the groups elements, respectively.
+# - For `GrpAbFinGen`, we compose this unwrapping/wrapping with
+#   an isomorphism to a `PcGroup` .
+#
+function isomorphism_to_GAP_group(G::GAPGroup)
+    f = function(x) return x.X; end
+    finv = function(x::GAP.Obj) return group_element(G, x); end
+    return MapFromFunc(f, finv, G, G.X)
+end
+
+function isomorphism_to_GAP_group(G::GrpAbFinGen)
+    @req isfinite(G) "the group is not finite"
+    iso = isomorphism(PcGroup, G)
+    C = codomain(iso)
+    @assert C isa GAPGroup
+    f = function(x) return iso(x).X; end
+    finv = function(x::GAP.Obj) return preimage(iso, group_element(C, x)); end
+    return MapFromFunc(f, finv, G, C.X)
+end
+
+function isomorphism_to_GAP_group(tbl::GAPGroupCharacterTable)
+    @req isdefined(tbl, :isomorphism) "character table stores no isomorphism"
+    return tbl.isomorphism
+end
+
+
+# If the character table stores an Oscar group `G` then
+# the columns correspond to conjugacy classes of `G`.
+# The vector `conjugacy_classes(G)` (stored or not stored in `G`) can be
+# independent of the vector of conjugacy classes of the corresponding
+# group on the GAP side.
+# Therefore we store a vector `conjugacy_classes(tbl)` via an attribute,
+# which is compatible with the `GAP.Globals.ConjugacyClasses` value of
+# the underlying GAP character table.
+function conjugacy_classes(tbl::GAPGroupCharacterTable)
+    return get_attribute!(tbl, :conjugacy_classes) do
+      @req isdefined(tbl, :group) "character table stores no group"
+
+      # If `GAPTable(tbl)` does not yet store conjugacy classes
+      # then compute them.
+      if characteristic(tbl) == 0
+        ccl = GAP.Globals.ConjugacyClasses(GAPTable(tbl))::GapObj
+        ccl = [conjugacy_class(group(tbl),
+                 preimage(isomorphism_to_GAP_group(tbl),
+                          GAP.Globals.Representative(x)))
+              for x in ccl]
+      else
+        ordtbl = get_attribute(tbl, :ordinary_table)
+        ccl = conjugacy_classes(ordtbl)
+        known, fus = known_class_fusion(tbl, ordtbl)
+        @assert known "the class fusion is not stored"
+        ccl = ccl[fus]
+      end
+      return ccl
+    end
+end
+
 
 """
     character_table(G::GAPGroup, p::Int = 0)
@@ -146,17 +225,21 @@ Sym( [ 1 .. 3 ] ) mod 2
 χ₂  2 -1
 ```
 """
-function character_table(G::GAPGroup, p::Int = 0)
+function character_table(G::Union{GAPGroup, GrpAbFinGen}, p::Int = 0)
     tbls = get_attribute!(() -> Dict{Int,Any}(), G, :character_tables)
     return get!(tbls, p) do
-      gaptbl = GAP.Globals.CharacterTable(G.X)::GapObj
-      if p != 0
+      if p == 0
+        iso = isomorphism_to_GAP_group(G)
+        gaptbl = GAP.Globals.CharacterTable(codomain(iso))::GapObj
+      else
         # Create the `p`-modular table if possible.
-        is_prime(p) || error("p must be 0 or a prime integer")
-        gaptbl = GAP.Globals.mod(gaptbl, GAP.Obj(p))::GapObj
+        @req is_prime(p) "p must be 0 or a prime integer"
+        ordtbl = character_table(G, 0)
+        iso = isomorphism_to_GAP_group(ordtbl)
+        gaptbl = GAP.Globals.mod(GAPTable(ordtbl), GAP.Obj(p))::GapObj
         gaptbl === GAP.Globals.fail && return nothing
       end
-      return GAPGroupCharacterTable(G, gaptbl, p)
+      return GAPGroupCharacterTable(G, gaptbl, iso, p)
     end
 end
 
@@ -187,12 +270,12 @@ nothing
 ```
 """
 function character_table(id::String, p::Int = 0)
-    hasproperty(GAP.Globals, :CTblLib) || error("no character table library available")
+    @req hasproperty(GAP.Globals, :CTblLib) "no character table library available"
 
     if p == 0
       modid = id
     else
-      is_prime(p) || error("p must be 0 or a prime integer")
+      @req is_prime(p) "p must be 0 or a prime integer"
       modid = "$(id)mod$(p)"
     end
 
@@ -243,7 +326,7 @@ Currently the following series are supported.
 | `:ExtraspecialPlusOdd` | odd power of odd prime |
 """
 function character_table(series::Symbol, parameter::Union{Int, Vector{Int}})
-    hasproperty(GAP.Globals, :CTblLib) || error("no character table library available")
+    @req hasproperty(GAP.Globals, :CTblLib) "no character table library available"
     args = GAP.Obj([string(series), parameter], recursive = true)
     tbl = GAP.Globals.CallFuncList(GAP.Globals.CharacterTable, args)::GapObj
     tbl === GAP.Globals.fail && return nothing
@@ -253,11 +336,22 @@ function character_table(series::Symbol, parameter::Union{Int, Vector{Int}})
 end
 
 
+# Assume that `isomorphism_to_GAP_group(tbl)` maps elements via `.X` access.
+function preimages(iso::MapFromFunc{T, GapObj}, H::GapObj) where T <: GAPGroup
+    return _as_subgroup(domain(iso), H)
+end
+
+# Use the isomorphism.
+function preimages(iso::MapFromFunc{GrpAbFinGen, GapObj}, H::GapObj)
+  return sub(domain(iso), [preimage(iso, x) for x in GAP.Globals.GeneratorsOfGroup(H)])
+end
+
+
 # For character tables with stored group, we take the hash value of the group.
 # For character tables without stored group, we take the table identifier.
 function Base.hash(tbl::GAPGroupCharacterTable, h::UInt)
-  if isdefined(tbl, :GAPGroup)
-    return Base.hash(tbl.GAPGroup, h)
+  if isdefined(tbl, :group)
+    return Base.hash(group(tbl), h)
   else
     return Base.hash(identifier(tbl), h)
   end
@@ -279,7 +373,7 @@ One application of this function is to restrict the search with
 [`all_character_table_names`](@ref) to only one library character table for each
 class of permutation equivalent tables.
 """
-@gapattribute is_duplicate_table(tbl::GAPGroupCharacterTable) = GAP.Globals.IsDuplicateTable(G.GAPTable)::Bool
+@gapattribute is_duplicate_table(tbl::GAPGroupCharacterTable) = GAP.Globals.IsDuplicateTable(GAPTable(tbl))::Bool
 
 """
     all_character_table_names(L...; ordered_by = nothing)
@@ -355,7 +449,7 @@ as a sum of multiples of powers of the primitive root which is printed as
 function as_sum_of_roots(val::nf_elem, root::String)
     F = parent(val)
     flag, N = Hecke.is_cyclotomic_type(F)
-    flag || error("$val is not an element of a cyclotomic field")
+    @req flag "$val is not an element of a cyclotomic field"
 
     # `string` yields an expression of the right structure,
     # but not in terms of `root`
@@ -434,7 +528,7 @@ function matrix_of_strings(tbl::GAPGroupCharacterTable; alphabet::String = "", r
               disp = as_sum_of_roots(valbar.data, root)
               push!(legend, (valbar, "\\overline{$name}", disp))
             else
-              info = Oscar.AbelianClosure.quadratic_irrationality_info(val)
+              info = AbelianClosure.quadratic_irrationality_info(val)
               if info != nothing
                 # `val` generates a quadratic field extension.
                 # Show the unique Galois conjugate of `A` different from
@@ -470,8 +564,8 @@ end
 # and sub-/superscripts if LaTeX output is not requested..
 function Base.show(io::IO, tbl::GAPGroupCharacterTable)
     n = nrows(tbl)
-    gaptbl = tbl.GAPTable
-    size = ZZRingElem(GAPWrap.Size(gaptbl))
+    gaptbl = GAPTable(tbl)
+    size = order(ZZRingElem, tbl)
     primes = [x[1] for x in collect(factor(size))]
     sort!(primes)
 
@@ -488,7 +582,7 @@ function Base.show(io::IO, tbl::GAPGroupCharacterTable)
     mat, legend = matrix_of_strings(tbl, alphabet = alphabet)
 
     # Compute the factored centralizer orders.
-    cents = Vector{ZZRingElem}(GAP.Globals.SizesCentralizers(gaptbl)::GapObj)
+    cents = orders_centralizers(tbl)
     fcents = [collect(factor(x)) for x in cents]
     d = Dict([p => fill(".", n) for p in primes]...)
     for i in 1:n
@@ -542,7 +636,7 @@ function Base.show(io::IO, tbl::GAPGroupCharacterTable)
     # Compute the degrees of the character fields if applicable.
     field_degrees = get(io, :character_field, false)::Bool
     if field_degrees
-      p = tbl.characteristic
+      p = characteristic(tbl)
       if p == 0
         field_degrees = [[string(GAP.Globals.Dimension(GAP.Globals.Field(GAP.Globals.Rationals, x.values))) for x in tbl]]
       else
@@ -557,10 +651,10 @@ function Base.show(io::IO, tbl::GAPGroupCharacterTable)
 
     emptycol = ["" for i in 1:n]
 
-    if isdefined(tbl, :GAPGroup)
-      headerstring = string(tbl.GAPGroup)
-      if tbl.characteristic != 0
-        headerstring = "$headerstring mod $(tbl.characteristic)"
+    if isdefined(tbl, :group)
+      headerstring = string(group(tbl))
+      if characteristic(tbl) != 0
+        headerstring = "$headerstring mod $(characteristic(tbl))"
       end
     else
       headerstring = identifier(tbl)
@@ -610,11 +704,11 @@ end
 
 # print: abbreviated form
 function Base.print(io::IO, tbl::GAPGroupCharacterTable)
-    gaptbl = tbl.GAPTable
-    if isdefined(tbl, :GAPGroup)
-      id = string(tbl.GAPGroup)
-      if tbl.characteristic != 0
-        id = "$(id)mod$(tbl.characteristic)"
+    gaptbl = GAPTable(tbl)
+    if isdefined(tbl, :group)
+      id = string(group(tbl))
+      if characteristic(tbl) != 0
+        id = "$(id)mod$(characteristic(tbl))"
       end
     else
       id = "\"" * identifier(tbl) * "\""
@@ -625,10 +719,10 @@ end
 
 ##############################################################################
 #
-length(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(tbl.GAPTable)::Int
-Oscar.nrows(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(tbl.GAPTable)::Int
-Oscar.ncols(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(tbl.GAPTable)::Int
-number_conjugacy_classes(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(tbl.GAPTable)::Int
+length(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(GAPTable(tbl))::Int
+Oscar.nrows(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(GAPTable(tbl))::Int
+Oscar.ncols(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(GAPTable(tbl))::Int
+number_conjugacy_classes(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(GAPTable(tbl))::Int
 
 @doc raw"""
     order(::Type{T} = ZZRingElem, tbl::GAPGroupCharacterTable) where T <: IntegerUnion
@@ -644,7 +738,7 @@ julia> order(character_table(symmetric_group(4)))
 order(tbl::GAPGroupCharacterTable) = order(ZZRingElem, tbl)
 
 function order(::Type{T}, tbl::GAPGroupCharacterTable) where T <: IntegerUnion
-  return T(GAPWrap.Size(tbl.GAPTable))
+  return T(GAPWrap.Size(GAPTable(tbl)))
 end
 
 @doc raw"""
@@ -659,7 +753,7 @@ julia> println(orders_class_representatives(character_table("A5")))
 [1, 2, 3, 5, 5]
 ```
 """
-@gapattribute orders_class_representatives(tbl::GAPGroupCharacterTable) = Vector{Int}(GAP.Globals.OrdersClassRepresentatives(tbl.GAPTable)::GapObj)
+@gapattribute orders_class_representatives(tbl::GAPGroupCharacterTable) = Vector{Int}(GAP.Globals.OrdersClassRepresentatives(GAPTable(tbl))::GapObj)
 
 @doc raw"""
     orders_centralizers(tbl::GAPGroupCharacterTable)
@@ -674,7 +768,7 @@ julia> println(orders_centralizers(character_table("A5")))
 ZZRingElem[60, 4, 3, 5, 5]
 ```
 """
-@gapattribute orders_centralizers(tbl::GAPGroupCharacterTable) = Vector{ZZRingElem}(GAP.Globals.SizesCentralizers(tbl.GAPTable)::GAP.Obj)
+@gapattribute orders_centralizers(tbl::GAPGroupCharacterTable) = Vector{ZZRingElem}(GAP.Globals.SizesCentralizers(GAPTable(tbl))::GAP.Obj)
 
 @doc raw"""
     class_lengths(tbl::GAPGroupCharacterTable)
@@ -685,7 +779,7 @@ julia> println(class_lengths(character_table("A5")))
 ZZRingElem[1, 15, 20, 12, 12]
 ```
 """
-@gapattribute class_lengths(tbl::GAPGroupCharacterTable) = Vector{ZZRingElem}(GAP.Globals.SizesConjugacyClasses(tbl.GAPTable)::GapObj)
+@gapattribute class_lengths(tbl::GAPGroupCharacterTable) = Vector{ZZRingElem}(GAP.Globals.SizesConjugacyClasses(GAPTable(tbl))::GapObj)
 
 @doc raw"""
     maxes(tbl::GAPGroupCharacterTable)
@@ -710,8 +804,8 @@ true
 ```
 """
 function maxes(tbl::GAPGroupCharacterTable)
-  if GAP.Globals.HasMaxes(tbl.GAPTable)::Bool
-    return Vector{String}(GAP.Globals.Maxes(tbl.GAPTable)::GapObj)
+  if GAP.Globals.HasMaxes(GAPTable(tbl))::Bool
+    return Vector{String}(GAP.Globals.Maxes(GAPTable(tbl))::GapObj)
   end
   return nothing
 end
@@ -728,7 +822,7 @@ julia> identifier(character_table("A5"))
 "A5"
 ```
 """
-@gapattribute identifier(tbl::GAPGroupCharacterTable) = string(GAP.Globals.Identifier(tbl.GAPTable)::GapObj)
+@gapattribute identifier(tbl::GAPGroupCharacterTable) = string(GAP.Globals.Identifier(GAPTable(tbl))::GapObj)
 
 @doc raw"""
     class_positions_of_pcore(tbl::GAPGroupCharacterTable, p::IntegerUnion)
@@ -743,7 +837,7 @@ julia> println(class_positions_of_pcore(character_table("2.A5"), 2))
 [1, 2]
 ```
 """
-class_positions_of_pcore(tbl::GAPGroupCharacterTable, p::IntegerUnion) = Vector{Int}(GAP.Globals.ClassPositionsOfPCore(tbl.GAPTable, GAP.Obj(p))::GapObj)
+class_positions_of_pcore(tbl::GAPGroupCharacterTable, p::IntegerUnion) = Vector{Int}(GAP.Globals.ClassPositionsOfPCore(GAPTable(tbl), GAP.Obj(p))::GapObj)
 
 @doc raw"""
     pcore(tbl::GAPGroupCharacterTable, p::IntegerUnion)
@@ -759,11 +853,11 @@ julia> order(pcore(character_table(symmetric_group(4)), 2)[1])
 ```
 """
 function pcore(tbl::GAPGroupCharacterTable, p::IntegerUnion)
-    isdefined(tbl, :GAPGroup) || error("character table stores no group")
-    G = tbl.GAPGroup
-    t = tbl.GAPTable
+    @req isdefined(tbl, :group) "character table stores no group"
+    t = GAPTable(tbl)
     pcorepos = GAP.Globals.ClassPositionsOfPCore(t, GAP.Obj(p))::GapObj
-    return _as_subgroup(G, GAP.Globals.NormalSubgroupClasses(t, pcorepos)::GapObj)
+    P = GAP.Globals.NormalSubgroupClasses(t, pcorepos)::GapObj
+    return preimages(isomorphism_to_GAP_group(tbl), P)
 end
 
 function class_positions_of_kernel(fus::Vector{Int})
@@ -771,13 +865,13 @@ function class_positions_of_kernel(fus::Vector{Int})
 end
 
 function Base.getindex(tbl::GAPGroupCharacterTable, i::Int)
-    irr = GAP.Globals.Irr(tbl.GAPTable)::GapObj
+    irr = GAP.Globals.Irr(GAPTable(tbl))::GapObj
     return group_class_function(tbl, irr[i])
 end
 #TODO: cache the irreducibles in the table
 
 function Base.getindex(tbl::GAPGroupCharacterTable, i::Int, j::Int)
-    irr = GAP.Globals.Irr(tbl.GAPTable)::GapObj
+    irr = GAP.Globals.Irr(GAPTable(tbl))::GapObj
     val = irr[i, j]
     return QQAbElem(val)
 end
@@ -794,16 +888,17 @@ or `nothing` if this table cannot be computed.
 An exception is thrown if `tbl` is not an ordinary character table.
 """
 function Base.mod(tbl::GAPGroupCharacterTable, p::Int)
-    is_prime(p) || error("p must be a prime integer")
-    tbl.characteristic == 0 || error("tbl mod p only for ordinary table tbl")
+    @req is_prime(p) "p must be a prime integer"
+    characteristic(tbl) == 0 || error("tbl mod p only for ordinary table tbl")
 
     modtbls = get_attribute!(() -> Dict{Int,Any}(), tbl, :brauer_tables)
     if ! haskey(modtbls, p)
-      modtblgap = mod(tbl.GAPTable, p)::GapObj
+      modtblgap = mod(GAPTable(tbl), p)::GapObj
       if modtblgap === GAP.Globals.fail
         modtbls[p] = nothing
-      elseif isdefined(tbl, :GAPGroup)
-        modtbls[p] = GAPGroupCharacterTable(tbl.GAPGroup, modtblgap, p)
+      elseif isdefined(tbl, :group)
+        modtbls[p] = GAPGroupCharacterTable(group(tbl), modtblgap,
+                       isomorphism_to_GAP_group(tbl), p)
       else
         modtbls[p] = GAPGroupCharacterTable(modtblgap, p)
       end
@@ -835,8 +930,8 @@ julia> decomposition_matrix(t2)
 ```
 """
 function decomposition_matrix(modtbl::GAPGroupCharacterTable)
-    is_prime(modtbl.characteristic) || error("characteristic of tbl must be a prime integer")
-    return matrix(ZZ, GAP.Globals.DecompositionMatrix(modtbl.GAPTable)::GapObj)
+    @req is_prime(characteristic(modtbl)) "characteristic of tbl must be a prime integer"
+    return matrix(ZZ, GAP.Globals.DecompositionMatrix(GAPTable(modtbl))::GapObj)
 end
 
 @doc raw"""
@@ -879,7 +974,7 @@ julia> class_multiplication_coefficient(character_table("A5"), 2, 4, 4)
 ```
 """
 function class_multiplication_coefficient(::Type{T}, tbl::GAPGroupCharacterTable, i::Int, j::Int, k::Int) where T <: IntegerUnion
-  return T(GAP.Globals.ClassMultiplicationCoefficient(tbl.GAPTable, i, j, k)::GAP.Obj)
+  return T(GAP.Globals.ClassMultiplicationCoefficient(GAPTable(tbl), i, j, k)::GAP.Obj)
 end
 
 class_multiplication_coefficient(tbl::GAPGroupCharacterTable, i::Int, j::Int, k::Int) = class_multiplication_coefficient(ZZRingElem, tbl, i, j, k)
@@ -903,7 +998,7 @@ julia> possible_class_fusions(character_table("A5"), character_table("A6"))
 ```
 """
 function possible_class_fusions(subtbl::GAPGroupCharacterTable, tbl::GAPGroupCharacterTable)
-  fus = GAP.Globals.PossibleClassFusions(subtbl.GAPTable, tbl.GAPTable)::GapObj
+  fus = GAP.Globals.PossibleClassFusions(GAPTable(subtbl), GAPTable(tbl))::GapObj
   return [Vector{Int}(x::GapObj) for x in fus]
 end
 
@@ -965,7 +1060,7 @@ julia> character_parameters(character_table("M11"))
 """
 function character_parameters(tbl::GAPGroupCharacterTable)
     return get_attribute!(tbl, :character_parameters) do
-      GAPt = tbl.GAPTable
+      GAPt = GAPTable(tbl)
       GAP.Globals.HasCharacterParameters(GAPt)::Bool || return nothing
       paras = Vector{GAP.Obj}(GAP.Globals.CharacterParameters(GAPt)::GapObj)
       return _translate_parameter_list(paras)
@@ -995,7 +1090,7 @@ julia> class_parameters(character_table("M11"))
 """
 function class_parameters(tbl::GAPGroupCharacterTable)
     return get_attribute!(tbl, :class_parameters) do
-      GAPt = tbl.GAPTable
+      GAPt = GAPTable(tbl)
       GAP.Globals.HasClassParameters(GAPt)::Bool || return nothing
       paras = Vector{GAP.Obj}(GAP.Globals.ClassParameters(GAPt)::GapObj)
       return _translate_parameter_list(paras)
@@ -1009,7 +1104,7 @@ Return the array of strings that are identifiers of those character tables
 which store a class fusion to `tbl`.
 """
 function names_of_fusion_sources(tbl::GAPGroupCharacterTable)
-    return [string(name) for name in GAP.Globals.NamesOfFusionSources(tbl.GAPTable)::GapObj]
+    return [string(name) for name in GAP.Globals.NamesOfFusionSources(GAPTable(tbl))::GapObj]
 end
 
 @doc raw"""
@@ -1031,7 +1126,7 @@ the image of the $i$-th conjugacy class `tbl1` under the relevant epimorphism
 is the `fus`[$i$]-th conjugacy class of `tbl2`.
 """
 function known_class_fusion(subtbl::GAPGroupCharacterTable, tbl::GAPGroupCharacterTable)
-    map = GAP.Globals.GetFusionMap(subtbl.GAPTable, tbl.GAPTable)::GapObj
+    map = GAP.Globals.GetFusionMap(GAPTable(subtbl), GAPTable(tbl))::GapObj
     if map === GAP.Globals.fail
       return (false, Int[])
     else
@@ -1061,13 +1156,13 @@ function values(chi::GAPGroupClassFunction)
 end
 
 function group_class_function(tbl::GAPGroupCharacterTable, values::GapObj)
-    GAPWrap.IsClassFunction(values) || error("values must be a class function")
+    @req GAPWrap.IsClassFunction(values) "values must be a class function"
     return GAPGroupClassFunction(tbl, values)
 end
 
 function group_class_function(tbl::GAPGroupCharacterTable, values::Vector{<:QQAbElem})
     gapvalues = GapObj([GAP.Obj(x) for x in values])
-    return GAPGroupClassFunction(tbl, GAP.Globals.ClassFunction(tbl.GAPTable, gapvalues)::GapObj)
+    return GAPGroupClassFunction(tbl, GAP.Globals.ClassFunction(GAPTable(tbl), gapvalues)::GapObj)
 end
 
 function group_class_function(G::GAPGroup, values::Vector{<:QQAbElem})
@@ -1102,7 +1197,8 @@ Return the permutation character of degree `degree(G)`
 that maps each element of `G` to the number of its fixed points.
 """
 function natural_character(G::PermGroup)
-    ccl = conjugacy_classes(G)
+    tbl = character_table(G)
+    ccl = conjugacy_classes(tbl)
     FF = abelian_closure(QQ)[1]
     n = degree(G)
     vals = [FF(n - number_moved_points(representative(x))) for x in ccl]
@@ -1116,15 +1212,16 @@ Return the character that maps each element of `G` to its trace.
 We assume that the entries of the elements of `G` are either of type `QQFieldElem`
 or contained in a cyclotomic field.
 """
-function natural_character(G::Union{MatrixGroup{QQFieldElem}, MatrixGroup{nf_elem}})
-    ccl = conjugacy_classes(G)
+function natural_character(G::Union{MatrixGroup{ZZRingElem}, MatrixGroup{QQFieldElem}, MatrixGroup{nf_elem}})
+    tbl = character_table(G)
+    ccl = conjugacy_classes(tbl)
     FF = abelian_closure(QQ)[1]
     vals = [FF(tr(representative(x))) for x in ccl]
     return group_class_function(G, vals)
 end
 
 @doc raw"""
-    induced_class_function(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable[, fusion::Vector{Int}])
+    induce(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable[, fusion::Vector{Int}])
 
 Return the class function of `tbl` that is induced from `chi`,
 which is a class function of a subgroup of the group of `tbl`.
@@ -1142,22 +1239,55 @@ julia> maps = possible_class_fusions(s, t);  length(maps)
 
 julia> chi = trivial_character(s);
 
-julia> ind = [induced_class_function(chi, t, x) for x in maps];  length(ind)
-4
+julia> ind = [induce(chi, t, x) for x in maps];
+
 julia> length(Set(ind))
 2
 ```
 """
-function induced_class_function(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable)
-  ind = GAP.Globals.InducedClassFunction(chi.values, tbl.GAPTable)::GapObj
+function induce(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable)
+  # If the class fusion is stored then use it.
+  known, fus = known_class_fusion(chi.table, tbl)
+  known && return induce(chi, tbl, fus)
+
+  subtbl = chi.table
+  if (!isdefined(tbl, :group)) || (!isdefined(subtbl, :group))
+    # If there is no stored group then let GAP try to find the result.
+    fus = GAP.Globals.FusionConjugacyClasses(GAPTable(subtbl), GAPTable(tbl))
+    @req fus !== GAP.Globals.fail "class fusion is not uniquely determinaed"
+    ind = GAP.Globals.InducedClassFunctionsByFusionMap(GAPTable(chi.table),
+          GAPTable(tbl), GapObj([chi.values]), GapObj(fus))::GapObj
+    return GAPGroupClassFunction(tbl, ind[1])
+  else
+    # Dispatch on the types of the stored groups.
+    return _induce(chi, tbl, group(subtbl), group(tbl))
+  end
+end
+
+function induce(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable, fusion::Vector{Int})
+  ind = GAP.Globals.InducedClassFunctionsByFusionMap(GAPTable(chi.table),
+          GAPTable(tbl), GapObj([chi.values]), GapObj(fusion))::GapObj
+  return GAPGroupClassFunction(tbl, ind[1])
+end
+
+# If `GAPGroup` groups are stored then we let GAP try to find the result.
+function _induce(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable, G_chi::GAPGroup, G_tbl::GAPGroup)
+  ind = GAP.Globals.InducedClassFunction(chi.values, GAPTable(tbl))::GapObj
   return GAPGroupClassFunction(tbl, ind)
 end
 
-function induced_class_function(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable, fusion::Vector{Int})
-  ind = GAP.Globals.InducedClassFunctionsByFusionMap(chi.table.GAPTable,
-          tbl.GAPTable, GapObj([chi.values]), GapObj(fusion))::GapObj
-  return GAPGroupClassFunction(tbl, ind[1])
+# If `GrpAbFinGen` groups are stored then we have to work with explicit
+# embeddings.
+function _induce(chi::GAPGroupClassFunction,
+              tbl::GAPGroupCharacterTable,
+              G_chi::GrpAbFinGen, G_tbl::GrpAbFinGen)
+  H, emb = is_subgroup(G_chi, G_tbl)
+  Hreps = [emb(representative(C)) for C in conjugacy_classes(chi.table)]
+  Greps = [representative(C) for C in conjugacy_classes(tbl)]
+  fus = [findfirst(x -> x == y, Greps) for y in Hreps]
+  return induce(chi, tbl, fus)
 end
+
 
 @doc raw"""
     induced_cyclic(tbl::GAPGroupCharacterTable)
@@ -1166,8 +1296,78 @@ Return the array of permutation characters of `tbl` that are induced from
 cyclic subgroups.
 """
 function induced_cyclic(tbl::GAPGroupCharacterTable)
-    return [GAPGroupClassFunction(tbl, chi) for chi in GAP.Globals.InducedCyclic(tbl.GAPTable)::GapObj]
+    return [GAPGroupClassFunction(tbl, chi) for chi in GAP.Globals.InducedCyclic(GAPTable(tbl))::GapObj]
 end
+
+"""
+    restrict(chi::GAPGroupClassFunction, subtbl::GAPGroupCharacterTable[, fusion::Vector{Int}])
+
+Return the class function of `subtbl` that is the restriction of `chi`,
+which is a class function of a supergroup of the group of `subtbl`.
+The default for the class fusion `fus` is given either by the fusion of the
+conjugacy classes of the two character tables (if groups are stored in the
+tables) or by the class fusion given by `known_class_fusion` for the two
+tables.
+
+# Examples
+```jldoctest
+julia> s = character_table("A5");  t = character_table("A6");
+
+julia> maps = possible_class_fusions(s, t);  length(maps)
+4
+
+julia> chi = t[2];  rest = [restrict(chi, s, x) for x in maps];
+
+julia> length(Set(rest))
+2
+```
+"""
+function restrict(chi::GAPGroupClassFunction, subtbl::GAPGroupCharacterTable)
+  # If the class fusion is stored then use it.
+  known, fus = known_class_fusion(subtbl, chi.table)
+  known && return restrict(chi, subtbl, fus)
+
+  tbl = chi.table
+  if (!isdefined(tbl, :group)) || (!isdefined(subtbl, :group))
+    # If there is no stored group then let GAP try to find the result.
+    fus = GAP.Globals.FusionConjugacyClasses(GAPTable(subtbl), GAPTable(tbl))::GapObj
+    @req fus !== GAP.Globals.fail "class fusion is not uniquely determinaed"
+    rest = GAP.Globals.ELMS_LIST(chi.values, GapObj(fus))::GapObj
+    rest = GAP.Globals.ClassFunction(GAPTable(subtbl), rest)::GapObj
+    return GAPGroupClassFunction(subtbl, rest)
+  else
+    # Dispatch on the types of the stored groups.
+    return _restrict(chi, subtbl, group(tbl), group(subtbl))
+  end
+end
+
+function restrict(chi::GAPGroupClassFunction, subtbl::GAPGroupCharacterTable, fusion::Vector{Int})
+  rest = GAP.Globals.ELMS_LIST(chi.values, GapObj(fusion))::GapObj
+  rest = GAP.Globals.ClassFunction(GAPTable(subtbl), rest)::GapObj
+  return GAPGroupClassFunction(subtbl, rest)
+end
+
+# If `GAPGroup` groups are stored then we let GAP try to find the result.
+function _restrict(chi::GAPGroupClassFunction, subtbl::GAPGroupCharacterTable, G_chi::GAPGroup, G_tbl::GAPGroup)
+  tbl = chi.table
+  fus = GAP.Globals.FusionConjugacyClasses(GAPTable(subtbl), GAPTable(tbl))::GapObj
+  rest = GAP.Globals.ELMS_LIST(chi.values, GapObj(fus))::GapObj
+  rest = GAP.Globals.ClassFunction(GAPTable(subtbl), rest)::GapObj
+  return GAPGroupClassFunction(subtbl, rest)
+end
+
+# If `GrpAbFinGen` groups are stored then we have to work with explicit
+# embeddings.
+function _restrict(chi::GAPGroupClassFunction,
+              subtbl::GAPGroupCharacterTable,
+              G_chi::GrpAbFinGen, G_subtbl::GrpAbFinGen)
+  H, emb = is_subgroup(G_subtbl, G_chi)
+  Hreps = [emb(representative(C)) for C in conjugacy_classes(subtbl)]
+  Greps = [representative(C) for C in conjugacy_classes(chi.table)]
+  fus = [findfirst(x -> x == y, Greps) for y in Hreps]
+  return restrict(chi, subtbl, fus)
+end
+
 
 Base.length(chi::GAPGroupClassFunction) = length(chi.values)
 
@@ -1197,7 +1397,7 @@ end
 
 # arithmetic with class functions
 function Base.:(==)(chi::GAPGroupClassFunction, psi::GAPGroupClassFunction)
-    chi.table === psi.table || error("character tables must be identical")
+    @req chi.table === psi.table "character tables must be identical"
 #T check_parent?
     return chi.values == psi.values
 end
@@ -1209,19 +1409,19 @@ function Base.hash(chi::GAPGroupClassFunction, h::UInt)
 end
 
 function Base.:+(chi::GAPGroupClassFunction, psi::GAPGroupClassFunction)
-    chi.table === psi.table || error("character tables must be identical")
+    @req chi.table === psi.table "character tables must be identical"
     return GAPGroupClassFunction(chi.table, chi.values + psi.values)
 end
 
 Base.:-(chi::GAPGroupClassFunction) = GAPGroupClassFunction(chi.table, - chi.values)
 
 function Base.:-(chi::GAPGroupClassFunction, psi::GAPGroupClassFunction)
-    chi.table === psi.table || error("character tables must be identical")
+    @req chi.table === psi.table "character tables must be identical"
     return GAPGroupClassFunction(chi.table, chi.values - psi.values)
 end
 
 function Base.:*(chi::GAPGroupClassFunction, psi::GAPGroupClassFunction)
-    chi.table === psi.table || error("character tables must be identical")
+    @req chi.table === psi.table "character tables must be identical"
     return GAPGroupClassFunction(chi.table, chi.values * psi.values)
 end
 
@@ -1242,7 +1442,7 @@ where $G$ is the group of both `chi` and `psi`.
 scalar_product(chi::GAPGroupClassFunction, psi::GAPGroupClassFunction) = scalar_product(QQFieldElem, chi, psi)
 
 function scalar_product(::Type{T}, chi::GAPGroupClassFunction, psi::GAPGroupClassFunction) where T <: Union{Integer, ZZRingElem, QQFieldElem, QQAbElem}
-    chi.table === psi.table || error("character tables must be identical")
+    @req chi.table === psi.table "character tables must be identical"
     return T(GAP.Globals.ScalarProduct(chi.values, psi.values)::GAP.Obj)::T
 end
 
@@ -1255,19 +1455,14 @@ function Base.:^(chi::GAPGroupClassFunction, n::IntegerUnion)
 end
 
 function Base.:^(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable)
-    return induced_class_function(chi, tbl)
+    return induce(chi, tbl)
 end
 
-function Base.:^(chi::GAPGroupClassFunction, g::GAPGroupElem)
+function Base.:^(chi::GAPGroupClassFunction, g::Union{GAPGroupElem, GrpAbFinGenElem})
     tbl = chi.table
-    isdefined(tbl, :GAPGroup) || error("character table stores no group")
-    G = tbl.GAPGroup
-    ccl = conjugacy_classes(G)
-    if tbl.characteristic != 0
-      known, fus = known_class_fusion(tbl, get_attribute(tbl, :ordinary_table))
-      @assert known "the class fusion is not stored"
-      ccl = ccl[fus]
-    end
+    @req isdefined(tbl, :group) "character table stores no group"
+    G = group(tbl)
+    ccl = conjugacy_classes(tbl)
     reps = [representative(c) for c in ccl]
     pi = [findfirst(x -> x^g in c, reps) for c in ccl]
     return group_class_function(tbl, values(chi)[pi])
@@ -1293,7 +1488,7 @@ function (sigma::QQAbAutomorphism)(chi::GAPGroupClassFunction)
     return GAPGroupClassFunction(chi.table, GAP.Globals.GaloisCyc(chi.values, sigma.exp)::GAP.Obj)
 end
 
-Base.:^(chi::Oscar.GAPGroupClassFunction, sigma::QQAbAutomorphism) = sigma(chi)
+Base.:^(chi::GAPGroupClassFunction, sigma::QQAbAutomorphism) = sigma(chi)
 
 @doc raw"""
     is_rational(chi::GAPGroupClassFunction)
@@ -1329,19 +1524,13 @@ function is_irreducible(chi::GAPGroupClassFunction)
 end
 
 # Apply a class function to a group element.
-function(chi::GAPGroupClassFunction)(g::GAPGroupElem)
+function(chi::GAPGroupClassFunction)(g::Union{GAPGroupElem, GrpAbFinGenElem})
     tbl = chi.table
-    if tbl.characteristic != 0
-      known, fus = known_class_fusion(tbl, get_attribute(tbl, :ordinary_table))
-      @assert known "the class fusion is not stored"
-    else
-      fus = 1:length(tbl)
-    end
 
     # Identify the conjugacy class of `g`.
-    ccl = conjugacy_classes(tbl.GAPGroup)
-    for i in 1:length(fus)
-      if g in ccl[fus[i]]
+    ccl = conjugacy_classes(tbl)
+    for i in 1:length(ccl)
+      if g in ccl[i]
         return chi[i]
       end
     end
@@ -1391,9 +1580,9 @@ julia> C, f = kernel(chi);  order(C)
 """
 function kernel(chi::GAPGroupClassFunction)
     tbl = chi.table
-    isdefined(tbl, :GAPGroup) || error("character table stores no group")
-    G = tbl.GAPGroup
-    return _as_subgroup(G, GAP.Globals.KernelOfCharacter(tbl.GAPTable, chi.values))
+    @req isdefined(tbl, :group) "character table stores no group"
+    GAP_K = GAP.Globals.KernelOfCharacter(GAPTable(tbl), chi.values)::GapObj
+    return preimages(isomorphism_to_GAP_group(tbl), GAP_K)
 end
 
 @doc raw"""
@@ -1433,9 +1622,10 @@ julia> C, f = center(chi);  order(C)
 """
 function center(chi::GAPGroupClassFunction)
     tbl = chi.table
-    isdefined(tbl, :GAPGroup) || error("character table stores no group")
-    G = tbl.GAPGroup
-    return _as_subgroup(G, GAP.Globals.CentreOfCharacter(tbl.GAPTable, chi.values))
+    @req isdefined(tbl, :group) "character table stores no group"
+    G = group(tbl)
+    C = GAP.Globals.CentreOfCharacter(GAPTable(tbl), chi.values)::GapObj
+    return preimages(isomorphism_to_GAP_group(tbl), C)
 end
 
 @doc raw"""
@@ -1491,7 +1681,7 @@ If `chi` is irreducible then `indicator(chi)` is
 `-1` if `chi` is real-valued but not afforded by a real representation of $G$.
 """
 function indicator(chi::GAPGroupClassFunction, n::Int = 2)
-    ind = GAP.Globals.Indicator(chi.table.GAPTable, GapObj([chi.values]), n)::GapObj
+    ind = GAP.Globals.Indicator(GAPTable(chi.table), GapObj([chi.values]), n)::GapObj
     return ind[1]::Int
 end
 
@@ -1510,11 +1700,11 @@ function character_field(chi::GAPGroupClassFunction)
     if GAPWrap.IsCyclotomicField(gapfield)
       # In this case, the want to return a field that knows to be cyclotomic
       # (and the embedding is easy).
-      F, z = Oscar.AbelianClosure.cyclotomic_field(FF, N)
+      F, z = AbelianClosure.cyclotomic_field(FF, N)
       f = x::nf_elem -> QQAbElem(x, N)
       finv = function(x::QQAbElem)
         g = gcd(x.c, N)
-        K, = Oscar.AbelianClosure.cyclotomic_field(FF, g)
+        K, = AbelianClosure.cyclotomic_field(FF, g)
         x = Hecke.force_coerce_cyclo(K, x.data)
         x = Hecke.force_coerce_cyclo(F, x)
         return x
@@ -1529,7 +1719,7 @@ function character_field(chi::GAPGroupClassFunction)
       R, = polynomial_ring(QQ, "x")
       f = R(v)
       F, z = number_field(f, "z"; cached = true, check = false)
-      K, zz = Oscar.AbelianClosure.cyclotomic_field(FF, N)
+      K, zz = AbelianClosure.cyclotomic_field(FF, N)
 
       nfelm = QQAbElem(gapgens[1]).data
 
@@ -1544,7 +1734,7 @@ function character_field(chi::GAPGroupClassFunction)
       finv = function(x::QQAbElem)
         # Write `x` w.r.t. the N-th cyclotomic field ...
         g = gcd(x.c, N)
-        Kg, = Oscar.AbelianClosure.cyclotomic_field(FF, g)
+        Kg, = AbelianClosure.cyclotomic_field(FF, g)
         x = Hecke.force_coerce_cyclo(Kg, x.data)
         x = Hecke.force_coerce_cyclo(K, x)
 
@@ -1583,7 +1773,7 @@ function schur_index(chi::GAPGroupClassFunction, recurse::Bool = true)
       N = GAPWrap.Conductor(gapfield)
       for n in reverse(sort(divisors(N)))
         if GAP.Globals.E(n)::GAP.Obj in gapfield
-          if isodd(n)
+          if Base.isodd(n)
             bound = ZZRingElem(2*n)
           else
             bound = ZZRingElem(n)
@@ -1631,9 +1821,9 @@ function schur_index(chi::GAPGroupClassFunction, recurse::Bool = true)
       end
     end
 
-    if isdefined(tbl, :GAPGroup) && hasproperty(GAP.Globals, :SchurIndexByCharacter)
-      g = tbl.GAPGroup
-      return GAP.Globals.SchurIndexByCharacter(GAP.Globals.Rationals, g.X, values)
+    if isdefined(tbl, :group) && hasproperty(GAP.Globals, :SchurIndexByCharacter)
+      g = group(tbl)
+      return GAP.Globals.SchurIndexByCharacter(GAP.Globals.Rationals, codomain(isomorphism_to_GAP_group(tbl)), values)
     end
 
     # For the moment, we do not have more character theoretic criteria.
@@ -1669,7 +1859,7 @@ function symmetrizations(characters::Vector{GAPGroupClassFunction}, n::Int)
     length(characters) == 0 && return eltype(typeof(characters))[]
     tbl = characters[1].table
     return [group_class_function(tbl, chi)
-            for chi in GAP.Globals.Symmetrizations(tbl.GAPTable,
+            for chi in GAP.Globals.Symmetrizations(GAPTable(tbl),
                          GAP.GapObj([chi.values for chi in characters]), n)]
 end
 
@@ -1684,7 +1874,7 @@ function symmetric_parts(characters::Vector{GAPGroupClassFunction}, n::Int)
     length(characters) == 0 && return eltype(typeof(characters))[]
     tbl = characters[1].table
     return [group_class_function(tbl, chi)
-            for chi in GAP.Globals.SymmetricParts(tbl.GAPTable,
+            for chi in GAP.Globals.SymmetricParts(GAPTable(tbl),
                          GAP.GapObj([chi.values for chi in characters]), n)]
 end
 
@@ -1699,7 +1889,7 @@ function anti_symmetric_parts(characters::Vector{GAPGroupClassFunction}, n::Int)
     length(characters) == 0 && return eltype(typeof(characters))[]
     tbl = characters[1].table
     return [group_class_function(tbl, chi)
-            for chi in GAP.Globals.AntiSymmetricParts(tbl.GAPTable,
+            for chi in GAP.Globals.AntiSymmetricParts(GAPTable(tbl),
                          GAP.GapObj([chi.values for chi in characters]), n)]
 end
 
@@ -1717,7 +1907,7 @@ function exterior_power(chi::GAPGroupClassFunction, n::Int)
 #T when GAP's `ExteriorPower` method becomes available then use it
     tbl = chi.table
     return group_class_function(tbl,
-      GAP.Globals.AntiSymmetricParts(tbl.GAPTable, GAP.Obj([chi.values]), n)[1])
+      GAP.Globals.AntiSymmetricParts(GAPTable(tbl), GAP.Obj([chi.values]), n)[1])
 end
 
 @doc raw"""
@@ -1734,7 +1924,7 @@ function symmetric_power(chi::GAPGroupClassFunction, n::Int)
 #T when GAP's `SymmetricPower` method becomes available then use it
     tbl = chi.table
     return group_class_function(tbl,
-      GAP.Globals.SymmetricParts(tbl.GAPTable, GAP.Obj([chi.values]), n)[1])
+      GAP.Globals.SymmetricParts(GAPTable(tbl), GAP.Obj([chi.values]), n)[1])
 end
 
 @doc raw"""
@@ -1747,11 +1937,11 @@ and where we assume that the entries of `characters` are irreducible
 characters with Frobenius-Schur indicator +1, see [`indicator`](@ref).
 """
 function orthogonal_components(characters::Vector{GAPGroupClassFunction}, n::Int)
-    (2 <= n && n <= 6) || error("the second ergument must be in 2:6")
+    @req (2 <= n && n <= 6) "the second ergument must be in 2:6"
     length(characters) == 0 && return eltype(typeof(characters))[]
     tbl = characters[1].table
     return [group_class_function(tbl, chi)
-            for chi in GAP.Globals.OrthogonalComponents(tbl.GAPTable,
+            for chi in GAP.Globals.OrthogonalComponents(GAPTable(tbl),
                          GAP.GapObj([chi.values for chi in characters]), n)]
 end
 
@@ -1765,16 +1955,16 @@ and where we assume that the entries of `characters` are irreducible
 characters with Frobenius-Schur indicator -1, see [`indicator`](@ref).
 """
 function symplectic_components(characters::Vector{GAPGroupClassFunction}, n::Int)
-    (2 <= n && n <= 6) || error("the second ergument must be in 2:6")
+    @req (2 <= n && n <= 6) "the second ergument must be in 2:6"
     length(characters) == 0 && return eltype(typeof(characters))[]
     tbl = characters[1].table
     return [group_class_function(tbl, chi)
-            for chi in GAP.Globals.SymplecticComponents(tbl.GAPTable,
+            for chi in GAP.Globals.SymplecticComponents(GAPTable(tbl),
                          GAP.GapObj([chi.values for chi in characters]), n)]
 end
 
 function character_table_complex_reflection_group(m::Int, p::Int, n::Int)
-    p == 1 || error("the case G(m,p,n) with p != 1 is not (yet) supported")
+    @req p == 1 "the case G(m,p,n) with p != 1 is not (yet) supported"
     tbl = GAP.Globals.CharacterTableWreathSymmetric(
             GAP.Globals.CharacterTable(GapObj("Cyclic"), m)::GapObj, n):GapObj
     tbl = GAPGroupCharacterTable(tbl, 0)

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -159,7 +159,7 @@ end
 # Therefore we store a vector `conjugacy_classes(tbl)` via an attribute,
 # which is compatible with the `GAP.Globals.ConjugacyClasses` value of
 # the underlying GAP character table.
-@attr Vector{T} function conjugacy_classes(tbl::GAPGroupCharacterTable) where T <: GAPGroupConjClass
+@attr function conjugacy_classes(tbl::GAPGroupCharacterTable)
     @req isdefined(tbl, :group) "character table stores no group"
 
     # If `GAPTable(tbl)` does not yet store conjugacy classes

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -580,6 +580,23 @@ function isomorphism(::Type{T}, A::GrpAbFinGen) where T <: GAPGroup
      # we let `hom` compute elements in `A2` that correspond to
      # `GAP.Globals.IndependentGenerators(G.X)`.
      Ggens = Vector{GapObj}(GAPWrap.GeneratorsOfGroup(G.X)::GapObj)
+     if length(Ggens) < length(exponents)
+       # It may happen that GAP omits the generators of order 1. Insert them.
+       @assert length(Ggens) + length(filter(x -> x == 1, exponents)) ==
+               length(exponents)
+       o = one(G).X
+       newGgens = []
+       pos = 1
+       for i in 1:length(exponents)
+         if exponents[i] == 1
+           push!(newGgens, o)
+         else
+           push!(newGgens, Ggens[pos])
+           pos = pos+1
+         end
+       end
+       Ggens = newGgens
+     end
      gensindep = GAP.Globals.IndependentGeneratorsOfAbelianGroup(G.X)::GapObj
      Aindep = abelian_group(ZZRingElem[GAPWrap.Order(g) for g in gensindep])
 

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -115,11 +115,11 @@ together with its embedding morphism into `G`.
 ###############################################################################
 
 """
-    index(::Type{I} = ZZRingElem, G::T, H::T) where I <: IntegerUnion where T <: GAPGroup
+    index(::Type{I} = ZZRingElem, G::T, H::T) where I <: IntegerUnion where T <: Union{GAPGroup, GrpAbFinGen}
 
 Return the index of `H` in `G`, as an instance of `I`.
 """
-index(G::T, H::T) where T <: GAPGroup = index(ZZRingElem, G, H)
+index(G::T, H::T) where T <: Union{GAPGroup, GrpAbFinGen} = index(ZZRingElem, G, H)
 
 function index(::Type{I}, G::T, H::T) where I <: IntegerUnion where T <: GAPGroup
    i = GAP.Globals.Index(G.X, H.X)::GapInt

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -234,7 +234,10 @@ end
    end
 
    @testset "Finite GrpAbFinGen to GAPGroup" begin
-      @testset for Agens in [[2, 4, 8], [2, 3, 4], [ 2, 12 ],
+#     @testset for Agens in [Int[], [2, 4, 8], [2, 3, 4], [2, 12],
+#T problem with GAP's `AbelianGroup`;
+#T see https://github.com/gap-system/gap/issues/5430
+      @testset for Agens in [[2, 4, 8], [2, 3, 4], [2, 12],
                              [1, 6], matrix(ZZ, 2, 2, [2, 3, 2, 6])]
          A = abelian_group(Agens)
          for T in [FPGroup, PcGroup, PermGroup]


### PR DESCRIPTION
For that, is must be made explicit that the `conjugacy_classes` of the character table objects on the Oscar side and on the GAP side correspond to each other, and the class fusions between `GrpAbFinGen` groups must be computed via the explicit embeddings.

related changes:

- renamed the `GAPGroup` field of character tables to `group`, since the value may now also be a `GrpAbFinGen`, and added a field `isomorphism` to a group in GAP; this way, all `.X` accesses happen now inside the functions that define this isomorphism
- renamed `induced_class_function` to `induce`
- added `restrict` for characters
- added `trivial_subgroup` and `index` for `GrpAbFinGen`
- added a workaround for an inconsistency in `GAP.Globals.AbelianGroup`
- use `@req` where possible