### PR TITLE
fix doctest following algebraicsolving 0.4.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ cohomCalg_jll = "5558cf25-a90e-53b0-b813-cadaa3ae7ade"
 
 [compat]
 AbstractAlgebra = "0.37.5"
-AlgebraicSolving = "0.4.6"
+AlgebraicSolving = "0.4.10"
 Distributed = "1.6"
 DocStringExtensions = "0.8, 0.9"
 GAP = "0.10.2"

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1038,7 +1038,7 @@ julia> Oscar._normal_form_f4(A, J)
 3-element Vector{FqMPolyRingElem}:
  a^3
  2*a^3 + 2*a + 65519*c
- 65519*c^2 + 4*a + 65520*c + 5
+ 4*a + 65519*c^2 + 65520*c + 5
 ```
 """
 function _normal_form_f4(A::Vector{T}, J::MPolyIdeal) where { T <: MPolyRingElem }


### PR DESCRIPTION
https://github.com/algebraic-solving/AlgebraicSolving.jl/pull/42 seems to have changed some output ordering in the doctest. I assume that this is still correct and we just need to adjust the printing.

cc: @joschmitt 

<details>
<summary>Details</summary>

```
│ Subexpression:
│ 
│ Oscar._normal_form_f4(A, J)
│ 
│ Evaluated output:
│ 
│ 3-element Vector{FqMPolyRingElem}:
│  a^3
│  2*a^3 + 2*a + 65519*c
│  4*a + 65519*c^2 + 65520*c + 5
│ 
│ Expected output:
│ 
│ 3-element Vector{FqMPolyRingElem}:
│  a^3
│  2*a^3 + 2*a + 65519*c
│  65519*c^2 + 4*a + 65520*c + 5
│ 
│   diff =
│    3-element Vector{FqMPolyRingElem}:
│     a^3
│     2*a^3 + 2*a + 65519*c
│     65519*c^2 + 4*a + 65519*c^2 + 65520*c + 5
└ @ Documenter ~/work/Oscar.jl/Oscar.jl/src/Rings/groebner.jl:1022
```

e.g. https://github.com/oscar-system/Oscar.jl/actions/runs/7927819812/job/21644888121#step:8:3229

</details>