### PR TITLE
docs: monkeypatch documenter into printing blocks and timings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -119,6 +119,7 @@ jobs:
         run: |
           julia --project=docs --depwarn=error --color=yes -e'
             using Documenter
+            include("docs/documenter_helpers.jl")
             using Oscar
             DocMeta.setdocmeta!(Oscar, :DocTestSetup, Oscar.doctestsetup(); recursive = true)
             doctest(Oscar)'

--- a/docs/documenter_helpers.jl
+++ b/docs/documenter_helpers.jl
@@ -1,0 +1,8 @@
+# this function is slightly more specific than the one from documenter, print the corresponding code location
+# calls the original function via invoke and prints a timing for the doctest
+#
+function Documenter.DocTests.eval_repl(block, sandbox::Module, meta::Dict, doc::Documenter.Documents.Document, page)
+  src_lines = Documenter.Utilities.find_block_in_file(block.code, meta[:CurrentFile])
+  println("page: $(Documenter.Utilities.locrepr(meta[:CurrentFile], src_lines))")
+  @time invoke(Documenter.DocTests.eval_repl, Tuple{Any,Any,Dict,Documenter.Documents.Document,Any}, block, sandbox, meta, doc, page)
+end

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -6,6 +6,8 @@ module BuildDoc
 
 using Documenter, DocumenterCitations
 
+include("documenter_helpers.jl")
+
 # Overwrite printing to make the header not full of redundant nonsense
 # Turns
 #   Hecke.Order - Method


### PR DESCRIPTION
This might help identifying doctest crashes, e.g. those mentioned in #2336. I have enabled this for CI and when running the doctests via `Oscar.doctest`.

Output currently looks like this:
```
page: ~/work/Oscar.jl/Oscar.jl/src/TropicalGeometry/semiring.jl:98-119
  1.244015 seconds (1.09 M allocations: 75.239 MiB, 98.65% compilation time)
page: ~/work/Oscar.jl/Oscar.jl/src/Combinatorics/Graphs/functions.jl:571-585
  0.157866 seconds (55.35 k allocations: 4.002 MiB, 97.90% compilation time)
page: ~/work/Oscar.jl/Oscar.jl/src/Combinatorics/Matroids/matroids.jl:409-419
  0.008892 seconds (1.32 k allocations: 156.484 KiB, 56.15% compilation time)
page: ~/work/Oscar.jl/Oscar.jl/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl:43-51
  0.036817 seconds (4.23 k allocations: 341.500 KiB, 19.96% compilation time)
page: ~/work/Oscar.jl/Oscar.jl/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl:615-620
  0.037494 seconds (1.27 k allocations: 178.234 KiB, 24.68% compilation time)
```