### PR TITLE
[FTheoryTools] More improvements

### DIFF
--- a/experimental/FTheoryTools/docs/src/tate.md
+++ b/experimental/FTheoryTools/docs/src/tate.md
@@ -203,6 +203,18 @@ singular_loci(t::GlobalTateModel)
 
 ## Methods
 
+### Blowup
+
+We can blow up a global Tate model:
+```@docs
+blow_up(t::GlobalTateModel, ideal_gens::Vector{String}; coordinate_name::String = "e")
+```
+Consequently, the model will thereafter be partially resolved.
+```@docs
+is_partially_resolved(t::GlobalTateModel)
+```
+
+
 ### Fiber study
 
 In F-theory, it is standard to not work with the singular space directly.

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -68,7 +68,7 @@ Torus-invariant, prime divisor on a normal toric variety
 julia> model_sections = Dict("w" => w);
 
 julia> t2 = literature_model(arxiv_id = "1109.3454", equation = "3.1", desired_base_space = B3, model_sections = model_sections, completeness_check = false)
-Global Tate model over a concrete base
+Global Tate model over a concrete base -- SU(5)xU(1) restricted Tate model based on arXiv paper 1109.3454 Eq. (3.1)
 
 julia> length(singular_loci(t2))
 2
@@ -148,7 +148,6 @@ function literature_model(; doi::String="", arxiv_id::String="", version::String
     # Appropriately construct the model
     if model_dict["model_descriptors"]["type"] == "tate"
       model = _construct_literature_tate_model(model_dict, desired_base_space, model_sections, completeness_check)
-      return model
     elseif model_dict["model_descriptors"]["type"] == "weierstrass"
       @req false "Weierstrass literature models can currently not be created over a concrete base space"
     else
@@ -289,6 +288,7 @@ function literature_model(; doi::String="", arxiv_id::String="", version::String
   end
 
   # Return the model
+  set_attribute!(model, :partially_resolved, false)
   return model
 end
 
@@ -407,9 +407,15 @@ function _construct_literature_tate_model(model_dict::Dict{String,Any}, desired_
     explicit_a6 = prod([explicit_model_sections[string(variables[k])]^exp_vector[k] for k in 1:ngens(auxiliary_base_ring)])
   end
 
-  # Finally, construct the model
+  # Construct the model
   ais = [explicit_a1, explicit_a2, explicit_a3, explicit_a4, explicit_a6]
-  return global_tate_model(desired_base_space, ais; completeness_check = completeness_check)
+  model = global_tate_model(desired_base_space, ais; completeness_check = completeness_check)
+
+  # Remember the explicit model sections for autoresolution
+  set_attribute!(model, :explicit_model_sections => explicit_model_sections)
+
+  # Return the model
+  return model
 end
 
 # Constructs Tate model from given Tate literature model

--- a/experimental/FTheoryTools/src/TateModels/constructors.jl
+++ b/experimental/FTheoryTools/src/TateModels/constructors.jl
@@ -66,6 +66,7 @@ function global_tate_model(base::NormalToricVariety, ais::Vector{T}; completenes
   pt = _tate_polynomial(ais, cox_ring(ambient_space))
   model = GlobalTateModel(ais[1], ais[2], ais[3], ais[4], ais[5], pt, base, ambient_space)
   set_attribute!(model, :base_fully_specified, true)
+  set_attribute!(model, :partially_resolved, false)
   return model
 end
 
@@ -185,6 +186,7 @@ function global_tate_model(auxiliary_base_ring::MPolyRing, auxiliary_base_gradin
   pt = _tate_polynomial([a1, a2, a3, a4, a6], R)
   model = GlobalTateModel(a1, a2, a3, a4, a6, pt, auxiliary_base_space, auxiliary_ambient_space)
   set_attribute!(model, :base_fully_specified, false)
+  set_attribute!(model, :partially_resolved, false)
   return model
 end
 
@@ -195,7 +197,12 @@ end
 ################################################
 
 function Base.show(io::IO, t::GlobalTateModel)
-  properties_string = ["Global Tate model over a"]
+  properties_string = String[]
+  if is_partially_resolved(t)
+    push!(properties_string, "Partially resolved global Tate model over a")
+  else
+    push!(properties_string, "Global Tate model over a")
+  end
   if base_fully_specified(t)
     push!(properties_string, "concrete base")
   else

--- a/experimental/FTheoryTools/src/TateModels/methods.jl
+++ b/experimental/FTheoryTools/src/TateModels/methods.jl
@@ -78,7 +78,7 @@ end
 #####################################################
 
 @doc raw"""
-    blow_up(t::GlobalTateModel, I::MPolyIdeal; coordinate_name::String = "e")
+    blow_up(t::GlobalTateModel, ideal_gens::Vector{String}; coordinate_name::String = "e")
 
 Resolve a global Tate model by blowing up a locus in the ambient space.
 
@@ -91,10 +91,10 @@ julia> w = torusinvariant_prime_divisors(B3)[1]
 Torus-invariant, prime divisor on a normal toric variety
 
 julia> t = literature_model(arxiv_id = "1109.3454", equation = "3.1", desired_base_space = B3, model_sections = Dict("w" => w), completeness_check = false)
-Global Tate model over a concrete base
+Global Tate model over a concrete base -- SU(5)xU(1) restricted Tate model based on arXiv paper 1109.3454 Eq. (3.1)
 
 julia> blow_up(t, ["x", "y", "x1"]; coordinate_name = "e1")
-Global Tate model over a concrete base
+Partially resolved global Tate model over a concrete base
 ```
 """
 function blow_up(t::GlobalTateModel, ideal_gens::Vector{String}; coordinate_name::String = "e")
@@ -116,6 +116,7 @@ function blow_up(t::GlobalTateModel, I::MPolyIdeal; coordinate_name::String = "e
   # Compute the new base
   # FIXME: THIS WILL IN GENERAL BE WRONG! IN PRINCIPLE, THE ABOVE ALLOWS TO BLOW UP THE BASE AND THE BASE ONLY.
   # FIXME: We should save the projection \pi from the ambient space to the base space.
+  # FIXME: This is also ties in with the model sections to be saved, see below. Should the base change, so do these sections...
   new_base = base_space(t)
 
   # Prepare for the computation of the strict transform of the tate polynomial
@@ -144,6 +145,12 @@ function blow_up(t::GlobalTateModel, I::MPolyIdeal; coordinate_name::String = "e
   # This is not really a Tate model any more, as the hypersurface equation is merely a strict transform of a Tate polynomial.
   # Change/Fix? We may want to provide not only output that remains true forever but also output, while the internals may change?
   model = GlobalTateModel(ais[1], ais[2], ais[3], ais[4], ais[5], new_pt, base_space(t), new_ambient_space)
+
+  # Set attributes
   set_attribute!(model, :base_fully_specified, true)
+  set_attribute!(model, :partially_resolved, true)
+  if has_attribute(t, :explicit_model_sections)
+    set_attribute!(model, :explicit_model_sections => get_attribute(t, :explicit_model_sections))
+  end
   return model
 end

--- a/experimental/FTheoryTools/src/TateModels/properties.jl
+++ b/experimental/FTheoryTools/src/TateModels/properties.jl
@@ -18,3 +18,27 @@ false
 ```
 """
 base_fully_specified(t::GlobalTateModel) = get_attribute(t, :base_fully_specified)
+
+@doc raw"""
+    is_partially_resolved(t::GlobalTateModel)
+
+Return `true` if resolution techniques were applies to the global Tate model,
+thereby potentially resolving its singularities.
+
+```jldoctest
+julia> t = literature_model(arxiv_id = "1109.3454", equation = "3.1")
+Assuming that the first row of the given grading is the grading under Kbar
+
+Global Tate model over a not fully specified base -- SU(5)xU(1) restricted Tate model based on arXiv paper 1109.3454 Eq. (3.1)
+
+julia> is_partially_resolved(t)
+false
+
+julia> t2 = blow_up(t, ["x", "y", "w"]; coordinate_name = "e1")
+Partially resolved global Tate model over a concrete base
+
+julia> is_partially_resolved(t2)
+true
+```
+"""
+is_partially_resolved(t::GlobalTateModel) = get_attribute(t, :partially_resolved)

--- a/experimental/FTheoryTools/src/exports.jl
+++ b/experimental/FTheoryTools/src/exports.jl
@@ -13,6 +13,7 @@ export ambient_space
 export analyze_fibers
 export base_fully_specified
 export base_space
+export blow_up
 export coordinate_ring
 export calabi_yau_hypersurface
 export discriminant
@@ -60,6 +61,7 @@ export has_weighted_resolutions
 export has_weighted_resolution_generating_sections
 export has_weighted_resolution_zero_sections
 export has_zero_section
+export is_partially_resolved
 export arxiv_id
 export arxiv_doi
 export arxiv_link


### PR DESCRIPTION
1. Bugfix - literature model returned model prematurely
2. Introduce attribute partially_resolved and display this via the print method
3. ~~Change desired_base_space argument for literature model to base_space~~ I get the error `objects of type NormalToricVariety are not callable`. Let us address this separately.

@apturner: As discussed