### PR TITLE
Fix Alnuth override when Oscar is not in Main

### DIFF
--- a/gap/OscarInterface/gap/alnuth.gi
+++ b/gap/OscarInterface/gap/alnuth.gi
@@ -127,14 +127,14 @@ BindGlobal("NormCosetsDescriptionOscar", function(F, norm)
   return rec(units := units, creps := creps);
 end);
 
-
+BindGlobal("_Vector_nf_elem", Oscar.eval(Julia.Meta.parse(GAPToJulia("Vector{nf_elem}"))));
 
 BindGlobal("PolynomialFactorsDescriptionOscar", function(F, coeffs)
   local K, cf, poly, facs, result, f, g, i;
 
   K := _OscarField(F);
 
-  cf := JuliaEvalString( "Vector{nf_elem}")(Reversed(List(coeffs, x -> K(GAPToJulia(x)))));
+  cf := _Vector_nf_elem(Reversed(List(coeffs, x -> K(GAPToJulia(x)))));
   poly := Oscar.polynomial(K, cf);
   facs := Oscar.factor(poly);
   Assert(0, Oscar.is_one(facs.unit));


### PR DESCRIPTION
If OSCAR is not loaded by the user in the REPL, but indirectly, then nf_elem won't be available in the Main module, and hence evaluating 'Vector{nf_elem}' in there will fail.

So instead eval this inside the Oscar module.