### PR TITLE
[TropicalGeometry] Fix weird looking docs

### DIFF
--- a/src/TropicalGeometry/valuation.jl
+++ b/src/TropicalGeometry/valuation.jl
@@ -25,7 +25,7 @@ Currently, the only supported valuations are:
 
 # Examples
 
-$p$-adic valuation on $\mathbb{Q}$:
+ $p$-adic valuation on $\mathbb{Q}$:
 ```jldoctest
 julia> val_2 = TropicalSemiringMap(QQ,2); # = TropicalSemiringMap(QQ,2,min)
 
@@ -41,7 +41,7 @@ julia> val_2(1//4)
 (2)
 ```
 
-$t$-adic valuation on $\mathbb{Q}(t)$:
+ $t$-adic valuation on $\mathbb{Q}(t)$:
 ```jldoctest
 julia> Kt,t = RationalFunctionField(QQ,"t");
 


### PR DESCRIPTION
f6da3dff5ed made these two "formulas" centered.
Could it be that `$bla$` at the beginning of a line is always centered? @fingolfin is there a preferred way to prevent this?