### PR TITLE
`is_finiteorder` -> `is_finite_order`

### DIFF
--- a/docs/src/Groups/basics.md
+++ b/docs/src/Groups/basics.md
@@ -17,7 +17,7 @@ BasicGAPGroupElem{T<:GAPGroup}
 elem_type(::Type{T}) where T <: GAPGroup
 one(x::GAPGroup)
 one(x::GAPGroupElem)
-is_finiteorder(x::GAPGroupElem)
+is_finite_order(x::GAPGroupElem)
 gens(::GAPGroup)
 has_gens(::GAPGroup)
 number_of_generators(G::GAPGroup)

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -75,21 +75,21 @@ false
 # Base.is_finite(G::PcGroup) = true
 
 """
-    is_finiteorder(g::GAPGroupElem) -> Bool
+    is_finite_order(g::GAPGroupElem) -> Bool
 
 Return `true` if `g` has finite order, and `false` otherwise.
 
 # Examples
 ```jldoctest
-julia> is_finiteorder(gen(symmetric_group(5), 1))
+julia> is_finite_order(gen(symmetric_group(5), 1))
 true
 
-julia> is_finiteorder(gen(free_group(2), 1))
+julia> is_finite_order(gen(free_group(2), 1))
 false
 
 ```
 """
-is_finiteorder(x::GAPGroupElem) = GAPWrap.IsInt(GAPWrap.Order(x.X))
+is_finite_order(x::GAPGroupElem) = GAPWrap.IsInt(GAPWrap.Order(x.X))
 
 
 """
@@ -103,7 +103,7 @@ For a group `x`, the order of `x` is the number of elements in `x`.
 
 An exception is thrown if the order of `x` is infinite,
 use [`is_finite`](@ref) for checking the finiteness of a group,
-and [`is_finiteorder`](@ref) for checking whether a group element
+and [`is_finite_order`](@ref) for checking whether a group element
 has finite order.
 
 # Examples
@@ -121,7 +121,7 @@ julia> g = free_group(1);
 julia> is_finite(g)
 false
 
-julia> is_finiteorder(gen(g, 1))
+julia> is_finite_order(gen(g, 1))
 false
 ```
 """

--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -20,7 +20,7 @@ is_element(x::FinGenAbGroupElem, G::FinGenAbGroup) = issubset(sub([x])[1], G)
 
 _coeff(x::FinGenAbGroupElem) = x.coeff
 
-function is_finiteorder(a::FinGenAbGroupElem)
+function is_finite_order(a::FinGenAbGroupElem)
   G, m = snf(a.parent)
   b = preimage(m, a)
   return any(i -> iszero(G.snf[i]) && !iszero(b[i]), 1:ngens(G))

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -760,7 +760,7 @@ export is_finalized
 export is_finite, has_is_finite, set_is_finite
 export is_finite_dimensional_vector_space
 export is_finitely_generated, has_is_finitely_generated, set_is_finitely_generated
-export is_finiteorder
+export is_finite_order
 export is_flat
 export is_full_direct_product
 export is_full_fp_group

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -85,7 +85,7 @@ import AbstractAlgebra:
   has_gens,
   Ideal,
   Indent,
-  is_finiteorder,
+  is_finite_order,
   is_trivial,
   is_unicode_allowed,
   Lowercase,

--- a/test/Groups/elements.jl
+++ b/test/Groups/elements.jl
@@ -11,7 +11,7 @@
     @test typeof(Vector(y))==Vector{Int64}
     @test typeof(Vector{ZZRingElem}(y))==Vector{ZZRingElem}
     @test x==G(Vector(x))
-    @test is_finiteorder(x)
+    @test is_finite_order(x)
     @test order(x) == lcm(15,n-8)
     for T in [Int, BigInt, ZZRingElem]
       @test order(T, x) == lcm(15,n-8)


### PR DESCRIPTION
Follow-up to https://github.com/Nemocas/AbstractAlgebra.jl/pull/1639. The old name is still available via an alias in AbstractAlgebra.
