### PR TITLE
fixed `is_subgroup(H::T, G::T) where T <: GAPGroup`

### DIFF
--- a/src/GAP/iso_oscar_gap.jl
+++ b/src/GAP/iso_oscar_gap.jl
@@ -175,7 +175,7 @@ end
 function _iso_oscar_gap(FO::FinField)
    p = GAP.Obj(characteristic(FO))::GAP.Obj
    d = degree(FO)
-   if GAPWrap.IsCheapConwayPolynomial(p, d)
+   if d == 1 || GAPWrap.IsCheapConwayPolynomial(p, d)
      FG = GAPWrap.GF(p, d)
    else
      # Calling `GAPWrap.GF(p, d)` would throw a GAP error.

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -83,7 +83,11 @@ function is_subgroup(H::T, G::T) where T <: GAPGroup
    if !is_subset(H, G)
       return (false, nothing)
    else
-      return (true, _as_subgroup(G, H.X)[2])
+      # We do not call `_as_subgroup` because we want to store `H`.
+      return (true, hom(H, G,
+                        x -> group_element(G, x.X),
+                        x -> group_element(H, x.X);
+                        is_known_to_be_bijective = false))
    end
 end
 

--- a/test/GAP/iso_oscar_gap.jl
+++ b/test/GAP/iso_oscar_gap.jl
@@ -55,6 +55,21 @@ end
       end
    end
 
+   p = 257  # GAP regards the Conway polynomial for `GF(257, 1)` as not cheap.
+   @testset for F in [Nemo.fpField(UInt(257)), Nemo.FpField(ZZRingElem(257))]
+      f = Oscar.iso_oscar_gap(F)
+      oO = one(F)
+      oG = f(oO)
+      for a in F
+         @test f(a*a) == f(a)*f(a)
+         @test f(a-oO) == f(a)-oG
+      end
+      C = codomain(f)
+      for a in C
+         @test preimage(f, a*a) == preimage(f, a)*preimage(f, a)
+      end
+   end
+
    @testset for (p,d) in [(2, 1), (5, 1), (2, 4), (3, 3)]
       for F in [FqPolyRepField(ZZRingElem(p),d,:z), FqField(ZZRingElem(p),d,:z)]
          f = Oscar.iso_oscar_gap(F)

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -13,8 +13,12 @@
    @test [f(x) for x in gens(H)]==gens(H)
    @test (H,f)==(K,g)
    @test is_subset(K, G)
-   @test g == is_subgroup(K, G)[2]
+   flag, emb = is_subgroup(K, G)
+   @test flag
+   @test g == emb
    @test g == embedding(K, G)
+   @test K === domain(emb)
+   @test G === codomain(emb)
    @test is_normal_subgroup(H, G)
    H,f=sub(G,[x,z])
    @test H==G


### PR DESCRIPTION
such that the `domain` of the returned embedding is identical with `H`