### PR TITLE
`iso_oscar_gap(FO::SimpleNumField{T}) where T <: FieldElem`

### DIFF
--- a/src/GAP/iso_oscar_gap.jl
+++ b/src/GAP/iso_oscar_gap.jl
@@ -309,7 +309,7 @@ function _iso_oscar_gap(FO::SimpleNumField{QQFieldElem})
 end
 
 # Deal with simple extensions of proper extensions of Q.
-function _iso_oscar_gap(FO::SimpleNumField{nf_elem})
+function _iso_oscar_gap(FO::SimpleNumField{T}) where T <: FieldElem
    B = base_field(FO)
    isoB = iso_oscar_gap(B)
    BG = codomain(isoB)::GapObj
@@ -322,7 +322,7 @@ function _iso_oscar_gap(FO::SimpleNumField{nf_elem})
    FG = GAPWrap.AlgebraicExtension(BG, polFG)
    fam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(FG))
 
-   f = function(x::SimpleNumFieldElem{nf_elem})
+   f = function(x::SimpleNumFieldElem{T})
       coeffs = GAP.GapObj([isoB(x) for x in coefficients(x)])::GapObj
       return GAPWrap.AlgExtElm(fam, coeffs)
    end

--- a/test/GAP/iso_oscar_gap.jl
+++ b/test/GAP/iso_oscar_gap.jl
@@ -234,8 +234,13 @@ end
    # non-absolute number fields
    F1, _ = number_field(x^2-2)
    R1, x1 = polynomial_ring(F1, "x")
-   push!(fields, number_field(x1^2-3)[1])            # simple
+   F2, _ = number_field(x1^2-3)
+   push!(fields, F2)                                 # simple
    push!(fields, number_field([x1^2-3, x1^2+1])[1])  # non-simple
+
+   # and a simple three-step construction (in order to exercise recursion)
+   R2, x2 = polynomial_ring(F2, "x")
+   push!(fields, number_field(x2^2+1)[1])
 
    @testset for F in fields
       f = Oscar.iso_oscar_gap(F)


### PR DESCRIPTION
This is a follow-up of #2511, addressing a comment by @thofma .