### PR TITLE
bugfix: add missing copy call

### DIFF
--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -2091,7 +2091,7 @@ end
 
 function _homogenization(f::MPolyRingElem, W::ZZMatrix, var::VarName, pos::Int = 1)
   R = parent(f)
-  A = symbols(R)
+  A = copy(symbols(R))
   l = length(A)
   @req pos in 1:l+1 "Index out of range."
   if size(W, 1) == 1

--- a/test/Rings/mpoly-graded-test.jl
+++ b/test/Rings/mpoly-graded-test.jl
@@ -321,3 +321,13 @@ end
   @test forget_decoration(I) == ideal(R, [ x + y ])
   @test forget_grading(I) == ideal(R, [ x + y ])
 end
+
+@testset "Verify homogenization bugfix" begin
+  R, (x, y) = polynomial_ring(QQ, ["x", "y"])
+  @test symbols(R) == [ :x, :y ]
+
+  f = x^3+x^2*y+x*y^2+y^3
+  W = [1 2; 3 4]
+  F = homogenization(f, W, "z", 3)
+  @test symbols(R) == [ :x, :y ]
+end


### PR DESCRIPTION
Need to copy `symbols(R)` as we modify it later on. Otherwise
this happens:

    julia> R, (x, y) = polynomial_ring(QQ, ["x", "y"]);

    julia> symbols(R)
    2-element Vector{Symbol}:
     :x
     :y

    julia> f = x^3+x^2*y+x*y^2+y^3; W = [1 2; 3 4];

    julia> F = homogenization(f, W, "z", 3);

    julia> symbols(R)
    4-element Vector{Symbol}:
     :x
     :y
     Symbol("z[1]")
     Symbol("z[2]")
