### PR TITLE
Fix `hom_product` docstring

### DIFF
--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -4965,7 +4965,7 @@ function show_morphism(f::ModuleFPHom)
 end
 
 @doc raw"""
-    hom_tensor(M::ModuleFP, N::ModuleFP, V::Vector{ <: ModuleFPHom})
+    hom_tensor(M::ModuleFP, N::ModuleFP, V::Vector{<:ModuleFPHom})
 
 Given modules `M`, `N` which are tensor products with the same number of factors,
 say $M = M_1 \otimes \cdots \otimes M_r$, $N = N_1 \otimes \cdots \otimes N_r$,
@@ -4998,8 +4998,8 @@ end
 @doc raw"""
     hom_product(M::ModuleFP, N::ModuleFP, A::Matrix{<:ModuleFPHom})
 
-Given modules `M`, `N` which are products with the same number of factors,  
-say $M = \prod_{i=1}^r M_i$, $N = \prod_{j=1}^r N_j$, and given a matrix 
+Given modules `M` and `N` which are products with `r` respective `s` factors,  
+say $M = \prod_{i=1}^r M_i$, $N = \prod_{j=1}^s N_j$, and given a $r \times s$ matrix 
 `A` of homomorphisms $a_{ij} : M_i \to N_j$, return the homomorphism
 $M \to N$ with $ij$-components $a_{ij}$.
 """

--- a/test/Modules/ModulesGraded.jl
+++ b/test/Modules/ModulesGraded.jl
@@ -946,7 +946,7 @@ end
 	@assert is_welldefined(M2_to_N2)
 
 	phi = hom_product(prod_M,prod_N,[M1_to_N1 M1_to_N2; M2_to_N1 M2_to_N2])
-    @test degree(phi) == 6*Z[1]
+	@test degree(phi) == 6*Z[1]
 	for g in gens(M1)
 		@test M1_to_N1(g) == Hecke.canonical_projection(prod_N,1)(phi(emb[1](g)))
 		@test M1_to_N2(g) == Hecke.canonical_projection(prod_N,2)(phi(emb[1](g)))


### PR DESCRIPTION
(...and a typo in `hom_tensor`.)

It states that both modules must be direct products of the same number of factors. However, this is not needed for the implementation to work.