### PR TITLE
Re-export deprecated bindings from AA and Nemo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 cohomCalg_jll = "5558cf25-a90e-53b0-b813-cadaa3ae7ade"
 
 [compat]
-AbstractAlgebra = "0.34.5"
+AbstractAlgebra = "0.34.7"
 AlgebraicSolving = "0.4.2"
 Distributed = "1.6"
 DocStringExtensions = "0.8, 0.9"

--- a/src/aliases.jl
+++ b/src/aliases.jl
@@ -1,3 +1,22 @@
+include(joinpath(pathof(AbstractAlgebra), "..", "Aliases.jl"))
+
+import Nemo: is_cyclo_type
+import Nemo: is_embedded
+import Nemo: is_maxreal_type
+import Nemo: ZZModRing  # FIXME: remove if/once Nemo exports this
+import Nemo: zzModRing  # FIXME: remove if/once Nemo exports this
+import Nemo: FpField  # FIXME: remove if/once Nemo exports this
+import Nemo: fpField  # FIXME: remove if/once Nemo exports this
+include(joinpath(pathof(Nemo), "..", "Aliases.jl"))
+
+#import Hecke: quadratic_genera
+#import Hecke: has_algebra
+#import Hecke: has_embedding
+#import Hecke: has_matrix_action
+#import Hecke: has_root
+#import Hecke: ...
+#include(joinpath(pathof(Hecke), "..", "Aliases.jl"))
+
 # make some Julia names compatible with our naming conventions
 @alias is_subset issubset
 @alias is_valid isvalid


### PR DESCRIPTION
This restores missing aliases like `PolynomialRing`, as discovered in #3114 (CC @thofma).

In principle I think we could merge this right away, or we could wait for AA/Nemo/Hecke releases to "simplify" this... but I don't see a major advantage, just merging this now and cleaning it up later would allow us to have 0.14.0 out before Christmas, maybe?