### PR TITLE
[FTheoryTools] Allow tuning sections to zero

### DIFF
--- a/experimental/FTheoryTools/src/HypersurfaceModels/methods.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/methods.jl
@@ -30,6 +30,11 @@ end
     function tune(h::HypersurfaceModel, input_sections::Dict{String, <:Any}; completeness_check::Bool = true)
 
 Tune a hypersurface model by fixing a special choice for the model sections.
+Note that it is in particular possible to set a section to zero. We anticipate
+that people might want to be able to come back from this by assigning a non-trivial
+value to a section that was previously tuned to zero. This is why we keep such
+trivial sections and do not delete them, say from `explicit_model_sections`
+or `classes_of_model_sections`.
 
 # Examples
 ```jldoctest
@@ -50,13 +55,47 @@ julia> x1, x2, x3 = gens(cox_ring(base_space(h)))
  x2
  x3
 
-julia> my_choice = Dict("b" => x2, "c0" => x1^10)
+julia> my_choice = Dict("b" => x2, "c0" => zero(parent(x1)))
+Dict{String, MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}} with 2 entries:
+  "b"  => x2
+  "c0" => 0
+
+julia> tuned_h = tune(h, my_choice)
+Hypersurface model over a concrete base
+
+julia> x1, x2, x3 = gens(cox_ring(base_space(tuned_h)))
+3-element Vector{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}:
+ x1
+ x2
+ x3
+
+julia> my_choice2 = Dict("b" => x2, "c0" => zero(parent(x1)))
+Dict{String, MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}} with 2 entries:
+  "b"  => x2
+  "c0" => 0
+
+julia> tuned_h2 = tune(tuned_h, my_choice2)
+Hypersurface model over a concrete base
+
+julia> is_zero(explicit_model_sections(tuned_h2)["c0"])
+true
+
+julia> x1, x2, x3 = gens(cox_ring(base_space(tuned_h2)))
+3-element Vector{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}:
+ x1
+ x2
+ x3
+
+julia> my_choice3 = Dict("b" => x2, "c0" => x1^10)
 Dict{String, MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}} with 2 entries:
   "b"  => x2
   "c0" => x1^10
 
-julia> tuned_h = tune(h, my_choice)
+julia> tuned_h3 = tune(tuned_h2, my_choice3)
 Hypersurface model over a concrete base
+
+julia> is_zero(explicit_model_sections(tuned_h3)["c0"])
+false
 ```
 """
 function tune(h::HypersurfaceModel, input_sections::Dict{String, <:Any}; completeness_check::Bool = true)
@@ -71,9 +110,10 @@ function tune(h::HypersurfaceModel, input_sections::Dict{String, <:Any}; complet
   explicit_secs = deepcopy(explicit_model_sections(h))
   for x in tuned_secs_names
     section_parent = parent(input_sections[x])
-    section_degree = degree(input_sections[x])
     @req section_parent == parent(explicit_model_sections(h)[x]) "Parent mismatch between given and existing model section"
-    @req section_degree == degree(explicit_model_sections(h)[x]) "Degree mismatch between given and existing model section"
+    if is_zero(input_sections[x]) == false
+      @req degree(input_sections[x]) == divisor_class(classes_of_model_sections(h)[x]) "Degree mismatch between given and existing model section"
+    end
     explicit_secs[x] = input_sections[x]
   end
   
@@ -89,5 +129,16 @@ function tune(h::HypersurfaceModel, input_sections::Dict{String, <:Any}; complet
   # 3. Build the new model
   model = HypersurfaceModel(explicit_secs, parametrized_hypersurface_equation, new_hypersurface_equation, base_space(h), ambient_space(h), fiber_ambient_space(h))
   set_attribute!(model, :partially_resolved, false)
+
+  # 4. Copy the classes of model sections, but only of those sections that are used!
+  new_classes_of_model_sections = Dict{String, ToricDivisorClass}()
+  for key in keys(explicit_model_sections(model))
+    m = divisor_class(classes_of_model_sections(h)[key]).coeff
+    @req nrows(m) == 1 "Encountered inconsistency"
+    new_classes_of_model_sections[key] = toric_divisor_class(base_space(model), m[1, :])
+  end
+  set_attribute!(model, :classes_of_model_sections => new_classes_of_model_sections)
+
+  # 5. Return the model
   return model
 end


### PR DESCRIPTION
@emikelsons and I uncovered that one cannot currently tune sections to zero. This PR should fix this.

Important: I am *not* removing such a trivial section from the model, nor do I purge it from the parametrization of the defining sections (f,g for Weierstrass and ai for Tate) or the parametrization of Weierstrass/Tate/hypersurface equation. As of right now, I believe this to be a feature rather than a bug: You can recover the original model by setting that trivial section to a non-trivial value. If you disagree and want trivial sections purged, then this can of course be adjusted.

cc @apturner @emikelsons 