### PR TITLE
Implement degree(I::MPolyIdeal)

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -1236,6 +1236,16 @@
   url           = {https://doi.org/10.1007/s10852-011-9168-y}
 }
 
+@Book{MS21,
+  author        = {Micha{\l}ek, Mateusz and Sturmfels, Bernd},
+  title         = {Invitation to nonlinear algebra},
+  fseries       = {Graduate Studies in Mathematics},
+  series        = {Grad. Stud. Math.},
+  volume        = {211},
+  year          = {2021},
+  publisher     = {Providence, RI: American Mathematical Society (AMS)}
+}
+
 @Article{Nik79,
   author        = {Nikulin, V. V.},
   title         = {Integer symmetric bilinear forms and some of their geometric applications},

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -1213,6 +1213,17 @@
   year          = {2015}
 }
 
+@Book{MS21,
+  author        = {Micha{\l}ek, Mateusz and Sturmfels, Bernd},
+  title         = {Invitation to nonlinear algebra},
+  journal       = {Grad. Stud. Math.},
+  fjournal      = {Graduate Studies in Mathematics},
+  volume        = {211},
+  publisher     = {Providence, RI: American Mathematical Society (AMS)},
+  pages         = {xiii + 226},
+  year          = {2021}
+}
+
 @Book{Mar18,
   author        = {Marcus, Daniel A.},
   title         = {Number fields},
@@ -1234,16 +1245,6 @@
   pages         = {89--104},
   year          = {2012},
   url           = {https://doi.org/10.1007/s10852-011-9168-y}
-}
-
-@Book{MS21,
-  author        = {Micha{\l}ek, Mateusz and Sturmfels, Bernd},
-  title         = {Invitation to nonlinear algebra},
-  fseries       = {Graduate Studies in Mathematics},
-  series        = {Grad. Stud. Math.},
-  volume        = {211},
-  year          = {2021},
-  publisher     = {Providence, RI: American Mathematical Society (AMS)}
 }
 
 @Article{Nik79,

--- a/docs/src/CommutativeAlgebra/ideals.md
+++ b/docs/src/CommutativeAlgebra/ideals.md
@@ -67,6 +67,13 @@ dim(I::MPolyIdeal)
 ```@docs
 codim(I::MPolyIdeal)
 ```
+
+### Degree
+
+```@docs
+degree(I::MPolyIdeal)
+```
+
 ### Minimal Sets of Generators
 
 In the graded case, we have:

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -1255,12 +1255,16 @@ codim(I::MPolyIdeal) = nvars(base_ring(I)) - dim(I)
 @doc raw"""
     degree(I::MPolyIdeal)
 
-Return the degree of `I` if it is homogeneous. Otherwise return the degree
-of its `homogenization`.
+If `base_ring(I)` is standard-graded, in which case `I` is necessarily
+homogeneous with respect to this grading, return the degree of `I` (that
+is, the degree of the quotient of `base_ring(I)` modulo `I`). Otherwise,
+return the degree of the homogenization of `I` with respect to the
+standard-grading.
 
-The degree of a homogeneous ideal `I` is the number of intersection points
-of its projective variety with a generic linear subspace of complementary
-dimension (counted with multiplicities). See also [MS21](@cite).
+!!! note
+Geometrically, the degree of a homogeneous ideal as above is the number of
+intersection points of its projective variety with a generic linear subspace
+of complementary dimension (counted with multiplicities). See also [MS21](@cite).
 
 # Examples
 ```jldoctest
@@ -1275,9 +1279,8 @@ julia> degree(I)
 ```
 """
 @attr Int function degree(I::MPolyIdeal)
-  J = homogenization(I, "_h")
-  A, _ = quo(base_ring(J), J)
-  return Int(degree(A))
+  is_standard_graded(base_ring(I)) || (I = homogenization(I, "_h"))
+  return Int(degree(HilbertData(I)))
 end
 
 ################################################################################

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -1250,6 +1250,32 @@ julia> codim(I)
 """
 codim(I::MPolyIdeal) = nvars(base_ring(I)) - dim(I)
 
+#######################################################
+#######################################################
+@doc raw"""
+    degree(I::MPolyIdeal)
+
+Return the degree of `I` if it is homogeneous. Otherwise return the degree
+of its `homogenization`.
+
+# Examples
+```jldoctest
+julia> R, (x, y, z) = polynomial_ring(QQ, ["x", "y", "z"])
+(Multivariate polynomial ring in 3 variables over QQ, QQMPolyRingElem[x, y, z])
+
+julia> I = ideal(R, [y-x^2, x-z^3])
+ideal(-x^2 + y, x - z^3)
+
+julia> degree(I)
+6
+```
+"""
+@attr Int function degree(I::MPolyIdeal)
+  J = homogenization(I, "_h")
+  A, _ = quo(base_ring(J), J)
+  return Int(degree(A))
+end
+
 ################################################################################
 #
 #  iszero and isone functions

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -1258,6 +1258,10 @@ codim(I::MPolyIdeal) = nvars(base_ring(I)) - dim(I)
 Return the degree of `I` if it is homogeneous. Otherwise return the degree
 of its `homogenization`.
 
+The degree of a homogeneous ideal `I` is the number of intersection points
+of its projective variety with a generic linear subspace of complementary
+dimension (counted with multiplicities). See also [MS21](@cite).
+
 # Examples
 ```jldoctest
 julia> R, (x, y, z) = polynomial_ring(QQ, ["x", "y", "z"])


### PR DESCRIPTION
Supply a `degree` method for ideals. It homogenizes the ideal if it has to and then computes the degree of its quotient algebra.

This feature is largely for convenience. Especially in `Macaulay2`, it is very easy to compute the pair `(dimension, degree)` for any (inhomogeneous) ideal to get very rough data about the geometry of an affine variety. With this commit, that becomes equally easy in Oscar.