### PR TITLE
timings: exclude gctime, repeat stanley reisner test, increase factor for polyhedral timing

### DIFF
--- a/test/AlgebraicGeometry/ToricVarieties/normal_toric_varieties.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/normal_toric_varieties.jl
@@ -8,7 +8,6 @@ using Test
     ntv2 = normal_toric_variety(Oscar.cube(2); set_attributes)
     ntv3 = normal_toric_varieties_from_glsm(matrix(ZZ, [[1, 1, 1]]); set_attributes)
     ntv4 = normal_toric_varieties_from_star_triangulations(convex_hull([0 0 0; 0 0 1; 1 0 1; 1 1 1; 0 1 1]); set_attributes)
-    ntv5 = normal_toric_variety(polarize(polyhedron(Polymake.polytope.rand_sphere(5, 60; seed=42))); set_attributes)
     
     @testset "Basic properties" begin
         @test is_complete(ntv) == true
@@ -22,8 +21,21 @@ using Test
     end
     
     @testset "Speed test for Stanley-Reisner ideal (at most a few seconds)" begin
-        duration = @elapsed stanley_reisner_ideal(ntv5)
-        @test duration < 10
+        success = false
+        for i in 1:5
+          ntv5 = normal_toric_variety(polarize(polyhedron(Polymake.polytope.rand_sphere(5, 60; seed=42))); set_attributes)
+          stats = @timed stanley_reisner_ideal(ntv5)
+          duration = stats.time - stats.gctime
+          if duration < 10
+              success = true
+              break
+          else
+              @warn "Stanley-Reisner ideal took $duration > 10 seconds (i=$i)"
+          end
+        end
+        @test success == true
+
+        ntv5 = normal_toric_variety(polarize(polyhedron(Polymake.polytope.rand_sphere(5, 60; seed=42))); set_attributes)
         @test ngens(stanley_reisner_ideal(ntv5)) == 1648
     end
 end

--- a/test/PolyhedralGeometry/timing.jl
+++ b/test/PolyhedralGeometry/timing.jl
@@ -11,7 +11,7 @@
     end
 
     # macos on github actions is very slow
-    factor = Sys.isapple() && haskey(ENV,"GITHUB_ACTIONS") ? 5.0 : 1.0
+    factor = Sys.isapple() && haskey(ENV,"GITHUB_ACTIONS") ? 8.0 : 2.0
 
     lp_provide = ["FACETS", "VERTICES", "VERTICES_IN_FACETS", "LATTICE", "BOUNDED"]
 
@@ -110,7 +110,8 @@
             result = 10
             for i in 1:repeat
                 copy = deepcopy(poly)
-                result = min(@elapsed fun(copy), result)
+                stats = @timed fun(copy)
+                result = min(stats.time - stats.gctime, result)
                 if result <= bound*factor
                     return true
                 else


### PR DESCRIPTION
Both test groups now exclude `gctime` and do a repeated experiment to avoid GC spikes.
This should avoid the timing error reported in #2539.