### PR TITLE
LieAlgebras: Restrict to work over fields only 

### DIFF
--- a/experimental/LieAlgebras/docs/src/ideals_and_subalgebras.md
+++ b/experimental/LieAlgebras/docs/src/ideals_and_subalgebras.md
@@ -20,7 +20,7 @@ dim(::LieAlgebraIdeal)
 basis(::LieAlgebraIdeal)
 basis(::LieAlgebraIdeal, ::Int)
 Base.in(::LieAlgebraElem, ::LieAlgebraIdeal)
-bracket(::LieAlgebraIdeal{C,LieT}, ::LieAlgebraIdeal{C,LieT}) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+bracket(::LieAlgebraIdeal{C,LieT}, ::LieAlgebraIdeal{C,LieT}) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
 normalizer(::LieAlgebra, ::LieAlgebraIdeal)
 centralizer(::LieAlgebra, ::LieAlgebraIdeal)
 ```
@@ -32,7 +32,7 @@ dim(::LieSubalgebra)
 basis(::LieSubalgebra)
 basis(::LieSubalgebra, ::Int)
 Base.in(::LieAlgebraElem, ::LieSubalgebra)
-bracket(::LieSubalgebra{C,LieT}, ::LieSubalgebra{C,LieT}) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+bracket(::LieSubalgebra{C,LieT}, ::LieSubalgebra{C,LieT}) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
 normalizer(::LieAlgebra, ::LieSubalgebra)
 centralizer(::LieAlgebra, ::LieSubalgebra)
 is_self_normalizing(S::LieSubalgebra)
@@ -44,7 +44,7 @@ is_self_normalizing(S::LieSubalgebra)
 
 ```@docs
 ideal(::LieAlgebra, ::Vector; is_basis::Bool=false)
-ideal(::LieAlgebra{C}, ::LieAlgebraElem{C}) where {C<:RingElement}
+ideal(::LieAlgebra{C}, ::LieAlgebraElem{C}) where {C<:FieldElem}
 ideal(::LieAlgebra)
 ```
 
@@ -52,7 +52,7 @@ ideal(::LieAlgebra)
 
 ```@docs
 sub(::LieAlgebra, ::Vector; is_basis::Bool=false)
-sub(::LieAlgebra{C}, ::LieAlgebraElem{C}) where {C<:RingElement}
+sub(::LieAlgebra{C}, ::LieAlgebraElem{C}) where {C<:FieldElem}
 sub(::LieAlgebra)
 ```
 
@@ -61,5 +61,5 @@ sub(::LieAlgebra)
 ```@docs
 lie_algebra(::LieSubalgebra)
 lie_algebra(::LieAlgebraIdeal)
-sub(::LieAlgebra{C}, ::LieAlgebraIdeal{C}) where {C<:RingElement}
+sub(::LieAlgebra{C}, ::LieAlgebraIdeal{C}) where {C<:FieldElem}
 ```

--- a/experimental/LieAlgebras/docs/src/lie_algebra_homs.md
+++ b/experimental/LieAlgebras/docs/src/lie_algebra_homs.md
@@ -16,10 +16,10 @@ Lie algebra homomorphisms $h: L_1 \to L_2$ are constructed by providing either
 the images of the basis elements of $L_1$ or a $\dim L_1 \times \dim L_2$ matrix.
 
 ```@docs
-hom(::LieAlgebra{C}, ::LieAlgebra{C}, ::Vector{<:LieAlgebraElem{C}}; check::Bool=true) where {C<:RingElement}
-hom(::LieAlgebra{C}, ::LieAlgebra{C}, ::MatElem{C}; check::Bool=true) where {C<:RingElement}
+hom(::LieAlgebra{C}, ::LieAlgebra{C}, ::Vector{<:LieAlgebraElem{C}}; check::Bool=true) where {C<:FieldElem}
+hom(::LieAlgebra{C}, ::LieAlgebra{C}, ::MatElem{C}; check::Bool=true) where {C<:FieldElem}
 identity_map(::LieAlgebra)
-zero_map(::LieAlgebra{C}, ::LieAlgebra{C}) where {C<:RingElement}
+zero_map(::LieAlgebra{C}, ::LieAlgebra{C}) where {C<:FieldElem}
 ```
 
 ## Functions
@@ -30,7 +30,7 @@ The following functions are available for `LieAlgebraHom`s:
 For a homomorphism $h: L_1 \to L_2$, `domain(h)` and `codomain(h)` return $L_1$ and $L_2$ respectively.
 
 ```@docs
-matrix(::LieAlgebraHom{<:LieAlgebra,<:LieAlgebra{C2}}) where {C2<:RingElement}
+matrix(::LieAlgebraHom{<:LieAlgebra,<:LieAlgebra{C2}}) where {C2<:FieldElem}
 ```
 
 ### Image

--- a/experimental/LieAlgebras/docs/src/lie_algebras.md
+++ b/experimental/LieAlgebras/docs/src/lie_algebras.md
@@ -29,10 +29,10 @@ symbols(::LieAlgebra)
 ## Special functions for `LinearLieAlgebra`s
 
 ```@docs
-coerce_to_lie_algebra_elem(::LinearLieAlgebra{C}, ::MatElem{C}) where {C<:RingElement}
-matrix_repr_basis(::LinearLieAlgebra{C}) where {C<:RingElement}
-matrix_repr_basis(::LinearLieAlgebra{C}, ::Int) where {C<:RingElement}
-matrix_repr(::LinearLieAlgebraElem{C}) where {C<:RingElement}
+coerce_to_lie_algebra_elem(::LinearLieAlgebra{C}, ::MatElem{C}) where {C<:FieldElem}
+matrix_repr_basis(::LinearLieAlgebra{C}) where {C<:FieldElem}
+matrix_repr_basis(::LinearLieAlgebra{C}, ::Int) where {C<:FieldElem}
+matrix_repr(::LinearLieAlgebraElem{C}) where {C<:FieldElem}
 ```
 
 ## Element constructors

--- a/experimental/LieAlgebras/docs/src/lie_algebras.md
+++ b/experimental/LieAlgebras/docs/src/lie_algebras.md
@@ -83,10 +83,10 @@ lie_algebra
 ## Classical Lie algebras
 
 ```@docs
-abelian_lie_algebra(R::Ring, n::Int)
-general_linear_lie_algebra(R::Ring, n::Int)
-special_linear_lie_algebra(R::Ring, n::Int)
-special_orthogonal_lie_algebra(R::Ring, n::Int)
+abelian_lie_algebra(R::Field, n::Int)
+general_linear_lie_algebra(R::Field, n::Int)
+special_linear_lie_algebra(R::Field, n::Int)
+special_orthogonal_lie_algebra(R::Field, n::Int)
 ```
 
 ## Relation to GAP Lie algebras

--- a/experimental/LieAlgebras/docs/src/module_homs.md
+++ b/experimental/LieAlgebras/docs/src/module_homs.md
@@ -17,10 +17,10 @@ $h: V_1 \to V_2$ are constructed by providing either the images of the basis ele
 or a $\dim V_1 \times \dim V_2$ matrix.
 
 ```@docs
-hom(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::Vector{<:LieAlgebraModuleElem{C}}; check::Bool=true) where {C<:RingElement}
-hom(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::MatElem{C}; check::Bool=true) where {C<:RingElement}
+hom(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::Vector{<:LieAlgebraModuleElem{C}}; check::Bool=true) where {C<:FieldElem}
+hom(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::MatElem{C}; check::Bool=true) where {C<:FieldElem}
 identity_map(::LieAlgebraModule)
-zero_map(::LieAlgebraModule{C}, ::LieAlgebraModule{C}) where {C<:RingElement}
+zero_map(::LieAlgebraModule{C}, ::LieAlgebraModule{C}) where {C<:FieldElem}
 ```
 
 ## Functions
@@ -31,7 +31,7 @@ The following functions are available for `LieAlgebraModuleHom`s:
 For a homomorphism $h: V_1 \to V_2$, `domain(h)` and `codomain(h)` return $V_1$ and $V_2$ respectively.
 
 ```@docs
-matrix(::LieAlgebraModuleHom{<:LieAlgebraModule,<:LieAlgebraModule{C2}}) where {C2<:RingElement}
+matrix(::LieAlgebraModuleHom{<:LieAlgebraModule,<:LieAlgebraModule{C2}}) where {C2<:FieldElem}
 ```
 
 ### Image
@@ -58,7 +58,7 @@ canonical_injections(::LieAlgebraModule)
 canonical_injection(::LieAlgebraModule, ::Int)
 canonical_projections(::LieAlgebraModule)
 canonical_projection(::LieAlgebraModule, ::Int)
-hom_direct_sum(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::Matrix{<:LieAlgebraModuleHom}) where {C<:RingElement}
-hom_tensor(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::Vector{<:LieAlgebraModuleHom}) where {C<:RingElement}
-hom_power(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::LieAlgebraModuleHom) where {C<:RingElement}
+hom_direct_sum(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::Matrix{<:LieAlgebraModuleHom}) where {C<:FieldElem}
+hom_tensor(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::Vector{<:LieAlgebraModuleHom}) where {C<:FieldElem}
+hom_power(::LieAlgebraModule{C}, ::LieAlgebraModule{C}, ::LieAlgebraModuleHom) where {C<:FieldElem}
 ```

--- a/experimental/LieAlgebras/docs/src/modules.md
+++ b/experimental/LieAlgebras/docs/src/modules.md
@@ -46,7 +46,7 @@ The usual arithmetics, e.g. `+`, `-`, and `*` (scalar multiplication), are defin
 
 The module action is defined as `*`.
 ```@docs
-*(x::LieAlgebraElem{C}, v::LieAlgebraModuleElem{C}) where {C<:RingElement}
+*(x::LieAlgebraElem{C}, v::LieAlgebraModuleElem{C}) where {C<:FieldElem}
 ```
 
 ## Module constructors
@@ -54,14 +54,14 @@ The module action is defined as `*`.
 ```@docs
 trivial_module(L::LieAlgebra, d::IntegerUnion=1)
 standard_module(::LinearLieAlgebra)
-dual(::LieAlgebraModule{C}) where {C<:RingElement}
-direct_sum(::LieAlgebraModule{C}, ::LieAlgebraModule{C}) where {C<:RingElement}
-tensor_product(::LieAlgebraModule{C}, ::LieAlgebraModule{C}) where {C<:RingElement}
-exterior_power(::LieAlgebraModule{C}, ::Int) where {C<:RingElement}
-symmetric_power(::LieAlgebraModule{C}, ::Int) where {C<:RingElement}
-tensor_power(::LieAlgebraModule{C}, ::Int) where {C<:RingElement}
-abstract_module(::LieAlgebra{C}, ::Int, ::Vector{<:MatElem{C}}, ::Vector{<:VarName}; ::Bool) where {C<:RingElement}
-abstract_module(::LieAlgebra{C}, ::Int, ::Matrix{SRow{C}}, ::Vector{<:VarName}; ::Bool) where {C<:RingElement}
+dual(::LieAlgebraModule{C}) where {C<:FieldElem}
+direct_sum(::LieAlgebraModule{C}, ::LieAlgebraModule{C}) where {C<:FieldElem}
+tensor_product(::LieAlgebraModule{C}, ::LieAlgebraModule{C}) where {C<:FieldElem}
+exterior_power(::LieAlgebraModule{C}, ::Int) where {C<:FieldElem}
+symmetric_power(::LieAlgebraModule{C}, ::Int) where {C<:FieldElem}
+tensor_power(::LieAlgebraModule{C}, ::Int) where {C<:FieldElem}
+abstract_module(::LieAlgebra{C}, ::Int, ::Vector{<:MatElem{C}}, ::Vector{<:VarName}; ::Bool) where {C<:FieldElem}
+abstract_module(::LieAlgebra{C}, ::Int, ::Matrix{SRow{C}}, ::Vector{<:VarName}; ::Bool) where {C<:FieldElem}
 ```
 
 # Type-dependent getters
@@ -74,6 +74,6 @@ is_tensor_product(::LieAlgebraModule)
 is_exterior_power(::LieAlgebraModule)
 is_symmetric_power(::LieAlgebraModule)
 is_tensor_power(::LieAlgebraModule)
-base_module(::LieAlgebraModule{C}) where {C<:RingElement}
-base_modules(::LieAlgebraModule{C}) where {C<:RingElement}
+base_module(::LieAlgebraModule{C}) where {C<:FieldElem}
+base_modules(::LieAlgebraModule{C}) where {C<:FieldElem}
 ```

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -1,11 +1,11 @@
 @attributes mutable struct AbstractLieAlgebra{C<:FieldElem} <: LieAlgebra{C}
-  R::Ring
+  R::Field
   dim::Int
   struct_consts::Matrix{SRow{C}}
   s::Vector{Symbol}
 
   function AbstractLieAlgebra{C}(
-    R::Ring,
+    R::Field,
     struct_consts::Matrix{SRow{C}},
     s::Vector{Symbol};
     cached::Bool=true,
@@ -45,7 +45,7 @@
 end
 
 const AbstractLieAlgebraDict = CacheDictType{
-  Tuple{Ring,Matrix{SRow},Vector{Symbol}},AbstractLieAlgebra
+  Tuple{Field,Matrix{SRow},Vector{Symbol}},AbstractLieAlgebra
 }()
 
 struct AbstractLieAlgebraElem{C<:FieldElem} <: LieAlgebraElem{C}
@@ -141,7 +141,7 @@ end
 ###############################################################################
 
 @doc raw"""
-    lie_algebra(R::Ring, struct_consts::Matrix{SRow{elem_type(R)}}, s::Vector{<:VarName}; cached::Bool, check::Bool) -> AbstractLieAlgebra{elem_type(R)}
+    lie_algebra(R::Field, struct_consts::Matrix{SRow{elem_type(R)}}, s::Vector{<:VarName}; cached::Bool, check::Bool) -> AbstractLieAlgebra{elem_type(R)}
 
 Construct the Lie algebra over the ring `R` with structure constants `struct_consts`
 and with basis element names `s`.
@@ -158,7 +158,7 @@ such that $[x_i, x_j] = \sum_k a_{i,j,k} x_k$.
   satisfy the Jacobi identity. This is `true` by default.
 """
 function lie_algebra(
-  R::Ring,
+  R::Field,
   struct_consts::Matrix{SRow{C}},
   s::Vector{<:VarName}=[Symbol("x_$i") for i in 1:size(struct_consts, 1)];
   cached::Bool=true,
@@ -169,7 +169,7 @@ function lie_algebra(
 end
 
 @doc raw"""
-    lie_algebra(R::Ring, struct_consts::Array{elem_type(R),3}, s::Vector{<:VarName}; cached::Bool, check::Bool) -> AbstractLieAlgebra{elem_type(R)}
+    lie_algebra(R::Field, struct_consts::Array{elem_type(R),3}, s::Vector{<:VarName}; cached::Bool, check::Bool) -> AbstractLieAlgebra{elem_type(R)}
 
 Construct the Lie algebra over the ring `R` with structure constants `struct_consts`
 and with basis element names `s`.
@@ -223,7 +223,7 @@ julia> h * f
 ```
 """
 function lie_algebra(
-  R::Ring,
+  R::Field,
   struct_consts::Array{C,3},
   s::Vector{<:VarName}=[Symbol("x_$i") for i in 1:size(struct_consts, 1)];
   cached::Bool=true,
@@ -264,14 +264,14 @@ function lie_algebra(
 end
 
 @doc raw"""
-    lie_algebra(R::Ring, dynkin::Tuple{Char,Int}; cached::Bool) -> AbstractLieAlgebra{elem_type(R)}
+    lie_algebra(R::Field, dynkin::Tuple{Char,Int}; cached::Bool) -> AbstractLieAlgebra{elem_type(R)}
 
 Construct the simple Lie algebra over the ring `R` with Dynkin type given by `dynkin`.
 The actual construction is done in GAP.
 
 If `cached` is `true`, the constructed Lie algebra is cached.
 """
-function lie_algebra(R::Ring, dynkin::Tuple{Char,Int}; cached::Bool=true)
+function lie_algebra(R::Field, dynkin::Tuple{Char,Int}; cached::Bool=true)
   @req dynkin[1] in 'A':'G' "Unknown Dynkin type"
 
   coeffs_iso = inv(Oscar.iso_oscar_gap(R))
@@ -286,7 +286,7 @@ function lie_algebra(R::Ring, dynkin::Tuple{Char,Int}; cached::Bool=true)
   return LO
 end
 
-function abelian_lie_algebra(::Type{T}, R::Ring, n::Int) where {T<:AbstractLieAlgebra}
+function abelian_lie_algebra(::Type{T}, R::Field, n::Int) where {T<:AbstractLieAlgebra}
   @req n >= 0 "Dimension must be non-negative."
   basis = [(b = zero_matrix(R, n, n); b[i, i] = 1; b) for i in 1:n]
   s = ["x_$(i)" for i in 1:n]

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -1,4 +1,4 @@
-@attributes mutable struct AbstractLieAlgebra{C<:RingElement} <: LieAlgebra{C}
+@attributes mutable struct AbstractLieAlgebra{C<:FieldElem} <: LieAlgebra{C}
   R::Ring
   dim::Int
   struct_consts::Matrix{SRow{C}}
@@ -10,7 +10,7 @@
     s::Vector{Symbol};
     cached::Bool=true,
     check::Bool=true,
-  ) where {C<:RingElement}
+  ) where {C<:FieldElem}
     return get_cached!(
       AbstractLieAlgebraDict, (R, struct_consts, s), cached
     ) do
@@ -48,7 +48,7 @@ const AbstractLieAlgebraDict = CacheDictType{
   Tuple{Ring,Matrix{SRow},Vector{Symbol}},AbstractLieAlgebra
 }()
 
-struct AbstractLieAlgebraElem{C<:RingElement} <: LieAlgebraElem{C}
+struct AbstractLieAlgebraElem{C<:FieldElem} <: LieAlgebraElem{C}
   parent::AbstractLieAlgebra{C}
   mat::MatElem{C}
 end
@@ -59,14 +59,13 @@ end
 #
 ###############################################################################
 
-parent_type(::Type{AbstractLieAlgebraElem{C}}) where {C<:RingElement} =
-  AbstractLieAlgebra{C}
+parent_type(::Type{AbstractLieAlgebraElem{C}}) where {C<:FieldElem} = AbstractLieAlgebra{C}
 
-elem_type(::Type{AbstractLieAlgebra{C}}) where {C<:RingElement} = AbstractLieAlgebraElem{C}
+elem_type(::Type{AbstractLieAlgebra{C}}) where {C<:FieldElem} = AbstractLieAlgebraElem{C}
 
 parent(x::AbstractLieAlgebraElem) = x.parent
 
-coefficient_ring(L::AbstractLieAlgebra{C}) where {C<:RingElement} = L.R::parent_type(C)
+coefficient_ring(L::AbstractLieAlgebra{C}) where {C<:FieldElem} = L.R::parent_type(C)
 
 dim(L::AbstractLieAlgebra) = L.dim
 
@@ -114,7 +113,7 @@ end
 
 function bracket(
   x::AbstractLieAlgebraElem{C}, y::AbstractLieAlgebraElem{C}
-) where {C<:RingElement}
+) where {C<:FieldElem}
   check_parent(x, y)
   L = parent(x)
   mat = sum(
@@ -164,7 +163,7 @@ function lie_algebra(
   s::Vector{<:VarName}=[Symbol("x_$i") for i in 1:size(struct_consts, 1)];
   cached::Bool=true,
   check::Bool=true,
-) where {C<:RingElement}
+) where {C<:FieldElem}
   @req C == elem_type(R) "Invalid coefficient type."
   return AbstractLieAlgebra{elem_type(R)}(R, struct_consts, Symbol.(s); cached, check)
 end
@@ -229,7 +228,7 @@ function lie_algebra(
   s::Vector{<:VarName}=[Symbol("x_$i") for i in 1:size(struct_consts, 1)];
   cached::Bool=true,
   check::Bool=true,
-) where {C<:RingElement}
+) where {C<:FieldElem}
   @req C == elem_type(R) "Invalid coefficient type."
   struct_consts2 = Matrix{SRow{elem_type(R)}}(
     undef, size(struct_consts, 1), size(struct_consts, 2)
@@ -245,7 +244,7 @@ end
 
 function lie_algebra(
   basis::Vector{AbstractLieAlgebraElem{C}}; check::Bool=true
-) where {C<:RingElement}
+) where {C<:FieldElem}
   parent_L = parent(basis[1])
   @req all(parent(x) === parent_L for x in basis) "Elements not compatible."
   R = coefficient_ring(parent_L)

--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -230,11 +230,7 @@ function Base.:*(x::LieAlgebraElem{C}, c::C) where {C<:FieldElem}
   return parent(x)(_matrix(x) * c)
 end
 
-function Base.:*(x::LieAlgebraElem, c::U) where {U<:Union{Rational,IntegerUnion}}
-  return parent(x)(_matrix(x) * c)
-end
-
-function Base.:*(x::LieAlgebraElem{ZZRingElem}, c::ZZRingElem)
+function Base.:*(x::LieAlgebraElem, c::U) where {U<:RationalUnion}
   return parent(x)(_matrix(x) * c)
 end
 
@@ -243,11 +239,7 @@ function Base.:*(c::C, x::LieAlgebraElem{C}) where {C<:FieldElem}
   return parent(x)(c * _matrix(x))
 end
 
-function Base.:*(c::U, x::LieAlgebraElem) where {U<:Union{Rational,IntegerUnion}}
-  return parent(x)(c * _matrix(x))
-end
-
-function Base.:*(c::ZZRingElem, x::LieAlgebraElem{ZZRingElem})
+function Base.:*(c::U, x::LieAlgebraElem) where {U<:RationalUnion}
   return parent(x)(c * _matrix(x))
 end
 

--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -225,7 +225,7 @@ function Base.:-(x1::LieAlgebraElem{C}, x2::LieAlgebraElem{C}) where {C<:FieldEl
   return parent(x1)(_matrix(x1) - _matrix(x2))
 end
 
-function Base.:*(x::LieAlgebraElem{C}, c::C) where {C<:RingElem}
+function Base.:*(x::LieAlgebraElem{C}, c::C) where {C<:FieldElem}
   coefficient_ring(x) != parent(c) && error("Incompatible rings.")
   return parent(x)(_matrix(x) * c)
 end
@@ -238,7 +238,7 @@ function Base.:*(x::LieAlgebraElem{ZZRingElem}, c::ZZRingElem)
   return parent(x)(_matrix(x) * c)
 end
 
-function Base.:*(c::C, x::LieAlgebraElem{C}) where {C<:RingElem}
+function Base.:*(c::C, x::LieAlgebraElem{C}) where {C<:FieldElem}
   coefficient_ring(x) != parent(c) && error("Incompatible rings.")
   return parent(x)(c * _matrix(x))
 end

--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -4,9 +4,9 @@
 #
 #################################################
 
-abstract type LieAlgebra{C<:RingElement} end
+abstract type LieAlgebra{C<:FieldElem} end
 
-abstract type LieAlgebraElem{C<:RingElement} end
+abstract type LieAlgebraElem{C<:FieldElem} end
 
 # To be implemented by subtypes:
 # parent_type(::Type{MyLieAlgebraElem{C}})
@@ -76,7 +76,7 @@ function iszero(x::LieAlgebraElem)
   return iszero(coefficients(x))
 end
 
-@inline function _matrix(x::LieAlgebraElem{C}) where {C<:RingElement}
+@inline function _matrix(x::LieAlgebraElem{C}) where {C<:FieldElem}
   return (x.mat)::dense_matrix_type(C)
 end
 
@@ -111,7 +111,7 @@ function Base.deepcopy_internal(x::LieAlgebraElem, dict::IdDict)
   return parent(x)(deepcopy_internal(_matrix(x), dict))
 end
 
-function check_parent(x1::LieAlgebraElem{C}, x2::LieAlgebraElem{C}) where {C<:RingElement}
+function check_parent(x1::LieAlgebraElem{C}, x2::LieAlgebraElem{C}) where {C<:FieldElem}
   parent(x1) !== parent(x2) && error("Incompatible Lie algebras.")
 end
 
@@ -168,7 +168,7 @@ end
 
 Return the element of `L` with coefficient vector `v`.
 """
-function (L::LieAlgebra{C})(v::Vector{C}) where {C<:RingElement}
+function (L::LieAlgebra{C})(v::Vector{C}) where {C<:FieldElem}
   @req length(v) == dim(L) "Length of vector does not match dimension."
   mat = matrix(coefficient_ring(L), 1, length(v), v)
   return elem_type(L)(L, mat)
@@ -180,7 +180,7 @@ end
 Return the element of `L` with coefficient vector equivalent to
 the $1 \times \dim(L)$ matrix `mat`.
 """
-function (L::LieAlgebra{C})(mat::MatElem{C}) where {C<:RingElement}
+function (L::LieAlgebra{C})(mat::MatElem{C}) where {C<:FieldElem}
   @req size(mat) == (1, dim(L)) "Invalid matrix dimensions."
   return elem_type(L)(L, mat)
 end
@@ -190,7 +190,7 @@ end
 
 Return the element of `L` with coefficient vector `v`.
 """
-function (L::LieAlgebra{C})(v::SRow{C}) where {C<:RingElement}
+function (L::LieAlgebra{C})(v::SRow{C}) where {C<:FieldElem}
   mat = dense_row(v, dim(L))
   return elem_type(L)(L, mat)
 end
@@ -200,7 +200,7 @@ end
 
 Return `x`. Fails if `x` is not an element of `L`.
 """
-function (L::LieAlgebra{C})(x::LieAlgebraElem{C}) where {C<:RingElement}
+function (L::LieAlgebra{C})(x::LieAlgebraElem{C}) where {C<:FieldElem}
   @req L === parent(x) "Incompatible modules."
   return x
 end
@@ -211,16 +211,16 @@ end
 #
 ###############################################################################
 
-function Base.:-(x::LieAlgebraElem{C}) where {C<:RingElement}
+function Base.:-(x::LieAlgebraElem{C}) where {C<:FieldElem}
   return parent(x)(-_matrix(x))
 end
 
-function Base.:+(x1::LieAlgebraElem{C}, x2::LieAlgebraElem{C}) where {C<:RingElement}
+function Base.:+(x1::LieAlgebraElem{C}, x2::LieAlgebraElem{C}) where {C<:FieldElem}
   check_parent(x1, x2)
   return parent(x1)(_matrix(x1) + _matrix(x2))
 end
 
-function Base.:-(x1::LieAlgebraElem{C}, x2::LieAlgebraElem{C}) where {C<:RingElement}
+function Base.:-(x1::LieAlgebraElem{C}, x2::LieAlgebraElem{C}) where {C<:FieldElem}
   check_parent(x1, x2)
   return parent(x1)(_matrix(x1) - _matrix(x2))
 end
@@ -251,7 +251,7 @@ function Base.:*(c::ZZRingElem, x::LieAlgebraElem{ZZRingElem})
   return parent(x)(c * _matrix(x))
 end
 
-function Base.:*(x::LieAlgebraElem{C}, y::LieAlgebraElem{C}) where {C<:RingElement}
+function Base.:*(x::LieAlgebraElem{C}, y::LieAlgebraElem{C}) where {C<:FieldElem}
   return bracket(x, y)
 end
 
@@ -261,7 +261,7 @@ end
 #
 ###############################################################################
 
-function Base.:(==)(x1::LieAlgebraElem{C}, x2::LieAlgebraElem{C}) where {C<:RingElement}
+function Base.:(==)(x1::LieAlgebraElem{C}, x2::LieAlgebraElem{C}) where {C<:FieldElem}
   check_parent(x1, x2)
   return coefficients(x1) == coefficients(x2)
 end

--- a/experimental/LieAlgebras/src/LieAlgebraHom.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraHom.jl
@@ -45,7 +45,7 @@ Return the transformation matrix of `h` w.r.t. the bases of the domain and codom
 
 Note: The matrix operates on the coefficient vectors from the right.
 """
-function matrix(h::LieAlgebraHom{<:LieAlgebra,<:LieAlgebra{C2}}) where {C2<:RingElement}
+function matrix(h::LieAlgebraHom{<:LieAlgebra,<:LieAlgebra{C2}}) where {C2<:FieldElem}
   return (h.matrix)::dense_matrix_type(C2)
 end
 
@@ -255,7 +255,7 @@ julia> [(x, h(x)) for x in basis(L1)]
 """
 function hom(
   L1::LieAlgebra{C}, L2::LieAlgebra{C}, imgs::Vector{<:LieAlgebraElem{C}}; check::Bool=true
-) where {C<:RingElement}
+) where {C<:FieldElem}
   return LieAlgebraHom(L1, L2, imgs; check)
 end
 
@@ -288,7 +288,7 @@ julia> [(x, h(x)) for x in basis(L1)]
 """
 function hom(
   L1::LieAlgebra{C}, L2::LieAlgebra{C}, mat::MatElem{C}; check::Bool=true
-) where {C<:RingElement}
+) where {C<:FieldElem}
   return LieAlgebraHom(L1, L2, mat; check)
 end
 
@@ -333,7 +333,7 @@ Lie algebra morphism
   to special linear Lie algebra of degree 3 over QQ
 ```
 """
-function zero_map(L1::LieAlgebra{C}, L2::LieAlgebra{C}) where {C<:RingElement}
+function zero_map(L1::LieAlgebra{C}, L2::LieAlgebra{C}) where {C<:FieldElem}
   return hom(L1, L2, zero_matrix(coefficient_ring(L2), dim(L1), dim(L2)); check=false)
 end
 

--- a/experimental/LieAlgebras/src/LieAlgebraIdeal.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraIdeal.jl
@@ -1,4 +1,4 @@
-@attributes mutable struct LieAlgebraIdeal{C<:RingElement,LieT<:LieAlgebraElem{C}}
+@attributes mutable struct LieAlgebraIdeal{C<:FieldElem,LieT<:LieAlgebraElem{C}}
   base_lie_algebra::LieAlgebra{C}
   gens::Vector{LieT}
   basis_elems::Vector{LieT}
@@ -6,7 +6,7 @@
 
   function LieAlgebraIdeal{C,LieT}(
     L::LieAlgebra{C}, gens::Vector{LieT}; is_basis::Bool=false
-  ) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+  ) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
     @req all(g -> parent(g) === L, gens) "Parent mismatch."
     L::parent_type(LieT)
     if is_basis
@@ -38,7 +38,7 @@
 
   function LieAlgebraIdeal{C,LieT}(
     L::LieAlgebra{C}, gens::Vector; kwargs...
-  ) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+  ) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
     return LieAlgebraIdeal{C,LieT}(L, Vector{LieT}(map(L, gens)); kwargs...)
   end
 end
@@ -49,9 +49,8 @@ end
 #
 ###############################################################################
 
-base_lie_algebra(
-  I::LieAlgebraIdeal{C,LieT}
-) where {C<:RingElement,LieT<:LieAlgebraElem{C}} = I.base_lie_algebra::parent_type(LieT)
+base_lie_algebra(I::LieAlgebraIdeal{C,LieT}) where {C<:FieldElem,LieT<:LieAlgebraElem{C}} =
+  I.base_lie_algebra::parent_type(LieT)
 
 function gens(I::LieAlgebraIdeal)
   return I.gens
@@ -67,7 +66,7 @@ end
 
 function basis_matrix(
   I::LieAlgebraIdeal{C,LieT}
-) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
   return I.basis_matrix::dense_matrix_type(C)
 end
 
@@ -131,14 +130,14 @@ end
 
 function Base.issubset(
   I1::LieAlgebraIdeal{C,LieT}, I2::LieAlgebraIdeal{C,LieT}
-) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
   @req base_lie_algebra(I1) === base_lie_algebra(I2) "Incompatible Lie algebras."
   return all(in(I2), gens(I1))
 end
 
 function Base.:(==)(
   I1::LieAlgebraIdeal{C,LieT}, I2::LieAlgebraIdeal{C,LieT}
-) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
   base_lie_algebra(I1) === base_lie_algebra(I2) || return false
   gens(I1) == gens(I2) && return true
   return issubset(I1, I2) && issubset(I2, I1)
@@ -174,7 +173,7 @@ end
 
 function Base.:+(
   I1::LieAlgebraIdeal{C,LieT}, I2::LieAlgebraIdeal{C,LieT}
-) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
   @req base_lie_algebra(I1) === base_lie_algebra(I2) "Incompatible Lie algebras."
   return ideal(base_lie_algebra(I1), [gens(I1); gens(I2)])
 end
@@ -186,14 +185,14 @@ Return $[I_1,I_2]$.
 """
 function bracket(
   I1::LieAlgebraIdeal{C,LieT}, I2::LieAlgebraIdeal{C,LieT}
-) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
   @req base_lie_algebra(I1) === base_lie_algebra(I2) "Incompatible Lie algebras."
   return ideal(base_lie_algebra(I1), [x * y for x in gens(I1) for y in gens(I2)])
 end
 
 function bracket(
   L::LieAlgebra{C}, I::LieAlgebraIdeal{C,LieT}
-) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
   @req L === base_lie_algebra(I) "Incompatible Lie algebras."
   return bracket(ideal(L), I)
 end
@@ -256,7 +255,7 @@ end
 
 Return `I` as a subalgebra of `L`.
 """
-function sub(L::LieAlgebra{C}, I::LieAlgebraIdeal{C}) where {C<:RingElement}
+function sub(L::LieAlgebra{C}, I::LieAlgebraIdeal{C}) where {C<:FieldElem}
   @req base_lie_algebra(I) === L "Incompatible Lie algebras."
   return sub(L, basis(I); is_basis=true)
 end
@@ -282,7 +281,7 @@ end
 
 Return the smallest ideal of `L` containing `gen`.
 """
-function ideal(L::LieAlgebra{C}, gen::LieAlgebraElem{C}) where {C<:RingElement}
+function ideal(L::LieAlgebra{C}, gen::LieAlgebraElem{C}) where {C<:FieldElem}
   return ideal(L, [gen])
 end
 

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -407,7 +407,7 @@ function Base.:-(
   return parent(v1)(_matrix(v1) - _matrix(v2))
 end
 
-function Base.:*(v::LieAlgebraModuleElem{C}, c::C) where {C<:RingElem}
+function Base.:*(v::LieAlgebraModuleElem{C}, c::C) where {C<:FieldElem}
   coefficient_ring(v) != parent(c) && error("Incompatible rings.")
   return parent(v)(_matrix(v) * c)
 end
@@ -420,7 +420,7 @@ function Base.:*(v::LieAlgebraModuleElem{ZZRingElem}, c::ZZRingElem)
   return parent(v)(_matrix(v) * c)
 end
 
-function Base.:*(c::C, v::LieAlgebraModuleElem{C}) where {C<:RingElem}
+function Base.:*(c::C, v::LieAlgebraModuleElem{C}) where {C<:FieldElem}
   coefficient_ring(v) != parent(c) && error("Incompatible rings.")
   return parent(v)(c * _matrix(v))
 end

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -1,4 +1,4 @@
-@attributes mutable struct LieAlgebraModule{C<:RingElement}
+@attributes mutable struct LieAlgebraModule{C<:FieldElem}
   L::LieAlgebra{C}
   dim::Int
   transformation_matrices::Vector{MatElem{C}}
@@ -10,7 +10,7 @@
     transformation_matrices::Vector{<:MatElem{C}},
     s::Vector{Symbol};
     check::Bool=true,
-  ) where {C<:RingElement}
+  ) where {C<:FieldElem}
     @req dimV == length(s) "Invalid number of basis element names."
     @req dim(L) == length(transformation_matrices) "Invalid number of transformation matrices."
     @req all(m -> size(m) == (dimV, dimV), transformation_matrices) "Invalid transformation matrix dimensions."
@@ -26,7 +26,7 @@
   end
 end
 
-struct LieAlgebraModuleElem{C<:RingElement}
+struct LieAlgebraModuleElem{C<:FieldElem}
   parent::LieAlgebraModule{C}
   mat::MatElem{C}
 end
@@ -37,9 +37,9 @@ end
 #
 ###############################################################################
 
-parent_type(::Type{LieAlgebraModuleElem{C}}) where {C<:RingElement} = LieAlgebraModule{C}
+parent_type(::Type{LieAlgebraModuleElem{C}}) where {C<:FieldElem} = LieAlgebraModule{C}
 
-elem_type(::Type{LieAlgebraModule{C}}) where {C<:RingElement} = LieAlgebraModuleElem{C}
+elem_type(::Type{LieAlgebraModule{C}}) where {C<:FieldElem} = LieAlgebraModuleElem{C}
 
 parent(v::LieAlgebraModuleElem) = v.parent
 
@@ -104,7 +104,7 @@ function iszero(v::LieAlgebraModuleElem)
   return iszero(coefficients(v))
 end
 
-@inline function _matrix(v::LieAlgebraModuleElem{C}) where {C<:RingElement}
+@inline function _matrix(v::LieAlgebraModuleElem{C}) where {C<:FieldElem}
   return (v.mat)::dense_matrix_type(C)
 end
 
@@ -141,7 +141,7 @@ end
 
 function check_parent(
   v1::LieAlgebraModuleElem{C}, v2::LieAlgebraModuleElem{C}
-) where {C<:RingElement}
+) where {C<:FieldElem}
   parent(v1) !== parent(v2) && error("Incompatible modules.")
 end
 
@@ -295,7 +295,7 @@ end
 
 Return the element of `V` with coefficient vector `v`.
 """
-function (V::LieAlgebraModule{C})(v::Vector{C}) where {C<:RingElement}
+function (V::LieAlgebraModule{C})(v::Vector{C}) where {C<:FieldElem}
   @req length(v) == dim(V) "Length of vector does not match dimension."
   mat = matrix(coefficient_ring(V), 1, length(v), v)
   return elem_type(V)(V, mat)
@@ -307,7 +307,7 @@ end
 Return the element of `V` with coefficient vector equivalent to
 the $1 \times \dim(L)$ matrix `mat`.
 """
-function (V::LieAlgebraModule{C})(v::MatElem{C}) where {C<:RingElement}
+function (V::LieAlgebraModule{C})(v::MatElem{C}) where {C<:FieldElem}
   @req ncols(v) == dim(V) "Length of vector does not match dimension"
   @req nrows(v) == 1 "Not a vector in module constructor"
   return elem_type(V)(V, v)
@@ -318,7 +318,7 @@ end
 
 Return the element of `V` with coefficient vector `v`.
 """
-function (V::LieAlgebraModule{C})(v::SRow{C}) where {C<:RingElement}
+function (V::LieAlgebraModule{C})(v::SRow{C}) where {C<:FieldElem}
   mat = dense_row(v, dim(V))
   return elem_type(V)(V, mat)
 end
@@ -330,7 +330,7 @@ Return `v`. Fails, in general, if `v` is not an element of `V`.
 
 If `V` is the dual module of the parent of `v`, return the dual of `v`.
 """
-function (V::LieAlgebraModule{C})(v::LieAlgebraModuleElem{C}) where {C<:RingElement}
+function (V::LieAlgebraModule{C})(v::LieAlgebraModuleElem{C}) where {C<:FieldElem}
   if is_dual(V) && base_module(V) === parent(v)
     return V(coefficients(v))
   end
@@ -351,7 +351,7 @@ where _correct_ depends on the case above.
 """
 function (V::LieAlgebraModule{C})(
   a::Vector{T}
-) where {T<:LieAlgebraModuleElem{C}} where {C<:RingElement}
+) where {T<:LieAlgebraModuleElem{C}} where {C<:FieldElem}
   if is_direct_sum(V)
     @req length(a) == length(base_modules(V)) "Length of vector does not match."
     @req all(i -> parent(a[i]) === base_modules(V)[i], 1:length(a)) "Incompatible modules."
@@ -375,11 +375,11 @@ end
 
 function (V::LieAlgebraModule{C})(
   a::Tuple{T,Vararg{T}}
-) where {T<:LieAlgebraModuleElem{C}} where {C<:RingElement}
+) where {T<:LieAlgebraModuleElem{C}} where {C<:FieldElem}
   return V(collect(a))
 end
 
-function (V::LieAlgebraModule{C})(_::Tuple{}) where {C<:RingElement}
+function (V::LieAlgebraModule{C})(_::Tuple{}) where {C<:FieldElem}
   return V(LieAlgebraModuleElem{C}[])
 end
 
@@ -389,20 +389,20 @@ end
 #
 ###############################################################################
 
-function Base.:-(v::LieAlgebraModuleElem{C}) where {C<:RingElement}
+function Base.:-(v::LieAlgebraModuleElem{C}) where {C<:FieldElem}
   return parent(v)(-_matrix(v))
 end
 
 function Base.:+(
   v1::LieAlgebraModuleElem{C}, v2::LieAlgebraModuleElem{C}
-) where {C<:RingElement}
+) where {C<:FieldElem}
   check_parent(v1, v2)
   return parent(v1)(_matrix(v1) + _matrix(v2))
 end
 
 function Base.:-(
   v1::LieAlgebraModuleElem{C}, v2::LieAlgebraModuleElem{C}
-) where {C<:RingElement}
+) where {C<:FieldElem}
   check_parent(v1, v2)
   return parent(v1)(_matrix(v1) - _matrix(v2))
 end
@@ -439,7 +439,7 @@ end
 #
 ###############################################################################
 
-function Base.:(==)(V1::LieAlgebraModule{C}, V2::LieAlgebraModule{C}) where {C<:RingElement}
+function Base.:(==)(V1::LieAlgebraModule{C}, V2::LieAlgebraModule{C}) where {C<:FieldElem}
   return V1.dim == V2.dim &&
          V1.s == V2.s &&
          V1.L == V2.L &&
@@ -457,7 +457,7 @@ end
 
 function Base.:(==)(
   v1::LieAlgebraModuleElem{C}, v2::LieAlgebraModuleElem{C}
-) where {C<:RingElement}
+) where {C<:FieldElem}
   check_parent(v1, v2)
   return coefficients(v1) == coefficients(v2)
 end
@@ -481,11 +481,11 @@ end
 
 Apply the action of `x` on `v`.
 """
-function Base.:*(x::LieAlgebraElem{C}, v::LieAlgebraModuleElem{C}) where {C<:RingElement}
+function Base.:*(x::LieAlgebraElem{C}, v::LieAlgebraModuleElem{C}) where {C<:FieldElem}
   return action(x, v)
 end
 
-function action(x::LieAlgebraElem{C}, v::LieAlgebraModuleElem{C}) where {C<:RingElement}
+function action(x::LieAlgebraElem{C}, v::LieAlgebraModuleElem{C}) where {C<:FieldElem}
   @req parent(x) === base_lie_algebra(parent(v)) "Incompatible Lie algebras."
 
   cx = coefficients(x)
@@ -499,7 +499,7 @@ function action(x::LieAlgebraElem{C}, v::LieAlgebraModuleElem{C}) where {C<:Ring
   )
 end
 
-function transformation_matrix(V::LieAlgebraModule{C}, i::Int) where {C<:RingElement}
+function transformation_matrix(V::LieAlgebraModule{C}, i::Int) where {C<:FieldElem}
   return (V.transformation_matrices[i])::dense_matrix_type(C)
 end
 
@@ -577,7 +577,7 @@ end
 
 Returns the base module of `V`, if `V` has been constructed as a power module.
 """
-function base_module(V::LieAlgebraModule{C}) where {C<:RingElement}
+function base_module(V::LieAlgebraModule{C}) where {C<:FieldElem}
   @req is_dual(V) || is_exterior_power(V) || is_symmetric_power(V) || is_tensor_power(V) "Not a power module."
   return get_attribute(V, :base_module)::LieAlgebraModule{C}
 end
@@ -588,7 +588,7 @@ end
 Returns the summands or tensor factors of `V`,
 if `V` has been constructed as a direct sum or tensor product of modules.
 """
-function base_modules(V::LieAlgebraModule{C}) where {C<:RingElement}
+function base_modules(V::LieAlgebraModule{C}) where {C<:FieldElem}
   if is_tensor_product(V)
     return get_attribute(V, :tensor_product)::Vector{LieAlgebraModule{C}}
   elseif is_direct_sum(V)
@@ -626,7 +626,7 @@ function abstract_module(
   transformation_matrices::Vector{<:MatElem{C}},
   s::Vector{<:VarName}=[Symbol("v_$i") for i in 1:dimV];
   check::Bool=true,
-) where {C<:RingElement}
+) where {C<:FieldElem}
   return LieAlgebraModule{C}(L, dimV, transformation_matrices, Symbol.(s); check)
 end
 
@@ -653,7 +653,7 @@ function abstract_module(
   struct_consts::Matrix{SRow{C}},
   s::Vector{<:VarName}=[Symbol("v_$i") for i in 1:dimV];
   check::Bool=true,
-) where {C<:RingElement}
+) where {C<:FieldElem}
   @req dim(L) == size(struct_consts, 1) "Invalid structure constants dimensions."
   @req dimV == size(struct_consts, 2) "Invalid structure constants dimensions."
   @req dimV == length(s) "Invalid number of basis element names."
@@ -762,7 +762,7 @@ Dual module
 over special linear Lie algebra of degree 3 over QQ
 ```
 """
-function dual(V::LieAlgebraModule{C}) where {C<:RingElement}
+function dual(V::LieAlgebraModule{C}) where {C<:FieldElem}
   L = base_lie_algebra(V)
   dim_dual_V = dim(V)
 
@@ -808,9 +808,7 @@ Direct sum module
 over special linear Lie algebra of degree 3 over QQ
 ```
 """
-function direct_sum(
-  V::LieAlgebraModule{C}, Vs::LieAlgebraModule{C}...
-) where {C<:RingElement}
+function direct_sum(V::LieAlgebraModule{C}, Vs::LieAlgebraModule{C}...) where {C<:FieldElem}
   Vs = [V; Vs...]
 
   L = base_lie_algebra(Vs[1])
@@ -837,7 +835,7 @@ function direct_sum(
   return direct_sum_V
 end
 
-⊕(V::LieAlgebraModule{C}, Vs::LieAlgebraModule{C}...) where {C<:RingElement} =
+⊕(V::LieAlgebraModule{C}, Vs::LieAlgebraModule{C}...) where {C<:FieldElem} =
   direct_sum(V, Vs...)
 
 @doc raw"""
@@ -868,7 +866,7 @@ over special linear Lie algebra of degree 3 over QQ
 """
 function tensor_product(
   V::LieAlgebraModule{C}, Vs::LieAlgebraModule{C}...
-) where {C<:RingElement}
+) where {C<:FieldElem}
   Vs = [V; Vs...]
   L = base_lie_algebra(Vs[1])
   @req all(x -> base_lie_algebra(x) === L, Vs) "All modules must have the same base Lie algebra."
@@ -944,7 +942,7 @@ function tensor_product(
   return tensor_product_V
 end
 
-⊗(V::LieAlgebraModule{C}, Vs::LieAlgebraModule{C}...) where {C<:RingElement} =
+⊗(V::LieAlgebraModule{C}, Vs::LieAlgebraModule{C}...) where {C<:FieldElem} =
   tensor_product(V, Vs...)
 
 @doc raw"""
@@ -967,7 +965,7 @@ Exterior power module
 over special linear Lie algebra of degree 3 over QQ
 ```
 """
-function exterior_power(V::LieAlgebraModule{C}, k::Int) where {C<:RingElement}
+function exterior_power(V::LieAlgebraModule{C}, k::Int) where {C<:FieldElem}
   @req k >= 0 "Non-negative exponent needed"
   L = base_lie_algebra(V)
   R = coefficient_ring(V)
@@ -1064,7 +1062,7 @@ Symmetric power module
 over special linear Lie algebra of degree 3 over QQ
 ```
 """
-function symmetric_power(V::LieAlgebraModule{C}, k::Int) where {C<:RingElement}
+function symmetric_power(V::LieAlgebraModule{C}, k::Int) where {C<:FieldElem}
   @req k >= 0 "Non-negative exponent needed"
   L = base_lie_algebra(V)
   R = coefficient_ring(V)
@@ -1182,7 +1180,7 @@ Tensor power module
 over special linear Lie algebra of degree 3 over QQ
 ```
 """
-function tensor_power(V::LieAlgebraModule{C}, k::Int) where {C<:RingElement}
+function tensor_power(V::LieAlgebraModule{C}, k::Int) where {C<:FieldElem}
   @req k >= 0 "Non-negative exponent needed"
   L = base_lie_algebra(V)
   R = coefficient_ring(V)

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -412,11 +412,7 @@ function Base.:*(v::LieAlgebraModuleElem{C}, c::C) where {C<:FieldElem}
   return parent(v)(_matrix(v) * c)
 end
 
-function Base.:*(v::LieAlgebraModuleElem, c::U) where {U<:Union{Rational,IntegerUnion}}
-  return parent(v)(_matrix(v) * c)
-end
-
-function Base.:*(v::LieAlgebraModuleElem{ZZRingElem}, c::ZZRingElem)
+function Base.:*(v::LieAlgebraModuleElem, c::U) where {U<:RationalUnion}
   return parent(v)(_matrix(v) * c)
 end
 
@@ -425,11 +421,7 @@ function Base.:*(c::C, v::LieAlgebraModuleElem{C}) where {C<:FieldElem}
   return parent(v)(c * _matrix(v))
 end
 
-function Base.:*(c::U, v::LieAlgebraModuleElem) where {U<:Union{Rational,IntegerUnion}}
-  return parent(v)(c * _matrix(v))
-end
-
-function Base.:*(c::ZZRingElem, v::LieAlgebraModuleElem{ZZRingElem})
+function Base.:*(c::U, v::LieAlgebraModuleElem) where {U<:RationalUnion}
   return parent(v)(c * _matrix(v))
 end
 

--- a/experimental/LieAlgebras/src/LieAlgebraModuleHom.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModuleHom.jl
@@ -52,7 +52,7 @@ Note: The matrix operates on the coefficient vectors from the right.
 """
 function matrix(
   h::LieAlgebraModuleHom{<:LieAlgebraModule,<:LieAlgebraModule{C2}}
-) where {C2<:RingElement}
+) where {C2<:FieldElem}
   return (h.matrix)::dense_matrix_type(C2)
 end
 
@@ -234,7 +234,7 @@ function hom(
   V2::LieAlgebraModule{C},
   imgs::Vector{<:LieAlgebraModuleElem{C}};
   check::Bool=true,
-) where {C<:RingElement}
+) where {C<:FieldElem}
   return LieAlgebraModuleHom(V1, V2, imgs; check)
 end
 
@@ -270,7 +270,7 @@ julia> [(v, h(v)) for v in basis(V1)]
 """
 function hom(
   V1::LieAlgebraModule{C}, V2::LieAlgebraModule{C}, mat::MatElem{C}; check::Bool=true
-) where {C<:RingElement}
+) where {C<:FieldElem}
   return LieAlgebraModuleHom(V1, V2, mat; check)
 end
 
@@ -319,7 +319,7 @@ Lie algebra module morphism
   to standard module of dimension 3 over sl_3
 ```
 """
-function zero_map(V1::LieAlgebraModule{C}, V2::LieAlgebraModule{C}) where {C<:RingElement}
+function zero_map(V1::LieAlgebraModule{C}, V2::LieAlgebraModule{C}) where {C<:FieldElem}
   return hom(V1, V2, zero_matrix(coefficient_ring(V2), dim(V1), dim(V2)); check=false)
 end
 
@@ -427,7 +427,7 @@ If `hs` is a vector, then it is interpreted as a diagonal matrix.
 """
 function hom_direct_sum(
   V::LieAlgebraModule{C}, W::LieAlgebraModule{C}, hs::Matrix{<:LieAlgebraModuleHom}
-) where {C<:RingElement}
+) where {C<:FieldElem}
   @req is_direct_sum(V) "First module must be a direct sum"
   @req is_direct_sum(W) "Second module must be a direct sum"
   Vs = base_modules(V)
@@ -453,7 +453,7 @@ end
 
 function hom_direct_sum(
   V::LieAlgebraModule{C}, W::LieAlgebraModule{C}, hs::Vector{<:LieAlgebraModuleHom}
-) where {C<:RingElement}
+) where {C<:FieldElem}
   @req is_direct_sum(V) "First module must be a direct sum"
   @req is_direct_sum(W) "Second module must be a direct sum"
   Vs = base_modules(V)
@@ -476,7 +476,7 @@ This works for $r$th tensor powers as well.
 """
 function hom_tensor(
   V::LieAlgebraModule{C}, W::LieAlgebraModule{C}, hs::Vector{<:LieAlgebraModuleHom}
-) where {C<:RingElement}
+) where {C<:FieldElem}
   @req is_tensor_product(V) || is_tensor_power(V) "First module must be a tensor product or power"
   @req is_tensor_product(W) || is_tensor_power(W) "Second module must be a tensor product or power"
   Vs = base_modules(V)
@@ -501,7 +501,7 @@ $S^k h: V \to W$ (analogous for other types of powers).
 """
 function hom_power(
   V::LieAlgebraModule{C}, W::LieAlgebraModule{C}, h::LieAlgebraModuleHom
-) where {C<:RingElement}
+) where {C<:FieldElem}
   if is_exterior_power(V)
     @req is_exterior_power(W) "First module is an exterior power, but second module is not"
     type = :ext

--- a/experimental/LieAlgebras/src/LieSubalgebra.jl
+++ b/experimental/LieAlgebras/src/LieSubalgebra.jl
@@ -1,4 +1,4 @@
-@attributes mutable struct LieSubalgebra{C<:RingElement,LieT<:LieAlgebraElem{C}}
+@attributes mutable struct LieSubalgebra{C<:FieldElem,LieT<:LieAlgebraElem{C}}
   base_lie_algebra::LieAlgebra{C}
   gens::Vector{LieT}
   basis_elems::Vector{LieT}
@@ -6,7 +6,7 @@
 
   function LieSubalgebra{C,LieT}(
     L::LieAlgebra{C}, gens::Vector{LieT}; is_basis::Bool=false
-  ) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+  ) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
     @req all(g -> parent(g) === L, gens) "Parent mismatch."
     L::parent_type(LieT)
     if is_basis
@@ -38,7 +38,7 @@
 
   function LieSubalgebra{C,LieT}(
     L::LieAlgebra{C}, gens::Vector; kwargs...
-  ) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+  ) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
     return LieSubalgebra{C,LieT}(L, Vector{LieT}(map(L, gens)); kwargs...)
   end
 end
@@ -49,7 +49,7 @@ end
 #
 ###############################################################################
 
-base_lie_algebra(S::LieSubalgebra{C,LieT}) where {C<:RingElement,LieT<:LieAlgebraElem{C}} =
+base_lie_algebra(S::LieSubalgebra{C,LieT}) where {C<:FieldElem,LieT<:LieAlgebraElem{C}} =
   S.base_lie_algebra::parent_type(LieT)
 
 function gens(S::LieSubalgebra)
@@ -64,9 +64,7 @@ function ngens(S::LieSubalgebra)
   return length(gens(S))
 end
 
-function basis_matrix(
-  S::LieSubalgebra{C,LieT}
-) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+function basis_matrix(S::LieSubalgebra{C,LieT}) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
   return S.basis_matrix::dense_matrix_type(C)
 end
 
@@ -130,14 +128,14 @@ end
 
 function Base.issubset(
   S1::LieSubalgebra{C,LieT}, S2::LieSubalgebra{C,LieT}
-) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
   @req base_lie_algebra(S1) === base_lie_algebra(S2) "Incompatible Lie algebras."
   return all(in(S2), gens(S1))
 end
 
 function Base.:(==)(
   S1::LieSubalgebra{C,LieT}, S2::LieSubalgebra{C,LieT}
-) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
   base_lie_algebra(S1) === base_lie_algebra(S2) || return false
   gens(S1) == gens(S2) && return true
   return issubset(S1, S2) && issubset(S2, S1)
@@ -178,14 +176,14 @@ Return $[S_1, S_2]$.
 """
 function bracket(
   S1::LieSubalgebra{C,LieT}, S2::LieSubalgebra{C,LieT}
-) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
   @req base_lie_algebra(S1) === base_lie_algebra(S2) "Incompatible Lie algebras."
   return ideal(base_lie_algebra(S1), [x * y for x in gens(S1) for y in gens(S2)])
 end
 
 function bracket(
   L::LieAlgebra{C}, S::LieSubalgebra{C,LieT}
-) where {C<:RingElement,LieT<:LieAlgebraElem{C}}
+) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
   @req L === base_lie_algebra(S) "Incompatible Lie algebras."
   return bracket(ideal(L), S)
 end
@@ -293,7 +291,7 @@ end
 
 Return the smallest Lie subalgebra of `L` containing `gen`.
 """
-function sub(L::LieAlgebra{C}, gen::LieAlgebraElem{C}) where {C<:RingElement}
+function sub(L::LieAlgebra{C}, gen::LieAlgebraElem{C}) where {C<:FieldElem}
   return sub(L, [gen])
 end
 

--- a/experimental/LieAlgebras/src/LinearLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LinearLieAlgebra.jl
@@ -1,4 +1,4 @@
-@attributes mutable struct LinearLieAlgebra{C<:RingElement} <: LieAlgebra{C}
+@attributes mutable struct LinearLieAlgebra{C<:FieldElem} <: LieAlgebra{C}
   R::Ring
   n::Int  # the n of the gl_n this embeds into
   dim::Int
@@ -12,7 +12,7 @@
     s::Vector{Symbol};
     cached::Bool=true,
     check::Bool=true,
-  ) where {C<:RingElement}
+  ) where {C<:FieldElem}
     return get_cached!(
       LinearLieAlgebraDict, (R, n, basis, s), cached
     ) do
@@ -35,7 +35,7 @@ const LinearLieAlgebraDict = CacheDictType{
   Tuple{Ring,Int,Vector{<:MatElem},Vector{Symbol}},LinearLieAlgebra
 }()
 
-struct LinearLieAlgebraElem{C<:RingElement} <: LieAlgebraElem{C}
+struct LinearLieAlgebraElem{C<:FieldElem} <: LieAlgebraElem{C}
   parent::LinearLieAlgebra{C}
   mat::MatElem{C}
 end
@@ -46,13 +46,13 @@ end
 #
 ###############################################################################
 
-parent_type(::Type{LinearLieAlgebraElem{C}}) where {C<:RingElement} = LinearLieAlgebra{C}
+parent_type(::Type{LinearLieAlgebraElem{C}}) where {C<:FieldElem} = LinearLieAlgebra{C}
 
-elem_type(::Type{LinearLieAlgebra{C}}) where {C<:RingElement} = LinearLieAlgebraElem{C}
+elem_type(::Type{LinearLieAlgebra{C}}) where {C<:FieldElem} = LinearLieAlgebraElem{C}
 
 parent(x::LinearLieAlgebraElem) = x.parent
 
-coefficient_ring(L::LinearLieAlgebra{C}) where {C<:RingElement} = L.R::parent_type(C)
+coefficient_ring(L::LinearLieAlgebra{C}) where {C<:FieldElem} = L.R::parent_type(C)
 
 dim(L::LinearLieAlgebra) = L.dim
 
@@ -62,7 +62,7 @@ dim(L::LinearLieAlgebra) = L.dim
 Return the basis `basis(L)` of the Lie algebra `L` in the underlying matrix
 representation.
 """
-function matrix_repr_basis(L::LinearLieAlgebra{C}) where {C<:RingElement}
+function matrix_repr_basis(L::LinearLieAlgebra{C}) where {C<:FieldElem}
   return Vector{dense_matrix_type(C)}(L.basis)
 end
 
@@ -72,7 +72,7 @@ end
 Return the `i`-th element of the basis `basis(L)` of the Lie algebra `L` in the
 underlying matrix representation.
 """
-function matrix_repr_basis(L::LinearLieAlgebra{C}, i::Int) where {C<:RingElement}
+function matrix_repr_basis(L::LinearLieAlgebra{C}, i::Int) where {C<:FieldElem}
   return (L.basis[i])::dense_matrix_type(C)
 end
 
@@ -147,7 +147,7 @@ If no such element exists, an error is thrown.
 """
 function coerce_to_lie_algebra_elem(
   L::LinearLieAlgebra{C}, x::MatElem{C}
-) where {C<:RingElement}
+) where {C<:FieldElem}
   @req size(x) == (L.n, L.n) "Invalid matrix dimensions."
   m = coefficient_vector(x, matrix_repr_basis(L))
   return L(m)
@@ -174,7 +174,7 @@ end
 
 function bracket(
   x::LinearLieAlgebraElem{C}, y::LinearLieAlgebraElem{C}
-) where {C<:RingElement}
+) where {C<:FieldElem}
   check_parent(x, y)
   L = parent(x)
   x_mat = matrix_repr(x)
@@ -205,13 +205,13 @@ function lie_algebra(
   s::Vector{<:VarName};
   cached::Bool=true,
   check::Bool=true,
-) where {C<:RingElement}
+) where {C<:FieldElem}
   return LinearLieAlgebra{elem_type(R)}(R, n, basis, Symbol.(s); cached)
 end
 
 function lie_algebra(
   basis::Vector{LinearLieAlgebraElem{C}}; check::Bool=true
-) where {C<:RingElement}
+) where {C<:FieldElem}
   parent_L = parent(basis[1])
   @req all(parent(x) === parent_L for x in basis) "Elements not compatible."
   R = coefficient_ring(parent_L)

--- a/experimental/LieAlgebras/src/LinearLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LinearLieAlgebra.jl
@@ -1,12 +1,12 @@
 @attributes mutable struct LinearLieAlgebra{C<:FieldElem} <: LieAlgebra{C}
-  R::Ring
+  R::Field
   n::Int  # the n of the gl_n this embeds into
   dim::Int
   basis::Vector{MatElem{C}}
   s::Vector{Symbol}
 
   function LinearLieAlgebra{C}(
-    R::Ring,
+    R::Field,
     n::Int,
     basis::Vector{<:MatElem{C}},
     s::Vector{Symbol};
@@ -32,7 +32,7 @@
 end
 
 const LinearLieAlgebraDict = CacheDictType{
-  Tuple{Ring,Int,Vector{<:MatElem},Vector{Symbol}},LinearLieAlgebra
+  Tuple{Field,Int,Vector{<:MatElem},Vector{Symbol}},LinearLieAlgebra
 }()
 
 struct LinearLieAlgebraElem{C<:FieldElem} <: LieAlgebraElem{C}
@@ -189,7 +189,7 @@ end
 ###############################################################################
 
 @doc raw"""
-    lie_algebra(R::Ring, n::Int, basis::Vector{<:MatElem{elem_type(R)}}, s::Vector{<:VarName}; cached::Bool) -> LinearLieAlgebra{elem_type(R)}
+    lie_algebra(R::Field, n::Int, basis::Vector{<:MatElem{elem_type(R)}}, s::Vector{<:VarName}; cached::Bool) -> LinearLieAlgebra{elem_type(R)}
 
 Construct the Lie algebra over the ring `R` with basis `basis` and basis element names
 given by `s`. The basis elements must be square matrices of size `n`.
@@ -199,7 +199,7 @@ two basis elements in its span.
 If `cached` is `true`, the constructed Lie algebra is cached.
 """
 function lie_algebra(
-  R::Ring,
+  R::Field,
   n::Int,
   basis::Vector{<:MatElem{C}},
   s::Vector{<:VarName};
@@ -221,20 +221,20 @@ function lie_algebra(
 end
 
 @doc raw"""
-    abelian_lie_algebra(R::Ring, n::Int) -> LinearLieAlgebra{elem_type(R)}
-    abelian_lie_algebra(::Type{LinearLieAlgebra}, R::Ring, n::Int) -> LinearLieAlgebra{elem_type(R)}
-    abelian_lie_algebra(::Type{AbstractLieAlgebra}, R::Ring, n::Int) -> AbstractLieAlgebra{elem_type(R)}
+    abelian_lie_algebra(R::Field, n::Int) -> LinearLieAlgebra{elem_type(R)}
+    abelian_lie_algebra(::Type{LinearLieAlgebra}, R::Field, n::Int) -> LinearLieAlgebra{elem_type(R)}
+    abelian_lie_algebra(::Type{AbstractLieAlgebra}, R::Field, n::Int) -> AbstractLieAlgebra{elem_type(R)}
 
 Return the abelian Lie algebra of dimension `n` over the ring `R`.
 The first argument can be optionally provided to specify the type of the returned
 Lie algebra.
 """
-function abelian_lie_algebra(R::Ring, n::Int)
+function abelian_lie_algebra(R::Field, n::Int)
   @req n >= 0 "Dimension must be non-negative."
   return abelian_lie_algebra(LinearLieAlgebra, R, n)
 end
 
-function abelian_lie_algebra(::Type{T}, R::Ring, n::Int) where {T<:LinearLieAlgebra}
+function abelian_lie_algebra(::Type{T}, R::Field, n::Int) where {T<:LinearLieAlgebra}
   @req n >= 0 "Dimension must be non-negative."
   basis = [(b = zero_matrix(R, n, n); b[i, i] = 1; b) for i in 1:n]
   s = ["x_$(i)" for i in 1:n]
@@ -244,7 +244,7 @@ function abelian_lie_algebra(::Type{T}, R::Ring, n::Int) where {T<:LinearLieAlge
 end
 
 @doc raw"""
-    general_linear_lie_algebra(R::Ring, n::Int) -> LinearLieAlgebra{elem_type(R)}
+    general_linear_lie_algebra(R::Field, n::Int) -> LinearLieAlgebra{elem_type(R)}
 
 Return the general linear Lie algebra $\mathfrak{gl}_n(R)$.
 
@@ -270,7 +270,7 @@ julia> matrix_repr_basis(L)
  [0 0; 0 1]
 ```
 """
-function general_linear_lie_algebra(R::Ring, n::Int)
+function general_linear_lie_algebra(R::Field, n::Int)
   basis = [(b = zero_matrix(R, n, n); b[i, j] = 1; b) for i in 1:n for j in 1:n]
   s = ["x_$(i)_$(j)" for i in 1:n for j in 1:n]
   L = lie_algebra(R, n, basis, s; check=false)
@@ -279,7 +279,7 @@ function general_linear_lie_algebra(R::Ring, n::Int)
 end
 
 @doc raw"""
-    special_linear_lie_algebra(R::Ring, n::Int) -> LinearLieAlgebra{elem_type(R)}
+    special_linear_lie_algebra(R::Field, n::Int) -> LinearLieAlgebra{elem_type(R)}
 
 Return the special linear Lie algebra $\mathfrak{sl}_n(R)$.
 
@@ -303,7 +303,7 @@ julia> matrix_repr_basis(L)
  [1 0; 0 -1]
 ```
 """
-function special_linear_lie_algebra(R::Ring, n::Int)
+function special_linear_lie_algebra(R::Field, n::Int)
   basis_e = [(b = zero_matrix(R, n, n); b[i, j] = 1; b) for i in 1:n for j in (i + 1):n]
   basis_f = [(b = zero_matrix(R, n, n); b[j, i] = 1; b) for i in 1:n for j in (i + 1):n]
   basis_h = [
@@ -318,7 +318,7 @@ function special_linear_lie_algebra(R::Ring, n::Int)
 end
 
 @doc raw"""
-    special_orthogonal_lie_algebra(R::Ring, n::Int) -> LinearLieAlgebra{elem_type(R)}
+    special_orthogonal_lie_algebra(R::Field, n::Int) -> LinearLieAlgebra{elem_type(R)}
 
 Return the special orthogonal Lie algebra $\mathfrak{so}_n(R)$.
 
@@ -342,7 +342,7 @@ julia> matrix_repr_basis(L)
  [0 0 0; 0 0 1; 0 -1 0]
 ```
 """
-function special_orthogonal_lie_algebra(R::Ring, n::Int)
+function special_orthogonal_lie_algebra(R::Field, n::Int)
   basis = [
     (b = zero_matrix(R, n, n); b[i, j] = 1; b[j, i] = -1; b) for i in 1:n for j in (i + 1):n
   ]

--- a/experimental/LieAlgebras/src/Util.jl
+++ b/experimental/LieAlgebras/src/Util.jl
@@ -10,9 +10,7 @@ julia> coefficient_vector(matrix(QQ, [1 2;3 4]), [matrix(QQ, [1 0;0 0]), matrix(
 [1   2   -3]
 ```
 """
-function coefficient_vector(
-  M::MatElem{T}, basis::Vector{<:MatElem{T}}
-) where {T<:RingElement}
+function coefficient_vector(M::MatElem{T}, basis::Vector{<:MatElem{T}}) where {T<:FieldElem}
   (nr, nc) = size(M)
   all(b -> size(b) == (nr, nc), basis) ||
     throw(DimensionMismatch("The matrices in B must have the same size as M."))

--- a/experimental/LieAlgebras/src/iso_oscar_gap.jl
+++ b/experimental/LieAlgebras/src/iso_oscar_gap.jl
@@ -6,7 +6,7 @@
 
 function _iso_oscar_gap_lie_algebra_functions(
   LO::LieAlgebra{C}, LG::GAP.GapObj, coeffs_iso::MapFromFunc
-) where {C<:RingElement}
+) where {C<:FieldElem}
   basis_LG = GAPWrap.Basis(LG)
 
   f = function (x::LieAlgebraElem{C})

--- a/experimental/LieAlgebras/test/AbstractLieAlgebra-test.jl
+++ b/experimental/LieAlgebras/test/AbstractLieAlgebra-test.jl
@@ -1,5 +1,5 @@
 @testset "LieAlgebras.AbstractLieAlgebra" begin
-  function sl2_struct_consts(R::Ring)
+  function sl2_struct_consts(R::Field)
     sc = zeros(R, 3, 3, 3)
     sc[1, 2, 3] = R(1)
     sc[2, 1, 3] = R(-1)

--- a/experimental/LieAlgebras/test/LieAlgebra-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebra-test.jl
@@ -1,7 +1,7 @@
 
 function lie_algebra_conformance_test(
   L::LieAlgebra{C}, parentT::DataType, elemT::DataType; num_random_tests::Int=10
-) where {C<:RingElement}
+) where {C<:FieldElem}
   @testset "basic manipulation" begin
     x = L(rand(-10:10, dim(L)))
 

--- a/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
@@ -5,7 +5,7 @@ function lie_algebra_module_conformance_test(
   parentT::DataType=LieAlgebraModule{C},
   elemT::DataType=LieAlgebraModuleElem{C};
   num_random_tests::Int=10,
-) where {C<:RingElement}
+) where {C<:FieldElem}
   @testset "basic manipulation" begin
     v = V(rand(-10:10, dim(V)))
 
@@ -440,7 +440,7 @@ end
   @testset "so_n correctness regression" begin
     function lie_algebra_module_struct_const(
       L::LieAlgebra{C}, V::LieAlgebraModule{C}
-    ) where {C<:RingElement}
+    ) where {C<:FieldElem}
       R = coefficient_ring(L)
       dimL = dim(L)
       dimV = dim(V)

--- a/experimental/LieAlgebras/test/LinearLieAlgebra-test.jl
+++ b/experimental/LieAlgebras/test/LinearLieAlgebra-test.jl
@@ -71,7 +71,7 @@
   end
 
   @testset "so_n correctness regression" begin
-    function lie_algebra_struct_const(L::LieAlgebra{C}) where {C<:RingElement}
+    function lie_algebra_struct_const(L::LieAlgebra{C}) where {C<:FieldElem}
       R = coefficient_ring(L)
       dimL = dim(L)
       struct_const_L = Matrix{Vector{Tuple{elem_type(R),Int}}}(undef, dimL, dimL)

--- a/experimental/LieAlgebras/test/iso_oscar_gap-test.jl
+++ b/experimental/LieAlgebras/test/iso_oscar_gap-test.jl
@@ -40,7 +40,7 @@ end
 
   @testset for RO in baserings
     @testset "AbstractLieAlgebra" begin
-      function sl2_struct_consts(R::Ring)
+      function sl2_struct_consts(R::Field)
         sc = zeros(R, 3, 3, 3)
         sc[1, 2, 3] = R(1)
         sc[2, 1, 3] = R(-1)


### PR DESCRIPTION
For some functions already defined, I have doubts about the correctness over general rings, in particular in the existence of zero divisors.
So, I would like to restrict everything to work only over fields for now. If someone (maybe @fingolfin ?) with the required knowledge wants to work with Lie rings in the future, after a per-case decision one can widen the signatures again.