### PR TITLE
Removing groebner_assure() in MPolyQuo

### DIFF
--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1484,7 +1484,7 @@ end
 
 # modular gröbner basis techniques using Singular
 @doc raw"""
-  groebner_basis_modular(I::MPolyIdeal{fmpq_mpoly}; ordering::MonomialOrdering = default_ordering(base_ring(I)), certify::Bool = false)
+    groebner_basis_modular(I::MPolyIdeal{fmpq_mpoly}; ordering::MonomialOrdering = default_ordering(base_ring(I)), certify::Bool = false)
 
 Compute the reduced Gröbner basis of `I` w.r.t. `ordering` using a
 multi-modular strategy.

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1484,8 +1484,7 @@ end
 
 # modular gröbner basis techniques using Singular
 @doc raw"""
-groebner_basis_modular(I::MPolyIdeal{fmpq_mpoly}; ordering::MonomialOrdering = default_ordering(base_ring(I)),
-                           certify::Bool = false)
+  groebner_basis_modular(I::MPolyIdeal{fmpq_mpoly}; ordering::MonomialOrdering = default_ordering(base_ring(I)), certify::Bool = false)
 
 Compute the reduced Gröbner basis of `I` w.r.t. `ordering` using a
 multi-modular strategy.


### PR DESCRIPTION
Removes `groebner_assure()` calls in for quotient rings and adds a specific accessor `singular_groebner_generators()` for quotient ring ideals