### PR TITLE
Change all occurrences of `Hecke.Map` to `Map`

### DIFF
--- a/docs/src/AlgebraicGeometry/Schemes/ArchitectureOfAffineSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/ArchitectureOfAffineSchemes.md
@@ -118,7 +118,7 @@ Any abstract morphism of affine schemes is of the following type:
 ```@docs
     AbsSpecMor{DomainType<:AbsSpec,
                CodomainType<:AbsSpec,
-               PullbackType<:Hecke.Map,
+               PullbackType<:Map,
                MorphismType,
                BaseMorType
                }
@@ -128,7 +128,7 @@ A concrete and minimalistic implementation exist for the type `SpecMor`:
 ```@docs
     SpecMor{DomainType<:AbsSpec,
             CodomainType<:AbsSpec,
-            PullbackType<:Hecke.Map
+            PullbackType<:Map
            }
 ```
 This basic functionality consists of

--- a/experimental/Laurent/src/Types.jl
+++ b/experimental/Laurent/src/Types.jl
@@ -1,7 +1,7 @@
 import .AbstractAlgebra.Generic: LaurentMPolyWrapRing, LaurentMPolyWrap
 import .AbstractAlgebra: LaurentMPolyRing, LaurentMPolyRingElem
 
-@attributes mutable struct LaurentMPolyAnyMap{D, C} <: Map{D, C, Hecke.Hecke.Map, LaurentMPolyAnyMap}
+@attributes mutable struct LaurentMPolyAnyMap{D, C} <: Map{D, C, Map, LaurentMPolyAnyMap}
   R::D
   S::C
   image_of_gens

--- a/experimental/Schemes/CoherentSheaves.jl
+++ b/experimental/Schemes/CoherentSheaves.jl
@@ -678,11 +678,11 @@ identifications given by the glueings in the `default_covering`.
 
     Mpre = PreSheafOnScheme(X, production_func, restriction_func,
                       OpenType=AbsSpec, OutputType=ModuleFP,
-                      RestrictionType=Hecke.Map,
+                      RestrictionType=Map,
                       is_open_func=_is_open_func_for_schemes_without_specopen(X)
                       #is_open_func=_is_open_for_modules(X)
                      )
-    M = new{typeof(X), AbsSpec, ModuleFP, Hecke.Map}(MD, OOX, Mpre, default_cov)
+    M = new{typeof(X), AbsSpec, ModuleFP, Map}(MD, OOX, Mpre, default_cov)
     if check
       # Check that all sheaves of modules are compatible on the overlaps.
       # TODO: eventually replace by a check that on every basic
@@ -924,10 +924,10 @@ end
       
     Mpre = PreSheafOnScheme(X, production_func, restriction_func,
                       OpenType=AbsSpec, OutputType=ModuleFP,
-                      RestrictionType=Hecke.Map,
+                      RestrictionType=Map,
                       is_open_func=_is_open_func_for_schemes_without_specopen(X)
                      )
-    M = new{typeof(X), AbsSpec, ModuleFP, Hecke.Map}(F, G, OOX, Mpre)
+    M = new{typeof(X), AbsSpec, ModuleFP, Map}(F, G, OOX, Mpre)
 
     return M
   end
@@ -988,10 +988,10 @@ codomain(M::HomSheaf) = M.codomain
       
     Mpre = PreSheafOnScheme(X, production_func, restriction_func,
                       OpenType=AbsSpec, OutputType=ModuleFP,
-                      RestrictionType=Hecke.Map,
+                      RestrictionType=Map,
                       is_open_func=_is_open_func_for_schemes_without_specopen(X)
                      )
-    M = new{typeof(X), AbsSpec, ModuleFP, Hecke.Map}(summands, OOX, Mpre)
+    M = new{typeof(X), AbsSpec, ModuleFP, Map}(summands, OOX, Mpre)
 
     return M
   end
@@ -1109,7 +1109,7 @@ end
   OOX::StructureSheafOfRings
   OOY::StructureSheafOfRings
   M::AbsCoherentSheaf
-  ident::IdDict{AbsSpec, Union{Hecke.Map, Nothing}} # a dictionary caching the identifications
+  ident::IdDict{AbsSpec, Union{Map, Nothing}} # a dictionary caching the identifications
   F::PreSheafOnScheme
 
   function PushforwardSheaf(inc::CoveredClosedEmbedding, M::AbsCoherentSheaf)
@@ -1183,15 +1183,15 @@ end
       return hom(MYV, MYU, (x->preimage(ident[U], x)).(img_gens), OOY(V, U))
     end
     
-    ident = IdDict{AbsSpec, Union{Hecke.Map, Nothing}}()
+    ident = IdDict{AbsSpec, Union{Map, Nothing}}()
 
     Blubber = PreSheafOnScheme(Y, production_func, restriction_func,
                       OpenType=AbsSpec, OutputType=ModuleFP,
-                      RestrictionType=Hecke.Map,
+                      RestrictionType=Map,
                       is_open_func=_is_open_func_for_schemes_without_specopen(Y)
                       #is_open_func=_is_open_for_modules(Y)
                      )
-    MY = new{typeof(Y), AbsSpec, ModuleFP, Hecke.Map}(inc, OOX, OOY, M, ident, Blubber)
+    MY = new{typeof(Y), AbsSpec, ModuleFP, Map}(inc, OOX, OOY, M, ident, Blubber)
     return MY
   end
 end
@@ -1255,7 +1255,7 @@ end
   OOX::StructureSheafOfRings # the sheaf of rings in the domain
   OOY::StructureSheafOfRings # the sheaf of rings in the codomain
   M::AbsCoherentSheaf        # the sheaf of modules on Y
-  pullback_of_sections::IdDict{AbsSpec, Union{Hecke.Map, Nothing}} # a dictionary caching the natural 
+  pullback_of_sections::IdDict{AbsSpec, Union{Map, Nothing}} # a dictionary caching the natural 
                                                                    # pullback maps along the maps in the `covering_morphism` of f 
   F::PreSheafOnScheme        # the internal caching instance doing the bookkeeping
 
@@ -1268,7 +1268,7 @@ end
     fcov = covering_morphism(f)::CoveringMorphism
     CX = domain(fcov)::Covering
     CY = codomain(fcov)::Covering
-    pullbacks = IdDict{AbsSpec, Hecke.Map}()
+    pullbacks = IdDict{AbsSpec, Map}()
 
     ### Production of the modules on open sets.
     #
@@ -1365,14 +1365,14 @@ end
       error("case not implemented")
     end
     
-    ident = IdDict{AbsSpec, Union{Hecke.Map, Nothing}}()
+    ident = IdDict{AbsSpec, Union{Map, Nothing}}()
 
     Blubber = PreSheafOnScheme(X, production_func, restriction_func,
                       OpenType=AbsSpec, OutputType=ModuleFP,
-                      RestrictionType=Hecke.Map,
+                      RestrictionType=Map,
                       is_open_func=_is_open_func_for_schemes_without_specopen(X)
                      )
-    MY = new{typeof(X), AbsSpec, ModuleFP, Hecke.Map}(f, OOX, OOY, M, pullbacks, Blubber)
+    MY = new{typeof(X), AbsSpec, ModuleFP, Map}(f, OOX, OOY, M, pullbacks, Blubber)
     return MY
   end
 end
@@ -1398,7 +1398,7 @@ end
 # with its identification map M' → M. Note that we can not give the 
 # inverse of this map, since there is no well-defined underlying ring 
 # homomorphism.
-function _pushforward(f::Hecke.Map{<:Ring, <:Ring}, I::Ideal, M::FreeMod)
+function _pushforward(f::Map{<:Ring, <:Ring}, I::Ideal, M::FreeMod)
   R = domain(f)
   S = codomain(f)
   base_ring(I) === R || error("ideal is not defined over the correct ring")
@@ -1410,7 +1410,7 @@ function _pushforward(f::Hecke.Map{<:Ring, <:Ring}, I::Ideal, M::FreeMod)
   return MR, ident
 end
 
-function _pushforward(f::Hecke.Map{<:Ring, <:Ring}, I::Ideal, M::SubquoModule)
+function _pushforward(f::Map{<:Ring, <:Ring}, I::Ideal, M::SubquoModule)
   R = domain(f)
   S = codomain(f)
   base_ring(I) === R || error("ideal is not defined over the correct ring")

--- a/experimental/Schemes/IdealSheaves.jl
+++ b/experimental/Schemes/IdealSheaves.jl
@@ -940,7 +940,7 @@ function match_on_intersections(
   return matches
 end
 
-function (phi::Hecke.Map{D, C})(I::Ideal) where {D<:Ring, C<:Ring}
+function (phi::Map{D, C})(I::Ideal) where {D<:Ring, C<:Ring}
   base_ring(I) === domain(phi) || error("ideal not defined over the domain of the map")
   R = domain(phi)
   S = codomain(phi)

--- a/experimental/Schemes/LazyGlueing.jl
+++ b/experimental/Schemes/LazyGlueing.jl
@@ -6,7 +6,7 @@
                                                     LeftSpecType,
                                                     RightSpecType, 
                                                     Scheme, Scheme,
-                                                    Hecke.Map, Hecke.Map
+                                                    Map, Map
                                                    }
 
   X::LeftSpecType

--- a/experimental/Schemes/Types.jl
+++ b/experimental/Schemes/Types.jl
@@ -203,10 +203,10 @@ identifications given by the glueings in the `default_covering`.
 
     R = PreSheafOnScheme(X, production_func, restriction_func,
                     OpenType=AbsSpec, OutputType=Ring,
-                    RestrictionType=Hecke.Map,
+                    RestrictionType=Map,
                     is_open_func=is_open_func
                    )
-    return new{typeof(X), Union{AbsSpec, SpecOpen}, Ring, Hecke.Map}(R)
+    return new{typeof(X), Union{AbsSpec, SpecOpen}, Ring, Map}(R)
   end
 
   ### Structure sheaf on covered schemes
@@ -394,10 +394,10 @@ identifications given by the glueings in the `default_covering`.
 
     R = PreSheafOnScheme(X, production_func, restriction_func,
                       OpenType=Union{AbsSpec, SpecOpen}, OutputType=Ring,
-                      RestrictionType=Hecke.Map,
+                      RestrictionType=Map,
                       is_open_func=_is_open_func_for_schemes(X)
                      )
-    return new{typeof(X), Union{AbsSpec, SpecOpen}, Ring, Hecke.Map}(R)
+    return new{typeof(X), Union{AbsSpec, SpecOpen}, Ring, Map}(R)
   end
 end
 
@@ -533,10 +533,10 @@ identifications given by the glueings in the `default_covering`.
 
     Ipre = PreSheafOnScheme(X, production_func, restriction_func,
                       OpenType=AbsSpec, OutputType=Ideal,
-                      RestrictionType=Hecke.Map,
+                      RestrictionType=Map,
                       is_open_func=_is_open_func_for_schemes_without_specopen(X)
                      )
-    I = new{typeof(X), AbsSpec, Ideal, Hecke.Map}(ID, OOX, Ipre)
+    I = new{typeof(X), AbsSpec, Ideal, Map}(ID, OOX, Ipre)
     @check begin
       # Check that all ideal sheaves are compatible on the overlaps.
       # TODO: eventually replace by a check that on every basic

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Morphisms/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Morphisms/Types.jl
@@ -7,7 +7,7 @@
 @doc raw"""
     AbsSpecMor{DomainType<:AbsSpec, 
                CodomainType<:AbsSpec, 
-               PullbackType<:Hecke.Map,
+               PullbackType<:Map,
                MorphismType, 
                BaseMorType
                }
@@ -25,7 +25,7 @@ Abstract type for morphisms ``f : X → Y`` of affine schemes where
 abstract type AbsSpecMor{
                          DomainType<:AbsSpec, 
                          CodomainType<:AbsSpec, 
-                         PullbackType<:Hecke.Map,
+                         PullbackType<:Map,
                          MorphismType, 
                          BaseMorType
                         }<:SchemeMor{DomainType, CodomainType, MorphismType, BaseMorType}
@@ -40,7 +40,7 @@ end
 @doc raw"""
     SpecMor{DomainType<:AbsSpec, 
             CodomainType<:AbsSpec, 
-            PullbackType<:Hecke.Map
+            PullbackType<:Map
            }
 
 A morphism ``f : X → Y`` of affine schemes ``X = Spec(S)`` of type 
@@ -51,7 +51,7 @@ over the same `base_ring`, with underlying ring homomorphism
 @attributes mutable struct SpecMor{
                                    DomainType<:AbsSpec, 
                                    CodomainType<:AbsSpec, 
-                                   PullbackType<:Hecke.Map
+                                   PullbackType<:Map
                                   } <: AbsSpecMor{DomainType, 
                                                   CodomainType, 
                                                   PullbackType, 
@@ -67,7 +67,7 @@ over the same `base_ring`, with underlying ring homomorphism
       Y::CodomainType,
       pullback::PullbackType;
       check::Bool=true
-    ) where {DomainType<:AbsSpec, CodomainType<:AbsSpec, PullbackType<:Hecke.Map}
+    ) where {DomainType<:AbsSpec, CodomainType<:AbsSpec, PullbackType<:Map}
     OO(X) == codomain(pullback) || error("the coordinate ring of the domain does not coincide with the codomain of the pullback")
     OO(Y) == domain(pullback) || error("the coordinate ring of the codomain does not coincide with the domain of the pullback")
     @check begin

--- a/src/AlgebraicGeometry/Schemes/ClosedEmbedding/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/ClosedEmbedding/Types.jl
@@ -11,7 +11,7 @@ ideal ``I ⊂ R``.
 """
 @attributes mutable struct ClosedEmbedding{DomainType<:AbsSpec,
                                            CodomainType<:AbsSpec,
-                                           PullbackType<:Hecke.Map
+                                           PullbackType<:Map
                                           }<:AbsSpecMor{DomainType,
                                                         CodomainType,
                                                         PullbackType,

--- a/src/AlgebraicGeometry/Schemes/Glueing/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/Glueing/Types.jl
@@ -13,8 +13,8 @@ abstract type AbsGlueing{LeftSpecType<:AbsSpec,
                          RightSpecType<:AbsSpec,
                          LeftOpenType<:Scheme,
                          RightOpenType<:Scheme,
-                         LeftMorType<:Hecke.Map,
-                         RightMorType<:Hecke.Map
+                         LeftMorType<:Map,
+                         RightMorType<:Map
                         } end
 
 ########################################################################

--- a/src/AlgebraicGeometry/Schemes/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/Methods.jl
@@ -6,7 +6,7 @@ we compute ``X' = X ×ₖ Spec(R)`` and return a pair `(X', f)` where
 ``f : X' → X`` is the canonical morphism.
 
 !!! note
-    We do not restrict `phi` to be a `Hecke.Map` so that one can also use coercion, anonymous functions, etc. 
+    We do not restrict `phi` to be a `Map` so that one can also use coercion, anonymous functions, etc. 
 """
 function base_change(phi::Any, X::Scheme)
   error("base_change not implemented for input of type $(typeof(X))")
@@ -24,7 +24,7 @@ where ``a : X' → X`` is the morphism from `base_change(phi, X)`,
 morphism on those fiber products.
 
 !!! note
-    We do not restrict `phi` to be a `Hecke.Map` so that one can also use coercion, anonymous functions, etc. 
+    We do not restrict `phi` to be a `Map` so that one can also use coercion, anonymous functions, etc. 
 
 !!! note 
     The morphisms ``a`` and ``b`` can be passed as the optional arguments `domain_map` and `codomain_map`, respectively. 

--- a/src/AlgebraicGeometry/Schemes/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/Methods.jl
@@ -24,7 +24,7 @@ where ``a : X' → X`` is the morphism from `base_change(phi, X)`,
 morphism on those fiber products.
 
 !!! note
-    We do not restrict `phi` to be a `Map` so that one can also use coercion, anonymous functions, etc. 
+    We do not restrict `phi` to be of type `Map` so that one can also use coercion, anonymous functions, etc. 
 
 !!! note 
     The morphisms ``a`` and ``b`` can be passed as the optional arguments `domain_map` and `codomain_map`, respectively. 

--- a/src/AlgebraicGeometry/Schemes/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/Methods.jl
@@ -6,7 +6,7 @@ we compute ``X' = X ×ₖ Spec(R)`` and return a pair `(X', f)` where
 ``f : X' → X`` is the canonical morphism.
 
 !!! note
-    We do not restrict `phi` to be a `Map` so that one can also use coercion, anonymous functions, etc. 
+    We do not restrict `phi` to be of type `Map` so that one can also use coercion, anonymous functions, etc. 
 """
 function base_change(phi::Any, X::Scheme)
   error("base_change not implemented for input of type $(typeof(X))")

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Attributes.jl
@@ -61,7 +61,7 @@ function map_on_affine_cones(
                              <:AbsProjectiveScheme{<:Union{MPolyRing, MPolyQuoRing, 
                                                            MPolyQuoLocRing, MPolyLocRing
                                                           }},
-                             <:Hecke.Map,
+                             <:Map,
                              Nothing # This indicates the same base scheme for domain and codomain.
                             };
     check::Bool=true
@@ -122,7 +122,7 @@ end
 
 function map_on_affine_cones(
     phi::ProjectiveSchemeMor{<:AbsProjectiveScheme{<:Field}, <:AbsProjectiveScheme{<:Field},
-                            <:Hecke.Map, Nothing};
+                            <:Map, Nothing};
     check::Bool=true
   )
   if !isdefined(phi, :map_on_affine_cones)

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Constructors.jl
@@ -50,7 +50,7 @@ end
 
 ### additional constructors
 
-function fiber_product(f::Hecke.Map{DomType, CodType}, P::AbsProjectiveScheme{DomType}) where {DomType<:Ring, CodType<:Ring}
+function fiber_product(f::Map{DomType, CodType}, P::AbsProjectiveScheme{DomType}) where {DomType<:Ring, CodType<:Ring}
   R = base_ring(P) 
   R === domain(f) || error("rings not compatible")
   Rnew = codomain(f)

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Types.jl
@@ -26,7 +26,7 @@ space over the same ring with the identity on the base.
 @attributes mutable struct ProjectiveSchemeMor{
     DomainType<:AbsProjectiveScheme,
     CodomainType<:AbsProjectiveScheme,
-    PullbackType<:Hecke.Map,
+    PullbackType<:Map,
     BaseMorType
   } <: SchemeMor{DomainType, CodomainType,
                  ProjectiveSchemeMor,
@@ -35,7 +35,7 @@ space over the same ring with the identity on the base.
   domain::DomainType
   codomain::CodomainType
   pullback::PullbackType
-  base_ring_morphism::Hecke.Map
+  base_ring_morphism::Map
 
   #fields for caching
   map_on_base_schemes::SchemeMor

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
@@ -201,7 +201,7 @@ one of the homogeneous coordinates of ``P``.
 
 **Note:** Since this map returns representatives only, it 
 is not a mathematical morphism and, hence, in particular 
-not an instance of `Hecke.Map`.
+not an instance of `Map`.
 
 # Examples
 ```jldoctest

--- a/src/AlgebraicGeometry/Schemes/SpecOpen/Morphisms/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/SpecOpen/Morphisms/Attributes.jl
@@ -30,7 +30,7 @@ function pullback(f::SpecOpenMor)
         return SpecOpenRingElem(OO(V), [OO(V[i])(a[i]) for i in 1:ngens(V)])
       end
       f.pullback = MapFromFunc(OO(U), OO(V), my_restr)
-      return f.pullback::Hecke.Map{typeof(OO(codomain(f))), typeof(OO(domain(f)))}
+      return f.pullback::Map{typeof(OO(codomain(f))), typeof(OO(domain(f)))}
     end
 
     pbs_from_ambient = [pullback(g) for g in maps_on_patches(f)]
@@ -66,7 +66,7 @@ function pullback(f::SpecOpenMor)
       return SpecOpenRingElem(OO(V), b, check=false)
 
       # shortcut for regular elements on the ambient variety
-      # Does not work because of parent check done by the Hecke.Map
+      # Does not work because of parent check done by the Map
       # function mymap(a::RingElem)
       #   parent(a) === OO(ambient(U)) || return mymap(OO(ambient(U))(a))
       #   return SpecOpenRingElem(OO(V), 
@@ -76,6 +76,6 @@ function pullback(f::SpecOpenMor)
     end
     f.pullback = MapFromFunc(OO(U), OO(V), mymap)
   end
-  return f.pullback::Hecke.Map{typeof(OO(codomain(f))), typeof(OO(domain(f)))}
+  return f.pullback::Map{typeof(OO(codomain(f))), typeof(OO(domain(f)))}
 end
 

--- a/src/AlgebraicGeometry/Schemes/SpecOpen/Morphisms/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/SpecOpen/Morphisms/Types.jl
@@ -26,7 +26,7 @@ mutable struct SpecOpenMor{DomainType<:SpecOpen,
 
   # fields used for caching
   inverse::SpecOpenMor
-  pullback::Hecke.Map
+  pullback::Map
 
   function SpecOpenMor(
       U::DomainType,

--- a/src/AlgebraicGeometry/Schemes/SpecOpen/Rings/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/SpecOpen/Rings/Methods.jl
@@ -407,7 +407,7 @@ end
 ########################################################################
 # Maps of SpecOpenRings                                                #
 ########################################################################
-function is_identity_map(f::Hecke.Map{DomType, CodType}) where {DomType<:SpecOpenRing, CodType<:SpecOpenRing}
+function is_identity_map(f::Map{DomType, CodType}) where {DomType<:SpecOpenRing, CodType<:SpecOpenRing}
   domain(f) === codomain(f) || return false
   R = ambient_coordinate_ring(scheme(domain(f)))
   return all(x->(domain(f)(x) == f(domain(f)(x))), gens(R))

--- a/src/AlgebraicGeometry/Schemes/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/Types.jl
@@ -25,12 +25,12 @@ abstract type SchemeMor{
                         CodomainType, 
                         MorphismType,
                         BaseMorType
-                       } <: Hecke.Map{
-                                      DomainType, 
-                                      CodomainType, 
-                                      SetMap, 
-                                      MorphismType
-                                     }
+                       } <: Map{
+                                DomainType,
+                                CodomainType,
+                                SetMap,
+                                MorphismType
+                                }
 end
 
 

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -850,11 +850,11 @@ FreeModuleHom(F::AbstractFreeMod{T}, G::S, mat::MatElem{T}) where {T,S} = FreeMo
 
 img_gens(f::FreeModuleHom) = gens(image(f)[1])
 base_ring_map(f::FreeModuleHom) = f.ring_map
-@attr Hecke.Map function base_ring_map(f::FreeModuleHom{<:SubquoModule, <:ModuleFP, Nothing})
+@attr Map function base_ring_map(f::FreeModuleHom{<:SubquoModule, <:ModuleFP, Nothing})
     return identity_map(base_ring(domain(f)))
 end
 base_ring_map(f::SubQuoHom) = f.ring_map
-@attr Hecke.Map function base_ring_map(f::SubQuoHom{<:SubquoModule, <:ModuleFP, Nothing})
+@attr Map function base_ring_map(f::SubQuoHom{<:SubquoModule, <:ModuleFP, Nothing})
     return identity_map(base_ring(domain(f)))
 end
 
@@ -6890,7 +6890,7 @@ function *(h::ModuleFPHom{T1, T2, Nothing}, g::ModuleFPHom{T2, T3, Nothing}) whe
   return hom(domain(h), codomain(g), Vector{elem_type(codomain(g))}([g(h(x)) for x = gens(domain(h))]))
 end
 
-function *(h::ModuleFPHom{T1, T2, <:Hecke.Map}, g::ModuleFPHom{T2, T3, <:Hecke.Map}) where {T1, T2, T3}
+function *(h::ModuleFPHom{T1, T2, <:Map}, g::ModuleFPHom{T2, T3, <:Map}) where {T1, T2, T3}
   @assert codomain(h) === domain(g)
   return hom(domain(h), codomain(g), Vector{elem_type(codomain(g))}([g(h(x)) for x = gens(domain(h))]), compose(base_ring_map(h), base_ring_map(g)))
 end
@@ -8627,7 +8627,7 @@ function change_base_ring(S::Ring, F::FreeMod)
   return FS, map
 end
 
-function change_base_ring(f::Hecke.Map{DomType, CodType}, F::FreeMod) where {DomType<:Ring, CodType<:Ring}
+function change_base_ring(f::Map{DomType, CodType}, F::FreeMod) where {DomType<:Ring, CodType<:Ring}
   domain(f) == base_ring(F) || error("ring map not compatible with the module")
   S = codomain(f)
   r = ngens(F)
@@ -8647,7 +8647,7 @@ function change_base_ring(S::Ring, M::SubquoModule)
   return MS, map
 end
 
-function change_base_ring(f::Hecke.Map{DomType, CodType}, M::SubquoModule) where {DomType<:Ring, CodType<:Ring}
+function change_base_ring(f::Map{DomType, CodType}, M::SubquoModule) where {DomType<:Ring, CodType<:Ring}
   domain(f) == base_ring(M) || error("ring map not compatible with the module")
   S = codomain(f)
   F = ambient_free_module(M)

--- a/src/Rings/MPolyMap/MPolyAnyMap.jl
+++ b/src/Rings/MPolyMap/MPolyAnyMap.jl
@@ -35,7 +35,7 @@ const _DomainTypes = Union{MPolyRing, MPolyQuoRing}
     D <: _DomainTypes,
     C <: NCRing,
     U,
-    V} <: Map{D, C, Hecke.Hecke.Map, MPolyAnyMap}
+    V} <: Map{D, C, Map, MPolyAnyMap}
 
   domain::D
   codomain::C

--- a/src/Rings/MPolyMap/flattenings.jl
+++ b/src/Rings/MPolyMap/flattenings.jl
@@ -10,15 +10,15 @@
 ########################################################################
 @attributes mutable struct RingFlattening{TowerRingType<:Union{MPolyRing, MPolyQuoRing}, 
                               FlatRingType<:Ring, CoeffRingType<:Ring
-                             } <: Hecke.Map{TowerRingType, FlatRingType, 
-                                            SetMap, RingFlattening
-                                           }
+                             } <: Map{TowerRingType, FlatRingType, 
+                                      SetMap, RingFlattening
+                                      }
   orig::TowerRingType
   flat::FlatRingType
   R::CoeffRingType
   orig_to_flat::MPolyAnyMap{TowerRingType, FlatRingType}
-  flat_to_orig::Hecke.Map{FlatRingType, TowerRingType}
-  base_ring_to_flat::Hecke.Map{CoeffRingType, FlatRingType}
+  flat_to_orig::Map{FlatRingType, TowerRingType}
+  base_ring_to_flat::Map{CoeffRingType, FlatRingType}
 
   function RingFlattening(
       S::MPolyRing{RingElemType}

--- a/src/Rings/affine-algebra-homs.jl
+++ b/src/Rings/affine-algebra-homs.jl
@@ -8,7 +8,7 @@ export AlgebraHomomorphism, codomain, compose, domain, hom,
 #
 ###############################################################################
 
-struct IdAlgHom{T} <: AbstractAlgebra.Map{Ring, Ring,
+struct IdAlgHom{T} <: Map{Ring, Ring,
          AbstractAlgebra.IdentityMap, IdAlgHom} where T <: Union{AbstractAlgebra.Ring, AbstractAlgebra.Field}
 
    domain::Union{MPolyRing, MPolyQuo}
@@ -79,7 +79,7 @@ end
 #
 ###############################################################################
 
-mutable struct AlgHom{T} <: AbstractAlgebra.Map{Ring, Ring,
+mutable struct AlgHom{T} <: Map{Ring, Ring,
          AbstractAlgebra.SetMap, AlgHom} where T <: Union{AbstractAlgebra.Ring, AbstractAlgebra.Field}
    domain::Union{MPolyRing, MPolyQuo}
    codomain::Union{MPolyRing, MPolyQuo}

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -1564,7 +1564,7 @@ Ideals in localizations of polynomial rings.
   W::LocRingType
 
   # fields for caching 
-  map_from_base_ring::Hecke.Map
+  map_from_base_ring::Map
 
   # The pre_saturated_ideal can be any ideal I in the `base_ring` of W
   # such that W(I) is this ideal
@@ -1586,7 +1586,7 @@ Ideals in localizations of polynomial rings.
   function MPolyLocalizedIdeal(
       W::MPolyLocRing, 
       gens::Vector{LocRingElemType};
-      map_from_base_ring::Hecke.Map = MapFromFunc(
+      map_from_base_ring::Map = MapFromFunc(
           base_ring(W), 
           W,
           x->W(x),
@@ -1944,7 +1944,7 @@ function coordinate_shift(
               )
     set_attribute!(L, :coordinate_shift, shift)
   end
-  return get_attribute(L, :coordinate_shift)::Hecke.Map
+  return get_attribute(L, :coordinate_shift)::Map
 end
 
 
@@ -2876,7 +2876,7 @@ end
 
 function compose(
     f::MPolyLocalizedRingHom, 
-    g::Hecke.Map{<:Ring, <:Ring}
+    g::Map{<:Ring, <:Ring}
   )
   codomain(f) === domain(g) || error("maps are not compatible")
   R = base_ring(domain(f))

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -1076,7 +1076,7 @@ end
 
 function compose(
     f::MPolyQuoLocalizedRingHom, 
-    g::Hecke.Map{<:Ring, <:Ring}
+    g::Map{<:Ring, <:Ring}
   )
   codomain(f) === domain(g) || error("maps are not compatible")
 
@@ -1572,14 +1572,14 @@ Ideals in localizations of affine algebras.
   W::LocRingType
 
   # fields for caching 
-  map_from_base_ring::Hecke.Map
+  map_from_base_ring::Map
 
   J::MPolyLocalizedIdealType
  
   function MPolyQuoLocalizedIdeal(
       W::MPolyQuoLocRing, 
       g::Vector{LocRingElemType};
-      map_from_base_ring::Hecke.Map = MapFromFunc(
+      map_from_base_ring::Map = MapFromFunc(
           base_ring(W), 
           W,
           x->W(x),

--- a/test/Rings/MPolyAnyMap/flattenings.jl
+++ b/test/Rings/MPolyAnyMap/flattenings.jl
@@ -40,7 +40,7 @@
   @test Oscar.map_from_coefficient_ring_to_flattening(phi).(gens(R)) == phi.(S.(gens(R)))
 
   f = hom(S, S, gens(S))
-  @test Oscar.flatten(f) isa Hecke.Map
+  @test Oscar.flatten(f) isa Map
   K = kernel(f) 
   @test zero(S) in K 
  


### PR DESCRIPTION
This semantically changes nothing, as
```julia
julia> Hecke.Hecke.Map === Hecke.Map === AbstractAlgebra.Map === Map
true
```
but in my opinion, it makes it clearer what happens. In particular, I always get confused between `Hecke.Map` (which is `=== Map`) and `Hecke.HeckeMap` (which has more stuff behind it).

I am asking all people who last edited these functions (@HechtiDerLachs, @HereAround, @thofma, @simonbrandhorst) to review this PR. Please check, that you did not get mixed up with `Map` and `Hecke.HeckeMap`. Since I am not that deep into the internals of your parts of Oscar, I will leave that to you.