### PR TITLE
Update julia versions in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,8 @@ jobs:
         julia-version:
           - '1.6'
           - '1.8'
-          - '~1.9.0-0'
+          - '1.9'
+          - '~1.10.0-0'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -75,7 +76,8 @@ jobs:
       matrix:
         julia-version:
           - '1.8'
-          - '~1.9.0-0'
+          - '1.9'
+          - '~1.10.0-0'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,6 @@ jobs:
       matrix:
         julia-version:
           - '1.6'
-          - '1.8'
           - '1.9'
           - '~1.10.0-0'
           - 'nightly'
@@ -54,16 +53,16 @@ jobs:
       - name: "Run tests"
         uses: julia-actions/julia-runtest@latest
         with:
-          annotate: ${{ matrix.julia-version == '1.8' }}
-          coverage: ${{ matrix.julia-version == '1.8' }}
+          annotate: ${{ matrix.julia-version == '1.9' }}
+          coverage: ${{ matrix.julia-version == '1.9' }}
           depwarn: error
       - name: "Process code coverage"
-        if: matrix.julia-version == '1.8'
+        if: matrix.julia-version == '1.9'
         uses: julia-actions/julia-processcoverage@v1
         with:
           directories: src,experimental
       - name: "Upload coverage data to Codecov"
-        if: matrix.julia-version == '1.8'
+        if: matrix.julia-version == '1.9'
         continue-on-error: true
         uses: codecov/codecov-action@v3
 
@@ -75,7 +74,6 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.8'
           - '1.9'
           - '~1.10.0-0'
           - 'nightly'
@@ -83,7 +81,7 @@ jobs:
           - ubuntu-latest
         include:
           # Add macOS jobs (not too many, the number we can run in parallel is limited)
-          - julia-version: '1.8'
+          - julia-version: '1.9'
             os: macOS-latest
 
     steps:
@@ -108,8 +106,8 @@ jobs:
         if: runner.os == 'macOS'
         uses: julia-actions/julia-runtest@latest
         with:
-          annotate: ${{ matrix.julia-version == '1.8' }}
-          coverage: ${{ matrix.julia-version == '1.8' }}
+          annotate: ${{ matrix.julia-version == '1.9' }}
+          coverage: ${{ matrix.julia-version == '1.9' }}
           depwarn: error
       - name: "Setup package"
         run: |
@@ -125,11 +123,11 @@ jobs:
             DocMeta.setdocmeta!(Oscar, :DocTestSetup, :(using Oscar; Oscar.AbstractAlgebra.set_current_module(@__MODULE__)); recursive = true)
             doctest(Oscar)'
       - name: "Process code coverage"
-        if: matrix.julia-version == '1.8'
+        if: matrix.julia-version == '1.9'
         uses: julia-actions/julia-processcoverage@v1
         with:
           directories: src,experimental
       - name: "Upload coverage data to Codecov"
-        if: matrix.julia-version == '1.8'
+        if: matrix.julia-version == '1.9'
         continue-on-error: true
         uses: codecov/codecov-action@v3

--- a/.github/workflows/Docu.yml
+++ b/.github/workflows/Docu.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.8'
+          version: '1.9'
       - name: Build package
         uses: julia-actions/julia-buildpkg@latest
       - name: Install dependencies

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -124,7 +124,7 @@ The optional parameter `doctest` can take three values:
   - `:fix`: Run the doctests and replace the output in the manual with
     the output produced by Oscar. Please use this option carefully.
 
-In GitHub Actions the Julia version used for building the manual is 1.8 and
+In GitHub Actions the Julia version used for building the manual is 1.9 and
 doctests are run with >= 1.7. Using a different Julia version may produce
 errors in some parts of Oscar, so please be careful, especially when setting
 `doctest=:fix`.


### PR DESCRIPTION
Now that julia `master` is `1.11.0-DEV` and the first `1.10` alpha is released, we should reflect that in our CI.

Open question:
Do we still test 1.8, or only 1.6, 1.9, 1.10, and nightly (i.e. just "add" 1.10 or keep the total number the same)?
If we want to adapt the default from 1.8 to 1.9, this has to be changed in multiple places in the workflow files as well.

Once this PR is approved, I can make similar PRs for the other repos.