### PR TITLE
Fix formatting error in docstring note

### DIFF
--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -1273,9 +1273,10 @@ return the degree of the homogenization of `I` with respect to the
 standard-grading.
 
 !!! note
-Geometrically, the degree of a homogeneous ideal as above is the number of
-intersection points of its projective variety with a generic linear subspace
-of complementary dimension (counted with multiplicities). See also [MS21](@cite).
+    Geometrically, the degree of a homogeneous ideal as above is the number
+    of intersection points of its projective variety with a generic linear
+    subspace of complementary dimension (counted with multiplicities).
+    See also [MS21](@cite).
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
There is a formatting error in the docstring `!!! note` from #2493 causing the note to be rendered outside of the note box, see https://docs.oscar-system.org/dev/CommutativeAlgebra/ideals/#Degree