### PR TITLE
Do not mess with documentation of upstream packages

### DIFF
--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -171,9 +171,9 @@ function doit(
 
   cd(joinpath(Oscar.oscardir, "docs")) do
     DocMeta.setdocmeta!(Oscar, :DocTestSetup, :(using Oscar; Oscar.AbstractAlgebra.set_current_module(@__MODULE__)); recursive=true)
-    DocMeta.setdocmeta!(Oscar.Hecke, :DocTestSetup, :(using Hecke; import AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__)); recursive=true)
-    DocMeta.setdocmeta!(Oscar.AbstractAlgebra, :DocTestSetup, :(using AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__)); recursive=true)
-    DocMeta.setdocmeta!(Oscar.Nemo, :DocTestSetup, :(using Nemo; import AbstractAlgebra; AbstractAlgebra.set_current_module(@__MODULE__)); recursive=true)
+    DocMeta.setdocmeta!(Oscar.Hecke, :DocTestSetup, :(using Hecke); recursive=true)
+    DocMeta.setdocmeta!(Oscar.AbstractAlgebra, :DocTestSetup, :(using AbstractAlgebra); recursive=true)
+    DocMeta.setdocmeta!(Oscar.Nemo, :DocTestSetup, :(using Nemo); recursive=true)
 
     makedocs(
       bib;


### PR DESCRIPTION
The function `Oscar.build_doc(;doctest = :fix)` runs the doctests also for all packages listed under `makedocs(..., modules = [...])`. But the documentation/docstrings of those packages does not use the magical printing, so those doctests are doomed to fail.

Edit: We do not see this during CI, because doctests are run with `doctest(Oscar)`.