### PR TITLE
load the GAP packages sotgrps and sglppow (extensions of the library of small groups)

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -107,6 +107,8 @@ function __init__()
   # We want some GAP packages. (It is no error if they cannot be loaded.)
   for pkg in [
      "ferret",   # backtrack in permutation groups
+     "sotgrps",  # extend the small groups library
+     "sglppow",  # extend the small groups library
      ]
     GAP.Packages.load(pkg)
   end


### PR DESCRIPTION
This was intended to belong to pull request #3478, which got merged before commit 9cec252 "arrived".

As soon as the GAP fix from gap-system/gap/pull/5666 becomes available, loading the two GAP packages will not cause strange error messages when leaving Julia.