### PR TITLE
Add docs and tests for CartanMatrix.jl

### DIFF
--- a/experimental/LieAlgebras/docs/doc.main
+++ b/experimental/LieAlgebras/docs/doc.main
@@ -6,5 +6,6 @@
       "lie_algebra_homs.md",
       "modules.md",
       "module_homs.md",
+      "cartan_matrix.md",
    ],
 ]

--- a/experimental/LieAlgebras/docs/src/cartan_matrix.md
+++ b/experimental/LieAlgebras/docs/src/cartan_matrix.md
@@ -1,0 +1,18 @@
+```@meta
+CurrentModule = Oscar
+DocTestSetup = quote
+using Oscar
+end
+```
+
+# Cartan Matrices
+
+```@docs
+cartan_matrix(::Symbol, ::Int)
+cartan_matrix(::Tuple{Symbol,Int}...)
+is_cartan_matrix(::ZZMatrix; generalized::Bool)
+cartan_symmetrizer(::ZZMatrix; check::Bool)
+cartan_bilinear_form(::ZZMatrix; check::Bool)
+cartan_type(::ZZMatrix; check::Bool)
+cartan_type_with_ordering(::ZZMatrix; check::Bool)
+```

--- a/experimental/LieAlgebras/src/CartanMatrix.jl
+++ b/experimental/LieAlgebras/src/CartanMatrix.jl
@@ -94,6 +94,7 @@ function cartan_matrix(types::Tuple{Symbol,Int}...)
 end
 
 @doc raw"""
+<<<<<<< HEAD
     cartan_to_coxeter_matrix(mat::ZZMatrix; check::Bool=true) -> ZZMatrix
 
 
@@ -123,6 +124,8 @@ function cartan_to_coxeter_matrix(gcm; check::Bool=true)
 end
 
 @doc raw"""
+=======
+>>>>>>> 1ea0a505c (move and rename cartan_to_coxeter_matrix)
     is_cartan_matrix(mat::ZZMatrix; generalized::Bool=true) -> Bool
 
 Test if `mat` is a generalized Cartan matrix. The keyword argument `generalized`

--- a/experimental/LieAlgebras/src/CartanMatrix.jl
+++ b/experimental/LieAlgebras/src/CartanMatrix.jl
@@ -6,17 +6,26 @@
 
 @doc raw"""
     cartan_matrix(fam::Symbol, rk::Int) -> ZZMatrix
+
+Returns the Cartan matrix of finite type, where `fam` is the family ($A$, $B$, $C$, $D$, $E$, $F$ $G$)
+and `rk` is the rank of the associated the root system.
+The convention is $(a_ij) = (\langle \alpha_i^\vee, \alpha_j \rangle)$ for simple roots $\alpha_i$.
+```jldoctest
+julia> cartan_matrix(:B, 2)
+[ 2   -1]
+[-2    2]
+```
 """
 function cartan_matrix(fam::Symbol, rk::Int)
   if fam == :A
-    @req rk >= 1 "type An requires rank rk of at least 1"
+    @req rk >= 1 "type An requires rank rk to be at least 1"
 
     mat = diagonal_matrix(ZZ(2), rk)
     for i in 1:(rk - 1)
       mat[i + 1, i], mat[i, i + 1] = -1, -1
     end
   elseif fam == :B
-    @req rk >= 2 "type Bn requires rank rk of at least  2"
+    @req rk >= 2 "type Bn requires rank rk to be at least  2"
 
     mat = diagonal_matrix(ZZ(2), rk)
     for i in 1:(rk - 1)
@@ -24,7 +33,7 @@ function cartan_matrix(fam::Symbol, rk::Int)
     end
     mat[rk, rk - 1] = -2
   elseif fam == :C
-    @req rk >= 2 "type Cn requires rank rk of at least 2"
+    @req rk >= 2 "type Cn requires rank rk to be at least 2"
 
     mat = diagonal_matrix(ZZ(2), rk)
     for i in 1:(rk - 1)
@@ -32,13 +41,14 @@ function cartan_matrix(fam::Symbol, rk::Int)
     end
     mat[rk - 1, rk] = -2
   elseif fam == :D
-    @req rk >= 3 "type Dn requires rank rk of at least 3"
+    @req rk >= 4 "type Dn requires rank to be at least 4"
 
     mat = diagonal_matrix(ZZ(2), rk)
-    for i in 1:(rk - 1)
+    for i in 1:(rk - 2)
       mat[i + 1, i], mat[i, i + 1] = -1, -1
     end
-    mat[rk - 1, rk] = -2
+    mat[rk - 2, rk] = -1
+    mat[rk, rk - 2] = -1
   elseif fam == :E
     @req rk in 6:8 "type En requires rank to be one of 6, 7, 8"
     mat = matrix(
@@ -61,41 +71,49 @@ function cartan_matrix(fam::Symbol, rk::Int)
       mat = mat[1:7, 1:7]
     end
   elseif fam == :F
-    @req rk == 4 "type Fn requires rank rk to be 4"
+    @req rk == 4 "type Fn requires rank to be 4"
     mat = matrix(ZZ, [2 -1 0 0; -1 2 -1 0; 0 -2 2 -1; 0 0 -1 2])
   elseif fam == :G
-    @req rk == 2 "type Gn requires rank rk to be 2"
+    @req rk == 2 "type Gn requires rank to be 2"
     mat = matrix(ZZ, [2 -3; -1 2])
   else
-    error("unknown family $fam")
+    throw(ArgumentError("unknown family"))
   end
 
   return mat
 end
 
+@doc raw"""
+    cartan_matrix(types::Tuple{Symbol,Int}...) -> ZZMatrix
+"""
 function cartan_matrix(types::Tuple{Symbol,Int}...)
   blocks = ZZMatrix[cartan_matrix(type...) for type in types]
 
   return block_diagonal_matrix(blocks)
 end
 
-function cartan_to_coxeter_matrix(mat; check=true)
-  @req !check || !is_cartan_matrix(mat) "$mat is not a (generalized) Cartan matrix"
+@doc raw"""
+    cartan_to_coxeter_matrix(mat::ZZMatrix; check::Bool=true) -> Bool
 
-  cm = identity_matrix(mat)
-  rk, _ = size(mat)
+
+"""
+function cartan_to_coxeter_matrix(gcm; check::Bool=true)
+  @req !check || is_cartan_matrix(gcm) "requires a generalized Cartan matrix"
+
+  cm = identity_matrix(gcm)
+  rk, _ = size(gcm)
   for i in 1:rk, j in 1:rk
     if i == j
       continue
     end
 
-    if mat[i, j] == 0
+    if gcm[i, j] == 0
       cm[i, j] = 2
-    elseif mat[i, j] == -1
+    elseif gcm[i, j] == -1
       cm[i, j] = 3
-    elseif mat[i, j] == -2
+    elseif gcm[i, j] == -2
       cm[i, j] = 4
-    elseif mat[i, j] == -3
+    elseif gcm[i, j] == -3
       cm[i, j] = 6
     end
   end
@@ -104,9 +122,16 @@ function cartan_to_coxeter_matrix(mat; check=true)
 end
 
 @doc raw"""
-    is_cartan_matrix(mat::ZZMatrix) -> Bool
+    is_cartan_matrix(mat::ZZMatrix; generalized::Bool=true) -> Bool
 
-Test if `mat` is a (`generalized`) Cartan matrix.
+Test if `mat` is a generalized Cartan matrix. The keyword argument `generalized`
+can be set to `false` to restrict this to Cartan matrices of finite type.
+```jldoctest
+julia> is_cartan_matrix(ZZ[2 -2; -2 2])
+true
+
+julia> is_cartan_matrix(ZZ[2 -2; -2 2]; generalized=false)
+false
 """
 function is_cartan_matrix(mat::ZZMatrix; generalized::Bool=true)
   n, m = size(mat)
@@ -141,4 +166,201 @@ function is_cartan_matrix(mat::ZZMatrix; generalized::Bool=true)
   end
 
   return true
+end
+
+@doc raw"""
+    cartan_matrix_symmetrizer(gcm::ZZMatrix; check::Bool=true) -> Vector{ZZRingElem}
+
+Return a vector $d$ such that $d_i a_{ij}$ is a symmtric matrix, where $a_{ij}$ are the entries of `gcm`.
+`check` optionally verifies that `gcm` is indeed a generalized Cartan matrix.
+```jldoctest
+julia> cartan_symmetrizer(cartan_matrix(:B, 2))
+2-element Vector{ZZRingElem}:
+2
+1
+"""
+function cartan_symmetrizer(gcm::ZZMatrix; check::Bool=true)
+  @req !check || is_cartan_matrix(gcm) "requires a generalized Cartan matrix"
+  rk = nrows(gcm)
+  diag = ones(ZZRingElem, rk)
+  for i in 1:rk, j in (i + 1):rk
+    if !is_zero_entry(gcm, i, j)
+      diag[i] = lcm(diag[i], gcm[i, j], gcm[j, i])
+    end
+  end
+
+  return diag
+end
+
+@doc raw"""
+    cartan_bilinear_form(gcm::ZZMatrix; check::Bool=true) -> ZZMatrix
+    
+```jldoctest
+julia> cartan_bilinear_form(cartan_matrix(:B, 2))
+[ 4   -2]
+[-2    2]
+"""
+function cartan_bilinear_form(gcm::ZZMatrix; check::Bool=true)
+  @req !check || is_cartan_matrix(gcm) "requires a generalized Cartan matrix"
+
+  bil = deepcopy(gcm)
+  sym = cartan_symmetrizer(gcm; check=false)
+  for i in 1:length(sym)
+    mul!(bil[i, :], sym[i])
+  end
+  return bil
+end
+
+@doc raw"""
+    cartan_type(gcm::ZZMatrix; check::Bool=true) -> Vector{Tuple{Symbol, Int}}
+
+Currently only works for Cartan matrices of finite type.
+"""
+function cartan_type(gcm::ZZMatrix; check::Bool=true)
+  type, _ = cartan_type_with_ordering(gcm; check=check)
+  return type
+end
+
+@doc raw"""
+    cartan_type(gcm::ZZMatrix; check::Bool=true) -> Tuple{Vector{Tuple{Symbol, Int}}, Vector{Int}}
+
+Currently only works for Cartan matrices of finite type.
+"""
+function cartan_type_with_ordering(gcm::ZZMatrix; check::Bool=true)
+  @req !check || is_cartan_matrix(gcm; generalized=false) "requires Cartan matrix of finite type"
+
+  rk = nrows(gcm)
+  type = Tuple{Symbol,Int}[]
+
+  # global information
+  ord = sizehint!(Int[], rk) # ordering of the roots
+  adj = [sizehint!(Int[], 3) for _ in 1:rk] # store adjacent roots
+
+  # information about current type
+  num = 0 # number of roots
+  roots = sizehint!(Int[], rk)
+
+  # used for traversal
+  undone = trues(rk)
+  plan = zeros(Int, 3) # a root is connected to up to 3 others
+  head = 0 # index up to which we planned (cyclic)
+  tail = 0 # index of plan which will be done next
+
+  i, j = 1, 2
+  while true
+    while i == j || (j <= rk && is_zero_entry(gcm, i, j))
+      j += 1
+    end
+    if j == rk + 1
+      num += 1
+      undone[i] = false
+      push!(roots, i)
+
+      if tail != head
+        tail += 1
+        if tail == 4
+          tail = 1
+        end
+        i = plan[tail]
+      else # nothing further is planned
+        offset = length(ord) + 1
+        if num == 1 # rank 1
+          push!(type, (:A, 1))
+          push!(ord, i)
+        elseif num == 2 # rank 2
+          i, j = roots[1], roots[2]
+          if gcm[i, j] * gcm[j, i] == 1
+            push!(type, (:A, 2))
+            push!(ord, i, j)
+          elseif gcm[i, j] == -2
+            push!(type, (:C, 2))
+            push!(ord, i, j)
+          elseif gcm[j, i] == -2
+            push!(type, (:B, 2))
+            push!(ord, i, j)
+          elseif gcm[i, j] == -3
+            push!(type, (:G, 2))
+            push!(ord, j, i)
+          else
+            push!(type, (:G, 2))
+            push!(ord, i, j)
+          end
+        else # rank > 2
+          # find start of the Dynkin graph
+          v = 0
+          for i in roots
+            j = adj[i][1]
+            # we dealt with the rank 2 case, so there is at least one root with the following properties
+            if length(adj[i]) == 1 && length(adj[j]) < 3 && gcm[i, j] * gcm[j, i] == 1
+              v = i
+              push!(ord, v)
+              break
+            end
+          end
+
+          n = 1
+          adj3 = false # true if found a root with 3 adjacents
+          while n < num
+            nv = v
+            for vv in adj[v]
+              filter!(x -> x != v, adj[vv])
+              push!(ord, vv)
+              n += 1
+              if length(adj[vv]) > 0
+                nv = vv
+                if length(adj[vv]) == 2 # +1 for the predecessor
+                  adj3 = true
+                end
+              end
+            end
+            v = nv
+          end
+
+          if adj3
+            if isempty(adj[ord[end]]) && isempty(adj[ord[end - 1]])
+              push!(type, (:D, num))
+            else
+              push!(type, (:E, num))
+            end
+          elseif num == 4 &&
+            gcm[ord[end - 2], ord[end - 1]] * gcm[ord[end - 1], ord[end - 2]] > 1
+            push!(type, (:F, 4))
+          elseif gcm[ord[end - 1], ord[end]] * gcm[ord[end], ord[end - 1]] == 1
+            push!(type, (:A, num))
+          elseif gcm[ord[end - 1], ord[end]] == -1
+            push!(type, (:B, num))
+          else
+            push!(type, (:C, num))
+          end
+        end
+
+        # find next component
+        i = findfirst(undone)
+        if isnothing(i)
+          break
+        end
+
+        # reset number of roots
+        num = 0
+        empty!(roots)
+      end
+
+      j = 1
+      continue
+    end
+
+    # plan to visit j if undone
+    if undone[j]
+      head += 1
+      if head == 4
+        head = 1
+      end
+      plan[head] = j
+    end
+
+    push!(adj[i], j)
+    j += 1
+  end
+
+  return type, ord
 end

--- a/experimental/LieAlgebras/src/CartanMatrix.jl
+++ b/experimental/LieAlgebras/src/CartanMatrix.jl
@@ -1,7 +1,8 @@
 ###############################################################################
 #
-#   Cartan Matrix Helpers
-#   
+#   Cartan Matrix Functionality
+#   - Cartan matrices (and root orderings) are taken from Bourbaki
+#
 ###############################################################################
 
 @doc raw"""
@@ -308,7 +309,7 @@ function cartan_type_with_ordering(gcm::ZZMatrix; check::Bool=true)
 
   # global information
   ord = sizehint!(Int[], rk) # ordering of the roots
-  adj = [sizehint!(Int[], 3) for _ in 1:rk] # store adjacent roots
+  adj = [sizehint!(Int[], 3) for _ in 1:rk] # store adjacent roots, adj[i] is ordered asc
 
   # information about current type
   num = 0 # number of roots
@@ -354,19 +355,24 @@ function cartan_type_with_ordering(gcm::ZZMatrix; check::Bool=true)
             push!(ord, i, j)
           elseif gcm[i, j] == -3
             push!(type, (:G, 2))
-            push!(ord, j, i)
+            push!(ord, i, j)
           else
             push!(type, (:G, 2))
-            push!(ord, i, j)
+            push!(ord, j, i)
           end
         else # rank > 2
           # find start of the Dynkin graph
-          v = roots[1] # default to the first root (this only matters for D4)
+          v = 0
           for i in roots
             j = adj[i][1]
-            if length(adj[i]) == 1 && length(adj[j]) < 3 && gcm[i, j] * gcm[j, i] == 1
-              v = i
-              break
+            if length(adj[i]) == 1 && gcm[i, j] * gcm[j, i] == 1
+              if length(adj[j]) == 1 ||
+                (length(adj[j]) == 2 && gcm[j, adj[j][2]] * gcm[adj[j][2], j] == 1)
+                v = i
+                break
+              elseif v == 0
+                v = i
+              end
             end
           end
           push!(ord, v)

--- a/experimental/LieAlgebras/src/CartanMatrix.jl
+++ b/experimental/LieAlgebras/src/CartanMatrix.jl
@@ -10,6 +10,7 @@
 Returns the Cartan matrix of finite type, where `fam` is the family ($A$, $B$, $C$, $D$, $E$, $F$ $G$)
 and `rk` is the rank of the associated the root system.
 The convention is $(a_ij) = (\langle \alpha_i^\vee, \alpha_j \rangle)$ for simple roots $\alpha_i$.
+# Example
 ```jldoctest
 julia> cartan_matrix(:B, 2)
 [ 2   -1]
@@ -93,7 +94,7 @@ function cartan_matrix(types::Tuple{Symbol,Int}...)
 end
 
 @doc raw"""
-    cartan_to_coxeter_matrix(mat::ZZMatrix; check::Bool=true) -> Bool
+    cartan_to_coxeter_matrix(mat::ZZMatrix; check::Bool=true) -> ZZMatrix
 
 
 """
@@ -222,7 +223,7 @@ function cartan_type(gcm::ZZMatrix; check::Bool=true)
 end
 
 @doc raw"""
-    cartan_type(gcm::ZZMatrix; check::Bool=true) -> Tuple{Vector{Tuple{Symbol, Int}}, Vector{Int}}
+    cartan_type_with_ordering(gcm::ZZMatrix; check::Bool=true) -> Vector{Tuple{Symbol, Int}}, Vector{Int}
 
 Currently only works for Cartan matrices of finite type.
 """

--- a/experimental/LieAlgebras/src/CartanMatrix.jl
+++ b/experimental/LieAlgebras/src/CartanMatrix.jl
@@ -290,13 +290,14 @@ function cartan_type_with_ordering(gcm::ZZMatrix; check::Bool=true)
           v = 0
           for i in roots
             j = adj[i][1]
-            # we dealt with the rank 2 case, so there is at least one root with the following properties
-            if length(adj[i]) == 1 && length(adj[j]) < 3 && gcm[i, j] * gcm[j, i] == 1
+            if length(adj[i]) == 1 && gcm[i, j] * gcm[j, i] == 1
               v = i
-              push!(ord, v)
-              break
+              if length(adj[j]) < 3
+                break
+              end
             end
           end
+          push!(ord, v)
 
           n = 1
           adj3 = false # true if found a root with 3 adjacents

--- a/experimental/LieAlgebras/src/CartanMatrix.jl
+++ b/experimental/LieAlgebras/src/CartanMatrix.jl
@@ -9,7 +9,7 @@
 
 Returns the Cartan matrix of finite type, where `fam` is the family ($A$, $B$, $C$, $D$, $E$, $F$ $G$)
 and `rk` is the rank of the associated the root system; for $B$ and $C$ the rank has to be at least 2, for $D$ at least 4.
-The convention is $(a_ij) = (\langle \alpha_i^\vee, \alpha_j \rangle)$ for simple roots $\alpha_i$.
+The convention is $(a_{ij}) = (\langle \alpha_i^\vee, \alpha_j \rangle)$ for simple roots $\alpha_i$.
 
 # Example
 ```jldoctest
@@ -107,7 +107,7 @@ julia> cartan_matrix((:A, 2), (:B, 2))
 function cartan_matrix(type::Tuple{Symbol,Int}...)
   @req length(type) > 0 "At least one type is required"
 
-  blocks = ZZMatrix[cartan_matrix(t...) for t in type]
+  blocks = [cartan_matrix(t...) for t in type]
   return block_diagonal_matrix(blocks)
 end
 
@@ -124,6 +124,7 @@ true
 
 julia> is_cartan_matrix(ZZ[2 -2; -2 2]; generalized=false)
 false
+```
 """
 function is_cartan_matrix(mat::ZZMatrix; generalized::Bool=true)
   n, m = size(mat)
@@ -158,7 +159,8 @@ end
 @doc raw"""
     cartan_symmetrizer(gcm::ZZMatrix; check::Bool=true) -> Vector{ZZRingElem}
 
-Return a vector $d$ of coprime integers such that $(d_i a_{ij})_{ij}$ is a symmetric matrix, where $a_{ij}$ are the entries of a Cartan matrix `gcm`.
+Return a vector $d$ of coprime integers such that $(d_i a_{ij})_{ij}$ is a symmetric matrix,
+where $a_{ij}$ are the entries of the Cartan matrix `gcm`.
 The keyword argument `check` can be set to `false` to skip verification whether `gcm` is indeed a generalized Cartan matrix.
 
 # Example
@@ -167,6 +169,7 @@ julia> cartan_symmetrizer(cartan_matrix(:B, 2))
 2-element Vector{ZZRingElem}:
  2
  1
+```
 """
 function cartan_symmetrizer(gcm::ZZMatrix; check::Bool=true)
   @req !check || is_cartan_matrix(gcm) "Requires a generalized Cartan matrix"
@@ -237,6 +240,7 @@ The keyword argument `check` can be set to `false` to skip verification whether 
 julia> cartan_bilinear_form(cartan_matrix(:B, 2))
 [ 4   -2]
 [-2    2]
+```
 """
 function cartan_bilinear_form(gcm::ZZMatrix; check::Bool=true)
   @req !check || is_cartan_matrix(gcm) "Requires a generalized Cartan matrix"
@@ -276,11 +280,22 @@ end
 @doc raw"""
     cartan_type_with_ordering(gcm::ZZMatrix; check::Bool=true) -> Vector{Tuple{Symbol, Int}}, Vector{Int}
 
-Returns the Cartan type of a Cartan matrix `gcm` together with a vector indicating the canonical ordering of the roots
-(currently only Cartan matrices of finite type are supported).
+Returns the Cartan type of a Cartan matrix `gcm` together with a vector indicating a canonical ordering
+of the roots in the Dynkin diagram (currently only Cartan matrices of finite type are supported).
 The keyword argument `check` can be set to `false` to skip verification whether `gcm` is indeed a Cartan matrix of finite type.
 # Example
 ```jldoctest
+julia> cartan_matrix(:E, 6)
+[ 2    0   -1    0    0    0]
+[ 0    2    0   -1    0    0]
+[-1    0    2   -1    0    0]
+[ 0   -1   -1    2   -1    0]
+[ 0    0    0   -1    2   -1]
+[ 0    0    0    0   -1    2]
+
+julia> cartan_type_with_ordering(cartan_matrix(:E, 6))
+([(:E, 6)], [1, 3, 4, 2, 5, 6])
+
 julia> cartan_type_with_ordering(ZZ[2 0 -1 0; 0 2 0 -2; -2 0 2 0; 0 -1 0 2])
 ([(:B, 2), (:C, 2)], [1, 3, 2, 4])
 ```

--- a/experimental/LieAlgebras/src/CartanMatrix.jl
+++ b/experimental/LieAlgebras/src/CartanMatrix.jl
@@ -366,8 +366,7 @@ function cartan_type_with_ordering(gcm::ZZMatrix; check::Bool=true)
           for i in roots
             j = adj[i][1]
             if length(adj[i]) == 1 && gcm[i, j] * gcm[j, i] == 1
-              if length(adj[j]) == 1 ||
-                (length(adj[j]) == 2 && gcm[j, adj[j][2]] * gcm[adj[j][2], j] == 1)
+              if length(adj[j]) == 1 || (length(adj[j]) == 2 && gcm[j, adj[j][2]] == -1)
                 v = i
                 break
               elseif v == 0

--- a/experimental/LieAlgebras/src/CartanMatrix.jl
+++ b/experimental/LieAlgebras/src/CartanMatrix.jl
@@ -142,19 +142,14 @@ function is_cartan_matrix(mat::ZZMatrix; generalized::Bool=true)
       if mat[i, j] >= 0 || mat[j, i] >= 0
         return false
       end
-
-      # if we only want a generalized Cartan matrix, we are done with this pair of entries
-      if generalized
-        continue
-      end
-
-      if !(mat[i, j] * mat[j, i] in 1:3)
-        return false
-      end
     end
   end
+  
+  if generalized
+    return true
+  end
 
-  return true
+  return is_positive_definite(mat)
 end
 
 @doc raw"""

--- a/experimental/LieAlgebras/src/CartanMatrix.jl
+++ b/experimental/LieAlgebras/src/CartanMatrix.jl
@@ -92,7 +92,8 @@ end
 @doc raw"""
     cartan_matrix(type::Tuple{Symbol,Int}...) -> ZZMatrix
 
-Returns a block diagonal matrix of indecomposable Cartan matrices as defined by type. For allowed values see `cartan_matrix(fam::Symbol, rk::Int)`.
+Returns a block diagonal matrix of indecomposable Cartan matrices as defined by type.
+For allowed values see `cartan_matrix(fam::Symbol, rk::Int)`.
 
 # Example
 ```jldoctest
@@ -104,7 +105,7 @@ julia> cartan_matrix((:A, 2), (:B, 2))
 ```
 """
 function cartan_matrix(type::Tuple{Symbol,Int}...)
-  @req length(type) > 0 "at least one type is required"
+  @req length(type) > 0 "At least one type is required"
 
   blocks = ZZMatrix[cartan_matrix(t...) for t in type]
   return block_diagonal_matrix(blocks)
@@ -113,7 +114,7 @@ end
 @doc raw"""
     is_cartan_matrix(mat::ZZMatrix; generalized::Bool=true) -> Bool
 
-Test if `mat` is a generalized Cartan matrix. The keyword argument `generalized`
+Checks if `mat` is a generalized Cartan matrix. The keyword argument `generalized`
 can be set to `false` to restrict this to Cartan matrices of finite type.
 
 # Example
@@ -168,7 +169,7 @@ julia> cartan_symmetrizer(cartan_matrix(:B, 2))
  1
 """
 function cartan_symmetrizer(gcm::ZZMatrix; check::Bool=true)
-  @req !check || is_cartan_matrix(gcm) "requires a generalized Cartan matrix"
+  @req !check || is_cartan_matrix(gcm) "Requires a generalized Cartan matrix"
   rk = nrows(gcm)
   diag = ones(ZZRingElem, rk)
 
@@ -238,7 +239,7 @@ julia> cartan_bilinear_form(cartan_matrix(:B, 2))
 [-2    2]
 """
 function cartan_bilinear_form(gcm::ZZMatrix; check::Bool=true)
-  @req !check || is_cartan_matrix(gcm) "requires a generalized Cartan matrix"
+  @req !check || is_cartan_matrix(gcm) "Requires a generalized Cartan matrix"
 
   bil = deepcopy(gcm)
   sym = cartan_symmetrizer(gcm; check=false)
@@ -254,7 +255,7 @@ end
 Returns the Cartan type of a Cartan matrix `gcm` (currently only Cartan matrices of finite type are supported).
 This function is left inverse to `cartan_matrix`, i.e. in the case of isomorphic types (e.g. $B_2$ and $C_2$)
 the ordering of the roots does matter (see the example below).
-The keyword argument `check` can be set to `false` to skip verification whether `gcm` is indeed a generalized Cartan matrix.
+The keyword argument `check` can be set to `false` to skip verification whether `gcm` is indeed a Cartan matrix of finite type.
 
 # Example
 ```jldoctest
@@ -277,7 +278,7 @@ end
 
 Returns the Cartan type of a Cartan matrix `gcm` together with a vector indicating the canonical ordering of the roots
 (currently only Cartan matrices of finite type are supported).
-The keyword argument `check` can be set to `false` to skip verification whether `gcm` is indeed a generalized Cartan matrix.
+The keyword argument `check` can be set to `false` to skip verification whether `gcm` is indeed a Cartan matrix of finite type.
 # Example
 ```jldoctest
 julia> cartan_type_with_ordering(ZZ[2 0 -1 0; 0 2 0 -2; -2 0 2 0; 0 -1 0 2])

--- a/experimental/LieAlgebras/src/CartanMatrix.jl
+++ b/experimental/LieAlgebras/src/CartanMatrix.jl
@@ -287,14 +287,12 @@ function cartan_type_with_ordering(gcm::ZZMatrix; check::Bool=true)
           end
         else # rank > 2
           # find start of the Dynkin graph
-          v = 0
+          v = roots[1] # default to the first root (this only matters for D4)
           for i in roots
             j = adj[i][1]
-            if length(adj[i]) == 1 && gcm[i, j] * gcm[j, i] == 1
+            if length(adj[i]) == 1 && length(adj[j]) < 3 && gcm[i, j] * gcm[j, i] == 1
               v = i
-              if length(adj[j]) < 3
-                break
-              end
+              break
             end
           end
           push!(ord, v)

--- a/experimental/LieAlgebras/src/CartanMatrix.jl
+++ b/experimental/LieAlgebras/src/CartanMatrix.jl
@@ -24,14 +24,14 @@ julia> cartan_matrix(:C, 2)
 """
 function cartan_matrix(fam::Symbol, rk::Int)
   if fam == :A
-    @req rk >= 1 "type An requires rank rk to be at least 1"
+    @req rk >= 1 "Type An requires rank rk to be at least 1"
 
     mat = diagonal_matrix(ZZ(2), rk)
     for i in 1:(rk - 1)
       mat[i + 1, i], mat[i, i + 1] = -1, -1
     end
   elseif fam == :B
-    @req rk >= 2 "type Bn requires rank rk to be at least  2"
+    @req rk >= 2 "Type Bn requires rank rk to be at least  2"
 
     mat = diagonal_matrix(ZZ(2), rk)
     for i in 1:(rk - 1)
@@ -39,7 +39,7 @@ function cartan_matrix(fam::Symbol, rk::Int)
     end
     mat[rk, rk - 1] = -2
   elseif fam == :C
-    @req rk >= 2 "type Cn requires rank rk to be at least 2"
+    @req rk >= 2 "Type Cn requires rank rk to be at least 2"
 
     mat = diagonal_matrix(ZZ(2), rk)
     for i in 1:(rk - 1)
@@ -47,7 +47,7 @@ function cartan_matrix(fam::Symbol, rk::Int)
     end
     mat[rk - 1, rk] = -2
   elseif fam == :D
-    @req rk >= 4 "type Dn requires rank to be at least 4"
+    @req rk >= 4 "Type Dn requires rank to be at least 4"
 
     mat = diagonal_matrix(ZZ(2), rk)
     for i in 1:(rk - 2)
@@ -56,7 +56,7 @@ function cartan_matrix(fam::Symbol, rk::Int)
     mat[rk - 2, rk] = -1
     mat[rk, rk - 2] = -1
   elseif fam == :E
-    @req rk in 6:8 "type En requires rank to be one of 6, 7, 8"
+    @req rk in 6:8 "Type En requires rank to be one of 6, 7, 8"
     mat = matrix(
       ZZ,
       [
@@ -77,10 +77,10 @@ function cartan_matrix(fam::Symbol, rk::Int)
       mat = mat[1:7, 1:7]
     end
   elseif fam == :F
-    @req rk == 4 "type Fn requires rank to be 4"
+    @req rk == 4 "Type Fn requires rank to be 4"
     mat = matrix(ZZ, [2 -1 0 0; -1 2 -1 0; 0 -2 2 -1; 0 0 -1 2])
   elseif fam == :G
-    @req rk == 2 "type Gn requires rank to be 2"
+    @req rk == 2 "Type Gn requires rank to be 2"
     mat = matrix(ZZ, [2 -3; -1 2])
   else
     throw(ArgumentError("unknown family"))

--- a/experimental/LieAlgebras/src/CoxeterGroup.jl
+++ b/experimental/LieAlgebras/src/CoxeterGroup.jl
@@ -7,7 +7,7 @@ abstract type CoxeterGroup end # <: Group
 
 Returns the Coxeter matrix $m$ associated to the Cartan matrix `gcm`. If there is no relation between $i$ and $j$,
 then this will be expressed by $m_{ij} = 0$ (instead of the usual convention $m_{ij} = \infty$).
-`check` optionally verifies that `gcm` is indeed a generalized Cartan matrix.
+The keyword argument `check` can be set to `false` to skip verification whether `gcm` is indeed a generalized Cartan matrix.
 """
 function coxeter_from_cartan_matrix(gcm; check::Bool=true)
   @req !check || is_cartan_matrix(gcm) "requires a generalized Cartan matrix"

--- a/experimental/LieAlgebras/src/CoxeterGroup.jl
+++ b/experimental/LieAlgebras/src/CoxeterGroup.jl
@@ -1,3 +1,34 @@
 abstract type CoxeterGroup end # <: Group
 
 #function is_coxeter_matrix(M::ZZMatrix) end
+
+@doc raw"""
+    coxeter_from_cartan_matrix(mat::ZZMatrix; check::Bool=true) -> Bool
+
+Returns the Coxeter matrix $m$ associated to the Cartan matrix `gcm`. If there is no relation between $i$ and $j$,
+then this will be expressed by $m_{ij} = 0$ (instead of the usual convention $m_{ij} = \infty$).
+`check` optionally verifies that `gcm` is indeed a generalized Cartan matrix.
+"""
+function coxeter_from_cartan_matrix(gcm; check::Bool=true)
+  @req !check || is_cartan_matrix(gcm) "requires a generalized Cartan matrix"
+
+  cm = identity_matrix(gcm)
+  rk, _ = size(gcm)
+  for i in 1:rk, j in 1:rk
+    if i == j
+      continue
+    end
+
+    if gcm[i, j] == 0
+      cm[i, j] = 2
+    elseif gcm[i, j] == -1
+      cm[i, j] = 3
+    elseif gcm[i, j] == -2
+      cm[i, j] = 4
+    elseif gcm[i, j] == -3
+      cm[i, j] = 6
+    end
+  end
+
+  return cm
+end

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -92,7 +92,11 @@ export base_lie_algebra
 export base_module
 export base_modules
 export bracket
+export cartan_bilinear_form
 export cartan_matrix
+export cartan_symmetrizer
+export cartan_type
+export cartan_type_with_ordering
 export chevalley_basis
 export coefficient_vector
 export coerce_to_lie_algebra_elem
@@ -190,8 +194,11 @@ export base_lie_algebra
 export base_module
 export base_modules
 export bracket
+export cartan_bilinear_form
 export cartan_matrix
-export cartan_matrix
+export cartan_symmetrizer
+export cartan_type
+export cartan_type_with_ordering
 export chevalley_basis
 export coerce_to_lie_algebra_elem
 export conjugate_dominant_weight

--- a/experimental/LieAlgebras/test/CartanMatrix-test.jl
+++ b/experimental/LieAlgebras/test/CartanMatrix-test.jl
@@ -73,7 +73,8 @@
 
     @test cartan_type(cartan_matrix(:C, 3); check=false) == [(:C, 3)]
     @test cartan_type(ZZ[2 -1 0; -2 2 -1; 0 -1 2]; check=false) == [(:C, 3)]
-
+    
+    @test cartan_type(cartan_matrix(:D, 4); check=false) == [(:D, 4)]
     @test cartan_type(cartan_matrix(:D, 6); check=false) == [(:D, 6)]
     @test cartan_type(cartan_matrix(:E, 6); check=false) == [(:E, 6)]
     @test cartan_type(cartan_matrix(:E, 7); check=false) == [(:E, 7)]

--- a/experimental/LieAlgebras/test/CartanMatrix-test.jl
+++ b/experimental/LieAlgebras/test/CartanMatrix-test.jl
@@ -107,7 +107,7 @@
     @test cartan_bilinear_form(cartan_matrix(:G, 2)) == ZZ[2 -3; -3 6]
 
     @test cartan_bilinear_form(cartan_matrix((:B, 2), (:A, 1))) == ZZ[4 -2 0; -2 2 0; 0 0 2]
-    @test cartan_symmetrizer(ZZ[2 0 -1 0; 0 2 0 -2; -2 0 2 0; 0 -1 0 2]) ==
+    @test cartan_bilinear_form(ZZ[2 0 -1 0; 0 2 0 -2; -2 0 2 0; 0 -1 0 2]) ==
       ZZ[4 0 -2 0; 0 2 0 -2; -2 0 2 0; 0 -2 0 4]
 
     # affine type

--- a/experimental/LieAlgebras/test/CartanMatrix-test.jl
+++ b/experimental/LieAlgebras/test/CartanMatrix-test.jl
@@ -88,7 +88,7 @@
 
     # affine type
     @test cartan_symmetrizer(ZZ[2 -2; -2 2]) == [1, 1] # A1~1
-    @test cartan_symmetrizer(ZZ[2 -2 0; -1 2 -1; 0 -2 2]) == [1, 2, 1] # B3~1
+    @test cartan_symmetrizer(ZZ[2 -2 0; -1 2 -1; 0 -2 2]) == [1, 2, 1] # D3~2
     @test cartan_symmetrizer(ZZ[2 -4; -1 2]) == [1, 4] # A1~2
 
     # hyperbolic type
@@ -150,5 +150,8 @@
     @test cartan_type(cartan_matrix((:C, 2), (:B, 2)); check=false) == [(:C, 2), (:B, 2)]
     @test cartan_type(ZZ[2 0 -1 0; 0 2 0 -2; -2 0 2 0; 0 -1 0 2]; check=false) ==
       [(:B, 2), (:C, 2)]
+  end
+
+  @testset "cartan_type_with_ordering(gcm::ZZMatrix; check::Bool)" begin
   end
 end

--- a/experimental/LieAlgebras/test/CartanMatrix-test.jl
+++ b/experimental/LieAlgebras/test/CartanMatrix-test.jl
@@ -135,7 +135,7 @@
 
     # Dn
     @test cartan_type(cartan_matrix(:D, 4); check=false) == [(:D, 4)]
-    @test cartan_type(ZZ[2 -1 -1 -1; -1 2 0 0; -1 0 2 0; -1 0 0 2])
+    @test cartan_type(ZZ[2 -1 -1 -1; -1 2 0 0; -1 0 2 0; -1 0 0 2]) == [(:D, 4)]
     @test cartan_type(cartan_matrix(:D, 6); check=false) == [(:D, 6)]
 
     @test cartan_type(cartan_matrix(:E, 6); check=false) == [(:E, 6)]
@@ -201,7 +201,7 @@
     _, ord = cartan_type_with_ordering(cartan_matrix(:F, 4))
     @test ord == [1, 2, 3, 4]
 
-    _, ord = cartan_type_with_ordering(ZZ[2 -1 0 0; -1 2 -1 0; 0 -2 2 -1; 0 0 -1 2])
+    _, ord = cartan_type_with_ordering(ZZ[2 -1 0 0; -1 2 -2 0; 0 -1 2 -1; 0 0 -1 2])
     @test ord == [4, 3, 2, 1]
 
     # G2

--- a/experimental/LieAlgebras/test/CartanMatrix-test.jl
+++ b/experimental/LieAlgebras/test/CartanMatrix-test.jl
@@ -54,8 +54,7 @@
     @test is_cartan_matrix(ZZ[2 -4; -1 2]; generalized=false) == false
 
     # how test for loops ?
-    @test is_cartan_matrix(ZZ[2 -1 -1; -1 2 -1; -1 -1 2]; generalized=false) == false broken =
-      true
+    @test_broken is_cartan_matrix(ZZ[2 -1 -1; -1 2 -1; -1 -1 2]; generalized=false) == false
   end
 
   @testset "cartan_type(gcm::ZZMatrix; check::Bool)" begin

--- a/experimental/LieAlgebras/test/CartanMatrix-test.jl
+++ b/experimental/LieAlgebras/test/CartanMatrix-test.jl
@@ -129,11 +129,15 @@
     @test cartan_type(cartan_matrix(:B, 3); check=false) == [(:B, 3)]
     @test cartan_type(ZZ[2 -2 0; -1 2 -1; 0 -1 2]; check=false) == [(:B, 3)]
 
+    # Cn
     @test cartan_type(cartan_matrix(:C, 3); check=false) == [(:C, 3)]
     @test cartan_type(ZZ[2 -1 0; -2 2 -1; 0 -1 2]; check=false) == [(:C, 3)]
 
+    # Dn
     @test cartan_type(cartan_matrix(:D, 4); check=false) == [(:D, 4)]
+    @test cartan_type(ZZ[2 -1 -1 -1; -1 2 0 0; -1 0 2 0; -1 0 0 2])
     @test cartan_type(cartan_matrix(:D, 6); check=false) == [(:D, 6)]
+
     @test cartan_type(cartan_matrix(:E, 6); check=false) == [(:E, 6)]
     @test cartan_type(cartan_matrix(:E, 7); check=false) == [(:E, 7)]
     @test cartan_type(cartan_matrix(:E, 8); check=false) == [(:E, 8)]
@@ -153,5 +157,58 @@
   end
 
   @testset "cartan_type_with_ordering(gcm::ZZMatrix; check::Bool)" begin
+    # we only test the ordering here the type detection is tested in "cartan_type(gcm::ZZMatrix; check::Bool)"
+
+    # An
+    _, ord = cartan_type_with_ordering(cartan_matrix(:A, 1))
+    @test ord == [1]
+
+    _, ord = cartan_type_with_ordering(cartan_matrix(:A, 2))
+    @test ord == [1, 2]
+
+    # Bn
+    _, ord = cartan_type_with_ordering(cartan_matrix(:B, 2))
+    @test ord == [1, 2]
+
+    _, ord = cartan_type_with_ordering(cartan_matrix(:B, 3))
+    @test ord == [1, 2, 3]
+
+    # Cn
+    _, ord = cartan_type_with_ordering(cartan_matrix(:C, 2))
+    @test ord == [1, 2]
+
+    _, ord = cartan_type_with_ordering(cartan_matrix(:C, 3))
+    @test ord == [1, 2, 3]
+
+    # Dn
+    _, ord = cartan_type_with_ordering(cartan_matrix(:D, 4))
+    @test ord == [1, 2, 3, 4]
+
+    _, ord = cartan_type_with_ordering(ZZ[2 -1 -1 -1; -1 2 0 0; -1 0 2 0; -1 0 0 2])
+    @test ord == [2, 1, 3, 4]
+
+    # En
+    _, ord = cartan_type_with_ordering(cartan_matrix(:E, 6))
+    @test ord == [1, 3, 4, 2, 5, 6]
+
+    _, ord = cartan_type_with_ordering(cartan_matrix(:E, 7))
+    @test ord == [1, 3, 4, 2, 5, 6, 7]
+
+    _, ord = cartan_type_with_ordering(cartan_matrix(:E, 8))
+    @test ord == [1, 3, 4, 2, 5, 6, 7, 8]
+
+    # F4
+    _, ord = cartan_type_with_ordering(cartan_matrix(:F, 4))
+    @test ord == [1, 2, 3, 4]
+
+    _, ord = cartan_type_with_ordering(ZZ[2 -1 0 0; -1 2 -1 0; 0 -2 2 -1; 0 0 -1 2])
+    @test ord == [4, 3, 2, 1]
+
+    # G2
+    _, ord = cartan_type_with_ordering(cartan_matrix(:G, 2))
+    @test ord == [1, 2]
+
+    _, ord = cartan_type_with_ordering(transpose(cartan_matrix(:G, 2)))
+    @test ord == [2, 1]
   end
 end

--- a/experimental/LieAlgebras/test/CartanMatrix-test.jl
+++ b/experimental/LieAlgebras/test/CartanMatrix-test.jl
@@ -1,0 +1,95 @@
+@testset "LieAlgebras.CartanMatrix" begin
+  @testset "cartan_matrix(fam::Symbol, rk::Int)" begin
+    @test cartan_matrix(:A, 1) == matrix(ZZ, 1, 1, [2])
+    @test cartan_matrix(:A, 2) == ZZ[2 -1; -1 2]
+
+    @test cartan_matrix(:B, 2) == ZZ[2 -1; -2 2]
+    @test cartan_matrix(:B, 3) == ZZ[2 -1 0; -1 2 -1; 0 -2 2]
+
+    @test cartan_matrix(:C, 2) == ZZ[2 -2; -1 2]
+    @test cartan_matrix(:C, 3) == ZZ[2 -1 0; -1 2 -2; 0 -1 2]
+
+    @test cartan_matrix(:D, 4) == ZZ[2 -1 0 0; -1 2 -1 -1; 0 -1 2 0; 0 -1 0 2]
+
+    @test_throws ArgumentError root_system(:X, 1)
+    @test_throws ArgumentError root_system(:A, 0)
+    @test_throws ArgumentError root_system(:B, 1)
+    @test_throws ArgumentError root_system(:C, 1)
+    @test_throws ArgumentError root_system(:D, 2)
+    @test_throws ArgumentError root_system(:E, 5)
+    @test_throws ArgumentError root_system(:E, 9)
+    @test_throws ArgumentError root_system(:F, 3)
+    @test_throws ArgumentError root_system(:F, 5)
+    @test_throws ArgumentError root_system(:G, 1)
+    @test_throws ArgumentError root_system(:G, 3)
+  end
+
+  @testset "cartan_to_coxeter_matrix(mat::ZZMatrix; generalized::Bool=true)" begin end
+
+  @testset "is_cartan_matrix(mat::ZZMatrix; generalized::Bool=true)" begin
+    # test finite type
+    @test is_cartan_matrix(cartan_matrix(:A, 1)) == true
+    @test is_cartan_matrix(cartan_matrix(:A, 1); generalized=false) == true
+
+    @test is_cartan_matrix(cartan_matrix(:A, 2)) == true
+    @test is_cartan_matrix(cartan_matrix(:A, 2); generalized=false) == true
+
+    @test is_cartan_matrix(cartan_matrix(:B, 2)) == true
+    @test is_cartan_matrix(cartan_matrix(:B, 2); generalized=false) == true
+
+    @test is_cartan_matrix(cartan_matrix(:C, 2)) == true
+    @test is_cartan_matrix(cartan_matrix(:C, 2); generalized=false) == true
+
+    @test is_cartan_matrix(cartan_matrix(:D, 4)) == true
+    @test is_cartan_matrix(cartan_matrix(:D, 4); generalized=false) == true
+
+    @test is_cartan_matrix(cartan_matrix(:G, 2)) == true
+    @test is_cartan_matrix(cartan_matrix(:G, 2); generalized=false) == true
+
+    # test affine type
+    @test is_cartan_matrix(ZZ[2 -2; -2 2]) == true
+    @test is_cartan_matrix(ZZ[2 -2; -2 2]; generalized=false) == false
+
+    @test is_cartan_matrix(ZZ[2 -4; -1 2]) == true
+    @test is_cartan_matrix(ZZ[2 -4; -1 2]; generalized=false) == false
+
+    # how test for loops ?
+    @test is_cartan_matrix(ZZ[2 -1 -1; -1 2 -1; -1 -1 2]; generalized=false) == false broken =
+      true
+  end
+
+  @testset "cartan_type(gcm::ZZMatrix; check::Bool)" begin
+    # test if we follow our own conventions
+    @test cartan_type(cartan_matrix(:A, 3); check=false) == [(:A, 3)]
+    @test cartan_type(cartan_matrix(:B, 2); check=false) == [(:B, 2)]
+    @test cartan_type(cartan_matrix(:C, 2); check=false) == [(:C, 2)]
+
+    # tests for irreducibles
+    @test cartan_type(cartan_matrix(:A, 1); check=false) == [(:A, 1)]
+    @test cartan_type(cartan_matrix(:A, 2); check=false) == [(:A, 2)]
+
+    @test cartan_type(cartan_matrix(:B, 3); check=false) == [(:B, 3)]
+    @test cartan_type(ZZ[2 -2 0; -1 2 -1; 0 -1 2]; check=false) == [(:B, 3)]
+
+    @test cartan_type(cartan_matrix(:C, 3); check=false) == [(:C, 3)]
+    @test cartan_type(ZZ[2 -1 0; -2 2 -1; 0 -1 2]; check=false) == [(:C, 3)]
+
+    @test cartan_type(cartan_matrix(:D, 6); check=false) == [(:D, 6)]
+    @test cartan_type(cartan_matrix(:E, 6); check=false) == [(:E, 6)]
+    @test cartan_type(cartan_matrix(:E, 7); check=false) == [(:E, 7)]
+    @test cartan_type(cartan_matrix(:E, 8); check=false) == [(:E, 8)]
+    @test cartan_type(cartan_matrix(:F, 4); check=false) == [(:F, 4)]
+    @test cartan_type(cartan_matrix(:G, 2); check=false) == [(:G, 2)]
+
+    # for F4 and G2 we also allow the transposed Cartan matrix
+    @test cartan_type(transpose(cartan_matrix(:F, 4))) == [(:F, 4)]
+    @test cartan_type(transpose(cartan_matrix(:G, 2))) == [(:G, 2)]
+
+    # test decomposable Cartan matrices
+    @test cartan_type(cartan_matrix((:A, 1), (:A, 2)); check=false) == [(:A, 1), (:A, 2)]
+    @test cartan_type(cartan_matrix((:A, 1), (:B, 2)); check=false) == [(:A, 1), (:B, 2)]
+    @test cartan_type(cartan_matrix((:C, 2), (:B, 2)); check=false) == [(:C, 2), (:B, 2)]
+    @test cartan_type([2 0 -1 0; 0 2 0 -2; -2 0 2 0; 0 -1 0 2]; check=false) ==
+      [(:B, 2), (:C, 2)]
+  end
+end

--- a/experimental/LieAlgebras/test/CartanMatrix-test.jl
+++ b/experimental/LieAlgebras/test/CartanMatrix-test.jl
@@ -89,7 +89,7 @@
     @test cartan_type(cartan_matrix((:A, 1), (:A, 2)); check=false) == [(:A, 1), (:A, 2)]
     @test cartan_type(cartan_matrix((:A, 1), (:B, 2)); check=false) == [(:A, 1), (:B, 2)]
     @test cartan_type(cartan_matrix((:C, 2), (:B, 2)); check=false) == [(:C, 2), (:B, 2)]
-    @test cartan_type([2 0 -1 0; 0 2 0 -2; -2 0 2 0; 0 -1 0 2]; check=false) ==
+    @test cartan_type(ZZ[2 0 -1 0; 0 2 0 -2; -2 0 2 0; 0 -1 0 2]; check=false) ==
       [(:B, 2), (:C, 2)]
   end
 end

--- a/experimental/LieAlgebras/test/RootSystem-test.jl
+++ b/experimental/LieAlgebras/test/RootSystem-test.jl
@@ -1,19 +1,21 @@
-@testset "root_system(cartan_matrix::ZZMatrix)" begin
-  R = root_system(:F, 4)
-  @test num_positive_roots(R) == 24
-  @test num_roots(R) == 48
+@testset "LieAlgebras.RootSystem" begin
+  @testset "root_system(cartan_matrix::ZZMatrix)" begin
+    R = root_system(:F, 4)
+    @test num_positive_roots(R) == 24
+    @test num_roots(R) == 48
 
-  R = root_system(:G, 2)
-  @test num_positive_roots(R) == 6
-  @test num_roots(R) == 12
+    R = root_system(:G, 2)
+    @test num_positive_roots(R) == 6
+    @test num_roots(R) == 12
 
-  @test coefficients(positive_root(R, 1)) == QQ[1 0]
-  @test coefficients(positive_root(R, 2)) == QQ[0 1]
-end
+    @test coefficients(positive_root(R, 1)) == QQ[1 0]
+    @test coefficients(positive_root(R, 2)) == QQ[0 1]
+  end
 
-@testset "WeightLatticeElem" begin
-  R = root_system(:A, 2)
-  w = WeightLatticeElem(R, [2, 2])
+  @testset "WeightLatticeElem" begin
+    R = root_system(:A, 2)
+    w = WeightLatticeElem(R, [2, 2])
 
-  @test root_system(w) === R
+    @test root_system(w) === R
+  end
 end

--- a/experimental/LieAlgebras/test/WeylGroup-test.jl
+++ b/experimental/LieAlgebras/test/WeylGroup-test.jl
@@ -1,4 +1,4 @@
-@testset "WeylGroup" begin
+@testset "LieAlgebras.WeylGroup" begin
   @testset "weyl_group(cartan_matrix::ZZMatrix)" begin
     W = weyl_group(cartan_matrix(:A, 2))
     @test isfinite(W) == true
@@ -48,84 +48,84 @@
     W = weyl_group(:G, 2)
     @test word(longest_element(W)) == UInt8[2, 1, 2, 1, 2, 1]
   end
-end
 
-@testset "Base.:(*)(x::WeylGroupElem, y::WeylGroupElem)" begin
-  # test A2
-  W = weyl_group(:A, 2)
-  s = gens(W)
+  @testset "Base.:(*)(x::WeylGroupElem, y::WeylGroupElem)" begin
+    # test A2
+    W = weyl_group(:A, 2)
+    s = gens(W)
 
-  @test parent(s[1] * s[2]) === parent(s[1]) === parent(s[2])
+    @test parent(s[1] * s[2]) === parent(s[1]) === parent(s[2])
 
-  @test word(s[2] * s[1]) == UInt[2, 1]
-  @test word(s[1] * s[2]) == UInt[1, 2]
+    @test word(s[2] * s[1]) == UInt[2, 1]
+    @test word(s[1] * s[2]) == UInt[1, 2]
 
-  @test word(s[1] * s[2] * s[1]) == UInt[1, 2, 1]
-  @test word(s[2] * s[1] * s[2]) == UInt[1, 2, 1]
+    @test word(s[1] * s[2] * s[1]) == UInt[1, 2, 1]
+    @test word(s[2] * s[1] * s[2]) == UInt[1, 2, 1]
 
-  # test A3
-  W = weyl_group(:A, 3)
-  s = gens(W)
+    # test A3
+    W = weyl_group(:A, 3)
+    s = gens(W)
 
-  @test parent(s[1] * s[2]) === parent(s[1]) === parent(s[2])
+    @test parent(s[1] * s[2]) === parent(s[1]) === parent(s[2])
 
-  @test word(s[2] * s[1]) == UInt8[2, 1]
-  @test word(s[1] * s[2]) == UInt8[1, 2]
+    @test word(s[2] * s[1]) == UInt8[2, 1]
+    @test word(s[1] * s[2]) == UInt8[1, 2]
 
-  @test word(s[3] * s[1]) == UInt8[3, 1]
-  @test word(s[1] * s[3]) == UInt8[3, 1]
+    @test word(s[3] * s[1]) == UInt8[3, 1]
+    @test word(s[1] * s[3]) == UInt8[3, 1]
 
-  @test word(s[3] * s[2]) == UInt8[3, 2]
-  @test word(s[2] * s[3]) == UInt8[2, 3]
+    @test word(s[3] * s[2]) == UInt8[3, 2]
+    @test word(s[2] * s[3]) == UInt8[2, 3]
 
-  @test word(s[1] * s[3] * s[1]) == UInt8[3]
-  @test word(s[3] * s[1] * s[3]) == UInt8[1]
+    @test word(s[1] * s[3] * s[1]) == UInt8[3]
+    @test word(s[3] * s[1] * s[3]) == UInt8[1]
 
-  @test word(s[1] * s[2] * s[1]) == UInt8[1, 2, 1]
-  @test word(s[2] * s[1] * s[2]) == UInt8[1, 2, 1]
+    @test word(s[1] * s[2] * s[1]) == UInt8[1, 2, 1]
+    @test word(s[2] * s[1] * s[2]) == UInt8[1, 2, 1]
 
-  @test word(s[2] * s[3] * s[2]) == UInt8[2, 3, 2]
-  @test word(s[3] * s[2] * s[3]) == UInt8[2, 3, 2]
-end
+    @test word(s[2] * s[3] * s[2]) == UInt8[2, 3, 2]
+    @test word(s[3] * s[2] * s[3]) == UInt8[2, 3, 2]
+  end
 
-@testset "Base.:(*)(x::WeylGroupElem, w::WeightLatticeElem)" begin
-  R = root_system(:A, 2)
-  W = weyl_group(R)
-  
-  rho = weyl_vector(R)
-  @test longest_element(W)*rho == -rho
-end
+  @testset "Base.:(*)(x::WeylGroupElem, w::WeightLatticeElem)" begin
+    R = root_system(:A, 2)
+    W = weyl_group(R)
 
-@testset "ReducedExpressionIterator" begin
-  W = weyl_group(:A, 3)
-  s = gens(W)
+    rho = weyl_vector(R)
+    @test longest_element(W) * rho == -rho
+  end
 
-  # test for s1
-  iter = reduced_expressions(s[1])
-  @test iter.el === s[1]
-  @test iter.up_to_commutation == false
+  @testset "ReducedExpressionIterator" begin
+    W = weyl_group(:A, 3)
+    s = gens(W)
 
-  re = collect(iter)
-  @test length(re) == 1
-  @test re[1] == word(s[1])
+    # test for s1
+    iter = reduced_expressions(s[1])
+    @test iter.el === s[1]
+    @test iter.up_to_commutation == false
 
-  # test for w0
-  w0 = longest_element(W)
-  iter = reduced_expressions(w0)
-  @test iter.el === w0
-  @test iter.up_to_commutation == false
+    re = collect(iter)
+    @test length(re) == 1
+    @test re[1] == word(s[1])
 
-  re = collect(iter)
-  @test length(re) == 16
-  @test re[1] == word(w0)
-  @test re[16] == UInt8[3, 2, 1, 3, 2, 3]
+    # test for w0
+    w0 = longest_element(W)
+    iter = reduced_expressions(w0)
+    @test iter.el === w0
+    @test iter.up_to_commutation == false
 
-  iter = reduced_expressions(w0; up_to_commutation=true)
-  @test iter.el === w0
-  @test iter.up_to_commutation == true
+    re = collect(iter)
+    @test length(re) == 16
+    @test re[1] == word(w0)
+    @test re[16] == UInt8[3, 2, 1, 3, 2, 3]
 
-  re = collect(iter)
-  @test length(re) == 8
-  @test re[1] == word(w0)
-  @test re[8] == UInt8[3, 2, 3, 1, 2, 3]
+    iter = reduced_expressions(w0; up_to_commutation=true)
+    @test iter.el === w0
+    @test iter.up_to_commutation == true
+
+    re = collect(iter)
+    @test length(re) == 8
+    @test re[1] == word(w0)
+    @test re[8] == UInt8[3, 2, 3, 1, 2, 3]
+  end
 end


### PR DESCRIPTION
This is a follow up of #2689 and adds docs and tests for the CartanMatrix.jl file added in this PR. It also adds four new functions, name `cartan_symmterizer`, `cartan_bilinear_form`, `cartan_type` and `cartan_type_with_ordering`.
Work isn't completely finished, but I want to open the discussion for the naming of functions.

For one @lgoettgens suggested to rename `cartan_to_coxeter_matrix` to something like `coxeter_from_cartan_matrix` (to follow the convention of dst_src if I remember correctly).

If time permits I will add a function for Cartan matrices of affine type. My suggestion would be `cartan_matrix(fam::Symbol, rk::Int, aff::Int)`. I do not plan on handling the hyperbolic case, What is you opinion @fingolfin ?