### PR TITLE
Convert partition methods to return iterators

### DIFF
--- a/docs/src/Combinatorics/EnumerativeCombinatorics/partitions.md
+++ b/docs/src/Combinatorics/EnumerativeCombinatorics/partitions.md
@@ -102,7 +102,7 @@ For counting the partitions the recurrence relation $p_k(n) = p_{k - 1}(n - 1) +
 
 ```@docs
 partitions(::Oscar.IntegerUnion, ::Oscar.IntegerUnion, ::Oscar.IntegerUnion, ::Oscar.IntegerUnion)
-partitions(::Oscar.IntegerUnion, ::Vector)
+partitions(::T, ::Vector{T}) where T <: Oscar.IntegerUnion
 ```
 
 ## Operations

--- a/docs/src/Combinatorics/EnumerativeCombinatorics/partitions.md
+++ b/docs/src/Combinatorics/EnumerativeCombinatorics/partitions.md
@@ -101,8 +101,8 @@ For counting the partitions the recurrence relation $p_k(n) = p_{k - 1}(n - 1) +
 7.2.1.4, Equation (39), and also [OEIS](@cite), [A008284](https://oeis.org/A008284).
 
 ```@docs
-partitions(::T, ::Oscar.IntegerUnion, ::Oscar.IntegerUnion, ::Oscar.IntegerUnion) where T <: Oscar.IntegerUnion
-partitions(::T, ::Vector{T}) where T <: Oscar.IntegerUnion
+partitions(::Oscar.IntegerUnion, ::Oscar.IntegerUnion, ::Oscar.IntegerUnion, ::Oscar.IntegerUnion)
+partitions(::Oscar.IntegerUnion, ::Vector)
 ```
 
 ## Operations

--- a/src/Combinatorics/EnumerativeCombinatorics/compositions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/compositions.jl
@@ -152,11 +152,11 @@ parts(C::CompositionsFixedNumParts) = C.k
 Base.eltype(C::CompositionsFixedNumParts{T}) where T = Composition{T}
 
 function Base.show(io::IO, C::CompositionsFixedNumParts)
-  if get(io, :supercompact, false)
-    print(io, "Iterator")
+  if is_terse(io)
+    print(io, "Iterator over the compositions of $(base(C)) into ", ItemQuantity(parts(C), "parts"))
   else
     io = pretty(io)
-    print(io, "Iterator over the compositions of $(base(C)) into ", ItemQuantity(parts(C), "part"))
+    print(io, "Iterator over the compositions of $(base(C)) into ", ItemQuantity(parts(C), "parts"))
   end
 end
 
@@ -218,8 +218,8 @@ base(C::Compositions) = C.n
 Base.eltype(C::Compositions{T}) where T = Composition{T}
 
 function Base.show(io::IO, C::Compositions)
-  if get(io, :supercompact, false)
-    print(io, "Iterator")
+  if is_terse(io)
+    print(io, "Iterator over the compositions of $(base(C))")
   else
     io = pretty(io)
     print(io, "Iterator over the compositions of $(base(C))")
@@ -304,8 +304,8 @@ base(C::AscendingCompositions) = C.n
 Base.eltype(C::AscendingCompositions{T}) where T = Composition{T}
 
 function Base.show(io::IO, C::AscendingCompositions)
-  if get(io, :supercompact, false)
-    print(io, "Iterator")
+  if is_terse(io)
+    print(io, "Iterator over the ascending compositions of $(base(C))")
   else
     io = pretty(io)
     print(io, "Iterator over the ascending compositions of $(base(C))")

--- a/src/Combinatorics/EnumerativeCombinatorics/compositions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/compositions.jl
@@ -152,12 +152,7 @@ parts(C::CompositionsFixedNumParts) = C.k
 Base.eltype(C::CompositionsFixedNumParts{T}) where T = Composition{T}
 
 function Base.show(io::IO, C::CompositionsFixedNumParts)
-  if is_terse(io)
-    print(io, "Iterator over the compositions of $(base(C)) into ", ItemQuantity(parts(C), "parts"))
-  else
-    io = pretty(io)
-    print(io, "Iterator over the compositions of $(base(C)) into ", ItemQuantity(parts(C), "parts"))
-  end
+  print(pretty(io), "Iterator over the compositions of $(base(C)) into ", ItemQuantity(parts(C), "part"))
 end
 
 Base.length(C::CompositionsFixedNumParts) = BigInt(number_of_compositions(base(C), parts(C)))
@@ -218,12 +213,7 @@ base(C::Compositions) = C.n
 Base.eltype(C::Compositions{T}) where T = Composition{T}
 
 function Base.show(io::IO, C::Compositions)
-  if is_terse(io)
-    print(io, "Iterator over the compositions of $(base(C))")
-  else
-    io = pretty(io)
-    print(io, "Iterator over the compositions of $(base(C))")
-  end
+  print(pretty(io), "Iterator over the compositions of $(base(C))")
 end
 
 Base.length(C::Compositions) = BigInt(number_of_compositions(base(C)))
@@ -304,12 +294,7 @@ base(C::AscendingCompositions) = C.n
 Base.eltype(C::AscendingCompositions{T}) where T = Composition{T}
 
 function Base.show(io::IO, C::AscendingCompositions)
-  if is_terse(io)
-    print(io, "Iterator over the ascending compositions of $(base(C))")
-  else
-    io = pretty(io)
-    print(io, "Iterator over the ascending compositions of $(base(C))")
-  end
+  print(pretty(io), "Iterator over the ascending compositions of $(base(C))")
 end
 
 # Ascending compositions are basically partitions turned around

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -373,6 +373,11 @@ function partitions(n::IntegerUnion, k::IntegerUnion; only_distinct_parts::Bool 
 end
 
 
+
+# Algorithm "parta" in [RJ76](@cite), de-gotoed from old ALGOL 60 code by E. Thiel.
+
+# Note that the algorithm is given as partitioning m into n parts,
+# but we have refactored to align more closely with standard terminology.
 function Base.iterate(P::PartitionsFixedNumParts{T}) where T
   n = P.n
   k = P.k
@@ -380,7 +385,6 @@ function Base.iterate(P::PartitionsFixedNumParts{T}) where T
   ub = P.ub
   only_distinct_parts = P.distinct_parts
 
-  # TODO : fix the states returned once we know what those will look like
   if n == 0 && k == 0
     return partition(T[], check=false), (T[], T[], 0, 0, 1, false)
   end
@@ -461,116 +465,6 @@ function Base.iterate(P::PartitionsFixedNumParts{T}, state::Tuple{Vector{T}, Vec
   x[i] = y[i] + N
   return partition(x[1:k], check = false), (x,y,N,L2,i,true)
 end
-
-
-# function partitions(n::T, k::IntegerUnion, lb::IntegerUnion, ub::IntegerUnion; only_distinct_parts::Bool = false) where T <: IntegerUnion
-#   # Algorithm "parta" in [RJ76](@cite), de-gotoed from old ALGOL 60 code by E. Thiel.
-#
-#   # Note that the algorithm is given as partitioning m into n parts,
-#   # but we have refactored to align more closely with standard terminology.
-#
-#   #Argument checking
-#   @req n >= 0 "n >= 0 required"
-#   @req k >= 0 "k >= 0 required"
-#   @req lb >= 0 "lb >= 0 required"
-#
-#   # Use type of n
-#   k = convert(T, k)
-#
-#   # If lb == 0 the algorithm parta will actually create lists containing the
-#   # entry zero, e.g. partitions(2, 2, 0, 2) will contain [2, 0].
-#   # This is nonsense, so we set lb = 1 in this case.
-#   if lb == 0
-#     lb = 1
-#   end
-#
-#   # Some trivial cases
-#   if n == 0 && k == 0
-#     return (p for p in Partition{T}[ partition(T[], check = false) ])
-#   end
-#
-#   if k == 0 || k > n
-#     return (p for p in Partition{T}[])
-#   end
-#
-#   if ub < lb
-#     return (p for p in Partition{T}[])
-#   end
-#
-#
-#
-#   #Algorithm starts here
-#   P = Partition{T}[]    #this will be the array of all partitions
-#   x = zeros(T, k)
-#   y = zeros(T, k)
-#   j = only_distinct_parts*k*(k - 1)
-#   n = n - k*lb - div(j, 2)
-#   ub = ub - lb
-#   if 0 <= n <= k*ub - j
-#
-#     for i = 1:k
-#       y[i] = x[i] = lb + only_distinct_parts*(k - i)
-#     end
-#
-#     i = 1
-#     ub = ub - only_distinct_parts*(k - 1)
-#
-#     while true
-#       while n > ub
-#         n -= ub
-#         x[i] = y[i] + ub
-#         i += 1
-#       end
-#
-#       x[i] = y[i] + n
-#       push!(P, partition(x[1:k], check = false))
-#
-#       if i < k && n > 1
-#         n = 1
-#         x[i] = x[i] - 1
-#         i += 1
-#         x[i] = y[i] + 1
-#         push!(P, partition(x[1:k], check = false))
-#       end
-#
-#       lcycle = false
-#       for j = i - 1:-1:1
-#         ub = x[j] - y[j] - 1
-#         n = n + 1
-#         if n <= (k - j)*ub
-#           x[j] = y[j] + ub
-#           lcycle = true
-#           break
-#         end
-#         n = n + ub
-#         x[i] = y[i]
-#         i = j
-#       end
-#
-#       if !lcycle
-#         break
-#       end
-#     end
-#   end
-#
-#   return (p for p in P)
-# end
-#
-# function partitions(n::T, k::IntegerUnion; only_distinct_parts::Bool = false) where T <: IntegerUnion
-#   @req n >= 0 "n >= 0 required"
-#   @req k >= 0 "k >= 0 required"
-#
-#   # Special cases
-#   if n == k
-#     return (p for p in [ partition(T[ 1 for i in 1:n], check = false) ])
-#   elseif n < k || k == 0
-#     return (p for p in Partition{T}[])
-#   elseif k == 1
-#     return (p for p in [ partition(T[n], check = false) ])
-#   end
-#
-#   return (p for p in partitions(n, k, 1, n; only_distinct_parts = only_distinct_parts))
-# end
 
 
 @doc raw"""

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -130,12 +130,7 @@ base(P::Partitions) = P.n
 Base.eltype(::Partitions{T}) where T = Partition{T}
 
 function Base.show(io::IO, ::MIME"text/plain", P::Partitions)
-  if is_terse(io)
-    print(io, "Iterator over the partitions of $(base(P))")
-  else
-    io = pretty(io)
-    print(io, "Iterator over the partitions of $(base(P))")
-  end
+  print(pretty(io), "Iterator over the partitions of $(base(P))")
 end
 
 Base.length(P::Partitions) = BigInt(number_of_partitions(P.n))
@@ -147,12 +142,7 @@ base(P::PartitionsFixedNumParts) = P.n
 Base.eltype(::PartitionsFixedNumParts{T}) where T = Partition{T}
 
 function Base.show(io::IO, ::MIME"text/plain", P::PartitionsFixedNumParts)
-  if is_terse(io)
-    print(io, "Iterator over the partitions of $(base(P)) into $(P.k) parts")
-  else
-    io = pretty(io)
-    print(io, "Iterator over the partitions of $(base(P)) into $(P.k) parts")
-  end
+  print(pretty(io), "Iterator over the partitions of $(base(P)) into $(P.k) parts")
 end
 
 # NOTE this will not be accurate in many cases,

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -157,6 +157,7 @@ end
 # in particular if upper/lower bounds are given,
 # or if `only_distinct_parts == true`.
 # Base.length(P::PartitionsFixedNumParts) = BigInt(number_of_partitions(P.n, P.k))
+
 Base.IteratorSize(::Type{PartitionsFixedNumParts{T}}) where T = Base.SizeUnknown()
 ################################################################################
 #

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -370,6 +370,26 @@ julia> collect(partitions(7, 3, 1, 4; only_distinct_parts = true))
  [4, 2, 1]
 ```
 """
+function partitions(n::IntegerUnion, m::IntegerUnion; only_distinct_parts::Bool = false)
+  return PartitionsFixedNumParts(n, m; only_distinct_parts = only_distinct_parts)
+end
+
+function partitions(n::IntegerUnion, m::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; only_distinct_parts::Bool = false)
+  return PartitionsFixedNumParts(n, m, l1, l2; only_distinct_parts = only_distinct_parts)
+end
+
+
+function Base.iterate(P::PartitionsFixedNumParts{T}, state::Nothing = nothing) where T
+  n = P.n
+
+
+
+
+
+
+
+
+
 function partitions(n::T, m::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; only_distinct_parts::Bool = false) where T <: IntegerUnion
   # Algorithm "parta" in [RJ76](@cite), de-gotoed from old ALGOL 60 code by E. Thiel.
 
@@ -384,6 +404,13 @@ function partitions(n::T, m::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; o
   # Use type of n
   m = convert(T, m)
 
+  # If l1 == 0 the algorithm parta will actually create lists containing the
+  # entry zero, e.g. partitions(2, 2, 0, 2) will contain [2, 0].
+  # This is nonsense, so we set l1 = 1 in this case.
+  if l1 == 0
+    l1 = 1
+  end
+
   # Some trivial cases
   if n == 0 && m == 0
     return (p for p in Partition{T}[ partition(T[], check = false) ])
@@ -397,12 +424,7 @@ function partitions(n::T, m::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; o
     return (p for p in Partition{T}[])
   end
 
-  # If l1 == 0 the algorithm parta will actually create lists containing the
-  # entry zero, e.g. partitions(2, 2, 0, 2) will contain [2, 0].
-  # This is nonsense, so we set l1 = 1 in this case.
-  if l1 == 0
-    l1 = 1
-  end
+
 
   #Algorithm starts here
   P = Partition{T}[]    #this will be the array of all partitions

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -125,8 +125,12 @@ function getindex_safe(P::Partition{T}, i::IntegerUnion) where T
   return (i > length(data(P)) ? zero(T) : getindex(data(P), Int(i)))
 end
 
-Base.eltype(::PartitionSet{T}) where T = Partition{T}
-Base.length(P::PartitionSet) = BigInt(number_of_partitions(P.n))
+
+function Base.show(io::IO, ::MIME"text/plain", P::Partitions)
+    print(io, "Iterator over partitions of ", P.n)
+end
+Base.eltype(::Partitions{T}) where T = Partition{T}
+Base.length(P::Partitions) = BigInt(number_of_partitions(P.n))
 
 ################################################################################
 #
@@ -192,12 +196,11 @@ julia> collect(partitions(Int8(4))) # using less memory
 ```
 """
 function partitions(n::T) where {T <: IntegerUnion}
-  @req n >= 0 "n >= 0 required"
-  return PartitionSet{T}(n)
+  return Partitions{T}(n)
 end
 
 
-function Base.iterate(P::PartitionSet{T}) where T
+function Base.iterate(P::Partitions{T}) where T
   if P.n == 0
     return partition(T), (T[], 0, 0)
   elseif P.n == 1
@@ -210,7 +213,7 @@ function Base.iterate(P::PartitionSet{T}) where T
 
 end
 
-function Base.iterate(P::PartitionSet, state)
+function Base.iterate(P::Partitions, state)
   d, k, q = state
   q==0 && return nothing
   if d[q] == 2

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -312,11 +312,11 @@ function number_of_partitions(n::IntegerUnion, k::IntegerUnion)
 end
 
 @doc raw"""
-    partitions(m::IntegerUnion, n::IntegerUnion; only_distinct_parts::Bool = false)
-    partitions(m::IntegerUnion, n::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; only_distinct_parts::Bool = false)
+    partitions(m::IntegerUnion, n_2::IntegerUnion; only_distinct_parts::Bool = false)
+    partitions(m::IntegerUnion, n_2::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; only_distinct_parts::Bool = false)
 
 Return an iterator over all partitions of a non-negative integer `m` into
-`n >= 0` parts. Optionally, a lower bound `l1 >= 0` and an upper bound `l2` for
+`n_2 >= 0` parts. Optionally, a lower bound `l1 >= 0` and an upper bound `l2` for
 the parts can be supplied. In this case, the partitions are produced in
 *decreasing* order.
 
@@ -351,27 +351,27 @@ julia> collect(partitions(7, 3, 1, 4; only_distinct_parts = true))
  [4, 2, 1]
 ```
 """
-function partitions(m::T, n::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; only_distinct_parts::Bool = false) where T <: IntegerUnion
+function partitions(m::T, n_2::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; only_distinct_parts::Bool = false) where T <: IntegerUnion
   # Algorithm "parta" in [RJ76](@cite), de-gotoed from old ALGOL 60 code by E. Thiel.
 
-  # Note that we are considering partitions of m here. I would switch m and n
+  # Note that we are considering partitions of m here. I would switch m and n_2
   # but the algorithm was given like that and I would otherwise confuse myself
   # implementing it.
 
   #Argument checking
   @req m >= 0 "m >= 0 required"
-  @req n >= 0 "n >= 0 required"
+  @req n_2 >= 0 "n_2 >= 0 required"
   @req l1 >= 0 "l1 >= 0 required"
 
   # Use type of m
-  n = convert(T, n)
+  n_2 = convert(T, n_2)
 
   # Some trivial cases
-  if m == 0 && n == 0
+  if m == 0 && n_2 == 0
     return (p for p in Partition{T}[ partition(T[], check = false) ])
   end
 
-  if n == 0 || n > m
+  if n_2 == 0 || n_2 > m
     return (p for p in Partition{T}[])
   end
 
@@ -388,19 +388,19 @@ function partitions(m::T, n::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; o
 
   #Algorithm starts here
   P = Partition{T}[]    #this will be the array of all partitions
-  x = zeros(T, n)
-  y = zeros(T, n)
-  j = only_distinct_parts*n*(n - 1)
-  m = m - n*l1 - div(j, 2)
+  x = zeros(T, n_2)
+  y = zeros(T, n_2)
+  j = only_distinct_parts*n_2*(n_2 - 1)
+  m = m - n_2*l1 - div(j, 2)
   l2 = l2 - l1
-  if 0 <= m <= n*l2 - j
+  if 0 <= m <= n_2*l2 - j
 
-    for i = 1:n
-      y[i] = x[i] = l1 + only_distinct_parts*(n - i)
+    for i = 1:n_2
+      y[i] = x[i] = l1 + only_distinct_parts*(n_2 - i)
     end
 
     i = 1
-    l2 = l2 - only_distinct_parts*(n - 1)
+    l2 = l2 - only_distinct_parts*(n_2 - 1)
 
     while true
       while m > l2
@@ -410,21 +410,21 @@ function partitions(m::T, n::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; o
       end
 
       x[i] = y[i] + m
-      push!(P, partition(x[1:n], check = false))
+      push!(P, partition(x[1:n_2], check = false))
 
-      if i < n && m > 1
+      if i < n_2 && m > 1
         m = 1
         x[i] = x[i] - 1
         i += 1
         x[i] = y[i] + 1
-        push!(P, partition(x[1:n], check = false))
+        push!(P, partition(x[1:n_2], check = false))
       end
 
       lcycle = false
       for j = i - 1:-1:1
         l2 = x[j] - y[j] - 1
         m = m + 1
-        if m <= (n - j)*l2
+        if m <= (n_2 - j)*l2
           x[j] = y[j] + l2
           lcycle = true
           break
@@ -443,29 +443,29 @@ function partitions(m::T, n::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; o
   return (p for p in P)
 end
 
-function partitions(m::T, n::IntegerUnion; only_distinct_parts::Bool = false) where T <: IntegerUnion
+function partitions(m::T, n_2::IntegerUnion; only_distinct_parts::Bool = false) where T <: IntegerUnion
   @req m >= 0 "m >= 0 required"
-  @req n >= 0 "n >= 0 required"
+  @req n_2 >= 0 "n_2 >= 0 required"
 
   # Special cases
-  if m == n
+  if m == n_2
     return (p for p in [ partition(T[ 1 for i in 1:m], check = false) ])
-  elseif m < n || n == 0
+  elseif m < n_2 || n_2 == 0
     return (p for p in Partition{T}[])
-  elseif n == 1
+  elseif n_2 == 1
     return (p for p in [ partition(T[m], check = false) ])
   end
 
-  return (p for p in partitions(m, n, 1, m; only_distinct_parts = only_distinct_parts))
+  return (p for p in partitions(m, n_2, 1, m; only_distinct_parts = only_distinct_parts))
 end
 
-function partitions(m::T, n::IntegerUnion, v::Vector{T}, mu::Vector{S}) where {T <: IntegerUnion, S <: IntegerUnion}
+function partitions(m::T, n_2::IntegerUnion, v::Vector{T}, mu::Vector{S}) where {T <: IntegerUnion, S <: IntegerUnion}
   # Algorithm "partb" in [RJ76](@cite), de-gotoed from old ALGOL 60 code by E. Thiel.
   # The algorithm as published in the paper has several issues and we hope to have fixed
   # them all, see below for details. Some initial fixing was done by T. Schmit.
 
   @req m >= 0 "m >= 0 required"
-  @req n >= 0 "n >= 0 required"
+  @req n_2 >= 0 "n_2 >= 0 required"
   @req length(mu) == length(v) "mu and v should have the same length"
 
   # Algorithm partb assumes that v is strictly increasing.
@@ -479,7 +479,7 @@ function partitions(m::T, n::IntegerUnion, v::Vector{T}, mu::Vector{S}) where {T
   @req all(>(0), mu) "Entries of mu must be positive"
 
   # Special cases
-  if n == 0
+  if n_2 == 0
     # TODO: I don't understand this distinction here
     # (it also makes the function tabe instable)
     if m == 0
@@ -510,9 +510,9 @@ function partitions(m::T, n::IntegerUnion, v::Vector{T}, mu::Vector{S}) where {T
   j = 1
   k = mu[1]
   ll = v[1]
-  x = zeros(T, n)
-  y = zeros(T, n)
-  ii = zeros(T, n)
+  x = zeros(T, n_2)
+  y = zeros(T, n_2)
+  ii = zeros(T, n_2)
 
   # The algorithm has three goto labels b1, b2, b3.
   # b3 terminates the algorithm.
@@ -525,7 +525,7 @@ function partitions(m::T, n::IntegerUnion, v::Vector{T}, mu::Vector{S}) where {T
   # This fills the array x from right with the values from v from the left
   # (the smallest) up to their specified multiplicity.
   # If this is larger than m, there cannot be a partition.
-  for i = n:-1:1
+  for i = n_2:-1:1
     x[i] = ll
     y[i] = ll
     k = k - 1
@@ -553,7 +553,7 @@ function partitions(m::T, n::IntegerUnion, v::Vector{T}, mu::Vector{S}) where {T
   ll = v[1]
 
   # This is a necessary condition for existence of a partition
-  if m < 0 || m > n * (lr - ll)
+  if m < 0 || m > n_2 * (lr - ll)
     return (p for p in P) #goto b3
   end
 
@@ -582,7 +582,7 @@ function partitions(m::T, n::IntegerUnion, v::Vector{T}, mu::Vector{S}) where {T
         end
         x[i] = lr
         ii[i] = r - 1
-        if i == n # Added, otherwise get out of bounds
+        if i == n_2 # Added, otherwise get out of bounds
           break
         end
         i = i + 1
@@ -609,7 +609,7 @@ function partitions(m::T, n::IntegerUnion, v::Vector{T}, mu::Vector{S}) where {T
       lr = v[r]
       if m == lr
         x[i] = lr
-        if i <= n # Added, otherwise get out of bounds
+        if i <= n_2 # Added, otherwise get out of bounds
           push!(P, partition(copy(x), check = false)) #need copy here!
         else
           break
@@ -631,7 +631,7 @@ function partitions(m::T, n::IntegerUnion, v::Vector{T}, mu::Vector{S}) where {T
       # But when we replace lr > k by lr >= k, everything works.
       # Finding this was a wild guess!
       # Found on Mar 27, 2023.
-      if lr >= k && m - lr <= (n - i)*(lr - ll)
+      if lr >= k && m - lr <= (n_2 - i)*(lr - ll)
         gotob2 = false
         continue
       else
@@ -643,7 +643,7 @@ function partitions(m::T, n::IntegerUnion, v::Vector{T}, mu::Vector{S}) where {T
         lr = v[r]
         m = m + x[i] - k
         k = y[i]
-        if lr >= k && m - lr <= (n - i)*(lr - ll) # >= here as well (probably...)
+        if lr >= k && m - lr <= (n_2 - i)*(lr - ll) # >= here as well (probably...)
           gotob2 = false
           break
         else
@@ -708,8 +708,8 @@ function partitions(m::T, v::Vector{T}, mu::Vector{S}) where {T <: IntegerUnion,
     end
   end
 
-  for n = nmin:nmax
-    append!(res, partitions(m, n, v, mu))
+  for n_2 = nmin:nmax
+    append!(res, partitions(m, n_2, v, mu))
   end
 
   return (p for p in res)
@@ -718,7 +718,7 @@ end
 @doc raw"""
     partitions(m::T, v::Vector{T}) where T <: IntegerUnion
     partitions(m::T, v::Vector{T}, mu::Vector{<:IntegerUnion}) where T <: IntegerUnion
-    partitions(m::T, n::IntegerUnion, v::Vector{T}, mu::Vector{<:IntegerUnion}) where T <: IntegerUnion
+    partitions(m::T, n_2::IntegerUnion, v::Vector{T}, mu::Vector{<:IntegerUnion}) where T <: IntegerUnion
 
 Return an iterator over all partitions of a non-negative integer `m` where each
 part is an element in the vector `v` of positive integers.
@@ -727,7 +727,7 @@ It is assumed that the entries in `v` are strictly increasing.
 If the optional vector `mu` is supplied, then each `v[i]` occurs a maximum of
 `mu[i] > 0` times per partition.
 
-If the optional integer `n >= 0` is supplied, the partitions will be into `n`
+If the optional integer `n_2 >= 0` is supplied, the partitions will be into `n_2`
 parts. In this case, the partitions are produced in lexicographically *decreasing*
 order.
 
@@ -784,8 +784,8 @@ function partitions(m::T, v::Vector{T}) where T <: IntegerUnion
   # Set the maximum multiplicity (equal to nmax above)
   mu = [ nmax for i in 1:r ]
 
-  for n = nmin:nmax
-    append!(res, partitions(m, n, v, mu))
+  for n_2 = nmin:nmax
+    append!(res, partitions(m, n_2, v, mu))
   end
 
   return (p for p in res)

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -427,7 +427,7 @@ function Base.iterate(P::PartitionsFixedNumParts{T}, state::Nothing = nothing) w
   return partition(x[1:m], check = false), (x, y, N, L2, i, true)
 end
 
-function Base.iterate(P::PartitionsFixedNumParts{T}, state::Tuple{}) where T
+function Base.iterate(P::PartitionsFixedNumParts{T}, state::Tuple{Vector{T}, Vector{T}, T, IntegerUnion, Int, Bool}) where T
 
   x, y, N, L2, i, flag = state
 

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -156,8 +156,8 @@ end
 # NOTE this will not be accurate in many cases,
 # in particular if upper/lower bounds are given,
 # or if `only_distinct_parts == true`.
-Base.length(P::PartitionsFixedNumParts) = BigInt(number_of_partitions(P.n, P.m))
-
+# Base.length(P::PartitionsFixedNumParts) = BigInt(number_of_partitions(P.n, P.m))
+Base.IteratorSize(::Type{PartitionsFixedNumParts}) = Base.SizeUnknown()
 ################################################################################
 #
 # Generating and counting unrestricted partitions

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -142,7 +142,7 @@ base(P::PartitionsFixedNumParts) = P.n
 Base.eltype(::PartitionsFixedNumParts{T}) where T = Partition{T}
 
 function Base.show(io::IO, ::MIME"text/plain", P::PartitionsFixedNumParts)
-  print(pretty(io), "Iterator over the partitions of $(base(P)) into",
+  print(pretty(io), "Iterator over the partitions of $(base(P)) into ",
   ItemQuantity(P.k, "part"))
 end
 

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -130,7 +130,12 @@ base(P::Partitions) = P.n
 Base.eltype(::Partitions{T}) where T = Partition{T}
 
 function Base.show(io::IO, ::MIME"text/plain", P::Partitions)
-  print(io, "Iterator over the partitions of $(base(P))")
+  if is_terse(io)
+    print(io, "Iterator over the partitions of $(base(P))")
+  else
+    io = pretty(io)
+    print(io, "Iterator over the partitions of $(base(P))")
+  end
 end
 
 Base.length(P::Partitions) = BigInt(number_of_partitions(P.n))
@@ -142,7 +147,12 @@ base(P::PartitionsFixedNumParts) = P.n
 Base.eltype(::PartitionsFixedNumParts{T}) where T = Partition{T}
 
 function Base.show(io::IO, ::MIME"text/plain", P::PartitionsFixedNumParts)
-  print(io, "Iterator over the partitions of $(base(P)) into $(P.k) parts")
+  if is_terse(io)
+    print(io, "Iterator over the partitions of $(base(P)) into $(P.k) parts")
+  else
+    io = pretty(io)
+    print(io, "Iterator over the partitions of $(base(P)) into $(P.k) parts")
+  end
 end
 
 # NOTE this will not be accurate in many cases,

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -196,7 +196,7 @@ julia> collect(partitions(Int8(4))) # using less memory
 ```
 """
 function partitions(n::T) where {T <: IntegerUnion}
-  return Partitions{T}(n)
+  return Partitions(n)
 end
 
 

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -688,27 +688,27 @@ function partitions(m::T, v::Vector{T}, mu::Vector{S}) where {T <: IntegerUnion,
   # We first determine the minimal and maximal number of parts.
   r = length(v)
 
-  nmax = 0
+  n_2max = 0
   cursum = 0
   for i in 1:r, j in 1:mu[i]
-    nmax += 1
+    n_2max += 1
     cursum += v[i]
     if cursum >= m
       break
     end
   end
 
-  nmin = 0
+  n_2min = 0
   cursum = 0
   for i in r:-1:1, j in 1:mu[i]
-    nmin += 1
+    n_2min += 1
     cursum += v[i]
     if cursum >= m
       break
     end
   end
 
-  for n_2 = nmin:nmax
+  for n_2 = n_2min:n_2max
     append!(res, partitions(m, n_2, v, mu))
   end
 
@@ -778,13 +778,13 @@ function partitions(m::T, v::Vector{T}) where T <: IntegerUnion
   # We will loop over the number of parts.
   # We first determine the minimal and maximal number of parts.
   r = length(v)
-  nmin = div(m, v[r])
-  nmax = div(m, v[1])
+  n_2min = div(m, v[r])
+  n_2max = div(m, v[1])
 
-  # Set the maximum multiplicity (equal to nmax above)
-  mu = [ nmax for i in 1:r ]
+  # Set the maximum multiplicity (equal to n_2max above)
+  mu = [ n_2max for i in 1:r ]
 
-  for n_2 = nmin:nmax
+  for n_2 = n_2min:n_2max
     append!(res, partitions(m, n_2, v, mu))
   end
 

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -241,7 +241,7 @@ function Base.iterate(P::Partitions{T}, state::Nothing = nothing) where T
 
 end
 
-function Base.iterate(P::Partitions{T}, state::Tuple{Vector{T}, Int, Int})
+function Base.iterate(P::Partitions{T}, state::Tuple{Vector{T}, Int, Int}) where T
   d, k, q = state
   q==0 && return nothing
   if d[q] == 2

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -142,7 +142,8 @@ base(P::PartitionsFixedNumParts) = P.n
 Base.eltype(::PartitionsFixedNumParts{T}) where T = Partition{T}
 
 function Base.show(io::IO, ::MIME"text/plain", P::PartitionsFixedNumParts)
-  print(pretty(io), "Iterator over the partitions of $(base(P)) into $(P.k) parts")
+  print(pretty(io), "Iterator over the partitions of $(base(P)) into",
+  ItemQuantity(P.k, "part"))
 end
 
 # NOTE this will not be accurate in many cases,

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -474,114 +474,114 @@ end
 
 
 
-function partitions(n::T, m::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; only_distinct_parts::Bool = false) where T <: IntegerUnion
-  # Algorithm "parta" in [RJ76](@cite), de-gotoed from old ALGOL 60 code by E. Thiel.
-
-  # Note that the algorithm is given as partitioning m into n parts,
-  # but we have refactored to align more closely with standard terminology.
-
-  #Argument checking
-  @req n >= 0 "n >= 0 required"
-  @req m >= 0 "m >= 0 required"
-  @req l1 >= 0 "l1 >= 0 required"
-
-  # Use type of n
-  m = convert(T, m)
-
-  # If l1 == 0 the algorithm parta will actually create lists containing the
-  # entry zero, e.g. partitions(2, 2, 0, 2) will contain [2, 0].
-  # This is nonsense, so we set l1 = 1 in this case.
-  if l1 == 0
-    l1 = 1
-  end
-
-  # Some trivial cases
-  if n == 0 && m == 0
-    return (p for p in Partition{T}[ partition(T[], check = false) ])
-  end
-
-  if m == 0 || m > n
-    return (p for p in Partition{T}[])
-  end
-
-  if l2 < l1
-    return (p for p in Partition{T}[])
-  end
-
-
-
-  #Algorithm starts here
-  P = Partition{T}[]    #this will be the array of all partitions
-  x = zeros(T, m)
-  y = zeros(T, m)
-  j = only_distinct_parts*m*(m - 1)
-  n = n - m*l1 - div(j, 2)
-  l2 = l2 - l1
-  if 0 <= n <= m*l2 - j
-
-    for i = 1:m
-      y[i] = x[i] = l1 + only_distinct_parts*(m - i)
-    end
-
-    i = 1
-    l2 = l2 - only_distinct_parts*(m - 1)
-
-    while true
-      while n > l2
-        n -= l2
-        x[i] = y[i] + l2
-        i += 1
-      end
-
-      x[i] = y[i] + n
-      push!(P, partition(x[1:m], check = false))
-
-      if i < m && n > 1
-        n = 1
-        x[i] = x[i] - 1
-        i += 1
-        x[i] = y[i] + 1
-        push!(P, partition(x[1:m], check = false))
-      end
-
-      lcycle = false
-      for j = i - 1:-1:1
-        l2 = x[j] - y[j] - 1
-        n = n + 1
-        if n <= (m - j)*l2
-          x[j] = y[j] + l2
-          lcycle = true
-          break
-        end
-        n = n + l2
-        x[i] = y[i]
-        i = j
-      end
-
-      if !lcycle
-        break
-      end
-    end
-  end
-
-  return (p for p in P)
-end
-
-function partitions(n::T, m::IntegerUnion; only_distinct_parts::Bool = false) where T <: IntegerUnion
-  @req n >= 0 "n >= 0 required"
-  @req m >= 0 "m >= 0 required"
-
-  # Special cases
-  if n == m
-    return (p for p in [ partition(T[ 1 for i in 1:n], check = false) ])
-  elseif n < m || m == 0
-    return (p for p in Partition{T}[])
-  elseif m == 1
-    return (p for p in [ partition(T[n], check = false) ])
-  end
-
-  return (p for p in partitions(n, m, 1, n; only_distinct_parts = only_distinct_parts))
-end
+# function partitions(n::T, m::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; only_distinct_parts::Bool = false) where T <: IntegerUnion
+#   # Algorithm "parta" in [RJ76](@cite), de-gotoed from old ALGOL 60 code by E. Thiel.
+#
+#   # Note that the algorithm is given as partitioning m into n parts,
+#   # but we have refactored to align more closely with standard terminology.
+#
+#   #Argument checking
+#   @req n >= 0 "n >= 0 required"
+#   @req m >= 0 "m >= 0 required"
+#   @req l1 >= 0 "l1 >= 0 required"
+#
+#   # Use type of n
+#   m = convert(T, m)
+#
+#   # If l1 == 0 the algorithm parta will actually create lists containing the
+#   # entry zero, e.g. partitions(2, 2, 0, 2) will contain [2, 0].
+#   # This is nonsense, so we set l1 = 1 in this case.
+#   if l1 == 0
+#     l1 = 1
+#   end
+#
+#   # Some trivial cases
+#   if n == 0 && m == 0
+#     return (p for p in Partition{T}[ partition(T[], check = false) ])
+#   end
+#
+#   if m == 0 || m > n
+#     return (p for p in Partition{T}[])
+#   end
+#
+#   if l2 < l1
+#     return (p for p in Partition{T}[])
+#   end
+#
+#
+#
+#   #Algorithm starts here
+#   P = Partition{T}[]    #this will be the array of all partitions
+#   x = zeros(T, m)
+#   y = zeros(T, m)
+#   j = only_distinct_parts*m*(m - 1)
+#   n = n - m*l1 - div(j, 2)
+#   l2 = l2 - l1
+#   if 0 <= n <= m*l2 - j
+#
+#     for i = 1:m
+#       y[i] = x[i] = l1 + only_distinct_parts*(m - i)
+#     end
+#
+#     i = 1
+#     l2 = l2 - only_distinct_parts*(m - 1)
+#
+#     while true
+#       while n > l2
+#         n -= l2
+#         x[i] = y[i] + l2
+#         i += 1
+#       end
+#
+#       x[i] = y[i] + n
+#       push!(P, partition(x[1:m], check = false))
+#
+#       if i < m && n > 1
+#         n = 1
+#         x[i] = x[i] - 1
+#         i += 1
+#         x[i] = y[i] + 1
+#         push!(P, partition(x[1:m], check = false))
+#       end
+#
+#       lcycle = false
+#       for j = i - 1:-1:1
+#         l2 = x[j] - y[j] - 1
+#         n = n + 1
+#         if n <= (m - j)*l2
+#           x[j] = y[j] + l2
+#           lcycle = true
+#           break
+#         end
+#         n = n + l2
+#         x[i] = y[i]
+#         i = j
+#       end
+#
+#       if !lcycle
+#         break
+#       end
+#     end
+#   end
+#
+#   return (p for p in P)
+# end
+#
+# function partitions(n::T, m::IntegerUnion; only_distinct_parts::Bool = false) where T <: IntegerUnion
+#   @req n >= 0 "n >= 0 required"
+#   @req m >= 0 "m >= 0 required"
+#
+#   # Special cases
+#   if n == m
+#     return (p for p in [ partition(T[ 1 for i in 1:n], check = false) ])
+#   elseif n < m || m == 0
+#     return (p for p in Partition{T}[])
+#   elseif m == 1
+#     return (p for p in [ partition(T[n], check = false) ])
+#   end
+#
+#   return (p for p in partitions(n, m, 1, n; only_distinct_parts = only_distinct_parts))
+# end
 
 
 @doc raw"""

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -199,9 +199,9 @@ end
 
 function Base.iterate(P::PartitionSet{T}) where T
   if P.n == 0
-    return Partition{T}[ partition(T[]) ], (T[], 0, 0)
+    return partition(T), (T[], 0, 0)
   elseif P.n == 1
-    return Partition{T}[ partition(T[1]) ], (T[1], 1, 0)
+    return partition(T[1]), (T[1], 1, 0)
   end
 
   d = fill( T(1), P.n )

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -370,12 +370,12 @@ julia> collect(partitions(7, 3, 1, 4; only_distinct_parts = true))
  [4, 2, 1]
 ```
 """
-function partitions(n::IntegerUnion, m::IntegerUnion; only_distinct_parts::Bool = false)
-  return PartitionsFixedNumParts(n, m; only_distinct_parts = only_distinct_parts)
-end
-
 function partitions(n::IntegerUnion, m::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; only_distinct_parts::Bool = false)
   return PartitionsFixedNumParts(n, m, l1, l2; only_distinct_parts = only_distinct_parts)
+end
+
+function partitions(n::IntegerUnion, m::IntegerUnion; only_distinct_parts::Bool = false)
+  return PartitionsFixedNumParts(n, m; only_distinct_parts = only_distinct_parts)
 end
 
 

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -149,7 +149,7 @@ function Base.show(io::IO, ::MIME"text/plain", P::PartitionsFixedNumParts)
   if is_terse(io)
     print(io, "Iterator")
   else
-    print(io, "Iterator over the partitions of $(base(P)) into $(P.k) parts")
+    print(io, "Iterator over the partitions of $(base(P)) into $(P.m) parts")
   end
 end
 
@@ -157,7 +157,7 @@ end
 # in particular if upper/lower bounds are given,
 # or if `only_distinct_parts == true`.
 # Base.length(P::PartitionsFixedNumParts) = BigInt(number_of_partitions(P.n, P.m))
-Base.IteratorSize(::Type{PartitionsFixedNumParts}) = Base.SizeUnknown()
+Base.IteratorSize(::Type{PartitionsFixedNumParts{T}}) where T = Base.SizeUnknown()
 ################################################################################
 #
 # Generating and counting unrestricted partitions
@@ -226,7 +226,7 @@ function partitions(n::IntegerUnion)
 end
 
 
-function Base.iterate(P::Partitions{T}, state::Nothing = nothing) where T
+function Base.iterate(P::Partitions{T}) where T
   n = base(P)
 
   if n == 0
@@ -379,11 +379,11 @@ function partitions(n::IntegerUnion, m::IntegerUnion, l1::IntegerUnion, l2::Inte
 end
 
 
-function Base.iterate(P::PartitionsFixedNumParts{T}, state::Nothing = nothing) where T
+function Base.iterate(P::PartitionsFixedNumParts{T}) where T
   n = P.n
   m = P.m
   l1 = P.lb
-  l2 = P.up
+  l2 = P.ub
   only_distinct_parts = P.distinct_parts
 
   # TODO : fix the states returned once we know what those will look like
@@ -423,12 +423,12 @@ function Base.iterate(P::PartitionsFixedNumParts{T}, state::Nothing = nothing) w
     x[i] = y[i] + L2
     i += 1
   end
-  x[i] = y[i] + n
+  x[i] = y[i] + N
   return partition(x[1:m], check = false), (x, y, N, L2, i, true)
 end
 
 function Base.iterate(P::PartitionsFixedNumParts{T}, state::Tuple{Vector{T}, Vector{T}, T, IntegerUnion, Int, Bool}) where T
-
+  m = P.m
   x, y, N, L2, i, flag = state
 
   N == 0 && return nothing
@@ -463,15 +463,9 @@ function Base.iterate(P::PartitionsFixedNumParts{T}, state::Tuple{Vector{T}, Vec
     x[i] = y[i] + L2
     i += 1
   end
-  x[i] = y[i] + n
+  x[i] = y[i] + N
   return partition(x[1:m], check = false), (x,y,N,L2,i,true)
 end
-
-
-
-
-
-
 
 
 # function partitions(n::T, m::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; only_distinct_parts::Bool = false) where T <: IntegerUnion

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -397,6 +397,7 @@ function Base.iterate(P::PartitionsFixedNumParts{T}) where T
   end
 
   if n == m && l1 == 1
+    only_distinct_parts && m > 1 && return nothing
     return partition(T[1 for i in 1:n], check=false), (T[], T[], 0, 0, 1, false)
   end
 

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -130,11 +130,7 @@ base(P::Partitions) = P.n
 Base.eltype(::Partitions{T}) where T = Partition{T}
 
 function Base.show(io::IO, ::MIME"text/plain", P::Partitions)
-  if is_terse(io)
-    print(io, "Iterator")
-  else
-    print(io, "Iterator over the partitions of $(base(P))")
-  end
+  print(io, "Iterator over the partitions of $(base(P))")
 end
 
 Base.length(P::Partitions) = BigInt(number_of_partitions(P.n))
@@ -146,11 +142,7 @@ base(P::PartitionsFixedNumParts) = P.n
 Base.eltype(::PartitionsFixedNumParts{T}) where T = Partition{T}
 
 function Base.show(io::IO, ::MIME"text/plain", P::PartitionsFixedNumParts)
-  if is_terse(io)
-    print(io, "Iterator")
-  else
-    print(io, "Iterator over the partitions of $(base(P)) into $(P.k) parts")
-  end
+  print(io, "Iterator over the partitions of $(base(P)) into $(P.k) parts")
 end
 
 # NOTE this will not be accurate in many cases,

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -281,33 +281,33 @@ end
     number_of_partitions(n::IntegerUnion, k::IntegerUnion)
 
 Return the number of integer partitions of the non-negative integer `n` into
-`k >= 0` parts.
-If `n < 0` or `k < 0`, return `0`.
+`m >= 0` parts.
+If `n < 0` or `m < 0`, return `0`.
 """
-function number_of_partitions(n::IntegerUnion, k::IntegerUnion)
-  if n < 0 || k < 0
+function number_of_partitions(n::IntegerUnion, m::IntegerUnion)
+  if n < 0 || m < 0
     return ZZ(0)
   end
 
   n = ZZ(n)
-  k = ZZ(k)
+  m = ZZ(m)
 
   # Special cases
-  if n == k
+  if n == m
     return ZZ(1)
-  elseif n < k || k == 0
+  elseif n < m || m == 0
     return ZZ(0)
-  elseif k == 1
+  elseif m == 1
     return ZZ(1)
 
   # See https://oeis.org/A008284
-  elseif n < 2*k
-    return number_of_partitions(n - k) #n - k >= 0 holds since the case n<k was already handled
+elseif n < 2*m
+    return number_of_partitions(n - m) #n - m >= 0 holds since the case n<k was already handled
 
   # See https://oeis.org/A008284
-  elseif n <= 2 + 3*k
-    p = number_of_partitions(n - k) #n - k >= 0 holds since the case n<k was already handled
-    for i = 0:Int(n) - 2*Int(k) - 1
+elseif n <= 2 + 3*m
+    p = number_of_partitions(n - m) #n - m >= 0 holds since the case n<k was already handled
+    for i = 0:Int(n) - 2*Int(m) - 1
       p = p - number_of_partitions(ZZ(i))
     end
     return p
@@ -318,14 +318,14 @@ function number_of_partitions(n::IntegerUnion, k::IntegerUnion)
   # way without recursion.
   else
     n = Int(n)
-    k = Int(k)
+    m = Int(m)
     p = fill( ZZ(1), n )
-    for l = 2:k
+    for l = 2:m
       for m = l + 1:n - l + 1
         p[m] = p[m] + p[m - l]
       end
     end
-    return p[n - k + 1]
+    return p[n - m + 1]
   end
 
 end

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -125,7 +125,7 @@ function getindex_safe(P::Partition{T}, i::IntegerUnion) where T
   return (i > length(data(P)) ? zero(T) : getindex(data(P), Int(i)))
 end
 
-base(C::Partitions) = P.n
+base(P::Partitions) = P.n
 
 Base.eltype(::Partitions{T}) where T = Partition{T}
 
@@ -138,6 +138,22 @@ function Base.show(io::IO, ::MIME"text/plain", P::Partitions)
 end
 
 Base.length(P::Partitions) = BigInt(number_of_partitions(P.n))
+
+
+
+base(P::PartitionsFixedNumParts) = P.n
+
+Base.eltype(::PartitionsFixedNumParts{T}) where T = Partition{T}
+
+function Base.show(io::IO, ::MIME"text/plain", P::PartitionsFixedNumParts)
+  if is_terse(io)
+    print(io, "Iterator")
+  else
+    print(io, "Iterator over the partitions of $(base(P)) into $(P.k) parts")
+  end
+end
+
+Base.length(P::PartitionsFixedNumParts) = BigInt(number_of_partitions(P.n, P.k))
 
 ################################################################################
 #

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -156,7 +156,7 @@ end
 # NOTE this will not be accurate in many cases,
 # in particular if upper/lower bounds are given,
 # or if `only_distinct_parts == true`.
-Base.length(P::PartitionsFixedNumParts) = BigInt(number_of_partitions(P.n, P.k))
+Base.length(P::PartitionsFixedNumParts) = BigInt(number_of_partitions(P.n, P.m))
 
 ################################################################################
 #

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -763,7 +763,7 @@ function partitions(n::T, k::IntegerUnion, v::Vector{T}, mu::Vector{S}) where {T
   # Initialize variables
   r = length(v)
   j = 1
-  k = mu[1]
+  m = mu[1]
   ll = v[1]
   x = zeros(T, k)
   y = zeros(T, k)
@@ -783,9 +783,9 @@ function partitions(n::T, k::IntegerUnion, v::Vector{T}, mu::Vector{S}) where {T
   for i = k:-1:1
     x[i] = ll
     y[i] = ll
-    k = k - 1
+    m = m - 1
     n = n - ll
-    if k == 0
+    if m == 0
       if j == r
         # In the original algorithm there's a goto b3 here which means
         # the program will terminate, and thus return an empty list.
@@ -794,7 +794,7 @@ function partitions(n::T, k::IntegerUnion, v::Vector{T}, mu::Vector{S}) where {T
         break
       end
       j = j + 1
-      k = mu[j]
+      m = mu[j]
       ll = v[j]
     end
     if i == 1
@@ -877,7 +877,7 @@ function partitions(n::T, k::IntegerUnion, v::Vector{T}, mu::Vector{S}) where {T
         lr = v[r]
       end #if
 
-      k = y[i]
+      m = y[i]
       # Here comes the most intricate mistake.
       # On "Knuth's" problem
       # 100, 7, [1, 2, 5, 10, 20, 50], [2, 2, 2, 2, 2, 2]
@@ -886,23 +886,23 @@ function partitions(n::T, k::IntegerUnion, v::Vector{T}, mu::Vector{S}) where {T
       # But when we replace lr > k by lr >= k, everything works.
       # Finding this was a wild guess!
       # Found on Mar 27, 2023.
-      if lr >= k && n - lr <= (k - i)*(lr - ll)
+      if lr >= m && n - lr <= (k - i)*(lr - ll)
         gotob2 = false
         continue
       else
-        x[i] = k
+        x[i] = m
       end #if
       for i_0 = i - 1:-1:1 #this is to replace the for i = i - 1 in ALGOL code
         i = i_0
         r = ii[i]
         lr = v[r]
-        n = n + x[i] - k
-        k = y[i]
-        if lr >= k && n - lr <= (k - i)*(lr - ll) # >= here as well (probably...)
+        n = n + x[i] - m
+        m = y[i]
+        if lr >= m && n - lr <= (k - i)*(lr - ll) # >= here as well (probably...)
           gotob2 = false
           break
         else
-          x[i] = k
+          x[i] = m
         end #if
       end #for
       if gotob2

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -159,6 +159,9 @@ struct PartitionsFixedNumParts{T<:IntegerUnion}
     @req n >= 0 "n >= 0 required"
     @req k >= 0 "k >= 0 required"
     @req lb >= 0 "lb >=0 required"
+    # If lb == 0 the algorithm will actually create lists containing the
+    # entry zero, e.g. partitions(2, 2, 0, 2) will contain [2, 0].
+    # This is nonsense, so we set lb = 1 in this case.
     if lb == 0
       lb = 1
     end

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -134,12 +134,26 @@ struct Partition{T<:IntegerUnion} <: AbstractVector{T}
   p::Vector{T}
 end
 
+# Iterator type
 struct Partitions{T<:IntegerUnion}
   n::T
 
   function Partitions(n::T) where T<:IntegerUnion
     @req n >= 0 "n >= 0 required"
     return new{T}(n)
+  end
+
+end
+
+struct PartitionsFixedNumParts{T<:IntegerUnion} <: AbstractVector{T}
+  n::T
+  k::Int
+  # part_iter::Partitions{T}
+
+  function PartitionsFixedNumParts(n::T, k::Int) where T<:IntegerUnion
+    @req n >= 0 "n >= 0 required"
+    @req k >= 0 "k >= 0 required"
+    return new{T}(n, k)
   end
 
 end

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -161,6 +161,9 @@ struct PartitionsFixedNumParts{T<:IntegerUnion}
     @req n >= 0 "n >= 0 required"
     @req m >= 0 "m >= 0 required"
     @req l1 >= 0 "l1 >=0 required"
+    if l1 == 0
+      l1 = 1
+    end
     return new{T}(n, convert(T, m), T(l1), T(l2), only_distinct_parts)
   end
 

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -171,8 +171,8 @@ function PartitionsFixedNumParts(n::T, k::IntegerUnion; only_distinct_parts::Boo
   return PartitionsFixedNumParts(n, k, 1, n, only_distinct_parts)
 end
 
-function PartitionsFixedNumParts(n::T, k::IntegerUnion, lb::IntegerUnion, lb::IntegerUnion; only_distinct_parts::Bool = false) where T<:IntegerUnion
-  return PartitionsFixedNumParts(n, k, lb, l2, only_distinct_parts)
+function PartitionsFixedNumParts(n::T, k::IntegerUnion, lb::IntegerUnion, ub::IntegerUnion; only_distinct_parts::Bool = false) where T<:IntegerUnion
+  return PartitionsFixedNumParts(n, k, lb, ub, only_distinct_parts)
 end
 
 

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -161,8 +161,7 @@ struct PartitionsFixedNumParts{T<:IntegerUnion} <: AbstractVector{T}
     @req n >= 0 "n >= 0 required"
     @req k >= 0 "m >= 0 required"
     @req l1 >= 0 "l1 >=0 required"
-    @req l2 >= l1 "l2 >= l1 required"
-    return new{T}(n, m, T(l1), T(l2), only_distinct_parts)
+    return new{T}(n, convert(T, m), T(l1), T(l2), only_distinct_parts)
   end
 
 end

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -151,16 +151,16 @@ end
 #  - support for upper/lower bounds
 struct PartitionsFixedNumParts{T<:IntegerUnion} <: AbstractVector{T}
   n::T
-  k::Int
+  m::Int
 
   lb::T
   ub::T
   distinct_parts::Bool
 
-  function PartitionsFixedNumParts(n::T, k::Int) where T<:IntegerUnion
+  function PartitionsFixedNumParts(n::T, m::Int) where T<:IntegerUnion
     @req n >= 0 "n >= 0 required"
-    @req k >= 0 "k >= 0 required"
-    return new{T}(n, k, 1, n, false)
+    @req k >= 0 "m >= 0 required"
+    return new{T}(n, m, 1, n, false)
   end
 
 end

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -134,7 +134,7 @@ struct Partition{T<:IntegerUnion} <: AbstractVector{T}
   p::Vector{T}
 end
 
-# Iterator type
+# Iterator type: all partitions of an integer n
 struct Partitions{T<:IntegerUnion}
   n::T
 
@@ -145,10 +145,8 @@ struct Partitions{T<:IntegerUnion}
 
 end
 
-# Iterator type
-# TODO: This should also have:
-#  - a flag for `only_distinct_parts`
-#  - support for upper/lower bounds
+# Iterator type: partitions of n into m parts, with optional lower/upper bounds on the parts
+# If distinct_parts == true, then all parts have distinct values.
 struct PartitionsFixedNumParts{T<:IntegerUnion}
   n::T
   m::Int

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -145,34 +145,34 @@ struct Partitions{T<:IntegerUnion}
 
 end
 
-# Iterator type: partitions of n into m parts, with optional lower/upper bounds on the parts
+# Iterator type: partitions of n into k parts, with optional lower/upper bounds on the parts
 # If distinct_parts == true, then all parts have distinct values.
 struct PartitionsFixedNumParts{T<:IntegerUnion}
   n::T
-  m::Int
+  k::Int
 
   lb::T
   ub::T
   distinct_parts::Bool
 
-  function PartitionsFixedNumParts(n::T, m::IntegerUnion, lb::IntegerUnion, ub::IntegerUnion, only_distinct_parts::Bool) where T<:IntegerUnion
+  function PartitionsFixedNumParts(n::T, k::IntegerUnion, lb::IntegerUnion, ub::IntegerUnion, only_distinct_parts::Bool) where T<:IntegerUnion
     @req n >= 0 "n >= 0 required"
-    @req m >= 0 "m >= 0 required"
+    @req k >= 0 "k >= 0 required"
     @req lb >= 0 "lb >=0 required"
     if lb == 0
       lb = 1
     end
-    return new{T}(n, convert(T, m), T(lb), T(ub), only_distinct_parts)
+    return new{T}(n, convert(T, k), T(lb), T(ub), only_distinct_parts)
   end
 
 end
 
-function PartitionsFixedNumParts(n::T, m::IntegerUnion; only_distinct_parts::Bool = false) where T<:IntegerUnion
-  return PartitionsFixedNumParts(n, m, 1, n, only_distinct_parts)
+function PartitionsFixedNumParts(n::T, k::IntegerUnion; only_distinct_parts::Bool = false) where T<:IntegerUnion
+  return PartitionsFixedNumParts(n, k, 1, n, only_distinct_parts)
 end
 
-function PartitionsFixedNumParts(n::T, m::IntegerUnion, lb::IntegerUnion, lb::IntegerUnion; only_distinct_parts::Bool = false) where T<:IntegerUnion
-  return PartitionsFixedNumParts(n, m, lb, l2, only_distinct_parts)
+function PartitionsFixedNumParts(n::T, k::IntegerUnion, lb::IntegerUnion, lb::IntegerUnion; only_distinct_parts::Bool = false) where T<:IntegerUnion
+  return PartitionsFixedNumParts(n, k, lb, l2, only_distinct_parts)
 end
 
 

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -134,6 +134,16 @@ struct Partition{T<:IntegerUnion} <: AbstractVector{T}
   p::Vector{T}
 end
 
+struct Partitions{T<:IntegerUnion}
+  n::T
+
+  function Partitions(n::T) where T<:IntegerUnion
+    @req n >= 0 "n >= 0 required"
+    return new{T}(n)
+  end
+
+end
+
 ################################################################################
 #
 #  Young Tableaux

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -149,16 +149,18 @@ end
 # TODO: This should also have:
 #  - a flag for `only_distinct_parts`
 #  - support for upper/lower bounds
-#  -
 struct PartitionsFixedNumParts{T<:IntegerUnion} <: AbstractVector{T}
   n::T
   k::Int
-  # part_iter::Partitions{T}
+
+  lb::T
+  ub::T
+  distinct_parts::Bool
 
   function PartitionsFixedNumParts(n::T, k::Int) where T<:IntegerUnion
     @req n >= 0 "n >= 0 required"
     @req k >= 0 "k >= 0 required"
-    return new{T}(n, k)
+    return new{T}(n, k, 1, n, false)
   end
 
 end

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -157,13 +157,25 @@ struct PartitionsFixedNumParts{T<:IntegerUnion} <: AbstractVector{T}
   ub::T
   distinct_parts::Bool
 
-  function PartitionsFixedNumParts(n::T, m::Int) where T<:IntegerUnion
+  function PartitionsFixedNumParts(n::T, m::Int, l1::IntegerUnion, l2::IntegerUnion, only_distinct_parts::Bool) where T<:IntegerUnion
     @req n >= 0 "n >= 0 required"
     @req k >= 0 "m >= 0 required"
-    return new{T}(n, m, 1, n, false)
+    @req l1 >= 0 "l1 >=0 required"
+    @req l2 >= l1 "l2 >= l1 required"
+    return new{T}(n, m, T(l1), T(l2), only_distinct_parts)
   end
 
 end
+
+function PartitionsFixedNumParts(n::T, m::Int; only_distinct_parts::Bool = false) where T<:IntegerUnion
+  return PartitionsFixedNumParts(n, m, T(1), T(n), only_distinct_parts)
+end
+
+function PartitionsFixedNumParts(n::T, m::Int, l1::IntegerUnion, l2::IntegerUnion; only_distinct_parts::Bool = false) where T<:IntegerUnion
+  return PartitionsFixedNumParts(n, m, T(l1), T(l2), only_distinct_parts)
+end
+
+
 
 ################################################################################
 #

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -145,6 +145,11 @@ struct Partitions{T<:IntegerUnion}
 
 end
 
+# Iterator type
+# TODO: This should also have:
+#  - a flag for `only_distinct_parts`
+#  - support for upper/lower bounds
+#  -
 struct PartitionsFixedNumParts{T<:IntegerUnion} <: AbstractVector{T}
   n::T
   k::Int

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -157,7 +157,7 @@ struct PartitionsFixedNumParts{T<:IntegerUnion} <: AbstractVector{T}
   ub::T
   distinct_parts::Bool
 
-  function PartitionsFixedNumParts(n::T, m::Int, l1::IntegerUnion, l2::IntegerUnion, only_distinct_parts::Bool) where T<:IntegerUnion
+  function PartitionsFixedNumParts(n::T, m::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion, only_distinct_parts::Bool) where T<:IntegerUnion
     @req n >= 0 "n >= 0 required"
     @req k >= 0 "m >= 0 required"
     @req l1 >= 0 "l1 >=0 required"
@@ -167,11 +167,11 @@ struct PartitionsFixedNumParts{T<:IntegerUnion} <: AbstractVector{T}
 
 end
 
-function PartitionsFixedNumParts(n::T, m::Int; only_distinct_parts::Bool = false) where T<:IntegerUnion
+function PartitionsFixedNumParts(n::T, m::IntegerUnion; only_distinct_parts::Bool = false) where T<:IntegerUnion
   return PartitionsFixedNumParts(n, m, T(1), T(n), only_distinct_parts)
 end
 
-function PartitionsFixedNumParts(n::T, m::Int, l1::IntegerUnion, l2::IntegerUnion; only_distinct_parts::Bool = false) where T<:IntegerUnion
+function PartitionsFixedNumParts(n::T, m::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; only_distinct_parts::Bool = false) where T<:IntegerUnion
   return PartitionsFixedNumParts(n, m, T(l1), T(l2), only_distinct_parts)
 end
 

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -149,7 +149,7 @@ end
 # TODO: This should also have:
 #  - a flag for `only_distinct_parts`
 #  - support for upper/lower bounds
-struct PartitionsFixedNumParts{T<:IntegerUnion} <: AbstractVector{T}
+struct PartitionsFixedNumParts{T<:IntegerUnion}
   n::T
   m::Int
 

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -159,7 +159,7 @@ struct PartitionsFixedNumParts{T<:IntegerUnion} <: AbstractVector{T}
 
   function PartitionsFixedNumParts(n::T, m::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion, only_distinct_parts::Bool) where T<:IntegerUnion
     @req n >= 0 "n >= 0 required"
-    @req k >= 0 "m >= 0 required"
+    @req m >= 0 "m >= 0 required"
     @req l1 >= 0 "l1 >=0 required"
     return new{T}(n, convert(T, m), T(l1), T(l2), only_distinct_parts)
   end

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -155,24 +155,24 @@ struct PartitionsFixedNumParts{T<:IntegerUnion}
   ub::T
   distinct_parts::Bool
 
-  function PartitionsFixedNumParts(n::T, m::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion, only_distinct_parts::Bool) where T<:IntegerUnion
+  function PartitionsFixedNumParts(n::T, m::IntegerUnion, lb::IntegerUnion, ub::IntegerUnion, only_distinct_parts::Bool) where T<:IntegerUnion
     @req n >= 0 "n >= 0 required"
     @req m >= 0 "m >= 0 required"
-    @req l1 >= 0 "l1 >=0 required"
-    if l1 == 0
-      l1 = 1
+    @req lb >= 0 "lb >=0 required"
+    if lb == 0
+      lb = 1
     end
-    return new{T}(n, convert(T, m), T(l1), T(l2), only_distinct_parts)
+    return new{T}(n, convert(T, m), T(lb), T(ub), only_distinct_parts)
   end
 
 end
 
 function PartitionsFixedNumParts(n::T, m::IntegerUnion; only_distinct_parts::Bool = false) where T<:IntegerUnion
-  return PartitionsFixedNumParts(n, m, T(1), T(n), only_distinct_parts)
+  return PartitionsFixedNumParts(n, m, 1, n, only_distinct_parts)
 end
 
-function PartitionsFixedNumParts(n::T, m::IntegerUnion, l1::IntegerUnion, l2::IntegerUnion; only_distinct_parts::Bool = false) where T<:IntegerUnion
-  return PartitionsFixedNumParts(n, m, T(l1), T(l2), only_distinct_parts)
+function PartitionsFixedNumParts(n::T, m::IntegerUnion, lb::IntegerUnion, lb::IntegerUnion; only_distinct_parts::Bool = false) where T<:IntegerUnion
+  return PartitionsFixedNumParts(n, m, lb, l2, only_distinct_parts)
 end
 
 

--- a/src/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
@@ -165,9 +165,9 @@ end
 
 function Base.show(io::IO, W::WeakCompositions)
   if is_terse(io)
-    print(io, "Iterator")
+    print(io, "Iterator over the weak compositions of $(base(W)) into ", ItemQuantity(parts(W), "parts"))
   else
     io = pretty(io)
-    print(io, "Iterator over the weak compositions of $(base(W)) into ", ItemQuantity(parts(W), "part"))
+    print(io, "Iterator over the weak compositions of $(base(W)) into ", ItemQuantity(parts(W), "parts"))
   end
 end

--- a/src/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
@@ -164,10 +164,5 @@ function Base.iterate(W::WeakCompositions{T}, s::Vector{T}) where T
 end
 
 function Base.show(io::IO, W::WeakCompositions)
-  if is_terse(io)
-    print(io, "Iterator over the weak compositions of $(base(W)) into ", ItemQuantity(parts(W), "parts"))
-  else
-    io = pretty(io)
-    print(io, "Iterator over the weak compositions of $(base(W)) into ", ItemQuantity(parts(W), "parts"))
-  end
+    print(pretty(io), "Iterator over the weak compositions of $(base(W)) into ", ItemQuantity(parts(W), "part"))
 end

--- a/test/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -100,15 +100,15 @@
   end
 
   ############################################################################
-  # partitions(n,k,l1,l2)
+  # partitions(n,k,lb,ub)
   ############################################################################
-  @testset "partitions($n,$k,$l1,$l2)" for n in 0:20, k in 0:n+1, l1 in 0:n, l2 in l1:n
-    P = collect(partitions(n,k,l1,l2))
+  @testset "partitions($n,$k,$lb,$ub)" for n in 0:20, k in 0:n+1, lb in 0:n, ub in lb:n
+    P = collect(partitions(n,k,lb,ub))
 
     # Create the same by filtering all partitions
     Q = collect(partitions(n,k))
-    filter!( Q->all(>=(l1),Q), Q)
-    filter!( Q->all(<=(l2),Q), Q)
+    filter!( Q->all(>=(lb),Q), Q)
+    filter!( Q->all(<=(ub),Q), Q)
 
     # Check that P and Q coincide (up to reordering)
     @test length(P) == length(Q)
@@ -116,13 +116,13 @@
   end
 
   ############################################################################
-  # partitions(n,k,l1,l2; only_distinct_parts=true)
+  # partitions(n,k,lb,ub; only_distinct_parts=true)
   ############################################################################
-  @testset "partitions($n,$k,$l1,$l2; only_distinct_parts=true)" for n in 0:20, k in 0:n+1, l1 in 0:n, l2 in l1:n
-    P = collect(partitions(n, k, l1, l2; only_distinct_parts=true))
+  @testset "partitions($n,$k,$lb,$ub; only_distinct_parts=true)" for n in 0:20, k in 0:n+1, lb in 0:n, ub in lb:n
+    P = collect(partitions(n, k, lb, ub; only_distinct_parts=true))
 
     # Create the same by filtering all partitions
-    Q = collect(partitions(n, k, l1, l2))
+    Q = collect(partitions(n, k, lb, ub))
     filter!( Q->Q==unique(Q), Q )
 
     # Check that P and Q coincide (up to reordering)

--- a/test/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -212,4 +212,5 @@
     for p in partitions(10)
       @test conjugate(conjugate(p)) == p
     end
+  end
 end

--- a/test/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -118,16 +118,18 @@
   ############################################################################
   # partitions(n,k,lb,ub; only_distinct_parts=true)
   ############################################################################
-  @testset "partitions($n,$k,$lb,$ub; only_distinct_parts=true)" for n in 0:20, k in 0:n+1, lb in 0:n, ub in lb:n
-    P = collect(partitions(n, k, lb, ub; only_distinct_parts=true))
+  @testset "partitions($n,$k,lb,ub; only_distinct_parts=true)" for n in 0:10, k in 0:n+1
+    @testset "partitions($n,$k,$lb,$ub; only_distinct_parts=true)" lb in 0:n, ub in lb:n
+      P = collect(partitions(n, k, lb, ub; only_distinct_parts=true))
 
-    # Create the same by filtering all partitions
-    Q = collect(partitions(n, k, lb, ub))
-    filter!( Q->Q==unique(Q), Q )
+      # Create the same by filtering all partitions
+      Q = collect(partitions(n, k, lb, ub))
+      filter!( Q->Q==unique(Q), Q )
 
-    # Check that P and Q coincide (up to reordering)
-    @test length(P) == length(Q)
-    @test Set(P) == Set(Q)
+      # Check that P and Q coincide (up to reordering)
+      @test length(P) == length(Q)
+      @test Set(P) == Set(Q)
+    end
   end
 
   ############################################################################

--- a/test/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -3,37 +3,40 @@
   ############################################################################
   # Partition constructor
   ############################################################################
-  @test partition(Int8,2,2,1) == partition(Int8[2,2,1])
-  @test typeof(partition(Int8,2,2,1)) == typeof(partition(Int8[2,2,1]))
-  @test partition(Int8,1) == partition(Int8[1])
-  @test typeof(partition(Int8,1)) == typeof(partition(Int8[1]))
-  @test partition(Int8,) == partition(Int8[])
-  @test typeof(partition(Int8,)) == typeof(partition(Int8[]))
+  @testset "Partition constructor" begin
+    @test partition(Int8,2,2,1) == partition(Int8[2,2,1])
+    @test typeof(partition(Int8,2,2,1)) == typeof(partition(Int8[2,2,1]))
+    @test partition(Int8,1) == partition(Int8[1])
+    @test typeof(partition(Int8,1)) == typeof(partition(Int8[1]))
+    @test partition(Int8,) == partition(Int8[])
+    @test typeof(partition(Int8,)) == typeof(partition(Int8[]))
 
-  @test partition(2,2,1) == partition([2,2,1])
-  @test partition(1) == partition([1])
-  @test partition() == partition([])
-  @test partition(Int8) == partition(Int8[])
+    @test partition(2,2,1) == partition([2,2,1])
+    @test partition(1) == partition([1])
+    @test partition() == partition([])
+    @test partition(Int8) == partition(Int8[])
+  end
 
   ############################################################################
   # number_of_partitions(n)
   ############################################################################
+  @testset "number_of_partitions(n)" begin
+    # From https://oeis.org/A000041
+    @test [ number_of_partitions(i) for i in 0:49 ] ==
+      ZZRingElem[ 1, 1, 2, 3, 5, 7, 11, 15, 22, 30, 42, 56, 77, 101, 135, 176, 231, 297, 385, 490, 627, 792, 1002, 1255, 1575, 1958, 2436, 3010, 3718, 4565, 5604, 6842, 8349, 10143, 12310, 14883, 17977, 21637, 26015, 31185, 37338, 44583, 53174, 63261, 75175, 89134, 105558, 124754, 147273, 173525 ]
 
-  # From https://oeis.org/A000041
-  @test [ number_of_partitions(i) for i in 0:49 ] ==
-    ZZRingElem[ 1, 1, 2, 3, 5, 7, 11, 15, 22, 30, 42, 56, 77, 101, 135, 176, 231, 297, 385, 490, 627, 792, 1002, 1255, 1575, 1958, 2436, 3010, 3718, 4565, 5604, 6842, 8349, 10143, 12310, 14883, 17977, 21637, 26015, 31185, 37338, 44583, 53174, 63261, 75175, 89134, 105558, 124754, 147273, 173525 ]
 
+    # For some random large numbers, checked with Sage
+    # Partitions(991).cardinality()
+    @test number_of_partitions(991) == ZZ(16839773100833956878604913215477)
 
-  # For some random large numbers, checked with Sage
-  # Partitions(991).cardinality()
-  @test number_of_partitions(991) == ZZ(16839773100833956878604913215477)
-
-  @test number_of_partitions(-1) == ZZ(0)
+    @test number_of_partitions(-1) == ZZ(0)
+  end
 
   ############################################################################
   # partitions(n)
   ############################################################################
-  for n = 0:20
+  @testset "partitions($n)" for n in 0:20
     P = collect(partitions(n))
 
     # Check that the number of partitions is correct
@@ -52,118 +55,105 @@
   ############################################################################
   # number_of_partitions(n,k)
   ############################################################################
-  @test number_of_partitions(0,0) == 1
-  @test number_of_partitions(1,0) == 0
-  @test number_of_partitions(1,1) == 1
-  @test number_of_partitions(0,1) == 0
-  @test number_of_partitions(2,3) == 0
+  @testset "number_of_partitions(n,k)" begin
+    @test number_of_partitions(0,0) == 1
+    @test number_of_partitions(1,0) == 0
+    @test number_of_partitions(1,1) == 1
+    @test number_of_partitions(0,1) == 0
+    @test number_of_partitions(2,3) == 0
 
-  # From https://oeis.org/A008284
-  @test [ number_of_partitions(n,k) for n in 1:14 for k in 1:n ] == 
-    ZZRingElem[ 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 2, 2, 1, 1, 1, 3, 3, 2, 1, 1, 1, 3, 4, 3, 2, 1, 1, 1, 4, 5, 5, 3, 2, 1, 1, 1, 4, 7, 6, 5, 3, 2, 1, 1, 1, 5, 8, 9, 7, 5, 3, 2, 1, 1, 1, 5, 10, 11, 10, 7, 5, 3, 2, 1, 1, 1, 6, 12, 15, 13, 11, 7, 5, 3, 2, 1, 1, 1, 6, 14, 18, 18, 14, 11, 7, 5, 3, 2, 1, 1, 1, 7, 16, 23, 23, 20, 15, 11, 7, 5, 3, 2, 1, 1 ]
+    # From https://oeis.org/A008284
+    @test [ number_of_partitions(n,k) for n in 1:14 for k in 1:n ] ==
+      ZZRingElem[ 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 2, 2, 1, 1, 1, 3, 3, 2, 1, 1, 1, 3, 4, 3, 2, 1, 1, 1, 4, 5, 5, 3, 2, 1, 1, 1, 4, 7, 6, 5, 3, 2, 1, 1, 1, 5, 8, 9, 7, 5, 3, 2, 1, 1, 1, 5, 10, 11, 10, 7, 5, 3, 2, 1, 1, 1, 6, 12, 15, 13, 11, 7, 5, 3, 2, 1, 1, 1, 6, 14, 18, 18, 14, 11, 7, 5, 3, 2, 1, 1, 1, 7, 16, 23, 23, 20, 15, 11, 7, 5, 3, 2, 1, 1 ]
 
-  # For some random large numbers, checked with Sage
-  # Partitions(1991,length=170).cardinality()
-  @test number_of_partitions(1991,170) == ZZ(22381599503916828837298114953756766080813312)
-  @test number_of_partitions(1991,1000) == ZZ(16839773100833956878604913215477)
-  @test number_of_partitions(1991,670) == ZZ(3329965216307826492368402165868892548)
-  @test number_of_partitions(1991,1991) == ZZ(1)
-  @test number_of_partitions(1991,1) == ZZ(1)
+    # For some random large numbers, checked with Sage
+    # Partitions(1991,length=170).cardinality()
+    @test number_of_partitions(1991,170) == ZZ(22381599503916828837298114953756766080813312)
+    @test number_of_partitions(1991,1000) == ZZ(16839773100833956878604913215477)
+    @test number_of_partitions(1991,670) == ZZ(3329965216307826492368402165868892548)
+    @test number_of_partitions(1991,1991) == ZZ(1)
+    @test number_of_partitions(1991,1) == ZZ(1)
 
-  # From Knuth (2011), p. 25.
-  @test sum([number_of_partitions(30, i) for i in 0:10]) == 3590
+    # From Knuth (2011), p. 25.
+    @test sum([number_of_partitions(30, i) for i in 0:10]) == 3590
 
-  @test number_of_partitions(-1, 0) == ZZ(0)
-  @test number_of_partitions(0, -1) == ZZ(0)
+    @test number_of_partitions(-1, 0) == ZZ(0)
+    @test number_of_partitions(0, -1) == ZZ(0)
+  end
 
   ############################################################################
   # partitions(n,k)
   ############################################################################
-  for n in 0:20
-    for k = 0:n+1
-      P = collect(partitions(n,k))
+  @testset "partitions($n,$k)" for n in 0:20, k in 0:n+1
+    P = collect(partitions(n,k))
 
-      # Create the same by filtering all partitions
-      Q = collect(partitions(n))
-      filter!( Q->length(Q) == k, Q)
+    # Create the same by filtering all partitions
+    Q = collect(partitions(n))
+    filter!( Q->length(Q) == k, Q)
 
-      # Check that P and Q coincide (up to reordering)
-      @test length(P) == length(Q)
-      @test Set(P) == Set(Q)
+    # Check that P and Q coincide (up to reordering)
+    @test length(P) == length(Q)
+    @test Set(P) == Set(Q)
 
-      # Compare length with number_of_partitions(n,k)
-      @test length(P) == number_of_partitions(n,k)
-    end
+    # Compare length with number_of_partitions(n,k)
+    @test length(P) == number_of_partitions(n,k)
   end
 
   ############################################################################
   # partitions(n,k,l1,l2)
   ############################################################################
-  for n in 0:20
-    for k = 0:n+1
-      for l1 = 0:n
-        for l2 = l1:n
-          P = collect(partitions(n,k,l1,l2))
+  @testset "partitions($n,$k,$l1,$l2)" for n in 0:20, k in 0:n+1, l1 in 0:n, l2 in l1:n
+    P = collect(partitions(n,k,l1,l2))
 
-          # Create the same by filtering all partitions
-          Q = collect(partitions(n,k))
-          filter!( Q->all(>=(l1),Q), Q)
-          filter!( Q->all(<=(l2),Q), Q)
+    # Create the same by filtering all partitions
+    Q = collect(partitions(n,k))
+    filter!( Q->all(>=(l1),Q), Q)
+    filter!( Q->all(<=(l2),Q), Q)
 
-          # Check that P and Q coincide (up to reordering)
-          @test length(P) == length(Q)
-          @test Set(P) == Set(Q)
-        end
-      end
-    end
+    # Check that P and Q coincide (up to reordering)
+    @test length(P) == length(Q)
+    @test Set(P) == Set(Q)
   end
 
   ############################################################################
   # partitions(n,k,l1,l2; only_distinct_parts=true)
   ############################################################################
-  for n in 0:20
-    for k = 0:n+1
-      for l1 = 0:n
-        for l2 = l1:n
-          P = collect(partitions(n, k, l1, l2; only_distinct_parts=true))
+  @testset "partitions($n,$k,$l1,$l2, only_distinct_parts=true)" for n in 0:20, k in 0:n+1, l1 in 0:n, l2 in l1:n
+    P = collect(partitions(n, k, l1, l2; only_distinct_parts=true))
 
-          # Create the same by filtering all partitions
-          Q = collect(partitions(n, k, l1, l2))
-          filter!( Q->Q==unique(Q), Q )
+    # Create the same by filtering all partitions
+    Q = collect(partitions(n, k, l1, l2))
+    filter!( Q->Q==unique(Q), Q )
 
-          # Check that P and Q coincide (up to reordering)
-          @test length(P) == length(Q)
-          @test Set(P) == Set(Q)
-        end
-      end
-    end
+    # Check that P and Q coincide (up to reordering)
+    @test length(P) == length(Q)
+    @test Set(P) == Set(Q)
   end
 
   ############################################################################
-  # partitions(m,n,v,mu)
+  # partitions(n,k,v,mu)
   ############################################################################
+  @testset "partitions(n,k,v,mu)" begin
+    # Check argument errors
+    @test_throws ArgumentError partitions(5,2, [1,2], [1,2,3])
+    @test_throws ArgumentError partitions(-1,2, [1,2,3], [1,2,3])
+    @test_throws ArgumentError partitions(5,0,[1,2,3], [1,2])
+    @test_throws ArgumentError partitions(6,3,[3,2,1],[1,2,3]) #req v strictly increasing
+    @test_throws ArgumentError partitions(6,3,[3,2,1],[0,2,3]) #mu > 0
+    @test_throws ArgumentError partitions(6,3,[0,2,1],[1,2,3]) #v > 0
 
-  # Check argument errors
-  @test_throws ArgumentError partitions(5,2, [1,2], [1,2,3])
-  @test_throws ArgumentError partitions(-1,2, [1,2,3], [1,2,3])
-  @test_throws ArgumentError partitions(5,0,[1,2,3], [1,2])
-  @test_throws ArgumentError partitions(6,3,[3,2,1],[1,2,3]) #req v strictly increasing
-  @test_throws ArgumentError partitions(6,3,[3,2,1],[0,2,3]) #mu > 0
-  @test_throws ArgumentError partitions(6,3,[0,2,1],[1,2,3]) #v > 0
+    # Issues from https://github.com/oscar-system/Oscar.jl/issues/2043
+    @test length(collect(partitions(17, 3, [1, 4], [1,4]))) == 0
+    @test collect(partitions(17, 5, [1, 4], [1, 4])) == [ partition(4, 4, 4, 4, 1) ]
+    @test length(collect(partitions(17, 6, [1, 2], [1, 7]))) == 0
+    @test length(collect(partitions(20, 5, [1, 2, 3], [1, 3, 6]))) == 0
 
-  # Issues from https://github.com/oscar-system/Oscar.jl/issues/2043
-  @test length(collect(partitions(17, 3, [1, 4], [1,4]))) == 0
-  @test collect(partitions(17, 5, [1, 4], [1, 4])) == [ partition(4, 4, 4, 4, 1) ]
-  @test length(collect(partitions(17, 6, [1, 2], [1, 7]))) == 0
-  @test length(collect(partitions(20, 5, [1, 2, 3], [1, 3, 6]))) == 0
+    # Issues UT found
+    @test length(collect(partitions(1, 1, [1], [1]))) == 1
+    @test length(collect(partitions(100, 7, [1, 2, 5, 10, 20, 50], [2, 2, 2, 2, 2, 2]))) == 1
 
-  # Issues UT found
-  @test length(collect(partitions(1, 1, [1], [1]))) == 1
-  @test length(collect(partitions(100, 7, [1, 2, 5, 10, 20, 50], [2, 2, 2, 2, 2, 2]))) == 1
-
-  # Special cases
-  for n in 0:20
-    for k in 0:n + 1
+    # Special cases
+    @testset "Special cases n=$n, k=$k" for n in 0:20, k in 0:n+1
       P = collect(partitions(n, k, [i for i in 1:n], [n for i in 1:n]))
       Q = collect(partitions(n, k))
       @test length(P) == length(Q)
@@ -174,50 +164,52 @@
       @test length(P) == length(Q)
       @test Set(P) == Set(Q)
     end
+
+    # From https://www.maa.org/frank-morgans-math-chat-293-ways-to-make-change-for-a-dollar
+    @test length(collect(partitions(100, [1, 5, 10, 25, 50]))) == 292
+    @test length(collect(partitions(200, [1, 5, 10, 25, 50, 100]))) == 2728
+
+    # From Knu11, Exercise 11 on page 408
+    @test length(collect(partitions(100, [1, 2, 5, 10, 20, 50], [2, 2, 2, 2, 2, 2]))) == 6
+    @test length(collect(partitions(100, [1, 2, 5, 10, 20, 50]))) == 4562
+
+    # From https://oeis.org/A000008
+    @test [ length(collect(partitions(n, [1,2,5,10]))) for n in 0:60 ] ==
+      [ 1, 1, 2, 2, 3, 4, 5, 6, 7, 8, 11, 12, 15, 16, 19, 22, 25, 28, 31, 34,
+      40, 43, 49, 52, 58, 64, 70, 76, 82, 88, 98, 104, 114, 120, 130, 140,
+      150, 160, 170, 180, 195, 205, 220, 230, 245, 260, 275, 290, 305, 320,
+      341, 356, 377, 392, 413, 434, 455, 476, 497, 518, 546 ]
   end
-
-  # From https://www.maa.org/frank-morgans-math-chat-293-ways-to-make-change-for-a-dollar
-  @test length(collect(partitions(100, [1, 5, 10, 25, 50]))) == 292
-  @test length(collect(partitions(200, [1, 5, 10, 25, 50, 100]))) == 2728
-
-  # From Knu11, Exercise 11 on page 408
-  @test length(collect(partitions(100, [1, 2, 5, 10, 20, 50], [2, 2, 2, 2, 2, 2]))) == 6
-  @test length(collect(partitions(100, [1, 2, 5, 10, 20, 50]))) == 4562
-
-  # From https://oeis.org/A000008
-  @test [ length(collect(partitions(n, [1,2,5,10]))) for n in 0:60 ] == 
-    [ 1, 1, 2, 2, 3, 4, 5, 6, 7, 8, 11, 12, 15, 16, 19, 22, 25, 28, 31, 34,
-    40, 43, 49, 52, 58, 64, 70, 76, 82, 88, 98, 104, 114, 120, 130, 140,
-    150, 160, 170, 180, 195, 205, 220, 230, 245, 260, 275, 290, 305, 320,
-    341, 356, 377, 392, 413, 434, 455, 476, 497, 518, 546 ]
 
 
   ############################################################################
   # dominates(P)
   ############################################################################
-  @test dominates(partition([4,2]), partition([3,2,1])) == true
-  @test dominates(partition([4,1,1]), partition([3,3])) == false
-  @test dominates(partition([3,3]), partition([4,1,1])) == false
-  @test dominates(partition([5]), partition([2,2,2])) == false
+  @testset "dominates(P)" begin
+    @test dominates(partition([4,2]), partition([3,2,1])) == true
+    @test dominates(partition([4,1,1]), partition([3,3])) == false
+    @test dominates(partition([3,3]), partition([4,1,1])) == false
+    @test dominates(partition([5]), partition([2,2,2])) == false
 
-  # Ful97, page 26
-  @test dominates( partition(3,1), partition(2,2) ) == true
-  @test dominates( partition(4,1), partition(3,3) ) == false
+    # Ful97, page 26
+    @test dominates( partition(3,1), partition(2,2) ) == true
+    @test dominates( partition(4,1), partition(3,3) ) == false
+  end
 
   ############################################################################
   # conjugate(P)
   ############################################################################
+  @testset "conjugate(P)" begin
+    # From Knu11, page 394
+    @test conjugate(partition(8,8,8,7,2,1,1)) == partition([7, 5, 4, 4, 4, 4, 4, 3])
 
-  # From Knu11, page 394
-  @test conjugate(partition(8,8,8,7,2,1,1)) == partition([7, 5, 4, 4, 4, 4, 4, 3])
+    # From Ful97, page 2
+    @test conjugate(partition([6,4,3,1])) == partition([4, 3, 3, 2, 1, 1])
 
-  # From Ful97, page 2
-  @test conjugate(partition([6,4,3,1])) == partition([4, 3, 3, 2, 1, 1])
+    @test conjugate(partition([])) == partition([])
 
-  @test conjugate(partition([])) == partition([])
-
-  # Check if conjugate is an involution
-  for p in partitions(10)
-    @test conjugate(conjugate(p)) == p
-  end
+    # Check if conjugate is an involution
+    for p in partitions(10)
+      @test conjugate(conjugate(p)) == p
+    end
 end

--- a/test/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -118,7 +118,7 @@
   ############################################################################
   # partitions(n,k,l1,l2; only_distinct_parts=true)
   ############################################################################
-  @testset "partitions($n,$k,$l1,$l2, only_distinct_parts=true)" for n in 0:20, k in 0:n+1, l1 in 0:n, l2 in l1:n
+  @testset "partitions($n,$k,$l1,$l2; only_distinct_parts=true)" for n in 0:20, k in 0:n+1, l1 in 0:n, l2 in l1:n
     P = collect(partitions(n, k, l1, l2; only_distinct_parts=true))
 
     # Create the same by filtering all partitions

--- a/test/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -36,7 +36,7 @@
   ############################################################################
   # partitions(n)
   ############################################################################
-  @testset "partitions($n)" for n in 0:20
+  @testset "partitions($n)" for n in 0:10
     P = collect(partitions(n))
 
     # Check that the number of partitions is correct
@@ -84,7 +84,7 @@
   ############################################################################
   # partitions(n,k)
   ############################################################################
-  @testset "partitions($n,$k)" for n in 0:20, k in 0:n+1
+  @testset "partitions($n,$k)" for n in 0:10, k in 0:n+1
     P = collect(partitions(n,k))
 
     # Create the same by filtering all partitions
@@ -102,24 +102,26 @@
   ############################################################################
   # partitions(n,k,lb,ub)
   ############################################################################
-  @testset "partitions($n,$k,$lb,$ub)" for n in 0:20, k in 0:n+1, lb in 0:n, ub in lb:n
-    P = collect(partitions(n,k,lb,ub))
+  @testset "partitions($n,$k,lb,ub)" for n in 0:10, k in 0:n+1
+    @testset "partitions($n,$k,$lb,$ub)" for lb in 0:n, ub in lb:n
+      P = collect(partitions(n,k,lb,ub))
 
-    # Create the same by filtering all partitions
-    Q = collect(partitions(n,k))
-    filter!( Q->all(>=(lb),Q), Q)
-    filter!( Q->all(<=(ub),Q), Q)
+      # Create the same by filtering all partitions
+      Q = collect(partitions(n,k))
+      filter!( Q->all(>=(lb),Q), Q)
+      filter!( Q->all(<=(ub),Q), Q)
 
-    # Check that P and Q coincide (up to reordering)
-    @test length(P) == length(Q)
-    @test Set(P) == Set(Q)
+      # Check that P and Q coincide (up to reordering)
+      @test length(P) == length(Q)
+      @test Set(P) == Set(Q)
+    end
   end
 
   ############################################################################
   # partitions(n,k,lb,ub; only_distinct_parts=true)
   ############################################################################
   @testset "partitions($n,$k,lb,ub; only_distinct_parts=true)" for n in 0:10, k in 0:n+1
-    @testset "partitions($n,$k,$lb,$ub; only_distinct_parts=true)" lb in 0:n, ub in lb:n
+    @testset "partitions($n,$k,$lb,$ub; only_distinct_parts=true)" for lb in 0:n, ub in lb:n
       P = collect(partitions(n, k, lb, ub; only_distinct_parts=true))
 
       # Create the same by filtering all partitions


### PR DESCRIPTION
With the recent migration of combinatorics functions from `experimental` to `src` in #3159 , there is some work to be done converting the methods to return iterators instead of very large collections of combinatorial objects. This is work to address #3147 

Here we are converting the methods that focus on returning integer partitions.

There are 3 different "batches" of partition methods that need to be converted in this way.

1. the basic `partitions(n)` for computing all integer partitions of n - this has been converted
2. the methods `partitions(n,m)` (also optionally with upper/lower bounds) for partitioning into a fixed number of parts - this has been converted.
3. the methods `partitions(n,v)` where v is a vector of allowed values to use in the partition (with options to specify the number of parts, or to restrict the multiplicities of the allowed values) - this one still needs to be converted.