### PR TITLE
Avoid linking a non-existing `docs/src` directory

### DIFF
--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -83,7 +83,7 @@ function setup_experimental_package(Oscar::Module, package_name::String)
 
   # Set symlink inside docs/src/experimental
   symlink_link = joinpath(Oscar.oscardir, "docs/src/Experimental", package_name)
-  symlink_target = joinpath(Oscar.oscardir, "experimental", package_name, "docs/src")
+  symlink_target = joinpath(Oscar.oscardir, "experimental", package_name, "docs", "src")
 
   if !ispath(symlink_target)
     return []

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -110,11 +110,9 @@ end
 function doit(Oscar::Module; strict::Bool = true, local_build::Bool = false, doctest::Union{Bool,Symbol} = true)
 
   # Remove symbolic links from earlier runs
-  expdocdir = joinpath(Oscar.oscardir, "docs/src/Experimental")
-  old_links = filter(x -> islink(joinpath(expdocdir, x)) && x in Oscar.exppkgs,
-                     readdir(expdocdir))
-  for x in old_links
-    rm(joinpath(expdocdir, x))
+  expdocdir = joinpath(Oscar.oscardir, "docs", "src", "Experimental")
+  for x in readdir(expdocdir; join=true)
+    islink(x) && rm(x)
   end
 
   # include the list of pages, performing substitutions

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -94,7 +94,7 @@ function setup_experimental_package(Oscar::Module, package_name::String)
   elseif !islink(symlink_link) || readlink(symlink_link) != symlink_target
       error("$symlink_link already exists, but is not a symlink to $symlink_target
 Please investigate the contents of $symlink_link,
-optionally move them somewhere else and delete the directiory once you are done.")
+optionally move them somewhere else and delete the directory once you are done.")
   end
 
   # Read doc.main of package
@@ -108,6 +108,14 @@ optionally move them somewhere else and delete the directiory once you are done.
 end
 
 function doit(Oscar::Module; strict::Bool = true, local_build::Bool = false, doctest::Union{Bool,Symbol} = true)
+
+  # Remove symbolic links from earlier runs
+  expdocdir = joinpath(Oscar.oscardir, "docs/src/Experimental")
+  old_links = filter(x -> islink(joinpath(expdocdir, x)) && x in Oscar.exppkgs,
+                     readdir(expdocdir))
+  for x in old_links
+    rm(joinpath(expdocdir, x))
+  end
 
   # include the list of pages, performing substitutions
   s = read(joinpath(Oscar.oscardir, "docs", "doc.main"), String)

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -83,7 +83,12 @@ function setup_experimental_package(Oscar::Module, package_name::String)
 
   # Set symlink inside docs/src/experimental
   symlink_link = joinpath(Oscar.oscardir, "docs/src/Experimental", package_name)
-  symlink_target = joinpath("../../../experimental", package_name, "docs/src")
+  symlink_target = joinpath(Oscar.oscardir, "experimental", package_name, "docs/src")
+
+  if !ispath(symlink_target)
+    return []
+  end
+
   if !ispath(symlink_link)
     symlink(symlink_target, symlink_link)
   elseif !islink(symlink_link) || readlink(symlink_link) != symlink_target
@@ -91,11 +96,11 @@ function setup_experimental_package(Oscar::Module, package_name::String)
 Please investigate the contents of $symlink_link,
 optionally move them somewhere else and delete the directiory once you are done.")
   end
-  
+
   # Read doc.main of package
   exp_s = read(doc_main_path, String)
   exp_doc = eval(Meta.parse(exp_s))
-  
+
   # Prepend path
   prefix = "Experimental/" * package_name * "/"
   result = add_prefix_to_experimental_docs(Oscar, exp_doc, prefix)


### PR DESCRIPTION
Fix a minor problem with the new experimental documentation: if a `docs/src` directory does not exist, building the documentation will create a dead link and then building it for a second time will error.
I made `symlink_target` an absolute path for this to work. I assume it was not a relative path for a reason?