### PR TITLE
Rename, extend, document and test `all_monomials`

### DIFF
--- a/src/InvariantTheory/helpers.jl
+++ b/src/InvariantTheory/helpers.jl
@@ -87,8 +87,8 @@ end
 # This function is meant to be used in the case where one needs the result for
 # different degrees d as results for lower degrees are reused (and cached in C).
 # If one is only interested in all monomials of a certain degree, one should use
-# all_monomials. Note that however also for a single degree d a naive evaluation
-# of the result of all_monomials at the elements of C.base is in general slower.
+# monomials_of_degree. Note that however also for a single degree d a naive evaluation
+# of the result of monomials_of_degree at the elements of C.base is in general slower.
 # If remember_exponents is true, the exponent vectors of the computed power
 # products will be stored in the dictionary C.exponent_vectors, that is, if
 # C.base = [ f_1, ..., f_k ] and we compute f = f_1^e_1 \cdots f_k^e_k, then

--- a/src/InvariantTheory/secondary_invariants.jl
+++ b/src/InvariantTheory/secondary_invariants.jl
@@ -234,7 +234,7 @@ function secondary_invariants_nonmodular(RG::InvRing)
 
     # We have to find more invariants of this degree not coming from power products
     # of smaller degree ones.
-    mons = all_monomials(Rgraded, d)
+    mons = monomials_of_degree(Rgraded, d)
     for m in mons
 
       # Can exclude some monomials, see DK15, Remark 3.7.3 (b)
@@ -449,7 +449,7 @@ function semi_invariants(RG::InvRing, chi::GAPGroupClassFunction)
     end
     invars_found = 0
 
-    mons = all_monomials(Rgraded, d)
+    mons = monomials_of_degree(Rgraded, d)
     for m in mons
 
       # Can exclude some monomials, see DK15, Remark 3.7.3 (b)

--- a/src/InvariantTheory/types.jl
+++ b/src/InvariantTheory/types.jl
@@ -101,13 +101,33 @@ mutable struct InvRing{FldT, GrpT, PolyRingElemT, PolyRingT, ActionT}
   end
 end
 
+# Produces all monomials in R of degree d
 struct AllMonomials{PolyRingT}
   R::PolyRingT
-  d::Int
+  d::Int # the degree
+
+  on_all_vars::Bool # whether we work on all variables or a subset
+  n_vars::Int # the number of variables we work on
+  used_vars::Vector{Int} # indices of the variables we work on
+  tmp::Vector{Int} # of length ngens(R), should be put back to zero after use
 
   function AllMonomials{PolyRingT}(R::PolyRingT, d::Int) where PolyRingT
     @assert d >= 0
-    return new{PolyRingT}(R, d)
+    return new{PolyRingT}(R, d, true, ngens(R))
+  end
+
+  function AllMonomials{PolyRingT}(R::PolyRingT, d::Int, vars::Vector{Int}) where PolyRingT
+    @assert d >= 0
+    vars = sort!(unique(vars))
+    @assert minimum(vars, init = 1) >= 1
+    @assert maximum(vars, init = 1) <= nvars(R)
+    n_vars = length(vars)
+    if n_vars == ngens(R)
+      return AllMonomials{PolyRingT}(R, d)
+    end
+
+    tmp = zeros(Int, ngens(R))
+    return new{PolyRingT}(R, d, false, n_vars, vars, tmp)
   end
 end
 

--- a/src/Modules/Iterators.jl
+++ b/src/Modules/Iterators.jl
@@ -29,7 +29,7 @@ function Base.length(amm::AllModuleMonomials)
   for i in 1:r
     d_loc = d - Int(degree(F[i])[1])
     d_loc < 0 && continue
-    result = result + length(all_monomials(R, d_loc))
+    result = result + length(monomials_of_degree(R, d_loc))
   end
   return result
 end
@@ -44,7 +44,7 @@ function Base.iterate(amm::AllModuleMonomials, state::Nothing = nothing)
   i === nothing && return nothing
   d_loc = d - Int(degree(F[i])[1])
 
-  mon_it = all_monomials(R, d_loc)
+  mon_it = monomials_of_degree(R, d_loc)
   res = iterate(mon_it, nothing)
   res === nothing && i == ngens(F) && return nothing
 
@@ -64,7 +64,7 @@ function Base.iterate(amm::AllModuleMonomials, state::Tuple{Int, AllMonomials, V
     i === nothing && return nothing
     d_loc = d - Int(degree(F[i])[1])
 
-    mon_it = all_monomials(R, d_loc)
+    mon_it = monomials_of_degree(R, d_loc)
     res_loc = iterate(mon_it, nothing)
     res_loc === nothing && i == ngens(F) && return nothing
 

--- a/src/Modules/UngradedModules.jl
+++ b/src/Modules/UngradedModules.jl
@@ -8850,7 +8850,7 @@ function vector_space_dimension(M::SubquoModule,d::Int64)
   o = default_ordering(M)
   LM = leading_module(Mq,o)
 
-  return count(t->!(t[1]*t[2] in LM), Iterators.product(all_monomials(R, d), gens(F)))
+  return count(t->!(t[1]*t[2] in LM), Iterators.product(monomials_of_degree(R, d), gens(F)))
 end
   
 function vector_space_dimension(M::SubquoModule{T}
@@ -8962,7 +8962,7 @@ function vector_space_basis(M::SubquoModule,d::Int64)
   o = default_ordering(M)
   LM = leading_module(Mq,o)
 
-  return [x*e for x in all_monomials(R, d) for e in gens(F) if !(x*e in LM)]
+  return [x*e for x in monomials_of_degree(R, d) for e in gens(F) if !(x*e in LM)]
 end
 
 function vector_space_basis(M::SubquoModule{T}

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -2048,12 +2048,12 @@ function vector_space(kk::Field, W::MPolyQuoLocRing{<:Field, <:FieldElem,
   done = false
   d = 0
   while !done
-    inc = [m for m in all_monomials(R, d) if !(m in lead_I)]
+    inc = [m for m in monomials_of_degree(R, d) if !(m in lead_I)]
     if iszero(length(inc))
       done = true
       break
     end
-    V_gens = vcat(V_gens, [m for m in all_monomials(R, d) if !(m in lead_I)])
+    V_gens = vcat(V_gens, [m for m in monomials_of_degree(R, d) if !(m in lead_I)])
     d = d + 1
   end
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1022,6 +1022,7 @@ export molien_series
 export monomial_basis
 export monomial_ordering
 export monomials
+export monomials_of_degree
 export mori_cone
 export morphism_from_cox_variety
 export MorphismFromRationalFunctions

--- a/test/InvariantTheory/iterators.jl
+++ b/test/InvariantTheory/iterators.jl
@@ -1,0 +1,12 @@
+@testset "Monomials of a given degree" begin
+  for R in [ QQ["x", "y", "z"][1], graded_polynomial_ring(QQ, ["x", "y", "z"])[1] ]
+    x, y, z = gens(R)
+    @test collect(monomials_of_degree(R, 2)) == [x^2, x*y, x*z, y^2, y*z, z^2]
+    @test collect(monomials_of_degree(R, 2, 1:3)) == [x^2, x*y, x*z, y^2, y*z, z^2]
+    @test collect(monomials_of_degree(R, 3, [1, 3])) == [x^3, x^2*z, x*z^2, z^3]
+    @test collect(monomials_of_degree(R, 3, [3, 1, 1])) == [x^3, x^2*z, x*z^2, z^3]
+    @test collect(monomials_of_degree(R, 3, 1:2)) == [x^3, x^2*y, x*y^2, y^3]
+    @test collect(monomials_of_degree(R, 3, 1:1)) == [x^3]
+    @test isempty(monomials_of_degree(R, 2, Int[]))
+  end
+end

--- a/test/InvariantTheory/secondary_invariants.jl
+++ b/test/InvariantTheory/secondary_invariants.jl
@@ -109,9 +109,9 @@
 
   R, x = polynomial_ring(QQ, "x" => 1:3)
   C = Oscar.PowerProductCache(R, x)
-  @test Set(Oscar.all_power_products_of_degree!(C, 3, false)) == Set(collect(Oscar.all_monomials(R, 3)))
+  @test Set(Oscar.all_power_products_of_degree!(C, 3, false)) == Set(collect(monomials_of_degree(R, 3)))
   mons = Oscar.all_power_products_of_degree!(C, 3, true)
-  @test Set(mons) == Set(collect(Oscar.all_monomials(R, 3)))
+  @test Set(mons) == Set(collect(monomials_of_degree(R, 3)))
   for m in mons
     @test haskey(C.exponent_vectors, m)
     @test set_exponent_vector!(one(R), 1, C.exponent_vectors[m]) == m


### PR DESCRIPTION
* I renamed `all_monomials`, which gives an iterator over all monomials of a polynomial ring of a given degree, to the more appropriate `monomials_of_degree` and exported (+test, document) this function.
* I added the variant `monomials_of_degree(::MPolyRing, ::Int, ::UnitRange)` which only works on a subset of the variables specified by the range and which should cover the use case in #2823 .
* I decided to make it throw an error for non-standard graded rings. So far it works for those rings by ignoring the grading. @HechtiDerLachs is this fine for you? I don't want to break your code or use case.