### PR TITLE
Add `is_conjugate*` to `docs/src/Groups/action.md`

### DIFF
--- a/docs/src/Groups/action.md
+++ b/docs/src/Groups/action.md
@@ -61,6 +61,8 @@ permutation
 acting_group(Omega::GSetByElements)
 action_function(Omega::GSetByElements)
 action_homomorphism(Omega::GSetByElements{T}) where T<:GAPGroup
+is_conjugate(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)
+is_conjugate_with_data(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)
 orbit(Omega::GSetByElements{<:GAPGroup}, omega::T) where T
 orbit(G::PermGroup, omega)
 orbits(Omega::T) where T <: GSetByElements{TG} where TG <: GAPGroup

--- a/docs/src/Groups/action.md
+++ b/docs/src/Groups/action.md
@@ -61,8 +61,8 @@ permutation
 acting_group(Omega::GSetByElements)
 action_function(Omega::GSetByElements)
 action_homomorphism(Omega::GSetByElements{T}) where T<:GAPGroup
-is_conjugate(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)
-is_conjugate_with_data(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)
+is_conjugate(Omega::GSet, omega1, omega2)
+is_conjugate_with_data(Omega::GSet, omega1, omega2)
 orbit(Omega::GSetByElements{<:GAPGroup}, omega::T) where T
 orbit(G::PermGroup, omega)
 orbits(Omega::T) where T <: GSetByElements{TG} where TG <: GAPGroup


### PR DESCRIPTION
Closes #3454 

Simple oversight, these docstrings belong here.

@benlorenz I think should be backported also.