### PR TITLE
Remove unnecessary doctest filter

### DIFF
--- a/src/Rings/FreeAssAlgIdeal.jl
+++ b/src/Rings/FreeAssAlgIdeal.jl
@@ -82,7 +82,7 @@ Returns `true` if intermediate degree calculations bounded by `deg_bound` prove 
 Otherwise, returning `false` indicates an inconclusive answer, but larger `deg_bound`s give more confidence in a negative answer. 
 If `deg_bound` is not specified, the default value is `-1`, which means that no degree bound is imposed,
 resulting in a calculation using a much slower algorithm that may not terminate, but will return a full Groebner basis if it does.
-```jldoctest; filter = r"(coeff \d+ already initialized\n|)"s
+```jldoctest
 julia> free, (x,y,z) = free_associative_algebra(QQ, ["x", "y", "z"]);
 
 julia> f1 = x*y + y*z;
@@ -136,7 +136,7 @@ _to_lpring(a::FreeAssAlgebra, deg_bound::Int) = Singular.FreeAlgebra(base_ring(a
     groebner_basis(I::FreeAssAlgIdeal, deg_bound::Int=-1; protocol::Bool=false)
 
 Return the Groebner basis of `I` with respect to the degree bound `deg_bound`. If `protocol` is `true`, the protocol of the computation is also returned. The default value of `deg_bound` is `-1`, which means that no degree bound is imposed, which leads to a computation that uses a much slower algorithm, that may not terminate, but returns a full groebner basis if it does.
-```jldoctest; filter = r"(coeff \d+ already initialized\n|)"s
+```jldoctest
 julia> free, (x,y,z) = free_associative_algebra(QQ, ["x", "y", "z"]);
 
 julia> f1 = x*y + y*z;

--- a/src/Rings/binomial_ideals.jl
+++ b/src/Rings/binomial_ideals.jl
@@ -672,7 +672,7 @@ Given a cellular binomial ideal `I`, return the associated primes of `I`.
 The result is defined over the abelian closure of $\mathbb Q$. In the output, if needed, the generator for roots of unities is denoted by `zeta`. So `zeta(3)`, for example, stands for a primitive third root of unity.
 
 # Examples
-```jldoctest; filter = r"(coeff \d+ already initialized\n|)"
+```jldoctest
 julia> R, x = polynomial_ring(QQ, "x" => 1:6)
 (Multivariate polynomial ring in 6 variables over QQ, QQMPolyRingElem[x[1], x[2], x[3], x[4], x[5], x[6]])
 
@@ -919,7 +919,7 @@ The result is defined over the abelian closure of $\mathbb Q$. In the output, if
 
 
 # Examples
-```jldoctest; filter = r"(coeff \d+ already initialized\n|)"s
+```jldoctest
 julia> R, (x,y,z) =  polynomial_ring(QQ, ["x", "y", "z"])
 (Multivariate polynomial ring in 3 variables over QQ, QQMPolyRingElem[x, y, z])
 


### PR DESCRIPTION
These are supposed to be unnecessary with the newest Singular.

CC @lkastner
