### PR TITLE
Catch empty polynomial ring in matroid code

### DIFF
--- a/src/Combinatorics/Matroids/ChowRings.jl
+++ b/src/Combinatorics/Matroids/ChowRings.jl
@@ -57,7 +57,8 @@ function chow_ring(M::Matroid; ring::Union{MPolyRing,Nothing}=nothing, extended:
             #add the variables for the simplicial generators
             var_names = [var_names; ["h_{" * join(S, ",") * "}" for S in [proper_flats;[Flats[number_flats]]]]]
         end
-        
+
+        @req length(var_names) > 0 "Chow ring is empty"
         if graded
             ring, vars = graded_polynomial_ring(QQ, var_names, cached=false)
         else

--- a/test/Combinatorics/Matroids/Chow_Ring.jl
+++ b/test/Combinatorics/Matroids/Chow_Ring.jl
@@ -17,7 +17,7 @@
     end
 
     @test_throws ErrorException chow_ring(uniform_matroid(0,2))
-    @test_throws ErrorException chow_ring(uniform_matroid(1,1))
+    @test_throws ArgumentError chow_ring(uniform_matroid(1, 1))
 
     @test nvars(base_ring(chow_ring(uniform_matroid(3,3), extended=true))) == 13
     M = matroid_from_nonbases([[1,2]],4)


### PR DESCRIPTION
The tests for the Chow ring of a matroid expect that the polynomial ring in zero variables cannot be constructed.
This is going to change with https://github.com/Nemocas/Nemo.jl/pull/1619 .
I added an explicit check now.

Just to say: with the new code in Nemo, `chow_ring(uniform_matroid(1, 1))` would return a polynomial ring in zero variables modulo the zero ideal, so I'm not even sure we have to throw an error here.