### PR TITLE
Remove two mentions of `Arb_jll`

### DIFF
--- a/src/Serialization/Fields.jl
+++ b/src/Serialization/Fields.jl
@@ -403,7 +403,7 @@ end
 
 # elements
 function save_object(s::SerializerState, r::ArbFieldElem)
-  c_str = ccall((:arb_dump_str, Nemo.Arb_jll.libarb), Ptr{UInt8}, (Ref{ArbFieldElem},), r)
+  c_str = ccall((:arb_dump_str, Nemo.libarb), Ptr{UInt8}, (Ref{ArbFieldElem},), r)
   save_object(s, unsafe_string(c_str))
   
   # free memory
@@ -413,7 +413,7 @@ end
 function load_object(s::DeserializerState, ::Type{ArbFieldElem}, parent::ArbField)
   r = Nemo.ArbFieldElem()
   load_node(s) do str
-    ccall((:arb_load_str, Nemo.Arb_jll.libarb),
+    ccall((:arb_load_str, Nemo.libarb),
           Int32, (Ref{ArbFieldElem}, Ptr{UInt8}), r, str)
   end
   r.parent = parent


### PR DESCRIPTION
This makes https://github.com/Nemocas/Nemo.jl/pull/1691 non-breaking. Similar references to libflint are already without the intermediate `FLINT_JLL` step, so this adds some consistency.

Adding a backport label to keep compatibility with Nemo versions with https://github.com/Nemocas/Nemo.jl/pull/1691 on the release branch.