### PR TITLE
[FTheoryTools] Hypersurface model

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -999,6 +999,21 @@
   url           = {https://doi.org/10.1007/978-3-030-52200-1_37}
 }
 
+@Article{KM-POPR15,
+  author        = {Klevers, Denis and Mayorga Pena, Damian Kaloni and Oehlmann, Paul-Konstantin and Piragua, Hernan and
+                  Reuter, Jonas},
+  title         = {F-Theory on all Toric Hypersurface Fibrations and its Higgs Branches},
+  journal       = {JHEP},
+  volume        = {01},
+  pages         = {142},
+  year          = {2015},
+  doi           = {10.1007/JHEP01(2015)142},
+  eprint        = {1408.4808},
+  archiveprefix = {arXiv},
+  primaryclass  = {hep-th},
+  reportnumber  = {UPR-1264-T, CERN-PH-TH-2014-171, Bonn-TH-2014-13}
+}
+
 @Article{KMSS11,
   author        = {Katz, Sheldon and Morrison, David R. and Schafer-Nameki, Sakura and Sully, James},
   title         = {Tate's algorithm and F-theory},

--- a/experimental/FTheoryTools/docs/doc.main
+++ b/experimental/FTheoryTools/docs/doc.main
@@ -3,5 +3,6 @@
       "introduction.md",
       "weierstrass.md",
       "tate.md",
+      "hypersurface.md",
    ],
 ]

--- a/experimental/FTheoryTools/docs/src/hypersurface.md
+++ b/experimental/FTheoryTools/docs/src/hypersurface.md
@@ -82,7 +82,11 @@ This functionality does not yet exist.
 
 ### Base space not specified
 
-This functionality does not yet exist.
+This method constructs a hypersurface model over a base space, where
+this base space is not (fully) specified. We currently provide the following constructors:
+```@docs
+hypersurface_model(auxiliary_base_vars::Vector{String}, auxiliary_base_grading::Matrix{Int64}, d::Int, fiber_ambient_space::NormalToricVariety, D1::Vector{Int64}, D2::Vector{Int64}, p::MPolyRingElem)
+```
 
 ### Standard constructions
 

--- a/experimental/FTheoryTools/docs/src/hypersurface.md
+++ b/experimental/FTheoryTools/docs/src/hypersurface.md
@@ -1,0 +1,131 @@
+```@meta
+CurrentModule = Oscar
+```
+
+# Hypersurface models
+
+## Introduction
+
+A hypersurface model describes a particular form of an elliptic fibration.
+For now, we consider such models in toric settings only, that is we restrict
+to a toric base space ``B`` and assume that the generic fiber is a
+hypersurface in a 2-dimensional toric fiber ambient space ``F``.
+
+In addition, we shall assume that the first two homogeneous coordinates of
+``F`` transform in the divisor classes ``D_1`` and ``D_2`` over the base ``B``
+of the elliptic fibration. The remaining coordinates of ``F`` are assumed to
+transform in the trivial bundle over ``B``. See [KM-POPR15](@cite) for more details.
+
+Given this set of information, it is possible to compute a toric ambient space ``A``
+for the elliptic fibration. The elliptic fibration is then a hypersurface in this toric
+space ``A``. Furthermore, since we assume that this fibration is Calabi-Yau,
+it is clear that the hypersurface equation is a (potentially very special) section
+of the ``\overline{K}_A``. This hypersurface equation completes the information
+required about a hypersurface model.
+
+
+## Constructors
+
+We aim to provide support for hypersurface models over the following bases:
+* a toric variety,
+* a toric scheme,
+* a (covered) scheme.
+
+[Often, one also wishes to obtain information about a hypersurface model without
+explicitly specifying the base space. Also for this application, we provide support.]
+
+Finally, we provide support for some standard constructions.
+
+Before we detail these constructors, we must comment on the constructors over toric base
+spaces. Namely, in order to construct a hypersurface model, we first have to construct
+the ambient space in question. For a toric base, one way to achieve this is by means of
+triangulations. However, this is a rather time consuming and computationally challenging
+task, which leads to a huge number of ambient spaces. Even more, typically one wishes to
+only pick one of thees many ambient spaces. For instance, a common and often appropriate
+choice is a toric ambient space which contains the toric base space in a manifest way.
+
+To circumvent this very demanding computation, our constructors operate in the opposite direction.
+That is, they begin by extracting the rays and maximal cones of the chosen toric base space.
+Subsequently, those rays and cones are extended to form one of the many toric ambient spaces.
+This proves hugely superior in performance than going through the triangulation task of enumerating
+all possible toric ambient spaces. One downside of this strategy is that the so-constructed ambient
+space need not be smooth.
+
+### A toric variety as base space
+
+We require that the provided toric base space is complete. This is a technical limitation as of now.
+The functionality of OSCAR only allows us to compute a section basis (or a finite subset thereof)
+for complete toric varieties. In the future, this could be extended.
+
+Completeness is an expensive check. Therefore, we provide an optional argument which
+ one can use to disable this check if desired. To this end, one passes the optional argument
+ `completeness_check = false` as last argument to the constructor. The following examples
+ demonstrate this:
+```@docs
+hypersurface_model(base::AbstractNormalToricVariety; completeness_check::Bool = true)
+hypersurface_model(base::AbstractNormalToricVariety, fiber_ambient_space::AbstractNormalToricVariety, D1::ToricDivisorClass, D2::ToricDivisorClass; completeness_check::Bool = true)
+```
+
+### A toric scheme as base space
+
+For the same reasons as above, the toric base must be complete. Similar to toric varieties as
+bases, we can use the optional argument `completeness_check = false` to switch off the
+expensive completeness check. The following examples demonstrate this:
+```@docs
+hypersurface_model(base::ToricCoveredScheme; completeness_check::Bool = true)
+hypersurface_model(base::ToricCoveredScheme, fiber_ambient_space::ToricCoveredScheme, D1::ToricDivisorClass, D2::ToricDivisorClass; completeness_check::Bool = true)
+```
+
+### A (covered) scheme as base space
+
+This functionality does not yet exist.
+
+### Base space not specified
+
+This functionality does not yet exist.
+
+### Standard constructions
+
+We provide convenient constructions of hypersurface models over
+famous base spaces. Currently, we support the following:
+```@docs
+hypersurface_model_over_projective_space(d::Int)
+hypersurface_model_over_hirzebruch_surface(r::Int)
+hypersurface_model_over_del_pezzo_surface(b::Int)
+```
+
+
+## Attributes
+
+### Basic attributes
+
+For all hypersurface models -- irrespective over whether the base is toric or not -- we support
+the following attributes:
+```@docs
+hypersurface_equation(h::HypersurfaceModel)
+```
+One can also decide to specify a custom hypersurface equation:
+```@docs
+set_hypersurface_equation(h::HypersurfaceModel, p::MPolyRingElem)
+```
+The fiber ambient space can be accessed via
+```@docs
+fiber_ambient_space(h::HypersurfaceModel)
+```
+In case the hypersurface model is constructed over a not fully specified base,
+recall that we construct an auxiliary (toric) base space as well as an
+auxiliary (toric) ambient space. The (auxiliary) base and ambient space can
+be accessed with the following functions:
+```@docs
+base_space(h::HypersurfaceModel)
+ambient_space(h::HypersurfaceModel)
+```
+The following method allows to tell if the base/ambient space is auxiliary or not:
+```@docs
+base_fully_specified(h::HypersurfaceModel)
+```
+The user can decide to get an information whenever an auxiliary base space,
+auxiliary ambient space or auxiliary hypersurface have been computed.
+To this end, one invokes `set_verbosity_level(:HypersurfaceModel, 1)`.
+More background information is available
+[here](http://www.thofma.com/Hecke.jl/dev/features/macros/).

--- a/experimental/FTheoryTools/docs/src/tate.md
+++ b/experimental/FTheoryTools/docs/src/tate.md
@@ -214,7 +214,7 @@ More background information is available
 The following attributes are currently only supported in a toric setting:
 ```@docs
 calabi_yau_hypersurface(t::GlobalTateModel)
-global_weierstrass_model(t::GlobalTateModel)
+weierstrass_model(t::GlobalTateModel)
 ```
 Note that for applications in F-theory, *singular* elliptic fibrations are key
 (cf. [Wei18](@cite) and references therein). Consequently the discriminant

--- a/experimental/FTheoryTools/docs/src/weierstrass.md
+++ b/experimental/FTheoryTools/docs/src/weierstrass.md
@@ -2,9 +2,9 @@
 CurrentModule = Oscar
 ```
 
-# Global Weierstrass models
+# Weierstrass models
 
-A global Weierstrass model describes a particular form of an elliptic fibration.
+A Weierstrass model describes a particular form of an elliptic fibration.
 We focus on an elliptic fibration over a complete base ``B``. Consider
 the weighted projective space ``\mathbb{P}^{2,3,1}`` with coordinates
 ``x, y, z``. In addition, consider
@@ -14,7 +14,7 @@ Then form a ``\mathbb{P}^{2,3,1}``-bundle over ``B`` such that
 * ``x`` transforms as a section of ``2 \overline{K}_{B}``,
 * ``y`` transforms as a section of ``3 \overline{K}_{B}``,
 * ``z`` transforms as a section of ``0 \overline{K}_{B} = \mathcal{O}_{B}``.
-In this 5-fold ambient space, a global Weierstrass model is the hypersurface defined
+In this 5-fold ambient space, a Weierstrass model is the hypersurface defined
 by the vanishing of the Weierstrass polynomial ``P_W = x^3 - y^2 + f x z^4 + g z^6``.
 
 Crucially, for non-trivial F-theory settings, the elliptic fibration in question must
@@ -48,11 +48,11 @@ This can be read-off from the Weierstrass table, which we have reproduced from
 
 ## Constructors
 
-We aim to provide support for global Weierstrass models over the following bases:
+We aim to provide support for Weierstrass models over the following bases:
 * a toric variety,
 * a toric scheme,
 * a (covered) scheme.
-Often, one also wishes to obtain information about a global Weierstrass model without
+Often, one also wishes to obtain information about a Weierstrass model without
 explicitly specifying the base space. Also for this application, we provide support.
 Finally, we provide support for some standard constructions.
 
@@ -86,8 +86,8 @@ However, completeness is an expensive check. Therefore, we provide an optional a
  `completeness_check = false` as last argument to the constructor. The following examples
  demonstrate this:
 ```@docs
-global_weierstrass_model(base::AbstractNormalToricVariety; completeness_check::Bool = true)
-global_weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::AbstractNormalToricVariety; completeness_check::Bool = true)
+weierstrass_model(base::AbstractNormalToricVariety; completeness_check::Bool = true)
+weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::AbstractNormalToricVariety; completeness_check::Bool = true)
 ```
 
 ### A toric scheme as base space
@@ -96,8 +96,8 @@ For the same reasons as above, the toric base must be complete. Similar to toric
 bases, we can use the optional argument `completeness_check = false` to switch off the
 expensive completeness check. The following examples demonstrate this:
 ```@docs
-global_weierstrass_model(base::ToricCoveredScheme; completeness_check::Bool = true)
-global_weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::ToricCoveredScheme; completeness_check::Bool = true)
+weierstrass_model(base::ToricCoveredScheme; completeness_check::Bool = true)
+weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::ToricCoveredScheme; completeness_check::Bool = true)
 ```
 
 ### A (covered) scheme as base space
@@ -106,7 +106,7 @@ This functionality does not yet exist.
 
 ### Base space not specified
 
-A global Weierstrass model can also be constructed over a base space that
+A Weierstrass model can also be constructed over a base space that
 is not fully specified. Rather, it assumes that a base space exists such that
 the Weierstrass sections ``f`` and ``g`` are well-defined, so that the
 Weierstrass model in question is well-defined.
@@ -125,17 +125,17 @@ the predictions from such an analysis are not limited to the world of toric vari
 
 For constructions along these lines, we support the following constructor:
 ```@docs
-global_weierstrass_model(weierstrass_f::MPolyRingElem, weierstrass_g::MPolyRingElem, auxiliary_base_ring::MPolyRing, d::Int)
+weierstrass_model(weierstrass_f::MPolyRingElem, weierstrass_g::MPolyRingElem, auxiliary_base_ring::MPolyRing, d::Int)
 ```
 
 ### Standard constructions
 
-We provide convenient constructions of global Weierstrass models
+We provide convenient constructions of Weierstrass models
 over famous base spaces. Currently, we support the following:
 ```@docs
-global_weierstrass_model_over_projective_space(d::Int)
-global_weierstrass_model_over_hirzebruch_surface(r::Int)
-global_weierstrass_model_over_del_pezzo_surface(b::Int)
+weierstrass_model_over_projective_space(d::Int)
+weierstrass_model_over_hirzebruch_surface(r::Int)
+weierstrass_model_over_del_pezzo_surface(b::Int)
 ```
 
 
@@ -153,29 +153,29 @@ su5_weierstrass_model_over_arbitrary_3d_base()
 
 ### Basic attributes
 
-For all global Weierstrass models -- irrespective over whether the base is toric or not -- we support
+For all Weierstrass models -- irrespective over whether the base is toric or not -- we support
 the following attributes:
 ```@docs
-weierstrass_section_f(w::GlobalWeierstrassModel)
-weierstrass_section_g(w::GlobalWeierstrassModel)
-weierstrass_polynomial(w::GlobalWeierstrassModel)
+weierstrass_section_f(w::WeierstrassModel)
+weierstrass_section_g(w::WeierstrassModel)
+weierstrass_polynomial(w::WeierstrassModel)
 ```
-In case the global Weierstrass model is constructed over a not fully specified base,
+In case the Weierstrass model is constructed over a not fully specified base,
 recall that we construct an auxiliary (toric) base space as well as an
 auxiliary (toric) ambient space. The (auxiliary) base and ambient space can
 be accessed with the following functions:
 ```@docs
-base_space(w::GlobalWeierstrassModel)
-ambient_space(w::GlobalWeierstrassModel)
-fiber_ambient_space(w::GlobalWeierstrassModel)
+base_space(w::WeierstrassModel)
+ambient_space(w::WeierstrassModel)
+fiber_ambient_space(w::WeierstrassModel)
 ```
 The following method allows to tell if the base/ambient space is auxiliary or not:
 ```@docs
-base_fully_specified(w::GlobalWeierstrassModel)
+base_fully_specified(w::WeierstrassModel)
 ```
 The user can decide to get an information whenever an auxiliary base space,
 auxiliary ambient space or auxiliary hypersurface have been computed.
-To this end, one invokes `set_verbosity_level(:GlobalWeierstrassModel, 1)`.
+To this end, one invokes `set_verbosity_level(:WeierstrassModel, 1)`.
 More background information is available
 [here](http://www.thofma.com/Hecke.jl/dev/features/macros/).
 
@@ -183,15 +183,15 @@ More background information is available
 
 The following attributes are currently only supported in a toric setting:
 ```@docs
-calabi_yau_hypersurface(w::GlobalWeierstrassModel)
+calabi_yau_hypersurface(w::WeierstrassModel)
 ```
 Note that for applications in F-theory, *singular* elliptic fibrations are key
 (cf. [Wei18](@cite) and references therein). Consequently the discriminant
 locus as well as the singular loci of the fibration in question are of ample
 importance:
 ```@docs
-discriminant(w::GlobalWeierstrassModel)
-singular_loci(w::GlobalWeierstrassModel)
+discriminant(w::WeierstrassModel)
+singular_loci(w::WeierstrassModel)
 ```
 
 ## Methods

--- a/experimental/FTheoryTools/src/FTheoryTools.jl
+++ b/experimental/FTheoryTools/src/FTheoryTools.jl
@@ -12,6 +12,11 @@ include("TateModels/properties.jl")
 include("TateModels/auxiliary.jl")
 include("TateModels/methods.jl")
 
+include("HypersurfaceModels/constructors.jl")
+include("HypersurfaceModels/attributes.jl")
+include("HypersurfaceModels/properties.jl")
+include("HypersurfaceModels/methods.jl")
+
 include("standard_constructions.jl")
 
 include("LiteratureTateModels/constructors.jl")

--- a/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
@@ -1,0 +1,82 @@
+###################################################################
+###################################################################
+# 1: Attributes that work the same tor toric and non-toric settings
+###################################################################
+###################################################################
+
+
+#####################################################
+# 1.1 Hypersurface equation
+#####################################################
+
+@doc raw"""
+    hypersurface_equation(h::HypersurfaceModel)
+
+Return the hypersurface equation.
+
+```jldoctest
+julia> h = hypersurface_model_over_projective_space(2)
+Hypersurface model over a concrete base
+
+julia> hypersurface_equation(h);
+```
+"""
+hypersurface_equation(h::HypersurfaceModel) = h.hypersurface_equation
+
+
+#####################################################
+# 1.2 Base, ambient space and fiber ambient space
+#####################################################
+
+@doc raw"""
+    base_space(h::HypersurfaceModel)
+
+Return the base space of the hypersurface model.
+
+```jldoctest
+julia> h = hypersurface_model_over_projective_space(2)
+Hypersurface model over a concrete base
+
+julia> base_space(h)
+Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0], [0, 1], [-1, -1]]
+```
+"""
+function base_space(h::HypersurfaceModel)
+  base_fully_specified(h) || @vprint :HypersurfaceModel 1 "Base space was not fully specified. Returning AUXILIARY base space.\n"
+  return h.base_space
+end
+
+
+@doc raw"""
+    ambient_space(h::HypersurfaceModel)
+
+Return the ambient space of the hypersurface model.
+
+```jldoctest
+julia> h = hypersurface_model_over_projective_space(2)
+Hypersurface model over a concrete base
+
+julia> ambient_space(h)
+Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0, 0, 3], [0, 1, 0, 0], [-1, -1, 0, 0], [0, 0, -1, 1//3], [0, 0, 1, -1//2], [0, 0, 0, 1]]
+```
+"""
+function ambient_space(h::HypersurfaceModel)
+  base_fully_specified(h) || @vprint :HypersurfaceModel 1 "Base space was not fully specified. Returning AUXILIARY ambient space.\n"
+  return h.ambient_space
+end
+
+
+@doc raw"""
+    fiber_ambient_space(HypersurfaceModel)
+
+Return the fiber ambient space of the hypersurface model.
+
+```jldoctest
+julia> h = hypersurface_model_over_projective_space(2)
+Hypersurface model over a concrete base
+
+julia> fiber_ambient_space(h)
+Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[-1, 1//3], [1, -1//2], [0, 1]]
+```
+"""
+fiber_ambient_space(h::HypersurfaceModel) = h.fiber_ambient_space

--- a/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
@@ -1,0 +1,211 @@
+################################################
+# 1: Constructors with toric variety as base
+################################################
+
+@doc raw"""
+    hypersurface_model(base::AbstractNormalToricVariety; completeness_check::Bool = true)
+
+Construct a hypersurface model. This constructor takes $\mathbb{P}^{2,3,1}$ as fiber
+ambient space with coordinates $[x:y:z]$ and ensures that $x$ transforms as
+$2 \overline{K}_{B_3}$ and $y$ as $3 \overline{K}_{B_3}$.
+
+# Examples
+```jldoctest
+julia> base = projective_space(NormalToricVariety, 2)
+Normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
+
+julia> hypersurface_model(base; completeness_check = false)
+Hypersurface model over a concrete base
+```
+"""
+function hypersurface_model(base::AbstractNormalToricVariety; completeness_check::Bool = true)
+  fiber_ambient_space = weighted_projective_space(NormalToricVariety, [2,3,1])
+  set_coordinate_names(fiber_ambient_space, ["x", "y", "z"])
+  D1 = 2 * anticanonical_divisor_class(base)
+  D2 = 3 * anticanonical_divisor_class(base)
+  return hypersurface_model(base, fiber_ambient_space, D1, D2; completeness_check = completeness_check)
+end
+
+
+@doc raw"""
+    hypersurface_model(base::AbstractNormalToricVariety, fiber_ambient_space::AbstractNormalToricVariety, D1::ToricDivisorClass, D2::ToricDivisorClass; completeness_check::Bool = true)
+
+Construct a hypersurface model, for which the user can specify a fiber ambient space
+as well as divisor classes of the toric base space, in which the first two homogeneous
+coordinates of the fiber ambient space transform.
+
+# Examples
+```jldoctest
+julia> base = projective_space(NormalToricVariety, 2)
+Normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
+
+julia> fiber_ambient_space = weighted_projective_space(NormalToricVariety, [2,3,1])
+Normal, non-affine, simplicial, projective, 2-dimensional toric variety without torusfactor
+
+julia> set_coordinate_names(fiber_ambient_space, ["x", "y", "z"])
+
+julia> D1 = 2 * anticanonical_divisor_class(base)
+Divisor class on a normal toric variety
+
+julia> D2 = 3 * anticanonical_divisor_class(base)
+Divisor class on a normal toric variety
+
+julia> hypersurface_model(base, fiber_ambient_space, D1, D2; completeness_check = false)
+Hypersurface model over a concrete base
+```
+"""
+function hypersurface_model(base::AbstractNormalToricVariety, fiber_ambient_space::AbstractNormalToricVariety, D1::ToricDivisorClass, D2::ToricDivisorClass; completeness_check::Bool = true)
+  
+  # Consistency checks
+  gens_base_names = [string(g) for g in gens(cox_ring(base))]
+  gens_fiber_names = [string(g) for g in gens(cox_ring(fiber_ambient_space))]
+  if length(findall(in(gens_base_names), gens_fiber_names)) != 0
+    @vprint :HypersurfaceModel 0 "Variable names duplicated between base and fiber coordinates.\n"
+  end
+  if completeness_check
+    @req is_complete(base) "Base space must be complete"
+  end
+  
+  # Compute an ambient space
+  ambient_space = _ambient_space(base, fiber_ambient_space, D1, D2)
+  
+  # Construct the model
+  hypersurface_equation = sum([rand(Int) * b for b in basis_of_global_sections(anticanonical_bundle(ambient_space))])
+  model = HypersurfaceModel(toric_covered_scheme(base), toric_covered_scheme(ambient_space), toric_covered_scheme(fiber_ambient_space), hypersurface_equation)
+  set_attribute!(model, :base_fully_specified, true)
+  return model
+end
+
+
+################################################
+# 2: Constructors with toric scheme as base
+################################################
+
+@doc raw"""
+    hypersurface_model(base::ToricCoveredScheme; completeness_check::Bool = true)
+
+Construct a hypersurface model. This constructor takes $\mathbb{P}^{2,3,1}$ as fiber
+ambient space with coordinates $[x:y:z]$ and ensures that $x$ transforms as
+$2 \overline{K}_{B_3}$ and $y$ as $3 \overline{K}_{B_3}$.
+
+# Examples
+```jldoctest
+julia> base = projective_space(ToricCoveredScheme, 2)
+Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0], [0, 1], [-1, -1]]
+
+julia> hypersurface_model(base; completeness_check = false)
+Hypersurface model over a concrete base
+```
+"""
+hypersurface_model(base::ToricCoveredScheme; completeness_check::Bool = true) = hypersurface_model(underlying_toric_variety(base); completeness_check = completeness_check)
+
+
+@doc raw"""
+    hypersurface_model(base::ToricCoveredScheme, fiber_ambient_space::ToricCoveredScheme, D1::ToricDivisorClass, D2::ToricDivisorClass; completeness_check::Bool = true)
+
+Construct a hypersurface model, for which the user can specify a fiber ambient space
+as well as divisor classes of the toric base space, in which the first two homogeneous
+coordinates of the fiber ambient space transform.
+
+# Examples
+```jldoctest
+julia> base = projective_space(ToricCoveredScheme, 2)
+Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0], [0, 1], [-1, -1]]
+
+julia> fiber_ambient_space = weighted_projective_space(NormalToricVariety, [2,3,1])
+Normal, non-affine, simplicial, projective, 2-dimensional toric variety without torusfactor
+
+julia> set_coordinate_names(fiber_ambient_space, ["x", "y", "z"])
+
+julia> fiber_ambient_space = ToricCoveredScheme(fiber_ambient_space)
+Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[-1, 1//3], [1, -1//2], [0, 1]]
+
+julia> D1 = 2 * anticanonical_divisor_class(underlying_toric_variety(base))
+Divisor class on a normal toric variety
+
+julia> D2 = 3 * anticanonical_divisor_class(underlying_toric_variety(base))
+Divisor class on a normal toric variety
+
+julia> h = hypersurface_model(base, fiber_ambient_space, D1, D2; completeness_check = false)
+Hypersurface model over a concrete base
+```
+"""
+hypersurface_model(base::ToricCoveredScheme, fiber_ambient_space::ToricCoveredScheme, D1::ToricDivisorClass, D2::ToricDivisorClass; completeness_check::Bool = true) = hypersurface_model(underlying_toric_variety(base), underlying_toric_variety(fiber_ambient_space), D1, D2; completeness_check = completeness_check)
+
+
+################################################
+# 3: Constructors with scheme as base
+################################################
+
+# Yet to come...
+
+
+################################################
+# 4: Constructors without specified base
+################################################
+
+
+@doc raw"""
+    hypersurface_model(p::MPolyRingElem, auxiliary_base_ring::MPolyRing, d::Int)
+
+This method constructs a hypersurface model over a base space that is not
+fully specified. The following example exemplifies this approach.
+
+# Examples
+```jldoctest
+julia> auxiliary_base_ring, (a10, a21, a32, a43, a65, w) = QQ["a10", "a21", "a32", "a43", "a65", "w"];
+
+julia> a1 = a10;
+
+julia> a2 = a21 * w;
+
+julia> a3 = a32 * w^2;
+
+julia> a4 = a43 * w^3;
+
+julia> a6 = a65 * w^5;
+
+julia> ais = [a1, a2, a3, a4, a6];
+
+julia> t = global_tate_model(ais, auxiliary_base_ring, 3)
+Global Tate model over a not fully specified base
+```
+"""
+function hypersurface_model(p::MPolyRingElem, auxiliary_base_ring::MPolyRing, d::Int)
+  # Do something cool!
+  #=
+  @req length(ais) == 5 "We expect exactly 5 Tate sections"
+  @req all(k -> parent(k) == auxiliary_base_ring, ais) "All Tate sections must reside in the provided auxiliary base ring"
+  @req d > 0 "The dimension of the base space must be positive"
+  @req ngens(auxiliary_base_ring) >= d "We expect at least as many base variables as the desired base dimension"
+  gens_base_names = [string(g) for g in gens(auxiliary_base_ring)]
+  if ("x" in gens_base_names) || ("y" in gens_base_names) || ("z" in gens_base_names)
+    @vprint :GlobalTateModel 0 "Variable names duplicated between base and fiber coordinates.\n"
+  end
+  
+  # convert Tate sections into polynomials of the auxiliary base
+  auxiliary_base_space = _auxiliary_base_space([string(k) for k in gens(auxiliary_base_ring)], d)
+  S = cox_ring(auxiliary_base_space)
+  ring_map = hom(auxiliary_base_ring, S, gens(S))
+  (a1, a2, a3, a4, a6) = [ring_map(k) for k in ais]
+  
+  # construct model
+  auxiliary_ambient_space = _ambient_space_from_base(auxiliary_base_space)
+  pt = _tate_polynomial([a1, a2, a3, a4, a6], cox_ring(auxiliary_ambient_space))
+  model = GlobalTateModel(a1, a2, a3, a4, a6, pt, toric_covered_scheme(auxiliary_base_space), toric_covered_scheme(auxiliary_ambient_space))
+  set_attribute!(model, :base_fully_specified, false)
+  return model=#
+end
+
+
+################################################
+# 5: Display
+################################################
+
+function Base.show(io::IO, h::HypersurfaceModel)
+  if base_fully_specified(h)
+    print(io, "Hypersurface model over a concrete base")
+  else
+    print(io, "Hypersurface model over a not fully specified base")
+  end
+end

--- a/experimental/FTheoryTools/src/HypersurfaceModels/methods.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/methods.jl
@@ -1,0 +1,22 @@
+@doc raw"""
+    set_hypersurface_equation(h::HypersurfaceModel, p::MPolyRingElem)
+
+Set the hypersurface equation to a custom value.
+
+```jldoctest
+julia> h = hypersurface_model_over_projective_space(2)
+Hypersurface model over a concrete base
+
+julia> R = parent(hypersurface_equation(h));
+
+julia> new_poly = gens(R)[4]^3
+x^3
+
+julia> set_hypersurface_equation(h, new_poly);
+```
+"""
+function set_hypersurface_equation(h::HypersurfaceModel, p::MPolyRingElem)
+  @req parent(p) == parent(hypersurface_equation(h)) "Polynomial must reside in the Cox ring of the ambient space"
+  @req degree(p) == degree(hypersurface_equation(h)) "Degree mismatch between specified polynomial and current hypersurface equation"
+  h.hypersurface_equation = p
+end

--- a/experimental/FTheoryTools/src/HypersurfaceModels/properties.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/properties.jl
@@ -1,0 +1,18 @@
+#####################################################
+# 1. Properties for general global Tate models
+#####################################################
+
+@doc raw"""
+    base_fully_specified(h::HypersurfaceModel)
+
+Return `true` is the hypersurface model has a concrete base space and `false` otherwise.
+
+```jldoctest
+julia> h = hypersurface_model_over_projective_space(2)
+Hypersurface model over a concrete base
+
+julia> base_fully_specified(h)
+true
+```
+"""
+base_fully_specified(h::HypersurfaceModel) = get_attribute(h, :base_fully_specified)

--- a/experimental/FTheoryTools/src/TateModels/attributes.jl
+++ b/experimental/FTheoryTools/src/TateModels/attributes.jl
@@ -207,20 +207,20 @@ end
 #####################################################
 
 @doc raw"""
-    global_weierstrass_model(t::GlobalTateModel)
+    weierstrass_model(t::GlobalTateModel)
 
-Return the global Weierstrass model which is equivalent to the given Tate model.
+Return the Weierstrass model which is equivalent to the given Tate model.
 
 ```jldoctest
 julia> t = literature_tate_model(arxiv_id = "1109.3454", equation = "3.1")
 Global Tate model over a not fully specified base -- SU(5)xU(1) restricted Tate model based on arXiv paper 1109.3454 Eq. (3.1)
 
-julia> global_weierstrass_model(t)
-Global Weierstrass model over a not fully specified base
+julia> weierstrass_model(t)
+Weierstrass model over a not fully specified base
 ```
 """
-@attr GlobalWeierstrassModel function global_weierstrass_model(t::GlobalTateModel)
-  @req typeof(base_space(t)) <: ToricCoveredScheme "Conversion of global Tate model into global Weierstrass model is currently only supported for toric varieties/schemes as base space"
+@attr WeierstrassModel function weierstrass_model(t::GlobalTateModel)
+  @req typeof(base_space(t)) <: ToricCoveredScheme "Conversion of global Tate model into Weierstrass model is currently only supported for toric varieties/schemes as base space"
   b2 = 4 * tate_section_a2(t) + tate_section_a1(t)^2
   b4 = 2 * tate_section_a4(t) + tate_section_a1(t) * tate_section_a3(t)
   b6 = 4 * tate_section_a6(t) + tate_section_a3(t)^2
@@ -230,7 +230,7 @@ Global Weierstrass model over a not fully specified base
   x, y, z = gens(S)[ngens(S)-2:ngens(S)]
   ring_map = hom(parent(f), S, gens(S)[1:ngens(parent(f))])
   pw = x^3 - y^2 + ring_map(f)*x*z^4 + ring_map(g)*z^6
-  model = GlobalWeierstrassModel(f, g, pw, base_space(t), ambient_space(t))
+  model = WeierstrassModel(f, g, pw, base_space(t), ambient_space(t))
   set_attribute!(model, :base_fully_specified, base_fully_specified(t))
   return model
 end
@@ -254,7 +254,7 @@ julia> discriminant(t);
 """
 @attr MPolyRingElem function discriminant(t::GlobalTateModel)
   @req typeof(base_space(t)) <: ToricCoveredScheme "Discriminant of global Tate model is currently only supported for toric varieties/schemes as base space"
-  return discriminant(global_weierstrass_model(t))
+  return discriminant(weierstrass_model(t))
 end
 
 
@@ -319,7 +319,7 @@ julia> singular_loci(t)[2]
 """
 @attr Vector{<:Tuple{<:MPolyIdeal{<:MPolyRingElem}, Tuple{Int64, Int64, Int64}, String}} function singular_loci(t::GlobalTateModel)
   @req typeof(base_space(t)) <: ToricCoveredScheme "Singular loci of global Tate model currently only supported for toric varieties/schemes as base space"
-  return singular_loci(global_weierstrass_model(t))
+  return singular_loci(weierstrass_model(t))
 end
 
 

--- a/experimental/FTheoryTools/src/TateModels/constructors.jl
+++ b/experimental/FTheoryTools/src/TateModels/constructors.jl
@@ -55,7 +55,7 @@ function global_tate_model(ais::Vector{T}, base::AbstractNormalToricVariety; com
     @req is_complete(base) "Base space must be complete"
   end
   
-  ambient_space = _ambient_space_from_base(base)
+  ambient_space = _tate_ambient_space_from_base(base)
   pt = _tate_polynomial(ais, cox_ring(ambient_space))
   model = GlobalTateModel(ais[1], ais[2], ais[3], ais[4], ais[5], pt, toric_covered_scheme(base), toric_covered_scheme(ambient_space))
   set_attribute!(model, :base_fully_specified, true)
@@ -167,7 +167,7 @@ function global_tate_model(ais::Vector{T}, auxiliary_base_ring::MPolyRing, d::In
   (a1, a2, a3, a4, a6) = [ring_map(k) for k in ais]
   
   # construct model
-  auxiliary_ambient_space = _ambient_space_from_base(auxiliary_base_space)
+  auxiliary_ambient_space = _tate_ambient_space_from_base(auxiliary_base_space)
   pt = _tate_polynomial([a1, a2, a3, a4, a6], cox_ring(auxiliary_ambient_space))
   model = GlobalTateModel(a1, a2, a3, a4, a6, pt, toric_covered_scheme(auxiliary_base_space), toric_covered_scheme(auxiliary_ambient_space))
   set_attribute!(model, :base_fully_specified, false)

--- a/experimental/FTheoryTools/src/WeierstrassModels/attributes.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/attributes.jl
@@ -10,35 +10,35 @@
 #####################################################
 
 @doc raw"""
-    weierstrass_section_f(w::GlobalWeierstrassModel)
+    weierstrass_section_f(w::WeierstrassModel)
 
 Return the polynomial ``f`` used for the
-construction of the global Weierstrass model.
+construction of the Weierstrass model.
 
 ```jldoctest
 julia> w = su5_weierstrass_model_over_arbitrary_3d_base()
-Global Weierstrass model over a not fully specified base
+Weierstrass model over a not fully specified base
 
 julia> weierstrass_section_f(w);
 ```
 """
-weierstrass_section_f(w::GlobalWeierstrassModel) = w.weierstrass_f
+weierstrass_section_f(w::WeierstrassModel) = w.weierstrass_f
 
 
 @doc raw"""
-    weierstrass_section_g(w::GlobalWeierstrassModel)
+    weierstrass_section_g(w::WeierstrassModel)
 
 Return the polynomial ``g`` used for the
-construction of the global Weierstrass model.
+construction of the Weierstrass model.
 
 ```jldoctest
 julia> w = su5_weierstrass_model_over_arbitrary_3d_base()
-Global Weierstrass model over a not fully specified base
+Weierstrass model over a not fully specified base
 
 julia> weierstrass_section_g(w);
 ```
 """
-weierstrass_section_g(w::GlobalWeierstrassModel) = w.weierstrass_g
+weierstrass_section_g(w::WeierstrassModel) = w.weierstrass_g
 
 
 #####################################################
@@ -46,18 +46,18 @@ weierstrass_section_g(w::GlobalWeierstrassModel) = w.weierstrass_g
 #####################################################
 
 @doc raw"""
-    weierstrass_polynomial(w::GlobalWeierstrassModel)
+    weierstrass_polynomial(w::WeierstrassModel)
 
-Return the Weierstrass polynomial of the global Weierstrass model.
+Return the Weierstrass polynomial of the Weierstrass model.
 
 ```jldoctest
 julia> w = su5_weierstrass_model_over_arbitrary_3d_base()
-Global Weierstrass model over a not fully specified base
+Weierstrass model over a not fully specified base
 
 julia> weierstrass_polynomial(w);
 ```
 """
-weierstrass_polynomial(w::GlobalWeierstrassModel) = w.weierstrass_polynomial
+weierstrass_polynomial(w::WeierstrassModel) = w.weierstrass_polynomial
 
 
 #####################################################
@@ -65,56 +65,56 @@ weierstrass_polynomial(w::GlobalWeierstrassModel) = w.weierstrass_polynomial
 #####################################################
 
 @doc raw"""
-    base_space(w::GlobalWeierstrassModel)
+    base_space(w::WeierstrassModel)
 
-Return the base space of the global Weierstrass model.
+Return the base space of the Weierstrass model.
 
 ```jldoctest
 julia> w = su5_weierstrass_model_over_arbitrary_3d_base()
-Global Weierstrass model over a not fully specified base
+Weierstrass model over a not fully specified base
 
 julia> base_space(w)
 Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0, 0, 0, 0, 0], [0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 1], [0, 1, 0, 0, 0, 0], [0, 0, 1, 0, 0, 0], [0, 0, 0, 1, 0, 0]]
 """
-function base_space(w::GlobalWeierstrassModel)
-  base_fully_specified(w) || @vprint :GlobalWeierstrassModel 1 "Base space was not fully specified. Returning AUXILIARY base space.\n"
+function base_space(w::WeierstrassModel)
+  base_fully_specified(w) || @vprint :WeierstrassModel 1 "Base space was not fully specified. Returning AUXILIARY base space.\n"
   return w.base_space
 end
 
 
 @doc raw"""
-    ambient_space(w::GlobalWeierstrassModel)
+    ambient_space(w::WeierstrassModel)
 
-Return the base space of the global Weierstrass model.
+Return the base space of the Weierstrass model.
 
 ```jldoctest
 julia> w = su5_weierstrass_model_over_arbitrary_3d_base()
-Global Weierstrass model over a not fully specified base
+Weierstrass model over a not fully specified base
 
 julia> ambient_space(w)
 Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0, 0, 0, 0, 0, -2, -3], [0, 0, 0, 0, 1, 0, -2, -3], [0, 0, 0, 0, 0, 1, -2, -3], [0, 1, 0, 0, 0, 0, -2, -3], [0, 0, 1, 0, 0, 0, -2, -3], [0, 0, 0, 1, 0, 0, -2, -3], [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 0, 0, 1], [0, 0, 0, 0, 0, 0, -1, -3//2]]
 ```
 """
-function ambient_space(w::GlobalWeierstrassModel)
-  base_fully_specified(w) || @vprint :GlobalWeierstrassModel 1 "Base space was not fully specified. Returning AUXILIARY ambient space.\n"
+function ambient_space(w::WeierstrassModel)
+  base_fully_specified(w) || @vprint :WeierstrassModel 1 "Base space was not fully specified. Returning AUXILIARY ambient space.\n"
   return w.ambient_space
 end
 
 
 @doc raw"""
-    fiber_ambient_space(w::GlobalWeierstrassModel)
+    fiber_ambient_space(w::WeierstrassModel)
 
-Return the fiber ambient space of the global Weierstrass model.
+Return the fiber ambient space of the Weierstrass model.
 
 ```jldoctest
 julia> w = su5_weierstrass_model_over_arbitrary_3d_base()
-Global Weierstrass model over a not fully specified base
+Weierstrass model over a not fully specified base
 
 julia> fiber_ambient_space(w)
 Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[-1, 1//3], [1, -1//2], [0, 1]]
 ```
 """
-fiber_ambient_space(w::GlobalWeierstrassModel) = w.fiber_ambient_space
+fiber_ambient_space(w::WeierstrassModel) = w.fiber_ambient_space
 
 
 
@@ -132,28 +132,28 @@ fiber_ambient_space(w::GlobalWeierstrassModel) = w.fiber_ambient_space
 #####################################################
 
 @doc raw"""
-    calabi_yau_hypersurface(w::GlobalWeierstrassModel)
+    calabi_yau_hypersurface(w::WeierstrassModel)
 
 Return the Calabi-Yau hypersurface in the toric ambient space
-which defines the global Weierstrass model.
+which defines the Weierstrass model.
 
 ```jldoctest
 julia> w = su5_weierstrass_model_over_arbitrary_3d_base()
-Global Weierstrass model over a not fully specified base
+Weierstrass model over a not fully specified base
 
 julia> calabi_yau_hypersurface(w)
 Closed subvariety of a normal toric variety
 ```
 """
-@attr ClosedSubvarietyOfToricVariety function calabi_yau_hypersurface(w::GlobalWeierstrassModel)
+@attr ClosedSubvarietyOfToricVariety function calabi_yau_hypersurface(w::WeierstrassModel)
   @req typeof(base_space(w)) <: ToricCoveredScheme "Calabi-Yau hypersurface currently only supported for toric varieties/schemes as base space"
-  base_fully_specified(w) || @vprint :GlobalWeierstrassModel 1 "Base space was not fully specified. Returning hypersurface in AUXILIARY ambient space.\n"
+  base_fully_specified(w) || @vprint :WeierstrassModel 1 "Base space was not fully specified. Returning hypersurface in AUXILIARY ambient space.\n"
   return closed_subvariety_of_toric_variety(underlying_toric_variety(ambient_space(w)), [weierstrass_polynomial(w)])
 end
 
 
 #####################################################
-# 2.2 Turn global Weierstrass model into Tate model
+# 2.2 Turn Weierstrass model into Tate model
 #####################################################
 
 # Currently no plan to include
@@ -164,27 +164,27 @@ end
 #####################################################
 
 @doc raw"""
-    discriminant(w::GlobalWeierstrassModel)
+    discriminant(w::WeierstrassModel)
 
 Return the discriminant ``\Delta = 4 f^3 + 27 g^2``.
 
 ```jldoctest
 julia> w = su5_weierstrass_model_over_arbitrary_3d_base()
-Global Weierstrass model over a not fully specified base
+Weierstrass model over a not fully specified base
 
 julia> discriminant(w);
 ```
 """
-@attr MPolyRingElem function discriminant(w::GlobalWeierstrassModel)
-  @req typeof(base_space(w)) <: ToricCoveredScheme "Discriminant of global Weierstrass model is currently only supported for toric varieties/schemes as base space"
+@attr MPolyRingElem function discriminant(w::WeierstrassModel)
+  @req typeof(base_space(w)) <: ToricCoveredScheme "Discriminant of Weierstrass model is currently only supported for toric varieties/schemes as base space"
   return 4 * w.weierstrass_f^3 + 27 * w.weierstrass_g^2
 end
 
 
 @doc raw"""
-    singular_loci(w::GlobalWeierstrassModel)
+    singular_loci(w::WeierstrassModel)
 
-Return the singular loci of the global Weierstrass model, along with the order of
+Return the singular loci of the Weierstrass model, along with the order of
 vanishing of ``(f, g, \Delta)`` at each locus and the refined Tate fiber type.
 
 For the time being, we either explicitly or implicitly focus on toric varieties
@@ -204,14 +204,14 @@ auxiliary base space.
 
 ```jldoctest
 julia> w = su5_weierstrass_model_over_arbitrary_3d_base()
-Global Weierstrass model over a not fully specified base
+Weierstrass model over a not fully specified base
 
 julia> length(singular_loci(w))
 2
 ```
 """
-@attr Vector{<:Tuple{<:MPolyIdeal{<:MPolyRingElem}, Tuple{Int64, Int64, Int64}, String}} function singular_loci(w::GlobalWeierstrassModel)
-  @req typeof(base_space(w)) <: ToricCoveredScheme "Singular loci of global Weierstrass model is currently only supported for toric varieties/schemes as base space"
+@attr Vector{<:Tuple{<:MPolyIdeal{<:MPolyRingElem}, Tuple{Int64, Int64, Int64}, String}} function singular_loci(w::WeierstrassModel)
+  @req typeof(base_space(w)) <: ToricCoveredScheme "Singular loci of Weierstrass model is currently only supported for toric varieties/schemes as base space"
   
   B = irrelevant_ideal(base_space(w))
   

--- a/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
@@ -3,28 +3,28 @@
 ################################################
 
 @doc raw"""
-    global_weierstrass_model(base::AbstractNormalToricVariety; completeness_check::Bool = true)
+    weierstrass_model(base::AbstractNormalToricVariety; completeness_check::Bool = true)
 
-This method constructs a global Weierstrass model over a given toric base
+This method constructs a Weierstrass model over a given toric base
 3-fold. The Weierstrass sections ``f`` and ``g`` are taken with (pseudo)random
 coefficients.
 
 # Examples
 ```jldoctest
-julia> w = global_weierstrass_model(sample_toric_variety(); completeness_check = false)
-Global Weierstrass model over a concrete base
+julia> w = weierstrass_model(sample_toric_variety(); completeness_check = false)
+Weierstrass model over a concrete base
 ```
 """
-function global_weierstrass_model(base::AbstractNormalToricVariety; completeness_check::Bool = true)
+function weierstrass_model(base::AbstractNormalToricVariety; completeness_check::Bool = true)
   (f, g) = _weierstrass_sections(base)
-  return global_weierstrass_model(f, g, base; completeness_check = completeness_check)
+  return weierstrass_model(f, g, base; completeness_check = completeness_check)
 end
 
 
 @doc raw"""
-    global_weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::AbstractNormalToricVariety; completeness_check::Bool = true)
+    weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::AbstractNormalToricVariety; completeness_check::Bool = true)
 
-This method operates analogously to `global_weierstrass_model(base::AbstractNormalToricVariety)`.
+This method operates analogously to `weierstrass_model(base::AbstractNormalToricVariety)`.
 The only difference is that the Weierstrass sections ``f`` and ``g`` can be specified with non-generic values.
 
 # Examples
@@ -36,16 +36,16 @@ julia> f = sum([rand(Int) * b for b in basis_of_global_sections(anticanonical_bu
 
 julia> g = sum([rand(Int) * b for b in basis_of_global_sections(anticanonical_bundle(base)^6)]);
 
-julia> w = global_weierstrass_model(f, g, base; completeness_check = false)
-Global Weierstrass model over a concrete base
+julia> w = weierstrass_model(f, g, base; completeness_check = false)
+Weierstrass model over a concrete base
 ```
 """
-function global_weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::AbstractNormalToricVariety; completeness_check::Bool = true)
+function weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::AbstractNormalToricVariety; completeness_check::Bool = true)
   @req ((parent(f) == cox_ring(base)) && (parent(g) == cox_ring(base))) "All Weierstrass sections must reside in the Cox ring of the base toric variety"
   
   gens_base_names = [string(g) for g in gens(cox_ring(base))]
   if ("x" in gens_base_names) || ("y" in gens_base_names) || ("z" in gens_base_names)
-    @vprint :GlobalWeierstrassModel 0 "Variable names duplicated between base and fiber coordinates.\n"
+    @vprint :WeierstrassModel 0 "Variable names duplicated between base and fiber coordinates.\n"
   end
   
   if completeness_check
@@ -54,7 +54,7 @@ function global_weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::Abst
   
   ambient_space = _weierstrass_ambient_space_from_base(base)
   pw = _weierstrass_polynomial(f, g, cox_ring(ambient_space))
-  model = GlobalWeierstrassModel(f, g, pw, toric_covered_scheme(base), toric_covered_scheme(ambient_space))
+  model = WeierstrassModel(f, g, pw, toric_covered_scheme(base), toric_covered_scheme(ambient_space))
   set_attribute!(model, :base_fully_specified, true)
   return model
 end
@@ -66,25 +66,25 @@ end
 
 
 @doc raw"""
-    global_weierstrass_model(base::ToricCoveredScheme; completeness_check::Bool = true)
+    weierstrass_model(base::ToricCoveredScheme; completeness_check::Bool = true)
 
-This method constructs a global Weierstrass model over a given toric base
+This method constructs a Weierstrass model over a given toric base
 3-fold. The Weierstrass sections ``f`` and ``g`` are taken with (pseudo)random
 coefficients.
 
 # Examples
 ```jldoctest
-julia> w = global_weierstrass_model(sample_toric_scheme(); completeness_check = false)
-Global Weierstrass model over a concrete base
+julia> w = weierstrass_model(sample_toric_scheme(); completeness_check = false)
+Weierstrass model over a concrete base
 ```
 """
-global_weierstrass_model(base::ToricCoveredScheme; completeness_check::Bool = true) = global_weierstrass_model(underlying_toric_variety(base), completeness_check = completeness_check)
+weierstrass_model(base::ToricCoveredScheme; completeness_check::Bool = true) = weierstrass_model(underlying_toric_variety(base), completeness_check = completeness_check)
 
 
 @doc raw"""
-    global_weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::ToricCoveredScheme; completeness_check::Bool = true)
+    weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::ToricCoveredScheme; completeness_check::Bool = true)
 
-This method operates analogously to `global_weierstrass_model(base::ToricCoveredScheme)`.
+This method operates analogously to `weierstrass_model(base::ToricCoveredScheme)`.
 The only difference is that the Weierstrass sections ``f`` and ``g`` can be specified with non-generic values.
 
 # Examples
@@ -96,11 +96,11 @@ julia> f = sum([rand(Int) * b for b in basis_of_global_sections(anticanonical_bu
 
 julia> g = sum([rand(Int) * b for b in basis_of_global_sections(anticanonical_bundle(underlying_toric_variety(base))^6)]);
 
-julia> w = global_weierstrass_model(f, g, base; completeness_check = false)
-Global Weierstrass model over a concrete base
+julia> w = weierstrass_model(f, g, base; completeness_check = false)
+Weierstrass model over a concrete base
 ```
 """
-global_weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::ToricCoveredScheme; completeness_check::Bool = true) = global_weierstrass_model(f, g, underlying_toric_variety(base), completeness_check = completeness_check)
+weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::ToricCoveredScheme; completeness_check::Bool = true) = weierstrass_model(f, g, underlying_toric_variety(base), completeness_check = completeness_check)
 
 
 ################################################
@@ -117,26 +117,26 @@ global_weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::ToricCoveredS
 ################################################
 
 @doc raw"""
-    global_weierstrass_model(weierstrass_f::MPolyRingElem, weierstrass_g::MPolyRingElem, auxiliary_base_ring::MPolyRing, d::Int)
+    weierstrass_model(weierstrass_f::MPolyRingElem, weierstrass_g::MPolyRingElem, auxiliary_base_ring::MPolyRing, d::Int)
 
-This method constructs a global Weierstrass model over a base space that is not
+This method constructs a Weierstrass model over a base space that is not
 fully specified. The following example illustrates this approach.
 
 # Examples
 ```jldoctest
 julia> auxiliary_base_ring, (f, g, u) = QQ["f", "g", "u"];
 
-julia> w = global_weierstrass_model(f, g, auxiliary_base_ring, 3)
-Global Weierstrass model over a not fully specified base
+julia> w = weierstrass_model(f, g, auxiliary_base_ring, 3)
+Weierstrass model over a not fully specified base
 ```
 """
-function global_weierstrass_model(weierstrass_f::MPolyRingElem, weierstrass_g::MPolyRingElem, auxiliary_base_ring::MPolyRing, d::Int)
+function weierstrass_model(weierstrass_f::MPolyRingElem, weierstrass_g::MPolyRingElem, auxiliary_base_ring::MPolyRing, d::Int)
   @req ((parent(weierstrass_f) == auxiliary_base_ring) && (parent(weierstrass_g) == auxiliary_base_ring)) "All Weierstrass sections must reside in the provided auxiliary base ring"
   @req d > 0 "The dimension of the base space must be positive"
   @req (ngens(auxiliary_base_ring) >= d) "We expect at least as many base variables as the desired base dimension"
   gens_base_names = [string(g) for g in gens(auxiliary_base_ring)]
   if ("x" in gens_base_names) || ("y" in gens_base_names) || ("z" in gens_base_names)
-    @vprint :GlobalWeierstrassModel 0 "Variable names duplicated between base and fiber coordinates.\n"
+    @vprint :WeierstrassModel 0 "Variable names duplicated between base and fiber coordinates.\n"
   end
   
   # convert Weierstrass sections into polynomials of the auxiliary base
@@ -151,7 +151,7 @@ function global_weierstrass_model(weierstrass_f::MPolyRingElem, weierstrass_g::M
   
   # compute model
   pw = _weierstrass_polynomial(f, g, cox_ring(auxiliary_ambient_space))
-  model = GlobalWeierstrassModel(f, g, pw, toric_covered_scheme(auxiliary_base_space), toric_covered_scheme(auxiliary_ambient_space))
+  model = WeierstrassModel(f, g, pw, toric_covered_scheme(auxiliary_base_space), toric_covered_scheme(auxiliary_ambient_space))
   set_attribute!(model, :base_fully_specified, false)
   return model
 end
@@ -161,10 +161,10 @@ end
 # 5: Display
 #######################################
 
-function Base.show(io::IO, w::GlobalWeierstrassModel)
+function Base.show(io::IO, w::WeierstrassModel)
   if base_fully_specified(w)
-    print(io, "Global Weierstrass model over a concrete base")
+    print(io, "Weierstrass model over a concrete base")
   else
-    print(io, "Global Weierstrass model over a not fully specified base")
+    print(io, "Weierstrass model over a not fully specified base")
   end
 end

--- a/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
@@ -52,7 +52,7 @@ function global_weierstrass_model(f::MPolyRingElem, g::MPolyRingElem, base::Abst
     @req is_complete(base) "Base space must be complete"
   end
   
-  ambient_space = _ambient_space_from_base(base)
+  ambient_space = _weierstrass_ambient_space_from_base(base)
   pw = _weierstrass_polynomial(f, g, cox_ring(ambient_space))
   model = GlobalWeierstrassModel(f, g, pw, toric_covered_scheme(base), toric_covered_scheme(ambient_space))
   set_attribute!(model, :base_fully_specified, true)
@@ -147,7 +147,7 @@ function global_weierstrass_model(weierstrass_f::MPolyRingElem, weierstrass_g::M
   g = ring_map(weierstrass_g)
   
   # construct auxiliary ambient space
-  auxiliary_ambient_space = _ambient_space_from_base(auxiliary_base_space)
+  auxiliary_ambient_space = _weierstrass_ambient_space_from_base(auxiliary_base_space)
   
   # compute model
   pw = _weierstrass_polynomial(f, g, cox_ring(auxiliary_ambient_space))

--- a/experimental/FTheoryTools/src/WeierstrassModels/properties.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/properties.jl
@@ -1,14 +1,14 @@
 @doc raw"""
-    base_fully_specified(w::GlobalWeierstrassModel)
+    base_fully_specified(w::WeierstrassModel)
 
 Return `true` is the Weierstrass model has a concrete base space and `false` otherwise.
 
 ```jldoctest
 julia> w = su5_weierstrass_model_over_arbitrary_3d_base()
-Global Weierstrass model over a not fully specified base
+Weierstrass model over a not fully specified base
 
 julia> base_fully_specified(w)
 false
 ```
 """
-base_fully_specified(w::GlobalWeierstrassModel) = get_attribute(w, :base_fully_specified)
+base_fully_specified(w::WeierstrassModel) = get_attribute(w, :base_fully_specified)

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -21,7 +21,7 @@ _ambient_space_from_base(base::ToricCoveredScheme, fiber_ambient_space::ToricCov
 function _ambient_space_from_base(base::AbstractNormalToricVariety)
   fiber_ambient_space = weighted_projective_space(NormalToricVariety, [2,3,1])
   D1 = 2 * anticanonical_divisor_class(base)
-  D2 = 2 * anticanonical_divisor_class(base)
+  D2 = 3 * anticanonical_divisor_class(base)
   set_coordinate_names(fiber_ambient_space, ["x", "y", "z"])
   return _ambient_space(base, fiber_ambient_space, D1, D2)
 end

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -16,7 +16,69 @@ end
 
 _ambient_space_from_base(base::ToricCoveredScheme) = _ambient_space_from_base(underlying_toric_variety(base))
 
+_ambient_space_from_base(base::ToricCoveredScheme, fiber_ambient_space::ToricCoveredScheme, D1::ToricDivisorClass, D2::ToricDivisorClass) = _ambient_space_from_base(underlying_toric_variety(base), underlying_toric_variety(fiber_ambient_space), D1, D2)
+
 function _ambient_space_from_base(base::AbstractNormalToricVariety)
+  fiber_ambient_space = weighted_projective_space(NormalToricVariety, [2,3,1])
+  D1 = 2 * anticanonical_divisor_class(base)
+  D2 = 2 * anticanonical_divisor_class(base)
+  set_coordinate_names(fiber_ambient_space, ["x", "y", "z"])
+  return _ambient_space(base, fiber_ambient_space, D1, D2)
+end
+
+function _ambient_space(base::AbstractNormalToricVariety, fiber_ambient_space::AbstractNormalToricVariety, D1::ToricDivisorClass, D2::ToricDivisorClass)
+  
+  # Consistency checks
+  @req ((toric_variety(D1) === base) && (toric_variety(D2) === base)) "The divisors must belong to the base space"
+  
+  # Extract information about the toric base
+  base_rays = matrix(ZZ, rays(base))
+  base_cones = matrix(ZZ, ray_indices(maximal_cones(base)))
+  
+  # Extract information about the fiber ambient space
+  fiber_rays = matrix(ZZ, rays(fiber_ambient_space))
+  fiber_cones = matrix(ZZ, ray_indices(maximal_cones(fiber_ambient_space)))
+  
+  # Compute the u-matrix
+  weights = transpose(vcat([elem.coeff for elem in cox_ring(base).d]))
+  m1 = transpose(vcat([divisor_class(D1).coeff, divisor_class(D2).coeff]))
+  m2 = fiber_rays[1:2,:]
+  u_matrix = solve(weights,(-1)*m1*m2)
+  
+  # Form the rays of the toric ambient space
+  new_base_rays = hcat(base_rays, u_matrix)
+  new_fiber_rays = hcat(zero_matrix(ZZ, nrows(fiber_rays), ncols(base_rays)), fiber_rays)
+  ambient_space_rays = vcat(new_base_rays, new_fiber_rays)
+  ambient_space_rays = vcat([[k for k in ambient_space_rays[i,:]] for i in 1:nrows(ambient_space_rays)]...)
+  
+  # Construct the incidence matrix for the maximal cones of the ambient space
+  ambient_space_max_cones = []
+  for i in 1:nrows(base_cones)
+    for j in 1:nrows(fiber_cones)
+      push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [c for c in fiber_cones[j,:]])])
+    end
+  end
+  ambient_space_max_cones = IncidenceMatrix(vcat(ambient_space_max_cones...))
+  
+  # Construct and return the ambient space
+  ambient_space = normal_toric_variety(polyhedral_fan(ambient_space_rays, ambient_space_max_cones; non_redundant = true))
+  set_coordinate_names(ambient_space, vcat([string(k) for k in gens(cox_ring(base))], [string(k) for k in gens(cox_ring(fiber_ambient_space))]))
+  return ambient_space
+  
+end
+
+
+################################################################
+# 3: Construct the Weierstrass/Tate ambient space
+################################################################
+
+_tate_ambient_space_from_base(base::NormalToricVariety) = _weierstrass_ambient_space_from_base(base)
+
+_tate_ambient_space_from_base(base::ToricCoveredScheme) = _weierstrass_ambient_space_from_base(underlying_toric_variety(base))
+
+_weierstrass_ambient_space_from_base(base::ToricCoveredScheme) = _weierstrass_ambient_space_from_base(underlying_toric_variety(base))
+
+function _weierstrass_ambient_space_from_base(base::AbstractNormalToricVariety)
   
   # Extract information about the toric base
   base_rays = matrix(ZZ, rays(base))
@@ -53,7 +115,7 @@ end
 
 
 ################################################################
-# 3: Construct the Weierstrass polynomial
+# 4: Construct the Weierstrass polynomial
 ################################################################
 
 function _weierstrass_sections(base::AbstractNormalToricVariety)

--- a/experimental/FTheoryTools/src/exports.jl
+++ b/experimental/FTheoryTools/src/exports.jl
@@ -2,8 +2,8 @@ export AbstractFTheoryModel
 export ClosedSubschemeModel
 export CompleteIntersectionModel
 export GlobalTateModel
-export GlobalWeierstrassModel
 export HypersurfaceModel
+export WeierstrassModel
 export _blowup_global
 export _blowup_global_sequence
 export _is_nontrivial
@@ -23,10 +23,6 @@ export global_tate_model
 export global_tate_model_over_del_pezzo_surface
 export global_tate_model_over_hirzebruch_surface
 export global_tate_model_over_projective_space
-export global_weierstrass_model
-export global_weierstrass_model_over_del_pezzo_surface
-export global_weierstrass_model_over_hirzebruch_surface
-export global_weierstrass_model_over_projective_space
 export hypersurface_equation
 export hypersurface_model_over_del_pezzo_surface
 export hypersurface_model_over_hirzebruch_surface
@@ -56,6 +52,10 @@ export tate_section_a3
 export tate_section_a4
 export tate_section_a6
 export version
+export weierstrass_model
+export weierstrass_model_over_del_pezzo_surface
+export weierstrass_model_over_hirzebruch_surface
+export weierstrass_model_over_projective_space
 export weierstrass_polynomial
 export weierstrass_section_f
 export weierstrass_section_g

--- a/experimental/FTheoryTools/src/exports.jl
+++ b/experimental/FTheoryTools/src/exports.jl
@@ -27,6 +27,10 @@ export global_weierstrass_model
 export global_weierstrass_model_over_del_pezzo_surface
 export global_weierstrass_model_over_hirzebruch_surface
 export global_weierstrass_model_over_projective_space
+export hypersurface_equation
+export hypersurface_model_over_del_pezzo_surface
+export hypersurface_model_over_hirzebruch_surface
+export hypersurface_model_over_projective_space
 export sample_toric_scheme
 export sample_toric_variety
 export has_arxiv_id
@@ -35,6 +39,8 @@ export has_doi
 export has_equation_number
 export has_link
 export has_version
+export hypersurface_model
+export set_hypersurface_equation
 export singular_loci
 export link
 export literature_tate_model

--- a/experimental/FTheoryTools/src/standard_constructions.jl
+++ b/experimental/FTheoryTools/src/standard_constructions.jl
@@ -17,17 +17,17 @@ global_tate_model_over_projective_space(d::Int) = global_tate_model(projective_s
 
 
 @doc raw"""
-    global_weierstrass_model_over_projective_space(d::Int)
+    weierstrass_model_over_projective_space(d::Int)
 
-This method constructs a global Weierstrass model over the projective space.
+This method constructs a Weierstrass model over the projective space.
 
 # Examples
 ```jldoctest
-julia> global_weierstrass_model_over_projective_space(3)
-Global Weierstrass model over a concrete base
+julia> weierstrass_model_over_projective_space(3)
+Weierstrass model over a concrete base
 ```
 """
-global_weierstrass_model_over_projective_space(d::Int) = global_weierstrass_model(projective_space(NormalToricVariety, d); completeness_check = false)
+weierstrass_model_over_projective_space(d::Int) = weierstrass_model(projective_space(NormalToricVariety, d); completeness_check = false)
 
 
 @doc raw"""
@@ -63,17 +63,17 @@ global_tate_model_over_hirzebruch_surface(r::Int) = global_tate_model(hirzebruch
 
 
 @doc raw"""
-    global_weierstrass_model_over_hirzebruch_surface(r::Int)
+    weierstrass_model_over_hirzebruch_surface(r::Int)
 
-This method constructs a global Weierstrass model over a Hirzebruch surface.
+This method constructs a Weierstrass model over a Hirzebruch surface.
 
 # Examples
 ```jldoctest
-julia> global_weierstrass_model_over_hirzebruch_surface(1)
-Global Weierstrass model over a concrete base
+julia> weierstrass_model_over_hirzebruch_surface(1)
+Weierstrass model over a concrete base
 ```
 """
-global_weierstrass_model_over_hirzebruch_surface(r::Int) = global_weierstrass_model(hirzebruch_surface(NormalToricVariety, r); completeness_check = false)
+weierstrass_model_over_hirzebruch_surface(r::Int) = weierstrass_model(hirzebruch_surface(NormalToricVariety, r); completeness_check = false)
 
 
 @doc raw"""
@@ -109,17 +109,17 @@ global_tate_model_over_del_pezzo_surface(b::Int) = global_tate_model(del_pezzo_s
 
 
 @doc raw"""
-    global_weierstrass_model_over_del_pezzo_surface(b::Int)
+    weierstrass_model_over_del_pezzo_surface(b::Int)
 
-This method constructs a global Weierstrass model over a del-Pezzo surface.
+This method constructs a Weierstrass model over a del-Pezzo surface.
 
 # Examples
 ```jldoctest
-julia> global_weierstrass_model_over_del_pezzo_surface(3)
-Global Weierstrass model over a concrete base
+julia> weierstrass_model_over_del_pezzo_surface(3)
+Weierstrass model over a concrete base
 ```
 """
-global_weierstrass_model_over_del_pezzo_surface(b::Int) = global_weierstrass_model(del_pezzo_surface(NormalToricVariety, b); completeness_check = false)
+weierstrass_model_over_del_pezzo_surface(b::Int) = weierstrass_model(del_pezzo_surface(NormalToricVariety, b); completeness_check = false)
 
 
 @doc raw"""
@@ -195,7 +195,7 @@ e.g. [Wei18](@cite) and references therein.
 
 ```jldoctest
 julia> tm = su5_weierstrass_model_over_arbitrary_3d_base()
-Global Weierstrass model over a not fully specified base
+Weierstrass model over a not fully specified base
 ```
 """
-su5_weierstrass_model_over_arbitrary_3d_base() = global_weierstrass_model(su5_tate_model_over_arbitrary_3d_base())
+su5_weierstrass_model_over_arbitrary_3d_base() = weierstrass_model(su5_tate_model_over_arbitrary_3d_base())

--- a/experimental/FTheoryTools/src/standard_constructions.jl
+++ b/experimental/FTheoryTools/src/standard_constructions.jl
@@ -30,6 +30,20 @@ Global Weierstrass model over a concrete base
 global_weierstrass_model_over_projective_space(d::Int) = global_weierstrass_model(projective_space(NormalToricVariety, d); completeness_check = false)
 
 
+@doc raw"""
+    hypersurface_model_over_projective_space(d::Int)
+
+This method constructs a hypersurface model over the projective space.
+
+# Examples
+```jldoctest
+julia> hypersurface_model_over_projective_space(2)
+Hypersurface model over a concrete base
+```
+"""
+hypersurface_model_over_projective_space(d::Int) = hypersurface_model(projective_space(NormalToricVariety, d); completeness_check = false)
+
+
 #####################################################
 # 2. Models over hirzebruch surfaces
 #####################################################
@@ -62,6 +76,20 @@ Global Weierstrass model over a concrete base
 global_weierstrass_model_over_hirzebruch_surface(r::Int) = global_weierstrass_model(hirzebruch_surface(NormalToricVariety, r); completeness_check = false)
 
 
+@doc raw"""
+    hypersurface_model_over_hirzebruch_surface(r::Int)
+
+This method constructs a hypersurface model over a Hirzebruch surface.
+
+# Examples
+```jldoctest
+julia> hypersurface_model_over_hirzebruch_surface(1)
+Hypersurface model over a concrete base
+```
+"""
+hypersurface_model_over_hirzebruch_surface(r::Int) = hypersurface_model(hirzebruch_surface(NormalToricVariety, r); completeness_check = false)
+
+
 #####################################################
 # 3. Models over del pezzo surface
 #####################################################
@@ -92,6 +120,20 @@ Global Weierstrass model over a concrete base
 ```
 """
 global_weierstrass_model_over_del_pezzo_surface(b::Int) = global_weierstrass_model(del_pezzo_surface(NormalToricVariety, b); completeness_check = false)
+
+
+@doc raw"""
+    hypersurface_model_over_del_pezzo_surface(b::Int)
+
+This method constructs a hypersurface model over a del-Pezzo surface.
+
+# Examples
+```jldoctest
+julia> hypersurface_model_over_del_pezzo_surface(3)
+Hypersurface model over a concrete base
+```
+"""
+hypersurface_model_over_del_pezzo_surface(b::Int) = hypersurface_model(del_pezzo_surface(NormalToricVariety, b); completeness_check = false)
 
 
 #####################################################

--- a/experimental/FTheoryTools/src/types.jl
+++ b/experimental/FTheoryTools/src/types.jl
@@ -39,8 +39,9 @@ end
 @attributes mutable struct HypersurfaceModel <: AbstractFTheoryModel
   base_space::AbsCoveredScheme
   ambient_space::AbsCoveredScheme
+  fiber_ambient_space::AbsCoveredScheme
   hypersurface_equation::MPolyRingElem
-  HypersurfaceModel(base_space::AbsCoveredScheme, ambient_space::AbsCoveredScheme, hypersurface_equation::MPolyRingElem) = new(base_space, ambient_space, hypersurface_equation)
+  HypersurfaceModel(base_space::AbsCoveredScheme, ambient_space::AbsCoveredScheme, fiber_ambient_space::AbsCoveredScheme, hypersurface_equation::MPolyRingElem) = new(base_space, ambient_space, fiber_ambient_space, hypersurface_equation)
 end
 
 

--- a/experimental/FTheoryTools/src/types.jl
+++ b/experimental/FTheoryTools/src/types.jl
@@ -45,14 +45,14 @@ end
 end
 
 
-@attributes mutable struct GlobalWeierstrassModel
+@attributes mutable struct WeierstrassModel
   weierstrass_f::MPolyRingElem
   weierstrass_g::MPolyRingElem
   weierstrass_polynomial::MPolyRingElem
   base_space::AbsCoveredScheme
   ambient_space::AbsCoveredScheme
   fiber_ambient_space::AbsCoveredScheme
-  function GlobalWeierstrassModel(weierstrass_f::MPolyRingElem,
+  function WeierstrassModel(weierstrass_f::MPolyRingElem,
                             weierstrass_g::MPolyRingElem,
                             weierstrass_polynomial::MPolyRingElem,
                             base_space::AbsCoveredScheme,
@@ -101,6 +101,6 @@ end
   # do something
 end
 
-@attr HypersurfaceModel function conceptual_parent(gwm::GlobalWeierstrassModel)
+@attr HypersurfaceModel function conceptual_parent(gwm::WeierstrassModel)
   # do something
 end

--- a/experimental/FTheoryTools/test/runtests.jl
+++ b/experimental/FTheoryTools/test/runtests.jl
@@ -60,7 +60,7 @@ t_nm = global_tate_model([a1p * v^1, a2p * v^2, a3p * v^3, a4p * v^4, a6p * v^6]
 # 1: Global Weierstrass models over concrete base space
 #############################################################
 
-w = global_weierstrass_model(sample_toric_variety(); completeness_check = false)
+w = weierstrass_model(sample_toric_variety(); completeness_check = false)
 Base.show(w)
 
 @testset "Attributes of global Weierstrass models over concrete base spaces" begin
@@ -75,7 +75,7 @@ Base.show(w)
 end
 
 @testset "Error messages in global Weierstrass models over concrete base spaces" begin
-  @test_throws ArgumentError global_weierstrass_model(sec_f, sec_g, base; completeness_check = false)
+  @test_throws ArgumentError weierstrass_model(sec_f, sec_g, base; completeness_check = false)
 end
 
 
@@ -84,7 +84,7 @@ end
 #############################################################
 
 auxiliary_base_ring, (f, g, u) = QQ["f", "g", "u"]
-w2 = global_weierstrass_model(f, g, auxiliary_base_ring, 3)
+w2 = weierstrass_model(f, g, auxiliary_base_ring, 3)
 
 @testset "Attributes of global Weierstrass models over generic base space" begin
   @test parent(weierstrass_section_f(w2)) == cox_ring(base_space(w2))
@@ -99,9 +99,9 @@ w2 = global_weierstrass_model(f, g, auxiliary_base_ring, 3)
 end
 
 @testset "Error messages in global Weierstrass models over generic base space" begin
-  @test_throws ArgumentError global_weierstrass_model(f, sec_f, auxiliary_base_ring, 3)
-  @test_throws ArgumentError global_weierstrass_model(f, g, auxiliary_base_ring, 0)
-  @test_throws ArgumentError global_weierstrass_model(f, g, auxiliary_base_ring, 4)
+  @test_throws ArgumentError weierstrass_model(f, sec_f, auxiliary_base_ring, 3)
+  @test_throws ArgumentError weierstrass_model(f, g, auxiliary_base_ring, 0)
+  @test_throws ArgumentError weierstrass_model(f, g, auxiliary_base_ring, 4)
 end
 
 
@@ -123,7 +123,7 @@ Base.show(t)
   @test dim(base_space(t)) == 3
   @test dim(ambient_space(t)) == 5
   @test base_fully_specified(t) == true
-  @test base_fully_specified(t) == base_fully_specified(global_weierstrass_model(t))
+  @test base_fully_specified(t) == base_fully_specified(weierstrass_model(t))
   @test is_smooth(ambient_space(t)) == false
   @test toric_variety(calabi_yau_hypersurface(t)) == underlying_toric_variety(ambient_space(t))
 end
@@ -149,7 +149,7 @@ end
   @test dim(base_space(t_i5_s)) == 3
   @test dim(ambient_space(t_i5_s)) == 5
   @test base_fully_specified(t_i5_s) == false
-  @test base_fully_specified(t_i5_s) == base_fully_specified(global_weierstrass_model(t_i5_s))
+  @test base_fully_specified(t_i5_s) == base_fully_specified(weierstrass_model(t_i5_s))
   @test is_smooth(ambient_space(t_i5_s)) == false
   @test toric_variety(calabi_yau_hypersurface(t_i5_s)) == underlying_toric_variety(ambient_space(t_i5_s))
 end

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -733,30 +733,35 @@ julia> (v1, v2) = normal_toric_varieties_from_star_triangulations(P)
  Normal toric variety
 
 julia> stanley_reisner_ideal(v1)
-ideal(x2*x4)
+ideal(x1*x4)
 
 julia> stanley_reisner_ideal(v2)
-ideal(x1*x3)
+ideal(x2*x3)
 ```
 """
 function normal_toric_varieties_from_star_triangulations(P::Polyhedron; set_attributes::Bool = true)
-    # triangulate the polyhedron
-    trias = star_triangulations(P)
     
-    # Currently, the rays in trias[1]
-    # (a) are encoded as QQMatrix (ZZRingElem expected)
-    # (b) contain the origin as first element (not a rays, so to be removed)
-    rays = trias[1]
-    integral_rays = zeros(ZZ, nrows(rays)-1, ncols(rays))
-    for i in 2:nrows(rays)
-        integral_rays[i-1, 1:ncols(rays)] = [ZZ(c) for c in rays[i, 1:ncols(rays)]]
-    end
+    # find position of origin in the lattices points of the polyhedron P
+    pts = matrix(ZZ, lattice_points(P))
+    zero = [0 for i in 1:ambient_dim(P)]
+    indices = findall(k -> pts[k,:] == matrix(ZZ, [zero]), 1:nrows(pts))
+    @req length(indices) == 1 "Polyhedron must contain origin (exactly once)"
     
-    # trias[2] contains the max_cones as list of lists
+    # change order of lattice points s.t. zero is the first point
+    tmp = pts[1,:]
+    pts[1,:] = pts[indices[1],:]
+    pts[indices[1],:] = tmp
+    
+    # triangulate the points - note that we enforce full, i.e. want all points to be rays
+    trias = star_triangulations(pts; full = true)
+    
+    # rays are all but the zero vector at the first position of pts
+    integral_rays = vcat([pts[k,:] for k in 2:nrows(pts)])
+    
+    # trias contains the max_cones as list of lists
     # (a) needs to be converted to incidence matrix
     # (b) one has to remove origin from list of indices (as removed above)
-    max_cones = trias[2]
-    max_cones = [IncidenceMatrix([[c[i]-1 for i in 2:length(c)] for c in t]) for t in max_cones]
+    max_cones = [IncidenceMatrix([[c[i]-1 for i in 2:length(c)] for c in t]) for t in trias]
     
     # construct the varieties
     return [normal_toric_variety(polyhedral_fan(integral_rays, cones; non_redundant = true), set_attributes = set_attributes) for cones in max_cones]
@@ -800,6 +805,19 @@ julia> charges = [[1, 1, 1]]
 julia> normal_toric_varieties_from_glsm(charges)
 1-element Vector{NormalToricVariety}:
  Normal toric variety
+
+julia> varieties = normal_toric_varieties_from_glsm(matrix(ZZ, [1 2 3 4 6 0; -1 -1 -2 -2 -3 1]))
+1-element Vector{NormalToricVariety}:
+ Normal toric variety
+
+julia> cox_ring(varieties[1])
+Multivariate polynomial ring in 6 variables over QQ graded by 
+  x1 -> [1 -1]
+  x2 -> [2 -1]
+  x3 -> [3 -2]
+  x4 -> [4 -2]
+  x5 -> [6 -3]
+  x6 -> [0 1]
 ```
 
 For convenience, we also support:
@@ -807,19 +825,16 @@ For convenience, we also support:
 - normal_toric_varieties_from_glsm(charges::Vector{Vector{ZZRingElem}})
 """
 function normal_toric_varieties_from_glsm(charges::ZZMatrix; set_attributes::Bool = true)
-    # compute the map from Div_T -> Cl
+    
+    # find the ray generators
     source = free_abelian_group(ncols(charges))
     range = free_abelian_group(nrows(charges))
     map = hom(source, range, transpose(charges))
-    
-    # compute the map char -> Div_T
     ker = kernel(map)
     embedding = snf(ker[1])[2] * ker[2]
-    
-    # identify the rays
     rays = transpose(embedding.map)
     
-    # construct vertices of polyhedron
+    # identify the points to be triangulated
     pts = zeros(QQ, nrows(rays), ncols(charges)-nrows(charges))
     for i in 1:nrows(rays)
         pts[i, :] = [ZZRingElem(c) for c in rays[i, :]]
@@ -827,9 +842,23 @@ function normal_toric_varieties_from_glsm(charges::ZZMatrix; set_attributes::Boo
     zero = [0 for i in 1:ncols(charges)-nrows(charges)]
     pts = vcat(matrix(QQ, transpose(zero)), matrix(QQ, pts))
     
-    # construct polyhedron
-    p = convex_hull(pts)
-    return normal_toric_varieties_from_star_triangulations(p; set_attributes = set_attributes)
+    # construct varieties
+    integral_rays = vcat([pts[k,:] for k in 2:nrows(pts)])
+    max_cones = [IncidenceMatrix([[c[i]-1 for i in 2:length(c)] for c in t]) for t in star_triangulations(pts; full = true)]
+    varieties = [normal_toric_variety(polyhedral_fan(integral_rays, cones; non_redundant = true), set_attributes = set_attributes) for cones in max_cones]
+    
+    # set the map from Div_T -> Cl to the desired matrix
+    for v in varieties
+      G1 = free_abelian_group(ncols(charges))
+      G2 = free_abelian_group(nrows(charges))
+      grading_of_cox_ring = hom(G1, G2, transpose(charges))
+      set_attribute!(v, :map_from_torusinvariant_weil_divisor_group_to_class_group, grading_of_cox_ring)
+      set_attribute!(v, :class_group, G2)
+      set_attribute!(v, :torusinvariant_weil_divisor_group, G1)
+    end
+    
+    # return the varieties
+    return varieties
 end
 normal_toric_varieties_from_glsm(charges::Vector{Vector{T}}; set_attributes::Bool = true) where {T <: IntegerUnion} = normal_toric_varieties_from_glsm(matrix(ZZ, charges); set_attributes = set_attributes)
 

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -94,7 +94,7 @@ function __init__()
     add_assert_scope(:K3Auto)
 
     add_verbose_scope(:GlobalTateModel)
-    add_verbose_scope(:GlobalWeierstrassModel)
+    add_verbose_scope(:WeierstrassModel)
     add_verbose_scope(:HypersurfaceModel)
     
     add_verbosity_scope(:LinearQuotients)

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -95,7 +95,8 @@ function __init__()
 
     add_verbose_scope(:GlobalTateModel)
     add_verbose_scope(:GlobalWeierstrassModel)
-
+    add_verbose_scope(:HypersurfaceModel)
+    
     add_verbosity_scope(:LinearQuotients)
 end
 


### PR DESCRIPTION
This implements the next class of models for FTheoryTools, namely hypersurface models. For now, this works only over a concrete base space. Generalization to arbitary base spaces hopefully soon.

cc @apturner 

(As discussed on slack: The grading of the auxiliary base space currently does not know what divisor classes of the actual base space are reflected. For instance, if we have a Z^2 grading, then the first Z could refer to Kbar and the second to a gauge divisor class W. But it could also be the other way around. Or could even be 2 Kbar - 3 W and 3 Kbar + 4 W. Some places in the code assume that it is always of the form (Kbar, W1, W2, ...) and will form divisor classes [2,0,...] and [3,0,...] for the construction of the auxiliary ambient space. We should think about this/add consistency checks/another field to the types and possibly also reflect this in the literature models...)