### PR TITLE
Fix for normal form computation using F4

### DIFF
--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1048,7 +1048,7 @@ function _normal_form_f4(A::Vector{T}, J::MPolyIdeal) where { T <: MPolyRingElem
   end
 
   AJ = AlgebraicSolving.Ideal(J.gens.O)
-  AJ.gb[0] = J.gb[degrevlex(base_ring(J))].gens.O
+  AJ.gb[0] = oscar_groebner_generators(J, degrevlex(base_ring(J)), true)
   
   return AlgebraicSolving.normal_form(A, AJ)
 end

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -56,6 +56,12 @@ function groebner_assure(I::MPolyIdeal, ordering::MonomialOrdering, complete_red
     end
 end
 
+function oscar_groebner_generators(I::MPolyIdeal, ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool = false)
+  standard_basis(I, ordering=ordering, complete_reduction = complete_reduction)
+  oscar_assure(I.gb[ordering])
+  return I.gb[ordering].gens.O
+end
+
 function singular_groebner_generators(I::MPolyIdeal, ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool = false)
   standard_basis(I, ordering=ordering, complete_reduction = complete_reduction)
   return singular_generators(I.gb[ordering], ordering)

--- a/test/Rings/groebner.jl
+++ b/test/Rings/groebner.jl
@@ -13,7 +13,7 @@
     @test leading_ideal(I, ordering=lex(gens(R))) == ideal(R,[y^7, x*y^2, x^3])
     R, (x, y) = polynomial_ring(GF(5), ["x", "y"])
     I = ideal(R, [x])
-    gb = groebner_basis_f4(I)
+    gb = groebner_basis(I)
     @test normal_form(y, I) == y
     @test Oscar._normal_form_singular([y], I, degrevlex(R)) == [y]
     @test Oscar._normal_form_f4([y], I) == [y]


### PR DESCRIPTION
Fixes #3522: Ensures the existence of the Oscar side of a precomputed Gröbner basis.