### PR TITLE
fix `quo` if the result is a group of automorphisms

### DIFF
--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -482,6 +482,12 @@ function _get_type(G::GapObj)
                  matgrp.X = dom
                  return matgrp
                end
+      elseif pair[2] == AutomorphismGroup
+        return function(A::GAP.GapObj)
+                 actdom_gap = GAP.Globals.AutomorphismDomain(A)
+                 actdom_oscar = _get_type(actdom_gap)(actdom_gap)
+                 return AutomorphismGroup(A, actdom_oscar)
+               end
       else
         return pair[2]
       end

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -72,6 +72,7 @@ function __init__()
         (GAP.Globals.IsPcGroup, PcGroup),
         (GAP.Globals.IsMatrixGroup, MatrixGroup),
         (GAP.Globals.IsSubgroupFpGroup, FPGroup),
+        (GAP.Globals.IsGroupOfAutomorphisms, AutomorphismGroup),
     ])
   __GAP_info_messages_off()
   # make Oscar module accessible from GAP (it may not be available as

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -651,6 +651,15 @@ end
 
    @test is_isomorphic(A,GL(2,3))
    @test order(inner_automorphism_group(A)[1])==1
+
+   # Create an Oscar group from a group of automorphisms in GAP.
+   G = alternating_group(6)
+   A = automorphism_group(G)
+   fun = Oscar._get_type(A.X)
+   B = fun(A.X)
+   @test B == A
+   @test B !== A
+   @test B.X === A.X
 end
 
 @testset "Composition of mappings" begin

--- a/test/Groups/quotients.jl
+++ b/test/Groups/quotients.jl
@@ -40,6 +40,12 @@ end
       @test quo(PermGroup, G, subgens)[1] isa PermGroup
       @test_throws ArgumentError quo(PcGroup, G, subgens)
    end
+   G = automorphism_group(small_group(12, 5))
+   N = trivial_subgroup(G)[1]
+   for subgens in [N, gens(N)]
+      @test quo(G, subgens)[1] isa AutomorphismGroup
+      @test quo(PermGroup, G, subgens)[1] isa PermGroup
+   end
 
    # - `maximal_abelian_quotient` without prescribed type:
    #   same type as the input type if abelian,


### PR DESCRIPTION
Support `Oscar._get_type` for groups in GAP that consist of automorphisms.
The idea behind `Oscar._get_type` is that a function is returned that wraps the given group `H` into a group `G` (of an appropriate Oscar type) such that `G.X == H` holds.

This applies in particular to the situation described in #3145, where `quo` shall factor out the trivial subgroup of a group of automorphisms, and GAP returns the given group.

resolves #3145