### PR TITLE
Function is_normal for covered and affine schemes

### DIFF
--- a/docs/src/AlgebraicGeometry/Schemes/AffineSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/AffineSchemes.md
@@ -107,6 +107,7 @@ is_subscheme(X::AbsAffineScheme, Y::AbsAffineScheme)
 ## Methods
 ```@docs
 tangent_space(X::AbsAffineScheme{<:Field}, P::AbsAffineRationalPoint)
+is_normal(X::AbsAffineScheme; check::Bool=true)
 normalization(X::AbsAffineScheme; check::Bool=true, algorithm=:equidimDec)
 ```
 

--- a/docs/src/AlgebraicGeometry/Schemes/CoveredSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/CoveredSchemes.md
@@ -52,6 +52,7 @@ An `AbsCoveredScheme` may have different properties such as
 ## Methods
 ```@docs
     fiber_product(f::AbsCoveredSchemeMorphism, g::AbsCoveredSchemeMorphism)
+    is_normal(X::AbsCoveredScheme; check::Bool=true)
     normalization(X::AbsCoveredScheme; check::Bool=true)
 ```
 

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
@@ -175,6 +175,31 @@ end
 # Normalization                                                        #
 ########################################################################
 
+@doc raw"""
+    is_normal(X::AbsAffineScheme; check::Bool=true) -> Bool
+
+# Input:
+- a reduced scheme ``X``,
+- if `check` is `true`, then confirm that ``X`` is reduced; this is expensive.
+
+# Output:
+Returns whether the scheme ``X`` is normal.
+
+# Examples
+```jldoctest
+julia> R, (x, y, z) = rational_field()["x", "y", "z"];
+
+julia> X = spec(R);
+
+julia> is_normal(X)
+```
+"""
+function is_normal(X::AbsAffineScheme; check::Bool=true)
+  !check || is_reduced(X) || return false
+  R = coordinate_ring(X)
+  return is_normal(R)
+end
+
 # Todo: Normalizations of localizations
 #function _normalization(X::AbsAffineScheme{<:Field, <:MPolyLocRing}; algorithm=:equidimDec)
 #  L = OO(X)

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
@@ -198,7 +198,7 @@ true
 function is_normal(X::AbsAffineScheme; check::Bool=true)
   !check || is_reduced(X) || return false
   R = coordinate_ring(X)
-  return is_normal(R)
+  return is_normal(R; check=check)
 end
 
 # Todo: Normalizations of localizations

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Methods.jl
@@ -192,6 +192,7 @@ julia> R, (x, y, z) = rational_field()["x", "y", "z"];
 julia> X = spec(R);
 
 julia> is_normal(X)
+true
 ```
 """
 function is_normal(X::AbsAffineScheme; check::Bool=true)

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Methods.jl
@@ -179,7 +179,7 @@ true
 function is_normal(X::AbsCoveredScheme; check::Bool=true)
   !check || is_reduced(X) || return false
   for U in default_covering(X)
-    is_normal(U) || return false
+    is_normal(U; check=check) || return false
   end
   return true
 end

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Methods.jl
@@ -173,6 +173,7 @@ julia> R, (x, y, z) = rational_field()["x", "y", "z"];
 julia> X = covered_scheme(spec(R));
 
 julia> is_normal(X)
+true
 ```
 """
 function is_normal(X::AbsCoveredScheme; check::Bool=true)

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Methods.jl
@@ -157,6 +157,33 @@ function base_change(phi::Any, X::AbsCoveredScheme)
 end
 
 @doc raw"""
+    is_normal(X::AbsCoveredScheme; check::Bool=true) -> Bool
+
+# Input:
+- a reduced scheme ``X``,
+- if `check` is `true`, then confirm that ``X`` is reduced; this is expensive.
+
+# Output:
+Returns whether the scheme ``X`` is normal.
+
+# Examples
+```jldoctest
+julia> R, (x, y, z) = rational_field()["x", "y", "z"];
+
+julia> X = covered_scheme(spec(R));
+
+julia> is_normal(X)
+```
+"""
+function is_normal(X::AbsCoveredScheme; check::Bool=true)
+  !check || is_reduced(X) || return false
+  for U in default_covering(X)
+    is_normal(U) || return false
+  end
+  return true
+end
+
+@doc raw"""
     normalization(X::AbsCoveredScheme; check::Bool=true) -> (AbsCoveredScheme, AbsCoveredSchemeMor, Vector{<:AbsCoveredSchemeMor})
 
 Return the normalization of the reduced scheme ``X``.

--- a/src/Rings/mpoly-affine-algebras.jl
+++ b/src/Rings/mpoly-affine-algebras.jl
@@ -63,7 +63,7 @@ end
     vector_space_dimension(A::MPolyQuoRing)
 
 If, say, `A = R/I`, where `R` is a multivariate polynomial ring over a field
-`K`, and `I` is a zero-dimensional ideal of `R`, return the dimension of `A` 
+`K`, and `I` is a zero-dimensional ideal of `R`, return the dimension of `A`
 as a `K`-vector space.
 
 If `A` is not a finite-dimensional vector space, an exception is raised.
@@ -108,7 +108,7 @@ end
     monomial_basis(A::MPolyQuoRing)
 
 If, say, `A = R/I`, where `R` is a multivariate polynomial ring over a field
-`K`, and `I` is a zero-dimensional ideal of `R`, return a vector of monomials of `R` 
+`K`, and `I` is a zero-dimensional ideal of `R`, return a vector of monomials of `R`
 such that the residue classes of these monomials form a basis of `A` as a `K`-vector
 space.
 
@@ -155,7 +155,7 @@ end
 
 Given an affine algebra `A` over a field which is graded by a free
 group of type `FinGenAbGroup`, and given an element `g` of that group,
-return a vector of monomials of `R` such that the residue classes of 
+return a vector of monomials of `R` such that the residue classes of
 these monomials form a `K`-basis of the graded part of `A` of degree `g`.
 
     monomial_basis(A::MPolyQuoRing, W::Vector{<:IntegerUnion})
@@ -225,16 +225,16 @@ end
 ##################################################################################
 
 
-# TODO: The function below now also works for rings which are not standard graded 
-# by virtue of Abbott's implementation. Clean up the docstring accordingly. 
+# TODO: The function below now also works for rings which are not standard graded
+# by virtue of Abbott's implementation. Clean up the docstring accordingly.
 @doc raw"""
     hilbert_series(A::MPolyQuoRing; backend::Symbol=:Singular, algorithm::Symbol=:BayerStillmanA)
 
-Given a $\mathbb Z$-graded affine algebra $A = R/I$ over a field $K$, where the grading 
-is inherited from a $\mathbb Z$-grading on the polynomial ring $R$ defined by assigning 
-positive integer weights to the variables, return a pair $(p,q)$, say, of univariate 
-polynomials $p, q\in\mathbb Z[t]$ such that $p/q$ represents the Hilbert series of $A$ as 
-a rational function with denominator 
+Given a $\mathbb Z$-graded affine algebra $A = R/I$ over a field $K$, where the grading
+is inherited from a $\mathbb Z$-grading on the polynomial ring $R$ defined by assigning
+positive integer weights to the variables, return a pair $(p,q)$, say, of univariate
+polynomials $p, q\in\mathbb Z[t]$ such that $p/q$ represents the Hilbert series of $A$ as
+a rational function with denominator
 
 $q = (1-t^{w_1})\cdots (1-t^{w_n}),$
 
@@ -242,10 +242,10 @@ where $n$ is the number of variables of $R$, and $w_1, \dots, w_n$ are the assig
 
 See also `hilbert_series_reduced`.
 
-!!! note 
-    The advanced user can select different backends for the computation (`:Singular` and 
-    `:Abbott` for the moment), as well as different algorithms. The latter might be 
-    ignored for certain backends. 
+!!! note
+    The advanced user can select different backends for the computation (`:Singular` and
+    `:Abbott` for the moment), as well as different algorithms. The latter might be
+    ignored for certain backends.
 
 # Examples
 ```jldoctest
@@ -287,11 +287,11 @@ number_of_generators(S::AbstractAlgebra.Generic.LaurentPolyWrapRing) = 1
 @doc raw"""
     hilbert_series_reduced(A::MPolyQuoRing)
 
-Given a $\mathbb Z$-graded affine algebra $A = R/I$ over a field $K$, where the grading 
-is inherited from a $\mathbb Z$-grading on the polynomial ring $R$ defined by assigning 
-positive integer weights to the variables, return a pair $(p,q)$, say, of univariate 
-polynomials $p, q\in\mathbb Z[t]$ such that $p/q$ represents the Hilbert series of 
-$A$ as a rational function written in lowest terms. 
+Given a $\mathbb Z$-graded affine algebra $A = R/I$ over a field $K$, where the grading
+is inherited from a $\mathbb Z$-grading on the polynomial ring $R$ defined by assigning
+positive integer weights to the variables, return a pair $(p,q)$, say, of univariate
+polynomials $p, q\in\mathbb Z[t]$ such that $p/q$ represents the Hilbert series of
+$A$ as a rational function written in lowest terms.
 
 See also `hilbert_series`.
 
@@ -326,9 +326,9 @@ end
 @doc raw"""
     hilbert_series_expanded(A::MPolyQuoRing, d::Int)
 
-Given a $\mathbb Z$-graded affine algebra $A = R/I$ over a field $K$, where the grading 
-is inherited from a $\mathbb Z$-grading on the polynomial ring $R$ defined by assigning 
-positive integer weights to the variables, return the Hilbert series of $A$ to precision $d$. 
+Given a $\mathbb Z$-graded affine algebra $A = R/I$ over a field $K$, where the grading
+is inherited from a $\mathbb Z$-grading on the polynomial ring $R$ defined by assigning
+positive integer weights to the variables, return the Hilbert series of $A$ to precision $d$.
 
 # Examples
 ```jldoctest
@@ -358,18 +358,18 @@ function hilbert_series_expanded(A::MPolyQuoRing, d::Int)
     T, t = power_series_ring(QQ, d+1, "t")
     return _rational_function_to_power_series(T, num, evaluate(denom))
   end
-  H = HilbertData(A.I)  
+  H = HilbertData(A.I)
   return hilbert_series_expanded(H, d)
 end
 
 @doc raw"""
     hilbert_function(A::MPolyQuoRing, d::Int)
 
-Given a $\mathbb Z$-graded affine algebra $A = R/I$ over a field $K$, where the grading 
-is inherited from a $\mathbb Z$-grading on the polynomial ring $R$ defined by assigning 
-positive integer weights to the variables, return the value $H(A, d),$ where 
+Given a $\mathbb Z$-graded affine algebra $A = R/I$ over a field $K$, where the grading
+is inherited from a $\mathbb Z$-grading on the polynomial ring $R$ defined by assigning
+positive integer weights to the variables, return the value $H(A, d),$ where
 
-$H(A, \underline{\phantom{d}}): \N \to \N, \; d  \mapsto \dim_K A_d,$ 
+$H(A, \underline{\phantom{d}}): \N \to \N, \; d  \mapsto \dim_K A_d,$
 
 is the Hilbert function of $A$.
 
@@ -399,11 +399,11 @@ function hilbert_function(A::MPolyQuoRing, d::Int)
    H = HilbertData(A.I)
    return hilbert_function(H, d)
 end
-   
+
 @doc raw"""
      hilbert_polynomial(A::MPolyQuoRing)
 
-Given a $\mathbb Z$-graded affine algebra $A = R/I$ over a field $K$, where the grading 
+Given a $\mathbb Z$-graded affine algebra $A = R/I$ over a field $K$, where the grading
 is inherited from the standard $\mathbb Z$-grading on the polynomial ring $R$,
 return the Hilbert polynomial of $A$.
 
@@ -437,7 +437,7 @@ end
 @doc raw"""
     degree(A::MPolyQuoRing)
 
-Given a $\mathbb Z$-graded affine algebra $A = R/I$ over a field $K$, where the grading 
+Given a $\mathbb Z$-graded affine algebra $A = R/I$ over a field $K$, where the grading
 is inherited from the standard $\mathbb Z$-grading on the polynomial ring $R$,
 return the degree of $A$.
 
@@ -466,11 +466,11 @@ end
 ###############################################################################
 
 ### TODO: Originally meant to be used in multi_hilbert_series; might be useful elsewhere
-function transform_to_positive_orthant(rs::Matrix{Int})   
+function transform_to_positive_orthant(rs::Matrix{Int})
     C = positive_hull(rs)
     @assert is_fulldimensional(C) "Cone spanned by generator degrees needs to be full-dimensional"
     F = linear_inequality_matrix(facets(C))
-    
+
     # Find a simplicial cone containing C
     index = 2
     full_rank_subset = [1]
@@ -490,7 +490,7 @@ function transform_to_positive_orthant(rs::Matrix{Int})
         end
     end
     Csimplicial = cone_from_inequalities(F[full_rank_subset,:])
-    
+
     @assert Polymake.polytope.included_polyhedra(C.pm_cone, Csimplicial.pm_cone) "Cone containment violated"
     CsRays = Polymake.common.primitive(Csimplicial.pm_cone.RAYS)
     CsRays = matrix(ZZ, CsRays)
@@ -514,8 +514,8 @@ end
 
 Return the Hilbert series of the graded affine algebra `A`.
 
-!!! note 
-    The advanced user can select an `algorithm` for the computation; 
+!!! note
+    The advanced user can select an `algorithm` for the computation;
     see the code for details.
 
 # Examples
@@ -573,8 +573,8 @@ Map
 ```
 """
 function multi_hilbert_series(
-    A::MPolyQuoRing; 
-    algorithm::Symbol=:BayerStillmanA, 
+    A::MPolyQuoRing;
+    algorithm::Symbol=:BayerStillmanA,
     backend::Symbol=:Abbott,
     parent::Union{Nothing, Ring}=nothing
   )
@@ -583,12 +583,12 @@ function multi_hilbert_series(
   @req coefficient_ring(R) isa AbstractAlgebra.Field "The coefficient ring must be a field"
   @req is_positively_graded(A) "the ring must be positively graded"
 
-  # Wrap the case where G is abstractly isomorphic to ℤᵐ, but not realized as a 
-  # free Abelian group. 
+  # Wrap the case where G is abstractly isomorphic to ℤᵐ, but not realized as a
+  # free Abelian group.
   #
-  # We use the Smith normal form to get there, recreate the graded ring with the 
-  # free grading group, do the computation there and return the isomorphism for 
-  # the grading. 
+  # We use the Smith normal form to get there, recreate the graded ring with the
+  # free grading group, do the computation there and return the isomorphism for
+  # the grading.
   G = grading_group(R)
   if !is_zm_graded(R)
     H, iso = snf(G)
@@ -604,7 +604,7 @@ function multi_hilbert_series(
   end
 
   # Now we may assume that the grading group is free Abelian.
-  m = ngens(G)  
+  m = ngens(G)
   n = ngens(R)
   HSRing = _hilbert_series_ring(parent, m)
 
@@ -660,7 +660,7 @@ end
 #      I = change(A.I)
 #      R = S
 #   end
-#   m = ngens(grading_group(R))  
+#   m = ngens(grading_group(R))
 #   n = ngens(R)
 #   W = R.d
 #   MI = Matrix{Int}(undef, n, m)
@@ -671,16 +671,16 @@ end
 #   end
 #   minMI = minimum(MI)
 #   if minMI<0
-#      MI, T = transform_to_positive_orthant(MI)     
+#      MI, T = transform_to_positive_orthant(MI)
 #   else
 #      T = identity_matrix(ZZ, m)
-#   end  
+#   end
 #   if m == 1
 #      VAR = ["t"]
 #   else
 #      VAR = ["t[$i]" for i = 1:m]
 #   end
-#   S, _ = polynomial_ring(ZZ, VAR) 
+#   S, _ = polynomial_ring(ZZ, VAR)
 #   q = one(S)
 #   for i = 1:n
 #      e = [Int(MI[i, :][j]) for j = 1:m]
@@ -706,8 +706,8 @@ end
 
 Return the reduced Hilbert series of the positively graded affine algebra `A`.
 
-!!! note 
-    The advanced user can select a `algorithm` for the computation; 
+!!! note
+    The advanced user can select a `algorithm` for the computation;
     see the code for details.
 
 # Examples
@@ -801,14 +801,14 @@ $H(A, \underline{\phantom{d}}): G \to \N, \; g\mapsto \dim_K(A_g).$
     multi_hilbert_function(A::MPolyQuoRing, g::Vector{<:IntegerUnion})
 
 Given a positively $\mathbb  Z^m$-graded affine algebra $A$ over a field $K$,
-and given a vector $g$ of $m$ integers, convert $g$ into an element 
+and given a vector $g$ of $m$ integers, convert $g$ into an element
 of the grading group of $A$, and return the value $H(A, g)$
 as above.
 
     multi_hilbert_function(A::MPolyQuoRing, g::IntegerUnion)
 
 Given a positively $\mathbb  Z$-graded affine algebra $A$ over a field $K$,
-and given an integer $g$, convert $g$ into an element of the grading group 
+and given an integer $g$, convert $g$ into an element of the grading group
 of $A$, and return the value $H(A, g)$ as above.
 
 # Examples
@@ -853,9 +853,9 @@ julia> multi_hilbert_function(A, 7*g)
 function multi_hilbert_function(A::MPolyQuoRing, g::FinGenAbGroupElem)
     R = base_ring(A)
     @req coefficient_ring(R) isa AbstractAlgebra.Field "The coefficient ring must be a field"
-    
+
     L = monomial_basis(R, g)
-    
+
     if size(L) == 0
        return 0
     end
@@ -863,7 +863,7 @@ function multi_hilbert_function(A::MPolyQuoRing, g::FinGenAbGroupElem)
     LI = leading_ideal(A.I, ordering=degrevlex(gens(R)))
     ### TODO: Decide whether we should check whether a GB with respect
     ### to another degree-compatible ordering is already available
-    
+
     cc = 0
     for i in 1:length(L)
         if !(L[i] in LI)
@@ -912,13 +912,23 @@ false
   return is_radical(I)
 end
 
+function is_normal(A::MPolyRing)
+  @req coefficient_ring(A) isa AbstractAlgebra.Field "Only implemented if coefficient ring is a field"
+  @req is_perfect(coefficient_ring(A)) "Only implemented if coefficient ring is a perfect field"
+  return true
+end
+
 @doc raw"""
-    is_normal(A::MPolyQuoRing)
+    is_normal(A::MPolyAnyRing) -> Bool
 
-Given an affine algebra `A` over a perfect field,
-return `true` if `A` is normal, `false` otherwise.
+# Input:
+- an affine algebra ``A`` over a perfect field,
+- if `check` is `true`, then confirm that ``A`` is reduced; this is expensive.
 
-!!! note 
+# Output:
+Returns `true` if the ring ``A`` is normal, `false` otherwise.
+
+!!! note
     This function performs the first step of the normalization algorithm of Greuel, Laplagne, and Seelisch [GLS10](@cite) and may, thus, be more efficient than computing the full normalization of `A`.
 
 # Examples
@@ -931,25 +941,29 @@ julia> is_normal(A)
 true
 ```
 """
-@attr Bool function is_normal(A::MPolyQuoRing)
-  @req coefficient_ring(A) isa AbstractAlgebra.Field "The coefficient ring must be a field"
-  @req !(base_ring(A) isa MPolyDecRing) "Not implemented for quotients of decorated rings"
+function is_normal(A::MPolyQuoRing; check::Bool=true)
+  return get_attribute!(A, :is_normal) do
+    @req coefficient_ring(A) isa AbstractAlgebra.Field "Only implemented if coefficient ring is a field"
+    @req is_perfect(coefficient_ring(A)) "Only implemented if coefficient ring is a perfect field"
+    @req !(base_ring(A) isa MPolyDecRing) "Not implemented for quotients of decorated rings"
+    !check || is_reduced(A) || return false
 
-  I = A.I
-  # TODO remove old1 & old2 once new Singular jll is out
-# QUESTION: How old is this? Has this been fixed yet?
-  old1 = Singular.libSingular.set_option("OPT_REDSB", false)
-  old2 = Singular.libSingular.set_option("OPT_RETURN_SB", false)
-  f = Singular.LibNormal.isNormal(singular_generators(I))::Int
-  Singular.libSingular.set_option("OPT_REDSB", old1)
-  Singular.libSingular.set_option("OPT_RETURN_SB", old2)
-  return Bool(f)
+    I = A.I
+    # TODO remove old1 & old2 once new Singular jll is out
+    # QUESTION: How old is this? Has this been fixed yet?
+    old1 = Singular.libSingular.set_option("OPT_REDSB", false)
+    old2 = Singular.libSingular.set_option("OPT_RETURN_SB", false)
+    f = Singular.LibNormal.isNormal(singular_generators(I))::Int
+    Singular.libSingular.set_option("OPT_REDSB", old1)
+    Singular.libSingular.set_option("OPT_RETURN_SB", old2)
+    return Bool(f)
+  end
 end
 
 @doc raw"""
-     is_cohen_macaulay(A::MPolyQuoRing) 
+     is_cohen_macaulay(A::MPolyQuoRing)
 
-Given a $\mathbb Z$-graded affine algebra `A = R/I` over a field, say, `K`, where the grading 
+Given a $\mathbb Z$-graded affine algebra `A = R/I` over a field, say, `K`, where the grading
 is inherited from the standard $\mathbb Z$-grading on the polynomial ring `R`,
 return `true` if `A` is a Cohen-Macaulay ring, `false` otherwise.
 
@@ -1109,7 +1123,7 @@ end
 @doc raw"""
     is_algebraically_independent(V::Vector{T}) where T <: Union{MPolyRingElem, MPolyQuoRingElem}
 
-Given a vector `V` of elements of a multivariate polynomial ring over a field `K`, say, or of a quotient of such a ring, 
+Given a vector `V` of elements of a multivariate polynomial ring over a field `K`, say, or of a quotient of such a ring,
 return if the elements of `V` are algebraically independent over `K`.
 
 # Examples
@@ -1138,7 +1152,7 @@ end
 @doc raw"""
     is_algebraically_independent_with_relations(V::Vector{T}) where T <: Union{MPolyRingElem, MPolyQuoRingElem}
 
-Given a vector `V` of elements of a multivariate polynomial ring over a field `K`, say, or of a quotient of such a ring, 
+Given a vector `V` of elements of a multivariate polynomial ring over a field `K`, say, or of a quotient of such a ring,
 return `(true, ideal(0))` if the elements of `V` are algebraically independent over `K`.
 Otherwise, return `false` together with the ideal of `K`-algebra relations.
 
@@ -1322,14 +1336,14 @@ end
 
 Find the normalization of a reduced affine algebra over a perfect field $K$.
 That is, given the quotient $A=R/I$ of a multivariate polynomial ring $R$ over $K$
-modulo a radical ideal $I$, compute the integral closure $\overline{A}$ 
-of $A$ in its total ring of fractions $Q(A)$, together with the embedding 
-$f: A \to \overline{A}$. 
+modulo a radical ideal $I$, compute the integral closure $\overline{A}$
+of $A$ in its total ring of fractions $Q(A)$, together with the embedding
+$f: A \to \overline{A}$.
 
 # Implemented Algorithms and how to Read the Output
 
-The function relies on the algorithm 
-of Greuel, Laplagne, and Seelisch which proceeds by finding a suitable decomposition 
+The function relies on the algorithm
+of Greuel, Laplagne, and Seelisch which proceeds by finding a suitable decomposition
 $I=I_1\cap\dots\cap I_r$ into radical ideals $I_k$, together with
 maps $A = R/I \to A_k=\overline{R/I_k}$ which give rise to the normalization map of $A$:
 
@@ -1339,10 +1353,10 @@ For each $k$, the function specifies two representations
 of $A_k$: It returns an array of triples $(A_k, f_k, \mathfrak a_k)$,
 where $A_k$ is represented as an affine $K$-algebra, and $f_k$ as a map of affine $K$-algebras.
 The third entry $\mathfrak a_k$ is a tuple $(d_k, J_k)$, consisting of an element
-$d_k\in A$ and an ideal $J_k\subset A$, such that $\frac{1}{d_k}J_k = A_k$ 
+$d_k\in A$ and an ideal $J_k\subset A$, such that $\frac{1}{d_k}J_k = A_k$
 as $A$-submodules of the total ring of fractions of $A$.
 
-By default (`algorithm = :equidimDec`), as a first step on its way to find the decomposition $I=I_1\cap\dots\cap I_r$, 
+By default (`algorithm = :equidimDec`), as a first step on its way to find the decomposition $I=I_1\cap\dots\cap I_r$,
 the algorithm computes an equidimensional decomposition of the radical ideal $I$.
 Alternatively, if specified by `algorithm = :primeDec`, the algorithm computes $I=I_1\cap\dots\cap I_r$
 as the prime decomposition of the radical ideal $I$.
@@ -1405,9 +1419,9 @@ Compute the normalization
 $A\hookrightarrow A_1\times \dots\times A_r=\overline{A}$
 
 of $A$ as does `normalize(A)`, but return additionally the `delta invariant` of $A$,
-that is, the dimension 
+that is, the dimension
 
-$\dim_K(\overline{A}/A)$. 
+$\dim_K(\overline{A}/A)$.
 
 # How to Read the Output
 
@@ -1465,8 +1479,8 @@ end
     noether_normalization(A::MPolyQuoRing)
 
 Given an affine algebra $A=R/I$ over a field $K$, return a triple $(V,F,G)$ such that:
-- ``V`` is a vector of $d=\dim A$ elements of $A$, represented by linear forms $l_i\in R$, and such that $K[V]\hookrightarrow A$ is a Noether normalization for $A$; 
-- ``F: A=R/I \to B = R/\phi(I)`` is an isomorphism, induced by a linear change $\phi$ of coordinates of $R$ which maps the $l_i$ to the the last $d$ variables of $R$; 
+- ``V`` is a vector of $d=\dim A$ elements of $A$, represented by linear forms $l_i\in R$, and such that $K[V]\hookrightarrow A$ is a Noether normalization for $A$;
+- ``F: A=R/I \to B = R/\phi(I)`` is an isomorphism, induced by a linear change $\phi$ of coordinates of $R$ which maps the $l_i$ to the the last $d$ variables of $R$;
 - ``G = F^{-1}.``
 
 !!! warning
@@ -1553,7 +1567,7 @@ function integral_basis(f::MPolyRingElem, i::Int; algorithm::Symbol = :normal_lo
   end
 
   @req !(R isa MPolyDecRing) "Not implemented for decorated rings"
-  
+
   @req nvars(R) == 2 "The parent ring must be a polynomial ring in two variables"
 
   @req i == 1 || i == 2 "The index $i must be either 1 or 2, indicating the integral variable"

--- a/src/Rings/mpoly-affine-algebras.jl
+++ b/src/Rings/mpoly-affine-algebras.jl
@@ -912,14 +912,14 @@ false
   return is_radical(I)
 end
 
-function is_normal(A::MPolyRing)
+function is_normal(A::MPolyRing; check::Bool=true)
   @req coefficient_ring(A) isa AbstractAlgebra.Field "Only implemented if coefficient ring is a field"
   @req is_perfect(coefficient_ring(A)) "Only implemented if coefficient ring is a perfect field"
   return true
 end
 
 @doc raw"""
-    is_normal(A::MPolyAnyRing) -> Bool
+    is_normal(A::MPolyAnyRing; check::Bool=true) -> Bool
 
 # Input:
 - an affine algebra ``A`` over a perfect field,

--- a/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
+++ b/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
@@ -380,8 +380,10 @@ end
   # non-normal
   I = ideal(R, x^3-y^2)
   X1 = spec(R,I)
+  @test !is_normal(X1; check=false)
   N1 = normalization(X1)
   @test length(N1) == 1
+  @test is_normal(N1[1][1]; check=false)
   @test is_smooth(N1[1][1])
   # normal
   J = ideal(R, x)

--- a/test/AlgebraicGeometry/Schemes/CoveredScheme.jl
+++ b/test/AlgebraicGeometry/Schemes/CoveredScheme.jl
@@ -326,9 +326,11 @@
     R, (x, y, z) = grade(QQ["x", "y", "z"][1])
     I = ideal(R, z*x^2 + y^3)
     X = covered_scheme(proj(R, I))
+    @test !is_normal(X; check=false)
     N = normalization(X)
     # trigger the computation of some gluings
     Xnorm = N[1]
+    @test is_normal(Xnorm; check=false)
     Cnorm = Xnorm[1] # a covering
     gluing_morphisms(Cnorm[1,2])
     gluing_morphisms(Cnorm[1,3])
@@ -339,9 +341,11 @@
     R, (x, y, z) = grade(QQ["x", "y", "z"][1])
     I = ideal(R, (z*x^2 + y^3)*(x))
     X = covered_scheme(proj(R, I))
+    @test !is_normal(X; check=false)
     N = normalization(X)
     # trigger the computation of some gluings
     Xnorm = N[1]
+    @test is_normal(Xnorm; check=false)
     Cnorm = Xnorm[1] # a covering
     gluing_morphisms(Cnorm[1,2])
 
@@ -354,5 +358,11 @@
     Xnorm = N[1]
     Cnorm = Xnorm[1] # a covering
     gluing_morphisms(Cnorm[1,2])
+
+    # Example non-reduced
+    R, (x, y) = polynomial_ring(rational_field(), ["x", "y"])
+    I = ideal(R, x^2)
+    X = covered_scheme(spec(R, I))
+    @test !is_normal(X)
   end
 end

--- a/test/Rings/mpoly_affine_algebras.jl
+++ b/test/Rings/mpoly_affine_algebras.jl
@@ -37,8 +37,9 @@
     end
   end
 
-  @test !is_normal(quo(R, ideal(R, [x^2 - y^3]))[1])
-  @test is_normal(quo(R, ideal(R, [x - y^3]))[1])
+  @test !is_normal(quo(R, ideal(R, [x^2 - y^3]))[1]; check=false)
+  @test is_normal(quo(R, ideal(R, [x - y^3]))[1]; check=false)
+  @test !is_normal(quo(R, ideal(R, [x^2]))[1])
 
   R, (x, y, z) = polynomial_ring(ZZ, ["x", "y", "z"])
   @test_throws ArgumentError is_normal(quo(R, ideal(R, [x - y^3]))[1])

--- a/test/Rings/mpoly_affine_algebras.jl
+++ b/test/Rings/mpoly_affine_algebras.jl
@@ -40,6 +40,7 @@
   @test !is_normal(quo(R, ideal(R, [x^2 - y^3]))[1]; check=false)
   @test is_normal(quo(R, ideal(R, [x - y^3]))[1]; check=false)
   @test !is_normal(quo(R, ideal(R, [x^2]))[1])
+  @test is_normal(quo(R, ideal(R, [z^2 - x*y]))[1])
 
   R, (x, y, z) = polynomial_ring(ZZ, ["x", "y", "z"])
   @test_throws ArgumentError is_normal(quo(R, ideal(R, [x - y^3]))[1])


### PR DESCRIPTION
Also fixed a bug in `is_normal` for quotient rings: now it checks that the ring is reduced. This bug is still present in Singular ( https://www.singular.uni-kl.de/hannes/sing_1485.htm#SEC1566 ).