### PR TITLE
Speed up fundamental invariants of finite groups

### DIFF
--- a/src/InvariantTheory/affine_algebra.jl
+++ b/src/InvariantTheory/affine_algebra.jl
@@ -65,7 +65,7 @@ Invariant ring
   of matrix group of degree 3 over K
 
 julia> affine_algebra(IR)
-(Quotient of multivariate polynomial ring by ideal with 1 generator, Hom: quotient of multivariate polynomial ring -> graded multivariate polynomial ring)
+(Quotient of multivariate polynomial ring by ideal (9*y1^6 + y1^3*y2^3 - 6*y1^3*y2*y3 + 3*y1^3*y4 - y2*y3*y4 + y3^3 + y4^2), Hom: quotient of multivariate polynomial ring -> graded multivariate polynomial ring)
 ```
 """
 function affine_algebra(IR::FinGroupInvarRing; algo_gens::Symbol = :default, algo_rels::Symbol = :groebner_basis)

--- a/src/InvariantTheory/fundamental_invariants.jl
+++ b/src/InvariantTheory/fundamental_invariants.jl
@@ -239,9 +239,9 @@ Invariant ring
 
 julia> fundamental_invariants(IR)
 4-element Vector{MPolyDecRingElem{AbsSimpleNumFieldElem, AbstractAlgebra.Generic.MPoly{AbsSimpleNumFieldElem}}}:
- x[1]^3 + x[2]^3 + x[3]^3
  x[1]*x[2]*x[3]
- x[1]^6 + x[2]^6 + x[3]^6
+ x[1]^3 + x[2]^3 + x[3]^3
+ x[1]^3*x[2]^3 + x[1]^3*x[3]^3 + x[2]^3*x[3]^3
  x[1]^3*x[2]^6 + x[1]^6*x[3]^3 + x[2]^3*x[3]^6
 ```
 """


### PR DESCRIPTION
Use linear algebra to produce new invariants instead of the Reynolds operator in King's algorithm if the group is big.

Without this, computing fundamental invariants of
```
julia> K, i = cyclotomic_field(4, "i");

julia> q1 = diagonal_matrix(K[i 0; 0 i^-1], identity_matrix(K, 4));

julia> q2 = diagonal_matrix(K[0 -1; 1 0], identity_matrix(K, 4));

julia> q3 = K[0 0 1 0 0 0; 0 0 0 1 0 0; 0 0 0 0 1 0; 0 0 0 0 0 1; 1 0 0 0 0 0; 0 1 0 0 0 0];

julia> q4 = K[0 0 1 0 0 0; 0 0 0 1 0 0; 1 0 0 0 0 0; 0 1 0 0 0 0; 0 0 0 0 1 0; 0 0 0 0 0 1];

julia> G = matrix_group(q1, q2, q3, q4);

julia> RG = invariant_ring(G);
```
would take 20 to 30 minutes, now we are down to ~20 seconds.

I can't guarantee that there is absolutely no regression. In particular, the heuristic I implemented is a bit "magical" (see the comments). But I would hope that this is only slower in small examples, where a difference of a few milliseconds shouldn't matter. I did not notice any regression in the examples I tried though!
