### PR TITLE
Revert "Serialization: disable IPC test until #3184 is solved (#3246)"

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,16 +139,14 @@ stats = reduce(merge, pmap(testlist) do x
 
 # this needs to run here to make sure it runs on the main process
 # it is in the ignore list for the other tests
-#
-# FIXME: disabled until #3184 is solved
-#if numprocs == 1 && test_subset != "short"
-#  # to debug GC corruption errors
-#  GC.gc()
-#  GC.gc()
-#
-#  println("Starting tests for Serialization/IPC.jl")
-#  push!(stats, Oscar._timed_include("Serialization/IPC.jl", Main))
-#end
+if numprocs == 1 && test_subset != "short"
+  # to debug GC corruption errors
+  GC.gc()
+  GC.gc()
+
+  println("Starting tests for Serialization/IPC.jl")
+  push!(stats, Oscar._timed_include("Serialization/IPC.jl", Main))
+end
 
 if haskey(ENV, "GITHUB_STEP_SUMMARY")
   open(ENV["GITHUB_STEP_SUMMARY"], "a") do io

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,10 +140,6 @@ stats = reduce(merge, pmap(testlist) do x
 # this needs to run here to make sure it runs on the main process
 # it is in the ignore list for the other tests
 if numprocs == 1 && test_subset != "short"
-  # to debug GC corruption errors
-  GC.gc()
-  GC.gc()
-
   println("Starting tests for Serialization/IPC.jl")
   push!(stats, Oscar._timed_include("Serialization/IPC.jl", Main))
 end


### PR DESCRIPTION
Fixed with julia 1.10.1, fixes #3184.

For comparison 12 runs each with 1.10.0 and 1.10.1 ([here](https://github.com/oscar-system/Oscar.jl/actions/runs/7908942592?pr=3368)):
![ipcjl-1 10 1](https://github.com/oscar-system/Oscar.jl/assets/1437056/cfe8b79c-a5f7-4b7a-9307-8f6a30c33261)
