### PR TITLE
Use coordinates accessor function

### DIFF
--- a/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
@@ -531,7 +531,7 @@ function sparse_matrix(phi::FreeModuleHom{FreeMod{T}, FreeMod{T}, Nothing}) wher
   n = ngens(W)
   result = sparse_matrix(kk, m, n)
   for i in 1:m
-    result[i] = phi(V[i]).coords
+    result[i] = coordinates(phi(V[i]))
   end
   return result
 end

--- a/src/Modules/FreeModElem-orderings.jl
+++ b/src/Modules/FreeModElem-orderings.jl
@@ -261,7 +261,7 @@ Return the tail of `f` with respect to the order `ordering`.
 """
 function tail(f::FreeModElem; ordering::ModuleOrdering = default_ordering(parent(f)))
   (i, j) = index_of_leading_term(f, ordering)
-  c = collect(k == i ? _delete_index(p, j) : p for (k, p) in f.coords)
+  c = collect(k == i ? _delete_index(p, j) : p for (k, p) in coordinates(f))
   return FreeModElem(c, parent(f))
 end
 

--- a/src/Modules/UngradedModules/FreeModElem.jl
+++ b/src/Modules/UngradedModules/FreeModElem.jl
@@ -124,7 +124,7 @@ end
 
 function expressify(e::AbstractFreeModElem; context = nothing)
   sum = Expr(:call, :+)
-  for (pos, val) in e.coords
+  for (pos, val) in coordinates(e)
      # assuming generator_symbols(parent(e)) is an array of strings/symbols
      push!(sum.args, Expr(:call, :*, expressify(val, context = context), generator_symbols(parent(e))[pos]))
   end
@@ -206,7 +206,7 @@ function (==)(a::AbstractFreeModElem, b::AbstractFreeModElem)
   if parent(a) !== parent(b)
     return false
   end
-  return a.coords == b.coords
+  return coordinates(a) == coordinates(b)
 end
 
 function hash(a::AbstractFreeModElem, h::UInt)

--- a/src/Modules/UngradedModules/FreeModuleHom.jl
+++ b/src/Modules/UngradedModules/FreeModuleHom.jl
@@ -382,13 +382,14 @@ function hom(F::FreeMod, G::FreeMod)
   m = ngens(G)
   R = base_ring(F)
   function im(x::FreeModElem)
-    return hom(F, G, Vector{elem_type(G)}([FreeModElem(x.coords[R, (i-1)*m+1:i*m], G) for i=1:n]), check=false)
+    c = coordinates(x)
+    return hom(F, G, Vector{elem_type(G)}([FreeModElem(c[R, (i-1)*m+1:i*m], G) for i=1:n]), check=false)
   end
   function pre(h::FreeModuleHom)
     s = sparse_row(F.R)
     o = 0
     for i=1:n
-      for (p,v) = h(gen(F, i)).coords
+      for (p,v) = coordinates(h(gen(F, i)))
         push!(s.pos, o+p)
         push!(s.values, v)
       end

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -354,7 +354,8 @@ function hom_matrices_helper(f1::MatElem{T}, g1::MatElem{T}) where T
       throw(DomainError("v does not represent a homomorphism"))
     end
     R = base_ring(M)
-    A = copy_and_reshape(dense_row(repres(v).coords[R, 1:s0*t0], s0*t0), s0, t0)
+    c = coordinates(repres(v))
+    A = copy_and_reshape(dense_row(c[R, 1:s0*t0], s0*t0), s0, t0)
     return A
   end
 

--- a/src/Modules/UngradedModules/ModuleGens.jl
+++ b/src/Modules/UngradedModules/ModuleGens.jl
@@ -250,7 +250,7 @@ function (SF::Singular.FreeMod)(m::FreeModElem)
   g = Singular.gens(SF)
   e = SF()
   Sx = base_ring(SF)
-  for (p,v) = m.coords
+  for (p,v) in coordinates(m)
     e += Sx(v)*g[p]
   end
   return e

--- a/src/Modules/UngradedModules/Presentation.jl
+++ b/src/Modules/UngradedModules/Presentation.jl
@@ -46,7 +46,7 @@ function presentation(SQ::SubquoModule)
 
     for x = c
       b = sparse_row(R)
-      for (i,v) = x.coords
+      for (i,v) in coordinates(x)
         if i>ngens(SQ)
           break
         end

--- a/src/Modules/UngradedModules/SubquoModuleElem.jl
+++ b/src/Modules/UngradedModules/SubquoModuleElem.jl
@@ -90,7 +90,7 @@ function repres(v::SubquoModuleElem)
   if !isdefined(v, :repres)
     @assert isdefined(v, :coeffs) "neither coeffs nor repres is defined on a SubquoModuleElem"
     M = parent(v)
-    v.repres = sum(a*M.sub[i] for (i, a) in v.coeffs; init=zero(M.sub))
+    v.repres = sum(a*M.sub[i] for (i, a) in coordinates(v); init=zero(M.sub))
   end
   return v.repres
 end
@@ -539,7 +539,6 @@ function sub(F::FreeMod{T}, s::SubquoModule{T}; cache_morphism::Bool=false) wher
   @assert !isdefined(s, :quo)
   @assert s.F === F
   emb = hom(s, F, elem_type(F)[repres(x) for x in gens(s)]; check=false)
-  #emb = hom(s, F, [FreeModElem(x.repres.coords, F) for x in gens(s)])
   set_attribute!(s, :canonical_inclusion => emb)
   cache_morphism && register_morphism!(emb)
   return s, emb
@@ -1023,7 +1022,7 @@ eltype(::ModuleGens{T}) where {T} = FreeModElem{T}
 function *(a::FreeModElem, b::Vector{FreeModElem})
   @assert dim(parent(a)) == length(b)
   s = zero(parent(a))
-  for (p,v) = a.coords
+  for (p,v) in coordinates(a)
     s += v*b[p]
   end
   return s

--- a/src/Modules/UngradedModules/Tensor.jl
+++ b/src/Modules/UngradedModules/Tensor.jl
@@ -29,13 +29,13 @@ function tensor_product(G::FreeMod...; task::Symbol = :none)
   function pure(g::FreeModElem...)
     @assert length(g) == length(G)
     @assert all(i -> parent(g[i]) === G[i], 1:length(G))
-    z = [[x] for x = g[1].coords.pos]
-    zz = g[1].coords.values
+    z = [[x] for x = coordinates(g[1]).pos]
+    zz = coordinates(g[1]).values
     for h = g[2:end]
       zzz = Vector{Int}[]
       zzzz = elem_type(F.R)[]
       for i = 1:length(z)
-        for (p, v) = h.coords
+        for (p, v) in coordinates(h)
           push!(zzz, push!(deepcopy(z[i]), p))
           push!(zzzz, zz[i]*v)
         end
@@ -50,12 +50,13 @@ function tensor_product(G::FreeMod...; task::Symbol = :none)
     return pure(T...)
   end
   function inv_pure(e::FreeModElem)
-    if length(e.coords.pos) == 0
+    c = coordinates(e)
+    if length(c.pos) == 0
       return Tuple(zero(g) for g = G)
     end
-    @assert length(e.coords.pos) == 1
-    @assert isone(e.coords.values[1])
-    return Tuple(gen(G[i], t[e.coords.pos[1]][i]) for i = 1:length(G))
+    @assert length(c.pos) == 1
+    @assert isone(c.values[1])
+    return Tuple(gen(G[i], t[c.pos[1]][i]) for i = 1:length(G))
   end
 
   set_attribute!(F, :tensor_pure_function => pure, :tensor_generator_decompose_function => inv_pure)


### PR DESCRIPTION
... instead of directly accessing members. In the future this will allow us to insert type assertions into the accessors for improved type stability

Extracted from #3679 so that it can be tested and merged now.