### PR TITLE
Renaming of sheaf cohomology command

### DIFF
--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -1620,7 +1620,7 @@ S^4 <---- S^6 <---- S^4 <---- S^1 <---- 0
 
 julia> M = cokernel(map(FI, 2));
 
-julia> tbl = _sheaf_cohomology_bgg(M, -6, 2)
+julia> tbl = Oscar._sheaf_cohomology_bgg(M, -6, 2)
 twist:  -6  -5  -4  -3  -2  -1   0   1   2
 ------------------------------------------
 0:      70  36  15   4   -   -   -   -   *
@@ -1642,7 +1642,7 @@ julia> R, x = grade(R);
 
 julia> F = graded_free_module(R, 1);
 
-julia> _sheaf_cohomology_bgg(F, -7, 2)
+julia> Oscar._sheaf_cohomology_bgg(F, -7, 2)
 twist:  -7  -6  -5  -4  -3  -2  -1   0   1   2
 ----------------------------------------------
 0:      15   5   1   -   -   -   *   *   *   *

--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -1522,7 +1522,7 @@ function Base.show(io::IO, table::sheafCohTable)
 end
 
 @doc raw"""
-    sheaf_cohomology_bgg(M::ModuleFP{T}, l::Int, h::Int) where {T <: MPolyDecRingElem}
+    sheaf_cohomology(M::ModuleFP{T}, l::Int, h::Int; algorithm::Symbol = :bgg) where {T <: MPolyDecRingElem}
 
 Compute the cohomology of twists of of the coherent sheaf on projective
 space associated to `M`. The range of twists is between `l` and `h`.
@@ -1548,7 +1548,7 @@ S^4 <---- S^6 <---- S^4 <---- S^1 <---- 0
 
 julia> M = cokernel(map(FI, 2));
 
-julia> tbl = sheaf_cohomology_bgg(M, -6, 2)
+julia> tbl = sheaf_cohomology(M, -6, 2)
 twist:  -6  -5  -4  -3  -2  -1   0   1   2
 ------------------------------------------
 0:      70  36  15   4   -   -   -   -   *
@@ -1570,7 +1570,7 @@ julia> R, x = grade(R);
 
 julia> F = graded_free_module(R, 1);
 
-julia> sheaf_cohomology_bgg(F, -7, 2)
+julia> sheaf_cohomology(F, -7, 2, algorithm = :bgg)
 twist:  -7  -6  -5  -4  -3  -2  -1   0   1   2
 ----------------------------------------------
 0:      15   5   1   -   -   -   *   *   *   *
@@ -1582,7 +1582,79 @@ twist:  -7  -6  -5  -4  -3  -2  -1   0   1   2
 chi:     *   *   *   *   -   -   *   *   *   *
 ```
 """
-function sheaf_cohomology_bgg(M::ModuleFP{T},
+function sheaf_cohomology(M::ModuleFP{T},
+                          l::Int,
+                          h::Int;
+                          algorithm::Symbol = :bgg) where {T <: MPolyDecRingElem}
+  if algorithm == :bgg
+    return _sheaf_cohomology_bgg(M, l, h)
+  else
+    error("Algorithm not supported.")
+  end
+end
+
+@doc raw"""
+    _sheaf_cohomology_bgg(M::ModuleFP{T}, l::Int, h::Int) where {T <: MPolyDecRingElem}
+
+Compute the cohomology of twists of of the coherent sheaf on projective
+space associated to `M`. The range of twists is between `l` and `h`.
+In the displayed result, '-' refers to a zero enty and '*' refers to a
+negative entry (= dimension not yet determined). To determine all values
+in the desired range between `l` and `h` use `sheafCoh_BGG_regul(M, l-ngens(base_ring(M)), h+ngens(base_ring(M)))`.
+The values of the returned table can be accessed by indexing it
+with a cohomological index and a value between `l` and `h` as shown
+in the example below.
+
+```jldoctest
+julia> R, x = polynomial_ring(QQ, "x" => 1:4);
+
+julia> S, _= grade(R);
+
+julia> I = ideal(S, gens(S))
+ideal(x[1], x[2], x[3], x[4])
+
+julia> FI = free_resolution(I)
+Free resolution of I
+S^4 <---- S^6 <---- S^4 <---- S^1 <---- 0
+0         1         2         3         4
+
+julia> M = cokernel(map(FI, 2));
+
+julia> tbl = _sheaf_cohomology_bgg(M, -6, 2)
+twist:  -6  -5  -4  -3  -2  -1   0   1   2
+------------------------------------------
+0:      70  36  15   4   -   -   -   -   *
+1:       *   -   -   -   -   -   -   -   -
+2:       *   *   -   -   -   -   1   -   -
+3:       *   *   *   -   -   -   -   -   6
+------------------------------------------
+chi:     *   *   *   4   -   -   1   -   *
+
+julia> tbl[0, -6]
+70
+
+julia> tbl[2, 0]
+1
+
+julia> R, x = polynomial_ring(QQ, "x" => 1:5);
+
+julia> R, x = grade(R);
+
+julia> F = graded_free_module(R, 1);
+
+julia> _sheaf_cohomology_bgg(F, -7, 2)
+twist:  -7  -6  -5  -4  -3  -2  -1   0   1   2
+----------------------------------------------
+0:      15   5   1   -   -   -   *   *   *   *
+1:       *   -   -   -   -   -   -   *   *   *
+2:       *   *   -   -   -   -   -   -   *   *
+3:       *   *   *   -   -   -   -   -   -   *
+4:       *   *   *   *   -   -   -   1   5  15
+----------------------------------------------
+chi:     *   *   *   *   -   -   *   *   *   *
+```
+"""
+function _sheaf_cohomology_bgg(M::ModuleFP{T},
                               l::Int,
                               h::Int) where {T <: MPolyDecRingElem}
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1316,7 +1316,7 @@ export set_relative_order!
 export set_relative_orders!
 export set_theoretic_intersection
 export sets
-export sheaf_cohomology_bgg
+export sheaf_cohomology
 export short_right_transversal
 export shortest_path_dijkstra
 export show_morphism

--- a/test/Modules/ModulesGraded.jl
+++ b/test/Modules/ModulesGraded.jl
@@ -1088,7 +1088,7 @@ end
   M = cokernel(map(FI, 2))
   tbl = Oscar._sheaf_cohomology_bgg(M, -6, 2)
   lbt = sheaf_cohomology(M, -6, 2, algorithm = :bgg)
-  @test tbl == lbt
+  @test tbl.values == lbt.values
   @test tbl[0, -6] == 70
   @test tbl[2, 0] == 1
   @test iszero(tbl[2, -2])

--- a/test/Modules/ModulesGraded.jl
+++ b/test/Modules/ModulesGraded.jl
@@ -1086,23 +1086,25 @@ end
   I = ideal(S, gens(S))
   FI = free_resolution(I)
   M = cokernel(map(FI, 2))
-  tbl = sheaf_cohomology_bgg(M, -6, 2)
+  tbl = _sheaf_cohomology_bgg(M, -6, 2)
+  lbt = sheaf_cohomology(M, -6, 2, algorithm = :bgg)
+  @test tbl == lbt
   @test tbl[0, -6] == 70
   @test tbl[2, 0] == 1
   @test iszero(tbl[2, -2])
 
   F = free_module(S, 1)
-  @test_throws AssertionError sheaf_cohomology_bgg(F, -6, 2)
+  @test_throws AssertionError _sheaf_cohomology_bgg(F, -6, 2)
 
   R, x = polynomial_ring(QQ, "x" => 1:4)
   S, _ = grade(R, [1,2,3,4])
   F = graded_free_module(S, 1)
-  @test_throws AssertionError sheaf_cohomology_bgg(F, -6, 2)
+  @test_throws AssertionError _sheaf_cohomology_bgg(F, -6, 2)
 
   R, x = polynomial_ring(QQ, "x" => 1:5)
   S, _ = grade(R)
   F = graded_free_module(S, 1)
-  tbl = sheaf_cohomology_bgg(F, -7, 2)
+  tbl = sheaf_cohomology(F, -7, 2)
   a = tbl.values
   b = transpose(a) * a
   @test is_symmetric(b)

--- a/test/Modules/ModulesGraded.jl
+++ b/test/Modules/ModulesGraded.jl
@@ -1086,7 +1086,7 @@ end
   I = ideal(S, gens(S))
   FI = free_resolution(I)
   M = cokernel(map(FI, 2))
-  tbl = _sheaf_cohomology_bgg(M, -6, 2)
+  tbl = Oscar._sheaf_cohomology_bgg(M, -6, 2)
   lbt = sheaf_cohomology(M, -6, 2, algorithm = :bgg)
   @test tbl == lbt
   @test tbl[0, -6] == 70
@@ -1094,12 +1094,12 @@ end
   @test iszero(tbl[2, -2])
 
   F = free_module(S, 1)
-  @test_throws AssertionError _sheaf_cohomology_bgg(F, -6, 2)
+  @test_throws AssertionError Oscar._sheaf_cohomology_bgg(F, -6, 2)
 
   R, x = polynomial_ring(QQ, "x" => 1:4)
   S, _ = grade(R, [1,2,3,4])
   F = graded_free_module(S, 1)
-  @test_throws AssertionError _sheaf_cohomology_bgg(F, -6, 2)
+  @test_throws AssertionError Oscar._sheaf_cohomology_bgg(F, -6, 2)
 
   R, x = polynomial_ring(QQ, "x" => 1:5)
   S, _ = grade(R)


### PR DESCRIPTION
This PR introduces a general function `sheaf_cohomology` for which the user can specify the given specialized algorithm used via the kwarg `algorithm`. RIght now, only `:bgg` is supported as algorithm, but this PR prepares the implementation of further algorithms.

@wdecker will write a corresponding documentation in a follow up PR. 