### PR TITLE
(Even) more changes in FTheoryTools

### DIFF
--- a/experimental/FTheoryTools/docs/src/tate.md
+++ b/experimental/FTheoryTools/docs/src/tate.md
@@ -102,7 +102,7 @@ However, completeness is an expensive check. Therefore, we provide an optional a
  demonstrate this:
 ```@docs
 global_tate_model(base::AbstractNormalToricVariety; completeness_check::Bool = true)
-global_tate_model(ais::Vector{T}, base::AbstractNormalToricVariety; completeness_check::Bool = true) where {T<:MPolyRingElem{QQFieldElem}}
+global_tate_model(ais::Vector{T}, base::AbstractNormalToricVariety; completeness_check::Bool = true) where {T<:MPolyRingElem}
 ```
 
 ### A toric scheme as base space
@@ -112,7 +112,7 @@ bases, we can use the optional argument `completeness_check = false` to switch o
 expensive completeness check. The following examples demonstrate this:
 ```@docs
 global_tate_model(base::ToricCoveredScheme; completeness_check::Bool = true)
-global_tate_model(ais::Vector{T}, base::ToricCoveredScheme; completeness_check::Bool = true) where {T<:MPolyRingElem{QQFieldElem}}
+global_tate_model(ais::Vector{T}, base::ToricCoveredScheme; completeness_check::Bool = true) where {T<:MPolyRingElem}
 ```
 
 ### A (covered) scheme as base space
@@ -146,7 +146,7 @@ such an analysis are not limited to the world of toric varieties.
 
 For constructions along these lines, we support the following constructor:
 ```@docs
-global_tate_model(ais::Vector{T}, auxiliary_base_ring::MPolyRing, d::Int) where {T<:MPolyRingElem{QQFieldElem}}
+global_tate_model(ais::Vector{T}, auxiliary_base_ring::MPolyRing, d::Int) where {T<:MPolyRingElem}
 ```
 
 ### Standard constructions

--- a/experimental/FTheoryTools/docs/src/weierstrass.md
+++ b/experimental/FTheoryTools/docs/src/weierstrass.md
@@ -87,7 +87,7 @@ However, completeness is an expensive check. Therefore, we provide an optional a
  demonstrate this:
 ```@docs
 global_weierstrass_model(base::AbstractNormalToricVariety; completeness_check::Bool = true)
-global_weierstrass_model(f::MPolyRingElem{QQFieldElem}, g::MPolyRingElem{QQFieldElem}, base::AbstractNormalToricVariety; completeness_check::Bool = true)
+global_weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::AbstractNormalToricVariety; completeness_check::Bool = true)
 ```
 
 ### A toric scheme as base space
@@ -97,7 +97,7 @@ bases, we can use the optional argument `completeness_check = false` to switch o
 expensive completeness check. The following examples demonstrate this:
 ```@docs
 global_weierstrass_model(base::ToricCoveredScheme; completeness_check::Bool = true)
-global_weierstrass_model(f::MPolyRingElem{QQFieldElem}, g::MPolyRingElem{QQFieldElem}, base::ToricCoveredScheme; completeness_check::Bool = true)
+global_weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::ToricCoveredScheme; completeness_check::Bool = true)
 ```
 
 ### A (covered) scheme as base space
@@ -125,7 +125,7 @@ the predictions from such an analysis are not limited to the world of toric vari
 
 For constructions along these lines, we support the following constructor:
 ```@docs
-global_weierstrass_model(weierstrass_f::MPolyRingElem{QQFieldElem}, weierstrass_g::MPolyRingElem{QQFieldElem}, auxiliary_base_ring::MPolyRing, d::Int)
+global_weierstrass_model(weierstrass_f::MPolyRingElem, weierstrass_g::MPolyRingElem, auxiliary_base_ring::MPolyRing, d::Int)
 ```
 
 ### Standard constructions

--- a/experimental/FTheoryTools/src/TateModels/attributes.jl
+++ b/experimental/FTheoryTools/src/TateModels/attributes.jl
@@ -190,7 +190,7 @@ Closed subvariety of a normal toric variety
 ```
 """
 @attr ClosedSubvarietyOfToricVariety function calabi_yau_hypersurface(t::GlobalTateModel)
-  @req typeof(base_space(t)) === ToricCoveredScheme{QQField} "Calabi-Yau hypersurface currently only supported for toric varieties/schemes as base space"
+  @req typeof(base_space(t)) <: ToricCoveredScheme "Calabi-Yau hypersurface currently only supported for toric varieties/schemes as base space"
   base_fully_specified(t) || @vprint :GlobalTateModel 1 "Base space was not fully specified. Returning hypersurface in AUXILIARY ambient space.\n"
   return closed_subvariety_of_toric_variety(underlying_toric_variety(ambient_space(t)), [tate_polynomial(t)])
 end
@@ -214,7 +214,7 @@ Global Weierstrass model over a not fully specified base
 ```
 """
 @attr GlobalWeierstrassModel function global_weierstrass_model(t::GlobalTateModel)
-  @req typeof(base_space(t)) === ToricCoveredScheme{QQField} "Conversion of global Tate model into global Weierstrass model is currently only supported for toric varieties/schemes as base space"
+  @req typeof(base_space(t)) <: ToricCoveredScheme "Conversion of global Tate model into global Weierstrass model is currently only supported for toric varieties/schemes as base space"
   b2 = 4 * tate_section_a2(t) + tate_section_a1(t)^2
   b4 = 2 * tate_section_a4(t) + tate_section_a1(t) * tate_section_a3(t)
   b6 = 4 * tate_section_a6(t) + tate_section_a3(t)^2
@@ -246,8 +246,8 @@ Global Tate model over a not fully specified base
 julia> discriminant(t);
 ```
 """
-@attr MPolyRingElem{QQFieldElem} function discriminant(t::GlobalTateModel)
-  @req typeof(base_space(t)) === ToricCoveredScheme{QQField} "Discriminant of global Tate model is currently only supported for toric varieties/schemes as base space"
+@attr MPolyRingElem function discriminant(t::GlobalTateModel)
+  @req typeof(base_space(t)) <: ToricCoveredScheme "Discriminant of global Tate model is currently only supported for toric varieties/schemes as base space"
   return discriminant(global_weierstrass_model(t))
 end
 
@@ -311,7 +311,7 @@ julia> singular_loci(t)[2]
 (ideal(w), (1, 2, 3), "III")
 ```
 """
-@attr Vector{Tuple{MPolyIdeal{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}, Tuple{Int64, Int64, Int64}, String}} function singular_loci(t::GlobalTateModel)
-  @req typeof(base_space(t)) === ToricCoveredScheme{QQField} "Singular loci of global Tate model currently only supported for toric varieties/schemes as base space"
+@attr Vector{<:Tuple{<:MPolyIdeal{<:MPolyRingElem}, Tuple{Int64, Int64, Int64}, String}} function singular_loci(t::GlobalTateModel)
+  @req typeof(base_space(t)) <: ToricCoveredScheme "Singular loci of global Tate model currently only supported for toric varieties/schemes as base space"
   return singular_loci(global_weierstrass_model(t))
 end

--- a/experimental/FTheoryTools/src/TateModels/constructors.jl
+++ b/experimental/FTheoryTools/src/TateModels/constructors.jl
@@ -18,7 +18,7 @@ global_tate_model(base::AbstractNormalToricVariety; completeness_check::Bool = t
 
 
 @doc raw"""
-    global_tate_model(ais::Vector{T}, base::AbstractNormalToricVariety; completeness_check::Bool = true) where {T<:MPolyRingElem{QQFieldElem}}
+    global_tate_model(ais::Vector{T}, base::AbstractNormalToricVariety; completeness_check::Bool = true) where {T<:MPolyRingElem}
 
 This method operates analogously to `global_tate_model(base::AbstractNormalToricVariety)`.
 The only difference is that the Tate sections ``a_i`` can be specified with non-generic values.
@@ -42,7 +42,7 @@ julia> t = global_tate_model([a1, a2, a3, a4, a6], base; completeness_check = fa
 Global Tate model over a concrete base
 ```
 """
-function global_tate_model(ais::Vector{T}, base::AbstractNormalToricVariety; completeness_check::Bool = true) where {T<:MPolyRingElem{QQFieldElem}}
+function global_tate_model(ais::Vector{T}, base::AbstractNormalToricVariety; completeness_check::Bool = true) where {T<:MPolyRingElem}
   if completeness_check
     @req is_complete(base) "Base space must be complete"
   end
@@ -77,7 +77,7 @@ global_tate_model(base::ToricCoveredScheme; completeness_check::Bool = true) = g
 
 
 @doc raw"""
-    global_tate_model(ais::Vector{T}, base::ToricCoveredScheme; completeness_check::Bool = true) where {T<:MPolyRingElem{QQFieldElem}}
+    global_tate_model(ais::Vector{T}, base::ToricCoveredScheme; completeness_check::Bool = true) where {T<:MPolyRingElem}
 
 This method operates analogously to `global_tate_model(base::ToricCoveredScheme)`.
 The only difference is that the Tate sections ``a_i`` can be specified with non-generic values.
@@ -101,7 +101,7 @@ julia> t = global_tate_model([a1, a2, a3, a4, a6], base; completeness_check = fa
 Global Tate model over a concrete base
 ```
 """
-global_tate_model(ais::Vector{T}, base::ToricCoveredScheme; completeness_check::Bool = true) where {T<:MPolyRingElem{QQFieldElem}} = global_tate_model(ais, underlying_toric_variety(base); completeness_check = completeness_check)
+global_tate_model(ais::Vector{T}, base::ToricCoveredScheme; completeness_check::Bool = true) where {T<:MPolyRingElem} = global_tate_model(ais, underlying_toric_variety(base); completeness_check = completeness_check)
 
 
 ################################################
@@ -118,7 +118,7 @@ global_tate_model(ais::Vector{T}, base::ToricCoveredScheme; completeness_check::
 ################################################
 
 @doc raw"""
-    global_tate_model(ais::Vector{T}, auxiliary_base_ring::MPolyRing, d::Int) where {T<:MPolyRingElem{QQFieldElem}}
+    global_tate_model(ais::Vector{T}, auxiliary_base_ring::MPolyRing, d::Int) where {T<:MPolyRingElem}
 
 This method constructs a global Tate model over a base space that is not
 fully specified. The following example exemplifies this approach.
@@ -143,7 +143,7 @@ julia> t = global_tate_model(ais, auxiliary_base_ring, 3)
 Global Tate model over a not fully specified base
 ```
 """
-function global_tate_model(ais::Vector{T}, auxiliary_base_ring::MPolyRing, d::Int) where {T<:MPolyRingElem{QQFieldElem}}
+function global_tate_model(ais::Vector{T}, auxiliary_base_ring::MPolyRing, d::Int) where {T<:MPolyRingElem}
   @req length(ais) == 5 "We expect exactly 5 Tate sections"
   @req all(k -> parent(k) == auxiliary_base_ring, ais) "All Tate sections must reside in the provided auxiliary base ring"
   @req d > 0 "The dimension of the base space must be positive"

--- a/experimental/FTheoryTools/src/TateModels/constructors.jl
+++ b/experimental/FTheoryTools/src/TateModels/constructors.jl
@@ -43,11 +43,18 @@ Global Tate model over a concrete base
 ```
 """
 function global_tate_model(ais::Vector{T}, base::AbstractNormalToricVariety; completeness_check::Bool = true) where {T<:MPolyRingElem}
+  @req length(ais) == 5 "We require exactly 5 Tate sections"
+  @req all(k -> parent(k) == cox_ring(base), ais) "All Tate sections must reside in the Cox ring of the base toric variety"
+  
+  gens_base_names = [string(g) for g in gens(cox_ring(base))]
+  if ("x" in gens_base_names) || ("y" in gens_base_names) || ("z" in gens_base_names)
+    @vprint :GlobalTateModel 0 "Variable names duplicated between base and fiber coordinates.\n"
+  end
+  
   if completeness_check
     @req is_complete(base) "Base space must be complete"
   end
-  @req length(ais) == 5 "We require exactly 5 Tate sections"
-  @req all(k -> parent(k) == cox_ring(base), ais) "All Tate sections must reside in the Cox ring of the base toric variety"
+  
   ambient_space = _ambient_space_from_base(base)
   pt = _tate_polynomial(ais, cox_ring(ambient_space))
   model = GlobalTateModel(ais[1], ais[2], ais[3], ais[4], ais[5], pt, toric_covered_scheme(base), toric_covered_scheme(ambient_space))
@@ -148,6 +155,10 @@ function global_tate_model(ais::Vector{T}, auxiliary_base_ring::MPolyRing, d::In
   @req all(k -> parent(k) == auxiliary_base_ring, ais) "All Tate sections must reside in the provided auxiliary base ring"
   @req d > 0 "The dimension of the base space must be positive"
   @req ngens(auxiliary_base_ring) >= d "We expect at least as many base variables as the desired base dimension"
+  gens_base_names = [string(g) for g in gens(auxiliary_base_ring)]
+  if ("x" in gens_base_names) || ("y" in gens_base_names) || ("z" in gens_base_names)
+    @vprint :GlobalTateModel 0 "Variable names duplicated between base and fiber coordinates.\n"
+  end
   
   # convert Tate sections into polynomials of the auxiliary base
   auxiliary_base_space = _auxiliary_base_space([string(k) for k in gens(auxiliary_base_ring)], d)

--- a/experimental/FTheoryTools/src/TateModels/methods.jl
+++ b/experimental/FTheoryTools/src/TateModels/methods.jl
@@ -11,7 +11,7 @@ Determine the fiber of a (singular) global Tate model over a particular base loc
 function analyze_fibers(model::GlobalTateModel, centers::Vector{<:Vector{<:Integer}})
   
   # This method only works if the model is defined over a toric variety over toric scheme
-  @req typeof(base_space(model)) === ToricCoveredScheme{QQField} "Analysis of fibers currently only supported for toric scheme/variety as base space"
+  @req typeof(base_space(model)) <: ToricCoveredScheme "Analysis of fibers currently only supported for toric scheme/variety as base space"
   
   # Ideal of the defining polynomial
   hypersurface_ideal = ideal([tate_polynomial(model)])

--- a/experimental/FTheoryTools/src/WeierstrassModels/attributes.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/attributes.jl
@@ -146,7 +146,7 @@ Closed subvariety of a normal toric variety
 ```
 """
 @attr ClosedSubvarietyOfToricVariety function calabi_yau_hypersurface(w::GlobalWeierstrassModel)
-  @req typeof(base_space(w)) === ToricCoveredScheme{QQField} "Calabi-Yau hypersurface currently only supported for toric varieties/schemes as base space"
+  @req typeof(base_space(w)) <: ToricCoveredScheme "Calabi-Yau hypersurface currently only supported for toric varieties/schemes as base space"
   base_fully_specified(w) || @vprint :GlobalWeierstrassModel 1 "Base space was not fully specified. Returning hypersurface in AUXILIARY ambient space.\n"
   return closed_subvariety_of_toric_variety(underlying_toric_variety(ambient_space(w)), [weierstrass_polynomial(w)])
 end
@@ -175,8 +175,8 @@ Global Weierstrass model over a not fully specified base
 julia> discriminant(w);
 ```
 """
-@attr MPolyRingElem{QQFieldElem} function discriminant(w::GlobalWeierstrassModel)
-  @req typeof(base_space(w)) === ToricCoveredScheme{QQField} "Discriminant of global Weierstrass model is currently only supported for toric varieties/schemes as base space"
+@attr MPolyRingElem function discriminant(w::GlobalWeierstrassModel)
+  @req typeof(base_space(w)) <: ToricCoveredScheme "Discriminant of global Weierstrass model is currently only supported for toric varieties/schemes as base space"
   return 4 * w.weierstrass_f^3 + 27 * w.weierstrass_g^2
 end
 
@@ -210,13 +210,13 @@ julia> length(singular_loci(w))
 2
 ```
 """
-@attr Vector{Tuple{MPolyIdeal{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}, Tuple{Int64, Int64, Int64}, String}} function singular_loci(w::GlobalWeierstrassModel)
-  @req typeof(base_space(w)) === ToricCoveredScheme{QQField} "Discriminant of global Weierstrass model is currently only supported for toric varieties/schemes as base space"
+@attr Vector{<:Tuple{<:MPolyIdeal{<:MPolyRingElem}, Tuple{Int64, Int64, Int64}, String}} function singular_loci(w::GlobalWeierstrassModel)
+  @req typeof(base_space(w)) <: ToricCoveredScheme "Singular loci of global Weierstrass model is currently only supported for toric varieties/schemes as base space"
   
   B = irrelevant_ideal(base_space(w))
   
   d_primes = primary_decomposition(ideal([discriminant(w)]))
-  nontrivial_d_primes = Tuple{MPolyIdeal{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}, MPolyIdeal{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}}[]
+  nontrivial_d_primes = Tuple{<:MPolyIdeal{<:MPolyRingElem}, <:MPolyIdeal{<:MPolyRingElem}}[]
   for k in 1:length(d_primes)
     if _is_nontrivial(d_primes[k][2], B)
       push!(nontrivial_d_primes, d_primes[k])
@@ -226,7 +226,7 @@ julia> length(singular_loci(w))
   f_primes = primary_decomposition(ideal([weierstrass_section_f(w)]))
   g_primes = primary_decomposition(ideal([weierstrass_section_g(w)]))
   
-  kodaira_types = Tuple{MPolyIdeal{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}, Tuple{Int64, Int64, Int64}, String}[]
+  kodaira_types = Tuple{<:MPolyIdeal{<:MPolyRingElem}, Tuple{Int64, Int64, Int64}, String}[]
   for d_prime in nontrivial_d_primes
     f_index = findfirst(fp -> fp[2] == d_prime[2], f_primes)
     g_index = findfirst(gp -> gp[2] == d_prime[2], g_primes)

--- a/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
@@ -22,7 +22,7 @@ end
 
 
 @doc raw"""
-    global_weierstrass_model(f::MPolyRingElem{QQFieldElem}, g::MPolyRingElem{QQFieldElem}, base::AbstractNormalToricVariety; completeness_check::Bool = true)
+    global_weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::AbstractNormalToricVariety; completeness_check::Bool = true)
 
 This method operates analogously to `global_weierstrass_model(base::AbstractNormalToricVariety)`.
 The only difference is that the Weierstrass sections ``f`` and ``g`` can be specified with non-generic values.
@@ -40,7 +40,7 @@ julia> w = global_weierstrass_model(f, g, base; completeness_check = false)
 Global Weierstrass model over a concrete base
 ```
 """
-function global_weierstrass_model(f::MPolyRingElem{QQFieldElem}, g::MPolyRingElem{QQFieldElem}, base::AbstractNormalToricVariety; completeness_check::Bool = true)
+function global_weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::AbstractNormalToricVariety; completeness_check::Bool = true)
   if completeness_check
     @req is_complete(base) "Base space must be complete"
   end
@@ -75,7 +75,7 @@ global_weierstrass_model(base::ToricCoveredScheme; completeness_check::Bool = tr
 
 
 @doc raw"""
-    global_weierstrass_model(f::MPolyRingElem{QQFieldElem}, g::MPolyRingElem{QQFieldElem}, base::ToricCoveredScheme; completeness_check::Bool = true)
+    global_weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::ToricCoveredScheme; completeness_check::Bool = true)
 
 This method operates analogously to `global_weierstrass_model(base::ToricCoveredScheme)`.
 The only difference is that the Weierstrass sections ``f`` and ``g`` can be specified with non-generic values.
@@ -93,7 +93,7 @@ julia> w = global_weierstrass_model(f, g, base; completeness_check = false)
 Global Weierstrass model over a concrete base
 ```
 """
-global_weierstrass_model(f::MPolyRingElem{QQFieldElem}, g::MPolyRingElem{QQFieldElem}, base::ToricCoveredScheme; completeness_check::Bool = true) = global_weierstrass_model(f, g, underlying_toric_variety(base), completeness_check = completeness_check)
+global_weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::ToricCoveredScheme; completeness_check::Bool = true) = global_weierstrass_model(f, g, underlying_toric_variety(base), completeness_check = completeness_check)
 
 
 ################################################

--- a/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
@@ -41,10 +41,17 @@ Global Weierstrass model over a concrete base
 ```
 """
 function global_weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::AbstractNormalToricVariety; completeness_check::Bool = true)
+  @req ((parent(f) == cox_ring(base)) && (parent(g) == cox_ring(base))) "All Weierstrass sections must reside in the Cox ring of the base toric variety"
+  
+  gens_base_names = [string(g) for g in gens(cox_ring(base))]
+  if ("x" in gens_base_names) || ("y" in gens_base_names) || ("z" in gens_base_names)
+    @vprint :GlobalWeierstrassModel 0 "Variable names duplicated between base and fiber coordinates.\n"
+  end
+  
   if completeness_check
     @req is_complete(base) "Base space must be complete"
   end
-  @req ((parent(f) == cox_ring(base)) && (parent(g) == cox_ring(base))) "All Weierstrass sections must reside in the Cox ring of the base toric variety"
+  
   ambient_space = _ambient_space_from_base(base)
   pw = _weierstrass_polynomial(f, g, cox_ring(ambient_space))
   model = GlobalWeierstrassModel(f, g, pw, toric_covered_scheme(base), toric_covered_scheme(ambient_space))
@@ -117,7 +124,7 @@ fully specified. The following example illustrates this approach.
 
 # Examples
 ```jldoctest
-julia> auxiliary_base_ring, (f, g, x) = QQ["f", "g", "x"];
+julia> auxiliary_base_ring, (f, g, u) = QQ["f", "g", "u"];
 
 julia> w = global_weierstrass_model(f, g, auxiliary_base_ring, 3)
 Global Weierstrass model over a not fully specified base
@@ -127,9 +134,13 @@ function global_weierstrass_model(weierstrass_f::MPolyRingElem, weierstrass_g::M
   @req ((parent(weierstrass_f) == auxiliary_base_ring) && (parent(weierstrass_g) == auxiliary_base_ring)) "All Weierstrass sections must reside in the provided auxiliary base ring"
   @req d > 0 "The dimension of the base space must be positive"
   @req (ngens(auxiliary_base_ring) >= d) "We expect at least as many base variables as the desired base dimension"
+  gens_base_names = [string(g) for g in gens(auxiliary_base_ring)]
+  if ("x" in gens_base_names) || ("y" in gens_base_names) || ("z" in gens_base_names)
+    @vprint :GlobalWeierstrassModel 0 "Variable names duplicated between base and fiber coordinates.\n"
+  end
   
   # convert Weierstrass sections into polynomials of the auxiliary base
-  auxiliary_base_space = _auxiliary_base_space([string(k) for k in gens(auxiliary_base_ring)], d)
+  auxiliary_base_space = _auxiliary_base_space(gens_base_names, d)
   S = cox_ring(auxiliary_base_space)
   ring_map = hom(auxiliary_base_ring, S, gens(S))
   f = ring_map(weierstrass_f)

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -62,12 +62,12 @@ function _weierstrass_sections(base::AbstractNormalToricVariety)
   return [f, g]
 end
 
-function _weierstrass_polynomial(base::AbstractNormalToricVariety, S::MPolyDecRing{QQFieldElem, QQMPolyRing})
+function _weierstrass_polynomial(base::AbstractNormalToricVariety, S::MPolyRing)
   (f, g) = _weierstrass_sections(base)
   return _weierstrass_polynomial(f, g, S)
 end
 
-function _weierstrass_polynomial(f::MPolyRingElem{QQFieldElem}, g::MPolyRingElem{QQFieldElem}, S::MPolyDecRing{QQFieldElem, QQMPolyRing})
+function _weierstrass_polynomial(f::MPolyRingElem, g::MPolyRingElem, S::MPolyRing)
   x, y, z = gens(S)[ngens(S)-2:ngens(S)]
   ring_map = hom(parent(f), S, gens(S)[1:ngens(S)-3])
   return x^3 - y^2 + ring_map(f)*x*z^4 + ring_map(g)*z^6
@@ -87,12 +87,12 @@ function _tate_sections(base::AbstractNormalToricVariety)
   return [a1, a2, a3, a4, a6]
 end
 
-function _tate_polynomial(base::AbstractNormalToricVariety, S::MPolyDecRing{QQFieldElem, QQMPolyRing})
+function _tate_polynomial(base::AbstractNormalToricVariety, S::MPolyRing)
   (a1, a2, a3, a4, a6) = _tate_sections(base)
   return _tate_polynomial([a1, a2, a3, a4, a6], S)
 end
 
-function _tate_polynomial(ais::Vector{<:MPolyRingElem{QQFieldElem}}, S::MPolyDecRing{QQFieldElem, QQMPolyRing})
+function _tate_polynomial(ais::Vector{<:MPolyRingElem}, S::MPolyRing)
   x, y, z = gens(S)[ngens(S)-2:ngens(S)]
   ring_map = hom(parent(ais[1]), S, gens(S)[1:ngens(S)-3])
   (a1, a2, a3, a4, a6) = [ring_map(k) for k in ais]
@@ -147,7 +147,7 @@ sample_toric_scheme() = toric_covered_scheme(sample_toric_variety())
 # 6: Check if an ideal/subvariety is nontrivial
 ################################################################
 
-_is_nontrivial(id::MPolyIdeal{T}, irr::MPolyIdeal{T}) where {T<:MPolyRingElem{QQFieldElem}} = !is_one(id) && !is_one(saturation(id, irr))
+_is_nontrivial(id::MPolyIdeal{T}, irr::MPolyIdeal{T}) where {T<:MPolyRingElem} = !is_one(id) && !is_one(saturation(id, irr))
 
 
 ################################################################
@@ -158,7 +158,7 @@ _count_factors(poly::QQMPolyRingElem) = mapreduce(p -> p[end], +, absolute_prima
 
 _string_from_factor_count(poly::QQMPolyRingElem, string_list::Vector{String}) = string_list[_count_factors(poly)]
 
-function _kodaira_type(id::MPolyIdeal{T}, f::T, g::T, d::T, ords::Tuple{Int64, Int64, Int64}) where {T<:MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}
+function _kodaira_type(id::MPolyIdeal{T}, f::T, g::T, d::T, ords::Tuple{Int64, Int64, Int64}) where {T<:MPolyRingElem}
   f_ord = ords[1]
   g_ord = ords[2]
   d_ord = ords[3]
@@ -258,7 +258,7 @@ function _blowup_global(id::MPolyIdeal{QQMPolyRingElem}, center::MPolyIdeal{QQMP
   
   return total_transform, strict_transform, exceptional_ideal, crepant, new_irr, new_sri, new_lin, S, S_gens, ring_map
 end
-_blowup_global(id::T, center::T, irr::T, sri::T, lin::MPolyIdeal{QQMPolyRingElem}; index::Integer = 1) where {T<:MPolyIdeal{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}} = _blowup_global(ideal(map(g -> g.f, gens(id))), ideal(map(g -> g.f, gens(center))), ideal(map(g -> g.f, gens(irr))), ideal(map(g -> g.f, gens(sri))), lin, index = index)
+_blowup_global(id::T, center::T, irr::T, sri::T, lin::MPolyIdeal{QQMPolyRingElem}; index::Integer = 1) where {T<:MPolyIdeal{<:MPolyRingElem}} = _blowup_global(ideal(map(g -> g.f, gens(id))), ideal(map(g -> g.f, gens(center))), ideal(map(g -> g.f, gens(irr))), ideal(map(g -> g.f, gens(sri))), lin, index = index)
 
 
 function _blowup_global_sequence(id::MPolyIdeal{QQMPolyRingElem}, centers::Vector{<:Vector{<:Integer}}, irr::MPolyIdeal{QQMPolyRingElem}, sri::MPolyIdeal{QQMPolyRingElem}, lin::MPolyIdeal{QQMPolyRingElem}; index::Integer = 1)
@@ -268,7 +268,7 @@ function _blowup_global_sequence(id::MPolyIdeal{QQMPolyRingElem}, centers::Vecto
   crepant = true
   ring_map = hom(cur_S, cur_S, cur_S_gens) # Identity map
   
-  exceptionals = MPolyIdeal{<:MPolyRingElem{QQFieldElem}}[]
+  exceptionals = MPolyIdeal{<:MPolyRingElem}[]
   for center in centers
     @req all(ind -> 1 <= ind <= length(cur_S_gens), center) "The given indices for the center generators are out of bounds"
     
@@ -286,4 +286,4 @@ function _blowup_global_sequence(id::MPolyIdeal{QQMPolyRingElem}, centers::Vecto
   
   return cur_strict_transform, exceptionals, crepant, cur_irr, cur_sri, cur_lin, cur_S, cur_S_gens, ring_map
 end
-_blowup_global_sequence(id::T, centers::Vector{<:Vector{<:Integer}}, irr::T, sri::T, lin::MPolyIdeal{QQMPolyRingElem}; index::Integer = 1) where {T<:MPolyIdeal{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}} = _blowup_global_sequence(ideal(map(g -> g.f, gens(id))), centers, ideal(map(g -> g.f, gens(irr))), ideal(map(g -> g.f, gens(sri))), lin, index = index)
+_blowup_global_sequence(id::T, centers::Vector{<:Vector{<:Integer}}, irr::T, sri::T, lin::MPolyIdeal{QQMPolyRingElem}; index::Integer = 1) where {T<:MPolyIdeal{<:MPolyRingElem}} = _blowup_global_sequence(ideal(map(g -> g.f, gens(id))), centers, ideal(map(g -> g.f, gens(irr))), ideal(map(g -> g.f, gens(sri))), lin, index = index)

--- a/experimental/FTheoryTools/src/types.jl
+++ b/experimental/FTheoryTools/src/types.jl
@@ -39,21 +39,21 @@ end
 @attributes mutable struct HypersurfaceModel <: AbstractFTheoryModel
   base_space::AbsCoveredScheme
   ambient_space::AbsCoveredScheme
-  hypersurface_equation::MPolyRingElem{QQFieldElem}
-  HypersurfaceModel(base_space::AbsCoveredScheme, ambient_space::AbsCoveredScheme, hypersurface_equation::MPolyRingElem{QQFieldElem}) = new(base_space, ambient_space, hypersurface_equation)
+  hypersurface_equation::MPolyRingElem
+  HypersurfaceModel(base_space::AbsCoveredScheme, ambient_space::AbsCoveredScheme, hypersurface_equation::MPolyRingElem) = new(base_space, ambient_space, hypersurface_equation)
 end
 
 
 @attributes mutable struct GlobalWeierstrassModel
-  weierstrass_f::MPolyRingElem{QQFieldElem}
-  weierstrass_g::MPolyRingElem{QQFieldElem}
-  weierstrass_polynomial::MPolyRingElem{QQFieldElem}
+  weierstrass_f::MPolyRingElem
+  weierstrass_g::MPolyRingElem
+  weierstrass_polynomial::MPolyRingElem
   base_space::AbsCoveredScheme
   ambient_space::AbsCoveredScheme
   fiber_ambient_space::AbsCoveredScheme
-  function GlobalWeierstrassModel(weierstrass_f::MPolyRingElem{QQFieldElem},
-                            weierstrass_g::MPolyRingElem{QQFieldElem},
-                            weierstrass_polynomial::MPolyRingElem{QQFieldElem},
+  function GlobalWeierstrassModel(weierstrass_f::MPolyRingElem,
+                            weierstrass_g::MPolyRingElem,
+                            weierstrass_polynomial::MPolyRingElem,
                             base_space::AbsCoveredScheme,
                             ambient_space::AbsCoveredScheme)
     return new(weierstrass_f, weierstrass_g, weierstrass_polynomial, base_space, ambient_space, weighted_projective_space(ToricCoveredScheme, [2,3,1]))
@@ -62,21 +62,21 @@ end
 
 
 @attributes mutable struct GlobalTateModel
-  tate_a1::MPolyRingElem{QQFieldElem}
-  tate_a2::MPolyRingElem{QQFieldElem}
-  tate_a3::MPolyRingElem{QQFieldElem}
-  tate_a4::MPolyRingElem{QQFieldElem}
-  tate_a6::MPolyRingElem{QQFieldElem}
-  tate_polynomial::MPolyRingElem{QQFieldElem}
+  tate_a1::MPolyRingElem
+  tate_a2::MPolyRingElem
+  tate_a3::MPolyRingElem
+  tate_a4::MPolyRingElem
+  tate_a6::MPolyRingElem
+  tate_polynomial::MPolyRingElem
   base_space::AbsCoveredScheme
   ambient_space::AbsCoveredScheme
   fiber_ambient_space::AbsCoveredScheme
-  function GlobalTateModel(tate_a1::MPolyRingElem{QQFieldElem},
-                          tate_a2::MPolyRingElem{QQFieldElem},
-                          tate_a3::MPolyRingElem{QQFieldElem},
-                          tate_a4::MPolyRingElem{QQFieldElem},
-                          tate_a6::MPolyRingElem{QQFieldElem},
-                          tate_polynomial::MPolyRingElem{QQFieldElem},
+  function GlobalTateModel(tate_a1::MPolyRingElem,
+                          tate_a2::MPolyRingElem,
+                          tate_a3::MPolyRingElem,
+                          tate_a4::MPolyRingElem,
+                          tate_a6::MPolyRingElem,
+                          tate_polynomial::MPolyRingElem,
                           base_space::AbsCoveredScheme,
                           ambient_space::AbsCoveredScheme)
     return new(tate_a1, tate_a2, tate_a3, tate_a4, tate_a6, tate_polynomial, base_space, ambient_space, weighted_projective_space(ToricCoveredScheme, [2,3,1]))

--- a/experimental/FTheoryTools/test/runtests.jl
+++ b/experimental/FTheoryTools/test/runtests.jl
@@ -83,7 +83,7 @@ end
 # 2: Global Weierstrass models over generic base space
 #############################################################
 
-auxiliary_base_ring, (f, g, x) = QQ["f", "g", "x"]
+auxiliary_base_ring, (f, g, u) = QQ["f", "g", "u"]
 w2 = global_weierstrass_model(f, g, auxiliary_base_ring, 3)
 
 @testset "Attributes of global Weierstrass models over generic base space" begin


### PR DESCRIPTION
* Remove restrictions to rationals whenever possible,
* Raise warning whenever variables names are duplicated among base and fiber. (One can still proceed in this case if really desired.)