### PR TITLE
Move test dependencies from `Project.toml`'s `[extra]` to `test/Project.toml`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,6 @@ cohomCalg_jll = "5558cf25-a90e-53b0-b813-cadaa3ae7ade"
 [compat]
 AbstractAlgebra = "0.29.3"
 AlgebraicSolving = "0.3.0"
-Aqua = "0.6"
 DocStringExtensions = "0.8, 0.9"
 GAP = "0.9.4"
 Hecke = "0.18.9"
@@ -40,13 +39,3 @@ Singular = "0.18.2"
 TOPCOM_jll = "0.17.8"
 cohomCalg_jll = "0.32.0"
 julia = "1.6"
-
-[extras]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
-Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test", "Aqua", "Documenter", "PrettyTables", "Printf"]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,10 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+Aqua = "0.6"


### PR DESCRIPTION
As originally requested by @fingolfin in https://github.com/oscar-system/Oscar.jl/pull/2370#discussion_r1190032346.

For the reasoning behind, please refer to [the Pkg docs](https://pkgdocs.julialang.org/v1.9/creating-packages/#test/Project.toml-file-test-specific-dependencies).
tl;dr: The current way using `[extra]` is pre-julia-1.2 compatible. The proposed way has been introduced in julia-1.2.

Closes #2374.