### PR TITLE
Prepare for name printing changes in AA

### DIFF
--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -1577,7 +1577,7 @@ julia> HC = gens(L[1]);
 
 julia> EMB = L[2]
 Map defined by a julia-function with inverse
-  from homogeneous component of graded multivariate polynomial ring in 5 variables over QQ of degree [2, 1]
+  from S_[2 1] of dim 9
   to graded multivariate polynomial ring in 5 variables over QQ
 
 julia> for i in 1:length(HC) println(EMB(HC[i])) end

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -1290,7 +1290,7 @@ Z^2
 julia> L = homogeneous_component(S, [1, 1]);
 
 julia> L[1]
-homogeneous component of graded multivariate polynomial ring in 5 variables over QQ of degree [1 1]
+S_[1 1] of dim 6
 
 julia> FG = gens(L[1]);
 

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -1162,7 +1162,7 @@ base_ring(f::MPolyDecRingElem) = base_ring(forget_decoration(f))
 
 function show_homo_comp(io::IO, M)
   (W, d) = get_attribute(M, :data)
-  n = get_attribute(W, :name)
+  n = AbstractAlgebra.find_name(W)
   io = pretty(io)
   if n !== nothing
     print(io, LowercaseOff(), "$(n)_$(d.coeff) of dim $(dim(M))")


### PR DESCRIPTION
Makes https://github.com/Nemocas/AbstractAlgebra.jl/pull/1594 non-breaking by using the interface instead of internals (see https://github.com/Nemocas/AbstractAlgebra.jl/pull/1594#issuecomment-1927623096)