### PR TITLE
More polish for elliptic surfaces

### DIFF
--- a/experimental/Schemes/elliptic_surface.jl
+++ b/experimental/Schemes/elliptic_surface.jl
@@ -458,16 +458,17 @@ This triggers the computation of the `underlying_scheme` of ``X``
 as a blowup from its Weierstrass model. It may take a few minutes.
 """
 function weierstrass_contraction(X::EllipticSurface)
-  if isdefined(E, :blowup)
-    return E.Y, E.blowup
+  Y = X
+  if isdefined(Y, :blowup)
+    return Y.blowup
   end
-  S, inc_S = weierstrass_model(E)
-  Crefined = _separate_singularities!(E)
+  S, inc_S = weierstrass_model(Y)
+  Crefined = _separate_singularities!(Y)
   # Blow up singular points (one at a time) until smooth
   # and compute the strict transforms of the `divisors`
   # collect the exceptional divisors
   # blowup ambient spaces: X0 → X   ⊂
-  # blowup pi: (K3 = Y0)  → (S singular weierstrass model)
+  # blowup pi: Y  → (S singular weierstrass model)
   #
   # initialization for the while loop
   X0 = codomain(inc_S)
@@ -547,26 +548,26 @@ function weierstrass_contraction(X::EllipticSurface)
     set_attribute!(X0, :is_reduced=>true)
     set_attribute!(X0, :is_integral=>true)
   end
-  E.Y = Y0
-  E.blowups = projectionsY
+  Y.Y = Y0
+  Y.blowups = projectionsY
 
-  # We need to rewrap the last maps so that the domain is really E
+  # We need to rewrap the last maps so that the domain is really Y
   last_pr = pop!(projectionsY)
-  last_pr_wrap = CoveredSchemeMorphism(E, codomain(last_pr), covering_morphism(last_pr))
+  last_pr_wrap = CoveredSchemeMorphism(Y, codomain(last_pr), covering_morphism(last_pr))
   push!(projectionsY, last_pr_wrap)
-  E.ambient_blowups = projectionsX
+  Y.ambient_blowups = projectionsX
 
-  E.ambient_exceptionals = ambient_exceptionals
+  Y.ambient_exceptionals = ambient_exceptionals
   piY = CompositeCoveredSchemeMorphism(reverse(projectionsY))
-  E.blowup = piY
+  Y.blowup = piY
 
-  inc_Y0_wrap = CoveredClosedEmbedding(E, codomain(inc_Y0), covering_morphism(inc_Y0), check=false)
-  E.inc_Y = inc_Y0_wrap
+  inc_Y0_wrap = CoveredClosedEmbedding(Y, codomain(inc_Y0), covering_morphism(inc_Y0), check=false)
+  Y.inc_Y = inc_Y0_wrap
 
-  set_attribute!(E, :is_irreducible=> true)
-  set_attribute!(E, :is_reduced=>true)
-  set_attribute!(E, :is_integral=>true)
-  return E, piY
+  set_attribute!(Y, :is_irreducible=> true)
+  set_attribute!(Y, :is_reduced=>true)
+  set_attribute!(Y, :is_integral=>true)
+  return piY
 end
 
 #  global divisors0 = [strict_transform(pr_X1, e) for e in divisors0]
@@ -1635,7 +1636,7 @@ function _elliptic_parameter_conversion(X::EllipticSurface, u::VarietyFunctionFi
 
     u_num = R_to_kkt_frac_XY(numerator(u_loc))
     u_den = R_to_kkt_frac_XY(denominator(u_loc))
-    @assert degree(u_num, 2) == 1 && degree(u_num, 1) == 0 "numerator does not have the correct degree"
+    @assert degree(u_num, 2) == 1 && degree(u_num, 1) <= 1 "numerator does not have the correct degree"
     @assert degree(u_den, 1) == 1 && degree(u_den, 2) == 0 "denominator does not have the correct degree"
 
     tmp = my_const(coeff(u_num, [xx, yy], [0, 1]))

--- a/experimental/Schemes/elliptic_surface.jl
+++ b/experimental/Schemes/elliptic_surface.jl
@@ -1,4 +1,4 @@
-export elliptic_surface, trivial_lattice, weierstrass_model, weierstrass_chart, algebraic_lattice, zero_section, section, weierstrass_contraction, fiber_components, generic_fiber, reducible_fibers, fibration_type, mordell_weil_lattice, elliptic_parameter, set_mordell_weil_basis!, EllipticSurface, weierstrass_chart
+export elliptic_surface, trivial_lattice, weierstrass_model, weierstrass_chart, algebraic_lattice, zero_section, section, weierstrass_contraction, fiber_components, generic_fiber, reducible_fibers, fibration_type, mordell_weil_lattice, elliptic_parameter, set_mordell_weil_basis!, EllipticSurface, weierstrass_chart, transform_to_weierstrass
 
 @doc raw"""
     EllipticSurface{BaseField<:Field, BaseCurveFieldType} <: AbsCoveredScheme{BaseField}

--- a/experimental/Schemes/elliptic_surface.jl
+++ b/experimental/Schemes/elliptic_surface.jl
@@ -476,7 +476,7 @@ function weierstrass_contraction(X::EllipticSurface)
   inc_Y0 = inc_S
 
 
-  ambient_exceptionals = EffectiveCartierDivisor{typeof(X0)}[]
+  ambient_exceptionals = EffectiveCartierDivisor[]
   varnames = [:a,:b,:c,:d,:e,:f,:g,:h,:i,:j,:k,:l,:m,:n,:o,:p,:q,:r,:u,:v,:w]
   projectionsX = BlowupMorphism[]
   projectionsY = AbsCoveredSchemeMorphism[]
@@ -527,7 +527,7 @@ function weierstrass_contraction(X::EllipticSurface)
 
     @vprint :EllipticSurface 2 "computing strict transforms\n"
     # compute the exceptional divisors
-    ambient_exceptionals = [strict_transform(pr_X1, e) for e in ambient_exceptionals]
+    ambient_exceptionals = EffectiveCartierDivisor[strict_transform(pr_X1, e) for e in ambient_exceptionals]
     # move the divisors coming originally from S up to the next chart
     push!(ambient_exceptionals, E1)
 

--- a/test/AlgebraicGeometry/Schemes/elliptic_surface.jl
+++ b/test/AlgebraicGeometry/Schemes/elliptic_surface.jl
@@ -72,8 +72,8 @@
     ff = QQFieldElem[9, 4, 0, 0, 0, 0, 0, 0, 0, 0, -2, -1, 0, 0, 0, -1]
     @test det(algebraic_lattice(X)[3])==-1183
     @test length(Oscar.mordell_weil_torsion(X)) == 0 # no torsion points
-    u = elliptic_parameter(X, ff)
-    two_neighbor_step(X, ff)
+    # u = elliptic_parameter(X, ff)
+    g, phi = two_neighbor_step(X, ff)
   end
 end
 

--- a/test/AlgebraicGeometry/Schemes/elliptic_surface.jl
+++ b/test/AlgebraicGeometry/Schemes/elliptic_surface.jl
@@ -17,7 +17,7 @@
   (4*t^4 + 5*t^3 + 5*t^2 + 6*t + 13,  9*t^6 + 21*t^5 + 17*t^4 + 12*t^2 + 3*t + 6)]]
   S = elliptic_surface(E, 2, mwl_basis)
   weierstrass_model(S)
-  relatively_minimal_model(S)
+  weierstrass_contraction(S)
 
   E = EllipticCurve(kP1, [0,0,0,1,t^10])
   X = elliptic_surface(E, 2)
@@ -52,7 +52,7 @@
   Qtf = fraction_field(Qt)
   E = EllipticCurve(Qtf, [0,0,0,0,t^5*(t-1)^2])
   X3 = elliptic_surface(E, 2)
-  relatively_minimal_model(X3)
+  weierstrass_contraction(X3)
   trivial_lattice(X3)
   =#
 
@@ -72,7 +72,8 @@
     ff = QQFieldElem[9, 4, 0, 0, 0, 0, 0, 0, 0, 0, -2, -1, 0, 0, 0, -1]
     @test det(algebraic_lattice(X)[3])==-1183
     @test length(Oscar.mordell_weil_torsion(X)) == 0 # no torsion points
-    elliptic_parameter(X, ff)
+    u = elliptic_parameter(X, ff)
+    two_neighbor_step(X, ff)
   end
 end
 

--- a/test/AlgebraicGeometry/Schemes/elliptic_surface.jl
+++ b/test/AlgebraicGeometry/Schemes/elliptic_surface.jl
@@ -105,3 +105,32 @@ end
   @test f_trans == x^3 + (-3//8*t^8 + 49//128)//t^16*x^2 + 7//8//t^8*x*y + (-1//4*t^24 + 9//256*t^16 - 147//2048*t^8 + 2401//65536)//t^32*x - y^2 + (5//16*t^16 - 21//128*t^8 + 343//2048)//t^24*y
 end
 
+
+#=
+# These tests are disabled, because they take too long. But one can run them if in doubt.
+@testset "two neighbor steps" begin
+  K = GF(7)
+  Kt, t = polynomial_ring(K, :t)
+  Ktf = fraction_field(Kt)
+  E = EllipticCurve(Ktf, [0, -t^3, 0, t^3, 0])
+  P = E([t^3, t^3])
+  X2 = elliptic_surface(E, 2, [P]);
+  KX2 = function_field(X2)
+  U = weierstrass_chart(X2)
+  (xx, yy, tt) = ambient_coordinates(U)
+  u4 = KX2(yy, xx*tt)
+  u5 = KX2(yy + tt^3, xx*tt - tt^4)
+  u6 = KX2(yy + tt^3, xx - tt^3)
+  fibers_in_X2 = [QQ.(vec(collect(i))) for i in [
+                                                 [4   2   0   0   0   0   0   0   0   -4   -4   -8   -7   -6   -5   -4   -3   -2   -1   0],
+                                                 [1   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0],
+                                                 [5   2   -2   -3   -4   -3   -2   -1   -2   -5   -4   -8   -7   -6   -5   -4   -3   -2   -1   0],
+                                                 [4   2   -2   -4   -6   -9//2   -3   -3//2   -7//2   -3   -5//2   -5   -9//2   -4   -7//2   -3   -5//2   -2   -3//2   0],
+                                                 [2   1   -1   -2   -3   -2   -1   0   -2   -1   -1   -2   -2   -2   -2   -2   -2   -1   0   1],
+                                                 [2   1   0   0   0   0   0   0   0   -2   -2   -4   -4   -4   -4   -3   -2   -1   0   1]
+                                                ]]
+  g4,_ = two_neighbor_step(X2, fibers_in_X2[4])  # this should be the 2-torsion case
+  g5,_ = two_neighbor_step(X2, fibers_in_X2[5])  # the non-torsion case
+  g6,_ = two_neighbor_step(X2, fibers_in_X2[6])  # the non-torsion case
+end
+=#


### PR DESCRIPTION
This replaces `relatively_minimal_model(X::EllipticSurface)` by `weierstrass_contraction(X::EllipticSurface)` 

@HechtiDerLachs  `two_neighbor_step(X, ff) ` is still buggy.  See the added line in the test file which fails. 
Kumar in his paper assumes that `a(t)` and `b(t)` are elemens of the function field k(t). You seem to assume that they are polynomials, which is not true in general. 
Probably the other cases of `_elliptic_parameter_conversion` are affected too. 
Please fix.



