### PR TITLE
small additions, mainly `parent(chi)`

### DIFF
--- a/docs/src/Groups/group_characters.md
+++ b/docs/src/Groups/group_characters.md
@@ -89,6 +89,10 @@ Ordinary and ``p``-modular Brauer tables in OSCAR are distinguished by
 their [`characteristic(tbl::GAPGroupCharacterTable)`](@ref);
 its value is `0` for ordinary tables and ``p`` otherwise.
 
+The character table to which a character `chi` belongs
+can be fetched as `parent(chi)`.
+
+
 ```@docs
 GAPGroupCharacterTable
 character_table(G::Union{GAPGroup, GrpAbFinGen}, p::T = 0) where T <: IntegerUnion
@@ -97,6 +101,7 @@ character_table(series::Symbol, parameter::Union{Int, Vector{Int}})
 Base.show(io::IO, ::MIME"text/plain", tbl::GAPGroupCharacterTable)
 characteristic(tbl::GAPGroupCharacterTable)
 Base.mod(tbl::GAPGroupCharacterTable, p::Int)
+quo(tbl::GAPGroupCharacterTable, nclasses::Vector{Int})
 all_character_table_names
 ```
 
@@ -224,6 +229,7 @@ class_positions_of_center(chi::GAPGroupClassFunction)
 class_positions_of_derived_subgroup
 kernel(chi::GAPGroupClassFunction)
 class_positions_of_kernel
+class_positions_of_normal_subgroups
 pcore(tbl::GAPGroupCharacterTable, p::IntegerUnion)
 class_positions_of_pcore
 class_positions_of_solvable_residuum

--- a/experimental/OrthogonalDiscriminants/src/data.jl
+++ b/experimental/OrthogonalDiscriminants/src/data.jl
@@ -37,7 +37,7 @@ julia> orthogonal_discriminant(t2[4])
 ```
 """
 function orthogonal_discriminant(chi::Oscar.GAPGroupClassFunction)
-  tbl = chi.table
+  tbl = parent(chi)
   pos = findfirst(x -> x === chi, tbl)
   pos === nothing && return ""
   p = characteristic(tbl)

--- a/experimental/OrthogonalDiscriminants/src/theoretical.jl
+++ b/experimental/OrthogonalDiscriminants/src/theoretical.jl
@@ -26,7 +26,7 @@ function od_from_order(chi::GAPGroupClassFunction)
   characteristic(chi) == 0 && return (false, "")
   d = numerator(degree(chi))
   q = order_field_of_definition(chi)
-  tbl = ordinary_table(chi.table)
+  tbl = ordinary_table(parent(chi))
   ord = order(ZZRingElem, tbl)
 
   # Compute the order of the subgroup that shall embed into
@@ -72,7 +72,7 @@ function od_from_eigenvalues(chi::GAPGroupClassFunction)
   p = characteristic(chi)
   p == 2 && return (false, "")
 
-  tbl = chi.table
+  tbl = parent(chi)
   ord = orders_class_representatives(tbl)
   for i in 2:length(chi)
     n = ord[i]
@@ -141,7 +141,7 @@ function od_for_specht_module(chi::GAPGroupClassFunction)
   characteristic(chi) == 0 || return (false, "")
 
   # Find out to which alternating or symmetric group `chi` belongs.
-  tbl = chi.table
+  tbl = parent(chi)
   name = identifier(tbl)
   startswith(name, "A") || return (false, "")
   pos = findfirst('.', name)

--- a/experimental/SymmetricIntersections/src/representations.jl
+++ b/experimental/SymmetricIntersections/src/representations.jl
@@ -216,7 +216,7 @@ irreducible in the character table of `char` and $alpha = scalar_product(char, c
 is the multiplicity of chi in char. If `alpha = 0`, it is not added.
 """
 function character_decomposition(char::Oscar.GAPGroupClassFunction)
-  ct = char.table
+  ct = parent(char)
   decomp = Tuple{Int, typeof(char)}[]
   for chi in ct
     alpha = Int(scalar_product(chi, char))
@@ -234,7 +234,7 @@ end
 Given a class function `chi` on a group `G`, return whether `chi` defines a
 character of `G` (over its codomain).
 """
-is_character(chi::Oscar.GAPGroupClassFunction) = GG.IsCharacter(chi.table.GAPTable, chi.values)::Bool
+is_character(chi::Oscar.GAPGroupClassFunction) = GG.IsCharacter(GAPTable(parent(chi)), chi.values)::Bool
 
 @doc raw"""
     is_constituent(chi::T, nu::T) where T <: Oscar.GAPGroupClassFunction -> Bool
@@ -344,7 +344,7 @@ Note: here matrices in `mr` should correspond to the cached set of
 generators of the underlying group of `RR` (order matters.)
 """
 function _linear_representation(RR::RepRing{S, T}, mr::Vector{V}, chi::Oscar.GAPGroupClassFunction) where {S, T, U, V <: MatElem{U}}
-  @req chi.table === character_table_underlying_group(RR) "Character should belong to the character table attached to the given representation ring"
+  @req parent(chi) === character_table_underlying_group(RR) "Character should belong to the character table attached to the given representation ring"
   G = underlying_group(RR)
   mg = matrix_group(mr)
   f = hom(G, mg, generators_underlying_group(RR), gens(mg), check = false)
@@ -369,7 +369,7 @@ domain of `f` corresponds to the underlying group of `RR`.
 If not provided, `chi` is automatically computed.
 """
 function linear_representation(RR::RepRing{S, T}, f::GAPGroupHomomorphism, chi::Oscar.GAPGroupClassFunction) where {S, T}
-  @req chi.table === character_table_underlying_group(RR) "Character should belong to the character table attached to the given representation ring"
+  @req parent(chi) === character_table_underlying_group(RR) "Character should belong to the character table attached to the given representation ring"
   @req domain(f) === underlying_group(RR) "f should be defined over the underlying group of the given representation ring"  
   @req codomain(f) isa MatrixGroup "f should take value in a matrix group"
   return LinRep{S, T, elem_type(S)}(RR, f, chi)
@@ -379,7 +379,7 @@ function linear_representation(RR::RepRing{S ,T}, f::GAPGroupHomomorphism) where
   @req domain(f) === underlying_group(RR) "f should be defined over the underlying group of the given representation ring"
   @req codomain(f) isa MatrixGroup "f should take value in a matrix group"
   chi = character_representation(RR, f)
-  @assert chi.table === character_table_underlying_group(RR)
+  @assert parent(chi) === character_table_underlying_group(RR)
   return LinRep{S, T, elem_type(S)}(RR, f, chi)
 end
 
@@ -394,7 +394,7 @@ projective representation of the codomain of `p`.
 This is equivalent to ask that the center of `chi` contains the kernel of `p`.
 """
 function is_projective(chi::Oscar.GAPGroupClassFunction, p::GAPGroupHomomorphism)
-  @req chi.table.GAPGroup === domain(p) "Incompatible representation ring of rep and domain of the cover p"
+  @req group(parent(chi)) === domain(p) "Incompatible representation ring of rep and domain of the cover p"
   return is_subgroup(kernel(p)[1], center(chi)[1])[1]
 end
 
@@ -627,7 +627,7 @@ projective representation of the codomain of `p`.
 This is equivalent to ask that the center of `chi` coincides with the kernel of `p`.
 """
 function is_faithful(chi::Oscar.GAPGroupClassFunction, p::GAPGroupHomomorphism{T, V}) where {T, V}
-  E = chi.table.GAPGroup::T
+  E = group(parent(chi))::T
   @req E === domain(p) "Incompatible underlying group of chi and domain of the cover p"
   @req is_projective(chi, p) "chi is not afforded by a p-projective representation"
   Z = center(chi)[1]::T

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -30,12 +30,14 @@ GAP.@wrap Characteristic(x::Any)::GapInt
 GAP.@wrap CharacterParameters(x::GapObj)::GapObj
 GAP.@wrap CharacterTable(x::GapObj)::GapObj
 GAP.@wrap CharacterTable(x::GapObj, y::GAP.Obj)::GapObj
+GAP.@wrap CharacterTableFactorGroup(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap CharacterTableWreathSymmetric(x::GapObj, y::GapInt)::GapObj
 GAP.@wrap ClassFunction(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap ClassNames(x::GapObj)::GapObj
 GAP.@wrap ClassMultiplicationCoefficient(x::GapObj, y::Int, z::Int, t::Int)::GAP.Obj
 GAP.@wrap ClassPositionsOfCentre(x::GapObj)::GapObj
 GAP.@wrap ClassPositionsOfDerivedSubgroup(x::GapObj)::GapObj
+GAP.@wrap ClassPositionsOfNormalSubgroups(x::GapObj)::GapObj
 GAP.@wrap ClassPositionsOfPCore(x::GapObj, y::GAP.Obj)::GapObj
 GAP.@wrap ClassPositionsOfSolvableResiduum(x::GapObj)::GapObj
 GAP.@wrap ClassParameters(x::GapObj)::GapObj

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -329,6 +329,7 @@ export class_parameters
 export class_positions_of_center
 export class_positions_of_derived_subgroup
 export class_positions_of_kernel
+export class_positions_of_normal_subgroups
 export class_positions_of_pcore
 export class_positions_of_solvable_residuum
 export closed_subvariety_of_toric_variety

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -818,6 +818,7 @@ end
   @test ncols(t) == 5
   @test_throws ErrorException t[6]
   tr = trivial_character(t)
+  @test parent(tr) === t
   @test tr in t
   @test tr != t[1]
   @test tr == t[5]


### PR DESCRIPTION
- support `parent(chi)` for a group character `chi` (suggested by @fieker ), and use it throughout instead of field access
- support `quo` for character tables, added `class_positions_of_normal_subgroups` (needed for examples)
- write "vector" instead of "array" in documentation where applicable