### PR TITLE
Use kwarg 'algorithm' instead of 'alg', 'algo'

### DIFF
--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/homological_algebra.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/homological_algebra.md
@@ -40,7 +40,7 @@ homology(C::ComplexOfMorphisms{<:ModuleFP}, i::Int)
 ## Hom and Ext
 
 ```@docs
-hom(M::ModuleFP, N::ModuleFP, alg::Symbol=:maps)
+hom(M::ModuleFP, N::ModuleFP, algorithm::Symbol=:maps)
 ```
 
 ```@docs

--- a/docs/src/CommutativeAlgebra/affine_algebras.md
+++ b/docs/src/CommutativeAlgebra/affine_algebras.md
@@ -647,7 +647,7 @@ degree(A::MPolyQuoRing)
 ### Positive Gradings in General
 
 ```@docs
-multi_hilbert_series(A::MPolyQuoRing; alg::Symbol=:BayerStillmanA)
-multi_hilbert_series_reduced(A::MPolyQuoRing; alg::Symbol=:BayerStillmanA)
+multi_hilbert_series(A::MPolyQuoRing; algorithm::Symbol=:BayerStillmanA)
+multi_hilbert_series_reduced(A::MPolyQuoRing; algorithm::Symbol=:BayerStillmanA)
 multi_hilbert_function(A::MPolyQuoRing, g::GrpAbFinGenElem)
 ```

--- a/docs/src/CommutativeAlgebra/ideals.md
+++ b/docs/src/CommutativeAlgebra/ideals.md
@@ -196,7 +196,7 @@ radical(I::MPolyIdeal)
 ### Primary Decomposition
 
 ```@docs
-primary_decomposition(I::MPolyIdeal; alg = :GTZ)
+primary_decomposition(I::MPolyIdeal; algorithm::Symbol = :GTZ)
 ```
 
 ### Absolute Primary Decomposition
@@ -208,7 +208,7 @@ absolute_primary_decomposition(I::MPolyIdeal{QQMPolyRingElem})
 ### Minimal Associated Primes
 
 ```@docs
-minimal_primes(I::MPolyIdeal; alg = :GTZ)
+minimal_primes(I::MPolyIdeal; algorithm::Symbol = :GTZ)
 ```
 
 ### Weak Equidimensional Decomposition

--- a/docs/src/InvariantTheory/finite_groups.md
+++ b/docs/src/InvariantTheory/finite_groups.md
@@ -133,13 +133,13 @@ reynolds_operator(IR::InvRing{FldT, GrpT, T}, f::T, chi::GAPGroupClassFunction) 
 ## Invariants of a Given Degree
 
 ```@docs
-basis(IR::InvRing, d::Int, algo::Symbol = :default)
+basis(IR::InvRing, d::Int, algorithm::Symbol = :default)
 
 basis(IR::InvRing, d::Int, chi::GAPGroupClassFunction)
 ```
 
 ```@docs
-iterate_basis(IR::InvRing, d::Int, algo::Symbol = :default)
+iterate_basis(IR::InvRing, d::Int, algorithm::Symbol = :default)
 
 iterate_basis(IR::InvRing, d::Int, chi::GAPGroupClassFunction)
 ```
@@ -169,7 +169,7 @@ irreducible_secondary_invariants(IR::InvRing)
 ## Fundamental Systems of Invariants
 
 ```@docs
-fundamental_invariants(IR::InvRing, algo::Symbol = :default; beta::Int = 0)
+fundamental_invariants(IR::InvRing, algorithm::Symbol = :default; beta::Int = 0)
 ```
 
 ## Invariant Rings as Affine Algebras

--- a/examples/BinomIdeal.jl
+++ b/examples/BinomIdeal.jl
@@ -1075,9 +1075,9 @@ function associated_primes(I::MPolyIdeal)
   return [MPolyIdeal(I.gens.Ox, x) for x = a]
 end
 
-function decomposition(I::MPolyIdeal; algo::Symbol = :auto)
+function decomposition(I::MPolyIdeal; algorithm::Symbol = :auto)
   singular_assure(I)
-  if algo == :auto
+  if algorithm == :auto
     C = cellularDecomp(I.gens.S)
   else
     C = cellularDecompMacaulay(I.gens.S)

--- a/examples/BinomIdeal2.jl
+++ b/examples/BinomIdeal2.jl
@@ -1092,9 +1092,9 @@ function associated_primes(I::MPolyIdeal)
   return [MPolyIdeal(I.gens.Ox, x) for x = a]
 end
 
-function decomposition(I::MPolyIdeal; algo::Symbol = :auto)
+function decomposition(I::MPolyIdeal; algorithm::Symbol = :auto)
   singular_assure(I)
-  if algo == :auto
+  if algorithm == :auto
     C = cellularDecomp(I.gens.S)
   else
     C = cellularDecompMacaulay(I.gens.S)

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -1083,7 +1083,7 @@ end
 #otherwise, this gives a basis of the symmetric matrices, stabilized
 #by the group - but possibly not pos. definite
 #
-#to always get pos. def. one needs a different algo
+#to always get pos. def. one needs a different algorithm
 # - sum over group
 # - approximate reynolds as in invar thy (for number fields and Q/ Z)
 function invariant_forms(C::GModule{<:Any, <:Generic.FreeModule})

--- a/experimental/JuLie/partitions.jl
+++ b/experimental/JuLie/partitions.jl
@@ -268,37 +268,36 @@ end
 
 
 @doc raw"""
-    ascending_partitions(n::IntegerUnion;alg="ks")
+    ascending_partitions(n::IntegerUnion; algorithm::Symbol=:ks)
 
 Instead of encoding a partition of an integer ``n ≥ 0`` as a *descending*
 sequence (which is our convention), one can also encode it as an *ascending*
 sequence. In the papers Kelleher & O'Sullivan (2014) and Merca (2012) it is
 said that generating the list of all ascending partitions is more efficient
-than generating descending ones. To test this, I have implemented the
+than generating descending ones. To test this, we have implemented the
 algorithms given in the papers:
-1. "ks" (*default*) is the algorithm "AccelAsc" (Algorithm 4.1) in [KO14](@cite).
-2. "m" is Algorithm 6 in [Mer12](@cite). This is actually similar to "ks".
+1. `:ks` (*default*) is the algorithm "AccelAsc" (Algorithm 4.1) in [KO14](@cite).
+2. `:m` is Algorithm 6 in [Mer12](@cite). This is actually similar to `:ks`.
 
 The ascending partitions are stored here as arrays and are not of type
-`Partition` since the latter are descending by our convention. I am using "ks"
-as default since it looks slicker and I believe there is a tiny mistake in the
-publication of "m" (which I fixed).
+`Partition` since the latter are descending by our convention. We are using `:ks`
+as default since it looks slicker.
 
 # Comparison
 
-I don't see a significant speed difference to the descending encoding:
+We don't see a significant speed difference to the descending encoding:
 ```julia-repl
 julia> @btime partitions(Int8(90));
 3.376 s (56634200 allocations: 6.24 GiB)
 
-julia> @btime ascending_partitions(Int8(90),alg="ks");
+julia> @btime ascending_partitions(Int8(90), algorithm=:ks);
 3.395 s (56634200 allocations: 6.24 GiB)
 
-julia> @btime ascending_partitions(Int8(90),alg="m");
+julia> @btime ascending_partitions(Int8(90), algorithm=:m);
 3.451 s (56634200 allocations: 6.24 GiB)
 ```
 """
-function ascending_partitions(n::IntegerUnion; alg="ks")
+function ascending_partitions(n::IntegerUnion; algorithm::Symbol="ks")
 
   #Argument checking
   @req n >= 0 "n >= 0 required"
@@ -314,7 +313,7 @@ function ascending_partitions(n::IntegerUnion; alg="ks")
   end
 
   # Now, the algorithm starts
-  if alg=="ks"
+  if algorithm === :ks
     P = Vector{T}[]    #this will be the array of all partitions
     a = zeros(T, n)
     k = 2
@@ -341,7 +340,7 @@ function ascending_partitions(n::IntegerUnion; alg="ks")
     end
     return P
 
-  elseif alg=="m"
+  elseif algorithm === :m
     P = Vector{T}[]    #this will be the array of all partitions
     a = zeros(T, n)
     k = 1
@@ -398,7 +397,7 @@ function ascending_partitions(n::IntegerUnion; alg="ks")
     end
     return P
   else
-    error("alg must be either ks or m")
+    error("algorithm must be either :ks or :m")
   end
 
 end

--- a/src/AlgebraicGeometry/Surfaces/K3Auto.jl
+++ b/src/AlgebraicGeometry/Surfaces/K3Auto.jl
@@ -1143,10 +1143,10 @@ Return the walls of the L|S chamber induced by `weyl_vector`.
 
 Corresponds Algorithm 5.11 in [Shi15](@cite) and calls Polymake.
 """
-function _walls_of_chamber(data::BorcherdsCtx, weyl_vector, alg=:short)
-  if alg==:short
+function _walls_of_chamber(data::BorcherdsCtx, weyl_vector, algorithm::Symbol=:short)
+  if algorithm==:short
     walls1 = _alg58_short_vector(data, weyl_vector)
-  elseif alg==:close
+  elseif algorithm==:close
     walls1 = _alg58_close_vector(data, weyl_vector)
   end
   if length(walls1)==rank(data.S)

--- a/src/InvariantTheory/fundamental_invariants.jl
+++ b/src/InvariantTheory/fundamental_invariants.jl
@@ -159,7 +159,7 @@ end
 ################################################################################
 
 @doc raw"""
-    fundamental_invariants(IR::InvRing, algo::Symbol = :default; beta::Int = 0)
+    fundamental_invariants(IR::InvRing, algorithm::Symbol = :default; beta::Int = 0)
 
 Return a system of fundamental invariants for `IR`.
 
@@ -176,7 +176,7 @@ supplied by the keyword argument `beta` and might result in an earlier terminati
 of the algorithm. By default, the algorithm uses the bounds from [DH00](@cite)
 and [Sez02](@cite).
 
-Alternatively, if specified by `algo = :primary_and_secondary`, the function computes
+Alternatively, if specified by `algorithm = :primary_and_secondary`, the function computes
 fundamental invariants from a collection of primary and irreducible secondary
 invariants.
 The optional keyword argument `beta` is ignored for this algorithm.
@@ -215,18 +215,18 @@ julia> fundamental_invariants(IR)
  x[1]^3*x[2]^6 + x[1]^6*x[3]^3 + x[2]^3*x[3]^6
 ```
 """
-function fundamental_invariants(IR::InvRing, algo::Symbol = :default; beta::Int = 0)
+function fundamental_invariants(IR::InvRing, algorithm::Symbol = :default; beta::Int = 0)
   if !isdefined(IR, :fundamental)
-    if algo == :default
-      algo = is_modular(IR) ? :primary_and_secondary : :king
+    if algorithm == :default
+      algorithm = is_modular(IR) ? :primary_and_secondary : :king
     end
 
-    if algo == :king
+    if algorithm == :king
       IR.fundamental = fundamental_invariants_via_king(IR, beta)
-    elseif algo == :primary_and_secondary
+    elseif algorithm == :primary_and_secondary
       IR.fundamental = fundamental_invariants_via_primary_and_secondary(IR)
     else
-      error("Unsupported argument :$(algo) for algo")
+      error("Unsupported argument :$(algorithm) for algorithm")
     end
   end
   return copy(IR.fundamental.invars)

--- a/src/InvariantTheory/invariant_rings.jl
+++ b/src/InvariantTheory/invariant_rings.jl
@@ -338,14 +338,14 @@ end
 ################################################################################
 
 @doc raw"""
-     basis(IR::InvRing, d::Int, algo::Symbol = :default)
+     basis(IR::InvRing, d::Int, algorithm::Symbol = :default)
 
 Given an invariant ring `IR` and an integer `d`, return a basis for the invariants in degree `d`.
 
-The optional argument `algo` specifies the algorithm to be used.
-If `algo = :reynolds`, the Reynolds operator is utilized (this method is only available in the non-modular case).
-Setting `algo = :linear_algebra` means that plain linear algebra is used.
-The default option `algo = :default` asks to select the heuristically best algorithm.
+The optional argument `algorithm` specifies the algorithm to be used.
+If `algorithm = :reynolds`, the Reynolds operator is utilized (this method is only available in the non-modular case).
+Setting `algorithm = :linear_algebra` means that plain linear algebra is used.
+The default option `algorithm = :default` asks to select the heuristically best algorithm.
 
 See also [`iterate_basis`](@ref).
 
@@ -405,7 +405,7 @@ julia> basis(IR, 3)
  x[1]^2*x[3] + 2*x[2]^2*x[3]
 ```
 """
-basis(IR::InvRing, d::Int, algo = :default) = collect(iterate_basis(IR, d, algo))
+basis(IR::InvRing, d::Int, algorithm::Symbol = :default) = collect(iterate_basis(IR, d, algorithm))
 
 @doc raw"""
     basis(IR::InvRing, d::Int, chi::GAPGroupClassFunction)

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -93,15 +93,15 @@ function dimension_via_molien_series(::Type{T}, R::InvRing, d::Int, chi::Union{G
 end
 
 @doc raw"""
-     iterate_basis(IR::InvRing, d::Int, algo::Symbol = :default)
+     iterate_basis(IR::InvRing, d::Int, algorithm::Symbol = :default)
 
 Given an invariant ring `IR` and an integer `d`, return an iterator over a basis
 for the invariants in degree `d`.
 
-The optional argument `algo` specifies the algorithm to be used.
-If `algo = :reynolds`, the Reynolds operator is utilized (this method is only available in the non-modular case).
-Setting `algo = :linear_algebra` means that plain linear algebra is used.
-The default option `algo = :default` asks to select the heuristically best algorithm.
+The optional argument `algorithm` specifies the algorithm to be used.
+If `algorithm = :reynolds`, the Reynolds operator is utilized (this method is only available in the non-modular case).
+Setting `algorithm = :linear_algebra` means that plain linear algebra is used.
+The default option `algorithm = :default` asks to select the heuristically best algorithm.
 
 When using the Reynolds operator, the basis is constructed element-by-element.
 With linear algebra, this is not possible and the basis will be constructed
@@ -174,12 +174,12 @@ julia> collect(B)
  x[3]^2
 ```
 """
-function iterate_basis(R::InvRing, d::Int, algo::Symbol = :default)
+function iterate_basis(R::InvRing, d::Int, algorithm::Symbol = :default)
   @assert d >= 0 "Degree must be non-negative"
 
-  if algo == :default
+  if algorithm == :default
     if is_modular(R)
-      algo = :linear_algebra
+      algorithm = :linear_algebra
     else
       # Use the estimate in KS99, Section 17.2
       # We use the "worst case" estimate, so 2d|G|/s instead of sqrt(2d|G|/s)
@@ -195,19 +195,19 @@ function iterate_basis(R::InvRing, d::Int, algo::Symbol = :default)
       n = degree(group(R))
       k = binomial(n + d - 1, n - 1)
       if k > d*g/s
-        algo = :reynolds
+        algorithm = :reynolds
       else
-        algo = :linear_algebra
+        algorithm = :linear_algebra
       end
     end
   end
 
-  if algo == :reynolds
+  if algorithm == :reynolds
     return iterate_basis_reynolds(R, d)
-  elseif algo == :linear_algebra
+  elseif algorithm == :linear_algebra
     return iterate_basis_linear_algebra(R, d)
   else
-    error("Unsupported argument :$(algo) for algo.")
+    error("Unsupported argument :$(algorithm) for algorithm")
   end
 end
 

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -5325,9 +5325,9 @@ julia> relations(H)
  y^2*(e[2] -> e[2])
 ```
 """
-function hom(M::ModuleFP, N::ModuleFP, alg::Symbol=:maps)
+function hom(M::ModuleFP, N::ModuleFP, algorithm::Symbol=:maps)
   #source: Janko's CA script: https://www.mathematik.uni-kl.de/~boehm/lehre/17_CA/ca.pdf
-  if alg == :matrices && M isa SubquoModule && N isa SubquoModule
+  if algorithm == :matrices && M isa SubquoModule && N isa SubquoModule
     if is_graded(M) && is_graded(N)
       error("This algorithm is not implemented for graded modules.")
     end

--- a/src/NumberTheory/GaloisGrp/GaloisGrp.jl
+++ b/src/NumberTheory/GaloisGrp/GaloisGrp.jl
@@ -763,7 +763,7 @@ end
 
 #one cannot compare (==) slpoly, no hash either..
 #(cannot be done, thus comparison is indirect via evaluation)
-#I assume algo can be improved (TODO: Max?)
+#I assume algorithm can be improved (TODO: Max?)
 function probable_orbit(G::Oscar.PermGroup, f::SLPoly; limit::Int = typemax(Int))
   n = ngens(parent(f))
   F = GF(next_prime(2^50))
@@ -1916,9 +1916,9 @@ julia> roots(C, 2)
  (19^0 + O(19^2))*a + 11*19^0 + 19^1 + O(19^2)
 ```
 """
-function galois_group(K::AnticNumberField, extra::Int = 5; useSubfields::Bool = true, pStart::Int = 2*degree(K), prime::Int = 0, algo::Symbol=:pAdic)
+function galois_group(K::AnticNumberField, extra::Int = 5; useSubfields::Bool = true, pStart::Int = 2*degree(K), prime::Int = 0, algorithm::Symbol=:pAdic)
 
-  @assert algo in [:pAdic, :Complex, :Symbolic]
+  @assert algorithm in [:pAdic, :Complex, :Symbolic]
 
   if prime != 0
     p = prime
@@ -1940,19 +1940,19 @@ function galois_group(K::AnticNumberField, extra::Int = 5; useSubfields::Bool = 
   #       or the RootCtx needs to learn to deal with bad primes
  
   while true
-    if algo == :pAdic
+    if algorithm == :pAdic
       GC = GaloisCtx(Hecke.Globals.Zx(numerator(K.pol)), p)
-    elseif algo == :Complex
+    elseif algorithm == :Complex
       GC = GaloisCtx(Hecke.Globals.Zx(numerator(K.pol)), AcbField(20))
-    elseif algo == :Symbolic
+    elseif algorithm == :Symbolic
       GC = GaloisCtx(Hecke.Globals.Zx(numerator(K.pol)))
     else
-      error("wrong algo used")
+      error("wrong algorithm used")
     end
     r = roots(GC, 5)
     if length(r) < degree(K) 
       @vprint :GaloisGroup 1 "in recursion: bad prime detected\n"
-      algo != :pAdic || error("internal error aborting")
+      algorithm != :pAdic || error("internal error aborting")
       prime == 0 || throw(Hecke.BadPrime(p))
       p, _ = find_prime(K.pol, pStart = p+1)
       continue

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -1749,12 +1749,12 @@ function _hilbert_numerator_from_leading_exponents(
     a::Vector{Vector{Int}},
     weight_matrix::Matrix{Int},
     return_ring::Ring,
-    #alg=:generator
-    #alg=:custom
-    #alg=:gcd
-    #alg=:indeterminate
-    #alg=:cocoa
-    alg::Symbol # =:BayerStillmanA, # This is by far the fastest strategy. Should be used.
+    #algorithm=:generator
+    #algorithm=:custom
+    #algorithm=:gcd
+    #algorithm=:indeterminate
+    #algorithm=:cocoa
+    algorithm::Symbol # =:BayerStillmanA, # This is by far the fastest strategy. Should be used.
     # short exponent vectors where the k-th bit indicates that the k-th 
     # exponent is non-zero.
   )
@@ -1762,17 +1762,17 @@ function _hilbert_numerator_from_leading_exponents(
   ret = _hilbert_numerator_trivial_cases(a, weight_matrix, return_ring, t)
   ret !== nothing && return ret
 
-  if alg == :BayerStillmanA
+  if algorithm == :BayerStillmanA
     return _hilbert_numerator_bayer_stillman(a, weight_matrix, return_ring, t)
-  elseif alg == :custom
+  elseif algorithm == :custom
     return _hilbert_numerator_custom(a, weight_matrix, return_ring, t)
-  elseif alg == :gcd # see Remark 5.3.11
+  elseif algorithm == :gcd # see Remark 5.3.11
     return _hilbert_numerator_gcd(a, weight_matrix, return_ring, t)
-  elseif alg == :generator # just choosing on random generator, cf. Remark 5.3.8
+  elseif algorithm == :generator # just choosing on random generator, cf. Remark 5.3.8
     return _hilbert_numerator_generator(a, weight_matrix, return_ring, t)
-  elseif alg == :indeterminate # see Remark 5.3.8
+  elseif algorithm == :indeterminate # see Remark 5.3.8
     return _hilbert_numerator_indeterminate(a, weight_matrix, return_ring, t)
-  elseif alg == :cocoa # see Remark 5.3.14
+  elseif algorithm == :cocoa # see Remark 5.3.14
     return _hilbert_numerator_cocoa(a, weight_matrix, return_ring, t)
   end
   error("invalid algorithm")

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -444,7 +444,7 @@ Computes the radical.
 end
 #######################################################
 @doc raw"""
-    primary_decomposition(I::MPolyIdeal; alg = :GTZ, cache=true)
+    primary_decomposition(I::MPolyIdeal; algorithm = :GTZ, cache=true)
 
 Return a minimal primary decomposition of `I`. If `I` is the unit ideal, return `[ideal(1)]`.
 
@@ -455,8 +455,8 @@ the $Q_i$ is `I`.
 # Implemented Algorithms
 
 If the base ring of `I` is a polynomial ring over a field, the algorithm of Gianni, Trager, and Zacharias
-is used by default (`alg = :GTZ`). Alternatively, the algorithm by Shimoyama and Yokoyama can be used
-by specifying `alg = :SY`.  For polynomial rings over the integers, the algorithm proceeds as suggested by
+is used by default (`algorithm = :GTZ`). Alternatively, the algorithm by Shimoyama and Yokoyama can be used
+by specifying `algorithm = :SY`.  For polynomial rings over the integers, the algorithm proceeds as suggested by
 Pfister, Sadiq, and Steidel. See [GTZ88](@cite), [SY96](@cite), and [PSS11](@cite).
 
 !!! warning
@@ -481,7 +481,7 @@ julia> L = primary_decomposition(I)
  (ideal(x^2 - 2*x*y - 2*x + y^2 + 2*y + 1), ideal(x - y - 1))
  (ideal(y, x^2), ideal(x, y))
 
-julia> L = primary_decomposition(I, alg = :SY, cache=false)
+julia> L = primary_decomposition(I, algorithm = :SY, cache=false)
 3-element Vector{Tuple{MPolyIdeal{QQMPolyRingElem}, MPolyIdeal{QQMPolyRingElem}}}:
  (ideal(x^3 - x - y^2), ideal(x^3 - x - y^2))
  (ideal(x^2 - 2*x*y - 2*x + y^2 + 2*y + 1), ideal(x - y - 1))
@@ -511,20 +511,20 @@ julia> L = primary_decomposition(I)
  (ideal(9, 3*d^5, d^10), ideal(3, d))
 ```
 """
-function primary_decomposition(I::T; alg=:GTZ, cache=true) where {T<:MPolyIdeal}
-  !cache && return _compute_primary_decomposition(I, alg=alg)
+function primary_decomposition(I::T; algorithm::Symbol=:GTZ, cache::Bool=true) where {T<:MPolyIdeal}
+  !cache && return _compute_primary_decomposition(I, algorithm=algorithm)
   return get_attribute!(I, :primary_decomposition) do
-    return _compute_primary_decomposition(I, alg=alg)
+    return _compute_primary_decomposition(I, algorithm=algorithm)
   end::Vector{Tuple{T,T}}
 end
 
-function _compute_primary_decomposition(I::MPolyIdeal; alg=:GTZ)
+function _compute_primary_decomposition(I::MPolyIdeal; algorithm::Symbol=:GTZ)
   R = base_ring(I)
   singular_assure(I)
   if elem_type(base_ring(R)) <: FieldElement
-    if alg == :GTZ
+    if algorithm == :GTZ
       L = Singular.LibPrimdec.primdecGTZ(I.gens.Sx, I.gens.S)
-    elseif alg == :SY
+    elseif algorithm == :SY
       L = Singular.LibPrimdec.primdecSY(I.gens.Sx, I.gens.S)
     else
       error("algorithm invalid")
@@ -642,7 +642,7 @@ end
 
 #######################################################
 @doc raw"""
-    minimal_primes(I::MPolyIdeal; alg = :GTZ)
+    minimal_primes(I::MPolyIdeal; algorithm::Symbol = :GTZ)
 
 Return a vector containing the minimal associated prime ideals of `I`.
 If `I` is the unit ideal, return `[ideal(1)]`.
@@ -650,8 +650,8 @@ If `I` is the unit ideal, return `[ideal(1)]`.
 # Implemented Algorithms
 
 If the base ring of `I` is a polynomial ring over a field, the algorithm of
-Gianni, Trager, and Zacharias is used by default (`alg = :GTZ`). Alternatively, characteristic sets can be
-used by specifying `alg = :charSets`. For polynomial rings over the integers,
+Gianni, Trager, and Zacharias is used by default (`algorithm = :GTZ`). Alternatively, characteristic sets can be
+used by specifying `algorithm = :charSets`. For polynomial rings over the integers,
 the algorithm proceeds as suggested by Pfister, Sadiq, and Steidel.
 See [GTZ88](@cite) and [PSS11](@cite).
 
@@ -671,7 +671,7 @@ julia> L = minimal_primes(I)
  ideal(x - y - 1)
  ideal(x^3 - x - y^2)
 
-julia> L = minimal_primes(I, alg = :charSets)
+julia> L = minimal_primes(I, algorithm = :charSets)
 2-element Vector{MPolyIdeal{QQMPolyRingElem}}:
  ideal(x - y - 1)
  ideal(x^3 - x - y^2)
@@ -698,13 +698,13 @@ julia> L = minimal_primes(I)
  ideal(17, a)
 ```
 """
-function minimal_primes(I::MPolyIdeal; alg = :GTZ)
+function minimal_primes(I::MPolyIdeal; algorithm::Symbol = :GTZ)
   R = base_ring(I)
   singular_assure(I)
   if elem_type(base_ring(R)) <: FieldElement
-    if alg == :GTZ
+    if algorithm == :GTZ
       l = Singular.LibPrimdec.minAssGTZ(I.gens.Sx, I.gens.S)
-    elseif alg == :charSets
+    elseif algorithm == :charSets
       l = Singular.LibPrimdec.minAssChar(I.gens.Sx, I.gens.S)
     else
       error("algorithm invalid")

--- a/src/StraightLinePrograms/atlas.jl
+++ b/src/StraightLinePrograms/atlas.jl
@@ -201,7 +201,7 @@ function evaluate!(res::Vector{S}, p::AbstractAtlasSL, xs::Vector{S}) where S
         # first copy the outputs at the end of res before moving them
         # at the beginning of the array, to avoid overwriting values
         # which are still needed
-        # TODO: this algo can be slightly optimized
+        # TODO: this algorithm can be slightly optimized
         for i in p.outputs
             push!(res, res[i])
         end

--- a/test/Experimental/JuLie/partitions.jl
+++ b/test/Experimental/JuLie/partitions.jl
@@ -64,8 +64,8 @@
 	check = true
 	for n in 0:20
 		# go through all algorithms
-		for a in [ "ks", "m" ]
-			P = ascending_partitions(n,alg=a)
+		for a in [ :ks, :m ]
+			P = ascending_partitions(n,algorithm=a)
 			# check that number of partitions is correct
 			if length(P) != num_partitions(n)
 				check = false

--- a/test/Experimental/galois-test.jl
+++ b/test/Experimental/galois-test.jl
@@ -26,8 +26,8 @@
 
   K, a = number_field(x^4-2)
   G, C = galois_group(K)
-  Gc, Cc = galois_group(K, algo = :Complex)
-  Gs, Cs = galois_group(K, algo = :Symbolic)
+  Gc, Cc = galois_group(K, algorithm = :Complex)
+  Gs, Cs = galois_group(K, algorithm = :Symbolic)
   @test is_isomorphic(G, Gc)
   @test is_isomorphic(G, Gs)
 end

--- a/test/Rings/mpoly-test.jl
+++ b/test/Rings/mpoly-test.jl
@@ -115,7 +115,7 @@ end
   i = ideal(R, [x, y*z^2])
   for method in (:GTZ, :SY)
     j = ideal(R, [R(1)])
-    for (q, p) in primary_decomposition(i, alg=method)
+    for (q, p) in primary_decomposition(i, algorithm=method)
       j = intersect(j, q)
       @test is_primary(q)
       @test is_prime(p)
@@ -138,7 +138,7 @@ end
   @test length(l) == 2
   @test l[1] == i1 && l[2] == i2 || l[1] == i2 && l[2] == i1
 
-  l = minimal_primes(i, alg=:charSets)
+  l = minimal_primes(i, algorithm=:charSets)
   @test length(l) == 2
   @test l[1] == i1 && l[2] == i2 || l[1] == i2 && l[2] == i1
 

--- a/test/Rings/mpoly_affine_algebras_test.jl
+++ b/test/Rings/mpoly_affine_algebras_test.jl
@@ -20,13 +20,13 @@
   for algorithm in (:equidimDec, :primeDec)
     R, (x, y, z) = polynomial_ring(QQ, ["x", "y", "z"])
     Q, _ = quo(R, ideal(R, [(x^2 - y^3)*(x^2 + y^2)*x]))
-    for (S, M, FI) in normalization(Q, alg=algorithm)
+    for (S, M, FI) in normalization(Q, algorithm=algorithm)
       @test parent(FI[1]) == Q
       @test isa(FI[2], Oscar.Ideal)
       @test parent(M(Q(x+y))) == S
     end
 
-    stuff, deltas, tot_delta = normalization_with_delta(Q, alg=algorithm)
+    stuff, deltas, tot_delta = normalization_with_delta(Q, algorithm=algorithm)
     @test isa(tot_delta, Int)
     @test length(stuff) == length(deltas)
     for ((S, M, FI), delta) in zip(stuff, deltas)
@@ -46,7 +46,7 @@ end
 
 @testset "mpoly_affine_algebras.integral_basis" begin
   R, (x, y) = polynomial_ring(QQ, ["x", "y"])
-  (den, nums) = integral_basis(y^5-x^3*(x+1)^4, 2; alg = :hensel)
+  (den, nums) = integral_basis(y^5-x^3*(x+1)^4, 2; algorithm = :hensel)
   @test all(p -> base_ring(parent(p)) == R, nums)
   @test base_ring(parent(den)) == R
   @test_throws ArgumentError integral_basis(x*y^5-x^3*(x+1)^4, 2)
@@ -54,9 +54,9 @@ end
   @test_throws ArgumentError integral_basis((x+y)*(x+y^2), 1)
 
   R, (x, y) = polynomial_ring(GF(2), ["x", "y"])
-  @test_throws ArgumentError integral_basis(y^5-x^3*(x+1)^4, 2; alg = :what)
-  (den, nums) = integral_basis(y^5-x^3*(x+1)^4, 2; alg = :normal_global)
-  (den, nums) = integral_basis(y^5-x^3*(x+1)^4, 2; alg = :normal_local)
+  @test_throws ArgumentError integral_basis(y^5-x^3*(x+1)^4, 2; algorithm = :what)
+  (den, nums) = integral_basis(y^5-x^3*(x+1)^4, 2; algorithm = :normal_global)
+  (den, nums) = integral_basis(y^5-x^3*(x+1)^4, 2; algorithm = :normal_local)
   @test all(p -> base_ring(parent(p)) == R, nums)
   @test base_ring(parent(den)) == R
 


### PR DESCRIPTION
Resolves #2258

I used `algorithm`, which @thofma and me prefer, but I know @fieker prefers `algo`. I can certainly live with that, too, but in order to make some progress, I decided to just make this PR -- if necessary it can still be changed to use `algorithm`