### PR TITLE
Fix printing for `EllipticSurface`

### DIFF
--- a/experimental/Schemes/elliptic_surface.jl
+++ b/experimental/Schemes/elliptic_surface.jl
@@ -47,10 +47,32 @@ For now functionality is restricted to $C = \mathbb{P}^1$.
 
 end
 
+base_ring(X::EllipticSurface) = coefficient_ring(base_ring(base_field(generic_fiber(X))))
+
 @doc raw"""
     elliptic_surface(generic_fiber::EllCrv, euler_characteristic::Int, mwl_basis::Vector{<:EllCrvPt}=EllCrvPt[]) -> EllipticSurface
 
 Return the relatively minimal elliptic surface with generic fiber ``E/k(t)``.
+
+# Examples
+```
+julia> Qt, t = polynomial_ring(QQ, :t);
+
+julia> Qtf = fraction_field(Qt);
+
+julia> E = EllipticCurve(Qtf, [0,0,0,0,t^5*(t-1)^2]);
+
+julia> X3 = elliptic_surface(E, 2)
+Elliptic surface
+  over rational field
+with generic fiber
+  -x^3 + y^2 - t^7 + 2*t^6 - t^5
+and relatively minimal model
+  scheme over QQ covered with 45 patches
+
+julia> Base.show(stdout, X3)
+Elliptic surface with generic fiber -x^3 + y^2 - t^7 + 2*t^6 - t^5
+```
 """
 function elliptic_surface(generic_fiber::EllCrv{BaseField}, euler_characteristic::Int,
                           mwl_basis::Vector{<:EllCrvPt}=EllCrvPt[]) where {
@@ -208,23 +230,6 @@ Return the torsion part of the Mordell-Weil group of the generic fiber of ``S``.
   return tors
 end
 
-@doc raw"""
-
-#Examples
-```jldoctest
-julia> Qt, t = polynomial_ring(QQ, :t);
-
-julia> Qtf = fraction_field(Qt);
-
-julia> E = EllipticCurve(Qtf, [0,0,0,0,t^5*(t-1)^2]);
-
-julia> X3 = elliptic_surface(E, 2);
-
-julia> Base.show(stdout, X3)
-Elliptic surface with generic fiber -x^3 + y^2 - t^7 + 2*t^6 - t^5
-
-```
-"""
 function Base.show(io::IO, S::EllipticSurface)
   io = pretty(io)
   if get(io, :supercompact, false)
@@ -235,25 +240,6 @@ function Base.show(io::IO, S::EllipticSurface)
   end
 end
 
-@doc raw"""
-#Examples
-```jldoctest
-julia> Qt, t = polynomial_ring(QQ, :t);
-
-julia> Qtf = fraction_field(Qt);
-
-julia> E = EllipticCurve(Qtf, [0,0,0,0,t^5*(t-1)^2]);
-
-julia> X3 = elliptic_surface(E, 2)
-Elliptic surface
-  over rational field
-with generic fiber
-  -x^3 + y^2 - t^7 + 2*t^6 - t^5
-and relatively minimal model
-  scheme over QQ covered with 45 patches
-
-```
-"""
 function Base.show(io::IO, ::MIME"text/plain", S::EllipticSurface)
   io = pretty(io)
   println(io, "Elliptic surface")
@@ -263,7 +249,7 @@ function Base.show(io::IO, ::MIME"text/plain", S::EllipticSurface)
   if isdefined(S, :Y)
     println(io)
     println(io, "and relatively minimal model")
-    print(io, Indent(), Lowercase(), relatively_minimal_model(S)[1], Dedent())
+    print(io, Indent(), Lowercase(), S.Y, Dedent())
   end
   print(io, Dedent())
 end

--- a/experimental/Schemes/elliptic_surface.jl
+++ b/experimental/Schemes/elliptic_surface.jl
@@ -55,7 +55,7 @@ base_ring(X::EllipticSurface) = coefficient_ring(base_ring(base_field(generic_fi
 Return the relatively minimal elliptic surface with generic fiber ``E/k(t)``.
 
 # Examples
-```
+```jldoctest
 julia> Qt, t = polynomial_ring(QQ, :t);
 
 julia> Qtf = fraction_field(Qt);

--- a/experimental/Schemes/elliptic_surface.jl
+++ b/experimental/Schemes/elliptic_surface.jl
@@ -67,8 +67,6 @@ Elliptic surface
   over rational field
 with generic fiber
   -x^3 + y^2 - t^7 + 2*t^6 - t^5
-and relatively minimal model
-  scheme over QQ covered with 45 patches
 
 julia> Base.show(stdout, X3)
 Elliptic surface with generic fiber -x^3 + y^2 - t^7 + 2*t^6 - t^5


### PR DESCRIPTION
A mistake of mine, I have not checked that `base_ring` was calling `underlying_scheme` which is in general expensive to compute for elliptic surfaces. Same with the access to the relatively minimal model: the way I wrote it, I was not accessing the relatively minimal model already computed, but I was asking to compute it again.

This should resolve #2584, @benlorenz  I also moved the doctest.

```
julia> Qt, t = QQ["t"];

julia> Qtf = fraction_field(Qt);

julia> E = EllipticCurve(Qtf, [0,0,0,0,t^5*(t-1)^2]);

julia> X3 = elliptic_surface(E,2);

julia> @time base_ring(X3)
  0.015081 seconds (2.63 k allocations: 157.180 KiB, 98.94% compilation time)
Rational field

julia> @time base_ring(X3)
  0.000013 seconds
Rational field

julia> @time Base.show(stdout, MIME"text/plain"(), X3)
Elliptic surface
  over rational field
with generic fiber
  -x^3 + y^2 - t^7 + 2*t^6 - t^5  0.240701 seconds (296.77 k allocations: 15.725 MiB, 99.66% compilation time)
0

julia> @time Base.show(stdout, MIME"text/plain"(), X3)
Elliptic surface
  over rational field
with generic fiber
  -x^3 + y^2 - t^7 + 2*t^6 - t^5  0.000507 seconds (667 allocations: 32.042 KiB)
0

```