### PR TITLE
Fixes `mres` and `nres` in `free_resolution`

### DIFF
--- a/src/Modules/UngradedModules/FreeResolutions.jl
+++ b/src/Modules/UngradedModules/FreeResolutions.jl
@@ -1,4 +1,4 @@
- function map(FR::FreeResolution, i::Int)
+function map(FR::FreeResolution, i::Int)
   return map(FR.C, i)
 end
 
@@ -313,7 +313,7 @@ function free_resolution(M::SubquoModule{<:MPolyRingElem};
   cc_complete = false
 
   #= Start with presentation =#
-  pm = presentation(M, minimal = algorithm in [:mres, :nres])
+  pm = algorithm == :mres ? _presentation_minimal(M, minimal_kernel=false) : presentation(M)
   maps = [pm.maps[j] for j in 2:3]
 
   br = base_ring(M)

--- a/src/Modules/UngradedModules/FreeResolutions.jl
+++ b/src/Modules/UngradedModules/FreeResolutions.jl
@@ -313,7 +313,7 @@ function free_resolution(M::SubquoModule{<:MPolyRingElem};
   cc_complete = false
 
   #= Start with presentation =#
-  pm = presentation(M)
+  pm = presentation(M, minimal = algorithm in [:mres, :nres])
   maps = [pm.maps[j] for j in 2:3]
 
   br = base_ring(M)

--- a/src/Modules/UngradedModules/Presentation.jl
+++ b/src/Modules/UngradedModules/Presentation.jl
@@ -559,6 +559,50 @@ function prune_with_map(M::ModuleFP{T}) where {T<:MPolyRingElem{<:FieldElem}} # 
   return M_new, phi
 end
 
+function _presentation_minimal(M::ModuleFP{T}) where {T<:MPolyRingElem{<:FieldElem}}
+  R = base_ring(M)
+
+  # Prepare to set some names
+  br_name = AbstractAlgebra.get_name(R)
+  if br_name === nothing
+    br_name = "br"
+  end
+  
+  M_new, phi = prune_with_map(M)
+  F0 = ambient_free_module(M_new)
+
+  # M_new is a quotient of a free module
+  proj_map = hom(F0, M_new, gens(M_new), check=false)
+  F0_to_M = compose(proj_map, phi)
+  F0_to_M.generators_map_to_generators = true
+  AbstractAlgebra.set_name!(F0, "$br_name^$(ngens(M.sub))")
+
+  K, inc = sub(F0, relations(M_new))
+  F1 = if is_graded(M)
+    graded_free_module(R, degrees_of_generators(K))
+  else
+    free_module(R, ngens(K))
+  end
+  F1_to_F0 = compose(hom(F1, K, gens(K), check=false), inc)
+  AbstractAlgebra.set_name!(F1, "$br_name^$(ngens(F1))")
+
+  # When there is no kernel, clean things up
+  if is_zero(F1)
+    F1 = FreeMod(R, 0)
+    F1_to_F0 = hom(F1, F0, elem_type(F0)[]; check=false)
+  end
+  
+  # prepare the end of the presentation
+  Z = FreeMod(R, 0)
+  AbstractAlgebra.set_name!(Z, "0")
+  M_to_Z = hom(M, Z, elem_type(Z)[zero(Z) for i in 1:ngens(M)]; check=false)
+
+  # compile the presentation complex
+  CC = Hecke.ComplexOfMorphisms(ModuleFP, ModuleFPHom[F1_to_F0, F0_to_M, M_to_Z], check=false, seed = -2)
+  set_attribute!(CC, :show => Hecke.pres_show)
+  return CC
+end
+
 function prune_with_map(F::FreeMod)
   return F, hom(F, F, gens(F))
 end

--- a/src/Modules/UngradedModules/Presentation.jl
+++ b/src/Modules/UngradedModules/Presentation.jl
@@ -563,7 +563,8 @@ function prune_with_map(M::ModuleFP{T}) where {T<:MPolyRingElem{<:FieldElem}} # 
   return M_new, phi
 end
 
-function _presentation_minimal(SQ::ModuleFP{T}) where {T<:MPolyRingElem{<:FieldElem}}
+function _presentation_minimal(SQ::ModuleFP{T};
+                               minimal_kernel::Bool=true) where {T<:MPolyRingElem{<:FieldElem}}
   R = base_ring(SQ)
 
   # Prepare to set some names
@@ -581,7 +582,12 @@ function _presentation_minimal(SQ::ModuleFP{T}) where {T<:MPolyRingElem{<:FieldE
   F0_to_SQ.generators_map_to_generators = true
   AbstractAlgebra.set_name!(F0, "$br_name^$(ngens(F0))")
 
+  # if we want a minimal kernel too, we go to prune_with_map
   K, inc = sub(F0, relations(SQ_new))
+  if minimal_kernel
+    K, inc2 = prune_with_map(K)
+    inc = compose(inc2, inc)
+  end
   F1 = if is_graded(SQ)
     graded_free_module(R, degrees_of_generators(K))
   else

--- a/src/Modules/UngradedModules/Presentation.jl
+++ b/src/Modules/UngradedModules/Presentation.jl
@@ -579,7 +579,7 @@ function _presentation_minimal(SQ::ModuleFP{T}) where {T<:MPolyRingElem{<:FieldE
   proj_map = hom(F0, SQ_new, gens(SQ_new), check=false)
   F0_to_SQ = compose(proj_map, phi)
   F0_to_SQ.generators_map_to_generators = true
-  AbstractAlgebra.set_name!(F0, "$br_name^$(ngens(SQ.sub))")
+  AbstractAlgebra.set_name!(F0, "$br_name^$(ngens(F0))")
 
   K, inc = sub(F0, relations(SQ_new))
   F1 = if is_graded(SQ)

--- a/src/Modules/UngradedModules/Presentation.jl
+++ b/src/Modules/UngradedModules/Presentation.jl
@@ -10,7 +10,7 @@ function presentation(SQ::SubquoModule;
                       minimal=false)
   if minimal
     return _presentation_minimal(SQ)
-  if is_graded(SQ)
+  elseif is_graded(SQ)
     return _presentation_graded(SQ)
   else
     return _presentation_simple(SQ)

--- a/test/Modules/ModulesGraded.jl
+++ b/test/Modules/ModulesGraded.jl
@@ -339,6 +339,12 @@ end
     @test codomain(psi) == N
     @test is_bijective(phi)
     @test is_bijective(psi)
+  I = ideal(R, [x^2, x*y, y])
+  A, _ = quo(R, I)
+  M = quotient_ring_as_module(A)
+  mp = presentation(M, minimal = true)
+  @test rank(pm[0]) == 1
+  @test rank(pm[1]) == 2
 end
 
 

--- a/test/Modules/ModulesGraded.jl
+++ b/test/Modules/ModulesGraded.jl
@@ -339,8 +339,8 @@ end
     @test codomain(psi) == N
     @test is_bijective(phi)
     @test is_bijective(psi)
-  I = ideal(R, [x^2, x*y, y])
-  A, _ = quo(R, I)
+  I = ideal(Rg, [x^2, x*y, y])
+  A, _ = quo(Rg, I)
   M = quotient_ring_as_module(A)
   mp = presentation(M, minimal = true)
   @test rank(pm[0]) == 1

--- a/test/Modules/ModulesGraded.jl
+++ b/test/Modules/ModulesGraded.jl
@@ -343,8 +343,8 @@ end
   A, _ = quo(Rg, I)
   M = quotient_ring_as_module(A)
   mp = presentation(M, minimal = true)
-  @test rank(pm[0]) == 1
-  @test rank(pm[1]) == 2
+  @test rank(mp[0]) == 1
+  @test rank(mp[1]) == 2
 end
 
 


### PR DESCRIPTION
This PR will fix the `mres` and `nres` options in `free_resolution` using `prune_with_map`. Previously, using these options
might not return a minimal free resolution.

For using `prune_with_map` conveniently in `free_resolution`, I would like add a `minimal` keyword to `presentation`, if this is set to `true` we would return a minimal presentation, computed from the output of `prune_with_map`.

@wdecker Do we want a user-facing option to compute a minimal presentation? If not, then I will do this just internally.