### PR TITLE
LieAlgebras: Enhance module interface

### DIFF
--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -102,8 +102,8 @@ function bracket(
   check_parent(x, y)
   L = parent(x)
   mat = sum(
-    cxi * cyj * L.struct_consts[i, j] for (i, cxi) in enumerate(Generic._matrix(x)),
-    (j, cyj) in enumerate(Generic._matrix(y))
+    cxi * cyj * L.struct_consts[i, j] for (i, cxi) in enumerate(coefficients(x)),
+    (j, cyj) in enumerate(coefficients(y))
   )
   return L(mat)
 end

--- a/experimental/LieAlgebras/src/GapWrapper.jl
+++ b/experimental/LieAlgebras/src/GapWrapper.jl
@@ -32,7 +32,7 @@ function gap_lie_algebra_by_struct_consts(L::LieAlgebra{C}) where {C<:RingElemen
       [
         begin
           pairs = filter(
-            pair -> !iszero(last(pair)), collect(enumerate(Generic._matrix(xi * xj)))
+            pair -> !iszero(last(pair)), collect(enumerate(coefficients(xi * xj)))
           )
           (map(first, pairs), GAP.Obj[isoR(c) for c in map(last, pairs)])
         end for xj in basis(L)

--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -46,11 +46,19 @@ function zero(L::LieAlgebra{C}) where {C<:RingElement}
 end
 
 function iszero(x::LieAlgebraElem{C}) where {C<:RingElement}
-  return iszero(Generic._matrix(x))
+  return iszero(coefficients(x))
 end
 
 @inline function Generic._matrix(x::LieAlgebraElem{C}) where {C<:RingElement}
   return (x.mat)::dense_matrix_type(C)
+end
+
+function coefficients(x::LieAlgebraElem{C}) where {C<:RingElement}
+  return collect(Generic._matrix(x))[1, :]
+end
+
+function coeff(x::LieAlgebraElem{C}, i::Int) where {C<:RingElement}
+  return Generic._matrix(x)[1, i]
 end
 
 @doc raw"""
@@ -59,7 +67,7 @@ end
 Return the $i$-th coefficient of the module element $x$.
 """
 function getindex(x::LieAlgebraElem{C}, i::Int) where {C<:RingElement}
-  return Generic._matrix(x)[1, i]
+  return coeff(x, i)
 end
 
 function Base.deepcopy_internal(x::LieAlgebraElem{C}, dict::IdDict) where {C<:RingElement}
@@ -80,7 +88,7 @@ function expressify(
   v::LieAlgebraElem{C}, s=symbols(parent(v)); context=nothing
 ) where {C<:RingElement}
   sum = Expr(:call, :+)
-  for (i, c) in enumerate(Generic._matrix(v))
+  for (i, c) in enumerate(coefficients(v))
     push!(sum.args, Expr(:call, :*, expressify(c; context=context), s[i]))
   end
   return sum
@@ -177,12 +185,12 @@ end
 
 function Base.:(==)(x1::LieAlgebraElem{C}, x2::LieAlgebraElem{C}) where {C<:RingElement}
   check_parent(x1, x2)
-  return Generic._matrix(x1) == Generic._matrix(x2)
+  return coefficients(x1) == coefficients(x2)
 end
 
 function Base.hash(x::LieAlgebraElem{C}, h::UInt) where {C<:RingElement}
   b = 0x6724cbedbd860982 % UInt
-  return xor(hash(Generic._matrix(x), hash(parent(x), h)), b)
+  return xor(hash(coefficients(x), hash(parent(x), h)), b)
 end
 
 ###############################################################################

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -120,17 +120,17 @@ end
 
 function show_exterior_power(io::IO, V::LieAlgebraModule{C}) where {C<:RingElement}
   print(io, "$(get_attribute(V, :power))-th exterior power of ")
-  print(IOContext(io, :compact => true), get_attribute(V, :inner_module))
+  print(IOContext(io, :compact => true), base_module(V))
 end
 
 function show_symmetric_power(io::IO, V::LieAlgebraModule{C}) where {C<:RingElement}
   print(io, "$(get_attribute(V, :power))-th symmetric power of ")
-  print(IOContext(io, :compact => true), get_attribute(V, :inner_module))
+  print(IOContext(io, :compact => true), base_module(V))
 end
 
 function show_tensor_power(io::IO, V::LieAlgebraModule{C}) where {C<:RingElement}
   print(io, "$(get_attribute(V, :power))-th tensor power of ")
-  print(IOContext(io, :compact => true), get_attribute(V, :inner_module))
+  print(IOContext(io, :compact => true), base_module(V))
 end
 
 function symbols(V::LieAlgebraModule{C}) where {C<:RingElement}
@@ -190,7 +190,7 @@ function (V::LieAlgebraModule{C})(
 ) where {T<:LieAlgebraModuleElem{C}} where {C<:RingElement}
   @req is_exterior_power(V) || is_symmetric_power(V) || is_tensor_power(V) "Only implemented for power modules."
   @req length(a) == get_attribute(V, :power) "Length of vector does not match power."
-  @req all(x -> parent(x) == get_attribute(V, :inner_module), a) "Incompatible modules."
+  @req all(x -> parent(x) == base_module(V), a) "Incompatible modules."
   mat = zero_matrix(base_ring(V), 1, dim(V))
   if is_exterior_power(V)
     for (i, _inds) in enumerate(get_attribute(V, :ind_map)),
@@ -340,6 +340,11 @@ function is_tensor_power(V::LieAlgebraModule{C}) where {C<:RingElement}
   return get_attribute(V, :type, :fallback) == :tensor_power
 end
 
+function base_module(V::LieAlgebraModule{C}) where {C<:RingElement}
+  @req is_exterior_power(V) || is_symmetric_power(V) || is_tensor_power(V) "Not a power module."
+  return get_attribute(V, :base_module)
+end
+
 ###############################################################################
 #
 #   Constructor
@@ -428,7 +433,7 @@ function exterior_power(V::LieAlgebraModule{C}, k::Int) where {C<:RingElement}
     pow_V,
     :type => :exterior_power,
     :power => k,
-    :inner_module => V,
+    :base_module => V,
     :ind_map => ind_map,
     :show => show_exterior_power,
   )
@@ -485,7 +490,7 @@ function symmetric_power(V::LieAlgebraModule{C}, k::Int) where {C<:RingElement}
     pow_V,
     :type => :symmetric_power,
     :power => k,
-    :inner_module => V,
+    :base_module => V,
     :ind_map => ind_map,
     :show => show_symmetric_power,
   )
@@ -520,7 +525,7 @@ function tensor_power(V::LieAlgebraModule{C}, k::Int) where {C<:RingElement}
     pow_V,
     :type => :tensor_power,
     :power => k,
-    :inner_module => V,
+    :base_module => V,
     :ind_map => ind_map,
     :show => show_tensor_power,
   )

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -488,7 +488,17 @@ function direct_sum(V::LieAlgebraModule{C}...) where {C<:RingElement}
   transformation_matrices = map(1:dim(L)) do i
     block_diagonal_matrix([transformation_matrix(Vj, i) for Vj in V])
   end
-  s = vcat(map(symbols, V)...)
+  parentheses = x -> "($x)"
+
+  if length(V) == 1
+    s = symbols(V[1])
+  else
+    s = [
+      Symbol("$s^($j)") for (j, Vj) in enumerate(V) for
+      s in (is_standard_module(Vj) ? symbols(Vj) : parentheses.(symbols(Vj)))
+    ]
+  end
+
   direct_sum_V = LieAlgebraModule{C}(
     L, dim_direct_sum_V, transformation_matrices, s; check=false
   )
@@ -501,7 +511,7 @@ function direct_sum(V::LieAlgebraModule{C}...) where {C<:RingElement}
   return direct_sum_V
 end
 
-⊕(V::LieAlgebraModule{C}...) where {C<:RingElement} = tensor_product(V...)
+⊗(V::LieAlgebraModule{C}...) where {C<:RingElement} = tensor_product(V...)
 
 function tensor_product(V::LieAlgebraModule{C}...) where {C<:RingElement}
   @req length(V) >= 1 "At least one module must be given."

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -293,10 +293,10 @@ end
 ###############################################################################
 
 function Base.:(==)(V1::LieAlgebraModule{C}, V2::LieAlgebraModule{C}) where {C<:RingElement}
-  return V1.L == V2.L &&
-         V1.dim == V2.dim &&
-         V1.transformation_matrices == V2.transformation_matrices &&
-         V1.s == V2.s
+  return V1.dim == V2.dim &&
+         V1.s == V2.s &&
+         V1.L == V2.L &&
+         V1.transformation_matrices == V2.transformation_matrices
 end
 
 function Base.hash(V::LieAlgebraModule{C}, h::UInt) where {C<:RingElement}
@@ -353,37 +353,37 @@ end
 ###############################################################################
 
 function is_standard_module(V::LieAlgebraModule{C}) where {C<:RingElement}
-  return get_attribute(V, :type, :fallback) == :standard_module
+  return get_attribute(V, :type, :fallback)::Symbol == :standard_module
 end
 
 function is_dual(V::LieAlgebraModule{C}) where {C<:RingElement}
-  return get_attribute(V, :type, :fallback) == :dual
+  return get_attribute(V, :type, :fallback)::Symbol == :dual
 end
 
 function is_direct_sum(V::LieAlgebraModule{C}) where {C<:RingElement}
-  return get_attribute(V, :type, :fallback) == :direct_sum
+  return get_attribute(V, :type, :fallback)::Symbol == :direct_sum
 end
 
 function is_exterior_power(V::LieAlgebraModule{C}) where {C<:RingElement}
-  return get_attribute(V, :type, :fallback) == :exterior_power
+  return get_attribute(V, :type, :fallback)::Symbol == :exterior_power
 end
 
 function is_symmetric_power(V::LieAlgebraModule{C}) where {C<:RingElement}
-  return get_attribute(V, :type, :fallback) == :symmetric_power
+  return get_attribute(V, :type, :fallback)::Symbol == :symmetric_power
 end
 
 function is_tensor_power(V::LieAlgebraModule{C}) where {C<:RingElement}
-  return get_attribute(V, :type, :fallback) == :tensor_power
+  return get_attribute(V, :type, :fallback)::Symbol == :tensor_power
 end
 
 function base_module(V::LieAlgebraModule{C}) where {C<:RingElement}
   @req is_dual(V) || is_exterior_power(V) || is_symmetric_power(V) || is_tensor_power(V) "Not a power module."
-  return get_attribute(V, :base_module)
+  return get_attribute(V, :base_module)::LieAlgebraModule{C}
 end
 
 function base_modules(V::LieAlgebraModule{C}) where {C<:RingElement}
   @req is_direct_sum(V) "Not a direct sum module."
-  return get_attribute(V, :base_modules)
+  return get_attribute(V, :base_modules)::Vector{LieAlgebraModule{C}}
 end
 
 ###############################################################################
@@ -476,7 +476,10 @@ function direct_sum(V::LieAlgebraModule{C}...) where {C<:RingElement}
     L, dim_direct_sum_V, transformation_matrices, s; check=false
   )
   set_attribute!(
-    direct_sum_V, :type => :direct_sum, :base_modules => V, :show => show_direct_sum
+    direct_sum_V,
+    :type => :direct_sum,
+    :base_modules => collect(V),
+    :show => show_direct_sum,
   )
   return direct_sum_V
 end

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -28,7 +28,9 @@ import ..Oscar:
   parent_type,
   symbols,
   symmetric_power,
-  ⊕
+  tensor_product,
+  ⊕,
+  ⊗
 
 import Base: getindex, iszero, parent, zero
 
@@ -53,6 +55,7 @@ export is_exterior_power
 export is_standard_module
 export is_symmetric_power
 export is_tensor_power
+export is_tensor_product
 export lie_algebra
 export matrix_repr_basis
 export multicombinations
@@ -95,6 +98,7 @@ export is_exterior_power
 export is_standard_module
 export is_symmetric_power
 export is_tensor_power
+export is_tensor_product
 export lie_algebra
 export matrix_repr_basis
 export special_linear_lie_algebra

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -14,6 +14,8 @@ import ..Oscar:
   action,
   base_ring,
   basis,
+  coeff,
+  coefficients,
   dim,
   elem_type,
   expressify,

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -84,10 +84,13 @@ export LinearLieAlgebra, LinearLieAlgebraElem
 export abstract_module
 export base_lie_algebra
 export base_module
+export base_modules
 export bracket
 export exterior_power
 export general_linear_lie_algebra
 export highest_weight_module
+export is_direct_sum
+export is_dual
 export is_exterior_power
 export is_standard_module
 export is_symmetric_power

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -17,6 +17,7 @@ import ..Oscar:
   coeff,
   coefficients,
   dim,
+  direct_sum,
   dual,
   elem_type,
   expressify,
@@ -26,7 +27,8 @@ import ..Oscar:
   ngens,
   parent_type,
   symbols,
-  symmetric_power
+  symmetric_power,
+  ⊕
 
 import Base: getindex, iszero, parent, zero
 
@@ -38,12 +40,14 @@ export LinearLieAlgebra, LinearLieAlgebraElem
 export abstract_module
 export base_lie_algebra
 export base_module
+export base_modules
 export bracket
 export coefficient_vector
 export combinations
 export exterior_power
 export general_linear_lie_algebra
 export highest_weight_module
+export is_direct_sum
 export is_dual
 export is_exterior_power
 export is_standard_module

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -34,6 +34,7 @@ export LinearLieAlgebra, LinearLieAlgebraElem
 
 export abstract_module
 export base_lie_algebra
+export base_module
 export bracket
 export coefficient_vector
 export combinations
@@ -74,6 +75,7 @@ export LinearLieAlgebra, LinearLieAlgebraElem
 
 export abstract_module
 export base_lie_algebra
+export base_module
 export bracket
 export exterior_power
 export general_linear_lie_algebra

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -17,6 +17,7 @@ import ..Oscar:
   coeff,
   coefficients,
   dim,
+  dual,
   elem_type,
   expressify,
   exterior_power,
@@ -43,6 +44,7 @@ export combinations
 export exterior_power
 export general_linear_lie_algebra
 export highest_weight_module
+export is_dual
 export is_exterior_power
 export is_standard_module
 export is_symmetric_power

--- a/experimental/LieAlgebras/test/AbstractLieAlgebra-test.jl
+++ b/experimental/LieAlgebras/test/AbstractLieAlgebra-test.jl
@@ -1,5 +1,5 @@
 @testset "LieAlgebras.AbstractLieAlgebra" begin
-  function sl2_struct_consts(R::Oscar.Ring)
+  function sl2_struct_consts(R::Ring)
     sc = zeros(R, 3, 3, 3)
     sc[1, 2, 3] = R(1)
     sc[2, 1, 3] = R(-1)

--- a/experimental/LieAlgebras/test/LieAlgebra-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebra-test.jl
@@ -13,9 +13,9 @@ function lie_algebra_conformance_test(
     @test parent_type(elemT) == parentT
     @test elem_type(parentT) == elemT
 
-    @test parent(x) == L
+    @test parent(x) === L
 
-    @test base_ring(x) == base_ring(L)
+    @test base_ring(x) === base_ring(L)
     @test elem_type(base_ring(L)) == C
 
     # this block stays only as long as `ngens` and `gens` are not specialized for Lie algebras
@@ -81,7 +81,7 @@ function lie_algebra_conformance_test(
     end
   end
 
-  @testset "lie algebra axioms" begin
+  @testset "Lie algebra axioms" begin
     for _ in 1:num_random_tests
       x = L(rand(-10:10, dim(L)))
       y = L(rand(-10:10, dim(L)))

--- a/experimental/LieAlgebras/test/LieAlgebra-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebra-test.jl
@@ -28,6 +28,8 @@ function lie_algebra_conformance_test(
 
     @test iszero(zero(L))
 
+    @test coefficients(x) == [coeff(x, i) for i in 1:dim(L)]
+    @test all(i -> coeff(x, i) == x[i], 1:dim(L))
     @test sum(x[i] * basis(L, i) for i in 1:dim(L)) == x
 
     @test x == x

--- a/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
@@ -32,6 +32,8 @@ function lie_algebra_module_conformance_test(
 
     @test iszero(zero(V))
 
+    @test coefficients(v) == [coeff(v, i) for i in 1:dim(V)]
+    @test all(i -> coeff(v, i) == v[i], 1:dim(V))
     @test sum(v[i] * basis(V, i) for i in 1:dim(V)) == v
 
     @test v == v
@@ -206,7 +208,7 @@ end
 
     x = L(rand(-10:10, dim(L)))
     v = V(rand(-10:10, dim(V)))
-    @test x * v == V(transpose(matrix_repr(x) * transpose(Generic._matrix(v))))
+    @test x * v == V(matrix_repr(x) * coefficients(v))
   end
 
   @testset "exterior_power" begin
@@ -315,7 +317,7 @@ end
       struct_const_V = Matrix{Vector{Tuple{elem_type(R),Int}}}(undef, dimL, dimV)
       for (i, xi) in enumerate(basis(L)), (j, vj) in enumerate(basis(V))
         struct_const_V[i, j] = [
-          (c, k) for (k, c) in enumerate(Generic._matrix(xi * vj)) if !iszero(c)
+          (c, k) for (k, c) in enumerate(coefficients(xi * vj)) if !iszero(c)
         ]
       end
       return struct_const_V

--- a/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
@@ -205,6 +205,7 @@ end
 
     @test is_standard_module(V)
     @test !is_dual(V)
+    @test !is_direct_sum(V)
     @test !is_exterior_power(V)
     @test !is_symmetric_power(V)
     @test !is_tensor_power(V)
@@ -227,6 +228,7 @@ end
 
     @test !is_standard_module(dual_V)
     @test is_dual(dual_V)
+    @test !is_direct_sum(V)
     @test !is_exterior_power(dual_V)
     @test !is_symmetric_power(dual_V)
     @test !is_tensor_power(dual_V)
@@ -239,6 +241,31 @@ end
         Oscar.LieAlgebras.transformation_matrix(V, i),
       1:dim(L),
     )
+  end
+
+  @testset "direct_sum" begin
+    L = special_orthogonal_lie_algebra(QQ, 4)
+    V = symmetric_power(standard_module(L), 2)
+    type_V = module_type_bools(V)
+
+    for k in 1:3
+      ds_V = direct_sum([V for _ in 1:k]...)
+      @test type_V == module_type_bools(V) # construction of ds_V should not change type of V
+      @test collect(base_modules(ds_V)) == [V for _ in 1:k]
+      @test dim(ds_V) == k * dim(V)
+      @test length(repr(ds_V)) < 10^4 # outputs tend to be excessively long due to recursion
+
+      @test !is_standard_module(ds_V)
+      @test !is_dual(ds_V)
+      @test is_direct_sum(ds_V)
+      @test !is_exterior_power(ds_V)
+      @test !is_symmetric_power(ds_V)
+      @test !is_tensor_power(ds_V)
+
+      x = L(rand(-10:10, dim(L)))
+      a = [V(rand(-10:10, dim(V))) for _ in 1:k]
+      @test ds_V([x * v for v in a]) == x * ds_V(a)
+    end
   end
 
   @testset "exterior_power" begin
@@ -255,6 +282,7 @@ end
 
       @test !is_standard_module(pow_V)
       @test !is_dual(V)
+      @test !is_direct_sum(V)
       @test is_exterior_power(pow_V)
       @test !is_symmetric_power(pow_V)
       @test !is_tensor_power(pow_V)
@@ -288,6 +316,7 @@ end
 
       @test !is_standard_module(pow_V)
       @test !is_dual(V)
+      @test !is_direct_sum(V)
       @test !is_exterior_power(pow_V)
       @test is_symmetric_power(pow_V)
       @test !is_tensor_power(pow_V)
@@ -321,6 +350,7 @@ end
 
       @test !is_standard_module(pow_V)
       @test !is_dual(V)
+      @test !is_direct_sum(V)
       @test !is_exterior_power(pow_V)
       @test !is_symmetric_power(pow_V)
       @test is_tensor_power(pow_V)

--- a/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
@@ -17,9 +17,9 @@ function lie_algebra_module_conformance_test(
     @test parent_type(elemT) == parentT
     @test elem_type(parentT) == elemT
 
-    @test parent(v) == V
+    @test parent(v) === V
 
-    @test base_ring(v) == base_ring(V)
+    @test base_ring(v) === base_ring(V)
     @test elem_type(base_ring(V)) == C
 
     @test base_lie_algebra(V) === L
@@ -87,7 +87,7 @@ function lie_algebra_module_conformance_test(
     end
   end
 
-  @testset "lie algebra action axioms" begin
+  @testset "Lie algebra action axioms" begin
     for _ in 1:num_random_tests
       x = L(rand(-10:10, dim(L)))
       y = L(rand(-10:10, dim(L)))

--- a/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
@@ -217,6 +217,7 @@ end
     for k in 1:3
       pow_V = exterior_power(V, k)
       @test type_V == module_type_bools(V) # construction of pow_V should not change type of V
+      @test base_module(pow_V) === V
       @test dim(pow_V) == binomial(dim(V), k)
       @test length(repr(pow_V)) < 10^4 # outputs tend to be excessively long due to recursion
 
@@ -248,6 +249,7 @@ end
     for k in 1:3
       pow_V = symmetric_power(V, k)
       @test type_V == module_type_bools(V) # construction of pow_V should not change type of V
+      @test base_module(pow_V) === V
       @test dim(pow_V) == binomial(dim(V) + k - 1, k)
       @test length(repr(pow_V)) < 10^4 # outputs tend to be excessively long due to recursion
 
@@ -279,6 +281,7 @@ end
     for k in 1:3
       pow_V = tensor_power(V, k)
       @test type_V == module_type_bools(V) # construction of pow_V should not change type of V
+      @test base_module(pow_V) === V
       @test dim(pow_V) == dim(V)^k
       @test length(repr(pow_V)) < 10^4 # outputs tend to be excessively long due to recursion
 

--- a/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
@@ -22,6 +22,8 @@ function lie_algebra_module_conformance_test(
     @test base_ring(v) == base_ring(V)
     @test elem_type(base_ring(V)) == C
 
+    @test base_lie_algebra(V) === L
+
     # this block stays only as long as `ngens` and `gens` are not specialized for Lie algebra modules
     @test dim(V) == ngens(V)
     @test basis(V) == gens(V)
@@ -202,6 +204,7 @@ end
     @test length(repr(V)) < 10^4 # outputs tend to be excessively long due to recursion
 
     @test is_standard_module(V)
+    @test !is_dual(V)
     @test !is_exterior_power(V)
     @test !is_symmetric_power(V)
     @test !is_tensor_power(V)
@@ -209,6 +212,33 @@ end
     x = L(rand(-10:10, dim(L)))
     v = V(rand(-10:10, dim(V)))
     @test x * v == V(matrix_repr(x) * coefficients(v))
+  end
+
+  @testset "dual" begin
+    L = special_orthogonal_lie_algebra(QQ, 4)
+    V = symmetric_power(standard_module(L), 2)
+    type_V = module_type_bools(V)
+
+    dual_V = dual(V)
+    @test type_V == module_type_bools(V) # construction of dual_V should not change type of V
+    @test base_module(dual_V) === V
+    @test dim(dual_V) == dim(V)
+    @test length(repr(dual_V)) < 10^4 # outputs tend to be excessively long due to recursion
+
+    @test !is_standard_module(dual_V)
+    @test is_dual(dual_V)
+    @test !is_exterior_power(dual_V)
+    @test !is_symmetric_power(dual_V)
+    @test !is_tensor_power(dual_V)
+
+    dual_dual_V = dual(dual_V)
+    @test dim(dual_dual_V) == dim(V)
+    @test all(
+      i ->
+        Oscar.LieAlgebras.transformation_matrix(dual_dual_V, i) ==
+        Oscar.LieAlgebras.transformation_matrix(V, i),
+      1:dim(L),
+    )
   end
 
   @testset "exterior_power" begin
@@ -224,6 +254,7 @@ end
       @test length(repr(pow_V)) < 10^4 # outputs tend to be excessively long due to recursion
 
       @test !is_standard_module(pow_V)
+      @test !is_dual(V)
       @test is_exterior_power(pow_V)
       @test !is_symmetric_power(pow_V)
       @test !is_tensor_power(pow_V)
@@ -256,6 +287,7 @@ end
       @test length(repr(pow_V)) < 10^4 # outputs tend to be excessively long due to recursion
 
       @test !is_standard_module(pow_V)
+      @test !is_dual(V)
       @test !is_exterior_power(pow_V)
       @test is_symmetric_power(pow_V)
       @test !is_tensor_power(pow_V)
@@ -288,6 +320,7 @@ end
       @test length(repr(pow_V)) < 10^4 # outputs tend to be excessively long due to recursion
 
       @test !is_standard_module(pow_V)
+      @test !is_dual(V)
       @test !is_exterior_power(pow_V)
       @test !is_symmetric_power(pow_V)
       @test is_tensor_power(pow_V)

--- a/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
@@ -251,7 +251,7 @@ end
     for k in 1:3
       ds_V = direct_sum([V for _ in 1:k]...)
       @test type_V == module_type_bools(V) # construction of ds_V should not change type of V
-      @test collect(base_modules(ds_V)) == [V for _ in 1:k]
+      @test base_modules(ds_V) == [V for _ in 1:k]
       @test dim(ds_V) == k * dim(V)
       @test length(repr(ds_V)) < 10^4 # outputs tend to be excessively long due to recursion
 

--- a/experimental/LieAlgebras/test/LinearLieAlgebra-test.jl
+++ b/experimental/LieAlgebras/test/LinearLieAlgebra-test.jl
@@ -61,7 +61,7 @@
       struct_const_L = Matrix{Vector{Tuple{elem_type(R),Int}}}(undef, dimL, dimL)
       for (i, xi) in enumerate(basis(L)), (j, xj) in enumerate(basis(L))
         struct_const_L[i, j] = [
-          (c, k) for (k, c) in enumerate(Generic._matrix(xi * xj)) if !iszero(c)
+          (c, k) for (k, c) in enumerate(coefficients(xi * xj)) if !iszero(c)
         ]
       end
       return struct_const_L


### PR DESCRIPTION
Currently, there is some weird behavior when two identical modules have been constructed in different ways, e.g. some module and its 1st exterior power.
```julia
julia> L = special_orthogonal_lie_algebra(QQ, 4)
LinearLieAlgebra (⊆ gl_4) over Rational Field

julia> std_V = standard_module(L)
StdModule of LinearLieAlgebra (⊆ gl_4) over Rational Field

julia> V = exterior_power(std_V, 1)
<StackOverflowError>

julia> is_exterior_power(std_V)
true
```
This PR first adds tests modeling the intended behavior and then approaches to fix the above accordingly.

While on my way, I may add some more module constructions.