### PR TITLE
Deprecate another weird getindex method

### DIFF
--- a/src/Modules/UngradedModules/FreeModuleHom.jl
+++ b/src/Modules/UngradedModules/FreeModuleHom.jl
@@ -383,7 +383,7 @@ function hom(F::FreeMod, G::FreeMod)
   R = base_ring(F)
   function im(x::FreeModElem)
     c = coordinates(x)
-    return hom(F, G, Vector{elem_type(G)}([FreeModElem(c[R, (i-1)*m+1:i*m], G) for i=1:n]), check=false)
+    return hom(F, G, Vector{elem_type(G)}([FreeModElem(c[(i-1)*m+1:i*m], G) for i=1:n]), check=false)
   end
   function pre(h::FreeModuleHom)
     s = sparse_row(F.R)

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -233,11 +233,7 @@ ring_map(f::SubQuoHom) = f.ring_map
 #  re-evaluate and use or not
 
 function getindex(r::Hecke.SRow, u::AbstractUnitRange)
-  return getindex(r, base_ring(r), u)
-end
-
-function getindex(r::Hecke.SRow, R::AbstractAlgebra.Ring, u::AbstractUnitRange)
-  s = sparse_row(R)
+  s = sparse_row(base_ring(r))
   shift = 1-first(u)
   for (p,v) = r
     if p in u

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -327,7 +327,7 @@ function hom_matrices_helper(f1::MatElem{T}, g1::MatElem{T}) where T
     end
     R = base_ring(M)
     c = coordinates(repres(v))
-    A = copy_and_reshape(dense_row(c[R, 1:s0*t0], s0*t0), s0, t0)
+    A = copy_and_reshape(dense_row(c[1:s0*t0], s0*t0), s0, t0)
     return A
   end
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -122,3 +122,9 @@ Base.@deprecate_binding StdSpec StdAffineScheme
 
 # deprecated for 1.1
 @deprecate morphism_of_projective_schemes morphism
+
+function Base.getindex(r::Hecke.SRow, R::AbstractAlgebra.Ring, u::AbstractUnitRange)
+  Base.depwarn("`getindex(::SRow, ::Ring, ::AbstractUnitRange)` is deprecated, use `getindex(::SRow, ::AbstractUnitRange)` instead.", :getindex)
+  @req base_ring(r) === R "Parent ring mismatch"
+  return getindex(r, u)
+end


### PR DESCRIPTION
x-ref https://github.com/oscar-system/Oscar.jl/pull/3697#pullrequestreview-2042645170

This time, I deprecated it instead of removing since it worked according to its semantics, and straight up removing it would be a breaking change. Let's wait for the `depwarn=error` CI job to see if I caught all callsites of this inside Oscar.