### PR TITLE
tests: adjust the project and load path to add test dependencies in test_module

### DIFF
--- a/src/utils/tests.jl
+++ b/src/utils/tests.jl
@@ -87,6 +87,12 @@ function _gather_tests(path::AbstractString; ignore=[])
   return tests
 end
 
+_setactiveproject(s::String) = @static if VERSION >= v"1.8"
+                                 Base.set_active_project(s)
+                               else
+                                 Base.ACTIVE_PROJECT[] = s
+                               end
+
 @doc raw"""
     test_module(path::AbstractString; new::Bool = true, timed::Bool=false, ignore=[])
 
@@ -113,7 +119,7 @@ This only works for `new=false`.
 
 For experimental modules, use [`test_experimental_module`](@ref) instead.
 """
-function test_module(path::AbstractString; new::Bool=true, timed::Bool=false, ignore=[])
+function test_module(path::AbstractString; new::Bool=true, timed::Bool=false, tempproject::Bool=true, ignore=[])
   with_unicode(false) do
     julia_exe = Base.julia_cmd()
     project_path = Base.active_project()
@@ -126,7 +132,12 @@ function test_module(path::AbstractString; new::Bool=true, timed::Bool=false, ig
     end
     if new
       @req isempty(ignore) && !timed "The `timed` and `ignore` options only work for `new=false`."
-      cmd = "using Test; using Oscar; Hecke.assertions(true); Oscar.test_module(\"$path\"; new=false);"
+      cmd = """
+            using Test;
+            using Oscar;
+            Hecke.assertions(true);
+            Oscar.test_module("$path"; new=false);
+            """
       @info("spawning ", `$julia_exe --project=$project_path -e \"$cmd\"`)
       run(`$julia_exe --project=$project_path -e $cmd`)
     else
@@ -140,18 +151,39 @@ function test_module(path::AbstractString; new::Bool=true, timed::Bool=false, ig
         Base.cumulative_compile_timing(true)
       end
       stats = Dict{String,NamedTuple}()
-      for entry in testlist
-        dir = dirname(entry)
-        if isfile(joinpath(dir, "setup_tests.jl"))
-          Base.include(identity, Main, joinpath(dir, "setup_tests.jl"))
-        end
-        if timed
-          push!(stats, _timed_include(entry; use_ctime=use_ctime))
-        else
-          Base.include(identity, Main, entry)
-        end
+
+      if tempproject
+        # we preserve the old load path
+        oldloadpath = copy(LOAD_PATH)
+        # make a copy of the test environment to make sure any existing manifest doesn't interfere
+        tmpproj = joinpath(mktempdir(), "Project.toml")
+        cp(joinpath(Oscar.oscardir, "test", "Project.toml"), tmpproj)
+        # activate the temporary project
+        _setactiveproject(tmpproj)
+        # and make sure the current project is still available to allow e.g. `using Oscar`
+        pushfirst!(LOAD_PATH, dirname(project_path))
+        Pkg.resolve()
       end
 
+      try
+        for entry in testlist
+          dir = dirname(entry)
+          if isfile(joinpath(dir, "setup_tests.jl"))
+            Base.include(identity, Main, joinpath(dir, "setup_tests.jl"))
+          end
+          if timed
+            push!(stats, _timed_include(entry; use_ctime=use_ctime))
+          else
+            Base.include(identity, Main, entry)
+          end
+        end
+      finally
+        # restore load path and project
+        if tempproject
+          copy!(LOAD_PATH, oldloadpath)
+          _setactiveproject(project_path)
+        end
+      end
       if timed
         use_ctime && Base.cumulative_compile_timing(false)
         return stats

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,7 +134,7 @@ end
 # otherwise, is essentially a serial loop
 stats = reduce(merge, pmap(testlist) do x
                         println("Starting tests for $x")
-                        Oscar.test_module(x; new=false, timed=true)
+                        Oscar.test_module(x; new=false, timed=true, tempproject=false)
                       end)
 
 # this needs to run here to make sure it runs on the main process


### PR DESCRIPTION
To have test dependencies (e.g. Documenter or Aqua) available when running tests via `test_module`.
Achieved by creating a temporary project using the `test/Project.toml` file and stacking this with the currently active project.
An alternative would be to try to hook into some of the internals of Pkg.jl and reuse that but it seemed rather fragile.

Seems to work fine in local tests, both with `new=false` and `new=true`, even for the `Aqua.jl` tests which use several temporary environments itself. Tested with the parallel test jobs as well.

This feature is always active unless one specifies `tempproject=false`, which is used in the main `runtests.jl` to avoid creating new projects for every testfile.

fixes #3354