### PR TITLE
Add `is_finite_dimensional_vector_space`

### DIFF
--- a/docs/src/CommutativeAlgebra/affine_algebras.md
+++ b/docs/src/CommutativeAlgebra/affine_algebras.md
@@ -116,6 +116,7 @@ dim(A::MPolyQuoRing)
 ```
 
 ```@docs
+is_finite_dimensional_vector_space(A::MPolyQuoRing)
 vector_space_dimension(A::MPolyQuoRing)
 ```
 

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -1740,6 +1740,14 @@ function vector_space_dimension(R::MPolyQuoLocRing{<:Field, <:Any,<:Any, <:Any,
   return vector_space_dimension(quo(base_ring(R),ideal(base_ring(R),gens(LI)))[1])
 end
 
+function is_finite_dimensional_vector_space(R::MPolyQuoLocRing)
+  throw(NotImplementedError(:is_finite_dimensional_vector_space, R))
+end
+
+function is_finite_dimensional_vector_space(R::MPAnyNonQuoRing)
+  return false
+end
+
 ### Conversion of ideals in the original ring to localized ideals
 function (W::MPolyQuoLocRing{BRT, BRET, RT, RET, MST})(I::MPolyIdeal{RET}) where {BRT, BRET, RT, RET, MST}
   return MPolyQuoLocalizedIdeal(W, W.(gens(I)))

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -84,6 +84,7 @@ export Hecke
 export HilbertData
 export Hyperplane
 export IncidenceMatrix
+export InfiniteDimensionError
 export K3Chamber
 export K3_surface_automorphism_group
 export LazyPoly
@@ -757,6 +758,7 @@ export is_fano
 export is_feasible
 export is_finalized
 export is_finite, has_is_finite, set_is_finite
+export is_finite_dimensional_vector_space
 export is_finitely_generated, has_is_finitely_generated, set_is_finitely_generated
 export is_finiteorder
 export is_flat

--- a/test/AlgebraicGeometry/Curves/AffinePlaneCurve.jl
+++ b/test/AlgebraicGeometry/Curves/AffinePlaneCurve.jl
@@ -55,7 +55,7 @@
       Q = F([0, -2])
 
       @test intersection_multiplicity(F, G, Q) == 1
-      @test_throws ArgumentError intersection_multiplicity(F, G, P)
+      @test_throws InfiniteDimensionError intersection_multiplicity(F, G, P)
   end
 
   @testset "singularity functions" begin

--- a/test/Rings/mpoly_affine_algebras.jl
+++ b/test/Rings/mpoly_affine_algebras.jl
@@ -87,9 +87,12 @@ end
 
 @testset "mpoly_affine_algebra.vector_space_dimension" begin
   r, (x, y) = polynomial_ring(QQ, [:x, :y])
-  @test_throws ArgumentError vector_space_dimension(quo(r, ideal(r, [x^2+y^2]))[1])
+  @test !is_finite_dimensional_vector_space(quo(r, ideal(r, [x^2+y^2]))[1])
+  @test_throws InfiniteDimensionError vector_space_dimension(quo(r, ideal(r, [x^2+y^2]))[1])
   @test vector_space_dimension(quo(r, ideal(r, [x^2+y^2, x^2-y^2]))[1]) == 4
+  @test is_finite_dimensional_vector_space(quo(r, ideal(r, [x^2+y^2, x^2-y^2]))[1])
   @test vector_space_dimension(quo(r, ideal(r, [one(r)]))[1]) == 0
+  @test is_finite_dimensional_vector_space(quo(r, ideal(r, [one(r)]))[1])
 
   r, (x, y) = polynomial_ring(ZZ, [:x, :y])
   @test_throws ErrorException vector_space_dimension(quo(r, ideal(r, [x, y]))[1])

--- a/test/Rings/mpoly_affine_algebras.jl
+++ b/test/Rings/mpoly_affine_algebras.jl
@@ -94,6 +94,8 @@ end
   @test vector_space_dimension(quo(r, ideal(r, [one(r)]))[1]) == 0
   @test is_finite_dimensional_vector_space(quo(r, ideal(r, [one(r)]))[1])
 
+  @test !is_finite_dimensional_vector_space(r)
+
   r, (x, y) = polynomial_ring(ZZ, [:x, :y])
   @test_throws ErrorException vector_space_dimension(quo(r, ideal(r, [x, y]))[1])
 end


### PR DESCRIPTION
Resolves #3510.

Implements what I believe to be the result of the discussion in #3510: A function `is_finite_dimensional_vector_space(::MPolyQuoRing)` is added and `vector_space_dimension` now throws an error of type `InfiniteDimensionError` if the dimension is infinite.

For completeness: `vector_space_dimension` also exists for certain localized rings and modules. In theory, we could/should add `is_finite_dimensional_vector_space` also for those, but it seems to me that in those cases `is_finite_dimensional_vector_space` would do some non-trivial computations which have to be repeated by `vector_space_dimension`.
