### PR TITLE
Call `GapObj` instead of accessing `chi.values` (for group characters) or `f.map` (for group homomorphisms)

### DIFF
--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -612,7 +612,7 @@ function Oscar.natural_character(C::GModule{<:Any, <:AbstractAlgebra.FPModule{<:
 
   vals = [GAP.Globals.BrauerCharacterValue(GAP.Obj(map(h, matrix(action(C, representative(x)))))) for x in ccl]
 
-  return Oscar.class_function(modtbl, GAPWrap.ClassFunction(Oscar.GAPTable(modtbl), Oscar.GapObj(vals)))
+  return Oscar.class_function(modtbl, GAPWrap.ClassFunction(GapObj(modtbl), GapObj(vals)))
 end
 
 function Oscar.sub(C::GModule{<:Any, <:AbstractAlgebra.FPModule{T}}, m::MatElem{T}) where {T <: FinFieldElem}

--- a/experimental/GModule/GModule.jl
+++ b/experimental/GModule/GModule.jl
@@ -1528,7 +1528,7 @@ function Oscar.gmodule(::Type{FinGenAbGroup}, C::GModule{T, <:AbstractAlgebra.FP
 end
 
 function Oscar.gmodule(chi::Oscar.GAPGroupClassFunction)
-  f = GAP.Globals.IrreducibleAffordingRepresentation(chi.values)
+  f = GAP.Globals.IrreducibleAffordingRepresentation(GapObj(chi))
   K = abelian_closure(QQ)[1]
   g = GAP.Globals.List(GAP.Globals.GeneratorsOfGroup(GapObj(group(chi))), f)
   z = map(x->matrix(map(y->map(K, y), g[x])), 1:GAP.Globals.Size(g))

--- a/experimental/OrthogonalDiscriminants/src/theoretical.jl
+++ b/experimental/OrthogonalDiscriminants/src/theoretical.jl
@@ -240,7 +240,7 @@ function od_from_p_subgroup(chi::GAPGroupClassFunction, p::Int,
   end
 
   fus = filter(i -> pi[i] != 0, 1:number_of_conjugacy_classes(tbl))
-  res = Oscar.GAPWrap.ELMS_LIST(chi.values, GAP.GapObj(fus))
+  res = Oscar.GAPWrap.ELMS_LIST(GapObj(chi), GapObj(fus))
 
   if l != 0
     # possible shortcut:

--- a/experimental/OrthogonalDiscriminants/src/utils.jl
+++ b/experimental/OrthogonalDiscriminants/src/utils.jl
@@ -150,10 +150,10 @@ function possible_permutation_characters_from_sylow_subgroup(tbl::Oscar.GAPGroup
   pos != nothing && return [induced_cyclic(tbl, [pos])[1]]
 
   # Do we have the table of marks?
-  tom = GAP.Globals.TableOfMarks(Oscar.GAPTable(tbl))
+  tom = GAP.Globals.TableOfMarks(GapObj(tbl))
   if tom != GAP.Globals.fail
     pos = findfirst(x -> x == q, Vector{Int}(GAP.Globals.OrdersTom(tom)))
-    return [Oscar.class_function(tbl, GAP.Globals.PermCharsTom(Oscar.GAPTable(tbl), tom)[pos])]
+    return [Oscar.class_function(tbl, GAP.Globals.PermCharsTom(GapObj(tbl), tom)[pos])]
   end
 
   # Does the table have a nontrivial 'p'-core
@@ -193,7 +193,7 @@ function possible_permutation_characters_from_sylow_subgroup(tbl::Oscar.GAPGroup
             for i in npos
               pi[i] = index
             end
-            pi = GAP.Globals.ClassFunction(Oscar.GAPTable(s), GapObj(pi, true))
+            pi = GAP.Globals.ClassFunction(GapObj(s), GapObj(pi, true))
             return [Oscar.class_function(s, pi)^tbl]
           else
             # Try to recurse.
@@ -219,7 +219,7 @@ function possible_permutation_characters_from_sylow_subgroup(tbl::Oscar.GAPGroup
               pi = GAP.Globals.CompositionMaps(GapObj(pi),
                        GAP.Globals.InverseMap(GapObj(fus)))
               union!(extcand, [Oscar.class_function(tbl, x) for x in
-                                GAP.Globals.PermChars(Oscar.GAPTable(tbl),
+                                GAP.Globals.PermChars(GapObj(tbl),
                                   GapObj(Dict(:torso => pi), true))])
             end
             if candlist == nothing

--- a/experimental/OrthogonalDiscriminants/src/utils.jl
+++ b/experimental/OrthogonalDiscriminants/src/utils.jl
@@ -216,11 +216,11 @@ function possible_permutation_characters_from_sylow_subgroup(tbl::Oscar.GAPGroup
           if cand != nothing
             extcand = []
             for pi in cand
-              pi = GAP.Globals.CompositionMaps(pi.values,
+              pi = GAP.Globals.CompositionMaps(GapObj(pi),
                        GAP.Globals.InverseMap(GapObj(fus)))
               union!(extcand, [Oscar.class_function(tbl, x) for x in
                                 GAP.Globals.PermChars(Oscar.GAPTable(tbl),
-                                  GAP.GapObj(Dict(:torso => pi), true))])
+                                  GapObj(Dict(:torso => pi), true))])
             end
             if candlist == nothing
               candlist = extcand

--- a/experimental/SymmetricIntersections/src/representations.jl
+++ b/experimental/SymmetricIntersections/src/representations.jl
@@ -234,7 +234,7 @@ end
 Given a class function `chi` on a group `G`, return whether `chi` defines a
 character of `G` (over its codomain).
 """
-is_character(chi::Oscar.GAPGroupClassFunction) = GG.IsCharacter(GAPTable(parent(chi)), chi.values)::Bool
+is_character(chi::Oscar.GAPGroupClassFunction) = GG.IsCharacter(GAPTable(parent(chi)), GapObj(chi))::Bool
 
 @doc raw"""
     is_constituent(chi::T, nu::T) where T <: Oscar.GAPGroupClassFunction -> Bool
@@ -502,7 +502,7 @@ function irreducible_affording_representation(RR::RepRing{S, T}, chi::Oscar.GAPG
   H = generators_underlying_group(RR)
 
   # the GAP function which we rely on
-  rep = GG.IrreducibleAffordingRepresentation(chi.values)::GAP.GapObj
+  rep = GG.IrreducibleAffordingRepresentation(GapObj(chi))::GAP.GapObj
 
   # we compute certain images than we will convert then.
   # we use them then to construct the mapping in

--- a/experimental/SymmetricIntersections/src/representations.jl
+++ b/experimental/SymmetricIntersections/src/representations.jl
@@ -234,7 +234,7 @@ end
 Given a class function `chi` on a group `G`, return whether `chi` defines a
 character of `G` (over its codomain).
 """
-is_character(chi::Oscar.GAPGroupClassFunction) = GG.IsCharacter(GAPTable(parent(chi)), GapObj(chi))::Bool
+is_character(chi::Oscar.GAPGroupClassFunction) = GG.IsCharacter(GapObj(parent(chi)), GapObj(chi))::Bool
 
 @doc raw"""
     is_constituent(chi::T, nu::T) where T <: Oscar.GAPGroupClassFunction -> Bool

--- a/src/GAP/oscar_to_gap.jl
+++ b/src/GAP/oscar_to_gap.jl
@@ -72,3 +72,15 @@ function GAP.julia_to_gap(
 
     return gapset
 end
+
+## TODO: remove the following once GAP.jl has it
+## (This will be the case when the change from
+## https://github.com/oscar-system/GAP.jl/pull/989
+## will be available.)
+function GAP.julia_to_gap(
+    obj::JSON3.Array,
+    recursion_dict::IdDict{Any,Any} = IdDict();
+    recursive::Bool = false)
+
+    return GAP.julia_to_gap(copy(obj), recursion_dict; recursive)
+end

--- a/src/GAP/oscar_to_gap.jl
+++ b/src/GAP/oscar_to_gap.jl
@@ -77,6 +77,8 @@ end
 ## (This will be the case when the change from
 ## https://github.com/oscar-system/GAP.jl/pull/989
 ## will be available.)
+using JSON3
+
 function GAP.julia_to_gap(
     obj::JSON3.Array,
     recursion_dict::IdDict{Any,Any} = IdDict();

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -136,7 +136,7 @@ in a `p`-modular table.
 end
 
 # access to field values via functions
-GAPTable(tbl::GAPGroupCharacterTable) = tbl.GAPTable
+GapObj(tbl::GAPGroupCharacterTable) = tbl.GAPTable
 
 @doc raw"""
     characteristic(::Type{T} = Int, tbl::GAPGroupCharacterTable) where T <: IntegerUnion
@@ -243,10 +243,10 @@ true
 @attr function conjugacy_classes(tbl::GAPGroupCharacterTable)
     G = group(tbl)
 
-    # If `GAPTable(tbl)` does not yet store conjugacy classes
+    # If `GapObj(tbl)` does not yet store conjugacy classes
     # then compute them.
     if characteristic(tbl) == 0
-      ccl = GAPWrap.ConjugacyClasses(GAPTable(tbl))::GapObj
+      ccl = GAPWrap.ConjugacyClasses(GapObj(tbl))::GapObj
       ccl = [conjugacy_class(G,
                preimage(isomorphism_to_GAP_group(tbl),
                         GAPWrap.Representative(x)))
@@ -446,7 +446,7 @@ julia> is_duplicate_table(character_table("A6M2"))
 true
 ```
 """
-@gapattribute is_duplicate_table(tbl::GAPGroupCharacterTable) = GAP.Globals.IsDuplicateTable(GAPTable(tbl))::Bool
+@gapattribute is_duplicate_table(tbl::GAPGroupCharacterTable) = GAP.Globals.IsDuplicateTable(GapObj(tbl))::Bool
 
 """
     all_character_table_names(L...; ordered_by = nothing)
@@ -793,7 +793,7 @@ $
 """
 function Base.show(io::IO, ::MIME"text/plain", tbl::GAPGroupCharacterTable)
     n = nrows(tbl)
-    gaptbl = GAPTable(tbl)
+    gaptbl = GapObj(tbl)
     size = order(ZZRingElem, tbl)
     primes = [x[1] for x in collect(factor(size))]
     sort!(primes)
@@ -937,10 +937,10 @@ end
 
 ##############################################################################
 #
-length(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(GAPTable(tbl))::Int
-number_of_rows(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(GAPTable(tbl))::Int
-number_of_columns(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(GAPTable(tbl))::Int
-number_of_conjugacy_classes(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(GAPTable(tbl))::Int
+length(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(GapObj(tbl))::Int
+number_of_rows(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(GapObj(tbl))::Int
+number_of_columns(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(GapObj(tbl))::Int
+number_of_conjugacy_classes(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(GapObj(tbl))::Int
 
 @doc raw"""
     order(::Type{T} = ZZRingElem, tbl::GAPGroupCharacterTable) where T <: IntegerUnion
@@ -957,7 +957,7 @@ julia> order(character_table(symmetric_group(4)))
 order(tbl::GAPGroupCharacterTable) = order(ZZRingElem, tbl)
 
 function order(::Type{T}, tbl::GAPGroupCharacterTable) where T <: IntegerUnion
-  return T(GAPWrap.Size(GAPTable(tbl)))
+  return T(GAPWrap.Size(GapObj(tbl)))
 end
 
 @doc raw"""
@@ -972,7 +972,7 @@ julia> println(orders_class_representatives(character_table("A5")))
 [1, 2, 3, 5, 5]
 ```
 """
-@gapattribute orders_class_representatives(tbl::GAPGroupCharacterTable) = Vector{Int}(GAP.Globals.OrdersClassRepresentatives(GAPTable(tbl))::GapObj)
+@gapattribute orders_class_representatives(tbl::GAPGroupCharacterTable) = Vector{Int}(GAP.Globals.OrdersClassRepresentatives(GapObj(tbl))::GapObj)
 
 @doc raw"""
     orders_centralizers(tbl::GAPGroupCharacterTable)
@@ -987,7 +987,7 @@ julia> println(orders_centralizers(character_table("A5")))
 ZZRingElem[60, 4, 3, 5, 5]
 ```
 """
-@gapattribute orders_centralizers(tbl::GAPGroupCharacterTable) = Vector{ZZRingElem}(GAP.Globals.SizesCentralizers(GAPTable(tbl))::GAP.Obj)
+@gapattribute orders_centralizers(tbl::GAPGroupCharacterTable) = Vector{ZZRingElem}(GAP.Globals.SizesCentralizers(GapObj(tbl))::GAP.Obj)
 
 @doc raw"""
     class_lengths(tbl::GAPGroupCharacterTable)
@@ -998,7 +998,7 @@ julia> println(class_lengths(character_table("A5")))
 ZZRingElem[1, 15, 20, 12, 12]
 ```
 """
-@gapattribute class_lengths(tbl::GAPGroupCharacterTable) = Vector{ZZRingElem}(GAP.Globals.SizesConjugacyClasses(GAPTable(tbl))::GapObj)
+@gapattribute class_lengths(tbl::GAPGroupCharacterTable) = Vector{ZZRingElem}(GAP.Globals.SizesConjugacyClasses(GapObj(tbl))::GapObj)
 
 @doc raw"""
     maxes(tbl::GAPGroupCharacterTable)
@@ -1023,8 +1023,8 @@ true
 ```
 """
 function maxes(tbl::GAPGroupCharacterTable)
-  if GAPWrap.HasMaxes(GAPTable(tbl))
-    return Vector{String}(GAPWrap.Maxes(GAPTable(tbl)))
+  if GAPWrap.HasMaxes(GapObj(tbl))
+    return Vector{String}(GAPWrap.Maxes(GapObj(tbl)))
   end
   return nothing
 end
@@ -1041,7 +1041,7 @@ julia> identifier(character_table("A5"))
 "A5"
 ```
 """
-@gapattribute identifier(tbl::GAPGroupCharacterTable) = string(GAP.Globals.Identifier(GAPTable(tbl))::GapObj)
+@gapattribute identifier(tbl::GAPGroupCharacterTable) = string(GAP.Globals.Identifier(GapObj(tbl))::GapObj)
 
 
 @doc raw"""
@@ -1064,7 +1064,7 @@ julia> class_positions_of_normal_subgroups(t)
 ```
 """
 function class_positions_of_normal_subgroups(tbl::GAPGroupCharacterTable)
-    return Vector{Vector{Int}}(GAPWrap.ClassPositionsOfNormalSubgroups(GAPTable(tbl)))
+    return Vector{Vector{Int}}(GAPWrap.ClassPositionsOfNormalSubgroups(GapObj(tbl)))
 end
 
 
@@ -1084,7 +1084,7 @@ julia> println(class_positions_of_center(tbl))
 ```
 """
 function class_positions_of_center(tbl::GAPGroupCharacterTable)
-    return Vector{Int}(GAPWrap.ClassPositionsOfCentre(GAPTable(tbl)))
+    return Vector{Int}(GAPWrap.ClassPositionsOfCentre(GapObj(tbl)))
 end
 
 
@@ -1103,7 +1103,7 @@ julia> println(class_positions_of_derived_subgroup(tbl))
 ```
 """
 function class_positions_of_derived_subgroup(tbl::GAPGroupCharacterTable)
-    return Vector{Int}(GAPWrap.ClassPositionsOfDerivedSubgroup(GAPTable(tbl)))
+    return Vector{Int}(GAPWrap.ClassPositionsOfDerivedSubgroup(GapObj(tbl)))
 end
 
 
@@ -1126,7 +1126,7 @@ julia> println(class_positions_of_solvable_residuum(tbl))
 ```
 """
 function class_positions_of_solvable_residuum(tbl::GAPGroupCharacterTable)
-    return Vector{Int}(GAPWrap.ClassPositionsOfSolvableResiduum(GAPTable(tbl)))
+    return Vector{Int}(GAPWrap.ClassPositionsOfSolvableResiduum(GapObj(tbl)))
 end
 
 
@@ -1143,7 +1143,7 @@ julia> println(class_positions_of_pcore(character_table("2.A5"), 2))
 [1, 2]
 ```
 """
-class_positions_of_pcore(tbl::GAPGroupCharacterTable, p::IntegerUnion) = Vector{Int}(GAPWrap.ClassPositionsOfPCore(GAPTable(tbl), GAP.Obj(p)))
+class_positions_of_pcore(tbl::GAPGroupCharacterTable, p::IntegerUnion) = Vector{Int}(GAPWrap.ClassPositionsOfPCore(GapObj(tbl), GAP.Obj(p)))
 
 @doc raw"""
     pcore(tbl::GAPGroupCharacterTable, p::IntegerUnion)
@@ -1160,7 +1160,7 @@ julia> order(pcore(character_table(symmetric_group(4)), 2)[1])
 """
 function pcore(tbl::GAPGroupCharacterTable, p::IntegerUnion)
     iso = isomorphism_to_GAP_group(tbl)
-    t = GAPTable(tbl)
+    t = GapObj(tbl)
     pcorepos = GAPWrap.ClassPositionsOfPCore(t, GAP.Obj(p))
     P = GAPWrap.NormalSubgroupClasses(t, pcorepos)
     return preimages(iso, P)
@@ -1171,7 +1171,7 @@ function class_positions_of_kernel(fus::Vector{Int})
 end
 
 function Base.getindex(tbl::GAPGroupCharacterTable, i::Int)
-    irr = GAPWrap.Irr(GAPTable(tbl))
+    irr = GAPWrap.Irr(GapObj(tbl))
     return class_function(tbl, irr[i])
 end
 #TODO: cache the irreducibles in the table
@@ -1185,7 +1185,7 @@ function Base.keys(tbl::GAPGroupCharacterTable)
 end
 
 function Base.getindex(tbl::GAPGroupCharacterTable, i::Int, j::Int)
-    irr = GAPWrap.Irr(GAPTable(tbl))
+    irr = GAPWrap.Irr(GapObj(tbl))
     val = irr[i, j]
     return QQAbElem(val)
 end
@@ -1216,7 +1216,7 @@ function Base.mod(tbl::GAPGroupCharacterTable, p::T) where T <: IntegerUnion
 
     modtbls = get_attribute!(() -> Dict{Int,Any}(), tbl, :brauer_tables)
     if ! haskey(modtbls, p)
-      modtblgap = mod(GAPTable(tbl), GAP.Obj(p))::GapObj
+      modtblgap = mod(GapObj(tbl), GAP.Obj(p))::GapObj
       if modtblgap === GAP.Globals.fail
         modtbls[p] = nothing
       elseif isdefined(tbl, :group)
@@ -1257,7 +1257,7 @@ julia> decomposition_matrix(t2)
 """
 function decomposition_matrix(modtbl::GAPGroupCharacterTable)
     @req is_prime(characteristic(modtbl)) "characteristic of tbl must be a prime integer"
-    return matrix(ZZ, GAPWrap.DecompositionMatrix(GAPTable(modtbl)))
+    return matrix(ZZ, GAPWrap.DecompositionMatrix(GapObj(modtbl)))
 end
 
 
@@ -1287,7 +1287,7 @@ julia> println(proj)
 """
 function quo(tbl::GAPGroupCharacterTable, nclasses::Vector{Int})
   @req characteristic(tbl) == 0 "supported only for ordinary character tables"
-  gap_fact = GAPWrap.CharacterTableFactorGroup(GAPTable(tbl), GapObj(nclasses))
+  gap_fact = GAPWrap.CharacterTableFactorGroup(GapObj(tbl), GapObj(nclasses))
   fact = GAPGroupCharacterTable(gap_fact, 0)
   flag, fus = known_class_fusion(tbl, fact)
   @assert flag
@@ -1335,7 +1335,7 @@ julia> class_multiplication_coefficient(character_table("A5"), 2, 4, 4)
 ```
 """
 function class_multiplication_coefficient(::Type{T}, tbl::GAPGroupCharacterTable, i::Int, j::Int, k::Int) where T <: IntegerUnion
-  return T(GAPWrap.ClassMultiplicationCoefficient(GAPTable(tbl), i, j, k))
+  return T(GAPWrap.ClassMultiplicationCoefficient(GapObj(tbl), i, j, k))
 end
 
 class_multiplication_coefficient(tbl::GAPGroupCharacterTable, i::Int, j::Int, k::Int) = class_multiplication_coefficient(ZZRingElem, tbl, i, j, k)
@@ -1364,7 +1364,7 @@ Union{Int64, Vector{Int64}}[1, 2, [3, 4], [6, 7], [6, 7]]
 """
 function approximate_class_fusion(subtbl::GAPGroupCharacterTable,
                                   tbl::GAPGroupCharacterTable)
-  fus = GAPWrap.InitFusion(GAPTable(subtbl), GAPTable(tbl))
+  fus = GAPWrap.InitFusion(GapObj(subtbl), GapObj(tbl))
   res = Union{Int, Vector{Int}}[]
   fus == GAP.Globals.fail && return res
   for i in 1:length(fus)
@@ -1417,7 +1417,7 @@ function possible_class_fusions(subtbl::GAPGroupCharacterTable,
   if length(fusionmap) != 0
     cond[:fusionmap] = GapObj(fusionmap, recursive = true)
   end
-  fus = GAPWrap.PossibleClassFusions(GAPTable(subtbl), GAPTable(tbl),
+  fus = GAPWrap.PossibleClassFusions(GapObj(subtbl), GapObj(tbl),
             GapObj(cond))
   return [Vector{Int}(x::GapObj) for x in fus]
 end
@@ -1444,7 +1444,7 @@ Dict{Symbol, Vector{Int64}} with 2 entries:
 """
 function block_distribution(tbl::GAPGroupCharacterTable, p::IntegerUnion)
   @req characteristic(tbl) == 0 "character table must be ordinary"
-  blocks = GAP.Globals.PrimeBlocks(GAPTable(tbl), GAP.Obj(p))
+  blocks = GAP.Globals.PrimeBlocks(GapObj(tbl), GAP.Obj(p))
   return Dict(:defect => Vector{Int}(blocks.defect),
               :block => Vector{Int}(blocks.block))
 end
@@ -1508,7 +1508,7 @@ julia> character_parameters(character_table("M11"))
 """
 function character_parameters(tbl::GAPGroupCharacterTable)
     return get_attribute!(tbl, :character_parameters) do
-      GAPt = GAPTable(tbl)
+      GAPt = GapObj(tbl)
       GAPWrap.HasCharacterParameters(GAPt) || return nothing
       paras = Vector{GAP.Obj}(GAPWrap.CharacterParameters(GAPt))
       return _translate_parameter_list(paras)
@@ -1538,7 +1538,7 @@ julia> class_parameters(character_table("M11"))
 """
 function class_parameters(tbl::GAPGroupCharacterTable)
     return get_attribute!(tbl, :class_parameters) do
-      GAPt = GAPTable(tbl)
+      GAPt = GapObj(tbl)
       GAPWrap.HasClassParameters(GAPt) || return nothing
       paras = Vector{GAP.Obj}(GAPWrap.ClassParameters(GAPt))
       return _translate_parameter_list(paras)
@@ -1563,7 +1563,7 @@ julia> println(class_names(character_table("S5")))
 """
 function class_names(tbl::GAPGroupCharacterTable)
     return get_attribute!(tbl, :class_names) do
-      return Vector{String}(GAPWrap.ClassNames(GAPTable(tbl)))
+      return Vector{String}(GAPWrap.ClassNames(GapObj(tbl)))
     end
 end
 
@@ -1587,7 +1587,7 @@ true
 ```
 """
 function names_of_fusion_sources(tbl::GAPGroupCharacterTable)
-    return [string(name) for name in GAPWrap.NamesOfFusionSources(GAPTable(tbl))]
+    return [string(name) for name in GAPWrap.NamesOfFusionSources(GapObj(tbl))]
 end
 
 @doc raw"""
@@ -1620,7 +1620,7 @@ julia> known_class_fusion(t2, t1)
 ```
 """
 function known_class_fusion(subtbl::GAPGroupCharacterTable, tbl::GAPGroupCharacterTable)
-    map = GAPWrap.GetFusionMap(GAPTable(subtbl), GAPTable(tbl))
+    map = GAPWrap.GetFusionMap(GapObj(subtbl), GapObj(tbl))
     if map === GAP.Globals.fail
       return (false, Int[])
     else
@@ -1638,7 +1638,7 @@ see [`known_class_fusion`](@ref).
 """
 function known_class_fusions(tbl::GAPGroupCharacterTable)
     return Tuple{String, Vector{Int64}}[(String(r.name), Vector{Int}(r.map))
-             for r in GAPWrap.ComputedClassFusions(GAPTable(tbl))]
+             for r in GAPWrap.ComputedClassFusions(GapObj(tbl))]
 end
 
 
@@ -1663,7 +1663,7 @@ julia> is_abelian(character_table("C2"))
 true
 ```
 """
-@gapattribute is_abelian(tbl::GAPGroupCharacterTable) = GAP.Globals.IsAbelian(GAPTable(tbl))::Bool
+@gapattribute is_abelian(tbl::GAPGroupCharacterTable) = GAP.Globals.IsAbelian(GapObj(tbl))::Bool
 
 
 """
@@ -1681,7 +1681,7 @@ julia> is_almost_simple(character_table("S4"))
 false
 ```
 """
-@gapattribute is_almost_simple(tbl::GAPGroupCharacterTable) = GAP.Globals.IsAlmostSimple(GAPTable(tbl))::Bool
+@gapattribute is_almost_simple(tbl::GAPGroupCharacterTable) = GAP.Globals.IsAlmostSimple(GapObj(tbl))::Bool
 
 
 """
@@ -1699,7 +1699,7 @@ julia> is_cyclic(character_table("S4"))
 false
 ```
 """
-@gapattribute is_cyclic(tbl::GAPGroupCharacterTable) = GAP.Globals.IsCyclic(GAPTable(tbl))::Bool
+@gapattribute is_cyclic(tbl::GAPGroupCharacterTable) = GAP.Globals.IsCyclic(GapObj(tbl))::Bool
 
 
 """
@@ -1718,7 +1718,7 @@ julia> is_elementary_abelian(character_table("S4"))
 false
 ```
 """
-@gapattribute is_elementary_abelian(tbl::GAPGroupCharacterTable) = GAP.Globals.IsElementaryAbelian(GAPTable(tbl))::Bool
+@gapattribute is_elementary_abelian(tbl::GAPGroupCharacterTable) = GAP.Globals.IsElementaryAbelian(GapObj(tbl))::Bool
 
 
 """
@@ -1736,7 +1736,7 @@ julia> is_nilpotent(character_table("S4"))
 false
 ```
 """
-@gapattribute is_nilpotent(tbl::GAPGroupCharacterTable) = GAP.Globals.IsNilpotent(GAPTable(tbl))::Bool
+@gapattribute is_nilpotent(tbl::GAPGroupCharacterTable) = GAP.Globals.IsNilpotent(GapObj(tbl))::Bool
 
 
 """
@@ -1754,7 +1754,7 @@ julia> is_perfect(character_table("S4"))
 false
 ```
 """
-@gapattribute is_perfect(tbl::GAPGroupCharacterTable) = GAP.Globals.IsPerfect(GAPTable(tbl))::Bool
+@gapattribute is_perfect(tbl::GAPGroupCharacterTable) = GAP.Globals.IsPerfect(GapObj(tbl))::Bool
 
 
 """
@@ -1772,7 +1772,7 @@ julia> is_quasisimple(character_table("S4"))
 false
 ```
 """
-@gapattribute is_quasisimple(tbl::GAPGroupCharacterTable) = GAP.Globals.IsQuasisimple(GAPTable(tbl))::Bool
+@gapattribute is_quasisimple(tbl::GAPGroupCharacterTable) = GAP.Globals.IsQuasisimple(GapObj(tbl))::Bool
 
 
 """
@@ -1790,7 +1790,7 @@ julia> is_simple(character_table("S4"))
 false
 ```
 """
-@gapattribute is_simple(tbl::GAPGroupCharacterTable) = GAP.Globals.IsSimple(GAPTable(tbl))::Bool
+@gapattribute is_simple(tbl::GAPGroupCharacterTable) = GAP.Globals.IsSimple(GapObj(tbl))::Bool
 
 
 """
@@ -1808,7 +1808,7 @@ julia> is_solvable(character_table("S4"))
 true
 ```
 """
-@gapattribute is_solvable(tbl::GAPGroupCharacterTable) = GAP.Globals.IsSolvable(GAPTable(tbl))::Bool
+@gapattribute is_solvable(tbl::GAPGroupCharacterTable) = GAP.Globals.IsSolvable(GapObj(tbl))::Bool
 
 
 """
@@ -1827,7 +1827,7 @@ julia> is_sporadic_simple(character_table("M11"))
 true
 ```
 """
-@gapattribute is_sporadic_simple(tbl::GAPGroupCharacterTable) = GAP.Globals.IsSporadicSimple(GAPTable(tbl))::Bool
+@gapattribute is_sporadic_simple(tbl::GAPGroupCharacterTable) = GAP.Globals.IsSporadicSimple(GapObj(tbl))::Bool
 
 
 """
@@ -1845,7 +1845,7 @@ julia> is_supersolvable(character_table("S3"))
 true
 ```
 """
-@gapattribute is_supersolvable(tbl::GAPGroupCharacterTable) = GAP.Globals.IsSupersolvable(GAPTable(tbl))::Bool
+@gapattribute is_supersolvable(tbl::GAPGroupCharacterTable) = GAP.Globals.IsSupersolvable(GapObj(tbl))::Bool
 
 
 #############################################################################
@@ -1883,7 +1883,7 @@ end
 
 function class_function(tbl::GAPGroupCharacterTable, values::Vector{<:Union{Integer, ZZRingElem, Rational, QQFieldElem, QQAbElem}})
     gapvalues = GapObj([GAP.Obj(x) for x in values])
-    return GAPGroupClassFunction(tbl, GAPWrap.ClassFunction(GAPTable(tbl), gapvalues))
+    return GAPGroupClassFunction(tbl, GAPWrap.ClassFunction(GapObj(tbl), gapvalues))
 end
 
 function class_function(G::GAPGroup, values::GapObj)
@@ -2043,7 +2043,7 @@ function natural_character(G::MatrixGroup{T, MT}) where T <: FinFieldElem where 
     tbl = character_table(G, p)
     ccl = conjugacy_classes(tbl)
     vals = [GAP.Globals.BrauerCharacterValue(representative(x).X) for x in ccl]
-    vals = GAPWrap.ClassFunction(GAPTable(tbl), GapObj(vals))
+    vals = GAPWrap.ClassFunction(GapObj(tbl), GapObj(vals))
 
     return class_function(G, vals)
 end
@@ -2090,7 +2090,7 @@ function natural_character(rho::GAPGroupHomomorphism)
         modtbl = mod(tbl, p)
         ccl = conjugacy_classes(modtbl)  # p-regular classes
         vals = [GAP.Globals.BrauerCharacterValue(rho(representative(x)).X) for x in ccl]
-        vals = GAPWrap.ClassFunction(GAPTable(modtbl), GapObj(vals))
+        vals = GAPWrap.ClassFunction(GapObj(modtbl), GapObj(vals))
       end
     else
       throw(ArgumentError("codomain must be a PermGroup or MatrixGroup"))
@@ -2132,7 +2132,7 @@ julia> length(linear_characters(tbl))
 ```
 """
 function linear_characters(tbl::GAPGroupCharacterTable)
-    return [class_function(tbl, chi) for chi in GAPWrap.LinearCharacters(GAPTable(tbl))]
+    return [class_function(tbl, chi) for chi in GAPWrap.LinearCharacters(GapObj(tbl))]
 end
 
 
@@ -2172,10 +2172,10 @@ function induce(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable)
   subtbl = parent(chi)
   if !(isdefined(tbl, :group) && isdefined(subtbl, :group))
     # If there is no stored group then let GAP try to find the result.
-    fus = GAPWrap.FusionConjugacyClasses(GAPTable(subtbl), GAPTable(tbl))
+    fus = GAPWrap.FusionConjugacyClasses(GapObj(subtbl), GapObj(tbl))
     @req fus !== GAP.Globals.fail "class fusion is not uniquely determinaed"
-    ind = GAPWrap.InducedClassFunctionsByFusionMap(GAPTable(subtbl),
-          GAPTable(tbl), GapObj([GapObj(chi)]), GapObj(fus))
+    ind = GAPWrap.InducedClassFunctionsByFusionMap(GapObj(subtbl),
+          GapObj(tbl), GapObj([GapObj(chi)]), GapObj(fus))
     return GAPGroupClassFunction(tbl, ind[1])
   else
     # Dispatch on the types of the stored groups.
@@ -2184,14 +2184,14 @@ function induce(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable)
 end
 
 function induce(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable, fusion::Vector{Int})
-  ind = GAPWrap.InducedClassFunctionsByFusionMap(GAPTable(parent(chi)),
-          GAPTable(tbl), GapObj([GapObj(chi)]), GapObj(fusion))
+  ind = GAPWrap.InducedClassFunctionsByFusionMap(GapObj(parent(chi)),
+          GapObj(tbl), GapObj([GapObj(chi)]), GapObj(fusion))
   return GAPGroupClassFunction(tbl, ind[1])
 end
 
 # If `GAPGroup` groups are stored then we let GAP try to find the result.
 function _induce(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable, G_chi::GAPGroup, G_tbl::GAPGroup)
-  ind = GAPWrap.InducedClassFunction(GapObj(chi), GAPTable(tbl))
+  ind = GAPWrap.InducedClassFunction(GapObj(chi), GapObj(tbl))
   return GAPGroupClassFunction(tbl, ind)
 end
 
@@ -2229,7 +2229,7 @@ true
 ```
 """
 function induced_cyclic(tbl::GAPGroupCharacterTable, classes::AbstractVector{Int} = 1:nrows(tbl))
-    return [GAPGroupClassFunction(tbl, chi) for chi in GAPWrap.InducedCyclic(GAPTable(tbl), GapObj(classes))]
+    return [GAPGroupClassFunction(tbl, chi) for chi in GAPWrap.InducedCyclic(GapObj(tbl), GapObj(classes))]
 end
 
 """
@@ -2264,10 +2264,10 @@ function restrict(chi::GAPGroupClassFunction, subtbl::GAPGroupCharacterTable)
 
   if !(isdefined(tbl, :group) && isdefined(subtbl, :group))
     # If there is no stored group then let GAP try to find the result.
-    fus = GAPWrap.FusionConjugacyClasses(GAPTable(subtbl), GAPTable(tbl))
+    fus = GAPWrap.FusionConjugacyClasses(GapObj(subtbl), GapObj(tbl))
     @req fus !== GAP.Globals.fail "class fusion is not uniquely determinaed"
     rest = GAPWrap.ELMS_LIST(GapObj(chi), GapObj(fus))
-    rest = GAPWrap.ClassFunction(GAPTable(subtbl), rest)
+    rest = GAPWrap.ClassFunction(GapObj(subtbl), rest)
     return GAPGroupClassFunction(subtbl, rest)
   else
     # Dispatch on the types of the stored groups.
@@ -2277,16 +2277,16 @@ end
 
 function restrict(chi::GAPGroupClassFunction, subtbl::GAPGroupCharacterTable, fusion::Vector{Int})
   rest = GAPWrap.ELMS_LIST(GapObj(chi), GapObj(fusion))
-  rest = GAPWrap.ClassFunction(GAPTable(subtbl), rest)
+  rest = GAPWrap.ClassFunction(GapObj(subtbl), rest)
   return GAPGroupClassFunction(subtbl, rest)
 end
 
 # If `GAPGroup` groups are stored then we let GAP try to find the result.
 function _restrict(chi::GAPGroupClassFunction, subtbl::GAPGroupCharacterTable, G_chi::GAPGroup, G_tbl::GAPGroup)
   tbl = parent(chi)
-  fus = GAPWrap.FusionConjugacyClasses(GAPTable(subtbl), GAPTable(tbl))
+  fus = GAPWrap.FusionConjugacyClasses(GapObj(subtbl), GapObj(tbl))
   rest = GAPWrap.ELMS_LIST(GapObj(chi), GapObj(fus))
-  rest = GAPWrap.ClassFunction(GAPTable(subtbl), rest)
+  rest = GAPWrap.ClassFunction(GapObj(subtbl), rest)
   return GAPGroupClassFunction(subtbl, rest)
 end
 
@@ -2391,7 +2391,7 @@ scalar_product(chi::GAPGroupClassFunction, psi::GAPGroupClassFunction) = scalar_
 
 function scalar_product(::Type{T}, chi::GAPGroupClassFunction, psi::GAPGroupClassFunction) where T <: Union{Integer, ZZRingElem, QQFieldElem, QQAbElem}
     @req parent(chi) === parent(psi) "character tables must be identical"
-    return T(GAPWrap.ScalarProduct(GAPTable(parent(chi)), GapObj(chi), GapObj(psi)))::T
+    return T(GAPWrap.ScalarProduct(GapObj(parent(chi)), GapObj(chi), GapObj(psi)))::T
 end
 
 
@@ -2434,7 +2434,7 @@ coordinates(chi::GAPGroupClassFunction) = coordinates(QQFieldElem, chi)
 
 function coordinates(::Type{T}, chi::GAPGroupClassFunction) where T <: Union{Integer, ZZRingElem, QQFieldElem, QQAbElem}
     t = parent(chi)
-    GAPt = GAPTable(t)
+    GAPt = GapObj(t)
     if characteristic(t) == 0
       # use scalar products for an ordinary character
       c = GAPWrap.MatScalarProducts(GAPt, GAPWrap.Irr(GAPt), GapObj([GapObj(chi)]))
@@ -2651,7 +2651,7 @@ julia> C, f = kernel(chi);  order(C)
 function kernel(chi::GAPGroupClassFunction)
     tbl = parent(chi)
     iso = isomorphism_to_GAP_group(tbl)
-    GAP_K = GAPWrap.KernelOfCharacter(GAPTable(tbl), GapObj(chi))
+    GAP_K = GAPWrap.KernelOfCharacter(GapObj(tbl), GapObj(chi))
     return preimages(iso, GAP_K)
 end
 
@@ -2693,7 +2693,7 @@ julia> C, f = center(chi);  order(C)
 function center(chi::GAPGroupClassFunction)
     tbl = parent(chi)
     iso = isomorphism_to_GAP_group(tbl)
-    C = GAPWrap.CentreOfCharacter(GAPTable(tbl), GapObj(chi))
+    C = GAPWrap.CentreOfCharacter(GapObj(tbl), GapObj(chi))
     return preimages(iso, C)
 end
 
@@ -2761,14 +2761,14 @@ function indicator(chi::GAPGroupClassFunction, n::Int = 2)
     tbl = parent(chi)
     if characteristic(tbl) == 0
       # The indicator can be computed for any character.
-      ind = GAPWrap.Indicator(GAPTable(tbl), GapObj([GapObj(chi)]), n)
+      ind = GAPWrap.Indicator(GapObj(tbl), GapObj([GapObj(chi)]), n)
       return ind[1]::Int
     else
       # The indicator is defined only for `n = 2` and irreducible characters.
       @req n == 2 "defined for Brauer characters only for n = 2"
       chipos = findfirst(isequal(chi), tbl)
       @req chipos !== nothing "defined only for irreducible Brauer characters"
-      ind = GAPWrap.Indicator(GAPTable(tbl), n)
+      ind = GAPWrap.Indicator(GapObj(tbl), n)
       return ind[chipos]::Int
     end
 end
@@ -3029,7 +3029,7 @@ function symmetrizations(characters::Vector{GAPGroupClassFunction}, n::Int)
     length(characters) == 0 && return eltype(typeof(characters))[]
     tbl = parent(characters[1])
     return [class_function(tbl, chi)
-            for chi in GAPWrap.Symmetrizations(GAPTable(tbl),
+            for chi in GAPWrap.Symmetrizations(GapObj(tbl),
                          GapObj([GapObj(chi) for chi in characters]), n)]
 end
 
@@ -3044,7 +3044,7 @@ function symmetric_parts(characters::Vector{GAPGroupClassFunction}, n::Int)
     length(characters) == 0 && return eltype(typeof(characters))[]
     tbl = parent(characters[1])
     return [class_function(tbl, chi)
-            for chi in GAPWrap.SymmetricParts(GAPTable(tbl),
+            for chi in GAPWrap.SymmetricParts(GapObj(tbl),
                          GapObj([GapObj(chi) for chi in characters]), n)]
 end
 
@@ -3059,7 +3059,7 @@ function anti_symmetric_parts(characters::Vector{GAPGroupClassFunction}, n::Int)
     length(characters) == 0 && return eltype(typeof(characters))[]
     tbl = parent(characters[1])
     return [class_function(tbl, chi)
-            for chi in GAPWrap.AntiSymmetricParts(GAPTable(tbl),
+            for chi in GAPWrap.AntiSymmetricParts(GapObj(tbl),
                          GapObj([GapObj(chi) for chi in characters]), n)]
 end
 
@@ -3077,7 +3077,7 @@ function exterior_power(chi::GAPGroupClassFunction, n::Int)
 #T when GAP's `ExteriorPower` method becomes available then use it
     tbl = parent(chi)
     return class_function(tbl,
-      GAPWrap.AntiSymmetricParts(GAPTable(tbl), GAP.Obj([GapObj(chi)]), n)[1])
+      GAPWrap.AntiSymmetricParts(GapObj(tbl), GAP.Obj([GapObj(chi)]), n)[1])
 end
 
 @doc raw"""
@@ -3094,7 +3094,7 @@ function symmetric_power(chi::GAPGroupClassFunction, n::Int)
 #T when GAP's `SymmetricPower` method becomes available then use it
     tbl = parent(chi)
     return class_function(tbl,
-      GAPWrap.SymmetricParts(GAPTable(tbl), GAP.Obj([GapObj(chi)]), n)[1])
+      GAPWrap.SymmetricParts(GapObj(tbl), GAP.Obj([GapObj(chi)]), n)[1])
 end
 
 @doc raw"""
@@ -3111,7 +3111,7 @@ function orthogonal_components(characters::Vector{GAPGroupClassFunction}, n::Int
     length(characters) == 0 && return eltype(typeof(characters))[]
     tbl = parent(characters[1])
     return [class_function(tbl, chi)
-            for chi in GAPWrap.OrthogonalComponents(GAPTable(tbl),
+            for chi in GAPWrap.OrthogonalComponents(GapObj(tbl),
                          GapObj([GapObj(chi) for chi in characters]), n)]
 end
 
@@ -3129,7 +3129,7 @@ function symplectic_components(characters::Vector{GAPGroupClassFunction}, n::Int
     length(characters) == 0 && return eltype(typeof(characters))[]
     tbl = parent(characters[1])
     return [class_function(tbl, chi)
-            for chi in GAPWrap.SymplecticComponents(GAPTable(tbl),
+            for chi in GAPWrap.SymplecticComponents(GapObj(tbl),
                          GapObj([GapObj(chi) for chi in characters]), n)]
 end
 

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -1861,6 +1861,10 @@ end
 
 GapObj(chi::GAPGroupClassFunction) = chi.values
 
+# The following is needed for recursive `GapObj` calls with arrays
+# of class functions.
+GAP.julia_to_gap(chi::GAPGroupClassFunction) = chi.values
+
 parent(chi::GAPGroupClassFunction) = chi.table
 
 function Base.show(io::IO, chi::GAPGroupClassFunction)
@@ -3030,7 +3034,7 @@ function symmetrizations(characters::Vector{GAPGroupClassFunction}, n::Int)
     tbl = parent(characters[1])
     return [class_function(tbl, chi)
             for chi in GAPWrap.Symmetrizations(GapObj(tbl),
-                         GapObj([GapObj(chi) for chi in characters]), n)]
+                         GapObj(characters; recursive = true), n)]
 end
 
 @doc raw"""
@@ -3045,7 +3049,7 @@ function symmetric_parts(characters::Vector{GAPGroupClassFunction}, n::Int)
     tbl = parent(characters[1])
     return [class_function(tbl, chi)
             for chi in GAPWrap.SymmetricParts(GapObj(tbl),
-                         GapObj([GapObj(chi) for chi in characters]), n)]
+                         GapObj(characters; recursive = true), n)]
 end
 
 @doc raw"""
@@ -3060,7 +3064,7 @@ function anti_symmetric_parts(characters::Vector{GAPGroupClassFunction}, n::Int)
     tbl = parent(characters[1])
     return [class_function(tbl, chi)
             for chi in GAPWrap.AntiSymmetricParts(GapObj(tbl),
-                         GapObj([GapObj(chi) for chi in characters]), n)]
+                         GapObj(characters; recursive = true), n)]
 end
 
 @doc raw"""
@@ -3112,7 +3116,7 @@ function orthogonal_components(characters::Vector{GAPGroupClassFunction}, n::Int
     tbl = parent(characters[1])
     return [class_function(tbl, chi)
             for chi in GAPWrap.OrthogonalComponents(GapObj(tbl),
-                         GapObj([GapObj(chi) for chi in characters]), n)]
+                         GapObj(characters; recursive = true), n)]
 end
 
 @doc raw"""
@@ -3130,7 +3134,7 @@ function symplectic_components(characters::Vector{GAPGroupClassFunction}, n::Int
     tbl = parent(characters[1])
     return [class_function(tbl, chi)
             for chi in GAPWrap.SymplecticComponents(GapObj(tbl),
-                         GapObj([GapObj(chi) for chi in characters]), n)]
+                         GapObj(characters; recursive = true), n)]
 end
 
 function character_table_complex_reflection_group(m::Int, p::Int, n::Int)

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -2179,7 +2179,7 @@ function induce(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable)
     fus = GAPWrap.FusionConjugacyClasses(GapObj(subtbl), GapObj(tbl))
     @req fus !== GAP.Globals.fail "class fusion is not uniquely determinaed"
     ind = GAPWrap.InducedClassFunctionsByFusionMap(GapObj(subtbl),
-          GapObj(tbl), GapObj([GapObj(chi)]), GapObj(fus))
+          GapObj(tbl), GapObj([chi]; recursive = true), GapObj(fus))
     return GAPGroupClassFunction(tbl, ind[1])
   else
     # Dispatch on the types of the stored groups.
@@ -2189,7 +2189,7 @@ end
 
 function induce(chi::GAPGroupClassFunction, tbl::GAPGroupCharacterTable, fusion::Vector{Int})
   ind = GAPWrap.InducedClassFunctionsByFusionMap(GapObj(parent(chi)),
-          GapObj(tbl), GapObj([GapObj(chi)]), GapObj(fusion))
+          GapObj(tbl), GapObj([chi]; recursive=true), GapObj(fusion))
   return GAPGroupClassFunction(tbl, ind[1])
 end
 
@@ -2441,10 +2441,10 @@ function coordinates(::Type{T}, chi::GAPGroupClassFunction) where T <: Union{Int
     GAPt = GapObj(t)
     if characteristic(t) == 0
       # use scalar products for an ordinary character
-      c = GAPWrap.MatScalarProducts(GAPt, GAPWrap.Irr(GAPt), GapObj([GapObj(chi)]))
+      c = GAPWrap.MatScalarProducts(GAPt, GAPWrap.Irr(GAPt), GapObj([chi]; recursive = true))
     else
       # decompose a Brauer character
-      c = GAPWrap.Decomposition(GAPWrap.Irr(GAPt), GapObj([GapObj(chi)]), GapObj("nonnegative"))
+      c = GAPWrap.Decomposition(GAPWrap.Irr(GAPt), GapObj([chi]; recursive = true), GapObj("nonnegative"))
     end
     return Vector{T}(c[1])::Vector{T}
 end
@@ -2765,7 +2765,7 @@ function indicator(chi::GAPGroupClassFunction, n::Int = 2)
     tbl = parent(chi)
     if characteristic(tbl) == 0
       # The indicator can be computed for any character.
-      ind = GAPWrap.Indicator(GapObj(tbl), GapObj([GapObj(chi)]), n)
+      ind = GAPWrap.Indicator(GapObj(tbl), GapObj([chi]; recursive = true), n)
       return ind[1]::Int
     else
       # The indicator is defined only for `n = 2` and irreducible characters.
@@ -3081,7 +3081,7 @@ function exterior_power(chi::GAPGroupClassFunction, n::Int)
 #T when GAP's `ExteriorPower` method becomes available then use it
     tbl = parent(chi)
     return class_function(tbl,
-      GAPWrap.AntiSymmetricParts(GapObj(tbl), GAP.Obj([GapObj(chi)]), n)[1])
+      GAPWrap.AntiSymmetricParts(GapObj(tbl), GAP.Obj([chi]; recursive = true), n)[1])
 end
 
 @doc raw"""
@@ -3098,7 +3098,7 @@ function symmetric_power(chi::GAPGroupClassFunction, n::Int)
 #T when GAP's `SymmetricPower` method becomes available then use it
     tbl = parent(chi)
     return class_function(tbl,
-      GAPWrap.SymmetricParts(GapObj(tbl), GAP.Obj([GapObj(chi)]), n)[1])
+      GAPWrap.SymmetricParts(GapObj(tbl), GAP.Obj([chi]; recursive = true), n)[1])
 end
 
 @doc raw"""

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -118,8 +118,8 @@ If `check` is set to `false` then it is not checked whether the mapping
 defines a group homomorphism.
 """
 function hom(G::GAPGroup, H::GAPGroup, gensG::Vector, imgs::Vector; check::Bool = true)
-  vgens = GapObj([GapObj(x) for x in gensG])
-  vimgs = GapObj([GapObj(x) for x in imgs])
+  vgens = GapObj(gensG; recursive = true)
+  vimgs = GapObj(imgs; recursive = true)
   if check
     mp = GAP.Globals.GroupHomomorphismByImages(GapObj(G), GapObj(H), vgens, vimgs)
   else

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -10,29 +10,29 @@ end
 
 
 function ==(f::GAPGroupHomomorphism{S,T}, g::GAPGroupHomomorphism{S,T}) where S where T
-  return f.map == g.map
+  return GapObj(f) == GapObj(g)
 end
 
 function Base.hash(f::GAPGroupHomomorphism{S,T}, h::UInt) where S where T
   b = 0xdc777737af4c0c7b % UInt
-  return xor(hash(f.map, hash((S, T), h)), b)
+  return xor(hash(GapObj(f), hash((S, T), h)), b)
 end
 
 Base.:*(f::GAPGroupHomomorphism{S, T}, g::GAPGroupHomomorphism{T, U}) where S where T where U = compose(f, g)
 
 function Base.inv(f::GAPGroupHomomorphism{S,T}) where S where T
-   @assert GAPWrap.IsBijective(f.map) "f is not bijective"
-   return GAPGroupHomomorphism(codomain(f), domain(f), GAP.Globals.InverseGeneralMapping(f.map))
+   @assert GAPWrap.IsBijective(GapObj(f)) "f is not bijective"
+   return GAPGroupHomomorphism(codomain(f), domain(f), GAP.Globals.InverseGeneralMapping(GapObj(f)))
 end
 
-order(f::GAPGroupHomomorphism) = GAPWrap.Order(f.map)
+order(f::GAPGroupHomomorphism) = GAPWrap.Order(GapObj(f))
 
 function Base.:^(f::GAPGroupHomomorphism{S,T}, n::Int64) where S where T
    if n==1
      return f
    else
       @assert domain(f) == codomain(f) "Domain and codomain do not coincide"
-      return GAPGroupHomomorphism(domain(f),codomain(f),(f.map)^n)
+      return GAPGroupHomomorphism(domain(f),codomain(f),(GapObj(f))^n)
    end
 end
 
@@ -40,7 +40,7 @@ function compose(f::GAPGroupHomomorphism{S, T}, g::GAPGroupHomomorphism{T, U}) w
   dom = domain(f)
   cod = codomain(g)
   @assert codomain(f) == domain(g)
-  mp = GAP.Globals.CompositionMapping(g.map, f.map)
+  mp = GAP.Globals.CompositionMapping(GapObj(g), GapObj(f))
   return GAPGroupHomomorphism(dom, cod, mp)
 end
 
@@ -52,7 +52,7 @@ end
 Return the identity homomorphism on the group `G`.
 """
 function id_hom(G::GAPGroup)
-  return GAPGroupHomomorphism(G, G, GAP.Globals.IdentityMapping(G.X))
+  return GAPGroupHomomorphism(G, G, GAP.Globals.IdentityMapping(GapObj(G)))
 end
 
 """
@@ -78,9 +78,9 @@ function hom(G::GAPGroup, H::GAPGroup, img::Function)
   function gap_fun(x::GapObj)
     el = group_element(G, x)
     img_el = img(el)
-    return img_el.X
+    return GapObj(img_el)
   end
-  mp = GAPWrap.GroupHomomorphismByFunction(G.X, H.X, GAP.Obj(gap_fun))
+  mp = GAPWrap.GroupHomomorphismByFunction(GapObj(G), GapObj(H), GAP.Obj(gap_fun))
   return GAPGroupHomomorphism(G, H, mp)
 end
 
@@ -90,19 +90,19 @@ function hom(G::GAPGroup, H::GAPGroup, img::Function, preimg::Function; is_known
   function gap_fun(x::GapObj)
     el = group_element(G, x)
     img_el = img(el)
-    return img_el.X
+    return GapObj(img_el)
   end
 
   function gap_pre_fun(x::GapObj)
     el = group_element(H, x)
     preimg_el = preimg(el)
-    return preimg_el.X
+    return GapObj(preimg_el)
   end
 
   if is_known_to_be_bijective
-    mp = GAPWrap.GroupHomomorphismByFunction(G.X, H.X, GAP.Obj(gap_fun), GAP.Obj(gap_pre_fun))
+    mp = GAPWrap.GroupHomomorphismByFunction(GapObj(G), GapObj(H), GAP.Obj(gap_fun), GAP.Obj(gap_pre_fun))
   else
-    mp = GAPWrap.GroupHomomorphismByFunction(G.X, H.X, GAP.Obj(gap_fun), false, GAP.Obj(gap_pre_fun))
+    mp = GAPWrap.GroupHomomorphismByFunction(GapObj(G), GapObj(H), GAP.Obj(gap_fun), false, GAP.Obj(gap_pre_fun))
   end
 
   return GAPGroupHomomorphism(G, H, mp)
@@ -118,12 +118,12 @@ If `check` is set to `false` then it is not checked whether the mapping
 defines a group homomorphism.
 """
 function hom(G::GAPGroup, H::GAPGroup, gensG::Vector, imgs::Vector; check::Bool = true)
-  vgens = GapObj([x.X for x in gensG])
-  vimgs = GapObj([x.X for x in imgs])
+  vgens = GapObj([GapObj(x) for x in gensG])
+  vimgs = GapObj([GapObj(x) for x in imgs])
   if check
-    mp = GAP.Globals.GroupHomomorphismByImages(G.X, H.X, vgens, vimgs)
+    mp = GAP.Globals.GroupHomomorphismByImages(GapObj(G), GapObj(H), vgens, vimgs)
   else
-    mp = GAP.Globals.GroupHomomorphismByImagesNC(G.X, H.X, vgens, vimgs)
+    mp = GAP.Globals.GroupHomomorphismByImagesNC(GapObj(G), GapObj(H), vgens, vimgs)
   end
   @req mp !== GAP.Globals.fail "Invalid input"
   return GAPGroupHomomorphism(G, H, mp)
@@ -177,7 +177,7 @@ Base.:^(x::GAPGroupElem,f::GAPGroupHomomorphism) = image(f,x)
 Return `f`(`x`).
 """
 function image(f::GAPGroupHomomorphism, x::GAPGroupElem)
-  return group_element(codomain(f), GAPWrap.ImagesRepresentative(f.map, x.X))
+  return group_element(codomain(f), GAPWrap.ImagesRepresentative(GapObj(f), GapObj(x)))
 end
 
 """
@@ -199,7 +199,7 @@ end
 Return whether `f` is surjective.
 """
 function is_surjective(f::GAPGroupHomomorphism)
-  return GAPWrap.IsSurjective(f.map)
+  return GAPWrap.IsSurjective(GapObj(f))
 end
 
 """
@@ -208,7 +208,7 @@ end
 Return whether `f` is injective.
 """
 function is_injective(f::GAPGroupHomomorphism)
-  return GAPWrap.IsInjective(f.map)
+  return GAPWrap.IsInjective(GapObj(f))
 end
 
 """
@@ -217,7 +217,7 @@ end
 Return whether `f` is invertible.
 """
 function is_invertible(f::GAPGroupHomomorphism)
-  return GAPWrap.IsBijective(f.map)
+  return GAPWrap.IsBijective(GapObj(f))
 end
 
 """
@@ -226,7 +226,7 @@ end
 Return whether `f` is bijective.
 """
 function is_bijective(f::GAPGroupHomomorphism)
-  return GAPWrap.IsBijective(f.map)
+  return GAPWrap.IsBijective(GapObj(f))
 end
 
 
@@ -240,8 +240,8 @@ or if `H` is not contained in `domain(f)`.
 """
 function is_invariant(f::GAPGroupHomomorphism, H::GAPGroup)
   @assert domain(f) == codomain(f) "Not an endomorphism!"
-  @assert GAPWrap.IsSubset(domain(f).X, H.X) "Not a subgroup of the domain"
-  return GAPWrap.Image(f.map, H.X) == H.X
+  @assert GAPWrap.IsSubset(GapObj(domain(f)), GapObj(H)) "Not a subgroup of the domain"
+  return GAPWrap.Image(GapObj(f), GapObj(H)) == GapObj(H)
 end
 
 """
@@ -258,7 +258,7 @@ function restrict_homomorphism(f::GAPGroupHomomorphism, H::GAPGroup)
   # in the case that `H` is not a subgroup of `f.domain`,
   # and in fact just the given map may be returned.)
   @assert is_subset(H, domain(f)) "Not a subgroup!"
-  return GAPGroupHomomorphism(H, f.codomain, GAP.Globals.RestrictedMapping(f.map,H.X)::GapObj)
+  return GAPGroupHomomorphism(H, f.codomain, GAP.Globals.RestrictedMapping(GapObj(f), GapObj(H))::GapObj)
 end
 
 ################################################################################
@@ -273,7 +273,7 @@ end
 Return the kernel of `f`, together with its embedding into `domain`(`f`).
 """
 function kernel(f::GAPGroupHomomorphism)
-  K = GAP.Globals.Kernel(f.map)::GapObj
+  K = GAP.Globals.Kernel(GapObj(f))::GapObj
   return _as_subgroup(domain(f), K)
 end
 
@@ -283,7 +283,7 @@ end
 Return the image of `f` as subgroup of `codomain`(`f`), together with the embedding homomorphism.
 """
 function image(f::GAPGroupHomomorphism)
-  K = GAPWrap.Image(f.map)
+  K = GAPWrap.Image(GapObj(f))
   return _as_subgroup(codomain(f), K)
 end
 
@@ -294,7 +294,7 @@ end
 Return `f`(`H`), together with the embedding homomorphism into `codomain`(`f`).
 """
 function image(f::GAPGroupHomomorphism{S, T}, H::S) where S <: GAPGroup where T <: GAPGroup
-  H1 = GAPWrap.Image(f.map, H.X)
+  H1 = GAPWrap.Image(GapObj(f), GapObj(H))
   return _as_subgroup(codomain(f), H1)
 end
 
@@ -323,7 +323,7 @@ If `check` is set to `false` then the test whether `x` is an element of
 `image(f)` is omitted.
 """
 function has_preimage_with_preimage(f::GAPGroupHomomorphism, x::GAPGroupElem; check::Bool = true)
-  return _haspreimage(f.map, domain(f), image(f)[1], x, check = check)
+  return _haspreimage(GapObj(f), domain(f), image(f)[1], x, check = check)
 end
 
 # helper function for computing `has_preimage_with_preimage` for
@@ -340,7 +340,7 @@ function _haspreimage(mp::GapObj, dom::GAPGroup, img::GAPGroup, x::GAPGroupElem;
 # Until this problem gets fixed on the GAP side, we perform a membership test
 # before calling `GAP.Globals.PreImagesRepresentative`.
   check && ! (x in img) && return false, one(dom)
-  r = GAP.Globals.PreImagesRepresentative(mp, x.X)::GapObj
+  r = GAP.Globals.PreImagesRepresentative(mp, GapObj(x))::GapObj
   if r == GAP.Globals.fail
     return false, one(dom)
   else
@@ -356,7 +356,7 @@ If `H` is a subgroup of the codomain of `f`, return the subgroup `f^-1(H)`,
 together with its embedding homomorphism into the domain of `f`.
 """
 function preimage(f::GAPGroupHomomorphism{S, T}, H::T) where S <: GAPGroup where T <: GAPGroup
-  H1 = GAP.Globals.PreImage(f.map, H.X)::GapObj
+  H1 = GAP.Globals.PreImage(GapObj(f), GapObj(H))::GapObj
   return _as_subgroup(domain(f), H1)
 end
 
@@ -381,7 +381,7 @@ julia> is_isomorphic_with_map(symmetric_group(3), dihedral_group(6))
 ```
 """
 function is_isomorphic_with_map(G::GAPGroup, H::GAPGroup)
-  mp = GAP.Globals.IsomorphismGroups(G.X, H.X)::GapObj
+  mp = GAP.Globals.IsomorphismGroups(GapObj(G), GapObj(H))::GapObj
   if mp === GAP.Globals.fail
     return false, trivial_morphism(G, H)
   else
@@ -423,7 +423,7 @@ true
 ```
 """
 function is_isomorphic(G::GAPGroup, H::GAPGroup)
-  mp = GAP.Globals.IsomorphismGroups(G.X, H.X)::GapObj
+  mp = GAP.Globals.IsomorphismGroups(GapObj(G), GapObj(H))::GapObj
   return mp !== GAP.Globals.fail
 end
 
@@ -452,7 +452,7 @@ Group homomorphism
 ```
 """
 function isomorphism(G::GAPGroup, H::GAPGroup)
-  mp = GAP.Globals.IsomorphismGroups(G.X, H.X)::GapObj
+  mp = GAP.Globals.IsomorphismGroups(GapObj(G), GapObj(H))::GapObj
   @req mp !== GAP.Globals.fail "the groups are not isomorphic"
   return GAPGroupHomomorphism(G, H, mp)
 end
@@ -520,11 +520,11 @@ function isomorphism(::Type{T}, G::GAPGroup) where T <: Union{PcGroup, PermGroup
    isos = get_attribute!(Dict{Tuple{Type, Bool}, Any}, G, :isomorphisms)::Dict{Tuple{Type, Bool}, Any}
    return get!(isos, (T, false)) do
      fun = _get_iso_function(T)
-     f = fun(G.X)::GapObj
+     f = fun(GapObj(G))::GapObj
      @req f !== GAP.Globals.fail "Could not convert group into a group of type $T"
      H = T(GAP.Globals.ImagesSource(f)::GapObj)
 # TODO: remove the next line once GAP 4.13.0 is available in Oscar
-     GAP.Globals.UseIsomorphismRelation(G.X, H.X)
+     GAP.Globals.UseIsomorphismRelation(GapObj(G), GapObj(H))
      return GAPGroupHomomorphism(G, H, f)
    end::GAPGroupHomomorphism{typeof(G), T}
 end
@@ -534,18 +534,18 @@ function isomorphism(::Type{FPGroup}, G::GAPGroup; on_gens::Bool=false)
    isos = get_attribute!(Dict{Tuple{Type, Bool}, Any}, G, :isomorphisms)::Dict{Tuple{Type, Bool}, Any}
    return get!(isos, (FPGroup, on_gens)) do
      if on_gens
-       Ggens = GAPWrap.GeneratorsOfGroup(G.X)
+       Ggens = GAPWrap.GeneratorsOfGroup(GapObj(G))
        if length(Ggens) == 0
 # TODO: remove this special treatment as soon as the change from
 #       https://github.com/gap-system/gap/pull/5700 is available in Oscar
 #       (not yet in GAP 4.13.0)
-         f = GAP.Globals.GroupHomomorphismByImages(G.X, GAP.Globals.FreeGroup(0), GAP.Obj([]), GAP.Obj([]))
+         f = GAP.Globals.GroupHomomorphismByImages(GapObj(G), GAP.Globals.FreeGroup(0), GAP.Obj([]), GAP.Obj([]))
          GAP.Globals.SetIsBijective(f, true)
        else
          # The computations are easy if `Ggens` is a pcgs,
          # otherwise GAP will call `CoKernel`.
-         if GAP.Globals.HasFamilyPcgs(G.X)
-           pcgs = GAP.Globals.InducedPcgsWrtFamilyPcgs(G.X)
+         if GAP.Globals.HasFamilyPcgs(GapObj(G))
+           pcgs = GAP.Globals.InducedPcgsWrtFamilyPcgs(GapObj(G))
            if pcgs == Ggens
              # `pcgs` fits *and* is an object in `GAP.Globals.IsPcgs`,
              # for which a special `GAPWrap.IsomorphismFpGroupByGenerators`
@@ -555,15 +555,15 @@ function isomorphism(::Type{FPGroup}, G::GAPGroup; on_gens::Bool=false)
              Ggens = pcgs
            end
          end
-         f = GAPWrap.IsomorphismFpGroupByGenerators(G.X, Ggens)
+         f = GAPWrap.IsomorphismFpGroupByGenerators(GapObj(G), Ggens)
        end
      else
-       f = GAPWrap.IsomorphismFpGroup(G.X)
+       f = GAPWrap.IsomorphismFpGroup(GapObj(G))
      end
      @req f !== GAP.Globals.fail "Could not convert group into a group of type FPGroup"
      H = FPGroup(GAP.Globals.ImagesSource(f)::GapObj)
 # TODO: remove the next line once GAP 4.13.0 is available in Oscar
-     GAP.Globals.UseIsomorphismRelation(G.X, H.X)
+     GAP.Globals.UseIsomorphismRelation(GapObj(G), GapObj(H))
      return GAPGroupHomomorphism(G, H, f)
    end::GAPGroupHomomorphism{typeof(G), FPGroup}
 end
@@ -583,15 +583,15 @@ function isomorphism(::Type{FinGenAbGroup}, G::GAPGroup)
      @req is_finite(G) "the group is not finite"
 #T this restriction is not nice
 
-     indep = GAP.Globals.IndependentGeneratorsOfAbelianGroup(G.X)::GapObj
+     indep = GAP.Globals.IndependentGeneratorsOfAbelianGroup(GapObj(G))::GapObj
      orders = ZZRingElem[GAPWrap.Order(x) for x in indep]
      n = length(indep)
      A = abelian_group(FinGenAbGroup, orders)
 
-     f(g) = A(Vector{ZZRingElem}(GAPWrap.IndependentGeneratorExponents(G.X, g.X)))
+     f(g) = A(Vector{ZZRingElem}(GAPWrap.IndependentGeneratorExponents(GapObj(G), GapObj(g))))
 
      finv = function(g::elem_type(FinGenAbGroup))
-       res = GAPWrap.One(G.X)
+       res = GAPWrap.One(GapObj(G))
        for i in 1:n
          res = res * indep[i]^GAP.Obj(g.coeff[i])
        end
@@ -624,21 +624,21 @@ function isomorphism(::Type{T}, A::FinGenAbGroup) where T <: GAPGroup
      A_to_A2 = inv(A2_to_A)
      # the isomorphic gap group
      G = abelian_group(T, exponents)
-     # `GAPWrap.GeneratorsOfGroup(G.X)` consists of independent elements
+     # `GAPWrap.GeneratorsOfGroup(GapObj(G))` consists of independent elements
      # of the orders in `exponents`.
-     # `GAP.Globals.IndependentGenerators(G.X)` chooses generators
+     # `GAP.Globals.IndependentGenerators(GapObj(G))` chooses generators
      # that may differ from these generators,
      # and that belong to the exponent vectors returned by
-     # `GAPWrap.IndependentGeneratorExponents(G.X, g)`.
-     # `GAPWrap.GeneratorsOfGroup(G.X)` corresponds to `gens(A2)`,
+     # `GAPWrap.IndependentGeneratorExponents(GapObj(G), g)`.
+     # `GAPWrap.GeneratorsOfGroup(GapObj(G))` corresponds to `gens(A2)`,
      # we let `hom` compute elements in `A2` that correspond to
-     # `GAP.Globals.IndependentGenerators(G.X)`.
-     Ggens = Vector{GapObj}(GAPWrap.GeneratorsOfGroup(G.X)::GapObj)
+     # `GAP.Globals.IndependentGenerators(GapObj(G))`.
+     Ggens = Vector{GapObj}(GAPWrap.GeneratorsOfGroup(GapObj(G))::GapObj)
      if length(Ggens) < length(exponents)
        # It may happen that GAP omits the generators of order 1. Insert them.
        @assert length(Ggens) + length(filter(x -> x == 1, exponents)) ==
                length(exponents)
-       o = one(G).X
+       o = GapObj(one(G))
        newGgens = Vector{GapObj}()
        pos = 1
        for i in 1:length(exponents)
@@ -651,17 +651,17 @@ function isomorphism(::Type{T}, A::FinGenAbGroup) where T <: GAPGroup
        end
        Ggens = newGgens
      end
-     gensindep = GAP.Globals.IndependentGeneratorsOfAbelianGroup(G.X)::GapObj
+     gensindep = GAP.Globals.IndependentGeneratorsOfAbelianGroup(GapObj(G))::GapObj
      Aindep = abelian_group(ZZRingElem[GAPWrap.Order(g) for g in gensindep])
 
-     imgs = [Vector{ZZRingElem}(GAPWrap.IndependentGeneratorExponents(G.X, a)) for a in Ggens]
+     imgs = [Vector{ZZRingElem}(GAPWrap.IndependentGeneratorExponents(GapObj(G), a)) for a in Ggens]
      A2_to_Aindep = hom(A2, Aindep, elem_type(Aindep)[Aindep(e) for e in imgs])
      Aindep_to_A = compose(inv(A2_to_Aindep), A2_to_A)
      n = length(exponents)
 
      f = function(a::elem_type(FinGenAbGroup))
        exp = A_to_A2(a)
-       img = GAP.Globals.One(G.X)
+       img = GAP.Globals.One(GapObj(G))
        for i in 1:n
          img = img * Ggens[i]^GAP.Obj(exp[i])
        end
@@ -669,7 +669,7 @@ function isomorphism(::Type{T}, A::FinGenAbGroup) where T <: GAPGroup
      end
 
      finv = function(g)
-       exp = Vector{ZZRingElem}(GAPWrap.IndependentGeneratorExponents(G.X, g.X))
+       exp = Vector{ZZRingElem}(GAPWrap.IndependentGeneratorExponents(GapObj(G), GapObj(g)))
        return Aindep_to_A(Aindep(exp))
      end
 
@@ -893,11 +893,11 @@ Finitely presented group of infinite order
 ```
 """
 function simplified_fp_group(G::FPGroup)
-   f = GAP.Globals.IsomorphismSimplifiedFpGroup(G.X)
+   f = GAP.Globals.IsomorphismSimplifiedFpGroup(GapObj(G))
    H = FPGroup(GAPWrap.Image(f))
    # TODO: remove the next line once https://github.com/gap-system/gap/pull/4810
    # is deployed to Oscar
-   GAP.Globals.UseIsomorphismRelation(G.X, H.X)
+   GAP.Globals.UseIsomorphismRelation(GapObj(G), GapObj(H))
    return H, GAPGroupHomomorphism(G,H,f)
 end
 
@@ -1050,12 +1050,12 @@ GAPGroupHomomorphism{PermGroup, PermGroup}
 ```
 """
 function automorphism_group(G::GAPGroup)
-  AutGAP = GAP.Globals.AutomorphismGroup(G.X)::GapObj
+  AutGAP = GAP.Globals.AutomorphismGroup(GapObj(G))::GapObj
   return AutomorphismGroup(AutGAP, G)
 end
 
 function Base.show(io::IO, A::AutomorphismGroup{T}) where T <: GAPGroup
-  print(io, "Aut( "* String(GAP.Globals.StringView(A.G.X)) * " )")
+  print(io, "Aut( "* String(GAP.Globals.StringView(GapObj(A.G))) * " )")
 end
 
 """
@@ -1090,7 +1090,7 @@ Return the element f of type `GAPGroupHomomorphism{T,T}`.
 function hom(x::GAPGroupElem{AutomorphismGroup{T}}) where T <: GAPGroup
   A = parent(x)
   G = A.G
-  return GAPGroupHomomorphism(G, G, x.X)
+  return GAPGroupHomomorphism(G, G, GapObj(x))
 end
 
 (f::GAPGroupElem{AutomorphismGroup{T}})(x::GAPGroupElem) where T <: GAPGroup = apply_automorphism(f, x, true)
@@ -1100,16 +1100,16 @@ Base.:^(x::GAPGroupElem{T},f::GAPGroupElem{AutomorphismGroup{T}}) where T <: GAP
 function (A::AutomorphismGroup{T})(f::GAPGroupHomomorphism{T,T}) where T <: GAPGroup
    @assert domain(f)==A.G && codomain(f)==A.G "f not in A"
    @assert is_bijective(f) "f not in A"
-   return group_element(A, f.map)
+   return group_element(A, GapObj(f))
 end
 
 function apply_automorphism(f::GAPGroupElem{AutomorphismGroup{T}}, x::GAPGroupElem, check::Bool=true) where T <: GAPGroup
   A = parent(f)
   G = parent(x)
   if check
-    @assert A.G == G || x.X in A.G.X "Not in the domain of f!"      #TODO Do we really need the IN check?
+    @assert A.G == G || GapObj(x) in GapObj(A.G) "Not in the domain of f!"      #TODO Do we really need the IN check?
   end
-  return typeof(x)(G, GAPWrap.ImagesRepresentative(f.X, x.X))
+  return typeof(x)(G, GAPWrap.ImagesRepresentative(GapObj(f), GapObj(x)))
 end
 
 Base.:*(f::GAPGroupElem{AutomorphismGroup{T}}, g::GAPGroupHomomorphism) where T = hom(f)*g
@@ -1121,7 +1121,7 @@ Base.:*(f::GAPGroupHomomorphism, g::GAPGroupElem{AutomorphismGroup{T}}) where T 
 Return the inner automorphism in `automorphism_group(parent(g))` defined by `x` -> `x^g`.
 """
 function inner_automorphism(g::GAPGroupElem)
-  return GAPGroupHomomorphism(parent(g), parent(g), GAP.Globals.ConjugatorAutomorphism(parent(g).X, g.X))
+  return GAPGroupHomomorphism(parent(g), parent(g), GAP.Globals.ConjugatorAutomorphism(GapObj(parent(g)), GapObj(g)))
 end
 
 """
@@ -1132,11 +1132,11 @@ Return whether `f` is an inner automorphism.
 """
 function is_inner_automorphism(f::GAPGroupHomomorphism)
   @assert domain(f) == codomain(f) "Not an automorphism!"
-  return GAPWrap.IsInnerAutomorphism(f.map)
+  return GAPWrap.IsInnerAutomorphism(GapObj(f))
 end
 
 function is_inner_automorphism(f::GAPGroupElem{AutomorphismGroup{T}}) where T <: GAPGroup
-  return GAPWrap.IsInnerAutomorphism(f.X)
+  return GAPWrap.IsInnerAutomorphism(GapObj(f))
 end
 
 """
@@ -1145,7 +1145,7 @@ end
 Return the subgroup of `A` of the inner automorphisms.
 """
 function inner_automorphism_group(A::AutomorphismGroup{T}) where T <: GAPGroup
-   AutGAP = GAP.Globals.InnerAutomorphismsAutomorphismGroup(A.X)
+   AutGAP = GAP.Globals.InnerAutomorphismsAutomorphismGroup(GapObj(A))
    return _as_subgroup(A, AutGAP)
 end
 
@@ -1155,8 +1155,8 @@ end
 Return whether `f`(`H`) == `H`.
 """
 function is_invariant(f::GAPGroupElem{AutomorphismGroup{T}}, H::T) where T<:GAPGroup
-  @assert GAPWrap.IsSubset(parent(f).G.X, H.X) "Not a subgroup of the domain"
-  return GAPWrap.Image(f.X, H.X) == H.X
+  @assert GAPWrap.IsSubset(GapObj(parent(f).G), GapObj(H)) "Not a subgroup of the domain"
+  return GAPWrap.Image(GapObj(f), GapObj(H)) == GapObj(H)
 end
 
 """
@@ -1170,7 +1170,7 @@ homomorphism defined over `G` such that the kernel of `f` is invariant under
 """
 function induced_automorphism(f::GAPGroupHomomorphism, mH::GAPGroupHomomorphism)
   @assert is_invariant(mH, kernel(f)[1]) "The kernel is not invariant under g!"
-  map = GAP.Globals.InducedAutomorphism(f.map, mH.map)
+  map = GAP.Globals.InducedAutomorphism(GapObj(f), GapObj(mH))
   A = automorphism_group(image(f)[1])
   return A(GAPGroupHomomorphism(codomain(f), codomain(f), map))
 end

--- a/src/Groups/libraries/atlasgroups.jl
+++ b/src/Groups/libraries/atlasgroups.jl
@@ -218,7 +218,7 @@ function all_atlas_group_infos(name::String, L...)
         iso = iso_oscar_gap(data)
         push!(gapargs, gapfunc, codomain(iso))
       elseif func === character
-        push!(gapargs, gapfunc, data.values)
+        push!(gapargs, gapfunc, GapObj(data))
       else
         # we can translate `data` to GAP
         push!(gapargs, gapfunc, GAP.Obj(data))

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -347,6 +347,8 @@ struct GAPGroupHomomorphism{S<: GAPGroup, T<: GAPGroup} <: Map{S,T,GAPMap,GAPGro
    end
 end
 
+GapObj(f::GAPGroupHomomorphism) = f.map
+
 
 """
     AutomorphismGroup{T} <: GAPGroup

--- a/src/InvariantTheory/invariant_rings.jl
+++ b/src/InvariantTheory/invariant_rings.jl
@@ -602,7 +602,7 @@ function _molien_series_nonmodular_via_gap(
   t = GAP.Globals.CharacterTable(GapObj(G))
   if G isa MatrixGroup
     if is_zero(characteristic(coefficient_ring(I)))
-      psi = natural_character(G).values
+      psi = GapObj(natural_character(G))
     else
       psi = [
         GAP.Globals.BrauerCharacterValue(GAPWrap.Representative(c)) for
@@ -617,10 +617,10 @@ function _molien_series_nonmodular_via_gap(
     ]
   end
   if chi === nothing
-    info = GAP.Globals.MolienSeriesInfo(GAP.Globals.MolienSeries(t, GAP.GapObj(psi)))
+    info = GAP.Globals.MolienSeriesInfo(GAP.Globals.MolienSeries(t, GapObj(psi)))
   else
     info = GAP.Globals.MolienSeriesInfo(
-      GAP.Globals.MolienSeries(t, GAP.GapObj(psi), chi.values)
+      GAP.Globals.MolienSeries(t, GapObj(psi), GapObj(chi))
     )
   end
   num = S(

--- a/src/Serialization/GAP.jl
+++ b/src/Serialization/GAP.jl
@@ -143,12 +143,12 @@ install_GAP_deserialization(
             GapObj(nameprefix)
           end
           init = load_node(s, :names) do names
-            GapObj([GapObj(x) for x in names], true)
+            GapObj(names; recursive = true)
           end
           G = GAP.Globals.FreeGroup(wfilt, GAP.Globals.infinity, prefix, init)::GapObj
         else
           init = load_node(s, :names) do names
-            GapObj([GapObj(x) for x in names], true)
+            GapObj(names; recursive = true)
           end
           G = GAP.Globals.FreeGroup(wfilt, init)::GapObj
         end

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -753,7 +753,7 @@ end
 @testset "access fields in character tables" begin
   # table without group
   t = character_table("A5")
-  @test Oscar.GAPTable(t) === t.GAPTable
+  @test GapObj(t) === t.GAPTable
   @test characteristic(t) == t.characteristic
   @test_throws UndefRefError t.group
   @test_throws UndefRefError t.isomorphism
@@ -761,7 +761,7 @@ end
   # table with `GAPGroup` group
   g = symmetric_group(4)
   t = character_table(g)
-  @test Oscar.GAPTable(t) === t.GAPTable
+  @test GapObj(t) === t.GAPTable
   @test characteristic(t) == t.characteristic
   @test group(t) === t.group === g
   @test Oscar.isomorphism_to_GAP_group(t) === t.isomorphism
@@ -769,7 +769,7 @@ end
   # table with `FinGenAbGroup` group
   g = abelian_group([2, 4])
   t = character_table(g)
-  @test Oscar.GAPTable(t) === t.GAPTable
+  @test GapObj(t) === t.GAPTable
   @test characteristic(t) == t.characteristic
   @test group(t) === t.group === g
   @test Oscar.isomorphism_to_GAP_group(t) === t.isomorphism


### PR DESCRIPTION
This is a follow-up of #3671.

