### PR TITLE
Make `print_constraints` use ASCII as default

### DIFF
--- a/docs/src/PolyhedralGeometry/Polyhedra/auxiliary.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/auxiliary.md
@@ -67,8 +67,8 @@ lattice_volume(P::Polyhedron{QQFieldElem})
 normalized_volume(P::Polyhedron{T}) where T<:scalar_types
 polarize(P::Polyhedron{T}) where T<:scalar_types
 project_full(P::Polyhedron{T}) where T<:scalar_types
-print_constraints(A::AnyVecOrMat, b::AbstractVector; trivial::Bool = false)
-print_constraints(P::Polyhedron; trivial::Bool = false)
+print_constraints(io::IO, A::AnyVecOrMat, b::AbstractVector; trivial::Bool = false, numbered::Bool = false, cmp = :lte)
+print_constraints(io::IO, P::Polyhedron; trivial::Bool = false, numbered::Bool = false)
 regular_triangulations
 regular_triangulation
 secondary_polytope

--- a/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
@@ -29,13 +29,13 @@ Polyhedron in ambient dimension 2
 
 julia> facets(P)
 2-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^2 described by:
--x₁ ≦ 0
-x₁ ≦ 1
+-x_1 <= 0
+x_1 <= 1
 
 
 julia> affine_hull(P)
 1-element SubObjectIterator{AffineHyperplane{QQFieldElem}} over the Hyperplanes of R^2 described by:
-x₂ = 0
+x_2 = 0
 
 
 julia> Q0 = polyhedron(facets(P))

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -434,9 +434,9 @@ Polyhedral cone in ambient dimension 3
 
 julia> f = facets(Halfspace, c)
 3-element SubObjectIterator{LinearHalfspace{QQFieldElem}} over the Halfspaces of R^3 described by:
--x₃ ≦ 0
--x₁ + x₃ ≦ 0
--x₂ + x₃ ≦ 0
+-x_3 <= 0
+-x_1 + x_3 <= 0
+-x_2 + x_3 <= 0
 ```
 """
 facets(as::Type{<:Union{LinearHalfspace{T}, Cone{T}}}, C::Cone) where T<:scalar_types = SubObjectIterator{as}(C, _facet_cone, nfacets(C))
@@ -496,7 +496,7 @@ julia> c = positive_hull([1 0 0; 0 1 0]);
 
 julia> linear_span(c)
 1-element SubObjectIterator{LinearHyperplane{QQFieldElem}} over the Hyperplanes of R^3 described by:
-x₃ = 0
+x_3 = 0
 ```
 """
 linear_span(C::Cone{T}) where T<:scalar_types = SubObjectIterator{LinearHyperplane{T}}(C, _linear_span, size(pm_object(C).LINEAR_SPAN, 1))

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -400,12 +400,12 @@ julia> facets(Polyhedron, C)
 
 julia> facets(Halfspace, C)
 6-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^3 described by:
--x₁ ≦ 1
-x₁ ≦ 1
--x₂ ≦ 1
-x₂ ≦ 1
--x₃ ≦ 1
-x₃ ≦ 1
+-x_1 <= 1
+x_1 <= 1
+-x_2 <= 1
+x_2 <= 1
+-x_3 <= 1
+x_3 <= 1
 ```
 """
 facets(as::Type{T}, P::Polyhedron{S}) where {R, S<:scalar_types, T<:Union{AffineHalfspace{S}, Pair{R, S}, Polyhedron{S}}} = SubObjectIterator{as}(P, _facet_polyhedron, nfacets(P))
@@ -451,12 +451,12 @@ julia> C = cube(3);
 
 julia> facets(C)
 6-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^3 described by:
--x₁ ≦ 1
-x₁ ≦ 1
--x₂ ≦ 1
-x₂ ≦ 1
--x₃ ≦ 1
-x₃ ≦ 1
+-x_1 <= 1
+x_1 <= 1
+-x_2 <= 1
+x_2 <= 1
+-x_3 <= 1
+x_3 <= 1
 ```
 """
 facets(P::Polyhedron{T}) where T<:scalar_types = facets(AffineHalfspace{T}, P)
@@ -773,8 +773,8 @@ julia> t = convex_hull([0 0 2 5; 1 0 2 5; 0 1 2 5]);
 
 julia> affine_hull(t)
 2-element SubObjectIterator{AffineHyperplane{QQFieldElem}} over the Hyperplanes of R^4 described by:
-x₃ = 2
-x₄ = 5
+x_3 = 2
+x_4 = 5
 ```
 """
 affine_hull(P::Polyhedron{T}) where T<:scalar_types = SubObjectIterator{AffineHyperplane{T}}(P, _affine_hull, size(pm_object(P).AFFINE_HULL, 1))
@@ -1260,19 +1260,19 @@ set to `true`.
 # Examples
 ```jldoctest
 julia> print_constraints([-1 0 4 5; 4 4 4 3; 1 0 0 0; 0 0 0 0; 0 0 0 0; 9 9 9 9], [0, 1, 2, 3, -4, 5]; numbered = true)
-1: -x₁ + 4*x₃ + 5*x₄ ≦ 0
-2: 4*x₁ + 4*x₂ + 4*x₃ + 3*x₄ ≦ 1
-3: x₁ ≦ 2
-5: 0 ≦ -4
-6: 9*x₁ + 9*x₂ + 9*x₃ + 9*x₄ ≦ 5
+1: -x_1 + 4*x_3 + 5*x_4 <= 0
+2: 4*x_1 + 4*x_2 + 4*x_3 + 3*x_4 <= 1
+3: x_1 <= 2
+5: 0 <= -4
+6: 9*x_1 + 9*x_2 + 9*x_3 + 9*x_4 <= 5
 
 julia> print_constraints([-1 0 4 5; 4 4 4 3; 1 0 0 0; 0 0 0 0; 0 0 0 0; 9 9 9 9], [0, 1, 2, 3, -4, 5]; trivial = true)
--x₁ + 4*x₃ + 5*x₄ ≦ 0
-4*x₁ + 4*x₂ + 4*x₃ + 3*x₄ ≦ 1
-x₁ ≦ 2
-0 ≦ 3
-0 ≦ -4
-9*x₁ + 9*x₂ + 9*x₃ + 9*x₄ ≦ 5
+-x_1 + 4*x_3 + 5*x_4 <= 0
+4*x_1 + 4*x_2 + 4*x_3 + 3*x_4 <= 1
+x_1 <= 2
+0 <= 3
+0 <= -4
+9*x_1 + 9*x_2 + 9*x_3 + 9*x_4 <= 5
 ```
 """
 function print_constraints(A::AnyVecOrMat, b::AbstractVector; trivial::Bool = false, numbered::Bool = false, io::IO = stdout, cmp::Symbol = :lte)
@@ -1321,12 +1321,12 @@ set to `true`.
 The 3-cube is given by $-1 ≦ x_i ≦ 1 ∀ i ∈ \{1, 2, 3\}$.
 ```jldoctest
 julia> print_constraints(cube(3))
--x₁ ≦ 1
-x₁ ≦ 1
--x₂ ≦ 1
-x₂ ≦ 1
--x₃ ≦ 1
-x₃ ≦ 1
+-x_1 <= 1
+x_1 <= 1
+-x_2 <= 1
+x_2 <= 1
+-x_3 <= 1
+x_3 <= 1
 ```
 """
 print_constraints(P::Polyhedron; trivial::Bool = false, numbered::Bool = false, io::IO = stdout) = print_constraints(halfspace_matrix_pair(facets(P))...; trivial = trivial, io = io)

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -1250,12 +1250,17 @@ _cmp_string(::Val{:lte}) = is_unicode_allowed() ? "≦" : "<="
 _cmp_string(::Val{:eq}) = "="
 
 @doc raw"""
-    print_constraints(A::AnyVecOrMat, b::AbstractVector; trivial::Bool = false, numbered::Bool = false)
+    print_constraints(A::AnyVecOrMat, b::AbstractVector; trivial = false, numbered = false, io = stdout, cmp = :lte)
 
 Pretty print the constraints given by $P(A,b) = \{ x |  Ax ≤ b \}$.
 
-Trivial inequalities are counted but omitted. They are included if `trivial` is
-set to `true`.
+# Keyword Arguments
+- `trivial::Bool`: If `true`, include trivial inequalities.
+- `numbered::Bool`: If `true`, the each constraint is printed with the index corresponding to the input `AnyVecOrMat`.
+- `io::IO`: Target `IO` where the  constraints are printed to.
+- `cmp::Symbol`: Defines the string used for the comparison sign; supports `:lte` (less than or equal) and `:eq` (equal).
+
+Trivial inequalities are always counted for numbering, even when omitted.
 
 # Examples
 ```jldoctest
@@ -1310,12 +1315,16 @@ _constraint_string(x::QQFieldElem) = string(x)
 _constraint_string(x::FieldElem) = string("(", x, ")")
 
 @doc raw"""
-    print_constraints(P::Polyhedron; trivial::Bool = false, numbered::Bool = false)
+    print_constraints(P::Polyhedron; trivial = false, numbered = false, io = stdout)
 
 Pretty print the constraints given by $P(A,b) = \{ x |  Ax ≤ b \}$.
 
-Trivial inequalities are counted but omitted. They are included if `trivial` is
-set to `true`.
+# Keyword Arguments
+- `trivial::Bool`: If `true`, include trivial inequalities.
+- `numbered::Bool`: If `true`, the each constraint is printed with the index corresponding to the input `AnyVecOrMat`.
+- `io::IO`: Target `IO` where the  constraints are printed to.
+
+Trivial inequalities are always counted for numbering, even when omitted.
 
 # Examples
 The 3-cube is given by $-1 ≦ x_i ≦ 1 ∀ i ∈ \{1, 2, 3\}$.

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -1340,9 +1340,9 @@ x_3 <= 1
 """
 print_constraints(io::IO, P::Polyhedron; trivial::Bool = false, numbered::Bool = false) = print_constraints(io, halfspace_matrix_pair(facets(P))...; trivial = trivial)
 
-print_constraints(io::IO, H::Halfspace; trivial::Bool = false) = print_constraints(io, hcat(normal_vector(H)...), [negbias(H)]; trivial = trivial)
+print_constraints(io::IO, H::Halfspace; trivial::Bool = false) = print_constraints(io, permutedims(normal_vector(H)), [negbias(H)]; trivial = trivial)
 
-print_constraints(io::IO, H::Hyperplane; trivial::Bool = false) = print_constraints(io, hcat(normal_vector(H)...), [negbias(H)]; trivial = trivial, cmp = :eq)
+print_constraints(io::IO, H::Hyperplane; trivial::Bool = false) = print_constraints(io, permutedims(normal_vector(H)), [negbias(H)]; trivial = trivial, cmp = :eq)
 
 print_constraints(io::IO, H::SubObjectIterator{<:Halfspace}; numbered::Bool = false) = print_constraints(io, halfspace_matrix_pair(H)...; trivial = true, numbered = numbered)
 

--- a/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
+++ b/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
@@ -598,28 +598,28 @@ Polyhedron in ambient dimension 7
 
 julia> facets(s)
 8-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^7 described by:
--x₁ ≦ 0
--x₂ ≦ 0
--x₃ ≦ 0
--x₄ ≦ 0
--x₅ ≦ 0
--x₆ ≦ 0
--x₇ ≦ 0
-x₁ + x₂ + x₃ + x₄ + x₅ + x₆ + x₇ ≦ 1
+-x_1 <= 0
+-x_2 <= 0
+-x_3 <= 0
+-x_4 <= 0
+-x_5 <= 0
+-x_6 <= 0
+-x_7 <= 0
+x_1 + x_2 + x_3 + x_4 + x_5 + x_6 + x_7 <= 1
 
 julia> t = simplex(7, 5)
 Polyhedron in ambient dimension 7
 
 julia> facets(t)
 8-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^7 described by:
--x₁ ≦ 0
--x₂ ≦ 0
--x₃ ≦ 0
--x₄ ≦ 0
--x₅ ≦ 0
--x₆ ≦ 0
--x₇ ≦ 0
-x₁ + x₂ + x₃ + x₄ + x₅ + x₆ + x₇ ≦ 5
+-x_1 <= 0
+-x_2 <= 0
+-x_3 <= 0
+-x_4 <= 0
+-x_5 <= 0
+-x_6 <= 0
+-x_7 <= 0
+x_1 + x_2 + x_3 + x_4 + x_5 + x_6 + x_7 <= 5
 ```
 """
 function simplex(f::Union{Type{T},Field}, d::Int, n) where {T<:scalar_types}
@@ -654,28 +654,28 @@ Polyhedron in ambient dimension 3
 
 julia> facets(C)
 8-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^3 described by:
-x₁ + x₂ + x₃ ≦ 1
--x₁ + x₂ + x₃ ≦ 1
-x₁ - x₂ + x₃ ≦ 1
--x₁ - x₂ + x₃ ≦ 1
-x₁ + x₂ - x₃ ≦ 1
--x₁ + x₂ - x₃ ≦ 1
-x₁ - x₂ - x₃ ≦ 1
--x₁ - x₂ - x₃ ≦ 1
+x_1 + x_2 + x_3 <= 1
+-x_1 + x_2 + x_3 <= 1
+x_1 - x_2 + x_3 <= 1
+-x_1 - x_2 + x_3 <= 1
+x_1 + x_2 - x_3 <= 1
+-x_1 + x_2 - x_3 <= 1
+x_1 - x_2 - x_3 <= 1
+-x_1 - x_2 - x_3 <= 1
 
 julia> D = cross_polytope(3, 2)
 Polyhedron in ambient dimension 3
 
 julia> facets(D)
 8-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^3 described by:
-x₁ + x₂ + x₃ ≦ 2
--x₁ + x₂ + x₃ ≦ 2
-x₁ - x₂ + x₃ ≦ 2
--x₁ - x₂ + x₃ ≦ 2
-x₁ + x₂ - x₃ ≦ 2
--x₁ + x₂ - x₃ ≦ 2
-x₁ - x₂ - x₃ ≦ 2
--x₁ - x₂ - x₃ ≦ 2
+x_1 + x_2 + x_3 <= 2
+-x_1 + x_2 + x_3 <= 2
+x_1 - x_2 + x_3 <= 2
+-x_1 - x_2 + x_3 <= 2
+x_1 + x_2 - x_3 <= 2
+-x_1 + x_2 - x_3 <= 2
+x_1 - x_2 - x_3 <= 2
+-x_1 - x_2 - x_3 <= 2
 ```
 """
 function cross_polytope(f::Union{Type{T},Field}, d::Int64, n) where {T<:scalar_types}
@@ -1318,11 +1318,11 @@ julia> vertices(A)
 
 julia> facets(A)
 5-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^4 described by:
--x₁ ≦ -1
--2*x₁ - 2*x₂ ≦ -10
--x₂ ≦ -1
--2*x₂ - 2*x₃ ≦ -10
--x₃ ≦ -1
+-x_1 <= -1
+-2*x_1 - 2*x_2 <= -10
+-x_2 <= -1
+-2*x_2 - 2*x_3 <= -10
+-x_3 <= -1
 ```
 """
 function associahedron(d::Int)
@@ -1517,10 +1517,10 @@ julia> f = fractional_knapsack_polytope([10,-2,-3,-5])
 Polyhedron in ambient dimension 3
 
 julia> print_constraints(f)
-2*x₁ + 3*x₂ + 5*x₃ ≦ 10
--x₁ ≦ 0
--x₂ ≦ 0
--x₃ ≦ 0
+2*x_1 + 3*x_2 + 5*x_3 <= 10
+-x_1 <= 0
+-x_2 <= 0
+-x_3 <= 0
 ```
 """
 fractional_knapsack_polytope(b::AbstractVector{<:Base.Number}) = Polyhedron{QQFieldElem}(
@@ -1547,17 +1547,17 @@ Polyhedron in ambient dimension 4
 
 julia> facets(G)
 4-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^4 described by:
-x₄ ≦ 1
-x₃ ≦ 1
--x₁ - x₃ - x₄ ≦ -2
-x₁ ≦ 1
+x_4 <= 1
+x_3 <= 1
+-x_1 - x_3 - x_4 <= -2
+x_1 <= 1
 
 julia> facets(H)
 4-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^4 described by:
-x₄ ≦ 1
-x₃ ≦ 1
--x₁ - x₃ - x₄ ≦ -2
-x₁ ≦ 1
+x_4 <= 1
+x_3 <= 1
+-x_1 - x_3 - x_4 <= -2
+x_1 <= 1
 ```
 """
 function hypersimplex(
@@ -1700,15 +1700,15 @@ julia> H = hypertruncated_cube(3,2,3)
 Polyhedron in ambient dimension 3
 
 julia> print_constraints(H)
--x₁ ≦ 0
--x₂ ≦ 0
--x₃ ≦ 0
-x₁ ≦ 1
-x₂ ≦ 1
-x₃ ≦ 1
-5*x₁ - 2*x₂ - 2*x₃ ≦ 3
--2*x₁ + 5*x₂ - 2*x₃ ≦ 3
--2*x₁ - 2*x₂ + 5*x₃ ≦ 3
+-x_1 <= 0
+-x_2 <= 0
+-x_3 <= 0
+x_1 <= 1
+x_2 <= 1
+x_3 <= 1
+5*x_1 - 2*x_2 - 2*x_3 <= 3
+-2*x_1 + 5*x_2 - 2*x_3 <= 3
+-2*x_1 - 2*x_2 + 5*x_3 <= 3
 ```
 """
 function hypertruncated_cube(d::Int, k::Number, lambda::Number)
@@ -1760,12 +1760,12 @@ julia> k = klee_minty_cube(3,1//8)
 Polyhedron in ambient dimension 3
 
 julia> print_constraints(k)
--x₁ ≦ 0
-x₁ ≦ 1
-1//8*x₁ - x₂ ≦ 0
-1//8*x₁ + x₂ ≦ 1
-1//8*x₂ - x₃ ≦ 0
-1//8*x₂ + x₃ ≦ 1
+-x_1 <= 0
+x_1 <= 1
+1//8*x_1 - x_2 <= 0
+1//8*x_1 + x_2 <= 1
+1//8*x_2 - x_3 <= 0
+1//8*x_2 + x_3 <= 1
 ```
 """
 function klee_minty_cube(d::Int, e::Number)
@@ -2146,15 +2146,15 @@ julia> vertices(a)
 
 julia> facets(a) 
 9-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^5 described by:
-x₁ - x₂ ≦ -1
-x₁ - x₃ ≦ -4
-x₁ - x₄ ≦ -9
-x₂ - x₃ ≦ -1
-x₂ - x₄ ≦ -4
-x₂ - x₅ ≦ -9
-x₃ - x₄ ≦ -1
-x₃ - x₅ ≦ -4
-x₄ - x₅ ≦ -1
+x_1 - x_2 <= -1
+x_1 - x_3 <= -4
+x_1 - x_4 <= -9
+x_2 - x_3 <= -1
+x_2 - x_4 <= -4
+x_2 - x_5 <= -9
+x_3 - x_4 <= -1
+x_3 - x_5 <= -4
+x_4 - x_5 <= -1
 ```
 """
 function rss_associahedron(n::Int)


### PR DESCRIPTION
Following the conventions on printing in Oscar, `print_constraints`, which was used in several different contexts, now uses ASCII as long as `Oscar.is_unicode_allowed() == false`, and uses Unicode otherwise.

Docstrings have been adjusted/extended accordingly.

`_constraint_string(x::FieldElem) = string("(", x, ")")` also places parentheses around single `FieldElem`s. This is because e.g. an `EmbeddedElem{nf_elem}` as a factor of `x_1` should print as `(-1//2*sqrt(5) - 1//2)*x_1` instead of `-1//2*sqrt(5) - 1//2*x_1`. This behaviour can be refined in the future, e.g. for specific `FieldElem` types or probably even specific instances.

This PR resolves #2820