### PR TITLE
Fix `Oscar.build()`

### DIFF
--- a/system/Build.jl
+++ b/system/Build.jl
@@ -14,6 +14,7 @@ CO = joinpath(tmp, "CompileOscar.jl")
 write(CO, """
 using Oscar
 using Pkg, Test
+buildingSysImage=true
 Oscar.system("precompile.jl")
 """)
 

--- a/system/Build.jl
+++ b/system/Build.jl
@@ -2,7 +2,16 @@ if VERSION < v"1.9.0-DEV"
   error("Julia >= 1.9 required")
 end
 
+oscarpath = pkgdir(Oscar)
+
+println("=====================")
+println(oscarpath)
+println("=====================")
+
 using Pkg
+Pkg.activate(temp=true)
+Pkg.add(path="$(oscarpath)")
+using Oscar
 Pkg.add("PackageCompiler")
 Pkg.add("Libdl")
 
@@ -11,10 +20,14 @@ using PackageCompiler, Libdl
 tmp = mktempdir(cleanup = false)
 CO = joinpath(tmp, "CompileOscar.jl")
 
+
 write(CO, """
+using Pkg
+Pkg.add(path="$(oscarpath)")
+Pkg.precompile()
 using Oscar
-using Pkg, Test
-buildingSysImage=true
+using Test
+println("oscarpath is $(oscarpath) , while Oscar path is $(pkgdir(Oscar))")
 Oscar.system("precompile.jl")
 """)
 

--- a/system/Build.jl
+++ b/system/Build.jl
@@ -4,13 +4,9 @@ end
 
 oscarpath = pkgdir(Oscar)
 
-println("=====================")
-println(oscarpath)
-println("=====================")
-
 using Pkg
 Pkg.activate(temp=true)
-Pkg.add(path="$(oscarpath)")
+Pkg.develop(path="$(oscarpath)")
 using Oscar
 Pkg.add("PackageCompiler")
 Pkg.add("Libdl")
@@ -23,11 +19,9 @@ CO = joinpath(tmp, "CompileOscar.jl")
 
 write(CO, """
 using Pkg
-Pkg.add(path="$(oscarpath)")
-Pkg.precompile()
+Pkg.develop(path="$(oscarpath)")
 using Oscar
 using Test
-println("oscarpath is $(oscarpath) , while Oscar path is $(pkgdir(Oscar))")
 Oscar.system("precompile.jl")
 """)
 

--- a/system/Build.jl
+++ b/system/Build.jl
@@ -23,3 +23,11 @@ PackageCompiler.create_sysimage([:Oscar], sysimage_path=sysimage, precompile_exe
 
 println("(re)start julia as")
 println("\tjulia -J $(sysimage)")
+
+# Remove the packages we added, so that 
+# Aqua doesn't complain in future testing
+Pkg.rm("PackageCompiler")
+Pkg.rm("Libdl")
+Pkg.rm("Documenter")
+Pkg.rm("PrettyTables")
+Pkg.rm("Printf")

--- a/system/Build.jl
+++ b/system/Build.jl
@@ -23,11 +23,3 @@ PackageCompiler.create_sysimage([:Oscar], sysimage_path=sysimage, precompile_exe
 
 println("(re)start julia as")
 println("\tjulia -J $(sysimage)")
-
-# Remove the packages we added, so that 
-# Aqua doesn't complain in future testing
-Pkg.rm("PackageCompiler")
-Pkg.rm("Libdl")
-Pkg.rm("Documenter")
-Pkg.rm("PrettyTables")
-Pkg.rm("Printf")

--- a/system/precompile.jl
+++ b/system/precompile.jl
@@ -2,6 +2,13 @@ import Pkg
 Pkg.add("Documenter")
 Pkg.add("PrettyTables")
 Pkg.add("Printf")
+Pkg.add("Aqua")
+
+Pkg.precompile()
+
+println("Path of Oscar is $(pkgdir(Oscar))")
+
+exit(1)
 
 include(joinpath(pkgdir(Oscar), "test", "runtests.jl"))
 Hecke.system("precompile.jl")

--- a/system/precompile.jl
+++ b/system/precompile.jl
@@ -6,10 +6,5 @@ Pkg.add("Aqua")
 
 Pkg.precompile()
 
-println("Path of Oscar is $(pkgdir(Oscar))")
-
-exit(1)
-
 include(joinpath(pkgdir(Oscar), "test", "runtests.jl"))
 Hecke.system("precompile.jl")
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ import Random
 numprocs_str = get(ENV, "NUMPROCS", "1")
 
 oldWorkingDirectory = pwd()
-cd( joinpath(pkgdir(Oscar), "test") )
+cd(joinpath(pkgdir(Oscar), "test"))
 
 if !isempty(ARGS)
   jargs = [arg for arg in ARGS if startswith(arg, "-j")]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,13 +106,9 @@ end
 
 println("Making test list")
 
-testlist = []
-
-if !(isdefined(Main, :buildingSysImage)) || buildingSysImage == false
-  append!(testlist, ["Aqua.jl"])
-end
-
-append!(testlist, [
+testlist = [
+  
+  "Aqua.jl"
 
   "printing.jl",
 
@@ -153,7 +149,7 @@ append!(testlist, [
   "Serialization/runtests.jl",
 
   "StraightLinePrograms/runtests.jl"
-])
+]
 
 # if many workers, distribute tasks across them
 # otherwise, is essentially a serial loop

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,7 +108,7 @@ println("Making test list")
 
 testlist = [
   
-  "Aqua.jl"
+  "Aqua.jl",
 
   "printing.jl",
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,9 @@ import Random
 
 numprocs_str = get(ENV, "NUMPROCS", "1")
 
+oldWorkingDirectory = pwd()
+cd( joinpath(pkgdir(Oscar), "test") )
+
 if !isempty(ARGS)
   jargs = [arg for arg in ARGS if startswith(arg, "-j")]
   if !isempty(jargs)
@@ -172,3 +175,5 @@ if numprocs == 1
     print_stats(stdout; max=10)
   end
 end
+
+cd(oldWorkingDirectory)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,8 +103,13 @@ end
 
 println("Making test list")
 
-const testlist = [
-  "Aqua.jl",
+testlist = []
+
+if !(isdefined(Main, :buildingSysImage)) || buildingSysImage == false
+  append!(testlist, ["Aqua.jl"])
+end
+
+append!(testlist, [
 
   "printing.jl",
 
@@ -145,7 +150,7 @@ const testlist = [
   "Serialization/runtests.jl",
 
   "StraightLinePrograms/runtests.jl"
-]
+])
 
 # if many workers, distribute tasks across them
 # otherwise, is essentially a serial loop


### PR DESCRIPTION
This commit splits the testlist into two, to optionally skip some tests if building a sysimage.

ToDo : also deal with the path issue.

Will eventually solve #2631 