### PR TITLE
PolyhedralFan: fix for trivial fans

### DIFF
--- a/test/PolyhedralGeometry/polyhedral_fan.jl
+++ b/test/PolyhedralGeometry/polyhedral_fan.jl
@@ -80,6 +80,17 @@
     @test lineality_space(F2NR) == collect(eachrow(L))
     @test ray_indices(maximal_cones(F2NR)) == incidence2
     @test IncidenceMatrix(maximal_cones(F2NR)) == incidence2
+
+    C = positive_hull(f, identity_matrix(ZZ, 0))
+    pf = polyhedral_fan(C)
+    @test n_maximal_cones(pf) == 1
+    @test dim(pf) == 0
+    pfc = polyhedral_fan(maximal_cones(pf))
+    @test n_maximal_cones(pfc) == 1
+
+    C = positive_hull(f, vcat(identity_matrix(ZZ, 4), -identity_matrix(ZZ,4)))
+    pf = polyhedral_fan(C)
+    @test n_maximal_cones(pf) == 1
   end
 
 end


### PR DESCRIPTION
Should fix the issue(s) with trivial fans mentioned in https://github.com/oscar-system/Oscar.jl/pull/2942#issuecomment-1772773236

```julia
julia> C = positive_hull(identity_matrix(ZZ, 0))
Polyhedral cone in ambient dimension 0

julia> pf = polyhedral_fan(C)
Polyhedral fan in ambient dimension 0

julia> maximal_cones(pf)
1-element SubObjectIterator{Cone{QQFieldElem}}:
 Polyhedral cone in ambient dimension 0

julia> n_maximal_cones(polyhedral_fan(maximal_cones(polyhedral_fan(C))))
1
```