### PR TITLE
Fix a `vcat`

### DIFF
--- a/experimental/Schemes/Resolution_structure.jl
+++ b/experimental/Schemes/Resolution_structure.jl
@@ -416,7 +416,7 @@ function find_refinement_with_local_system_of_params(W::AbsAffineScheme; check::
     minor_dict[U_ij] = (indices(I), indices(J), M_ext[i, j])
   end
   res_cov = Covering(ref_patches)
-  inherit_glueings!(res_cov, Covering(W))
+  inherit_gluings!(res_cov, Covering(W))
   return res_cov, minor_dict
 end
 
@@ -694,9 +694,9 @@ function common_refinement(list::Vector{<:Covering}, def_cov::Covering)
       !match_found && error("no common ancestor found for $U and $V")
     end
     #anc_cov = Covering(anc_list)
-    #inherit_glueings!(anc_cov, def_cov)
+    #inherit_gluings!(anc_cov, def_cov)
     result = Covering(patch_list)
-    inherit_glueings!(result, def_cov)
+    inherit_gluings!(result, def_cov)
 
     tot_inc1 = CoveringMorphism(result, list[1], to_U_dict; check=false)
     tot_inc2 = CoveringMorphism(result, list[2], to_V_dict; check=false)

--- a/src/Modules/mpolyquo-localizations.jl
+++ b/src/Modules/mpolyquo-localizations.jl
@@ -56,7 +56,7 @@ function has_solution(A::MatrixType, b::MatrixType) where {T<:MPolyQuoLocRingEle
   R = base_ring(S)
   S === base_ring(b) || error("matrices must be defined over the same ring")
   nrows(b) == 1 || error("only matrices with one row are allowed!")
-  Aext = vcat(A, modulus_matrix(S, ncols(A)))
+  Aext = vcat(A, change_base_ring(S, modulus_matrix(S, ncols(A))))
   B, D = clear_denominators(Aext)
   c, u = clear_denominators(b)
   (success, y, v) = has_solution(B, c, inverted_set(S))


### PR DESCRIPTION
`vcat` shouldn't work for matrices over different base rings and here it does so just by accident.

(Also replaces some glueings by gluings.)
