### PR TITLE
LieAlgebras: Adapt some tests

### DIFF
--- a/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
@@ -175,6 +175,12 @@ end
       lie_algebra_module_conformance_test(L, V)
     end
 
+    @testset "⋀^2 T^2 V of so_4(QQ)" begin
+      L = special_orthogonal_lie_algebra(QQ, 4)
+      V = exterior_power(tensor_power(standard_module(L), 2), 2)
+      lie_algebra_module_conformance_test(L, V)
+    end
+
     @testset "⋀^2 V of so_4(CF(4))" begin
       L = special_orthogonal_lie_algebra(cyclotomic_field(4)[1], 4)
       V = exterior_power(standard_module(L), 3)
@@ -183,7 +189,13 @@ end
 
     @testset "S^2 ⋀^2 V of so_4(QQ)" begin
       L = special_orthogonal_lie_algebra(QQ, 4)
-      V = tensor_power(symmetric_power(standard_module(L), 2), 2)
+      V = symmetric_power(exterior_power(standard_module(L), 2), 2)
+      lie_algebra_module_conformance_test(L, V)
+    end
+
+    @testset "S^2 T^2 V of so_4(QQ)" begin
+      L = special_orthogonal_lie_algebra(QQ, 4)
+      V = symmetric_power(tensor_power(standard_module(L), 2), 2)
       lie_algebra_module_conformance_test(L, V)
     end
 
@@ -196,6 +208,12 @@ end
     @testset "T^2 ⋀^2 V of sl_4(QQ)" begin
       L = special_linear_lie_algebra(QQ, 4)
       V = tensor_power(exterior_power(standard_module(L), 2), 2)
+      lie_algebra_module_conformance_test(L, V)
+    end
+
+    @testset "T^2 S^2 V of sl_4(QQ)" begin
+      L = special_linear_lie_algebra(QQ, 4)
+      V = tensor_power(symmetric_power(standard_module(L), 2), 2)
       lie_algebra_module_conformance_test(L, V)
     end
 
@@ -217,222 +235,230 @@ end
   )
 
   @testset "standard_module" begin
-    L = special_orthogonal_lie_algebra(QQ, 4)
-    V = standard_module(L)
-    @test dim(V) == 4
-    @test length(repr(V)) < 10^4 # outputs tend to be excessively long due to recursion
+    for (L, dimV) in
+        [(general_linear_lie_algebra(QQ, 3), 3), (special_orthogonal_lie_algebra(QQ, 4), 4)]
+      V = standard_module(L)
+      @test dim(V) == dimV
+      @test length(repr(V)) < 10^4 # outputs tend to be excessively long due to recursion
 
-    @test module_type_bools(V) == (true, false, false, false, false, false, false) # standard_module
+      @test module_type_bools(V) == (true, false, false, false, false, false, false) # standard_module
 
-    x = L(rand(-10:10, dim(L)))
-    v = V(rand(-10:10, dim(V)))
-    @test x * v == V(matrix_repr(x) * coefficients(v))
+      x = L(rand(-10:10, dim(L)))
+      v = V(rand(-10:10, dim(V)))
+      @test x * v == V(matrix_repr(x) * coefficients(v))
+    end
   end
 
   @testset "dual" begin
-    L = special_orthogonal_lie_algebra(QQ, 4)
-    V = symmetric_power(standard_module(L), 2)
-    type_V = module_type_bools(V)
+    for L in [general_linear_lie_algebra(QQ, 3), special_orthogonal_lie_algebra(QQ, 4)]
+      V = symmetric_power(standard_module(L), 2)
+      type_V = module_type_bools(V)
 
-    dual_V = dual(V)
-    @test type_V == module_type_bools(V) # construction of dual_V should not change type of V
-    @test base_module(dual_V) === V
-    @test dim(dual_V) == dim(V)
-    @test length(repr(dual_V)) < 10^4 # outputs tend to be excessively long due to recursion
+      dual_V = dual(V)
+      @test type_V == module_type_bools(V) # construction of dual_V should not change type of V
+      @test base_module(dual_V) === V
+      @test dim(dual_V) == dim(V)
+      @test length(repr(dual_V)) < 10^4 # outputs tend to be excessively long due to recursion
 
-    @test module_type_bools(dual_V) == (false, true, false, false, false, false, false) # dual
+      @test module_type_bools(dual_V) == (false, true, false, false, false, false, false) # dual
 
-    dual_dual_V = dual(dual_V)
-    @test dim(dual_dual_V) == dim(V)
-    @test all(
-      i ->
-        Oscar.LieAlgebras.transformation_matrix(dual_dual_V, i) ==
-        Oscar.LieAlgebras.transformation_matrix(V, i),
-      1:dim(L),
-    )
+      dual_dual_V = dual(dual_V)
+      @test dim(dual_dual_V) == dim(V)
+      @test all(
+        i ->
+          Oscar.LieAlgebras.transformation_matrix(dual_dual_V, i) ==
+          Oscar.LieAlgebras.transformation_matrix(V, i),
+        1:dim(L),
+      )
+    end
   end
 
   @testset "direct_sum" begin
-    L = special_orthogonal_lie_algebra(QQ, 4)
-    V = symmetric_power(standard_module(L), 2)
-    type_V = module_type_bools(V)
+    for L in [general_linear_lie_algebra(QQ, 3), special_orthogonal_lie_algebra(QQ, 4)]
+      V = symmetric_power(standard_module(L), 2)
+      type_V = module_type_bools(V)
 
-    for k in 1:3
-      ds_V = direct_sum([V for _ in 1:k]...)
-      @test type_V == module_type_bools(V) # construction of ds_V should not change type of V
-      @test base_modules(ds_V) == [V for _ in 1:k]
-      @test dim(ds_V) == k * dim(V)
+      for k in 1:3
+        ds_V = direct_sum([V for _ in 1:k]...)
+        @test type_V == module_type_bools(V) # construction of ds_V should not change type of V
+        @test base_modules(ds_V) == [V for _ in 1:k]
+        @test dim(ds_V) == k * dim(V)
+        @test length(repr(ds_V)) < 10^4 # outputs tend to be excessively long due to recursion
+
+        @test module_type_bools(ds_V) == (false, false, true, false, false, false, false) # direct_sum
+
+        x = L(rand(-10:10, dim(L)))
+        a = [V(rand(-10:10, dim(V))) for _ in 1:k]
+        @test ds_V([x * v for v in a]) == x * ds_V(a)
+      end
+
+      V1 = symmetric_power(standard_module(L), 2)
+      V2 = exterior_power(standard_module(L), 2)
+      type_V1 = module_type_bools(V1)
+      type_V2 = module_type_bools(V2)
+
+      ds_V = direct_sum(V1, V2)
+      @test type_V1 == module_type_bools(V1) # construction of ds_V should not change type of V1
+      @test type_V2 == module_type_bools(V2) # construction of ds_V should not change type of V2
+      @test base_modules(ds_V) == [V1, V2]
+      @test dim(ds_V) == dim(V1) + dim(V2)
       @test length(repr(ds_V)) < 10^4 # outputs tend to be excessively long due to recursion
 
       @test module_type_bools(ds_V) == (false, false, true, false, false, false, false) # direct_sum
 
       x = L(rand(-10:10, dim(L)))
-      a = [V(rand(-10:10, dim(V))) for _ in 1:k]
+      a = [Vi(rand(-10:10, dim(Vi))) for Vi in [V1, V2]]
       @test ds_V([x * v for v in a]) == x * ds_V(a)
     end
-
-    V1 = symmetric_power(standard_module(L), 2)
-    V2 = exterior_power(standard_module(L), 2)
-    type_V1 = module_type_bools(V1)
-    type_V2 = module_type_bools(V2)
-
-    ds_V = direct_sum(V1, V2)
-    @test type_V1 == module_type_bools(V1) # construction of ds_V should not change type of V1
-    @test type_V2 == module_type_bools(V2) # construction of ds_V should not change type of V2
-    @test base_modules(ds_V) == [V1, V2]
-    @test dim(ds_V) == dim(V1) + dim(V2)
-    @test length(repr(ds_V)) < 10^4 # outputs tend to be excessively long due to recursion
-
-    @test module_type_bools(ds_V) == (false, false, true, false, false, false, false) # direct_sum
-
-    x = L(rand(-10:10, dim(L)))
-    a = [Vi(rand(-10:10, dim(Vi))) for Vi in [V1, V2]]
-    @test ds_V([x * v for v in a]) == x * ds_V(a)
   end
 
   @testset "tensor_product" begin
-    L = special_orthogonal_lie_algebra(QQ, 4)
-    V = symmetric_power(standard_module(L), 2)
-    type_V = module_type_bools(V)
+    for L in [general_linear_lie_algebra(QQ, 3), special_orthogonal_lie_algebra(QQ, 4)]
+      V = symmetric_power(standard_module(L), 2)
+      type_V = module_type_bools(V)
 
-    for k in 1:3
-      tp_V = tensor_product([V for _ in 1:k]...)
-      @test type_V == module_type_bools(V) # construction of tp_V should not change type of V
-      @test base_modules(tp_V) == [V for _ in 1:k]
-      @test dim(tp_V) == dim(V)^k
+      for k in 1:3
+        tp_V = tensor_product([V for _ in 1:k]...)
+        @test type_V == module_type_bools(V) # construction of tp_V should not change type of V
+        @test base_modules(tp_V) == [V for _ in 1:k]
+        @test dim(tp_V) == dim(V)^k
+        @test length(repr(tp_V)) < 10^4 # outputs tend to be excessively long due to recursion
+
+        @test module_type_bools(tp_V) == (false, false, false, true, false, false, false) # tensor_product
+
+        x = L(rand(-10:10, dim(L)))
+        a = [V(rand(-10:10, dim(V))) for _ in 1:k]
+        @test sum(tp_V([i == j ? x * v : v for (j, v) in enumerate(a)]) for i in 1:k) == x * tp_V(a)
+
+        @test tp_V == tensor_power(V, k)
+      end
+
+      V1 = symmetric_power(standard_module(L), 2)
+      V2 = exterior_power(standard_module(L), 2)
+      type_V1 = module_type_bools(V1)
+      type_V2 = module_type_bools(V2)
+
+      tp_V = tensor_product(V1, V2)
+      @test type_V1 == module_type_bools(V1) # construction of tp_V should not change type of V1
+      @test type_V2 == module_type_bools(V2) # construction of tp_V should not change type of V2
+      @test base_modules(tp_V) == [V1, V2]
+      @test dim(tp_V) == dim(V1) * dim(V2)
       @test length(repr(tp_V)) < 10^4 # outputs tend to be excessively long due to recursion
 
       @test module_type_bools(tp_V) == (false, false, false, true, false, false, false) # tensor_product
 
       x = L(rand(-10:10, dim(L)))
-      a = [V(rand(-10:10, dim(V))) for _ in 1:k]
-      @test sum(tp_V([i == j ? x * v : v for (j, v) in enumerate(a)]) for i in 1:k) == x * tp_V(a)
-
-      @test tp_V == tensor_power(V, k)
+      a = [Vi(rand(-10:10, dim(Vi))) for Vi in [V1, V2]]
+      @test sum(tp_V([i == j ? x * v : v for (j, v) in enumerate(a)]) for i in 1:2) == x * tp_V(a)
     end
-
-    V1 = symmetric_power(standard_module(L), 2)
-    V2 = exterior_power(standard_module(L), 2)
-    type_V1 = module_type_bools(V1)
-    type_V2 = module_type_bools(V2)
-
-    tp_V = tensor_product(V1, V2)
-    @test type_V1 == module_type_bools(V1) # construction of tp_V should not change type of V1
-    @test type_V2 == module_type_bools(V2) # construction of tp_V should not change type of V2
-    @test base_modules(tp_V) == [V1, V2]
-    @test dim(tp_V) == dim(V1) * dim(V2)
-    @test length(repr(tp_V)) < 10^4 # outputs tend to be excessively long due to recursion
-
-    @test module_type_bools(tp_V) == (false, false, false, true, false, false, false) # tensor_product
-
-    x = L(rand(-10:10, dim(L)))
-    a = [Vi(rand(-10:10, dim(Vi))) for Vi in [V1, V2]]
-    @test sum(tp_V([i == j ? x * v : v for (j, v) in enumerate(a)]) for i in 1:2) == x * tp_V(a)
   end
 
   @testset "exterior_power" begin
-    L = special_orthogonal_lie_algebra(QQ, 4)
-    V = symmetric_power(standard_module(L), 2)
-    type_V = module_type_bools(V)
+    for L in [general_linear_lie_algebra(QQ, 3), special_orthogonal_lie_algebra(QQ, 4)]
+      V = symmetric_power(standard_module(L), 2)
+      type_V = module_type_bools(V)
 
-    for k in 1:3
-      E = exterior_power(V, k)
-      @test type_V == module_type_bools(V) # construction of pow_V should not change type of V
-      @test base_module(E) === V
-      @test dim(E) == binomial(dim(V), k)
-      @test length(repr(E)) < 10^4 # outputs tend to be excessively long due to recursion
+      for k in 1:3
+        E = exterior_power(V, k)
+        @test type_V == module_type_bools(V) # construction of pow_V should not change type of V
+        @test base_module(E) === V
+        @test dim(E) == binomial(dim(V), k)
+        @test length(repr(E)) < 10^4 # outputs tend to be excessively long due to recursion
 
-      @test module_type_bools(E) == (false, false, false, false, true, false, false) # exterior_power
+        @test module_type_bools(E) == (false, false, false, false, true, false, false) # exterior_power
 
-      if k == 1
-        x = L(rand(-10:10, dim(L)))
-        a = V(rand(-10:10, dim(V)))
-        @test E([x * a]) == x * E([a])
-      elseif k == 2
-        a = V(rand(-10:10, dim(V)))
-        b = V(rand(-10:10, dim(V)))
-        @test !iszero(E([a, b]))
-        @test iszero(E([a, b]) + E([b, a]))
-        @test !iszero(E([a, b]) - E([b, a]))
-        @test iszero(E([a, a]))
+        if k == 1
+          x = L(rand(-10:10, dim(L)))
+          a = V(rand(-10:10, dim(V)))
+          @test E([x * a]) == x * E([a])
+        elseif k == 2
+          a = V(rand(-10:10, dim(V)))
+          b = V(rand(-10:10, dim(V)))
+          @test !iszero(E([a, b]))
+          @test iszero(E([a, b]) + E([b, a]))
+          @test !iszero(E([a, b]) - E([b, a]))
+          @test iszero(E([a, a]))
+        end
+
+        T = get_attribute(E, :embedding_tensor_power)
+        E_to_T = get_attribute(E, :embedding_tensor_power_embedding)
+        T_to_E = get_attribute(E, :embedding_tensor_power_projection)
+        @test T == tensor_power(V, k)
+        @test domain(E_to_T) === E
+        @test codomain(E_to_T) === T
+        @test domain(T_to_E) === T
+        @test codomain(T_to_E) === E
+        @test compose(E_to_T, T_to_E) == identity_map(E)
       end
-
-      T = get_attribute(E, :embedding_tensor_power)
-      E_to_T = get_attribute(E, :embedding_tensor_power_embedding)
-      T_to_E = get_attribute(E, :embedding_tensor_power_projection)
-      @test T == tensor_power(V, k)
-      @test domain(E_to_T) === E
-      @test codomain(E_to_T) === T
-      @test domain(T_to_E) === T
-      @test codomain(T_to_E) === E
-      @test compose(E_to_T, T_to_E) == identity_map(E)
     end
   end
 
   @testset "symmetric_power" begin
-    L = special_orthogonal_lie_algebra(QQ, 4)
-    V = exterior_power(standard_module(L), 2)
-    type_V = module_type_bools(V)
+    for L in [general_linear_lie_algebra(QQ, 3), special_orthogonal_lie_algebra(QQ, 4)]
+      V = exterior_power(standard_module(L), 2)
+      type_V = module_type_bools(V)
 
-    for k in 1:3
-      S = symmetric_power(V, k)
-      @test type_V == module_type_bools(V) # construction of pow_V should not change type of V
-      @test base_module(S) === V
-      @test dim(S) == binomial(dim(V) + k - 1, k)
-      @test length(repr(S)) < 10^4 # outputs tend to be excessively long due to recursion
+      for k in 1:3
+        S = symmetric_power(V, k)
+        @test type_V == module_type_bools(V) # construction of pow_V should not change type of V
+        @test base_module(S) === V
+        @test dim(S) == binomial(dim(V) + k - 1, k)
+        @test length(repr(S)) < 10^4 # outputs tend to be excessively long due to recursion
 
-      @test module_type_bools(S) == (false, false, false, false, false, true, false) # symmetric_power
+        @test module_type_bools(S) == (false, false, false, false, false, true, false) # symmetric_power
 
-      if k == 1
-        x = L(rand(-10:10, dim(L)))
-        a = V(rand(-10:10, dim(V)))
-        @test S([x * a]) == x * S([a])
-      elseif k == 2
-        a = V(rand(-10:10, dim(V)))
-        b = V(rand(-10:10, dim(V)))
-        @test !iszero(S([a, b]))
-        @test !iszero(S([a, b]) + S([b, a]))
-        @test iszero(S([a, b]) - S([b, a]))
-        @test !iszero(S([a, a]))
+        if k == 1
+          x = L(rand(-10:10, dim(L)))
+          a = V(rand(-10:10, dim(V)))
+          @test S([x * a]) == x * S([a])
+        elseif k == 2
+          a = V(rand(-10:10, dim(V)))
+          b = V(rand(-10:10, dim(V)))
+          @test !iszero(S([a, b]))
+          @test !iszero(S([a, b]) + S([b, a]))
+          @test iszero(S([a, b]) - S([b, a]))
+          @test !iszero(S([a, a]))
+        end
+
+        T = get_attribute(S, :embedding_tensor_power)
+        S_to_T = get_attribute(S, :embedding_tensor_power_embedding)
+        T_to_S = get_attribute(S, :embedding_tensor_power_projection)
+        @test T == tensor_power(V, k)
+        @test domain(S_to_T) === S
+        @test codomain(S_to_T) === T
+        @test domain(T_to_S) === T
+        @test codomain(T_to_S) === S
+        @test compose(S_to_T, T_to_S) == identity_map(S)
       end
-
-      T = get_attribute(S, :embedding_tensor_power)
-      S_to_T = get_attribute(S, :embedding_tensor_power_embedding)
-      T_to_S = get_attribute(S, :embedding_tensor_power_projection)
-      @test T == tensor_power(V, k)
-      @test domain(S_to_T) === S
-      @test codomain(S_to_T) === T
-      @test domain(T_to_S) === T
-      @test codomain(T_to_S) === S
-      @test compose(S_to_T, T_to_S) == identity_map(S)
     end
   end
 
   @testset "tensor_power" begin
-    L = special_orthogonal_lie_algebra(QQ, 4)
-    V = standard_module(L)
-    T = module_type_bools(V)
+    for L in [general_linear_lie_algebra(QQ, 3), special_orthogonal_lie_algebra(QQ, 4)]
+      V = standard_module(L)
+      T = module_type_bools(V)
 
-    for k in 1:3
-      pow_V = tensor_power(V, k)
-      @test T == module_type_bools(V) # construction of pow_V should not change type of V
-      @test base_module(pow_V) === V
-      @test dim(pow_V) == dim(V)^k
-      @test length(repr(pow_V)) < 10^4 # outputs tend to be excessively long due to recursion
+      for k in 1:3
+        pow_V = tensor_power(V, k)
+        @test T == module_type_bools(V) # construction of pow_V should not change type of V
+        @test base_module(pow_V) === V
+        @test dim(pow_V) == dim(V)^k
+        @test length(repr(pow_V)) < 10^4 # outputs tend to be excessively long due to recursion
 
-      @test module_type_bools(pow_V) == (false, false, false, false, false, false, true) # tensor_power
+        @test module_type_bools(pow_V) == (false, false, false, false, false, false, true) # tensor_power
 
-      if k == 1
-        x = L(rand(-10:10, dim(L)))
-        a = V(rand(-10:10, dim(V)))
-        @test pow_V([x * a]) == x * pow_V([a])
-      elseif k == 2
-        a = V(rand(-10:10, dim(V)))
-        b = V(rand(-10:10, dim(V)))
-        @test !iszero(pow_V([a, b]))
-        @test !iszero(pow_V([a, b]) + pow_V([b, a]))
-        @test !iszero(pow_V([a, b]) - pow_V([b, a]))
-        @test !iszero(pow_V([a, a]))
+        if k == 1
+          x = L(rand(-10:10, dim(L)))
+          a = V(rand(-10:10, dim(V)))
+          @test pow_V([x * a]) == x * pow_V([a])
+        elseif k == 2
+          a = V(rand(-10:10, dim(V)))
+          b = V(rand(-10:10, dim(V)))
+          @test !iszero(pow_V([a, b]))
+          @test !iszero(pow_V([a, b]) + pow_V([b, a]))
+          @test !iszero(pow_V([a, b]) - pow_V([b, a]))
+          @test !iszero(pow_V([a, a]))
+        end
       end
     end
   end


### PR DESCRIPTION
Extracts some changes from https://github.com/oscar-system/Oscar.jl/pull/2844 that had nothing to do with sparse data structures: Make one test consistent with its testset label, and add a few more test cases that helped in https://github.com/oscar-system/Oscar.jl/pull/2844 to spot errors in the implementation. Even as https://github.com/oscar-system/Oscar.jl/pull/2844 is discontinued, they might be of benefit in the future.