### PR TITLE
fix: minor fix for upcoming broadcasting changes

### DIFF
--- a/experimental/Schemes/ProjectiveModules.jl
+++ b/experimental/Schemes/ProjectiveModules.jl
@@ -218,7 +218,7 @@ function _is_projective_without_denominators(A::MatElem;
     end
 
     # pull the denominator u from the result and make the matrix liftable. 
-    d = lcm(_lifted_denominator.(result))
+    d = reduce(lcm, _lifted_denominator.(result))
     if isone(d)
       return true, result, 0
     end


### PR DESCRIPTION
The upcoming broadcasting changes in AA will preserve the type of the matrix,
e.g., turn Oscar matrices into Oscar matrices and for those, `lcm(...)`
is not implemented.
