### PR TITLE
init: warning for outdated manifest

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -135,6 +135,12 @@ function __init__()
 
     add_assertion_scope(:ZZLatWithIsom)
     add_verbosity_scope(:ZZLatWithIsom)
+
+    # Pkg.is_manifest_current() returns false if the manifest might be out of date
+    # (but might return nothing when there is no project_hash)
+    if is_dev && VERSION >= v"1.8" && Pkg.is_manifest_current() === false
+      @warn "Project dependencies might have changed, please run `]up` or `]resolve`."
+    end
 end
 
 const PROJECT_TOML = Pkg.TOML.parsefile(joinpath(@__DIR__, "..", "Project.toml"))


### PR DESCRIPTION
This prints a warning if a git clone is updated (and the Project.toml changes) but the Manifest was not re-resolved:
```
Version 0.14.0-DEV ... 
 ... which comes with absolutely no warranty whatsoever
Type: '?Oscar' for more information
(c) 2019-2023 by The OSCAR Development Team
┌ Warning: Project dependencies might have changed, please run `]up` or `]resolve`.
└ @ Oscar ~/software/polymake/julia/Oscar.jl/src/Oscar.jl:142
```

Pkg will print a similar warning when running `]st` but this doesn't seem to get notices. And it happens quite often that users / developers forget to do `]up`.

cc: @thofma @HechtiDerLachs @lkastner 

PS: This is only active for `Oscar.is_dev` and works only for julia >= 1.8.