### PR TITLE
CI: switch to 1.11-nightly for now

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,8 @@ jobs:
           - '1.6'
           - '1.9'   # to be removed in the near future
           - '1.10'
-          - 'nightly'
+          - '1.11-nightly'
+          #- 'nightly'
         group: [ 'short', 'long' ]
         os:
           - ubuntu-latest
@@ -112,7 +113,8 @@ jobs:
         julia-version:
           - '1.9'   # to be removed in the near future
           - '1.10'
-          - 'nightly'
+          - '1.11-nightly'
+          #- 'nightly'
         os:
           - ubuntu-latest
         depwarn: [ '' ]


### PR DESCRIPTION
Nightly was changed to 1.12 and we do not have any compatible jlls yet. To keep testing with 1.11 use those nightlies for now.