### PR TITLE
Add check to NoExperimental whitelist to being current

### DIFF
--- a/experimental/Experimental.jl
+++ b/experimental/Experimental.jl
@@ -31,6 +31,7 @@ include_dependency(".")
 isfile(joinpath(expdir, "NoExperimental_whitelist_.jl")) || error("experimental/NoExperimental_whitelist_.jl is missing")
 if islink(joinpath(expdir, "NoExperimental_whitelist.jl"))
   include(joinpath(expdir, "NoExperimental_whitelist.jl"))
+  issubset(whitelist, union(exppkgs, oldexppkgs)) || error("experimental/NoExperimental_whitelist.jl contains unknown packages")
   filter!(in(whitelist), exppkgs)
   filter!(in(whitelist), oldexppkgs)
 end


### PR DESCRIPTION
I forgot to remove `Rings` from there in https://github.com/oscar-system/Oscar.jl/pull/3551 before. This simple test seems to be a suitable measure against the rotting of ancient entries in the whitelist.