### PR TITLE
[Backport 1.0] list group types that can be serialized (#3767)

### DIFF
--- a/docs/src/General/serialization.md
+++ b/docs/src/General/serialization.md
@@ -38,6 +38,15 @@ Polynomial
 polynomial_ring
 ```
 
+### Groups
+```julia
+FPGroup
+FinGenAbGroup
+PcGroup
+PermGroup
+SubPcGroup
+```
+
 ### Polyhedral Geometry
 ```julia
 Cone

--- a/docs/src/General/serialization.md
+++ b/docs/src/General/serialization.md
@@ -44,7 +44,6 @@ FPGroup
 FinGenAbGroup
 PcGroup
 PermGroup
-SubPcGroup
 ```
 
 ### Polyhedral Geometry


### PR DESCRIPTION
`SubPcGroup` does not exist in Oscar 1.0.

(PS: CI doesn't run here)