### PR TITLE
Free resolution fixes

### DIFF
--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -6253,8 +6253,6 @@ function _extend_free_resolution(cc::Hecke.ComplexOfMorphisms, idx::Int; algorit
   len = len_missing + 1
   if algorithm == :fres
     res = Singular.fres(singular_kernel_entry, len, "complete")
-  elseif algorithm == :sres
-    res = Singular.fres(singular_kernel_entry, len)
   elseif algorithm == :lres
     error("LaScala's method is not yet available in Oscar.")
   else
@@ -6300,7 +6298,7 @@ end
 Return a free resolution of `M`.
 
 If `length != 0`, the free resolution is only computed up to the `length`-th free module.
-`algorithm` can be set to `:sres` or `:fres`.
+At the moment, `algorithm` only allows the option `:fres`.
 
 # Examples
 ```jldoctest
@@ -6348,7 +6346,7 @@ degree | 4  3  2  1  0
 julia> is_complete(fr)
 true
 
-julia> fr = free_resolution(M, algorithm=:sres)
+julia> fr = free_resolution(M, algorithm=:fres)
 
 rank   | 0  2  6  6  2
 -------|---------------
@@ -6390,9 +6388,7 @@ function free_resolution(M::SubquoModule{<:MPolyRingElem};
 
   #= This is the single computational hard part of this function =#
   if algorithm == :fres
-    res = Singular.fres(singular_kernel_entry, length, "complete")
-  elseif algorithm == :sres
-    res = Singular.fres(singular_kernel_entry, length)
+    res = Singular.fres(Singular.std(singular_kernel_entry), length, "complete")
   elseif algorithm == :lres
     error("LaScala's method is not yet available in Oscar.")
   else

--- a/test/Modules/ModulesGraded.jl
+++ b/test/Modules/ModulesGraded.jl
@@ -541,7 +541,7 @@ end
     M = SubquoModule(F, A, B)
     free_res1 = free_resolution(M, length=1)
     free_res1a = free_resolution(M)
-    free_res2 = free_resolution(M, algorithm=:sres)
+    free_res2 = free_resolution(M)
     free_res3 = free_resolution_via_kernels(M)
     @test first(chain_range(free_res1)) == 1
     @test first(chain_range(free_res1a)) == 4
@@ -600,9 +600,6 @@ end
     free_res1 = free_resolution(M)
     @test is_graded(free_res1)
     @test_broken all(iszero, homology(free_res1.C))
-    free_res2 = free_resolution(M, algorithm=:sres)
-    @test is_graded(free_res2)
-    @test_broken all(iszero, homology(free_res2.C))
     free_res3 = free_resolution_via_kernels(M)
     @test is_graded(free_res3)
     B = betti(free_res3)

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -177,7 +177,7 @@ end
 	@test free_res[3] == free_module(R, 2)
 	@test free_res[4] == free_module(R, 0)
     @test is_complete(free_res) == true
-	free_res = free_resolution(M, algorithm=:sres)
+	free_res = free_resolution(M)
 	@test all(iszero, homology(free_res.C))
 	free_res = free_resolution_via_kernels(M)
 	@test all(iszero, homology(free_res))


### PR DESCRIPTION
1. Removes usage of `sres` (not needed at the moment).
2. Computes a Gröbner basis of the input for `fres`.
3. Adjusts tests correspondingly.