### PR TITLE
let `right_cosets` return a G-set

### DIFF
--- a/docs/src/DeveloperDocumentation/printing_details.md
+++ b/docs/src/DeveloperDocumentation/printing_details.md
@@ -187,18 +187,18 @@ struct A{T}
 end
 
 function Base.show(io::IO, a::A)
-  io = AbstractAlgebra.pretty(io)
+  io = pretty(io)
   println(io, "Something of type A")
-  print(io, AbstractAlgebra.Indent(), "over ", AbstractAlgebra.Lowercase(), a.x)
-  print(io, AbstractAlgebra.Dedent()) # don't forget to undo the indentation!
+  print(io, Indent(), "over ", Lowercase(), a.x)
+  print(io, Dedent()) # don't forget to undo the indentation!
 end
 
 struct B
 end
 
 function Base.show(io::IO, b::B)
-  io = AbstractAlgebra.pretty(io)
-  print(io, AbstractAlgebra.LowercaseOff(), "Hilbert thing")
+  io = pretty(io)
+  print(io, LowercaseOff(), "Hilbert thing")
 end
 ```
 
@@ -233,7 +233,7 @@ julia> struct C{T}
 julia> function Base.show(io::IO, c::C{T}) where T
        x = c.x
        n = length(x)
-       print(io, "Something with ", AbstractAlgebra.ItemQuantity(n, "element"), " of type $T")
+       print(io, "Something with ", ItemQuantity(n, "element"), " of type $T")
        end
 ```
 

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -95,9 +95,9 @@ julia> H = symmetric_group(3)
 Sym(3)
 
 julia> gH = left_coset(H, g)
-Left coset of permutation group of degree 3 and order 6
+Left coset of Sym(3)
   with representative (1,3)(2,4,5)
-  in permutation group of degree 5 and order 120
+  in Sym(5)
 ```
 """
 function left_coset(H::GAPGroup, g::GAPGroupElem)
@@ -164,9 +164,9 @@ julia> H = symmetric_group(3)
 Sym(3)
 
 julia> gH = left_coset(H,g)
-Left coset of permutation group of degree 3 and order 6
+Left coset of Sym(3)
   with representative (1,3)(2,4,5)
-  in permutation group of degree 5 and order 120
+  in Sym(5)
 
 julia> acting_domain(gH)
 Sym(3)
@@ -191,9 +191,9 @@ julia> H = symmetric_group(3)
 Sym(3)
 
 julia> gH = left_coset(H, g)
-Left coset of permutation group of degree 3 and order 6
+Left coset of Sym(3)
   with representative (1,3)(2,4,5)
-  in permutation group of degree 5 and order 120
+  in Sym(5)
 
 julia> representative(gH)
 (1,3)(2,4,5)
@@ -220,9 +220,9 @@ julia> g = perm(G,[3,4,1,5,2])
 (1,3)(2,4,5)
 
 julia> gH = left_coset(H, g)
-Left coset of permutation group of degree 4 and order 24
+Left coset of Sym(4)
   with representative (1,3)(2,4,5)
-  in permutation group of degree 5 and order 120
+  in Sym(5)
 
 julia> is_bicoset(gH)
 false
@@ -231,9 +231,9 @@ julia> f = perm(G,[2,1,4,3,5])
 (1,2)(3,4)
 
 julia> fH = left_coset(H, f)
-Left coset of permutation group of degree 4 and order 24
+Left coset of Sym(4)
   with representative (1,2)(3,4)
-  in permutation group of degree 5 and order 120
+  in Sym(5)
 
 julia> is_bicoset(fH)
 true
@@ -258,15 +258,15 @@ Sym(3)
 
 julia> rc = right_cosets(G, H)
 Right cosets of
-  permutation group of degree 3 and order 6 in
-  permutation group of degree 4 and order 24
+  Sym(3) in
+  Sym(4)
 
 julia> collect(rc)
 4-element Vector{GroupCoset{PermGroup, PermGroupElem}}:
- Right coset of permutation group with representative ()
- Right coset of permutation group with representative (1,4)
- Right coset of permutation group with representative (1,4,2)
- Right coset of permutation group with representative (1,4,3)
+ Right coset of Sym(3) with representative ()
+ Right coset of Sym(3) with representative (1,4)
+ Right coset of Sym(3) with representative (1,4,2)
+ Right coset of Sym(3) with representative (1,4,3)
 ```
 """
 function right_cosets(G::T, H::T; check::Bool=true) where T<: GAPGroup
@@ -290,10 +290,10 @@ Sym(3)
 
 julia> left_cosets(G, H)
 4-element Vector{GroupCoset{PermGroup, PermGroupElem}}:
- Left coset of permutation group with representative ()
- Left coset of permutation group with representative (1,4)
- Left coset of permutation group with representative (1,2,4)
- Left coset of permutation group with representative (1,3,4)
+ Left coset of Sym(3) with representative ()
+ Left coset of Sym(3) with representative (1,4)
+ Left coset of Sym(3) with representative (1,2,4)
+ Left coset of Sym(3) with representative (1,3,4)
 ```
 """
 function left_cosets(G::T, H::T; check::Bool=true) where T<: GAPGroup
@@ -376,13 +376,8 @@ Sym(3)
 
 julia> T = right_transversal(G, H)
 Right transversal of length 4 of
-<<<<<<< HEAD
   Sym(3) in
   Sym(4)
-=======
-  permutation group of degree 3 and order 6 in
-  permutation group of degree 4 and order 24
->>>>>>> address comments
 
 julia> collect(T)
 4-element Vector{PermGroupElem}:
@@ -418,13 +413,8 @@ Sym(3)
 
 julia> T = left_transversal(G, H)
 Left transversal of length 4 of
-<<<<<<< HEAD
   Sym(3) in
   Sym(4)
-=======
-  permutation group of degree 3 and order 6 in
-  permutation group of degree 4 and order 24
->>>>>>> address comments
 
 julia> collect(T)
 4-element Vector{PermGroupElem}:

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -28,11 +28,11 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", x::GroupCoset)
   side = x.side === :left ? "Left" : "Right"
-  println(io, "$side coset of ", x.H)
-  io = AbstractAlgebra.pretty(io)
+  io = pretty(io)
+  println(io, "$side coset of ", Lowercase(), x.H)
   print(io, Indent())
   println(io, "with representative ", x.repr)
-  print(io, "in ", x.G)
+  print(io, "in ", Lowercase(), x.G)
   print(io, Dedent())
 end
 
@@ -43,7 +43,7 @@ function Base.show(io::IO, x::GroupCoset)
   else
     print(io, "$side coset of ")
     io = pretty(io)
-    print(IOContext(io, :supercompact => true), x.H, " with representative ", x.repr)
+    print(IOContext(io, :supercompact => true), Lowercase(), x.H, " with representative ", x.repr)
   end
 end
 
@@ -95,9 +95,9 @@ julia> H = symmetric_group(3)
 Sym(3)
 
 julia> gH = left_coset(H, g)
-Left coset of Permutation group of degree 3 and order 6
+Left coset of permutation group of degree 3 and order 6
   with representative (1,3)(2,4,5)
-  in Permutation group of degree 5 and order 120
+  in permutation group of degree 5 and order 120
 ```
 """
 function left_coset(H::GAPGroup, g::GAPGroupElem)
@@ -164,9 +164,9 @@ julia> H = symmetric_group(3)
 Sym(3)
 
 julia> gH = left_coset(H,g)
-Left coset of Permutation group of degree 3 and order 6
+Left coset of permutation group of degree 3 and order 6
   with representative (1,3)(2,4,5)
-  in Permutation group of degree 5 and order 120
+  in permutation group of degree 5 and order 120
 
 julia> acting_domain(gH)
 Sym(3)
@@ -191,9 +191,9 @@ julia> H = symmetric_group(3)
 Sym(3)
 
 julia> gH = left_coset(H, g)
-Left coset of Permutation group of degree 3 and order 6
+Left coset of permutation group of degree 3 and order 6
   with representative (1,3)(2,4,5)
-  in Permutation group of degree 5 and order 120
+  in permutation group of degree 5 and order 120
 
 julia> representative(gH)
 (1,3)(2,4,5)
@@ -220,9 +220,9 @@ julia> g = perm(G,[3,4,1,5,2])
 (1,3)(2,4,5)
 
 julia> gH = left_coset(H, g)
-Left coset of Permutation group of degree 4 and order 24
+Left coset of permutation group of degree 4 and order 24
   with representative (1,3)(2,4,5)
-  in Permutation group of degree 5 and order 120
+  in permutation group of degree 5 and order 120
 
 julia> is_bicoset(gH)
 false
@@ -231,9 +231,9 @@ julia> f = perm(G,[2,1,4,3,5])
 (1,2)(3,4)
 
 julia> fH = left_coset(H, f)
-Left coset of Permutation group of degree 4 and order 24
+Left coset of permutation group of degree 4 and order 24
   with representative (1,2)(3,4)
-  in Permutation group of degree 5 and order 120
+  in permutation group of degree 5 and order 120
 
 julia> is_bicoset(fH)
 true
@@ -258,15 +258,15 @@ Sym(3)
 
 julia> rc = right_cosets(G, H)
 Right cosets of
-  Permutation group of degree 3 and order 6 in
-  Permutation group of degree 4 and order 24
+  permutation group of degree 3 and order 6 in
+  permutation group of degree 4 and order 24
 
 julia> collect(rc)
 4-element Vector{GroupCoset{PermGroup, PermGroupElem}}:
- Right coset of Permutation group with representative ()
- Right coset of Permutation group with representative (1,4)
- Right coset of Permutation group with representative (1,4,2)
- Right coset of Permutation group with representative (1,4,3)
+ Right coset of permutation group with representative ()
+ Right coset of permutation group with representative (1,4)
+ Right coset of permutation group with representative (1,4,2)
+ Right coset of permutation group with representative (1,4,3)
 ```
 """
 function right_cosets(G::T, H::T; check::Bool=true) where T<: GAPGroup
@@ -290,10 +290,10 @@ Sym(3)
 
 julia> left_cosets(G, H)
 4-element Vector{GroupCoset{PermGroup, PermGroupElem}}:
- Left coset of Permutation group with representative ()
- Left coset of Permutation group with representative (1,4)
- Left coset of Permutation group with representative (1,2,4)
- Left coset of Permutation group with representative (1,3,4)
+ Left coset of permutation group with representative ()
+ Left coset of permutation group with representative (1,4)
+ Left coset of permutation group with representative (1,2,4)
+ Left coset of permutation group with representative (1,3,4)
 ```
 """
 function left_cosets(G::T, H::T; check::Bool=true) where T<: GAPGroup
@@ -316,10 +316,10 @@ end
 function Base.show(io::IO, ::MIME"text/plain", x::SubgroupTransversal)
   side = x.side === :left ? "Left" : "Right"
   println(io, "$side transversal of length $(length(x)) of")
-  io = AbstractAlgebra.pretty(io)
+  io = pretty(io)
   print(io, Indent())
-  println(io, x.H, " in")
-  print(io, x.G)
+  println(io, Lowercase(), x.H, " in")
+  print(io, Lowercase(), x.G)
   print(io, Dedent())
 end
 
@@ -330,7 +330,7 @@ function Base.show(io::IO, x::SubgroupTransversal)
   else
     print(io, "$side transversal of ")
     io = pretty(io)
-    print(IOContext(io, :supercompact => true), x.H, " in ", x.G)
+    print(IOContext(io, :supercompact => true), Lowercase(), x.H, " in ", Lowercase(), x.G)
   end
 end
 
@@ -376,8 +376,13 @@ Sym(3)
 
 julia> T = right_transversal(G, H)
 Right transversal of length 4 of
+<<<<<<< HEAD
   Sym(3) in
   Sym(4)
+=======
+  permutation group of degree 3 and order 6 in
+  permutation group of degree 4 and order 24
+>>>>>>> address comments
 
 julia> collect(T)
 4-element Vector{PermGroupElem}:
@@ -413,8 +418,13 @@ Sym(3)
 
 julia> T = left_transversal(G, H)
 Left transversal of length 4 of
+<<<<<<< HEAD
   Sym(3) in
   Sym(4)
+=======
+  permutation group of degree 3 and order 6 in
+  permutation group of degree 4 and order 24
+>>>>>>> address comments
 
 julia> collect(T)
 4-element Vector{PermGroupElem}:

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -26,6 +26,27 @@ function ==(x::GroupCoset, y::GroupCoset)
    return x.X == y.X && x.side == y.side
 end
 
+function Base.show(io::IO, ::MIME"text/plain", x::GroupCoset)
+  side = x.side === :left ? "Left" : "Right"
+  println(io, "$side coset of ", x.H)
+  io = AbstractAlgebra.pretty(io)
+  print(io, Indent())
+  println(io, "with representative ", x.repr)
+  print(io, "in ", x.G)
+  print(io, Dedent())
+end
+
+function Base.show(io::IO, x::GroupCoset)
+  side = x.side === :left ? "Left" : "Right"
+  if get(io, :supercompact, false)
+    print(io, "$side coset of a group")
+  else
+    print(io, "$side coset of ")
+    io = pretty(io)
+    print(IOContext(io, :supercompact => true), x.H, " with representative ", x.repr)
+  end
+end
+
 
 """
     right_coset(H::Group, g::GAPGroupElem)
@@ -43,6 +64,11 @@ julia> g = perm(G,[3,4,1,5,2])
 
 julia> H = symmetric_group(3)
 Sym(3)
+
+julia> right_coset(H, g)
+Right coset of Sym(3)
+  with representative (1,3)(2,4,5)
+  in Sym(5)
 ```
 """
 function right_coset(H::GAPGroup, g::GAPGroupElem)
@@ -68,8 +94,10 @@ julia> g = perm([3,4,1,5,2])
 julia> H = symmetric_group(3)
 Sym(3)
 
-julia> gH = left_coset(H,g)
-Left coset   (1,3)(2,4,5) * Sym( [ 1 .. 3 ] )
+julia> gH = left_coset(H, g)
+Left coset of Permutation group of degree 3 and order 6
+  with representative (1,3)(2,4,5)
+  in Permutation group of degree 5 and order 120
 ```
 """
 function left_coset(H::GAPGroup, g::GAPGroupElem)
@@ -78,16 +106,6 @@ function left_coset(H::GAPGroup, g::GAPGroupElem)
    return _group_coset(parent(g), H, g, :left, GAP.Globals.RightCoset(GAP.Globals.ConjugateSubgroup(H.X,GAP.Globals.Inverse(g.X)),g.X))
 end
 
-function show(io::IO, x::GroupCoset)
-   a = String(GAPWrap.StringViewObj(x.H.X))
-   b = String(GAPWrap.StringViewObj(x.repr.X))
-   if x.side == :right
-      print(io, "Right coset   $a * $b")
-   else
-      print(io, "Left coset   $b * $a")
-   end
-   return nothing
-end
 
 """
     is_left(c::GroupCoset)
@@ -146,7 +164,9 @@ julia> H = symmetric_group(3)
 Sym(3)
 
 julia> gH = left_coset(H,g)
-Left coset   (1,3)(2,4,5) * Sym( [ 1 .. 3 ] )
+Left coset of Permutation group of degree 3 and order 6
+  with representative (1,3)(2,4,5)
+  in Permutation group of degree 5 and order 120
 
 julia> acting_domain(gH)
 Sym(3)
@@ -170,8 +190,10 @@ julia> g = perm(G,[3,4,1,5,2])
 julia> H = symmetric_group(3)
 Sym(3)
 
-julia> gH = left_coset(H,g)
-Left coset   (1,3)(2,4,5) * Sym( [ 1 .. 3 ] )
+julia> gH = left_coset(H, g)
+Left coset of Permutation group of degree 3 and order 6
+  with representative (1,3)(2,4,5)
+  in Permutation group of degree 5 and order 120
 
 julia> representative(gH)
 (1,3)(2,4,5)
@@ -197,8 +219,10 @@ Sym(4)
 julia> g = perm(G,[3,4,1,5,2])
 (1,3)(2,4,5)
 
-julia> gH = left_coset(H,g)
-Left coset   (1,3)(2,4,5) * Sym( [ 1 .. 4 ] )
+julia> gH = left_coset(H, g)
+Left coset of Permutation group of degree 4 and order 24
+  with representative (1,3)(2,4,5)
+  in Permutation group of degree 5 and order 120
 
 julia> is_bicoset(gH)
 false
@@ -206,8 +230,10 @@ false
 julia> f = perm(G,[2,1,4,3,5])
 (1,2)(3,4)
 
-julia> fH = left_coset(H,f)
-Left coset   (1,2)(3,4) * Sym( [ 1 .. 4 ] )
+julia> fH = left_coset(H, f)
+Left coset of Permutation group of degree 4 and order 24
+  with representative (1,2)(3,4)
+  in Permutation group of degree 5 and order 120
 
 julia> is_bicoset(fH)
 true
@@ -218,7 +244,7 @@ is_bicoset(C::GroupCoset) = GAPWrap.IsBiCoset(C.X)
 """
     right_cosets(G::T, H::T; check::Bool=true) where T<: GAPGroup
 
-Return the vector of the right cosets of `H` in `G`.
+Return the G-set that describes the right cosets of `H` in `G`.
 
 If `check == false`, do not check whether `H` is a subgroup of `G`.
 
@@ -230,17 +256,21 @@ Sym(4)
 julia> H = symmetric_group(3)
 Sym(3)
 
-julia> right_cosets(G,H)
+julia> rc = right_cosets(G, H)
+Right cosets of
+  Permutation group of degree 3 and order 6 in
+  Permutation group of degree 4 and order 24
+
+julia> collect(rc)
 4-element Vector{GroupCoset{PermGroup, PermGroupElem}}:
- Right coset   Sym( [ 1 .. 3 ] ) * ()
- Right coset   Sym( [ 1 .. 3 ] ) * (1,4)
- Right coset   Sym( [ 1 .. 3 ] ) * (1,4,2)
- Right coset   Sym( [ 1 .. 3 ] ) * (1,4,3)
+ Right coset of Permutation group with representative ()
+ Right coset of Permutation group with representative (1,4)
+ Right coset of Permutation group with representative (1,4,2)
+ Right coset of Permutation group with representative (1,4,3)
 ```
 """
 function right_cosets(G::T, H::T; check::Bool=true) where T<: GAPGroup
-  t = right_transversal(G, H, check = check)
-  return [right_coset(H, x) for x in t]
+  return GSetByRightTransversal(G, H, check = check)
 end
 
 """
@@ -258,12 +288,12 @@ Sym(4)
 julia> H = symmetric_group(3)
 Sym(3)
 
-julia> left_cosets(G,H)
+julia> left_cosets(G, H)
 4-element Vector{GroupCoset{PermGroup, PermGroupElem}}:
- Left coset   () * Sym( [ 1 .. 3 ] )
- Left coset   (1,4) * Sym( [ 1 .. 3 ] )
- Left coset   (1,2,4) * Sym( [ 1 .. 3 ] )
- Left coset   (1,3,4) * Sym( [ 1 .. 3 ] )
+ Left coset of Permutation group with representative ()
+ Left coset of Permutation group with representative (1,4)
+ Left coset of Permutation group with representative (1,2,4)
+ Left coset of Permutation group with representative (1,3,4)
 ```
 """
 function left_cosets(G::T, H::T; check::Bool=true) where T<: GAPGroup

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -48,10 +48,28 @@ abstract type GSet{T} end
 end
 #TODO: How can I specify that `seeds` should be an iterable object?
 
+function Base.show(io::IO, ::MIME"text/plain", x::GSetByElements)
+  println(io, "G-set of")
+  io = AbstractAlgebra.pretty(io)
+  print(io, Indent())
+  println(io, x.group)
+  print(io, "with seeds ", x.seeds)
+  print(io, Dedent())
+end
+
+function Base.show(io::IO, x::GSetByElements)
+  if get(io, :supercompact, false)
+    print(io, "G-set")
+  else
+    print(io, "G-set of ")
+    io = pretty(io)
+    print(IOContext(io, :supercompact => true), x.group, " with seeds ", x.seeds)
+  end
+end
+
 # TODO: document `acting_group`, `action_function`
 acting_group(Omega::GSetByElements) = Omega.group
 action_function(Omega::GSetByElements) = Omega.action_function
-
 
 #############################################################################
 ##
@@ -90,7 +108,6 @@ julia> length(gset(G, [[1, 2]]))  # action on ordered pairs
 
 julia> length(gset(G, on_sets, [[1, 2]]))  # action on unordered pairs
 6
-
 ```
 """
 function gset(G::GAPGroup, fun::Function, seeds; closed::Bool = false)
@@ -171,7 +188,7 @@ end
 #TODO: Compute membership without writing down all elements,
 #      using what is called `RepresentativeAction` in GAP.
 
-function Base.in(omega, Omega::GSet)
+function Base.in(omega, Omega::GSetByElements)
     omega in Omega.seeds && return true
     return omega in elements(Omega)
 end
@@ -225,6 +242,8 @@ end
 
 Base.in(omega::ElementOfGSet, Omega::GSet) = Base.in(omega.obj, Omega)
 
+Base.in(omega::ElementOfGSet, Omega::GSetByElements) = Base.in(omega.obj, Omega)
+
 orbit(omega::ElementOfGSet) = orbit(omega.gset, omega.obj)
 
 
@@ -262,7 +281,6 @@ julia> length(orbit(G, [1, 2]))
 
 julia> length(orbit(G, on_sets, [1, 2]))
 6
-
 ```
 """
 orbit(G::GAPGroup, omega) = gset_by_type(G, [omega], typeof(omega))
@@ -270,7 +288,7 @@ orbit(G::GAPGroup, omega) = gset_by_type(G, [omega], typeof(omega))
 orbit(G::GAPGroup, fun::Function, omega) = GSetByElements(G, fun, [omega])
 
 """
-    orbit(Omega::GSet, omega::T) where T
+    orbit(Omega::GSet, omega)
 
 Return the G-set that consists of the elements `fun(omega, g)` where
 `g` is in the group of `Omega` and `fun` is the underlying action of `Omega`.
@@ -284,7 +302,6 @@ julia> Omega = gset(G, [1, 5]);
 
 julia> length(orbit(Omega, 1))
 4
-
 ```
 """
 function orbit(Omega::GSetByElements{<:GAPGroup}, omega::T) where T
@@ -306,7 +323,7 @@ end
 
 # simpleminded alternative directly in Julia
 # In fact, '<:GAPGroup' is not used at all in this function.
-function orbit_via_Julia(Omega::GSetByElements{<:GAPGroup}, omega)
+function orbit_via_Julia(Omega::GSet{<:GAPGroup}, omega)
     acts = gens(acting_group(Omega))
     orbarray = [omega]
     orb = Set(orbarray)
@@ -348,7 +365,6 @@ julia> map(collect, orbs)
 2-element Vector{Vector{Int64}}:
  [1, 2, 3, 4]
  [5, 6]
-
 ```
 """
 @attr Vector{GSetByElements{TG}} function orbits(Omega::T) where T <: GSetByElements{TG} where TG <: GAPGroup
@@ -378,7 +394,6 @@ julia> map(length, orbs)
 2-element Vector{Int64}:
  4
  2
-
 ```
 """
 @attr Vector{GSetByElements{PermGroup}} orbits(G::PermGroup) = orbits(gset(G))
@@ -418,7 +433,6 @@ julia> x = gen(G, 1)
 
 julia> permutation(Omega, x)
 (1,2,4,7)(3,6,9,12)(5,8,10,11)
-
 ```
 """
 function permutation(Omega::GSetByElements{T}, g::GAPGroupElem) where T<:GAPGroup
@@ -433,6 +447,119 @@ function permutation(Omega::GSetByElements{T}, g::GAPGroupElem) where T<:GAPGrou
       return symmetric_group(length(Omega))
     end
     return group_element(sym, pi)
+end
+
+
+#############################################################################
+##
+##  GSetByRightTransversal:
+##  a G-set that describes the right cosets of a subgroup $H$ in a group $G$,
+##  on which $G$ acts by multiplication from the right.
+##  The G-set stores just a right transversal, not the coset objects;
+##  fields are
+##  - the group that acts, of type `T`, with elements of type `E`,
+##  - the subgroup whose cosets are the elements, of type `S`,
+##  - the right transversal, of type `SubgroupTransversal{T, S, E}`,
+##  - the dictionary used to store attributes (orbits, elements, ...)
+
+@attributes mutable struct GSetByRightTransversal{T, S, E} <: GSet{T}
+    group::T
+    subgroup::S
+    transversal::SubgroupTransversal{T, S, E}
+
+    function GSetByRightTransversal(G::T, H::S; check::Bool = true) where {T<:GAPGroup, S<:GAPGroup}
+        check && @req is_subgroup(H, G)[1] "H must be a subgroup of G"
+        E = eltype(G)
+        return new{T, S, E}(G, H, right_transversal(G, H), Dict{Symbol,Any}())
+    end
+end
+
+function Base.show(io::IO, ::MIME"text/plain", x::GSetByRightTransversal)
+  println(io, "Right cosets of")
+  io = AbstractAlgebra.pretty(io)
+  print(io, Indent())
+  println(io, x.subgroup, " in")
+  print(io, x.group)
+  print(io, Dedent())
+end
+
+function Base.show(io::IO, x::GSetByRightTransversal)
+  if get(io, :supercompact, false)
+    print(io, "Right cosets of groups")
+  else
+    print(io, "Right cosets of ")
+    io = pretty(io)
+    print(IOContext(io, :supercompact => true), x.subgroup, " in ", x.group)
+  end
+end
+
+acting_group(Omega::GSetByRightTransversal) = Omega.group
+action_function(Omega::GSetByRightTransversal) = *
+
+function Base.in(omega::GroupCoset, Omega::GSetByRightTransversal)
+    return omega.G == Omega.group && omega.H == Omega.subgroup &&
+           omega.side == :right
+end
+
+Base.length(Omega::GSetByRightTransversal) = index(Int, Omega.group, Omega.subgroup)
+Base.lastindex(Omega::GSetByRightTransversal) = length(Omega)
+
+Base.keys(Omega::GSetByRightTransversal) = keys(1:length(Omega))
+
+representative(Omega::GSetByRightTransversal) = right_coset(Omega.subgroup, one(Omega.group))
+
+function Base.iterate(Omega::GSetByRightTransversal, state = 1)
+  T = Omega.transversal
+  state > length(T) && return nothing
+  return (right_coset(Omega.subgroup, T[state]), state+1)
+end
+
+Base.eltype(Omega::GSetByRightTransversal{T, S, E}) where {S, T, E} = GroupCoset{T, E}
+
+Base.getindex(Omega::GSetByRightTransversal, i::Int) = right_coset(Omega.subgroup, Omega.transversal[i])
+
+is_transitive(Omega::GSetByRightTransversal) = true
+
+function orbit(G::T, omega::GroupCoset{T, S}) where T <: GAPGroup where S
+    @req G == omega.G "omega must be a right coset in G"
+    return GSetByRightTransversal(G, omega.H, check = false)
+end
+# We could admit the more general `is_subset(G, omega.G)`.
+# One problem would be that `omega` would not be a point in the orbit,
+# according to the definition of equality for cosets.
+
+function orbit(Omega::GSetByRightTransversal{T, S, E}, omega::GroupCoset{T, E}) where T <: GAPGroup where S <: GAPGroup where E
+    @req Omega.group == omega.G && Omega.subgroup == omega.H "omega is not in Omega"
+    return Omega
+end
+
+function orbits(Omega::GSetByRightTransversal)
+    return [Omega]
+end
+
+function permutation(Omega::GSetByRightTransversal{T, S, E}, g::E) where T <: GAPGroup where S <: GAPGroup where E
+  # The following works because GAP uses its `PositionCanonical`.
+  pi = GAP.Globals.PermutationOp(g.X, Omega.transversal.X, GAP.Globals.OnRight)::GapObj
+  sym = get_attribute!(Omega, :action_range) do
+    return symmetric_group(length(Omega))
+  end
+  return group_element(sym, pi)
+end
+
+@attr GAPGroupHomomorphism{T, PermGroup} function action_homomorphism(Omega::GSetByRightTransversal{T, S, E}) where T <: GAPGroup where S <: GAPGroup where E
+  G = Omega.group
+
+  # The following works because GAP uses its `PositionCanonical`.
+  acthom = GAP.Globals.ActionHomomorphism(G.X, Omega.transversal.X, GAP.Globals.OnRight)::GapObj
+
+  # See the comment about `SetJuliaData` in the `action_homomorphism` method
+  # for `GSetByElements`.
+  GAP.Globals.SetJuliaData(acthom, GAP.Obj([Omega, G]))
+
+  sym = get_attribute!(Omega, :action_range) do
+    return symmetric_group(length(Omega))
+  end
+  return GAPGroupHomomorphism(G, sym, acthom)
 end
 
 
@@ -474,7 +601,6 @@ true
 
 julia> 1^actg == 2
 true
-
 ```
 """
 @attr GAPGroupHomomorphism{T, PermGroup} function action_homomorphism(Omega::GSetByElements{T}) where T<:GAPGroup
@@ -485,7 +611,7 @@ true
 
   # The following works only because GAP does not check
   # whether the given generators in GAP and Julia fit together.
-  acthom = GAP.Globals.ActionHomomorphism(G.X, omega_list, GAP.Obj(gap_gens), GAP.Obj(gens(G)), gfun)
+  acthom = GAP.Globals.ActionHomomorphism(G.X, omega_list, GAP.Obj(gap_gens), GAP.Obj(gens(G)), gfun)::GapObj
 
   # The first difficulty on the GAP side is `ImagesRepresentative`
   # (which is the easy direction of the action homomorphism):
@@ -538,7 +664,6 @@ true
 
 julia> is_conjugate(Omega, 1, 5)
 false
-
 ```
 """
 is_conjugate(Omega::GSet, omega1, omega2) = omega2 in orbit(Omega, omega1)
@@ -564,7 +689,6 @@ julia> is_conjugate_with_data(Omega, 1, 2)
 
 julia> is_conjugate_with_data(Omega, 1, 5)
 (false, ())
-
 ```
 """
 function is_conjugate_with_data(Omega::GSet, omega1, omega2)
@@ -591,13 +715,13 @@ end
 
 ############################################################################
 
-Base.length(Omega::GSet) = length(elements(Omega))
-
-representative(Omega::GSet) = first(Omega.seeds)
-
 acting_domain(Omega::GSet) = acting_group(Omega)
 
-function Base.iterate(Omega::GSet, state = 1)
+Base.length(Omega::GSetByElements) = length(elements(Omega))
+
+representative(Omega::GSetByElements) = first(Omega.seeds)
+
+function Base.iterate(Omega::GSetByElements, state = 1)
   elms = elements(Omega)
   state > length(elms) && return nothing
   return (elms[state], state+1)
@@ -605,14 +729,14 @@ end
 
 Base.eltype(Omega::GSetByElements) = eltype(Omega.seeds)
 
-Base.getindex(Omega::GSet, i::Int) = elements(Omega)[i]
+Base.getindex(Omega::GSetByElements, i::Int) = elements(Omega)[i]
 
 blocks(G::GSet) = error("not implemented")
 maximal_blocks(G::GSet) = error("not implemented")
 minimal_block_reps(G::GSet) = error("not implemented")
 all_blocks(G::GSet) = error("not implemented")
 
-function is_transitive(Omega::GSet)
+function is_transitive(Omega::GSetByElements)
     length(Omega.seeds) == 1 && return true
     return length(orbits(Omega)) == 1
 end
@@ -648,7 +772,6 @@ julia> collect(blocks(g))
 2-element Vector{Vector{Int64}}:
  [1, 2]
  [3, 4]
-
 ```
 """
 function blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
@@ -678,7 +801,6 @@ julia> collect(maximal_blocks(G))
 2-element Vector{Vector{Int64}}:
  [1, 2, 3, 8]
  [4, 5, 6, 7]
-
 ```
 """
 function maximal_blocks(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
@@ -710,7 +832,6 @@ julia> minimal_block_reps(G)
  [1, 3]
  [1, 5]
  [1, 7]
-
 ```
 """
 function minimal_block_reps(G::PermGroup, L::AbstractVector{Int} = moved_points(G))
@@ -738,7 +859,6 @@ julia> all_blocks(G)
  [1, 3]
  [1, 3, 4, 6]
  [1, 7]
-
 ```
 """
 all_blocks(G::PermGroup) = Vector{Vector{Int}}(GAP.Globals.AllBlocks(G.X))
@@ -841,7 +961,6 @@ false
 
 julia> is_transitive(stabilizer(G, 1)[1])
 false
-
 ```
 """
 is_transitive(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAPWrap.IsTransitive(G.X, GapObj(L))
@@ -871,7 +990,6 @@ julia> [(order(H), is_primitive(H)) for H in mx]
  (24, 0)
  (36, 0)
  (60, 1)
-
 ```
 """
 is_primitive(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAPWrap.IsPrimitive(G.X, GapObj(L))
@@ -895,7 +1013,6 @@ true
 
 julia> is_regular(G)
 false
-
 ```
 """
 is_regular(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAPWrap.IsRegular(G.X, GapObj(L))
@@ -919,7 +1036,6 @@ true
 
 julia> is_regular(H)
 false
-
 ```
 """
 is_semiregular(G::PermGroup, L::AbstractVector{Int} = 1:degree(G)) = GAPWrap.IsSemiRegular(G.X, GapObj(L))

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -50,9 +50,9 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", x::GSetByElements)
   println(io, "G-set of")
-  io = AbstractAlgebra.pretty(io)
+  io = pretty(io)
   print(io, Indent())
-  println(io, x.group)
+  println(io, Lowercase(), x.group)
   print(io, "with seeds ", x.seeds)
   print(io, Dedent())
 end
@@ -63,7 +63,7 @@ function Base.show(io::IO, x::GSetByElements)
   else
     print(io, "G-set of ")
     io = pretty(io)
-    print(IOContext(io, :supercompact => true), x.group, " with seeds ", x.seeds)
+    print(IOContext(io, :supercompact => true), Lowercase(), x.group, " with seeds ", x.seeds)
   end
 end
 
@@ -476,10 +476,10 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", x::GSetByRightTransversal)
   println(io, "Right cosets of")
-  io = AbstractAlgebra.pretty(io)
+  io = pretty(io)
   print(io, Indent())
-  println(io, x.subgroup, " in")
-  print(io, x.group)
+  println(io, Lowercase(), x.subgroup, " in")
+  print(io, Lowercase(), x.group)
   print(io, Dedent())
 end
 
@@ -489,7 +489,7 @@ function Base.show(io::IO, x::GSetByRightTransversal)
   else
     print(io, "Right cosets of ")
     io = pretty(io)
-    print(IOContext(io, :supercompact => true), x.subgroup, " in ", x.group)
+    print(IOContext(io, :supercompact => true), Lowercase(), x.subgroup, " in ", Lowercase(), x.group)
   end
 end
 

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -315,3 +315,59 @@ end
   orb = orbit(G, f)
   @test length(orb) == 3
 end
+
+@testset "G-sets by right transversals" begin
+  G = symmetric_group(5)
+  H = sylow_subgroup(G, 2)[1]
+  Omega = right_cosets(G, H)
+  @test isa(Omega, GSet)
+  @test acting_group(Omega) == G
+  @test length(Omega) == index(G, H)
+  @test Omega[end] == Omega[length(Omega)]
+  @test length(orbits(Omega)) == 1
+  @test is_transitive(Omega)
+  @test ! is_regular(Omega)
+  @test ! is_semiregular(Omega)
+
+  @test eltype(Omega) == typeof(representative(Omega))
+
+  # iteration
+  for i in 1:length(Omega)
+    @test findfirst(is_equal(Omega[i]), Omega) == i
+  end
+  rep = representative(Omega)
+  for omega in Omega
+    @test one(G) in omega || omega != rep
+  end
+
+  # orbit
+  g = gen(G, 1)
+  pnt = right_coset(H, g)
+  @test pnt in Omega
+  @test length(orbit(Omega, pnt)) == length(Oscar.orbit_via_Julia(Omega, pnt))
+
+  # permutation
+  pi = permutation(Omega, g)
+  @test order(pi) == order(g)
+  @test degree(parent(pi)) == length(Omega)
+
+  # action homomorphism
+  acthom = action_homomorphism(Omega)
+  @test pi == g^acthom
+  flag, pre = haspreimage(acthom, pi)
+  @test flag
+  @test pre == g
+  @test order(image(acthom)[1]) == order(G)
+  rest = restrict_homomorphism(acthom, derived_subgroup(G)[1])
+  @test ! is_bijective(rest)
+
+  # is_conjugate
+  x, y = [right_coset(H, g) for g in gens(G)]
+  @test is_conjugate(Omega, x, y)
+
+  # is_conjugate_with_data
+  rep = is_conjugate_with_data(Omega, x, y)
+  @test rep[1]
+  @test x * rep[2] == y
+  @test Oscar.action_function(Omega)(x, rep[2]) == y
+end

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -3,6 +3,7 @@
   # natural constructions (determined by the types of the seeds)
   G = symmetric_group(6)
   Omega = gset(G)
+  @test repr(Omega, context = :supercompact => true) == "G-set"
   @test isa(Omega, GSet)
   @test length(Omega) == 6
   @test length(orbits(Omega)) == 1
@@ -320,6 +321,7 @@ end
   G = symmetric_group(5)
   H = sylow_subgroup(G, 2)[1]
   Omega = right_cosets(G, H)
+  @test repr(Omega, context = :supercompact => true) == "Right cosets of groups"
   @test isa(Omega, GSet)
   @test acting_group(Omega) == G
   @test length(Omega) == index(G, H)

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -156,8 +156,11 @@ end
    C = right_coset(H, G[1])
    @test is_right(C)
    @test order(C) == length(collect(C))
+   @test repr(C, context = :supercompact => true) == "Right coset of a group"
   
-   @test length(right_transversal(G, H)) == index(G, H)
+   T = right_transversal(G, H)
+   @test length(T) == index(G, H)
+   @test repr(T, context = :supercompact => true) == "Right transversal of groups"
    @test_throws ArgumentError right_transversal(H, G)
    @test_throws ArgumentError left_transversal(H, G)
 
@@ -213,6 +216,7 @@ end
 
    H = sub(G, [cperm(G,[1,2,3]), cperm(G,[2,3,4])])[1]
    L = right_cosets(G,H)
+   @test repr(L, context = :supercompact => true) == "Right cosets of groups"
    @test_throws ArgumentError right_cosets(H, G)
    T = right_transversal(G,H)
    @test length(L)==10


### PR DESCRIPTION
- add `GSetByRightTransversal`
- change `right_cosets` to return a `GSetByRightTransversal` object
- change `show` methods for `GSetByElements` and `GroupCoset`

resolves #3221,
addresses the comment about `right_cosets` in the discussion of #3216