### PR TITLE
trim_trailing_whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ charset = utf-8
 end_of_line = lf
 indent_style = space
 insert_final_newline = true
-#trim_trailing_whitespace = true  # as long as we don't enforce this, this option causes more trouble than it helps
+trim_trailing_whitespace = true
 
 [*.jl]
 indent_size = 2


### PR DESCRIPTION
@joschmitt noticed in https://github.com/oscar-system/Oscar.jl/pull/3740#issuecomment-2117295514 that there is a lot of trailing whitespace in OSCAR code and asked to set `remove_trailing_whitespace` to `false` in the code editor. It would be nice to agree on a convention about this and write it in the `.editorconfig` file.

While there is nothing said about this in the official Julia styleguide, the most popular style guides for the most popular programming languages advise not to have trailing whitespace. I would personally prefer if `remove_trailing_whitespace` to `true`, so this is what I put in this pull request (but we should change it to the consensus opinion once people agree).

This does not influence code diffs since we can always set git and github to ignore whitespace changes.