### PR TITLE
Corrected defn of deg(ideal); correction from W Decker

### DIFF
--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -2383,11 +2383,12 @@ julia> degree(I)
 6
 ```
 """
-@attr Int function degree(I::MPolyIdeal)
+@attr ZZRingElem function degree(I::MPolyIdeal)
   P = base_ring(I)
   if !is_standard_graded(P)
     H = homogenizer(P, "_h")
     I = H(I)
   end
-  return Int(degree(HilbertData(I)))
+  A, _ = quo(base_ring(I), I)
+  return degree(A)
 end

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -346,7 +346,7 @@ false
        return true
     end
   end
-  try 
+  try
     homogeneous_component(R, zero(G))
   catch e
     if e isa ArgumentError && e.msg == "Polyhedron not bounded"
@@ -1241,7 +1241,7 @@ function monomial_basis(W::MPolyDecRing, d::FinGenAbGroupElem)
      #Ax = b, Cx >= 0
      C = identity_matrix(FlintZZ, ngens(W))
      A = reduce(vcat, [x.coeff for x = W.d])
-     k = solve_mixed(transpose(A), transpose(d.coeff), C)    
+     k = solve_mixed(transpose(A), transpose(d.coeff), C)
      for ee = 1:nrows(k)
        e = k[ee, :]
        a = MPolyBuildCtx(forget_decoration(W))
@@ -1264,7 +1264,7 @@ function monomial_basis(R::MPolyDecRing, g::IntegerUnion)
 end
 
 @doc raw"""
-    homogeneous_component(R::MPolyDecRing, g::FinGenAbGroupElem) 
+    homogeneous_component(R::MPolyDecRing, g::FinGenAbGroupElem)
 
 Given a polynomial ring `R` over a field which is graded by a free
 group of type `FinGenAbGroup`, and given an element `g` of that group,
@@ -1404,7 +1404,7 @@ end
 
 ###########################################
 # needs re-thought
-function (W::MPolyDecRing)(m::Generic.FreeModuleElem) 
+function (W::MPolyDecRing)(m::Generic.FreeModuleElem)
   h = has_relshp(parent(m), W)
   if h !== nothing
     return h(m)
@@ -1451,11 +1451,11 @@ mutable struct HilbertData
 
     W = R.d
     W = [Int(W[i][1]) for i = 1:ngens(R)]
-    
+
     @req minimum(W) > 0 "The weights must be positive"
     @req coefficient_ring(R) isa AbstractAlgebra.Field "The coefficient ring must be a field"
     @req all(is_homogeneous, gens(I)) "The generators of the ideal must be homogeneous"
-    
+
     G = groebner_assure(I)
     h = Singular.hilbert_series(G.S, W)
     return new(h, W, I)
@@ -1482,13 +1482,13 @@ end
 function hilbert_polynomial(H::HilbertData)
 
   @req all(isone, H.weights) "All weights must be 1"
-  
+
   q, dn = hilbert_series_reduced(H)
   a = QQFieldElem[]
   nf = QQFieldElem(1)
   d = degree(dn)-1
   for i=1:d+1
-    push!(a, q(1)//nf)    
+    push!(a, q(1)//nf)
     nf *= i
     q = derivative(q)
   end
@@ -1506,7 +1506,7 @@ end
 function Oscar.degree(H::HilbertData)
 
   @req all(isone, H.weights) "All weights must be 1"
-  
+
   P = hilbert_polynomial(H)
   if iszero(P)
      q, _ = hilbert_series_reduced(H)


### PR DESCRIPTION
Two corrections:
* return type is now `ZZRingElem` (previously `Int`)
* defn is now correct
* no longer triggers SEGV when given zero ideal