### PR TITLE
Adresses issue with equality/hashing on module orderings

### DIFF
--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -1783,7 +1783,11 @@ end
 
 function canonical_matrix(o::ModuleOrdering)
   if !isdefined(o, :canonical_matrix)
-    o.canonical_matrix = _canonical_matrix_intern(o)
+    if isone(ngens(o.M))
+      o.canonical_matrix = canonical_matrix(induced_ring_ordering(o))
+    else
+      o.canonical_matrix = _canonical_matrix_intern(o)
+    end
   end
   return o.canonical_matrix
 end

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -1775,6 +1775,14 @@ function _canonical_matrix(o::ModuleOrdering)
   return canonical_matrix(nvrs, eo)
 end
 
+function Base.:(==)(o1::ModuleOrdering, o2::ModuleOrdering)
+  return _canonical_matrix(o1) == _canonical_matrix(o2)
+end
+
+function Base.hash(o::ModuleOrdering, h::UInt)
+  return hash(_canonical_matrix(o), h)
+end
+
 #### _cmp_vector_monomials: cmp f[k]*gen(m) with g[l]*gen(n)
 
 function _cmp_vector_monomials(

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -1717,6 +1717,7 @@ end
 
 # Module orderings (not module Orderings)
 
+# For ordering the generators (I think)
 mutable struct ModOrdering{T} <: AbsModOrdering
    gens::T
    ord::Symbol
@@ -1740,32 +1741,15 @@ mutable struct ModProdOrdering <: AbsModOrdering
    b::AbsOrdering
 end
 
-# Equality checking and hashing
-# Helper for checking equality by checking equality for each entry in a struct
-@generated function _fieldsequal(x, y)
-  if !isempty(fieldnames(x))
-    mapreduce(n -> :(_fieldsequal(x.$n, y.$n)), (a,b)->:($a && $b), fieldnames(x))
-  else
-    :(x == y)
-  end
-end
-
-@generated function _hashbyfields(x, h)
-  if !isempty(fieldnames(x))
-    mapreduce(n -> :(_hashbyfields(x.$n, h)), (a,b) -> :(hash(($a, $b), h)), fieldnames(x))
-  else
-    :(hash(x, h))
-  end
-end 
-
-Base.hash(o1::AbsModOrdering, h::UInt) = _hashbyfields(o1, h)
-Base.hash(o1::ModuleOrdering, h::UInt) = hash((hash(o1.o), hash(o1.M)), h)
-==(o1::AbsModOrdering, o2::AbsModOrdering) = _fieldsequal(o1, o2)
-==(o1::ModuleOrdering, o2::ModuleOrdering) = o1.M == o2.M && o1.o == o2.o
-
 Base.:*(a::AbsGenOrdering, b::AbsModOrdering) = ModProdOrdering(a, b)
 
 Base.:*(a::AbsModOrdering, b::AbsGenOrdering) = ModProdOrdering(a, b)
+
+# Canonical Matrix strategy:
+# - any ModOrdering is embedded into a suitable polynomial ring
+# - take canonical matrix there
+# - take product ordering
+# - pray to the gods
 
 #### _cmp_vector_monomials: cmp f[k]*gen(m) with g[l]*gen(n)
 

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -1728,10 +1728,6 @@ mutable struct ModOrdering{T} <: AbsModOrdering
    end
 end
 
-function ==(o1::ModOrdering, o2::ModOrdering)
-  return o1.gens == o2.gens && o1.ord == o2.ord
-end
-
 mutable struct ModuleOrdering{S}
    M::S
    o::AbsModOrdering # must allow gen*mon or mon*gen product ordering

--- a/test/Rings/orderings.jl
+++ b/test/Rings/orderings.jl
@@ -422,3 +422,12 @@ end
    @test invlex([a, b])*neglex([c]) == induce([a, b, c], invlex([x, y])*neglex([z]))
    @test lex([a])*lex([b])*lex([c]) == induce([a, b, c], lex([x])*lex([y])*lex([z]))
 end
+
+@testset "Monomial Orderings comparison" begin
+  R, (x,y,z,w) = polynomial_ring(GF(32003), ["x", "y", "z", "w"]);
+  F = FreeMod(R, 2)
+  o = lex(gens(F))*lex(gens(R))
+  oo = lex(gens(F))*lex(gens(R))
+  @test o == oo
+  @test hash(o) == hash(oo)
+end

--- a/test/Rings/orderings.jl
+++ b/test/Rings/orderings.jl
@@ -430,4 +430,10 @@ end
   oo = lex(gens(F))*lex(gens(R))
   @test o == oo
   @test hash(o) == hash(oo)
+
+  F = FreeMod(R, 1)
+  o = lex(gens(F))*degrevlex(gens(R))
+  oo = degrevlex(gens(R))*invlex(gens(F))
+  @test o == oo
+  @test hash(o) == hash(oo)
 end


### PR DESCRIPTION
Adds `==` and hashing for `ModuleOrdering`s.

I don't know if this is the best solution, I essentially just circumvent what julia does by default when calling `==` on structs (which is to call `===` on every field) by instead calling `==` recursively on every field.

If this is potentially to dangerous, let me know. It does fix https://github.com/oscar-system/Oscar.jl/issues/3347 on my machine.

Tag: @ederc 