### PR TITLE
Remove obsolete `getindex` methods for accessing generators

### DIFF
--- a/experimental/GModule/Brueckner.jl
+++ b/experimental/GModule/Brueckner.jl
@@ -265,7 +265,6 @@ function brueckner(mQ::Map{<:Oscar.GAPGroup, PcGroup}; primes::Vector=[])
   return allR
 end
 
-Base.getindex(M::AbstractAlgebra.FPModule, i::Int) = i==0 ? zero(M) : gens(M)[i]
 Oscar.gen(M::AbstractAlgebra.FPModule, i::Int) = M[i]
 
 Oscar.is_free(M::Generic.FreeModule) = true

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -460,7 +460,6 @@ function gen(G::GAPGroup, i::Int)
    @assert length(L) >= i "The number of generators is lower than the given index"
    return group_element(G, L[i]::GapObj)
 end
-Base.getindex(G::GAPGroup, i::Int) = gen(G, i)
 
 """
     ngens(G::GAPGroup) -> Int

--- a/src/Groups/matrices/matrix_manipulation.jl
+++ b/src/Groups/matrices/matrix_manipulation.jl
@@ -228,8 +228,6 @@ end
 #
 ########################################################################
 
-Base.getindex(V::AbstractAlgebra.Generic.FreeModule, i::Int) = gen(V, i)
-
 
 Base.:*(v::AbstractAlgebra.Generic.FreeModuleElem{T},x::MatElem{T}) where T <: RingElem = v.parent(v.v*x)
 Base.:*(x::MatElem{T},u::AbstractAlgebra.Generic.FreeModuleElem{T}) where T <: RingElem = x*transpose(u.v)

--- a/src/Modules/FreeModules-graded.jl
+++ b/src/Modules/FreeModules-graded.jl
@@ -1294,7 +1294,7 @@ function tensor_product(G::FreeModule_dec...; task::Symbol = :none)
     return Tuple(gen(G[i], t[e.r.pos[1]][i]) for i = 1:length(G))
   end
 
-  return F, MapFromFunc(Hecke.TupleParent(Tuple([g[0] for g = G])), F, pure, inv_pure)
+  return F, MapFromFunc(Hecke.TupleParent(Tuple([zero(g) for g = G])), F, pure, inv_pure)
 end
 
 ⊗(G::ModuleFP_dec...) = tensor_product(G..., task = :none)

--- a/src/Modules/FreeModules-graded.jl
+++ b/src/Modules/FreeModules-graded.jl
@@ -156,11 +156,6 @@ function gen(F::FreeModule_dec, i::Int)
   return FreeModuleElem_dec(s, F)
 end
 
-function Base.getindex(F::FreeModule_dec, i::Int)
-  i == 0 && return zero(F)
-  return gen(F, i)
-end
-
 base_ring(F::FreeModule_dec) = F.R
 
 #TODO: Parent - checks everywhere!!!
@@ -703,11 +698,6 @@ zero(SQ::SubquoDecModule) = SubquoDecModuleElem(zero(SQ.F), SQ)
 
 function Base.iszero(F::SubquoDecModule)
   return all(iszero, gens(F))
-end
-
-function Base.getindex(F::SubquoDecModule, i::Int)
-  i == 0 && return zero(F)
-  return gen(F, i)
 end
 
 function Base.iterate(F::BiModArray, i::Int = 1)

--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -560,7 +560,7 @@ function graded_map(F::FreeMod{T}, A::MatrixElem{T}) where {T <: RingElement}
   source_degrees = Vector{eltype(G)}()
   for i in 1:nrows(A)
       for j in 1:ncols(A)
-          if A[i, j] != R[0]
+          if !is_zero(A[i, j])
               push!(source_degrees, degree(A[i, j]) + degree(F[j]))
               break
           end
@@ -580,7 +580,7 @@ function graded_map(F::FreeMod{T}, V::Vector{<:AbstractFreeModElem{T}}) where {T
   source_degrees = Vector{eltype(G)}()
   for i in 1:nrows
     for j in 1:ncols
-      if coordinates(V[i])[j] != R[0]
+      if !is_zero(coordinates(V[i])[j])
         push!(source_degrees, degree(coordinates(V[i])[j]) + degree(F[j]))
         break
       end
@@ -599,7 +599,7 @@ function graded_map(F::SubquoModule{T}, V::Vector{<:ModuleFPElem{T}}) where {T <
   source_degrees = Vector{eltype(G)}()
   for i in 1:nrows
     for (j, coord_val) in coordinates(V[i])
-      if coord_val != R[0]
+      if !is_zero(coord_val)
         push!(source_degrees, degree(coord_val) + degree(F[j]))
         break
       end
@@ -2246,7 +2246,7 @@ function tensor_product(G::FreeMod_dec...; task::Symbol = :none)
   if task == :none
     return F
   end
-  return F, MapFromFunc(Hecke.TupleParent(Tuple([g[0] for g = G])), F, pure, inv_pure)
+  return F, MapFromFunc(Hecke.TupleParent(Tuple([zero(g) for g = G])), F, pure, inv_pure)
 end
 
 

--- a/src/Modules/UngradedModules/FreeModElem.jl
+++ b/src/Modules/UngradedModules/FreeModElem.jl
@@ -177,11 +177,6 @@ function basis(F::AbstractFreeMod, i::Int)
 end
 gen(F::AbstractFreeMod, i::Int) = basis(F,i)
 
-function getindex(F::AbstractFreeMod, i::Int)
-  i == 0 && return zero(F)
-  return gen(F, i)
-end
-
 @doc raw"""
     base_ring(F::AbstractFreeMod)
 

--- a/src/Modules/UngradedModules/SubquoModuleElem.jl
+++ b/src/Modules/UngradedModules/SubquoModuleElem.jl
@@ -899,16 +899,6 @@ function is_zero(M::SubquoModule)
   return all(iszero, gens(M))
 end
 
-@doc raw"""
-    getindex(F::SubquoModule, i::Int)
-
-Return the `i`th generator of `F`.
-"""
-function getindex(F::SubquoModule, i::Int)
-  i == 0 && return zero(F)
-  return gen(F, i)
-end
-
 function iterate(F::ModuleGens, i::Int = 1)
   if i>length(F)
     return nothing

--- a/src/Modules/UngradedModules/Tensor.jl
+++ b/src/Modules/UngradedModules/Tensor.jl
@@ -69,7 +69,7 @@ function tensor_product(G::FreeMod...; task::Symbol = :none)
     return F
   end
 
-  return F, MapFromFunc(Hecke.TupleParent(Tuple([g[0] for g = G])), F, pure, inv_pure)
+  return F, MapFromFunc(Hecke.TupleParent(Tuple([zero(g) for g = G])), F, pure, inv_pure)
 end
 
 ⊗(G::ModuleFP...) = tensor_product(G..., task = :none)
@@ -163,7 +163,7 @@ function tensor_product(G::ModuleFP...; task::Symbol = :none)
     return s
   end
 
-  return s, MapFromFunc(Hecke.TupleParent(Tuple([g[0] for g = G])), s, pure)
+  return s, MapFromFunc(Hecke.TupleParent(Tuple([zero(g) for g = G])), s, pure)
 end
 
 

--- a/src/Rings/FreeAssAlgIdeal.jl
+++ b/src/Rings/FreeAssAlgIdeal.jl
@@ -10,11 +10,11 @@
 # necessarily be confined to a degree bound.
 
 @doc raw"""
-    mutable struct FreeAssAlgIdeal{T} <: FreeAssAlgIdeal{T}
+    mutable struct FreeAssAlgIdeal{T}
 
 Two-sided ideal of a free associative algebra with elements of type `T`.
 """
-mutable struct FreeAssAlgIdeal{T}
+mutable struct FreeAssAlgIdeal{T} <: Ideal{T}
   gens::IdealGens{T}
   gb::IdealGens{T}
 

--- a/src/Rings/Laurent.jl
+++ b/src/Rings/Laurent.jl
@@ -13,7 +13,7 @@ import AbstractAlgebra: LaurentMPolyRing, LaurentMPolyRingElem
   end
 end
 
-mutable struct LaurentMPolyIdeal{T}
+mutable struct LaurentMPolyIdeal{T} <: Ideal{T}
   R
   gens::Vector{T}
   data # ideal of of _polyringquo(R)

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -63,7 +63,6 @@ end
 gens(Q::MPolyQuoRing) = [Q(x) for x = gens(base_ring(Q))]
 ngens(Q::MPolyQuoRing) = ngens(base_ring(Q))
 gen(Q::MPolyQuoRing, i::Int) = Q(gen(base_ring(Q), i))
-Base.getindex(Q::MPolyQuoRing, i::Int) = Q(base_ring(Q)[i])::elem_type(Q)
 base_ring(Q::MPolyQuoRing) = base_ring(Q.I)
 coefficient_ring(Q::MPolyQuoRing) = coefficient_ring(base_ring(Q))
 modulus(Q::MPolyQuoRing) = Q.I
@@ -347,7 +346,6 @@ function gens(a::MPolyQuoIdeal)
 end
 
 gen(a::MPolyQuoIdeal, i::Int) = a.gens.Ox(a.gens.O[i])
-getindex(a::MPolyQuoIdeal, i::Int) = gen(a, i)
 
 @doc raw"""
     ngens(a::MPolyQuoIdeal)

--- a/src/Rings/PBWAlgebra.jl
+++ b/src/Rings/PBWAlgebra.jl
@@ -249,10 +249,6 @@ function gen(R::PBWAlgRing, i::Int)
   return PBWAlgElem(R, gen(R.sring, i))
 end
 
-function Base.getindex(R::PBWAlgRing, i::Int)
-  return gen(R, i)
-end
-
 function var_index(a::PBWAlgElem)
   return Singular.var_index(a.sdata)
 end
@@ -616,8 +612,6 @@ function gen(a::PBWAlgIdeal, i::Int)
   R = base_ring(a)
   return PBWAlgElem(R, a.sdata[i])
 end
-
-getindex(I::PBWAlgIdeal, i::Int) = gen(I, i)
 
 function expressify(a::PBWAlgIdeal{D}; context = nothing) where D
   dir = D < 0 ? :left_ideal : D > 0 ? :right_ideal : :two_sided_ideal

--- a/src/Rings/PBWAlgebra.jl
+++ b/src/Rings/PBWAlgebra.jl
@@ -20,7 +20,7 @@ mutable struct PBWAlgElem{T, S} <: NCRingElem
   sdata::Singular.spluralg{S}
 end
 
-mutable struct PBWAlgIdeal{D, T, S}
+mutable struct PBWAlgIdeal{D, T, S} <: Ideal{PBWAlgIdeal{T, S}}
   basering::PBWAlgRing{T, S}
   sdata::Singular.sideal{Singular.spluralg{S}}    # the gens of this ideal, always defined
   sopdata::Singular.sideal{Singular.spluralg{S}}  # the gens mapped to the opposite

--- a/src/Rings/PBWAlgebra.jl
+++ b/src/Rings/PBWAlgebra.jl
@@ -20,7 +20,7 @@ mutable struct PBWAlgElem{T, S} <: NCRingElem
   sdata::Singular.spluralg{S}
 end
 
-mutable struct PBWAlgIdeal{D, T, S} <: Ideal{PBWAlgIdeal{T, S}}
+mutable struct PBWAlgIdeal{D, T, S} <: Ideal{PBWAlgElem{T, S}}
   basering::PBWAlgRing{T, S}
   sdata::Singular.sideal{Singular.spluralg{S}}    # the gens of this ideal, always defined
   sopdata::Singular.sideal{Singular.spluralg{S}}  # the gens mapped to the opposite

--- a/src/Rings/PBWAlgebraQuo.jl
+++ b/src/Rings/PBWAlgebraQuo.jl
@@ -126,10 +126,6 @@ function gen(Q::PBWAlgQuo, i::Int)
   return PBWAlgQuoElem(Q, PBWAlgElem(Q.I.basering, gen(Q.sring, i)))
 end
 
-function Base.getindex(Q::PBWAlgQuo, i::Int)
-  return gen(Q, i)
-end
-
 function zero(Q::PBWAlgQuo)
   return PBWAlgQuoElem(Q, PBWAlgElem(Q.I.basering, zero(Q.sring)))
 end

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -1135,7 +1135,6 @@ base_ring(W::MPolyDecRing) = base_ring(forget_decoration(W))
 Nemo.ngens(W::MPolyDecRing) = Nemo.ngens(forget_decoration(W))
 Nemo.gens(W::MPolyDecRing) = map(W, gens(forget_decoration(W)))
 Nemo.gen(W::MPolyDecRing, i::Int) = W(gen(forget_decoration(W), i))
-Base.getindex(W::MPolyDecRing, i::Int) = W(forget_decoration(W)[i])
 
 base_ring(f::MPolyDecRingElem) = base_ring(forget_decoration(f))
 

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -1375,7 +1375,6 @@ function gens(I::MPolyIdeal)
 end
 
 gen(I::MPolyIdeal, i::Int) = I.gens[Val(:O), i]
-getindex(I::MPolyIdeal, i::Int) = gen(I, i)
 
 #######################################################
 @doc raw"""

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -1646,7 +1646,6 @@ end
 ### required getter functions
 gens(I::MPolyLocalizedIdeal) = copy(I.gens)
 gen(I::MPolyLocalizedIdeal, i::Int) = I.gens[i]
-getindex(I::MPolyLocalizedIdeal, i::Int) = I.gens[i]
 base_ring(I::MPolyLocalizedIdeal) = I.W
 
 ### type getters

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -20,11 +20,6 @@ function _variables_for_singular(n::Int)
 end
 _variables_for_singular(S::Vector{Symbol}) = _variables_for_singular(length(S))
 
-function Base.getindex(R::MPolyRing, i::Int)
-  i == 0 && return zero(R)
-  return gen(R, i)
-end
-
 ngens(F::AbstractAlgebra.Generic.FracField{T}) where {T <: MPolyRingElem} = ngens(base_ring(F))
 
 function gen(F::AbstractAlgebra.Generic.FracField{T}) where {T <: PolyRingElem}
@@ -37,11 +32,6 @@ end
 
 function gens(F::AbstractAlgebra.Generic.FracField{T}) where {T <: Union{PolyRingElem, MPolyRingElem}}
   return map(F, gens(base_ring(F)))
-end
-
-function Base.getindex(F::AbstractAlgebra.Generic.FracField{T}, i::Int) where {T <: MPolyRingElem}
-  i == 0 && return zero(F)
-  return gen(F, i)
 end
 
 ######################################################################

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -1614,7 +1614,6 @@ end
 ### required getter functions
 gens(I::MPolyQuoLocalizedIdeal) = copy(I.gens)
 gen(I::MPolyQuoLocalizedIdeal, i::Int) = I.gens[i]
-getindex(I::MPolyQuoLocalizedIdeal, i::Int) = I.gens[i]
 base_ring(I::MPolyQuoLocalizedIdeal) = I.W
 
 ### additional getter functions 

--- a/test/Rings/mpoly.jl
+++ b/test/Rings/mpoly.jl
@@ -295,7 +295,6 @@ end
   @test gen(F, 2) == F(y)
   @test gens(F) == elem_type(F)[ F(x), F(y), F(z) ]
   @test F[1] == F(x)
-  @test F[0] == zero(F)
 end
 
 @testset "Grassmann Plücker Relations" begin


### PR DESCRIPTION
AA defines this generically, with one exception `R[0]` is not defined, yet some code uses it to represent `zero(R)`. Such code should be changed to use `R(0)` or `zero(R)`.

I fixed two of these, but there might be more, we'll see.