### PR TITLE
fix iso to GrpGen

### DIFF
--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -775,7 +775,7 @@ function isomorphism(::Type{T}, A::GrpGen) where T <: GAPGroup
      newgens = elem_type(S)[]
      for g in gensA
        j = g.i
-       p = S(A.mult_table[j, :])
+       p = S(A.mult_table[:, j])
        push!(newgens, p)
      end
 

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -270,16 +270,19 @@ end
    end
 
    @testset "GrpGen to GAPGroups" begin
-      G = Hecke.small_group(64, 14, DB = Hecke.DefaultSmallGroupDB())
-      for T in [FPGroup, PcGroup, PermGroup]
-         iso = @inferred isomorphism(T, G)
-         for x in gens(G), y in gens(G)
-            z = x * y
-            @test iso(x) * iso(y) == iso(z)
-            @test all(a -> preimage(iso, iso(a)) == a, [x, y, z])
+      for G in [Hecke.small_group(64, 14, DB = Hecke.DefaultSmallGroupDB()),
+                Hecke.small_group(20, 3, DB = Hecke.DefaultSmallGroupDB())]
+         for T in [FPGroup, PcGroup, PermGroup]
+            iso = @inferred isomorphism(T, G)
+            for x in gens(G), y in gens(G)
+               z = x * y
+               @test iso(x) * iso(y) == iso(z)
+               @test all(a -> preimage(iso, iso(a)) == a, [x, y, z])
+            end
          end
-      end
+      end   
 
+      G  = Hecke.small_group(64, 14, DB = Hecke.DefaultSmallGroupDB())
       H = small_group(64, 14)
       @test isisomorphic(G, H)
       f = isomorphism(G, H)


### PR DESCRIPTION
in particular fixes:
```
  Qx, x = QQ["x"];
  k5,a5=number_field( x^5 - 2 ,"a")
  K5,i5=normal_closure(k5)
  G5,mG5=automorphism_group(PermGroup, K5)
  map(mG5, G5)

```
The map used to fail. The test does it without the number theory