### PR TITLE
Remove duplicate import of `MPolyRingElem`

### DIFF
--- a/src/imports.jl
+++ b/src/imports.jl
@@ -109,13 +109,6 @@ import AbstractAlgebra:
   symbols,
   total_degree
 
-# FIXME/TODO: clean up the following once AbstractAlgebra provides the new name
-if isdefined(AbstractAlgebra, :MPolyRingElem)
-  import AbstractAlgebra: MPolyRingElem
-else
-  @alias MPolyRingElem MPolyRingElem
-end
-
 import AbstractAlgebra.GroupsCore
 import AbstractAlgebra.GroupsCore:
   hasgens,


### PR DESCRIPTION
... another small fix (sorry!).
I don't really know about the history, but I assume this originated in the big renaming. (In case you wonder: `MPolyRingElem` is imported in line 93 in `src/imports.jl`.)