### PR TITLE
Bump `Documenter.jl` to `v1.0`

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,5 +3,5 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 
 [compat]
-Documenter = "0.27.0"
+Documenter = "1.1"
 DocumenterCitations = "~1.1, ~1.2"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,4 +4,4 @@ DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 
 [compat]
 Documenter = "1.1"
-DocumenterCitations = "~1.1, ~1.2"
+DocumenterCitations = "~1.2"

--- a/docs/citation_style.jl
+++ b/docs/citation_style.jl
@@ -8,7 +8,7 @@
 import DocumenterCitations
 
 # we use some (undocumented) internal helper functions for formatting...
-using DocumenterCitations: format_names, tex2unicode, italicize_md_et_al
+using DocumenterCitations: format_names, tex2unicode
 
 const oscar_style = :oscar
 
@@ -66,7 +66,7 @@ function DocumenterCitations.format_citation(
       )
     end
     capitalize && (names = uppercasefirst(names))
-    link_text = italicize_md_et_al("$names $link_text")
+    link_text = "$names $link_text"
   end
   return link_text
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, Oscar
 
 include(normpath(joinpath(Oscar.oscardir, "docs", "make_work.jl")))
 
-BuildDoc.doit(Oscar; strict=true, local_build=false, doctest=false)
+BuildDoc.doit(Oscar; warnonly=false, local_build=false, doctest=false)
 
 deploydocs(
    repo   = "github.com/oscar-system/Oscar.jl.git",

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -111,7 +111,7 @@ end
 
 function doit(
   Oscar::Module;
-  strict::Bool=true,
+  warnonly=false,
   local_build::Bool=false,
   doctest::Union{Bool,Symbol}=true,
 )
@@ -189,7 +189,7 @@ function doit(
       modules=[Oscar, Oscar.Hecke, Oscar.Nemo, Oscar.AbstractAlgebra, Oscar.Singular],
       clean=true,
       doctest=false,
-      strict=strict,
+      warnonly=warnonly,
       checkdocs=:none,
       pages=doc,
     )

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -182,8 +182,7 @@ function doit(
       Documenter.doctest(Oscar, fix = doctest === :fix)
     end
 
-    makedocs(
-      bib;
+    makedocs(;
       format=Documenter.HTML(; prettyurls=!local_build, collapselevel=1),
       sitename="Oscar.jl",
       modules=[Oscar, Oscar.Hecke, Oscar.Nemo, Oscar.AbstractAlgebra, Oscar.Singular],
@@ -192,6 +191,7 @@ function doit(
       warnonly=warnonly,
       checkdocs=:none,
       pages=doc,
+      plugins=[bib],
     )
   end
 

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -183,7 +183,13 @@ function doit(
     end
 
     makedocs(;
-      format=Documenter.HTML(; prettyurls=!local_build, collapselevel=1),
+      format=Documenter.HTML(;
+        prettyurls=!local_build,
+        collapselevel=1,
+        size_threshold=409600,
+        size_threshold_warn=204800,
+        size_threshold_ignore=["manualindex.md"],
+      ),
       sitename="Oscar.jl",
       modules=[Oscar, Oscar.Hecke, Oscar.Nemo, Oscar.AbstractAlgebra, Oscar.Singular],
       clean=true,

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -191,6 +191,7 @@ function doit(
       warnonly=warnonly,
       checkdocs=:none,
       pages=doc,
+      remotes=nothing,  # TODO: make work with Hecke, Nemo, AbstractAlgebra, see https://github.com/oscar-system/Oscar.jl/issues/588
       plugins=[bib],
     )
   end

--- a/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
+++ b/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
@@ -1633,7 +1633,7 @@ For $g=0$ we obtain a Klee-Minty cube,
 in particular for $e=g=0$ we obtain the standard cube. 
 
 # Example
-The following produces a $3$-dimensional Klee-Minty cube for $e=\frac{1}{3}.
+The following produces a $3$-dimensional Klee-Minty cube for $e=\frac{1}{3}$.
 ```jldoctest
 julia> c = goldfarb_cube(3,1//3,0)
 Polyhedron in ambient dimension 3

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -133,7 +133,7 @@ function start_doc_preview_server(;open_browser::Bool = true, port::Int = 8000)
 end
 
 @doc raw"""
-    build_doc(; doctest=false, strict=false, open_browser=true, start_server=false)
+    build_doc(; doctest=false, warnonly=true, open_browser=true, start_server=false)
 
 Build the manual of `Oscar.jl` locally and open the front page in a
 browser.
@@ -149,9 +149,11 @@ doctests are run with >= 1.7. Using a different Julia version may produce
 errors in some parts of Oscar, so please be careful, especially when setting
 `doctest=:fix`.
 
-The optional parameter `strict` is passed on to `makedocs` of `Documenter.jl`
-and if set to `true` then according to the manual of `Documenter.jl` "a
+The optional parameter `warnonly` is passed on to `makedocs` of `Documenter.jl`
+and if set to `false` then according to the manual of `Documenter.jl` "a
 doctesting error will always make makedocs throw an error in this mode".
+Alternatively, one can pass a list of symbols to `warnonly` to suppress
+errors for the given error types.
 
 To prevent the opening of the browser at the end, set the optional parameter
 `open_browser` to `false`.
@@ -177,11 +179,10 @@ using Revise, Oscar;
 The first run of `build_doc` will take the usual few minutes, subsequent runs
 will be significantly faster.
 """
-function build_doc(; doctest::Union{Symbol, Bool} = false, strict::Bool = false, open_browser::Bool = true, start_server::Bool = false)
+function build_doc(; doctest::Union{Symbol, Bool} = false, warnonly = true, open_browser::Bool = true, start_server::Bool = false)
   versioncheck = (VERSION.major == 1) && (VERSION.minor >= 7)
-  versionwarn = 
-"The Julia reference version for the doctests is 1.7 or later, but you are using
-$(VERSION). Running the doctests will produce errors that you do not expect."
+  versionwarn = """The Julia reference version for the doctests is 1.7 or later, but you are using
+                $(VERSION). Running the doctests will produce errors that you do not expect."""
   if doctest != false && !versioncheck
     @warn versionwarn
   end
@@ -189,7 +190,7 @@ $(VERSION). Running the doctests will produce errors that you do not expect."
     doc_init()
   end
   Pkg.activate(docsproject) do
-    Base.invokelatest(Main.BuildDoc.doit, Oscar; strict=strict, local_build=true, doctest=doctest)
+    Base.invokelatest(Main.BuildDoc.doit, Oscar; warnonly=warnonly, local_build=true, doctest=doctest)
   end
   if start_server
     start_doc_preview_server(open_browser = open_browser)


### PR DESCRIPTION
See title.

Documenter.jl v1.0 has a lot more features for cross-referencing between docs of different packages, that can be very useful for our copy-pasting hack. But I skipped dealing with that / deactivated it for now and leave the fix to https://github.com/oscar-system/Oscar.jl/issues/588.

Preview: https://docs.oscar-system.org/previews/PR2927/