### PR TITLE
Temp fix: Show FTheoryTools docs again

### DIFF
--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -132,6 +132,12 @@ function doit(
       append!(collected, pkgdocs)
     end
   end
+  if "FTheoryTools" in oldexppkgs # remove this block once FTheoryTools is upgraded to new experimental structure
+    pkgdocs = setup_experimental_package(Oscar, "FTheoryTools")
+    if length(pkgdocs) > 0
+      append!(collected, pkgdocs)
+    end
+  end
   push!(doc, ("Experimental" => collected))
 
   # Load the bibliography

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -132,7 +132,7 @@ function doit(
       append!(collected, pkgdocs)
     end
   end
-  if "FTheoryTools" in oldexppkgs # remove this block once FTheoryTools is upgraded to new experimental structure
+  if "FTheoryTools" in Oscar.oldexppkgs # remove this block once FTheoryTools is upgraded to new experimental structure
     pkgdocs = setup_experimental_package(Oscar, "FTheoryTools")
     if length(pkgdocs) > 0
       append!(collected, pkgdocs)


### PR DESCRIPTION
This should get reverted once FTheoryTools gets upgraded to the experimental structure again.

A preview should be available soon-ish at https://docs.oscar-system.org/previews/PR3585