### PR TITLE
Degree for finite affine schemes

### DIFF
--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
@@ -481,8 +481,8 @@ julia> codim(Y)
   return dim(ideal(ambient_coordinate_ring(X), [zero(ambient_coordinate_ring(X))])) - dim(X)
 end
 
-@attr Int function degree(X::Spec{BRT, RT}) where {BRT<:Field, RT}
-  @req dim(X) == 0 "The affine scheme X needs to be zero-dimensional"
+@attr Int function degree(X::Spec{BRT, RT}; check::Bool=true) where {BRT<:Field, RT}
+  @check dim(X) == 0 "The affine scheme X needs to be zero-dimensional"
   return vector_space_dimension(OO(X))
 end
 

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
@@ -482,7 +482,7 @@ julia> codim(Y)
 end
 
 function degree(X::Spec{BRT, RT}; check::Bool=true) where {BRT<:Field, RT}
-  @check dim(X) == 0 "The affine scheme X needs to be zero-dimensional"
+  @check dim(X) == 0 "the affine scheme X needs to be zero-dimensional"
   get_attribute!(X, :degree) do
     return vector_space_dimension(OO(X))
   end

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
@@ -481,6 +481,10 @@ julia> codim(Y)
   return dim(ideal(ambient_coordinate_ring(X), [zero(ambient_coordinate_ring(X))])) - dim(X)
 end
 
+@attr Int function degree(X::Spec{BRT, RT}) where {BRT<:Field, RT}
+  @req dim(X) == 0 "The affine scheme X needs to be zero-dimensional"
+  return vector_space_dimension(OO(X))
+end
 
 @doc raw"""
     name(X::AbsSpec)

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
@@ -481,9 +481,11 @@ julia> codim(Y)
   return dim(ideal(ambient_coordinate_ring(X), [zero(ambient_coordinate_ring(X))])) - dim(X)
 end
 
-@attr Int function degree(X::Spec{BRT, RT}; check::Bool=true) where {BRT<:Field, RT}
+function degree(X::Spec{BRT, RT}; check::Bool=true) where {BRT<:Field, RT}
   @check dim(X) == 0 "The affine scheme X needs to be zero-dimensional"
-  return vector_space_dimension(OO(X))
+  get_attribute!(X, :degree) do
+    return vector_space_dimension(OO(X))
+  end
 end
 
 @doc raw"""

--- a/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
+++ b/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
@@ -358,3 +358,19 @@ end
   @test compose(p1, there) == compose(p2, there)
 end
 
+@testset "degree of zero-dimensional affine schemes" begin
+  R, (x,) = polynomial_ring(QQ, [:x])
+  I = ideal(R, x^2 - 1)
+  X = Spec(R)
+  Q, _ = quo(R, I)
+  Y = Spec(Q)
+  @test dim(Y) == 0
+  @test degree(Y) == 2
+
+  R, (x,y) = QQ[:x,:y]
+  I = ideal(R, [x^2 + y^2 - 1, 2x^2 + (1//2)y^2 - 1])
+  X = Spec(R)
+  Y,_ = sub(X, I)
+  @test dim(Y) == 0
+  @test degree(Y) == 4
+end


### PR DESCRIPTION
I noticed that projective schemes do have a `degree` function, but finite affine schemes don't work with those, because the dimension can't be picked up by the type system. 

I added an overload for affine schemes that's parallel to the degree function for projective schemes.
I did not add a docstring as the version of `degree` for projective schemes didn't have one either (yet).