### PR TITLE
Implement `simplify` for `ComplexOfMorphisms`

### DIFF
--- a/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
@@ -332,6 +332,14 @@ function can_compute(fac::BaseChangeFromOriginalFactory, phi::AbsHyperComplexMor
 end
 
 
+function simplify(c::FreeResolution)
+  return simplify(SimpleComplexWrapper(c.C))
+end
+
+function simplify(c::ComplexOfMorphisms)
+  return simplify(SimpleComplexWrapper(c))
+end
+
 function simplify(c::AbsHyperComplex{ChainType, MorphismType}) where {ChainType, MorphismType}
   @assert dim(c) == 1 "complex must be one-dimensional"
   chain_fac = SimplifiedChainFactory(c)

--- a/experimental/DoubleAndHyperComplexes/test/ext.jl
+++ b/experimental/DoubleAndHyperComplexes/test/ext.jl
@@ -365,7 +365,7 @@ end
     SX = homogeneous_coordinate_ring(X)
     n = ngens(SX)-1
     c = codim(X)
-    res, _ = free_resolution(Oscar.SimpleFreeResolution, SX)
+    res = free_resolution(SX)
     C_simp = simplify(res);
     C_shift = shift(C_simp, c);
     S = base_ring(SX)

--- a/experimental/DoubleAndHyperComplexes/test/ext.jl
+++ b/experimental/DoubleAndHyperComplexes/test/ext.jl
@@ -360,21 +360,7 @@ end
 
   I = ideal(S, V);
   X = variety(I, check = false, is_radical = false);
-
-  function canonical_bundle(X::AbsProjectiveVariety)
-    SX = homogeneous_coordinate_ring(X)
-    n = ngens(SX)-1
-    c = codim(X)
-    res = free_resolution(SX)
-    C_simp = simplify(res);
-    C_shift = shift(C_simp, c);
-    S = base_ring(SX)
-    OmegaPn = graded_free_module(S, [n+1])
-    D = hom(C_shift, OmegaPn);
-    D_simp = simplify(D);
-    return homology(D_simp, 0)[1]
-  end
-
+  
   @test !is_zero(canonical_bundle(X))
 end
 

--- a/src/AlgebraicGeometry/Surfaces/AdjunctionProcess/AdjunctionProcess.jl
+++ b/src/AlgebraicGeometry/Surfaces/AdjunctionProcess/AdjunctionProcess.jl
@@ -204,14 +204,13 @@ function canonical_bundle(X::AbsProjectiveVariety)
   n = ngens(Pn)-1
   c = codim(X)
   FA = free_resolution(A, algorithm = :fres)
-  C = Oscar.SimpleComplexWrapper(FA.C[0:first(range(FA.C))])
-  C_simp = simplify(C)
+  C_simp = simplify(FA)
   C_shift = shift(C_simp, c)
   OmegaPn = graded_free_module(Pn, [n+1])
   D = hom(C_shift, OmegaPn)
   D_simp = simplify(D)
   Z, inc = kernel(D_simp, 0)
-  B, inc_B = Oscar.boundary(D_simp, 0)
+  B, inc_B = boundary(D_simp, 0)
   return prune_with_map(SubquoModule(D_simp[0], ambient_representatives_generators(Z), ambient_representatives_generators(B)))[1] 
 end
 


### PR DESCRIPTION
Now the code for `canonical_bundle` looks sane. 

What happened? There was no method `simplify(::ComplexOfMorphism)`. And there could not be any reasonable such method which would not switch to the new lazy complexes as return values, since the `ComplexOfMorphism`s would need a lot of extra care to become sufficiently lazy. Hence I added that method and everything works just fine. No dubious calls to special methods in the code for `canonical_bundle` anymore. 

Ping @wdecker @jankoboehm 