### PR TITLE
Minor fix for show method of character tables; fix printing of named groups like `SL(2,2)` in some situations

### DIFF
--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -891,7 +891,9 @@ function Base.show(io::IO, ::MIME"text/plain", tbl::GAPGroupCharacterTable)
     emptycol = ["" for i in 1:n]
 
     if isdefined(tbl, :group)
-      headerstring = lowercasefirst(string(group(tbl)))
+      str_io = IOBuffer()
+      print(pretty(str_io), Lowercase(), group(tbl))
+      headerstring = String(take!(str_io))
       if characteristic(tbl) != 0
         headerstring = "$(characteristic(tbl))-modular Brauer table of $(headerstring)"
       else

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -117,12 +117,13 @@ end
 ########################################################################
 
 function _print_matrix_group_desc(io::IO, x::MatrixGroup)
+  io = pretty(io)
+  print(io, LowercaseOff(), string(x.descr), "(", x.deg ,",")
   if x.descr==:GU || x.descr==:SU
-    print(io, string(x.descr), "(",x.deg,",",characteristic(x.ring)^(div(degree(x.ring),2)),")")
+    print(io, characteristic(x.ring)^(div(degree(x.ring),2)),")")
   elseif x.ring isa Field && is_finite(x.ring)
-    print(io, string(x.descr), "(",x.deg,",",order(x.ring),")")
+    print(io, order(x.ring),")")
   else
-    print(io, string(x.descr), "(",x.deg,",")
     print(IOContext(io, :supercompact => true), x.ring)
     print(io ,")")
   end
@@ -131,7 +132,7 @@ end
 function Base.show(io::IO, ::MIME"text/plain", x::MatrixGroup)
   isdefined(x, :descr) && return _print_matrix_group_desc(io, x)
   println(io, "Matrix group of degree ", degree(x))
-  io = AbstractAlgebra.pretty(io)
+  io = pretty(io)
   print(io, Indent())
   print(io, "over ", Lowercase(), base_ring(x))
   print(io, Dedent())

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -727,6 +727,22 @@ $\begin{array}{rrrrr}
 \end{array}
 $
 ```
+
+Test the case where a group has a custom name where the first character
+should not be turned into lowercase
+```jldoctest group_characters.test
+julia> character_table(SL(2,2))
+Character table of SL(2,2)
+
+  2  1  1  .
+  3  1  .  1
+
+    1a 2a 3a
+
+X_1  1 -1  1
+X_2  2  . -1
+X_3  1  1  1
+```
 """
 function dummy_placeholder end
 


### PR DESCRIPTION
Don't print the name 'SL(2,2)' as 'sL(2,2)'.