### PR TITLE
Failing tests on master fail job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,6 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 150
-    continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:
@@ -73,7 +72,6 @@ jobs:
   doctest:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 150
-    continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
There are recent cases where the test CI job on julia-master gets canceled after 150 minutes, but still shows as succeeded (green checkmark), e.g. https://github.com/oscar-system/Oscar.jl/actions/runs/6628343890/job/18015084488#step:7:1069

I think that this change will change that behavior to show the job as failed in these cases.