### PR TITLE
Intersection of ideals

### DIFF
--- a/docs/src/CommutativeAlgebra/affine_algebras.md
+++ b/docs/src/CommutativeAlgebra/affine_algebras.md
@@ -280,6 +280,7 @@ minimal_generating_set(I::MPolyQuoIdeal{<:MPolyDecRingElem})
 
 ```@docs
 intersect(a::MPolyQuoIdeal{T}, bs::MPolyQuoIdeal{T}...) where T
+intersect(V::Vector{MPolyQuoIdeal{T}}) where T
 ```
 
 #### Ideal Quotients

--- a/docs/src/CommutativeAlgebra/ideals.md
+++ b/docs/src/CommutativeAlgebra/ideals.md
@@ -107,6 +107,7 @@ minimal_generating_set(I::MPolyIdeal{<:MPolyDecRingElem})
 
 ```@docs
 intersect(I::MPolyIdeal{T}, Js::MPolyIdeal{T}...) where T
+intersect(V::Vector{MPolyIdeal{T}}) where T
 ```
 
 ### Ideal Quotients

--- a/docs/src/NoncommutativeAlgebra/PBWAlgebras/ideals.md
+++ b/docs/src/NoncommutativeAlgebra/PBWAlgebras/ideals.md
@@ -92,6 +92,7 @@ dx
 
 ```@docs
 intersect(I::PBWAlgIdeal{D, T, S}, Js::PBWAlgIdeal{D, T, S}...) where {D, T, S}
+intersect(V::Vector{PBWAlgIdeal{D, T, S}}) where {D, T, S}
 ```
 
 ### Elimination

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -334,6 +334,7 @@ end
 
 @doc raw"""
     intersect(a::MPolyQuoIdeal{T}, bs::MPolyQuoIdeal{T}...) where T
+    intersect(V::Vector{MPolyQuoIdeal{T}}) where T
 
 Return the intersection of two or more ideals.
 
@@ -351,6 +352,9 @@ ideal(x)
 
 julia> intersect(a,b)
 ideal(x*y)
+
+julia> intersect([a,b])
+ideal(x*y)
 ```
 """
 function intersect(a::MPolyQuoIdeal{T}, b::MPolyQuoIdeal{T}...) where T
@@ -359,10 +363,16 @@ function intersect(a::MPolyQuoIdeal{T}, b::MPolyQuoIdeal{T}...) where T
   for g in b
     base_ring(g) == base_ring(a) || error("base rings must match")
     singular_assure(g)
-    gs = g.gens.S
-    as = Singular.intersection(as, gs)
   end
+  as = Singular.intersection(as, [g.gens.S for g in b]...)
   return MPolyQuoIdeal(base_ring(a), as)
+end
+
+function intersect(V::Vector{MPolyQuoIdeal{T}}) where T
+  @assert length(V) != 0
+  length(V) == 1 && return V[1]
+
+  return intersect(V[1], V[2:end]...)
 end
 
 #######################################################

--- a/src/Rings/PBWAlgebra.jl
+++ b/src/Rings/PBWAlgebra.jl
@@ -917,6 +917,7 @@ end
 
 @doc raw"""
     intersect(I::PBWAlgIdeal{D, T, S}, Js::PBWAlgIdeal{D, T, S}...) where {D, T, S}
+    intersect(V::Vector{PBWAlgIdeal{D, T, S}}) where {D, T, S}
 
 Return the intersection of two or more ideals.
 
@@ -936,26 +937,30 @@ function Base.intersect(a::PBWAlgIdeal{D, T, S}, b::PBWAlgIdeal{D, T, S}...) whe
   end
   if D < 0
     res = a.sdata
-    for bi in b
-      res = Singular.intersection(res, bi.sdata)
-    end
+    res = Singular.intersection(res, [bi.sdata for bi in b]...)
     return PBWAlgIdeal{D, T, S}(R, res)
   elseif D > 0
     _sopdata_assure!(a)
     res = a.sopdata
     for bi in b
       _sopdata_assure!(bi)
-      res = Singular.intersection(res, bi.sopdata)
     end
+    res = Singular.intersection(res, [bi.sopdata for bi in b]...)
     return PBWAlgIdeal{D, T, S}(R, _opmap(R, res, _opposite(R)), res)
   else
     res = _as_left_ideal(a)
-    for bi in b
-      res = Singular.intersection(res, _as_left_ideal(bi))
-    end
+    res = Singular.intersection(res, [_as_left_ideal(bi) for bi in b]...)
     return PBWAlgIdeal{D, T, S}(R, res)
   end
 end
+
+function Base.intersect(V::Vector{PBWAlgIdeal{D, T, S}}) where {D, T, S}
+  @assert length(V) != 0
+  length(V) == 1 && return V[1]
+
+  return Base.intersect(V[1], V[2:end]...)
+end
+
 
 @doc raw"""
     ideal_membership(f::PBWAlgElem{T, S}, I::PBWAlgIdeal{D, T, S}) where {D, T, S}

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -162,6 +162,7 @@ end
 # ideal intersection #######################################################
 @doc raw"""
     intersect(I::MPolyIdeal{T}, Js::MPolyIdeal{T}...) where T
+    intersect(V::Vector{MPolyIdeal{T}}) where T
 
 Return the intersection of two or more ideals.
 
@@ -170,7 +171,11 @@ Return the intersection of two or more ideals.
 julia> R, (x, y) = polynomial_ring(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, QQMPolyRingElem[x, y])
 
-julia> I = intersect(ideal(R, [x, y])^2, ideal(R, [y^2-x^3+x]))
+julia> I = ideal(R, [x, y])^2
+julia> J = ideal(R, [y^2-x^3+x])
+julia> intersect(I, J)
+ideal(x^3*y - x*y - y^3, x^4 - x^2 - x*y^2)
+julia> intersect([I, J])
 ideal(x^3*y - x*y - y^3, x^4 - x^2 - x*y^2)
 ```
 """
@@ -179,10 +184,18 @@ function Base.intersect(I::MPolyIdeal{T}, Js::MPolyIdeal{T}...) where T
   si = I.gens.S
   for J in Js
     singular_assure(J)
-    si = Singular.intersection(si, J.gens.S)
   end
+  si = Singular.intersection(si, [J.gens.S for J in Js]...)
   return MPolyIdeal(base_ring(I), si)
 end
+
+function Base.intersect(V::Vector{MPolyIdeal{T}}) where T
+  @assert length(V) != 0
+  length(V) == 1 && return V[1]
+
+  return Base.intersect(V[1], V[2:end]...)
+end
+
 
 #######################################################
 

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -171,10 +171,13 @@ Return the intersection of two or more ideals.
 julia> R, (x, y) = polynomial_ring(QQ, ["x", "y"])
 (Multivariate Polynomial Ring in x, y over Rational Field, QQMPolyRingElem[x, y])
 
-julia> I = ideal(R, [x, y])^2
-julia> J = ideal(R, [y^2-x^3+x])
+julia> I = ideal(R, [x, y])^2;
+
+julia> J = ideal(R, [y^2-x^3+x]);
+
 julia> intersect(I, J)
 ideal(x^3*y - x*y - y^3, x^4 - x^2 - x*y^2)
+
 julia> intersect([I, J])
 ideal(x^3*y - x*y - y^3, x^4 - x^2 - x*y^2)
 ```

--- a/test/Rings/MPolyQuo_test.jl
+++ b/test/Rings/MPolyQuo_test.jl
@@ -109,6 +109,9 @@ end
   @test (I == J) == false
   @test dim(J)  == 1
   @test dim(J)  == J.dim  # test case if dim(J) is already set
+  K = ideal(Q, [ x*y+1 ])
+  @test intersect(I,J,K) == ideal(Q, [y+1, x])
+  @test intersect(I,J,K) == intersect([I,J,k])
 
   R, (x, y) = grade(polynomial_ring(QQ, [ "x", "y"])[1], [ 1, 2 ])
   I = ideal(R, [ x*y ])

--- a/test/Rings/MPolyQuo_test.jl
+++ b/test/Rings/MPolyQuo_test.jl
@@ -111,7 +111,7 @@ end
   @test dim(J)  == J.dim  # test case if dim(J) is already set
   K = ideal(Q, [ x*y+1 ])
   @test intersect(I,J,K) == ideal(Q, [y+1, x])
-  @test intersect(I,J,K) == intersect([I,J,k])
+  @test intersect(I,J,K) == intersect([I,J,K])
 
   R, (x, y) = grade(polynomial_ring(QQ, [ "x", "y"])[1], [ 1, 2 ])
   I = ideal(R, [ x*y ])

--- a/test/Rings/PBWAlgebra-test.jl
+++ b/test/Rings/PBWAlgebra-test.jl
@@ -115,6 +115,7 @@ end
   I = intersect(left_ideal(R, [dy]), left_ideal(R, [dx]))
   @test x*dy*dx in I
   @test !(dy*dx*x in I)
+  @test intersect(left_ideal(R, [dy]), left_ideal(R, [dx])) ==  intersect([left_ideal(R, [dy]), left_ideal(R, [dx])])
 
   I = intersect(right_ideal(R, [dy]), right_ideal(R, [dx]))
   @test dy*dx*x in I

--- a/test/Rings/PBWAlgebra-test.jl
+++ b/test/Rings/PBWAlgebra-test.jl
@@ -115,7 +115,7 @@ end
   I = intersect(left_ideal(R, [dy]), left_ideal(R, [dx]))
   @test x*dy*dx in I
   @test !(dy*dx*x in I)
-  @test intersect(left_ideal(R, [dy]), left_ideal(R, [dx])) ==  intersect([left_ideal(R, [dy]), left_ideal(R, [dx])])
+  @test intersect(left_ideal(R, [dy]), left_ideal(R, [dx])) == intersect([left_ideal(R, [dy]), left_ideal(R, [dx])])
 
   I = intersect(right_ideal(R, [dy]), right_ideal(R, [dx]))
   @test dy*dx*x in I

--- a/test/Rings/mpoly-test.jl
+++ b/test/Rings/mpoly-test.jl
@@ -82,6 +82,9 @@ end
   @test Oscar.check_base_rings(I, J) === nothing
   @test I+J == I-J == S
   @test I*J == P
+  @test intersect(I,J,P) == ideal(R,[x^2*y^2, x^4, x*y^4])
+  @test intersect(I,J,P) == intersect([I,J,P])
+
   f = x^2 + y^2
   g = x^4*y - x*y^3
   I = [f, g]


### PR DESCRIPTION
1. Uses more efficient intersection for ideals from Singular if there are more than two ideals to be intersected.
2. Allows vectors of ideals as input for `intersect`.

The above two points are applied to `MPolyIdeal`, `MPolyQuoIdeal` and `PBWAlgIdeal`.