### PR TITLE
Refactor graphs, streamline some polyhedral constructors

### DIFF
--- a/docs/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties.md
@@ -29,9 +29,7 @@ affine_normal_toric_variety(v::NormalToricVariety)
 ### Normal Toric Varieties
 
 ```@docs
-normal_toric_variety(rays::AbstractCollection[RayVector], max_cones::Vector{Vector{Int64}}; non_redundant::Bool = false)
-normal_toric_variety(PF::PolyhedralFan)
-normal_toric_variety(P::Polyhedron)
+normal_toric_variety
 ```
 
 ### Famous Toric Vareties

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -22,7 +22,7 @@ function _auxiliary_base_space(auxiliary_base_variable_names::Vector{String}, au
   if dim(auxiliary_base_space) != d
     integral_rays = matrix(ZZ, rays(variety))
     new_max_cones = IncidenceMatrix(cones(variety, d))
-    auxiliary_base_space = normal_toric_variety(integral_rays, new_max_cones; non_redundant = true)
+    auxiliary_base_space = normal_toric_variety(new_max_cones, integral_rays; non_redundant = true)
   end
 
   # Set attributes of this base space and return it
@@ -81,7 +81,7 @@ function _ambient_space(base::NormalToricVariety, fiber_ambient_space::NormalTor
   ambient_space_max_cones = IncidenceMatrix(vcat(ambient_space_max_cones...))
   
   # Construct the ambient space
-  ambient_space = normal_toric_variety(ambient_space_rays, ambient_space_max_cones; non_redundant = true)
+  ambient_space = normal_toric_variety(ambient_space_max_cones, ambient_space_rays; non_redundant = true)
   
   # Compute torusinvariant weil divisor group and the class group
   ambient_space_torusinvariant_weil_divisor_group = free_abelian_group(nrows(ambient_space_rays))
@@ -198,7 +198,7 @@ function sample_toric_variety()
           [5, 11, 12], [5, 6, 32], [5, 6, 12], [4, 31, 32], [4, 10, 11], [4, 5, 32],
           [4, 5, 11], [3, 30, 31], [3, 9, 10], [3, 4, 31], [3, 4, 10], [2, 29, 30],
           [2, 8, 9], [2, 3, 30], [2, 3, 9], [1, 8, 29], [1, 2, 29], [1, 2, 8]])
-  return normal_toric_variety(rays, cones)
+  return normal_toric_variety(cones, rays)
 end
 
 

--- a/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/special_attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/special_attributes.jl
@@ -27,7 +27,7 @@ true
 julia> ngens(chow_ring(p2))
 3
 
-julia> v = normal_toric_variety([[1, 0], [0, 1], [-1, -1]], [[1], [2], [3]])
+julia> v = normal_toric_variety(IncidenceMatrix([[1], [2], [3]]), [[1, 0], [0, 1], [-1, -1]])
 Normal toric variety
 
 julia> is_complete(v)

--- a/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/methods.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/methods.jl
@@ -58,9 +58,9 @@ julia> m = 2;
 
 julia> ray_generators = [e1, -e1, e2, e3, - e2 - e3 - m * e1];
 
-julia> max_cones = [[1,3,4], [1,3,5], [1,4,5], [2,3,4], [2,3,5], [2,4,5]];
+julia> max_cones = IncidenceMatrix([[1,3,4], [1,3,5], [1,4,5], [2,3,4], [2,3,5], [2,4,5]]);
 
-julia> X = normal_toric_variety(ray_generators, max_cones; non_redundant = true)
+julia> X = normal_toric_variety(max_cones, ray_generators; non_redundant = true)
 Normal toric variety
 
 julia> cox_ring(X)

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -63,7 +63,7 @@ end
 
 
 @doc raw"""
-    normal_toric_variety(rays::AbstractCollection[RayVector], max_cones::IncidenceMatrix; non_redundant::Bool = false)
+    normal_toric_variety(max_cones::IncidenceMatrix, rays::AbstractCollection[RayVector]; non_redundant::Bool = false)
 
 Construct a normal toric variety $X$ by providing the rays and maximal cones
 as vector of vectors. By default, this method assumes that the input is not
@@ -82,23 +82,23 @@ julia> ray_generators = [[1,0], [0, 1], [-1, 5], [0, -1]]
  [-1, 5]
  [0, -1]
 
-julia> max_cones = [[1, 2], [2, 3], [3, 4], [4, 1]]
-4-element Vector{Vector{Int64}}:
- [1, 2]
- [2, 3]
- [3, 4]
- [4, 1]
+julia> max_cones = IncidenceMatrix([[1, 2], [2, 3], [3, 4], [4, 1]])
+4×4 IncidenceMatrix
+[1, 2]
+[2, 3]
+[3, 4]
+[1, 4]
 
-julia> normal_toric_variety(ray_generators, max_cones)
+julia> normal_toric_variety(max_cones, ray_generators)
 Normal toric variety
 
-julia> normal_toric_variety(ray_generators, max_cones; non_redundant = true)
+julia> normal_toric_variety(max_cones, ray_generators; non_redundant = true)
 Normal toric variety
 ```
 """
-normal_toric_variety(rays::AbstractCollection[RayVector], max_cones::Vector{Vector{Int64}}; non_redundant::Bool = false) = normal_toric_variety(rays, IncidenceMatrix(max_cones); non_redundant = non_redundant)
-function normal_toric_variety(rays::AbstractCollection[RayVector], max_cones::IncidenceMatrix; non_redundant::Bool = false)
-  fan = polyhedral_fan(rays, max_cones; non_redundant=non_redundant)
+normal_toric_variety(max_cones::Vector{Vector{Int64}}, rays::AbstractCollection[RayVector]; non_redundant::Bool = false) = normal_toric_variety(IncidenceMatrix(max_cones), rays; non_redundant)
+function normal_toric_variety(max_cones::IncidenceMatrix, rays::AbstractCollection[RayVector]; non_redundant::Bool = false)
+  fan = polyhedral_fan(max_cones, rays; non_redundant)
   return normal_toric_variety(fan)
 end
 

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/standard_constructions.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/standard_constructions.jl
@@ -80,8 +80,8 @@ Normal toric variety
 """
 function hirzebruch_surface(::Type{NormalToricVariety}, r::Int)
   fan_rays = [1 0; 0 1; -1 r; 0 -1]
-  cones = [[1, 2], [2, 3], [3, 4], [4, 1]]
-  variety = normal_toric_variety(fan_rays, cones; non_redundant = true)
+  cones = IncidenceMatrix([[1, 2], [2, 3], [3, 4], [4, 1]])
+  variety = normal_toric_variety(cones, fan_rays; non_redundant = true)
   set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(4))
   set_attribute!(variety, :class_group, free_abelian_group(2))
   weights = matrix(ZZ, [1 0; 0 1; 1 0; r 1])
@@ -126,7 +126,7 @@ function del_pezzo_surface(::Type{NormalToricVariety}, b::Int)
     fan_rays = [1 0; 0 1; -1 -1; 1 1; 0 -1; -1 0]
     cones = IncidenceMatrix([[1, 4], [2, 4], [1, 5], [5, 3], [2, 6], [6, 3]])
   end
-  variety = normal_toric_variety(fan_rays, cones; non_redundant = true)
+  variety = normal_toric_variety(cones, fan_rays; non_redundant = true)
   set_attribute!(variety, :torusinvariant_weil_divisor_group, free_abelian_group(b+3))
   set_attribute!(variety, :class_group, free_abelian_group(b+1))
   if b == 1
@@ -245,7 +245,7 @@ function normal_toric_variety_from_star_triangulation(P::Polyhedron)
   integral_rays = vcat([pts[k,:] for k in 2:nrows(pts)])
 
   # construct the variety
-  return normal_toric_variety(integral_rays, max_cones; non_redundant = true)
+  return normal_toric_variety(max_cones, integral_rays; non_redundant = true)
 end
 
 
@@ -298,7 +298,7 @@ function normal_toric_varieties_from_star_triangulations(P::Polyhedron)
   max_cones = [IncidenceMatrix([[c[i]-1 for i in 2:length(c)] for c in t]) for t in trias]
   
   # construct the varieties
-  return [normal_toric_variety(integral_rays, cones; non_redundant = true) for cones in max_cones]
+  return [normal_toric_variety(cones, integral_rays; non_redundant = true) for cones in max_cones]
 end
 
 
@@ -341,7 +341,7 @@ function normal_toric_variety_from_glsm(charges::ZZMatrix)
   # construct varieties
   triang = _find_full_star_triangulation(pts)
   max_cones = IncidenceMatrix([[c[i]-1 for i in 2:length(c)] for c in triang])
-  variety = normal_toric_variety(integral_rays, max_cones; non_redundant = true)
+  variety = normal_toric_variety(max_cones, integral_rays; non_redundant = true)
 
   # set the attributes and return the variety
   set_attribute!(variety, :torusinvariant_weil_divisor_group, G1)
@@ -408,7 +408,7 @@ function normal_toric_varieties_from_glsm(charges::ZZMatrix)
   # construct varieties
   integral_rays = vcat([pts[k,:] for k in 2:nrows(pts)])
   max_cones = [IncidenceMatrix([[c[i]-1 for i in 2:length(c)] for c in t]) for t in star_triangulations(pts; full = true)]
-  varieties = [normal_toric_variety(integral_rays, cones; non_redundant = true) for cones in max_cones]
+  varieties = [normal_toric_variety(cones, integral_rays; non_redundant = true) for cones in max_cones]
   
   # set the map from Div_T -> Cl to the desired matrix
   for v in varieties

--- a/src/AlgebraicGeometry/ToricVarieties/Proj/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/Proj/constructors.jl
@@ -76,7 +76,7 @@ function _proj_and_total_space(is_proj::Bool, E::Vector{T}) where T <: Union{Tor
 
   total_rays_gens = vcat([modified_ray_gens[ray] for ray in rays(v)], [vcat(ray_vector(zeros(Int64, dim(v))), l[i]) for i in eachindex(E)])
 
-  return normal_toric_variety(polyhedral_fan(total_rays_gens, IncidenceMatrix(new_maximal_cones)))
+  return normal_toric_variety(polyhedral_fan(IncidenceMatrix(new_maximal_cones), total_rays_gens))
 end
 
 function _m_sigma(sigma::Cone{QQFieldElem}, pol_sigma::Cone{QQFieldElem}, D::Union{ToricDivisor, ToricLineBundle})::RayVector{QQFieldElem}

--- a/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/attributes.jl
@@ -37,7 +37,7 @@ julia> is_feasible(polyhedron(td2))
 false
 ```
 """
-@attr Polyhedron polyhedron(td::ToricDivisor) = polyhedron(pm_tdivisor(td).SECTION_POLYTOPE)
+@attr Polyhedron polyhedron(td::ToricDivisor) = polyhedron(pm_object(td).SECTION_POLYTOPE)
 
 
 @doc raw"""

--- a/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/constructors.jl
@@ -11,7 +11,7 @@
                         coeffs::Vector{T}) where {T <: IntegerUnion} = new(polymake_divisor, toric_variety, [ZZRingElem(c) for c in coeffs])
 end
 
-pm_tdivisor(td::ToricDivisor) = td.polymake_divisor
+pm_object(td::ToricDivisor) = td.polymake_divisor
 
 
 ######################

--- a/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/properties.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/properties.jl
@@ -15,7 +15,7 @@ julia> is_cartier(td)
 true
 ```
 """
-@attr Bool is_cartier(td::ToricDivisor) = pm_tdivisor(td).CARTIER
+@attr Bool is_cartier(td::ToricDivisor) = pm_object(td).CARTIER
 
 
 @doc raw"""
@@ -35,7 +35,7 @@ julia> is_principal(td)
 false
 ```
 """
-@attr Bool is_principal(td::ToricDivisor) = pm_tdivisor(td).PRINCIPAL
+@attr Bool is_principal(td::ToricDivisor) = pm_object(td).PRINCIPAL
 
 @attr Bool is_trivial(td::ToricDivisor) = all([c == 0 for c in coefficients(td)])
 
@@ -57,7 +57,7 @@ julia> is_basepoint_free(td)
 true
 ```
 """
-@attr Bool is_basepoint_free(td::ToricDivisor) = pm_tdivisor(td).BASEPOINT_FREE
+@attr Bool is_basepoint_free(td::ToricDivisor) = pm_object(td).BASEPOINT_FREE
 
 
 @doc raw"""
@@ -103,7 +103,7 @@ julia> is_integral(td)
 true
 ```
 """
-@attr Bool is_integral(td::ToricDivisor) = pm_tdivisor(td).INTEGRAL
+@attr Bool is_integral(td::ToricDivisor) = pm_object(td).INTEGRAL
 
 
 @doc raw"""
@@ -122,7 +122,7 @@ julia> is_ample(td)
 false
 ```
 """
-@attr Bool is_ample(td::ToricDivisor) = pm_tdivisor(td).AMPLE
+@attr Bool is_ample(td::ToricDivisor) = pm_object(td).AMPLE
 
 
 @doc raw"""
@@ -141,7 +141,7 @@ julia> is_very_ample(td)
 false
 ```
 """
-@attr Bool is_very_ample(td::ToricDivisor) = pm_tdivisor(td).VERY_AMPLE
+@attr Bool is_very_ample(td::ToricDivisor) = pm_object(td).VERY_AMPLE
 
 
 @doc raw"""
@@ -160,7 +160,7 @@ julia> is_nef(td)
 true
 ```
 """
-@attr Bool is_nef(td::ToricDivisor) = pm_tdivisor(td).NEF
+@attr Bool is_nef(td::ToricDivisor) = pm_object(td).NEF
 
 
 @doc raw"""
@@ -179,7 +179,7 @@ julia> is_q_cartier(td)
 true
 ```
 """
-@attr Bool is_q_cartier(td::ToricDivisor) = pm_tdivisor(td).Q_CARTIER
+@attr Bool is_q_cartier(td::ToricDivisor) = pm_object(td).Q_CARTIER
 
 
 @doc raw"""

--- a/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/standard_constructions.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/standard_constructions.jl
@@ -16,7 +16,7 @@ Toric morphism
     mapping_matrix = matrix(ZZ, rays(variety))
     max_cones_for_cox_variety = ray_indices(maximal_cones(variety))
     rays_for_cox_variety = matrix(ZZ, [[if i==j 1 else 0 end for j in 1:nrays(variety)] for i in 1:nrays(variety)])
-    cox_variety = normal_toric_variety(polyhedral_fan(rays_for_cox_variety, max_cones_for_cox_variety))
+    cox_variety = normal_toric_variety(polyhedral_fan(max_cones_for_cox_variety, rays_for_cox_variety))
     return toric_morphism(cox_variety, mapping_matrix, variety)
 end
 

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -63,12 +63,12 @@ Undirected graph with 2 nodes and the following edges:
 """
 graph_from_adjacency_matrix(::Type, G::Union{MatElem, Matrix})
 
-function graph_from_adjacency_matrix(::Type{Undirected}, G::Union{MatElem, Matrix})
+function graph_from_adjacency_matrix(::Type{T}, G::Union{MatElem, Matrix}) where {T <: Union{Directed, Undirected}}
   n = nrows(G)
   @req nrows(G)==ncols(G) "not a square matrix"
-  g = Graph{Undirected}(n)
+  g = Graph{T}(n)
   for i in 1:n
-    for j in 1:i-1
+    for j in 1:(T==Undirected ? i-1 : n)
       if isone(G[i,j])
         add_edge!(g, i, j)
       else
@@ -79,21 +79,6 @@ function graph_from_adjacency_matrix(::Type{Undirected}, G::Union{MatElem, Matri
   return g
 end
 
-function graph_from_adjacency_matrix(::Type{Directed}, G::Union{MatElem, Matrix})
-  n = nrows(G)
-  @req nrows(G)==ncols(G) "not a square matrix"
-  g = Graph{Directed}(n)
-  for i in 1:n
-    for j in 1:n
-      if isone(G[i,j])
-        add_edge!(g, i, j)
-      else
-        iszero(G[i,j]) || error("not an adjacency matrix")
-      end
-    end
-  end
-  return g
-end
 
 _has_node(G::Graph, node::Int64) = 0 < node <= nv(G)
 

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -220,11 +220,7 @@ julia> nv(g)
 ```
 """
 function add_vertices!(g::Graph{T}, n::Int64) where {T <: Union{Directed, Undirected}}
-  result = 0
-  for i = 1:n
-    result += add_vertex!(g) ? 1 : 0
-  end
-  return result
+  return count(_->add_vertex!(g), 1:n)
 end
 
 

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -86,20 +86,27 @@ _has_node(G::Graph, node::Int64) = 0 < node <= nv(G)
     add_edge!(g::Graph{T}, s::Int64, t::Int64) where {T <: Union{Directed, Undirected}}
 
 Add edge `(s,t)` to the graph `g`.
+Return `true` if a new edge `(s,t)` was added, `false` otherwise.
 
 # Examples
 ```jldoctest
 julia> g = Graph{Directed}(2);
 
-julia> add_edge!(g, 1, 2);
+julia> add_edge!(g, 1, 2)
+true
+
+julia> add_edge!(g, 1, 2)
+false
 
 julia> ne(g)
 1
 ```
 """
 function add_edge!(g::Graph{T}, source::Int64, target::Int64) where {T <: Union{Directed, Undirected}}
-    @req _has_node(g, source) && _has_node(g, target) "Nodes must be between 1 and $(nv(g)), but edge given is $source -- $target"
-    Polymake._add_edge(pm_object(g), source-1, target-1)
+  _has_node(g, source) && _has_node(g, target) || return false
+  old_nedges = nedges(g)
+  Polymake._add_edge(pm_object(g), source-1, target-1)
+  return nedges(g) == old_nedges + 1
 end
 
 
@@ -107,32 +114,39 @@ end
     rem_edge!(g::Graph{T}, s::Int64, t::Int64) where {T <: Union{Directed, Undirected}}
 
 Remove edge `(s,t)` from the graph `g`.
+Return `true` if there was an edge from `s` to `t` and it got removed, `false`
+otherwise.
 
 # Examples
 ```jldoctest
 julia> g = Graph{Directed}(2);
 
-julia> add_edge!(g, 1, 2);
+julia> add_edge!(g, 1, 2)
+true
 
 julia> ne(g)
 1
 
-julia> rem_edge!(g, 1, 2);
+julia> rem_edge!(g, 1, 2)
+true
 
 julia> ne(g)
 0
 ```
 """
 function rem_edge!(g::Graph{T}, s::Int64, t::Int64) where {T <: Union{Directed, Undirected}}
-    pmg = pm_object(g)
-    return Polymake._rem_edge(pmg, s-1, t-1)
+  has_edge(g, s, t) || return false
+  old_nedges = nedges(g)
+  Polymake._rem_edge(pm_object(g), s-1, t-1)
+  return nedges(g) == old_nedges - 1
 end
 
 
 @doc raw"""
     add_vertex!(g::Graph{T}) where {T <: Union{Directed, Undirected}}
 
-Add a vertex to the graph `g`. The return value is the new vertex.
+Add a vertex to the graph `g`. Return `true` if there a new vertex was actually
+added.
 
 # Examples
 ```jldoctest
@@ -142,7 +156,7 @@ julia> nv(g)
 2
 
 julia> add_vertex!(g)
-3
+true
 
 julia> nv(g)
 3
@@ -150,14 +164,17 @@ julia> nv(g)
 """
 function add_vertex!(g::Graph{T}) where {T <: Union{Directed, Undirected}}
     pmg = pm_object(g)
-    return Polymake._add_vertex(pmg) + 1
+    old_nvertices = nv(g)
+    Polymake._add_vertex(pmg)
+    return nv(g) - 1 == old_nvertices
 end
 
 
 @doc raw"""
     rem_vertex!(g::Graph{T}, v::Int64) where {T <: Union{Directed, Undirected}}
 
-Remove the vertex `v` from the graph `g`.
+Remove the vertex `v` from the graph `g`. Return `true` if node `v` existed and
+was actually removed, `false` otherwise.
 
 # Examples
 ```jldoctest
@@ -167,23 +184,27 @@ julia> nv(g)
 2
 
 julia> rem_vertex!(g, 1)
+true
 
 julia> nv(g)
 1
 ```
 """
 function rem_vertex!(g::Graph{T}, v::Int64) where {T <: Union{Directed, Undirected}}
-    pmg = pm_object(g)
-    result = Polymake._rem_vertex(pmg, v-1)
-    Polymake._squeeze(pmg)
-    return result
+  _has_node(g, v) || return false
+  pmg = pm_object(g)
+  old_nvertices = nv(g)
+  result = Polymake._rem_vertex(pmg, v-1)
+  Polymake._squeeze(pmg)
+  return nv(g) + 1 == old_nvertices
 end
 
 
 @doc raw"""
     add_vertices!(g::Graph{T}, n::Int64) where {T <: Union{Directed, Undirected}}
 
-Add a `n` new vertices to the graph `g`.
+Add a `n` new vertices to the graph `g`. Return the number of vertices that
+were actually added to the graph `g`.
 
 # Examples
 ```jldoctest
@@ -199,9 +220,11 @@ julia> nv(g)
 ```
 """
 function add_vertices!(g::Graph{T}, n::Int64) where {T <: Union{Directed, Undirected}}
-    for i = 1:n
-        add_vertex!(g)
-    end
+  result = 0
+  for i = 1:n
+    result += add_vertex!(g) ? 1 : 0
+  end
+  return result
 end
 
 

--- a/src/PolyhedralGeometry/PolyhedralFan/constructors.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/constructors.jl
@@ -45,7 +45,7 @@ julia> R = [1 0; 1 1; 0 1; -1 0; 0 -1];
 
 julia> IM=IncidenceMatrix([[1,2],[2,3],[3,4],[4,5],[1,5]]);
 
-julia> PF=polyhedral_fan(R,IM)
+julia> PF=polyhedral_fan(IM, R)
 Polyhedral fan in ambient dimension 2
 ```
 
@@ -57,7 +57,7 @@ julia> L = [0 1 0];
 
 julia> IM = IncidenceMatrix([[1],[2]]);
 
-julia> PF=polyhedral_fan(R, L, IM)
+julia> PF=polyhedral_fan(IM, R, L)
 Polyhedral fan in ambient dimension 3
 
 julia> lineality_dim(PF)
@@ -65,9 +65,9 @@ julia> lineality_dim(PF)
 ```
 """
 function polyhedral_fan(f::scalar_type_or_field,
+                        Incidence::IncidenceMatrix,
                         Rays::AbstractCollection[RayVector], 
-                        LS::Union{AbstractCollection[RayVector], Nothing},
-                        Incidence::IncidenceMatrix; 
+                        LS::Union{AbstractCollection[RayVector], Nothing};
                         non_redundant::Bool = false)
   parent_field, scalar_type = _determine_parent_and_scalar(f, Rays, LS)
   RM = unhomogenized_matrix(Rays)
@@ -90,9 +90,9 @@ function polyhedral_fan(f::scalar_type_or_field,
     ), parent_field)
   end
 end
-polyhedral_fan(f::scalar_type_or_field, Rays::AbstractCollection[RayVector], Incidence::IncidenceMatrix; non_redundant::Bool = false) = polyhedral_fan(f, Rays, nothing, Incidence; non_redundant=non_redundant)
-polyhedral_fan(Rays::AbstractCollection[RayVector], LS::Union{AbstractCollection[RayVector], Nothing}, Incidence::IncidenceMatrix; non_redundant::Bool = false) = polyhedral_fan(QQFieldElem, Rays, LS, Incidence; non_redundant = non_redundant)
-polyhedral_fan(Rays::AbstractCollection[RayVector], Incidence::IncidenceMatrix; non_redundant::Bool = false) = polyhedral_fan(QQFieldElem, Rays, Incidence; non_redundant = non_redundant)
+polyhedral_fan(f::scalar_type_or_field, Incidence::IncidenceMatrix, Rays::AbstractCollection[RayVector]; non_redundant::Bool = false) = polyhedral_fan(f, Incidence, Rays, nothing; non_redundant)
+polyhedral_fan(Incidence::IncidenceMatrix, Rays::AbstractCollection[RayVector], LS::Union{AbstractCollection[RayVector], Nothing}; non_redundant::Bool = false) = polyhedral_fan(QQFieldElem, Incidence, Rays, LS; non_redundant)
+polyhedral_fan(Incidence::IncidenceMatrix, Rays::AbstractCollection[RayVector]; non_redundant::Bool = false) = polyhedral_fan(QQFieldElem, Incidence, Rays; non_redundant)
 
 """
     pm_object(PF::PolyhedralFan)
@@ -117,10 +117,10 @@ function polyhedral_fan(cones::AbstractVector{Cone{T}}; non_redundant::Bool=fals
 end
 
 #Same construction for when the user gives Matrix{Bool} as incidence matrix
-polyhedral_fan(f::scalar_type_or_field, Rays::AbstractCollection[RayVector], LS::AbstractCollection[RayVector], Incidence::Matrix{Bool}) =
-  polyhedral_fan(f, Rays, LS, IncidenceMatrix(Polymake.IncidenceMatrix(Incidence)))
-polyhedral_fan(f::scalar_type_or_field, Rays::AbstractCollection[RayVector], Incidence::Matrix{Bool}) =
-  polyhedral_fan(f, Rays, IncidenceMatrix(Polymake.IncidenceMatrix(Incidence)))
+polyhedral_fan(f::scalar_type_or_field, Incidence::Matrix{Bool}, Rays::AbstractCollection[RayVector], LS::AbstractCollection[RayVector]) =
+  polyhedral_fan(f, IncidenceMatrix(Polymake.IncidenceMatrix(Incidence)), Rays, LS)
+polyhedral_fan(f::scalar_type_or_field, Incidence::Matrix{Bool}, Rays::AbstractCollection[RayVector]) =
+  polyhedral_fan(f, IncidenceMatrix(Polymake.IncidenceMatrix(Incidence)), Rays)
 
 polyhedral_fan(C::Cone{T}) where T<:scalar_types = polyhedral_fan([C])
 

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -230,7 +230,7 @@ Return the dimension of `PF`.
 This fan in the plane contains a 2-dimensional cone and is thus 2-dimensional
 itself.
 ```jldoctest
-julia> PF = polyhedral_fan([1 0; 0 1; -1 -1], IncidenceMatrix([[1, 2], [3]]));
+julia> PF = polyhedral_fan(IncidenceMatrix([[1, 2], [3]]), [1 0; 0 1; -1 -1]);
 
 julia> dim(PF)
 2
@@ -247,7 +247,7 @@ Return the number of maximal cones of `PF`.
 The cones given in this construction are non-redundant. Thus there are two
 maximal cones.
 ```jldoctest
-julia> PF = polyhedral_fan([1 0; 0 1; -1 -1], IncidenceMatrix([[1, 2], [3]]));
+julia> PF = polyhedral_fan(IncidenceMatrix([[1, 2], [3]]), [1 0; 0 1; -1 -1]);
 
 julia> n_maximal_cones(PF)
 2
@@ -264,7 +264,7 @@ Return the number of cones of `PF`.
 The cones given in this construction are non-redundant. There are six
 cones in this fan.
 ```jldoctest
-julia> PF = polyhedral_fan([1 0; 0 1; -1 -1], IncidenceMatrix([[1, 2], [3]]))
+julia> PF = polyhedral_fan(IncidenceMatrix([[1, 2], [3]]), [1 0; 0 1; -1 -1])
 Polyhedral fan in ambient dimension 2
 
 julia> n_cones(PF)
@@ -386,7 +386,7 @@ This fan consists of two cones, one containing all the points with $y ≤ 0$ and
 one containing all the points with $y ≥ 0$. The fan's lineality is the common
 lineality of these two cones, i.e. in $x$-direction.
 ```jldoctest
-julia> PF = polyhedral_fan([1 0; 0 1; -1 0; 0 -1], IncidenceMatrix([[1, 2, 3], [3, 4, 1]]))
+julia> PF = polyhedral_fan(IncidenceMatrix([[1, 2, 3], [3, 4, 1]]), [1 0; 0 1; -1 0; 0 -1])
 Polyhedral fan in ambient dimension 2
 
 julia> lineality_space(PF)
@@ -441,7 +441,7 @@ Determine whether `PF` is smooth.
 Even though the cones of this fan cover the positive orthant together, one of
 these und thus the whole fan is not smooth.
 ```jldoctest
-julia> PF = polyhedral_fan([0 1; 2 1; 1 0], IncidenceMatrix([[1, 2], [2, 3]]));
+julia> PF = polyhedral_fan(IncidenceMatrix([[1, 2], [2, 3]]), [0 1; 2 1; 1 0]);
 
 julia> is_smooth(PF)
 false
@@ -457,7 +457,7 @@ Determine whether `PF` is regular, i.e. the normal fan of a polytope.
 # Examples
 This fan is not complete and thus not regular.
 ```jldoctest
-julia> PF = polyhedral_fan([1 0; 0 1; -1 -1], IncidenceMatrix([[1, 2], [3]]));
+julia> PF = polyhedral_fan(IncidenceMatrix([[1, 2], [3]]), [1 0; 0 1; -1 -1]);
 
 julia> is_regular(PF)
 false
@@ -473,7 +473,7 @@ Determine whether `PF` is pure, i.e. all maximal cones have the same dimension.
 
 # Examples
 ```jldoctest
-julia> PF = polyhedral_fan([1 0; 0 1; -1 -1], IncidenceMatrix([[1, 2], [3]]));
+julia> PF = polyhedral_fan(IncidenceMatrix([[1, 2], [3]]), [1 0; 0 1; -1 -1]);
 
 julia> is_pure(PF)
 false
@@ -490,7 +490,7 @@ dimension.
 
 # Examples
 ```jldoctest
-julia> PF = polyhedral_fan([1 0; 0 1; -1 -1], IncidenceMatrix([[1, 2], [3]]));
+julia> PF = polyhedral_fan(IncidenceMatrix([[1, 2], [3]]), [1 0; 0 1; -1 -1]);
 
 julia> is_fulldimensional(PF)
 true

--- a/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
@@ -127,7 +127,7 @@ function star_subdivision(Sigma::_FanLikeType, new_ray::AbstractVector{<:Integer
     end
   end
   
-  return polyhedral_fan(coefficient_field(Sigma), new_rays, IncidenceMatrix([nc for nc in new_cones]); non_redundant=true)
+  return polyhedral_fan(coefficient_field(Sigma), IncidenceMatrix([nc for nc in new_cones]), new_rays; non_redundant=true)
 end
 
 function _get_refinable_facets(Sigma::_FanLikeType, new_ray::AbstractVector{<:IntegerUnion}, refinable_cones::Vector{Int}, facet_normals::AbstractMatrix, mc_old::IncidenceMatrix)

--- a/src/TropicalGeometry/groebner_fan.jl
+++ b/src/TropicalGeometry/groebner_fan.jl
@@ -390,7 +390,7 @@ function polyhedral_fan_from_cones(listOfCones::Vector{<:Cone})
     fanIncidences = IncidenceMatrix(fanIncidences)
     fanRays = matrix(QQ,fanRays)
     fanLineality = matrix(QQ,lineality_space(first(listOfCones)))
-    return polyhedral_fan(fanRays,fanLineality,fanIncidences)
+    return polyhedral_fan(fanIncidences, fanRays, fanLineality)
 end
 
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -265,14 +265,14 @@ function PolyhedralFan{T}(Rays::AbstractCollection[RayVector],
                           Incidence::IncidenceMatrix; 
                           non_redundant::Bool = false) where T<:scalar_types
   Base.depwarn("'PolyhedralFan{$T}(x...)' is deprecated, use 'polyhedral_fan($T, x...)' instead.", :PolyhedralFan)
-  return polyhedral_fan(T, Rays, LS, Incidence; non_redundant=non_redundant)
+  return polyhedral_fan(T, Incidence, Rays, LS; non_redundant=non_redundant)
 end
 function PolyhedralFan{T}(Rays::AbstractCollection[RayVector], Incidence::IncidenceMatrix; non_redundant::Bool = false) where T<:scalar_types
   Base.depwarn("'PolyhedralFan{$T}(x...)' is deprecated, use 'polyhedral_fan($T, x...)' instead.", :PolyhedralFan)
-  return polyhedral_fan(T, Rays, Incidence; non_redundant=non_redundant)
+  return polyhedral_fan(T, Incidence, Rays; non_redundant=non_redundant)
 end
-@deprecate PolyhedralFan(Rays::AbstractCollection[RayVector], LS::Union{AbstractCollection[RayVector], Nothing}, Incidence::IncidenceMatrix; non_redundant::Bool = false) polyhedral_fan(QQFieldElem, Rays, LS, Incidence; non_redundant = non_redundant)
-@deprecate PolyhedralFan(Rays::AbstractCollection[RayVector], Incidence::IncidenceMatrix; non_redundant::Bool = false) polyhedral_fan(QQFieldElem, Rays, Incidence; non_redundant = non_redundant)
+@deprecate PolyhedralFan(Rays::AbstractCollection[RayVector], LS::Union{AbstractCollection[RayVector], Nothing}, Incidence::IncidenceMatrix; non_redundant::Bool = false) polyhedral_fan(QQFieldElem, Incidence, Rays, LS; non_redundant = non_redundant)
+@deprecate PolyhedralFan(Rays::AbstractCollection[RayVector], Incidence::IncidenceMatrix; non_redundant::Bool = false) polyhedral_fan(QQFieldElem, Incidence, Rays; non_redundant = non_redundant)
 function PolyhedralFan(itr::AbstractVector{Cone{T}}) where T<:scalar_types
   Base.depwarn("'PolyhedralFan' is deprecated, use 'polyhedral_fan' instead.", :PolyhedralFan)
   return polyhedral_fan(itr)
@@ -283,11 +283,11 @@ function PolyhedralFan(C::Cone{T}) where T<:scalar_types
 end
 function PolyhedralFan{T}(Rays::AbstractCollection[RayVector], LS::AbstractCollection[RayVector], Incidence::Matrix{Bool}) where T<:scalar_types
   Base.depwarn("'PolyhedralFan{$T}(x...)' is deprecated, use 'polyhedral_fan($T, x...)' instead.", :PolyhedralFan)
-  return polyhedral_fan(T, Rays, LS, Incidence)
+  return polyhedral_fan(T, Incidence, Rays, LS)
 end
 function PolyhedralFan{T}(Rays::AbstractCollection[RayVector], Incidence::Matrix{Bool}) where T<:scalar_types
   Base.depwarn("'PolyhedralFan{$T}(x...)' is deprecated, use 'polyhedral_fan($T, x...)' instead.", :PolyhedralFan)
-  return polyhedral_fan(T, Rays, Incidence)
+  return polyhedral_fan(T, Incidence, Rays)
 end
 
 # SubdivisionOfPoints -> subdivision_of_points
@@ -494,3 +494,14 @@ end
 @deprecate revlex(v::AbstractVector{<:MPolyRingElem}) invlex(v::AbstractVector{<:MPolyRingElem})
 @deprecate negrevlex(R::MPolyRing) ngeinvlex(R::MPolyRing)
 @deprecate negrevlex(v::AbstractVector{<:MPolyRingElem}) neginvlex(v::AbstractVector{<:MPolyRingElem})
+@deprecate polyhedral_fan(f::scalar_type_or_field, Rays::AbstractCollection[RayVector], Incidence::IncidenceMatrix; non_redundant::Bool = false) polyhedral_fan(f, Incidence, Rays, nothing; non_redundant)
+@deprecate polyhedral_fan(Rays::AbstractCollection[RayVector], LS::Union{AbstractCollection[RayVector], Nothing}, Incidence::IncidenceMatrix; non_redundant::Bool = false) polyhedral_fan(QQFieldElem, Incidence, Rays, LS; non_redundant)
+@deprecate polyhedral_fan(Rays::AbstractCollection[RayVector], Incidence::IncidenceMatrix; non_redundant::Bool = false) polyhedral_fan(QQFieldElem, Incidence, Rays; non_redundant)
+@deprecate polyhedral_fan(f::scalar_type_or_field,
+                        Rays::AbstractCollection[RayVector], 
+                        LS::Union{AbstractCollection[RayVector], Nothing},
+                        Incidence::IncidenceMatrix; 
+                        non_redundant::Bool = false) polyhedral_fan(f, Incidence, Rays, LS; non_redundant)
+@deprecate polyhedral_fan(f::scalar_type_or_field, Rays::AbstractCollection[RayVector], LS::AbstractCollection[RayVector], Incidence::Matrix{Bool}) polyhedral_fan(f, Rays, LS, IncidenceMatrix(Polymake.IncidenceMatrix(Incidence)))
+@deprecate polyhedral_fan(f::scalar_type_or_field, Rays::AbstractCollection[RayVector], Incidence::Matrix{Bool}) polyhedral_fan(f, Rays, IncidenceMatrix(Polymake.IncidenceMatrix(Incidence)))
+@deprecate normal_toric_variety(rays::AbstractCollection[RayVector], max_cones::IncidenceMatrix; non_redundant::Bool = false) normal_toric_variety(max_cones, rays; non_redundant)

--- a/test/AlgebraicGeometry/ToricVarieties/affine_normal_varieties.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/affine_normal_varieties.jl
@@ -5,7 +5,7 @@
   antv3 = affine_normal_toric_variety(antv2)
   antv4 = affine_normal_toric_variety(Oscar.positive_hull([1 0]))
   antv5 = affine_space(NormalToricVariety, 2)
-  antv6 = normal_toric_variety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]])
+  antv6 = normal_toric_variety(IncidenceMatrix([[1,2,3,4]]), [[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]])
   
   @testset "Basic properties" begin
     @test is_smooth(antv) == false

--- a/test/AlgebraicGeometry/ToricVarieties/direct_products.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/direct_products.jl
@@ -1,6 +1,6 @@
 @testset "Direct products" begin
     
-    F5 = normal_toric_variety([[1, 0], [0, 1], [-1, 5], [0, -1]], [[1, 2], [2, 3], [3, 4], [4, 1]])
+  F5 = normal_toric_variety(IncidenceMatrix([[1, 2], [2, 3], [3, 4], [4, 1]]), [[1, 0], [0, 1], [-1, 5], [0, -1]])
     P2 = normal_toric_variety(normal_fan(Oscar.simplex(2)))
     variety = F5 * P2
     

--- a/test/AlgebraicGeometry/ToricVarieties/intersection_numbers.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/intersection_numbers.jl
@@ -2,9 +2,9 @@
   
   antv = affine_normal_toric_variety(Oscar.positive_hull([1 1; -1 1]))
   
-  antv2 = normal_toric_variety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]])
+  antv2 = normal_toric_variety(IncidenceMatrix([[1,2,3,4]]), [[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]])
   
-  v = normal_toric_variety([[1, 0], [0, 1], [-1, -1]], [[1], [2], [3]])
+  v = normal_toric_variety(IncidenceMatrix([[1], [2], [3]]), [[1, 0], [0, 1], [-1, -1]])
     
   dP1 = del_pezzo_surface(NormalToricVariety, 1)
   c0 = cohomology_class(dP1, gens(cohomology_ring(dP1))[1])

--- a/test/AlgebraicGeometry/ToricVarieties/line_bundle_cohomologies.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/line_bundle_cohomologies.jl
@@ -5,8 +5,8 @@
   F5 = hirzebruch_surface(NormalToricVariety, 5)
   
   ray_generators = [[1, 0, 0,-2,-3], [0, 1, 0,-2,-3], [0, 0, 1,-2,-3], [-1,-1,-1,-2,-3], [0, 0, 0, 1, 0], [0, 0, 0, 0, 1], [0, 0, 0,-2,-3]]
-  max_cones = [[1, 2, 3, 5, 6], [1, 2, 3, 5, 7], [1, 2, 3, 6, 7], [2, 3, 4, 5, 6], [2, 3, 4, 5, 7], [2, 3, 4, 6, 7], [1, 3, 4, 5, 6], [1, 3, 4, 5, 7], [1, 3, 4, 6, 7], [1, 2, 4, 5, 6], [1, 2, 4, 5, 7], [1, 2, 4, 6, 7]]
-  weierstrass_over_p3 = normal_toric_variety(ray_generators, max_cones; non_redundant = true)
+  max_cones = IncidenceMatrix([[1, 2, 3, 5, 6], [1, 2, 3, 5, 7], [1, 2, 3, 6, 7], [2, 3, 4, 5, 6], [2, 3, 4, 5, 7], [2, 3, 4, 6, 7], [1, 3, 4, 5, 6], [1, 3, 4, 5, 7], [1, 3, 4, 6, 7], [1, 2, 4, 5, 6], [1, 2, 4, 5, 7], [1, 2, 4, 6, 7]])
+  weierstrass_over_p3 = normal_toric_variety(max_cones, ray_generators; non_redundant = true)
   
   l = toric_line_bundle(dP3, [1, 2, 3, 4])
   l2 = toric_line_bundle(divisor_of_character(F5, [1, 2]))

--- a/test/AlgebraicGeometry/ToricVarieties/subvarieties.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/subvarieties.jl
@@ -1,6 +1,6 @@
 @testset "Closed subvarieties" begin
   
-  antv = normal_toric_variety([[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]], [[1, 2, 3, 4]])
+  antv = normal_toric_variety(IncidenceMatrix([[1,2,3,4]]), [[1, 0, 0], [1, 0, 1], [1, 1, 1], [1, 1, 0]])
   
   ntv = normal_toric_variety(cube(2))
   (x1, x2, y1, y2) = gens(cox_ring(ntv));

--- a/test/AlgebraicGeometry/ToricVarieties/toric_schemes.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/toric_schemes.jl
@@ -97,7 +97,7 @@
 end
 
 @testset "Lazy glueings" begin
-  f = polyhedral_fan([0 0 1; 1 0 1; 0 1 0; -1 0 1; -1 -1 1; 0 -1 1], IncidenceMatrix([[1, 2, 3],[1, 4, 5, 6]]))
+  f = polyhedral_fan(IncidenceMatrix([[1, 2, 3],[1, 4, 5, 6]]), [0 0 1; 1 0 1; 0 1 0; -1 0 1; -1 -1 1; 0 -1 1])
   n_maximal_cones(f)
   ntv = normal_toric_variety(f)
   X = underlying_scheme(ntv)

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -10,8 +10,7 @@
         rem_edge!(g, 1, 2)
         @test ne(g) == 0
         @test !has_edge(g, 1, 2)
-        v = add_vertex!(g)
-        @test v == 6
+        @test add_vertex!(g)
         @test nv(g) == 6
         @test has_vertex(g, 6)
         rem_vertex!(g, 1)
@@ -121,6 +120,6 @@
 
     @testset "errors" begin
         g = Graph{Undirected}(1)
-        @test_throws ArgumentError add_edge!(g,1,2)
+        @test !add_edge!(g,1,2)
     end
 end

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -17,6 +17,8 @@
         @test nv(g) == 5
         @test has_vertex(g, 1)
         @test !has_vertex(g, 6)
+        @test add_vertices!(g, 5) == 5
+        @test nv(g) == 10
 
         g = Graph{Directed}(4)
         add_edge!(g, 1, 2)

--- a/test/PolyhedralGeometry/extended.jl
+++ b/test/PolyhedralGeometry/extended.jl
@@ -205,7 +205,7 @@
         lincone = positive_hull([1 0 0], [0 1 0])
 
         @test positive_hull(rays_modulo_lineality(lincone)...) == lincone
-        @test ambient_dim(polyhedral_fan(rays_modulo_lineality(lincone)..., IM)) == 3
+        @test ambient_dim(polyhedral_fan(IM, rays_modulo_lineality(lincone)...)) == 3
         
     end
 

--- a/test/PolyhedralGeometry/polyhedral_fan.jl
+++ b/test/PolyhedralGeometry/polyhedral_fan.jl
@@ -12,12 +12,12 @@
   I3 = [1 0 0; 0 1 0; 0 0 1]
   incidence1 = IncidenceMatrix([[1,2],[2,3]])
   incidence2 = IncidenceMatrix([[1,2]])
-  @test polyhedral_fan(f, I3, incidence1) isa PolyhedralFan{T}
-  F1 = polyhedral_fan(f, I3, incidence1)
-  F1NR = polyhedral_fan(f, I3, incidence1; non_redundant = true)
-  @test polyhedral_fan(f, I3, incidence1) isa PolyhedralFan{T}
-  F2 = polyhedral_fan(f, R, L, incidence2)
-  F2NR = polyhedral_fan(f, R, L, incidence2; non_redundant = true)
+  @test polyhedral_fan(f, incidence1, I3) isa PolyhedralFan{T}
+  F1 = polyhedral_fan(f, incidence1, I3)
+  F1NR = polyhedral_fan(f, incidence1, I3; non_redundant = true)
+  @test polyhedral_fan(f, incidence1, I3) isa PolyhedralFan{T}
+  F2 = polyhedral_fan(f, incidence2, R, L)
+  F2NR = polyhedral_fan(f, incidence2, R, L; non_redundant = true)
 
   @test Polymake.exists(Oscar.pm_object(F2NR), "RAYS")
   @test !Polymake.exists(Oscar.pm_object(F2NR), "INPUT_RAYS")
@@ -66,7 +66,7 @@
     @test cones(IncidenceMatrix, F1, 2) == incidence1
 
     II = ray_indices(maximal_cones(NFsquare))
-    NF0 = polyhedral_fan(rays(NFsquare), II)
+    NF0 = polyhedral_fan(II, rays(NFsquare))
     @test nrays(NF0) == 4
     FF0 = face_fan(C0)
     @test nrays(FF0) == 4
@@ -141,7 +141,7 @@ end
 end
 
 @testset "Star Subdivision" begin
-  f = polyhedral_fan([1 0 0; 1 1 0; 1 1 1; 1 0 1], IncidenceMatrix([[1,2,3,4]]))
+  f = polyhedral_fan(IncidenceMatrix([[1,2,3,4]]), [1 0 0; 1 1 0; 1 1 1; 1 0 1])
   @test is_pure(f)
   @test is_fulldimensional(f)
   v0 = [1;0;0]
@@ -154,7 +154,7 @@ end
   @test n_maximal_cones(sf1) == 3
   @test n_maximal_cones(sf2) == 4
 
-  ff = polyhedral_fan([1 0 0; -1 0 0; 0 1 0], IncidenceMatrix([[1],[2,3]]))
+  ff = polyhedral_fan(IncidenceMatrix([[1],[2,3]]), [1 0 0; -1 0 0; 0 1 0])
   @test !is_pure(ff)
   @test !is_fulldimensional(ff)
   w0 = [1;0;0]

--- a/test/PolyhedralGeometry/scalar_types.jl
+++ b/test/PolyhedralGeometry/scalar_types.jl
@@ -45,7 +45,7 @@
         @test recession_cone(ms) == positive_hull(E, [0 0 0 1])
     end
     nf = normal_fan(sd)
-    nfc =  polyhedral_fan(E, rays(nf), maximal_cones(IncidenceMatrix,nf))
+    nfc =  polyhedral_fan(E, maximal_cones(IncidenceMatrix,nf), rays(nf))
     @test is_regular(nfc)
 
     @testset "Scalar detection" begin


### PR DESCRIPTION
- Reduce duplication
- Let `{add,rem}_edge!` return bools whether operation succeeded.
- `polyhedral_fan` and `normal_toric_variety` now use the same order of arguments as `polyhedral_complex`. @YueRen 
- Due to `Matrix{Int}` being used for both encoding incidences or rays in `normal_toric_variety` it was impossible to cleanly deprecate all old constructors.
- Rename `pm_tdivisor` to `pm_object` as this is used everywhere else.