### PR TITLE
Add `hash` methods for many types with `==` method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oscar"
 uuid = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
 authors = ["The OSCAR Team <oscar@mathematik.uni-kl.de>"]
-version = "0.12.2-DEV"
+version = "0.13.0-DEV"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/constructors.jl
@@ -267,11 +267,17 @@ end
 
 
 ####################################################
-# 6: Equality
+# 6: Equality and hash
 ####################################################
 
 function Base.:(==)(ac1::RationalEquivalenceClass, ac2::RationalEquivalenceClass)
     return toric_variety(ac1) === toric_variety(ac2) && iszero(polynomial(ac1-ac2))
+end
+
+function Base.hash(ac::RationalEquivalenceClass, h::UInt) 
+  b = 0xb5d4ac6b9084eb6e  % UInt
+  h = hash(toric_variety(ac), h)
+  return xor(h, b)
 end
 
 

--- a/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/constructors.jl
@@ -271,13 +271,14 @@ end
 ####################################################
 
 function Base.:(==)(ac1::RationalEquivalenceClass, ac2::RationalEquivalenceClass)
-    return toric_variety(ac1) === toric_variety(ac2) && iszero(polynomial(ac1-ac2))
+    return toric_variety(ac1) === toric_variety(ac2) && polynomial(ac1) == polynomial(ac2)
 end
 
 function Base.hash(ac::RationalEquivalenceClass, h::UInt) 
-  b = 0xb5d4ac6b9084eb6e  % UInt
-  h = hash(toric_variety(ac), h)
-  return xor(h, b)
+    b = 0xb5d4ac6b9084eb6e  % UInt
+    h = hash(toric_variety(ac), h)
+    h = hash(polynomial(ac), h)
+    return xor(h, b)
 end
 
 

--- a/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/constructors.jl
@@ -148,12 +148,15 @@ Base.:^(cc::CohomologyClass, p::T) where {T <: IntegerUnion} = CohomologyClass(t
 # 5: Equality and hash
 ########################
 
-Base.:(==)(cc1::CohomologyClass, cc2::CohomologyClass) = toric_variety(cc1) === toric_variety(cc2) && iszero(polynomial(cc1-cc2))
+function Base.:(==)(cc1::CohomologyClass, cc2::CohomologyClass) 
+    toric_variety(cc1) === toric_variety(cc2) && polynomial(cc1) == polynomial(cc2)
+end
 
 function Base.hash(cc::CohomologyClass, h::UInt) 
-  b = 0x4de32042e67d89c8 % UInt
-  h = hash(toric_variety(cc), h)
-  return xor(h, b)
+    b = 0x4de32042e67d89c8 % UInt
+    h = hash(toric_variety(cc), h)
+    h = hash(polynomial(cc), h)
+    return xor(h, b)
 end
 
 ######################

--- a/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/constructors.jl
@@ -145,11 +145,16 @@ Base.:^(cc::CohomologyClass, p::T) where {T <: IntegerUnion} = CohomologyClass(t
 
 
 ########################
-# 5: Equality
+# 5: Equality and hash
 ########################
 
 Base.:(==)(cc1::CohomologyClass, cc2::CohomologyClass) = toric_variety(cc1) === toric_variety(cc2) && iszero(polynomial(cc1-cc2))
 
+function Base.hash(cc::CohomologyClass, h::UInt) 
+  b = 0x4de32042e67d89c8 % UInt
+  h = hash(toric_variety(cc), h)
+  return xor(h, b)
+end
 
 ######################
 # 6: Display

--- a/src/AlgebraicGeometry/ToricVarieties/ToricDivisorClasses/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricDivisorClasses/constructors.jl
@@ -100,11 +100,17 @@ Base.:*(c::T, tdc::ToricDivisorClass) where {T <: IntegerUnion} = toric_divisor_
 
 
 ########################
-# 5: Equality
+# 5: Equality and hash
 ########################
 
 function Base.:(==)(tdc1::ToricDivisorClass, tdc2::ToricDivisorClass)
     return toric_variety(tdc1) === toric_variety(tdc2) && iszero(divisor_class(tdc1) - divisor_class(tdc2))
+end
+
+function Base.hash(tdc::ToricDivisorClass, h::UInt)
+    b = 0x118eb1fba136490c % UInt
+    h = hash(toric_variety(tdc), h)
+    return xor(h, b)
 end
 
 

--- a/src/AlgebraicGeometry/ToricVarieties/ToricDivisorClasses/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricDivisorClasses/constructors.jl
@@ -104,12 +104,13 @@ Base.:*(c::T, tdc::ToricDivisorClass) where {T <: IntegerUnion} = toric_divisor_
 ########################
 
 function Base.:(==)(tdc1::ToricDivisorClass, tdc2::ToricDivisorClass)
-    return toric_variety(tdc1) === toric_variety(tdc2) && iszero(divisor_class(tdc1) - divisor_class(tdc2))
+    return toric_variety(tdc1) === toric_variety(tdc2) && divisor_class(tdc1) == divisor_class(tdc2)
 end
 
 function Base.hash(tdc::ToricDivisorClass, h::UInt)
     b = 0x118eb1fba136490c % UInt
     h = hash(toric_variety(tdc), h)
+    h = hash(divisor_class(tdc), h)
     return xor(h, b)
 end
 

--- a/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/constructors.jl
@@ -99,11 +99,18 @@ Base.:*(c::T, td::ToricDivisor) where {T <: IntegerUnion} = toric_divisor(toric_
 
 
 ######################
-# 5: Equality
+# 5: Equality and hash
 ######################s
 
 function Base.:(==)(td1::ToricDivisor, td2::ToricDivisor)
     return toric_variety(td1) === toric_variety(td2) && coefficients(td1) == coefficients(td2)
+end
+
+function Base.hash(td::ToricDivisor, h::UInt)
+    b = 0x92bd6ac4f87d834e % UInt
+    h = hash(toric_variety(td), h)
+    h = hash(coefficients(td), h)
+    return xor(h, b)
 end
 
 

--- a/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles/constructors.jl
@@ -174,11 +174,17 @@ Base.:^(l::ToricLineBundle, p::Int) = l^ZZRingElem(p)
 
 
 ########################
-# 5: Equality
+# 5: Equality and hash
 ########################
 
 function Base.:(==)(l1::ToricLineBundle, l2::ToricLineBundle)
     return toric_variety(l1) === toric_variety(l2) && picard_class(l1) == picard_class(l2)
+end
+
+function Base.hash(l::ToricLineBundle, h::UInt)
+    b = 0xa2b0a2cd60a8ffbf % UInt
+    h = hash(toric_variety(l), h)
+    return xor(h, b)
 end
 
 

--- a/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles/constructors.jl
@@ -184,6 +184,7 @@ end
 function Base.hash(l::ToricLineBundle, h::UInt)
     b = 0xa2b0a2cd60a8ffbf % UInt
     h = hash(toric_variety(l), h)
+    h = hash(picard_class(l), h)
     return xor(h, b)
 end
 

--- a/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/constructors.jl
@@ -220,11 +220,19 @@ end
 
 
 ####################################################
-# 6: Equality of toric morphisms
+# 6: Equality and hash of toric morphisms
 ####################################################
 
 function Base.:(==)(tm1::ToricMorphism, tm2::ToricMorphism)
     return domain(tm1) == domain(tm2) && codomain(tm1) == codomain(tm2) && grid_morphism(tm1) == grid_morphism(tm2)
+end
+
+function Base.hash(tm::ToricMorphism, h::UInt)
+    b = 0x1a66f927cae2d409 % UInt
+    h = hash(domain(tm), h)
+    h = hash(codomain(tm), h)
+    h = hash(grid_morphism(tm), h)
+    return xor(h, b)
 end
 
 

--- a/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/constructors.jl
@@ -237,7 +237,7 @@ end
 
 
 ######################
-# 6: Display
+# 7: Display
 ######################
 
 function Base.show(io::IO, tm::ToricMorphism)

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -213,7 +213,15 @@ function ^(omega::ElementOfGSet, g::T) where {T<:AbstractAlgebra.GroupElem}
     return ElementOfGSet(Omega, fun(omega.obj, g))
 end
 
-==(omega1::ElementOfGSet, omega2::ElementOfGSet) = ((omega1.gset == omega2.gset) && (omega1.obj == omega2.obj))
+==(omega1::ElementOfGSet, omega2::ElementOfGSet) = 
+  ((omega1.gset == omega2.gset) && (omega1.obj == omega2.obj))
+
+function Base.hash(omega::ElementOfGSet, h::UInt)
+  b = 0x4dd1b3e65edeab89 % UInt
+  h = hash(omega.gset, h)
+  h = hash(omega.obj, h)
+  return xor(h, b)
+end
 
 Base.in(omega::ElementOfGSet, Omega::GSet) = Base.in(omega.obj, Omega)
 

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -6,7 +6,12 @@ function Base.show(io::IO, x::GAPGroupHomomorphism)
 end
 
 function ==(f::GAPGroupHomomorphism{S,T}, g::GAPGroupHomomorphism{S,T}) where S where T
-   return f.map == g.map
+  return f.map == g.map
+end
+
+function Base.hash(f::GAPGroupHomomorphism{S,T}, h::UInt) where S where T
+  b = 0xdc777737af4c0c7b % UInt
+  return xor(hash(f.map, hash((S, T), h)), b)
 end
 
 Base.:*(f::GAPGroupHomomorphism{S, T}, g::GAPGroupHomomorphism{T, U}) where S where T where U = compose(f, g)

--- a/src/Groups/matrices/forms.jl
+++ b/src/Groups/matrices/forms.jl
@@ -176,7 +176,14 @@ end
 ########################################################################
 
 #TODO: checking whether two quadratic forms coincide by checking their polynomials is not possible yet.
-==(B::SesquilinearForm, C::SesquilinearForm) = gram_matrix(B)==gram_matrix(C) && B.descr==C.descr
+==(B::SesquilinearForm, C::SesquilinearForm) = B.descr == C.descr && gram_matrix(B) == gram_matrix(C)
+
+function Base.hash(f::SesquilinearForm, h::UInt)
+   b = 0xf64440baac005f8c % UInt
+   h = hash(f.descr, h)
+   h = hash(gram_matrix(f), h)
+   return xor(h, b)
+end
 
 function base_ring(B::SesquilinearForm)
    if isdefined(B,:matrix) return base_ring(gram_matrix(B))

--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -1644,6 +1644,11 @@ function Base.:(==)(F::FreeMod_dec, G::FreeMod_dec)
   return forget_decoration(F) == forget_decoration(G) && F.d == G.d
 end
 
+function Base.hash(F::FreeMod_dec, h::UInt)
+  b = 0x13d6e1b453cb661a % UInt
+  return xor(hash(forget_decoration(F), hash(F.d, h)), b)
+end
+
 ###############################################################################
 # FreeModElem_dec constructors
 ###############################################################################

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -3523,37 +3523,50 @@ function +(a::SubquoModuleElem, b::SubquoModuleElem)
   check_parent(a,b)
   return SubquoModuleElem(coordinates(a)+coordinates(b), a.parent)
 end
+
 function -(a::SubquoModuleElem, b::SubquoModuleElem) 
   check_parent(a,b)
   return SubquoModuleElem(coordinates(a)-coordinates(b), a.parent)
 end
+
 -(a::SubquoModuleElem) = SubquoModuleElem(-coordinates(a), a.parent)
+
 function *(a::MPolyDecRingElem, b::SubquoModuleElem) 
   if parent(a) !== base_ring(parent(b))
     return base_ring(parent(b))(a)*b # this will throw if conversion is not possible
   end
   return SubquoModuleElem(a*coordinates(b), b.parent)
 end
+
 function *(a::MPolyRingElem, b::SubquoModuleElem) 
   if parent(a) !== base_ring(parent(b))
     return base_ring(parent(b))(a)*b # this will throw if conversion is not possible
   end
   return SubquoModuleElem(a*coordinates(b), b.parent)
 end
+
 function *(a::RingElem, b::SubquoModuleElem) 
   if parent(a) !== base_ring(parent(b))
     return base_ring(parent(b))(a)*b # this will throw if conversion is not possible
   end
   return SubquoModuleElem(a*coordinates(b), b.parent)
 end
+
 *(a::Int, b::SubquoModuleElem) = SubquoModuleElem(a*coordinates(b), b.parent)
 *(a::Integer, b::SubquoModuleElem) = SubquoModuleElem(a*coordinates(b), b.parent)
 *(a::QQFieldElem, b::SubquoModuleElem) = SubquoModuleElem(a*coordinates(b), b.parent)
+
 function (==)(a::SubquoModuleElem, b::SubquoModuleElem) 
   if parent(a) !== parent(b)
     return false
   end
   return iszero(a-b)
+end
+
+function Base.hash(a::SubquoModuleElem, h::UInt)
+  b = 0x0361a2f6467e4200 % UInt
+  h = hash(parent(a), h)
+  return xor(h, b)
 end
 
 function Base.deepcopy_internal(a::SubquoModuleElem, dict::IdDict)

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -3564,9 +3564,7 @@ function (==)(a::SubquoModuleElem, b::SubquoModuleElem)
 end
 
 function Base.hash(a::SubquoModuleElem, h::UInt)
-  b = 0x0361a2f6467e4200 % UInt
-  h = hash(parent(a), h)
-  return xor(h, b)
+  error("not implemented")
 end
 
 function Base.deepcopy_internal(a::SubquoModuleElem, dict::IdDict)

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -4820,6 +4820,15 @@ function (==)(f::ModuleFPHom, g::ModuleFPHom)
   end
   return true
 end
+
+function Base.hash(f::ModuleFPHom, h::UInt)
+  b = 0x535bbdbb2bc54b46 % UInt
+  h = hash(typeof(f), h)
+  h = hash(domain(f), h)
+  h = hash(codomain(f), h)
+  return xor(h, b)
+end
+
 ###################################################################
 
 @doc raw"""

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -181,8 +181,12 @@ function (==)(F::FreeMod, G::FreeMod)
 end
 
 function hash(F::FreeMod, h::UInt)
-  is_graded(F) && return hash((base_ring(F), rank(F), F.S, F.d), h)
-  return hash((base_ring(F), rank(F), F.S), h)
+  b = is_graded(F) ? (0x2d55d561d3f7e215 % UInt) : (0x62ca4181ff3a12f4 % UInt)
+  h = hash(base_ring(F), h)
+  h = hash(rank(F), h)
+  h = hash(F.S, h)
+  is_graded(F) && (h = hash(F.d, h))
+  return xor(h, b)
 end
 
 @doc raw"""
@@ -490,7 +494,11 @@ function (==)(a::AbstractFreeModElem, b::AbstractFreeModElem)
 end
 
 function hash(a::AbstractFreeModElem, h::UInt)
-  return xor(hash(tuple(parent(a), coordinates(a)), h), hash(typeof(a)))
+  b = 0xaa2ba4a32dd0b431 % UInt
+  h = hash(typeof(a), h)
+  h = hash(parent(a), h)
+  h = hash(coordinates(a), h)
+  return xor(h, b)
 end
 
 function Base.deepcopy_internal(a::AbstractFreeModElem, dict::IdDict)

--- a/src/PolyhedralGeometry/iterators.jl
+++ b/src/PolyhedralGeometry/iterators.jl
@@ -188,6 +188,12 @@ Base.:(==)(x::AffineHyperplane, y::AffineHyperplane) = x.a == y.a && x.b == y.b
 
 Base.:(==)(x::LinearHyperplane, y::LinearHyperplane) = x.a == y.a
 
+Base.hash(x::T, h::UInt) where {T<:Union{AffineHalfspace,AffineHyperplane}} =
+  hash((x.a, x.b), hash(T, h))
+
+Base.hash(x::T, h::UInt) where {T<:Union{LinearHalfspace,LinearHyperplane}} =
+  hash(x.a, hash(T, h))
+
 ################################################################################
 
 for T in [LinearHalfspace, LinearHyperplane]

--- a/src/Rings/PBWAlgebra.jl
+++ b/src/Rings/PBWAlgebra.jl
@@ -1078,6 +1078,10 @@ function Base.:(==)(a::PBWAlgIdeal{D, T, S}, b::PBWAlgIdeal{D, T, S}) where {D, 
   return is_subset(a, b) && is_subset(b, a)
 end
 
+function Base.hash(a::PBWAlgIdeal{D, T, S}, h::UInt) where {D, T, S}
+  b = 0x91c65dda1eed350f % UInt
+  return xor(hash(base_ring(a), hash(D, h)), b)
+end
 
 #### elimination
 

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -674,11 +674,8 @@ function ==(T::AbsMPolyMultSet, U::AbsMPolyMultSet)
   return (issubset(T, U) && issubset(U, T))
 end
 
-function Base.hash(T::AbsMPolyMultSet, h::UInt)
-  b = 0x7ce51a28c47ec5e1 % UInt
-  h = hash(typeof(T), h)
-  h = hash(ambient_ring(T), h)
-  return xor(h, b)
+function Base.hash(T::AbsMPolyMultSet{BRT, BRET, RT, RET}, h::UInt) where {BRT,BRET,RT,RET}
+  error("not implemented")
 end
 
 function issubset(

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -674,6 +674,13 @@ function ==(T::AbsMPolyMultSet, U::AbsMPolyMultSet)
   return (issubset(T, U) && issubset(U, T))
 end
 
+function Base.hash(T::AbsMPolyMultSet, h::UInt)
+  b = 0x7ce51a28c47ec5e1 % UInt
+  h = hash(typeof(T), h)
+  h = hash(ambient_ring(T), h)
+  return xor(h, b)
+end
+
 function issubset(
     T::MPolyComplementOfPrimeIdeal{BRT, BRET, RT, RET},
     U::MPolyComplementOfPrimeIdeal{BRT, BRET, RT, RET}

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -2901,6 +2901,9 @@ function Base.hash(f::MPolyLocalizedRingHom, h::UInt)
   b = 0xe29cdc1ecb68b7a0 % UInt
   h = hash(domain(f), h)
   h = hash(codomain(f), h)
+  for x in gens(base_ring(domain(f)))
+    h = hash(f(x), h)
+  end
   return xor(h, b)
 end
 

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -2897,6 +2897,13 @@ function ==(f::MPolyLocalizedRingHom, g::MPolyLocalizedRingHom)
   return true
 end
 
+function Base.hash(f::MPolyLocalizedRingHom, h::UInt)
+  b = 0xe29cdc1ecb68b7a0 % UInt
+  h = hash(domain(f), h)
+  h = hash(codomain(f), h)
+  return xor(h, b)
+end
+
 function divides(a::MPolyLocRingElem, b::MPolyLocRingElem)
   W = parent(a)
   W == parent(b) || error("elements do not belong to the same ring")

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -1079,6 +1079,13 @@ function ==(f::MPolyQuoLocalizedRingHom, g::MPolyQuoLocalizedRingHom)
   return true
 end
 
+function Base.hash(f::MPolyQuoLocalizedRingHom, h::UInt)
+  b = 0xd6d389598ad28724  % UInt
+  h = hash(domain(f), h)
+  h = hash(codomain(f), h)
+  return xor(h, b)
+end
+
 ### printing
 function Base.show(io::IO, ::MIME"text/plain", phi::MPolyQuoLocalizedRingHom)
   R = base_ring(domain(phi))

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -1083,6 +1083,9 @@ function Base.hash(f::MPolyQuoLocalizedRingHom, h::UInt)
   b = 0xd6d389598ad28724  % UInt
   h = hash(domain(f), h)
   h = hash(codomain(f), h)
+  for x in gens(base_ring(domain(f)))
+    h = hash(f(x), h)
+  end
   return xor(h, b)
 end
 

--- a/src/TropicalGeometry/semiring.jl
+++ b/src/TropicalGeometry/semiring.jl
@@ -227,7 +227,7 @@ Oscar.isone(x::TropicalSemiringElem) = !isinf(x) && iszero(data(x))
 
 ################################################################################
 #
-#  Equality
+#  Equality and hash
 #
 ################################################################################
 
@@ -235,6 +235,15 @@ function Base.:(==)(x::TropicalSemiringElem, y::TropicalSemiringElem)
   (isinf(x) && isinf(y)) && return true
   ((isinf(x) && !isinf(y)) || (!isinf(x) && isinf(y))) && return false
   return data(x) == data(y)
+end
+
+function Base.hash(x::TropicalSemiringElem, h::UInt)
+  b = 0x4df38853cc07aa27   % UInt
+  h = hash(isinf(x), h)
+  if !isinf(x)
+    h = hash(data(x), h)
+  end
+  return xor(h, b)
 end
 
 ################################################################################


### PR DESCRIPTION
This addresses parts of #2222 and resolves #1264.

Julia requires that equal elements (w.r.t. `==`) hash to the same value to make `Set`s etc. work.
For many OSCAR types (cf. #2222), there currently is a dedicated `==`, but no `hash`; thus contradicting the requirement.