### PR TITLE
Fix printing of character tables in Jupyter

### DIFF
--- a/src/Groups/MatrixDisplay.jl
+++ b/src/Groups/MatrixDisplay.jl
@@ -278,6 +278,10 @@ function labelled_matrix_formatted(io::IO, mat::Matrix{String})
       write(io, line, "\n")
     end
 
+    if TeX
+      print(io, "\$")
+    end
+
     separators_col = get(io, :separators_col, [])
     separators_row = map(x -> x+m1, get(io, :separators_row, []))
 
@@ -435,6 +439,10 @@ function labelled_matrix_formatted(io::IO, mat::Matrix{String})
           write(io, line, "\n")
         end
       end
+    end
+
+    if TeX
+      print(io, "\$")
     end
 
     return

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -664,9 +664,7 @@ end
 # Produce LaTeX output if `"text/latex"` is prescribed,
 # via the `:TeX` attribute of the io context.
 function Base.show(io::IO, ::MIME"text/latex", tbl::GAPGroupCharacterTable)
-  print(io, "\$")
   show(IOContext(io, :TeX => true), MIME("text/plain"), tbl)
-  print(io, "\$")
 end
 
 @doc raw"""
@@ -783,9 +781,9 @@ C3
 julia> Oscar.with_unicode() do
          show(IOContext(stdout, :with_legend => true), MIME("text/latex"), tbl)
        end;
-$C3
+C3
 
-\begin{array}{rrrr}
+$\begin{array}{rrrr}
 3 & 1 & 1 & 1 \\
  &  &  &  \\
  & 1a & 3a & 3b \\

--- a/test/Groups/MatrixDisplay.jl
+++ b/test/Groups/MatrixDisplay.jl
@@ -321,10 +321,11 @@ no labels
 
 ```jldoctest labelled_matrix_formatted.test
 julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true), mat)
-\begin{array}{rr}
+$\begin{array}{rr}
 1/1 & 1/2 \\
 2/1 & 2/2 \\
 \end{array}
+$
 ```
 
 with header
@@ -334,10 +335,11 @@ julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
          :header => ["header", ""]), mat)
 header
 
-\begin{array}{rr}
+$\begin{array}{rr}
 1/1 & 1/2 \\
 2/1 & 2/2 \\
 \end{array}
+$
 ```
 
 with footer
@@ -345,7 +347,7 @@ with footer
 ```jldoctest labelled_matrix_formatted.test
 julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
          :footer => ["footer"]), mat)
-\begin{array}{rr}
+$\begin{array}{rr}
 1/1 & 1/2 \\
 2/1 & 2/2 \\
 \end{array}
@@ -353,6 +355,7 @@ julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
 \begin{array}{l}
 footer \\
 \end{array}
+$
 ```
 
 with row labels as vector
@@ -360,10 +363,11 @@ with row labels as vector
 ```jldoctest labelled_matrix_formatted.test
 julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
          :labels_row => [string(i)*":" for i in 1:m]), mat)
-\begin{array}{rrr}
+$\begin{array}{rrr}
 1: & 1/1 & 1/2 \\
 2: & 2/1 & 2/2 \\
 \end{array}
+$
 ```
 
 with row labels as matrix
@@ -371,10 +375,11 @@ with row labels as matrix
 ```jldoctest labelled_matrix_formatted.test
 julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
          :labels_row => reshape([string(i)*":" for i in 1:m], m, 1)), mat)
-\begin{array}{rrr}
+$\begin{array}{rrr}
 1: & 1/1 & 1/2 \\
 2: & 2/1 & 2/2 \\
 \end{array}
+$
 ```
 
 with column labels as vector
@@ -382,11 +387,12 @@ with column labels as vector
 ```jldoctest labelled_matrix_formatted.test
 julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
         :labels_col => [string(j) for j in 1:n]), mat)
-\begin{array}{rr}
+$\begin{array}{rr}
 1 & 2 \\
 1/1 & 1/2 \\
 2/1 & 2/2 \\
 \end{array}
+$
 ```
 
 with column labels as matrix
@@ -394,11 +400,12 @@ with column labels as matrix
 ```jldoctest labelled_matrix_formatted.test
 julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
          :labels_col => reshape([string(j) for j in 1:n], 1, n)), mat)
-\begin{array}{rr}
+$\begin{array}{rr}
 1 & 2 \\
 1/1 & 1/2 \\
 2/1 & 2/2 \\
 \end{array}
+$
 ```
 
 with row and column labels
@@ -407,11 +414,12 @@ with row and column labels
 julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
          :labels_row => [string(i)*":" for i in 1:m],
          :labels_col => [string(j) for j in 1:n]), mat)
-\begin{array}{rrr}
+$\begin{array}{rrr}
  & 1 & 2 \\
 1: & 1/1 & 1/2 \\
 2: & 2/1 & 2/2 \\
 \end{array}
+$
 ```
 
 with row separators but without column labels
@@ -419,13 +427,14 @@ with row separators but without column labels
 ```jldoctest labelled_matrix_formatted.test
 julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
          :separators_row => [0, 1, 2]), mat)
-\begin{array}{rr}
+$\begin{array}{rr}
 \hline
 1/1 & 1/2 \\
 \hline
 2/1 & 2/2 \\
 \hline
 \end{array}
+$
 ```
 
 with row separators and column labels
@@ -434,7 +443,7 @@ with row separators and column labels
 julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
          :labels_col => [string(j) for j in 1:n],
          :separators_row => [0,1,2]), mat)
-\begin{array}{rr}
+$\begin{array}{rr}
 1 & 2 \\
 \hline
 1/1 & 1/2 \\
@@ -442,6 +451,7 @@ julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
 2/1 & 2/2 \\
 \hline
 \end{array}
+$
 ```
 
 with column separators but without row labels
@@ -449,10 +459,11 @@ with column separators but without row labels
 ```jldoctest labelled_matrix_formatted.test
 julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
          :separators_col => [0, 1, 2]), mat)
-\begin{array}{|r|r|}
+$\begin{array}{|r|r|}
 1/1 & 1/2 \\
 2/1 & 2/2 \\
 \end{array}
+$
 ```
 
 with column separators and row labels
@@ -461,10 +472,11 @@ with column separators and row labels
 julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
          :labels_row => [string(i)*":" for i in 1:m],
          :separators_col => [0, 1, 2]), mat)
-\begin{array}{r|r|r|}
+$\begin{array}{r|r|r|}
 1: & 1/1 & 1/2 \\
 2: & 2/1 & 2/2 \\
 \end{array}
+$
 ```
 
 with row and column labels and separators
@@ -475,7 +487,7 @@ julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
          :labels_col => [string(j) for j in 1:n],
          :separators_row => [0, 1, 2],
          :separators_col => [0, 1, 2]), mat)
-\begin{array}{r|r|r|}
+$\begin{array}{r|r|r|}
  & 1 & 2 \\
 \hline
 1: & 1/1 & 1/2 \\
@@ -483,6 +495,7 @@ julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
 2: & 2/1 & 2/2 \\
 \hline
 \end{array}
+$
 ```
 
 with row and column portions
@@ -495,7 +508,7 @@ julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
          :separators_col => [0],
          :portions_row => [1,1],
          :portions_col => [1,1]), mat)
-\begin{array}{r|r}
+$\begin{array}{r|r}
  & 1 \\
 \hline
 1 & 1/1 \\
@@ -518,6 +531,7 @@ julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
 \hline
 2 & 2/2 \\
 \end{array}
+$
 ```
 """
 function dummy_placeholder end

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -114,9 +114,9 @@ LaTeX format
 
 ```jldoctest group_characters.test
 julia> show(stdout, MIME("text/latex"), t_a4)
-$Character table of permutation group of degree 4 and order 12
+Character table of permutation group of degree 4 and order 12
 
-\begin{array}{rrrrr}
+$\begin{array}{rrrrr}
 2 & 2 & 2 & . & . \\
 3 & 1 & . & 1 & 1 \\
  &  &  &  &  \\
@@ -181,9 +181,9 @@ A = -z_3 - 1
 ... and in LaTeX format
 ```jldoctest group_characters.test
 julia> show(IOContext(stdout, :with_legend => true), MIME("text/latex"), t_a4)
-$Character table of permutation group of degree 4 and order 12
+Character table of permutation group of degree 4 and order 12
 
-\begin{array}{rrrrr}
+$\begin{array}{rrrrr}
 2 & 2 & 2 & . & . \\
 3 & 1 & . & 1 & 1 \\
  &  &  &  &  \\
@@ -326,9 +326,9 @@ X_5| 5  1 -1                 .                 .|
 julia> show(IOContext(stdout, :separators_col => [0,5],
                           :separators_row => [0,5]),
             MIME("text/latex"), t_a5)
-$A5
+A5
 
-\begin{array}{r|rrrrr|}
+$\begin{array}{r|rrrrr|}
 2 & 2 & 2 & . & . & . \\
 3 & 1 & . & 1 & . & . \\
 5 & 1 & . & . & 1 & 1 \\
@@ -441,9 +441,9 @@ julia> show(IOContext(stdout, :separators_col => [0],
                      :separators_row => [0],
                      :portions_col => [2,3]),
        MIME("text/latex"), t_a5)
-$A5
+A5
 
-\begin{array}{r|rr}
+$\begin{array}{r|rr}
 2 & 2 & 2 \\
 3 & 1 & . \\
 5 & 1 & . \\
@@ -564,9 +564,9 @@ julia> show(IOContext(stdout, :separators_col => [0],
                           :separators_row => [0],
                           :portions_row => [2,3]),
             MIME("text/latex"), t_a5)
-$A5
+A5
 
-\begin{array}{r|rrrrr}
+$\begin{array}{r|rrrrr}
 2 & 2 & 2 & . & . & . \\
 3 & 1 & . & 1 & . & . \\
 5 & 1 & . & . & 1 & 1 \\
@@ -624,9 +624,9 @@ Character table of permutation group of degree 4 and order 12
 
 ```jldoctest group_characters.test
 julia> show(IOContext(stdout, :indicator => [2]), MIME("text/latex"), t_a4)
-$Character table of permutation group of degree 4 and order 12
+Character table of permutation group of degree 4 and order 12
 
-\begin{array}{rrrrrr}
+$\begin{array}{rrrrrr}
  & 2 & 2 & 2 & . & . \\
  & 3 & 1 & . & 1 & 1 \\
  &  &  &  &  &  \\
@@ -668,9 +668,9 @@ Character table of permutation group of degree 4 and order 12
 
 ```jldoctest group_characters.test
 julia> show(IOContext(stdout, :character_field => true), MIME("text/latex"), t_a4)
-$Character table of permutation group of degree 4 and order 12
+Character table of permutation group of degree 4 and order 12
 
-\begin{array}{rrrrrr}
+$\begin{array}{rrrrrr}
  & 2 & 2 & 2 & . & . \\
  & 3 & 1 & . & 1 & 1 \\
  &  &  &  &  &  \\
@@ -711,9 +711,9 @@ julia> Oscar.with_unicode() do
 
 ```jldoctest group_characters.test
 julia> show(IOContext(stdout, :character_field => true), MIME("text/latex"), mod(t_a4, 2))
-$2-modular Brauer table of permutation group of degree 4 and order 12
+2-modular Brauer table of permutation group of degree 4 and order 12
 
-\begin{array}{rrrrr}
+$\begin{array}{rrrrr}
  & 2 & 2 & . & . \\
  & 3 & 1 & 1 & 1 \\
  &  &  &  &  \\


### PR DESCRIPTION
The header should not be inside math mode.