### PR TITLE
Use julia 1.10 as default in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,8 +23,7 @@ jobs:
       matrix:
         julia-version:
           - '1.6'
-          - '1.9'
-          - '~1.10.0-0'
+          - '1.10'
           - 'nightly'
         group: [ 'short', 'long' ]
         os:
@@ -32,11 +31,11 @@ jobs:
         depwarn: [ '' ]
         include:
           # Add a single job per group with deprecation errors on the most recent stable julia version
-          - julia-version: '1.9'
+          - julia-version: '1.10'
             os: ubuntu-latest
             group: 'short'
             depwarn: 'depwarn=error'
-          - julia-version: '1.9'
+          - julia-version: '1.10'
             os: ubuntu-latest
             group: 'long'
             depwarn: 'depwarn=error'
@@ -66,16 +65,16 @@ jobs:
       - name: "Run tests"
         uses: julia-actions/julia-runtest@latest
         with:
-          annotate: ${{ matrix.julia-version == '1.9' }}
-          coverage: ${{ matrix.julia-version == '1.9' }}
+          annotate: ${{ matrix.julia-version == '1.10' }}
+          coverage: ${{ matrix.julia-version == '1.10' }}
           depwarn: ${{ matrix.depwarn == 'depwarn=error' && 'error' || 'no' }}
       - name: "Process code coverage"
-        if: matrix.julia-version == '1.9' && matrix.depwarn != 'depwarn=error'
+        if: matrix.julia-version == '1.10' && matrix.depwarn != 'depwarn=error'
         uses: julia-actions/julia-processcoverage@v1
         with:
           directories: src,experimental
       - name: "Upload coverage data to Codecov"
-        if: matrix.julia-version == '1.9' && matrix.depwarn != 'depwarn=error'
+        if: matrix.julia-version == '1.10' && matrix.depwarn != 'depwarn=error'
         continue-on-error: true
         uses: codecov/codecov-action@v3
 
@@ -86,19 +85,18 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.9'
-          - '~1.10.0-0'
+          - '1.10'
           - 'nightly'
         os:
           - ubuntu-latest
         depwarn: [ '' ]
         include:
           # Add a single job with deprecation errors on the most recent stable julia version
-          - julia-version: '1.9'
+          - julia-version: '1.10'
             os: ubuntu-latest
             depwarn: 'depwarn=error'
           # Add macOS jobs (not too many, the number we can run in parallel is limited)
-          - julia-version: '1.9'
+          - julia-version: '1.10'
             os: macOS-latest
 
     steps:
@@ -123,8 +121,8 @@ jobs:
         if: runner.os == 'macOS'
         uses: julia-actions/julia-runtest@latest
         with:
-          annotate: ${{ matrix.julia-version == '1.9' }}
-          coverage: ${{ matrix.julia-version == '1.9' }}
+          annotate: ${{ matrix.julia-version == '1.10' }}
+          coverage: ${{ matrix.julia-version == '1.10' }}
           depwarn: ${{ matrix.depwarn == 'depwarn=error' && 'error' || 'no' }}
       - name: "Setup package"
         run: |
@@ -134,7 +132,7 @@ jobs:
             Pkg.instantiate()'
       - name: "Run doctests"
         run: |
-          julia ${{ matrix.julia-version == '1.9' && '--code-coverage' || '' }} \
+          julia ${{ matrix.julia-version == '1.10' && '--code-coverage' || '' }} \
             --project=docs --depwarn=${{ matrix.depwarn == 'depwarn=error' && 'error' || 'no' }} --color=yes -e'
               using Documenter
               include("docs/documenter_helpers.jl")
@@ -142,11 +140,11 @@ jobs:
               DocMeta.setdocmeta!(Oscar, :DocTestSetup, Oscar.doctestsetup(); recursive = true)
               doctest(Oscar)'
       - name: "Process code coverage"
-        if: matrix.julia-version == '1.9' && matrix.depwarn != 'depwarn=error'
+        if: matrix.julia-version == '1.10' && matrix.depwarn != 'depwarn=error'
         uses: julia-actions/julia-processcoverage@v1
         with:
           directories: src,experimental
       - name: "Upload coverage data to Codecov"
-        if: matrix.julia-version == '1.9' && matrix.depwarn != 'depwarn=error'
+        if: matrix.julia-version == '1.10' && matrix.depwarn != 'depwarn=error'
         continue-on-error: true
         uses: codecov/codecov-action@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         julia-version:
           - '1.6'
+          - '1.9'   # to be removed in the near future
           - '1.10'
           - 'nightly'
         group: [ 'short', 'long' ]
@@ -85,6 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
+          - '1.9'   # to be removed in the near future
           - '1.10'
           - 'nightly'
         os:

--- a/.github/workflows/Docu.yml
+++ b/.github/workflows/Docu.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.9'
+          version: '1.10'
       - name: Build package
         uses: julia-actions/julia-buildpkg@v1
       - name: Install dependencies

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -160,7 +160,7 @@ The optional parameter `doctest` can take three values:
   - `:fix`: Run the doctests and replace the output in the manual with
     the output produced by Oscar. Please use this option carefully.
 
-In GitHub Actions the Julia version used for building the manual is 1.9 and
+In GitHub Actions the Julia version used for building the manual is 1.10 and
 doctests are run with >= 1.7. Using a different Julia version may produce
 errors in some parts of Oscar, so please be careful, especially when setting
 `doctest=:fix`.


### PR DESCRIPTION
Now that julia 1.10 is released, we can drop 1.9 in CI in favor of 1.10.
Once this is merged, we need a change to https://github.com/oscar-system/OscarDevTools.jl/blob/master/src/defaults.jl

Edit: Merging this needs also an update to the list of required CI jobs.