### PR TITLE
Implement minimal_generating_set for localized rings.

### DIFF
--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -2711,3 +2711,36 @@ end
   return dim(saturated_ideal(I))
 end
 
+@attr Vector{<:MPolyLocRingElem} function minimal_generating_set(
+    I::MPolyLocalizedIdeal{<:MPolyLocRing{<:Field, <:FieldElem, 
+                                          <:MPolyRing, <:MPolyElem, 
+                                          <:MPolyComplementOfKPointIdeal}
+                          }
+  )
+  L = base_ring(I)::MPolyLocRing # Type annotation for the reader's convenience.
+  R = base_ring(L)::MPolyRing
+
+  shift, back_shift = base_ring_shifts(L) # The shifting maps of R moving the localization point to 
+                                          # origin and back. 
+  I_shift = shifted_ideal(I)::MPolyIdeal # The pre_saturated_ideal of I in R after the shift 
+                                         # moving the localization point to the origin
+  o = negdegrevlex(gens(R)) # the default local ordering
+
+  # Three lines as suggested by @afkafkafk13:
+  singular_assure(I_shift, o) # Fills the singular side with a ring with the correct ordering.
+  I_shift_gb, I_shift_min = Singular.mstd(I_shift.gens.gens.S) # The duplication of gens seems awkward, but it is probably correct.
+                                                               # This returns a pair of singular ideals
+  I_min = L.(back_shift.(R.(gens(I_shift_min)))) # We convert the generators back to the oscar side, 
+                                                 # shift them, and consider them as elements in the 
+                                                 # localization.
+  return I_min
+# std_I_shift = standard_basis(I_shift, ordering=o)::IdealGens # Refers to a pre-computed standard basis if there is any.
+# bpa = std_I_shift.gens::BiPolyArray # Only the BiPolyArray has a "singular side".
+# l_sing = Singular.minimal_generating_set(bpa.S) # This should have the correct ordering set due 
+#                                                 # to the construction history. TODO: Please confirm!
+# l_shift = R.(l_sing)::Vector{<:MPolyElem}
+# l_poly = back_shift.(l_shift)::Vector{<:MPolyElem}
+# l_loc = L.(l_poly)::Vector{<:MPolyLocRingElem}
+# return l_loc
+end
+

--- a/test/Rings/mpoly-localizations.jl
+++ b/test/Rings/mpoly-localizations.jl
@@ -421,3 +421,14 @@ end
   @test L(x)/L(y) == L(x//y)
   @test_throws ErrorException L(y)/L(x-1)
 end
+
+@testset "minimal generating sets" begin
+  R, (x, y) = QQ["x", "y"]
+  L, _ = localization(R, complement_of_point_ideal(R, [1, 2]))
+  I_loc = ideal(L, [x-1, y-2])^2
+  @test length(minimal_generating_set(I_loc)) == 3
+  
+  I_loc = ideal(L, [x, y])^2
+  @test length(minimal_generating_set(I_loc)) == 1
+  @test isone(first(minimal_generating_set(I_loc)))
+end


### PR DESCRIPTION
This addresses #2295. 

I found it quite hard to understand how to handle the 'singular side' with all the `IdealGens` and nested `BiPolyArray`s floating around. I tried from reading the code in `MPolyIdeals.jl` and the like, but I can often only guess what there is to be done. 

One thing that confused me is that I don't seem to be able to call `Singular.mstd` as was done in #2291 . The only command I found was `Singular.minimal_generating_set`. Are the corresponding lines in #2291 tested? 

In either case it would be good if the people more involved with the internals of Groebner basis computations could have a look whether I did things right. My code seems to work, but I had no means to verify that what I do is correctly following the design ideas of `IdealGens`, `BiPolyArray`, for instance when it comes to caching of gbs and  preserving orderings and the like. 