### PR TITLE
Merge `nv` and `nvertices`

### DIFF
--- a/src/Combinatorics/Graphs.jl
+++ b/src/Combinatorics/Graphs.jl
@@ -269,6 +269,8 @@ end
 ##  Accessing properties
 ################################################################################
 ################################################################################
+@alias nv nvertices
+
 @doc raw"""
     nv(g::Graph{T}) where {T <: Union{Directed, Undirected}}
 
@@ -309,6 +311,7 @@ function ne(g::Graph{T}) where {T <: Union{Directed, Undirected}}
     return Polymake.ne(pm_object(g))
 end
 
+@alias nedges ne
 
 @doc raw"""
     edges(g::Graph{T}) where {T <: Union{Directed, Undirected}}

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -967,6 +967,7 @@ export name
 export names_of_fusion_sources
 export natural_character
 export ne
+export nedges
 export nef_cone
 export negbias
 export negdeglex


### PR DESCRIPTION
and similar for edges.

Currently, there is `nv` and `nvertices`, both giving the number of vertices of something.
```julia
julia> methods(nv)
# 1 method for generic function "nv" from Oscar:
 [1] nv(g::Graph{T}) where T<:Union{Directed, Undirected}
     @ ~/code/Oscar.jl/src/Combinatorics/Graphs.jl:288

julia> methods(nvertices)
# 4 methods for generic function "nvertices" from Oscar:
 [1] nvertices(P::Polyhedron)
     @ ~/code/Oscar.jl/src/PolyhedralGeometry/Polyhedron/properties.jl:289
 [2] nvertices(PC::PolyhedralComplex)
     @ ~/code/Oscar.jl/src/PolyhedralGeometry/PolyhedralComplex/properties.jl:496
 [3] nvertices(T::Oscar.TropicalVarietySupertype{M, EMB}) where {M, EMB}
     @ ~/code/Oscar.jl/src/TropicalGeometry/variety_supertype.jl:406
 [4] nvertices(K::SimplicialComplex)
     @ ~/code/Oscar.jl/src/Combinatorics/SimplicialComplexes.jl:104
```
As `nv` is used in `Graphs.jl`, but `nvertices` is better understandable, I propose to merge them into one function by using `@alias` to keep them both, but with equal semantics.

If anyone has a better idea to do that instead of putting the `@alias` at those weird positions, I am happy to change.

Out of sake of convenience, I would provide `nedges` as alias for `ne` as well, although that is not in use yet.