### PR TITLE
Remove some type piracy to get rid of a warning

### DIFF
--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -356,10 +356,6 @@ function prime_ideal(S::MPolyComplementOfKPointIdeal)
   return S.m
 end
 
-function is_prime(P::Hecke.ZZIdl) 
-  return is_prime(first(gens(P)))
-end
-
 dim(kk::Field) = 0
 
 maximal_ideal(S::MPolyComplementOfKPointIdeal{<:Field}) = prime_ideal(S)


### PR DESCRIPTION
Should fix the following warning
```
WARNING: Method definition is_prime(Hecke.ZZIdl) in module Hecke at .julia/dev/Hecke/src/NumField/QQ.jl:154 overwritten in module Oscar at .julia/dev/Oscar/src/Rings/mpoly-localizations.jl:359.
  ** incremental compilation may be fatally broken for this module **
```