### PR TITLE
Bugfix for bugfix for printing of affine schemes

### DIFF
--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
@@ -81,7 +81,7 @@ function _show(io::IO, X::AbsAffineScheme{<:Any, <:MPolyQuoLocRing{<:Any, <:Any,
   else
     AA = AbstractAlgebra
     PP = AbstractAlgebra.PrettyPrinting
-    print(io, raw" \ ")
+    print(io, raw") \ ")
     AA.show_obj(io,
                 MIME("text/plain"),
                 PP.canonicalize(Expr(:call,

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
@@ -78,12 +78,18 @@ function _show(io::IO, X::AbsAffineScheme{<:Any, <:MPolyQuoLocRing{<:Any, <:Any,
   join(io, gens(I), ", ")
   if is_empty(denominators(S))
     print(io, raw")")
-  elseif isone(length(denominators(S)))
-    print(io, raw") \ scheme(", first(denominators(S)), ")")
   else
-    print(io, raw") \ scheme((")
-    join(io, denominators(S), ")*(")
-    print(io, "))")
+    AA = AbstractAlgebra
+    PP = AbstractAlgebra.PrettyPrinting
+    print(io, raw" \ ")
+    AA.show_obj(io,
+                MIME("text/plain"),
+                PP.canonicalize(Expr(:call,
+                                     :scheme,
+                                     Expr(:call, :*, PP.expressify.(denominators(S))...)
+                                    )
+                               )
+               )
   end
 end
 
@@ -93,12 +99,18 @@ function _show(io::IO, X::AbsAffineScheme{<:Any, <:MPolyLocRing{<:Any, <:Any, <:
   S = inverted_set(OO(X))
   if is_empty(denominators(S))
     # do nothing more
-  elseif isone(length(denominators(S)))
-    print(io, raw" \ scheme(", first(denominators(S)), ")")
   else
-    print(io, raw" \ scheme((")
-    join(io, denominators(S), ")*(")
-    print(io, "))")
+    AA = AbstractAlgebra
+    PP = AbstractAlgebra.PrettyPrinting
+    print(io, raw" \ ")
+    AA.show_obj(io,
+                MIME("text/plain"),
+                PP.canonicalize(Expr(:call,
+                                     :scheme,
+                                     Expr(:call, :*, PP.expressify.(denominators(S))...)
+                                    )
+                               )
+               )
   end
 end
 


### PR DESCRIPTION
Turns
```
julia> [Spec(L)]
1-element Vector{AffineScheme{QQField, Oscar.MPolyLocRing{QQField, QQFieldElem, QQMPolyRing, QQMPolyRingElem, Oscar.MPolyPowersOfElement{QQField, QQFieldElem, QQMPolyRing, QQMPolyRingElem}}}}:
AA^2 \ scheme((x)*(y)*(x*y))
```
into
```
julia> [Spec(L)]
1-element Vector{AffineScheme{QQField, Oscar.MPolyLocRing{QQField, QQFieldElem, QQMPolyRing, QQMPolyRingElem, Oscar.MPolyPowersOfElement{QQField, QQFieldElem, QQMPolyRing, QQMPolyRingElem}}}}:
AA^2 \ scheme(x*y*x*y)
```

I dedicate this to Dan S., who taught us to avoid parentheses like never before.