### PR TITLE
Bump `Aqua.jl` to `0.6.2`

### DIFF
--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -7,7 +7,7 @@ using Aqua
     unbound_args=false,     # TODO: fix unbound type parameters
     undefined_exports=true,
     project_extras=true,
-    stale_deps=false,       # some weird error with GAP_lib_jll
+    stale_deps=true,
     deps_compat=true,
     project_toml_formatting=true,
     piracy=false,           # TODO: check the reported methods to be moved upstream

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,4 +6,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Aqua = "0.6"
+Aqua = "0.6.2"


### PR DESCRIPTION
Bump Aqua.jl to have https://github.com/JuliaTesting/Aqua.jl/pull/113 available.
Cf. https://github.com/oscar-system/Oscar.jl/issues/2385#issuecomment-1556655585

cc @fingolfin