### PR TITLE
Fix dim for affine schemes (#2369)

### DIFF
--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
@@ -391,12 +391,10 @@ dim(X::AbsSpec)
 end
 
 @attr function dim(X::AbsSpec{<:Ring, <:MPolyQuoLocRing{<:Any,<:Any,<:MPolyRing,<:MPolyRingElem, <:MPolyPowersOfElement}})
-  println("QuoLoc PowersOfElement")
   return dim(closure(X))
 end
 
-@attr function dim(X::AbsSpec{<:Ring, <:MPolyQuoLocRing{<:Any,<:Any,<:MPolyRing,<:MPolyRingElem, <:MPolyComplementOfPrimeIdeal}})
-  println("QuoLoc ComplementOfPrimeIdeal")
+@attr function dim(X::AbsSpec{<:Ring, <:MPolyQuoLocRing{<:Any,<:Any,<:MPolyRing,<:MPolyRingElem, <:Union{MPolyComplementOfPrimeIdeal, MPolyComplementOfKPointIdeal}}})
   # Spec (R / I)_P
   R = OO(X)
   P = prime_ideal(inverted_set(R))
@@ -409,13 +407,11 @@ end
 end
 
 @attr function dim(X::AbsSpec{<:Ring, <:MPolyLocRing{<:Any,<:Any,<:MPolyRing,<:MPolyRingElem, <:MPolyPowersOfElement}})
-  println("Loc PowersOfElement")
   # zariski open subset of A^n
   return dim(closure(X))
 end
 
-@attr function dim(X::AbsSpec{<:Ring, <:MPolyLocRing{<:Any,<:Any,<:MPolyRing,<:MPolyRingElem, <:MPolyComplementOfPrimeIdeal}})
-  println("Loc ComplementOfPrimeIdeal")
+@attr function dim(X::AbsSpec{<:Ring, <:MPolyLocRing{<:Any,<:Any,<:MPolyRing,<:MPolyRingElem, <:Union{MPolyComplementOfPrimeIdeal, MPolyComplementOfKPointIdeal}}})
   P = prime_ideal(inverted_set(OO(X)))
   return codim(P)
 end

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
@@ -387,13 +387,37 @@ julia> dim(Y) # one dimension comes from ZZ and two from x1 and x2
 dim(X::AbsSpec)
 
 @attr function dim(X::AbsSpec{<:Ring, <:MPolyQuoLocRing})
-  return dim(saturated_ideal(modulus(OO(X))))
+  error("Not implemented")
+end
+
+@attr function dim(X::AbsSpec{<:Ring, <:MPolyQuoLocRing{<:Any,<:Any,<:MPolyRing,<:MPolyRingElem, <:MPolyPowersOfElement}})
+  println("QuoLoc PowersOfElement")
+  return dim(closure(X))
+end
+
+@attr function dim(X::AbsSpec{<:Ring, <:MPolyQuoLocRing{<:Any,<:Any,<:MPolyRing,<:MPolyRingElem, <:MPolyComplementOfPrimeIdeal}})
+  println("QuoLoc ComplementOfPrimeIdeal")
+  # Spec (R / I)_P
+  R = OO(X)
+  P = prime_ideal(inverted_set(R))
+  I = saturated_ideal(modulus(R))
+  return dim(I) - dim(P)
 end
 
 @attr function dim(X::AbsSpec{<:Ring, <:MPolyLocRing})
-  # the following line is supposed to refer the problem to the
-  # algebra side of the problem
-  return dim(ideal(ambient_coordinate_ring(X), [zero(ambient_coordinate_ring(X))]))
+  error("Not implemented")
+end
+
+@attr function dim(X::AbsSpec{<:Ring, <:MPolyLocRing{<:Any,<:Any,<:MPolyRing,<:MPolyRingElem, <:MPolyPowersOfElement}})
+  println("Loc PowersOfElement")
+  # zariski open subset of A^n
+  return dim(closure(X))
+end
+
+@attr function dim(X::AbsSpec{<:Ring, <:MPolyLocRing{<:Any,<:Any,<:MPolyRing,<:MPolyRingElem, <:MPolyComplementOfPrimeIdeal}})
+  println("Loc ComplementOfPrimeIdeal")
+  P = prime_ideal(inverted_set(OO(X)))
+  return codim(P)
 end
 
 @attr function dim(X::AbsSpec{<:Ring, <:MPolyRing})
@@ -403,7 +427,6 @@ end
 @attr function dim(X::AbsSpec{<:Ring, <:MPolyQuoRing})
   return dim(modulus(OO(X)))
 end
-
 
 @doc raw"""
     codim(X::AbsSpec)

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -1311,7 +1311,12 @@ julia> codim(I)
 2
 ```
 """
-codim(I::MPolyIdeal) = nvars(base_ring(I)) - dim(I)
+codim(I::MPolyIdeal{T}) where {T<:MPolyElem{<:FieldElem}}= nvars(base_ring(I)) - dim(I)
+codim(I::MPolyIdeal) = dim(base_ring(I)) - dim(I)
+
+# Some fixes which were necessary for the above
+dim(R::MPolyRing) = dim(base_ring(R)) + nvars(R)
+dim(R::ZZRing) = 1
 
 
 ################################################################################

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -214,7 +214,7 @@ mutable struct MPolyComplementOfPrimeIdeal{
 
   function MPolyComplementOfPrimeIdeal(
       P::MPolyIdeal{RingElemType}; 
-      check::Bool=false
+      check::Bool=true
     ) where {RingElemType}
     R = base_ring(P)
     check && (is_prime(P) || error("the ideal $P is not prime"))
@@ -378,7 +378,7 @@ Complement
   in multivariate polynomial ring in 3 variables over QQ
 ```
 """
-complement_of_prime_ideal(P::MPolyIdeal; check::Bool=false) = MPolyComplementOfPrimeIdeal(P; check)
+complement_of_prime_ideal(P::MPolyIdeal; check::Bool=true) = MPolyComplementOfPrimeIdeal(P; check)
 
 @doc raw"""  
     powers_of_element(f::MPolyRingElem)
@@ -1178,7 +1178,7 @@ function Localization(
 end
 
 ### additional constructors
-MPolyLocRing(R::RingType, P::MPolyIdeal{RingElemType}) where {RingType, RingElemType} = MPolyLocRing(R, MPolyComplementOfPrimeIdeal(P))
+MPolyLocRing(R::RingType, P::MPolyIdeal{RingElemType}; check::Bool=true) where {RingType, RingElemType} = MPolyLocRing(R, MPolyComplementOfPrimeIdeal(P); check)
 
 Localization(R::MPolyRing, v::Vector{T}) where {T<:MPolyRingElem} = Localization(MPolyPowersOfElement(R, v))
 

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -336,7 +336,9 @@ end
 # A function with this name exists with a method for 
 # MPolyComplementOfPrimeIdeal. In order to treat them in 
 # parallel, we introduce the analogous method here. 
-function prime_ideal(S::MPolyComplementOfKPointIdeal) 
+prime_ideal(S::MPolyComplementOfKPointIdeal) = maximal_ideal(S)
+
+function maximal_ideal(S::MPolyComplementOfKPointIdeal) 
   if !isdefined(S, :m)
     R = ambient_ring(S)
     x = gens(R)

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -345,7 +345,7 @@ function prime_ideal(S::MPolyComplementOfKPointIdeal)
     n = ngens(R)
     m = ideal(R, [x[i]-a for (i, a) in enumerate(point_coordinates(S))])
     set_attribute!(m, :is_prime=>true)
-    set_attribute!(m, :is_maximal=>iszero(dim(kk)))
+    kk isa Field && set_attribute!(m, :is_maximal=>true)
     set_attribute!(m, :dim=>dim(coefficient_ring(ambient_ring(S))))
     S.m = m
   end

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -332,6 +332,14 @@ mutable struct MPolyComplementOfKPointIdeal{
   end
 end
 
+# the name matches MPolyComplementOfPrimeIdeal
+function prime_ideal(S::MPolyComplementOfKPointIdeal) 
+  R = ambient_ring(S)
+  x = gens(R)
+  n = ngens(R)
+  return ideal(R, [x[i]-S.a[i] for i in 1:n])
+end
+
 @doc raw"""  
     complement_of_point_ideal(R::MPolyRing, a::Vector)
 
@@ -355,13 +363,13 @@ Complement
 complement_of_point_ideal(R::MPolyRing, a::Vector) = MPolyComplementOfKPointIdeal(R, a)
 
 @doc raw"""
-    complement_of_prime_ideal(P::MPolyIdeal; check::Bool=false)
+    complement_of_prime_ideal(P::MPolyIdeal; check::Bool=true)
 
 Given a prime ideal ``P`` of a polynomial ring ``R``, say,
 return the multiplicatively closed subset ``R\setminus P.``
 
 !!! note
-    If  `check` is set to `true`, the function checks whether ``P`` is indeed a prime ideal. 
+    Since  `check` is set to `true`, the function checks whether ``P`` is indeed a prime ideal. 
 
     This may take some time.
 

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -336,21 +336,29 @@ end
 # A function with this name exists with a method for 
 # MPolyComplementOfPrimeIdeal. In order to treat them in 
 # parallel, we introduce the analogous method here. 
-prime_ideal(S::MPolyComplementOfKPointIdeal) = maximal_ideal(S)
-
-function maximal_ideal(S::MPolyComplementOfKPointIdeal) 
+function prime_ideal(S::MPolyComplementOfKPointIdeal) 
+  kk = coefficient_ring(ambient_ring(S))
+  # TODO: Test whether kk is an integral domain
   if !isdefined(S, :m)
     R = ambient_ring(S)
     x = gens(R)
     n = ngens(R)
     m = ideal(R, [x[i]-a for (i, a) in enumerate(point_coordinates(S))])
     set_attribute!(m, :is_prime=>true)
-    set_attribute!(m, :is_maximal=>true)
-    set_attribute!(m, :dim=>0)
+    set_attribute!(m, :is_maximal=>iszero(dim(kk)))
+    set_attribute!(m, :dim=>dim(coefficient_ring(ambient_ring(S))))
     S.m = m
   end
   return S.m
 end
+
+function is_prime(P::Hecke.ZZIdl) 
+  return is_prime(first(gens(P)))
+end
+
+dim(kk::Field) = 0
+
+maximal_ideal(S::MPolyComplementOfKPointIdeal{<:Field}) = prime_ideal(S)
 
 @doc raw"""  
     complement_of_point_ideal(R::MPolyRing, a::Vector)

--- a/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
+++ b/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
@@ -141,6 +141,24 @@ end
   @test dim(Spec(W)) == 1
 end
 
+@testset "dimensions of affine schemes over the integers" begin
+  kk, _ = quo(ZZ, 4)
+  R, (x,y,z) = kk["x", "y", "z"]
+  A3 = Spec(R)
+  X = subscheme(A3, x*y)
+  U = hypersurface_complement(A3, z)
+  @test dim(A3) == 3
+  @test dim(U) == 3
+  @test codim(A3) == 0
+  @test codim(X) == 1
+  disjoint_plane_and_line = subscheme(A3, [x*(x - 1), x*y])
+  line = hypersurface_complement(disjoint_plane_and_line, x)
+  plane = hypersurface_complement(disjoint_plane_and_line, y)
+  @test dim(line) == 1
+  @test dim(plane) == 2
+  # The other tests from above do not run, because the singular side does not digest the rings.
+end
+
 
 @testset "smoothness tests" begin
   R, (x,y,z) = QQ["x", "y", "z"]

--- a/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
+++ b/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
@@ -77,11 +77,22 @@
   @test !issubset(A3, X)
   @test issubset(A3,A3)
   @test issubset(intersect(A3,A3), A3)
+  
+  # Tests for dimension when localizing with respect to either a prime
+  # ideal or powers of an element
   @test dim(A3) == 3
   @test dim(U) == 3
   @test dim(X) == 2
   @test codim(A3) == 0
   @test codim(X) == 1
+  disjoint_plane_and_line = subscheme(A3, [x*(x - 1), x*y])
+  line = hypersurface_complement(disjoint_plane_and_line, x)
+  plane = hypersurface_complement(disjoint_plane_and_line, y)
+  @test dim(line) == 1
+  @test dim(plane) == 2
+  A3_localized_along_line = Spec(Localization(R, complement_of_prime_ideal(ideal(R, [x, y])))[1])
+  @test dim(A3_localized_along_line) == 2
+  @test dim(standard_spec(A3_localized_along_line)) == 2
 end
 
 @testset "smoothness tests" begin

--- a/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
+++ b/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
@@ -81,9 +81,11 @@ end
 
 # Tests for dimension when localizing with respect to either a prime
 # ideal or powers of an element
-@testset "affine schemes" begin
+@testset "dimensions of affine schemes" begin
   R, (x,y,z) = QQ["x", "y", "z"]
   A3 = Spec(R)
+  X = subscheme(A3, x*y)
+  U = hypersurface_complement(A3, z)
   @test dim(A3) == 3
   @test dim(U) == 3
   @test dim(X) == 2
@@ -97,6 +99,34 @@ end
   A3_localized_along_line = Spec(Localization(R, complement_of_prime_ideal(ideal(R, [x, y])))[1])
   @test dim(A3_localized_along_line) == 2
   @test dim(standard_spec(A3_localized_along_line)) == 2
+end
+
+@testset "dimensions of affine schemes over the integers" begin
+  R, (x,y,z) = ZZ["x", "y", "z"]
+  A3 = Spec(R)
+  X = subscheme(A3, x*y)
+  U = hypersurface_complement(A3, z)
+  @test dim(A3) == 4
+  @test dim(U) == 4
+  @test codim(A3) == 0
+  @test codim(X) == 1
+  disjoint_plane_and_line = subscheme(A3, [x*(x - 1), x*y])
+  line = hypersurface_complement(disjoint_plane_and_line, x)
+  plane = hypersurface_complement(disjoint_plane_and_line, y)
+  @test dim(line) == 2
+  @test dim(plane) == 3
+  A3_localized_along_line = Spec(Localization(R, complement_of_prime_ideal(ideal(R, [x, y])))[1])
+  @test dim(A3_localized_along_line) == 2
+  @test dim(standard_spec(A3_localized_along_line)) == 2
+  P = ideal(R, R(5))
+  @test is_prime(P)
+  S = complement_of_prime_ideal(P)
+  Y = Spec(R, S)
+  @test dim(Y) == 1
+  Q = ideal(R, R.([7, x, y, z]))
+  S = complement_of_prime_ideal(Q)
+  Z = Spec(R, S)
+  @test dim(Z) == 4
 end
 
 

--- a/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
+++ b/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
@@ -99,6 +99,12 @@ end
   A3_localized_along_line = Spec(Localization(R, complement_of_prime_ideal(ideal(R, [x, y])))[1])
   @test dim(A3_localized_along_line) == 2
   @test dim(standard_spec(A3_localized_along_line)) == 2
+  
+  S = complement_of_point_ideal(R, [1, 1, 1])
+  I = ideal(R, [x-1, y-1])*ideal(R, z)
+  L, _ = localization(R, S)
+  W, _ = quo(L, L(I))
+  @test dim(Spec(W)) == 1
 end
 
 @testset "dimensions of affine schemes over the integers" begin
@@ -127,6 +133,12 @@ end
   S = complement_of_prime_ideal(Q)
   Z = Spec(R, S)
   @test dim(Z) == 4
+
+  S = complement_of_point_ideal(R, [1, 1, 1])
+  I = ideal(R, [x-1, y-1])*ideal(R, z)
+  L, _ = localization(R, S)
+  W, _ = quo(L, L(I))
+  @test dim(Spec(W)) == 1
 end
 
 

--- a/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
+++ b/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
@@ -141,7 +141,7 @@ end
   @test dim(Spec(W)) == 1
 end
 
-@testset "dimensions of affine schemes over the integers" begin
+@testset "dimensions of affine schemes over quotients of the integers" begin
   kk, _ = quo(ZZ, 4)
   R, (x,y,z) = kk["x", "y", "z"]
   A3 = Spec(R)

--- a/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
+++ b/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
@@ -77,9 +77,13 @@
   @test !issubset(A3, X)
   @test issubset(A3,A3)
   @test issubset(intersect(A3,A3), A3)
-  
-  # Tests for dimension when localizing with respect to either a prime
-  # ideal or powers of an element
+end
+
+# Tests for dimension when localizing with respect to either a prime
+# ideal or powers of an element
+@testset "affine schemes" begin
+  R, (x,y,z) = QQ["x", "y", "z"]
+  A3 = Spec(R)
   @test dim(A3) == 3
   @test dim(U) == 3
   @test dim(X) == 2
@@ -94,6 +98,7 @@
   @test dim(A3_localized_along_line) == 2
   @test dim(standard_spec(A3_localized_along_line)) == 2
 end
+
 
 @testset "smoothness tests" begin
   R, (x,y,z) = QQ["x", "y", "z"]

--- a/test/Rings/MPolyQuo.jl
+++ b/test/Rings/MPolyQuo.jl
@@ -180,7 +180,7 @@ end
   Al, _ = quo(Rl, Il)
   @test modulus(Rl) == ideal(Rl,[zero(Rl)])
   @test modulus(Al) == Il
-  U2=MPolyComplementOfPrimeIdeal(ideal(R,[x^2+1,y^2+1,z]))
+  U2=MPolyComplementOfPrimeIdeal(ideal(R,[x^2+1,y-x,z]))
   Rl2,_ = Localization(R,U2)
   Il2 = Rl2(I)
   Al2,_ = quo(Rl2,Il2)


### PR DESCRIPTION
Implemented dimension for localizations along

  * MPolyPowersOfElement,
  * MPolyComplementOfPrimeIdeal, and
  * MPolyComplementOfKPointIdeal

Not implemented for other localizations.
Enabled check for primeness in creating localized rings.
@HechtiDerLachs 