### PR TITLE
Fix precompilation issue

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 cohomCalg_jll = "5558cf25-a90e-53b0-b813-cadaa3ae7ade"
 
 [compat]
-AbstractAlgebra = "0.40.1"
+AbstractAlgebra = "0.40.6"
 AlgebraicSolving = "0.4.11"
 Distributed = "1.6"
 DocStringExtensions = "0.8, 0.9"

--- a/src/Rings/mpoly-affine-algebras.jl
+++ b/src/Rings/mpoly-affine-algebras.jl
@@ -282,7 +282,6 @@ end
 
 # TODO: The method below is missing. It should be made better and put to the correct place (AA).
 number_of_generators(S::AbstractAlgebra.Generic.LaurentPolyWrapRing) = 1
-number_of_generators(P::PolyRing) = 1
 
 
 @doc raw"""


### PR DESCRIPTION
introduced in the AA 0.40.6 release.
fixes the issue observed by @HereAround in https://github.com/oscar-system/Oscar.jl/pull/3363#issuecomment-2039811661
As the release-1.0 branch uses this AA version as well, this should get backported.