### PR TITLE
admit `has_preimage` for embedding into abelian closure

### DIFF
--- a/docs/src/NumberTheory/abelian_closure.md
+++ b/docs/src/NumberTheory/abelian_closure.md
@@ -48,3 +48,9 @@ Generator of abelian closure of Q
 julia> ζ(5) + ζ(3)
 ζ(15)^5 + ζ(15)^3
 ```
+
+## Reduction to characteristic ``p``
+
+```@docs
+reduce(val::QQAbElem, F::FinField)
+```

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -970,6 +970,35 @@ end
       end
     end
   end
+
+  # embeddings of abelian number fields into the abelian closure
+  # - for cyclotomic character fields
+  t = character_table("A4")
+  chi = t[2]
+  F, emb = character_field(chi)
+  @test Hecke.is_cyclotomic_type(F)[1]
+  for elm in [gen(F), one(F)]
+    img = emb(elm)
+    @test preimage(emb, img) == elm
+    @test has_preimage(emb, img) == (true, elm)
+    z5 = gen(parent(img))(5)
+    @test has_preimage(emb, z5)[1] == false
+    @test_throws ErrorException preimage(emb, z5)
+  end
+
+  # - for non-cyclotomic character fields
+  t = character_table("A5")
+  chi = t[2]
+  F, emb = character_field(chi)
+  @test ! Hecke.is_cyclotomic_type(F)[1]
+  for elm in [gen(F), one(F)]
+    img = emb(elm)
+    @test preimage(emb, img) == elm
+    @test has_preimage(emb, img) == (true, elm)
+    z5 = gen(parent(img))(5)
+    @test has_preimage(emb, z5)[1] == false
+    @test_throws ErrorException preimage(emb, z5)
+  end
 end
 
 @testset "character fields of Brauer characters" begin

--- a/test/Rings/AbelianClosure.jl
+++ b/test/Rings/AbelianClosure.jl
@@ -160,6 +160,31 @@ end
     end
   end
 
+  @testset "Reduction to finite fields" for gf_fun in [GF, Nemo._GF]
+    K, z = abelian_closure(QQ)
+    F = gf_fun(2, 1)
+    @test reduce(z(2), F) == one(F)
+    @test reduce(one(K), F) == one(F)
+    @test reduce(zero(K), F) == zero(F)
+    @test_throws ErrorException reduce(z(3), F)
+    @test_throws ErrorException reduce(z(4), F)
+    F = gf_fun(2, 2)
+    red = reduce(z(3), F)
+    @test red != one(F) && red^3 == one(F)
+    @test reduce(one(K), F) == one(F)
+    @test reduce(zero(K), F) == zero(F)
+    @test_throws ErrorException reduce(z(7), F)
+    F = gf_fun(2, 3)
+    red = reduce(z(7), F)
+    @test red != one(F) && red^7 == one(F)
+    @test reduce(one(K), F) == one(F)
+    @test reduce(zero(K), F) == zero(F)
+    F = gf_fun(3, 2)
+    @test reduce(one(K), F) == one(F)
+    @test reduce(zero(K), F) == zero(F)
+    @test_throws ErrorException reduce(z(3), F)
+  end
+
   @testset "Unsafe operations" begin
     K, z = abelian_closure(QQ)
     rand_elem() = begin n = rand([3, 4, 5]); sum(rand(-1:1) * z(n) for i in 1:3) end


### PR DESCRIPTION
- moved the code that creates the embeddings from the function `character_field` to `src/Rings/AbelianClosure.jl`,
- added `has_preimage` for such embeddings, using a keyword argument in the defining function for computing preimages; note that the auxiliary data needed to decide whether preimages exist are known to the mapping only inside the function -- I do not really like this code but I do not have a better idea
- added `reduce` for p-modular reductions of `QQAbElem` to finite fields