### PR TITLE
CI: disable cache for selfhosted runner

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
       - uses: julia-actions/cache@v1
+        if: runner.environment != 'self-hosted'
         with:
           cache-name: julia-cache;workflow=${{ github.workflow }};julia=${{ matrix.julia-version }};arch=${{ runner.arch }}
           include-matrix: false
@@ -143,6 +144,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
       - uses: julia-actions/cache@v1
+        if: runner.environment != 'self-hosted'
         with:
           cache-name: julia-cache;workflow=${{ github.workflow }};julia=${{ matrix.julia-version }};arch=${{ runner.arch }}
           include-matrix: false


### PR DESCRIPTION
As suggested in slack, this might help with race-conditions when the cache action modifies the shared depot.

Edit:
Errors like this: https://github.com/oscar-system/Oscar.jl/actions/runs/9114205319/job/25057562605#step:9:255
```
     Testing Running tests...
ERROR: LoadError: SystemError: opening file "/Users/aaruni/.julia/compiled/v1.10/Oscar/aJ3Pg_GQbme.ji": No such file or directory
```
In this case even outside of the extra initialization stuff from Polymake or GAP.