### PR TITLE
Revert "CI: use buildpkg@v1"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
       - name: "Build package"
-        uses: julia-actions/julia-buildpkg@v1
+        uses: julia-actions/julia-buildpkg@latest
       - name: "limit OpenMP threads"
         if: runner.os == 'macOS'
         # restrict number of openMP threads on macOS due to oversubscription
@@ -95,7 +95,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
       - name: "Build package"
-        uses: julia-actions/julia-buildpkg@v1
+        uses: julia-actions/julia-buildpkg@latest
       - name: "limit OpenMP threads"
         if: runner.os == 'macOS'
         # restrict number of openMP threads on macOS due to oversubscription

--- a/.github/workflows/Docu.yml
+++ b/.github/workflows/Docu.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           version: '1.9'
       - name: Build package
-        uses: julia-actions/julia-buildpkg@v1
+        uses: julia-actions/julia-buildpkg@latest
       - name: Install dependencies
         run: julia --project=. --color=yes -e 'using Oscar; Oscar.doc_init(; path="docs/")'
       - name: Build and deploy


### PR DESCRIPTION
Reverts oscar-system/Oscar.jl#2770.
The issue to be circumvented by this is now solved.