### PR TITLE
Replace type declarations

### DIFF
--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Morphisms/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Morphisms/Attributes.jl
@@ -56,8 +56,8 @@ given by the pullback function
     (y//z) -> 0
 ```
 """
-function covering_morphism(f::AbsCoveredSchemeMorphism)::CoveringMorphism
-  return covering_morphism(underlying_morphism(f))
+function covering_morphism(f::AbsCoveredSchemeMorphism)
+  return covering_morphism(underlying_morphism(f))::CoveringMorphism
 end
 
 ### generically derived getters

--- a/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/methods.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/methods.jl
@@ -122,5 +122,5 @@ function integrate(c::CohomologyClass)
     end
     n = AbstractAlgebra.leading_coefficient(top_form.f)
     m = AbstractAlgebra.leading_coefficient(polynomial(volume_form(toric_variety(c))).f)
-    return QQFieldElem(ZZ(n),ZZ(m))
+    return n//m
 end

--- a/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/methods.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/methods.jl
@@ -122,5 +122,5 @@ function integrate(c::CohomologyClass)
     end
     n = AbstractAlgebra.leading_coefficient(top_form.f)
     m = AbstractAlgebra.leading_coefficient(polynomial(volume_form(toric_variety(c))).f)
-    return QQFieldElem(n,m)
+    return QQFieldElem(ZZ(n),ZZ(m))
 end

--- a/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/methods.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/methods.jl
@@ -88,7 +88,7 @@ julia> integrate(cohomology_class(anticanonical_divisor_class(X))^3)
 62
 ```
 """
-function integrate(c::CohomologyClass)::QQFieldElem
+function integrate(c::CohomologyClass)
     # can only integrate if the variety is simplicial, complete
     @req is_simplicial(toric_variety(c)) && is_complete(toric_variety(c)) "Integration only supported over complete and simplicial toric varieties"
     
@@ -97,30 +97,30 @@ function integrate(c::CohomologyClass)::QQFieldElem
         intersection_dict = _intersection_form_via_exponents(toric_variety(c))
         coeffs = coefficients(c)
         expos = exponents(c)
-        integral = 0
+        integral = zero(QQ)
         for i in 1:nrows(expos)
             if expos[i, :] in keys(intersection_dict)
                 integral += coeffs[i] * intersection_dict[expos[i, :]]
             end
         end
-        return integral
+        return integral::QQFieldElem
     end
     
     # otherwise, proceed "by hand"
     if is_trivial(c)
-        return 0
+        return zero(QQ)
     end
     poly = polynomial(c)
     dict = homogeneous_components(poly)
     elem = base_ring(parent(poly)).D([dim(toric_variety(c))])
     if !(elem in keys(dict))
-        return 0
+        return zero(QQ)
     end
     top_form = dict[elem]
     if iszero(top_form)
-        return 0
+        return zero(QQ)
     end
     n = AbstractAlgebra.leading_coefficient(top_form.f)
     m = AbstractAlgebra.leading_coefficient(polynomial(volume_form(toric_variety(c))).f)
-    return QQFieldElem(n//m)
+    return QQFieldElem(n,m)
 end

--- a/src/Rings/mpoly-affine-algebras.jl
+++ b/src/Rings/mpoly-affine-algebras.jl
@@ -369,13 +369,13 @@ julia> hilbert_polynomial(A)
 3*t + 1
 ```
 """
-function hilbert_polynomial(A::MPolyQuoRing)::QQPolyRingElem
+function hilbert_polynomial(A::MPolyQuoRing)
    if iszero(A.I)
        R = base_ring(A.I)
        @req is_standard_graded(R) "The base ring must be standard ZZ-graded"
        n = ngens(A)
        Qt, t = QQ["t"]
-       b = one(parent(t))
+       b = one(Qt)
        for i in QQ(1):QQ(n-1)
            b = b * (t+i)
        end
@@ -383,7 +383,7 @@ function hilbert_polynomial(A::MPolyQuoRing)::QQPolyRingElem
        return b
    end
    H = HilbertData(A.I)
-   return hilbert_polynomial(H)
+   return hilbert_polynomial(H)::QQPolyRingElem
 end
 
 @doc raw"""


### PR DESCRIPTION
Type declarations insert `convert` calls. Instead, use type assertions
(which just verify the object has the right type to start with), or
fix the code to actually be type stable and return the right type.
