### PR TITLE
LieAlgebras: Constructions for module homs

### DIFF
--- a/experimental/LieAlgebras/docs/src/lie_algebra_homs.md
+++ b/experimental/LieAlgebras/docs/src/lie_algebra_homs.md
@@ -19,6 +19,7 @@ the images of the basis elements of $L_1$ or a $\dim L_1 \times \dim L_2$ matrix
 hom(::LieAlgebra{C}, ::LieAlgebra{C}, ::Vector{<:LieAlgebraElem{C}}; check::Bool=true) where {C<:RingElement}
 hom(::LieAlgebra{C}, ::LieAlgebra{C}, ::MatElem{C}; check::Bool=true) where {C<:RingElement}
 identity_map(::LieAlgebra)
+zero_map(::LieAlgebra{C}, ::LieAlgebra{C}) where {C<:RingElement}
 ```
 
 ## Functions

--- a/experimental/LieAlgebras/docs/src/module_homs.md
+++ b/experimental/LieAlgebras/docs/src/module_homs.md
@@ -57,4 +57,5 @@ canonical_injections(::LieAlgebraModule)
 canonical_injection(::LieAlgebraModule, ::Int)
 canonical_projections(::LieAlgebraModule)
 canonical_projection(::LieAlgebraModule, ::Int)
+hom_tensor(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::Vector{<:LieAlgebraModuleHom}) where {C<:RingElement}
 ```

--- a/experimental/LieAlgebras/docs/src/module_homs.md
+++ b/experimental/LieAlgebras/docs/src/module_homs.md
@@ -60,5 +60,5 @@ canonical_projections(::LieAlgebraModule)
 canonical_projection(::LieAlgebraModule, ::Int)
 hom_direct_sum(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::Matrix{<:LieAlgebraModuleHom}) where {C<:RingElement}
 hom_tensor(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::Vector{<:LieAlgebraModuleHom}) where {C<:RingElement}
-hom_tensor(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::LieAlgebraModuleHom) where {C<:RingElement}
+hom_power(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::LieAlgebraModuleHom) where {C<:RingElement}
 ```

--- a/experimental/LieAlgebras/docs/src/module_homs.md
+++ b/experimental/LieAlgebras/docs/src/module_homs.md
@@ -20,6 +20,7 @@ or a $\dim V_1 \times \dim V_2$ matrix.
 hom(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::Vector{<:LieAlgebraModuleElem{C}}; check::Bool=true) where {C<:RingElement}
 hom(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::MatElem{C}; check::Bool=true) where {C<:RingElement}
 identity_map(::LieAlgebraModule)
+zero_map(::LieAlgebraModule{C}, ::LieAlgebraModule{C}) where {C<:RingElement}
 ```
 
 ## Functions

--- a/experimental/LieAlgebras/docs/src/module_homs.md
+++ b/experimental/LieAlgebras/docs/src/module_homs.md
@@ -48,3 +48,13 @@ compose(::LieAlgebraModuleHom{T1,T2}, ::LieAlgebraModuleHom{T2,T3}) where {T1<:L
 is_isomorphism(::LieAlgebraModuleHom)
 inv(::LieAlgebraModuleHom)
 ```
+
+### Hom constructions
+Lie algebra module homomorphisms support `+` and `-` if they have the same domain and codomain.
+
+```@docs
+canonical_injections(::LieAlgebraModule)
+canonical_injection(::LieAlgebraModule, ::Int)
+canonical_projections(::LieAlgebraModule)
+canonical_projection(::LieAlgebraModule, ::Int)
+```

--- a/experimental/LieAlgebras/docs/src/module_homs.md
+++ b/experimental/LieAlgebras/docs/src/module_homs.md
@@ -57,5 +57,6 @@ canonical_injections(::LieAlgebraModule)
 canonical_injection(::LieAlgebraModule, ::Int)
 canonical_projections(::LieAlgebraModule)
 canonical_projection(::LieAlgebraModule, ::Int)
+hom_direct_sum(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::Matrix{<:LieAlgebraModuleHom}) where {C<:RingElement}
 hom_tensor(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::Vector{<:LieAlgebraModuleHom}) where {C<:RingElement}
 ```

--- a/experimental/LieAlgebras/docs/src/module_homs.md
+++ b/experimental/LieAlgebras/docs/src/module_homs.md
@@ -60,4 +60,5 @@ canonical_projections(::LieAlgebraModule)
 canonical_projection(::LieAlgebraModule, ::Int)
 hom_direct_sum(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::Matrix{<:LieAlgebraModuleHom}) where {C<:RingElement}
 hom_tensor(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::Vector{<:LieAlgebraModuleHom}) where {C<:RingElement}
+hom_tensor(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::LieAlgebraModuleHom) where {C<:RingElement}
 ```

--- a/experimental/LieAlgebras/src/LieAlgebraHom.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraHom.jl
@@ -26,9 +26,7 @@
     h.matrix = mat::dense_matrix_type(coefficient_ring(L2))
     h.header = MapHeader(L1, L2)
     if check
-      for x1 in basis(L1), x2 in basis(L1)
-        @req h(x1) * h(x2) == h(x1 * x2) "Not a homomorphism"
-      end
+      @req is_welldefined(h) "Not a homomorphism"
     end
     return h
   end
@@ -49,6 +47,20 @@ Note: The matrix operates on the coefficient vectors from the right.
 """
 function matrix(h::LieAlgebraHom{<:LieAlgebra,<:LieAlgebra{C2}}) where {C2<:RingElement}
   return (h.matrix)::dense_matrix_type(C2)
+end
+
+@doc raw"""
+    is_welldefined(h::LieAlgebraHom) -> Bool
+
+Return `true` if `h` is a well-defined homomorphism of Lie algebras.
+This function is used internally when calling `hom` with `check=true`.
+"""
+function is_welldefined(h::LieAlgebraHom)
+  L1 = domain(h)
+  for x1 in basis(L1), x2 in basis(L1)
+    h(x1) * h(x2) == h(x1 * x2) || return false
+  end
+  return true
 end
 
 ###############################################################################

--- a/experimental/LieAlgebras/src/LieAlgebraHom.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraHom.jl
@@ -301,3 +301,30 @@ Lie algebra morphism
 function identity_map(L::LieAlgebra)
   return hom(L, L, basis(L); check=false)
 end
+
+@doc raw"""
+    zero_map(L1::LieAlgebra, L2::LieAlgebra) -> LieAlgebraHom
+    zero_map(L::LieAlgebra) -> LieAlgebraHom
+
+Construct the zero map from `L1` to `L2` or from `L` to `L`.
+
+# Examples
+```jldoctest
+julia> L = special_linear_lie_algebra(QQ, 3)
+Special linear Lie algebra of degree 3
+  of dimension 8
+over rational field
+
+julia> zero_map(L)
+Lie algebra morphism
+  from special linear Lie algebra of degree 3 over QQ
+  to   special linear Lie algebra of degree 3 over QQ
+```
+"""
+function zero_map(L1::LieAlgebra{C}, L2::LieAlgebra{C}) where {C<:RingElement}
+  return hom(L1, L2, zero_matrix(coefficient_ring(L2), dim(L1), dim(L2)); check=false)
+end
+
+function zero_map(L::LieAlgebra)
+  return zero_map(L, L)
+end

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -1020,7 +1020,6 @@ function exterior_power(V::LieAlgebraModule{C}, k::Int) where {C<:RingElement}
     :type => :exterior_power,
     :power => k,
     :base_module => V,
-    :ind_map => ind_map, # deprecated
     :exterior_pure_function => pure,
     :exterior_pure_preimage_function => inv_pure,
     :embedding_tensor_power => T,
@@ -1139,7 +1138,6 @@ function symmetric_power(V::LieAlgebraModule{C}, k::Int) where {C<:RingElement}
     :type => :symmetric_power,
     :power => k,
     :base_module => V,
-    :ind_map => ind_map, #deprecated
     :symmetric_pure_function => pure,
     :symmetric_pure_preimage_function => inv_pure,
     :embedding_tensor_power => T,
@@ -1234,7 +1232,6 @@ function tensor_power(V::LieAlgebraModule{C}, k::Int) where {C<:RingElement}
     :type => :tensor_power,
     :power => k,
     :base_module => V,
-    :ind_map => ind_map, # deprecated
     :tensor_pure_function => pure,
     :tensor_pure_preimage_function => inv_pure,
   )

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -913,7 +913,7 @@ function tensor_product(
   function pure(as::Tuple)
     return pure(as...)::LieAlgebraModuleElem{C}
   end
-  function pure(as::Vector{LieAlgebraModuleElem})
+  function pure(as::Vector{LieAlgebraModuleElem{C}})
     return pure(as...)::LieAlgebraModuleElem{C}
   end
 

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -373,6 +373,16 @@ function (V::LieAlgebraModule{C})(
   end
 end
 
+function (V::LieAlgebraModule{C})(
+  a::Tuple{T,Vararg{T}}
+) where {T<:LieAlgebraModuleElem{C}} where {C<:RingElement}
+  return V(collect(a))
+end
+
+function (V::LieAlgebraModule{C})(_::Tuple{}) where {C<:RingElement}
+  return V(LieAlgebraModuleElem{C}[])
+end
+
 ###############################################################################
 #
 #   Arithmetic operations
@@ -968,7 +978,7 @@ function exterior_power(V::LieAlgebraModule{C}, k::Int) where {C<:RingElement}
   E_to_T_mat = zero_matrix(coefficient_ring(V), dim_E, dim(T))
   T_to_E_mat = zero_matrix(coefficient_ring(V), dim(T), dim_E)
   for (i, _inds) in enumerate(ind_map), (inds, sgn) in permutations_with_sign(_inds)
-    j = 1 + sum((ind - 1) * dim(V)^(k - 1) for (k, ind) in enumerate(reverse(inds)))
+    j = 1 + sum((ind - 1) * dim(V)^(k - 1) for (k, ind) in enumerate(reverse(inds)); init=0)
     E_to_T_mat[i, j] = sgn//factorial(k)
     T_to_E_mat[j, i] = sgn
   end
@@ -1065,7 +1075,7 @@ function symmetric_power(V::LieAlgebraModule{C}, k::Int) where {C<:RingElement}
   S_to_T_mat = zero_matrix(coefficient_ring(V), dim_S, dim(T))
   T_to_S_mat = zero_matrix(coefficient_ring(V), dim(T), dim_S)
   for (i, _inds) in enumerate(ind_map), inds in permutations(_inds)
-    j = 1 + sum((ind - 1) * dim(V)^(k - 1) for (k, ind) in enumerate(reverse(inds)))
+    j = 1 + sum((ind - 1) * dim(V)^(k - 1) for (k, ind) in enumerate(reverse(inds)); init=0)
     S_to_T_mat[i, j] += 1//factorial(k)
     T_to_S_mat[j, i] = 1
   end

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -596,6 +596,8 @@ function base_modules(V::LieAlgebraModule{C}) where {C<:RingElement}
     return get_attribute(V, :tensor_product)::Vector{LieAlgebraModule{C}}
   elseif is_direct_sum(V)
     return get_attribute(V, :direct_sum)::Vector{LieAlgebraModule{C}}
+  elseif is_tensor_power(V)
+    return [base_module(V) for _ in 1:get_attribute(V, :power)]
   else
     error("Not a direct sum or tensor product module.")
   end

--- a/experimental/LieAlgebras/src/LieAlgebraModuleHom.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModuleHom.jl
@@ -466,12 +466,6 @@ function hom_tensor(
   @req length(Vs) == length(Ws) == length(hs) "Length mismatch"
   @req all(i -> domain(hs[i]) === Vs[i] && codomain(hs[i]) === Ws[i], 1:length(hs)) "Domain/codomain mismatch"
 
-  decompose_V = get_attribute(V, :tensor_generator_decompose_function)::Function
-  pure_W = get_attribute(W, :tensor_pure_function)::Function
-  function map_basis(v)
-    v_decomposed = decompose_V(v)
-    image_as_tuple = Tuple(hi(vi) for (hi, vi) in zip(hs, v_decomposed))
-    return pure_W(image_as_tuple)
-  end
-  return hom(V, W, map(map_basis, basis(V)); check=false)
+  mat = reduce(kronecker_product, [matrix(hi) for hi in hs])
+  return hom(V, W, mat; check=false)
 end

--- a/experimental/LieAlgebras/src/LieAlgebraModuleHom.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModuleHom.jl
@@ -298,6 +298,35 @@ function identity_map(V::LieAlgebraModule)
   return hom(V, V, basis(V); check=false)
 end
 
+@doc raw"""
+    zero_map(V1::LieAlgebraModule, V2::LieAlgebraModule) -> LieAlgebraModuleHom
+    zero_map(V::LieAlgebraModule) -> LieAlgebraModuleHom
+
+Construct the zero map from `V1` to `V2` or from `V` to `V`.
+
+# Examples
+```jldoctest
+julia> L = special_linear_lie_algebra(QQ, 3);
+
+julia> V = standard_module(L)
+Standard module
+  of dimension 3
+over special linear Lie algebra of degree 3 over QQ
+
+julia> zero_map(V)
+Lie algebra module morphism
+  from standard module of dimension 3 over sl_3
+  to   standard module of dimension 3 over sl_3
+```
+"""
+function zero_map(V1::LieAlgebraModule{C}, V2::LieAlgebraModule{C}) where {C<:RingElement}
+  return hom(V1, V2, zero_matrix(coefficient_ring(V2), dim(V1), dim(V2)); check=false)
+end
+
+function zero_map(V::LieAlgebraModule)
+  return zero_map(V, V)
+end
+
 ###############################################################################
 #
 #   Hom constructions

--- a/experimental/LieAlgebras/src/LieAlgebraModuleHom.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModuleHom.jl
@@ -416,11 +416,14 @@ end
 
 @doc raw"""
     hom_direct_sum(V::LieAlgebraModule{C}, W::LieAlgebraModule{C}, hs::Matrix{<:LieAlgebraModuleHom}) -> LieAlgebraModuleHom
+    hom_direct_sum(V::LieAlgebraModule{C}, W::LieAlgebraModule{C}, hs::Vector{<:LieAlgebraModuleHom}) -> LieAlgebraModuleHom
 
 Given modules `V` and `W` which are direct sums with `r` respective `s` summands,  
 say $M = M_1 \oplus \cdots \oplus M_r$, $N = N_1 \oplus \cdots \oplus N_s$, and given a $r \times s$ matrix 
 `hs` of homomorphisms $h_{ij} : V_i \to W_j$, return the homomorphism
 $V \to W$ with $ij$-components $h_{ij}$.
+
+If `hs` is a vector, then it is interpreted as a diagonal matrix.
 """
 function hom_direct_sum(
   V::LieAlgebraModule{C}, W::LieAlgebraModule{C}, hs::Matrix{<:LieAlgebraModuleHom}
@@ -446,6 +449,19 @@ function hom_direct_sum(
     )
   end
   return hom(V, W, map(map_basis, basis(V)); check=false)
+end
+
+function hom_direct_sum(
+  V::LieAlgebraModule{C}, W::LieAlgebraModule{C}, hs::Vector{<:LieAlgebraModuleHom}
+) where {C<:RingElement}
+  @req is_direct_sum(V) "First module must be a direct sum"
+  @req is_direct_sum(W) "Second module must be a direct sum"
+  Vs = base_modules(V)
+  Ws = base_modules(W)
+  @req length(Vs) == length(Ws) == length(hs) "Length mismatch"
+  @req all(i -> domain(hs[i]) === Vs[i] && codomain(hs[i]) === Ws[i], 1:length(hs)) "Domain/codomain mismatch"
+
+  return hom(V, W, diagonal_matrix(matrix.(hs)); check=false)
 end
 
 @doc raw"""

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -57,6 +57,7 @@ import ..Oscar:
   symbols,
   symmetric_power,
   tensor_product,
+  zero_map,
   ⊕,
   ⊗
 

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -36,6 +36,7 @@ import ..Oscar:
   gen,
   gens,
   hom,
+  hom_tensor,
   identity_map,
   ideal,
   image,

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -85,6 +85,7 @@ export exterior_power
 export general_linear_lie_algebra
 export highest_weight_module
 export hom_direct_sum
+export hom_power
 export is_direct_sum
 export is_dual
 export is_exterior_power
@@ -145,6 +146,7 @@ export exterior_power
 export general_linear_lie_algebra
 export highest_weight_module
 export hom_direct_sum
+export hom_power
 export is_direct_sum
 export is_dual
 export is_exterior_power

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -4,6 +4,11 @@ using ..Oscar
 
 import Oscar: GAPWrap, IntegerUnion, MapHeader
 
+import Hecke:
+  canonical_injection, canonical_injections, canonical_projection, canonical_projections # Until https://github.com/thofma/Hecke.jl/pull/1196 is available
+export canonical_injection,
+  canonical_injections, canonical_projection, canonical_projections # Until https://github.com/thofma/Hecke.jl/pull/1196 is available
+
 # not importet in Oscar
 using AbstractAlgebra: CacheDictType, ProductIterator, get_cached!, ordinal_number_string
 
@@ -153,3 +158,6 @@ export symmetric_power
 export tensor_power
 export trivial_module
 export universal_enveloping_algebra
+
+export canonical_injection,
+  canonical_injections, canonical_projection, canonical_projections # Until https://github.com/thofma/Hecke.jl/pull/1196 is available

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -83,6 +83,7 @@ export derived_algebra
 export exterior_power
 export general_linear_lie_algebra
 export highest_weight_module
+export hom_direct_sum
 export is_direct_sum
 export is_dual
 export is_exterior_power
@@ -142,6 +143,7 @@ export derived_algebra
 export exterior_power
 export general_linear_lie_algebra
 export highest_weight_module
+export hom_direct_sum
 export is_direct_sum
 export is_dual
 export is_exterior_power

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -46,6 +46,7 @@ import ..Oscar:
   is_perfect,
   is_simple,
   is_solvable,
+  is_welldefined,
   kernel,
   matrix,
   ngens,

--- a/experimental/LieAlgebras/test/LieAlgebraHom-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraHom-test.jl
@@ -37,6 +37,31 @@
     @test h(ideal(L, [x2, x3, x4])) == sub(L, [x3])
   end
 
+  @testset "Identity and zero map" begin
+    L1 = special_linear_lie_algebra(QQ, 3)
+    L2 = general_linear_lie_algebra(QQ, 3)
+
+    h = identity_map(L1)
+    @test domain(h) == L1
+    @test codomain(h) == L1
+    @test matrix(h) == identity_matrix(QQ, dim(L1))
+    for x in basis(L1)
+      @test h(x) == x
+    end
+    @test image(h) == sub(L1)
+    @test kernel(h) == ideal(L1, [zero(L1)])
+
+    h = zero_map(L1, L2)
+    @test domain(h) == L1
+    @test codomain(h) == L2
+    @test matrix(h) == zero_matrix(QQ, dim(L1), dim(L2))
+    for x in basis(L1)
+      @test h(x) == zero(L2)
+    end
+    @test image(h) == sub(L2, [zero(L2)])
+    @test kernel(h) == ideal(L1)
+  end
+
   @testset "Composition" begin
     L1 = special_linear_lie_algebra(QQ, 2)
     L2 = special_linear_lie_algebra(QQ, 3)
@@ -76,6 +101,8 @@
 
     @test is_isomorphism(identity_map(L1))
     @test identity_map(L1) == inv(identity_map(L1))
+
+    @test !is_isomorphism(zero_map(L1))
   end
 
   @testset "Hum72, Exercise 2.10" begin

--- a/experimental/LieAlgebras/test/LieAlgebraHom-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraHom-test.jl
@@ -7,11 +7,7 @@
     @test domain(h) == L1
     @test codomain(h) == L2
     @test matrix(h) == matrix(QQ, [0 1 0 0; 0 0 1 0; 1 0 0 -1])
-    for x1 in basis(L1)
-      for x2 in basis(L1)
-        @test h(x1 * x2) == h(x1) * h(x2)
-      end
-    end
+    @test is_welldefined(h)
   end
 
   @testset "Image and kernel" begin
@@ -45,6 +41,7 @@
     @test domain(h) == L1
     @test codomain(h) == L1
     @test matrix(h) == identity_matrix(QQ, dim(L1))
+    @test is_welldefined(h)
     for x in basis(L1)
       @test h(x) == x
     end
@@ -55,6 +52,7 @@
     @test domain(h) == L1
     @test codomain(h) == L2
     @test matrix(h) == zero_matrix(QQ, dim(L1), dim(L2))
+    @test is_welldefined(h)
     for x in basis(L1)
       @test h(x) == zero(L2)
     end

--- a/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
@@ -324,26 +324,36 @@ end
     type_V = module_type_bools(V)
 
     for k in 1:3
-      pow_V = exterior_power(V, k)
+      E = exterior_power(V, k)
       @test type_V == module_type_bools(V) # construction of pow_V should not change type of V
-      @test base_module(pow_V) === V
-      @test dim(pow_V) == binomial(dim(V), k)
-      @test length(repr(pow_V)) < 10^4 # outputs tend to be excessively long due to recursion
+      @test base_module(E) === V
+      @test dim(E) == binomial(dim(V), k)
+      @test length(repr(E)) < 10^4 # outputs tend to be excessively long due to recursion
 
-      @test module_type_bools(pow_V) == (false, false, false, false, true, false, false) # exterior_power
+      @test module_type_bools(E) == (false, false, false, false, true, false, false) # exterior_power
 
       if k == 1
         x = L(rand(-10:10, dim(L)))
         a = V(rand(-10:10, dim(V)))
-        @test pow_V([x * a]) == x * pow_V([a])
+        @test E([x * a]) == x * E([a])
       elseif k == 2
         a = V(rand(-10:10, dim(V)))
         b = V(rand(-10:10, dim(V)))
-        @test !iszero(pow_V([a, b]))
-        @test iszero(pow_V([a, b]) + pow_V([b, a]))
-        @test !iszero(pow_V([a, b]) - pow_V([b, a]))
-        @test iszero(pow_V([a, a]))
+        @test !iszero(E([a, b]))
+        @test iszero(E([a, b]) + E([b, a]))
+        @test !iszero(E([a, b]) - E([b, a]))
+        @test iszero(E([a, a]))
       end
+
+      T = get_attribute(E, :embedding_tensor_power)
+      E_to_T = get_attribute(E, :embedding_tensor_power_embedding)
+      T_to_E = get_attribute(E, :embedding_tensor_power_projection)
+      @test T == tensor_power(V, k)
+      @test domain(E_to_T) === E
+      @test codomain(E_to_T) === T
+      @test domain(T_to_E) === T
+      @test codomain(T_to_E) === E
+      @test compose(E_to_T, T_to_E) == identity_map(E)
     end
   end
 
@@ -353,37 +363,47 @@ end
     type_V = module_type_bools(V)
 
     for k in 1:3
-      pow_V = symmetric_power(V, k)
+      S = symmetric_power(V, k)
       @test type_V == module_type_bools(V) # construction of pow_V should not change type of V
-      @test base_module(pow_V) === V
-      @test dim(pow_V) == binomial(dim(V) + k - 1, k)
-      @test length(repr(pow_V)) < 10^4 # outputs tend to be excessively long due to recursion
+      @test base_module(S) === V
+      @test dim(S) == binomial(dim(V) + k - 1, k)
+      @test length(repr(S)) < 10^4 # outputs tend to be excessively long due to recursion
 
-      @test module_type_bools(pow_V) == (false, false, false, false, false, true, false) # symmetric_power
+      @test module_type_bools(S) == (false, false, false, false, false, true, false) # symmetric_power
 
       if k == 1
         x = L(rand(-10:10, dim(L)))
         a = V(rand(-10:10, dim(V)))
-        @test pow_V([x * a]) == x * pow_V([a])
+        @test S([x * a]) == x * S([a])
       elseif k == 2
         a = V(rand(-10:10, dim(V)))
         b = V(rand(-10:10, dim(V)))
-        @test !iszero(pow_V([a, b]))
-        @test !iszero(pow_V([a, b]) + pow_V([b, a]))
-        @test iszero(pow_V([a, b]) - pow_V([b, a]))
-        @test !iszero(pow_V([a, a]))
+        @test !iszero(S([a, b]))
+        @test !iszero(S([a, b]) + S([b, a]))
+        @test iszero(S([a, b]) - S([b, a]))
+        @test !iszero(S([a, a]))
       end
+
+      T = get_attribute(S, :embedding_tensor_power)
+      S_to_T = get_attribute(S, :embedding_tensor_power_embedding)
+      T_to_S = get_attribute(S, :embedding_tensor_power_projection)
+      @test T == tensor_power(V, k)
+      @test domain(S_to_T) === S
+      @test codomain(S_to_T) === T
+      @test domain(T_to_S) === T
+      @test codomain(T_to_S) === S
+      @test compose(S_to_T, T_to_S) == identity_map(S)
     end
   end
 
   @testset "tensor_power" begin
     L = special_orthogonal_lie_algebra(QQ, 4)
     V = standard_module(L)
-    type_V = module_type_bools(V)
+    T = module_type_bools(V)
 
     for k in 1:3
       pow_V = tensor_power(V, k)
-      @test type_V == module_type_bools(V) # construction of pow_V should not change type of V
+      @test T == module_type_bools(V) # construction of pow_V should not change type of V
       @test base_module(pow_V) === V
       @test dim(pow_V) == dim(V)^k
       @test length(repr(pow_V)) < 10^4 # outputs tend to be excessively long due to recursion

--- a/experimental/LieAlgebras/test/LieAlgebraModuleHom-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModuleHom-test.jl
@@ -94,6 +94,27 @@
     ) == identity_map(V)
   end
 
+  @testset "hom_direct_sum" begin
+    L = special_orthogonal_lie_algebra(QQ, 4)
+    V11 = standard_module(L)
+    V12 = dual(standard_module(L))
+    V21 = exterior_power(standard_module(L), 2)
+    V22 = dual(dual(standard_module(L)))
+    V1 = direct_sum(V11, V12)
+    V2 = direct_sum(V21, V22)
+    h11 = hom(V11, V21, [zero(V21) for _ in basis(V11)])
+    h12 = hom(V11, V22, basis(V22))
+    h21 = hom(V12, V21, [zero(V21) for _ in basis(V12)])
+    h22 = hom(V12, V22, [zero(V22) for _ in basis(V12)])
+
+    h = hom_direct_sum(V1, V2, [h11 h12; h21 h22])
+    @test domain(h) == V1
+    @test codomain(h) == V2
+    @test is_welldefined(h)
+    #@test image(h) == image(canonical_injection(V2, 2))
+    #@test kernel(h) == kernel(canonical_injjection(V1, 1))
+  end
+
   @testset "hom_tensor" begin
     L = special_orthogonal_lie_algebra(QQ, 4)
     V11 = standard_module(L)

--- a/experimental/LieAlgebras/test/LieAlgebraModuleHom-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModuleHom-test.jl
@@ -33,6 +33,35 @@
     @test image(h, v6) == h(v6) == v3
   end
 
+  @testset "Identity and zero map" begin
+    L = special_linear_lie_algebra(QQ, 3)
+    stdV = standard_module(L)
+    V1 = symmetric_power(stdV, 3)
+    V2 = exterior_power(stdV, 2)
+
+    h = identity_map(V1)
+    @test domain(h) == V1
+    @test codomain(h) == V1
+    @test matrix(h) == identity_matrix(QQ, dim(V1))
+    @test is_welldefined(h)
+    for v in basis(V1)
+      @test h(v) == v
+    end
+    # @test image(h) == ...
+    # @test kernel(h) == ...
+
+    h = zero_map(V1, V2)
+    @test domain(h) == V1
+    @test codomain(h) == V2
+    @test matrix(h) == zero_matrix(QQ, dim(V1), dim(V2))
+    @test is_welldefined(h)
+    for v in basis(V1)
+      @test h(v) == zero(V2)
+    end
+    # @test image(h) == ...
+    # @test kernel(h) == ...
+  end
+
   @testset "Composition" begin
     L = special_orthogonal_lie_algebra(QQ, 3)
     V1 = standard_module(L)

--- a/experimental/LieAlgebras/test/LieAlgebraModuleHom-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModuleHom-test.jl
@@ -144,7 +144,7 @@
     #@test kernel(h) == kernel(canonical_injjection(V1, 1))
   end
 
-  @testset "hom_tensor" begin
+  @testset "hom_tensor (tensor product)" begin
     L = special_orthogonal_lie_algebra(QQ, 4)
     V11 = standard_module(L)
     V12 = dual(standard_module(L))
@@ -158,6 +158,33 @@
     h = hom_tensor(V1, V2, [h1, h2])
     @test domain(h) == V1
     @test codomain(h) == V2
+    @test is_welldefined(h)
+
+    V11 = standard_module(L)
+    V12 = dual(standard_module(L))
+    V2i = dual(dual(standard_module(L)))
+    V1 = tensor_product(V11, V12)
+    V2 = tensor_power(V2i, 2)
+    h1 = hom(V11, V2i, basis(V2i))
+    h2 = hom(V12, V2i, [zero(V2i) for _ in basis(V12)])
+
+    h = hom_tensor(V1, V2, [h1, h2])
+    @test domain(h) == V1
+    @test codomain(h) == V2
+    @test is_welldefined(h)
+  end
+
+  @testset "hom_tensor (tensor power)" begin
+    L = special_orthogonal_lie_algebra(QQ, 4)
+    Vb = standard_module(L)
+    Wb = dual(dual(standard_module(L)))
+    V = tensor_power(Vb, 3)
+    W = tensor_power(Wb, 3)
+    hb = hom(Vb, Wb, basis(Wb))
+
+    h = hom_tensor(V, W, hb)
+    @test domain(h) == V
+    @test codomain(h) == W
     @test is_welldefined(h)
   end
 end

--- a/experimental/LieAlgebras/test/LieAlgebraModuleHom-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModuleHom-test.jl
@@ -144,7 +144,7 @@
     #@test kernel(h) == kernel(canonical_injjection(V1, 1))
   end
 
-  @testset "hom_tensor (tensor product)" begin
+  @testset "hom_tensor" begin
     L = special_orthogonal_lie_algebra(QQ, 4)
     V11 = standard_module(L)
     V12 = dual(standard_module(L))
@@ -174,17 +174,22 @@
     @test is_welldefined(h)
   end
 
-  @testset "hom_tensor (tensor power)" begin
-    L = special_orthogonal_lie_algebra(QQ, 4)
-    Vb = standard_module(L)
-    Wb = dual(dual(standard_module(L)))
-    V = tensor_power(Vb, 3)
-    W = tensor_power(Wb, 3)
-    hb = hom(Vb, Wb, basis(Wb))
+  @testset "hom_power ($f_power)" for f_power in
+                                      [exterior_power, symmetric_power, tensor_power]
+    for k in 1:3
+      L = special_orthogonal_lie_algebra(QQ, 4)
+      Vb = standard_module(L)
+      Wb = dual(dual(standard_module(L)))
+      V = f_power(Vb, k)
+      W = f_power(Wb, k)
+      hb = hom(Vb, Wb, [2 * b for b in basis(Wb)])
 
-    h = hom_tensor(V, W, hb)
-    @test domain(h) == V
-    @test codomain(h) == W
-    @test is_welldefined(h)
+      h = hom_power(V, W, hb)
+      @test domain(h) == V
+      @test codomain(h) == W
+      @test is_welldefined(h)
+      vs = [Vb(rand(-10:10, dim(Vb))) for _ in 1:k]
+      @test h(V(vs)) == W(hb.(vs))
+    end
   end
 end

--- a/experimental/LieAlgebras/test/LieAlgebraModuleHom-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModuleHom-test.jl
@@ -17,11 +17,7 @@
         0 0 1 0 0 0
       ],
     )
-    for x in basis(L)
-      for v in basis(V1)
-        @test h(x * v) == x * h(v)
-      end
-    end
+    @test is_welldefined(h)
   end
 
   @testset "Image and kernel" begin
@@ -55,6 +51,7 @@
     for x in basis(V1)
       @test h(x) == g(f(x))
     end
+    @test is_welldefined(h)
   end
 
   @testset "Inverses" begin
@@ -69,6 +66,7 @@
 
     h = hom(V, V, [v4, v5, v6, v1, v2, v3])
     @test is_isomorphism(h)
+    @test is_welldefined(inv(h))
     @test h == inv(h)
     @test identity_map(V) == compose(h, inv(h))
     @test identity_map(V) == compose(inv(h), h)
@@ -83,6 +81,9 @@
 
     @test canonical_injections(V) == [canonical_injection(V, i) for i in 1:length(Vs)]
     @test canonical_projections(V) == [canonical_projection(V, i) for i in 1:length(Vs)]
+
+    @test all(is_welldefined, canonical_injections(V))
+    @test all(is_welldefined, canonical_projections(V))
 
     # direct sum universal properties
     for i in 1:length(Vs)

--- a/experimental/LieAlgebras/test/LieAlgebraModuleHom-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModuleHom-test.jl
@@ -93,4 +93,21 @@
       proj * inj for (proj, inj) in zip(canonical_projections(V), canonical_injections(V))
     ) == identity_map(V)
   end
+
+  @testset "hom_tensor" begin
+    L = special_orthogonal_lie_algebra(QQ, 4)
+    V11 = standard_module(L)
+    V12 = dual(standard_module(L))
+    V21 = dual(dual(standard_module(L)))
+    V22 = exterior_power(standard_module(L), 2)
+    V1 = tensor_product(V11, V12)
+    V2 = tensor_product(V21, V22)
+    h1 = hom(V11, V21, basis(V21))
+    h2 = hom(V12, V22, [zero(V22) for _ in basis(V12)])
+
+    h = hom_tensor(V1, V2, [h1, h2])
+    @test domain(h) == V1
+    @test codomain(h) == V2
+    @test is_welldefined(h)
+  end
 end

--- a/experimental/LieAlgebras/test/LieAlgebraModuleHom-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModuleHom-test.jl
@@ -73,4 +73,23 @@
     @test identity_map(V) == compose(h, inv(h))
     @test identity_map(V) == compose(inv(h), h)
   end
+
+  @testset "Direct sum constructions" begin
+    L = special_orthogonal_lie_algebra(QQ, 4)
+    Vs = [
+      standard_module(L), dual(standard_module(L)), exterior_power(standard_module(L), 2)
+    ]
+    V = direct_sum(Vs...)
+
+    @test canonical_injections(V) == [canonical_injection(V, i) for i in 1:length(Vs)]
+    @test canonical_projections(V) == [canonical_projection(V, i) for i in 1:length(Vs)]
+
+    # direct sum universal properties
+    for i in 1:length(Vs)
+      @test canonical_injection(V, i) * canonical_projection(V, i) == identity_map(Vs[i])
+    end
+    @test sum(
+      proj * inj for (proj, inj) in zip(canonical_projections(V), canonical_injections(V))
+    ) == identity_map(V)
+  end
 end


### PR DESCRIPTION
~~This builds upon https://github.com/oscar-system/Oscar.jl/pull/2644 and thus includes that PR. Once https://github.com/oscar-system/Oscar.jl/pull/2644 gets merged, I will rebase this PR.~~

Introduces new constructions for Lie algebra module homs:

- [x] injections/projections for direct sums
- [x] `hom_tensor`
- [x] `hom_direct_sum`
- [x] lift hom $V \to W$ to $T^k V \to T^k W$
- [x] lift hom $V \to W$ to $\bigwedge^k V \to \bigwedge^k W$
- [x] lift hom $V \to W$ to $S^k V \to S^k W$

While doing that, refactor the constructions of the modules and put more helpful stuff in attribute storage:

- [x] direct sum
- [x] tensor product
- [x] tensor power
- [x] exterior power
- [x] symmetric power

More changes:
- [x] add `is_welldefined` to be able to check that even if using `check=false` in the `hom` constructor
- [x] add `zero_map`
- [x] change the internals of modules to use right multiplication with a matrix as the action

Missing: 
- [ ] Handle 0-th powers