### PR TITLE
Fix citations to CLS11 in toric varieties

### DIFF
--- a/experimental/Schemes/src/NormalToricVarieties/attributes.jl
+++ b/experimental/Schemes/src/NormalToricVarieties/attributes.jl
@@ -1,9 +1,9 @@
 # Compute the ideal sheaves and Weil divisors of the rays of `polyhedral_fan(X)` 
 # according to the "orbit-cone-correspondence", Theorem 3.2.6 in 
-# Cox-Little-Schenk.
+# CLS11.
 #
 # We would like to use Equation (3.2.7) from page 121 of the electronic
-# version of the CLS book. It turned out that there is a misprint in this
+# version of CLS11. It turned out that there is a misprint in this
 # formula in the online version, always leading to the unit ideal. In the
 # print version, which might not be accessible to all of us, the formula
 # has been corrected.
@@ -25,7 +25,7 @@
 #       ideal.
 #
 # What we do above is also supported by the description of divisors 
-# in CLS, Formula (4.3.2): For a ray ρ ∈ Σ(1) the divisor -D with 
+# in CLS11, Formula (4.3.2): For a ray ρ ∈ Σ(1) the divisor -D with 
 # linear system consisting of the rational functions f which vanish 
 # on D is then locally given by 
 #

--- a/experimental/Schemes/src/ToricIdealSheaves/constructors.jl
+++ b/experimental/Schemes/src/ToricIdealSheaves/constructors.jl
@@ -159,7 +159,7 @@ function ideal_sheaf(X::NormalToricVariety, tau::Cone)
   # Maybe it's a mistake in the book and we really need the dual?
   #tau_perp = polarize(tau)
   ideal_dict = IdDict{AbsAffineScheme, Ideal}()
-  # We are using Equation (3.2.7) in CLS to determine the local 
+  # We are using Equation (3.2.7) in CLS11 to determine the local 
   # form of the ideal.
   for U in affine_charts(X)
     cu = cone(U)
@@ -199,7 +199,7 @@ function Base.in(tau::Cone, Sigma::PolyhedralFan)
 end
 
 function _dehomogenize_to_chart(X::NormalToricVariety, I::MPolyIdeal, k::Int)
-  # We use CLS, Proposition 5.2.10 and Exercise 5.2.5.
+  # We use CLS11, Proposition 5.2.10 and Exercise 5.2.5.
   IM = maximal_cones(IncidenceMatrix, X)
   U = affine_charts(X)[k]
 
@@ -210,7 +210,7 @@ function _dehomogenize_to_chart(X::NormalToricVariety, I::MPolyIdeal, k::Int)
 #  phi_s_star = hom(cox_ring(X), help_ring, imgs_phi_star; check=false)
 # 
 #  # Now we need to create alpha*.
-#  # We do this with the description on p. 224 in CLS.
+#  # We do this with the description on p. 224 in CLS11.
 #  hb_U = hilbert_basis(weight_cone(U))
 #  r = matrix(ZZ, rays(U))
 #  imgs_alpha_star = [prod(x_rho[l]^Int(dot(hb_U[j], r[l, :])) for l in 1:nrows(r); init=one(help_ring)) for j in 1:length(hb_U)]


### PR DESCRIPTION
The name of the authors of `[CLS11](@cite)` was misspelled in a comment. Only in a comment, but still should be corrected. Instead of the names, I instead put `[CLS11](@cite)`.