### PR TITLE
add documentation about group libraries

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -133,6 +133,15 @@
   doi           = {10.1016/j.jsc.2012.07.002}
 }
 
+@Misc{BEO23,
+  author        = {Besche, Hans Ulrich and Eick, Bettina and O'Brien, Eamonn},
+  title         = {SmallGrp, The GAP Small Groups Library, Version 1.5.3},
+  note          = {GAP package},
+  year          = {2023},
+  month         = {5},
+  url           = {https://gap-packages.github.io/smallgrp/}
+}
+
 @InProceedings{BES-E-D21,
   author        = {Berthomieu, Jérémy and Eder, Christian and Safey El Din, Mohab},
   title         = {Msolve: A Library for Solving Polynomial Systems},
@@ -1052,6 +1061,15 @@
   year          = {1989}
 }
 
+@Misc{HRR23,
+  author        = {Hulpke, Alexander and Roney-Dougal, Colva and Russell, Christopher},
+  title         = {PrimGrp, GAP Primitive Permutation Groups Library, Version 3.4.4},
+  note          = {GAP package},
+  year          = {2023},
+  month         = {2},
+  url           = {https://gap-packages.github.io/primgrp/}
+}
+
 @Book{Har77,
   author        = {Hartshorne, Robin},
   title         = {Algebraic Geometry},
@@ -1060,6 +1078,25 @@
   pages         = {xvi+496},
   year          = {1977},
   doi           = {10.1007/978-1-4757-3849-0}
+}
+
+@Article{Hul22,
+  author        = {Hulpke, Alexander},
+  title         = {The perfect groups of order up to two million},
+  journal       = {Math. Comp.},
+  volume        = {91},
+  pages         = {1007--1017},
+  year          = {2022},
+  doi           = {10.1090/mcom/3684}
+}
+
+@Misc{Hul23,
+  author        = {Hulpke, Alexander},
+  title         = {TransGrp, Transitive Groups Library, Version 3.6.5},
+  note          = {GAP package},
+  year          = {2023},
+  month         = {12},
+  url           = {https://www.math.colostate.edu/~hulpke/transgrp}
 }
 
 @Book{Hum72,

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -1686,6 +1686,15 @@
   year          = {1997}
 }
 
+@Misc{Pan23,
+  author        = {Pan, Eileen},
+  title         = {SOTGrps, Constructing and identifying groups of small order type, Version 1.2},
+  note          = {GAP package},
+  year          = {2023},
+  month         = {6},
+  url           = {https://gap-packages.github.io/sotgrps/}
+}
+
 @MastersThesis{Peg14,
   author        = {Pegel, Christoph},
   title         = {Chow Rings of Toric Varieties},
@@ -1953,6 +1962,15 @@
   year          = {1987},
   eprint        = {2201.09155},
   primaryclass  = {math.GR}
+}
+
+@Misc{VE22,
+  author        = {Vaughan-Lee, Michael and Eick, Bettina},
+  title         = {SglPPow, Database of groups of prime-power order for some prime-powers, Version 2.3},
+  note          = {GAP package},
+  year          = {2022},
+  month         = {11},
+  url           = {https://gap-packages.github.io/sglppow/}
 }
 
 @MastersThesis{Vol23,

--- a/docs/src/Groups/grouplib.md
+++ b/docs/src/Groups/grouplib.md
@@ -10,10 +10,10 @@ end
 ## Transitive permutation groups of small degree
 
 The functions in this section are wrappers for the GAP library of
-transitive permutation groups up to degree ``48'',
+transitive permutation groups up to degree 48,
 via the GAP package `TransGrp` [Hul23](@cite).
 
-(The groups of degrees ``32'' and ``48'' are currently not automatically
+(The groups of degrees 32 and 48 are currently not automatically
 available in Oscar,
 one has to install additional data in order to access them.)
 
@@ -40,7 +40,7 @@ transitive_group_identification
 ## Primitive permutation groups of small degree
 
 The functions in this section are wrappers for the GAP library of
-primitive permutation groups up to degree ``8191'',
+primitive permutation groups up to degree 8191,
 via the GAP package `PrimGrp` [HRR23](@cite).
 See the documentation of this package for more information about
 the source of the data.
@@ -61,14 +61,14 @@ The functions in this section are wrappers for the GAP library of finite perfect
 groups which provides, up to isomorphism, a list of all perfect groups whose
 sizes are less than $2\cdot 10^6$. The groups of most orders up to $10^6$ have been
 enumerated by Derek Holt and Wilhelm Plesken, see [HP89](@cite). For orders
-$n = 86016$, 368640, or 737280 this work only counted the groups (but did not
-explicitly list them), the groups of orders $n = 61440$, 122880, 172032,
+86016, 368640, or 737280 this work only counted the groups (but did not
+explicitly list them), the groups of orders 61440, 122880, 172032,
 245760, 344064, 491520, 688128, or 983040 were omitted.
 
 Several additional groups omitted from the book [HP89](@cite) have also
 been included. Two groups -- one of order 450000 with a factor group of
-type $A_6$ and the one of order 962280 -- were found by Jack Schmidt in
-2005. Two groups of order 243000 and one each of orders 729000, 871200, 878460
+type $A_6$ and the one of order 962280 -- were found in 2005 by Jack Schmidt.
+Two groups of order 243000 and one each of orders 729000, 871200, 878460
 were found in 2020 by Alexander Hulpke.
 
 The perfect groups of size less than $2\cdot 10^6$ which had not been
@@ -95,9 +95,29 @@ perfect_group_identification
 
 ## Groups of small order
 
-The functions in this section are wrappers for the GAP library of groups
-of order up to 2000 (except those of order 1024),
-via the GAP package `SmallGrp` [BEO23](@cite).
+The functions in this section are wrappers for the GAP library of
+the following groups.
+
+The GAP package `SmallGrp` [BEO23](@cite) provides
+
+- those of order at most 2000 (except those of order 1024),
+- those of cubefree order at most 50000,
+- those of order $p^7$ for the primes $p = 3, 5, 7, 11$,
+- those of order $p^n$ for $n \leq 6$ and all primes $p$,
+- those of order $q^n p$ where $q^n$ divides $2^8$, $3^6$, $5^5$
+  or $7^4$ and $p$ is an arbitrary prime not equal to $q$,
+- those of squarefree order,
+- those whose order factorises into at most 3 primes.
+
+The GAP package `SOTGrps` [Pan23](@cite) provides
+
+- those whose order factorises into at most 4 primes,
+- those of order $p^4 q$ where $p$ and $q$ are distinct primes.
+
+The GAP package `SglPPow` [VE22](@cite)  provides
+
+- those of order $p^7$ for primes $p > 11$,
+- those of order $3^8$.
 
 ```@docs
 all_small_groups

--- a/docs/src/Groups/grouplib.md
+++ b/docs/src/Groups/grouplib.md
@@ -9,9 +9,13 @@ end
 
 ## Transitive permutation groups of small degree
 
-TODO: explain about the scope of this.
+The functions in this section are wrappers for the GAP library of
+transitive permutation groups up to degree ``48'',
+via the GAP package `TransGrp` [Hul23](@cite).
 
-TODO: give proper attribution to the transgrp package (in particular, cite it)
+(The groups of degrees ``32'' and ``48'' are currently not automatically
+available in Oscar,
+one has to install additional data in order to access them.)
 
 The arrangement and the names of the groups of degree up to 15 is the same as given in
 [CHM98](@cite). With the exception of the symmetric and alternating group (which are represented
@@ -35,9 +39,11 @@ transitive_group_identification
 
 ## Primitive permutation groups of small degree
 
-TODO: explain about the scope of this.
-
-TODO: give proper attribution to the primitive groups library (in particular, cite it)
+The functions in this section are wrappers for the GAP library of
+primitive permutation groups up to degree ``8191'',
+via the GAP package `PrimGrp` [HRR23](@cite).
+See the documentation of this package for more information about
+the source of the data.
 
 ```@docs
 all_primitive_groups
@@ -67,7 +73,8 @@ were found in 2020 by Alexander Hulpke.
 
 The perfect groups of size less than $2\cdot 10^6$ which had not been
 classified in the work of Holt and Plesken have been enumerated by Alexander
-Hulpke. They are stored directly and provide less construction information
+Hulpke, see [Hul22](@cite).
+They are stored directly and provide less construction information
 in their names.
 
 As all groups are stored by presentations, a permutation representation
@@ -88,9 +95,9 @@ perfect_group_identification
 
 ## Groups of small order
 
-TODO: explain about the scope of this.
-
-TODO: give proper attribution to the smallgrp package and other things used (in particular, cite it)
+The functions in this section are wrappers for the GAP library of groups
+of order up to 2000 (except those of order 1024),
+via the GAP package `SmallGrp` [BEO23](@cite).
 
 ```@docs
 all_small_groups


### PR DESCRIPTION
The additions were guided by the corresponding descriptions in the Groups chapter of the Oscar book.

(Note that currently the GAP packages `SOTGrps` and `SglPPow` that are mentioned in the book as extensions of the Small Groups Library are actually not loaded into Oscar.)