### PR TITLE
Follow-up to #3087

### DIFF
--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -1898,8 +1898,7 @@ end
 
 elem_type(::Type{FreeMod_dec{T}}) where {T} = FreeModElem_dec{T}
 parent_type(::Type{FreeModElem_dec{T}}) where {T} = FreeMod_dec{T}
-elem_type(::FreeMod_dec{T}) where {T} = FreeModElem_dec{T}
-parent_type(::FreeModElem_dec{T}) where {T} = FreeMod_dec{T}
+
 
 @doc raw"""
 """


### PR DESCRIPTION
These are not necessary as pointed out by @thofma in https://github.com/oscar-system/Oscar.jl/pull/3087/files#r1422359650 as AbstractAlgebra already provides them (see https://github.com/Nemocas/AbstractAlgebra.jl/blob/9dd22199b5262f23ad071b877f5d4fb5ce9ad436/src/fundamental_interface.jl#L53). Oscar only needs to define `elem/parent_type` for `Type` parameters, not concrete instances.

I cannot choose @RafaelDavidMohr as a reviewer, so pinging him here.