### PR TITLE
workaround for a bug in `GAP.Globals.TestDirectory`

### DIFF
--- a/test/GAP/runtests.jl
+++ b/test/GAP/runtests.jl
@@ -7,4 +7,6 @@ include("iso_oscar_gap.jl")
 include("oscar_to_gap.jl")
 
 # Test the OscarInterface package
+GAP_assertion_level = GAP.Globals.AssertionLevel()
 @test GAP.Globals.TestDirectory(GAP.Globals.DirectoriesPackageLibrary(GAP.Obj("OscarInterface"), GAP.Obj("tst")))
+GAP.Globals.SetAssertionLevel(GAP_assertion_level)


### PR DESCRIPTION
resolves #2259