### PR TITLE
remove trivial `==` methods

### DIFF
--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -175,10 +175,6 @@ end
 #
 ###############################################################################
 
-function Base.:(==)(L1::LieAlgebra{C}, L2::LieAlgebra{C}) where {C<:RingElement}
-  return L1 === L2
-end
-
 function Base.:(==)(x1::LieAlgebraElem{C}, x2::LieAlgebraElem{C}) where {C<:RingElement}
   check_parent(x1, x2)
   return Generic._matrix(x1) == Generic._matrix(x2)

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -273,10 +273,6 @@ end
 #
 ###############################################################################
 
-function Base.:(==)(V1::LieAlgebraModule{C}, V2::LieAlgebraModule{C}) where {C<:RingElement}
-  return V1 === V2
-end
-
 function Base.:(==)(
   v1::LieAlgebraModuleElem{C}, v2::LieAlgebraModuleElem{C}
 ) where {C<:RingElement}


### PR DESCRIPTION
Removes some cases, which pop up in #2222, but are not of interest there.