### PR TITLE
Add filter to `convention(::TropicalSemiring)` doctest

### DIFF
--- a/src/TropicalGeometry/semiring.jl
+++ b/src/TropicalGeometry/semiring.jl
@@ -181,7 +181,7 @@ Return `min` if `T` is the min tropical semiring,
 return `max` if `T` is the max tropical semiring.
 
 # Examples
-```jldoctest
+```jldoctest; filter = r"\(generic function with [0-9]+ methods\)"
 julia> T = TropicalSemiring(min)
 Tropical semiring (min)
 


### PR DESCRIPTION
A changing number of methods for `max` and `min` should not break the doctest.