### PR TITLE
various improvements for characters

### DIFF
--- a/docs/src/Groups/group_characters.md
+++ b/docs/src/Groups/group_characters.md
@@ -134,6 +134,8 @@ trivial_character(tbl::GAPGroupCharacterTable)
 ```@docs
 natural_character(G::PermGroup)
 natural_character(G::Union{MatrixGroup{QQFieldElem}, MatrixGroup{nf_elem}})
+natural_character(G::MatrixGroup{T, MT}) where T <: FinFieldElem where MT
+natural_character(rho::GAPGroupHomomorphism)
 trivial_character(G::GAPGroup)
 ```
 

--- a/docs/src/Groups/group_characters.md
+++ b/docs/src/Groups/group_characters.md
@@ -81,12 +81,14 @@ of ``G`` (or the `j`-th conjugacy class of ``p``-regular elements
 in the case of Brauer tables).
 
 Ordinary and ``p``-modular Brauer tables in OSCAR are distinguished by
-the field `characteristic`; its value is `0` for ordinary tables and
-``p`` otherwise.
+their [`characteristic(tbl::GAPGroupCharacterTable)`](@ref);
+its value is `0` for ordinary tables and ``p`` otherwise.
 
 ```@docs
 GAPGroupCharacterTable
 character_table
+Base.show(io::IO, ::MIME"text/plain", tbl::GAPGroupCharacterTable)
+characteristic(tbl::GAPGroupCharacterTable)
 Base.mod(tbl::GAPGroupCharacterTable, p::Int)
 all_character_table_names
 ```
@@ -101,16 +103,19 @@ indicator
 is_faithful(chi::GAPGroupClassFunction)
 is_rational(chi::GAPGroupClassFunction)
 is_irreducible(chi::GAPGroupClassFunction)
-schur_index
+schur_index(chi::GAPGroupClassFunction, recurse::Bool = true)
 det(chi::GAPGroupClassFunction)
 order(chi::GAPGroupClassFunction)
+order_field_of_definition(chi::GAPGroupClassFunction)
 ```
 
 ## Attributes of character tables
 
 ```@docs
 character_parameters
+class_names(tbl::GAPGroupCharacterTable)
 class_parameters
+conjugacy_classes(tbl::GAPGroupCharacterTable)
 decomposition_matrix
 identifier
 induced_cyclic(tbl::GAPGroupCharacterTable)
@@ -120,6 +125,7 @@ names_of_fusion_sources
 class_lengths
 orders_centralizers
 orders_class_representatives
+ordinary_table(tbl::GAPGroupCharacterTable)
 trivial_character(tbl::GAPGroupCharacterTable)
 ```
 

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -358,16 +358,16 @@ function Oscar.character(C::GModule{<:Any, <:Generic.FreeModule{nf_elem}})
   QQAb = abelian_closure(QQ)[1]
   K = cyclotomic_field(QQAb, Int(c))[1]
   fl, em = is_subfield(k, K)
-  return Oscar.group_class_function(group(C), [QQAb(em(preimage(mkK, x[2]))) for x = chr])
+  return Oscar.class_function(group(C), [QQAb(em(preimage(mkK, x[2]))) for x = chr])
 end
 
 function Oscar.character(C::GModule{<:Any, <:Generic.FreeModule{QQFieldElem}})
   QQAb = abelian_closure(QQ)[1]
-  return Oscar.group_class_function(group(C), [QQAb(x[2]) for x = _character(C)])
+  return Oscar.class_function(group(C), [QQAb(x[2]) for x = _character(C)])
 end
 
 function Oscar.character(C::GModule{<:Any, <:Generic.FreeModule{<:AbstractAlgebra.FieldElem}})
-  return Oscar.group_class_function(group(C), [base_ring(C)(x[2]) for x = _character(C)])
+  return Oscar.class_function(group(C), [base_ring(C)(x[2]) for x = _character(C)])
 end
 
 

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -164,10 +164,6 @@ function __init__()
   set_verbose_level(:MinField, 0)
 end
 
-function Hecke.number_field(::QQField, chi::Oscar.GAPGroupClassFunction; cached::Bool = false)
-  return number_field(QQ, map(x->GAP.gap_to_julia(QQAbElem, x), chi.values), cached = cached)
-end
-
 function irreducible_modules(G::Oscar.GAPGroup)
   im = GAP.Globals.IrreducibleRepresentations(G.X)
   IM = GModule[] 
@@ -1159,10 +1155,6 @@ function Oscar.abelian_group(M::Generic.FreeModule{fqPolyRepFieldElem})
     return M(m)
   end
   return A, MapFromFunc(A, M, to_M, to_A)
-end
-
-function Oscar.group(chi::Oscar.GAPGroupClassFunction)
-  return chi.table.GAPGroup
 end
 
 function Oscar.gmodule(chi::Oscar.GAPGroupClassFunction)

--- a/experimental/GModule/Misc.jl
+++ b/experimental/GModule/Misc.jl
@@ -172,5 +172,4 @@ end
 Base.getindex(::QQField, a::QQAbElem) = number_field(QQ, a)
 Base.getindex(::QQField, a::Vector{QQAbElem}) = number_field(QQ, a)
 Base.getindex(::QQField, a::QQAbElem...) = number_field(QQ, [x for x =a])
-Base.getindex(::QQField, chi::Oscar.GAPGroupClassFunction) = number_field(QQ, chi)
 

--- a/experimental/SymmetricIntersections/src/representations.jl
+++ b/experimental/SymmetricIntersections/src/representations.jl
@@ -183,7 +183,7 @@ function character_representation(RR::RepRing{S, T}, f::GAPGroupHomomorphism{T, 
     b = f(representative(h))
     push!(coll, Q(trace(b)))
   end
-  c = Oscar.group_class_function(character_table_underlying_group(RR), coll)
+  c = Oscar.class_function(character_table_underlying_group(RR), coll)
   return c
 end
 

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -211,7 +211,7 @@ GAP.@wrap MinimalGeneratingSet(x::GapObj)::GapObj
 GAP.@wrap mod(x::Any, y::Any)::GAP.Obj
 GAP.@wrap NamesOfFusionSources(x::GapObj)::GapObj
 GAP.@wrap NextIterator(x::GapObj)::Any
-GAP.@wrap NormalSubgroupClasses(x::GapObj)::GapObj
+GAP.@wrap NormalSubgroupClasses(x::GapObj, y::GAP.Obj)::GapObj
 GAP.@wrap NrCols(x::GapObj)::Int
 GAP.@wrap NrConjugacyClasses(x::Any)::GapInt
 GAP.@wrap NrRows(x::GapObj)::Int

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -14,34 +14,54 @@ using GAP
 
 GAP.@wrap AlgExtElm(x::GapObj, y::GAP.Obj)::GapObj
 GAP.@wrap AlgebraicExtension(x::GapObj, y::GapObj)::GapObj
+GAP.@wrap AntiSymmetricParts(x::GapObj, y::GapObj, z::GapInt)::GapObj
 GAP.@wrap AsList(x::GapObj)::GapObj
 GAP.@wrap AsSet(x::GapObj)::GapObj
+GAP.@wrap AtlasIrrationality(x::GapObj)::GAP.Obj
 GAP.@wrap Basis(x::GapObj)::GapObj
 GAP.@wrap Basis(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap BasisNC(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap CanonicalBasis(x::GapObj)::GapObj
+GAP.@wrap CentreOfCharacter(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap CF(x::Any, y::Any)::GapObj
 GAP.@wrap CF(x::Any)::GapObj
 GAP.@wrap CHAR_FFE_DEFAULT(x::Any)::GapInt
 GAP.@wrap Characteristic(x::Any)::GapInt
+GAP.@wrap CharacterParameters(x::GapObj)::GapObj
+GAP.@wrap CharacterTable(x::GapObj)::GapObj
+GAP.@wrap CharacterTable(x::GapObj, y::GAP.Obj)::GapObj
+GAP.@wrap CharacterTableWreathSymmetric(x::GapObj, y::GapInt)::GapObj
+GAP.@wrap ClassFunction(x::GapObj, y::GapObj)::GapObj
+GAP.@wrap ClassNames(x::GapObj)::GapObj
+GAP.@wrap ClassMultiplicationCoefficient(x::GapObj, y::Int, z::Int, t::Int)::GAP.Obj
+GAP.@wrap ClassPositionsOfCentre(x::GapObj)::GapObj
+GAP.@wrap ClassPositionsOfPCore(x::GapObj, y::GAP.Obj)::GapObj
+GAP.@wrap ClassParameters(x::GapObj)::GapObj
 GAP.@wrap Coefficients(x::Any, y::Any)::GapObj
 GAP.@wrap CoefficientsFamily(x::GapObj)::GapObj
 GAP.@wrap CoefficientsOfUnivariatePolynomial(x::GapObj)::GapObj
 GAP.@wrap CoeffsCyc(x::GAP.Obj, y::Int)::GapObj
+GAP.@wrap ComputedPowerMaps(x::GapObj)::GapObj
 GAP.@wrap Conductor(x::Any)::GapInt
+GAP.@wrap ConjugacyClasses(x::GapObj)::GapObj
 GAP.@wrap CycList(x::GapObj)::GapInt
 GAP.@wrap CyclotomicPol(x::Int)::GapObj
 GAP.@wrap Decomposition(x::GapObj, y::GapObj, z::GAP.Obj)::GapObj
+GAP.@wrap DecompositionMatrix(x::GapObj)::GapObj
 GAP.@wrap DefiningPolynomial(x::GapObj)::GapObj
 GAP.@wrap DegreeFFE(x::Any)::Int
 GAP.@wrap DegreeOfLaurentPolynomial(x::GapObj)::GapInt
 GAP.@wrap DegreeOverPrimeField(x::GapObj)::Int
 GAP.@wrap DenominatorCyc(x::Any)::GapInt
 GAP.@wrap DenominatorRat(x::Any)::GapInt
+GAP.@wrap DescriptionOfRootOfUnity(x::Any)::GapObj
+GAP.@wrap DeterminantOfCharacter(x::GapObj)::GapObj
 GAP.@wrap Dimension(x::GapObj)::Int
 GAP.@wrap E(x::Any)::GapInt
+GAP.@wrap EigenvaluesChar(x::GapObj, y::GAP.Obj)::GapObj
 GAP.@wrap Elements(x::GapObj)::GapObj
 GAP.@wrap ElementsFamily(x::GapObj)::GapObj
+GAP.@wrap ELMS_LIST(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap ExtRepOfObj(x::GapObj)::GapObj
 GAP.@wrap ExtRepPolynomialRatFun(x::GapObj)::GapObj
 GAP.@wrap FamilyObj(x::GAP.Obj)::GapObj
@@ -49,15 +69,20 @@ GAP.@wrap Field(x::Any)::GapObj
 GAP.@wrap FreeAbelianGroup(x::Int)::GapObj
 GAP.@wrap FreeGeneratorsOfFpGroup(x::GapObj)::GapObj
 GAP.@wrap FreeGroupOfFpGroup(x::GapObj)::GapObj
+GAP.@wrap FusionConjugacyClasses(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap GaloisCyc(x::GAP.Obj, GapInt)::GAP.Obj
 GAP.@wrap GeneratorsOfField(x::GapObj)::GapObj
 GAP.@wrap GeneratorsOfGroup(x::GapObj)::GapObj
+GAP.@wrap GetFusionMap(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap GF(x::Any, y::Any)::GapObj
 GAP.@wrap GF(x::Any)::GapObj
 GAP.@wrap GroupHomomorphismByFunction(x1, x2, x3)::GapObj
 GAP.@wrap GroupHomomorphismByFunction(x1, x2, x3, x4)::GapObj
 GAP.@wrap GroupHomomorphismByFunction(x1, x2, x3, x4, x5)::GapObj
+GAP.@wrap HasCharacterParameters(x::GapObj)::Bool
+GAP.@wrap HasClassParameters(x::GapObj)::Bool
 GAP.@wrap HasMaximalAbelianQuotient(x::Any)::Bool
+GAP.@wrap HasMaxes(x::GapObj)::Bool
 GAP.@wrap HasSize(x::Any)::Bool
 GAP.@wrap Image(x::Any, y::Any)::GapObj
 GAP.@wrap Image(x::Any)::GapObj
@@ -67,6 +92,10 @@ GAP.@wrap Indeterminate(x::GapObj)::GapObj
 GAP.@wrap Indeterminate(x::GapObj, y::GAP.Obj)::GapObj
 GAP.@wrap IndeterminateNumberOfUnivariateRationalFunction(x::GapObj)::Int
 GAP.@wrap IndeterminatesOfPolynomialRing(x::GapObj)::GapObj
+GAP.@wrap Indicator(x::GapObj, y::GapObj, z::GapInt)::GapObj
+GAP.@wrap InducedClassFunctionsByFusionMap(x::GapObj, y::GapObj, z::GapObj, t::GapObj)::GapObj
+GAP.@wrap InducedClassFunction(x::GapObj, y::GapObj)::GapObj
+GAP.@wrap InducedCyclic(x::GapObj)::GapObj
 GAP.@wrap INT_FFE_DEFAULT(x::Any)::GapInt
 GAP.@wrap IntFFE(x::Any)::GapInt
 GAP.@wrap Inverse(x::GapObj)::GapObj
@@ -171,14 +200,18 @@ GAP.@wrap IsZero(x::Any)::Bool
 GAP.@wrap IsZmodnZObj(x::Any)::Bool
 GAP.@wrap IsZmodnZObjNonprimeCollection(x::Any)::Bool
 GAP.@wrap Iterator(x::Any)::GapObj
+GAP.@wrap KernelOfCharacter(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap LargestMovedPoint(x::Any)::Int
 GAP.@wrap LeftActingDomain(x::GapObj)::GapObj
 GAP.@wrap LinearCombination(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap MatScalarProducts(x::GapObj, y::GapObj, z::GapObj)::GapObj
+GAP.@wrap Maxes(x::GapObj)::GapObj
 GAP.@wrap MinimalPolynomial(x::GapObj, y::GAP.Obj)::GapObj
 GAP.@wrap MinimalGeneratingSet(x::GapObj)::GapObj
 GAP.@wrap mod(x::Any, y::Any)::GAP.Obj
+GAP.@wrap NamesOfFusionSources(x::GapObj)::GapObj
 GAP.@wrap NextIterator(x::GapObj)::Any
+GAP.@wrap NormalSubgroupClasses(x::GapObj)::GapObj
 GAP.@wrap NrCols(x::GapObj)::Int
 GAP.@wrap NrConjugacyClasses(x::Any)::GapInt
 GAP.@wrap NrRows(x::GapObj)::Int
@@ -193,10 +226,13 @@ GAP.@wrap OnSets(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap OnSetsSets(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap OnTuples(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap Order(x::Any)::GapInt
+GAP.@wrap OrthogonalComponents(x::GapObj, y::GapObj, z::GapInt)::GapObj
+GAP.@wrap OrthogonalDiscriminants(x::GapObj)::GapObj
 GAP.@wrap Permuted(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap PolynomialByExtRep(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap PolynomialRing(x::GapObj)::GapObj
 GAP.@wrap PolynomialRing(x::GapObj, y::Int)::GapObj
+GAP.@wrap PossibleClassFusions(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap PrimePGroup(x::GapObj)::GapInt
 GAP.@wrap PrimitiveElement(x::GapObj)::GapObj
 GAP.@wrap Range(x::GapObj)::GapObj
@@ -204,18 +240,26 @@ GAP.@wrap ReduceCoeffs(x::GapObj, y::GapObj)
 GAP.@wrap RelatorsOfFpGroup(x::GapObj)::GapObj
 GAP.@wrap Representative(x::GapObj)::GAP.Obj
 GAP.@wrap ScalarProduct(x::GapObj, y::GapObj, z::GapObj)::GAP.Obj
+GAP.@wrap SchurIndexByCharacter(x::GapObj, y::GapObj, z::GapObj)::GAP.Obj
 GAP.@wrap SetMaximalAbelianQuotient(x::Any, y::Any)::Nothing
 GAP.@wrap SetSize(x::Any, y::Any)::Nothing
 GAP.@wrap Size(x::Any)::GapInt
+GAP.@wrap SizeOfFieldOfDefinition(x::GapObj, y::GapInt)::GapInt
+GAP.@wrap SizesCentralizers(x::GapObj)::GapObj
+GAP.@wrap SizesConjugacyClasses(x::GapObj)::GapObj
 GAP.@wrap Source(x::GapObj)::GapObj
 GAP.@wrap Sqrt(x::Int64)::GAP.Obj
 GAP.@wrap StringViewObj(x::Any)::GapObj
+GAP.@wrap SymmetricParts(x::GapObj, y::GapObj, z::GapInt)::GapObj
+GAP.@wrap Symmetrizations(x::GapObj, y::GapObj, z::GapInt)::GapObj
+GAP.@wrap SymplecticComponents(x::GapObj, y::GapObj, z::GapInt)::GapObj
 GAP.@wrap UnderlyingElement(x::GapObj)::GapObj
 GAP.@wrap UnderlyingRingElement(x::GapObj)::GapObj
 GAP.@wrap UnivariatePolynomialByCoefficients(x::GapObj, y::GapObj, z::Int)::GapObj
 GAP.@wrap Value(x::GapObj, y::Any)::Any
 GAP.@wrap Value(x::GapObj, y::Any, z::Any)::Any
 GAP.@wrap Value(x::GapObj, y::GapObj, z::GapObj, a::Any)::Any
+GAP.@wrap ValuesOfClassFunction(x::GapObj)::GapObj
 GAP.@wrap Z(x::Any)::GAP.Obj
 GAP.@wrap Zero(x::Any)::GAP.Obj
 

--- a/src/Groups/MatrixDisplay.jl
+++ b/src/Groups/MatrixDisplay.jl
@@ -419,8 +419,22 @@ function labelled_matrix_formatted(io::IO, mat::Matrix{String})
     end
 
     # footer (vector of strings)
-    for line in footer
-      write(io, line, "\n")
+    if length(footer) > 0
+      if TeX
+        write(io, "\n\\begin{array}{l}\n")
+        # Omit a separating empty line.
+        if footer[1] != ""
+          write(io, footer[1], " \\\\\n")
+        end
+        for line in footer[2:end]
+          write(io, line, " \\\\\n")
+        end
+        write(io, "\\end{array}\n")
+      else
+        for line in footer
+          write(io, line, "\n")
+        end
+      end
     end
 end
 

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -338,10 +338,10 @@ Return the ordinary character table of the group described by the series
 # Examples
 ```jldoctest
 julia> println(character_table(:Symmetric, 5))
-character_table("Sym(5)")
+character table of Sym(5)
 
 julia> println(character_table(:WeylB, 3))
-character_table("W(B3)")
+character table of W(B3)
 ```
 
 Currently the following series are supported.
@@ -384,7 +384,8 @@ end
 
 # Use the isomorphism.
 function preimages(iso::MapFromFunc{GrpAbFinGen, GapObj}, H::GapObj)
-  return sub(domain(iso), [preimage(iso, x) for x in GAPWrap.GeneratorsOfGroup(H)])
+  return sub(domain(iso),
+             GrpAbFinGenElem[preimage(iso, x) for x in GAPWrap.GeneratorsOfGroup(H)])
 end
 
 
@@ -1933,6 +1934,8 @@ the values of `chi`.
 
 # Examples
 ```jldoctest
+julia> tbl = character_table(alternating_group(4));
+
 julia> println([findfirst(y -> y == conj(x), tbl) for x in tbl])
 [1, 3, 2, 4]
 ```
@@ -2218,7 +2221,7 @@ function character_field(chi::GAPGroupClassFunction)
     if p != 0
       # Brauer character, construct a finite field
       q = order_field_of_definition(chi)
-      flag, pp, e = is_prime_power_with_data(q)
+      flag, e, pp = is_prime_power_with_data(q)
       (flag && p == pp) || error("something is wrong with 'GAPWrap.SizeOfFieldOfDefinition'")
       F = Nemo._GF(p, e)
       return (F, identity_map(F))
@@ -2313,6 +2316,8 @@ in order to compute `order_field_of_definition(chi)`.
 
 # Examples
 ```jldoctest
+julia> tbl = character_table("A5", 2);
+
 julia> println([order_field_of_definition(chi) for chi in tbl])
 ZZRingElem[2, 4, 4, 2]
 ```

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -56,12 +56,12 @@ julia> Oscar.with_unicode() do
 ```
 """
 function atlas_irrationality(F::AnticNumberField, description::String)
-    return F(GAP.Globals.AtlasIrrationality(GapObj(description))::GAP.Obj)
+    return F(GAPWrap.AtlasIrrationality(GapObj(description)))
 end
 
 function atlas_irrationality(description::String)
     F = abelian_closure(QQ)[1]
-    return F(GAP.Globals.AtlasIrrationality(GapObj(description))::GAP.Obj)
+    return F(GAPWrap.AtlasIrrationality(GapObj(description)))
 end
 
 
@@ -101,20 +101,47 @@ in a `p`-modular table.
     end
 
     function GAPGroupCharacterTable(tab::GapObj, char::Int)
-      #group is left undefined
+      # group and isomorphism are left undefined
       return new(tab, char)
     end
 end
 
 # access to field values via functions
 GAPTable(tbl::GAPGroupCharacterTable) = tbl.GAPTable
-group(tbl::GAPGroupCharacterTable) = tbl.group
-characteristic(tbl::GAPGroupCharacterTable) = tbl.characteristic
+
+@doc raw"""
+    characteristic(::Type{T} = Int, tbl::GAPGroupCharacterTable) where T <: IntegerUnion
+
+Return `T(0)` if `tbl` is an ordinary character table,
+and `T(p)` if `tbl` is a `p`-modular character table.
+
+# Examples
+```jldoctest
+julia> tbl = character_table("A5");
+
+julia> characteristic(tbl)
+0
+
+julia> characteristic(mod(tbl, 2))
+2
+```
+"""
+characteristic(tbl::GAPGroupCharacterTable) = characteristic(Int, tbl)
+
+function characteristic(::Type{T}, tbl::GAPGroupCharacterTable) where T <: IntegerUnion
+    return T(tbl.characteristic)
+end
+
+
+function group(tbl::GAPGroupCharacterTable)
+  @req isdefined(tbl, :group) "character table stores no group"
+  return tbl.group
+end
 
 # backwards compatibility:
-# return `tbl.group` when one accesses `tbl.GAPGroup`
+# return `group(tbl)` when one accesses `tbl.GAPGroup`
 function Base.getproperty(tbl::GAPGroupCharacterTable, sym::Symbol)
-   sym === :GAPGroup && return tbl.group
+   sym === :GAPGroup && return group(tbl)
    return getfield(tbl, sym)
 end
 
@@ -146,27 +173,60 @@ function isomorphism_to_GAP_group(G::GrpAbFinGen)
 end
 
 function isomorphism_to_GAP_group(tbl::GAPGroupCharacterTable)
-    @req isdefined(tbl, :isomorphism) "character table stores no isomorphism"
+    @req isdefined(tbl, :group) "character table stores no group"
+    @assert isdefined(tbl, :isomorphism) "character table with group must store also an isomorphism"
     return tbl.isomorphism
 end
 
+@doc raw"""
+    ordinary_table(tbl::GAPGroupCharacterTable)
 
-# If the character table stores an Oscar group `G` then
-# the columns correspond to conjugacy classes of `G`.
-# The vector `conjugacy_classes(G)` (stored or not stored in `G`) can be
-# independent of the vector of conjugacy classes of the corresponding
-# group on the GAP side.
-# Therefore we store a vector `conjugacy_classes(tbl)` via an attribute,
-# which is compatible with the `GAP.Globals.ConjugacyClasses` value of
-# the underlying GAP character table.
+Return the ordinary character table of `tbl`,
+provided that `tbl` is a Brauer character table.
+
+# Examples
+```jldoctest
+julia> tbl = character_table("A5");
+
+julia> ordinary_table(mod(tbl, 2)) === tbl
+true
+```
+"""
+function ordinary_table(tbl::GAPGroupCharacterTable)
+    @req characteristic(tbl) != 0 "the character table must be a Brauer table"
+    return get_attribute(tbl, :ordinary_table)
+end
+
+
+@doc raw"""
+    conjugacy_classes(tbl::GAPGroupCharacterTable)
+
+Return the vector of conjugacy classes of `group(tbl)`,
+ordered such that they correspond to the columns of `tbl`
+and to the `GAPWrap.ConjugacyClasses` value of the underlying
+GAP character table.
+Note that the vector `conjugacy_classes(group(tbl))` can be independent
+of the vector of conjugacy classes stored in the group of the underlying
+GAP character table.
+
+An error is thrown if `tbl` does  not store a group.
+
+# Examples
+```jldoctest
+julia> g = symmetric_group(4);  tbl = character_table(g);
+
+julia> [length(c) for c in conjugacy_classes(tbl)] == class_lengths(tbl)
+true
+```
+"""
 @attr function conjugacy_classes(tbl::GAPGroupCharacterTable)
-    @req isdefined(tbl, :group) "character table stores no group"
+    G = group(tbl)
 
     # If `GAPTable(tbl)` does not yet store conjugacy classes
     # then compute them.
     if characteristic(tbl) == 0
-      ccl = GAP.Globals.ConjugacyClasses(GAPTable(tbl))::GapObj
-      ccl = [conjugacy_class(group(tbl),
+      ccl = GAPWrap.ConjugacyClasses(GAPTable(tbl))::GapObj
+      ccl = [conjugacy_class(G,
                preimage(isomorphism_to_GAP_group(tbl),
                         GAPWrap.Representative(x)))
              for x in ccl]
@@ -192,7 +252,7 @@ then `nothing` is returned.
 # Examples
 ```jldoctest
 julia> Oscar.with_unicode() do
-         show(character_table(symmetric_group(3)))
+         show(stdout, MIME("text/plain"), character_table(symmetric_group(3)))
        end;
 Sym( [ 1 .. 3 ] )
 
@@ -208,7 +268,7 @@ Sym( [ 1 .. 3 ] )
 χ₃  1  1  1
 
 julia> Oscar.with_unicode() do
-         show(character_table(symmetric_group(3), 2))
+         show(stdout, MIME("text/plain"), character_table(symmetric_group(3), 2))
        end;
 Sym( [ 1 .. 3 ] ) mod 2
 
@@ -228,13 +288,13 @@ function character_table(G::Union{GAPGroup, GrpAbFinGen}, p::Int = 0)
     return get!(tbls, p) do
       if p == 0
         iso = isomorphism_to_GAP_group(G)
-        gaptbl = GAP.Globals.CharacterTable(codomain(iso))::GapObj
+        gaptbl = GAPWrap.CharacterTable(codomain(iso))
       else
         # Create the `p`-modular table if possible.
         @req is_prime(p) "p must be 0 or a prime integer"
         ordtbl = character_table(G, 0)
         iso = isomorphism_to_GAP_group(ordtbl)
-        gaptbl = GAP.Globals.mod(GAPTable(ordtbl), GAP.Obj(p))::GapObj
+        gaptbl = GAPWrap.mod(GAPTable(ordtbl), GAP.Obj(p))
         gaptbl === GAP.Globals.fail && return nothing
       end
       return GAPGroupCharacterTable(G, gaptbl, iso, p)
@@ -242,11 +302,13 @@ function character_table(G::Union{GAPGroup, GrpAbFinGen}, p::Int = 0)
 end
 
 # A character table with stored group object is stored in this group.
-# Character tables from the table library do not store groups,
-# they are cached in the dictionary `character_tables_by_id`,
+# Character tables from the table library do not store groups;
+# the ordinary ones are cached in the dictionary `character_tables_by_id`,
 # in order to achieve that fetching the same table twice yields the same
-# object.
+# object, and the modular ones are stored in their ordinary tables.
 const character_tables_by_id = Dict{String, Union{GAPGroupCharacterTable, Nothing}}()
+
+#T provide a function to clear this cache!
 
 """
     character_table(id::String, p::Int = 0)
@@ -258,27 +320,21 @@ If no such table is available then `nothing` is returned.
 # Examples
 ```jldoctest
 julia> println(character_table("A5"))
-character_table("A5")
+character table of A5
 
 julia> println(character_table("A5", 2))
-character_table("A5mod2")
+2-modular Brauer table of A5
 
 julia> println(character_table("J5"))
 nothing
 ```
 """
 function character_table(id::String, p::Int = 0)
-    if p == 0
-      modid = id
-    else
-      @req is_prime(p) "p must be 0 or a prime integer"
-      modid = "$(id)mod$(p)"
-    end
-
-    return get!(character_tables_by_id, modid) do
-      tbl = GAP.Globals.CharacterTable(GapObj(modid))::GapObj
+    p != 0 && return mod(character_table(id, 0), p)
+    return get!(character_tables_by_id, id) do
+      tbl = GAPWrap.CharacterTable(GapObj(id))
       tbl === GAP.Globals.fail && return nothing
-      return GAPGroupCharacterTable(tbl, p)
+      return GAPGroupCharacterTable(tbl, 0)
     end
 end
 
@@ -322,8 +378,8 @@ Currently the following series are supported.
 | `:ExtraspecialPlusOdd` | odd power of odd prime |
 """
 function character_table(series::Symbol, parameter::Union{Int, Vector{Int}})
-    args = GAP.Obj([string(series), parameter], recursive = true)
-    tbl = GAP.Globals.CallFuncList(GAP.Globals.CharacterTable, args)::GapObj
+    paras = GAP.Obj(parameter, recursive = true)
+    tbl = GAPWrap.CharacterTable(GapObj(series), paras)
     tbl === GAP.Globals.fail && return nothing
     tbl = GAPGroupCharacterTable(tbl, 0)
     set_attribute!(tbl, :series, (series, parameter))
@@ -338,7 +394,7 @@ end
 
 # Use the isomorphism.
 function preimages(iso::MapFromFunc{GrpAbFinGen, GapObj}, H::GapObj)
-  return sub(domain(iso), [preimage(iso, x) for x in GAP.Globals.GeneratorsOfGroup(H)])
+  return sub(domain(iso), [preimage(iso, x) for x in GAPWrap.GeneratorsOfGroup(H)])
 end
 
 
@@ -360,13 +416,23 @@ end
 """
     is_duplicate_table(tbl::GAPGroupCharacterTable)
 
-Return whether `tbl` is a table from the character table library
+Return whether `tbl` is an ordinary table from the character table library
 that was constructed from another library character table by permuting rows
 and columns.
 
 One application of this function is to restrict the search with
 [`all_character_table_names`](@ref) to only one library character table for each
 class of permutation equivalent tables.
+
+
+# Examples
+```jldoctest
+julia> is_duplicate_table(character_table("A5"))
+false
+
+julia> is_duplicate_table(character_table("A6M2"))
+true
+```
 """
 @gapattribute is_duplicate_table(tbl::GAPGroupCharacterTable) = GAP.Globals.IsDuplicateTable(GAPTable(tbl))::Bool
 
@@ -398,7 +464,7 @@ function all_character_table_names(L...; ordered_by = nothing)
     gapargs = translate_group_library_args(L; filter_attrs = _ctbl_filter_attrs)
 
     if ordered_by isa Function
-      K = GAP.call_gap_func(GAP.Globals.AllCharacterTableNames, gapargs...;
+      K = GAP.Globals.AllCharacterTableNames(gapargs...;
             OrderedBy = find_index_function(ordered_by, _ctbl_filter_attrs)[2])::GapObj
     else
       K = GAP.Globals.AllCharacterTableNames(gapargs...)::GapObj
@@ -547,17 +613,177 @@ function matrix_of_strings(tbl::GAPGroupCharacterTable; alphabet::String = "", r
   return (m, legend)
 end
 
-# Produce LaTeX output if `"text/html"` is prescribed,
+# supercompact and one-line printing
+function Base.show(io::IO, tbl::GAPGroupCharacterTable)
+  if get(io, :supercompact, false)
+    # no nested printing
+    if characteristic(tbl) == 0
+      print(io, "character table of a group")
+    else
+      print(io, "$(characteristic(tbl))-modular Brauer table of a group")
+    end
+  else
+    # nested printing allowed, preferably supercompact
+    if isdefined(tbl, :group)
+      if characteristic(tbl) == 0
+        print(io, "character table of group ")
+      else
+        print(io, "$(characteristic(tbl))-modular Brauer table of group ")
+      end
+      print(IOContext(io, :supercompact => true), group(tbl))
+    elseif characteristic(tbl) == 0
+      print(io, "character table of ", identifier(tbl))
+    else
+      print(io, "$(characteristic(tbl))-modular Brauer table of ",
+        identifier(ordinary_table(tbl)))
+    end
+  end
+end
+
+# Produce LaTeX output if `"text/latex"` is prescribed,
 # via the `:TeX` attribute of the io context.
 function Base.show(io::IO, ::MIME"text/latex", tbl::GAPGroupCharacterTable)
   print(io, "\$")
-  show(IOContext(io, :TeX => true), tbl)
+  show(IOContext(io, :TeX => true), MIME("text/plain"), tbl)
   print(io, "\$")
 end
 
-# Produce a screen format without LaTeX markup but with unicode characters
-# and sub-/superscripts if LaTeX output is not requested..
-function Base.show(io::IO, tbl::GAPGroupCharacterTable)
+@doc raw"""
+    Base.show(io::IO, ::MIME"text/plain", tbl::GAPGroupCharacterTable)
+
+Display the irreducible characters of `tbl` and context information
+as a two-dimensional array.
+
+- First a *header* is shown.
+  If `tbl` stores a group then the header describes this group,
+  otherwise it is equal to the
+  [`identifier(tbl::GAPGroupCharacterTable)`](@ref) value of `tbl`.
+
+- Then the irreducible characters of `tbl` are shown in column portions
+  that fit on the screen,
+  together with *column labels* above each portion
+  and *row labels* on the left of each portion.
+
+  The column labels consist of
+  the factored centralizer orders (see [`orders_centralizers`](@ref),
+  one row for each prime divisor of the group order),
+  followed by one row showing the class names (see [`class_names`](@ref)),
+  followed by the power maps (one row for each stored power map).
+
+  The row labels are `X_1`, `X_2`, ...
+  (or χ with subscripts `1`, `2`, ... if unicode output is allowed).
+  If `io` is an `IOContext` with key `:indicator` set to `true` then
+  a second column of row labels shows the 2nd Frobenius-Schur indicator
+  of the irreducibles (see [`indicator`](@ref));
+  analogously, setting the key `:character_field` to `true` yields a
+  column showing the degrees of the character fields
+  (see [`character_field`](@ref)),
+  and setting the key `:OD` to `true` yields a column showing the known
+  orthogonal discriminants of those irreducibles that have indicator `+`
+  and even degree.
+
+- Depending on the way how irrational character values are shown,
+  a *footer* may be shown in the end.
+  By default, irrationalities are shown as sums of roots of unity,
+  where `z_n` (or ζ with subscript `n` if unicode output is allowed)
+  denotes the primitive `n`-th root $\exp(2 \pi i/n)$.
+  If `io` is an `IOContext` with key `:with_legend` set to `true`
+  then irrationalities are abbreviated as `A`, `B`, ...,
+  and these names together with the corresponding expression as
+  sums of roots of unity appear in the footer.
+
+Output in ``\LaTeX`` syntax can be created by calling `show`
+with second argument `MIME("text/latex")`.
+
+# Examples
+```jldoctest
+julia> tbl = character_table(:Cyclic, 3);
+
+julia> Oscar.with_unicode() do
+         show(stdout, MIME("text/plain"), tbl)
+       end;
+C3
+
+ 3  1       1       1
+                     
+   1a      3a      3b
+3P 1a      1a      1a
+                     
+χ₁  1       1       1
+χ₂  1      ζ₃ -ζ₃ - 1
+χ₃  1 -ζ₃ - 1      ζ₃
+
+julia> Oscar.with_unicode() do
+         show(IOContext(stdout, :with_legend => true), MIME("text/plain"), tbl)
+       end;
+C3
+
+ 3  1  1  1
+           
+   1a 3a 3b
+3P 1a 1a 1a
+           
+χ₁  1  1  1
+χ₂  1  A  A̅
+χ₃  1  A̅  A
+
+A = ζ₃
+A̅ = -ζ₃ - 1
+
+julia> Oscar.with_unicode() do
+         show(IOContext(stdout, :indicator => true), MIME("text/plain"), tbl)
+       end;
+C3
+
+    3  1       1       1
+                        
+      1a      3a      3b
+   3P 1a      1a      1a
+    2                   
+χ₁  +  1       1       1
+χ₂  o  1      ζ₃ -ζ₃ - 1
+χ₃  o  1 -ζ₃ - 1      ζ₃
+
+julia> Oscar.with_unicode() do
+         show(IOContext(stdout, :character_field => true), MIME("text/plain"), tbl)
+       end;
+C3
+
+    3  1       1       1
+                        
+      1a      3a      3b
+   2P 1a      3b      3a
+   3P 1a      1a      1a
+    d                   
+χ₁  1  1       1       1
+χ₂  2  1      ζ₃ -ζ₃ - 1
+χ₃  2  1 -ζ₃ - 1      ζ₃
+
+julia> Oscar.with_unicode() do
+         show(IOContext(stdout, :with_legend => true), MIME("text/latex"), tbl)
+       end;
+$C3
+
+\begin{array}{rrrr}
+3 & 1 & 1 & 1 \\
+ &  &  &  \\
+ & 1a & 3a & 3b \\
+2P & 1a & 3b & 3a \\
+3P & 1a & 1a & 1a \\
+ &  &  &  \\
+\chi_{1} & 1 & 1 & 1 \\
+\chi_{2} & 1 & A & \overline{A} \\
+\chi_{3} & 1 & \overline{A} & A \\
+\end{array}
+
+\begin{array}{l}
+A = \zeta_{3} \\
+\overline{A} = -\zeta_{3} - 1 \\
+\end{array}
+$
+```
+"""
+function Base.show(io::IO, ::MIME"text/plain", tbl::GAPGroupCharacterTable)
     n = nrows(tbl)
     gaptbl = GAPTable(tbl)
     size = order(ZZRingElem, tbl)
@@ -588,8 +814,8 @@ function Base.show(io::IO, tbl::GAPGroupCharacterTable)
     cents_strings = [d[p] for p in primes]
 
     # Compute display format for power maps.
-    names = Vector{String}(GAP.Globals.ClassNames(gaptbl)::GapObj)
-    pmaps = Vector{Any}(GAP.Globals.ComputedPowerMaps(gaptbl)::GapObj)
+    names = class_names(tbl)
+    pmaps = Vector{Any}(GAPWrap.ComputedPowerMaps(gaptbl))
     power_maps_primes = String[]
     power_maps_strings = Vector{String}[]
     for i in 2:length(pmaps)
@@ -620,7 +846,7 @@ function Base.show(io::IO, tbl::GAPGroupCharacterTable)
     OD = get(io, :OD, false)::Bool
     if OD && hasproperty(GAP.Globals, :OrthogonalDiscriminants)
       ODs = [replace(x -> isnothing(x) ? "" : string(x),
-                     Vector{Any}(GAP.Globals.OrthogonalDiscriminants(gaptbl)::GapObj))]
+                     Vector{Any}(GAPWrap.OrthogonalDiscriminants(gaptbl)))]
       for i in (length(ODs[1])+1):n
         push!(ODs[1], "")
       end
@@ -636,9 +862,9 @@ function Base.show(io::IO, tbl::GAPGroupCharacterTable)
     if field_degrees
       p = characteristic(tbl)
       if p == 0
-        field_degrees = [[string(GAP.Globals.Dimension(GAP.Globals.Field(GAP.Globals.Rationals, x.values))) for x in tbl]]
+        field_degrees = [[string(degree(character_field(x)[1])) for x in tbl]]
       else
-        field_degrees = [[string(collect(factor(GAP.Globals.SizeOfFieldOfDefinition(x.values, p)))[1][2]) for x in tbl]]
+        field_degrees = [[string(collect(factor(order_field_of_definition(x)))[1][2]) for x in tbl]]
       end
       field_label = ["d"]
       push!(emptycor, "")
@@ -700,20 +926,6 @@ function Base.show(io::IO, tbl::GAPGroupCharacterTable)
     labelled_matrix_formatted(ioc, mat)
 end
 
-# print: abbreviated form
-function Base.print(io::IO, tbl::GAPGroupCharacterTable)
-    gaptbl = GAPTable(tbl)
-    if isdefined(tbl, :group)
-      id = string(group(tbl))
-      if characteristic(tbl) != 0
-        id = "$(id)mod$(characteristic(tbl))"
-      end
-    else
-      id = "\"" * identifier(tbl) * "\""
-    end
-    print(io, "character_table($id)")
-end
-
 
 ##############################################################################
 #
@@ -725,7 +937,8 @@ number_conjugacy_classes(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClass
 @doc raw"""
     order(::Type{T} = ZZRingElem, tbl::GAPGroupCharacterTable) where T <: IntegerUnion
 
-Return the order of the group for which `tbl` is the character table.
+Return the order of the group for which `tbl` is the character table,
+as an instance of `T`.
 
 # Examples
 ```jldoctest
@@ -802,8 +1015,8 @@ true
 ```
 """
 function maxes(tbl::GAPGroupCharacterTable)
-  if GAP.Globals.HasMaxes(GAPTable(tbl))::Bool
-    return Vector{String}(GAP.Globals.Maxes(GAPTable(tbl))::GapObj)
+  if GAPWrap.HasMaxes(GAPTable(tbl))
+    return Vector{String}(GAPWrap.Maxes(GAPTable(tbl)))
   end
   return nothing
 end
@@ -835,7 +1048,7 @@ julia> println(class_positions_of_pcore(character_table("2.A5"), 2))
 [1, 2]
 ```
 """
-class_positions_of_pcore(tbl::GAPGroupCharacterTable, p::IntegerUnion) = Vector{Int}(GAP.Globals.ClassPositionsOfPCore(GAPTable(tbl), GAP.Obj(p))::GapObj)
+class_positions_of_pcore(tbl::GAPGroupCharacterTable, p::IntegerUnion) = Vector{Int}(GAPWrap.ClassPositionsOfPCore(GAPTable(tbl), GAP.Obj(p)))
 
 @doc raw"""
     pcore(tbl::GAPGroupCharacterTable, p::IntegerUnion)
@@ -851,11 +1064,11 @@ julia> order(pcore(character_table(symmetric_group(4)), 2)[1])
 ```
 """
 function pcore(tbl::GAPGroupCharacterTable, p::IntegerUnion)
-    @req isdefined(tbl, :group) "character table stores no group"
+    iso = isomorphism_to_GAP_group(tbl)
     t = GAPTable(tbl)
-    pcorepos = GAP.Globals.ClassPositionsOfPCore(t, GAP.Obj(p))::GapObj
-    P = GAP.Globals.NormalSubgroupClasses(t, pcorepos)::GapObj
-    return preimages(isomorphism_to_GAP_group(tbl), P)
+    pcorepos = GAPWrap.ClassPositionsOfPCore(t, GAP.Obj(p))
+    P = GAPWrap.NormalSubgroupClasses(t, pcorepos)
+    return preimages(iso, P)
 end
 
 function class_positions_of_kernel(fus::Vector{Int})
@@ -863,7 +1076,7 @@ function class_positions_of_kernel(fus::Vector{Int})
 end
 
 function Base.getindex(tbl::GAPGroupCharacterTable, i::Int)
-    irr = GAP.Globals.Irr(GAPTable(tbl))::GapObj
+    irr = GAPWrap.Irr(GAPTable(tbl))
     return group_class_function(tbl, irr[i])
 end
 #TODO: cache the irreducibles in the table
@@ -877,7 +1090,7 @@ function Base.keys(tbl::GAPGroupCharacterTable)
 end
 
 function Base.getindex(tbl::GAPGroupCharacterTable, i::Int, j::Int)
-    irr = GAP.Globals.Irr(GAPTable(tbl))::GapObj
+    irr = GAPWrap.Irr(GAPTable(tbl))
     val = irr[i, j]
     return QQAbElem(val)
 end
@@ -892,6 +1105,12 @@ Return the `p`-modular character table of `tbl`,
 or `nothing` if this table cannot be computed.
 
 An exception is thrown if `tbl` is not an ordinary character table.
+
+# Examples
+```jldoctest
+julia> show(mod(character_table("A5"), 2))
+2-modular Brauer table of A5
+```
 """
 function Base.mod(tbl::GAPGroupCharacterTable, p::Int)
     @req is_prime(p) "p must be a prime integer"
@@ -905,12 +1124,13 @@ function Base.mod(tbl::GAPGroupCharacterTable, p::Int)
       elseif isdefined(tbl, :group)
         modtbls[p] = GAPGroupCharacterTable(group(tbl), modtblgap,
                        isomorphism_to_GAP_group(tbl), p)
+        set_attribute!(modtbls[p], :ordinary_table, tbl)
       else
         modtbls[p] = GAPGroupCharacterTable(modtblgap, p)
+        set_attribute!(modtbls[p], :ordinary_table, tbl)
       end
     end
 
-    set_attribute!(modtbls[p], :ordinary_table, tbl)
     return modtbls[p]
 end
 
@@ -937,7 +1157,7 @@ julia> decomposition_matrix(t2)
 """
 function decomposition_matrix(modtbl::GAPGroupCharacterTable)
     @req is_prime(characteristic(modtbl)) "characteristic of tbl must be a prime integer"
-    return matrix(ZZ, GAP.Globals.DecompositionMatrix(GAPTable(modtbl))::GapObj)
+    return matrix(ZZ, GAPWrap.DecompositionMatrix(GAPTable(modtbl)))
 end
 
 @doc raw"""
@@ -980,7 +1200,7 @@ julia> class_multiplication_coefficient(character_table("A5"), 2, 4, 4)
 ```
 """
 function class_multiplication_coefficient(::Type{T}, tbl::GAPGroupCharacterTable, i::Int, j::Int, k::Int) where T <: IntegerUnion
-  return T(GAP.Globals.ClassMultiplicationCoefficient(GAPTable(tbl), i, j, k)::GAP.Obj)
+  return T(GAPWrap.ClassMultiplicationCoefficient(GAPTable(tbl), i, j, k))
 end
 
 class_multiplication_coefficient(tbl::GAPGroupCharacterTable, i::Int, j::Int, k::Int) = class_multiplication_coefficient(ZZRingElem, tbl, i, j, k)
@@ -1004,7 +1224,7 @@ julia> possible_class_fusions(character_table("A5"), character_table("A6"))
 ```
 """
 function possible_class_fusions(subtbl::GAPGroupCharacterTable, tbl::GAPGroupCharacterTable)
-  fus = GAP.Globals.PossibleClassFusions(GAPTable(subtbl), GAPTable(tbl))::GapObj
+  fus = GAPWrap.PossibleClassFusions(GAPTable(subtbl), GAPTable(tbl))
   return [Vector{Int}(x::GapObj) for x in fus]
 end
 
@@ -1019,7 +1239,7 @@ function _translate_parameter(para)
       return para
     elseif GAPWrap.IsCyc(para)
       # happens for the `P:Q` table, only roots of unity occur
-      return [x for x in GAP.Globals.DescriptionOfRootOfUnity(para)::GapObj]
+      return [x for x in GAPWrap.DescriptionOfRootOfUnity(para)]
     elseif ! GAPWrap.IsList(para)
       # What can this parameter be?
       return GAP.gap_to_julia(para)
@@ -1067,8 +1287,8 @@ julia> character_parameters(character_table("M11"))
 function character_parameters(tbl::GAPGroupCharacterTable)
     return get_attribute!(tbl, :character_parameters) do
       GAPt = GAPTable(tbl)
-      GAP.Globals.HasCharacterParameters(GAPt)::Bool || return nothing
-      paras = Vector{GAP.Obj}(GAP.Globals.CharacterParameters(GAPt)::GapObj)
+      GAPWrap.HasCharacterParameters(GAPt) || return nothing
+      paras = Vector{GAP.Obj}(GAPWrap.CharacterParameters(GAPt))
       return _translate_parameter_list(paras)
     end
 end
@@ -1097,20 +1317,55 @@ julia> class_parameters(character_table("M11"))
 function class_parameters(tbl::GAPGroupCharacterTable)
     return get_attribute!(tbl, :class_parameters) do
       GAPt = GAPTable(tbl)
-      GAP.Globals.HasClassParameters(GAPt)::Bool || return nothing
-      paras = Vector{GAP.Obj}(GAP.Globals.ClassParameters(GAPt)::GapObj)
+      GAPWrap.HasClassParameters(GAPt) || return nothing
+      paras = Vector{GAP.Obj}(GAPWrap.ClassParameters(GAPt))
       return _translate_parameter_list(paras)
     end
 end
+
+
+@doc raw"""
+    class_names(tbl::GAPGroupCharacterTable)
+
+Return a vector of strings corresponding to the columns of `tbl`.
+The $i$-th entry consists of the element order for the $i$-th column,
+followed by at least one distinguishing letter.
+For example, the classes of elements of order two have class names
+`"2a", "2b", and so on.
+
+# Examples
+```jldoctest
+julia> println(class_names(character_table("S5")))
+["1a", "2a", "3a", "5a", "2b", "4a", "6a"]
+```
+"""
+function class_names(tbl::GAPGroupCharacterTable)
+    return get_attribute!(tbl, :class_names) do
+      return Vector{String}(GAPWrap.ClassNames(GAPTable(tbl)))
+    end
+end
+
 
 @doc raw"""
     names_of_fusion_sources(tbl::GAPGroupCharacterTable)
 
 Return the array of strings that are identifiers of those character tables
-which store a class fusion to `tbl`.
+which store a class fusion to `tbl`,
+which must be an ordinary character table.
+
+# Examples
+```jldoctest
+julia> tbl = character_table("A5");
+
+julia> println(maxes(tbl))
+["a4", "D10", "S3"]
+
+julia> all(x -> x in names_of_fusion_sources(tbl), maxes(tbl))
+true
+```
 """
 function names_of_fusion_sources(tbl::GAPGroupCharacterTable)
-    return [string(name) for name in GAP.Globals.NamesOfFusionSources(GAPTable(tbl))::GapObj]
+    return [string(name) for name in GAPWrap.NamesOfFusionSources(GAPTable(tbl))]
 end
 
 @doc raw"""
@@ -1132,7 +1387,7 @@ the image of the $i$-th conjugacy class `tbl1` under the relevant epimorphism
 is the `fus`[$i$]-th conjugacy class of `tbl2`.
 """
 function known_class_fusion(subtbl::GAPGroupCharacterTable, tbl::GAPGroupCharacterTable)
-    map = GAP.Globals.GetFusionMap(GAPTable(subtbl), GAPTable(tbl))::GapObj
+    map = GAPWrap.GetFusionMap(GAPTable(subtbl), GAPTable(tbl))
     if map === GAP.Globals.fail
       return (false, Int[])
     else
@@ -1157,9 +1412,13 @@ function Base.show(io::IO, chi::GAPGroupClassFunction)
 end
 
 function values(chi::GAPGroupClassFunction)
-    gapvalues = GAP.Globals.ValuesOfClassFunction(chi.values)::GapObj
+    gapvalues = GAPWrap.ValuesOfClassFunction(chi.values)
     return [QQAbElem(x) for x in gapvalues]
 end
+
+group(chi::GAPGroupClassFunction) = group(chi.table)
+
+characteristic(chi::GAPGroupClassFunction) = characteristic(chi.table)
 
 function group_class_function(tbl::GAPGroupCharacterTable, values::GapObj)
     @req GAPWrap.IsClassFunction(values) "values must be a class function"
@@ -1168,7 +1427,7 @@ end
 
 function group_class_function(tbl::GAPGroupCharacterTable, values::Vector{<:QQAbElem})
     gapvalues = GapObj([GAP.Obj(x) for x in values])
-    return GAPGroupClassFunction(tbl, GAP.Globals.ClassFunction(GAPTable(tbl), gapvalues)::GapObj)
+    return GAPGroupClassFunction(tbl, GAPWrap.ClassFunction(GAPTable(tbl), gapvalues))
 end
 
 function group_class_function(G::GAPGroup, values::Vector{<:QQAbElem})
@@ -1179,6 +1438,14 @@ end
     trivial_character(tbl::GAPGroupCharacterTable)
 
 Return the character of `tbl` that has the value `QQAbElem(1)` in each position.
+
+# Examples
+```jldoctest
+julia> t = character_table(symmetric_group(4));
+
+julia> all(x -> x == 1, trivial_character(t))
+true
+```
 """
 function trivial_character(tbl::GAPGroupCharacterTable)
     val = QQAbElem(1)
@@ -1190,6 +1457,14 @@ end
 
 Return the character of (the ordinary character table of) `G`
 that has the value `QQAbElem(1)` in each position.
+
+# Examples
+```jldoctest
+julia> g = symmetric_group(4);
+
+julia> all(x -> x == 1, trivial_character(g))
+true
+```
 """
 function trivial_character(G::GAPGroup)
     val = QQAbElem(1)
@@ -1201,6 +1476,17 @@ end
 
 Return the permutation character of degree `degree(G)`
 that maps each element of `G` to the number of its fixed points.
+
+# Examples
+```jldoctest
+julia> g = symmetric_group(4);
+
+julia> degree(natural_character(g))
+4
+
+julia> degree(natural_character(stabilizer(g, 4)[1]))
+4
+```
 """
 function natural_character(G::PermGroup)
     tbl = character_table(G)
@@ -1259,10 +1545,10 @@ function induce(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable)
   subtbl = chi.table
   if !(isdefined(tbl, :group) && isdefined(subtbl, :group))
     # If there is no stored group then let GAP try to find the result.
-    fus = GAP.Globals.FusionConjugacyClasses(GAPTable(subtbl), GAPTable(tbl))
+    fus = GAPWrap.FusionConjugacyClasses(GAPTable(subtbl), GAPTable(tbl))
     @req fus !== GAP.Globals.fail "class fusion is not uniquely determinaed"
-    ind = GAP.Globals.InducedClassFunctionsByFusionMap(GAPTable(chi.table),
-          GAPTable(tbl), GapObj([chi.values]), GapObj(fus))::GapObj
+    ind = GAPWrap.InducedClassFunctionsByFusionMap(GAPTable(chi.table),
+          GAPTable(tbl), GapObj([chi.values]), GapObj(fus))
     return GAPGroupClassFunction(tbl, ind[1])
   else
     # Dispatch on the types of the stored groups.
@@ -1271,14 +1557,14 @@ function induce(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable)
 end
 
 function induce(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable, fusion::Vector{Int})
-  ind = GAP.Globals.InducedClassFunctionsByFusionMap(GAPTable(chi.table),
-          GAPTable(tbl), GapObj([chi.values]), GapObj(fusion))::GapObj
+  ind = GAPWrap.InducedClassFunctionsByFusionMap(GAPTable(chi.table),
+          GAPTable(tbl), GapObj([chi.values]), GapObj(fusion))
   return GAPGroupClassFunction(tbl, ind[1])
 end
 
 # If `GAPGroup` groups are stored then we let GAP try to find the result.
 function _induce(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable, G_chi::GAPGroup, G_tbl::GAPGroup)
-  ind = GAP.Globals.InducedClassFunction(chi.values, GAPTable(tbl))::GapObj
+  ind = GAPWrap.InducedClassFunction(chi.values, GAPTable(tbl))
   return GAPGroupClassFunction(tbl, ind)
 end
 
@@ -1302,7 +1588,7 @@ Return the array of permutation characters of `tbl` that are induced from
 cyclic subgroups.
 """
 function induced_cyclic(tbl::GAPGroupCharacterTable)
-    return [GAPGroupClassFunction(tbl, chi) for chi in GAP.Globals.InducedCyclic(GAPTable(tbl))::GapObj]
+    return [GAPGroupClassFunction(tbl, chi) for chi in GAPWrap.InducedCyclic(GAPTable(tbl))]
 end
 
 """
@@ -1336,10 +1622,10 @@ function restrict(chi::GAPGroupClassFunction, subtbl::GAPGroupCharacterTable)
   tbl = chi.table
   if !(isdefined(tbl, :group) && isdefined(subtbl, :group))
     # If there is no stored group then let GAP try to find the result.
-    fus = GAP.Globals.FusionConjugacyClasses(GAPTable(subtbl), GAPTable(tbl))::GapObj
+    fus = GAPWrap.FusionConjugacyClasses(GAPTable(subtbl), GAPTable(tbl))
     @req fus !== GAP.Globals.fail "class fusion is not uniquely determinaed"
-    rest = GAP.Globals.ELMS_LIST(chi.values, GapObj(fus))::GapObj
-    rest = GAP.Globals.ClassFunction(GAPTable(subtbl), rest)::GapObj
+    rest = GAPWrap.ELMS_LIST(chi.values, GapObj(fus))
+    rest = GAPWrap.ClassFunction(GAPTable(subtbl), rest)
     return GAPGroupClassFunction(subtbl, rest)
   else
     # Dispatch on the types of the stored groups.
@@ -1348,17 +1634,17 @@ function restrict(chi::GAPGroupClassFunction, subtbl::GAPGroupCharacterTable)
 end
 
 function restrict(chi::GAPGroupClassFunction, subtbl::GAPGroupCharacterTable, fusion::Vector{Int})
-  rest = GAP.Globals.ELMS_LIST(chi.values, GapObj(fusion))::GapObj
-  rest = GAP.Globals.ClassFunction(GAPTable(subtbl), rest)::GapObj
+  rest = GAPWrap.ELMS_LIST(chi.values, GapObj(fusion))
+  rest = GAPWrap.ClassFunction(GAPTable(subtbl), rest)
   return GAPGroupClassFunction(subtbl, rest)
 end
 
 # If `GAPGroup` groups are stored then we let GAP try to find the result.
 function _restrict(chi::GAPGroupClassFunction, subtbl::GAPGroupCharacterTable, G_chi::GAPGroup, G_tbl::GAPGroup)
   tbl = chi.table
-  fus = GAP.Globals.FusionConjugacyClasses(GAPTable(subtbl), GAPTable(tbl))::GapObj
-  rest = GAP.Globals.ELMS_LIST(chi.values, GapObj(fus))::GapObj
-  rest = GAP.Globals.ClassFunction(GAPTable(subtbl), rest)::GapObj
+  fus = GAPWrap.FusionConjugacyClasses(GAPTable(subtbl), GAPTable(tbl))
+  rest = GAPWrap.ELMS_LIST(chi.values, GapObj(fus))
+  rest = GAPWrap.ClassFunction(GAPTable(subtbl), rest)
   return GAPGroupClassFunction(subtbl, rest)
 end
 
@@ -1397,7 +1683,7 @@ Nemo.degree(::Type{T}, chi::GAPGroupClassFunction) where T <: IntegerUnion = T(N
 
 # access character values
 function Base.getindex(chi::GAPGroupClassFunction, i::Int)
-  vals = GAP.Globals.ValuesOfClassFunction(chi.values)::GapObj
+  vals = GAPWrap.ValuesOfClassFunction(chi.values)
   return QQAbElem(vals[i])
 end
 
@@ -1533,7 +1819,7 @@ julia> println(multiplicities_eigenvalues(chi, 5))
 ```
 """
 function multiplicities_eigenvalues(::Type{T}, chi::GAPGroupClassFunction, i::Int) where T <: IntegerUnion
-    return Vector{T}(GAP.Globals.EigenvaluesChar(chi.values, i))
+    return Vector{T}(GAPWrap.EigenvaluesChar(chi.values, i))
 end
 
 multiplicities_eigenvalues(chi::GAPGroupClassFunction, i::Int) = multiplicities_eigenvalues(Int, chi, i)
@@ -1553,8 +1839,6 @@ end
 
 function Base.:^(chi::GAPGroupClassFunction, g::Union{GAPGroupElem, GrpAbFinGenElem})
     tbl = chi.table
-    @req isdefined(tbl, :group) "character table stores no group"
-    G = group(tbl)
     ccl = conjugacy_classes(tbl)
     reps = [representative(c) for c in ccl]
     pi = [findfirst(x -> x^g in c, reps) for c in ccl]
@@ -1566,9 +1850,15 @@ end
 
 Return the class function whose values are the complex conjugates of
 the values of `chi`.
+
+# Examples
+```jldoctest
+julia> println([findfirst(y -> y == conj(x), tbl) for x in tbl])
+[1, 3, 2, 4]
+```
 """
 function conj(chi::GAPGroupClassFunction)
-    return GAPGroupClassFunction(chi.table, GAP.Globals.GaloisCyc(chi.values, -1)::GAP.Obj)
+    return GAPGroupClassFunction(chi.table, GAPWrap.GaloisCyc(chi.values, -1))
 end
 
 @doc raw"""
@@ -1578,7 +1868,7 @@ Return the class function whose values are the images of the values of `chi`
 under `sigma`.
 """
 function (sigma::QQAbAutomorphism)(chi::GAPGroupClassFunction)
-    return GAPGroupClassFunction(chi.table, GAP.Globals.GaloisCyc(chi.values, sigma.exp)::GAP.Obj)
+    return GAPGroupClassFunction(chi.table, GAPWrap.GaloisCyc(chi.values, sigma.exp))
 end
 
 Base.:^(chi::GAPGroupClassFunction, sigma::QQAbAutomorphism) = sigma(chi)
@@ -1612,6 +1902,17 @@ characters.
 For ordinary characters this can be checked using the scalar product of
 class functions (see [`scalar_product`](@ref).
 For Brauer characters there is no generic method for checking irreducibility.
+
+# Examples
+```jldoctest
+julia> g = symmetric_group(4);
+
+julia> all(is_irreducible, character_table(g))
+true
+
+julia> is_irreducible(natural_character(g))
+false
+```
 """
 function is_irreducible(chi::GAPGroupClassFunction)
     return GAPWrap.IsIrreducibleCharacter(chi.values)
@@ -1628,7 +1929,7 @@ the representations affording `chi` have trivial kernel.
 
 # Examples
 ```jldoctest
-julia> show(map(is_faithful, character_table(symmetric_group(3))))
+julia> println(map(is_faithful, character_table(symmetric_group(3))))
 Bool[0, 1, 0]
 ```
 """
@@ -1693,9 +1994,9 @@ julia> C, f = kernel(chi);  order(C)
 """
 function kernel(chi::GAPGroupClassFunction)
     tbl = chi.table
-    @req isdefined(tbl, :group) "character table stores no group"
-    GAP_K = GAP.Globals.KernelOfCharacter(GAPTable(tbl), chi.values)::GapObj
-    return preimages(isomorphism_to_GAP_group(tbl), GAP_K)
+    iso = isomorphism_to_GAP_group(tbl)
+    GAP_K = GAPWrap.KernelOfCharacter(GAPTable(tbl), chi.values)
+    return preimages(iso, GAP_K)
 end
 
 @doc raw"""
@@ -1711,7 +2012,7 @@ julia> println(class_positions_of_center(character_table("2.A5")[2]))
 ```
 """
 function class_positions_of_center(chi::GAPGroupClassFunction)
-    return Vector{Int}(GAP.Globals.ClassPositionsOfCentre(chi.values))
+    return Vector{Int}(GAPWrap.ClassPositionsOfCentre(chi.values))
 end
 
 @doc raw"""
@@ -1735,10 +2036,9 @@ julia> C, f = center(chi);  order(C)
 """
 function center(chi::GAPGroupClassFunction)
     tbl = chi.table
-    @req isdefined(tbl, :group) "character table stores no group"
-    G = group(tbl)
-    C = GAP.Globals.CentreOfCharacter(GAPTable(tbl), chi.values)::GapObj
-    return preimages(isomorphism_to_GAP_group(tbl), C)
+    iso = isomorphism_to_GAP_group(tbl)
+    C = GAPWrap.CentreOfCharacter(GAPTable(tbl), chi.values)
+    return preimages(iso, C)
 end
 
 @doc raw"""
@@ -1757,7 +2057,7 @@ true
 ```
 """
 function det(chi::GAPGroupClassFunction)
-    values = GAP.Globals.DeterminantOfCharacter(chi.values)
+    values = GAPWrap.DeterminantOfCharacter(chi.values)
     return GAPGroupClassFunction(chi.table, values)
 end
 
@@ -1779,7 +2079,7 @@ ZZRingElem[2, 1, 2, 2, 1]
 order(chi::GAPGroupClassFunction) = order(ZZRingElem, chi)::ZZRingElem
 
 function order(::Type{T}, chi::GAPGroupClassFunction) where T <: IntegerUnion
-    return T(GAP.Globals.Order(det(chi).values))::T
+    return T(GAPWrap.Order(det(chi).values))::T
 end
 
 @doc raw"""
@@ -1792,22 +2092,60 @@ If `chi` is irreducible then `indicator(chi)` is
 `0` if `chi` is not real-valued,
 `1` if `chi` is afforded by a real representation of $G$, and
 `-1` if `chi` is real-valued but not afforded by a real representation of $G$.
+
+# Examples
+```jldoctest
+julia> tbl = character_table("U3(3)");
+
+julia> println([indicator(chi) for chi in tbl])
+[1, -1, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0]
+```
 """
 function indicator(chi::GAPGroupClassFunction, n::Int = 2)
-    ind = GAP.Globals.Indicator(GAPTable(chi.table), GapObj([chi.values]), n)::GapObj
+    ind = GAPWrap.Indicator(GAPTable(chi.table), GapObj([chi.values]), n)
     return ind[1]::Int
 end
 
 @doc raw"""
     character_field(chi::GAPGroupClassFunction)
 
-Return the pair `(F, phi)` where `F` is a number field that is generated
+If `chi` is an ordinary character then
+return the pair `(F, phi)` where `F` is a number field that is generated
 by the character values of `chi`, and `phi` is the embedding of `F` into
 `abelian_closure(QQ)`.
+
+If `chi` is a Brauer character in characteristic `p` then
+return the pair `(F, phi)` where `F` is the finite field that is generated
+by the `p`-modular reductions of the values of `chi`,
+and `phi` is the identity map on `F`.
+
+# Examples
+```jldoctest
+julia> t = character_table("A5");
+
+julia> character_field(t[2])[1]
+Number field with defining polynomial x^2 + x - 1
+  over rational field
+
+julia> flds_2 = map(character_field, mod(t, 2));
+
+julia> println([degree(x[1]) for x in flds_2])
+[1, 2, 2, 1]
+```
 """
 function character_field(chi::GAPGroupClassFunction)
+    p = characteristic(chi)
+    if p != 0
+      # Brauer character, construct a finite field
+      q = order_field_of_definition(chi)
+      flag, pp, e = is_prime_power_with_data(q)
+      (flag && p == pp) || error("something is wrong with 'GAPWrap.SizeOfFieldOfDefinition'")
+      F = Nemo._GF(p, e)
+      return (F, identity_map(F))
+    end
+
     values = chi.values  # a list of GAP cyclotomics
-    gapfield = GAP.Globals.Field(values)::GapObj
+    gapfield = GAPWrap.Field(values)
     N = GAPWrap.Conductor(gapfield)
     FF, = abelian_closure(QQ)
     if GAPWrap.IsCyclotomicField(gapfield)
@@ -1824,10 +2162,10 @@ function character_field(chi::GAPGroupClassFunction)
       end
     else
       # In the general case, we have to work for the embedding.
-      gapgens = GAP.Globals.GeneratorsOfField(gapfield)::GapObj
+      gapgens = GAPWrap.GeneratorsOfField(gapfield)
       @assert length(gapgens) == 1
-      gappol = GAP.Globals.MinimalPolynomial(GAP.Globals.Rationals, gapgens[1])::GapObj
-      gapcoeffs = GAP.Globals.CoefficientsOfUnivariatePolynomial(gappol)::GapObj
+      gappol = GAPWrap.MinimalPolynomial(GAP.Globals.Rationals, gapgens[1])
+      gapcoeffs = GAPWrap.CoefficientsOfUnivariatePolynomial(gappol)
       v = Vector{QQFieldElem}(gapcoeffs)
       R, = polynomial_ring(QQ, "x")
       f = R(v)
@@ -1863,14 +2201,72 @@ function character_field(chi::GAPGroupClassFunction)
 end
 
 @doc raw"""
-    schur_index(chi::GAPGroupClassFunction)
+    number_field(::QQField, chi::GAPGroupClassFunction; cached::Bool = false)
 
-Return the minimal integer `m` such that the character `m * chi`
+Return a pair `(F, a)` where `F` is a number field that describes the
+character field of the ordinary character `chi`,
+and `a` is a generator of `F`.
+The syntax `QQ[chi]` is also supported.
+
+No embedding of `F` into the abelian closure of `QQ` is computed,
+use [`character_field`](@ref) if you are interested in the relations
+between the character fields of several characters.
+"""
+function Hecke.number_field(::QQField, chi::GAPGroupClassFunction; cached::Bool = false)
+  @req characteristic(chi) == 0 "character must be ordinary"
+  return number_field(QQ, values(chi), cached = cached)
+end
+
+# support the syntax `QQ[chi]`
+Base.getindex(::QQField, chi::Oscar.GAPGroupClassFunction) = number_field(QQ, chi)
+
+
+@doc raw"""
+    order_field_of_definition(::Type{T} = ZZRingElem, chi::GAPGroupClassFunction) where T <: IntegerUnion
+
+Return $p^n$, as an instance of `T`, if `chi` is a $p$-modular Brauer character
+such that the $p$-modular reductions of the values of `chi`
+span the field with $p^n$ elements.
+
+Note that one need not compute the [`character_field`](@ref) value of `chi`
+in order to compute `order_field_of_definition(chi)`.
+
+# Examples
+```jldoctest
+julia> println([order_field_of_definition(chi) for chi in tbl])
+ZZRingElem[2, 4, 4, 2]
+```
+"""
+order_field_of_definition(chi::GAPGroupClassFunction) =
+    order_field_of_definition(ZZRingElem, chi)
+
+function order_field_of_definition(::Type{T}, chi::GAPGroupClassFunction) where
+  T <: IntegerUnion
+    p = characteristic(chi)
+    @req p != 0 "the character must be a Brauer character"
+    return T(GAPWrap.SizeOfFieldOfDefinition(chi.values, p))
+end
+
+
+@doc raw"""
+    schur_index(chi::GAPGroupClassFunction) -> Int
+
+For an ordinary irreducible character `chi`,
+return the minimal integer `m` such that the character `m * chi`
 is afforded by a representation over the character field of `chi`,
 or throw an exception if the currently used character theoretic criteria
 do not suffice for computing `m`.
+
+# Examples
+```jldoctest
+julia> t = character_table(quaternion_group(8));
+
+julia> println(map(schur_index, t))
+[1, 1, 1, 1, 2]
+```
 """
 function schur_index(chi::GAPGroupClassFunction, recurse::Bool = true)
+    @req characteristic(chi) == 0 "defined only for ordinary characters"
     deg = numerator(degree(chi))
     deg == 1 && return 1
     indicator(chi) == -1 && return 2
@@ -1882,10 +2278,10 @@ function schur_index(chi::GAPGroupClassFunction, recurse::Bool = true)
     else
       # Compute the conductor of the largest cyclotomic field
       # that is contained in the character field of `chi`.
-      gapfield = GAP.Globals.Field(values)::GapObj
+      gapfield = GAPWrap.Field(values)
       N = GAPWrap.Conductor(gapfield)
       for n in reverse(sort(divisors(N)))
-        if GAP.Globals.E(n)::GAP.Obj in gapfield
+        if GAPWrap.E(n) in gapfield
           if Base.isodd(n)
             bound = ZZRingElem(2*n)
           else
@@ -1935,8 +2331,9 @@ function schur_index(chi::GAPGroupClassFunction, recurse::Bool = true)
     end
 
     if isdefined(tbl, :group) && hasproperty(GAP.Globals, :SchurIndexByCharacter)
+      # The function is defined in the Wedderga package.
       g = group(tbl)
-      return GAP.Globals.SchurIndexByCharacter(GAP.Globals.Rationals, codomain(isomorphism_to_GAP_group(tbl)), values)
+      return GAPWrap.SchurIndexByCharacter(GAP.Globals.Rationals, codomain(isomorphism_to_GAP_group(tbl)), values)
     end
 
     # For the moment, we do not have more character theoretic criteria.
@@ -1972,7 +2369,7 @@ function symmetrizations(characters::Vector{GAPGroupClassFunction}, n::Int)
     length(characters) == 0 && return eltype(typeof(characters))[]
     tbl = characters[1].table
     return [group_class_function(tbl, chi)
-            for chi in GAP.Globals.Symmetrizations(GAPTable(tbl),
+            for chi in GAPWrap.Symmetrizations(GAPTable(tbl),
                          GAP.GapObj([chi.values for chi in characters]), n)]
 end
 
@@ -1987,7 +2384,7 @@ function symmetric_parts(characters::Vector{GAPGroupClassFunction}, n::Int)
     length(characters) == 0 && return eltype(typeof(characters))[]
     tbl = characters[1].table
     return [group_class_function(tbl, chi)
-            for chi in GAP.Globals.SymmetricParts(GAPTable(tbl),
+            for chi in GAPWrap.SymmetricParts(GAPTable(tbl),
                          GAP.GapObj([chi.values for chi in characters]), n)]
 end
 
@@ -2002,7 +2399,7 @@ function anti_symmetric_parts(characters::Vector{GAPGroupClassFunction}, n::Int)
     length(characters) == 0 && return eltype(typeof(characters))[]
     tbl = characters[1].table
     return [group_class_function(tbl, chi)
-            for chi in GAP.Globals.AntiSymmetricParts(GAPTable(tbl),
+            for chi in GAPWrap.AntiSymmetricParts(GAPTable(tbl),
                          GAP.GapObj([chi.values for chi in characters]), n)]
 end
 
@@ -2020,7 +2417,7 @@ function exterior_power(chi::GAPGroupClassFunction, n::Int)
 #T when GAP's `ExteriorPower` method becomes available then use it
     tbl = chi.table
     return group_class_function(tbl,
-      GAP.Globals.AntiSymmetricParts(GAPTable(tbl), GAP.Obj([chi.values]), n)[1])
+      GAPWrap.AntiSymmetricParts(GAPTable(tbl), GAP.Obj([chi.values]), n)[1])
 end
 
 @doc raw"""
@@ -2037,7 +2434,7 @@ function symmetric_power(chi::GAPGroupClassFunction, n::Int)
 #T when GAP's `SymmetricPower` method becomes available then use it
     tbl = chi.table
     return group_class_function(tbl,
-      GAP.Globals.SymmetricParts(GAPTable(tbl), GAP.Obj([chi.values]), n)[1])
+      GAPWrap.SymmetricParts(GAPTable(tbl), GAP.Obj([chi.values]), n)[1])
 end
 
 @doc raw"""
@@ -2054,7 +2451,7 @@ function orthogonal_components(characters::Vector{GAPGroupClassFunction}, n::Int
     length(characters) == 0 && return eltype(typeof(characters))[]
     tbl = characters[1].table
     return [group_class_function(tbl, chi)
-            for chi in GAP.Globals.OrthogonalComponents(GAPTable(tbl),
+            for chi in GAPWrap.OrthogonalComponents(GAPTable(tbl),
                          GAP.GapObj([chi.values for chi in characters]), n)]
 end
 
@@ -2072,14 +2469,14 @@ function symplectic_components(characters::Vector{GAPGroupClassFunction}, n::Int
     length(characters) == 0 && return eltype(typeof(characters))[]
     tbl = characters[1].table
     return [group_class_function(tbl, chi)
-            for chi in GAP.Globals.SymplecticComponents(GAPTable(tbl),
+            for chi in GAPWrap.SymplecticComponents(GAPTable(tbl),
                          GAP.GapObj([chi.values for chi in characters]), n)]
 end
 
 function character_table_complex_reflection_group(m::Int, p::Int, n::Int)
     @req p == 1 "the case G(m,p,n) with p != 1 is not (yet) supported"
-    tbl = GAP.Globals.CharacterTableWreathSymmetric(
-            GAP.Globals.CharacterTable(GapObj("Cyclic"), m)::GapObj, n):GapObj
+    tbl = GAPWrap.CharacterTableWreathSymmetric(
+            GAPWrap.CharacterTable(GapObj("Cyclic"), m), n)
     tbl = GAPGroupCharacterTable(tbl, 0)
     set_attribute!(tbl, :type, (m, p, n))
 

--- a/src/InvariantTheory/invariant_rings.jl
+++ b/src/InvariantTheory/invariant_rings.jl
@@ -316,7 +316,7 @@ julia> x = gens(R);
 julia> F = abelian_closure(QQ)[1];
 
 julia> chi = Oscar.class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
-class_function(character_table(Sym( [ 1 .. 2 ] )), QQAbElem{nf_elem}[1, -1])
+class_function(character table of group Sym( [ 1 .. 2 ] ), QQAbElem{nf_elem}[1, -1])
 
 julia> reynolds_operator(IR, x[1], chi)
 1//2*x[1] - 1//2*x[2]
@@ -447,7 +447,7 @@ julia> R = invariant_ring(QQ, S2);
 julia> F = abelian_closure(QQ)[1];
 
 julia> chi = Oscar.class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
-class_function(character_table(Sym( [ 1 .. 2 ] )), QQAbElem{nf_elem}[1, -1])
+class_function(character table of group Sym( [ 1 .. 2 ] ), QQAbElem{nf_elem}[1, -1])
 
 julia> basis(R, 3, chi)
 2-element Vector{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}:
@@ -579,7 +579,7 @@ julia> IR = invariant_ring(QQ, S2);
 julia> F = abelian_closure(QQ)[1];
 
 julia> chi = Oscar.class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
-class_function(character_table(Sym( [ 1 .. 2 ] )), QQAbElem{nf_elem}[1, -1])
+class_function(character table of group Sym( [ 1 .. 2 ] ), QQAbElem{nf_elem}[1, -1])
 
 julia> molien_series(IR)
 1//(t^3 - t^2 - t + 1)

--- a/src/InvariantTheory/invariant_rings.jl
+++ b/src/InvariantTheory/invariant_rings.jl
@@ -315,8 +315,8 @@ julia> x = gens(R);
 
 julia> F = abelian_closure(QQ)[1];
 
-julia> chi = Oscar.group_class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
-group_class_function(character_table(Sym( [ 1 .. 2 ] )), QQAbElem{nf_elem}[1, -1])
+julia> chi = Oscar.class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
+class_function(character_table(Sym( [ 1 .. 2 ] )), QQAbElem{nf_elem}[1, -1])
 
 julia> reynolds_operator(IR, x[1], chi)
 1//2*x[1] - 1//2*x[2]
@@ -446,8 +446,8 @@ julia> R = invariant_ring(QQ, S2);
 
 julia> F = abelian_closure(QQ)[1];
 
-julia> chi = Oscar.group_class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
-group_class_function(character_table(Sym( [ 1 .. 2 ] )), QQAbElem{nf_elem}[1, -1])
+julia> chi = Oscar.class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
+class_function(character_table(Sym( [ 1 .. 2 ] )), QQAbElem{nf_elem}[1, -1])
 
 julia> basis(R, 3, chi)
 2-element Vector{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}:
@@ -578,8 +578,8 @@ julia> IR = invariant_ring(QQ, S2);
 
 julia> F = abelian_closure(QQ)[1];
 
-julia> chi = Oscar.group_class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
-group_class_function(character_table(Sym( [ 1 .. 2 ] )), QQAbElem{nf_elem}[1, -1])
+julia> chi = Oscar.class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
+class_function(character_table(Sym( [ 1 .. 2 ] )), QQAbElem{nf_elem}[1, -1])
 
 julia> molien_series(IR)
 1//(t^3 - t^2 - t + 1)

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -259,7 +259,7 @@ julia> R = invariant_ring(QQ, S2);
 julia> F = abelian_closure(QQ)[1];
 
 julia> chi = Oscar.class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
-class_function(character_table(Sym( [ 1 .. 2 ] )), QQAbElem{nf_elem}[1, -1])
+class_function(character table of group Sym( [ 1 .. 2 ] ), QQAbElem{nf_elem}[1, -1])
 
 julia> B = iterate_basis(R, 3, chi)
 Iterator over a basis of the component of degree 3 of

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -258,8 +258,8 @@ julia> R = invariant_ring(QQ, S2);
 
 julia> F = abelian_closure(QQ)[1];
 
-julia> chi = Oscar.group_class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
-group_class_function(character_table(Sym( [ 1 .. 2 ] )), QQAbElem{nf_elem}[1, -1])
+julia> chi = Oscar.class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
+class_function(character_table(Sym( [ 1 .. 2 ] )), QQAbElem{nf_elem}[1, -1])
 
 julia> B = iterate_basis(R, 3, chi)
 Iterator over a basis of the component of degree 3 of

--- a/src/InvariantTheory/secondary_invariants.jl
+++ b/src/InvariantTheory/secondary_invariants.jl
@@ -414,8 +414,8 @@ julia> RS2 = invariant_ring(S2);
 
 julia> F = abelian_closure(QQ)[1];
 
-julia> chi = Oscar.group_class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
-group_class_function(character_table(Sym( [ 1 .. 2 ] )), QQAbElem{nf_elem}[1, -1])
+julia> chi = Oscar.class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
+class_function(character_table(Sym( [ 1 .. 2 ] )), QQAbElem{nf_elem}[1, -1])
 
 julia> semi_invariants(RS2, chi)
 1-element Vector{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}:

--- a/src/InvariantTheory/secondary_invariants.jl
+++ b/src/InvariantTheory/secondary_invariants.jl
@@ -415,7 +415,7 @@ julia> RS2 = invariant_ring(S2);
 julia> F = abelian_closure(QQ)[1];
 
 julia> chi = Oscar.class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
-class_function(character_table(Sym( [ 1 .. 2 ] )), QQAbElem{nf_elem}[1, -1])
+class_function(character table of group Sym( [ 1 .. 2 ] ), QQAbElem{nf_elem}[1, -1])
 
 julia> semi_invariants(RS2, chi)
 1-element Vector{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}:

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -365,6 +365,12 @@ end
 # see https://github.com/oscar-system/Oscar.jl/pull/2368
 @deprecate FreeModElem(coords::SRow{T}, parent::FreeMod_dec{T}) where T <: CRingElem_dec FreeModElem_dec(coords, parent)
 
+# see https://github.com/oscar-system/Oscar.jl/pull/2519
+@deprecate group_class_function(tbl::GAPGroupCharacterTable, values::GapObj) class_function(tbl, values)
+@deprecate group_class_function(tbl::GAPGroupCharacterTable, values::Vector{<:QQAbElem}) class_function(tbl, values)
+@deprecate group_class_function(G::GAPGroup, values::GapObj) class_function(G, values)
+@deprecate group_class_function(G::GAPGroup, values::Vector{<:QQAbElem}) class_function(G, values)
+
 # Deprecated after 0.13.0
 @deprecate fan(v::AbstractNormalToricVariety) polyhedral_fan(v)
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -314,6 +314,7 @@ export circuits
 export class_group
 export class_lengths
 export class_multiplication_coefficient
+export class_names
 export class_parameters
 export class_positions_of_center
 export class_positions_of_kernel
@@ -1046,7 +1047,9 @@ export orbits
 export order, has_order, set_order
 export orders_centralizers
 export orders_class_representatives
+export order_field_of_definition
 export orders_perfect_groups
+export ordinary_table
 export orthogonal_components
 export orthogonal_group
 export orthogonal_sign

--- a/test/Groups/MatrixDisplay.jl
+++ b/test/Groups/MatrixDisplay.jl
@@ -197,7 +197,7 @@ end
           :footer => ["footer"],
         );
   labelled_matrix_formatted(ioc, mat)
-  @test String(take!(io)) == "\\begin{array}{rr}\n1/1 & 1/2 \\\\\n2/1 & 2/2 \\\\\n\\end{array}\nfooter\n"
+  @test String(take!(io)) == "\\begin{array}{rr}\n1/1 & 1/2 \\\\\n2/1 & 2/2 \\\\\n\\end{array}\n\n\\begin{array}{l}\nfooter \\\\\n\\end{array}\n"
 
   # with row labels as vector
   ioc = IOContext(io, :TeX => true,

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -1,16 +1,54 @@
+# Make sure that the tests start without cached character tables.
+# (Running the tests will store information that changes some test outputs,
+# thus running the tests twice needs these calls.)
+GAP.Globals.UnloadCharacterTableData()
+empty!(Oscar.character_tables_by_id)
+
 @testset "show and print character tables" begin
   io = IOBuffer();
 
   t_a4 = character_table(alternating_group(4))
   t_a5 = character_table("A5")
+  t_a4_2 = mod(t_a4, 2)
+  t_a5_2 = mod(t_a5, 2)
 
   # `print` shows an abbrev. form
   print(io, t_a4)
-  @test String(take!(io)) == "character_table(Alt( [ 1 .. 4 ] ))"
+  @test String(take!(io)) == "character table of group Alt( [ 1 .. 4 ] )"
+  print(io, t_a5)
+  @test String(take!(io)) == "character table of A5"
+  print(io, t_a4_2)
+  @test String(take!(io)) == "2-modular Brauer table of group Alt( [ 1 .. 4 ] )"
+  print(io, t_a5_2)
+  @test String(take!(io)) == "2-modular Brauer table of A5"
+
+  # `show` uses the abbrev. form for nested objects
+  show(io, [t_a4])
+  @test String(take!(io)) ==
+    "Oscar.GAPGroupCharacterTable[character table of group Alt( [ 1 .. 4 ] )]"
+  show(io, [t_a5])
+  @test String(take!(io)) ==
+    "Oscar.GAPGroupCharacterTable[character table of A5]"
+  show(io, [t_a4_2])
+  @test String(take!(io)) ==
+    "Oscar.GAPGroupCharacterTable[2-modular Brauer table of group Alt( [ 1 .. 4 ] )]"
+  show(io, [t_a5_2])
+  @test String(take!(io)) ==
+    "Oscar.GAPGroupCharacterTable[2-modular Brauer table of A5]"
+
+  # supercompact printing
+  print(IOContext(io, :supercompact => true), t_a4)
+  @test String(take!(io)) == "character table of a group"
+  print(IOContext(io, :supercompact => true), t_a5)
+  @test String(take!(io)) == "character table of a group"
+  print(IOContext(io, :supercompact => true), t_a4_2)
+  @test String(take!(io)) == "2-modular Brauer table of a group"
+  print(IOContext(io, :supercompact => true), t_a5_2)
+  @test String(take!(io)) == "2-modular Brauer table of a group"
 
   # default `show`
   Oscar.with_unicode() do
-    show(io, t_a4)
+    show(io, MIME("text/plain"), t_a4)
   end
   @test String(take!(io)) ==
   """
@@ -29,7 +67,7 @@
   χ₄  3 -1       .       .
   """
 
-  show(io, t_a4)
+  show(io, MIME("text/plain"), t_a4)
   @test String(take!(io)) ==
   """
   Alt( [ 1 .. 4 ] )
@@ -71,7 +109,7 @@
   # show a legend of irrationalities instead of self-explanatory values,
   # in the screen format ...
   Oscar.with_unicode() do
-    show(IOContext(io, :with_legend => true), t_a4)
+    show(IOContext(io, :with_legend => true), MIME("text/plain"), t_a4)
   end
   @test String(take!(io)) ==
   """
@@ -93,7 +131,7 @@
   A̅ = ζ₃
   """
 
-  show(IOContext(io, :with_legend => true), t_a4)
+  show(IOContext(io, :with_legend => true), MIME("text/plain"), t_a4)
   @test String(take!(io)) ==
   """
   Alt( [ 1 .. 4 ] )
@@ -134,13 +172,16 @@
   \\chi_{4} & 3 & -1 & . & . \\\\
   \\end{array}
 
-  A = -\\zeta_{3} - 1
-  \\overline{A} = \\zeta_{3}
+  \\begin{array}{l}
+  A = -\\zeta_{3} - 1 \\\\
+  \\overline{A} = \\zeta_{3} \\\\
+  \\end{array}
   \$"""
 
   # show the screen format for a table with real and non-real irrationalities
   Oscar.with_unicode() do
-    show(IOContext(io, :with_legend => true), character_table("L2(11)"))
+    show(IOContext(io, :with_legend => true),
+         MIME("text/plain"), character_table("L2(11)"))
   end
   @test String(take!(io)) ==
   """
@@ -172,7 +213,8 @@
   B̅ = -ζ₁₁⁹ - ζ₁₁⁵ - ζ₁₁⁴ - ζ₁₁³ - ζ₁₁ - 1
   """
 
-  show(IOContext(io, :with_legend => true), character_table("L2(11)"))
+  show(IOContext(io, :with_legend => true),
+       MIME("text/plain"), character_table("L2(11)"))
   @test String(take!(io)) ==
   """
   L2(11)
@@ -206,7 +248,8 @@
   # show some separating lines, in the screen format ...
   Oscar.with_unicode() do
     show(IOContext(io, :separators_col => [0,5],
-                       :separators_row => [0,5]), t_a5)
+                       :separators_row => [0,5]),
+         MIME("text/plain"), t_a5)
   end
   @test String(take!(io)) ==
   """
@@ -231,7 +274,8 @@
   """
 
   show(IOContext(io, :separators_col => [0,5],
-                     :separators_row => [0,5]), t_a5)
+                     :separators_row => [0,5]),
+       MIME("text/plain"), t_a5)
   @test String(take!(io)) ==
   """
   A5
@@ -257,7 +301,7 @@
   # ... and in LaTeX format
   show(IOContext(io, :separators_col => [0,5],
                      :separators_row => [0,5]),
-                     MIME("text/latex"), t_a5)
+       MIME("text/latex"), t_a5)
   @test String(take!(io)) ==
   """
   \$A5
@@ -286,7 +330,8 @@
   Oscar.with_unicode() do
     show(IOContext(io, :separators_col => [0],
                        :separators_row => [0],
-                       :portions_col => [2,3]), t_a5)
+                       :portions_col => [2,3]),
+         MIME("text/plain"), t_a5)
   end
   @test String(take!(io)) ==
   """
@@ -327,7 +372,8 @@
 
   show(IOContext(io, :separators_col => [0],
                      :separators_row => [0],
-                     :portions_col => [2,3]), t_a5)
+                     :portions_col => [2,3]),
+       MIME("text/plain"), t_a5)
   @test String(take!(io)) ==
   """
   A5
@@ -368,7 +414,8 @@
   # ... and in LaTeX format
   show(IOContext(io, :separators_col => [0],
                      :separators_row => [0],
-                     :portions_col => [2,3]), MIME("text/latex"), t_a5)
+                     :portions_col => [2,3]),
+       MIME("text/latex"), t_a5)
   @test String(take!(io)) ==
   """
   \$A5
@@ -415,7 +462,8 @@
   Oscar.with_unicode() do
     show(IOContext(io, :separators_col => [0],
                        :separators_row => [0],
-                       :portions_row => [2,3]), t_a5)
+                       :portions_row => [2,3]),
+         MIME("text/plain"), t_a5)
   end
   @test String(take!(io)) ==
   """
@@ -451,7 +499,8 @@
 
   show(IOContext(io, :separators_col => [0],
                      :separators_row => [0],
-                     :portions_row => [2,3]), t_a5)
+                     :portions_row => [2,3]),
+       MIME("text/plain"), t_a5)
   @test String(take!(io)) ==
   """
   A5
@@ -487,7 +536,8 @@
   # ... and in LaTeX format (may be interesting)
   show(IOContext(io, :separators_col => [0],
                      :separators_row => [0],
-                     :portions_row => [2,3]), MIME("text/latex"), t_a5)
+                     :portions_row => [2,3]),
+       MIME("text/latex"), t_a5)
   @test String(take!(io)) ==
   """\$A5
 
@@ -525,7 +575,7 @@
 
   # show indicators in the screen format ...
   Oscar.with_unicode() do
-    show(IOContext(io, :indicator => [2]), t_a4)
+    show(IOContext(io, :indicator => [2]), MIME("text/plain"), t_a4)
   end
   @test String(take!(io)) ==
   """
@@ -567,7 +617,7 @@
   # ordinary table:
   # show character field degrees in the screen format ...
   Oscar.with_unicode() do
-    show(IOContext(io, :character_field => true), t_a4)
+    show(IOContext(io, :character_field => true), MIME("text/plain"), t_a4)
   end
   @test String(take!(io)) ==
   """
@@ -609,7 +659,7 @@
   # Brauer table:
   # show character field degrees in the screen format ...
   Oscar.with_unicode() do
-    show(IOContext(io, :character_field => true), mod(t_a4, 2))
+    show(IOContext(io, :character_field => true), MIME("text/plain"), mod(t_a4, 2))
   end
   @test String(take!(io)) ==
   """
@@ -679,6 +729,39 @@ end
   @test characteristic(t) == t.characteristic
   @test group(t) === t.group === g
   @test Oscar.isomorphism_to_GAP_group(t) === t.isomorphism
+end
+
+@testset "attributes of character tables" begin
+  ordtbl = character_table("A5")
+  modtbl = mod(ordtbl, 2)
+
+  @test characteristic(ordtbl) == 0
+  @test characteristic(modtbl) == 2
+  @test character_parameters(ordtbl) == [[1, 1, 1, 1, 1], [[3, 1, 1], '+'], [[3, 1, 1], '-'], [2, 1, 1, 1], [2, 2, 1]]
+  @test character_parameters(modtbl) == nothing
+  @test class_lengths(ordtbl) == [1, 15, 20, 12, 12]
+  @test class_lengths(modtbl) == [1, 20, 12, 12]
+  @test class_names(ordtbl) == ["1a", "2a", "3a", "5a", "5b"]
+  @test class_names(modtbl) == ["1a", "3a", "5a", "5b"]
+  @test class_parameters(ordtbl) == [[1, 1, 1, 1, 1], [2, 2, 1], [3, 1, 1], [[5], '+'], [[5], '-']]
+  @test class_parameters(modtbl) == [[1, 1, 1, 1, 1], [3, 1, 1], [[5], '+'], [[5], '-']]
+  @test decomposition_matrix(modtbl) == matrix(ZZ, [1 0 0 0; 1 0 1 0; 1 1 0 0; 0 0 0 1; 1 1 1 0])
+  @test identifier(ordtbl) == "A5"
+  @test identifier(modtbl) == "A5mod2"
+  @test !is_duplicate_table(ordtbl)
+  @test maxes(ordtbl) == ["a4", "D10", "S3"]
+  @test maxes(modtbl) == nothing
+  @test "D10" in names_of_fusion_sources(ordtbl)
+  @test order(ordtbl) == 60
+  @test order(modtbl) == 60
+  @test ordinary_table(modtbl) === ordtbl
+  @test_throws ArgumentError ordinary_table(ordtbl)
+  @test orders_centralizers(ordtbl) == [60, 4, 3, 5, 5]
+  @test orders_centralizers(modtbl) == [60, 3, 5, 5]
+  @test orders_class_representatives(ordtbl) == [1, 2, 3, 5, 5]
+  @test orders_class_representatives(modtbl) == [1, 3, 5, 5]
+  @test trivial_character(ordtbl)[1] == 1
+  @test trivial_character(modtbl)[1] == 1
 end
 
 @testset "characters" begin
@@ -849,18 +932,35 @@ end
   end
 end
 
-@testset "character fields" begin
+@testset "character fields of ordinary characters" begin
+  tbl = character_table("A5")
+  @test [degree(character_field(chi)[1]) for chi in tbl] == [1, 2, 2, 1, 1]
+  @test characteristic(character_field(tbl[1])[1]) == 0
+
   for id in [ "C5", "A5" ]   # cyclotomic and non-cyclotomic number fields
     for chi in character_table(id)
-      F, phi = character_field(chi)
+      F1, phi = character_field(chi)
+      F2, _ = number_field(QQ, chi)
+      F3, _ = QQ[chi]
+      @test degree(F1) == degree(F2)
+      @test degree(F1) == degree(F3)
       for i in 1:length(chi)
         x = chi[i]
         xF = preimage(phi, x)
-        @test parent(xF) == F
+        @test parent(xF) == F1
         @test phi(xF) == x
       end
     end
   end
+end
+
+@testset "character fields of Brauer characters" begin
+  ordtbl = character_table("A5")
+  modtbl = mod(ordtbl, 2)
+  @test [order_field_of_definition(chi) for chi in modtbl] == [2, 4, 4, 2]
+  @test [order(character_field(chi)[1]) for chi in modtbl] == [2, 4, 4, 2]
+  @test order_field_of_definition(Int, modtbl[1]) isa Int
+  @test_throws ArgumentError order_field_of_definition(ordtbl[1])
 end
 
 @testset "Schur index" begin
@@ -899,6 +999,10 @@ end
       @test msg == "cannot determine the Schur index with the currently used criteria"
     end
   end
+
+  # The function is defined only for ordinary characters.
+  t = mod(t, 2)
+  @test_throws ArgumentError schur_index(t[1])
 end
 
 @testset "specialized generic tables" begin
@@ -1016,7 +1120,7 @@ end
     end
 
     # a corresponding Brauer table
-    tmod2 = mod(tbl1, 2);
+    tmod2 = mod(tbl1, 2)
     @test tmod2 isa Oscar.GAPGroupCharacterTable
     n = ncols(tmod2)
     chi = tmod2[1]

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -929,7 +929,22 @@ end
     G = matrix_group(mats)
     chi = Oscar.natural_character(G)
     @test degree(chi) == degree(G)
+    @test chi == natural_character(hom(G, G, gens(G)))
   end
+
+  G = symmetric_group(3)
+  @test values(natural_character(hom(G, G, gens(G)))) == [3, 1, 0]
+
+  K, a = cyclotomic_field(8, "a")
+  o = one(K)
+  z = zero(K)
+  G = general_linear_group(2, 3)
+  @test values(natural_character(hom(G, G, gens(G)))) ==
+        [QQAbElem(x, 8) for x in [2*o, -2*o, z, -a^3-a, a^3+a, z]]
+
+  G = small_group(4, 1)  # pc group
+  @test_throws MethodError natural_character(G)
+  @test_throws ArgumentError natural_character(hom(G, G, gens(G)))
 end
 
 @testset "character fields of ordinary characters" begin

--- a/test/InvariantTheory/invariant_rings.jl
+++ b/test/InvariantTheory/invariant_rings.jl
@@ -176,7 +176,7 @@ end
   R = polynomial_ring(RS2)
   x = gens(R)
   F = abelian_closure(QQ)[1]
-  chi = Oscar.group_class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
+  chi = Oscar.class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
   @test reynolds_operator(RS2, x[1] - x[2], chi) == x[1] - x[2]
   @test reynolds_operator(RS2, x[1] + x[2], chi) == zero(R)
 


### PR DESCRIPTION
- adjusted the print functions for character tables to the rules from "Details on printing in Oscar" (and adjusted the manual examples and tests)

- document the output of the text/plain method for `show` (addresses issue #2482)

- fixed the text/latex output in the case that the irrationalities are shown via a legend (and that there are several lines in the legend)

- added more documentation and doctests

- changed `character_field` for Brauer characters: The field is now a *finite field* in this case.

- use the `GAPWrap` approach for more GAP functions