### PR TITLE
fixes regression loading vectors parametrized types

### DIFF
--- a/src/Serialization/containers.jl
+++ b/src/Serialization/containers.jl
@@ -67,7 +67,11 @@ end
 function load_object(s::DeserializerState, ::Type{<: Vector},
                                  v::Vector, params::Tuple)
   T = params[1]
-  return T[load_object(s, T, x, params[2]) for x in v]
+  if isempty(v)
+    return T[]
+  else
+    return [load_object(s, T, x, params[2]) for x in v]
+  end
 end
 
 function load_object(s::DeserializerState, ::Type{<: Vector},
@@ -208,7 +212,6 @@ function load_object(s::DeserializerState, ::Type{<: NamedTuple},
   keys = map(Symbol, keys)
   return NamedTuple{Tuple(keys), typeof(tuple)}(tuple)
 end
-
 
 ################################################################################
 # Saving and loading matrices

--- a/test/Serialization/containers.jl
+++ b/test/Serialization/containers.jl
@@ -17,6 +17,17 @@
       end
     end
 
+    @testset "Preserve Vector type" begin
+      Qx, x = QQ[:x]
+      F, a = number_field(x^2 + 1)
+      Fy, y = F[:y]
+      v = [y^2, y + 1]
+
+      test_save_load_roundtrip(path, v) do loaded
+        @test typeof(loaded) == typeof(v)
+      end
+    end
+  
     @testset "ids in containers" begin
       R, x = QQ[:x]
       test_save_load_roundtrip(path, (x^2, x + 1, R)) do loaded

--- a/test/Serialization/containers.jl
+++ b/test/Serialization/containers.jl
@@ -16,17 +16,6 @@
         @test nt == loaded
       end
     end
-
-    @testset "Preserve Vector type" begin
-      Qx, x = QQ[:x]
-      F, a = number_field(x^2 + 1)
-      Fy, y = F[:y]
-      v = [y^2, y + 1]
-
-      test_save_load_roundtrip(path, v) do loaded
-        @test typeof(loaded) == typeof(v)
-      end
-    end
   
     @testset "ids in containers" begin
       R, x = QQ[:x]

--- a/test/Serialization/setup_tests.jl
+++ b/test/Serialization/setup_tests.jl
@@ -10,11 +10,8 @@ function test_save_load_roundtrip(func, path, original::T; params=nothing) where
   filename = joinpath(path, "original.json")
   save(filename, original)
   loaded = load(filename; params=params)
-  if T <: Vector
-    @test loaded isa Vector
-  else
-    @test loaded isa T
-  end
+
+  @test loaded isa T
   func(loaded)
 
   # save and load from an IO buffer
@@ -23,11 +20,7 @@ function test_save_load_roundtrip(func, path, original::T; params=nothing) where
   seekstart(io)
   loaded = load(io; params=params)
 
-  if T <: Vector
-    @test loaded isa Vector
-  else
-    @test loaded isa T
-  end
+  @test loaded isa T
   func(loaded)
 
   # save and load from an IO buffer, with prescribed type
@@ -35,11 +28,8 @@ function test_save_load_roundtrip(func, path, original::T; params=nothing) where
   save(io, original)
   seekstart(io)
   loaded = load(io; type=T, params=params)
-  if T <: Vector
-    @test loaded isa Vector
-  else
-    @test loaded isa T
-  end
+
+  @test loaded isa T
   func(loaded)
 
   # test loading on a empty state


### PR DESCRIPTION
Doesn't force containers to be of a potentially more general type when non empty.