### PR TITLE
CI: run apt-get update before installing bibtool

### DIFF
--- a/.github/workflows/BibtoolCI.yml
+++ b/.github/workflows/BibtoolCI.yml
@@ -20,7 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install bibtool
-        run: sudo apt-get install -y bibtool
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y bibtool
       - name: Execute bibtool and check for changes
         run: |
           bibtool docs/oscar_references.bib -o docs/oscar_references.bib


### PR DESCRIPTION
Otherwise the repo caches might be outdated.

This should fix #2263, lets see if it works.

_Edit:_ Seems to work: `Bibtool test / check-standard-refs (pull_request) Successful in 38s`