### PR TITLE
Replace GAP variable `_Vector_nf_elem` in Julia

### DIFF
--- a/gap/OscarInterface/gap/alnuth.gi
+++ b/gap/OscarInterface/gap/alnuth.gi
@@ -127,14 +127,12 @@ BindGlobal("NormCosetsDescriptionOscar", function(F, norm)
   return rec(units := units, creps := creps);
 end);
 
-BindGlobal("_Vector_nf_elem", Oscar.eval(Julia.Meta.parse(GAPToJulia("Vector{nf_elem}"))));
-
 BindGlobal("PolynomialFactorsDescriptionOscar", function(F, coeffs)
   local K, cf, poly, facs, result, f, g, i;
 
   K := _OscarField(F);
 
-  cf := _Vector_nf_elem(Reversed(List(coeffs, x -> K(GAPToJulia(x)))));
+  cf := Oscar.Alnuth._Vector_nf_elem(Reversed(List(coeffs, x -> K(GAPToJulia(x)))));
   poly := Oscar.polynomial(K, cf);
   facs := Oscar.factor(poly);
   Assert(0, Oscar.is_one(facs.unit));

--- a/gap/OscarInterface/julia/alnuth.jl
+++ b/gap/OscarInterface/julia/alnuth.jl
@@ -1,0 +1,7 @@
+module Alnuth
+
+using Oscar
+
+const _Vector_nf_elem = Vector{nf_elem}
+
+end # end module

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -522,6 +522,7 @@ include("GAP/gap_to_oscar.jl")
 include("GAP/oscar_to_gap.jl")
 include("GAP/iso_gap_oscar.jl")
 include("GAP/iso_oscar_gap.jl")
+include("../gap/OscarInterface/julia/alnuth.jl")
 
 include("Groups/group_characters.jl")  # needs some Rings functionality
 include("Groups/action.jl")  # needs some PolynomialRings functionality


### PR DESCRIPTION
It turns out that using `Oscar.eval` in our GAP code like this causes problems when trying to use `Oscar` from within other Julia packages:

    [ Info: Precompiling test [e4ec5996-89d2-46bd-a9a8-6b9987a9712d]
    ERROR: LoadError: InitError: Error thrown by GAP: Error, Evaluation into
    the closed module `Oscar` breaks incremental compilation because the side
    effects will not be permanent. This is likely due to some other module
    mutating `Oscar` with `eval` during precompilation - don't do this.