### PR TITLE
Workaround for https://github.com/oscar-system/Singular.jl/issues/796

### DIFF
--- a/src/Modules/UngradedModules/Presentation.jl
+++ b/src/Modules/UngradedModules/Presentation.jl
@@ -522,7 +522,8 @@ function prune_with_map(M::ModuleFP{T}) where {T<:MPolyRingElem{<:FieldElem}} # 
   pres_map = map(pm, 1)
   krnel = SubquoModule(pm[0], pres_map.(gens(pm[1]))) # Create the image of pres_map without the inclusion map
 
-  # work around if we're passing the zero module to singular
+  # work around if we're passing the zero module to singular, see
+  # https://github.com/oscar-system/Singular.jl/issues/796
   if iszero(krnel)
     return M, identity_map(M)
   end

--- a/src/Modules/UngradedModules/Presentation.jl
+++ b/src/Modules/UngradedModules/Presentation.jl
@@ -521,6 +521,12 @@ function prune_with_map(M::ModuleFP{T}) where {T<:MPolyRingElem{<:FieldElem}} # 
   pm = presentation(M)
   pres_map = map(pm, 1)
   krnel = SubquoModule(pm[0], pres_map.(gens(pm[1]))) # Create the image of pres_map without the inclusion map
+
+  # work around if we're passing the zero module to singular
+  if iszero(krnel)
+    return M, identity_map(M)
+  end
+  
   s_fmod  = Oscar.singular_module(ambient_free_module(krnel))
   s_mod = Singular.Module(base_ring(s_fmod),
                           [s_fmod(repres(g)) for g in gens(krnel)]...)


### PR DESCRIPTION
This is a workaround if we pass the zero module to Singular in `prune_with_map`. In this case the Singular function `prune_with_map_projection` has inconsistent output with other modules, causing a bug.