### PR TITLE
Simplify for modules

### DIFF
--- a/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
@@ -589,7 +589,17 @@ end
 
 ### Taylormade functionality for modules
 # Provided as a hotfix for issue #3108.
-function _alt_simplify(M::SubquoModule)
+@doc raw"""
+    simplify(M::SubquoModule)
+
+Simplify the given subquotient `M` and return the simplified subquotient `N` along
+with the injection map $N \to M$ and the projection map $M \to N$. These maps are
+isomorphisms.
+The simplifcation is heuristical and includes steps like for example removing
+zero-generators or removing the i-th component of all vectors if those are
+reduced by a relation.
+"""
+function simplify(M::SubquoModule)
   res, aug = free_resolution(SimpleFreeResolution, M)
   simp = simplify(res)
   simp_to_orig = map_to_original_complex(simp)
@@ -601,7 +611,10 @@ function _alt_simplify(M::SubquoModule)
                     elem_type(M)[aug[0](simp_to_orig[0](inc_Z0(preimage(Z0_to_result, x)))) for x in gens(result)]; check=false)
   M_to_result = hom(M, result,
                     elem_type(result)[Z0_to_result(preimage(inc_Z0, orig_to_simp[0](preimage(aug[0], y)))) for y in gens(M)]; check=false)
-  return result, M_to_result, result_to_M
+  set_attribute!(M_to_result, :inverse=>result_to_M)
+  set_attribute!(result_to_M, :inverse=>M_to_result)
+  #return result, M_to_result, result_to_M
+  return result, result_to_M
 end
 
 # Some special shortcuts

--- a/src/Modules/UngradedModules/Presentation.jl
+++ b/src/Modules/UngradedModules/Presentation.jl
@@ -511,7 +511,7 @@ e[2]
 function prune_with_map(M::ModuleFP)
   # TODO: take special care of graded modules 
   # by stripping off the grading and rewrapping it afterwards.
-  N, a, b = _alt_simplify(M)
+  N, b = simplify(M)
   return N, b
 end
 

--- a/src/Modules/UngradedModules/SubQuoHom.jl
+++ b/src/Modules/UngradedModules/SubQuoHom.jl
@@ -1163,17 +1163,10 @@ function simplify_with_same_ambient_free_module(M::SubquoModule)
   #return N, N_to_M, hom(M, N, [N(repres(g)) for g in gens(M)])
 end
 
-@doc raw"""
-    simplify(M::SubquoModule)
-
-Simplify the given subquotient `M` and return the simplified subquotient `N` along
-with the injection map $N \to M$ and the projection map $M \to N$. These maps are
-isomorphisms.
-The simplifcation is heuristical and includes steps like for example removing
-zero-generators or removing the i-th component of all vectors if those are
-reduced by a relation.
-"""
-function simplify(M::SubquoModule)
+### Old version of simplify which is trying to do things directly on the 
+# subquotient without a presentation. Does not respect gradings and is, 
+# hence, not fully functional; see issue #3108.
+function _old_simplify(M::SubquoModule)
   respect_grading = is_graded(M)
   function standard_unit_vector_in_relations(i::Int, M::SubquoModule)
     F = ambient_free_module(M)

--- a/src/Modules/UngradedModules/SubQuoHom.jl
+++ b/src/Modules/UngradedModules/SubQuoHom.jl
@@ -1157,7 +1157,7 @@ with the injection map $N \to M$ and the projection map $M \to N$. These maps ar
 isomorphisms. The ambient free module of `N` is the same as that of `M`.
 """
 function simplify_with_same_ambient_free_module(M::SubquoModule)
-  _, to_M, from_M = simplify(M)
+  _, to_M, from_M = _old_simplify(M)
   N, N_to_M = image(to_M)
   return N, N_to_M, hom(M, N, [N(coordinates(from_M(g))) for g in gens(M)], check=false)
   #return N, N_to_M, hom(M, N, [N(repres(g)) for g in gens(M)])

--- a/test/Modules/GradedModules.jl
+++ b/test/Modules/GradedModules.jl
@@ -146,7 +146,8 @@ end
   D = hom(C, OmegaPn)
   Omega = homology(D, 0);
   is_graded(Omega)
-  SOmega, a, b = Oscar._alt_simplify(Omega)
+  SOmega, b = simplify(Omega)
+  a = get_attribute(b, :inverse)
   @test is_graded(SOmega)
   @test is_isomorphism(a)
   @test is_isomorphism(b)

--- a/test/Modules/ModulesGraded.jl
+++ b/test/Modules/ModulesGraded.jl
@@ -1213,7 +1213,8 @@ end
   D = hom(C, OmegaPn)
   Omega = homology(D, 0);
   is_graded(Omega)
-  SOmega, a, b = Oscar._alt_simplify(Omega)
+  SOmega, b = simplify(Omega)
+  a = get_attribute(b, :inverse)
   @test is_graded(SOmega)
   @test is_isomorphism(a)
   @test is_isomorphism(b)

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -320,7 +320,7 @@ end
   T1 = tor(M, Q, 1)
   T2 = tor(M, Q, 2)
   @test is_canonically_isomorphic(present_as_cokernel(T0), M_coker)
-  @test is_canonically_isomorphic(simplify(present_as_cokernel(T1))[1], M_coker)
+  @test is_canonically_isomorphic(Oscar._old_simplify(present_as_cokernel(T1))[1], M_coker)
   @test iszero(T2)
 
   E0 = ext(Q, M, 0)
@@ -337,7 +337,7 @@ end
   E4 = ext(M, Q, 4)
   @test iszero(E0)
   @test iszero(E1)
-  @test is_canonically_isomorphic(present_as_cokernel(simplify(E2)[1]), M_coker)
+  @test is_canonically_isomorphic(present_as_cokernel(Oscar._old_simplify(E2)[1]), M_coker)
   @test is_canonically_isomorphic(E3, M_coker)
   @test iszero(E4)
 end
@@ -462,7 +462,7 @@ end
   A1 = R[x*y R(0)]
   B1 = R[R(0) R(1)]
   M1 = SubquoModule(A1,B1)
-  M2,i2,p2 = simplify(M1)
+  M2,i2,p2 = Oscar._old_simplify(M1)
   for k=1:5
     elem = SubquoModuleElem(sparse_row(matrix([randpoly(R) for _=1:1,i=1:1])), M1)
     @test elem == i2(p2(elem))
@@ -487,7 +487,7 @@ end
   A1 = matrix([randpoly(R,0:15,2,1) for i=1:3,j=1:2])
   B1 = matrix([randpoly(R,0:15,2,1) for i=1:1,j=1:2])
   M1 = SubquoModule(A1,B1)
-  M2,i2,p2 = simplify(M1)
+  M2,i2,p2 = Oscar._old_simplify(M1)
   for k=1:5
     elem = SubquoModuleElem(sparse_row(matrix([randpoly(R) for _=1:1,i=1:3])), M1)
     @test elem == i2(p2(elem))
@@ -503,7 +503,7 @@ end
   A1 = matrix([randpoly(R,0:15,2,1) for i=1:3,j=1:3])
   B1 = matrix([randpoly(R,0:15,2,1) for i=1:2,j=1:3])
   M1 = SubquoModule(A1,B1)
-  M2,i2,p2 = simplify(M1)
+  M2,i2,p2 = Oscar._old_simplify(M1)
 
   for k=1:5
     elem = SubquoModuleElem(sparse_row(matrix([randpoly(R) for _=1:1, i=1:3])), M1)
@@ -518,7 +518,7 @@ end
   @test is_bijective(p2)
 
   M1 = SubquoModule(B1,A1)
-  M2,i2,p2 = simplify(M1)
+  M2,i2,p2 = Oscar._old_simplify(M1)
   for k=1:5
     elem = SubquoModuleElem(sparse_row(matrix([randpoly(R) for _=1:1, i=1:2])), M1)
     @test elem == i2(p2(elem))

--- a/test/Modules/flattenings.jl
+++ b/test/Modules/flattenings.jl
@@ -35,7 +35,7 @@ end
   I = ideal(S, [f, g]);
   X, inc_X = sub(IP5, I);
   Om1X = Oscar.relative_cotangent_module(X);
-  M, b = Oscar.simplify(W1X)
+  M, b = Oscar.simplify(Om1X)
   a = get_attribute(b, :inverse)
   @test is_isomorphism(a)
   @test is_isomorphism(b)

--- a/test/Modules/flattenings.jl
+++ b/test/Modules/flattenings.jl
@@ -14,7 +14,8 @@
   TX,_ = hom(Om1X,F1X);
   TXamb,_ = pushforward(inc_X,TX);
   W1X,_ = hom(TX,F1X)
-  M, a, b = Oscar._alt_simplify(W1X)
+  M, b = Oscar.simplify(W1X)
+  a = get_attribute(b, :inverse)
   @test is_isomorphism(a)
   @test is_isomorphism(b)
   @test compose(a, b) == identity_map(domain(a))
@@ -34,7 +35,8 @@ end
   I = ideal(S, [f, g]);
   X, inc_X = sub(IP5, I);
   Om1X = Oscar.relative_cotangent_module(X);
-  M, a, b = Oscar._alt_simplify(Om1X)
+  M, b = Oscar.simplify(W1X)
+  a = get_attribute(b, :inverse)
   @test is_isomorphism(a)
   @test is_isomorphism(b)
   @test compose(a, b) == identity_map(domain(a))


### PR DESCRIPTION
Makes `_alt_simplify` (which is also the workhorse behind `prune_with_map` in the generic case) the new `simplify` and resolves #3108.