### PR TITLE
Bugfix for printing of affine schemes

### DIFF
--- a/experimental/Schemes/MorphismFromRationalFunctions.jl
+++ b/experimental/Schemes/MorphismFromRationalFunctions.jl
@@ -134,7 +134,7 @@ julia> realizations = Oscar.realize_on_patch(Phi, U);
 
 julia> realizations[3]
 Affine scheme morphism
-  from [(t//s)]          AA^1 \ scheme()
+  from [(t//s)]          AA^1
   to   [(x//z), (y//z)]  affine 2-space
 given by the pullback function
   (x//z) -> (t//s)^2

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Constructors.jl
@@ -513,7 +513,7 @@ Spectrum
   of localization
     of multivariate polynomial ring in 3 variables x1, x2, x3
       over rational field
-    at products of (x1,x2)
+    at products of (x1, x2)
 ```
 """
 function hypersurface_complement(X::AbsAffineScheme, f::Vector{<:RingElem})

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
@@ -76,18 +76,26 @@ function _show(io::IO, X::AbsAffineScheme{<:Any, <:MPolyQuoLocRing{<:Any, <:Any,
   I = modulus(OO(X))
   S = inverted_set(OO(X))
   join(io, gens(I), ", ")
-  print(io, raw") \ scheme(")
-  join(io, denominators(S), ",")
-  print(io, ")")
+  if isone(length(denominators(S)))
+    print(io, raw" \ scheme(", first(denominators(S)), ")")
+  else
+    print(io, raw") \ scheme((")
+    join(io, denominators(S), ")*(")
+    print(io, "))")
+  end
 end
 
 function _show(io::IO, X::AbsAffineScheme{<:Any, <:MPolyLocRing{<:Any, <:Any, <:Any, <:Any, <:MPolyPowersOfElement}})
   io = pretty(io)
   print(io, LowercaseOff(), "AA^", ngens(OO(X)))
   S = inverted_set(OO(X))
-  print(io, raw" \ scheme(")
-  join(io, denominators(S), ",")
-  print(io, ")")
+  if isone(length(denominators(S)))
+    print(io, raw" \ scheme(", first(denominators(S)), ")")
+  else
+    print(io, raw" \ scheme((")
+    join(io, denominators(S), ")*(")
+    print(io, "))")
+  end
 end
 
 ########################################################

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
@@ -76,8 +76,10 @@ function _show(io::IO, X::AbsAffineScheme{<:Any, <:MPolyQuoLocRing{<:Any, <:Any,
   I = modulus(OO(X))
   S = inverted_set(OO(X))
   join(io, gens(I), ", ")
-  if isone(length(denominators(S)))
-    print(io, raw" \ scheme(", first(denominators(S)), ")")
+  if is_empty(denominators(S))
+    print(io, raw")")
+  elseif isone(length(denominators(S)))
+    print(io, raw") \ scheme(", first(denominators(S)), ")")
   else
     print(io, raw") \ scheme((")
     join(io, denominators(S), ")*(")
@@ -89,7 +91,9 @@ function _show(io::IO, X::AbsAffineScheme{<:Any, <:MPolyLocRing{<:Any, <:Any, <:
   io = pretty(io)
   print(io, LowercaseOff(), "AA^", ngens(OO(X)))
   S = inverted_set(OO(X))
-  if isone(length(denominators(S)))
+  if is_empty(denominators(S))
+    # do nothing more
+  elseif isone(length(denominators(S)))
     print(io, raw" \ scheme(", first(denominators(S)), ")")
   else
     print(io, raw" \ scheme((")

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -125,7 +125,7 @@ function Base.show(io::IO, S::MPolyPowersOfElement)
     print(io, ItemQuantity(length(denominators(S)), "element"))
   else
     print(io, "Products of (")
-    join(io, denominators(S), ",")
+    join(io, denominators(S), ", ")
     print(io, ")")
   end
 end


### PR DESCRIPTION
This corrects the printing of affine schemes which are hypersurface complements.

Docfix will follow.