### PR TITLE
Rename invalidations CI test

### DIFF
--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  evaluate:
+  compare-invalidations:
     # Only run on PRs to the default branch.
     # In the PR trigger above branches can be specified only explicitly whereas this check should work for master, main, or any other default branch
     if: github.base_ref == github.event.repository.default_branch


### PR DESCRIPTION
In some parts of the GitHub UI, only 'evaluate' is showing, which
is not helpful. A more meaningful name alleviates this problem.
