### PR TITLE
Improve `cone_from_inequalities`

### DIFF
--- a/docs/src/PolyhedralGeometry/cones.md
+++ b/docs/src/PolyhedralGeometry/cones.md
@@ -37,6 +37,7 @@ reason for keeping cones as a distinct type.
 
 ```@docs
 positive_hull(::Type{T}, ::Union{Oscar.MatElem, AbstractMatrix}) where T<:scalar_types
+cone_from_inequalities
 secondary_cone(SOP::SubdivisionOfPoints{T}) where T<:scalar_types
 ```
 

--- a/docs/src/PolyhedralGeometry/cones.md
+++ b/docs/src/PolyhedralGeometry/cones.md
@@ -38,6 +38,7 @@ reason for keeping cones as a distinct type.
 ```@docs
 positive_hull(::Type{T}, ::Union{Oscar.MatElem, AbstractMatrix}) where T<:scalar_types
 cone_from_inequalities
+cone_from_equations
 secondary_cone(SOP::SubdivisionOfPoints{T}) where T<:scalar_types
 ```
 

--- a/docs/src/PolyhedralGeometry/intro.md
+++ b/docs/src/PolyhedralGeometry/intro.md
@@ -89,6 +89,7 @@ Type                                   | A `LinearHalfspace` corresponds to...
 :------------------------------------- | :----------------------------------------------------------
 `AbstractVector{<:Halfspace}`          | an element of the vector.
 `AbstractMatrix`/`MatElem` `A`         | the halfspace with normal vector `A[i, :]`.
+`AbstractVector{<:AbstractVector}` `A` | the halfspace with normal vector `A[i]`.
 `SubObjectIterator{<:Halfspace}`       | an element of the iterator.
 
 `AbstractCollection[LinearHyperplane]` can be given as:
@@ -97,6 +98,7 @@ Type                                   | A `LinearHyperplane` corresponds to...
 :------------------------------------- | :-----------------------------------------------------------
 `AbstractVector{<:Hyperplane}`         | an element of the vector.
 `AbstractMatrix`/`MatElem` `A`         | the hyperplane with normal vector `A[i, :]`.
+`AbstractVector{<:AbstractVector}` `A` | the hyperplane with normal vector `A[i]`.
 `SubObjectIterator{<:Hyperplane}`      | an element of the iterator.
 
 `AbstractCollection[AffineHalfspace]` can be given as:

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -353,6 +353,7 @@ export components
 export compose
 export composition_series
 export cone
+export cone_from_equations
 export cone_from_inequalities
 export cones
 export conjugacy_class

--- a/src/PolyhedralGeometry/Cone/constructors.jl
+++ b/src/PolyhedralGeometry/Cone/constructors.jl
@@ -119,13 +119,12 @@ function cone_from_inequalities(::Type{T}, I::AbstractCollection[LinearHalfspace
 end
 
 @doc raw"""
-
     cone_from_equations([::Type{T} = QQFieldElem,] E::AbstractCollection[LinearHyperplane]; non_redundant::Bool = false)
 
 The (convex) cone defined by
-
-$$\{ x | Ex = 0 \}.$$
-
+```math
+\{ x | Ex = 0 \}.
+```
 Use `non_redundant = true` if the given description contains no redundant rows to
 avoid unnecessary redundancy checks.
 

--- a/src/PolyhedralGeometry/Cone/constructors.jl
+++ b/src/PolyhedralGeometry/Cone/constructors.jl
@@ -118,7 +118,39 @@ function cone_from_inequalities(::Type{T}, I::AbstractCollection[LinearHalfspace
     end
 end
 
+@doc raw"""
+
+    cone_from_equations([::Type{T} = QQFieldElem,] E::AbstractCollection[LinearHyperplane]; non_redundant::Bool = false)
+
+The (convex) cone defined by
+
+$$\{ x | Ex = 0 \}.$$
+
+Use `non_redundant = true` if the given description contains no redundant rows to
+avoid unnecessary redundancy checks.
+
+# Examples
+```jldoctest
+julia> C = cone_from_equations([1 0 0; 0 -1 1])
+Polyhedral cone in ambient dimension 3
+
+julia> lineality_space(C)
+1-element SubObjectIterator{RayVector{QQFieldElem}}:
+ [0, 1, 1]
+
+julia> dim(C)
+1
+```
+"""
+function cone_from_equations(s::Type{T}, E::AbstractCollection[LinearHyperplane]; non_redundant::Bool = false) where T<:scalar_types
+    EM = linear_matrix_for_polymake(E)
+    IM = Polymake.Matrix{scalar_type_to_polymake[T]}(undef, 0, size(EM, 2))
+    return cone_from_inequalities(s, IM, EM; non_redundant = non_redundant)
+end
+
 cone_from_inequalities(x...) = cone_from_inequalities(QQFieldElem, x...)
+
+cone_from_equations(E::AbstractCollection[LinearHyperplane]; non_redundant::Bool = false) = cone_from_equations(QQFieldElem, E; non_redundant = non_redundant)
 
 """
     pm_object(C::Cone)

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -44,6 +44,8 @@ _cannot_convert_to_fmpq(x::Any) = !hasmethod(convert, Tuple{Type{QQFieldElem}, t
 
 linear_matrix_for_polymake(x::Union{Oscar.ZZMatrix, Oscar.QQMatrix, AbstractMatrix}) = assure_matrix_polymake(x)
 
+linear_matrix_for_polymake(x::AbstractVector{<:AbstractVector}) = assure_matrix_polymake(stack(x...))
+
 matrix_for_polymake(x::Union{Oscar.ZZMatrix, Oscar.QQMatrix, AbstractMatrix}) = assure_matrix_polymake(x)
 
 nrows(x::SubArray{T, 2, U, V, W}) where {T, U, V, W} = size(x, 1)

--- a/test/PolyhedralGeometry/Cone.jl
+++ b/test/PolyhedralGeometry/Cone.jl
@@ -128,5 +128,6 @@ const pm = Polymake
         @test cone_from_inequalities(T, [-1 0 0; 0 0 -1]; non_redundant = true) == Cone2
         @test cone_from_inequalities(T, facets(Cone4), linear_span(Cone4)) == Cone4
         @test cone_from_inequalities(T, facets(Cone4), linear_span(Cone4); non_redundant = true) == Cone4
+	@test cone_from_equations(T, [0 1 0]) == cone_from_inequalities(T, Matrix{Int}(undef, 0, 3), linear_span(Cone4))
     end
 end

--- a/test/PolyhedralGeometry/Cone.jl
+++ b/test/PolyhedralGeometry/Cone.jl
@@ -128,6 +128,6 @@ const pm = Polymake
         @test cone_from_inequalities(T, [-1 0 0; 0 0 -1]; non_redundant = true) == Cone2
         @test cone_from_inequalities(T, facets(Cone4), linear_span(Cone4)) == Cone4
         @test cone_from_inequalities(T, facets(Cone4), linear_span(Cone4); non_redundant = true) == Cone4
-	@test cone_from_equations(T, [0 1 0]) == cone_from_inequalities(T, Matrix{Int}(undef, 0, 3), linear_span(Cone4))
+        @test cone_from_equations(T, [0 1 0]) == cone_from_inequalities(T, Matrix{Int}(undef, 0, 3), linear_span(Cone4))
     end
 end

--- a/test/PolyhedralGeometry/extended.jl
+++ b/test/PolyhedralGeometry/extended.jl
@@ -181,6 +181,9 @@
             
             @test cone_from_inequalities(facets(x), collect(affine_hull(y))) == x
             @test cone_from_inequalities(facets(y), collect(linear_span(x))) == x
+
+	    @test cone_from_inequalities([[-1, 0, 0], [0, -1, 0]], [0 0 1]) == x
+	    @test cone_from_inequalities([-1 0 0; 0 -1 0], [[0, 0, 1]]) == x
         end
         
         # Here the content of the SubObjectIterator does not fit the idea of the

--- a/test/PolyhedralGeometry/extended.jl
+++ b/test/PolyhedralGeometry/extended.jl
@@ -182,8 +182,8 @@
             @test cone_from_inequalities(facets(x), collect(affine_hull(y))) == x
             @test cone_from_inequalities(facets(y), collect(linear_span(x))) == x
 
-	    @test cone_from_inequalities([[-1, 0, 0], [0, -1, 0]], [0 0 1]) == x
-	    @test cone_from_inequalities([-1 0 0; 0 -1 0], [[0, 0, 1]]) == x
+            @test cone_from_inequalities([[-1, 0, 0], [0, -1, 0]], [0 0 1]) == x
+            @test cone_from_inequalities([-1 0 0; 0 -1 0], [[0, 0, 1]]) == x
         end
         
         # Here the content of the SubObjectIterator does not fit the idea of the


### PR DESCRIPTION
Add missing docstrings to the docs for cones.
Extended type support for `AbstractCollection[LinearHalfspace/Hyperplane]`.
Add `cone_from_equations`. This could possibly called by a new method `cone_from_inequalities(::Type{T}, ::Nothing, ::AbstractCollection[LinearHyperplane])`?
This solves #2218 .