### PR TITLE
Wrap tests/doctests into `with_unicode(false)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 cohomCalg_jll = "5558cf25-a90e-53b0-b813-cadaa3ae7ade"
 
 [compat]
-AbstractAlgebra = "0.37.3"
+AbstractAlgebra = "0.37.5"
 AlgebraicSolving = "0.4.6"
 Distributed = "1.6"
 DocStringExtensions = "0.8, 0.9"

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -67,12 +67,14 @@ function doctest_fix(f::Function; set_meta::Bool = false)
   S = Symbol(f)
   doc, doctest = get_document(set_meta)
 
-  #essentially inspired by Documenter/src/DocTests.jl
-  pm = parentmodule(f)
-  bm = Base.Docs.meta(pm)
-  md = bm[Base.Docs.Binding(pm, S)]
-  for s in md.order
-    doctest(md.docs[s], Oscar, doc)
+  with_unicode(false) do
+    #essentially inspired by Documenter/src/DocTests.jl
+    pm = parentmodule(f)
+    bm = Base.Docs.meta(pm)
+    md = bm[Base.Docs.Binding(pm, S)]
+    for s in md.order
+      doctest(md.docs[s], Oscar, doc)
+    end
   end
 end
 
@@ -92,13 +94,15 @@ julia> Oscar.doctest_fix("/Rings/")
 function doctest_fix(path::String; set_meta::Bool=false)
   doc, doctest = get_document(set_meta)
 
-  walkmodules(Oscar) do m
-    #essentially inspired by Documenter/src/DocTests.jl
-    bm = Base.Docs.meta(m)
-    for (_, md) in bm
-      for s in md.order
-        if occursin(path, md.docs[s].data[:path])
-          doctest(md.docs[s], Oscar, doc)
+  with_unicode(false) do
+    walkmodules(Oscar) do m
+      #essentially inspired by Documenter/src/DocTests.jl
+      bm = Base.Docs.meta(m)
+      for (_, md) in bm
+        for s in md.order
+          if occursin(path, md.docs[s].data[:path])
+            doctest(md.docs[s], Oscar, doc)
+          end
         end
       end
     end
@@ -211,8 +215,12 @@ function build_doc(; doctest::Union{Symbol, Bool} = false, warnonly = true, open
   if !isdefined(Main, :BuildDoc)
     doc_init()
   end
-  Pkg.activate(docsproject) do
-    Base.invokelatest(Main.BuildDoc.doit, Oscar; warnonly=warnonly, local_build=true, doctest=doctest)
+  with_unicode(false) do
+    Pkg.activate(docsproject) do
+      Base.invokelatest(
+        Main.BuildDoc.doit, Oscar; warnonly=warnonly, local_build=true, doctest=doctest
+      )
+    end
   end
   if start_server
     start_doc_preview_server(open_browser = open_browser)

--- a/test/Combinatorics/EnumerativeCombinatorics/tableaux.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/tableaux.jl
@@ -210,7 +210,7 @@ julia> young_tableau([[1, 2, 3, 4, 5, 6, 7, 8, 9], [10]])
 | 10 |
 +----+
 
-julia> old_unicode = Oscar.allow_unicode(true);
+julia> old_unicode = Oscar.allow_unicode(true; temporary=true);
 
 julia> young_tableau(Vector{Int}[])
 Empty Young tableau
@@ -257,7 +257,7 @@ julia> young_tableau([[1, 2, 3, 4, 5, 6, 7, 8, 9], [10]])
 │ 10 │
 └────┘
 
-julia> Oscar.allow_unicode(old_unicode);
+julia> Oscar.allow_unicode(old_unicode; temporary=true);
 ```
 """
 function dummy_placeholder end

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -2,7 +2,7 @@
   old_flag = Oscar.is_unicode_allowed()
 
   @test Oscar.is_unicode_allowed() == false
-  @test allow_unicode(true) == false
+  @test allow_unicode(true; temporary=true) == false
   @test Oscar.is_unicode_allowed() == true
 
   struct AtoB
@@ -16,11 +16,11 @@
     end
   end
 
-  allow_unicode(false)
+  allow_unicode(false; temporary=true)
   @test sprint(show, AtoB()) == "A->B"
-  allow_unicode(true)
+  allow_unicode(true; temporary=true)
   @test sprint(show, AtoB()) == "A→B"
 
   # Restore old flag
-  allow_unicode(old_flag)
+  allow_unicode(old_flag; temporary=true)
 end


### PR DESCRIPTION
Needs https://github.com/Nemocas/AbstractAlgebra.jl/pull/1586.

If one has unicode enabled and runs tests/doctests/`doctest_fix` locally, this may lead to inconsistent results (as the printing may use unicode).
This PR wraps all of these functions into a block that disables unicode temporarily to get consistent output.