### PR TITLE
First attempt: use selfhosted macOS runner

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -130,7 +130,7 @@ jobs:
             depwarn: 'depwarn=error'
           # Add macOS jobs (not too many, the number we can run in parallel is limited)
           - julia-version: '1.10'
-            os: macOS-14
+            os: [macOS, RPTU] #runs on self hosted runner
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,10 +49,10 @@ jobs:
           # Add a few macOS jobs (not too many, the number we can run in parallel is limited)
           - julia-version: '1.10'
             group: 'short'
-            os: macOS-14
+            os: [macOS, RPTU]
           - julia-version: '1.10'
             group: 'long'
-            os: macOS-latest
+            os: [macOS, RPTU]
           - julia-version: '1.10'
             group: 'book'
             os: ubuntu-latest
@@ -85,6 +85,11 @@ jobs:
         if: runner.os == 'macOS'
         # restrict number of openMP threads on macOS due to oversubscription
         run: echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
+      - name: "Use multiple threads for self-hosted runners"
+        if: runner.os == 'macOS' && runner.environment == 'self-hosted'
+        # runner.environment is supposed to be a valid property : https://github.com/orgs/community/discussions/48359#discussioncomment-9059557
+        env:
+          NUMPROCS: '5'
       - name: "set test subgroup"
         if: ${{ matrix.group }} != ''
         run: echo "OSCAR_TEST_SUBSET=${{matrix.group}}" >> $GITHUB_ENV

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,10 +49,10 @@ jobs:
           # Add a few macOS jobs (not too many, the number we can run in parallel is limited)
           - julia-version: '1.10'
             group: 'short'
-            os: [macOS, RPTU]  # run on self-hosted run
+            os: [macOS, RPTU]  # runs on self-hosted runner
           - julia-version: '1.10'
             group: 'long'
-            os: [macOS, RPTU]  # run on self-hosted run
+            os: [macOS, RPTU]  # runs on self-hosted runner
           - julia-version: '1.10'
             group: 'book'
             os: ubuntu-latest
@@ -85,7 +85,7 @@ jobs:
         if: runner.os == 'macOS'
         # restrict number of openMP threads on macOS due to oversubscription
         run: echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
-      - name: "Use multiple threads for self-hosted runners"
+      - name: "Use multiple processes for self-hosted runners"
         if: runner.os == 'macOS' && runner.environment == 'self-hosted'
         # runner.environment is supposed to be a valid property: https://github.com/orgs/community/discussions/48359#discussioncomment-9059557
         run: echo "NUMPROCS=5" >> $GITHUB_ENV
@@ -130,7 +130,7 @@ jobs:
             depwarn: 'depwarn=error'
           # Add macOS jobs (not too many, the number we can run in parallel is limited)
           - julia-version: '1.10'
-            os: [macOS, RPTU] #runs on self hosted runner
+            os: [macOS, RPTU] # runs on self hosted runner
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,8 +88,7 @@ jobs:
       - name: "Use multiple threads for self-hosted runners"
         if: runner.os == 'macOS' && runner.environment == 'self-hosted'
         # runner.environment is supposed to be a valid property : https://github.com/orgs/community/discussions/48359#discussioncomment-9059557
-        env:
-          NUMPROCS: '5'
+        run: echo "NUMPROCS=5" >> $GITHUB_ENV
       - name: "set test subgroup"
         if: ${{ matrix.group }} != ''
         run: echo "OSCAR_TEST_SUBSET=${{matrix.group}}" >> $GITHUB_ENV

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,10 +49,10 @@ jobs:
           # Add a few macOS jobs (not too many, the number we can run in parallel is limited)
           - julia-version: '1.10'
             group: 'short'
-            os: [macOS, RPTU]
+            os: [macOS, RPTU]  # run on self-hosted run
           - julia-version: '1.10'
             group: 'long'
-            os: [macOS, RPTU]
+            os: [macOS, RPTU]  # run on self-hosted run
           - julia-version: '1.10'
             group: 'book'
             os: ubuntu-latest
@@ -87,7 +87,7 @@ jobs:
         run: echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
       - name: "Use multiple threads for self-hosted runners"
         if: runner.os == 'macOS' && runner.environment == 'self-hosted'
-        # runner.environment is supposed to be a valid property : https://github.com/orgs/community/discussions/48359#discussioncomment-9059557
+        # runner.environment is supposed to be a valid property: https://github.com/orgs/community/discussions/48359#discussioncomment-9059557
         run: echo "NUMPROCS=5" >> $GITHUB_ENV
       - name: "set test subgroup"
         if: ${{ matrix.group }} != ''


### PR DESCRIPTION
Currently 4 runners with 5 workers per runner.

Probably needs a review by a Github actions expert

cc @fingolfin @benlorenz 