### PR TITLE
Use codecovs `after_n_builds`

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,8 @@
-coverage:
+codecov:
   notify:
     # Keep this in sync with the number of CI jobs uploading coverage.
     after_n_builds: 3
+coverage:
   status:
     project:
       default:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,7 @@
 coverage:
+  notify:
+    # Keep this in sync with the number of CI jobs uploading coverage.
+    after_n_builds: 3
   status:
     project:
       default:


### PR DESCRIPTION
Currently, we have 3 ci jobs uploading coverage data to codecov (test-ubuntu-1.8, doctest-ubuntu-1.8, doctest-macos-1.8).
After the first one of these finishing, codecov adds the comment, and thus everyone participating in e.g. a PR will get an email. In the following minutes, after the other two jobs finish, the comment will get edited automatically (the email of course will not). This can lead to big drops in coverage being reported after only one of three jobs is finished (e.g. doctests will be fast, but have a lot less coverage).

This change would delay the codecov comment and notification next to the running ci jobs until `3` jobs have uploaded coverage data. This number has to be kept in sync with the ci.