### PR TITLE
[ToricVarieties] Fix for is_effective of toric divisor class

### DIFF
--- a/src/AlgebraicGeometry/ToricVarieties/ToricDivisorClasses/properties.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricDivisorClasses/properties.jl
@@ -25,4 +25,4 @@ julia> is_effective(tdc2)
 false
 ```
 """
-@attr Bool is_effective(tdc::ToricDivisorClass) = is_effective(toric_divisor(tdc))
+@attr Bool is_effective(tdc::ToricDivisorClass) = (length(basis_of_global_sections(toric_line_bundle(tdc))) > 0)

--- a/test/AlgebraicGeometry/ToricVarieties/toric_divisor_classes.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/toric_divisor_classes.jl
@@ -3,7 +3,11 @@
   F5 = hirzebruch_surface(NormalToricVariety, 5)
   dP3 = del_pezzo_surface(NormalToricVariety, 3)
   P2 = projective_space(NormalToricVariety, 2)
-    
+  
+  rs = [[0, 1, 0], [-1, 1, 1], [-1, 0, 0], [-1, -2, -2], [0, -1, -1], [0, 0, 1], [-1, -1, -1], [1, 0, 0]]
+  cs = IncidenceMatrix([[1, 2, 3], [1, 4, 5], [3, 6, 7], [4, 5, 6], [1, 4, 7], [5, 6, 8], [1, 6, 8], [2, 3, 6], [1, 5, 8], [1, 3, 7], [1, 2, 6], [4, 6, 7]])
+  test_space = normal_toric_variety(cs, rs)
+
   DC = toric_divisor_class(F5, [ZZRingElem(0), ZZRingElem(0)])
   DC2 = toric_divisor_class(F5, [1, 2])
   DC3 = toric_divisor_class(dP3, [4, 3, 2, 1])
@@ -17,6 +21,7 @@
     @test is_trivial(toric_divisor(DC2)) == false
     @test is_effective(DC7) == true
     @test is_effective(DC8) == false
+    @test is_effective(anticanonical_divisor_class(test_space)) == true
   end
   
   @testset "Basic attributes" begin


### PR DESCRIPTION
So far, the check `is_effective` of a `divisor_class` proceeded as follows:

* Compute one (!) (torus-invariant) divisor `D` in the given divisor class `[D]`.
* Express this divisor `D` as linear combination of the torus-invariant prime divisor, a.k.a. those associated to the rays.
* Return `true` if all coefficients in this linear combination are non-negative and otherwise `false`.

The trouble with this approach is that we may pick a divisor `D` in the given divisor class which involves a negative multiple of one (or even multiple) torus-invariant prime divisors. Therefore, the correct criterion is to verify that `D` is linearly equivalent to an effective divisor.

To fix this, I propose a different approach: `[D]` is effective iff `O_(X_Sigma)([D])` has at least one global section.