### PR TITLE
Stop importing `exponent_vectors` from AbstractAlgebra

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 cohomCalg_jll = "5558cf25-a90e-53b0-b813-cadaa3ae7ade"
 
 [compat]
-AbstractAlgebra = "0.29.2"
+AbstractAlgebra = "0.29.3"
 AlgebraicSolving = "0.3.0"
 DocStringExtensions = "0.8, 0.9"
 GAP = "0.9.4"

--- a/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/constructors.jl
@@ -296,7 +296,7 @@ function Base.show(io::IO, ac::RationalEquivalenceClass)
       # otherwise, extract properties to represent the rational equivalence class
       r = representative(ac)
       coeffs = [c for c in AbstractAlgebra.coefficients(r)]
-      expos = [matrix(ZZ, [k for k in exponent_vectors(m)]) for m in AbstractAlgebra.monomials(r)]
+      expos = [matrix(ZZ, [k for k in AbstractAlgebra.exponent_vectors(m)]) for m in AbstractAlgebra.monomials(r)]
       indets = gens(chow_ring(toric_variety(ac)))
 
       # form string to be printed

--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -1,6 +1,5 @@
 @alias has_isfinite has_is_finite
 @alias SymmetricGroup symmetric_group
-@alias exponent_vectors exponents
 
 # make some Julia names compatible with our naming conventions
 @alias is_subset issubset

--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -1,5 +1,6 @@
 @alias has_isfinite has_is_finite
 @alias SymmetricGroup symmetric_group
+@alias exponent_vectors exponents
 
 # make some Julia names compatible with our naming conventions
 @alias is_subset issubset

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -27,3 +27,6 @@ function tail(a...)
   return AbstractAlgebra.tail(a...)
 end
 
+function exponents(a...)
+  return AbstractAlgebra.exponent_vectors(a...)
+end

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -161,7 +161,8 @@ import Nemo:
 exclude = [:Nemo, :AbstractAlgebra, :Rational, :change_uniformizer,
     :genus_symbol, :data, :narrow_class_group, :perm, :SymmetricGroup,
     :coefficients, :leading_coefficient, :coefficients_and_exponents,
-    :exponents, :monomials, :leading_monomial, :terms, :leading_term, :tail, :Partition]
+    :exponents, :exponent_vectors, :monomials, :leading_monomial, :terms,
+    :leading_term, :tail, :Partition]
 
 for i in names(Hecke)
   (i in exclude || !isdefined(Hecke, i)) && continue

--- a/test/Rings/PBWAlgebra-test.jl
+++ b/test/Rings/PBWAlgebra-test.jl
@@ -56,12 +56,12 @@ end
   @test p == leading_coefficient(p)*leading_monomial(p) + tail(p)
 
   s = build_ctx(R)
-  for (c, e) in zip(coefficients(p), exponent_vectors(p))
+  for (c, e) in zip(coefficients(p), exponents(p))
     push_term!(s, c, e)
   end
   @test p == finish(s)
 
-  @test p == R(collect(coefficients(p)), collect(exponent_vectors(p)))
+  @test p == R(collect(coefficients(p)), collect(exponents(p)))
 end
 
 @testset "PBWAlgebra.weyl_algebra" begin

--- a/test/Serialization/polymake/runtests.jl
+++ b/test/Serialization/polymake/runtests.jl
@@ -22,7 +22,7 @@
         i = load(joinpath(@__DIR__, "ideal.mv"))
         @test i isa Oscar.Ideal
         @test map(collect, map(coefficients, gens(i))) == [[1, 1], [1, -4]]
-        @test map(collect, map(exponent_vectors, gens(i))) ==
+        @test map(collect, map(exponents, gens(i))) ==
             [[[2, 0], [0, 1]], [[3, 0], [0, 1]]]
     end
 end


### PR DESCRIPTION
Closes #1903 .
I might have overlooked a place where it is used, so lets see the CI run.
~~We could also make `exponent_vectors` an alias for `exponents`?~~
Also, should there be a documentation on this as discussed in #1903 ?