### PR TITLE
UngradedModules: don't use display(...) in special show methods

### DIFF
--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -1966,16 +1966,16 @@ function show_subquo(SQ::SubquoModule)
       else
         println("Cokernel of")
       end
-      display(generator_matrix(SQ.quo))
+      show(stdout, "text/plain", generator_matrix(SQ.quo))
     else
       if is_graded(SQ)
         println("Graded subquotient of")
       else
         println("Subquotient of")
       end
-      display(generator_matrix(SQ.sub))
-      println("by image of")
-      display(generator_matrix(SQ.quo))
+      show(stdout, "text/plain", generator_matrix(SQ.sub))
+      println("\nby image of")
+      show(stdout, "text/plain", generator_matrix(SQ.quo))
     end
   else
     if is_graded(SQ)
@@ -1983,9 +1983,9 @@ function show_subquo(SQ::SubquoModule)
     else
       println("Image of")
     end
-    display(generator_matrix(SQ.sub))
+    show(stdout, "text/plain", generator_matrix(SQ.sub))
   end
-  print(io_compact, "with ambient free module ", SQ.F)
+  print(io_compact, "\nwith ambient free module ", SQ.F)
 end
 
 function show_morphism_as_map(f::ModuleFPHom, print_non_zero_only = false)
@@ -5027,7 +5027,7 @@ function matrix(f::SubQuoHom)
 end
 
 function show_morphism(f::ModuleFPHom)
-  display(matrix(f))
+  show(stdout, "text/plain", matrix(f))
 end
 
 @doc raw"""


### PR DESCRIPTION
From the help of `display(...)`:

> In general, you cannot assume that `display` output goes to `stdout`...

But all the text surrounding that `display` call goes to `stdout`.

Also it doesn't get captured by Documenter which is used for checking the code for the oscar-book.

The new show call seems to replicate the previous output:
```
julia> show_subquo(H)
Graded subquotient of
[1   0   0   0]
[0   0   0   1]
by image of
[x     0   0     0]
[0   y^2   0     0]
[0     0   x     0]
[0     0   0   y^2]
with ambient free module Rg^4
```

Anyone who knows more about all the pretty-printing features please feel free to add suggestions.