### PR TITLE
Remove unneeded GAP package `sla`

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -103,7 +103,6 @@ function __init__()
      "forms",    # bilinear/sesquilinear/quadratic forms
      "primgrp",  # primitive groups library
      "repsn",    # constructing representations of finite groups
-     "sla",      # computing with simple Lie algebras
      "smallgrp", # small groups library
      "transgrp", # transitive groups library
      "wedderga", # provides a function to compute Schur indices


### PR DESCRIPTION
When reading through https://github.com/oscar-system/Oscar.jl/issues/3395, I noticed that `sla` has been added in https://github.com/oscar-system/Oscar.jl/pull/2572, but I don't think it is used anywhere anymore (e.g. as https://github.com/oscar-system/Oscar.jl/pull/2572 has been majorly refactored in https://github.com/oscar-system/Oscar.jl/pull/2689).
