### PR TITLE
Bump `DocumenterCitations` to `v1.0.0`

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 
 [compat]
-DocumenterCitations = "0.2.5"
+DocumenterCitations = "1.0.0"

--- a/docs/citation_style.jl
+++ b/docs/citation_style.jl
@@ -1,0 +1,44 @@
+#
+# This file is included by docs/make_work.jl to define the custom citation style `oscar_style`.
+#
+# It is heavily based upon
+# https://juliadocs.org/DocumenterCitations.jl/v1.0.0/gallery/#Custom-style:-Citation-key-labels
+#
+
+import DocumenterCitations
+
+# we use some (undocumented) internal helper functions for formatting...
+using DocumenterCitations: format_names, tex2unicode, italicize_md_et_al
+
+const oscar_style = :oscar
+
+# The long reference string in the bibliography
+function DocumenterCitations.format_bibliography_reference(::Val{oscar_style}, entry)
+  return DocumenterCitations.format_bibliography_reference(:numeric, entry)
+end
+
+# The label in the bibliography
+function DocumenterCitations.format_bibliography_label(::Val{oscar_style}, entry, citations)
+  return "[$(entry.id)]"
+end
+
+# The order of entries in the bibliography
+DocumenterCitations.bib_sorting(::Val{oscar_style}) = :nyt  # name, year, title
+
+# The type of html tag to use for the bibliography
+DocumenterCitations.bib_html_list_style(::Val{oscar_style}) = :dl
+
+function DocumenterCitations.format_citation(
+  ::Val{oscar_style}, entry, citations; note, cite_cmd, capitalize, starred
+)
+  link_text = isnothing(note) ? "[$(entry.id)]" : "[$(entry.id), $note]"
+  if cite_cmd == :citet
+    et_al = starred ? 0 : 1  # 0: no "et al."; 1: "et al." after 1st author
+    names = tex2unicode(
+      format_names(entry; names=:lastonly, and=true, et_al, et_al_text="*et al.*")
+    )
+    capitalize && (names = uppercasefirst(names))
+    link_text = italicize_md_et_al("$names $link_text")
+  end
+  return link_text
+end

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -133,7 +133,7 @@ function doit(
 
   # Load the bibliography
   bib = CitationBibliography(
-    joinpath(Oscar.oscardir, "docs", "oscar_references.bib"); sorting=:nyt
+    joinpath(Oscar.oscardir, "docs", "oscar_references.bib"); style=:alpha
   )
 
   # Copy documentation from Hecke, Nemo, AnstratAlgebra

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -6,6 +6,8 @@ module BuildDoc
 
 using Documenter, DocumenterCitations
 
+include("citation_style.jl")
+
 # Overwrite printing to make the header not full of redundant nonsense
 # Turns
 #   Hecke.Order - Method
@@ -133,7 +135,7 @@ function doit(
 
   # Load the bibliography
   bib = CitationBibliography(
-    joinpath(Oscar.oscardir, "docs", "oscar_references.bib"); style=:alpha
+    joinpath(Oscar.oscardir, "docs", "oscar_references.bib"); style=oscar_style
   )
 
   # Copy documentation from Hecke, Nemo, AnstratAlgebra

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -36,7 +36,7 @@
 @Misc{Aut00,
   author        = {{A}uthors, {T}he {S}tacks {P}roject},
   title         = {{S}tacks {P}roject},
-  year          = {0000},
+  howpublished  = {Published electronically},
   url           = {https://stacks.math.columbia.edu/}
 }
 
@@ -101,12 +101,15 @@
   location      = {Virtual Event, Russian Federation}
 }
 
-@Misc{BES19,
+@Article{BES19,
   author        = {Backman, Spencer and Eur, Christopher and Simpson, Connor},
   title         = {Simplicial generation of Chow rings of matroids},
   publisher     = {arXiv},
   year          = {2019},
-  doi           = {10.48550/ARXIV.1905.07114},
+  eprint        = {1905.07114},
+  archiveprefix = {arXiv},
+  primaryclass  = {math.CO},
+  doi           = {10.48550/arxiv.1905.07114},
   url           = {https://arxiv.org/abs/1905.07114}
 }
 
@@ -144,12 +147,15 @@
   doi           = {10.1017/fms.2023.50}
 }
 
-@Misc{BHMPW20,
+@Article{BHMPW20,
   author        = {Braden, Tom and Huh, June and Matherne, Jacob P. and Proudfoot, Nicholas and Wang, Botong},
   title         = {A semi-small decomposition of the Chow ring of a matroid},
   publisher     = {arXiv},
   year          = {2020},
-  doi           = {10.48550/ARXIV.2002.03341},
+  eprint        = {2002.03341},
+  archiveprefix = {arXiv},
+  primaryclass  = {math.AG},
+  doi           = {10.48550/arXiv.2002.03341},
   url           = {https://arxiv.org/abs/2002.03341}
 }
 
@@ -172,6 +178,7 @@
   title         = {cohomCalg package},
   note          = {High-performance line bundle cohomology computation based on BJRR10},
   year          = {2010},
+  howpublished  = {Published electronically on GitHub},
   url           = {https://github.com/BenjaminJurke/cohomCalg}
 }
 
@@ -406,12 +413,15 @@
   zbmath        = {404355}
 }
 
-@Misc{DF20,
+@Article{DF20,
   bibkey        = {{DF20}},
   author        = {De Franceschi, G.},
   title         = {Centralizers and conjugacy classes in finite classical groups},
-  year          = 2020,
-  doi           = {10.48550/ARXIV.2008.12651},
+  year          = {2020},
+  eprint        = {2008.12651},
+  archiveprefix = {arXiv},
+  primaryclass  = {math.GR},
+  doi           = {10.48550/arXiv.2008.12651},
   url           = {https://arxiv.org/abs/2008.12651}
 }
 
@@ -841,7 +851,8 @@
 @Misc{Gat18,
   author        = {Gathmann, Andreas},
   title         = {Class notes „Plane Algebraic Curves” (SS 2018)},
-  year          = 2018,
+  year          = {2018},
+  howpublished  = {Published electronically},
   url           = {https://www.mathematik.uni-kl.de/~gathmann/en/curves.php}
 }
 
@@ -1081,10 +1092,14 @@
   reportnumber  = {UCSB-MATH-2011-09, IPMU11-0107, NSF-KITP-11-110, KCL-MTH-11-13}
 }
 
-@Misc{KO14,
-  author        = {Kelleher, J. and O'Sullivan, B.},
+@Article{KO14,
+  author        = {Kelleher, Jerome and O'Sullivan, Barry},
   title         = {Generating All Partitions: A Comparison Of Two Encodings},
   year          = {2014},
+  eprint        = {0909.2331},
+  archiveprefix = {arXiv},
+  primaryclass  = {cs.DS},
+  doi           = {10.48550/arXiv.0909.2331},
   url           = {https://arxiv.org/abs/0909.2331}
 }
 
@@ -1147,12 +1162,15 @@
   url           = {https://doi.org/10.1006/jsco.1998.0247}
 }
 
-@Misc{Kin07,
+@Article{Kin07,
   author        = {King, Simon},
   title         = {Fast computation of secondary invariants},
-  howpublished  = {arXiv:math/0701270},
   year          = {2007},
-  doi           = {10.48550/arXiv.math/0701270}
+  eprint        = {math/0701270},
+  archiveprefix = {arXiv},
+  primaryclass  = {math.AC},
+  doi           = {10.48550/arXiv.math/0701270},
+  url           = {https://arxiv.org/abs/math/0701270}
 }
 
 @Article{Kin13,
@@ -1316,7 +1334,8 @@
   bibkey        = {OEIS},
   author        = {OEIS Foundation Inc.},
   title         = {The {O}n-{L}ine {E}ncyclopedia of {I}nteger {S}equences},
-  note          = {Published electronically at \url{http://oeis.org}},
+  howpublished  = {Published electronically at http://oeis.org},
+  url           = {http://oeis.org},
   year          = {2023}
 }
 
@@ -1573,6 +1592,7 @@
   author        = {Wilson, R. A. and Walsh, P. and Tripp, J. and Suleiman, I. and Parker, R. A. and Norton, S. P. and
                   Nickerson, S. and Linton, S. and Bray, J. and Abbott, R.},
   title         = {ATLAS of Finite Group Representations},
+  howpublished  = {Published electronically},
   url           = {http://atlas.math.rwth-aachen.de/Atlas/v3}
 }
 

--- a/docs/src/Combinatorics/partitions.md
+++ b/docs/src/Combinatorics/partitions.md
@@ -23,8 +23,8 @@ num_partitions(::Oscar.IntegerUnion)
 > How many ways are there to pay one euro, using coins worth 1, 2, 5, 10, 20, 50, and/or 100
 > cents? What if you are allowed to use at most two of each coin? 
 
-This is Exercise 11 in [Knu11](@ref), Section 7.2.1.4 (page 408). It goes back to the famous
-"Ways to change one dollar" problem, see [Pol56](@ref). Generally, the problem is to
+This is Exercise 11 in [Knu11](@cite), Section 7.2.1.4 (page 408). It goes back to the famous
+"Ways to change one dollar" problem, see [Pol56](@cite). Generally, the problem is to
 generate and/or count partitions satisfying some restrictions. Of course, one could generate
 the list of all partitions of 100 (there are about 190 million) and then filter the result
 by the restrictions. But for certain types of restrictions there are much more efficient

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -14,4 +14,5 @@ margin-bottom: 0.75em;
 </style>
 ```
 ```@bibliography
+*
 ```


### PR DESCRIPTION
(Follow-up to https://github.com/oscar-system/Oscar.jl/pull/2598 being broken somehow)

DocumenterCitations (the package that we use for references in the documentation) has received a major update including some breaking changes and a lot of new fancy stuff.
I will first try to get it to work exactly like it does currently with the old version and then try to nice things up.