### PR TITLE
G module missing methods

### DIFF
--- a/experimental/GModule/Cohomology.jl
+++ b/experimental/GModule/Cohomology.jl
@@ -572,14 +572,23 @@ end
 struct CoChain{N, G, M}
   C::GModule
   d::Dict{NTuple{N, G}, M}
+  D::Function
 
   function CoChain{N, G, M}(C::GModule, d::Dict{NTuple{N, G}, M}) where {N, G, M}
     return new{N, G, M}(C, d)
+  end
+
+  function CoChain{N, G, M}(C::GModule, d::Dict{NTuple{N, G}, M}, D) where {N, G, M}
+    return new{N, G, M}(C, d, D::Function)
   end
 end
 
 function Base.show(io::IO, C::CoChain{N}) where {N}
   print(io, "$N-cochain with values in ", C.C.M)
+end
+
+function Base.keys(C::CoChain{N}) where {N}
+  return Iterators.ProductIterator(Tuple([C.C.G for i=1:N]))
 end
 
 Oscar.Nemo.elem_type(::Type{AllCoChains{N,G,M}}) where {N,G,M} = CoChain{N,G,M}
@@ -599,11 +608,19 @@ function differential(C::CoChain{N, G, M}) where {N, G, M}
 end
 
 function action(C::CoChain, g::PermGroupElem)
-  C = deepcopy(C)
-  for x = keys(C.d)
-    C.d[x] = action(C.C, g, C.d[x])
+  CC = deepcopy(C)
+  if isdefined(C, :D)
+    for x = keys(CC.d)
+      CC.d[x] = action(C.C, g, C.d[x])
+    end
+    CC.D = x->action(C.C, g, C.D(x))
+  else
+    for x = keys(C)
+      CC.d[x] = action(C.C, g, C[x])
+    end
   end
-  return C
+
+  return CC
 end
 
 
@@ -660,6 +677,7 @@ function (C::CoChain{2})(g::Oscar.BasicGAPGroupElem, h::Oscar.BasicGAPGroupElem)
   if haskey(C.d, (g,h))
     return C.d[(g,h)]
   end
+  return C.d[(g,h)] = C.D((g, h))
 end
 (C::CoChain{2})(g::NTuple{2, <:Oscar.BasicGAPGroupElem}) = C(g[1], g[2])
 
@@ -1040,7 +1058,7 @@ UNIVERSAL COVERS OF FINITE GROUPS
 https://arxiv.org/pdf/1910.11453.pdf
 almost the same as Holt
 =#
-function H_two(C::GModule; force_rws::Bool = false, redo::Bool = false)
+function H_two(C::GModule; force_rws::Bool = false, redo::Bool = false, lazy::Bool = false)
   z = get_attribute(C, :H_two)
   if !redo && z !== nothing
     return domain(z[1]), z[1], z[2]
@@ -1406,6 +1424,37 @@ function H_two(C::GModule; force_rws::Bool = false, redo::Bool = false)
     return CoChain{2,elem_type(G),elem_type(M)}(C, di)
   end
 
+  function TailToCoChainLazy(t, g, h)
+    c.f = function(C::CollectCtx, w::Vector{Int}, r::Int, p::Int)
+      #w = ABC and B == r[1], B -> r[2] * tail[r]
+      # -> A r[2] C C(tail)
+      # C = c1 c2 ... C(tail):
+      @assert w[p:p+length(R[r][1])-1] == R[r][1]
+
+      if pos[r] == 0
+        return
+      end
+      T = pro[pos[r]](t)
+      for i=w[p+length(R[r][1]):end]
+        if i < 0
+          T = iac[-i](T)
+        else
+          T = ac[i](T)
+        end
+      end
+      C.T += T
+    end
+
+    c.T = zero(M)
+    if order(G) > 1
+      gg = collect(word(preimage(mFF, g)), c)
+      hh = collect(word(preimage(mFF, h)), c)
+      c.T = zero(M)
+      d = collect(vcat(gg, hh), c)
+    end
+    return c.T
+  end
+
   symbolic_chain = function(g, h)
     c.f = symbolic_collect
     if order(G) == 1
@@ -1464,10 +1513,19 @@ function H_two(C::GModule; force_rws::Bool = false, redo::Bool = false)
     return mH2(preimage(mE, T))
   end
 
-  z = (MapFromFunc(H2, AllCoChains{2,elem_type(G),elem_type(M)}(),
+  if !lazy
+    z = (MapFromFunc(H2, AllCoChains{2,elem_type(G),elem_type(M)}(),
                    x->TailToCoChain(mE(preimage(mH2, x))), z2),
+             is_coboundary)
+           else
+    z = (MapFromFunc(H2, AllCoChains{2,elem_type(G),elem_type(M)}(),
+          x->CoChain{2, elem_type(G),elem_type(M)}(C, Dict{NTuple{2, elem_type(G)}, elem_type(M)}(), t->TailToCoChainLazy(mE(preimage(mH2, x)), t[1], t[2])),
+                   z2),
+#                   x->TailToCoChain(mE(preimage(mH2, x))), z2),
 #                         y->TailFromCoChain(y), D, AllCoChains{2,elem_type(G),elem_type(M)}()),
              is_coboundary)
+  end
+
   set_attribute!(C, :H_two => z)
   return H2, z[1], z[2]
   #now the rest...
@@ -1505,7 +1563,7 @@ function istwo_cocycle(c::CoChain{2})
 
              However, if we mix the conventions, all bets are off...
         =#
-        a = c.d[(g, h*k)] + c.d[(h, k)] - action(C, k, c.d[(g, h)])- c.d[(g*h, k)]
+        a = c(g, h*k) + c(h, k) - action(C, k, c(g, h))- c(g*h, k)
 #        @show a, iszero(a) || valuation(a)
 iszero(a) || (@show g, h, k, a ; return false)
         @assert iszero(a) # only for local stuff...|| valuation(a) > 20
@@ -2202,8 +2260,13 @@ function compatible_pairs(C::GModule)
   function action_on_chain(g::GAPGroupElem, c::CoChain{2, S, T}) where {S, T}
     al = pro[1](func(g)::elem_type(D))::elem_type(autM)
     ga = pro[2](func(g)::elem_type(D))::elem_type(autG)
-    d = Dict{Tuple{S, S}, T}(ab=> al(c((inv(ga)(ab[1]), inv(ga)(ab[2])))) for ab = keys(c.d))
-    return CoChain{2, S, T}(C, d)
+    if isdefined(C, :D)
+      d = Dict{Tuple{S, S}, T}(ab=> al(c((inv(ga)(ab[1]), inv(ga)(ab[2])))) for ab = keys(c.d))
+      return CoChain{2, S, T}(C, d, ab->al(c((inv(ga)(ab[1]), inv(ga)(ab[2])))))
+    else
+      d = Dict{Tuple{S, S}, T}(ab=> al(c((inv(ga)(ab[1]), inv(ga)(ab[2])))) for ab = keys(c))
+      return CoChain{2, S, T}(C, d)
+    end
   end
 
   h = hom(G, autM, [autM(x) for x = C.ac])

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -496,7 +496,7 @@ end
 function irreducible_modules(::QQField, G::Oscar.GAPGroup)
   #if cyclo is not minimal, this is not irreducible
   z = irreducible_modules(CyclotomicField, G)
-  return [gmodule(QQ, m) for m in z]
+  return [gmodule(QQ, descent_to_minimal_degree_field(m)) for m in z]
 end
 
 function irreducible_modules(::ZZRing, G::Oscar.GAPGroup)

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -83,7 +83,7 @@ G-module for G acting on vector space of dimension 8 over rational field
 ```
 """
 function restriction_of_scalars(M::GModule{<:Oscar.GAPGroup, <:AbstractAlgebra.FPModule{<:FieldElem}}, phi::Map)
-  #works iff relative_field above works. At least for AnticNumberField and
+  #works iff relative_field above works. At least for AbsSimpleNumField and
   #finite fields
   @assert codomain(phi) == base_ring(M)
   d = divexact(degree(codomain(phi)), degree(domain(phi)))

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -200,10 +200,27 @@ where `M` is a module over `R`.
 
 (modules over finite fields or number fields)
 """
-function descent_to_minimal_degree_field(M::GModule)
-  error("not yet ...")
+function descent_to_minimal_degree_field(C::GModule{<:Any, <:AbstractAlgebra.FPModule{fpFieldElem}})
+  return C
 end
 
+function descent_to_minimal_degree_field(C::GModule{<:Any, <:AbstractAlgebra.FPModule{<:FinFieldElem}})
+  #always over char field
+  K =  base_ring(C)
+  d = 0
+  while d < degree(K)-1
+    d += 1
+    degree(K) % d == 0 || continue
+    k = GF(Int(characteristic(K)), d)
+    D = gmodule_over(k, C, do_error = false)
+    D === nothing || return D
+  end
+  return C
+end
+
+function descent_to_minimal_degree_field(C::GModule{<:Any, <:AbstractAlgebra.FPModule{nf_elem}})
+  return _minimize(C)
+end
 
 """
     invariant_lattice_classes(M::GModule, phi::Map)

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -509,7 +509,7 @@ end
 
 TODO
 """
-function gmodule(::typeof(CyclotomicField), C::GModule)
+function gmodule(a::Type{CyclotomicField}, C::GModule)
   @assert isa(base_ring(C), QQAbField)
   d = dim(C)
   l = 1
@@ -1555,19 +1555,19 @@ function Oscar.gmodule(G::Oscar.GAPGroup, v::Vector{<:MatElem})
   return gmodule(G, [hom(F, F, x) for x = v])
 end
 
+function Oscar.gmodule(::Type{FinGenAbGroup}, C::GModule{T, <:AbstractAlgebra.FPModule{FqFieldElem}}) where {T <: Oscar.GAPGroup}
+  k = base_ring(C.M)
+  A = abelian_group([characteristic(k) for i=1:rank(C.M)*absolute_degree(k)])
+  return GModule(group(C), [hom(A, A, map_entries(x->lift(ZZ, x), hvcat(dim(C), [absolute_representation_matrix(x) for x = transpose(matrix(y))]...))) for y = C.ac])
+end
 
-function Oscar.gmodule(::Type{FinGenAbGroup}, C::GModule{T, AbstractAlgebra.FPModule{ZZRingElem}}) where {T <: Oscar.GAPGroup}
+function Oscar.gmodule(::Type{FinGenAbGroup}, C::GModule{T, <:AbstractAlgebra.FPModule{ZZRingElem}}) where {T <: Oscar.GAPGroup}
   A = free_abelian_group(rank(C.M))
   return Oscar.gmodule(Group(C), [hom(A, A, matrix(x)) for x = C.ac])
 end
 
-function Oscar.gmodule(::Type{FinGenAbGroup}, C::GModule{T, AbstractAlgebra.FPModule{FpFieldElem}}) where {T <: Oscar.GAPGroup}
+function Oscar.gmodule(::Type{FinGenAbGroup}, C::GModule{T, <:AbstractAlgebra.FPModule{<:Union{FpFieldElem, fpFieldElem}}}) where {T <: Oscar.GAPGroup}
   A = abelian_group([characteristic(base_ring(C)) for i=1:rank(C.M)])
-  return Oscar.gmodule(A, Group(C), [hom(A, A, map_entries(lift, matrix(x))) for x = C.ac])
-end
-
-function Oscar.gmodule(::Type{FinGenAbGroup}, C::GModule{T, <:AbstractAlgebra.FPModule{fpFieldElem}}) where {T <: Oscar.GAPGroup}
-  A = abelian_group([characteristic(base_ring(C)) for i=1:dim(C.M)])
   return Oscar.gmodule(A, Group(C), [hom(A, A, map_entries(lift, matrix(x))) for x = C.ac])
 end
 
@@ -1581,6 +1581,7 @@ function Oscar.gmodule(::Type{FinGenAbGroup}, C::GModule{T, <:AbstractAlgebra.FP
   return Oscar.gmodule(A, Group(C), [hom(A, A, matrix(x)) for x = C.ac])
 end
 
+#TODO: for modern fin. fields as well
 function Oscar.abelian_group(M::AbstractAlgebra.FPModule{fqPolyRepFieldElem})
   k = base_ring(M)
   A = abelian_group([characteristic(k) for i = 1:dim(M)*degree(k)])

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -265,7 +265,7 @@ end
 
 function descent_to_minimal_degree_field(C::GModule{<:Any, <:AbstractAlgebra.FPModule{<:FinFieldElem}})
   #always over char field
-  K =  base_ring(C)
+  K = base_ring(C)
   d = 0
   while d < absolute_degree(K)-1
     d += 1

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -149,7 +149,9 @@ function can_be_defined_over(M::GModule{<:Any, <:AbstractAlgebra.FPModule{<:FinF
   K = base_ring(M)
   d = absolute_degree(k)
   @assert absolute_degree(K) != d
+
   s = absolute_frobenius(K, d)
+  mkK = embed(k, K)
   os = divexact(absolute_degree(K), d)
   hB = hom_base(M, gmodule(M.M, Group(M),
                       [hom(M.M, M.M, map_entries(s, matrix(x))) for x = M.ac]))
@@ -187,6 +189,7 @@ function can_be_defined_over_with_data(M::GModule{<:Any, <:AbstractAlgebra.FPMod
   @assert absolute_degree(K) != d
 
   s = absolute_frobenius(K, d)
+  mkK = embed(k, K)
   os = divexact(absolute_degree(K), d)
   hB = hom_base(M, gmodule(M.M, Group(M),
                       [hom(M.M, M.M, map_entries(s, matrix(x))) for x = M.ac]))
@@ -199,17 +202,15 @@ function can_be_defined_over_with_data(M::GModule{<:Any, <:AbstractAlgebra.FPMod
   D = norm(B, s, os)
   lambda = D[1,1]
   @hassert :MinField 2 D == lambda*identity_matrix(K, dim(C))
-  alpha = norm_equation(K, preimage(phi, lambda))
+  alpha = norm_equation(K, preimage(mkK, lambda))
   B *= inv(alpha)
   @hassert :MinField 2 isone(norm(B, s, os))
   D = hilbert90_cyclic(B, s, os)
   Di = inv(D)
   F = free_module(k, dim(M))
-  N = gmodule(F, Group(M), [hom(F, F, map_entries(x -> preimage(phi, x), Di*matrix(x)*D)) for x = C.ac])
-  # TODO: Get this map working
-  # psi = GModuleHom(N, M, , phi)
-  psi = nothing
-  return (true, N, psi)
+  return (true,
+          gmodule(F, Group(M), [hom(F, F, map_entries(x -> preimage(mkK, x), Di*matrix(x)*D)) for x = C.ac])
+          )
 end
 
 """
@@ -240,7 +241,7 @@ function descent_to(M::GModule{<:Any, <:AbstractAlgebra.FPModule{<:FinFieldElem}
   k = domain(phi)
   success, N, psi = can_be_defined_over_with_data(M, phi)
   success || error("Module cannot be written over $k")
-  return N
+  return N, psi
 end
 
 

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -343,7 +343,7 @@ Oscar.rank(M::AbstractAlgebra.Generic.Submodule{ZZRingElem}) = ngens(M)
 function maximal_submodule_bases(M::GModule{<:Oscar.GAPGroup, <:AbstractAlgebra.FPModule{<:FinFieldElem}})
   C = Gap(M)
   S = GAP.Globals.MTX.BasesMaximalSubmodules(C)
-  res = []
+  res = dense_matrix_type(base_ring(M))[]
   for s = S
     if length(s) == 0
       m = matrix(base_ring(M), 0, dim(M), [])
@@ -716,7 +716,7 @@ function gmodule_minimal_field(C::GModule{<:Any, <:AbstractAlgebra.FPModule{AbsS
 end
 
 """
-    gmodule_over(Field, GModule)
+    gmodule_over(k::Field, C::GModule)
 """
 function gmodule_over(k::FinField, C::GModule{<:Any, <:AbstractAlgebra.FPModule{<:FinFieldElem}}; do_error::Bool = false)
   #mathematically, k needs to contain the character field
@@ -1642,7 +1642,7 @@ end
 
 function Oscar.simplify(C::GModule{<:Any, <:AbstractAlgebra.FPModule{ZZRingElem}})
  f = invariant_forms(C)[1]
- global last_f = f
+ # global last_f = f
  @assert all(i->det(f[1:i, 1:i])>0, 1:nrows(f))
  m = map(matrix, C.ac)
  S = identity_matrix(ZZ, dim(C))

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -43,7 +43,7 @@ function relative_field(m::Map{<:AbstractAlgebra.Field, <:AbstractAlgebra.Field}
     m = collect(Hecke.coefficients(c))
     m = vcat(m, zeros(k, degree(h) - length(m)))
     r = m
-    for i=2:degree(h)
+    for i in 2:degree(h)
       c = shift_left(c, 1) % h
       m = collect(Hecke.coefficients(c))
       m = vcat(m, zeros(k, degree(h) - length(m)))
@@ -91,12 +91,12 @@ function restriction_of_scalars(M::GModule{<:Oscar.GAPGroup, <:AbstractAlgebra.F
   F = free_module(domain(phi), dim(M)*d)
   _, _, rep = relative_field(phi)
 
-  return GModule(F, group(M), [hom(F, F, hvcat(dim(M), [rep(x) for x = transpose(matrix(y))]...)) for y = M.ac])
+  return GModule(F, group(M), [hom(F, F, hvcat(dim(M), [rep(x) for x in transpose(matrix(y))]...)) for y in M.ac])
 end
 
 function restriction_of_scalars(C::GModule{<:Any, <:AbstractAlgebra.FPModule{AbsSimpleNumFieldElem}}, ::QQField)
   F = free_module(QQ, dim(C)*degree(base_ring(C)))
-  return GModule(F, group(C), [hom(F, F, hvcat(dim(C), [representation_matrix(x) for x = transpose(matrix(y))]...)) for y = C.ac])
+  return GModule(F, group(C), [hom(F, F, hvcat(dim(C), [representation_matrix(x) for x in transpose(matrix(y))]...)) for y in C.ac])
 end
 
 
@@ -317,13 +317,13 @@ function invariant_lattice_classes(M::GModule{<:Oscar.GAPGroup, <:AbstractAlgebr
     for X in res[sres:end]
       for p in lp
         F = free_module(GF(p), dim(M))
-        pM = gmodule(M.G, [hom(F, F, map_entries(base_ring(F), x)) for x = map(matrix, action(M))])
+        pM = gmodule(M.G, [hom(F, F, map_entries(base_ring(F), x)) for x in map(matrix, action(M))])
         S = maximal_submodule_bases(pM)
         pG = p.*gens(M.M)
-        for s = S
-          x, mx = sub(M.M, vcat(pG, [M.M(map_entries(x->lift(ZZ, x), s[i:i, :])) for i=1:nrows(s)]))
+        for s in S
+          x, mx = sub(M.M, vcat(pG, [M.M(map_entries(x->lift(ZZ, x), s[i:i, :])) for i in 1:nrows(s)]))
 
-          r = (gmodule(M.G, [_hom(mx*h*pseudo_inv(mx)) for h = M.ac]), mx)
+          r = (gmodule(M.G, [_hom(mx*h*pseudo_inv(mx)) for h in M.ac]), mx)
           if any(x->is_isomorphic(r[1], x[1]), res)
             continue
           else

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -277,7 +277,7 @@ function descent_to_minimal_degree_field(C::GModule{<:Any, <:AbstractAlgebra.FPM
   return C
 end
 
-function descent_to_minimal_degree_field(C::GModule{<:Any, <:AbstractAlgebra.FPModule{AbsSimpleNumField}})
+function descent_to_minimal_degree_field(C::GModule{<:Any, <:AbstractAlgebra.FPModule{AbsSimpleNumFieldElem}})
   return _minimize(C)
 end
 

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -149,9 +149,7 @@ function can_be_defined_over(M::GModule{<:Any, <:AbstractAlgebra.FPModule{<:FinF
   K = base_ring(M)
   d = absolute_degree(k)
   @assert absolute_degree(K) != d
-
   s = absolute_frobenius(K, d)
-  mkK = embed(k, K)
   os = divexact(absolute_degree(K), d)
   hB = hom_base(M, gmodule(M.M, Group(M),
                       [hom(M.M, M.M, map_entries(s, matrix(x))) for x = M.ac]))
@@ -189,7 +187,6 @@ function can_be_defined_over_with_data(M::GModule{<:Any, <:AbstractAlgebra.FPMod
   @assert absolute_degree(K) != d
 
   s = absolute_frobenius(K, d)
-  mkK = embed(k, K)
   os = divexact(absolute_degree(K), d)
   hB = hom_base(M, gmodule(M.M, Group(M),
                       [hom(M.M, M.M, map_entries(s, matrix(x))) for x = M.ac]))
@@ -202,15 +199,17 @@ function can_be_defined_over_with_data(M::GModule{<:Any, <:AbstractAlgebra.FPMod
   D = norm(B, s, os)
   lambda = D[1,1]
   @hassert :MinField 2 D == lambda*identity_matrix(K, dim(C))
-  alpha = norm_equation(K, preimage(mkK, lambda))
+  alpha = norm_equation(K, preimage(phi, lambda))
   B *= inv(alpha)
   @hassert :MinField 2 isone(norm(B, s, os))
   D = hilbert90_cyclic(B, s, os)
   Di = inv(D)
   F = free_module(k, dim(M))
-  return (true,
-          gmodule(F, Group(M), [hom(F, F, map_entries(x -> preimage(mkK, x), Di*matrix(x)*D)) for x = C.ac])
-          )
+  N = gmodule(F, Group(M), [hom(F, F, map_entries(x -> preimage(phi, x), Di*matrix(x)*D)) for x = C.ac])
+  # TODO: Get this map working
+  # psi = GModuleHom(N, M, , phi)
+  psi = nothing
+  return (true, N, psi)
 end
 
 """
@@ -241,7 +240,7 @@ function descent_to(M::GModule{<:Any, <:AbstractAlgebra.FPModule{<:FinFieldElem}
   k = domain(phi)
   success, N, psi = can_be_defined_over_with_data(M, phi)
   success || error("Module cannot be written over $k")
-  return N, psi
+  return N
 end
 
 

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -471,9 +471,9 @@ function _minimize(V::GModule{<:Oscar.GAPGroup, <:AbstractAlgebra.FPModule{AbsSi
       d = 1 # only a lower bound is known
     end
     s = subfields(base_ring(V))
-    s = [x for x = s if degree(x[1]) >= d*degree(k)]
+    s = [x for x in s if degree(x[1]) >= d*degree(k)]
     sort!(s, lt = (a,b) -> degree(a[1]) < degree(b[1]))
-    for (m, mm) = s
+    for (m, mm) in s
       if m == base_ring(V)
         @vprint :MinField 1 "no smaller field possible\n"
         return V

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -579,7 +579,8 @@ function _character(C::GModule{<:Any, <:AbstractAlgebra.FPModule{<:AbstractAlgeb
     end
     #use T = action(C, r) instead?
     p = preimage(phi, r)
-    T = map_word(p, ac; genimgs_inv = iac)
+    T = action(C, r)
+    # T = map_word(p, ac; genimgs_inv = iac)
     push!(chr, (c, trace(matrix(T))))
   end
   return chr

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -148,9 +148,7 @@ function can_be_defined_over(M::GModule{<:Any, <:AbstractAlgebra.FPModule{<:FinF
   K = base_ring(M)
   d = absolute_degree(k)
   @assert absolute_degree(K) != d
-
   s = absolute_frobenius(K, d)
-  mkK = embed(k, K)
   os = divexact(absolute_degree(K), d)
   hB = hom_base(M, gmodule(M.M, Group(M),
                       [hom(M.M, M.M, map_entries(s, matrix(x))) for x = M.ac]))
@@ -188,7 +186,6 @@ function can_be_defined_over_with_data(M::GModule{<:Any, <:AbstractAlgebra.FPMod
   @assert absolute_degree(K) != d
 
   s = absolute_frobenius(K, d)
-  mkK = embed(k, K)
   os = divexact(absolute_degree(K), d)
   hB = hom_base(M, gmodule(M.M, Group(M),
                       [hom(M.M, M.M, map_entries(s, matrix(x))) for x = M.ac]))
@@ -201,15 +198,17 @@ function can_be_defined_over_with_data(M::GModule{<:Any, <:AbstractAlgebra.FPMod
   D = norm(B, s, os)
   lambda = D[1,1]
   @hassert :MinField 2 D == lambda*identity_matrix(K, dim(C))
-  alpha = norm_equation(K, preimage(mkK, lambda))
+  alpha = norm_equation(K, preimage(phi, lambda))
   B *= inv(alpha)
   @hassert :MinField 2 isone(norm(B, s, os))
   D = hilbert90_cyclic(B, s, os)
   Di = inv(D)
   F = free_module(k, dim(M))
-  return (true,
-          gmodule(F, Group(M), [hom(F, F, map_entries(x -> preimage(mkK, x), Di*matrix(x)*D)) for x = C.ac])
-          )
+  N = gmodule(F, Group(M), [hom(F, F, map_entries(x -> preimage(phi, x), Di*matrix(x)*D)) for x = C.ac])
+  # TODO: Get this map working
+  # psi = GModuleHom(N, M, , phi)
+  psi = nothing
+  return (true, N, psi)
 end
 
 """
@@ -240,7 +239,7 @@ function descent_to(M::GModule{<:Any, <:AbstractAlgebra.FPModule{<:FinFieldElem}
   k = domain(phi)
   success, N, psi = can_be_defined_over_with_data(M, phi)
   success || error("Module cannot be written over $k")
-  return N, psi
+  return N
 end
 
 

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -83,7 +83,7 @@ G-module for G acting on vector space of dimension 8 over rational field
 ```
 """
 function restriction_of_scalars(M::GModule{<:Oscar.GAPGroup, <:AbstractAlgebra.FPModule{<:FieldElem}}, phi::Map)
-  #works iff relative_field above works. At least for AbsSimpleNumField and
+  #works iff relative_field above works. At least for AnticNumberField and
   #finite fields
   @assert codomain(phi) == base_ring(M)
   d = divexact(degree(codomain(phi)), degree(domain(phi)))

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -24,6 +24,7 @@ import Base: parent
 function relative_field(m::Map{<:AbstractAlgebra.Field, <:AbstractAlgebra.Field})
   k = domain(m)
   K = codomain(m)
+  @assert base_field(k) == base_field(K)
   kt, t = polynomial_ring(k, cached = false)
   f = defining_polynomial(K)
   Qt = parent(f)
@@ -268,7 +269,7 @@ function descent_to_minimal_degree_field(C::GModule{<:Any, <:AbstractAlgebra.FPM
   d = 0
   while d < absolute_degree(K)-1
     d += 1
-    degree(K) % d == 0 || continue
+    absolute_degree(K) % d == 0 || continue
     k = GF(characteristic(K), d)
     D = gmodule_over(k, C, do_error = false)
     D === nothing || return D
@@ -683,7 +684,7 @@ function Hecke.frobenius(K::FinField, i::Int=1)
 end
 
 function Hecke.absolute_frobenius(K::FinField, i::Int=1)
-  MapFromFunc(K, K, x->Hecke.absolute_frobenius(x, i), y -> Hecke.absolute_frobenius(x, degree(K)-i))
+  MapFromFunc(K, K, x->Hecke.absolute_frobenius(x, i), y -> Hecke.absolute_frobenius(x, absolute_degree(K)-i))
 end
 
 @doc raw"""
@@ -700,10 +701,10 @@ function gmodule_minimal_field(C::GModule{<:Any, <:AbstractAlgebra.FPModule{<:Fi
   #always over char field
   K =  base_ring(C)
   d = 0
-  while d < degree(K)-1
+  while d < absolute_degree(K)-1
     d += 1
-    degree(K) % d == 0 || continue
-    k = GF(Int(characteristic(K)), d)
+    absolute_degree(K) % d == 0 || continue
+    k = GF(characteristic(K), d)
     D = gmodule_over(k, C, do_error = false)
     D === nothing || return D
   end

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -84,7 +84,7 @@ G-module for G acting on vector space of dimension 8 over rational field
 ```
 """
 function restriction_of_scalars(M::GModule{<:Oscar.GAPGroup, <:AbstractAlgebra.FPModule{<:FieldElem}}, phi::Map)
-  #works iff relative_field above works. At least for AnticNumberField and
+  #works iff relative_field above works. At least for AbsSimpleNumField and
   #finite fields
   @assert codomain(phi) == base_ring(M)
   d = divexact(degree(codomain(phi)), degree(domain(phi)))

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -1561,11 +1561,6 @@ function Oscar.gmodule(::Type{FinGenAbGroup}, C::GModule{T, <:AbstractAlgebra.FP
   return GModule(group(C), [hom(A, A, map_entries(x->lift(ZZ, x), hvcat(dim(C), [absolute_representation_matrix(x) for x = transpose(matrix(y))]...))) for y = C.ac])
 end
 
-function Oscar.gmodule(::Type{FinGenAbGroup}, C::GModule{T, <:AbstractAlgebra.FPModule{ZZRingElem}}) where {T <: Oscar.GAPGroup}
-  A = free_abelian_group(rank(C.M))
-  return Oscar.gmodule(Group(C), [hom(A, A, matrix(x)) for x = C.ac])
-end
-
 function Oscar.gmodule(::Type{FinGenAbGroup}, C::GModule{T, <:AbstractAlgebra.FPModule{<:Union{FpFieldElem, fpFieldElem}}}) where {T <: Oscar.GAPGroup}
   A = abelian_group([characteristic(base_ring(C)) for i=1:rank(C.M)])
   return Oscar.gmodule(A, Group(C), [hom(A, A, map_entries(lift, matrix(x))) for x = C.ac])

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -84,7 +84,7 @@ G-module for G acting on vector space of dimension 8 over rational field
 ```
 """
 function restriction_of_scalars(M::GModule{<:Oscar.GAPGroup, <:AbstractAlgebra.FPModule{<:FieldElem}}, phi::Map)
-  #works iff relative_field above works. At least for AbsSimpleNumField and
+  #works iff relative_field above works. At least for AnticNumberField and
   #finite fields
   @assert codomain(phi) == base_ring(M)
   d = divexact(degree(codomain(phi)), degree(domain(phi)))

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -277,7 +277,7 @@ function descent_to_minimal_degree_field(C::GModule{<:Any, <:AbstractAlgebra.FPM
   return C
 end
 
-function descent_to_minimal_degree_field(C::GModule{<:Any, <:AbstractAlgebra.FPModule{nf_elem}})
+function descent_to_minimal_degree_field(C::GModule{<:Any, <:AbstractAlgebra.FPModule{AbsSimpleNumField}})
   return _minimize(C)
 end
 

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -269,8 +269,8 @@ function descent_to_minimal_degree_field(C::GModule{<:Any, <:AbstractAlgebra.FPM
   d = 0
   while d < absolute_degree(K)-1
     d += 1
-    absolute_degree(K) % d == 0 || continue
-    k = GF(Int(characteristic(K)), d)
+    degree(K) % d == 0 || continue
+    k = GF(characteristic(K), d)
     D = gmodule_over(k, C, do_error = false)
     D === nothing || return D
   end


### PR DESCRIPTION
This is some work in progress to address #3224. There are a few methods that need to be implemented, these are

### Missing GModule methods
- [x] `extension_of_scalars` I wrote a simple method for this
- [ ] `can_be_defined_over`
- [ ] `can_be_defined_over_with_data`
- [x]  `descent_to_minimal_degree_field` I borrowed the contents for `descent_to_minimal_degree_field` from the preexisting `gmodule_minimal_field` methods
- [ ] `invariant_lattice_classes`

I believe that the `can_be_defined_over*` methods can be in some cases defined using `gmodule_over`, but the latter seems to only be implemented for fields, while the former seems like it should also work for the ring of integers.

I am not sure of how to implement  `invariant_lattice_classes`. 

I appreciate any feedback on what's here, advice on the remaining methods, and tips for some easy tests to write that won't take too long to run.