### PR TITLE
Handle empty charts for subschemes of ideal sheaves

### DIFF
--- a/experimental/Schemes/IdealSheaves.jl
+++ b/experimental/Schemes/IdealSheaves.jl
@@ -333,33 +333,28 @@ end
 For an ideal sheaf ``ℐ`` on an `AbsCoveredScheme` ``X`` return
 the subscheme ``Y ⊂ X`` given by the zero locus of ``ℐ``.
 """
-function subscheme(I::AbsIdealSheaf)
+function subscheme(I::AbsIdealSheaf; covering::Covering=default_covering(scheme(I)))
   X = space(I)
-  C = default_covering(X)
-  new_patches = [subscheme(U, I(U)) for U in basic_patches(C)]
+  C = covering
+  new_patches = IdDict{AbsAffineScheme, AbsAffineScheme}([U=>subscheme(U, I(U)) for U in basic_patches(C) if !isone(I(U))])
   new_gluings = IdDict{Tuple{AbsAffineScheme, AbsAffineScheme}, AbsGluing}()
   decomp_dict = IdDict{AbsAffineScheme, Vector{RingElem}}()
-  for (U, V) in keys(gluings(C))
-    i = C[U]
-    j = C[V]
-    Unew = new_patches[i]
-    Vnew = new_patches[j]
-    G = C[U, V]
-    #new_gluings[(Unew, Vnew)] = restrict(C[U, V], Unew, Vnew, check=false)
-    new_gluings[(Unew, Vnew)] = LazyGluing(Unew, Vnew, _compute_restriction,
+  for (U, Unew) in new_patches
+    for (V, Vnew) in new_patches
+      (U, V) in keys(gluings(C)) || continue # No gluing before, no gluing after.
+      old_glue = C[U, V]
+      new_gluings[(Unew, Vnew)] = LazyGluing(Unew, Vnew, _compute_restriction,
                                              RestrictionDataClosedEmbedding(C[U, V], Unew, Vnew)
                                             )
-    #new_gluings[(Vnew, Unew)] = inverse(new_gluings[(Unew, Vnew)])
-    new_gluings[(Vnew, Unew)] = LazyGluing(Vnew, Unew, inverse, new_gluings[(Unew, Vnew)])
+      #new_gluings[(Vnew, Unew)] = LazyGluing(Vnew, Unew, inverse, new_gluings[(Unew, Vnew)])
+    end
   end
-  Cnew = Covering(new_patches, new_gluings, check=false)
+  Cnew = Covering(collect(values(new_patches)), new_gluings, check=false)
 
   # Inherit decomposition information if applicable
   if has_decomposition_info(C)
-    for k in 1:length(new_patches)
-      U = new_patches[k]
-      V = basic_patches(C)[k]
-      set_decomposition_info!(Cnew, U, elem_type(OO(U))[OO(U)(a, check=false) for a in decomposition_info(C)[V]])
+    for (U, V) in new_patches
+      set_decomposition_info!(Cnew, V, elem_type(OO(V))[OO(V)(a, check=false) for a in decomposition_info(C)[U]])
     end
   end
   return CoveredScheme(Cnew)

--- a/experimental/Schemes/IdealSheaves.jl
+++ b/experimental/Schemes/IdealSheaves.jl
@@ -1618,3 +1618,11 @@ function produce_object(I::PullbackIdealSheaf, U::AbsAffineScheme)
   # Infer the ideal from the root
   return OO(X)(V, U)(I(V))
 end
+
+function sub(I::AbsIdealSheaf)
+  X = scheme(I)
+  inc = CoveredClosedEmbedding(X, I)
+  return domain(inc), inc
+end
+
+

--- a/test/AlgebraicGeometry/Schemes/IdealSheaves.jl
+++ b/test/AlgebraicGeometry/Schemes/IdealSheaves.jl
@@ -196,3 +196,23 @@ end
   JJ = pushforward(bl, E)
   @test JJ == II
 end
+
+@testset "subschemes of ideal sheaves" begin
+  IP2 = projective_space(QQ, [:x, :y, :z])
+
+  X = covered_scheme(IP2)
+  S = homogeneous_coordinate_ring(IP2)
+  x, y, z = gens(S)
+  I = ideal(S, [x*y, x*z, y*z])
+  II = IdealSheaf(IP2, I)
+  H = IdealSheaf(IP2, ideal(S, z))
+  Y = subscheme(II + H)
+  U = affine_charts(Y)
+  @test length(U) == 2
+  f, g = glueing_morphisms(Y[1][U[1], U[2]])
+  A = domain(f)
+  B = domain(g)
+  @test isempty(A)
+  @test isempty(B)
+end
+

--- a/test/AlgebraicGeometry/Schemes/WeilDivisor.jl
+++ b/test/AlgebraicGeometry/Schemes/WeilDivisor.jl
@@ -93,8 +93,8 @@
   phi = K(-8*t^8 + 4*t^7 + 6*t^5 + 4*x*t^3 + 3*t^4 - 13*x*t^2 - 7*y*t^2 - 12*t^3 - 12*x*t + 12*y*t - 14*t^2 - 14*x - y - 10*t + 10)//K(6*t^8 - 5*t^7 + 14*t^6 - 7*x*t^4 - 13*t^5 - 5*x*t^3 - 6*x*t^2 - 5*t^3 - 9*x*t - 10*t^2 + 4*x - 8*t + 4)
   @test Oscar.order_on_divisor(phi, D, check=false) == -1
 
-  (x,z,t) = coordinates(adeK3[1][2])
-  o = weil_divisor(ideal_sheaf(adeK3, adeK3[1][2], [z,x]), check=false)
+  (x,z,t) = coordinates(adeK3[1][1])
+  o = weil_divisor(ideal_sheaf(adeK3, adeK3[1][1], [z,x]), check=false)
   @test order_on_divisor(K(z), o, check=false) == 3
   @test order_on_divisor(K(x), o, check=false) == 1
 end

--- a/test/AlgebraicGeometry/Schemes/WeilDivisor.jl
+++ b/test/AlgebraicGeometry/Schemes/WeilDivisor.jl
@@ -76,25 +76,27 @@
   x, y, t = coordinates(Ut)
   ft = y^2 - (x^3 + 21*x + (28*t^7+18))
   I = IdealSheaf(X, Ut, [ft])
-  adeK3 = subscheme(I)
+  adeK3, inc_adeK3 = sub(I)
   @test dim(singular_locus(adeK3)[1]) == 0
 
-  x,y,t = coordinates(adeK3[1][6])
+  weier_chart = first([U for U in affine_charts(adeK3) if codomain(covering_morphism(inc_adeK3)[U]) === X[1][6]]) # Order of charts is random due to use of dictionaries in the constructor
+  x,y,t = coordinates(weier_chart)
   # ideal defining a section of the fibration
   P = [(5*t^8 + 20*t^7 + 2*t^6 + 23*t^5 + 20*t^3 + 11*t^2 + 3*t + 13) - x*(t^4 + 9*t^3 + 5*t^2 + 22*t + 16),
   (26*t^12 + 11*t^11 + 15*t^10 + 8*t^9 + 20*t^8 + 25*t^7 + 16*t^6 + 3*t^5 + 10*t^4 + 15*t^3 + 4*t^2 + 28*t + 28) - y*(t^6 + 28*t^5 + 27*t^4 + 23*t^3 + 8*t^2 + 13*t + 23)]
   # the following computation dies ... but it should not.
-  D = IdealSheaf(adeK3, adeK3[1][6], P)
-  Dscheme = subscheme(D)
+  D = IdealSheaf(adeK3, weier_chart, P)
+  Dscheme, inc_Dscheme = sub(D)
 
   # an interesting rational function
   K = function_field(adeK3)
-  x,y,t= ambient_coordinates(adeK3[1][6])
+  x,y,t= ambient_coordinates(weier_chart)
   phi = K(-8*t^8 + 4*t^7 + 6*t^5 + 4*x*t^3 + 3*t^4 - 13*x*t^2 - 7*y*t^2 - 12*t^3 - 12*x*t + 12*y*t - 14*t^2 - 14*x - y - 10*t + 10)//K(6*t^8 - 5*t^7 + 14*t^6 - 7*x*t^4 - 13*t^5 - 5*x*t^3 - 6*x*t^2 - 5*t^3 - 9*x*t - 10*t^2 + 4*x - 8*t + 4)
   @test Oscar.order_on_divisor(phi, D, check=false) == -1
 
-  (x,z,t) = coordinates(adeK3[1][1])
-  o = weil_divisor(ideal_sheaf(adeK3, adeK3[1][1], [z,x]), check=false)
+  other_chart = first([U for U in affine_charts(adeK3) if codomain(covering_morphism(inc_adeK3)[U]) === X[1][2]]) # Order of charts is random due to use of dictionaries in the constructor
+  (x,z,t) = coordinates(other_chart)
+  o = weil_divisor(ideal_sheaf(adeK3, other_chart, [z,x]), check=false)
   @test order_on_divisor(K(z), o, check=false) == 3
   @test order_on_divisor(K(x), o, check=false) == 1
 end


### PR DESCRIPTION
As was pointed out by @afkafkafk13 in #3494, the constructor for subschemes from ideal sheaves had some deficiencies. This should be ruled out with this fix. 