### PR TITLE
Improve _normal_form_singular: accept more inputs, allocate less

### DIFF
--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1157,11 +1157,13 @@ julia> Oscar._normal_form_singular(A, J, default_ordering(base_ring(J)))
 ```
 """
 function _normal_form_singular(A::Vector{T}, J::MPolyIdeal, ordering::MonomialOrdering) where { T <: MPolyRingElem }
-  SR = singular_poly_ring(base_ring(J), ordering)
-  IS = Singular.Ideal(SR, [SR(x) for x in A])
   GS = singular_groebner_generators(J, ordering)
-  K  = ideal(base_ring(J), reduce(IS, GS))
-  return [J.gens.Ox(x) for x = gens(K.gens.S)]
+  SR = base_ring(GS)
+  tmp = map(SR, A)
+  IS = Singular.Ideal(SR, tmp)
+  K = reduce(IS, GS)
+  OR = base_ring(J)
+  return map(OR, gens(K))
 end
 
 @doc raw"""

--- a/test/Rings/groebner.jl
+++ b/test/Rings/groebner.jl
@@ -122,6 +122,13 @@
     @test_throws ArgumentError standard_basis_highest_corner(I)
 end
 
+@testset "normal form graded" begin
+    R, (a, b, c) = graded_polynomial_ring(QQ, ["a", "b", "c"])
+    I = ideal([a^2+b^2, c^3])
+    # verify normal form of inhomogeneous polynomial work
+    @test normal_form(a^2+b, I) == -b^2+b
+end
+
 @testset "groebner leading ideal" begin
    R, (t, x, y, z) = polynomial_ring(QQ, ["t", "x", "y", "z"])
 


### PR DESCRIPTION
Instead of creating a fresh Singular ring each time, use the one we already have.

Fixes #3658 for me.

No tests yet. I am happy to add some, but first I want to know that this PR is OK, i.e., there is no deeper reason why normal forms of non-homogeneous polynomials can't be computed right now.

It also reveals a deeper issue: this function got faster with my change,  but it is still makes a *ton* of computations. E.g. to convert a single polynomial:
```
julia> @time Oscar._normal_form_singular([a^2+b^2+c^2], J, ordering);
  0.000100 seconds (136 allocations: 3.469 KiB)
```
So there are 136 allocations. Of these 125 are for converting that polynomial from Oscar to Singular, and the result back. That's IMHO way too much. I will open a separate issue for that.

Ping @wdecker @simonbrandhorst @afkafkafk13 @jankoboehm @HechtiDerLachs @ederc 


