### PR TITLE
Standard basis computations using highest corner

### DIFF
--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -308,7 +308,7 @@ function groebner_basis(I::MPolyIdeal; ordering::MonomialOrdering = default_orde
 end
 
 @doc raw"""
-    standard_basis_with_highest_corner(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I))) 
+    standard_basis_highest_corner(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I))) 
 
 Return a standard basis of `I` with respect to `ordering`. `ordering` needs to be local, the coefficient ring needs to be `QQ`.
 The algorithm first computes a standard basis over a finite field in order to get a highest corner fast. Then this highest corner

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -318,26 +318,8 @@ function standard_basis_highest_corner(I::MPolyIdeal; ordering::MonomialOrdering
     @req is_local(ordering) "Monomial ordering must be local for this variant."
     @req coefficient_ring(I) == QQ "Base ring must be QQ."
 
-    p = 32003
-    #p = next_prime(rand(2^30:2^31))
-
-    R     = base_ring(I)
-    Rp, t = polynomial_ring(GF(p), R.S)
-    Ip    = ideal(Rp, gens(I))
-    
-    hc = Singular.highcorner(singular_groebner_generators(Ip, ordering))
-    if iszero(hc)
-      #= fall back to general standard basis algorithm =#
-      ssb = Singular.std(singular_generators(I, ordering))
-    else
-      #= construct hc over QQ =#
-      sr = singular_poly_ring(R)
-      sf = base_ring(sr)
-      ct = MPolyBuildCtx(sr)
-      push_term!(ct, sf(1), Singular.leading_exponent_vector(hc))
-      #= apply highest corner variant of standard basis algorithm =#
-      ssb = Singular.std_with_HC(singular_generators(I, ordering), finish(ct))
-    end
+    #= apply highest corner standard basis variant in Singular =#
+    ssb = Singular.LibStandard.groebner(singular_groebner_generators(I, ordering), "HC")
 
     sb = IdealGens(I.gens.Ox, ssb, false)
     sb.isGB = true

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -342,6 +342,7 @@ function standard_basis_highest_corner(I::MPolyIdeal; ordering::MonomialOrdering
     if isdefined(sb, :S)
         sb.S.isGB = true
     end
+    I.gb[ordering] = sb
     return sb
 end
 

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -311,8 +311,8 @@ end
     standard_basis_highest_corner(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I))) 
 
 Return a standard basis of `I` with respect to `ordering`. `ordering` needs to be local, the coefficient ring needs to be `QQ`.
-The algorithm first computes a standard basis over a finite field in order to get a highest corner fast. Then this highest corner
-is used to speed up the standard basis computation over `QQ´.
+The algorithm first computes a standard basis over a finite field in order to get an upper bound for the highest corner fast.
+Then this bound is used to speed up the standard basis computation over `QQ´.
 """
 function standard_basis_highest_corner(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)))
     @req is_local(ordering) "Monomial ordering must be local for this variant."

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -130,9 +130,10 @@ Return a standard basis of `I` with respect to `ordering`.
 
 The keyword `algorithm` can be set to
 - `:buchberger` (implementation of Buchberger's algorithm in *Singular*),
-- `:hilbert` (implementation of a Hilbert driven Gröbner basis computation in *Singular*),
-- `:fglm` (implementation of the FGLM algorithm in *Singular*), and
-- `:f4` (implementation of Faugère's F4 algorithm in the *msolve* package).
+- `:f4` (implementation of Faugère's F4 algorithm in the *msolve* package),
+- `:fglm` (implementation of the FGLM algorithm in *Singular*),
+- `:hc` (implementation of Buchberger's algorithm in *Singular* trying to first compute the highest corner modulo some prime), and
+- `:hilbert` (implementation of a Hilbert driven Gröbner basis computation in *Singular*).
 
 !!! note
     See the description of the functions `groebner_basis_hilbert_driven`, `fglm`, 
@@ -171,6 +172,8 @@ function standard_basis(I::MPolyIdeal; ordering::MonomialOrdering = default_orde
     end
   elseif algorithm == :fglm
     _compute_groebner_basis_using_fglm(I, ordering)
+  elseif algorithm == :hc
+    standard_basis_highest_corner(I, ordering=ordering)
   elseif algorithm == :hilbert
     weights = _find_weights(gens(I))
     if !any(iszero, weights)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1368,6 +1368,7 @@ export src
 export stable_intersection
 export stable_set_polytope
 export standard_basis
+export standard_basis_highest_corner
 export standard_basis_with_transformation_matrix
 export standard_tableaux
 export stanley_reisner_ideal

--- a/test/Rings/groebner.jl
+++ b/test/Rings/groebner.jl
@@ -90,6 +90,13 @@
     R, (x,y) = polynomial_ring(AcbField(64),["x","y"])
     I = ideal([x^2+y^2+1//3,x^2+x*y+1//3*x])
     @test_throws ArgumentError groebner_basis(I)
+
+    R, (x, y) = polynomial_ring(QQ, ["x", "y"])
+    I = ideal(R, [x+y^2, x^2+x*y+3*y])
+    H = QQMPolyRingElem[x,y]
+    standard_basis_highest_corner(I, ordering=negdeglex(R))
+    @test elements(I.gb[negdeglex(R)]) == H
+    @test_throws ArgumentError standard_basis_highest_corner(I)
 end
 
 @testset "groebner leading ideal" begin


### PR DESCRIPTION
This implements a variant of standard basis computations from Singular for local monomial orderings: If computing over QQ, do a first computation over a finite field in order to get the highest corner. Now use this highest corner to speed up the computation over QQ. If the highest corner approach does not work (e.g. dimension  > 0) Singular's usual standard basis implementation is used.