### PR TITLE
do not show the OscarInterface banner

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -83,7 +83,7 @@ function __init__()
   # `Julia.Oscar` if Oscar is loaded indirectly as a package dependency)
   GAP.Globals.BindGlobal(GapObj("Oscar"), Oscar)
   GAP.Globals.SetPackagePath(GAP.Obj("OscarInterface"), GAP.Obj(joinpath(@__DIR__, "..", "gap", "OscarInterface")))
-  GAP.Globals.LoadPackage(GAP.Obj("OscarInterface"))
+  GAP.Globals.LoadPackage(GAP.Obj("OscarInterface"), false)
   withenv("TERMINFO_DIRS" => joinpath(GAP.GAP_jll.Readline_jll.Ncurses_jll.find_artifact_dir(), "share", "terminfo")) do
     GAP.Packages.load("browse"; install=true) # needed for all_character_table_names doctest
   end


### PR DESCRIPTION
The banner can be switched off by calling `GAP.Globals.LoadPackage` with second argument `false`.
(We cannot call `GAP.load` because `OscarInterface` is outside the GAP root paths.)

The question is rather why `using Oscar` did *not* show the banner before this change. 

resolves #3414