### PR TITLE
next round for `algebraic_closure`

### DIFF
--- a/docs/doc.main
+++ b/docs/doc.main
@@ -57,6 +57,7 @@
         "Nemo/qadic.md",
      ],
      "Nemo/finitefield.md",
+     "Fields/algebraic_closure_fp.md",
   ],
 
   "Linear Algebra" => [

--- a/docs/src/Fields/algebraic_closure_fp.md
+++ b/docs/src/Fields/algebraic_closure_fp.md
@@ -1,0 +1,19 @@
+```@meta
+CurrentModule = Oscar
+DocTestSetup = quote
+  using Oscar
+end
+```
+
+# Algebraic closure of finite prime fields
+
+It is sometimes useful to consider various finite fields in a fixed
+characteristic at the same time, together with natural embeddings
+between these fields.
+The fields returned by [`abelian_closure`](@ref) are intended for that
+purpose.
+
+```@docs
+algebraic_closure
+ext_of_degree
+```

--- a/src/Rings/AlgClosureFp.jl
+++ b/src/Rings/AlgClosureFp.jl
@@ -15,8 +15,8 @@ import Base: +, -, *, //, ==, deepcopy_internal, hash, isone, iszero, one,
   parent, show, zero
 
 import ..Oscar: base_field, base_ring, characteristic, data, degree, divexact,
-  elem_type, embedding, IntegerUnion, is_unit, map_entries, minpoly,
-  parent_type, promote_rule, roots
+  elem_type, embedding, has_preimage, IntegerUnion, is_unit, map_entries,
+  minpoly, parent_type, promote_rule, roots
 
 struct AlgClosure{T} <: AbstractAlgebra.Field
   # T <: FinField
@@ -177,7 +177,7 @@ function roots(a::AlgClosureElem, b::Int)
   return [AlgClosureElem(x, parent(a)) for x = r]
 end
 
-function roots(a::Generic.Poly{AlgClosureElem})
+function roots(a::Generic.Poly{AlgClosureElem{T}}) where T
   A = base_ring(a)
   b = minimize(FinField, collect(coefficients(a)))
   kx, x = polynomial_ring(parent(b[1]), cached = false)
@@ -309,9 +309,15 @@ end
 
 function embedding(k::T, K::AlgClosure{T}) where T <: FinField
   @req characteristic(k) == characteristic(K) "incompatible characteristics"
-  f = x::FqFieldElem -> K(x)
+  f = x::FinFieldElem -> K(x)
   finv = x::AlgClosureElem{T} -> k(x)
   return MapFromFunc(k, K, f, finv)
+end
+
+function has_preimage(mp::MapFromFunc{T, AlgClosure{S}}, elm::AlgClosureElem{S}) where T <: FinField where S <: FinField
+  F = domain(mp)
+  mod(degree(F), degree(elm)) != 0 && return false, zero(F)
+  return true, preimage(mp, elm)
 end
 
 end # AlgClosureFp

--- a/src/Rings/AlgClosureFp.jl
+++ b/src/Rings/AlgClosureFp.jl
@@ -15,7 +15,8 @@ import Base: +, -, *, //, ==, deepcopy_internal, hash, isone, iszero, one,
   parent, show, zero
 
 import ..Oscar: base_field, base_ring, characteristic, data, degree, divexact,
-  elem_type, map_entries, minpoly, parent_type, roots
+  elem_type, embedding, IntegerUnion, is_unit, map_entries, minpoly,
+  parent_type, promote_rule, roots
 
 struct AlgClosure{T} <: AbstractAlgebra.Field
   # T <: FinField
@@ -35,7 +36,7 @@ base_ring(A::AlgClosure) = A.k
 characteristic(k::AlgClosure) = characteristic(base_field(k))
 
 struct AlgClosureElem{T} <: FieldElem
-  # T <: FinFieldElem
+  # T <: FinField
   data::FinFieldElem
   parent::AlgClosure{T}
 end
@@ -50,10 +51,10 @@ function show(io::IO, a::AlgClosureElem)
 end
 
 function deepcopy_internal(a::AlgClosureElem, d::IdDict)
-  return AlgClosureElem(data(a), parent(a))
+  return AlgClosureElem(deepcopy_internal(data(a), d), parent(a))
 end
 
-(A::AlgClosure)(a::Int) = AlgClosureElem(A.k(a), A)
+(A::AlgClosure)(a::IntegerUnion) = AlgClosureElem(A.k(a), A)
 (A::AlgClosure)(a::AlgClosureElem) = a
 (A::AlgClosure)() = A(0)
 function (A::AlgClosure)(a::FinFieldElem)
@@ -75,6 +76,16 @@ function check_parent(a::AlgClosureElem, b::AlgClosureElem)
   parent(a) == parent(b) || error("incompatible elements")
 end
 
+#TODO: Guarantee to return a field of the same type as `base_ring(A)`?
+# (Then `Nemo.fpField` cannot be supported as `base_ring(A)`)
+@doc raw"""
+    ext_of_degree(A::AlgClosure, d::Int)
+
+Return a finite field `F` of order `p^d`
+where `p` is the characteristic of `K`.
+This field is compatible with `A` in the sense that `A(x)` returns the
+element of `A` that corresponds to the element `x` of `F`.
+"""
 function ext_of_degree(A::AlgClosure, d::Int)
   if haskey(A.fld, d)
     return A.fld[d]
@@ -82,6 +93,8 @@ function ext_of_degree(A::AlgClosure, d::Int)
   k = base_ring(A)
   if isa(k, Nemo.fpField) || isa(k, fqPolyRepField)
     K = GF(Int(characteristic(k)), d, cached = false)
+  elseif isa(k, FqField)
+    K = Nemo._GF(characteristic(k), d, cached = false)
   else
     K = GF(characteristic(k), d, cached = false)
   end
@@ -111,13 +124,46 @@ end
 
 +(a::AlgClosureElem, b::AlgClosureElem) = AlgClosureElem(op(+, a, b), parent(a))
 -(a::AlgClosureElem, b::AlgClosureElem) = AlgClosureElem(op(-, a, b), parent(a))
+#TODO: do we really want to support different types here? (implies different parents)
 *(a::AlgClosureElem{T}, b::AlgClosureElem{S}) where S where T = AlgClosureElem(op(*, a, b), parent(a))
 //(a::AlgClosureElem, b::AlgClosureElem) = AlgClosureElem(op(//, a, b), parent(a))
-divexact(a::AlgClosureElem, b::AlgClosureElem) = AlgClosureElem(op(divexact, a, b), parent(a))
+divexact(a::AlgClosureElem, b::AlgClosureElem; check = true) = AlgClosureElem(op(divexact, a, b), parent(a))
 ==(a::AlgClosureElem, b::AlgClosureElem) = op(==, a, b)
 iszero(a::AlgClosureElem) = iszero(data(a))
 isone(a::AlgClosureElem) = isone(data(a))
 -(a::AlgClosureElem) = AlgClosureElem(-data(a), parent(a))
+
+
+################################################################################
+#
+#  Ad hoc binary operations
+#
+################################################################################
+
+*(a::IntegerUnion, b::AlgClosureElem) = AlgClosureElem(data(b)*a, parent(b))
+
+*(a::AlgClosureElem, b::IntegerUnion) = b*a
+
++(a::IntegerUnion, b::AlgClosureElem) = AlgClosureElem(data(b) + a, parent(b))
+
++(a::AlgClosureElem, b::IntegerUnion) = b + a
+
+-(a::IntegerUnion, b::AlgClosureElem) = AlgClosureElem(-(a, data(b)), parent(b))
+
+-(a::AlgClosureElem, b::IntegerUnion) = AlgClosureElem(-(data(a), b), parent(a))
+
+//(a::AlgClosureElem, b::Integer) = AlgClosureElem(data(a)//b, parent(a))
+//(a::AlgClosureElem, b::ZZRingElem) = AlgClosureElem(data(a)//b, parent(a))
+
+
+is_unit(a::AlgClosureElem) = !iszero(a)
+
+
+###############################################################################
+#
+#   Functions for computing roots
+#
+###############################################################################
 
 function roots(a::AlgClosureElem, b::Int)
   ad = data(a)
@@ -131,7 +177,7 @@ function roots(a::AlgClosureElem, b::Int)
   return [AlgClosureElem(x, parent(a)) for x = r]
 end
 
-function roots(a::Generic.Poly{AlgClosureElem{T}}) where T
+function roots(a::Generic.Poly{AlgClosureElem})
   A = base_ring(a)
   b = minimize(FinField, collect(coefficients(a)))
   kx, x = polynomial_ring(parent(b[1]), cached = false)
@@ -145,15 +191,22 @@ function roots(a::Generic.Poly{AlgClosureElem{T}}) where T
 end
 
 
+#TODO: Does this really make sense?
+# K = algebraic_closure(GF(3, 1))
+# F2 = ext_of_degree(K, 2)
+# a = gen(F2); fa = minpoly(a); fa(a)  # works
+# c = K(a); fc = minpoly(c); fc(c)  # does not work
 function minpoly(a::AlgClosureElem)
   return minpoly(data(a))
 end
 
+#TODO: Move to Nemo.
 function minpoly(a::fpFieldElem)
   kx, x = polynomial_ring(parent(a), cached = false)
   return x-a
 end
 
+# Note: We want the degree of the smallest finite field that contains `a`.
 function degree(a::AlgClosureElem)
   #TODO: via Frobenius? as a fixed s.th.?
   return degree(minpoly(data(a)))
@@ -215,11 +268,61 @@ function map_entries(K::FinField, M::MatElem{<:AlgClosureElem})
   return N
 end
 
+
+################################################################################
+#
+#  Creation of the field
+#
+################################################################################
+
+@doc raw"""
+    algebraic_closure(F::FinField)
+
+Let `F` be a prime field of order `p`.
+Return a field `K` that is the union of finite fields of oder `p^d`,
+for all positive integers `d`.
+The degree `d` extension of `F` can be obtained as `ext_of_degree(K, d)`.
+
+`K` is cached in `F`, and the fields returned by `ext_of_degree` are
+cached in `K`.
+
+# Examples
+```jldoctest; setup = :(using Oscar)
+julia> K = algebraic_closure(GF(3, 1));
+
+julia> F2 = ext_of_degree(K, 2);
+
+julia> F3 = ext_of_degree(K, 3);
+
+julia> x = K(gen(F2)) + K(gen(F3));
+
+julia> degree(x)
+6
+```
+"""
+function algebraic_closure(F::T) where T <: FinField
+  @req is_prime(order(F)) "only for finite prime fields"
+  return get_attribute!(F, :algebraic_closure) do
+    return AlgClosure(F)
+  end::AlgClosure{T}
+end
+
+function embedding(k::T, K::AlgClosure{T}) where T <: FinField
+  @req characteristic(k) == characteristic(K) "incompatible characteristics"
+  f = x::FqFieldElem -> K(x)
+  finv = x::AlgClosureElem{T} -> k(x)
+  return MapFromFunc(k, K, f, finv)
+end
+
 end # AlgClosureFp
 
 import .AlgClosureFp:
        AlgClosure,
-       AlgClosureElem
+       AlgClosureElem,
+       algebraic_closure,
+       ext_of_degree
 
 export AlgClosure,
-       AlgClosureElem
+       AlgClosureElem,
+       algebraic_closure,
+       ext_of_degree

--- a/test/Rings/AlgClosureFp.jl
+++ b/test/Rings/AlgClosureFp.jl
@@ -1,0 +1,173 @@
+function test_elem(K::AlgClosure{T}) where T <: FinField
+  d = rand(1:8)
+  F = ext_of_degree(K, d)
+  return K(rand(F))
+end
+
+@testset "AlgClosureFp" begin
+  @testset "Interface" begin
+    K = algebraic_closure(GF(3,1))
+    test_Field_interface(K)
+  end
+
+  @testset "Creation" begin
+    F = GF(3, 1)
+    K = algebraic_closure(F)
+    @test base_field(K) === F
+    @test characteristic(K) == characteristic(F)
+
+    @inferred algebraic_closure(F)
+    @test K === algebraic_closure(F)
+    @test K isa AlgClosure
+    @test elem_type(K) === AlgClosureElem{typeof(F)}
+    @test elem_type(typeof(K)) === AlgClosureElem{typeof(F)}
+    @test parent_type(AlgClosureElem{typeof(F)}) === AlgClosure{typeof(F)}
+    @test parent_type(one(K)) === AlgClosure{typeof(F)}
+
+    a = @inferred K()
+    @test a isa AlgClosureElem
+    @test parent(a) === K
+
+    a = @inferred K(1)
+    @test parent(a) === K
+    @test a isa AlgClosureElem
+    @test isone(a)
+    @test isone(one(a))
+    @test !iszero(a)
+
+    a = @inferred K(0)
+    @test parent(a) === K
+    @test a isa AlgClosureElem
+    @test iszero(a)
+    @test iszero(zero(a))
+    @test !isone(a)
+
+    c = one(K) + one(K)
+    for T in [Int, BigInt, ZZRingElem]
+      b = @inferred K(T(2))
+      @test b == c
+    end
+
+    b = deepcopy(a)
+    @test a !== b
+    @test a == b
+  end
+
+  @testset "Printing" begin
+    F = GF(3, 1)
+    K = algebraic_closure(F)
+    @test sprint(show, "text/plain", K) == "Algebraic Closure of Finite field of degree 1 over GF(3)"
+
+    for x in F
+      @test sprint(show, "text/plain", K(x)) == sprint(show, "text/plain", x)
+    end
+  end
+
+  @testset "Coercion and conversion" begin
+    F1 = GF(3, 1)
+    K = algebraic_closure(F1)
+    F2 = ext_of_degree(K, 2)
+    a = gen(F2)
+    c = K(a)
+    @test F2(c) == a
+    F3 = ext_of_degree(K, 3)
+    b = gen(F3)
+    d = K(b)
+    @test F3(d) == b
+    @test_throws ErrorException F2(d)
+  end
+
+  @testset "Arithmetic" begin
+    F1 = GF(3, 1)
+    K = algebraic_closure(F1)
+    @test is_unit(K(gen(F1)))
+    @test !is_unit(zero(K))
+    a = one(K)
+    @test isone(inv(a))
+    for i in 1:10
+      a = test_elem(K)
+      b = test_elem(K)
+      c = test_elem(K)
+      @test iszero(a - a)
+      @test iszero(a + (-a))
+      @test a * (b + c) == a*b + a*c
+      @test (b + c) * a == b*a + c*a
+      @test a * (b - c) == a*b - a*c
+      @test (b - c) * a == b*a - c*a
+      if !iszero(a)
+        @test isone(a * inv(a))
+        @test divexact(a * b, a) == b
+        @test //(a * b, a) == b
+        @test div(a * b, a) == b
+      end
+      @test a^10 == reduce(*, fill(a, 10))
+      @test a^ZZRingElem(10) == reduce(*, fill(a, 10))
+    end
+  end
+
+  @testset "Ad hoc operations" begin
+    F1 = GF(3, 1)
+    K = algebraic_closure(F1)
+    for i in 1:10
+      a = test_elem(K)
+      for T in [Int, BigInt, ZZRingElem]
+        b = rand(-10:10)
+        @test a * b == a * K(b)
+        @test b * a == a * K(b)
+        @test a + b == a + K(b)
+        @test b + a == a + K(b)
+        @test a - b == a - K(b)
+        @test b - a == K(b) - a
+        if !iszero(b % characteristic(K))
+          @test //(a * b, b) == a
+        end
+      end
+    end
+  end
+
+  @testset "Comparison" begin
+    p = 3
+    F1 = GF(p, 1)
+    K = algebraic_closure(F1)
+    F2 = ext_of_degree(K, 2)
+    F3 = ext_of_degree(K, 3)
+    F4 = ext_of_degree(K, 4)
+    a = K(gen(F1))
+    b = K(gen(F2))
+    c = K(gen(F4))
+
+#TODO: make the setup type stable
+#   @test @inferred a == b^(p+1)
+    @test a == b^(p+1)
+    @test b == c^(p^2+1)
+
+    @test hash(a, zero(UInt)) == hash(b^(p+1), zero(UInt))
+  end
+
+  @testset "Polynomial" begin
+    p = 3
+    F1 = GF(p, 1)
+    K = algebraic_closure(F1)
+    Kx, x = K["x"]
+    @test (x^2 + 1)(K(1)) == 2*K(1)
+  end
+
+  @testset "Matrix" begin
+    p = 3
+    F1 = GF(p, 1)
+    K = algebraic_closure(F1)
+    z = zero(K)
+    o = one(K)
+    M = matrix(K, 2, 2, [o, o, z, o])
+    @test M^2 == M * M
+  end
+
+  @testset "Singular ring" begin
+    p = 3
+    F1 = GF(p, 1)
+    K = algebraic_closure(F1)
+    L = Oscar.singular_coeff_ring(K)
+    a = K(gen(F1))
+    @test K(L(a)) == a
+  end
+end

--- a/test/Rings/AlgClosureFp.jl
+++ b/test/Rings/AlgClosureFp.jl
@@ -76,8 +76,7 @@ end
 
   @testset "Arithmetic for $F1" for F1 in [GF(3, 1), Nemo._GF(3, 1)]
     K = algebraic_closure(F1)
-#TODO: uncomment when https://github.com/Nemocas/Nemo.jl/issues/1520 is fixed
-#   @test is_unit(K(gen(F1)))
+    @test is_unit(K(one(F1)))
     @test !is_unit(zero(K))
     a = one(K)
     @test isone(inv(a))
@@ -127,20 +126,14 @@ end
     K = algebraic_closure(F1)
     F2 = ext_of_degree(K, 2)
     F3 = ext_of_degree(K, 3)
-    F4 = ext_of_degree(K, 4)
-    a = K(gen(F1))
-    b = K(gen(F2))
-    c = K(gen(F4))
 
-    p = characteristic(F1)
 #TODO: make the setup type stable
-#   @test @inferred a == b^(p+1)
-#TODO: uncomment when https://github.com/Nemocas/Nemo.jl/issues/1520 is fixed
-#   @test a == b^(p+1)
-    @test b == c^(p^2+1)
+#   @test @inferred K(one(F1)) == K(one(F2))
+    @test K(one(F1)) == K(one(F2))
+    @test K(one(F2)) == K(one(F3))
 
-#   @test hash(a, zero(UInt)) == hash(b^(p+1), zero(UInt))
-    @test hash(b, zero(UInt)) == hash(c^(p^2+1), zero(UInt))
+    @test hash(K(one(F1)), zero(UInt)) == hash(K(one(F2)), zero(UInt))
+    @test hash(K(one(F2)), zero(UInt)) == hash(K(one(F3)), zero(UInt))
   end
 
   @testset "Embeddings for $F1" for F1 in [GF(3, 1), Nemo._GF(3, 1)]

--- a/test/Rings/AlgClosureFp.jl
+++ b/test/Rings/AlgClosureFp.jl
@@ -5,13 +5,12 @@ function test_elem(K::AlgClosure{T}) where T <: FinField
 end
 
 @testset "AlgClosureFp" begin
-  @testset "Interface" begin
+  @testset "Interface for $F" for F in [GF(3, 1), Nemo._GF(3, 1)]
     K = algebraic_closure(GF(3,1))
     test_Field_interface(K)
   end
 
-  @testset "Creation" begin
-    F = GF(3, 1)
+  @testset "Creation for $F" for F in [GF(3, 1), Nemo._GF(3, 1)]
     K = algebraic_closure(F)
     @test base_field(K) === F
     @test characteristic(K) == characteristic(F)
@@ -53,8 +52,7 @@ end
     @test a == b
   end
 
-  @testset "Printing" begin
-    F = GF(3, 1)
+  @testset "Printing for $F" for F in [GF(3, 1), Nemo._GF(3, 1)]
     K = algebraic_closure(F)
     @test sprint(show, "text/plain", K) == "Algebraic Closure of Finite field of degree 1 over GF(3)"
 
@@ -63,8 +61,7 @@ end
     end
   end
 
-  @testset "Coercion and conversion" begin
-    F1 = GF(3, 1)
+  @testset "Coercion and conversion for $F1" for F1 in [GF(3, 1), Nemo._GF(3, 1)]
     K = algebraic_closure(F1)
     F2 = ext_of_degree(K, 2)
     a = gen(F2)
@@ -77,10 +74,10 @@ end
     @test_throws ErrorException F2(d)
   end
 
-  @testset "Arithmetic" begin
-    F1 = GF(3, 1)
+  @testset "Arithmetic for $F1" for F1 in [GF(3, 1), Nemo._GF(3, 1)]
     K = algebraic_closure(F1)
-    @test is_unit(K(gen(F1)))
+#TODO: uncomment when https://github.com/Nemocas/Nemo.jl/issues/1520 is fixed
+#   @test is_unit(K(gen(F1)))
     @test !is_unit(zero(K))
     a = one(K)
     @test isone(inv(a))
@@ -102,11 +99,12 @@ end
       end
       @test a^10 == reduce(*, fill(a, 10))
       @test a^ZZRingElem(10) == reduce(*, fill(a, 10))
+      x = 5
+      @test a // x == a // ZZRingElem(x)
     end
   end
 
-  @testset "Ad hoc operations" begin
-    F1 = GF(3, 1)
+  @testset "Ad hoc operations for $F1" for F1 in [GF(3, 1), Nemo._GF(3, 1)]
     K = algebraic_closure(F1)
     for i in 1:10
       a = test_elem(K)
@@ -125,9 +123,7 @@ end
     end
   end
 
-  @testset "Comparison" begin
-    p = 3
-    F1 = GF(p, 1)
+  @testset "Comparison for $F1" for F1 in [GF(3, 1), Nemo._GF(3, 1)]
     K = algebraic_closure(F1)
     F2 = ext_of_degree(K, 2)
     F3 = ext_of_degree(K, 3)
@@ -136,25 +132,44 @@ end
     b = K(gen(F2))
     c = K(gen(F4))
 
+    p = characteristic(F1)
 #TODO: make the setup type stable
 #   @test @inferred a == b^(p+1)
-    @test a == b^(p+1)
+#TODO: uncomment when https://github.com/Nemocas/Nemo.jl/issues/1520 is fixed
+#   @test a == b^(p+1)
     @test b == c^(p^2+1)
 
-    @test hash(a, zero(UInt)) == hash(b^(p+1), zero(UInt))
+#   @test hash(a, zero(UInt)) == hash(b^(p+1), zero(UInt))
+    @test hash(b, zero(UInt)) == hash(c^(p^2+1), zero(UInt))
   end
 
-  @testset "Polynomial" begin
-    p = 3
-    F1 = GF(p, 1)
+  @testset "Embeddings for $F1" for F1 in [GF(3, 1), Nemo._GF(3, 1)]
+    K = algebraic_closure(F1)
+    F2 = ext_of_degree(K, 2)
+    F3 = ext_of_degree(K, 3)
+    emb = embedding(F2, K)
+    for x in [one(F2), gen(F2)]
+      img = emb(x)
+      @test K(x) == img
+      @test preimage(emb, img) == x
+    end
+    @test has_preimage(emb, K(one(F3)))[1]
+    @test preimage(emb, K(one(F3))) == one(F2)
+    @test !has_preimage(emb, K(gen(F3)))[1]
+  end
+
+  @testset "Polynomial for $F1" for F1 in [GF(3, 1), Nemo._GF(3, 1)]
+    p = characteristic(F1)
     K = algebraic_closure(F1)
     Kx, x = K["x"]
     @test (x^2 + 1)(K(1)) == 2*K(1)
+
+    r = roots(x^4 -1)
+    @test sort!(map(degree, r)) == [1, 1, 2, 2]
   end
 
-  @testset "Matrix" begin
-    p = 3
-    F1 = GF(p, 1)
+  @testset "Matrix for $F1" for F1 in [GF(3, 1), Nemo._GF(3, 1)]
+    p = characteristic(F1)
     K = algebraic_closure(F1)
     z = zero(K)
     o = one(K)
@@ -162,9 +177,8 @@ end
     @test M^2 == M * M
   end
 
-  @testset "Singular ring" begin
-    p = 3
-    F1 = GF(p, 1)
+  @testset "Singular ring for $F1" for F1 in [GF(3, 1), Nemo._GF(3, 1)]
+    p = characteristic(F1)
     K = algebraic_closure(F1)
     L = Oscar.singular_coeff_ring(K)
     a = K(gen(F1))

--- a/test/Rings/runtests.jl
+++ b/test/Rings/runtests.jl
@@ -20,6 +20,8 @@ include("NumberField.jl")
 include("FunctionField.jl")
 include("AbelianClosure.jl")
 
+include("AlgClosureFp.jl")
+
 include("MPolyAnyMap/MPolyRing.jl")
 include("MPolyAnyMap/MPolyQuo.jl")
 include("MPolyAnyMap/AffineAlgebras.jl")


### PR DESCRIPTION
This is a follow-up to #2602.
Some of the open items mentioned there are now done:
- caching,
- tests (in particular, `test_Field_interface` succeeds now; several additional methods had to be added for that),
- new function `algebraic_closure`, and
- a first bit of documentation is available
  (Is it o.k. to put the documentation behind the section on finite fields? It would be tempting to put it *into* the section about finite fields, but this is just copied from Nemo. Is this perhaps an argument to move the whole code to Nemo?)

There are still open questions:
- Currently the code is not type-stable in several places. For example, the type of the field returned by `ext_of_degree` cannot be derived from the type of the given algebraic closure. My understanding is that one wants to admit the field `F = GF(p)` as input for `algebraic_closure`, but then the extension fields cannot have the same type as `F`. Similarly, the `data` field of an `AlgClosureElem` has no concrete type.
- The `minpoly` method for `AlgClosureElem` returns a polynomial over a perhaps unsuitable field. (The underlying `minpoly` method for the finite field element chooses a field; here we should insist in a prime field that fits to the given element.)