### PR TITLE
Revert "tests and cleanup for elliptic surfaces (#3654)"

### DIFF
--- a/experimental/Schemes/elliptic_surface.jl
+++ b/experimental/Schemes/elliptic_surface.jl
@@ -1323,7 +1323,7 @@ function horizontal_decomposition(X::EllipticSurface, F::Vector{QQFieldElem})
   else
     found = false
     for (i,(T, tor)) in enumerate(tors)
-      d = F1 - _vec(tor)
+      d = F2 - _vec(tor)
       if all(isone(denominator(i)) for i in d)
         found = true
         T0 = mordell_weil_torsion(X)[i]
@@ -1570,17 +1570,24 @@ end
     elliptic_surface(g::MPolyRingElem, P::Vector{<:RingElem})
 
 Transform a bivariate polynomial `g` of the form `y^2 - Q(x)` with `Q(x)` of
-degree at most ``4`` to Weierstrass form, apply Tate's algorithm and 
-return the corresponding relatively minimal elliptic surface 
-as well as the coordinate transformation.
+degree at most ``4`` to Weierstrass form and return the corresponding
+elliptic surface as well as the coordinate transformation.
 """
 function elliptic_surface(g::MPolyRingElem, P::Vector{<:RingElem})
   R = parent(g)
   (x, y) = gens(R)
   P = base_ring(R).(P)
   g2, phi2 = transform_to_weierstrass(g, x, y, P);
-  Y2, phi1 = _elliptic_surface_with_trafo(g2)
-  return Y2, phi2 * phi1  
+  E2 = elliptic_curve(g2, x, y);
+  t2 = gen(base_field(E2));
+  Y2 = elliptic_surface(E2, 2)
+
+  W = weierstrass_chart(Y2)
+  RW = ambient_coordinate_ring(W); FRW = fraction_field(RW);
+  (x, y, t) = gens(RW) # Output of phi2 lives in (k(t))(x, y), so we need to convert
+  psi = hom(base_ring(codomain(phi2)), FRW, f->evaluate(f, t), FRW.([x,y])); # a helper function
+  psi_ext = extend_domain_to_fraction_field(psi)
+  return Y2, phi2 * psi_ext
 end
 
 @doc raw"""
@@ -1594,6 +1601,22 @@ on the curve defined by `g`, i.e. `g(P) == 0`.
 function transform_to_weierstrass(g::MPolyRingElem, x::MPolyRingElem, y::MPolyRingElem, P::Vector{<:RingElem})
   R = parent(g)
   F = fraction_field(R)
+
+  # In case of variables in the wrong order, switch and transform the result.
+  if x == R[2] && y == R[1]
+    switch = hom(R, R, reverse(gens(R)))
+    g_trans, trans = transform_to_weierstrass(switch(g), y, x, reverse(P))
+    new_trans = MapFromFunc(F, F, f->begin
+                                switch_num = switch(numerator(f))
+                                switch_den = switch(denominator(f))
+                                interm_res = trans(F(switch_num))//trans(F(switch(den)))
+                                num = numerator(interm_res)
+                                den = denominator(interm_res)
+                                switch(num)//switch(den)
+                            end
+                           )
+    return switch(g_trans), new_trans
+  end
   @assert ngens(R) == 2 "input polynomial must be bivariate"
   @assert x in gens(R) "second argument must be a variable of the parent of the first"
   @assert y in gens(R) "third argument must be a variable of the parent of the first"
@@ -2439,14 +2462,15 @@ function check_isomorphism_on_generic_fibers(phi::MorphismFromRationalFunctions{
   return divides(hX, numerator(hh))[1]
 end
 
+# Given two elliptic surfaces X and Y with abstractly isomorphic generic 
+# fibers, construct the corresponding isomorphism X -> Y.
 function isomorphism_from_generic_fibers(
-    X::EllipticSurface, Y::EllipticSurface, f::Hecke.EllCrvIso
+    X::EllipticSurface, Y::EllipticSurface
   )
   EX = generic_fiber(X)
   EY = generic_fiber(Y)
-  iso_ell = f
-  @req domain(f) == EX "must be an isomorphism of the generic fibers"
-  @req codomain(f) == EY "must be an isomorphism of the generic fibers"
+  is_isomorphic(EX, EY) || error("generic fibers are not isomorphic")
+  iso_ell = isomorphism(EX, EY)
   a, b, _ = rational_maps(iso_ell)
   kt = base_field(EX)
   t = gen(kt)
@@ -2468,40 +2492,7 @@ function isomorphism_from_generic_fibers(
   A = to_FRX(a)
   B = to_FRX(b)
   img_gens = [A, B, FRX(RX[3])]
-  m = morphism_from_rational_functions(X, Y, WX, WY, FRX.(img_gens); check=false)
-  set_attribute!(m, :is_isomorphism=>true)
-  return m
-end
-
-# Given two elliptic surfaces X and Y with abstractly isomorphic generic 
-# fibers, construct the corresponding isomorphism X -> Y.
-function isomorphism_from_generic_fibers(
-    X::EllipticSurface, Y::EllipticSurface
-  )
-  EX = generic_fiber(X)
-  EY = generic_fiber(Y)
-  is_isomorphic(EX, EY) || error("generic fibers are not isomorphic")
-  iso_ell = isomorphism(EX, EY)
-  return isomorphism_from_generic_fibers(X, Y, iso_ell)
-end
-
-
-"""
-    pushforward_on_algebraic_lattices(f::MorphismFromRationalFunctions{<:EllipticSurface, <:EllipticSurface}) -> QQMatrix
-    
-Return the pushforward `f_*: V_1 -> V_2` where `V_i` is the ambient quadratic space of the `algebraic_lattice`.
-
-This assumes that the image `f_*(V_1)` is contained in `V_2`. If this is not the case, you will get  
-``f_*`` composed with the orthogonal projection to `V_2`. 
-"""
-function pushforward_on_algebraic_lattices(f::MorphismFromRationalFunctions{<:EllipticSurface, <:EllipticSurface})
-  imgs_divs = _pushforward_lattice_along_isomorphism(f)
-  M = matrix([basis_representation(codomain(f),i) for i in imgs_divs])
-  V1 = ambient_space(algebraic_lattice(domain(f))[3])
-  V2 = ambient_space(algebraic_lattice(codomain(f))[3])
-  # keep the check on since it is simple compared to all the other computations done here
-  fstar = hom(V1,V2, M; check=true)
-  return fstar
+  return morphism_from_rational_functions(X, Y, WX, WY, FRX.(img_gens); check=true)
 end
 
 # Given an irreducible divisor D on an elliptic surface X, try to extract a point 

--- a/test/AlgebraicGeometry/Schemes/elliptic_surface.jl
+++ b/test/AlgebraicGeometry/Schemes/elliptic_surface.jl
@@ -1,29 +1,31 @@
 @testset "elliptic surfaces" begin
-  @testset "trivial lattice" begin
-    k = GF(29)
-    # The generic fiber of the elliptic fibration
-    # as an elliptic curve over k(t)
-    kt, t = polynomial_ring(k, :t)
-    kP1 = fraction_field(kt)
-    t = gen(kP1)
-    E = elliptic_curve(kP1, [3*t^8 + 10*t^7 + 6*t^6 + 17*t^5 + 25*t^4 + 4*t^3 + 23*t^2 + 9*t + 14, 5*t^12 + 25*t^11 + 2*t^10 + 28*t^9 + 28*t^8 + 19*t^7 + 3*t^6 + 17*t^5 + 19*t^4 + 12*t^3 + 25*t^2 + 12*t + 6])
-    # A basis for the Mordell-Weil group of E
-    mwl_basis = [E(collect(i)) for i in [
-    (12*t^4 + 21*t^3 + 5*t^2 + 12*t + 18, 23*t^5 + 7*t^4 + 22*t^3 + 13*t^2),
-    (12*t^4 + 20*t^3 + 22*t^2 + 27*t + 18, 15*t^4 + 12*t^3 + 12*t),
-    (12*t^4 + 20*t^3 + 27*t^2 + 11*t + 18, -(16*t^4 + 24*t^3 + 3*t^2 + 24*t)),
-    (4*t^4 + 5*t^3 + 5*t^2 + 6*t + 13,  9*t^6 + 21*t^5 + 17*t^4 + 12*t^2 + 3*t + 6)]]
-    S = elliptic_surface(E, 2, mwl_basis)
-    weierstrass_model(S)
-    weierstrass_contraction(S)
+  #=
+  # The tests in this file are quite expensive
+  # hence this one is disabled
+  k = GF(29)
+  # The generic fiber of the elliptic fibration
+  # as an elliptic curve over k(t)
+  kt, t = polynomial_ring(k, :t)
+  kP1 = fraction_field(kt)
+  t = gen(kP1)
+  E = elliptic_curve(kP1, [3*t^8 + 10*t^7 + 6*t^6 + 17*t^5 + 25*t^4 + 4*t^3 + 23*t^2 + 9*t + 14, 5*t^12 + 25*t^11 + 2*t^10 + 28*t^9 + 28*t^8 + 19*t^7 + 3*t^6 + 17*t^5 + 19*t^4 + 12*t^3 + 25*t^2 + 12*t + 6])
+  # A basis for the Mordell-Weil group of E
+  mwl_basis = [E(collect(i)) for i in [
+  (12*t^4 + 21*t^3 + 5*t^2 + 12*t + 18, 23*t^5 + 7*t^4 + 22*t^3 + 13*t^2),
+  (12*t^4 + 20*t^3 + 22*t^2 + 27*t + 18, 15*t^4 + 12*t^3 + 12*t),
+  (12*t^4 + 20*t^3 + 27*t^2 + 11*t + 18, -(16*t^4 + 24*t^3 + 3*t^2 + 24*t)),
+  (4*t^4 + 5*t^3 + 5*t^2 + 6*t + 13,  9*t^6 + 21*t^5 + 17*t^4 + 12*t^2 + 3*t + 6)]]
+  S = elliptic_surface(E, 2, mwl_basis)
+  weierstrass_model(S)
+  weierstrass_contraction(S)
 
-    E = elliptic_curve(kP1, [0,0,0,1,t^10])
-    X = elliptic_surface(E, 2)
-    triv = trivial_lattice(X)
-    @test det(triv[2])==-3
-  end  
-  
-  # This test takes about 1 minute
+  E = elliptic_curve(kP1, [0,0,0,1,t^10])
+  X = elliptic_surface(E, 2)
+  triv = trivial_lattice(X)
+  =#
+
+  #=
+  # This test takes about 5 minutes
   @testset "mordel weil lattices" begin
     k = GF(29,2)
     # The generic fiber of the elliptic fibration
@@ -41,14 +43,11 @@
     alg = algebraic_lattice(X)
     @test det(alg[3]) == -192
     @test det(mordell_weil_lattice(X)) == 3
-    
-    X1 = elliptic_surface(short_weierstrass_model(E)[1],2)
-    Oscar.isomorphism_from_generic_fibers(X,X1)
   end
+  =#
   #=
   # this test is quite expensive
   # probably because it is over QQ
-  # ... and because there are loads of complicated singular fibers
   Qt, t = polynomial_ring(QQ, :t)
   Qtf = fraction_field(Qt)
   E = elliptic_curve(Qtf, [0,0,0,0,t^5*(t-1)^2])
@@ -77,11 +76,15 @@
     g, phi = two_neighbor_step(X, ff)
 
 
+    #=
+    # takes far too long
     mwl_gens_new = vcat([mwl_basis[1] + mwl_basis[2], mwl_basis[1] - mwl_basis[2]])
     set_mordell_weil_basis!(X, mwl_gens_new)
-    @test det(algebraic_lattice(X)[3])==96
-    Oscar.algebraic_lattice_primitive_closure!(X)
-    @test det(algebraic_lattice(X)[3])==24
+    @test det(algebraic_lattice(X)[3])==-96
+    algebraic_lattice_primitive_closure!(X)
+    @test det(algebraic_lattice(X)[3])==-24
+    =#
+
 
   end
 end
@@ -112,16 +115,11 @@ end
   f = y^2 - 4*x^4 + 5*x^3 - 3*x^2 + 7*x - 4*t^8
   f_trans, trans = Oscar.transform_to_weierstrass(f, x, y, kt.([0, 2*t^4]))
   @test f_trans == x^3 + (-3//8*t^8 + 49//128)//t^16*x^2 + 7//8//t^8*x*y + (-1//4*t^24 + 9//256*t^16 - 147//2048*t^8 + 2401//65536)//t^32*x - y^2 + (5//16*t^16 - 21//128*t^8 + 343//2048)//t^24*y
-  
-  R, (x, y) = polynomial_ring(kt, [:x, :y])
-  f = y^2 - 4*x^4 + 5*x^3 - 3*x^2 + 7*x - 4*t^8
-  Y,trafo = elliptic_surface(f, kt.([0, 2*t^4]))
 end
 
 
 #=
-# These tests are disabled, because they take too long, about 5 minutes. But one can run them if in doubt.
-# most of the time is spent in decomposing the fibers
+# These tests are disabled, because they take too long. But one can run them if in doubt.
 @testset "two neighbor steps" begin
   K = GF(7)
   Kt, t = polynomial_ring(K, :t)
@@ -228,10 +226,10 @@ end
                [56*t^4 + 49*t^3 + 85*t^2 + 57*t + 57, 72*t^6 + 25*t^5 + 22*t^4 + 101*t^3 + 104*t^2 + 88*t + 50],
                [22*t^4 + 87*t^3 + 77*t^2 + 26*t + 22, 44*t^6 + 27*t^5 + 68*t^4 + 98*t^3 + 45*t^2 + 27*t + 69],
                [112*t^4 + 44*t^3 + 49*t^2 + 44*t + 112, 100*t^6 + 74*t^5 + 49*t^4 + 8*t^3 + 49*t^2 + 74*t + 100]]
-  basis_mwl = [E(i) for i in basis_mwl];  
+  basis_mwl = [E(i) for i in basis_mwl];
 
-  X = elliptic_surface(E, 2, basis_mwl[1:0])  # speed up test by hiding the sections
-  
+  X = elliptic_surface(E, 2, basis_mwl)
+
   moeb = Oscar.admissible_moebius_transformations(X, X)
 
   @test length(moeb) == 16 # This must really be the number for this particular surface.
@@ -248,22 +246,19 @@ end
     phi_loc = Oscar.cheap_realization(phi, W, U)
     @test all(iszero(pullback(phi_loc)(lifted_numerator(g))) for g in gens(modulus(OO(U))))
   end
+
+  # Do something reasonable to see whether this is really working
+  lat, _, L = algebraic_lattice(X)
+  A = gram_matrix(ambient_space(L))
+ 
+  ll = Oscar._pushforward_lattice_along_isomorphism(phi)
+  res_mat = [Oscar.basis_representation(X, d) for d in ll]
   
-  phi_star = Oscar.pushforward_on_algebraic_lattices(phi)
-  # Check that the pushforward preserves the numerical lattice of X
-  Triv = algebraic_lattice(X)[3]
-  @test phi_star(Triv)==Triv
+  res_mat = matrix(QQ, res_mat)
+  # Check that the base change matrix is indeed orthogonal for the given lattice
+  @test res_mat*A*transpose(res_mat) == A
   
-  # test translation
-  P = Oscar.mordell_weil_torsion(X)[1]
-  torsion_translation = Oscar.translation_morphism(X, P)
-  tors_of_P = pushforward(torsion_translation,zero_section(X)) 
-  Psect = section(X, P)
-  @test tors_of_P == Psect
-  
-  # add a section so that there is something to compute (although rather trivial)
-  set_mordell_weil_basis!(X, basis_mwl[1:1])
-  P = Oscar.extract_mordell_weil_basis(torsion_translation)
-  @test length(P) == 2
+  P = Oscar.extract_mordell_weil_basis(phi)
+  @test length(P) == 9
 end
 


### PR DESCRIPTION
This reverts PR #3654 which was merged despite some CI runs failing with a timeout in `test/AlgebraicGeometry/Schemes/elliptic_surface.jl`. And now master and other PRs are running into these timeouts.