### PR TITLE
Start web server after building the documentation

### DIFF
--- a/docs/src/DeveloperDocumentation/documentation.md
+++ b/docs/src/DeveloperDocumentation/documentation.md
@@ -79,6 +79,14 @@ build_doc
 ```
 Please also read the section below on repairing the `jldoctest`s using
 `build_doc`.
+!!! note "Browser reports denied access"
+    Depending on your system, it might happen that the browser opens after a
+    successful build, but only informs you that the access to the file was denied.
+    This happens, for example, on Ubuntu which comes with a sandboxed Firefox.
+    A workaround for this is to move the directory containing the documentation
+    `docs/build` to a more accessible place on your computer (for example, the
+    desktop).
+    Of course, this has to be repeated everytime you (re-)build the documentation.
 
 
 ### Automatically repairing `jldoctest`s

--- a/docs/src/DeveloperDocumentation/documentation.md
+++ b/docs/src/DeveloperDocumentation/documentation.md
@@ -83,10 +83,8 @@ Please also read the section below on repairing the `jldoctest`s using
     Depending on your system, it might happen that the browser opens after a
     successful build, but only informs you that the access to the file was denied.
     This happens, for example, on Ubuntu which comes with a sandboxed Firefox.
-    A workaround for this is to move the directory containing the documentation
-    `docs/build` to a more accessible place on your computer (for example, the
-    desktop).
-    Of course, this has to be repeated everytime you (re-)build the documentation.
+    In this case, using `build_doc` with `start_server = true` should circumvent
+    this problem.
 
 
 ### Automatically repairing `jldoctest`s

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -120,7 +120,7 @@ function start_doc_preview_server(;open_browser::Bool = true, port::Int = 8000)
         using LiveServer;
         LiveServer.serve(dir = "$build_dir", launch_browser = $open_browser, port = $port);
         """
-  live_server_process = run(`julia -e $cmd`, wait = false)
+  live_server_process = run(`$(Base.julia_cmd()) -e $cmd`, wait = false)
   atexit(_ -> kill(live_server_process))
   @info "Starting server with PID $(getpid(live_server_process)) listening on 127.0.0.1:$port"
   return nothing

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -155,7 +155,7 @@ terminated, so the proposed usage for this option is to run
 `build_doc(open_browser = false)` for following builds and only refresh the
 browser tab.
 
-When working on the manual the `Revise` package can significantly sped
+When working on the manual the `Revise` package can significantly speed
 up running `build_doc`. First, install `Revise` in the following way:
 ```
 using Pkg ; Pkg.add("Revise")
@@ -164,7 +164,7 @@ Second, restart Julia and load `Revise` before Oscar:
 ```
 using Revise, Oscar;
 ```
-The first run of `build_doc` will take the usual few minutes, subsequently runs
+The first run of `build_doc` will take the usual few minutes, subsequent runs
 will be significantly faster.
 """
 function build_doc(; doctest=false, strict=false, open_browser=true, start_server = false)

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -111,9 +111,19 @@ function open_doc()
     end
 end
 
+function start_doc_preview_server(;open_browser::Bool = true, port::Int = 8000)
+  build_dir = normpath(Oscar.oscardir, "docs", "build")
+  cmd = "using Pkg; Pkg.activate(temp = true);
+         Pkg.add(\"LiveServer\"); using LiveServer;
+         LiveServer.serve(dir = \"$build_dir\", launch_browser = $open_browser, port = $port);"
+  live_server_process = run(`julia -e $cmd`, wait = false)
+  atexit(_ -> kill(live_server_process))
+  @info "Starting server with PID $(getpid(live_server_process)) listening on 127.0.0.1:$port"
+  return nothing
+end
 
 @doc raw"""
-    build_doc(; doctest=false, strict=false, open_browser=true)
+    build_doc(; doctest=false, strict=false, open_browser=true, start_server=false)
 
 Build the manual of `Oscar.jl` locally and open the front page in a
 browser.
@@ -136,6 +146,15 @@ doctesting error will always make makedocs throw an error in this mode".
 To prevent the opening of the browser at the end, set the optional parameter
 `open_browser` to `false`.
 
+Alternatively, one can use the optional parameter `start_server` to start a web
+server in the build directory which is accessible via `127.0.0.1:8000`. If both
+`start_server` and `open_browser` are `true`, the browser will show this page.
+The server keeps running in the background until the `julia` session is
+terminated, so the proposed usage for this option is to run
+`build_doc(start_server = true)` for the first build and
+`build_doc(open_browser = false)` for following builds and only refresh the
+browser tab.
+
 When working on the manual the `Revise` package can significantly sped
 up running `build_doc`. First, install `Revise` in the following way:
 ```
@@ -148,7 +167,7 @@ using Revise, Oscar;
 The first run of `build_doc` will take the usual few minutes, subsequently runs
 will be significantly faster.
 """
-function build_doc(; doctest=false, strict=false, open_browser=true)
+function build_doc(; doctest=false, strict=false, open_browser=true, start_server = false)
   versioncheck = (VERSION.major == 1) && (VERSION.minor >= 7)
   versionwarn = 
 "The Julia reference version for the doctests is 1.7 or later, but you are using
@@ -162,8 +181,11 @@ $(VERSION). Running the doctests will produce errors that you do not expect."
   Pkg.activate(docsproject) do
     Base.invokelatest(Main.BuildDoc.doit, Oscar; strict=strict, local_build=true, doctest=doctest)
   end
-  if open_browser
+  if open_browser && !start_server
     open_doc()
+  end
+  if start_server
+    start_doc_preview_server(open_browser = open_browser)
   end
   if doctest != false && !versioncheck
     @warn versionwarn


### PR DESCRIPTION
As discussed in Slack, the `open_browser` option of `build_doc` does not work (at least) on Ubuntu's sandboxed snap-firefox. I added a comment regarding this to the documentation (first commit).
@benlorenz suggested to start a web server using `LiveServer.jl` in the build directory, so I also tried this.
~I'm not really familiar with the setup for building the documentation and eventually added `LiveServer` as a dependency at every place I could find because this seemed to be the only way to make it work. Is there a better way and do we want to have this dependency at all?~

As of now this will of course simply start the server, but not update anything, when the user edits the documentation (like the `LiveServer.servedocs` function claims to do).
