### PR TITLE
Remove `FreeModElem(::SRow, ::FreeMod_dec)`

### DIFF
--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -1317,16 +1317,6 @@ function (F::FreeMod_dec)()
 end
 
 @doc raw"""
-    FreeModElem(coords::SRow{T}, parent::FreeMod_dec{T}) where T <: CRingElem_dec
-
-Return the element of `F` whose coefficients with respect to the basis of 
-standard unit vectors of `F` are given by the entries of `c`.
-"""
-function FreeModElem(coords::SRow{T}, parent::FreeMod_dec{T}) where T <: CRingElem_dec
-  return FreeModElem_dec{T}(coords, parent)
-end
-
-@doc raw"""
     FreeModElem_dec(v::FreeModElem{T}, parent::FreeMod_dec{T}) where T <: CRingElem_dec
 
 Lift `v` to the decorated module `parent`.

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -423,7 +423,7 @@ function basis(F::AbstractFreeMod)
   bas = elem_type(F)[]
   for i=1:dim(F)
     s = Hecke.sparse_row(base_ring(F), [(i, base_ring(F)(1))])
-    push!(bas, FreeModElem(s, F))
+    push!(bas, F(s))
   end
   return bas
 end
@@ -446,7 +446,7 @@ Return the `i`th basis vector of `F`, that is, return the `i`th standard unit ve
 function basis(F::AbstractFreeMod, i::Int)
   @assert 0 < i <= ngens(F)
   s = Hecke.sparse_row(base_ring(F), [(i, base_ring(F)(1))])
-  return FreeModElem(s, F)
+  return F(s)
 end
 gen(F::AbstractFreeMod, i::Int) = basis(F,i)
 
@@ -465,18 +465,18 @@ base_ring(F::FreeMod) = F.R
 #TODO: Parent - checks everywhere!!!
 
 # the negative of a free module element
--(a::AbstractFreeModElem) = FreeModElem(-coordinates(a), parent(a))
+-(a::AbstractFreeModElem) = parent(a)(-coordinates(a))
 
 # Addition of free module elements
 function +(a::AbstractFreeModElem, b::AbstractFreeModElem)
    check_parent(a, b)
-   return FreeModElem(coordinates(a)+coordinates(b), parent(a))
+   return parent(a)(coordinates(a)+coordinates(b))
 end
 
 # Subtraction of free module elements
 function -(a::AbstractFreeModElem, b::AbstractFreeModElem)
     check_parent(a,b)
-    return FreeModElem(coordinates(a)-coordinates(b), parent(a))
+    return parent(a)(coordinates(a)-coordinates(b))
 end
 
 # Equality of free module elements
@@ -492,7 +492,7 @@ function hash(a::AbstractFreeModElem, h::UInt)
 end
 
 function Base.deepcopy_internal(a::AbstractFreeModElem, dict::IdDict)
-  return FreeModElem(deepcopy_internal(coordinates(a), dict), parent(a))
+  return parent(a)(deepcopy_internal(coordinates(a), dict))
 end
 
 # scalar multiplication with polynomials, integers
@@ -500,30 +500,31 @@ function *(a::MPolyDecRingElem, b::AbstractFreeModElem)
   if parent(a) !== base_ring(parent(b))
     error("elements not compatible")
   end
-  return FreeModElem(a*coordinates(b), parent(b))
+  return parent(b)(a*coordinates(b))
 end
 function *(a::MPolyRingElem, b::AbstractFreeModElem) 
   if parent(a) !== base_ring(parent(b))
     return base_ring(parent(b))(a)*b # this will throw if conversion is not possible
   end
-  return FreeModElem(a*coordinates(b), parent(b))
+  return parent(b)(a*coordinates(b))
 end
 function *(a::RingElem, b::AbstractFreeModElem) 
   if parent(a) !== base_ring(parent(b))
     return base_ring(parent(b))(a)*b # this will throw if conversion is not possible
   end
-  return FreeModElem(a*coordinates(b), parent(b))
+  return parent(b)(a*coordinates(b))
 end
-*(a::Int, b::AbstractFreeModElem) = FreeModElem(a*coordinates(b), parent(b))
-*(a::Integer, b::AbstractFreeModElem) = FreeModElem(base_ring(parent(b))(a)*coordinates(b), parent(b))
-*(a::QQFieldElem, b::AbstractFreeModElem) = FreeModElem(base_ring(parent(b))(a)*coordinates(b), parent(b))
+
+*(a::Int, b::AbstractFreeModElem) = parent(b)(a*coordinates(b))
+*(a::Integer, b::AbstractFreeModElem) = parent(b)(base_ring(parent(b))(a)*coordinates(b))
+*(a::QQFieldElem, b::AbstractFreeModElem) = parent(b)(base_ring(parent(b))(a)*coordinates(b))
 
 @doc raw"""
     zero(F::AbstractFreeMod)
 
 Return the zero element of  `F`.
 """
-zero(F::AbstractFreeMod) = FreeModElem(sparse_row(base_ring(F), Tuple{Int, elem_type(base_ring(F))}[]), F)
+zero(F::AbstractFreeMod) = F(sparse_row(base_ring(F), Tuple{Int, elem_type(base_ring(F))}[]))
 
 @doc raw"""
     parent(a::AbstractFreeModElem)

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -488,7 +488,7 @@ function (==)(a::AbstractFreeModElem, b::AbstractFreeModElem)
 end
 
 function hash(a::AbstractFreeModElem, h::UInt)
-  return hash(tuple(parent(a), coordinates(a)), h)
+  return xor(hash(tuple(parent(a), coordinates(a)), h), hash(typeof(a)))
 end
 
 function Base.deepcopy_internal(a::AbstractFreeModElem, dict::IdDict)
@@ -497,17 +497,17 @@ end
 
 # scalar multiplication with polynomials, integers
 function *(a::MPolyDecRingElem, b::AbstractFreeModElem)
-  if parent(a) !== base_ring(parent(b))
-    error("elements not compatible")
-  end
+  @req parent(a) === base_ring(parent(b)) "elements not compatible"
   return parent(b)(a*coordinates(b))
 end
+
 function *(a::MPolyRingElem, b::AbstractFreeModElem) 
   if parent(a) !== base_ring(parent(b))
     return base_ring(parent(b))(a)*b # this will throw if conversion is not possible
   end
   return parent(b)(a*coordinates(b))
 end
+
 function *(a::RingElem, b::AbstractFreeModElem) 
   if parent(a) !== base_ring(parent(b))
     return base_ring(parent(b))(a)*b # this will throw if conversion is not possible
@@ -3820,7 +3820,7 @@ function index_of_gen(v::SubquoModuleElem)
   return coordinates(v).pos[1]
 end
 
-# function to check whether a free module element is in a particular free module
+# function to check whether two module elements are in the same module
 function check_parent(a::Union{AbstractFreeModElem,SubquoModuleElem}, b::Union{AbstractFreeModElem,SubquoModuleElem})
   if parent(a) !== parent(b)
     error("elements not compatible")

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -361,3 +361,6 @@ function MixedIntegerLinearProgram{T}(A::Union{Oscar.MatElem,AbstractMatrix}, b,
   Base.depwarn("'MixedIntegerLinearProgram(x...)' is deprecated, use 'mixed_integer_linear_program(x...)' instead.", :MixedIntegerLinearProgram)
   return mixed_integer_linear_program(T, A, b, c; kwargs...)
 end
+
+# see https://github.com/oscar-system/Oscar.jl/pull/2368
+@deprecate FreeModElem(coords::SRow{T}, parent::FreeMod_dec{T}) where T <: CRingElem_dec FreeModElem_dec(coords, parent)


### PR DESCRIPTION
The function proposed to be removed confused @thofma and me (cf. https://github.com/oscar-system/Oscar.jl/pull/2351#discussion_r1187546053), since it is called as a concrete type (`FreeModElem`), but returns some object of a different type (`FreeModElem_dec`).
I Replaced its usages by `(::FreeMod_dec)(::SRow)` which in turn calls `FreeModElem_dec(::SRow, ::FreeMod_dec)`. Since the first one is a special dispatch of `(::AbstractFreeMod)(::SRow)`, the generic code in `UngradedModules.jl` for `FreeModElem` and `FreeModElem_dec` still works.

~For my convenience, this contains the changes from #2351. Once that PR is merged, I will rebase this PR onto `master` and fix the conflicts in `deprecations.jl` due to #2342.~