### PR TITLE
Make `check` as a keyword argument

### DIFF
--- a/src/Groups/abelian_aut.jl
+++ b/src/Groups/abelian_aut.jl
@@ -377,7 +377,7 @@ By default, the function checks whether `i` is injective and whether `i`
 is a torsion quadratic module morphism. One can disable these checks
 by setting `check = false`.
 """
-function restrict_automorphism_group(G::AutomorphismGroup{TorQuadModule}, i::TorQuadModuleMor, check::Bool = true)
+function restrict_automorphism_group(G::AutomorphismGroup{TorQuadModule}, i::TorQuadModuleMor; check::Bool = true)
 
   if check
     @req is_injective(i) "i must be an injection"

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -366,6 +366,7 @@ end
 
 # Deprecated after 0.13.0
 @deprecate fan(v::NormalToricVarietyType) polyhedral_fan(v)
+@deprecate restrict_automorphism_group(G::AutomorphismGroup{TorQuadModule}, i::TorQuadModuleMor, check::Bool) restrict_automorphism_group(G, i; check)
 
 # Polyhedral object wrappers now require a parent field
 function Cone{T}(obj::Polymake.BigObject) where T<:scalar_types


### PR DESCRIPTION
It should have been a semicolon since the implementation of the code, but looks like I missed it.