### PR TITLE
CI: avoid timeouts on macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -100,15 +100,17 @@ jobs:
         if: runner.os == 'macOS'
         # restrict number of openMP threads on macOS due to oversubscription
         run: echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
-      - name: "Run tests"
-        # HACK: since macOS runners are so expensive, we reuse this one to run
-        # both regular tests and doctests
-        if: runner.os == 'macOS'
-        uses: julia-actions/julia-runtest@latest
-        with:
-          annotate: ${{ matrix.julia-version == '1.9' }}
-          coverage: ${{ matrix.julia-version == '1.9' }}
-          depwarn: error
+#       - name: "Run tests"
+#         # HACK: since macOS runners are so expensive, we reuse this one to run
+#         # both regular tests and doctests
+#         # FIXME: since the tests got too slow, we can't afford this HACK anymore,
+#         # so disable it again....
+#         if: runner.os == 'macOS'
+#         uses: julia-actions/julia-runtest@latest
+#         with:
+#           annotate: ${{ matrix.julia-version == '1.9' }}
+#           coverage: ${{ matrix.julia-version == '1.9' }}
+#           depwarn: error
       - name: "Setup package"
         run: |
           julia --project=docs --color=yes -e '


### PR DESCRIPTION
To conserve resources, we were running both the regular test suites and the doctest on a single macOS instance. That was good until the test suite became so slow that this started routinely time out. That means that now those macOS jobs run ~150 minutes just to fail.

That's a waste, as those macOS runner are strictly limited and often pose the bottleneck for our CI tests to run.

So until the test suite gets faster again (if ever), revert to just running the doctests. Together with the regular tests being run under macOS with Julia nightly, plus several of us developing on macOS, this should hopefully still catch the worst and most obvious macOS regressions.

If this turns out problematic, we'll have to consider alternatives, including:
1. using a third macOS runner again,
2. increasing the timeout
3. using a custom GitHub runner, using a macOS machine we own and control,