### PR TITLE
Fix conversion bug for PBWAlgQuo elements

### DIFF
--- a/src/Rings/PBWAlgebraQuo.jl
+++ b/src/Rings/PBWAlgebraQuo.jl
@@ -279,11 +279,11 @@ function (Q::PBWAlgQuo)(a::PBWAlgElem)
 end
 
 function (Q::PBWAlgQuo)()
-  return PBWAlgQuoElem(Q, base_ring(Q)())
+  return PBWAlgQuoElem(Q, PBWAlgElem(base_ring(Q), Q.sring(0)))
 end
 
 function (Q::PBWAlgQuo{T, S})(c::T) where {T, S}
-  return PBWAlgQuoElem(Q, base_ring(Q)(c))
+  return PBWAlgQuoElem(Q, PBWAlgElem(base_ring(Q), Q.sring(c)))
 end
 
 function (Q::PBWAlgQuo)(c::IntegerUnion)

--- a/test/Rings/PBWAlgebraQuo.jl
+++ b/test/Rings/PBWAlgebraQuo.jl
@@ -38,3 +38,11 @@ end
   test_NCRing_interface(Q; reps = 1)
 end
 
+@testset "PBWAlgebraQuo.conversion" begin
+  # [2023-12-21] Used to have incorrect parent object
+  E,_ = exterior_algebra(QQ,3)
+  @test  E() == E(0)
+  three = QQFieldElem(3)
+  @test  E(three) == E(3)
+end
+


### PR DESCRIPTION
Previously got "parents do not match" error; now fixed.