### PR TITLE
[ToricVarieties] Bugfixes in toric line bundles

### DIFF
--- a/docs/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles.md
@@ -11,10 +11,12 @@ CurrentModule = Oscar
 ### Generic constructors
 
 ```@docs
-toric_line_bundle(v::AbstractNormalToricVariety, class::GrpAbFinGenElem)
-toric_line_bundle(v::AbstractNormalToricVariety, c::Vector{T}) where {T <: IntegerUnion}
+toric_line_bundle(v::AbstractNormalToricVariety, picard_class::GrpAbFinGenElem)
+toric_line_bundle(v::AbstractNormalToricVariety, picard_class::Vector{T}) where {T <: IntegerUnion}
 toric_line_bundle(v::AbstractNormalToricVariety, d::ToricDivisor)
 toric_line_bundle(d::ToricDivisor)
+toric_line_bundle(v::AbstractNormalToricVariety, dc::ToricDivisorClass)
+toric_line_bundle(dc::ToricDivisorClass)
 ```
 
 ### Tensor products
@@ -49,8 +51,9 @@ is_very_ample(l::ToricLineBundle)
 
 ```@docs
 degree(l::ToricLineBundle)
-divisor_class(l::ToricLineBundle)
+picard_class(l::ToricLineBundle)
 toric_divisor(l::ToricLineBundle)
+toric_divisor_class(l::ToricLineBundle)
 toric_variety(l::ToricLineBundle)
 ```
 

--- a/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles/attributes.jl
@@ -3,9 +3,9 @@
 #####################
 
 @doc raw"""
-    divisor_class(l::ToricLineBundle)
+    picard_class(l::ToricLineBundle)
 
-Return the divisor class which defines the toric line bundle `l`.
+Return the class in the Picard group which defines the toric line bundle `l`.
 
 # Examples
 ```jldoctest
@@ -15,13 +15,13 @@ Normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric va
 julia> l = toric_line_bundle(v, [ZZRingElem(2)])
 Toric line bundle on a normal toric variety
 
-julia> divisor_class(l)
+julia> picard_class(l)
 Element of
 GrpAb: Z
 with components [2]
 ```
 """
-divisor_class(l::ToricLineBundle) = l.divisor_class
+picard_class(l::ToricLineBundle) = l.picard_class
 
 
 @doc raw"""
@@ -47,7 +47,7 @@ toric_variety(l::ToricLineBundle) = l.toric_variety
 @doc raw"""
     toric_divisor(l::ToricLineBundle)
 
-Return a divisor corresponding to the toric line bundle `l`.
+Return a toric divisor corresponding to the toric line bundle `l`.
 
 # Examples
 ```jldoctest
@@ -65,7 +65,7 @@ true
 ```
 """
 @attr ToricDivisor function toric_divisor(l::ToricLineBundle)
-    class = divisor_class(l)
+    class = picard_class(l)
     map1 = map_from_torusinvariant_cartier_divisor_group_to_picard_group(toric_variety(l))
     map2 = map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group(toric_variety(l))
     image = map2(preimage(map1, class)).coeff
@@ -74,6 +74,29 @@ true
     set_attribute!(td, :is_cartier, true)
     return td
 end
+
+
+@doc raw"""
+    toric_divisor_class(l::ToricLineBundle)
+
+Return a divisor class in the Class group corresponding to the toric line bundle `l`.
+
+# Examples
+```jldoctest
+julia> v = projective_space(NormalToricVariety, 2)
+Normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
+
+julia> l = toric_line_bundle(v, [ZZRingElem(2)])
+Toric line bundle on a normal toric variety
+
+julia> toric_divisor(l)
+Torus-invariant, cartier, non-prime divisor on a normal toric variety
+
+julia> is_cartier(toric_divisor(l))
+true
+```
+"""
+@attr ToricDivisorClass toric_divisor_class(l::ToricLineBundle) = toric_divisor_class(toric_divisor(l))
 
 
 @doc raw"""
@@ -177,7 +200,7 @@ julia> basis_of_global_sections(l)
             return MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}[]
         end
     end
-    hc = homogeneous_component(cox_ring(toric_variety(l)), divisor_class(l))
+    hc = homogeneous_component(cox_ring(toric_variety(l)), divisor_class(toric_divisor_class(l)))
     generators = gens(hc[1])
     return MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}[hc[2](x) for x in generators]
 end

--- a/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles/constructors.jl
@@ -6,10 +6,10 @@ abstract type ToricCoherentSheaf end
 
 @attributes mutable struct ToricLineBundle <: ToricCoherentSheaf
     toric_variety::AbstractNormalToricVariety
-    divisor_class::GrpAbFinGenElem
-    function ToricLineBundle(toric_variety::AbstractNormalToricVariety, class::GrpAbFinGenElem)
-        @req parent(class) === picard_group(toric_variety) "The class must belong to the Picard group of the toric variety"
-        return new(toric_variety, class)
+    picard_class::GrpAbFinGenElem
+    function ToricLineBundle(toric_variety::AbstractNormalToricVariety, picard_class::GrpAbFinGenElem)
+        @req parent(picard_class) === picard_group(toric_variety) "The class must belong to the Picard group of the toric variety"
+        return new(toric_variety, picard_class)
     end
 end
 
@@ -19,9 +19,10 @@ end
 ########################
 
 @doc raw"""
-    toric_line_bundle(v::AbstractNormalToricVariety, class::GrpAbFinGenElem)
+    toric_line_bundle(v::AbstractNormalToricVariety, picard_class::GrpAbFinGenElem)
 
-Construct the line bundle on the abstract normal toric variety `v` with class `c`.
+Construct the line bundle on the abstract normal toric variety with given class
+in the Picard group of the toric variety in question.
 
 # Examples
 ```jldoctest
@@ -32,13 +33,14 @@ julia> l = toric_line_bundle(P2, picard_group(P2)([1]))
 Toric line bundle on a normal toric variety
 ```
 """
-toric_line_bundle(v::AbstractNormalToricVariety, class::GrpAbFinGenElem) = ToricLineBundle(v, class)
+toric_line_bundle(v::AbstractNormalToricVariety, picard_class::GrpAbFinGenElem) = ToricLineBundle(v, picard_class)
 
 
 @doc raw"""
-    toric_line_bundle(v::AbstractNormalToricVariety, c::Vector{T}) where {T <: IntegerUnion}
+    toric_line_bundle(v::AbstractNormalToricVariety, picard_class::Vector{T}) where {T <: IntegerUnion}
 
-Construct the line bundle on the abstract normal toric variety `v` with class `c`.
+Construct the line bundle on the abstract normal toric variety `v` with class `c`
+in the Picard group of `v`.
 
 # Examples
 ```jldoctest
@@ -49,9 +51,8 @@ julia> l = toric_line_bundle(v, [ZZRingElem(2)])
 Toric line bundle on a normal toric variety
 ```
 """
-function toric_line_bundle(v::AbstractNormalToricVariety, input_class::Vector{T}) where {T <: IntegerUnion}
-    class = picard_group(v)(input_class)
-    return ToricLineBundle(v, class)
+function toric_line_bundle(v::AbstractNormalToricVariety, picard_class::Vector{T}) where {T <: IntegerUnion}
+    return ToricLineBundle(v, picard_group(v)(picard_class))
 end
 
 
@@ -76,8 +77,10 @@ Toric line bundle on a normal toric variety
 function toric_line_bundle(v::AbstractNormalToricVariety, d::ToricDivisor)
     @req is_cartier(d) "The toric divisor must be Cartier to define a toric line bundle"
     f = map_from_torusinvariant_cartier_divisor_group_to_picard_group(v)
-    class = f(sum(coefficients(d)[i] * gens(domain(f))[i] for i in 1:length(gens(domain(f)))))
-    l = ToricLineBundle(v, class)
+    g = map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group(v)
+    cartier_d = preimage(g, sum(coefficients(d) .* gens(torusinvariant_weil_divisor_group(v))))
+    picard_class = f(cartier_d)
+    l = ToricLineBundle(v, picard_class)
     set_attribute!(l, :toric_divisor, d)
     return l
 end
@@ -100,6 +103,62 @@ Toric line bundle on a normal toric variety
 """
 toric_line_bundle(d::ToricDivisor) = toric_line_bundle(toric_variety(d), d)
 
+@doc raw"""
+    toric_line_bundle(v::AbstractNormalToricVariety, dc::ToricDivisorClass)
+
+Construct the toric variety associated to a divisor class in the class group
+of a toric variety.
+
+# Examples
+```jldoctest
+julia> v = projective_space(NormalToricVariety, 2)
+Normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
+
+julia> d = toric_divisor(v, [1, 2, 3])
+Torus-invariant, non-prime divisor on a normal toric variety
+
+julia> dc = toric_divisor_class(d)
+Divisor class on a normal toric variety
+
+julia> l = toric_line_bundle(v, dc)
+Toric line bundle on a normal toric variety
+```
+"""
+function toric_line_bundle(v::AbstractNormalToricVariety, dc::ToricDivisorClass)
+  f = map_from_torusinvariant_weil_divisor_group_to_class_group(v)
+  g = map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group(v)
+  h = map_from_torusinvariant_cartier_divisor_group_to_picard_group(v)
+  cartier_class = preimage(g*f, divisor_class(dc))
+  td = toric_divisor(v, vec(g(cartier_class).coeff))
+  l = ToricLineBundle(v, h(cartier_class))
+  set_attribute!(td, :is_cartier, true)
+  set_attribute!(l, :toric_divisor, td)
+  return l
+end
+
+@doc raw"""
+    toric_line_bundle(dc::ToricDivisorClass)
+
+Construct the toric variety associated to a divisor class in the class group
+of a toric variety.
+
+# Examples
+```jldoctest
+julia> v = projective_space(NormalToricVariety, 2)
+Normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
+
+julia> d = toric_divisor(v, [1, 2, 3])
+Torus-invariant, non-prime divisor on a normal toric variety
+
+julia> dc = toric_divisor_class(d)
+Divisor class on a normal toric variety
+
+julia> l = toric_line_bundle(dc)
+Toric line bundle on a normal toric variety
+```
+"""
+toric_line_bundle(dc::ToricDivisorClass) = toric_line_bundle(toric_variety(dc), dc)
+
 
 ########################
 # 4: Tensor products
@@ -107,10 +166,10 @@ toric_line_bundle(d::ToricDivisor) = toric_line_bundle(toric_variety(d), d)
 
 function Base.:*(l1::ToricLineBundle, l2::ToricLineBundle)
     @req toric_variety(l1) === toric_variety(l2) "The line bundles must be defined on the same toric variety"
-    return toric_line_bundle(toric_variety(l1), divisor_class(l1) + divisor_class(l2))
+    return toric_line_bundle(toric_variety(l1), picard_class(l1) + picard_class(l2))
 end
-Base.:inv(l::ToricLineBundle) = toric_line_bundle(toric_variety(l), (-1)*divisor_class(l))
-Base.:^(l::ToricLineBundle, p::ZZRingElem) = toric_line_bundle(toric_variety(l), p * divisor_class(l))
+Base.:inv(l::ToricLineBundle) = toric_line_bundle(toric_variety(l), (-1)*picard_class(l))
+Base.:^(l::ToricLineBundle, p::ZZRingElem) = toric_line_bundle(toric_variety(l), p * picard_class(l))
 Base.:^(l::ToricLineBundle, p::Int) = l^ZZRingElem(p)
 
 
@@ -119,7 +178,7 @@ Base.:^(l::ToricLineBundle, p::Int) = l^ZZRingElem(p)
 ########################
 
 function Base.:(==)(l1::ToricLineBundle, l2::ToricLineBundle)
-    return toric_variety(l1) === toric_variety(l2) && iszero(divisor_class(l1) - divisor_class(l2))
+    return toric_variety(l1) === toric_variety(l2) && picard_class(l1) == picard_class(l2)
 end
 
 

--- a/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles/special_attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles/special_attributes.jl
@@ -35,7 +35,7 @@ julia> anticanonical_bundle(v)
 Toric line bundle on a normal toric variety
 ```
 """
-@attr ToricLineBundle anticanonical_bundle(v::AbstractNormalToricVariety) = prod(toric_line_bundle(v, d) for d in torusinvariant_prime_divisors(v))
+@attr ToricLineBundle anticanonical_bundle(v::AbstractNormalToricVariety) = toric_line_bundle(v, anticanonical_divisor(v))
 
 
 @doc raw"""

--- a/src/AlgebraicGeometry/ToricVarieties/cohomCalg/VanishingSets/methods.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/cohomCalg/VanishingSets/methods.jl
@@ -37,7 +37,7 @@ function contains(tvs::ToricVanishingSet, l::ToricLineBundle)
     if toric_variety(l) !== toric_variety(tvs)
         return false
     end
-    class = divisor_class(l).coeff
+    class = divisor_class(toric_divisor_class(l)).coeff
     class = [class[1, i] for i in 1:ncols(class)]
     for p in polyhedra(tvs)
         if class in p

--- a/src/AlgebraicGeometry/ToricVarieties/cohomCalg/special_attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/cohomCalg/special_attributes.jl
@@ -120,7 +120,7 @@ function all_cohomologies(l::ToricLineBundle)
         # -> Hooray! We found the line bundle cohomologies in question.
         
         # obtain the command string
-        class = vec([ZZRingElem(x) for x in divisor_class(l).coeff])
+        class = vec([ZZRingElem(x) for x in divisor_class(toric_divisor_class(l)).coeff])
         command = command_string(v, class)
         
         # execute cohomCalg

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1055,6 +1055,7 @@ export permutation_group
 export permutation_matrix
 export permutation_of_terms
 export permuted
+export picard_class
 export picard_group
 export platonic_solid
 export point_coordinates

--- a/test/AlgebraicGeometry/ToricVarieties/line_bundle_cohomologies.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/line_bundle_cohomologies.jl
@@ -7,9 +7,14 @@ using Test
     dP3 = del_pezzo_surface(NormalToricVariety, 3; set_attributes)
     F5 = hirzebruch_surface(NormalToricVariety, 5; set_attributes)
     
+    ray_generators = [[1, 0, 0,-2,-3], [0, 1, 0,-2,-3], [0, 0, 1,-2,-3], [-1,-1,-1,-2,-3], [0, 0, 0, 1, 0], [0, 0, 0, 0, 1], [0, 0, 0,-2,-3]]
+    max_cones = [[1, 2, 3, 5, 6], [1, 2, 3, 5, 7], [1, 2, 3, 6, 7], [2, 3, 4, 5, 6], [2, 3, 4, 5, 7], [2, 3, 4, 6, 7], [1, 3, 4, 5, 6], [1, 3, 4, 5, 7], [1, 3, 4, 6, 7], [1, 2, 4, 5, 6], [1, 2, 4, 5, 7], [1, 2, 4, 6, 7]]
+    weierstrass_over_p3 = normal_toric_variety(ray_generators, max_cones; non_redundant = true)
+    
     l = toric_line_bundle(dP3, [1, 2, 3, 4])
     l2 = toric_line_bundle(divisor_of_character(F5, [1, 2]))
     l3 = toric_line_bundle(P2, [1])
+    l4 = anticanonical_bundle(weierstrass_over_p3)
     
     vs = vanishing_sets(dP3)
     vs2 = vanishing_sets(P2)
@@ -62,5 +67,10 @@ using Test
         @test length(basis_of_global_sections(canonical_bundle(dP3))) == 0
         @test length(basis_of_global_sections_via_rational_functions(l)) == 0
         @test length(basis_of_global_sections(l)) == 0
+    end
+    
+    @testset "Sections of anticanonical bundle" begin
+        @test all_cohomologies(l4) == [4551, 0, 0, 0, 0, 0]
+        @test length(basis_of_global_sections(l4)) == 4551
     end
 end

--- a/test/AlgebraicGeometry/ToricVarieties/line_bundles.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/line_bundles.jl
@@ -27,7 +27,7 @@ using Test
         @test degree(l) == -6
         @test degree(l^(-1)) == 6
         @test degree(l*l) == -12
-        @test divisor_class(l).coeff == AbstractAlgebra.matrix(ZZ, [1 2 3 4])
+        @test picard_class(l).coeff == AbstractAlgebra.matrix(ZZ, [1 2 3 4])
         @test dim(toric_variety(l)) == 2
     end
     


### PR DESCRIPTION
While working on `FTheoryTools`, I wanted to work with the anticanonical bundle of a particular toric space, so I tried:

```julia
v = underlying_toric_variety(ambient_space(global_weierstrass_model_over_projective_space(3)))
candidate1 = prod(toric_line_bundle(v, d) for d in torusinvariant_prime_divisors(v))
```

To my surprise, this method did not succeed because one torusinvariant prime divisor (actually, there are two in this case) are not Cartier. Indeed, here is the current implementation is as follows:
```julia
@attr ToricLineBundle anticanonical_bundle(v::AbstractNormalToricVariety) = prod(toric_line_bundle(v, d) for d in torusinvariant_prime_divisors(v))
```
So this only works, if every torusinvariant prime divisor is Cartier. But this is not a given.

Rather, by CLS11 it is guaranteed that the sum of all torusinvariant prime divisors is Cartier. And so, this implementation should be changed as follows:

```julia
@attr ToricLineBundle anticanonical_bundle(v::AbstractNormalToricVariety) = toric_line_bundle(v, anticanonical_divisor_class(v))
```
Sadly, this did not work because no method was implemented that would allow to define a toric variety by a divisor class (in the class group).

The third approach that I tried was then the following:
```julia
candidate3 = toric_line_bundle(v, anticanonical_divisor(v))
```
This finally managed to construct the bundle. It is worth noting that the anticanonical divisor in this case has degrees [0,6] and so the global sections are all monomials with this multidegree in the cox ring:
```julia
julia> cox_ring(v)
Multivariate polynomial ring in 7 variables over QQ graded by 
  x1 -> [1 0]
  x2 -> [1 0]
  x3 -> [1 0]
  x4 -> [1 0]
  x -> [0 2]
  y -> [0 3]
  z -> [-4 1]
```
Clearly, there are many such monomials (x^3, y^2, ...). But still...
```julia
julia> all_cohomologies(candidate3)
  6-element Vector{ZZRingElem}:
   0
   0
   0
   35101
   0
   0
```
The reason for this last failure is that the following distinct notions were mixed up in parts of the code:
1. The divisor class in the class group of the Cartier toric divisor that defines the line bundle in question.
2. The element in the Picard group that corresponds to the line bundle.

Specifically, in the case at hand the Picard group is one to one to the toric divisor classes with multidegrees `[a, 6b]`. In particular, the anticanonical bundle is associated to the anticanonical divisor `[0,6]`. Indeed, the image of the mapping of Cartier toric divisors (isomorphic to Z^7 here) to the Picard group (here isomorphic to Z^2) has an image embedding given by the matrix
```julia
[1 0]
[0 6]
```
We use the method `restrict_codomain` to restrict this mapping to its image. This "chooses" to represent the image of the anticanonical bundle of `v` to be the element `[0, 1]` in the Picard group.

In summary, I stumbled upon a combination of the following three issues:
1. Wrong implementation of the anticanonical bundle.
2. Missing implementation to create a toric line bundle from a divisor class (in the class group).
4. Mixing up of elements in the class group and in the Picard group.

This PR aims to fix all of this.