### PR TITLE
PolyhedralGeometry: Refactor facets

### DIFF
--- a/experimental/GITFans/src/GITFans.jl
+++ b/experimental/GITFans/src/GITFans.jl
@@ -461,11 +461,11 @@ function fan_traversal(orbit_list::Vector{Vector{Cone{T}}}, q_cone::Cone{T}, per
         current_cone_list = cones_from_bitlist(orbit_list, current_hash)
         intersected_cone = intersect(current_cone_list)
         ic_facets = -linear_inequality_matrix(facets(intersected_cone))
-        facet_points = [T[relative_interior_point(f)...] for f in faces(intersected_cone, dim(intersected_cone)-1)]
+        facet_points = [T[relative_interior_point(f)...] for f in facets(Cone, intersected_cone)]
 
         neighbor_hashes = []
         for i in 1:length(facet_points)
-          !any(f->facet_points[i] in f, faces(q_cone, dim(q_cone)-1)) || continue
+          !any(f->facet_points[i] in f, facets(Cone, q_cone)) || continue
           push!(neighbor_hashes, get_neighbor_hash(orbit_list, facet_points[i], Vector{T}([ic_facets[i, :]...])))
         end
 

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -439,15 +439,11 @@ julia> f = facets(Halfspace, c)
 -x₂ + x₃ ≦ 0
 ```
 """
-facets(as::Type{<:Union{AffineHalfspace{T}, LinearHalfspace{T}, Polyhedron{T}, Cone{T}}}, C::Cone) where T<:scalar_types = SubObjectIterator{as}(C, _facet_cone, nfacets(C))
-
-_facet_cone(::Type{Polyhedron{T}}, C::Cone, i::Base.Integer) where T<:scalar_types = polyhedron(coefficient_field(C), -view(pm_object(C).FACETS, [i], :), 0)
-
-_facet_cone(::Type{AffineHalfspace{T}}, C::Cone, i::Base.Integer) where T<:scalar_types = affine_halfspace(coefficient_field(C), -view(pm_object(C).FACETS, [i], :), 0)
+facets(as::Type{<:Union{LinearHalfspace{T}, Cone{T}}}, C::Cone) where T<:scalar_types = SubObjectIterator{as}(C, _facet_cone, nfacets(C))
 
 _facet_cone(::Type{LinearHalfspace{T}}, C::Cone, i::Base.Integer) where T<:scalar_types = linear_halfspace(coefficient_field(C), -pm_object(C).FACETS[[i], :])
 
-_facet_cone(::Type{Cone{T}}, C::Cone, i::Base.Integer) where T<:scalar_types = cone_from_inequalities(coefficient_field(C), -view(pm_object(C).FACETS, [i], :))
+_facet_cone(::Type{Cone{T}}, C::Cone, i::Base.Integer) where T<:scalar_types = Cone{T}(Polymake.polytope.facet(pm_object(C), i-1), coefficient_field(C))
 
 _linear_inequality_matrix(::Val{_facet_cone}, C::Cone) = -pm_object(C).FACETS
 
@@ -460,6 +456,8 @@ _incidencematrix(::Val{_facet_cone}) = _ray_indices
 facets(C::Cone{T}) where T<:scalar_types = facets(LinearHalfspace{T}, C)
 
 facets(::Type{Halfspace}, C::Cone{T}) where T<:scalar_types = facets(LinearHalfspace{T}, C)
+
+facets(::Type{Cone}, C::Cone{T}) where T<:scalar_types = facets(Cone{T}, C)
 
 @doc raw"""
     lineality_space(C::Cone)

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -420,8 +420,7 @@ function _facet_polyhedron(::Type{Pair{R, S}}, P::Polyhedron, i::Base.Integer) w
     return Pair{R, S}(f.(view(h[1], :, :)), f(h[2][])) # view_broadcast
 end
 function _facet_polyhedron(::Type{Polyhedron{T}}, P::Polyhedron, i::Base.Integer) where T<:scalar_types
-    h = decompose_hdata(view(pm_object(P).FACETS, [_facet_index(pm_object(P), i)], :))
-    return polyhedron(coefficient_field(P), h[1], h[2][])
+  return Polyhedron{T}(Polymake.polytope.facet(pm_object(P), _facet_index(pm_object(P), i)-1), coefficient_field(P))
 end
 
 _affine_inequality_matrix(::Val{_facet_polyhedron}, P::Polyhedron) = -_remove_facet_at_infinity(pm_object(P))

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -52,8 +52,8 @@ end
 
 function NormalToricVariety(PF::PolyhedralFan; set_attributes::Bool = true)
     Base.depwarn("'NormalToricVariety(PF::PolyhedralFan; set_attributes::Bool = true)' is deprecated, use"*
-    "'normal_toric_variety(PF::PolyhedralFan; set_attributes::Bool = true)' instead.", :NormalToricVariety)
-    normal_toric_variety(PF; set_attributes = set_attributes)
+    "'normal_toric_variety(PF::PolyhedralFan)' instead.", :NormalToricVariety)
+    normal_toric_variety(PF)
 end
 
 function NormalToricVariety(P::Polyhedron; set_attributes::Bool = true)

--- a/test/PolyhedralGeometry/cone.jl
+++ b/test/PolyhedralGeometry/cone.jl
@@ -53,7 +53,7 @@ for f in (QQ, NF, K)
             end
             @test length(rays(Cone1)) == 2
             @test rays(Cone1) == [[1, 0], [0, 1]]
-            for S in [AffineHalfspace{T}, LinearHalfspace{T}, Cone{T}, Polyhedron{T}]
+            for S in [LinearHalfspace{T}, Cone{T}]
                 @test facets(S, Cone1) isa SubObjectIterator{S}
                 @test length(facets(S, Cone1)) == 2
                 if T == QQFieldElem
@@ -61,28 +61,16 @@ for f in (QQ, NF, K)
                     @test Oscar.linear_matrix_for_polymake(facets(S, Cone1)) == [-1 0; 0 -1]
                     @test ray_indices(facets(S, Cone1)) == IncidenceMatrix([[2], [1]])
                     @test IncidenceMatrix(facets(S, Cone1)) == IncidenceMatrix([[2], [1]])
-                    if S == Cone{T}
-                        @test facets(S, Cone1) == cone_from_inequalities.([[-1 0], [0 -1]])
-                    elseif S == LinearHalfspace{T}
+                    if S == LinearHalfspace{T}
                         @test facets(S, Cone1) == linear_halfspace.([f], [[-1, 0], [0, -1]])
-                    elseif S == AffineHalfspace{T}
-                        @test facets(S, Cone1) == affine_halfspace.([f], [[-1 0], [0 -1]], [0])
-                    else
-                        @test facets(S, Cone1) == polyhedron.(T, [[-1 0], [0 -1]], [0])
                     end
                 else
                     @test linear_inequality_matrix(facets(S, Cone1)) == matrix(f, [0 -1; -1 0])
                     @test Oscar.linear_matrix_for_polymake(facets(S, Cone1)) == [0 -1; -1 0]
                     @test ray_indices(facets(S, Cone1)) == IncidenceMatrix([[1], [2]])
                     @test IncidenceMatrix(facets(S, Cone1)) == IncidenceMatrix([[1], [2]])
-                    if S == Cone{T}
-                        @test facets(S, Cone1) == cone_from_inequalities.([f], [[0 -1], [-1 0]])
-                    elseif S == LinearHalfspace{T}
+                    if S == LinearHalfspace{T}
                         @test facets(S, Cone1) == linear_halfspace.([f], [[0, -1], [-1, 0]])
-                    elseif S == AffineHalfspace{T}
-                        @test facets(S, Cone1) == affine_halfspace.([f], [[0 -1], [-1 0]], [0])
-                    else
-                        @test facets(S, Cone1) == polyhedron.([f], [[0 -1], [-1 0]], [0])
                     end
                 end
             end

--- a/test/PolyhedralGeometry/polyhedron.jl
+++ b/test/PolyhedralGeometry/polyhedron.jl
@@ -138,11 +138,9 @@ for f in (QQ, ENF)
                       Pair{Matrix{T}, T},
                       Polyhedron{T}]
                 @test facets(S, Pos) isa SubObjectIterator{S}
-                if S == Polyhedron{T}
-                    @test facets(S, Pos) == polyhedron.([f], [[-1 0 0], [0 -1 0], [0 0 -1]], [0])
-                elseif S == Pair{Matrix{T}, T}
+                if S == Pair{Matrix{T}, T}
                     @test facets(S, Pos) == S.([f.([-1 0 0]), f.([0 -1 0]), f.([0 0 -1])], [f(0)])
-                else
+                  elseif S == AffineHalfspace{T}
                     @test facets(S, Pos) == affine_halfspace.([f], [[-1 0 0], [0 -1 0], [0 0 -1]], [0])
                 end
                 @test length(facets(S, Pos)) == 3


### PR DESCRIPTION
- facets(*, Cone) cannot return Polyhedron or AffineHalfspace
- facets(::Type{Cone}, Cone) properly redirects
- facets(::Type{Polyhedron}, Polyhedron) now returns honest subpolyhedra
- facets(::Type{Cone}, Cone) now returns honest subcones