### PR TITLE
LieAlgebras: Add docs

### DIFF
--- a/experimental/LieAlgebras/docs/doc.main
+++ b/experimental/LieAlgebras/docs/doc.main
@@ -1,2 +1,7 @@
 [
+   "Lie Algebras" => [
+      "introduction.md",
+      "lie_algebras.md",
+      "modules.md",
+   ],
 ]

--- a/experimental/LieAlgebras/docs/src/introduction.md
+++ b/experimental/LieAlgebras/docs/src/introduction.md
@@ -1,0 +1,20 @@
+```@meta
+CurrentModule = Oscar
+```
+
+# Introduction
+
+This project aims to provide functionality for Lie algebras and their representations.
+
+## Status
+
+This part of OSCAR is in an experimental state; please see [Adding new projects to experimental](@ref) for what this means.
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Lars Göttgens](https://lgoe.li/)
+
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).

--- a/experimental/LieAlgebras/docs/src/introduction.md
+++ b/experimental/LieAlgebras/docs/src/introduction.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 # Introduction

--- a/experimental/LieAlgebras/docs/src/lie_algebras.md
+++ b/experimental/LieAlgebras/docs/src/lie_algebras.md
@@ -4,9 +4,12 @@ CurrentModule = Oscar
 
 # Lie algebras
 
-Lie algebras in OSCAR are always finite dimensional, and represented by two different types, 
-namely `LinearLieAlgebra` and `AbstractLieAlgebra`, depending on whether a matrix representation is available or not.
-Both types are subtypes of `LieAlgebra`. Similar to other types in OSCAR, each Lie algebra type has a corresponding element type.
+Lie algebras in OSCAR are always finite dimensional, and represented by two different types,
+namely `LinearLieAlgebra{C}` and `AbstractLieAlgebra{C}`, depending on whether a matrix
+representation is available or not.
+Both types are subtypes of `LieAlgebra{C}`. Similar to other types in OSCAR, each Lie algebra
+type has a corresponding element type.
+The type parameter `C` is the element type of the coefficient ring. 
 
 ```@docs
 zero(::LieAlgebra{C}) where {C<:RingElement}
@@ -17,7 +20,7 @@ basis(::LieAlgebra{C}, ::Int) where {C<:RingElement}
 coefficients(::LieAlgebraElem{C}) where {C<:RingElement}
 coeff(::LieAlgebraElem{C}, ::Int) where {C<:RingElement}
 getindex(::LieAlgebraElem{C}, ::Int) where {C<:RingElement}
-symbols(_::LieAlgebra{C}) where {C<:RingElement}
+symbols(::LieAlgebra{C}) where {C<:RingElement}
 ```
 
 ## Special functions for `LinearLieAlgebra`s
@@ -26,15 +29,12 @@ symbols(_::LieAlgebra{C}) where {C<:RingElement}
 matrix_repr_basis(::LinearLieAlgebra{C}) where {C<:RingElement}
 matrix_repr_basis(::LinearLieAlgebra{C}, ::Int) where {C<:RingElement}
 matrix_repr(::LinearLieAlgebraElem{C}) where {C<:RingElement}
-```
-```
 (::LinearLieAlgebra{C})(::MatElem{C}) where {C<:RingElement}
-
 ```
 
 ## Element constructors
 
-```
+```@docs
 (::LieAlgebra{C})() where {C<:RingElement}
 (::LieAlgebra{C})(::Vector{C}) where {C<:RingElement}
 (::LieAlgebra{C})(::Vector{Int}) where {C<:RingElement}
@@ -44,7 +44,7 @@ matrix_repr(::LinearLieAlgebraElem{C}) where {C<:RingElement}
 ```
 
 ## Arithmetics
-The usual arithmetics, e.g. `+`, `-`, and `*` are defined for `LieAlgebraElem`s.
+The usual arithmetics, e.g. `+`, `-`, and `*`, are defined for `LieAlgebraElem`s.
 
 !!! warning
     Please note that `*` refers to the Lie bracket and is thus not associative.

--- a/experimental/LieAlgebras/docs/src/lie_algebras.md
+++ b/experimental/LieAlgebras/docs/src/lie_algebras.md
@@ -32,19 +32,26 @@ symbols(::LieAlgebra{C}) where {C<:RingElement}
 matrix_repr_basis(::LinearLieAlgebra{C}) where {C<:RingElement}
 matrix_repr_basis(::LinearLieAlgebra{C}, ::Int) where {C<:RingElement}
 matrix_repr(::LinearLieAlgebraElem{C}) where {C<:RingElement}
-(::LinearLieAlgebra{C})(::MatElem{C}) where {C<:RingElement}
 ```
 
 ## Element constructors
 
-```@docs
-(::LieAlgebra{C})() where {C<:RingElement}
-(::LieAlgebra{C})(::Vector{C}) where {C<:RingElement}
-(::LieAlgebra{C})(::Vector{Int}) where {C<:RingElement}
-(::LieAlgebra{C})(::MatElem{C}) where {C<:RingElement}
-(::LieAlgebra{C})(::SRow{C}) where {C<:RingElement}
-(::LieAlgebra{C})(::LieAlgebraElem{C}) where {C<:RingElement}
-```
+`(L::LieAlgebra{C})()` returns the zero element of the Lie algebra `L`.
+
+`(L::LieAlgebra{C})(x::LieAlgebraElem{C})` returns `x` if `x` is an element of `L`,
+and fails otherwise.
+
+`(L::LieAlgebra{C})(v)` constructs the element of `L` with coefficient vector `v`.
+`v` can be of type `Vector{C}`, `Vector{Int}`, `SRow{C}`,
+or `MatElem{C}` (of size $1 \times \dim(L)$).
+
+If `L` is a `LinearLieAlgebra` of `dim(L) > 1`, the call
+`(L::LinearLieAlgebra{C})(m::MatElem{C})` returns the Lie algebra element whose
+matrix representation corresponds to `m`.
+This requires `m` to be a square matrix of size `n > 1` (the dimension of `L`), and
+to lie in the Lie algebra `L` (i.e. to be in the span of `basis(L)`).
+The case of `m` being a $1 \times \dim(L)$ matrix still works as explained above.
+
 
 ## Arithmetics
 The usual arithmetics, e.g. `+`, `-`, and `*`, are defined for `LieAlgebraElem`s.

--- a/experimental/LieAlgebras/docs/src/lie_algebras.md
+++ b/experimental/LieAlgebras/docs/src/lie_algebras.md
@@ -1,0 +1,62 @@
+```@meta
+CurrentModule = Oscar
+```
+
+# Lie algebras
+
+Lie algebras in OSCAR are always finite dimensional, and represented by two different types, 
+namely `LinearLieAlgebra` and `AbstractLieAlgebra`, depending on whether a matrix representation is available or not.
+Both types are subtypes of `LieAlgebra`. Similar to other types in OSCAR, each Lie algebra type has a corresponding element type.
+
+```@docs
+zero(::LieAlgebra{C}) where {C <: RingElement}
+iszero(::LieAlgebraElem{C}) where {C <: RingElement}
+dim(::LieAlgebra{C}) where {C <: RingElement}
+basis(::LieAlgebra{C}) where {C <: RingElement}
+basis(::LieAlgebra{C}, ::Int) where {C <: RingElement}
+coefficients(::LieAlgebraElem{C}) where {C <: RingElement}
+coeff(::LieAlgebraElem{C}, ::Int) where {C <: RingElement}
+getindex(::LieAlgebraElem{C}, ::Int) where {C <: RingElement}
+```
+
+## Special functions for `LinearLieAlgebra`s
+
+```@docs
+matrix_repr_basis(::LinearLieAlgebra{C}) where {C <: RingElement}
+matrix_repr_basis(::LinearLieAlgebra{C}, ::Int) where {C <: RingElement}
+matrix_repr(::LinearLieAlgebraElem{C}) where {C <: RingElement}
+```
+```
+(::LinearLieAlgebra{C})(::MatElem{C}) where {C <: RingElement}
+
+```
+
+## Element constructors
+
+```
+(::LieAlgebra{C})() where {C<:RingElement}
+(::LieAlgebra{C})(::Vector{C}) where {C<:RingElement}
+(::LieAlgebra{C})(::Vector{Int}) where {C<:RingElement}
+(::LieAlgebra{C})(::MatElem{C}) where {C<:RingElement}
+(::LieAlgebra{C})(::LieAlgebraElem{C}) where {C<:RingElement}
+```
+
+## Arithmetics
+The usual arithmetics, e.g. `+`, `-`, and `*` are defined for `LieAlgebraElem`s.
+
+!!! warning
+    Please note that `*` refers to the Lie bracket and is thus not associative.
+
+## Lie algebra constructors
+
+```@docs
+lie_algebra
+```
+
+## Classical Lie algebras
+
+```@docs
+general_linear_lie_algebra(R::Ring, n::Int)
+special_linear_lie_algebra(R::Ring, n::Int)
+special_orthogonal_lie_algebra(R::Ring, n::Int)
+```

--- a/experimental/LieAlgebras/docs/src/lie_algebras.md
+++ b/experimental/LieAlgebras/docs/src/lie_algebras.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 # Lie algebras

--- a/experimental/LieAlgebras/docs/src/lie_algebras.md
+++ b/experimental/LieAlgebras/docs/src/lie_algebras.md
@@ -4,7 +4,7 @@ CurrentModule = Oscar
 
 # Lie algebras
 
-Lie algebras in OSCAR are always finite dimensional, and represented by two different types,
+Lie algebras in OSCAR are currently always finite dimensional, and represented by two different types,
 namely `LinearLieAlgebra{C}` and `AbstractLieAlgebra{C}`, depending on whether a matrix
 representation is available or not.
 Both types are subtypes of `LieAlgebra{C}`. Similar to other types in OSCAR, each Lie algebra

--- a/experimental/LieAlgebras/docs/src/lie_algebras.md
+++ b/experimental/LieAlgebras/docs/src/lie_algebras.md
@@ -9,25 +9,26 @@ namely `LinearLieAlgebra` and `AbstractLieAlgebra`, depending on whether a matri
 Both types are subtypes of `LieAlgebra`. Similar to other types in OSCAR, each Lie algebra type has a corresponding element type.
 
 ```@docs
-zero(::LieAlgebra{C}) where {C <: RingElement}
-iszero(::LieAlgebraElem{C}) where {C <: RingElement}
-dim(::LieAlgebra{C}) where {C <: RingElement}
-basis(::LieAlgebra{C}) where {C <: RingElement}
-basis(::LieAlgebra{C}, ::Int) where {C <: RingElement}
-coefficients(::LieAlgebraElem{C}) where {C <: RingElement}
-coeff(::LieAlgebraElem{C}, ::Int) where {C <: RingElement}
-getindex(::LieAlgebraElem{C}, ::Int) where {C <: RingElement}
+zero(::LieAlgebra{C}) where {C<:RingElement}
+iszero(::LieAlgebraElem{C}) where {C<:RingElement}
+dim(::LieAlgebra{C}) where {C<:RingElement}
+basis(::LieAlgebra{C}) where {C<:RingElement}
+basis(::LieAlgebra{C}, ::Int) where {C<:RingElement}
+coefficients(::LieAlgebraElem{C}) where {C<:RingElement}
+coeff(::LieAlgebraElem{C}, ::Int) where {C<:RingElement}
+getindex(::LieAlgebraElem{C}, ::Int) where {C<:RingElement}
+symbols(_::LieAlgebra{C}) where {C<:RingElement}
 ```
 
 ## Special functions for `LinearLieAlgebra`s
 
 ```@docs
-matrix_repr_basis(::LinearLieAlgebra{C}) where {C <: RingElement}
-matrix_repr_basis(::LinearLieAlgebra{C}, ::Int) where {C <: RingElement}
-matrix_repr(::LinearLieAlgebraElem{C}) where {C <: RingElement}
+matrix_repr_basis(::LinearLieAlgebra{C}) where {C<:RingElement}
+matrix_repr_basis(::LinearLieAlgebra{C}, ::Int) where {C<:RingElement}
+matrix_repr(::LinearLieAlgebraElem{C}) where {C<:RingElement}
 ```
 ```
-(::LinearLieAlgebra{C})(::MatElem{C}) where {C <: RingElement}
+(::LinearLieAlgebra{C})(::MatElem{C}) where {C<:RingElement}
 
 ```
 
@@ -38,6 +39,7 @@ matrix_repr(::LinearLieAlgebraElem{C}) where {C <: RingElement}
 (::LieAlgebra{C})(::Vector{C}) where {C<:RingElement}
 (::LieAlgebra{C})(::Vector{Int}) where {C<:RingElement}
 (::LieAlgebra{C})(::MatElem{C}) where {C<:RingElement}
+(::LieAlgebra{C})(::SRow{C}) where {C<:RingElement}
 (::LieAlgebra{C})(::LieAlgebraElem{C}) where {C<:RingElement}
 ```
 
@@ -60,3 +62,8 @@ general_linear_lie_algebra(R::Ring, n::Int)
 special_linear_lie_algebra(R::Ring, n::Int)
 special_orthogonal_lie_algebra(R::Ring, n::Int)
 ```
+
+## Relation to GAP Lie algebras
+
+Using `Oscar.iso_oscar_gap(L)`, one can get an isomorphism from the OSCAR Lie algebra `L`
+to some isomorphic GAP Lie algebra. For more details, please refer to [`iso_oscar_gap`](@ref).

--- a/experimental/LieAlgebras/docs/src/modules.md
+++ b/experimental/LieAlgebras/docs/src/modules.md
@@ -1,0 +1,8 @@
+```@meta
+CurrentModule = Oscar
+```
+
+# Lie algebra modules
+
+```@docs
+```

--- a/experimental/LieAlgebras/docs/src/modules.md
+++ b/experimental/LieAlgebras/docs/src/modules.md
@@ -4,5 +4,68 @@ CurrentModule = Oscar
 
 # Lie algebra modules
 
+Lie algebra modules in OSCAR are always finite dimensional and represented by the type
+`LieAlgebraModule{C}`. Similar to other types in OSCAR, there is the corresponding
+element type `LieAlgebraModuleElem{C}`.
+The type parameter `C` is the element type of the coefficient ring.
+
 ```@docs
+base_lie_algebra(V::LieAlgebraModule{C}) where {C<:RingElement}
+zero(::LieAlgebraModule{C}) where {C<:RingElement}
+iszero(::LieAlgebraModuleElem{C}) where {C<:RingElement}
+dim(::LieAlgebraModule{C}) where {C<:RingElement}
+basis(::LieAlgebraModule{C}) where {C<:RingElement}
+basis(::LieAlgebraModule{C}, ::Int) where {C<:RingElement}
+coefficients(::LieAlgebraModuleElem{C}) where {C<:RingElement}
+coeff(::LieAlgebraModuleElem{C}, ::Int) where {C<:RingElement}
+getindex(::LieAlgebraModuleElem{C}, ::Int) where {C<:RingElement}
+symbols(::LieAlgebraModule{C}) where {C<:RingElement}
+```
+
+## Element constructors
+
+```@docs
+(::LieAlgebraModule{C})() where {C<:RingElement}
+(::LieAlgebraModule{C})(::Vector{C}) where {C<:RingElement}
+(::LieAlgebraModule{C})(::Vector{Int}) where {C<:RingElement}
+(::LieAlgebraModule{C})(::MatElem{C}) where {C<:RingElement}
+(::LieAlgebraModule{C})(::SRow{C}) where {C<:RingElement}
+(::LieAlgebraModule{C})(::LieAlgebraModuleElem{C}) where {C<:RingElement}
+(::LieAlgebraModule{C})(::Vector{T}) where {T<:LieAlgebraModuleElem{C}} where {C<:RingElement}
+```
+
+## Arithmetics
+The usual arithmetics, e.g. `+`, `-`, and `*` (scalar multiplication), are defined for `LieAlgebraModuleElem`s.
+
+The module action is defined as `*`.
+```@docs
+*(x::LieAlgebraElem{C}, v::LieAlgebraModuleElem{C}) where {C<:RingElement}
+```
+
+## Module constructors
+
+```@docs
+standard_module(::LinearLieAlgebra{C}) where {C<:RingElement}
+dual(::LieAlgebraModule{C}) where {C<:RingElement}
+direct_sum(::LieAlgebraModule{C}, ::LieAlgebraModule{C}) where {C<:RingElement}
+tensor_product(::LieAlgebraModule{C}, ::LieAlgebraModule{C}) where {C<:RingElement}
+exterior_power(::LieAlgebraModule{C}, ::Int) where {C<:RingElement}
+symmetric_power(::LieAlgebraModule{C}, ::Int) where {C<:RingElement}
+tensor_power(::LieAlgebraModule{C}, ::Int) where {C<:RingElement}
+abstract_module(::LieAlgebra{C}, ::Int, ::Vector{<:MatElem{C}}, ::Vector{<:VarName}; ::Bool) where {C<:RingElement}
+abstract_module(::LieAlgebra{C}, ::Int, ::Matrix{SRow{C}}, ::Vector{<:VarName}; ::Bool) where {C<:RingElement}
+```
+
+# Type-dependent getters
+
+```@docs
+is_standard_module(::LieAlgebraModule{C}) where {C<:RingElement}
+is_dual(::LieAlgebraModule{C}) where {C<:RingElement}
+is_direct_sum(::LieAlgebraModule{C}) where {C<:RingElement}
+is_tensor_product(::LieAlgebraModule{C}) where {C<:RingElement}
+is_exterior_power(::LieAlgebraModule{C}) where {C<:RingElement}
+is_symmetric_power(::LieAlgebraModule{C}) where {C<:RingElement}
+is_tensor_power(::LieAlgebraModule{C}) where {C<:RingElement}
+base_module(::LieAlgebraModule{C}) where {C<:RingElement}
+base_modules(::LieAlgebraModule{C}) where {C<:RingElement}
 ```

--- a/experimental/LieAlgebras/docs/src/modules.md
+++ b/experimental/LieAlgebras/docs/src/modules.md
@@ -27,15 +27,19 @@ symbols(::LieAlgebraModule{C}) where {C<:RingElement}
 
 ## Element constructors
 
-```@docs
-(::LieAlgebraModule{C})() where {C<:RingElement}
-(::LieAlgebraModule{C})(::Vector{C}) where {C<:RingElement}
-(::LieAlgebraModule{C})(::Vector{Int}) where {C<:RingElement}
-(::LieAlgebraModule{C})(::MatElem{C}) where {C<:RingElement}
-(::LieAlgebraModule{C})(::SRow{C}) where {C<:RingElement}
-(::LieAlgebraModule{C})(::LieAlgebraModuleElem{C}) where {C<:RingElement}
-(::LieAlgebraModule{C})(::Vector{T}) where {T<:LieAlgebraModuleElem{C}} where {C<:RingElement}
-```
+`(V::LieAlgebraModule{C})()` returns the zero element of the Lie algebra module `V`.
+
+`(V::LieAlgebraModule{C})(v::LieAlgebraModuleElem{C})` returns `v` if `v` is an element of `L`. If `V` is the dual module of the parent of `v`, it returns the dual of `v`. In all other cases, it fails.
+
+`(V::LieAlgebraModule{C})(v)` constructs the element of `V` with coefficient vector `v`. `v` can be of type `Vector{C}`, `Vector{Int}`, `SRow{C}`, or `MatElem{C}` (of size $1 \times \dim(L)$).
+
+`(V::LieAlgebraModule{C})(a::Vector{T}) where {T<:LieAlgebraModuleElem{C}})`: If `V` is a direct sum, return its element, where the $i$-th component is equal to `a[i]`.
+If `V` is a tensor product, return the tensor product of the `a[i]`.
+If `V` is a exterior (symmetric, tensor) power, return the wedge product
+(product, tensor product) of the `a[i]`.
+Requires that `a` has a suitable length, and that the `a[i]` are elements of the correct modules,
+where _correct_ depends on the case above.
+
 
 ## Arithmetics
 The usual arithmetics, e.g. `+`, `-`, and `*` (scalar multiplication), are defined for `LieAlgebraModuleElem`s.

--- a/experimental/LieAlgebras/docs/src/modules.md
+++ b/experimental/LieAlgebras/docs/src/modules.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
 ```
 
 # Lie algebra modules

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -209,7 +209,7 @@ end
 @doc raw"""
     lie_algebra(R::Ring, dynkin::Tuple{Char,Int}; cached::Bool) -> AbstractLieAlgebra{elem_type(R)}
 
-Construct the Lie algebra over the ring `R` with Dynkin type given by `dynkin`.
+Construct the simple Lie algebra over the ring `R` with Dynkin type given by `dynkin`.
 The actual construction is done in GAP.
 
 If `cached` is `true`, the constructed Lie algebra is cached.

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -155,14 +155,21 @@ Construct the Lie algebra over the ring `R` with structure constants given by
 # Examples
 ```jldoctest
 julia> struct_consts = zeros(QQ, 3, 3, 3);
+
 julia> struct_consts[1, 2, 3] = QQ(1);
+
 julia> struct_consts[2, 1, 3] = QQ(-1);
+
 julia> struct_consts[3, 1, 1] = QQ(2);
+
 julia> struct_consts[1, 3, 1] = QQ(-2);
+
 julia> struct_consts[3, 2, 2] = QQ(-2);
+
 julia> struct_consts[2, 3, 2] = QQ(2);
+
 julia> sl2 = lie_algebra(QQ, struct_consts, ["e", "f", "h"])
-AbstractLieAlgebra over Rational Field
+AbstractLieAlgebra over Rational field
 
 julia> e, f, h = basis(sl2)
 3-element Vector{AbstractLieAlgebraElem{QQFieldElem}}:

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -190,7 +190,7 @@ function lie_algebra(
 end
 
 function lie_algebra(R::Ring, dynkin::Tuple{Char,Int}; cached::Bool=true)
-  @req is_valid_dynkin(dynkin...) "Input not allowed by GAP."
+  @req dynkin[1] in 'A':'G' "Unknown Dynkin type"
 
   coeffs_iso = inv(Oscar.iso_oscar_gap(R))
   LG = GAP.Globals.SimpleLieAlgebra(

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -161,13 +161,23 @@ julia> struct_consts[3, 1, 1] = QQ(2);
 julia> struct_consts[1, 3, 1] = QQ(-2);
 julia> struct_consts[3, 2, 2] = QQ(-2);
 julia> struct_consts[2, 3, 2] = QQ(2);
-julia> L = lie_algebra(QQ, struct_consts, ["e", "f", "h"])
+julia> sl2 = lie_algebra(QQ, struct_consts, ["e", "f", "h"])
 AbstractLieAlgebra over Rational Field
-julia> basis(L)
+
+julia> e, f, h = basis(sl2)
 3-element Vector{AbstractLieAlgebraElem{QQFieldElem}}:
  e
  f
  h
+
+julia> e * f
+h
+
+julia> h * e
+2*e
+
+julia> h * f
+-2*f
 ```
 """
 function lie_algebra(

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -117,11 +117,14 @@ end
 @doc raw"""
     lie_algebra(R::Ring, struct_consts::Matrix{SRow{C}}, s::Vector{<:VarName}; cached::Bool, check::Bool) -> AbstractLieAlgebra{elem_type(R)}
 
-Construct the Lie algebra over the ring `R` with structure constants given by
-`struct_consts` and with basis element names `s`.
+Construct the Lie algebra over the ring `R` with structure constants `struct_consts`
+and with basis element names `s`.
 
-* `struct_consts`: The entry with indices `[i,j][k]` is the scalar $a_{i,j}^k$
-  such that $[x_i, x_j] = \sum_k a_{i,j}^k x_k$.
+The Lie bracket on the newly constructed Lie algebra `L` is determined by the structure
+constants in `struct_consts` as follows: let $x_i$ denote the $i$-th standard basis vector
+of `L`. Then the entry `struct_consts[i,j][k]` is a scalar $a_{i,j,k}$
+such that $[x_i, x_j] = \sum_k a_{i,j,k} x_k$.
+
 * `s`: A vector of basis element names. This is 
   `[Symbol("x_$i") for i in 1:size(struct_consts, 1)]` by default.
 * `cached`: If `true`, cache the result. This is `true` by default.
@@ -141,11 +144,14 @@ end
 @doc raw"""
     lie_algebra(R::Ring, struct_consts::Array{elem_type(R),3}, s::Vector{<:VarName}; cached::Bool, check::Bool) -> AbstractLieAlgebra{elem_type(R)}
 
-Construct the Lie algebra over the ring `R` with structure constants given by
-`struct_consts` and with basis element names `s`.
+Construct the Lie algebra over the ring `R` with structure constants `struct_consts`
+and with basis element names `s`.
 
-* `struct_consts`: The entry with indices `[i,j,k]` is the scalar $a_{i,j}^k$
-  such that $[x_i, x_j] = \sum_k a_{i,j}^k x_k$.
+The Lie bracket on the newly constructed Lie algebra `L` is determined by the structure
+constants in `struct_consts` as follows: let $x_i$ denote the $i$-th standard basis vector
+of `L`. Then the entry `struct_consts[i,j,k]` is a scalar $a_{i,j,k}$
+such that $[x_i, x_j] = \sum_k a_{i,j,k} x_k$.
+
 * `s`: A vector of basis element names. This is
   `[Symbol("x_$i") for i in 1:size(struct_consts, 1)]` by default.
 * `cached`: If `true`, cache the result. This is `true` by default.

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -118,12 +118,12 @@ end
     lie_algebra(R::Ring, struct_consts::Matrix{SRow{C}}, s::Vector{<:VarName}; cached::Bool, check::Bool) -> AbstractLieAlgebra{elem_type(R)}
 
 Construct the Lie algebra over the ring `R` with structure constants given by
-`struct_consts` and basis element names given by `s`.
+`struct_consts` and with basis element names `s`.
 
-* `struct_consts`: The entry with indices `[i,j][k]` is the element $a_{i,j}^k$
+* `struct_consts`: The entry with indices `[i,j][k]` is the scalar $a_{i,j}^k$
   such that $[x_i, x_j] = \sum_k a_{i,j}^k x_k$.
 * `s`: A vector of basis element names. This is 
-  `([Symbol("x_$i") for i in 1:size(struct_consts, 1)])` by default.
+  `[Symbol("x_$i") for i in 1:size(struct_consts, 1)]` by default.
 * `cached`: If `true`, cache the result. This is `true` by default.
 * `check`: If `true`, check that the structure constants are anti-symmetric and
   satisfy the Jacobi identity. This is `true` by default.
@@ -142,12 +142,12 @@ end
     lie_algebra(R::Ring, struct_consts::Array{elem_type(R),3}, s::Vector{<:VarName}; cached::Bool, check::Bool) -> AbstractLieAlgebra{elem_type(R)}
 
 Construct the Lie algebra over the ring `R` with structure constants given by
-`struct_consts` and basis element names given by `s`.
+`struct_consts` and with basis element names `s`.
 
-* `struct_consts`: The entry with indices `[i,j,k]` is the element $a_{i,j}^k$
+* `struct_consts`: The entry with indices `[i,j,k]` is the scalar $a_{i,j}^k$
   such that $[x_i, x_j] = \sum_k a_{i,j}^k x_k$.
 * `s`: A vector of basis element names. This is
-  `([Symbol("x_$i") for i in 1:size(struct_consts, 1)])` by default.
+  `[Symbol("x_$i") for i in 1:size(struct_consts, 1)]` by default.
 * `cached`: If `true`, cache the result. This is `true` by default.
 * `check`: If `true`, check that the structure constants are anti-symmetric and
   satisfy the Jacobi identity. This is `true` by default.
@@ -199,6 +199,14 @@ function lie_algebra(
   return AbstractLieAlgebra{elem_type(R)}(R, struct_consts2, Symbol.(s); cached, check)
 end
 
+@doc raw"""
+    lie_algebra(R::Ring, dynkin::Tuple{Char,Int}; cached::Bool) -> AbstractLieAlgebra{elem_type(R)}
+
+Construct the Lie algebra over the ring `R` with Dynkin type given by `dynkin`.
+The actual construction is done in GAP.
+
+If `cached` is `true`, the constructed Lie algebra is cached.
+"""
 function lie_algebra(R::Ring, dynkin::Tuple{Char,Int}; cached::Bool=true)
   @req dynkin[1] in 'A':'G' "Unknown Dynkin type"
 

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -114,6 +114,20 @@ end
 #
 ###############################################################################
 
+@doc raw"""
+    lie_algebra(R::Ring, struct_consts::Matrix{SRow{C}}, s::Vector{<:VarName}; cached::Bool, check::Bool) -> AbstractLieAlgebra{elem_type(R)}
+
+Construct the Lie algebra over the ring `R` with structure constants given by
+`struct_consts` and basis element names given by `s`.
+
+* `struct_consts`: The entry with indices `[i,j][k]` is the element $a_{i,j}^k$
+  such that $[x_i, x_j] = \sum_k a_{i,j}^k x_k$.
+* `s`: A vector of basis element names. This is 
+  `([Symbol("x_$i") for i in 1:size(struct_consts, 1)])` by default.
+* `cached`: If `true`, cache the result. This is `true` by default.
+* `check`: If `true`, check that the structure constants are anti-symmetric and
+  satisfy the Jacobi identity. This is `true` by default.
+"""
 function lie_algebra(
   R::Ring,
   struct_consts::Matrix{SRow{C}},
@@ -124,6 +138,38 @@ function lie_algebra(
   return AbstractLieAlgebra{elem_type(R)}(R, struct_consts, Symbol.(s); cached, check)
 end
 
+@doc raw"""
+    lie_algebra(R::Ring, struct_consts::Array{elem_type(R),3}, s::Vector{<:VarName}; cached::Bool, check::Bool) -> AbstractLieAlgebra{elem_type(R)}
+
+Construct the Lie algebra over the ring `R` with structure constants given by
+`struct_consts` and basis element names given by `s`.
+
+* `struct_consts`: The entry with indices `[i,j,k]` is the element $a_{i,j}^k$
+  such that $[x_i, x_j] = \sum_k a_{i,j}^k x_k$.
+* `s`: A vector of basis element names. This is
+  `([Symbol("x_$i") for i in 1:size(struct_consts, 1)])` by default.
+* `cached`: If `true`, cache the result. This is `true` by default.
+* `check`: If `true`, check that the structure constants are anti-symmetric and
+  satisfy the Jacobi identity. This is `true` by default.
+
+# Examples
+```jldoctest
+julia> struct_consts = zeros(QQ, 3, 3, 3);
+julia> struct_consts[1, 2, 3] = QQ(1);
+julia> struct_consts[2, 1, 3] = QQ(-1);
+julia> struct_consts[3, 1, 1] = QQ(2);
+julia> struct_consts[1, 3, 1] = QQ(-2);
+julia> struct_consts[3, 2, 2] = QQ(-2);
+julia> struct_consts[2, 3, 2] = QQ(2);
+julia> L = lie_algebra(QQ, struct_consts, ["e", "f", "h"])
+AbstractLieAlgebra over Rational Field
+julia> basis(L)
+3-element Vector{AbstractLieAlgebraElem{QQFieldElem}}:
+ e
+ f
+ h
+```
+"""
 function lie_algebra(
   R::Ring,
   struct_consts::Array{C,3},

--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -160,7 +160,7 @@ end
     (L::LieAlgebra{C})(v::Vector{Int}) -> LieAlgebraElem{C}
 
 Return the element of `L` with coefficent vector `v`.
-Fails, if `Int` cannot be coerced into the base ring of `L`.
+Fail, if `Int` cannot be coerced into the base ring of `L`.
 """
 function (L::LieAlgebra{C})(v::Vector{Int}) where {C<:RingElement}
   return L(base_ring(L).(v))

--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -267,7 +267,9 @@ end
 
 function Base.hash(x::LieAlgebraElem{C}, h::UInt) where {C<:RingElement}
   b = 0x6724cbedbd860982 % UInt
-  return xor(hash(coefficients(x), hash(parent(x), h)), b)
+  h = hash(parent(x), h)
+  h = hash(coefficients(x), h)
+  return xor(h, b)
 end
 
 ###############################################################################

--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -35,10 +35,9 @@ gen(L::LieAlgebra{C}, i::Int) where {C<:RingElement} = basis(L, i)
 @doc raw"""
     dim(L::LieAlgebra{C}) -> Int
 
-Return the dimension the Lie algebra `L`.
+Return the dimension of the Lie algebra `L`.
 """
-dim(_::LieAlgebra{C}) where {C<:RingElement} =
-  error("Unreachable. Should be implemented by subtypes.")
+dim(_::LieAlgebra{C}) where {C<:RingElement} = error("Should be implemented by subtypes.")
 
 @doc raw"""
     basis(L::LieAlgebra{C}) -> Vector{LieAlgebraElem{C}}
@@ -122,6 +121,14 @@ end
 #
 ###############################################################################
 
+@doc raw"""
+    symbols(L::LieAlgebra{C}) -> Vector{Symbol}
+
+Return the symbols used for printing basis elements of the Lie algebra `L`.
+"""
+symbols(_::LieAlgebra{C}) where {C<:RingElement} =
+  error("Should be implemented by subtypes.")
+
 function expressify(
   v::LieAlgebraElem{C}, s=symbols(parent(v)); context=nothing
 ) where {C<:RingElement}
@@ -181,6 +188,11 @@ function (L::LieAlgebra{C})(mat::MatElem{C}) where {C<:RingElement}
   return elem_type(L)(L, mat)
 end
 
+@doc raw"""
+    (L::LieAlgebra{C})(v::SRow{C}) -> LieAlgebraElem{C}
+
+Return the Lie algebra element with coefficent vector `v`.
+"""
 function (L::LieAlgebra{C})(v::SRow{C}) where {C<:RingElement}
   mat = dense_row(v, dim(L))
   return elem_type(L)(L, mat)
@@ -264,6 +276,16 @@ end
 #
 ###############################################################################
 
+@doc raw"""
+    lie_algebra(gapL::GAP.GapObj, s::Vector{<:VarName}; cached::Bool) -> LieAlgebra{elem_type(R)}
+
+Construct a Lie algebra isomorphic to the GAP Lie algebra `gapL`. Its basis element are named by `s`,
+or by `x_i` by default.
+We require `gapL` to be a finite-dimensional GAP Lie algebra. The return type is dependent on
+properties of `gapL`, in particular, whether GAP knows about a matrix representation.
+
+If `cached` is `true`, the constructed Lie algebra is cached.
+"""
 function lie_algebra(
   gapL::GAP.GapObj,
   s::Vector{<:VarName}=[Symbol("x_$i") for i in 1:GAPWrap.Dimension(gapL)];

--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -32,19 +32,47 @@ gens(L::LieAlgebra{C}) where {C<:RingElement} = basis(L)
 
 gen(L::LieAlgebra{C}, i::Int) where {C<:RingElement} = basis(L, i)
 
+@doc raw"""
+    dim(L::LieAlgebra{C}) -> Int
+
+Return the dimension the Lie algebra `L`.
+"""
+dim(_::LieAlgebra{C}) where {C<:RingElement} =
+  error("Unreachable. Should be implemented by subtypes.")
+
+@doc raw"""
+    basis(L::LieAlgebra{C}) -> Vector{LieAlgebraElem{C}}
+
+Return a basis of the Lie algebra `L` as a vector of lie algebra elements.
+"""
 basis(L::LieAlgebra{C}) where {C<:RingElement} =
   [basis(L, i)::elem_type(L) for i in 1:dim(L)]
 
+@doc raw"""
+    basis(L::LieAlgebra{C}, i::Int) -> LieAlgebraElem{C}
+
+Return the `i`-th basis element of the Lie algebra `L`.
+"""
 function basis(L::LieAlgebra{C}, i::Int) where {C<:RingElement}
   R = base_ring(L)
   return L([(j == i ? one(R) : zero(R)) for j in 1:dim(L)])
 end
 
+@doc raw"""
+    zero(L::LieAlgebra{C}) -> LieAlgebraElem{C}
+
+Return the zero element of the Lie algebra `L`.
+"""
 function zero(L::LieAlgebra{C}) where {C<:RingElement}
   mat = zero_matrix(base_ring(L), 1, dim(L))
   return elem_type(L)(L, mat)
 end
 
+@doc raw"""
+    iszero(x::LieAlgebraElem{C}) -> Bool
+
+Check whether the Lie algebra element `x` is zero.
+"""
 function iszero(x::LieAlgebraElem{C}) where {C<:RingElement}
   return iszero(coefficients(x))
 end
@@ -53,18 +81,28 @@ end
   return (x.mat)::dense_matrix_type(C)
 end
 
+@doc raw"""
+    coefficients(x::LieAlgebraElem{C}) -> Vector{C}
+
+Return the coefficients of `x` with respect to [`basis(::LieAlgebra)`](@ref).
+"""
 function coefficients(x::LieAlgebraElem{C}) where {C<:RingElement}
   return collect(Generic._matrix(x))[1, :]
 end
 
+@doc raw"""
+    coeff(x::LieAlgebraElem{C}, i::Int) -> C
+
+Return the `i`-th coefficient of `x` with respect to [`basis(::LieAlgebra)`](@ref).
+"""
 function coeff(x::LieAlgebraElem{C}, i::Int) where {C<:RingElement}
   return Generic._matrix(x)[1, i]
 end
 
 @doc raw"""
-    getindex(x::LieAlgebraElem{C}, i::Int) where C <: RingElement
+    getindex(x::LieAlgebraElem{C}, i::Int) -> C
 
-Return the $i$-th coefficient of the module element $x$.
+Return the `i`-th coefficient of `x` with respect to [`basis(::LieAlgebra)`](@ref).
 """
 function getindex(x::LieAlgebraElem{C}, i::Int) where {C<:RingElement}
   return coeff(x, i)
@@ -102,20 +140,42 @@ end
 #
 ###############################################################################
 
+@doc raw"""
+    (L::LieAlgebra{C})() -> LieAlgebraElem{C}
+
+Return the zero element of the Lie algebra `L`.
+"""
 function (L::LieAlgebra{C})() where {C<:RingElement}
   return zero(L)
 end
 
+@doc raw"""
+    (L::LieAlgebra{C})(v::Vector{Int}) -> LieAlgebraElem{C}
+
+Return the Lie algebra element with coefficent vector `v`.
+Fails, if `Int` cannot be coerced into the base ring of `L`.
+"""
 function (L::LieAlgebra{C})(v::Vector{Int}) where {C<:RingElement}
   return L(base_ring(L).(v))
 end
 
+@doc raw"""
+    (L::LieAlgebra{C})(v::Vector{C}) -> LieAlgebraElem{C}
+
+Return the Lie algebra element with coefficent vector `v`.
+"""
 function (L::LieAlgebra{C})(v::Vector{C}) where {C<:RingElement}
   @req length(v) == dim(L) "Length of vector does not match dimension."
   mat = matrix(base_ring(L), 1, length(v), v)
   return elem_type(L)(L, mat)
 end
 
+@doc raw"""
+    (L::LieAlgebra{C})(mat::MatElem{C}) -> LieAlgebraElem{C}
+
+Return the Lie algebra element with coefficient vector equivalent to
+the $1 \times \dim(L)$ matrix `mat`.
+"""
 function (L::LieAlgebra{C})(mat::MatElem{C}) where {C<:RingElement}
   @req size(mat) == (1, dim(L)) "Invalid matrix dimensions."
   return elem_type(L)(L, mat)
@@ -126,6 +186,11 @@ function (L::LieAlgebra{C})(v::SRow{C}) where {C<:RingElement}
   return elem_type(L)(L, mat)
 end
 
+@doc raw"""
+    (L::LieAlgebra{C})(v::LieAlgebraElem{C}) -> LieAlgebraElem{C}
+
+Return the Lie algebra element `v`. Fails if `v` is not an element of `L`.
+"""
 function (L::LieAlgebra{C})(v::LieAlgebraElem{C}) where {C<:RingElement}
   @req L == parent(v) "Incompatible modules."
   return v

--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -42,7 +42,7 @@ dim(_::LieAlgebra{C}) where {C<:RingElement} = error("Should be implemented by s
 @doc raw"""
     basis(L::LieAlgebra{C}) -> Vector{LieAlgebraElem{C}}
 
-Return a basis of the Lie algebra `L` as a vector of lie algebra elements.
+Return a basis of the Lie algebra `L`.
 """
 basis(L::LieAlgebra{C}) where {C<:RingElement} =
   [basis(L, i)::elem_type(L) for i in 1:dim(L)]
@@ -159,7 +159,7 @@ end
 @doc raw"""
     (L::LieAlgebra{C})(v::Vector{Int}) -> LieAlgebraElem{C}
 
-Return the Lie algebra element with coefficent vector `v`.
+Return the element of `L` with coefficent vector `v`.
 Fails, if `Int` cannot be coerced into the base ring of `L`.
 """
 function (L::LieAlgebra{C})(v::Vector{Int}) where {C<:RingElement}
@@ -169,7 +169,7 @@ end
 @doc raw"""
     (L::LieAlgebra{C})(v::Vector{C}) -> LieAlgebraElem{C}
 
-Return the Lie algebra element with coefficent vector `v`.
+Return the element of `L` with coefficent vector `v`.
 """
 function (L::LieAlgebra{C})(v::Vector{C}) where {C<:RingElement}
   @req length(v) == dim(L) "Length of vector does not match dimension."
@@ -180,7 +180,7 @@ end
 @doc raw"""
     (L::LieAlgebra{C})(mat::MatElem{C}) -> LieAlgebraElem{C}
 
-Return the Lie algebra element with coefficient vector equivalent to
+Return the element of `L` with coefficient vector equivalent to
 the $1 \times \dim(L)$ matrix `mat`.
 """
 function (L::LieAlgebra{C})(mat::MatElem{C}) where {C<:RingElement}
@@ -191,7 +191,7 @@ end
 @doc raw"""
     (L::LieAlgebra{C})(v::SRow{C}) -> LieAlgebraElem{C}
 
-Return the Lie algebra element with coefficent vector `v`.
+Return the element of `L` with coefficent vector `v`.
 """
 function (L::LieAlgebra{C})(v::SRow{C}) where {C<:RingElement}
   mat = dense_row(v, dim(L))
@@ -199,13 +199,13 @@ function (L::LieAlgebra{C})(v::SRow{C}) where {C<:RingElement}
 end
 
 @doc raw"""
-    (L::LieAlgebra{C})(v::LieAlgebraElem{C}) -> LieAlgebraElem{C}
+    (L::LieAlgebra{C})(x::LieAlgebraElem{C}) -> LieAlgebraElem{C}
 
-Return the Lie algebra element `v`. Fails if `v` is not an element of `L`.
+Return `x`. Fails if `x` is not an element of `L`.
 """
-function (L::LieAlgebra{C})(v::LieAlgebraElem{C}) where {C<:RingElement}
-  @req L == parent(v) "Incompatible modules."
-  return v
+function (L::LieAlgebra{C})(x::LieAlgebraElem{C}) where {C<:RingElement}
+  @req L == parent(x) "Incompatible modules."
+  return x
 end
 
 ###############################################################################

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -314,7 +314,11 @@ end
 
 function Base.hash(V::LieAlgebraModule{C}, h::UInt) where {C<:RingElement}
   b = 0x28b0c111e3ff8526 % UInt
-  return xor(hash(V.L, hash(V.dim, hash(V.transformation_matrices, hash(V.s, h)))), b)
+  h = hash(V.dim, h)
+  h = hash(V.s, h)
+  h = hash(V.L, h)
+  h = hash(V.transformation_matrices, h)
+  return xor(h, b)
 end
 
 function Base.:(==)(
@@ -326,7 +330,9 @@ end
 
 function Base.hash(v::LieAlgebraModuleElem{C}, h::UInt) where {C<:RingElement}
   b = 0x723913014484513a % UInt
-  return xor(hash(coefficients(v), hash(parent(v), h)), b)
+  h = hash(parent(v), h)
+  h = hash(coefficients(v), h)
+  return xor(h, b)
 end
 
 ###############################################################################

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -585,9 +585,12 @@ end
 Construct the the Lie algebra module over `L` of dimension `dimV` given by
 structure constants `struct_consts` and with basis element names `s`.
 
-* `struct_consts`: The entry with indices `[i,j][k]` is the scalar $a_{i,j}^k$ 
-  such that $x_i * v_j = \sum_k a_{i,j}^k v_k$, where $x_i$ denotes the $i$-th
-  basis element of `L` and $v_j$ the $j$-th basis element of the constructed module.
+The action on the newly constructed Lie algebra module `V` is determined by the structure
+constants in `struct_consts` as follows: let $x_i$ denote the $i$-th standard basis vector
+of `L`, and $v_i$ the $i$-th standard basis vector of `V`.
+Then the entry `struct_consts[i,j][k]` is a scalar $a_{i,j,k}$
+such that $x_i * v_j = \sum_k a_{i,j,k} v_k$.
+
 * `s`: A vector of basis element names. This is 
   `[Symbol("v_$i") for i in 1:dimV]` by default.
 * `check`: If `true`, check that the structure constants are anti-symmetric and

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -46,6 +46,11 @@ base_ring(V::LieAlgebraModule{C}) where {C<:RingElement} = base_ring(base_lie_al
 
 base_ring(v::LieAlgebraModuleElem{C}) where {C<:RingElement} = base_ring(parent(v))
 
+@doc raw"""
+    base_lie_algebra(V::LieAlgebraModule{C}) -> LieAlgebra{C}
+
+Return the Lie algebra `V` is a module over.
+"""
 base_lie_algebra(V::LieAlgebraModule{C}) where {C<:RingElement} = V.L
 
 ngens(L::LieAlgebraModule{C}) where {C<:RingElement} = dim(L)
@@ -54,21 +59,46 @@ gens(L::LieAlgebraModule{C}) where {C<:RingElement} = basis(L)
 
 gen(L::LieAlgebraModule{C}, i::Int) where {C<:RingElement} = basis(L, i)
 
+@doc raw"""
+    dim(V::LieAlgebraModule{C}) -> Int
+
+Return the dimension of the Lie algebra module `V`.
+"""
 dim(V::LieAlgebraModule{C}) where {C<:RingElement} = V.dim
 
+@doc raw"""
+    basis(V::LieAlgebraModule{C}) -> Vector{LieAlgebraModuleElem{C}}
+
+Return a basis of the Lie algebra module `V`.
+"""
 basis(L::LieAlgebraModule{C}) where {C<:RingElement} =
   [basis(L, i)::elem_type(L) for i in 1:dim(L)]
 
+@doc raw"""
+    basis(V::LieAlgebraModule{C}, i::Int) -> LieAlgebraModuleElem{C}
+
+Return the `i`-th basis element of the Lie algebra module `V`.
+"""
 function basis(L::LieAlgebraModule{C}, i::Int) where {C<:RingElement}
   R = base_ring(L)
   return L([(j == i ? one(R) : zero(R)) for j in 1:dim(L)])
 end
 
+@doc raw"""
+    zero(V::LieAlgebraModule{C}) -> LieAlgebraModuleElem{C}
+
+Return the zero element of the Lie algebra module `V`.
+"""
 function zero(V::LieAlgebraModule{C}) where {C<:RingElement}
   mat = zero_matrix(base_ring(V), 1, dim(V))
   return elem_type(V)(V, mat)
 end
 
+@doc raw"""
+    iszero(v::LieAlgebraModuleElem{C}) -> Bool
+
+Check whether the Lie algebra module element `v` is zero.
+"""
 function iszero(v::LieAlgebraModuleElem{C}) where {C<:RingElement}
   return iszero(coefficients(v))
 end
@@ -77,18 +107,28 @@ end
   return (v.mat)::dense_matrix_type(C)
 end
 
+@doc raw"""
+    coefficients(v::LieAlgebraModuleElem{C}) -> Vector{C}
+
+Return the coefficients of `v` with respect to [`basis(::LieAlgebraModule)`](@ref).
+"""
 function coefficients(v::LieAlgebraModuleElem{C}) where {C<:RingElement}
   return collect(Generic._matrix(v))[1, :]
 end
 
+@doc raw"""
+    coeff(v::LieAlgebraModuleElem{C}, i::Int) -> C
+
+Return the `i`-th coefficient of `v` with respect to [`basis(::LieAlgebraModule)`](@ref).
+"""
 function coeff(v::LieAlgebraModuleElem{C}, i::Int) where {C<:RingElement}
   return Generic._matrix(v)[1, i]
 end
 
 @doc raw"""
-    getindex(v::LieAlgebraElem{C}, i::Int) where C <: RingElement
+    getindex(v::LieAlgebraModuleElem{C}, i::Int) -> C
 
-Return the $i$-th coefficient of the module element $x$.
+Return the `i`-th coefficient of `v` with respect to [`basis(::LieAlgebraModule)`](@ref).
 """
 function getindex(v::LieAlgebraModuleElem{C}, i::Int) where {C<:RingElement}
   return coeff(v, i)
@@ -156,6 +196,11 @@ function show_tensor_power(io::IO, V::LieAlgebraModule{C}) where {C<:RingElement
   print(IOContext(io, :compact => true), base_module(V))
 end
 
+@doc raw"""
+    symbols(V::LieAlgebraModule{C}) -> Vector{Symbol}
+
+Return the symbols used for printing basis elements of the Lie algebra module `V`.
+"""
 function symbols(V::LieAlgebraModule{C}) where {C<:RingElement}
   return V.s
 end
@@ -178,31 +223,65 @@ end
 #
 ###############################################################################
 
+@doc raw"""
+    (V::LieAlgebraModule{C})() -> LieAlgebraModuleElem{C}
+
+Return the zero element of the Lie algebra module `V`.
+"""
 function (V::LieAlgebraModule{C})() where {C<:RingElement}
   return zero(V)
 end
 
+@doc raw"""
+    (V::LieAlgebraModule{C})(v::Vector{Int}) -> LieAlgebraModuleElem{C}
+
+Return the element of `V` with coefficent vector `v`.
+Fails, if `Int` cannot be coerced into the base ring of `L`.
+"""
 function (V::LieAlgebraModule{C})(v::Vector{Int}) where {C<:RingElement}
   return V(base_ring(V).(v))
 end
 
+@doc raw"""
+    (V::LieAlgebraModule{C})(v::Vector{C}) -> LieAlgebraModuleElem{C}
+
+Return the element of `V` with coefficent vector `v`.
+"""
 function (V::LieAlgebraModule{C})(v::Vector{C}) where {C<:RingElement}
   @req length(v) == dim(V) "Length of vector does not match dimension."
   mat = matrix(base_ring(V), 1, length(v), v)
   return elem_type(V)(V, mat)
 end
 
+@doc raw"""
+    (V::LieAlgebraModule{C})(mat::MatElem{C}) -> LieAlgebraModuleElem{C}
+
+Return the element of `V` with coefficient vector equivalent to
+the $1 \times \dim(L)$ matrix `mat`.
+"""
 function (V::LieAlgebraModule{C})(v::MatElem{C}) where {C<:RingElement}
   @req ncols(v) == dim(V) "Length of vector does not match dimension"
   @req nrows(v) == 1 "Not a vector in module constructor"
   return elem_type(V)(V, v)
 end
 
+@doc raw"""
+    (V::LieAlgebraModule{C})(v::SRow{C}) -> LieAlgebraModuleElem{C}
+
+Return the element of `V` with coefficent vector `v`.
+"""
 function (V::LieAlgebraModule{C})(v::SRow{C}) where {C<:RingElement}
   mat = dense_row(v, dim(V))
   return elem_type(V)(V, mat)
 end
 
+@doc raw"""
+    (V::LieAlgebraModule{C})(v::LieAlgebraModuleElem{C}) -> LieAlgebraModuleElem{C}
+
+Return `v`. Fails, in general, if `v` is not an element of `V`.
+
+If `V` is the dual module of the parent of `v`, return the dual of `v`.
+"""
 function (V::LieAlgebraModule{C})(v::LieAlgebraModuleElem{C}) where {C<:RingElement}
   if is_dual(V) && base_module(V) == parent(v)
     return V(coefficients(v))
@@ -211,6 +290,17 @@ function (V::LieAlgebraModule{C})(v::LieAlgebraModuleElem{C}) where {C<:RingElem
   return v
 end
 
+@doc raw"""
+    (V::LieAlgebraModule{C})(a::Vector{T}) where {T<:LieAlgebraModuleElem{C}}) -> LieAlgebraModuleElem{C}
+
+If `V` is a direct sum, return its element, where the $i$-th component is equal to `a[i]`.
+If `V` is a tensor product, return the tensor product of the `a[i]`.
+If `V` is a exterior (symmetric, tensor) power, return the wedge product
+(product, tensor product) of the `a[i]`.
+
+Requires that `a` has a suitable length, and that the `a[i]` are elements of the correct modules,
+where _correct_ depends on the case above.
+"""
 function (V::LieAlgebraModule{C})(
   a::Vector{T}
 ) where {T<:LieAlgebraModuleElem{C}} where {C<:RingElement}
@@ -341,6 +431,12 @@ end
 #
 ###############################################################################
 
+@doc raw"""
+    action(x::LieAlgebraElem{C}, v::LieAlgebraModuleElem{C}) -> LieAlgebraModuleElem{C}
+    *(x::LieAlgebraElem{C}, v::LieAlgebraModuleElem{C}) -> LieAlgebraModuleElem{C}
+
+Apply the action of `x` on `v`.
+"""
 function Base.:*(x::LieAlgebraElem{C}, v::LieAlgebraModuleElem{C}) where {C<:RingElement}
   return action(x, v)
 end
@@ -369,39 +465,85 @@ end
 #
 ###############################################################################
 
+@doc raw"""
+    is_standard_module(V::LieAlgebraModule{C}) -> Bool
+
+Check whether `V` is a standard module.
+"""
 function is_standard_module(V::LieAlgebraModule{C}) where {C<:RingElement}
   return get_attribute(V, :type, :fallback)::Symbol == :standard_module
 end
 
+@doc raw"""
+    is_dual(V::LieAlgebraModule{C}) -> Bool
+
+Check whether `V` is a dual module.
+"""
 function is_dual(V::LieAlgebraModule{C}) where {C<:RingElement}
   return get_attribute(V, :type, :fallback)::Symbol == :dual
 end
 
-function is_tensor_product(V::LieAlgebraModule{C}) where {C<:RingElement}
-  return get_attribute(V, :type, :fallback)::Symbol == :tensor_product
-end
+@doc raw"""
+    is_direct_sum(V::LieAlgebraModule{C}) -> Bool
 
+Check whether `V` is a direct sum of modules.
+"""
 function is_direct_sum(V::LieAlgebraModule{C}) where {C<:RingElement}
   return get_attribute(V, :type, :fallback)::Symbol == :direct_sum
 end
 
+@doc raw"""
+    is_tensor_product(V::LieAlgebraModule{C}) -> Bool
+
+Check whether `V` is a tensor product of modules.
+"""
+function is_tensor_product(V::LieAlgebraModule{C}) where {C<:RingElement}
+  return get_attribute(V, :type, :fallback)::Symbol == :tensor_product
+end
+
+@doc raw"""
+    is_exterior_power(V::LieAlgebraModule{C}) -> Bool
+
+Check whether `V` is an exterior power of a module.
+"""
 function is_exterior_power(V::LieAlgebraModule{C}) where {C<:RingElement}
   return get_attribute(V, :type, :fallback)::Symbol == :exterior_power
 end
 
+@doc raw"""
+    is_symmetric_power(V::LieAlgebraModule{C}) -> Bool
+
+Check whether `V` is a symmetric power of a module.
+"""
 function is_symmetric_power(V::LieAlgebraModule{C}) where {C<:RingElement}
   return get_attribute(V, :type, :fallback)::Symbol == :symmetric_power
 end
 
+@doc raw"""
+    is_tensor_power(V::LieAlgebraModule{C}) -> Bool
+
+Check whether `V` is a tensor power of a module.
+"""
 function is_tensor_power(V::LieAlgebraModule{C}) where {C<:RingElement}
   return get_attribute(V, :type, :fallback)::Symbol == :tensor_power
 end
 
+@doc raw"""
+    base_module(V::LieAlgebraModule{C}) -> LieAlgebraModule{C}
+
+Returns the base module of `V`, if `V` is a power module.
+"""
 function base_module(V::LieAlgebraModule{C}) where {C<:RingElement}
   @req is_dual(V) || is_exterior_power(V) || is_symmetric_power(V) || is_tensor_power(V) "Not a power module."
   return get_attribute(V, :base_module)::LieAlgebraModule{C}
 end
 
+@doc raw"""
+    base_modules(V::LieAlgebraModule{C}) -> Vector{LieAlgebraModule{C}}
+
+Returns the summands or tensor factors base modules of `V`,
+if `V` is a direct sum or tensor product module.
+"""
 function base_modules(V::LieAlgebraModule{C}) where {C<:RingElement}
   @req is_direct_sum(V) || is_tensor_product(V) "Not a direct sum or tensor product module."
   return get_attribute(V, :base_modules)::Vector{LieAlgebraModule{C}}
@@ -413,6 +555,20 @@ end
 #
 ###############################################################################
 
+@doc raw"""
+    abstract_module(L::LieAlgebra{C}, dimV::Int, transformation_matrices::Vector{<:MatElem{C}}, s::Vector{<:VarName}; check::Bool) -> LieAlgebraModule{C}
+
+Construct the the Lie algebra module over `L` of dimension `dimV` given by
+`transformation_matrices` and with basis element names `s`.
+
+* `transformation_matrices`: The action of the $i$-th basis element of `L`
+  on some element $v$ of the constructed module is given by left multiplication 
+  of the matrix `transformation_matrices[i]` to the coefficient vector of $v$.
+* `s`: A vector of basis element names. This is 
+  `[Symbol("v_$i") for i in 1:dimV]` by default.
+* `check`: If `true`, check that the structure constants are anti-symmetric and
+  satisfy the Jacobi identity. This is `true` by default.
+"""
 function abstract_module(
   L::LieAlgebra{C},
   dimV::Int,
@@ -423,6 +579,20 @@ function abstract_module(
   return LieAlgebraModule{C}(L, dimV, transformation_matrices, Symbol.(s); check)
 end
 
+@doc raw"""
+    abstract_module(L::LieAlgebra{C}, dimV::Int, struct_consts::Matrix{SRow{C}}, s::Vector{<:VarName}; check::Bool) -> LieAlgebraModule{C}
+
+Construct the the Lie algebra module over `L` of dimension `dimV` given by
+structure constants `struct_consts` and with basis element names `s`.
+
+* `struct_consts`: The entry with indices `[i,j][k]` is the scalar $a_{i,j}^k$ 
+  such that $x_i * v_j = \sum_k a_{i,j}^k v_k$, where $x_i$ denotes the $i$-th
+  basis element of `L` and $v_j$ the $j$-th basis element of the constructed module.
+* `s`: A vector of basis element names. This is 
+  `[Symbol("v_$i") for i in 1:dimV]` by default.
+* `check`: If `true`, check that the structure constants are anti-symmetric and
+  satisfy the Jacobi identity. This is `true` by default.
+"""
 function abstract_module(
   L::LieAlgebra{C},
   dimV::Int,
@@ -442,6 +612,12 @@ function abstract_module(
   return LieAlgebraModule{C}(L, dimV, transformation_matrices, Symbol.(s); check)
 end
 
+@doc raw"""
+    highest_weight_module(L::LieAlgebra{C}, weight::Vector{Int}) -> LieAlgebraModule{C}
+
+Construct the highest weight module of the Lie algebra `L` with highest weight `weight`.
+The actual construction is done in GAP.
+"""
 function highest_weight_module(L::LieAlgebra{C}, weight::Vector{Int}) where {C<:RingElement}
   struct_consts = lie_algebra_highest_weight_module_struct_consts_gap(L, weight)
   dimV = size(struct_consts, 2)
@@ -450,6 +626,13 @@ function highest_weight_module(L::LieAlgebra{C}, weight::Vector{Int}) where {C<:
   return V
 end
 
+@doc raw"""
+    standard_module(L::LinearLieAlgebra{C}) -> LieAlgebraModule{C}
+
+Construct the standard module of the linear Lie algebra `L`.
+If `L` is a Lie subalgebra of $\mathfrak{gl}_n(R)$, then the standard module
+is $R^n$ with the action of $L$ given by left multiplication.
+"""
 function standard_module(L::LinearLieAlgebra{C}) where {C<:RingElement}
   dim_std_V = L.n
   transformation_matrices = matrix_repr_basis(L)
@@ -461,6 +644,11 @@ function standard_module(L::LinearLieAlgebra{C}) where {C<:RingElement}
   return std_V
 end
 
+@doc raw"""
+    dual(V::LieAlgebraModule{C}) -> LieAlgebraModule{C}
+
+Construct the dual module of `V`.
+"""
 function dual(V::LieAlgebraModule{C}) where {C<:RingElement}
   L = base_lie_algebra(V)
   dim_dual_V = dim(V)
@@ -481,6 +669,12 @@ function dual(V::LieAlgebraModule{C}) where {C<:RingElement}
   return pow_V
 end
 
+@doc raw"""
+    direct_sum(V::LieAlgebraModule{C}...) -> LieAlgebraModule{C}
+    ⊕(V::LieAlgebraModule{C}...) -> LieAlgebraModule{C}
+
+Construct the direct sum of the modules `V...`.
+"""
 function direct_sum(
   V::LieAlgebraModule{C}, Vs::LieAlgebraModule{C}...
 ) where {C<:RingElement}
@@ -517,6 +711,12 @@ end
 ⊕(V::LieAlgebraModule{C}, Vs::LieAlgebraModule{C}...) where {C<:RingElement} =
   direct_sum(V, Vs...)
 
+@doc raw"""
+  tensor_product(V::LieAlgebraModule{C}...) -> LieAlgebraModule{C}
+  ⊗(V::LieAlgebraModule{C}...) -> LieAlgebraModule{C}
+
+Construct the tensor product of the modules `V...`.
+"""
 function tensor_product(
   V::LieAlgebraModule{C}, Vs::LieAlgebraModule{C}...
 ) where {C<:RingElement}
@@ -564,6 +764,11 @@ end
 ⊗(V::LieAlgebraModule{C}, Vs::LieAlgebraModule{C}...) where {C<:RingElement} =
   tensor_product(V, Vs...)
 
+@doc raw"""
+    exterior_power(V::LieAlgebraModule{C}, k::Int) -> LieAlgebraModule{C}
+
+Construct the `k`-th exterior power $\bigwedge^k (V)$ of the module `V`.
+"""
 function exterior_power(V::LieAlgebraModule{C}, k::Int) where {C<:RingElement}
   L = base_lie_algebra(V)
   dim_pow_V = binomial(dim(V), k)
@@ -605,6 +810,11 @@ function exterior_power(V::LieAlgebraModule{C}, k::Int) where {C<:RingElement}
   return pow_V
 end
 
+@doc raw"""
+    symmetric_power(V::LieAlgebraModule{C}, k::Int) -> LieAlgebraModule{C}
+
+Construct the `k`-th symmetric power $S^k (V)$ of the module `V`.
+"""
 function symmetric_power(V::LieAlgebraModule{C}, k::Int) where {C<:RingElement}
   L = base_lie_algebra(V)
   dim_pow_V = binomial(dim(V) + k - 1, k)
@@ -662,6 +872,11 @@ function symmetric_power(V::LieAlgebraModule{C}, k::Int) where {C<:RingElement}
   return pow_V
 end
 
+@doc raw"""
+    tensor_power(V::LieAlgebraModule{C}, k::Int) -> LieAlgebraModule{C}
+
+Construct the `k`-th tensor power $T^k (V)$ of the module `V`.
+"""
 function tensor_power(V::LieAlgebraModule{C}, k::Int) where {C<:RingElement}
   L = base_lie_algebra(V)
   dim_pow_V = dim(V)^k

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -7,8 +7,6 @@ import Oscar: GAPWrap
 # not importet in Oscar
 using AbstractAlgebra: CacheDictType, ProductIterator, get_cached!
 
-using Base: deepcopy_internal
-
 # functions with new methods
 import ..Oscar:
   _iso_oscar_gap,
@@ -33,7 +31,7 @@ import ..Oscar:
   ⊕,
   ⊗
 
-import Base: getindex, iszero, parent, zero
+import Base: getindex, deepcopy_internal, hash, iszero, parent, zero
 
 export AbstractLieAlgebra, AbstractLieAlgebraElem
 export LieAlgebra, LieAlgebraElem

--- a/experimental/LieAlgebras/src/LinearLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LinearLieAlgebra.jl
@@ -136,8 +136,10 @@ end
 @doc raw"""
     lie_algebra(R::Ring, n::Int, basis::Vector{<:MatElem{elem_type(R)}}, s::Vector{<:VarName}; cached::Bool) -> LinearLieAlgebra{elem_type(R)}
 
-Construct the Lie algebra over the ring `R` with basis `basis` and basis element names given by `s`. The basis elements must be square matrices of size `n`.
-We require `basis` to be linearly independent, and to contain the Lie bracket of any two basis elements in its span.
+Construct the Lie algebra over the ring `R` with basis `basis` and basis element names
+given by `s`. The basis elements must be square matrices of size `n`.
+We require `basis` to be linearly independent, and to contain the Lie bracket of any
+two basis elements in its span.
 
 If `cached` is `true`, the constructed Lie algebra is cached.
 """

--- a/experimental/LieAlgebras/src/LinearLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LinearLieAlgebra.jl
@@ -43,10 +43,22 @@ base_ring(L::LinearLieAlgebra{C}) where {C<:RingElement} = L.R::parent_type(C)
 
 dim(L::LinearLieAlgebra{C}) where {C<:RingElement} = L.dim
 
+@doc raw"""
+    matrix_repr_basis(L::LinearLieAlgebra{C}) -> Vector{MatElem{C}}
+
+Return the basis `basis(L)` of the Lie algebra `L` in the underlying matrix
+representation.
+"""
 function matrix_repr_basis(L::LinearLieAlgebra{C}) where {C<:RingElement}
   return Vector{dense_matrix_type(C)}(L.basis)
 end
 
+@doc raw"""
+    matrix_repr_basis(L::LinearLieAlgebra{C}, i::Int) -> MatElem{C}
+
+Return the `i`-th element of the basis `basis(L)` of the Lie algebra `L` in the
+underlying matrix representation.
+"""
 function matrix_repr_basis(L::LinearLieAlgebra{C}, i::Int) where {C<:RingElement}
   return (L.basis[i])::dense_matrix_type(C)
 end
@@ -72,6 +84,16 @@ end
 #
 ###############################################################################
 
+@doc raw"""
+    (L::LinearLieAlgebra{C})(m::MatElem{C}) -> LieAlgebraElem{C}
+
+Return the Lie algebra element whose matrix representation corresponds to `m`.
+This requires `m` to be a square matrix of size `n` (the dimension of `L`), and
+to lie in the Lie algebra `L` (i.e. to be in the span of `basis(L)`).
+
+If `m` is a $1 \times \dim(L)` vector, it is assumed to be a coefficient vector in the
+basis `basis(L)`.
+"""
 function (L::LinearLieAlgebra{C})(m::MatElem{C}) where {C<:RingElement}
   if size(m) == (L.n, L.n)
     m = coefficient_vector(m, matrix_repr_basis(L))
@@ -86,6 +108,11 @@ end
 #
 ###############################################################################
 
+@doc raw"""
+    matrix_repr(x::LinearLieAlgebraElem{C}) -> Mat{C}
+
+Return the Lie algebra element `x` in the underlying matrix representation.
+"""
 function Generic.matrix_repr(x::LinearLieAlgebraElem{C}) where {C<:RingElement}
   return sum(c * b for (c, b) in zip(x.mat, matrix_repr_basis(parent(x))))
 end
@@ -106,12 +133,45 @@ end
 #
 ###############################################################################
 
+@doc raw"""
+    lie_algebra(R::Ring, n::Int, basis::Vector{<:MatElem{elem_type(R)}}, s::Vector{<:VarName}; cached::Bool) -> LinearLieAlgebra{elem_type(R)}
+
+Construct the Lie algebra over the ring `R` with basis `basis` and basis element names given by `s`. The basis elements must be square matrices of size `n`.
+We require `basis` to be linearly independent, and to contain the Lie bracket of any two basis elements in its span.
+
+If `cached` is `true`, the constructed Lie algebra is cached.
+"""
 function lie_algebra(
   R::Ring, n::Int, basis::Vector{<:MatElem{C}}, s::Vector{<:VarName}; cached::Bool=true
 ) where {C<:RingElement}
   return LinearLieAlgebra{elem_type(R)}(R, n, basis, Symbol.(s); cached)
 end
 
+@doc raw"""
+    general_linear_lie_algebra(R::Ring, n::Int) -> LinearLieAlgebra{elem_type(R)}
+
+Return the general linear Lie algebra $\mathfrak{gl}_n(R)$.
+
+# Examples
+```jldoctest
+julia> L = general_linear_lie_algebra(QQ, 2)
+LinearLieAlgebra (⊆ gl_2) over Rational Field
+
+julia> basis(L)
+4-element Vector{LinearLieAlgebraElem{QQFieldElem}}:
+ x_1_1
+ x_1_2
+ x_2_1
+ x_2_2
+
+julia> matrix_repr_basis(L)
+ 4-element Vector{QQMatrix}:
+  [1 0; 0 0]
+  [0 1; 0 0]
+  [0 0; 1 0]
+  [0 0; 0 1]
+```
+"""
 function general_linear_lie_algebra(R::Ring, n::Int)
   basis = [(b = zero_matrix(R, n, n); b[i, j] = 1; b) for i in 1:n for j in 1:n]
   s = ["x_$(i)_$(j)" for i in 1:n for j in 1:n]
@@ -120,6 +180,29 @@ function general_linear_lie_algebra(R::Ring, n::Int)
   return L
 end
 
+@doc raw"""
+    special_linear_lie_algebra(R::Ring, n::Int) -> LinearLieAlgebra{elem_type(R)}
+
+Return the special linear Lie algebra $\mathfrak{sl}_n(R)$.
+
+# Examples
+```jldoctest
+julia> L = special_linear_lie_algebra(QQ, 2)
+LinearLieAlgebra (⊆ gl_2) over Rational Field
+
+julia> basis(L)
+3-element Vector{LinearLieAlgebraElem{QQFieldElem}}:
+ e_1_2
+ f_1_2
+ h_1
+
+julia> matrix_repr_basis(L)
+3-element Vector{QQMatrix}:
+ [0 1; 0 0]
+ [0 0; 1 0]
+ [1 0; 0 -1]
+```
+"""
 function special_linear_lie_algebra(R::Ring, n::Int)
   basis_e = [(b = zero_matrix(R, n, n); b[i, j] = 1; b) for i in 1:n for j in (i + 1):n]
   basis_f = [(b = zero_matrix(R, n, n); b[j, i] = 1; b) for i in 1:n for j in (i + 1):n]
@@ -134,6 +217,29 @@ function special_linear_lie_algebra(R::Ring, n::Int)
   return L
 end
 
+@doc raw"""
+    special_orthogonal_lie_algebra(R::Ring, n::Int) -> LinearLieAlgebra{elem_type(R)}
+
+Return the special orthogonal Lie algebra $\mathfrak{so}_n(R)$.
+
+# Examples
+```jldoctest
+julia> L = special_orthogonal_lie_algebra(QQ, 3)
+LinearLieAlgebra (⊆ gl_3) over Rational Field
+
+julia> basis(L)
+3-element Vector{LinearLieAlgebraElem{QQFieldElem}}:
+ x_1_2
+ x_1_3
+ x_2_3
+
+julia> matrix_repr_basis(L)
+3-element Vector{QQMatrix}:
+ [0 1 0; -1 0 0; 0 0 0]
+ [0 0 1; 0 0 0; -1 0 0]
+ [0 0 0; 0 0 1; 0 -1 0]
+```
+"""
 function special_orthogonal_lie_algebra(R::Ring, n::Int)
   basis = [
     (b = zero_matrix(R, n, n); b[i, j] = 1; b[j, i] = -1; b) for i in 1:n for j in (i + 1):n

--- a/experimental/LieAlgebras/src/LinearLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LinearLieAlgebra.jl
@@ -88,14 +88,14 @@ end
     (L::LinearLieAlgebra{C})(m::MatElem{C}) -> LieAlgebraElem{C}
 
 Return the Lie algebra element whose matrix representation corresponds to `m`.
-This requires `m` to be a square matrix of size `n` (the dimension of `L`), and
+This requires `m` to be a square matrix of size `n > 1` (the dimension of `L`), and
 to lie in the Lie algebra `L` (i.e. to be in the span of `basis(L)`).
 
 If `m` is a $1 \times \dim(L)` vector, it is assumed to be a coefficient vector in the
 basis `basis(L)`.
 """
 function (L::LinearLieAlgebra{C})(m::MatElem{C}) where {C<:RingElement}
-  if size(m) == (L.n, L.n)
+  if L.n > 1 && size(m) == (L.n, L.n)
     m = coefficient_vector(m, matrix_repr_basis(L))
   end
   @req size(m) == (1, dim(L)) "Invalid matrix dimensions."

--- a/experimental/LieAlgebras/src/LinearLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LinearLieAlgebra.jl
@@ -157,7 +157,7 @@ Return the general linear Lie algebra $\mathfrak{gl}_n(R)$.
 # Examples
 ```jldoctest
 julia> L = general_linear_lie_algebra(QQ, 2)
-LinearLieAlgebra (⊆ gl_2) over Rational Field
+LinearLieAlgebra (⊆ gl_2) over Rational field
 
 julia> basis(L)
 4-element Vector{LinearLieAlgebraElem{QQFieldElem}}:
@@ -167,11 +167,11 @@ julia> basis(L)
  x_2_2
 
 julia> matrix_repr_basis(L)
- 4-element Vector{QQMatrix}:
-  [1 0; 0 0]
-  [0 1; 0 0]
-  [0 0; 1 0]
-  [0 0; 0 1]
+4-element Vector{QQMatrix}:
+ [1 0; 0 0]
+ [0 1; 0 0]
+ [0 0; 1 0]
+ [0 0; 0 1]
 ```
 """
 function general_linear_lie_algebra(R::Ring, n::Int)
@@ -190,7 +190,7 @@ Return the special linear Lie algebra $\mathfrak{sl}_n(R)$.
 # Examples
 ```jldoctest
 julia> L = special_linear_lie_algebra(QQ, 2)
-LinearLieAlgebra (⊆ gl_2) over Rational Field
+LinearLieAlgebra (⊆ gl_2) over Rational field
 
 julia> basis(L)
 3-element Vector{LinearLieAlgebraElem{QQFieldElem}}:
@@ -227,7 +227,7 @@ Return the special orthogonal Lie algebra $\mathfrak{so}_n(R)$.
 # Examples
 ```jldoctest
 julia> L = special_orthogonal_lie_algebra(QQ, 3)
-LinearLieAlgebra (⊆ gl_3) over Rational Field
+LinearLieAlgebra (⊆ gl_3) over Rational field
 
 julia> basis(L)
 3-element Vector{LinearLieAlgebraElem{QQFieldElem}}:

--- a/experimental/LieAlgebras/src/Util.jl
+++ b/experimental/LieAlgebras/src/Util.jl
@@ -28,36 +28,3 @@ function coefficient_vector(
   end
   return transpose(solve(lgs, rhs))
 end
-
-"""
-    is_valid_dynkin(dynkin::Char, n::Int)
-
-Check if there given parameters uniquely define a dynkin diagram,
-i.e. are of one of the forms
-  * ``A_n`` for ``n \\geq 1``,
-  * ``B_n`` for ``n \\geq 2``,
-  * ``C_n`` for ``n \\geq 2``,
-  * ``D_n`` for ``n \\geq 4``,
-  * ``E_5``, ``E_6``, ``E_7``,
-  * ``F_4``,
-  * ``G_2``.
-"""
-function is_valid_dynkin(dynkin::Char, n::Int)
-  if dynkin == 'A'
-    return n >= 1
-  elseif dynkin == 'B'
-    return n >= 2
-  elseif dynkin == 'C'
-    return n >= 2
-  elseif dynkin == 'D'
-    return n >= 4
-  elseif dynkin == 'E'
-    return 6 <= n <= 8
-  elseif dynkin == 'F'
-    return n == 4
-  elseif dynkin == 'G'
-    return n == 2
-  else
-    return false
-  end
-end


### PR DESCRIPTION
This PR adds documentation to the LieAlgebras folder in experimental.

Weirdly, some docstrings will not show up in the HTML, e.g. `(::LieAlgebra{C})(::Vector{C}) where {C<:RingElement}`.
Can someone help me with that?

Edit: Additionally some minor changes.