### PR TITLE
Call Oscar.randseed! at start of test suite

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,7 @@ end
 @everywhere using Test
 @everywhere using Oscar
 @everywhere Oscar.set_seed!($seed)
+@everywhere Oscar.randseed!($seed)
 
 # hotfix, otherwise StraightLinePrograms returns something which then leads to an error
 module SLPTest


### PR DESCRIPTION
... to make test runs *slightly* easier to reproduce.

However, this is not enough. We also need to reset the RNGs at the start of `@testset` like is done for the global RNG. Indeed, `Test.@testset` does this at the start:
```julia
        local RNG = default_rng()
        local oldrng = copy(RNG)
        local oldseed = Random.GLOBAL_SEED
        try
            # RNG is re-seeded with its own seed to ease reproduce a failed test
            Random.seed!(Random.GLOBAL_SEED)
```
and then this at the end of each testset:
```julia
        finally
            copy!(RNG, oldrng)
            Random.set_global_seed!(oldseed)
```

Ideally something similar would be done for `Oscar.randseed!` -- IMHO it would be fully sufficient to do `Oscar.randseed!(SOME_SESSION_FIXED_VALUE)` at the start of each testset.

There are various hacky ways to achieve that (e.g. we could monkey patch various methods), but a clean solution would be to implement a custom `AbstractTestSet` subtype which implements the desired behavior....


CC @benlorenz 