### PR TITLE
No longer load code dependent on `is_dev`

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -283,13 +283,6 @@ include("Serialization/main.jl")
 
 include("../experimental/Experimental.jl")
 
-if is_dev
-#  include("../examples/ModStdNF.jl")
-#  include("../examples/ModStdQ.jl")
-#  include("../examples/ModStdQt.jl")
-  include("../examples/PrimDec.jl")
-end
-
 include("deprecations.jl")
 
 @doc raw"""


### PR DESCRIPTION
This could lead to very hard to track down bugs in released versions (as it is not reproducible in the local clone).

I would even consider backporting this to 1.0. What do you guys think?