### PR TITLE
bug: fix galois_group regression

### DIFF
--- a/src/NumberTheory/GaloisGrp/GaloisGrp.jl
+++ b/src/NumberTheory/GaloisGrp/GaloisGrp.jl
@@ -2730,14 +2730,22 @@ function are_disjoint(G::GaloisCtx{T}, S::GaloisCtx{T}) where T <: Union{Hecke.q
     @vprint :GaloisGroup 2 "\n poly discs have small gcd ($g)..."
     o1 = any_order(number_field(G.f, cached = false, check = false)[1])
     p = radical(g)
-    O1 = pmaximal_overorder(o1, p)
+    if is_probable_prime(p)
+      O1 = pmaximal_overorder(o1, p)
+    else
+      O1, = Hecke._TameOverorderBL(o1, [p])
+    end
     p = gcd(discriminant(O1), p)
     if isone(p)
       @vprint :GaloisGroup 2 "p-maximal order of 1st is p-free\n"
       return true
     end
     o2 = any_order(number_field(S.f, cached = false, check = false)[1])
-    O2 = pmaximal_overorder(o2, p)
+    if is_probable_prime(p)
+      O2 = pmaximal_overorder(o2, p)
+    else
+      O2, = Hecke._TameOverorderBL(o2, [p])
+    end
     @vprint :GaloisGroup 2 "p-maximal order of 2nd is "
     p = gcd(discriminant(O2), p)
     if isone(p)

--- a/test/NumberTheory/galthy.jl
+++ b/test/NumberTheory/galthy.jl
@@ -77,4 +77,10 @@ sample_cycle_structures(G::PermGroup) = Set(cycle_structure(rand_pseudo(G)) for 
     @test all(G -> !an_sn_by_shape(sample_cycle_structures(G),n) || naive_is_giant(G), grps[n] )
   end
 
+  let # Ehrhart polynomial problems
+    Qx, x = QQ["x"]
+    f = 4//45*x^6 + 4//15*x^5 + 14//9*x^4 + 8//3*x^3 + 196//45*x^2 + 46//15*x + 1
+    G, = galois_group(f)
+    @test small_group_identification(G) == (4, 2)
+  end
 end


### PR DESCRIPTION
- `pmaximal_overorder` requires a prime
- since we don't want to factor, we compute a tame overorder

@fieker: I think the code is still correct, but maybe you want to do trial division + `pmaximal_overorder` call?

CC: @micjoswig (should fix the Ehrhart polynomial problems).