### PR TITLE
fix: better performance for labelled matrix display

### DIFF
--- a/src/Groups/MatrixDisplay.jl
+++ b/src/Groups/MatrixDisplay.jl
@@ -36,8 +36,8 @@ mylpad(s::String,n::Int) = " "^(n-textwidth(s))*s
 const superscript = Dict(zip("-0123456789", "⁻⁰¹²³⁴⁵⁶⁷⁸⁹"))
 const subscript = Dict(zip("-0123456789", "₋₀₁₂₃₄₅₆₇₈₉"))
 
-function replace_TeX(str::String)
-  if Oscar.is_unicode_allowed()
+function replace_TeX(str::String; is_unicode_allowed = Oscar.is_unicode_allowed())
+  if is_unicode_allowed
     str = replace(str, "\\chi" => "χ")
     str = replace(str, "\\phi" => "φ")
     str = replace(str, "\\varphi" => "φ")
@@ -250,8 +250,9 @@ function labeled_matrix_formatted(io::IO, mat::Matrix{String})
     if ! TeX
       # If no `TeX` output is required then
       # replace markup in the matrices, ...
-      leftpart = map(replace_TeX, leftpart)
-      rightpart = map(replace_TeX, rightpart)
+      with_unicode = Oscar.is_unicode_allowed()
+      leftpart = map(x -> replace_TeX(x, is_unicode_allowed = with_unicode), leftpart)
+      rightpart = map(x -> replace_TeX(x, is_unicode_allowed = with_unicode), rightpart)
 
       header = map(replace_TeX, header)
       footer = map(replace_TeX, footer)
@@ -259,12 +260,14 @@ function labeled_matrix_formatted(io::IO, mat::Matrix{String})
       # ... compute columns widths of the corner entries and row labels ...
       leftwidth = map(textwidth, leftpart)
       leftrows = [leftwidth[i,:] for i in 1:m]
-      widths_leftpart = map(max, leftrows...)
+      #widths_leftpart = map(max, leftrows...)
+      widths_leftpart = [maximum(f[i] for f in leftrows; init = 0) for i in 1:length(first(leftrows))]
+
 
       # ... and of the column labels and matrix entries.
       rightwidth = map(textwidth, rightpart)
       rightrows = [rightwidth[i,:] for i in 1:m]
-      widths_rightpart = map(max, rightrows...)
+      widths_rightpart = [maximum(f[i] for f in rightrows; init = 0) for i in 1:length(first(rightrows))]
 
       # Compute the width of the row labels part.
       leftwidthsum = sum(widths_leftpart) + length(widths_leftpart) - 1

--- a/src/Groups/MatrixDisplay.jl
+++ b/src/Groups/MatrixDisplay.jl
@@ -262,7 +262,6 @@ function labeled_matrix_formatted(io::IO, mat::Matrix{String})
       leftrows = [leftwidth[i,:] for i in 1:m]
       widths_leftpart = [maximum(f[i] for f in leftrows; init = 0) for i in 1:length(first(leftrows))]
 
-
       # ... and of the column labels and matrix entries.
       rightwidth = map(textwidth, rightpart)
       rightrows = [rightwidth[i,:] for i in 1:m]

--- a/src/Groups/MatrixDisplay.jl
+++ b/src/Groups/MatrixDisplay.jl
@@ -260,7 +260,6 @@ function labeled_matrix_formatted(io::IO, mat::Matrix{String})
       # ... compute columns widths of the corner entries and row labels ...
       leftwidth = map(textwidth, leftpart)
       leftrows = [leftwidth[i,:] for i in 1:m]
-      #widths_leftpart = map(max, leftrows...)
       widths_leftpart = [maximum(f[i] for f in leftrows; init = 0) for i in 1:length(first(leftrows))]
 
 


### PR DESCRIPTION
Current master:
```
julia> t = character_table("B");  # if you really want to see the formatted output then omit the semicolon

julia> @time show(IOBuffer(), "text/plain", t);
  9.962639 seconds (74.39 M allocations: 4.077 GiB, 5.35% gc time, 76.55% compilation time)

julia> @time show(IOBuffer(), "text/plain", t);
  2.275388 seconds (20.78 M allocations: 1.275 GiB, 3.93% gc time)
```
With this PR:
```
julia> t = character_table("B");  # if you really want to see the formatted output then omit the semicolon

julia> @time show(IOBuffer(), "text/plain", t);
  2.590985 seconds (8.90 M allocations: 575.139 MiB, 10.43% gc time, 95.47% compilation time)

julia> @time show(IOBuffer(), "text/plain", t);
  0.130060 seconds (1.57 M allocations: 76.671 MiB)
```
