### PR TITLE
Some improvement on default ordering

### DIFF
--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -745,11 +745,10 @@ function has_weighted_ordering(R::MPolyDecRing)
 end
 
 function default_ordering(R::MPolyDecRing)
-  fl, w_ord = has_weighted_ordering(R)
-  if fl
-    return w_ord
+  return get_attribute!(R, :default_ordering) do
+    fl, w_ord = has_weighted_ordering(R)
+    fl ? w_ord : degrevlex(gens(R))
   end
-  return degrevlex(gens(R))
 end
 
 function singular_poly_ring(R::MPolyDecRing; keep_ordering::Bool = false)

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -161,7 +161,16 @@ using .Orderings
 #type for orderings, use this...
 #in general: all algos here needs revision: do they benefit from gb or not?
 
-default_ordering(R::MPolyRing) = degrevlex(R)
+function default_ordering(R::MPolyRing)
+  if has_attribute(R, :default_ordering)
+    return get_attribute(R, :default_ordering)
+  else
+    default_ordering = degrevlex(R)
+    set_attribute!(R, :default_ordering => default_ordering)
+    return default_ordering
+  end
+end
+
 
 mutable struct BiPolyArray{S}
   Ox::NCRing #Oscar Poly Ring or Algebra

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -162,12 +162,8 @@ using .Orderings
 #in general: all algos here needs revision: do they benefit from gb or not?
 
 function default_ordering(R::MPolyRing)
-  if has_attribute(R, :default_ordering)
-    return get_attribute(R, :default_ordering)
-  else
-    default_ordering = degrevlex(R)
-    set_attribute!(R, :default_ordering => default_ordering)
-    return default_ordering
+  return get_attribute!(R, :default_ordering) do
+    degrevlex(R)
   end
 end
 

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -1326,7 +1326,7 @@ end
 
 import Base.==
 function ==(M::MonomialOrdering, N::MonomialOrdering)
-  return canonical_matrix(M) == canonical_matrix(N)
+   return M === N || canonical_matrix(M) == canonical_matrix(N)
 end
 
 function Base.hash(M::MonomialOrdering, u::UInt)


### PR DESCRIPTION
This is a further step to improve the lookup of Gröbner bases via a MonomialOrdering key in issue #2498 and #2099. The default ordering is now cached in the ring. Using the modified test file from issue #2498 we get now from

```julia
 1.573602 seconds (8.53 M allocations: 349.677 MiB, 20.44% gc time)
```

to

```julia
 0.900222 seconds (5.71 M allocations: 262.352 MiB, 18.01% gc time)
```

Caching in addition the hash and is_global in the ordering did not give any further improvement, but rather made it slightly slower and increased allocations and memory usage.