### PR TITLE
Enable GC logging in the test suite

### DIFF
--- a/experimental/OrthogonalDiscriminants/test/data.jl
+++ b/experimental/OrthogonalDiscriminants/test/data.jl
@@ -118,6 +118,9 @@ function dummy_placeholder end
 end
 
 @testset "show and print character tables" begin
+  # temporarily disable GC logging to avoid glitches in the doctests
+  VERSION >= v"1.8.0" && GC.enable_logging(false)
   doctest(nothing, [AuxDocTest_show_with_ODs])
   #doctest(nothing, [AuxDocTest_show_with_ODs]; fix=true)
+  VERSION >= v"1.8.0" && GC.enable_logging(true)
 end

--- a/test/Groups/MatrixDisplay.jl
+++ b/test/Groups/MatrixDisplay.jl
@@ -539,6 +539,9 @@ function dummy_placeholder end
 end
 
 @testset "show and print formatted matrices" begin
+  # temporarily disable GC logging to avoid glitches in the doctests
+  VERSION >= v"1.8.0" && GC.enable_logging(false)
   doctest(nothing, [AuxDocTest_labelled_matrix_formatted])
   #doctest(nothing, [AuxDocTest_labelled_matrix_formatted]; fix=true)
+  VERSION >= v"1.8.0" && GC.enable_logging(true)
 end

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -734,8 +734,11 @@ end
 
 
 @testset "show and print character tables" begin
+  # temporarily disable GC logging to avoid glitches in the doctests
+  VERSION >= v"1.8.0" && GC.enable_logging(false)
   doctest(nothing, [AuxDocTest_GroupCharacters])
   #doctest(nothing, [AuxDocTest_GroupCharacters]; fix=true)
+  VERSION >= v"1.8.0" && GC.enable_logging(true)
 end
 
 @testset "create character tables" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,14 @@ end
 @everywhere Oscar.set_seed!($seed)
 @everywhere Oscar.randseed!($seed)
 
+if VERSION >= v"1.8.0"
+  # Enable GC logging to help track down certain GC related issues.
+  # Note that several test files need to temporarily disable and then
+  # re-enable this. If we need to disable this globally, those files
+  # need to be adjusted as well.
+  @everywhere  GC.enable_logging(true)
+end
+
 @everywhere import Oscar.Nemo.AbstractAlgebra
 @everywhere include(joinpath(pathof(Oscar.Nemo.AbstractAlgebra), "..", "..", "test", "Rings-conformance-tests.jl"))
 


### PR DESCRIPTION
For AbstractAlgebra this was quite helpful in tracking down the source of some memory hogs in the test suite.