### PR TITLE
README: use the correct badge (or make it static?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Forschungsgemeinschaft DFG within the
 [docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
 [docs-stable-url]: https://docs.oscar-system.org/stable/
 
-[ga-img]: https://github.com/oscar-system/Oscar.jl/workflows/Run%20tests/badge.svg
+[ga-img]: https://github.com/oscar-system/Oscar.jl/actions/workflows/CI.yml/badge.svg?branch=master&event=push
 [ga-url]: https://github.com/oscar-system/Oscar.jl/actions?query=workflow%3A%22Run+tests%22
 
 [codecov-img]: https://codecov.io/gh/oscar-system/Oscar.jl/branch/master/graph/badge.svg?branch=master


### PR DESCRIPTION
TLDR; Make the badge in the README more often green.

1. The github README is probably the first encounter for people looking for Oscar (it is the first hit on various search engines).
2. I think it gives a very bad first impression for non-developers, if they get directed to the README and see right at the top a big scary red "tests failing". What it is supposed to tell someone? Don't use it? Use it and expect wrong results?
3. A "tests failing" is always a CI fluke or some other non-actionable thing.
4. A green "tests passing" gives a fuzzy warm feeling.

To summarize:
- red bagde = scary and useless, makes me wonder whether I should use Oscar?
- green badge = nice, makes me want to use Oscar!

My actual proposal of a static "tests passing" badge (without any connection to the actual status of CI) might be a bit controversial, so here is a less controversial one. Just show the badge for the push action on the master branch.