### PR TITLE
CI: add code coverage to doctests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -117,12 +117,13 @@ jobs:
             Pkg.instantiate()'
       - name: "Run doctests"
         run: |
-          julia --project=docs --depwarn=error --color=yes -e'
-            using Documenter
-            include("docs/documenter_helpers.jl")
-            using Oscar
-            DocMeta.setdocmeta!(Oscar, :DocTestSetup, Oscar.doctestsetup(); recursive = true)
-            doctest(Oscar)'
+          julia ${{ matrix.julia-version == '1.9' && '--code-coverage' || '' }} \
+            --project=docs --depwarn=error --color=yes -e'
+              using Documenter
+              include("docs/documenter_helpers.jl")
+              using Oscar
+              DocMeta.setdocmeta!(Oscar, :DocTestSetup, Oscar.doctestsetup(); recursive = true)
+              doctest(Oscar)'
       - name: "Process code coverage"
         if: matrix.julia-version == '1.9'
         uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
The doctests were running without any codecov options.

cc: @thofma @simonbrandhorst 

The logs for the codecov step after the doctest show that there are no coverage files:
```
[ Info: CoverageTools.process_file: Detecting coverage for src/AlgebraicGeometry/Schemes/AffineAlgebraicSet/Objects/Methods.jl
┌ Info: CoverageTools.process_cov: Coverage file(s) for src/AlgebraicGeometry/Schemes/AffineAlgebraicSet/Objects/Methods.jl do not exist.
└ Assuming file has no coverage.
```