### PR TITLE
Improvements and bug fixes for toric varieties

### DIFF
--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -412,9 +412,7 @@ julia> ngens(ideal_of_linear_relations(p2))
 ```
 """
 @attr MPolyIdeal function ideal_of_linear_relations(v::NormalToricVarietyType)
-    R, _ = polynomial_ring(coefficient_ring(v), coordinate_names(v))
-    weights = [1 for i in 1:ngens(R)]
-    grade(R, weights)
+    R, _ = graded_polynomial_ring(coefficient_ring(v), coordinate_names(v), cached = false)
     return ideal_of_linear_relations(R, v)
 end
 

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/standard_constructions.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/standard_constructions.jl
@@ -10,6 +10,7 @@ Normal toric variety
 ```
 """
 function affine_space(::Type{NormalToricVariety}, d::Int)
+  @req d >= 0 "Dimension must be non-negative"
   C = positive_hull(identity_matrix(ZZ, d))
   variety = normal_toric_variety(C)
   return variety
@@ -28,6 +29,7 @@ Normal toric variety
 ```
 """
 function projective_space(::Type{NormalToricVariety}, d::Int)
+  @req d >= 0 "Dimension must be non-negative"
   f = normal_fan(Oscar.simplex(d))
   pm_object = Polymake.fulton.NormalToricVariety(Oscar.pm_object(f))
   variety = NormalToricVariety(pm_object)
@@ -51,6 +53,7 @@ Normal toric variety
 ```
 """
 function weighted_projective_space(::Type{NormalToricVariety}, w::Vector{T}) where {T <: IntegerUnion}
+  @req length(w) > 0 "At least one weight must be specified"
   if all(a -> isone(a), w)
     return projective_space(NormalToricVariety, length(w)-1)
   end


### PR DESCRIPTION
* Use graded_polynomial_ring to construct the ideal of linear relations. (So far, no grading was given to its ambient ring.)
* Add checks to (weighted) projective space and affine space to prevent edge cases/inconsistent input.

Hopefully, we can also fix the inconsistent behavior among affine_space and projective_space of dimension 0. Details below.