### PR TITLE
oscar_assure fix for MPolyQuoIdeals

### DIFF
--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -679,7 +679,12 @@ end
 
 function oscar_assure(B::BiPolyArray)
   if !isdefined(B, :O) || !isassigned(B.O, 1)
-    B.O = [B.Ox(x) for x = gens(B.S)]
+    if typeof(B.Ox) <: MPolyQuoRing
+      R = oscar_origin_ring(B.Ox)
+    else
+      R = B.Ox
+    end
+    B.O = [R(x) for x = gens(B.S)]
   end
 end
 

--- a/test/Rings/MPolyQuo_test.jl
+++ b/test/Rings/MPolyQuo_test.jl
@@ -216,3 +216,13 @@ end
   @test iszero(A(u) * A(u))
   @test iszero(A(x)*u)
 end
+
+@testset "issue #2292" begin
+  R, (x, y, z) = graded_polynomial_ring(QQ, ["x", "y", "z"])
+  A, p = quo(R, ideal(R, [x-y]))
+  V = [x, z^2, x^3+y^3, y^4, y*z^5]
+  a = ideal(A, V)
+  dim(a) # cashes a.gb
+  gens(a.gb)
+  @test a.gb.gens.O == MPolyDecRingElm[y, z^2]
+end

--- a/test/Rings/MPolyQuo_test.jl
+++ b/test/Rings/MPolyQuo_test.jl
@@ -224,5 +224,5 @@ end
   a = ideal(A, V)
   dim(a) # cashes a.gb
   gens(a.gb)
-  @test a.gb.gens.O == MPolyDecRingElm[y, z^2]
+  @test a.gb.gens.O == MPolyDecRingElem[y, z^2]
 end


### PR DESCRIPTION
This fixes the handling of the oscar side of IdealGens of MPolyQuoIdeals.

Fixes #2292, and adds this issue as a test.