### PR TITLE
Add `reduce(::MPolyRingPoly, ::IdealGens)` etc.

### DIFF
--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -646,14 +646,14 @@ function reduce(I::IdealGens, J::IdealGens; ordering::MonomialOrdering = default
 end
 
 @doc raw"""
-    reduce(g::T, F::Vector{T}; 
-           ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where T <: MPolyRingElem
+    reduce(g::T, F::Union{Vector{T}, IdealGens{T}};
+           ordering::MonomialOrdering = default_ordering(g)), complete_reduction::Bool = false) where T <: MPolyRingElem
 
 If `ordering` is global, return the remainder in a standard representation for `g` on division by the polynomials in `F` with respect to `ordering`.
 Otherwise, return the remainder in a *weak* standard representation for `g` on division by the polynomials in `F` with respect to `ordering`.
 
-    reduce(G::Vector{T}, F::Vector{T};
-           ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where T <: MPolyRingElem
+    reduce(G::Vector{T}, F::Union{Vector{T}, IdealGens{T}};
+           ordering::MonomialOrdering = default_ordering(parent(G[1])), complete_reduction::Bool = false) where T <: MPolyRingElem
 
 Return a `Vector` which contains, for each element `g` of `G`, a remainder as above.
 
@@ -694,31 +694,41 @@ x^5 - x^3 + y^6 + z^6
 """
 function reduce(f::T, F::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(f)), complete_reduction::Bool = false) where {T <: MPolyRingElem}
   isempty(F) && return f
-  @assert parent(f) == parent(F[1])
-  R = parent(f)
-  I = IdealGens(R, [f], ordering)
-  J = IdealGens(R, F, ordering)
-  redv = reduce(I, J, ordering=ordering, complete_reduction=complete_reduction)
-  return redv[1]
+  J = IdealGens(parent(F[1]), F, ordering)
+  return reduce(f, J; ordering=ordering, complete_reduction=complete_reduction)
 end
 
 function reduce(F::Vector{T}, G::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where {T <: MPolyRingElem}
+  isempty(G) && return F
+  J = IdealGens(parent(G[1]), G, ordering)
+  return reduce(F, J; ordering=ordering, complete_reduction=complete_reduction)
+end
+
+function reduce(f::T, F::IdealGens{T}; ordering::MonomialOrdering = default_ordering(parent(f)), complete_reduction::Bool = false) where {T <: MPolyRingElem}
+  isempty(F) && return f
+  @assert parent(f) == base_ring(F)
+  R = parent(f)
+  I = IdealGens(R, [f], ordering)
+  redv = reduce(I, F, ordering=ordering, complete_reduction=complete_reduction)
+  return redv[1]
+end
+
+function reduce(F::Vector{T}, G::IdealGens{T}; ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where {T <: MPolyRingElem}
   (isempty(F) || isempty(G)) && return F
-  @assert parent(F[1]) == parent(G[1])
+  @assert parent(F[1]) == base_ring(G)
   R = parent(F[1])
   I = IdealGens(R, F, ordering)
-  J = IdealGens(R, G, ordering)
-  return reduce(I, J, ordering=ordering, complete_reduction=complete_reduction)
+  return reduce(I, G, ordering=ordering, complete_reduction=complete_reduction)
 end
 
 @doc raw"""
-    reduce_with_quotients_and_unit(g::T, F::Vector{T};
-           ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where T <: MPolyRingElem
+    reduce_with_quotients_and_unit(g::T, F::Union{Vector{T}, IdealGens{T}};
+           ordering::MonomialOrdering = default_ordering(parent(g)), complete_reduction::Bool = false) where T <: MPolyRingElem
 
 Return the unit, the quotients and the remainder in a weak standard representation for `g` on division by the polynomials in `F` with respect to `ordering`.
 
-    reduce_with_quotients_and_unit(G::Vector{T}, F::Vector{T};
-           ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where T <: MPolyRingElem
+    reduce_with_quotients_and_unit(G::Vector{T}, F::Union{Vector{T}, IdealGens{T}};
+           ordering::MonomialOrdering = default_ordering(parent(G[1])), complete_reduction::Bool = false) where T <: MPolyRingElem
 
 Return a `Vector` which contains, for each element `g` of `G`, a unit, quotients, and a remainder as above.
 
@@ -768,12 +778,8 @@ function reduce_with_quotients_and_unit(f::T, F::Vector{T}; ordering::MonomialOr
   if isempty(F)
     return identity_matrix(parent(f), 1), zero_matrix(parent(f), 1, 0), f
   end
-  @assert parent(f) == parent(F[1])
-  R = parent(f)
-  I = IdealGens(R, [f], ordering)
-  J = IdealGens(R, F, ordering)
-  u, q, r = _reduce_with_quotients_and_unit(I, J, ordering, complete_reduction)
-  return u, q, r[1]
+  J = IdealGens(parent(F[1]), F, ordering)
+  return reduce_with_quotients_and_unit(f, J; ordering=ordering, complete_reduction=complete_reduction)
 end
 
 function reduce_with_quotients_and_unit(F::Vector{T}, G::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where {T <: MPolyRingElem}
@@ -781,11 +787,30 @@ function reduce_with_quotients_and_unit(F::Vector{T}, G::Vector{T}; ordering::Mo
   if isempty(G)
     return identity_matrix(parent(F[1]), length(F)), zero_matrix(parent(F[1]), length(F), 0), F
   end
-  @assert parent(F[1]) == parent(G[1])
+  J = IdealGens(parent(G[1]), G, ordering)
+  return reduce_with_quotients_and_unit(F, J; ordering=ordering, complete_reduction=complete_reduction)
+end
+
+function reduce_with_quotients_and_unit(f::T, F::IdealGens{T}; ordering::MonomialOrdering = default_ordering(parent(f)), complete_reduction::Bool = false) where {T <: MPolyRingElem}
+  if isempty(F)
+    return identity_matrix(parent(f), 1), zero_matrix(parent(f), 1, 0), f
+  end
+  @assert parent(f) == base_ring(F)
+  R = parent(f)
+  I = IdealGens(R, [f], ordering)
+  u, q, r = _reduce_with_quotients_and_unit(I, F, ordering, complete_reduction)
+  return u, q, r[1]
+end
+
+function reduce_with_quotients_and_unit(F::Vector{T}, G::IdealGens{T}; ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where {T <: MPolyRingElem}
+  @assert !isempty(F)
+  if isempty(G)
+    return identity_matrix(parent(F[1]), length(F)), zero_matrix(parent(F[1]), length(F), 0), F
+  end
+  @assert parent(F[1]) == base_ring(G)
   R = parent(F[1])
   I = IdealGens(R, F, ordering)
-  J = IdealGens(R, G, ordering)
-  return _reduce_with_quotients_and_unit(I, J, ordering, complete_reduction)
+  return _reduce_with_quotients_and_unit(I, G, ordering, complete_reduction)
 end
 
 @doc raw"""
@@ -900,14 +925,14 @@ function reduce_with_quotients(I::IdealGens, J::IdealGens; ordering::MonomialOrd
 end
 
 @doc raw"""
-    reduce_with_quotients(g::T, F::Vector{T}; 
-           ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where T <: MPolyRingElem
+    reduce_with_quotients(g::T, F::Union{Vector{T}, IdealGens{T}};
+           ordering::MonomialOrdering = default_ordering(parent(g)), complete_reduction::Bool = false) where T <: MPolyRingElem
 
 If `ordering` is global, return the quotients and the remainder in a standard representation for `g` on division by the polynomials in `F` with respect to `ordering`.
 Otherwise, return the quotients and the remainder in a *weak* standard representation for `g` on division by the polynomials in `F` with respect to `ordering`.
 
-    reduce_with_quotients(G::Vector{T}, F::Vector{T}; 
-           ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where T <: MPolyRingElem
+    reduce_with_quotients(G::Vector{T}, F::Union{Vector{T}, IdealGens{T}};
+           ordering::MonomialOrdering = default_ordering(parent(G[1])), complete_reduction::Bool = false) where T <: MPolyRingElem
 
 Return a `Vector` which contains, for each element `g` of `G`, quotients and a remainder as above.
 
@@ -934,22 +959,33 @@ true
 """
 function reduce_with_quotients(f::T, F::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(f)), complete_reduction::Bool = false) where {T <: MPolyRingElem}
   isempty(F) && return zero_matrix(parent(f), 1, 0), f
-  @assert parent(f) == parent(F[1])
-  R = parent(f)
-  I = IdealGens(R, [f], ordering)
-  J = IdealGens(R, F, ordering)
-  _, q, r = _reduce_with_quotients_and_unit(I, J, ordering, complete_reduction)
-  return q, r[1]
+  J = IdealGens(parent(F[1]), F, ordering)
+  return reduce_with_quotients(f, J; ordering=ordering, complete_reduction=complete_reduction)
 end
 
 function reduce_with_quotients(F::Vector{T}, G::Vector{T}; ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where {T <: MPolyRingElem}
   @assert !isempty(F)
   isempty(G) && return zero_matrix(parent(F[1]), length(F), 0), F
+  J = IdealGens(parent(G[1]), G, ordering)
+  return reduce_with_quotients(F, J; ordering=ordering, complete_reduction=complete_reduction)
+end
+
+function reduce_with_quotients(f::T, F::IdealGens{T}; ordering::MonomialOrdering = default_ordering(parent(f)), complete_reduction::Bool = false) where {T <: MPolyRingElem}
+  isempty(F) && return zero_matrix(parent(f), 1, 0), f
+  @assert parent(f) == parent(F[1])
+  R = parent(f)
+  I = IdealGens(R, [f], ordering)
+  _, q, r = _reduce_with_quotients_and_unit(I, F, ordering, complete_reduction)
+  return q, r[1]
+end
+
+function reduce_with_quotients(F::Vector{T}, G::IdealGens{T}; ordering::MonomialOrdering = default_ordering(parent(F[1])), complete_reduction::Bool = false) where {T <: MPolyRingElem}
+  @assert !isempty(F)
+  isempty(G) && return zero_matrix(parent(F[1]), length(F), 0), F
   @assert parent(F[1]) == parent(G[1])
   R = parent(F[1])
   I = IdealGens(R, F, ordering)
-  J = IdealGens(R, G, ordering)
-  _, q, r = _reduce_with_quotients_and_unit(I, J, ordering, complete_reduction)
+  _, q, r = _reduce_with_quotients_and_unit(I, G, ordering, complete_reduction)
   return q, r
 end
 

--- a/test/Rings/groebner.jl
+++ b/test/Rings/groebner.jl
@@ -21,15 +21,22 @@
     G = groebner_basis(I)
     J = ideal(R, y)
     @test reduce(J.gens, G) == [y]
+    @test reduce(y, G) == y
     J = ideal(R, x*y^2)
     matrix, res = reduce_with_quotients(J.gens, G)
     @test matrix * gens(G) + res == gens(J)
+    matrix, res = reduce_with_quotients(x*y^2, G)
+    @test matrix * gens(G) + [res] == [x*y^2]
     units, quots, res = reduce_with_quotients_and_unit(J.gens, G)
     @test matrix * gens(G) + res == units * gens(J)
+    unit, quots, res = reduce_with_quotients_and_unit(x*y^2, G)
+    @test matrix * gens(G) + [res] == units * [x*y^2]
     @test reduce(y^3, [y^2 - x, x^3 - 2*y^2]) == x*y
     @test reduce(y^3, elem_type(R)[]) == y^3
+    @test reduce(y^3, Oscar.IdealGens(R, elem_type(R)[])) == y^3
     @test reduce([y^3], [y^2 - x, x^3 - 2*y^2]) == [x*y]
     @test reduce([y^3], elem_type(R)[]) == [y^3]
+    @test reduce([y^3], Oscar.IdealGens(R, elem_type(R)[])) == [y^3]
     @test reduce([y^3], [y^2 - x, x^3 - 2*y^2], ordering=lex(R)) == [y^3]
     f = x+y^3
     g = x
@@ -41,17 +48,25 @@
     @test q * F + [r] == [f]
     q, r = reduce_with_quotients(f, elem_type(R)[])
     @test q * elem_type(R)[] + [r] == [f]
+    q, r = reduce_with_quotients(f, Oscar.IdealGens(R, elem_type(R)[]))
+    @test q * elem_type(R)[] + [r] == [f]
     q, r = reduce_with_quotients([f], F)
     @test q * F + r == [f]
     q, r = reduce_with_quotients([f], elem_type(R)[])
+    @test q * elem_type(R)[] + r == [f]
+    q, r = reduce_with_quotients([f], Oscar.IdealGens(R, elem_type(R)[]))
     @test q * elem_type(R)[] + r == [f]
     u, q, r = reduce_with_quotients_and_unit(f, F)
     @test q * F + [r] == u * [f]
     u, q, r = reduce_with_quotients_and_unit(f, elem_type(R)[])
     @test q * elem_type(R)[] + [r] == u * [f]
+    u, q, r = reduce_with_quotients_and_unit(f, Oscar.IdealGens(R, elem_type(R)[]))
+    @test q * elem_type(R)[] + [r] == u * [f]
     u, q, r = reduce_with_quotients_and_unit([f], F)
     @test q * F + r == u * [f]
     u, q, r = reduce_with_quotients_and_unit([f], elem_type(R)[])
+    @test q * elem_type(R)[] + r == u * [f]
+    u, q, r = reduce_with_quotients_and_unit([f], Oscar.IdealGens(R, elem_type(R)[]))
     @test q * elem_type(R)[] + r == u * [f]
     f = x
     F = [1-x]


### PR DESCRIPTION
Adds the variants `reduce(::T, ::IdealGens{T}; ...)` and `reduce(::Vector{T}, ::IdealGens{T})` and similar for `reduce_with_quotients` and `reduce_with_quotients_and_unit`.

Without this the following would not work:
```
julia> R, (x, y) = QQ["x", "y"];

julia> I = ideal(R, [y^2 - x, x^3 - 2*y^2]);

julia> G = groebner_basis(I);

julia> reduce(x, G)
x
```
(It works by calling `reduce` with `collect(G)`, but then the information on the Singular side is forgotten and has to be recreated.)
