### PR TITLE
Change `is_skewsymmetric_matrix` to `is_alternating`

### DIFF
--- a/docs/src/Groups/matgroup.md
+++ b/docs/src/Groups/matgroup.md
@@ -83,7 +83,7 @@ lower_triangular_matrix(L)
 conjugate_transpose(x::MatElem{T}) where T <: FinFieldElem
 complement(V::AbstractAlgebra.Generic.FreeModule{T}, W::AbstractAlgebra.Generic.Submodule{T}) where T <: FieldElem
 permutation_matrix(F::Ring, Q::AbstractVector{<:IntegerUnion})
-is_skewsymmetric_matrix(B::MatElem{T}) where T <: RingElem
+is_alternating(B::MatElem)
 is_hermitian(B::MatElem{T}) where T <: FinFieldElem
 ```
 

--- a/src/Groups/matrices/forms.jl
+++ b/src/Groups/matrices/forms.jl
@@ -26,7 +26,7 @@ mutable struct SesquilinearForm{T<:RingElem}
       elseif sym==:symmetric
          @assert is_symmetric(B) "The matrix is not symmetric"
       elseif sym==:alternating
-         @assert is_skewsymmetric_matrix(B) "The matrix is not skew-symmetric"
+         @assert is_alternating(B) "The matrix does not correspond to an alternating form"
       elseif sym != :quadratic
          error("Unsupported description")
       end

--- a/src/Groups/matrices/matrix_manipulation.jl
+++ b/src/Groups/matrices/matrix_manipulation.jl
@@ -160,15 +160,15 @@ permutation_matrix(F::Ring, p::PermGroupElem) = permutation_matrix(F, Vector(p))
 #
 ########################################################################
 
-# TODO: not sure whether this definition of skew-symmetric is standard (for fields of characteristic 2)
+# TODO: Move to AbstractAlgebra
 """
-    is_skewsymmetric_matrix(B::MatElem{T}) where T <: Ring
+    is_alternating(B::MatElem)
 
-Return whether the matrix `B` is skew-symmetric,
+Return whether the form corresponding to the matrix `B` is alternating,
 i.e. `B = -transpose(B)` and `B` has zeros on the diagonal.
 Return `false` if `B` is not a square matrix.
 """
-function is_skewsymmetric_matrix(B::MatElem{T}) where T <: RingElem
+function is_alternating(B::MatElem)
    n = nrows(B)
    n==ncols(B) || return false
 

--- a/src/aliases.jl
+++ b/src/aliases.jl
@@ -61,7 +61,6 @@
 @alias issemisimple is_semisimple
 @alias issimplicial is_simplicial
 @alias issingular is_singular
-@alias isskewsymmetric_matrix is_skewsymmetric_matrix
 @alias issmooth_curve is_smooth_curve
 @alias issolvable is_solvable
 @alias issupersolvable is_supersolvable

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -394,9 +394,6 @@ function SubdivisionOfPoints{T}(obj::Polymake.BigObject) where T<:scalar_types
   return SubdivisionOfPoints{T}(obj, _detect_default_field(T, obj))
 end
 
-@deprecate is_skewsymmetric_matrix(B::MatElem{T}) where T <: RingElem is_alternating(B)
-@alias isskewsymmetric_matrix is_skewsymmetric_matrix
-
 @deprecate is_hermitian_matrix(B::MatElem{T}) where T <: FinFieldElem is_hermitian(B)
 @alias ishermitian_matrix is_hermitian_matrix
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -394,6 +394,9 @@ function SubdivisionOfPoints{T}(obj::Polymake.BigObject) where T<:scalar_types
   return SubdivisionOfPoints{T}(obj, _detect_default_field(T, obj))
 end
 
+@deprecate is_skewsymmetric_matrix(B::MatElem{T}) where T <: RingElem is_alternating(B)
+@alias isskewsymmetric_matrix is_skewsymmetric_matrix
+
 @deprecate is_hermitian_matrix(B::MatElem{T}) where T <: FinFieldElem is_hermitian(B)
 @alias ishermitian_matrix is_hermitian_matrix
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -800,7 +800,6 @@ export is_semisimple
 export is_simple, has_is_simple, set_is_simple
 export is_simplicial
 export is_singular
-export is_skewsymmetric_matrix
 export is_smooth
 export is_solvable, has_is_solvable, set_is_solvable
 export is_sporadic_simple, has_is_sporadic_simple, set_is_sporadic_simple

--- a/test/Groups/forms.jl
+++ b/test/Groups/forms.jl
@@ -3,7 +3,7 @@
    F,z = FiniteField(t^2+1,"z")
 
    B = matrix(F,4,4,[0 1 0 0; 2 0 0 0; 0 0 0 z+2; 0 0 1-z 0])
-   @test is_skewsymmetric_matrix(B)
+   @test is_alternating(B)
    f = alternating_form(B)
    @test f isa SesquilinearForm
    @test gram_matrix(f)==B
@@ -473,7 +473,7 @@ end
    end
    B = Oscar.invariant_quadratic_form(G)
    @testset for g in gens(G)
-      @test is_skewsymmetric_matrix(g.elm*B*transpose(g.elm)-B)
+      @test is_alternating(g.elm*B*transpose(g.elm)-B)
    end
 
    G = GU(4,5)

--- a/test/Groups/operations.jl
+++ b/test/Groups/operations.jl
@@ -80,16 +80,19 @@ end
    @test f(identity_matrix(F,6))==f(1)*identity_matrix(F,6)
    @test_throws ArgumentError conjugate_transpose(x)
    @test is_symmetric(P+transpose(P))
-   @test is_skewsymmetric_matrix(P-transpose(P))
+   @test is_skew_symmetric(P-transpose(P))
+   @test is_alternating(P-transpose(P))
 
    F,z = FiniteField(2,2)
    x=matrix(F,4,4,[1,z,0,0,0,1,z^2,z,z,0,0,1,0,0,z+1,0])
    y=x+transpose(x)
    @test is_symmetric(y)
    @test is_hermitian(x+conjugate_transpose(x))
-   @test is_skewsymmetric_matrix(y)
+   @test is_skew_symmetric(y)
+   @test is_alternating(y)
    y[1,1]=1
-   @test !is_skewsymmetric_matrix(y)
+   @test is_skew_symmetric(y)
+   @test !is_alternating(y)
    @test conjugate_transpose(x)==transpose(matrix(F,4,4,[1,z+1,0,0,0,1,z,z+1,z+1,0,0,1,0,0,z,0]))
 
 end


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/2555.

I renamed `is_skewsymmetric_matrix` to `is_alternating`, and updated all uses accordingly. In one test, there was a natural place to test that this indeed differs from `is_skew_symmetric` in characteristic 2.