### PR TITLE
Cleaning up scalar support (Polyhedral Geometry)

### DIFF
--- a/docs/src/PolyhedralGeometry/Polyhedra/auxiliary.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/auxiliary.md
@@ -64,7 +64,7 @@ is_smooth(P::Polyhedron{QQFieldElem})
 is_very_ample(P::Polyhedron{QQFieldElem})
 lattice_points(P::Polyhedron{QQFieldElem})
 lattice_volume(P::Polyhedron{QQFieldElem})
-normalized_volume(P::Polyhedron{T}) where T<:scalar_types
+normalized_volume(P::Polyhedron)
 polarize(P::Polyhedron{T}) where T<:scalar_types
 project_full(P::Polyhedron{T}) where T<:scalar_types
 print_constraints(A::AnyVecOrMat, b::AbstractVector; trivial::Bool = false)

--- a/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
@@ -17,8 +17,8 @@ from other objects in OSCAR.
 ### Intersecting halfspaces: $H$-representation
 
 ```@docs
-polyhedron(::Type{T}, A::AnyVecOrMat, b::AbstractVector) where T<:scalar_types
-polyhedron(::Type{T}, I::Union{Nothing, AbstractCollection[AffineHalfspace]}, E::Union{Nothing, AbstractCollection[AffineHyperplane]} = nothing) where T<:scalar_types
+polyhedron(::Oscar.scalar_type_or_field, A::AnyVecOrMat, b::AbstractVector)
+polyhedron(::Oscar.scalar_type_or_field, I::Union{Nothing, AbstractCollection[AffineHalfspace]}, E::Union{Nothing, AbstractCollection[AffineHyperplane]} = nothing)
 ```
 
 The complete $H$-representation can be retrieved using [`facets`](@ref facets)
@@ -54,7 +54,7 @@ true
 ### Computing convex hulls: $V$-representation
 
 ```@docs
-convex_hull(::Type{T}, ::AnyVecOrMat; non_redundant::Bool=false) where T<:scalar_types
+convex_hull(::Oscar.scalar_type_or_field, ::AnyVecOrMat; non_redundant::Bool=false)
 ```
 
 This is a standard triangle, defined via a (redundant) $V$-representation  and

--- a/docs/src/PolyhedralGeometry/cones.md
+++ b/docs/src/PolyhedralGeometry/cones.md
@@ -27,7 +27,7 @@ reason for keeping cones as a distinct type.
 ## Construction
 
 ```@docs
-positive_hull(::Type{T}, ::Union{Oscar.MatElem, AbstractMatrix}) where T<:scalar_types
+positive_hull(::Oscar.scalar_type_or_field, ::Union{Oscar.MatElem, AbstractMatrix})
 cone_from_inequalities
 cone_from_equations
 secondary_cone(SOP::SubdivisionOfPoints{T}) where T<:scalar_types

--- a/docs/src/PolyhedralGeometry/intro.md
+++ b/docs/src/PolyhedralGeometry/intro.md
@@ -72,6 +72,13 @@ any of the corresponding notions below.
 
 ### Vectors
 
+There are two specialized `Vector`-like types, `PointVector` and `RayVector`, which commonly are returned by functions from Polyhedral Geometry. These can also be manually constructed:
+
+```@docs
+point_vector
+ray_vector
+```
+
 While `RayVector`s can not be used do describe `PointVector`s (and vice versa),
 matrices are generally allowed.
 
@@ -97,6 +104,15 @@ Type                               | A `RayVector` corresponds to...
 
 
 ### Halfspaces and Hyperplanes
+
+Similar to points and rays, there are types `AffineHalfspace`, `LinearHalfspace`, `AffineHyperplane` and `LinearHyperplane`:
+
+```@docs
+affine_halfspace
+linear_halfspace
+affine_hyperplane
+linar_hyperplane
+```
 
 These collections allow to mix up affine halfspaces/hyperplanes and their linear
 counterparts, but note that an error will be produced when trying to convert

--- a/docs/src/PolyhedralGeometry/intro.md
+++ b/docs/src/PolyhedralGeometry/intro.md
@@ -111,7 +111,7 @@ Similar to points and rays, there are types `AffineHalfspace`, `LinearHalfspace`
 affine_halfspace
 linear_halfspace
 affine_hyperplane
-linar_hyperplane
+linear_hyperplane
 ```
 
 These collections allow to mix up affine halfspaces/hyperplanes and their linear

--- a/docs/src/PolyhedralGeometry/subdivisions_of_points.md
+++ b/docs/src/PolyhedralGeometry/subdivisions_of_points.md
@@ -34,8 +34,8 @@ vector, but if it does, it is called `regular`.
 
 
 ```@docs
-subdivision_of_points(::Type{T}, Points::Union{Oscar.MatElem,AbstractMatrix}, Incidence::IncidenceMatrix) where T<:scalar_types
-subdivision_of_points(::Type{T}, Points::Union{Oscar.MatElem,AbstractMatrix}, Weights::AbstractVector) where T<:scalar_types
+subdivision_of_points(::Oscar.scalar_type_or_field, Points::Union{Oscar.MatElem,AbstractMatrix}, Incidence::IncidenceMatrix)
+subdivision_of_points(::Oscar.scalar_type_or_field, Points::Union{Oscar.MatElem,AbstractMatrix}, Weights::AbstractVector)
 ```
 
 From a subdivision of points one can construct the
@@ -50,6 +50,6 @@ is_regular(SOP::SubdivisionOfPoints)
 maximal_cells
 min_weights
 n_maximal_cells(SOP::SubdivisionOfPoints)
-points(SOP::SubdivisionOfPoints)
+points(SOP::SubdivisionOfPoints{T}) where T<:scalar_types
 secondary_cone
 ```

--- a/src/AlgebraicGeometry/Surfaces/K3Auto.jl
+++ b/src/AlgebraicGeometry/Surfaces/K3Auto.jl
@@ -1594,7 +1594,7 @@ function span_in_S(L, S, weyl)
   if N==0
     M = zero_matrix(QQ, 0, rank(S))
   else
-    M = reduce(vcat, (matrix(QQ, 1, rank(S), v.a) for v in spanC))
+    M = linear_equation_matrix(spanC)
   end
   k, K = kernel(M)
   gensN = transpose(K)[1:k,:]

--- a/src/AlgebraicGeometry/ToricVarieties/Proj/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/Proj/constructors.jl
@@ -74,14 +74,14 @@ function _proj_and_total_space(is_proj::Bool, E::Vector{T}) where T <: Union{Tor
     end
   end
 
-  total_rays_gens = vcat([modified_ray_gens[ray] for ray in rays(v)], [vcat(RayVector(zeros(Int64, dim(v))), l[i]) for i in eachindex(E)])
+  total_rays_gens = vcat([modified_ray_gens[ray] for ray in rays(v)], [vcat(ray_vector(zeros(Int64, dim(v))), l[i]) for i in eachindex(E)])
 
   return normal_toric_variety(polyhedral_fan(total_rays_gens, IncidenceMatrix(new_maximal_cones)))
 end
 
 function _m_sigma(sigma::Cone{QQFieldElem}, pol_sigma::Cone{QQFieldElem}, D::Union{ToricDivisor, ToricLineBundle})::RayVector{QQFieldElem}
 
-  ans = RayVector(zeros(QQFieldElem, dim(sigma)))
+  ans = ray_vector(zeros(QQFieldElem, dim(sigma)))
   coeff = coefficients(isa(D, ToricDivisor) ? D : toric_divisor(D))
 
   dual_ray = QQFieldElem[]

--- a/src/PolyhedralGeometry/Cone/constructors.jl
+++ b/src/PolyhedralGeometry/Cone/constructors.jl
@@ -62,25 +62,25 @@ julia> HS = positive_hull(R, L)
 Polyhedral cone in ambient dimension 2
 ```
 """
-function positive_hull(f::Union{Type{T}, Field}, R::AbstractCollection[RayVector], L::Union{AbstractCollection[RayVector], Nothing} = nothing; non_redundant::Bool = false) where T<:scalar_types
-    parent_field, scalar_type = _determine_parent_and_scalar(f, R, L)
-    inputrays = remove_zero_rows(unhomogenized_matrix(R))
-    if isnothing(L) || isempty(L)
-        L = Polymake.Matrix{_scalar_type_to_polymake(scalar_type)}(undef, 0, _ambient_dim(R))
-    end
+function positive_hull(f::scalar_type_or_field, R::AbstractCollection[RayVector], L::Union{AbstractCollection[RayVector], Nothing} = nothing; non_redundant::Bool = false)
+  parent_field, scalar_type = _determine_parent_and_scalar(f, R, L)
+  inputrays = remove_zero_rows(unhomogenized_matrix(R))
+  if isnothing(L) || isempty(L)
+    L = Polymake.Matrix{_scalar_type_to_polymake(scalar_type)}(undef, 0, _ambient_dim(R))
+  end
 
-    if non_redundant
-        return Cone{scalar_type}(Polymake.polytope.Cone{_scalar_type_to_polymake(scalar_type)}(RAYS = inputrays, LINEALITY_SPACE = unhomogenized_matrix(L),), parent_field)
-    else
-        return Cone{scalar_type}(Polymake.polytope.Cone{_scalar_type_to_polymake(scalar_type)}(INPUT_RAYS = inputrays, INPUT_LINEALITY = unhomogenized_matrix(L),), parent_field)
-    end
+  if non_redundant
+    return Cone{scalar_type}(Polymake.polytope.Cone{_scalar_type_to_polymake(scalar_type)}(RAYS = inputrays, LINEALITY_SPACE = unhomogenized_matrix(L),), parent_field)
+  else
+    return Cone{scalar_type}(Polymake.polytope.Cone{_scalar_type_to_polymake(scalar_type)}(INPUT_RAYS = inputrays, INPUT_LINEALITY = unhomogenized_matrix(L),), parent_field)
+  end
 end
 # Redirect everything to the above constructor, use QQFieldElem as default for the
 # scalar type T.
 positive_hull(R::AbstractCollection[RayVector], L::Union{AbstractCollection[RayVector], Nothing} = nothing; non_redundant::Bool = false) = positive_hull(QQFieldElem, R, L; non_redundant=non_redundant)
 cone(R::AbstractCollection[RayVector], L::Union{AbstractCollection[RayVector], Nothing} = nothing; non_redundant::Bool = false) = positive_hull(QQFieldElem, R, L; non_redundant=non_redundant)
-cone(f::Union{Type{T}, Field}, R::AbstractCollection[RayVector], L::Union{AbstractCollection[RayVector], Nothing} = nothing; non_redundant::Bool = false) where T<:scalar_types = positive_hull(f, R, L; non_redundant=non_redundant)
-cone(f::Union{Type{T}, Field}, x...) where T<:scalar_types = positive_hull(f, x...)
+cone(f::scalar_type_or_field, R::AbstractCollection[RayVector], L::Union{AbstractCollection[RayVector], Nothing} = nothing; non_redundant::Bool = false) = positive_hull(f, R, L; non_redundant=non_redundant)
+cone(f::scalar_type_or_field, x...) = positive_hull(f, x...)
 
 
 function ==(C0::Cone{T}, C1::Cone{T}) where T<:scalar_types
@@ -115,16 +115,16 @@ julia> rays(C)
  [1, 1]
 ```
 """
-function cone_from_inequalities(f::Union{Type{T}, Field}, I::AbstractCollection[LinearHalfspace], E::Union{Nothing, AbstractCollection[LinearHyperplane]} = nothing; non_redundant::Bool = false) where T<:scalar_types
-    parent_field, scalar_type = _determine_parent_and_scalar(f, I, E)
-    IM = -linear_matrix_for_polymake(I)
-    EM = isnothing(E) || isempty(E) ? Polymake.Matrix{_scalar_type_to_polymake(scalar_type)}(undef, 0, size(IM, 2)) : linear_matrix_for_polymake(E)
+function cone_from_inequalities(f::scalar_type_or_field, I::AbstractCollection[LinearHalfspace], E::Union{Nothing, AbstractCollection[LinearHyperplane]} = nothing; non_redundant::Bool = false)
+  parent_field, scalar_type = _determine_parent_and_scalar(f, I, E)
+  IM = -linear_matrix_for_polymake(I)
+  EM = isnothing(E) || isempty(E) ? Polymake.Matrix{_scalar_type_to_polymake(scalar_type)}(undef, 0, size(IM, 2)) : linear_matrix_for_polymake(E)
 
-    if non_redundant
-        return Cone{scalar_type}(Polymake.polytope.Cone{_scalar_type_to_polymake(scalar_type)}(FACETS = IM, LINEAR_SPAN = EM), parent_field)
-    else
-        return Cone{scalar_type}(Polymake.polytope.Cone{_scalar_type_to_polymake(scalar_type)}(INEQUALITIES = IM, EQUATIONS = EM), parent_field)
-    end
+  if non_redundant
+    return Cone{scalar_type}(Polymake.polytope.Cone{_scalar_type_to_polymake(scalar_type)}(FACETS = IM, LINEAR_SPAN = EM), parent_field)
+  else
+    return Cone{scalar_type}(Polymake.polytope.Cone{_scalar_type_to_polymake(scalar_type)}(INEQUALITIES = IM, EQUATIONS = EM), parent_field)
+  end
 end
 
 @doc raw"""
@@ -152,11 +152,11 @@ julia> dim(C)
 1
 ```
 """
-function cone_from_equations(f::Union{Type{T}, Field}, E::AbstractCollection[LinearHyperplane]; non_redundant::Bool = false) where T<:scalar_types
-    parent_field, scalar_type = _determine_parent_and_scalar(f, E)
-    EM = linear_matrix_for_polymake(E)
-    IM = Polymake.Matrix{_scalar_type_to_polymake(scalar_type)}(undef, 0, size(EM, 2))
-    return cone_from_inequalities(f, IM, EM; non_redundant = non_redundant)
+function cone_from_equations(f::scalar_type_or_field, E::AbstractCollection[LinearHyperplane]; non_redundant::Bool = false)
+  parent_field, scalar_type = _determine_parent_and_scalar(f, E)
+  EM = linear_matrix_for_polymake(E)
+  IM = Polymake.Matrix{_scalar_type_to_polymake(scalar_type)}(undef, 0, size(EM, 2))
+  return cone_from_inequalities(f, IM, EM; non_redundant = non_redundant)
 end
 
 cone_from_inequalities(x...) = cone_from_inequalities(QQFieldElem, x...)

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -439,7 +439,7 @@ julia> f = facets(Halfspace, c)
 -x₂ + x₃ ≦ 0
 ```
 """
-facets(as::Type{<:Union{LinearHalfspace{T}, Cone{T}}}, C::Cone) where T<:scalar_types = SubObjectIterator{as}(C, _facet_cone, nfacets(C))
+facets(as::Type{<:Union{LinearHalfspace{T}, Cone{T}}}, C::Cone{T}) where T<:scalar_types = SubObjectIterator{as}(C, _facet_cone, nfacets(C))
 
 _facet_cone(U::Type{LinearHalfspace{T}}, C::Cone{T}, i::Base.Integer) where T<:scalar_types = linear_halfspace(coefficient_field(C), -pm_object(C).FACETS[[i], :])::U
 

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -162,7 +162,7 @@ end
 function _face_cone_facet(::Type{Cone{T}}, C::Cone{T}, i::Base.Integer) where T<:scalar_types
   R = pm_object(C).RAYS[collect(pm_object(C).RAYS_IN_FACETS[i, :]), :]
   L = pm_object(C).LINEALITY_SPACE
-  PT = _scalar_type_to_polymake(T, eltype(R))
+  PT = _scalar_type_to_polymake(T)
   return Cone{T}(Polymake.polytope.Cone{PT}(RAYS = R, LINEALITY_SPACE = pm_object(C).LINEALITY_SPACE), coefficient_field(C))
 end
 

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -530,7 +530,7 @@ function hilbert_basis(C::Cone{QQFieldElem})
    return SubObjectIterator{PointVector{ZZRingElem}}(C, _hilbert_generator, size(pm_object(C).HILBERT_BASIS_GENERATORS[1], 1))
 end
 
-_hilbert_generator(::Type{PointVector{ZZRingElem}}, C::Cone, i::Base.Integer) = PointVector{ZZRingElem}(view(pm_object(C).HILBERT_BASIS_GENERATORS[1], i, :))
+_hilbert_generator(T::Type{PointVector{ZZRingElem}}, C::Cone, i::Base.Integer) = point_vector(ZZ, view(pm_object(C).HILBERT_BASIS_GENERATORS[1], i, :))::T
 
 _generator_matrix(::Val{_hilbert_generator}, C::Cone; homogenized=false) = homogenized ? homogenize(pm_object(C).HILBERT_BASIS_GENERATORS[1], 0) : pm_object(C).HILBERT_BASIS_GENERATORS[1]
 
@@ -586,4 +586,4 @@ Base.in(v::AbstractVector, C::Cone) = Polymake.polytope.contains(pm_object(C), v
 Compute a point in the relative interior point of `C`, i.e. a point in `C` not
 contained in any facet.
 """
-relative_interior_point(C::Cone{T}) where T<:scalar_types = PointVector{T}(coefficient_field(C), view(Polymake.common.dense(pm_object(C).REL_INT_POINT), :)) # broadcast_view
+relative_interior_point(C::Cone{T}) where T<:scalar_types = point_vector(coefficient_field(C), view(Polymake.common.dense(pm_object(C).REL_INT_POINT), :))::PointVector{T} # broadcast_view

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -7,7 +7,7 @@
 rays(as::Type{RayVector{T}}, C::Cone) where T<:scalar_types = lineality_dim(C) == 0 ? _rays(as, C) : _empty_subobjectiterator(as, C)
 _rays(as::Type{RayVector{T}}, C::Cone) where T<:scalar_types = SubObjectIterator{as}(C, _ray_cone, _nrays(C))
 
-_ray_cone(::Type{RayVector{T}}, C::Cone, i::Base.Integer) where T<:scalar_types = RayVector{T}(coefficient_field(C).(view(pm_object(C).RAYS, i, :)))
+_ray_cone(U::Type{RayVector{T}}, C::Cone{T}, i::Base.Integer) where T<:scalar_types = ray_vector(coefficient_field(C), view(pm_object(C).RAYS, i, :))::U
 
 _vector_matrix(::Val{_ray_cone}, C::Cone; homogenized=false) = homogenized ? homogenize(pm_object(C).RAYS, 0) : pm_object(C).RAYS
 
@@ -477,7 +477,7 @@ julia> lineality_space(UH)
 """
 lineality_space(C::Cone{T}) where T<:scalar_types = SubObjectIterator{RayVector{T}}(C, _lineality_cone, lineality_dim(C))
 
-_lineality_cone(::Type{RayVector{T}}, C::Cone, i::Base.Integer) where T<:scalar_types = RayVector{T}(coefficient_field(C).(view(pm_object(C).LINEALITY_SPACE, i, :)))
+_lineality_cone(U::Type{RayVector{T}}, C::Cone{T}, i::Base.Integer) where T<:scalar_types = ray_vector(coefficient_field(C), view(pm_object(C).LINEALITY_SPACE, i, :))::U
 
 _generator_matrix(::Val{_lineality_cone}, C::Cone; homogenized=false) = homogenized ? homogenize(pm_object(C).LINEALITY_SPACE, 0) : pm_object(C).LINEALITY_SPACE
 

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -147,8 +147,11 @@ function faces(C::Cone{T}, face_dim::Int) where T<:scalar_types
    return SubObjectIterator{Cone{T}}(C, _face_cone, size(Polymake.polytope.faces_of_dim(pm_object(C), n), 1), (f_dim = n,))
 end
 
-function _face_cone(U::Type{Cone{T}}, C::Cone{T}, i::Base.Integer; f_dim::Int = 0) where T<:scalar_types
-  return cone(coefficient_field(C), pm_object(C).RAYS[collect(Polymake.to_one_based_indexing(Polymake.polytope.faces_of_dim(pm_object(C), f_dim)[i])), :], pm_object(C).LINEALITY_SPACE)::U
+function _face_cone(::Type{Cone{T}}, C::Cone{T}, i::Base.Integer; f_dim::Int = 0) where T<:scalar_types
+  R = pm_object(C).RAYS[collect(Polymake.to_one_based_indexing(Polymake.polytope.faces_of_dim(pm_object(C), f_dim)[i])), :]
+  L = pm_object(C).LINEALITY_SPACE
+  PT = _scalar_type_to_polymake(T, eltype(R))
+  return Cone{T}(Polymake.polytope.Cone{PT}(RAYS = R, LINEALITY_SPACE = L), coefficient_field(C))
 end
 
 function _ray_indices(::Val{_face_cone}, C::Cone; f_dim::Int = 0)
@@ -156,8 +159,11 @@ function _ray_indices(::Val{_face_cone}, C::Cone; f_dim::Int = 0)
    return IncidenceMatrix([collect(f[i]) for i in 1:length(f)])
 end
 
-function _face_cone_facet(U::Type{Cone{T}}, C::Cone{T}, i::Base.Integer) where T<:scalar_types
-  return cone(coefficient_field(C), pm_object(C).RAYS[collect(pm_object(C).RAYS_IN_FACETS[i, :]), :], pm_object(C).LINEALITY_SPACE)::U
+function _face_cone_facet(::Type{Cone{T}}, C::Cone{T}, i::Base.Integer) where T<:scalar_types
+  R = pm_object(C).RAYS[collect(pm_object(C).RAYS_IN_FACETS[i, :]), :]
+  L = pm_object(C).LINEALITY_SPACE
+  PT = _scalar_type_to_polymake(T, eltype(R))
+  return Cone{T}(Polymake.polytope.Cone{PT}(RAYS = R, LINEALITY_SPACE = pm_object(C).LINEALITY_SPACE), coefficient_field(C))
 end
 
 _ray_indices(::Val{_face_cone_facet}, C::Cone) = pm_object(C).RAYS_IN_FACETS

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -4,8 +4,8 @@
 ###############################################################################
 ###############################################################################
 
-rays(as::Type{RayVector{T}}, C::Cone) where T<:scalar_types = lineality_dim(C) == 0 ? _rays(as, C) : _empty_subobjectiterator(as, C)
-_rays(as::Type{RayVector{T}}, C::Cone) where T<:scalar_types = SubObjectIterator{as}(C, _ray_cone, _nrays(C))
+rays(as::Type{RayVector{T}}, C::Cone{T}) where T<:scalar_types = lineality_dim(C) == 0 ? _rays(as, C) : _empty_subobjectiterator(as, C)
+_rays(as::Type{RayVector{T}}, C::Cone{T}) where T<:scalar_types = SubObjectIterator{as}(C, _ray_cone, _nrays(C))
 
 _ray_cone(U::Type{RayVector{T}}, C::Cone{T}, i::Base.Integer) where T<:scalar_types = ray_vector(coefficient_field(C), view(pm_object(C).RAYS, i, :))::U
 
@@ -13,8 +13,8 @@ _vector_matrix(::Val{_ray_cone}, C::Cone; homogenized=false) = homogenized ? hom
 
 _matrix_for_polymake(::Val{_ray_cone}) = _vector_matrix
 
-rays(::Type{RayVector}, C::Cone{T}) where T<:scalar_types = rays(RayVector{T}, C)
-_rays(::Type{RayVector}, C::Cone{T}) where T<:scalar_types = _rays(RayVector{T}, C)
+rays(::Type{<:RayVector}, C::Cone{T}) where T<:scalar_types = rays(RayVector{T}, C)
+_rays(::Type{<:RayVector}, C::Cone{T}) where T<:scalar_types = _rays(RayVector{T}, C)
 
 @doc raw"""
     rays(C::Cone)
@@ -111,13 +111,13 @@ julia> RML.lineality_basis
 ```
 """                                                             
 rays_modulo_lineality(C::Cone{T}) where T<:scalar_types = rays_modulo_lineality(NamedTuple{(:rays_modulo_lineality, :lineality_basis), Tuple{SubObjectIterator{RayVector{T}}, SubObjectIterator{RayVector{T}}}}, C) 
-function rays_modulo_lineality(as::Type{NamedTuple{(:rays_modulo_lineality, :lineality_basis), Tuple{SubObjectIterator{RayVector{T}}, SubObjectIterator{RayVector{T}}}}}, C::Cone) where T<:scalar_types
+function rays_modulo_lineality(::Type{NamedTuple{(:rays_modulo_lineality, :lineality_basis), Tuple{SubObjectIterator{RayVector{T}}, SubObjectIterator{RayVector{T}}}}}, C::Cone{T}) where T<:scalar_types
     return (
         rays_modulo_lineality = _rays(C),
         lineality_basis = lineality_space(C)
     )
 end
-rays_modulo_lineality(as::Type{RayVector}, C::Cone) = _rays(C)
+rays_modulo_lineality(::Type{<:RayVector}, C::Cone) = _rays(C)
     
 
 @doc raw"""
@@ -147,8 +147,8 @@ function faces(C::Cone{T}, face_dim::Int) where T<:scalar_types
    return SubObjectIterator{Cone{T}}(C, _face_cone, size(Polymake.polytope.faces_of_dim(pm_object(C), n), 1), (f_dim = n,))
 end
 
-function _face_cone(::Type{Cone{T}}, C::Cone, i::Base.Integer; f_dim::Int = 0) where T<:scalar_types
-   return Cone{T}(Polymake.polytope.Cone{_scalar_type_to_polymake(T)}(RAYS = pm_object(C).RAYS[collect(Polymake.to_one_based_indexing(Polymake.polytope.faces_of_dim(pm_object(C), f_dim)[i])), :], LINEALITY_SPACE = pm_object(C).LINEALITY_SPACE))
+function _face_cone(U::Type{Cone{T}}, C::Cone{T}, i::Base.Integer; f_dim::Int = 0) where T<:scalar_types
+  return cone(coefficient_field(C), pm_object(C).RAYS[collect(Polymake.to_one_based_indexing(Polymake.polytope.faces_of_dim(pm_object(C), f_dim)[i])), :], pm_object(C).LINEALITY_SPACE)::U
 end
 
 function _ray_indices(::Val{_face_cone}, C::Cone; f_dim::Int = 0)
@@ -156,8 +156,8 @@ function _ray_indices(::Val{_face_cone}, C::Cone; f_dim::Int = 0)
    return IncidenceMatrix([collect(f[i]) for i in 1:length(f)])
 end
 
-function _face_cone_facet(::Type{Cone{T}}, C::Cone, i::Base.Integer) where T<:scalar_types
-   return Cone{T}(Polymake.polytope.Cone{_scalar_type_to_polymake(T)}(RAYS = pm_object(C).RAYS[collect(pm_object(C).RAYS_IN_FACETS[i, :]), :], LINEALITY_SPACE = pm_object(C).LINEALITY_SPACE), coefficient_field(C))
+function _face_cone_facet(U::Type{Cone{T}}, C::Cone{T}, i::Base.Integer) where T<:scalar_types
+  return cone(coefficient_field(C), pm_object(C).RAYS[collect(pm_object(C).RAYS_IN_FACETS[i, :]), :], pm_object(C).LINEALITY_SPACE)::U
 end
 
 _ray_indices(::Val{_face_cone_facet}, C::Cone) = pm_object(C).RAYS_IN_FACETS
@@ -441,9 +441,9 @@ julia> f = facets(Halfspace, c)
 """
 facets(as::Type{<:Union{LinearHalfspace{T}, Cone{T}}}, C::Cone) where T<:scalar_types = SubObjectIterator{as}(C, _facet_cone, nfacets(C))
 
-_facet_cone(::Type{LinearHalfspace{T}}, C::Cone, i::Base.Integer) where T<:scalar_types = linear_halfspace(coefficient_field(C), -pm_object(C).FACETS[[i], :])
+_facet_cone(U::Type{LinearHalfspace{T}}, C::Cone{T}, i::Base.Integer) where T<:scalar_types = linear_halfspace(coefficient_field(C), -pm_object(C).FACETS[[i], :])::U
 
-_facet_cone(::Type{Cone{T}}, C::Cone, i::Base.Integer) where T<:scalar_types = Cone{T}(Polymake.polytope.facet(pm_object(C), i-1), coefficient_field(C))
+_facet_cone(::Type{Cone{T}}, C::Cone{T}, i::Base.Integer) where T<:scalar_types = Cone{T}(Polymake.polytope.facet(pm_object(C), i-1), coefficient_field(C))
 
 _linear_inequality_matrix(::Val{_facet_cone}, C::Cone) = -pm_object(C).FACETS
 
@@ -455,7 +455,9 @@ _incidencematrix(::Val{_facet_cone}) = _ray_indices
 
 facets(C::Cone{T}) where T<:scalar_types = facets(LinearHalfspace{T}, C)
 
-facets(::Type{Halfspace}, C::Cone{T}) where T<:scalar_types = facets(LinearHalfspace{T}, C)
+facets(::Type{<:Halfspace}, C::Cone{T}) where T<:scalar_types = facets(LinearHalfspace{T}, C)
+
+facets(::Type{<:AffineHalfspace}, C::Cone{T}) where T<:scalar_types = facets(AffineHalfspace{T}, C)
 
 facets(::Type{Cone}, C::Cone{T}) where T<:scalar_types = facets(Cone{T}, C)
 
@@ -501,7 +503,7 @@ x₃ = 0
 """
 linear_span(C::Cone{T}) where T<:scalar_types = SubObjectIterator{LinearHyperplane{T}}(C, _linear_span, size(pm_object(C).LINEAR_SPAN, 1))
 
-_linear_span(::Type{LinearHyperplane{T}}, C::Cone, i::Base.Integer) where T<:scalar_types = linear_hyperplane(coefficient_field(C), view(pm_object(C).LINEAR_SPAN, i, :))
+_linear_span(U::Type{LinearHyperplane{T}}, C::Cone{T}, i::Base.Integer) where T<:scalar_types = linear_hyperplane(coefficient_field(C), view(pm_object(C).LINEAR_SPAN, i, :))::U
 
 _linear_equation_matrix(::Val{_linear_span}, C::Cone) = pm_object(C).LINEAR_SPAN
 
@@ -530,7 +532,7 @@ function hilbert_basis(C::Cone{QQFieldElem})
    return SubObjectIterator{PointVector{ZZRingElem}}(C, _hilbert_generator, size(pm_object(C).HILBERT_BASIS_GENERATORS[1], 1))
 end
 
-_hilbert_generator(T::Type{PointVector{ZZRingElem}}, C::Cone, i::Base.Integer) = point_vector(ZZ, view(pm_object(C).HILBERT_BASIS_GENERATORS[1], i, :))::T
+_hilbert_generator(T::Type{PointVector{ZZRingElem}}, C::Cone{QQFieldElem}, i::Base.Integer) = point_vector(ZZ, view(pm_object(C).HILBERT_BASIS_GENERATORS[1], i, :))::T
 
 _generator_matrix(::Val{_hilbert_generator}, C::Cone; homogenized=false) = homogenized ? homogenize(pm_object(C).HILBERT_BASIS_GENERATORS[1], 0) : pm_object(C).HILBERT_BASIS_GENERATORS[1]
 

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -150,7 +150,7 @@ end
 function _face_cone(::Type{Cone{T}}, C::Cone{T}, i::Base.Integer; f_dim::Int = 0) where T<:scalar_types
   R = pm_object(C).RAYS[collect(Polymake.to_one_based_indexing(Polymake.polytope.faces_of_dim(pm_object(C), f_dim)[i])), :]
   L = pm_object(C).LINEALITY_SPACE
-  PT = _scalar_type_to_polymake(T, eltype(R))
+  PT = _scalar_type_to_polymake(T)
   return Cone{T}(Polymake.polytope.Cone{PT}(RAYS = R, LINEALITY_SPACE = L), coefficient_field(C))
 end
 
@@ -462,8 +462,6 @@ _incidencematrix(::Val{_facet_cone}) = _ray_indices
 facets(C::Cone{T}) where T<:scalar_types = facets(LinearHalfspace{T}, C)
 
 facets(::Type{<:Halfspace}, C::Cone{T}) where T<:scalar_types = facets(LinearHalfspace{T}, C)
-
-facets(::Type{<:AffineHalfspace}, C::Cone{T}) where T<:scalar_types = facets(AffineHalfspace{T}, C)
 
 facets(::Type{Cone}, C::Cone{T}) where T<:scalar_types = facets(Cone{T}, C)
 

--- a/src/PolyhedralGeometry/PolyhedralComplex/constructors.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/constructors.jl
@@ -75,36 +75,36 @@ julia> lineality_dim(PC)
 1
 ```
 """
-function polyhedral_complex(f::Union{Type{T}, Field},
+function polyhedral_complex(f::scalar_type_or_field,
                             polyhedra::IncidenceMatrix, 
                             vr::AbstractCollection[PointVector], 
                             far_vertices::Union{Vector{Int}, Nothing} = nothing, 
                             L::Union{AbstractCollection[RayVector], Nothing} = nothing;
                             non_redundant::Bool = false
-                            ) where T<:scalar_types
-    parent_field, scalar_type = _determine_parent_and_scalar(f, vr, L)
-    points = homogenized_matrix(vr, 1)
-    LM = isnothing(L) || isempty(L) ? zero_matrix(QQ, 0, size(points, 2)) : homogenized_matrix(L, 0)
+                            )
+  parent_field, scalar_type = _determine_parent_and_scalar(f, vr, L)
+  points = homogenized_matrix(vr, 1)
+  LM = isnothing(L) || isempty(L) ? zero_matrix(QQ, 0, size(points, 2)) : homogenized_matrix(L, 0)
 
-    # Rays and Points are homogenized and combined and
-    # If some vertices are far vertices, give them a leading 0
-    if !isnothing(far_vertices)
-        points[far_vertices,1] .= 0
-    end
+  # Rays and Points are homogenized and combined and
+  # If some vertices are far vertices, give them a leading 0
+  if !isnothing(far_vertices)
+    points[far_vertices,1] .= 0
+  end
 
-    if non_redundant
-        return PolyhedralComplex{scalar_type}(Polymake.fan.PolyhedralComplex{_scalar_type_to_polymake(scalar_type)}(
-            VERTICES = points,
-            LINEALITY_SPACE = LM,
-            MAXIMAL_CONES = polyhedra,
-        ), parent_field)
-    else
-        return PolyhedralComplex{scalar_type}(Polymake.fan.PolyhedralComplex{_scalar_type_to_polymake(scalar_type)}(
-            POINTS = points,
-            INPUT_LINEALITY = LM,
-            INPUT_CONES = polyhedra,
-        ), parent_field)
-    end
+  if non_redundant
+    return PolyhedralComplex{scalar_type}(Polymake.fan.PolyhedralComplex{_scalar_type_to_polymake(scalar_type)}(
+      VERTICES = points,
+      LINEALITY_SPACE = LM,
+      MAXIMAL_CONES = polyhedra,
+    ), parent_field)
+  else
+    return PolyhedralComplex{scalar_type}(Polymake.fan.PolyhedralComplex{_scalar_type_to_polymake(scalar_type)}(
+      POINTS = points,
+      INPUT_LINEALITY = LM,
+      INPUT_CONES = polyhedra,
+    ), parent_field)
+  end
 end
 # default scalar type: `QQFieldElem`
 polyhedral_complex(polyhedra::IncidenceMatrix, 
@@ -114,11 +114,11 @@ polyhedral_complex(polyhedra::IncidenceMatrix,
                 non_redundant::Bool = false) =
   polyhedral_complex(QQFieldElem, polyhedra, vr, far_vertices, L; non_redundant=non_redundant)
 
-function polyhedral_complex(f::Union{Type{T}, Field}, v::AbstractCollection[PointVector], vi::IncidenceMatrix, r::AbstractCollection[RayVector], ri::IncidenceMatrix, L::Union{AbstractCollection[RayVector], Nothing} = nothing; non_redundant::Bool = false) where T<:scalar_types
-    vr = [unhomogenized_matrix(v); unhomogenized_matrix(r)]
-    far_vertices = collect((size(v, 1) + 1):size(vr, 1))
-    polyhedra = hcat(vi, ri)
-    return polyhedral_complex(f, polyhedra, vr, far_vertices, L; non_redundant = non_redundant)
+function polyhedral_complex(f::scalar_type_or_field, v::AbstractCollection[PointVector], vi::IncidenceMatrix, r::AbstractCollection[RayVector], ri::IncidenceMatrix, L::Union{AbstractCollection[RayVector], Nothing} = nothing; non_redundant::Bool = false)
+  vr = [unhomogenized_matrix(v); unhomogenized_matrix(r)]
+  far_vertices = collect((size(v, 1) + 1):size(vr, 1))
+  polyhedra = hcat(vi, ri)
+  return polyhedral_complex(f, polyhedra, vr, far_vertices, L; non_redundant = non_redundant)
 end
 
 # TODO: Only works for this specific case; implement generalization using `iter.Acc`

--- a/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
@@ -268,12 +268,10 @@ _rays(PC::PolyhedralComplex{T}) where {T<:scalar_types} = _rays(RayVector{T}, PC
 _ray_indices_polyhedral_complex(PC::Polymake.BigObject) =
   collect(Polymake.to_one_based_indexing(PC.FAR_VERTICES))
 
-_ray_polyhedral_complex(
-  ::Type{RayVector{T}}, PC::PolyhedralComplex, i::Base.Integer
-) where {T<:scalar_types} = RayVector{T}(
+_ray_polyhedral_complex(U::Type{RayVector{T}}, PC::PolyhedralComplex{T}, i::Base.Integer) where {T<:scalar_types} = ray_vector(
   coefficient_field(PC),
   @view pm_object(PC).VERTICES[_ray_indices_polyhedral_complex(pm_object(PC))[i], 2:end]
-)
+)::U
 
 _matrix_for_polymake(::Val{_ray_polyhedral_complex}) = _vector_matrix
 
@@ -493,10 +491,10 @@ end
 lineality_space(PC::PolyhedralComplex{T}) where {T<:scalar_types} =
   SubObjectIterator{RayVector{T}}(PC, _lineality_complex, lineality_dim(PC))
 
-_lineality_complex(
-  ::Type{RayVector{T}}, PC::PolyhedralComplex, i::Base.Integer
-) where {T<:scalar_types} =
-  RayVector{T}(coefficient_field(PC), @view pm_object(PC).LINEALITY_SPACE[i, 2:end])
+_lineality_complex(U::Type{RayVector{T}}, PC::PolyhedralComplex{T}, i::Base.Integer) where {T<:scalar_types} = ray_vector(
+  coefficient_field(PC),
+  @view pm_object(PC).LINEALITY_SPACE[i, 2:end]
+)::U
 
 _generator_matrix(::Val{_lineality_complex}, PC::PolyhedralComplex; homogenized=false) =
   if homogenized

--- a/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
@@ -466,7 +466,7 @@ function _ith_polyhedron(
   pface = Polymake.row(Polymake.fan.cones_of_dim(pm_object(PC), f_dim), f_ind[i])
   V = pm_object(PC).VERTICES[collect(pface), :]
   L = pm_object(PC).LINEALITY_SPACE
-  PT = _scalar_type_to_polymake(T, eltype(V))
+  PT = _scalar_type_to_polymake(T)
   return Polyhedron{T}(
     Polymake.polytope.Polytope{PT}(VERTICES = V, LINEALITY_SPACE = L),
     coefficient_field(PC)

--- a/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
@@ -464,8 +464,11 @@ function _ith_polyhedron(
   f_ind::Vector{Int64} = Vector{Int64}()
   ) where {T<:scalar_types}
   pface = Polymake.row(Polymake.fan.cones_of_dim(pm_object(PC), f_dim), f_ind[i])
+  V = pm_object(PC).VERTICES[collect(pface), :]
+  L = pm_object(PC).LINEALITY_SPACE
+  PT = _scalar_type_to_polymake(T, eltype(V))
   return Polyhedron{T}(
-    Polymake.polytope.Polytope{_scalar_type_to_polymake(T)}(VERTICES = pm_object(PC).VERTICES[collect(pface), :], LINEALITY_SPACE = pm_object(PC).LINEALITY_SPACE),
+    Polymake.polytope.Polytope{PT}(VERTICES = V, LINEALITY_SPACE = L),
     coefficient_field(PC)
   )
 end

--- a/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
@@ -63,12 +63,10 @@ vertices(as::Type{PointVector{T}}, PC::PolyhedralComplex{T}) where {T<:scalar_ty
 _vertices(as::Type{PointVector{T}}, PC::PolyhedralComplex) where {T<:scalar_types} =
   SubObjectIterator{as}(PC, _vertex_complex, length(_vertex_indices(pm_object(PC))))
 
-_vertex_complex(
-  ::Type{PointVector{T}}, PC::PolyhedralComplex, i::Base.Integer
-) where {T<:scalar_types} = PointVector{T}(
+_vertex_complex(U::Type{PointVector{T}}, PC::PolyhedralComplex{T}, i::Base.Integer) where {T<:scalar_types} = point_vector(
   coefficient_field(PC),
   @view pm_object(PC).VERTICES[_vertex_indices(pm_object(PC))[i], 2:end]
-)
+)::U
 
 _point_matrix(::Val{_vertex_complex}, PC::PolyhedralComplex; homogenized=false) =
   @view pm_object(PC).VERTICES[_vertex_indices(pm_object(PC)), (homogenized ? 1 : 2):end]
@@ -85,20 +83,18 @@ function _all_vertex_indices(P::Polymake.BigObject)
   return vi
 end
 
-function _vertex_or_ray_complex(
-  ::Type{Union{PointVector{T},RayVector{T}}}, PC::PolyhedralComplex, i::Base.Integer
-) where {T<:scalar_types}
+function _vertex_or_ray_complex(::Type{Union{PointVector{T}, RayVector{T}}}, PC::PolyhedralComplex{T}, i::Base.Integer) where T<:scalar_types
   A = pm_object(PC).VERTICES
   if iszero(A[_all_vertex_indices(pm_object(PC))[i], 1])
-    return RayVector{T}(
+    return ray_vector(
       coefficient_field(PC),
       @view pm_object(PC).VERTICES[_all_vertex_indices(pm_object(PC))[i], 2:end]
-    )
+    )::RayVector{T}
   else
-    return PointVector{T}(
+    return point_vector(
       coefficient_field(PC),
       @view pm_object(PC).VERTICES[_all_vertex_indices(pm_object(PC))[i], 2:end]
-    )
+    )::PointVector{T}
   end
 end
 

--- a/src/PolyhedralGeometry/PolyhedralFan/constructors.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/constructors.jl
@@ -64,33 +64,33 @@ julia> lineality_dim(PF)
 1
 ```
 """
-function polyhedral_fan(f::Union{Type{T}, Field},
+function polyhedral_fan(f::scalar_type_or_field,
                         Rays::AbstractCollection[RayVector], 
                         LS::Union{AbstractCollection[RayVector], Nothing},
                         Incidence::IncidenceMatrix; 
-                        non_redundant::Bool = false) where T<:scalar_types
-    parent_field, scalar_type = _determine_parent_and_scalar(f, Rays, LS)
-    RM = unhomogenized_matrix(Rays)
-    if isnothing(LS)
-        LM = Polymake.Matrix{_scalar_type_to_polymake(scalar_type)}(undef, 0, size(RM, 2))
-    else
-        LM = unhomogenized_matrix(LS)
-    end
-    if non_redundant
-        return PolyhedralFan{scalar_type}(Polymake.fan.PolyhedralFan{_scalar_type_to_polymake(scalar_type)}(
-            RAYS = RM,
-            LINEALITY_SPACE = LM,
-            MAXIMAL_CONES = Incidence,
-        ), parent_field)
-    else
-        return PolyhedralFan{scalar_type}(Polymake.fan.PolyhedralFan{_scalar_type_to_polymake(scalar_type)}(
-            INPUT_RAYS = RM,
-            INPUT_LINEALITY = LM,
-            INPUT_CONES = Incidence,
-        ), parent_field)
-    end
+                        non_redundant::Bool = false)
+  parent_field, scalar_type = _determine_parent_and_scalar(f, Rays, LS)
+  RM = unhomogenized_matrix(Rays)
+  if isnothing(LS)
+    LM = Polymake.Matrix{_scalar_type_to_polymake(scalar_type)}(undef, 0, size(RM, 2))
+  else
+    LM = unhomogenized_matrix(LS)
+  end
+  if non_redundant
+    return PolyhedralFan{scalar_type}(Polymake.fan.PolyhedralFan{_scalar_type_to_polymake(scalar_type)}(
+      RAYS = RM,
+      LINEALITY_SPACE = LM,
+      MAXIMAL_CONES = Incidence,
+    ), parent_field)
+  else
+    return PolyhedralFan{scalar_type}(Polymake.fan.PolyhedralFan{_scalar_type_to_polymake(scalar_type)}(
+      INPUT_RAYS = RM,
+      INPUT_LINEALITY = LM,
+      INPUT_CONES = Incidence,
+    ), parent_field)
+  end
 end
-polyhedral_fan(f::Union{Type{T}, Field}, Rays::AbstractCollection[RayVector], Incidence::IncidenceMatrix; non_redundant::Bool = false) where T<:scalar_types = polyhedral_fan(f, Rays, nothing, Incidence; non_redundant=non_redundant)
+polyhedral_fan(f::scalar_type_or_field, Rays::AbstractCollection[RayVector], Incidence::IncidenceMatrix; non_redundant::Bool = false) = polyhedral_fan(f, Rays, nothing, Incidence; non_redundant=non_redundant)
 polyhedral_fan(Rays::AbstractCollection[RayVector], LS::Union{AbstractCollection[RayVector], Nothing}, Incidence::IncidenceMatrix; non_redundant::Bool = false) = polyhedral_fan(QQFieldElem, Rays, LS, Incidence; non_redundant = non_redundant)
 polyhedral_fan(Rays::AbstractCollection[RayVector], Incidence::IncidenceMatrix; non_redundant::Bool = false) = polyhedral_fan(QQFieldElem, Rays, Incidence; non_redundant = non_redundant)
 
@@ -104,9 +104,9 @@ pm_object(PF::PolyhedralFan) = PF.pm_fan
 polyhedral_fan(itr::AbstractVector{Cone{T}}) where T<:scalar_types = PolyhedralFan{T}(Polymake.fan.check_fan_objects(pm_object.(itr)...), coefficient_field(iterate(itr)[1]))
 
 #Same construction for when the user gives Matrix{Bool} as incidence matrix
-polyhedral_fan(f::Union{Type{T}, Field}, Rays::AbstractCollection[RayVector], LS::AbstractCollection[RayVector], Incidence::Matrix{Bool}) where T<:scalar_types =
+polyhedral_fan(f::scalar_type_or_field, Rays::AbstractCollection[RayVector], LS::AbstractCollection[RayVector], Incidence::Matrix{Bool}) =
   polyhedral_fan(f, Rays, LS, IncidenceMatrix(Polymake.IncidenceMatrix(Incidence)))
-polyhedral_fan(f::Union{Type{T}, Field}, Rays::AbstractCollection[RayVector], Incidence::Matrix{Bool}) where T<:scalar_types =
+polyhedral_fan(f::scalar_type_or_field, Rays::AbstractCollection[RayVector], Incidence::Matrix{Bool}) =
   polyhedral_fan(f, Rays, IncidenceMatrix(Polymake.IncidenceMatrix(Incidence)))
 
 
@@ -135,15 +135,15 @@ parent `Field`.
   group acting on the rays of the fan.
 
 """
-function polyhedral_fan_from_rays_action(f::Union{Type{T}, Field}, Rays::AbstractCollection[RayVector], MC_reps::IncidenceMatrix, perms::AbstractVector{PermGroupElem}) where T<:scalar_types
-    parent_field, scalar_type = _determine_parent_and_scalar(f, Rays)
-    pf = Polymake.fan.PolyhedralFan{_scalar_type_to_polymake(scalar_type)}()
-    Polymake.take(pf, "RAYS", Polymake.Matrix{_scalar_type_to_polymake(scalar_type)}(unhomogenized_matrix(Rays)))
-    d = length(Rays)
-    gp = _group_generators_to_pm_arr_arr(perms, d)
-    Polymake.take(pf, "GROUP.RAYS_ACTION.GENERATORS", gp)
-    Polymake.take(pf, "GROUP.MAXIMAL_CONES_ACTION.MAXIMAL_CONES_GENERATORS", MC_reps)
-    return PolyhedralFan{scalar_type}(pf, parent_field)
+function polyhedral_fan_from_rays_action(f::scalar_type_or_field, Rays::AbstractCollection[RayVector], MC_reps::IncidenceMatrix, perms::AbstractVector{PermGroupElem})
+  parent_field, scalar_type = _determine_parent_and_scalar(f, Rays)
+  pf = Polymake.fan.PolyhedralFan{_scalar_type_to_polymake(scalar_type)}()
+  Polymake.take(pf, "RAYS", Polymake.Matrix{_scalar_type_to_polymake(scalar_type)}(unhomogenized_matrix(Rays)))
+  d = length(Rays)
+  gp = _group_generators_to_pm_arr_arr(perms, d)
+  Polymake.take(pf, "GROUP.RAYS_ACTION.GENERATORS", gp)
+  Polymake.take(pf, "GROUP.MAXIMAL_CONES_ACTION.MAXIMAL_CONES_GENERATORS", MC_reps)
+  return PolyhedralFan{scalar_type}(pf, parent_field)
 end
 polyhedral_fan_from_rays_action(Rays::AbstractCollection[RayVector], MC_reps::IncidenceMatrix, perms::AbstractVector{PermGroupElem}) = polyhedral_fan_from_rays_action(QQFieldElem, Rays, MC_reps, perms)
 

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -46,7 +46,7 @@ julia> matrix(QQ, rays(NF))
 rays(PF::_FanLikeType) = lineality_dim(PF) == 0 ? _rays(PF) : _empty_subobjectiterator(RayVector{_get_scalar_type(PF)}, PF)
 _rays(PF::_FanLikeType) = SubObjectIterator{RayVector{_get_scalar_type(PF)}}(PF, _ray_fan, _nrays(PF))
 
-_ray_fan(::Type{RayVector{T}}, PF::_FanLikeType, i::Base.Integer) where T<:scalar_types = RayVector{T}(coefficient_field(PF), view(pm_object(PF).RAYS, i, :))
+_ray_fan(U::Type{RayVector{T}}, PF::_FanLikeType{T}, i::Base.Integer) where T<:scalar_types = ray_vector(coefficient_field(PF), view(pm_object(PF).RAYS, i, :))::U
 
 _vector_matrix(::Val{_ray_fan}, PF::_FanLikeType; homogenized=false) = homogenized ? homogenize(pm_object(PF).RAYS, 0) : pm_object(PF).RAYS
 
@@ -385,7 +385,7 @@ julia> lineality_space(PF)
 """
 lineality_space(PF::_FanLikeType) = SubObjectIterator{RayVector{_get_scalar_type(PF)}}(PF, _lineality_fan, lineality_dim(PF))
 
-_lineality_fan(::Type{RayVector{T}}, PF::_FanLikeType, i::Base.Integer) where T<:scalar_types = RayVector{T}(coefficient_field(PF), view(pm_object(PF).LINEALITY_SPACE, i, :))
+_lineality_fan(U::Type{RayVector{T}}, PF::_FanLikeType{T}, i::Base.Integer) where T<:scalar_types = ray_vector(coefficient_field(PF), view(pm_object(PF).LINEALITY_SPACE, i, :))::U
 
 _generator_matrix(::Val{_lineality_fan}, PF::_FanLikeType; homogenized=false) = homogenized ? homogenize(pm_object(PF).LINEALITY_SPACE, 0) : pm_object(PF).LINEALITY_SPACE
 

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -46,13 +46,15 @@ julia> matrix(QQ, rays(NF))
 rays(PF::_FanLikeType) = lineality_dim(PF) == 0 ? _rays(PF) : _empty_subobjectiterator(RayVector{_get_scalar_type(PF)}, PF)
 _rays(PF::_FanLikeType) = SubObjectIterator{RayVector{_get_scalar_type(PF)}}(PF, _ray_fan, _nrays(PF))
 
-_ray_fan(U::Type{RayVector{T}}, PF::_FanLikeType{T}, i::Base.Integer) where T<:scalar_types = ray_vector(coefficient_field(PF), view(pm_object(PF).RAYS, i, :))::U
+_ray_fan(U::Type{RayVector{T}}, PF::_FanLikeType, i::Base.Integer) where {T<:scalar_types} =
+  ray_vector(coefficient_field(PF), view(pm_object(PF).RAYS, i, :))::U
 
 _vector_matrix(::Val{_ray_fan}, PF::_FanLikeType; homogenized=false) = homogenized ? homogenize(pm_object(PF).RAYS, 0) : pm_object(PF).RAYS
 
 _matrix_for_polymake(::Val{_ray_fan}) = _vector_matrix
 
-_maximal_cone(::Type{Cone{T}}, PF::_FanLikeType{T}, i::Base.Integer) where T<:scalar_types = Cone{T}(Polymake.fan.cone(pm_object(PF), i - 1), coefficient_field(PF))
+_maximal_cone(::Type{Cone{T}}, PF::_FanLikeType, i::Base.Integer) where {T<:scalar_types} =
+  Cone{T}(Polymake.fan.cone(pm_object(PF), i - 1), coefficient_field(PF))
 
 
 @doc raw"""                                                 
@@ -87,13 +89,13 @@ julia> rays(NF)
 0-element SubObjectIterator{RayVector{QQFieldElem}}
 ```
 """
-rays_modulo_lineality(F::_FanLikeType{T}) where {T<:scalar_types} =
+rays_modulo_lineality(F::_FanLikeType) =
   rays_modulo_lineality(
-    NamedTuple{(:rays_modulo_lineality, :lineality_basis), Tuple{SubObjectIterator{RayVector{T}}, SubObjectIterator{RayVector{T}}}},
+    NamedTuple{(:rays_modulo_lineality, :lineality_basis), Tuple{SubObjectIterator{RayVector{_get_scalar_type(F)}}, SubObjectIterator{RayVector{_get_scalar_type(F)}}}},
     F
   )
 
-function rays_modulo_lineality(::Type{NamedTuple{(:rays_modulo_lineality, :lineality_basis), Tuple{SubObjectIterator{RayVector{T}}, SubObjectIterator{RayVector{T}}}}}, F::_FanLikeType{T}) where T<:scalar_types
+function rays_modulo_lineality(::Type{NamedTuple{(:rays_modulo_lineality, :lineality_basis), Tuple{SubObjectIterator{RayVector{T}}, SubObjectIterator{RayVector{T}}}}}, F::_FanLikeType) where {T<:scalar_types}
     return (
         rays_modulo_lineality = _rays(F),
         lineality_basis = lineality_space(F)
@@ -164,10 +166,10 @@ function cones(PF::_FanLikeType, cone_dim::Int)
     return SubObjectIterator{Cone{_get_scalar_type(PF)}}(PF, _cone_of_dim, size(Polymake.fan.cones_of_dim(pm_object(PF), l), 1), (c_dim = l,))
 end
 
-function _cone_of_dim(::Type{Cone{T}}, PF::_FanLikeType{T}, i::Base.Integer; c_dim::Int = 0) where T<:scalar_types
+function _cone_of_dim(::Type{Cone{T}}, PF::_FanLikeType, i::Base.Integer; c_dim::Int = 0) where T<:scalar_types
   R = pm_object(PF).RAYS[collect(Polymake.row(Polymake.fan.cones_of_dim(pm_object(PF), c_dim), i)), :]
   L = pm_object(PF).LINEALITY_SPACE
-  PT = _scalar_type_to_polymake(T, eltype(R))
+  PT = _scalar_type_to_polymake(T)
   return Cone{T}(Polymake.polytope.Cone{PT}(RAYS = R, LINEALITY_SPACE = L), coefficient_field(PF))
 end
 
@@ -394,7 +396,7 @@ julia> lineality_space(PF)
 """
 lineality_space(PF::_FanLikeType) = SubObjectIterator{RayVector{_get_scalar_type(PF)}}(PF, _lineality_fan, lineality_dim(PF))
 
-_lineality_fan(U::Type{RayVector{T}}, PF::_FanLikeType{T}, i::Base.Integer) where T<:scalar_types = ray_vector(coefficient_field(PF), view(pm_object(PF).LINEALITY_SPACE, i, :))::U
+_lineality_fan(U::Type{RayVector{T}}, PF::_FanLikeType, i::Base.Integer) where {T<:scalar_types} = ray_vector(coefficient_field(PF), view(pm_object(PF).LINEALITY_SPACE, i, :))::U
 
 _generator_matrix(::Val{_lineality_fan}, PF::_FanLikeType; homogenized=false) = homogenized ? homogenize(pm_object(PF).LINEALITY_SPACE, 0) : pm_object(PF).LINEALITY_SPACE
 

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -164,8 +164,11 @@ function cones(PF::_FanLikeType, cone_dim::Int)
     return SubObjectIterator{Cone{_get_scalar_type(PF)}}(PF, _cone_of_dim, size(Polymake.fan.cones_of_dim(pm_object(PF), l), 1), (c_dim = l,))
 end
 
-function _cone_of_dim(U::Type{Cone{T}}, PF::_FanLikeType{T}, i::Base.Integer; c_dim::Int = 0) where T<:scalar_types
-    return cone(coefficient_field(PF), pm_object(PF).RAYS[collect(Polymake.row(Polymake.fan.cones_of_dim(pm_object(PF), c_dim), i)),:], pm_object(PF).LINEALITY_SPACE)::U
+function _cone_of_dim(::Type{Cone{T}}, PF::_FanLikeType{T}, i::Base.Integer; c_dim::Int = 0) where T<:scalar_types
+  R = pm_object(PF).RAYS[collect(Polymake.row(Polymake.fan.cones_of_dim(pm_object(PF), c_dim), i)), :]
+  L = pm_object(PF).LINEALITY_SPACE
+  PT = _scalar_type_to_polymake(T, eltype(R))
+  return Cone{T}(Polymake.polytope.Cone{PT}(RAYS = R, LINEALITY_SPACE = L), coefficient_field(PF))
 end
 
 _ray_indices(::Val{_cone_of_dim}, PF::_FanLikeType; c_dim::Int = 0) = Polymake.fan.cones_of_dim(pm_object(PF), c_dim)

--- a/src/PolyhedralGeometry/Polyhedron/constructors.jl
+++ b/src/PolyhedralGeometry/Polyhedron/constructors.jl
@@ -31,12 +31,8 @@ Construct a `Polyhedron` corresponding to a `Polymake.BigObject` of type `Polyto
 """
 function polyhedron(p::Polymake.BigObject)
   T, f = _detect_scalar_and_field(Polyhedron, p)
-  if T == EmbeddedElem{nf_elem} && Hecke.isquadratic_type(number_field(f))[1]
-    scalar_regexp = match(r"[^<]*<(.*)>[^>]*", String(Polymake.type_name(p)))
-    typename = scalar_regexp[1]
-    if typename == "QuadraticExtension<Rational>"
-      p = _polyhedron_qe_to_on(p, f)
-    end
+  if T == EmbeddedElem{nf_elem} && Hecke.isquadratic_type(number_field(f))[1] && Polymake.bigobject_eltype(p) == "QuadraticExtension"
+    p = _polyhedron_qe_to_on(p, f)
   end 
   return Polyhedron{T}(p, f)
 end

--- a/src/PolyhedralGeometry/Polyhedron/constructors.jl
+++ b/src/PolyhedralGeometry/Polyhedron/constructors.jl
@@ -30,8 +30,15 @@ polyhedron(A) = polyhedron(QQFieldElem, A)
 Construct a `Polyhedron` corresponding to a `Polymake.BigObject` of type `Polytope`. Scalar type and parent field will be detected automatically. To improve type stability and performance, please use [`Polyhedron{T}(p::Polymake.BigObject, f::Field) where T<:scalar_types`](@ref) instead, where possible.
 """
 function polyhedron(p::Polymake.BigObject)
-    T, f = _detect_scalar_and_field(Polyhedron, p)
-    return Polyhedron{T}(p, f)
+  T, f = _detect_scalar_and_field(Polyhedron, p)
+  if T == EmbeddedElem{nf_elem} && Hecke.isquadratic_type(number_field(f))[1]
+    scalar_regexp = match(r"[^<]*<(.*)>[^>]*", String(Polymake.type_name(p)))
+    typename = scalar_regexp[1]
+    if typename == "QuadraticExtension<Rational>"
+      p = _polyhedron_qe_to_on(p, f)
+    end
+  end 
+  return Polyhedron{T}(p, f)
 end
 
 @doc raw"""

--- a/src/PolyhedralGeometry/Polyhedron/constructors.jl
+++ b/src/PolyhedralGeometry/Polyhedron/constructors.jl
@@ -131,36 +131,8 @@ Get the underlying polymake `Polytope`.
 pm_object(P::Polyhedron) = P.pm_polytope
 
 function ==(P0::Polyhedron{T}, P1::Polyhedron{T}) where T<:scalar_types
-    # TODO: Remove the following 3 lines, see #758
-    for pair in Iterators.product([P0, P1], ["RAYS", "FACETS"])
-        Polymake.give(pm_object(pair[1]),pair[2])
-    end
     Polymake.polytope.equal_polyhedra(pm_object(P0), pm_object(P1))
 end
-
-function Base.:(==)(P0::Polyhedron{EmbeddedElem{nf_elem}}, P1::Polyhedron{EmbeddedElem{nf_elem}})
-  R0 = pm_object(P0).RAYS
-  R1 = pm_object(P1).RAYS
-  T0 = eltype(R0)
-  T1 = eltype(R1)
-  if T0 != T1
-    if T0 <: Polymake.QuadraticExtension
-      Q0 = convex_hull(coefficient_field(P0), point_matrix(vertices(P0)), vector_matrix(rays(P0)), generator_matrix(lineality_space(P0)); non_redundant = true)
-      Polymake.give(pm_object(Q0), "FACETS")
-      Polymake.give(pm_object(P1), "FACETS")
-      return Polymake.polytope.equal_polyhedra(pm_object(Q0), pm_object(P1))
-    else
-      Q1 = convex_hull(coefficient_field(P1), point_matrix(vertices(P1)), vector_matrix(rays(P1)), generator_matrix(lineality_space(P1)); non_redundant = true)
-      Polymake.give(pm_object(P0), "FACETS")
-      Polymake.give(pm_object(Q1), "FACETS")
-      return Polymake.polytope.equal_polyhedra(pm_object(P0), pm_object(Q1))
-    end
-  end
-  Polymake.give(pm_object(P0), "FACETS")
-  Polymake.give(pm_object(P1), "FACETS")
-  Polymake.polytope.equal_polyhedra(pm_object(P0), pm_object(P1))
-end
-
 
 ### Construct polyhedron from V-data, as the convex hull of points, rays and lineality.
 @doc raw"""

--- a/src/PolyhedralGeometry/Polyhedron/constructors.jl
+++ b/src/PolyhedralGeometry/Polyhedron/constructors.jl
@@ -106,7 +106,7 @@ julia> vertices(P)
  [0, 0]
 ```
 """
-function polyhedron(f::scalar_type_or_field, I::Union{Nothing, AbstractCollection[AffineHalfspace]}, E::Union{Nothing, AbstractCollection[AffineHyperplane]} = nothing; parent_field::Union{Nothing, Field} = nothing)
+function polyhedron(f::scalar_type_or_field, I::Union{Nothing, AbstractCollection[AffineHalfspace]}, E::Union{Nothing, AbstractCollection[AffineHyperplane]} = nothing)
   parent_field, scalar_type = _determine_parent_and_scalar(f, I, E)
   if isnothing(I) || _isempty_halfspace(I)
     EM = affine_matrix_for_polymake(E)

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -39,7 +39,7 @@ function _face_polyhedron(::Type{Polyhedron{T}}, P::Polyhedron{T}, i::Base.Integ
   pface = Polymake.to_one_based_indexing(Polymake.polytope.faces_of_dim(pm_object(P), f_dim))[f_ind[i]]
   V = pm_object(P).VERTICES[collect(pface), :]
   L = pm_object(P).LINEALITY_SPACE
-  PT = _scalar_type_to_polymake(T, eltype(V))
+  PT = _scalar_type_to_polymake(T)
   return Polyhedron{T}(Polymake.polytope.Polytope{PT}(VERTICES = V, LINEALITY_SPACE = L), coefficient_field(P))
 end
 
@@ -61,7 +61,7 @@ function _face_polyhedron_facet(::Type{Polyhedron{T}}, P::Polyhedron{T}, i::Base
   pface = pm_object(P).VERTICES_IN_FACETS[_facet_index(pm_object(P), i), :]
   V = pm_object(P).VERTICES[collect(pface), :]
   L = pm_object(P).LINEALITY_SPACE
-  PT = _scalar_type_to_polymake(T, eltype(V))
+  PT = _scalar_type_to_polymake(T)
   return Polyhedron{T}(Polymake.polytope.Polytope{PT}(VERTICES = V, LINEALITY_SPACE = L), coefficient_field(P))
 end
 

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -200,7 +200,7 @@ julia> vertices(PointVector, P)
 vertices(as::Type{PointVector{T}}, P::Polyhedron) where T<:scalar_types = lineality_dim(P) == 0 ? _vertices(as, P) : _empty_subobjectiterator(as, P)
 _vertices(as::Type{PointVector{T}}, P::Polyhedron) where T<:scalar_types = SubObjectIterator{as}(P, _vertex_polyhedron, length(_vertex_indices(pm_object(P))))
 
-_vertex_polyhedron(::Type{PointVector{T}}, P::Polyhedron, i::Base.Integer) where T<:scalar_types = PointVector{T}(coefficient_field(P).(@view pm_object(P).VERTICES[_vertex_indices(pm_object(P))[i], 2:end]))
+_vertex_polyhedron(U::Type{PointVector{T}}, P::Polyhedron{T}, i::Base.Integer) where T<:scalar_types = point_vector(coefficient_field(P), @view pm_object(P).VERTICES[_vertex_indices(pm_object(P))[i], 2:end])::U
 
 _point_matrix(::Val{_vertex_polyhedron}, P::Polyhedron; homogenized=false) = @view pm_object(P).VERTICES[_vertex_indices(pm_object(P)), (homogenized ? 1 : 2):end]
 
@@ -615,7 +615,7 @@ function lattice_points(P::Polyhedron{QQFieldElem})
     return SubObjectIterator{PointVector{ZZRingElem}}(P, _lattice_point, size(pm_object(P).LATTICE_POINTS_GENERATORS[1], 1))
 end
 
-_lattice_point(::Type{PointVector{ZZRingElem}}, P::Polyhedron, i::Base.Integer) = PointVector{ZZRingElem}(@view pm_object(P).LATTICE_POINTS_GENERATORS[1][i, 2:end])
+_lattice_point(T::Type{PointVector{ZZRingElem}}, P::Polyhedron, i::Base.Integer) = point_vector(ZZ, @view pm_object(P).LATTICE_POINTS_GENERATORS[1][i, 2:end])::T
 
 _point_matrix(::Val{_lattice_point}, P::Polyhedron; homogenized=false) = @view pm_object(P).LATTICE_POINTS_GENERATORS[1][:, (homogenized ? 1 : 2):end]
 
@@ -646,7 +646,7 @@ function interior_lattice_points(P::Polyhedron{QQFieldElem})
     return SubObjectIterator{PointVector{ZZRingElem}}(P, _interior_lattice_point, size(pm_object(P).INTERIOR_LATTICE_POINTS, 1))
 end
 
-_interior_lattice_point(::Type{PointVector{ZZRingElem}}, P::Polyhedron, i::Base.Integer) = PointVector{ZZRingElem}(@view pm_object(P).INTERIOR_LATTICE_POINTS[i, 2:end])
+_interior_lattice_point(T::Type{PointVector{ZZRingElem}}, P::Polyhedron, i::Base.Integer) = point_vector(ZZ, @view pm_object(P).INTERIOR_LATTICE_POINTS[i, 2:end])::T
 
 _point_matrix(::Val{_interior_lattice_point}, P::Polyhedron; homogenized=false) = homogenized ? pm_object(P).INTERIOR_LATTICE_POINTS : @view pm_object(P).INTERIOR_LATTICE_POINTS[:, 2:end]
 
@@ -686,7 +686,7 @@ function boundary_lattice_points(P::Polyhedron{QQFieldElem})
     return SubObjectIterator{PointVector{ZZRingElem}}(P, _boundary_lattice_point, size(pm_object(P).BOUNDARY_LATTICE_POINTS, 1))
 end
 
-_boundary_lattice_point(::Type{PointVector{ZZRingElem}}, P::Polyhedron, i::Base.Integer) = PointVector{ZZRingElem}(@view pm_object(P).BOUNDARY_LATTICE_POINTS[i, 2:end])
+_boundary_lattice_point(T::Type{PointVector{ZZRingElem}}, P::Polyhedron, i::Base.Integer) = point_vector(ZZ, @view pm_object(P).BOUNDARY_LATTICE_POINTS[i, 2:end])::T
 
 _point_matrix(::Val{_boundary_lattice_point}, P::Polyhedron; homogenized=false) = homogenized ? pm_object(P).BOUNDARY_LATTICE_POINTS : @view pm_object(P).BOUNDARY_LATTICE_POINTS[:, 2:end]
 
@@ -1213,7 +1213,7 @@ julia> matrix(QQ, vertices(square))
 [ 1    1]
 ```
 """
-relative_interior_point(P::Polyhedron{T}) where T<:scalar_types = PointVector{T}(coefficient_field(P).(view(dehomogenize(Polymake.common.dense(pm_object(P).REL_INT_POINT)), :))) #view_broadcast
+relative_interior_point(P::Polyhedron{T}) where T<:scalar_types = point_vector(coefficient_field(P), view(dehomogenize(Polymake.common.dense(pm_object(P).REL_INT_POINT)), :))::PointVector{T} #view_broadcast
 
 
 @doc raw"""

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -35,9 +35,9 @@ function faces(P::Polyhedron{T}, face_dim::Int) where T<:scalar_types
     return SubObjectIterator{Polyhedron{T}}(P, _face_polyhedron, length(rfaces), (f_dim = n, f_ind = rfaces))
 end
 
-function _face_polyhedron(::Type{Polyhedron{T}}, P::Polyhedron, i::Base.Integer; f_dim::Int = -1, f_ind::Vector{Int64} = Vector{Int64}()) where T<:scalar_types
-    pface = Polymake.to_one_based_indexing(Polymake.polytope.faces_of_dim(pm_object(P), f_dim))[f_ind[i]]
-    return Polyhedron{T}(Polymake.polytope.Polytope{_scalar_type_to_polymake(T)}(VERTICES = pm_object(P).VERTICES[collect(pface),:], LINEALITY_SPACE = pm_object(P).LINEALITY_SPACE), coefficient_field(P))
+function _face_polyhedron(::Type{Polyhedron{T}}, P::Polyhedron{T}, i::Base.Integer; f_dim::Int = -1, f_ind::Vector{Int64} = Vector{Int64}()) where T<:scalar_types
+  pface = Polymake.to_one_based_indexing(Polymake.polytope.faces_of_dim(pm_object(P), f_dim))[f_ind[i]]
+  return Polyhedron{T}(Polymake.polytope.Polytope{_scalar_type_to_polymake(T)}(VERTICES = pm_object(P).VERTICES[collect(pface), :], LINEALITY_SPACE = pm_object(P).LINEALITY_SPACE), coefficient_field(P))
 end
 
 function _vertex_indices(::Val{_face_polyhedron}, P::Polyhedron; f_dim = -1, f_ind::Vector{Int64} = Vector{Int64}())
@@ -54,9 +54,9 @@ end
 
 _incidencematrix(::Val{_face_polyhedron}) = _vertex_and_ray_indices
 
-function _face_polyhedron_facet(::Type{Polyhedron{T}}, P::Polyhedron, i::Base.Integer) where T<:scalar_types
-    pface = pm_object(P).VERTICES_IN_FACETS[_facet_index(pm_object(P), i), :]
-    return Polyhedron{T}(Polymake.polytope.Polytope{_scalar_type_to_polymake(T)}(VERTICES = pm_object(P).VERTICES[collect(pface),:], LINEALITY_SPACE = pm_object(P).LINEALITY_SPACE), coefficient_field(P))
+function _face_polyhedron_facet(::Type{Polyhedron{T}}, P::Polyhedron{T}, i::Base.Integer) where T<:scalar_types
+  pface = pm_object(P).VERTICES_IN_FACETS[_facet_index(pm_object(P), i), :]
+  return Polyhedron{T}(Polymake.polytope.Polytope{_scalar_type_to_polymake(T)}(VERTICES = pm_object(P).VERTICES[collect(pface), :], LINEALITY_SPACE = pm_object(P).LINEALITY_SPACE), coefficient_field(P))
 end
 
 _vertex_indices(::Val{_face_polyhedron_facet}, P::Polyhedron) = vcat(pm_object(P).VERTICES_IN_FACETS[1:(_facet_at_infinity(pm_object(P)) - 1), _vertex_indices(pm_object(P))], pm_object(P).VERTICES_IN_FACETS[(_facet_at_infinity(pm_object(P)) + 1):end, _vertex_indices(pm_object(P))])
@@ -127,13 +127,13 @@ julia> minimal_faces(P)
 ```
 """
 minimal_faces(P::Polyhedron{T}) where T<:scalar_types = minimal_faces(NamedTuple{(:base_points, :lineality_basis), Tuple{SubObjectIterator{PointVector{T}}, SubObjectIterator{RayVector{T}}}}, P)
-function minimal_faces(as::Type{NamedTuple{(:base_points, :lineality_basis), Tuple{SubObjectIterator{PointVector{T}}, SubObjectIterator{RayVector{T}}}}}, P::Polyhedron{T}) where T<:scalar_types
-    return (
-        base_points = _vertices(PointVector{T}, P),
-        lineality_basis = lineality_space(P)
-    )
+function minimal_faces(::Type{NamedTuple{(:base_points, :lineality_basis), Tuple{SubObjectIterator{PointVector{T}}, SubObjectIterator{RayVector{T}}}}}, P::Polyhedron{T}) where T<:scalar_types
+  return (
+    base_points = _vertices(PointVector{T}, P),
+    lineality_basis = lineality_space(P)
+  )
 end
-minimal_faces(as::Type{PointVector{T}}, P::Polyhedron{T}) where T<:scalar_types = _vertices(PointVector{T}, P)
+minimal_faces(::Type{<:PointVector}, P::Polyhedron) = _vertices(P)
 
 
 
@@ -163,13 +163,13 @@ julia> rmlP.lineality_basis
 ```
 """
 rays_modulo_lineality(P::Polyhedron{T}) where T<:scalar_types = rays_modulo_lineality(NamedTuple{(:rays_modulo_lineality, :lineality_basis), Tuple{SubObjectIterator{RayVector{T}}, SubObjectIterator{RayVector{T}}}}, P)
-function rays_modulo_lineality(as::Type{NamedTuple{(:rays_modulo_lineality, :lineality_basis), Tuple{SubObjectIterator{RayVector{T}}, SubObjectIterator{RayVector{T}}}}}, P::Polyhedron) where T<:scalar_types
-    return (
-        rays_modulo_lineality = _rays(P),
-        lineality_basis = lineality_space(P)
-    )
+function rays_modulo_lineality(::Type{NamedTuple{(:rays_modulo_lineality, :lineality_basis), Tuple{SubObjectIterator{RayVector{T}}, SubObjectIterator{RayVector{T}}}}}, P::Polyhedron{T}) where T<:scalar_types
+  return (
+    rays_modulo_lineality = _rays(P),
+    lineality_basis = lineality_space(P)
+  )
 end
-rays_modulo_lineality(as::Type{RayVector}, P::Polyhedron) = _rays(P)
+rays_modulo_lineality(::Type{<:RayVector}, P::Polyhedron) = _rays(P)
 
 
 @doc raw"""
@@ -197,8 +197,8 @@ julia> vertices(PointVector, P)
  [1, 2]
 ```
 """
-vertices(as::Type{PointVector{T}}, P::Polyhedron) where T<:scalar_types = lineality_dim(P) == 0 ? _vertices(as, P) : _empty_subobjectiterator(as, P)
-_vertices(as::Type{PointVector{T}}, P::Polyhedron) where T<:scalar_types = SubObjectIterator{as}(P, _vertex_polyhedron, length(_vertex_indices(pm_object(P))))
+vertices(as::Type{PointVector{T}}, P::Polyhedron{T}) where T<:scalar_types = lineality_dim(P) == 0 ? _vertices(as, P) : _empty_subobjectiterator(as, P)
+_vertices(as::Type{PointVector{T}}, P::Polyhedron{T}) where T<:scalar_types = SubObjectIterator{as}(P, _vertex_polyhedron, length(_vertex_indices(pm_object(P))))
 
 _vertex_polyhedron(U::Type{PointVector{T}}, P::Polyhedron{T}, i::Base.Integer) where T<:scalar_types = point_vector(coefficient_field(P), @view pm_object(P).VERTICES[_vertex_indices(pm_object(P))[i], 2:end])::U
 
@@ -206,8 +206,8 @@ _point_matrix(::Val{_vertex_polyhedron}, P::Polyhedron; homogenized=false) = @vi
 
 _matrix_for_polymake(::Val{_vertex_polyhedron}) = _point_matrix
 
-vertices(::Type{PointVector}, P::Polyhedron{T}) where T<:scalar_types = vertices(PointVector{T}, P)
-_vertices(::Type{PointVector}, P::Polyhedron{T}) where T<:scalar_types = _vertices(PointVector{T}, P)
+vertices(::Type{<:PointVector}, P::Polyhedron{T}) where T<:scalar_types = vertices(PointVector{T}, P)
+_vertices(::Type{<:PointVector}, P::Polyhedron{T}) where T<:scalar_types = _vertices(PointVector{T}, P)
 
 _facet_indices(::Val{_vertex_polyhedron}, P::Polyhedron) = pm_object(P).FACETS_THRU_VERTICES[_vertex_indices(pm_object(P)),_facet_indices(pm_object(P))]
 
@@ -311,8 +311,8 @@ julia> rays(RayVector, PO)
  [0, 1]
 ```
 """
-rays(as::Type{RayVector{T}}, P::Polyhedron) where T<:scalar_types = lineality_dim(P) == 0 ? _rays(as, P) : _empty_subobjectiterator(as, P)
-_rays(as::Type{RayVector{T}}, P::Polyhedron) where T<:scalar_types = SubObjectIterator{as}(P, _ray_polyhedron, length(_ray_indices(pm_object(P))))
+rays(as::Type{RayVector{T}}, P::Polyhedron{T}) where T<:scalar_types = lineality_dim(P) == 0 ? _rays(as, P) : _empty_subobjectiterator(as, P)
+_rays(as::Type{RayVector{T}}, P::Polyhedron{T}) where T<:scalar_types = SubObjectIterator{as}(P, _ray_polyhedron, length(_ray_indices(pm_object(P))))
 
 _ray_polyhedron(U::Type{RayVector{T}}, P::Polyhedron{T}, i::Base.Integer) where T<:scalar_types = ray_vector(coefficient_field(P), @view pm_object(P).VERTICES[_ray_indices(pm_object(P))[i], 2:end])::U
 
@@ -324,8 +324,8 @@ _matrix_for_polymake(::Val{_ray_polyhedron}) = _vector_matrix
 
 _incidencematrix(::Val{_ray_polyhedron}) = _facet_indices
 
-rays(::Type{RayVector}, P::Polyhedron{T}) where T<:scalar_types = rays(RayVector{T}, P)
-_rays(::Type{RayVector}, P::Polyhedron{T}) where T<:scalar_types = _rays(RayVector{T}, P)
+rays(::Type{<:RayVector}, P::Polyhedron{T}) where T<:scalar_types = rays(RayVector{T}, P)
+_rays(::Type{<:RayVector}, P::Polyhedron{T}) where T<:scalar_types = _rays(RayVector{T}, P)
 
 @doc raw"""
     rays(P::Polyhedron)
@@ -410,17 +410,17 @@ x₃ ≦ 1
 """
 facets(as::Type{T}, P::Polyhedron{S}) where {R, S<:scalar_types, T<:Union{AffineHalfspace{S}, Pair{R, S}, Polyhedron{S}}} = SubObjectIterator{as}(P, _facet_polyhedron, nfacets(P))
 
-function _facet_polyhedron(::Type{AffineHalfspace{S}}, P::Polyhedron, i::Base.Integer) where S<:scalar_types
-    h = decompose_hdata(view(pm_object(P).FACETS, [_facet_index(pm_object(P), i)], :))
-    return affine_halfspace(coefficient_field(P), h[1], h[2][])
+function _facet_polyhedron(U::Type{AffineHalfspace{S}}, P::Polyhedron{S}, i::Base.Integer) where S<:scalar_types
+  h = decompose_hdata(view(pm_object(P).FACETS, [_facet_index(pm_object(P), i)], :))
+  return affine_halfspace(coefficient_field(P), h[1], h[2][])::U
 end
-function _facet_polyhedron(::Type{Pair{R, S}}, P::Polyhedron, i::Base.Integer) where {R, S<:scalar_types}
-    f = coefficient_field(P)
-    h = decompose_hdata(view(pm_object(P).FACETS, [_facet_index(pm_object(P), i)], :))
-    return Pair{R, S}(f.(view(h[1], :, :)), f(h[2][])) # view_broadcast
+function _facet_polyhedron(U::Type{Pair{R, S}}, P::Polyhedron{S}, i::Base.Integer) where {R, S<:scalar_types}
+  f = coefficient_field(P)
+  h = decompose_hdata(view(pm_object(P).FACETS, [_facet_index(pm_object(P), i)], :))
+  return U(f.(view(h[1], :, :)), f(h[2][])) # view_broadcast
 end
-function _facet_polyhedron(::Type{Polyhedron{T}}, P::Polyhedron, i::Base.Integer) where T<:scalar_types
-  return Polyhedron{T}(Polymake.polytope.facet(pm_object(P), _facet_index(pm_object(P), i)-1), coefficient_field(P))
+function _facet_polyhedron(::Type{Polyhedron{T}}, P::Polyhedron{T}, i::Base.Integer) where T<:scalar_types
+  return Polyhedron{T}(Polymake.polytope.facet(pm_object(P), _facet_index(pm_object(P), i) - 1), coefficient_field(P))
 end
 
 _affine_inequality_matrix(::Val{_facet_polyhedron}, P::Polyhedron) = -_remove_facet_at_infinity(pm_object(P))
@@ -435,7 +435,7 @@ _vertex_and_ray_indices(::Val{_facet_polyhedron}, P::Polyhedron) = vcat(pm_objec
 
 _incidencematrix(::Val{_facet_polyhedron}) = _vertex_and_ray_indices
 
-facets(::Type{Pair}, P::Polyhedron{T}) where T<:scalar_types = facets(Pair{Matrix{T}, T}, P)
+facets(::Type{<:Pair}, P::Polyhedron{T}) where T<:scalar_types = facets(Pair{Matrix{T}, T}, P)
 
 facets(::Type{Polyhedron}, P::Polyhedron{T}) where T<:scalar_types = facets(Polyhedron{T}, P)
 
@@ -461,9 +461,7 @@ x₃ ≦ 1
 """
 facets(P::Polyhedron{T}) where T<:scalar_types = facets(AffineHalfspace{T}, P)
 
-facets(::Type{Halfspace}, P::Polyhedron{T}) where T<:scalar_types = facets(AffineHalfspace{T}, P)
-
-facets(::Type{AffineHalfspace}, P::Polyhedron{T}) where T<:scalar_types = facets(AffineHalfspace{T}, P)
+facets(::Type{<:Halfspace}, P::Polyhedron{T}) where T<:scalar_types = facets(AffineHalfspace{T}, P)
 
 function _facet_index(P::Polymake.BigObject, i::Base.Integer)
     i < _facet_at_infinity(P) && return i
@@ -562,7 +560,7 @@ julia> normalized_volume(C)
 8
 ```
 """
-normalized_volume(P::Polyhedron{T}) where T<:scalar_types = coefficient_field(P)(factorial(dim(P))*(pm_object(P)).VOLUME)
+normalized_volume(P::Polyhedron) = coefficient_field(P)(factorial(dim(P))*(pm_object(P)).VOLUME)
 
 
 @doc raw"""
@@ -615,7 +613,7 @@ function lattice_points(P::Polyhedron{QQFieldElem})
     return SubObjectIterator{PointVector{ZZRingElem}}(P, _lattice_point, size(pm_object(P).LATTICE_POINTS_GENERATORS[1], 1))
 end
 
-_lattice_point(T::Type{PointVector{ZZRingElem}}, P::Polyhedron, i::Base.Integer) = point_vector(ZZ, @view pm_object(P).LATTICE_POINTS_GENERATORS[1][i, 2:end])::T
+_lattice_point(T::Type{PointVector{ZZRingElem}}, P::Polyhedron{QQFieldElem}, i::Base.Integer) = point_vector(ZZ, @view pm_object(P).LATTICE_POINTS_GENERATORS[1][i, 2:end])::T
 
 _point_matrix(::Val{_lattice_point}, P::Polyhedron; homogenized=false) = @view pm_object(P).LATTICE_POINTS_GENERATORS[1][:, (homogenized ? 1 : 2):end]
 
@@ -646,7 +644,7 @@ function interior_lattice_points(P::Polyhedron{QQFieldElem})
     return SubObjectIterator{PointVector{ZZRingElem}}(P, _interior_lattice_point, size(pm_object(P).INTERIOR_LATTICE_POINTS, 1))
 end
 
-_interior_lattice_point(T::Type{PointVector{ZZRingElem}}, P::Polyhedron, i::Base.Integer) = point_vector(ZZ, @view pm_object(P).INTERIOR_LATTICE_POINTS[i, 2:end])::T
+_interior_lattice_point(T::Type{PointVector{ZZRingElem}}, P::Polyhedron{QQFieldElem}, i::Base.Integer) = point_vector(ZZ, @view pm_object(P).INTERIOR_LATTICE_POINTS[i, 2:end])::T
 
 _point_matrix(::Val{_interior_lattice_point}, P::Polyhedron; homogenized=false) = homogenized ? pm_object(P).INTERIOR_LATTICE_POINTS : @view pm_object(P).INTERIOR_LATTICE_POINTS[:, 2:end]
 
@@ -686,7 +684,7 @@ function boundary_lattice_points(P::Polyhedron{QQFieldElem})
     return SubObjectIterator{PointVector{ZZRingElem}}(P, _boundary_lattice_point, size(pm_object(P).BOUNDARY_LATTICE_POINTS, 1))
 end
 
-_boundary_lattice_point(T::Type{PointVector{ZZRingElem}}, P::Polyhedron, i::Base.Integer) = point_vector(ZZ, @view pm_object(P).BOUNDARY_LATTICE_POINTS[i, 2:end])::T
+_boundary_lattice_point(T::Type{PointVector{ZZRingElem}}, P::Polyhedron{QQFieldElem}, i::Base.Integer) = point_vector(ZZ, @view pm_object(P).BOUNDARY_LATTICE_POINTS[i, 2:end])::T
 
 _point_matrix(::Val{_boundary_lattice_point}, P::Polyhedron; homogenized=false) = homogenized ? pm_object(P).BOUNDARY_LATTICE_POINTS : @view pm_object(P).BOUNDARY_LATTICE_POINTS[:, 2:end]
 
@@ -779,9 +777,9 @@ x₄ = 5
 """
 affine_hull(P::Polyhedron{T}) where T<:scalar_types = SubObjectIterator{AffineHyperplane{T}}(P, _affine_hull, size(pm_object(P).AFFINE_HULL, 1))
 
-function _affine_hull(::Type{AffineHyperplane{T}}, P::Polyhedron, i::Base.Integer) where T<:scalar_types
-    h = decompose_hdata(-view(pm_object(P).AFFINE_HULL, [i], :))
-    return affine_hyperplane(coefficient_field(P), h[1], h[2][])
+function _affine_hull(U::Type{AffineHyperplane{T}}, P::Polyhedron{T}, i::Base.Integer) where T<:scalar_types
+  h = decompose_hdata(-view(pm_object(P).AFFINE_HULL, [i], :))
+  return affine_hyperplane(coefficient_field(P), h[1], h[2][])::U
 end
 
 _affine_equation_matrix(::Val{_affine_hull}, P::Polyhedron) = pm_object(P).AFFINE_HULL

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -37,7 +37,10 @@ end
 
 function _face_polyhedron(::Type{Polyhedron{T}}, P::Polyhedron{T}, i::Base.Integer; f_dim::Int = -1, f_ind::Vector{Int64} = Vector{Int64}()) where T<:scalar_types
   pface = Polymake.to_one_based_indexing(Polymake.polytope.faces_of_dim(pm_object(P), f_dim))[f_ind[i]]
-  return Polyhedron{T}(Polymake.polytope.Polytope{_scalar_type_to_polymake(T)}(VERTICES = pm_object(P).VERTICES[collect(pface), :], LINEALITY_SPACE = pm_object(P).LINEALITY_SPACE), coefficient_field(P))
+  V = pm_object(P).VERTICES[collect(pface), :]
+  L = pm_object(P).LINEALITY_SPACE
+  PT = _scalar_type_to_polymake(T, eltype(V))
+  return Polyhedron{T}(Polymake.polytope.Polytope{PT}(VERTICES = V, LINEALITY_SPACE = L), coefficient_field(P))
 end
 
 function _vertex_indices(::Val{_face_polyhedron}, P::Polyhedron; f_dim = -1, f_ind::Vector{Int64} = Vector{Int64}())
@@ -56,7 +59,10 @@ _incidencematrix(::Val{_face_polyhedron}) = _vertex_and_ray_indices
 
 function _face_polyhedron_facet(::Type{Polyhedron{T}}, P::Polyhedron{T}, i::Base.Integer) where T<:scalar_types
   pface = pm_object(P).VERTICES_IN_FACETS[_facet_index(pm_object(P), i), :]
-  return Polyhedron{T}(Polymake.polytope.Polytope{_scalar_type_to_polymake(T)}(VERTICES = pm_object(P).VERTICES[collect(pface), :], LINEALITY_SPACE = pm_object(P).LINEALITY_SPACE), coefficient_field(P))
+  V = pm_object(P).VERTICES[collect(pface), :]
+  L = pm_object(P).LINEALITY_SPACE
+  PT = _scalar_type_to_polymake(T, eltype(V))
+  return Polyhedron{T}(Polymake.polytope.Polytope{PT}(VERTICES = V, LINEALITY_SPACE = L), coefficient_field(P))
 end
 
 _vertex_indices(::Val{_face_polyhedron_facet}, P::Polyhedron) = vcat(pm_object(P).VERTICES_IN_FACETS[1:(_facet_at_infinity(pm_object(P)) - 1), _vertex_indices(pm_object(P))], pm_object(P).VERTICES_IN_FACETS[(_facet_at_infinity(pm_object(P)) + 1):end, _vertex_indices(pm_object(P))])

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -314,7 +314,7 @@ julia> rays(RayVector, PO)
 rays(as::Type{RayVector{T}}, P::Polyhedron) where T<:scalar_types = lineality_dim(P) == 0 ? _rays(as, P) : _empty_subobjectiterator(as, P)
 _rays(as::Type{RayVector{T}}, P::Polyhedron) where T<:scalar_types = SubObjectIterator{as}(P, _ray_polyhedron, length(_ray_indices(pm_object(P))))
 
-_ray_polyhedron(::Type{RayVector{T}}, P::Polyhedron, i::Base.Integer) where T<:scalar_types = RayVector{T}(coefficient_field(P).(@view pm_object(P).VERTICES[_ray_indices(pm_object(P))[i], 2:end]))
+_ray_polyhedron(U::Type{RayVector{T}}, P::Polyhedron{T}, i::Base.Integer) where T<:scalar_types = ray_vector(coefficient_field(P), @view pm_object(P).VERTICES[_ray_indices(pm_object(P))[i], 2:end])::U
 
 _facet_indices(::Val{_ray_polyhedron}, P::Polyhedron) = pm_object(P).FACETS_THRU_RAYS[_ray_indices(pm_object(P)), _facet_indices(pm_object(P))]
 
@@ -753,7 +753,7 @@ julia> lineality_space(UH)
 """
 lineality_space(P::Polyhedron{T}) where T<:scalar_types = SubObjectIterator{RayVector{T}}(P, _lineality_polyhedron, lineality_dim(P))
 
-_lineality_polyhedron(::Type{RayVector{T}}, P::Polyhedron, i::Base.Integer) where T<:scalar_types = RayVector{T}(coefficient_field(P).(@view pm_object(P).LINEALITY_SPACE[i, 2:end]))
+_lineality_polyhedron(U::Type{RayVector{T}}, P::Polyhedron{T}, i::Base.Integer) where T<:scalar_types = ray_vector(coefficient_field(P), @view pm_object(P).LINEALITY_SPACE[i, 2:end])::U
 
 _generator_matrix(::Val{_lineality_polyhedron}, P::Polyhedron; homogenized=false) = homogenized ? pm_object(P).LINEALITY_SPACE : @view pm_object(P).LINEALITY_SPACE[:, 2:end]
 

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -1014,7 +1014,7 @@ julia> [1, -2] in PO
 false
 ```
 """
-Base.in(v::AbstractVector, P::Polyhedron) = Polymake.polytope.contains(pm_object(P), [1; v])::Bool
+Base.in(v::AbstractVector, P::Polyhedron) = Polymake.polytope.contains(pm_object(P), coefficient_field(P).([1; v]))::Bool
 
 
 @doc raw"""

--- a/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
+++ b/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
@@ -206,14 +206,14 @@ julia> normalized_volume(C)
 120
 ```
 """
-function cube(f::Union{Type{T},Field}, d::Int) where {T<:scalar_types}
+function cube(f::scalar_type_or_field, d::Int)
   parent_field, scalar_type = _determine_parent_and_scalar(f)
   return Polyhedron{scalar_type}(
     Polymake.polytope.cube{_scalar_type_to_polymake(scalar_type)}(d), parent_field
   )
 end
 cube(d::Int) = cube(QQFieldElem, d)
-function cube(f::Union{Type{T},Field}, d::Int, l, u) where {T<:scalar_types}
+function cube(f::scalar_type_or_field, d::Int, l, u)
   parent_field, scalar_type = _determine_parent_and_scalar(f, l, u)
   return Polyhedron{scalar_type}(
     Polymake.polytope.cube{_scalar_type_to_polymake(scalar_type)}(d, u, l), parent_field
@@ -622,14 +622,14 @@ julia> facets(t)
 x₁ + x₂ + x₃ + x₄ + x₅ + x₆ + x₇ ≦ 5
 ```
 """
-function simplex(f::Union{Type{T},Field}, d::Int, n) where {T<:scalar_types}
+function simplex(f::scalar_type_or_field, d::Int, n)
   parent_field, scalar_type = _determine_parent_and_scalar(f, n)
   return Polyhedron{scalar_type}(
     Polymake.polytope.simplex{_scalar_type_to_polymake(scalar_type)}(d, n), parent_field
   )
 end
 simplex(d::Int, n) = simplex(QQFieldElem, d, n)
-function simplex(f::Union{Type{T},Field}, d::Int) where {T<:scalar_types}
+function simplex(f::scalar_type_or_field, d::Int)
   parent_field, scalar_type = _determine_parent_and_scalar(f)
   return Polyhedron{scalar_type}(
     Polymake.polytope.simplex{_scalar_type_to_polymake(scalar_type)}(d), parent_field
@@ -678,14 +678,14 @@ x₁ - x₂ - x₃ ≦ 2
 -x₁ - x₂ - x₃ ≦ 2
 ```
 """
-function cross_polytope(f::Union{Type{T},Field}, d::Int64, n) where {T<:scalar_types}
+function cross_polytope(f::scalar_type_or_field, d::Int64, n)
   parent_field, scalar_type = _determine_parent_and_scalar(f, n)
   return Polyhedron{scalar_type}(
     Polymake.polytope.cross{_scalar_type_to_polymake(scalar_type)}(d, n), parent_field
   )
 end
 cross_polytope(d::Int64, n) = cross_polytope(QQFieldElem, d, n)
-function cross_polytope(f::Union{Type{T},Field}, d::Int64) where {T<:scalar_types}
+function cross_polytope(f::scalar_type_or_field, d::Int64)
   parent_field, scalar_type = _determine_parent_and_scalar(f)
   return Polyhedron{scalar_type}(
     Polymake.polytope.cross{_scalar_type_to_polymake(scalar_type)}(d), parent_field

--- a/src/PolyhedralGeometry/SubdivisionOfPoints/constructors.jl
+++ b/src/PolyhedralGeometry/SubdivisionOfPoints/constructors.jl
@@ -53,14 +53,14 @@ julia> MOAE = subdivision_of_points(moaepts, moaeimnonreg0)
 Subdivision of points in ambient dimension 3
 ```
 """
-function subdivision_of_points(f::Union{Type{T}, Field}, points::AbstractCollection[PointVector], cells::IncidenceMatrix) where T<:scalar_types
-   @req size(points)[1] == ncols(cells) "Number of points must be the same as columns of IncidenceMatrix"
-   parent_field, scalar_type = _determine_parent_and_scalar(f, points)
-   arr = @Polymake.convert_to Array{Set{Int}} Polymake.common.rows(cells)
-   SubdivisionOfPoints{scalar_type}(Polymake.fan.SubdivisionOfPoints{_scalar_type_to_polymake(scalar_type)}(
-      POINTS = homogenize(points,1),
-      MAXIMAL_CELLS = arr,
-   ), parent_field)
+function subdivision_of_points(f::scalar_type_or_field, points::AbstractCollection[PointVector], cells::IncidenceMatrix)
+  @req size(points)[1] == ncols(cells) "Number of points must be the same as columns of IncidenceMatrix"
+  parent_field, scalar_type = _determine_parent_and_scalar(f, points)
+  arr = @Polymake.convert_to Array{Set{Int}} Polymake.common.rows(cells)
+  SubdivisionOfPoints{scalar_type}(Polymake.fan.SubdivisionOfPoints{_scalar_type_to_polymake(scalar_type)}(
+    POINTS = homogenize(points,1),
+    MAXIMAL_CELLS = arr,
+  ), parent_field)
 end
 
 
@@ -91,13 +91,13 @@ julia> n_maximal_cells(SOP)
 1
 ```
 """
-function subdivision_of_points(f::Union{Type{T}, Field}, points::AbstractCollection[PointVector], weights::AbstractVector) where T<:scalar_types
-   @req size(points)[1] == length(weights) "Number of points must equal number of weights"
-   parent_field, scalar_type = _determine_parent_and_scalar(f, points, weights)
-   SubdivisionOfPoints{scalar_type}(Polymake.fan.SubdivisionOfPoints{_scalar_type_to_polymake(scalar_type)}(
-      POINTS = homogenize(points,1),
-      WEIGHTS = weights,
-   ), parent_field)
+function subdivision_of_points(f::scalar_type_or_field, points::AbstractCollection[PointVector], weights::AbstractVector)
+  @req size(points)[1] == length(weights) "Number of points must equal number of weights"
+  parent_field, scalar_type = _determine_parent_and_scalar(f, points, weights)
+  SubdivisionOfPoints{scalar_type}(Polymake.fan.SubdivisionOfPoints{_scalar_type_to_polymake(scalar_type)}(
+    POINTS = homogenize(points,1),
+    WEIGHTS = weights,
+  ), parent_field)
 end
 
 """
@@ -109,13 +109,13 @@ pm_object(SOP::SubdivisionOfPoints) = SOP.pm_subdivision
 
 
 #Same construction for when the user provides maximal cells
-function subdivision_of_points(::Union{Type{T}, Field}, points::AbstractCollection[PointVector], cells::Vector{Vector{Int64}}) where T<:scalar_types
-   subdivision_of_points(T, points, IncidenceMatrix(cells))
+function subdivision_of_points(f::scalar_type_or_field, points::AbstractCollection[PointVector], cells::Vector{Vector{Int64}})
+  subdivision_of_points(f, points, IncidenceMatrix(cells))
 end
 
 #Same construction for when the user gives Matrix{Bool} as incidence matrix
-function subdivision_of_points(::Union{Type{T}, Field}, Points::Union{Oscar.MatElem,AbstractMatrix}, cells::Matrix{Bool}) where T<:scalar_types
-   subdivision_of_points(T, points, IncidenceMatrix(Polymake.IncidenceMatrix(cells)))
+function subdivision_of_points(f::scalar_type_or_field, Points::Union{Oscar.MatElem,AbstractMatrix}, cells::Matrix{Bool})
+  subdivision_of_points(f, points, IncidenceMatrix(Polymake.IncidenceMatrix(cells)))
 end
 
 ###############################################################################

--- a/src/PolyhedralGeometry/SubdivisionOfPoints/properties.jl
+++ b/src/PolyhedralGeometry/SubdivisionOfPoints/properties.jl
@@ -33,7 +33,7 @@ function points(SOP::SubdivisionOfPoints)
     return SubObjectIterator{PointVector{QQFieldElem}}(SOP, _point, size(pm_object(SOP).POINTS, 1))
 end
 
-_point(::Type{PointVector{QQFieldElem}}, SOP::SubdivisionOfPoints, i::Base.Integer) = PointVector{QQFieldElem}(pm_object(SOP).POINTS[i, 2:end])
+_point(T::Type{PointVector{QQFieldElem}}, SOP::SubdivisionOfPoints, i::Base.Integer) = point_vector(QQ, pm_object(SOP).POINTS[i, 2:end])::T
 
 _point_matrix(::Val{_point}, SOP::SubdivisionOfPoints; homogenized=false) = pm_object(SOP).POINTS[:, (homogenized ? 1 : 2):end]
 

--- a/src/PolyhedralGeometry/SubdivisionOfPoints/properties.jl
+++ b/src/PolyhedralGeometry/SubdivisionOfPoints/properties.jl
@@ -29,11 +29,11 @@ julia> points(MOAE)
  [1, 1, 2]
 ```
 """
-function points(SOP::SubdivisionOfPoints)
-    return SubObjectIterator{PointVector{QQFieldElem}}(SOP, _point, size(pm_object(SOP).POINTS, 1))
+function points(SOP::SubdivisionOfPoints{T}) where T<:scalar_types
+  return SubObjectIterator{PointVector{T}}(SOP, _point, size(pm_object(SOP).POINTS, 1))
 end
 
-_point(T::Type{PointVector{QQFieldElem}}, SOP::SubdivisionOfPoints, i::Base.Integer) = point_vector(QQ, pm_object(SOP).POINTS[i, 2:end])::T
+_point(U::Type{PointVector{T}}, SOP::SubdivisionOfPoints{T}, i::Base.Integer) where T<:scalar_types = point_vector(coefficient_field(SOP), pm_object(SOP).POINTS[i, 2:end])::U
 
 _point_matrix(::Val{_point}, SOP::SubdivisionOfPoints; homogenized=false) = pm_object(SOP).POINTS[:, (homogenized ? 1 : 2):end]
 
@@ -185,7 +185,7 @@ julia> min_weights(SOP)
  0
 ```
 """
-min_weights(SOP::SubdivisionOfPoints{T}) where T<:scalar_types = Vector{Int}(pm_object(SOP).MIN_WEIGHTS)
+min_weights(SOP::SubdivisionOfPoints) = Vector{Int}(pm_object(SOP).MIN_WEIGHTS)
 
 
 @doc raw"""

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -386,6 +386,8 @@ const scalar_type_to_oscar = Dict{String, Type}([("Rational", QQFieldElem),
 
 const scalar_types_extended = Union{scalar_types, ZZRingElem}
 
+const scalar_type_or_field = Union{Type{<:scalar_types}, Field}
+
 _scalar_type_to_polymake(::Type{QQFieldElem}) = Polymake.Rational
 _scalar_type_to_polymake(::Type{<:FieldElem}) = Polymake.OscarNumber
 _scalar_type_to_polymake(::Type{Float64}) = Float64

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -392,6 +392,10 @@ _scalar_type_to_polymake(::Type{QQFieldElem}) = Polymake.Rational
 _scalar_type_to_polymake(::Type{<:FieldElem}) = Polymake.OscarNumber
 _scalar_type_to_polymake(::Type{Float64}) = Float64
 
+_scalar_type_to_polymake(::Type{EmbeddedElem{nf_elem}}, ::Type{Polymake.OscarNumber}) = Polymake.OscarNumber
+_scalar_type_to_polymake(::Type{EmbeddedElem{nf_elem}}, ::Type{<:Polymake.QuadraticExtension}) = Polymake.QuadraticExtension{Polymake.Rational}
+_scalar_type_to_polymake(::Type{T}, ::Type{U}) where {T<:scalar_types, U} = _scalar_type_to_polymake(T)
+
 ####################################################################
 # Parent Fields
 ####################################################################

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -485,7 +485,7 @@ function _detect_default_field(::Type{T}, p::Polymake.BigObject) where T<:FieldE
   propnames = intersect(Polymake.list_properties(p), ["INPUT_RAYS", "POINTS", "RAYS", "VERTICES", "VECTORS", "INPUT_LINEALITY", "LINEALITY_SPACE", "FACETS", "INEQUALITIES", "EQUATIONS", "LINEAR_SPAN", "AFFINE_HULL"])
   # find first OscarNumber wrapping a FieldElem
   for pn in propnames
-    prop = getproperty(p, pn)
+    prop = getproperty(p, convert(String, pn))
     for el in prop
       on = Polymake.unwrap(el)
       if on isa T
@@ -501,7 +501,7 @@ function _detect_wrapped_type_and_field(p::Polymake.BigObject)
   propnames = intersect(Polymake.list_properties(p), ["INPUT_RAYS", "POINTS", "RAYS", "VERTICES", "VECTORS", "INPUT_LINEALITY", "LINEALITY_SPACE", "FACETS", "INEQUALITIES", "EQUATIONS", "LINEAR_SPAN", "AFFINE_HULL"])
   # find first OscarNumber wrapping a FieldElem
   for pn in propnames
-    prop = getproperty(p, pn)
+    prop = getproperty(p, convert(String, pn))
     for el in prop
       on = Polymake.unwrap(el)
       if on isa FieldElem

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -392,10 +392,6 @@ _scalar_type_to_polymake(::Type{QQFieldElem}) = Polymake.Rational
 _scalar_type_to_polymake(::Type{<:FieldElem}) = Polymake.OscarNumber
 _scalar_type_to_polymake(::Type{Float64}) = Float64
 
-_scalar_type_to_polymake(::Type{EmbeddedElem{nf_elem}}, ::Type{Polymake.OscarNumber}) = Polymake.OscarNumber
-_scalar_type_to_polymake(::Type{EmbeddedElem{nf_elem}}, ::Type{<:Polymake.QuadraticExtension}) = Polymake.QuadraticExtension{Polymake.Rational}
-_scalar_type_to_polymake(::Type{T}, ::Type{U}) where {T<:scalar_types, U} = _scalar_type_to_polymake(T)
-
 ####################################################################
 # Parent Fields
 ####################################################################

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -521,6 +521,8 @@ end
 
 _parent_or_coefficient_field(r::Base.RefValue{<:Union{FieldElem, ZZRingElem}}) = parent(r.x)
 
+_parent_or_coefficient_field(v::AbstractVector{T}) where T<:Union{FieldElem, ZZRingElem} = _determine_parent_and_scalar(T, v)[1]
+
 function _promoted_bigobject(::Type{T}, obj::PolyhedralObject{U}) where {T <: scalar_types, U <: scalar_types}
   T == U ? pm_object(obj) : Polymake.common.convert_to{_scalar_type_to_polymake(T)}(pm_object(obj))
 end

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -540,3 +540,28 @@ end
 function Polymake._fieldelem_is_rational(e::Hecke.EmbeddedNumFieldElem)
    return is_rational(e)
 end
+
+# convert a Polymake.BigObject's scalar from QuadraticExtension to OscarNumber (Polytope only)
+
+function _polyhedron_qe_to_on(x::Polymake.BigObject, f::Field)
+  res = Polymake.polytope.Polytope{Polymake.OscarNumber}()
+  for pn in Polymake.list_properties(x)
+    prop = Polymake.give(x, pn)
+    Polymake.take(res, string(pn), _property_qe_to_on(prop, f))
+  end
+  return res
+end
+
+_property_qe_to_on(x::Polymake.BigObject, f::Field) = Polymake.BigObject(Polymake.bigobject_type(x), x)
+
+_property_qe_to_on(x::Polymake.PropertyValue, f::Field) = x
+
+_property_qe_to_on(x::Polymake.QuadraticExtension{Polymake.Rational}, f::Field) = f(x)
+
+function _property_qe_to_on(x, f::Field)
+  if hasmethod(length, (typeof(x),)) && eltype(x) <: Polymake.QuadraticExtension{Polymake.Rational}
+    return f.(x)
+  else
+    return x
+  end
+end

--- a/src/PolyhedralGeometry/iterators.jl
+++ b/src/PolyhedralGeometry/iterators.jl
@@ -352,8 +352,7 @@ for f in ("_point_matrix", "_vector_matrix", "_generator_matrix")
     M = Symbol(f)
     @eval begin
         function $M(::Val{_empty_access}, P::PolyhedralObjectUnion; homogenized=false)
-            scalar_regexp = match(r"[^<]*<(.*)>[^>]*", String(Polymake.type_name(pm_object(P))))
-            typename = scalar_regexp[1]
+            typename = Polymake.bigobject_eltype(pm_object(P))
             T = typename == "OscarNumber" ? Polymake.OscarNumber : _scalar_type_to_polymake(scalar_type_to_oscar[typename])
             return Polymake.Matrix{T}(undef, 0, Polymake.polytope.ambient_dim(pm_object(P)) + homogenized)
         end

--- a/src/PolyhedralGeometry/iterators.jl
+++ b/src/PolyhedralGeometry/iterators.jl
@@ -63,6 +63,22 @@ for (T, _t) in ((:PointVector, :point_vector), (:RayVector, :ray_vector))
   end
 end
 
+@doc """
+    point_vector(p = QQ, v::AbstractVector)
+
+Return a `PointVector` resembling a point whose coordinates equal the entries of `v`.
+`p` specifies the `Field` or `Type` of its coefficient.
+"""
+point_vector
+
+@doc """
+    ray_vector(p = QQ, v::AbstractVector)
+
+Return a `RayVector` resembling a ray from the origin through the point whose coordinates equal the entries of `v`.
+`p` specifies the `Field` or `Type` of its coefficient.
+"""
+ray_vector
+
 ################################################################################
 ######## Halfspaces and Hyperplanes
 ################################################################################
@@ -94,9 +110,9 @@ for (h, comp) in (("alfspace", "≤"), ("yperplane", "="))
     invert(H::$Haff{T}) where T<:scalar_types = $Haff{T}(-H.a, -negbias(H))
 
     @doc """
-    """ * string($Faff) * """([p,] a, b)
+    """ * string($Faff) * """(p = QQ, a, b)
 
-Return the """ * string($Haff) * raw""" `H(a,b)`, which is given by a vector `a` and a value `b` such that
+Return the `""" * string($Haff) * raw"""` `H(a,b)`, which is given by a vector `a` and a value `b` such that
 $$H(a,b) = \{ x | ax """ * $comp * raw""" b \}.$$
 `p` specifies the `Field` or `Type` of its coefficient.
     """
@@ -123,9 +139,9 @@ $$H(a,b) = \{ x | ax """ * $comp * raw""" b \}.$$
     invert(H::$Hlin{T}) where T<:scalar_types = $Hlin{T}(-H.a)
 
     @doc """
-    """ * string($Flin) * """([p,] a, b)
+    """ * string($Flin) * """(p = QQ, a, b)
 
-Return the """ * string($Hlin) * raw""" `H(a,b)`, which is given by a vector `a` such that
+Return the `""" * string($Hlin) * raw"""` `H(a,b)`, which is given by a vector `a` such that
 $$H(a,b) = \{ x | ax """ * $comp * raw""" 0 \}.$$
 `p` specifies the `Field` or `Type` of its coefficient.
     """

--- a/src/PolyhedralGeometry/iterators.jl
+++ b/src/PolyhedralGeometry/iterators.jl
@@ -57,7 +57,7 @@ for (T, _t) in ((:PointVector, :point_vector), (:RayVector, :ray_vector))
 
     Base.:*(k::scalar_types_extended, po::$T) = k .* po
 
-    Base.:*(A::MatElem, v::$T) = A * v.p
+    Base.:*(A::MatElem, v::$T) = A * transpose(v.p)
     
   end
 end

--- a/src/PolyhedralGeometry/iterators.jl
+++ b/src/PolyhedralGeometry/iterators.jl
@@ -353,7 +353,7 @@ for f in ("_point_matrix", "_vector_matrix", "_generator_matrix")
         function $M(::Val{_empty_access}, P::PolyhedralObjectUnion; homogenized=false)
             scalar_regexp = match(r"[^<]*<(.*)>[^>]*", String(Polymake.type_name(pm_object(P))))
             typename = scalar_regexp[1]
-            T = _scalar_type_to_polymake(scalar_type_to_oscar[typename])
+            T = typename == "OscarNumber" ? Polymake.OscarNumber : _scalar_type_to_polymake(scalar_type_to_oscar[typename])
             return Polymake.Matrix{T}(undef, 0, Polymake.polytope.ambient_dim(pm_object(P)) + homogenized)
         end
     end

--- a/src/PolyhedralGeometry/iterators.jl
+++ b/src/PolyhedralGeometry/iterators.jl
@@ -165,14 +165,26 @@ normal_vector(H::Union{Halfspace, Hyperplane}) = [H.a[1, i] for i in 1:length(H.
 
 _ambient_dim(x::Union{Halfspace, Hyperplane}) = length(x.a)
 
-# TODO: abstract notion of equality
-Base.:(==)(x::AffineHalfspace, y::AffineHalfspace) = x.a == y.a && x.b == y.b
+function Base.:(==)(x::Halfspace, y::Halfspace)
+  ax = normal_vector(x)
+  ay = normal_vector(y)
+  ix = findfirst(a -> !iszero(a), ax)
+  iy = findfirst(a -> !iszero(a), ay)
+  ix == iy || return false
+  r = y.a[iy]//x.a[ix]
+  r > 0 || return false
+  return (r .* ax == ay) && (r * negbias(x) == negbias(y))
+end
 
-Base.:(==)(x::LinearHalfspace, y::LinearHalfspace) = x.a == y.a
-
-Base.:(==)(x::AffineHyperplane, y::AffineHyperplane) = x.a == y.a && x.b == y.b
-
-Base.:(==)(x::LinearHyperplane, y::LinearHyperplane) = x.a == y.a
+function Base.:(==)(x::Hyperplane, y::Hyperplane)
+  ax = normal_vector(x)
+  ay = normal_vector(y)
+  ix = findfirst(a -> !iszero(a), ax)
+  iy = findfirst(a -> !iszero(a), ay)
+  ix == iy || return false
+  r = y.a[iy]//x.a[ix]
+  return (r .* ax == ay) && (r * negbias(x) == negbias(y))
+end
 
 Base.hash(x::T, h::UInt) where {T<:Union{AffineHalfspace,AffineHyperplane}} =
   hash((x.a, x.b), hash(T, h))

--- a/src/PolyhedralGeometry/iterators.jl
+++ b/src/PolyhedralGeometry/iterators.jl
@@ -13,7 +13,6 @@ for (T, _t) in ((:PointVector, :point_vector), (:RayVector, :ray_vector))
     end
 
     Base.IndexStyle(::Type{<:$T}) = IndexLinear()
-
     Base.getindex(po::$T, i::Base.Integer) = po.p[1, i]
 
     function Base.setindex!(po::$T, val, i::Base.Integer)
@@ -67,7 +66,7 @@ end
     point_vector(p = QQ, v::AbstractVector)
 
 Return a `PointVector` resembling a point whose coordinates equal the entries of `v`.
-`p` specifies the `Field` or `Type` of its coefficient.
+`p` specifies the `Field` or `Type` of its coefficients.
 """
 point_vector
 
@@ -75,7 +74,7 @@ point_vector
     ray_vector(p = QQ, v::AbstractVector)
 
 Return a `RayVector` resembling a ray from the origin through the point whose coordinates equal the entries of `v`.
-`p` specifies the `Field` or `Type` of its coefficient.
+`p` specifies the `Field` or `Type` of its coefficients.
 """
 ray_vector
 
@@ -110,11 +109,11 @@ for (h, comp) in (("alfspace", "≤"), ("yperplane", "="))
     invert(H::$Haff{T}) where T<:scalar_types = $Haff{T}(-H.a, -negbias(H))
 
     @doc """
-    """ * string($Faff) * """(p = QQ, a, b)
+    $($Faff)(p = QQ, a, b)
 
-Return the `""" * string($Haff) * raw"""` `H(a,b)`, which is given by a vector `a` and a value `b` such that
-$$H(a,b) = \{ x | ax """ * $comp * raw""" b \}.$$
-`p` specifies the `Field` or `Type` of its coefficient.
+Return the `$($Haff)` `H(a,b)`, which is given by a vector `a` and a value `b` such that
+\$\$H(a,b) = \\{ x | ax $($comp) b \\}.\$\$
+`p` specifies the `Field` or `Type` of its coefficients.
     """
     function $Faff(f::scalar_type_or_field, a::Union{MatElem, AbstractMatrix, AbstractVector}, b = 0)
       parent_field, scalar_type = _determine_parent_and_scalar(f, a, b)
@@ -139,11 +138,11 @@ $$H(a,b) = \{ x | ax """ * $comp * raw""" b \}.$$
     invert(H::$Hlin{T}) where T<:scalar_types = $Hlin{T}(-H.a)
 
     @doc """
-    """ * string($Flin) * """(p = QQ, a, b)
+    $($Flin)(p = QQ, a, b)
 
-Return the `""" * string($Hlin) * raw"""` `H(a,b)`, which is given by a vector `a` such that
-$$H(a,b) = \{ x | ax """ * $comp * raw""" 0 \}.$$
-`p` specifies the `Field` or `Type` of its coefficient.
+Return the `$($Hlin)` `H(a)`, which is given by a vector `a` such that
+\$\$H(a,b) = \\{ x | ax $($comp) 0 \\}.\$\$
+`p` specifies the `Field` or `Type` of its coefficients.
     """
     function $Flin(f::scalar_type_or_field, a::Union{MatElem, AbstractMatrix, AbstractVector})
       parent_field, scalar_type = _determine_parent_and_scalar(f, a)

--- a/src/PolyhedralGeometry/iterators.jl
+++ b/src/PolyhedralGeometry/iterators.jl
@@ -115,13 +115,13 @@ struct AffineHalfspace{T} <: Halfspace{T}
 end
 
 halfspace(a::Union{MatElem, AbstractMatrix, AbstractVector}, b) = affine_halfspace(a, b)
-halfspace(f::Union{Type{T}, Field}, a::Union{MatElem, AbstractMatrix, AbstractVector}, b) where T<:scalar_types = affine_halfspace(f, a, b)
+halfspace(f::scalar_type_or_field, a::Union{MatElem, AbstractMatrix, AbstractVector}, b) = affine_halfspace(f, a, b)
 
 invert(H::AffineHalfspace{T}) where T<:scalar_types = AffineHalfspace{T}(coefficient_field(H), -normal_vector(H), -negbias(H))
 
-function affine_halfspace(f::Union{Type{T}, Field}, a::Union{MatElem, AbstractMatrix, AbstractVector}, b = 0) where T<:scalar_types
-    parent_field, scalar_type = _determine_parent_and_scalar(f, a, b)
-    return AffineHalfspace{scalar_type}(parent_field, a, b)
+function affine_halfspace(f::scalar_type_or_field, a::Union{MatElem, AbstractMatrix, AbstractVector}, b = 0)
+  parent_field, scalar_type = _determine_parent_and_scalar(f, a, b)
+  return AffineHalfspace{scalar_type}(parent_field, a, b)
 end
 
 affine_halfspace(a::Union{MatElem, AbstractMatrix, AbstractVector}, b = 0) = affine_halfspace(QQ, a, b)
@@ -136,13 +136,13 @@ struct LinearHalfspace{T} <: Halfspace{T}
 end
 
 halfspace(a::Union{MatElem, AbstractMatrix, AbstractVector}) = linear_halfspace(a)
-halfspace(f::Union{Type{T}, Field}, a::Union{MatElem, AbstractMatrix, AbstractVector}) where T<:scalar_types = linear_halfspace(f, a)
+halfspace(f::scalar_type_or_field, a::Union{MatElem, AbstractMatrix, AbstractVector}) = linear_halfspace(f, a)
 
 invert(H::LinearHalfspace{T}) where T<:scalar_types = LinearHalfspace{T}(coefficient_field(H), -normal_vector(H))
 
-function linear_halfspace(f::Union{Type{T}, Field}, a::Union{MatElem, AbstractMatrix, AbstractVector}) where T<:scalar_types
-    parent_field, scalar_type = _determine_parent_and_scalar(f, a)
-    return LinearHalfspace{scalar_type}(parent_field, a)
+function linear_halfspace(f::scalar_type_or_field, a::Union{MatElem, AbstractMatrix, AbstractVector})
+  parent_field, scalar_type = _determine_parent_and_scalar(f, a)
+  return LinearHalfspace{scalar_type}(parent_field, a)
 end
 
 linear_halfspace(a::Union{MatElem, AbstractMatrix, AbstractVector}) = linear_halfspace(QQ, a)
@@ -170,11 +170,11 @@ struct AffineHyperplane{T} <: Hyperplane{T}
 end
 
 hyperplane(a::Union{MatElem, AbstractMatrix, AbstractVector}, b) = affine_hyperplane(a, b)
-hyperplane(f::Union{Type{T}, Field}, a::Union{MatElem, AbstractMatrix, AbstractVector}, b) where T<:scalar_types = affine_hyperplane(f, a, b)
+hyperplane(f::scalar_type_or_field, a::Union{MatElem, AbstractMatrix, AbstractVector}, b) = affine_hyperplane(f, a, b)
 
-function affine_hyperplane(f::Union{Type{T}, Field}, a::Union{MatElem, AbstractMatrix, AbstractVector}, b = 0) where T<:scalar_types
-    parent_field, scalar_type = _determine_parent_and_scalar(f, a, b)
-    return AffineHyperplane{scalar_type}(parent_field, a, b)
+function affine_hyperplane(f::scalar_type_or_field, a::Union{MatElem, AbstractMatrix, AbstractVector}, b = 0)
+  parent_field, scalar_type = _determine_parent_and_scalar(f, a, b)
+  return AffineHyperplane{scalar_type}(parent_field, a, b)
 end
 
 affine_hyperplane(a::Union{MatElem, AbstractMatrix, AbstractVector}, b = 0) = affine_hyperplane(QQ, a, b)
@@ -189,11 +189,11 @@ struct LinearHyperplane{T} <: Hyperplane{T}
 end
 
 hyperplane(a::Union{MatElem, AbstractMatrix, AbstractVector}) = linear_hyperplane(a)
-hyperplane(f::Union{Type{T}, Field}, a::Union{MatElem, AbstractMatrix, AbstractVector}) where T<:scalar_types = linear_hyperplane(f, a)
+hyperplane(f::scalar_type_or_field, a::Union{MatElem, AbstractMatrix, AbstractVector}) = linear_hyperplane(f, a)
 
-function linear_hyperplane(f::Union{Type{T}, Field}, a::Union{MatElem, AbstractMatrix, AbstractVector}) where T<:scalar_types
-    parent_field, scalar_type = _determine_parent_and_scalar(f, a)
-    return LinearHyperplane{scalar_type}(parent_field, a)
+function linear_hyperplane(f::scalar_type_or_field, a::Union{MatElem, AbstractMatrix, AbstractVector})
+  parent_field, scalar_type = _determine_parent_and_scalar(f, a)
+  return LinearHyperplane{scalar_type}(parent_field, a)
 end
 
 linear_hyperplane(a::Union{MatElem, AbstractMatrix, AbstractVector}) = linear_hyperplane(QQ, a)

--- a/src/PolyhedralGeometry/iterators.jl
+++ b/src/PolyhedralGeometry/iterators.jl
@@ -82,14 +82,15 @@ ray_vector
 ######## Halfspaces and Hyperplanes
 ################################################################################
 
-for (h, comp) in (("alfspace", "≤"), ("yperplane", "="))
+for (h, comp) in (("halfspace", "≤"), ("hyperplane", "="))
 
-  Habs = Symbol("H", h)
-  Haff = Symbol("AffineH", h)
-  Hlin = Symbol("LinearH", h)
-  Fabs = Symbol("h", h)
-  Faff = Symbol("affine_h", h)
-  Flin = Symbol("linear_h", h)
+  H = uppercasefirst(h)
+  Habs = Symbol(H)
+  Haff = Symbol("Affine", H)
+  Hlin = Symbol("Linear", H)
+  Fabs = Symbol(h)
+  Faff = Symbol("affine_", h)
+  Flin = Symbol("linear_", h)
 
   @eval begin
 

--- a/src/PolyhedralGeometry/linear_program.jl
+++ b/src/PolyhedralGeometry/linear_program.jl
@@ -153,7 +153,7 @@ function optimal_vertex(lp::LinearProgram{T}) where {T<:scalar_types}
     opt_vert = lp.polymake_lp.MINIMAL_VERTEX
   end
   if !isnothing(opt_vert)
-    return PointVector{T}(coefficient_field(lp), view(dehomogenize(opt_vert), :))
+    return point_vector(coefficient_field(lp), view(dehomogenize(opt_vert), :))::PointVector{T}
   else
     return nothing
   end

--- a/src/PolyhedralGeometry/linear_program.jl
+++ b/src/PolyhedralGeometry/linear_program.jl
@@ -44,13 +44,13 @@ function linear_program(
 end
 
 linear_program(
-  f::Union{Type{T},Field},
+  f::scalar_type_or_field,
   A::AbstractCollection[AffineHalfspace],
   b,
   c::AbstractVector;
   k=0,
   convention=:max,
-) where {T<:scalar_types} =
+) =
   linear_program(polyhedron(f, A, b), c; k=k, convention=convention)
 
 pm_object(lp::LinearProgram) = lp.polymake_lp

--- a/src/PolyhedralGeometry/mixed_integer_linear_program.jl
+++ b/src/PolyhedralGeometry/mixed_integer_linear_program.jl
@@ -176,7 +176,7 @@ function optimal_solution(milp::MixedIntegerLinearProgram{T}) where {T<:scalar_t
     opt_vert = milp.polymake_milp.MINIMAL_SOLUTION
   end
   if !isnothing(opt_vert)
-    return PointVector{T}(dehomogenize(opt_vert))
+    return point_vector(coefficient_field(milp), dehomogenize(opt_vert))::PointVector{T}
   else
     return nothing
   end

--- a/src/PolyhedralGeometry/solving_integrally.jl
+++ b/src/PolyhedralGeometry/solving_integrally.jl
@@ -57,7 +57,7 @@ SubObjectIterator{PointVector{ZZRingElem}}
 julia> for x in it
        print(A*x," ")
        end
-ZZRingElem[7] ZZRingElem[7] ZZRingElem[7] ZZRingElem[7] ZZRingElem[7] ZZRingElem[7] ZZRingElem[7] ZZRingElem[7] 
+[7] [7] [7] [7] [7] [7] [7] [7] 
 ```
 """
 solve_mixed(as::Type{T}, A::ZZMatrix, b::ZZMatrix, C::ZZMatrix, d::ZZMatrix) where {T} = solve_mixed(T, A, b, C, d)
@@ -106,7 +106,7 @@ SubObjectIterator{PointVector{ZZRingElem}}
 julia> for x in it
        print(A*x," ")
        end
-ZZRingElem[3] ZZRingElem[3] ZZRingElem[3] ZZRingElem[3] 
+[3] [3] [3] [3] 
 ```
 """
 solve_mixed(as::Type{T}, A::ZZMatrix, b::ZZMatrix, C::ZZMatrix) where {T} = solve_mixed(T, A, b, C, zero_matrix(FlintZZ, nrows(C), 1))

--- a/src/PolyhedralGeometry/type_functions.jl
+++ b/src/PolyhedralGeometry/type_functions.jl
@@ -6,7 +6,7 @@
 function detect_scalar_type(n::Type{T}, p::Polymake.BigObject) where T<:Union{Polyhedron, Cone, PolyhedralFan, SubdivisionOfPoints, PolyhedralComplex}
     scalar_regexp = match(r"[^<]*<(.*)>[^>]*", String(Polymake.type_name(p)))
     typename = scalar_regexp[1]
-    return scalar_type_to_oscar[typename]
+    return typename == "OscarNumber" ? nothing : scalar_type_to_oscar[typename]
 end
 
 scalar_type(::Union{Polyhedron{T}, Cone{T}, Hyperplane{T}, Halfspace{T}}) where T<:scalar_types = T

--- a/src/PolyhedralGeometry/type_functions.jl
+++ b/src/PolyhedralGeometry/type_functions.jl
@@ -28,13 +28,13 @@ end
 
 
 function halfspace_matrix_pair(iter::SubObjectIterator{<:Union{Halfspace{T}, Hyperplane{T}, Polyhedron{T}, Cone{T}, Pair{Matrix{T}, T}}}) where T<:scalar_types
-    try
-        f = coefficient_field(iter.Obj)
-        h = affine_matrix_for_polymake(iter)
-        return (A = matrix(f, h[:, 2:end]), b = Vector{T}(f.(-h[:, 1])))
-    catch e
-        throw(ArgumentError("Halfspace-Matrix-Pair not defined in this context."))
-    end
+  try
+    f = coefficient_field(iter.Obj)
+    h = affine_matrix_for_polymake(iter)
+    return (A = matrix(f, h[:, 2:end]), b = [f(x) for x in -h[:, 1]])
+  catch e
+    throw(ArgumentError("Halfspace-Matrix-Pair not defined in this context."))
+  end
 end
 
 for fun in (

--- a/src/PolyhedralGeometry/type_functions.jl
+++ b/src/PolyhedralGeometry/type_functions.jl
@@ -4,8 +4,7 @@
 
 
 function detect_scalar_type(n::Type{T}, p::Polymake.BigObject) where T<:Union{Polyhedron, Cone, PolyhedralFan, SubdivisionOfPoints, PolyhedralComplex}
-    scalar_regexp = match(r"[^<]*<(.*)>[^>]*", String(Polymake.type_name(p)))
-    typename = scalar_regexp[1]
+    typename = Polymake.bigobject_eltype(p)
     return typename == "OscarNumber" ? nothing : scalar_type_to_oscar[typename]
 end
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1196,6 +1196,7 @@ export rational_equivalence_class
 export rational_solutions
 export rational_to_continued_fraction_hirzebruch_jung
 export ray_indices
+export ray_vector
 export rays
 export rays_modulo_lineality
 export real_projective_plane

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1120,6 +1120,7 @@ export pitman_stanley_polytope
 export platonic_solid
 export point_coordinates
 export point_matrix
+export point_vector
 export points
 export pol_elementary_divisors
 export polarize

--- a/test/PolyhedralGeometry/cone.jl
+++ b/test/PolyhedralGeometry/cone.jl
@@ -4,7 +4,7 @@ NF, sr2 = quadratic_field(2)
 Qx, x = QQ["x"]
 K, (a1, a2) = embedded_number_field([x^2 - 2, x^3 - 5], [(0, 2), (0, 2)])
 
-for f in (QQ, NF, K)
+for f in (QQ, K)
     
     T = elem_type(f)
 

--- a/test/PolyhedralGeometry/polyhedral_complex.jl
+++ b/test/PolyhedralGeometry/polyhedral_complex.jl
@@ -1,8 +1,8 @@
 NF, sr2 = quadratic_field(2)
 Qx, x = QQ["x"]
-K, (a1, a2) = embedded_number_field([x^2 - 2, x^3 - 5], [(0, 2), (0, 2)])
+K, a = Hecke.embedded_field(NF, real_embeddings(NF)[2])
 
-for f in (QQ, NF, K)
+for f in (QQ, K)
 
     T = elem_type(f)
     @testset "PolyhedralComplex{$T}" begin

--- a/test/PolyhedralGeometry/polyhedral_fan.jl
+++ b/test/PolyhedralGeometry/polyhedral_fan.jl
@@ -1,9 +1,7 @@
-NF, sr2 = quadratic_field(2)
-ENF, sre2 = Hecke.embedded_field(NF, real_embeddings(NF)[2])
 Qx, x = QQ["x"]
 K, (a1, a2) = embedded_number_field([x^2 - 2, x^3 - 5], [(0, 2), (0, 2)])
 
-for f in (QQ, ENF, K)
+for f in (QQ, K)
 
     T = elem_type(f)
     @testset "PolyhedralFan{$T}" begin

--- a/test/PolyhedralGeometry/polyhedron.jl
+++ b/test/PolyhedralGeometry/polyhedron.jl
@@ -532,7 +532,7 @@ for f in (QQ, ENF)
                         if S == Pair{Matrix{T}, T}
                             @test facets(S, D) == [Pair(A[i], b[i]) for i in 1:12]
                         elseif S == Polyhedron{T}
-                            # @test facets(S, D) == [polyhedron(R, A[i], b[i]) for i in 1:12]
+                            @test nvertices.(facets(S, D)) == repeat([5], 12)
                         else
                             @test facets(S, D) == [affine_halfspace(R, A[i], b[i]) for i in 1:12]
                         end
@@ -565,7 +565,7 @@ for f in (QQ, ENF)
                 @test isempty(rays(D))
                 @test lineality_dim(D) == 0
                 @test isempty(lineality_space(D))
-                # @test faces(D, 0) == convex_hull.(T, V)
+                @test faces(D, 0) == convex_hull.(T, V)
                 @test isempty(affine_hull(D))
                 @test relative_interior_point(D) == [0, 0, 0]
             end

--- a/test/PolyhedralGeometry/polyhedron.jl
+++ b/test/PolyhedralGeometry/polyhedron.jl
@@ -487,8 +487,14 @@ for f in (QQ, ENF)
 
             @testset "Dodecahedron" begin
 
-              Q,  = quadratic_field(5)
-              R, a = Hecke.embedded_field(Q, real_embeddings(Q)[2])
+              D = polyhedron(Polymake.polytope.dodecahedron())
+              R = coefficient_field(D)
+              NF = number_field(R)
+              let isq = Hecke.isquadratic_type(NF)
+                @test isq[1]
+                @test isq[2] == 5
+              end
+              a = R(gens(NF)[])
 
                 V = [[1//2, a//4 + 3//4, 0],
                     [-1//2, a//4 + 3//4, 0],
@@ -511,9 +517,7 @@ for f in (QQ, ENF)
                     [1//2, -a//4 - 3//4, 0],
                     [-1//2, -a//4 - 3//4, 0]]
 
-                D = Polyhedron{T}(Polymake.polytope.dodecahedron(), R)
                 @test D isa Polyhedron{T}
-                @test polyhedron(Polymake.polytope.dodecahedron()) == D
 
                 @test nvertices(D) == 20
                 @test vertices(D) == V

--- a/test/PolyhedralGeometry/polyhedron.jl
+++ b/test/PolyhedralGeometry/polyhedron.jl
@@ -483,11 +483,12 @@ for f in (QQ, ENF)
 
         end
 
-        if T == nf_elem
+        if T == EmbeddedElem{nf_elem}
 
             @testset "Dodecahedron" begin
 
-                R, a = quadratic_field(5)
+              Q,  = quadratic_field(5)
+              R, a = Hecke.embedded_field(Q, real_embeddings(Q)[2])
 
                 V = [[1//2, a//4 + 3//4, 0],
                     [-1//2, a//4 + 3//4, 0],
@@ -527,13 +528,14 @@ for f in (QQ, ENF)
                         if S == Pair{Matrix{T}, T}
                             @test facets(S, D) == [Pair(A[i], b[i]) for i in 1:12]
                         elseif S == Polyhedron{T}
-                            @test facets(S, D) == [polyhedron(R, A[i], b[i]) for i in 1:12]
+                            # @test facets(S, D) == [polyhedron(R, A[i], b[i]) for i in 1:12]
                         else
                             @test facets(S, D) == [affine_halfspace(R, A[i], b[i]) for i in 1:12]
                         end
                         @test length(facets(S, D)) == 12
                         @test affine_inequality_matrix(facets(S, D)) == matrix(R, hcat(-b, vcat(A...)))
-                        @test halfspace_matrix_pair(facets(S, D)).A == vcat(A...) && halfspace_matrix_pair(facets(S, D)).b == b
+                        @test halfspace_matrix_pair(facets(S, D)) == (A = matrix(R, vcat(A...)),  b = b)
+
                         @test ray_indices(facets(S, D)) == IncidenceMatrix(12, 0)
                         @test vertex_indices(facets(S, D)) == IncidenceMatrix([[1, 3, 5, 9, 10], [1, 2, 3, 4, 6], [1, 2, 5, 7, 8], [11, 12, 16, 18, 20], [5, 8, 10, 15, 17], [2, 4, 7, 11, 12], [3, 6, 9, 13, 14], [4, 6, 11, 13, 16], [13, 14, 16, 19, 20], [7, 8, 12, 15, 18], [9, 10, 14, 17, 19], [15, 17, 18, 19, 20]])
                         @test vertex_and_ray_indices(facets(S, D)) == IncidenceMatrix([[1, 3, 5, 9, 10], [1, 2, 3, 4, 6], [1, 2, 5, 7, 8], [11, 12, 16, 18, 20], [5, 8, 10, 15, 17], [2, 4, 7, 11, 12], [3, 6, 9, 13, 14], [4, 6, 11, 13, 16], [13, 14, 16, 19, 20], [7, 8, 12, 15, 18], [9, 10, 14, 17, 19], [15, 17, 18, 19, 20]])
@@ -559,7 +561,7 @@ for f in (QQ, ENF)
                 @test isempty(rays(D))
                 @test lineality_dim(D) == 0
                 @test isempty(lineality_space(D))
-                @test faces(D, 0) == convex_hull.(T, V)
+                # @test faces(D, 0) == convex_hull.(T, V)
                 @test isempty(affine_hull(D))
                 @test relative_interior_point(D) == [0, 0, 0]
 

--- a/test/PolyhedralGeometry/polyhedron.jl
+++ b/test/PolyhedralGeometry/polyhedron.jl
@@ -568,9 +568,6 @@ for f in (QQ, ENF)
                 # @test faces(D, 0) == convex_hull.(T, V)
                 @test isempty(affine_hull(D))
                 @test relative_interior_point(D) == [0, 0, 0]
-
-                @test platonic_solid("dodecahedron") == D
-
             end
 
         end

--- a/test/PolyhedralGeometry/scalar_types.jl
+++ b/test/PolyhedralGeometry/scalar_types.jl
@@ -221,6 +221,14 @@
         @test facets(f[i])[] in facets(l)
       end
     end
+
+    for n in (2, 3) # faces which are facets have a different access function
+      let f = faces(l, n)
+        for i in 1:Int(f_vector(l)[n])
+          @test issubset(rays(f[i]), rays(l))
+        end
+      end
+    end
     
   end
 

--- a/test/PolyhedralGeometry/scalar_types.jl
+++ b/test/PolyhedralGeometry/scalar_types.jl
@@ -196,7 +196,7 @@
       end
       @test halfspace_matrix_pair(f) isa NamedTuple{(:A, :b), Tuple{AbstractAlgebra.Generic.MatSpaceElem{EmbeddedElem{nf_elem}}, Vector{EmbeddedElem{nf_elem}}}}
       g = halfspace_matrix_pair(f)
-      affine_halfspace(coefficient_field(j), g.A[1, :], g.b[1]) in facets(j)
+      @test affine_halfspace(coefficient_field(j), g.A[1, :], g.b[1]) in facets(j)
     end
     for n in (1, 2) # faces which are facets have a different access function
       let f = faces(j, n)

--- a/test/PolyhedralGeometry/scalar_types.jl
+++ b/test/PolyhedralGeometry/scalar_types.jl
@@ -186,4 +186,42 @@
         end
     end
 
+  @testset "QuadraticExtension-templated sub-objects" begin
+
+    j = johnson_solid(2)
+
+    let f = facets(Polyhedron, j)
+      for i in 1:nfacets(j)
+        @test facets(f[i])[] in facets(j)
+      end
+      @test halfspace_matrix_pair(f) isa NamedTuple{(:A, :b), Tuple{AbstractAlgebra.Generic.MatSpaceElem{EmbeddedElem{nf_elem}}, Vector{EmbeddedElem{nf_elem}}}}
+      g = halfspace_matrix_pair(f)
+      affine_halfspace(coefficient_field(j), g.A[1, :], g.b[1]) in facets(j)
+    end
+    for n in (1, 2) # faces which are facets have a different access function
+      let f = faces(j, n)
+        for i in 1:Int(f_vector(j)[n + 1])
+          @test issubset(vertices(f[i]), vertices(j))
+        end
+      end
+    end
+
+    k = face_fan(j)
+    let f = cones(k, 3)
+      for i in 1:Int(f_vector(k)[3])
+        @test issubset(rays(f[i]), rays(k))
+      end
+      l = f[1]
+    end
+
+    l = cone(Polymake.polytope.Cone{Polymake.QuadraticExtension{Polymake.Rational}}(RAYS = Oscar.pm_object(j).VERTICES))
+
+    let f = facets(Polyhedron, l)
+      for i in 1:nfacets(l)
+        @test facets(f[i])[] in facets(l)
+      end
+    end
+    
+  end
+
 end

--- a/test/PolyhedralGeometry/scalar_types.jl
+++ b/test/PolyhedralGeometry/scalar_types.jl
@@ -70,7 +70,7 @@
             @test isq[2] == 2
         end
         let j = johnson_solid(1)
-            jj = polyhedron(Polymake.polytope.Polytope{Polymake.QuadraticExtension{Polymake.Rational}}(POINTS=Oscar.pm_object(j).VERTICES))
+            jj = polyhedron(Polymake.polytope.Polytope{Polymake.OscarNumber}(POINTS=Oscar.pm_object(j).VERTICES))
             @test number_field(coefficient_field(j)) == number_field(coefficient_field(jj))
         end
     end
@@ -212,22 +212,6 @@
         @test issubset(rays(f[i]), rays(k))
       end
       l = f[1]
-    end
-
-    l = cone(Polymake.polytope.Cone{Polymake.QuadraticExtension{Polymake.Rational}}(RAYS = Oscar.pm_object(j).VERTICES))
-
-    let f = facets(Polyhedron, l)
-      for i in 1:nfacets(l)
-        @test facets(f[i])[] in facets(l)
-      end
-    end
-
-    for n in (2, 3) # faces which are facets have a different access function
-      let f = faces(l, n)
-        for i in 1:Int(f_vector(l)[n])
-          @test issubset(rays(f[i]), rays(l))
-        end
-      end
     end
     
   end

--- a/test/PolyhedralGeometry/scalar_types.jl
+++ b/test/PolyhedralGeometry/scalar_types.jl
@@ -191,8 +191,10 @@
     j = johnson_solid(2)
 
     let f = facets(Polyhedron, j)
+      fj = normal_vector.(facets(j))
+      fj = [fj; -fj]
       for i in 1:nfacets(j)
-        @test facets(f[i])[] in facets(j)
+        @test normal_vector(affine_hull(f[i])[]) in fj
       end
       @test halfspace_matrix_pair(f) isa NamedTuple{(:A, :b), Tuple{AbstractAlgebra.Generic.MatSpaceElem{EmbeddedElem{nf_elem}}, Vector{EmbeddedElem{nf_elem}}}}
       g = halfspace_matrix_pair(f)

--- a/test/PolyhedralGeometry/types.jl
+++ b/test/PolyhedralGeometry/types.jl
@@ -16,12 +16,13 @@
   b = [8, 6, 4]
 
   NF, sr2 = quadratic_field(2)
+  ENF, sre2 = Hecke.embedded_field(NF, real_embeddings(NF)[2])
 
   @testset "$T" for (T, fun) in ((PointVector, point_vector), (RayVector, ray_vector))
 
     @test fun(a) isa T{QQFieldElem}
 
-    for f in (ZZ, QQ, NF)
+    for f in (ZZ, QQ, ENF)
 
       U = elem_type(f)
       @testset "$T{$U}" begin
@@ -49,7 +50,7 @@
         @test_throws BoundsError A[0]
         @test_throws BoundsError A[4]
 
-        for g in (ZZ, QQ, NF)
+        for g in (ZZ, QQ, ENF)
           V = elem_type(g)
 
           B = fun(g, b)
@@ -79,7 +80,7 @@
 
   @testset "$T" for (T, f) in ((AffineHalfspace, affine_halfspace), (AffineHyperplane, affine_hyperplane))
         
-    for p in [QQ, NF]
+    for p in [QQ, ENF]
       U = elem_type(p)
       @test f(p, a, 0) isa T{U}
       @test f(p, permutedims(a), 0) isa T{U}
@@ -107,7 +108,7 @@
     
   @testset "$T" for (T, f) in ((LinearHalfspace, linear_halfspace), (LinearHyperplane, linear_hyperplane))
         
-    for p in [QQ, NF]
+    for p in [QQ, ENF]
       U = elem_type(p)
       @test f(p, a) isa T{U}
       @test f(p, permutedims(a)) isa T{U}

--- a/test/PolyhedralGeometry/types.jl
+++ b/test/PolyhedralGeometry/types.jl
@@ -1,157 +1,157 @@
 @testset "types" begin
     
-    @testset "IncidenceMatrix" begin
+  @testset "IncidenceMatrix" begin
         
-        im = IncidenceMatrix([[1,2,3],[4,5,6]])
-        @test nrows(im) == 2
-        @test ncols(im) == 6
-        @test row(im, 1) isa Set{Int}
-        @test row(im, 1) == Set{Int}([1, 2, 3])
-        @test column(im, 2) isa Set{Int}
-        @test column(im, 2) == Set{Int}([1])
+    im = IncidenceMatrix([[1,2,3],[4,5,6]])
+    @test nrows(im) == 2
+    @test ncols(im) == 6
+    @test row(im, 1) isa Set{Int}
+    @test row(im, 1) == Set{Int}([1, 2, 3])
+    @test column(im, 2) isa Set{Int}
+    @test column(im, 2) == Set{Int}([1])
         
-    end
+  end
 
-    a = [1, 2, 3]
-    b = [8, 6, 4]
+  a = [1, 2, 3]
+  b = [8, 6, 4]
 
-    NF, sr2 = quadratic_field(2)
+  NF, sr2 = quadratic_field(2)
 
-    #TODO: RayVector
-    @testset "$T" for T in (PointVector, RayVector)
+  #TODO: RayVector
+  @testset "$T" for (T, fun) in ((PointVector, point_vector),)
 
-        @test T(a) isa T{QQFieldElem}
+    @test fun(a) isa T{QQFieldElem}
 
-        for f in (ZZ, QQ, NF)
+    for f in (ZZ, QQ, NF)
 
-            U = elem_type(f)
-            @testset "$T{$U}" begin
+      U = elem_type(f)
+      @testset "$T{$U}" begin
 
-                @test T{U} <: AbstractVector
-                @test T{U} <: AbstractVector{U}
+        @test T{U} <: AbstractVector
+        @test T{U} <: AbstractVector{U}
 
-                @test T{U}(f.(a)) isa T
-                @test T{U}(f.(a)) isa T{U}
+        @test fun(f, a) isa T
+        @test fun(f, a) isa T{U}
 
-                @test T{U}(f, 7) == f.(zeros(Int, 7))
+        @test fun(f, 7) == f.(zeros(Int, 7))
 
-                A = T{U}(f.(a))
+        A = fun(f, a)
 
-                @test A[1] isa U
-                @test A[2] == 2
-                @test A[begin] == 1
-                @test A[end] == 3
-                A[3] = f(7)
-                @test A[end] == 7
-                A[3] = f(3)
+        @test A[1] isa U
+        @test A[2] == 2
+        @test A[begin] == 1
+        @test A[end] == 3
+        A[3] = f(7)
+        @test A[end] == 7
+        A[3] = f(3)
 
-                @test size(A) == (3,)
+        @test size(A) == (3,)
 
-                @test_throws BoundsError A[0]
-                @test_throws BoundsError A[4]
+        @test_throws BoundsError A[0]
+        @test_throws BoundsError A[4]
 
-                for g in (ZZ, QQ, NF)
-                V = elem_type(g)
+        for g in (ZZ, QQ, NF)
+          V = elem_type(g)
 
-                    B = T{V}(g.(b))
+          B = fun(g, b)
 
-                    for op in [+, -]
-                        @test op(A, B) isa T
+          for op in [+, -]
+            @test op(A, B) isa T
 
-                        @test op(A, B) == op(a, b)
-                    end
+            @test op(A, B) == op(a, b)
+          end
 
-                    @test *(g(3), A) isa T
+          @test *(g(3), A) isa T
 
-                    @test *(g(3), A) == 3 * a
+          @test *(g(3), A) == 3 * a
 
-                    @test [A; B] == [a; b]
+          # @test [A; B] == [a; b]
 
-                end
-
-            end
         end
 
+      end
     end
 
+  end
 
 
 
 
-    @testset "$T" for (T, f) in ((AffineHalfspace, affine_halfspace), (AffineHyperplane, affine_hyperplane))
+
+  @testset "$T" for (T, f) in ((AffineHalfspace, affine_halfspace), (AffineHyperplane, affine_hyperplane))
         
-        for p in [QQ, NF]
-            U = elem_type(p)
-            @test f(p, a, 0) isa T{U}
-            @test f(p, permutedims(a), 0) isa T{U}
-
-            @test f(p, a, 0) == f(p, permutedims(a), 0) == f(p, a) == f(p, permutedims(a))
-
-            A = f(p, a, 0)
-            B = f(p, b, 2)
-
-            @test A != B
-
-            @test normal_vector(A) isa Vector{U}
-            @test normal_vector(A) == a
-            @test negbias(A) isa U
-            @test negbias(A) == 0
-            
-            
-            @test normal_vector(B) == b
-            @test negbias(B) == 2
-        end
-        
-        @test f(a, 0) isa T{QQFieldElem}
-        
-    end
-    
-    @testset "$T" for (T, f) in ((LinearHalfspace, linear_halfspace), (LinearHyperplane, linear_hyperplane))
-        
-        for p in [QQ, NF]
-            U = elem_type(p)
-            @test f(p, a) isa T{U}
-            @test f(p, permutedims(a)) isa T{U}
-
-            @test f(p, a) == f(p, permutedims(a))
-
-            A = f(p, a)
-            B = f(p, b)
-
-            @test A != B
-
-            @test normal_vector(A) isa Vector{U}
-            @test normal_vector(A) == a
-            @test negbias(A) isa U
-            @test negbias(A) == 0
-            
-            
-            @test normal_vector(B) == b
-            @test negbias(B) == 0
-        end
-        
-        @test f(a) isa T{QQFieldElem}
-        
-    end
-    
     for p in [QQ, NF]
-        U = elem_type(p)
-        let A = linear_halfspace(p, a)
-            @test invert(A) isa LinearHalfspace{U}
-            Ai = invert(A)
-            @test normal_vector(Ai) == -a
-        end
-        let A = affine_halfspace(p, a, 8)
-            @test invert(A) isa AffineHalfspace{U}
-            Ai = invert(A)
-            @test normal_vector(Ai) == -a
-            @test negbias(Ai) == -8
-        end
+      U = elem_type(p)
+      @test f(p, a, 0) isa T{U}
+      @test f(p, permutedims(a), 0) isa T{U}
+
+      @test f(p, a, 0) == f(p, permutedims(a), 0) == f(p, a) == f(p, permutedims(a))
+
+      A = f(p, a, 0)
+      B = f(p, b, 2)
+
+      @test A != B
+
+      @test normal_vector(A) isa Vector{U}
+      @test normal_vector(A) == a
+      @test negbias(A) isa U
+      @test negbias(A) == 0
+            
+            
+      @test normal_vector(B) == b
+      @test negbias(B) == 2
     end
+        
+    @test f(a, 0) isa T{QQFieldElem}
+        
+  end
     
-    @test halfspace(a) isa LinearHalfspace{QQFieldElem}
-    @test hyperplane(a) isa LinearHyperplane{QQFieldElem}
-    @test halfspace(a, 0) isa AffineHalfspace{QQFieldElem}
-    @test hyperplane(a, 0) isa AffineHyperplane{QQFieldElem}
+  @testset "$T" for (T, f) in ((LinearHalfspace, linear_halfspace), (LinearHyperplane, linear_hyperplane))
+        
+    for p in [QQ, NF]
+      U = elem_type(p)
+      @test f(p, a) isa T{U}
+      @test f(p, permutedims(a)) isa T{U}
+
+      @test f(p, a) == f(p, permutedims(a))
+
+      A = f(p, a)
+      B = f(p, b)
+
+      @test A != B
+
+      @test normal_vector(A) isa Vector{U}
+      @test normal_vector(A) == a
+      @test negbias(A) isa U
+      @test negbias(A) == 0
+            
+            
+      @test normal_vector(B) == b
+      @test negbias(B) == 0
+    end
+        
+    @test f(a) isa T{QQFieldElem}
+        
+  end
+    
+  for p in [QQ, NF]
+    U = elem_type(p)
+    let A = linear_halfspace(p, a)
+      @test invert(A) isa LinearHalfspace{U}
+      Ai = invert(A)
+      @test normal_vector(Ai) == -a
+    end
+    let A = affine_halfspace(p, a, 8)
+      @test invert(A) isa AffineHalfspace{U}
+      Ai = invert(A)
+      @test normal_vector(Ai) == -a
+      @test negbias(Ai) == -8
+    end
+  end
+    
+  @test halfspace(a) isa LinearHalfspace{QQFieldElem}
+  @test hyperplane(a) isa LinearHyperplane{QQFieldElem}
+  @test halfspace(a, 0) isa AffineHalfspace{QQFieldElem}
+  @test hyperplane(a, 0) isa AffineHyperplane{QQFieldElem}
 
 end

--- a/test/PolyhedralGeometry/types.jl
+++ b/test/PolyhedralGeometry/types.jl
@@ -65,8 +65,6 @@
 
           @test *(g(3), A) == 3 * a
 
-          # @test [A; B] == [a; b]
-
         end
 
       end

--- a/test/PolyhedralGeometry/types.jl
+++ b/test/PolyhedralGeometry/types.jl
@@ -17,8 +17,7 @@
 
   NF, sr2 = quadratic_field(2)
 
-  #TODO: RayVector
-  @testset "$T" for (T, fun) in ((PointVector, point_vector),)
+  @testset "$T" for (T, fun) in ((PointVector, point_vector), (RayVector, ray_vector))
 
     @test fun(a) isa T{QQFieldElem}
 


### PR DESCRIPTION
This PR includes:
* re-factoring for support types like `PointVector` and `Halfspace` to consistently integrate their handling into polyhedral geometry and Oscar while improving performance and reducing code cuplication.
* the helper type union `scalar_type_or_field` which is used by any constructor that allows different scalar types
* adjustments on tests, e.g. removal of `nf_elem` scalars (which are not embedded)
* adjustments on several access functions of the `SubObjectIterator` to increase type stability

Also, while the code that has made it into the master (greatly) does its job for the majority of its destined functionality, some edge cases in the context of quadratic number fields did not work as intended. As of now, a big part of this is already is solved with this PR, although not entirely.