### PR TITLE
Sort out some weird formatting issue

### DIFF
--- a/experimental/GITFans/src/GITFans.jl
+++ b/experimental/GITFans/src/GITFans.jl
@@ -186,7 +186,7 @@ Group homomorphism
 
 ```
 
-Note that $\rho(\pi)$, for $\pi \in $`G`, satisfies
+Note that $\rho(\pi)$, for $\pi \in$ `G`, satisfies
 `Q`$^\pi$ = `Q` * $\rho(\pi^{-1})$, where `Q`$^\pi$ is the matrix obtained
 from `Q` by permuting its rows by $\pi$.
 

--- a/src/AlgebraicGeometry/Surfaces/K3Auto.jl
+++ b/src/AlgebraicGeometry/Surfaces/K3Auto.jl
@@ -1375,7 +1375,7 @@ a fundamental domain for the action of ``\mathrm{Aut}(X)`` on the set of nef L|S
 This is almost a fundamental domain for ``\mathrm{Aut}(X)`` on the nef cone.
 
 Here very general means that ``Num(X)`` is isomorphic to `S` and the image of
-$\mathrm{Aut}(X) \to H^0(X,\Omega^2_X)$ is $ \pm 1$.
+$\mathrm{Aut}(X) \to H^0(X,\Omega^2_X)$ is $\pm 1$.
 
 The function returns generators for the image of
 

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1738,7 +1738,7 @@ If `g` is an element of a free group $G$, say, then the rank of $G$ must be
 equal to the length of `genimgs`, `g` is a product of the form
 $g_{i_1}^{e_i} g_{i_2}^{e_2} \cdots g_{i_n}^{e_n}$
 where $g_i$ is the $i$-th generator of $G$ and the $e_i$ are nonzero integers,
-and $R_j = $`imgs[`$i_j$`]`$^{e_j}$.
+and $R_j =$ `imgs[`$i_j$`]`$^{e_j}$.
 
 If `g` is an element of a finitely presented group then the result is
 defined as `map_word` applied to a representing element of the underlying
@@ -1747,7 +1747,7 @@ free group.
 If the first argument is a vector `v` of integers $k_i$ or pairs `k_i => e_i`,
 respectively,
 then the absolute values of the $k_i$ must be at most the length of `genimgs`,
-and $R_j = $`imgs[`$|k_i|$`]`$^{\epsilon_i}$
+and $R_j =$ `imgs[`$|k_i|$`]`$^{\epsilon_i}$
 where $\epsilon_i$ is the `sign` of $k_i$ (times $e_i$).
 
 If a vector `genimgs_inv` is given then its assigned entries are expected

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -1383,7 +1383,7 @@ end
     g_vector(P::Polyhedron)
 
 Return the (toric) $g$-vector of a polytope.
-Defined by $g_0 = 1 $ and $g_k = h_k - h_{k-1}$, for $1 \leq k \leq \lceil (d+1)/2\rceil$ where $h$ is the $h$-vector and $d=\dim(P)$.
+Defined by $g_0 = 1$ and $g_k = h_k - h_{k-1}$, for $1 \leq k \leq \lceil (d+1)/2\rceil$ where $h$ is the $h$-vector and $d=\dim(P)$.
 Undefined for unbounded polyhedra.
 
 # Examples

--- a/src/Rings/mpoly-affine-algebras.jl
+++ b/src/Rings/mpoly-affine-algebras.jl
@@ -1416,7 +1416,7 @@ end
 
 Given an affine algebra $A=R/I$ over a field $K$, return a triple $(V,F,G)$ such that:
 - ``V`` is a vector of $d=\dim A$ elements of $A$, represented by linear forms $l_i\in R$, and such that $K[V]\hookrightarrow A$ is a Noether normalization for $A$; 
-- ``F: A=R/I \to B = R/\phi(I)`` is an isomorphism, induced by a linear change $ \phi $ of coordinates of $R$ which maps the $l_i$ to the the last $d$ variables of $R$; 
+- ``F: A=R/I \to B = R/\phi(I)`` is an isomorphism, induced by a linear change $\phi$ of coordinates of $R$ which maps the $l_i$ to the the last $d$ variables of $R$; 
 - ``G = F^{-1}.``
 
 !!! warning


### PR DESCRIPTION
Resolves #3319.

Apparently, doc strings are sensitive to the spacing around dollar signs. These changes make the doc string for `map_word` render correctly in the REPL (tested with Julia 1.9 and 1.10).
I found a few more such occasions besides the one mentioned in #3319, but I'm far from certain that I found all as grepping for ' \$' is not that helpful.
