### PR TITLE
Refactor parts of toric geometry

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -117,7 +117,7 @@ jobs:
             Pkg.instantiate()'
       - name: "Run doctests"
         run: |
-          julia --project=docs --color=yes -e '
+          julia --project=docs --depwarn=error --color=yes -e'
             using Documenter
             using Oscar
             DocMeta.setdocmeta!(Oscar, :DocTestSetup, :(using Oscar; Oscar.AbstractAlgebra.set_current_module(@__MODULE__)); recursive = true)

--- a/docs/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties.md
@@ -38,8 +38,8 @@ affine_normal_toric_variety(v::NormalToricVariety; set_attributes::Bool = true)
 ### Normal Toric Varieties
 
 ```@docs
-normal_toric_variety(rays::Vector{Vector{Int64}}, max_cones::Vector{Vector{Int64}}; non_redundant::Bool = false, set_attributes::Bool = true)
-normal_toric_variety(PF::PolyhedralFan; set_attributes::Bool = true)
+normal_toric_variety(rays::AbstractCollection[RayVector], max_cones::Vector{Vector{Int64}}; non_redundant::Bool = false)
+normal_toric_variety(PF::PolyhedralFan)
 normal_toric_variety(P::Polyhedron; set_attributes::Bool = true)
 ```
 

--- a/docs/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties.md
@@ -109,7 +109,7 @@ torusinvariant_prime_divisors(v::AbstractNormalToricVariety)
 ### Cones and Fans
 
 ```@docs
-fan(v::AbstractNormalToricVariety)
+polyhedral_fan(v::AbstractNormalToricVariety)
 cone(v::AffineNormalToricVariety)
 dual_cone(v::AffineNormalToricVariety)
 hilbert_basis(v::AffineNormalToricVariety)

--- a/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
@@ -24,7 +24,7 @@ polyhedron(::Type{T}, I::Union{Nothing, AbstractCollection[AffineHalfspace]}, E:
 The complete $H$-representation can be retrieved using [`facets`](@ref facets)
 and [`affine_hull`](@ref affine_hull):
 ```jldoctest
-julia> P = Polyhedron(([-1 0; 1 0], [0,1]), ([0 1], [0]))
+julia> P = polyhedron(([-1 0; 1 0], [0,1]), ([0 1], [0]))
 Polyhedron in ambient dimension 2
 
 julia> facets(P)
@@ -38,13 +38,13 @@ julia> affine_hull(P)
 x₂ = 0
 
 
-julia> Q0 = Polyhedron(facets(P))
+julia> Q0 = polyhedron(facets(P))
 Polyhedron in ambient dimension 2
 
 julia> P == Q0
 false
 
-julia> Q1 = Polyhedron(facets(P), affine_hull(P))
+julia> Q1 = polyhedron(facets(P), affine_hull(P))
 Polyhedron in ambient dimension 2
 
 julia> P == Q1

--- a/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
@@ -38,7 +38,7 @@ julia> h = hypersurface_model_over_projective_space(2)
 Hypersurface model over a concrete base
 
 julia> base_space(h)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0], [0, 1], [-1, -1]]
+Scheme of a toric variety
 ```
 """
 function base_space(h::HypersurfaceModel)
@@ -57,7 +57,7 @@ julia> h = hypersurface_model_over_projective_space(2)
 Hypersurface model over a concrete base
 
 julia> ambient_space(h)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0, 0, 3], [0, 1, 0, 0], [-1, -1, 0, 0], [0, 0, -1, 1//3], [0, 0, 1, -1//2], [0, 0, 0, 1]]
+Scheme of a toric variety
 ```
 """
 function ambient_space(h::HypersurfaceModel)
@@ -76,7 +76,7 @@ julia> h = hypersurface_model_over_projective_space(2)
 Hypersurface model over a concrete base
 
 julia> fiber_ambient_space(h)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[-1, 1//3], [1, -1//2], [0, 1]]
+Scheme of a toric variety
 ```
 """
 fiber_ambient_space(h::HypersurfaceModel) = h.fiber_ambient_space

--- a/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
@@ -91,7 +91,7 @@ $2 \overline{K}_{B_3}$ and $y$ as $3 \overline{K}_{B_3}$.
 # Examples
 ```jldoctest
 julia> base = projective_space(ToricCoveredScheme, 2)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0], [0, 1], [-1, -1]]
+Scheme of a toric variety
 
 julia> hypersurface_model(base; completeness_check = false)
 Hypersurface model over a concrete base
@@ -110,7 +110,7 @@ coordinates of the fiber ambient space transform.
 # Examples
 ```jldoctest
 julia> base = projective_space(ToricCoveredScheme, 2)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0], [0, 1], [-1, -1]]
+Scheme of a toric variety
 
 julia> fiber_ambient_space = weighted_projective_space(NormalToricVariety, [2,3,1])
 Normal, non-affine, simplicial, projective, 2-dimensional toric variety without torusfactor
@@ -118,7 +118,7 @@ Normal, non-affine, simplicial, projective, 2-dimensional toric variety without 
 julia> set_coordinate_names(fiber_ambient_space, ["x", "y", "z"])
 
 julia> fiber_ambient_space = ToricCoveredScheme(fiber_ambient_space)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[-1, 1//3], [1, -1//2], [0, 1]]
+Scheme of a toric variety
 
 julia> D1 = 2 * anticanonical_divisor_class(underlying_toric_variety(base))
 Divisor class on a normal toric variety
@@ -263,8 +263,8 @@ function hypersurface_model(auxiliary_base_vars::Vector{String}, auxiliary_base_
   auxiliary_base_space = _auxiliary_base_space(auxiliary_base_vars, auxiliary_base_grading, d)
 
   # Construct auxiliary ambient space
-  D1_class = ToricDivisorClass(auxiliary_base_space, D1)
-  D2_class = ToricDivisorClass(auxiliary_base_space, D2)
+  D1_class = toric_divisor_class(auxiliary_base_space, D1)
+  D2_class = toric_divisor_class(auxiliary_base_space, D2)
   auxiliary_ambient_space = _ambient_space(auxiliary_base_space, fiber_ambient_space, D1_class, D2_class)
   
   # Map p to cox ring of ambient space

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -29,7 +29,7 @@ Assuming that the first row of the given grading is the grading under Kbar
 Global Tate model over a not fully specified base -- SU(5)xU(1) restricted Tate model based on arXiv paper 1109.3454 Eq. (3.1)
 
 julia> v = ambient_space(t)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 2, -2, 0, 1], [-1, -3//2, 1//2, 0, 0], [1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 0], [0, 0, 0, -1, 1//3], [0, 0, 0, 1, -1//2], [0, 0, 0, 0, 1]]
+Scheme of a toric variety
 
 julia> a1,a21,a32,a43,w,x,y,z = gens(cox_ring(v));
 

--- a/experimental/FTheoryTools/src/LiteratureModels/methods.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/methods.jl
@@ -80,7 +80,7 @@ Assuming that the first row of the given grading is the grading under Kbar
 Global Tate model over a not fully specified base -- SU(5)xU(1) restricted Tate model based on arXiv paper 1109.3454 Eq. (3.1)
 
 julia> v = resolve(m, 1)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 2, -2, 0, 1], [-1, -3//2, 1//2, 0, 0], [1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 0], [0, 0, 0, -1, 1//3], [0, 0, 0, 1, -1//2], [0, 0, 0, 0, 1], [0, 0, 1, -1, 0], [0, 0, 1, 1, -1], [0, 0, 1, -2, 0], [0, 0, 1, 0, -1], [0, 0, 0, -1, 0]]
+Scheme of a toric variety
 
 julia> cox_ring(v)
 Multivariate polynomial ring in 13 variables over QQ graded by 

--- a/experimental/FTheoryTools/src/TateModels/attributes.jl
+++ b/experimental/FTheoryTools/src/TateModels/attributes.jl
@@ -137,7 +137,7 @@ Assuming that the first row of the given grading is the grading under Kbar
 Global Tate model over a not fully specified base -- SU(5)xU(1) restricted Tate model based on arXiv paper 1109.3454 Eq. (3.1)
 
 julia> base_space(t)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 2, -2], [-1, -3//2, 1//2], [1, 0, 0], [0, 1, 0], [0, 0, 1]]
+Scheme of a toric variety
 ```
 """
 function base_space(t::GlobalTateModel)
@@ -158,7 +158,7 @@ Assuming that the first row of the given grading is the grading under Kbar
 Global Tate model over a not fully specified base -- SU(5)xU(1) restricted Tate model based on arXiv paper 1109.3454 Eq. (3.1)
 
 julia> ambient_space(t)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 2, -2, 0, 1], [-1, -3//2, 1//2, 0, 0], [1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 0], [0, 0, 0, -1, 1//3], [0, 0, 0, 1, -1//2], [0, 0, 0, 0, 1]]
+Scheme of a toric variety
 ```
 """
 function ambient_space(t::GlobalTateModel)
@@ -179,7 +179,7 @@ Assuming that the first row of the given grading is the grading under Kbar
 Global Tate model over a not fully specified base
 
 julia> fiber_ambient_space(t)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[-1, 1//3], [1, -1//2], [0, 1]]
+Scheme of a toric variety
 ```
 """
 fiber_ambient_space(t::GlobalTateModel) = t.fiber_ambient_space

--- a/experimental/FTheoryTools/src/TateModels/constructors.jl
+++ b/experimental/FTheoryTools/src/TateModels/constructors.jl
@@ -99,7 +99,7 @@ The only difference is that the Tate sections ``a_i`` can be specified with non-
 # Examples
 ```jldoctest
 julia> base = sample_toric_scheme()
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[0, 1, 0], [0, 1, -1//2], [1, -1, -1], [0, 1, -1], [0, 0, 1], [0, 0, -1], [0, -1, 2], [0, -1, 1], [0, -1, 0], [0, -1, -1], [-1, 4, 0], [-1, 5, -1], [-1, 4, -1], [-1, 3, 1], [-1, 3, 0], [-1, 3, -1], [-1, 2, 2], [-1, 2, 1], [-1, 2, 0], [-1, 2, -1], [-1, 1, 3], [-1, 1, 2], [-1, 1, 1], [-1, 1, 0], [-1, 1, -1], [-1, 0, 4], [-1, 0, 3], [-1, 0, 2], [-1, 0, 1], [-1, 0, 0], [-1, 0, -1], [-1, -1, 5], [-1, -1, 4], [-1, -1, 3], [-1, -1, 2], [-1, -1, 1], [-1, -1, 0], [-1, -1, -1]]
+Scheme of a toric variety
 
 julia> a1 = sum([rand(Int) * b for b in basis_of_global_sections(anticanonical_bundle(underlying_toric_variety(base)))]);
 

--- a/experimental/FTheoryTools/src/WeierstrassModels/attributes.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/attributes.jl
@@ -100,7 +100,7 @@ Assuming that the first row of the given grading is the grading under Kbar
 Weierstrass model over a not fully specified base
 
 julia> ambient_space(w)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 2, 4, -2, 0, 1], [-1, -3//2, -5//2, 1//2, 0, 0], [1, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0], [0, 0, 1, 0, 0, 0], [0, 0, 0, 1, 0, 0], [0, 0, 0, 0, -1, 1//3], [0, 0, 0, 0, 1, -1//2], [0, 0, 0, 0, 0, 1]]
+Scheme of a toric variety
 ```
 """
 function ambient_space(w::WeierstrassModel)
@@ -121,7 +121,7 @@ Assuming that the first row of the given grading is the grading under Kbar
 Weierstrass model over a not fully specified base
 
 julia> fiber_ambient_space(w)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[-1, 1//3], [1, -1//2], [0, 1]]
+Scheme of a toric variety
 ```
 """
 fiber_ambient_space(w::WeierstrassModel) = w.fiber_ambient_space

--- a/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
@@ -90,7 +90,7 @@ The only difference is that the Weierstrass sections ``f`` and ``g`` can be spec
 # Examples
 ```jldoctest
 julia> base = sample_toric_scheme()
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[0, 1, 0], [0, 1, -1//2], [1, -1, -1], [0, 1, -1], [0, 0, 1], [0, 0, -1], [0, -1, 2], [0, -1, 1], [0, -1, 0], [0, -1, -1], [-1, 4, 0], [-1, 5, -1], [-1, 4, -1], [-1, 3, 1], [-1, 3, 0], [-1, 3, -1], [-1, 2, 2], [-1, 2, 1], [-1, 2, 0], [-1, 2, -1], [-1, 1, 3], [-1, 1, 2], [-1, 1, 1], [-1, 1, 0], [-1, 1, -1], [-1, 0, 4], [-1, 0, 3], [-1, 0, 2], [-1, 0, 1], [-1, 0, 0], [-1, 0, -1], [-1, -1, 5], [-1, -1, 4], [-1, -1, 3], [-1, -1, 2], [-1, -1, 1], [-1, -1, 0], [-1, -1, -1]]
+Scheme of a toric variety
 
 julia> f = sum([rand(Int) * b for b in basis_of_global_sections(anticanonical_bundle(underlying_toric_variety(base))^4)]);
 

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -7,7 +7,7 @@ function _auxiliary_base_space(auxiliary_base_variable_names::Vector{String}, au
   # Find candidate base spaces
   candidates = normal_toric_varieties_from_glsm(matrix(ZZ, auxiliary_base_grading))
   @req length(candidates) > 0 "Could not find a full star triangulation"
-  f = fan(candidates[1])
+  f = polyhedral_fan(candidates[1])
   @req dim(f) >= d "Cannot construct an auxiliary base space of the desired dimension"
   
   # Construct one base space of desired dimension

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -7,7 +7,7 @@ function _auxiliary_base_space(auxiliary_base_variable_names::Vector{String}, au
   # Find candidate base spaces
   candidates = normal_toric_varieties_from_glsm(matrix(ZZ, auxiliary_base_grading))
   @req length(candidates) > 0 "Could not find a full star triangulation"
-  f = polyhedral_fan(candidates[1])
+  f = candidates[1]
   @req dim(f) >= d "Cannot construct an auxiliary base space of the desired dimension"
   
   # Construct one base space of desired dimension
@@ -86,7 +86,7 @@ function _ambient_space(base::AbstractNormalToricVariety, fiber_ambient_space::A
   ambient_space_max_cones = IncidenceMatrix(vcat(ambient_space_max_cones...))
   
   # Construct the ambient space
-  ambient_space = normal_toric_variety(polyhedral_fan(ambient_space_rays, ambient_space_max_cones; non_redundant = true))
+  ambient_space = normal_toric_variety(ambient_space_rays, ambient_space_max_cones; non_redundant = true)
   
   # Compute torusinvariant weil divisor group and the class group
   ambient_space_torusinvariant_weil_divisor_group = free_abelian_group(nrows(ambient_space_rays))
@@ -161,7 +161,7 @@ function _weierstrass_ambient_space_from_base(base::AbstractNormalToricVariety)
   ambient_space_max_cones = IncidenceMatrix(vcat(ambient_space_max_cones...))
   
   # Construct and return the ambient space
-  ambient_space = normal_toric_variety(polyhedral_fan(ambient_space_rays, ambient_space_max_cones; non_redundant = true))
+  ambient_space = normal_toric_variety(ambient_space_rays, ambient_space_max_cones; non_redundant = true)
   set_coordinate_names(ambient_space, vcat([string(k) for k in gens(cox_ring(base))], ["x", "y", "z"]))
   return ambient_space
   
@@ -247,7 +247,7 @@ function sample_toric_variety()
           [5, 11, 12], [5, 6, 32], [5, 6, 12], [4, 31, 32], [4, 10, 11], [4, 5, 32],
           [4, 5, 11], [3, 30, 31], [3, 9, 10], [3, 4, 31], [3, 4, 10], [2, 29, 30],
           [2, 8, 9], [2, 3, 30], [2, 3, 9], [1, 8, 29], [1, 2, 29], [1, 2, 8]])
-  return normal_toric_variety(polyhedral_fan(rays, cones))
+  return normal_toric_variety(rays, cones)
 end
 
 @doc raw"""

--- a/experimental/ToricSchemes/docs/src/normal_toric_schemes.md
+++ b/experimental/ToricSchemes/docs/src/normal_toric_schemes.md
@@ -42,7 +42,7 @@ We overload the following attributes from the underlying toric variety:
 * ``dim(X::ToricCoveredScheme)``,
 * ``dim_of_torusfactor(X::ToricCoveredScheme)``,
 * ``euler_characteristic(X::ToricCoveredScheme)``,
-* ``fan(X::ToricCoveredScheme)``,
+* ``polyhedral_fan(X::ToricCoveredScheme)``,
 * ``ideal_of_linear_relations(R::MPolyRing, X::ToricCoveredScheme)``,
 * ``ideal_of_linear_relations(X::ToricCoveredScheme)``,
 * ``irrelevant_ideal(R::MPolyRing, X::ToricCoveredScheme)``,

--- a/experimental/ToricSchemes/src/NormalToricSchemes/Attributes.jl
+++ b/experimental/ToricSchemes/src/NormalToricSchemes/Attributes.jl
@@ -19,7 +19,7 @@ julia> antv = affine_normal_toric_variety(C)
 Normal, affine toric variety
 
 julia> affine_toric_scheme = ToricSpec(antv)
-Spec of an affine toric variety with cone spanned by RayVector{QQFieldElem}[[1, 0], [0, 1]]
+Spec of an affine toric variety
 
 julia> underlying_scheme(affine_toric_scheme)
 Spec of Quotient of multivariate polynomial ring by ideal with 1 generator
@@ -42,7 +42,7 @@ julia> P2 = projective_space(NormalToricVariety, 2)
 Normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
 julia> toric_scheme = ToricCoveredScheme(P2)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0], [0, 1], [-1, -1]]
+Scheme of a toric variety
 
 julia> underlying_scheme(toric_scheme)
 covered scheme with 3 affine patches in its default covering
@@ -145,7 +145,7 @@ cox_ring(X::ToricCoveredScheme) = cox_ring(X.ntv)
 dim(X::ToricCoveredScheme) = dim(X.ntv)
 dim_of_torusfactor(X::ToricCoveredScheme) = dim_of_torusfactor(X.ntv)
 euler_characteristic(X::ToricCoveredScheme) = euler_characteristic(X.ntv)
-fan(X::ToricCoveredScheme) = fan(X.ntv)
+polyhedral_fan(X::ToricCoveredScheme) = polyhedral_fan(X.ntv)
 ideal_of_linear_relations(R::MPolyRing, X::ToricCoveredScheme) = ideal_of_linear_relations(R, X.ntv)
 ideal_of_linear_relations(X::ToricCoveredScheme) = ideal_of_linear_relations(X.ntv)
 irrelevant_ideal(R::MPolyRing, X::ToricCoveredScheme) = irrelevant_ideal(R, X.ntv)
@@ -186,7 +186,7 @@ cox_ring(X::ToricSpec) = cox_ring(X.antv)
 dim(X::ToricSpec) = dim(X.antv)
 dim_of_torusfactor(X::ToricSpec) = dim_of_torusfactor(X.antv)
 euler_characteristic(X::ToricSpec) = euler_characteristic(X.antv)
-fan(X::ToricSpec) = fan(X.antv)
+polyhedral_fan(X::ToricSpec) = polyhedral_fan(X.antv)
 ideal_of_linear_relations(R::MPolyRing, X::ToricSpec) = ideal_of_linear_relations(R, X.antv)
 ideal_of_linear_relations(X::ToricSpec) = ideal_of_linear_relations(X.antv)
 irrelevant_ideal(R::MPolyRing, X::ToricSpec) = irrelevant_ideal(R, X.antv)

--- a/experimental/ToricSchemes/src/NormalToricSchemes/Constructors.jl
+++ b/experimental/ToricSchemes/src/NormalToricSchemes/Constructors.jl
@@ -16,7 +16,7 @@ julia> antv = affine_normal_toric_variety(C)
 Normal, affine toric variety
 
 julia> toric_spec(antv)
-Spec of an affine toric variety with cone spanned by RayVector{QQFieldElem}[[1, 0], [0, 1]]
+Spec of an affine toric variety
 ```
 """
 toric_spec(antv::AffineNormalToricVariety) = ToricSpec(antv)
@@ -36,10 +36,10 @@ julia> antv = affine_normal_toric_variety(C)
 Normal, affine toric variety
 
 julia> toric_covered_scheme(antv)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0], [0, 1]]
+Scheme of a toric variety
 ```
 """
-toric_covered_scheme(antv::AffineNormalToricVariety) = ToricCoveredScheme(normal_toric_variety(fan(antv)))
+toric_covered_scheme(antv::AffineNormalToricVariety) = ToricCoveredScheme(normal_toric_variety(polyhedral_fan(antv)))
 
 
 @doc raw"""
@@ -53,7 +53,7 @@ julia> ntv = projective_space(NormalToricVariety, 2)
 Normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
 julia> toric_covered_scheme(ntv)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0], [0, 1], [-1, -1]]
+Scheme of a toric variety
 ```
 """
 toric_covered_scheme(ntv::NormalToricVariety) = ToricCoveredScheme(ntv)
@@ -71,7 +71,7 @@ Constructs the affine space of dimension `d` as toric (covered) scheme.
 # Examples
 ```jldoctest
 julia> affine_space(ToricCoveredScheme, 2)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0], [0, 1]]
+Scheme of a toric variety
 ```
 """
 affine_space(::Type{ToricCoveredScheme}, d::Int; set_attributes::Bool = true) = ToricCoveredScheme(affine_space(NormalToricVariety, d; set_attributes = set_attributes))
@@ -85,7 +85,7 @@ Construct the projective space of dimension `d` as toric (covered) scheme.
 # Examples
 ```jldoctest
 julia> projective_space(ToricCoveredScheme, 2)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0], [0, 1], [-1, -1]]
+Scheme of a toric variety
 ```
 """
 projective_space(::Type{ToricCoveredScheme}, d::Int; set_attributes::Bool = true) = ToricCoveredScheme(projective_space(NormalToricVariety, d; set_attributes = set_attributes))
@@ -99,7 +99,7 @@ Construct the weighted projective space corresponding to the weights `w` as tori
 # Examples
 ```jldoctest
 julia> weighted_projective_space(ToricCoveredScheme, [2,3,1])
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[-1, 1//3], [1, -1//2], [0, 1]]
+Scheme of a toric variety
 ```
 """
 weighted_projective_space(::Type{ToricCoveredScheme}, w::Vector{T}; set_attributes::Bool = true) where {T <: IntegerUnion} = ToricCoveredScheme(weighted_projective_space(NormalToricVariety, w; set_attributes = set_attributes))
@@ -113,10 +113,10 @@ Constructs the r-th Hirzebruch surface as toric (covered) scheme.
 # Examples
 ```jldoctest
 julia> hirzebruch_surface(ToricCoveredScheme, 5)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0], [0, 1], [-1, 5], [0, -1]]
+Scheme of a toric variety
 ```
 """
-hirzebruch_surface(::Type{ToricCoveredScheme}, r::Int; set_attributes::Bool = true) = ToricCoveredScheme(hirzebruch_surface(r; set_attributes = set_attributes))
+hirzebruch_surface(::Type{ToricCoveredScheme}, r::Int; set_attributes::Bool = true) = ToricCoveredScheme(hirzebruch_surface(NormalToricVariety, r; set_attributes = set_attributes))
 
 
 @doc raw"""
@@ -127,7 +127,7 @@ Constructs the del Pezzo surface with `b` blowups for `b` at most 3 as toric (co
 # Examples
 ```jldoctest
 julia> del_pezzo_surface(ToricCoveredScheme, 3)
-Scheme of a toric variety with fan spanned by RayVector{QQFieldElem}[[1, 0], [0, 1], [-1, -1], [1, 1], [0, -1], [-1, 0]]
+Scheme of a toric variety
 ```
 """
-del_pezzo_surface(::Type{ToricCoveredScheme}, b::Int; set_attributes::Bool = true) = ToricCoveredScheme(del_pezzo_surface(b; set_attributes = set_attributes))
+del_pezzo_surface(::Type{ToricCoveredScheme}, b::Int; set_attributes::Bool = true) = ToricCoveredScheme(del_pezzo_surface(NormalToricVariety, b; set_attributes = set_attributes))

--- a/experimental/ToricSchemes/src/NormalToricSchemes/Types.jl
+++ b/experimental/ToricSchemes/src/NormalToricSchemes/Types.jl
@@ -20,9 +20,9 @@ end
 ###############################
 
 function Base.show(io::IO, X::ToricSpec)
-  print(io, "Spec of an affine toric variety with cone spanned by $(rays(fan(X)))")
+  print(io, "Spec of an affine toric variety with cone spanned by $(rays(polyhedral_fan(X)))")
 end
 
 function Base.show(io::IO, X::ToricCoveredScheme)
-  print(io, "Scheme of a toric variety with fan spanned by $(rays(fan(X)))")
+  print(io, "Scheme of a toric variety with fan spanned by $(rays(polyhedral_fan(X)))")
 end

--- a/experimental/ToricSchemes/src/NormalToricSchemes/Types.jl
+++ b/experimental/ToricSchemes/src/NormalToricSchemes/Types.jl
@@ -20,9 +20,9 @@ end
 ###############################
 
 function Base.show(io::IO, X::ToricSpec)
-  print(io, "Spec of an affine toric variety with cone spanned by $(rays(polyhedral_fan(X)))")
+  print(io, "Spec of an affine toric variety")
 end
 
 function Base.show(io::IO, X::ToricCoveredScheme)
-  print(io, "Scheme of a toric variety with fan spanned by $(rays(polyhedral_fan(X)))")
+  print(io, "Scheme of a toric variety")
 end

--- a/experimental/ToricSchemes/test/runtests.jl
+++ b/experimental/ToricSchemes/test/runtests.jl
@@ -23,7 +23,7 @@ end
     @test is_smooth(X) == true
     @test is_smooth(underlying_scheme(X)) == true
     @test is_smooth(underlying_toric_variety(X)) == true
-    @test dim(fan(X)) == 2
+    @test dim(polyhedral_fan(X)) == 2
   end
   
   IP1 = projective_space(NormalToricVariety, 1)

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -938,7 +938,7 @@ julia> dim(mori)
 
 
 @doc raw"""
-    fan(v::AbstractNormalToricVariety)
+    polyhedral_fan(v::AbstractNormalToricVariety)
 
 Return the fan of an abstract normal toric variety `v`.
 
@@ -947,11 +947,15 @@ Return the fan of an abstract normal toric variety `v`.
 julia> p2 = projective_space(NormalToricVariety, 2)
 Normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor
 
-julia> fan(p2)
+julia> polyhedral_fan(p2)
 Polyhedral fan in ambient dimension 2
 ```
 """
-@attr PolyhedralFan{QQFieldElem} fan(v::AbstractNormalToricVariety) = PolyhedralFan{QQFieldElem}(pm_object(v), QQ)
+function polyhedral_fan(v::AbstractNormalToricVariety)
+  result = Base.deepcopy(pm_object(v))
+  Polymake.cast!(result, Polymake.BigObjectType("fan::PolyhedralFan<Rational>"))
+  return PolyhedralFan{QQFieldElem}(result, QQ)
+end
 
 
 @doc raw"""

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -615,7 +615,7 @@ Multivariate polynomial ring in 5 variables over QQ graded by
 ```
 """
 function blow_up(v::AbstractNormalToricVariety, new_ray::AbstractVector{<:IntegerUnion}; coordinate_name::String = "e", set_attributes::Bool = true)
-    new_fan = star_subdivision(polyhedral_fan(v), new_ray)
+    new_fan = star_subdivision(v, new_ray)
     new_variety = normal_toric_variety(new_fan; set_attributes = set_attributes)
     new_rays = rays(new_fan)
     old_rays = rays(v)

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -615,10 +615,10 @@ Multivariate polynomial ring in 5 variables over QQ graded by
 ```
 """
 function blow_up(v::AbstractNormalToricVariety, new_ray::AbstractVector{<:IntegerUnion}; coordinate_name::String = "e", set_attributes::Bool = true)
-    new_fan = star_subdivision(fan(v), new_ray)
+    new_fan = star_subdivision(polyhedral_fan(v), new_ray)
     new_variety = normal_toric_variety(new_fan; set_attributes = set_attributes)
     new_rays = rays(new_fan)
-    old_rays = rays(fan(v))
+    old_rays = rays(v)
     old_vars = string.(symbols(cox_ring(v)))
     @req !(coordinate_name in old_vars) "The name for the blowup coordinate is already taken"
     new_vars = Vector{String}(undef, length(new_rays))
@@ -660,10 +660,10 @@ Multivariate polynomial ring in 5 variables over QQ graded by
 ```
 """
 function blow_up(v::AbstractNormalToricVariety, n::Int; coordinate_name::String = "e", set_attributes::Bool = true)
-    new_fan = star_subdivision(fan(v), n)
+    new_fan = star_subdivision(polyhedral_fan(v), n)
     new_variety = normal_toric_variety(new_fan; set_attributes = set_attributes)
     new_rays = rays(new_fan)
-    old_rays = rays(fan(v))
+    old_rays = rays(v)
     old_vars = string.(symbols(cox_ring(v)))
     @req !(coordinate_name in old_vars) "The name for the blowup coordinate is already taken"
     new_vars = Vector{String}(undef, length(new_rays))
@@ -723,6 +723,7 @@ Normal toric variety
 
 julia> set_coordinate_names(v2, ["x1", "x2", "x3", "y1", "y2", "y3"])
 
+
 julia> cox_ring(v2)
 Multivariate polynomial ring in 6 variables over QQ graded by
   x1 -> [1 0]
@@ -734,7 +735,7 @@ Multivariate polynomial ring in 6 variables over QQ graded by
 ```
 """
 function Base.:*(v::AbstractNormalToricVariety, w::AbstractNormalToricVariety; set_attributes::Bool = true)
-    product = normal_toric_variety(fan(v)*fan(w); set_attributes = set_attributes)
+    product = normal_toric_variety(polyhedral_fan(v)*polyhedral_fan(w); set_attributes = set_attributes)
     set_coordinate_names(product, vcat(["x$(i)" for i in coordinate_names(v)], ["y$(i)" for i in coordinate_names(w)]))
     return product
 end

--- a/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/special_attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/special_attributes.jl
@@ -13,7 +13,7 @@ A toric morphism
 ```
 """
 @attr ToricMorphism function morphism_from_cox_variety(variety::AbstractNormalToricVariety)
-    mapping_matrix = matrix(ZZ, rays(fan(variety)))
+    mapping_matrix = matrix(ZZ, rays(variety))
     max_cones_for_cox_variety = ray_indices(maximal_cones(variety))
     rays_for_cox_variety = matrix(ZZ, [[if i==j 1 else 0 end for j in 1:nrays(variety)] for i in 1:nrays(variety)])
     cox_variety = normal_toric_variety(polyhedral_fan(rays_for_cox_variety, max_cones_for_cox_variety))

--- a/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
+++ b/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
@@ -1097,7 +1097,7 @@ julia> nvertices(rand_subpolytope(cube(3), 5))
 ```
 """
 function rand_subpolytope(P::Polyhedron{T}, n::Int; seed=nothing) where T<:scalar_types
-  if !bounded(P)
+  if !is_bounded(P)
     throw(ArgumentError("rand_subpolytope: Polyhedron unbounded"))
   end
   nv = nvertices(P)

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -357,7 +357,7 @@ Return the parent `Field` of the coefficients of `P`.
 
 # Examples
 ```jldoctest
-julia> c = cross(2)
+julia> c = cross_polytope(2)
 Polyhedron in ambient dimension 2
 
 julia> coefficient_field(c)

--- a/src/TropicalGeometry/curve.jl
+++ b/src/TropicalGeometry/curve.jl
@@ -64,7 +64,7 @@ julia> VR = [0 0; 1 0; -1 0; 0 1]
  -1  0
   0  1
 
-julia> PC = PolyhedralComplex{QQFieldElem}(IM, VR)
+julia> PC = polyhedral_complex(QQFieldElem, IM, VR)
 Polyhedral complex in ambient dimension 2
 
 julia> TC = TropicalCurve(PC)

--- a/src/TropicalGeometry/hypersurface.jl
+++ b/src/TropicalGeometry/hypersurface.jl
@@ -236,7 +236,7 @@ function dual_subdivision(TH::TropicalHypersurface{M,EMB}) where {M,EMB}
         error("tropical hypersurface not embedded")
     end
 
-    return SubdivisionOfPoints(pm_object(TH).DUAL_SUBDIVISION)
+    return subdivision_of_points(pm_object(TH).DUAL_SUBDIVISION)
 end
 
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -365,6 +365,9 @@ end
 # see https://github.com/oscar-system/Oscar.jl/pull/2368
 @deprecate FreeModElem(coords::SRow{T}, parent::FreeMod_dec{T}) where T <: CRingElem_dec FreeModElem_dec(coords, parent)
 
+# Deprecated after 0.13.0
+@deprecate fan(v::AbstractNormalToricVariety) polyhedral_fan(v)
+
 # Polyhedral object wrappers now require a parent field
 function Cone{T}(obj::Polymake.BigObject) where T<:scalar_types
   Base.depwarn("'Cone{$T}(obj::Polymake.BigObject)' is deprecated, use 'Cone{$T}(obj, f)' with 'f::Field', or 'cone(obj)' instead.", :Cone)
@@ -390,3 +393,4 @@ function SubdivisionOfPoints{T}(obj::Polymake.BigObject) where T<:scalar_types
   Base.depwarn("'SubdivisionOfPoints{$T}(obj::Polymake.BigObject)' is deprecated, use 'SubdivisionOfPoints{$T}(obj, f)' with 'f::Field', or 'subdivision_of_points(obj)' instead.", :SubdivisionOfPoints)
   return SubdivisionOfPoints{T}(obj, _detect_default_field(T, obj))
 end
+

--- a/test/AlgebraicGeometry/ToricVarieties/affine_normal_varieties.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/affine_normal_varieties.jl
@@ -8,7 +8,7 @@ using Test
     antv3 = affine_normal_toric_variety(antv2; set_attributes)
     antv4 = affine_normal_toric_variety(Oscar.positive_hull([1 0]); set_attributes)
     antv5 = affine_space(NormalToricVariety, 2; set_attributes)
-    antv6 = normal_toric_variety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]]; set_attributes)
+    antv6 = normal_toric_variety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]])
     
     @testset "Basic properties" begin
         @test is_smooth(antv) == false

--- a/test/AlgebraicGeometry/ToricVarieties/affine_normal_varieties.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/affine_normal_varieties.jl
@@ -17,7 +17,7 @@ using Test
     end
     
     @testset "Basic attributes" begin
-        @test dim(fan(antv)) == 2
+        @test dim(polyhedral_fan(antv)) == 2
         @test dim(cone(antv)) == 2
         @test length(affine_open_covering(antv)) == 1
         @test length(gens(toric_ideal(antv))) == 1

--- a/test/AlgebraicGeometry/ToricVarieties/direct_products.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/direct_products.jl
@@ -1,10 +1,10 @@
 using Oscar
 using Test
 
-@testset "Direct products (set_attributes = $set_attributes)" for set_attributes in [true, false]
+@testset "Direct products" begin
     
-    F5 = normal_toric_variety([[1, 0], [0, 1], [-1, 5], [0, -1]], [[1, 2], [2, 3], [3, 4], [4, 1]]; set_attributes)
-    P2 = normal_toric_variety(normal_fan(Oscar.simplex(2)); set_attributes)
+    F5 = normal_toric_variety([[1, 0], [0, 1], [-1, 5], [0, -1]], [[1, 2], [2, 3], [3, 4], [4, 1]])
+    P2 = normal_toric_variety(normal_fan(Oscar.simplex(2)))
     variety = F5 * P2
     
     @testset "Properties of a direct product of two toric varieties" begin

--- a/test/AlgebraicGeometry/ToricVarieties/hirzebruch_surfaces.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/hirzebruch_surfaces.jl
@@ -36,7 +36,7 @@ using Test
         @test betti_number(F5, 3) == 0
         @test betti_number(F5, 4) == 1
         @test length(affine_open_covering(F5)) == 4
-        @test dim(fan(F5)) == 2
+        @test dim(polyhedral_fan(F5)) == 2
         @test rank(torusinvariant_weil_divisor_group(F5)) == 4
         @test rank(character_lattice(F5)) == 2
         @test ngens(cox_ring(F5)) == 4

--- a/test/AlgebraicGeometry/ToricVarieties/intersection_numbers.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/intersection_numbers.jl
@@ -3,11 +3,11 @@ using Test
 
 @testset "Topological intersection numbers (set_attributes = $set_attributes)" for set_attributes in [true, false]
     
-    antv = affine_normal_toric_variety(Oscar.positive_hull([1 1; -1 1]); set_attributes)
+    antv = affine_normal_toric_variety(Oscar.positive_hull([1 1; -1 1]))
     
-    antv2 = normal_toric_variety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]]; set_attributes)
+    antv2 = normal_toric_variety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]])
     
-    v = normal_toric_variety([[1, 0], [0, 1], [-1, -1]], [[1], [2], [3]]; set_attributes)
+    v = normal_toric_variety([[1, 0], [0, 1], [-1, -1]], [[1], [2], [3]])
     
     dP1 = del_pezzo_surface(NormalToricVariety, 1; set_attributes)
     c0 = cohomology_class(dP1, gens(cohomology_ring(dP1))[1])

--- a/test/AlgebraicGeometry/ToricVarieties/normal_toric_varieties.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/normal_toric_varieties.jl
@@ -3,7 +3,7 @@ using Test
 
 @testset "Normal toric varieties (set_attributes = $set_attributes)" for set_attributes in [true, false]
     
-    ntv = normal_toric_variety(Oscar.normal_fan(Oscar.cube(2)); set_attributes)
+    ntv = normal_toric_variety(Oscar.normal_fan(Oscar.cube(2)))
     set_coordinate_names(ntv, ["x1", "x2", "y1", "y2"])
     ntv2 = normal_toric_variety(Oscar.cube(2); set_attributes)
     ntv3 = normal_toric_varieties_from_glsm(matrix(ZZ, [[1, 1, 1]]); set_attributes)

--- a/test/AlgebraicGeometry/ToricVarieties/subvarieties.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/subvarieties.jl
@@ -3,9 +3,9 @@ using Test
 
 @testset "Closed subvarieties (set_attributes = $set_attributes)" for set_attributes in [true, false]
     
-    antv = normal_toric_variety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]]; set_attributes)
+    antv = normal_toric_variety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]])
     
-    ntv = normal_toric_variety(Oscar.normal_fan(Oscar.cube(2)); set_attributes)
+    ntv = normal_toric_variety(cube(2); set_attributes)
     (x1, x2, y1, y2) = gens(cox_ring(ntv));
     sv1 = closed_subvariety_of_toric_variety(ntv, [x1])
     sv2 = closed_subvariety_of_toric_variety(ntv, [x1^2+x1*x2+x2^2, y2])


### PR DESCRIPTION
- `fan` renamed to `polyhedral_fan`
- Eliminate hack in `polyhedral_fan` that was used at some point since casting did not work
- The `polyhedral_fan` is also not stored as an attribute anymore, as this only duplicates information and the toric variety itself already provides the full fan functionality.
- Disable printing of `rays` of a fan in toric schemes part. We will never want that kind of detail in the printout except if someone calls rays directly. Also in case of a fan this information does not even describe the fan completely.
- Enable `--depwarn=error` for the doctests
- Fix doctests