### PR TITLE
fix some problems with group automorphisms

### DIFF
--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -860,8 +860,7 @@ function quo(G::T, N::T) where T <: GAPGroup
   S = elem_type(G)
   S1 = _get_type(cod)
   codom = S1(cod)
-  mp_julia = __create_fun(mp, codom, S)
-  return codom, hom(G, codom, mp_julia)
+  return codom, GAPGroupHomomorphism(G, codom, mp)
 end
 
 function quo(::Type{Q}, G::T, N::T) where {Q <: GAPGroup, T <: GAPGroup}

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -660,6 +660,15 @@ end
    @test B == A
    @test B !== A
    @test B.X === A.X
+
+   F = free_group(2)
+   x, y = gens(F)
+   Q, = quo(F, [x^-3*y^-3*x^-1*y*x^-2,
+                x*y^-1*x^-1*y*x^-1*y^-1*x^3*y^-1,
+                x*y^-1*x^-1*y^2*x^-2*y^-1*x^2])
+   A = automorphism_group(Q)
+   q = gen(Q, 1)
+   @test all(a -> a(preimage(a, q)) == q, collect(A))
 end
 
 @testset "Composition of mappings" begin


### PR DESCRIPTION
- provide `preimage` for `AutomorphismGroupElem`, analogous to `preimage` for `GAPGroupHomomorphism` (addresses #3171)
- change the construction of the underlying GAP map of group automorphisms (addresses #3167)