### PR TITLE
avoid GAP errors when computing `G.X` for classical matrix groups

### DIFF
--- a/gap/OscarInterface/gap/OscarInterface.gi
+++ b/gap/OscarInterface/gap/OscarInterface.gi
@@ -50,6 +50,42 @@ Perform( Oscar._iso_gap_oscar_methods,
 
 ############################################################################
 
+# GAP supports classical matrix groups over the ring `R` in the following
+# cases.
+# - `descr` one of "GL", "SL":
+#   finite fields, Z, residue rings of Z,
+# - `descr` "Sp":
+#   finite fields, residue rings Z/p^n Z for primes p,
+# - `descr` one of "GO", "GO+", "GO-", "SO", "SO+", "SO-",
+#   "Omega", "Omega+", "Omega-":
+#   finite fields, residue rings Z/p^n Z for odd primes p,
+# - `descr` one of "GU", "SU":
+#   finite fields.
+BindGlobal( "IsBaseRingSupportedForClassicalMatrixGroup", function( R, descr )
+  if descr in [ "GL", "SL" ] then
+    return ( IsField( R ) and IsFinite( R ) ) or
+           IsIntegers( R ) or
+           ( IsZmodnZObjNonprimeCollection( R ) and
+             HasIsWholeFamily( R ) and IsWholeFamily( R ) );
+  elif descr = "Sp" then
+    return ( IsField( R ) and IsFinite( R ) ) or
+           ( IsZmodnZObjNonprimeCollection( R ) and
+             HasIsWholeFamily( R ) and IsWholeFamily( R ) and
+             IsPrimePowerInt( Size( R ) ) );
+  elif descr in [ "GO", "GO+", "GO-", "SO", "SO+", "SO-",
+                  "Omega", "Omega+", "Omega-" ] then
+    return ( IsField( R ) and IsFinite( R ) ) or
+           ( IsZmodnZObjNonprimeCollection( R ) and
+             HasIsWholeFamily( R ) and IsWholeFamily( R ) and
+             IsOddInt( Size( R ) ) and IsPrimePowerInt( Size( R ) ) );
+  elif descr in [ "GU", "SU" ] then
+    return IsField( R ) and IsFinite( R );
+  fi;
+  return false;
+end );
+
+############################################################################
+
 BindGlobal("_OSCAR_GroupElem", Oscar.AbstractAlgebra.GroupElem);
 
 # the following code ensures that `GAP.Globals.Group` accepts a GAP list

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -149,8 +149,10 @@ Base.show(io::IO, mi::MIME"text/plain", x::MatrixGroupElem) = show(io, mi, x.elm
 
 group_element(G::MatrixGroup, x::GapObj) = MatrixGroupElem(G,x)
 
+# Compute and store the component `G.X` if this is possible.
 function assign_from_description(G::MatrixGroup)
    F = codomain(_ring_iso(G))
+   GAP.Globals.IsBaseRingSupportedForClassicalMatrixGroup(F, GAP.GapObj(G.descr)) || error("no generators are known for the matrix group of type $(G.descr) over $(base_ring(G))")
    if G.descr==:GL G.X=GAP.Globals.GL(G.deg, F)
    elseif G.descr==:SL G.X=GAP.Globals.SL(G.deg, F)
    elseif G.descr==:Sp G.X=GAP.Globals.Sp(G.deg, F)
@@ -619,14 +621,14 @@ end
 
 Return the general linear group of dimension `n` over the ring `R` respectively the field `GF(q)`.
 
-Currently, this function only supports rings of type `FqField`.
+Currently `R` must be either a finite field or a residue ring or `ZZ`.
 
 # Examples
 ```jldoctest
-julia> F = GF(7,1)
+julia> F = GF(7)
 Prime field of characteristic 7
 
-julia> H = general_linear_group(2,F)
+julia> H = general_linear_group(2, F)
 GL(2,7)
 
 julia> gens(H)
@@ -634,6 +636,8 @@ julia> gens(H)
  [3 0; 0 1]
  [6 1; 6 0]
 
+julia> order(general_linear_group(2, residue_ring(ZZ, 6)[1]))
+288
 ```
 """
 function general_linear_group(n::Int, R::Ring)
@@ -653,14 +657,14 @@ end
 
 Return the special linear group of dimension `n` over the ring `R` respectively the field `GF(q)`.
 
-Currently, this function only supports rings of type `FqField`.
+Currently `R` must be either a finite field or a residue ring or `ZZ`.
 
 # Examples
 ```jldoctest
-julia> F = GF(7,1)
+julia> F = GF(7)
 Prime field of characteristic 7
 
-julia> H = special_linear_group(2,F)
+julia> H = special_linear_group(2, F)
 SL(2,7)
 
 julia> gens(H)
@@ -668,6 +672,8 @@ julia> gens(H)
  [3 0; 0 5]
  [6 1; 6 0]
 
+julia> order(special_linear_group(2, residue_ring(ZZ, 6)[1]))
+144
 ```
 """
 function special_linear_group(n::Int, R::Ring)
@@ -688,14 +694,15 @@ end
 Return the symplectic group of dimension `n` over the ring `R` respectively the
 field `GF(q)`. The dimension `n` must be even.
 
-Currently, this function only supports rings of type `FqField`.
+Currently `R` must be either a finite field
+or a residue ring of prime power order.
 
 # Examples
 ```jldoctest
-julia> F = GF(7,1)
+julia> F = GF(7)
 Prime field of characteristic 7
 
-julia> H = symplectic_group(2,F)
+julia> H = symplectic_group(2, F)
 Sp(2,7)
 
 julia> gens(H)
@@ -703,6 +710,8 @@ julia> gens(H)
  [3 0; 0 5]
  [6 1; 6 0]
 
+julia> order(symplectic_group(2, residue_ring(ZZ, 4)[1]))
+48
 ```
 """
 function symplectic_group(n::Int, R::Ring)
@@ -725,21 +734,24 @@ Return the orthogonal group of dimension `n` over the ring `R` respectively the
 field `GF(q)`, and of type `e`, where `e` in {`+1`,`-1`} for `n` even and `e`=`0`
 for `n` odd. If `n` is odd, `e` can be omitted.
 
-Currently, this function only supports rings of type `FqField`.
+Currently `R` must be either a finite field
+or a residue ring of odd prime power order.
 
 # Examples
 ```jldoctest
-julia> F = GF(7,1)
+julia> F = GF(7)
 Prime field of characteristic 7
 
-julia> H = symplectic_group(2,F)
-Sp(2,7)
+julia> H = orthogonal_group(1, 2, F)
+GO+(2,7)
 
 julia> gens(H)
 2-element Vector{MatrixGroupElem{FqFieldElem, FqMatrix}}:
  [3 0; 0 5]
- [6 1; 6 0]
+ [0 1; 1 0]
 
+julia> order(orthogonal_group(-1, 2, residue_ring(ZZ, 9)[1]))
+24
 ```
 """
 function orthogonal_group(e::Int, n::Int, R::Ring)
@@ -777,14 +789,15 @@ Return the special orthogonal group of dimension `n` over the ring `R` respectiv
 the field `GF(q)`, and of type `e`, where `e` in {`+1`,`-1`} for `n` even and
 `e`=`0` for `n` odd. If `n` is odd, `e` can be omitted.
 
-Currently, this function only supports rings of type `FqField`.
+Currently `R` must be either a finite field
+or a residue ring of odd prime power order.
 
 # Examples
 ```jldoctest
-julia> F = GF(7,1)
+julia> F = GF(7)
 Prime field of characteristic 7
 
-julia> H = special_orthogonal_group(1,2,F)
+julia> H = special_orthogonal_group(1, 2, F)
 SO+(2,7)
 
 julia> gens(H)
@@ -793,6 +806,8 @@ julia> gens(H)
  [5 0; 0 3]
  [1 0; 0 1]
 
+julia> order(special_orthogonal_group(-1, 2, residue_ring(ZZ, 9)[1]))
+12
 ```
 """
 function special_orthogonal_group(e::Int, n::Int, R::Ring)
@@ -830,20 +845,23 @@ Return the Omega group of dimension `n` over the field `GF(q)` of type `e`,
 where `e` in {`+1`,`-1`} for `n` even and `e`=`0` for `n` odd. If `n` is odd,
 `e` can be omitted.
 
-Currently, this function only supports rings of type `FqField`.
+Currently `R` must be either a finite field
+or a residue ring of odd prime power order.
 
 # Examples
 ```jldoctest
-julia> F = GF(7,1)
+julia> F = GF(7)
 Prime field of characteristic 7
 
-julia> H = omega_group(1,2,F)
+julia> H = omega_group(1, 2, F)
 Omega+(2,7)
 
 julia> gens(H)
 1-element Vector{MatrixGroupElem{FqFieldElem, FqMatrix}}:
  [2 0; 0 4]
 
+julia> order(omega_group(0, 3, residue_ring(ZZ, 9)[1]))
+324
 ```
 """
 function omega_group(e::Int, n::Int, R::Ring)

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -168,6 +168,51 @@ end
 
 end
 
+@testset "Classical groups over rings that are not supported by GAP" begin
+   G = GL(2, QQ)
+   @test_throws ErrorException G[1]
+   G = GL(2, ZZ)
+   @test nrows(G[1]) == 2
+   G = GL(2, residue_ring(ZZ, 6)[1])
+   @test nrows(G[1]) == 2
+
+   G = SL(2, QQ)
+   @test_throws ErrorException G[1]
+   G = SL(2, ZZ)
+   @test nrows(G[1]) == 2
+   G = SL(2, residue_ring(ZZ, 6)[1])
+   @test nrows(G[1]) == 2
+
+   G = Sp(2, QQ)
+   @test_throws ErrorException G[1]
+   G = Sp(2, ZZ)
+   @test_throws ErrorException G[1]
+   G = Sp(2, residue_ring(ZZ, 6)[1])
+   @test_throws ErrorException G[1]
+   G = Sp(2, residue_ring(ZZ, 4)[1])
+   @test nrows(G[1]) == 2
+   G = Sp(2, residue_ring(ZZ, 9)[1])
+   @test nrows(G[1]) == 2
+
+   G = GO(3, QQ)
+   @test_throws ErrorException G[1]
+   G = GO(3, ZZ)
+   @test_throws ErrorException G[1]
+   G = GO(3, residue_ring(ZZ, 6)[1])
+   @test_throws ErrorException G[1]
+   G = GO(3, residue_ring(ZZ, 9)[1])
+   @test nrows(G[1]) == 3
+
+   G = SO(3, QQ)
+   @test_throws ErrorException G[1]
+   G = SO(3, ZZ)
+   @test_throws ErrorException G[1]
+   G = SO(3, residue_ring(ZZ, 6)[1])
+   @test_throws ErrorException G[1]
+   G = SO(3, residue_ring(ZZ, 9)[1])
+   @test nrows(G[1]) == 3
+end
+
 @testset "Type operations" begin
    G = GL(5,5)
    x = rand(G)


### PR DESCRIPTION
Check whether GAP supports the base ring in question before asking GAP to construct the matrix group.

Currently supported rings are at most finite fields, (certain) residue rings, and ZZ.

resolves #3634