### PR TITLE
Normal form checks for msolve compatibility

### DIFF
--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1060,7 +1060,7 @@ end
 
 function normal_form(A::Vector{T}, J::MPolyIdeal; ordering::MonomialOrdering=default_ordering(base_ring(J))) where { T <: MPolyRingElem }
   @req is_exact_type(elem_type(base_ring(J))) "This functionality is only supported over exact fields."
-  if ordering == degrevlex(base_ring(J)) && is_prime(characteristic(base_ring(J)))
+  if ordering == degrevlex(base_ring(J)) && typeof(base_ring(J)) == FqField && prime_field(base_ring(J)) == base_ring(J)
     res = _normal_form_f4(A, J)
   else
     res = _normal_form_singular(A, J, ordering)

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -1060,7 +1060,7 @@ end
 
 function normal_form(A::Vector{T}, J::MPolyIdeal; ordering::MonomialOrdering=default_ordering(base_ring(J))) where { T <: MPolyRingElem }
   @req is_exact_type(elem_type(base_ring(J))) "This functionality is only supported over exact fields."
-  if ordering == degrevlex(base_ring(J)) && typeof(base_ring(J)) == FqField && prime_field(base_ring(J)) == base_ring(J)
+  if ordering == degrevlex(base_ring(J)) && typeof(base_ring(J)) == FqField && absolute_degree(base_ring(J)) == 1
     res = _normal_form_f4(A, J)
   else
     res = _normal_form_singular(A, J, ordering)

--- a/test/Rings/groebner.jl
+++ b/test/Rings/groebner.jl
@@ -11,6 +11,13 @@
     @test leading_ideal(I, ordering=degrevlex(gens(R))) == ideal(R,[x*y^2, x^4, y^5])
     @test leading_ideal(I) == ideal(R,[x*y^2, x^4, y^5])
     @test leading_ideal(I, ordering=lex(gens(R))) == ideal(R,[y^7, x*y^2, x^3])
+    # issue 3665
+    kt,t = polynomial_ring(GF(2),:t)
+    Ft = fraction_field(kt)
+    P,(x,y) = polynomial_ring(Ft,[:x,:y])
+    I = ideal(P,[x,y])
+    @test normal_form([x], I) == [0]
+
     R, (x, y) = polynomial_ring(GF(5), ["x", "y"])
     I = ideal(R, [x])
     gb = groebner_basis(I)
@@ -18,6 +25,7 @@
     @test Oscar._normal_form_singular([y], I, degrevlex(R)) == [y]
     @test Oscar._normal_form_f4([y], I) == [y]
     @test normal_form(y, I) == y
+
     G = groebner_basis(I)
     J = ideal(R, y)
     @test reduce(J.gens, G) == [y]


### PR DESCRIPTION
Fixes checks in `normal_form` when `msolve` is applicable.

This fixes #3665.