### PR TITLE
Remove instance dispatches for `{elem,parent}_type`

### DIFF
--- a/experimental/GModule/Cohomology.jl
+++ b/experimental/GModule/Cohomology.jl
@@ -54,6 +54,7 @@ end
 
 Oscar.parent(a::MultGrpElem) = a.parent
 Oscar.elem_type(::Type{MultGrp{T}}) where T = MultGrpElem{T}
+Oscar.parent_type(::Type{MultGrpElem{T}}) where T = MultGrp{T}
 Oscar.zero(a::MultGrpElem) = parent(a)(one(a.data))
 
 import Base: ==, +, -, *
@@ -558,7 +559,7 @@ function Base.show(io::IO, C::CoChain{N}) where {N}
 end
 
 Oscar.Nemo.elem_type(::Type{AllCoChains{N,G,M}}) where {N,G,M} = CoChain{N,G,M}
-Oscar.Nemo.parent_type(::CoChain{N,G,M})  where {N,G,M}= AllCoChains{N,G,M}
+Oscar.Nemo.parent_type(::Type{CoChain{N,G,M}}) where {N,G,M} = AllCoChains{N,G,M}
 Oscar.parent(::CoChain{N,G,M}) where {N, G, M} = AllCoChains{N, G, M}()
 
 function differential(C::CoChain{N, G, M}) where {N, G, M}

--- a/experimental/GModule/Cohomology.jl
+++ b/experimental/GModule/Cohomology.jl
@@ -53,7 +53,6 @@ end
 (M::MultGrp{T})(a::T) where {T}  = MultGrpElem{T}(a, M)
 
 Oscar.parent(a::MultGrpElem) = a.parent
-Oscar.elem_type(::MultGrp{T}) where T = MultGrpElem{T}
 Oscar.elem_type(::Type{MultGrp{T}}) where T = MultGrpElem{T}
 Oscar.zero(a::MultGrpElem) = parent(a)(one(a.data))
 
@@ -558,7 +557,6 @@ function Base.show(io::IO, C::CoChain{N}) where {N}
   print(io, "$N-cochain with values in ", C.C.M)
 end
 
-Oscar.Nemo.elem_type(::AllCoChains{N,G,M}) where {N,G,M} = CoChain{N,G,M}
 Oscar.Nemo.elem_type(::Type{AllCoChains{N,G,M}}) where {N,G,M} = CoChain{N,G,M}
 Oscar.Nemo.parent_type(::CoChain{N,G,M})  where {N,G,M}= AllCoChains{N,G,M}
 Oscar.parent(::CoChain{N,G,M}) where {N, G, M} = AllCoChains{N, G, M}()

--- a/experimental/SymmetricIntersections/src/types.jl
+++ b/experimental/SymmetricIntersections/src/types.jl
@@ -68,8 +68,6 @@ representations affording some of the irreducible characters (only the one neede
 
 end
 
-elem_type(RR::RepRing{S, T}) where {S, T} = LinRep{S, T, Oscar.elem_type(S)}
-
 elem_type(::Type{RepRing{S, T}}) where {S, T} = LinRep{S, T, Oscar.elem_type(S)}
 
 ###############################################################################

--- a/src/AlgebraicGeometry/Miscellaneous/basics.jl
+++ b/src/AlgebraicGeometry/Miscellaneous/basics.jl
@@ -79,7 +79,7 @@ function _isprojective(a::Vector{ZZRingElem})
 end
 
 parent(a::ProjSpcElem) = a.parent
-Nemo.elem_type(::ProjSpc{T}) where {T} = ProjSpcElem{T}
+Nemo.elem_type(::Type{ProjSpc{T}}) where {T} = ProjSpcElem{T}
 Nemo.parent_type(::ProjSpcElem{T}) where {T} = ProjSpc{T}
 Nemo.base_ring(P::ProjSpc) = P.R
 

--- a/src/AlgebraicGeometry/Miscellaneous/basics.jl
+++ b/src/AlgebraicGeometry/Miscellaneous/basics.jl
@@ -80,7 +80,7 @@ end
 
 parent(a::ProjSpcElem) = a.parent
 Nemo.elem_type(::Type{ProjSpc{T}}) where {T} = ProjSpcElem{T}
-Nemo.parent_type(::ProjSpcElem{T}) where {T} = ProjSpc{T}
+Nemo.parent_type(::Type{ProjSpcElem{T}}) where {T} = ProjSpc{T}
 Nemo.base_ring(P::ProjSpc) = P.R
 
 Base.getindex(a::ProjSpcElem, i::Int) = a.v[i+1]

--- a/src/AlgebraicGeometry/RationalPoint/ProjectiveRationalPoint.jl
+++ b/src/AlgebraicGeometry/RationalPoint/ProjectiveRationalPoint.jl
@@ -161,7 +161,7 @@ function _is_projective(a::Vector{ZZRingElem})
   return isone(gcd(a))
 end
 
-Nemo.parent_type(::AbsProjectiveRationalPoint{S,T}) where {S,T} = T
+Nemo.parent_type(::Type{AbsProjectiveRationalPoint{S,T}}) where {S,T} = T
 
 function ==(a::AbsProjectiveRationalPoint{S, T}, b::AbsProjectiveRationalPoint{S, U}) where {S<:Union{FieldElem,ZZRingElem},T, U}
   ambient_space(a) == ambient_space(b) || return false

--- a/src/AlgebraicGeometry/Schemes/SpecOpen/Rings/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/SpecOpen/Rings/Attributes.jl
@@ -46,7 +46,6 @@ domain(R::SpecOpenRing) = R.domain
 ########################################################################
 elem_type(::Type{SpecOpenRing{S, T}}) where {S, T} = SpecOpenRingElem{SpecOpenRing{S, T}}
 parent_type(::Type{SpecOpenRingElem{S}}) where {S} = S
-parent_type(f::SpecOpenRingElem) = parent_type(typeof(f))
 
 ########################################################################
 # Basic getters                                                        #

--- a/src/AlgebraicGeometry/Schemes/SpecOpen/Rings/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/SpecOpen/Rings/Attributes.jl
@@ -45,9 +45,6 @@ domain(R::SpecOpenRing) = R.domain
 # Type getters                                                         #
 ########################################################################
 elem_type(::Type{SpecOpenRing{S, T}}) where {S, T} = SpecOpenRingElem{SpecOpenRing{S, T}}
-
-elem_type(R::SpecOpenRing) = elem_type(typeof(R))
-
 parent_type(::Type{SpecOpenRingElem{S}}) where {S} = S
 parent_type(f::SpecOpenRingElem) = parent_type(typeof(f))
 

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -80,7 +80,6 @@ mat_elem_type(::Type{MatrixGroup{S,T}}) where {S,T} = T
 _gap_filter(::Type{<:MatrixGroup}) = GAP.Globals.IsMatrixGroup
 
 elem_type(::Type{MatrixGroup{S,T}}) where {S,T} = MatrixGroupElem{S,T}
-elem_type(::MatrixGroup{S,T}) where {S,T} = MatrixGroupElem{S,T}
 Base.eltype(::Type{MatrixGroup{S,T}}) where {S,T} = MatrixGroupElem{S,T}
 
 # `parent_type` is defined and documented in AbstractAlgebra.

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -83,8 +83,7 @@ elem_type(::Type{MatrixGroup{S,T}}) where {S,T} = MatrixGroupElem{S,T}
 Base.eltype(::Type{MatrixGroup{S,T}}) where {S,T} = MatrixGroupElem{S,T}
 
 # `parent_type` is defined and documented in AbstractAlgebra.
-parent_type(::Type{T}) where T<:MatrixGroupElem{RE,S} where {RE,S} = MatrixGroup{RE,S}
-parent_type(::T) where T<:MatrixGroupElem{RE,S} where {RE,S} = MatrixGroup{RE,S}
+parent_type(::Type{MatrixGroupElem{S,T}}) where {S,T} = MatrixGroup{S,T}
 
 
 function Base.deepcopy_internal(x::MatrixGroupElem, dict::IdDict)

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -457,8 +457,7 @@ elem_type(::Type{T}) where T <: GAPGroup = BasicGAPGroupElem{T}
 Base.eltype(::Type{T}) where T <: GAPGroup = BasicGAPGroupElem{T}
 
 # `parent_type` is defined and documented in AbstractAlgebra.
-parent_type(::Type{T}) where T<:BasicGAPGroupElem{S} where S = S
-parent_type(::T) where T<:BasicGAPGroupElem{S} where S = S
+parent_type(::Type{BasicGAPGroupElem{T}}) where T <: GAPGroup = T
 
 #
 # The array _gap_group_types contains pairs (X,Y) where

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -453,7 +453,6 @@ In the future, a more elaborate setup for group element types
 might also be needed.
 """
 elem_type(::Type{T}) where T <: GAPGroup = BasicGAPGroupElem{T}
-elem_type(::T) where T <: GAPGroup = BasicGAPGroupElem{T}
 
 Base.eltype(::Type{T}) where T <: GAPGroup = BasicGAPGroupElem{T}
 

--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -1970,7 +1970,6 @@ end
 
 elem_type(::Type{FreeMod_dec{T}}) where {T} = FreeModElem_dec{T}
 parent_type(::Type{FreeModElem_dec{T}}) where {T} = FreeMod_dec{T}
-parent_type(::FreeModElem_dec{T}) where {T} = FreeMod_dec{T}
 
 @doc raw"""
 """

--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -1970,7 +1970,6 @@ end
 
 elem_type(::Type{FreeMod_dec{T}}) where {T} = FreeModElem_dec{T}
 parent_type(::Type{FreeModElem_dec{T}}) where {T} = FreeMod_dec{T}
-elem_type(::FreeMod_dec{T}) where {T} = FreeModElem_dec{T}
 parent_type(::FreeModElem_dec{T}) where {T} = FreeMod_dec{T}
 
 @doc raw"""

--- a/src/Modules/UngradedModules/FreeModElem.jl
+++ b/src/Modules/UngradedModules/FreeModElem.jl
@@ -117,7 +117,6 @@ end
 
 elem_type(::Type{FreeMod{T}}) where {T} = FreeModElem{T}
 parent_type(::Type{FreeModElem{T}}) where {T} = FreeMod{T}
-elem_type(::FreeMod{T}) where {T} = FreeModElem{T}
 parent_type(::FreeModElem{T}) where {T} = FreeMod{T}
 
 function generator_symbols(F::FreeMod)

--- a/src/Modules/UngradedModules/FreeModElem.jl
+++ b/src/Modules/UngradedModules/FreeModElem.jl
@@ -117,7 +117,6 @@ end
 
 elem_type(::Type{FreeMod{T}}) where {T} = FreeModElem{T}
 parent_type(::Type{FreeModElem{T}}) where {T} = FreeMod{T}
-parent_type(::FreeModElem{T}) where {T} = FreeMod{T}
 
 function generator_symbols(F::FreeMod)
   return F.S

--- a/src/Modules/UngradedModules/SubquoModuleElem.jl
+++ b/src/Modules/UngradedModules/SubquoModuleElem.jl
@@ -16,7 +16,6 @@ Construct an element $v \in SQ$ that is represented by $a$.
 """
 SubquoModuleElem(a::FreeModElem{R}, SQ::SubquoModule; is_reduced::Bool=false) where {R} = SubquoModuleElem{R}(a, SQ; is_reduced) 
 
-elem_type(::SubquoModule{T}) where {T} = SubquoModuleElem{T}
 parent_type(::SubquoModuleElem{T}) where {T} = SubquoModule{T}
 elem_type(::Type{SubquoModule{T}}) where {T} = SubquoModuleElem{T}
 parent_type(::Type{SubquoModuleElem{T}}) where {T} = SubquoModule{T}

--- a/src/Modules/UngradedModules/SubquoModuleElem.jl
+++ b/src/Modules/UngradedModules/SubquoModuleElem.jl
@@ -16,7 +16,6 @@ Construct an element $v \in SQ$ that is represented by $a$.
 """
 SubquoModuleElem(a::FreeModElem{R}, SQ::SubquoModule; is_reduced::Bool=false) where {R} = SubquoModuleElem{R}(a, SQ; is_reduced) 
 
-parent_type(::SubquoModuleElem{T}) where {T} = SubquoModule{T}
 elem_type(::Type{SubquoModule{T}}) where {T} = SubquoModuleElem{T}
 parent_type(::Type{SubquoModuleElem{T}}) where {T} = SubquoModule{T}
 

--- a/src/NumberTheory/GaloisGrp/GaloisGrp.jl
+++ b/src/NumberTheory/GaloisGrp/GaloisGrp.jl
@@ -97,7 +97,6 @@ value(a::BoundRingElem) = a.val
 Base.isless(a::BoundRingElem, b::BoundRingElem) = check_parent(a, b) && isless(value(a), value(b))
 
 Oscar.parent_type(::BoundRingElem{T}) where T = BoundRing{T}
-Oscar.elem_type(::BoundRing{T}) where T = BoundRingElem{T}
 Oscar.parent_type(::Type{BoundRingElem{T}}) where T = BoundRing{T}
 Oscar.elem_type(::Type{BoundRing{T}}) where T = BoundRingElem{T}
 

--- a/src/NumberTheory/GaloisGrp/GaloisGrp.jl
+++ b/src/NumberTheory/GaloisGrp/GaloisGrp.jl
@@ -96,7 +96,6 @@ Oscar.parent(a::BoundRingElem) = a.p
 value(a::BoundRingElem) = a.val
 Base.isless(a::BoundRingElem, b::BoundRingElem) = check_parent(a, b) && isless(value(a), value(b))
 
-Oscar.parent_type(::BoundRingElem{T}) where T = BoundRing{T}
 Oscar.parent_type(::Type{BoundRingElem{T}}) where T = BoundRing{T}
 Oscar.elem_type(::Type{BoundRing{T}}) where T = BoundRingElem{T}
 

--- a/src/Rings/AbelianClosure.jl
+++ b/src/Rings/AbelianClosure.jl
@@ -136,13 +136,11 @@ end
 ################################################################################
 
 elem_type(::Type{QQAbField{AnticNumberField}}) = QQAbElem{nf_elem}
-elem_type(::QQAbField{AnticNumberField}) = QQAbElem{nf_elem}
 parent_type(::Type{QQAbElem{nf_elem}}) = QQAbField{AnticNumberField}
 parent_type(::QQAbElem{nf_elem}) = QQAbField{AnticNumberField}
 parent(::QQAbElem{nf_elem}) = _QQAb
 
 elem_type(::Type{QQAbField{NfAbsNS}}) = QQAbElem{NfAbsNSElem}
-elem_type(::QQAbField{NfAbsNS}) = QQAbElem{NfAbsNSElem}
 parent_type(::Type{QQAbElem{NfAbsNSElem}}) = QQAbField{NfAbsNS}
 parent_type(::QQAbElem{NfAbsNSElem}) = QQAbField{NfAbsNS}
 parent(::QQAbElem{NfAbsNSElem}) = _QQAb_sparse

--- a/src/Rings/AbelianClosure.jl
+++ b/src/Rings/AbelianClosure.jl
@@ -137,12 +137,10 @@ end
 
 elem_type(::Type{QQAbField{AnticNumberField}}) = QQAbElem{nf_elem}
 parent_type(::Type{QQAbElem{nf_elem}}) = QQAbField{AnticNumberField}
-parent_type(::QQAbElem{nf_elem}) = QQAbField{AnticNumberField}
 parent(::QQAbElem{nf_elem}) = _QQAb
 
 elem_type(::Type{QQAbField{NfAbsNS}}) = QQAbElem{NfAbsNSElem}
 parent_type(::Type{QQAbElem{NfAbsNSElem}}) = QQAbField{NfAbsNS}
-parent_type(::QQAbElem{NfAbsNSElem}) = QQAbField{NfAbsNS}
 parent(::QQAbElem{NfAbsNSElem}) = _QQAb_sparse
 
 ################################################################################

--- a/src/Rings/AlgClosureFp.jl
+++ b/src/Rings/AlgClosureFp.jl
@@ -42,7 +42,6 @@ struct AlgClosureElem{T} <: FieldElem
 end
 
 elem_type(::Type{AlgClosure{T}}) where T = AlgClosureElem{T}
-parent_type(::AlgClosureElem{T}) where T = AlgClosure{T}
 parent_type(::Type{AlgClosureElem{T}}) where T = AlgClosure{T}
 
 function show(io::IO, a::AlgClosureElem)

--- a/src/Rings/AlgClosureFp.jl
+++ b/src/Rings/AlgClosureFp.jl
@@ -42,7 +42,6 @@ struct AlgClosureElem{T} <: FieldElem
 end
 
 elem_type(::Type{AlgClosure{T}}) where T = AlgClosureElem{T}
-elem_type(::AlgClosure{T}) where T = AlgClosureElem{T}
 parent_type(::AlgClosureElem{T}) where T = AlgClosure{T}
 parent_type(::Type{AlgClosureElem{T}}) where T = AlgClosure{T}
 

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -632,7 +632,6 @@ end
 
 parent_type(::MPolyQuoRingElem{S}) where S = MPolyQuoRing{S}
 parent_type(::Type{MPolyQuoRingElem{S}}) where S = MPolyQuoRing{S}
-elem_type(::MPolyQuoRing{S})  where S= MPolyQuoRingElem{S}
 elem_type(::Type{MPolyQuoRing{S}})  where S= MPolyQuoRingElem{S}
 
 canonical_unit(a::MPolyQuoRingElem) = one(parent(a))

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -630,7 +630,6 @@ function ideal(A::MPolyQuoRing{T}, x::MPolyQuoRingElem{T}) where T <: MPolyRingE
 end
 ##################################################################
 
-parent_type(::MPolyQuoRingElem{S}) where S = MPolyQuoRing{S}
 parent_type(::Type{MPolyQuoRingElem{S}}) where S = MPolyQuoRing{S}
 elem_type(::Type{MPolyQuoRing{S}})  where S= MPolyQuoRingElem{S}
 

--- a/src/Rings/NumberField.jl
+++ b/src/Rings/NumberField.jl
@@ -52,8 +52,6 @@ parent_type(::NfNSGenElem{T, S}) where {T, S} = NfNSGen{T, S}
 
 parent_type(::Type{NfNSGenElem{T, S}}) where {T, S} = NfNSGen{T, S}
 
-elem_type(::NfNSGen{T, S}) where {T, S} = NfNSGenElem{T, S}
-
 elem_type(::Type{NfNSGen{T, S}}) where {T, S} = NfNSGenElem{T, S}
 
 is_simple(::NfNSGen) = false

--- a/src/Rings/NumberField.jl
+++ b/src/Rings/NumberField.jl
@@ -48,8 +48,6 @@ const NfAbsNSGen = NfNSGen{QQFieldElem, QQMPolyRingElem}
 
 const NfAbsNSGenElem = NfNSGenElem{QQFieldElem, QQMPolyRingElem}
 
-parent_type(::NfNSGenElem{T, S}) where {T, S} = NfNSGen{T, S}
-
 parent_type(::Type{NfNSGenElem{T, S}}) where {T, S} = NfNSGen{T, S}
 
 elem_type(::Type{NfNSGen{T, S}}) where {T, S} = NfNSGenElem{T, S}

--- a/src/Rings/PBWAlgebra.jl
+++ b/src/Rings/PBWAlgebra.jl
@@ -57,8 +57,6 @@ end
 
 elem_type(::Type{PBWAlgRing{T, S}}) where {T, S} = PBWAlgElem{T, S}
 
-parent_type(::PBWAlgElem{T, S}) where {T, S} = PBWAlgRing{T, S}
-
 parent_type(::Type{PBWAlgElem{T, S}}) where {T, S} = PBWAlgRing{T, S}
 
 parent(a::PBWAlgElem) = a.parent

--- a/src/Rings/PBWAlgebra.jl
+++ b/src/Rings/PBWAlgebra.jl
@@ -55,8 +55,6 @@ function is_exact_type(a::Type{U}) where {T, U <: PBWAlgElem{T}}
    return is_exact_type(T)
 end
 
-elem_type(::PBWAlgRing{T, S}) where {T, S} = PBWAlgElem{T, S}
-
 elem_type(::Type{PBWAlgRing{T, S}}) where {T, S} = PBWAlgElem{T, S}
 
 parent_type(::PBWAlgElem{T, S}) where {T, S} = PBWAlgRing{T, S}

--- a/src/Rings/PBWAlgebraQuo.jl
+++ b/src/Rings/PBWAlgebraQuo.jl
@@ -63,8 +63,6 @@ function is_exact_type(a::Type{U}) where {T, U <: PBWAlgQuoElem{T}}
    return is_exact_type(T)
 end
 
-elem_type(::PBWAlgQuo{T, S}) where {T, S} = PBWAlgQuoElem{T, S}
-
 elem_type(::Type{PBWAlgQuo{T, S}}) where {T, S} = PBWAlgQuoElem{T, S}
 
 parent_type(::PBWAlgQuoElem{T, S}) where {T, S} = PBWAlgQuo{T, S}

--- a/src/Rings/PBWAlgebraQuo.jl
+++ b/src/Rings/PBWAlgebraQuo.jl
@@ -65,8 +65,6 @@ end
 
 elem_type(::Type{PBWAlgQuo{T, S}}) where {T, S} = PBWAlgQuoElem{T, S}
 
-parent_type(::PBWAlgQuoElem{T, S}) where {T, S} = PBWAlgQuo{T, S}
-
 parent_type(::Type{PBWAlgQuoElem{T, S}}) where {T, S} = PBWAlgQuo{T, S}
 
 parent(a::PBWAlgQuoElem) = a.parent

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -562,7 +562,6 @@ parent(a::MPolyDecRingElem{T, S}) where {T, S} = a.parent::MPolyDecRing{T, paren
 Nemo.symbols(R::MPolyDecRing) = symbols(forget_decoration(R))
 Nemo.nvars(R::MPolyDecRing) = nvars(forget_decoration(R))
 
-elem_type(::MPolyDecRing{T, S}) where {T, S} = MPolyDecRingElem{T, elem_type(S)}
 elem_type(::Type{MPolyDecRing{T, S}}) where {T, S} = MPolyDecRingElem{T, elem_type(S)}
 parent_type(::Type{MPolyDecRingElem{T, S}}) where {T, S} = MPolyDecRing{T, parent_type(S)}
 

--- a/src/Rings/mpoly-local.jl
+++ b/src/Rings/mpoly-local.jl
@@ -102,7 +102,6 @@ Nemo.parent(f::MPolyRingElemLoc) = f.parent
 Nemo.numerator(f::MPolyRingElemLoc) = numerator(f.frac)
 Nemo.denominator(f::MPolyRingElemLoc) = denominator(f.frac)
 
-elem_type(::MPolyRingLoc{T}) where {T} = MPolyRingElemLoc{T}
 elem_type(::Type{MPolyRingLoc{T}}) where {T} = MPolyRingElemLoc{T}
 parent_type(::Type{MPolyRingElemLoc{T}}) where {T} = MPolyRingLoc{T}
 

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -1542,11 +1542,8 @@ end
 one(W::MPolyLocRing) = W(one(base_ring(W)))
 zero(W::MPolyLocRing) = W(zero(base_ring(W)))
 
-elem_type(W::MPolyLocRing{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}) where {BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType} = MPolyLocRingElem{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}
-elem_type(T::Type{MPolyLocRing{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}}) where {BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType} = MPolyLocRingElem{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}
-
-parent_type(f::MPolyLocRingElem{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}) where {BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType} = MPolyLocRing{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}
-parent_type(T::Type{MPolyLocRingElem{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}}) where {BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType} = MPolyLocRing{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}
+elem_type(::Type{MPolyLocRing{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}}) where {BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType} = MPolyLocRingElem{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}
+parent_type(::Type{MPolyLocRingElem{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}}) where {BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType} = MPolyLocRing{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}
 
 function (W::MPolyLocRing{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType})(f::MPolyLocRingElem{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}; check::Bool=true) where {BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType} 
   parent(f) === W && return f

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -867,12 +867,8 @@ end
 one(W::MPolyQuoLocRing) = W(one(base_ring(W)))
 zero(W::MPolyQuoLocRing)= W(zero(base_ring(W)))
 
-elem_type(W::MPolyQuoLocRing{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}) where {BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType} = MPolyQuoLocRingElem{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}
-elem_type(T::Type{MPolyQuoLocRing{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}}) where {BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType} = MPolyQuoLocRingElem{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}
-
-parent_type(W::MPolyQuoLocRingElem{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}) where {BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType} = MPolyQuoLocRing{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}
-parent_type(T::Type{MPolyQuoLocRingElem{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}}) where {BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType} = MPolyQuoLocRing{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}
-
+elem_type(::Type{MPolyQuoLocRing{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}}) where {BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType} = MPolyQuoLocRingElem{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}
+parent_type(::Type{MPolyQuoLocRingElem{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}}) where {BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType} = MPolyQuoLocRing{BaseRingType, BaseRingElemType, RingType, RingElemType, MultSetType}
 
 
 @doc raw"""


### PR DESCRIPTION
As they already exist via https://github.com/Nemocas/AbstractAlgebra.jl/blob/9dd22199b5262f23ad071b877f5d4fb5ce9ad436/src/fundamental_interface.jl#L53 and are only inconsistently used throughout Oscar.