### PR TITLE
Resolve warning `could not import Oscar.is_linearly_equivalent into PlaneCurveModule`

### DIFF
--- a/experimental/PlaneCurve/src/DivisorCurve.jl
+++ b/experimental/PlaneCurve/src/DivisorCurve.jl
@@ -1,4 +1,4 @@
-import Oscar: is_effective, is_linearly_equivalent
+import Oscar: is_effective
 
 export AffineCurveDivisor
 export ProjCurveDivisor


### PR DESCRIPTION
This seems to be present since the merge of https://github.com/oscar-system/Oscar.jl/pull/2832.