### PR TITLE
Bump `DocumenterCitations` to `v1.0.0`

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 
 [compat]
-DocumenterCitations = "0.2.5"
+DocumenterCitations = "1.0.0"

--- a/docs/citation_style.jl
+++ b/docs/citation_style.jl
@@ -1,0 +1,44 @@
+#
+# This file is included by docs/make_work.jl to define the custom citation style `oscar_style`.
+#
+# It is heavily based upon
+# https://juliadocs.org/DocumenterCitations.jl/v1.0.0/gallery/#Custom-style:-Citation-key-labels
+#
+
+import DocumenterCitations
+
+# we use some (undocumented) internal helper functions for formatting...
+using DocumenterCitations: format_names, tex2unicode, italicize_md_et_al
+
+const oscar_style = :oscar
+
+# The long reference string in the bibliography
+function DocumenterCitations.format_bibliography_reference(::Val{oscar_style}, entry)
+  return DocumenterCitations.format_bibliography_reference(:numeric, entry)
+end
+
+# The label in the bibliography
+function DocumenterCitations.format_bibliography_label(::Val{oscar_style}, entry, citations)
+  return "[$(entry.id)]"
+end
+
+# The order of entries in the bibliography
+DocumenterCitations.bib_sorting(::Val{oscar_style}) = :nyt  # name, year, title
+
+# The type of html tag to use for the bibliography
+DocumenterCitations.bib_html_list_style(::Val{oscar_style}) = :dl
+
+function DocumenterCitations.format_citation(
+  ::Val{oscar_style}, entry, citations; note, cite_cmd, capitalize, starred
+)
+  link_text = isnothing(note) ? "[$(entry.id)]" : "[$(entry.id), $note]"
+  if cite_cmd == :citet
+    et_al = starred ? 0 : 1  # 0: no "et al."; 1: "et al." after 1st author
+    names = tex2unicode(
+      format_names(entry; names=:lastonly, and=true, et_al, et_al_text="*et al.*")
+    )
+    capitalize && (names = uppercasefirst(names))
+    link_text = italicize_md_et_al("$names $link_text")
+  end
+  return link_text
+end

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -133,7 +133,7 @@ function doit(
 
   # Load the bibliography
   bib = CitationBibliography(
-    joinpath(Oscar.oscardir, "docs", "oscar_references.bib"); sorting=:nyt
+    joinpath(Oscar.oscardir, "docs", "oscar_references.bib"); style=:alpha
   )
 
   # Copy documentation from Hecke, Nemo, AnstratAlgebra

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -6,6 +6,8 @@ module BuildDoc
 
 using Documenter, DocumenterCitations
 
+include("citation_style.jl")
+
 # Overwrite printing to make the header not full of redundant nonsense
 # Turns
 #   Hecke.Order - Method
@@ -133,7 +135,7 @@ function doit(
 
   # Load the bibliography
   bib = CitationBibliography(
-    joinpath(Oscar.oscardir, "docs", "oscar_references.bib"); style=:alpha
+    joinpath(Oscar.oscardir, "docs", "oscar_references.bib"); style=oscar_style
   )
 
   # Copy documentation from Hecke, Nemo, AnstratAlgebra

--- a/docs/src/Combinatorics/partitions.md
+++ b/docs/src/Combinatorics/partitions.md
@@ -23,8 +23,8 @@ num_partitions(::Oscar.IntegerUnion)
 > How many ways are there to pay one euro, using coins worth 1, 2, 5, 10, 20, 50, and/or 100
 > cents? What if you are allowed to use at most two of each coin? 
 
-This is Exercise 11 in [Knu11](@ref), Section 7.2.1.4 (page 408). It goes back to the famous
-"Ways to change one dollar" problem, see [Pol56](@ref). Generally, the problem is to
+This is Exercise 11 in [Knu11](@cite), Section 7.2.1.4 (page 408). It goes back to the famous
+"Ways to change one dollar" problem, see [Pol56](@cite). Generally, the problem is to
 generate and/or count partitions satisfying some restrictions. Of course, one could generate
 the list of all partitions of 100 (there are about 190 million) and then filter the result
 by the restrictions. But for certain types of restrictions there are much more efficient


### PR DESCRIPTION
WIP

DocumenterCitations (the package that we use for references in the documentation) has received a major update including some breaking changes and a lot of new fancy stuff.
I will first try to get it to work exactly like it does currently with the old version and then try to nice things up.