### PR TITLE
Version 0.14.0-DEV

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oscar"
 uuid = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
 authors = ["The OSCAR Team <oscar@mathematik.uni-kl.de>"]
-version = "0.13.1-DEV"
+version = "0.14.0-DEV"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ julia> using Oscar
  -----    -----    -----   -     -  -     -
 
 ...combining (and extending) ANTIC, GAP, Polymake and Singular
-Version 0.13.1-DEV ...
+Version 0.14.0-DEV ...
 ... which comes with absolutely no warranty whatsoever
 Type: '?Oscar' for more information
 (c) 2019-2023 by The OSCAR Development Team
@@ -133,7 +133,7 @@ pm::Array<topaz::HomologyGroup<pm::Integer> >
 If you have used OSCAR in the preparation of a paper please cite it as described below:
 
     [OSCAR]
-        OSCAR -- Open Source Computer Algebra Research system, Version 0.13.1-DEV, The OSCAR Team, 2023. (https://www.oscar-system.org)
+        OSCAR -- Open Source Computer Algebra Research system, Version 0.14.0-DEV, The OSCAR Team, 2023. (https://www.oscar-system.org)
     [OSCAR-book]
         Wolfram Decker, Christian Eder, Claus Fieker, Max Horn, Michael Joswig, The OSCAR book, 2024.
 
@@ -143,7 +143,7 @@ If you are using BibTeX, you can use the following BibTeX entries:
       key          = {OSCAR},
       organization = {The OSCAR Team},
       title        = {OSCAR -- Open Source Computer Algebra Research system,
-                      Version 0.13.1-DEV},
+                      Version 0.14.0-DEV},
       year         = {2023},
       url          = {https://www.oscar-system.org},
       }

--- a/gap/OscarInterface/PackageInfo.g
+++ b/gap/OscarInterface/PackageInfo.g
@@ -10,8 +10,8 @@ SetPackageInfo( rec(
 
 PackageName := "OscarInterface",
 Subtitle := "GAP interface to OSCAR",
-Version := "0.13.1-DEV",
-Date := "04/09/2023", # dd/mm/yyyy format
+Version := "0.14.0-DEV",
+Date := "16/10/2023", # dd/mm/yyyy format
 License := "GPL-2.0-or-later",
 
 Persons := [


### PR DESCRIPTION
We have many potentially breaking changes, including transitively from
our dependencies, so the next release should be 0.14.0, not 0.13.1.
