### PR TITLE
`GModule`: replace `_hom`

### DIFF
--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -317,7 +317,7 @@ function maximal_submodule_bases(M::GModule{<:Oscar.GAPGroup, <:AbstractAlgebra.
 end
 
 function maximal_submodules(M::GModule{<:Oscar.GAPGroup, <:AbstractAlgebra.FPModule{<:FinFieldElem}})
-  return [sub(M, s) for s = maximal_submodule_bases]
+  return [sub(M, s) for s = maximal_submodule_bases(M)]
 end
 
 

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -279,12 +279,7 @@ function invariant_lattice_classes(M::GModule{<:Oscar.GAPGroup, <:AbstractAlgebr
         pG = p.*gens(M.M)
         for s in S
           x, mx = sub(M.M, vcat(pG, [M.M(map_entries(x->lift(ZZ, x), s[i:i, :])) for i in 1:nrows(s)]))
-          # Compute the restriction of the `M.G`-action from `M.M`
-          # to the submodule given by the embedding `mx`.
-          hgens = gens(domain(mx))
-          mxac = [hom(domain(mx), domain(mx),
-                      [preimage(mx, h(mx(x))) for x in hgens]) for h in M.ac]
-          r = (gmodule(M.G, mxac), mx)
+          r = (sub(M, mx), mx)
           if any(x->is_isomorphic(r[1], x[1]), res)
             continue
           else
@@ -633,6 +628,15 @@ function Oscar.sub(C::GModule{<:Any, <:AbstractAlgebra.FPModule{T}}, m::MatElem{
   F = free_module(k, nrows(b))
   return gmodule(F, Group(C), [hom(F, F, matrix([preimage(h, x[i, j]) for i in 1:GAPWrap.NrRows(x), j in 1:GAPWrap.NrCols(x)])) for x = y.generators]), hom(F, C.M, b)
   return b
+end
+
+# Compute the restriction of the `M.G`-action from `M.M`
+# to the submodule given by the embedding `f`.
+function Oscar.sub(M::GModule{<:Any, <:AbstractAlgebra.FPModule{T}}, f::AbstractAlgebra.Generic.ModuleHomomorphism{T}) where T
+  @assert codomain(f) == M.M
+  S = domain(f)
+  Sac = [hom(S, S, [preimage(f, h(f(x))) for x in gens(S)]) for h in M.ac]
+  return gmodule(S, M.G, Sac)
 end
 
 function gmodule(k::Nemo.FinField, C::GModule{<:Any, <:AbstractAlgebra.FPModule{<:FinFieldElem}})

--- a/experimental/GModule/test/runtests.jl
+++ b/experimental/GModule/test/runtests.jl
@@ -79,6 +79,10 @@ end
 
   @test extension_of_scalars(M, phi) == GModule(mE, G, [hom(mE, mE, a) for a in LE])
 
+  G = pc_group(symmetric_group(3))
+  z = irreducible_modules(ZZ, G)
+  @test length(Oscar.GModuleFromGap.invariant_lattice_classes(z[3])) == 2
+
   # G = Oscar.GrpCoh.fp_group_with_isomorphism(gens(G))[1]
   # q, mq = maximal_abelian_quotient(PcGroup, G)
   # @test length(Oscar.RepPc.brueckner(mq)) == 24


### PR DESCRIPTION
Create the images of generators directly, instead of first creating pseudo-inverses and compositions of maps.
(Eventually, restricting the group action to a submodule should become a function of its own.)

(also fixed a call of `maximal_submodule_bases`)