### PR TITLE
`experimental/GModule`: collect AA/Nemo/Hecke stuff in `Misc.jl`

### DIFF
--- a/experimental/GModule/Brueckner.jl
+++ b/experimental/GModule/Brueckner.jl
@@ -1,8 +1,6 @@
 module RepPc
 using Oscar
 
-export coimage
-
 #=TODO
  - construct characters along the way as well?
  - compare characters rather than the hom_base
@@ -265,10 +263,6 @@ function brueckner(mQ::Map{<:Oscar.GAPGroup, PcGroup}; primes::Vector=[])
   return allR
 end
 
-function coimage(h::Map)
-  return quo(domain(h), kernel(h)[1])
-end
-
 """
   mp: G ->> Q
   C a F_p[Q]-module
@@ -427,5 +421,3 @@ orbits(G)
 end #module RepPc
 
 using .RepPc
-
-export coimage

--- a/experimental/GModule/Brueckner.jl
+++ b/experimental/GModule/Brueckner.jl
@@ -3,17 +3,6 @@ using Oscar
 
 export coimage
 
-Base.pairs(M::MatElem) = Base.pairs(IndexCartesian(), M)
-Base.pairs(::IndexCartesian, M::MatElem) = Base.Iterators.Pairs(M, CartesianIndices(axes(M)))
-
-function Hecke.roots(a::FinFieldElem, i::Int)
-  kx, x = polynomial_ring(parent(a), cached = false)
-  return roots(x^i-a)
-end
-
-Oscar.matrix(phi::Generic.IdentityMap{<:AbstractAlgebra.FPModule}) = identity_matrix(base_ring(domain(phi)), dim(domain(phi)))
-
-
 #=TODO
  - construct characters along the way as well?
  - compare characters rather than the hom_base
@@ -276,68 +265,9 @@ function brueckner(mQ::Map{<:Oscar.GAPGroup, PcGroup}; primes::Vector=[])
   return allR
 end
 
-Oscar.gen(M::AbstractAlgebra.FPModule, i::Int) = M[i]
-
-Oscar.is_free(M::Generic.FreeModule) = true
-Oscar.is_free(M::Generic.DirectSumModule) = all(is_free, M.m)
-
-function Oscar.dual(h::Map{FinGenAbGroup, FinGenAbGroup})
-  A = domain(h)
-  B = codomain(h)
-  @assert is_free(A) && is_free(B)
-  return hom(B, A, transpose(h.map))
-end
-
-function Oscar.dual(h::Map{<:AbstractAlgebra.FPModule{ZZRingElem}, <:AbstractAlgebra.FPModule{ZZRingElem}})
-  A = domain(h)
-  B = codomain(h)
-  @assert is_free(A) && is_free(B)
-  return hom(B, A, transpose(matrix(h)))
-end
-
 function coimage(h::Map)
   return quo(domain(h), kernel(h)[1])
 end
-
-function Oscar.cokernel(h::Map)
-  return quo(codomain(h), image(h)[1])
-end
-
-function Base.iterate(M::AbstractAlgebra.FPModule{T}) where T <: FinFieldElem
-  k = base_ring(M)
-  if dim(M) == 0
-    return zero(M), iterate([1])
-  end
-  p = Base.Iterators.ProductIterator(Tuple([k for i=1:dim(M)]))
-  f = iterate(p)
-  return M(elem_type(k)[f[1][i] for i=1:dim(M)]), (f[2], p)
-end
-
-function Base.iterate(::AbstractAlgebra.FPModule{<:FinFieldElem}, ::Tuple{Int64, Int64})
-  return nothing
-end
-
-function Base.iterate(M::AbstractAlgebra.FPModule{T}, st::Tuple{<:Tuple, <:Base.Iterators.ProductIterator}) where T <: FinFieldElem
-  n = iterate(st[2], st[1])
-  if n === nothing
-    return n
-  end
-  return M(elem_type(base_ring(M))[n[1][i] for i=1:dim(M)]), (n[2], st[2])
-end
-
-function Base.length(M::AbstractAlgebra.FPModule{T}) where T <: FinFieldElem
-  return Int(order(base_ring(M))^dim(M))
-end
-
-function Base.eltype(M::AbstractAlgebra.FPModule{T}) where T <: FinFieldElem
-  return elem_type(M)
-end
-
-function Oscar.dim(M::AbstractAlgebra.Generic.DirectSumModule{<:FieldElem})
-  return sum(dim(x) for x = M.m)
-end
-
-Oscar.is_finite(M::AbstractAlgebra.FPModule{<:FinFieldElem}) = true
 
 """
   mp: G ->> Q

--- a/experimental/GModule/Cohomology.jl
+++ b/experimental/GModule/Cohomology.jl
@@ -372,11 +372,6 @@ function Oscar.quo(C::GModule, mDC::Map{FinGenAbGroup, FinGenAbGroup}, add_to_la
   return S, mq
 end
 
-function Oscar.direct_sum(M::AbstractAlgebra.Generic.DirectSumModule{T}, N::AbstractAlgebra.Generic.DirectSumModule{T}, mp::Vector{AbstractAlgebra.Generic.ModuleHomomorphism{T}})  where T
-  @assert length(M.m) == length(mp) == length(N.m)
-  return hom(M, N, cat(map(matrix, mp)..., dims = (1,2)))
-end
-
 function Oscar.direct_product(C::GModule...; task::Symbol = :none)
   @assert task in [:sum, :prod, :both, :none]
   G = C[1].G
@@ -1745,71 +1740,8 @@ function fp_group_with_isomorphism(M::AbstractAlgebra.FPModule{<:FinFieldElem})
 end
 
 #########################################################
-#XXX: should be in AA and supplemented by a proper quo
-Oscar.issubset(M::AbstractAlgebra.FPModule{T}, N::AbstractAlgebra.FPModule{T}) where T<:RingElement = is_submodule(M, N)
-
-function is_sub_with_data(M::AbstractAlgebra.FPModule{T}, N::AbstractAlgebra.FPModule{T}) where T<:RingElement
-  fl = is_submodule(N, M)
-  if fl
-    return fl, hom(M, N, elem_type(N)[N(m) for m = gens(M)])
-  else
-    return fl, hom(M, N, elem_type(N)[zero(N) for m = gens(M)])
-  end
-end
-is_sub_with_data(M::FinGenAbGroup, N::FinGenAbGroup) = is_subgroup(M, N)
-
-function Oscar.hom(V::Module, W::Module, v::Vector{<:ModuleElem}; check::Bool = true)
-  if ngens(V) == 0
-    return Generic.ModuleHomomorphism(V, W, zero_matrix(base_ring(V), ngens(V), ngens(W)))
-  end
-  return Generic.ModuleHomomorphism(V, W, reduce(vcat, [x.v for x = v]))
-end
-function Oscar.hom(V::Module, W::Module, v::MatElem; check::Bool = true)
-  return Generic.ModuleHomomorphism(V, W, v)
-end
-function Oscar.inv(M::Generic.ModuleHomomorphism)
-  return hom(codomain(M), domain(M), inv(matrix(M)))
-end
-
-function Oscar.direct_product(M::Module...; task::Symbol = :none)
-  D, inj, pro = direct_sum(M...)
-  if task == :none
-    return D
-  elseif task == :both
-    return D, pro, inj
-  elseif task == :sum
-    return D, inj
-  elseif task == :prod
-    return D, pro
-  end
-  error("illegal task")
-end
-
-Base.:*(a::T, b::Generic.ModuleHomomorphism{T}) where {T} = hom(domain(b), codomain(b), a * matrix(b))
-Base.:*(a::T, b::Generic.ModuleIsomorphism{T}) where {T} = hom(domain(b), codomain(b), a * matrix(b))
-Base.:+(a::Generic.ModuleHomomorphism, b::Generic.ModuleHomomorphism) = hom(domain(a), codomain(a), matrix(a) + matrix(b))
-Base.:-(a::Generic.ModuleHomomorphism, b::Generic.ModuleHomomorphism) = hom(domain(a), codomain(a), matrix(a) - matrix(b))
-Base.:-(a::Generic.ModuleHomomorphism) = hom(domain(a), codomain(a), -matrix(a))
-
 function Oscar.matrix(M::FreeModuleHom{FreeMod{QQAbElem}, FreeMod{QQAbElem}})
   return M.matrix
-end
-
-function ==(a::Union{Generic.ModuleHomomorphism, Generic.ModuleIsomorphism}, b::Union{Generic.ModuleHomomorphism, Generic.ModuleIsomorphism})
-  domain(a) === domain(b) || return false
-  codomain(a) === codomain(b) || return false
-  return matrix(a) == matrix(b)
-end
-
-function Base.hash(a::Union{Generic.ModuleHomomorphism, Generic.ModuleIsomorphism}, h::UInt)
-  h = hash(domain(a), h)
-  h = hash(codomain(a), h)
-  h = hash(matrix(a), h)
-  return h
-end
-
-function Oscar.id_hom(A::AbstractAlgebra.FPModule)
-  return Generic.ModuleHomomorphism(A, A, identity_matrix(base_ring(A), ngens(A)))
 end
 
 ###########################################################
@@ -1918,19 +1850,6 @@ function pc_group_with_isomorphism(M::FinGenAbGroup; refine::Bool = true)
     codomain(mM), B,
     y->PcGroupElem(B, Julia_to_gap(preimage(mM, y))),
     x->image(mM, gap_to_julia(x.X)))
-end
-
-function (k::Nemo.fpField)(a::Vector)
-  @assert length(a) == 1
-  return k(a[1])
-end
-
-function (k::fqPolyRepField)(a::Vector)
-  return k(polynomial(Native.GF(Int(characteristic(k))), a))
-end
-
-function Oscar.order(F::AbstractAlgebra.FPModule{<:FinFieldElem})
-  return order(base_ring(F))^dim(F)
 end
 
 function pc_group_with_isomorphism(M::AbstractAlgebra.FPModule{<:FinFieldElem}; refine::Bool = true)

--- a/experimental/GModule/GaloisCohomology.jl
+++ b/experimental/GModule/GaloisCohomology.jl
@@ -13,9 +13,6 @@ export local_invariants, global_fundamental_class, shrink
 export local_index, units_mod_ideal
 
 
-Oscar.elem_type(::Type{Hecke.NfMorSet{T}}) where {T <: Hecke.LocalField} = Hecke.LocalFieldMor{T, T}
-parent(f::Hecke.LocalFieldMor) = Hecke.NfMorSet(domain(f))
-
 _can_cache_aut(::PadicField) = nothing
 function _can_cache_aut(k) 
   a = get_attribute(k, :AutGroup)
@@ -622,12 +619,6 @@ function debeerst(M::FinGenAbGroup, sigma::Map{FinGenAbGroup, FinGenAbGroup})
   =#
 
   return vcat(b[r+1:end], y[r+1:end]), [-y[i] - b[i] for i=1:r]
-end
-
-function (G::FinGenAbGroup)(x::FinGenAbGroupElem)
-  fl, m = is_subgroup(parent(x), G)
-  @assert fl
-  return m(x)
 end
 
 function Hecke.extend_easy(m::Hecke.CompletionMap, L::FacElemMon{AbsSimpleNumField})
@@ -1497,13 +1488,6 @@ function (B::RelativeBrauerGroup)(CC::GrpCoh.CoChain{2, PermGroupElem, GrpCoh.Mu
 end
 
 
-#trivia for QQ
-Base.minimum(::Map{QQField, AbsSimpleNumField}, I::Union{Hecke.AbsNumFieldOrderIdeal, Hecke.AbsNumFieldOrderFractionalIdeal}) = minimum(I)*ZZ
-
-Hecke.extend(::Hecke.QQEmb, mp::MapFromFunc{QQField, AbsSimpleNumField}) = complex_embeddings(codomain(mp))
-
-Hecke.restrict(::Hecke.NumFieldEmb, ::Map{QQField, AbsSimpleNumField}) = complex_embeddings(QQ)[1]
-
 """
     relative_brauer_group(K::AbsSimpleNumField, k)
 
@@ -1929,27 +1913,6 @@ function shrink(C::GModule{PermGroup, FinGenAbGroup}, attempts::Int = 10)
     end
     prog || return q, mq
   end
-end
-
-"""
-    direct_sum(G::FinGenAbGroup, H::FinGenAbGroup, V::Vector{<:Map{FinGenAbGroup, FinGenAbGroup}})
-
-For groups `G = prod G_i` and `H = prod H_i` as well as maps `V_i: G_i -> H_i`,
-build the induced map from `G -> H`.
-"""
-function Oscar.direct_sum(G::FinGenAbGroup, H::FinGenAbGroup, V::Vector{<:Map{FinGenAbGroup, FinGenAbGroup}})
-  dG = get_attribute(G, :direct_product)
-  dH = get_attribute(H, :direct_product)
-
-  if dG === nothing || dH === nothing
-    error("both groups need to be direct products")
-  end
-  @assert length(V) == length(dG) == length(dH)
-
-  @assert all(i -> domain(V[i]) == dG[i] && codomain(V[i]) == dH[i], 1:length(V))
-  h = hom(G, H, cat([matrix(V[i]) for i=1:length(V)]..., dims=(1,2)), check = !true)
-  return h
-
 end
 
 function Oscar.simplify(C::GModule{PermGroup, FinGenAbGroup})

--- a/experimental/GModule/Misc.jl
+++ b/experimental/GModule/Misc.jl
@@ -2,6 +2,7 @@ module Misc
 using Oscar
 import Base: ==, parent
 
+export coimage
 export relative_field
 
 Hecke.minpoly(a::QQBarFieldElem) = minpoly(Hecke.Globals.Qx, a)
@@ -508,6 +509,11 @@ function Oscar.direct_sum(M::AbstractAlgebra.Generic.DirectSumModule{T}, N::Abst
   return hom(M, N, cat(map(matrix, mp)..., dims = (1,2)))
 end
 
+function coimage(h::Map)
+  return quo(domain(h), kernel(h)[1])
+end
+
 end # module
 using .Misc
+export coimage
 export relative_field

--- a/experimental/GModule/Misc.jl
+++ b/experimental/GModule/Misc.jl
@@ -2,6 +2,8 @@ module Misc
 using Oscar
 import Base: ==, parent
 
+export relative_field
+
 Hecke.minpoly(a::QQBarFieldElem) = minpoly(Hecke.Globals.Qx, a)
 
 function primitive_element(a::Vector{QQBarFieldElem})
@@ -508,3 +510,4 @@ end
 
 end # module
 using .Misc
+export relative_field

--- a/experimental/GModule/Misc.jl
+++ b/experimental/GModule/Misc.jl
@@ -1,5 +1,6 @@
 module Misc
 using Oscar
+import Base: ==, parent
 
 Hecke.minpoly(a::QQBarFieldElem) = minpoly(Hecke.Globals.Qx, a)
 
@@ -182,6 +183,327 @@ function cyclo_fixed_group_gens(A::AbstractArray{AbsSimpleNumFieldElem})
     end
   end
   return [(mR(sR(ms(x))), F) for x = gens(s)]
+end
+
+
+#############################################################################
+##
+## functions that will eventually get defined in Hecke.jl,
+## and then should get removed here
+
+function Hecke.roots(a::FinFieldElem, i::Int)
+  kx, x = polynomial_ring(parent(a), cached = false)
+  return roots(x^i-a)
+end
+
+function Oscar.dual(h::Map{FinGenAbGroup, FinGenAbGroup})
+  A = domain(h)
+  B = codomain(h)
+  @assert is_free(A) && is_free(B)
+  return hom(B, A, transpose(h.map))
+end
+
+function Oscar.dual(h::Map{<:AbstractAlgebra.FPModule{ZZRingElem}, <:AbstractAlgebra.FPModule{ZZRingElem}})
+  A = domain(h)
+  B = codomain(h)
+  @assert is_free(A) && is_free(B)
+  return hom(B, A, transpose(matrix(h)))
+end
+
+function Oscar.cokernel(h::Map)
+  return quo(codomain(h), image(h)[1])
+end
+
+is_sub_with_data(M::FinGenAbGroup, N::FinGenAbGroup) = is_subgroup(M, N)
+
+function Oscar.direct_product(M::AbstractAlgebra.Module...; task::Symbol = :none)
+  D, inj, pro = direct_sum(M...)
+  if task == :none
+    return D
+  elseif task == :both
+    return D, pro, inj
+  elseif task == :sum
+    return D, inj
+  elseif task == :prod
+    return D, pro
+  end
+  error("illegal task")
+end
+
+function Oscar.id_hom(A::AbstractAlgebra.FPModule)
+  return Generic.ModuleHomomorphism(A, A, identity_matrix(base_ring(A), ngens(A)))
+end
+
+Oscar.elem_type(::Type{Hecke.NfMorSet{T}}) where {T <: Hecke.LocalField} = Hecke.LocalFieldMor{T, T}
+parent(f::Hecke.LocalFieldMor) = Hecke.NfMorSet(domain(f))
+
+function (G::FinGenAbGroup)(x::FinGenAbGroupElem)
+  fl, m = is_subgroup(parent(x), G)
+  @assert fl
+  return m(x)
+end
+
+#trivia for QQ
+Base.minimum(::Map{QQField, AbsSimpleNumField}, I::Union{Hecke.AbsNumFieldOrderIdeal, Hecke.AbsNumFieldOrderFractionalIdeal}) = minimum(I)*ZZ
+
+Hecke.extend(::Hecke.QQEmb, mp::MapFromFunc{QQField, AbsSimpleNumField}) = complex_embeddings(codomain(mp))
+
+Hecke.restrict(::Hecke.NumFieldEmb, ::Map{QQField, AbsSimpleNumField}) = complex_embeddings(QQ)[1]
+
+"""
+    direct_sum(G::FinGenAbGroup, H::FinGenAbGroup, V::Vector{<:Map{FinGenAbGroup, FinGenAbGroup}})
+
+For groups `G = prod G_i` and `H = prod H_i` as well as maps `V_i: G_i -> H_i`,
+build the induced map from `G -> H`.
+"""
+function Oscar.direct_sum(G::FinGenAbGroup, H::FinGenAbGroup, V::Vector{<:Map{FinGenAbGroup, FinGenAbGroup}})
+  dG = get_attribute(G, :direct_product)
+  dH = get_attribute(H, :direct_product)
+
+  if dG === nothing || dH === nothing
+    error("both groups need to be direct products")
+  end
+  @assert length(V) == length(dG) == length(dH)
+
+  @assert all(i -> domain(V[i]) == dG[i] && codomain(V[i]) == dH[i], 1:length(V))
+  h = hom(G, H, cat([matrix(V[i]) for i=1:length(V)]..., dims=(1,2)), check = !true)
+  return h
+
+end
+
+#XXX: have a type for an implicit field - in Hecke?
+#     add all(?) the other functions to it
+function relative_field(m::Map{<:AbstractAlgebra.Field, <:AbstractAlgebra.Field})
+  k = domain(m)
+  K = codomain(m)
+  @assert base_field(k) == base_field(K)
+  kt, t = polynomial_ring(k, cached = false)
+  f = defining_polynomial(K)
+  Qt = parent(f)
+  #the Trager construction, works for extensions of the same field given
+  #via primitive elements
+  h = gcd(gen(k) - map_coefficients(k, Qt(m(gen(k))), parent = kt), map_coefficients(k, f, parent = kt))
+  coordinates = function(x::FieldElem)
+    @assert parent(x) == K
+    c = collect(Hecke.coefficients(map_coefficients(k, Qt(x), parent = kt) % h))
+    c = vcat(c, zeros(k, degree(h)-length(c)))
+    return c
+  end
+  rep_mat = function(x::FieldElem)
+    @assert parent(x) == K
+    c = map_coefficients(k, Qt(x), parent = kt) % h
+    m = collect(Hecke.coefficients(c))
+    m = vcat(m, zeros(k, degree(h) - length(m)))
+    r = m
+    for i in 2:degree(h)
+      c = shift_left(c, 1) % h
+      m = collect(Hecke.coefficients(c))
+      m = vcat(m, zeros(k, degree(h) - length(m)))
+      r = hcat(r, m)
+    end
+    return transpose(matrix(r))
+  end
+  return h, coordinates, rep_mat
+end
+
+Oscar.parent(H::AbstractAlgebra.Generic.ModuleHomomorphism{<:FieldElem}) = Hecke.MapParent(domain(H), codomain(H), "homomorphisms")
+
+function Oscar.hom(F::AbstractAlgebra.FPModule{T}, G::AbstractAlgebra.FPModule{T}) where T
+  k = base_ring(F)
+  @assert base_ring(G) == k
+  H = free_module(k, dim(F)*dim(G))
+  return H, MapFromFunc(H, Hecke.MapParent(F, G, "homomorphisms"), x->hom(F, G, matrix(k, dim(F), dim(G), vec(collect(x.v)))), y->H(vec(collect(transpose(matrix(y))))))
+end
+
+function Oscar.abelian_group(M::Generic.FreeModule{ZZRingElem})
+  A = free_abelian_group(rank(M))
+  return A, MapFromFunc(A, M, x->M(x.coeff), y->A(y.v))
+end
+
+#TODO: for modern fin. fields as well
+function Oscar.abelian_group(M::AbstractAlgebra.FPModule{fqPolyRepFieldElem})
+  k = base_ring(M)
+  A = abelian_group([characteristic(k) for i = 1:dim(M)*degree(k)])
+  n = degree(k)
+  function to_A(m::AbstractAlgebra.FPModuleElem{fqPolyRepFieldElem})
+    a = ZZRingElem[]
+    for i=1:dim(M)
+      c = m[i]
+      for j=0:n-1
+        push!(a, coeff(c, j))
+      end
+    end
+    return A(a)
+  end
+  function to_M(a::FinGenAbGroupElem)
+    m = fqPolyRepFieldElem[]
+    for i=1:dim(M)
+      push!(m, k([a[j] for j=(i-1)*n+1:i*n]))
+    end
+    return M(m)
+  end
+  return A, MapFromFunc(A, M, to_M, to_A)
+end
+
+function Hecke.induce_crt(a::Generic.MatSpaceElem{AbsSimpleNumFieldElem}, b::Generic.MatSpaceElem{AbsSimpleNumFieldElem}, p::ZZRingElem, q::ZZRingElem)
+  c = parent(a)()
+  pi = invmod(p, q)
+  mul!(pi, pi, p)
+  pq = p*q
+  z = ZZRingElem(0)
+
+  for i=1:nrows(a)
+    for j=1:ncols(a)
+      c[i,j] = Hecke.induce_inner_crt(a[i,j], b[i,j], pi, pq, z)
+    end
+  end
+  return c
+end
+
+function Hecke.induce_rational_reconstruction(a::Generic.MatSpaceElem{AbsSimpleNumFieldElem}, pg::ZZRingElem; ErrorTolerant::Bool = false)
+  c = parent(a)()
+  for i=1:nrows(a)
+    for j=1:ncols(a)
+      fl, c[i,j] = rational_reconstruction(a[i,j], pg)#, ErrorTolerant = ErrorTolerant)
+      fl || return fl, c
+    end
+  end
+  return true, c
+end
+
+function Hecke.induce_rational_reconstruction(a::ZZMatrix, pg::ZZRingElem; ErrorTolerant::Bool = false)
+  c = zero_matrix(QQ, nrows(a), ncols(a))
+  for i=1:nrows(a)
+    for j=1:ncols(a)
+      fl, n, d = rational_reconstruction(a[i,j], pg, ErrorTolerant = ErrorTolerant)
+      fl || return fl, c
+      c[i,j] = n//d
+    end
+  end
+  return true, c
+end
+
+
+#############################################################################
+##
+## functions that will eventually get defined in Nemo.jl,
+## and then should get removed here
+
+function (k::Nemo.fpField)(a::Vector)
+  @assert length(a) == 1
+  return k(a[1])
+end
+
+function (k::fqPolyRepField)(a::Vector)
+  return k(polynomial(Native.GF(Int(characteristic(k))), a))
+end
+
+
+#############################################################################
+##
+## functions that will eventually get defined in AbstractAlgebra.jl,
+## and then should get removed here
+
+Base.pairs(M::MatElem) = Base.pairs(IndexCartesian(), M)
+Base.pairs(::IndexCartesian, M::MatElem) = Base.Iterators.Pairs(M, CartesianIndices(axes(M)))
+
+Oscar.matrix(phi::Generic.IdentityMap{<:AbstractAlgebra.FPModule}) = identity_matrix(base_ring(domain(phi)), dim(domain(phi)))
+
+Oscar.gen(M::AbstractAlgebra.FPModule, i::Int) = M[i]
+
+Oscar.is_free(M::Generic.FreeModule) = true
+Oscar.is_free(M::Generic.DirectSumModule) = all(is_free, M.m)
+
+function Base.iterate(M::AbstractAlgebra.FPModule{T}) where T <: FinFieldElem
+  k = base_ring(M)
+  if dim(M) == 0
+    return zero(M), iterate([1])
+  end
+  p = Base.Iterators.ProductIterator(Tuple([k for i=1:dim(M)]))
+  f = iterate(p)
+  return M(elem_type(k)[f[1][i] for i=1:dim(M)]), (f[2], p)
+end
+
+function Base.iterate(::AbstractAlgebra.FPModule{<:FinFieldElem}, ::Tuple{Int64, Int64})
+  return nothing
+end
+
+Oscar.issubset(M::AbstractAlgebra.FPModule{T}, N::AbstractAlgebra.FPModule{T}) where T<:RingElement = is_submodule(M, N)
+
+function is_sub_with_data(M::AbstractAlgebra.FPModule{T}, N::AbstractAlgebra.FPModule{T}) where T<:RingElement
+  fl = is_submodule(N, M)
+  if fl
+    return fl, hom(M, N, elem_type(N)[N(m) for m = gens(M)])
+  else
+    return fl, hom(M, N, elem_type(N)[zero(N) for m = gens(M)])
+  end
+end
+
+function Oscar.hom(V::AbstractAlgebra.Module, W::AbstractAlgebra.Module, v::Vector{<:ModuleElem}; check::Bool = true)
+  if ngens(V) == 0
+    return Generic.ModuleHomomorphism(V, W, zero_matrix(base_ring(V), ngens(V), ngens(W)))
+  end
+  return Generic.ModuleHomomorphism(V, W, reduce(vcat, [x.v for x = v]))
+end
+function Oscar.hom(V::AbstractAlgebra.Module, W::AbstractAlgebra.Module, v::MatElem; check::Bool = true)
+  return Generic.ModuleHomomorphism(V, W, v)
+end
+function Oscar.inv(M::Generic.ModuleHomomorphism)
+  return hom(codomain(M), domain(M), inv(matrix(M)))
+end
+
+Oscar.is_finite(M::AbstractAlgebra.FPModule{<:FinFieldElem}) = true
+
+function Oscar.order(F::AbstractAlgebra.FPModule{<:FinFieldElem})
+  return order(base_ring(F))^dim(F)
+end
+
+function Base.iterate(M::AbstractAlgebra.FPModule{T}, st::Tuple{<:Tuple, <:Base.Iterators.ProductIterator}) where T <: FinFieldElem
+  n = iterate(st[2], st[1])
+  if n === nothing
+    return n
+  end
+  return M(elem_type(base_ring(M))[n[1][i] for i=1:dim(M)]), (n[2], st[2])
+end
+
+function Base.length(M::AbstractAlgebra.FPModule{T}) where T <: FinFieldElem
+  return Int(order(M))
+end
+
+function Base.eltype(M::AbstractAlgebra.FPModule{T}) where T <: FinFieldElem
+  return elem_type(M)
+end
+
+function Oscar.dim(M::AbstractAlgebra.Generic.DirectSumModule{<:FieldElem})
+  return sum(dim(x) for x = M.m)
+end
+
+Base.:*(a::T, b::Generic.ModuleHomomorphism{T}) where {T} = hom(domain(b), codomain(b), a * matrix(b))
+Base.:*(a::T, b::Generic.ModuleIsomorphism{T}) where {T} = hom(domain(b), codomain(b), a * matrix(b))
+Base.:+(a::Generic.ModuleHomomorphism, b::Generic.ModuleHomomorphism) = hom(domain(a), codomain(a), matrix(a) + matrix(b))
+Base.:-(a::Generic.ModuleHomomorphism, b::Generic.ModuleHomomorphism) = hom(domain(a), codomain(a), matrix(a) - matrix(b))
+Base.:-(a::Generic.ModuleHomomorphism) = hom(domain(a), codomain(a), -matrix(a))
+
+function Base.:(==)(a::Union{Generic.ModuleHomomorphism, Generic.ModuleIsomorphism}, b::Union{Generic.ModuleHomomorphism, Generic.ModuleIsomorphism})
+  domain(a) === domain(b) || return false
+  codomain(a) === codomain(b) || return false
+  return matrix(a) == matrix(b)
+end
+
+function Base.hash(a::Union{Generic.ModuleHomomorphism, Generic.ModuleIsomorphism}, h::UInt)
+  h = hash(domain(a), h)
+  h = hash(codomain(a), h)
+  h = hash(matrix(a), h)
+  return h
+end
+
+function Oscar.pseudo_inv(h::Generic.ModuleHomomorphism)
+  return MapFromFunc(codomain(h), domain(h), x->preimage(h, x))
+end
+
+function Oscar.direct_sum(M::AbstractAlgebra.Generic.DirectSumModule{T}, N::AbstractAlgebra.Generic.DirectSumModule{T}, mp::Vector{AbstractAlgebra.Generic.ModuleHomomorphism{T}})  where T
+  @assert length(M.m) == length(mp) == length(N.m)
+  return hom(M, N, cat(map(matrix, mp)..., dims = (1,2)))
 end
 
 end # module


### PR DESCRIPTION
In `experimental/GModule`, move code to `Misc.jl` that belongs to AbstractAlgebra.jl, Nemo.jl, or Hecke.jl.

Once we agree that this code should be moved to these packages, the code should be added there,
and as soon as it becomes available in Oscar, it can be removed from `Misc.jl`.