### PR TITLE
Fix some part of the modules.

### DIFF
--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -1194,7 +1194,6 @@ function SubModuleOfFreeModule(F::FreeMod{L}, A::MatElem{L}) where {L}
   return subModule
 end
 
-# missing method
 function sparse_row(A::MatElem)
   @assert isone(nrows(A)) "matrix must have only one row"
   R = base_ring(A)

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -1194,6 +1194,15 @@ function SubModuleOfFreeModule(F::FreeMod{L}, A::MatElem{L}) where {L}
   return subModule
 end
 
+# missing method
+function sparse_row(A::MatElem)
+  @assert isone(nrows(A)) "matrix must have only one row"
+  R = base_ring(A)
+  result = sparse_row(R, [(i, a) for (i, a) in enumerate(A[1, :]) if !iszero(a)])
+  return result
+end
+
+
 @doc raw"""
     SubModuleOfFreeModule(F::FreeMod{L}, A::MatElem{L}, default_ordering::ModuleOrdering) where {L}
 


### PR DESCRIPTION
The script where this raised an error was 
```julia
IP1 = projective_space(QQ, [:s, :t])
B = covered_scheme(IP1)
E = direct_sum([twisting_sheaf(IP1, k) for k in [-4, -6, 1]])
IPE = projectivization(E, var_names=["z", "x", "y"])
X = covered_scheme(IPE)
pr = covered_projection_to_base(IPE)
U = first(affine_charts(X))
(x, y, t) = gens(OO(U))
f = y^2 -(x^3 + t^5*(t-1)^2)
I = IdealSheaf(X, U, [f])
inc = Oscar.CoveredClosedEmbedding(X, I)
S = domain(inc)
I_sing_S = Oscar.ideal_sheaf_of_singular_locus(S)
I_sing_X = radical(pushforward(inc, I_sing_S))
singular_components = Oscar.maximal_associated_points(I_sing_X)
Y = X
iota = inc
projections = AbsCoveredSchemeMorphism[]
blowdowns = BlowupMorphism[]
k = 0 # A variable counting the blowups
  global k = k + 1
  global iota
  global projections
  J = radical(first(singular_components))
  @show "blowing up $J"
  for U in affine_charts(scheme(J))
    @show gens(J(U))
  end
  cov = Oscar.simplified_covering(Y)
  @assert cov in coverings(Y)
  global bl = blow_up(J, covering=cov, var_name=Symbol("u$(k)_"))
  push!(blowdowns, bl)
  Sup, iota, pr = strict_transform(bl, iota)
  push!(projections, pr)
  global I_sing_S = Oscar.ideal_sheaf_of_singular_locus(Sup)
  @show isone(I_sing_S)
  @show dim(I_sing_S)
  global I_sing_X = radical(pushforward(iota, I_sing_S))
  @show isone(I_sing_X)
  @show I_sing_X
  @show dim(I_sing_X)
  for U in affine_charts(scheme(I_sing_X))
    @show gens(I_sing_X(U))
  end
  global singular_components = Oscar.maximal_associated_points(I_sing_X)
```
which is certainly not a minimal example. But it runs now. 

CC: @jankoboehm 

Edit: Actually, when executed in the REPL, the above code also produces another error due to printing. Ignore that one, please. It will be fixed elsewhere. 