### PR TITLE
add `map_word` for `PcGroupElem`

### DIFF
--- a/docs/src/Groups/fpgroup.md
+++ b/docs/src/Groups/fpgroup.md
@@ -14,5 +14,5 @@ free_group(n::Int)
 is_full_fp_group(G::FPGroup)
 relators(G::FPGroup)
 length(g::FPGroupElem)
-map_word
+map_word(g::FPGroupElem, genimgs::Vector; genimgs_inv::Vector = Vector(undef, length(genimgs)), init = nothing)
 ```

--- a/docs/src/Groups/pcgroup.md
+++ b/docs/src/Groups/pcgroup.md
@@ -10,6 +10,7 @@ end
 ```@docs
 PcGroup
 PcGroupElem
+map_word(g::PcGroupElem, genimgs::Vector; genimgs_inv::Vector = Vector(undef, length(genimgs)), init = nothing)
 ```
 
 Julia has the following functions that allow to generate polycyclic groups:

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1797,7 +1797,7 @@ that is described by `g` or `v`, respectively.
 
 If `g` is an element of a free group $G$, say, then the rank of $G$ must be
 equal to the length of `genimgs`, `g` is a product of the form
-$g_{i_1}^{e_i} g_{i_2}^{e_2} \cdots g_{i_n}^{e_n}$
+$g_{i_1}^{e_1} g_{i_2}^{e_2} \cdots g_{i_n}^{e_n}$
 where $g_i$ is the $i$-th generator of $G$ and the $e_i$ are nonzero integers,
 and $R_j =$ `imgs[`$i_j$`]`$^{e_j}$.
 
@@ -1877,6 +1877,29 @@ function map_word(g::FPGroupElem, genimgs::Vector; genimgs_inv::Vector = Vector(
   return map_word(ll, genimgs, genimgs_inv = genimgs_inv, init = init)
 end
 
+
+@doc raw"""
+    map_word(g::PcGroupElem, genimgs::Vector; genimgs_inv::Vector = Vector(undef, length(genimgs)), init = nothing)
+
+Return the product $R_1 R_2 \cdots R_n$ that is described by `g`,
+which is a product of the form
+$g_{i_1}^{e_1} g_{i_2}^{e_2} \cdots g_{i_n}^{e_n}$
+where $g_i$ is the $i$-th entry in the defining polycyclic generating sequence
+of $G$ and the $e_i$ are nonzero integers,
+and $R_j =$ `imgs[`$i_j$`]`$^{e_j}$.
+
+# Examples
+```jldoctest
+julia> G = dihedral_group(10)
+Pc group of order 10
+
+julia> x, y = gens(G);  g = x * y^4
+f1*f2^4
+
+julia> map_word(g, gens(free_group(:x, :y)))
+x*y^4
+```
+"""
 function map_word(g::PcGroupElem, genimgs::Vector; genimgs_inv::Vector = Vector(undef, length(genimgs)), init = nothing)
   G = parent(g)
   Ggens = gens(G)
@@ -1890,6 +1913,7 @@ function map_word(g::PcGroupElem, genimgs::Vector; genimgs_inv::Vector = Vector(
   else  # GAP.Globals.IsPcpGroup(G.X)
     l = GAP.Globals.Exponents(gX)
   end
+  @assert length(l) == length(genimgs)
   ll = Pair{Int, Int}[i => l[i] for i in 1:length(l)]
   return map_word(ll, genimgs, genimgs_inv = genimgs_inv, init = init)
 end

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1877,6 +1877,23 @@ function map_word(g::FPGroupElem, genimgs::Vector; genimgs_inv::Vector = Vector(
   return map_word(ll, genimgs, genimgs_inv = genimgs_inv, init = init)
 end
 
+function map_word(g::PcGroupElem, genimgs::Vector; genimgs_inv::Vector = Vector(undef, length(genimgs)), init = nothing)
+  G = parent(g)
+  Ggens = gens(G)
+  if length(Ggens) == 0
+    return init
+  end
+  gX = g.X
+
+  if GAP.Globals.IsPcGroup(G.X)
+    l = GAP.Globals.ExponentsOfPcElement(GAP.Globals.FamilyPcgs(G.X), gX)
+  else  # GAP.Globals.IsPcpGroup(G.X)
+    l = GAP.Globals.Exponents(gX)
+  end
+  ll = Pair{Int, Int}[i => l[i] for i in 1:length(l)]
+  return map_word(ll, genimgs, genimgs_inv = genimgs_inv, init = init)
+end
+
 function map_word(v::Union{Vector{Int}, Vector{Pair{Int, Int}}, Vector{Any}}, genimgs::Vector; genimgs_inv::Vector = Vector(undef, length(genimgs)), init = nothing)
   length(genimgs) == 0 && (@assert length(v) == 0; return init)
   length(v) == 0 && return one(genimgs[1])

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -136,7 +136,7 @@ end
    @test order(q4) == 2
 end
 
-@testset "map_word" begin
+@testset "map_word for f.p. groups" begin
    # Create a free group in GAP in syllable words family,
    # in order to make the tests.
    GAP.Globals.PushOptions(GAP.GapObj(Dict(:FreeGroupFamilyType => GAP.GapObj("syllable"))))
@@ -208,6 +208,22 @@ end
    @test_throws AssertionError map_word([3], [])
    @test_throws AssertionError map_word([-3], [2, 3])
    @test_throws AssertionError map_word([3 => 1], [2, 3])
+end
+
+@testset "map_word for pc groups" begin
+   for G in [ PcGroup(symmetric_group(4)),         # GAP Pc Group
+            # abelian_group(PcGroup, [2, 3, 4]),   # problem with gens vs. pcgs
+              abelian_group(PcGroup, [0, 3, 4]) ]  # GAP Pcp group
+     n = number_of_generators(G)
+     F = free_group(n)
+     for x in [one(G), rand(G)]
+       img = map_word(x, gens(F))
+       @test x == map_word(img, gens(G))
+       invs = Vector(undef, n)
+       img = map_word(x, gens(F), genimgs_inv = invs)
+       @test x == map_word(img, gens(G))
+     end
+   end
 end
 
 @testset "Isomorphic groups" begin


### PR DESCRIPTION
addresses #3468 

There is still a problem with the requirements for `gens` of pc groups (corresponding to the generators of the underlying presentation) and `gens` of abelian groups (corresponding to the given orders of cyclic factors):
`abelian_group([2,3,4])` has 3 generators but the presentation on the GAP side has 4 generators.
Perhaps we have to use GAP's Pcp groups for all such groups (not just for the infinite ones).
