### PR TITLE
Revert "Update TagBot.yml"

### DIFF
--- a/.github/workflows/Docu.yml
+++ b/.github/workflows/Docu.yml
@@ -6,6 +6,7 @@ on:
       - master
     tags: '*'
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   # group by workflow and ref; the last slightly strange component ensures that for pull

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -28,4 +28,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          #ssh: ${{ secrets.DOCUMENTER_KEY }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
This reverts commit 73bfbd84771e8a32677c40cf5ea45d185ff31acc.

Possibly fixes parts of #2274.

According to the [TagBot docs](https://documenter.juliadocs.org/stable/man/hosting/#GitHub-Actions) (in the yellow box `TagBot & tagged versions`) and the [TagBot Readme.md](https://github.com/JuliaRegistries/TagBot#setup), the ssh key should be contained. The rate-limit problem of tagbot hasn't been fixed by 73bfbd84771e8a32677c40cf5ea45d185ff31acc, so I see no point in keeping it longer.

Edit: Added `workflow_dispatch` as a trigger for easier re-runs in the future.

cc @benlorenz @fingolfin 