### PR TITLE
Change return argument order of `is_prime_power_with_data`

### DIFF
--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -366,7 +366,7 @@ is_sporadic_simple(G::GrpAbFinGen) = false
 function is_pgroup_with_prime(::Type{T}, G::GrpAbFinGen) where T <: IntegerUnion
   is_trivial(G) && return true, nothing
   is_finite(G) || return false, nothing
-  flag, p, e = is_prime_power_with_data(order(G))
+  flag, _, p = is_prime_power_with_data(order(G))
   flag && return true, T(p)
   return false, nothing
 end
@@ -382,7 +382,7 @@ nilpotency_class(G::GrpAbFinGen) = (order(G) == 1 ? 0 : 1)
 # prime_of_pgroup.
 # TODO: enhance @gapattribute so this is not necessary
 function _prime_of_pgroup(G::GrpAbFinGen)
-  flag, p, e = is_prime_power_with_data(order(G))
+  flag, _, p = is_prime_power_with_data(order(G))
   @req flag "only supported for non-trivial p-groups"
   return p
 end

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -864,7 +864,7 @@ julia> gens(H)
 ```
 """
 function unitary_group(n::Int, q::Int)
-   fl, b, a = is_prime_power_with_data(q)
+   fl, a, b = is_prime_power_with_data(q)
    @req fl "The field size must be a prime power"
    G = MatrixGroup(n,GF(b, 2*a))
    G.descr = :GU
@@ -890,7 +890,7 @@ julia> gens(H)
 ```
 """
 function special_unitary_group(n::Int, q::Int)
-   fl, b, a = is_prime_power_with_data(q)
+   fl, a, b = is_prime_power_with_data(q)
    @req fl "The field size must be a prime power"
    G = MatrixGroup(n,GF(b, 2*a))
    G.descr = :SU


### PR DESCRIPTION
Downstream sibling PR to https://github.com/Nemocas/Nemo.jl/pull/1484.

This should fix all uses of is_prime_power_with_data in OSCAR, after the Nemo-PR has been merged.