### PR TITLE
replace `GAP.GapObj` by `GapObj`

### DIFF
--- a/experimental/GModule/Cohomology.jl
+++ b/experimental/GModule/Cohomology.jl
@@ -1750,7 +1750,7 @@ end
 ###########################################################
 
 #=
-function get_collector(G::GAP.GapObj)
+function get_collector(G::GapObj)
   @show G
   return GAP.evalstr("x -> FamilyObj(x.1)!.rewritingSystem")(G)
 end
@@ -1836,7 +1836,7 @@ function pc_group_with_isomorphism(M::FinGenAbGroup; refine::Bool = true)
     return GAP.Globals.ObjByExtRep(FB, GAP.Obj(r, recursive = true))
   end
 
-  gap_to_julia = function(a::GAP.GapObj)
+  gap_to_julia = function(a::GapObj)
     e = GAPWrap.ExtRepOfObj(a)
     z = zeros(ZZRingElem, ngens(M))
     for i=1:2:length(e)
@@ -1905,7 +1905,7 @@ function pc_group_with_isomorphism(M::AbstractAlgebra.FPModule{<:FinFieldElem}; 
   end
 
 
-  gap_to_julia = function(a::GAP.GapObj)
+  gap_to_julia = function(a::GapObj)
     e = GAPWrap.ExtRepOfObj(a)
     z = zeros(ZZRingElem, ngens(M)*degree(k))
     for i=1:2:length(e)

--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -477,7 +477,7 @@ end
 ###############################################################################
 
 @doc raw"""
-    lie_algebra(gapL::GAP.GapObj, s::Vector{<:VarName}; cached::Bool) -> LieAlgebra{elem_type(R)}
+    lie_algebra(gapL::GapObj, s::Vector{<:VarName}; cached::Bool) -> LieAlgebra{elem_type(R)}
 
 Construct a Lie algebra isomorphic to the GAP Lie algebra `gapL`. Its basis element are named by `s`,
 or by `x_i` by default.
@@ -487,7 +487,7 @@ properties of `gapL`, in particular, whether GAP knows about a matrix representa
 If `cached` is `true`, the constructed Lie algebra is cached.
 """
 function lie_algebra(
-  gapL::GAP.GapObj,
+  gapL::GapObj,
   s::Vector{<:VarName}=[Symbol("x_$i") for i in 1:GAPWrap.Dimension(gapL)];
   cached::Bool=true,
 )

--- a/experimental/LieAlgebras/src/iso_gap_oscar.jl
+++ b/experimental/LieAlgebras/src/iso_gap_oscar.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-function _iso_gap_oscar_lie_algebra(F::GAP.GapObj)
+function _iso_gap_oscar_lie_algebra(F::GapObj)
   if GAPWrap.IsFiniteDimensional(F)
     if GAPWrap.IsLieObjectCollection(F)
       return _iso_gap_oscar_linear_lie_algebra(F)
@@ -19,9 +19,9 @@ end
 push!(Oscar._iso_gap_oscar_methods, "IsLieAlgebra" => _iso_gap_oscar_lie_algebra)
 
 function _iso_gap_oscar_abstract_lie_algebra(
-  LG::GAP.GapObj,
+  LG::GapObj,
   s::Vector{<:VarName}=[Symbol("x_$i") for i in 1:GAPWrap.Dimension(LG)];
-  coeffs_iso::Map{GAP.GapObj}=Oscar.iso_gap_oscar(GAPWrap.LeftActingDomain(LG)),
+  coeffs_iso::Map{GapObj}=Oscar.iso_gap_oscar(GAPWrap.LeftActingDomain(LG)),
   cached::Bool=true,
 )
   LO = _abstract_lie_algebra_from_GAP(LG, coeffs_iso, s; cached)
@@ -33,9 +33,9 @@ function _iso_gap_oscar_abstract_lie_algebra(
 end
 
 function _iso_gap_oscar_linear_lie_algebra(
-  LG::GAP.GapObj,
+  LG::GapObj,
   s::Vector{<:VarName}=[Symbol("x_$i") for i in 1:GAPWrap.Dimension(LG)];
-  coeffs_iso::Map{GAP.GapObj}=Oscar.iso_gap_oscar(GAPWrap.LeftActingDomain(LG)),
+  coeffs_iso::Map{GapObj}=Oscar.iso_gap_oscar(GAPWrap.LeftActingDomain(LG)),
   cached::Bool=true,
 )
   LO = _linear_lie_algebra_from_GAP(LG, coeffs_iso, s; cached)
@@ -47,7 +47,7 @@ function _iso_gap_oscar_linear_lie_algebra(
 end
 
 function _abstract_lie_algebra_from_GAP(
-  LG::GAP.GapObj, coeffs_iso::Map{GAP.GapObj}, s::Vector{<:VarName}; cached::Bool=true
+  LG::GapObj, coeffs_iso::Map{GapObj}, s::Vector{<:VarName}; cached::Bool=true
 )
   RO = codomain(coeffs_iso)
   dimL = GAPWrap.Dimension(LG)
@@ -72,7 +72,7 @@ function _abstract_lie_algebra_from_GAP(
 end
 
 function _linear_lie_algebra_from_GAP(
-  LG::GAP.GapObj, coeffs_iso::Map{GAP.GapObj}, s::Vector{<:VarName}; cached::Bool=true
+  LG::GapObj, coeffs_iso::Map{GapObj}, s::Vector{<:VarName}; cached::Bool=true
 )
   @req GAPWrap.IsLieObjectCollection(LG) "Input is not a linear Lie algebra."
 

--- a/experimental/LieAlgebras/src/iso_oscar_gap.jl
+++ b/experimental/LieAlgebras/src/iso_oscar_gap.jl
@@ -5,7 +5,7 @@
 ###############################################################################
 
 function _iso_oscar_gap_lie_algebra_functions(
-  LO::LieAlgebra{C}, LG::GAP.GapObj, coeffs_iso::MapFromFunc
+  LO::LieAlgebra{C}, LG::GapObj, coeffs_iso::MapFromFunc
 ) where {C<:FieldElem}
   basis_LG = GAPWrap.Basis(LG)
 

--- a/experimental/MatrixGroups/src/MatrixGroups.jl
+++ b/experimental/MatrixGroups/src/MatrixGroups.jl
@@ -10,7 +10,7 @@ export _wrap_for_gap
 # Initialize GAP function, i.e. GAP reads the file matrix.g
 #
 function __init__()
-    GAP.Globals.Read(GAP.GapObj(joinpath(@__DIR__, "matrix.g")))
+    GAP.Globals.Read(GapObj(joinpath(@__DIR__, "matrix.g")))
 end
 
 ################################################################################

--- a/experimental/SymmetricIntersections/src/representations.jl
+++ b/experimental/SymmetricIntersections/src/representations.jl
@@ -502,12 +502,12 @@ function irreducible_affording_representation(RR::RepRing{S, T}, chi::Oscar.GAPG
   H = generators_underlying_group(RR)
 
   # the GAP function which we rely on
-  rep = GG.IrreducibleAffordingRepresentation(GapObj(chi))::GAP.GapObj
+  rep = GG.IrreducibleAffordingRepresentation(GapObj(chi))::GapObj
 
   # we compute certain images than we will convert then.
   # we use them then to construct the mapping in
   # `_linear_representation`
-  _Mat = GAP.GapObj[GG.Image(rep, h.X) for h in H]
+  _Mat = GapObj[GG.Image(rep, h.X) for h in H]
   Mat = AbstractAlgebra.Generic.MatSpaceElem{elem_type(F)}[]
   for _M in _Mat
     rM = eltype(Mat)[transpose(matrix(F.(m))) for m in _M]
@@ -1060,15 +1060,15 @@ end
 function _has_pfr(G::Oscar.GAPGroup, dim::Int)
   # we start by computing a Schur cover and we turn it into an Oscar object
   G_gap = G.X
-  f_gap = GG.EpimorphismSchurCover(G_gap)::GAP.GapObj
-  H_gap = GG.Source(f_gap)::GAP.GapObj
+  f_gap = GG.EpimorphismSchurCover(G_gap)::GapObj
+  H_gap = GG.Source(f_gap)::GapObj
   n, p = is_power(GG.Size(H_gap))::Tuple{Int, Int}
   if is_prime(p)
-    fff_gap = GG.EpimorphismPGroup(H_gap, p)::GAP.GapObj
-    E_gap = fff_gap(H_gap)::GAP.GapObj
+    fff_gap = GG.EpimorphismPGroup(H_gap, p)::GapObj
+    E_gap = fff_gap(H_gap)::GapObj
   else
-    fff_gap = GG.IsomorphismPermGroup(H_gap)::GAP.GapObj
-    E_gap = fff_gap(H_gap)::GAP.GapObj
+    fff_gap = GG.IsomorphismPermGroup(H_gap)::GapObj
+    E_gap = fff_gap(H_gap)::GapObj
   end
   E = Oscar._oscar_group(E_gap)
   H = Oscar._oscar_group(H_gap)

--- a/src/GAP/customize.jl
+++ b/src/GAP/customize.jl
@@ -2,12 +2,12 @@
 # when GAP is used by Oscar.
 # More generally, `GAP_info_messages_off` can set all info levels either
 # to zero or to those values that were valid when Oscar was started.
-const __GAP_info_levels_default = Pair{GAP.GapObj, Int}[]
+const __GAP_info_levels_default = Pair{GapObj, Int}[]
 
 function __GAP_info_messages_off(off::Bool = true)
   if length(__GAP_info_levels_default) == 0
     # Initialize the info about default levels.
-    for c in Vector{GAP.GapObj}(GAP.Globals.INFO_CLASSES)
+    for c in Vector{GapObj}(GAP.Globals.INFO_CLASSES)
       push!(__GAP_info_levels_default, c => GAP.Globals.InfoLevel(c))
     end
   end

--- a/src/GAP/gap_to_oscar.jl
+++ b/src/GAP/gap_to_oscar.jl
@@ -162,7 +162,7 @@ end
 
 GAP.gap_to_julia(::Type{QQAbElem}, a::GapInt) = QQAbElem(a)
 
-(::QQAbField)(a::GAP.GapObj) = GAP.gap_to_julia(QQAbElem, a)
+(::QQAbField)(a::GapObj) = GAP.gap_to_julia(QQAbElem, a)
 
 ## nonempty list of GAP matrices over a given cyclotomic field
 function matrices_over_cyclotomic_field(F::AbsSimpleNumField, gapmats::GapObj)

--- a/src/GAP/iso_gap_oscar.jl
+++ b/src/GAP/iso_gap_oscar.jl
@@ -29,7 +29,7 @@ end
 #
 ################################################################################
 
-function _iso_gap_oscar_field_of_cyclotomics(F::GAP.GapObj)
+function _iso_gap_oscar_field_of_cyclotomics(F::GapObj)
    GAPWrap.IsCyclotomicField(F) && return _iso_gap_oscar_field_cyclotomic(F)
    F === GAP.Globals.Cyclotomics && return _iso_gap_oscar_abelian_closure(F)
    GAPWrap.DegreeOverPrimeField(F) == 2 && return _iso_gap_oscar_field_quadratic(F)
@@ -37,9 +37,9 @@ function _iso_gap_oscar_field_of_cyclotomics(F::GAP.GapObj)
    error("no method found")
 end
 
-function _iso_gap_oscar_residue_ring(RG::GAP.GapObj)
+function _iso_gap_oscar_residue_ring(RG::GapObj)
    n = GAPWrap.Size(RG)
-   if n isa GAP.GapObj
+   if n isa GapObj
      n = ZZRingElem(n)
    end
    RO = residue_ring(ZZ, n)[1]
@@ -49,7 +49,7 @@ function _iso_gap_oscar_residue_ring(RG::GAP.GapObj)
    return MapFromFunc(RG, RO, f, finv)
 end
 
-function _iso_gap_oscar_field_finite(FG::GAP.GapObj)
+function _iso_gap_oscar_field_finite(FG::GapObj)
    FO = GF(characteristic(FG), GAPWrap.DegreeOverPrimeField(FG))
 
    finv, f = _iso_oscar_gap_field_finite_functions(FO, FG)
@@ -57,28 +57,28 @@ function _iso_gap_oscar_field_finite(FG::GAP.GapObj)
    return MapFromFunc(FG, FO, f, finv)
 end
 
-function _iso_gap_oscar_field_rationals(FG::GAP.GapObj)
+function _iso_gap_oscar_field_rationals(FG::GapObj)
    FO = QQ
    finv, f = _iso_oscar_gap_field_rationals_functions(FO, FG)
 
    return MapFromFunc(FG, FO, f, finv)
 end
 
-function _iso_gap_oscar_ring_integers(FG::GAP.GapObj)
+function _iso_gap_oscar_ring_integers(FG::GapObj)
    FO = ZZ
    finv, f = _iso_oscar_gap_ring_integers_functions(FO, FG)
 
    return MapFromFunc(FG, FO, f, finv)
 end
 
-function _iso_gap_oscar_field_cyclotomic(FG::GAP.GapObj)
+function _iso_gap_oscar_field_cyclotomic(FG::GapObj)
    FO = cyclotomic_field(GAPWrap.Conductor(FG))[1]
    finv, f = _iso_oscar_gap_field_cyclotomic_functions(FO, FG)
 
    return MapFromFunc(FG, FO, f, finv)
 end
 
-function _iso_gap_oscar_field_quadratic(FG::GAP.GapObj)
+function _iso_gap_oscar_field_quadratic(FG::GapObj)
    if GAPWrap.IsCyclotomicCollection(FG)
      # Determine the root that is contained in `FG`.
      N = GAPWrap.Conductor(FG)
@@ -127,7 +127,7 @@ function _iso_gap_oscar_number_field(FG::GapObj)
      B = GAPWrap.Basis(FG, powers)
 
      finv = function(x::Nemo.AbsSimpleNumFieldElem)
-        coeffs = GAP.GapObj(coefficients(x), recursive = true)::GapObj
+        coeffs = GapObj(coefficients(x), recursive = true)::GapObj
         return (coeffs * powers)::GAP.Obj
      end
 
@@ -145,7 +145,7 @@ function _iso_gap_oscar_number_field(FG::GapObj)
      fam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(FG))
 
      finv = function(x::Nemo.AbsSimpleNumFieldElem)
-        coeffs = GAP.GapObj(coefficients(x), recursive = true)::GapObj
+        coeffs = GapObj(coefficients(x), recursive = true)::GapObj
         return GAPWrap.ObjByExtRep(fam, coeffs)
      end
 
@@ -184,7 +184,7 @@ function _iso_gap_oscar_number_field(FG::GapObj)
      Mpowers = GapObj(Mpowers)
 
      finv = function(x::Nemo.AbsSimpleNumFieldElem)
-        coeffs = GAP.GapObj(coefficients(x), recursive = true)::GapObj
+        coeffs = GapObj(coefficients(x), recursive = true)::GapObj
         return GAPWrap.LinearCombination(coeffs, Mpowers)
      end
 
@@ -200,14 +200,14 @@ function _iso_gap_oscar_number_field(FG::GapObj)
    return MapFromFunc(FG, FO, f, finv)
 end
 
-function _iso_gap_oscar_abelian_closure(FG::GAP.GapObj)
+function _iso_gap_oscar_abelian_closure(FG::GapObj)
    FO, _ = abelian_closure(QQ)
    finv, f = _iso_oscar_gap_abelian_closure_functions(FO, FG)
 
    return MapFromFunc(FG, FO, f, finv)
 end
 
-function _iso_gap_oscar_univariate_polynomial_ring(RG::GAP.GapObj)
+function _iso_gap_oscar_univariate_polynomial_ring(RG::GapObj)
    coeffs_iso = iso_gap_oscar(GAPWrap.LeftActingDomain(RG))
    RO, x = polynomial_ring(codomain(coeffs_iso), "x", cached = false)
    finv, f = _iso_oscar_gap_polynomial_ring_functions(RO, RG, inv(coeffs_iso))
@@ -215,7 +215,7 @@ function _iso_gap_oscar_univariate_polynomial_ring(RG::GAP.GapObj)
    return MapFromFunc(RG, RO, f, finv)
 end
 
-function _iso_gap_oscar_multivariate_polynomial_ring(RG::GAP.GapObj)
+function _iso_gap_oscar_multivariate_polynomial_ring(RG::GapObj)
    coeffs_iso = iso_gap_oscar(GAPWrap.LeftActingDomain(RG))
    nams = [string(x) for x in GAPWrap.IndeterminatesOfPolynomialRing(RG)]
    RO, x = polynomial_ring(codomain(coeffs_iso), nams, cached = false)
@@ -226,7 +226,7 @@ end
 
 
 """
-    Oscar.iso_gap_oscar(R) -> Map{GAP.GapObj, T}
+    Oscar.iso_gap_oscar(R) -> Map{GapObj, T}
 
 Return an isomorphism `f` with `domain` the GAP object `R`
 and `codomain` an Oscar object `S`.
@@ -297,7 +297,7 @@ true
     but that the codomain of this map is not identical with
     or even not equal to the given `R`.
 """
-iso_gap_oscar(F::GAP.GapObj) = GAP.Globals.IsoGapOscar(F)
+iso_gap_oscar(F::GapObj) = GAP.Globals.IsoGapOscar(F)
 
 
 # Compute the isomorphism between a GAP domain

--- a/src/GAP/iso_oscar_gap.jl
+++ b/src/GAP/iso_oscar_gap.jl
@@ -32,7 +32,7 @@ end
 
 # Assume that `RO` and `RG` are residue rings of the same size
 # in Oscar and GAP, respectively.
-function _iso_oscar_gap_residue_ring_functions(RO::Union{Nemo.zzModRing, Nemo.ZZModRing}, RG::GAP.GapObj)
+function _iso_oscar_gap_residue_ring_functions(RO::Union{Nemo.zzModRing, Nemo.ZZModRing}, RG::GapObj)
    e = GAPWrap.One(RG)
    f(x) = GAP.Obj(lift(x))*e
 
@@ -78,11 +78,11 @@ end
 
 # Assume that `FO` and `FG` are finite fields of the same order
 # in Oscar and GAP, respectively.
-function _iso_oscar_gap_field_finite_functions(FO::Union{Nemo.fpField, Nemo.FpField}, FG::GAP.GapObj)
+function _iso_oscar_gap_field_finite_functions(FO::Union{Nemo.fpField, Nemo.FpField}, FG::GapObj)
    return _make_prime_field_functions(FO, FG)
 end
 
-function _iso_oscar_gap_field_finite_functions(FO::Union{FqPolyRepField, FqField, fqPolyRepField}, FG::GAP.GapObj)
+function _iso_oscar_gap_field_finite_functions(FO::Union{FqPolyRepField, FqField, fqPolyRepField}, FG::GapObj)
    p = characteristic(FO)
    d = degree(FO)
 
@@ -201,7 +201,7 @@ function _iso_oscar_gap(FO::FinField)
 
      e = one(GAPWrap.Z(p))
      fam = GAPWrap.FamilyObj(e)
-     coeffsFG = GAP.GapObj([GAP.Obj(lift(x))*e for x in coeffsFO])
+     coeffsFG = GapObj([GAP.Obj(lift(x))*e for x in coeffsFO])
      polFG = GAPWrap.UnivariatePolynomialByCoefficients(fam, coeffsFG, 1)
      FG = GAPWrap.GF(p, polFG)
    end
@@ -240,14 +240,14 @@ end
 # Assume that `FO` and `FG` are cyclotomic fields with the same conductor
 # in Oscar and GAP, respectively.
 # (Cyclotomic fields are easier to handle than general number fields.)
-function _iso_oscar_gap_field_cyclotomic_functions(FO::AbsSimpleNumField, FG::GAP.GapObj)
+function _iso_oscar_gap_field_cyclotomic_functions(FO::AbsSimpleNumField, FG::GapObj)
    N = conductor(FO)
    cycpol = GAPWrap.CyclotomicPol(N)
    dim = length(cycpol)-1
 
    f = function(x::Nemo.AbsSimpleNumFieldElem)
       coeffs = [Nemo.coeff(x, i) for i in 0:(N-1)]
-      return GAPWrap.CycList(GAP.GapObj(coeffs; recursive=true))
+      return GAPWrap.CycList(GapObj(coeffs; recursive=true))
    end
 
    finv = function(x)
@@ -268,7 +268,7 @@ end
 # Assume that `FO` and `FG` are quadratic fields with the same square root
 # in Oscar and GAP, respectively.
 # (Quadratic fields are easier to handle than general number fields.)
-function _iso_oscar_gap_field_quadratic_functions(FO::AbsSimpleNumField, FG::GAP.GapObj)
+function _iso_oscar_gap_field_quadratic_functions(FO::AbsSimpleNumField, FG::GapObj)
    flag, N = Hecke.is_quadratic_type(FO)
    @assert flag
 
@@ -310,13 +310,13 @@ function _iso_oscar_gap(FO::SimpleNumField{QQFieldElem})
      polFO = defining_polynomial(FO)
      coeffs_polFO = collect(coefficients(polFO))
      fam = GAP.Globals.CyclotomicsFamily::GapObj
-     cfs = GAP.GapObj(coeffs_polFO, recursive = true)::GapObj
+     cfs = GapObj(coeffs_polFO, recursive = true)::GapObj
      polFG = GAPWrap.UnivariatePolynomialByCoefficients(fam, cfs, 1)
      FG = GAPWrap.AlgebraicExtension(GAP.Globals.Rationals::GapObj, polFG)
      fam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(FG))
 
      f = function(x::SimpleNumFieldElem{QQFieldElem})
-        coeffs = GAP.GapObj(coefficients(x), recursive = true)::GapObj
+        coeffs = GapObj(coefficients(x), recursive = true)::GapObj
         return GAPWrap.AlgExtElm(fam, coeffs)
      end
 
@@ -338,13 +338,13 @@ function _iso_oscar_gap(FO::SimpleNumField{T}) where T <: FieldElem
    polFO = defining_polynomial(FO)
    coeffs_polFO = collect(coefficients(polFO))
    fam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(BG))
-   cfs = GAP.GapObj([isoB(x) for x in coeffs_polFO])::GapObj
+   cfs = GapObj([isoB(x) for x in coeffs_polFO])::GapObj
    polFG = GAPWrap.UnivariatePolynomialByCoefficients(fam, cfs, 1)
    FG = GAPWrap.AlgebraicExtension(BG, polFG)
    fam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(FG))
 
    f = function(x::SimpleNumFieldElem{T})
-      coeffs = GAP.GapObj([isoB(x) for x in coefficients(x)])::GapObj
+      coeffs = GapObj([isoB(x) for x in coefficients(x)])::GapObj
       return GAPWrap.AlgExtElm(fam, coeffs)
    end
 
@@ -371,7 +371,7 @@ function _iso_oscar_gap(FO::NumField)
    isoB = iso_oscar_gap(B)
 
    f = function(x::NumFieldElem)
-      coeffs = GAP.GapObj([isoB(x) for x in coefficients(preimage(emb, x))])::GapObj
+      coeffs = GapObj([isoB(x) for x in coefficients(preimage(emb, x))])::GapObj
       return GAPWrap.AlgExtElm(fam, coeffs)
    end
 
@@ -392,7 +392,7 @@ end
 
 
 # Assume that `FO` is a `QQAbField` and `FG` is `GAP.Globals.Cyclotomics`.
-function _iso_oscar_gap_abelian_closure_functions(FO::QQAbField, FG::GAP.GapObj)
+function _iso_oscar_gap_abelian_closure_functions(FO::QQAbField, FG::GapObj)
    return (GAP.julia_to_gap, QQAbElem)
 end
 
@@ -404,7 +404,7 @@ function _iso_oscar_gap(FO::QQAbField)
 end
 
 """
-    Oscar.iso_oscar_gap(R) -> Map{T, GAP.GapObj}
+    Oscar.iso_oscar_gap(R) -> Map{T, GapObj}
 
 Return an isomorphism `f` with domain `R`
 and `codomain` a GAP object `S`.
@@ -492,13 +492,13 @@ end
 #
 # Univariate polynomial rings
 #
-function _iso_oscar_gap_polynomial_ring_functions(RO::PolyRing{T}, RG::GAP.GapObj, coeffs_iso::MapFromFunc) where T
+function _iso_oscar_gap_polynomial_ring_functions(RO::PolyRing{T}, RG::GapObj, coeffs_iso::MapFromFunc) where T
    fam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(codomain(coeffs_iso)))
    ind = GAPWrap.IndeterminateNumberOfUnivariateRationalFunction(
            GAPWrap.IndeterminatesOfPolynomialRing(RG)[1])
 
    f = function(x::PolyRingElem{T})
-      cfs = GAP.GapObj([coeffs_iso(x) for x in coefficients(x)])
+      cfs = GapObj([coeffs_iso(x) for x in coefficients(x)])
       return GAPWrap.UnivariatePolynomialByCoefficients(fam, cfs, ind)
    end
 
@@ -525,7 +525,7 @@ end
 #
 # Multivariate polynomial rings
 #
-function _iso_oscar_gap_polynomial_ring_functions(RO::MPolyRing{T}, RG::GAP.GapObj, coeffs_iso::MapFromFunc) where T
+function _iso_oscar_gap_polynomial_ring_functions(RO::MPolyRing{T}, RG::GapObj, coeffs_iso::MapFromFunc) where T
    fam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(RG))
    n = nvars(RO)
    indets = GAPWrap.IndeterminatesOfPolynomialRing(RG)
@@ -541,10 +541,10 @@ function _iso_oscar_gap_polynomial_ring_functions(RO::MPolyRing{T}, RG::GAP.GapO
             append!(v, [i, l[i]])
           end
         end
-        push!(extrep, GAP.GapObj(v))
+        push!(extrep, GapObj(v))
         push!(extrep, coeffs_iso(c))
       end
-      return GAPWrap.PolynomialByExtRep(fam, GAP.GapObj(extrep))
+      return GAPWrap.PolynomialByExtRep(fam, GapObj(extrep))
    end
 
    finv = function(x)

--- a/src/GAP/oscar_to_gap.jl
+++ b/src/GAP/oscar_to_gap.jl
@@ -37,7 +37,7 @@ end
 ## `QQAbElem` to GAP cyclotomic
 function GAP.julia_to_gap(elm::QQAbElem)
     coeffs = [Nemo.coeff(elm.data, i) for i in 0:(elm.c-1)]  # QQFieldElem
-    return GAPWrap.CycList(GAP.GapObj(coeffs; recursive=true))
+    return GAPWrap.CycList(GapObj(coeffs; recursive=true))
 end
 
 ## matrix of elements of cyclotomic field to GAP matrix of cyclotomics

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -31,7 +31,7 @@ The following ones are commonly used.
 ##  common actions of group elements
 ##
 ##  The idea is to delegate the action of `GAPGroupElem` objects
-##  on `GAP.GapObj` objects to the corresponding GAP action,
+##  on `GapObj` objects to the corresponding GAP action,
 ##  and to implement the action on native Julia objects case by case.
 
 """
@@ -66,7 +66,7 @@ GAP: [ Z(3)^0, 0*Z(3) ]
 
 
 """
-    on_tuples(tuple::GAP.GapObj, x::GAPGroupElem)
+    on_tuples(tuple::GapObj, x::GAPGroupElem)
     on_tuples(tuple::Vector, x::GAPGroupElem)
     on_tuples(tuple::T, x::GAPGroupElem) where T <: Tuple
 
@@ -81,7 +81,7 @@ one can also call `^` instead of `on_tuples`.
 julia> g = symmetric_group(3);  g[1]
 (1,2,3)
 
-julia> l = GAP.GapObj([1, 2, 4])
+julia> l = GapObj([1, 2, 4])
 GAP: [ 1, 2, 4 ]
 
 julia> on_tuples(l, g[1])
@@ -110,7 +110,7 @@ on_tuples(tuple::T, x::GAPGroupElem) where T <: Tuple = T(pnt^x for pnt in tuple
 
 
 """
-    on_sets(set::GAP.GapObj, x::GAPGroupElem)
+    on_sets(set::GapObj, x::GAPGroupElem)
     on_sets(set::Vector, x::GAPGroupElem)
     on_sets(set::Tuple, x::GAPGroupElem)
     on_sets(set::AbstractSet, x::GAPGroupElem)
@@ -127,7 +127,7 @@ For `Set` objects, one can also call `^` instead of `on_sets`.
 julia> g = symmetric_group(3);  g[1]
 (1,2,3)
 
-julia> l = GAP.GapObj([1, 3])
+julia> l = GapObj([1, 3])
 GAP: [ 1, 3 ]
 
 julia> on_sets(l, g[1])
@@ -171,7 +171,7 @@ end
 ^(set::AbstractSet, x::GAPGroupElem) = on_sets(set, x)
 
 """
-    on_sets_sets(set::GAP.GapObj, x::GAPGroupElem)
+    on_sets_sets(set::GapObj, x::GAPGroupElem)
     on_sets_sets(set::Vector, x::GAPGroupElem)
     on_sets_sets(set::Tuple, x::GAPGroupElem)
     on_sets_sets(set::AbstractSet, x::GAPGroupElem)
@@ -186,7 +186,7 @@ respectively.
 julia> g = symmetric_group(3);  g[1]
 (1,2,3)
 
-julia> l = GAP.GapObj([[1, 2], [3, 4]], recursive = true)
+julia> l = GapObj([[1, 2], [3, 4]], recursive = true)
 GAP: [ [ 1, 2 ], [ 3, 4 ] ]
 
 julia> on_sets_sets(l, g[1])
@@ -234,7 +234,7 @@ end
 
 
 """
-    permuted(pnt::GAP.GapObj, x::PermGroupElem)
+    permuted(pnt::GapObj, x::PermGroupElem)
     permuted(pnt::Vector, x::PermGroupElem)
     permuted(pnt::Tuple, x::PermGroupElem)
 
@@ -261,7 +261,7 @@ julia> permuted(a, g[1])
 julia> permuted(("a", "b", "c"), g[1])
 ("c", "a", "b")
 
-julia> l = GAP.GapObj(a, recursive = true)
+julia> l = GapObj(a, recursive = true)
 GAP: [ "a", "b", "c" ]
 
 julia> permuted(l, g[1])
@@ -282,7 +282,7 @@ end
 
 
 @doc raw"""
-    on_indeterminates(f::GAP.GapObj, p::PermGroupElem)
+    on_indeterminates(f::GapObj, p::PermGroupElem)
     on_indeterminates(f::MPolyRingElem, p::PermGroupElem)
     on_indeterminates(f::FreeAssAlgElem, p::PermGroupElem)
     on_indeterminates(f::MPolyIdeal, p::PermGroupElem)
@@ -343,7 +343,7 @@ function on_indeterminates(f::FreeAssAlgElem{T}, s::PermGroupElem) where T
 end
 
 @doc raw"""
-    on_indeterminates(f::GAP.GapObj, p::MatrixGroupElem)
+    on_indeterminates(f::GapObj, p::MatrixGroupElem)
     on_indeterminates(f::MPolyRingElem{T}, p::MatrixGroupElem{T}) where T
     on_indeterminates(f::MPolyIdeal, p::MatrixGroupElem)
 
@@ -415,7 +415,7 @@ end
 # because for example `*(::fpFieldElem, ::Vector{fpFieldElem})`
 # is not supported.
 """
-    on_lines(line::GAP.GapObj, x::GAPGroupElem)
+    on_lines(line::GapObj, x::GAPGroupElem)
     on_lines(line::AbstractAlgebra.Generic.FreeModuleElem, x::GAPGroupElem)
 
 Return the image of the nonzero vector `line` under `x`,

--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -120,7 +120,7 @@ end
 # special handling for pc groups: distinguish on the GAP side
 function cyclic_group(::Type{T}, n::Union{IntegerUnion,PosInf}) where T <: Union{PcGroup, SubPcGroup}
   if is_infinite(n)
-    return T(GAP.Globals.AbelianPcpGroup(1, GAP.GapObj([])))
+    return T(GAP.Globals.AbelianPcpGroup(1, GapObj([])))
   elseif n > 0
     return T(GAP.Globals.CyclicGroup(GAP.Globals.IsPcGroup, GAP.Obj(n))::GapObj)
   end
@@ -200,7 +200,7 @@ function abelian_group(::Type{TG}, v::Vector{T}) where TG <: Union{PcGroup, SubP
 #      so we keep the code from the master branch here.
     # We cannot construct an `IsPcGroup` group if some generator shall have
     # order infinity or 1 or a composed number.
-    return TG(GAP.Globals.AbelianPcpGroup(length(v), GAP.GapObj(v, recursive=true)))
+    return TG(GAP.Globals.AbelianPcpGroup(length(v), GapObj(v, recursive=true)))
   elseif TG == PcGroup && any(x -> ! is_prime(x), v)
     # GAP's IsPcGroup groups cannot have generators that correspond to the
     # orders given by `v` and to the defining presentation.
@@ -508,23 +508,23 @@ function free_group(n::Int, s::VarName = :f; eltype::Symbol = :letter)
    @req n >= 0 "n must be a non-negative integer"
    t = s isa Char ? string(s) : s
    if eltype == :syllable
-     G = FPGroup(GAP.Globals.FreeGroup(n, GAP.GapObj(t); FreeGroupFamilyType = GapObj("syllable"))::GapObj)
+     G = FPGroup(GAP.Globals.FreeGroup(n, GapObj(t); FreeGroupFamilyType = GapObj("syllable"))::GapObj)
    else
-     G = FPGroup(GAP.Globals.FreeGroup(n, GAP.GapObj(t))::GapObj)
+     G = FPGroup(GAP.Globals.FreeGroup(n, GapObj(t))::GapObj)
    end
    GAP.Globals.SetRankOfFreeGroup(GapObj(G), n)
    return G
 end
 
 function free_group(L::Vector{<:VarName})
-   J = GAP.GapObj(L, recursive = true)
+   J = GapObj(L, recursive = true)
    G = FPGroup(GAP.Globals.FreeGroup(J)::GapObj)
    GAP.Globals.SetRankOfFreeGroup(GapObj(G), length(J))
    return G
 end
 
 function free_group(L::Vector{<:Char})
-   J = GAP.GapObj(Symbol.(L), recursive = true)
+   J = GapObj(Symbol.(L), recursive = true)
    G = FPGroup(GAP.Globals.FreeGroup(J)::GapObj)
    GAP.Globals.SetRankOfFreeGroup(GapObj(G), length(J))
    return G

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -706,7 +706,7 @@ function isomorphism(::Type{T}, A::FinGenAbGroup) where T <: GAPGroup
      # `T == PcGroup`, hence we cannot call `abelian_group(T, exponents)`.)
      if T == PcGroup
        if 0 in exponents
-         GapG = GAP.Globals.AbelianPcpGroup(length(exponents), GAP.GapObj(exponents, recursive=true))
+         GapG = GAP.Globals.AbelianPcpGroup(length(exponents), GapObj(exponents, recursive=true))
        else
          GapG = GAP.Globals.AbelianGroup(GAP.Globals.IsPcGroup, GapObj(exponents, recursive=true))
        end

--- a/src/Groups/libraries/atlasgroups.jl
+++ b/src/Groups/libraries/atlasgroups.jl
@@ -64,7 +64,7 @@ Permutation group of degree 5 and order 60
 function atlas_group(info::Dict)
   gapname = info[:name]
   l = GAP.Globals.AGR.MergedTableOfContents(GapObj("all"), GapObj(gapname))::GapObj
-  pos = findfirst(r -> String(r.repname) == info[:repname], Vector{GAP.GapObj}(l))
+  pos = findfirst(r -> String(r.repname) == info[:repname], Vector{GapObj}(l))
   @req (pos !== nothing) "no Atlas group for $info"
   G = GAP.Globals.AtlasGroup(l[pos])
   @req (G !== GAP.Globals.fail) "the group atlas does not provide a representation for $info"

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -152,7 +152,7 @@ group_element(G::MatrixGroup, x::GapObj) = MatrixGroupElem(G,x)
 # Compute and store the component `G.X` if this is possible.
 function assign_from_description(G::MatrixGroup)
    F = codomain(_ring_iso(G))
-   GAP.Globals.IsBaseRingSupportedForClassicalMatrixGroup(F, GAP.GapObj(G.descr)) || error("no generators are known for the matrix group of type $(G.descr) over $(base_ring(G))")
+   GAP.Globals.IsBaseRingSupportedForClassicalMatrixGroup(F, GapObj(G.descr)) || error("no generators are known for the matrix group of type $(G.descr) over $(base_ring(G))")
    if G.descr==:GL G.X=GAP.Globals.GL(G.deg, F)
    elseif G.descr==:SL G.X=GAP.Globals.SL(G.deg, F)
    elseif G.descr==:Sp G.X=GAP.Globals.Sp(G.deg, F)
@@ -249,7 +249,7 @@ function Base.getproperty(G::MatrixGroup{T}, sym::Symbol) where T
       if isdefined(G,:descr)
          assign_from_description(G)
       elseif isdefined(G,:gens)
-         V = GAP.GapObj([g.X for g in gens(G)])
+         V = GapObj([g.X for g in gens(G)])
          G.X = isempty(V) ? GAP.Globals.Group(V, one(G).X) : GAP.Globals.Group(V)
       else
          error("Cannot determine underlying GAP object")

--- a/src/Groups/matrices/iso_nf_fq.jl
+++ b/src/Groups/matrices/iso_nf_fq.jl
@@ -91,7 +91,7 @@ function _isomorphic_group_over_finite_field(G::MatrixGroup{T}; min_char::Int = 
   preimg = function(y)
     return GAP.Globals.MappedWord(GAPWrap.UnderlyingElement(GAPWrap.Image(GptoF, map_entries(_ring_iso(Gp), matrix(y)))),
                                   GAPWrap.FreeGeneratorsOfFpGroup(F),
-                                  GAP.GapObj(gen))
+                                  GapObj(gen))
   end
 
   return Gp, MapFromFunc(G, Gp, img, preimg)

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -123,7 +123,7 @@ Sym(6)
 ```
 """
 function perm(L::AbstractVector{<:IntegerUnion})
-  return PermGroupElem(symmetric_group(length(L)), GAPWrap.PermList(GAP.GapObj(L;recursive=true)))
+  return PermGroupElem(symmetric_group(length(L)), GAPWrap.PermList(GapObj(L;recursive=true)))
 end
 
 
@@ -161,7 +161,7 @@ true
 ```
 """
 function perm(g::PermGroup, L::AbstractVector{<:IntegerUnion})
-   x = GAPWrap.PermList(GAP.GapObj(L;recursive=true))
+   x = GAPWrap.PermList(GapObj(L;recursive=true))
    @req x !== GAP.Globals.fail "the list does not describe a permutation"
    @req (length(L) <= degree(g) && x in GapObj(g)) "the element does not embed in the group"
    return PermGroupElem(g, x)
@@ -170,7 +170,7 @@ end
 perm(g::PermGroup, L::AbstractVector{<:ZZRingElem}) = perm(g, [Int(y) for y in L])
 
 function (g::PermGroup)(L::AbstractVector{<:IntegerUnion})
-   x = GAPWrap.PermList(GAP.GapObj(L;recursive=true))
+   x = GAPWrap.PermList(GapObj(L;recursive=true))
    @req (length(L) <= degree(g) && x in GapObj(g)) "the element does not embed in the group"
    return PermGroupElem(g, x)
 end

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -552,7 +552,7 @@ parent_type(::Type{BasicGAPGroupElem{T}}) where T <: GAPGroup = T
 # X is a GAP filter such as IsPermGroup, and Y is a corresponding
 # Julia type such as `PermGroup`.
 #
-const _gap_group_types = Tuple{GAP.GapObj, Type}[]
+const _gap_group_types = Tuple{GapObj, Type}[]
 
 # `_oscar_group(G)` wraps the GAP group `G` into a suitable Oscar group `OG`,
 # such that `GapObj(OG)` is equal to `G`.

--- a/src/Serialization/GAP.jl
+++ b/src/Serialization/GAP.jl
@@ -31,7 +31,7 @@ end
 #
 # the Oscar (de)serialization methods that delegate to GAP's method selection
 #
-@register_serialization_type GAP.GapObj uses_id
+@register_serialization_type GapObj uses_id
 
 function save_object(s::SerializerState, X::GapObj)
   GAP.Globals.SerializeInOscar(X, s)

--- a/test/GAP/iso_gap_oscar.jl
+++ b/test/GAP/iso_gap_oscar.jl
@@ -92,7 +92,7 @@ end
 end
 
 @testset "field of rationals, ring of integers" begin
-  for (R, x, y) in [(GAP.Globals.Rationals, GAP.GapObj(2//3), 1),
+  for (R, x, y) in [(GAP.Globals.Rationals, GapObj(2//3), 1),
                     (GAP.Globals.Integers, 2, 3),
                    ]
     iso = Oscar.iso_gap_oscar(R)

--- a/test/GAP/oscar_to_gap.jl
+++ b/test/GAP/oscar_to_gap.jl
@@ -124,9 +124,9 @@ end
     # create sort duplicate free list (this is how GAP represents sets)
     l = sort(unique(coll))
 
-    x = GAP.GapObj(s)
-    @test x == GAP.GapObj(l)
+    x = GapObj(s)
+    @test x == GapObj(l)
 
-    x = GAP.GapObj(s; recursive=true)
-    @test x == GAP.GapObj(l; recursive=true)
+    x = GapObj(s; recursive=true)
+    @test x == GapObj(l; recursive=true)
 end

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -139,7 +139,7 @@ end
 @testset "map_word for f.p. groups" begin
    # Create a free group in GAP in syllable words family,
    # in order to make the tests.
-   GAP.Globals.PushOptions(GAP.GapObj(Dict(:FreeGroupFamilyType => GAP.GapObj("syllable"))))
+   GAP.Globals.PushOptions(GapObj(Dict(:FreeGroupFamilyType => GapObj("syllable"))))
    FS = free_group(2)   # syllable representation
    GAP.Globals.PopOptions()
    FL = free_group(2)   # letter representation

--- a/test/Serialization/GAP.jl
+++ b/test/Serialization/GAP.jl
@@ -31,7 +31,7 @@
 
         # subgroup of full free group
         Fgens = GAP.Globals.GeneratorsOfGroup(F)
-        U = GAP.Globals.Subgroup(F, GAP.GapObj([Fgens[1]]))
+        U = GAP.Globals.Subgroup(F, GapObj([Fgens[1]]))
         test_save_load_roundtrip(path, U) do loaded
           @test U == loaded
         end
@@ -54,7 +54,7 @@
         @test GAP.Globals.GeneratorsOfGroup(loadedU)[1] in loadedF
 
         # full group and subgroup together in the same Julia session
-        V = GAP.Globals.Subgroup(F, GAP.GapObj([Fgens[2]]))
+        V = GAP.Globals.Subgroup(F, GapObj([Fgens[2]]))
         v = (F, U, V)
         test_save_load_roundtrip(path, v) do loaded
           @test v == loaded
@@ -74,14 +74,14 @@
       # full f.p. group
       F = GAP.Globals.FreeGroup(2)
       Fgens = GAP.Globals.GeneratorsOfGroup(F)
-      G = F/GAP.GapObj([x^2 for x in Fgens])
+      G = F/GapObj([x^2 for x in Fgens])
       test_save_load_roundtrip(path, G) do loaded
         @test G == loaded
       end
 
       # subgroup of full f.p. group
       Ggens = GAP.Globals.GeneratorsOfGroup(G)
-      U = GAP.Globals.Subgroup(G, GAP.GapObj([Ggens[1]]))
+      U = GAP.Globals.Subgroup(G, GapObj([Ggens[1]]))
       test_save_load_roundtrip(path, U) do loaded
         @test U == loaded
       end
@@ -104,7 +104,7 @@
       @test GAP.Globals.GeneratorsOfGroup(loadedU)[1] in loadedG
 
       # full group and subgroup together in the same Julia session
-      V = GAP.Globals.Subgroup(G, GAP.GapObj([Ggens[2]]))
+      V = GAP.Globals.Subgroup(G, GapObj([Ggens[2]]))
       v = (G, U, V)
       test_save_load_roundtrip(path, v) do loaded
         @test v == loaded


### PR DESCRIPTION
(since `GapObj` is meanwhile exported,
because it turned out to be useful as a constructor)