### PR TITLE
Change in -> issubset

### DIFF
--- a/docs/src/PolyhedralGeometry/Polyhedra/auxiliary.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/auxiliary.md
@@ -60,7 +60,7 @@ automorphism_group_generators(IM::IncidenceMatrix)
 all_triangulations
 boundary_lattice_points(P::Polyhedron{QQFieldElem})
 Base.in(v::AbstractVector, P::Polyhedron)
-Base.in(P::Polyhedron{T}, Q::Polyhedron{T}) where T<:scalar_types
+Base.issubset(P::Polyhedron{T}, Q::Polyhedron{T}) where T<:scalar_types
 ehrhart_polynomial(P::Polyhedron{QQFieldElem})
 ehrhart_polynomial(R::QQPolyRing, P::Polyhedron{QQFieldElem})
 h_star_polynomial(P::Polyhedron{QQFieldElem})

--- a/docs/src/PolyhedralGeometry/cones.md
+++ b/docs/src/PolyhedralGeometry/cones.md
@@ -44,7 +44,7 @@ secondary_cone(SOP::SubdivisionOfPoints{T}) where T<:scalar_types
 ```@docs
 ambient_dim(C::Cone)
 Base.in(v::AbstractVector, C::Cone)
-Base.in(C0::Cone{T}, C1::Cone{T}) where T<:scalar_types
+Base.issubset(C0::Cone{T}, C1::Cone{T}) where T<:scalar_types
 f_vector(C::Cone)
 hilbert_basis(C::Cone{QQFieldElem})
 codim(C::Cone)

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -535,9 +535,9 @@ _matrix_for_polymake(::Val{_hilbert_generator}) = _generator_matrix
 
 
 @doc raw"""
-    in(C0::Cone, C1::Cone)                           
+    issubset(C0::Cone, C1::Cone)                           
     
-Check whether `C0` is contained in `C1` as a subset.
+Check whether `C0` is a subset of the cone `C1`.
                                              
 # Examples                 
 ```jldoctest                                                                                
@@ -547,14 +547,14 @@ Polyhedral cone in ambient dimension 2
 julia> C1 = positive_hull([1 0; 0 1])
 Polyhedral cone in ambient dimension 2
 
-julia> C0 in C1
+julia> issubset(C0, C1)
 true
 
-julia> C1 in C0
+julia> issubset(C1, C0)
 false
 ```
 """
-Base.in(C0::Cone{T}, C1::Cone{T}) where T<:scalar_types = Polymake.polytope.included_polyhedra(pm_object(C0), pm_object(C1))::Bool
+Base.issubset(C0::Cone{T}, C1::Cone{T}) where T<:scalar_types = Polymake.polytope.included_polyhedra(pm_object(C0), pm_object(C1))::Bool
 
 
 @doc raw"""

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -936,9 +936,9 @@ is_feasible(P::Polyhedron) = pm_object(P).FEASIBLE::Bool
 
 
 @doc raw"""
-    in(P::Polyhedron, Q::Polyhedron)
+    issubset(P::Polyhedron, Q::Polyhedron)
 
-Check whether `P` is contained in `Q` as a subset.
+Check whether `P` is a subset of the polyhedron `Q`.
 
 # Examples
 ```jldoctest
@@ -948,14 +948,14 @@ Polyhedron in ambient dimension 3
 julia> Q = cube(3,-1,2)
 Polyhedron in ambient dimension 3
 
-julia> P in Q
+julia> issubset(P, Q)
 true
 
-julia> Q in P
+julia> issubset(Q, P)
 false
 ```
 """
-Base.in(P::Polyhedron{T}, Q::Polyhedron{T}) where T<:scalar_types = Polymake.polytope.included_polyhedra(pm_object(P), pm_object(Q))::Bool
+Base.issubset(P::Polyhedron{T}, Q::Polyhedron{T}) where T<:scalar_types = Polymake.polytope.included_polyhedra(pm_object(P), pm_object(Q))::Bool
 
 
 @doc raw"""

--- a/test/PolyhedralGeometry/Cone.jl
+++ b/test/PolyhedralGeometry/Cone.jl
@@ -16,8 +16,8 @@ const pm = Polymake
 
     @testset "core functionality" begin
         @test is_pointed(Cone1)
-        @test Cone7 in Cone1
-        @test !(Cone1 in Cone7)
+        @test issubset(Cone7, Cone1)
+        @test !issubset(Cone1, Cone7)
         @test [1, 0] in Cone1
         @test !([-1, -1] in Cone1)
         if T == QQFieldElem

--- a/test/PolyhedralGeometry/Polyhedron.jl
+++ b/test/PolyhedralGeometry/Polyhedron.jl
@@ -21,8 +21,8 @@
     R,x = polynomial_ring(QQ, "x")
 
     @testset "core functionality" begin
-        @test Q0 in Q1
-        @test !(Q1 in Q0)
+      @test issubset(Q0, Q1)
+        @test !issubset(Q1, Q0)
         @test [1, 0] in Q0
         @test !([-1, -1] in Q0)
         @test nvertices(Q0) == 3

--- a/test/PolyhedralGeometry/Polyhedron.jl
+++ b/test/PolyhedralGeometry/Polyhedron.jl
@@ -21,7 +21,7 @@
     R,x = polynomial_ring(QQ, "x")
 
     @testset "core functionality" begin
-      @test issubset(Q0, Q1)
+        @test issubset(Q0, Q1)
         @test !issubset(Q1, Q0)
         @test [1, 0] in Q0
         @test !([-1, -1] in Q0)


### PR DESCRIPTION
Address misunderstanding of https://github.com/oscar-system/Oscar.jl/pull/2230#discussion_r1162565560
- `in(Cone, Cone)` becomes `issubset(Cone, Cone)`
- `in(Polyhedron, Polyhedron)` becomes `issubset(Polyhedron, Polyhedron)`