### PR TITLE
list the needed GAP packages

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -101,6 +101,8 @@ function __init__()
      "crisp",    # faster normal subgroups, socles, p-socles for finite solvable groups
      "fga",      # dealing with free groups
      "forms",    # bilinear/sesquilinear/quadratic forms
+     "packagemanager", # has been loaded already by GAP.jl
+     "polycyclic", # needed for Oscar's pc groups
      "primgrp",  # primitive groups library
      "repsn",    # constructing representations of finite groups
      "smallgrp", # small groups library
@@ -108,6 +110,12 @@ function __init__()
      "wedderga", # provides a function to compute Schur indices
      ]
     GAP.Packages.load(pkg) || error("cannot load the GAP package $pkg")
+  end
+  # We want some GAP packages. (It is no error if they cannot be loaded.)
+  for pkg in [
+     "ferret",   # backtrack in permutation groups
+     ]
+    GAP.Packages.load(pkg)
   end
   __init_group_libraries()
 


### PR DESCRIPTION
We want to have the needed GAP packages in the list in `src/Oscar,jl`.

- `polycyclic` gets loaded automatically by GAP, but we want to get an error if it is for some reason not loadable.
- `packagemanager` gets loaded by GAP.jl.
- `ferret` gets loaded in the Oscar module `GaloisGrp`, in fact there we even try to install this package if it is not yet there. However, it is not an error if the package cannot be loaded.

addresses #3395