### PR TITLE
[FTheoryTools] Add literature models

### DIFF
--- a/experimental/FTheoryTools/src/LiteratureTateModels/Models/model1b.json
+++ b/experimental/FTheoryTools/src/LiteratureTateModels/Models/model1b.json
@@ -1,0 +1,124 @@
+{
+    "arxiv_data": {
+        "id": "1109.3454",
+        "doi": "10.48550/arXiv.1109.3454",
+        "version": "2",
+        "discipline": "hep-th",
+        "link": "https://arxiv.org/abs/1109.3454v2"
+    },
+    "journal_data": {
+        "doi": "10.1016/j.nuclphysb.2011.12.013",
+        "journal": "Nucl. Phys. B",
+        "volume": "858",
+        "pages": "1--47",
+        "year": "2012",
+        "link": "https://www.sciencedirect.com/science/article/pii/S0550321311007115"
+    },
+    "paper_metadata": {
+        "authors": ["Sven Krause", "Christoph Mayrhofer", "Timo Weigand"],
+        "title": "$G_4$ flux, chiral matter and singularity resolution in F-theory compactifications",
+        "description": "SU(5)xU(1) restricted Tate model",
+        "buzzwords": ["GUT model", "Tate", "U(1)", "SU(5)"]
+    },
+    "model_location": {
+        "section": "3",
+        "equation": "3.1",
+        "page": "10"
+    },
+    "model_data": {
+        "type": "tate",
+        "description": "SU(5)xU(1) restricted Tate model",
+        "gauge_algebra": ["su(5)", "u(1)"],
+        "base_dim": 3,
+        "base_coordinates": ["a1", "a21", "a32", "a43", "w"],
+        "a1": "a1",
+        "a2": "a21*w",
+        "a3": "a32*w^2",
+        "a4": "a43*w^3",
+        "a6": "0",
+        "generating_sections": [[["0", "0", "1"]]],
+        "resolutions": [
+            [
+                [
+                    ["x", "y", "w"],
+                    ["y", "e1"],
+                    ["x", "e4"],
+                    ["y", "e2"],
+                    ["x", "y"]
+                ],
+                ["e1", "e4", "e2", "e3", "s"]
+            ]
+        ],
+        "resolution_zero_section": [
+            [
+                ["1", "1", "0"],
+                ["1", "1", "w"],
+                ["1", "1"],
+                ["1", "1"],
+                ["1", "1"],
+                ["1", "1"]
+            ]
+        ],
+        "resolution_generating_sections": [
+            [
+                [
+                    ["0", "0", "1"],
+                    ["0", "0", "1"],
+                    ["0", "1"],
+                    ["0", "1"],
+                    ["0", "1"],
+                    ["a32", "-a43"]
+                ]
+            ]
+        ],
+        "weighted_resolutions": [
+            [
+                [
+                    [
+                        ["x", "y", "w"],
+                        [1, 1, 1]
+                    ],
+                    [
+                        ["x", "y", "w"],
+                        [1, 2, 1]
+                    ],
+                    [
+                        ["x", "y", "w"],
+                        [2, 2, 1]
+                    ],
+                    [
+                        ["x", "y", "w"],
+                        [2, 3, 1]
+                    ],
+                    [
+                        ["x", "y"],
+                        [1, 1]
+                    ]
+                ],
+                ["e1", "e4", "e2", "e3", "s"]
+            ]
+        ],
+        "weighted_resolution_zero_section": [
+            [
+                ["1", "1", "0"],
+                ["1", "1", "w"],
+                ["1", "1", "w"],
+                ["1", "1", "w"],
+                ["1", "1", "w"],
+                ["1", "1"]
+            ]
+        ],
+        "weighted_resolution_generating_sections": [
+            [
+                [
+                    ["0", "0", "1"],
+                    ["0", "0", "1"],
+                    ["0", "0", "1"],
+                    ["0", "0", "1"],
+                    ["0", "0", "1"],
+                    ["a32", "-a43"]
+                ]
+            ]
+        ]
+    }
+}

--- a/experimental/FTheoryTools/src/LiteratureTateModels/Models/model2b.json
+++ b/experimental/FTheoryTools/src/LiteratureTateModels/Models/model2b.json
@@ -1,0 +1,74 @@
+{
+    "arxiv_data": {
+        "id": "1212.2949",
+        "doi": "10.48550/arXiv.1212.2949",
+        "version": "2",
+        "discipline": "hep-th",
+        "link": "https://arxiv.org/abs/1212.2949v2"
+    },
+    "journal_data": {
+        "doi": "10.1007/JHEP04(2013)061",
+        "report_numbers": ["KCL-MTH-12-14"],
+        "journal": "JHEP",
+        "volume": "04",
+        "pages": "061",
+        "year": "2013",
+        "link": "https://www.sciencedirect.com/science/article/pii/S0550321311007115"
+    },
+    "paper_metadata": {
+        "authors": ["Craig Lawrie", "Sakura Schäfer-Nameki"],
+        "title": "The Tate Form on Steroids: Resolution and Higher Codimension Fibers",
+        "description": "Systematic classification of ADE Tate models and their resolutions",
+        "buzzwords": ["Tate", "classification", "resolution"]
+    },
+    "model_location": {
+        "section": "3.1",
+        "equation": "3.2",
+        "page": "19"
+    },
+    "model_parameters": ["k"],
+    "model_data": {
+        "type": "tate",
+        "description": "SU(2k+1) Tate model",
+        "gauge_algebra": ["su(2k+1)"],
+        "base_dim": 3,
+        "base_coordinates": ["b1", "b2", "b3", "b4", "b6", "ζ0"],
+        "a1": "b1",
+        "a2": "b2*ζ0",
+        "a3": "b3*ζ0^k",
+        "a4": "b4*ζ0^(k + 1)",
+        "a6": "b6*ζ0^(2*k + 1)",
+        "resolutions": [
+            [
+                [
+                    [
+                        ["x", "y", ["ζ", "i"]],
+                        ["index", 0, "k - 1"]
+                    ],
+                    [
+                        ["y", ["ζ", "index"]],
+                        ["index", 1, "k"]
+                    ]
+                ],
+                [
+                    [
+                        ["ζ", "index"],
+                        ["index", 1, "k"]
+                    ],
+                    [
+                        ["δ", "index"],
+                        ["index", 1, "k"]
+                    ]
+                ]
+            ]
+        ]
+    },
+    "related_models": [
+        "model3.json",
+        "model4.json",
+        "model5.json",
+        "model6.json",
+        "model7.json",
+        "model8.json"
+    ]
+}

--- a/experimental/FTheoryTools/src/LiteratureTateModels/Models/model3.json
+++ b/experimental/FTheoryTools/src/LiteratureTateModels/Models/model3.json
@@ -1,0 +1,74 @@
+{
+    "arxiv_data": {
+        "id": "1212.2949",
+        "doi": "10.48550/arXiv.1212.2949",
+        "version": "2",
+        "discipline": "hep-th",
+        "link": "https://arxiv.org/abs/1212.2949v2"
+    },
+    "journal_data": {
+        "doi": "10.1007/JHEP04(2013)061",
+        "report_numbers": ["KCL-MTH-12-14"],
+        "journal": "JHEP",
+        "volume": "04",
+        "pages": "061",
+        "year": "2013",
+        "link": "https://www.sciencedirect.com/science/article/pii/S0550321311007115"
+    },
+    "paper_metadata": {
+        "authors": ["Craig Lawrie", "Sakura Schäfer-Nameki"],
+        "title": "The Tate Form on Steroids: Resolution and Higher Codimension Fibers",
+        "description": "Systematic classification of ADE Tate models and their resolutions",
+        "buzzwords": ["Tate", "classification", "resolution"]
+    },
+    "model_location": {
+        "section": "3.2",
+        "equation": "3.42",
+        "page": "31"
+    },
+    "model_parameters": ["k"],
+    "model_data": {
+        "type": "tate",
+        "description": "SU(2k) Tate model",
+        "gauge_algebra": ["su(2k)"],
+        "base_dim": 3,
+        "base_coordinates": ["b1", "b2", "b3", "b4", "b6", "z0"],
+        "a1": "b1",
+        "a2": "b2*ζ0",
+        "a3": "b3*ζ0^k",
+        "a4": "b4*ζ0^k",
+        "a6": "b6*ζ0^(2*k)",
+        "resolutions": [
+            [
+                [
+                    [
+                        ["x", "y", ["ζ", "index"]],
+                        ["index", 0, "k - 1"]
+                    ],
+                    [
+                        ["y", ["ζ", "index"]],
+                        ["index", 1, "k - 1"]
+                    ]
+                ],
+                [
+                    [
+                        ["ζ", "index"],
+                        ["index", 1, "k"]
+                    ],
+                    [
+                        ["δ", "index"],
+                        ["index", 1, "k - 1"]
+                    ]
+                ]
+            ]
+        ]
+    },
+    "related_models": [
+        "model2.json",
+        "model4.json",
+        "model5.json",
+        "model6.json",
+        "model7.json",
+        "model8.json"
+    ]
+}

--- a/experimental/FTheoryTools/src/LiteratureTateModels/Models/model4.json
+++ b/experimental/FTheoryTools/src/LiteratureTateModels/Models/model4.json
@@ -1,0 +1,96 @@
+{
+    "arxiv_data": {
+        "id": "1212.2949",
+        "doi": "10.48550/arXiv.1212.2949",
+        "version": "2",
+        "discipline": "hep-th",
+        "link": "https://arxiv.org/abs/1212.2949v2"
+    },
+    "journal_data": {
+        "doi": "10.1007/JHEP04(2013)061",
+        "report_numbers": ["KCL-MTH-12-14"],
+        "journal": "JHEP",
+        "volume": "04",
+        "pages": "061",
+        "year": "2013",
+        "link": "https://www.sciencedirect.com/science/article/pii/S0550321311007115"
+    },
+    "paper_metadata": {
+        "authors": ["Craig Lawrie", "Sakura Schäfer-Nameki"],
+        "title": "The Tate Form on Steroids: Resolution and Higher Codimension Fibers",
+        "description": "Systematic classification of ADE Tate models and their resolutions",
+        "buzzwords": ["Tate", "classification", "resolution"]
+    },
+    "model_location": {
+        "section": "4.1",
+        "equation": "4.1",
+        "page": "37"
+    },
+    "model_parameters": ["k"],
+    "model_data": {
+        "type": "tate",
+        "description": "SO(4k+2) Tate model",
+        "gauge_algebra": ["so(4k+2)"],
+        "base_dim": 3,
+        "base_coordinates": ["b1", "b2", "b3", "b4", "b6", "ζ0"],
+        "a1": "b1*ζ0",
+        "a2": "b2*ζ0",
+        "a3": "b3*ζ0^k",
+        "a4": "b4*ζ0^(k + 1)",
+        "a6": "b6*ζ0^(2*k + 1)",
+        "resolutions": [
+            [
+                [
+                    [
+                        ["x", "y", ["ζ", "index"]],
+                        ["index", 0, "k - 1"]
+                    ],
+                    [
+                        ["y", ["ζ", "index"]],
+                        ["index", 1, "k"]
+                    ],
+                    [
+                        [
+                            ["ζ", "index"],
+                            ["δ", "index"]
+                        ],
+                        ["index", 1, "k - 1"]
+                    ],
+                    [
+                        [
+                            ["ζ", "i + 1"],
+                            ["δ", "index"]
+                        ],
+                        ["index", 1, "k - 1"]
+                    ]
+                ],
+                [
+                    [
+                        ["ζ", "index"],
+                        ["index", 1, "k"]
+                    ],
+                    [
+                        ["δ", "index"],
+                        ["index", 1, "k"]
+                    ],
+                    [
+                        ["κ", "index"],
+                        ["index", 1, "k"]
+                    ],
+                    [
+                        ["ϵ", "index"],
+                        ["index", 1, "k"]
+                    ]
+                ]
+            ]
+        ]
+    },
+    "related_models": [
+        "model2.json",
+        "model3.json",
+        "model5.json",
+        "model6.json",
+        "model7.json",
+        "model8.json"
+    ]
+}

--- a/experimental/FTheoryTools/src/LiteratureTateModels/Models/model5.json
+++ b/experimental/FTheoryTools/src/LiteratureTateModels/Models/model5.json
@@ -1,0 +1,98 @@
+{
+    "arxiv_data": {
+        "id": "1212.2949",
+        "doi": "10.48550/arXiv.1212.2949",
+        "version": "2",
+        "discipline": "hep-th",
+        "link": "https://arxiv.org/abs/1212.2949v2"
+    },
+    "journal_data": {
+        "doi": "10.1007/JHEP04(2013)061",
+        "report_numbers": ["KCL-MTH-12-14"],
+        "journal": "JHEP",
+        "volume": "04",
+        "pages": "061",
+        "year": "2013",
+        "link": "https://www.sciencedirect.com/science/article/pii/S0550321311007115"
+    },
+    "paper_metadata": {
+        "authors": ["Craig Lawrie", "Sakura Schäfer-Nameki"],
+        "title": "The Tate Form on Steroids: Resolution and Higher Codimension Fibers",
+        "description": "Systematic classification of ADE Tate models and their resolutions",
+        "buzzwords": ["Tate", "classification", "resolution"]
+    },
+    "model_location": {
+        "section": "4.2",
+        "equation": "4.23",
+        "page": "44"
+    },
+    "model_parameters": ["k"],
+    "model_data": {
+        "type": "tate",
+        "description": "SO(4k+4)xU(1) Tate model",
+        "comment": "The paper only states that this is an SO(4k+4) model, but setting a6 = 0 also introduces an additional generating section, so there is additionally a U(1) factor, which may not have been relevant for the authors' purposes.",
+        "gauge_algebra": ["so(4k+4)", "u(1)"],
+        "base_dim": 3,
+        "base_coordinates": ["b1", "b2", "b3", "b4", "ζ0"],
+        "a1": "b1*ζ0",
+        "a2": "b2*ζ0",
+        "a3": "b3*ζ0^(k + 1)",
+        "a4": "b4*ζ0^(k + 1)",
+        "a6": "0",
+        "generating_sections": [["0", "0", "1"]],
+        "resolutions": [
+            [
+                [
+                    [
+                        ["x", "y", ["ζ", "index"]],
+                        ["index", 0, "k"]
+                    ],
+                    [
+                        ["y", ["ζ", "index"]],
+                        ["index", 1, "k"]
+                    ],
+                    [
+                        [
+                            ["ζ", "index"],
+                            ["δ", "index"]
+                        ],
+                        ["index", 1, "k"]
+                    ],
+                    [
+                        [
+                            ["ζ", "i + 1"],
+                            ["δ", "index"]
+                        ],
+                        ["index", 1, "k - 1"]
+                    ]
+                ],
+                [
+                    [
+                        ["ζ", "index"],
+                        ["index", 1, "k + 1"]
+                    ],
+                    [
+                        ["δ", "index"],
+                        ["index", 1, "k"]
+                    ],
+                    [
+                        ["κ", "index"],
+                        ["index", 1, "k"]
+                    ],
+                    [
+                        ["ϵ", "index"],
+                        ["index", 1, "k"]
+                    ]
+                ]
+            ]
+        ]
+    },
+    "related_models": [
+        "model2.json",
+        "model3.json",
+        "model4.json",
+        "model6.json",
+        "model7.json",
+        "model8.json"
+    ]
+}

--- a/experimental/FTheoryTools/src/LiteratureTateModels/Models/model6.json
+++ b/experimental/FTheoryTools/src/LiteratureTateModels/Models/model6.json
@@ -1,0 +1,64 @@
+{
+    "arxiv_data": {
+        "id": "1212.2949",
+        "doi": "10.48550/arXiv.1212.2949",
+        "version": "2",
+        "discipline": "hep-th",
+        "link": "https://arxiv.org/abs/1212.2949v2"
+    },
+    "journal_data": {
+        "doi": "10.1007/JHEP04(2013)061",
+        "report_numbers": ["KCL-MTH-12-14"],
+        "journal": "JHEP",
+        "volume": "04",
+        "pages": "061",
+        "year": "2013",
+        "link": "https://www.sciencedirect.com/science/article/pii/S0550321311007115"
+    },
+    "paper_metadata": {
+        "authors": ["Craig Lawrie", "Sakura Schäfer-Nameki"],
+        "title": "The Tate Form on Steroids: Resolution and Higher Codimension Fibers",
+        "description": "Systematic classification of ADE Tate models and their resolutions",
+        "buzzwords": ["Tate", "classification", "resolution"]
+    },
+    "model_location": {
+        "section": "5.1",
+        "equation": "5.1",
+        "page": "49"
+    },
+    "model_data": {
+        "type": "tate",
+        "description": "E6 Tate model",
+        "gauge_algebra": ["e6"],
+        "base_dim": 3,
+        "base_coordinates": ["b1", "b2", "b3", "b4", "b6", "ζ0"],
+        "a1": "b1*ζ0",
+        "a2": "b2*ζ0^2",
+        "a3": "b3*ζ0^2",
+        "a4": "b4*ζ0^3",
+        "a6": "b6*ζ0^5",
+        "resolutions": [
+            [
+                [
+                    ["x", "y", "ζ0"],
+                    ["x", "y", "ζ1"],
+                    ["y", "ζ1"],
+                    ["y", "ζ2"],
+                    ["δ1", "ζ1"],
+                    ["δ1", "ζ2"],
+                    ["δ1", "δ2"],
+                    ["δ1", "ϵ1"]
+                ],
+                ["ζ1", "ζ2", "δ1", "δ2", "κ1", "ϵ1", "ϵ2", "ϵ3"]
+            ]
+        ]
+    },
+    "related_models": [
+        "model2.json",
+        "model3.json",
+        "model4.json",
+        "model5.json",
+        "model7.json",
+        "model8.json"
+    ]
+}

--- a/experimental/FTheoryTools/src/LiteratureTateModels/Models/model7.json
+++ b/experimental/FTheoryTools/src/LiteratureTateModels/Models/model7.json
@@ -1,0 +1,66 @@
+{
+    "arxiv_data": {
+        "id": "1212.2949",
+        "doi": "10.48550/arXiv.1212.2949",
+        "version": "2",
+        "discipline": "hep-th",
+        "link": "https://arxiv.org/abs/1212.2949v2"
+    },
+    "journal_data": {
+        "doi": "10.1007/JHEP04(2013)061",
+        "report_numbers": ["KCL-MTH-12-14"],
+        "journal": "JHEP",
+        "volume": "04",
+        "pages": "061",
+        "year": "2013",
+        "link": "https://www.sciencedirect.com/science/article/pii/S0550321311007115"
+    },
+    "paper_metadata": {
+        "authors": ["Craig Lawrie", "Sakura Schäfer-Nameki"],
+        "title": "The Tate Form on Steroids: Resolution and Higher Codimension Fibers",
+        "description": "Systematic classification of ADE Tate models and their resolutions",
+        "buzzwords": ["Tate", "classification", "resolution"]
+    },
+    "model_location": {
+        "section": "5.1",
+        "equation": "5.1",
+        "page": "49"
+    },
+    "model_data": {
+        "type": "tate",
+        "description": "E7 Tate model",
+        "gauge_algebra": ["e7"],
+        "base_dim": 3,
+        "base_coordinates": ["b1", "b2", "b3", "b4", "b6", "ζ0"],
+        "a1": "b1*ζ0",
+        "a2": "b2*ζ0^2",
+        "a3": "b3*ζ0^3",
+        "a4": "b4*ζ0^3",
+        "a6": "b6*ζ0^5",
+        "resolutions": [
+            [
+                [
+                    ["x", "y", "ζ0"],
+                    ["x", "y", "ζ1"],
+                    ["y", "ζ1"],
+                    ["y", "ζ2"],
+                    ["ζ2", "δ1"],
+                    ["ζ1", "δ1"],
+                    ["ζ2", "δ2"],
+                    ["δ1", "δ2"],
+                    ["δ2", "ϵ1"],
+                    ["ϵ1", "ϵ4"]
+                ],
+                ["ζ1", "ζ2", "δ1", "δ2", "ϵ1", "ϵ2", "ϵ3", "ϵ4", "ϵ5", "ϵ6"]
+            ]
+        ]
+    },
+    "related_models": [
+        "model2.json",
+        "model3.json",
+        "model4.json",
+        "model5.json",
+        "model6.json",
+        "model8.json"
+    ]
+}

--- a/experimental/FTheoryTools/src/LiteratureTateModels/Models/model8.json
+++ b/experimental/FTheoryTools/src/LiteratureTateModels/Models/model8.json
@@ -1,0 +1,85 @@
+{
+    "arxiv_data": {
+        "id": "1212.2949",
+        "doi": "10.48550/arXiv.1212.2949",
+        "version": "2",
+        "discipline": "hep-th",
+        "link": "https://arxiv.org/abs/1212.2949v2"
+    },
+    "journal_data": {
+        "doi": "10.1007/JHEP04(2013)061",
+        "report_numbers": ["KCL-MTH-12-14"],
+        "journal": "JHEP",
+        "volume": "04",
+        "pages": "061",
+        "year": "2013",
+        "link": "https://www.sciencedirect.com/science/article/pii/S0550321311007115"
+    },
+    "paper_metadata": {
+        "authors": ["Craig Lawrie", "Sakura Schäfer-Nameki"],
+        "title": "The Tate Form on Steroids: Resolution and Higher Codimension Fibers",
+        "description": "Systematic classification of ADE Tate models and their resolutions",
+        "buzzwords": ["Tate", "classification", "resolution"]
+    },
+    "model_location": {
+        "section": "5.1",
+        "equation": "5.1",
+        "page": "49"
+    },
+    "model_data": {
+        "type": "tate",
+        "description": "E8 Tate model",
+        "gauge_algebra": ["e8"],
+        "base_dim": 3,
+        "base_coordinates": ["b1", "b2", "b3", "b4", "b6", "ζ0"],
+        "a1": "b1*ζ0",
+        "a2": "b2*ζ0^2",
+        "a3": "b3*ζ0^3",
+        "a4": "b4*ζ0^4",
+        "a6": "b6*ζ0^5",
+        "resolutions": [
+            [
+                [
+                    ["x", "y", "ζ0"],
+                    ["x", "y", "ζ1"],
+                    ["y", "ζ1"],
+                    ["y", "ζ2"],
+                    ["ζ2", "δ1"],
+                    ["ζ1", "δ1"],
+                    ["ζ2", "δ2"],
+                    ["δ1", "δ2"],
+                    ["δ2", "ϵ1"],
+                    ["ϵ1", "ϵ4"],
+                    ["δ2", "ϵ4"],
+                    ["δ2", "ϵ5"],
+                    ["ϵ4", "ϵ5"],
+                    ["ϵ5", "ϵ7"]
+                ],
+                [
+                    "ζ1",
+                    "ζ2",
+                    "δ1",
+                    "δ2",
+                    "ϵ1",
+                    "ϵ2",
+                    "ϵ3",
+                    "ϵ4",
+                    "ϵ5",
+                    "ϵ6",
+                    "ϵ7",
+                    "ϵ8",
+                    "ϵ9",
+                    "ϵ10"
+                ]
+            ]
+        ]
+    },
+    "related_models": [
+        "model2.json",
+        "model3.json",
+        "model4.json",
+        "model5.json",
+        "model6.json",
+        "model7.json"
+    ]
+}

--- a/experimental/FTheoryTools/src/LiteratureTateModels/Models/model9.json
+++ b/experimental/FTheoryTools/src/LiteratureTateModels/Models/model9.json
@@ -1,0 +1,249 @@
+{
+    "arxiv_data": {
+        "id": "1507.05954",
+        "doi": "10.48550/arXiv.1507.05954",
+        "version": "2",
+        "discipline": "hep-th",
+        "link": "https://arxiv.org/abs/2507.05954v2"
+    },
+    "journal_data": {
+        "doi": "10.1007/JHEP11(2015)204",
+        "report_numbers": ["UPR-1274-T, CERN-PH-TH-2015-157, MIT-CTP-4678"],
+        "journal": "JHEP",
+        "volume": "11",
+        "pages": "204",
+        "year": "2015",
+        "link": "https://link.springer.com/article/10.1007/JHEP11(2015)204"
+    },
+    "paper_metadata": {
+        "authors": [
+            "Mirjam Cvetič",
+            "Denis Klevers",
+            "Hernan Piragua",
+            "Washington Taylor"
+        ],
+        "title": "General U(1)×U(1) F-theory compactifications and beyond: geometry of unHiggsings and novel matter structure",
+        "description": "General construction of U(1)xU(1) model",
+        "buzzwords": ["U(1)", "Mordell–Weil", "rational sections"]
+    },
+    "model_location": {
+        "section": "A",
+        "equation": "A.1",
+        "page": "71"
+    },
+    "model_data": {
+        "type": "hypersurface",
+        "description": "U(1)xU(1) hypersurface model",
+        "gauge_algebra": ["u1", "u1"],
+        "base_dim": 2,
+        "base_coordinates": [
+            "s1",
+            "s2",
+            "s3",
+            "s5",
+            "s6",
+            "s8",
+            "a1",
+            "a2",
+            "a3",
+            "b1",
+            "b2",
+            "b3"
+        ],
+        "fiber_coordinates": ["u", "v", "w"],
+        "zero_section": ["0", "-b1", "a1"],
+        "generating_sections": [
+            ["0", "-b2", "a2"],
+            ["0", "-b3", "a3"]
+        ],
+        "hypersurface_equation": "u*(s1*u^2 + s2*u*v + s3*v^2 + s5*u*w + s6*v*w + s8*w^2) + (a1*v + b1*w) * (a2*v + b2*w) * (a3*v + b3*w)",
+        "resolutions": [
+            [
+                [
+                    ["u", "a1*v + b1*w"],
+                    [
+                        "s1*u^2 + s2*u*v + s3*v^2 + s5*u*w + s6*v*w + s8*w^2",
+                        "a2*v + b2*w"
+                    ]
+                ],
+                ["e1", "e2"]
+            ],
+            [
+                [
+                    ["u", "a1*v + b1*w"],
+                    [
+                        "s1*u^2 + s2*u*v + s3*v^2 + s5*u*w + s6*v*w + s8*w^2",
+                        "a3*v + b3*w"
+                    ]
+                ],
+                ["e1", "e2"]
+            ],
+            [
+                [
+                    ["u", "a2*v + b2*w"],
+                    [
+                        "s1*u^2 + s2*u*v + s3*v^2 + s5*u*w + s6*v*w + s8*w^2",
+                        "a1*v + b1*w"
+                    ]
+                ],
+                ["e1", "e2"]
+            ],
+            [
+                [
+                    ["u", "a2*v + b2*w"],
+                    [
+                        "s1*u^2 + s2*u*v + s3*v^2 + s5*u*w + s6*v*w + s8*w^2",
+                        "a3*v + b3*w"
+                    ]
+                ],
+                ["e1", "e2"]
+            ],
+            [
+                [
+                    ["u", "a3*v + b3*w"],
+                    [
+                        "s1*u^2 + s2*u*v + s3*v^2 + s5*u*w + s6*v*w + s8*w^2",
+                        "a1*v + b1*w"
+                    ]
+                ],
+                ["e1", "e2"]
+            ],
+            [
+                [
+                    ["u", "a3*v + b3*w"],
+                    [
+                        "s1*u^2 + s2*u*v + s3*v^2 + s5*u*w + s6*v*w + s8*w^2",
+                        "a2*v + b2*w"
+                    ]
+                ],
+                ["e1", "e2"]
+            ]
+        ],
+        "resolution_zero_section": [
+            [
+                ["0", "-b1", "a1"],
+                [
+                    "s3*b1^2 - s6*a1*b1 + s8*a1^2",
+                    "(a3*b1 - b3*a1)*(a1 b2 - b1 a2)"
+                ],
+                ["(a2 b1 - b2 a1)", "s3*b1^2 - s6*a1*b1 + s8*a1^2"]
+            ],
+            [
+                ["0", "-b1", "a1"],
+                [
+                    "s3*b1^2 - s6*a1*b1 + s8*a1^2",
+                    "(a2*b1 - b2*a1)*(a1 b3 - b1 a3)"
+                ],
+                ["(a3 b1 - b3 a1)", "s3*b1^2 - s6*a1*b1 + s8*a1^2"]
+            ],
+            [
+                ["0", "-b1", "a1"],
+                ["1", "0"],
+                ["0", "1"]
+            ],
+            [
+                ["0", "-b1", "a1"],
+                ["1", "0"],
+                ["(a3 b1 - b3 a1)", "s3*b1^2 - s6*a1*b1 + s8*a1^2"]
+            ],
+            [
+                ["0", "-b1", "a1"],
+                ["1", "0"],
+                ["0", "1"]
+            ],
+            [
+                ["0", "-b1", "a1"],
+                ["1", "0"],
+                ["(a2 b1 - b2 a1)", "s3*b1^2 - s6*a1*b1 + s8*a1^2"]
+            ]
+        ],
+        "resolution_generating_sections": [
+            [
+                [
+                    ["0", "-b2", "a2"],
+                    ["1", "0"],
+                    ["0", "1"]
+                ],
+                [
+                    ["0", "-b3", "a3"],
+                    ["1", "0"],
+                    ["(a2 b3 - b2 a3)", "s3*b3^2 - s6*a3*b3 + s8*a3^2"]
+                ]
+            ],
+            [
+                [
+                    ["0", "-b2", "a2"],
+                    ["1", "0"],
+                    ["(a3 b2 - b3 a2)", "s3*b2^2 - s6*a2*b2 + s8*a2^2"]
+                ],
+                [
+                    ["0", "-b3", "a3"],
+                    ["1", "0"],
+                    ["0", "1"]
+                ]
+            ],
+            [
+                [
+                    ["0", "-b2", "a2"],
+                    [
+                        "s3*b2^2 - s6*a2*b2 + s8*a2^2",
+                        "(a3*b2 - b3*a2)*(a2 b1 - b2 a1)"
+                    ],
+                    ["(a1 b2 - b1 a2)", "s3*b2^2 - s6*a2*b2 + s8*a2^2"]
+                ],
+                [
+                    ["0", "-b3", "a3"],
+                    ["1", "0"],
+                    ["(a1 b3 - b1 a3)", "s3*b3^2 - s6*a3*b3 + s8*a3^2"]
+                ]
+            ],
+            [
+                [
+                    ["0", "-b2", "a2"],
+                    [
+                        "s3*b2^2 - s6*a2*b2 + s8*a2^2",
+                        "(a1*b2 - b1*a2)*(a2 b3 - b2 a3)"
+                    ],
+                    ["(a3 b2 - b3 a2)", "s3*b2^2 - s6*a2*b2 + s8*a2^2"]
+                ],
+                [
+                    ["0", "-b3", "a3"],
+                    ["1", "0"],
+                    ["0", "1"]
+                ]
+            ],
+            [
+                [
+                    ["0", "-b2", "a2"],
+                    ["1", "0"],
+                    ["(a1 b2 - b1 a2)", "s3*b2^2 - s6*a2*b2 + s8*a2^2"]
+                ],
+                [
+                    ["0", "-b3", "a3"],
+                    [
+                        "s3*b3^2 - s6*a3*b3 + s8*a3^2",
+                        "(a2*b3 - b2*a3)*(a3 b1 - b3 a1)"
+                    ],
+                    ["(a1 b3 - b1 a3)", "s3*b3^2 - s6*a3*b3 + s8*a3^2"]
+                ]
+            ],
+            [
+                [
+                    ["0", "-b2", "a2"],
+                    ["1", "0"],
+                    ["0", "1"]
+                ],
+                [
+                    ["0", "-b3", "a3"],
+                    [
+                        "s3*b3^2 - s6*a3*b3 + s8*a3^2",
+                        "(a1*b3 - b1*a3)*(a3 b2 - b3 a2)"
+                    ],
+                    ["(a2 b3 - b2 a3)", "s3*b3^2 - s6*a3*b3 + s8*a3^2"]
+                ]
+            ]
+        ]
+    },
+    "associated_models": ["model10.json"],
+    "related_models": [""]
+}

--- a/experimental/FTheoryTools/src/LiteratureTateModels/Models/model_reference.json
+++ b/experimental/FTheoryTools/src/LiteratureTateModels/Models/model_reference.json
@@ -1,0 +1,59 @@
+{
+    "arxiv_data": {
+        "id": "",
+        "doi": "",
+        "version": "",
+        "discipline": "",
+        "link": ""
+    },
+    "journal_data": {
+        "doi": "",
+        "report_numbers": [""],
+        "journal": "",
+        "volume": "",
+        "pages": "",
+        "year": "",
+        "link": ""
+    },
+    "paper_metadata": {
+        "authors": [""],
+        "title": "",
+        "description": "",
+        "buzzwords": [""]
+    },
+    "model_location": {
+        "section": "",
+        "equation": "",
+        "page": ""
+    },
+    "model_parameters": [""],
+    "model_data": {
+        "type": "",
+        "description": "",
+        "comment": "",
+        "gauge_algebra": [""],
+        "global_gauge_quotients": [""],
+        "discrete_factors": [""],
+        "base_dim": 3,
+        "base_coordinates": [""],
+        "fiber_coordinates": [""],
+        "a1": "",
+        "a2": "",
+        "a3": "",
+        "a4": "",
+        "a6": "",
+        "f": "",
+        "g": "",
+        "zero_section": [["", "", ""]],
+        "generating_sections": [[["", "", ""]]],
+        "hypersurface_equation": "",
+        "resolutions": [[[[""]], [""]]],
+        "resolution_zero_section": [[["", "", ""]]],
+        "resolution_generating_sections": [[[["", "", ""]]]],
+        "weighted_resolutions": [[[[[""], []]], [""]]],
+        "weighted_resolution_zero_section": [[["", "", ""]]],
+        "weighted_resolution_generating_sections": [[[["", "", ""]]]]
+    },
+    "associated_models": [""],
+    "related_models": [""]
+}


### PR DESCRIPTION
Add nine literature models, including many additional fields beyond those in the previous models.

Models 1b and 2b will ultimately replace 1 and 2, but the latter are kept for now so that tests will pass while we are still updating the code to catch up to the new format.

@HereAround, @lkastner