### PR TITLE
Initial ideals and marked Groebner bases from `TropicalGeometry/groebner_fan.jl/groebner_fan` 

### DIFF
--- a/src/TropicalGeometry/groebner_fan.jl
+++ b/src/TropicalGeometry/groebner_fan.jl
@@ -397,7 +397,7 @@ end
 
 
 @doc raw"""
-    groebner_fan(I::MPolyIdeal; return_groebner_bases::Bool=false, return_orderings::Bool=false, verbose_level::Int=0)
+    groebner_fan(I::MPolyIdeal; return_groebner_bases::Bool=false, return_orderings::Bool=false, return_initial_ideals::Bool=false, marked_groebner_bases::Bool=false, verbose_level::Int=0)
 
 Return a `PolyhedralFan` representing the Groebner fan of `I`, where is a multivariate polynomial ideal over a field.
 
@@ -407,7 +407,11 @@ If `I` is not weighted homogeneous with respect to a positive weight vector, the
 
 If `return_groebner_bases==true`, also return a dictionary whose keys are interior points of the maximal cones and whose values are the Groebner bases for those cones.  Their union will be a universal Groebner basis.
 
+If additionally `marked_groebner_bases==true`, the values of above dictionary are the Groebner bases for those cones together with the leading term for each generator.  
+
 If `return_orderings==true`, also return a dictionary whose keys are interior points of the maximal Groebner cones and whose values are monomial orderings for those cones.  These orderings are suboptimal and hence it is generally recommended to create new orderings with the interior points.  However they do contain information on how the fan was traversed.
+
+If `return_initial_ideals==true`, also return a dictionary whose keys are interior points of the maximal cones and whose values are the initial ideals for those cones.
 
 # Examples
 ```jldoctest

--- a/src/TropicalGeometry/groebner_fan.jl
+++ b/src/TropicalGeometry/groebner_fan.jl
@@ -429,7 +429,7 @@ julia> SigmaI,gbs,ords = groebner_fan(I,return_groebner_bases=true,return_orderi
 ```
 """
 
-function groebner_fan(I::MPolyIdeal; return_groebner_bases::Bool=false, return_orderings::Bool=false, verbose_level::Int=0)
+function groebner_fan(I::MPolyIdeal; return_groebner_bases::Bool=false, return_orderings::Bool=false, return_initial_ideals::Bool=false, verbose_level::Int=0)
     ###
     # Preparation:
     #   Test whether the ideal is weighted homogeneous with respect to a positive weight vector
@@ -521,6 +521,10 @@ function groebner_fan(I::MPolyIdeal; return_groebner_bases::Bool=false, return_o
     if return_orderings == true
         orderings = Dict([(pt,ord) for (_,ord,_,pt) in finishedList])
         push!(output,orderings)
+    end
+    if return_initial_ideals == true
+        initial_ideals = Dict([(pt,leading_ideal(I;ordering=ord)) for (_,ord,_,pt) in finishedList])
+        push!(output,initial_ideals)
     end
     return output
 end

--- a/src/TropicalGeometry/groebner_fan.jl
+++ b/src/TropicalGeometry/groebner_fan.jl
@@ -401,7 +401,6 @@ julia> SigmaI,gbs,ords = groebner_fan(I,return_groebner_bases=true,return_orderi
 
 ```
 """
-
 function groebner_fan(I::MPolyIdeal; 
                       return_interior_points::Bool=false,
                       return_groebner_bases::Bool=false, 

--- a/src/TropicalGeometry/groebner_fan.jl
+++ b/src/TropicalGeometry/groebner_fan.jl
@@ -370,13 +370,17 @@ If `verbose_level` is positive, also print how many cones have been computed dur
 
 If `I` is not weighted homogeneous with respect to a positive weight vector, the Groebner fan will be restricted to the positive orthant.  Otherwise, the Groebner fan will span the entire space and have a non-trivial lineality space.
 
-If `return_groebner_bases==true`, also return a dictionary whose keys are interior points of the maximal cones and whose values are the Groebner bases for those cones.  Their union will be a universal Groebner basis.
+If any of `return_interior_points`, `return_groebner_bases`, `return_orderings` or `return_initial_ideals`
+is set to true, also return a list with the corresponding information for each cone.
 
-If additionally `marked_groebner_bases==true`, the values of above dictionary are the Groebner bases for those cones together with the leading term for each generator.  
+If `return_interior_points==true`, this includes the interior points of the maximal cones.
 
-If `return_orderings==true`, also return a dictionary whose keys are interior points of the maximal Groebner cones and whose values are monomial orderings for those cones.  These orderings are suboptimal and hence it is generally recommended to create new orderings with the interior points.  However they do contain information on how the fan was traversed.
+If `return_groebner_bases==true`, above list includes the Groebner bases for those cones.  Their union will be a universal Groebner basis.
+If additionally `marked_groebner_bases==true`, the values the Groebner bases for those cones together with the leading term for each generator.  
 
-If `return_initial_ideals==true`, also return a dictionary whose keys are interior points of the maximal cones and whose values are the initial ideals for those cones.
+If `return_orderings==true`, above list includes the monomial orderings for those cones.  These orderings are suboptimal and hence it is generally recommended to create new orderings with the interior points.  However they do contain information on how the fan was traversed.
+
+If `return_initial_ideals==true`, above list includes the initial ideals for those cones.
 
 # Examples
 ```jldoctest

--- a/src/TropicalGeometry/groebner_fan.jl
+++ b/src/TropicalGeometry/groebner_fan.jl
@@ -429,7 +429,7 @@ julia> SigmaI,gbs,ords = groebner_fan(I,return_groebner_bases=true,return_orderi
 ```
 """
 
-function groebner_fan(I::MPolyIdeal; return_groebner_bases::Bool=false, return_orderings::Bool=false, return_initial_ideals::Bool=false, verbose_level::Int=0)
+function groebner_fan(I::MPolyIdeal; return_groebner_bases::Bool=false, return_orderings::Bool=false, return_initial_ideals::Bool=false, marked_groebner_bases::Bool=false, verbose_level::Int=0)
     ###
     # Preparation:
     #   Test whether the ideal is weighted homogeneous with respect to a positive weight vector
@@ -507,7 +507,7 @@ function groebner_fan(I::MPolyIdeal; return_groebner_bases::Bool=false, return_o
     ###
     # construct polyhedral fan and return it if nothing else was required
     Sigma = polyhedral_fan_from_cones([entry[3] for entry in finishedList])
-    if !return_groebner_bases && !return_orderings
+    if !return_groebner_bases && !return_orderings && !return_initial_ideals
         return Sigma
     end
 
@@ -515,7 +515,13 @@ function groebner_fan(I::MPolyIdeal; return_groebner_bases::Bool=false, return_o
     output = []
     push!(output,Sigma)
     if return_groebner_bases == true
-        groebner_bases = Dict([(pt,GB) for (GB,_,_,pt) in finishedList])
+        if marked_groebner_bases == true
+            groebner_bases = Dict([
+                (pt,[(f,leading_term(f;ordering=ord)) for f in GB]) for (GB,ord,_,pt) in finishedList
+            ])
+        else
+            groebner_bases = Dict([(pt,GB) for (GB,_,_,pt) in finishedList])
+        end
         push!(output,groebner_bases)
     end
     if return_orderings == true

--- a/src/TropicalGeometry/groebner_fan.jl
+++ b/src/TropicalGeometry/groebner_fan.jl
@@ -393,11 +393,10 @@ ideal(x1, x2 + x3)
 julia> SigmaI = groebner_fan(I)
 Polyhedral fan in ambient dimension 3
 
-julia> SigmaI,gbs,ords = groebner_fan(I,return_groebner_bases=true,return_orderings=true)
-3-element Vector{Any}:
+julia> SigmaI,output = groebner_fan(I,return_groebner_bases=true,return_orderings=true)
+2-element Vector{Any}:
  Polyhedral fan in ambient dimension 3
- Dict{Vector{ZZRingElem}, Vector{QQMPolyRingElem}}([0, -1, 0] => [x1, x2 + x3], [0, 0, -1] => [x2 + x3, x1])
- Dict{Vector{ZZRingElem}, MonomialOrdering{QQMPolyRing}}([0, -1, 0] => matrix_ordering([x1, x2, x3], [1 1 1])*matrix_ordering([x1, x2, x3], [0 0 0])*matrix_ordering([x1, x2, x3], [0 -1 1])*invlex([x1, x2, x3]), [0, 0, -1] => degrevlex([x1, x2, x3]))
+ Any[Any[QQMPolyRingElem[x1, x2 + x3], matrix_ordering([x1, x2, x3], [1 1 1])*matrix_ordering([x1, x2, x3], [0 0 0])*matrix_ordering([x1, x2, x3], [0 -1 1])*invlex([x1, x2, x3])], Any[QQMPolyRingElem[x2 + x3, x1], degrevlex([x1, x2, x3])]]
 
 ```
 """

--- a/src/TropicalGeometry/groebner_fan.jl
+++ b/src/TropicalGeometry/groebner_fan.jl
@@ -488,24 +488,29 @@ function groebner_fan(I::MPolyIdeal;
 
     # otherwise return what was required
     output = []
-    push!(output,Sigma)
-    if return_groebner_bases == true
-        if marked_groebner_bases == true
-            groebner_bases = Dict([
-                (pt,[(f,leading_term(f;ordering=ord)) for f in GB]) for (GB,ord,_,pt) in finishedList
-            ])
-        else
-            groebner_bases = Dict([(pt,GB) for (GB,_,_,pt) in finishedList])
+
+    for (GB,ord,_,pt) in finishedList
+        output_C = []
+
+        if return_interior_points == true
+            push!(output_C,pt)
         end
-        push!(output,groebner_bases)
+        if return_groebner_bases == true
+            if marked_groebner_bases == true
+                push!(output_C,(f,leading_term(f;ordering=ord)))
+            else
+                push!(output_C,GB)
+            end
+        end
+        if return_orderings == true
+            push!(output_C,ord)
+        end
+        if return_initial_ideals == true
+            initial_ideal = leading_ideal(I;ordering=ord)
+            push!(output_C,initial_ideal)
+        end
+
+        push!(output, output_C)
     end
-    if return_orderings == true
-        orderings = Dict([(pt,ord) for (_,ord,_,pt) in finishedList])
-        push!(output,orderings)
-    end
-    if return_initial_ideals == true
-        initial_ideals = Dict([(pt,leading_ideal(I;ordering=ord)) for (_,ord,_,pt) in finishedList])
-        push!(output,initial_ideals)
-    end
-    return output
+    return [Sigma, output]
 end

--- a/src/TropicalGeometry/groebner_fan.jl
+++ b/src/TropicalGeometry/groebner_fan.jl
@@ -483,7 +483,7 @@ function groebner_fan(I::MPolyIdeal;
     # construct polyhedral fan and return it if nothing else was required
     Sigma = polyhedral_fan(getindex.(finishedList,3);non_redundant=true)
     if !return_interior_points && !return_groebner_bases && !return_orderings && !return_initial_ideals
-        return Sigma, getindex.(finishedList,3)
+        return Sigma
     end
 
     # otherwise return what was required


### PR DESCRIPTION
While working with `groebner_fan`, I found myself computing the corresponding initial ideals very often. That's why I thought it would be convenient to have a parameter `return_initial_ideals` resulting in another dictionary mapping interior points of cones to the initial ideals (like the other two optional parameters).

Also, I added an optional parameter `marked_grobener_bases` that modifies the dictionary of Groebner bases that is already returned to instead give pairs of generators and initial term. In the package `gfanInterface` for Macaulay2, this is called a marked polynomial list, hence the name for this parameter.