### PR TITLE
make sure that certain GAP packages are loaded

### DIFF
--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -268,8 +268,6 @@ nothing
 ```
 """
 function character_table(id::String, p::Int = 0)
-    @req hasproperty(GAP.Globals, :CTblLib) "no character table library available"
-
     if p == 0
       modid = id
     else
@@ -324,7 +322,6 @@ Currently the following series are supported.
 | `:ExtraspecialPlusOdd` | odd power of odd prime |
 """
 function character_table(series::Symbol, parameter::Union{Int, Vector{Int}})
-    @req hasproperty(GAP.Globals, :CTblLib) "no character table library available"
     args = GAP.Obj([string(series), parameter], recursive = true)
     tbl = GAP.Globals.CallFuncList(GAP.Globals.CharacterTable, args)::GapObj
     tbl === GAP.Globals.fail && return nothing

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -240,10 +240,13 @@ function __init__()
     withenv("TERMINFO_DIRS" => joinpath(GAP.GAP_jll.Readline_jll.Ncurses_jll.find_artifact_dir(), "share", "terminfo")) do
       GAP.Packages.load("browse"; install=true) # needed for all_character_table_names doctest
     end
-    GAP.Packages.load("ctbllib")
-    GAP.Packages.load("forms")
-    GAP.Packages.load("wedderga") # provides a function to compute Schur indices
-    GAP.Packages.load("repsn")
+    for pkg in ["ctbllib",
+                "forms",
+                "wedderga", # provides a function to compute Schur indices
+                "repsn",
+               ]
+      GAP.Packages.load(pkg) || error("cannot load the GAP package $pkg")
+    end
     __init_group_libraries()
 
     add_verbose_scope(:K3Auto)


### PR DESCRIPTION
Up to now, `GAP.Packages.load` is called for several GAP packages in Oscar's `__init__`, but we do not check whether the GAP package is really loaded afterwards.
(This means "load the package if it is available, but do not complain if it isn't".)

Now we throw an error if the packages cannot be loaded. Hence the Oscar code can assume that they are available, and need not check for it.

The GAP packages in question do not require compilation, thus I do not expect complications at runtime because of this change. (This is the reason why the packages `Browse` and `ferret` are currently not forced to be loaded.)