### PR TITLE
Relax signature of `==(::MPolyIdeal, ::MPolyIdeal)`

### DIFF
--- a/docs/src/CommutativeAlgebra/ideals.md
+++ b/docs/src/CommutativeAlgebra/ideals.md
@@ -167,13 +167,13 @@ is_monomial(f::MPolyRingElem)
 ### Containment of Ideals
 
 ```@docs
-is_subset(I::MPolyIdeal{T}, J::MPolyIdeal{T}) where T
+is_subset(I::MPolyIdeal, J::MPolyIdeal)
 ```
 
 ### Equality of Ideals
 
 ```@docs
-==(I::MPolyIdeal{T}, J::MPolyIdeal{T}) where T
+==(I::MPolyIdeal, J::MPolyIdeal)
 ```
 
 ### Ideal Membership

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -66,11 +66,11 @@ end
 
 # elementary operations #######################################################
 @doc raw"""
-    check_base_rings(I::MPolyIdeal{T}, J::MPolyIdeal{T}) where T
+    check_base_rings(I::MPolyIdeal, J::MPolyIdeal)
 
 Throws an error if the base rings of the ideals `I` and `J` do not coincide.
 """
-function check_base_rings(I::MPolyIdeal{T}, J::MPolyIdeal{T}) where T
+function check_base_rings(I::MPolyIdeal, J::MPolyIdeal)
   if !isequal(base_ring(I), base_ring(J))
     error("Base rings must coincide.")
   end
@@ -970,7 +970,7 @@ end
 
 #######################################################
 @doc raw"""
-    ==(I::MPolyIdeal{T}, J::MPolyIdeal{T}) where T
+    ==(I::MPolyIdeal, J::MPolyIdeal)
 
 Return `true` if `I` is equal to `J`, `false` otherwise.
 
@@ -989,7 +989,8 @@ julia> I == J
 false
 ```
 """
-function ==(I::MPolyIdeal{T}, J::MPolyIdeal{T}) where T
+function ==(I::MPolyIdeal, J::MPolyIdeal)
+  check_base_rings(I, J)
   I === J && return true
   gens(I) == gens(J) && return true
   return issubset(I, J) && issubset(J, I)
@@ -999,7 +1000,7 @@ end
 
 #######################################################
 @doc raw"""
-    is_subset(I::MPolyIdeal{T}, J::MPolyIdeal{T}) where T
+    is_subset(I::MPolyIdeal, J::MPolyIdeal)
 
 Return `true` if `I` is contained in `J`, `false` otherwise.
 
@@ -1018,7 +1019,8 @@ julia> is_subset(I, J)
 true
 ```
 """
-function is_subset(I::MPolyIdeal{T}, J::MPolyIdeal{T}) where T
+function is_subset(I::MPolyIdeal, J::MPolyIdeal)
+  check_base_rings(I, J)
   return Singular.iszero(Singular.reduce(singular_generators(I), singular_groebner_generators(J)))
 end
 

--- a/test/Rings/mpoly-graded.jl
+++ b/test/Rings/mpoly-graded.jl
@@ -421,7 +421,7 @@ end
 
 
 
-@testset "homogenizaton: big principal ideal" begin
+@testset "homogenization: big principal ideal" begin
   # It is easy to honogenize a principal ideal: just homogenize the gen!
   # Do not really need lots of vars; just a "large" single polynomial
   LotsOfVars = 250;
@@ -463,9 +463,10 @@ end
                           x^3*y^2+x*y*z^3+x*y+y^2,
                           x^2*y^3*w+y^3*z^2*w-y*z^3*w^2-y*w^2], W1, "h");
   Ih_std = homogenization(I, "h")
-  Ih_expected = ideal(Ih_W1)
+  Ih_expected = ideal(base_ring(Ih_std), Ih_W1)
   @test Ih_std == Ih_expected
   Ih = homogenization(I, W1, "h")
+  Ih_expected = ideal(base_ring(Ih), Ih_W1)
   @test Ih == Ih_expected
   Ih_W2 = homogenization([x*y*z^3+x^3*y^2+y^2+x*y,
                           x*y*z^2*w+x^3*w^2+x^3*y*w+w^2,
@@ -473,19 +474,19 @@ end
                           x^5*w^3+x^3*y^3*z*w-y*z^2*w^2+2*x^5*y*w^2+x^2*w^3+x^5*y^2*w+y^3*z*w+x*y^2*z*w+x^2*y*w^2,
                           y*z^3*w^2-y^3*z^2*w-x^2*y^3*w+y*w^2],
                          W2, "h");
-  Ih_expected = ideal(Ih_W2)
   Ih = homogenization(I, W2, "h")
+  Ih_expected = ideal(base_ring(Ih), Ih_W2)
   @test Ih == Ih_expected
   Ih_W3 = homogenization([x^2*y^3*w+y^3*z^2*w-y*z^3*w^2-y*w^2,
                           x^3*y*w+x*y*z^2*w+x^3*w^2+w^2,
                           x^3*y^2+y^2+x*y*z^3+x*y],
                          W3, "h");
-  Ih_expected = ideal(Ih_W3)
   Ih = homogenization(I, W3, "h")
+  Ih_expected = ideal(base_ring(Ih), Ih_W3)
   @test Ih == Ih_expected
   # Ih_W4 = ????
-  # Ih_expected = ideal(Ih_W4)
   # Ih = homogenization(I, W4, "h")
+  # Ih_expected = ideal(base_ring(Ih), Ih_W4)
   # @test Ih = Ih_expected
   Ih_W2a = homogenization([x*y*z^3+x^3*y^2+y^2+x*y,
                            x*y*z^2*w+x^3*w^2+x^3*y*w+w^2,
@@ -493,12 +494,12 @@ end
                            y*z^3*w^2-y^3*z^2*w-x^2*y^3*w+y*w^2,
                            x^5*w^3+x^3*y^3*z*w-y*z^2*w^2+2*x^5*y*w^2+x^2*w^3+x^5*y^2*w+y^3*z*w+x*y^2*z*w+x^2*y*w^2],
                           W2a, "h");
-  Ih_expected = ideal(Ih_W2a)  
   Ih = homogenization(I, W2a, "h")
+  Ih_expected = ideal(base_ring(Ih), Ih_W2a)
   @test Ih == Ih_expected
   # Ih_W2b = ????
-  # Ih_expected = ideal(Ih_W2b)
   # Ih = homogenization(I, W2b, "h")
+  # Ih_expected = ideal(base_ring(Ih), Ih_W2b)
   # @test Ih == Ih_expected
 end
 

--- a/test/Rings/mpoly.jl
+++ b/test/Rings/mpoly.jl
@@ -85,6 +85,13 @@ end
   @test intersect(I,J,P) == ideal(R,[x^2*y^2, x^4, x*y^4])
   @test intersect(I,J,P) == intersect([I,J,P])
 
+  @test I != J
+  RR, (xx, yy) = grade(R, [1, 1])
+  @test_throws ErrorException ideal(R, [x]) == ideal(RR, [xx])
+  @test is_subset(I, I)
+  RR, (xx, yy) = polynomial_ring(QQ, ["xx", "yy"])
+  @test_throws ErrorException is_subset(ideal(R, [x]), ideal(RR, [xx]))
+
   f = x^2 + y^2
   g = x^4*y - x*y^3
   I = [f, g]


### PR DESCRIPTION
Small change, but requires a long explanation:
The current signature of `==` for ideals in multivariate polynomial rings is
```
==(::MPolyIdeal{T}, ::MPolyIdeal{T}) where T
```
so this function is not called if one tries to compare ideals in polynomial rings of different type (`T`), instead the generic `==` is called:
```
julia> R, (x, y) = QQ["x", "y"];

julia> S, (u, v) = grade(R, [ 1, 1 ]);

julia> ideal(R, [x]) == ideal(S, [u])
false

julia> @which ideal(R, [x]) == ideal(S, [u])
==(x, y)
     @ Base Base.jl:127
```
The answer `false` is of course not wrong, but in my opinion this should **error** because the comparison doesn't make sense; this is what I added in this PR:
```
julia> ideal(R, [x]) == ideal(S, [u])
ERROR: Base rings must coincide.
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] check_base_rings(I::MPolyIdeal{QQMPolyRingElem}, J::MPolyIdeal{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}})
   @ Oscar ~/.julia/dev/Oscar/src/Rings/mpoly-ideals.jl:75
 [3] ==(I::MPolyIdeal{QQMPolyRingElem}, J::MPolyIdeal{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}})
   @ Oscar ~/.julia/dev/Oscar/src/Rings/mpoly-ideals.jl:993
 [4] top-level scope
   @ REPL[6]:1

julia> @which ideal(R, [x]) == ideal(S, [u])
==(I::MPolyIdeal, J::MPolyIdeal)
     @ Oscar ~/.julia/dev/Oscar/src/Rings/mpoly-ideals.jl:992
```