### PR TITLE
[ToricVarieties] Bugfix in ideal of linear relations

### DIFF
--- a/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/methods.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/methods.jl
@@ -40,6 +40,48 @@ Cohomology class on a normal toric variety given by 2//3*x2^2
 julia> integrate(c)
 2
 ```
+
+The following example constructs the Fano variety 2-36
+(cf. https://www.fanography.info/2-36) and verifies
+that the triple self-intersection number of its anticanonical
+bundle is 62.
+
+# Examples
+```jldoctest
+julia> e1 = [1,0,0];
+
+julia> e2 = [0,1,0];
+
+julia> e3 = [0,0,1];
+
+julia> m = 2;
+
+julia> ray_generators = [e1, -e1, e2, e3, - e2 - e3 - m * e1];
+
+julia> max_cones = [[1,3,4], [1,3,5], [1,4,5], [2,3,4], [2,3,5], [2,4,5]];
+
+julia> X = normal_toric_variety(ray_generators, max_cones; non_redundant = true)
+Normal toric variety
+
+julia> cox_ring(X)
+Multivariate polynomial ring in 5 variables over QQ graded by
+  x1 -> [1 0]
+  x2 -> [1 2]
+  x3 -> [0 -1]
+  x4 -> [0 -1]
+  x5 -> [0 -1]
+
+julia> cohomology_ring(X)
+Quotient
+  of graded multivariate polynomial ring in 5 variables over QQ
+  by ideal(x1 - x2 - 2*x5, x3 - x5, x4 - x5, x1*x2, x3*x4*x5)
+
+julia> integrate(cohomology_class(anticanonical_divisor(X))^3)
+62
+
+julia> integrate(cohomology_class(anticanonical_divisor_class(X))^3)
+62
+```
 """
 function integrate(c::CohomologyClass)::QQFieldElem
     # can only integrate if the variety is simplicial, complete

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -394,11 +394,7 @@ julia> ngens(ideal_of_linear_relations(R, p2))
 function ideal_of_linear_relations(R::MPolyRing, v::AbstractNormalToricVariety)
     @req is_simplicial(v) "The ideal of linear relations is only supported for simplicial toric varieties"
     @req ngens(R) == nrays(v) "The given polynomial ring must have exactly as many indeterminates as rays for the toric variety"
-
-    indeterminates = gens(R)
-    d = rank(character_lattice(v))
-    generators = [sum([rays(v)[j][i] * indeterminates[j] for j in 1:nrays(v)]) for i in 1:d]
-    return ideal(generators)
+    return ideal(transpose(matrix(ZZ, rays(v))) * gens(R))
 end
 
 


### PR DESCRIPTION
As reported by Giosuè Muratore on slack, an intersection number is computed incorrectly for a particular smooth, Fano 3-fold:
```julia
e1 = [1,0,0]
e2 = [0,1,0]
e3 = [0,0,1]
m = 2
ray_generators = [e1, -e1, e2, e3, - e2 - e3 - m * e1]
max_cones = [[1,3,4], [1,3,5], [1,4,5], [2,3,4], [2,3,5], [2,4,5]]
X = normal_toric_variety(ray_generators, max_cones; non_redundant = true)
integrate(cohomology_class(anticanonical_divisor(X))^3)
```
The answer should be 62 and not 104 (https://www.fanography.info/2-36). Note that the following line gives the desired answer of 62:
```julia
integrate(cohomology_class(anticanonical_divisor_class(X))^3)
```
I investigated this and found the following:
* Both commands compute **linearly equivalent** toric divisors.
* They then map these divisors to **distinct** elements of the cohomology ring.
* The "sanity check" to prevent this from happening is the ideal of linear relations. Namely, the cohomology ring is obtained as quotient of the Cox ring by this ideal. This should ensure that linearly equivalent divisors are mapped to the same element of the cohomology ring.
* It was thus natural to look into the ideal of linear relations, and sure enough I found a bug in that routine. Specifically, we must use primitive elements `u_i` rather than the ray generators `rho_i` (cf. CLS equ. 12.4.3 on page 593).
~~* The fix in this PR uses a different route. Under the assumption that the Cox ring is graded by `Z^n` (that is at least covering all my applications), we can think of this grading as a matrix over Z. Then the generators of the ideal of linear relations are 1:1 to a basis of the kernel of said matrix.~~

I have modified the code accordingly. Thereby, the above example works fine. As refined check for the future, I have added this example to the documentation of the command `integrate` for cohomology classes.

cc @lkastner