### PR TITLE
TropicalGeometry: fixed det over tropical polynomials

### DIFF
--- a/src/TropicalGeometry/matrix.jl
+++ b/src/TropicalGeometry/matrix.jl
@@ -29,7 +29,7 @@ julia> det(A)
 (5)
 ```
 """
-function det(A::Generic.MatSpaceElem{<:TropicalSemiringElem})
+function det(A::Generic.MatSpaceElem{R}) where {R<:Union{TropicalSemiringElem,MPolyRingElem{<:TropicalSemiringElem},PolyRingElem{<:TropicalSemiringElem}}}
     detA = zero(base_ring(A))
     nrows(A)!=ncols(A) && return detA # return tropical zero if matrix not square
     for sigma in AbstractAlgebra.SymmetricGroup(nrows(A)) # otherwise follow Leibniz Formula
@@ -38,6 +38,6 @@ function det(A::Generic.MatSpaceElem{<:TropicalSemiringElem})
     return detA
 end
 
-function det(A::Matrix{TropicalSemiringElem{minOrMax}}) where {minOrMax<:Union{typeof(min),typeof(max)}}
+function det(A::Matrix{R}) where {R<:Union{TropicalSemiringElem,MPolyRingElem{<:TropicalSemiringElem},PolyRingElem{<:TropicalSemiringElem}}}
     return det(matrix(TropicalSemiring{minOrMax},A))
 end

--- a/src/TropicalGeometry/matrix.jl
+++ b/src/TropicalGeometry/matrix.jl
@@ -39,5 +39,5 @@ function det(A::Generic.MatSpaceElem{R}) where {R<:Union{TropicalSemiringElem,MP
 end
 
 function det(A::Matrix{R}) where {R<:Union{TropicalSemiringElem,MPolyRingElem{<:TropicalSemiringElem},PolyRingElem{<:TropicalSemiringElem}}}
-    return det(matrix(TropicalSemiring{minOrMax},A))
+    return det(matrix(parent(first(A)),A))
 end

--- a/test/TropicalGeometry/matrix.jl
+++ b/test/TropicalGeometry/matrix.jl
@@ -3,10 +3,10 @@
     for minOrMax in (min,max)
         T = tropical_semiring(minOrMax)
         @testset "det(A::Generic.MatSpaceElem{<:TropicalSemiringElem})" begin
-            A = matrix(T,[1 2; 3 5]) # matrix over tropical numbers
+            A = Matrix(T[1 2; 3 5]) # (julia) matrix over tropical numbers
             @test det(A) == (minOrMax==min ? T(5) : T(6))
             R, (x,y) = T[:x,:y]
-            A = identity_matrix(R,2) # matrix over tropical polynomials
+            A = identity_matrix(R,2) # (Oscar) matrix over tropical polynomials
             @test det(A) == one(R)
         end
     end

--- a/test/TropicalGeometry/matrix.jl
+++ b/test/TropicalGeometry/matrix.jl
@@ -6,7 +6,7 @@
             A = Matrix(T[1 2; 3 5]) # (julia) matrix over tropical numbers
             @test det(A) == (minOrMax==min ? T(5) : T(6))
             R, (x,y) = T[:x,:y]
-            A = identity_matrix(R,2) # (Oscar) matrix over tropical polynomials
+            A = Matrix(identity_matrix(R,2)) # (julia) matrix over tropical polynomials
             @test det(A) == one(R)
         end
     end

--- a/test/TropicalGeometry/matrix.jl
+++ b/test/TropicalGeometry/matrix.jl
@@ -3,8 +3,11 @@
     for minOrMax in (min,max)
         T = tropical_semiring(minOrMax)
         @testset "det(A::Generic.MatSpaceElem{<:TropicalSemiringElem})" begin
-            A = matrix(T,[1 2; 3 5])
+            A = matrix(T,[1 2; 3 5]) # matrix over tropical numbers
             @test det(A) == (minOrMax==min ? T(5) : T(6))
+            R, (x,y) = T[:x,:y]
+            A = identity_matrix(R,2) # matrix over tropical polynomials
+            @test det(A) == one(R)
         end
     end
 


### PR DESCRIPTION
Fixes https://github.com/oscar-system/Oscar.jl/issues/3714.  Is there any better way than writing
```
function det(A::Generic.MatSpaceElem{R}) where {R<:Union{TropicalSemiringElem,MPolyRingElem{<:TropicalSemiringElem},PolyRingElem{<:TropicalSemiringElem}}}
```