### PR TITLE
Enable edit and show source buttons in docs

### DIFF
--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -1,6 +1,6 @@
 #
 # This file is included by docs/make.jl and by a helper function
-# in src/Oscar.jl
+# in src/utils/docs.jl
 #
 module BuildDoc
 
@@ -139,7 +139,7 @@ function doit(
     joinpath(Oscar.oscardir, "docs", "oscar_references.bib"); style=oscar_style
   )
 
-  # Copy documentation from Hecke, Nemo, AnstratAlgebra
+  # Copy documentation from Hecke, Nemo, AbstractAlgebra
   other_packages = [
     (Oscar.Hecke, Oscar.heckedir),
     (Oscar.Nemo, Oscar.nemodir),

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -172,6 +172,20 @@ function doit(
     end
   end
 
+  function get_rev(uuid::Base.UUID)
+    deps = Documenter.Pkg.dependencies()
+    @assert haskey(deps, uuid)
+    if !isnothing(deps[uuid].git_revision)
+      return deps[uuid].git_revision
+    else
+      return "v$(deps[uuid].version)"
+    end
+  end
+  aarev = get_rev(Base.UUID("c3fe647b-3220-5bb0-a1ea-a7954cac585d"))
+  nemorev = get_rev(Base.UUID("2edaba10-b0f1-5616-af89-8c11ac63239a"))
+  heckerev = get_rev(Base.UUID("3e1990a7-5d81-5526-99ce-9ba3ff248f21"))
+  singularrev = get_rev(Base.UUID("bcd08a7b-43d2-5ff7-b6d4-c458787f915c"))
+
   cd(joinpath(Oscar.oscardir, "docs")) do
     DocMeta.setdocmeta!(Oscar, :DocTestSetup, Oscar.doctestsetup(); recursive=true)
     DocMeta.setdocmeta!(Oscar.Hecke, :DocTestSetup, :(using Hecke); recursive=true)
@@ -184,6 +198,7 @@ function doit(
 
     makedocs(;
       format=Documenter.HTML(;
+        edit_link=nothing, # TODO: make work for imported pages
         prettyurls=!local_build,
         collapselevel=1,
         size_threshold=409600,
@@ -197,7 +212,12 @@ function doit(
       warnonly=warnonly,
       checkdocs=:none,
       pages=doc,
-      remotes=nothing,  # TODO: make work with Hecke, Nemo, AbstractAlgebra, see https://github.com/oscar-system/Oscar.jl/issues/588
+      remotes=Dict(
+        Oscar.aadir => (Remotes.GitHub("Nemocas", "AbstractAlgebra.jl"), aarev),
+        Oscar.nemodir => (Remotes.GitHub("Nemocas", "Nemo.jl"), nemorev),
+        Oscar.heckedir => (Remotes.GitHub("thofma", "Hecke.jl"), heckerev),
+        Oscar.singulardir => (Remotes.GitHub("oscar-system", "Singular.jl"), singularrev),
+      ),
       plugins=[bib],
     )
   end

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -185,10 +185,10 @@ function doit(
       return "v$(deps[uuid].version)"
     end
   end
-  aarev = get_rev(Base.UUID("c3fe647b-3220-5bb0-a1ea-a7954cac585d"))
-  nemorev = get_rev(Base.UUID("2edaba10-b0f1-5616-af89-8c11ac63239a"))
-  heckerev = get_rev(Base.UUID("3e1990a7-5d81-5526-99ce-9ba3ff248f21"))
-  singularrev = get_rev(Base.UUID("bcd08a7b-43d2-5ff7-b6d4-c458787f915c"))
+  aarev = get_rev(Base.PkgId(Oscar.AbstractAlgebra).uuid)
+  nemorev = get_rev(Base.PkgId(Oscar.Nemo).uuid)
+  heckerev = get_rev(Base.PkgId(Oscar.Hecke).uuid)
+  singularrev = get_rev(Base.PkgId(Oscar.Singular).uuid)
 
   cd(joinpath(Oscar.oscardir, "docs")) do
     DocMeta.setdocmeta!(Oscar, :DocTestSetup, Oscar.doctestsetup(); recursive=true)

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -166,7 +166,11 @@ function doit(
         end
         src = normpath(root, file)
         dst = normpath(dstbase, relpath(root, srcbase), file)
-        cp(src, dst; force=true)
+        if endswith(file, ".md")
+          symlink(src, dst)
+        else
+          cp(src, dst; force=true)
+        end
         chmod(dst, 0o644)
       end
     end
@@ -198,7 +202,6 @@ function doit(
 
     makedocs(;
       format=Documenter.HTML(;
-        edit_link=nothing, # TODO: make work for imported pages
         prettyurls=!local_build,
         collapselevel=1,
         size_threshold=409600,

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -5,6 +5,7 @@ const jll_deps = String["Antic_jll", "Arb_jll", "Calcium_jll", "FLINT_jll", "GAP
 const aadir = Base.pkgdir(AbstractAlgebra)
 const nemodir = Base.pkgdir(Nemo)
 const heckedir = Base.pkgdir(Hecke)
+const singulardir = Base.pkgdir(Singular)
 
 include("versioninfo.jl")
 include("docs.jl")


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/588.

In the upgrade to Documenter.jl version 1.0 in https://github.com/oscar-system/Oscar.jl/pull/2927, the Documenter cross-referencing features were disabled due to issues with the imported doc pages from AA/Nemo/Hecke.

This PR enables the "show source" buttons in all docstring blocks and resolves the URL for non-oscar docstrings based on some heuristic with `Pkg.jl` internals (if a `git_revision` is known take that, otherwise a version is known and we can take the corresponding git tag).

Furthermore, it enables the "edit page on github" buttons in the top navigation bar, which now point to the markdown file in the correct project (again based on the same heuristic). (For reviewers: Using a `symlink` instead `cp` to for the import makes it possible for Documenter to guess where a file comes from as the symlink gets resolved using `realpath`.)

Note that the links behind these buttons may be broken/useless in a local build with non-released (dev'ed) versions of dependencies. Anyway, I think this is a great addition.

A preview is available here: https://docs.oscar-system.org/previews/PR3381/