### PR TITLE
Add paragraph about `number_of_` to the styleguide.

### DIFF
--- a/docs/src/DeveloperDocumentation/styleguide.md
+++ b/docs/src/DeveloperDocumentation/styleguide.md
@@ -60,7 +60,7 @@ Here is a summary of the naming convention followed in OSCAR:
   Julia functions, e.g. `is_one` as alias for `isone`.
 - A function returning the number of some things should be named `number_of_things`.
   For some very common things, like the number of generators, we additionally
-  provide an alias `ngens` for `number_of_generators`. These aliases should be
+  provide a shorter alias, e.g. `ngens` for `number_of_generators`. These aliases should be
   short (< 15 chararacters) and without underscores, and one should only use
   them inside of functions, not in the user interface and documentation.
 - For generic concepts choose generic names, based on general algebraic

--- a/docs/src/DeveloperDocumentation/styleguide.md
+++ b/docs/src/DeveloperDocumentation/styleguide.md
@@ -58,11 +58,12 @@ Here is a summary of the naming convention followed in OSCAR:
   For compatibility with standard Julia, while staying consistent internally,
   we also provide aliases (using `AbstractAlgebra.@alias`) for various standard
   Julia functions, e.g. `is_one` as alias for `isone`.
-- A function returning the number of some things should be named `number_of_things`.
+- A function returning the number of some things should be named `number_of_things`,
+  alternatively it can be named `n_things` with an alias to `number_of_things`.
+  The preferred style should be consistent throughout the corresponding part.
   For some very common things, like the number of generators, we additionally
   provide a shorter alias, e.g. `ngens` for `number_of_generators`. These aliases should be
-  short (< 15 chararacters) and without underscores, and one should only use
-  them inside of functions, not in the user interface and documentation.
+  very short and without underscores.
 - For generic concepts choose generic names, based on general algebraic
   concepts, preferably not special names from your area of speciality.
 - **Avoid direct access to members of our objects.** This means, do not use

--- a/docs/src/DeveloperDocumentation/styleguide.md
+++ b/docs/src/DeveloperDocumentation/styleguide.md
@@ -57,7 +57,12 @@ Here is a summary of the naming convention followed in OSCAR:
   also being consistent.
   For compatibility with standard Julia, while staying consistent internally,
   we also provide aliases (using `AbstractAlgebra.@alias`) for various standard
-  Julia functions, e.g. `is_one` as alias for `isone`
+  Julia functions, e.g. `is_one` as alias for `isone`.
+- A function returning the number of some things should be named `number_of_things`.
+  For some very common things, like the number of generators, we additionally
+  provide an alias `ngens` for `number_of_generators`. These aliases should be
+  short (< 15 chararacters) and without underscores, and one should only use
+  them inside of functions, not in the user interface and documentation.
 - For generic concepts choose generic names, based on general algebraic
   concepts, preferably not special names from your area of speciality.
 - **Avoid direct access to members of our objects.** This means, do not use


### PR DESCRIPTION
As layed out in https://hackmd.io/nRnyfrSxTVe5CzXidB1cBQ?both#number-of-%E2%80%A6 and implemented in https://github.com/Nemocas/AbstractAlgebra.jl/pull/1553, https://github.com/Nemocas/Nemo.jl/pull/1624, https://github.com/thofma/Hecke.jl/pull/1364, https://github.com/oscar-system/Oscar.jl/pull/3272.

Thanks to  @lkastner for pointing out that the style guide change was missed.