### PR TITLE
Follow-up PR #2537

### DIFF
--- a/experimental/Schemes/AlgebraicCycles.jl
+++ b/experimental/Schemes/AlgebraicCycles.jl
@@ -191,9 +191,6 @@ julia> R = ZZ;
 julia> algebraic_cycle(Ycov, R)
 Zero algebraic cycle
   on scheme over QQ covered with 3 patches
-    1: [(y//x), (z//x)]   spec of quotient of multivariate polynomial ring
-    2: [(x//y), (z//y)]   spec of quotient of multivariate polynomial ring
-    3: [(x//z), (y//z)]   spec of quotient of multivariate polynomial ring
 with coefficients in integer Ring
 ```
 """
@@ -230,17 +227,11 @@ julia> II = IdealSheaf(Y, I);
 julia> R = ZZ;
 
 julia> algebraic_cycle(II, R)
-Irreducible algebraic cycle
+Effective algebraic cycle
   on scheme over QQ covered with 3 patches
-    1: [(y//x), (z//x)]   spec of multivariate polynomial ring
-    2: [(x//y), (z//y)]   spec of multivariate polynomial ring
-    3: [(x//z), (y//z)]   spec of multivariate polynomial ring
 with coefficients in integer Ring
 given as the formal sum of
-  1*sheaf of ideals with restrictions
-      1: ideal(-(y//x)^2*(z//x) + 1)
-      2: ideal((x//y)^3 - (z//y))
-      3: ideal((x//z)^3 - (y//z)^2)
+  1 * sheaf of ideals
 
 ```
 """
@@ -277,17 +268,11 @@ julia> II = IdealSheaf(Y, I);
 julia> R = ZZ;
 
 julia> algebraic_cycle(II, R)
-Irreducible algebraic cycle
+Effective algebraic cycle
   on scheme over QQ covered with 3 patches
-    1: [(y//x), (z//x)]   spec of multivariate polynomial ring
-    2: [(x//y), (z//y)]   spec of multivariate polynomial ring
-    3: [(x//z), (y//z)]   spec of multivariate polynomial ring
 with coefficients in integer Ring
 given as the formal sum of
-  1*sheaf of ideals with restrictions
-      1: ideal(-(y//x)^2*(z//x) + 1)
-      2: ideal((x//y)^3 - (z//y))
-      3: ideal((x//z)^3 - (y//z)^2)
+  1 * sheaf of ideals
 ```
 """
 algebraic_cycle(I::IdealSheaf) = AlgebraicCycle(I)
@@ -317,22 +302,16 @@ function Base.show(io::IO, ::MIME"text/plain", D::AlgebraicCycle, cov::Covering 
   io = pretty(io)
   X = scheme(D)
   eff = all(i >= 0 for i in collect(values(D.coefficients)))
-  if length(components(D)) == 1
-    prim = D[components(D)[1]] == 1
-  else
-    prim = false
-  end
   if length(components(D)) == 0
     print(io, "Zero algebraic cycle")
   else
     if eff
-      if prim
-        print(io, "Irreducible algebraic cycle")
-      else
-        print(io, "Effective algebraic cycle")
-      end
+      print(io, "Effective algebraic cycle")
     else
       print(io, "Algebraic cycle")
+    end
+    if has_name(D)
+      print(io, " ", get_attribute(D, :name))
     end
     if has_attribute(D, :dim)
       print(io, " of dimension $(dim(D))")
@@ -340,7 +319,7 @@ function Base.show(io::IO, ::MIME"text/plain", D::AlgebraicCycle, cov::Covering 
   end
   println(io)
   print(io, Indent(), "on ", Lowercase())
-  Oscar._show_semi_compact(io, X, cov)
+  show(io, X, cov)
   println(io, Dedent())
   print(io, "with coefficients in ", Lowercase(), coefficient_ring(D))
   if length(components(D)) != 0
@@ -353,13 +332,10 @@ function Base.show(io::IO, ::MIME"text/plain", D::AlgebraicCycle, cov::Covering 
       println(io)
       I = components(D)[i]
       kI = length(co_str[i])
-      print(io, " "^(k-kI)*"$(D[I])*")
+      print(io, " "^(k-kI)*"$(D[I]) * ")
       print(io, Indent(), Lowercase())
-      Oscar._show_semi_compact(io, I, cov)
+      show(io, I, false)
       print(io, Dedent())
-      if i != length(components(D))
-        println(io, "--------------------------------------------------------------------------------")
-      end
     end
   end
   print(io, Dedent())

--- a/experimental/Schemes/CartierDivisor.jl
+++ b/experimental/Schemes/CartierDivisor.jl
@@ -168,15 +168,9 @@ defined by
 julia> cartier_divisor(E)
 Cartier divisor
   on scheme over QQ covered with 3 patches
-    1: [(y//x), (z//x)]   spec of multivariate polynomial ring
-    2: [(x//y), (z//y)]   spec of multivariate polynomial ring
-    3: [(x//z), (y//z)]   spec of multivariate polynomial ring
 with coefficients in integer Ring
 defined by the formal sum of
-  1*sheaf of ideals with restrictions
-    1: ideal(-(y//x)^2*(z//x) + 1)
-    2: ideal((x//y)^3 - (z//y))
-    3: ideal((x//z)^3 - (y//z)^2)
+  1 * sheaf of ideals
 ```
 """
 cartier_divisor(E::EffectiveCartierDivisor) = CartierDivisor(E)
@@ -405,6 +399,8 @@ function Base.show(io::IO, C::EffectiveCartierDivisor)
   io = pretty(io)
   if get(io, :supercompact, false)
     print(io, "Cartier divisor")
+  elseif has_attribute(C, :name)
+    print(io, get_attribute(C, :name))
   else
     print(io, "Effective cartier divisor on ", Lowercase())
     show(io, scheme(C))
@@ -418,7 +414,11 @@ function Base.show(io::IO, ::MIME"text/plain", C::EffectiveCartierDivisor, cov::
   I = ideal_sheaf(C)
   X = scheme(C)
 
-  println(io, "Effective cartier divisor")
+  print(io, "Effective cartier divisor")
+  if has_attribute(C, :name)
+    print(io, " ", get_attribute(C, :name))
+  end
+  println(io)
   print(io, Indent(), "on ", Lowercase())
   Oscar._show_semi_compact(io, scheme(C), cov)
   println(io, Dedent())
@@ -439,7 +439,11 @@ end
 function _show_semi_compact(io::IO, C::EffectiveCartierDivisor, cov::Covering = get_attribute(scheme(C), :simplified_covering, default_covering(scheme(C))), n::String = "")
   io = pretty(io)
   X = scheme(C)
-  println(io, "Effective cartier divisor defined by")
+  print(io, "Effective cartier divisor")
+  if has_attribute(C, :name)
+    print(io, " ", get_attribute(C, :name))
+  end
+  println(io, " defined by")
   print(io, Indent(), Lowercase())
   Oscar._show_semi_compact(io, ideal_sheaf(C), cov, n)
   print(io, Dedent())
@@ -449,6 +453,8 @@ function Base.show(io::IO, C::CartierDivisor)
   io = pretty(io)
   if get(io, :supercompact, false)
     print(io, "Cartier divisor")
+  elseif has_attribute(C, :name)
+    print(io, get_attribute(C, :name))
   else
     print(io, "Cartier divisor on ", Lowercase())
     show(io, scheme(C))
@@ -467,12 +473,16 @@ function Base.show(io::IO, ::MIME"text/plain", C::CartierDivisor, cov::Covering 
   if length(cc) == 0
     print(io, "Zero cartier divisor ")
     print(io, Indent(), "on ", Lowercase())
-    Oscar._show_semi_compact(io, scheme(C), cov)
+    show(io, scheme(C), cov)
     print(io, Dedent())
   else
-    println(io, "Cartier divisor")
+    print(io, "Cartier divisor")
+    if has_attribute(C, :name)
+      print(io, " ", get_attribute(C, :name))
+    end
+    println(io)
     print(io, Indent(), "on ", Lowercase())
-    Oscar._show_semi_compact(io, scheme(C), cov)
+    show(io, scheme(C), cov)
     println(io)
     println(io, Dedent(), "with coefficients in ", Lowercase(), coefficient_ring(C))
     print(io, "defined by the formal sum of")
@@ -482,12 +492,9 @@ function Base.show(io::IO, ::MIME"text/plain", C::CartierDivisor, cov::Covering 
     for i in 1:length(components(C))
       I = cc[i]
       kI = length(co_str[i])
-      print(io, " "^(k-kI)*"$(C[I])*")
+      print(io, " "^(k-kI)*"$(C[I]) * ")
       print(io, Lowercase())
-      Oscar._show_semi_compact(io, ideal_sheaf(I), cov)
-      if i != length(components(C))
-        println(io, "--------------------------------------------------------------------------------")
-      end
+      show(io, ideal_sheaf(I), false)
     end
     print(io, Dedent())
   end
@@ -508,14 +515,18 @@ function _show_semi_compact(io::IO, C::CartierDivisor, cov::Covering = get_attri
   if length(cc) == 0
     print(io, "Zero cartier divisor")
   else
-    println(io, "Cartier divisor defined by the formal sum of")
+    print(io, "Cartier divisor")
+    if has_attribute(C, :name)
+      print(io, " ", get_attribute(C, :name))
+    end
+    println(io, " defined by the formal sum of")
     print(io, Indent())
     co_str = String["$(C[I])" for I in cc]
     k = max(length.(co_str)...)
     for i in 1:length(components(C))
       I = cc[i]
       kI = length(co_str[i])
-      print(io, " "^(k-kI)*"$(C[I])*")
+      print(io, " "^(k-kI)*"$(C[I]) * ")
       print(io, Lowercase())
       Oscar._show_semi_compact(io, ideal_sheaf(I), cov, n)
       if i != length(components(C))

--- a/experimental/Schemes/CoherentSheaves.jl
+++ b/experimental/Schemes/CoherentSheaves.jl
@@ -45,7 +45,11 @@ function Base.show(io::IO, ::MIME"text/plain", M::AbsCoherentSheaf)
   X = scheme(M)
   cov = default_covering(X)
   D = M.ID 
-  println(io, "Coherent sheaf of modules")
+  print(io, "Coherent sheaf of modules")
+  if has_attribute(M, :name)
+    print(io, " ", get_attribute(M, :name))
+  end
+  println(io)
   print(io, Indent(), "on ", Lowercase())
   Oscar._show_semi_compact(io, X, cov)
   if length(cov) > 0
@@ -68,6 +72,8 @@ function Base.show(io::IO, M::AbsCoherentSheaf)
   io = pretty(io)
   if get(io, :supercompact, false)
     print(io, "Presheaf")
+  elseif has_attribute(M, :name)
+    print(io, get_attribute(M, :name))
   else
     if is_unicode_allowed()
       print(io, "Coherent sheaf of $(sheaf_of_rings(M))-modules on ", Lowercase(), scheme(M))
@@ -706,7 +712,7 @@ For a `ProjectiveScheme` ``ℙ`` return the ``d``-th twisting sheaf
 julia> P = projective_space(QQ,3)
 Projective space of dimension 3
   over rational field
-with homogeneous coordinates s0, s1, s2, s3
+with homogeneous coordinates [s0, s1, s2, s3]
 
 julia> twisting_sheaf(P, 4)
 Coherent sheaf of modules
@@ -767,7 +773,7 @@ For a `ProjectiveScheme` ``ℙ`` return the sheaf ``𝒪(-1)`` as a `CoherentShe
 julia> P = projective_space(QQ,3)
 Projective space of dimension 3
   over rational field
-with homogeneous coordinates s0, s1, s2, s3
+with homogeneous coordinates [s0, s1, s2, s3]
 
 julia> tautological_bundle(P)
 Coherent sheaf of modules

--- a/experimental/Schemes/IdealSheaves.jl
+++ b/experimental/Schemes/IdealSheaves.jl
@@ -32,7 +32,7 @@ julia> I = ideal([x^3-y^2*z]);
 julia> Y = projective_scheme(P)
 Projective space of dimension 2
   over rational field
-with homogeneous coordinates x, y, z
+with homogeneous coordinates [x, y, z]
 
 julia> IdealSheaf(Y, I)
 Sheaf of ideals
@@ -1008,7 +1008,7 @@ end
 ###########################################################################
 
 # If we know things about the ideal sheaf, we print them
-function Base.show(io::IO, I::IdealSheaf)
+function Base.show(io::IO, I::IdealSheaf, show_scheme::Bool = true)
   io = pretty(io)
   X = scheme(I)
   if has_attribute(I, :dim) && has_attribute(X, :dim)
@@ -1017,8 +1017,9 @@ function Base.show(io::IO, I::IdealSheaf)
     z = false
   end
   prim = get_attribute(I, :is_prime, false)
-
-  if get(io, :supercompact, false)
+  if has_attribute(I, :name)
+    print(io, get_attribute(I, :name))
+  elseif get(io, :supercompact, false)
     print(io, "Presheaf")
   else
     if get_attribute(I, :is_one, false)
@@ -1030,7 +1031,9 @@ function Base.show(io::IO, I::IdealSheaf)
     else
       print(io, "Sheaf of ideals")
     end
-    print(io," on ", Lowercase(), X)
+    if show_scheme
+      print(io," on ", Lowercase(), X)
+    end
   end
 end
 

--- a/experimental/Schemes/elliptic_surface.jl
+++ b/experimental/Schemes/elliptic_surface.jl
@@ -228,7 +228,7 @@ Elliptic surface with generic fiber -x^3 + y^2 - t^7 + 2*t^6 - t^5
 function Base.show(io::IO, S::EllipticSurface)
   io = pretty(io)
   if get(io, :supercompact, false)
-    print(io, "Elliptic surface")
+    print(io, "Scheme")
   else
     E = generic_fiber(S)
     print(io, "Elliptic surface with generic fiber ", equation(E))
@@ -246,20 +246,23 @@ julia> E = EllipticCurve(Qtf, [0,0,0,0,t^5*(t-1)^2]);
 
 julia> X3 = elliptic_surface(E, 2)
 Elliptic surface
-  with generic fiber
-    elliptic curve with equation
-        y^2 = x^3 + t^7 - 2*t^6 + t^5
+  over rational field
+with generic fiber
+  -x^3 + y^2 - t^7 + 2*t^6 - t^5
+and relatively minimal model
+  scheme over QQ covered with 45 patches
 
 ```
 """
 function Base.show(io::IO, ::MIME"text/plain", S::EllipticSurface)
   io = pretty(io)
   println(io, "Elliptic surface")
-  println(io, Indent(), "with generic fiber")
-  print(io, Indent(), Lowercase(), generic_fiber(S), Dedent())
+  println(io, Indent(), "over ", Lowercase(), base_ring(S))
+  println(io, Dedent(), "with generic fiber")
+  print(io, Indent(), Lowercase(), equation(generic_fiber(S)), Dedent())
   if isdefined(S, :Y)
-    println(io, "")
-    println(io, "with relatively minimal model")
+    println(io)
+    println(io, "and relatively minimal model")
     print(io, Indent(), Lowercase(), relatively_minimal_model(S)[1], Dedent())
   end
   print(io, Dedent())

--- a/src/AlgebraicGeometry/Schemes/AffineAlgebraicSet/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineAlgebraicSet/Objects/Attributes.jl
@@ -81,7 +81,7 @@ If `X` is constructed from an ideal `I` this returns `I`.
 julia> A2 = affine_space(QQ, [:x,:y])
 Affine space of dimension 2
   over rational field
-with coordinates x, y
+with coordinates [x, y]
 
 julia> (x, y) = coordinates(A2);
 
@@ -89,7 +89,7 @@ julia> I = ideal([x^2, y]);
 
 julia> X = algebraic_set(I)
 Affine algebraic set
-  in affine 2-space over QQ with coordinates x, y
+  in affine 2-space over QQ with coordinates [x, y]
 defined by ideal(x^2, y)
 
 julia> fat_ideal(X) === I

--- a/src/AlgebraicGeometry/Schemes/AffineAlgebraicSet/Objects/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineAlgebraicSet/Objects/Constructors.jl
@@ -26,7 +26,7 @@ julia> R, (x,y) = GF(2)[:x,:y];
 
 julia> X = algebraic_set(ideal([y^2+y+x^3+1,x]))
 Affine algebraic set
-  in affine 2-space over GF(2) with coordinates x, y
+  in affine 2-space over GF(2) with coordinates [x, y]
 defined by ideal(x^3 + y^2 + y + 1, x)
 
 ```
@@ -46,14 +46,14 @@ julia> R, (x,y) = QQ[:x,:y];
 
 julia> X = algebraic_set((y^2+y+x^3+1)*x^2)
 Affine algebraic set
-  in affine 2-space over QQ with coordinates x, y
+  in affine 2-space over QQ with coordinates [x, y]
 defined by ideal(x^5 + x^2*y^2 + x^2*y + x^2)
 
 julia> R, (x,y) = GF(2)[:x,:y];
 
 julia> X = algebraic_set((y^2+y+x^3+1)*x^2)
 Affine algebraic set
-  in affine 2-space over GF(2) with coordinates x, y
+  in affine 2-space over GF(2) with coordinates [x, y]
 defined by ideal(x^5 + x^2*y^2 + x^2*y + x^2)
 
 ```
@@ -76,7 +76,7 @@ Return the set theoretic intersection of `X` and `Y` as an algebraic set.
 julia> A = affine_space(QQ, [:x,:y])
 Affine space of dimension 2
   over rational field
-with coordinates x, y
+with coordinates [x, y]
 
 julia> (x, y) = coordinates(A)
 2-element Vector{QQMPolyRingElem}:
@@ -85,17 +85,17 @@ julia> (x, y) = coordinates(A)
 
 julia> X = algebraic_set(ideal([y - x^2]))
 Affine algebraic set
-  in affine 2-space over QQ with coordinates x, y
+  in affine 2-space over QQ with coordinates [x, y]
 defined by ideal(-x^2 + y)
 
 julia> Y = algebraic_set(ideal([y]))
 Affine algebraic set
-  in affine 2-space over QQ with coordinates x, y
+  in affine 2-space over QQ with coordinates [x, y]
 defined by ideal(y)
 
 julia> Zred = set_theoretic_intersection(X, Y)
 Affine algebraic set
-  in affine 2-space over QQ with coordinates x, y
+  in affine 2-space over QQ with coordinates [x, y]
 defined by ideal(-x^2 + y, y)
 
 

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Morphisms/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Morphisms/Attributes.jl
@@ -22,7 +22,7 @@ On a morphism ``f : X → Y`` of affine schemes, this returns ``X``.
 julia> Y = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(Y)
 Multivariate polynomial ring in 3 variables x1, x2, x3
@@ -69,7 +69,7 @@ On a morphism ``f : X → Y`` of affine schemes, this returns ``Y``.
 julia> Y = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(Y)
 Multivariate polynomial ring in 3 variables x1, x2, x3
@@ -99,7 +99,7 @@ given by the pullback function
 julia> codomain(f)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 ```
 """
 codomain(f::AbsSpecMor) = codomain(underlying_morphism(f))
@@ -116,7 +116,7 @@ On a morphism ``f : X → Y`` of affine schemes ``X = Spec(S)`` and
 julia> Y = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(Y)
 Multivariate polynomial ring in 3 variables x1, x2, x3
@@ -226,7 +226,7 @@ Return the graph of ``f : X → Y`` as a subscheme of ``X×Y`` as well as the tw
 julia> Y = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(Y)
 Multivariate polynomial ring in 3 variables x1, x2, x3
@@ -254,7 +254,7 @@ given by the pullback function
   x3 -> x3
 
 julia> graph(f)
-(Spec of quotient of multivariate polynomial ring, Morphism: spec of quotient of multivariate polynomial ring -> spec of quotient of multivariate polynomial ring, Morphism: spec of quotient of multivariate polynomial ring -> affine 3-space over QQ with coordinates x1, x2, x3)
+(Spec of quotient of multivariate polynomial ring, Morphism: spec of quotient of multivariate polynomial ring -> spec of quotient of multivariate polynomial ring, Morphism: spec of quotient of multivariate polynomial ring -> affine 3-space over QQ with coordinates [x1, x2, x3])
 ```
 """
 function graph(f::AbsSpecMor{<:AbsSpec{BRT}, <:AbsSpec{BRT}}) where {BRT}

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Morphisms/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Morphisms/Constructors.jl
@@ -20,12 +20,12 @@ Note that expensive checks can be turned off by setting `check=false`.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> Y = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> SpecMor(X, Y, gens(OO(X)))
 Morphism
@@ -80,7 +80,7 @@ This method constructs the identity morphism from an affine scheme to itself.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> identity_map(X)
 Morphism
@@ -108,7 +108,7 @@ Return the inclusion map from ``X`` to ``Y``.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(X)
 Multivariate polynomial ring in 3 variables x1, x2, x3
@@ -155,7 +155,7 @@ This method computes the composition of two morphisms.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(X)
 Multivariate polynomial ring in 3 variables x1, x2, x3
@@ -221,7 +221,7 @@ to ``U`` and its codomain to ``V``.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(X)
 Multivariate polynomial ring in 3 variables x1, x2, x3

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Morphisms/Properties.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Morphisms/Properties.jl
@@ -35,7 +35,7 @@ This method checks if a morphism is the identity map.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(X)
 Multivariate polynomial ring in 3 variables x1, x2, x3

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
@@ -15,7 +15,7 @@ On an affine scheme ``X = Spec(R)``, return the ring ``R``.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> coordinate_ring(X)
 Multivariate polynomial ring in 3 variables x1, x2, x3
@@ -27,7 +27,7 @@ We allow the shortcut `OO`
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> OO(X)
 Multivariate polynomial ring in 3 variables x1, x2, x3
@@ -67,7 +67,7 @@ its ambient affine space.
 julia> X = affine_space(QQ, [:x,:y])
 Affine space of dimension 2
   over rational field
-with coordinates x, y
+with coordinates [x, y]
 
 julia> ambient_space(X) == X
 true
@@ -207,7 +207,7 @@ Return the embedding of ``X`` in its ambient affine space.
 julia> X = affine_space(QQ, [:x,:y])
 Affine space of dimension 2
   over rational field
-with coordinates x, y
+with coordinates [x, y]
 
 julia> (x, y) = coordinates(X);
 
@@ -245,7 +245,7 @@ See also [`ambient_space(::AbsSpec)`](@ref).
 julia> X = affine_space(QQ, [:x,:y])
 Affine space of dimension 2
   over rational field
-with coordinates x, y
+with coordinates [x, y]
 
 julia> (x,y) = coordinates(X);
 
@@ -276,7 +276,7 @@ See also [`ambient_space(::AbsSpec)`](@ref).
 julia> X = affine_space(QQ, [:x,:y])
 Affine space of dimension 2
   over rational field
-with coordinates x, y
+with coordinates [x, y]
 
 julia> (x,y) = coordinates(X);
 
@@ -309,7 +309,7 @@ by the ambient affine space.
 julia> X = affine_space(QQ, [:x,:y])
 Affine space of dimension 2
   over rational field
-with coordinates x, y
+with coordinates [x, y]
 
 julia> (x, y) = coordinates(X)
 2-element Vector{QQMPolyRingElem}:
@@ -343,7 +343,7 @@ On an affine scheme ``X/𝕜`` over ``𝕜`` this returns the ring ``𝕜``.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> base_ring(X)
 Rational field
@@ -370,7 +370,7 @@ By definition, this is the Krull dimension of ``R``.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> dim(X)
 3
@@ -415,7 +415,7 @@ Throws and error if ``X`` does not have an ambient affine space.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> codim(X)
 0
@@ -457,7 +457,7 @@ This name can be specified via `set_name!`.
 julia> X = affine_space(QQ, 3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> name(X)
 "unnamed affine variety"
@@ -779,7 +779,7 @@ Return the defining ideal of the closure of ``X`` in its ambient affine space.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(X)
 Multivariate polynomial ring in 3 variables x1, x2, x3

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Constructors.jl
@@ -131,12 +131,12 @@ and so on. This choice can be overwritten with a third optional argument.
 julia> affine_space(QQ, 5)
 Affine space of dimension 5
   over rational field
-with coordinates x1, x2, x3, x4, x5
+with coordinates [x1, x2, x3, x4, x5]
 
 julia> affine_space(QQ,5,variable_name="y")
 Affine space of dimension 5
   over rational field
-with coordinates y1, y2, y3, y4, y5
+with coordinates [y1, y2, y3, y4, y5]
 ```
 """
 function affine_space(kk::BRT, n::Int; variable_name="x") where {BRT<:Ring}
@@ -157,7 +157,7 @@ The following example demonstrates this.
 julia> affine_space(QQ,[:y1,:z2,:a])
 Affine space of dimension 3
   over rational field
-with coordinates y1, z2, a
+with coordinates [y1, z2, a]
 ```
 """
 function affine_space(kk::BRT, var_symbols::Vector{Symbol}) where {BRT<:Ring}
@@ -270,7 +270,7 @@ the subscheme ``V(f_1, f_2, \dots)`` of ``X``.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(X)
 Multivariate polynomial ring in 3 variables x1, x2, x3
@@ -314,7 +314,7 @@ return the closed subscheme defined by ``I``.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(X)
 Multivariate polynomial ring in 3 variables x1, x2, x3
@@ -358,7 +358,7 @@ defined by the complement of the vanishing locus of ``f``.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(X)
 Multivariate polynomial ring in 3 variables x1, x2, x3
@@ -436,7 +436,7 @@ defined by the complement of the vanishing locus of the product ``f₁⋅f₂⋅
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(X)
 Multivariate polynomial ring in 3 variables x1, x2, x3
@@ -531,7 +531,7 @@ schemes that reside in the same ambient affine space.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(X)
 Multivariate polynomial ring in 3 variables x1, x2, x3
@@ -711,7 +711,7 @@ Return the closure of ``X`` in ``Y``.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(X)
 Multivariate polynomial ring in 3 variables x1, x2, x3

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
@@ -75,7 +75,7 @@ in the coordinate ring of an affine scheme.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> (x1, x2, x3) = gens(OO(X))
 3-element Vector{QQMPolyRingElem}:

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Properties.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Properties.jl
@@ -12,7 +12,7 @@ Check whether the affine scheme ``X`` is empty.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> isempty(X)
 false
@@ -48,7 +48,7 @@ See [`inclusion_morphism(::AbsSpec, ::AbsSpec)`](@ref) for the corresponding mor
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(X)
 Multivariate polynomial ring in 3 variables x1, x2, x3
@@ -302,7 +302,7 @@ Checks whether ``X`` is openly embedded in ``Y``.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(X)
 Multivariate polynomial ring in 3 variables x1, x2, x3
@@ -376,7 +376,7 @@ Checks whether ``X`` is closed embedded in ``Y``.
 julia> X = affine_space(QQ,3)
 Affine space of dimension 3
   over rational field
-with coordinates x1, x2, x3
+with coordinates [x1, x2, x3]
 
 julia> R = OO(X)
 Multivariate polynomial ring in 3 variables x1, x2, x3

--- a/src/AlgebraicGeometry/Schemes/AffineVariety/Objects/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineVariety/Objects/Constructors.jl
@@ -32,7 +32,7 @@ julia> R, (x,y) = QQ[:x,:y]
 
 julia> variety(ideal([x,y]))
 Affine variety
-  in affine 2-space over QQ with coordinates x, y
+  in affine 2-space over QQ with coordinates [x, y]
 defined by defined by ideal(x, y)
 
 ```
@@ -44,7 +44,7 @@ julia> R, (x,y) = GF(2)[:x,:y];
 
 julia> variety(x^3+y+1, check=false)
 Affine variety
-  in affine 2-space over GF(2) with coordinates x, y
+  in affine 2-space over GF(2) with coordinates [x, y]
 defined by defined by ideal(x^3 + y + 1)
 
 ```
@@ -71,7 +71,7 @@ julia> Q,_ = quo(R,ideal([x,y]));
 
 julia> variety(Q)
 Affine variety
-  in affine 2-space over QQ with coordinates x, y
+  in affine 2-space over QQ with coordinates [x, y]
 defined by defined by ideal(x, y)
 
 ```
@@ -89,13 +89,13 @@ This checks that `f` is irreducible over the algebraic closure.
 julia> A2 = affine_space(QQ,[:x,:y])
 Affine space of dimension 2
   over rational field
-with coordinates x, y
+with coordinates [x, y]
 
 julia> (x,y) = coordinates(A2);
 
 julia> variety(y^2-x^3-1)
 Affine variety
-  in affine 2-space over QQ with coordinates x, y
+  in affine 2-space over QQ with coordinates [x, y]
 defined by defined by ideal(-x^3 + y^2 - 1)
 
 ```

--- a/src/AlgebraicGeometry/Schemes/AffineVariety/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineVariety/Objects/Methods.jl
@@ -72,8 +72,8 @@ function Base.show(io::IO, ::MIME"text/plain", X::AffineVariety{<:Field,<:MPolyR
   println(io, Lowercase(), base_ring(X))
   print(io, Dedent(), "with coordinate")
   length(coordinates(X)) > 1 && print(io, "s")
-  print(io, " ")
-  print(io, join(coordinates(X), ", "))
+  print(io, " [")
+  print(io, join(coordinates(X), ", "), "]")
 end
 
 # In a more compact printing, we allow unicode printing, whenever unicode is
@@ -116,8 +116,8 @@ function Base.show(io::IO, X::AffineVariety{<:Field, <:MPolyRing}, show_coord::B
         c = coordinates(X)
         print(io, " with coordinate")
         length(c) > 1 && print(io, "s")
-        print(io, " ")
-        print(io, join(c, ", "))
+        print(io, " [")
+        print(io, join(c, ", "), "]")
       end
     else
       print(io, "Affine $(dim(X))-space over ")
@@ -130,8 +130,8 @@ function Base.show(io::IO, X::AffineVariety{<:Field, <:MPolyRing}, show_coord::B
         c = coordinates(X)
         print(io, " with coordinate")
         length(c) > 1 && print(io, "s")
-        print(io, " ")
-        print(io, join(c, ", "))
+        print(io, " [")
+        print(io, join(c, ", "), "]")
       end
     end
   end

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Morphisms/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Morphisms/Attributes.jl
@@ -23,7 +23,7 @@ julia> P, (x, y, z) = graded_polynomial_ring(QQ, [:x, :y, :z]);
 
 julia> Y = variety(ideal([x^3-y^2*z]))
 Projective variety
-  in projective 2-space over QQ with coordinates x, y, z
+  in projective 2-space over QQ with coordinates [x, y, z]
 defined by ideal(x^3 - y^2*z)
 
 julia> Ycov = covered_scheme(Y)

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Morphisms/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Morphisms/Constructors.jl
@@ -16,7 +16,7 @@ julia> P, x = graded_polynomial_ring(QQ, [:x, :y, :z]);
 
 julia> X = variety(ideal(x[1:2]))
 Projective variety
-  in projective 2-space over QQ with coordinates x, y, z
+  in projective 2-space over QQ with coordinates [x, y, z]
 defined by ideal(y, x)
 
 julia> Xcov = covered_scheme(X)

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Attributes.jl
@@ -215,7 +215,7 @@ julia> P, (x, y, z) = graded_polynomial_ring(QQ, [:x, :y, :z]);
 
 julia> Y = variety(ideal([x^3-y^2*z]))
 Projective variety
-  in projective 2-space over QQ with coordinates x, y, z
+  in projective 2-space over QQ with coordinates [x, y, z]
 defined by ideal(x^3 - y^2*z)
 
 julia> Ycov = covered_scheme(Y)

--- a/src/AlgebraicGeometry/Schemes/ProjectiveAlgebraicSet/Objects/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveAlgebraicSet/Objects/Constructors.jl
@@ -19,7 +19,7 @@ defined by ideal(x0*x1^2, x2)
 
 julia> Y = algebraic_set(X)
 Algebraic set
-  in projective 2-space over QQ with coordinates x0, x1, x2
+  in projective 2-space over QQ with coordinates [x0, x1, x2]
 defined by ideal(x2, x0*x1)
 
 ```
@@ -38,7 +38,7 @@ julia> P,(x0,x1) = graded_polynomial_ring(QQ,[:x0,:x1]);
 
 julia> algebraic_set(ideal([x0,x1]))
 Algebraic set
-  in projective 1-space over QQ with coordinates x0, x1
+  in projective 1-space over QQ with coordinates [x0, x1]
 defined by ideal(x1, x0)
 
 ```
@@ -91,13 +91,13 @@ Note that even if ``X`` is irreducible, there may be several geometrically irred
 julia> P1 = projective_space(QQ,1)
 Projective space of dimension 1
   over rational field
-with homogeneous coordinates s0, s1
+with homogeneous coordinates [s0, s1]
 
 julia> (s0,s1) = homogeneous_coordinates(P1);
 
 julia> X = algebraic_set((s0^2+s1^2)*s1)
 Algebraic set
-  in projective 1-space over QQ with coordinates s0, s1
+  in projective 1-space over QQ with coordinates [s0, s1]
 defined by ideal(s0^2*s1 + s1^3)
 
 julia> (X1,X2) = irreducible_components(X)
@@ -107,7 +107,7 @@ julia> (X1,X2) = irreducible_components(X)
 
 julia> X1  # irreducible but not geometrically irreducible
 Algebraic set
-  in projective 1-space over QQ with coordinates s0, s1
+  in projective 1-space over QQ with coordinates [s0, s1]
 defined by ideal(s0^2 + s1^2)
 
 ```

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl
@@ -141,7 +141,7 @@ defined by ideal(x + y)
 julia> P = ambient_space(X)
 Projective space of dimension 2
   over rational field
-with homogeneous coordinates x, y, z
+with homogeneous coordinates [x, y, z]
 ```
 """
 @attr function ambient_space(X::AbsProjectiveScheme)
@@ -222,7 +222,7 @@ julia> S, _ = grade(Q["x", "y", "z"][1]);
 julia> P = projective_scheme(S)
 Projective space of dimension 2
   over quotient of multivariate polynomial ring by ideal with 1 generator
-with homogeneous coordinates x, y, z
+with homogeneous coordinates [x, y, z]
 
 julia> defining_ideal(P)
 ideal()
@@ -258,7 +258,7 @@ julia> S, _ = grade(Q["x", "y", "z"][1]);
 julia> P = projective_scheme(S)
 Projective space of dimension 2
   over quotient of multivariate polynomial ring by ideal with 1 generator
-with homogeneous coordinates x, y, z
+with homogeneous coordinates [x, y, z]
 
 julia> affine_cone(P)
 (Spec of quotient of multivariate polynomial ring, Map with following data
@@ -387,7 +387,7 @@ julia> S, _ = grade(Q["x", "y", "z"][1]);
 julia> P = projective_scheme(S)
 Projective space of dimension 2
   over quotient of multivariate polynomial ring by ideal with 1 generator
-with homogeneous coordinates x, y, z
+with homogeneous coordinates [x, y, z]
 
 julia> homogeneous_coordinates_on_affine_cone(P)
 3-element Vector{MPolyQuoRingElem{QQMPolyRingElem}}:

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Constructors.jl
@@ -70,7 +70,7 @@ where `x₀,…,xₙ` is a list of variable names.
 julia> projective_space(QQ, [:x, :PPP, :?])
 Projective space of dimension 2
   over rational field
-with homogeneous coordinates x, PPP, ?
+with homogeneous coordinates [x, PPP, ?]
 
 julia> homogeneous_coordinate_ring(ans)
 Multivariate polynomial ring in 3 variables over QQ graded by

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
@@ -35,8 +35,8 @@ function Base.show(io::IO, ::MIME"text/plain", P::AbsProjectiveScheme{<:Any, <:M
   println(io, Lowercase(), base_ring(P))
   print(io, Dedent(), "with homogeneous coordinate")
   length(homogeneous_coordinates(P)) > 1 && print(io, "s")
-  print(io, " ")
-  print(io, join(homogeneous_coordinates(P), ", "))
+  print(io, " [")
+  print(io, join(homogeneous_coordinates(P), ", "), "]")
 end
 
 function Base.show(io::IO, P::AbsProjectiveScheme{<:Any, <:MPolyDecRing})
@@ -80,8 +80,8 @@ function Base.show(io::IO, P::AbsProjectiveScheme{<:Any, <:MPolyDecRing})
       c = homogeneous_coordinates(P)
       print(io, " with coordinate")
       length(c) > 1 && print(io, "s")
-      print(io, " ")
-      print(io, join(c, ", "))
+      print(io, " [")
+      print(io, join(c, ", "), "]")
     end
   end
 end
@@ -97,7 +97,7 @@ Return the restriction morphism from the graded coordinate ring of ``X`` to `ð’
 julia> P = projective_space(QQ, ["x0", "x1", "x2"])
 Projective space of dimension 2
   over rational field
-with homogeneous coordinates x0, x1, x2
+with homogeneous coordinates [x0, x1, x2]
 
 julia> X = covered_scheme(P);
 
@@ -210,7 +210,7 @@ julia> A, _ = QQ["u", "v"];
 julia> P = projective_space(A, ["x0", "x1", "x2"])
 Projective space of dimension 2
   over multivariate polynomial ring in 2 variables over QQ
-with homogeneous coordinates x0, x1, x2
+with homogeneous coordinates [x0, x1, x2]
 
 julia> X = covered_scheme(P)
 Scheme

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Types.jl
@@ -19,7 +19,7 @@ julia> Sgr, _ = grade(S);
 julia> P = ProjectiveScheme(Sgr)
 Projective space of dimension 2
   over rational field
-with homogeneous coordinates x, y, z
+with homogeneous coordinates [x, y, z]
 
 julia> (x, y, z) = gens(Sgr);
 

--- a/src/AlgebraicGeometry/Schemes/ProjectiveVariety/Objects/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveVariety/Objects/Constructors.jl
@@ -26,13 +26,13 @@ Note that the ideal ``I`` must live in a standard graded ring.
 julia> P3 = projective_space(QQ,3)
 Projective space of dimension 3
   over rational field
-with homogeneous coordinates s0, s1, s2, s3
+with homogeneous coordinates [s0, s1, s2, s3]
 
 julia> (s0,s1,s2,s3) = homogeneous_coordinates(P3);
 
 julia> X = variety(s0^3 + s1^3 + s2^3 + s3^3)
 Projective variety
-  in projective 3-space over QQ with coordinates s0, s1, s2, s3
+  in projective 3-space over QQ with coordinates [s0, s1, s2, s3]
 defined by ideal(s0^3 + s1^3 + s2^3 + s3^3)
 
 julia> dim(X)
@@ -40,7 +40,7 @@ julia> dim(X)
 
 julia> Y = variety(ideal([s0^3 + s1^3 + s2^3 + s3^3, s0]))
 Projective variety
-  in projective 3-space over QQ with coordinates s0, s1, s2, s3
+  in projective 3-space over QQ with coordinates [s0, s1, s2, s3]
 defined by ideal(s0, s1^3 + s2^3 + s3^3)
 
 julia> dim(Y)

--- a/src/AlgebraicGeometry/Schemes/SpecOpen/Objects/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/SpecOpen/Objects/Constructors.jl
@@ -116,7 +116,7 @@ SpecOpen(X::AbsSpec) = SpecOpen(X, [one(ambient_coordinate_ring(X))], check=fals
 Given a Zariski open subset `U` of an affine scheme `X`, complement to
 a subscheme `Y` of `X`, and given an affine scheme `Z`, return the product
 scheme $V := U \times Z$ as a Zariski open subset of the affine scheme
-$X\times Z$ complement to the closed subschme $Y\times Z$.
+$X\times Z$ complement to the closed subscheme $Y\times Z$.
 
 It is returned with the two product maps $U \to V$ and $Z \to V$.
 
@@ -153,7 +153,7 @@ julia> V, iU, iZ = product(U2, Y1)
 
 julia> V
 Open subset
-  of affine 6-space over QQ with coordinates x2, y2, z2, x1, y1, z1
+  of affine 6-space over QQ with coordinates [x2, y2, z2, x1, y1, z1]
 complement to V(x2^2 - y2^2 + z2^2)
 
 julia> iU

--- a/src/AlgebraicGeometry/Schemes/SpecOpen/Rings/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/SpecOpen/Rings/Constructors.jl
@@ -43,7 +43,7 @@ Regular function
   covered by 1 affine patch
     1: [x, y, z]   spec of localized ring
 with restriction
-  1: 1
+  pacth 1: 1
 ```
 """
 function OO(U::SpecOpen) 

--- a/src/AlgebraicGeometry/Schemes/SpecOpen/Rings/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/SpecOpen/Rings/Constructors.jl
@@ -43,7 +43,7 @@ Regular function
   covered by 1 affine patch
     1: [x, y, z]   spec of localized ring
 with restriction
-  pacth 1: 1
+  patch 1: 1
 ```
 """
 function OO(U::SpecOpen) 

--- a/src/AlgebraicGeometry/Schemes/SpecOpen/Rings/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/SpecOpen/Rings/Methods.jl
@@ -495,7 +495,7 @@ function Base.show(io::IO, ::MIME"text/plain", a::SpecOpenRingElem)
     for i in 1:length(r)
       li = ndigits(i)
       println(io)
-      print(io, "pacth", " "^(l-li+1)*"$(i): ", r[i])
+      print(io, "patch", " "^(l-li+1)*"$(i): ", r[i])
     end
     print(io, Dedent())
   end

--- a/src/AlgebraicGeometry/Schemes/SpecOpen/Rings/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/SpecOpen/Rings/Methods.jl
@@ -495,7 +495,7 @@ function Base.show(io::IO, ::MIME"text/plain", a::SpecOpenRingElem)
     for i in 1:length(r)
       li = ndigits(i)
       println(io)
-      print(io, " "^(l-li)*"$(i): ", r[i])
+      print(io, "pacth", " "^(l-li+1)*"$(i): ", r[i])
     end
     print(io, Dedent())
   end


### PR DESCRIPTION
* Re-work of the printing for divisors and cycles by taking off the charts details and the expansion of the ideal sheaves
* New printing for `EllipticSurface`
* Fix a typo
* Put coordinates and homogeneous coordinates in brackets for affine/projective spaces compact printing
* Put more comments on the function `is_prime(D::WeilDivisor)`
* Change the doctests accordingly
* Allow more `name` printings if known
* Fix on the "non-satisfying" printing for `SpecOpenRingElem`