### PR TITLE
GIT-Fans: compute the symmetry group of the Q-matrix

### DIFF
--- a/docs/src/Groups/permgroup.md
+++ b/docs/src/Groups/permgroup.md
@@ -91,6 +91,7 @@ blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
 maximal_blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
 minimal_block_reps(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
 all_blocks(G::PermGroup)
+subgroup_property(prop::Function, G::PermGroup)
 ```
 
 ## Cycle structures

--- a/docs/src/Groups/permgroup.md
+++ b/docs/src/Groups/permgroup.md
@@ -91,7 +91,7 @@ blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
 maximal_blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
 minimal_block_reps(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
 all_blocks(G::PermGroup)
-subgroup_property(prop::Function, G::PermGroup)
+subgroup_by_property(prop::Function, G::PermGroup)
 ```
 
 ## Cycle structures

--- a/experimental/GITFans/src/GITFans.jl
+++ b/experimental/GITFans/src/GITFans.jl
@@ -101,7 +101,7 @@ function is_monomial_free(I::MPolyIdeal, vars_to_zero::Vector{Int} = Int[])
 end
 
 """
-    orbit_cones(I::MPolyIdeal, Q::Matrix{Int}, G::PermGroup = symmetric_group(1))
+    orbit_cones(I::MPolyIdeal, Q::QQMatrix, G::PermGroup = symmetric_group(1))
 
 Return orbit representatives of `G` on the set of those cones
 whose defining rays are given by subsets `S` of the rows of `Q`,
@@ -109,7 +109,7 @@ such that the matrix `S` has full rank and such that `I` is
 monomial-free (see [`is_monomial_free`](@ref)) w.r.t. the variables `x_i`
 for which the `i`-th row of `Q` is not contained in `S`.
 """
-function orbit_cones(I::MPolyIdeal, Q::Matrix{Int}, G::PermGroup = symmetric_group(1))
+function orbit_cones(I::MPolyIdeal, Q::QQMatrix, G::PermGroup = symmetric_group(1))
     nr_variables, projected_dimension = size(Q)
 
     collector_cones = Cone{QQFieldElem}[]
@@ -145,8 +145,42 @@ end
 #T what if some projections lie in the same orbit?
 #T later we expand the orbits, do we want to check this here?
 
+
 @doc raw"""
-    action_on_target(Q::Matrix{Int}, G::PermGroup)
+    symmetry_group_q_matrix(Q::QQMatrix)
+
+Return the group of those permutations $\pi$ of degree `size(Q, 1)`
+such that permuting the rows of `Q` with $\pi$ has the same effect
+as multiplying `Q` from the right with a matrix over `QQ`.
+
+# Examples
+
+```jldoctest
+julia> Q = matrix(QQ, [ 1  1 ; -1  1 ; -1 -1 ; 1 -1 ])
+[ 1    1]
+[-1    1]
+[-1   -1]
+[ 1   -1]
+
+julia> S, emb = symmetry_group_qmatrix(Q);
+
+julia> describe(S)
+"D8"
+```
+"""
+function symmetry_group_q_matrix(Q::QQMatrix)
+  n = ncols(Q)
+  prop = function(elm)
+    Qimg = Q[Vector{Int}(elm), 1:n]  # permute the rows with `pi`
+    return can_solve(Q, Qimg)
+  end
+  G = symmetric_group(nrows(Q))
+  return subgroup_property(prop, G)
+end
+
+
+@doc raw"""
+    action_on_target(Q::QQMatrix, G::PermGroup)
 
 Let `Q` be an $n \times m$ Q-matrix, and `G` be a permutation group
 on $n$ points that describes an action on the rows of `Q`.
@@ -156,17 +190,17 @@ to its induced matrix action on the $m$-dimensional space over the Rationals.
 # Examples
 
 ```jldoctest
-julia> Q = [
-        1  1   0   0   0
-        1  0   1   1   0
-        1  0   1   0   1
-        1  0   0   1   1
-        0  1   0   0  -1
-        0  1   0  -1   0
-        0  1  -1   0   0
-        0  0   1   0   0
-        0  0   0   1   0
-        0  0   0   0   1 ];
+julia> Q = matrix(QQ, [
+        1  1   0   0   0 ;
+        1  0   1   1   0 ;
+        1  0   1   0   1 ;
+        1  0   0   1   1 ;
+        0  1   0   0  -1 ;
+        0  1   0  -1   0 ;
+        0  1  -1   0   0 ;
+        0  0   1   0   0 ;
+        0  0   0   1   0 ;
+        0  0   0   0   1 ] );
 
 julia> n = nrows(Q)
 10
@@ -196,18 +230,17 @@ The cone defined by $Q{J}$ is mapped to
 $Q{J} \cdot \rho(\pi^{-1}) = (Q \cdot \rho(\pi^{-1}))\{J\} = Q^\pi\{J\}$,
 which is equal to $Q\{J^{\pi^{-1}}\}$.
 """
-function action_on_target(Q::Matrix{Int}, G::PermGroup)
+function action_on_target(Q::QQMatrix, G::PermGroup)
 
     # For each permutation generator describing the action on the rows of Q,
     # compute the induced action on the column space,
     # by solving a linear equation system.
     m, n = size(Q)
-    mat = matrix(QQ, Q)
     permgens = gens(G)
-    matgens = typeof(mat)[]
+    matgens = typeof(Q)[]
     for ppi in permgens
-      matimg = mat[Vector{Int}(ppi), 1:n]  # permute the rows with `ppi`
-      push!(matgens, solve(mat, matimg))
+      matimg = Q[Vector{Int}(ppi), 1:n]  # permute the rows with `ppi`
+      push!(matgens, solve(Q, matimg))
     end
 
     # Create the matrix group.
@@ -557,12 +590,12 @@ end
 
 
 """
-    git_fan(a::MPolyIdeal, Q::Matrix{Int}, G::PermGroup)
+    git_fan(a::MPolyIdeal, Q::QQMatrix, G::PermGroup)
 
 Return the object that represents the polyhedral fan given by
 the ideal `a`, the grading matrix `Q`, and the symmetry group `G`.
 """
-function git_fan(a::MPolyIdeal, Q::Matrix{Int}, G::PermGroup)
+function git_fan(a::MPolyIdeal, Q::QQMatrix, G::PermGroup)
     collector_cones = orbit_cones(a, Q, G)
     matrix_action = action_on_target(Q, G)
     orbit_list = orbit_cone_orbits(collector_cones, matrix_action)

--- a/experimental/GITFans/src/GITFans.jl
+++ b/experimental/GITFans/src/GITFans.jl
@@ -162,7 +162,7 @@ julia> Q = matrix(QQ, [ 1  1 ; -1  1 ; -1 -1 ; 1 -1 ])
 [-1   -1]
 [ 1   -1]
 
-julia> S, emb = symmetry_group_qmatrix(Q);
+julia> S, emb = symmetry_group_q_matrix(Q);
 
 julia> describe(S)
 "D8"

--- a/experimental/GITFans/src/GITFans.jl
+++ b/experimental/GITFans/src/GITFans.jl
@@ -162,7 +162,7 @@ julia> Q = matrix(QQ, [ 1  1 ; -1  1 ; -1 -1 ; 1 -1 ])
 [-1   -1]
 [ 1   -1]
 
-julia> S, emb = symmetry_group_q_matrix(Q);
+julia> S, emb = Oscar.GITFans.symmetry_group_q_matrix(Q);
 
 julia> describe(S)
 "D8"

--- a/experimental/GITFans/src/GITFans.jl
+++ b/experimental/GITFans/src/GITFans.jl
@@ -175,7 +175,7 @@ function symmetry_group_q_matrix(Q::QQMatrix)
     return can_solve(Q, Qimg)
   end
   G = symmetric_group(nrows(Q))
-  return subgroup_property(prop, G)
+  return subgroup_by_property(prop, G)
 end
 
 

--- a/experimental/GITFans/test/runtests.jl
+++ b/experimental/GITFans/test/runtests.jl
@@ -3,23 +3,25 @@
     using Oscar
     using Oscar.GITFans
 
-    Q = [
-     1  1   0   0   0
-     1  0   1   1   0
-     1  0   1   0   1
-     1  0   0   1   1
-     0  1   0   0  -1
-     0  1   0  -1   0
-     0  1  -1   0   0
-     0  0   1   0   0
-     0  0   0   1   0
+    Qint = [
+     1  1   0   0   0 ;
+     1  0   1   1   0 ;
+     1  0   1   0   1 ;
+     1  0   0   1   1 ;
+     0  1   0   0  -1 ;
+     0  1   0  -1   0 ;
+     0  1  -1   0   0 ;
+     0  0   1   0   0 ;
+     0  0   0   1   0 ;
      0  0   0   0   1
      ]
+
+    Q = matrix(QQ, Qint)
 
     n = nrows(Q)
     Qt, T = polynomial_ring(QQ, :T => 1:n)
     D = free_abelian_group(ncols(Q))
-    w = [D(Q[i, :]) for i = 1:n]
+    w = [D(Qint[i, :]) for i = 1:n]
     R, T = grade(Qt, w)
     a = ideal([
         T[5]*T[10] - T[6]*T[9] + T[7]*T[8],
@@ -29,9 +31,12 @@
         T[2]*T[10] - T[3]*T[9] + T[4]*T[8],
     ])
 
-    perms_list = [ [1,3,2,4,6,5,7,8,10,9], [5,7,1,6,9,2,8,4,10,3] ];
-    sym = symmetric_group(n);
-    G, emb = sub([sym(x) for x in perms_list]...);
+    # Compute the symmetry group of `Q`,
+    # check that it is equal to the group claimed in the paper.
+    # (The function returns different generators.)
+    G, emb = GITFans.symmetry_group_q_matrix(Q)
+    @test describe(G) == "S5"
+    @test G == sub(G([1,3,2,4,6,5,7,8,10,9]), G([5,7,1,6,9,2,8,4,10,3]))[1]
 
     fanobj = GITFans.git_fan(a, Q, G)
     @test f_vector(fanobj) == [20, 110, 240, 225, 76]

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -265,6 +265,7 @@ GAP.@wrap SizesConjugacyClasses(x::GapObj)::GapObj
 GAP.@wrap Source(x::GapObj)::GapObj
 GAP.@wrap Sqrt(x::Int64)::GAP.Obj
 GAP.@wrap StringViewObj(x::Any)::GapObj
+GAP.@wrap SubgroupProperty(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap SymmetricParts(x::GapObj, y::GapObj, z::GapInt)::GapObj
 GAP.@wrap Symmetrizations(x::GapObj, y::GapObj, z::GapInt)::GapObj
 GAP.@wrap SymplecticComponents(x::GapObj, y::GapObj, z::GapInt)::GapObj

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1311,13 +1311,15 @@ end
 ################################################################################
 
 """
-    subgroup_property(prop::Function, G:: PermGroup)
+    subgroup_by_property(prop::Function, G::PermGroup)
 
 Return the subgroup of all those elements `g` in `G` for which `prop(g)`
 is `true`.
 
 For that, `prop(g)` must be `true` or `false` for each `g` in `G`,
 and the set of those `g` with `prop(g) == true` must form a group.
+However, this is *not* checked and if violated, results of operations
+with the resulting "group" object are unpredictable.
 
 # Examples
 ```jldoctest
@@ -1326,11 +1328,11 @@ julia> G = symmetric_group(4);  x = gen(G, 2)
 
 julia> prop = g -> g*x == x*g;  # centralizer of x
 
-julia> describe(subgroup_property(prop, G)[1])
+julia> describe(subgroup_by_property(prop, G)[1])
 "C2 x C2"
 ```
 """
-function subgroup_property(prop::Function, G:: PermGroup)
+function subgroup_by_property(prop::Function, G::PermGroup)
    gapprop = GAP.WrapJuliaFunc(gapelm -> prop(group_element(G, gapelm)))
    S = GAPWrap.SubgroupProperty(G.X, gapprop)
    return _as_subgroup(G, S)

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1306,6 +1306,39 @@ end
 
 ################################################################################
 #
+# Subgroups defined by properties
+#
+################################################################################
+
+"""
+    subgroup_property(prop::Function, G:: PermGroup)
+
+Return the subgroup of all those elements `g` in `G` for which `prop(g)`
+is `true`.
+
+For that, `prop(g)` must be `true` or `false` for each `g` in `G`,
+and the set of those `g` with `prop(g) == true` must form a group.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(4);  x = gen(G, 2)
+(1,2)
+
+julia> prop = g -> g*x == x*g;  # centralizer of x
+
+julia> describe(subgroup_property(prop, G)[1])
+"C2 x C2"
+```
+"""
+function subgroup_property(prop::Function, G:: PermGroup)
+   gapprop = GAP.WrapJuliaFunc(gapelm -> prop(group_element(G, gapelm)))
+   S = GAPWrap.SubgroupProperty(G.X, gapprop)
+   return _as_subgroup(G, S)
+end
+
+
+################################################################################
+#
 # Some Properties
 #
 ################################################################################

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1357,7 +1357,7 @@ export structure_tropical_jacobian
 export sub
 export subalgebra_membership
 export subalgebra_membership_homogeneous
-export subgroup_property
+export subgroup_by_property
 export subgroup_reps
 export subquo_type
 export subquotient

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1357,6 +1357,7 @@ export structure_tropical_jacobian
 export sub
 export subalgebra_membership
 export subalgebra_membership_homogeneous
+export subgroup_property
 export subgroup_reps
 export subquo_type
 export subquotient

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -331,6 +331,19 @@ end
    
 end
 
+@testset "Subgroups of perm. groups defined by properties" begin
+   G = symmetric_group(4)
+   S = subgroup_property(is_one, G)[1]
+   @test order(S) == 1
+   S = subgroup_property(x -> isa(x, PermGroupElem), G)[1]
+   @test order(S) == order(G)
+   S = subgroup_property(x -> sign(x) == 1, G)[1]
+   index = all(x -> sign(x) == 1, gens(G)) ? 1 : 2
+   @test index * order(S) == order(G)
+
+   @test_throws MethodError subgroup_property(is_one, small_group(2, 1))
+end
+
 @testset "Complement classes" begin
    # solvable group
    G = symmetric_group(4)

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -333,15 +333,15 @@ end
 
 @testset "Subgroups of perm. groups defined by properties" begin
    G = symmetric_group(4)
-   S = subgroup_property(is_one, G)[1]
+   S = subgroup_by_property(is_one, G)[1]
    @test order(S) == 1
-   S = subgroup_property(x -> isa(x, PermGroupElem), G)[1]
+   S = subgroup_by_property(x -> isa(x, PermGroupElem), G)[1]
    @test order(S) == order(G)
-   S = subgroup_property(x -> sign(x) == 1, G)[1]
+   S = subgroup_by_property(x -> sign(x) == 1, G)[1]
    index = all(x -> sign(x) == 1, gens(G)) ? 1 : 2
    @test index * order(S) == order(G)
 
-   @test_throws MethodError subgroup_property(is_one, small_group(2, 1))
+   @test_throws MethodError subgroup_by_property(is_one, small_group(2, 1))
 end
 
 @testset "Complement classes" begin


### PR DESCRIPTION
- Add `subgroup_property` to Oscar.

- Use `subgroup_property` in the GIT-Fans stuff for computing the symmetry group of the Q-matrix.
  (@fieker had suggested to compute the symmetries instead of just prescribing and verifying them.)

- Distinguish between the matrix `Qint` of integers (which is needed for prescribing the grading) and the matrix `Q` of type `QQMatrix` (which is needed everywhere else).

- Require the type `QQMatrix` instead of `Matrix{Int}` for the argument `Q` of `orbit_cones`, `action_on_target`, `git_fan`.

- Change the input syntax of the matrix `Q` such that rows are separated by semicolons.
  (Julia admits the syntax where line breaks separate rows, but this has caused already some confusion.)

Some thoughts about further steps:

- @jankoboehm Is "Q-matrix" the correct technical term, and what would be a better function name than `symmetry_group_q_matrix`?

- Instead of computing just the permutation group, we could in fact regard the isomorphism from this group to the corresponding matrix group (that is acting from the right) as "the symmetry group" of the Q-matrix; this way, we could get rid of the function `action_on_target` whose name was already criticized.

  (With a permutation group `G` as an optional second argument, `symmetry_group_q_matrix(Q, G)` could then just compute the isomorphism from `G`, without trying to compute more symmetries.)

- We could change `git_fan` such that the symmetry group `G` is an optional argument, since we can compute the full symmetry group of `Q`.