### PR TITLE
add is_isomorphic_with_permutation for graphs

### DIFF
--- a/docs/src/Combinatorics/graphs.md
+++ b/docs/src/Combinatorics/graphs.md
@@ -62,7 +62,7 @@ neighbors(g::Graph{T}, v::Int64) where {T <: Union{Directed, Undirected}}
 nv(g::Graph{T}) where {T <: Union{Directed, Undirected}}
 outneighbors(g::Graph{T}, v::Int64) where {T <: Union{Directed, Undirected}}
 shortest_path_dijkstra
-is_isomorphic(g1::Graph, g2::Graph)
+is_isomorphic(g1::Graph{T}, g2::Graph{T}) where {T <: Union{Directed, Undirected}}
 is_isomorphic_with_permutation(G1::Graph, G2::Graph)
 ```
 

--- a/docs/src/Combinatorics/graphs.md
+++ b/docs/src/Combinatorics/graphs.md
@@ -35,6 +35,7 @@ allow for easier integration elsewhere.
 Graph{T}(nverts::Int64) where {T <: Union{Directed, Undirected}}
 dualgraph(p::Polyhedron)
 edgegraph(p::Polyhedron)
+graph_from_adjacency_matrix
 ```
 
 ### Modifying graphs
@@ -61,6 +62,8 @@ neighbors(g::Graph{T}, v::Int64) where {T <: Union{Directed, Undirected}}
 nv(g::Graph{T}) where {T <: Union{Directed, Undirected}}
 outneighbors(g::Graph{T}, v::Int64) where {T <: Union{Directed, Undirected}}
 shortest_path_dijkstra
+is_isomorphic(g1::Graph, g2::Graph)
+is_isomorphic_with_permutation(G1::Graph, G2::Graph)
 ```
 
 ### Edges

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -536,8 +536,7 @@ julia> add_edge!(g,1,2); add_edge!(g,2,3); add_edge!(g,3,4); add_edge!(g,4,5); a
 julia> signed_incidence_matrix(g)
 5×5 Matrix{Int64}:
  -1   0   0   0   1
-  1  -1   0   0   0Tuple{Vector{WeilDivisor{CoveredScheme{Nemo.fpField}, ZZRing, ZZRingElem}}, ZZMatrix}
-
+  1  -1   0   0   0
   0   1  -1   0   0
   0   0   1  -1   0
   0   0   0   1  -1

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -40,8 +40,10 @@ end
 
 Return the graph with adjacency matrix `G`.
 
-This means that the nodes ``i > j`` are connected by an edge
+This means that the nodes ``i, j`` are connected by an edge
 if and only if ``G_{i,j}`` is one.
+In the undirected case, it is assumed that ``i > j`` i.e. the upper triangular
+part of ``G`` is ignored.
 
 # Examples
 ```jldoctest
@@ -878,7 +880,8 @@ Return a permutation `I` such that `A1[I,I] == A2` and whether it exists.
 
 The method assumes that both matrices are symmetric, their diagonal entries
 are all equal (and so irrelevant) and the off-diagonal entries are either ``0``
-or ``1``.
+or ``1``. It is assumed that `A1` and `A2` are symmetric and
+their upper triangular part is ignored.
 """
 function _is_equal_up_to_permutation_with_permutation(A1::MatElem, A2::MatElem)
   g1 = graph_from_adjacency_matrix(Undirected, A1)

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -35,6 +35,68 @@ function Graph{T}(nverts::Int64) where {T <: Union{Directed, Undirected}}
     return Graph{T}(pmg)
 end
 
+@doc raw"""
+    graph_from_adjacency_matrix(::Type{T}, G) where {T <:Union{Directed, Undirected}}
+
+Return the graph with adjacency matrix `G`.
+
+This means that the nodes ``i > j`` are connected by an edge
+if and only if ``G_{i,j}`` is one.
+
+# Examples
+```jldoctest
+julia> G = ZZ[0 0; 1 0]
+[0   0]
+[1   0]
+
+julia> graph_from_adjacency_matrix(Directed, G)
+Graph{Directed}(pm::graph::Graph<pm::graph::Directed>
+{}
+{0}
+)
+
+julia> graph_from_adjacency_matrix(Undirected, G)
+Graph{Undirected}(pm::graph::Graph<pm::graph::Undirected>
+{1}
+{0}
+)
+
+```
+"""
+graph_from_adjacency_matrix(::Type, G::Union{MatElem, Matrix})
+
+function graph_from_adjacency_matrix(::Type{Undirected}, G::Union{MatElem, Matrix})
+  n = nrows(G)
+  @req nrows(G)==ncols(G) "not a square matrix"
+  g = Graph{Undirected}(n)
+  for i in 1:n
+    for j in 1:i-1
+      if isone(G[i,j])
+        add_edge!(g, i, j)
+      else
+        iszero(G[i,j]) || error("not an adjacency matrix")
+      end
+    end
+  end
+  return g
+end
+
+function graph_from_adjacency_matrix(::Type{Directed}, G::Union{MatElem, Matrix})
+  n = nrows(G)
+  @req nrows(G)==ncols(G) "not a square matrix"
+  g = Graph{Directed}(n)
+  for i in 1:n
+    for j in 1:n
+      if isone(G[i,j])
+        add_edge!(g, i, j)
+      else
+        iszero(G[i,j]) || error("not an adjacency matrix")
+      end
+    end
+  end
+  return g
+end
+
 _has_node(G::Graph, node::Int64) = 0 < node <= nv(G)
 
 @doc raw"""
@@ -793,8 +855,15 @@ is_isomorphic(g1::Graph{T}, g2::Graph{T}) where {T <: Union{Directed, Undirected
 
 Return whether `G1` is isomorphic to `G2` as well as a permutation
 of the nodes of `G1` such that both graphs agree.
+
+# Examples
+```jldoctest
+julia> is_isomorphic_with_permutation(edgegraph(simplex(3)), dualgraph(simplex(3)))
+(true, [1, 2, 3, 4])
+
+```
 """
-function is_isomorphic_with_data(G1::Graph, G2::Graph)
+function is_isomorphic_with_permutation(G1::Graph, G2::Graph)
   f12 = Polymake.graph.find_node_permutation(G1.pm_graph, G2.pm_graph)
   if isnothing(f12)
     return false, Vector{Int}()
@@ -803,67 +872,18 @@ function is_isomorphic_with_data(G1::Graph, G2::Graph)
 end
 
 @doc raw"""
-    graph_from_adjacency_matrix(::Type{T}, G::MatElem) where T<:Union{Directed, Undirected}
-
-Return the graph with adjacency matrix `G`.
-
-This means that the nodes ``i`` and ``j`` are connected by an edge
-if and only if ``G_{i,j}`` is one.
-
-# Examples
-```jldoctest
-julia> G = ZZ[0 1; 0 0]
-
-julia> oscar.graph_from_adjacency_matrix(Directed, G)
-
-julia> oscar.graph_from_adjacency_matrix(Undirected, G)
-
-```
-"""
-graph_from_adjacency_matrix(::Type, G::MatElem)
-
-function graph_from_adjacency_matrix(::Type{Undirected}, G::MatElem)
-  n = nrows(G)
-  @req nrows(G)==ncols(G) "not a square matrix"
-  g = Graph{T}(n)
-  for i in 1:n
-    for j in 1:i-1
-      if isone(G[i,j])
-        add_edge!(g, i, j)
-      else
-        iszero(G[i,j]) || error("not an adjacency matrix")
-      end
-    end
-  end
-  return g
-end
-
-function graph_from_adjacency_matrix(::Type{Directed}, G::MatElem)
-  n = nrows(G)
-  @req nrows(G)==ncols(G) "not a square matrix"
-  g = Graph{T}(n)
-  for i in 1:n
-    for j in 1:n
-      if isone(G[i,j])
-        add_edge!(g, i, j)
-      else
-        iszero(G[i,j]) || error("not an adjacency matrix")
-      end
-    end
-  end
-  return g
-end
-
-
-@doc raw"""
-    is_equal_up_to_permutation_with_permutation(A1::MatElem, A2::MatElem) -> Bool, Vector{Int}
+    _is_equal_up_to_permutation_with_permutation(A1::MatElem, A2::MatElem) -> Bool, Vector{Int}
 
 Return a permutation `I` such that `A1[I,I] == A2` and whether it exists.
+
+The method assumes that both matrices are symmetric, their diagonal entries
+are all equal (and so irrelevant) and the off-diagonal entries are either ``0``
+or ``1``.
 """
-function is_equal_up_to_permutation_with_permutation(A1::MatElem, A2::MatElem)
+function _is_equal_up_to_permutation_with_permutation(A1::MatElem, A2::MatElem)
   g1 = graph_from_adjacency_matrix(Undirected, A1)
   g2 = graph_from_adjacency_matrix(Undirected, A2)
-  b, T = is_isomorphic_with_map(g1, g2)
+  b, T = is_isomorphic_with_permutation(g1, g2)
   if b
     @assert A1[T, T] == A2
   end

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -788,6 +788,35 @@ false
 """
 is_isomorphic(g1::Graph{T}, g2::Graph{T}) where {T <: Union{Directed, Undirected}} = Polymake.graph.isomorphic(pm_object(g1), pm_object(g2))::Bool
 
+
+function is_isomorphic_with_map(G1::Graph, G2::Graph)
+  f12 = Polymake.graph.find_node_permutation(G1.pm_graph, G2.pm_graph)
+  if isnothing(f12)
+    return false, Vector{Int}()
+  end
+  return true, Polymake.to_one_based_indexing(f12)
+end
+
+function graph(G::MatElem)
+  n = nrows(G)
+  g = Graph{Undirected}(n)
+  for i in 1:n
+    for j in 1:i-1
+      if isone(G[i,j])
+        add_edge!(g,i,j)
+      end
+    end
+  end
+  return g
+end
+
+function is_isomorphic_with_permutation(A1::MatElem, A2::MatElem)
+  b, T = is_isomorphic_with_map(graph(A1),graph(A2))
+  @assert b || A1[T] == A2
+  return b, T
+end
+
+
 ################################################################################
 ################################################################################
 ##  Standard constructions

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -566,6 +566,7 @@ export graded_polynomial_ring
 export grading
 export grading_group
 export graph
+export graph_from_adjacency_matrix
 export grassmann_pluecker_ideal
 export grid_morphism
 export groebner_basis
@@ -752,6 +753,7 @@ export is_irreducible
 export is_isomorphic
 export is_isomorphic_with_alternating_group, has_is_isomorphic_with_alternating_group, set_is_isomorphic_with_alternating_group
 export is_isomorphic_with_map
+export is_isomorphic_with_permutation
 export is_isomorphic_with_symmetric_group, has_is_isomorphic_with_symmetric_group, set_is_isomorphic_with_symmetric_group
 export is_isomorphism
 export is_k_separation

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -71,10 +71,10 @@
         add_edge!(gg, 4, 3)
         @test is_isomorphic(g, gg)
 
-        G = matrix(ZZ, 3, 3, [0,1,0,0,0,1,0,0,0])
+        G = matrix(ZZ, 3, 3, [0,1,0,1,0,1,0,1,0])
         J = [2,3,1]
         H = G[J,J]
-        b, I = oscar.is_equal_up_to_permutation_with_permutation(G, H)
+        b, I = oscar._is_equal_up_to_permutation_with_permutation(G, H)
         @assert G[I,I] == H
     end
 

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -70,6 +70,12 @@
         rem_edge!(gg, 3, 4)
         add_edge!(gg, 4, 3)
         @test is_isomorphic(g, gg)
+
+        G = matrix(ZZ, 3, 3, [0,1,0,0,0,1,0,0,0])
+        J = [2,3,1]
+        H = G[J,J]
+        b, I = oscar.is_equal_up_to_permutation_with_permutation(G, H)
+        @assert G[I,I] == H
     end
 
     @testset "connectivity" begin


### PR DESCRIPTION
This originates in a question that I asked a while ago on slack.
One could also argue for the name
`is_isomorphic_with_permutation` 
instead of
`is_isomorphic_with_map`