### PR TITLE
for issue #3488 -- avoid corruption of internal ideal data

### DIFF
--- a/src/Rings/mpoly-affine-algebras.jl
+++ b/src/Rings/mpoly-affine-algebras.jl
@@ -1302,11 +1302,13 @@ function _conv_normalize_alg(algorithm::Symbol)
 end
 
 function _conv_normalize_data(A::MPolyQuoRing, l, br)
+# Note: The ugly construction of newAmap is due to the need to avoid
+# inheriting corrupted internal data of the ideal
   return [
     begin
       newSR = l[1][i][1]::Singular.PolyRing
       newOR, _ = polynomial_ring(br, [string(x) for x in gens(newSR)])
-      newA, newAmap = quo(newOR, ideal(newOR, l[1][i][2][:norid]))
+      newA, newAmap = quo(newOR, ideal(newOR, newOR.(gens(l[1][i][2][:norid]))))
       set_attribute!(newA, :is_normal=>true)
       newgens = newOR.(gens(l[1][i][2][:normap]))
       _hom = hom(A, newA, newA.(newgens))

--- a/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
+++ b/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
@@ -416,4 +416,12 @@ end
   N3 = normalization(X3)
   @test all(is_smooth(i[1]) for i in N3)
   @test length(N3) == 2
+
+  # data corruption bug, throws an error if bug reappears
+  P,(a,b) = polynomial_ring(QQ,[:a,:b])
+  I = ideal(P,a^2-b)
+  Q = normalization(quo(P,I)[1])[1][1]
+  R = base_ring(Q)
+  J = ideal(R, R[1])
+  Sat = saturation(modulus(Q),J)
 end


### PR DESCRIPTION
#3488  is due to inheriting internal data in a corner case in src/Rings/mpoly-affine-algebras.jl.
This is a workaround avoiding corruption by forcing creation of a new object. 