### PR TITLE
Rename `isweighted` -> `is_weighted`

### DIFF
--- a/src/AlgebraicGeometry/Miscellaneous/basics.jl
+++ b/src/AlgebraicGeometry/Miscellaneous/basics.jl
@@ -45,7 +45,7 @@ function weights(P::ProjSpc)
   return Int[x[1] for x = P.Rx.d]
 end
 
-function isweighted(P::ProjSpc)
+function is_weighted(P::ProjSpc)
   return !all(x->isone(x[1]), P.Rx.d)
 end
 
@@ -173,7 +173,7 @@ function normalize!(a::ProjSpcElem{ZZRingElem})
 end
 
 function Base.hash(a::ProjSpcElem, u::UInt=UInt(123432))
-  if isweighted(parent(a))
+  if is_weighted(parent(a))
     return u
   end
   normalize!(a)

--- a/src/AlgebraicGeometry/RationalPoint/ProjectiveRationalPoint.jl
+++ b/src/AlgebraicGeometry/RationalPoint/ProjectiveRationalPoint.jl
@@ -208,7 +208,7 @@ function normalize!(a::AbsProjectiveRationalPoint{ZZRingElem})
 end
 
 function Base.hash(a::AbsProjectiveRationalPoint, u::UInt=UInt(123432))
-  if isweighted(codomain(a))
+  if is_weighted(codomain(a))
     return u
   end
   normalize!(a)

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -18,7 +18,7 @@ export is_global
 export is_local
 export is_mixed
 export is_total
-export is_weighted
+export _is_weighted
 export lex
 export matrix_ordering
 export monomial_ordering
@@ -124,7 +124,7 @@ function _unique_var_indices(a::AbstractVector{<:MPolyRingElem})
   return z
 end
 
-function is_weighted(ord::Symbol)
+function _is_weighted(ord::Symbol)
    return ord == :wdeglex || ord == :wdegrevlex ||
           ord == :negwdeglex || ord == :negwdegrevlex
 end

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -18,7 +18,7 @@ export is_global
 export is_local
 export is_mixed
 export is_total
-export isweighted
+export is_weighted
 export lex
 export matrix_ordering
 export monomial_ordering
@@ -124,7 +124,7 @@ function _unique_var_indices(a::AbstractVector{<:MPolyRingElem})
   return z
 end
 
-function isweighted(ord::Symbol)
+function is_weighted(ord::Symbol)
    return ord == :wdeglex || ord == :wdegrevlex ||
           ord == :negwdeglex || ord == :negwdegrevlex
 end

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -869,7 +869,6 @@ export is_unital
 export is_vertical_k_separation
 export is_very_ample
 export is_weakly_connected
-export is_weighted
 export is_welldefined
 export is_z_graded
 export is_zero

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -869,6 +869,7 @@ export is_unital
 export is_vertical_k_separation
 export is_very_ample
 export is_weakly_connected
+export is_weighted
 export is_welldefined
 export is_z_graded
 export is_zero


### PR DESCRIPTION
This is used in #2936, and I think it should follow our naming scheme. As the function was not exported before, I think we can omit the deprecation.