### PR TITLE
CI: disable nightly for macos to reduce test time

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,12 +52,14 @@ jobs:
           - julia-version: '1.10'
             group: 'long'
             os: macOS-latest
-          - julia-version: 'nightly'
-            group: 'short'
-            os: macOS-latest
-          - julia-version: 'nightly'
-            group: 'long'
-            os: macOS-latest
+          # nightly on macos is disabled for now since the macos jobs take too long
+          # with just 5 runners
+          #- julia-version: 'nightly'
+          #  group: 'short'
+          #  os: macOS-latest
+          #- julia-version: 'nightly'
+          #  group: 'long'
+          #  os: macOS-latest
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
cc: @fingolfin @lgoettgens 