### PR TITLE
When printing groups in the REPL, including information about their generators (and for fp groups, also relations)

### DIFF
--- a/docs/src/Groups/fpgroup.md
+++ b/docs/src/Groups/fpgroup.md
@@ -30,7 +30,7 @@ it has an empty vector of defining relators.
 
 ```jldoctest fpgroupxpl
 julia> F = free_group(2)
-Free group of rank 2
+Free group of rank 2 with 2 generators f1, f2
 
 julia> gens(F)
 2-element Vector{FPGroupElem}:

--- a/docs/src/Groups/matgroup.md
+++ b/docs/src/Groups/matgroup.md
@@ -37,6 +37,12 @@ julia> matelms = map(m -> matrix(ZZ, m), mats)
 julia> g = matrix_group(matelms)
 Matrix group of degree 2
   over integer ring
+with 2 generators
+  [0   -1]
+  [1   -1]
+
+  [0   1]
+  [1   0]
 
 julia> describe(g)
 "S3"
@@ -44,6 +50,7 @@ julia> describe(g)
 julia> t = matrix_group(ZZ, 2, typeof(matelms[1])[])
 Matrix group of degree 2
   over integer ring
+with 0 generators
 
 julia> t == trivial_subgroup(g)[1]
 true
@@ -56,6 +63,12 @@ julia> F = GF(3); matelms = map(m -> matrix(F, m), mats)
 julia> g = matrix_group(matelms)
 Matrix group of degree 2
   over prime field of characteristic 3
+with 2 generators
+  [0   2]
+  [1   2]
+
+  [0   1]
+  [1   0]
 
 julia> describe(g)
 "S3"
@@ -80,6 +93,14 @@ false
 julia> h = change_base_ring(F, g)
 Matrix group of degree 3
   over finite field of degree 2 and characteristic 2
+with 2 generators
+  [1   1   0]
+  [0   1   0]
+  [0   0   1]
+
+  [0   0   1]
+  [1   0   0]
+  [0   1   0]
 
 julia> flag, mp = is_subgroup(h, G)
 (true, Hom: h -> G)

--- a/docs/src/Groups/pcgroup.md
+++ b/docs/src/Groups/pcgroup.md
@@ -82,7 +82,7 @@ julia> set_relative_orders!(c, [2, 3])
 julia> set_conjugate!(c, 2, 1, [2 => 2])
 
 julia> gg = pc_group(c)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> describe(gg)
 "S3"
@@ -93,12 +93,14 @@ and let Oscar compute a pc presentation for it.
 
 ```jldoctest
 julia> g = symmetric_group(4)
-Sym(4)
+Symmetric group of degree 4 and order 24 with 2 generators
+  (1,2,3,4)
+  (1,2)
 
 julia> iso = isomorphism(PcGroup, g);
 
 julia> h = codomain(iso)
-Pc group of order 24
+Pc group of order 24 with 4 generators f1, f2, f3, f4
 ```
 
 For certain series of groups, one can
@@ -106,7 +108,7 @@ For certain series of groups, one can
 
 ```jldoctest
 julia> dihedral_group(8)
-Pc group of order 8
+Pc group of order 8 with 3 generators f1, f2, f3
 ```
 
 And the groups from [the small groups library](@ref "Groups of small order")
@@ -114,7 +116,7 @@ are represented by pc groups whenever they are solvable.
 
 ```jldoctest
 julia> small_group(24, 12)
-Pc group of order 24
+Pc group of order 24 with 4 generators f1, f2, f3, f4
 ```
 
 ## Functions for elements of (subgroups of) pc groups

--- a/docs/src/InvariantTheory/finite_groups.md
+++ b/docs/src/InvariantTheory/finite_groups.md
@@ -92,6 +92,14 @@ julia> M2 = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1])
 julia> G = matrix_group(M1, M2)
 Matrix group of degree 3
   over cyclotomic field of order 3
+with 2 generators
+  [0   0   1]
+  [1   0   0]
+  [0   1   0]
+
+  [1   0        0]
+  [0   a        0]
+  [0   0   -a - 1]
 
 julia> IR = invariant_ring(G)
 Invariant ring
@@ -100,6 +108,14 @@ Invariant ring
 julia> group(IR)
 Matrix group of degree 3
   over cyclotomic field of order 3
+with 2 generators
+  [0   0   1]
+  [1   0   0]
+  [0   1   0]
+
+  [1   0        0]
+  [0   a        0]
+  [0   0   -a - 1]
 
 julia> coefficient_ring(IR)
 Number field with defining polynomial _$^2 + _$ + 1

--- a/experimental/GaloisGrp/src/Solve.jl
+++ b/experimental/GaloisGrp/src/Solve.jl
@@ -291,12 +291,12 @@ one, compute the corresponding subfields as a tower.
 julia> Qx, x = QQ[:x];
 
 julia> G, C = galois_group(x^3-3*x+17)
-(Sym(3), Galois context for x^3 - 3*x + 17 and prime 7)
+(Symmetric group of degree 3 and order 6, Galois context for x^3 - 3*x + 17 and prime 7)
 
 julia> d = derived_series(G)
 3-element Vector{PermGroup}:
- Sym(3)
- Alt(3)
+ Symmetric group of degree 3 and order 6
+ Alternating group of degree 3 and order 3
  Permutation group of degree 3 and order 1
 
 julia> fixed_field(C, d)

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -884,7 +884,10 @@ Return the automorphism group of the graph `g`.
 julia> g = complete_graph(4);
 
 julia> automorphism_group(g)
-Permutation group of degree 4
+Permutation group of degree 4 with 3 generators
+  (3,4)
+  (2,3)
+  (1,2)
 ```
 """
 function automorphism_group(g::Graph{T}) where {T <: Union{Directed, Undirected}}

--- a/src/Combinatorics/Matroids/matroids.jl
+++ b/src/Combinatorics/Matroids/matroids.jl
@@ -1010,7 +1010,10 @@ julia> M = uniform_matroid(2, 4)
 Matroid of rank 2 on 4 elements
 
 julia> automorphism_group(M)
-Permutation group of degree 4
+Permutation group of degree 4 with 3 generators
+  (3,4)
+  (1,2)
+  (2,3)
 ```
 """
 function automorphism_group(M::Matroid) 

--- a/src/Combinatorics/SimplicialComplexes.jl
+++ b/src/Combinatorics/SimplicialComplexes.jl
@@ -650,7 +650,9 @@ julia> K = simplicial_complex([[1, 2, 3], [2, 3, 4]])
 Abstract simplicial complex of dimension 2 on 4 vertices
 
 julia> automorphism_group(K)
-Permutation group of degree 4
+Permutation group of degree 4 with 2 generators
+  (2,3)
+  (1,4)
 ```
 """
 function automorphism_group(K::SimplicialComplex; action=:on_vertices)
@@ -681,7 +683,9 @@ julia> K = simplicial_complex([[1, 2, 3], [2, 3, 4]])
 Abstract simplicial complex of dimension 2 on 4 vertices
 
 julia> G = automorphism_group(K)
-Permutation group of degree 4
+Permutation group of degree 4 with 2 generators
+  (2,3)
+  (1,4)
 
 julia> g = collect(G)[2]
 (1,4)

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -532,31 +532,36 @@ function Base.show(io::IO, ::MIME"text/plain", G::FPGroup)
   _print_generators(io, G)
   rels = relators(G)
   if !isempty(rels)
-    print(io, " and ", ItemQuantity(length(rels), "relator"))
+    print(io, " and ")
+    # TODO: relators can be pretty long; it would be good to abbreviate them
+    # if they don't fit in a single line...
+   _print_stuff_with_limit(io, rels, "relator")
   end
 end
 
-
-
 function _print_generators(io::IO, G::AbstractAlgebra.Group)
-  io = pretty(io)
-  n = ngens(G)
   if G isa PermGroup
     print(io, " ")
   else
     println(io)
   end
-  print(io, "with ", ItemQuantity(n, "generator"))
+  _print_stuff_with_limit(io, gens(G), "generator")
+end
+
+function _print_stuff_with_limit(io::IO, v, what::String)
+  io = pretty(io)
+  n = length(v)
+  print(io, "with ", ItemQuantity(n, what))
 
   # compute maximum number of generators that can fit on the screen
   # assuming each of those requires just one line
   rows,cols = displaysize(io)
-  maxgens = rows - 6
-  maxgens > 0 || return
+  limit = rows - 6
+  limit > 0 || return
 
   println(io, Indent())
-  for (i, g) in enumerate(gens(G))
-    if i > maxgens
+  for (i, g) in enumerate(v)
+    if i > limit
       print(io, "⋮")
       break
     end
@@ -568,7 +573,7 @@ function _print_generators(io::IO, G::AbstractAlgebra.Group)
   print(io, Dedent())
 end
 
-function _print_generators(io::IO, G::Union{FPGroup, PcGroup, SubFPGroup, SubPcGroup}) # TODO: what about subgroups of those?
+function _print_generators(io::IO, G::Union{FPGroup, PcGroup, SubFPGroup, SubPcGroup})
   io = pretty(io)
   n = ngens(G)
   print(io, " with ", ItemQuantity(n, "generator"))

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -898,7 +898,7 @@ julia> G = symmetric_group(4);
 julia> C = conjugacy_class(G, G([2, 1, 3, 4]))
 Conjugacy class of
   (1,2) in
-  symmetric group of degree 4 and order 24
+  symmetric group of degree 4
 
 julia> representative(C)
 (1,2)
@@ -918,7 +918,7 @@ julia> G = symmetric_group(4);
 julia> C = conjugacy_class(G, G([2, 1, 3, 4]))
 Conjugacy class of
   (1,2) in
-  symmetric group of degree 4 and order 24
+  symmetric group of degree 4
 
 julia> acting_group(C) === G
 true
@@ -940,7 +940,7 @@ julia> G = symmetric_group(4);
 julia> C = conjugacy_class(G, G([2, 1, 3, 4]))
 Conjugacy class of
   (1,2) in
-  symmetric group of degree 4 and order 24
+  symmetric group of degree 4
 ```
 """
 function conjugacy_class(G::GAPGroup, g::GAPGroupElem)
@@ -1058,7 +1058,7 @@ if `order` is positive, the classes of subgroups of this order.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(3)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
@@ -1303,7 +1303,7 @@ use [`is_conjugate`](@ref) or [`is_conjugate_with_data`](@ref).
 julia> G = symmetric_group(4);
 
 julia> U = derived_subgroup(G)[1]
-Alternating group of degree 4 and order 12 with 2 generators
+Alternating group of degree 4 with 2 generators
   (1,2,3)
   (2,3,4)
 
@@ -1337,7 +1337,7 @@ otherwise, return `false, one(G)`.
 julia> G = symmetric_group(4);
 
 julia> U = derived_subgroup(G)[1]
-Alternating group of degree 4 and order 12 with 2 generators
+Alternating group of degree 4 with 2 generators
   (1,2,3)
   (2,3,4)
 

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -489,28 +489,25 @@ function Base.show(io::IO, G::PermGroup)
   if has_is_natural_symmetric_group(G) && is_natural_symmetric_group(G) &&
      number_of_moved_points(G) == degree(G)
     if !is_terse(io)
-      print(io, "Symmetric group")
+      print(io, "Symmetric group of degree ", degree(G))
     else
       print(io, LowercaseOff(), "Sym(", degree(G), ")")
     end
+    return
   elseif has_is_natural_alternating_group(G) && is_natural_alternating_group(G) &&
      number_of_moved_points(G) == degree(G)
     if !is_terse(io)
-      print(io, "Alternating group")
+      print(io, "Alternating group of degree ", degree(G))
     else
       print(io, LowercaseOff(), "Alt(", degree(G), ")")
     end
-  else
-    print(io, "Permutation group")
+    return
   end
+  print(io, "Permutation group")
   if !is_terse(io)
     print(io, " of degree ", degree(G))
     if has_order(G)
-      if is_finite(G)
-        print(io, " and order ", order(G))
-      else
-        print(io, " and infinite order")
-      end
+      print(io, " and order ", order(G))
     elseif GAP.Globals.HasStabChainMutable(GapObj(G))
       # HACK: to show order in a few more cases where it is trivial to get
       # but really, GAP should be using this anyway?

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -695,13 +695,13 @@ Return whether generators for the group `G` are known.
 # Examples
 ```jldoctest
 julia> F = free_group(2)
-Free group of rank 2
+Free group of rank 2 with 2 generators f1, f2
 
 julia> has_gens(F)
 true
 
 julia> H = derived_subgroup(F)[1]
-Free group
+Free group of unknown rank
 
 julia> has_gens(H)
 false
@@ -901,7 +901,7 @@ julia> G = symmetric_group(4);
 julia> C = conjugacy_class(G, G([2, 1, 3, 4]))
 Conjugacy class of
   (1,2) in
-  Sym(4)
+  symmetric group of degree 4 and order 24
 
 julia> representative(C)
 (1,2)
@@ -921,7 +921,7 @@ julia> G = symmetric_group(4);
 julia> C = conjugacy_class(G, G([2, 1, 3, 4]))
 Conjugacy class of
   (1,2) in
-  Sym(4)
+  symmetric group of degree 4 and order 24
 
 julia> acting_group(C) === G
 true
@@ -943,7 +943,7 @@ julia> G = symmetric_group(4);
 julia> C = conjugacy_class(G, G([2, 1, 3, 4]))
 Conjugacy class of
   (1,2) in
-  Sym(4)
+  symmetric group of degree 4 and order 24
 ```
 """
 function conjugacy_class(G::GAPGroup, g::GAPGroupElem)
@@ -1061,7 +1061,9 @@ if `order` is positive, the classes of subgroups of this order.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(3)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> subgroup_classes(G)
 4-element Vector{GAPGroupConjClass{PermGroup, PermGroup}}:
@@ -1189,10 +1191,12 @@ Return the group `G^x` that consists of the elements `g^x`, for `g` in `G`.
 julia> G = symmetric_group(4);
 
 julia> H = sylow_subgroup(G, 3)[1]
-Permutation group of degree 4 and order 3
+Permutation group of degree 4 and order 3 with 1 generator
+  (1,2,3)
 
 julia> conjugate_group(H, gen(G, 1))
-Permutation group of degree 4 and order 3
+Permutation group of degree 4 and order 3 with 1 generator
+  (2,3,4)
 
 ```
 """
@@ -1222,16 +1226,19 @@ To also return the element `z`, use
 julia> G = symmetric_group(4);
 
 julia> H = sub(G, [G([2, 1, 3, 4])])[1]
-Permutation group of degree 4
+Permutation group of degree 4 with 1 generator
+  (1,2)
 
 julia> K = sub(G, [G([1, 2, 4, 3])])[1]
-Permutation group of degree 4
+Permutation group of degree 4 with 1 generator
+  (3,4)
 
 julia> is_conjugate(G, H, K)
 true
 
 julia> K = sub(G, [G([2, 1, 4, 3])])[1]
-Permutation group of degree 4
+Permutation group of degree 4 with 1 generator
+  (1,2)(3,4)
 
 julia> is_conjugate(G, H, K)
 false
@@ -1254,16 +1261,19 @@ If the conjugating element `z` is not needed, use
 julia> G = symmetric_group(4);
 
 julia> H = sub(G, [G([2, 1, 3, 4])])[1]
-Permutation group of degree 4
+Permutation group of degree 4 with 1 generator
+  (1,2)
 
 julia> K = sub(G, [G([1, 2, 4, 3])])[1]
-Permutation group of degree 4
+Permutation group of degree 4 with 1 generator
+  (3,4)
 
 julia> is_conjugate_with_data(G, H, K)
 (true, (1,3)(2,4))
 
 julia> K = sub(G, [G([2, 1, 4, 3])])[1]
-Permutation group of degree 4
+Permutation group of degree 4 with 1 generator
+  (1,2)(3,4)
 
 julia> is_conjugate_with_data(G, H, K)
 (false, nothing)
@@ -1296,16 +1306,20 @@ use [`is_conjugate`](@ref) or [`is_conjugate_with_data`](@ref).
 julia> G = symmetric_group(4);
 
 julia> U = derived_subgroup(G)[1]
-Alt(4)
+Alternating group of degree 4 and order 12 with 2 generators
+  (1,2,3)
+  (2,3,4)
 
 julia> V = sub(G, [G([2,1,3,4])])[1]
-Permutation group of degree 4
+Permutation group of degree 4 with 1 generator
+  (1,2)
 
 julia> is_conjugate_subgroup(G, U, V)
 false
 
 julia> V = sub(G, [G([2, 1, 4, 3])])[1]
-Permutation group of degree 4
+Permutation group of degree 4 with 1 generator
+  (1,2)(3,4)
 
 julia> is_conjugate_subgroup(G, U, V)
 true
@@ -1326,16 +1340,20 @@ otherwise, return `false, one(G)`.
 julia> G = symmetric_group(4);
 
 julia> U = derived_subgroup(G)[1]
-Alt(4)
+Alternating group of degree 4 and order 12 with 2 generators
+  (1,2,3)
+  (2,3,4)
 
 julia> V = sub(G, [G([2,1,3,4])])[1]
-Permutation group of degree 4
+Permutation group of degree 4 with 1 generator
+  (1,2)
 
 julia> is_conjugate_subgroup_with_data(G, U, V)
 (false, ())
 
 julia> V = sub(G, [G([2, 1, 4, 3])])[1]
-Permutation group of degree 4
+Permutation group of degree 4 with 1 generator
+  (1,2)(3,4)
 
 julia> is_conjugate_subgroup_with_data(G, U, V)
 (true, ())
@@ -1372,7 +1390,8 @@ such that `H^g` contains the element `s`.
 julia> G = symmetric_group(4);
 
 julia> H = sylow_subgroup(G, 3)[1]
-Permutation group of degree 4 and order 3
+Permutation group of degree 4 and order 3 with 1 generator
+  (1,2,3)
 
 julia> short_right_transversal(G, H, G([2, 1, 3, 4]))
 PermGroupElem[]
@@ -1660,7 +1679,7 @@ julia> complement_classes(G, derived_subgroup(G)[1])
  Conjugacy class of permutation group in G
 
 julia> G = dihedral_group(8)
-Pc group of order 8
+Pc group of order 8 with 3 generators f1, f2, f3
 
 julia> complement_classes(G, center(G)[1])
 GAPGroupConjClass{PcGroup, SubPcGroup}[]
@@ -1953,7 +1972,7 @@ julia> rank(free_group(5))
 5
 
 julia> G = pc_group(abelian_group(5,0))
-Pc group of infinite order
+Pc group of infinite order with 2 generators g1, g2
 
 julia> rank(G)
 2
@@ -1992,13 +2011,13 @@ Return whether `G` is a finitely generated group.
 # Examples
 ```jldoctest
 julia> F = free_group(2)
-Free group of rank 2
+Free group of rank 2 with 2 generators f1, f2
 
 julia> is_finitely_generated(F)
 true
 
 julia> H = derived_subgroup(F)[1]
-Free group
+Free group of unknown rank
 
 julia> is_finitely_generated(H)
 false
@@ -2099,7 +2118,7 @@ of `G`.
 # Examples
 ```jldoctest
 julia> g = dihedral_group(8)
-Pc group of order 8
+Pc group of order 8 with 3 generators f1, f2, f3
 
 julia> relators(g)
 6-element Vector{FPGroupElem}:
@@ -2263,7 +2282,7 @@ See also: [`map_word(::Union{FPGroupElem, SubFPGroupElem}, ::Vector)`](@ref),
 # Examples
 ```jldoctest
 julia> G = dihedral_group(10)
-Pc group of order 10
+Pc group of order 10 with 2 generators f1, f2
 
 julia> x, y = gens(G);  g = x * y^4
 f1*f2^4

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -412,7 +412,30 @@ Return the identity of the parent group of `x`.
 """
 Base.one(x::GAPGroupElem) = one(parent(x))
 
-Base.show(io::IO, x::GAPGroupElem) = print(io, String(GAPWrap.StringViewObj(GapObj(x))))
+function Base.show(io::IO, x::GAPGroupElem)
+  print(io, String(GAPWrap.StringViewObj(GapObj(x))))
+end
+
+#function Base.show(io::IO, ::MIME"text/plain", x::FPGroupElem)
+#  println(io, "limit = ", get(io, :limit, false))
+#  print(io, String(GAPWrap.StringViewObj(GapObj(x))))
+#end
+
+function Base.show(io::IO, x::FPGroupElem)
+#  print(io, String(GAPWrap.StringViewObj(GapObj(x))))
+#  println(io, "compact = ", get(io, :compact, false))
+#  println(io, "limit = ", get(io, :limit, false))
+#  println(io, "is_terse = ", is_terse(io))
+  s = String(GAPWrap.StringViewObj(GapObj(x)))
+  if get(io, :limit, false)::Bool
+    screenheight, screenwidth = displaysize(io)::Tuple{Int,Int}
+    #println(length(s), " vs ", screenwidth)
+    if length(s) > screenwidth - 3
+      s = s[1:screenwidth-6] * "..."
+    end
+  end
+  print(io, s)
+end
 
 # Printing GAP groups
 function Base.show(io::IO, G::GAPGroup)
@@ -535,7 +558,7 @@ function Base.show(io::IO, ::MIME"text/plain", G::FPGroup)
     print(io, " and ")
     # TODO: relators can be pretty long; it would be good to abbreviate them
     # if they don't fit in a single line...
-   _print_stuff_with_limit(io, rels, "relator")
+   _print_stuff_with_limit(terse(io), rels, "relator")
   end
 end
 
@@ -555,8 +578,8 @@ function _print_stuff_with_limit(io::IO, v, what::String)
 
   # compute maximum number of generators that can fit on the screen
   # assuming each of those requires just one line
-  rows,cols = displaysize(io)
-  limit = rows - 6
+  screenheight, screenwidth = displaysize(io)::Tuple{Int,Int}
+  limit = screenheight - 6
   limit > 0 || return
 
   println(io, Indent())

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -521,6 +521,23 @@ function Base.show(io::IO, ::MIME"text/plain", G::GAPGroup)
   _print_generators(io, G)
 end
 
+#function Base.show(io::IO, ::MIME"text/plain", G::Union{FPGroup, SubFPGroup})
+function Base.show(io::IO, ::MIME"text/plain", G::FPGroup)
+  @show_name(io, G)
+  @show_special(io, G)
+
+  # Recurse to regular printing
+  print(io, G)
+  has_gens(G) || return
+  _print_generators(io, G)
+  rels = relators(G)
+  if !isempty(rels)
+    print(io, " and ", ItemQuantity(length(rels), "relator"))
+  end
+end
+
+
+
 function _print_generators(io::IO, G::AbstractAlgebra.Group)
   io = pretty(io)
   n = ngens(G)

--- a/src/Groups/abelian_aut.jl
+++ b/src/Groups/abelian_aut.jl
@@ -158,7 +158,7 @@ function Base.show(io::IO, aut::AutomorphismGroup{TorQuadModule})
   T = domain(aut)
   io = pretty(io)
   n = ngens(aut)
-  print(IOContext(io, :compact => true), "Group of isometries of ", Lowercase(), T, " with ", ItemQuantity(n, "generator"))
+  print(IOContext(io, :compact => true), "Group of isometries of ", Lowercase(), T)
 end
 
 

--- a/src/Groups/abelian_aut.jl
+++ b/src/Groups/abelian_aut.jl
@@ -434,7 +434,10 @@ Gram matrix quadratic form:
 [4//15]
 
 julia> OT = orthogonal_group(T)
-Group of isometries of finite quadratic module: Z/15 -> Q/2Z with 2 generators
+Group of isometries of finite quadratic module: Z/15 -> Q/2Z
+with 2 generators
+  [4]
+  [11]
 
 julia> T3inT = primary_part(T, 3)[2]
 Map
@@ -476,7 +479,10 @@ of the codomain of `i`.
 julia> T = torsion_quadratic_module(matrix(QQ, 2, 2, [2//3 0; 0 2//5]));
 
 julia> OT = orthogonal_group(T)
-Group of isometries of finite quadratic module: Z/15 -> Q/2Z with 2 generators
+Group of isometries of finite quadratic module: Z/15 -> Q/2Z
+with 2 generators
+  [4]
+  [11]
 
 julia> T3inT = primary_part(T, 3)[2]
 Map
@@ -484,7 +490,7 @@ Map
   to finite quadratic module: Z/15 -> Q/2Z
 
 julia> S, _ = stabilizer(OT, T3inT)
-(Group of isometries of finite quadratic module: Z/15 -> Q/2Z with 2 generators, Hom: group of isometries of finite quadratic module with 2 generators -> group of isometries of finite quadratic module with 2 generators)
+(Group of isometries of finite quadratic module: Z/15 -> Q/2Z, Hom: group of isometries of finite quadratic module -> group of isometries of finite quadratic module)
 
 julia> order(S)
 4

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -437,10 +437,14 @@ be a subgroup of the domain of `g`.
 # Examples
 ```jldoctest
 julia> C = cyclic_group(20)
-Pc group of order 20
+Pc group of order 20 with 3 generators f1, f2, f3
 
 julia> S = automorphism_group(C)
-Aut( <pc group of size 20 with 3 generators> )
+Automorphism group of
+  pc group of order 20
+with 2 generators
+  [ f3^3, f1*f2*f3^3 ] -> [ f3^3, f1*f3 ]
+  [ f1*f2*f3^3, f3^3 ] -> [ f1*f2*f3^3, f3 ]
 
 julia> H, _ = sub(C, [gens(C)[1]^4])
 (Sub-pc group of order 5, Hom: H -> C)
@@ -678,7 +682,11 @@ Compute the action of `G` on the right cosets of its subgroup `U`.
 julia> G = symmetric_group(6);
 
 julia> H = sylow_subgroup(G, 2)[1]
-Permutation group of degree 6 and order 16
+Permutation group of degree 6 and order 16 with 4 generators
+  (1,2)
+  (3,4)
+  (1,3)(2,4)
+  (5,6)
 
 julia> index(G, H)
 45

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -92,18 +92,22 @@ Return the coset `Hg`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Sym(5)
+Symmetric group of degree 5 and order 120 with 2 generators
+  (1,2,3,4,5)
+  (1,2)
 
 julia> g = perm(G,[3,4,1,5,2])
 (1,3)(2,4,5)
 
 julia> H = symmetric_group(3)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> right_coset(H, g)
-Right coset of Sym(3)
+Right coset of symmetric group of degree 3 and order 6
   with representative (1,3)(2,4,5)
-  in Sym(5)
+  in symmetric group of degree 5 and order 120
 ```
 """
 function right_coset(H::GAPGroup, g::GAPGroupElem)
@@ -127,12 +131,14 @@ julia> g = perm([3,4,1,5,2])
 (1,3)(2,4,5)
 
 julia> H = symmetric_group(3)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> gH = left_coset(H, g)
-Left coset of Sym(3)
+Left coset of symmetric group of degree 3 and order 6
   with representative (1,3)(2,4,5)
-  in Sym(5)
+  in symmetric group of degree 5 and order 120
 ```
 """
 function left_coset(H::GAPGroup, g::GAPGroupElem)
@@ -192,15 +198,20 @@ That is, `C` is a left or right coset of a subgroup of `G` in `G`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Sym(5)
+Symmetric group of degree 5 and order 120 with 2 generators
+  (1,2,3,4,5)
+  (1,2)
 
 julia> H = sylow_subgroup(G, 2)[1]
-Permutation group of degree 5 and order 8
+Permutation group of degree 5 and order 8 with 3 generators
+  (1,2)
+  (3,4)
+  (1,3)(2,4)
 
 julia> C = right_coset(H, gen(G, 1))
 Right coset of permutation group of degree 5 and order 8
   with representative (1,2,3,4,5)
-  in Sym(5)
+  in symmetric group of degree 5 and order 120
 
 julia> group(C) == G
 true
@@ -218,15 +229,19 @@ or `xH` (if `C` is a left coset), for an element `x` in `C`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Sym(5)
+Symmetric group of degree 5 and order 120 with 2 generators
+  (1,2,3,4,5)
+  (1,2)
 
 julia> H = symmetric_group(3)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> C = right_coset(H, gen(G, 1))
-Right coset of Sym(3)
+Right coset of symmetric group of degree 3 and order 6
   with representative (1,2,3,4,5)
-  in Sym(5)
+  in symmetric group of degree 5 and order 120
 
 julia> acting_group(C) == H
 true
@@ -244,18 +259,22 @@ or `xH` (if `C` is a left coset).
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Sym(5)
+Symmetric group of degree 5 and order 120 with 2 generators
+  (1,2,3,4,5)
+  (1,2)
 
 julia> g = perm(G,[3,4,1,5,2])
 (1,3)(2,4,5)
 
 julia> H = symmetric_group(3)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> Hg = right_coset(H, g)
-Right coset of Sym(3)
+Right coset of symmetric group of degree 3 and order 6
   with representative (1,3)(2,4,5)
-  in Sym(5)
+  in symmetric group of degree 5 and order 120
 
 julia> representative(Hg)
 (1,3)(2,4,5)
@@ -275,18 +294,22 @@ This is the case if and only if the coset representative normalizes
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Sym(5)
+Symmetric group of degree 5 and order 120 with 2 generators
+  (1,2,3,4,5)
+  (1,2)
 
 julia> H = symmetric_group(4)
-Sym(4)
+Symmetric group of degree 4 and order 24 with 2 generators
+  (1,2,3,4)
+  (1,2)
 
 julia> g = perm(G,[3,4,1,5,2])
 (1,3)(2,4,5)
 
 julia> gH = left_coset(H, g)
-Left coset of Sym(4)
+Left coset of symmetric group of degree 4 and order 24
   with representative (1,3)(2,4,5)
-  in Sym(5)
+  in symmetric group of degree 5 and order 120
 
 julia> is_bicoset(gH)
 false
@@ -295,9 +318,9 @@ julia> f = perm(G,[2,1,4,3,5])
 (1,2)(3,4)
 
 julia> fH = left_coset(H, f)
-Left coset of Sym(4)
+Left coset of symmetric group of degree 4 and order 24
   with representative (1,2)(3,4)
-  in Sym(5)
+  in symmetric group of degree 5 and order 120
 
 julia> is_bicoset(fH)
 true
@@ -317,15 +340,19 @@ Use [`right_transversal`](@ref) to compute the vector of coset representatives.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(4)
-Sym(4)
+Symmetric group of degree 4 and order 24 with 2 generators
+  (1,2,3,4)
+  (1,2)
 
 julia> H = symmetric_group(3)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> rc = right_cosets(G, H)
 Right cosets of
-  Sym(3) in
-  Sym(4)
+  symmetric group of degree 3 and order 6 in
+  symmetric group of degree 4 and order 24
 
 julia> collect(rc)
 4-element Vector{GroupCoset{PermGroup, PermGroup, PermGroupElem}}:
@@ -351,15 +378,19 @@ Use [`left_transversal`](@ref) to compute the vector of coset representatives.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(4)
-Sym(4)
+Symmetric group of degree 4 and order 24 with 2 generators
+  (1,2,3,4)
+  (1,2)
 
 julia> H = symmetric_group(3)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> left_cosets(G, H)
 Left cosets of
-  Sym(3) in
-  Sym(4)
+  symmetric group of degree 3 and order 6 in
+  symmetric group of degree 4 and order 24
 ```
 """
 function left_cosets(G::GAPGroup, H::GAPGroup; check::Bool=true)
@@ -453,15 +484,20 @@ That is, `T` is a left or right transversal of a subgroup of `G`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Sym(5)
+Symmetric group of degree 5 and order 120 with 2 generators
+  (1,2,3,4,5)
+  (1,2)
 
 julia> H = sylow_subgroup(G, 2)[1]
-Permutation group of degree 5 and order 8
+Permutation group of degree 5 and order 8 with 3 generators
+  (1,2)
+  (3,4)
+  (1,3)(2,4)
 
 julia> T = right_transversal(G, H)
 Right transversal of length 15 of
   permutation group of degree 5 and order 8 in
-  Sym(5)
+  symmetric group of degree 5 and order 120
 
 julia> group(T) == G
 true
@@ -478,15 +514,19 @@ transversal of `H`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Sym(5)
+Symmetric group of degree 5 and order 120 with 2 generators
+  (1,2,3,4,5)
+  (1,2)
 
 julia> H = symmetric_group(3)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> T = right_transversal(G, H)
 Right transversal of length 20 of
-  Sym(3) in
-  Sym(5)
+  symmetric group of degree 3 and order 6 in
+  symmetric group of degree 5 and order 120
 
 julia> subgroup(T) == H
 true
@@ -509,15 +549,19 @@ Use [`right_cosets`](@ref) to compute the G-set of right cosets.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(4)
-Sym(4)
+Symmetric group of degree 4 and order 24 with 2 generators
+  (1,2,3,4)
+  (1,2)
 
 julia> H = symmetric_group(3)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> T = right_transversal(G, H)
 Right transversal of length 4 of
-  Sym(3) in
-  Sym(4)
+  symmetric group of degree 3 and order 6 in
+  symmetric group of degree 4 and order 24
 
 julia> collect(T)
 4-element Vector{PermGroupElem}:
@@ -551,15 +595,19 @@ Use [`left_cosets`](@ref) to compute the G-set of left cosets.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(4)
-Sym(4)
+Symmetric group of degree 4 and order 24 with 2 generators
+  (1,2,3,4)
+  (1,2)
 
 julia> H = symmetric_group(3)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> T = left_transversal(G, H)
 Left transversal of length 4 of
-  Sym(3) in
-  Sym(4)
+  symmetric group of degree 3 and order 6 in
+  symmetric group of degree 4 and order 24
 
 julia> collect(T)
 4-element Vector{PermGroupElem}:
@@ -659,22 +707,27 @@ Return the double coset `HxK`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Sym(5)
+Symmetric group of degree 5 and order 120 with 2 generators
+  (1,2,3,4,5)
+  (1,2)
 
 julia> g = perm(G,[3,4,5,1,2])
 (1,3,5,2,4)
 
 julia> H = symmetric_group(3)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> K = symmetric_group(2)
-Sym(2)
+Symmetric group of degree 2 and order 2 with 1 generator
+  (1,2)
 
 julia> double_coset(H,g,K)
-Double coset of Sym(3)
-  and Sym(2)
+Double coset of symmetric group of degree 3 and order 6
+  and symmetric group of degree 2 and order 2
   with representative (1,3,5,2,4)
-  in Sym(5)
+  in symmetric group of degree 5 and order 120
 ```
 """
 function double_coset(G::GAPGroup, g::GAPGroupElem, H::GAPGroup)
@@ -695,13 +748,18 @@ If `check == false`, do not check whether `H` and `K` are subgroups of `G`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(4)
-Sym(4)
+Symmetric group of degree 4 and order 24 with 2 generators
+  (1,2,3,4)
+  (1,2)
 
 julia> H = symmetric_group(3)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> K = symmetric_group(2)
-Sym(2)
+Symmetric group of degree 2 and order 2 with 1 generator
+  (1,2)
 
 julia> double_cosets(G,H,K)
 3-element Vector{GroupDoubleCoset{PermGroup, PermGroupElem}}:
@@ -770,15 +828,17 @@ That is, `C` is a double coset of two subgroups of `G` in `G`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Sym(5)
+Symmetric group of degree 5 and order 120 with 2 generators
+  (1,2,3,4,5)
+  (1,2)
 
 julia> H = symmetric_group(3); K = symmetric_group(2);
 
 julia> HgK = double_coset(H, gen(G, 1), K)
-Double coset of Sym(3)
-  and Sym(2)
+Double coset of symmetric group of degree 3 and order 6
+  and symmetric group of degree 2 and order 2
   with representative (1,2,3,4,5)
-  in Sym(5)
+  in symmetric group of degree 5 and order 120
 
 julia> group(HgK) == G
 true
@@ -794,15 +854,17 @@ Return an element `x` of the double coset `C` = `HxK`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Sym(5)
+Symmetric group of degree 5 and order 120 with 2 generators
+  (1,2,3,4,5)
+  (1,2)
 
 julia> H = symmetric_group(3); K = symmetric_group(2);
 
 julia> HgK = double_coset(H, gen(G, 1), K)
-Double coset of Sym(3)
-  and Sym(2)
+Double coset of symmetric group of degree 3 and order 6
+  and symmetric group of degree 2 and order 2
   with representative (1,2,3,4,5)
-  in Sym(5)
+  in symmetric group of degree 5 and order 120
 
 julia> representative(HgK)
 (1,2,3,4,5)
@@ -818,15 +880,17 @@ Return `H` if `C` = `HxK`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Sym(5)
+Symmetric group of degree 5 and order 120 with 2 generators
+  (1,2,3,4,5)
+  (1,2)
 
 julia> H = symmetric_group(3); K = symmetric_group(2);
 
 julia> HgK = double_coset(H, gen(G, 1), K)
-Double coset of Sym(3)
-  and Sym(2)
+Double coset of symmetric group of degree 3 and order 6
+  and symmetric group of degree 2 and order 2
   with representative (1,2,3,4,5)
-  in Sym(5)
+  in symmetric group of degree 5 and order 120
 
 julia> left_acting_group(HgK) == H
 true
@@ -842,15 +906,17 @@ Return `K` if `C` = `HxK`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Sym(5)
+Symmetric group of degree 5 and order 120 with 2 generators
+  (1,2,3,4,5)
+  (1,2)
 
 julia> H = symmetric_group(3); K = symmetric_group(2);
 
 julia> HgK = double_coset(H, gen(G, 1), K)
-Double coset of Sym(3)
-  and Sym(2)
+Double coset of symmetric group of degree 3 and order 6
+  and symmetric group of degree 2 and order 2
   with representative (1,2,3,4,5)
-  in Sym(5)
+  in symmetric group of degree 5 and order 120
 
 julia> right_acting_group(HgK) == K
 true

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -92,7 +92,7 @@ Return the coset `Hg`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Symmetric group of degree 5 and order 120 with 2 generators
+Symmetric group of degree 5 with 2 generators
   (1,2,3,4,5)
   (1,2)
 
@@ -100,14 +100,14 @@ julia> g = perm(G,[3,4,1,5,2])
 (1,3)(2,4,5)
 
 julia> H = symmetric_group(3)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
 julia> right_coset(H, g)
-Right coset of symmetric group of degree 3 and order 6
+Right coset of symmetric group of degree 3
   with representative (1,3)(2,4,5)
-  in symmetric group of degree 5 and order 120
+  in symmetric group of degree 5
 ```
 """
 function right_coset(H::GAPGroup, g::GAPGroupElem)
@@ -131,14 +131,14 @@ julia> g = perm([3,4,1,5,2])
 (1,3)(2,4,5)
 
 julia> H = symmetric_group(3)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
 julia> gH = left_coset(H, g)
-Left coset of symmetric group of degree 3 and order 6
+Left coset of symmetric group of degree 3
   with representative (1,3)(2,4,5)
-  in symmetric group of degree 5 and order 120
+  in symmetric group of degree 5
 ```
 """
 function left_coset(H::GAPGroup, g::GAPGroupElem)
@@ -198,7 +198,7 @@ That is, `C` is a left or right coset of a subgroup of `G` in `G`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Symmetric group of degree 5 and order 120 with 2 generators
+Symmetric group of degree 5 with 2 generators
   (1,2,3,4,5)
   (1,2)
 
@@ -211,7 +211,7 @@ Permutation group of degree 5 and order 8 with 3 generators
 julia> C = right_coset(H, gen(G, 1))
 Right coset of permutation group of degree 5 and order 8
   with representative (1,2,3,4,5)
-  in symmetric group of degree 5 and order 120
+  in symmetric group of degree 5
 
 julia> group(C) == G
 true
@@ -229,19 +229,19 @@ or `xH` (if `C` is a left coset), for an element `x` in `C`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Symmetric group of degree 5 and order 120 with 2 generators
+Symmetric group of degree 5 with 2 generators
   (1,2,3,4,5)
   (1,2)
 
 julia> H = symmetric_group(3)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
 julia> C = right_coset(H, gen(G, 1))
-Right coset of symmetric group of degree 3 and order 6
+Right coset of symmetric group of degree 3
   with representative (1,2,3,4,5)
-  in symmetric group of degree 5 and order 120
+  in symmetric group of degree 5
 
 julia> acting_group(C) == H
 true
@@ -259,7 +259,7 @@ or `xH` (if `C` is a left coset).
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Symmetric group of degree 5 and order 120 with 2 generators
+Symmetric group of degree 5 with 2 generators
   (1,2,3,4,5)
   (1,2)
 
@@ -267,14 +267,14 @@ julia> g = perm(G,[3,4,1,5,2])
 (1,3)(2,4,5)
 
 julia> H = symmetric_group(3)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
 julia> Hg = right_coset(H, g)
-Right coset of symmetric group of degree 3 and order 6
+Right coset of symmetric group of degree 3
   with representative (1,3)(2,4,5)
-  in symmetric group of degree 5 and order 120
+  in symmetric group of degree 5
 
 julia> representative(Hg)
 (1,3)(2,4,5)
@@ -294,12 +294,12 @@ This is the case if and only if the coset representative normalizes
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Symmetric group of degree 5 and order 120 with 2 generators
+Symmetric group of degree 5 with 2 generators
   (1,2,3,4,5)
   (1,2)
 
 julia> H = symmetric_group(4)
-Symmetric group of degree 4 and order 24 with 2 generators
+Symmetric group of degree 4 with 2 generators
   (1,2,3,4)
   (1,2)
 
@@ -307,9 +307,9 @@ julia> g = perm(G,[3,4,1,5,2])
 (1,3)(2,4,5)
 
 julia> gH = left_coset(H, g)
-Left coset of symmetric group of degree 4 and order 24
+Left coset of symmetric group of degree 4
   with representative (1,3)(2,4,5)
-  in symmetric group of degree 5 and order 120
+  in symmetric group of degree 5
 
 julia> is_bicoset(gH)
 false
@@ -318,9 +318,9 @@ julia> f = perm(G,[2,1,4,3,5])
 (1,2)(3,4)
 
 julia> fH = left_coset(H, f)
-Left coset of symmetric group of degree 4 and order 24
+Left coset of symmetric group of degree 4
   with representative (1,2)(3,4)
-  in symmetric group of degree 5 and order 120
+  in symmetric group of degree 5
 
 julia> is_bicoset(fH)
 true
@@ -340,19 +340,19 @@ Use [`right_transversal`](@ref) to compute the vector of coset representatives.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(4)
-Symmetric group of degree 4 and order 24 with 2 generators
+Symmetric group of degree 4 with 2 generators
   (1,2,3,4)
   (1,2)
 
 julia> H = symmetric_group(3)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
 julia> rc = right_cosets(G, H)
 Right cosets of
-  symmetric group of degree 3 and order 6 in
-  symmetric group of degree 4 and order 24
+  symmetric group of degree 3 in
+  symmetric group of degree 4
 
 julia> collect(rc)
 4-element Vector{GroupCoset{PermGroup, PermGroup, PermGroupElem}}:
@@ -378,19 +378,19 @@ Use [`left_transversal`](@ref) to compute the vector of coset representatives.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(4)
-Symmetric group of degree 4 and order 24 with 2 generators
+Symmetric group of degree 4 with 2 generators
   (1,2,3,4)
   (1,2)
 
 julia> H = symmetric_group(3)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
 julia> left_cosets(G, H)
 Left cosets of
-  symmetric group of degree 3 and order 6 in
-  symmetric group of degree 4 and order 24
+  symmetric group of degree 3 in
+  symmetric group of degree 4
 ```
 """
 function left_cosets(G::GAPGroup, H::GAPGroup; check::Bool=true)
@@ -484,7 +484,7 @@ That is, `T` is a left or right transversal of a subgroup of `G`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Symmetric group of degree 5 and order 120 with 2 generators
+Symmetric group of degree 5 with 2 generators
   (1,2,3,4,5)
   (1,2)
 
@@ -497,7 +497,7 @@ Permutation group of degree 5 and order 8 with 3 generators
 julia> T = right_transversal(G, H)
 Right transversal of length 15 of
   permutation group of degree 5 and order 8 in
-  symmetric group of degree 5 and order 120
+  symmetric group of degree 5
 
 julia> group(T) == G
 true
@@ -514,19 +514,19 @@ transversal of `H`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Symmetric group of degree 5 and order 120 with 2 generators
+Symmetric group of degree 5 with 2 generators
   (1,2,3,4,5)
   (1,2)
 
 julia> H = symmetric_group(3)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
 julia> T = right_transversal(G, H)
 Right transversal of length 20 of
-  symmetric group of degree 3 and order 6 in
-  symmetric group of degree 5 and order 120
+  symmetric group of degree 3 in
+  symmetric group of degree 5
 
 julia> subgroup(T) == H
 true
@@ -549,19 +549,19 @@ Use [`right_cosets`](@ref) to compute the G-set of right cosets.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(4)
-Symmetric group of degree 4 and order 24 with 2 generators
+Symmetric group of degree 4 with 2 generators
   (1,2,3,4)
   (1,2)
 
 julia> H = symmetric_group(3)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
 julia> T = right_transversal(G, H)
 Right transversal of length 4 of
-  symmetric group of degree 3 and order 6 in
-  symmetric group of degree 4 and order 24
+  symmetric group of degree 3 in
+  symmetric group of degree 4
 
 julia> collect(T)
 4-element Vector{PermGroupElem}:
@@ -595,19 +595,19 @@ Use [`left_cosets`](@ref) to compute the G-set of left cosets.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(4)
-Symmetric group of degree 4 and order 24 with 2 generators
+Symmetric group of degree 4 with 2 generators
   (1,2,3,4)
   (1,2)
 
 julia> H = symmetric_group(3)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
 julia> T = left_transversal(G, H)
 Left transversal of length 4 of
-  symmetric group of degree 3 and order 6 in
-  symmetric group of degree 4 and order 24
+  symmetric group of degree 3 in
+  symmetric group of degree 4
 
 julia> collect(T)
 4-element Vector{PermGroupElem}:
@@ -707,7 +707,7 @@ Return the double coset `HxK`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Symmetric group of degree 5 and order 120 with 2 generators
+Symmetric group of degree 5 with 2 generators
   (1,2,3,4,5)
   (1,2)
 
@@ -715,19 +715,19 @@ julia> g = perm(G,[3,4,5,1,2])
 (1,3,5,2,4)
 
 julia> H = symmetric_group(3)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
 julia> K = symmetric_group(2)
-Symmetric group of degree 2 and order 2 with 1 generator
+Symmetric group of degree 2 with 1 generator
   (1,2)
 
 julia> double_coset(H,g,K)
-Double coset of symmetric group of degree 3 and order 6
-  and symmetric group of degree 2 and order 2
+Double coset of symmetric group of degree 3
+  and symmetric group of degree 2
   with representative (1,3,5,2,4)
-  in symmetric group of degree 5 and order 120
+  in symmetric group of degree 5
 ```
 """
 function double_coset(G::GAPGroup, g::GAPGroupElem, H::GAPGroup)
@@ -748,17 +748,17 @@ If `check == false`, do not check whether `H` and `K` are subgroups of `G`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(4)
-Symmetric group of degree 4 and order 24 with 2 generators
+Symmetric group of degree 4 with 2 generators
   (1,2,3,4)
   (1,2)
 
 julia> H = symmetric_group(3)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
 julia> K = symmetric_group(2)
-Symmetric group of degree 2 and order 2 with 1 generator
+Symmetric group of degree 2 with 1 generator
   (1,2)
 
 julia> double_cosets(G,H,K)
@@ -828,17 +828,17 @@ That is, `C` is a double coset of two subgroups of `G` in `G`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Symmetric group of degree 5 and order 120 with 2 generators
+Symmetric group of degree 5 with 2 generators
   (1,2,3,4,5)
   (1,2)
 
 julia> H = symmetric_group(3); K = symmetric_group(2);
 
 julia> HgK = double_coset(H, gen(G, 1), K)
-Double coset of symmetric group of degree 3 and order 6
-  and symmetric group of degree 2 and order 2
+Double coset of symmetric group of degree 3
+  and symmetric group of degree 2
   with representative (1,2,3,4,5)
-  in symmetric group of degree 5 and order 120
+  in symmetric group of degree 5
 
 julia> group(HgK) == G
 true
@@ -854,17 +854,17 @@ Return an element `x` of the double coset `C` = `HxK`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Symmetric group of degree 5 and order 120 with 2 generators
+Symmetric group of degree 5 with 2 generators
   (1,2,3,4,5)
   (1,2)
 
 julia> H = symmetric_group(3); K = symmetric_group(2);
 
 julia> HgK = double_coset(H, gen(G, 1), K)
-Double coset of symmetric group of degree 3 and order 6
-  and symmetric group of degree 2 and order 2
+Double coset of symmetric group of degree 3
+  and symmetric group of degree 2
   with representative (1,2,3,4,5)
-  in symmetric group of degree 5 and order 120
+  in symmetric group of degree 5
 
 julia> representative(HgK)
 (1,2,3,4,5)
@@ -880,17 +880,17 @@ Return `H` if `C` = `HxK`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Symmetric group of degree 5 and order 120 with 2 generators
+Symmetric group of degree 5 with 2 generators
   (1,2,3,4,5)
   (1,2)
 
 julia> H = symmetric_group(3); K = symmetric_group(2);
 
 julia> HgK = double_coset(H, gen(G, 1), K)
-Double coset of symmetric group of degree 3 and order 6
-  and symmetric group of degree 2 and order 2
+Double coset of symmetric group of degree 3
+  and symmetric group of degree 2
   with representative (1,2,3,4,5)
-  in symmetric group of degree 5 and order 120
+  in symmetric group of degree 5
 
 julia> left_acting_group(HgK) == H
 true
@@ -906,17 +906,17 @@ Return `K` if `C` = `HxK`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Symmetric group of degree 5 and order 120 with 2 generators
+Symmetric group of degree 5 with 2 generators
   (1,2,3,4,5)
   (1,2)
 
 julia> H = symmetric_group(3); K = symmetric_group(2);
 
 julia> HgK = double_coset(H, gen(G, 1), K)
-Double coset of symmetric group of degree 3 and order 6
-  and symmetric group of degree 2 and order 2
+Double coset of symmetric group of degree 3
+  and symmetric group of degree 2
   with representative (1,2,3,4,5)
-  in symmetric group of degree 5 and order 120
+  in symmetric group of degree 5
 
 julia> right_acting_group(HgK) == K
 true

--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -17,15 +17,18 @@ vectors of the embeddings (resp. projections) of the direct product `G`.
 # Examples
 ```jldoctest
 julia> H = symmetric_group(3)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> K = symmetric_group(2)
-Sym(2)
+Symmetric group of degree 2 and order 2 with 1 generator
+  (1,2)
 
 julia> G = direct_product(H,K)
 Direct product of
- Sym(3)
- Sym(2)
+  Symmetric group of degree 3 and order 6
+  Symmetric group of degree 2 and order 2
 
 julia> collect(G)
 12-element Vector{Oscar.BasicGAPGroupElem{DirectProductGroup}}:
@@ -162,22 +165,23 @@ It is not defined for proper subgroups of direct products.
 # Examples
 ```jldoctest
 julia> H = symmetric_group(3)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> K = symmetric_group(2)
-Sym(2)
+Symmetric group of degree 2 and order 2 with 1 generator
+  (1,2)
 
 julia> G = direct_product(H, K)
 Direct product of
- Sym(3)
- Sym(2)
+  Symmetric group of degree 3 and order 6
+  Symmetric group of degree 2 and order 2
 
 julia> inj1 = canonical_injection(G, 1)
 Group homomorphism
-  from Sym(3)
-  to direct product of
-   Sym(3)
-   Sym(2)
+  from symmetric group of degree 3 and order 6
+  to H x K
 
 julia> h = perm(H, [2,3,1])
 (1,2,3)
@@ -187,10 +191,8 @@ julia> inj1(h)
 
 julia> inj2 = canonical_injection(G, 2)
 Group homomorphism
-  from Sym(2)
-  to direct product of
-   Sym(3)
-   Sym(2)
+  from symmetric group of degree 2 and order 2
+  to H x K
 
 julia> k = perm(K, [2,1])
 (1,2)
@@ -228,29 +230,28 @@ Return the projection of `G` into the `j`-th component of `G`, for `j` = 1,...,#
 # Examples
 ```jldoctest
 julia> H = symmetric_group(3)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> K = symmetric_group(2)
-Sym(2)
+Symmetric group of degree 2 and order 2 with 1 generator
+  (1,2)
 
 julia> G = direct_product(H, K)
 Direct product of
- Sym(3)
- Sym(2)
+  Symmetric group of degree 3 and order 6
+  Symmetric group of degree 2 and order 2
 
 julia> proj1 = canonical_projection(G, 1)
 Group homomorphism
-  from direct product of
-   Sym(3)
-   Sym(2)
-  to Sym(3)
+  from H x K
+  to symmetric group of degree 3 and order 6
 
 julia> proj2 = canonical_projection(G, 2)
 Group homomorphism
-  from direct product of
-   Sym(3)
-   Sym(2)
-  to Sym(2)
+  from H x K
+  to symmetric group of degree 2 and order 2
 
 julia> g = perm([2,3,1,5,4])
 (1,2,3)(4,5)
@@ -377,13 +378,19 @@ where `f` is a group homomorphism from `H` to the automorphism group of `N`.
 # Examples
 ```jldoctest
 julia> Q = quaternion_group(8)
-Pc group of order 8
+Pc group of order 8 with 3 generators x, y, y2
 
 julia> C = cyclic_group(2)
-Pc group of order 2
+Pc group of order 2 with 1 generator f1
 
 julia> A = automorphism_group(Q)
-Aut( <pc group of size 8 with 3 generators> )
+Automorphism group of
+  pc group of order 8
+with 4 generators
+  Pcgs([ x, y, y2 ]) -> [ x*y, y, y2 ]
+  Pcgs([ x, y, y2 ]) -> [ y, x*y, y2 ]
+  Pcgs([ x, y, y2 ]) -> [ x*y2, y, y2 ]
+  Pcgs([ x, y, y2 ]) -> [ x, y*y2, y2 ]
 
 julia> au = A(hom(Q,Q,[Q[1],Q[2]],[Q[1]^3,Q[2]^3]))
 [ x, y ] -> [ x*y2, y*y2 ]
@@ -391,13 +398,16 @@ julia> au = A(hom(Q,Q,[Q[1],Q[2]],[Q[1]^3,Q[2]^3]))
 julia> f = hom(C,A,[C[1]],[au])
 Group homomorphism
   from pc group of order 2
-  to aut( <pc group of size 8 with 3 generators> )
+  to automorphism group of
+    pc group of order 8
 
 julia> G = semidirect_product(Q,f,C)
-SemidirectProduct( <pc group of size 8 with 3 generators> , <pc group of size 2 with 1 generator> )
+Semidirect product of
+  pc group of order 8
+  pc group of order 2
 
 julia> derived_subgroup(G)
-(Group([ f4 ]), Hom: group([ f4 ]) -> semidirectProduct( <pc group of size 8 with 3 generators> , <pc group of size 2 with 1 generator> ))
+(Subgroup of Q : C, Hom: subgroup of semidirect product of groups -> semidirect product of groups)
 ```
 """
 function semidirect_product(
@@ -544,13 +554,16 @@ W(g_1,...,g_n, h).
 # Examples
 ```jldoctest
 julia> G = cyclic_group(3)
-Pc group of order 3
+Pc group of order 3 with 1 generator f1
 
 julia> H = symmetric_group(2)
-Sym(2)
+Symmetric group of degree 2 and order 2 with 1 generator
+  (1,2)
 
 julia> W = wreath_product(G,H)
-<group of size 18 with 2 generators>
+Wreath product of
+  pc group of order 3
+  symmetric group of degree 2 and order 2
 
 julia> a = gen(W,1)
 WreathProductElement(f1,<identity> of ...,())
@@ -607,16 +620,19 @@ Return `G`, where `W` is the wreath product of `G` and `H`.
 # Examples
 ```jldoctest
 julia> G = cyclic_group(3)
-Pc group of order 3
+Pc group of order 3 with 1 generator f1
 
 julia> H = symmetric_group(2)
-Sym(2)
+Symmetric group of degree 2 and order 2 with 1 generator
+  (1,2)
 
 julia> W = wreath_product(G,H)
-<group of size 18 with 2 generators>
+Wreath product of
+  pc group of order 3
+  symmetric group of degree 2 and order 2
 
 julia> normal_subgroup(W)
-Pc group of order 3
+Pc group of order 3 with 1 generator f1
 ```
 """
 normal_subgroup(W::WreathProductGroup) = W.G
@@ -629,16 +645,20 @@ Return `H`, where `W` is the wreath product of `G` and `H`.
 # Examples
 ```jldoctest
 julia> G = cyclic_group(3)
-Pc group of order 3
+Pc group of order 3 with 1 generator f1
 
 julia> H = symmetric_group(2)
-Sym(2)
+Symmetric group of degree 2 and order 2 with 1 generator
+  (1,2)
 
 julia> W = wreath_product(G,H)
-<group of size 18 with 2 generators>
+Wreath product of
+  pc group of order 3
+  symmetric group of degree 2 and order 2
 
 julia> acting_subgroup(W)
-Sym(2)
+Symmetric group of degree 2 and order 2 with 1 generator
+  (1,2)
 ```
 """
 acting_subgroup(W::WreathProductGroup) = W.H

--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -27,7 +27,7 @@ Direct product of
  Sym(3)
  Sym(2)
 
-julia> elements(G)
+julia> collect(G)
 12-element Vector{Oscar.BasicGAPGroupElem{DirectProductGroup}}:
  ()
  (4,5)
@@ -297,19 +297,36 @@ function _as_subgroup_bare(G::DirectProductGroup, H::GapObj)
   return DirectProductGroup(H, G.L, GapObj(G), false)
 end
 
+function Base.show(io::IO, ::MIME"text/plain", G::DirectProductGroup)
+  @show_name(io, G)
+  @show_special(io, G)
+
+  io = pretty(io)
+  if !G.isfull
+    print(io, "Subgroup of ", Lowercase())
+  end
+  println(io, "Direct product of", Indent())
+  join(io, G.L, "\n")
+  print(io, Dedent())
+
+  # We could show generators but it seems less useful for direct products
+#  has_gens(G) || return
+#  _print_generators(io, G)
+end
+
 function Base.show(io::IO, G::DirectProductGroup)
   io = pretty(io)
   if !G.isfull
     print(io, "Subgroup of ", Lowercase())
   end
-  if all(x -> !isnothing(AbstractAlgebra.PrettyPrinting.get_name(x)), G.L)
-    join(io, G.L, " x ")
+  if is_terse(io)
+    print(io, "Direct product of groups")
   else
-    print(io, "Direct product of", Indent())
-    for x in G.L
-      print(io, "\n", x)
+    io = terse(io)
+    for (i,x) in enumerate(G.L)
+      i > 1 && print(io, " x ")
+      print(io, Lowercase(), x)
     end
-    print(io, Dedent())
   end
 end
 
@@ -467,18 +484,36 @@ function _as_subgroup_bare(G::SemidirectProductGroup{S,T}, H::GapObj) where {S,T
   return SemidirectProductGroup{S,T}(H, G.N, G.H, G.f, GapObj(G), false)
 end
 
-function Base.show(io::IO, x::SemidirectProductGroup)
+function Base.show(io::IO, ::MIME"text/plain", G::SemidirectProductGroup)
+  @show_name(io, G)
+  @show_special(io, G)
+
   io = pretty(io)
-  if !x.isfull
+  if !G.isfull
     print(io, "Subgroup of ", Lowercase())
   end
-  #print(io, String(GAPWrap.StringViewObj(GapObj(x))))
-  print(io, "Semidirect product")
-  if !get(io, :supercompact, false)
-    println(io, " ", Indent())
-    print(io, Lowercase(), x.N)
+  println(io, "Semidirect product of", Indent())
+  println(io, Lowercase(), G.N)
+  print(io, Lowercase(), G.H)
+  print(io, Dedent())
+
+  # We could show generators but it seems less useful for direct products
+#  has_gens(G) || return
+#  _print_generators(io, G)
+end
+
+function Base.show(io::IO, G::SemidirectProductGroup)
+  io = pretty(io)
+  if !G.isfull
+    print(io, "Subgroup of ", Lowercase())
+  end
+  if is_terse(io)
+    print(io, "Semidirect product of groups")
+  else
+    io = terse(io)
+    print(io, Lowercase(), G.N)
     print(io, is_unicode_allowed() ? " ⋊ " : " : ")
-    print(io, Lowercase(), x.H)
+    print(io, Lowercase(), G.H)
   end
 end
 
@@ -663,16 +698,36 @@ function canonical_injections(W::WreathProductGroup)
   return [canonical_injection(W, n) for n in 1:GAP.Globals.NrMovedPoints(GAPWrap.Image(W.a.map)) + 1]
 end
 
-function Base.show(io::IO, x::WreathProductGroup)
-  #print(io, String(GAPWrap.StringViewObj(x.X)))
-  if get(io, :supercompact, false)
-    print(io, "Wreath product group")
+function Base.show(io::IO, ::MIME"text/plain", G::WreathProductGroup)
+  @show_name(io, G)
+  @show_special(io, G)
+
+  io = pretty(io)
+  if !G.isfull
+    print(io, "Subgroup of ", Lowercase())
+  end
+  println(io, "Wreath product of", Indent())
+  println(io, Lowercase(), G.G)
+  print(io, Lowercase(), G.H)
+  print(io, Dedent())
+
+  # We could show generators but it seems less useful for direct products
+#  has_gens(G) || return
+#  _print_generators(io, G)
+end
+
+function Base.show(io::IO, G::WreathProductGroup)
+  io = pretty(io)
+  if !G.isfull
+    print(io, "Subgroup of ", Lowercase())
+  end
+  if is_terse(io)
+    print(io, "Wreath product of groups")
   else
-    io = pretty(io)
-    println(io, "Wreath product of", Indent())
-    print(io, Lowercase(), x.G)
+    io = terse(io)
+    print(io, Lowercase(), G.G)
     print(io, is_unicode_allowed() ? " ≀ " : " wr ")
-    print(io, Lowercase(), x.H)
+    print(io, Lowercase(), G.H)
   end
 end
 

--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -17,18 +17,18 @@ vectors of the embeddings (resp. projections) of the direct product `G`.
 # Examples
 ```jldoctest
 julia> H = symmetric_group(3)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
 julia> K = symmetric_group(2)
-Symmetric group of degree 2 and order 2 with 1 generator
+Symmetric group of degree 2 with 1 generator
   (1,2)
 
 julia> G = direct_product(H,K)
 Direct product of
-  Symmetric group of degree 3 and order 6
-  Symmetric group of degree 2 and order 2
+  Symmetric group of degree 3
+  Symmetric group of degree 2
 
 julia> collect(G)
 12-element Vector{Oscar.BasicGAPGroupElem{DirectProductGroup}}:
@@ -165,22 +165,22 @@ It is not defined for proper subgroups of direct products.
 # Examples
 ```jldoctest
 julia> H = symmetric_group(3)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
 julia> K = symmetric_group(2)
-Symmetric group of degree 2 and order 2 with 1 generator
+Symmetric group of degree 2 with 1 generator
   (1,2)
 
 julia> G = direct_product(H, K)
 Direct product of
-  Symmetric group of degree 3 and order 6
-  Symmetric group of degree 2 and order 2
+  Symmetric group of degree 3
+  Symmetric group of degree 2
 
 julia> inj1 = canonical_injection(G, 1)
 Group homomorphism
-  from symmetric group of degree 3 and order 6
+  from symmetric group of degree 3
   to H x K
 
 julia> h = perm(H, [2,3,1])
@@ -191,7 +191,7 @@ julia> inj1(h)
 
 julia> inj2 = canonical_injection(G, 2)
 Group homomorphism
-  from symmetric group of degree 2 and order 2
+  from symmetric group of degree 2
   to H x K
 
 julia> k = perm(K, [2,1])
@@ -230,28 +230,28 @@ Return the projection of `G` into the `j`-th component of `G`, for `j` = 1,...,#
 # Examples
 ```jldoctest
 julia> H = symmetric_group(3)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
 julia> K = symmetric_group(2)
-Symmetric group of degree 2 and order 2 with 1 generator
+Symmetric group of degree 2 with 1 generator
   (1,2)
 
 julia> G = direct_product(H, K)
 Direct product of
-  Symmetric group of degree 3 and order 6
-  Symmetric group of degree 2 and order 2
+  Symmetric group of degree 3
+  Symmetric group of degree 2
 
 julia> proj1 = canonical_projection(G, 1)
 Group homomorphism
   from H x K
-  to symmetric group of degree 3 and order 6
+  to symmetric group of degree 3
 
 julia> proj2 = canonical_projection(G, 2)
 Group homomorphism
   from H x K
-  to symmetric group of degree 2 and order 2
+  to symmetric group of degree 2
 
 julia> g = perm([2,3,1,5,4])
 (1,2,3)(4,5)
@@ -557,13 +557,13 @@ julia> G = cyclic_group(3)
 Pc group of order 3 with 1 generator f1
 
 julia> H = symmetric_group(2)
-Symmetric group of degree 2 and order 2 with 1 generator
+Symmetric group of degree 2 with 1 generator
   (1,2)
 
 julia> W = wreath_product(G,H)
 Wreath product of
   pc group of order 3
-  symmetric group of degree 2 and order 2
+  symmetric group of degree 2
 
 julia> a = gen(W,1)
 WreathProductElement(f1,<identity> of ...,())
@@ -623,13 +623,13 @@ julia> G = cyclic_group(3)
 Pc group of order 3 with 1 generator f1
 
 julia> H = symmetric_group(2)
-Symmetric group of degree 2 and order 2 with 1 generator
+Symmetric group of degree 2 with 1 generator
   (1,2)
 
 julia> W = wreath_product(G,H)
 Wreath product of
   pc group of order 3
-  symmetric group of degree 2 and order 2
+  symmetric group of degree 2
 
 julia> normal_subgroup(W)
 Pc group of order 3 with 1 generator f1
@@ -648,16 +648,16 @@ julia> G = cyclic_group(3)
 Pc group of order 3 with 1 generator f1
 
 julia> H = symmetric_group(2)
-Symmetric group of degree 2 and order 2 with 1 generator
+Symmetric group of degree 2 with 1 generator
   (1,2)
 
 julia> W = wreath_product(G,H)
 Wreath product of
   pc group of order 3
-  symmetric group of degree 2 and order 2
+  symmetric group of degree 2
 
 julia> acting_subgroup(W)
-Symmetric group of degree 2 and order 2 with 1 generator
+Symmetric group of degree 2 with 1 generator
   (1,2)
 ```
 """

--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -298,13 +298,18 @@ function _as_subgroup_bare(G::DirectProductGroup, H::GapObj)
 end
 
 function Base.show(io::IO, G::DirectProductGroup)
-  if G.isfull
-    print(io, "Direct product of")
-    for x in G.L
-      print(io, "\n ", x)
-    end
+  io = pretty(io)
+  if !G.isfull
+    print(io, "Subgroup of ", Lowercase())
+  end
+  if all(x -> !isnothing(AbstractAlgebra.PrettyPrinting.get_name(x)), G.L)
+    join(io, G.L, " x ")
   else
-    print(io, String(GAPWrap.StringViewObj(GapObj(G))))
+    print(io, "Direct product of", Indent())
+    for x in G.L
+      print(io, "\n", x)
+    end
+    print(io, Dedent())
   end
 end
 
@@ -463,17 +468,17 @@ function _as_subgroup_bare(G::SemidirectProductGroup{S,T}, H::GapObj) where {S,T
 end
 
 function Base.show(io::IO, x::SemidirectProductGroup)
-  if x.isfull
-    print(
-      io,
-      "SemidirectProduct( ",
-      String(GAPWrap.StringViewObj(GapObj(x.N))),
-      " , ",
-      String(GAPWrap.StringViewObj(GapObj(x.H))),
-      " )",
-    )
-  else
-    print(io, String(GAPWrap.StringViewObj(GapObj(x))))
+  io = pretty(io)
+  if !x.isfull
+    print(io, "Subgroup of ", Lowercase())
+  end
+  #print(io, String(GAPWrap.StringViewObj(GapObj(x))))
+  print(io, "Semidirect product")
+  if !get(io, :supercompact, false)
+    println(io, " ", Indent())
+    print(io, Lowercase(), x.N)
+    print(io, is_unicode_allowed() ? " ⋊ " : " : ")
+    print(io, Lowercase(), x.H)
   end
 end
 
@@ -658,7 +663,18 @@ function canonical_injections(W::WreathProductGroup)
   return [canonical_injection(W, n) for n in 1:GAP.Globals.NrMovedPoints(GAPWrap.Image(W.a.map)) + 1]
 end
 
-Base.show(io::IO, x::WreathProductGroup) = print(io, String(GAPWrap.StringViewObj(GapObj(x))))
+function Base.show(io::IO, x::WreathProductGroup)
+  #print(io, String(GAPWrap.StringViewObj(x.X)))
+  if get(io, :supercompact, false)
+    print(io, "Wreath product group")
+  else
+    io = pretty(io)
+    println(io, "Wreath product of", Indent())
+    print(io, Lowercase(), x.G)
+    print(io, is_unicode_allowed() ? " ≀ " : " wr ")
+    print(io, Lowercase(), x.H)
+  end
+end
 
 #TODO : to be fixed
 function _as_subgroup_bare(W::WreathProductGroup, X::GapObj)

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -275,7 +275,7 @@ then `nothing` is returned.
 julia> Oscar.with_unicode() do
          show(stdout, MIME("text/plain"), character_table(symmetric_group(3)))
        end;
-Character table of Sym(3)
+Character table of symmetric group of degree 3 and order 6
 
  2  1  1  .
  3  1  .  1
@@ -291,7 +291,7 @@ Character table of Sym(3)
 julia> Oscar.with_unicode() do
          show(stdout, MIME("text/plain"), character_table(symmetric_group(3), 2))
        end;
-2-modular Brauer table of Sym(3)
+2-modular Brauer table of symmetric group of degree 3 and order 6
 
  2  1  .
  3  1  1
@@ -2737,7 +2737,9 @@ The result is an instance of `Vector{T}`.
 # Examples
 ```jldoctest
 julia> g = symmetric_group(4)
-Sym(4)
+Symmetric group of degree 4 and order 24 with 2 generators
+  (1,2,3,4)
+  (1,2)
 
 julia> chi = natural_character(g);
 
@@ -3408,7 +3410,7 @@ julia> phi[1], n, m
 (3, 2, 3)
 
 julia> G = quaternion_group(8)
-Pc group of order 8
+Pc group of order 8 with 3 generators x, y, y2
 
 julia> t = character_table(G);
 

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -275,7 +275,7 @@ then `nothing` is returned.
 julia> Oscar.with_unicode() do
          show(stdout, MIME("text/plain"), character_table(symmetric_group(3)))
        end;
-Character table of symmetric group of degree 3 and order 6
+Character table of symmetric group of degree 3
 
  2  1  1  .
  3  1  .  1
@@ -291,7 +291,7 @@ Character table of symmetric group of degree 3 and order 6
 julia> Oscar.with_unicode() do
          show(stdout, MIME("text/plain"), character_table(symmetric_group(3), 2))
        end;
-2-modular Brauer table of symmetric group of degree 3 and order 6
+2-modular Brauer table of symmetric group of degree 3
 
  2  1  .
  3  1  1
@@ -2737,7 +2737,7 @@ The result is an instance of `Vector{T}`.
 # Examples
 ```jldoctest
 julia> g = symmetric_group(4)
-Symmetric group of degree 4 and order 24 with 2 generators
+Symmetric group of degree 4 with 2 generators
   (1,2,3,4)
   (1,2)
 

--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -28,7 +28,7 @@ Return the full symmetric group on the set `{1, 2, ..., n}`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Symmetric group of degree 5 and order 120 with 2 generators
+Symmetric group of degree 5 with 2 generators
   (1,2,3,4,5)
   (1,2)
 
@@ -76,7 +76,7 @@ Return the full alternating group on the set `{1, 2, ..., n}`..
 # Examples
 ```jldoctest
 julia> G = alternating_group(5)
-Alternating group of degree 5 and order 60 with 2 generators
+Alternating group of degree 5 with 2 generators
   (1,2,3,4,5)
   (3,4,5)
 

--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -28,7 +28,9 @@ Return the full symmetric group on the set `{1, 2, ..., n}`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(5)
-Sym(5)
+Symmetric group of degree 5 and order 120 with 2 generators
+  (1,2,3,4,5)
+  (1,2)
 
 julia> order(G)
 120
@@ -74,7 +76,9 @@ Return the full alternating group on the set `{1, 2, ..., n}`..
 # Examples
 ```jldoctest
 julia> G = alternating_group(5)
-Alt(5)
+Alternating group of degree 5 and order 60 with 2 generators
+  (1,2,3,4,5)
+  (3,4,5)
 
 julia> order(G)
 60
@@ -111,13 +115,14 @@ Return the cyclic group of order `n`, as an instance of type `T`.
 # Examples
 ```jldoctest
 julia> G = cyclic_group(5)
-Pc group of order 5
+Pc group of order 5 with 1 generator f1
 
 julia> G = cyclic_group(PermGroup, 5)
-Permutation group of degree 5 and order 5
+Permutation group of degree 5 and order 5 with 1 generator
+  (1,2,3,4,5)
 
 julia> G = cyclic_group(PosInf())
-Pc group of infinite order
+Pc group of infinite order with 1 generator g1
 
 ```
 """
@@ -155,7 +160,9 @@ and throw an error otherwise.
 # Examples
 ```jldoctest
 julia> g = permutation_group(5, [cperm(1:3), cperm(4:5)])
-Permutation group of degree 5
+Permutation group of degree 5 with 2 generators
+  (1,2,3)
+  (4,5)
 
 julia> cyclic_generator(g)
 (1,2,3)(4,5)
@@ -244,10 +251,13 @@ The `gens` vector of the result has minimal length.
 # Examples
 ```jldoctest
 julia> g = elementary_abelian_group(27)
-Pc group of order 27
+Pc group of order 27 with 3 generators f1, f2, f3
 
 julia> g = elementary_abelian_group(PermGroup, 27)
-Permutation group of degree 9 and order 27
+Permutation group of degree 9 and order 27 with 3 generators
+  (1,2,3)
+  (4,5,6)
+  (7,8,9)
 ```
 """
 elementary_abelian_group(n::IntegerUnion) = elementary_abelian_group(PcGroup, n)
@@ -320,7 +330,9 @@ The group is represented as a permutation group.
 # Examples
 ```jldoctest
 julia> g = projective_general_linear_group(2, 3)
-Permutation group of degree 4 and order 24
+Permutation group of degree 4 and order 24 with 2 generators
+  (3,4)
+  (1,2,4)
 
 julia> order(g)
 24
@@ -343,7 +355,9 @@ The group is represented as a permutation group.
 # Examples
 ```jldoctest
 julia> g = projective_special_linear_group(2, 3)
-Permutation group of degree 4 and order 12
+Permutation group of degree 4 and order 12 with 2 generators
+  (2,3,4)
+  (1,2)(3,4)
 
 julia> order(g)
 12
@@ -366,7 +380,9 @@ The group is represented as a permutation group.
 # Examples
 ```jldoctest
 julia> g = projective_symplectic_group(2, 3)
-Permutation group of degree 4 and order 12
+Permutation group of degree 4 and order 12 with 2 generators
+  (2,3,4)
+  (1,2)(3,4)
 
 julia> order(g)
 12
@@ -390,7 +406,9 @@ The group is represented as a permutation group.
 # Examples
 ```jldoctest
 julia> g = projective_unitary_group(2, 3)
-Permutation group of degree 10 and order 24
+Permutation group of degree 10 and order 24 with 2 generators
+  (3,4)(5,8)(6,9)(7,10)
+  (1,2,6)(3,7,10)(4,8,5)
 
 julia> order(g)
 24
@@ -413,7 +431,9 @@ The group is represented as a permutation group.
 # Examples
 ```jldoctest
 julia> g = projective_special_unitary_group(2, 3)
-Permutation group of degree 10 and order 12
+Permutation group of degree 10 and order 12 with 2 generators
+  (2,9,6)(3,8,10)(4,7,5)
+  (1,2)(5,10)(6,9)(7,8)
 
 julia> order(g)
 12
@@ -575,7 +595,7 @@ representation by a vector of integers is chosen in the default case of
 # Examples
 ```jldoctest
 julia> F = free_group(:a, :b)
-Free group of rank 2
+Free group of rank 2 with 2 generators a, b
 
 julia> w = F[1]^3 * F[2]^F[1] * F[-2]^2
 a^2*b*a*b^-2
@@ -662,7 +682,7 @@ its generators as Julia variables into the current scope.
 # Examples
 ```jldoctest
 julia> F = @free_group(:a, :b)
-Free group of rank 2
+Free group of rank 2 with 2 generators a, b
 
 julia> a^2*b*a*b^-2
 a^2*b*a*b^-2
@@ -772,13 +792,15 @@ where `T` is in {`PcGroup`, `SubPcGroup`, `PermGroup`, `FPGroup`, `SubFPGroup`}.
 # Examples
 ```jldoctest
 julia> dihedral_group(6)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> dihedral_group(PermGroup, 6)
-Permutation group of degree 3
+Permutation group of degree 3 with 2 generators
+  (1,2,3)
+  (2,3)
 
 julia> dihedral_group(PosInf())
-Pc group of infinite order
+Pc group of infinite order with 2 generators g1, g2
 
 julia> dihedral_group(7)
 ERROR: ArgumentError: n must be a positive even integer or infinity
@@ -837,13 +859,18 @@ and `T` is a suitable group type such as
 # Examples
 ```jldoctest
 julia> g = dicyclic_group(8)
-Pc group of order 8
+Pc group of order 8 with 3 generators x, y, y2
 
 julia> dicyclic_group(PermGroup, 8)
-Permutation group of degree 8
+Permutation group of degree 8 with 2 generators
+  (1,5,3,7)(2,8,4,6)
+  (1,2,3,4)(5,6,7,8)
 
 julia> g = dicyclic_group(FPGroup, 8)
-Finitely presented group of order 8
+Finitely presented group of order 8 with 2 generators r, s and with 3 relators
+  r^2*s^-2
+  s^4
+  r^-1*s*r*s
 
 julia> relators(g)
 3-element Vector{FPGroupElem}:
@@ -949,7 +976,7 @@ of order 8 and one quaternion group of order 8 if `p` is 2.
 # Examples
 ```jldoctest
 julia> extraspecial_group(3, 2, :-)
-Pc group of order 243
+Pc group of order 243 with 5 generators f1, f2, f3, f4, f5
 
 julia> describe(extraspecial_group(2, 1, :+))
 "D8"

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -882,8 +882,8 @@ julia> Omega = gset(G, [Set([1, 2])]);  # action on unordered pairs
 
 julia> acthom = action_homomorphism(Omega)
 Group homomorphism
-  from symmetric group of degree 6 and order 720
-  to symmetric group of degree 15 and order 1307674368000
+  from symmetric group of degree 6
+  to symmetric group of degree 15
 
 julia> g = gen(G, 1)
 (1,2,3,4,5,6)

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -440,7 +440,11 @@ Return the G-set that consists of the elements `fun(omega, g)` where
 # Examples
 ```jldoctest
 julia> G = sylow_subgroup(symmetric_group(6), 2)[1]
-Permutation group of degree 6 and order 16
+Permutation group of degree 6 and order 16 with 4 generators
+  (1,2)
+  (3,4)
+  (1,3)(2,4)
+  (5,6)
 
 julia> Omega = gset(G, [1, 5]);
 
@@ -539,7 +543,11 @@ Return the vector of transitive G-sets in `Omega`.
 # Examples
 ```jldoctest
 julia> G = sylow_subgroup(symmetric_group(6), 2)[1]
-Permutation group of degree 6 and order 16
+Permutation group of degree 6 and order 16 with 4 generators
+  (1,2)
+  (3,4)
+  (1,3)(2,4)
+  (5,6)
 
 julia> orbs = orbits(natural_gset(G));
 
@@ -568,7 +576,11 @@ Return the orbits of the natural G-set of `G`.
 # Examples
 ```jldoctest
 julia> G = sylow_subgroup(symmetric_group(6), 2)[1]
-Permutation group of degree 6 and order 16
+Permutation group of degree 6 and order 16 with 4 generators
+  (1,2)
+  (3,4)
+  (1,3)(2,4)
+  (5,6)
 
 julia> orbs = orbits(G);
 
@@ -870,8 +882,8 @@ julia> Omega = gset(G, [Set([1, 2])]);  # action on unordered pairs
 
 julia> acthom = action_homomorphism(Omega)
 Group homomorphism
-  from Sym(6)
-  to Sym(15)
+  from symmetric group of degree 6 and order 720
+  to symmetric group of degree 15 and order 1307674368000
 
 julia> g = gen(G, 1)
 (1,2,3,4,5,6)
@@ -938,7 +950,11 @@ To also obtain a conjugating element use [`is_conjugate_with_data`](@ref).
 # Examples
 ```jldoctest
 julia> G = sylow_subgroup(symmetric_group(6), 2)[1]
-Permutation group of degree 6 and order 16
+Permutation group of degree 6 and order 16 with 4 generators
+  (1,2)
+  (3,4)
+  (1,3)(2,4)
+  (5,6)
 
 julia> Omega = natural_gset(G);
 
@@ -964,7 +980,11 @@ If the conjugating element `g` is not needed, use [`is_conjugate`](@ref).
 # Examples
 ```jldoctest
 julia> G = sylow_subgroup(symmetric_group(6), 2)[1]
-Permutation group of degree 6 and order 16
+Permutation group of degree 6 and order 16 with 4 generators
+  (1,2)
+  (3,4)
+  (1,3)(2,4)
+  (5,6)
 
 julia> Omega = natural_gset(G);
 
@@ -1209,7 +1229,11 @@ In other word, this tests if `Omega` consists of precisely one orbit.
 # Examples
 ```jldoctest
 julia> G = sylow_subgroup(symmetric_group(6), 2)[1]
-Permutation group of degree 6 and order 16
+Permutation group of degree 6 and order 16 with 4 generators
+  (1,2)
+  (3,4)
+  (1,3)(2,4)
+  (5,6)
 
 julia> Omega = natural_gset(G);
 
@@ -1236,7 +1260,8 @@ is regular, i.e., is transitive and semiregular.
 julia> G = symmetric_group(6);
 
 julia> H = sub(G, [G([2, 3, 4, 5, 6, 1])])[1]
-Permutation group of degree 6
+Permutation group of degree 6 with 1 generator
+  (1,2,3,4,5,6)
 
 julia> OmegaG = natural_gset(G);
 
@@ -1262,7 +1287,8 @@ is semiregular, i.e., the stabilizer of each point is the identity.
 julia> G = symmetric_group(6);
 
 julia> H = sub(G, [G([2, 3, 1, 5, 6, 4])])[1]
-Permutation group of degree 6
+Permutation group of degree 6 with 1 generator
+  (1,2,3)(4,5,6)
 
 julia> OmegaH = natural_gset(H);
 
@@ -1317,7 +1343,10 @@ An exception is thrown if this action is not transitive.
 # Examples
 ```jldoctest
 julia> g = sylow_subgroup(symmetric_group(4), 2)[1]
-Permutation group of degree 4 and order 8
+Permutation group of degree 4 and order 8 with 3 generators
+  (1,2)
+  (3,4)
+  (1,3)(2,4)
 
 julia> collect(blocks(g))
 2-element Vector{Vector{Int64}}:
@@ -1346,7 +1375,9 @@ An exception is thrown if this action is not transitive.
 # Examples
 ```jldoctest
 julia> G = transitive_group(8, 2)
-Permutation group of degree 8
+Permutation group of degree 8 with 2 generators
+  (1,2,3,8)(4,5,6,7)
+  (1,5)(2,6)(3,7)(4,8)
 
 julia> collect(maximal_blocks(G))
 2-element Vector{Vector{Int64}}:
@@ -1376,7 +1407,9 @@ An exception is thrown if this action is not transitive.
 # Examples
 ```jldoctest
 julia> G = transitive_group(8, 2)
-Permutation group of degree 8
+Permutation group of degree 8 with 2 generators
+  (1,2,3,8)(4,5,6,7)
+  (1,5)(2,6)(3,7)(4,8)
 
 julia> minimal_block_reps(G)
 3-element Vector{Vector{Int64}}:
@@ -1400,7 +1433,9 @@ for the action of `G` on the set of moved points of `G`.
 # Examples
 ```jldoctest
 julia> G = transitive_group(8, 2)
-Permutation group of degree 8
+Permutation group of degree 8 with 2 generators
+  (1,2,3,8)(4,5,6,7)
+  (1,5)(2,6)(3,7)(4,8)
 
 julia> all_blocks(G)
 6-element Vector{Vector{Int64}}:
@@ -1433,13 +1468,18 @@ julia> G = symmetric_group(4); rank_action(G)  # 4-transitive
 2
 
 julia> H = sylow_subgroup(G, 2)[1]
-Permutation group of degree 4 and order 8
+Permutation group of degree 4 and order 8 with 3 generators
+  (1,2)
+  (3,4)
+  (1,3)(2,4)
 
 julia> rank_action(H)  # not 2-transitive
 3
 
 julia> K = stabilizer(G, 1)[1]
-Permutation group of degree 4 and order 6
+Permutation group of degree 4 and order 6 with 2 generators
+  (2,3,4)
+  (2,3)
 
 julia> rank_action(K, 2:4)  # 2-transitive
 2
@@ -1559,7 +1599,8 @@ Return whether the action of `G` on `L` is regular
 julia> G = symmetric_group(6);
 
 julia> H = sub(G, [G([2, 3, 4, 5, 6, 1])])[1]
-Permutation group of degree 6
+Permutation group of degree 6 with 1 generator
+  (1,2,3,4,5,6)
 
 julia> is_regular(H)
 true
@@ -1582,7 +1623,8 @@ Return whether the action of `G` on `L` is semiregular
 julia> G = symmetric_group(6);
 
 julia> H = sub(G, [G([2, 3, 1, 5, 6, 4])])[1]
-Permutation group of degree 6
+Permutation group of degree 6 with 1 generator
+  (1,2,3)(4,5,6)
 
 julia> is_semiregular(H)
 true

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -515,7 +515,7 @@ Otherwise throw an exception.
 ```jldoctest
 julia> isomorphism(symmetric_group(3), dihedral_group(6))
 Group homomorphism
-  from Sym(3)
+  from symmetric group of degree 3 and order 6
   to pc group of order 6
 ```
 """
@@ -1164,7 +1164,7 @@ can be used instead.
 # Examples
 ```jldoctest
 julia> G = dihedral_group(6)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> iso = isomorphism(PermGroup, G)
 Group homomorphism
@@ -1172,7 +1172,9 @@ Group homomorphism
   to permutation group of degree 3 and order 6
 
 julia> permutation_group(G)
-Permutation group of degree 3 and order 6
+Permutation group of degree 3 and order 6 with 2 generators
+  (2,3)
+  (1,2,3)
 
 julia> codomain(iso) === ans
 true
@@ -1268,13 +1270,14 @@ generators, the number of relators, and the relator lengths.
 # Examples
 ```jldoctest
 julia> F = free_group(3)
-Free group of rank 3
+Free group of rank 3 with 3 generators f1, f2, f3
 
 julia> G = quo(F, [gen(F,1)])[1]
-Finitely presented group of infinite order
+Finitely presented group of infinite order with 3 generators f1, f2, f3 and with 1 relator
+  f1
 
 julia> simplified_fp_group(G)[1]
-Finitely presented group of infinite order
+Finitely presented group of infinite order with 2 generators f2, f3
 ```
 """
 function simplified_fp_group(G::FPGroup)
@@ -1301,13 +1304,19 @@ Groups of automorphisms over a group `G` have parametric type `AutomorphismGroup
 # Examples
 ```jldoctest
 julia> S = symmetric_group(3)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> typeof(S)
 PermGroup
 
 julia> A = automorphism_group(S)
-Aut( Sym( [ 1 .. 3 ] ) )
+Automorphism group of
+  symmetric group of degree 3 and order 6
+with 2 generators
+  Pcgs([ (2,3), (1,2,3) ]) -> [ (2,3), (1,3,2) ]
+  Pcgs([ (2,3), (1,2,3) ]) -> [ (1,2), (1,2,3) ]
 
 julia> typeof(A)
 AutomorphismGroup{PermGroup}
@@ -1318,10 +1327,18 @@ it can be obtained by typing either `f(x)` or `x^f`.
 
 ```jldoctest
 julia> S = symmetric_group(4)
-Sym(4)
+Symmetric group of degree 4 and order 24 with 2 generators
+  (1,2,3,4)
+  (1,2)
 
 julia> A = automorphism_group(S)
-Aut( Sym( [ 1 .. 4 ] ) )
+Automorphism group of
+  symmetric group of degree 4 and order 24
+with 4 generators
+  Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (3,4), (2,3,4), (1,3)(2,4), (1,4)(2,3) ]
+  Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (2,3), (2,4,3), (1,3)(2,4), (1,2)(3,4) ]
+  Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (1,2), (1,4,2), (1,4)(2,3), (1,3)(2,4) ]
+  Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (3,4), (1,3,4), (1,4)(2,3), (1,3)(2,4) ]
 
 julia> x = perm(S,[2,1,4,3])
 (1,2)(3,4)
@@ -1340,10 +1357,18 @@ It is possible to turn an automorphism `f` into a homomorphism by typing `hom(f)
 
 ```jldoctest
 julia> S = symmetric_group(4)
-Sym(4)
+Symmetric group of degree 4 and order 24 with 2 generators
+  (1,2,3,4)
+  (1,2)
 
 julia> A = automorphism_group(S)
-Aut( Sym( [ 1 .. 4 ] ) )
+Automorphism group of
+  symmetric group of degree 4 and order 24
+with 4 generators
+  Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (3,4), (2,3,4), (1,3)(2,4), (1,4)(2,3) ]
+  Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (2,3), (2,4,3), (1,3)(2,4), (1,2)(3,4) ]
+  Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (1,2), (1,4,2), (1,4)(2,3), (1,3)(2,4) ]
+  Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (3,4), (1,3,4), (1,4)(2,3), (1,3)(2,4) ]
 
 julia> f = A[2]
 Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (2,3), (2,4,3), (1,3)(2,4), (1,2)(3,4) ]
@@ -1362,18 +1387,26 @@ automorphisms, is shown in Section [Inner_automorphisms](@ref inner_automorphism
 # Examples
 ```jldoctest
 julia> S = symmetric_group(4)
-Sym(4)
+Symmetric group of degree 4 and order 24 with 2 generators
+  (1,2,3,4)
+  (1,2)
 
 julia> a = perm(S,[2,1,4,3])
 (1,2)(3,4)
 
 julia> f = hom(S,S,x ->x^a)
 Group homomorphism
-  from Sym(4)
-  to Sym(4)
+  from symmetric group of degree 4 and order 24
+  to symmetric group of degree 4 and order 24
 
 julia> A = automorphism_group(S)
-Aut( Sym( [ 1 .. 4 ] ) )
+Automorphism group of
+  symmetric group of degree 4 and order 24
+with 4 generators
+  Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (3,4), (2,3,4), (1,3)(2,4), (1,4)(2,3) ]
+  Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (2,3), (2,4,3), (1,3)(2,4), (1,2)(3,4) ]
+  Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (1,2), (1,4,2), (1,4)(2,3), (1,3)(2,4) ]
+  Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (3,4), (1,3,4), (1,4)(2,3), (1,3)(2,4) ]
 
 julia> A(f)
 MappingByFunction( Sym( [ 1 .. 4 ] ), Sym( [ 1 .. 4 ] ), <Julia: gap_fun> )
@@ -1414,15 +1447,23 @@ true
 In Oscar it is possible to multiply homomorphisms and automorphisms (whenever it makes sense); in such cases, the output is always a variable of type `GAPGroupHomomorphism{S,T}`.
 ```jldoctest
 julia> S = symmetric_group(4)
-Sym(4)
+Symmetric group of degree 4 and order 24 with 2 generators
+  (1,2,3,4)
+  (1,2)
 
 julia> A = automorphism_group(S)
-Aut( Sym( [ 1 .. 4 ] ) )
+Automorphism group of
+  symmetric group of degree 4 and order 24
+with 4 generators
+  Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (3,4), (2,3,4), (1,3)(2,4), (1,4)(2,3) ]
+  Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (2,3), (2,4,3), (1,3)(2,4), (1,2)(3,4) ]
+  Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (1,2), (1,4,2), (1,4)(2,3), (1,3)(2,4) ]
+  Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (3,4), (1,3,4), (1,4)(2,3), (1,3)(2,4) ]
 
 julia> g = hom(S,S,x->x^S[1])
 Group homomorphism
-  from Sym(4)
-  to Sym(4)
+  from symmetric group of degree 4 and order 24
+  to symmetric group of degree 4 and order 24
 
 julia> f = A(g)
 MappingByFunction( Sym( [ 1 .. 4 ] ), Sym( [ 1 .. 4 ] ), <Julia: gap_fun> )

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -1436,8 +1436,14 @@ function automorphism_group(G::GAPGroup)
   return AutomorphismGroup(AutGAP, G)
 end
 
+#function Base.show(io::IO, ::MIME"text/plain", A::AutomorphismGroup{T}) where T <: GAPGroup
+#  io = pretty(io)
+#  println(io, "Automorphism group of", Indent())
+#  print(io, Lowercase(), A.G)
+#end
+
 function Base.show(io::IO, A::AutomorphismGroup{T}) where T <: GAPGroup
-  if get(io, :supercompact, false)
+  if is_terse(io)
     print(io, "Automorphism group")
   else
     io = pretty(io)
@@ -1445,6 +1451,7 @@ function Base.show(io::IO, A::AutomorphismGroup{T}) where T <: GAPGroup
     print(io, Lowercase(), A.G)
   end
 end
+
 
 """
     domain(A::AutomorphismGroup) -> Group

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -1437,7 +1437,13 @@ function automorphism_group(G::GAPGroup)
 end
 
 function Base.show(io::IO, A::AutomorphismGroup{T}) where T <: GAPGroup
-  print(io, "Aut( "* String(GAP.Globals.StringView(GapObj(A.G))) * " )")
+  if get(io, :supercompact, false)
+    print(io, "Automorphism group")
+  else
+    io = pretty(io)
+    println(io, "Automorphism group of", Indent())
+    print(io, Lowercase(), A.G)
+  end
 end
 
 """

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -515,7 +515,7 @@ Otherwise throw an exception.
 ```jldoctest
 julia> isomorphism(symmetric_group(3), dihedral_group(6))
 Group homomorphism
-  from symmetric group of degree 3 and order 6
+  from symmetric group of degree 3
   to pc group of order 6
 ```
 """
@@ -1304,7 +1304,7 @@ Groups of automorphisms over a group `G` have parametric type `AutomorphismGroup
 # Examples
 ```jldoctest
 julia> S = symmetric_group(3)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
@@ -1313,7 +1313,7 @@ PermGroup
 
 julia> A = automorphism_group(S)
 Automorphism group of
-  symmetric group of degree 3 and order 6
+  symmetric group of degree 3
 with 2 generators
   Pcgs([ (2,3), (1,2,3) ]) -> [ (2,3), (1,3,2) ]
   Pcgs([ (2,3), (1,2,3) ]) -> [ (1,2), (1,2,3) ]
@@ -1327,13 +1327,13 @@ it can be obtained by typing either `f(x)` or `x^f`.
 
 ```jldoctest
 julia> S = symmetric_group(4)
-Symmetric group of degree 4 and order 24 with 2 generators
+Symmetric group of degree 4 with 2 generators
   (1,2,3,4)
   (1,2)
 
 julia> A = automorphism_group(S)
 Automorphism group of
-  symmetric group of degree 4 and order 24
+  symmetric group of degree 4
 with 4 generators
   Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (3,4), (2,3,4), (1,3)(2,4), (1,4)(2,3) ]
   Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (2,3), (2,4,3), (1,3)(2,4), (1,2)(3,4) ]
@@ -1357,13 +1357,13 @@ It is possible to turn an automorphism `f` into a homomorphism by typing `hom(f)
 
 ```jldoctest
 julia> S = symmetric_group(4)
-Symmetric group of degree 4 and order 24 with 2 generators
+Symmetric group of degree 4 with 2 generators
   (1,2,3,4)
   (1,2)
 
 julia> A = automorphism_group(S)
 Automorphism group of
-  symmetric group of degree 4 and order 24
+  symmetric group of degree 4
 with 4 generators
   Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (3,4), (2,3,4), (1,3)(2,4), (1,4)(2,3) ]
   Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (2,3), (2,4,3), (1,3)(2,4), (1,2)(3,4) ]
@@ -1387,7 +1387,7 @@ automorphisms, is shown in Section [Inner_automorphisms](@ref inner_automorphism
 # Examples
 ```jldoctest
 julia> S = symmetric_group(4)
-Symmetric group of degree 4 and order 24 with 2 generators
+Symmetric group of degree 4 with 2 generators
   (1,2,3,4)
   (1,2)
 
@@ -1396,12 +1396,12 @@ julia> a = perm(S,[2,1,4,3])
 
 julia> f = hom(S,S,x ->x^a)
 Group homomorphism
-  from symmetric group of degree 4 and order 24
-  to symmetric group of degree 4 and order 24
+  from symmetric group of degree 4
+  to symmetric group of degree 4
 
 julia> A = automorphism_group(S)
 Automorphism group of
-  symmetric group of degree 4 and order 24
+  symmetric group of degree 4
 with 4 generators
   Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (3,4), (2,3,4), (1,3)(2,4), (1,4)(2,3) ]
   Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (2,3), (2,4,3), (1,3)(2,4), (1,2)(3,4) ]
@@ -1447,13 +1447,13 @@ true
 In Oscar it is possible to multiply homomorphisms and automorphisms (whenever it makes sense); in such cases, the output is always a variable of type `GAPGroupHomomorphism{S,T}`.
 ```jldoctest
 julia> S = symmetric_group(4)
-Symmetric group of degree 4 and order 24 with 2 generators
+Symmetric group of degree 4 with 2 generators
   (1,2,3,4)
   (1,2)
 
 julia> A = automorphism_group(S)
 Automorphism group of
-  symmetric group of degree 4 and order 24
+  symmetric group of degree 4
 with 4 generators
   Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (3,4), (2,3,4), (1,3)(2,4), (1,4)(2,3) ]
   Pcgs([ (3,4), (2,4,3), (1,4)(2,3), (1,3)(2,4) ]) -> [ (2,3), (2,4,3), (1,3)(2,4), (1,2)(3,4) ]
@@ -1462,8 +1462,8 @@ with 4 generators
 
 julia> g = hom(S,S,x->x^S[1])
 Group homomorphism
-  from symmetric group of degree 4 and order 24
-  to symmetric group of degree 4 and order 24
+  from symmetric group of degree 4
+  to symmetric group of degree 4
 
 julia> f = A(g)
 MappingByFunction( Sym( [ 1 .. 4 ] ), Sym( [ 1 .. 4 ] ), <Julia: gap_fun> )

--- a/src/Groups/libraries/atlasgroups.jl
+++ b/src/Groups/libraries/atlasgroups.jl
@@ -13,14 +13,28 @@ for `name` is available, and `MatrixGroup` otherwise.
 # Examples
 ```jldoctest
 julia> atlas_group("A5")  # alternating group A5
-Permutation group of degree 5 and order 60
+Permutation group of degree 5 and order 60 with 2 generators
+  (1,2)(3,4)
+  (1,3,5)
 
 julia> atlas_group(MatrixGroup, "A5")
 Matrix group of degree 4
   over prime field of characteristic 2
+with 2 generators
+  [1   0   0   0]
+  [0   0   1   0]
+  [0   1   0   0]
+  [1   1   1   1]
+
+  [0   1   0   0]
+  [0   0   0   1]
+  [0   0   1   0]
+  [1   0   0   0]
 
 julia> atlas_group("M11")  # Mathieu group M11
-Permutation group of degree 11 and order 7920
+Permutation group of degree 11 and order 7920 with 2 generators
+  (2,10)(4,11)(5,7)(8,9)
+  (1,4,3,8)(2,5,6,9)
 
 julia> atlas_group("M")  # Monster group M
 ERROR: ArgumentError: the group atlas does not provide a representation for M
@@ -83,7 +97,9 @@ julia> info = all_atlas_group_infos("A5", degree => 5)
  Dict(:constituents => [1, 4], :repname => "A5G1-p5B0", :degree => 5, :name => "A5")
 
 julia> atlas_group(info[1])
-Permutation group of degree 5 and order 60
+Permutation group of degree 5 and order 60 with 2 generators
+  (1,2)(3,4)
+  (1,3,5)
 
 ```
 """
@@ -137,22 +153,41 @@ thrown.
 julia> g = atlas_group("M11");  # Mathieu group M11
 
 julia> h1, emb = atlas_subgroup(g, 1);  h1
-Permutation group of degree 11 and order 720
+Permutation group of degree 11 and order 720 with 2 generators
+  (1,4)(2,10)(3,7)(6,9)
+  (1,6,10,7,11,3,9,2)(4,5)
 
 julia> order(h1)  # largest maximal subgroup of M11
 720
 
 julia> h2, emb = atlas_subgroup("M11", 1);  h2
-Permutation group of degree 11 and order 720
+Permutation group of degree 11 and order 720 with 2 generators
+  (1,4)(2,10)(3,7)(6,9)
+  (1,6,10,7,11,3,9,2)(4,5)
 
 julia> h3, emb = atlas_subgroup(MatrixGroup, "M11", 1 );  h3
 Matrix group of degree 10
   over prime field of characteristic 2
+with 2 generators
+  [0   1   0   1   0   1   0   0   0   0]
+  [0   0   1   0   0   0   0   0   0   0]
+  [0   1   0   0   0   0   0   0   0   0]
+  [1   1   1   1   1   0   0   0   0   0]
+  [1   1   0   1   1   1   0   0   0   0]
+  [0   1   0   1   1   0   0   0   0   0]
+  [0   0   1   1   1   1   1   0   0   0]
+  [0   0   0   1   1   0   0   1   1   0]
+  [0   0   1   1   1   1   0   0   1   0]
+  [0   0   1   0   0   1   0   0   1   1]
+
+  ⋮
 
 julia> info = all_atlas_group_infos("M11", degree => 11);
 
 julia> h4, emb = atlas_subgroup(info[1], 1);  h4
-Permutation group of degree 11 and order 720
+Permutation group of degree 11 and order 720 with 2 generators
+  (1,4)(2,10)(3,7)(6,9)
+  (1,6,10,7,11,3,9,2)(4,5)
 ```
 """
 function atlas_subgroup(G::GAPGroup, nr::Int)
@@ -221,7 +256,9 @@ julia> info = all_atlas_group_infos("A5", degree => [5, 6])
  Dict(:constituents => [1, 5], :repname => "A5G1-p6B0", :degree => 6, :name => "A5")
 
 julia> atlas_group(info[1])
-Permutation group of degree 5 and order 60
+Permutation group of degree 5 and order 60 with 2 generators
+  (1,2)(3,4)
+  (1,3,5)
 
 julia> info = all_atlas_group_infos("A5", dim => 4, characteristic => 3)
 1-element Vector{Dict{Symbol, Any}}:
@@ -230,6 +267,16 @@ julia> info = all_atlas_group_infos("A5", dim => 4, characteristic => 3)
 julia> atlas_group(info[1])
 Matrix group of degree 4
   over prime field of characteristic 3
+with 2 generators
+  [1   0   0   0]
+  [0   0   1   0]
+  [0   1   0   0]
+  [2   2   2   2]
+
+  [0   1   0   0]
+  [0   0   0   1]
+  [0   0   1   0]
+  [1   0   0   0]
 
 ```
 """

--- a/src/Groups/libraries/perfectgroups.jl
+++ b/src/Groups/libraries/perfectgroups.jl
@@ -98,7 +98,9 @@ The type `T` can be either `PermGroup` or `FPGroup`.
 # Examples
 ```jldoctest
 julia> perfect_group(60, 1)
-Permutation group of degree 5 and order 60
+Permutation group of degree 5 and order 60 with 2 generators
+  (1,2)(4,5)
+  (2,3,4)
 
 julia> gens(ans)
 2-element Vector{PermGroupElem}:
@@ -106,7 +108,10 @@ julia> gens(ans)
  (2,3,4)
 
 julia> perfect_group(FPGroup, 60, 1)
-Finitely presented group of order 60
+Finitely presented group of order 60 with 2 generators a, b and with 3 relators
+  a^2
+  b^3
+  (a*b)^5
 
 julia> gens(ans)
 2-element Vector{FPGroupElem}:

--- a/src/Groups/libraries/primitivegroups.jl
+++ b/src/Groups/libraries/primitivegroups.jl
@@ -200,12 +200,12 @@ The type of the returned groups is `PermGroup`.
 ```jldoctest
 julia> all_primitive_groups(4)
 2-element Vector{PermGroup}:
- Alternating group of degree 4 and order 12
- Symmetric group of degree 4 and order 24
+ Alternating group of degree 4
+ Symmetric group of degree 4
 
 julia> all_primitive_groups(degree => 3:5, is_abelian)
 2-element Vector{PermGroup}:
- Alternating group of degree 3 and order 3
+ Alternating group of degree 3
  Permutation group of degree 5 and order 5
 ```
 """

--- a/src/Groups/libraries/primitivegroups.jl
+++ b/src/Groups/libraries/primitivegroups.jl
@@ -89,7 +89,9 @@ The output is a group of type `PermGroup`.
 # Examples
 ```jldoctest
 julia> primitive_group(10,1)
-Permutation group of degree 10 and order 60
+Permutation group of degree 10 and order 60 with 2 generators
+  (1,5,7)(2,9,4)(3,8,10)
+  (2,6)(3,5)(4,7)(9,10)
 
 julia> primitive_group(10,10)
 ERROR: ArgumentError: there are only 9 primitive permutation groups of degree 10, not 10
@@ -121,7 +123,9 @@ julia> order(primitive_group(m...)) == order(G)
 true
 
 julia> S = stabilizer(G, 1)[1]
-Permutation group of degree 7 and order 720
+Permutation group of degree 7 and order 720 with 2 generators
+  (2,3,4,5,6,7)
+  (2,3)
 
 julia> is_primitive(S)
 false
@@ -196,12 +200,12 @@ The type of the returned groups is `PermGroup`.
 ```jldoctest
 julia> all_primitive_groups(4)
 2-element Vector{PermGroup}:
- Alt(4)
- Sym(4)
+ Alternating group of degree 4 and order 12
+ Symmetric group of degree 4 and order 24
 
 julia> all_primitive_groups(degree => 3:5, is_abelian)
 2-element Vector{PermGroup}:
- Alt(3)
+ Alternating group of degree 3 and order 3
  Permutation group of degree 5 and order 5
 ```
 """

--- a/src/Groups/libraries/smallgroups.jl
+++ b/src/Groups/libraries/smallgroups.jl
@@ -73,13 +73,15 @@ solvable, otherwise it will be of type `PermGroup`.
 # Examples
 ```jldoctest
 julia> small_group(60, 4)
-Pc group of order 60
+Pc group of order 60 with 4 generators f1, f2, f3, f4
 
 julia> small_group(60, 5)
-Permutation group of degree 5 and order 60
+Permutation group of degree 5 and order 60 with 2 generators
+  (1,2,3,4,5)
+  (1,2,3)
 
 julia> small_group(PcGroup, 60, 4)
-Pc group of order 60
+Pc group of order 60 with 4 generators f1, f2, f3, f4
 ```
 """
 function small_group(::Type{T}, n::IntegerUnion, m::IntegerUnion) where T
@@ -188,17 +190,17 @@ List all abelian non-cyclic groups of order 12:
 ```jldoctest
 julia> all_small_groups(12, !is_cyclic, is_abelian)
 1-element Vector{PcGroup}:
- Pc group of order 12
+ Pc group of order 12 with 3 generators f1, f2, f3
 ```
 
 List groups of order 1 to 10 which are not abelian:
 ```jldoctest
 julia> all_small_groups(1:10, !is_abelian)
 4-element Vector{PcGroup}:
- Pc group of order 6
- Pc group of order 8
- Pc group of order 8
- Pc group of order 10
+ Pc group of order 6 with 2 generators f1, f2
+ Pc group of order 8 with 3 generators f1, f2, f3
+ Pc group of order 8 with 3 generators f1, f2, f3
+ Pc group of order 10 with 2 generators f1, f2
 ```
 """
 function all_small_groups(L...)

--- a/src/Groups/libraries/transitivegroups.jl
+++ b/src/Groups/libraries/transitivegroups.jl
@@ -85,7 +85,7 @@ The output is a group of type `PermGroup`.
 # Examples
 ```jldoctest
 julia> transitive_group(5,4)
-Alternating group of degree 5 and order 60 with 2 generators
+Alternating group of degree 5 with 2 generators
   (1,2,3,4,5)
   (3,4,5)
 
@@ -198,12 +198,12 @@ julia> all_transitive_groups(4)
  Permutation group of degree 4
  Permutation group of degree 4
  Permutation group of degree 4
- Alternating group of degree 4 and order 12
- Symmetric group of degree 4 and order 24
+ Alternating group of degree 4
+ Symmetric group of degree 4
 
 julia> all_transitive_groups(degree => 3:5, is_abelian)
 4-element Vector{PermGroup}:
- Alternating group of degree 3 and order 3
+ Alternating group of degree 3
  Permutation group of degree 4
  Permutation group of degree 4
  Permutation group of degree 5

--- a/src/Groups/libraries/transitivegroups.jl
+++ b/src/Groups/libraries/transitivegroups.jl
@@ -85,7 +85,9 @@ The output is a group of type `PermGroup`.
 # Examples
 ```jldoctest
 julia> transitive_group(5,4)
-Alt(5)
+Alternating group of degree 5 and order 60 with 2 generators
+  (1,2,3,4,5)
+  (3,4,5)
 
 julia> transitive_group(5,6)
 ERROR: ArgumentError: there are only 5 transitive groups of degree 5, not 6
@@ -117,7 +119,8 @@ julia> order(transitive_group(m...)) == order(G)
 true
 
 julia> S = sub(G, [perm([1, 3, 4, 5, 2])])[1]
-Permutation group of degree 7
+Permutation group of degree 7 with 1 generator
+  (2,3,4,5)
 
 julia> is_transitive(S)
 false
@@ -195,12 +198,12 @@ julia> all_transitive_groups(4)
  Permutation group of degree 4
  Permutation group of degree 4
  Permutation group of degree 4
- Alt(4)
- Sym(4)
+ Alternating group of degree 4 and order 12
+ Symmetric group of degree 4 and order 24
 
 julia> all_transitive_groups(degree => 3:5, is_abelian)
 4-element Vector{PermGroup}:
- Alt(3)
+ Alternating group of degree 3 and order 3
  Permutation group of degree 4
  Permutation group of degree 4
  Permutation group of degree 5

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -153,11 +153,11 @@ change_base_ring(R::Ring, G::MatrixGroup) = map_entries(R, G)
 #
 ########################################################################
 
-function _print_matrix_group_desc(io::IO, x::MatrixGroup)
+function _print_matrix_group_desc(io::IO, G::MatrixGroup)
   io = pretty(io)
-  R = base_ring(x)
-  print(io, LowercaseOff(), string(x.descr), "(", degree(x) ,",")
-  if x.descr==:GU || x.descr==:SU
+  R = base_ring(G)
+  print(io, LowercaseOff(), string(G.descr), "(", degree(G) ,",")
+  if G.descr==:GU || G.descr==:SU
     print(io, characteristic(R)^(div(degree(R),2)),")")
   elseif R isa Field && is_finite(R)
     print(io, order(R),")")
@@ -167,24 +167,53 @@ function _print_matrix_group_desc(io::IO, x::MatrixGroup)
   end
 end
 
-function Base.show(io::IO, ::MIME"text/plain", x::MatrixGroup)
-  isdefined(x, :descr) && return _print_matrix_group_desc(io, x)
-  println(io, "Matrix group of degree ", degree(x))
+function Base.show(io::IO, ::MIME"text/plain", G::MatrixGroup)
+  isdefined(G, :descr) && return _print_matrix_group_desc(io, G)
+  println(io, "Matrix group of degree ", degree(G))
   io = pretty(io)
   print(io, Indent())
-  print(io, "over ", Lowercase(), base_ring(x))
+  println(io, "over ", Lowercase(), base_ring(G))
+  print(io, Dedent())
+  has_gens(G) || return
+
+  _print_generators(io, G)
+end
+
+
+function _print_generators(io::IO, G::MatrixGroup)
+  io = pretty(io)
+  n = ngens(G)
+  print(io, "with ", ItemQuantity(n, "generator"))
+
+  # compute maximum number of generators that can fit on the screen
+  rows,cols = displaysize(io)
+  maxgens = div(rows-4, degree(G)+1)  # with separator we have deg+1 rows per generator
+  maxgens > 0 || return
+
+  println(io, Indent())
+  for (i, g) in enumerate(gens(G))
+    if i > maxgens
+      print(io, "⋮")
+      break
+    end
+    show(io, MIME"text/plain"(), g)
+    if i < n
+      println(io)
+      println(io)
+    end
+  end
   print(io, Dedent())
 end
 
-function Base.show(io::IO, x::MatrixGroup)
-  @show_name(io, x)
-  @show_special(io, x)
-  isdefined(x, :descr) && return _print_matrix_group_desc(io, x)
+function Base.show(io::IO, G::MatrixGroup)
+  @show_name(io, G)
+  @show_special(io, G)
+  isdefined(G, :descr) && return _print_matrix_group_desc(io, G)
   print(io, "Matrix group")
   if !is_terse(io)
-    print(io, " of degree ", degree(x))
+    print(io, " of degree ", degree(G))
     io = pretty(io)
-    print(terse(io), " over ", Lowercase(), base_ring(x))
+    print(terse(io), " over ", Lowercase(), base_ring(G))
   end
 end
 

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -710,6 +710,9 @@ julia> G = matrix_group(mat);
 julia> G2 = map_entries(x -> -x, G)
 Matrix group of degree 2
   over integer ring
+with 1 generator
+  [-1   -1]
+  [ 0   -1]
 
 julia> is_finite(G2)
 false

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -189,19 +189,21 @@ function _print_generators(io::IO, G::MatrixGroup)
   rows,cols = displaysize(io)
   maxgens = div(rows-4, degree(G)+1)  # with separator we have deg+1 rows per generator
   maxgens > 0 || return
+  if maxgens > ngens(G)
+    maxgens = ngens(G)
+  end
 
   println(io, Indent())
-  for (i, g) in enumerate(gens(G))
-    if i > maxgens
-      print(io, "⋮")
-      break
-    end
-    show(io, MIME"text/plain"(), g)
+  for i in 1:maxgens
+    show(io, MIME"text/plain"(), G[i])
     if i < n
+      # one extra newline between matrices
       println(io)
       println(io)
     end
   end
+  # if necessary, indicate that we had to leave out some generators
+  ngens(G) > maxgens && print(io, "⋮")
   print(io, Dedent())
 end
 

--- a/src/Groups/pcgroup.jl
+++ b/src/Groups/pcgroup.jl
@@ -42,7 +42,7 @@ It describes a free abelian group of rank `n`.
 # Examples
 ```jldoctest
 julia> G = pc_group(collector(2))
-Pc group of infinite order
+Pc group of infinite order with 2 generators g1, g2
 
 julia> is_abelian(G)
 true
@@ -447,7 +447,7 @@ julia> Oscar.set_relative_orders!(c, [2, 3])
 julia> Oscar.set_conjugate!(c, 2, 1, [2 => 2])
 
 julia> gg = pc_group(c)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> describe(gg)
 "S3"
@@ -489,7 +489,7 @@ See also [`syllables(::Union{PcGroupElem, SubPcGroupElem})`](@ref).
 
 ```jldoctest
 julia> g = abelian_group(PcGroup, [0, 5])
-Pc group of infinite order
+Pc group of infinite order with 2 generators g1, g2
 
 julia> x = g[1]^-3 * g[2]^-3
 g1^-3*g2^2
@@ -505,7 +505,7 @@ julia> letters(x)
 
 ```jldoctest
 julia> gg = small_group(6, 1)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> x = gg[1]^5*gg[2]^-4
 f1*f2^2
@@ -546,7 +546,7 @@ See also [`letters(::Union{PcGroupElem, SubPcGroupElem})`](@ref).
 
 ```jldoctest
 julia> gg = small_group(6, 1)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> x = gg[1]^5*gg[2]^-4
 f1*f2^2
@@ -565,7 +565,7 @@ true
 
 ```jldoctest
 julia> g = abelian_group(PcGroup, [5, 0])
-Pc group of infinite order
+Pc group of infinite order with 2 generators g1, g2
 
 julia> x = g[1]^-3 * g[2]^-3
 g1^2*g2^-3
@@ -650,12 +650,12 @@ Return a collector object for `G`.
 # Examples
 ```jldoctest
 julia> g = small_group(12, 3)
-Pc group of order 12
+Pc group of order 12 with 3 generators f1, f2, f3
 
 julia> c = collector(g);
 
 julia> gc = pc_group(c)
-Pc group of order 12
+Pc group of order 12 with 3 generators f1, f2, f3
 
 julia> is_isomorphic(g, gc)
 true

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -142,7 +142,9 @@ julia> x = perm([2,4,6,1,3,5])
 (1,2,4)(3,6,5)
 
 julia> parent(x)
-Sym(6)
+Symmetric group of degree 6 and order 720 with 2 generators
+  (1,2,3,4,5,6)
+  (1,2)
 ```
 """
 function perm(L::AbstractVector{<:IntegerUnion})
@@ -277,7 +279,9 @@ julia> x = cperm(G, [1,2,3]);
 julia> y = cperm(A, [1,2,3]);
 
 julia> z = cperm([1,2,3]); parent(z)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> x == y
 true
@@ -817,7 +821,9 @@ julia> x = @perm (1,2,3)(4,5)(factorial(3),7,8)
 (1,2,3)(4,5)(6,7,8)
 
 julia> parent(x)
-Sym(8)
+Symmetric group of degree 8 and order 40320 with 2 generators
+  (1,2,3,4,5,6,7,8)
+  (1,2)
 
 julia> x == @perm 8 (1,2,3)(4,5)(factorial(3),7,8)
 true
@@ -853,7 +859,9 @@ julia> gens = @perm [
  (1,2)(10,11)
  
 julia> parent(gens[1])
-Sym(14)
+Symmetric group of degree 14 and order 87178291200 with 2 generators
+  (1,2,3,4,5,6,7,8,9,10,11,12,13,14)
+  (1,2)
 ```
 """
 macro perm(expr)
@@ -940,7 +948,9 @@ elements in `perms`.
 julia> x = cperm([1,2,3], [4,5]);  y = cperm([1,4]);
 
 julia> permutation_group(5, [x, y])
-Permutation group of degree 5
+Permutation group of degree 5 with 2 generators
+  (1,2,3)(4,5)
+  (1,4)
 ```
 """
 function permutation_group(n::IntegerUnion, perms::Vector{PermGroupElem})
@@ -956,7 +966,9 @@ given by permutations in cycle notation.
 # Examples
 ```jldoctest
 julia> g = @permutation_group(7, (1,2), (1,2,3)(4,5))
-Permutation group of degree 7
+Permutation group of degree 7 with 2 generators
+  (1,2)
+  (1,2,3)(4,5)
 
 julia> degree(g)
 7

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -142,7 +142,7 @@ julia> x = perm([2,4,6,1,3,5])
 (1,2,4)(3,6,5)
 
 julia> parent(x)
-Symmetric group of degree 6 and order 720 with 2 generators
+Symmetric group of degree 6 with 2 generators
   (1,2,3,4,5,6)
   (1,2)
 ```
@@ -279,7 +279,7 @@ julia> x = cperm(G, [1,2,3]);
 julia> y = cperm(A, [1,2,3]);
 
 julia> z = cperm([1,2,3]); parent(z)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
@@ -821,7 +821,7 @@ julia> x = @perm (1,2,3)(4,5)(factorial(3),7,8)
 (1,2,3)(4,5)(6,7,8)
 
 julia> parent(x)
-Symmetric group of degree 8 and order 40320 with 2 generators
+Symmetric group of degree 8 with 2 generators
   (1,2,3,4,5,6,7,8)
   (1,2)
 
@@ -859,7 +859,7 @@ julia> gens = @perm [
  (1,2)(10,11)
  
 julia> parent(gens[1])
-Symmetric group of degree 14 and order 87178291200 with 2 generators
+Symmetric group of degree 14 with 2 generators
   (1,2,3,4,5,6,7,8,9,10,11,12,13,14)
   (1,2)
 ```

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -174,8 +174,8 @@ Return all normal subgroups of `G` (see [`is_normal`](@ref)).
 ```jldoctest
 julia> normal_subgroups(symmetric_group(5))
 3-element Vector{PermGroup}:
- Symmetric group of degree 5 and order 120
- Alternating group of degree 5 and order 60
+ Symmetric group of degree 5
+ Alternating group of degree 5
  Permutation group of degree 5 and order 1
 
 julia> normal_subgroups(quaternion_group(8))
@@ -202,7 +202,7 @@ subgroups.
 ```jldoctest
 julia> maximal_normal_subgroups(symmetric_group(4))
 1-element Vector{PermGroup}:
- Alternating group of degree 4 and order 12
+ Alternating group of degree 4
 
 julia> maximal_normal_subgroups(quaternion_group(8))
 3-element Vector{SubPcGroup}:
@@ -245,7 +245,7 @@ i.e., those subgroups that are invariant under all automorphisms of `G`.
 ```jldoctest
 julia> characteristic_subgroups(symmetric_group(3))
 3-element Vector{PermGroup}:
- Symmetric group of degree 3 and order 6
+ Symmetric group of degree 3
  Permutation group of degree 3 and order 3
  Permutation group of degree 3 and order 1
 
@@ -339,7 +339,7 @@ function returns an arbitrary one.
 ```jldoctest
 julia> chief_series(alternating_group(4))
 3-element Vector{PermGroup}:
- Alternating group of degree 4 and order 12
+ Alternating group of degree 4
  Permutation group of degree 4 and order 4
  Permutation group of degree 4 and order 1
 
@@ -423,11 +423,11 @@ An exception is thrown if $p$ is not a prime.
 ```jldoctest
 julia> p_central_series(alternating_group(4), 2)
 1-element Vector{PermGroup}:
- Alternating group of degree 4 and order 12
+ Alternating group of degree 4
 
 julia> p_central_series(alternating_group(4), 3)
 2-element Vector{PermGroup}:
- Alternating group of degree 4 and order 12
+ Alternating group of degree 4
  Permutation group of degree 4 and order 4
 
 julia> p_central_series(alternating_group(4), 4)
@@ -469,8 +469,8 @@ julia> lower_central_series(dihedral_group(12))
 
 julia> lower_central_series(symmetric_group(4))
 2-element Vector{PermGroup}:
- Symmetric group of degree 4 and order 24
- Alternating group of degree 4 and order 12
+ Symmetric group of degree 4
+ Alternating group of degree 4
 ```
 """
 @gapattribute lower_central_series(G::GAPGroup) = _as_subgroups(G, GAP.Globals.LowerCentralSeriesOfGroup(GapObj(G)))
@@ -823,7 +823,7 @@ An exception is thrown if `N` is not a normal subgroup of `G`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(4)
-Symmetric group of degree 4 and order 24 with 2 generators
+Symmetric group of degree 4 with 2 generators
   (1,2,3,4)
   (1,2)
 
@@ -1091,7 +1091,7 @@ julia> G = symmetric_group(4);
 julia> epi = epimorphism_from_free_group(G)
 Group homomorphism
   from free group of rank 2
-  to symmetric group of degree 4 and order 24
+  to symmetric group of degree 4
 
 julia> pi = G([2,4,3,1])
 (1,2,4)
@@ -1125,7 +1125,7 @@ together with an embedding `G'` into `G`.
 # Examples
 ```jldoctest
 julia> derived_subgroup(symmetric_group(5))
-(Alternating group of degree 5 and order 60, Hom: Alt(5) -> Sym(5))
+(Alternating group of degree 5, Hom: Alt(5) -> Sym(5))
 ```
 """
 @gapattribute derived_subgroup(G::GAPGroup) =
@@ -1142,15 +1142,15 @@ See also [`derived_length`](@ref).
 ```jldoctest
 julia> G = derived_series(symmetric_group(4))
 4-element Vector{PermGroup}:
- Symmetric group of degree 4 and order 24
- Alternating group of degree 4 and order 12
+ Symmetric group of degree 4
+ Alternating group of degree 4
  Permutation group of degree 4 and order 4
  Permutation group of degree 4 and order 1
 
 julia> derived_series(symmetric_group(5))
 2-element Vector{PermGroup}:
- Symmetric group of degree 5 and order 120
- Alternating group of degree 5 and order 60
+ Symmetric group of degree 5
+ Alternating group of degree 5
 
 julia> derived_series(dihedral_group(8))
 3-element Vector{SubPcGroup}:

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -174,18 +174,18 @@ Return all normal subgroups of `G` (see [`is_normal`](@ref)).
 ```jldoctest
 julia> normal_subgroups(symmetric_group(5))
 3-element Vector{PermGroup}:
- Sym(5)
- Alt(5)
+ Symmetric group of degree 5 and order 120
+ Alternating group of degree 5 and order 60
  Permutation group of degree 5 and order 1
 
 julia> normal_subgroups(quaternion_group(8))
 6-element Vector{SubPcGroup}:
- Sub-pc group of order 8
- Sub-pc group of order 4
- Sub-pc group of order 4
- Sub-pc group of order 4
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 8 with 3 generators x, y, y2
+ Sub-pc group of order 4 with 2 generators y, y2
+ Sub-pc group of order 4 with 2 generators x*y*y2, y2
+ Sub-pc group of order 4 with 2 generators x, y2
+ Sub-pc group of order 2 with 1 generator y2
+ Sub-pc group of order 1 with 0 generators
 ```
 """
 @gapattribute normal_subgroups(G::GAPGroup) =
@@ -202,13 +202,13 @@ subgroups.
 ```jldoctest
 julia> maximal_normal_subgroups(symmetric_group(4))
 1-element Vector{PermGroup}:
- Alt(4)
+ Alternating group of degree 4 and order 12
 
 julia> maximal_normal_subgroups(quaternion_group(8))
 3-element Vector{SubPcGroup}:
- Sub-pc group of order 4
- Sub-pc group of order 4
- Sub-pc group of order 4
+ Sub-pc group of order 4 with 2 generators y2, x
+ Sub-pc group of order 4 with 2 generators y2, y
+ Sub-pc group of order 4 with 2 generators y2, x*y
 ```
 """
 @gapattribute maximal_normal_subgroups(G::GAPGroup) =
@@ -229,7 +229,7 @@ julia> minimal_normal_subgroups(symmetric_group(4))
 
 julia> minimal_normal_subgroups(quaternion_group(8))
 1-element Vector{SubPcGroup}:
- Sub-pc group of order 2
+ Sub-pc group of order 2 with 1 generator y2
 ```
 """
 @gapattribute minimal_normal_subgroups(G::GAPGroup) =
@@ -245,15 +245,15 @@ i.e., those subgroups that are invariant under all automorphisms of `G`.
 ```jldoctest
 julia> characteristic_subgroups(symmetric_group(3))
 3-element Vector{PermGroup}:
- Sym(3)
+ Symmetric group of degree 3 and order 6
  Permutation group of degree 3 and order 3
  Permutation group of degree 3 and order 1
 
 julia> characteristic_subgroups(quaternion_group(8))
 3-element Vector{SubPcGroup}:
- Sub-pc group of order 8
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 8 with 3 generators x, y, y2
+ Sub-pc group of order 2 with 1 generator y2
+ Sub-pc group of order 1 with 0 generators
 ```
 """
 @gapattribute characteristic_subgroups(G::GAPGroup) =
@@ -287,7 +287,8 @@ in `H`, together with its embedding morphism into `G`.
 # Examples
 ```jldoctest
 julia> g = symmetric_group(5);  h = sylow_subgroup(g, 3)[1]
-Permutation group of degree 5 and order 3
+Permutation group of degree 5 and order 3 with 1 generator
+  (1,2,3)
 
 julia> centralizer(g, h)
 (Permutation group of degree 5 and order 6, Hom: permutation group -> g)
@@ -338,16 +339,16 @@ function returns an arbitrary one.
 ```jldoctest
 julia> chief_series(alternating_group(4))
 3-element Vector{PermGroup}:
- Alt(4)
+ Alternating group of degree 4 and order 12
  Permutation group of degree 4 and order 4
  Permutation group of degree 4 and order 1
 
 julia> chief_series(quaternion_group(8))
 4-element Vector{SubPcGroup}:
- Sub-pc group of order 8
- Sub-pc group of order 4
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 8 with 3 generators x, y, y2
+ Sub-pc group of order 4 with 2 generators y, y2
+ Sub-pc group of order 2 with 1 generator y2
+ Sub-pc group of order 1 with 0 generators
 ```
 """
 @gapattribute chief_series(G::GAPGroup) = _as_subgroups(G, GAP.Globals.ChiefSeries(GapObj(G)))
@@ -373,10 +374,10 @@ julia> composition_series(alternating_group(4))
 
 julia> composition_series(quaternion_group(8))
 4-element Vector{SubPcGroup}:
- Sub-pc group of order 8
- Sub-pc group of order 4
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 8 with 3 generators x, y, y2
+ Sub-pc group of order 4 with 2 generators y, y2
+ Sub-pc group of order 2 with 1 generator y2
+ Sub-pc group of order 1 with 0 generators
 ```
 """
 @gapattribute composition_series(G::GAPGroup) = _as_subgroups(G, GAP.Globals.CompositionSeries(GapObj(G)))
@@ -394,11 +395,11 @@ An exception is thrown if $G$ is not a $p$-group.
 ```jldoctest
 julia> jennings_series(dihedral_group(16))
 5-element Vector{SubPcGroup}:
- Sub-pc group of order 16
- Sub-pc group of order 4
- Sub-pc group of order 2
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 16 with 4 generators f1, f2, f3, f4
+ Sub-pc group of order 4 with 2 generators f3, f4
+ Sub-pc group of order 2 with 1 generator f4
+ Sub-pc group of order 2 with 1 generator f4
+ Sub-pc group of order 1 with 1 generator <identity> of ...
 
 julia> jennings_series(dihedral_group(10))
 ERROR: ArgumentError: group must be a p-group
@@ -422,11 +423,11 @@ An exception is thrown if $p$ is not a prime.
 ```jldoctest
 julia> p_central_series(alternating_group(4), 2)
 1-element Vector{PermGroup}:
- Alt(4)
+ Alternating group of degree 4 and order 12
 
 julia> p_central_series(alternating_group(4), 3)
 2-element Vector{PermGroup}:
- Alt(4)
+ Alternating group of degree 4 and order 12
  Permutation group of degree 4 and order 4
 
 julia> p_central_series(alternating_group(4), 4)
@@ -457,19 +458,19 @@ See also [`upper_central_series`](@ref) and [`nilpotency_class`](@ref).
 ```jldoctest
 julia> lower_central_series(dihedral_group(8))
 3-element Vector{SubPcGroup}:
- Sub-pc group of order 8
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 8 with 3 generators f1, f2, f3
+ Sub-pc group of order 2 with 1 generator f3
+ Sub-pc group of order 1 with 1 generator <identity> of ...
 
 julia> lower_central_series(dihedral_group(12))
 2-element Vector{SubPcGroup}:
- Sub-pc group of order 12
- Sub-pc group of order 3
+ Sub-pc group of order 12 with 3 generators f1, f2, f3
+ Sub-pc group of order 3 with 1 generator f3
 
 julia> lower_central_series(symmetric_group(4))
 2-element Vector{PermGroup}:
- Sym(4)
- Alt(4)
+ Symmetric group of degree 4 and order 24
+ Alternating group of degree 4 and order 12
 ```
 """
 @gapattribute lower_central_series(G::GAPGroup) = _as_subgroups(G, GAP.Globals.LowerCentralSeriesOfGroup(GapObj(G)))
@@ -493,14 +494,14 @@ See also [`lower_central_series`](@ref) and [`nilpotency_class`](@ref).
 ```jldoctest
 julia> upper_central_series(dihedral_group(8))
 3-element Vector{SubPcGroup}:
- Sub-pc group of order 8
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 8 with 3 generators f3, f1, f2
+ Sub-pc group of order 2 with 1 generator f3
+ Sub-pc group of order 1 with 0 generators
 
 julia> upper_central_series(dihedral_group(12))
 2-element Vector{SubPcGroup}:
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 2 with 1 generator f2*f3
+ Sub-pc group of order 1 with 0 generators
 
 julia> upper_central_series(symmetric_group(4))
 1-element Vector{PermGroup}:
@@ -822,7 +823,9 @@ An exception is thrown if `N` is not a normal subgroup of `G`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(4)
-Sym(4)
+Symmetric group of degree 4 and order 24 with 2 generators
+  (1,2,3,4)
+  (1,2)
 
 julia> N = pcore(G, 2)[1];
 
@@ -1012,7 +1015,7 @@ julia> schur_multiplier(symmetric_group(4))
 Z/2
 
 julia> schur_multiplier(PcGroup, alternating_group(6))
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> schur_multiplier(abelian_group([2, 12]))
 Z/2
@@ -1088,7 +1091,7 @@ julia> G = symmetric_group(4);
 julia> epi = epimorphism_from_free_group(G)
 Group homomorphism
   from free group of rank 2
-  to Sym(4)
+  to symmetric group of degree 4 and order 24
 
 julia> pi = G([2,4,3,1])
 (1,2,4)
@@ -1122,7 +1125,7 @@ together with an embedding `G'` into `G`.
 # Examples
 ```jldoctest
 julia> derived_subgroup(symmetric_group(5))
-(Alt(5), Hom: Alt(5) -> Sym(5))
+(Alternating group of degree 5 and order 60, Hom: Alt(5) -> Sym(5))
 ```
 """
 @gapattribute derived_subgroup(G::GAPGroup) =
@@ -1139,21 +1142,21 @@ See also [`derived_length`](@ref).
 ```jldoctest
 julia> G = derived_series(symmetric_group(4))
 4-element Vector{PermGroup}:
- Sym(4)
- Alt(4)
+ Symmetric group of degree 4 and order 24
+ Alternating group of degree 4 and order 12
  Permutation group of degree 4 and order 4
  Permutation group of degree 4 and order 1
 
 julia> derived_series(symmetric_group(5))
 2-element Vector{PermGroup}:
- Sym(5)
- Alt(5)
+ Symmetric group of degree 5 and order 120
+ Alternating group of degree 5 and order 60
 
 julia> derived_series(dihedral_group(8))
 3-element Vector{SubPcGroup}:
- Sub-pc group of order 8
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 8 with 3 generators f1, f2, f3
+ Sub-pc group of order 2 with 1 generator f3
+ Sub-pc group of order 1 with 0 generators
 ```
 """
 @gapattribute derived_series(G::GAPGroup) = _as_subgroups(G, GAP.Globals.DerivedSeriesOfGroup(GapObj(G)))

--- a/src/Groups/tom.jl
+++ b/src/Groups/tom.jl
@@ -92,11 +92,11 @@ Return the table of marks of the finite group `G`.
 # Examples
 ```jldoctest
 julia> show(stdout, MIME("text/plain"), table_of_marks(symmetric_group(3)))
-Table of marks of Sym(3)
+Table of marks of symmetric group of degree 3 and order 6
 
-1: 6      
-2: 3 1    
-3: 2 . 2  
+1: 6
+2: 3 1
+3: 2 . 2
 4: 1 1 1 1
 ```
 """
@@ -446,7 +446,8 @@ or if `i` is larger than `length(tom)`.
 # Examples
 ```jldoctest
 julia> representative(table_of_marks("A5"), 2)
-Permutation group of degree 5 and order 2
+Permutation group of degree 5 and order 2 with 1 generator
+  (2,3)(4,5)
 ```
 """
 function representative(tom::GAPGroupTableOfMarks, i::Int)

--- a/src/Groups/tom.jl
+++ b/src/Groups/tom.jl
@@ -92,7 +92,7 @@ Return the table of marks of the finite group `G`.
 # Examples
 ```jldoctest
 julia> show(stdout, MIME("text/plain"), table_of_marks(symmetric_group(3)))
-Table of marks of symmetric group of degree 3 and order 6
+Table of marks of symmetric group of degree 3
 
 1: 6
 2: 3 1

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -73,19 +73,25 @@ If `G` is a permutation group and `x` is a permutation,
 an exception is thrown if `x` does not embed into `G`.
 ```jldoctest
 julia> G=symmetric_group(5)
-Sym(5)
+Symmetric group of degree 5 and order 120 with 2 generators
+  (1,2,3,4,5)
+  (1,2)
 
 julia> x=cperm([1,2,3])
 (1,2,3)
 
 julia> parent(x)
-Sym(3)
+Symmetric group of degree 3 and order 6 with 2 generators
+  (1,2,3)
+  (1,2)
 
 julia> y=G(x)
 (1,2,3)
 
 julia> parent(y)
-Sym(5)
+Symmetric group of degree 5 and order 120 with 2 generators
+  (1,2,3,4,5)
+  (1,2)
 ```
 
 If `G` is a permutation group and `x` is a vector of integers,
@@ -95,13 +101,17 @@ an exception is thrown if the element does not embed into `G`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(6)
-Sym(6)
+Symmetric group of degree 6 and order 720 with 2 generators
+  (1,2,3,4,5,6)
+  (1,2)
 
 julia> x = G([2,4,6,1,3,5])
 (1,2,4)(3,6,5)
 
 julia> parent(x)
-Sym(6)
+Symmetric group of degree 6 and order 720 with 2 generators
+  (1,2,3,4,5,6)
+  (1,2)
 ```
 """
 @attributes mutable struct PermGroup <: GAPGroup

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -73,7 +73,7 @@ If `G` is a permutation group and `x` is a permutation,
 an exception is thrown if `x` does not embed into `G`.
 ```jldoctest
 julia> G=symmetric_group(5)
-Symmetric group of degree 5 and order 120 with 2 generators
+Symmetric group of degree 5 with 2 generators
   (1,2,3,4,5)
   (1,2)
 
@@ -81,7 +81,7 @@ julia> x=cperm([1,2,3])
 (1,2,3)
 
 julia> parent(x)
-Symmetric group of degree 3 and order 6 with 2 generators
+Symmetric group of degree 3 with 2 generators
   (1,2,3)
   (1,2)
 
@@ -89,7 +89,7 @@ julia> y=G(x)
 (1,2,3)
 
 julia> parent(y)
-Symmetric group of degree 5 and order 120 with 2 generators
+Symmetric group of degree 5 with 2 generators
   (1,2,3,4,5)
   (1,2)
 ```
@@ -101,7 +101,7 @@ an exception is thrown if the element does not embed into `G`.
 # Examples
 ```jldoctest
 julia> G = symmetric_group(6)
-Symmetric group of degree 6 and order 720 with 2 generators
+Symmetric group of degree 6 with 2 generators
   (1,2,3,4,5,6)
   (1,2)
 
@@ -109,7 +109,7 @@ julia> x = G([2,4,6,1,3,5])
 (1,2,4)(3,6,5)
 
 julia> parent(x)
-Symmetric group of degree 6 and order 720 with 2 generators
+Symmetric group of degree 6 with 2 generators
   (1,2,3,4,5,6)
   (1,2)
 ```

--- a/src/InvariantTheory/affine_algebra.jl
+++ b/src/InvariantTheory/affine_algebra.jl
@@ -59,6 +59,14 @@ julia> M2 = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1])
 julia> G = matrix_group(M1, M2)
 Matrix group of degree 3
   over cyclotomic field of order 3
+with 2 generators
+  [0   0   1]
+  [1   0   0]
+  [0   1   0]
+
+  [1   0        0]
+  [0   a        0]
+  [0   0   -a - 1]
 
 julia> IR = invariant_ring(G)
 Invariant ring

--- a/src/InvariantTheory/fundamental_invariants.jl
+++ b/src/InvariantTheory/fundamental_invariants.jl
@@ -268,6 +268,14 @@ julia> M2 = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1])
 julia> G = matrix_group(M1, M2)
 Matrix group of degree 3
   over cyclotomic field of order 3
+with 2 generators
+  [0   0   1]
+  [1   0   0]
+  [0   1   0]
+
+  [1   0        0]
+  [0   a        0]
+  [0   0   -a - 1]
 
 julia> IR = invariant_ring(G)
 Invariant ring

--- a/src/InvariantTheory/invariant_rings.jl
+++ b/src/InvariantTheory/invariant_rings.jl
@@ -108,7 +108,7 @@ Invariant ring
 
 julia> IRp = invariant_ring(symmetric_group(3))
 Invariant ring
-  of Sym(3)
+  of symmetric group of degree 3 and order 6
 
 julia> coefficient_ring(IRp)
 Rational field
@@ -247,6 +247,14 @@ julia> M2 = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1])
 julia> G = matrix_group(M1, M2)
 Matrix group of degree 3
   over cyclotomic field of order 3
+with 2 generators
+  [0   0   1]
+  [1   0   0]
+  [0   1   0]
+
+  [1   0        0]
+  [0   a        0]
+  [0   0   -a - 1]
 
 julia> IR = invariant_ring(G)
 Invariant ring
@@ -278,6 +286,10 @@ julia> M = matrix(GF(3), [0 1 0; -1 0 0; 0 0 -1])
 julia> G = matrix_group(M)
 Matrix group of degree 3
   over prime field of characteristic 3
+with 1 generator
+  [0   1   0]
+  [2   0   0]
+  [0   0   2]
 
 julia> IR = invariant_ring(G)
 Invariant ring
@@ -456,6 +468,14 @@ julia> M2 = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1])
 julia> G = matrix_group(M1, M2)
 Matrix group of degree 3
   over cyclotomic field of order 3
+with 2 generators
+  [0   0   1]
+  [1   0   0]
+  [0   1   0]
+
+  [1   0        0]
+  [0   a        0]
+  [0   0   -a - 1]
 
 julia> IR = invariant_ring(G)
 Invariant ring
@@ -476,6 +496,10 @@ julia> M = matrix(GF(3), [0 1 0; -1 0 0; 0 0 -1])
 julia> G = matrix_group(M)
 Matrix group of degree 3
   over prime field of characteristic 3
+with 1 generator
+  [0   1   0]
+  [2   0   0]
+  [0   0   2]
 
 julia> IR = invariant_ring(G)
 Invariant ring

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -167,6 +167,14 @@ julia> M2 = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1])
 julia> G = matrix_group(M1, M2)
 Matrix group of degree 3
   over cyclotomic field of order 3
+with 2 generators
+  [0   0   1]
+  [1   0   0]
+  [0   1   0]
+
+  [1   0        0]
+  [0   a        0]
+  [0   0   -a - 1]
 
 julia> IR = invariant_ring(G)
 Invariant ring
@@ -191,6 +199,10 @@ julia> M = matrix(GF(3), [0 1 0; -1 0 0; 0 0 -1])
 julia> G = matrix_group(M)
 Matrix group of degree 3
   over prime field of characteristic 3
+with 1 generator
+  [0   1   0]
+  [2   0   0]
+  [0   0   2]
 
 julia> IR = invariant_ring(G)
 Invariant ring

--- a/src/PolyhedralGeometry/groups.jl
+++ b/src/PolyhedralGeometry/groups.jl
@@ -58,13 +58,16 @@ julia> quad = convex_hull([0 0; 1 0; 2 2; 0 1])
 Polyhedron in ambient dimension 2
 
 julia> G = combinatorial_symmetries(quad)
-Permutation group of degree 4
+Permutation group of degree 4 with 2 generators
+  (2,4)
+  (1,2)(3,4)
 
 julia> order(G)
 8
 
 julia> G = linear_symmetries(quad)
-Permutation group of degree 4
+Permutation group of degree 4 with 1 generator
+  (2,4)
 
 julia> order(G)
 2
@@ -88,7 +91,10 @@ julia> c = cube(3)
 Polytope in ambient dimension 3
 
 julia> G = linear_symmetries(c)
-Permutation group of degree 8
+Permutation group of degree 8 with 3 generators
+  (3,5)(4,6)
+  (2,3)(6,7)
+  (1,2)(3,4)(5,6)(7,8)
 
 julia> order(G)
 48
@@ -101,7 +107,8 @@ julia> quad = convex_hull([0 0; 1 0; 2 2; 0 1])
 Polyhedron in ambient dimension 2
 
 julia> G = linear_symmetries(quad)
-Permutation group of degree 4
+Permutation group of degree 4 with 1 generator
+  (2,4)
 
 julia> order(G)
 2

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -71,7 +71,7 @@ default `show` with unicode
 julia> Oscar.with_unicode() do
          show(stdout, MIME("text/plain"), t_a4)
        end
-Character table of Alt(4)
+Character table of alternating group of degree 4 and order 12
 
  2  2  2       .       .
  3  1  .       1       1
@@ -90,7 +90,7 @@ default `show` without unicode
 
 ```jldoctest group_characters.test
 julia> show(stdout, MIME("text/plain"), t_a4)
-Character table of Alt(4)
+Character table of alternating group of degree 4 and order 12
 
   2  2  2        .        .
   3  1  .        1        1
@@ -109,7 +109,7 @@ LaTeX format
 
 ```jldoctest group_characters.test
 julia> show(stdout, MIME("text/latex"), t_a4)
-Character table of Alt(4)
+Character table of alternating group of degree 4 and order 12
 
 $\begin{array}{rrrrr}
 2 & 2 & 2 & . & . \\
@@ -135,7 +135,7 @@ in the screen format ...
 julia> Oscar.with_unicode() do
          show(IOContext(stdout, :with_legend => true), MIME("text/plain"), t_a4)
        end
-Character table of Alt(4)
+Character table of alternating group of degree 4 and order 12
 
  2  2  2  .  .
  3  1  .  1  1
@@ -155,7 +155,7 @@ A̅ = ζ₃
 
 ```jldoctest group_characters.test
 julia> show(IOContext(stdout, :with_legend => true), MIME("text/plain"), t_a4)
-Character table of Alt(4)
+Character table of alternating group of degree 4 and order 12
 
   2  2  2  .  .
   3  1  .  1  1
@@ -176,7 +176,7 @@ A = -z_3 - 1
 ... and in LaTeX format
 ```jldoctest group_characters.test
 julia> show(IOContext(stdout, :with_legend => true), MIME("text/latex"), t_a4)
-Character table of Alt(4)
+Character table of alternating group of degree 4 and order 12
 
 $\begin{array}{rrrrr}
 2 & 2 & 2 & . & . \\
@@ -600,7 +600,7 @@ show indicators in the screen format ...
 julia> Oscar.with_unicode() do
          show(IOContext(stdout, :indicator => [2]), MIME("text/plain"), t_a4)
        end
-Character table of Alt(4)
+Character table of alternating group of degree 4 and order 12
 
     2  2  2       .       .
     3  1  .       1       1
@@ -619,7 +619,7 @@ Character table of Alt(4)
 
 ```jldoctest group_characters.test
 julia> show(IOContext(stdout, :indicator => [2]), MIME("text/latex"), t_a4)
-Character table of Alt(4)
+Character table of alternating group of degree 4 and order 12
 
 $\begin{array}{rrrrrr}
  & 2 & 2 & 2 & . & . \\
@@ -644,7 +644,7 @@ show character field degrees in the screen format ...
 julia> Oscar.with_unicode() do
          show(IOContext(stdout, :character_field => true), MIME("text/plain"), t_a4)
        end
-Character table of Alt(4)
+Character table of alternating group of degree 4 and order 12
 
     2  2  2       .       .
     3  1  .       1       1
@@ -663,7 +663,7 @@ Character table of Alt(4)
 
 ```jldoctest group_characters.test
 julia> show(IOContext(stdout, :character_field => true), MIME("text/latex"), t_a4)
-Character table of Alt(4)
+Character table of alternating group of degree 4 and order 12
 
 $\begin{array}{rrrrrr}
  & 2 & 2 & 2 & . & . \\
@@ -688,7 +688,7 @@ show character field degrees in the screen format ...
 julia> Oscar.with_unicode() do
          show(IOContext(stdout, :character_field => true), MIME("text/plain"), mod(t_a4, 2))
        end
-2-modular Brauer table of Alt(4)
+2-modular Brauer table of alternating group of degree 4 and order 12
 
     2  2       .       .
     3  1       1       1
@@ -706,7 +706,7 @@ julia> Oscar.with_unicode() do
 
 ```jldoctest group_characters.test
 julia> show(IOContext(stdout, :character_field => true), MIME("text/latex"), mod(t_a4, 2))
-2-modular Brauer table of Alt(4)
+2-modular Brauer table of alternating group of degree 4 and order 12
 
 $\begin{array}{rrrrr}
  & 2 & 2 & . & . \\

--- a/test/Groups/tom.jl
+++ b/test/Groups/tom.jl
@@ -50,7 +50,7 @@ default `show`
 
 ```jldoctest tables_of_marks.test
 julia> show(stdout, MIME("text/plain"), t_a4)
-Table of marks of Alt(4)
+Table of marks of alternating group of degree 4 and order 12
 
 1: 12        
 2:  6 2      
@@ -63,7 +63,7 @@ LaTeX format
 
 ```jldoctest tables_of_marks.test
 julia> show(stdout, MIME("text/latex"), t_a4)
-Table of marks of Alt(4)
+Table of marks of alternating group of degree 4 and order 12
 
 $\begin{array}{rrrrrr}
 1: & 12 &  &  &  &  \\ 

--- a/test/book/cornerstones/algebraic-geometry/monodromy.jlcon
+++ b/test/book/cornerstones/algebraic-geometry/monodromy.jlcon
@@ -21,7 +21,9 @@ julia> g1t = phi(g1yz[1]);
 julia> G1,_ = galois_group(g1t);
 
 julia> G1
-Sym(24)
+Symmetric group of degree 24 and order 620448401733239439360000 with 2 generators
+  (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24)
+  (1,2)
 
 julia> g2 = 7713*f1 - 1313*f2;
 

--- a/test/book/cornerstones/groups/actions.jlcon
+++ b/test/book/cornerstones/groups/actions.jlcon
@@ -1,12 +1,12 @@
 julia> gset(alternating_group(4))
 G-set of
-  Alt(4)
+  alternating group of degree 4 and order 12
   with seeds 1:4
 
 julia> G = dihedral_group(6);
 
 julia> U = sub(G, [g for g in gens(G) if order(g) == 2])[1]
-Sub-pc group of order 2
+Sub-pc group of order 2 with 1 generator f1
 
 julia> r = right_cosets(G, U)
 Right cosets of
@@ -14,7 +14,7 @@ Right cosets of
   pc group of order 6
 
 julia> acting_group(r)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> collect(r)
 3-element Vector{GroupCoset{PcGroup, SubPcGroup, PcGroupElem}}:
@@ -23,7 +23,7 @@ julia> collect(r)
  Right coset of U with representative f2^2
 
 julia> action_function(r)
-* (generic function with 1736 methods)
+* (generic function with 1719 methods)
 
 julia> permutation(r, G[1])
 (2,3)
@@ -49,7 +49,7 @@ julia> function optimal_transitive_perm_rep(G)
        end;
 
 julia> U = dihedral_group(8)
-Pc group of order 8
+Pc group of order 8 with 3 generators f1, f2, f3
 
 julia> optimal_transitive_perm_rep(U)
 Group homomorphism
@@ -62,7 +62,10 @@ Group homomorphism
   to permutation group of degree 4 and order 8
 
 julia> permutation_group(U)
-Permutation group of degree 4 and order 8
+Permutation group of degree 4 and order 8 with 3 generators
+  (2,4)
+  (1,2,3,4)
+  (1,3)(2,4)
 
 julia> for g in all_transitive_groups(degree => 3:8, !is_primitive)
          h = image(optimal_transitive_perm_rep(g))[1]

--- a/test/book/cornerstones/groups/cohomology.jlcon
+++ b/test/book/cornerstones/groups/cohomology.jlcon
@@ -1,8 +1,8 @@
 julia> irreducible_modules(symmetric_group(3))
 3-element Vector{GModule}:
- G-module for Sym(3) acting on vector space of dimension 1 over abelian closure of QQ
- G-module for Sym(3) acting on vector space of dimension 1 over abelian closure of QQ
- G-module for Sym(3) acting on vector space of dimension 2 over abelian closure of QQ
+ G-module for symmetric group of degree 3 and order 6 acting on vector space of dimension 1 over abelian closure of QQ
+ G-module for symmetric group of degree 3 and order 6 acting on vector space of dimension 1 over abelian closure of QQ
+ G-module for symmetric group of degree 3 and order 6 acting on vector space of dimension 2 over abelian closure of QQ
 
 julia> G = symmetric_group(3);
 

--- a/test/book/cornerstones/groups/intro.jlcon
+++ b/test/book/cornerstones/groups/intro.jlcon
@@ -84,14 +84,17 @@ Generic group of order 10 with multiplication table
 
 julia> permutation_group(G_generic)
 Permutation group of degree 10 with 2 generators
-  (1,6)(2,7)(3,8)(4,9)(5,10)
-  (1,3,5,2,4)(6,9,7,10,8)
+  (1,2,3,4,5)(6,10,9,8,7)
+  (1,8)(2,9)(3,10)(4,6)(5,7)
 
 julia> is_isomorphic(ans, G_perm)
 true
 
 julia> G_fp = fp_group(G_perm)
-Finitely presented group of order 10 with 2 generators F1, F2
+Finitely presented group of order 10 with 2 generators F1, F2 and with 3 relators
+  F1^2
+  F1^-1*F2*F1*F2^-4
+  F2^5
 
 julia> gens(G_fp)
 2-element Vector{FPGroupElem}:

--- a/test/book/cornerstones/groups/intro.jlcon
+++ b/test/book/cornerstones/groups/intro.jlcon
@@ -1,5 +1,7 @@
 julia> G_perm = @permutation_group(5, (2,5)(3,4), (1,3)(4,5))
-Permutation group of degree 5
+Permutation group of degree 5 with 2 generators
+  (2,5)(3,4)
+  (1,3)(4,5)
 
 julia> order(G_perm)
 10
@@ -41,6 +43,12 @@ julia> mat_sigma1 = matrix(K, [ -1 0 ; 0 1 ]);
 julia> G_mat = matrix_group(mat_rot, mat_sigma1)
 Matrix group of degree 2
   over algebraic closure of rational field
+with 2 generators
+  [    Root 0.309017 of 4x^2 + 2x - 1   Root -0.951057 of 16x^4 - 20x^2 + 5]
+  [Root 0.951057 of 16x^4 - 20x^2 + 5        Root 0.309017 of 4x^2 + 2x - 1]
+
+  [Root -1.00000 of x + 1             Root 0 of x]
+  [           Root 0 of x   Root 1.00000 of x - 1]
 
 julia> is_isomorphic(G_mat, G_perm)
 true
@@ -75,13 +83,15 @@ julia> G_generic = generic_group(closure([rot, sigma_1], *), *)[1]
 Generic group of order 10 with multiplication table
 
 julia> permutation_group(G_generic)
-Permutation group of degree 10
+Permutation group of degree 10 with 2 generators
+  (1,6)(2,7)(3,8)(4,9)(5,10)
+  (1,3,5,2,4)(6,9,7,10,8)
 
 julia> is_isomorphic(ans, G_perm)
 true
 
 julia> G_fp = fp_group(G_perm)
-Finitely presented group of order 10
+Finitely presented group of order 10 with 2 generators F1, F2
 
 julia> gens(G_fp)
 2-element Vector{FPGroupElem}:
@@ -95,7 +105,7 @@ julia> relators(G_fp)
  F2^5
 
 julia> F = free_group(2)
-Free group of rank 2
+Free group of rank 2 with 2 generators f1, f2
 
 julia> G_cox, _ = quo(F, [F[1]^2, F[2]^2, (F[1]*F[2])^5])
 (Finitely presented group, Hom: F -> G_cox)
@@ -133,7 +143,9 @@ julia> describe(quo(H, H2)[1])
 "(C3 x C3) : C2"
 
 julia> dihedral_group(10)
-Pc group of order 10
+Pc group of order 10 with 2 generators f1, f2
 
 julia> dihedral_group(PermGroup, 10)
-Permutation group of degree 5
+Permutation group of degree 5 with 2 generators
+  (1,2,3,4,5)
+  (2,5)(3,4)

--- a/test/book/cornerstones/number-theory/sym.jlcon
+++ b/test/book/cornerstones/number-theory/sym.jlcon
@@ -3,7 +3,9 @@ julia> Qx, x = QQ["x"];
 julia> K, a = number_field(x^4 - 13*x^2 + 16, "a");
 
 julia> G, m = automorphism_group(PermGroup, K); G # we only print G
-Permutation group of degree 4
+Permutation group of degree 4 with 2 generators
+  (1,3)(2,4)
+  (1,2)(3,4)
 
 julia> describe(G)
 "C2 x C2"

--- a/test/book/cornerstones/polyhedral-geometry/GKZ_orbits.jlcon
+++ b/test/book/cornerstones/polyhedral-geometry/GKZ_orbits.jlcon
@@ -1,5 +1,8 @@
 julia> G = automorphism_group(C)[:on_vertices]
-Permutation group of degree 8
+Permutation group of degree 8 with 3 generators
+  (3,5)(4,6)
+  (2,3)(6,7)
+  (1,2)(3,4)(5,6)(7,8)
 
 julia> OrbitRepresentatives=
         unique([minimum(gset(G,permuted,[v])) 

--- a/test/book/specialized/boehm-breuer-git-fans/explG25_2.jlcon
+++ b/test/book/specialized/boehm-breuer-git-fans/explG25_2.jlcon
@@ -5,7 +5,9 @@ julia> sym = symmetric_group(n);
 julia> G, emb = sub([sym(x) for x in perms_list]...);
 
 julia> G
-Permutation group of degree 10
+Permutation group of degree 10 with 2 generators
+  (2,3)(5,6)(9,10)
+  (1,5,9,10,3)(2,7,8,4,6)
 
 julia> describe(G)
 "S5"

--- a/test/book/specialized/decker-schmitt-invariant-theory/H3.jlcon
+++ b/test/book/specialized/decker-schmitt-invariant-theory/H3.jlcon
@@ -13,6 +13,14 @@ julia> T = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1])
 julia> H3 = matrix_group(S, T)
 Matrix group of degree 3
   over cyclotomic field of order 3
+with 2 generators
+  [0   0   1]
+  [1   0   0]
+  [0   1   0]
+
+  [1   0        0]
+  [0   a        0]
+  [0   0   -a - 1]
 
 julia> order(H3)
 27

--- a/test/book/specialized/decker-schmitt-invariant-theory/cox_ring.jlcon
+++ b/test/book/specialized/decker-schmitt-invariant-theory/cox_ring.jlcon
@@ -8,6 +8,14 @@ julia> g2 = matrix(K, 3, 3, [ 0 0 1; 1 0 0; 0 1 0 ]);
 julia> G = matrix_group(g1, g2)
 Matrix group of degree 3
   over cyclotomic field of order 3
+with 2 generators
+  [-1   0   0]
+  [ 0   1   0]
+  [ 0   0   1]
+
+  [0   0   1]
+  [1   0   0]
+  [0   1   0]
 
 julia> chi = character_table(G)[6];
 

--- a/test/book/specialized/decker-schmitt-invariant-theory/klein.jlcon
+++ b/test/book/specialized/decker-schmitt-invariant-theory/klein.jlcon
@@ -13,6 +13,16 @@ julia> B = matrix(QQ, [0 0 1 0; 0 0 0 1; 1 0 0 0; 0 1 0 0])
 julia> K4 = matrix_group(A, B)
 Matrix group of degree 4
   over rational field
+with 2 generators
+  [0   1   0   0]
+  [1   0   0   0]
+  [0   0   0   1]
+  [0   0   1   0]
+
+  [0   0   1   0]
+  [0   0   0   1]
+  [1   0   0   0]
+  [0   1   0   0]
 
 julia> small_group_identification(K4)
 (4, 2)

--- a/test/book/specialized/decker-schmitt-invariant-theory/sym.jlcon
+++ b/test/book/specialized/decker-schmitt-invariant-theory/sym.jlcon
@@ -1,6 +1,6 @@
 julia> RS4 = invariant_ring(GF(2), symmetric_group(4))
 Invariant ring
-  of Sym(4)
+  of symmetric group of degree 4 and order 24
 
 julia> L = fundamental_invariants(RS4)
 4-element Vector{MPolyDecRingElem{FqFieldElem, FqMPolyRingElem}}:


### PR DESCRIPTION
This is an experiment to see what happens if we print the generators of groups, at least in "detailed" mode. I find it quite useful in some cases, but in others it is annoying. Would be interesting to know what others think about this.
