### PR TITLE
Rename jacobi_matrix to jacobian_matrix

### DIFF
--- a/experimental/PlaneCurve/docs/src/non_plane_curves.md
+++ b/experimental/PlaneCurve/docs/src/non_plane_curves.md
@@ -23,6 +23,6 @@ in(P::Oscar.Geometry.ProjSpcElem, C::ProjCurve)
 curve_components(C::ProjCurve)
 is_irreducible(C::ProjCurve)
 reduction(C::ProjCurve)
-jacobi_ideal(C::ProjCurve)
+jacobian_ideal(C::ProjCurve)
 invert_birational_map(phi::Vector{T}, C::ProjCurve) where {T <: MPolyRingElem}
 ```

--- a/experimental/PlaneCurve/docs/src/plane_curves.md
+++ b/experimental/PlaneCurve/docs/src/plane_curves.md
@@ -114,7 +114,7 @@ geometric_genus(C::AffinePlaneCurve)
 ## Smoothness, tangents and singularity related functions
 
 ```@docs
-jacobi_ideal(C::Oscar.PlaneCurveModule.PlaneCurve)
+jacobian_ideal(C::Oscar.PlaneCurveModule.PlaneCurve)
 is_smooth(C::AffinePlaneCurve{S}, P::Point{S}) where S <: FieldElem
 is_smooth(C::Oscar.PlaneCurveModule.ProjectivePlaneCurve{S}, P::Oscar.Geometry.ProjSpcElem{S}) where S <: FieldElem
 tangent(C::AffinePlaneCurve{S}, P::Point{S}) where S <: FieldElem

--- a/experimental/PlaneCurve/src/AffinePlaneCurve.jl
+++ b/experimental/PlaneCurve/src/AffinePlaneCurve.jl
@@ -46,7 +46,7 @@ false
 function Oscar.is_smooth(C::AffinePlaneCurve{S}, P::Point{S}) where S <: FieldElem
   P.ambient_dim == 2 || error("The point needs to be in a two dimensional space")
   iszero(evaluate(C.eq, P.coord)) || error("The point is not on the curve defined by ", C.eq)
-  J = jacobi_ideal(C)
+  J = jacobian_ideal(C)
   L = gens(J)
   a = evaluate(L[1], P.coord)
   b = evaluate(L[2], P.coord)
@@ -80,7 +80,7 @@ Affine plane curve defined by -48*x - 48*y
 function tangent(C::AffinePlaneCurve{S}, P::Point{S}) where S <: FieldElem
   P.ambient_dim == 2 || error("The point needs to be in a two dimensional space")
   iszero(evaluate(C.eq, P.coord)) || error("The point is not on the curve")
-  J = jacobi_ideal(C)
+  J = jacobian_ideal(C)
   L = gens(J)
   a = evaluate(L[1], P.coord)
   b = evaluate(L[2], P.coord)
@@ -256,7 +256,7 @@ function curve_singular_locus(C::AffinePlaneCurve)
       push!(CC, AffinePlaneCurve(g))
    end
    # Computation of the singular locus of the reduction of C.
-   J = jacobi_ideal(D)
+   J = jacobian_ideal(D)
    F = D.eq
    FX, FY = gens(J)
    # The case FX = FY = 0 cannot occur in the reduced case.
@@ -402,7 +402,7 @@ end
 Return the singular locus of `C` as a variety.
 """
 function singular_locus(C::AffinePlaneCurve)
-  J = jacobi_ideal(C)
+  J = jacobian_ideal(C)
   R = parent(C.eq)
   S = ideal(R, [gens(J); C.eq])
   return Variety(S)

--- a/experimental/PlaneCurve/src/PlaneCurve.jl
+++ b/experimental/PlaneCurve/src/PlaneCurve.jl
@@ -13,7 +13,7 @@ export hash
 export ideal_point
 export is_irreducible
 export is_reduced
-export jacobi_ideal
+export jacobian_ideal
 export reduction
 export ring
 export union
@@ -267,7 +267,7 @@ end
 ################################################################################
 
 @doc raw"""
-    jacobi_ideal(C::PlaneCurve)
+    jacobian_ideal(C::PlaneCurve)
 
 Return the Jacobian ideal of the defining polynomial of `C`.
 
@@ -279,12 +279,12 @@ julia> R, (x, y) = polynomial_ring(QQ, ["x", "y"])
 julia> C = AffinePlaneCurve(y^3*x^6 - y^6*x^2)
 Affine plane curve defined by x^6*y^3 - x^2*y^6
 
-julia> Oscar.jacobi_ideal(C)
+julia> Oscar.jacobian_ideal(C)
 ideal(6*x^5*y^3 - 2*x*y^6, 3*x^6*y^2 - 6*x^2*y^5)
 ```
 """
-function Oscar.jacobi_ideal(C::PlaneCurve)
- return jacobi_ideal(C.eq)
+function Oscar.jacobian_ideal(C::PlaneCurve)
+ return jacobian_ideal(C.eq)
 end
 
 ################################################################################
@@ -494,7 +494,7 @@ end
 using .PlaneCurveModule
 
 export Point, ideal_point, AffinePlaneCurve, ProjPlaneCurve, hash, degree,
-       jacobi_ideal, curve_components, is_irreducible, is_reduced, reduction,
+       jacobian_ideal, curve_components, is_irreducible, is_reduced, reduction,
        union, defining_equation, ring, ProjectivePlaneCurve
 
 export is_smooth, tangent, common_components, curve_intersect,
@@ -503,7 +503,7 @@ export is_smooth, tangent, common_components, curve_intersect,
        arithmetic_genus, geometric_genus
 
 export ProjCurve, defining_ideal, curve_components, reduction, is_irreducible,
-       jacobi_ideal
+       jacobian_ideal
        
 export parametrization_plane_curve, adjoint_ideal, rational_point_conic,
        parametrization_conic, map_to_rational_normal_curve,

--- a/experimental/PlaneCurve/src/ProjCurve.jl
+++ b/experimental/PlaneCurve/src/ProjCurve.jl
@@ -2,7 +2,7 @@ export ProjCurve
 export curve_components
 export defining_ideal
 export is_irreducible
-export jacobi_ideal
+export jacobian_ideal
 export reduction
 
 import Oscar.defining_ideal
@@ -187,7 +187,7 @@ end
 ################################################################################
 
 @doc raw"""
-    jacobi_ideal(C::ProjCurve)
+    jacobian_ideal(C::ProjCurve)
 
 Return the Jacobian ideal of the defining ideal of `C`.
 
@@ -205,15 +205,15 @@ ideal(x^2, y^2*z, z^2)
 julia> C = Oscar.ProjCurve(I)
 Projective curve defined by the ideal(x^2, y^2*z, z^2)
 
-julia> Oscar.jacobi_ideal(C)
+julia> Oscar.jacobian_ideal(C)
 ideal(4*x*y*z, 2*x*y^2, 4*x*z, 4*y*z^2)
 ```
 """
-function Oscar.jacobi_ideal(C::ProjCurve)
+function Oscar.jacobian_ideal(C::ProjCurve)
     I = defining_ideal(C)
     R = base_ring(I)
     k = C.ambiant_dim - 1
-    M = jacobi_matrix(gens(I))
+    M = jacobian_matrix(gens(I))
     V = minors(M, k)
     filter!(!iszero, V)
     return ideal(R, V)

--- a/experimental/PlaneCurve/src/ProjEllipticCurve.jl
+++ b/experimental/PlaneCurve/src/ProjEllipticCurve.jl
@@ -52,7 +52,7 @@ end
 ################################################################################
 
 function is_inflection(F::Oscar.MPolyDecRingElem{S}, P::Oscar.Geometry.ProjSpcElem{S}) where S <: FieldElem
-   J = jacobi_matrix([jacobi_matrix(F)[i] for i in 1:3])
+   J = jacobian_matrix([jacobian_matrix(F)[i] for i in 1:3])
    H = det(J)
    return iszero(evaluate(F, P.v)) && iszero(evaluate(H, P.v))
 end

--- a/experimental/PlaneCurve/src/ProjPlaneCurve.jl
+++ b/experimental/PlaneCurve/src/ProjPlaneCurve.jl
@@ -47,7 +47,7 @@ false
 function Oscar.is_smooth(C::ProjectivePlaneCurve{S}, P::Oscar.Geometry.ProjSpcElem{S}) where S <: FieldElem
   dim(P.parent) == 2 || error("The point needs to be in a projective two dimensional space")
   iszero(evaluate(C.eq, P.v)) || error("The point is not on the curve defined by ", C.eq)
-  J = jacobi_ideal(C)
+  J = jacobian_ideal(C)
   L = gens(J)
   a = evaluate(L[1], P.v)
   b = evaluate(L[2], P.v)
@@ -85,7 +85,7 @@ Projective plane curve defined by -48*x - 48*y
 function tangent(C::ProjectivePlaneCurve{S}, P::Oscar.Geometry.ProjSpcElem{S}) where S <: FieldElem
   dim(P.parent) == 2 || error("The point needs to be in a projective two dimensional space")
   iszero(evaluate(C.eq, P.v)) || error("The point is not on the curve")
-  J = jacobi_ideal(C)
+  J = jacobian_ideal(C)
   L = gens(J)
   a = evaluate(L[1], P.v)
   b = evaluate(L[2], P.v)
@@ -238,7 +238,7 @@ function curve_singular_locus(PP::Oscar.Geometry.ProjSpc{S}, C::ProjectivePlaneC
      g = prod(f)
      push!(CC, ProjPlaneCurve(g))
   end
-  J = jacobi_ideal(D)
+  J = jacobian_ideal(D)
   FX, FY, FZ = gens(J)
   # Computation of the singular locus of the reduction of C.
   # With the fact that the equation is now squarefree, only points can appear.
@@ -300,7 +300,7 @@ Return `true` if `C` has no singular point, and `false` otherwise.
 function is_smooth_curve(C::ProjectivePlaneCurve)
    F = defining_equation(C)
    R = parent(F)
-   J = jacobi_ideal(F)
+   J = jacobian_ideal(F)
    if dim(J) > 0
       return false
    else

--- a/experimental/PlaneCurve/test/runtests.jl
+++ b/experimental/PlaneCurve/test/runtests.jl
@@ -470,7 +470,7 @@ end
     P = Oscar.Geometry.ProjSpcElem(PP[1], [QQ(0), QQ(2), QQ(0), QQ(5)])
     @test P in C
     @test PC.is_irreducible(C)
-    J = PC.jacobi_ideal(C)
+    J = PC.jacobian_ideal(C)
     L = gens(J)
     @test length(L) == 4
     @test length(findall(a -> a == 4*x*y*z, L)) == 1

--- a/experimental/Schemes/CoherentSheaves.jl
+++ b/experimental/Schemes/CoherentSheaves.jl
@@ -811,8 +811,8 @@ on ``X`` as a `CoherentSheaf`.
     (U, V) = patches(G)
     (UU, VV) = glueing_domains(G)
     (f, g) = glueing_morphisms(G)
-    MG[(U, V)] = transpose(jacobi_matrix(pullback(g).(gens(OO(UU)))))
-    MG[(V, U)] = transpose(jacobi_matrix(pullback(f).(gens(OO(VV)))))
+    MG[(U, V)] = transpose(jacobian_matrix(pullback(g).(gens(OO(UU)))))
+    MG[(V, U)] = transpose(jacobian_matrix(pullback(f).(gens(OO(VV)))))
   end
 
 
@@ -846,7 +846,7 @@ end
   R = OO(X)
   P = base_ring(R)
   F = FreeMod(R, ["d$(x)" for x in symbols(P)])
-  rels, _ = sub(F, transpose(change_base_ring(R, jacobi_matrix(base_ring(modulus(R)), gens(modulus(R))))))
+  rels, _ = sub(F, transpose(change_base_ring(R, jacobian_matrix(base_ring(modulus(R)), gens(modulus(R))))))
   M, _ = quo(F, rels)
   return M
 end
@@ -855,7 +855,7 @@ end
   R = OO(X)
   P = base_ring(R)
   F = FreeMod(R, ["d$(x)" for x in symbols(P)])
-  rels, _ = sub(F, transpose(change_base_ring(R, jacobi_matrix(base_ring(modulus(R)), gens(modulus(R))))))
+  rels, _ = sub(F, transpose(change_base_ring(R, jacobian_matrix(base_ring(modulus(R)), gens(modulus(R))))))
   M, _ = quo(F, rels)
   return M
 end

--- a/experimental/Schemes/CoveredProjectiveSchemes.jl
+++ b/experimental/Schemes/CoveredProjectiveSchemes.jl
@@ -1187,12 +1187,12 @@ end
 #  verbose && println("call with $X and $f")
 #  R = base_ring(OO(X))
 #  g = gens(modulus(OO(X)))
-#  Dg = jacobi_matrix(g)
+#  Dg = jacobian_matrix(g)
 #  d = dim(X)
 #  n = nvars(R)
 #  verbose && println("generators:")
 #  verbose && println(f)
-#  verbose && println("jacobian matrix:")
+#  verbose && println("Jacobian matrix:")
 #  if verbose
 #    for i in 1:nrows(Dg)
 #      println(Dg[i, 1:end])
@@ -1206,7 +1206,7 @@ end
 #    verbose && println("proceed with finding a regular sequence on $U")
 #    g = X_dict[U][2]
 #    f_ext = vcat(g, f)
-#    Df_ext = jacobi_matrix(f_ext)
+#    Df_ext = jacobian_matrix(f_ext)
 #    good = X_dict[U][3]
 #    Z = subscheme(U, f)
 #    d = dim(Z)
@@ -1233,11 +1233,11 @@ end
 #function as_smooth_lci_of_cod(X::Spec, c::Int; check::Bool=true, verbose::Bool=false)
 #  R = base_ring(OO(X))
 #  f = gens(modulus(OO(X)))
-#  Df = jacobi_matrix(f)
+#  Df = jacobian_matrix(f)
 #  n = nvars(R)
 ##  verbose && println("generators:")
 ##  verbose && println(f)
-##  verbose && println("jacobian matrix:")
+##  verbose && println("Jacobian matrix:")
 ##  if verbose
 ##    for i in 1:nrows(Df)
 ##      println(Df[i, 1:end])
@@ -1249,11 +1249,11 @@ end
 ##      push!(f_part, sum([(rand(Int)%1000)*g for g in f]))
 ##    end
 ##    @show "first try"
-##    while !isempty(degeneracy_locus(X, jacobi_matrix(f_part), c, verbose=true))
+##    while !isempty(degeneracy_locus(X, jacobian_matrix(f_part), c, verbose=true))
 ##      @show "new try"
 ##      push!(f_part, dot([rand(Int)%1000 for j in 1:length(f)], f))
 ##    end
-##    return _as_smooth_lci_rec(X, X, poly_type(X)[], (Int[], Int[]), Vector{Tuple{Int, Int}}(), f_part, jacobi_matrix(f_part), n-c, n, check=check, verbose=verbose)
+##    return _as_smooth_lci_rec(X, X, poly_type(X)[], (Int[], Int[]), Vector{Tuple{Int, Int}}(), f_part, jacobian_matrix(f_part), n-c, n, check=check, verbose=verbose)
 #  return _as_smooth_lci_rec(X, X, poly_type(X)[], (Int[], Int[]), Vector{Tuple{Int, Int}}(), f, Df, Df, n-c, n, check=check, verbose=verbose)
 #end
 #
@@ -1271,12 +1271,12 @@ end
 #function as_smooth_local_complete_intersection(X::Spec; check::Bool=true, verbose::Bool=false)
 #  R = base_ring(OO(X))
 #  f = gens(modulus(OO(X)))
-#  Df = jacobi_matrix(f)
+#  Df = jacobian_matrix(f)
 #  d = dim(X)
 #  n = nvars(R)
 #  verbose && println("generators:")
 #  verbose && println(f)
-#  verbose && println("jacobian matrix:")
+#  verbose && println("Jacobian matrix:")
 #  if verbose
 #    for i in 1:nrows(Df)
 #      println(Df[i, 1:end])
@@ -1672,7 +1672,7 @@ end
 #
 #function test_cover(C, f, hl, ql, rl, cl)
 #  n = length(hl)
-#  Df = jacobi_matrix(f)
+#  Df = jacobian_matrix(f)
 #  for i in 1:n
 #    h = prod(hl[i])
 #    A = Df[rl[i], cl[i]]

--- a/experimental/Schemes/IdealSheaves.jl
+++ b/experimental/Schemes/IdealSheaves.jl
@@ -517,7 +517,7 @@ end
 #  h = vcat(f, g)
 #  r = length(f)
 #  s = length(g)
-#  Dh = jacobi_matrix(h)
+#  Dh = jacobian_matrix(h)
 #  (ll, ql, rl, cl) = _non_degeneration_cover(subscheme(U, g), Dh, codimension + codim(U), 
 #                          verbose=verbose, check=check, 
 #                          restricted_columns=[collect(1:r), [r + k for k in 1:s]])

--- a/experimental/Schemes/duValSing.jl
+++ b/experimental/Schemes/duValSing.jl
@@ -220,7 +220,7 @@ function _check_duval_at_point(IX::Ideal,Ipt::Ideal)
   kk = base_ring(R)
   characteristic(kk) == 0 || error("only available in characteristic zero")
  
-  JM = jacobi_matrix(gens(IX))
+  JM = jacobian_matrix(gens(IX))
 
   smooth = (:A,0)
 

--- a/src/AlgebraicGeometry/RationalPoint/AffineRationalPoint.jl
+++ b/src/AlgebraicGeometry/RationalPoint/AffineRationalPoint.jl
@@ -191,7 +191,7 @@ See also [`tangent_space(P::AbsAffineRationalPoint{<:Field})`](@ref)
 """
 function tangent_space(X::AbsSpec{<:Field}, P::AbsAffineRationalPoint)
   @req P in X "the point needs to lie on the algebraic set"
-  J = jacobi_matrix(gens(ambient_closure_ideal(X)))
+  J = jacobian_matrix(gens(ambient_closure_ideal(X)))
   v = coordinates(P)
   JP = map_entries(x->evaluate(x, v), J)
   V = ambient_coordinates(X)

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
@@ -799,7 +799,7 @@ end
 ## compute *some* representative of the Jacobian matrix of gens(modulus),
 ## forgetting about the denominators (contribution killed by modulus anyway)
 
-function _jacobi_matrix_modulus(X::AbsSpec{<:Ring, <:MPAnyQuoRing})
+function _jacobian_matrix_modulus(X::AbsSpec{<:Ring, <:MPAnyQuoRing})
   g = gens(modulus(underlying_quotient(OO(X))))
   L = base_ring(underlying_quotient(OO(X)))
   n = nvars(L)

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
@@ -751,7 +751,7 @@ function _singular_locus_with_decomposition(X::AbsSpec{<:Field, <:MPAnyQuoRing},
   empty = typeof(X)[]
   result = empty
 
-# equidimensional decomposition to allow Jacobi criterion on each component
+# equidimensional decomposition to allow Jacobian criterion on each component
   P = Ideal[]
 
   if has_attribute(X, :is_equidimensional) && is_equidimensional(X) && !reduced 
@@ -764,12 +764,12 @@ function _singular_locus_with_decomposition(X::AbsSpec{<:Field, <:MPAnyQuoRing},
     end
   end
 
-# if irreducible, just do Jacobi criterion
+# if irreducible, just do Jacobian criterion
   if length(P)==1 && !reduced
     d = dim(X)
     R = base_ring(I)
     n = nvars(R) 
-    M = _jacobi_matrix_modulus(X)
+    M = _jacobian_matrix_modulus(X)
     minvec = minors(M, n-d)
     J = ideal(R, minvec)
     JX = ideal(OO(X),minvec)
@@ -795,8 +795,8 @@ function _singular_locus_with_decomposition(X::AbsSpec{<:Field, <:MPAnyQuoRing},
   return result
 end
 
-## cheaper version of jacobi_matrix specifically for Jacobi matrix of modulus
-## compute *some* representative of the jacobian matrix of gens(modulus),
+## cheaper version of jacobian_matrix specifically for Jacobian matrix of modulus
+## compute *some* representative of the Jacobian matrix of gens(modulus),
 ## forgetting about the denominators (contribution killed by modulus anyway)
 
 function _jacobi_matrix_modulus(X::AbsSpec{<:Ring, <:MPAnyQuoRing})

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Properties.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Properties.jl
@@ -690,7 +690,7 @@ true
   L = localized_ring(OO(X))
   I = modulus(OO(X))
   f = gens(saturated_ideal(I))
-  Df = jacobi_matrix(f)
+  Df = jacobian_matrix(f)
   A = map_entries(x->OO(X)(x), Df)
   success, _, _ = Oscar._is_projective_without_denominators(A, task=:without_projector)
   return success
@@ -700,7 +700,7 @@ end
   R = base_ring(OO(X))
   I = modulus(OO(X))
   f = gens(I)
-  Df = jacobi_matrix(f)
+  Df = jacobian_matrix(f)
   A = map_entries(x->OO(X)(x), Df)
   success, _, _ = Oscar._is_projective_without_denominators(A, task=:without_projector)
   return success

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Properties.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Properties.jl
@@ -36,7 +36,7 @@ is_smooth(X::AbsCoveredScheme) = is_smooth(underlying_scheme(X))
     return true
   end
   # TODO: Can this be optimized? We only need to check the rank of
-  # the jacobian matrices where we haven't checked in another chart before.
+  # the Jacobian matrices where we haven't checked in another chart before.
   # This is a tradeoff between cost of Jacobian criterion and cost of
   # optimizing the use of the covering
   return all(is_smooth, affine_charts(X))
@@ -55,7 +55,7 @@ function _jacobian_criterion(X::CoveredScheme{<:Field})
   for (V, fs) in dec_info
     R = base_ring(OO(V))
     I = ambient_closure_ideal(V)
-    mat = jacobi_matrix(R, gens(I))
+    mat = jacobian_matrix(R, gens(I))
     sing_locus = ideal(R, fs) + ideal(R, minors(mat, codim(V)))
     sing_subscheme = subscheme(V, sing_locus)
     if !isempty(sing_subscheme)

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Properties.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Properties.jl
@@ -116,7 +116,7 @@ function _projective_jacobian_criterion(P::AbsProjectiveScheme)
   end
   R = base_ring(homogeneous_coordinate_ring(P))
   I = defining_ideal(P)
-  mat = jacobi_matrix(R, gens(I))
+  mat = jacobian_matrix(R, gens(I))
   sing_locus = ideal(R, minors(mat, codim(P)))
   return dim(sing_locus + I) <= 0
 end

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -791,19 +791,19 @@ function finish(M::MPolyBuildCtx{<:MPolyDecRingElem})
   return parent(M.poly)(f)
 end
 
-function jacobi_matrix(f::MPolyDecRingElem)
+function jacobian_matrix(f::MPolyDecRingElem)
   R = parent(f)
   n = nvars(R)
   return matrix(R, n, 1, [derivative(f, i) for i=1:n])
 end
 
-function jacobi_ideal(f::MPolyDecRingElem)
+function jacobian_ideal(f::MPolyDecRingElem)
   R = parent(f)
   n = nvars(R)
   return ideal(R, [derivative(f, i) for i=1:n])
 end
 
-function jacobi_matrix(g::Vector{<:MPolyDecRingElem})
+function jacobian_matrix(g::Vector{<:MPolyDecRingElem})
   R = parent(g[1])
   n = nvars(R)
   @assert all(x->parent(x) === R, g)

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -2987,13 +2987,13 @@ function derivative(f::MPolyLocRingElem, i::Int)
   return parent(f)(divexact(num, g), divexact(den, g), check=false)
 end
 
-function jacobi_matrix(f::MPolyLocRingElem)
+function jacobian_matrix(f::MPolyLocRingElem)
   L = parent(f)
   n = nvars(base_ring(L))
   return matrix(L, n, 1, [derivative(f, i) for i=1:n])
 end
 
-function jacobi_matrix(g::Vector{<:MPolyLocRingElem})
+function jacobian_matrix(g::Vector{<:MPolyLocRingElem})
   R = parent(g[1])
   n = nvars(base_ring(R))
   @assert all(x->parent(x) == R, g)

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -878,40 +878,40 @@ function (F::Generic.FreeModule)(s::Singular.svector)
 end
 
 @doc raw"""
-    jacobi_matrix(f::MPolyRingElem)
+    jacobian_matrix(f::MPolyRingElem)
 
 Given a polynomial $f$, return the Jacobian matrix ``J_f=(\partial_{x_1}f,...,\partial_{x_n}f)^T`` of $f$.
 """
-function jacobi_matrix(f::MPolyRingElem)
+function jacobian_matrix(f::MPolyRingElem)
   R = parent(f)
   n = nvars(R)
   return matrix(R, n, 1, [derivative(f, i) for i=1:n])
 end
 
 @doc raw"""
-    jacobi_ideal(f::MPolyRingElem)
+    jacobian_ideal(f::MPolyRingElem)
 
 Given a polynomial $f$, return the Jacobian ideal of $f$.
 """
-function jacobi_ideal(f::MPolyRingElem)
+function jacobian_ideal(f::MPolyRingElem)
   R = parent(f)
   n = nvars(R)
   return ideal(R, [derivative(f, i) for i=1:n])
 end
 
 @doc raw"""
-    jacobi_matrix([R::MPolyRing,] g::Vector{<:MPolyRingElem})
+    jacobian_matrix([R::MPolyRing,] g::Vector{<:MPolyRingElem})
 
 Given an array ``g=[f_1,...,f_m]`` of polynomials over the same base ring `R`,
 return the Jacobian matrix ``J=(\partial_{x_i}f_j)_{i,j}`` of ``g``.
 """
-function jacobi_matrix(g::Vector{<:MPolyRingElem})
+function jacobian_matrix(g::Vector{<:MPolyRingElem})
   @req length(g) > 0 "specify the common parent as first argument"
   R = parent(g[1])
-  return jacobi_matrix(R, g)
+  return jacobian_matrix(R, g)
 end
 
-function jacobi_matrix(R::MPolyRing, g::Vector{<:MPolyRingElem})
+function jacobian_matrix(R::MPolyRing, g::Vector{<:MPolyRingElem})
   n = nvars(R)
   @req all(x->parent(x) === R, g) "polynomials must be elements of R"
   return matrix(R, n, length(g), [derivative(x, i) for i=1:n for x = g])
@@ -1330,7 +1330,7 @@ lift(f::MPolyRingElem) = f
 function hessian_matrix(f::MPolyRingElem)
   R = parent(f)
   n = nvars(R)
-  df = jacobi_matrix(f)
+  df = jacobian_matrix(f)
   result = zero_matrix(R, n, n)
   for i in 1:n
     for j in i:n

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -1844,13 +1844,13 @@ function derivative(f::MPolyQuoLocRingElem, i::Int)
   return parent(f)(divexact(num, g), divexact(den, g), check=false)
 end
 
-function jacobi_matrix(f::MPolyQuoLocRingElem)
+function jacobian_matrix(f::MPolyQuoLocRingElem)
   L = parent(f)
   n = nvars(base_ring(L))
   return matrix(L, n, 1, [derivative(f, i) for i=1:n])
 end
 
-function jacobi_matrix(g::Vector{<:MPolyQuoLocRingElem})
+function jacobian_matrix(g::Vector{<:MPolyQuoLocRingElem})
   L = parent(g[1])
   n = nvars(base_ring(L))
   @assert all(x->parent(x) === L, g)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -527,3 +527,7 @@ Base.@deprecate_binding set_is_isomorphic_with_symmetric_group set_is_isomorphic
 Base.@deprecate_binding is_isomorphic_with_alternating_group is_isomorphic_to_alternating_group
 Base.@deprecate_binding has_is_isomorphic_with_alternating_group has_is_isomorphic_to_alternating_group
 Base.@deprecate_binding set_is_isomorphic_with_alternating_group set_is_isomorphic_to_alternating_group
+
+# Deprecated after 0.15.0
+Base.@deprecate_binding jacobi_matrix jacobian_matrix
+Base.@deprecate_binding jacobi_ideal jacobian_ideal

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -903,8 +903,8 @@ export isqrtrem
 export issubset
 export iszero
 export iterate_basis
-export jacobi_ideal
-export jacobi_matrix
+export jacobian_ideal
+export jacobian_matrix
 export jacobi_symbol
 export jennings_series, has_jennings_series, set_jennings_series
 export johnson_solid

--- a/test/Rings/mpoly.jl
+++ b/test/Rings/mpoly.jl
@@ -109,9 +109,9 @@ end
   r2 = b^2*c+c^3+2*c^2+2
   L = gens(radical(J))
 
-  @test jacobi_ideal(f) == ideal(R, [2*x, 2*y])
-  @test jacobi_matrix(f) == matrix(R, 2, 1, [2*x, 2*y])
-  @test jacobi_matrix(I) == matrix(R, 2, 2, [2*x, 4*x^3*y-y^3, 2*y, x^4-3*x*y^2])
+  @test jacobian_ideal(f) == ideal(R, [2*x, 2*y])
+  @test jacobian_matrix(f) == matrix(R, 2, 1, [2*x, 2*y])
+  @test jacobian_matrix(I) == matrix(R, 2, 2, [2*x, 4*x^3*y-y^3, 2*y, x^4-3*x*y^2])
   @test length(L) == 2
 
   # Test disabled because it could not be reliably reproduced and also 


### PR DESCRIPTION
The correct spelling in English is "Jacobian matrix", "Jacobian ideal" and "Jacobi symbol".

Added deprecations:

# Deprecated after 0.15.0
Base.@deprecate_binding jacobi_matrix jacobian_matrix
Base.@deprecate_binding jacobi_ideal jacobian_ideal