### PR TITLE
`QuadFormAndIsom`: Serialization infinite order isometries and a minor fix

### DIFF
--- a/experimental/QuadFormAndIsom/src/embeddings.jl
+++ b/experimental/QuadFormAndIsom/src/embeddings.jl
@@ -2028,12 +2028,12 @@ function _glue_stabilizers(phi::TorQuadModuleMap,
   OqA = domain(OqAinOD)
   imA, _ = image(actA)
   kerA = elem_type(OD)[OqAinOD(x) for x in gens(kernel(actA)[1])]
-  push!(kerA, OqAinOD(one(OqA)))
+  push!(kerA, one(OD))
 
   OqB = domain(OqBinOD)
   imB, _ = image(actB)
   kerB = elem_type(OD)[OqBinOD(x) for x in gens(kernel(actB)[1])]
-  push!(kerB, OqBinOD(one(OqB)))
+  push!(kerB, one(OD))
 
   ext = domain(graph)
   perp, j = orthogonal_submodule(codomain(graph), ext)

--- a/experimental/QuadFormAndIsom/src/serialization.jl
+++ b/experimental/QuadFormAndIsom/src/serialization.jl
@@ -10,8 +10,12 @@ function save_object(s::SerializerState, QS::QuadSpaceWithIsom)
   save_data_dict(s) do
     save_typed_object(s, space(QS), :quad_space)
     save_typed_object(s, isometry(QS), :isom)
+    _n = order_of_isometry(QS)
 
-    save_object(s, order_of_isometry(QS), :order)
+    # Since for finite order isometries we do not go below -1,
+    # we store -2 for infinite order isometries
+    n = is_finite(_n) ? _n : -2
+    save_object(s, n, :order)
   end
 end
 
@@ -19,12 +23,8 @@ function load_object(s::DeserializerState, ::Type{QuadSpaceWithIsom})
   quad_space = load_typed_object(s, :quad_space)
   isom = load_typed_object(s, :isom)
 
-  # not quite sure how to deal with IntExt/PosInf yet..
-  # we could add it to the basic type section
-  # then we could use
-  # load_object(s, IntExt, dict[:order]) 
-  n = load_object(s, Int, :order)
-  
+  _n = load_object(s, Int, :order)
+  n = _n == -2 ? inf : _n
   return QuadSpaceWithIsom(quad_space, isom, n)
 end
 

--- a/experimental/QuadFormAndIsom/src/serialization.jl
+++ b/experimental/QuadFormAndIsom/src/serialization.jl
@@ -10,12 +10,9 @@ function save_object(s::SerializerState, QS::QuadSpaceWithIsom)
   save_data_dict(s) do
     save_typed_object(s, space(QS), :quad_space)
     save_typed_object(s, isometry(QS), :isom)
-    _n = order_of_isometry(QS)
+    n = order_of_isometry(QS)
 
-    # Since for finite order isometries we do not go below -1,
-    # we store -2 for infinite order isometries
-    n = is_finite(_n) ? _n : -2
-    save_object(s, n, :order)
+    save_typed_object(s, n, :order)
   end
 end
 
@@ -23,8 +20,7 @@ function load_object(s::DeserializerState, ::Type{QuadSpaceWithIsom})
   quad_space = load_typed_object(s, :quad_space)
   isom = load_typed_object(s, :isom)
 
-  _n = load_object(s, Int, :order)
-  n = _n == -2 ? inf : _n
+  n = load_typed_object(s, :order)
   return QuadSpaceWithIsom(quad_space, isom, n)
 end
 

--- a/experimental/QuadFormAndIsom/test/runtests.jl
+++ b/experimental/QuadFormAndIsom/test/runtests.jl
@@ -104,7 +104,17 @@ end
       @test Lf == loaded
     end
   end
-  
+
+  L = integer_lattice(; gram = QQ[1 2; 2 1])
+  h = QQ[4 -1; 1 0]
+  Lf = integer_lattice_with_isometry(L, h)
+
+  mktempdir() do path
+    test_save_load_roundtrip(path, Lf) do loaded
+      @test Lf == loaded
+    end
+  end
+
   L = @inferred integer_lattice_with_isometry(A3)
   @test is_primary(L, 2)
   @test !is_elementary(L, 2)

--- a/src/Serialization/Upgrades/1.1.0.jl
+++ b/src/Serialization/Upgrades/1.1.0.jl
@@ -16,6 +16,15 @@ push!(upgrade_scripts_set, UpgradeScript(
       if !haskey(dict[:data], :basis)
         upgraded_dict[:data][:basis] = dict[:data][:lattice][:data][:basis]
       end
+
+      # In the past, we saved only finite order isometries, but the order
+      # was not typed. Now we need to reference the type otherwise we cannot
+      # read old files.
+      if !(dict[:data][:ambient_space][:data][:order] isa Dict)
+        n = Base.parse(Int, dict[:data][:ambient_space][:data][:order])
+        upgraded_dict[:data][:ambient_space][:data][:order] =
+        Dict{Symbol, Any}(:_type => "Base.Int", :data => "$n")
+      end
     end
 
     return upgraded_dict

--- a/src/Serialization/basic_types.jl
+++ b/src/Serialization/basic_types.jl
@@ -63,11 +63,15 @@ end
 @register_serialization_type Float32
 @register_serialization_type Float64
 
+
 function load_object(s::DeserializerState, ::Type{T}) where {T<:Number}
   load_node(s) do str
     parse(T, str)
   end
 end
+
+@register_serialization_type PosInf
+
 
 ################################################################################
 # Strings

--- a/src/Serialization/basic_types.jl
+++ b/src/Serialization/basic_types.jl
@@ -63,7 +63,6 @@ end
 @register_serialization_type Float32
 @register_serialization_type Float64
 
-
 function load_object(s::DeserializerState, ::Type{T}) where {T<:Number}
   load_node(s) do str
     parse(T, str)
@@ -71,7 +70,6 @@ function load_object(s::DeserializerState, ::Type{T}) where {T<:Number}
 end
 
 @register_serialization_type PosInf
-
 
 ################################################################################
 # Strings


### PR DESCRIPTION
Up to now, since there is no serialization of `PosInf`, we could not store the order for isometries of infinite order. Since, in the finite or trivial case, this order `n` is at least -1, for the storing I have opted for `n = -2`  in the case of infinite order. 

Eventually, even if we implement the serialization of infinity, I guess it could stay as is: there is no possible conflict, and it is something that humans are not suppose to read.

@antonydellavecchia does it seem good ? Any objection ? 

The extra minor fix is trivial: `OqAinOD`, by construction, sends the identity to the identity (similarly for the other one).