### PR TITLE
Tweaks for the documentation build

### DIFF
--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -170,10 +170,14 @@ function doit(
   end
 
   cd(joinpath(Oscar.oscardir, "docs")) do
-    DocMeta.setdocmeta!(Oscar, :DocTestSetup, :(using Oscar; Oscar.AbstractAlgebra.set_current_module(@__MODULE__)); recursive=true)
+    DocMeta.setdocmeta!(Oscar, :DocTestSetup, Oscar.doctestsetup(); recursive=true)
     DocMeta.setdocmeta!(Oscar.Hecke, :DocTestSetup, :(using Hecke); recursive=true)
     DocMeta.setdocmeta!(Oscar.AbstractAlgebra, :DocTestSetup, :(using AbstractAlgebra); recursive=true)
     DocMeta.setdocmeta!(Oscar.Nemo, :DocTestSetup, :(using Nemo); recursive=true)
+
+    if doctest !== false
+      Documenter.doctest(Oscar, fix = doctest === :fix)
+    end
 
     makedocs(
       bib;
@@ -181,7 +185,7 @@ function doit(
       sitename="Oscar.jl",
       modules=[Oscar, Oscar.Hecke, Oscar.Nemo, Oscar.AbstractAlgebra, Oscar.Singular],
       clean=true,
-      doctest=doctest,
+      doctest=false,
       strict=strict,
       checkdocs=:none,
       pages=doc,

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -6,6 +6,16 @@
 ###############################################################################
 ###############################################################################
 
+################################################################################
+#
+#  DocTestSetup
+#
+################################################################################
+
+# Oscar needs some complicated setup to get the printing right. This provides a
+# helper function to set this up consistently.
+doctestsetup() = :(using Oscar; Oscar.AbstractAlgebra.set_current_module(@__MODULE__))
+
 # use tempdir by default to ensure a clean manifest (and avoid modifying the project)
 function doc_init(;path=mktempdir())
   global docsproject = path


### PR DESCRIPTION
- Introduce `doctestsetup()`.
- Do not run upstream doctests in `build_doc`.
