### PR TITLE
Fix a doc signature

### DIFF
--- a/docs/src/NumberTheory/abelian_closure.md
+++ b/docs/src/NumberTheory/abelian_closure.md
@@ -20,7 +20,7 @@ abelian_closure(::QQField)
 Given the abelian closure, the generator can be recovered as follows:
 
 ```@docs
-gen(::QQAbField)
+gen(::QQAbField{AbsSimpleNumField})
 atlas_irrationality
 atlas_description
 ```


### PR DESCRIPTION
Documenter didn't find the correct doc string and used `gen(::SubquoModule)` instead.
