### PR TITLE
TropicalGeometry: fixed typo in documentation

### DIFF
--- a/src/TropicalGeometry/variety.jl
+++ b/src/TropicalGeometry/variety.jl
@@ -143,7 +143,7 @@ If `skip_saturation==true`, will not saturate `I` with respect to the product of
 If `skip_primary_decomposition==true`, will not decompose `I`.
 
 !!! warning
-    `tropical_variety` is currently under development and only works for ideal that primary decompose into
+    `tropical_variety` is currently under development and only works for ideals that primary decompose into
     principal, linear, and binomial ideals.
 
 # Examples

--- a/src/TropicalGeometry/variety.jl
+++ b/src/TropicalGeometry/variety.jl
@@ -143,8 +143,8 @@ If `skip_saturation==true`, will not saturate `I` with respect to the product of
 If `skip_primary_decomposition==true`, will not decompose `I`.
 
 !!! warning
-    `tropical_variety` is currently under development and only works for ideal that decompose into
-    primary ideals, linear ideals, and binomial ideals.
+    `tropical_variety` is currently under development and only works for ideal that primary decompose into
+    principal, linear, and binomial ideals.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Fixed a typo in documentation where primary ideals should be principal ideals.

Found by @VictoriaSchleis.