### PR TITLE
deduce finiteness of the normal subgroup in `quo`

### DIFF
--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -483,6 +483,10 @@ PermGroup
 """
 function quo(G::T, N::T) where T <: GAPGroup
   mp = GAP.Globals.NaturalHomomorphismByNormalSubgroup(G.X, N.X)::GapObj
+  # The call may have found out new information about `G.X`,
+  # for example that `G.X` is finite.
+#FIXME: The GAP function should deal with this situation.
+  GAP.Globals.UseSubsetRelation(G.X, N.X)
   cod = GAP.Globals.ImagesSource(mp)::GapObj
   S = elem_type(G)
   S1 = _get_type(cod)

--- a/test/Groups/quotients.jl
+++ b/test/Groups/quotients.jl
@@ -117,3 +117,14 @@ end
    @test f(S([1,2,4,3]))==G[1]
    @test f(S([2,1,4,3]))==one(G)
 end
+
+@testset "matrix groups" begin
+   K, a = CyclotomicField(3, "a");
+   S = matrix(K, [0 0 1; 1 0 0; 0 1 0])
+   T = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1])
+   H3 = matrix_group(S, T)
+   C, iC = center(H3);
+   @test !has_is_finite(C)
+   Q, pQ = quo(H3, C);
+   @test has_is_finite(C)
+end


### PR DESCRIPTION
if finiteness of the whole group was set in the computation on the GAP side
(suggested by @wdecker)