### PR TITLE
Make some group function names consistent with overall naming

### DIFF
--- a/docs/src/Groups/basics.md
+++ b/docs/src/Groups/basics.md
@@ -81,7 +81,7 @@ is_simple(G::GAPGroup)
 is_almostsimple
 is_quasisimple
 is_sporadic_simple
-is_finitelygenerated
+is_finitely_generated(G::GAPGroup)
 ```
 
 

--- a/docs/src/Groups/basics.md
+++ b/docs/src/Groups/basics.md
@@ -78,7 +78,7 @@ is_supersolvable
 is_solvable
 is_perfect
 is_simple(G::GAPGroup)
-is_almostsimple
+is_almost_simple(G::GAPGroup)
 is_quasisimple
 is_sporadic_simple
 is_finitely_generated(G::GAPGroup)

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1551,7 +1551,7 @@ end
 #end
 
 """
-    is_finitelygenerated(G::GAPGroup)
+    is_finitely_generated(G::GAPGroup)
 
 Return whether `G` is a finitely generated group.
 
@@ -1560,17 +1560,17 @@ Return whether `G` is a finitely generated group.
 julia> F = free_group(2)
 Free group of rank 2
 
-julia> is_finitelygenerated(F)
+julia> is_finitely_generated(F)
 true
 
 julia> H = derived_subgroup(F)[1]
 Free group
 
-julia> is_finitelygenerated(H)
+julia> is_finitely_generated(H)
 false
 ```
 """
-@gapattribute is_finitelygenerated(G::GAPGroup) = GAP.Globals.IsFinitelyGeneratedGroup(G.X)::Bool
+@gapattribute is_finitely_generated(G::GAPGroup) = GAP.Globals.IsFinitelyGeneratedGroup(G.X)::Bool
 
 
 # TODO/FIXME: is_free is disabled for now as it is not universal; it only
@@ -2031,7 +2031,7 @@ julia> describe(free_group(3))
 ```
 """
 function describe(G::GAPGroup)
-   is_finitelygenerated(G) || return "a non-finitely generated group"
+   is_finitely_generated(G) || return "a non-finitely generated group"
 
    # handle groups whose finiteness is known
    if has_is_finite(G)
@@ -2054,7 +2054,7 @@ end
 function describe(G::FPGroup)
    # despite the name, there are non-finitely generated (and hence non-finitely presented)
    # FPGroup instances
-   is_finitelygenerated(G) || return "a non-finitely generated group"
+   is_finitely_generated(G) || return "a non-finitely generated group"
 
    if GAPWrap.IsFreeGroup(G.X)
       r = GAP.Globals.RankOfFreeGroup(G.X)::GapInt

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -2078,7 +2078,7 @@ function describe(G::FPGroup)
    # abelian groups can be dealt with by GAP
    extra = ""
    if !has_is_abelian(G)
-      if is_obviouslyabelian(G)
+      if is_obviously_abelian(G)
          set_is_abelian(G, true) # TODO: Claus won't like this...
          return String(GAP.Globals.StructureDescription(G.X)::GapObj)
       end
@@ -2102,7 +2102,7 @@ function describe(G::FPGroup)
 
 end
 
-function is_obviouslyabelian(G::FPGroup)
+function is_obviously_abelian(G::FPGroup)
     rels = relators(G)
     fgens = gens(free_group(G))
     signs = [(e1,e2,e3) for e1 in (-1,1) for e2 in (-1,1) for e3 in (-1,1)]

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1349,7 +1349,7 @@ false
 @gapattribute is_simple(G::GAPGroup) = GAP.Globals.IsSimpleGroup(G.X)::Bool
 
 @doc raw"""
-    is_almostsimple(G::GAPGroup)
+    is_almost_simple(G::GAPGroup)
 
 Return whether `G` is an almost simple group,
 i.e., `G` is isomorphic to a group $H$ with the property
@@ -1357,15 +1357,15 @@ $S \leq H \leq Aut(S)$, for some non-abelian simple group $S$.
 
 # Examples
 ```jldoctest
-julia> is_almostsimple(symmetric_group(5))
+julia> is_almost_simple(symmetric_group(5))
 true
 
-julia> is_almostsimple(special_linear_group(2, 5))
+julia> is_almost_simple(special_linear_group(2, 5))
 false
 
 ```
 """
-@gapattribute is_almostsimple(G::GAPGroup) = GAP.Globals.IsAlmostSimpleGroup(G.X)::Bool
+@gapattribute is_almost_simple(G::GAPGroup) = GAP.Globals.IsAlmostSimpleGroup(G.X)::Bool
 
 @doc raw"""
     is_quasisimple(G::GAPGroup)

--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -350,7 +350,7 @@ end
 
 is_almostsimple(G::GrpAbFinGen) = false
 
-is_finitelygenerated(G::GrpAbFinGen) = true
+is_finitely_generated(G::GrpAbFinGen) = true
 
 is_perfect(G::GrpAbFinGen) = is_trivial(G)
 

--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -348,7 +348,7 @@ end
 #
 ################################################################################
 
-is_almostsimple(G::GrpAbFinGen) = false
+is_almost_simple(G::GrpAbFinGen) = false
 
 is_finitely_generated(G::GrpAbFinGen) = true
 

--- a/src/Groups/libraries/libraries.jl
+++ b/src/Groups/libraries/libraries.jl
@@ -26,7 +26,7 @@ end
 function __init_group_libraries()
   props = [
     is_abelian => GAP.Globals.IsAbelian,
-    is_almostsimple => GAP.Globals.IsAlmostSimple,
+    is_almost_simple => GAP.Globals.IsAlmostSimple,
     is_cyclic => GAP.Globals.IsCyclic,
     is_nilpotent => GAP.Globals.IsNilpotent,
     is_perfect => GAP.Globals.IsPerfect,

--- a/src/Groups/libraries/primitivegroups.jl
+++ b/src/Groups/libraries/primitivegroups.jl
@@ -166,7 +166,7 @@ may be of one of the following forms:
 The following functions are currently supported as values for `func`:
 - `degree`
 - `is_abelian`
-- `is_almostsimple`
+- `is_almost_simple`
 - `is_cyclic`
 - `is_nilpotent`
 - `is_perfect`

--- a/src/Groups/libraries/smallgroups.jl
+++ b/src/Groups/libraries/smallgroups.jl
@@ -167,7 +167,7 @@ order, otherwise an exception is thrown.
 The following functions are currently supported as values for `func`:
 - `exponent`
 - `is_abelian`
-- `is_almostsimple`
+- `is_almost_simple`
 - `is_cyclic`
 - `is_nilpotent`
 - `is_perfect`

--- a/src/Groups/libraries/transitivegroups.jl
+++ b/src/Groups/libraries/transitivegroups.jl
@@ -162,7 +162,7 @@ may be of one of the following forms:
 The following functions are currently supported as values for `func`:
 - `degree`
 - `is_abelian`
-- `is_almostsimple`
+- `is_almost_simple`
 - `is_cyclic`
 - `is_nilpotent`
 - `is_perfect`

--- a/src/aliases.jl
+++ b/src/aliases.jl
@@ -27,7 +27,7 @@ Base.@deprecate_binding hasrelshp has_relshp
 Base.@deprecate_binding hastorusfactor has_torusfactor
 Base.@deprecate_binding inner_automorphisms_group inner_automorphism_group
 Base.@deprecate_binding isaffine is_affine
-Base.@deprecate_binding isalmostsimple is_almostsimple
+Base.@deprecate_binding isalmostsimple is_almost_simple
 Base.@deprecate_binding isample is_ample
 Base.@deprecate_binding isbicoset is_bicoset
 Base.@deprecate_binding isbinomial is_binomial

--- a/src/aliases.jl
+++ b/src/aliases.jl
@@ -43,7 +43,7 @@ Base.@deprecate_binding isfano is_fano
 Base.@deprecate_binding isfeasible is_feasible
 Base.@deprecate_binding isfiltered is_filtered
 Base.@deprecate_binding isfinite_order is_finiteorder
-Base.@deprecate_binding isfinitelygenerated is_finitelygenerated
+Base.@deprecate_binding isfinitelygenerated is_finitely_generated
 Base.@deprecate_binding isfull_direct_product is_full_direct_product
 Base.@deprecate_binding isfull_semidirect_product is_full_semidirect_product
 Base.@deprecate_binding isfull_wreath_product is_full_wreath_product

--- a/src/aliases.jl
+++ b/src/aliases.jl
@@ -62,7 +62,7 @@ Base.@deprecate_binding ismolien_series_implemented is_molien_series_implemented
 Base.@deprecate_binding isnatural_alternating_group is_natural_alternating_group
 Base.@deprecate_binding isnatural_symmetric_group is_natural_symmetric_group
 Base.@deprecate_binding isnef is_nef
-Base.@deprecate_binding isobviouslyabelian is_obviouslyabelian
+Base.@deprecate_binding isobviouslyabelian is_obviously_abelian false
 Base.@deprecate_binding isorbifold is_orbifold
 Base.@deprecate_binding isperfect is_perfect
 Base.@deprecate_binding ispgroup is_pgroup

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -512,3 +512,5 @@ end
 Base.@deprecate_binding is_finitelygenerated is_finitely_generated
 Base.@deprecate_binding has_is_finitelygenerated has_is_finitely_generated
 Base.@deprecate_binding set_is_finitelygenerated set_is_finitely_generated
+
+Base.@deprecate_binding is_obviouslyabelian is_obviously_abelian false

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -514,3 +514,7 @@ Base.@deprecate_binding has_is_finitelygenerated has_is_finitely_generated
 Base.@deprecate_binding set_is_finitelygenerated set_is_finitely_generated
 
 Base.@deprecate_binding is_obviouslyabelian is_obviously_abelian false
+
+Base.@deprecate_binding is_almostsimple is_almost_simple
+Base.@deprecate_binding has_is_almostsimple has_is_almost_simple
+Base.@deprecate_binding set_is_almostsimple set_is_almost_simple

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -508,3 +508,7 @@ end
 @deprecate normal_toric_variety(rays::AbstractCollection[RayVector], max_cones::IncidenceMatrix; non_redundant::Bool = false) normal_toric_variety(max_cones, rays; non_redundant)
 
 @deprecate components(X::AbsSpec) connected_components(X::AbsSpec)
+
+Base.@deprecate_binding is_finitelygenerated is_finitely_generated
+Base.@deprecate_binding has_is_finitelygenerated has_is_finitely_generated
+Base.@deprecate_binding set_is_finitelygenerated set_is_finitely_generated

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -788,7 +788,7 @@ export is_fano
 export is_feasible
 export is_finalized
 export is_finite, has_is_finite, set_is_finite
-export is_finitelygenerated, has_is_finitelygenerated, set_is_finitelygenerated
+export is_finitely_generated, has_is_finitely_generated, set_is_finitely_generated
 export is_finiteorder
 export is_flat
 export is_full_direct_product

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -745,7 +745,7 @@ export irrelevant_ideal
 export is_abelian, has_is_abelian, set_is_abelian
 export is_admissible_ordering
 export is_affine
-export is_almostsimple, has_is_almostsimple, set_is_almostsimple
+export is_almost_simple, has_is_almost_simple, set_is_almost_simple
 export is_alternating
 export is_ample
 export is_basepoint_free

--- a/test/Groups/GrpAb.jl
+++ b/test/Groups/GrpAb.jl
@@ -40,7 +40,7 @@ end
     # properties
     @test is_abelian(G1) == is_abelian(G2)
     @test is_finite(G1) == is_finite(G2)
-    @test is_finitelygenerated(G1) == is_finitelygenerated(G2)
+    @test is_finitely_generated(G1) == is_finitely_generated(G2)
     @test is_perfect(G1) == is_perfect(G2)
     @test is_pgroup(G1) == is_pgroup(G2)
     @test is_quasisimple(G1) == is_quasisimple(G2)

--- a/test/Groups/libraries.jl
+++ b/test/Groups/libraries.jl
@@ -25,7 +25,7 @@
    @test length(grps)==16
    props = [
       is_abelian,
-      is_almostsimple,
+      is_almost_simple,
       is_cyclic,
       is_nilpotent,
       is_perfect,

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -259,7 +259,7 @@ end
    @test is_simple(alternating_group(5))
    @test is_simple(quo(SL(4,3), center(SL(4,3))[1])[1])
 
-   @test is_almostsimple(symmetric_group(5))
+   @test is_almost_simple(symmetric_group(5))
    @test !is_simple(symmetric_group(5))
 
    @test is_perfect(alternating_group(5))


### PR DESCRIPTION
While working on https://github.com/oscar-system/Oscar.jl/pull/3157, I stumbled upon some functions with inconsistently used `_` in their names. This PR renames them (with appropriate deprecations).