### PR TITLE
CI: update to codecov/codecov-action@v4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,7 +98,7 @@ jobs:
       - name: "Upload coverage data to Codecov"
         if: matrix.julia-version == '1.10' && matrix.depwarn != 'depwarn=error'
         continue-on-error: true
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
 
   doctest:
     runs-on: ${{ matrix.os }}
@@ -165,4 +165,4 @@ jobs:
       - name: "Upload coverage data to Codecov"
         if: matrix.julia-version == '1.10' && matrix.depwarn != 'depwarn=error'
         continue-on-error: true
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,6 +99,8 @@ jobs:
         if: matrix.julia-version == '1.10' && matrix.depwarn != 'depwarn=error'
         continue-on-error: true
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   doctest:
     runs-on: ${{ matrix.os }}
@@ -166,3 +168,5 @@ jobs:
         if: matrix.julia-version == '1.10' && matrix.depwarn != 'depwarn=error'
         continue-on-error: true
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Unlike prior versions, this *requires* that CODECOV_TOKEN is provided. In practice, already v3 has issues without it. I added this as an organization secret to oscar-system a few days ago, so it should be safe to use here.

Replacement for #3329