### PR TITLE
Cache `canonical_matrix(::MonomialOrdering)`

### DIFF
--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -169,11 +169,16 @@ end
 """
 Orderings actually applied to polynomial rings (as opposed to variable indices)
 """
-mutable struct MonomialOrdering{S}
+@attributes mutable struct MonomialOrdering{S}
   R::S
   o::AbsGenOrdering
   is_total::Bool
   is_total_is_known::Bool
+
+  # default constructor for @attributes
+  function MonomialOrdering{S}(R::S, o::AbsGenOrdering, is_total::Bool, is_total_is_known::Bool) where S
+    return new{S}(R, o, is_total, is_total_is_known)
+  end
 end
 
 function MonomialOrdering(R::S, o::AbsGenOrdering) where S
@@ -1312,7 +1317,7 @@ julia> canonical_matrix(o2)
 [0   -1   0]
 ```
 """
-function canonical_matrix(M::MonomialOrdering)
+@attr ZZMatrix function canonical_matrix(M::MonomialOrdering)
   return canonical_matrix(nvars(base_ring(M)), M.o)
 end
 

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -169,16 +169,12 @@ end
 """
 Orderings actually applied to polynomial rings (as opposed to variable indices)
 """
-@attributes mutable struct MonomialOrdering{S}
+mutable struct MonomialOrdering{S}
   R::S
   o::AbsGenOrdering
   is_total::Bool
   is_total_is_known::Bool
-
-  # default constructor for @attributes
-  function MonomialOrdering{S}(R::S, o::AbsGenOrdering, is_total::Bool, is_total_is_known::Bool) where S
-    return new{S}(R, o, is_total, is_total_is_known)
-  end
+  canonical_matrix::ZZMatrix
 end
 
 function MonomialOrdering(R::S, o::AbsGenOrdering) where S
@@ -1317,8 +1313,11 @@ julia> canonical_matrix(o2)
 [0   -1   0]
 ```
 """
-@attr ZZMatrix function canonical_matrix(M::MonomialOrdering)
-  return canonical_matrix(nvars(base_ring(M)), M.o)
+function canonical_matrix(M::MonomialOrdering)
+  if !isdefined(M, :canonical_matrix)
+    M.canonical_matrix = canonical_matrix(nvars(base_ring(M)), M.o)
+  end
+  return M.canonical_matrix
 end
 
 import Base.==

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -175,10 +175,14 @@ mutable struct MonomialOrdering{S}
   is_total::Bool
   is_total_is_known::Bool
   canonical_matrix::ZZMatrix
-end
 
-function MonomialOrdering(R::S, o::AbsGenOrdering) where S
-   return MonomialOrdering{S}(R, o, false, false)
+  function MonomialOrdering(R::S, o::AbsGenOrdering) where {S}
+    return new{S}(R, o, false, false)
+  end
+
+  function MonomialOrdering(R::S, o::AbsGenOrdering, is_total::Bool) where {S}
+    return new{S}(R, o, is_total, true)
+  end
 end
 
 base_ring(a::MonomialOrdering) = a.R
@@ -1630,7 +1634,7 @@ function induce(vars::AbstractVector{<: MPolyRingElem}, o::MonomialOrdering)
   @assert !isempty(vars)
   v = _unique_var_indices(vars)
   o2 = induce(v, o.o)
-  return MonomialOrdering(parent(vars[1]), o2, false, false)
+  return MonomialOrdering(parent(vars[1]), o2)
 end
 
 ###################################################


### PR DESCRIPTION
Implements the proposal of https://github.com/oscar-system/Oscar.jl/issues/2498#issuecomment-1612689919.

The speed change is shown in https://github.com/oscar-system/Oscar.jl/issues/2498#issuecomment-1612720461.

Feel free to close this and propose an alternative to this @HechtiDerLachs.