### PR TITLE
Adapt some Group function docstrings

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -177,7 +177,7 @@ julia> exponent(symmetric_group(13))
 Base.exponent(::Type{T}, G::GAPGroup) where T <: IntegerUnion = T(GAP.Globals.Exponent(G.X)::GapInt)
 
 """
-    rand(rng::Random.AbstractRNG = Random.GLOBAL_RNG, G::Group)
+    rand(rng::Random.AbstractRNG = Random.GLOBAL_RNG, G::GAPGroup)
 
 Return a random element of `G`, using the random number generator `rng`.
 """
@@ -411,7 +411,7 @@ The parent of `g` need not be equal to `G`.
 Base.in(g::GAPGroupElem, G::GAPGroup) = g.X in G.X
 
 """
-    gens(G::Group)
+    gens(G::GAPGroup)
 
 Return a vector of generators of `G`.
 To get the `i`-th generator,
@@ -443,7 +443,7 @@ function gens(G::GAPGroup)
 end
 
 """
-    has_gens(G::Group)
+    has_gens(G::GAPGroup)
 
 Return whether generators for the group `G` are known.
 
@@ -614,7 +614,7 @@ acting_group(C::GroupConjClass) = C.X
 # START elements conjugation
 
 """
-    conjugacy_class(G::Group, g::GAPGroupElem) -> GroupConjClass
+    conjugacy_class(G::GAPGroup, g::GAPGroupElem) -> GroupConjClass
 
 Return the conjugacy class `cc` of `g` in `G`, where `g` = `representative`(`cc`).
 
@@ -650,7 +650,7 @@ Return the number of conjugacy classes of elements in `G`.
 number_conjugacy_classes(::Type{T}, G::GAPGroup) where T <: IntegerUnion = T(GAPWrap.NrConjugacyClasses(G.X))
 
 """
-    conjugacy_classes(G::Group)
+    conjugacy_classes(G::GAPGroup)
 
 Return the vector of all conjugacy classes of elements in `G`.
 It is guaranteed that the class of the identity is in the first position.
@@ -674,7 +674,7 @@ function is_conjugate(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)
 end
 
 """
-    is_conjugate_with_data(G::Group, x::GAPGroupElem, y::GAPGroupElem)
+    is_conjugate_with_data(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)
 
 If `x` and `y` are conjugate in `G`,
 return `(true, z)`, where `x^z == y` holds;
@@ -695,7 +695,7 @@ end
 
 # START subgroups conjugation
 """
-    conjugacy_class(G::T, H::T) where T<:Group -> GroupConjClass
+    conjugacy_class(G::T, H::T) where T<:GAPGroup -> GroupConjClass
 
 Return the subgroup conjugacy class `cc` of `H` in `G`, where `H` = `representative`(`cc`).
 """
@@ -712,7 +712,7 @@ function Base.rand(rng::Random.AbstractRNG, C::GroupConjClass{S,T}) where S wher
 end
 
 """
-    conjugacy_classes_subgroups(G::Group)
+    conjugacy_classes_subgroups(G::GAPGroup)
 
 Return the vector of all conjugacy classes of subgroups of G.
 
@@ -768,7 +768,7 @@ function subgroup_reps(G::GAPGroup; order::ZZRingElem = ZZRingElem(-1))
 end
 
 """
-    conjugacy_classes_maximal_subgroups(G::Group)
+    conjugacy_classes_maximal_subgroups(G::GAPGroup)
 
 Return the vector of all conjugacy classes of maximal subgroups of G.
 
@@ -888,7 +888,7 @@ false
 is_conjugate(G::GAPGroup, H::GAPGroup, K::GAPGroup) = GAPWrap.IsConjugate(G.X,H.X,K.X)
 
 """
-    is_conjugate_with_data(G::Group, H::Group, K::Group)
+    is_conjugate_with_data(G::GAPGroup, H::GAPGroup, K::GAPGroup)
 
 If `H` and `K` are conjugate subgroups in `G`, return `true, z`
 where `H^z = K`; otherwise, return `false, nothing`.
@@ -1051,7 +1051,7 @@ end
 ################################################################################
 
 """
-    normalizer(G::Group, H::Group)
+    normalizer(G::GAPGroup, H::GAPGroup)
 
 Return `N, f`, where `N` is the normalizer of `H` in `G`,
 i.e., the largest subgroup of `G` in which `H` is normal,
@@ -1060,7 +1060,7 @@ and `f` is the embedding morphism of `N` into `G`.
 normalizer(G::T, H::T) where T<:GAPGroup = _as_subgroup(G, GAPWrap.Normalizer(G.X, H.X))
 
 """
-    normalizer(G::Group, x::GAPGroupElem)
+    normalizer(G::GAPGroup, x::GAPGroupElem)
 
 Return `N, f`, where `N` is the normalizer of the cyclic subgroup generated
 by `x` in `G` and `f` is the embedding morphism of `N` into `G`.
@@ -1068,7 +1068,7 @@ by `x` in `G` and `f` is the embedding morphism of `N` into `G`.
 normalizer(G::GAPGroup, x::GAPGroupElem) = _as_subgroup(G, GAPWrap.Normalizer(G.X, x.X))
 
 """
-    core(G::Group, H::Group)
+    core(G::GAPGroup, H::GAPGroup)
 
 Return `C, f`, where `C` is the normal core of `H` in `G`,
 that is, the largest normal subgroup of `G` that is contained in `H`,
@@ -1077,7 +1077,7 @@ and `f` is the embedding morphism of `C` into `G`.
 core(G::T, H::T) where T<:GAPGroup = _as_subgroup(G, GAPWrap.Core(G.X, H.X))
 
 """
-    normal_closure(G::Group, H::Group)
+    normal_closure(G::GAPGroup, H::GAPGroup)
 
 Return `N, f`, where `N` is the normal closure of `H` in `G`,
 that is, the smallest normal subgroup of `G` that contains `H`,
@@ -1094,7 +1094,7 @@ normal_closure(G::T, H::T) where T<:GAPGroup = _as_subgroup(G, GAPWrap.NormalClo
 # but then the user should have the possibility to omit this check.)
 
 """
-    pcore(G::Group, p::IntegerUnion)
+    pcore(G::GAPGroup, p::IntegerUnion)
 
 Return `C, f`, where `C` is the `p`-core
 (i.e. the largest normal `p`-subgroup) of `G`
@@ -1163,7 +1163,7 @@ see [`minimal_normal_subgroups`](@ref).
 ################################################################################
 
 """
-    sylow_subgroup(G::Group, p::IntegerUnion)
+    sylow_subgroup(G::GAPGroup, p::IntegerUnion)
 
 Return a Sylow `p`-subgroup of the finite group `G`, for a prime `p`.
 This is a subgroup of `p`-power order in `G`
@@ -1196,7 +1196,7 @@ function hall_subgroup(G::GAPGroup, P::AbstractVector{<:IntegerUnion})
 end
 
 """
-    hall_subgroup_reps(G::Group, P::AbstractVector{<:IntegerUnion})
+    hall_subgroup_reps(G::GAPGroup, P::AbstractVector{<:IntegerUnion})
 
 Return a vector that contains representatives of conjugacy classes of
 Hall `P`-subgroups of the finite group `G`, for a vector `P` of primes.
@@ -1243,7 +1243,7 @@ function hall_subgroup_reps(G::GAPGroup, P::AbstractVector{<:IntegerUnion})
 end
 
 @doc raw"""
-    sylow_system(G::Group)
+    sylow_system(G::GAPGroup)
 
 Return a vector of Sylow $p$-subgroups of the finite group `G`,
 where $p$ runs over the prime factors of the order of `G`,
@@ -1288,7 +1288,7 @@ function complement_class_reps(G::T, N::T) where T <: GAPGroup
 end
 
 @doc raw"""
-    complement_system(G::Group)
+    complement_system(G::GAPGroup)
 
 Return a vector of Hall $p'$-subgroups of the finite group `G`,
 where $p$ runs over the prime factors of the order of `G`.
@@ -1302,7 +1302,7 @@ an exception is thrown if `G` is not solvable.
 end
 
 @doc raw"""
-    hall_system(G::Group)
+    hall_system(G::GAPGroup)
 
 Return a vector of Hall $P$-subgroups of the finite group `G`,
 where $P$ runs over the subsets of prime factors of the order of `G`.

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -1,6 +1,6 @@
 # T=type of the group, S=type of the element
 """
-    GroupCoset{T<: Group, S <: GAPGroupElem}
+    GroupCoset{T<: GAPGroup, S <: GAPGroupElem}
 
 Type of group cosets. It is displayed as `H * x` (right cosets) or `x * H`
 (left cosets), where `H` is a subgroup of a group `G` and `x` is an element of
@@ -28,8 +28,8 @@ end
 
 
 """
-    right_coset(H::Group, g::GAPGroupElem)
-    *(H::Group, g::GAPGroupElem)
+    right_coset(H::GAPGroup, g::GAPGroupElem)
+    *(H::GAPGroup, g::GAPGroupElem)
 
 Return the coset `Hg`.
 
@@ -52,8 +52,8 @@ function right_coset(H::GAPGroup, g::GAPGroupElem)
 end
 
 """
-    left_coset(H::Group, g::GAPGroupElem)
-    *(g::GAPGroupElem, H::Group)
+    left_coset(H::GAPGroup, g::GAPGroupElem)
+    *(g::GAPGroupElem, H::GAPGroup)
 
 Return the coset `gH`.
 !!! note
@@ -327,7 +327,7 @@ end
 
 
 """
-    right_transversal(G::T, H::T; check::Bool=true) where T<: GAPGroup
+    right_transversal(G::T, H::T; check::Bool=true) where T <: GAPGroup
 
 Return a vector containing a complete set of representatives for
 the right cosets of `H` in `G`.
@@ -364,7 +364,7 @@ function right_transversal(G::T, H::T; check::Bool=true) where T<: GAPGroup
 end
 
 """
-    left_transversal(G::T, H::T; check::Bool=true) where T<: Group
+    left_transversal(G::T, H::T; check::Bool=true) where T <: GAPGroup
 
 Return a vector containing a complete set of representatives for
 the left cosets for `H` in `G`.
@@ -414,7 +414,7 @@ end
 
 
 """
-    GroupDoubleCoset{T<: Group, S <: GAPGroupElem}
+    GroupDoubleCoset{T <: GAPGroup, S <: GAPGroupElem}
 
 Group double coset. It is displayed as `H * x * K`, where `H` and `K` are
 subgroups of a group `G` and `x` is an element of `G`. Two double cosets are
@@ -446,8 +446,8 @@ end
 
 
 """
-    double_coset(H::Group, x::GAPGroupElem, K::Group)
-    *(H::Group, x::GAPGroupElem, K::Group)
+    double_coset(H::GAPGroup, x::GAPGroupElem, K::GAPGroup)
+    *(H::GAPGroup, x::GAPGroupElem, K::GAPGroup)
 
 Return the double coset `HxK`.
 

--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -459,7 +459,7 @@ end
 
 """
     wreath_product(G::T, H::S, a::GAPGroupHomomorphism{S,PermGroup})
-    wreath_product(G::T, H::PermGroup) where T<: Group
+    wreath_product(G::T, H::PermGroup) where T<: GAPGroup
 
 Return the wreath product of the group `G` and the group `H`, where `H` acts
 on `n` copies of `G` through the homomorphism `a` from `H` to a permutation

--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -161,7 +161,7 @@ end
 =#
 
 @doc raw"""
-    abelian_group(::Type{T}, v::Vector{Int}) where T <: Group -> PcGroup
+    abelian_group(::Type{T}, v::Vector{Int}) where T <: GAPGroup -> PcGroup
 
 Return the direct product of cyclic groups of the orders
 `v[1]`, `v[2]`, $\ldots$, `v[n]`, as an instance of `T`.
@@ -188,7 +188,7 @@ function abelian_group(::Type{PcGroup}, v::Vector{T}) where T <: IntegerUnion
 end
 
 @doc raw"""
-    is_abelian(G::Group)
+    is_abelian(G::GAPGroup)
 
 Return `true` if `G` is abelian (commutative),
 that is, $x*y = y*x$ holds for all elements $x, y$ in `G`.
@@ -196,7 +196,7 @@ that is, $x*y = y*x$ holds for all elements $x, y$ in `G`.
 @gapattribute is_abelian(G::GAPGroup) = GAP.Globals.IsAbelian(G.X)::Bool
 
 @doc raw"""
-    is_elementary_abelian(G::Group)
+    is_elementary_abelian(G::GAPGroup)
 
 Return `true` if `G` is a abelian (see [`is_abelian`](@ref))
 and if there is a prime `p` such that the order of each element in `G`

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -231,7 +231,7 @@ end
 
 
 """
-    is_invariant(f::GAPGroupHomomorphism, H::Group)
+    is_invariant(f::GAPGroupHomomorphism, H::GAPGroup)
     is_invariant(f::GAPGroupElem{AutomorphismGroup{T}}, H::T)
 
 Return whether `f(H) == H` holds.
@@ -245,8 +245,8 @@ function is_invariant(f::GAPGroupHomomorphism, H::GAPGroup)
 end
 
 """
-    restrict_homomorphism(f::GAPGroupHomomorphism, H::Group)
-    restrict_homomorphism(f::GAPGroupElem{AutomorphismGroup{T}}, H::T) where T <: Group
+    restrict_homomorphism(f::GAPGroupHomomorphism, H::GAPGroup)
+    restrict_homomorphism(f::GAPGroupElem{AutomorphismGroup{T}}, H::T) where T <: GAPGroup
 
 Return the restriction of `f` to `H`.
 An exception is thrown if `H` is not a subgroup of `domain(f)`.
@@ -864,7 +864,7 @@ end
 ################################################################################
 
 """
-    automorphism_group(G::Group) -> A::AutomorphismGroup{T}
+    automorphism_group(G::GAPGroup) -> A::AutomorphismGroup{T}
 
 Return the full automorphism group of `G`. If `f` is an object of type
 `GAPGroupHomomorphism` and it is bijective from `G` to itself, then `A(f)`

--- a/src/Groups/libraries/smallgroups.jl
+++ b/src/Groups/libraries/smallgroups.jl
@@ -101,7 +101,7 @@ end
 
 
 """
-    small_group_identification(G::Group)
+    small_group_identification(G::GAPGroup)
 
 Return a pair of integer `(n, m)`, where `G` is isomorphic with `small_group(n, m)`.
 

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -162,7 +162,7 @@ end
 
 
 """
-    normal_subgroups(G::Group)
+    normal_subgroups(G::GAPGroup)
 
 Return all normal subgroups of `G` (see [`is_normal`](@ref)).
 
@@ -188,7 +188,7 @@ julia> normal_subgroups(quaternion_group(8))
   _as_subgroups(G, GAP.Globals.NormalSubgroups(G.X))
 
 """
-    subgroups(G::Group)
+    subgroups(G::GAPGroup)
 
 Return all subgroups of `G`.
 
@@ -220,7 +220,7 @@ function subgroups(G::GAPGroup)
 end
 
 """
-    maximal_subgroups(G::Group)
+    maximal_subgroups(G::GAPGroup)
 
 Return all maximal subgroups of `G`.
 
@@ -244,7 +244,7 @@ julia> maximal_subgroups(quaternion_group(8))
   _as_subgroups(G, GAP.Globals.MaximalSubgroups(G.X))
 
 """
-    maximal_normal_subgroups(G::Group)
+    maximal_normal_subgroups(G::GAPGroup)
 
 Return all maximal normal subgroups of `G`, i.e., those proper
 normal subgroups of `G` that are maximal among the proper normal
@@ -267,7 +267,7 @@ julia> maximal_normal_subgroups(quaternion_group(8))
   _as_subgroups(G, GAP.Globals.MaximalNormalSubgroups(G.X))
 
 """
-    minimal_normal_subgroups(G::Group)
+    minimal_normal_subgroups(G::GAPGroup)
 
 Return all minimal normal subgroups of `G`, i.e., of those
 nontrivial normal subgroups of `G` that are minimal among the
@@ -288,7 +288,7 @@ julia> minimal_normal_subgroups(quaternion_group(8))
   _as_subgroups(G, GAP.Globals.MinimalNormalSubgroups(G.X))
 
 """
-    characteristic_subgroups(G::Group)
+    characteristic_subgroups(G::GAPGroup)
 
 Return the list of characteristic subgroups of `G`,
 i.e., those subgroups that are invariant under all automorphisms of `G`.
@@ -315,7 +315,7 @@ julia> characteristic_subgroups(quaternion_group(8))
   _as_subgroups(G, GAP.Globals.CharacteristicSubgroups(G.X))
 
 @doc raw"""
-    center(G::Group)
+    center(G::GAPGroup)
 
 Return the center of `G`, i.e.,
 the subgroup of all $x$ in `G` such that $x y$ equals $y x$ for every $y$
@@ -333,7 +333,7 @@ julia> center(quaternion_group(8))
 @gapattribute center(G::GAPGroup) = _as_subgroup(G, GAP.Globals.Centre(G.X))
 
 @doc raw"""
-    centralizer(G::Group, H::Group)
+    centralizer(G::GAPGroup, H::GAPGroup)
 
 Return the centralizer of `H` in `G`, i.e.,
 the subgroup of all $g$ in `G` such that $g h$ equals $h g$ for every $h$
@@ -344,7 +344,7 @@ function centralizer(G::T, H::T) where T <: GAPGroup
 end
 
 @doc raw"""
-    centralizer(G::Group, x::GroupElem)
+    centralizer(G::GAPGroup, x::GAPGroupElem)
 
 Return the centralizer of `x` in `G`, i.e.,
 the subgroup of all $g$ in `G` such that $g$ `x` equals `x` $g$,
@@ -1159,8 +1159,8 @@ julia> derived_length(dihedral_group(8))
 ################################################################################
 
 @doc raw"""
-    intersect(V::T...) where T <: Group
-    intersect(V::AbstractVector{T}) where T <: Group
+    intersect(V::T...) where T <: GAPGroup
+    intersect(V::AbstractVector{T}) where T <: GAPGroup
 
 If `V` is $[ G_1, G_2, \ldots, G_n ]$,
 return the intersection $K$ of the groups $G_1, G_2, \ldots, G_n$,


### PR DESCRIPTION
As they used to contain `::Group` in the signature even though they actually only work for `GAPGroup`s.