### PR TITLE
Matroids: add constructors for algebraic matroids

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -207,6 +207,7 @@ export affine_space
 export alexander_dual
 export algebraic_ideal
 export algebraic_matrix
+export algebraic_matroid
 export algebraic_pluecker_vector
 export algebraic_polynomial
 export algebraic_set
@@ -959,6 +960,7 @@ export matroid_from_hyperplanes
 export matroid_from_matrix_columns
 export matroid_from_matrix_rows
 export matroid_from_nonbases
+export matroid_from_prime_ideal
 export matroid_from_revlex_basis_encoding
 export matroid_groundset
 export max_GC_rank_polytope


### PR DESCRIPTION
Add `matroid_from_prime_ideal` and `algebraic_matroid` which create a `Matroid` from a prime ideal in a multivariate polynomial ring or a list of elements in an affine algebra (or a fraction field of one), respectively.

*Note:* that most of the added code in `algebraic_matroid` is used to find the algebraic relations among elements in a fraction field of (a quotient of) a polynomial ring. Neither `is_algebraically_dependent_with_relations` nor `kernel` of a homomorphism currently seem to support such fraction fields.