### PR TITLE
CI: update to codecov/codecov-action@v4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,7 +98,7 @@ jobs:
       - name: "Upload coverage data to Codecov"
         if: matrix.julia-version == '1.10' && matrix.depwarn != 'depwarn=error'
         continue-on-error: true
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
 
   doctest:
     runs-on: ${{ matrix.os }}
@@ -165,4 +165,4 @@ jobs:
       - name: "Upload coverage data to Codecov"
         if: matrix.julia-version == '1.10' && matrix.depwarn != 'depwarn=error'
         continue-on-error: true
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4


### PR DESCRIPTION
Unlike prior versions, this *requires* that CODECOV_TOKEN is provided (see [here](https://github.com/codecov/codecov-action?tab=readme-ov-file#v4-release)). In practice, already v3 has issues without it. I added this as an organization secret to the `oscar-system` and `nemocas` GitHub organizations a few days ago, so it should be safe to use here.

Before merging this, the output of the `codecov` step in the CI logs should be checked to verify it all went well.