### PR TITLE
Some clean-up on monomial orderings of ideal gens

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -148,6 +148,7 @@ function __init__()
   add_verbosity_scope(:ZZLatWithIsom)
   
   add_assertion_scope(:IdealSheaves)
+  add_assertion_scope(:IdealGens)
 
   # Pkg.is_manifest_current() returns false if the manifest might be out of date
   # (but might return nothing when there is no project_hash)

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -315,8 +315,8 @@ function singular_generators(B::IdealGens, monorder::MonomialOrdering=default_or
     # Whenever both are set, the monomial orderings on the Oscar side and the Singular side should agree.
     # However, it might be the case that some (newly added) code is breaking this. In order to snoop 
     # for that, we allow for the assertion level to be put up and then this will throw. 
-    @hassert :IdealGens 1 monomial_ordering(B.Ox, Singular.ordering(base_ring(B.S))) == B.ord "orderings did not agree on the Oscar and the Singular side"
-    #@assert monomial_ordering(B.Ox, Singular.ordering(base_ring(B.S))) == B.ord "orderings did not agree on the Oscar and the Singular side"
+    @hassert :IdealGens 1 monomial_ordering(B.Ox, Singular.ordering(base_ring(B.S))) == B.ord
+    @assert monomial_ordering(B.Ox, Singular.ordering(base_ring(B.S))) == B.ord "orderings did not agree on the Oscar and the Singular side"
     return B.gens.S
   end
   SR = singular_poly_ring(B.Ox, monorder)

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -311,7 +311,11 @@ function singular_generators(B::IdealGens, monorder::MonomialOrdering=default_or
   singular_assure(B)
   # in case of quotient rings, monomial ordering is ignored so far in singular_poly_ring
   isa(B.gens.Ox, MPolyQuoRing) && return B.gens.S
-  isdefined(B, :ord) && B.ord == monorder && monomial_ordering(B.Ox, Singular.ordering(base_ring(B.S))) == B.ord && return B.gens.S
+  if isdefined(B, :ord) && (B.ord === monorder || B.ord == monorder)
+    @hassert :IdealGens 1 monomial_ordering(B.Ox, Singular.ordering(base_ring(B.S))) == B.ord "orderings did not agree on the Oscar and the Singular side"
+    @assert monomial_ordering(B.Ox, Singular.ordering(base_ring(B.S))) == B.ord "orderings did not agree on the Oscar and the Singular side"
+    return B.gens.S
+  end
   SR = singular_poly_ring(B.Ox, monorder)
   f = Singular.AlgebraHomomorphism(B.Sx, SR, gens(SR))
   return Singular.map_ideal(f, B.gens.S)

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -312,8 +312,11 @@ function singular_generators(B::IdealGens, monorder::MonomialOrdering=default_or
   # in case of quotient rings, monomial ordering is ignored so far in singular_poly_ring
   isa(B.gens.Ox, MPolyQuoRing) && return B.gens.S
   if isdefined(B, :ord) && (B.ord === monorder || B.ord == monorder)
+    # Whenever both are set, the monomial orderings on the Oscar side and the Singular side should agree.
+    # However, it might be the case that some (newly added) code is breaking this. In order to snoop 
+    # for that, we allow for the assertion level to be put up and then this will throw. 
     @hassert :IdealGens 1 monomial_ordering(B.Ox, Singular.ordering(base_ring(B.S))) == B.ord "orderings did not agree on the Oscar and the Singular side"
-    @assert monomial_ordering(B.Ox, Singular.ordering(base_ring(B.S))) == B.ord "orderings did not agree on the Oscar and the Singular side"
+    #@assert monomial_ordering(B.Ox, Singular.ordering(base_ring(B.S))) == B.ord "orderings did not agree on the Oscar and the Singular side"
     return B.gens.S
   end
   SR = singular_poly_ring(B.Ox, monorder)


### PR DESCRIPTION
After talking with @jankoboehm today about the problem mentioned on the other (merged) PR, we would like to try this new solution to hopefully avoid unnecessary comparison of monomial orderings in the call to `singular_generators`. 

The current version is to check whether the CI passes. If this is the case, then the assertion will be turned into an `hassert` so that one can still test this, but the check is not run all the time and the unnecessary comparison of monomial orderings does not take place. 

CC: @joschmitt , @fingolfin 