### PR TITLE
Don't run doctests as part of documentation deployment

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, Oscar
 
 include(normpath(joinpath(Oscar.oscardir, "docs", "make_work.jl")))
 
-BuildDoc.doit(Oscar; strict=true, local_build=false, doctest=true)
+BuildDoc.doit(Oscar; strict=true, local_build=false, doctest=false)
 
 deploydocs(
    repo   = "github.com/oscar-system/Oscar.jl.git",


### PR DESCRIPTION
This was part of PR #2171 but I think it makes sense
isolated, so we could merge it immediately while that PR
still matures.