### PR TITLE
Support more rings for `is_graded` and friends

### DIFF
--- a/src/Rings/mpoly-affine-algebras.jl
+++ b/src/Rings/mpoly-affine-algebras.jl
@@ -412,11 +412,10 @@ function multi_hilbert_series(A::MPolyQuoRing; alg=:BayerStillmanA)
    R = base_ring(A)
    I = A.I
    @req coefficient_ring(R) isa AbstractAlgebra.Field "The coefficient ring must be a field"
-   if !(R isa MPolyDecRing && is_graded(R) && is_positively_graded(R))
-       throw(ArgumentError("The base ring must be positively graded."))
-   end
+   @req is_positively_graded(R) "The base ring must be positively graded"
+
    G = grading_group(R)
-   if !(is_zm_graded(R))
+   if !is_zm_graded(R)
       H, iso = snf(G)
       V = [preimage(iso, x) for x in gens(G)]
       isoinv = hom(G, H, V)
@@ -466,9 +465,7 @@ end
 #   R = base_ring(A)
 #   I = A.I
 #   @req coefficient_ring(R) isa AbstractAlgebra.Field "The coefficient ring must be a field"
-#   if !(R isa MPolyDecRing && is_graded(R) && is_positively_graded(R))
-#       throw(ArgumentError("The base ring must be positively graded."))
-#   end
+#   @req is_positively_graded(R) "The base ring must be positively graded"
 #   if !(is_zm_graded(R))
 #      G = grading_group(R)
 #      H, iso = snf(G)
@@ -1023,9 +1020,9 @@ function minimal_subalgebra_generators(V::Vector{T}) where T <: Union{MPolyRingE
   @assert all(x->parent(x) == p, V)
   @req coefficient_ring(p) isa AbstractAlgebra.Field "The coefficient ring must be a field"
   if p isa MPolyRing
-      @req p isa MPolyDecRing && is_positively_graded(p) "The base ring must be positively graded"
+      @req is_positively_graded(p) "The base ring must be positively graded"
   else
-      @req base_ring(p) isa MPolyDecRing && is_graded(p) "The base ring must be graded"
+      @req is_graded(p) "The base ring must be graded"
   end
   @req all(is_homogeneous, V) "The input data is not homogeneous"
   # iterate over the generators, starting with those in lowest degree, then work up

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -49,7 +49,12 @@ Return `true` if `R` is graded, `false` otherwise.
 function is_graded(R::MPolyDecRing)
    return !isdefined(R, :lt)
 end
+
+is_graded(::MPolyRing) = false
+
 is_filtered(R::MPolyDecRing) = isdefined(R, :lt)
+is_filtered(::MPolyRing) = false
+
 
 function show(io::IO, W::MPolyDecRing)
   Hecke.@show_name(io, W)
@@ -212,6 +217,8 @@ function is_standard_graded(R::MPolyDecRing)
   return true
 end
 
+is_standard_graded(::MPolyRing) = false
+
 @doc raw"""
     is_z_graded(R::MPolyDecRing)
 
@@ -242,6 +249,8 @@ function is_z_graded(R::MPolyDecRing)
   A = grading_group(R)
   return ngens(A) == 1 && rank(A) == 1 && is_free(A)
 end
+
+is_z_graded(::MPolyRing) = false
 
 @doc raw"""
     is_zm_graded(R::MPolyDecRing)
@@ -299,6 +308,8 @@ function is_zm_graded(R::MPolyDecRing)
   A = grading_group(R)
   return is_free(A) && ngens(A) == rank(A)
 end
+
+is_zm_graded(::MPolyRing) = false
 
 @doc raw"""
     is_positively_graded(R::MPolyDecRing)
@@ -368,6 +379,8 @@ function is_positively_graded(R::MPolyDecRing)
   end
   return true
 end
+
+is_positively_graded(::MPolyRing) = false
 
 @doc raw"""
     graded_polynomial_ring(C::Ring, V, W; ordering=:lex)
@@ -1493,9 +1506,7 @@ mutable struct HilbertData
   I::MPolyIdeal
   function HilbertData(I::MPolyIdeal)
     R = base_ring(I)
-    if !((R isa Oscar.MPolyDecRing) && is_graded(R))
-      throw(ArgumentError("The base ring must be graded."))
-    end
+    @req is_graded(R) "The base ring must be graded"
 
     W = R.d
     W = [Int(W[i][1]) for i = 1:ngens(R)]


### PR DESCRIPTION
Allow invoking `is_graded` and friends on any multivariate polynomial
ring, even undecorated ones -- in the undecorated case just always
return `false`.

This allows to simplify code that performs argument checking and also
seems fine in terms of correctness.
