### PR TITLE
improve `isomorphism(FPGroup, G, on_gens = true)`

### DIFF
--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -547,6 +547,11 @@ function isomorphism(::Type{FPGroup}, G::GAPGroup; on_gens::Bool=false)
          if GAP.Globals.HasFamilyPcgs(G.X)
            pcgs = GAP.Globals.InducedPcgsWrtFamilyPcgs(G.X)
            if pcgs == Ggens
+             # `pcgs` fits *and* is an object in `GAP.Globals.IsPcgs`,
+             # for which a special `GAPWrap.IsomorphismFpGroupByGenerators`
+             # method is applicable.
+             # (Currently the alternative is a cokernel computation.
+             # It might be useful to improve this on the GAP side.)
              Ggens = pcgs
            end
          end

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -542,6 +542,14 @@ function isomorphism(::Type{FPGroup}, G::GAPGroup; on_gens::Bool=false)
          f = GAP.Globals.GroupHomomorphismByImages(G.X, GAP.Globals.FreeGroup(0), GAP.Obj([]), GAP.Obj([]))
          GAP.Globals.SetIsBijective(f, true)
        else
+         # The computations are easy if `Ggens` is a pcgs,
+         # otherwise GAP will call `CoKernel`.
+         if GAP.Globals.HasFamilyPcgs(G.X)
+           pcgs = GAP.Globals.InducedPcgsWrtFamilyPcgs(G.X)
+           if pcgs == Ggens
+             Ggens = pcgs
+           end
+         end
          f = GAPWrap.IsomorphismFpGroupByGenerators(G.X, Ggens)
        end
      else


### PR DESCRIPTION
in the situation that the generators of G form a pcgs, for example if `gens(G)` is the tail of the defining pcgs of the full pc group that contains `G`.
@fieker had noticed that one runs into big unnecessary computations in this situation.

(Perhaps this situation should be supported also in GAP.)