### PR TITLE
Cleanup of `Groups/directproducts.jl`

### DIFF
--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -44,6 +44,7 @@ julia> elements(G)
 ```
 """
 function direct_product(L::AbstractVector{<:GAPGroup}; morphisms=false)
+  @req length(L) > 0 "the collection of groups must be non-empty"
   X = GAP.Globals.DirectProduct(GapObj([G.X for G in L]))
   DP = DirectProductGroup(X, L, X, true)
   if morphisms
@@ -57,8 +58,8 @@ function direct_product(L::AbstractVector{<:GAPGroup}; morphisms=false)
   end
 end
 
-function direct_product(L::GAPGroup...; morphisms=false)
-  return direct_product([x for x in L]; morphisms=morphisms)
+function direct_product(L::GAPGroup, Ls::GAPGroup...; morphisms=false)
+  return direct_product([L, Ls...]; morphisms=morphisms)
 end
 
 """
@@ -76,6 +77,7 @@ vectors of the embeddings (resp. projections) of the direct product `G`.
 function inner_direct_product(
   L::AbstractVector{T}; morphisms=false
 ) where {T<:Union{PcGroup,FPGroup}}
+  @req length(L) > 0 "the collection of groups must be non-empty"
   P = GAP.Globals.DirectProduct(GapObj([G.X for G in L]))
   DP = T(P)
   if morphisms
@@ -90,6 +92,7 @@ function inner_direct_product(
 end
 
 function inner_direct_product(L::AbstractVector{PermGroup}; morphisms=false)
+  @req length(L) > 0 "the collection of groups must be non-empty"
   P = GAP.Globals.DirectProductOfPermGroupsWithMovedPoints(
     GapObj([G.X for G in L]), GAP.Obj([collect(1:degree(G)) for G in L]; recursive=true)
   )
@@ -106,9 +109,9 @@ function inner_direct_product(L::AbstractVector{PermGroup}; morphisms=false)
 end
 
 function inner_direct_product(
-  L::T...; morphisms=false
+  L::T, Ls::T...; morphisms=false
 ) where {T<:Union{PcGroup,PermGroup,FPGroup}}
-  return inner_direct_product([x for x in L]; morphisms=morphisms)
+  return inner_direct_product([L, Ls...]; morphisms=morphisms)
 end
 
 """
@@ -119,13 +122,12 @@ Return the number of factors of `G`.
 number_of_factors(G::DirectProductGroup) = length(G.L)
 
 """
-    cartesian_power(G::T, n::Int)
+    cartesian_power(G::GAPGroup, n::Int)
 
 Return the direct product of `n` copies of `G`.
 """
 function cartesian_power(G::GAPGroup, n::Int)
-  L = [G for i in 1:n]
-  return direct_product(L)
+  return direct_product(fill(G, n))
 end
 
 """
@@ -138,8 +140,7 @@ the output is a triple (`G`, `emb`, `proj`), where `emb` and `proj` are the
 vectors of the embeddings (resp. projections) of the direct product `G`.
 """
 function inner_cartesian_power(G::T, n::Int; morphisms=false) where {T<:GAPGroup}
-  L = [G for i in 1:n]
-  return inner_direct_product(L; morphisms=morphisms)
+  return inner_direct_product(fill(G, n); morphisms=morphisms)
 end
 
 """
@@ -307,8 +308,8 @@ function (G::DirectProductGroup)(V::AbstractVector{<:GAPGroupElem})
   return group_element(G, xgap)
 end
 
-function (G::DirectProductGroup)(V::GAPGroupElem...)
-  return G([x for x in V])
+function (G::DirectProductGroup)(v::GAPGroupElem, V::GAPGroupElem...)
+  return G([v, V...])
 end
 
 function _as_subgroup_bare(G::DirectProductGroup, H::GapObj)

--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -137,9 +137,8 @@ end
 Return the `j`-th factor of `G`.
 """
 function factor_of_direct_product(G::DirectProductGroup, j::Int)
-   if j in 1:length(G.L) return G.L[j]
-   else throw(ArgumentError("index not valid"))
-   end
+  @req j in 1:length(G.L) "index not valid"
+  return G.L[j]
 end
 
 """
@@ -165,11 +164,8 @@ Group([ (1,2,3), (1,2), (4,5) ])
 ```
 """
 function as_perm_group(G::DirectProductGroup)
-   if [typeof(H)==PermGroup for H in G.L]==[true for i in 1:length(G.L)]
-      return PermGroup(G.X, GAP.Globals.Maximum(GAP.Globals.MovedPoints(G.X)))
-   else
-      throw(ArgumentError("The group is not a permutation group"))
-   end
+  @req all(H -> H isa PermGroup, G.L) "The group is not a permutation group"
+  return PermGroup(G.X, GAP.Globals.Maximum(GAP.Globals.MovedPoints(G.X)))
 end
 
 """
@@ -178,11 +174,8 @@ end
 If `G` is direct product of polycyclic groups, return `G` as polycyclic group.
 """
 function as_polycyclic_group(G::DirectProductGroup)
-   if [typeof(H)==PcGroup for H in G.L]==[true for i in 1:length(G.L)]
-      return PcGroup(G.X)
-   else
-      throw(ArgumentError("The group is not a polycyclic group"))
-   end
+  @req all(H -> H isa PcGroup, G.L) "The group is not a polycyclic group"
+  return PcGroup(G.X)
 end
 
 """
@@ -240,7 +233,6 @@ function embedding(G::DirectProductGroup, j::Int)
    @req G.isfull "Embedding is not defined for proper subgroups of direct products"
    f=GAP.Globals.Embedding(G.X,j)
    gr=G.L[j]
-   typeG=typeof(gr)
    return GAPGroupHomomorphism(gr,G,f)
 end
 
@@ -289,8 +281,8 @@ julia> proj2(g)
 ```
 """
 function projection(G::DirectProductGroup, j::Int)
+  @req j in 1:length(G.L) "index not valid"
    f=GAP.Globals.Projection(G.Xfull,j)
-   @req j in 1:length(G.L) "index not valid"
    H = G.L[j]
    p = GAPWrap.GroupHomomorphismByFunction(G.X,H.X,y->GAPWrap.Image(f,y))
    return GAPGroupHomomorphism(G,H,p)
@@ -417,7 +409,7 @@ Return the embedding of the `n`-th component of `G` into `G`, for `n` = 1,2.
 It is not defined for proper subgroups of semidirect products.
 """
 function embedding(G::SemidirectProductGroup, n::Int)
-   @assert G.isfull "Embedding not defined for proper subgroups of semidirect products"
+   @req G.isfull "Embedding not defined for proper subgroups of semidirect products"
    if n==1
       f=GAP.Globals.Embedding(G.X,2)
       gr=G.N
@@ -523,7 +515,9 @@ end
 function (W::WreathProductGroup)(L::Union{GAPGroupElem{T},GAPGroupElem{PermGroup}}...) where T <: GAPGroup
    d = GAP.Globals.NrMovedPoints(GAPWrap.Image(W.a.map))
    @req length(L)==d+1 "Wrong number of arguments"
-   for i in 1:d @assert L[i] in W.G "Wrong input" end
+   for i in 1:d
+      @req L[i] in W.G "Wrong input"
+   end
    @req L[d+1] in W.H "Wrong input"
 # simply put parent(L[d+1])==W.H does not work. Example: if I want to write explicitly a permutation in H proper subgroup of Sym(n).
    arr = [GAPWrap.Image(GAP.Globals.Embedding(W.Xfull,i),L[i].X) for i in 1:length(L)]
@@ -598,7 +592,7 @@ is_full_wreath_product(G::WreathProductGroup) = G.isfull
 Return the projection of `wreath_product(G,H)` onto the permutation group `H`.
 """
 function projection(W::WreathProductGroup)
-  # @assert W.isfull "Projection not defined for proper subgroups of wreath products"
+  #  @req W.isfull "Projection not defined for proper subgroups of wreath products"
    f=GAP.Globals.Projection(W.Xfull)
    H = W.H
    p = GAPWrap.GroupHomomorphismByFunction(W.X,H.X,y->GAPWrap.Image(f,y))

--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -44,19 +44,21 @@ julia> elements(G)
 ```
 """
 function direct_product(L::AbstractVector{<:GAPGroup}; morphisms=false)
-   X = GAP.Globals.DirectProduct(GapObj([G.X for G in L]))
-   DP = DirectProductGroup(X,L,X,true)
-   if morphisms
-      emb = [GAPGroupHomomorphism(L[i],DP,GAP.Globals.Embedding(X,i)) for i in 1:length(L)]
-      proj = [GAPGroupHomomorphism(DP,L[i],GAP.Globals.Projection(X,i)) for i in 1:length(L)]
-      return DP, emb, proj
-   else
-      return DP
-   end
+  X = GAP.Globals.DirectProduct(GapObj([G.X for G in L]))
+  DP = DirectProductGroup(X, L, X, true)
+  if morphisms
+    emb = [GAPGroupHomomorphism(L[i], DP, GAP.Globals.Embedding(X, i)) for i in 1:length(L)]
+    proj = [
+      GAPGroupHomomorphism(DP, L[i], GAP.Globals.Projection(X, i)) for i in 1:length(L)
+    ]
+    return DP, emb, proj
+  else
+    return DP
+  end
 end
 
 function direct_product(L::GAPGroup...; morphisms=false)
-   return direct_product([x for x in L]; morphisms=morphisms)
+  return direct_product([x for x in L]; morphisms=morphisms)
 end
 
 """
@@ -71,33 +73,42 @@ The parameter `morphisms` is `false` by default. If it is set `true`, then
 the output is a triple (`G`, `emb`, `proj`), where `emb` and `proj` are the
 vectors of the embeddings (resp. projections) of the direct product `G`.
 """
-function inner_direct_product(L::AbstractVector{T}; morphisms=false) where T<:Union{PcGroup,FPGroup}
-   P = GAP.Globals.DirectProduct(GapObj([G.X for G in L]))
-   DP = T(P)
-   if morphisms
-      emb = [GAPGroupHomomorphism(L[i],DP,GAP.Globals.Embedding(P,i)) for i in 1:length(L)]
-      proj = [GAPGroupHomomorphism(DP,L[i],GAP.Globals.Projection(P,i)) for i in 1:length(L)]
-      return DP, emb, proj
-   else
-      return DP
-   end
+function inner_direct_product(
+  L::AbstractVector{T}; morphisms=false
+) where {T<:Union{PcGroup,FPGroup}}
+  P = GAP.Globals.DirectProduct(GapObj([G.X for G in L]))
+  DP = T(P)
+  if morphisms
+    emb = [GAPGroupHomomorphism(L[i], DP, GAP.Globals.Embedding(P, i)) for i in 1:length(L)]
+    proj = [
+      GAPGroupHomomorphism(DP, L[i], GAP.Globals.Projection(P, i)) for i in 1:length(L)
+    ]
+    return DP, emb, proj
+  else
+    return DP
+  end
 end
 
-function inner_direct_product(L::AbstractVector{PermGroup}; morphisms=false) 
-   P = GAP.Globals.DirectProductOfPermGroupsWithMovedPoints(GapObj([G.X for G in L]), GAP.Obj([collect(1:degree(G)) for G in L], recursive = true))
-   DP = PermGroup(P, sum([degree(G) for G in L], init = 0))
-   if morphisms
-      emb = [GAPGroupHomomorphism(L[i],DP,GAP.Globals.Embedding(P,i)) for i in 1:length(L)]
-      proj = [GAPGroupHomomorphism(DP,L[i],GAP.Globals.Projection(P,i)) for i in 1:length(L)]
-      return DP, emb, proj
-   else
-      return DP
-   end
+function inner_direct_product(L::AbstractVector{PermGroup}; morphisms=false)
+  P = GAP.Globals.DirectProductOfPermGroupsWithMovedPoints(
+    GapObj([G.X for G in L]), GAP.Obj([collect(1:degree(G)) for G in L]; recursive=true)
+  )
+  DP = PermGroup(P, sum([degree(G) for G in L]; init=0))
+  if morphisms
+    emb = [GAPGroupHomomorphism(L[i], DP, GAP.Globals.Embedding(P, i)) for i in 1:length(L)]
+    proj = [
+      GAPGroupHomomorphism(DP, L[i], GAP.Globals.Projection(P, i)) for i in 1:length(L)
+    ]
+    return DP, emb, proj
+  else
+    return DP
+  end
 end
 
-
-function inner_direct_product(L::T... ; morphisms=false) where T<:Union{PcGroup,PermGroup,FPGroup}
-   return inner_direct_product([x for x in L]; morphisms=morphisms)
+function inner_direct_product(
+  L::T...; morphisms=false
+) where {T<:Union{PcGroup,PermGroup,FPGroup}}
+  return inner_direct_product([x for x in L]; morphisms=morphisms)
 end
 
 """
@@ -113,8 +124,8 @@ number_of_factors(G::DirectProductGroup) = length(G.L)
 Return the direct product of `n` copies of `G`.
 """
 function cartesian_power(G::GAPGroup, n::Int)
-   L = [G for i in 1:n]
-   return direct_product(L)
+  L = [G for i in 1:n]
+  return direct_product(L)
 end
 
 """
@@ -126,9 +137,9 @@ The parameter `morphisms` is `false` by default. If it is set `true`, then
 the output is a triple (`G`, `emb`, `proj`), where `emb` and `proj` are the
 vectors of the embeddings (resp. projections) of the direct product `G`.
 """
-function inner_cartesian_power(G::T, n::Int; morphisms=false) where T <: GAPGroup
-   L = [G for i in 1:n]
-   return inner_direct_product(L; morphisms=morphisms)
+function inner_cartesian_power(G::T, n::Int; morphisms=false) where {T<:GAPGroup}
+  L = [G for i in 1:n]
+  return inner_direct_product(L; morphisms=morphisms)
 end
 
 """
@@ -229,11 +240,11 @@ julia> emb1(h)*emb2(k)
 ```
 """
 function embedding(G::DirectProductGroup, j::Int)
-   @req j in 1:length(G.L) "index not valid"
-   @req G.isfull "Embedding is not defined for proper subgroups of direct products"
-   f=GAP.Globals.Embedding(G.X,j)
-   gr=G.L[j]
-   return GAPGroupHomomorphism(gr,G,f)
+  @req j in 1:length(G.L) "index not valid"
+  @req G.isfull "Embedding is not defined for proper subgroups of direct products"
+  f = GAP.Globals.Embedding(G.X, j)
+  gr = G.L[j]
+  return GAPGroupHomomorphism(gr, G, f)
 end
 
 """
@@ -282,37 +293,38 @@ julia> proj2(g)
 """
 function projection(G::DirectProductGroup, j::Int)
   @req j in 1:length(G.L) "index not valid"
-   f=GAP.Globals.Projection(G.Xfull,j)
-   H = G.L[j]
-   p = GAPWrap.GroupHomomorphismByFunction(G.X,H.X,y->GAPWrap.Image(f,y))
-   return GAPGroupHomomorphism(G,H,p)
+  f = GAP.Globals.Projection(G.Xfull, j)
+  H = G.L[j]
+  p = GAPWrap.GroupHomomorphismByFunction(G.X, H.X, y -> GAPWrap.Image(f, y))
+  return GAPGroupHomomorphism(G, H, p)
 end
 
-
 function (G::DirectProductGroup)(V::AbstractVector{<:GAPGroupElem})
-   @req length(V)==length(G.L) "Wrong number of entries"
-   arr = [GAPWrap.Image(GAP.Globals.Embedding(G.Xfull,i),V[i].X) for i in 1:length(V)]
-   xgap = prod(arr)
-   @req xgap in G.X "Element not in the group"
-   return group_element(G,xgap)
+  @req length(V) == length(G.L) "Wrong number of entries"
+  arr = [GAPWrap.Image(GAP.Globals.Embedding(G.Xfull, i), V[i].X) for i in 1:length(V)]
+  xgap = prod(arr)
+  @req xgap in G.X "Element not in the group"
+  return group_element(G, xgap)
 end
 
 function (G::DirectProductGroup)(V::GAPGroupElem...)
-   return G([x for x in V])
+  return G([x for x in V])
 end
 
 function _as_subgroup_bare(G::DirectProductGroup, H::GapObj)
-#  t = H==G.X
+  #  t = H==G.X
   return DirectProductGroup(H, G.L, G.X, false)
 end
 
 function Base.show(io::IO, G::DirectProductGroup)
-   if G.isfull
-      print(io, "DirectProduct of")
-      for x in G.L print(io, "\n ", x) end
-   else
-      print(io, String(GAPWrap.StringViewObj(G.X)))
-   end
+  if G.isfull
+    print(io, "DirectProduct of")
+    for x in G.L
+      print(io, "\n ", x)
+    end
+  else
+    print(io, String(GAPWrap.StringViewObj(G.X)))
+  end
 end
 
 # if a subgroup of a direct product of groups is also a direct product of groups
@@ -327,15 +339,15 @@ return this full direct product of the $H_i$.
 An exception is thrown if such $H_i$ do not exist.
 """
 function write_as_full(G::DirectProductGroup)
-   if G.isfull
-      return G
-   else
-      LK = [image(projection(G,j))[1] for j in 1:length(G.L)]
-      H = direct_product(LK)
-# index(H,G)==1 does not work because it does not recognize G as a subgroup of H
-      @req order(H)==order(G) "G is not a direct product of groups"
-      return H
-   end
+  if G.isfull
+    return G
+  else
+    LK = [image(projection(G, j))[1] for j in 1:length(G.L)]
+    H = direct_product(LK)
+    # index(H,G)==1 does not work because it does not recognize G as a subgroup of H
+    @req order(H) == order(G) "G is not a direct product of groups"
+    return H
+  end
 end
 
 """
@@ -346,7 +358,6 @@ Return whether `G` is direct product of its factors (`false` if it is a proper s
 is_full_direct_product(G::DirectProductGroup) = G.isfull
 
 Base.:^(H::DirectProductGroup, y::GAPGroupElem) = sub([h^y for h in gens(H)]...)[1]
-
 
 ################################################################################
 #
@@ -360,17 +371,23 @@ Base.:^(H::DirectProductGroup, y::GAPGroupElem) = sub([h^y for h in gens(H)]...)
 Return the semidirect product of `N` and `H`, of type `SemidirectProductGroup{S,T}`,
 where `f` is a group homomorphism from `H` to the automorphism group of `N`.
 """
-function semidirect_product(N::S, f::GAPGroupHomomorphism{T,AutomorphismGroup{S}}, H::T) where S <: GAPGroup where T <: GAPGroup
-   sdp=GAP.Globals.SemidirectProduct(H.X,f.map,N.X)
-   return SemidirectProductGroup{S,T}(sdp,N,H,f,sdp,true)
+function semidirect_product(
+  N::S, f::GAPGroupHomomorphism{T,AutomorphismGroup{S}}, H::T
+) where {S<:GAPGroup} where {T<:GAPGroup}
+  sdp = GAP.Globals.SemidirectProduct(H.X, f.map, N.X)
+  return SemidirectProductGroup{S,T}(sdp, N, H, f, sdp, true)
 end
 
 # return the element (a,b) in G
-function (G::SemidirectProductGroup{S,T})(a::GAPGroupElem{S},b::GAPGroupElem{T}) where {S,T}
-# simply put parent(L[d+1])==W.H does not work. Example: if I want to write explicitly a permutation in H proper subgroup of Sym(n).
-   xgap = GAPWrap.Image(GAP.Globals.Embedding(G.Xfull,1),b.X)*GAPWrap.Image(GAP.Globals.Embedding(G.Xfull,2),a.X)
-   @req xgap in G.X "Element not in the group"
-   return group_element(G,xgap)
+function (G::SemidirectProductGroup{S,T})(
+  a::GAPGroupElem{S}, b::GAPGroupElem{T}
+) where {S,T}
+  # simply put parent(L[d+1])==W.H does not work. Example: if I want to write explicitly a permutation in H proper subgroup of Sym(n).
+  xgap =
+    GAPWrap.Image(GAP.Globals.Embedding(G.Xfull, 1), b.X) *
+    GAPWrap.Image(GAP.Globals.Embedding(G.Xfull, 2), a.X)
+  @req xgap in G.X "Element not in the group"
+  return group_element(G, xgap)
 end
 
 """
@@ -409,17 +426,17 @@ Return the embedding of the `n`-th component of `G` into `G`, for `n` = 1,2.
 It is not defined for proper subgroups of semidirect products.
 """
 function embedding(G::SemidirectProductGroup, n::Int)
-   @req G.isfull "Embedding not defined for proper subgroups of semidirect products"
-   if n==1
-      f=GAP.Globals.Embedding(G.X,2)
-      gr=G.N
-   elseif n==2
-      f=GAP.Globals.Embedding(G.X,1)
-      gr=G.H
-   else
-      throw(ArgumentError("n must be 1 or 2"))
-   end
-   return GAPGroupHomomorphism(gr,G,f)
+  @req G.isfull "Embedding not defined for proper subgroups of semidirect products"
+  if n == 1
+    f = GAP.Globals.Embedding(G.X, 2)
+    gr = G.N
+  elseif n == 2
+    f = GAP.Globals.Embedding(G.X, 1)
+    gr = G.H
+  else
+    throw(ArgumentError("n must be 1 or 2"))
+  end
+  return GAPGroupHomomorphism(gr, G, f)
 end
 
 """
@@ -428,24 +445,30 @@ end
 Return the projection of `G` into the second component of `G`.
 """
 function projection(G::SemidirectProductGroup)
-   f=GAP.Globals.Projection(G.Xfull)
-   H = G.H
-   p = GAPWrap.GroupHomomorphismByFunction(G.X,H.X,y->GAPWrap.Image(f,y))
-   return GAPGroupHomomorphism(G,H,p)
+  f = GAP.Globals.Projection(G.Xfull)
+  H = G.H
+  p = GAPWrap.GroupHomomorphismByFunction(G.X, H.X, y -> GAPWrap.Image(f, y))
+  return GAPGroupHomomorphism(G, H, p)
 end
 
-function _as_subgroup_bare(G::SemidirectProductGroup{S,T}, H::GapObj) where { S , T }
-#  t = G.X==H
+function _as_subgroup_bare(G::SemidirectProductGroup{S,T}, H::GapObj) where {S,T}
+  #  t = G.X==H
   return SemidirectProductGroup{S,T}(H, G.N, G.H, G.f, G.X, false)
 end
 
 function Base.show(io::IO, x::SemidirectProductGroup)
-   if x.isfull
-      print(io, "SemidirectProduct( ", String(GAPWrap.StringViewObj(x.N.X)),
-                " , ", String(GAP.Globals.StringView(x.H.X))," )")
-   else
-      print(io, String(GAPWrap.StringViewObj(x.X)))
-   end
+  if x.isfull
+    print(
+      io,
+      "SemidirectProduct( ",
+      String(GAPWrap.StringViewObj(x.N.X)),
+      " , ",
+      String(GAP.Globals.StringView(x.H.X)),
+      " )",
+    )
+  else
+    print(io, String(GAPWrap.StringViewObj(x.X)))
+  end
 end
 
 ################################################################################
@@ -493,39 +516,42 @@ julia> a*b
 WreathProductElement(f1,<identity> of ...,(1,2))
 ```
 """
-function wreath_product(G::T, H::PermGroup) where T<: GAPGroup
-   if Set{Int}(GAP.Globals.MovedPoints(H.X))==Set(1:H.deg)
-      Wgap=GAP.Globals.WreathProduct(G.X,H.X)
-      return WreathProductGroup(Wgap,G,H,id_hom(H),Wgap,true)
-   else
-      S=symmetric_group(H.deg)
-      Wgap=GAP.Globals.WreathProduct(G.X,S.X)
-      W1=GAP.Globals.PreImage(GAP.Globals.Projection(Wgap),H.X)
-   # not id_hom(H) because I need NrMovedPoints(Image(a))==degree(H), see function embedding
-      return WreathProductGroup(W1,G,H,id_hom(symmetric_group(H.deg)),Wgap,true)
-   end
+function wreath_product(G::T, H::PermGroup) where {T<:GAPGroup}
+  if Set{Int}(GAP.Globals.MovedPoints(H.X)) == Set(1:(H.deg))
+    Wgap = GAP.Globals.WreathProduct(G.X, H.X)
+    return WreathProductGroup(Wgap, G, H, id_hom(H), Wgap, true)
+  else
+    S = symmetric_group(H.deg)
+    Wgap = GAP.Globals.WreathProduct(G.X, S.X)
+    W1 = GAP.Globals.PreImage(GAP.Globals.Projection(Wgap), H.X)
+    # not id_hom(H) because I need NrMovedPoints(Image(a))==degree(H), see function embedding
+    return WreathProductGroup(W1, G, H, id_hom(symmetric_group(H.deg)), Wgap, true)
+  end
 end
 
-function wreath_product(G::T, H::S, a::GAPGroupHomomorphism{S,PermGroup}) where S<:GAPGroup where T<:GAPGroup
-   Wgap=GAP.Globals.WreathProduct(G.X,H.X,a.map)
-   return WreathProductGroup(Wgap,G,H,a,Wgap,true)
+function wreath_product(
+  G::T, H::S, a::GAPGroupHomomorphism{S,PermGroup}
+) where {S<:GAPGroup} where {T<:GAPGroup}
+  Wgap = GAP.Globals.WreathProduct(G.X, H.X, a.map)
+  return WreathProductGroup(Wgap, G, H, a, Wgap, true)
 end
 
 # return the element (L[1],L[2],...) in W
-function (W::WreathProductGroup)(L::Union{GAPGroupElem{T},GAPGroupElem{PermGroup}}...) where T <: GAPGroup
-   d = GAP.Globals.NrMovedPoints(GAPWrap.Image(W.a.map))
-   @req length(L)==d+1 "Wrong number of arguments"
-   for i in 1:d
-      @req L[i] in W.G "Wrong input"
-   end
-   @req L[d+1] in W.H "Wrong input"
-# simply put parent(L[d+1])==W.H does not work. Example: if I want to write explicitly a permutation in H proper subgroup of Sym(n).
-   arr = [GAPWrap.Image(GAP.Globals.Embedding(W.Xfull,i),L[i].X) for i in 1:length(L)]
-   xgap = prod(arr)
-   @req xgap in W.X "Element not in the group"
-   return group_element(W,xgap)
+function (W::WreathProductGroup)(
+  L::Union{GAPGroupElem{T},GAPGroupElem{PermGroup}}...
+) where {T<:GAPGroup}
+  d = GAP.Globals.NrMovedPoints(GAPWrap.Image(W.a.map))
+  @req length(L) == d + 1 "Wrong number of arguments"
+  for i in 1:d
+    @req L[i] in W.G "Wrong input"
+  end
+  @req L[d + 1] in W.H "Wrong input"
+  # simply put parent(L[d+1])==W.H does not work. Example: if I want to write explicitly a permutation in H proper subgroup of Sym(n).
+  arr = [GAPWrap.Image(GAP.Globals.Embedding(W.Xfull, i), L[i].X) for i in 1:length(L)]
+  xgap = prod(arr)
+  @req xgap in W.X "Element not in the group"
+  return group_element(W, xgap)
 end
-
 
 """
     normal_subgroup(W::WreathProductGroup)
@@ -593,10 +619,10 @@ Return the projection of `wreath_product(G,H)` onto the permutation group `H`.
 """
 function projection(W::WreathProductGroup)
   #  @req W.isfull "Projection not defined for proper subgroups of wreath products"
-   f=GAP.Globals.Projection(W.Xfull)
-   H = W.H
-   p = GAPWrap.GroupHomomorphismByFunction(W.X,H.X,y->GAPWrap.Image(f,y))
-   return GAPGroupHomomorphism(W,H,p)
+  f = GAP.Globals.Projection(W.Xfull)
+  H = W.H
+  p = GAPWrap.GroupHomomorphismByFunction(W.X, H.X, y -> GAPWrap.Image(f, y))
+  return GAPGroupHomomorphism(W, H, p)
 end
 
 """
@@ -605,23 +631,21 @@ end
 Return the embedding of the `n`-th component of `G` into `G`.
 """
 function embedding(W::WreathProductGroup, n::Int)
-   @req W.isfull "Embedding not defined for proper subgroups of wreath products"
-   @req n <= GAP.Globals.NrMovedPoints(GAPWrap.Image(W.a.map))+1 "n is too big"
-   f = GAP.Globals.Embedding(W.Xfull,n)
-   if n== GAP.Globals.NrMovedPoints(GAPWrap.Image(W.a.map))+1 C=W.H
-   else C=W.G
-   end
-   return GAPGroupHomomorphism(C,W,f)
+  @req W.isfull "Embedding not defined for proper subgroups of wreath products"
+  @req n <= GAP.Globals.NrMovedPoints(GAPWrap.Image(W.a.map)) + 1 "n is too big"
+  f = GAP.Globals.Embedding(W.Xfull, n)
+  if n == GAP.Globals.NrMovedPoints(GAPWrap.Image(W.a.map)) + 1
+    C = W.H
+  else
+    C = W.G
+  end
+  return GAPGroupHomomorphism(C, W, f)
 end
 
 Base.show(io::IO, x::WreathProductGroup) = print(io, String(GAP.Globals.StringView(x.X)))
 
-
 #TODO : to be fixed
 function _as_subgroup_bare(W::WreathProductGroup, X::GapObj)
-#   t = X==W.X
+  #   t = X==W.X
   return WreathProductGroup(X, W.G, W.H, W.a, W.Xfull, false)
 end
-
-
-

--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -10,7 +10,7 @@
 
 Return the direct product of the groups in the collection `L`.
 
-The parameter `morphisms` is `false` by default. If it is set `true`, then
+The keyword argument `morphisms` is `false` by default. If it is set `true`, then
 the output is a triple (`G`, `emb`, `proj`), where `emb` and `proj` are the
 vectors of the embeddings (resp. projections) of the direct product `G`.
 
@@ -43,7 +43,7 @@ julia> elements(G)
  (1,3)(4,5)
 ```
 """
-function direct_product(L::AbstractVector{<:GAPGroup}; morphisms=false)
+function direct_product(L::AbstractVector{<:GAPGroup}; morphisms::Bool=false)
   @req length(L) > 0 "the collection of groups must be non-empty"
   X = GAP.Globals.DirectProduct(GapObj([G.X for G in L]))
   DP = DirectProductGroup(X, L, X, true)
@@ -58,7 +58,7 @@ function direct_product(L::AbstractVector{<:GAPGroup}; morphisms=false)
   end
 end
 
-function direct_product(L::GAPGroup, Ls::GAPGroup...; morphisms=false)
+function direct_product(L::GAPGroup, Ls::GAPGroup...; morphisms::Bool=false)
   return direct_product([L, Ls...]; morphisms=morphisms)
 end
 
@@ -70,12 +70,12 @@ Return a direct product of groups of the same type `T` as a group of type
 `T`. It works for `T` of the following types:
 - `PermGroup`, `PcGroup`, `FPGroup`.
 
-The parameter `morphisms` is `false` by default. If it is set `true`, then
+The keyword argument `morphisms` is `false` by default. If it is set `true`, then
 the output is a triple (`G`, `emb`, `proj`), where `emb` and `proj` are the
 vectors of the embeddings (resp. projections) of the direct product `G`.
 """
 function inner_direct_product(
-  L::AbstractVector{T}; morphisms=false
+  L::AbstractVector{T}; morphisms::Bool=false
 ) where {T<:Union{PcGroup,FPGroup}}
   @req length(L) > 0 "the collection of groups must be non-empty"
   P = GAP.Globals.DirectProduct(GapObj([G.X for G in L]))
@@ -91,7 +91,7 @@ function inner_direct_product(
   end
 end
 
-function inner_direct_product(L::AbstractVector{PermGroup}; morphisms=false)
+function inner_direct_product(L::AbstractVector{PermGroup}; morphisms::Bool=false)
   @req length(L) > 0 "the collection of groups must be non-empty"
   P = GAP.Globals.DirectProductOfPermGroupsWithMovedPoints(
     GapObj([G.X for G in L]), GAP.Obj([collect(1:degree(G)) for G in L]; recursive=true)
@@ -109,7 +109,7 @@ function inner_direct_product(L::AbstractVector{PermGroup}; morphisms=false)
 end
 
 function inner_direct_product(
-  L::T, Ls::T...; morphisms=false
+  L::T, Ls::T...; morphisms::Bool=false
 ) where {T<:Union{PcGroup,PermGroup,FPGroup}}
   return inner_direct_product([L, Ls...]; morphisms=morphisms)
 end
@@ -135,11 +135,11 @@ end
 
 Return the direct product of `n` copies of `G` as group of type `T`.
 
-The parameter `morphisms` is `false` by default. If it is set `true`, then
+The keyword argument `morphisms` is `false` by default. If it is set `true`, then
 the output is a triple (`G`, `emb`, `proj`), where `emb` and `proj` are the
 vectors of the embeddings (resp. projections) of the direct product `G`.
 """
-function inner_cartesian_power(G::T, n::Int; morphisms=false) where {T<:GAPGroup}
+function inner_cartesian_power(G::T, n::Int; morphisms::Bool=false) where {T<:GAPGroup}
   return inner_direct_product(fill(G, n); morphisms=morphisms)
 end
 

--- a/src/Groups/matrices/stuff_field_gen.jl
+++ b/src/Groups/matrices/stuff_field_gen.jl
@@ -19,7 +19,7 @@ end
 # then return a polynomial g such that g(z) is a generator for the unit group of F(z)
 # return a generator for the unit group of F = K[X] / (f), where K = base_ring(f)
 function _centralizer(f::PolyRingElem{T}) where T <: FinFieldElem
-  if typeof(f)!=fqPolyRepPolyRingElem && typeof(f)!=FqPolyRepPolyRingElem
+  if !(f isa Union{fqPolyRepPolyRingElem, FqPolyRepPolyRingElem})
      f = _change_type(f)
   end
   L, mL = field_extension(f)


### PR DESCRIPTION
This PR includes the following changes to the file `Groups/directproducts.jl`:

- Refactor the code mentioned in https://github.com/oscar-system/Oscar.jl/issues/1718 using `@req` and the proposal there (thus closes https://github.com/oscar-system/Oscar.jl/issues/1718).
- Some more uses of `@req`
- Add some checks for empty input lists
- Make functions with vararg params unambiguous by explicitly expecting at least one object
- Run formatter