### PR TITLE
Adjust invariant theory code to allow polynomial rings with ordering different from `:degrevlex`

### DIFF
--- a/src/InvariantTheory/fundamental_invariants.jl
+++ b/src/InvariantTheory/fundamental_invariants.jl
@@ -84,7 +84,9 @@ function fundamental_invariants_via_king(RG::InvRing, beta::Int = 0)
         continue
       end
 
-      push!(S, inv(leading_coefficient(f))*f)
+      # Cancelling the leading coefficient is not mathematically necessary and
+      # should be done with the ordering that is used for the printing
+      push!(S, inv(AbstractAlgebra.leading_coefficient(f))*f)
       push!(GO, g)
     end
 

--- a/src/InvariantTheory/fundamental_invariants.jl
+++ b/src/InvariantTheory/fundamental_invariants.jl
@@ -23,10 +23,8 @@ end
 function fundamental_invariants_via_king(RG::InvRing, beta::Int = 0)
   @assert !is_modular(RG)
 
-  Rgraded = polynomial_ring(RG)
+  Rgraded = _internal_polynomial_ring(RG)
   R = forget_grading(Rgraded)
-  # R needs to have the correct ordering for application of divrem
-  @assert ordering(R) == :degrevlex
   ordR = degrevlex(gens(R))
 
   S = elem_type(R)[]
@@ -74,7 +72,7 @@ function fundamental_invariants_via_king(RG::InvRing, beta::Int = 0)
     end
 
     for m in mons
-      f = forget_grading(reynolds_operator(RG, Rgraded(m)))
+      f = forget_grading(_cast_in_internal_poly_ring(RG, reynolds_operator(RG, _cast_in_external_poly_ring(RG, Rgraded(m)))))
       if is_zero(f)
         continue
       end
@@ -84,9 +82,7 @@ function fundamental_invariants_via_king(RG::InvRing, beta::Int = 0)
         continue
       end
 
-      # Cancelling the leading coefficient is not mathematically necessary and
-      # should be done with the ordering that is used for the printing
-      push!(S, inv(AbstractAlgebra.leading_coefficient(f))*f)
+      push!(S, f)
       push!(GO, g)
     end
 
@@ -94,7 +90,10 @@ function fundamental_invariants_via_king(RG::InvRing, beta::Int = 0)
   end
 
   invars_cache = FundamentalInvarsCache{elem_type(Rgraded), typeof(Rgraded)}()
-  invars_cache.invars = [ Rgraded(f) for f in S ]
+  polys_ext = [ _cast_in_external_poly_ring(RG, Rgraded(f)) for f in S ]
+  # Cancelling the leading coefficient is not mathematically necessary and
+  # should be done with the ordering that is used for the printing
+  invars_cache.invars = [ inv(AbstractAlgebra.leading_coefficient(f))*f for f in polys_ext ]
   invars_cache.via_primary_and_secondary = false
   invars_cache.S = graded_polynomial_ring(coefficient_ring(R), [ "y$i" for i = 1:length(S) ], [ total_degree(f) for f in S ])[1]
   return invars_cache

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -468,7 +468,9 @@ function iterate_reynolds(BI::InvRingBasisIterator)
     if iszero(g)
       continue
     end
-    g = inv(leading_coefficient(g))*g
+    # Cancelling the leading coefficient is not mathematically necessary and
+    # should be done with the ordering that is used for the printing
+    g = inv(AbstractAlgebra.leading_coefficient(g))*g
     B = BasisOfPolynomials(polynomial_ring(BI.R), [ g ])
     return g, (B, state)
   end
@@ -501,7 +503,9 @@ function iterate_reynolds(BI::InvRingBasisIterator, state)
     end
 
     if add_to_basis!(B, g)
-      return inv(leading_coefficient(g))*g, (B, monomial_state)
+      # Cancelling the leading coefficient is not mathematically necessary and
+      # should be done with the ordering that is used for the printing
+      return inv(AbstractAlgebra.leading_coefficient(g))*g, (B, monomial_state)
     end
   end
 end
@@ -523,7 +527,9 @@ function iterate_linear_algebra(BI::InvRingBasisIterator)
   # Have to (should...) divide by the leading coefficient again:
   # The matrix was in echelon form, but the columns were not necessarily sorted
   # w.r.t. the monomial ordering.
-  return inv(leading_coefficient(f))*f, 2
+  # Cancelling the leading coefficient is not mathematically necessary and
+  # should be done with the ordering that is used for the printing
+  return inv(AbstractAlgebra.leading_coefficient(f))*f, 2
 end
 
 function iterate_linear_algebra(BI::InvRingBasisIterator, state::Int)
@@ -540,7 +546,9 @@ function iterate_linear_algebra(BI::InvRingBasisIterator, state::Int)
     end
     f += N[i, state]*BI.monomials_collected[i]
   end
-  return inv(leading_coefficient(f))*f, state + 1
+  # Cancelling the leading coefficient is not mathematically necessary and
+  # should be done with the ordering that is used for the printing
+  return inv(AbstractAlgebra.leading_coefficient(f))*f, state + 1
 end
 
 ################################################################################

--- a/src/InvariantTheory/secondary_invariants.jl
+++ b/src/InvariantTheory/secondary_invariants.jl
@@ -156,16 +156,16 @@ end
 # DK15, Algorithm 3.7.2 and Kin07, Section 4 "Improved new algorithm"
 function secondary_invariants_nonmodular(RG::InvRing)
   @assert !is_modular(RG)
-  p_invars = primary_invariants(RG)
+  Rext = polynomial_ring(RG)
+  Rgraded = _internal_polynomial_ring(RG)
+  R = forget_grading(Rgraded)
+
+  p_invars = [ _cast_in_internal_poly_ring(RG, f) for f in primary_invariants(RG) ]
   I = ideal_of_primary_invariants(RG)
   LI = leading_ideal(I, ordering = default_ordering(base_ring(I)))
+  gensLI = [ _cast_in_internal_poly_ring(RG, f) for f in gens(LI) ]
 
   h = reduce_hilbert_series_by_primary_degrees(RG)
-
-  Rgraded = polynomial_ring(RG)
-  R = forget_grading(Rgraded)
-  # R needs to have the correct ordering for application of divrem
-  @assert ordering(R) == :degrevlex
 
   K = coefficient_ring(R)
   s_invars_cache = SecondaryInvarsCache{elem_type(Rgraded)}()
@@ -183,7 +183,7 @@ function secondary_invariants_nonmodular(RG::InvRing)
   is_invars = Vector{Int}()
 
   # The Groebner basis should already be cached
-  gbI = [ forget_grading(f) for f in groebner_basis(I, ordering = degrevlex(Rgraded)) ]
+  gbI = [ forget_grading(_cast_in_internal_poly_ring(RG, f)) for f in groebner_basis(I, ordering = degrevlex(Rext)) ]
 
   for d = 1:degree(h)
     k = coeff(h, d) # number of invariants we need in degree d
@@ -217,7 +217,7 @@ function secondary_invariants_nonmodular(RG::InvRing)
 
         # DK15 propose to check containment via linear algebra; this approach
         # from Kin07 using d-truncated Groebner bases appears to be faster.
-        _, r = divrem(fg, gb) # degrevlex from assert ordering(R) == :degrevlex
+        _, r = divrem(fg, gb) # via degrevlex
         if !is_zero(r)
           # fg is a product of monic polynomials, so monic itself
           exp = copy(s_invars_cache.sec_in_irred[j])
@@ -241,7 +241,7 @@ function secondary_invariants_nonmodular(RG::InvRing)
 
       # Can exclude some monomials, see DK15, Remark 3.7.3 (b)
       skip = false
-      for g in gens(LI)
+      for g in gensLI
         if mod(forget_grading(m), forget_grading(g)) == 0
           skip = true
           break
@@ -249,14 +249,12 @@ function secondary_invariants_nonmodular(RG::InvRing)
       end
       skip && continue
 
-      f = forget_grading(reynolds_operator(RG, m))
+      f = forget_grading(_cast_in_internal_poly_ring(RG, reynolds_operator(RG, _cast_in_external_poly_ring(RG, m))))
       if iszero(f)
         continue
       end
-      _, r = divrem(f, gb)  # degrevlex from assert ordering(R) == :degrevlex
+      _, r = divrem(f, gb)  # via degrevlex
       if !is_zero(r)
-        # Cancelling the leading coefficient is not mathematically necessary and
-        # should be done with the ordering that is used for the printing
         f = inv(AbstractAlgebra.leading_coefficient(f))*f
         add_invariant!(s_invars_cache, Rgraded(f), true, push!(zeros(Int, length(is_invars)), 1))
         push!(s_invars_sorted[total_degree(f)], length(s_invars_cache.invars))
@@ -266,6 +264,17 @@ function secondary_invariants_nonmodular(RG::InvRing)
         invars_found == k && break
       end
     end
+  end
+
+  if Rext !== Rgraded
+    ext_cache = SecondaryInvarsCache{elem_type(Rext)}()
+    ext = [ _cast_in_external_poly_ring(RG, f) for f in s_invars_cache.invars ]
+    # Cancelling the leading coefficient is not mathematically necessary and
+    # should be done with the ordering that is used for the printing
+    ext_cache.invars = [ inv(AbstractAlgebra.leading_coefficient(f))*f for f in ext ]
+    ext_cache.is_irreducible = s_invars_cache.is_irreducible
+    ext_cache.sec_in_irred = s_invars_cache.sec_in_irred
+    s_invars_cache = ext_cache
   end
 
   return s_invars_cache

--- a/src/InvariantTheory/secondary_invariants.jl
+++ b/src/InvariantTheory/secondary_invariants.jl
@@ -134,6 +134,8 @@ function secondary_invariants_modular(RG::InvRing)
         end
         f += N[j, c]*forget_grading(Bd.monomials_collected[j])
       end
+      # Cancelling the leading coefficient is not mathematically necessary and
+      # should be done with the ordering that is used for the printing
       f = inv(AbstractAlgebra.leading_coefficient(f))*f
       push!(s_invars, f)
       add_invariant!(s_invars_cache, Rgraded(f), true, push!(zeros(Int, length(is_invars)), 1))
@@ -181,7 +183,7 @@ function secondary_invariants_nonmodular(RG::InvRing)
   is_invars = Vector{Int}()
 
   # The Groebner basis should already be cached
-  gbI = [ forget_grading(f) for f in groebner_basis(I, ordering = degrevlex(gens(base_ring(I)))) ]
+  gbI = [ forget_grading(f) for f in groebner_basis(I, ordering = degrevlex(Rgraded)) ]
 
   for d = 1:degree(h)
     k = coeff(h, d) # number of invariants we need in degree d
@@ -253,6 +255,8 @@ function secondary_invariants_nonmodular(RG::InvRing)
       end
       _, r = divrem(f, gb)  # degrevlex from assert ordering(R) == :degrevlex
       if !is_zero(r)
+        # Cancelling the leading coefficient is not mathematically necessary and
+        # should be done with the ordering that is used for the printing
         f = inv(AbstractAlgebra.leading_coefficient(f))*f
         add_invariant!(s_invars_cache, Rgraded(f), true, push!(zeros(Int, length(is_invars)), 1))
         push!(s_invars_sorted[total_degree(f)], length(s_invars_cache.invars))
@@ -468,6 +472,8 @@ function semi_invariants(RG::InvRing, chi::GAPGroupClassFunction)
       end
       nf = forget_grading(normal_form(f, I))
       if add_to_basis!(B, nf)
+        # Cancelling the leading coefficient is not mathematically necessary and
+        # should be done with the ordering that is used for the printing
         f = inv(AbstractAlgebra.leading_coefficient(f))*f
         push!(semi_invars, Rgraded(f))
         invars_found += 1

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -687,6 +687,7 @@ x^5 - x^3 + y^6 + z^6
 
 """
 function reduce(f::T, F::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(f)), complete_reduction::Bool = false) where {T <: MPolyRingElem}
+  isempty(F) && return f
   @assert parent(f) == parent(F[1])
   R = parent(f)
   I = IdealGens(R, [f], ordering)
@@ -696,6 +697,7 @@ function reduce(f::T, F::Vector{T}; ordering::MonomialOrdering = default_orderin
 end
 
 function reduce(F::Vector{T}, G::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where {T <: MPolyRingElem}
+  (isempty(F) || isempty(G)) && return F
   @assert parent(F[1]) == parent(G[1])
   R = parent(F[1])
   I = IdealGens(R, F, ordering)
@@ -756,7 +758,10 @@ julia> U*G == Q*[f1, f2, f3]+H
 true
 ```
 """
-function reduce_with_quotients_and_unit(f::T, F::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where {T <: MPolyRingElem}
+function reduce_with_quotients_and_unit(f::T, F::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(f)), complete_reduction::Bool = false) where {T <: MPolyRingElem}
+  if isempty(F)
+    return identity_matrix(parent(f), 1), zero_matrix(parent(f), 1, 0), f
+  end
   @assert parent(f) == parent(F[1])
   R = parent(f)
   I = IdealGens(R, [f], ordering)
@@ -766,6 +771,10 @@ function reduce_with_quotients_and_unit(f::T, F::Vector{T}; ordering::MonomialOr
 end
 
 function reduce_with_quotients_and_unit(F::Vector{T}, G::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where {T <: MPolyRingElem}
+  @assert !isempty(F)
+  if isempty(G)
+    return identity_matrix(parent(F[1]), length(F)), zero_matrix(parent(F[1]), length(F), 0), F
+  end
   @assert parent(F[1]) == parent(G[1])
   R = parent(F[1])
   I = IdealGens(R, F, ordering)
@@ -922,7 +931,8 @@ julia> g == Q[1]*f1+Q[2]*f2+Q[3]*f3+h
 true
 ```
 """
-function reduce_with_quotients(f::T, F::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where {T <: MPolyRingElem}
+function reduce_with_quotients(f::T, F::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(f)), complete_reduction::Bool = false) where {T <: MPolyRingElem}
+  isempty(F) && return zero_matrix(parent(f), 1, 0), f
   @assert parent(f) == parent(F[1])
   R = parent(f)
   I = IdealGens(R, [f], ordering)
@@ -932,6 +942,8 @@ function reduce_with_quotients(f::T, F::Vector{T}; ordering::MonomialOrdering = 
 end
 
 function reduce_with_quotients(F::Vector{T}, G::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where {T <: MPolyRingElem}
+  @assert !isempty(F)
+  isempty(G) && return zero_matrix(parent(F[1]), length(F), 0), F
   @assert parent(F[1]) == parent(G[1])
   R = parent(F[1])
   I = IdealGens(R, F, ordering)

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -2315,10 +2315,7 @@ Return the ideal in the underlying ungraded ring.
 """
 forget_grading(I::MPolyIdeal{<:MPolyDecRingElem}) = forget_decoration(I)
 
-### This is a temporary fix that needs to be addressed in AbstractAlgebra, issue #1105.
-# TODO: This still seems to be not resolved!!!
-Generic.ordering(S::MPolyDecRing) = :degrevlex
-
+Generic.ordering(S::MPolyDecRing) = ordering(S.R)
 
 #############truncation#############
 

--- a/test/InvariantTheory/fundamental_invariants.jl
+++ b/test/InvariantTheory/fundamental_invariants.jl
@@ -1,9 +1,11 @@
 @testset "Fundamental invariants (for matrix groups)" begin
   # Char 0
   K, a = cyclotomic_field(3, "a")
+  # Force use of internal polynomial_ring with ordering = :lex
+  R, _ = graded_polynomial_ring(K, 3, ordering = :lex)
   M1 = matrix(K, 3, 3, [ 0, 1, 0, 0, 0, 1, 1, 0, 0 ])
   M2 = matrix(K, 3, 3, [ 1, 0, 0, 0, a, 0, 0, 0, -a - 1 ])
-  RG0 = invariant_ring(M1, M2)
+  RG0 = invariant_ring(R, matrix_group(M1, M2))
 
   # Call it once without specifying `algo`
   @test length(fundamental_invariants(RG0)) == 4

--- a/test/InvariantTheory/secondary_invariants.jl
+++ b/test/InvariantTheory/secondary_invariants.jl
@@ -1,8 +1,10 @@
 @testset "Secondary invariants (for matrix groups)" begin
   K, a = cyclotomic_field(3, "a")
+  # Force use of internal polynomial_ring with ordering = :lex
+  R, _ = graded_polynomial_ring(K, 3, ordering = :lex)
   M1 = matrix(K, 3, 3, [ 0, 1, 0, 1, 0, 0, 0, 0, 1 ])
   M2 = matrix(K, 3, 3, [ 1, 0, 0, 0, a, 0, 0, 0, -a - 1 ])
-  RG0 = invariant_ring(M1, M2)
+  RG0 = invariant_ring(R, matrix_group(M1, M2))
 
   # Should fail if the wrong monomial ordering is used in
   # secondary_invariants_nonmodular

--- a/test/Rings/groebner.jl
+++ b/test/Rings/groebner.jl
@@ -24,7 +24,9 @@
     units, quots, res = reduce_with_quotients_and_unit(J.gens, G)
     @test matrix * gens(G) + res == units * gens(J)
     @test reduce(y^3, [y^2 - x, x^3 - 2*y^2]) == x*y
+    @test reduce(y^3, elem_type(R)[]) == y^3
     @test reduce([y^3], [y^2 - x, x^3 - 2*y^2]) == [x*y]
+    @test reduce([y^3], elem_type(R)[]) == [y^3]
     @test reduce([y^3], [y^2 - x, x^3 - 2*y^2], ordering=lex(R)) == [y^3]
     f = x+y^3
     g = x
@@ -34,12 +36,20 @@
     F = [x*y^2-x,x^3-2*x*y^2]
     q, r = reduce_with_quotients(f, F)
     @test q * F + [r] == [f]
+    q, r = reduce_with_quotients(f, elem_type(R)[])
+    @test q * elem_type(R)[] + [r] == [f]
     q, r = reduce_with_quotients([f], F)
     @test q * F + r == [f]
+    q, r = reduce_with_quotients([f], elem_type(R)[])
+    @test q * elem_type(R)[] + r == [f]
     u, q, r = reduce_with_quotients_and_unit(f, F)
     @test q * F + [r] == u * [f]
+    u, q, r = reduce_with_quotients_and_unit(f, elem_type(R)[])
+    @test q * elem_type(R)[] + [r] == u * [f]
     u, q, r = reduce_with_quotients_and_unit([f], F)
     @test q * F + r == u * [f]
+    u, q, r = reduce_with_quotients_and_unit([f], elem_type(R)[])
+    @test q * elem_type(R)[] + r == u * [f]
     f = x
     F = [1-x]
     q, r = reduce_with_quotients(f, F, ordering=neglex(R))


### PR DESCRIPTION
This removes the requirement that the underlying polynomial ring of an invariant ring needs to be created with `ordering = :degrevlex` which was always a hack.

I also adjusted the various `reduce*` functions, so that they can handle an empty array of divisors.

Related: Is there any chance to rename/alias/whatever `reduce` to `rem` and `reduce_with_quotients` to `divrem`? I understand that this is not that easy because functions under these names exist, but I also don't think it is impossible. And it would improve the discoverability of `reduce` and friends significantly in my opinion.

EDIT: The comment is mostly obsolete.