### PR TITLE
avoid calling `FamilyPcgs`

### DIFF
--- a/experimental/GModule/Cohomology.jl
+++ b/experimental/GModule/Cohomology.jl
@@ -443,7 +443,7 @@ function Oscar.relations(G::Oscar.GAPGroup)
 end
 
 function Oscar.relations(G::PcGroup)
-   f = GAP.Globals.IsomorphismFpGroupByPcgs(GAP.Globals.FamilyPcgs(G.X), GAP.Obj("g"))
+   f = GAP.Globals.IsomorphismFpGroupByPcgs(GAP.Globals.Pcgs(G.X), GAP.Obj("g"))
    @req f != GAP.Globals.fail "Could not convert group into a group of type FPGroup"
    H = FPGroup(GAPWrap.Image(f))
    return relations(H)


### PR DESCRIPTION
Calling GAP's `FamilyPcgs` with a proper subgroup of a pc group yields a pcgs for the full pc group, see gap-system/gap/issues/5483.

If I remember right then the idea of `relations(G)` for a group `G` was that the relations hold w.r.t. the generators stored for `G`, and then the proposed change will in general violate this assumption.

Perhaps it would be safer to change `relations` such that also the list of generators is returned w.r.t. which the relations hold.