### PR TITLE
Tweak `exterior_algebra` tests

### DIFF
--- a/experimental/ExteriorAlgebra/test/runtests.jl
+++ b/experimental/ExteriorAlgebra/test/runtests.jl
@@ -4,18 +4,26 @@
 
   ######## CONSTRUCTOR TESTs
   @test_throws ArgumentError exterior_algebra(QQ, 0)
-  exterior_algebra(QQ, 1)   # --> special case (is commutative)
-  exterior_algebra(QQ, 2)   # --> first general case
-  exterior_algebra(QQ, 99)  # --> Also tried with 999 indets, but takes a long time [~19s]
+  @testset "exterior_algebra constructor" for (R,n) in [
+      (QQ, 1)   # --> special case (is commutative)
+      (QQ, 2)   # --> first general case
+      (QQ, 99)  # --> Also tried with 999 indets, but takes a long time [~19s]
 
-  exterior_algebra(GF(2), 2)  # BUG??  not recognized as commutative!!
-  exterior_algebra(GF(3), 4)
-  exterior_algebra(residue_field(ZZ, 2)[1], 2)
-  exterior_algebra(residue_field(ZZ, 3)[1], 4)
-  ##  exterior_algebra(GF(2), 1500);   ## limit 1500 on my 32Gbyte machine (!NB printing requires a lot of space!)
-
-  @test_broken exterior_algebra(GF(1180591620717411303449), 2)  #  --> ERROR prime too big (for GF)
-  @test_broken exterior_algebra(residue_field(ZZ, 1180591620717411303449)[1], 2)
+      (GF(2), 2)  # BUG??  not recognized as commutative!!
+      (GF(3), 4)
+      (residue_field(ZZ, 2)[1], 2)
+      (residue_field(ZZ, 3)[1], 4)
+      #(GF(1180591620717411303449), 2)
+      #(residue_field(ZZ, 1180591620717411303449)[1], 2)
+      ## (GF(2), 1500);   ## limit 1500 on my 32Gbyte machine (!NB printing requires a lot of space!)
+  ]
+    A, g = exterior_algebra(R, n)
+    @test A isa PBWAlgQuo
+    @test g isa Vector{elem_type(A)}
+    @test length(g) == n
+    @test ngens(g) == n
+    @test gens(g) == g
+  end
 
   # Duplicate names are allowed
   exterior_algebra(QQ, ["x", "y", "x"])

--- a/experimental/ExteriorAlgebra/test/runtests.jl
+++ b/experimental/ExteriorAlgebra/test/runtests.jl
@@ -21,8 +21,8 @@
     @test A isa PBWAlgQuo
     @test g isa Vector{elem_type(A)}
     @test length(g) == n
-    @test ngens(g) == n
-    @test gens(g) == g
+    @test ngens(A) == n
+    @test gens(A) == g
   end
 
   # Duplicate names are allowed


### PR DESCRIPTION
Do not just verify that certain `exterior_algebra` invocations don't error out; also check that the returned values satisfy certain properties.

Also disable two `@test_broken` tests for now, because (a) the underlying issue is fixed in a Singular PR, but this causes OscarCI failures there.. (b) even if the underlying issue is fixed, those test were wrong, because `exterior_algebra` doesn't return a boolean, but the return value was used in a context where it must be boolean (namely as "argument" for `@test_broken`).

I hope we can quickly merge this, then we can re-run the https://github.com/oscar-system/Singular.jl/pull/773 CI tests. If those pass, we'd merge that into Singular.jl, release Singular.jl -- then finally we could enable the two currently commented out (former `@test_broken`) tests.

CC @hannes14 