### PR TITLE
Edit `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@
 /docs/src/Hecke/
 /docs/src/Nemo/
 /docs/src/Experimental/
+profile.pb.gz
+LocalPreferences.toml
 Manifest.toml
 .DS_Store


### PR DESCRIPTION
I cannot count how often I had accidentally committed these two files and had to amend and/or force-push. It makes life easier to just add them to the `.gitignore` file.

For reference:
* `profile.bp.gz` gets created from using `@profile`
* `LocalPreferences.toml` is an artifact of using e.g. `Oscar.allow_unicode`