### PR TITLE
Clarify the right action on polynomials

### DIFF
--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -286,18 +286,8 @@ end
     on_indeterminates(f::MPolyRingElem, p::PermGroupElem)
     on_indeterminates(f::FreeAssAlgElem, p::PermGroupElem)
     on_indeterminates(f::MPolyIdeal, p::PermGroupElem)
-    on_indeterminates(f::GAP.GapObj, p::MatrixGroupElem)
-    on_indeterminates(f::MPolyRingElem{T}, p::MatrixGroupElem{T}) where T
-    on_indeterminates(f::MPolyIdeal, p::MatrixGroupElem)
 
-Return the image of `f` under `p`.
-
-If `p` is a `PermGroupElem` then it acts via permuting the indeterminates.
-
-If `p` is a `MatrixGroupElem` then it acts via evaluating `f` at the
-vector obtained by multiplying `p` with the (column) vector of indeterminates.
-This corresponds to considering the variables of `parent(f)` as the basis of a
-vector space on which `p` acts by multiplication from the right.
+Return the image of `f` under `p` where `p` acts via permuting the indeterminates.
 
 For `MPolyRingElem`, `FreeAssAlgElem`, and `MPolyIdeal` objects,
 one can also call `^` instead of `on_indeterminates`.
@@ -322,18 +312,6 @@ GAP: x_1*x_2+x_2*x_3
 
 julia> on_indeterminates(f, p)
 GAP: x_1*x_3+x_2*x_3
-
-julia> g = general_linear_group(2, 5);  m = g[2]
-[4   1]
-[4   0]
-
-julia> R, x = polynomial_ring(base_ring(g), degree(g));
-
-julia> f = x[1]*x[2] + x[1]
-x1*x2 + x1
-
-julia> f^m
-x1^2 + 4*x1*x2 + 4*x1 + x2
 ```
 """
 on_indeterminates(f::GapObj, p::PermGroupElem) = GAPWrap.OnIndeterminates(f, p.X)
@@ -364,6 +342,35 @@ function on_indeterminates(f::FreeAssAlgElem{T}, s::PermGroupElem) where T
   return S(c, es)
 end
 
+@doc raw"""
+    on_indeterminates(f::GAP.GapObj, p::MatrixGroupElem)
+    on_indeterminates(f::MPolyRingElem{T}, p::MatrixGroupElem{T}) where T
+    on_indeterminates(f::MPolyIdeal, p::MatrixGroupElem)
+
+Return the image of `f` under `p` where `p` acts via evaluating `f` at the
+vector obtained by multiplying `p` with the (column) vector of indeterminates.
+This corresponds to considering the variables of the polynomial ring containing
+`f` as the basis of a vector space on which `p` acts by multiplication from the
+right.
+
+For `MPolyRingElem` and `MPolyIdeal` objects, one can also call `^` instead of
+`on_indeterminates`.
+
+# Examples
+```jldoctest
+julia> g = general_linear_group(2, 5);  m = g[2]
+[4   1]
+[4   0]
+
+julia> R, x = polynomial_ring(base_ring(g), degree(g));
+
+julia> f = x[1]*x[2] + x[1]
+x1*x2 + x1
+
+julia> f^m
+x1^2 + 4*x1*x2 + 4*x1 + x2
+```
+"""
 function on_indeterminates(f::GapObj, p::MatrixGroupElem)
   # We assume that we act on the indeterminates with numbers 1, ..., nrows(p).
   # (Note that `f` does not know about a polynomial ring to which it belongs.)

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -281,19 +281,23 @@ function permuted(pnt::T, x::PermGroupElem) where T <: Tuple
 end
 
 
-"""
+@doc raw"""
     on_indeterminates(f::GAP.GapObj, p::PermGroupElem)
     on_indeterminates(f::MPolyRingElem, p::PermGroupElem)
     on_indeterminates(f::FreeAssAlgElem, p::PermGroupElem)
     on_indeterminates(f::MPolyIdeal, p::PermGroupElem)
     on_indeterminates(f::GAP.GapObj, p::MatrixGroupElem)
-    on_indeterminates(f::MPolyRingElem{T}, p::MatrixGroupElem{T, S}) where T where S
+    on_indeterminates(f::MPolyRingElem{T}, p::MatrixGroupElem{T}) where T
     on_indeterminates(f::MPolyIdeal, p::MatrixGroupElem)
 
 Return the image of `f` under `p`.
-If `p` is a `PermGroupElem` then it acts via permuting the indeterminates,
-if `p` is a `MatrixGroupElem` then it acts via evaluating `f` at the
+
+If `p` is a `PermGroupElem` then it acts via permuting the indeterminates.
+
+If `p` is a `MatrixGroupElem` then it acts via evaluating `f` at the
 vector obtained by multiplying `p` with the (column) vector of indeterminates.
+This corresponds to considering the variables of `parent(f)` as the basis of a
+vector space on which `p` acts by multiplication from the right.
 
 For `MPolyRingElem`, `FreeAssAlgElem`, and `MPolyIdeal` objects,
 one can also call `^` instead of `on_indeterminates`.
@@ -369,10 +373,10 @@ function on_indeterminates(f::GapObj, p::MatrixGroupElem)
   return GAPWrap.Value(f, indets, p.X * indets)
 end
 
-function on_indeterminates(f::MPolyRingElem{T}, p::MatrixGroupElem{T, S}) where T where S
+function on_indeterminates(f::MPolyRingElem{T}, p::MatrixGroupElem{T}) where T
   @assert base_ring(f) == base_ring(p)
   @assert ngens(parent(f)) == degree(parent(p))
-  act = Oscar.right_action(parent(f), p)
+  act = right_action(parent(f), p)
   return act(f)
 end
 

--- a/src/InvariantTheory/invariant_rings.jl
+++ b/src/InvariantTheory/invariant_rings.jl
@@ -101,12 +101,19 @@ function Base.show(io::IO, IR::InvRing)
   print(io, Indent(), action(IR))
 end
 
-# Return a map performing the right action of M on the ring R
+# Return a map performing the right action of M on the ring R.
 function right_action(R::MPolyRing{T}, M::MatrixElem{T}) where T
   @assert nvars(R) == ncols(M)
   @assert nrows(M) == ncols(M)
   n = nvars(R)
 
+  # We consider gens(R) as the basis of a vector space given as row vectors
+  # on which M acts by multiplication from the right.
+  # That is, we identify gen(R, i) with the vector (0 ... 0 1 0 ... 0)
+  # with 1 in position i. Then M acts on gen(R, i) via
+  #   gen(R, i)^M = (0 ... 0 1 0 ... 0)*M = (M[i, 1] ... M[i, n])
+  #               = M[i, 1]*gen(R, 1) + ... + M[i, n]*gen(R, n)
+  # We now compute these actions of M on the variables of R.
   vars = zeros(R, n)
   x = gens(R)
   for i = 1:n
@@ -118,6 +125,8 @@ function right_action(R::MPolyRing{T}, M::MatrixElem{T}) where T
     end
   end
 
+  # The action of M on an arbitrary polynomial is given by evaluating the
+  # polynomial at gen(R, 1)^M, ..., gen(R, n)^M.
   right_action_by_M = (f::MPolyRingElem{T}) -> evaluate(f, vars)
 
   return MapFromFunc(R, R, right_action_by_M)


### PR DESCRIPTION
This is almost only comments, but I just thought a lot about left and right actions on polynomials for The Book and wanted to clarify the choice in OSCAR also in the code. (In particular, since `right_action` de facto computes the product of the matrix by the column vector of variables, which made me question several times whether left is right.)