### PR TITLE
minor improvements

### DIFF
--- a/docs/src/General/other.md
+++ b/docs/src/General/other.md
@@ -20,6 +20,15 @@ This section describes differences between GAP and Oscar.
     and one assigns a value to a variable with `:=`.
     In Julia, equality is checked with `==`,
     and `=` denotes assignment.
+    Similarly, inequality of objects is checked with `<>` in GAP
+    and with `!=` in Julia.
+
+  - In GAP, the operator `not` is used to negate boolean expressions,
+    whereas `!` is used in Julia.
+
+  - In GAP, object identity is checked with the function `IsIdenticalObj`,
+    whereas the infix operator `===` (with negation `!==`)
+    is used in Julia.
 
   - In GAP, `if` statements have the form
     ```

--- a/docs/src/Groups/subgroups.md
+++ b/docs/src/Groups/subgroups.md
@@ -70,8 +70,8 @@ complement_system
 ```@docs
 is_conjugate(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)
 is_conjugate(G::GAPGroup, H::GAPGroup, K::GAPGroup)
-representative_action(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)
-representative_action(G::GAPGroup, H::GAPGroup, K::GAPGroup)
+is_conjugate_with_data(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)
+is_conjugate_with_data(G::GAPGroup, H::GAPGroup, K::GAPGroup)
 centralizer(G::GAPGroup, x::GAPGroupElem)
 centralizer(G::T, H::T) where T <: GAPGroup
 normalizer(G::GAPGroup, x::GAPGroupElem)

--- a/experimental/QuadFormAndIsom/src/embeddings.jl
+++ b/experimental/QuadFormAndIsom/src/embeddings.jl
@@ -1131,7 +1131,7 @@ function admissible_equivariant_primitive_extensions(A::ZZLatWithIsom,
     # If not, we try the next potential pair.
     fSAinOSB = OSB(compose(inv(phi), compose(hom(fSA), phi)))
     @hassert :ZZLatWithIsom 1 fSAinOSB in OSBrB  # Same as before, since phi is admissible, then the image of fSA should preserve rho_{l+1}(B)
-    bool, g0 = representative_action(OSBrB, OSBrB(fSAinOSB), fSB)
+    bool, g0 = is_conjugate_with_data(OSBrB, OSBrB(fSAinOSB), fSB)
     bool || continue
 
     # The new phi is "sending" the restriction of fA to this of fB

--- a/experimental/QuadFormAndIsom/src/hermitian_miranda_morrison.jl
+++ b/experimental/QuadFormAndIsom/src/hermitian_miranda_morrison.jl
@@ -319,7 +319,7 @@ function _local_determinants_morphism(Lf::ZZLatWithIsom)
     OqL2 = orthogonal_group(qL2)
     ok, phi12 = is_isometric_with_isometry(qL, qL2)
     @hassert :ZZLatWithIsom 1 ok
-    ok, g0 = representative_action(OqL, fqL, OqL(compose(phi12, compose(hom(fqL2), inv(phi12)))))
+    ok, g0 = is_conjugate_with_data(OqL, fqL, OqL(compose(phi12, compose(hom(fqL2), inv(phi12)))))
     @hassert :ZZLatWithIsom 1 ok
     phi12 = compose(hom(OqL(g0)), phi12)
     @hassert :ZZLatWithIsom 1 is_isometry(phi12)

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -575,21 +575,21 @@ i.e., there is an element $z$ in `G` such that `x^`$z$ equals `y`.
 """
 function is_conjugate(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)
    if isdefined(G,:descr) && (G.descr == :GL || G.descr == :SL)
-     return representative_action_in_gl_or_sl(G, x, y)[1]
+     return is_conjugate_with_data_in_gl_or_sl(G, x, y)[1]
    end
    return GAPWrap.IsConjugate(G.X, x.X, y.X)
 end
 
 """
-    representative_action(G::Group, x::GAPGroupElem, y::GAPGroupElem)
+    is_conjugate_with_data(G::Group, x::GAPGroupElem, y::GAPGroupElem)
 
 If `x` and `y` are conjugate in `G`,
 return `(true, z)`, where `x^z == y` holds;
 otherwise, return `(false, nothing)`.
 """
-function representative_action(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)
+function is_conjugate_with_data(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)
    if isdefined(G,:descr) && (G.descr == :GL || G.descr == :SL)
-     return representative_action_in_gl_or_sl(G, x, y)
+     return is_conjugate_with_data_in_gl_or_sl(G, x, y)
    end
    conj = GAP.Globals.RepresentativeAction(G.X, x.X, y.X)::GapObj
    if conj != GAP.Globals.fail
@@ -795,7 +795,7 @@ false
 is_conjugate(G::GAPGroup, H::GAPGroup, K::GAPGroup) = GAPWrap.IsConjugate(G.X,H.X,K.X)
 
 """
-    representative_action(G::Group, H::Group, K::Group)
+    is_conjugate_with_data(G::Group, H::Group, K::Group)
 
 If `H` and `K` are conjugate subgroups in `G`, return `true, z`
 where `H^z = K`; otherwise, return `false, nothing`.
@@ -810,18 +810,18 @@ Group([ (1,2) ])
 julia> K = sub(G, [G([1, 2, 4, 3])])[1]
 Group([ (3,4) ])
 
-julia> representative_action(G, H, K)
+julia> is_conjugate_with_data(G, H, K)
 (true, (1,3)(2,4))
 
 julia> K = sub(G, [G([2, 1, 4, 3])])[1]
 Group([ (1,2)(3,4) ])
 
-julia> representative_action(G, H, K)
+julia> is_conjugate_with_data(G, H, K)
 (false, nothing)
 
 ```
 """
-function representative_action(G::GAPGroup, H::GAPGroup, K::GAPGroup)
+function is_conjugate_with_data(G::GAPGroup, H::GAPGroup, K::GAPGroup)
    conj = GAP.Globals.RepresentativeAction(G.X, H.X, K.X)::GapObj
    if conj != GAP.Globals.fail
       return true, group_element(G, conj)
@@ -912,7 +912,7 @@ function short_right_transversal(G::PermGroup, H::PermGroup, s::PermGroupElem)
 
   R = PermGroupElem[]
   for c in can
-    success, d = representative_action(G, c, s)
+    success, d = is_conjugate_with_data(G, c, s)
     if success
       push!(R, d)
       @assert c^R[end] == s

--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -111,10 +111,9 @@ conjugacy_classes(G::GrpAbFinGen) = [GrpAbFinGenConjClass(G, x) for x in G]
 
 is_conjugate(G::GrpAbFinGen, x::GrpAbFinGenElem, y::GrpAbFinGenElem) = (x == y)
 
-function representative_action(G::GrpAbFinGen, x::GrpAbFinGenElem, y::GrpAbFinGenElem)
+function is_conjugate_with_data(G::GrpAbFinGen, x::GrpAbFinGenElem, y::GrpAbFinGenElem)
    x == y ? (true, zero(G)) : (false, nothing)
 end
-
 
 ################################################################################
 #
@@ -172,7 +171,7 @@ function is_conjugate(G::GrpAbFinGen, H::GrpAbFinGen, K::GrpAbFinGen)
           is_subgroup(H, K)[1] && is_subgroup(K, H)[1]
 end
 
-function representative_action(G::GrpAbFinGen, H::GrpAbFinGen, K::GrpAbFinGen)
+function is_conjugate_with_data(G(G::GrpAbFinGen, H::GrpAbFinGen, K::GrpAbFinGen)
    if is_subgroup(H, K)[1] && is_subgroup(K, H)[1]
      return true, zero(G)
    else

--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -171,7 +171,7 @@ function is_conjugate(G::GrpAbFinGen, H::GrpAbFinGen, K::GrpAbFinGen)
           is_subgroup(H, K)[1] && is_subgroup(K, H)[1]
 end
 
-function is_conjugate_with_data(G(G::GrpAbFinGen, H::GrpAbFinGen, K::GrpAbFinGen)
+function is_conjugate_with_data(G::GrpAbFinGen, H::GrpAbFinGen, K::GrpAbFinGen)
    if is_subgroup(H, K)[1] && is_subgroup(K, H)[1]
      return true, zero(G)
    else

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -122,7 +122,7 @@ julia> tbl = character_table("A5");
 julia> characteristic(tbl)
 0
 
-julia> characteristic(mod(tbl, 2))
+julia> characteristic(tbl % 2)
 2
 ```
 """
@@ -188,7 +188,7 @@ provided that `tbl` is a Brauer character table.
 ```jldoctest
 julia> tbl = character_table("A5");
 
-julia> ordinary_table(mod(tbl, 2)) === tbl
+julia> ordinary_table(tbl % 2) === tbl
 true
 ```
 """
@@ -1091,15 +1091,18 @@ Base.iterate(tbl::GAPGroupCharacterTable, state = 1) = state > nrows(tbl) ? noth
 
 """
     mod(tbl::GAPGroupCharacterTable, p::T) where T <: IntegerUnion
+    rem(tbl::GAPGroupCharacterTable, p::T) where T <: IntegerUnion
 
 Return the `p`-modular character table of `tbl`,
 or `nothing` if this table cannot be computed.
+
+The syntax `tbl % p` is also supported.
 
 An exception is thrown if `tbl` is not an ordinary character table.
 
 # Examples
 ```jldoctest
-julia> show(mod(character_table("A5"), 2))
+julia> show(character_table("A5") % 2)
 2-modular Brauer table of A5
 ```
 """
@@ -1124,6 +1127,8 @@ function Base.mod(tbl::GAPGroupCharacterTable, p::T) where T <: IntegerUnion
 
     return modtbls[p]
 end
+
+rem(tbl::GAPGroupCharacterTable, p::T) where T <: IntegerUnion = mod(tbl, p)
 
 """
     decomposition_matrix(modtbl::GAPGroupCharacterTable)

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -546,7 +546,7 @@ is_conjugate(Omega::GSet, omega1, omega2) = omega2 in orbit(Omega, omega1)
 
 
 """
-    representative_action(Omega::GSet, omega1, omega2)
+    is_conjugate_with_data(Omega::GSet, omega1, omega2)
 
 Determine whether `omega1`, `omega2` are in the same orbit of `Omega`.
 If yes, return `true, g` where `g` is an element in the group `G` of
@@ -560,15 +560,15 @@ Group([ (1,2), (3,4), (1,3)(2,4), (5,6) ])
 
 julia> Omega = gset(G);
 
-julia> representative_action(Omega, 1, 2)
+julia> is_conjugate_with_data(Omega, 1, 2)
 (true, (1,2))
 
-julia> representative_action(Omega, 1, 5)
+julia> is_conjugate_with_data(Omega, 1, 5)
 (false, ())
 
 ```
 """
-function representative_action(Omega::GSet, omega1, omega2)
+function is_conjugate_with_data(G(Omega::GSet, omega1, omega2)
     # We do not call GAP's 'RepresentativeAction' with points, generators,
     # and actors.
     # The method in question would create a new 'ExternalSet' object
@@ -589,7 +589,6 @@ function representative_action(Omega::GSet, omega1, omega2)
     @assert(pre[1])
     return true, pre[2]
 end
-
 
 ############################################################################
 

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -568,7 +568,7 @@ julia> is_conjugate_with_data(Omega, 1, 5)
 
 ```
 """
-function is_conjugate_with_data(G(Omega::GSet, omega1, omega2)
+function is_conjugate_with_data(Omega::GSet, omega1, omega2)
     # We do not call GAP's 'RepresentativeAction' with points, generators,
     # and actors.
     # The method in question would create a new 'ExternalSet' object

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -118,14 +118,12 @@ function Base.show(io::IO, x::MatrixGroup)
    if isdefined(x, :descr)
       if x.descr==:GU || x.descr==:SU
          print(io, string(x.descr), "(",x.deg,",",characteristic(x.ring)^(div(degree(x.ring),2)),")")
+      elseif x.ring isa Field && is_finite(x.ring)
+         print(io, string(x.descr), "(",x.deg,",",order(x.ring),")")
       else
-         if x.ring isa Field
-            print(io, string(x.descr), "(",x.deg,",",order(x.ring),")")
-         else
-            print(io, string(x.descr), "(",x.deg,",")
-            print(IOContext(io, :supercompact => true), x.ring)
-            print(io ,")")
-         end
+         print(io, string(x.descr), "(",x.deg,",")
+         print(IOContext(io, :supercompact => true), x.ring)
+         print(io ,")")
       end
    else
       print(io, "Matrix group of degree ", x.deg, " over ")
@@ -529,8 +527,9 @@ end
 ########################################################################
 
 function _field_from_q(q::Int)
-   (n,p) = is_power(q)
-   @req is_prime(p) "The field size must be a prime power"
+   flag, n, p = is_prime_power_with_data(q)
+   @req flag "The field size must be a prime power"
+
    return GF(p, n)
 end
 

--- a/src/Groups/matrices/linear_isconjugate.jl
+++ b/src/Groups/matrices/linear_isconjugate.jl
@@ -134,7 +134,7 @@ function generalized_jordan_form(A::MatElem{T}; with_pol::Bool=false) where T
 end
 
 
-function representative_action_in_gl_or_sl(G::MatrixGroup, x::MatrixGroupElem, y::MatrixGroupElem)
+function is_conjugate_with_data_in_gl_or_sl(G::MatrixGroup, x::MatrixGroupElem, y::MatrixGroupElem)
    (isdefined(G,:descr) && (G.descr == :GL || G.descr == :SL)) ||
    throw(ArgumentError("Group must be general or special linear group"))
 

--- a/src/aliases.jl
+++ b/src/aliases.jl
@@ -68,6 +68,8 @@
 @alias isunipotent is_unipotent
 @alias isunital is_unital
 @alias iswelldefined is_welldefined
+@alias representative_action is_conjugate_with_data
+@alias representative_action_in_gl_or_sl is_conjugate_with_data_in_gl_or_sl
 
 # Allow backwards compatibility after removal of Oscar.Graphs module.
 const Graphs = Oscar

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -707,6 +707,7 @@ export is_complete
 export is_congruent
 export is_conjugate
 export is_conjugate_subgroup
+export is_conjugate_with_data
 export is_connected
 export is_cyclic, has_is_cyclic, set_is_cyclic
 export is_degenerate
@@ -1170,7 +1171,6 @@ export rem_vertex!
 export renest
 export repres
 export representative
-export representative_action
 export represents_element
 export restrict
 export restrict_automorphism

--- a/test/Groups/GrpAb.jl
+++ b/test/Groups/GrpAb.jl
@@ -73,7 +73,7 @@ end
     @test acting_group(cc[1]) == G1
     for x in gens(G1), y in gens(G1)
       @test is_conjugate(G1, x, y) == (x == y)
-      @test is_conjugate_with_data_in_gl_or_sl(G1, x, y)[1] == (x == y)
+      @test is_conjugate_with_data(G1, x, y)[1] == (x == y)
     end
     C = cc[1]
     for H in C
@@ -95,7 +95,7 @@ end
       H = representative(C1)
       K = representative(C2)
       @test is_conjugate(G1, H, K) == (H == K)
-      @test is_conjugate_with_data_in_gl_or_sl(G1, H, K)[1] == (H == K)
+      @test is_conjugate_with_data(G1, H, K)[1] == (H == K)
       @test is_conjugate_subgroup(G1, H, K) == is_subgroup(K, H)[1]
     end
     C = CC[1]

--- a/test/Groups/GrpAb.jl
+++ b/test/Groups/GrpAb.jl
@@ -73,7 +73,7 @@ end
     @test acting_group(cc[1]) == G1
     for x in gens(G1), y in gens(G1)
       @test is_conjugate(G1, x, y) == (x == y)
-      @test representative_action(G1, x, y)[1] == (x == y)
+      @test is_conjugate_with_data_in_gl_or_sl(G1, x, y)[1] == (x == y)
     end
     C = cc[1]
     for H in C
@@ -95,7 +95,7 @@ end
       H = representative(C1)
       K = representative(C2)
       @test is_conjugate(G1, H, K) == (H == K)
-      @test representative_action(G1, H, K)[1] == (H == K)
+      @test is_conjugate_with_data_in_gl_or_sl(G1, H, K)[1] == (H == K)
       @test is_conjugate_subgroup(G1, H, K) == is_subgroup(K, H)[1]
     end
     C = CC[1]

--- a/test/Groups/conjugation.jl
+++ b/test/Groups/conjugation.jl
@@ -25,12 +25,12 @@
   y = rand(cc)
   @test order(y) == order(x)
   @test is_conjugate(G,x,x^y)
-  @test representative_action(G,x,x^y)[1]
-  z = representative_action(G,x,x^y)[2]
+  @test is_conjugate_with_data(G,x,x^y)[1]
+  z = is_conjugate_with_data(G,x,x^y)[2]
   @test x^z == x^y
   z = cperm(G,[1,2])
   @test !is_conjugate(G,x,z)
-  @test !representative_action(G,x,z)[1]
+  @test !is_conjugate_with_data(G,x,z)[1]
 
 
   @inferred ZZRingElem number_conjugacy_classes(symmetric_group(4))
@@ -62,12 +62,12 @@
      x = rand(c)
      y = rand(c)
      @test is_conjugate(G,x,y)
-     @test representative_action(G,x,y)[1]
-     z = representative_action(G,x,y)[2]
+     @test is_conjugate_with_data(G,x,y)[1]
+     z = is_conjugate_with_data(G,x,y)[2]
      @test x^z == y
      y = rand(C[(i%5)+1])
      @test !is_conjugate(G,x,y)
-     @test !representative_action(G,x,y)[1]
+     @test !is_conjugate_with_data(G,x,y)[1]
   end
 
   CC = @inferred conjugacy_classes_subgroups(G)
@@ -86,12 +86,12 @@
      x = rand(c)
      y = rand(c)
      @test is_conjugate(G,x,y)
-     @test representative_action(G,x,y)[1]
-     z = representative_action(G,x,y)[2]
+     @test is_conjugate_with_data(G,x,y)[1]
+     z = is_conjugate_with_data(G,x,y)[2]
      @test x^z == y
      y = rand(CC[(i % length(CC))+1])
      @test !is_conjugate(G,x,y)
-     @test !representative_action(G,x,y)[1]
+     @test !is_conjugate_with_data(G,x,y)[1]
   end
 
   CC = @inferred conjugacy_classes_maximal_subgroups(G)
@@ -155,10 +155,10 @@ end
    @test order(M) == 4
    @test is_conjugate(G, M, inv(M))
    @test ! is_conjugate(G, M, M^2)
-   flag, N = representative_action(G, M, inv(M))
+   flag, N = is_conjugate_with_data(G, M, inv(M))
    @test flag
    @test M^N == inv(M)
-   flag, _ = representative_action(G, M, M^2)
+   flag, _ = is_conjugate_with_data(G, M, M^2)
    @test ! flag
 end
 
@@ -172,14 +172,14 @@ end
    y = generalized_jordan_block(t-1,8)
    x[7,8]=l
    x=S(x); y=S(y);
-   vero, z = representative_action(G, x, y)
+   vero, z = is_conjugate_with_data(G, x, y)
    @test vero
    @test z in G
    @test x^z==y
-   vero, z = representative_action(S, x, y)
+   vero, z = is_conjugate_with_data(S, x, y)
    @test !vero
    x.elm[7,8]=l^8
-   vero, z = representative_action(S, x, y)
+   vero, z = is_conjugate_with_data(S, x, y)
    @test z in S
    @test x^z==y
 

--- a/test/Groups/describe.jl
+++ b/test/Groups/describe.jl
@@ -35,8 +35,13 @@ end
 end
 
 @testset "describe() for projective groups" begin
-   # TODO: PGL / projective_general_linear_group constructor is missing
-   # TODO: PSL / projective_general_linear_group constructor is missing
+   @test describe(projective_general_linear_group(2, 2)) == "S3"
+   @test describe(projective_general_linear_group(2, 7)) == "PSL(3,2) : C2"
+   @test describe(projective_general_linear_group(3, 2)) == "PSL(3,2)"
+
+   @test describe(projective_special_linear_group(2, 2)) == "S3"
+   @test describe(projective_special_linear_group(2, 7)) == "PSL(3,2)"
+   @test describe(projective_special_linear_group(3, 2)) == "PSL(3,2)"
 end
 
 @testset "describe() for free groups" begin

--- a/test/Groups/directproducts.jl
+++ b/test/Groups/directproducts.jl
@@ -58,8 +58,8 @@
    P=sylow_subgroup(G,2)[1]
    PP=direct_product(P1,P2)
    @test order(P)==order(P1)*order(P2)
-   @test representative_action(G,P,PP)[1]
-   x = representative_action(G,P,PP)[2]
+   @test is_conjugate_with_data(G,P,PP)[1]
+   x = is_conjugate_with_data(G,P,PP)[2]
    @test P^x==PP
 
    @test_throws ArgumentError as_perm_group(G)

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -735,6 +735,9 @@ end
   ordtbl = character_table("A5")
   modtbl = mod(ordtbl, 2)
 
+  @test modtbl === rem(ordtbl, 2)
+  @test modtbl === ordtbl % 2
+
   @test characteristic(ordtbl) == 0
   @test characteristic(modtbl) == 2
   @test character_parameters(ordtbl) == [[1, 1, 1, 1, 1], [[3, 1, 1], '+'], [[3, 1, 1], '-'], [2, 1, 1, 1], [2, 2, 1]]

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -131,13 +131,13 @@
   @test is_conjugate(Omega, [0,1,0,1,0,1], [1,0,1,0,1,0])
   @test ! is_conjugate(Omega, [0,1,0,1,0,1], [1,2,3,4,5,6])
 
-  # representative_action
+  # is_conjugate_with_data
   G = symmetric_group(6)
   Omega = gset(G, permuted, [[0,1,0,1,0,1], [1,2,3,4,5,6]])
-  rep = representative_action(Omega, [0,1,0,1,0,1], [1,0,1,0,1,0])
+  rep = is_conjugate_with_data(Omega, [0,1,0,1,0,1], [1,0,1,0,1,0])
   @test rep[1]
   @test permuted([0,1,0,1,0,1], rep[2]) == [1,0,1,0,1,0]
-  rep = representative_action(Omega, [0,1,0,1,0,1], [1,2,3,4,5,6])
+  rep = is_conjugate_with_data(Omega, [0,1,0,1,0,1], [1,2,3,4,5,6])
   @test ! rep[1]
 
 end
@@ -266,12 +266,12 @@ end
   @test isconjugate(Omega, gen(V, 1), gen(V, 2))
   @test ! isconjugate(Omega, zero(V), gen(V, 1))
 
-  # representative_action
+  # is_conjugate_with_data
   Omega = gset(G)
-  rep = representative_action(Omega, gens(V)...)
+  rep = is_conjugate_with_data(Omega, gens(V)...)
   @test rep[1]
   @test gen(V, 1) * rep[2] == gen(V, 2)
-  rep = representative_action(Omega, zero(V), gen(V, 1))
+  rep = is_conjugate_with_data(Omega, zero(V), gen(V, 1))
   @test ! rep[1]
 
 end

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -291,7 +291,7 @@ end
    @test is_isomorphic(P,dihedral_group(8))
    P = sylow_subgroup(G,3)[1]
    @test order(P)==3
-   @test representative_action(G, P, sub(G, [cperm(1:3)])[1])[1]
+   @test is_conjugate_with_data(G, P, sub(G, [cperm(1:3)])[1])[1]
    P = sylow_subgroup(G,5)[1]
    @test P==sub(G,[one(G)])[1]
    @test_throws ArgumentError P=sylow_subgroup(G,4)


### PR DESCRIPTION
- renamed `representative_action` to `is_conjugate_with_data`, as suggested by @fieker (but keep `representative_action` as an alias),
- support the syntax `tbl % p` for constructing `p`-modular character tables, as suggested by @fieker,
- added some tests for `describe(projective_general_linear_group(n, q))` and `describe(projective_special_linear_group(n, q))`,
- mention more differences between Julia and GAP