### PR TITLE
versioninfo: fix oscar branch+commit

### DIFF
--- a/docs/src/General/architecture.md
+++ b/docs/src/General/architecture.md
@@ -5,6 +5,10 @@ DocTestSetup = quote
 end
 ```
 
+```@setup oscar
+using Oscar
+```
+
 # Architecture
 
 This page aims to give a short technical overview of the architecture of OSCAR.

--- a/src/utils/versioninfo.jl
+++ b/src/utils/versioninfo.jl
@@ -71,7 +71,7 @@ function versioninfo(io::IO=stdout; branch=false, jll=false, julia=false, commit
       branch = jll = julia = commit = true
    end
    print(io, "OSCAR version $(VERSION_NUMBER)")
-   println(io, branch ? _lookup_git_branch(dirname(@__DIR__); commit=commit) : "")
+   println(io, branch ? _lookup_git_branch(Oscar.oscardir; commit=commit) : "")
    println(io, "  combining:")
    _print_dependency_versions(io, cornerstones; suffix=".jl", branch=branch, commit=commit)
    if jll


### PR DESCRIPTION
This was broken when the functions where moved to a subfolder. I changed it to use `oscardir` instead of `@__DIR__`.

```julia
julia> Oscar.versioninfo(;full=true)
OSCAR version 0.13.1-DEV - #bl/oscarversioncommit, f96a0e81ad -- 2023-09-29 17:45:00 +0200
  combining:
...
```

fixes #2874 