### PR TITLE
Disable AlgClosureFp tests for now

### DIFF
--- a/test/Rings/runtests.jl
+++ b/test/Rings/runtests.jl
@@ -23,7 +23,9 @@ include("NumberField.jl")
 include("FunctionField.jl")
 include("AbelianClosure.jl")
 
-include("AlgClosureFp.jl")
+# FIXME: temporarily disable AlgClosureFp tests until we resolve
+# issue https://github.com/oscar-system/Oscar.jl/issues/2691
+#include("AlgClosureFp.jl")
 include("Laurent.jl")
 
 include("MPolyAnyMap/MPolyRing.jl")


### PR DESCRIPTION
Failures caused by these are more and more frequent and also e.g. affect OscarCI tests in AA, Nemo, ...

So we should disable them here for now, until #2691 is properly resolved. Of course disabling tests like this is somewhat risky, but as long as there are no changes to the `AlgClosureFp` code, I think we can live with it. And of course I hope we'll resolve the issue properly and can then re-enable the tests.