### PR TITLE
Revise some character table tests to use a doctest

### DIFF
--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -1,700 +1,750 @@
+using Documenter
+
 # Make sure that the tests start without cached character tables.
 # (Running the tests will store information that changes some test outputs,
 # thus running the tests twice needs these calls.)
 GAP.Globals.UnloadCharacterTableData()
 empty!(Oscar.character_tables_by_id)
 
+#
+# This module only exists to "host" a doctest used by the test suite.
+#
+module AuxDocTest_GroupCharacters
+@doc raw"""
+```jldoctest group_characters.test
+julia> using Oscar
+
+julia> t_a4 = character_table(alternating_group(4));
+
+julia> t_a5 = character_table("A5");
+
+julia> t_a4_2 = mod(t_a4, 2);
+
+julia> t_a5_2 = mod(t_a5, 2);
+```
+
+`print` shows an abbrev. form
+
+```jldoctest group_characters.test
+julia> print(t_a4)
+character table of group Alt( [ 1 .. 4 ] )
+
+julia> print(t_a5)
+character table of A5
+
+julia> print(t_a4_2)
+2-modular Brauer table of group Alt( [ 1 .. 4 ] )
+
+julia> print(t_a5_2)
+2-modular Brauer table of A5
+```
+
+`show` uses the abbrev. form for nested objects
+
+```jldoctest group_characters.test
+julia> show([t_a4])
+Oscar.GAPGroupCharacterTable[character table of group Alt( [ 1 .. 4 ] )]
+
+julia> show([t_a5])
+Oscar.GAPGroupCharacterTable[character table of A5]
+
+julia> show([t_a4_2])
+Oscar.GAPGroupCharacterTable[2-modular Brauer table of group Alt( [ 1 .. 4 ] )]
+
+julia> show([t_a5_2])
+Oscar.GAPGroupCharacterTable[2-modular Brauer table of A5]
+```
+
+supercompact printing
+```jldoctest group_characters.test
+julia> print(IOContext(stdout, :supercompact => true), t_a4)
+character table of a group
+
+julia> print(IOContext(stdout, :supercompact => true), t_a5)
+character table of a group
+
+julia> print(IOContext(stdout, :supercompact => true), t_a4_2)
+2-modular Brauer table of a group
+
+julia> print(IOContext(stdout, :supercompact => true), t_a5_2)
+2-modular Brauer table of a group
+```
+
+default `show` with unicode
+
+```jldoctest group_characters.test
+julia> Oscar.with_unicode() do
+         show(stdout, MIME("text/plain"), t_a4)
+       end
+Alt( [ 1 .. 4 ] )
+
+ 2  2  2       .       .
+ 3  1  .       1       1
+
+   1a 2a      3a      3b
+2P 1a 1a      3b      3a
+3P 1a 2a      1a      1a
+
+χ₁  1  1       1       1
+χ₂  1  1 -ζ₃ - 1      ζ₃
+χ₃  1  1      ζ₃ -ζ₃ - 1
+χ₄  3 -1       .       .
+true
+```
+
+default `show` without unicode
+
+```jldoctest group_characters.test
+julia> show(stdout, MIME("text/plain"), t_a4)
+Alt( [ 1 .. 4 ] )
+
+  2  2  2        .        .
+  3  1  .        1        1
+
+    1a 2a       3a       3b
+ 2P 1a 1a       3b       3a
+ 3P 1a 2a       1a       1a
+
+X_1  1  1        1        1
+X_2  1  1 -z_3 - 1      z_3
+X_3  1  1      z_3 -z_3 - 1
+X_4  3 -1        .        .
+```
+
+LaTeX format
+
+```jldoctest group_characters.test
+julia> show(stdout, MIME("text/latex"), t_a4)
+$Alt( [ 1 .. 4 ] )
+
+\begin{array}{rrrrr}
+2 & 2 & 2 & . & . \\
+3 & 1 & . & 1 & 1 \\
+ &  &  &  &  \\
+ & 1a & 2a & 3a & 3b \\
+2P & 1a & 1a & 3b & 3a \\
+3P & 1a & 2a & 1a & 1a \\
+ &  &  &  &  \\
+\chi_{1} & 1 & 1 & 1 & 1 \\
+\chi_{2} & 1 & 1 & -\zeta_{3} - 1 & \zeta_{3} \\
+\chi_{3} & 1 & 1 & \zeta_{3} & -\zeta_{3} - 1 \\
+\chi_{4} & 3 & -1 & . & . \\
+\end{array}
+$
+
+```
+
+show a legend of irrationalities instead of self-explanatory values,
+in the screen format ...
+
+```jldoctest group_characters.test
+julia> Oscar.with_unicode() do
+         show(IOContext(stdout, :with_legend => true), MIME("text/plain"), t_a4)
+       end
+Alt( [ 1 .. 4 ] )
+
+ 2  2  2  .  .
+ 3  1  .  1  1
+
+   1a 2a 3a 3b
+2P 1a 1a 3b 3a
+3P 1a 2a 1a 1a
+
+χ₁  1  1  1  1
+χ₂  1  1  A  A̅
+χ₃  1  1  A̅  A
+χ₄  3 -1  .  .
+
+A = -ζ₃ - 1
+A̅ = ζ₃
+true
+```
+
+```jldoctest group_characters.test
+julia> show(IOContext(stdout, :with_legend => true), MIME("text/plain"), t_a4)
+Alt( [ 1 .. 4 ] )
+
+  2  2  2  .  .
+  3  1  .  1  1
+
+    1a 2a 3a 3b
+ 2P 1a 1a 3b 3a
+ 3P 1a 2a 1a 1a
+
+X_1  1  1  1  1
+X_2  1  1  A /A
+X_3  1  1 /A  A
+X_4  3 -1  .  .
+
+A = -z_3 - 1
+/A = z_3
+```
+
+... and in LaTeX format
+```jldoctest group_characters.test
+julia> show(IOContext(stdout, :with_legend => true), MIME("text/latex"), t_a4)
+$Alt( [ 1 .. 4 ] )
+
+\begin{array}{rrrrr}
+2 & 2 & 2 & . & . \\
+3 & 1 & . & 1 & 1 \\
+ &  &  &  &  \\
+ & 1a & 2a & 3a & 3b \\
+2P & 1a & 1a & 3b & 3a \\
+3P & 1a & 2a & 1a & 1a \\
+ &  &  &  &  \\
+\chi_{1} & 1 & 1 & 1 & 1 \\
+\chi_{2} & 1 & 1 & A & \overline{A} \\
+\chi_{3} & 1 & 1 & \overline{A} & A \\
+\chi_{4} & 3 & -1 & . & . \\
+\end{array}
+
+\begin{array}{l}
+A = -\zeta_{3} - 1 \\
+\overline{A} = \zeta_{3} \\
+\end{array}
+$
+```
+
+Show the screen format for a table with real and non-real irrationalities.
+```jldoctest group_characters.test
+julia> Oscar.with_unicode() do
+         show(IOContext(stdout, :with_legend => true),
+              MIME("text/plain"), character_table("L2(11)"))
+       end
+L2(11)
+
+  2  2  2  1  .  .  1   .   .
+  3  1  1  1  .  .  1   .   .
+  5  1  .  .  1  1  .   .   .
+ 11  1  .  .  .  .  .   1   1
+
+    1a 2a 3a 5a 5b 6a 11a 11b
+ 2P 1a 1a 3a 5b 5a 3a 11b 11a
+ 3P 1a 2a 1a 5b 5a 2a 11a 11b
+ 5P 1a 2a 3a 1a 1a 6a 11a 11b
+11P 1a 2a 3a 5a 5b 6a  1a  1a
+
+ χ₁  1  1  1  1  1  1   1   1
+ χ₂  5  1 -1  .  .  1   B   B̅
+ χ₃  5  1 -1  .  .  1   B̅   B
+ χ₄ 10 -2  1  .  .  1  -1  -1
+ χ₅ 10  2  1  .  . -1  -1  -1
+ χ₆ 11 -1 -1  1  1 -1   .   .
+ χ₇ 12  .  .  A A*  .   1   1
+ χ₈ 12  .  . A*  A  .   1   1
+
+A = -ζ₅³ - ζ₅² - 1
+A* = ζ₅³ + ζ₅²
+B = ζ₁₁⁹ + ζ₁₁⁵ + ζ₁₁⁴ + ζ₁₁³ + ζ₁₁
+B̅ = -ζ₁₁⁹ - ζ₁₁⁵ - ζ₁₁⁴ - ζ₁₁³ - ζ₁₁ - 1
+true
+```
+
+```jldoctest group_characters.test
+julia> show(IOContext(stdout, :with_legend => true),
+            MIME("text/plain"), character_table("L2(11)"))
+L2(11)
+
+  2  2  2  1  .  .  1   .   .
+  3  1  1  1  .  .  1   .   .
+  5  1  .  .  1  1  .   .   .
+ 11  1  .  .  .  .  .   1   1
+
+    1a 2a 3a 5a 5b 6a 11a 11b
+ 2P 1a 1a 3a 5b 5a 3a 11b 11a
+ 3P 1a 2a 1a 5b 5a 2a 11a 11b
+ 5P 1a 2a 3a 1a 1a 6a 11a 11b
+11P 1a 2a 3a 5a 5b 6a  1a  1a
+
+X_1  1  1  1  1  1  1   1   1
+X_2  5  1 -1  .  .  1   B  /B
+X_3  5  1 -1  .  .  1  /B   B
+X_4 10 -2  1  .  .  1  -1  -1
+X_5 10  2  1  .  . -1  -1  -1
+X_6 11 -1 -1  1  1 -1   .   .
+X_7 12  .  .  A A*  .   1   1
+X_8 12  .  . A*  A  .   1   1
+
+A = -z_5^3 - z_5^2 - 1
+A* = z_5^3 + z_5^2
+B = z_11^9 + z_11^5 + z_11^4 + z_11^3 + z_11
+/B = -z_11^9 - z_11^5 - z_11^4 - z_11^3 - z_11 - 1
+```
+
+Show some separating lines, in the screen format ...
+```jldoctest group_characters.test
+julia> Oscar.with_unicode() do
+         show(IOContext(stdout, :separators_col => [0,5],
+                                :separators_row => [0,5]),
+              MIME("text/plain"), t_a5)
+       end
+A5
+
+ 2│ 2  2  .             .             .│
+ 3│ 1  .  1             .             .│
+ 5│ 1  .  .             1             1│
+  │                                    │
+  │1a 2a 3a            5a            5b│
+2P│1a 1a 3a            5b            5a│
+3P│1a 2a 1a            5b            5a│
+5P│1a 2a 3a            1a            1a│
+  │                                    │
+──┼────────────────────────────────────┼
+χ₁│ 1  1  1             1             1│
+χ₂│ 3 -1  . ζ₅³ + ζ₅² + 1    -ζ₅³ - ζ₅²│
+χ₃│ 3 -1  .    -ζ₅³ - ζ₅² ζ₅³ + ζ₅² + 1│
+χ₄│ 4  .  1            -1            -1│
+χ₅│ 5  1 -1             .             .│
+──┼────────────────────────────────────┼
+true
+```
+
+```jldoctest group_characters.test
+julia> show(IOContext(stdout, :separators_col => [0,5],
+                          :separators_row => [0,5]),
+            MIME("text/plain"), t_a5)
+A5
+
+  2| 2  2  .                 .                 .|
+  3| 1  .  1                 .                 .|
+  5| 1  .  .                 1                 1|
+   |                                            |
+   |1a 2a 3a                5a                5b|
+ 2P|1a 1a 3a                5b                5a|
+ 3P|1a 2a 1a                5b                5a|
+ 5P|1a 2a 3a                1a                1a|
+   |                                            |
+---+--------------------------------------------+
+X_1| 1  1  1                 1                 1|
+X_2| 3 -1  . z_5^3 + z_5^2 + 1    -z_5^3 - z_5^2|
+X_3| 3 -1  .    -z_5^3 - z_5^2 z_5^3 + z_5^2 + 1|
+X_4| 4  .  1                -1                -1|
+X_5| 5  1 -1                 .                 .|
+---+--------------------------------------------+
+```
+
+... and in LaTeX format
+
+```jldoctest group_characters.test
+julia> show(IOContext(stdout, :separators_col => [0,5],
+                          :separators_row => [0,5]),
+            MIME("text/latex"), t_a5)
+$A5
+
+\begin{array}{r|rrrrr|}
+2 & 2 & 2 & . & . & . \\
+3 & 1 & . & 1 & . & . \\
+5 & 1 & . & . & 1 & 1 \\
+ &  &  &  &  &  \\
+ & 1a & 2a & 3a & 5a & 5b \\
+2P & 1a & 1a & 3a & 5b & 5a \\
+3P & 1a & 2a & 1a & 5b & 5a \\
+5P & 1a & 2a & 3a & 1a & 1a \\
+ &  &  &  &  &  \\
+\hline
+\chi_{1} & 1 & 1 & 1 & 1 & 1 \\
+\chi_{2} & 3 & -1 & . & \zeta_{5}^{3} + \zeta_{5}^{2} + 1 & -\zeta_{5}^{3} - \zeta_{5}^{2} \\
+\chi_{3} & 3 & -1 & . & -\zeta_{5}^{3} - \zeta_{5}^{2} & \zeta_{5}^{3} + \zeta_{5}^{2} + 1 \\
+\chi_{4} & 4 & . & 1 & -1 & -1 \\
+\chi_{5} & 5 & 1 & -1 & . & . \\
+\hline
+\end{array}
+$
+```
+
+distribute the table into column portions, in the screen format ...
+
+```jldoctest group_characters.test
+julia> Oscar.with_unicode() do
+         show(IOContext(stdout, :separators_col => [0],
+                            :separators_row => [0],
+                            :portions_col => [2,3]),
+              MIME("text/plain"), t_a5)
+       end
+A5
+
+ 2│ 2  2
+ 3│ 1  .
+ 5│ 1  .
+  │
+  │1a 2a
+2P│1a 1a
+3P│1a 2a
+5P│1a 2a
+  │
+──┼─────
+χ₁│ 1  1
+χ₂│ 3 -1
+χ₃│ 3 -1
+χ₄│ 4  .
+χ₅│ 5  1
+
+ 2│ .             .             .
+ 3│ 1             .             .
+ 5│ .             1             1
+  │
+  │3a            5a            5b
+2P│3a            5b            5a
+3P│1a            5b            5a
+5P│3a            1a            1a
+  │
+──┼──────────────────────────────
+χ₁│ 1             1             1
+χ₂│ . ζ₅³ + ζ₅² + 1    -ζ₅³ - ζ₅²
+χ₃│ .    -ζ₅³ - ζ₅² ζ₅³ + ζ₅² + 1
+χ₄│ 1            -1            -1
+χ₅│-1             .             .
+true
+```
+
+
+```jldoctest group_characters.test
+julia> show(IOContext(stdout, :separators_col => [0],
+                     :separators_row => [0],
+                     :portions_col => [2,3]),
+       MIME("text/plain"), t_a5)
+A5
+
+  2| 2  2
+  3| 1  .
+  5| 1  .
+   |
+   |1a 2a
+ 2P|1a 1a
+ 3P|1a 2a
+ 5P|1a 2a
+   |
+---+-----
+X_1| 1  1
+X_2| 3 -1
+X_3| 3 -1
+X_4| 4  .
+X_5| 5  1
+
+  2| .                 .                 .
+  3| 1                 .                 .
+  5| .                 1                 1
+   |
+   |3a                5a                5b
+ 2P|3a                5b                5a
+ 3P|1a                5b                5a
+ 5P|3a                1a                1a
+   |
+---+--------------------------------------
+X_1| 1                 1                 1
+X_2| . z_5^3 + z_5^2 + 1    -z_5^3 - z_5^2
+X_3| .    -z_5^3 - z_5^2 z_5^3 + z_5^2 + 1
+X_4| 1                -1                -1
+X_5|-1                 .                 .
+```
+
+... and in LaTeX format
+
+```jldoctest group_characters.test
+julia> show(IOContext(stdout, :separators_col => [0],
+                     :separators_row => [0],
+                     :portions_col => [2,3]),
+       MIME("text/latex"), t_a5)
+$A5
+
+\begin{array}{r|rr}
+2 & 2 & 2 \\
+3 & 1 & . \\
+5 & 1 & . \\
+ &  &  \\
+ & 1a & 2a \\
+2P & 1a & 1a \\
+3P & 1a & 2a \\
+5P & 1a & 2a \\
+ &  &  \\
+\hline
+\chi_{1} & 1 & 1 \\
+\chi_{2} & 3 & -1 \\
+\chi_{3} & 3 & -1 \\
+\chi_{4} & 4 & . \\
+\chi_{5} & 5 & 1 \\
+\end{array}
+
+\begin{array}{r|rrr}
+2 & . & . & . \\
+3 & 1 & . & . \\
+5 & . & 1 & 1 \\
+ &  &  &  \\
+ & 3a & 5a & 5b \\
+2P & 3a & 5b & 5a \\
+3P & 1a & 5b & 5a \\
+5P & 3a & 1a & 1a \\
+ &  &  &  \\
+\hline
+\chi_{1} & 1 & 1 & 1 \\
+\chi_{2} & . & \zeta_{5}^{3} + \zeta_{5}^{2} + 1 & -\zeta_{5}^{3} - \zeta_{5}^{2} \\
+\chi_{3} & . & -\zeta_{5}^{3} - \zeta_{5}^{2} & \zeta_{5}^{3} + \zeta_{5}^{2} + 1 \\
+\chi_{4} & 1 & -1 & -1 \\
+\chi_{5} & -1 & . & . \\
+\end{array}
+$
+```
+
+distribute the table into row portions,
+in the screen format (perhaps not relevant) ...
+
+```jldoctest group_characters.test
+julia> Oscar.with_unicode() do
+         show(IOContext(stdout, :separators_col => [0],
+                            :separators_row => [0],
+                            :portions_row => [2,3]),
+              MIME("text/plain"), t_a5)
+       end
+A5
+
+ 2│ 2  2  .             .             .
+ 3│ 1  .  1             .             .
+ 5│ 1  .  .             1             1
+  │
+  │1a 2a 3a            5a            5b
+2P│1a 1a 3a            5b            5a
+3P│1a 2a 1a            5b            5a
+5P│1a 2a 3a            1a            1a
+  │
+──┼────────────────────────────────────
+χ₁│ 1  1  1             1             1
+χ₂│ 3 -1  . ζ₅³ + ζ₅² + 1    -ζ₅³ - ζ₅²
+
+ 2│ 2  2  .             .             .
+ 3│ 1  .  1             .             .
+ 5│ 1  .  .             1             1
+  │
+  │1a 2a 3a            5a            5b
+2P│1a 1a 3a            5b            5a
+3P│1a 2a 1a            5b            5a
+5P│1a 2a 3a            1a            1a
+  │
+──┼────────────────────────────────────
+χ₃│ 3 -1  .    -ζ₅³ - ζ₅² ζ₅³ + ζ₅² + 1
+χ₄│ 4  .  1            -1            -1
+χ₅│ 5  1 -1             .             .
+true
+```
+
+
+```jldoctest group_characters.test
+julia> show(IOContext(stdout, :separators_col => [0],
+                          :separators_row => [0],
+                          :portions_row => [2,3]),
+            MIME("text/plain"), t_a5)
+A5
+
+  2| 2  2  .                 .                 .
+  3| 1  .  1                 .                 .
+  5| 1  .  .                 1                 1
+   |
+   |1a 2a 3a                5a                5b
+ 2P|1a 1a 3a                5b                5a
+ 3P|1a 2a 1a                5b                5a
+ 5P|1a 2a 3a                1a                1a
+   |
+---+--------------------------------------------
+X_1| 1  1  1                 1                 1
+X_2| 3 -1  . z_5^3 + z_5^2 + 1    -z_5^3 - z_5^2
+
+  2| 2  2  .                 .                 .
+  3| 1  .  1                 .                 .
+  5| 1  .  .                 1                 1
+   |
+   |1a 2a 3a                5a                5b
+ 2P|1a 1a 3a                5b                5a
+ 3P|1a 2a 1a                5b                5a
+ 5P|1a 2a 3a                1a                1a
+   |
+---+--------------------------------------------
+X_3| 3 -1  .    -z_5^3 - z_5^2 z_5^3 + z_5^2 + 1
+X_4| 4  .  1                -1                -1
+X_5| 5  1 -1                 .                 .
+```
+
+... and in LaTeX format (may be interesting)
+
+```jldoctest group_characters.test
+julia> show(IOContext(stdout, :separators_col => [0],
+                          :separators_row => [0],
+                          :portions_row => [2,3]),
+            MIME("text/latex"), t_a5)
+$A5
+
+\begin{array}{r|rrrrr}
+2 & 2 & 2 & . & . & . \\
+3 & 1 & . & 1 & . & . \\
+5 & 1 & . & . & 1 & 1 \\
+ &  &  &  &  &  \\
+ & 1a & 2a & 3a & 5a & 5b \\
+2P & 1a & 1a & 3a & 5b & 5a \\
+3P & 1a & 2a & 1a & 5b & 5a \\
+5P & 1a & 2a & 3a & 1a & 1a \\
+ &  &  &  &  &  \\
+\hline
+\chi_{1} & 1 & 1 & 1 & 1 & 1 \\
+\chi_{2} & 3 & -1 & . & \zeta_{5}^{3} + \zeta_{5}^{2} + 1 & -\zeta_{5}^{3} - \zeta_{5}^{2} \\
+\end{array}
+
+\begin{array}{r|rrrrr}
+2 & 2 & 2 & . & . & . \\
+3 & 1 & . & 1 & . & . \\
+5 & 1 & . & . & 1 & 1 \\
+ &  &  &  &  &  \\
+ & 1a & 2a & 3a & 5a & 5b \\
+2P & 1a & 1a & 3a & 5b & 5a \\
+3P & 1a & 2a & 1a & 5b & 5a \\
+5P & 1a & 2a & 3a & 1a & 1a \\
+ &  &  &  &  &  \\
+\hline
+\chi_{3} & 3 & -1 & . & -\zeta_{5}^{3} - \zeta_{5}^{2} & \zeta_{5}^{3} + \zeta_{5}^{2} + 1 \\
+\chi_{4} & 4 & . & 1 & -1 & -1 \\
+\chi_{5} & 5 & 1 & -1 & . & . \\
+\end{array}
+$
+```
+
+show indicators in the screen format ...
+
+```jldoctest group_characters.test
+julia> Oscar.with_unicode() do
+         show(IOContext(stdout, :indicator => [2]), MIME("text/plain"), t_a4)
+       end
+Alt( [ 1 .. 4 ] )
+
+    2  2  2       .       .
+    3  1  .       1       1
+
+      1a 2a      3a      3b
+   2P 1a 1a      3b      3a
+   3P 1a 2a      1a      1a
+    2
+χ₁  +  1  1       1       1
+χ₂  o  1  1 -ζ₃ - 1      ζ₃
+χ₃  o  1  1      ζ₃ -ζ₃ - 1
+χ₄  +  3 -1       .       .
+true
+```
+
+... and in LaTeX format
+
+```jldoctest group_characters.test
+julia> show(IOContext(stdout, :indicator => [2]), MIME("text/latex"), t_a4)
+$Alt( [ 1 .. 4 ] )
+
+\begin{array}{rrrrrr}
+ & 2 & 2 & 2 & . & . \\
+ & 3 & 1 & . & 1 & 1 \\
+ &  &  &  &  &  \\
+ &  & 1a & 2a & 3a & 3b \\
+ & 2P & 1a & 1a & 3b & 3a \\
+ & 3P & 1a & 2a & 1a & 1a \\
+ & 2 &  &  &  &  \\
+\chi_{1} & + & 1 & 1 & 1 & 1 \\
+\chi_{2} & o & 1 & 1 & -\zeta_{3} - 1 & \zeta_{3} \\
+\chi_{3} & o & 1 & 1 & \zeta_{3} & -\zeta_{3} - 1 \\
+\chi_{4} & + & 3 & -1 & . & . \\
+\end{array}
+$
+```
+
+ordinary table:
+show character field degrees in the screen format ...
+
+```jldoctest group_characters.test
+julia> Oscar.with_unicode() do
+         show(IOContext(stdout, :character_field => true), MIME("text/plain"), t_a4)
+       end
+Alt( [ 1 .. 4 ] )
+
+    2  2  2       .       .
+    3  1  .       1       1
+
+      1a 2a      3a      3b
+   2P 1a 1a      3b      3a
+   3P 1a 2a      1a      1a
+    d
+χ₁  1  1  1       1       1
+χ₂  2  1  1 -ζ₃ - 1      ζ₃
+χ₃  2  1  1      ζ₃ -ζ₃ - 1
+χ₄  1  3 -1       .       .
+true
+```
+
+... and in LaTeX format
+
+```jldoctest group_characters.test
+julia> show(IOContext(stdout, :character_field => true), MIME("text/latex"), t_a4)
+$Alt( [ 1 .. 4 ] )
+
+\begin{array}{rrrrrr}
+ & 2 & 2 & 2 & . & . \\
+ & 3 & 1 & . & 1 & 1 \\
+ &  &  &  &  &  \\
+ &  & 1a & 2a & 3a & 3b \\
+ & 2P & 1a & 1a & 3b & 3a \\
+ & 3P & 1a & 2a & 1a & 1a \\
+ & d &  &  &  &  \\
+\chi_{1} & 1 & 1 & 1 & 1 & 1 \\
+\chi_{2} & 2 & 1 & 1 & -\zeta_{3} - 1 & \zeta_{3} \\
+\chi_{3} & 2 & 1 & 1 & \zeta_{3} & -\zeta_{3} - 1 \\
+\chi_{4} & 1 & 3 & -1 & . & . \\
+\end{array}
+$
+```
+
+Brauer table:
+show character field degrees in the screen format ...
+
+```jldoctest group_characters.test
+julia> Oscar.with_unicode() do
+         show(IOContext(stdout, :character_field => true), MIME("text/plain"), mod(t_a4, 2))
+       end
+Alt( [ 1 .. 4 ] ) mod 2
+
+    2  2       .       .
+    3  1       1       1
+
+      1a      3a      3b
+   2P 1a      3b      3a
+   3P 1a      1a      1a
+    d
+χ₁  1  1       1       1
+χ₂  2  1 -ζ₃ - 1      ζ₃
+χ₃  2  1      ζ₃ -ζ₃ - 1
+true
+```
+
+... and in LaTeX format
+
+```jldoctest group_characters.test
+julia> show(IOContext(stdout, :character_field => true), MIME("text/latex"), mod(t_a4, 2))
+$Alt( [ 1 .. 4 ] ) mod 2
+
+\begin{array}{rrrrr}
+ & 2 & 2 & . & . \\
+ & 3 & 1 & 1 & 1 \\
+ &  &  &  &  \\
+ &  & 1a & 3a & 3b \\
+ & 2P & 1a & 3b & 3a \\
+ & 3P & 1a & 1a & 1a \\
+ & d &  &  &  \\
+\chi_{1} & 1 & 1 & 1 & 1 \\
+\chi_{2} & 2 & 1 & -\zeta_{3} - 1 & \zeta_{3} \\
+\chi_{3} & 2 & 1 & \zeta_{3} & -\zeta_{3} - 1 \\
+\end{array}
+$
+```
+"""
+function dummy_placeholder end
+
+end
+
+
 @testset "show and print character tables" begin
-  io = IOBuffer();
-
-  t_a4 = character_table(alternating_group(4))
-  t_a5 = character_table("A5")
-  t_a4_2 = mod(t_a4, 2)
-  t_a5_2 = mod(t_a5, 2)
-
-  # `print` shows an abbrev. form
-  print(io, t_a4)
-  @test String(take!(io)) == "character table of group Alt( [ 1 .. 4 ] )"
-  print(io, t_a5)
-  @test String(take!(io)) == "character table of A5"
-  print(io, t_a4_2)
-  @test String(take!(io)) == "2-modular Brauer table of group Alt( [ 1 .. 4 ] )"
-  print(io, t_a5_2)
-  @test String(take!(io)) == "2-modular Brauer table of A5"
-
-  # `show` uses the abbrev. form for nested objects
-  show(io, [t_a4])
-  @test String(take!(io)) ==
-    "Oscar.GAPGroupCharacterTable[character table of group Alt( [ 1 .. 4 ] )]"
-  show(io, [t_a5])
-  @test String(take!(io)) ==
-    "Oscar.GAPGroupCharacterTable[character table of A5]"
-  show(io, [t_a4_2])
-  @test String(take!(io)) ==
-    "Oscar.GAPGroupCharacterTable[2-modular Brauer table of group Alt( [ 1 .. 4 ] )]"
-  show(io, [t_a5_2])
-  @test String(take!(io)) ==
-    "Oscar.GAPGroupCharacterTable[2-modular Brauer table of A5]"
-
-  # supercompact printing
-  print(IOContext(io, :supercompact => true), t_a4)
-  @test String(take!(io)) == "character table of a group"
-  print(IOContext(io, :supercompact => true), t_a5)
-  @test String(take!(io)) == "character table of a group"
-  print(IOContext(io, :supercompact => true), t_a4_2)
-  @test String(take!(io)) == "2-modular Brauer table of a group"
-  print(IOContext(io, :supercompact => true), t_a5_2)
-  @test String(take!(io)) == "2-modular Brauer table of a group"
-
-  # default `show`
-  Oscar.with_unicode() do
-    show(io, MIME("text/plain"), t_a4)
-  end
-  @test String(take!(io)) ==
-  """
-  Alt( [ 1 .. 4 ] )
-  
-   2  2  2       .       .
-   3  1  .       1       1
-                          
-     1a 2a      3a      3b
-  2P 1a 1a      3b      3a
-  3P 1a 2a      1a      1a
-                          
-  χ₁  1  1       1       1
-  χ₂  1  1 -ζ₃ - 1      ζ₃
-  χ₃  1  1      ζ₃ -ζ₃ - 1
-  χ₄  3 -1       .       .
-  """
-
-  show(io, MIME("text/plain"), t_a4)
-  @test String(take!(io)) ==
-  """
-  Alt( [ 1 .. 4 ] )
-  
-    2  2  2        .        .
-    3  1  .        1        1
-                             
-      1a 2a       3a       3b
-   2P 1a 1a       3b       3a
-   3P 1a 2a       1a       1a
-                             
-  X_1  1  1        1        1
-  X_2  1  1 -z_3 - 1      z_3
-  X_3  1  1      z_3 -z_3 - 1
-  X_4  3 -1        .        .
-  """
-
-  # LaTeX format
-  show(io, MIME("text/latex"), t_a4)
-  @test String(take!(io)) ==
-  """
-  \$Alt( [ 1 .. 4 ] )
-
-  \\begin{array}{rrrrr}
-  2 & 2 & 2 & . & . \\\\
-  3 & 1 & . & 1 & 1 \\\\
-   &  &  &  &  \\\\
-   & 1a & 2a & 3a & 3b \\\\
-  2P & 1a & 1a & 3b & 3a \\\\
-  3P & 1a & 2a & 1a & 1a \\\\
-   &  &  &  &  \\\\
-  \\chi_{1} & 1 & 1 & 1 & 1 \\\\
-  \\chi_{2} & 1 & 1 & -\\zeta_{3} - 1 & \\zeta_{3} \\\\
-  \\chi_{3} & 1 & 1 & \\zeta_{3} & -\\zeta_{3} - 1 \\\\
-  \\chi_{4} & 3 & -1 & . & . \\\\
-  \\end{array}
-  \$"""
-
-  # show a legend of irrationalities instead of self-explanatory values,
-  # in the screen format ...
-  Oscar.with_unicode() do
-    show(IOContext(io, :with_legend => true), MIME("text/plain"), t_a4)
-  end
-  @test String(take!(io)) ==
-  """
-  Alt( [ 1 .. 4 ] )
-
-   2  2  2  .  .
-   3  1  .  1  1
-                
-     1a 2a 3a 3b
-  2P 1a 1a 3b 3a
-  3P 1a 2a 1a 1a
-                
-  χ₁  1  1  1  1
-  χ₂  1  1  A  A̅
-  χ₃  1  1  A̅  A
-  χ₄  3 -1  .  .
-
-  A = -ζ₃ - 1
-  A̅ = ζ₃
-  """
-
-  show(IOContext(io, :with_legend => true), MIME("text/plain"), t_a4)
-  @test String(take!(io)) ==
-  """
-  Alt( [ 1 .. 4 ] )
-  
-    2  2  2  .  .
-    3  1  .  1  1
-                 
-      1a 2a 3a 3b
-   2P 1a 1a 3b 3a
-   3P 1a 2a 1a 1a
-                 
-  X_1  1  1  1  1
-  X_2  1  1  A /A
-  X_3  1  1 /A  A
-  X_4  3 -1  .  .
-  
-  A = -z_3 - 1
-  /A = z_3
-  """
-
-  # ... and in LaTeX format
-  show(IOContext(io, :with_legend => true), MIME("text/latex"), t_a4)
-  @test String(take!(io)) ==
-  """
-  \$Alt( [ 1 .. 4 ] )
-
-  \\begin{array}{rrrrr}
-  2 & 2 & 2 & . & . \\\\
-  3 & 1 & . & 1 & 1 \\\\
-   &  &  &  &  \\\\
-   & 1a & 2a & 3a & 3b \\\\
-  2P & 1a & 1a & 3b & 3a \\\\
-  3P & 1a & 2a & 1a & 1a \\\\
-   &  &  &  &  \\\\
-  \\chi_{1} & 1 & 1 & 1 & 1 \\\\
-  \\chi_{2} & 1 & 1 & A & \\overline{A} \\\\
-  \\chi_{3} & 1 & 1 & \\overline{A} & A \\\\
-  \\chi_{4} & 3 & -1 & . & . \\\\
-  \\end{array}
-
-  \\begin{array}{l}
-  A = -\\zeta_{3} - 1 \\\\
-  \\overline{A} = \\zeta_{3} \\\\
-  \\end{array}
-  \$"""
-
-  # show the screen format for a table with real and non-real irrationalities
-  Oscar.with_unicode() do
-    show(IOContext(io, :with_legend => true),
-         MIME("text/plain"), character_table("L2(11)"))
-  end
-  @test String(take!(io)) ==
-  """
-  L2(11)
-
-    2  2  2  1  .  .  1   .   .
-    3  1  1  1  .  .  1   .   .
-    5  1  .  .  1  1  .   .   .
-   11  1  .  .  .  .  .   1   1
-                               
-      1a 2a 3a 5a 5b 6a 11a 11b
-   2P 1a 1a 3a 5b 5a 3a 11b 11a
-   3P 1a 2a 1a 5b 5a 2a 11a 11b
-   5P 1a 2a 3a 1a 1a 6a 11a 11b
-  11P 1a 2a 3a 5a 5b 6a  1a  1a
-                               
-   χ₁  1  1  1  1  1  1   1   1
-   χ₂  5  1 -1  .  .  1   B   B̅
-   χ₃  5  1 -1  .  .  1   B̅   B
-   χ₄ 10 -2  1  .  .  1  -1  -1
-   χ₅ 10  2  1  .  . -1  -1  -1
-   χ₆ 11 -1 -1  1  1 -1   .   .
-   χ₇ 12  .  .  A A*  .   1   1
-   χ₈ 12  .  . A*  A  .   1   1
-
-  A = -ζ₅³ - ζ₅² - 1
-  A* = ζ₅³ + ζ₅²
-  B = ζ₁₁⁹ + ζ₁₁⁵ + ζ₁₁⁴ + ζ₁₁³ + ζ₁₁
-  B̅ = -ζ₁₁⁹ - ζ₁₁⁵ - ζ₁₁⁴ - ζ₁₁³ - ζ₁₁ - 1
-  """
-
-  show(IOContext(io, :with_legend => true),
-       MIME("text/plain"), character_table("L2(11)"))
-  @test String(take!(io)) ==
-  """
-  L2(11)
-  
-    2  2  2  1  .  .  1   .   .
-    3  1  1  1  .  .  1   .   .
-    5  1  .  .  1  1  .   .   .
-   11  1  .  .  .  .  .   1   1
-                               
-      1a 2a 3a 5a 5b 6a 11a 11b
-   2P 1a 1a 3a 5b 5a 3a 11b 11a
-   3P 1a 2a 1a 5b 5a 2a 11a 11b
-   5P 1a 2a 3a 1a 1a 6a 11a 11b
-  11P 1a 2a 3a 5a 5b 6a  1a  1a
-                               
-  X_1  1  1  1  1  1  1   1   1
-  X_2  5  1 -1  .  .  1   B  /B
-  X_3  5  1 -1  .  .  1  /B   B
-  X_4 10 -2  1  .  .  1  -1  -1
-  X_5 10  2  1  .  . -1  -1  -1
-  X_6 11 -1 -1  1  1 -1   .   .
-  X_7 12  .  .  A A*  .   1   1
-  X_8 12  .  . A*  A  .   1   1
-  
-  A = -z_5^3 - z_5^2 - 1
-  A* = z_5^3 + z_5^2
-  B = z_11^9 + z_11^5 + z_11^4 + z_11^3 + z_11
-  /B = -z_11^9 - z_11^5 - z_11^4 - z_11^3 - z_11 - 1
-  """
-
-  # show some separating lines, in the screen format ...
-  Oscar.with_unicode() do
-    show(IOContext(io, :separators_col => [0,5],
-                       :separators_row => [0,5]),
-         MIME("text/plain"), t_a5)
-  end
-  @test String(take!(io)) ==
-  """
-  A5
-
-   2│ 2  2  .             .             .│
-   3│ 1  .  1             .             .│
-   5│ 1  .  .             1             1│
-    │                                    │
-    │1a 2a 3a            5a            5b│
-  2P│1a 1a 3a            5b            5a│
-  3P│1a 2a 1a            5b            5a│
-  5P│1a 2a 3a            1a            1a│
-    │                                    │
-  ──┼────────────────────────────────────┼
-  χ₁│ 1  1  1             1             1│
-  χ₂│ 3 -1  . ζ₅³ + ζ₅² + 1    -ζ₅³ - ζ₅²│
-  χ₃│ 3 -1  .    -ζ₅³ - ζ₅² ζ₅³ + ζ₅² + 1│
-  χ₄│ 4  .  1            -1            -1│
-  χ₅│ 5  1 -1             .             .│
-  ──┼────────────────────────────────────┼
-  """
-
-  show(IOContext(io, :separators_col => [0,5],
-                     :separators_row => [0,5]),
-       MIME("text/plain"), t_a5)
-  @test String(take!(io)) ==
-  """
-  A5
-  
-    2| 2  2  .                 .                 .|
-    3| 1  .  1                 .                 .|
-    5| 1  .  .                 1                 1|
-     |                                            |
-     |1a 2a 3a                5a                5b|
-   2P|1a 1a 3a                5b                5a|
-   3P|1a 2a 1a                5b                5a|
-   5P|1a 2a 3a                1a                1a|
-     |                                            |
-  ---+--------------------------------------------+
-  X_1| 1  1  1                 1                 1|
-  X_2| 3 -1  . z_5^3 + z_5^2 + 1    -z_5^3 - z_5^2|
-  X_3| 3 -1  .    -z_5^3 - z_5^2 z_5^3 + z_5^2 + 1|
-  X_4| 4  .  1                -1                -1|
-  X_5| 5  1 -1                 .                 .|
-  ---+--------------------------------------------+
-  """
-
-  # ... and in LaTeX format
-  show(IOContext(io, :separators_col => [0,5],
-                     :separators_row => [0,5]),
-       MIME("text/latex"), t_a5)
-  @test String(take!(io)) ==
-  """
-  \$A5
-
-  \\begin{array}{r|rrrrr|}
-  2 & 2 & 2 & . & . & . \\\\
-  3 & 1 & . & 1 & . & . \\\\
-  5 & 1 & . & . & 1 & 1 \\\\
-   &  &  &  &  &  \\\\
-   & 1a & 2a & 3a & 5a & 5b \\\\
-  2P & 1a & 1a & 3a & 5b & 5a \\\\
-  3P & 1a & 2a & 1a & 5b & 5a \\\\
-  5P & 1a & 2a & 3a & 1a & 1a \\\\
-   &  &  &  &  &  \\\\
-  \\hline
-  \\chi_{1} & 1 & 1 & 1 & 1 & 1 \\\\
-  \\chi_{2} & 3 & -1 & . & \\zeta_{5}^{3} + \\zeta_{5}^{2} + 1 & -\\zeta_{5}^{3} - \\zeta_{5}^{2} \\\\
-  \\chi_{3} & 3 & -1 & . & -\\zeta_{5}^{3} - \\zeta_{5}^{2} & \\zeta_{5}^{3} + \\zeta_{5}^{2} + 1 \\\\
-  \\chi_{4} & 4 & . & 1 & -1 & -1 \\\\
-  \\chi_{5} & 5 & 1 & -1 & . & . \\\\
-  \\hline
-  \\end{array}
-  \$"""
-
-  # distribute the table into column portions, in the screen format ...
-  Oscar.with_unicode() do
-    show(IOContext(io, :separators_col => [0],
-                       :separators_row => [0],
-                       :portions_col => [2,3]),
-         MIME("text/plain"), t_a5)
-  end
-  @test String(take!(io)) ==
-  """
-  A5
-
-   2│ 2  2
-   3│ 1  .
-   5│ 1  .
-    │     
-    │1a 2a
-  2P│1a 1a
-  3P│1a 2a
-  5P│1a 2a
-    │     
-  ──┼─────
-  χ₁│ 1  1
-  χ₂│ 3 -1
-  χ₃│ 3 -1
-  χ₄│ 4  .
-  χ₅│ 5  1
-
-   2│ .             .             .
-   3│ 1             .             .
-   5│ .             1             1
-    │                              
-    │3a            5a            5b
-  2P│3a            5b            5a
-  3P│1a            5b            5a
-  5P│3a            1a            1a
-    │                              
-  ──┼──────────────────────────────
-  χ₁│ 1             1             1
-  χ₂│ . ζ₅³ + ζ₅² + 1    -ζ₅³ - ζ₅²
-  χ₃│ .    -ζ₅³ - ζ₅² ζ₅³ + ζ₅² + 1
-  χ₄│ 1            -1            -1
-  χ₅│-1             .             .
-  """
-
-  show(IOContext(io, :separators_col => [0],
-                     :separators_row => [0],
-                     :portions_col => [2,3]),
-       MIME("text/plain"), t_a5)
-  @test String(take!(io)) ==
-  """
-  A5
-  
-    2| 2  2
-    3| 1  .
-    5| 1  .
-     |     
-     |1a 2a
-   2P|1a 1a
-   3P|1a 2a
-   5P|1a 2a
-     |     
-  ---+-----
-  X_1| 1  1
-  X_2| 3 -1
-  X_3| 3 -1
-  X_4| 4  .
-  X_5| 5  1
-  
-    2| .                 .                 .
-    3| 1                 .                 .
-    5| .                 1                 1
-     |                                      
-     |3a                5a                5b
-   2P|3a                5b                5a
-   3P|1a                5b                5a
-   5P|3a                1a                1a
-     |                                      
-  ---+--------------------------------------
-  X_1| 1                 1                 1
-  X_2| . z_5^3 + z_5^2 + 1    -z_5^3 - z_5^2
-  X_3| .    -z_5^3 - z_5^2 z_5^3 + z_5^2 + 1
-  X_4| 1                -1                -1
-  X_5|-1                 .                 .
-  """
-
-  # ... and in LaTeX format
-  show(IOContext(io, :separators_col => [0],
-                     :separators_row => [0],
-                     :portions_col => [2,3]),
-       MIME("text/latex"), t_a5)
-  @test String(take!(io)) ==
-  """
-  \$A5
-
-  \\begin{array}{r|rr}
-  2 & 2 & 2 \\\\
-  3 & 1 & . \\\\
-  5 & 1 & . \\\\
-   &  &  \\\\
-   & 1a & 2a \\\\
-  2P & 1a & 1a \\\\
-  3P & 1a & 2a \\\\
-  5P & 1a & 2a \\\\
-   &  &  \\\\
-  \\hline
-  \\chi_{1} & 1 & 1 \\\\
-  \\chi_{2} & 3 & -1 \\\\
-  \\chi_{3} & 3 & -1 \\\\
-  \\chi_{4} & 4 & . \\\\
-  \\chi_{5} & 5 & 1 \\\\
-  \\end{array}
-
-  \\begin{array}{r|rrr}
-  2 & . & . & . \\\\
-  3 & 1 & . & . \\\\
-  5 & . & 1 & 1 \\\\
-   &  &  &  \\\\
-   & 3a & 5a & 5b \\\\
-  2P & 3a & 5b & 5a \\\\
-  3P & 1a & 5b & 5a \\\\
-  5P & 3a & 1a & 1a \\\\
-   &  &  &  \\\\
-  \\hline
-  \\chi_{1} & 1 & 1 & 1 \\\\
-  \\chi_{2} & . & \\zeta_{5}^{3} + \\zeta_{5}^{2} + 1 & -\\zeta_{5}^{3} - \\zeta_{5}^{2} \\\\
-  \\chi_{3} & . & -\\zeta_{5}^{3} - \\zeta_{5}^{2} & \\zeta_{5}^{3} + \\zeta_{5}^{2} + 1 \\\\
-  \\chi_{4} & 1 & -1 & -1 \\\\
-  \\chi_{5} & -1 & . & . \\\\
-  \\end{array}
-  \$"""
-
-  # distribute the table into row portions,
-  # in the screen format (perhaps not relevant) ...
-  Oscar.with_unicode() do
-    show(IOContext(io, :separators_col => [0],
-                       :separators_row => [0],
-                       :portions_row => [2,3]),
-         MIME("text/plain"), t_a5)
-  end
-  @test String(take!(io)) ==
-  """
-  A5
-
-   2│ 2  2  .             .             .
-   3│ 1  .  1             .             .
-   5│ 1  .  .             1             1
-    │                                    
-    │1a 2a 3a            5a            5b
-  2P│1a 1a 3a            5b            5a
-  3P│1a 2a 1a            5b            5a
-  5P│1a 2a 3a            1a            1a
-    │                                    
-  ──┼────────────────────────────────────
-  χ₁│ 1  1  1             1             1
-  χ₂│ 3 -1  . ζ₅³ + ζ₅² + 1    -ζ₅³ - ζ₅²
-
-   2│ 2  2  .             .             .
-   3│ 1  .  1             .             .
-   5│ 1  .  .             1             1
-    │                                    
-    │1a 2a 3a            5a            5b
-  2P│1a 1a 3a            5b            5a
-  3P│1a 2a 1a            5b            5a
-  5P│1a 2a 3a            1a            1a
-    │                                    
-  ──┼────────────────────────────────────
-  χ₃│ 3 -1  .    -ζ₅³ - ζ₅² ζ₅³ + ζ₅² + 1
-  χ₄│ 4  .  1            -1            -1
-  χ₅│ 5  1 -1             .             .
-  """
-
-  show(IOContext(io, :separators_col => [0],
-                     :separators_row => [0],
-                     :portions_row => [2,3]),
-       MIME("text/plain"), t_a5)
-  @test String(take!(io)) ==
-  """
-  A5
-  
-    2| 2  2  .                 .                 .
-    3| 1  .  1                 .                 .
-    5| 1  .  .                 1                 1
-     |                                            
-     |1a 2a 3a                5a                5b
-   2P|1a 1a 3a                5b                5a
-   3P|1a 2a 1a                5b                5a
-   5P|1a 2a 3a                1a                1a
-     |                                            
-  ---+--------------------------------------------
-  X_1| 1  1  1                 1                 1
-  X_2| 3 -1  . z_5^3 + z_5^2 + 1    -z_5^3 - z_5^2
-  
-    2| 2  2  .                 .                 .
-    3| 1  .  1                 .                 .
-    5| 1  .  .                 1                 1
-     |                                            
-     |1a 2a 3a                5a                5b
-   2P|1a 1a 3a                5b                5a
-   3P|1a 2a 1a                5b                5a
-   5P|1a 2a 3a                1a                1a
-     |                                            
-  ---+--------------------------------------------
-  X_3| 3 -1  .    -z_5^3 - z_5^2 z_5^3 + z_5^2 + 1
-  X_4| 4  .  1                -1                -1
-  X_5| 5  1 -1                 .                 .
-  """
-
-  # ... and in LaTeX format (may be interesting)
-  show(IOContext(io, :separators_col => [0],
-                     :separators_row => [0],
-                     :portions_row => [2,3]),
-       MIME("text/latex"), t_a5)
-  @test String(take!(io)) ==
-  """\$A5
-
-  \\begin{array}{r|rrrrr}
-  2 & 2 & 2 & . & . & . \\\\
-  3 & 1 & . & 1 & . & . \\\\
-  5 & 1 & . & . & 1 & 1 \\\\
-   &  &  &  &  &  \\\\
-   & 1a & 2a & 3a & 5a & 5b \\\\
-  2P & 1a & 1a & 3a & 5b & 5a \\\\
-  3P & 1a & 2a & 1a & 5b & 5a \\\\
-  5P & 1a & 2a & 3a & 1a & 1a \\\\
-   &  &  &  &  &  \\\\
-  \\hline
-  \\chi_{1} & 1 & 1 & 1 & 1 & 1 \\\\
-  \\chi_{2} & 3 & -1 & . & \\zeta_{5}^{3} + \\zeta_{5}^{2} + 1 & -\\zeta_{5}^{3} - \\zeta_{5}^{2} \\\\
-  \\end{array}
-
-  \\begin{array}{r|rrrrr}
-  2 & 2 & 2 & . & . & . \\\\
-  3 & 1 & . & 1 & . & . \\\\
-  5 & 1 & . & . & 1 & 1 \\\\
-   &  &  &  &  &  \\\\
-   & 1a & 2a & 3a & 5a & 5b \\\\
-  2P & 1a & 1a & 3a & 5b & 5a \\\\
-  3P & 1a & 2a & 1a & 5b & 5a \\\\
-  5P & 1a & 2a & 3a & 1a & 1a \\\\
-   &  &  &  &  &  \\\\
-  \\hline
-  \\chi_{3} & 3 & -1 & . & -\\zeta_{5}^{3} - \\zeta_{5}^{2} & \\zeta_{5}^{3} + \\zeta_{5}^{2} + 1 \\\\
-  \\chi_{4} & 4 & . & 1 & -1 & -1 \\\\
-  \\chi_{5} & 5 & 1 & -1 & . & . \\\\
-  \\end{array}
-  \$"""
-
-  # show indicators in the screen format ...
-  Oscar.with_unicode() do
-    show(IOContext(io, :indicator => [2]), MIME("text/plain"), t_a4)
-  end
-  @test String(take!(io)) ==
-  """
-  Alt( [ 1 .. 4 ] )
-
-      2  2  2       .       .
-      3  1  .       1       1
-                             
-        1a 2a      3a      3b
-     2P 1a 1a      3b      3a
-     3P 1a 2a      1a      1a
-      2                      
-  χ₁  +  1  1       1       1
-  χ₂  o  1  1 -ζ₃ - 1      ζ₃
-  χ₃  o  1  1      ζ₃ -ζ₃ - 1
-  χ₄  +  3 -1       .       .
-  """
-
-  # ... and in LaTeX format
-  show(IOContext(io, :indicator => [2]), MIME("text/latex"), t_a4)
-  @test String(take!(io)) ==
-  """\$Alt( [ 1 .. 4 ] )
-
-  \\begin{array}{rrrrrr}
-   & 2 & 2 & 2 & . & . \\\\
-   & 3 & 1 & . & 1 & 1 \\\\
-   &  &  &  &  &  \\\\
-   &  & 1a & 2a & 3a & 3b \\\\
-   & 2P & 1a & 1a & 3b & 3a \\\\
-   & 3P & 1a & 2a & 1a & 1a \\\\
-   & 2 &  &  &  &  \\\\
-  \\chi_{1} & + & 1 & 1 & 1 & 1 \\\\
-  \\chi_{2} & o & 1 & 1 & -\\zeta_{3} - 1 & \\zeta_{3} \\\\
-  \\chi_{3} & o & 1 & 1 & \\zeta_{3} & -\\zeta_{3} - 1 \\\\
-  \\chi_{4} & + & 3 & -1 & . & . \\\\
-  \\end{array}
-  \$"""
-
-  # ordinary table:
-  # show character field degrees in the screen format ...
-  Oscar.with_unicode() do
-    show(IOContext(io, :character_field => true), MIME("text/plain"), t_a4)
-  end
-  @test String(take!(io)) ==
-  """
-  Alt( [ 1 .. 4 ] )
-  
-      2  2  2       .       .
-      3  1  .       1       1
-                             
-        1a 2a      3a      3b
-     2P 1a 1a      3b      3a
-     3P 1a 2a      1a      1a
-      d                      
-  χ₁  1  1  1       1       1
-  χ₂  2  1  1 -ζ₃ - 1      ζ₃
-  χ₃  2  1  1      ζ₃ -ζ₃ - 1
-  χ₄  1  3 -1       .       .
-  """
-
-  # ... and in LaTeX format
-  show(IOContext(io, :character_field => true), MIME("text/latex"), t_a4)
-  @test String(take!(io)) ==
-  """\$Alt( [ 1 .. 4 ] )
-
-  \\begin{array}{rrrrrr}
-   & 2 & 2 & 2 & . & . \\\\
-   & 3 & 1 & . & 1 & 1 \\\\
-   &  &  &  &  &  \\\\
-   &  & 1a & 2a & 3a & 3b \\\\
-   & 2P & 1a & 1a & 3b & 3a \\\\
-   & 3P & 1a & 2a & 1a & 1a \\\\
-   & d &  &  &  &  \\\\
-  \\chi_{1} & 1 & 1 & 1 & 1 & 1 \\\\
-  \\chi_{2} & 2 & 1 & 1 & -\\zeta_{3} - 1 & \\zeta_{3} \\\\
-  \\chi_{3} & 2 & 1 & 1 & \\zeta_{3} & -\\zeta_{3} - 1 \\\\
-  \\chi_{4} & 1 & 3 & -1 & . & . \\\\
-  \\end{array}
-  \$"""
-
-  # Brauer table:
-  # show character field degrees in the screen format ...
-  Oscar.with_unicode() do
-    show(IOContext(io, :character_field => true), MIME("text/plain"), mod(t_a4, 2))
-  end
-  @test String(take!(io)) ==
-  """
-  Alt( [ 1 .. 4 ] ) mod 2
-  
-      2  2       .       .
-      3  1       1       1
-                          
-        1a      3a      3b
-     2P 1a      3b      3a
-     3P 1a      1a      1a
-      d                   
-  χ₁  1  1       1       1
-  χ₂  2  1 -ζ₃ - 1      ζ₃
-  χ₃  2  1      ζ₃ -ζ₃ - 1
-  """
-
-  # ... and in LaTeX format
-  show(IOContext(io, :character_field => true), MIME("text/latex"), mod(t_a4, 2))
-  @test String(take!(io)) ==
-  """\$Alt( [ 1 .. 4 ] ) mod 2
-  
-  \\begin{array}{rrrrr}
-   & 2 & 2 & . & . \\\\
-   & 3 & 1 & 1 & 1 \\\\
-   &  &  &  &  \\\\
-   &  & 1a & 3a & 3b \\\\
-   & 2P & 1a & 3b & 3a \\\\
-   & 3P & 1a & 1a & 1a \\\\
-   & d &  &  &  \\\\
-  \\chi_{1} & 1 & 1 & 1 & 1 \\\\
-  \\chi_{2} & 2 & 1 & -\\zeta_{3} - 1 & \\zeta_{3} \\\\
-  \\chi_{3} & 2 & 1 & \\zeta_{3} & -\\zeta_{3} - 1 \\\\
-  \\end{array}
-  \$"""
+  doctest(nothing, [AuxDocTest_GroupCharacters])
+  #doctest(nothing, [AuxDocTest_GroupCharacters]; fix=true)
 end
 
 @testset "create character tables" begin

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -8,3 +9,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.7"
+Documenter = "0.27, 1.0"


### PR DESCRIPTION
These tests deal with testing how character tables are printed in various situations. We change this to (ab)use the `jldoctest` system from Documenter. This brings with it the advantage that it is very easy to adjust the tests for desired changes to the printing: it can be done changing

    doctest(nothing, [AuxDocTest_GroupCharacters])

to

    doctest(nothing, [AuxDocTest_GroupCharacters]; fix=true)

and then running this in the Julia REPL:

    include("test/Groups/group_characters.jl")


This PR is motived by PR #2774 where it helps me to adjust the tests for the revised printing. But I think it's also of independent benefit.