### PR TITLE
booktests: clear verbosity levels before running each chapter

### DIFF
--- a/test/book/test.jl
+++ b/test/book/test.jl
@@ -205,6 +205,9 @@ isdefined(Main, :FakeTerminals) || include(joinpath(pkgdir(REPL),"test","FakeTer
             mockrepl = MockREPLHelper(chapter)
             println("  created mockrepl: $(mockrepl.mockdule)")
 
+            # clear verbosity levels before each chapter
+            empty!(Hecke.VERBOSE_LOOKUP)
+
             copy!(LOAD_PATH, custom_load_path)
             auxmain = joinpath(Oscar.oscardir, "test/book", chapter, "auxiliary_code", "main.jl")
             if isfile(auxmain)


### PR DESCRIPTION
Make sure the booktests are not affected by other tests changing verbosity levels and just use the defaults.

cc: @thofma 