### PR TITLE
Tweak epimorphism_from_free_group

### DIFF
--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -1003,7 +1003,7 @@ julia> G = symmetric_group(4);
 
 julia> epi = epimorphism_from_free_group(G)
 Group homomorphism
-  from free group
+  from free group of rank 2
   to Sym(4)
 
 julia> pi = G([2,4,3,1])
@@ -1018,6 +1018,7 @@ julia> map_word(w, gens(G))
 function epimorphism_from_free_group(G::GAPGroup)
   mfG = GAP.Globals.EpimorphismFromFreeGroup(G.X)
   fG = FPGroup(GAPWrap.Source(mfG))
+  GAP.Globals.RankOfFreeGroup(fG.X)  # force rank computation
   return Oscar.GAPGroupHomomorphism(fG, G, mfG)
 end
 


### PR DESCRIPTION
... to ensure rank of the free group is set.

Pure cosmetics for the book.

Longterm we need to tweak GAP to always set this. Part of the issue is that the rank functionality is not in the GAP library itself but rather provided by the FGA package.

One way to ensure it is always set "when reasonable" is to add GAP code like this to our code base:
```
InstallImmediateMethod(RankOfFreeGroup, IsFreeGroup and IsWholeFamily and IsGroupOfFamily,
    0, G -> Size(FreeGeneratorsOfWholeGroup(G)));
```
@ThomasBreuer note the use of `IsGroupOfFamily` which we've been wondering about... I still think it shouldn't really exist, but here it is useful because it is set last in GAP's free group constructor... while `IsWholeFamily` is set "too soon", before `FamilyObj(G)!.wholeGroup := G;` has been set, and this then screws up the immediate method, as it gets triggered "too soon".