### PR TITLE
ModStdQt `ref_ff_rc` regression fix

### DIFF
--- a/experimental/ModStd/ModStdQt.jl
+++ b/experimental/ModStd/ModStdQt.jl
@@ -481,9 +481,9 @@ A generic fraction free row echelon form for matrices over multivariate
 function ref_ff_rc!(M::MatElem{<:MPolyRingElem})
   rk = 0
   for i=1:nrows(M)
-    c = content(M[i, :])
+    c = content(M[i:i, :])
     if !isone(c)
-      M[i, :] = divexact(M[i, :], c)
+      M[i, :] = divexact(M[i:i, :], c)
     end
   end
   j = 1
@@ -524,8 +524,8 @@ function ref_ff_rc!(M::MatElem{<:MPolyRingElem})
         continue
       end
       g, a, b = gcd_with_cofactors(M[k, j], M[i, j])
-      M[k, :] = b*M[k, :] - a * M[i, :]
-      M[k, :] = divexact(M[k, :], content(M[k, :]))
+      M[k, :] = b*M[k:k, :] - a * M[i:i, :]
+      M[k, :] = divexact(M[k:k, :], content(M[k:k, :]))
     end
     j += 1
   end

--- a/experimental/ModStd/test/ModStdQt.jl
+++ b/experimental/ModStd/test/ModStdQt.jl
@@ -21,3 +21,10 @@ end
   f = factor_absolute(u^2+v^2*a)
   @test length(f) == 2
 end
+
+@testset "Examples.ref_ff_rc!" begin
+  S, (a, b) = polynomial_ring(QQ, ["a", "b"]);
+  A = matrix(S, [a b; b a])
+  Oscar.ModStdQt.ref_ff_rc!(A)
+  @test A == matrix(S, [a b ; 0 1])
+end


### PR DESCRIPTION
Fixes regression for `ModStdQt.ref_ff_rc!` that was introduce after the abstract algebra update.
`content` expects a `MatElem` but was getting a `Vector` after the update.