### PR TITLE
use stored OD values for factor groups

### DIFF
--- a/docs/src/Groups/group_characters.md
+++ b/docs/src/Groups/group_characters.md
@@ -209,6 +209,7 @@ symplectic_components(characters::Vector{GAPGroupClassFunction}, n::Int)
 ```@docs
 class_multiplication_coefficient
 known_class_fusion
+known_class_fusions
 order(tbl::GAPGroupCharacterTable)
 possible_class_fusions
 approximate_class_fusion

--- a/experimental/OrthogonalDiscriminants/src/data.jl
+++ b/experimental/OrthogonalDiscriminants/src/data.jl
@@ -147,9 +147,8 @@ function orthogonal_discriminants(tbl::Oscar.GAPGroupCharacterTable)
         res[mp[l[2]]] = l[4]
       end
       # Set values for faithful characters if applicable.
-      perf = (length(filter(i -> degree(tbl[i]) == 1, 1:length(tbl))) == 1)
-      if p == 0 && perf && order(tbl) == 2*order(facttbl)
-#TODO: compute the reductions mod p (not dividing the group order)
+      perf = (count(chi -> degree(chi) == 1, tbl) == 1)
+      if perf && order(tbl) == 2*order(facttbl) && p != 2
         # deal with the faithful characters of a perfect central extension 2.G,
         # the image of the spinor norm is trivial
         for i in 1:length(tbl)
@@ -157,10 +156,23 @@ function orthogonal_discriminants(tbl::Oscar.GAPGroupCharacterTable)
           deg = degree(chi)
           ind = indicator(chi)
           if ind == 1 && length(class_positions_of_kernel(chi)) == 1
-            if mod(deg, 4 ) == 0
-              res[i] = "1"
-            elseif mod(deg, 2 ) == 0
-              res[i] = "-1"
+            if mod(deg, 4) == 0
+              if p == 0
+                res[i] = "1"
+              else
+                res[i] = "O+"
+              end
+            elseif mod(deg, 2) == 0
+              if p == 0
+                res[i] = "-1"
+              else
+                # Check whether -1 is a square in the character field.
+                if mod(p-1, 4) == 0 || mod(degree(character_field(chi)[1]), 2) == 0
+                  res[i] = "O+"
+                else
+                  res[i] = "O-"
+                end
+              end
             end
           end
         end
@@ -532,7 +544,7 @@ function all_od_infos(L...)
             (!comment_matches(comment)) && (good_comment = false)
           elseif comment_matches isa String
             (!(comment_matches in comment)) && (good_comment = false)
-          elseif is_empty(intersect(comment, comment_matches ))
+          elseif is_empty(intersect(comment, comment_matches))
             good_comment = false
           end
         end

--- a/experimental/OrthogonalDiscriminants/test/data.jl
+++ b/experimental/OrthogonalDiscriminants/test/data.jl
@@ -50,6 +50,13 @@ end
   end
 end
 
+@testset "orthogonal_discriminants for central extensions" begin
+  name = "2.L3(4)"
+  t = character_table(name)
+  @test orthogonal_discriminants(t) ==
+  ["","21","","","","","","","","105","","","1","1","1","1","-1","-1"]
+end
+
 using Documenter
 
 #

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -48,6 +48,7 @@ GAP.@wrap CoefficientsFamily(x::GapObj)::GapObj
 GAP.@wrap CoefficientsOfUnivariatePolynomial(x::GapObj)::GapObj
 GAP.@wrap CoeffsCyc(x::GAP.Obj, y::Int)::GapObj
 GAP.@wrap CollectionsFamily(x::GapObj)::GapObj
+GAP.@wrap ComputedClassFusions(x::GapObj)::GapObj
 GAP.@wrap ComputedPowerMaps(x::GapObj)::GapObj
 GAP.@wrap Conductor(x::Any)::GapInt
 GAP.@wrap ConjugacyClass(x::GapObj, y::GapObj)::GapObj

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -1601,6 +1601,19 @@ function known_class_fusion(subtbl::GAPGroupCharacterTable, tbl::GAPGroupCharact
     end
 end
 
+@doc raw"""
+    known_class_fusions(tbl::GAPGroupCharacterTable)
+
+Return the vector of pairs `(name, fus)` where `name` is the identifier of
+a character table
+and `fus` is the stored class fusion from `tbl` to this table,
+see [`known_class_fusion`](@ref).
+"""
+function known_class_fusions(tbl::GAPGroupCharacterTable)
+    return Tuple{String, Vector{Int64}}[(String(r.name), Vector{Int}(r.map))
+             for r in GAPWrap.ComputedClassFusions(GAPTable(tbl))]
+end
+
 
 #############################################################################
 ##

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -883,6 +883,7 @@ export kernel
 export klee_minty_cube
 export klein_bottle
 export known_class_fusion
+export known_class_fusions
 export koszul_complex
 export koszul_homology
 export koszul_matrix


### PR DESCRIPTION
... and set obvious `orthogonal_discriminants` values automatically for perfect central extensions

This way, the character table display with ODs works automatically for "2.A8", "2.HS", etc.