### PR TITLE
Eliminate more spelling differences between American and British English

### DIFF
--- a/docs/src/AlgebraicGeometry/Schemes/CoveredSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/CoveredSchemes.md
@@ -49,7 +49,7 @@ An `AbsCoveredScheme` may have different properties such as
     fiber_product(f::AbsCoveredSchemeMorphism, g::AbsCoveredSchemeMorphism)
 ```
 
-## The modeling of covered schemes and their expected behaviour 
+## The modeling of covered schemes and their expected behavior 
 
 Any `AbsCoveredScheme` may possess several `Covering`s. This is necessary for 
 several reasons; for instance, a morphism $f : X \to Y$ between `AbsCoveredScheme`s 

--- a/docs/src/CommutativeAlgebra/FrameWorks/ring_localizations.md
+++ b/docs/src/CommutativeAlgebra/FrameWorks/ring_localizations.md
@@ -8,7 +8,7 @@ end
 # A Framework for Localizing Rings
 
 For the convenience of the developer, we outline a general framework for creating concrete instances of localized rings in OSCAR,
-addressing relevant abstract types as well as a standardized set of functions whose concrete behaviour must be implemented.
+addressing relevant abstract types as well as a standardized set of functions whose concrete behavior must be implemented.
 
 We roughly follow the outline of the previous subsection on localizing multivariate rings which provides illustrating examples.
 With regard to notation, the name `Rloc` will refer to the localization of a commutative ring `R` with 1.

--- a/docs/src/CommutativeAlgebra/FrameWorks/ring_localizations.md
+++ b/docs/src/CommutativeAlgebra/FrameWorks/ring_localizations.md
@@ -45,7 +45,7 @@ to set `check = false`.
 
 For any concrete instance of type `AbsLocalizedRingElem`, methods for the functions
 `parent`, `numerator`, and `denominator` must be provided. Moreover,
-if a cancellation function for the type of fractions under consideration is
+if a cancelation function for the type of fractions under consideration is
 not yet available, such a function should be implemented and named
 `reduce_fraction`.
 

--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/free_modules.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/free_modules.md
@@ -22,7 +22,7 @@ and homomorphisms between free modules by matrices.
 All OSCAR types for the modules considered here belong to the
 abstract type `ModuleFP{T}`, where `T` is the element type of the underlying ring.
 Graded or not, the free modules belong to the abstract subtype `AbstractFreeMod{T} <: ModuleFP{T}`,
-they are modelled as objects of the concrete type `FreeMod{T} <: AbstractFreeMod{T}`.
+they are modeled as objects of the concrete type `FreeMod{T} <: AbstractFreeMod{T}`.
 
 !!! note
     Canonical maps such us the canonical projection onto a quotient module arise in many 
@@ -98,7 +98,7 @@ degrees_of_generators(F::FreeMod)
 All OSCAR types for elements of the modules considered here belong
 to the abstract type `ModuleElemFP{T}`, where `T` is the element type of the underlying ring.
 The free modules belong to the abstract subtype `AbstractFreeModElem{T} <: ModuleFPElem{T}`.
-They are modelled as objects of the concrete type `FreeModElem{T} <: AbstractFreeModElem{T}`
+They are modeled as objects of the concrete type `FreeModElem{T} <: AbstractFreeModElem{T}`
 which implements an element $f$ of a free module $F$ as a sparse row, that is, as an object of
 type `SRow{T}`. This object specifies the coordinates of $f$ with respect to the basis of standard
 unit vectors of $F$. To create an element, enter its coordinates as a sparse row or a vector: 

--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/subquotients.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/subquotients.md
@@ -52,7 +52,7 @@ and regard $M$ as a submodule of that ambient module, embedded in the natural wa
 All OSCAR types for the finitely presented modules considered here belong to the
 abstract type `ModuleFP{T}`, where `T` is the element type of the underlying ring.
 Graded or not, the subquotients belong to the abstract subtype `AbstractSubQuo{T} <: ModuleFP{T}`,
-they are modelled as objects of the concrete type `SubquoModule{T} <: AbstractSubQuo{T}`.
+they are modeled as objects of the concrete type `SubquoModule{T} <: AbstractSubQuo{T}`.
 
 !!! note
     Canonical maps such us the canonical projection onto a quotient module arise in many 

--- a/docs/src/CommutativeAlgebra/localizations.md
+++ b/docs/src/CommutativeAlgebra/localizations.md
@@ -290,7 +290,7 @@ internally represented by a pair `(r, u)` of elements of `R`, then
 - `parent(f)` refers to `RQL`,
 - `numerator(f)` to the image of `r` in `RQ`, and
 - `denominator(f)` to the image of `u` in `RQ`.
-That is, the behaviour of the functions `numerator` and `denominator` reflects the mathematical viewpoint
+That is, the behavior of the functions `numerator` and `denominator` reflects the mathematical viewpoint
 of representing `f` by pairs of elements of `RQ` and not the internal representation of `f` as pairs of elements of `R`.
 
 ##### Examples

--- a/docs/src/CommutativeAlgebra/rings.md
+++ b/docs/src/CommutativeAlgebra/rings.md
@@ -230,7 +230,7 @@ we follow the former book.
 
 ### Types
 
-Multivariate rings with gradings are modelled by objects of type
+Multivariate rings with gradings are modeled by objects of type
 `MPolyDecRing{T, S}  :< MPolyRing{T}`, with elements of type
 `MPolyRingElem_dec{T, S}  :< MPolyRingElem{T}`. Here, `S` is the element type of the
 multivariate ring, and  `T` is the element type of its coefficient ring as above.

--- a/docs/src/DeveloperDocumentation/debugging.md
+++ b/docs/src/DeveloperDocumentation/debugging.md
@@ -3,7 +3,7 @@
 ## Pitfalls: Mutable objects in OSCAR code
 
 Suppose you are having the following difficulties. Your code is exhibiting
-inexplicable behaviour and values that should not be changing are changing in
+inexplicable behavior and values that should not be changing are changing in
 seemingly random locations. To get to the bottom of these kind of issues
 it is necessary to be familiar with mutable objects in Julia and some of the
 relevant conventions in place in OSCAR. This section discusses these
@@ -92,7 +92,7 @@ julia> evaluate(x)  # x is now unchanged
 
 It is of course not true that all Julia functions take ownership of their
 arguments, but the GOP derives from the fact that this decision is an
-implementation detail with performance consequences. The behaviour of a
+implementation detail with performance consequences. The behavior of a
 function may be inconsistent across different types and versions of OSCAR.
 In the following two snippets, the GOP says both modifications of `a` are
 illegal since they have since been passed to a function. If `K = QQ`, the two
@@ -161,7 +161,7 @@ julia> a
  3
 ```
 
-The preceding behaviour of the function `modular_proj` is an artifact of
+The preceding behavior of the function `modular_proj` is an artifact of
 internal efficiency and may be desirable in certain circumstances. In other
 circumstances, the following `deepcopy`s may be necessary for your code to
 function correctly.

--- a/docs/src/DeveloperDocumentation/serialization.md
+++ b/docs/src/DeveloperDocumentation/serialization.md
@@ -1,6 +1,6 @@
 # Serialization
 
-This document summarises the serialization efforts of OSCAR, how it is supposed
+This document summarizes the serialization efforts of OSCAR, how it is supposed
 to work, how it works and the overall goal.
 [Serialization](https://en.wikipedia.org/wiki/Serialization) broadly speaking
 is the process of reading and writing data. There are many reasons for this

--- a/docs/src/Experimental/Singularities/intro.md
+++ b/docs/src/Experimental/Singularities/intro.md
@@ -9,7 +9,7 @@ The singularities part of OSCAR provides functionality for handling
 - space germs
 - map germs
 
-For readers' convenience, the documentation is organised by typical settings, 
+For readers' convenience, the documentation is organized by typical settings, 
 This, on the other hand, implies that certain keywords may appear in several 
 settings. In particular, there are overlaps between hypersurface 
 singularities and curve singularities and between hypersurface singularities

--- a/docs/src/NoncommutativeAlgebra/PBWAlgebras/creation.md
+++ b/docs/src/NoncommutativeAlgebra/PBWAlgebras/creation.md
@@ -9,7 +9,7 @@ end
 
 ## Types
 
-PBW-algebras are modelled by objects of type `PBWAlgRing{T, S} <: NCRing`, their elements are objects of type
+PBW-algebras are modeled by objects of type `PBWAlgRing{T, S} <: NCRing`, their elements are objects of type
 `PBWAlgElem{T, S} <: NCRingElem`. Here,  `T` is the element type of the field over which the PBW-algebra
 is defined (the type `S` is added for internal use).
 

--- a/docs/src/NoncommutativeAlgebra/PBWAlgebras/quotients.md
+++ b/docs/src/NoncommutativeAlgebra/PBWAlgebras/quotients.md
@@ -16,7 +16,7 @@ functionality for dealing with quotients of PBW-algebras modulo two-sided ideals
 
 ## Types
 
-GR-algebras are modelled by objects of type `PBWAlgQuo{T, S} <: NCRing`, their elements are objects of type
+GR-algebras are modeled by objects of type `PBWAlgQuo{T, S} <: NCRing`, their elements are objects of type
 `PBWAlgQuoElem{T, S} <: NCRingElem`. Here,  `T` is the element type of the field over which the GR-algebra
 is defined (the type `S` is added for internal use).
 

--- a/docs/src/Rings/integer.md
+++ b/docs/src/Rings/integer.md
@@ -275,7 +275,7 @@ julia> ZZ(1)^(-2)
 
 !!! note
     In Julia `2^-2` is called a literal power. The value returned is a
-    floating point value. To get behaviour that agrees with OSCAR, one can
+    floating point value. To get behavior that agrees with OSCAR, one can
     write `2^Int(-2)`.
 
 The following is allowed for convenience.
@@ -643,7 +643,7 @@ ERROR: 7 is not a factor of -1 * 5 * 2^2 * 3
 !!! note
     The functions in this section that take `Int` arguments will return an
     `Int`, which may overflow or throw an error. Use the `ZZRingElem` versions if
-    this is not the desired behaviour.
+    this is not the desired behavior.
 
 ### Factorial
 
@@ -753,7 +753,7 @@ julia> fibonacci(-2)
 !!! note
     The functions in this section that take `Int` arguments will return a
     `Int`, which may overflow or throw an error. Use the `ZZRingElem` versions if
-    this is not the desired behaviour.
+    this is not the desired behavior.
 
 ### Moebius mu function
 

--- a/examples/MatrixDisplay.jl
+++ b/examples/MatrixDisplay.jl
@@ -1,6 +1,6 @@
 #############################################################################
 ##
-##  functionality for displaying labelled matrices,
+##  functionality for displaying labeled matrices,
 ##  that is, 2-dimensional arrays of strings
 ##  together with row labels, columns labels, header, and footer
 ##
@@ -47,7 +47,7 @@ function replace_TeX(str::String)
 end
 
 """
-    labelled_matrix_formatted(io::IO, mat::Matrix{String})
+    labeled_matrix_formatted(io::IO, mat::Matrix{String})
 
 Output a formatted version of `mat` to `io`.
 The following attributes of `io` are supported.
@@ -89,18 +89,18 @@ The following attributes of `io` are supported.
   (enter `0` for a line above the first row),
 
 - `:column_portions`:
-  array of column numbers after which a new labelled table shall be started;
+  array of column numbers after which a new labeled table shall be started;
   the default is to have just one portion in the `:TeX` case,
   and to create portions according to the screen width otherwise,
 
 - `:row_portions`:
-  array of row numbers after which a new labelled table shall be started;
+  array of row numbers after which a new labeled table shall be started;
   the default is to have just one portion.
 
 ## Examples:
 ...
 """
-function labelled_matrix_formatted(io::IO, mat::Matrix{String})
+function labeled_matrix_formatted(io::IO, mat::Matrix{String})
     TeX = get(io, :TeX, false)
 
     subset_row = get(io, :subset_row, 1:size(mat, 1))

--- a/examples/Timo.jl
+++ b/examples/Timo.jl
@@ -8,9 +8,9 @@ function timo(f::QQPolyRingElem, p_all::Vector{Int})
 
   all_g = [x for x = G]
   @show :aut
-  @time au = Oscar.SolveRadical.recognise(S, K, [K.pe^g for g = all_g])
+  @time au = Oscar.SolveRadical.recognize(S, K, [K.pe^g for g = all_g])
 #  au = Hecke.closure([hom(k.fld, k.fld, x) for x = au])
-#recognise seems to be faster than closure - and keeps the link
+#recognize seems to be faster than closure - and keeps the link
 #between the Galois group and the automorphisms
   @time au = [hom(K.fld, K.fld, x, check = false) for x = au]
   

--- a/experimental/DoubleAndHyperComplexes/test/DoubleComplex.jl
+++ b/experimental/DoubleAndHyperComplexes/test/DoubleComplex.jl
@@ -90,7 +90,7 @@
   @test matrix(map(tot_xyz, 2)) == R[-y z 0; -x 0 z; 0 -x y]
   @test matrix(map(tot_xyz, 3)) == R[x -y z]
 
-  # Test behaviour w.r.t zero entries
+  # Test behavior w.r.t zero entries
   Z = FreeMod(R, 0)
   Kx = ComplexOfMorphisms([hom(Z, R1, elem_type(R1)[]), hom(R1, R1, [x*R1[1]]), hom(R1, Z, [zero(Z)])], seed = -1)
   Ky = ComplexOfMorphisms([hom(Z, R1, elem_type(R1)[]), hom(R1, R1, [y*R1[1]]), hom(R1, Z, [zero(Z)])], seed = -1)
@@ -206,7 +206,7 @@ end
   @test matrix(map(tot_xyz, 2)) == R[-y z 0; -x 0 z; 0 -x y]
   @test matrix(map(tot_xyz, 3)) == R[x -y z]
 
-  # Test behaviour w.r.t zero entries
+  # Test behavior w.r.t zero entries
   Z = FreeMod(R, 0)
   Kx = ComplexOfMorphisms([hom(Z, R1, elem_type(R1)[]), hom(R1, R1, [x*R1[1]]), hom(R1, Z, [zero(Z)])], seed = -1)
   Ky = ComplexOfMorphisms([hom(Z, R1, elem_type(R1)[]), hom(R1, R1, [y*R1[1]]), hom(R1, Z, [zero(Z)])], seed = -1)

--- a/experimental/GaloisGrp/src/Solve.jl
+++ b/experimental/GaloisGrp/src/Solve.jl
@@ -8,6 +8,7 @@ function __init__()
   Hecke.add_assertion_scope(:SolveRadical)
 end
 
+@deprecate recognise recognize
 
 mutable struct SubField
   coeff_field::Union{Nothing, SubField}
@@ -376,13 +377,13 @@ function conjugates(C::GaloisCtx, S::SubField, a::QQFieldElem, pr::Int = 10)
   return [parent(rt[1])(a)]
 end
 
-function recognise(C::GaloisCtx, S::SubField, I::SLPoly)
-  r = recognise(C, S, [I])
+function recognize(C::GaloisCtx, S::SubField, I::SLPoly)
+  r = recognize(C, S, [I])
   r === nothing && return r
   return r[1]
 end
 
-function recognise(C::GaloisCtx, S::SubField, J::Vector{<:SLPoly}, d=false)
+function recognize(C::GaloisCtx, S::SubField, J::Vector{<:SLPoly}, d=false)
   if d != false
     B = d
   elseif isdefined(S, :ts)
@@ -541,20 +542,20 @@ function Oscar.solve(f::ZZPolyRingElem; max_prec::Int=typemax(Int), show_radical
   
   cyclo = fld_arr[length(pp)+1]
   @vprint :SolveRadical 1 "finding roots-of-1...\n"
-  @vtime :SolveRadical 1 zeta = [recognise(C, cyclo, gens(parent(cyclo.pe))[i])//scale for i=pp]
+  @vtime :SolveRadical 1 zeta = [recognize(C, cyclo, gens(parent(cyclo.pe))[i])//scale for i=pp]
   @hassert :SolveRadical 1 all(i->isone(zeta[i]^lp[i]), 1:length(pp))
   aut = []
   @vprint :SolveRadical 1 "finding automorphisms...\n"
   for i=length(pp)+2:length(fld_arr)
     @vprint :SolveRadical 1 "..on level $(i-length(pp)-1)...\n"
     K = fld_arr[i]
-    @vtime :SolveRadical 1 push!(aut, hom(K.fld, K.fld, recognise(C, K, K.pe^K.conj[2])))
+    @vtime :SolveRadical 1 push!(aut, hom(K.fld, K.fld, recognize(C, K, K.pe^K.conj[2])))
   end
   for i=1:length(pp)
     fld_arr[i+1].fld.S = Symbol("z_$(lp[i])")
   end
   @vprint :SolveRadical 1 "find roots...\n"
-  @vtime :SolveRadical 1 R = recognise(C, All, gens(S)[rt])
+  @vtime :SolveRadical 1 R = recognize(C, All, gens(S)[rt])
   R = R .// scale
   #now, rewrite as radicals..
   #the cyclos are fine:
@@ -761,7 +762,7 @@ function galois_factor(C::GaloisCtx)
     end
   end
   z = _fixed_field(C, Gi, invar = I)
-  return recognise(C, z, x)
+  return recognize(C, z, x)
 end
 
 end # SolveRadical

--- a/experimental/IntersectionTheory/src/Bott.jl
+++ b/experimental/IntersectionTheory/src/Bott.jl
@@ -34,7 +34,7 @@ end
 # TnBundle, TnVariety - varieties with a torus action and equivariant bundles
 #
 # A Tⁿ-abstract_variety X is represented as the set of fixed points X.points, each
-# labelled using some value of type P (e.g. an array), and has a multiplicity e
+# labeled using some value of type P (e.g. an array), and has a multiplicity e
 # (orbifold multiplicity);
 # 
 # A Tⁿ-equivariant bundle on X is represented by its localization/restriction

--- a/experimental/LieAlgebras/test/WeylGroup-test.jl
+++ b/experimental/LieAlgebras/test/WeylGroup-test.jl
@@ -188,7 +188,7 @@ include(
     @test word(s[1] * s[2] * s[1]) == UInt8[1, 2, 1]
     @test word(s[3] * s[2] * s[3]) == UInt8[2, 3, 2]
 
-    # test general multiplication behaviour
+    # test general multiplication behavior
     W = weyl_group(:B, 4)
     @test W(b4_w0) == W(b4_w0; normalize=false)
 

--- a/experimental/OrthogonalDiscriminants/gap/fix.g
+++ b/experimental/OrthogonalDiscriminants/gap/fix.g
@@ -8,7 +8,7 @@
 
 ###############################################################################
 ##
-##  Improve the behaviour of 'Indicator' in characteristic 2.
+##  Improve the behavior of 'Indicator' in characteristic 2.
 ##
 InstallMethod( IndicatorOp,
     "for a Brauer character table and <n> = 2",

--- a/experimental/OrthogonalDiscriminants/src/utils.jl
+++ b/experimental/OrthogonalDiscriminants/src/utils.jl
@@ -402,7 +402,7 @@ function show_OD_info(tbl::Oscar.GAPGroupCharacterTable, io::IO = stdout)
          :separators_col => 0:(length(result[1])-1),
         )
 
-  labelled_matrix_formatted(ioc, permutedims(reduce(hcat, result)))
+  labeled_matrix_formatted(ioc, permutedims(reduce(hcat, result)))
   println(io, "")
 end
 

--- a/experimental/Schemes/CoherentSheaves.jl
+++ b/experimental/Schemes/CoherentSheaves.jl
@@ -223,7 +223,7 @@ identifications given by the gluings in the `default_covering`.
     ### Lookup and production pattern for sheaves of modules
     #
     # When asked to produce a module on an open affine U, the functions
-    # below lead to the following behaviour.
+    # below lead to the following behavior.
     #
     #                     U₁                    an `affine_chart` of `X`
     #           _________/|\______________      (`patches` of `default_covering(X)`)

--- a/experimental/Schemes/elliptic_surface.jl
+++ b/experimental/Schemes/elliptic_surface.jl
@@ -1704,7 +1704,7 @@ function _elliptic_parameter_conversion(X::EllipticSurface, u::VarietyFunctionFi
     eqn1 = numerator(f_trans)
     # According to 
     #   A. Kumar: "Elliptic Fibrations on a generic Jacobian Kummer surface" 
-    # p. 45, l. 1 we expect the following cancellation to be possible:
+    # p. 45, l. 1 we expect the following cancelation to be possible:
     divisor_num = evaluate(numerator(x0), x2)
     divisor_den = evaluate(denominator(x0), x2)
     divisor = divisor_den * y2 - divisor_num
@@ -1733,7 +1733,7 @@ function _elliptic_parameter_conversion(X::EllipticSurface, u::VarietyFunctionFi
     eqn1 = numerator(f_trans)
     # According to 
     #   A. Kumar: "Elliptic Fibrations on a generic Jacobian Kummer surface" 
-    # p. 45, l. 15 we expect the following cancellation to be possible:
+    # p. 45, l. 15 we expect the following cancelation to be possible:
     success, eqn1 = divides(eqn1, y2)
     @assert success "equation did not come out in the anticipated form"
     return eqn1, phi

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Morphisms/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Morphisms/Methods.jl
@@ -1,5 +1,5 @@
 ###########################################################
-# (1) The fibre product of two morphisms of affine schemes
+# (1) The fiber product of two morphisms of affine schemes
 ###########################################################
 
 @doc raw"""

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
@@ -828,7 +828,7 @@ If `X = Spec(R)` and `R` is...
   - a localized polynomial ring `R[U⁻¹]`, then this returns the zero ideal in that ring;
   - a quotient of a localized polynomial ring `(R[U⁻¹])/J`, then this returns the ideal `J` in the ring `R[U⁻¹]`.
 
-This behaviour is streamlined with the return values of `modulus` on the algebraic side.
+This behavior is streamlined with the return values of `modulus` on the algebraic side.
 If you are looking for an ideal `I` in the polynomial `ambient_ring` of `X` defining 
 the closure of `X` in its `ambient_space`, use for instance `saturated_ideal(defining_ideal(X))`.
 ```jldoctest

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1480,7 +1480,7 @@ false
     is_quasisimple(G::GAPGroup)
 
 Return whether `G` is a quasisimple group,
-i.e., `G` is perfect such that the factor group modulo its centre is
+i.e., `G` is perfect such that the factor group modulo its center is
 a non-abelian simple group.
 
 # Examples

--- a/src/Groups/MatrixDisplay.jl
+++ b/src/Groups/MatrixDisplay.jl
@@ -1,6 +1,6 @@
 #############################################################################
 ##
-##  Provide functionality for displaying labelled matrices,
+##  Provide functionality for displaying labeled matrices,
 ##  that is, two-dimensional arrays of strings
 ##  together with row labels, columns labels, header, and footer
 ##
@@ -59,7 +59,7 @@ end
 
 
 """
-    labelled_matrix_formatted(io::IO, mat::Matrix{String})
+    labeled_matrix_formatted(io::IO, mat::Matrix{String})
 
 Write a formatted version of `mat` to `io`.
 The following attributes of `io` are supported.
@@ -108,11 +108,11 @@ The following attributes of `io` are supported.
   (enter `0` for a line in front of the first column),
 
 - `:portions_row`:
-  array of numbers of rows after which a new labelled table shall be started;
+  array of numbers of rows after which a new labeled table shall be started;
   the default is to have just one portion.
 
 - `:portions_col`:
-  array of numbers of column after which a new labelled table shall be started;
+  array of numbers of column after which a new labeled table shall be started;
   the default is to have just one portion in the `:TeX` case,
   and to create portions according to the screen width otherwise,
 
@@ -131,7 +131,7 @@ julia> mat
 julia> io = IOBuffer();   # simply using `stdout` does not work in doctests
 
 julia> ioc = IOContext(io,
-              :header => ["", "a labelled matrix", ""],
+              :header => ["", "a labeled matrix", ""],
               :labels_row => [string(i) for i in 1:m],
               :labels_col => [string(j) for j in 1:n],
               :separators_row => [0],
@@ -140,12 +140,12 @@ julia> ioc = IOContext(io,
              );
 
 julia> Oscar.with_unicode() do
-         labelled_matrix_formatted(ioc, mat)
+         labeled_matrix_formatted(ioc, mat)
        end;
 
 julia> print(String(take!(io)))
 
-a labelled matrix
+a labeled matrix
 
  │     1      2      3      4
 ─┼───────────────────────────
@@ -165,7 +165,7 @@ julia> ioc = IOContext(io,
              );
 
 julia> Oscar.with_unicode() do
-         labelled_matrix_formatted(ioc, mat)
+         labeled_matrix_formatted(ioc, mat)
        end;
 
 julia> print(String(take!(io)))
@@ -189,7 +189,7 @@ julia> print(String(take!(io)))
 
 ```
 """
-function labelled_matrix_formatted(io::IO, mat::Matrix{String})
+function labeled_matrix_formatted(io::IO, mat::Matrix{String})
     TeX = get(io, :TeX, false)
 
     if Oscar.is_unicode_allowed()

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -942,7 +942,7 @@ function Base.show(io::IO, ::MIME"text/plain", tbl::GAPGroupCharacterTable)
     )
 
     # print the table
-    labelled_matrix_formatted(ioc, mat)
+    labeled_matrix_formatted(ioc, mat)
 end
 
 

--- a/src/InvariantTheory/primary_invariants.jl
+++ b/src/InvariantTheory/primary_invariants.jl
@@ -258,11 +258,11 @@ An a priori known number $k \geq 1$ with $d_1\cdots d_n \geq k \cdot |G|$, where
 $G$ is the underlying group, can be specified by `degree_bound = k`. The default value is
 `degree_bound = 1`.
 In some situations, the runtime of the algorithm might be improved by assigning
-a positive integer to `ensure_minimality`. This leads to an early cancellation of
+a positive integer to `ensure_minimality`. This leads to an early cancelation of
 loops in the algorithm and the described minimality of the degrees is not
 guaranteed anymore. A smaller (positive) value of `ensure_minimality` corresponds
-to an earlier cancellation. However, the default value `ensure_minimality = 0`
-corresponds to no cancellation.
+to an earlier cancelation. However, the default value `ensure_minimality = 0`
+corresponds to no cancelation.
 
 # Examples
 ```jldoctest

--- a/src/Rings/AbelianClosure.jl
+++ b/src/Rings/AbelianClosure.jl
@@ -5,7 +5,7 @@
 ###############################################################################
 
 # This is an implementation of Q^ab, the abelian closure of the rationals,
-# which is modelled as the union of cyclotomic fields.
+# which is modeled as the union of cyclotomic fields.
 #
 # We make Q^ab a singleton, similar to ZZ and QQ. Thus there will ever be only
 # one copy of Q^ab. In particular the elements do not have a parent stored.

--- a/src/Rings/AlgClosureFp.jl
+++ b/src/Rings/AlgClosureFp.jl
@@ -5,7 +5,7 @@
 ###############################################################################
 
 # This is an implementation of the algebraic closure of finite fields,
-# which is modelled as the union of finite fields.
+# which is modeled as the union of finite fields.
 
 module AlgClosureFp
 

--- a/src/Rings/PBWAlgebraQuo.jl
+++ b/src/Rings/PBWAlgebraQuo.jl
@@ -13,7 +13,7 @@ export PBWAlgQuo, PBWAlgQuoElem
 #      achieve this a "new" pointer to the Singular ring is needed;
 #      this pointer is a new data field (sring) in PBQAlgQuo.
 #
-#  To preserve the original behaviour the new field "sdata" in PBWAlgQuo
+#  To preserve the original behavior the new field "sdata" in PBWAlgQuo
 #  is set to the same value as the field "sdata" in PBWAlg (unless
 #  created by constructor for exterior_algebra.
 #

--- a/src/Rings/hilbert.jl
+++ b/src/Rings/hilbert.jl
@@ -311,7 +311,7 @@ end
 ###################################################################
 # This function is also private/local to this file.
 
-# Think of a graph where each vertex is labelled by an indeterminate.
+# Think of a graph where each vertex is labeled by an indeterminate.
 # Each PP in the list L is interpreted as saying that all indeterminates
 # involved in that PP are "connected".  The task is to find (minimal)
 # connected components of the entire graph.

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -800,7 +800,7 @@ end
 ### Why are the `//`-methods not implemented?
 # Since a quotient ring Q = R/I of a polynomial ring R is not necessarily 
 # factorial, it is difficult to decide, whether or not a and b have a 
-# common factor g that can be cancelled so that b'= b/g ∈  Q belongs 
+# common factor g that can be canceled so that b'= b/g ∈  Q belongs 
 # to the multiplicative set. Moreover, this would be the case if any 
 # lift of b' belonged to S + I where S ⊂ R is the original multiplicative 
 # set. Such containment can not easily be checked based only on the 

--- a/src/TropicalGeometry/curve.jl
+++ b/src/TropicalGeometry/curve.jl
@@ -218,7 +218,7 @@ end
 # @doc raw"""
 #    chip_firing_move(dtc::DivisorOnTropicalCurve, position::Int)
 
-# Given a divisor `dtc` and vertex labelled `position`, compute the linearly equivalent divisor obtained by a chip firing move from the given vertex `position`.
+# Given a divisor `dtc` and vertex labeled `position`, compute the linearly equivalent divisor obtained by a chip firing move from the given vertex `position`.
 
 # # Examples
 # ```jldoctest
@@ -285,7 +285,7 @@ end
 # @doc raw"""
 #    v_reduced(dtc::DivisorOnTropicalCurve, vertex::Int)
 
-# Given a divisor `dtc` and vertex labelled `vertex`, compute the unique divisor reduced with repspect to `vertex`
+# Given a divisor `dtc` and vertex labeled `vertex`, compute the unique divisor reduced with repspect to `vertex`
 # as defined in [BN07](@cite).
 # The divisor `dtc` must have positive coefficients apart from `vertex`.
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -91,3 +91,5 @@ end
 @deprecate subgroup_reps(G::T) where T <: Union{GAPGroup, FinGenAbGroup} map(representative, subgroup_classes(G))
 @deprecate conjugacy_classes_maximal_subgroups(G::T) where T <: Union{GAPGroup, FinGenAbGroup} maximal_subgroup_classes(G)
 @deprecate conjugacy_classes_subgroups(G::T) where T <: Union{GAPGroup, FinGenAbGroup} subgroup_classes(G)
+
+@deprecate labelled_matrix_formatted labeled_matrix_formatted

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -905,7 +905,7 @@ export known_class_fusions
 export koszul_complex
 export koszul_homology
 export koszul_matrix
-export labelled_matrix_formatted
+export labeled_matrix_formatted
 export lattice_points
 export lattice_volume
 export leading_coefficient

--- a/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
+++ b/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
@@ -288,7 +288,7 @@ end
   (a, b, c) = base_change(pr, inc_U)
   @test compose(a, inc_U) == compose(b, c)
 
-  # Behaviour for special types
+  # Behavior for special types
   U = PrincipalOpenSubset(IA2, y)
   UU, f = base_change(pr, U)
   @test UU isa PrincipalOpenSubset

--- a/test/Groups/MatrixDisplay.jl
+++ b/test/Groups/MatrixDisplay.jl
@@ -3,11 +3,11 @@ using Documenter
 #
 # This module only exists to "host" a doctest used by the test suite.
 #
-module AuxDocTest_labelled_matrix_formatted
+module AuxDocTest_labeled_matrix_formatted
 @doc raw"""
 create the test matrix
 
-```jldoctest labelled_matrix_formatted.test
+```jldoctest labeled_matrix_formatted.test
 julia> using Oscar
 
 julia> m = 2; n = 2;  mat = Array{String}(undef, m, n);
@@ -19,16 +19,16 @@ text format
 
 no labels
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout), mat)
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout), mat)
 1/1 1/2
 2/1 2/2
 ```
 
 with header
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout,
          :header => ["header", ""]), mat)
 header
 
@@ -38,8 +38,8 @@ header
 
 with footer
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout,
          :footer => ["footer"]), mat)
 1/1 1/2
 2/1 2/2
@@ -48,8 +48,8 @@ footer
 
 with row labels as vector
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout,
          :labels_row => [string(i)*":" for i in 1:m]), mat)
 1: 1/1 1/2
 2: 2/1 2/2
@@ -57,8 +57,8 @@ julia> labelled_matrix_formatted(IOContext(stdout,
 
 with row labels as matrix
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout,
          :labels_row => reshape([string(i)*":" for i in 1:m], m, 1)), mat)
 1: 1/1 1/2
 2: 2/1 2/2
@@ -66,8 +66,8 @@ julia> labelled_matrix_formatted(IOContext(stdout,
 
 with too wide row labels
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout,
          :labels_row => reshape(["_"^30*string(i)*":" for i in 1:m], m, 1),
          :displaysize => (52, 30)), mat)
 (row label part is too wide for the screen)
@@ -75,8 +75,8 @@ julia> labelled_matrix_formatted(IOContext(stdout,
 
 with column labels as vector
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout,
          :labels_col => [string(j) for j in 1:n]), mat)
   1   2
 1/1 1/2
@@ -85,8 +85,8 @@ julia> labelled_matrix_formatted(IOContext(stdout,
 
 with column labels as matrix
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout,
          :labels_col => reshape([string(j) for j in 1:n], 1, n)), mat)
   1   2
 1/1 1/2
@@ -95,8 +95,8 @@ julia> labelled_matrix_formatted(IOContext(stdout,
 
 with row and column labels
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout,
          :labels_row => [string(i)*":" for i in 1:m],
          :labels_col => [string(j) for j in 1:n]), mat)
      1   2
@@ -106,8 +106,8 @@ julia> labelled_matrix_formatted(IOContext(stdout,
 
 with row and column labels and corner as vector
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout,
          :labels_row => [string(i)*":" for i in 1:m],
          :labels_col => [string(j) for j in 1:n],
          :corner => ["(i,j)"]), mat)
@@ -118,8 +118,8 @@ julia> labelled_matrix_formatted(IOContext(stdout,
 
 with row and column labels and corner as matrix
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout,
          :labels_row => [string(i)*":" for i in 1:m],
          :labels_col => [string(j) for j in 1:n],
          :corner => reshape(["(i,j)"], 1, 1)), mat)
@@ -130,8 +130,8 @@ julia> labelled_matrix_formatted(IOContext(stdout,
 
 with a too wide column
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout,
          :labels_row => [string(i)*":" for i in 1:m],
          :labels_col => ["_"^30*string(j) for j in 1:n],
          :corner => reshape(["(i,j)"], 1, 1),
@@ -147,9 +147,9 @@ julia> labelled_matrix_formatted(IOContext(stdout,
 
 with row separators but without column labels
 
-```jldoctest labelled_matrix_formatted.test
+```jldoctest labeled_matrix_formatted.test
 julia> Oscar.with_unicode() do
-         labelled_matrix_formatted(IOContext(stdout,
+         labeled_matrix_formatted(IOContext(stdout,
            :separators_row => [0, 1, 2]), mat)
        end
 ───────
@@ -157,7 +157,7 @@ julia> Oscar.with_unicode() do
 ───────
 2/1 2/2
 ───────
-julia> labelled_matrix_formatted(IOContext(stdout,
+julia> labeled_matrix_formatted(IOContext(stdout,
          :separators_row => [0, 1, 2]), mat)
 -------
 1/1 1/2
@@ -168,9 +168,9 @@ julia> labelled_matrix_formatted(IOContext(stdout,
 
 with row separators and column labels
 
-```jldoctest labelled_matrix_formatted.test
+```jldoctest labeled_matrix_formatted.test
 julia> Oscar.with_unicode() do
-         labelled_matrix_formatted(IOContext(stdout,
+         labeled_matrix_formatted(IOContext(stdout,
          :labels_col => [string(j) for j in 1:n],
          :separators_row => [0,1,2]), mat)
        end
@@ -180,7 +180,7 @@ julia> Oscar.with_unicode() do
 ───────
 2/1 2/2
 ───────
-julia> labelled_matrix_formatted(IOContext(stdout,
+julia> labeled_matrix_formatted(IOContext(stdout,
          :labels_col => [string(j) for j in 1:n],
          :separators_row => [0,1,2]), mat)
   1   2
@@ -193,14 +193,14 @@ julia> labelled_matrix_formatted(IOContext(stdout,
 
 with column separators but without row labels
 
-```jldoctest labelled_matrix_formatted.test
+```jldoctest labeled_matrix_formatted.test
 julia> Oscar.with_unicode() do
-         labelled_matrix_formatted(IOContext(stdout,
+         labeled_matrix_formatted(IOContext(stdout,
          :separators_col => [0, 1, 2]), mat)
        end
 │1/1│1/2│
 │2/1│2/2│
-julia> labelled_matrix_formatted(IOContext(stdout,
+julia> labeled_matrix_formatted(IOContext(stdout,
          :separators_col => [0, 1, 2]), mat)
 |1/1|1/2|
 |2/1|2/2|
@@ -208,15 +208,15 @@ julia> labelled_matrix_formatted(IOContext(stdout,
 
 with column separators and row labels
 
-```jldoctest labelled_matrix_formatted.test
+```jldoctest labeled_matrix_formatted.test
 julia> Oscar.with_unicode() do
-         labelled_matrix_formatted(IOContext(stdout,
+         labeled_matrix_formatted(IOContext(stdout,
          :labels_row => [string(i)*":" for i in 1:m],
          :separators_col => [0, 1, 2]), mat)
        end
 1:│1/1│1/2│
 2:│2/1│2/2│
-julia> labelled_matrix_formatted(IOContext(stdout,
+julia> labeled_matrix_formatted(IOContext(stdout,
          :labels_row => [string(i)*":" for i in 1:m],
          :separators_col => [0, 1, 2]), mat)
 1:|1/1|1/2|
@@ -225,9 +225,9 @@ julia> labelled_matrix_formatted(IOContext(stdout,
 
 with row and column labels and separators
 
-```jldoctest labelled_matrix_formatted.test
+```jldoctest labeled_matrix_formatted.test
 julia> Oscar.with_unicode() do
-         labelled_matrix_formatted(IOContext(stdout,
+         labeled_matrix_formatted(IOContext(stdout,
          :labels_row => [string(i)*":" for i in 1:m],
          :labels_col => [string(j) for j in 1:n],
          :separators_row => [0, 1, 2],
@@ -239,7 +239,7 @@ julia> Oscar.with_unicode() do
 ──┼───┼───┼
 2:│2/1│2/2│
 ──┼───┼───┼
-julia> labelled_matrix_formatted(IOContext(stdout,
+julia> labeled_matrix_formatted(IOContext(stdout,
          :labels_row => [string(i)*":" for i in 1:m],
          :labels_col => [string(j) for j in 1:n],
          :separators_row => [0, 1, 2],
@@ -254,9 +254,9 @@ julia> labelled_matrix_formatted(IOContext(stdout,
 
 with row and column portions
 
-```jldoctest labelled_matrix_formatted.test
+```jldoctest labeled_matrix_formatted.test
 julia> Oscar.with_unicode() do
-         labelled_matrix_formatted(IOContext(stdout,
+         labeled_matrix_formatted(IOContext(stdout,
          :labels_row => [string(i)*":" for i in 1:m],
          :labels_col => [string(j) for j in 1:n],
          :separators_row => [0],
@@ -279,7 +279,7 @@ julia> Oscar.with_unicode() do
   │  2
 ──┼───
 2:│2/2
-julia> labelled_matrix_formatted(IOContext(stdout,
+julia> labeled_matrix_formatted(IOContext(stdout,
          :labels_row => [string(i)*":" for i in 1:m],
          :labels_col => [string(j) for j in 1:n],
          :separators_row => [0],
@@ -305,7 +305,7 @@ julia> labelled_matrix_formatted(IOContext(stdout,
 
 LaTeX format
 
-```jldoctest labelled_matrix_formatted.test
+```jldoctest labeled_matrix_formatted.test
 julia> m = 2; n = 2;  mat = Array{String}(undef, m, n);
 
 julia> for i in 1:m for j in 1:n mat[i,j] = string(i)*"/"*string(j); end; end;
@@ -313,8 +313,8 @@ julia> for i in 1:m for j in 1:n mat[i,j] = string(i)*"/"*string(j); end; end;
 
 no labels
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true), mat)
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout, :TeX => true), mat)
 $\begin{array}{rr}
 1/1 & 1/2 \\
 2/1 & 2/2 \\
@@ -324,8 +324,8 @@ $
 
 with header
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout, :TeX => true,
          :header => ["header", ""]), mat)
 header
 
@@ -338,8 +338,8 @@ $
 
 with footer
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout, :TeX => true,
          :footer => ["footer"]), mat)
 $\begin{array}{rr}
 1/1 & 1/2 \\
@@ -354,8 +354,8 @@ $
 
 with row labels as vector
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout, :TeX => true,
          :labels_row => [string(i)*":" for i in 1:m]), mat)
 $\begin{array}{rrr}
 1: & 1/1 & 1/2 \\
@@ -366,8 +366,8 @@ $
 
 with row labels as matrix
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout, :TeX => true,
          :labels_row => reshape([string(i)*":" for i in 1:m], m, 1)), mat)
 $\begin{array}{rrr}
 1: & 1/1 & 1/2 \\
@@ -378,8 +378,8 @@ $
 
 with column labels as vector
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout, :TeX => true,
         :labels_col => [string(j) for j in 1:n]), mat)
 $\begin{array}{rr}
 1 & 2 \\
@@ -391,8 +391,8 @@ $
 
 with column labels as matrix
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout, :TeX => true,
          :labels_col => reshape([string(j) for j in 1:n], 1, n)), mat)
 $\begin{array}{rr}
 1 & 2 \\
@@ -404,8 +404,8 @@ $
 
 with row and column labels
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout, :TeX => true,
          :labels_row => [string(i)*":" for i in 1:m],
          :labels_col => [string(j) for j in 1:n]), mat)
 $\begin{array}{rrr}
@@ -418,8 +418,8 @@ $
 
 with row separators but without column labels
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout, :TeX => true,
          :separators_row => [0, 1, 2]), mat)
 $\begin{array}{rr}
 \hline
@@ -433,8 +433,8 @@ $
 
 with row separators and column labels
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout, :TeX => true,
          :labels_col => [string(j) for j in 1:n],
          :separators_row => [0,1,2]), mat)
 $\begin{array}{rr}
@@ -450,8 +450,8 @@ $
 
 with column separators but without row labels
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout, :TeX => true,
          :separators_col => [0, 1, 2]), mat)
 $\begin{array}{|r|r|}
 1/1 & 1/2 \\
@@ -462,8 +462,8 @@ $
 
 with column separators and row labels
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout, :TeX => true,
          :labels_row => [string(i)*":" for i in 1:m],
          :separators_col => [0, 1, 2]), mat)
 $\begin{array}{r|r|r|}
@@ -475,8 +475,8 @@ $
 
 with row and column labels and separators
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout, :TeX => true,
          :labels_row => [string(i)*":" for i in 1:m],
          :labels_col => [string(j) for j in 1:n],
          :separators_row => [0, 1, 2],
@@ -494,8 +494,8 @@ $
 
 with row and column portions
 
-```jldoctest labelled_matrix_formatted.test
-julia> labelled_matrix_formatted(IOContext(stdout, :TeX => true,
+```jldoctest labeled_matrix_formatted.test
+julia> labeled_matrix_formatted(IOContext(stdout, :TeX => true,
          :labels_row => [string(i) for i in 1:m],
          :labels_col => [string(j) for j in 1:n],
          :separators_row => [0],
@@ -535,7 +535,7 @@ end
 @testset "show and print formatted matrices" begin
   # temporarily disable GC logging to avoid glitches in the doctests
   VERSION >= v"1.8.0" && GC.enable_logging(false)
-  doctest(nothing, [AuxDocTest_labelled_matrix_formatted])
-  #doctest(nothing, [AuxDocTest_labelled_matrix_formatted]; fix=true)
+  doctest(nothing, [AuxDocTest_labeled_matrix_formatted])
+  #doctest(nothing, [AuxDocTest_labeled_matrix_formatted]; fix=true)
   VERSION >= v"1.8.0" && GC.enable_logging(true)
 end


### PR DESCRIPTION
Follow-up to https://github.com/oscar-system/Oscar.jl/pull/3367 with even more things I found.

This introduces two new deprecations, namely:

- `labelled_matrix_formatted` -> `labeled_matrix_formatted`
- `recognise` -> `recognize` (in the `SolveRadical` submodule)

Can someone with access to the book please check, if these deprecations are an issue?