### PR TITLE
Unexport normalise

### DIFF
--- a/experimental/ModStd/ModStdQt.jl
+++ b/experimental/ModStd/ModStdQt.jl
@@ -21,7 +21,6 @@ function Oscar.evaluate(f::FracElem{<:MPolyRingElem}, v::Vector{<:RingElem}; Err
   return n//d
 end
 
-Oscar.normalise(f::QQPolyRingElem, ::Int64) = error("no normalise") #length(f)
 #Oscar.set_length!(f::QQPolyRingElem, ::Int64) = error("no set_length") #f
 
 #=

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -167,6 +167,7 @@ let exclude_hecke = [
     :leading_term,
     :monomials,
     :narrow_class_group,
+    :normalise,
     :number_of_partitions,
     :Partition,
     :perm,


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/3330 by not exporting the internal function `normalise`. There are several issues with this function, which will not be fixed in the near future. Furthermore, this function should never be called by a user.