### PR TITLE
Align `all_*_groups` methods some more

### DIFF
--- a/src/Groups/libraries/primitivegroups.jl
+++ b/src/Groups/libraries/primitivegroups.jl
@@ -163,6 +163,10 @@ may be of one of the following forms:
 - `func` selects groups for which the function `func` returns `true`
 - `!func` selects groups for which the function `func` returns `false`
 
+As a special case, the first argument may also be one of the following:
+- `intval` selects groups whose degree equals `intval`; this is equivalent to `degree => intval`
+- `intlist` selects groups whose degree is in `intlist`; this is equivalent to `degree => intlist`
+
 The following functions are currently supported as values for `func`:
 - `degree`
 - `is_abelian`
@@ -184,9 +188,6 @@ The following functions are currently supported as values for `func`:
 
 The type of the returned groups is `PermGroup`.
 
-If no conditions beside the degree are used, one can also use the shorthand
-`all_primitive_groups(degree)` where `degree` is an integer or a list or range of integers.
-
 # Examples
 ```jldoctest
 julia> all_primitive_groups(4)
@@ -199,25 +200,15 @@ julia> all_primitive_groups(degree => 3:5, is_abelian)
  Alt(3)
  Permutation group of degree 5 and order 5
 ```
-returns the list of all abelian primitive permutation groups acting on 3, 4 or 5 points.
 """
 function all_primitive_groups(L...)
    @req !isempty(L) "must specify at least one filter"
+   if L[1] isa IntegerUnion || L[1] isa AbstractVector{<:IntegerUnion}
+      L = (degree => L[1], L[2:end]...)
+   end
    gapargs = translate_group_library_args(L; filter_attrs = _permgroup_filter_attrs)
    K = GAP.Globals.AllPrimitiveGroups(gapargs...)
    return [PermGroup(x) for x in K]
-end
-
-function all_primitive_groups(deg::Integer)
-  return all_primitive_groups(degree => deg)
-end
-
-function all_primitive_groups(degs::Vector{<:Integer})
-  return all_primitive_groups(degree => degs)
-end
-
-function all_primitive_groups(degs::AbstractRange{<:Integer})
-  return all_primitive_groups(degree => degs)
 end
 
 # TODO: turn this into an iterator, possibly using PrimitiveGroupsIterator

--- a/src/Groups/libraries/transitivegroups.jl
+++ b/src/Groups/libraries/transitivegroups.jl
@@ -159,6 +159,10 @@ may be of one of the following forms:
 - `func` selects groups for which the function `func` returns `true`
 - `!func` selects groups for which the function `func` returns `false`
 
+As a special case, the first argument may also be one of the following:
+- `intval` selects groups whose degree equals `intval`; this is equivalent to `degree => intval`
+- `intlist` selects groups whose degree is in `intlist`; this is equivalent to `degree => intlist`
+
 The following functions are currently supported as values for `func`:
 - `degree`
 - `is_abelian`
@@ -180,9 +184,6 @@ The following functions are currently supported as values for `func`:
 
 The type of the returned groups is `PermGroup`.
 
-If no conditions beside the degree are used, one can also use the shorthand
-`all_transitive_groups(degree)` where `degree` is an integer or a list or range of integers.
-
 # Examples
 ```jldoctest
 julia> all_transitive_groups(4)
@@ -200,24 +201,15 @@ julia> all_transitive_groups(degree => 3:5, is_abelian)
  Permutation group of degree 4
  Permutation group of degree 5
 ```
-returns the list of all abelian transitive groups acting on 3, 4 or 5 points.
 """
 function all_transitive_groups(L...)
+   @req !isempty(L) "must specify at least one filter"
+   if L[1] isa IntegerUnion || L[1] isa AbstractVector{<:IntegerUnion}
+      L = (degree => L[1], L[2:end]...)
+   end
    gapargs = translate_group_library_args(L; filter_attrs = _permgroup_filter_attrs)
    K = GAP.Globals.AllTransitiveGroups(gapargs...)
    return [PermGroup(x) for x in K]
-end
-
-function all_transitive_groups(deg::Integer)
-  return all_transitive_groups(degree => deg)
-end
-
-function all_transitive_groups(degs::Vector{<:Integer})
-  return all_transitive_groups(degree => degs)
-end
-
-function all_transitive_groups(degs::AbstractRange{<:Integer})
-  return all_transitive_groups(degree => degs)
 end
 
 # TODO: turn this into an iterator, possibly using PrimitiveGroupsIterator

--- a/test/Groups/libraries.jl
+++ b/test/Groups/libraries.jl
@@ -87,6 +87,9 @@ end
    @test issetequal(all_transitive_groups(3:2:9), all_transitive_groups(degree => 3:2:9))
    @test issetequal(all_transitive_groups(collect(3:2:9)), all_transitive_groups(3:2:9))
    @test issetequal(reduce(vcat, (all_transitive_groups(i) for i in 3:2:9)), all_transitive_groups(3:2:9))
+
+   @test issetequal(all_transitive_groups(3:2:9, is_abelian), all_transitive_groups(degree => 3:2:9, is_abelian))
+   @test issetequal(all_transitive_groups(9, is_abelian), all_transitive_groups(degree => 9, is_abelian))
 end
 
 @testset "Perfect groups" begin
@@ -164,6 +167,9 @@ end
    @test issetequal(all_primitive_groups(3:2:9), all_primitive_groups(degree => 3:2:9))
    @test issetequal(all_primitive_groups(collect(3:2:9)), all_primitive_groups(3:2:9))
    @test issetequal(reduce(vcat, (all_primitive_groups(i) for i in 3:2:9)), all_primitive_groups(3:2:9))
+
+   @test issetequal(all_primitive_groups(3:2:9, is_abelian), all_primitive_groups(degree => 3:2:9, is_abelian))
+   @test issetequal(all_primitive_groups(9, is_abelian), all_primitive_groups(degree => 9, is_abelian))
 end
 
 @testset "Atlas groups" begin


### PR DESCRIPTION
For `all_small_groups` we allow specifying the order as a single
integer or abstract vector, followed by any number of additional
filters. For transitive and primitive groups, we also allowed
specifying the degree as a single integer or abstract vector, but
this then could not be followed by filters. With this patch the
additional filters work in all cases.


Depends on PR #3404 (which has already been merged), so this PR here can only be backported after PR #3404.
