### PR TITLE
Temporarily change the default ordering

### DIFF
--- a/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
@@ -53,6 +53,10 @@ The *leading monomial* $\text{LM}_>(f)$, the *leading exponent* $\text{LE}_>(f)$
     positive weights. Then the corresponding `wdegrevlex` ordering is used. Given a free $R$-module $F$, the
     `default_ordering` is `default_ordering(R)*lex(gens(F))`.
 
+```@docs
+default_ordering(::MPolyRing)
+```
+
 Here are some illustrating OSCAR examples:
 
 ##### Examples
@@ -75,6 +79,11 @@ julia> S, _ = grade(R, [1, 2, 3])
 
 julia> default_ordering(S)
 wdegrevlex([x, y, z], [1, 2, 3])
+```
+
+Expert users may temporarily choose a different default ordering for a given ring.
+```@docs
+with_ordering
 ```
 
 ## [Monomials, Terms, and More](@id monomials_terms_more)

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -120,8 +120,11 @@ z^2 + z
 function with_ordering(f, R::MPolyRing, o::MonomialOrdering)
   old = default_ordering(R)
   set_default_ordering!(R, o)
-  x = f()
-  set_default_ordering!(R, old)
+  x = try
+    f()
+  finally
+    set_default_ordering!(R, old)
+  end
   return x
 end
 

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -63,10 +63,67 @@ using .Orderings
 #type for orderings, use this...
 #in general: all algos here needs revision: do they benefit from gb or not?
 
+@doc raw"""
+    default_ordering(R::MPolyRing)
+
+Return the monomial ordering that is used for computations with ideals in `R`
+if no other ordering is specified -- either directly by the user or by
+requirements of a specific algorithm.
+"""
 @attr MonomialOrdering{T} function default_ordering(R::T) where {T<:MPolyRing}
   return degrevlex(R)
 end
 
+# Only for internal use
+function set_default_ordering!(R::MPolyRing, o::MonomialOrdering)
+  @assert R === base_ring(o)
+  set_attribute!(R, :default_ordering, o)
+  return nothing
+end
+
+@doc raw"""
+    with_ordering(f, R::MPolyRing, o::MonomialOrdering)
+
+Use the monomial ordering `o` for computations in `R` during the execution of
+`f`.
+This may be used with `do` block syntax, see the example.
+
+This functionality is meant for advanced users. In general it should not be
+necessary to explicitly set a monomial ordering.
+Further, there is no guarantee that `o` is actually used. For example, if an
+algorithm requires an elimination ordering, `o` might be ignored.
+
+# Example
+```jldoctest withordering
+julia> R, (x, y, z) = QQ["x", "y", "z"];
+
+julia> f = x + y^2;
+
+julia> I = ideal(R, [y^2 - z, x - z^2]);
+
+julia> normal_form(f, I) # this uses degrevlex
+x + z
+
+julia> with_ordering(R, lex(R)) do
+           # this uses lex
+           normal_form(f, I)
+       end
+z^2 + z
+```
+Notice that in this small example we could have achieved the same by using the
+keyword argument `ordering`:
+```jldoctest withordering
+julia> normal_form(f, I, ordering = lex(R))
+z^2 + z
+```
+"""
+function with_ordering(f, R::MPolyRing, o::MonomialOrdering)
+  old = default_ordering(R)
+  set_default_ordering!(R, o)
+  x = f()
+  set_default_ordering!(R, old)
+  return x
+end
 
 mutable struct BiPolyArray{S}
   Ox::NCRing #Oscar Poly Ring or Algebra
@@ -301,7 +358,7 @@ function singular_generators(B::IdealGens, monorder::MonomialOrdering=default_or
 end
 
 @doc raw"""
-set_ordering(I::IdealGens, monord::MonomialOrdering)
+    set_ordering(I::IdealGens, monord::MonomialOrdering)
 
 Return an ideal generating system with an associated monomial ordering.
 
@@ -1216,7 +1273,3 @@ function hessian_matrix(f::MPolyRingElem)
 end
 
 hessian(f::MPolyRingElem) = det(hessian_matrix(f))
-
-function set_default_ordering!(S::MPolyRing, ord::MonomialOrdering)
-  set_attribute!(S, :default_ordering, ord)
-end

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1513,6 +1513,7 @@ export weight_ordering
 export weighted_projective_space
 export weyl_algebra
 export weyl_vector
+export with_ordering
 export witt_index
 export wreath_product
 export write_as_full

--- a/test/Rings/mpoly.jl
+++ b/test/Rings/mpoly.jl
@@ -565,5 +565,12 @@ end
         end
     @test f == normal_form(f, I, ordering = invlex(T))
     @test default_ordering(T) == old_default
+
+    # Make sure the ordering is reset in case of an error
+    # The `@test_throws` is just here to catch the error
+    @test_throws ErrorException with_ordering(T, invlex(T)) do
+      error()
+    end
+    @test default_ordering(T) == old_default
   end
 end

--- a/test/Rings/mpoly.jl
+++ b/test/Rings/mpoly.jl
@@ -555,7 +555,15 @@ end
 @testset "default ordering" begin
   R, _ = QQ["x", "y", "z"]
   S, _ = grade(R, [2, 1, 2])
-  # test type stability
-  @inferred default_ordering(R)
-  @inferred default_ordering(S)
+  for T in [R, S]
+    x, y, z = gens(T)
+    f = x + y^2
+    I = ideal(T, [y^2 - z, x - z])
+    old_default = @inferred default_ordering(T)
+    f = with_ordering(T, invlex(T)) do
+          normal_form(f, I)
+        end
+    @test f == normal_form(f, I, ordering = invlex(T))
+    @test default_ordering(T) == old_default
+  end
 end


### PR DESCRIPTION
Introduces a function `with_ordering(f, ::MPolyRing, ::MonomialOrdering)` that allows to set the default ordering of a ring for the execution of a function (or `do` block).
For example, in #1487 one could now do:
```
n = 6
R, c = polynomial_ring(QQ,vcat(["c$i" for i in 1:n+7]))
x, y, z, u, v, w, t = c[n + 1:n + 7];
p = c[1] + c[2]*y + c[3]*y*z + c[4]*y^2 + c[5]*x + c[6]*x*y^4*z
q = evaluate(p,[x,y,z],[u,v,w])
I = ideal(R,[p,q,derivative(p,x),derivative(p,y),derivative(p,z),derivative(q,u),derivative(q,v),derivative(q,w),1-t*x*y*z*u*v*w])
with_ordering(R, degrevlex(gens(R)[1:6])*degrevlex(gens(R)[7:13])) do
  saturation(I, ideal(R,[x-u,y-v,z-w]))
end
```

This is certainly only intended for expert users who know what they do. I'm open to other solutions, but I really want to have some functionality like this.

This closes #1487 from my point of view. It still doesn't help if one doesn't know the ring because it is created several levels down, but I don't see what we can do in this case anyway.
