### PR TITLE
New naming conventions in PolyhedralGeometry

### DIFF
--- a/docs/src/DeveloperDocumentation/serialization.md
+++ b/docs/src/DeveloperDocumentation/serialization.md
@@ -64,8 +64,8 @@ loading larger objects twice (or multiple times). Consider the following
 example code snippet:
 ```
 c = cube(3);
-LP0 = LinearProgram(c, [2,2,-3]);
-LP1 = LinearProgram(c, [2,2,4]);
+LP0 = linear_program(c, [2,2,-3]);
+LP1 = linear_program(c, [2,2,4]);
 v = [LP0, LP1];
 save("vector_of_lp.json", v)
 ```

--- a/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
@@ -17,8 +17,8 @@ from other objects in OSCAR.
 ### Intersecting halfspaces: $H$-representation
 
 ```@docs
-Polyhedron{T}(A::AnyVecOrMat, b::AbstractVector) where T<:scalar_types
-Polyhedron{T}(I::Union{Nothing, AbstractCollection[AffineHalfspace]}, E::Union{Nothing, AbstractCollection[AffineHyperplane]} = nothing) where T<:scalar_types
+polyhedron(::Type{T}, A::AnyVecOrMat, b::AbstractVector) where T<:scalar_types
+polyhedron(::Type{T}, I::Union{Nothing, AbstractCollection[AffineHalfspace]}, E::Union{Nothing, AbstractCollection[AffineHyperplane]} = nothing) where T<:scalar_types
 ```
 
 The complete $H$-representation can be retrieved using [`facets`](@ref facets)

--- a/docs/src/PolyhedralGeometry/fans.md
+++ b/docs/src/PolyhedralGeometry/fans.md
@@ -25,7 +25,7 @@ To construct a polyhedral fan, you must pass the rays of each cone in the fan,
 along with an `IncidenceMatrix` encoding which rays generate which cones.
 
 ```@docs
-PolyhedralFan
+polyhedral_fan
 polyhedral_fan_from_rays_action
 ```
 

--- a/docs/src/PolyhedralGeometry/intro.md
+++ b/docs/src/PolyhedralGeometry/intro.md
@@ -125,7 +125,8 @@ row(i::IncidenceMatrix, n::Int)
 column(i::IncidenceMatrix, n::Int)
 ```
 
-A typical application is the assignment of rays to the cones of a polyhedral fan for its construction, see [`PolyhedralFan{T}`](@ref).
+A typical application is the assignment of rays to the cones of a polyhedral
+fan for its construction, see [`polyhedral_fan`](@ref).
 
 
 ## Visualization

--- a/docs/src/PolyhedralGeometry/linear_programs.md
+++ b/docs/src/PolyhedralGeometry/linear_programs.md
@@ -22,7 +22,7 @@ which is described by a vector and (optionally) a translation. One can select wh
 problem is to maximize or to minimize the objective function.
 
 ```@docs
-LinearProgram
+linear_program
 ```
 
 ## Solving a linear program - an example
@@ -35,7 +35,7 @@ Computationally, this means first defining a linear program:
 julia> P = cube(3)
 Polyhedron in ambient dimension 3
 
-julia> LP = LinearProgram(P,[3,-2,4];k=2,convention = :min)
+julia> LP = linear_program(P,[3,-2,4];k=2,convention = :min)
 Linear program
    min{c⋅x + k | x ∈ P}
 where P is a Polyhedron{QQFieldElem} and
@@ -48,7 +48,7 @@ The information about the linear program `LP` can be easily extracted.
 ```jldoctest
 julia> P = cube(3);
 
-julia> LP = LinearProgram(P,[3,-2,4];k=2,convention = :min);
+julia> LP = linear_program(P,[3,-2,4];k=2,convention = :min);
 
 julia> c, k = objective_function(LP)
 (QQFieldElem[3, -2, 4], 2)
@@ -63,7 +63,7 @@ where the optimal value is `m`, and that value is attained at `v`.
 ```jldoctest
 julia> P = cube(3);
 
-julia> LP = LinearProgram(P,[3,-2,4];k=2,convention = :min);
+julia> LP = linear_program(P,[3,-2,4];k=2,convention = :min);
 
 julia> m, v = solve_lp(LP)
 (-7, QQFieldElem[-1, 1, -1])
@@ -84,7 +84,7 @@ The optimal value and an optimal vertex may be obtained individually as well.
 ```jldoctest
 julia> P = cube(3);
 
-julia> LP = LinearProgram(P,[3,-2,4];k=2,convention = :min);
+julia> LP = linear_program(P,[3,-2,4];k=2,convention = :min);
 
 julia> M = optimal_value(LP)
 -7

--- a/docs/src/PolyhedralGeometry/mixed_integer_linear_programs.md
+++ b/docs/src/PolyhedralGeometry/mixed_integer_linear_programs.md
@@ -23,7 +23,7 @@ to minimize the objective function. Furthermore one can optionally specify
 given as a set of integers, their respective indices.
 
 ```@docs
-MixedIntegerLinearProgram
+mixed_integer_linear_program
 ```
 
 ## Functions

--- a/docs/src/PolyhedralGeometry/polyhedral_complexes.md
+++ b/docs/src/PolyhedralGeometry/polyhedral_complexes.md
@@ -24,7 +24,7 @@ along with an `IncidenceMatrix` encoding which points generate which
 polyhedron.
 
 ```@docs
-PolyhedralComplex
+polyhedral_complex
 ```
 
 

--- a/docs/src/PolyhedralGeometry/subdivisions_of_points.md
+++ b/docs/src/PolyhedralGeometry/subdivisions_of_points.md
@@ -34,8 +34,8 @@ vector, but if it does, it is called `regular`.
 
 
 ```@docs
-SubdivisionOfPoints(Points::Union{Oscar.MatElem,AbstractMatrix}, Incidence::IncidenceMatrix)
-SubdivisionOfPoints(Points::Union{Oscar.MatElem,AbstractMatrix}, Weights::AbstractVector)
+subdivision_of_points(::Type{T}, Points::Union{Oscar.MatElem,AbstractMatrix}, Incidence::IncidenceMatrix) where T<:scalar_types
+subdivision_of_points(::Type{T}, Points::Union{Oscar.MatElem,AbstractMatrix}, Weights::AbstractVector) where T<:scalar_types
 ```
 
 From a subdivision of points one can construct the

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -45,7 +45,7 @@ function _ambient_space_from_base(base::AbstractNormalToricVariety)
   ambient_space_max_cones = IncidenceMatrix(vcat(ambient_space_max_cones...))
   
   # Construct and return the ambient space
-  ambient_space = normal_toric_variety(PolyhedralFan(ambient_space_rays, ambient_space_max_cones; non_redundant = true))
+  ambient_space = normal_toric_variety(polyhedral_fan(ambient_space_rays, ambient_space_max_cones; non_redundant = true))
   set_coordinate_names(ambient_space, vcat([string(k) for k in gens(cox_ring(base))], ["x", "y", "z"]))
   return ambient_space
   
@@ -131,7 +131,7 @@ function sample_toric_variety()
           [5, 11, 12], [5, 6, 32], [5, 6, 12], [4, 31, 32], [4, 10, 11], [4, 5, 32],
           [4, 5, 11], [3, 30, 31], [3, 9, 10], [3, 4, 31], [3, 4, 10], [2, 29, 30],
           [2, 8, 9], [2, 3, 30], [2, 3, 9], [1, 8, 29], [1, 2, 29], [1, 2, 8]])
-  return normal_toric_variety(PolyhedralFan(rays, cones))
+  return normal_toric_variety(polyhedral_fan(rays, cones))
 end
 
 @doc raw"""

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -453,8 +453,8 @@ ideal(-x1*x2 + x3*x4)
 ```
 """
 function toric_ideal(R::MPolyRing, antv::AffineNormalToricVariety)
-    cone = Cone(pm_object(antv).WEIGHT_CONE)
-    gens = pm_object(cone).CONE_TORIC_IDEAL.BINOMIAL_GENERATORS
+    C = cone(pm_object(antv).WEIGHT_CONE)
+    gens = pm_object(C).CONE_TORIC_IDEAL.BINOMIAL_GENERATORS
     return binomial_exponents_to_ideal(R, gens)
 end
 
@@ -481,8 +481,8 @@ ideal(-x1*x2 + x3*x4)
 ```
 """
 @attr MPolyIdeal function toric_ideal(antv::AffineNormalToricVariety)
-    cone = Cone(pm_object(antv).WEIGHT_CONE)
-    n = length(hilbert_basis(cone))
+    C = cone(pm_object(antv).WEIGHT_CONE)
+    n = length(hilbert_basis(C))
     R, _ = polynomial_ring(coefficient_ring(antv), n, cached=false)
     return toric_ideal(R, antv)
 end
@@ -910,7 +910,7 @@ julia> dim(nef)
 1
 ```
 """
-@attr Cone nef_cone(v::NormalToricVariety) = Cone(pm_object(v).NEF_CONE)
+@attr Cone nef_cone(v::NormalToricVariety) = cone(pm_object(v).NEF_CONE)
 
 
 """
@@ -930,7 +930,7 @@ julia> dim(mori)
 1
 ```
 """
-@attr Cone mori_cone(v::NormalToricVariety) = Cone(pm_object(v).MORI_CONE)
+@attr Cone mori_cone(v::NormalToricVariety) = cone(pm_object(v).MORI_CONE)
 
 
 @doc raw"""
@@ -1039,7 +1039,7 @@ julia> affine_open_covering(p2)
 @attr Vector{AffineNormalToricVariety} function affine_open_covering(v::AbstractNormalToricVariety)
     charts = Vector{AffineNormalToricVariety}(undef, pm_object(v).N_MAXIMAL_CONES)
     for i in 1:pm_object(v).N_MAXIMAL_CONES
-        charts[i] = affine_normal_toric_variety(Cone(Polymake.fan.cone(pm_object(v), i-1)))
+        charts[i] = affine_normal_toric_variety(cone(Polymake.fan.cone(pm_object(v), i-1)))
     end
     return charts
 end

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -36,7 +36,7 @@ Normal, affine toric variety
 ```
 """
 function affine_normal_toric_variety(C::Cone; set_attributes::Bool = true)
-    fan = PolyhedralFan(C)
+    fan = polyhedral_fan(C)
     pmntv = Polymake.fulton.NormalToricVariety(Oscar.pm_object(fan))
     variety = AffineNormalToricVariety(pmntv)
     
@@ -71,7 +71,7 @@ Normal, affine toric variety
 ```
 """
 function normal_toric_variety(C::Cone; set_attributes::Bool = true)
-    fan = PolyhedralFan(C)
+    fan = polyhedral_fan(C)
     pmntv = Polymake.fulton.NormalToricVariety(Oscar.pm_object(fan))
     variety = NormalToricVariety(pmntv)
     
@@ -123,7 +123,7 @@ Normal toric variety
 ```
 """
 function normal_toric_variety(rays::Vector{Vector{Int64}}, max_cones::Vector{Vector{Int64}}; non_redundant::Bool = false, set_attributes::Bool = true)
-    fan = PolyhedralFan(transpose(hcat(rays...)), IncidenceMatrix(max_cones); non_redundant = non_redundant)
+    fan = polyhedral_fan(transpose(hcat(rays...)), IncidenceMatrix(max_cones); non_redundant = non_redundant)
     return normal_toric_variety(fan; set_attributes = set_attributes)
 end
 
@@ -234,7 +234,7 @@ Normal, affine, 2-dimensional toric variety
 """
 function affine_space(::Type{NormalToricVariety}, d::Int; set_attributes::Bool = true)
     C = positive_hull(identity_matrix(ZZ, d))
-    fan = PolyhedralFan(C)
+    fan = polyhedral_fan(C)
     pmntv = Polymake.fulton.NormalToricVariety(Oscar.pm_object(fan))
     variety = NormalToricVariety(pmntv)
     
@@ -342,7 +342,7 @@ function weighted_projective_space(::Type{NormalToricVariety}, w::Vector{T}; set
     tr,_ = pseudo_inv(lattice_gens)
     ray_gens = ray_gens * transpose(tr)
     mc = IncidenceMatrix(subsets(Vector{Int}(1:length(w)), length(w)-1))
-    variety = normal_toric_variety(PolyhedralFan(ray_gens, mc; non_redundant=true ))
+    variety = normal_toric_variety(polyhedral_fan(ray_gens, mc; non_redundant=true ))
     
     # make standard choice for the weights of the cox ring
     set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(length(w)))
@@ -381,7 +381,7 @@ Normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional tori
 function hirzebruch_surface(::Type{NormalToricVariety}, r::Int; set_attributes::Bool = true)
     fan_rays = [1 0; 0 1; -1 r; 0 -1]
     cones = IncidenceMatrix([[1, 2], [2, 3], [3, 4], [4, 1]])
-    variety = normal_toric_variety(PolyhedralFan(fan_rays, cones; non_redundant = true))
+    variety = normal_toric_variety(polyhedral_fan(fan_rays, cones; non_redundant = true))
     
     # make standard choice for the weights of the cox ring
     set_attribute!(variety, :torusinvariant_cartier_divisor_group, free_abelian_group(4))
@@ -457,7 +457,7 @@ function del_pezzo_surface(::Type{NormalToricVariety}, b::Int; set_attributes::B
         fan_rays = [1 0; 0 1; -1 -1; 1 1; 0 -1; -1 0]
         cones = IncidenceMatrix([[1, 4], [2, 4], [1, 5], [5, 3], [2, 6], [6, 3]])
     end
-    variety = normal_toric_variety(PolyhedralFan(fan_rays, cones; non_redundant = true))
+    variety = normal_toric_variety(polyhedral_fan(fan_rays, cones; non_redundant = true))
     
     # make standard choice for weights of the cox ring
     if b == 1
@@ -754,7 +754,7 @@ function normal_toric_varieties_from_star_triangulations(P::Polyhedron; set_attr
     max_cones = [IncidenceMatrix([[c[i]-1 for i in 2:length(c)] for c in t]) for t in max_cones]
     
     # construct the varieties
-    return [normal_toric_variety(PolyhedralFan(integral_rays, cones; non_redundant = true), set_attributes = set_attributes) for cones in max_cones]
+    return [normal_toric_variety(polyhedral_fan(integral_rays, cones; non_redundant = true), set_attributes = set_attributes) for cones in max_cones]
 end
 
 

--- a/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/attributes.jl
@@ -37,7 +37,7 @@ julia> is_feasible(polyhedron(td2))
 false
 ```
 """
-@attr Polyhedron polyhedron(td::ToricDivisor) = Polyhedron(pm_tdivisor(td).SECTION_POLYTOPE)
+@attr Polyhedron polyhedron(td::ToricDivisor) = polyhedron(pm_tdivisor(td).SECTION_POLYTOPE)
 
 
 @doc raw"""

--- a/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/constructors.jl
@@ -145,7 +145,7 @@ function toric_morphism(domain::AbstractNormalToricVariety, grid_morphism::GrpAb
     # compute the image
     image_rays = matrix(ZZ, rays(domain)) * matrix(grid_morphism)
     image_rays = hcat([[Int(image_rays[i, j]) for i in 1:nrows(image_rays)] for j in 1:ncols(image_rays)]...)
-    image = normal_toric_variety(PolyhedralFan(image_rays, ray_indices(maximal_cones(domain))))
+    image = normal_toric_variety(polyhedral_fan(image_rays, ray_indices(maximal_cones(domain))))
 
     # compute the morphism
     if codomain === nothing

--- a/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/special_attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/special_attributes.jl
@@ -16,7 +16,7 @@ A toric morphism
     mapping_matrix = matrix(ZZ, rays(fan(variety)))
     max_cones_for_cox_variety = ray_indices(maximal_cones(variety))
     rays_for_cox_variety = matrix(ZZ, [[if i==j 1 else 0 end for j in 1:nrays(variety)] for i in 1:nrays(variety)])
-    cox_variety = normal_toric_variety(PolyhedralFan(rays_for_cox_variety, max_cones_for_cox_variety))
+    cox_variety = normal_toric_variety(polyhedral_fan(rays_for_cox_variety, max_cones_for_cox_variety))
     return toric_morphism(cox_variety, mapping_matrix, variety)
 end
 

--- a/src/AlgebraicGeometry/TropicalGeometry/curve.jl
+++ b/src/AlgebraicGeometry/TropicalGeometry/curve.jl
@@ -82,7 +82,7 @@ end
 function TropicalCurve(graph::IncidenceMatrix, M::Union{typeof(min),typeof(max)}=min)
     # Columns correspond to nodes
     # Rows correpons to edges
-    empty = PolyhedralComplex(Polymake.fan.PolyhedralComplex())
+    empty = polyhedral_complex(Polymake.fan.PolyhedralComplex())
     result = TropicalCurve{M, false}(empty)
     set_attribute!(result, :graph, graph)
     return result

--- a/src/AlgebraicGeometry/TropicalGeometry/groebner_polyhedron.jl
+++ b/src/AlgebraicGeometry/TropicalGeometry/groebner_polyhedron.jl
@@ -90,5 +90,5 @@ function groebner_polyhedron(GB::Vector{<:MPolyRingElem}, inGB::Vector{<:MPolyRi
     end
   end
 
-  return Polyhedron(A,b)
+  return polyhedron(A,b)
 end

--- a/src/AlgebraicGeometry/TropicalGeometry/hypersurface.jl
+++ b/src/AlgebraicGeometry/TropicalGeometry/hypersurface.jl
@@ -82,7 +82,7 @@ function TropicalHypersurface(f::AbstractAlgebra.Generic.MPoly{Oscar.TropicalSem
     pmpoly = Polymake.common.totropicalpolynomial(fstr...)
     pmhypproj = Polymake.tropical.Hypersurface{M}(POLYNOMIAL=pmpoly)
     pmhyp = Polymake.tropical.affine_chart(pmhypproj)
-    Vf = TropicalHypersurface{M, true}(PolyhedralComplex(pmhyp))
+    Vf = TropicalHypersurface{M, true}(polyhedral_complex(pmhyp))
     w = pmhypproj.WEIGHTS
     set_attribute!(Vf,:polymake_bigobject,pmhypproj)
     set_attribute!(Vf,:tropical_polynomial,f)

--- a/src/AlgebraicGeometry/TropicalGeometry/links.jl
+++ b/src/AlgebraicGeometry/TropicalGeometry/links.jl
@@ -36,7 +36,7 @@ function homogeneity_space(I; compute_groebner_basis::Bool=false)
     end
   end
 
-  return Polyhedron((zeros(Int,0,n),zeros(Int,0)),(A,b))
+  return polyhedron((zeros(Int,0,n),zeros(Int,0)),(A,b))
 end
 
 

--- a/src/AlgebraicGeometry/TropicalGeometry/variety.jl
+++ b/src/AlgebraicGeometry/TropicalGeometry/variety.jl
@@ -277,7 +277,7 @@ function tropical_variety(I::MPolyIdeal, val::TropicalSemiringMap, convention::U
     # 3.0.1: dehomogenize Groebner polyhedra
     zeroth_unit_vector_as_row_vector = zeros(Int,1,n)
     zeroth_unit_vector_as_row_vector[1,1] = 1
-    dehomogenising_hyperplane = Polyhedron((zeros(Int,0,n),zeros(Int,0)),
+    dehomogenising_hyperplane = polyhedron((zeros(Int,0,n),zeros(Int,0)),
                                            (zeroth_unit_vector_as_row_vector,[1]))
     for wCG in working_list_done
       wCG[2] = intersect(wCG[2],dehomogenising_hyperplane)

--- a/src/AlgebraicGeometry/TropicalGeometry/variety.jl
+++ b/src/AlgebraicGeometry/TropicalGeometry/variety.jl
@@ -81,7 +81,7 @@ julia> VR = [0 0; 1 0; 0 1; -1 -1];
 
 julia> far_vertices = [2,3,4];
 
-julia> Sigma = PolyhedralComplex(IM, VR, far_vertices);
+julia> Sigma = polyhedral_complex(IM, VR, far_vertices);
 
 julia> tropicalLine = TropicalVariety{min,true}(Sigma)
 """
@@ -333,7 +333,7 @@ function tropical_variety(I::MPolyIdeal, val::TropicalSemiringMap, convention::U
 
 
 
-  PC = PolyhedralComplex(IncidenceMatrix(incidence_matrix),
+  PC = polyhedral_complex(IncidenceMatrix(incidence_matrix),
   verts_rays_matrix,
   far_vertices,
   lineality_space_gens)

--- a/src/Combinatorics/Graphs.jl
+++ b/src/Combinatorics/Graphs.jl
@@ -927,7 +927,7 @@ julia> fractional_cut_polytope(G)
 Polyhedron in ambient dimension 6
 ```
 """
-fractional_cut_polytope(G::Graph{Undirected}) = Polyhedron(Polymake.polytope.fractional_cut_polytope(pm_object(G)))
+fractional_cut_polytope(G::Graph{Undirected}) = polyhedron(Polymake.polytope.fractional_cut_polytope(pm_object(G)))
 
 
 @doc raw"""
@@ -944,4 +944,4 @@ julia> fractional_matching_polytope(G)
 Polyhedron in ambient dimension 6
 ```
 """
-fractional_matching_polytope(G::Graph{Undirected}) = Polyhedron(Polymake.polytope.fractional_matching_polytope(pm_object(G)))
+fractional_matching_polytope(G::Graph{Undirected}) = polyhedron(Polymake.polytope.fractional_matching_polytope(pm_object(G)))

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -325,3 +325,23 @@ function Cone{T}(R; kwargs...) where T<:scalar_types
   return positive_hull(T, R; kwargs...)
 end
 
+# LinearProgram -> linear_program
+function LinearProgram(p::Polyhedron{T}, lp, c) where T<:scalar_types
+  Base.depwarn("'LinearProgram(x...)' is deprecated, use 'LinearProgram(x...)' instead.", :LinearProgram)
+  return linear_program(p, lp, c)
+end
+function LinearProgram{T}(P::Polyhedron{T}, objective::AbstractVector; k = 0, convention = :max) where T<:scalar_types
+  Base.depwarn("'LinearProgram(x...)' is deprecated, use 'LinearProgram(x...)' instead.", :LinearProgram)
+  return linear_program(P, objective; k=k, convention=convention)
+end
+function LinearProgram(P::Polyhedron{T}, objective::AbstractVector; k = 0, convention = :max) where T<:scalar_types
+  Base.depwarn("'LinearProgram(x...)' is deprecated, use 'LinearProgram(x...)' instead.", :LinearProgram)
+  return linear_program(P, objective; k=k, convention=convention)
+end
+function LinearProgram{T}(A::Union{Oscar.MatElem,AbstractMatrix}, b, c::AbstractVector; k = 0, convention = :max)  where T<:scalar_types
+  Base.depwarn("'LinearProgram(x...)' is deprecated, use 'LinearProgram(x...)' instead.", :LinearProgram)
+  return linear_program(T, A, b, c; k=k, convention=convention)
+end
+
+
+

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -264,3 +264,35 @@ function PolyhedralComplex(iter::SubObjectIterator{Polyhedron{T}}) where T<:scal
 end
 @deprecate PolyhedralComplex(p::Polymake.BigObject) polyhedral_complex(p)
 
+
+@deprecate PolyhedralFan(p::Polymake.BigObject) polyhedral_fan(p)
+function PolyhedralFan{T}(Rays::AbstractCollection[RayVector], 
+                          LS::Union{AbstractCollection[RayVector], Nothing}, 
+                          Incidence::IncidenceMatrix; 
+                          non_redundant::Bool = false) where T<:scalar_types
+  Base.depwarn("'PolyhedralFan{$T}(x...)' is deprecated, use 'polyhedral_fan($T, x...)' instead.", :PolyhedralFan)
+  return polyhedral_fan(T, Rays, LS, Incidence; non_redundant=non_redundant)
+end
+function PolyhedralFan{T}(Rays::AbstractCollection[RayVector], Incidence::IncidenceMatrix; non_redundant::Bool = false) where T<:scalar_types
+  Base.depwarn("'PolyhedralFan{$T}(x...)' is deprecated, use 'polyhedral_fan($T, x...)' instead.", :PolyhedralFan)
+  return polyhedral_fan(T, Rays, Incidence; non_redundant=non_redundant)
+end
+@deprecate PolyhedralFan(Rays::AbstractCollection[RayVector], LS::Union{AbstractCollection[RayVector], Nothing}, Incidence::IncidenceMatrix; non_redundant::Bool = false) polyhedral_fan(QQFieldElem, Rays, LS, Incidence; non_redundant = non_redundant)
+@deprecate PolyhedralFan(Rays::AbstractCollection[RayVector], Incidence::IncidenceMatrix; non_redundant::Bool = false) polyhedral_fan(QQFieldElem, Rays, Incidence; non_redundant = non_redundant)
+function PolyhedralFan(itr::AbstractVector{Cone{T}}) where T<:scalar_types
+  Base.depwarn("'PolyhedralFan' is deprecated, use 'polyhedral_fan' instead.", :PolyhedralFan)
+  return polyhedral_fan(itr)
+end
+function PolyhedralFan(C::Cone{T}) where T<:scalar_types
+  Base.depwarn("'PolyhedralFan' is deprecated, use 'polyhedral_fan' instead.", :PolyhedralFan)
+  return polyhedral_fan(C)
+end
+function PolyhedralFan{T}(Rays::AbstractCollection[RayVector], LS::AbstractCollection[RayVector], Incidence::Matrix{Bool}) where T<:scalar_types
+  Base.depwarn("'PolyhedralFan{$T}(x...)' is deprecated, use 'polyhedral_fan($T, x...)' instead.", :PolyhedralFan)
+  return polyhedral_fan(T, Rays, LS, Incidence)
+end
+function PolyhedralFan{T}(Rays::AbstractCollection[RayVector], Incidence::Matrix{Bool}) where T<:scalar_types
+  Base.depwarn("'PolyhedralFan{$T}(x...)' is deprecated, use 'polyhedral_fan($T, x...)' instead.", :PolyhedralFan)
+  return polyhedral_fan(T, Rays, Incidence)
+end
+

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -312,3 +312,16 @@ function Polyhedron{T}(first, second) where T<:scalar_types
 end
 @deprecate Polyhedron(A) polyhedron(A)
 @deprecate Polyhedron(A, b) polyhedron(A, b)
+
+# Cone -> positive_hull
+@deprecate Cone(R;kwargs...) positive_hull(R;kwargs...)
+@deprecate Cone(R,L;kwargs...) positive_hull(R,L;kwargs...)
+function Cone{T}(R, L; kwargs...) where T<:scalar_types
+  Base.depwarn("'Cone{$T}(x...)' is deprecated, use 'positive_hull($T, x...)' instead.", :Polyhedron)
+  return positive_hull(T, R, L; kwargs...)
+end
+function Cone{T}(R; kwargs...) where T<:scalar_types
+  Base.depwarn("'Cone{$T}(x...)' is deprecated, use 'positive_hull($T, x...)' instead.", :Polyhedron)
+  return positive_hull(T, R; kwargs...)
+end
+

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -238,6 +238,7 @@ end
 @deprecate hirzebruch_surface(r::Int; set_attributes::Bool = true) hirzebruch_surface(NormalToricVariety, r; set_attributes = set_attributes)
 @deprecate del_pezzo_surface(b::Int; set_attributes::Bool = true) del_pezzo_surface(NormalToricVariety, b; set_attributes = set_attributes)
 
+# PolyhedralComplex -> polyhedral_complex
 function PolyhedralComplex{T}(
                 polyhedra::IncidenceMatrix, 
                 vr::AbstractCollection[PointVector], 
@@ -264,7 +265,7 @@ function PolyhedralComplex(iter::SubObjectIterator{Polyhedron{T}}) where T<:scal
 end
 @deprecate PolyhedralComplex(p::Polymake.BigObject) polyhedral_complex(p)
 
-
+# PolyhedralFan -> polyhedral_fan
 @deprecate PolyhedralFan(p::Polymake.BigObject) polyhedral_fan(p)
 function PolyhedralFan{T}(Rays::AbstractCollection[RayVector], 
                           LS::Union{AbstractCollection[RayVector], Nothing}, 
@@ -295,4 +296,12 @@ function PolyhedralFan{T}(Rays::AbstractCollection[RayVector], Incidence::Matrix
   Base.depwarn("'PolyhedralFan{$T}(x...)' is deprecated, use 'polyhedral_fan($T, x...)' instead.", :PolyhedralFan)
   return polyhedral_fan(T, Rays, Incidence)
 end
+
+# SubdivisionOfPoints -> subdivision_of_points
+@deprecate SubdivisionOfPoints(points, C) subdivision_of_points(points, C)
+function SubdivisionOfPoints{T}(points, C) where T<:scalar_types
+  Base.depwarn("'SubdivisionOfPoints{$T}(x...)' is deprecated, use 'subdivision_of_points($T, x...)' instead.", :SubdivisionOfPoints)
+  return subdivision_of_points(T, points, C)
+end
+@deprecate SubdivisionOfPoints(p::Polymake.BigObject) subdivision_of_points(p)
 

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -234,5 +234,33 @@ end
 @deprecate blowup_on_ith_minimal_torus_orbit(v::AbstractNormalToricVariety, n::Int, coordinate_name::String; set_attributes::Bool = true) blow_up(v, n; coordinate_name = coordinate_name, set_attributes = set_attributes)
 @deprecate starsubdivision(PF::_FanLikeType{T}, n::Int) where T<:scalar_types star_subdivision(PF, n)
 
+# Deprecated after 0.12.1
 @deprecate hirzebruch_surface(r::Int; set_attributes::Bool = true) hirzebruch_surface(NormalToricVariety, r; set_attributes = set_attributes)
 @deprecate del_pezzo_surface(b::Int; set_attributes::Bool = true) del_pezzo_surface(NormalToricVariety, b; set_attributes = set_attributes)
+
+function PolyhedralComplex{T}(
+                polyhedra::IncidenceMatrix, 
+                vr::AbstractCollection[PointVector], 
+                far_vertices::Union{Vector{Int}, Nothing} = nothing, 
+                L::Union{AbstractCollection[RayVector], Nothing} = nothing;
+                non_redundant::Bool = false
+            ) where T<:scalar_types
+  Base.depwarn("'PolyhedralComplex{$T}(x...)' is deprecated, use 'polyhedral_complex($T, x...)' instead.", :PolyhedralComplex)
+  return polyhedral_complex(T, polyhedra, vr, far_vertices, L; non_redundant=non_redundant)
+end
+function PolyhedralComplex(
+                polyhedra::IncidenceMatrix, 
+                vr::AbstractCollection[PointVector], 
+                far_vertices::Union{Vector{Int}, Nothing} = nothing, 
+                L::Union{AbstractCollection[RayVector], Nothing} = nothing;
+                non_redundant::Bool = false
+            )
+  Base.depwarn("'PolyhedralComplex' is deprecated, use 'polyhedral_complex' instead.", :PolyhedralComplex)
+  return polyhedral_complex(QQFieldElem, polyhedra, vr, far_vertices, L; non_redundant=non_redundant)
+end
+function PolyhedralComplex(iter::SubObjectIterator{Polyhedron{T}}) where T<:scalar_types
+  Base.depwarn("'PolyhedralComplex' is deprecated, use 'polyhedral_complex' instead.", :PolyhedralComplex)
+  return polyhedral_complex(iter)
+end
+@deprecate PolyhedralComplex(p::Polymake.BigObject) polyhedral_complex(p)
+

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -305,3 +305,10 @@ function SubdivisionOfPoints{T}(points, C) where T<:scalar_types
 end
 @deprecate SubdivisionOfPoints(p::Polymake.BigObject) subdivision_of_points(p)
 
+# Polyhedron -> polyhedron
+function Polyhedron{T}(first, second) where T<:scalar_types
+  Base.depwarn("'Polyhedron{$T}(x...)' is deprecated, use 'polyhedron($T, x...)' instead.", :Polyhedron)
+  return polyhedron(T, first, second)
+end
+@deprecate Polyhedron(A) polyhedron(A)
+@deprecate Polyhedron(A, b) polyhedron(A, b)

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -327,21 +327,37 @@ end
 
 # LinearProgram -> linear_program
 function LinearProgram(p::Polyhedron{T}, lp, c) where T<:scalar_types
-  Base.depwarn("'LinearProgram(x...)' is deprecated, use 'LinearProgram(x...)' instead.", :LinearProgram)
+  Base.depwarn("'LinearProgram(x...)' is deprecated, use 'linear_program(x...)' instead.", :LinearProgram)
   return linear_program(p, lp, c)
 end
-function LinearProgram{T}(P::Polyhedron{T}, objective::AbstractVector; k = 0, convention = :max) where T<:scalar_types
-  Base.depwarn("'LinearProgram(x...)' is deprecated, use 'LinearProgram(x...)' instead.", :LinearProgram)
-  return linear_program(P, objective; k=k, convention=convention)
+function LinearProgram{T}(P::Polyhedron{T}, objective::AbstractVector; kwargs...) where T<:scalar_types
+  Base.depwarn("'LinearProgram(x...)' is deprecated, use 'linear_program(x...)' instead.", :LinearProgram)
+  return linear_program(P, objective; kwargs...)
 end
-function LinearProgram(P::Polyhedron{T}, objective::AbstractVector; k = 0, convention = :max) where T<:scalar_types
-  Base.depwarn("'LinearProgram(x...)' is deprecated, use 'LinearProgram(x...)' instead.", :LinearProgram)
-  return linear_program(P, objective; k=k, convention=convention)
+function LinearProgram(P::Polyhedron{T}, objective::AbstractVector; kwargs...) where T<:scalar_types
+  Base.depwarn("'LinearProgram(x...)' is deprecated, use 'linear_program(x...)' instead.", :LinearProgram)
+  return linear_program(P, objective; kwargs...)
 end
-function LinearProgram{T}(A::Union{Oscar.MatElem,AbstractMatrix}, b, c::AbstractVector; k = 0, convention = :max)  where T<:scalar_types
-  Base.depwarn("'LinearProgram(x...)' is deprecated, use 'LinearProgram(x...)' instead.", :LinearProgram)
-  return linear_program(T, A, b, c; k=k, convention=convention)
+function LinearProgram{T}(A::Union{Oscar.MatElem,AbstractMatrix}, b, c::AbstractVector; kwargs...)  where T<:scalar_types
+  Base.depwarn("'LinearProgram(x...)' is deprecated, use 'linear_program(x...)' instead.", :LinearProgram)
+  return linear_program(T, A, b, c; kwargs...)
 end
 
 
-
+# MixedIntegerLinearProgram -> mixed_integer_linear_program
+function MixedIntegerLinearProgram(p::Polyhedron{T}, lp, c) where T<:scalar_types
+  Base.depwarn("'MixedIntegerLinearProgram(x...)' is deprecated, use 'mixed_integer_linear_program(x...)' instead.", :MixedIntegerLinearProgram)
+  return mixed_integer_linear_program(p, lp, c)
+end
+function MixedIntegerLinearProgram{T}(P::Polyhedron{T}, objective::AbstractVector; kwargs...) where T<:scalar_types
+  Base.depwarn("'MixedIntegerLinearProgram(x...)' is deprecated, use 'mixed_integer_linear_program(x...)' instead.", :MixedIntegerLinearProgram)
+  return mixed_integer_linear_program(P, objective; kwargs...)
+end
+function MixedIntegerLinearProgram(P::Polyhedron{T}, objective::AbstractVector; kwargs...) where T<:scalar_types
+  Base.depwarn("'MixedIntegerLinearProgram(x...)' is deprecated, use 'mixed_integer_linear_program(x...)' instead.", :MixedIntegerLinearProgram)
+  return mixed_integer_linear_program(P, objective; kwargs...)
+end
+function MixedIntegerLinearProgram{T}(A::Union{Oscar.MatElem,AbstractMatrix}, b, c::AbstractVector; kwargs...)  where T<:scalar_types
+  Base.depwarn("'MixedIntegerLinearProgram(x...)' is deprecated, use 'mixed_integer_linear_program(x...)' instead.", :MixedIntegerLinearProgram)
+  return mixed_integer_linear_program(T, A, b, c; kwargs...)
+end

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -165,7 +165,7 @@ export SpecOpenRingElem
 export StdSpec
 export SubObjectIterator
 export SubQuoHom
-export SubdivisionOfPoints
+export SubdivisionOfPoints, subdivision_of_points
 export SubquoModule
 export SubquoModuleElem
 export ToricDivisor
@@ -1275,7 +1275,6 @@ export structure_tropical_jacobian
 export sub
 export subalgebra_membership
 export subalgebra_membership_homogeneous
-export subdivision_of_vertices
 export subgroup_reps
 export subquo_type
 export subquotient

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -132,7 +132,7 @@ export PermGroup
 export PermGroupElem
 export PointVector
 export PolyhedralComplex, polyhedral_complex
-export PolyhedralFan
+export PolyhedralFan, polyhedral_fan
 export Polyhedron
 export Polymake
 export PrincipalOpenSubset

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -111,7 +111,7 @@ export MPolyRingElemLoc
 export MatrixGroup
 export MatrixGroupElem
 export Matroid
-export MixedIntegerLinearProgram
+export MixedIntegerLinearProgram, mixed_integer_linear_program
 export ModuleFP
 export ModuleFPElem
 export ModuleFPHom

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -85,7 +85,7 @@ export LazyPoly
 export LazyPolyRing
 export LinearHalfspace
 export LinearHyperplane
-export LinearProgram
+export LinearProgram, linear_program
 export Localization
 export MPolyComplementOfKPointIdeal
 export MPolyComplementOfPrimeIdeal

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -131,7 +131,7 @@ export PcGroupElem
 export PermGroup
 export PermGroupElem
 export PointVector
-export PolyhedralComplex
+export PolyhedralComplex, polyhedral_complex
 export PolyhedralFan
 export Polyhedron
 export Polymake

--- a/src/PolyhedralGeometry/Cone/constructors.jl
+++ b/src/PolyhedralGeometry/Cone/constructors.jl
@@ -16,11 +16,11 @@ struct Cone{T} #a real polymake polyhedron
 end
 
 # default scalar type: `QQFieldElem`
-Cone(x...; kwargs...) = Cone{QQFieldElem}(x...; kwargs...)
+cone(x...; kwargs...) = Cone{QQFieldElem}(x...; kwargs...)
 
 # Automatic detection of corresponding OSCAR scalar type;
 # Avoid, if possible, to increase type stability
-Cone(p::Polymake.BigObject) = Cone{detect_scalar_type(Cone, p)}(p)
+cone(p::Polymake.BigObject) = Cone{detect_scalar_type(Cone, p)}(p)
 
 @doc raw"""
     positive_hull([::Type{T} = QQFieldElem,] R::AbstractCollection[RayVector] [, L::AbstractCollection[RayVector]]; non_redundant::Bool = false) where T<:scalar_types
@@ -71,9 +71,9 @@ end
 # Redirect everything to the above constructor, use QQFieldElem as default for the
 # scalar type T.
 positive_hull(R::AbstractCollection[RayVector], L::Union{AbstractCollection[RayVector], Nothing} = nothing; non_redundant::Bool = false) = positive_hull(QQFieldElem, R, L; non_redundant=non_redundant)
-Cone(R::AbstractCollection[RayVector], L::Union{AbstractCollection[RayVector], Nothing} = nothing; non_redundant::Bool = false) = positive_hull(QQFieldElem, R, L; non_redundant=non_redundant)
-Cone{T}(R::AbstractCollection[RayVector], L::Union{AbstractCollection[RayVector], Nothing} = nothing; non_redundant::Bool = false) where T<:scalar_types = positive_hull(T, R, L; non_redundant=non_redundant)
-Cone(::Type{T}, x...) where T<:scalar_types = positive_hull(T, x...)
+cone(R::AbstractCollection[RayVector], L::Union{AbstractCollection[RayVector], Nothing} = nothing; non_redundant::Bool = false) = positive_hull(QQFieldElem, R, L; non_redundant=non_redundant)
+cone(::Type{T}, R::AbstractCollection[RayVector], L::Union{AbstractCollection[RayVector], Nothing} = nothing; non_redundant::Bool = false) where T<:scalar_types = positive_hull(T, R, L; non_redundant=non_redundant)
+cone(::Type{T}, x...) where T<:scalar_types = positive_hull(T, x...)
 
 
 function ==(C0::Cone{T}, C1::Cone{T}) where T<:scalar_types

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -441,7 +441,9 @@ julia> f = facets(Halfspace, c)
 """
 facets(as::Type{<:Union{AffineHalfspace{T}, LinearHalfspace{T}, Polyhedron{T}, Cone{T}}}, C::Cone) where T<:scalar_types = SubObjectIterator{as}(pm_object(C), _facet_cone, nfacets(C))
 
-_facet_cone(::Type{T}, C::Polymake.BigObject, i::Base.Integer) where {U<:scalar_types, T<:Union{Polyhedron{U}, AffineHalfspace{U}}} = T(-view(C.FACETS, [i], :), 0)
+_facet_cone(::Type{Polyhedron{T}}, C::Polymake.BigObject, i::Base.Integer) where T<:scalar_types = polyhedron(T, -view(C.FACETS, [i], :), 0)
+
+_facet_cone(::Type{AffineHalfspace{T}}, C::Polymake.BigObject, i::Base.Integer) where T<:scalar_types = AffineHalfspace{T}(-view(C.FACETS, [i], :), 0)
 
 _facet_cone(::Type{LinearHalfspace{T}}, C::Polymake.BigObject, i::Base.Integer) where T<:scalar_types = LinearHalfspace{T}(-C.FACETS[[i], :])
 

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -219,7 +219,7 @@ Return the dimension of `C`.
 # Examples
 The cone `C` in this example is 2-dimensional within a 3-dimensional ambient space.
 ```jldoctest
-julia> C = Cone([1 0 0; 1 1 0; 0 1 0]);
+julia> C = positive_hull([1 0 0; 1 1 0; 0 1 0]);
 
 julia> dim(C)
 2
@@ -235,7 +235,7 @@ Return the ambient dimension of `C`.
 # Examples
 The cone `C` in this example is 2-dimensional within a 3-dimensional ambient space.
 ```jldoctest
-julia> C = Cone([1 0 0; 1 1 0; 0 1 0]);
+julia> C = positive_hull([1 0 0; 1 1 0; 0 1 0]);
 
 julia> ambient_dim(C)
 3
@@ -251,7 +251,7 @@ Return the codimension of `C`.
 # Examples
 The cone `C` in this example is 2-dimensional within a 3-dimensional ambient space.
 ```jldoctest
-julia> C = Cone([1 0 0; 1 1 0; 0 1 0]);
+julia> C = positive_hull([1 0 0; 1 1 0; 0 1 0]);
 
 julia> codim(C)
 1
@@ -311,7 +311,7 @@ true
 julia> lineality_dim(C)
 0
 
-julia> C1 = Cone([1 0],[0 1; 0 -1])
+julia> C1 = positive_hull([1 0],[0 1; 0 -1])
 Polyhedral cone in ambient dimension 2
 
 julia> is_pointed(C1)
@@ -384,12 +384,12 @@ Determine whether `C` is pointed, i.e. whether the origin is a face of `C`.
 # Examples
 A cone with lineality is not pointed, but a cone only consisting of a single ray is.
 ```jldoctest
-julia> C = Cone([1 0], [0 1]);
+julia> C = positive_hull([1 0], [0 1]);
 
 julia> is_pointed(C)
 false
 
-julia> C = Cone([1 0]);
+julia> C = positive_hull([1 0]);
 
 julia> is_pointed(C)
 true
@@ -405,7 +405,7 @@ Determine whether `C` is full-dimensional.
 # Examples
 The cone `C` in this example is 2-dimensional within a 3-dimensional ambient space.
 ```jldoctest
-julia> C = Cone([1 0 0; 1 1 0; 0 1 0]);
+julia> C = positive_hull([1 0 0; 1 1 0; 0 1 0]);
 
 julia> is_fulldimensional(C)
 false
@@ -470,7 +470,7 @@ Return a basis of the lineality space of `C`.
 Three rays are used here to construct the upper half-plane. Actually, two of these rays point in opposite directions.
 This gives us a 1-dimensional lineality.
 ```jldoctest
-julia> UH = Cone([1 0; 0 1; -1 0]);
+julia> UH = positive_hull([1 0; 0 1; -1 0]);
 
 julia> lineality_space(UH)
 1-element SubObjectIterator{RayVector{QQFieldElem}}:
@@ -494,7 +494,7 @@ Return the (linear) hyperplanes generating the linear span of `C`.
 This 2-dimensional cone in $\mathbb{R}^3$ lives in exactly one hyperplane $H$, with
 $H = \{ (x_1, x_2, x_3) | x_3 = 0 \}$.
 ```jldoctest
-julia> c = Cone([1 0 0; 0 1 0]);
+julia> c = positive_hull([1 0 0; 0 1 0]);
 
 julia> linear_span(c)
 1-element SubObjectIterator{LinearHyperplane{QQFieldElem}} over the Hyperplanes of R^3 described by:
@@ -517,7 +517,7 @@ Return the Hilbert basis of a pointed cone `C` as the rows of a matrix.
 # Examples
 This (non-smooth) cone in the plane has a hilbert basis with three elements.
 ```jldoctest; filter = r".*"
-julia> C = Cone([1 0; 1 2])
+julia> C = positive_hull([1 0; 1 2])
 A polyhedral cone in ambient dimension 2
 
 julia> matrix(ZZ, hilbert_basis(C))

--- a/src/PolyhedralGeometry/LPFiles.jl
+++ b/src/PolyhedralGeometry/LPFiles.jl
@@ -48,7 +48,7 @@ Print the object in LP format to stdout:
 julia> c = cube(2, -1//2, 3//2)
 Polyhedron in ambient dimension 2
 
-julia> milp = MixedIntegerLinearProgram(c, [1,1], integer_variables=[1])
+julia> milp = mixed_integer_linear_program(c, [1,1], integer_variables=[1])
 Mixed integer linear program
 
 julia> save_lp(stdout, milp)
@@ -87,7 +87,7 @@ Print the object in MPS format to stdout:
 julia> c = cube(2, -1//2, 3//2)
 Polyhedron in ambient dimension 2
 
-julia> milp = MixedIntegerLinearProgram(c, [1,1], integer_variables=[1])
+julia> milp = mixed_integer_linear_program(c, [1,1], integer_variables=[1])
 Mixed integer linear program
 
 julia> save_mps(stdout, milp)
@@ -139,7 +139,7 @@ function load_mps(file::String)
   elseif Polymake.exists(poly, "MILP")
     milp = poly.MILP
     Polymake.attach(milp, "convention", "max")
-    return MixedIntegerLinearProgram(polyhedron(poly), milp, :max)
+    return mixed_integer_linear_program(polyhedron(poly), milp, :max)
   else
     error("load_mps: cannot find LP or MILP subobject in polymake object")
   end
@@ -162,7 +162,7 @@ function load_lp(file::String)
     milp = poly.MILP
     convention = occursin("MAXIMIZE", String(Polymake.getdescription(milp))) ? :max : :min
     Polymake.attach(milp, "convention", String(convention))
-    return MixedIntegerLinearProgram(polyhedron(poly), milp, convention)
+    return mixed_integer_linear_program(polyhedron(poly), milp, convention)
   else
     error("load_lp: cannot find LP or MILP subobject in polymake object")
   end

--- a/src/PolyhedralGeometry/LPFiles.jl
+++ b/src/PolyhedralGeometry/LPFiles.jl
@@ -135,7 +135,7 @@ function load_mps(file::String)
   if Polymake.exists(poly, "LP")
     lp = poly.LP
     Polymake.attach(lp, "convention", "max")
-    return LinearProgram(polyhedron(poly), lp, :max)
+    return linear_program(polyhedron(poly), lp, :max)
   elseif Polymake.exists(poly, "MILP")
     milp = poly.MILP
     Polymake.attach(milp, "convention", "max")
@@ -157,7 +157,7 @@ function load_lp(file::String)
     lp = poly.LP
     convention = occursin("MAXIMIZE", String(Polymake.getdescription(lp))) ? :max : :min
     Polymake.attach(lp, "convention", String(convention))
-    return LinearProgram(polyhedron(poly), lp, convention)
+    return linear_program(polyhedron(poly), lp, convention)
   elseif Polymake.exists(poly, "MILP")
     milp = poly.MILP
     convention = occursin("MAXIMIZE", String(Polymake.getdescription(milp))) ? :max : :min

--- a/src/PolyhedralGeometry/LPFiles.jl
+++ b/src/PolyhedralGeometry/LPFiles.jl
@@ -135,11 +135,11 @@ function load_mps(file::String)
   if Polymake.exists(poly, "LP")
     lp = poly.LP
     Polymake.attach(lp, "convention", "max")
-    return LinearProgram(Polyhedron(poly), lp, :max)
+    return LinearProgram(polyhedron(poly), lp, :max)
   elseif Polymake.exists(poly, "MILP")
     milp = poly.MILP
     Polymake.attach(milp, "convention", "max")
-    return MixedIntegerLinearProgram(Polyhedron(poly), milp, :max)
+    return MixedIntegerLinearProgram(polyhedron(poly), milp, :max)
   else
     error("load_mps: cannot find LP or MILP subobject in polymake object")
   end
@@ -157,12 +157,12 @@ function load_lp(file::String)
     lp = poly.LP
     convention = occursin("MAXIMIZE", String(Polymake.getdescription(lp))) ? :max : :min
     Polymake.attach(lp, "convention", String(convention))
-    return LinearProgram(Polyhedron(poly), lp, convention)
+    return LinearProgram(polyhedron(poly), lp, convention)
   elseif Polymake.exists(poly, "MILP")
     milp = poly.MILP
     convention = occursin("MAXIMIZE", String(Polymake.getdescription(milp))) ? :max : :min
     Polymake.attach(milp, "convention", String(convention))
-    return MixedIntegerLinearProgram(Polyhedron(poly), milp, convention)
+    return MixedIntegerLinearProgram(polyhedron(poly), milp, convention)
   else
     error("load_lp: cannot find LP or MILP subobject in polymake object")
   end

--- a/src/PolyhedralGeometry/LinearProgram.jl
+++ b/src/PolyhedralGeometry/LinearProgram.jl
@@ -1,10 +1,3 @@
-@doc raw"""
-    LinearProgram(P, c; k = 0, convention = :max)
-
-The linear program on the feasible set `P` (a Polyhedron) with
-respect to the function x ↦ dot(c,x)+k.
-
-"""
 struct LinearProgram{T}
    feasible_region::Polyhedron{T}
    polymake_lp::Polymake.BigObject
@@ -14,9 +7,17 @@ struct LinearProgram{T}
 end
 
 # no default = `QQFieldElem` here; scalar type can be derived from the feasible region
-LinearProgram(p::Polyhedron{T}, x...) where T<:scalar_types = LinearProgram{T}(p, x...)
+linear_program(p::Polyhedron{T}, lp, c) where T<:scalar_types = LinearProgram{T}(p, lp, c)
 
-function LinearProgram{T}(P::Polyhedron{T}, objective::AbstractVector; k = 0, convention = :max) where T<:scalar_types
+
+@doc raw"""
+    linear_program(P, c; k = 0, convention = :max)
+
+The linear program on the feasible set `P` (a Polyhedron) with
+respect to the function x ↦ dot(c,x)+k.
+
+"""
+function linear_program(P::Polyhedron{T}, objective::AbstractVector; k = 0, convention = :max) where T<:scalar_types
    if convention != :max && convention != :min
       throw(ArgumentError("convention must be set to :min or :max."))
    end
@@ -32,12 +33,10 @@ function LinearProgram{T}(P::Polyhedron{T}, objective::AbstractVector; k = 0, co
    LinearProgram{T}(P, lp, convention)
 end
 
-LinearProgram(Q::Polyhedron{T},  objective::AbstractVector; k = 0, convention = :max) where T<:scalar_types = LinearProgram{T}(Q, objective; k = k, convention = convention)
 
-LinearProgram{T}(A::Union{Oscar.MatElem,AbstractMatrix}, b, c::AbstractVector; k = 0, convention = :max)  where T<:scalar_types =
-   LinearProgram{T}(Polyhedron{T}(A, b), c;  k = k, convention = convention)
+linear_program(::Type{T}, A::Union{Oscar.MatElem,AbstractMatrix}, b, c::AbstractVector; k = 0, convention = :max)  where T<:scalar_types =
+   linear_program(polyhedron(T, A, b), c;  k = k, convention = convention)
 
-LinearProgram(x...) = LinearProgram{QQFieldElem}(x...)
 
 pm_object(lp::LinearProgram) = lp.polymake_lp
 
@@ -119,7 +118,7 @@ obtains the vertex of the cube which maximizes the function (x,y,z) ↦ x+2y-3z.
 julia> C=cube(3)
 Polyhedron in ambient dimension 3
 
-julia> LP=LinearProgram(C,[1,2,-3])
+julia> LP=linear_program(C,[1,2,-3])
 Linear program
    max{c⋅x + k | x ∈ P}
 where P is a Polyhedron{QQFieldElem} and
@@ -161,7 +160,7 @@ obtains the minimal value of the function (x,y,z) ↦ x+2y-3z over that cube.
 julia> C=cube(3)
 Polyhedron in ambient dimension 3
 
-julia> LP=LinearProgram(C,[1,2,-3]; convention = :min)
+julia> LP=linear_program(C,[1,2,-3]; convention = :min)
 Linear program
    min{c⋅x + k | x ∈ P}
 where P is a Polyhedron{QQFieldElem} and

--- a/src/PolyhedralGeometry/MixedIntegerLinearProgram.jl
+++ b/src/PolyhedralGeometry/MixedIntegerLinearProgram.jl
@@ -1,12 +1,3 @@
-@doc raw"""
-    MixedIntegerLinearProgram(P, c; integer_variables = [], k = 0, convention = :max)
-
-The mixed integer linear program on the feasible set `P` (a Polyhedron) with
-respect to the function x ↦ dot(c,x)+k, where $x_i\in\mathbb{Z}$ for all $i$ in
-`integer_variables`. If `integer_variables` is empty, or not specified, all
-entries of `x` are required to be integral. If this is not intended, consider
-using a [`linear_program`](@ref) instead.
-"""
 struct MixedIntegerLinearProgram{T}
    feasible_region::Polyhedron{T}
    polymake_milp::Polymake.BigObject
@@ -16,9 +7,18 @@ struct MixedIntegerLinearProgram{T}
 end
 
 # no default = `QQFieldElem` here; scalar type can be derived from the feasible region
-MixedIntegerLinearProgram(p::Polyhedron{T}, x...) where T<:scalar_types = MixedIntegerLinearProgram{T}(p, x...)
+mixed_integer_linear_program(p::Polyhedron{T}, x...) where T<:scalar_types = MixedIntegerLinearProgram{T}(p, x...)
 
-function MixedIntegerLinearProgram{T}(P::Polyhedron{T}, objective::AbstractVector; integer_variables=Int64[], k = 0, convention = :max) where T<:scalar_types
+@doc raw"""
+    mixed_integer_linear_program(P, c; integer_variables = [], k = 0, convention = :max)
+
+The mixed integer linear program on the feasible set `P` (a Polyhedron) with
+respect to the function x ↦ dot(c,x)+k, where $x_i\in\mathbb{Z}$ for all $i$ in
+`integer_variables`. If `integer_variables` is empty, or not specified, all
+entries of `x` are required to be integral. If this is not intended, consider
+using a [`linear_program`](@ref) instead.
+"""
+function mixed_integer_linear_program(P::Polyhedron{T}, objective::AbstractVector; integer_variables=Int64[], k = 0, convention = :max) where T<:scalar_types
    if convention != :max && convention != :min
       throw(ArgumentError("convention must be set to :min or :max."))
    end
@@ -37,12 +37,9 @@ function MixedIntegerLinearProgram{T}(P::Polyhedron{T}, objective::AbstractVecto
    MixedIntegerLinearProgram{T}(P, milp, convention)
 end
 
-MixedIntegerLinearProgram(Q::Polyhedron{T}, objective::AbstractVector; integer_variables=Vector{Int64}([]), k = 0, convention = :max) where T<:scalar_types = MixedIntegerLinearProgram{T}(Q, objective; integer_variables = integer_variables, k = k, convention = convention)
 
-MixedIntegerLinearProgram{T}(A::Union{Oscar.MatElem,AbstractMatrix}, b, c::AbstractVector; integer_variables=Vector{Int64}([]), k = 0, convention = :max)  where T<:scalar_types =
-   MixedIntegerLinearProgram{T}(Polyhedron{T}(A, b), c; integer_variables = integer_variables, k = k, convention = convention)
-
-MixedIntegerLinearProgram(x...) = MixedIntegerLinearProgram{QQFieldElem}(x...)
+mixed_integer_linear_program(::Type{T}, A::Union{Oscar.MatElem,AbstractMatrix}, b, c::AbstractVector; integer_variables=Vector{Int64}([]), k = 0, convention = :max)  where T<:scalar_types =
+   mixed_integer_linear_program(polyhedron(T, A, b), c; integer_variables = integer_variables, k = k, convention = convention)
 
 pm_object(milp::MixedIntegerLinearProgram) = milp.polymake_milp
 
@@ -135,7 +132,7 @@ Take the square $[-1/2,3/2]^2$ and optimize $[1,1]$ in different settings.
 julia> c = cube(2, -1//2, 3//2)
 Polyhedron in ambient dimension 2
 
-julia> milp = MixedIntegerLinearProgram(c, [1,1], integer_variables=[1])
+julia> milp = mixed_integer_linear_program(c, [1,1], integer_variables=[1])
 Mixed integer linear program
 
 julia> optimal_solution(milp)
@@ -143,7 +140,7 @@ julia> optimal_solution(milp)
  1
  3//2
 
-julia> milp = MixedIntegerLinearProgram(c, [1,1])
+julia> milp = mixed_integer_linear_program(c, [1,1])
 Mixed integer linear program
 
 julia> optimal_solution(milp)
@@ -180,13 +177,13 @@ Take the square $[-1/2,3/2]^2$ and optimize $[1,1]$ in different settings.
 julia> c = cube(2, -1//2, 3//2)
 Polyhedron in ambient dimension 2
 
-julia> milp = MixedIntegerLinearProgram(c, [1,1], integer_variables=[1])
+julia> milp = mixed_integer_linear_program(c, [1,1], integer_variables=[1])
 Mixed integer linear program
 
 julia> optimal_value(milp)
 5/2
 
-julia> milp = MixedIntegerLinearProgram(c, [1,1])
+julia> milp = mixed_integer_linear_program(c, [1,1])
 Mixed integer linear program
 
 julia> optimal_value(milp)
@@ -216,13 +213,13 @@ Take the square $[-1/2,3/2]^2$ and optimize $[1,1]$ in different settings.
 julia> c = cube(2, -1//2, 3//2)
 Polyhedron in ambient dimension 2
 
-julia> milp = MixedIntegerLinearProgram(c, [1,1], integer_variables=[1])
+julia> milp = mixed_integer_linear_program(c, [1,1], integer_variables=[1])
 Mixed integer linear program
 
 julia> solve_milp(milp)
 (5/2, QQFieldElem[1, 3//2])
 
-julia> milp = MixedIntegerLinearProgram(c, [1,1])
+julia> milp = mixed_integer_linear_program(c, [1,1])
 Mixed integer linear program
 
 julia> solve_milp(milp)

--- a/src/PolyhedralGeometry/MixedIntegerLinearProgram.jl
+++ b/src/PolyhedralGeometry/MixedIntegerLinearProgram.jl
@@ -5,7 +5,7 @@ The mixed integer linear program on the feasible set `P` (a Polyhedron) with
 respect to the function x ↦ dot(c,x)+k, where $x_i\in\mathbb{Z}$ for all $i$ in
 `integer_variables`. If `integer_variables` is empty, or not specified, all
 entries of `x` are required to be integral. If this is not intended, consider
-using a [`LinearProgram`](@ref) instead.
+using a [`linear_program`](@ref) instead.
 """
 struct MixedIntegerLinearProgram{T}
    feasible_region::Polyhedron{T}

--- a/src/PolyhedralGeometry/PolyhedralComplex/constructors.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/constructors.jl
@@ -10,25 +10,25 @@ struct PolyhedralComplex{T}
      PolyhedralComplex{T}(pm::Polymake.BigObject) where T<:scalar_types = new{T}(pm)
 end
 
-# default scalar type: `QQFieldElem`
-PolyhedralComplex(x...) = PolyhedralComplex{QQFieldElem}(x...)
 
-PolyhedralComplex(p::Polymake.BigObject) = PolyhedralComplex{detect_scalar_type(PolyhedralComplex, p)}(p)
+polyhedral_complex(p::Polymake.BigObject) = PolyhedralComplex{detect_scalar_type(PolyhedralComplex, p)}(p)
 
 pm_object(pc::PolyhedralComplex) = pc.pm_complex
 
 
 @doc raw"""
-    PolyhedralComplex{T}(polyhedra, vr, far_vertices, L) where T<:scalar_types
+    polyhedral_complex(::T, polyhedra, vr, far_vertices, L) where T<:scalar_types
 
 # Arguments
+- `T`: Type of scalar to use, defaults to `QQFieldElem`.
 - `polyhedra::IncidenceMatrix`: An incidence matrix; there is a 1 at position
   (i,j) if the ith polytope contains point j and 0 otherwise.
-- `vr::AbstractCollection[PointVector]`: The points whose convex hulls make up the polyhedral
-  complex. This matrix also contains the far vertices.
+- `vr::AbstractCollection[PointVector]`: The points whose convex hulls make up
+  the polyhedral complex. This matrix also contains the far vertices.
 - `far_vertices::Vector{Int}`: Vector containing the indices of the rows
   corresponding to the far vertices in `vr`.
-- `L::AbstractCollection[RayVector]`: Generators of the lineality space of the polyhedral complex.
+- `L::AbstractCollection[RayVector]`: Generators of the lineality space of the
+  polyhedral complex.
 
 A polyhedral complex formed from points, rays, and lineality combined into
 polyhedra indicated by an incidence matrix, where the columns represent the
@@ -49,7 +49,7 @@ julia> vr = [0 0; 1 0; 1 1; 0 1]
  1  1
  0  1
 
-julia> PC = PolyhedralComplex(IM, vr)
+julia> PC = polyhedral_complex(IM, vr)
 Polyhedral complex in ambient dimension 2
 ```
 
@@ -63,14 +63,14 @@ julia> far_vertices = [2,3,4];
 
 julia> L = [0 0 1];
 
-julia> PC = PolyhedralComplex(IM, VR, far_vertices, L)
+julia> PC = polyhedral_complex(IM, VR, far_vertices, L)
 Polyhedral complex in ambient dimension 3
 
 julia> lineality_dim(PC)
 1
 ```
 """
-function PolyhedralComplex{T}(
+function polyhedral_complex(::Type{T},
                 polyhedra::IncidenceMatrix, 
                 vr::AbstractCollection[PointVector], 
                 far_vertices::Union{Vector{Int}, Nothing} = nothing, 
@@ -103,11 +103,18 @@ function PolyhedralComplex{T}(
         ))
     end
 end
+# default scalar type: `QQFieldElem`
+polyhedral_complex(polyhedra::IncidenceMatrix, 
+                vr::AbstractCollection[PointVector], 
+                far_vertices::Union{Vector{Int}, Nothing} = nothing, 
+                L::Union{AbstractCollection[RayVector], Nothing} = nothing;
+                non_redundant::Bool = false) =
+  polyhedral_complex(QQFieldElem, polyhedra, vr, far_vertices, L; non_redundant=non_redundant)
 
 # TODO: Only works for this specific case; implement generalization using `iter.Acc`
 # Fallback like: PolyhedralFan(itr::AbstractVector{Cone{T}}) where T<:scalar_types
-# This makes sure that PolyhedralComplex(maximal_polyhedra(PC)) returns an Oscar PolyhedralComplex,
-PolyhedralComplex(iter::SubObjectIterator{Polyhedron{T}}) where T<:scalar_types = PolyhedralComplex{T}(iter.Obj)
+# This makes sure that polyhedral_complex(maximal_polyhedra(PC)) returns an Oscar PolyhedralComplex,
+polyhedral_complex(iter::SubObjectIterator{Polyhedron{T}}) where T<:scalar_types = PolyhedralComplex{T}(iter.Obj)
 
 ###############################################################################
 ###############################################################################

--- a/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
@@ -18,7 +18,7 @@ julia> V = [0 0; 1 0; 1 1; 0 1]
  1  1
  0  1
 
-julia> PC = PolyhedralComplex(IM, V)
+julia> PC = polyhedral_complex(IM, V)
 Polyhedral complex in ambient dimension 2
 
 julia> ambient_dim(PC)
@@ -46,7 +46,7 @@ julia> IM = IncidenceMatrix([[1,2,3],[1,3,4]]);
 
 julia> V = [0 0; 1 0; 1 1; 0 1];
 
-julia> PC = PolyhedralComplex(IM, V)
+julia> PC = polyhedral_complex(IM, V)
 Polyhedral complex in ambient dimension 2
 
 julia> vertices(PC)
@@ -121,7 +121,7 @@ julia> far_vertices = [2,3,4];
 
 julia> L = [0 0 1];
 
-julia> PC = PolyhedralComplex(IM, VR, far_vertices, L)
+julia> PC = polyhedral_complex(IM, VR, far_vertices, L)
 Polyhedral complex in ambient dimension 3
 
 julia> RML = rays_modulo_lineality(PC)
@@ -168,7 +168,7 @@ julia> far_vertices = [2,3,4];
 
 julia> L = [0 0 1];
 
-julia> PC = PolyhedralComplex(IM, VR, far_vertices, L)
+julia> PC = polyhedral_complex(IM, VR, far_vertices, L)
 Polyhedral complex in ambient dimension 3
 
 julia> MFPC = minimal_faces(PC)
@@ -204,7 +204,7 @@ julia> IM = IncidenceMatrix([[1,2,3],[1,3,4]]);
 
 julia> VR = [0 0; 1 0; 1 1; 0 1];
 
-julia> PC = PolyhedralComplex(IM, VR, [2])
+julia> PC = polyhedral_complex(IM, VR, [2])
 Polyhedral complex in ambient dimension 2
 
 julia> rays(PC)
@@ -257,7 +257,7 @@ julia> VR = [0 0; 1 0; 1 1; 0 1]
  1  1
  0  1
 
-julia> PC = PolyhedralComplex(IM, VR, [2])
+julia> PC = polyhedral_complex(IM, VR, [2])
 Polyhedral complex in ambient dimension 2
 
 julia> maximal_polyhedra(PC)
@@ -289,7 +289,7 @@ julia> VR = [0 0; 1 0; 1 1; 0 1]
  1  1
  0  1
 
-julia> PC = PolyhedralComplex(IM, VR, [2])
+julia> PC = polyhedral_complex(IM, VR, [2])
 Polyhedral complex in ambient dimension 2
 
 julia> n_maximal_polyhedra(PC)
@@ -310,7 +310,7 @@ julia> IM = IncidenceMatrix([[1,2,3],[1,3,4]]);
 
 julia> VR = [0 0; 1 0; 1 1; 0 1];
 
-julia> PC = PolyhedralComplex(IM, VR)
+julia> PC = polyhedral_complex(IM, VR)
 Polyhedral complex in ambient dimension 2
 
 julia> is_simplicial(PC)
@@ -331,7 +331,7 @@ julia> IM = IncidenceMatrix([[1,2,3],[1,3,4]]);
 
 julia> VR = [0 0; 1 0; 1 1; 0 1];
 
-julia> PC = PolyhedralComplex(IM, VR)
+julia> PC = polyhedral_complex(IM, VR)
 Polyhedral complex in ambient dimension 2
 
 julia> is_pure(PC)
@@ -352,7 +352,7 @@ julia> IM = IncidenceMatrix([[1,2,3],[1,3,4]]);
 
 julia> VR = [0 0; 1 0; 1 1; 0 1];
 
-julia> PC = PolyhedralComplex(IM, VR)
+julia> PC = polyhedral_complex(IM, VR)
 Polyhedral complex in ambient dimension 2
 
 julia> dim(PC)
@@ -372,7 +372,7 @@ julia> IM = IncidenceMatrix([[1,2,3],[1,3,4]]);
 
 julia> VR = [0 0; 1 0; 1 1; 0 1];
 
-julia> PC = PolyhedralComplex(IM, VR);
+julia> PC = polyhedral_complex(IM, VR);
 
 julia> P1s = polyhedra_of_dim(PC,1)
 5-element SubObjectIterator{Polyhedron{QQFieldElem}}:
@@ -435,7 +435,7 @@ julia> IM = IncidenceMatrix([[1,2,4],[1,3,4]]);
 
 julia> far_vertices = [2,3,4];
 
-julia> PC = PolyhedralComplex(IM, VR, far_vertices);
+julia> PC = polyhedral_complex(IM, VR, far_vertices);
 
 julia> f_vector(PC)
 3-element Vector{Int64}:
@@ -464,7 +464,7 @@ julia> IM = IncidenceMatrix([[1,2,4],[1,3,4]]);
 
 julia> far_vertices = [2,3,4];
 
-julia> PC = PolyhedralComplex(IM, VR, far_vertices);
+julia> PC = polyhedral_complex(IM, VR, far_vertices);
 
 julia> nrays(PC)
 3
@@ -487,7 +487,7 @@ julia> IM = IncidenceMatrix([[1,2,4],[1,3,4]]);
 
 julia> far_vertices = [2,3,4];
 
-julia> PC = PolyhedralComplex(IM, VR, far_vertices);
+julia> PC = polyhedral_complex(IM, VR, far_vertices);
 
 julia> nvertices(PC)
 1
@@ -510,7 +510,7 @@ julia> IM = IncidenceMatrix([[1,2,4],[1,3,4]]);
 
 julia> far_vertices = [2,3,4];
 
-julia> PC = PolyhedralComplex(IM, VR, far_vertices);
+julia> PC = polyhedral_complex(IM, VR, far_vertices);
 
 julia> npolyhedra(PC)
 6
@@ -531,7 +531,7 @@ julia> IM = IncidenceMatrix([[1,2],[1,3],[1,4]]);
 
 julia> far_vertices = [2,3,4];
 
-julia> PC = PolyhedralComplex(IM, VR, far_vertices)
+julia> PC = polyhedral_complex(IM, VR, far_vertices)
 A polyhedral complex in ambient dimension 2
 
 julia> codim(PC)
@@ -553,7 +553,7 @@ julia> VR = [0 0; 1 0; -1 0; 0 1];
 
 julia> IM = IncidenceMatrix([[1,2],[1,3],[1,4]]);
 
-julia> PC = PolyhedralComplex(IM, VR)
+julia> PC = polyhedral_complex(IM, VR)
 Polyhedral complex in ambient dimension 2
 
 julia> is_embedded(PC)

--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -22,10 +22,10 @@ julia> VR2 = [0 0; 0 1; 1 1]
  0  1
  1  1
 
-julia> PC1 = PolyhedralComplex(IM,VR1)
+julia> PC1 = polyhedral_complex(IM,VR1)
 Polyhedral complex in ambient dimension 2
 
-julia> PC2 = PolyhedralComplex(IM,VR2)
+julia> PC2 = polyhedral_complex(IM,VR2)
 Polyhedral complex in ambient dimension 2
 
 julia> common_refinement(PC1,PC2)
@@ -57,7 +57,7 @@ julia> VR = [0 0; 1 0; 1 1]
  1  0
  1  1
 
-julia> PC1 = PolyhedralComplex(IM,VR)
+julia> PC1 = polyhedral_complex(IM,VR)
 Polyhedral complex in ambient dimension 2
 
 julia> k_skeleton(PC1,1)

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -219,7 +219,7 @@ Return the dimension of `PF`.
 This fan in the plane contains a 2-dimensional cone and is thus 2-dimensional
 itself.
 ```jldoctest
-julia> PF = PolyhedralFan([1 0; 0 1; -1 -1], IncidenceMatrix([[1, 2], [3]]));
+julia> PF = polyhedral_fan([1 0; 0 1; -1 -1], IncidenceMatrix([[1, 2], [3]]));
 
 julia> dim(PF)
 2
@@ -236,7 +236,7 @@ Return the number of maximal cones of `PF`.
 The cones given in this construction are non-redundant. Thus there are two
 maximal cones.
 ```jldoctest
-julia> PF = PolyhedralFan([1 0; 0 1; -1 -1], IncidenceMatrix([[1, 2], [3]]));
+julia> PF = polyhedral_fan([1 0; 0 1; -1 -1], IncidenceMatrix([[1, 2], [3]]));
 
 julia> n_maximal_cones(PF)
 2
@@ -253,7 +253,7 @@ Return the number of cones of `PF`.
 The cones given in this construction are non-redundant. There are six
 cones in this fan.
 ```jldoctest
-julia> PF = PolyhedralFan([1 0; 0 1; -1 -1], IncidenceMatrix([[1, 2], [3]]))
+julia> PF = polyhedral_fan([1 0; 0 1; -1 -1], IncidenceMatrix([[1, 2], [3]]))
 Polyhedral fan in ambient dimension 2
 
 julia> n_cones(PF)
@@ -375,7 +375,7 @@ This fan consists of two cones, one containing all the points with $y ≤ 0$ and
 one containing all the points with $y ≥ 0$. The fan's lineality is the common
 lineality of these two cones, i.e. in $x$-direction.
 ```jldoctest
-julia> PF = PolyhedralFan([1 0; 0 1; -1 0; 0 -1], IncidenceMatrix([[1, 2, 3], [3, 4, 1]]))
+julia> PF = polyhedral_fan([1 0; 0 1; -1 0; 0 -1], IncidenceMatrix([[1, 2, 3], [3, 4, 1]]))
 Polyhedral fan in ambient dimension 2
 
 julia> lineality_space(PF)
@@ -430,7 +430,7 @@ Determine whether `PF` is smooth.
 Even though the cones of this fan cover the positive orthant together, one of
 these und thus the whole fan is not smooth.
 ```jldoctest
-julia> PF = PolyhedralFan([0 1; 2 1; 1 0], IncidenceMatrix([[1, 2], [2, 3]]));
+julia> PF = polyhedral_fan([0 1; 2 1; 1 0], IncidenceMatrix([[1, 2], [2, 3]]));
 
 julia> is_smooth(PF)
 false
@@ -446,7 +446,7 @@ Determine whether `PF` is regular, i.e. the normal fan of a polytope.
 # Examples
 This fan is not complete and thus not regular.
 ```jldoctest
-julia> PF = PolyhedralFan([1 0; 0 1; -1 -1], IncidenceMatrix([[1, 2], [3]]));
+julia> PF = polyhedral_fan([1 0; 0 1; -1 -1], IncidenceMatrix([[1, 2], [3]]));
 
 julia> is_regular(PF)
 false

--- a/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
@@ -133,7 +133,7 @@ function star_subdivision(Sigma::_FanLikeType{T}, n::Int) where T<:scalar_types
   newmaxcones = IncidenceMatrix(newmaxcones)
   
   # return the new fan
-  return PolyhedralFan{T}(newrays, newmaxcones; non_redundant=true)
+  return polyhedral_fan(T, newrays, newmaxcones; non_redundant=true)
   
 end
 

--- a/src/PolyhedralGeometry/Polyhedron/constructors.jl
+++ b/src/PolyhedralGeometry/Polyhedron/constructors.jl
@@ -20,14 +20,15 @@ struct Polyhedron{T<:scalar_types} #a real polymake polyhedron
 end
 
 # default scalar type: `QQFieldElem`
-Polyhedron(x...) = Polyhedron{QQFieldElem}(x...)
+polyhedron(A, b) = polyhedron(QQFieldElem, A, b)
+polyhedron(A) = polyhedron(QQFieldElem, A)
 
 # Automatic detection of corresponding OSCAR scalar type;
 # Avoid, if possible, to increase type stability
-Polyhedron(p::Polymake.BigObject) = Polyhedron{detect_scalar_type(Polyhedron, p)}(p)
+polyhedron(p::Polymake.BigObject) = Polyhedron{detect_scalar_type(Polyhedron, p)}(p)
 
 @doc raw"""
-    Polyhedron{T}(A::AnyVecOrMat, b) where T<:scalar_types
+    polyhedron(::Type{T}, A::AnyVecOrMat, b) where T<:scalar_types
 
 The (convex) polyhedron defined by
 
@@ -42,24 +43,24 @@ julia> A = [1 0; 0 1; -1 0 ; 0 -1];
 
 julia> b = [1, 1, 0, 0];
 
-julia> Polyhedron(A,b)
+julia> polyhedron(A,b)
 Polyhedron in ambient dimension 2
 ```
 """
-Polyhedron{T}(A::AnyVecOrMat, b::AbstractVector) where T<:scalar_types = Polyhedron{T}((A, b))
+polyhedron(::Type{T}, A::AnyVecOrMat, b::AbstractVector) where T<:scalar_types = polyhedron(T, (A, b))
 
-Polyhedron{T}(A::AbstractVector, b::Any) where T<:scalar_types = Polyhedron{T}(([A], [b]))
+polyhedron(::Type{T}, A::AbstractVector, b::Any) where T<:scalar_types = polyhedron(T, ([A], [b]))
 
-Polyhedron{T}(A::AbstractVector, b::AbstractVector) where T<:scalar_types = Polyhedron{T}(([A], b))
+polyhedron(::Type{T}, A::AbstractVector, b::AbstractVector) where T<:scalar_types = polyhedron(T, ([A], b))
 
-Polyhedron{T}(A::AbstractVector{<:AbstractVector}, b::Any) where T<:scalar_types = Polyhedron{T}((A, [b]))
+polyhedron(::Type{T}, A::AbstractVector{<:AbstractVector}, b::Any) where T<:scalar_types = polyhedron(T, (A, [b]))
 
-Polyhedron{T}(A::AbstractVector{<:AbstractVector}, b::AbstractVector) where T<:scalar_types = Polyhedron{T}((A, b))
+polyhedron(::Type{T}, A::AbstractVector{<:AbstractVector}, b::AbstractVector) where T<:scalar_types = polyhedron(T, (A, b))
 
-Polyhedron{T}(A::AnyVecOrMat, b::Any) where T<:scalar_types = Polyhedron{T}(A, [b])
+polyhedron(::Type{T}, A::AnyVecOrMat, b::Any) where T<:scalar_types = polyhedron(T, A, [b])
 
 @doc raw"""
-    Polyhedron{T}(I::Union{Nothing, AbstractCollection[AffineHalfspace]}, E::Union{Nothing, AbstractCollection[AffineHyperplane]} = nothing) where T<:scalar_types
+    polyhedron(::Type{T}, I::Union{Nothing, AbstractCollection[AffineHalfspace]}, E::Union{Nothing, AbstractCollection[AffineHyperplane]} = nothing) where T<:scalar_types
 
 The (convex) polyhedron obtained intersecting the halfspaces `I` (inequalities)
 and the hyperplanes `E` (equations).
@@ -71,14 +72,14 @@ julia> A = [1 0; 0 1; -1 0 ; 0 -1];
 
 julia> b = [1, 1, 0, 0];
 
-julia> Polyhedron((A,b))
+julia> polyhedron((A,b))
 Polyhedron in ambient dimension 2
 ```
 
 As an example for a polyhedron constructed from both inequalities and
 equations, we construct the polytope $[0,1]\times\{0\}\subset\mathbb{R}^2$
 ```jldoctest
-julia> P = Polyhedron(([-1 0; 1 0], [0,1]), ([0 1], [0]))
+julia> P = polyhedron(([-1 0; 1 0], [0,1]), ([0 1], [0]))
 Polyhedron in ambient dimension 2
 
 julia> is_feasible(P)
@@ -93,7 +94,7 @@ julia> vertices(P)
  [0, 0]
 ```
 """
-function Polyhedron{T}(I::Union{Nothing, AbstractCollection[AffineHalfspace]}, E::Union{Nothing, AbstractCollection[AffineHyperplane]} = nothing) where T<:scalar_types
+function polyhedron(::Type{T}, I::Union{Nothing, AbstractCollection[AffineHalfspace]}, E::Union{Nothing, AbstractCollection[AffineHyperplane]} = nothing) where T<:scalar_types
     if isnothing(I) || _isempty_halfspace(I)
         EM = affine_matrix_for_polymake(E)
         IM = Polymake.Matrix{scalar_type_to_polymake[T]}(undef, 0, size(EM, 2))

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -410,9 +410,13 @@ x₃ ≦ 1
 """
 facets(as::Type{T}, P::Polyhedron{S}) where {R, S<:scalar_types, T<:Union{AffineHalfspace{S}, Pair{R, S}, Polyhedron{S}}} = SubObjectIterator{as}(pm_object(P), _facet_polyhedron, nfacets(P))
 
-function _facet_polyhedron(::Type{T}, P::Polymake.BigObject, i::Base.Integer) where {R, S<:scalar_types, T<:Union{Polyhedron{S}, AffineHalfspace{S}, Pair{R, S}}}
+function _facet_polyhedron(::Type{T}, P::Polymake.BigObject, i::Base.Integer) where {R, S<:scalar_types, T<:Union{AffineHalfspace{S}, Pair{R, S}}}
     h = decompose_hdata(view(P.FACETS, [_facet_index(P, i)], :))
     return T(h[1], h[2][])
+end
+function _facet_polyhedron(::Type{Polyhedron{T}}, P::Polymake.BigObject, i::Base.Integer) where T<:scalar_types
+    h = decompose_hdata(view(P.FACETS, [_facet_index(P, i)], :))
+    return polyhedron(T, h[1], h[2][])
 end
 
 _affine_inequality_matrix(::Val{_facet_polyhedron}, P::Polymake.BigObject) = -_remove_facet_at_infinity(P)
@@ -792,7 +796,7 @@ Return the recession cone of `P`.
 
 # Examples
 ```jldoctest
-julia> P = Polyhedron([1 -2; -1 1; -1 0; 0 -1],[2,1,1,1]);
+julia> P = polyhedron([1 -2; -1 1; -1 0; 0 -1],[2,1,1,1]);
 
 julia> vertices(P)
 3-element SubObjectIterator{PointVector{QQFieldElem}}:
@@ -957,7 +961,7 @@ Check whether `P` is feasible, i.e. non-empty.
 
 # Examples
 ```jldoctest
-julia> P = Polyhedron([1 -1; -1 1; -1 0; 0 -1],[-1,-1,1,1]);
+julia> P = polyhedron([1 -1; -1 1; -1 0; 0 -1],[-1,-1,1,1]);
 
 julia> is_feasible(P)
 false
@@ -997,7 +1001,7 @@ Check whether the vector `v` is contained in the polyhedron `P`.
 # Examples
 The positive orthant only contains vectors with non-negative entries:
 ```jldoctest
-julia> PO = Polyhedron([-1 0; 0 -1], [0, 0]);
+julia> PO = polyhedron([-1 0; 0 -1], [0, 0]);
 
 julia> [1, 2] in PO
 true
@@ -1058,7 +1062,7 @@ Check whether `P` is bounded.
 
 # Examples
 ```jldoctest
-julia> P = Polyhedron([1 -3; -1 1; -1 0; 0 -1],[1,1,1,1]);
+julia> P = polyhedron([1 -3; -1 1; -1 0; 0 -1],[1,1,1,1]);
 
 julia> is_bounded(P)
 false

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -1239,7 +1239,7 @@ julia> ψ([1,2,3])
 """
 function support_function(P::Polyhedron{T}; convention = :max) where T<:scalar_types
     function h(ω::AbstractVector)
-        lp=LinearProgram{T}(P,ω; convention = convention)
+        lp=linear_program(P,ω; convention = convention)
         return solve_lp(lp)[1]
     end
     return h

--- a/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
+++ b/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
@@ -29,7 +29,7 @@ julia> vertices(b)
  [0, 0, 1, 0, 1, 0, 1, 0, 0]
 ```
 """
-birkhoff_polytope(n::Integer; even::Bool = false) = Polyhedron(Polymake.polytope.birkhoff(n, Int(even), group=true))
+birkhoff_polytope(n::Integer; even::Bool = false) = polyhedron(Polymake.polytope.birkhoff(n, Int(even), group=true))
 
 
 
@@ -194,21 +194,21 @@ cube(d::Int, l, u) = cube(QQFieldElem, d, l, u)
 
 Construct the regular tetrahedron, one of the Platonic solids.
 """
-tetrahedron() = Polyhedron(Polymake.polytope.tetrahedron());
+tetrahedron() = polyhedron(Polymake.polytope.tetrahedron());
 
 @doc raw"""
     dodecahedron()
 
 Construct the regular dodecahedron, one out of two Platonic solids.
 """
-dodecahedron() = Polyhedron(Polymake.polytope.dodecahedron());
+dodecahedron() = polyhedron(Polymake.polytope.dodecahedron());
 
 @doc raw"""
     icosahedron()
 
 Construct the regular icosahedron, one out of two exceptional Platonic solids.
 """
-icosahedron() = Polyhedron(Polymake.polytope.icosahedron());
+icosahedron() = polyhedron(Polymake.polytope.icosahedron());
 
 @doc raw"""
     johnson_solid(i::Int)
@@ -218,28 +218,28 @@ Construct the `i`-th proper Johnson solid.
 A Johnson solid is a 3-polytope whose facets are regular polygons, of various gonalities.
 It is proper if it is not an Archimedean solid.  Up to scaling there are exactly 92 proper Johnson solids.
 """
-johnson_solid(index::Int) = Polyhedron(Polymake.polytope.johnson_solid(index));
+johnson_solid(index::Int) = polyhedron(Polymake.polytope.johnson_solid(index));
 
 @doc raw"""
     regular_24_cell()
 
 Construct the regular 24-cell, one out of three exceptional regular 4-polytopes.
 """
-regular_24_cell() = Polyhedron(Polymake.polytope.regular_24_cell());
+regular_24_cell() = polyhedron(Polymake.polytope.regular_24_cell());
 
 @doc raw"""
     regular_120_cell()
 
 Construct the regular 120-cell, one out of three exceptional regular 4-polytopes.
 """
-regular_120_cell() = Polyhedron(Polymake.polytope.regular_120_cell());
+regular_120_cell() = polyhedron(Polymake.polytope.regular_120_cell());
 
 @doc raw"""
     regular_600_cell()
 
 Construct the regular 600-cell, one out of three exceptional regular 4-polytopes.
 """
-regular_600_cell() = Polyhedron(Polymake.polytope.regular_600_cell());
+regular_600_cell() = polyhedron(Polymake.polytope.regular_600_cell());
 
 """
     newton_polytope(poly::Polynomial)
@@ -270,13 +270,13 @@ function newton_polytope(f)
 end
 
 
-Polyhedron(H::Halfspace{T}) where T<:scalar_types = Polyhedron{T}(normal_vector(H), negbias(H))
+polyhedron(H::Halfspace{T}) where T<:scalar_types = polyhedron(T, normal_vector(H), negbias(H))
 
-Polyhedron(H::Halfspace{Union{QQFieldElem, nf_elem}}) = Polyhedron{nf_elem}(normal_vector(H), negbias(H))
+polyhedron(H::Halfspace{Union{QQFieldElem, nf_elem}}) = polyhedron(nf_elem, normal_vector(H), negbias(H))
 
-Polyhedron(H::Hyperplane{T}) where T<:scalar_types = Polyhedron{T}(nothing, (normal_vector(H), [negbias(H)]))
+polyhedron(H::Hyperplane{T}) where T<:scalar_types = polyhedron(T, nothing, (normal_vector(H), [negbias(H)]))
 
-Polyhedron(H::Hyperplane{Union{QQFieldElem, nf_elem}}) = Polyhedron{nf_elem}(nothing, (normal_vector(H), [negbias(H)]))
+polyhedron(H::Hyperplane{Union{QQFieldElem, nf_elem}}) = polyhedron(nf_elem, nothing, (normal_vector(H), [negbias(H)]))
 
 @doc raw"""
     intersect(P::Polyhedron, Q::Polyhedron)
@@ -661,7 +661,7 @@ julia> nfacets(T)
 20
 ```
 """
-platonic_solid(s::String) = Polyhedron(Polymake.polytope.platonic_solid(s))
+platonic_solid(s::String) = polyhedron(Polymake.polytope.platonic_solid(s))
 
 @doc raw"""
     archimedean_solid(s)
@@ -722,7 +722,7 @@ julia> nfacets(T)
 14
 ```
 """
-archimedean_solid(s::String) = Polyhedron(Polymake.polytope.archimedean_solid(s))
+archimedean_solid(s::String) = polyhedron(Polymake.polytope.archimedean_solid(s))
 
 @doc raw"""
     catalan_solid(s::String)
@@ -781,7 +781,7 @@ julia> nfacets(T)
 12
 ```
 """
-catalan_solid(s::String) = Polyhedron(Polymake.polytope.catalan_solid(s))
+catalan_solid(s::String) = polyhedron(Polymake.polytope.catalan_solid(s))
 
 
 @doc raw"""
@@ -962,7 +962,7 @@ julia> nvertices(cp)
 20
 ```
 """
-cyclic_polytope(d::Int, n::Int) = Polyhedron(Polymake.polytope.cyclic(d, n))
+cyclic_polytope(d::Int, n::Int) = polyhedron(Polymake.polytope.cyclic(d, n))
 
 # random constructions
 

--- a/src/PolyhedralGeometry/SubdivisionOfPoints/constructors.jl
+++ b/src/PolyhedralGeometry/SubdivisionOfPoints/constructors.jl
@@ -12,18 +12,23 @@ end
 
 
 # default scalar type: `QQFieldElem`
-SubdivisionOfPoints(x...) = SubdivisionOfPoints{QQFieldElem}(x...)
+subdivision_of_points(points::AbstractCollection[PointVector], cells) =
+  subdivision_of_points(QQFieldElem, points, cells)
+subdivision_of_points(points::AbstractCollection[PointVector], weights::AbstractVector) =
+  subdivision_of_points(QQFieldElem, points, weights)
 
 # Automatic detection of corresponding OSCAR scalar type;
 # Avoid, if possible, to increase type stability
-SubdivisionOfPoints(p::Polymake.BigObject) = SubdivisionOfPoints{detect_scalar_type(SubdivisionOfPoints, p)}(p)
+subdivision_of_points(p::Polymake.BigObject) = SubdivisionOfPoints{detect_scalar_type(SubdivisionOfPoints, p)}(p)
 
 @doc raw"""
-    SubdivisionOfPoints(points, cells)
+    subdivision_of_points(points, cells)
 
 # Arguments
-- `points::AbstractCollection[PointVector]`: Points generating the cells of the subdivision; encoded row-wise as representative vectors.
-- `cells::IncidenceMatrix`: An incidence matrix; there is a 1 at position (i,j) if cell i contains point j, and 0 otherwise.
+- `points::AbstractCollection[PointVector]`: Points generating the cells of the
+  subdivision; encoded row-wise as representative vectors.
+- `cells::IncidenceMatrix`: An incidence matrix; there is a 1 at position (i,j)
+  if cell i contains point j, and 0 otherwise.
 
 A subdivision of points formed from points and cells made of these points. The
 cells are given as an IncidenceMatrix, where the columns represent the points
@@ -37,11 +42,11 @@ julia> moaepts = [4 0 0; 0 4 0; 0 0 4; 2 1 1; 1 2 1; 1 1 2];
 
 julia> moaeimnonreg0 = IncidenceMatrix([[4,5,6],[1,4,2],[2,4,5],[2,3,5],[3,5,6],[1,3,6],[1,4,6]]);
 
-julia> MOAE = SubdivisionOfPoints(moaepts, moaeimnonreg0)
+julia> MOAE = subdivision_of_points(moaepts, moaeimnonreg0)
 Subdivision of points in ambient dimension 3
 ```
 """
-function SubdivisionOfPoints{T}(points::AbstractCollection[PointVector], cells::IncidenceMatrix) where T<:scalar_types
+function subdivision_of_points(::Type{T}, points::AbstractCollection[PointVector], cells::IncidenceMatrix) where T<:scalar_types
    arr = @Polymake.convert_to Array{Set{Int}} Polymake.common.rows(cells)
    SubdivisionOfPoints{T}(Polymake.fan.SubdivisionOfPoints{scalar_type_to_polymake[T]}(
       POINTS = homogenize(points,1),
@@ -51,11 +56,13 @@ end
 
 
 @doc raw"""
-    SubdivisionOfPoints(points, weights)
+    subdivision_of_points(points, weights)
 
 # Arguments
-- `points::AbstractCollection[PointVector]`: Points generating the cells of the subdivision; encoded row-wise as representative vectors.
-- `weights::AbstractVector`: A vector with one entry for every point indicating the height of this point.
+- `points::AbstractCollection[PointVector]`: Points generating the cells of the
+  subdivision; encoded row-wise as representative vectors.
+- `weights::AbstractVector`: A vector with one entry for every point indicating
+  the height of this point.
 
 A subdivision of points formed by placing every point at the corresponding
 height, then taking the convex hull and then only considering those cells
@@ -66,14 +73,14 @@ We use the MOAE points, but give a weight vector instead of cells:
 ```jldoctest
 julia> moaepts = [4 0 0; 0 4 0; 0 0 4; 2 1 1; 1 2 1; 1 1 2];
 
-julia> SOP = SubdivisionOfPoints(moaepts, [1,1,1,1,1,1])
+julia> SOP = subdivision_of_points(moaepts, [1,1,1,1,1,1])
 Subdivision of points in ambient dimension 3
 
 julia> n_maximal_cells(SOP)
 1
 ```
 """
-function SubdivisionOfPoints{T}(points::AbstractCollection[PointVector], weights::AbstractVector) where T<:scalar_types
+function subdivision_of_points(::Type{T}, points::AbstractCollection[PointVector], weights::AbstractVector) where T<:scalar_types
    SubdivisionOfPoints{T}(Polymake.fan.SubdivisionOfPoints{scalar_type_to_polymake[T]}(
       POINTS = homogenize(points,1),
       WEIGHTS = weights,
@@ -89,13 +96,13 @@ pm_object(SOP::SubdivisionOfPoints) = SOP.pm_subdivision
 
 
 #Same construction for when the user provides maximal cells
-function SubdivisionOfPoints{T}(points::AbstractCollection[PointVector], cells::Vector{Vector{Int64}}) where T<:scalar_types
-   SubdivisionOfPoints{T}(points, IncidenceMatrix(cells))
+function subdivision_of_points(::Type{T}, points::AbstractCollection[PointVector], cells::Vector{Vector{Int64}}) where T<:scalar_types
+   subdivision_of_points(T, points, IncidenceMatrix(cells))
 end
 
 #Same construction for when the user gives Matrix{Bool} as incidence matrix
-function SubdivisionOfPoints{T}(Points::Union{Oscar.MatElem,AbstractMatrix}, cells::Matrix{Bool}) where T<:scalar_types
-   SubdivisionOfPoints{T}(points, IncidenceMatrix(Polymake.IncidenceMatrix(cells)))
+function subdivision_of_points(::Type{T}, Points::Union{Oscar.MatElem,AbstractMatrix}, cells::Matrix{Bool}) where T<:scalar_types
+   subdivision_of_points(T, points, IncidenceMatrix(Polymake.IncidenceMatrix(cells)))
 end
 
 ###############################################################################

--- a/src/PolyhedralGeometry/SubdivisionOfPoints/functions.jl
+++ b/src/PolyhedralGeometry/SubdivisionOfPoints/functions.jl
@@ -18,7 +18,7 @@ julia> moaepts = [4 0 0; 0 4 0; 0 0 4; 2 1 1; 1 2 1; 1 1 2];
 
 julia> moaeimnonreg0 = IncidenceMatrix([[4,5,6],[1,4,2],[2,4,5],[2,3,5],[3,5,6],[1,3,6],[1,4,6]]);
 
-julia> MOAE = SubdivisionOfPoints(moaepts, moaeimnonreg0)
+julia> MOAE = subdivision_of_points(moaepts, moaeimnonreg0)
 Subdivision of points in ambient dimension 3
 
 julia> C = secondary_cone(MOAE)

--- a/src/PolyhedralGeometry/SubdivisionOfPoints/properties.jl
+++ b/src/PolyhedralGeometry/SubdivisionOfPoints/properties.jl
@@ -17,7 +17,7 @@ julia> moaepts = [4 0 0; 0 4 0; 0 0 4; 2 1 1; 1 2 1; 1 1 2];
 
 julia> moaeimnonreg0 = IncidenceMatrix([[4,5,6],[1,4,2],[2,4,5],[2,3,5],[3,5,6],[1,3,6],[1,4,6]]);
 
-julia> MOAE = SubdivisionOfPoints(moaepts, moaeimnonreg0);
+julia> MOAE = subdivision_of_points(moaepts, moaeimnonreg0);
 
 julia> points(MOAE)
 6-element SubObjectIterator{PointVector{QQFieldElem}}:
@@ -71,7 +71,7 @@ julia> moaeimnonreg0 = IncidenceMatrix([[4,5,6],[1,4,2],[2,4,5],[2,3,5],[3,5,6],
 [1, 4, 6]
 
 
-julia> MOAE = SubdivisionOfPoints(moaepts, moaeimnonreg0);
+julia> MOAE = subdivision_of_points(moaepts, moaeimnonreg0);
 
 julia> maximal_cells(MOAE)
 7-element SubObjectIterator{Vector{Int64}}:
@@ -111,7 +111,7 @@ If all points have the same weight, there is only one cell.
 ```jldoctest
 julia> moaepts = [4 0 0; 0 4 0; 0 0 4; 2 1 1; 1 2 1; 1 1 2];
 
-julia> SOP = SubdivisionOfPoints(moaepts, [1,1,1,1,1,1]);
+julia> SOP = subdivision_of_points(moaepts, [1,1,1,1,1,1]);
 
 julia> n_maximal_cells(SOP)
 1
@@ -130,7 +130,7 @@ The ambient dimension of the MOAE is 3, independent of the subdivision chosen.
 ```jldoctest
 julia> moaepts = [4 0 0; 0 4 0; 0 0 4; 2 1 1; 1 2 1; 1 1 2];
 
-julia> SOP = SubdivisionOfPoints(moaepts, [1,1,1,1,1,1]);
+julia> SOP = subdivision_of_points(moaepts, [1,1,1,1,1,1]);
 
 julia> ambient_dim(SOP)
 3
@@ -148,7 +148,7 @@ Return the number of points of a `SubdivisionOfPoints`.
 ```jldoctest
 julia> moaepts = [4 0 0; 0 4 0; 0 0 4; 2 1 1; 1 2 1; 1 1 2];
 
-julia> SOP = SubdivisionOfPoints(moaepts, [1,1,1,1,1,1]);
+julia> SOP = subdivision_of_points(moaepts, [1,1,1,1,1,1]);
 
 julia> npoints(SOP)
 6
@@ -173,7 +173,7 @@ If all points have the same weight, then the 0-vector is minimal.
 ```jldoctest
 julia> moaepts = [4 0 0; 0 4 0; 0 0 4; 2 1 1; 1 2 1; 1 1 2];
 
-julia> SOP = SubdivisionOfPoints(moaepts, [1,1,1,1,1,1]);
+julia> SOP = subdivision_of_points(moaepts, [1,1,1,1,1,1]);
 
 julia> min_weights(SOP)
 6-element Vector{Int64}:
@@ -209,7 +209,7 @@ julia> moaepts = [4 0 0; 0 4 0; 0 0 4; 2 1 1; 1 2 1; 1 1 2]
  1  2  1
  1  1  2
 
-julia> SOP = SubdivisionOfPoints(moaepts, [1,1,1,1,1,1])
+julia> SOP = subdivision_of_points(moaepts, [1,1,1,1,1,1])
 Subdivision of points in ambient dimension 3
 
 julia> maximal_cells(IncidenceMatrix, SOP)
@@ -237,12 +237,12 @@ julia> moaepts = [4 0 0; 0 4 0; 0 0 4; 2 1 1; 1 2 1; 1 1 2];
 
 julia> moaeimnonreg0 = IncidenceMatrix([[4,5,6],[1,4,2],[2,4,5],[2,3,5],[3,5,6],[1,3,6],[1,4,6]]);
 
-julia> MOAE = SubdivisionOfPoints(moaepts, moaeimnonreg0);
+julia> MOAE = subdivision_of_points(moaepts, moaeimnonreg0);
 
 julia> is_regular(MOAE)
 false
 
-julia> SOP = SubdivisionOfPoints(moaepts, [1,1,1,1,1,1]);
+julia> SOP = subdivision_of_points(moaepts, [1,1,1,1,1,1]);
 
 julia> is_regular(SOP)
 true

--- a/src/PolyhedralGeometry/solving_integrally.jl
+++ b/src/PolyhedralGeometry/solving_integrally.jl
@@ -4,7 +4,7 @@ function solve_mixed(as::Type{SubObjectIterator{PointVector{ZZRingElem}}}, A::ZZ
     @req nrows(C) == nrows(d) "solve_mixed(A,b,C,d): C and d must have the same number of rows."
     @req ncols(b) == 1 "solve_mixed(A,b,C,d): b must be a matrix with a single column."
     @req ncols(d) == 1 "solve_mixed(A,b,C,d): d must be a matrix with a single column."
-    P = Polyhedron((-C, vec(-d)), (A, vec(b)))
+    P = polyhedron((-C, vec(-d)), (A, vec(b)))
     return lattice_points(P)
 end
 

--- a/src/PolyhedralGeometry/triangulations.jl
+++ b/src/PolyhedralGeometry/triangulations.jl
@@ -460,7 +460,7 @@ true
 ```
 """
 function isregular(pts::AbstractCollection[PointVector], cells::Vector{Vector{Int64}})
-    as_sop = SubdivisionOfPoints(pts,cells)
+    as_sop = subdivision_of_points(pts,cells)
     is_regular(as_sop)
 end
 
@@ -469,7 +469,7 @@ end
 
 
 @doc raw"""
-    SubdivisionOfPoints(P::Polyhdron, cells::IncidenceMatrix)
+    subdivision_of_points(P::Polyhdron, cells::IncidenceMatrix)
 
 # Arguments
 - `P::Polyhedron`: A polyhedron whose vertices are the points of the subdivision.
@@ -486,15 +486,15 @@ julia> C = cube(2);
 
 julia> cells = IncidenceMatrix([[1,2,3],[2,3,4]]);
 
-julia> S = SubdivisionOfPoints(C, cells)
+julia> S = subdivision_of_points(C, cells)
 Subdivision of points in ambient dimension 2
 ```
 """
-SubdivisionOfPoints(P::Polyhedron, cells::IncidenceMatrix) = SubdivisionOfPoints(vertices(P), cells)
+subdivision_of_points(P::Polyhedron, cells::IncidenceMatrix) = subdivision_of_points(vertices(P), cells)
 
 
 @doc raw"""
-    SubdivisionOfPoints(P::Polyhdron, weights::AbstractVector)
+    subdivision_of_points(P::Polyhdron, weights::AbstractVector)
 
 # Arguments
 - `P::Polyhedron`: A polyhedron whose vertices are the points of the subdivision.
@@ -511,15 +511,15 @@ julia> C = cube(2);
 
 julia> weights = [0,0,1,2];
 
-julia> S = SubdivisionOfPoints(C, weights)
+julia> S = subdivision_of_points(C, weights)
 Subdivision of points in ambient dimension 2
 ```
 """
-SubdivisionOfPoints(P::Polyhedron, weights::AbstractVector) = SubdivisionOfPoints(vertices(P), weights)
-SubdivisionOfPoints(P::Polyhedron, cells::Vector{Vector{Int64}}) = SubdivisionOfPoints(vertices(P), IncidenceMatrix(cells))
-SubdivisionOfPoints(Iter::SubObjectIterator{<:PointVector}, cells::IncidenceMatrix) = SubdivisionOfPoints(point_matrix(Iter), cells)
-SubdivisionOfPoints(Iter::SubObjectIterator{<:PointVector}, weights::AbstractVector) = SubdivisionOfPoints(point_matrix(Iter), weights)
-SubdivisionOfPoints(Iter::SubObjectIterator{<:PointVector}, cells::Vector{Vector{Int64}}) = SubdivisionOfPoints(point_matrix(Iter), IncidenceMatrix(cells))
+subdivision_of_points(P::Polyhedron, weights::AbstractVector) = subdivision_of_points(vertices(P), weights)
+subdivision_of_points(P::Polyhedron, cells::Vector{Vector{Int64}}) = subdivision_of_points(vertices(P), IncidenceMatrix(cells))
+subdivision_of_points(Iter::SubObjectIterator{<:PointVector}, cells::IncidenceMatrix) = subdivision_of_points(point_matrix(Iter), cells)
+subdivision_of_points(Iter::SubObjectIterator{<:PointVector}, weights::AbstractVector) = subdivision_of_points(point_matrix(Iter), weights)
+subdivision_of_points(Iter::SubObjectIterator{<:PointVector}, cells::Vector{Vector{Int64}}) = subdivision_of_points(point_matrix(Iter), IncidenceMatrix(cells))
 
 
 
@@ -534,7 +534,7 @@ Compute the gkz vector of one of the two regular triangulations of the square.
 ```jldoctest
 julia> C = cube(2);
 
-julia> Triang = SubdivisionOfPoints(C,[[1,2,3],[2,3,4]])
+julia> Triang = subdivision_of_points(C,[[1,2,3],[2,3,4]])
 Subdivision of points in ambient dimension 2
 
 julia> gkz_vector(Triang)

--- a/src/Rings/PBWAlgebra.jl
+++ b/src/Rings/PBWAlgebra.jl
@@ -1144,7 +1144,7 @@ function _elimination_ordering_weights(R::PBWAlgRing, sigmaC::Vector{Int})
   push!(b, 2^16)
 
   P = polyhedron(AA, b)
-  LP = MixedIntegerLinearProgram(P, c; convention = :min)
+  LP = mixed_integer_linear_program(P, c; convention = :min)
   s = optimal_solution(LP)
   if isnothing(s)
     return false, Int[]

--- a/src/Rings/PBWAlgebra.jl
+++ b/src/Rings/PBWAlgebra.jl
@@ -1143,7 +1143,7 @@ function _elimination_ordering_weights(R::PBWAlgRing, sigmaC::Vector{Int})
   end
   push!(b, 2^16)
 
-  P = Polyhedron(AA, b)
+  P = polyhedron(AA, b)
   LP = MixedIntegerLinearProgram(P, c; convention = :min)
   s = optimal_solution(LP)
   if isnothing(s)

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1462,7 +1462,7 @@ function _find_weights(F::Vector{P}) where {P <: MPolyRingElem}
   # Here we try to find a vector with strictly positive entries in K
   # this method to find such a vector is taken from
   # https://mathoverflow.net/questions/363181/intersection-of-a-vector-subspace-with-a-cone
-  Pol = Polyhedron(-K,  zeros(Int, ncols))
+  Pol = polyhedron(-K,  zeros(Int, ncols))
   !is_feasible(Pol) && return zeros(Int, ncols)
   pos_vec = zeros(Int, ncols)
   for i in 1:ncols
@@ -1471,7 +1471,7 @@ function _find_weights(F::Vector{P}) where {P <: MPolyRingElem}
     L = LinearProgram(Pol, obj_func)
     m, v = solve_lp(L)
     if isnothing(v)
-      Pol_new = intersect(Pol, Polyhedron(ei*K, [1]))
+      Pol_new = intersect(Pol, polyhedron(ei*K, [1]))
       L = LinearProgram(Pol_new, obj_func)
       v = optimal_vertex(L)
     end

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1468,11 +1468,11 @@ function _find_weights(F::Vector{P}) where {P <: MPolyRingElem}
   for i in 1:ncols
     ei = [j == i ? one(QQ) : zero(QQ) for j in 1:ncols]
     obj_func = ei * K
-    L = LinearProgram(Pol, obj_func)
+    L = linear_program(Pol, obj_func)
     m, v = solve_lp(L)
     if isnothing(v)
       Pol_new = intersect(Pol, polyhedron(ei*K, [1]))
-      L = LinearProgram(Pol_new, obj_func)
+      L = linear_program(Pol_new, obj_func)
       v = optimal_vertex(L)
     end
     pos_vec += K*(v.p)

--- a/test/AlgebraicGeometry/ToricVarieties/normal_toric_varieties.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/normal_toric_varieties.jl
@@ -8,7 +8,7 @@ using Test
     ntv2 = normal_toric_variety(Oscar.cube(2); set_attributes)
     ntv3 = normal_toric_varieties_from_glsm(matrix(ZZ, [[1, 1, 1]]); set_attributes)
     ntv4 = normal_toric_varieties_from_star_triangulations(convex_hull([0 0 0; 0 0 1; 1 0 1; 1 1 1; 0 1 1]); set_attributes)
-    ntv5 = normal_toric_variety(polarize(Polyhedron(Polymake.polytope.rand_sphere(5, 60; seed=42))); set_attributes)
+    ntv5 = normal_toric_variety(polarize(polyhedron(Polymake.polytope.rand_sphere(5, 60; seed=42))); set_attributes)
     
     @testset "Basic properties" begin
         @test is_complete(ntv) == true

--- a/test/PolyhedralGeometry/Cone.jl
+++ b/test/PolyhedralGeometry/Cone.jl
@@ -59,8 +59,10 @@ const pm = Polymake
                     @test facets(S, Cone1) == cone_from_inequalities.([[-1 0], [0 -1]])
                 elseif S == LinearHalfspace{T}
                     @test facets(S, Cone1) == S.([[-1, 0], [0, -1]])
-                else
+                elseif S == AffineHalfspace{T}
                     @test facets(S, Cone1) == S.([[-1 0], [0 -1]], [0])
+                else
+                    @test facets(S, Cone1) == polyhedron.(T, [[-1 0], [0 -1]], [0])
                 end
             else
                 @test linear_inequality_matrix(facets(S, Cone1)) == [0 -1; -1 0]
@@ -71,8 +73,10 @@ const pm = Polymake
                     @test facets(S, Cone1) == cone_from_inequalities.(T, [[0 -1], [-1 0]])
                 elseif S == LinearHalfspace{T}
                     @test facets(S, Cone1) == S.([[0, -1], [-1, 0]])
-                else
+                elseif S == AffineHalfspace{T}
                     @test facets(S, Cone1) == S.([[0 -1], [-1 0]], [0])
+                else
+                    @test facets(S, Cone1) == polyhedron.(T, [[0 -1], [-1 0]], [0])
                 end
             end
         end

--- a/test/PolyhedralGeometry/Cone.jl
+++ b/test/PolyhedralGeometry/Cone.jl
@@ -6,8 +6,8 @@ const pm = Polymake
     Cone1=positive_hull(T, pts)
     R = [1 0 0; 0 0 1]
     L = [0 1 0]
-    Cone2 = Cone{T}(R, L)
-    Cone3 = Cone{T}(R, L; non_redundant=true)
+    Cone2 = positive_hull(T, R, L)
+    Cone3 = positive_hull(T, R, L; non_redundant=true)
     Cone4 = positive_hull(T, R)
     Cone5 = positive_hull(T, [1 0 0; 1 1 0; 1 1 1; 1 0 1])
     Cone6 = positive_hull(T, [1//3 1//2; 4//5 2])
@@ -123,20 +123,20 @@ const pm = Polymake
         @test faces(Cone4, 1) isa SubObjectIterator{Cone{T}}
         @test length(faces(Cone4, 1)) == 2
         if T == QQFieldElem
-            @test faces(Cone2, 2) == Cone{T}.([[0 0 1], [1 0 0]], [[0 1 0]])
+            @test faces(Cone2, 2) == positive_hull.(T, [[0 0 1], [1 0 0]], [[0 1 0]])
             @test ray_indices(faces(Cone2, 2)) == IncidenceMatrix([[2], [1]])
             @test IncidenceMatrix(faces(Cone2, 2)) == IncidenceMatrix([[2], [1]])
             @test faces(IncidenceMatrix, Cone2, 2) == IncidenceMatrix([[2], [1]])
-            @test faces(Cone4, 1) == Cone{T}.([[0 0 1], [1 0 0]])
+            @test faces(Cone4, 1) == positive_hull.(T, [[0 0 1], [1 0 0]])
             @test ray_indices(faces(Cone4, 1)) == IncidenceMatrix([[2], [1]])
             @test IncidenceMatrix(faces(Cone4, 1)) == IncidenceMatrix([[2], [1]])
             @test faces(IncidenceMatrix, Cone4, 1) == IncidenceMatrix([[2], [1]])
         else
-            @test faces(Cone2, 2) == Cone{T}.([[1 0 0], [0 0 1]], [[0 1 0]])
+            @test faces(Cone2, 2) == positive_hull.(T, [[1 0 0], [0 0 1]], [[0 1 0]])
             @test ray_indices(faces(Cone2, 2)) == IncidenceMatrix([[1], [2]])
             @test IncidenceMatrix(faces(Cone2, 2)) == IncidenceMatrix([[1], [2]])
             @test faces(IncidenceMatrix, Cone2, 2) == IncidenceMatrix([[1], [2]])
-            @test faces(Cone4, 1) == Cone{T}.([[1 0 0], [0 0 1]])
+            @test faces(Cone4, 1) == positive_hull.(T, [[1 0 0], [0 0 1]])
             @test ray_indices(faces(Cone4, 1)) == IncidenceMatrix([[1], [2]])
             @test IncidenceMatrix(faces(Cone4, 1)) == IncidenceMatrix([[1], [2]])
             @test faces(IncidenceMatrix, Cone4, 1) == IncidenceMatrix([[1], [2]])

--- a/test/PolyhedralGeometry/Group.jl
+++ b/test/PolyhedralGeometry/Group.jl
@@ -23,7 +23,7 @@
         C0 = cube(2)
         G0 = linear_symmetries(C0)
         @test degree(G0) == 4
-        P = Polyhedron([-1 0 0; 0 -1 0; 0 0 -1],[0,0,0])
+        P = polyhedron([-1 0 0; 0 -1 0; 0 0 -1],[0,0,0])
         @test_throws ArgumentError linear_symmetries(P)
     end
 
@@ -31,7 +31,7 @@
         C = cube(3)
         A = automorphism_group(C; action = :on_facets)
         @test degree(A) == 6
-        P = Polyhedron([-1 0 0; 0 -1 0; 0 0 -1],[0,0,0])
+        P = polyhedron([-1 0 0; 0 -1 0; 0 0 -1],[0,0,0])
         @test_throws ArgumentError automorphism_group(P; action = :on_facets)
     end
 
@@ -39,7 +39,7 @@
         C = cube(3)
         A = combinatorial_symmetries(C)
         @test degree(A) == 8
-        P = Polyhedron([-1 0 0; 0 -1 0; 0 0 -1],[0,0,0])
+        P = polyhedron([-1 0 0; 0 -1 0; 0 0 -1],[0,0,0])
         @test_throws ArgumentError combinatorial_symmetries(P)
     end
 

--- a/test/PolyhedralGeometry/LinearProgram.jl
+++ b/test/PolyhedralGeometry/LinearProgram.jl
@@ -17,9 +17,9 @@
   rsquare = cube(T, 2, QQFieldElem(-3,2), QQFieldElem(3,2))
 
   @testset "linear programs" begin
-    LP1 = LinearProgram(square,[1,3])
-    LP2 = LinearProgram(square,[2,2]; k=3, convention = :min)
-    LP3 = LinearProgram(Pos,[1,2,3])
+    LP1 = linear_program(square,[1,3])
+    LP2 = linear_program(square,[2,2]; k=3, convention = :min)
+    LP3 = linear_program(Pos,[1,2,3])
     @test LP1 isa LinearProgram{T}
     @test LP2 isa LinearProgram{T}
     @test LP3 isa LinearProgram{T}
@@ -55,8 +55,8 @@
     end
 
     @testset "LinearProgram: lp and mps files" begin
-      LP1 = LinearProgram(square,[1,3])
-      LP2 = LinearProgram(rsquare,[2,2]; k=3, convention = :min)
+      LP1 = linear_program(square,[1,3])
+      LP2 = linear_program(rsquare,[2,2]; k=3, convention = :min)
 
       buffer = IOBuffer()
       @test save_lp(buffer, LP2) === nothing

--- a/test/PolyhedralGeometry/LinearProgram.jl
+++ b/test/PolyhedralGeometry/LinearProgram.jl
@@ -37,9 +37,9 @@
   if T == QQFieldElem
 
     @testset "mixed integer linear programs" begin
-      MILP1 = MixedIntegerLinearProgram(rsquare, [1,3], integer_variables=[1])
-      MILP2 = MixedIntegerLinearProgram(rsquare, [2,2]; k=3, convention = :min)
-      MILP3 = MixedIntegerLinearProgram(Pos, [1,2,3])
+      MILP1 = mixed_integer_linear_program(rsquare, [1,3], integer_variables=[1])
+      MILP2 = mixed_integer_linear_program(rsquare, [2,2]; k=3, convention = :min)
+      MILP3 = mixed_integer_linear_program(Pos, [1,2,3])
       @test MILP1 isa MixedIntegerLinearProgram{T}
       @test MILP2 isa MixedIntegerLinearProgram{T}
       @test MILP3 isa MixedIntegerLinearProgram{T}
@@ -74,8 +74,8 @@
                     x2 free
                   END
                   """
-      MILP1 = MixedIntegerLinearProgram(rsquare,[1,3], integer_variables=[1])
-      MILP2 = MixedIntegerLinearProgram(rsquare,[2,2]; k=3, convention = :max)
+      MILP1 = mixed_integer_linear_program(rsquare,[1,3], integer_variables=[1])
+      MILP2 = mixed_integer_linear_program(rsquare,[2,2]; k=3, convention = :max)
 
       @test save_mps(buffer, MILP1) === nothing
       @test String(take!(buffer)) ==

--- a/test/PolyhedralGeometry/LinearProgram.jl
+++ b/test/PolyhedralGeometry/LinearProgram.jl
@@ -6,8 +6,8 @@
   Q2 = convex_hull(T, pts, [1 1], [1 1])
   square = cube(T, 2)
   C1 = cube(T, 2, 0, 1)
-  Pos = Polyhedron{T}([-1 0 0; 0 -1 0; 0 0 -1], [0,0,0])
-  L = Polyhedron{T}([-1 0 0; 0 -1 0], [0,0])
+  Pos = polyhedron(T, [-1 0 0; 0 -1 0; 0 0 -1], [0,0,0])
+  L = polyhedron(T, [-1 0 0; 0 -1 0], [0,0])
   point = convex_hull(T, [0 1 0])
   # this is to make sure the order of some matrices below doesn't change
   Polymake.prefer("beneath_beyond") do

--- a/test/PolyhedralGeometry/PolyhedralComplex.jl
+++ b/test/PolyhedralGeometry/PolyhedralComplex.jl
@@ -8,19 +8,19 @@
     
     @testset "constructors" begin
         
-        @test PolyhedralComplex{T}(I, P) isa PolyhedralComplex{T}
-        @test PolyhedralComplex{T}(I, P, F) isa PolyhedralComplex{T}
-        @test PolyhedralComplex{T}(I, P2, F, L) isa PolyhedralComplex{T}
-        @test PolyhedralComplex{T}(I, P2, F, L; non_redundant = true) isa PolyhedralComplex{T}
-        @test PolyhedralComplex{T}(I, P2, nothing, L) isa PolyhedralComplex{T}
+        @test polyhedral_complex(T, I, P) isa PolyhedralComplex{T}
+        @test polyhedral_complex(T, I, P, F) isa PolyhedralComplex{T}
+        @test polyhedral_complex(T, I, P2, F, L) isa PolyhedralComplex{T}
+        @test polyhedral_complex(T, I, P2, F, L; non_redundant = true) isa PolyhedralComplex{T}
+        @test polyhedral_complex(T, I, P2, nothing, L) isa PolyhedralComplex{T}
         
     end
     
-     PC = PolyhedralComplex{T}(I, P)
-     PCF = PolyhedralComplex{T}(I, -P, F)
-     PCFL = PolyhedralComplex{T}(I, P2, F, L)
-     PCFLN = PolyhedralComplex{T}(I, P2, F, L; non_redundant = true)
-     PCL = PolyhedralComplex{T}(I, P2, nothing, L)
+     PC = polyhedral_complex(T, I, P)
+     PCF = polyhedral_complex(T, I, -P, F)
+     PCFL = polyhedral_complex(T, I, P2, F, L)
+     PCFLN = polyhedral_complex(T, I, P2, F, L; non_redundant = true)
+     PCL = polyhedral_complex(T, I, P2, nothing, L)
      
      @test common_refinement(PC, PCF) isa PolyhedralComplex{T}
      PCR = common_refinement(PC, PCF)

--- a/test/PolyhedralGeometry/PolyhedralFan.jl
+++ b/test/PolyhedralGeometry/PolyhedralFan.jl
@@ -7,17 +7,17 @@
     Cone4 = positive_hull(T, R)
     Cone5 = positive_hull(T, [1 0 0; 0 1 0])
 
-    @test PolyhedralFan([Cone4, Cone5]) isa PolyhedralFan{T}
-    F0 = PolyhedralFan([Cone4, Cone5])
+    @test polyhedral_fan([Cone4, Cone5]) isa PolyhedralFan{T}
+    F0 = polyhedral_fan([Cone4, Cone5])
     I3 = [1 0 0; 0 1 0; 0 0 1]
     incidence1 = IncidenceMatrix([[1,2],[2,3]])
     incidence2 = IncidenceMatrix([[1,2]])
-    @test PolyhedralFan{T}(I3, incidence1) isa PolyhedralFan{T}
-    F1 = PolyhedralFan{T}(I3, incidence1)
-    F1NR = PolyhedralFan{T}(I3, incidence1; non_redundant = true)
-    @test PolyhedralFan{T}(I3, incidence1) isa PolyhedralFan{T}
-    F2 = PolyhedralFan{T}(R, L, incidence2)
-    F2NR = PolyhedralFan{T}(R, L, incidence2; non_redundant = true)
+    @test polyhedral_fan(T, I3, incidence1) isa PolyhedralFan{T}
+    F1 = polyhedral_fan(T, I3, incidence1)
+    F1NR = polyhedral_fan(T, I3, incidence1; non_redundant = true)
+    @test polyhedral_fan(T, I3, incidence1) isa PolyhedralFan{T}
+    F2 = polyhedral_fan(T, R, L, incidence2)
+    F2NR = polyhedral_fan(T, R, L, incidence2; non_redundant = true)
 
     @testset "core functionality" begin
         if T == QQFieldElem
@@ -65,7 +65,7 @@
         @test cones(IncidenceMatrix, F1, 2) == incidence1
 
         II = ray_indices(maximal_cones(NFsquare))
-        NF0 = PolyhedralFan(rays(NFsquare), II)
+        NF0 = polyhedral_fan(rays(NFsquare), II)
         @test nrays(NF0) == 4
         FF0 = face_fan(C0)
         @test nrays(FF0) == 4

--- a/test/PolyhedralGeometry/SubdivisionOfPoints.jl
+++ b/test/PolyhedralGeometry/SubdivisionOfPoints.jl
@@ -5,9 +5,9 @@
    square_max_cells = [[1,2,3],[2,3,4]]
    square_incidence = IncidenceMatrix(square_max_cells)
 
-   square_by_weights = SubdivisionOfPoints(C,square_weights)
-   square_by_cells = SubdivisionOfPoints(C,square_max_cells)
-   square_by_incidence = SubdivisionOfPoints(C,square_incidence)
+   square_by_weights = subdivision_of_points(C,square_weights)
+   square_by_cells = subdivision_of_points(C,square_max_cells)
+   square_by_incidence = subdivision_of_points(C,square_incidence)
 
    @testset "alternative inputs" begin
       @test collect(maximal_cells(square_by_incidence)) == collect(maximal_cells(square_by_weights))
@@ -20,13 +20,13 @@
    moaeimreg0 = IncidenceMatrix([[1,2,3]])
    moaeimnonreg0 = IncidenceMatrix([[4,5,6],[1,4,2],[2,4,5],[2,3,5],[3,5,6],[1,3,6],[1,4,6]])
 
-   MOAE = SubdivisionOfPoints(moaepts, moaeimnonreg0)
-   fulldim_MOAE = SubdivisionOfPoints(fulldim_moaepts,moaeimnonreg0)
-   SOP0 = SubdivisionOfPoints(moaepts, moaeimreg0)
+   MOAE = subdivision_of_points(moaepts, moaeimnonreg0)
+   fulldim_MOAE = subdivision_of_points(fulldim_moaepts,moaeimnonreg0)
+   SOP0 = subdivision_of_points(moaepts, moaeimreg0)
 
    CMOAE = secondary_cone(MOAE)
 
-   SOP1 = SubdivisionOfPoints(moaepts, [1,2,3,4,5,6])
+   SOP1 = subdivision_of_points(moaepts, [1,2,3,4,5,6])
    C1 = secondary_cone(SOP1)
 
     @testset "core functionality" begin

--- a/test/PolyhedralGeometry/extended.jl
+++ b/test/PolyhedralGeometry/extended.jl
@@ -200,9 +200,9 @@
 
         @test_throws ArgumentError IncidenceMatrix(lineality_space(Pos_poly))
         IM = IncidenceMatrix([[1]])
-        lincone = Cone([1 0 0], [0 1 0])
+        lincone = positive_hull([1 0 0], [0 1 0])
 
-        @test Cone(rays_modulo_lineality(lincone)...) == lincone
+        @test positive_hull(rays_modulo_lineality(lincone)...) == lincone
         @test ambient_dim(polyhedral_fan(rays_modulo_lineality(lincone)..., IM)) == 3
         
     end

--- a/test/PolyhedralGeometry/extended.jl
+++ b/test/PolyhedralGeometry/extended.jl
@@ -203,7 +203,7 @@
         lincone = Cone([1 0 0], [0 1 0])
 
         @test Cone(rays_modulo_lineality(lincone)...) == lincone
-        @test ambient_dim(PolyhedralFan(rays_modulo_lineality(lincone)..., IM)) == 3
+        @test ambient_dim(polyhedral_fan(rays_modulo_lineality(lincone)..., IM)) == 3
         
     end
 

--- a/test/PolyhedralGeometry/extended.jl
+++ b/test/PolyhedralGeometry/extended.jl
@@ -91,7 +91,7 @@
         A[3, 2] = 4
         @test point_matrix(vertices(convex_hull(A))) == matrix(QQ, [1 0; 0 0; 0 4])
 
-        lhs, rhs = halfspace_matrix_pair(facets(Polyhedron(A, [1, 2, -3])))
+        lhs, rhs = halfspace_matrix_pair(facets(polyhedron(A, [1, 2, -3])))
         @test lhs == matrix(QQ, [1 0; 0 4])
         @test rhs == [1, -3]
     end
@@ -102,7 +102,7 @@
         A[3, 2] = 4
         @test point_matrix(vertices(convex_hull(A))) == matrix(QQ, [1 0; 0 0; 0 4])
 
-        lhs, rhs = halfspace_matrix_pair(facets(Polyhedron(A, [1, 2, -3])))
+        lhs, rhs = halfspace_matrix_pair(facets(polyhedron(A, [1, 2, -3])))
         @test lhs == matrix(QQ, [1 0; 0 4])
         @test rhs == [1, -3]
     end
@@ -136,48 +136,48 @@
         @test convex_hull([0, 0, 0], rays(Pos_poly)) == Pos_poly
         @test rays(positive_hull([1, 0, 0]))[] == [1, 0, 0]
         
-        @test Polyhedron(facets(Pos_poly)) == Pos_poly
-        @test Polyhedron(facets(Pos_cone)) == Pos_poly
+        @test polyhedron(facets(Pos_poly)) == Pos_poly
+        @test polyhedron(facets(Pos_cone)) == Pos_poly
         
         @test cone_from_inequalities(facets(Pos_poly)) == Pos_cone
         @test cone_from_inequalities(facets(Pos_cone)) == Pos_cone
         
-        @test Polyhedron(collect(facets(Pos_poly))) == Pos_poly
-        @test Polyhedron(collect(facets(Pos_cone))) == Pos_poly
+        @test polyhedron(collect(facets(Pos_poly))) == Pos_poly
+        @test polyhedron(collect(facets(Pos_cone))) == Pos_poly
         
         @test cone_from_inequalities(collect(facets(Pos_poly))) == Pos_cone
         @test cone_from_inequalities(collect(facets(Pos_cone))) == Pos_cone
         
         # testing correct dispatch and tuple processing for Polyhedron
-        @test Polyhedron([-1 0 0; 0 -1 0; 0 0 -1], [0, 0, 0]) == Pos_poly
-        @test Polyhedron([[-1, 0, 0], [0, -1, 0], [0, 0, -1]], QQFieldElem[0, 0, 0]) == Pos_poly
-        @test Polyhedron(matrix(ZZ, [-1 0 0; 0 -1 0; 0 0 -1]), [0, 0, 0]) == Pos_poly
-        @test Polyhedron(matrix(QQ, [-1 0 0; 0 -1 0; 0 0 -1]), [0, 0, 0]) == Pos_poly
+        @test polyhedron([-1 0 0; 0 -1 0; 0 0 -1], [0, 0, 0]) == Pos_poly
+        @test polyhedron([[-1, 0, 0], [0, -1, 0], [0, 0, -1]], QQFieldElem[0, 0, 0]) == Pos_poly
+        @test polyhedron(matrix(ZZ, [-1 0 0; 0 -1 0; 0 0 -1]), [0, 0, 0]) == Pos_poly
+        @test polyhedron(matrix(QQ, [-1 0 0; 0 -1 0; 0 0 -1]), [0, 0, 0]) == Pos_poly
         
         # testing different input types
-        @test Polyhedron([-1 0 0; 0 -1 0; 0 0 -1], Float64[0, 0, 0]) == Pos_poly
-        @test Polyhedron(Float64[-1 0 0; 0 -1 0; 0 0 -1], [0, 0, 0]) == Pos_poly
+        @test polyhedron([-1 0 0; 0 -1 0; 0 0 -1], Float64[0, 0, 0]) == Pos_poly
+        @test polyhedron(Float64[-1 0 0; 0 -1 0; 0 0 -1], [0, 0, 0]) == Pos_poly
         
         let y = convex_hull([0, 0, 0], [1, 0, 0], [[0, 1, 0], [0, 0, 1]])
-            @test Polyhedron([-1 0 0], [0]) == y
-            @test Polyhedron([-1 0 0], 0) == y
-            @test Polyhedron([-[1, 0, 0]], QQFieldElem[0]) == y
-            @test Polyhedron([-1, 0, 0], QQFieldElem[0]) == y
-            @test Polyhedron([[-1, 0, 0]], QQFieldElem(0)) == y
-            @test Polyhedron([-1, 0, 0], QQFieldElem(0)) == y
-            @test Polyhedron(matrix(ZZ, [-1 0 0]), [0]) == y
-            @test Polyhedron(matrix(QQ, [-1 0 0]), [0]) == y
+            @test polyhedron([-1 0 0], [0]) == y
+            @test polyhedron([-1 0 0], 0) == y
+            @test polyhedron([-[1, 0, 0]], QQFieldElem[0]) == y
+            @test polyhedron([-1, 0, 0], QQFieldElem[0]) == y
+            @test polyhedron([[-1, 0, 0]], QQFieldElem(0)) == y
+            @test polyhedron([-1, 0, 0], QQFieldElem(0)) == y
+            @test polyhedron(matrix(ZZ, [-1 0 0]), [0]) == y
+            @test polyhedron(matrix(QQ, [-1 0 0]), [0]) == y
         end
         
         let x = positive_hull([1 0 0; 0 1 0]), y = convex_hull([0 0 0], [1 0 0; 0 1 0])
-            @test Polyhedron(facets(y), affine_hull(y)) == y
-            @test Polyhedron(facets(y), linear_span(x)) == y
+            @test polyhedron(facets(y), affine_hull(y)) == y
+            @test polyhedron(facets(y), linear_span(x)) == y
             
             @test cone_from_inequalities(facets(y), affine_hull(y)) == x
             @test cone_from_inequalities(facets(x), linear_span(x)) == x
             
-            @test Polyhedron(facets(y), collect(affine_hull(y))) == y
-            @test Polyhedron(facets(x), collect(linear_span(x))) == y
+            @test polyhedron(facets(y), collect(affine_hull(y))) == y
+            @test polyhedron(facets(x), collect(linear_span(x))) == y
             
             @test cone_from_inequalities(facets(x), collect(affine_hull(y))) == x
             @test cone_from_inequalities(facets(y), collect(linear_span(x))) == x
@@ -189,7 +189,7 @@
         # Here the content of the SubObjectIterator does not fit the idea of the
         # methods; we want ArgumentErrors to be thrown
         @test_throws ArgumentError convex_hull(facets(Pos_poly))
-        @test_throws MethodError Polyhedron(vertices(Pos_poly)) #TODO
+        @test_throws MethodError polyhedron(vertices(Pos_poly)) #TODO
         @test_throws ArgumentError convex_hull(rays(Pos_poly))
         @test_throws ArgumentError convex_hull(rays(Pos_poly), [-1 -1 -1])
         @test_throws ArgumentError convex_hull([0 0 0], vertices(Pos_poly))

--- a/test/PolyhedralGeometry/lineality.jl
+++ b/test/PolyhedralGeometry/lineality.jl
@@ -1,6 +1,6 @@
 @testset "Polyhedral objects with lineality" begin
     @testset "Cone" begin
-        C = Cone(QQFieldElem, [0 1], [1 0])
+        C = positive_hull(QQFieldElem, [0 1], [1 0])
         @test lineality_dim(C) == 1
         @test nrays(C) == 0
         @test length(rays(C)) == 0

--- a/test/PolyhedralGeometry/lineality.jl
+++ b/test/PolyhedralGeometry/lineality.jl
@@ -64,7 +64,7 @@
         IM = IncidenceMatrix([[1,2,3],[1,3,4]])
         far_vertices = [2,3,4]
         L = [0 0 1]
-        PC = PolyhedralComplex(IM, VR, far_vertices, L)
+        PC = polyhedral_complex(IM, VR, far_vertices, L)
         @test length(vertices(PC)) == 0
         @test size(point_matrix(vertices(PC))) == (0, 3)
         @test length(rays(PC)) == 0

--- a/test/PolyhedralGeometry/timing.jl
+++ b/test/PolyhedralGeometry/timing.jl
@@ -20,7 +20,7 @@
             end
         end
         Polymake.setname!(p, "matching($n)")
-        return Polyhedron(p)
+        return polyhedron(p)
     end
 
 
@@ -32,7 +32,7 @@
             end
         end
         Polymake.setname!(p, "rand_box($d,$n,5)")
-        return Polyhedron(p)
+        return polyhedron(p)
     end
 
 
@@ -52,7 +52,7 @@
             end
         end
         Polymake.setname!(p, "knapsack($d,$b)")
-        return Polyhedron(p)
+        return polyhedron(p)
     end
 
 
@@ -65,7 +65,7 @@
         #end
         p = Polymake.polytope.Polytope(POINTS=points, BOUNDED=true, POINTED=true)
         Polymake.setname!(p, "knapsack_pts($d,$b)")
-        return Polyhedron(p)
+        return polyhedron(p)
     end
 
 
@@ -84,7 +84,7 @@
         Polymake.give(c,"N_RAYS | N_INPUT_RAYS")
         Polymake.give(c,"POINTED")
         Polymake.setname!(c,"non-sym-cutpoly($n)")
-        return Polyhedron(c);
+        return polyhedron(c);
     end
 
 
@@ -94,7 +94,7 @@
         p = Polymake.polytope.VoronoiPolyhedron(SITES=r.POINTS);
         Polymake.give(p,"FACETS")
         Polymake.setname!(p, "rand-voronoi($d,$n)");
-        return Polyhedron(p);
+        return polyhedron(p);
     end
     
 

--- a/test/Serialization/PolyhedralGeometry.jl
+++ b/test/Serialization/PolyhedralGeometry.jl
@@ -90,7 +90,7 @@ using Oscar: _integer_variables
         @testset "SubdivisionOfPoints" begin
             moaepts = [4 0 0; 0 4 0; 0 0 4; 2 1 1; 1 2 1; 1 1 2]
             moaeimnonreg0 = IncidenceMatrix([[4,5,6],[1,4,2],[2,4,5],[2,3,5],[3,5,6],[1,3,6],[1,4,6]])
-            MOAE = SubdivisionOfPoints(moaepts, moaeimnonreg0)
+            MOAE = subdivision_of_points(moaepts, moaeimnonreg0)
             test_save_load_roundtrip(path, MOAE) do loaded
               @test loaded isa SubdivisionOfPoints
               @test Base.propertynames(MOAE) == Base.propertynames(loaded)

--- a/test/Serialization/PolyhedralGeometry.jl
+++ b/test/Serialization/PolyhedralGeometry.jl
@@ -37,7 +37,7 @@ using Oscar: _integer_variables
         @testset "PolyhedralComplex" begin
             IM = IncidenceMatrix([[1,2,3],[1,3,4]])
             vr = [0 0; 1 0; 1 1; 0 1]
-            PC = PolyhedralComplex(IM, vr)
+            PC = polyhedral_complex(IM, vr)
             test_save_load_roundtrip(path, PC) do loaded
               @test loaded isa PolyhedralComplex
               @test Base.propertynames(PC) == Base.propertynames(loaded)

--- a/test/Serialization/PolyhedralGeometry.jl
+++ b/test/Serialization/PolyhedralGeometry.jl
@@ -71,7 +71,7 @@ using Oscar: _integer_variables
         
         @testset "MixedIntegerLinearProgram" begin
             P = cube(3)
-            MILP = MixedIntegerLinearProgram(
+            MILP = mixed_integer_linear_program(
                 P,
                 [3,-2,4];
                 k=2,

--- a/test/Serialization/PolyhedralGeometry.jl
+++ b/test/Serialization/PolyhedralGeometry.jl
@@ -60,7 +60,7 @@ using Oscar: _integer_variables
 
         @testset "LinearProgram" begin
             P = cube(3)
-            LP = LinearProgram(P,[3,-2,4];k=2,convention = :min)
+            LP = linear_program(P,[3,-2,4];k=2,convention = :min)
             test_save_load_roundtrip(path, LP) do loaded
               @test loaded isa LinearProgram
               @test Base.propertynames(LP) == Base.propertynames(loaded)

--- a/test/Serialization/TropicalGeometry.jl
+++ b/test/Serialization/TropicalGeometry.jl
@@ -11,7 +11,7 @@
 
             @testset "Embedded" begin
                 VR = [0 0; 1 0; -1 0; 0 1]
-                PC = PolyhedralComplex{QQFieldElem}(IM, VR)
+                PC = polyhedral_complex(QQFieldElem, IM, VR)
                 TC = TropicalCurve(PC)
                 test_save_load_roundtrip(path, TC) do loaded
                     loaded_PC = underlying_polyhedral_complex(loaded)

--- a/test/Serialization/containers.jl
+++ b/test/Serialization/containers.jl
@@ -2,8 +2,8 @@
     mktempdir() do path
         @testset "Vector{LinearProgram}" begin
             c = cube(3)
-            LP0 = LinearProgram(c, [2,2,-3])
-            LP1 = LinearProgram(c, [2,2,4])
+            LP0 = linear_program(c, [2,2,-3])
+            LP1 = linear_program(c, [2,2,4])
             v = [LP0, LP1]
             test_save_load_roundtrip(path, v) do loaded
               @test length(v) == length(loaded)
@@ -44,7 +44,7 @@
 
         @testset "Vector{Any}" begin
             c = cube(3)
-            LP0 = LinearProgram(c, [2,2,-3])
+            LP0 = linear_program(c, [2,2,-3])
             v = [c, LP0]
             test_save_load_roundtrip(path, v) do loaded
               @test length(v) == length(loaded)
@@ -56,7 +56,7 @@
         
         @testset "Vector{Union{Polyhedron, LinearProgram}}" begin
             c = cube(3)
-            LP0 = LinearProgram(c, [2,2,-3])
+            LP0 = linear_program(c, [2,2,-3])
             v = Vector{Union{Polyhedron, LinearProgram}}([c, LP0])
             test_save_load_roundtrip(path, v) do loaded
               @test length(v) == length(loaded)

--- a/test/Serialization/loading.jl
+++ b/test/Serialization/loading.jl
@@ -2,8 +2,8 @@
     
     @testset "loading Vector{LinearProgram}" begin
         c = cube(3)
-        LP0 = LinearProgram(c, [2,2,-3])
-        LP1 = LinearProgram(c, [2,2,4])
+        LP0 = linear_program(c, [2,2,-3])
+        LP1 = linear_program(c, [2,2,4])
         v = [LP0, LP1]
         loaded = load(joinpath(@__DIR__,"vlp.json"))
         @test length(v) == length(loaded)


### PR DESCRIPTION
For now I will only do a lot of renaming in this PR and think about new constructors elsewhere:
- `PolyhedralFan -> polyhedral_fan`
- `PolyhedralComplex -> polyhedral_complex`
- `SubdivisionOfPoints -> subdivision_of_points`
- `Polyhedron -> polyhedron`
- `Cone -> positive_hull/cone`
- `LinearProgram -> linear_program`
- `MixedIntegerLinearProgram -> mixed_integer_linear_program`