### PR TITLE
renaming: `haspreimage/has_preimage` -> `has_preimage_with_preimage`

### DIFF
--- a/docs/src/Groups/grouphom.md
+++ b/docs/src/Groups/grouphom.md
@@ -80,7 +80,7 @@ julia> x^f
 
 A sort of "inverse" of the evaluation is the following
 ```@docs
-haspreimage(f::GAPGroupHomomorphism, x::GAPGroupElem; check::Bool = true)
+has_preimage_with_preimage(f::GAPGroupHomomorphism, x::GAPGroupElem; check::Bool = true)
 ```
   **Example:**
 ```jldoctest
@@ -90,12 +90,9 @@ julia> f=hom(S,S,x->x^S[1]);
 
 julia> x=cperm(S,[1,2]);
 
-julia> haspreimage(f,x)
+julia> has_preimage_with_preimage(f,x)
 (true, (1,4))
 ```
-
-!!! warning
-    Do not confuse `haspreimage` with the function `has_preimage`, which works on variable of type `GrpGenToGrpGenMor`.
 
 ## Operations on homomorphisms
 

--- a/experimental/GModule/Cohomology.jl
+++ b/experimental/GModule/Cohomology.jl
@@ -1410,7 +1410,7 @@ function H_two(C::GModule; force_rws::Bool = false, redo::Bool = false)
 
   function is_coboundary(cc::CoChain{2})
     t = TailFromCoChain(cc)
-    fl, b = haspreimage(CC, t)
+    fl, b = has_preimage_with_preimage(CC, t)
     if !fl
       return false, nothing
     end

--- a/experimental/GModule/GaloisCohomology.jl
+++ b/experimental/GModule/GaloisCohomology.jl
@@ -818,7 +818,7 @@ function idel_class_gmodule(k::AnticNumberField, s::Vector{Int} = Int[]; redo::B
     not_inv = Int[]
     for i=1:length(x)
       w = theta_i[i]
-      fl, pe = haspreimage(mz, w)
+      fl, pe = has_preimage_with_preimage(mz, w)
       if fl
         push!(inv, i)
         zz = mq(x[i])
@@ -1654,7 +1654,7 @@ function Oscar.cansolve(A::Vector{RelativeBrauerGroupElem}, b::RelativeBrauerGro
  
   h = hom(F, G, a[1:end-1])
   pop!(A)
-  return haspreimage(h, a[end])
+  return has_preimage_with_preimage(h, a[end])
 end  
 
 """

--- a/experimental/OrthogonalDiscriminants/src/data.jl
+++ b/experimental/OrthogonalDiscriminants/src/data.jl
@@ -155,7 +155,7 @@ function is_equal_field(emb1, emb2)
   p == characteristic(dom2) || return false
   degree(dom1) == degree(dom2) || return false
   p == 0 || return order(dom1) == order(dom2)
-  return has_preimage(emb2, emb1(gen(dom1)))[1]
+  return has_preimage_with_preimage(emb2, emb1(gen(dom1)))[1]
 end
 
 

--- a/experimental/QuadFormAndIsom/src/embeddings.jl
+++ b/experimental/QuadFormAndIsom/src/embeddings.jl
@@ -881,7 +881,7 @@ function _subgroups_orbit_representatives_and_stabilizers_elementary(Vinq::TorQu
   end
 
   # In theory, V should contain H0 := p^l*pq where pq is the p-primary part of q
-  all(a -> has_preimage(Vinq, (p^l)*pqtoq(a))[1], gens(pq)) || return res
+  all(a -> has_preimage_with_preimage(Vinq, (p^l)*pqtoq(a))[1], gens(pq)) || return res
   H0, H0inq = sub(q, elem_type(q)[q(lift((p^l)*a)) for a in gens(pq)])
   @hassert :ZZLatWithIsom 1 is_invariant(f, H0inq)
 

--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -6,7 +6,7 @@ function restrict_codomain(f::GrpAbFinGenMap)
   H, Htocd = image(f, false)
   imgs = elem_type(H)[]
   for g in gens(G)
-    fl, h = haspreimage(Htocd, f(g))
+    fl, h = has_preimage_with_preimage(Htocd, f(g))
     @assert fl
     push!(imgs, h)
   end

--- a/src/Groups/abelian_aut.jl
+++ b/src/Groups/abelian_aut.jl
@@ -287,7 +287,7 @@ function is_invariant(f::TorQuadModuleMap, i::TorQuadModuleMap)
   U = domain(i)
   for a in gens(U)
     b = f(i(a))
-    has_preimage(i, b)[1] || return false
+    has_preimage_with_preimage(i, b)[1] || return false
   end
   return true
 end
@@ -337,7 +337,7 @@ function restrict_endomorphism(f::TorQuadModuleMap, i::TorQuadModuleMap; check::
   U = domain(i)
   for a in gens(U)
     b = f(i(a))
-    ok, c = has_preimage(i, b)
+    ok, c = has_preimage_with_preimage(i, b)
     @req ok "The domain of i is not invariant under the action of f"
     push!(imgs, c)
   end

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -708,7 +708,7 @@ function is_conjugate_with_data(Omega::GSet, omega1, omega2)
     pos2 === nothing && return false, one(G)
     img = GAP.Globals.RepresentativeAction(image(acthom)[1].X, pos1, pos2)
     img == GAP.Globals.fail && return false, one(G)
-    pre = haspreimage(acthom, group_element(image(acthom)[1], img))
+    pre = has_preimage_with_preimage(acthom, group_element(image(acthom)[1], img))
     @assert(pre[1])
     return true, pre[2]
 end

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -184,11 +184,11 @@ end
     preimage(f::GAPGroupHomomorphism, x::GAPGroupElem)
 
 Return an element `y` in the domain of `f` with the property `f(y) == x`.
-See [`haspreimage(f::GAPGroupHomomorphism, x::GAPGroupElem; check::Bool = true)`](@ref)
+See [`has_preimage_with_preimage(f::GAPGroupHomomorphism, x::GAPGroupElem; check::Bool = true)`](@ref)
 for a check whether `x` has such a preimage.
 """
 function preimage(f::GAPGroupHomomorphism, x::GAPGroupElem)
-  fl, p = haspreimage(f, x)
+  fl, p = has_preimage_with_preimage(f, x)
   @assert fl
   return p
 end
@@ -313,7 +313,7 @@ function cokernel(f::GAPGroupHomomorphism)
 end
 
 """
-    haspreimage(f::GAPGroupHomomorphism, x::GAPGroupElem; check::Bool = true)
+    has_preimage_with_preimage(f::GAPGroupHomomorphism, x::GAPGroupElem; check::Bool = true)
 
 Return (`true`, `y`) if there exists `y` in `domain(f)`
 such that `f`(`y`) = `x` holds;
@@ -322,11 +322,11 @@ otherwise, return (`false`, `o`) where `o` is the identity of `domain(f)`.
 If `check` is set to `false` then the test whether `x` is an element of
 `image(f)` is omitted.
 """
-function haspreimage(f::GAPGroupHomomorphism, x::GAPGroupElem; check::Bool = true)
-  return _haspreimage(f.map, domain(f), image(f)[1], x, check = check)
+function has_preimage_with_preimage(f::GAPGroupHomomorphism, x::GAPGroupElem; check::Bool = true)
+  return _haspreimage(f.map, domain(f), image(f)[1], x; check)
 end
 
-# helper function for computing `haspreimage` for
+# helper function for computing `has_preimage_with_preimage` for
 # both `GAPGroupHomomorphism` (fieldnames `domain`, `codomain`, `map`)
 # and `AutomorphismGroupElem{T}` (fieldnames `parent`, `X`)
 function _haspreimage(mp::GapObj, dom::GAPGroup, img::GAPGroup, x::GAPGroupElem; check::Bool = true)
@@ -339,6 +339,7 @@ function _haspreimage(mp::GapObj, dom::GAPGroup, img::GAPGroup, x::GAPGroupElem;
 # see https://github.com/gap-system/gap/issues/4088.
 # Until this problem gets fixed on the GAP side, we perform a membership test
 # before calling `GAP.Globals.PreImagesRepresentative`.
+# Setting `check = false` avoids this argument check.
   check && ! (x in img) && return false, one(dom)
   r = GAP.Globals.PreImagesRepresentative(mp, x.X)::GapObj
   if r == GAP.Globals.fail
@@ -1020,6 +1021,9 @@ Return the domain of this group of automorphisms.
 """
 domain(A::AutomorphismGroup) = A.G
 
+# As mentioned before, the check argument is needed because the underlying GAP
+# function does not ensure to return anything sensible if x is not in the image
+# of f.
 """
     domain(f::AutomorphismGroupElem) -> Group
 
@@ -1027,12 +1031,12 @@ Return the domain of this automorphism.
 """
 domain(f::AutomorphismGroupElem) = domain(parent(f))
 
-function haspreimage(f::AutomorphismGroupElem, x::GAPGroupElem; check::Bool = true)
-  return _haspreimage(f.X, domain(parent(f)), domain(parent(f)), x, check = check)
+function has_preimage_with_preimage(f::AutomorphismGroupElem, x::GAPGroupElem; check::Bool = true)
+  return _haspreimage(f.X, domain(parent(f)), domain(parent(f)), x; check)
 end
 
 function preimage(f::AutomorphismGroupElem, x::GAPGroupElem)
-  fl, p = haspreimage(f, x)
+  fl, p = has_preimage_with_preimage(f, x)
   @assert fl
   return p
 end

--- a/src/NumberTheory/NmbThy.jl
+++ b/src/NumberTheory/NmbThy.jl
@@ -74,7 +74,7 @@ function norm_equation_fac_elem(R::Hecke.NfRelOrd{nf_elem,Hecke.NfOrdFracIdl}, a
     b = norm(mkK, aa)
     c = b*inv(FacElem(k(a)))
     d = preimage(mu, c)
-    fl, p = haspreimage(No, d)
+    fl, p = has_preimage_with_preimage(No, d)
     if fl
       push!(sol, FacElem(Dict(mKa(x) => v for (x, v) = (aa*inv(mU(p))).fac)))
     end

--- a/src/Rings/AbelianClosure.jl
+++ b/src/Rings/AbelianClosure.jl
@@ -35,7 +35,7 @@ import Base: +, *, -, //, ==, zero, one, ^, div, isone, iszero,
 #import ..Oscar.AbstractAlgebra: promote_rule
 
 import ..Oscar: AbstractAlgebra, addeq!, characteristic, elem_type, divexact, gen,
-                has_preimage, is_root_of_unity, is_unit, mul!, parent,
+                has_preimage_with_preimage, is_root_of_unity, is_unit, mul!, parent,
                 parent_type, promote_rule, root, root_of_unity, roots
 
 using Hecke
@@ -940,8 +940,8 @@ end
 
 # The following works only if `mp.g` admits a second argument,
 # which is the case if `mp` has been constructed by `_embedding` above.
-function has_preimage(mp::MapFromFunc{AnticNumberField, QQAbField{AnticNumberField}}, x::QQAbElem{nf_elem})
-  pre = mp.g(x, check = true)
+function has_preimage_with_preimage(mp::MapFromFunc{AnticNumberField, QQAbField{AnticNumberField}}, x::QQAbElem{nf_elem})
+  pre = mp.g(x; check = true)
   if isnothing(pre)
     return false, zero(domain(mp))
   else

--- a/src/Rings/AlgClosureFp.jl
+++ b/src/Rings/AlgClosureFp.jl
@@ -17,7 +17,7 @@ import Base: +, -, *, //, ==, deepcopy_internal, hash, isone, iszero, one,
 import ..Oscar.AbstractAlgebra: pretty, Lowercase
 
 import ..Oscar: base_field, base_ring, characteristic, data, degree, divexact,
-  elem_type, embedding, has_preimage, IntegerUnion, is_unit, map_entries,
+  elem_type, embedding, has_preimage_with_preimage, IntegerUnion, is_unit, map_entries,
   minpoly, parent_type, promote_rule, roots
 
 struct AlgClosure{T} <: AbstractAlgebra.Field
@@ -324,7 +324,7 @@ function embedding(k::T, K::AlgClosure{T}) where T <: FinField
   return MapFromFunc(k, K, f, finv)
 end
 
-function has_preimage(mp::MapFromFunc{T, AlgClosure{S}}, elm::AlgClosureElem{S}) where T <: FinField where S <: FinField
+function has_preimage_with_preimage(mp::MapFromFunc{T, AlgClosure{S}}, elm::AlgClosureElem{S}) where T <: FinField where S <: FinField
   F = domain(mp)
   mod(degree(F), degree(elm)) != 0 && return false, zero(F)
   return true, preimage(mp, elm)

--- a/src/Rings/MPolyMap/AffineAlgebras.jl
+++ b/src/Rings/MPolyMap/AffineAlgebras.jl
@@ -81,7 +81,7 @@ end
 Return `true` if `F` is surjective, `false` otherwise.
 """
 function is_surjective(F::AffAlgHom)
-  return all(x -> has_preimage(F, x)[1], gens(codomain(F)))
+  return all(x -> has_preimage_with_preimage(F, x)[1], gens(codomain(F)))
 end
 
 ################################################################################
@@ -174,7 +174,7 @@ function inverse(F::AffAlgHom)
 
   preimgs = elem_type(R)[]
   for i in 1:ngens(S)
-    fl, p = has_preimage(F, gen(S, i))
+    fl, p = has_preimage_with_preimage(F, gen(S, i))
     fl || error("Homomorphism is not surjective")
     push!(preimgs, p)
   end
@@ -187,12 +187,12 @@ function preimage_with_kernel(F::AffAlgHom, f::Union{MPolyRingElem, MPolyQuoRing
 end
 
 function preimage(F::AffAlgHom, f::Union{MPolyRingElem, MPolyQuoRingElem})
-  fl, g = has_preimage(F, f)
+  fl, g = has_preimage_with_preimage(F, f)
   !fl && error("Element not contained in image")
   return g
 end
 
-function has_preimage(F::AffAlgHom, f::Union{MPolyRingElem, MPolyQuoRingElem})
+function has_preimage_with_preimage(F::AffAlgHom, f::Union{MPolyRingElem, MPolyQuoRingElem})
   # Basically [GP09, p. 86, Solution 2]
   @req parent(f) === codomain(F) "Polynomial is not element of the codomain"
 

--- a/src/Rings/NumberField.jl
+++ b/src/Rings/NumberField.jl
@@ -904,7 +904,7 @@ end
 function Hecke._compute_inverse_data(f#= image Hecke.data =#, K, LL, L::NfAbsNSGen)
   preimg_gens = elem_type(K)[]
   for g in gens(L)
-    fl, preimg = haspreimage(f, LL(g))
+    fl, preimg = has_preimage_with_preimage(f, LL(g))
     @assert fl
     push!(preimg_gens, preimg)
   end
@@ -1007,7 +1007,7 @@ end
 function Hecke._compute_inverse_data(f, K, LL, L::NfNSGen)
   preimg_gens = elem_type(K)[]
   for g in gens(L)
-    fl, preimg = haspreimage(f, LL(g))
+    fl, preimg = has_preimage_with_preimage(f, LL(g))
     push!(preimg_gens, preimg)
   end
   inverse_data_base_field = Hecke._compute_inverse_data(f, K, LL, base_field(L))

--- a/src/Rings/mpoly-affine-algebras.jl
+++ b/src/Rings/mpoly-affine-algebras.jl
@@ -980,7 +980,7 @@ function subalgebra_membership(f::T, v::Vector{T}) where T <: Union{MPolyRingEle
 
   S, _ = polynomial_ring(coefficient_ring(R), length(v), "t")
   phi = hom(S, R, v)
-  return has_preimage(phi, f)
+  return has_preimage_with_preimage(phi, f)
 end
 
 @doc raw"""

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -1199,7 +1199,7 @@ function monomial_basis(W::MPolyDecRing, d::GrpAbFinGenElem)
   D = W.D
   is_free(D) || error("Grading group must be free")
   h = hom(free_abelian_group(ngens(W)), W.d)
-  fl, p = haspreimage(h, d)
+  fl, p = has_preimage_with_preimage(h, d)
   R = base_ring(W)
   B = elem_type(W)[]
   if fl

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -547,6 +547,8 @@ Base.@deprecate_binding glueing_domains gluing_domains
 Base.@deprecate_binding glueing_graph gluing_graph
 Base.@deprecate_binding glueing_morphisms gluing_morphisms
 Base.@deprecate_binding glueings gluings
+Base.@deprecate_binding has_preimage has_preimage_with_preimage
+Base.@deprecate_binding haspreimage has_preimage_with_preimage
 Base.@deprecate_binding inherit_glueings! inherit_gluings!
 Base.@deprecate_binding is_connected_glueing is_connected_gluing
 Base.@deprecate_binding pruned_glueing_graph pruned_gluing_graph

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -610,7 +610,7 @@ export has_small_groups
 export has_torusfactor
 export has_transitive_groups
 export has_vertex
-export haspreimage
+export has_preimage_with_preimage
 export height
 export hermitian_form
 export hessian

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -1062,9 +1062,9 @@ end
   for elm in [gen(F), one(F)]
     img = emb(elm)
     @test preimage(emb, img) == elm
-    @test has_preimage(emb, img) == (true, elm)
+    @test has_preimage_with_preimage(emb, img) == (true, elm)
     z5 = gen(parent(img))(5)
-    @test has_preimage(emb, z5)[1] == false
+    @test has_preimage_with_preimage(emb, z5)[1] == false
     @test_throws ErrorException preimage(emb, z5)
   end
 
@@ -1076,9 +1076,9 @@ end
   for elm in [gen(F), one(F)]
     img = emb(elm)
     @test preimage(emb, img) == elm
-    @test has_preimage(emb, img) == (true, elm)
+    @test has_preimage_with_preimage(emb, img) == (true, elm)
     z5 = gen(parent(img))(5)
-    @test has_preimage(emb, z5)[1] == false
+    @test has_preimage_with_preimage(emb, z5)[1] == false
     @test_throws ErrorException preimage(emb, z5)
   end
 end

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -121,7 +121,7 @@
   Omega = gset(G, permuted, [[0,1,0,1,0,1], [1,2,3,4,5,6]])
   acthom = action_homomorphism(Omega)
   @test pi == g^acthom
-  @test haspreimage(acthom, pi)[1]
+  @test has_preimage_with_preimage(acthom, pi)[1]
   @test order(image(acthom)[1]) == 720
   rest = restrict_homomorphism(acthom, derived_subgroup(G)[1])
   @test ! is_bijective(rest)
@@ -259,7 +259,7 @@ end
   Omega = gset(G)
   acthom = action_homomorphism(Omega)
   @test pi == g^acthom
-  @test haspreimage(acthom, pi)[1]
+  @test has_preimage_with_preimage(acthom, pi)[1]
   @test order(image(acthom)[1]) == 48
 
   # isconjugate
@@ -356,7 +356,7 @@ end
   # action homomorphism
   acthom = action_homomorphism(Omega)
   @test pi == g^acthom
-  flag, pre = haspreimage(acthom, pi)
+  flag, pre = has_preimage_with_preimage(acthom, pi)
   @test flag
   @test pre == g
   @test order(image(acthom)[1]) == order(G)

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -5,7 +5,7 @@
      x = gen(H, 1)
      y = image(emb, x)
      @test preimage(emb, y) == x
-     @test any(g -> ! haspreimage(emb, g)[1], gens(G))
+     @test any(g -> ! has_preimage_with_preimage(emb, g)[1], gens(G))
    end
 end
 
@@ -542,8 +542,8 @@ function test_kernel(G,H,f)
    @test preimage(f,H)==(G,id_hom(G))
    @test preimage(f,sub(H,[one(H)])[1])==(K,i)
    z=rand(Im)
-   @test haspreimage(f,z)[1]
-   @test f(haspreimage(f,z)[2])==z
+   @test has_preimage_with_preimage(f,z)[1]
+   @test f(has_preimage_with_preimage(f,z)[2])==z
 
    @test is_injective(i)
    for j in 1:ngens(K)

--- a/test/Rings/AlgClosureFp.jl
+++ b/test/Rings/AlgClosureFp.jl
@@ -152,9 +152,9 @@ end
       @test K(x) == img
       @test preimage(emb, img) == x
     end
-    @test has_preimage(emb, K(one(F3)))[1]
+    @test has_preimage_with_preimage(emb, K(one(F3)))[1]
     @test preimage(emb, K(one(F3))) == one(F2)
-    @test !has_preimage(emb, K(gen(F3)))[1]
+    @test !has_preimage_with_preimage(emb, K(gen(F3)))[1]
   end
 
   @testset "Polynomial for $F1" for F1 in [GF(3, 1), Nemo.Native.GF(3, 1)]


### PR DESCRIPTION
Should logically follow https://github.com/thofma/Hecke.jl/pull/1367. So for now it stays as a draft.

This decision comes from the HackMD https://hackmd.io/nRnyfrSxTVe5CzXidB1cBQ, where it was suggested to merge both `haspreimage` and `has_preimage` to only use `has_preimage_with_preimage`. As far I have checked, all such functions have two outputs.

Two of them, from the GAPGroup part, have a `check` keyword argument. The reason, as spotted in several gap-related issues and in comment in the code, is that the underlying GAP function may have unexpected behaviour if the said element is not in the image of the input function. Hence, as mentioned there, the `check` argument is kept until some decisions are made on the GAP side (so I did not dare removing it)