### PR TITLE
Add describe(G::MultTableGroup)

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -2198,3 +2198,5 @@ function is_obviously_abelian(G::FPGroup)
     end
     return true
 end
+
+describe(G::MultTableGroup) = describe(PermGroup(G))


### PR DESCRIPTION
We probably should add even more methods for this to get feature parity.

For this it would be useful if GrpGen could cache an isomorphism
with a permutation group, if it doesn't do that already (similar
to the 'nice monomorphism' feature in GAP). We then also need a
way to do this more generally... I.e. I don't want to define
`derived_series` for every type, ideally, but rather have some
generic fallbacks, as in GAP...


