### PR TITLE
Allow choice of target while building systemimage

### DIFF
--- a/system/Build.jl
+++ b/system/Build.jl
@@ -26,7 +26,12 @@ Oscar.system("precompile.jl")
 """)
 
 sysimage=joinpath(tmp, "Oscar.$(Libdl.dlext)")
-PackageCompiler.create_sysimage([:Oscar], sysimage_path=sysimage, precompile_execution_file=CO)
+if !("JULIA_CPU_TARGET" in keys(ENV)) || (ENV["JULIA_CPU_TARGET"] == "")
+  PackageCompiler.create_sysimage([:Oscar], sysimage_path=sysimage, precompile_execution_file=CO)
+else
+  target = ENV["JULIA_CPU_TARGET"]
+  PackageCompiler.create_sysimage([:Oscar], sysimage_path=sysimage, precompile_execution_file=CO; cpu_target=target)
+end
 
 println("(re)start julia as")
 println("\tjulia -J $(sysimage)")


### PR DESCRIPTION
Allows one to choose a CPU target while using `Oscar.build()` to build a system image.

[skip ci] 