### PR TITLE
Assign each GAP object a *unique* isomorphism from/to OSCAR

### DIFF
--- a/src/GAP/iso_oscar_gap.jl
+++ b/src/GAP/iso_oscar_gap.jl
@@ -383,8 +383,11 @@ julia> preimage(f, y) == pol
 true
 ```
 """
-@attr Map function iso_oscar_gap(F)
-   return _iso_oscar_gap(F)
+@attr Map function iso_oscar_gap(R)
+  iso = _iso_oscar_gap(R)
+  S = codomain(iso)
+  GAP.Globals.SetIsoGapOscar(S, inv(iso))
+  return iso
 end
 
 

--- a/src/GAP/iso_oscar_gap.jl
+++ b/src/GAP/iso_oscar_gap.jl
@@ -386,7 +386,9 @@ true
 @attr Map function iso_oscar_gap(R)
   iso = _iso_oscar_gap(R)
   S = codomain(iso)
-  GAP.Globals.SetIsoGapOscar(S, inv(iso))
+  f = inv(iso)
+  GAP.Globals.SetIsoGapOscar(S, f)
+  @assert GAP.Globals.IsoGapOscar(S) === f  # could differ if IsoGapOscar was set before
   return iso
 end
 


### PR DESCRIPTION
This has been brought up by @fingolfin in https://github.com/oscar-system/Oscar.jl/pull/2207#issuecomment-1518424941.

Currently, there are cases, where computing an isomorphism from an OSCAR object to GAP and then one from its codomain (a GAP object) to OSCAR gives a different object than we started from. For example:
```julia
julia> FO = GF(2,2)
Finite field of degree 2 over F_2

julia> FG = codomain(Oscar.iso_oscar_gap(FO))
GAP: GF(2^2)

julia> FO2 = codomain(Oscar.iso_gap_oscar(FG))
Finite field of degree 2 over F_2

julia> FO2 == FO
false
```

Whenever a `Oscar.iso_gap_oscar` is created, it is cached as an attribute of the domain (a GAP object).
This PR would add the additional behaviour, that when a GAP object is created as the codomain of `Oscar.iso_oscar_gap`, this isomorphism (to be correct its inverse) is put into the cache of that GAP object. For the above example, this will lead to `true` in the last line.

Please see this PR as an opportunity to write your opinion and discuss. If you are in favor of this change, I will add some corresponding tests as well.

Pinging @fingolfin and @ThomasBreuer for their opinion.