### PR TITLE
Revamp `graded_polynomial_ring`

### DIFF
--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -1565,7 +1565,6 @@ julia> HC = gens(L[1]);
 julia> EMB = L[2]
 Map defined by a julia-function with inverse
   from homogeneous component of Graded multivariate polynomial ring in 5 variables over QQ of degree Element of G with components [2 1]
-
   to graded multivariate polynomial ring in 5 variables over QQ
 
 julia> for i in 1:length(HC) println(EMB(HC[i])) end


### PR DESCRIPTION
It now accepts exactly the same variants for specifying variables as `polynomial_ring` (by passing them on unchanged).

Moreover, the weight vector can now be passed as a keyword argument. At some point we could drop support for passing it as final argument.

Finally, weight vectors can now be specified as `AbstractVector` instances, making them slightly more usable.

So this is now valid:

    R, x, y = graded_polynomial_ring(QQ, :x => 1:3, :y => (1:2, 1:2); weights=1:7)


Once this is merged I'll update #2924.


The current plan is to follow up to this change in a *future PR* by adding another way for specifying the weights: instead of a flat vector assigning weights to the variables in sequential order, it will then be made possible to specify a weight *tuple* with entries that correspond to the "variable blocks" (such as `:x => 1:3` or `:y => (1:2, 1:2)` or `[:a, :b, :c]`). For each block one then can specify either...
- an integer or abelian group element: all variables in the block will get that weight
- a vector/matrix/higher array of integers/group elements of length/shape matching the length/shape of the variables in that block
- maybe more... tell me your wishes


This will then make it possible to do e.g. this, with three variable blocks:

    R, (a,b), x, y = graded_polynomial_ring(QQ, [:a, :b], :x => 1:3, :y => (1:2, 1:2);
                                            weights=([1,2], 3, [4 5 ; 6 7]))

In that example,
- `weight(a) == 1`
- `weight(b) == 2`
- `weight(x[i]) == 3` for $1\leq i\leq 3$
- `weight(y[i,j])` is 4, 5, 6 or 7, depending on the position in the weight matrix


CC @mgkurtz (this should be mostly orthogonal to your work, except maybe for the macro bit...)