### PR TITLE
galois_group: fix is_normal call after removed deprecations

### DIFF
--- a/src/NumberTheory/GaloisGrp/GaloisGrp.jl
+++ b/src/NumberTheory/GaloisGrp/GaloisGrp.jl
@@ -2091,7 +2091,7 @@ function descent(GC::GaloisCtx, G::PermGroup, F::GroupFilter, si::PermGroupElem;
       local lt
       if index(G, s) < 100
         @vtime :GaloisGroup 2 lt = right_transversal(G, s)
-      elseif is_normal(G, s)
+      elseif is_normalized_by(s, G)
         lt = [one(G)] # I don't know how to get the identity
       else
         @vtime :GaloisGroup 2 lt = short_right_transversal(G, s, si)

--- a/test/NumberTheory/galthy.jl
+++ b/test/NumberTheory/galthy.jl
@@ -30,6 +30,12 @@
   Gs, Cs = galois_group(K, algorithm = :Symbolic)
   @test is_isomorphic(G, Gc)
   @test is_isomorphic(G, Gs)
+
+  # from the book
+  K, a = number_field(x^9 - 3*x^8 + x^6 + 15*x^5 - 13*x^4 -
+                      3*x^3 + 4*x - 1, "a")
+  G, C = galois_group(K)
+  @test order(G) == 216
 end
 
 import Oscar.GaloisGrp: primitive_by_shape, an_sn_by_shape, cycle_structures


### PR DESCRIPTION
Example from the book code.

We previously had
```julia
@deprecate is_normal(G::T, H::T) where T <: GAPGroup is_normalized_by(H, G)
```
but this code line was not covered by the tests.