### PR TITLE
Remove outdated printing code

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -1,35 +1,3 @@
-if !isdefined(AbstractAlgebra, Symbol("@enable_all_show_via_expressify"))
-
-# Only when AbstractAlgebra.expressify(a::T; context = nothing) has been
-# defined may these be used.
-# AA defines Base.show for "text/latex" and "text/html" for a general set
-# of x, but for backward compatibility it is not defined for general x and
-# "text/plain" or the mime-less version.
-# Rationale: when neither Base.show nor AA.expressify is defined for T, then,
-# since expressify calls Base.show for backward compatibility, a definition of
-# Base.show in terms of expressify would give a stack overflow.
-
-macro enable_all_show_via_expressify(T)
-  return quote
-    function Base.show(io::IO, x::$(esc(T)))
-       AbstractAlgebra.show_via_expressify(io, x)
-    end
-
-    function Base.show(io::IO, mi::MIME"text/plain", x::$(esc(T)))
-       AbstractAlgebra.show_via_expressify(io, mi, x)
-    end
-
-    function Base.show(io::IO, mi::MIME"text/latex", x::$(esc(T)))
-       AbstractAlgebra.show_via_expressify(io, mi, x)
-    end
-
-    function Base.show(io::IO, mi::MIME"text/html", x::$(esc(T)))
-       AbstractAlgebra.show_via_expressify(io, mi, x)
-    end
-  end
-end
-end
-
 # Several interfaces (expressify, iteration, ...) require a single object. Use
 # OscarPair as an easy way to pass multiple objects without creating an official
 # type for the combinations: polynomial + ordering, old iter + new iter, ...


### PR DESCRIPTION
This is no longer needed since https://github.com/Nemocas/AbstractAlgebra.jl/pull/1022 that was released as part of AA 0.22.0.