### PR TITLE
undo a renaming in a list of type names

### DIFF
--- a/docs/src/General/serialization.md
+++ b/docs/src/General/serialization.md
@@ -34,8 +34,8 @@ SimplicialComplex
 ### Commutative Algebra
 ```julia
 Ideal
-Polynomial
-polynomial_ring
+PolyRing
+PolyRingElem
 ```
 
 ### Groups


### PR DESCRIPTION
The documentation of serializable objects lists types, thus `polynomial_ring` is not what one wants here.

Concerning the entry `Polynomial`: This variable does not exist, `PolyRingElem` would be the type in question.
However, I am not sure whether `SomethingElem` types should be mentioned here at all:

Can elements of a serializable object perhaps be assumed to be serializable?
If yes then `PolyRingElem` can be omitted, if no then I should add also the element types of the group types that are listed in the file.