### PR TITLE
Fix tests for primitive_by_shape and an_sn_by_shape

### DIFF
--- a/src/NumberTheory/GaloisGrp/GaloisGrp.jl
+++ b/src/NumberTheory/GaloisGrp/GaloisGrp.jl
@@ -1782,7 +1782,7 @@ end
 
 
 @doc raw"""
-  primitive_by_shape(ct::Set{CycleType}, n::Int)
+    primitive_by_shape(ct::Set{CycleType}, n::Int)
 
 Return `true` if a transitive group $G \leq Sym(n)$ containing permutations
 matching the cycle types in `ct` must be primitive, otherwise return `false`.

--- a/test/NumberTheory/galthy.jl
+++ b/test/NumberTheory/galthy.jl
@@ -52,7 +52,11 @@ sample_cycle_structures(G::PermGroup) = Set(cycle_structure(rand_pseudo(G)) for 
   # note that we only check the implication, as there are cases in degree 15 and above
   # where primitive_by_shape fails to detect primitivity
   @testset "primitive_by_shape (randomized) in degree $n" for n in 12:length(grps)
-    @test all(G -> is_primitive(G) || !primitive_by_shape(sample_cycle_structures(G),n), grps[n] )
+    # If primitive_by_shape returns true then is_primitive must return true. If
+    # primitive_by_shape returns false then we can't say anything, as we just
+    # might have sampled bad elements.
+    # In other words, we test for the implication `primitive_by_shape => is_primitive`.
+    @test all(G -> !primitive_by_shape(sample_cycle_structures(G),n) || is_primitive(G), grps[n] )
   end
 
   @testset "an_sn_by_shape (exact) in degree $n" for n in 1:11
@@ -60,7 +64,11 @@ sample_cycle_structures(G::PermGroup) = Set(cycle_structure(rand_pseudo(G)) for 
   end
 
   @testset "an_sn_by_shape (randomized) in degree $n" for n in 12:length(grps)
-    @test all(G -> naive_is_giant(G) == an_sn_by_shape(sample_cycle_structures(G),n), grps[n] )
+    # If an_sn_by_shape returns true then naive_is_giant must return true. If
+    # an_sn_by_shape returns false then we can't say anything, as we just
+    # might have sampled bad elements.
+    # In other words, we test for the implication `an_sn_by_shape => naive_is_giant`.
+    @test all(G -> !an_sn_by_shape(sample_cycle_structures(G),n) || naive_is_giant(G), grps[n] )
   end
 
 end


### PR DESCRIPTION
If we sampled a bad set of elements, the tests could erroneously fail.