### PR TITLE
Move printing of banner to its own function

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -38,6 +38,24 @@ if Sys.iswindows()
   windows_error()
 end
 
+function _print_banner()
+  println(" -----    -----    -----      -      -----   ")
+  println("|     |  |     |  |     |    | |    |     |  ")
+  println("|     |  |        |         |   |   |     |  ")
+  println("|     |   -----   |        |     |  |-----   ")
+  println("|     |        |  |        |-----|  |   |    ")
+  println("|     |  |     |  |     |  |     |  |    |   ")
+  println(" -----    -----    -----   -     -  -     -  ")
+  println()
+  println("...combining (and extending) ANTIC, GAP, Polymake and Singular")
+  print("Version")
+  printstyled(" $VERSION_NUMBER ", color = :green)
+  print("... \n ... which comes with absolutely no warranty whatsoever")
+  println()
+  println("Type: '?Oscar' for more information")
+  println("(c) 2019-2024 by The OSCAR Development Team")
+end
+
 
 
 function __init__()
@@ -49,21 +67,7 @@ function __init__()
   set_seed!(rand(UInt32))
 
   if isinteractive() && Base.JLOptions().banner != 0
-    println(" -----    -----    -----      -      -----   ")
-    println("|     |  |     |  |     |    | |    |     |  ")
-    println("|     |  |        |         |   |   |     |  ")
-    println("|     |   -----   |        |     |  |-----   ")
-    println("|     |        |  |        |-----|  |   |    ")
-    println("|     |  |     |  |     |  |     |  |    |   ")
-    println(" -----    -----    -----   -     -  -     -  ")
-    println()
-    println("...combining (and extending) ANTIC, GAP, Polymake and Singular")
-    print("Version")
-    printstyled(" $VERSION_NUMBER ", color = :green)
-    print("... \n ... which comes with absolutely no warranty whatsoever")
-    println()
-    println("Type: '?Oscar' for more information")
-    println("(c) 2019-2024 by The OSCAR Development Team")
+    _print_banner()
   end
 
   append!(_gap_group_types,


### PR DESCRIPTION
A trivial change, which simply moves the banner printing to its own (unexported) function. This is so that we can compile runtimes with system images of Oscar, and still print the banner upon loading (otherwise, potential users might be confused with "I typed `using Oscar`, but nothing happened!")

This should not cause any conflicts at all with the book.