### PR TITLE
Rename `is_hermitian_matrix` to `is_hermitian`

### DIFF
--- a/docs/src/Groups/matgroup.md
+++ b/docs/src/Groups/matgroup.md
@@ -84,7 +84,7 @@ conjugate_transpose(x::MatElem{T}) where T <: FinFieldElem
 complement(V::AbstractAlgebra.Generic.FreeModule{T}, W::AbstractAlgebra.Generic.Submodule{T}) where T <: FieldElem
 permutation_matrix(F::Ring, Q::AbstractVector{<:IntegerUnion})
 is_skewsymmetric_matrix(B::MatElem{T}) where T <: RingElem
-is_hermitian_matrix(B::MatElem{T}) where T <: FinFieldElem
+is_hermitian(B::MatElem{T}) where T <: FinFieldElem
 ```
 
 ## Classical groups

--- a/src/Groups/matrices/forms.jl
+++ b/src/Groups/matrices/forms.jl
@@ -22,7 +22,7 @@ mutable struct SesquilinearForm{T<:RingElem}
 
    function SesquilinearForm{T}(B::MatElem{T},sym) where T
       if sym==:hermitian
-         @assert is_hermitian_matrix(B) "The matrix is not hermitian"
+         @assert is_hermitian(B) "The matrix is not hermitian"
       elseif sym==:symmetric
          @assert is_symmetric(B) "The matrix is not symmetric"
       elseif sym==:alternating

--- a/src/Groups/matrices/matrix_manipulation.jl
+++ b/src/Groups/matrices/matrix_manipulation.jl
@@ -183,12 +183,12 @@ function is_skewsymmetric_matrix(B::MatElem{T}) where T <: RingElem
 end
 
 """
-    is_hermitian_matrix(B::MatElem{T}) where T <: FinFieldElem
+    is_hermitian(B::MatElem{T}) where T <: FinFieldElem
 
 Return whether the matrix `B` is hermitian, i.e. `B = conjugate_transpose(B)`.
 Return `false` if `B` is not a square matrix, or the field has not even degree.
 """
-function is_hermitian_matrix(B::MatElem{T}) where T <: FinFieldElem
+function is_hermitian(B::MatElem{T}) where T <: FinFieldElem
    n = nrows(B)
    n==ncols(B) || return false
    e = degree(base_ring(B))

--- a/src/aliases.jl
+++ b/src/aliases.jl
@@ -39,7 +39,6 @@
 @alias isglobal is_global
 @alias isgraded is_graded
 @alias ishermitian_form is_hermitian_form
-@alias ishermitian_matrix is_hermitian_matrix
 @alias isinner_automorphism is_inner_automorphism
 @alias isinvariant is_invariant
 @alias isisomorphic_with_alternating_group is_isomorphic_with_alternating_group

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -394,3 +394,5 @@ function SubdivisionOfPoints{T}(obj::Polymake.BigObject) where T<:scalar_types
   return SubdivisionOfPoints{T}(obj, _detect_default_field(T, obj))
 end
 
+@deprecate is_hermitian_matrix(B::MatElem{T}) where T <: FinFieldElem is_hermitian(B)
+@alias ishermitian_matrix is_hermitian_matrix

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -738,7 +738,6 @@ export is_gorenstein
 export is_graded
 export is_groebner_basis
 export is_hermitian_form
-export is_hermitian_matrix
 export is_homogeneous
 export is_identity_map
 export is_injective

--- a/test/Groups/forms.jl
+++ b/test/Groups/forms.jl
@@ -10,7 +10,7 @@
    @test f==alternating_form(gram_matrix(f))
    @test base_ring(B)==F
    @test !is_symmetric(B)
-   @test !is_hermitian_matrix(B)
+   @test !is_hermitian(B)
    @test is_alternating_form(f)
    @test !is_quadratic_form(f)
    @test !is_symmetric_form(f)
@@ -19,7 +19,7 @@
    @test_throws AssertionError f = hermitian_form(B)
 
    B = matrix(F,4,4,[0 1 0 0; 1 0 0 0; 0 0 0 z+2; 0 0 -1-z 0])
-   @test is_hermitian_matrix(B)
+   @test is_hermitian(B)
    f = hermitian_form(B)
    @test f isa SesquilinearForm
    @test gram_matrix(f)==B

--- a/test/Groups/operations.jl
+++ b/test/Groups/operations.jl
@@ -86,7 +86,7 @@ end
    x=matrix(F,4,4,[1,z,0,0,0,1,z^2,z,z,0,0,1,0,0,z+1,0])
    y=x+transpose(x)
    @test is_symmetric(y)
-   @test is_hermitian_matrix(x+conjugate_transpose(x))
+   @test is_hermitian(x+conjugate_transpose(x))
    @test is_skewsymmetric_matrix(y)
    y[1,1]=1
    @test !is_skewsymmetric_matrix(y)


### PR DESCRIPTION
`is_hermitian` already exists for other types and is more streamlined with similar function names, e.g. `is_symmetric`.