### PR TITLE
Invariant rings with an existing polynomial ring

### DIFF
--- a/src/InvariantTheory/types.jl
+++ b/src/InvariantTheory/types.jl
@@ -70,15 +70,23 @@ mutable struct InvRing{FldT, GrpT, PolyRingElemT, PolyRingT, ActionT}
 
   function InvRing(K::FldT, G::GrpT, action::Vector{ActionT}) where {FldT <: Field, GrpT <: AbstractAlgebra.Group, ActionT}
     n = degree(G)
-
     # We want to use divrem w.r.t. degrevlex e.g. for the computation of
     # secondary invariants and fundamental invariants
     R, = grade(polynomial_ring(K, "x" => 1:n, cached = false, ordering = :degrevlex)[1], ones(Int, n))
-    PolyRingT = typeof(R)
-    PolyRingElemT = elem_type(R)
+    return InvRing(K, G, action, R)
+  end
+
+  function InvRing(K::FldT, G::GrpT, action::Vector{ActionT}, poly_ring::PolyRingT) where {FldT <: Field, GrpT <: AbstractAlgebra.Group, ActionT, PolyRingT <: MPolyDecRing}
+    @assert coefficient_ring(poly_ring) === K
+    @assert ngens(poly_ring) == degree(G)
+    # We want to use divrem w.r.t. degrevlex e.g. for the computation of
+    # secondary invariants and fundamental invariants
+    @assert ordering(poly_ring) == :degrevlex
+
+    PolyRingElemT = elem_type(poly_ring)
     z = new{FldT, GrpT, PolyRingElemT, PolyRingT, ActionT}()
     z.field = K
-    z.poly_ring = R
+    z.poly_ring = poly_ring
     z.group = G
     z.action = action
     z.modular = true

--- a/test/InvariantTheory/invariant_rings.jl
+++ b/test/InvariantTheory/invariant_rings.jl
@@ -9,6 +9,11 @@
   invariant_ring(K, [ M1, M2 ])
   invariant_ring(matrix_group([ M1, M2 ]))
 
+  R, _ = graded_polynomial_ring(K, 3, "x", ones(Int, 3), ordering = :degrevlex)
+  @test polynomial_ring(invariant_ring(R, [ M1, M2 ])) === R
+  @test polynomial_ring(invariant_ring(R, M1, M2)) === R
+  @test polynomial_ring(invariant_ring(R, matrix_group(M1, M2))) === R
+
   F = GF(3)
   N1 = matrix(F, 3, 3, [ 0, 1, 0, 2, 0, 0, 0, 0, 2 ])
   N2 = matrix(F, 3, 3, [ 2, 0, 0, 0, 2, 0, 0, 0, 2 ])
@@ -112,6 +117,9 @@ end
 
   F3 = GF(3)
   RGM = invariant_ring(F3, G)  # char. p, modular
+
+  R, _ = graded_polynomial_ring(K, 3, "x", ones(Int, 3), ordering = :degrevlex)
+  @test polynomial_ring(invariant_ring(R, G)) === R
 
   @test coefficient_ring(RGQ) == QQ
   @test coefficient_ring(RGK) == K


### PR DESCRIPTION
Add constructors to allow setting the underlying polynomial ring of an invariant ring (as requested by @wdecker ; I also already had this problem).

We can argue about the syntax: Right now the functions are `invariant_ring(::MPolyDecRing, ::Group)` (so the ring as first argument). This slightly collides with the existing `invariant_ring(::Field, ::Group)` which creates an invariant ring with the corresponding coefficient field. Should I change the signature to `invariant_ring([::Field], ::Group, [::MPolyDecRing])`?