### PR TITLE
support `gen(G::GAPGroup, 0)`

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -446,18 +446,29 @@ has_gens(G::GAPGroup) = GAP.Globals.HasGeneratorsOfGroup(G.X)::Bool
     gen(G::GAPGroup, i::Int)
 
 Return `one(G)` if `i == 0`,
-otherwise the `i`-th element of the vector `gens(G)`.
-This is equivalent to `G[i]`, and returns `gens(G)[i]`
+the `i`-th element of the vector `gens(G)` if `i` is positive,
+and the inverse of the `i`-th element of `gens(G)` if `i` is negative.
+
+For positive `i`, this is equivalent to `G[i]`, and returns `gens(G)[i]`
 but may be more efficient than the latter.
 
-An exception is thrown if `i` is negative or larger than the length of
-`gens(G)`.
+An exception is thrown if `abs(i)` is larger than the length of `gens(G)`.
+
+# Examples
+```jldoctest
+julia> g = symmetric_group(5);  gen(g, 1)
+(1,2,3,4,5)
+
+julia> g[-1]
+(1,5,4,3,2)
+```
 """
 function gen(G::GAPGroup, i::Int)
    i == 0 && return one(G)
    L = GAPWrap.GeneratorsOfGroup(G.X)::GapObj
-   @req 0 < i && i <= length(L) "i must be in the range 0:$(length(L))"
-   return group_element(G, L[i]::GapObj)
+   0 < i && i <= length(L) && return group_element(G, L[i]::GapObj)
+   i < 0 && -i <= length(L) && return group_element(G, inv(L[-i])::GapObj)
+   @req false "i must be in the range -$(length(L)):$(length(L))"
 end
 
 """

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -445,15 +445,18 @@ has_gens(G::GAPGroup) = GAP.Globals.HasGeneratorsOfGroup(G.X)::Bool
 """
     gen(G::GAPGroup, i::Int)
 
-Return the `i`-th element of the vector `gens(G)`.
+Return `one(G)` if `i == 0`,
+otherwise the `i`-th element of the vector `gens(G)`.
 This is equivalent to `G[i]`, and returns `gens(G)[i]`
 but may be more efficient than the latter.
 
-An exception is thrown if `i` is larger than the length of `gens(G)`.
+An exception is thrown if `i` is negative or larger than the length of
+`gens(G)`.
 """
 function gen(G::GAPGroup, i::Int)
+   i == 0 && return one(G)
    L = GAPWrap.GeneratorsOfGroup(G.X)::GapObj
-   @assert length(L) >= i "The number of generators is lower than the given index"
+   @req 0 < i && i <= length(L) "i must be in the range 0:$(length(L))"
    return group_element(G, L[i]::GapObj)
 end
 

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -505,6 +505,16 @@ function gens(G::MatrixGroup)
    return G.gens
 end
 
+# Note that the `gen(G::GAPGroup, i::Int)` method cannot be used
+# for `MatrixGroup` because of the `:gens` attribute.
+function gen(G::MatrixGroup, i::Int)
+  i == 0 && return one(G)
+  L = gens(G)
+  0 < i && i <= length(L) && return L[i]
+  i < 0 && -i <= length(L) && return inv(L[-i])
+  @req false "i must be in the range -$(length(L)):$(length(L))"
+end
+
 number_of_generators(G::MatrixGroup) = length(gens(G))
 
 

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -505,8 +505,6 @@ function gens(G::MatrixGroup)
    return G.gens
 end
 
-gen(G::MatrixGroup, i::Int) = gens(G)[i]
-
 number_of_generators(G::MatrixGroup) = length(gens(G))
 
 

--- a/test/Groups/conformance.jl
+++ b/test/Groups/conformance.jl
@@ -33,6 +33,13 @@ include(joinpath(dirname(pathof(AbstractAlgebra)), "..", "test", "Groups-conform
       @test ngens(G) isa Int
       @test gens(G) isa Vector{typeof(g)}
 
+      @test G[0] == one(G)
+      l = ngens(G)
+      @test G[l] == gen(G, l)
+      @test G[-l] == inv(gen(G, l))
+      @test_throws ArgumentError G[l+1]
+      @test_throws ArgumentError G[-l-1]
+
       if is_finite(G)
          @test order(G) isa ZZRingElem
          @test order(G) > 0

--- a/test/Groups/elements.jl
+++ b/test/Groups/elements.jl
@@ -145,7 +145,7 @@ end
 
    G = free_group(2)
    @test_throws ArgumentError gen(G, 3)
-   @test_throws ArgumentError gen(G, -1)
+   @test_throws ArgumentError gen(G, -3)
 end
 
 @testset "deepcopy" begin

--- a/test/Groups/elements.jl
+++ b/test/Groups/elements.jl
@@ -138,11 +138,14 @@ end
          @test K[i] == G[i]
          @test K[i] == gen(G,i)
       end
+      @test G[0] == gen(G, 0)
+      @test G[0] == one(G)
+      @test_throws BoundsError K[0]
    end
 
    G = free_group(2)
-   @test_throws AssertionError gen(G, 3)
-   @test_throws ErrorException gen(G, 0)
+   @test_throws ArgumentError gen(G, 3)
+   @test_throws ArgumentError gen(G, -1)
 end
 
 @testset "deepcopy" begin


### PR DESCRIPTION
@fieker had noticed that this is missing.

This was already supported for `FinGenAbGroup`.

(The delegations between methods are not the same: For `FinGenAbGroup`, there is special code for `getindex(A, i)`, and `gen(A, i)` calls `getindex(A, i)`.
For `GAPGroup`, there is special code for `gen(G, i)`, and the generic `getindex` method from AbstractAlgebra calls `gen(G, i)`.)