### PR TITLE
Revert "Disable a test in elliptic surfaces (#3698)"

### DIFF
--- a/test/AlgebraicGeometry/Schemes/elliptic_surface.jl
+++ b/test/AlgebraicGeometry/Schemes/elliptic_surface.jl
@@ -63,8 +63,6 @@
   trivial_lattice(X3)
   =#
 
-  #=
-  This testset is disabled (for now), see https://github.com/oscar-system/Oscar.jl/issues/3676
   @testset "elliptic parameter" begin
     k = GF(29)
     kt, _ = polynomial_ring(k, :t)
@@ -92,7 +90,6 @@
     @test det(algebraic_lattice(X)[3])==24
 
   end
-  =#
 end
 
 @testset "normalize_quartic and transform_to_weierstrass" begin


### PR DESCRIPTION
With #3672 merged, the test is now commented out twice. To avoid future confusion, I revert my commit.
