### PR TITLE
star_subdivision: refactor facet_signs to operate on oscar types

### DIFF
--- a/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
@@ -112,7 +112,7 @@ function star_subdivision(Sigma::_FanLikeType, new_ray::AbstractVector{<:Integer
   end
   mc_old = maximal_cones(IncidenceMatrix, Sigma)
 
-  facet_normals = pm_object(Sigma).FACET_NORMALS
+  facet_normals = matrix(QQ, pm_object(Sigma).FACET_NORMALS)
   refinable_cones = _get_maximal_cones_containing_vector(Sigma, new_ray)
   @req length(refinable_cones) > 0 "$new_ray not contained in support of fan."
   new_cones = _get_refinable_facets(Sigma, new_ray, refinable_cones, facet_normals, mc_old)
@@ -137,12 +137,12 @@ function _get_refinable_facets(
   Sigma::_FanLikeType,
   new_ray::AbstractVector{<:IntegerUnion},
   refinable_cones::Vector{Int},
-  facet_normals::AbstractMatrix,
+  facet_normals::MatElem,
   mc_old::IncidenceMatrix,
 )
   new_cones = Vector{Int}[]
   v_facet_signs = _facet_signs(facet_normals, new_ray)
-  R = pm_object(Sigma).RAYS
+  R = rays(Sigma)
   hd = pm_object(Sigma).HASSE_DIAGRAM
   hd_graph = Graph{Directed}(hd.ADJACENCY)
   hd_maximal_cones = inneighbors(hd_graph, hd.TOP_NODE + 1)
@@ -168,11 +168,11 @@ end
 
 function _get_refinable_facets_of_cone(
   mc_hd_index::Int,
-  facet_normals::AbstractMatrix,
+  facet_normals::MatElem,
   hd,
   hd_graph::Graph{Directed},
   v_facet_signs::AbstractVector,
-  R::AbstractMatrix,
+  R::AbstractVector{<:RayVector},
   mcfi::Vector{Int},
 )
   refinable_facets = Vector{Int}[]
@@ -182,7 +182,7 @@ function _get_refinable_facets_of_cone(
   for fc_index in inneighbors(hd_graph, mc_hd_index)
     fc_indices = Polymake.to_one_based_indexing(Polymake._get_entry(hd.FACES, fc_index - 1))
     length(fc_indices) > 0 || return refinable_facets # The only facet was 0
-    inner_ray = sum([R[i, :] for i in fc_indices])
+    inner_ray = sum([R[i] for i in fc_indices])
     fc_facet_signs = _facet_signs(facet_normals, inner_ray)
     if (!_check_containment_via_facet_signs(v_facet_signs[mcfi], fc_facet_signs[mcfi]))
       push!(refinable_facets, Vector{Int}(fc_indices))
@@ -191,11 +191,8 @@ function _get_refinable_facets_of_cone(
   return refinable_facets
 end
 
-# FIXME: Small workaround, since sign does not work for polymake types.
-_int_sign(e) = e > 0 ? 1 : (e < 0 ? -1 : 0)
-_facet_signs(F::AbstractMatrix, v::AbstractVector{<:IntegerUnion}) =
-  [_int_sign(e) for e in (F * Polymake.Vector{Polymake.Integer}(v))]
-_facet_signs(F::AbstractMatrix, v::AbstractVector) = [_int_sign(e) for e in (F * v)]
+_facet_signs(F::MatElem, v::AbstractVector) = sign.(Int, F * v)[:,1]
+
 function _check_containment_via_facet_signs(smaller::Vector{Int}, bigger::Vector{Int})
   for a in zip(smaller, bigger)
     p = prod(a)

--- a/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
@@ -191,7 +191,7 @@ function _get_refinable_facets_of_cone(
   return refinable_facets
 end
 
-_facet_signs(F::MatElem, v::AbstractVector) = sign.(Int, F * v)[:,1]
+_facet_signs(F::MatElem, v::AbstractVector) = sign.(Int, F * v)[:, 1]
 
 function _check_containment_via_facet_signs(smaller::Vector{Int}, bigger::Vector{Int})
   for a in zip(smaller, bigger)


### PR DESCRIPTION
To improve performance and avoid rare crashes:

I don't fully understand why the old code sometimes accesses already deleted `Polymake.Rational` numbers. They are created in the `F*v` multiplication but I don't see why these can be GCed and still be used for some assignment later on.


The crash usually looks like this
```
[28924] signal (11.128): Segmentation fault
in expression starting at REPL[18]:1
__gmpn_copyi_x86_64 at /home/lorenz/software/polymake/julia/julia/julia-1.10.3/bin/../lib/julia/libgmp.so.10 (unknown line)
Allocations: 540062742 (Pool: 540017641; Big: 45101); GC: 81
Segmentation fault
```
and for example appeared in the book tests (`specialized/bies-turner-string-theory-applications`), but also this one looks similar : https://github.com/oscar-system/Oscar.jl/actions/runs/9032323010/job/24820290639#step:9:336

I even got a similar crash while trying to benchmark the old and the new code. When it doesn't crash the old code runs like this:
```julia
julia> @benchmark _facet_signs(mp,new_ray)
BenchmarkTools.Trial: 8571 samples with 1 evaluation.
 Range (min … max):  278.723 μs … 731.682 ms  ┊ GC (min … max): 0.00% … 20.37%
 Time  (median):     324.794 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   591.597 μs ±  12.505 ms  ┊ GC (mean ± σ):  9.74% ±  0.48%

                           ▃█▃   ▅▂                              
  ▂▂▂▂▂▁▁▁▁▁▁▂▂▂▂▂▂▂▂▃▃▂▃▃▃███▅▄███▅▄▃▃▃▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  279 μs           Histogram: frequency by time          372 μs <

 Memory estimate: 89.72 KiB, allocs estimate: 9112.
```

And the new code:
```julia
julia> @benchmark _facet_signs(mo,new_ray_o)
BenchmarkTools.Trial: 10000 samples with 3 evaluations.
 Range (min … max):   8.470 μs … 65.220 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):      9.949 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   10.206 μs ±  2.345 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

         ▂▆██▇▄▂                                               
  ▂▂▂▂▃▅▆███████▇▅▄▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  8.47 μs         Histogram: frequency by time        16.7 μs <

 Memory estimate: 10.79 KiB, allocs estimate: 81.
```

This could fix some of the crashes in #3633.

cc: @lkastner 