### PR TITLE
Add Aqua.jl for some static testing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,6 +26,7 @@ cohomCalg_jll = "5558cf25-a90e-53b0-b813-cadaa3ae7ade"
 [compat]
 AbstractAlgebra = "0.29.3"
 AlgebraicSolving = "0.3.0"
+Aqua = "0.6"
 DocStringExtensions = "0.8, 0.9"
 GAP = "0.9.4"
 Hecke = "0.18.9"
@@ -36,13 +37,16 @@ Preferences = "1"
 RandomExtensions = "0.4.3"
 RecipesBase = "1.2.1"
 Singular = "0.18.2"
+TOPCOM_jll = "0.17.8"
+cohomCalg_jll = "0.32.0"
 julia = "1.6"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Documenter", "PrettyTables", "Printf"]
+test = ["Test", "Aqua", "Documenter", "PrettyTables", "Printf"]

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -1,0 +1,13 @@
+@testset "Aqua.jl" begin
+  Aqua.test_all(
+    Oscar;
+    ambiguities=false,      # TODO: fix ambiguities
+    unbound_args=false,     # TODO: fix unbound type parameters
+    undefined_exports=true,
+    project_extras=true,
+    stale_deps=false,       # some weird error with GAP_lib_jll
+    deps_compat=true,
+    project_toml_formatting=true,
+    piracy=false,           # TODO: check the reported methods to be moved upstream
+  )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,17 +85,7 @@ end
 # Used in both Rings/slpolys.jl and StraightLinePrograms/runtests.jl
 const SLP = Oscar.StraightLinePrograms
 
-Aqua.test_all(
-  Oscar;
-  ambiguities=false,      # TODO: fix ambiguities
-  unbound_args=false,     # TODO: fix unbound type parameters
-  undefined_exports=true,
-  project_extras=true,
-  stale_deps=false,       # some weird error with GAP_lib_jll
-  deps_compat=true,
-  project_toml_formatting=true,
-  piracy=false,           # TODO: check the reported methods to be moved upstream
-)
+include("Aqua.jl")
 
 include("printing.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Oscar
 using Test
+using Aqua
 using Documenter
 
 import Random
@@ -78,10 +79,24 @@ function include(str::String)
 end
 
 @static if compiletimes
-  Base.cumulative_compile_timing(true);
+  Base.cumulative_compile_timing(true)
 end
+
 # Used in both Rings/slpolys.jl and StraightLinePrograms/runtests.jl
 const SLP = Oscar.StraightLinePrograms
+
+Aqua.test_all(
+  Oscar;
+  ambiguities=false,      # TODO: fix ambiguities
+  unbound_args=false,     # TODO: fix unbound type parameters
+  undefined_exports=true,
+  project_extras=true,
+  stale_deps=false,       # some weird error with GAP_lib_jll
+  deps_compat=true,
+  project_toml_formatting=true,
+  piracy=false,           # TODO: check the reported methods to be moved upstream
+)
+
 include("printing.jl")
 
 include("PolyhedralGeometry/runtests.jl")


### PR DESCRIPTION
Resolves #1964.

Three of the performed tests (`ambiguities`, `unbound_args`, and `piracy`) currently fail and are thus disabled (with a comment to check if/with how much work they can be fixed).

`deps_compat` requires all dependencies to have a `[compat]` entry, so I added the missing ones. The JuliaRegistry currently does not require those for JLLs (cf. the last paragraph of https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/#Upper-bounded-[compat]-entries), but adding them should not hurt.

`stale_deps` fails on my local setup with some weird error containing the UUID of `GAP_lib_jll`. This can be investigated in a separate PR.