### PR TITLE
call GAP's `ImagesRepresentative` instead of `Image`

### DIFF
--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -108,6 +108,7 @@ GAP.@wrap HasSize(x::Any)::Bool
 GAP.@wrap Identity(x::GapObj)::GapObj
 GAP.@wrap Image(x::Any)::GapObj
 GAP.@wrap Image(x::Any, y::Any)::GapObj
+GAP.@wrap ImagesRepresentative(x::GapObj, y::Any)::GAP.Obj
 GAP.@wrap ImmutableMatrix(x::GapObj, y::GapObj, z::Bool)::GapObj
 GAP.@wrap IndependentGeneratorExponents(x::Any, y::Any)::GapObj
 GAP.@wrap Indeterminate(x::GapObj)::GapObj

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -177,7 +177,7 @@ Base.:^(x::GAPGroupElem,f::GAPGroupHomomorphism) = image(f,x)
 Return `f`(`x`).
 """
 function image(f::GAPGroupHomomorphism, x::GAPGroupElem)
-  return group_element(codomain(f), GAPWrap.Image(f.map,x.X))
+  return group_element(codomain(f), GAPWrap.ImagesRepresentative(f.map, x.X))
 end
 
 """
@@ -1109,7 +1109,7 @@ function apply_automorphism(f::GAPGroupElem{AutomorphismGroup{T}}, x::GAPGroupEl
   if check
     @assert A.G == G || x.X in A.G.X "Not in the domain of f!"      #TODO Do we really need the IN check?
   end
-  return typeof(x)(G, GAPWrap.Image(f.X,x.X))
+  return typeof(x)(G, GAPWrap.ImagesRepresentative(f.X, x.X))
 end
 
 Base.:*(f::GAPGroupElem{AutomorphismGroup{T}}, g::GAPGroupHomomorphism) where T = hom(f)*g


### PR DESCRIPTION
The point is that the mapping on the GAP side may be not single-valued. (For example, it can be an "inverse" of an epimorphism.)

Oscar uses `preimage` with the meaning of GAP's `PreImagesRepresentative`, thus `ImagesRepresentative` should be used in the other direction.