### PR TITLE
Add missing hash methods for maps

### DIFF
--- a/experimental/GModule/Cohomology.jl
+++ b/experimental/GModule/Cohomology.jl
@@ -1713,7 +1713,13 @@ function Oscar.matrix(M::FreeModuleHom{FreeMod{QQAbElem}, FreeMod{QQAbElem}})
 end
 
 function ==(a::Union{Generic.ModuleHomomorphism, Generic.ModuleIsomorphism}, b::Union{Generic.ModuleHomomorphism, Generic.ModuleIsomorphism})
+  domain(a) === domain(b) || return false
+  codomain(a) === codomain(b) || return false
   return matrix(a) == matrix(b)
+end
+
+function Base.hash(a::Union{Generic.ModuleHomomorphism, Generic.ModuleIsomorphism}, h::UInt)
+  return hash(matrix(a), h)
 end
 
 function Oscar.id_hom(A::AbstractAlgebra.FPModule)

--- a/experimental/GModule/Cohomology.jl
+++ b/experimental/GModule/Cohomology.jl
@@ -1719,7 +1719,10 @@ function ==(a::Union{Generic.ModuleHomomorphism, Generic.ModuleIsomorphism}, b::
 end
 
 function Base.hash(a::Union{Generic.ModuleHomomorphism, Generic.ModuleIsomorphism}, h::UInt)
-  return hash(matrix(a), h)
+  h = hash(domain(a), h)
+  h = hash(codomain(a), h)
+  h = hash(matrix(a), h)
+  return h
 end
 
 function Oscar.id_hom(A::AbstractAlgebra.FPModule)

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -2407,6 +2407,14 @@ function Base.:(==)(
   return all(x->f(x) == g(x), gens(domain(f)))
 end
 
+function Base.hash(f::Map{<:MPolyAnyRing, <:MPolyAnyRing}, h::UInt)
+    h = hash(domain(f), h)
+    h = hash(codomain(f), h)
+    # TODO: add in coefficient_map if available
+    h = hash(f.(gens(domain(f))), h)
+    return h
+end
+
 coefficient_map(f::MPolyLocalizedRingHom) = coefficient_map(restricted_map(f))
 coefficient_map(f::MPolyQuoLocalizedRingHom) = coefficient_map(restricted_map(f))
 


### PR DESCRIPTION
We have this method in Oscar (I think @HechtiDerLachs added it?):
```julia
# Problems arise with comparison for non-trivial coefficient maps 
# in all constellations. This calls for a streamlined set of commands 
# to check whether coefficient maps exist and if so, what they are, 
# so that they can be compared. 
function Base.:(==)(
    f::Map{<:MPolyAnyRing, <:MPolyAnyRing},
    g::Map{<:MPolyAnyRing, <:MPolyAnyRing}
   )
...
```

However, many of our `Map` types don't implement `hash` -- but implementing
`==` for a type requires that also `hash` is implemented for correctness.

As a result, we currently get this:
```
julia> R, (x, y) = QQ[:x,:y]
(Multivariate polynomial ring in 2 variables over QQ, QQMPolyRingElem[x, y])

julia> f1 = hom(R, R, [y,x]);

julia> f2 = hom(R, R, [y,x]);

julia> f1 == f2
true

julia> hash(f1)
0xb7ee188fb7693c7c

julia> hash(f2)
0x683deafb5f3b9ec7
```


This patch proposes a fix. Note that the TODO in the new `hash` function (which points out that the coefficient map could also be taken into account for computing the hash) is just about getting a better hash, it is not needed for correctness.


A similar issue is fixed in `experimental/GModule/Cohomology.jl` ; that code there should perhaps only apply to `FPModuleHomomorphism` but that's a slightly bigger change....


I guess I should add tests ...
