### PR TITLE
Use a new OSCAR email address on our domain

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oscar"
 uuid = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
-authors = ["The OSCAR Team <oscar@mathematik.uni-kl.de>"]
+authors = ["The OSCAR Team <oscar@oscar-system.org>"]
 version = "1.1.0-DEV"
 
 [deps]


### PR DESCRIPTION
The old address was that of the OSCAR mailing list, but IMHO the mathematik.uni-kl.de address had at least two issues:
1. its legacy these days as we were renamed; so at some point everything will migrate to a new address...
2. it is not reflective of the fact that OSCAR is developed by many people in many places.


So I've now set up a new address oscar@oscar-system.org -- for now this just forwards mails to @fieker and myself, though we can change that in the future as needed (up to having a "proper" mailing list backing it should we want to). But I don't think we'll get much traffic there.

CC @micjoswig @thofma @simonbrandhorst @wdecker 