### PR TITLE
change one line printing of affine schemes from V(...) to scheme(...)

### DIFF
--- a/experimental/Schemes/BlowupMorphism.jl
+++ b/experimental/Schemes/BlowupMorphism.jl
@@ -217,9 +217,9 @@ Blowup
     1b: Ideal (x, y, z)
 with domain
   scheme over QQ covered with 3 patches
-    1a: [(s1//s0), (s2//s0), x]   V(0, 0, 0)
-    2a: [(s0//s1), (s2//s1), y]   V(0, 0, 0)
-    3a: [(s0//s2), (s1//s2), z]   V(0, 0, 0)
+    1a: [(s1//s0), (s2//s0), x]   scheme(0, 0, 0)
+    2a: [(s0//s1), (s2//s1), y]   scheme(0, 0, 0)
+    3a: [(s0//s2), (s1//s2), z]   scheme(0, 0, 0)
 and exceptional divisor
   effective cartier divisor defined by
     sheaf of ideals with restrictions
@@ -230,9 +230,9 @@ and exceptional divisor
 julia> E = exceptional_divisor(bl)
 Effective cartier divisor
   on scheme over QQ covered with 3 patches
-    1: [(s1//s0), (s2//s0), x]   V(0, 0, 0)
-    2: [(s0//s1), (s2//s1), y]   V(0, 0, 0)
-    3: [(s0//s2), (s1//s2), z]   V(0, 0, 0)
+    1: [(s1//s0), (s2//s0), x]   scheme(0, 0, 0)
+    2: [(s0//s1), (s2//s1), y]   scheme(0, 0, 0)
+    3: [(s0//s2), (s1//s2), z]   scheme(0, 0, 0)
 defined by
   sheaf of ideals with restrictions
     1: ideal(x)

--- a/experimental/Schemes/FunctionFields.jl
+++ b/experimental/Schemes/FunctionFields.jl
@@ -48,9 +48,9 @@ Scheme
   over rational field
 with default covering
   described by patches
-    1: V(-(y//x)^2*(z//x) + 1)
-    2: V((x//y)^3 - (z//y))
-    3: V((x//z)^3 - (y//z)^2)
+    1: scheme(-(y//x)^2*(z//x) + 1)
+    2: scheme((x//y)^3 - (z//y))
+    3: scheme((x//z)^3 - (y//z)^2)
   in the coordinate(s)
     1: [(y//x), (z//x)]
     2: [(x//y), (z//y)]
@@ -59,18 +59,18 @@ with default covering
 julia> K = function_field(Ycov)
 Field of rational functions
   on scheme over QQ covered with 3 patches
-    1: [(y//x), (z//x)]   V(-(y//x)^2*(z//x) + 1)
-    2: [(x//y), (z//y)]   V((x//y)^3 - (z//y))
-    3: [(x//z), (y//z)]   V((x//z)^3 - (y//z)^2)
+    1: [(y//x), (z//x)]   scheme(-(y//x)^2*(z//x) + 1)
+    2: [(x//y), (z//y)]   scheme((x//y)^3 - (z//y))
+    3: [(x//z), (y//z)]   scheme((x//z)^3 - (y//z)^2)
 represented by
   patch 1: fraction field of multivariate polynomial ring
 
 julia> one(K)
 Rational function
   on scheme over QQ covered with 3 patches
-    1: [(y//x), (z//x)]   V(-(y//x)^2*(z//x) + 1)
-    2: [(x//y), (z//y)]   V((x//y)^3 - (z//y))
-    3: [(x//z), (y//z)]   V((x//z)^3 - (y//z)^2)
+    1: [(y//x), (z//x)]   scheme(-(y//x)^2*(z//x) + 1)
+    2: [(x//y), (z//y)]   scheme((x//y)^3 - (z//y))
+    3: [(x//z), (y//z)]   scheme((x//z)^3 - (y//z)^2)
 represented by
   patch 1: 1
 ```

--- a/experimental/Schemes/MorphismFromRationalFunctions.jl
+++ b/experimental/Schemes/MorphismFromRationalFunctions.jl
@@ -134,7 +134,7 @@ julia> realizations = Oscar.realize_on_patch(Phi, U);
 
 julia> realizations[3]
 Affine scheme morphism
-  from [(t//s)]          AA^1 \ V()
+  from [(t//s)]          AA^1 \ scheme()
   to   [(x//z), (y//z)]  affine 2-space
 given by the pullback function
   (x//z) -> (t//s)^2

--- a/experimental/Schemes/Sheaves.jl
+++ b/experimental/Schemes/Sheaves.jl
@@ -430,9 +430,9 @@ Scheme
   over rational field
 with default covering
   described by patches
-    1: V(-(y//x)^2*(z//x) + 1)
-    2: V((x//y)^3 - (z//y))
-    3: V((x//z)^3 - (y//z)^2)
+    1: scheme(-(y//x)^2*(z//x) + 1)
+    2: scheme((x//y)^3 - (z//y))
+    3: scheme((x//z)^3 - (y//z)^2)
   in the coordinate(s)
     1: [(y//x), (z//x)]
     2: [(x//y), (z//y)]
@@ -441,9 +441,9 @@ with default covering
 julia> OO(Ycov)
 Structure sheaf of rings of regular functions
   on scheme over QQ covered with 3 patches
-    1: [(y//x), (z//x)]   V(-(y//x)^2*(z//x) + 1)
-    2: [(x//y), (z//y)]   V((x//y)^3 - (z//y))
-    3: [(x//z), (y//z)]   V((x//z)^3 - (y//z)^2)
+    1: [(y//x), (z//x)]   scheme(-(y//x)^2*(z//x) + 1)
+    2: [(x//y), (z//y)]   scheme((x//y)^3 - (z//y))
+    3: [(x//z), (y//z)]   scheme((x//z)^3 - (y//z)^2)
 ```
 """
 @attr StructureSheafOfRings function OO(X::AbsCoveredScheme)

--- a/experimental/Schemes/SpaceGerms.jl
+++ b/experimental/Schemes/SpaceGerms.jl
@@ -645,7 +645,7 @@ Spectrum
 julia> phi
 Affine scheme morphism
   from [x1, x2, x3]  Spec of localization of Q at complement of maximal ideal
-  to   [x1, x2, x3]  V(x1^2 + x2^2 + x3^2)
+  to   [x1, x2, x3]  scheme(x1^2 + x2^2 + x3^2)
 given by the pullback function
   x1 -> x1
   x2 -> x2
@@ -723,7 +723,7 @@ Spectrum
 julia> phi
 Affine scheme morphism
   from [x1, x2, x3]  Spec of localization of Q at complement of maximal ideal
-  to   [x1, x2, x3]  V(x1^2 + x2^2 + x3^2)
+  to   [x1, x2, x3]  scheme(x1^2 + x2^2 + x3^2)
 given by the pullback function
   x1 -> x1
   x2 -> x2
@@ -798,7 +798,7 @@ Spectrum
 julia> phi
 Affine scheme morphism
   from [x1, x2, x3]  Spec of localization of Q at complement of maximal ideal
-  to   [x1, x2, x3]  V(x1^2 + x2^2 + x3^2, x1*x2)
+  to   [x1, x2, x3]  scheme(x1^2 + x2^2 + x3^2, x1*x2)
 given by the pullback function
   x1 -> x1
   x2 -> x2

--- a/src/AlgebraicGeometry/Curves/AffinePlaneCurve.jl
+++ b/src/AlgebraicGeometry/Curves/AffinePlaneCurve.jl
@@ -109,7 +109,7 @@ julia> D = plane_curve(x*(x+y)*(x-y));
 
 julia> common_components(C, D)
 1-element Vector{AffinePlaneCurve{QQField, MPolyQuoRing{QQMPolyRingElem}}}:
- V(x^2 + x*y)
+ scheme(x^2 + x*y)
 
 ```
 """
@@ -162,7 +162,7 @@ julia> C = plane_curve(x^2*(x+y)*(y^3-x^2));
 
 julia> P = C([2,-2])
 Rational point
-  of V(-x^4 - x^3*y + x^2*y^3 + x*y^4)
+  of scheme(-x^4 - x^3*y + x^2*y^3 + x*y^4)
 with coordinates (2, -2)
 
 julia> multiplicity(C, P)
@@ -199,13 +199,13 @@ julia> C = plane_curve(x^2*(x+y)*(y^3-x^2));
 
 julia> P = C([0, 0])
 Rational point
-  of V(-x^4 - x^3*y + x^2*y^3 + x*y^4)
+  of scheme(-x^4 - x^3*y + x^2*y^3 + x*y^4)
 with coordinates (0, 0)
 
 julia> tangent_lines(C, P)
 Dict{AffinePlaneCurve{QQField, MPolyQuoRing{QQMPolyRingElem}}, Int64} with 2 entries:
-  V(x)     => 3
-  V(x + y) => 1
+  scheme(x)     => 3
+  scheme(x + y) => 1
 
 ```
 """
@@ -290,12 +290,12 @@ Affine plane curve
 
 julia> P = C([QQ(0), QQ(0)])
 Rational point
-  of V(x^2 + x*y)
+  of scheme(x^2 + x*y)
 with coordinates (0, 0)
 
 julia> Q = C([QQ(2), QQ(-2)])
 Rational point
-  of V(x^2 + x*y)
+  of scheme(x^2 + x*y)
 with coordinates (2, -2)
 
 julia> is_transverse_intersection(C, D, P)

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Morphisms/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Morphisms/Attributes.jl
@@ -43,7 +43,7 @@ Spectrum
 
 julia> f = inclusion_morphism(X, Y)
 Affine scheme morphism
-  from [x1, x2, x3]  V(x1)
+  from [x1, x2, x3]  scheme(x1)
   to   [x1, x2, x3]  affine 3-space over QQ
 given by the pullback function
   x1 -> 0
@@ -92,7 +92,7 @@ Spectrum
 
 julia> f = inclusion_morphism(X, Y)
 Affine scheme morphism
-  from [x1, x2, x3]  V(x1)
+  from [x1, x2, x3]  scheme(x1)
   to   [x1, x2, x3]  affine 3-space over QQ
 given by the pullback function
   x1 -> 0
@@ -251,7 +251,7 @@ Spectrum
 
 julia> f = inclusion_morphism(X, Y)
 Affine scheme morphism
-  from [x1, x2, x3]  V(x1)
+  from [x1, x2, x3]  scheme(x1)
   to   [x1, x2, x3]  affine 3-space over QQ
 given by the pullback function
   x1 -> 0
@@ -259,7 +259,7 @@ given by the pullback function
   x3 -> x3
 
 julia> graph(f)
-(V(x1, -x1, x2 - x2, x3 - x3), Hom: V(x1, -x1, x2 - x2, x3 - x3) -> V(x1), Hom: V(x1, -x1, x2 - x2, x3 - x3) -> affine 3-space over QQ with coordinates [x1, x2, x3])
+(scheme(x1, -x1, x2 - x2, x3 - x3), Hom: scheme(x1, -x1, x2 - x2, x3 - x3) -> scheme(x1), Hom: scheme(x1, -x1, x2 - x2, x3 - x3) -> affine 3-space over QQ with coordinates [x1, x2, x3])
 ```
 """
 function graph(f::AbsSpecMor{<:AbsSpec{BRT}, <:AbsSpec{BRT}}) where {BRT}

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Morphisms/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Morphisms/Constructors.jl
@@ -129,7 +129,7 @@ Spectrum
 
 julia> f = inclusion_morphism(Y, X)
 Affine scheme morphism
-  from [x1, x2, x3]  V(x1)
+  from [x1, x2, x3]  scheme(x1)
   to   [x1, x2, x3]  affine 3-space over QQ
 given by the pullback function
   x1 -> 0
@@ -178,7 +178,7 @@ Spectrum
 
 julia> m1 = inclusion_morphism(Y, X)
 Affine scheme morphism
-  from [x1, x2, x3]  V(x1)
+  from [x1, x2, x3]  scheme(x1)
   to   [x1, x2, x3]  affine 3-space over QQ
 given by the pullback function
   x1 -> 0
@@ -196,8 +196,8 @@ given by the pullback function
 
 julia> m3 = identity_map(Y)
 Affine scheme morphism
-  from [x1, x2, x3]  V(x1)
-  to   [x1, x2, x3]  V(x1)
+  from [x1, x2, x3]  scheme(x1)
+  to   [x1, x2, x3]  scheme(x1)
 given by the pullback function
   x1 -> 0
   x2 -> x2

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
@@ -231,7 +231,7 @@ Spectrum
 
 julia> inc = ambient_embedding(Y)
 Affine scheme morphism
-  from [x, y]  V(x)
+  from [x, y]  scheme(x)
   to   [x, y]  affine 2-space over QQ
 given by the pullback function
   x -> 0
@@ -560,7 +560,7 @@ Spectrum
     at complement of maximal ideal of point (0, 0)
 
 julia> reduced_scheme(X)
-(V(x^2 - 2*x*y + y^2, x - y), Hom: V(x^2 - 2*x*y + y^2, x - y) -> V(x^2 - 2*x*y + y^2))
+(scheme(x^2 - 2*x*y + y^2, x - y), Hom: scheme(x^2 - 2*x*y + y^2, x - y) -> scheme(x^2 - 2*x*y + y^2))
 
 julia> reduced_scheme(Y)
 (Spec of localization of quotient of multivariate polynomial ring at complement of maximal ideal, Hom: Spec of localization of quotient of multivariate polynomial ring at complement of maximal ideal -> Spec of localization of quotient of multivariate polynomial ring at complement of maximal ideal)
@@ -644,10 +644,10 @@ Spectrum
     by ideal (x^2 - y^2 + z^2)
 
 julia> singular_locus(A3)
-(V(1), Hom: V(1) -> affine 3-space)
+(scheme(1), Hom: scheme(1) -> affine 3-space)
 
 julia> singular_locus(X)
-(V(x^2 - y^2 + z^2, z, y, x), Hom: V(x^2 - y^2 + z^2, z, y, x) -> V(x^2 - y^2 + z^2))
+(scheme(x^2 - y^2 + z^2, z, y, x), Hom: scheme(x^2 - y^2 + z^2, z, y, x) -> scheme(x^2 - y^2 + z^2))
 
 julia> U = complement_of_point_ideal(R, [0,0,0])
 Complement
@@ -724,10 +724,10 @@ Spectrum
     by ideal (x^4 - 2*x^2*y^2 + 2*x^2*z^2 + y^4 - 2*y^2*z^2 + z^4)
 
 julia> singular_locus_reduced(X)
-(V(x^4 - 2*x^2*y^2 + 2*x^2*z^2 + y^4 - 2*y^2*z^2 + z^4, z, y, x), Hom: V(x^4 - 2*x^2*y^2 + 2*x^2*z^2 + y^4 - 2*y^2*z^2 + z^4, z, y, x) -> V(x^4 - 2*x^2*y^2 + 2*x^2*z^2 + y^4 - 2*y^2*z^2 + z^4))
+(scheme(x^4 - 2*x^2*y^2 + 2*x^2*z^2 + y^4 - 2*y^2*z^2 + z^4, z, y, x), Hom: scheme(x^4 - 2*x^2*y^2 + 2*x^2*z^2 + y^4 - 2*y^2*z^2 + z^4, z, y, x) -> scheme(x^4 - 2*x^2*y^2 + 2*x^2*z^2 + y^4 - 2*y^2*z^2 + z^4))
 
 julia> singular_locus(X)
-(V(x^4 - 2*x^2*y^2 + 2*x^2*z^2 + y^4 - 2*y^2*z^2 + z^4, x^2 - y^2 + z^2), Hom: V(x^4 - 2*x^2*y^2 + 2*x^2*z^2 + y^4 - 2*y^2*z^2 + z^4, x^2 - y^2 + z^2) -> V(x^4 - 2*x^2*y^2 + 2*x^2*z^2 + y^4 - 2*y^2*z^2 + z^4))
+(scheme(x^4 - 2*x^2*y^2 + 2*x^2*z^2 + y^4 - 2*y^2*z^2 + z^4, x^2 - y^2 + z^2), Hom: scheme(x^4 - 2*x^2*y^2 + 2*x^2*z^2 + y^4 - 2*y^2*z^2 + z^4, x^2 - y^2 + z^2) -> scheme(x^4 - 2*x^2*y^2 + 2*x^2*z^2 + y^4 - 2*y^2*z^2 + z^4))
 
 ```
 """

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
@@ -64,7 +64,7 @@ end
 
 function _show(io::IO, X::AbsSpec{<:Any,<:MPolyQuoRing})
   io = pretty(io)
-  print(io, LowercaseOff(), "V(")
+  print(io, "scheme(")
   I = modulus(OO(X))
   join(io, gens(I), ", ")
   print(io, ")")
@@ -72,11 +72,11 @@ end
 
 function _show(io::IO, X::AbsSpec{<:Any, <:MPolyQuoLocRing{<:Any, <:Any, <:Any, <:Any, <:MPolyPowersOfElement}})
   io = pretty(io)
-  print(io, LowercaseOff(), "V(")
+  print(io, "scheme(")
   I = modulus(OO(X))
   S = inverted_set(OO(X))
   join(io, gens(I), ", ")
-  print(io, raw") \ V(")
+  print(io, raw") \ scheme(")
   join(io, denominators(S), ",")
   print(io, ")")
 end
@@ -85,7 +85,7 @@ function _show(io::IO, X::AbsSpec{<:Any, <:MPolyLocRing{<:Any, <:Any, <:Any, <:A
   io = pretty(io)
   print(io, LowercaseOff(), "AA^", ngens(OO(X)))
   S = inverted_set(OO(X))
-  print(io, raw" \ V(")
+  print(io, raw" \ scheme(")
   join(io, denominators(S), ",")
   print(io, ")")
 end

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Morphisms/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Morphisms/Attributes.jl
@@ -31,9 +31,9 @@ Scheme
   over rational field
 with default covering
   described by patches
-    1: V(-(y//x)^2*(z//x) + 1)
-    2: V((x//y)^3 - (z//y))
-    3: V((x//z)^3 - (y//z)^2)
+    1: scheme(-(y//x)^2*(z//x) + 1)
+    2: scheme((x//y)^3 - (z//y))
+    3: scheme((x//z)^3 - (y//z)^2)
   in the coordinate(s)
     1: [(y//x), (z//x)]
     2: [(x//y), (z//y)]
@@ -45,11 +45,11 @@ julia> I, s = singular_locus(Ycov)
 julia> covering_morphism(s)
 Covering morphism
   from covering with 1 patch
-    1a: [(x//z), (y//z)]   V((x//z)^3 - (y//z)^2, (y//z), (x//z))
+    1a: [(x//z), (y//z)]   scheme((x//z)^3 - (y//z)^2, (y//z), (x//z))
   to covering with 3 patches
-    1b: [(y//x), (z//x)]   V(-(y//x)^2*(z//x) + 1)
-    2b: [(x//y), (z//y)]   V((x//y)^3 - (z//y))
-    3b: [(x//z), (y//z)]   V((x//z)^3 - (y//z)^2)
+    1b: [(y//x), (z//x)]   scheme(-(y//x)^2*(z//x) + 1)
+    2b: [(x//y), (z//y)]   scheme((x//y)^3 - (z//y))
+    3b: [(x//z), (y//z)]   scheme((x//z)^3 - (y//z)^2)
 given by the pullback function
   1a -> 3b
     (x//z) -> 0

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Morphisms/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Morphisms/Constructors.jl
@@ -24,16 +24,16 @@ Scheme
   over rational field
 with default covering
   described by patches
-    1: V((y//z), (x//z))
+    1: scheme((y//z), (x//z))
   in the coordinate(s)
     1: [(x//z), (y//z)]
 
 julia> identity_map(Xcov)
 Covered scheme morphism
   from scheme over QQ covered with 1 patch
-    1a: [(x//z), (y//z)]   V((y//z), (x//z))
+    1a: [(x//z), (y//z)]   scheme((y//z), (x//z))
   to scheme over QQ covered with 1 patch
-    1b: [(x//z), (y//z)]   V((y//z), (x//z))
+    1b: [(x//z), (y//z)]   scheme((y//z), (x//z))
 given by the pullback function
   1a -> 1b
     (x//z) -> 0

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Attributes.jl
@@ -68,9 +68,9 @@ Scheme
   over rational field
 with default covering
   described by patches
-    1: V((s1//s0) - (s2//s0)^2)
-    2: V((s0//s1) - (s2//s1)^2)
-    3: V((s0//s2)*(s1//s2) - 1)
+    1: scheme((s1//s0) - (s2//s0)^2)
+    2: scheme((s0//s1) - (s2//s1)^2)
+    3: scheme((s0//s2)*(s1//s2) - 1)
   in the coordinate(s)
     1: [(s1//s0), (s2//s0)]
     2: [(s0//s1), (s2//s1)]
@@ -79,9 +79,9 @@ with default covering
 julia> default_covering(Xcov)
 Covering
   described by patches
-    1: V((s1//s0) - (s2//s0)^2)
-    2: V((s0//s1) - (s2//s1)^2)
-    3: V((s0//s2)*(s1//s2) - 1)
+    1: scheme((s1//s0) - (s2//s0)^2)
+    2: scheme((s0//s1) - (s2//s1)^2)
+    3: scheme((s0//s2)*(s1//s2) - 1)
   in the coordinate(s)
     1: [(s1//s0), (s2//s0)]
     2: [(s0//s1), (s2//s1)]
@@ -123,9 +123,9 @@ Scheme
   over rational field
 with default covering
   described by patches
-    1: V((s1//s0) - (s2//s0)^2)
-    2: V((s0//s1) - (s2//s1)^2)
-    3: V((s0//s2)*(s1//s2) - 1)
+    1: scheme((s1//s0) - (s2//s0)^2)
+    2: scheme((s0//s1) - (s2//s1)^2)
+    3: scheme((s0//s2)*(s1//s2) - 1)
   in the coordinate(s)
     1: [(s1//s0), (s2//s0)]
     2: [(s0//s1), (s2//s1)]
@@ -133,9 +133,9 @@ with default covering
 
 julia> affine_charts(Xcov)
 3-element Vector{Spec{QQField, MPolyQuoRing{QQMPolyRingElem}}}:
- V((s1//s0) - (s2//s0)^2)
- V((s0//s1) - (s2//s1)^2)
- V((s0//s2)*(s1//s2) - 1)
+ scheme((s1//s0) - (s2//s0)^2)
+ scheme((s0//s1) - (s2//s1)^2)
+ scheme((s0//s2)*(s1//s2) - 1)
 
 ```
 """
@@ -223,9 +223,9 @@ Scheme
   over rational field
 with default covering
   described by patches
-    1: V(-(y//x)^2*(z//x) + 1)
-    2: V((x//y)^3 - (z//y))
-    3: V((x//z)^3 - (y//z)^2)
+    1: scheme(-(y//x)^2*(z//x) + 1)
+    2: scheme((x//y)^3 - (z//y))
+    3: scheme((x//z)^3 - (y//z)^2)
   in the coordinate(s)
     1: [(y//x), (z//x)]
     2: [(x//y), (z//y)]
@@ -239,18 +239,18 @@ Scheme
   over rational field
 with default covering
   described by patches
-    1: V((x//z)^3 - (y//z)^2, (y//z), (x//z))
+    1: scheme((x//z)^3 - (y//z)^2, (y//z), (x//z))
   in the coordinate(s)
     1: [(x//z), (y//z)]
 
 julia> s
 Covered scheme morphism
   from scheme over QQ covered with 1 patch
-    1a: [(x//z), (y//z)]   V((x//z)^3 - (y//z)^2, (y//z), (x//z))
+    1a: [(x//z), (y//z)]   scheme((x//z)^3 - (y//z)^2, (y//z), (x//z))
   to scheme over QQ covered with 3 patches
-    1b: [(y//x), (z//x)]   V(-(y//x)^2*(z//x) + 1)
-    2b: [(x//y), (z//y)]   V((x//y)^3 - (z//y))
-    3b: [(x//z), (y//z)]   V((x//z)^3 - (y//z)^2)
+    1b: [(y//x), (z//x)]   scheme(-(y//x)^2*(z//x) + 1)
+    2b: [(x//y), (z//y)]   scheme((x//y)^3 - (z//y))
+    3b: [(x//z), (y//z)]   scheme((x//z)^3 - (y//z)^2)
 given by the pullback function
   1a -> 3b
     (x//z) -> 0

--- a/src/AlgebraicGeometry/Schemes/Covering/Morphisms/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/Covering/Morphisms/Constructors.jl
@@ -19,9 +19,9 @@ julia> Ycov = covered_scheme(Y);
 julia> C = default_covering(Ycov)
 Covering
   described by patches
-    1: V(-(y//x)^2*(z//x) + 1)
-    2: V((x//y)^3 - (z//y))
-    3: V((x//z)^3 - (y//z)^2)
+    1: scheme(-(y//x)^2*(z//x) + 1)
+    2: scheme((x//y)^3 - (z//y))
+    3: scheme((x//z)^3 - (y//z)^2)
   in the coordinate(s)
     1: [(y//x), (z//x)]
     2: [(x//y), (z//y)]
@@ -30,13 +30,13 @@ Covering
 julia> identity_map(C)
 Covering morphism
   from covering with 3 patches
-    1a: [(y//x), (z//x)]   V(-(y//x)^2*(z//x) + 1)
-    2a: [(x//y), (z//y)]   V((x//y)^3 - (z//y))
-    3a: [(x//z), (y//z)]   V((x//z)^3 - (y//z)^2)
+    1a: [(y//x), (z//x)]   scheme(-(y//x)^2*(z//x) + 1)
+    2a: [(x//y), (z//y)]   scheme((x//y)^3 - (z//y))
+    3a: [(x//z), (y//z)]   scheme((x//z)^3 - (y//z)^2)
   to covering with 3 patches
-    1b: [(y//x), (z//x)]   V(-(y//x)^2*(z//x) + 1)
-    2b: [(x//y), (z//y)]   V((x//y)^3 - (z//y))
-    3b: [(x//z), (y//z)]   V((x//z)^3 - (y//z)^2)
+    1b: [(y//x), (z//x)]   scheme(-(y//x)^2*(z//x) + 1)
+    2b: [(x//y), (z//y)]   scheme((x//y)^3 - (z//y))
+    3b: [(x//z), (y//z)]   scheme((x//z)^3 - (y//z)^2)
 given by the pullback functions
   1a -> 1b
     (y//x) -> (y//x)

--- a/src/AlgebraicGeometry/Schemes/Gluing/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/Gluing/Constructors.jl
@@ -27,8 +27,8 @@ Gluing
   of affine 2-space
   and affine 2-space
 along the open subsets
-  [x, y]   AA^2 \ V(x)
-  [u, v]   AA^2 \ V(u)
+  [x, y]   AA^2 \ scheme(x)
+  [u, v]   AA^2 \ scheme(u)
 given by the pullback function
   u -> 1/x
   v -> y/x
@@ -53,7 +53,7 @@ along the open subsets
   [u, v]   complement to V(u) in affine scheme with coordinates [u, v]
 defined by the map
   affine scheme morphism
-    from [x, y]  AA^2 \ V(x)
+    from [x, y]  AA^2 \ scheme(x)
     to   [u, v]  affine 2-space
   given by the pullback function
     u -> 1/x

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Methods.jl
@@ -42,9 +42,9 @@ Scheme
   over rational field
 with default covering
   described by patches
-    1: V(-(y//x)^2*(z//x) + 1)
-    2: V((x//y)^3 - (z//y))
-    3: V((x//z)^3 - (y//z)^2)
+    1: scheme(-(y//x)^2*(z//x) + 1)
+    2: scheme((x//y)^3 - (z//y))
+    3: scheme((x//z)^3 - (y//z)^2)
   in the coordinate(s)
     1: [(y//x), (z//x)]
     2: [(x//y), (z//y)]

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl
@@ -281,7 +281,7 @@ Projective space of dimension 2
 with homogeneous coordinates [x, y, z]
 
 julia> affine_cone(P)
-(V(u^2 + v^2), Map: S -> quotient of multivariate polynomial ring)
+(scheme(u^2 + v^2), Map: S -> quotient of multivariate polynomial ring)
 ```
 """
 affine_cone(P::AbsProjectiveScheme)

--- a/src/AlgebraicGeometry/Schemes/SpecOpen/Objects/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/SpecOpen/Objects/Constructors.jl
@@ -163,7 +163,7 @@ Spec open morphism
   to   [x2, y2, z2]              complement to V(x2^2 - y2^2 + z2^2)
 defined by the map
   affine scheme morphism
-    from [x2, y2, z2, x1, y1, z1]  V(x1^3 - y1^2*z1) \ V(x2^2 - y2^2 + z2^2)
+    from [x2, y2, z2, x1, y1, z1]  scheme(x1^3 - y1^2*z1) \ scheme(x2^2 - y2^2 + z2^2)
     to   [x2, y2, z2]              affine 3-space
   given by the pullback function
     x2 -> x2
@@ -176,8 +176,8 @@ Spec open morphism
   to   [x1, y1, z1]              complement to V(1)
 defined by the map
   affine scheme morphism
-    from [x2, y2, z2, x1, y1, z1]  V(x1^3 - y1^2*z1) \ V(x2^2 - y2^2 + z2^2)
-    to   [x1, y1, z1]              V(x1^3 - y1^2*z1)
+    from [x2, y2, z2, x1, y1, z1]  scheme(x1^3 - y1^2*z1) \ scheme(x2^2 - y2^2 + z2^2)
+    to   [x1, y1, z1]              scheme(x1^3 - y1^2*z1)
   given by the pullback function
     x1 -> x1
     y1 -> y1

--- a/src/AlgebraicGeometry/Schemes/SpecOpen/Rings/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/SpecOpen/Rings/Constructors.jl
@@ -42,7 +42,7 @@ Regular function
     of affine scheme with coordinates [x, y, z]
   complement to V(x^3 - y^2*z)
   covered by 1 affine patch
-    1: [x, y, z]   AA^3 \ V(x^3 - y^2*z)
+    1: [x, y, z]   AA^3 \ scheme(x^3 - y^2*z)
 with restriction
   patch 1: 1
 ```

--- a/src/AlgebraicGeometry/ToricVarieties/ToricSchemes/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricSchemes/attributes.jl
@@ -17,7 +17,7 @@ julia> antv = affine_normal_toric_variety(C)
 Normal toric variety
 
 julia> forget_toric_structure(antv)
-(V(0), Hom: V(0) -> normal toric variety)
+(scheme(0), Hom: scheme(0) -> normal toric variety)
 ```
 """
 function forget_toric_structure(X::AffineNormalToricVariety)


### PR DESCRIPTION
Currently affine algebraic sets and schemes both print in one line mode with `V(...)` but then it is unclear 
whether or not the scheme considered is assumed to be reduced or not. 
After this PR we have `V(...)` for affine algebraic sets and `scheme(...)` for  affine schemes.