### PR TITLE
use `unhomogenized_matrix` for construction of `Cone` and `PolyhedralFan`

### DIFF
--- a/src/PolyhedralGeometry/Cone/constructors.jl
+++ b/src/PolyhedralGeometry/Cone/constructors.jl
@@ -63,9 +63,9 @@ function positive_hull(::Type{T}, R::AbstractCollection[RayVector], L::Union{Abs
     end
 
     if non_redundant
-        return Cone{T}(Polymake.polytope.Cone{scalar_type_to_polymake[T]}(RAYS = inputrays, LINEALITY_SPACE = L,))
+        return Cone{T}(Polymake.polytope.Cone{scalar_type_to_polymake[T]}(RAYS = inputrays, LINEALITY_SPACE = unhomogenized_matrix(L),))
     else
-        return Cone{T}(Polymake.polytope.Cone{scalar_type_to_polymake[T]}(INPUT_RAYS = inputrays, INPUT_LINEALITY = L,))
+        return Cone{T}(Polymake.polytope.Cone{scalar_type_to_polymake[T]}(INPUT_RAYS = inputrays, INPUT_LINEALITY = unhomogenized_matrix(L),))
     end
 end
 # Redirect everything to the above constructor, use QQFieldElem as default for the

--- a/src/PolyhedralGeometry/PolyhedralFan/constructors.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/constructors.jl
@@ -79,12 +79,12 @@ Polyhedral fan in ambient dimension 2
 function PolyhedralFan{T}(Rays::AbstractCollection[RayVector], Incidence::IncidenceMatrix; non_redundant::Bool = false) where T<:scalar_types
    if non_redundant
       return PolyhedralFan{T}(Polymake.fan.PolyhedralFan{scalar_type_to_polymake[T]}(
-         RAYS = Rays,
+         RAYS = unhomogenized_matrix(Rays),
          MAXIMAL_CONES = Incidence,
       ))
    else
       return PolyhedralFan{T}(Polymake.fan.PolyhedralFan{scalar_type_to_polymake[T]}(
-         INPUT_RAYS = Rays,
+         INPUT_RAYS = unhomogenized_matrix(Rays),
          INPUT_CONES = Incidence,
       ))
    end
@@ -92,14 +92,14 @@ end
 function PolyhedralFan{T}(Rays::AbstractCollection[RayVector], LS::AbstractCollection[RayVector], Incidence::IncidenceMatrix; non_redundant::Bool = false) where T<:scalar_types
    if non_redundant
       return PolyhedralFan{T}(Polymake.fan.PolyhedralFan{scalar_type_to_polymake[T]}(
-         RAYS = Rays,
-         LINEALITY_SPACE = LS,
+         RAYS = unhomogenized_matrix(Rays),
+         LINEALITY_SPACE = unhomogenized_matrix(LS),
          MAXIMAL_CONES = Incidence,
       ))
    else
       return PolyhedralFan{T}(Polymake.fan.PolyhedralFan{scalar_type_to_polymake[T]}(
-         INPUT_RAYS = Rays,
-         INPUT_LINEALITY = LS,
+         INPUT_RAYS = unhomogenized_matrix(Rays),
+         INPUT_LINEALITY = unhomogenized_matrix(LS),
          INPUT_CONES = Incidence,
       ))
    end

--- a/test/PolyhedralGeometry/extended.jl
+++ b/test/PolyhedralGeometry/extended.jl
@@ -197,6 +197,12 @@
         @test_throws ArgumentError convex_hull(collect(rays(Pos_poly)))
         @test_throws ArgumentError convex_hull(vertices(Pos_poly), collect(vertices(Pos_poly)))
         @test_throws ArgumentError positive_hull(collect(vertices(Pos_poly)))
+
+	IM = IncidenceMatrix([[1]])
+	lincone = Cone([1 0 0], [0 1 0])
+
+	@test Cone(rays_modulo_lineality(lincone)...) == lincone
+	@test ambient_dim(PolyhedralFan(rays_modulo_lineality(lincone)..., IM)) == 3
         
     end
 

--- a/test/PolyhedralGeometry/extended.jl
+++ b/test/PolyhedralGeometry/extended.jl
@@ -198,11 +198,11 @@
         @test_throws ArgumentError convex_hull(vertices(Pos_poly), collect(vertices(Pos_poly)))
         @test_throws ArgumentError positive_hull(collect(vertices(Pos_poly)))
 
-	IM = IncidenceMatrix([[1]])
-	lincone = Cone([1 0 0], [0 1 0])
+        IM = IncidenceMatrix([[1]])
+        lincone = Cone([1 0 0], [0 1 0])
 
-	@test Cone(rays_modulo_lineality(lincone)...) == lincone
-	@test ambient_dim(PolyhedralFan(rays_modulo_lineality(lincone)..., IM)) == 3
+        @test Cone(rays_modulo_lineality(lincone)...) == lincone
+        @test ambient_dim(PolyhedralFan(rays_modulo_lineality(lincone)..., IM)) == 3
         
     end
 


### PR DESCRIPTION
This PR solves #2305 by using `unhomogenized_matrix` during the construction of `PolyhedralFan` objects. The reported error could also appear for `Cone`s and for rays given as `SubObjectIterator`, which is also fixed here. Some small tests were added to check for this specific case.