### PR TITLE
add a remark to the docstring of `iso_oscar_gap`

### DIFF
--- a/src/GAP/iso_oscar_gap.jl
+++ b/src/GAP/iso_oscar_gap.jl
@@ -456,6 +456,15 @@ true
     of `Oscar.iso_gap_oscar(S)`,
     but that the codomain of this map is not identical with
     or even not equal to the given `R`.
+
+    Note also that `R` and `S` may differ w.r.t. some structural properties
+    because GAP does not support all kinds of constructions that are
+    possible in Oscar.
+    For example, if `R` is a non-simple number field then `S` will be a
+    simple extension because GAP knows only simple field extensions.
+    Thus using `Oscar.iso_oscar_gap(R)` for objects `R` whose recursive
+    structure is not fully supported in GAP will likely cause overhead
+    at runtime.
 """
 @attr Map function iso_oscar_gap(F)
    return _iso_oscar_gap(F)


### PR DESCRIPTION
as announced in the discussion of issue #2534