### PR TITLE
Bump `DocumenterCitations` to `v1.0.0`

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,5 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 
 [compat]
+Documenter = "0.27.0"
 DocumenterCitations = "1.0.0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,4 +4,4 @@ DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 
 [compat]
 Documenter = "0.27.0"
-DocumenterCitations = "1.0.0"
+DocumenterCitations = "1.1.0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,4 +4,4 @@ DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 
 [compat]
 Documenter = "0.27.0"
-DocumenterCitations = "1.1.0"
+DocumenterCitations = "~1.1, ~1.2"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 
 [compat]
-DocumenterCitations = "0.2.5"
+DocumenterCitations = "1.0.0"

--- a/docs/citation_style.jl
+++ b/docs/citation_style.jl
@@ -1,0 +1,44 @@
+#
+# This file is included by docs/make_work.jl to define the custom citation style `oscar_style`.
+#
+# It is heavily based upon
+# https://juliadocs.org/DocumenterCitations.jl/v1.0.0/gallery/#Custom-style:-Citation-key-labels
+#
+
+import DocumenterCitations
+
+# we use some (undocumented) internal helper functions for formatting...
+using DocumenterCitations: format_names, tex2unicode, italicize_md_et_al
+
+const oscar_style = :oscar
+
+# The long reference string in the bibliography
+function DocumenterCitations.format_bibliography_reference(::Val{oscar_style}, entry)
+  return DocumenterCitations.format_bibliography_reference(:numeric, entry)
+end
+
+# The label in the bibliography
+function DocumenterCitations.format_bibliography_label(::Val{oscar_style}, entry, citations)
+  return "[$(entry.id)]"
+end
+
+# The order of entries in the bibliography
+DocumenterCitations.bib_sorting(::Val{oscar_style}) = :nyt  # name, year, title
+
+# The type of html tag to use for the bibliography
+DocumenterCitations.bib_html_list_style(::Val{oscar_style}) = :dl
+
+function DocumenterCitations.format_citation(
+  ::Val{oscar_style}, entry, citations; note, cite_cmd, capitalize, starred
+)
+  link_text = isnothing(note) ? "[$(entry.id)]" : "[$(entry.id), $note]"
+  if cite_cmd == :citet
+    et_al = starred ? 0 : 1  # 0: no "et al."; 1: "et al." after 1st author
+    names = tex2unicode(
+      format_names(entry; names=:lastonly, and=true, et_al, et_al_text="*et al.*")
+    )
+    capitalize && (names = uppercasefirst(names))
+    link_text = italicize_md_et_al("$names $link_text")
+  end
+  return link_text
+end

--- a/docs/citation_style.jl
+++ b/docs/citation_style.jl
@@ -14,6 +14,29 @@ const oscar_style = :oscar
 
 # The long reference string in the bibliography
 function DocumenterCitations.format_bibliography_reference(::Val{oscar_style}, entry)
+  if entry.id in ["OEIS", "Stacks"]
+    # patch DocumenterCitations.format_bibliography_reference(:numeric, entry) for corporate authors (https://github.com/JuliaDocs/DocumenterCitations.jl/issues/44)
+    authors = tex2unicode(format_names(entry; names=:full))
+    title = DocumenterCitations.xtitle(entry)
+    if !isempty(title)
+      title = "<i>" * tex2unicode(title) * "</i>"
+    end
+    linked_title = DocumenterCitations.linkify(title, entry.access.url)
+    published_in = DocumenterCitations.linkify(
+      tex2unicode(DocumenterCitations.format_published_in(entry)),
+      DocumenterCitations._doi_link(entry),
+    )
+    eprint = DocumenterCitations.format_eprint(entry)
+    note = DocumenterCitations.format_note(entry)
+    parts = String[]
+    for part in (authors, linked_title, published_in, eprint, note)
+      if !isempty(part)
+        push!(parts, part)
+      end
+    end
+    html = DocumenterCitations._join_bib_parts(parts)
+    return html
+  end
   return DocumenterCitations.format_bibliography_reference(:numeric, entry)
 end
 
@@ -23,7 +46,7 @@ function DocumenterCitations.format_bibliography_label(::Val{oscar_style}, entry
 end
 
 # The order of entries in the bibliography
-DocumenterCitations.bib_sorting(::Val{oscar_style}) = :nyt  # name, year, title
+DocumenterCitations.bib_sorting(::Val{oscar_style}) = :key  # sort by citation key
 
 # The type of html tag to use for the bibliography
 DocumenterCitations.bib_html_list_style(::Val{oscar_style}) = :dl
@@ -34,9 +57,14 @@ function DocumenterCitations.format_citation(
   link_text = isnothing(note) ? "[$(entry.id)]" : "[$(entry.id), $note]"
   if cite_cmd == :citet
     et_al = starred ? 0 : 1  # 0: no "et al."; 1: "et al." after 1st author
-    names = tex2unicode(
-      format_names(entry; names=:lastonly, and=true, et_al, et_al_text="*et al.*")
-    )
+    if entry.id in ["OEIS", "Stacks"]
+      # patch for corporate authors (https://github.com/JuliaDocs/DocumenterCitations.jl/issues/44)
+      names = tex2unicode(format_names(entry; names=:full))
+    else
+      names = tex2unicode(
+        format_names(entry; names=:lastonly, and=true, et_al, et_al_text="*et al.*")
+      )
+    end
     capitalize && (names = uppercasefirst(names))
     link_text = italicize_md_et_al("$names $link_text")
   end

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -7,6 +7,7 @@ module BuildDoc
 using Documenter, DocumenterCitations
 
 include("documenter_helpers.jl")
+include("citation_style.jl")
 
 # Overwrite printing to make the header not full of redundant nonsense
 # Turns
@@ -135,7 +136,7 @@ function doit(
 
   # Load the bibliography
   bib = CitationBibliography(
-    joinpath(Oscar.oscardir, "docs", "oscar_references.bib"); style=:alpha
+    joinpath(Oscar.oscardir, "docs", "oscar_references.bib"); style=oscar_style
   )
 
   # Copy documentation from Hecke, Nemo, AnstratAlgebra

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -135,7 +135,7 @@ function doit(
 
   # Load the bibliography
   bib = CitationBibliography(
-    joinpath(Oscar.oscardir, "docs", "oscar_references.bib"); sorting=:nyt
+    joinpath(Oscar.oscardir, "docs", "oscar_references.bib"); style=:alpha
   )
 
   # Copy documentation from Hecke, Nemo, AnstratAlgebra

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -69,13 +69,6 @@
   pdf           = {https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=6eaea4b5c868c84295a0977ed9fce92d7c960a39}
 }
 
-@Misc{Aut00,
-  author        = {{A}uthors, {T}he {S}tacks {P}roject},
-  title         = {{S}tacks {P}roject},
-  year          = {0000},
-  url           = {https://stacks.math.columbia.edu/}
-}
-
 @Article{BBS02,
   author        = {Bayer, M. and Bruening, A. and Stewart, J.},
   title         = {A Combinatorial Study of Multiplexes and Ordinary Polytopes},
@@ -147,13 +140,13 @@
   location      = {Virtual Event, Russian Federation}
 }
 
-@Misc{BES19,
+@Article{BES19,
   author        = {Backman, Spencer and Eur, Christopher and Simpson, Connor},
   title         = {Simplicial generation of Chow rings of matroids},
-  publisher     = {arXiv},
+  journal       = {arXiv:1905.07114},
   year          = {2019},
-  doi           = {10.48550/ARXIV.1905.07114},
-  url           = {https://arxiv.org/abs/1905.07114}
+  doi           = {10.48550/arxiv.1905.07114},
+  primaryclass  = {math.CO}
 }
 
 @Book{BGV03,
@@ -190,13 +183,13 @@
   doi           = {10.1017/fms.2023.50}
 }
 
-@Misc{BHMPW20,
+@Article{BHMPW20,
   author        = {Braden, Tom and Huh, June and Matherne, Jacob P. and Proudfoot, Nicholas and Wang, Botong},
   title         = {A semi-small decomposition of the Chow ring of a matroid},
-  publisher     = {arXiv},
+  journal       = {arXiv:2002.03341},
   year          = {2020},
-  doi           = {10.48550/ARXIV.2002.03341},
-  url           = {https://arxiv.org/abs/2002.03341}
+  doi           = {10.48550/arXiv.2002.03341},
+  primaryclass  = {math.AG}
 }
 
 @Article{BJRR10,
@@ -217,6 +210,7 @@
   author        = {Blumenhagen, Ralph and Jurke, Benjamin and Rahn, Thorsten and Roschy, Helmut},
   title         = {cohomCalg package},
   note          = {High-performance line bundle cohomology computation based on BJRR10},
+  howpublished  = {Published electronically on GitHub},
   year          = {2010},
   url           = {https://github.com/BenjaminJurke/cohomCalg}
 }
@@ -477,13 +471,14 @@
   zbmath        = {404355}
 }
 
-@Misc{DF20,
+@Article{DF20,
   bibkey        = {{DF20}},
   author        = {De Franceschi, G.},
   title         = {Centralizers and conjugacy classes in finite classical groups},
-  year          = 2020,
-  doi           = {10.48550/ARXIV.2008.12651},
-  url           = {https://arxiv.org/abs/2008.12651}
+  journal       = {arXiv:2008.12651},
+  year          = {2020},
+  doi           = {10.48550/arXiv.2008.12651},
+  primaryclass  = {math.GR}
 }
 
 @Article{DFO13,
@@ -856,7 +851,7 @@
   year          = {2010},
   doi           = {10.1007/s00791-009-0127-3},
   url           = {http://dx.doi.org/10.1007/s00791-009-0127-3},
-  arxiv         = {0711.2397}
+  eprint        = {0711.2397}
 }
 
 @InProceedings{GK14,
@@ -934,7 +929,8 @@
 @Misc{Gat18,
   author        = {Gathmann, Andreas},
   title         = {Class notes „Plane Algebraic Curves” (SS 2018)},
-  year          = 2018,
+  howpublished  = {Published electronically},
+  year          = {2018},
   url           = {https://www.mathematik.uni-kl.de/~gathmann/en/curves.php}
 }
 
@@ -1213,7 +1209,6 @@
   year          = {2015},
   doi           = {10.1007/JHEP01(2015)142},
   eprint        = {1408.4808},
-  archiveprefix = {arXiv},
   primaryclass  = {hep-th},
   reportnumber  = {UPR-1264-T, CERN-PH-TH-2014-171, Bonn-TH-2014-13}
 }
@@ -1227,16 +1222,17 @@
   year          = {2011},
   doi           = {10.1007/JHEP08(2011)094},
   eprint        = {1106.3854},
-  archiveprefix = {arXiv},
   primaryclass  = {hep-th},
   reportnumber  = {UCSB-MATH-2011-09, IPMU11-0107, NSF-KITP-11-110, KCL-MTH-11-13}
 }
 
-@Misc{KO14,
-  author        = {Kelleher, J. and O'Sullivan, B.},
+@Article{KO14,
+  author        = {Kelleher, Jerome and O'Sullivan, Barry},
   title         = {Generating All Partitions: A Comparison Of Two Encodings},
+  journal       = {arXiv:0909.2331},
   year          = {2014},
-  url           = {https://arxiv.org/abs/0909.2331}
+  doi           = {10.48550/arXiv.0909.2331},
+  primaryclass  = {cs.DS}
 }
 
 @Book{KR05,
@@ -1298,12 +1294,13 @@
   url           = {https://doi.org/10.1006/jsco.1998.0247}
 }
 
-@Misc{Kin07,
+@Article{Kin07,
   author        = {King, Simon},
   title         = {Fast computation of secondary invariants},
-  howpublished  = {arXiv:math/0701270},
+  journal       = {arXiv:math/0701270},
   year          = {2007},
-  doi           = {10.48550/arXiv.math/0701270}
+  doi           = {10.48550/arXiv.math/0701270},
+  primaryclass  = {math.AC}
 }
 
 @Article{Kin13,
@@ -1467,8 +1464,9 @@
   bibkey        = {OEIS},
   author        = {OEIS Foundation Inc.},
   title         = {The {O}n-{L}ine {E}ncyclopedia of {I}nteger {S}equences},
-  note          = {Published electronically at \url{http://oeis.org}},
-  year          = {2023}
+  howpublished  = {Published electronically at https://oeis.org},
+  year          = {2023},
+  url           = {https://oeis.org}
 }
 
 @Book{OM78,
@@ -1746,6 +1744,14 @@
   year          = {1979}
 }
 
+@Misc{Stacks,
+  bibkey        = {Stacks},
+  author        = {{A}uthors, {T}he {S}tacks {P}roject},
+  title         = {{S}tacks {P}roject},
+  howpublished  = {Published electronically},
+  url           = {https://stacks.math.columbia.edu/}
+}
+
 @InCollection{Ste91,
   author        = {Stevens, Jan},
   title         = {On the versal deformation of cyclic quotient singularities},
@@ -1789,7 +1795,8 @@
   volume        = {3},
   pages         = {76--85},
   year          = {1987},
-  url           = {https://arxiv.org/abs/2201.09155}
+  eprint        = {2201.09155},
+  primaryclass  = {math.GR}
 }
 
 @Misc{WWTSPNNLBA,
@@ -1797,6 +1804,7 @@
   author        = {Wilson, R. A. and Walsh, P. and Tripp, J. and Suleiman, I. and Parker, R. A. and Norton, S. P. and
                   Nickerson, S. and Linton, S. and Bray, J. and Abbott, R.},
   title         = {ATLAS of Finite Group Representations},
+  howpublished  = {Published electronically},
   url           = {http://atlas.math.rwth-aachen.de/Atlas/v3}
 }
 
@@ -1823,7 +1831,6 @@
   year          = {2010},
   doi           = {10.1088/0264-9381/27/21/214004},
   eprint        = {1009.3497},
-  archiveprefix = {arXiv},
   primaryclass  = {hep-th}
 }
 
@@ -1835,7 +1842,6 @@
   pages         = {016},
   year          = {2018},
   eprint        = {1806.01854},
-  archiveprefix = {arXiv},
   primaryclass  = {hep-th},
   reportnumber  = {CERN-TH-2018-126}
 }

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -54,8 +54,7 @@
   series        = {Graduate studies in mathematics},
   publisher     = {American Mathematical Society},
   year          = {1994},
-  doi           = {10.1090/gsm/003},
-  url           = {https://doi.org/10.1090/gsm/003}
+  doi           = {10.1090/gsm/003}
 }
 
 @Article{AZ99,
@@ -76,7 +75,7 @@
   volume        = {27},
   pages         = {49–63},
   year          = {2002},
-  doi           = {https://doi.org/10.1007/s00454-001-0051-x}
+  doi           = {10.1007/s00454-001-0051-x}
 }
 
 @Article{BDEPS04,
@@ -88,8 +87,7 @@
   number        = {3},
   pages         = {237--252},
   year          = {2004},
-  doi           = {10.1093/qjmath/55.3.237},
-  url           = {https://doi.org/10.1093/qjmath/55.3.237}
+  doi           = {10.1093/qjmath/55.3.237}
 }
 
 @InCollection{BDLP17,
@@ -99,8 +97,7 @@
   publisher     = {Springer, Cham},
   pages         = {51--96},
   year          = {2017},
-  doi           = {10.1007/978-3-319-70566-8_3},
-  url           = {https://doi.org/10.1007/978-3-319-70566-8_3}
+  doi           = {10.1007/978-3-319-70566-8_3}
 }
 
 @InProceedings{BDLP19,
@@ -122,8 +119,7 @@
   note          = {Effective Methods in Algebraic Geometry},
   pages         = {99-114},
   year          = {2013},
-  doi           = {10.1016/j.jsc.2012.07.002},
-  url           = {https://www.sciencedirect.com/science/article/pii/S0747717112001186}
+  doi           = {10.1016/j.jsc.2012.07.002}
 }
 
 @InProceedings{BES-E-D21,
@@ -136,7 +132,6 @@
   pages         = {51--58},
   year          = {2021},
   doi           = {10.1145/3452143.3465545},
-  url           = {https://doi.org/10.1145/3452143.3465545},
   location      = {Virtual Event, Russian Federation}
 }
 
@@ -202,8 +197,7 @@
   pages         = {103525},
   year          = {2010},
   month         = {Oct},
-  doi           = {10.1063/1.3501132},
-  url           = {https://doi.org/10.1063/1.3501132}
+  doi           = {10.1063/1.3501132}
 }
 
 @Misc{BJRR10*1,
@@ -225,8 +219,7 @@
   pages         = {012302},
   year          = {2012},
   month         = {Jan},
-  doi           = {10.1063/1.3677646},
-  url           = {https://doi.org/10.1063/1.3677646}
+  doi           = {10.1063/1.3677646}
 }
 
 @Article{BKR20,
@@ -238,8 +231,7 @@
   number        = {326},
   pages         = {3003--3021},
   year          = {2020},
-  doi           = {10.1090/mcom/3546},
-  url           = {https://doi.org/10.1090/mcom/3546}
+  doi           = {10.1090/mcom/3546}
 }
 
 @Article{BL81,
@@ -251,8 +243,7 @@
   number        = {3},
   pages         = {237--255},
   year          = {1981},
-  doi           = {10.1016/0097-3165(81)90058-3},
-  url           = {https://doi.org/10.1016/0097-3165(81)90058-3}
+  doi           = {10.1016/0097-3165(81)90058-3}
 }
 
 @Article{BN07,
@@ -265,8 +256,7 @@
   number        = {2},
   pages         = {766--788},
   year          = {2007},
-  doi           = {10.1016/j.aim.2007.04.012},
-  url           = {https://doi.org/10.1016/j.aim.2007.04.012}
+  doi           = {10.1016/j.aim.2007.04.012}
 }
 
 @Book{Ben93,
@@ -293,7 +283,6 @@
   year          = {2018},
   month         = {2},
   doi           = {10.11588/heidok.00024045},
-  url           = {https://doi.org/10.11588/heidok.00024045},
   school        = {Heidelberg U.}
 }
 
@@ -315,8 +304,7 @@
   publisher     = {Springer-Verlag, Cham},
   pages         = {xviii+601},
   year          = {2020},
-  doi           = {10.1007/978-3-030-53061-7},
-  url           = {https://doi.org/10.1007/978-3-030-53061-7}
+  doi           = {10.1007/978-3-030-53061-7}
 }
 
 @Book{C-MLS21,
@@ -325,8 +313,7 @@
   publisher     = {Springer-Verlag, Cham},
   pages         = {xii+578},
   year          = {2021},
-  doi           = {10.1007/978-3-030-78024-1},
-  url           = {https://doi.org/10.1007/978-3-030-78024-1}
+  doi           = {10.1007/978-3-030-78024-1}
 }
 
 @Book{CCNPW85,
@@ -350,8 +337,7 @@
   volume        = {1},
   pages         = {1--8},
   year          = {1998},
-  doi           = {10.1112/S1461157000000115},
-  url           = {https://doi.org/10.1112/S1461157000000115}
+  doi           = {10.1112/S1461157000000115}
 }
 
 @Book{CLS11,
@@ -363,8 +349,7 @@
   publisher     = {Providence, RI: American Mathematical Society (AMS)},
   pages         = {xxiv+841},
   year          = {2011},
-  doi           = {10.1090/gsm/124},
-  url           = {https://doi.org/10.1090/gsm/124}
+  doi           = {10.1090/gsm/124}
 }
 
 @Book{CS99,
@@ -379,8 +364,7 @@
   edition       = {Third},
   pages         = {lxxiv+703},
   year          = {1999},
-  doi           = {10.1007/978-1-4757-6568-7},
-  url           = {https://doi.org/10.1007/978-1-4757-6568-7}
+  doi           = {10.1007/978-1-4757-6568-7}
 }
 
 @Article{CSZ15,
@@ -392,8 +376,7 @@
   publisher     = {Springer},
   pages         = {513--551},
   year          = {2015},
-  doi           = {10.1007/s00493-014-2959-9},
-  url           = {https://doi.org/10.1007/s00493-014-2959-9}
+  doi           = {10.1007/s00493-014-2959-9}
 }
 
 @Book{Cam99,
@@ -404,8 +387,7 @@
   publisher     = {Cambridge University Press, Cambridge},
   pages         = {x+220},
   year          = {1999},
-  doi           = {10.1017/CBO9780511623677},
-  url           = {https://doi.org/10.1017/CBO9780511623677}
+  doi           = {10.1017/CBO9780511623677}
 }
 
 @InCollection{Chr91,
@@ -417,8 +399,7 @@
   publisher     = {Springer, Berlin},
   pages         = {81--92},
   year          = {1991},
-  doi           = {10.1007/BFb0086376},
-  url           = {https://doi.org/10.1007/BFb0086376}
+  doi           = {10.1007/BFb0086376}
 }
 
 @Book{Coh00,
@@ -429,8 +410,7 @@
   publisher     = {Springer-Verlag, New York},
   pages         = {xvi+578},
   year          = {2000},
-  doi           = {10.1007/978-1-4419-8489-0},
-  url           = {https://doi.org/10.1007/978-1-4419-8489-0}
+  doi           = {10.1007/978-1-4419-8489-0}
 }
 
 @Book{Coh93,
@@ -441,8 +421,7 @@
   publisher     = {Springer-Verlag, Berlin},
   pages         = {xii+534},
   year          = {1993},
-  doi           = {10.1007/978-3-662-02945-9},
-  url           = {https://doi.org/10.1007/978-3-662-02945-9}
+  doi           = {10.1007/978-3-662-02945-9}
 }
 
 @Article{Cor21,
@@ -453,8 +432,7 @@
   volume        = {27},
   number        = {57},
   year          = {2021},
-  doi           = {10.1007/s00029-021-00679-6},
-  url           = {https://doi.org/10.1007/s00029-021-00679-6}
+  doi           = {10.1007/s00029-021-00679-6}
 }
 
 @Article{DES93,
@@ -489,8 +467,7 @@
   volume        = {50},
   pages         = {100--109},
   year          = {2013},
-  doi           = {10.1016/j.jsc.2012.04.002},
-  url           = {https://doi.org/10.1016/j.jsc.2012.04.002}
+  doi           = {10.1016/j.jsc.2012.04.002}
 }
 
 @InCollection{DGP99,
@@ -501,8 +478,7 @@
   publisher     = {Springer, Berlin},
   pages         = {187--220},
   year          = {1999},
-  doi           = {10.1007/978-3-642-59932-3},
-  url           = {https://doi.org/10.1007/978-3-642-59932-3}
+  doi           = {10.1007/978-3-642-59932-3}
 }
 
 @Article{DH00,
@@ -515,8 +491,7 @@
   number        = {3},
   pages         = {161--167},
   year          = {2000},
-  doi           = {10.1007/s000130050426},
-  url           = {https://doi.org/10.1007/s000130050426}
+  doi           = {10.1007/s000130050426}
 }
 
 @Article{DHS98,
@@ -528,8 +503,7 @@
   number        = {6},
   pages         = {727--731},
   year          = {1998},
-  doi           = {10.1006/jsco.1997.0196},
-  url           = {https://doi.org/10.1006/jsco.1997.0196}
+  doi           = {10.1006/jsco.1997.0196}
 }
 
 @InCollection{DJ98,
@@ -543,8 +517,7 @@
   publisher     = {Cambridge Univ. Press, Cambridge},
   pages         = {61--89},
   year          = {1998},
-  doi           = {10.1017/CBO9780511565847.005},
-  url           = {https://doi.org/10.1017/CBO9780511565847.005}
+  doi           = {10.1017/CBO9780511565847.005}
 }
 
 @Book{DK15,
@@ -557,8 +530,7 @@
   edition       = {enlarged},
   pages         = {xxii+366},
   year          = {2015},
-  doi           = {10.1007/978-3-662-48422-7},
-  url           = {https://doi.org/10.1007/978-3-662-48422-7}
+  doi           = {10.1007/978-3-662-48422-7}
 }
 
 @Article{DK17,
@@ -579,8 +551,7 @@
   publisher     = {Springer-Verlag, Berlin; Hindustan Book Agency, New Delhi},
   pages         = {xvi+327},
   year          = {2006},
-  doi           = {10.1007/3-540-28993-3},
-  url           = {https://doi.org/10.1007/3-540-28993-3}
+  doi           = {10.1007/3-540-28993-3}
 }
 
 @Book{DLRS10,
@@ -604,8 +575,7 @@
   publisher     = {Cambridge University Press, Cambridge},
   pages         = {viii+118},
   year          = {2013},
-  doi           = {10.1017/CBO9781139565769},
-  url           = {https://doi.org/10.1017/CBO9781139565769}
+  doi           = {10.1017/CBO9781139565769}
 }
 
 @Article{DS00,
@@ -657,8 +627,7 @@
   number        = {2},
   pages         = {207--235},
   year          = {1992},
-  doi           = {10.1007/BF01231331},
-  url           = {https://doi.org/10.1007/BF01231331}
+  doi           = {10.1007/BF01231331}
 }
 
 @Article{EM16,
@@ -670,8 +639,7 @@
   number        = {2},
   pages         = {409--426},
   year          = {2016},
-  doi           = {10.1112/jlms/jdw012},
-  url           = {https://doi.org/10.1112/jlms/jdw012}
+  doi           = {10.1112/jlms/jdw012}
 }
 
 @Article{EM19,
@@ -683,8 +651,7 @@
   number        = {2},
   pages         = {717--719},
   year          = {2019},
-  doi           = {10.1112/jlms.12232},
-  url           = {https://doi.org/10.1112/jlms.12232}
+  doi           = {10.1112/jlms.12232}
 }
 
 @Article{ES96,
@@ -696,8 +663,7 @@
   number        = {1},
   pages         = {1--45},
   year          = {1996},
-  doi           = {10.1215/S0012-7094-96-08401-X},
-  url           = {https://doi.org/10.1215/S0012-7094-96-08401-X}
+  doi           = {10.1215/S0012-7094-96-08401-X}
 }
 
 @Book{Eis95,
@@ -720,8 +686,7 @@
   number        = {4},
   pages         = {329-344},
   year          = {1993},
-  doi           = {https://doi.org/10.1006/jsco.1993.1051},
-  url           = {https://www.sciencedirect.com/science/article/pii/S0747717183710515}
+  doi           = {10.1006/jsco.1993.1051}
 }
 
 @Article{FJR17,
@@ -734,8 +699,7 @@
   pages         = {235-303},
   year          = {2017},
   month         = {Oct},
-  doi           = {10.2140/gt.2018.22.235},
-  url           = {https://doi.org/10.2140/gt.2018.22.235}
+  doi           = {10.2140/gt.2018.22.235}
 }
 
 @InProceedings{FLINT,
@@ -763,8 +727,7 @@
   pages         = {515--536},
   year          = 2004,
   month         = {mar},
-  doi           = {10.1007/s00222-003-0327-2},
-  url           = {https://doi.org/10.1007%2Fs00222-003-0327-2}
+  doi           = {10.1007/s00222-003-0327-2}
 }
 
 @Article{Fau99,
@@ -812,8 +775,7 @@
   edition       = {Second},
   pages         = {xiv+470},
   year          = {1998},
-  doi           = {10.1007/978-1-4612-1700-8},
-  url           = {https://doi.org/10.1007/978-1-4612-1700-8}
+  doi           = {10.1007/978-1-4612-1700-8}
 }
 
 @InProceedings{GHJ16,
@@ -836,7 +798,7 @@
   publisher     = {Birkhäuser},
   pages         = {43--74},
   year          = {2000},
-  url           = {https://doi.org/10.1007/978-3-0348-8438-9_2}
+  doi           = {10.1007/978-3-0348-8438-9_2}
 }
 
 @Article{GJRW10,
@@ -850,7 +812,6 @@
   pages         = {99--110},
   year          = {2010},
   doi           = {10.1007/s00791-009-0127-3},
-  url           = {http://dx.doi.org/10.1007/s00791-009-0127-3},
   eprint        = {0711.2397}
 }
 
@@ -883,8 +844,7 @@
   number        = {9},
   pages         = {887--901},
   year          = {2010},
-  doi           = {10.1016/j.jsc.2010.04.002},
-  url           = {https://doi.org/10.1016/j.jsc.2010.04.002}
+  doi           = {10.1016/j.jsc.2010.04.002}
 }
 
 @Book{GP08,
@@ -895,8 +855,7 @@
   publisher     = {Springer, Berlin},
   pages         = {xx+689},
   year          = {2008},
-  doi           = {10.1007/978-3-540-73542-7},
-  url           = {https://doi.org/10.1007/978-3-540-73542-7}
+  doi           = {10.1007/978-3-540-73542-7}
 }
 
 @Article{GS79,
@@ -908,8 +867,7 @@
   publisher     = {Elsevier},
   pages         = {277--285},
   year          = {1979},
-  doi           = {10.1016/0166-218X(79)90004-0},
-  url           = {https://doi.org/10.1016/0166-218X(79)90004-0}
+  doi           = {10.1016/0166-218X(79)90004-0}
 }
 
 @InCollection{GTZ88,
@@ -922,8 +880,7 @@
   publisher     = {Elsevier Ltd, Oxford},
   pages         = {149--167},
   year          = {1988},
-  doi           = {10.1016/S0747-7171(88)80040-3},
-  url           = {https://doi.org/10.1016/S0747-7171(88)80040-3}
+  doi           = {10.1016/S0747-7171(88)80040-3}
 }
 
 @Misc{Gat18,
@@ -943,7 +900,7 @@
   number        = {2},
   pages         = {105--124},
   year          = {1996},
-  url           = {https://doi.org/10.1007/BF01191379}
+  doi           = {10.1007/BF01191379}
 }
 
 @Book{Gru03,
@@ -957,8 +914,7 @@
   edition       = {Second},
   pages         = {xvi+468},
   year          = {2003},
-  doi           = {10.1007/978-1-4613-0019-9},
-  url           = {https://doi.org/10.1007/978-1-4613-0019-9}
+  doi           = {10.1007/978-1-4613-0019-9}
 }
 
 @Book{HEO05,
@@ -968,8 +924,7 @@
   publisher     = {Chapman & Hall/CRC, Boca Raton, FL},
   pages         = {xvi+514},
   year          = {2005},
-  doi           = {10.1201/9781420035216},
-  url           = {https://doi.org/10.1201/9781420035216}
+  doi           = {10.1201/9781420035216}
 }
 
 @Article{HHS11,
@@ -1001,8 +956,7 @@
   publisher     = {Springer-Verlag, New York},
   pages         = {xvi+496},
   year          = {1977},
-  doi           = {10.1007/978-1-4757-3849-0},
-  url           = {https://doi.org/10.1007/978-1-4757-3849-0}
+  doi           = {10.1007/978-1-4757-3849-0}
 }
 
 @Book{Hum72,
@@ -1013,8 +967,7 @@
   publisher     = {Springer-Verlag, New York},
   pages         = {xii+169},
   year          = {1972},
-  doi           = {10.1007/978-1-4612-6398-2},
-  url           = {https://doi.org/10.1007/978-1-4612-6398-2}
+  doi           = {10.1007/978-1-4612-6398-2}
 }
 
 @Book{Hup67,
@@ -1025,8 +978,7 @@
   publisher     = {Springer-Verlag, Berlin-New York},
   pages         = {xii+793},
   year          = {1967},
-  doi           = {10.1007/978-3-642-64981-3},
-  url           = {https://doi.org/10.1007/978-3-642-64981-3}
+  doi           = {10.1007/978-3-642-64981-3}
 }
 
 @Book{Huy16,
@@ -1038,8 +990,7 @@
   publisher     = {Cambridge University Press, Cambridge},
   pages         = {xi+485},
   year          = {2016},
-  doi           = {10.1017/CBO9781316594193},
-  url           = {https://doi.org/10.1017/CBO9781316594193}
+  doi           = {10.1017/CBO9781316594193}
 }
 
 @InCollection{IR96,
@@ -1083,8 +1034,7 @@
   publisher     = {Vieweg+Teubner Verlag},
   pages         = {xi+384},
   year          = {2000},
-  doi           = {10.1007/978-3-322-90159-0},
-  url           = {https://doi.org/10.1007/978-3-322-90159-0}
+  doi           = {10.1007/978-3-322-90159-0}
 }
 
 @Book{JT13,
@@ -1095,8 +1045,7 @@
   publisher     = {Springer, London},
   pages         = {x+250},
   year          = {2013},
-  doi           = {10.1007/978-1-4471-4817-3},
-  url           = {https://doi.org/10.1007/978-1-4471-4817-3}
+  doi           = {10.1007/978-1-4471-4817-3}
 }
 
 @Article{JZ00,
@@ -1106,7 +1055,7 @@
   volume        = {24},
   pages         = {325–344},
   year          = {2000},
-  doi           = {https://doi.org/10.1007/s004540010039}
+  doi           = {10.1007/s004540010039}
 }
 
 @Article{Joh12,
@@ -1118,8 +1067,7 @@
   volume        = {15},
   pages         = {341--359},
   year          = {2012},
-  doi           = {10.1112/S1461157012001088},
-  url           = {https://doi.org/10.1112/S1461157012001088}
+  doi           = {10.1112/S1461157012001088}
 }
 
 @InProceedings{Jos03,
@@ -1131,8 +1079,7 @@
   publisher     = {Springer Berlin Heidelberg},
   pages         = {1--21},
   year          = {2003},
-  doi           = {10.1007/978-3-662-05148-1_1},
-  url           = {https://doi.org/10.1007/978-3-662-05148-1_1}
+  doi           = {10.1007/978-3-662-05148-1_1}
 }
 
 @InCollection{Jos05,
@@ -1168,8 +1115,7 @@
   pages         = {033506},
   year          = {2011},
   month         = {Mar},
-  doi           = {10.1063/1.3562523},
-  url           = {https://doi.org/10.1063/1.3562523}
+  doi           = {10.1063/1.3562523}
 }
 
 @InCollection{KL91,
@@ -1181,8 +1127,7 @@
   publisher     = {Springer, Berlin},
   pages         = {195--205},
   year          = {1991},
-  doi           = {10.1007/3-540-54522-0_108},
-  url           = {https://doi.org/10.1007/3-540-54522-0_108}
+  doi           = {10.1007/3-540-54522-0_108}
 }
 
 @InProceedings{KLT20,
@@ -1195,8 +1140,7 @@
   publisher     = {Springer International Publishing},
   pages         = {377--385},
   year          = {2020},
-  doi           = {10.1007/978-3-030-52200-1_37},
-  url           = {https://doi.org/10.1007/978-3-030-52200-1_37}
+  doi           = {10.1007/978-3-030-52200-1_37}
 }
 
 @Article{KM-POPR15,
@@ -1264,8 +1208,7 @@
   number        = {4},
   pages         = {727--745},
   year          = {2010},
-  doi           = {10.1007/s10463-010-0290-9},
-  url           = {https://doi.org/10.1007/s10463-010-0290-9}
+  doi           = {10.1007/s10463-010-0290-9}
 }
 
 @Article{Kem02,
@@ -1277,8 +1220,7 @@
   number        = {3},
   pages         = {229--238},
   year          = {2002},
-  doi           = {10.1006/jsco.2002.0560},
-  url           = {https://doi.org/10.1006/jsco.2002.0560}
+  doi           = {10.1006/jsco.2002.0560}
 }
 
 @Article{Kem99,
@@ -1290,8 +1232,7 @@
   number        = {2},
   pages         = {171--184},
   year          = {1999},
-  doi           = {10.1006/jsco.1998.0247},
-  url           = {https://doi.org/10.1006/jsco.1998.0247}
+  doi           = {10.1006/jsco.1998.0247}
 }
 
 @Article{Kin07,
@@ -1341,8 +1282,7 @@
   volume        = {21},
   publisher     = {Springer, Berlin},
   year          = {2008},
-  doi           = {10.1007/978-3-540-71962-5},
-  url           = {https://doi.org/10.1007/978-3-540-71962-5}
+  doi           = {10.1007/978-3-540-71962-5}
 }
 
 @Book{LN97,
@@ -1433,8 +1373,7 @@
   publisher     = {Springer, Cham},
   pages         = {xviii+203},
   year          = {2018},
-  doi           = {10.1007/978-3-319-90233-3},
-  url           = {https://doi.org/10.1007/978-3-319-90233-3}
+  doi           = {10.1007/978-3-319-90233-3}
 }
 
 @Article{Mer12,
@@ -1445,7 +1384,7 @@
   number        = {1},
   pages         = {89--104},
   year          = {2012},
-  url           = {https://doi.org/10.1007/s10852-011-9168-y}
+  doi           = {10.1007/s10852-011-9168-y}
 }
 
 @Article{Nik79,
@@ -1489,8 +1428,7 @@
   number        = {4},
   pages         = {383--400},
   year          = {2000},
-  doi           = {10.1006/jsco.1999.0413},
-  url           = {https://doi.org/10.1006/jsco.1999.0413}
+  doi           = {10.1006/jsco.1999.0413}
 }
 
 @Book{Oxl11,
@@ -1538,8 +1476,7 @@
   number        = {4},
   pages         = {897--904},
   year          = {2011},
-  doi           = {10.2478/s11533-011-0037-8},
-  url           = {https://doi.org/10.2478/s11533-011-0037-8}
+  doi           = {10.2478/s11533-011-0037-8}
 }
 
 @Book{PZ97,
@@ -1572,8 +1509,7 @@
   volume        = {63},
   pages         = {689--697},
   year          = {1956},
-  doi           = {10.2307/2309555},
-  url           = {https://doi.org/10.2307/2309555}
+  doi           = {10.2307/2309555}
 }
 
 @PhDThesis{Pop93,
@@ -1613,7 +1549,7 @@
   volume        = {16},
   pages         = {163--168},
   year          = {1976},
-  url           = {https://link.springer.com/article/10.1007/BF02241987}
+  doi           = {10.1007/BF02241987}
 }
 
 @Article{RR10,
@@ -1626,8 +1562,7 @@
   pages         = {103520},
   year          = {2010},
   month         = {Oct},
-  doi           = {10.1063/1.3501135},
-  url           = {https://doi.org/10.1063/1.3501135}
+  doi           = {10.1063/1.3501135}
 }
 
 @Article{RSS03,
@@ -1648,8 +1583,7 @@
   publisher     = {Elsevier},
   pages         = {850--870},
   year          = {2012},
-  doi           = {10.1016/j.jcta.2011.12.005},
-  url           = {https://doi.org/10.1016/j.jcta.2011.12.005}
+  doi           = {10.1016/j.jcta.2011.12.005}
 }
 
 @Article{SY96,
@@ -1661,8 +1595,7 @@
   number        = {3},
   pages         = {247--277},
   year          = {1996},
-  doi           = {10.1006/jsco.1996.0052},
-  url           = {https://doi.org/10.1006/jsco.1996.0052}
+  doi           = {10.1006/jsco.1996.0052}
 }
 
 @PhDThesis{Sch23,
@@ -1688,8 +1621,7 @@
   publisher     = {Cambridge University Press, Cambridge},
   pages         = {x+264},
   year          = {2003},
-  doi           = {10.1017/CBO9780511546549},
-  url           = {https://doi.org/10.1017/CBO9780511546549}
+  doi           = {10.1017/CBO9780511546549}
 }
 
 @Article{Sez02,
@@ -1702,8 +1634,7 @@
   number        = {2},
   pages         = {252--263},
   year          = {2002},
-  doi           = {10.1016/S0021-8693(02)00018-2},
-  url           = {https://doi.org/10.1016/S0021-8693(02)00018-2}
+  doi           = {10.1016/S0021-8693(02)00018-2}
 }
 
 @Article{Shi15,
@@ -1716,8 +1647,7 @@
   number        = {22},
   pages         = {11961--12014},
   year          = {2015},
-  doi           = {10.1093/imrn/rnv006},
-  url           = {https://doi.org/10.1093/imrn/rnv006}
+  doi           = {10.1093/imrn/rnv006}
 }
 
 @Article{Shi18,
@@ -1729,8 +1659,7 @@
   publisher     = {University of Michigan, Department of Mathematics},
   pages         = {511 -- 559},
   year          = {2018},
-  doi           = {10.1307/mmj/1528941621},
-  url           = {https://doi.org/10.1307/mmj/1528941621}
+  doi           = {10.1307/mmj/1528941621}
 }
 
 @Article{Sta79,
@@ -1761,8 +1690,7 @@
   publisher     = {Springer, Berlin},
   pages         = {302--319},
   year          = {1991},
-  doi           = {10.1007/BFb0086390},
-  url           = {https://doi.org/10.1007/BFb0086390}
+  doi           = {10.1007/BFb0086390}
 }
 
 @Book{Stu93,
@@ -1772,8 +1700,7 @@
   publisher     = {Springer-Verlag, Vienna},
   pages         = {vi+197},
   year          = {1993},
-  doi           = {10.1007/978-3-7091-4368-1},
-  url           = {https://doi.org/10.1007/978-3-7091-4368-1}
+  doi           = {10.1007/978-3-7091-4368-1}
 }
 
 @Article{Sym11,
@@ -1817,8 +1744,7 @@
   edition       = {Second},
   pages         = {xviii+513},
   year          = {2008},
-  doi           = {10.1201/9781420071474},
-  url           = {https://doi.org/10.1201/9781420071474}
+  doi           = {10.1201/9781420071474}
 }
 
 @Article{Wei10,
@@ -1855,8 +1781,7 @@
   number        = {12},
   pages         = {4573--4583},
   year          = {2013},
-  doi           = {10.1016/j.laa.2013.02.026},
-  url           = {https://doi.org/10.1016/j.laa.2013.02.026}
+  doi           = {10.1016/j.laa.2013.02.026}
 }
 
 @Article{Wit88,
@@ -1890,7 +1815,7 @@
   number        = {2},
   pages         = {319--332},
   year          = {1998},
-  url           = {https://doi.org/10.1080/00207169808804755}
+  doi           = {10.1080/00207169808804755}
 }
 
 @Book{Zie95,
@@ -1901,6 +1826,5 @@
   publisher     = {Springer-Verlag, New York},
   pages         = {x+370},
   year          = {1995},
-  doi           = {10.1007/978-1-4613-8431-1},
-  url           = {https://doi.org/10.1007/978-1-4613-8431-1}
+  doi           = {10.1007/978-1-4613-8431-1}
 }

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -1,6 +1,6 @@
 
 @Article{ABGJ18,
-  author        = {Allamigeon, Xavier and Benchimol, Pascal and Gaubert, St{\'e}phane and Joswig, Michael},
+  author        = {Allamigeon, Xavier and Benchimol, Pascal and Gaubert, Stéphane and Joswig, Michael},
   title         = {Log-barrier interior point methods are not strongly polynomial},
   journal       = {SIAM Journal on Applied Algebra and Geometry},
   volume        = {2},
@@ -25,10 +25,10 @@
 }
 
 @Article{AG10,
-  author        = {Arzhantsev, Ivan V. and Ga\v{i}fullin, Sergei A.},
+  author        = {Arzhantsev, Ivan V. and Gaĭfullin, Sergey A.},
   title         = {Cox rings, semigroups, and automorphisms of affine varieties},
   journal       = {Mat. Sb.},
-  fjournal      = {Matematicheski\v{i} Sbornik},
+  fjournal      = {Matematicheskiĭ Sbornik},
   volume        = {201},
   number        = {1},
   pages         = {3--24},
@@ -73,13 +73,13 @@
   title         = {A Combinatorial Study of Multiplexes and Ordinary Polytopes},
   journal       = {Discrete & Computational Geometry},
   volume        = {27},
-  pages         = {49–63},
+  pages         = {49--63},
   year          = {2002},
   doi           = {10.1007/s00454-001-0051-x}
 }
 
 @Article{BDEPS04,
-  author        = {Berry, Neil and Dubickas, Art\={u}ras and Elkies, Noam D. and Poonen, Bjorn and Smyth, Chris},
+  author        = {Berry, Neil and Dubickas, Artūras and Elkies, Noam D. and Poonen, Bjorn and Smyth, Chris},
   title         = {The conjugate dimension of algebraic numbers},
   journal       = {Q. J. Math.},
   fjournal      = {The Quarterly Journal of Mathematics},
@@ -123,7 +123,7 @@
 }
 
 @InProceedings{BES-E-D21,
-  author        = {Berthomieu, J\'{e}r\'{e}my and Eder, Christian and Safey El Din, Mohab},
+  author        = {Berthomieu, Jérémy and Eder, Christian and Safey El Din, Mohab},
   title         = {Msolve: A Library for Solving Polynomial Systems},
   booktitle     = {Proceedings of the 2021 on International Symposium on Symbolic and Algebraic Computation},
   series        = {ISSAC '21},
@@ -145,7 +145,7 @@
 }
 
 @Book{BGV03,
-  author        = {Bueso, Jos\'{e} and G\'{o}mez-Torrecillas, Jos\'{e} and Verschoren, Alain},
+  author        = {Bueso, José Luis and Gómez-Torrecillas, José and Verschoren, Alain},
   title         = {Algorithmic methods in non-commutative algebra. {Applications} to quantum groups.},
   zbl           = {1063.16054},
   series        = {Math. Model.: Theory Appl.},
@@ -293,7 +293,7 @@
   volume        = {43},
   number        = {2},
   publisher     = {London Mathematical Society},
-  pages         = {274–285},
+  pages         = {274--285},
   year          = {1996},
   doi           = {10.1112/S0025579300011773}
 }
@@ -482,7 +482,7 @@
 }
 
 @Article{DH00,
-  author        = {Domokos, M\'{a}ty\'{a}s and Heged\H{u}s, P\'{a}l},
+  author        = {Domokos, Mátyás and Hegedűs, Pál},
   title         = {Noether's bound for polynomial invariants of finite groups},
   mrnumber      = {1739493},
   journal       = {Arch. Math. (Basel)},
@@ -904,11 +904,12 @@
 }
 
 @Book{Gru03,
-  author        = {Gr\"{u}nbaum, Branko},
+  bibkey        = {Gru03},
+  author        = {Grünbaum, Branko},
   title         = {Convex polytopes},
   series        = {Graduate Texts in Mathematics},
   volume        = {221},
-  note          = {Prepared and with a preface by Volker Kaibel, Victor Klee and G\"{u}nter M. Ziegler},
+  note          = {Prepared and with a preface by Volker Kaibel, Victor Klee and Günter M. Ziegler},
   address       = {New York},
   publisher     = {Springer-Verlag},
   edition       = {Second},
@@ -928,7 +929,7 @@
 }
 
 @Article{HHS11,
-  author        = {Hausen, J\"{u}rgen and Herppich, Elaine and S\"{u}ss, Hendrik},
+  author        = {Hausen, Jürgen and Herppich, Elaine and Süss, Hendrik},
   title         = {Multigraded factorial rings and {F}ano varieties with torus action},
   mrnumber      = {2804508},
   journal       = {Doc. Math.},
@@ -1053,7 +1054,7 @@
   title         = {Neighborly Cubical Polytopes},
   journal       = {Discrete & Computational Geometry },
   volume        = {24},
-  pages         = {325–344},
+  pages         = {325--344},
   year          = {2000},
   doi           = {10.1007/s004540010039}
 }
@@ -1265,11 +1266,11 @@
 }
 
 @Book{Kol13,
-  author        = {Koll\'{a}r, J\'{a}nos},
+  author        = {Kollár, János},
   title         = {Singularities of the minimal model program},
   series        = {Cambridge Tracts in Mathematics},
   volume        = {200},
-  note          = {With a collaboration of S\'{a}ndor Kov\'{a}cs},
+  note          = {With a collaboration of Sándor Kovács},
   publisher     = {Cambridge University Press},
   year          = {2013},
   location      = {Cambridge}
@@ -1355,7 +1356,7 @@
 }
 
 @Book{MS21,
-  author        = {Micha{\l}ek, Mateusz and Sturmfels, Bernd},
+  author        = {Michałek, Mateusz and Sturmfels, Bernd},
   title         = {Invitation to nonlinear algebra},
   journal       = {Grad. Stud. Math.},
   fjournal      = {Graduate Studies in Mathematics},
@@ -1458,7 +1459,7 @@
 
 @Article{PS11,
   author        = {Pokutta, Sebastian and Schulz, Andreas S},
-  title         = {Integer-empty polytopes in the 0/1-cube with maximal Gomory--Chv{\'a}tal rank},
+  title         = {Integer-empty polytopes in the 0/1-cube with maximal Gomory--Chvátal rank},
   journal       = {Operations research letters},
   volume        = {39},
   number        = {6},
@@ -1501,7 +1502,8 @@
 }
 
 @Article{Pol56,
-  author        = {P\'{o}lya, G.},
+  bibkey        = {Pol56},
+  author        = {Pólya, G.},
   title         = {On picture-writing},
   mrnumber      = {81865},
   journal       = {Amer. Math. Monthly},
@@ -1518,7 +1520,7 @@
   year          = {1993},
   url           = {https://www.math.stonybrook.edu/~sorin/eprints/thesis.pdf},
   type          = {doctoralthesis},
-  school        = {Universität des Saarlandes, Saarbr\"{u}cken}
+  school        = {Universität des Saarlandes, Saarbrücken}
 }
 
 @Article{Pos09,
@@ -1613,7 +1615,7 @@
 }
 
 @Book{Ser03,
-  author        = {Seress, \'{A}kos},
+  author        = {Seress, Ákos},
   title         = {Permutation group algorithms},
   mrnumber      = {1970241},
   series        = {Cambridge Tracts in Mathematics},
@@ -1625,7 +1627,7 @@
 }
 
 @Article{Sez02,
-  author        = {Sezer, M\"{u}fit},
+  author        = {Sezer, Müfit},
   title         = {Sharpening the generalized {N}oether bound in the invariant theory of finite groups},
   mrnumber      = {1933869},
   journal       = {J. Algebra},

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -1681,7 +1681,7 @@
 
 @Misc{Stacks,
   bibkey        = {Stacks},
-  author        = {{A}uthors, {T}he {S}tacks {P}roject},
+  author        = {The Stacks Project Authors},
   title         = {{S}tacks {P}roject},
   howpublished  = {Published electronically},
   url           = {https://stacks.math.columbia.edu/}

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -238,7 +238,7 @@
 
 @Article{BL81,
   author        = {Billera, Louis J. and Lee, Carl W.},
-  title         = {A proof of the sufficiency of {M}c{M}ullen's conditions for {$f$}-vectors of simplicial convex
+  title         = {A proof of the sufficiency of {M}c{M}ullen's conditions for $f$-vectors of simplicial convex
                   polytopes},
   journal       = {J. Combin. Theory Ser. A},
   volume        = {31},
@@ -452,7 +452,7 @@
 }
 
 @Article{DF20,
-  bibkey        = {{DF20}},
+  bibkey        = {DF20},
   author        = {De Franceschi, G.},
   title         = {Centralizers and conjugacy classes in finite classical groups},
   journal       = {arXiv:2008.12651},
@@ -1423,7 +1423,7 @@
 }
 
 @Article{OMdCS00,
-  bibkey        = {{OMdCS00}},
+  bibkey        = {OMdCS00},
   author        = {Ojeda Martínez de Castilla, Ignacio and Sánchez, Ramón Peidra},
   title         = {Cellular binomial ideals. Primary decomposition of binomial ideals},
   journal       = {J. Symbolic Comput.},
@@ -1606,14 +1606,14 @@
 
 @PhDThesis{Sch23,
   author        = {Schmitt, Johannes},
-  title         = {{On $\mathbb Q$-factorial terminalizations of symplectic linear quotient singularities}},
+  title         = {On $\mathbb Q$-factorial terminalizations of symplectic linear quotient singularities},
   year          = {2023},
   school        = {RPTU Kaiserslautern-Landau}
 }
 
 @PhDThesis{Sch95,
   author        = {Schuchert, Peter},
-  title         = {{Matroid-Polytope und Einbettungen kombinatorischer Mannigfaltigkeiten}},
+  title         = {Matroid-Polytope und Einbettungen kombinatorischer Mannigfaltigkeiten},
   year          = {1995},
   school        = {TU Darmstadt}
 }

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -7,7 +7,8 @@
   number        = {1},
   publisher     = {SIAM},
   pages         = {140--178},
-  year          = {2018}
+  year          = {2018},
+  doi           = {10.1137/17M1142132}
 }
 
 @Article{ABS97,
@@ -32,7 +33,8 @@
   volume        = {201},
   number        = {1},
   pages         = {3--24},
-  year          = {2010}
+  year          = {2010},
+  eprint        = {0810.1148}
 }
 
 @Article{AHK18,
@@ -65,7 +67,7 @@
   publisher     = {Providence, RI: American Mathematical Society},
   pages         = {57--90},
   year          = {1999},
-  pdf           = {https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=6eaea4b5c868c84295a0977ed9fce92d7c960a39}
+  url           = {https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=6eaea4b5c868c84295a0977ed9fce92d7c960a39}
 }
 
 @Article{BBS02,
@@ -106,8 +108,8 @@
   booktitle     = {MEGA 2019 - International Conference on Effective Methods in Algebraic Geometry},
   address       = {Madrid, Spain},
   year          = {2019},
-  url           = {https://hal.inria.fr/hal-02912148},
-  pdf           = {https://hal.inria.fr/hal-02912148/file/07.pdf}
+  archiveprefix = {HAL},
+  eprint        = {hal-02912148}
 }
 
 @Article{BDLPSS13,
@@ -437,7 +439,7 @@
 
 @Article{DES93,
   author        = {Decker, Wolfram and Ein, Lawrence and Schreyer, Frank-Olaf},
-  title         = {Construction of surfaces in ${\mathbb P}_4$},
+  title         = {Construction of surfaces in ${\mathbb P}^4$},
   zbl           = {0795.14019},
   journal       = {J. Algebr. Geom.},
   fjournal      = {Journal of Algebraic Geometry},
@@ -708,7 +710,7 @@
   title         = {Fast Library for Number Theory: An Introduction},
   booktitle     = {Proceedings of the Third International Congress on Mathematical Software},
   series        = {ICMS'10},
-  note          = {\url{https://flintlib.org}},
+  note          = {https://flintlib.org},
   address       = {Berlin, Heidelberg},
   publisher     = {Springer-Verlag},
   pages         = {88--91},
@@ -740,7 +742,8 @@
   pages         = {61--88},
   year          = {1999},
   doi           = {10.1016/S0022-4049(99)00005-5},
-  url           = {https://hal.archives-ouvertes.fr/hal-01148855}
+  archiveprefix = {HAL},
+  eprint        = {hal-01148855}
 }
 
 @Book{Ful69,
@@ -1415,7 +1418,7 @@
   series        = {Lectures on mathematics and physics},
   publisher     = {Tata Institute of Fundamental Research},
   year          = {1978},
-  url           = {https://books.google.de/books?id=e1YgAQAAIAAJ},
+  url           = {https://mathweb.tifr.res.in/sites/default/files/publications/ln/tifr58.pdf},
   lccn          = {lc81901205}
 }
 
@@ -1465,7 +1468,8 @@
   number        = {6},
   publisher     = {Elsevier},
   pages         = {457--460},
-  year          = {2011}
+  year          = {2011},
+  doi           = {10.1016/j.orl.2011.09.004}
 }
 
 @Article{PSS11,

--- a/docs/src/Combinatorics/partitions.md
+++ b/docs/src/Combinatorics/partitions.md
@@ -23,8 +23,8 @@ num_partitions(::Oscar.IntegerUnion)
 > How many ways are there to pay one euro, using coins worth 1, 2, 5, 10, 20, 50, and/or 100
 > cents? What if you are allowed to use at most two of each coin? 
 
-This is Exercise 11 in [Knu11](@ref), Section 7.2.1.4 (page 408). It goes back to the famous
-"Ways to change one dollar" problem, see [Pol56](@ref). Generally, the problem is to
+This is Exercise 11 in [Knu11](@cite), Section 7.2.1.4 (page 408). It goes back to the famous
+"Ways to change one dollar" problem, see [Pol56](@cite). Generally, the problem is to
 generate and/or count partitions satisfying some restrictions. Of course, one could generate
 the list of all partitions of 100 (there are about 190 million) and then filter the result
 by the restrictions. But for certain types of restrictions there are much more efficient

--- a/docs/src/DeveloperDocumentation/documentation.md
+++ b/docs/src/DeveloperDocumentation/documentation.md
@@ -129,6 +129,7 @@ this failure by running `bibtool` locally as explained above.
 Please follow the additional guidelines below, that are not checked by bibtool:
 
 - Do not escape special characters like umlauts or accented characters. Instead, use the unicode character directly.
+- You do not need to use braces to preserve capitalization as `DocumenterCitations.jl` keeps entries as is (in contrast to `bibtex`). In some cases, braces can even be harmful, i.e., show up in the output.
 - If a DOI is available for your reference, please add it as a `doi` field to the BibTeX entry. In this case, please refrain from adding an additional `url` field.
 - If your reference has no DOI or the paper is not open-access, but is available as an arXiv preprint, you can add the arXiv link as a `eprint` field (even additionally to a `doi` field). For other preprint servers (e.g. HAL), please refer to the [DocumenterCitations.jl docs](https://juliadocs.org/DocumenterCitations.jl/stable/syntax/#Preprint-support).
 - Documents available only as an arXiv preprint should be added as `@Article` entries with, e.g., `arXiv:2003.10132` in the `journal` field, and, e.g., `10.48550/arxiv.2003.10132` in the `doi` field, but without an `eprint` field.

--- a/docs/src/DeveloperDocumentation/documentation.md
+++ b/docs/src/DeveloperDocumentation/documentation.md
@@ -125,3 +125,10 @@ changes in the bibliography. If so, this test fails and indicates that the
 (recently) added bibliography entries are not standardized. For a merge, it
 is not required that this test is passed. Still, please feel encouraged to fix
 this failure by running `bibtool` locally as explained above.
+
+Please follow the additional guidelines below, that are not checked by bibtool:
+
+- Do not escape special characters like umlauts or accented characters. Instead, use the unicode character directly.
+- If a DOI is available for your reference, please add it as a `doi` field to the BibTeX entry. In this case, please refrain from adding an additional `url` field.
+- If your reference has no DOI or the paper is not open-access, but is available as an arXiv preprint, you can add the arXiv link as a `eprint` field (even additionally to a `doi` field). For other preprint servers (e.g. HAL), please refer to the [DocumenterCitations.jl docs](https://juliadocs.org/DocumenterCitations.jl/stable/syntax/#Preprint-support).
+- Documents available only as an arXiv preprint should be added as `@Article` entries with, e.g., `arXiv:2003.10132` in the `journal` field, and, e.g., `10.48550/arxiv.2003.10132` in the `doi` field, but without an `eprint` field.

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -14,4 +14,5 @@ margin-bottom: 0.75em;
 </style>
 ```
 ```@bibliography
+*
 ```


### PR DESCRIPTION
(Follow-up to https://github.com/oscar-system/Oscar.jl/pull/2598 being broken somehow)

DocumenterCitations (the package that we use for references in the documentation) has received a major update including some breaking changes and a lot of new fancy stuff.
I will first try to get it to work exactly like it does currently with the old version and then try to nice things up.

Preview at  https://docs.oscar-system.org/previews/PR2605/references/