### PR TITLE
Add `present_as_cokernel(::FreeMod)` dummy method

### DIFF
--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -4470,6 +4470,7 @@ end
 
 function present_as_cokernel(F::FreeMod, task::Symbol = :none)
   presentation_module, inverse_isomorphism = quo(F, [zero(F)])
+  isomorphism = hom(presentation_module, F, gens(F))
 
   if task == :none
     return presentation_module

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -4468,6 +4468,22 @@ function present_as_cokernel(SQ::SubquoModule, task::Symbol = :none)
   return presentation_module, isomorphism
 end
 
+function present_as_cokernel(F::FreeMod, task::Symbol = :none)
+  presentation_module, inverse_isomorphism = quo(F, [zero(F)])
+
+  if task == :none
+    return presentation_module
+  end
+
+  if task == :cache_morphism
+    register_morphism!(isomorphism)
+    register_morphism!(inverse_isomorphism)
+  end
+  task == :only_morphism && return isomorphism
+  
+  return presentation_module, isomorphism
+end
+
 @doc raw"""
     is_equal_with_morphism(M::SubquoModule{T}, N::SubquoModule{T}, task::Symbol = :none) where {T}
 

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -4468,9 +4468,48 @@ function present_as_cokernel(SQ::SubquoModule, task::Symbol = :none)
   return presentation_module, isomorphism
 end
 
+@doc raw"""
+    present_as_cokernel(F::FreeMod, task::Symbol = :none)
+
+Represent `F` as the quotient `C` of itself with no relations. This method exists for compatibility reasons with `present_as_cokernel(M::SubQuoModule, task::Symbol = :none)`. 
+
+Additionally,
+
+- return an isomorphism `F` $\to$ `C` if `task = :with_morphism`,
+- return and cache an isomorphism `F` $\to$ `C` if `task = :cache_morphism`,
+- do none of the above if `task = :none` (default).
+
+If `task = :only_morphism`, return only an isomorphism.
+
+# Examples
+```jldoctest
+julia> R, (x, y, z) = polynomial_ring(QQ, ["x", "y", "z"]);
+
+julia> F = free_module(R, 2)
+Free module of rank 2 over Multivariate polynomial ring in 3 variables over QQ
+
+julia> present_as_cokernel(F)
+Submodule with 2 generators
+1 -> e[1]
+2 -> e[2]
+represented as subquotient with no relations.
+
+julia> present_as_cokernel(F, :only_morphism)
+Map with following data
+Domain:
+=======
+Free module of rank 2 over Multivariate polynomial ring in 3 variables over QQ
+Codomain:
+=========
+Submodule with 2 generators
+1 -> e[1]
+2 -> e[2]
+represented as subquotient with no relations.
+```
+"""
 function present_as_cokernel(F::FreeMod, task::Symbol = :none)
-  presentation_module, inverse_isomorphism = quo(F, [zero(F)])
-  isomorphism = hom(presentation_module, F, gens(F))
+  presentation_module, isomorphism = quo(F, [zero(F)])
+  inverse_isomorphism = hom(presentation_module, F, gens(F))
 
   if task == :none
     return presentation_module

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -251,6 +251,14 @@ end
   end
   hom_hom_resolution = hom_without_reversing_direction(hom_resolution,N)
   @test chain_range(hom_hom_resolution) == chain_range(free_res)
+
+  R, (x, y, z) = polynomial_ring(QQ, ["x", "y", "z"])
+  F = free_module(R, 2)
+  C, isom = present_as_cokernel(F, :cache_morphism)
+  @test ambient_free_module(C) == F
+  @test relations(C) == [zero(F)]
+  @test domain(isom) == F
+  @test codomain(isom) == C
 end
 
 @testset "Ext, Tor" begin


### PR DESCRIPTION
Adds the dummy method `present_as_cokernel(::FreeMod)` to represent a free module as a subquotient of itself with no relations.

With this method,  we can pass subquotients and free modules to Singular in a uniform way.