### PR TITLE
Optimize `BasisLieHighestWeight`

### DIFF
--- a/experimental/BasisLieHighestWeight/src/LieAlgebras.jl
+++ b/experimental/BasisLieHighestWeight/src/LieAlgebras.jl
@@ -58,8 +58,8 @@ function matrices_of_operators_gap(
   """
   M = GAP.Globals.HighestWeightModule(L.lie_algebra_gap, GAP.Obj(Int.(highest_weight)))
   matrices_of_operators = [
-    sparse_matrix(matrix(QQ, GAP.Globals.MatrixOfAction(GAPWrap.Basis(M), o)))
-    for o in operators
+    sparse_matrix(matrix(QQ, GAP.Globals.MatrixOfAction(GAPWrap.Basis(M), o))) for
+    o in operators
   ]
   denominators = map(y -> denominator(y[2]), union(union(matrices_of_operators...)...))
   common_denominator = lcm(denominators)# // 1

--- a/experimental/BasisLieHighestWeight/src/LieAlgebras.jl
+++ b/experimental/BasisLieHighestWeight/src/LieAlgebras.jl
@@ -58,7 +58,7 @@ function matrices_of_operators_gap(
   """
   M = GAP.Globals.HighestWeightModule(L.lie_algebra_gap, GAP.Obj(Int.(highest_weight)))
   matrices_of_operators = [
-    sparse_matrix(transpose(matrix(QQ, GAP.Globals.MatrixOfAction(GAPWrap.Basis(M), o)))) # TODO: remove transpose?
+    sparse_matrix(matrix(QQ, GAP.Globals.MatrixOfAction(GAPWrap.Basis(M), o)))
     for o in operators
   ]
   denominators = map(y -> denominator(y[2]), union(union(matrices_of_operators...)...))

--- a/experimental/BasisLieHighestWeight/src/MainAlgorithm.jl
+++ b/experimental/BasisLieHighestWeight/src/MainAlgorithm.jl
@@ -103,6 +103,7 @@ function compute_monomials(
   """
   # simple cases
   # we already computed the highest_weight result in a prior recursion step
+
   if haskey(calc_highest_weight, highest_weight)
     return calc_highest_weight[highest_weight]
   elseif highest_weight == [ZZ(0) for i in 1:(L.rank)] # we mathematically know the solution
@@ -136,7 +137,7 @@ function compute_monomials(
       lambda_1 = sub_weights_w[i]
       lambda_2 = highest_weight .- lambda_1
 
-      if lambda_2 > lambda_1
+      if lambda_1 > lambda_2
         continue
       end
 
@@ -171,6 +172,7 @@ function compute_monomials(
         L, birational_sequence, ZZx, highest_weight, monomial_ordering, set_mon
       )
     end
+
     push!(calc_highest_weight, highest_weight => set_mon)
     return set_mon
   end

--- a/experimental/BasisLieHighestWeight/src/NewMonomial.jl
+++ b/experimental/BasisLieHighestWeight/src/NewMonomial.jl
@@ -12,9 +12,7 @@ function calc_vec(
   degree_mon = degrees(mon)
   for i in length(degree_mon):-1:1
     for _ in 1:degree_mon[i]
-      # currently there is no sparse matrix * vector mult
-      # this is also the line that takes up almost all the computation time for big examples
-      v = v * transpose(matrices_of_operators[i]) # TODO: remove transpose?
+      v = v * matrices_of_operators[i]
     end
   end
   return v

--- a/experimental/BasisLieHighestWeight/test/NewMonomial-test.jl
+++ b/experimental/BasisLieHighestWeight/test/NewMonomial-test.jl
@@ -7,10 +7,10 @@
   mon1 = ZZx(1)
   mon2 = x[1]^2 * x[2]
   weights = [[ZZ(1), ZZ(1)], [ZZ(2), ZZ(1)]]
-  A = sparse_matrix(ZZ, 2, 2) # [0, 1; 2, 1]
-  setindex!(A, sparse_row(ZZ, [2], [ZZ(1)]), 1)
-  setindex!(A, sparse_row(ZZ, [1, 2], [ZZ(2), ZZ(1)]), 2)
-  B = sparse_matrix(ZZ, 2, 2) # [1, 0; 2, 0]
+  A = sparse_matrix(ZZ, 2, 2) # [0, 2; 1, 1]
+  setindex!(A, sparse_row(ZZ, [2], [ZZ(2)]), 1)
+  setindex!(A, sparse_row(ZZ, [1, 2], [ZZ(1), ZZ(1)]), 2)
+  B = sparse_matrix(ZZ, 2, 2) # [1, 0; 0, 2]
   setindex!(B, sparse_row(ZZ, [1], [ZZ(1)]), 1)
   setindex!(B, sparse_row(ZZ, [2], [ZZ(2)]), 2)
   matrices_of_operators = [A, B]


### PR DESCRIPTION
Computing the transpose of sparse matrices has been eleminated from the code at two positions. Further, experiments have shown that using the symmetry of partitions of a dominant weight does not speed up the algorithm in this order, so it is reversed.