### PR TITLE
`QuadFormWithIsom`: further cleanups + preparation for incoming new features

### DIFF
--- a/experimental/QuadFormAndIsom/README.md
+++ b/experimental/QuadFormAndIsom/README.md
@@ -15,6 +15,7 @@ forms.
 We introduce two new structures
 * `QuadSpaceWithIsom`
 * `ZZLatWithIsom`
+
 The former parametrizes pairs $(V, f)$ where $V$ is a rational quadratic form
 and $f$ is an isometry of $V$. The latter parametrizes pairs $(L, f)$ where
 $L$ is an integral quadratic form, also known as $\mathbb Z$-lattice and $f$
@@ -40,7 +41,7 @@ Among the possible improvements and extensions:
 * Implement extra methods for lattices with isometries of infinite order;
 * Extend existing methods for equivariant primitive embeddings/extensions.
 
-## Currently application of this project
+## Current applications of this project
 
 The project was initiated by S. Brandhorst and T. Hofmann for classifying
 finite subgroups of automorphisms of K3 surfaces. Our current goal is to use

--- a/experimental/QuadFormAndIsom/docs/src/enumeration.md
+++ b/experimental/QuadFormAndIsom/docs/src/enumeration.md
@@ -85,6 +85,6 @@ Note that an important feature from the theory in [BH23](@cite) is the notion of
 *admissible gluings* and equivariant primitive embeddings for admissible triples.
 In the next chapter, we present the methods regarding Nikulins's theory on primitive
 embeddings and their equivariant version. We use this basis to introduce the
-method [`admissible_equivariant_primitive_extension`](@ref) (Algorithm 2 in
+method [`admissible_equivariant_primitive_extensions`](@ref) (Algorithm 2 in
 [BH23](@cite)) which is the major tool making the previous enumeration
 possible and fast, from an algorithmic point of view.

--- a/experimental/QuadFormAndIsom/docs/src/enumeration.md
+++ b/experimental/QuadFormAndIsom/docs/src/enumeration.md
@@ -12,19 +12,19 @@ reference.
 
 ## Admissible triples
 
-Roughly speaking, for a prime number $p$, a *$p$-admissible triple* `(A, B, C)`
-is a triple of integer lattices such that, in certain cases, `C` can be obtained
-as a primitive extension $A \perp B \to C$ where one can glue along
-$p$-elementary subgroups of the respective discriminant groups of `A` and `B`.
+Roughly speaking, for a prime number $p$, a *$p$-admissible triple* $(A, B, C)$
+is a triple of integer lattices such that, in some cases, $C$ can be obtained
+as a primitive extension $A \oplus B \to C$ where one can glue along
+$p$-elementary subgroups of the respective discriminant groups of $A$ and $B$.
 Note that not all admissible triples satisfy this extension property.
 
-For instance, if $f$ is an isometry of an integer lattice `C` of prime order
-`p`, then for $A := \ker \Phi_1(f)$ and $B := \ker \Phi_p(f)$, one has that
-`(A, B, C)` is $p$-admissible (see Lemma 4.15. in [BH23](@cite)).
+For instance, if $f$ is an isometry of an integer lattice $C$ of prime order
+$p$, then for $A := \ker \Phi_1(f)$ and $B := \ker \Phi_p(f)$, one has that
+$(A, B, C)$ is $p$-admissible (see Lemma 4.15. in [BH23](@cite)).
 
-We say that a triple `(AA, BB, CC)` of genus symbols for integer lattices is
-*$p$-admissible* if there are some lattices $A \in AA$, $B \in BB$ and
-$C \in CC$ such that $(A, B, C)$ is $p$-admissible.
+We say that a triple $(G_A, G_B, G_C)$ of genus symbols for integer lattices is
+*$p$-admissible* if there are some lattices $A \in G_A$, $B \in G_B$ and
+$C \in G_C$ such that $(A, B, C)$ is $p$-admissible.
 
 We use Definition 4.13. and Algorithm 1 of [BH23](@cite) to implement the necessary
 tools for working with admissible triples. Most of the computations consists of
@@ -70,7 +70,8 @@ iteratively the order up to $p^dq^e$.
 ### Underlying machinery
 
 Here is a list of the algorithmic machinery provided by [BH23](@cite) used
-previously to enumerate lattices with isometry:
+previously to enumerate lattices with isometry. The following correspond
+respectively to Algorithms 3, 4, 5, 6 and 7 of the aforementioned paper:
 
 ```@docs
 representatives_of_hermitian_type(::ZZLatWithIsom, ::Int)
@@ -84,6 +85,6 @@ Note that an important feature from the theory in [BH23](@cite) is the notion of
 *admissible gluings* and equivariant primitive embeddings for admissible triples.
 In the next chapter, we present the methods regarding Nikulins's theory on primitive
 embeddings and their equivariant version. We use this basis to introduce the
-method `admissible_equivariant_primitive_extension` (Algorithm 2 in
+method [`admissible_equivariant_primitive_extension`](@ref) (Algorithm 2 in
 [BH23](@cite)) which is the major tool making the previous enumeration
 possible and fast, from an algorithmic point of view.

--- a/experimental/QuadFormAndIsom/docs/src/introduction.md
+++ b/experimental/QuadFormAndIsom/docs/src/introduction.md
@@ -15,17 +15,18 @@ forms.
 We introduce two new structures
 * [`QuadSpaceWithIsom`](@ref)
 * [`ZZLatWithIsom`](@ref)
+
 The former parametrizes pairs $(V, f)$ where $V$ is a rational quadratic form
 and $f$ is an isometry of $V$. The latter parametrizes pairs $(L, f)$ where
 $L$ is an integral quadratic form, also known as $\mathbb Z$-lattice and $f$
 is an isometry of $L$. One of the main features of this project is the
 enumeration of isomorphism classes of pairs $(L, f)$, where $f$ is an isometry
 of finite order with at most two prime divisors. The methods we resort to
-for this purpose are developed in the paper [BH23].
+for this purpose are developed in the paper [BH23](@cite).
 
 We also provide some algorithms computing isomorphism classes of primitive
 embeddings of even lattices following Nikulin's theory. More precisely, the
-function `primitive_embeddings` offers, under certain conditions,
+function [`primitive_embeddings`](@ref) offers, under certain conditions,
 the possibility to compute representatives of primitive embeddings and classify
 them in different ways. Note nonetheless that these functions are not efficient
 in the case were the discriminant groups have a large number of subgroups.
@@ -40,7 +41,7 @@ Among the possible improvements and extensions:
 * Implement extra methods for lattices with isometries of infinite order;
 * Extend existing methods for equivariant primitive embeddings/extensions.
 
-## Currently application of this project
+## Current applications of this project
 
 The project was initiated by S. Brandhorst and T. Hofmann for classifying
 finite subgroups of automorphisms of K3 surfaces. Our current goal is to use

--- a/experimental/QuadFormAndIsom/docs/src/latwithisom.md
+++ b/experimental/QuadFormAndIsom/docs/src/latwithisom.md
@@ -2,11 +2,11 @@
 CurrentModule = Oscar
 ```
 
-# Lattice with isometry
+# Lattices with isometry
 
 We call *lattice with isometry* any pair $(L, f)$ consisting of an integer
 lattice $L$ together with an isometry $f \in O(L)$. We refer to the section
-about integer lattices of the documentation for new users.
+about [Integer Lattices](@ref) of the documentation for new users.
 
 In Oscar, such a pair is encoded in the type called `ZZLatWithIsom`:
 
@@ -14,7 +14,7 @@ In Oscar, such a pair is encoded in the type called `ZZLatWithIsom`:
 ZZLatWithIsom
 ```
 
-and it is seen as a quadruple $(Vf, L, f, n)$ where $Vf = (V, f_a)$ consists of
+It is seen as a quadruple $(Vf, L, f, n)$ where $Vf = (V, f_a)$ consists of
 the ambient rational quadratic space $V$ of $L$ and an isometry $f_a$ of $V$
 preserving $L$ and inducing $f$ on $L$. The integer $n$ is the order of $f$,
 which is a divisor of the order of the isometry $f_a\in O(V)$.
@@ -34,7 +34,7 @@ Note that for some computations, it is more convenient to work either with the
 isometry of the lattice itself, or with the fixed isometry of the ambient
 quadratic space inducing it on the lattice.
 
-## Constructor
+## Constructors
 
 We provide two ways to construct a pair $Lf = (L,f)$ consisting of an integer
 lattice endowed with an isometry. One way to construct an object of type
@@ -81,9 +81,14 @@ genus(::ZZLatWithIsom)
 gram_matrix(::ZZLatWithIsom)
 is_definite(::ZZLatWithIsom)
 is_even(::ZZLatWithIsom)
+is_elementary(::ZZLatWithIsom, ::IntegerUnion)
+is_elementary_with_prime(::ZZLatWithIsom)
 is_integral(::ZZLatWithIsom)
 is_positive_definite(::ZZLatWithIsom)
+is_primary(::ZZLatWithIsom, ::IntegerUnion)
+is_primary_with_prime(::ZZLatWithIsom)
 is_negative_definite(::ZZLatWithIsom)
+is_unimodular(::ZZLatWithIsom)
 minimum(::ZZLatWithIsom)
 minimal_polynomial(::ZZLatWithIsom)
 norm(::ZZLatWithIsom)
@@ -93,8 +98,8 @@ scale(::ZZLatWithIsom)
 signature_tuple(::ZZLatWithIsom)
 ```
 
-Similarly, some basic operations on $\mathbb Z$-lattices are available for
-lattices with isometry.
+Similarly, some basic operations on $\mathbb Z$-lattices and matrices are
+available for integer lattices with isometry.
 
 ```@docs
 Base.:^(::ZZLatWithIsom, ::Int)
@@ -103,6 +108,7 @@ direct_product(::Vector{ZZLatWithIsom})
 direct_sum(::Vector{ZZLatWithIsom})
 dual(::ZZLatWithIsom)
 lll(::ZZLatWithIsom)
+orthogonal_submodule(::ZZLatWithIsom, ::QQMatrix)
 rescale(::ZZLatWithIsom, ::RationalUnion)
 ```
 
@@ -131,7 +137,7 @@ pair $(L, f)$ is of *hermitian type*. The type of a lattice with isometry of
 hermitian type is called *hermitian* (note that the type is only defined for
 finite order isometries).
 
-These namings follow from the fact that, by the trace equivalence, one can
+These names follow from the fact that, by the trace equivalence, one can
 associate to the pair $(L, f)$ a hermitian lattice over the equation order of
 $f$, if it is maximal in the associated number field $\mathbb{Q}[f]$.
 
@@ -140,7 +146,7 @@ is_of_hermitian_type(::ZZLatWithIsom)
 is_hermitian(::Dict)
 ```
 
-## Hermitian structure and trace equivalence
+## Hermitian structures and trace equivalence
 
 As mentioned in the previous section, to a lattice with isometry $Lf := (L, f)$
 such that the minimal polynomial of $f$ is irreducible, one can associate a
@@ -152,7 +158,7 @@ to perform the trace equivalence for lattices with isometry of hermitian type.
 hermitian_structure(::ZZLatWithIsom)
 ```
 
-## Discriminant group
+## Discriminant groups
 
 Given an integral lattice with isometry $Lf := (L, f)$, if one denotes by $D_L$ the
 discriminant group of $L$, there exists a natural map $\pi\colon O(L) \to O(D_L)$
@@ -168,18 +174,25 @@ discriminant_group(::ZZLatWithIsom)
 
 For simple cases as for definite lattices, $f$ being plus-or-minus the identity
 or if the rank of $L$ is equal to the totient of the order of $f$ (in the
-finite case), $G_{L,f}$ can be easily computed. The only other case which can
-be currently handled is for lattices with isometry of hermitian type following
-the *hermitian Miranda-Morisson theory* from [BH23](@cite). This has been implemented
-in this project and it can be indirectly used through the general following method:
+finite case), $G_{L,f}$ can be easily computed. For the remaining cases, we use
+the hermitian version of *Miranda-Morrison theory* as presented in
+[BH23](@cite). The general computation of $G_{L, f}$ has been implemented in this
+project and it can be indirectly used through the general following method:
 
 ```@docs
 image_centralizer_in_Oq(::ZZLatWithIsom)
 ```
 
-For an implementation of the regular Miranda-Morisson theory, we refer to the
+For an implementation of the regular Miranda-Morrison theory, we refer to the
 function `image_in_Oq` which actually computes the image of
 $\pi$ in both the definite and the indefinite case.
+
+More generally, for a finitely generated subgroup $G$ of $O(L)$, we have
+implemented a function which computes the representation of $G$ on $D_L$:
+
+```@docs
+discriminant_representation(::ZZLat, ::MatrixGroup)
+```
 
 We will see later in the section about enumeration of lattices with isometry
 that one can compute $G_{L,f}$ in some particular cases arising from equivariant
@@ -204,6 +217,7 @@ the so-called *invariant* and *coinvariant* lattices of $(L, f)$:
 ```@docs
 coinvariant_lattice(::ZZLatWithIsom)
 invariant_lattice(::ZZLatWithIsom)
+invariant_coinvariant_pair(::ZZLatWithIsom)
 ```
 
 Similarly, we provide the possibility to compute invariant and coinvariant
@@ -221,7 +235,7 @@ invariant_coinvariant_pair(::ZZLat, ::MatrixGroup)
 We conclude this introduction about standard functionalities for lattices with
 isometry by introducing a last invariant for lattices with finite isometry of
 hermitian type $(L, f)$, called the *signatures*. These signatures are
-are intrinsequely connected to the local archimedean invariants of the
+intrinsically connected to the local archimedean invariants of the
 hermitian structure associated to $(L, f)$ via the trace equivalence.
 
 ```@docs
@@ -232,7 +246,6 @@ signatures(::ZZLatWithIsom)
 
 We choose as a convention that two pairs $(L, f)$ and $(L', f')$ of integer
 lattices with isometries are *equal* if their ambient quadratic space with
-isometry of type `QuadSpaceWithIsom` are equal, and if the underlying lattices
+isometry of type [`QuadSpaceWithIsom`](@ref) are equal, and if the underlying lattices
 $L$ and $L'$ are equal as $\mathbb Z$-modules in the common ambient quadratic
 space.
-

--- a/experimental/QuadFormAndIsom/docs/src/primembed.md
+++ b/experimental/QuadFormAndIsom/docs/src/primembed.md
@@ -53,14 +53,17 @@ primitive_embeddings(::TorQuadModule, ::Tuple{Int, Int},
 ```
 
 In order to compute such primitive embeddings of a lattice $M$ into a lattice
-$L$, one first computes the possible genera for the orthogonal of $M$ in $L$
-(after embedding). For each lattice $N$ representing an isometry class in such
-a genus, one computes isomorphism classes of *primitive extensions* of
-$M \oplus N$ modulo $\overline{O(N)}$ (and $\overline{O(M)}$ in the case
-of classification of primitive sublattices of $L$ isometric to $M$).
+$L$, we follow the proof of Proposition 1.15.1 of [Nik79](@cite).
+
+Note: for the implementation of the algorithm, we construct an even lattice
+$T := M(-1)\oplus U$ where $U$ is a hyperbolic plane - $T$ is unique in its
+genus and $O(T)\to O(D_T)$ is surjective. We then classify all primitive
+extensions of $M\oplus T$ modulo $O(D_T)$ (and modulo $O(M)$ for a
+classification of primitive sublattices). To classify such primitive
+extensions, we use Proposition 1.5.1 of [Nik79](@cite):
 
 ```@docs
-primitive_extensions(::ZZLat, ::ZZLat, ::TorQuadModule)
+primitive_extensions(::ZZLat, ::ZZLat)
 ```
 
 We recall that a *primitive extension* of the orthogonal direct sum of two

--- a/experimental/QuadFormAndIsom/docs/src/primembed.md
+++ b/experimental/QuadFormAndIsom/docs/src/primembed.md
@@ -3,11 +3,12 @@ CurrentModule = Oscar
 ```
 
 We introduce here the necessary definitions and results which lie behind the
-methods presented. Most of the content is taken from [Nik79](@cite).
+methods about primitive embeddings. Most of the content is taken from
+[Nik79](@cite).
 
-# Primitive embeddings in even lattices
+# Nikulin's theory on primitive embeddings
 
-## Nikulin's theory
+## Primitive embeddings
 
 Given an embedding $i\colon S\hookrightarrow T$ of non-degenerate integral
 integer lattices, we call $i$ *primitive* if its cokernel $T/i(S)$ is torsion
@@ -22,7 +23,7 @@ In his paper, V. V. Nikulin gives necessary and sufficient condition for an even
 integral lattice $M$ to embed primitively into an even unimodular lattice with
 given invariants (see Theorem 1.12.2 in [Nik79](@cite)). More generally, the
 author also provides methods to compute primitive embeddings of any even lattice
-into an even lattice in a given genus (see Proposition 1.15.1 in [Nik79](@cite)).
+into an even lattice of a given genus (see Proposition 1.15.1 in [Nik79](@cite)).
 In the latter proposition, it is explained how to classify such embeddings as
 isomorphic embeddings or as isomorphic sublattices.
 
@@ -51,38 +52,42 @@ primitive_embeddings(::TorQuadModule, ::Tuple{Int, Int},
 ::ZZLat)
 ```
 
-In order to compute such primitive embeddings of a lattice `M` into a lattice
-`L`, one first computes the possible genera for the orthogonal of `M` in `L`
-(after embedding), and for each lattice `N` in such a genus, one computes
-isomorphism classes of *primitive extensions* of $M \perp N$ modulo $\bar{O}(N)$
-(and $\bar{O}(M)$ in the case of classification of primitive sublattices of `L`
-isometric to `M`).
+In order to compute such primitive embeddings of a lattice $M$ into a lattice
+$L$, one first computes the possible genera for the orthogonal of $M$ in $L$
+(after embedding). For each lattice $N$ representing an isometry class in such
+a genus, one computes isomorphism classes of *primitive extensions* of
+$M \oplus N$ modulo $\overline{O(N)}$ (and $\overline{O(M)}$ in the case
+of classification of primitive sublattices of $L$ isometric to $M$).
+
+```@docs
+primitive_extensions(::ZZLat, ::ZZLat, ::TorQuadModule)
+```
 
 We recall that a *primitive extension* of the orthogonal direct sum of two
-integral integer lattices `M` and `N` is an overlattice `L` of $M\perp N$ such
-that both `M` and `N` embed primitively in `L` (via the natural embeddings
-$M,N \to M\perp N\subseteq L$). Such primitive extensions are obtained, and
-classified, by looking for *gluings* between anti-isometric subgroups of the
-respective discriminant groups of `M` and `N`. The construction of an
-overlattice is determined by the graph of such glue map. 
+integral integer lattices $M$ and $N$ is an overlattice $L$ of $M\oplus N$ such
+that both $M$ and $N$ embed primitively in $L$ (via the natural embeddings
+$M,N \to M\oplus N\subseteq L$). Such primitive extensions are obtained, and
+classified, by classifying *gluings* between anti-isometric subgroups of the
+respective discriminant groups of $M$ and $N$. The construction of an
+overlattice is determined by the graph of such gluing.
 
 ## Admissible equivariant primitive extensions
 
-The following function is an interesting tool provided by [BH23](@cite). Given
-a triple of integer lattices with isometry `((A, a), (B, b), (C, c))` and two prime
-numbers `p` and `q` (possibly equal), if `(A, B, C)` is `p`-admissible, this
+The following function is a major tool provided by [BH23](@cite). Given
+a triple of integer lattices with isometry $((A, a), (B, b), (C, c))$ and two prime
+numbers $p$ and $q$ (possibly equal), if $(A, B, C)$ is $p$-admissible, this
 function returns representatives of isomorphism classes of equivariant primitive
-extensions $(A, a)\perp (B, b)\to (D, d)$ such that the type of $(D, d^p)$ is
+extensions $(A, a)\oplus (B, b)\to (D, d)$ such that the type of $(D, d^q)$ is
 equal to the type of $(C, c)$ (see [`type(::ZZLatWithIsom)`](@ref)).
 
 ```@docs
-admissible_equivariant_primitive_extensions(::ZZLatWithIsom, ::ZZLatWithIsom, ::ZZLatWithIsom, ::Integer, ::Integer)
+admissible_equivariant_primitive_extensions(::ZZLatWithIsom, ::ZZLatWithIsom, ::ZZLatWithIsom, ::IntegerUnion, ::IntegerUnion)
 ```
 
 An *equivariant primitive extension* of a pair of integer lattices with
-isometries $(M, f_M)$ and $(N, f_N)$ is a primitive extension of `M` and `N`
-obtained by gluing two subgroups which are respectively $\bar{f_M}$ and
-$\bar{f_N}$ stable along a glue map which commutes with these two actions. If
-such a gluing exists, then the overlattice `L` of $M\perp N$ is equipped with
-an isometry $f_L$ which preserves both `M` and `N`, and restricts to $f_M$ and
+isometries $(M, f_M)$ and $(N, f_N)$ is a primitive extension of $M$ and $N$
+obtained by gluing two subgroups which are respectively $\overline{f_M}$ and
+$\overline{f_N}$ stable along a glue map which commutes with these two actions.
+If such a gluing exists, then the overlattice $L$ of $M\oplus N$ is equipped with
+an isometry $f_L$ which preserves both $M$ and $N$, and restricts to $f_M$ and
 $f_N$ respectively.

--- a/experimental/QuadFormAndIsom/docs/src/spacewithisom.md
+++ b/experimental/QuadFormAndIsom/docs/src/spacewithisom.md
@@ -2,15 +2,15 @@
 CurrentModule = Oscar
 ```
 
-# Quadratic space with isometry
+# Quadratic spaces with isometry
 
 We call *quadratic space with isometry* any pair $(V, f)$ consisting of a
 non-degenerate quadratic space $V$ together with an isometry $f\in O(V)$.
-We refer to the section about quadratic spaces of the documentation for
+We refer to the section about [Spaces](@ref) of the documentation for
 new users.
 
 Note that currently, we support only rational quadratic forms, i.e.
-quadratic spaces defined over the rational.
+quadratic spaces defined over $\mathbb{Q}$.
 
 In Oscar, such a pair is encoded by the type called `QuadSpaceWithIsom`:
 
@@ -18,7 +18,7 @@ In Oscar, such a pair is encoded by the type called `QuadSpaceWithIsom`:
 QuadSpaceWithIsom
 ```
 
-and it is seen as a triple $(V, f, n)$ where $n$ is the order of $f$. We
+It is seen as a triple $(V, f, n)$ where $n$ is the order of $f$. We
 actually support isometries of finite and infinite order. In the case where
 $f$ is of infinite order, then `n = PosInf`. If $V$ has rank 0, then any
 isometry $f$ of $V$ is trivial and we set by default `n = -1`.
@@ -77,8 +77,8 @@ rank(::QuadSpaceWithIsom)
 signature_tuple(::QuadSpaceWithIsom)
 ```
 
-Similarly, some basic operations on quadratic spaces are available for quadratic
-spaces with isometry.
+Similarly, some basic operations on quadratic spaces and matrices are available
+for quadratic spaces with isometry.
 
 ```@docs
 Base.:^(::QuadSpaceWithIsom, ::Int)
@@ -91,6 +91,6 @@ rescale(::QuadSpaceWithIsom, ::RationalUnion)
 ## Equality
 
 We choose as a convention that two pairs $(V, f)$ and $(V', f')$ of quadratic
-spaces with isometries are *equal* if and only if $V$ and $V'$ are the same
-space, and $f$ and $f'$ are represented by the same matrix with respect to the
-standard basis of $V = V'$.
+spaces with isometries are *equal* if $V$ and $V'$ are the same space, and $f$
+and $f'$ are represented by the same matrix with respect to the standard basis
+of $V = V'$.

--- a/experimental/QuadFormAndIsom/src/embeddings.jl
+++ b/experimental/QuadFormAndIsom/src/embeddings.jl
@@ -579,6 +579,9 @@ end
 #
 ###############################################################################
 
+# For deprecation reasons, let us keep track of that function
+_isomorphism_classes_primitive_extensions(N::ZZLat, M::ZZLat, H::TorQuadModule, classification::Symbol) = primitive_extensions(M, N, H; classification)
+
 @doc raw"""
     primitive_extensions(M::ZZLat, N::ZZLat, H::TorQuadModule;
                                              classification::Symbol = :sublat)

--- a/experimental/QuadFormAndIsom/src/embeddings.jl
+++ b/experimental/QuadFormAndIsom/src/embeddings.jl
@@ -1368,6 +1368,6 @@ function _glue_stabilizers(phi::TorQuadModuleMor,
   union!(stab, kerB)
   stab = TorQuadModuleMor[restrict_automorphism(g, j; check = false) for g in stab]
   stab = TorQuadModuleMor[hom(disc, disc, elem_type(disc)[disc(lift(g(perp(lift(l))))) for l in gens(disc)]) for g in stab]
-
+  unique!(stab)
   return disc, stab
 end

--- a/experimental/QuadFormAndIsom/src/embeddings.jl
+++ b/experimental/QuadFormAndIsom/src/embeddings.jl
@@ -699,7 +699,6 @@ of isomorphism classes of primitive extensions $M \oplus N \subseteq L$.
 
 One can decide to choose the index of $[L:(M\oplus N)]$, which should be a
 positive integer by setting `x` to the desired value.
-
 One can also decide on the isometry class of the discriminant form of the
 primitive extension by setting `q` to the desired value.
 If there are no primitive extensions of $M\oplus N$ satisfying the conditions
@@ -929,7 +928,7 @@ end
 Given an even integer lattice $L$, which is unique in its genus, and an even
 integer lattice $M$, return whether $M$ embeds primitively in $L$.
 
-The first input of the function is a boolean `T` stating whether $M$ embeds
+The first output of the function is a boolean `T` stating whether $M$ embeds
 primitively in $L$. The second output $V$ consists of triples $(L', M', N')$
 where $L'$ is isometric to $L$, $M'$ is a primitive sublattice of $L'$ isometric
 to $M$, and $N'$ is the orthogonal complement of $M'$ in $L'$.
@@ -992,7 +991,7 @@ Given a tuple `sign` of non-negative integers and a torsion quadratic module
 $q$ which define a genus symbol $G$ for even integer lattices, return whether the
 even integer lattice $M$ embeds primitively in a lattice in $G$.
 
-The first input of the function is a boolean `T` stating whether $M$ embeds
+The first output of the function is a boolean `T` stating whether $M$ embeds
 primitively in a lattice in $G$. The second output $V$ consists of triples
 $(L', M', N')$ where $L'$ is a lattice in $G$, $M'$ is a sublattice of
 $L'$ isometric to $M$, and $N'$ is the orthogonal complement of $M'$ in $L'$.
@@ -1030,7 +1029,7 @@ end
 Given a genus symbol $G$ for even integer lattices and an even integer
 lattice $M$, return whether $M$ embeds primitively in a lattice in $G$.
 
-The first input of the function is a boolean `T` stating whether $M$ embeds
+The first output of the function is a boolean `T` stating whether $M$ embeds
 primitively in a lattice in $G$. The second output $V$ consists of triples
 $(L', M', N')$ where $L'$ is a lattice in $G$, $M'$ is a sublattice of
 $L'$ isometric to $M$, and $N'$ is the orthogonal complement of $M'$ in $L'$.
@@ -1100,7 +1099,7 @@ function primitive_embeddings(G::ZZGenus, M::ZZLat; classification::Symbol = :su
   # genus)
   Vs = primitive_extensions(M, T)
 
-  # L is our big unimodular lattice where we embed each of the V in Vs
+  # GL is our big unimodular genus where we embed each of the V in Vs
   GL = genus(torsion_quadratic_module(QQ[0;]), (rank(G)+1, rank(G)+1))
   # M2 is M seen in V, and T2 is T seen in V
   for (V, M2, T2) in Vs
@@ -1119,6 +1118,9 @@ function primitive_embeddings(G::ZZGenus, M::ZZLat; classification::Symbol = :su
       @hassert :ZZLatWithIsom 1 is_primitive(L, M3)
       # And this is the orthogonal complement of M in L
       N = orthogonal_submodule(L, M3)
+      # L, M3 and N live in a very big ambient space: we redescribed them in the
+      # rational span of L so that L has full rank and we keep only the
+      # necessary information.
       bM = solve_left(basis_matrix(L), basis_matrix(M3))
       bN = solve_left(basis_matrix(L), basis_matrix(N))
       L = integer_lattice(; gram = gram_matrix(L))

--- a/experimental/QuadFormAndIsom/src/exports.jl
+++ b/experimental/QuadFormAndIsom/src/exports.jl
@@ -4,6 +4,7 @@ export ZZLatWithIsom
 export admissible_equivariant_primitive_extensions
 export admissible_triples
 export ambient_isometry
+export discriminant_representation
 export enumerate_classes_of_lattices_with_isometry
 export image_centralizer_in_Oq
 export integer_lattice_with_isometry
@@ -16,6 +17,7 @@ export is_of_type
 export is_hermitian
 export order_of_isometry
 export primitive_embeddings
+export primitive_extensions
 export quadratic_space_with_isometry
 export representatives_of_hermitian_type
 export splitting_of_hermitian_prime_power

--- a/experimental/QuadFormAndIsom/src/lattices_with_isometry.jl
+++ b/experimental/QuadFormAndIsom/src/lattices_with_isometry.jl
@@ -8,7 +8,7 @@
 @doc raw"""
     lattice(Lf::ZZLatWithIsom) -> ZZLat
 
-Given a lattice with isometry $(L, f)$, return the underlying lattice `L`.
+Given a lattice with isometry $(L, f)$, return the underlying lattice $L$.
 
 # Examples
 ```jldoctest
@@ -25,7 +25,7 @@ lattice(Lf::ZZLatWithIsom) = Lf.Lb
 @doc raw"""
     isometry(Lf::ZZLatWithIsom) -> QQMatrix
 
-Given a lattice with isometry $(L, f)$, return the underlying isometry `f`.
+Given a lattice with isometry $(L, f)$, return the underlying isometry $f$.
 
 # Examples
 ```jldoctest
@@ -47,11 +47,11 @@ isometry(Lf::ZZLatWithIsom) = Lf.f
     ambient_space(Lf::ZZLatWithIsom) -> QuadSpaceWithIsom
 
 Given a lattice with isometry $(L, f)$, return the pair $(V, g)$ where
-`V` is the ambient quadratic space of `L` and `g` is an isometry of `V`
-inducing `f` on `L`.
+$V$ is the ambient quadratic space of $L$ and $g$ is an isometry of $V$
+inducing $f$ on $L$.
 
-Note that `g` might not be unique and we fix such a global isometry
-together with `V` into a container type `QuadSpaceWithIsom`.
+Note that $g$ might not be unique and we fix such a global isometry
+together with $V$ into a container type `QuadSpaceWithIsom`.
 
 # Examples
 ```jldoctest
@@ -79,7 +79,7 @@ ambient_space(Lf::ZZLatWithIsom) = Lf.Vf
    ambient_isometry(Lf::ZZLatWithIsom) -> QQMatrix
 
 Given a lattice with isometry $(L, f)$, return an isometry of the ambient
-space of `L` inducing `f` on `L`.
+space of $L$ inducing $f$ on $L$.
 
 # Examples
 ```jldoctest
@@ -101,7 +101,7 @@ ambient_isometry(Lf::ZZLatWithIsom) = isometry(ambient_space(Lf))
     order_of_isometry(Lf::ZZLatWithIsom) -> IntExt
 
 Given a lattice with isometry $(L, f)$, return the order of the underlying
-isometry `f`.
+isometry $f$.
 
 # Examples
 ```jldoctest
@@ -125,7 +125,7 @@ order_of_isometry(Lf::ZZLatWithIsom) = Lf.n
     rank(Lf::ZZLatWithIsom) -> Integer
 
 Given a lattice with isometry $(L, f)$, return the rank of the underlying lattice
-`L`.
+$L$.
 
 # Examples
 ```jldoctest
@@ -143,7 +143,7 @@ rank(Lf::ZZLatWithIsom) = rank(lattice(Lf))
     characteristic_polynomial(Lf::ZZLatWithIsom) -> QQPolyRingElem
 
 Given a lattice with isometry $(L, f)$, return the characteristic polynomial of the
-underlying isometry `f`.
+underlying isometry $f$.
 
 # Examples
 ```jldoctest
@@ -161,7 +161,7 @@ characteristic_polynomial(Lf::ZZLatWithIsom) = characteristic_polynomial(isometr
     minimal_polynomial(Lf::ZZLatWithIsom) -> QQPolyRingElem
 
 Given a lattice with isometry $(L, f)$, return the minimal polynomial of the
-underlying isometry `f`.
+underlying isometry $f$.
 
 # Examples
 ```jldoctest
@@ -179,7 +179,7 @@ minimal_polynomial(Lf::ZZLatWithIsom) = minimal_polynomial(isometry(Lf))
     genus(Lf::ZZLatWithIsom) -> ZZGenus
 
 Given a lattice with isometry $(L, f)$, return the genus of the underlying 
-lattice `L`.
+lattice $L$.
 
 # Examples
 ```jldoctest
@@ -201,7 +201,7 @@ genus(Lf::ZZLatWithIsom) = genus(lattice(Lf))
     basis_matrix(Lf::ZZLatWithIsom) -> QQMatrix
 
 Given a lattice with isometry $(L, f)$, return the basis matrix of the underlying
-lattice `L`.
+lattice $L$.
 
 # Examples
 ```jldoctest
@@ -236,7 +236,7 @@ basis_matrix(Lf::ZZLatWithIsom) = basis_matrix(lattice(Lf))
     gram_matrix(Lf::ZZLatWithIsom) -> QQMatrix
 
 Given a lattice with isometry $(L, f)$, return the gram matrix of the underlying
-lattice `L` with respect to its basis matrix.
+lattice $L$ with respect to its basis matrix.
 
 # Examples
 ```jldoctest
@@ -258,8 +258,8 @@ gram_matrix(Lf::ZZLatWithIsom) = gram_matrix(lattice(Lf))
     rational_span(Lf::ZZLatWithIsom) -> QuadSpaceWithIsom
 
 Given a lattice with isometry $(L, f)$, return the rational span
-$L \otimes \mathbb{Q}$ of the underlying lattice `L` together with the
-underlying isometry of `L`.
+$L \otimes \mathbb{Q}$ of the underlying lattice $L$ together with the
+underlying isometry of $L$.
 
 # Examples
 ```jldoctest
@@ -287,7 +287,7 @@ rational_span(Lf::ZZLatWithIsom) = quadratic_space_with_isometry(rational_span(l
     det(Lf::ZZLatWithIsom) -> QQFieldElem
 
 Given a lattice with isometry $(L, f)$, return the determinant of the
-underlying lattice `L`.
+underlying lattice $L$.
 
 # Examples
 ```jldoctest
@@ -305,7 +305,7 @@ det(Lf::ZZLatWithIsom) = det(lattice(Lf))
     scale(Lf::ZZLatWithIsom) -> QQFieldElem
 
 Given a lattice with isometry $(L, f)$, return the scale of the underlying
-lattice `L`.
+lattice $L$.
 
 # Examples
 ```jldoctest
@@ -323,7 +323,7 @@ scale(Lf::ZZLatWithIsom) = scale(lattice(Lf))
     norm(Lf::ZZLatWithIsom) -> QQFieldElem
 
 Given a lattice with isometry $(L, f)$, return the norm of the underlying
-lattice `L`.
+lattice $L$.
 
 # Examples
 ```jldoctest
@@ -341,7 +341,7 @@ norm(Lf::ZZLatWithIsom) = norm(lattice(Lf))
     is_positive_definite(Lf::ZZLatWithIsom) -> Bool
 
 Given a lattice with isometry $(L, f)$, return whether the underlying
-lattice `L` is positive definite.
+lattice $L$ is positive definite.
 
 # Examples
 ```jldoctest
@@ -359,7 +359,7 @@ is_positive_definite(Lf::ZZLatWithIsom) = is_positive_definite(lattice(Lf))
     is_negative_definite(Lf::ZZLatWithIsom) -> Bool
 
 Given a lattice with isometry $(L, f)$, return whether the underlying
-lattice `L` is negative definite.
+lattice $L$ is negative definite.
 
 # Examples
 ```jldoctest
@@ -377,7 +377,7 @@ is_negative_definite(Lf::ZZLatWithIsom) = is_negative_definite(lattice(Lf))
     is_definite(Lf::ZZLatWithIsom) -> Bool
 
 Given a lattice with isometry $(L, f)$, return whether the underlying
-lattice `L` is definite.
+lattice $L$ is definite.
 
 # Examples
 ```jldoctest
@@ -395,7 +395,7 @@ is_definite(Lf::ZZLatWithIsom) = is_definite(lattice(Lf))
     minimum(Lf::ZZLatWithIsom) -> QQFieldElem
 
 Given a positive definite lattice with isometry $(L, f)$, return the minimum
-of the underlying lattice `L`.
+of the underlying lattice $L$.
 
 # Examples
 ```jldoctest
@@ -416,7 +416,7 @@ end
     is_integral(Lf::ZZLatWithIsom) -> Bool
 
 Given a lattice with isometry $(L, f)$, return whether the underlying lattice
-`L` is integral.
+$L$ is integral.
 
 # Examples
 ```jldoctest
@@ -434,7 +434,7 @@ is_integral(Lf::ZZLatWithIsom) = is_integral(lattice(Lf))
     degree(Lf::ZZLatWithIsom) -> Int
 
 Given a lattice with isometry $(L, f)$, return the degree of the underlying
-lattice `L`.
+lattice $L$.
 
 # Examples
 ```jldoctest
@@ -452,7 +452,7 @@ degree(Lf::ZZLatWithIsom) = degree(lattice(Lf))
     is_even(Lf::ZZLatWithIsom) -> Bool
 
 Given a lattice with isometry $(L, f)$, return whether the underlying lattice
-`L` is even.
+$L$ is even.
 
 # Examples
 ```jldoctest
@@ -470,7 +470,7 @@ is_even(Lf::ZZLatWithIsom) = iseven(lattice(Lf))
     discriminant(Lf::ZZLatWithIsom) -> QQFieldElem
 
 Given a lattice with isometry $(L, f)$, return the discriminant of the underlying
-lattice `L`.
+lattice $L$.
 
 # Examples
 ```jldoctest
@@ -488,7 +488,7 @@ discriminant(Lf::ZZLatWithIsom) = discriminant(lattice(Lf))
     signature_tuple(Lf::ZZLatWithIsom) -> Tuple{Int, Int, Int}
 
 Given a lattice with isometry $(L, f)$, return the signature tuple of the
-underlying lattice `L`.
+underlying lattice $L$.
 
 # Examples
 ```jldoctest
@@ -502,6 +502,145 @@ julia> signature_tuple(Lf)
 """
 signature_tuple(Lf::ZZLatWithIsom) = signature_tuple(lattice(Lf))
 
+@doc raw"""
+    is_primary_with_prime(Lf::ZZLatWithIsom) -> Bool, ZZRingElem
+
+Given a lattice with isometry $(L, f)$, return whether $L$ is primary,
+that is whether $L$ is integral and its discriminant group is a
+$p$-group for some prime number $p$. In case it is, $p$ is also returned as
+second output.
+
+Note that for unimodular lattices, this function returns `(true, 1)`. If the
+lattice is not primary, the second return value is `-1` by default.
+
+# Examples
+```jldoctest
+julia> L = root_lattice(:A, 5);
+
+julia> Lf = integer_lattice_with_isometry(L);
+
+julia> is_primary_with_prime(Lf)
+(false, -1)
+
+julia> genus(Lf)
+Genus symbol for integer lattices
+Signatures: (5, 0, 0)
+Local symbols:
+  Local genus symbol at 2: 1^-4 2^1_7
+  Local genus symbol at 3: 1^-4 3^1
+```
+"""
+is_primary_with_prime(Lf::ZZLatWithIsom) = is_primary_with_prime(lattice(Lf))
+
+@doc raw"""
+    is_primary(Lf::ZZLatWithIsom, p::IntegerUnion) -> Bool
+
+Given a lattice with isometry $(L, f)$ and a prime number $p$,
+return whether $L$ is $p$-primary, that is whether its discriminant group
+is a $p$-group.
+
+# Examples
+```jldoctest
+julia> L = root_lattice(:A, 6);
+
+julia> Lf = integer_lattice_with_isometry(L);
+
+julia> is_primary(Lf, 7)
+true
+
+julia> genus(Lf)
+Genus symbol for integer lattices
+Signatures: (6, 0, 0)
+Local symbols:
+  Local genus symbol at 2: 1^6
+  Local genus symbol at 7: 1^-5 7^-1
+```
+"""
+is_primary(Lf::ZZLatWithIsom, p::IntegerUnion) = is_primary(lattice(Lf), p)
+
+@doc raw"""
+    is_unimodular(Lf::ZZLatWithIsom) -> Bool
+
+Given a lattice with isometry $(L, f)$, return whether `$L$ is unimodular,
+that is whether its discriminant group is trivial.
+
+# Examples
+```jldoctest
+julia> L = root_lattice(:E, 8);
+
+julia> Lf = integer_lattice_with_isometry(L);
+
+julia> is_unimodular(Lf)
+true
+
+julia> genus(Lf)
+Genus symbol for integer lattices
+Signatures: (8, 0, 0)
+Local symbol:
+  Local genus symbol at 2: 1^8
+```
+"""
+is_unimodular(Lf::ZZLatWithIsom) = is_unimodular(lattice(Lf))
+
+@doc raw"""
+    is_elementary_with_prime(Lf::ZZLatWithIsom) -> Bool, ZZRingElem
+
+Given a lattice with isometry $(L, f)$, return whether $L$ is elementary, that is
+whether $L$ is integral and its discriminant group is an elemenentary $p$-group for
+some prime number $p$. In case it is, $p$ is also returned as second output.
+
+Note that for unimodular lattices, this function returns `(true, 1)`. If the lattice
+is not elementary, the second return value is `-1` by default.
+
+# Examples
+```jldoctest
+julia> L = root_lattice(:A, 7);
+
+julia> Lf = integer_lattice_with_isometry(L);
+
+julia> is_elementary_with_prime(Lf)
+(false, -1)
+
+julia> is_primary(Lf, 2)
+true
+
+julia> genus(Lf)
+Genus symbol for integer lattices
+Signatures: (7, 0, 0)
+Local symbol:
+  Local genus symbol at 2: 1^6 8^1_7
+```
+"""
+is_elementary_with_prime(Lf::ZZLatWithIsom) = is_elementary_with_prime(lattice(Lf))
+
+@doc raw"""
+    is_elementary(Lf::ZZLatWithIsom, p::IntegerUnion) -> Bool
+
+Given a lattice with isometry $(L, f)$ and a prime number $p$, return whether
+$L$ is $p$-elementary, that is whether its discriminant group is an elementary
+$p$-group.
+
+# Examples
+```jldoctest
+julia> L = root_lattice(:E, 7);
+
+julia> Lf = integer_lattice_with_isometry(L);
+
+julia> is_elementary(Lf, 3)
+false
+
+julia> is_elementary(Lf, 2)
+true
+
+julia> genus(Lf)
+Genus symbol for integer lattices
+Signatures: (7, 0, 0)
+Local symbol:
+  Local genus symbol at 2: 1^6 2^1_7
+```
+"""
+is_elementary(Lf::ZZLatWithIsom, p::IntegerUnion) = is_elementary(lattice(Lf), p)
+
 ###############################################################################
 #
 #  Constructors
@@ -513,13 +652,15 @@ signature_tuple(Lf::ZZLatWithIsom) = signature_tuple(lattice(Lf))
                                                 ambient_representation = true)
                                                              -> ZZLatWithIsom
 
-Given a $\mathbb Z$-lattice `L` and a matrix `f`, if `f` defines an isometry
-of `L` of order `n`, return the corresponding lattice with isometry pair $(L, f)$.
+Given a $\mathbb Z$-lattice $L$ and a matrix $f$, if $f$ defines an isometry
+of $L$ of order $n$, return the corresponding lattice with isometry pair $(L, f)$.
 
-If `ambient_representation` is set to true, `f` is consider as an isometry of the
-ambient space of `L` and the induced isometry on `L` is automatically computed.
-Otherwise, an isometry of the ambient space of `L` is constructed, setting the identity
-on the complement of the rational span of `L` if it is not of full rank.
+If `ambient_representation` is set to `true`, $f$ is consider as an isometry of
+the ambient space of $L$ and the induced isometry on $L$ is automatically
+computed as long as $f$ preserves $L$.
+
+Otherwise, an isometry of the ambient space of $L$ is constructed, setting the
+identity on the complement of the rational span of $L$ if it is not of full rank.
 
 # Examples
 
@@ -596,7 +737,7 @@ function integer_lattice_with_isometry(L::ZZLat, f::QQMatrix; check::Bool = true
     Vf = quadratic_space_with_isometry(ambient_space(L), f_ambient; check)
     B = basis_matrix(L)
     ok, f = can_solve_with_solution(B, B*f_ambient; side = :left)
-    @req ok "Isometry does not restrict to L"
+    @req ok "Isometry does not preserve the lattice"
   else
     V = ambient_space(L)
     B = basis_matrix(L)
@@ -620,10 +761,10 @@ end
 @doc raw"""
     integer_lattice_with_isometry(L::ZZLat; neg::Bool = false) -> ZZLatWithIsom
 
-Given a $\mathbb Z$-lattice `L` return the lattice with isometry pair $(L, f)$,
-where `f` corresponds to the identity mapping of `L`.
+Given a $\mathbb Z$-lattice $L$ return the lattice with isometry pair $(L, f)$,
+where $f$ corresponds to the identity mapping of $L$.
 
-If `neg` is set to `true`, then the isometry `f` is negative the identity of `L`.
+If `neg` is set to `true`, then the isometry $f$ is negative the identity of $L$.
 
 # Examples
 ```jldoctest
@@ -652,9 +793,9 @@ end
 @doc raw"""
     lattice(Vf::QuadSpaceWithIsom) -> ZZLatWithIsom
 
-Given a quadratic space with isometry $(V, f)$, return the full rank lattice `L`
-in `V` with basis the standard basis, together with the induced action of `f`
-on `L`.
+Given a quadratic space with isometry $(V, f)$, return the full rank lattice $L$
+in $V$ with basis the standard basis, together with the induced action of $f$
+on $L$.
 
 # Examples
 ```jldoctest
@@ -691,10 +832,10 @@ lattice(Vf::QuadSpaceWithIsom) = ZZLatWithIsom(Vf, lattice(space(Vf)), isometry(
                                    isbasis::Bool = true, check::Bool = true)
                                                               -> ZZLatWithIsom
 
-Given a quadratic space with isometry $(V, f)$ and a matrix `B` generating a
-lattice `L` in `V`, if `L` is preserved under the action of `f`, return the
-lattice with isometry $(L, f_L)$ where $f_L$ is induced by the action of `f`
-on `L`.
+Given a quadratic space with isometry $(V, f)$ and a matrix $B$ generating a
+lattice $L$ in $V$, if $L$ is preserved under the action of $f$, return the
+lattice with isometry $(L, f_L)$ where $f_L$ is induced by the action of $f$
+on $L$.
 
 # Examples
 ```jldoctest
@@ -741,11 +882,11 @@ end
                                                     check::Bool = true)
                                                             -> ZZLatWithIsom
 
-Given a lattice with isometry $(L, f)$ and a matrix `B` whose rows define a free
-system of vectors in the ambient space `V` of `L`, if the lattice `M` in `V` defined
-by `B` is preserved under the fixed isometry `g` of `V` inducing `f` on `L`, return
+Given a lattice with isometry $(L, f)$ and a matrix $B$ whose rows define a free
+system of vectors in the ambient space $V$ of $L$, if the lattice $M$ in $V$ defined
+by $B$ is preserved under the fixed isometry $g$ of $V$ inducing $f$ on $L$, return
 the lattice with isometry pair $(M, f_M)$ where $f_M$ is induced by the action of
-`g` on `M`.
+$g$ on $M$.
 
 # Examples
 ```jldoctest
@@ -791,9 +932,49 @@ end
 ###############################################################################
 
 @doc raw"""
+    orthogonal_submodule(Lf::ZZLatWithIsom, B::QQMatrix) -> ZZLatWithIsom
+
+Given a lattice with isometry $(L, f)$ and a matrix $B$ with rational entries
+defining an $f$-stable sublattice of $L$, return the largest submodule of $L$
+orthogonal to each row of $B$, equipped with the induced action from $f$.
+
+# Examples
+```jldoctest
+julia> L = root_lattice(:A,5);
+
+julia> f = matrix(QQ, 5, 5, [ 1  0  0  0  0;
+                             -1 -1 -1 -1 -1;
+                              0  0  0  0  1;
+                              0  0  0  1  0;
+                              0  0  1  0  0]);
+
+julia> Lf = integer_lattice_with_isometry(L, f);
+
+julia> B = matrix(QQ,3,5,[1 0 0 0 0;
+                          0 0 1 0 1;
+                          0 0 0 1 0])
+[1   0   0   0   0]
+[0   0   1   0   1]
+[0   0   0   1   0]
+
+julia> orthogonal_submodule(Lf, B)
+Integer lattice of rank 2 and degree 5
+  with isometry of finite order 2
+  given by
+  [-1    0]
+  [ 0   -1]
+```
+"""
+function orthogonal_submodule(Lf::ZZLatWithIsom, B::QQMatrix)
+  @req ncols(B) == degree(Lf) "The rows of B should represent vectors in the ambient space of Lf"
+  B2 = basis_matrix(orthogonal_submodule(lattice(Lf), B))
+  return lattice_in_same_ambient_space(Lf, B2; check = false)
+end
+
+@doc raw"""
     rescale(Lf::ZZLatWithIsom, a::RationalUnion) -> ZZLatWithIsom
 
-Given a lattice with isometry $(L, f)$ and a rational number `a`, return the
+Given a lattice with isometry $(L, f)$ and a rational number $a$, return the
 lattice with isometry $(L(a), f)$.
 
 # Examples
@@ -892,9 +1073,9 @@ end
     dual(Lf::ZZLatWithIsom) -> ZZLatWithIsom
 
 Given a lattice with isometry $(L, f)$ inside the space $(V, \Phi)$, such that
-`f` is induced by an isometry `g` of $(V, \Phi)$, return the lattice with
-isometry $(L^{\vee}, h)$ where $L^{\vee}$ is the dual of `L` in $(V, \Phi)$
-and `h` is induced by `g`.
+$f$ is induced by an isometry $g$ of $(V, \Phi)$, return the lattice with
+isometry $(L^{\vee}, h)$ where $L^{\vee}$ is the dual of $L$ in $(V, \Phi)$
+and $h$ is induced by $g$.
 
 # Examples
 ```jldoctest
@@ -939,11 +1120,11 @@ end
     lll(Lf::ZZLatWithIsom) -> ZZLatWithIsom
 
 Given a lattice with isometry $(L, f)$, return the same lattice with isometry
-with a different basis matrix for `L`  obtained by performing an LLL-reduction
-on the associated gram matrix of `L`.
+with a different basis matrix for $L$  obtained by performing an LLL-reduction
+on the associated gram matrix of $L$.
 
-Note that matrix representing the action of `f` on `L` changes but the global action
-on the ambient space of `L` stays the same.
+Note that matrix representing the action of $f$ on $L$ changes but the global action
+on the ambient space of $L$ stays the same.
 
 # Examples
 ```jldoctest
@@ -996,8 +1177,8 @@ end
 
 Given a collection of lattices with isometries $(L_1, f_1), \ldots, (L_n, f_n)$,
 return the lattice with isometry $(L, f)$ together with the injections $L_i \to L$,
-where `L` is the direct sum $L := L_1 \oplus \ldots \oplus L_n$ and `f` is the
-isometry of `L` induced by the diagonal actions of the $f_i$'s.
+where $L$ is the direct sum $L := L_1 \oplus \ldots \oplus L_n$ and $f$ is the
+isometry of $L$ induced by the diagonal actions of the $f_i$'s.
 
 For objects of type `ZZLatWithIsom`, finite direct sums and finite direct products
 agree and they are therefore called biproducts.
@@ -1077,8 +1258,8 @@ direct_sum(x::Vararg{ZZLatWithIsom}) = direct_sum(collect(x))
 
 Given a collection of lattices with isometries $(L_1, f_1), \ldots, (L_n, f_n)$,
 return the lattice with isometry $(L, f)$ together with the projections $L \to L_i$,
-where `L` is the direct product $L := L_1 \times \ldots \times L_n$ and `f` is the
-isometry of `L` induced by the diagonal actions of the $f_i$'s.
+where $L$ is the direct product $L := L_1 \times \ldots \times L_n$ and $f$ is the
+isometry of $L$ induced by the diagonal actions of the $f_i$'s.
 
 For objects of type `ZZLatWithIsom`, finite direct sums and finite direct products
 agree and they are therefore called biproducts.
@@ -1160,8 +1341,8 @@ direct_product(x::Vararg{ZZLatWithIsom}) = direct_product(collect(x))
 
 Given a collection of lattices with isometries $(L_1, f_1), \ldots, (L_n, f_n)$,
 return the lattice with isometry $(L, f)$ together with the injections
-$L_i \to L$ and the projections $L \to L_i$, where `L` is the biproduct
-$L := L_1 \oplus \ldots \oplus L_n$ and `f` is the isometry of `L` induced by the
+$L_i \to L$ and the projections $L \to L_i$, where $L$ is the biproduct
+$L := L_1 \oplus \ldots \oplus L_n$ and $f$ is the isometry of $L$ induced by the
 diagonal actions of the $f_i$'s.
 
 For objects of type `ZZLatWithIsom`, finite direct sums and finite direct products
@@ -1274,10 +1455,10 @@ end
     is_of_hermitian_type(Lf::ZZLatWithIsom) -> Bool
 
 Given a lattice with isometry $(L, f)$, return whether the minimal polynomial of
-the underlying isometry `f` is irreducible.
+the underlying isometry $f$ is irreducible.
 
-Note that if $(L, f)$ is of hermitian type with `f` of minimal polynomial $\chi$,
-then `L` can be seen as a hermitian lattice over the order $\mathbb{Z}[\chi]$.
+Note that if $(L, f)$ is of hermitian type with $f$ of minimal polynomial $\chi$,
+then $L$ can be seen as a hermitian lattice over the order $\mathbb{Z}[\chi]$.
 
 # Examples
 ```jldoctest
@@ -1315,9 +1496,9 @@ end
     hermitian_structure(Lf::ZZLatWithIsom) -> HermLat
 
 Given a lattice with isometry $(L, f)$ such that the minimal polynomial of the
-underlying isometry `f` is irreducible, return the hermitian structure of the
-underlying lattice `L` over the equation order of the minimal polynomial of
-`f`.
+underlying isometry $f$ is irreducible, return the hermitian structure of the
+underlying lattice $L$ over the equation order of the minimal polynomial of
+$f$.
 
 If it exists, the hermitian structure is stored. For now, we only cover the case
 where the equation order is maximal (which is always the case when the order is
@@ -1378,16 +1559,16 @@ end
 
 ###############################################################################
 #
-#  Image centralizer in discriminant group
+#  Discriminant actions
 #
 ###############################################################################
 
 @doc raw"""
     discriminant_group(Lf::ZZLatWithIsom) -> TorQuadModule, AutomorphismGroupElem
 
-Given an integral lattice with isometry $(L, f)$, return the discriminant group `q`
-of the underlying lattice `L` as well as this image of the underlying isometry
-`f` inside $O(q)$.
+Given an integral lattice with isometry $(L, f)$, return the discriminant group
+$D_L$ of the underlying lattice $L$ as well as the image $D_f$ of the underlying
+isometry $f$ inside $O(D_L)$.
 
 # Examples
 ```jldoctest
@@ -1436,8 +1617,48 @@ function discriminant_group(Lf::ZZLatWithIsom)
   f = ambient_isometry(Lf)
   q = discriminant_group(L)
   f = hom(q, q, elem_type(q)[q(lift(t)*f) for t in gens(q)])
-  f = gens(Oscar._orthogonal_group(q, ZZMatrix[matrix(f)]; check = false))[1]
-  return (q, f)
+  fq = gens(Oscar._orthogonal_group(q, ZZMatrix[matrix(f)]; check = false))[1]
+  return (q, fq)
+end
+
+@doc raw"""
+    discriminant_representation(L::ZZLat, G::MatrixGroup;
+                                          ambient_representation::Bool = true,
+                                          check::Bool = true) -> GAPGroupHomomorphism
+
+Given an integer lattice $L$ and a group $G$ of isometries of $L$, return the
+orthogonal representation $G\to O(D_L)$ of $G$ on the discriminant group $D_L$
+of $L$.
+
+If `ambient_representation` is set to `true`, then the isometries in $G$ are
+considered as matrix representation of their action on the standard basis of
+the ambient space of $L$. Otherwise, they are considered as matrix representation
+of their action on the basis matrix of $L$.
+"""
+function discriminant_representation(L::ZZLat, G::MatrixGroup;
+                                               ambient_representation::Bool = true,
+                                               check::Bool = true)
+  V = ambient_space(L)
+  if ambient_representation
+    @check all(g -> matrix(g)*gram_matrix(V)*transpose(matrix(g)) == gram_matrix(V), gens(G)) "G does not define a group of isometries of the ambient space of L"
+  else
+    @check all(g -> matrix(g)*gram_matrix(L)*transpose(matrix(g)) == gram_matrix(L), gens(G)) "G does not define a group of isometries of L"
+    B = basis_matrix(L)
+    B2 = orthogonal_complement(V, B)
+    C = vcat(B, B2)
+  end
+  q = discriminant_group(L)
+  Oq = orthogonal_group(q)
+  imag_lis = elem_type(Oq)[]
+  geneG = gens(G)
+  for g in geneG
+    if !ambient_representation
+      g = block_diagonal_matrix(QQMatrix[matrix(g), identity_matrix(QQ, nrows(B2))])
+      g = inv(C)*g*C
+    end
+    push!(imag_lis, Oq(hom(q, q, TorQuadModuleElem[q(lift(a)*matrix(g)) for a in gens(q)]); check = false))
+  end
+  return hom(G, Oq, geneG, imag_lis; check = false)
 end
 
 @doc raw"""
@@ -1445,9 +1666,9 @@ end
                                                   GAPGroupHomomorphism
 
 Given an integral lattice with isometry $(L, f)$, return the image $G_L$ in
-$O(q_L, \bar{f})$ of the centralizer $O(L, f)$ of `f` in $O(L)$. Here $q_L$
-denotes the discriminant group of `L` and $\bar{f}$ is the isometry of
-$q_L$ induced by `f`.
+$O(D_L, D_f)$ of the centralizer $O(L, f)$ of $f$ in $O(L)$. Here $D_L$
+denotes the discriminant group of $L$ and $D_f$ is the isometry of
+$D_L$ induced by $f$.
 
 # Examples
 ```jldoctest
@@ -1471,43 +1692,104 @@ julia> order(G)
   @req is_integral(Lf) "Underlying lattice must be integral"
   n = order_of_isometry(Lf)
   L = lattice(Lf)
-  if (n in [1, -1]) || (isometry(Lf) == -identity_matrix(QQ, rank(L)))
+  if is_unimodular(L)
+    # If L is unimodular we do not have to do any wizard's trick since the
+    # discriminant group is trivial
+    qL = discriminant_group(L)
+    OqL = orthogonal_group(qL)
+    return OqL, id_hom(OqL)
+  elseif (n in [1, -1]) || (isometry(Lf) == -identity_matrix(QQ, rank(L)))
     # Trivial cases: the lattice has rank 0, or is endowed with +- identity
     return image_in_Oq(L)
   elseif rank(L) == euler_phi(n)
-    # this should also cover the case of rank 1
-    # The image of -id and multiplication by primitive root of unity
+    # Hermitian type with hermitian structure of rank 1
+    # The image consists of -id and multiplication by primitive root of unity,
+    # which itself correspond to f along the trace construction
     qL, fqL = discriminant_group(Lf)
     OqL = orthogonal_group(qL)
-    UL = ZZMatrix[-matrix(one(OqL)), matrix(fqL)]
-    UL = elem_type(OqL)[OqL(m; check = false) for m in UL]
+    UL = elem_type(OqL)[OqL(m; check = false) for m in ZZMatrix[-matrix(one(OqL)), matrix(fqL)]]
     return sub(OqL, unique!(UL))
   elseif is_definite(L) || rank(L) == 2
     # We can compute the orthogonal groups and centralizer with GAP
     OL = orthogonal_group(L)
+    discL = discriminant_representation(L, OL)
     f = isometry(Lf)
+    # The ambient isometry might not be identity on the complement of L, so we
+    # built another ambient isometry extending f by the identity
     V = ambient_space(L)
     B = basis_matrix(L)
     B2 = orthogonal_complement(V, B)
     C = vcat(B, B2)
     f = block_diagonal_matrix(QQMatrix[f, identity_matrix(QQ, nrows(B2))])
     f = inv(C)*f*C
-    f = OL(f; check = false)
-    UL = QQMatrix[matrix(s) for s in gens(centralizer(OL, f)[1])]
-    qL = discriminant_group(L)
-    UL = ZZMatrix[matrix(hom(qL, qL, elem_type(qL)[qL(lift(t)*g) for t in gens(qL)])) for g in UL]
-    unique!(UL)
-    OqL = orthogonal_group(qL)
-    UL = elem_type(OqL)[OqL(m; check = false) for m in UL]
-    return sub(OqL, UL)
-  else
-    @req is_of_hermitian_type(Lf) "Not yet implemented for indefinite lattices with isometry which are not of hermitian type"
-    # indefinite of rank bigger or equal to 3
+    fL = OL(f; check = false)
+    UL, _ = centralizer(OL, fL)
+    return image(discriminant_representation(L, UL; check = false))
+  elseif is_of_hermitian_type(Lf)
+    # Indefinite of rank bigger or equal to 3
     # We use Hermitian Miranda-Morrison (see [BH23, Part 6])
     dets, j = Oscar._local_determinants_morphism(Lf)
     _, jj = kernel(dets)
     jj = compose(jj, j)
     return image(jj)
+  else
+    # For this last case, we cut our lattice into two orthogonal parts and we
+    # proceed by induction by gluing the stabilizers. For now we do naively,
+    # and we split the "largest non trivial exponent of the isometry".
+    #
+    # TODO: make a "smart search", for instance for some particular stable
+    # kernel sublattices of small rank or for which rank(L) == euler_phi(n)
+    #
+    # We use the similar method as used for extending stabilizers along
+    # equivariant primitive extensions as seen in the function
+    # `admissible_equivariant_primitive_extensions`.
+    divs = sort!(divisors(n); rev = true)
+    k = divs[findfirst(k -> rank(kernel_lattice(Lf, k)) != 0, divs)]
+
+    M = kernel_lattice(Lf, k)
+    qM, fqM = discriminant_group(M)
+    GM, _ = image_centralizer_in_Oq(M)
+
+    N = orthogonal_submodule(Lf, basis_matrix(M))
+    qN, fqN = discriminant_group(N)
+    GN, _ = image_centralizer_in_Oq(N)
+
+    phi, HMinqM, HNinqN = glue_map(L, lattice(M), lattice(N); check = false)
+
+    # Since M and N are obtained by cutting some parts of `f \in O(L)`, the glue
+    # map should be equivariant!
+    @hassert :ZZLatWithIsom 1 is_invariant(fqM, HMinqM)
+    @hassert :ZZLatWithIsom 1 is_invariant(fqN, HNinqN)
+    @hassert :ZZLatWithIsom 1 matrix(compose(restrict_automorphism(fqM, HMinqM; check = false), phi)) == matrix(compose(phi, restrict_automorphism(fqN, HNinqN; check = false)))
+
+    HM = domain(HMinqM)
+    OHM = orthogonal_group(HM)
+
+    HN = domain(HNinqN)
+    OHN = orthogonal_group(HN)
+
+    _, qMinD, qNinD, _, OqMinOD, OqNinOD = _sum_with_embeddings_orthogonal_groups(qM, qN)
+    HMinD = compose(HMinqM, qMinD)
+    HNinD = compose(HNinqN, qNinD)
+
+    stabM, _ = stabilizer(GM, HMinqM)
+    stabN, _ = stabilizer(GN, HNinqN)
+
+    actM = hom(stabM, OHM, elem_type(OHM)[OHM(restrict_automorphism(x, HMinqM; check = false)) for x in gens(stabM)])
+    actN = hom(stabN, OHN, elem_type(OHN)[OHN(restrict_automorphism(x, HNinqN; check = false)) for x in gens(stabN)])
+
+    _, _, graph = _overlattice(phi, HMinD, HNinD, isometry(M), isometry(N); same_ambient = true)
+    disc, stab = _glue_stabilizers(phi, actM, actN, OqMinOD, OqNinOD, graph)
+    qL, fqL = discriminant_group(Lf)
+    OqL = orthogonal_group(qL)
+    phi = hom(qL, disc, TorQuadModuleElem[disc(lift(x)) for x in gens(qL)])
+    @hassert :ZZLatWithIsom 1 is_isometry(phi)
+    @hassert :ZZLatWithIsom 1 qL == disc
+
+    stab = sub(OqL, elem_type(OqL)[OqL(compose(phi, compose(g, inv(phi))); check = false) for g in stab])
+
+    @hassert :ZZLatWithIsom 1 fqL in stab[1]
+    return stab
   end
 end
 
@@ -1520,9 +1802,9 @@ end
 function _real_kernel_signatures(L::ZZLat, M::MatElem)
   C = base_ring(M)
   G = gram_matrix(L)
-  G = change_base_ring(C, G)
+  GC = change_base_ring(C, G)
   _, K = left_kernel(M)
-  diag = K*G*transpose(K)
+  diag = K*GC*transpose(K)
 
   diag = Hecke._gram_schmidt(diag, C)[1]
   diag = diagonal(diag)
@@ -1539,11 +1821,11 @@ end
 @doc raw"""
     signatures(Lf::ZZLatWithIsom) -> Dict{Int, Tuple{Int, Int}}
 
-Given a lattice with isometry $(L, f)$ where the minimal polynomial of `f`
-is irreducible cyclotomic, return the signatures of $(L, f)$.
+Given a lattice with isometry $(L, f)$ where the minimal polynomial of $f$
+is irreducible cyclotomic, return the signatures of the pair $(L, f)$.
 
-In this context, if we denote $z$ a primitive `n`-th root of unity, where `n`
-is the order of `f`, then for each $1 \leq i \leq n/2$ such that $(i, n) = 1$,
+In this context, if we denote $z$ a primitive $n$-th root of unity, where $n$
+is the order of $f$, then for each $1 \leq i \leq n/2$ such that $(i, n) = 1$,
 the $i$-th signature of $(L, f)$ is given by the signatures of the real quadratic
 form $\ker(f + f^{-1} - z^i - z^{-i})$.
 
@@ -1578,9 +1860,9 @@ function signatures(Lf::ZZLatWithIsom)
   lambda = C(eig[j])
   Sq = Int[i for i in 1:div(n,2) if gcd(i,n) == 1]
   D = Dict{Integer, Tuple{Int, Int}}()
-  f = change_base_ring(C, f)
+  fC = change_base_ring(C, f)
   for i in Sq
-    M = f + inv(f) - lambda^i - lambda^(-i)
+    M = fC + inv(fC) - lambda^i - lambda^(-i)
     D[i] = _real_kernel_signatures(L, M)
   end
   return D
@@ -1601,9 +1883,9 @@ end
     kernel_lattice(Lf::ZZLatWithIsom, p::Union{fmpz_poly, QQPolyRingElem})
                                                          -> ZZLatWithIsom
 
-Given a lattice with isometry $(L, f)$ and a polynomial `p` with rational
+Given a lattice with isometry $(L, f)$ and a polynomial $p$ with rational
 coefficients, return the sublattice $M := \ker(p(f))$ of the underlying lattice
-`L` with isometry `f`, together with the restriction $f_{\mid M}$.
+$L$ with isometry $f$, together with the restriction $f_{\mid M}$.
 
 # Examples
 ```jldoctest
@@ -1659,8 +1941,8 @@ kernel_lattice(Lf::ZZLatWithIsom, p::ZZPolyRingElem) = kernel_lattice(Lf, change
 @doc raw"""
     kernel_lattice(Lf::ZZLatWithIsom, l::Integer) -> ZZLatWithIsom
 
-Given a lattice with isometry $(L, f)$ and an integer `l`, return the kernel
-lattice of $(L, f)$ associated to the `l`-th cyclotomic polynomial.
+Given a lattice with isometry $(L, f)$ and an integer $l$, return the kernel
+lattice of $(L, f)$ associated to the $l-$th cyclotomic polynomial.
 
 # Examples
 ```jldoctest
@@ -1700,7 +1982,7 @@ end
     invariant_lattice(Lf::ZZLatWithIsom) -> ZZLatWithIsom
 
 Given a lattice with isometry $(L, f)$, return the invariant lattice $L^f$ of
-$(L, f)$ together with the restriction of `f` to $L^f$ (which is the identity
+$(L, f)$ together with the restriction of $f$ to $L^f$ (which is the identity
 in this case).
 
 # Examples
@@ -1728,12 +2010,13 @@ invariant_lattice(Lf::ZZLatWithIsom) = kernel_lattice(Lf, 1)
     invariant_lattice(L::ZZLat, G::MatrixGroup;
                                 ambient_representation::Bool = true) -> ZZLat
 
-Given an integer lattice `L` and a group `G` of isometries of `L` in matrix,
-return the invariant sublattice $L^G$ of `L`.
+Given an integer lattice $L$ and a group $G$ of isometries of $L$ in matrix,
+return the invariant sublattice $L^G$ of $L$.
 
-If `ambient_representation` is set to true, the isometries in `G` are seen as
-isometries of the ambient quadratic space of `L` preserving `L`. Otherwise, they
-are considered as honnest isometries of `L`.
+If `ambient_representation` is set to `true`, the isometries in $G$ are considered
+as matrix representation of their action on the standard basis of the ambient
+space of $L$. Otherwise, they are considered as matrix representation of their
+action on the basis matrix of $L$.
 
 # Examples
 ```jldoctest
@@ -1755,10 +2038,10 @@ end
     coinvariant_lattice(Lf::ZZLatWithIsom) -> ZZLatWithIsom
 
 Given a lattice with isometry $(L, f)$, return the coinvariant lattice $L_f$ of
-$(L, f)$ together with the restriction of `f` to $L_f$.
+$(L, f)$ together with the restriction of $f$ to $L_f$.
 
 The coinvariant lattice $L_f$ of $(L, f)$ is the orthogonal complement in
-`L` of the invariant lattice $L_f$.
+$L$ of the invariant lattice $L_f$.
 
 # Examples
 ```jldoctest
@@ -1799,13 +2082,14 @@ end
                                   ambient_representation::Bool = true)
                                                         -> ZZLat, MatrixGroup
 
-Given an integer lattice `L` and a group `G` of isometries of `L` in matrix,
-return the coinvariant sublattice $L_G$ of `L`, together with the subgroup `H`
-of isometries of $L_G$ induced by the action of $G$.
+Given an integer lattice $L$ and a group $G$ of isometries of $L$, return the
+coinvariant sublattice $L_G$ of $L$, together with the subgroup $H$ of
+isometries of $L_G$ induced by the action of $G$.
 
-If `ambient_representation` is set to true, the isometries in `G` and `H` are seen
-as isometries of the ambient quadratic space of `L` preserving `L`. Otherwise,
-they are considered as honnest isometries of `L`.
+If `ambient_representation` is set to `true`, the isometries in $G$ and $H$ are
+considered as matrix representation of their action on the standard basis of the
+ambient space of $L$. Otherwise, they are considered as matrix representation of
+their action on the basis matrices of $L$ and $L_G$ respectively.
 
 # Examples
 ```jldoctest
@@ -1847,18 +2131,33 @@ function coinvariant_lattice(L::ZZLat, G::MatrixGroup; ambient_representation::B
 end
 
 @doc raw"""
+    invariant_coinvariant_pair(Lf::ZZLatWithIsom) -> ZZLatWithIsom, ZZLatWithIsom
+
+Given a lattice with isometry $(L, f)$, return the pair of lattices with
+isometries consisting of $(L^f, f_{\mid L^f})$ and $(L_f, f_{\mid L_f})$,
+the invariant and coinvariant sublattices with isometry of $(L, f)$.
+"""
+function invariant_coinvariant_pair(Lf::ZZLatWithIsom)
+  F = invariant_lattice(Lf)
+  B = basis_matrix(F)
+  C = orthogonal_submodule(Lf, B)
+  return F, C
+end
+
+@doc raw"""
     invariant_coinvariant_pair(L::ZZLat, G::MatrixGroup;
                                          ambient_representation::Bool = true)
                                                    -> ZZLat, ZZLat, MatrixGroup
 
-Given an integer lattice `L` and a group `G` of isometries of `L` in matrix,
-return the invariant sublattice $L^G$ of `L` and its coinvariant sublattice
-$L_G$ together with the subgroup `H` of isometries of $L_G$ induced by the
-action of $G$.
+Given an integer lattice $L$ and a group $G$ of isometries of $L$, return
+the invariant sublattice $L^G$ of $L$ and its coinvariant sublattice
+$L_G$ together with the subgroup $H$ of isometries of $L_G$ induced by the
+action of $G$ on $L$.
 
-If `ambient_representation` is set to true, the isometries in `G` and `H` are seen
-as isometries of the ambient quadratic space of `L` preserving `L`. Otherwise,
-they are considered as honnest isometries of `L`.
+If `ambient_representation` is set to `true`, the isometries in $G$ and $H$ are
+considered as matrix representation of their action on the standard basis of the
+ambient space of $L$. Otherwise, they are considered as matrix representation of
+their action on the basis matrices of $L$ and $L_G$ respectively.
 
 # Examples
 ```jldoctest
@@ -1915,13 +2214,13 @@ end
     type(Lf::ZZLatWithIsom)
                       -> Dict{Int, Tuple{ <: Union{ZZGenus, HermGenus}, ZZGenus}}
 
-Given a lattice with isometry $(L, f)$ with `f` of finite order `n`, return the
-type of $(L, f)$.
+Given a lattice with isometry $(L, f)$ with $f$ of finite order $n$, return the
+type of the pair $(L, f)$.
 
-In this context, the type is defined as follows: for each divisor `k` of `n`,
-the `k`-type of $(L, f)$ is the tuple $(H_k, A_K)$ consisting of the genus
+In this context, the type is defined as follows: for each divisor $k$ of $n$,
+the $k$-type of $(L, f)$ is the tuple $(H_k, A_K)$ consisting of the genus
 $H_k$ of the lattice $\ker(\Phi_k(f))$ viewed as a hermitian $\mathbb{Z}[\zeta_k]$-
-lattice (so a $\mathbb{Z}$-lattice for k= 1, 2) and of the genus $A_k$ of the
+lattice (so a $\mathbb{Z}$-lattice for $k= 1, 2$) and of the genus $A_k$ of the
 $\mathbb{Z}$-lattice $\ker(f^k-1)$.
 
 # Examples
@@ -1965,7 +2264,7 @@ end
 @doc raw"""
     is_of_type(Lf::ZZLatWithIsom, t::Dict) -> Bool
 
-Given a lattice with isometry $(L, f)$, return whether $(L, f)$ is of type `t`.
+Given a lattice with isometry $(L, f)$, return whether $(L, f)$ is of type $t$.
 
 # Examples
 ```jldoctest
@@ -2036,7 +2335,7 @@ end
 @doc raw"""
     is_hermitian(t::Dict) -> Bool
 
-Given a type `t` of lattices with isometry, return whether `t` is hermitian, i.e.
+Given a type $t$ of lattices with isometry, return whether $t$ is hermitian, i.e.
 whether it defines the type of a hermitian lattice with isometry.
 
 # Examples
@@ -2083,4 +2382,3 @@ function to_oscar(io::IO, Lf::ZZLatWithIsom)
 end
 
 to_oscar(Lf::ZZLatWithIsom) = to_oscar(stdout, Lf)
-

--- a/experimental/QuadFormAndIsom/src/lattices_with_isometry.jl
+++ b/experimental/QuadFormAndIsom/src/lattices_with_isometry.jl
@@ -1712,7 +1712,6 @@ julia> order(G)
   elseif is_definite(L) || rank(L) == 2
     # We can compute the orthogonal groups and centralizer with GAP
     OL = orthogonal_group(L)
-    discL = discriminant_representation(L, OL)
     f = isometry(Lf)
     # The ambient isometry might not be identity on the complement of L, so we
     # built another ambient isometry extending f by the identity

--- a/experimental/QuadFormAndIsom/src/lattices_with_isometry.jl
+++ b/experimental/QuadFormAndIsom/src/lattices_with_isometry.jl
@@ -1646,6 +1646,7 @@ function discriminant_representation(L::ZZLat, G::MatrixGroup;
     B = basis_matrix(L)
     B2 = orthogonal_complement(V, B)
     C = vcat(B, B2)
+    iC = inv(C)
   end
   q = discriminant_group(L)
   Oq = orthogonal_group(q)
@@ -1654,7 +1655,7 @@ function discriminant_representation(L::ZZLat, G::MatrixGroup;
   for g in geneG
     if !ambient_representation
       mg = block_diagonal_matrix(QQMatrix[matrix(g), identity_matrix(QQ, nrows(B2))])
-      mg = inv(C)*mg*C
+      mg = iC*mg*C
     else
       mg = matrix(g)
     end
@@ -1884,8 +1885,9 @@ function signatures(Lf::ZZLatWithIsom)
   Sq = Int[i for i in 1:div(n,2) if gcd(i,n) == 1]
   D = Dict{Integer, Tuple{Int, Int}}()
   fC = change_base_ring(C, f)
+  ifC = inv(fC)
   for i in Sq
-    M = fC + inv(fC) - lambda^i - lambda^(-i)
+    M = fC + ifC - lambda^i - lambda^(-i)
     D[i] = _real_kernel_signatures(L, M)
   end
   return D
@@ -2138,12 +2140,13 @@ function coinvariant_lattice(L::ZZLat, G::MatrixGroup; ambient_representation::B
     B = basis_matrix(L)
     B2 = orthogonal_complement(V, B)
     B3 = vcat(B, B2)
+    iB3 = inv(B3)
   end
   gene = QQMatrix[]
   for g in gens(G)
     if !ambient_representation
       g_ambient = block_diagonal_matrix(QQMatrix[matrix(g), identity_matrix(QQ, nrows(B2))])
-      g_ambient = inv(B3)*g_ambient*B3
+      g_ambient = iB3*g_ambient*B3
       m = solve_left(basis_matrix(C), basis_matrix(C)*g_ambient)
       push!(gene, m)
     else
@@ -2212,12 +2215,13 @@ function invariant_coinvariant_pair(L::ZZLat, G::MatrixGroup; ambient_representa
     B = basis_matrix(L)
     B2 = orthogonal_complement(V, B)
     B3 = vcat(B, B2)
+    iB3 = inv(B3)
   end
   gene = QQMatrix[]
   for g in gens(G)
     if !ambient_representation
       g_ambient = block_diagonal_matrix(QQMatrix[matrix(g), identity_matrix(QQ, nrows(B2))])
-      g_ambient = inv(B3)*g_ambient*B3
+      g_ambient = iB3*g_ambient*B3
       m = solve_left(basis_matrix(C), basis_matrix(C)*g_ambient)
       push!(gene, m)
     else

--- a/experimental/QuadFormAndIsom/src/spaces_with_isometry.jl
+++ b/experimental/QuadFormAndIsom/src/spaces_with_isometry.jl
@@ -8,7 +8,7 @@
 @doc raw"""
     space(Vf::QuadSpaceWithIsom) -> QuadSpace
 
-Given a quadratic space with isometry $(V, f)$, return the underlying space `V`.
+Given a quadratic space with isometry $(V, f)$, return the underlying space $V$.
 
 # Examples
 ```jldoctest
@@ -26,7 +26,7 @@ space(Vf::QuadSpaceWithIsom) = Vf.V
     isometry(Vf::QuadSpaceWithIsom) -> QQMatrix
 
 Given a quadratic space with isometry $(V, f)$, return the underlying isometry
-`f`.
+$f$.
 
 # Examples
 ```jldoctest
@@ -45,7 +45,7 @@ isometry(Vf::QuadSpaceWithIsom) = Vf.f
     order_of_isometry(Vf::QuadSpaceWithIsom) -> IntExt
 
 Given a quadratic space with isometry $(V, f)$, return the order of the
-underlying isometry `f`.
+underlying isometry $f$.
 
 # Examples
 ```jldoctest
@@ -69,7 +69,7 @@ order_of_isometry(Vf::QuadSpaceWithIsom) = Vf.n
     rank(Vf::QuadSpaceWithIsom) -> Integer
 
 Given a quadratic space with isometry $(V, f)$, return the rank of the underlying
-space `V`.
+space $V$.
 
 # Examples
 ```jldoctest
@@ -87,7 +87,7 @@ rank(Vf::QuadSpaceWithIsom) = rank(space(Vf))
     dim(Vf::QuadSpaceWithIsom) -> Integer
 
 Given a quadratic space with isometry $(V, f)$, return the dimension of the
-underlying space of `V`.
+underlying space of $V$.
 
 # Examples
 ```jldoctest
@@ -105,7 +105,7 @@ dim(Vf::QuadSpaceWithIsom) = dim(space(Vf))
     characteristic_polynomial(Vf::QuadSpaceWithIsom) -> QQPolyRingElem
 
 Given a quadratic space with isometry $(V, f)$, return the characteristic
-polynomial of the underlying isometry `f`.
+polynomial of the underlying isometry $f$.
 
 # Examples
 ```jldoctest
@@ -123,7 +123,7 @@ characteristic_polynomial(Vf::QuadSpaceWithIsom) = characteristic_polynomial(iso
     minimal_polynomial(Vf::QuadSpaceWithIsom) -> QQPolyRingElem
 
 Given a quadratic space with isometry $(V, f)$, return the minimal
-polynomial of the underlying isometry `f`.
+polynomial of the underlying isometry $f$.
 
 # Examples
 ```jldoctest
@@ -141,7 +141,7 @@ minimal_polynomial(Vf) = minimal_polynomial(isometry(Vf))
     gram_matrix(Vf::QuadSpaceWithIsom) -> QQMatrix
 
 Given a quadratic space with isometry $(V, f)$, return the Gram matrix
-of the underlying space `V` with respect to its standard basis.
+of the underlying space $V$ with respect to its standard basis.
 
 # Examples
 ```jldoctest
@@ -159,7 +159,7 @@ gram_matrix(Vf::QuadSpaceWithIsom) = gram_matrix(space(Vf))
     det(Vf::QuadSpaceWithIsom) -> QQFieldElem
 
 Given a quadratic space with isometry $(V, f)$, return the determinant
-of the underlying space `V`.
+of the underlying space $V$.
 
 # Examples
 ```jldoctest
@@ -177,7 +177,7 @@ det(Vf::QuadSpaceWithIsom) = det(space(Vf))
     discriminant(Vf::QuadSpaceWithIsom) -> QQFieldElem
 
 Given a quadratic space with isometry $(V, f)$, return the discriminant
-of the underlying space `V`.
+of the underlying space $V$.
 
 # Examples
 ```jldoctest
@@ -195,7 +195,7 @@ discriminant(Vf::QuadSpaceWithIsom) = discriminant(space(Vf))
     is_positive_definite(Vf::QuadSpaceWithIsom) -> Bool
 
 Given a quadratic space with isometry $(V, f)$, return whether the underlying
-space `V` is positive definite.
+space $V$ is positive definite.
 
 # Examples
 ```jldoctest
@@ -213,7 +213,7 @@ is_positive_definite(Vf::QuadSpaceWithIsom) = is_positive_definite(space(Vf))
     is_negative_definite(Vf::QuadSpaceWithIsom) -> Bool
 
 Given a quadratic space with isometry $(V, f)$, return whether the underlying
-space `V` is negative definite.
+space $V$ is negative definite.
 
 # Examples
 ```jldoctest
@@ -231,7 +231,7 @@ is_negative_definite(Vf::QuadSpaceWithIsom) = is_negative_definite(space(Vf))
     is_definite(Vf::QuadSpaceWithIsom) -> Bool
 
 Given a quadratic space with isometry $(V, f)$, return whether the underlying
-space `V` is definite.
+space $V$ is definite.
 
 # Examples
 ```jldoctest
@@ -249,7 +249,7 @@ is_definite(Vf::QuadSpaceWithIsom) = is_definite(space(Vf))
     diagonal(Vf::QuadSpaceWithIsom) -> Vector{QQFieldElem}
 
 Given a quadratic space with isometry $(V, f)$, return the diagonal of the
-underlying space `V`.
+underlying space $V$.
 
 # Examples
 ```jldoctest
@@ -269,7 +269,7 @@ diagonal(Vf::QuadSpaceWithIsom) = diagonal(space(Vf))
     signature_tuple(Vf::QuadSpaceWithIsom) -> Tuple{Int, Int, Int}
 
 Given a quadratic space with isometry $(V, f)$, return the signature
-tuple of the underlying space `V`.
+tuple of the underlying space $V$.
 
 # Examples
 ```jldoctest
@@ -293,8 +293,8 @@ signature_tuple(Vf::QuadSpaceWithIsom) = signature_tuple(space(Vf))
     quadratic_space_with_isometry(V:QuadSpace, f::QQMatrix; check::Bool = false)
                                                             -> QuadSpaceWithIsom
 
-Given a quadratic space `V` and a matrix `f`, if `f` defines an isometry of `V`
-of order `n` (possibly infinite), return the corresponding quadratic space with
+Given a quadratic space $V$ and a matrix $f$, if $f$ defines an isometry of $V$
+of order $n$ (possibly infinite), return the corresponding quadratic space with
 isometry pair $(V, f)$.
 
 # Examples
@@ -339,10 +339,10 @@ end
 @doc raw"""
     quadratic_space_with_isometry(V::QuadSpace; neg::Bool = false) -> QuadSpaceWithIsom
 
-Given a quadratic space `V`, return the quadratic space with isometry pair $(V, f)$
-where `f` is represented by the identity matrix.
+Given a quadratic space $V$, return the quadratic space with isometry pair $(V, f)$
+where $f$ is represented by the identity matrix.
 
-If `neg` is set to true, then the isometry `f` is negative the identity on `V`.
+If `neg` is set to `true`, then the isometry $f$ is negative the identity on $V$.
 
 # Examples
 ```jldoctest
@@ -378,7 +378,7 @@ end
     rescale(Vf::QuadSpaceWithIsom, a::RationalUnion)
 
 Given a quadratic space with isometry $(V, f)$, return the pair $(V^a, f$) where
-$V^a$ is the same space as `V` with the associated quadratic form rescaled by `a`.
+$V^a$ is the same space as $V$ with the associated quadratic form rescaled by $a$.
 
 # Examples
 ```jldoctest
@@ -462,8 +462,8 @@ end
 
 Given a collection of quadratic spaces with isometries $(V_1, f_1), \ldots, (V_n, f_n)$,
 return the quadratic space with isometry $(V, f)$ together with the injections
-$V_i \to V$, where `V` is the direct sum $V := V_1 \oplus \ldots \oplus V_n$ and
-`f` is the isometry of `V` induced by the diagonal actions of the $f_i$'s.
+$V_i \to V$, where $V$ is the direct sum $V := V_1 \oplus \ldots \oplus V_n$ and
+$f$ is the isometry of $V$ induced by the diagonal actions of the $f_i$'s.
 
 For objects of type `QuadSpaceWithIsom`, finite direct sums and finite direct products
 agree and they are therefore called biproducts.
@@ -545,8 +545,8 @@ direct_sum(x::Vararg{QuadSpaceWithIsom}) = direct_sum(collect(x))
 
 Given a collection of quadratic spaces with isometries $(V_1, f_1), \ldots, (V_n, f_n)$,
 return the quadratic space with isometry $(V, f)$ together with the projections
-$V \to V_i$, where `V` is the direct product $V := V_1 \times \ldots \times V_n$ and
-`f` is the isometry of `V` induced by the diagonal actions of the $f_i$'s.
+$V \to V_i$, where $V$ is the direct product $V := V_1 \times \ldots \times V_n$ and
+$f$ is the isometry of $V$ induced by the diagonal actions of the $f_i$'s.
 
 For objects of type `QuadSpaceWithIsom`, finite direct sums and finite direct products
 agree and they are therefore called biproducts.
@@ -628,8 +628,8 @@ direct_product(x::Vararg{QuadSpaceWithIsom}) = direct_product(collect(x))
 
 Given a collection of quadratic spaces with isometries $(V_1, f_1), \ldots, (V_n, f_n)$,
 return the quadratic space with isometry $(V, f)$ together with the injections
-$V_i \to V$ and the projections $V \to V_i$, where `V` is the biproduct
-$V := V_1 \oplus \ldots \oplus V_n$ and `f` is the isometry of `V` induced by the
+$V_i \to V$ and the projections $V \to V_i$, where $V$ is the biproduct
+$V := V_1 \oplus \ldots \oplus V_n$ and $f$ is the isometry of $V$ induced by the
 diagonal actions of the $f_i$'s.
 
 For objects of type `QuadSpaceWithIsom`, finite direct sums and finite direct products

--- a/experimental/QuadFormAndIsom/src/types.jl
+++ b/experimental/QuadFormAndIsom/src/types.jl
@@ -1,11 +1,11 @@
 @doc raw"""
     QuadSpaceWithIsom
 
-A container type for pairs `(V, f)` consisting on an rational quadratic space
-`V` of type `QuadSpace` and an isometry `f` given as a `QQMatrix` representing
-the action on the standard basis of `V`.
+A container type for pairs $(V, f)$ consisting of a rational quadratic space
+$V$ of type `QuadSpace` and an isometry $f$ given as a `QQMatrix` representing
+the action on the standard basis of $V$.
 
-We store the order of `f` too, which can finite or of infinite order.
+We store the order of $f$ too, which can finite or infinite.
 
 To construct an object of type `QuadSpaceWithIsom`, see the set of functions
 called [`quadratic_space_with_isometry`](@ref)
@@ -59,13 +59,13 @@ end
 @doc raw"""
     ZZLatWithIsom
 
-A container type for pairs `(L, f)` consisting on an integer lattice `L` of
-type `ZZLat` and an isometry `f` given as a `QQMatrix` representing the action
-on a given basis of `L`.
+A container type for pairs $(L, f)$ consisting of an integer lattice $L$ of
+type `ZZLat` and an isometry $f$ given as a `QQMatrix` representing the action
+on the basis matrix of $L$.
 
-We store the ambient space `V` of `L` together with an isometry `f_ambient`
-inducing `f` on `L` seen as a pair $(V, f_ambient)$ of type `QuadSpaceWithIsom`.
-We moreover store the order `n` of `f`, which can be finite or infinite.
+We store the ambient space $V$ of $L$ together with an isometry $f_a$
+inducing $f$ on $L$ seen as a pair $(V, f_a)$ of type `QuadSpaceWithIsom`.
+We moreover store the order $n$ of $f$, which can be finite or infinite.
 
 To construct an object of type `ZZLatWithIsom`, see the following examples:
 
@@ -180,7 +180,7 @@ julia> Cf == Cf2
 true
 ```
 
-The last equality of the last example shows why we care about "ambient context":
+The last equality of the last example shows why we care about *ambient context*:
 the two pairs of lattice with isometry `Cf` and `Cf2` are basically the same
 mathematical objects. Indeed, they lie in the same space, defines the same module
 and their respective isometries are induced by the same isometry of the ambient

--- a/experimental/QuadFormAndIsom/test/runtests.jl
+++ b/experimental/QuadFormAndIsom/test/runtests.jl
@@ -8,8 +8,20 @@ set_verbosity_level(:ZZLatWithIsom, -1)
   function _show_details(io::IO, X::Union{ZZLatWithIsom, QuadSpaceWithIsom})
     return show(io, MIME"text/plain"(), X)
   end
+  # Finite order
   L = root_lattice(:A, 2)
   Lf = integer_lattice_with_isometry(L)
+  Vf = ambient_space(Lf)
+  for X in [Lf, Vf]
+    @test sprint(_show_details, X) isa String
+    @test sprint(Oscar.to_oscar, X) isa String
+    @test sprint(show, X) isa String
+    @test sprint(show, X; context=:supercompact => true) isa String
+  end
+  # Infinite order
+  L = integer_lattice(; gram = QQ[1 2; 2 1])
+  f = QQ[4 -1; 1 0]
+  Lf = integer_lattice_with_isometry(L, f)
   Vf = ambient_space(Lf)
   for X in [Lf, Vf]
     @test sprint(_show_details, X) isa String
@@ -301,4 +313,7 @@ end
   reps = @inferred admissible_equivariant_primitive_extensions(F, C, Lf^0, 5)
   @test length(reps) == 1
   @test is_of_same_type(Lf, reps[1])
+  reps = @inferred primitive_extensions(lattice(F), lattice(C); q = discriminant_group(L), classification = :emb)
+  @test length(reps) == 1
+  @test reps[1] == (L, lattice(F), lattice(C))
 end

--- a/experimental/QuadFormAndIsom/test/runtests.jl
+++ b/experimental/QuadFormAndIsom/test/runtests.jl
@@ -77,6 +77,15 @@ end
   Lf = integer_lattice_with_isometry(L; neg = true)
   @test order_of_isometry(Lf) == -1
 
+  F, C = invariant_coinvariant_pair(Lf)
+  @test rank(F) + rank(C) == rank(Lf)
+  @test order_of_isometry(C) == order_of_isometry(Lf)
+  @test is_one(isometry(F))
+
+  @test is_primary_with_prime(integer_lattice_with_isometry(root_lattice(:E, 6)))[1]
+  @test is_elementary_with_prime(integer_lattice_with_isometry(root_lattice(:E, 7)))[1]
+  @test is_unimodular(integer_lattice_with_isometry(hyperbolic_plane_lattice()))
+
   isdefined(Main, :test_save_load_roundtrip) || include(
     joinpath(Oscar.oscardir, "test", "Serialization", "test_save_load_roundtrip.jl")
   )
@@ -88,6 +97,8 @@ end
   end
   
   L = @inferred integer_lattice_with_isometry(A3)
+  @test is_primary(L, 2)
+  @test !is_elementary(L, 2)
   @test length(unique([L, L, L])) == 1
   @test ambient_space(L) isa QuadSpaceWithIsom
   @test isone(isometry(L))
@@ -195,9 +206,15 @@ end
   @test C == A3
   _, _, G = invariant_coinvariant_pair(A3, OA3; ambient_representation = false)
   @test order(G) == order(OA3)
-  C, _ = coinvariant_lattice(A3, sub(OA3, elem_type(OA3)[OA3(agg[2]), OA3(agg[4])])[1])
+  C, _ = coinvariant_lattice(A3, sub(OA3, elem_type(OA3)[OA3(agg[2]), OA3(agg[4])])[1]; ambient_representation = false)
   @test is_sublattice(A3, C)
 
+  B = matrix(QQ, 3, 3, [1 0 0; 0 1 0; 0 0 1]);
+  G = matrix(QQ, 3, 3, [2 -1 0; -1 2 0; 0 0 -4]);
+  L = integer_lattice(B, gram = G);
+  f = matrix(QQ, 3, 3, [0 -1 0; 1 1 0; 0 0 1]);
+  Lf = integer_lattice_with_isometry(L, f);
+  @test is_bijective(image_centralizer_in_Oq(Lf)[2])
 end
 
 @testset "Enumeration of lattices with finite isometries" begin


### PR DESCRIPTION
Here are some further minor changes for the package:
- Clean-up of the docstrings and of the html documentation (I was not happy with how it looked);
  * Fix the different bugs in display, the typos and other mistakes
  * Add more internal references to different part of the html documentation
  * Add more descriptions/comments for the internal functions 
 
- More improvements following the previous patch: 
  * Disable more unnecessary checks
  * Avoid the creation of some lists in largely used functions when it can be replace by "smarter math"
  * Avoid to use `cartesian_product_iterator` for products of two lists, and put back `inplace = true`  for products of multiple lists (we might save more time and memory now)
  * Rename some variables which should not have the same type in a same code
  
- Few more functionalities for the soon to be added complement on equivariant primitive embeddings:
  * Recognition of primary, elementary and unimodular lattices with isometry
  * Computation of orthogonal submodules (whenever it makes sense)
  *  Computation of the representation of a group of isometries for a lattice on the discriminant group of that lattice
  * `image_centralizer_in_Oq` extended to the general case using hermitian Miranda-Morrison and gluing of stabilizers along equivariant primitive extensions
  * Make the function `primitive_extensions` part of the available functions and not only a background routine (to be safe I have added a sort of deprecations)