### PR TITLE
fix two tests in preparation for julia nightly

### DIFF
--- a/test/Rings/MPolyAnyMap/flattenings.jl
+++ b/test/Rings/MPolyAnyMap/flattenings.jl
@@ -302,10 +302,16 @@ end
   R, (x,y,z) = polynomial_ring(QQ, ["x", "y", "z"], cached=false)
   S, _ = polynomial_ring(R, ["s", "t"], cached=false)
   phi = Oscar.flatten(S)
-  a = x^2 + y^2
-  b = phi(a)
-  @test phi(a) === b
-  a = 5
+  # julia might not consider `x^2+y^2` as being unused until the end of the scope
+  # see https://github.com/JuliaLang/julia/issues/51818
+  # so we put this into a function
+  function use_it(phi)
+    a = x^2 + y^2
+    b = phi(a)
+    @test phi(a) === b
+    a = nothing
+  end
+  use_it(phi)
   GC.gc()
   @test isempty(keys(Oscar.flat_counterparts(phi)))
 end

--- a/test/StraightLinePrograms/straightline.jl
+++ b/test/StraightLinePrograms/straightline.jl
@@ -458,8 +458,10 @@ end
     @test SLP.aslazyrec(p) == (x+2)*3.0-big(4)
 
     @test_throws InexactError SLP.addeq!(p, SLProgram(Const(1.2)))
-    @assert length(p.cs) == 4 # p.cs was resized before append! failed
-    pop!(p.cs) # set back consistent state
+    # for julia 1.10 and older append! did resize before failing
+    # https://github.com/JuliaLang/julia/pull/51903
+    VERSION < v"1.11.0-DEV.884" && pop!(p.cs) # set back consistent state
+    @assert length(p.cs) == 3
     @assert length(p.lines) == 3 # p.lines was *not* resized before append! failed
     @test SLP.aslazyrec(p) == (x+2)*3.0-big(4)
 


### PR DESCRIPTION
To adapt for changes in julia nightly, found while trying the Oscar tests locally with custom builds for the CxxWrap based packages.

Older julia versions have the weird effect of resizing arrays even when `append!` fails:
```
julia> v = [1,2,3];

julia> append!(v,[1.2]);
ERROR: InexactError: Int64(1.2)
...

julia> v
4-element Vector{Int64}:
 1
 2
 3
 0
```
This was changed in https://github.com/JuliaLang/julia/pull/51903.

And julia might not always consider objects in the same scope as unused, even if they do not appear to be used anymore, see https://github.com/JuliaLang/julia/issues/51818. This seems to depend where the GC marking is happening in the generated code and this was changed recently.
To avoid this one can put the code with the data that needs to be collected in a separate function (this pattern is also used in the julia tests).