### PR TITLE
Fix `free_group` for `Char` arguments

### DIFF
--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -471,13 +471,23 @@ where the `i`-th generator is printed as `L[i]`.
 
 !!! warning "Note"
     Variables named like the group generators are *not* created by this function.
+
+# Examples
+```jldoctest
+julia> F = free_group(:a, :b)
+Free group of rank 2
+
+julia> w = F[1]^3 * F[2]^F[1] * F[-2]^2
+a^2*b*a*b^-2
+```
 """
 function free_group(n::Int, s::VarName = :f; eltype::Symbol = :letter)
    @req n >= 0 "n must be a non-negative integer"
+   t = s isa Char ? string(s) : s
    if eltype == :syllable
-     G = FPGroup(GAP.Globals.FreeGroup(n, GAP.GapObj(s); FreeGroupFamilyType = GapObj("syllable"))::GapObj)
+     G = FPGroup(GAP.Globals.FreeGroup(n, GAP.GapObj(t); FreeGroupFamilyType = GapObj("syllable"))::GapObj)
    else
-     G = FPGroup(GAP.Globals.FreeGroup(n, GAP.GapObj(s))::GapObj)
+     G = FPGroup(GAP.Globals.FreeGroup(n, GAP.GapObj(t))::GapObj)
    end
    GAP.Globals.SetRankOfFreeGroup(G.X, n)
    return G
@@ -490,12 +500,14 @@ function free_group(L::Vector{<:VarName})
    return G
 end
 
-function free_group(L::VarName...)
-   J = GAP.GapObj(L, recursive = true)
+function free_group(L::Vector{<:Char})
+   J = GAP.GapObj(Symbol.(L), recursive = true)
    G = FPGroup(GAP.Globals.FreeGroup(J)::GapObj)
    GAP.Globals.SetRankOfFreeGroup(G.X, length(J))
    return G
 end
+
+free_group(L::VarName...) = free_group(collect(L))
 
 # FIXME: a function `free_abelian_group` with the same signature is
 # already being defined by Hecke

--- a/test/Groups/constructors.jl
+++ b/test/Groups/constructors.jl
@@ -128,35 +128,22 @@ end
   @test_throws ArgumentError mathieu_group(20)
   @test_throws ArgumentError mathieu_group(25)
 
+  @testset "free_group($args)" for args in [
+          ("x","y"), (:x,:y), ('x','y'),
+          (["x","y"],), ([:x,:y],), (['x','y'],),
+          (2, ), (2, "x"), (2, :x), (2, 'x'),
+      ]
+    F = free_group(args...)
+    @test F isa FPGroup
+    @test_throws InfiniteOrderError{FPGroup} order(F)
+    @test_throws ArgumentError index(F, trivial_subgroup(F)[1])
+    @test_throws MethodError degree(F)
+    @test !is_finite(F)
+    @test !is_abelian(F)
+    @test ngens(F) == 2
+    @test length(gens(F)) == 2
+  end
 
-  F = free_group("x","y")
-  @test F isa FPGroup
-  @test_throws InfiniteOrderError{FPGroup} order(F)
-  @test_throws ArgumentError index(F, trivial_subgroup(F)[1])
-  @test_throws MethodError degree(F)
-  @test !is_finite(F)
-  @test !is_abelian(F)
-
-  F = free_group(:x,:y)
-  @test F isa FPGroup
-  @test_throws InfiniteOrderError{FPGroup} order(F)
-  @test_throws ArgumentError index(F, trivial_subgroup(F)[1])
-  @test_throws MethodError degree(F)
-  @test !is_finite(F)
-  @test !is_abelian(F)
-
-  F = free_group("x",:y)
-  @test F isa FPGroup
-  
-  F = free_group(2)
-  @test F isa FPGroup
-  
-  F = free_group(["x","y"])
-  @test F isa FPGroup
-  
-  F = free_group([:x,:y])
-  @test F isa FPGroup
-  
   F = free_group(3,"y")
   @test F isa FPGroup
   


### PR DESCRIPTION
It used to do this:

    julia> F = free_group('x','y');

    julia> gens(f)
    1-element Vector{FPGroupElem}:
     xy

because for GAP lists of chars are strings and vice versa. The fix is to make sure all variable names get converted into GAP strings, no matter whether they are strings, symbols or chars on the Julia side.