### PR TITLE
feat: more information in banner for dev version

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -41,14 +41,23 @@ if Sys.iswindows()
   windows_error()
 end
 
-function _print_banner()
-  if displaysize(stdout)[2] >= 79
+function _print_banner(;is_dev = Oscar.is_dev)
+  # lets assemble a version string for the banner
+  version_string = string(VERSION_NUMBER)
+  if is_dev
+    gitinfo = _get_oscar_git_info()
+    version_string = version_string * " #$(gitinfo[:branch]) $(gitinfo[:commit][1:7]) $(gitinfo[:date][1:10])"
+  else
+    version_string = "Version " * version_string
+  end
+  
+  if displaysize(stdout)[2] >= 80 
     println(
       raw"""  ___   ____   ____    _    ____
              / _ \ / ___| / ___|  / \  |  _ \   |  Combining ANTIC, GAP, Polymake, Singular
             | | | |\___ \| |     / _ \ | |_) |  |  Type "?Oscar" for more information
             | |_| | ___) | |___ / ___ \|  _ <   |  Manual: https://docs.oscar-system.org
-             \___/ |____/ \____/_/   \_\_| \_\  |  Version """ * "$VERSION_NUMBER")
+             \___/ |____/ \____/_/   \_\_| \_\  |  """ * version_string)
   else
     println("OSCAR $VERSION_NUMBER  https://docs.oscar-system.org  Type \"?Oscar\" for help")
   end


### PR DESCRIPTION
For reasons of space I had to remove the "Version" for the line. Here is how it looks:
```
  ___   ____   ____    _    ____
 / _ \ / ___| / ___|  / \  |  _ \   |  Combining ANTIC, GAP, Polymake, Singular
| | | |\___ \| |     / _ \ | |_) |  |  Type "?Oscar" for more information
| |_| | ___) | |___ / ___ \|  _ <   |  Manual: https://docs.oscar-system.org
 \___/ |____/ \____/_/   \_\_| \_\  |  1.1.0-DEV #master 0e79592 2024-05-03
```
It looks good with branch names that are not too long. I did not try to shorten the branch names to fit the 80 character limit (@antonydellavecchia was this name created automatically? If so, which tool?):
```
  ___   ____   ____    _    ____
 / _ \ / ___| / ___|  / \  |  _ \   |  Combining ANTIC, GAP, Polymake, Singular
| | | |\___ \| |     / _ \ | |_) |  |  Type "?Oscar" for more information
| |_| | ___) | |___ / ___ \|  _ <   |  Manual: https://docs.oscar-system.org
 \___/ |____/ \____/_/   \_\_| \_\  |  1.1.0-DEV #3632-currently-the-function-grassmann_pluecker_ideal-returns-an-ideal-in-a-non-graded-polynomial-ring-shouldnt-we-rather-use-a-standard-graded-ring 4430dd9 2024-04-24
```
I could spend more time and use `..` for long branch names, but this can be added later.

Closes #3680.

P.S.: I decided against printing the "x days old", since there is no space and I did not want to pull in `Base.Dates` for the dates arithmetic.