### PR TITLE
docs: stop verbose doctest output after a failure

### DIFF
--- a/docs/documenter_helpers.jl
+++ b/docs/documenter_helpers.jl
@@ -3,6 +3,11 @@
 #
 function Documenter.DocTests.eval_repl(block, sandbox::Module, meta::Dict, doc::Documenter.Documents.Document, page)
   src_lines = Documenter.Utilities.find_block_in_file(block.code, meta[:CurrentFile])
-  println("page: $(Documenter.Utilities.locrepr(meta[:CurrentFile], src_lines))")
-  @time invoke(Documenter.DocTests.eval_repl, Tuple{Any,Any,Dict,Documenter.Documents.Document,Any}, block, sandbox, meta, doc, page)
+  # skip stats if there was a failure
+  if length(doc.internal.errors) > 0
+    invoke(Documenter.DocTests.eval_repl, Tuple{Any,Any,Dict,Documenter.Documents.Document,Any}, block, sandbox, meta, doc, page)
+  else
+    println("page: $(Documenter.Utilities.locrepr(meta[:CurrentFile], src_lines))")
+    @time invoke(Documenter.DocTests.eval_repl, Tuple{Any,Any,Dict,Documenter.Documents.Document,Any}, block, sandbox, meta, doc, page)
+  end
 end


### PR DESCRIPTION
This avoids burying the failure in lots of output as observed in #2741.