### PR TITLE
FTheoryTools: Updates to hypersurface model constructor

### DIFF
--- a/experimental/FTheoryTools/docs/src/hypersurface.md
+++ b/experimental/FTheoryTools/docs/src/hypersurface.md
@@ -71,12 +71,14 @@ The functionality of OSCAR only allows us to compute a section basis (or a finit
 for complete toric varieties. In the future, this could be extended.
 
 Completeness is an expensive check. Therefore, we provide an optional argument which
- one can use to disable this check if desired. To this end, one passes the optional argument
- `completeness_check = false` as last argument to the constructor. The following examples
- demonstrate this:
+one can use to disable this check if desired. To this end, one passes the optional argument
+`completeness_check = false` as last argument to the constructor. Here is how we can construct
+a hypersurface model in OSCAR:
 ```@docs
-hypersurface_model(base::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}; completeness_check::Bool = true)
+hypersurface_model(base::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}, p::MPolyRingElem; completeness_check::Bool = true)
 ```
+For convenience, it also possible to provide the hypersurface polynomial `p` as a string.
+
 
 ### A (covered) scheme as base space
 

--- a/experimental/FTheoryTools/docs/src/hypersurface.md
+++ b/experimental/FTheoryTools/docs/src/hypersurface.md
@@ -75,7 +75,6 @@ Completeness is an expensive check. Therefore, we provide an optional argument w
  `completeness_check = false` as last argument to the constructor. The following examples
  demonstrate this:
 ```@docs
-hypersurface_model(base::NormalToricVariety; completeness_check::Bool = true)
 hypersurface_model(base::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}; completeness_check::Bool = true)
 ```
 
@@ -91,16 +90,6 @@ this base space is not (fully) specified. We currently provide the following con
 hypersurface_model(auxiliary_base_vars::Vector{String}, auxiliary_base_grading::Matrix{Int64}, d::Int, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{Vector{Int64}}, p::MPolyRingElem)
 ```
 For convenience, the fiber_twist_divisor_classes can also be provided as `ZZMatrix`.
-
-### Standard constructions
-
-We provide convenient constructions of hypersurface models over
-famous base spaces. Currently, we support the following:
-```@docs
-hypersurface_model_over_projective_space(d::Int)
-hypersurface_model_over_hirzebruch_surface(r::Int)
-hypersurface_model_over_del_pezzo_surface(b::Int)
-```
 
 
 ## Attributes

--- a/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
@@ -10,7 +10,15 @@
 Return the hypersurface equation.
 
 ```jldoctest
-julia> h = hypersurface_model_over_projective_space(2)
+julia> B2 = projective_space(NormalToricVariety, 2)
+Normal toric variety
+
+julia> b = torusinvariant_prime_divisors(B2)[1]
+Torus-invariant, prime divisor on a normal toric variety
+
+julia> h = literature_model(arxiv_id = "1208.2695", equation = "B.5", base_space = B2, model_sections = Dict("b" => b))
+Construction over concrete base may lead to singularity enhancement. Consider computing singular_loci. However, this may take time!
+
 Hypersurface model over a concrete base
 
 julia> hypersurface_equation(h);
@@ -96,7 +104,15 @@ Return the Calabi-Yau hypersurface in the toric ambient space
 which defines the hypersurface model.
 
 ```jldoctest
-julia> h = hypersurface_model_over_projective_space(2)
+julia> B2 = projective_space(NormalToricVariety, 2)
+Normal toric variety
+
+julia> b = torusinvariant_prime_divisors(B2)[1]
+Torus-invariant, prime divisor on a normal toric variety
+
+julia> h = literature_model(arxiv_id = "1208.2695", equation = "B.5", base_space = B2, model_sections = Dict("b" => b))
+Construction over concrete base may lead to singularity enhancement. Consider computing singular_loci. However, this may take time!
+
 Hypersurface model over a concrete base
 
 julia> calabi_yau_hypersurface(h)

--- a/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
@@ -3,32 +3,6 @@
 ################################################
 
 @doc raw"""
-    hypersurface_model(base::NormalToricVariety; completeness_check::Bool = true)
-
-Construct a hypersurface model. This constructor takes $\mathbb{P}^{2,3,1}$ as fiber
-ambient space with coordinates $[x:y:z]$ and ensures that $x$ transforms as
-$2 \overline{K}_{B_3}$ and $y$ as $3 \overline{K}_{B_3}$.
-
-# Examples
-```jldoctest
-julia> base = projective_space(NormalToricVariety, 2)
-Normal toric variety
-
-julia> hypersurface_model(base; completeness_check = false)
-Hypersurface model over a concrete base
-```
-"""
-function hypersurface_model(base::NormalToricVariety; completeness_check::Bool = true)
-  fiber_ambient_space = weighted_projective_space(NormalToricVariety, [2,3,1])
-  set_coordinate_names(fiber_ambient_space, ["x", "y", "z"])
-  D1 = 2 * anticanonical_divisor_class(base)
-  D2 = 3 * anticanonical_divisor_class(base)
-  D3 = trivial_divisor_class(base)
-  return hypersurface_model(base, fiber_ambient_space, [D1, D2, D3]; completeness_check = completeness_check)
-end
-
-
-@doc raw"""
     hypersurface_model(base::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}; completeness_check::Bool = true)
 
 Construct a hypersurface model, for which the user can specify a fiber ambient space

--- a/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-11.json
+++ b/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-11.json
@@ -62,7 +62,7 @@
             [ 0, -1, 0, 0, 0, 0, 0],
             [ 1,  1, 0, 0, 0, 0, 0]
         ],
-        "hypersurface_equation": "s1*e1^2*e2^2*e3*e4^4*u^3 + s2*e1*e2^2*e3^2*e4^2*u^2*v + s3*e2^2*e3^2*u*v^2 + s5*e1^2*e2*e4^3*u^2*w + s6*e1*e2*e3*e4*u*v*w + s9*e1*v*w^2",
+        "hypersurface_equation": "s1*e1^2*e2^2*e3*e4^4*u^3 + s2*e1*e2^2*e3^2*e4^2*u^2*v + s3*e2^2*e3^3*u*v^2 + s5*e1^2*e2*e4^3*u^2*w + s6*e1*e2*e3*e4*u*v*w + s9*e1*v*w^2",
         "zero_section": ["1", "0", "s5", "1", "1", "-s5", "1"],
         "generating_sections": [
             ["s9", "1", "1", "-s3", "1", "1", "0"]

--- a/experimental/FTheoryTools/src/exports.jl
+++ b/experimental/FTheoryTools/src/exports.jl
@@ -82,9 +82,6 @@ export has_zero_section
 export hypersurface_equation
 export hypersurface_equation_parametrization
 export hypersurface_model
-export hypersurface_model_over_del_pezzo_surface
-export hypersurface_model_over_hirzebruch_surface
-export hypersurface_model_over_projective_space
 export irrelevant_ideal
 export is_base_space_fully_specified
 export is_partially_resolved

--- a/experimental/FTheoryTools/src/standard_constructions.jl
+++ b/experimental/FTheoryTools/src/standard_constructions.jl
@@ -30,20 +30,6 @@ Weierstrass model over a concrete base
 weierstrass_model_over_projective_space(d::Int) = weierstrass_model(projective_space(NormalToricVariety, d); completeness_check = false)
 
 
-@doc raw"""
-    hypersurface_model_over_projective_space(d::Int)
-
-This method constructs a hypersurface model over the projective space.
-
-# Examples
-```jldoctest
-julia> hypersurface_model_over_projective_space(2)
-Hypersurface model over a concrete base
-```
-"""
-hypersurface_model_over_projective_space(d::Int) = hypersurface_model(projective_space(NormalToricVariety, d); completeness_check = false)
-
-
 #####################################################
 # 2. Models over hirzebruch surfaces
 #####################################################
@@ -76,20 +62,6 @@ Weierstrass model over a concrete base
 weierstrass_model_over_hirzebruch_surface(r::Int) = weierstrass_model(hirzebruch_surface(NormalToricVariety, r); completeness_check = false)
 
 
-@doc raw"""
-    hypersurface_model_over_hirzebruch_surface(r::Int)
-
-This method constructs a hypersurface model over a Hirzebruch surface.
-
-# Examples
-```jldoctest
-julia> hypersurface_model_over_hirzebruch_surface(1)
-Hypersurface model over a concrete base
-```
-"""
-hypersurface_model_over_hirzebruch_surface(r::Int) = hypersurface_model(hirzebruch_surface(NormalToricVariety, r); completeness_check = false)
-
-
 #####################################################
 # 3. Models over del pezzo surface
 #####################################################
@@ -120,20 +92,6 @@ Weierstrass model over a concrete base
 ```
 """
 weierstrass_model_over_del_pezzo_surface(b::Int) = weierstrass_model(del_pezzo_surface(NormalToricVariety, b); completeness_check = false)
-
-
-@doc raw"""
-    hypersurface_model_over_del_pezzo_surface(b::Int)
-
-This method constructs a hypersurface model over a del-Pezzo surface.
-
-# Examples
-```jldoctest
-julia> hypersurface_model_over_del_pezzo_surface(3)
-Hypersurface model over a concrete base
-```
-"""
-hypersurface_model_over_del_pezzo_surface(b::Int) = hypersurface_model(del_pezzo_surface(NormalToricVariety, b); completeness_check = false)
 
 
 #####################################################

--- a/experimental/FTheoryTools/test/hypersurface_models.jl
+++ b/experimental/FTheoryTools/test/hypersurface_models.jl
@@ -2,17 +2,18 @@
 # 1: Hypersurface models over concrete bases
 #############################################################
 
-base = projective_space(NormalToricVariety, 3)
+B3 = projective_space(NormalToricVariety, 3)
 ambient_space_of_fiber = weighted_projective_space(NormalToricVariety, [2,3,1])
 set_coordinate_names(ambient_space_of_fiber, ["x", "y", "z"])
-D1 = 2 * anticanonical_divisor_class(base)
-D2 = 3 * anticanonical_divisor_class(base)
-D3 = trivial_divisor_class(base)
-h = hypersurface_model(base, ambient_space_of_fiber, [D1, D2, D3]; completeness_check = false)
+D1 = 2 * anticanonical_divisor_class(B3)
+D2 = 3 * anticanonical_divisor_class(B3)
+D3 = trivial_divisor_class(B3)
+p = "x^3 - 2*y^2 + x1^16*x*z^4 + x2^24*z^6 + 13*x3^4*x*y*z"
+h = hypersurface_model(B3, ambient_space_of_fiber, [D1, D2, D3], p; completeness_check = false)
 
 @testset "Attributes and properties of hypersurface models over concrete base space and fiber ambient space P2" begin
   @test parent(hypersurface_equation(h)) == cox_ring(ambient_space(h))
-  @test dim(base_space(h)) == dim(base)
+  @test dim(base_space(h)) == dim(B3)
   @test fiber_ambient_space(h) == ambient_space_of_fiber
   @test is_smooth(fiber_ambient_space(h)) == false
   @test [string(g) for g in gens(cox_ring(fiber_ambient_space(h)))] == ["x", "y", "z"]

--- a/experimental/FTheoryTools/test/hypersurface_models.jl
+++ b/experimental/FTheoryTools/test/hypersurface_models.jl
@@ -2,77 +2,62 @@
 # 1: Hypersurface models over concrete bases
 #############################################################
 
-base = projective_space(NormalToricVariety, 2)
-h1 = hypersurface_model(base; completeness_check = false)
-
-@testset "Attributes and properties of hypersurface models over concrete base space and fiber ambient space P231" begin
-  @test parent(hypersurface_equation(h1)) == cox_ring(ambient_space(h1))
-  @test dim(base_space(h1)) == dim(base)
-  @test is_smooth(fiber_ambient_space(h1)) == false
-  @test is_simplicial(fiber_ambient_space(h1)) == true
-  @test [string(g) for g in gens(cox_ring(fiber_ambient_space(h1)))] == ["x", "y", "z"]
-  @test toric_variety(calabi_yau_hypersurface(h1)) == ambient_space(h1)
-  @test is_base_space_fully_specified(h1) == true
-  @test is_partially_resolved(h1) == false
-end
-
-ambient_space_of_fiber = projective_space(NormalToricVariety, 2)
+base = projective_space(NormalToricVariety, 3)
+ambient_space_of_fiber = weighted_projective_space(NormalToricVariety, [2,3,1])
 set_coordinate_names(ambient_space_of_fiber, ["x", "y", "z"])
 D1 = 2 * anticanonical_divisor_class(base)
 D2 = 3 * anticanonical_divisor_class(base)
 D3 = trivial_divisor_class(base)
-h2 = hypersurface_model(base, ambient_space_of_fiber, [D1, D2, D3]; completeness_check = false)
+h = hypersurface_model(base, ambient_space_of_fiber, [D1, D2, D3]; completeness_check = false)
 
 @testset "Attributes and properties of hypersurface models over concrete base space and fiber ambient space P2" begin
-  @test parent(hypersurface_equation(h2)) == cox_ring(ambient_space(h2))
-  @test dim(base_space(h2)) == dim(base)
-  @test fiber_ambient_space(h2) == ambient_space_of_fiber
-  @test is_smooth(fiber_ambient_space(h2)) == true
-  @test [string(g) for g in gens(cox_ring(fiber_ambient_space(h2)))] == ["x", "y", "z"]
-  @test toric_variety(calabi_yau_hypersurface(h2)) == ambient_space(h2)
-  @test is_base_space_fully_specified(h2) == true
+  @test parent(hypersurface_equation(h)) == cox_ring(ambient_space(h))
+  @test dim(base_space(h)) == dim(base)
+  @test fiber_ambient_space(h) == ambient_space_of_fiber
+  @test is_smooth(fiber_ambient_space(h)) == false
+  @test [string(g) for g in gens(cox_ring(fiber_ambient_space(h)))] == ["x", "y", "z"]
+  @test toric_variety(calabi_yau_hypersurface(h)) == ambient_space(h)
+  @test is_base_space_fully_specified(h) == true
 end
 
 @testset "Error messages in hypersurface models over concrete base spaces" begin
-  @test_throws ArgumentError hypersurface_model(affine_space(NormalToricVariety, 3))
-  @test_throws ArgumentError weierstrass_model(h1)
-  @test_throws ArgumentError global_tate_model(h1)
-  @test_throws ArgumentError discriminant(h1)
-  @test_throws ArgumentError singular_loci(h1)
-  @test_throws ArgumentError weierstrass_model(h2)
-  @test_throws ArgumentError global_tate_model(h2)
-  @test_throws ArgumentError discriminant(h2)
-  @test_throws ArgumentError singular_loci(h2)
+  @test_throws ArgumentError weierstrass_model(h)
+  @test_throws ArgumentError global_tate_model(h)
+  @test_throws ArgumentError discriminant(h)
+  @test_throws ArgumentError singular_loci(h)
 end
 
 @testset "Saving and loading hypersurface models over concrete base space" begin
   mktempdir() do path
-    test_save_load_roundtrip(path, h2) do loaded
-      @test hypersurface_equation(h2) == hypersurface_equation(loaded)
-      @test base_space(h2) == base_space(loaded)
-      @test ambient_space(h2) == ambient_space(loaded)
-      @test fiber_ambient_space(h2) == fiber_ambient_space(loaded)
-      @test is_base_space_fully_specified(h2) == is_base_space_fully_specified(loaded)
-      @test is_partially_resolved(h2) == is_partially_resolved(loaded)
+    test_save_load_roundtrip(path, h) do loaded
+      @test hypersurface_equation(h) == hypersurface_equation(loaded)
+      @test base_space(h) == base_space(loaded)
+      @test ambient_space(h) == ambient_space(loaded)
+      @test fiber_ambient_space(h) == fiber_ambient_space(loaded)
+      @test is_base_space_fully_specified(h) == is_base_space_fully_specified(loaded)
+      @test is_partially_resolved(h) == is_partially_resolved(loaded)
     end
   end
 end
 
-h3 = hypersurface_model_over_projective_space(2)
-R = parent(hypersurface_equation(h3))
-new_poly = gens(R)[4]^3
-h4 = tune(h3, new_poly)
+(x1, x2, x3, x4, x, y, z) = gens(parent(hypersurface_equation(h)))
+new_poly = x^3 - y^2 + 3*x1^16*x*z^4 - 7*x2^24*z^6
+h2 = tune(h, new_poly)
 
 @testset "Tune hypersurface model" begin
-  @test h3 == tune(h3, hypersurface_equation(h3))
-  @test hypersurface_equation(h4) == new_poly
-  @test hypersurface_equation(h4) != hypersurface_equation(h3)
-  @test fiber_ambient_space(h4) == fiber_ambient_space(h3)
+  @test h == tune(h, hypersurface_equation(h))
+  @test hypersurface_equation(h2) == new_poly
+  @test hypersurface_equation(h2) != hypersurface_equation(h)
+  @test fiber_ambient_space(h2) == fiber_ambient_space(h)
 end
 
+B2 = projective_space(NormalToricVariety, 2)
+b = torusinvariant_prime_divisors(B2)[1]
+h3 = literature_model(arxiv_id = "1208.2695", equation = "B.5", base_space = B2, model_sections = Dict("b" => b))
+
 @testset "Errors from tuning hypersurface models" begin
-  @test_throws ArgumentError tune(h3, new_poly^2)
-  @test_throws ArgumentError tune(h3, hypersurface_equation(h1))
+  @test_throws ArgumentError tune(h, new_poly^2)
+  @test_throws ArgumentError tune(h, hypersurface_equation(h3))
 end
 
 # Currently, none of the hypersurface models in our database has corresponding Weierstrass/Tate models.
@@ -87,18 +72,14 @@ set_global_tate_model(h3, gt_model)
   @test global_tate_model(h3) == gt_model
 end
 
-B2 = projective_space(NormalToricVariety, 2)
-b = torusinvariant_prime_divisors(B2)[1]
-h5 = literature_model(arxiv_id = "1208.2695", equation = "B.5", base_space = B2, model_sections = Dict("b" => b))
-
 @testset "Attributes and properties of hypersurface literature models over concrete base space" begin
-  @test parent(hypersurface_equation(h5)) == cox_ring(ambient_space(h5))
-  @test dim(base_space(h5)) == 2
-  @test is_smooth(fiber_ambient_space(h5)) == false
-  @test is_simplicial(fiber_ambient_space(h5)) == true
-  @test [string(g) for g in gens(cox_ring(fiber_ambient_space(h5)))] == ["u", "w", "v"]
-  @test is_base_space_fully_specified(h5) == true
-  @test is_partially_resolved(h5) == false
+  @test parent(hypersurface_equation(h3)) == cox_ring(ambient_space(h3))
+  @test dim(base_space(h3)) == 2
+  @test is_smooth(fiber_ambient_space(h3)) == false
+  @test is_simplicial(fiber_ambient_space(h3)) == true
+  @test [string(g) for g in gens(cox_ring(fiber_ambient_space(h3)))] == ["u", "w", "v"]
+  @test is_base_space_fully_specified(h3) == true
+  @test is_partially_resolved(h3) == false
 end
 
 
@@ -117,32 +98,32 @@ ambient_space_of_fiber_2 = weighted_projective_space(NormalToricVariety, [2,3,1]
 set_coordinate_names(ambient_space_of_fiber_2, ["x", "y", "z"])
 auxiliary_ambient_ring, (a1, a21, a32, a43, a65, w, x, y, z)  = QQ["a1", "a21", "a32", "a43", "a65", "w", "x", "y", "z"]
 p = x^3 - y^2 - x * y * z * a1 + x^2 * z^2 * a21 * w - y * z^3 * a32 * w^2 + x * z^4 * a43 * w^3 + z^6 * a65 * w^5
-h6 = hypersurface_model(auxiliary_base_vars, auxiliary_base_grading, d, ambient_space_of_fiber_2, [D1, D2, D3], p)
+h4 = hypersurface_model(auxiliary_base_vars, auxiliary_base_grading, d, ambient_space_of_fiber_2, [D1, D2, D3], p)
 
 @testset "Attributes and properties of hypersurface models over concrete base space and fiber ambient space P2" begin
-  @test parent(hypersurface_equation(h6)) == coordinate_ring(ambient_space(h6))
-  @test dim(base_space(h6)) == d
-  @test fiber_ambient_space(h6) == ambient_space_of_fiber_2
-  @test is_smooth(fiber_ambient_space(h6)) == false
-  @test is_simplicial(fiber_ambient_space(h6)) == true
-  @test [string(g) for g in gens(cox_ring(fiber_ambient_space(h6)))] == ["x", "y", "z"]
-  @test is_base_space_fully_specified(h6) == false
-  @test is_partially_resolved(h6) == false
+  @test parent(hypersurface_equation(h4)) == coordinate_ring(ambient_space(h4))
+  @test dim(base_space(h4)) == d
+  @test fiber_ambient_space(h4) == ambient_space_of_fiber_2
+  @test is_smooth(fiber_ambient_space(h4)) == false
+  @test is_simplicial(fiber_ambient_space(h4)) == true
+  @test [string(g) for g in gens(cox_ring(fiber_ambient_space(h4)))] == ["x", "y", "z"]
+  @test is_base_space_fully_specified(h4) == false
+  @test is_partially_resolved(h4) == false
 end
 
 @testset "Error messages in hypersurface models over not fully specified base spaces" begin
   @test_throws ArgumentError hypersurface_model(auxiliary_base_vars, auxiliary_base_grading, -1, ambient_space_of_fiber_2, [D1, D2, D3], p)
-  @test_throws ArgumentError tune(h6, hypersurface_equation(h6))
+  @test_throws ArgumentError tune(h4, hypersurface_equation(h4))
 end
 
-h7 = literature_model(arxiv_id = "1208.2695", equation = "B.5")
+h5 = literature_model(arxiv_id = "1208.2695", equation = "B.5")
 
 @testset "Attributes and properties of hypersurface models over concrete base space and fiber ambient space P2" begin
-  @test parent(hypersurface_equation(h7)) == coordinate_ring(ambient_space(h7))
-  @test dim(base_space(h7)) == 2
-  @test is_smooth(fiber_ambient_space(h7)) == false
-  @test is_simplicial(fiber_ambient_space(h7)) == true
-  @test [string(g) for g in gens(cox_ring(fiber_ambient_space(h7)))] == ["u", "w", "v"]
-  @test is_base_space_fully_specified(h7) == false
-  @test is_partially_resolved(h7) == false
+  @test parent(hypersurface_equation(h5)) == coordinate_ring(ambient_space(h5))
+  @test dim(base_space(h5)) == 2
+  @test is_smooth(fiber_ambient_space(h5)) == false
+  @test is_simplicial(fiber_ambient_space(h5)) == true
+  @test [string(g) for g in gens(cox_ring(fiber_ambient_space(h5)))] == ["u", "w", "v"]
+  @test is_base_space_fully_specified(h5) == false
+  @test is_partially_resolved(h5) == false
 end


### PR DESCRIPTION
* Remove method `hypersurface_model(base::NormalToricVariety; completeness_check::Bool = true)`.
(This requires to also remove `hypersurface_model_over_projective_space(d::Int)`, `hypersurface_model_over_hirzebruch_surface(r::Int)` and `hypersurface_model_over_del_pezzo_surface(b::Int)` as well as significant changes to the CI tests of hypersurface models.)
* Overhaul constructor `hypersurface_model(auxiliary_base_vars::Vector{String}, auxiliary_base_grading::Matrix{Int64}, d::Int, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{Vector{Int64}}` by providing the hypersurface equation as argument. Sanity checks added and fixed a typo in the hypersurface equation of the F11 hypersurface model.

cc @apturner @emikelsons 
