### PR TITLE
Add `cycles` for `PermGroupElem`

### DIFF
--- a/docs/src/Groups/permgroup.md
+++ b/docs/src/Groups/permgroup.md
@@ -89,6 +89,7 @@ sign(g::PermGroupElem)
 isodd(g::PermGroupElem)
 iseven(g::PermGroupElem)
 cycle_structure(g::PermGroupElem)
+cycles(g::PermGroupElem)
 ```
 
 ## Permutations as functions

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -642,7 +642,8 @@ end
 @doc raw"""
     cycles(g::PermGroupElem)
 
-Return the cycles of the permutation `g` as a list of integer vectors.
+Return all cycles (including trivial ones) of the permutation `g` as
+a sorted list of integer vectors.
 
 # Examples
 ```jldoctest

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -639,6 +639,42 @@ function cycle_structures(G::PermGroup)
   return Set(cycle_structure(x) for x in r)
 end
 
+@doc raw"""
+    cycles(g::PermGroupElem)
+
+Return the cycles of the permutation `g` as a list of integer vectors.
+
+# Examples
+```jldoctest
+julia> g = cperm(1:3, 6:7, 8:10, 11:15)
+(1,2,3)(6,7)(8,9,10)(11,12,13,14,15)
+
+julia> cycles(g)
+6-element Vector{Vector{Int64}}:
+ [1, 2, 3]
+ [4]
+ [5]
+ [6, 7]
+ [8, 9, 10]
+ [11, 12, 13, 14, 15]
+
+julia> g = cperm()
+()
+
+julia> cycles(g)
+1-element Vector{Vector{Int64}}:
+ [1]
+```
+"""
+function cycles(g::PermGroupElem)
+  ccycles, cptrs = AbstractAlgebra.Generic.cycledec(Vector(g))
+
+  cycles = Vector{Vector{Int}}(undef, length(cptrs) - 1)
+  for i in 1:length(cptrs) - 1
+    cycles[i] = ccycles[cptrs[i]:cptrs[i + 1] - 1]
+  end
+  return cycles
+end
 
 ################################################################################
 #

--- a/test/Groups/Permutations.jl
+++ b/test/Groups/Permutations.jl
@@ -168,4 +168,14 @@ end
       @test isodd(g) == isodd(c)
     end
   end
+
+  @testset "cycles" begin
+    g = cperm(1:3, 4:5, 6:7, 8:10, 11:15)
+    c = cycle_structure(g)
+    cc = cycles(g)
+    for i in 1:length(c)
+      @test length(filter(x -> length(x) == c[i][1], cc)) == c[i][2]
+    end
+    @test cc == [[1, 2, 3], [4, 5], [6, 7], [8, 9, 10], [11, 12, 13, 14, 15]]
+  end
 end


### PR DESCRIPTION
A function `cycles` is requested for `PermGroupElem` in https://github.com/oscar-system/Oscar.jl/pull/3439#discussion_r1515993975 . Here is an easy implementation of this by calling the AbstractAlgebra function `cycledec`. I find this a bit weird since the element must know its cycles on the GAP side; after all it prints as a cycle decomposition. I didn't find out how to access this piece of information directly though.

AbstractAlgebra also has a fancy iterator type for the cycles. I don't see a reason for this (other than nicer printing maybe?).
