### PR TITLE
Remove superfluous whitespace in documentation

### DIFF
--- a/docs/src/AlgebraicGeometry/FrameWorks/ArchitectureOfAffineSchemes.md
+++ b/docs/src/AlgebraicGeometry/FrameWorks/ArchitectureOfAffineSchemes.md
@@ -83,7 +83,7 @@ Note that the morphism ``P → R`` is induced by natural coercions.
 
 The abstract type for affine schemes is
 ```@docs
-    AbsAffineScheme{BaseRingType, RingType<:Ring}
+AbsAffineScheme{BaseRingType, RingType<:Ring}
 ```
 For any concrete instance of this type, we require the following
 functions to be implemented:
@@ -92,7 +92,7 @@ functions to be implemented:
 
 A concrete instance of this type is
 ```@docs
-    AffineScheme{BaseRingType, RingType}
+AffineScheme{BaseRingType, RingType}
 ```
 It provides an implementation of affine schemes for rings ``R`` of type
 `MPolyRing`, `MPolyQuoRing`, `MPolyLocRing`, and `MPolyQuoLocRing`
@@ -116,20 +116,20 @@ Of course, it can be overwritten for any higher type `MyAffineScheme<:AbsAffineS
 
 Any abstract morphism of affine schemes is of the following type:
 ```@docs
-    AbsAffineSchemeMor{DomainType<:AbsAffineScheme,
-               CodomainType<:AbsAffineScheme,
-               PullbackType<:Map,
-               MorphismType,
-               BaseMorType
-               }
+AbsAffineSchemeMor{DomainType<:AbsAffineScheme,
+            CodomainType<:AbsAffineScheme,
+            PullbackType<:Map,
+            MorphismType,
+            BaseMorType
+            }
 ```
 Any such morphism has the attributes `domain`, `codomain` and `pullback`.
 A concrete and minimalistic implementation exist for the type `AffineSchemeMor`:
 ```@docs
-    AffineSchemeMor{DomainType<:AbsAffineScheme,
-            CodomainType<:AbsAffineScheme,
-            PullbackType<:Map
-           }
+AffineSchemeMor{DomainType<:AbsAffineScheme,
+        CodomainType<:AbsAffineScheme,
+        PullbackType<:Map
+        }
 ```
 This basic functionality consists of
 - `compose(f::AbsAffineSchemeMor, g::AbsAffineSchemeMor)`,

--- a/docs/src/AlgebraicGeometry/FrameWorks/ArchitectureOfAffineSchemes.md
+++ b/docs/src/AlgebraicGeometry/FrameWorks/ArchitectureOfAffineSchemes.md
@@ -10,21 +10,21 @@ CurrentModule = Oscar
 Any type of ring ``R`` to be used within the schemes framework
 must come with its own ideal type `IdealType<:Ideal` for which
 we require the following interface to be implemented:
-```
-    # constructor of ideals in R
-    ideal(R::RingType, g::Vector{<:RingElem})::Ideal
+```julia
+# constructor of ideals in R
+ideal(R::RingType, g::Vector{<:RingElem})::Ideal
 
-    # constructor for quotient rings
-    quo(R::RingType, I::IdealType)::Tuple{<:Ring, <:Map}
+# constructor for quotient rings
+quo(R::RingType, I::IdealType)::Tuple{<:Ring, <:Map}
 
-    # ideal membership test
-    in(f::RingElem, I::IdealType)::Bool
+# ideal membership test
+in(f::RingElem, I::IdealType)::Bool
 
-    # a (fixed) set of generators
-    gens(I::IdealType)::Vector{<:RingElem}
+# a (fixed) set of generators
+gens(I::IdealType)::Vector{<:RingElem}
 
-    # writing an element as linear combination of the generators
-    coordinates(f::RingElem, I::IdealType)::Vector{<:RingElem}
+# writing an element as linear combination of the generators
+coordinates(f::RingElem, I::IdealType)::Vector{<:RingElem}
 ```
 The latter function must return a vector ``v = (a_1,\dots, a_r)``
 of elements in ``R`` such that ``f = a_1 \cdot g_1 + \dots + a_r \cdot g_r``
@@ -34,8 +34,8 @@ not belong to ``I``, it must error. Note that the ring returned by
 
 With a view towards the use of the `ambient_coordinate_ring(X)` for computations,
 it is customary to also implement
-```
-    saturated_ideal(I::IdealType)::MPolyIdeal
+```julia
+saturated_ideal(I::IdealType)::MPolyIdeal
 ```
 returning an ideal ``J`` in the `ambient_coordinate_ring(X)` with the property
 that ``a \in I`` for some element ``a \in R`` if and only if
@@ -51,9 +51,9 @@ this is another reason to include the ambient affine space in our abstract
 interface for affine schemes. In order to make the `ambient_coordinate_ring(X)`
 accessible for this purpose, we need the following methods to be implemented
 for elements ``a\in R`` of type `RingElemType`:
-```
-   lifted_numerator(a::RingElemType)
-   lifted_denominator(a::RingElemType)
+```julia
+lifted_numerator(a::RingElemType)
+lifted_denominator(a::RingElemType)
 ```
 These must return representatives of the numerator and the denominator
 of ``a``. Note that the denominator is equal to `one(P)` in case
@@ -63,8 +63,8 @@ Recall that the coordinates ``x_i`` of ``X`` are induced by the coordinates of
 the ambient affine space.
 Moreover, we will assume that for homomorphisms from ``R``
 there is a method
-```
-    hom(R::RingType, S::Ring, a::Vector{<:RingElem})
+```julia
+hom(R::RingType, S::Ring, a::Vector{<:RingElem})
 ```
 where `RingType` is the type of ``R`` and `a` the images
 of the coordinates ``x_i`` in ``S``. This will be important
@@ -102,8 +102,8 @@ concrete types `MyAffineScheme<:AbsAffineScheme` such as, for instance,
 group schemes, toric schemes, schemes of a particular dimension
 like curves and surfaces, etc. To this end, one has to store
 an instance `Y` of `AffineScheme` in `MyAffineScheme` and implement the methods
-```
-    underlying_scheme(X::MyAffineScheme)::AffineScheme # return Y as above
+```julia
+underlying_scheme(X::MyAffineScheme)::AffineScheme # return Y as above
 ```
 Then all methods implemented for `AffineScheme` are automatically
 forwarded to any instance of `MyAffineScheme`.
@@ -144,7 +144,7 @@ should run naturally.
 We may derive higher types of morphisms of affine schemes `MyAffineSchemeMor<:AbsAffineSchemeMor`
 by storing an instance `g` of `AffineSchemeMor` inside an instance `f` of
 `MyAffineSchemeMor` and implementing
-```
-    underlying_morphism(f::MyAffineSchemeMor)::AffineSchemeMor # return g
+```julia
+underlying_morphism(f::MyAffineSchemeMor)::AffineSchemeMor # return g
 ```
 For example, this allows us to define closed embeddings.

--- a/docs/src/AlgebraicGeometry/Schemes/CoveredSchemeMorphisms.md
+++ b/docs/src/AlgebraicGeometry/Schemes/CoveredSchemeMorphisms.md
@@ -14,8 +14,8 @@ This information is held by a `CoveringMorphism`:
 ```
 The basic functionality of `CoveringMorphism`s comprises `domain` and `codomain` which 
 both return a `Covering`, together with 
-```
-    getindex(f::CoveringMorphism, U::AbsAffineScheme)
+```julia
+getindex(f::CoveringMorphism, U::AbsAffineScheme)
 ```
 which for ``U = U_i`` returns the `AbsAffineSchemeMor` ``f_i : U_i \to V_{F(i)}``.
 
@@ -27,10 +27,10 @@ in order to realize the covering morphism in the first place.
 ## The interface for morphisms of covered schemes
 Every `AbsCoveredSchemeMorphism` ``f : X \to Y`` is required to implement the following minimal 
 interface.
-```
-    domain(f::AbsCoveredSchemeMorphism)                 # returns X
-    codomain(f::AbsCoveredSchemeMorphism)               # returns Y
-    covering_morphism(f::AbsCoveredSchemeMorphism)      # returns the underlying covering morphism {f_i}
+```julia
+domain(f::AbsCoveredSchemeMorphism)                 # returns X
+codomain(f::AbsCoveredSchemeMorphism)               # returns Y
+covering_morphism(f::AbsCoveredSchemeMorphism)      # returns the underlying covering morphism {f_i}
 ```
 For the user's convenience, also the domain and codomain 
 of the underlying `covering_morphism` are forwarded as `domain_covering` and 

--- a/docs/src/AlgebraicGeometry/Schemes/CoveredSchemeMorphisms.md
+++ b/docs/src/AlgebraicGeometry/Schemes/CoveredSchemeMorphisms.md
@@ -64,7 +64,7 @@ on ``X`` and ``Y`` can be extracted from the ``f^* v_i`` more directly.
 
 A lazy concrete data structure to house this kind of morphism is 
 ```@docs
-    MorphismFromRationalFunctions
+MorphismFromRationalFunctions
 ```
 Note that the key idea of this data type is to *not* use the `underlying_morphism` 
 together with its `covering_morphism`, but to find cheaper ways to do computations! 
@@ -81,12 +81,12 @@ there is no need to realize the full `covering_morphism` of ``f``.
 In order to facilitate such computations as lazy as possible, there are various fine-grained 
 entry points and caching mechanisms to realize ``f`` on open subsets:
 ```@docs
-    realize_on_patch(Phi::MorphismFromRationalFunctions, U::AbsAffineScheme)
-    realize_on_open_subset(Phi::MorphismFromRationalFunctions, U::AbsAffineScheme, V::AbsAffineScheme)
-    realization_preview(Phi::MorphismFromRationalFunctions, U::AbsAffineScheme, V::AbsAffineScheme)
-    random_realization(Phi::MorphismFromRationalFunctions, U::AbsAffineScheme, V::AbsAffineScheme)
-    cheap_realization(Phi::MorphismFromRationalFunctions, U::AbsAffineScheme, V::AbsAffineScheme)
-    realize_maximally_on_open_subset(Phi::MorphismFromRationalFunctions, U::AbsAffineScheme, V::AbsAffineScheme)
-    realize(Phi::MorphismFromRationalFunctions)
+realize_on_patch(Phi::MorphismFromRationalFunctions, U::AbsAffineScheme)
+realize_on_open_subset(Phi::MorphismFromRationalFunctions, U::AbsAffineScheme, V::AbsAffineScheme)
+realization_preview(Phi::MorphismFromRationalFunctions, U::AbsAffineScheme, V::AbsAffineScheme)
+random_realization(Phi::MorphismFromRationalFunctions, U::AbsAffineScheme, V::AbsAffineScheme)
+cheap_realization(Phi::MorphismFromRationalFunctions, U::AbsAffineScheme, V::AbsAffineScheme)
+realize_maximally_on_open_subset(Phi::MorphismFromRationalFunctions, U::AbsAffineScheme, V::AbsAffineScheme)
+realize(Phi::MorphismFromRationalFunctions)
 ```
 

--- a/docs/src/AlgebraicGeometry/Schemes/CoveredSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/CoveredSchemes.md
@@ -44,9 +44,9 @@ Other attributes are the `base_ring` over which the scheme is defined and
 
 ## Properties
 An `AbsCoveredScheme` may have different properties such as
-```
-    is_empty(X::AbsCoveredScheme)
-    is_smooth(X::AbsCoveredScheme)
+```julia
+is_empty(X::AbsCoveredScheme)
+is_smooth(X::AbsCoveredScheme)
 ```
 
 ## Methods

--- a/docs/src/AlgebraicGeometry/Schemes/CoveredSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/CoveredSchemes.md
@@ -9,22 +9,22 @@ Oscar supports modeling abstract schemes by means of a covering by affine charts
 ## Types
 The abstract type for these is:
 ```@docs
-    AbsCoveredScheme{BaseRingType}
+AbsCoveredScheme{BaseRingType}
 ```
 The basic concrete instance of an `AbsCoveredScheme` is:
 ```@docs
-    CoveredScheme{BaseRingType}
+CoveredScheme{BaseRingType}
 ```
 
 ## Constructors
 You can manually construct a `CoveredScheme` from a `Covering` using
 ```@docs
-    CoveredScheme(C::Covering)
+CoveredScheme(C::Covering)
 ```
 In most cases, however, you may wish for the computer to provide you with a ready-made
 `Covering` and use a more high-level constructor, such as, for instance,
 ```@docs
-    covered_scheme(P::ProjectiveScheme)
+covered_scheme(P::ProjectiveScheme)
 ```
 
 Other constructors:
@@ -35,11 +35,11 @@ disjoint_union(Xs::Vector{<:AbsCoveredScheme})
 ## Attributes
 To access the affine charts of a `CoveredScheme` $X$ use
 ```@docs
-    affine_charts(X::AbsCoveredScheme)
+affine_charts(X::AbsCoveredScheme)
 ```
 Other attributes are the `base_ring` over which the scheme is defined and
 ```@docs
-    default_covering(X::AbsCoveredScheme)
+default_covering(X::AbsCoveredScheme)
 ```
 
 ## Properties
@@ -51,9 +51,9 @@ is_smooth(X::AbsCoveredScheme)
 
 ## Methods
 ```@docs
-    fiber_product(f::AbsCoveredSchemeMorphism, g::AbsCoveredSchemeMorphism)
-    is_normal(X::AbsCoveredScheme; check::Bool=true)
-    normalization(X::AbsCoveredScheme; check::Bool=true)
+fiber_product(f::AbsCoveredSchemeMorphism, g::AbsCoveredSchemeMorphism)
+is_normal(X::AbsCoveredScheme; check::Bool=true)
+normalization(X::AbsCoveredScheme; check::Bool=true)
 ```
 
 ## The modeling of covered schemes and their expected behavior
@@ -63,7 +63,7 @@ several reasons; for instance, a morphism $f : X \to Y$ between `AbsCoveredSchem
 will in general only be given on affine patches on a refinement of the `default_covering` of `X`.
 The list of available `Covering`s can be obtained using
 ```@docs
-    coverings(X::AbsCoveredScheme)
+coverings(X::AbsCoveredScheme)
 ```
 Every `AbsCoveredScheme` $X$ has to be modeled using one original `default_covering` $C$, simply
 to gather the data necessary to fully describe $X$. The `affine_charts` of $X$ return the

--- a/docs/src/AlgebraicGeometry/Schemes/CoveringsAndGluings.md
+++ b/docs/src/AlgebraicGeometry/Schemes/CoveringsAndGluings.md
@@ -6,24 +6,24 @@ CurrentModule = Oscar
 
 `Covering`s are the backbone data structure for `CoveredScheme`s in Oscar. 
 ```@docs
-    Covering
+Covering
 ```
 
 ## Constructors
 ```@docs
-    Covering(patches::Vector{<:AbsAffineScheme})
-    disjoint_union(C1::Covering, C2::Covering)
+Covering(patches::Vector{<:AbsAffineScheme})
+disjoint_union(C1::Covering, C2::Covering)
 ```
 
 ## Attributes
 ```@docs
-    affine_charts(C::Covering)
-    gluings(C::Covering)
+affine_charts(C::Covering)
+gluings(C::Covering)
 ```
 
 ## Methods
 ```@docs
-    add_gluing!(C::Covering, G::AbsGluing)
+add_gluing!(C::Covering, G::AbsGluing)
 ```
 
 # Gluings
@@ -34,32 +34,32 @@ of affine schemes along an isomorphism $f \colon U \leftrightarrow V \colon g$.
 ## Types 
 The abstract type of any such gluing is 
 ```@docs
-    AbsGluing
+AbsGluing
 ```
 The available concrete types are 
 ```@docs
-    Gluing
-    SimpleGluing
+Gluing
+SimpleGluing
 ```
 
 ## Constructors
 ```@docs
-    Gluing(X::AbsAffineScheme, Y::AbsAffineScheme, f::SchemeMor, g::SchemeMor)
+Gluing(X::AbsAffineScheme, Y::AbsAffineScheme, f::SchemeMor, g::SchemeMor)
 ```
 
 ## Attributes
 ```@docs
-    patches(G::AbsGluing)
-    gluing_domains(G::AbsGluing)
-    gluing_morphisms(G::AbsGluing)
-    inverse(G::AbsGluing)
+patches(G::AbsGluing)
+gluing_domains(G::AbsGluing)
+gluing_morphisms(G::AbsGluing)
+inverse(G::AbsGluing)
 ```
 
 ## Methods
 ```@docs
-    compose(G::AbsGluing, H::AbsGluing)
-    maximal_extension(G::Gluing)
-    restrict(G::AbsGluing, f::AbsAffineSchemeMor, g::AbsAffineSchemeMor; check::Bool=true)
+compose(G::AbsGluing, H::AbsGluing)
+maximal_extension(G::Gluing)
+restrict(G::AbsGluing, f::AbsAffineSchemeMor, g::AbsAffineSchemeMor; check::Bool=true)
 ```
 
 

--- a/docs/src/AlgebraicGeometry/Schemes/GeneralSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/GeneralSchemes.md
@@ -11,14 +11,14 @@ Scheme{BaseRingType<:Ring}
 ```
 Morphisms of schemes shall be derived from the abstract type
 ```@docs
-    SchemeMor{DomainType, CodomainType, MorphismType, BaseMorType}
+SchemeMor{DomainType, CodomainType, MorphismType, BaseMorType}
 ```
 
 ## Change of base
 ```@docs
-    base_change(phi::Any, X::Scheme)
-    base_change(phi::Any, f::SchemeMor;
-        domain_map::AbsSchemeMor, codomain_map::AbsSchemeMor
-      )
+base_change(phi::Any, X::Scheme)
+base_change(phi::Any, f::SchemeMor;
+    domain_map::AbsSchemeMor, codomain_map::AbsSchemeMor
+    )
 ```
    

--- a/docs/src/AlgebraicGeometry/Schemes/MorphismsOfAffineSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/MorphismsOfAffineSchemes.md
@@ -40,7 +40,7 @@ graph(f::AbsAffineSchemeMor)
 In addition to the standard getters and methods for instances
 of `AffineSchemeMor`, we also have
 ```@docs
-    image_ideal(f::ClosedEmbedding)
+image_ideal(f::ClosedEmbedding)
 ```
 
 ### Undocumented

--- a/docs/src/AlgebraicGeometry/Schemes/MorphismsOfProjectiveSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/MorphismsOfProjectiveSchemes.md
@@ -28,9 +28,9 @@ out.
 ```
 ## Attributes
 As every instance of `Map`, a morphism of projective schemes can be asked for its (co-)domain:
-```
-    domain(phi::ProjectiveSchemeMor) 
-    codomain(phi::ProjectiveSchemeMor)
+```julia
+domain(phi::ProjectiveSchemeMor) 
+codomain(phi::ProjectiveSchemeMor)
 ```
 Moreover, we provide getters for the associated morphisms of rings:
 ```@docs

--- a/docs/src/AlgebraicGeometry/Schemes/MorphismsOfProjectiveSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/MorphismsOfProjectiveSchemes.md
@@ -17,14 +17,14 @@ out.
 
 ## Types 
 ```@docs
-    ProjectiveSchemeMor
+ProjectiveSchemeMor
 ```
 
 ## Constructors
 ```@docs
-    morphism(P::AbsProjectiveScheme, Q::AbsProjectiveScheme, f::Map; check::Bool=true )
-    morphism(P::AbsProjectiveScheme, Q::AbsProjectiveScheme, f::Map, h::SchemeMor; check::Bool=true )
-    morphism(X::AbsProjectiveScheme, Y::AbsProjectiveScheme, a::Vector{<:RingElem})
+morphism(P::AbsProjectiveScheme, Q::AbsProjectiveScheme, f::Map; check::Bool=true )
+morphism(P::AbsProjectiveScheme, Q::AbsProjectiveScheme, f::Map, h::SchemeMor; check::Bool=true )
+morphism(X::AbsProjectiveScheme, Y::AbsProjectiveScheme, a::Vector{<:RingElem})
 ```
 ## Attributes
 As every instance of `Map`, a morphism of projective schemes can be asked for its (co-)domain:
@@ -34,13 +34,13 @@ codomain(phi::ProjectiveSchemeMor)
 ```
 Moreover, we provide getters for the associated morphisms of rings:
 ```@docs
-    pullback(phi::ProjectiveSchemeMor)
-    base_ring_morphism(phi::ProjectiveSchemeMor) 
-    base_map(phi::ProjectiveSchemeMor)
-    map_on_affine_cones(phi::ProjectiveSchemeMor)
+pullback(phi::ProjectiveSchemeMor)
+base_ring_morphism(phi::ProjectiveSchemeMor) 
+base_map(phi::ProjectiveSchemeMor)
+map_on_affine_cones(phi::ProjectiveSchemeMor)
 ```
 ## Methods
 ```@docs
-    covered_scheme_morphism(f::AbsProjectiveSchemeMorphism)
+covered_scheme_morphism(f::AbsProjectiveSchemeMorphism)
 ```
 

--- a/docs/src/AlgebraicGeometry/Schemes/ProjectiveSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/ProjectiveSchemes.md
@@ -20,8 +20,8 @@ and `MPolyQuoLocRing`.
 
 ## Abstract types and basic interface
 The abstract type for such projective schemes is
-```
-    AbsProjectiveScheme{CoeffRingType, RingType} where {CoeffRingType<:Ring}
+```julia
+AbsProjectiveScheme{CoeffRingType, RingType} where {CoeffRingType<:Ring}
 ```
 where, in the above notation, `CoeffRingType` denotes the type of `A`
 and `RingType` the type of either `S` or `S/I`, respectively.
@@ -39,8 +39,8 @@ The abstract type comes with the following interface:
     covered_scheme(P::AbsProjectiveScheme)
 ```
 The minimal concrete type realizing this interface is
-```
-    ProjectiveScheme{CoeffRingType, RingType} <: AbsProjectiveScheme{CoeffRingType, RingType}
+```julia
+ProjectiveScheme{CoeffRingType, RingType} <: AbsProjectiveScheme{CoeffRingType, RingType}
 ```
 
 
@@ -48,11 +48,11 @@ The minimal concrete type realizing this interface is
 
 Besides `proj(S)` for some graded polynomial ring or a graded affine algebra `S`, we
 provide the following constructors:
-```
-    proj(S::MPolyDecRing)
-    proj(S::MPolyDecRing, I::MPolyIdeal{T}) where {T<:MPolyDecRingElem}
-    proj(I::MPolyIdeal{<:MPolyDecRingElem})
-    proj(Q::MPolyQuoRing{<:MPolyDecRingElem})
+```julia
+proj(S::MPolyDecRing)
+proj(S::MPolyDecRing, I::MPolyIdeal{T}) where {T<:MPolyDecRingElem}
+proj(I::MPolyIdeal{<:MPolyDecRingElem})
+proj(Q::MPolyQuoRing{<:MPolyDecRingElem})
 ```
 Subschemes defined by homogeneous ideals, ring elements, or lists of elements can be created
 via the respective methods of the `subscheme(P::AbsProjectiveScheme, ...)` function.
@@ -66,10 +66,10 @@ Special constructors are provided for projective space itself via the function
 ## Attributes
 Besides those attributes already covered by the above general interface we have the following
 (self-explanatory) ones for projective schemes over a field.
-```
-    dim(P::AbsProjectiveScheme{<:Field})
-    hilbert_polynomial(P::AbsProjectiveScheme{<:Field})
-    degree(P::AbsProjectiveScheme{<:Field})
+```julia
+dim(P::AbsProjectiveScheme{<:Field})
+hilbert_polynomial(P::AbsProjectiveScheme{<:Field})
+degree(P::AbsProjectiveScheme{<:Field})
 ```
 
 ```@docs
@@ -91,12 +91,12 @@ Further properties of projective schemes:
 ```@docs
     is_smooth(P::AbsProjectiveScheme)
 ```
-```
-    is_empty(P::AbsProjectiveScheme{<:Field})
-    is_irreducible(P::AbsProjectiveScheme)
-    is_reduced(P::AbsProjectiveScheme)
-    is_geometrically_reduced(P::AbsProjectiveScheme{<:Field})
-    is_geometrically_irreducible(P::AbsProjectiveScheme{<:Field})
-    is_integral(X::AbsProjectiveScheme{<:Field})
-    is_geometrically_integral(X::AbsProjectiveScheme{<:Field})
+```julia
+is_empty(P::AbsProjectiveScheme{<:Field})
+is_irreducible(P::AbsProjectiveScheme)
+is_reduced(P::AbsProjectiveScheme)
+is_geometrically_reduced(P::AbsProjectiveScheme{<:Field})
+is_geometrically_irreducible(P::AbsProjectiveScheme{<:Field})
+is_integral(X::AbsProjectiveScheme{<:Field})
+is_geometrically_integral(X::AbsProjectiveScheme{<:Field})
 ```

--- a/docs/src/AlgebraicGeometry/Schemes/ProjectiveSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/ProjectiveSchemes.md
@@ -27,16 +27,16 @@ where, in the above notation, `CoeffRingType` denotes the type of `A`
 and `RingType` the type of either `S` or `S/I`, respectively.
 The abstract type comes with the following interface:
 ```@docs
-    base_ring(X::AbsProjectiveScheme)
-    base_scheme(X::AbsProjectiveScheme)
-    homogeneous_coordinate_ring(P::AbsProjectiveScheme)
-    relative_ambient_dimension(X::AbsProjectiveScheme)
-    ambient_coordinate_ring(P::AbsProjectiveScheme)
-    ambient_space(P::AbsProjectiveScheme)
-    defining_ideal(X::AbsProjectiveScheme)
-    affine_cone(X::AbsProjectiveScheme)
-    homogeneous_coordinates_on_affine_cone(X::AbsProjectiveScheme)
-    covered_scheme(P::AbsProjectiveScheme)
+base_ring(X::AbsProjectiveScheme)
+base_scheme(X::AbsProjectiveScheme)
+homogeneous_coordinate_ring(P::AbsProjectiveScheme)
+relative_ambient_dimension(X::AbsProjectiveScheme)
+ambient_coordinate_ring(P::AbsProjectiveScheme)
+ambient_space(P::AbsProjectiveScheme)
+defining_ideal(X::AbsProjectiveScheme)
+affine_cone(X::AbsProjectiveScheme)
+homogeneous_coordinates_on_affine_cone(X::AbsProjectiveScheme)
+covered_scheme(P::AbsProjectiveScheme)
 ```
 The minimal concrete type realizing this interface is
 ```julia
@@ -59,8 +59,8 @@ via the respective methods of the `subscheme(P::AbsProjectiveScheme, ...)` funct
 Special constructors are provided for projective space itself via the function
 `projective_space` and its various methods.
 ```@docs
-    projective_space(A::Ring, var_symb::Vector{VarName})
-    projective_space(A::Ring, r::Int; var_name::VarName=:s)
+projective_space(A::Ring, var_symb::Vector{VarName})
+projective_space(A::Ring, r::Int; var_name::VarName=:s)
 ```
 
 ## Attributes
@@ -73,7 +73,7 @@ degree(P::AbsProjectiveScheme{<:Field})
 ```
 
 ```@docs
-    arithmetic_genus(P::AbsProjectiveScheme{<:Field})
+arithmetic_genus(P::AbsProjectiveScheme{<:Field})
 ```
 
 ## Methods
@@ -81,15 +81,15 @@ degree(P::AbsProjectiveScheme{<:Field})
 To facilitate the interplay between an `AbsProjectiveScheme` and the affine charts of its
 `covered_scheme` we provide the following methods:
 ```@docs
-    dehomogenization_map(X::AbsProjectiveScheme, U::AbsAffineScheme)
-    homogenization_map(P::AbsProjectiveScheme, U::AbsAffineScheme)
+dehomogenization_map(X::AbsProjectiveScheme, U::AbsAffineScheme)
+homogenization_map(P::AbsProjectiveScheme, U::AbsAffineScheme)
 ```
 
 ## Properties
 
 Further properties of projective schemes:
 ```@docs
-    is_smooth(P::AbsProjectiveScheme)
+is_smooth(P::AbsProjectiveScheme)
 ```
 ```julia
 is_empty(P::AbsProjectiveScheme{<:Field})

--- a/docs/src/CommutativeAlgebra/FrameWorks/module_localizations.md
+++ b/docs/src/CommutativeAlgebra/FrameWorks/module_localizations.md
@@ -23,7 +23,7 @@ requirements are met:
 
  2) The user has to solve the *localization problem* by implementing `has_nonempty_intersection(U::MultSetType, I::IdealType)` for the type `MultSetType` of multiplicative sets and the type `IdealType` of ideals in `R` that they would like to consider.
 ```@docs
-    has_nonempty_intersection(U::AbsMultSet, I::Ideal)
+has_nonempty_intersection(U::AbsMultSet, I::Ideal)
 ```
 **Note:** In order to clear denominators of row vectors, the generic code uses the method `lcm(v::Vector{T})` where `T = elem_type(R)`. 
 If no such method already exists, this has to also be provided; in the worst case by simply returning the product of the denominators. 

--- a/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
@@ -243,7 +243,7 @@ reduce(g::T, F::Vector{T};
 reduce_with_quotients(g::T, F::Vector{T}; 
     ordering::MonomialOrdering = default_ordering(parent(F[1]))) where T <: MPolyRingElem
 ```
-      
+
 ```@docs
 reduce_with_quotients_and_unit(g::T, F::Vector{T}; 
     ordering::MonomialOrdering = default_ordering(parent(F[1]))) where T <: MPolyRingElem

--- a/docs/src/CommutativeAlgebra/ideals.md
+++ b/docs/src/CommutativeAlgebra/ideals.md
@@ -90,7 +90,7 @@ cm_regularity(I::MPolyIdeal)
 ```@docs
 degree(I::MPolyIdeal)
 ```
-    
+
 ## Operations on Ideals
 
 ### Simple Ideal Operations
@@ -100,6 +100,7 @@ degree(I::MPolyIdeal)
 ```@docs
 ^(I::MPolyIdeal, m::Int)
 ```
+
 #### Sum of Ideals
 
 ```@docs

--- a/docs/src/CommutativeAlgebra/localizations.md
+++ b/docs/src/CommutativeAlgebra/localizations.md
@@ -62,9 +62,9 @@ In accordance with the above mentioned types, we have the following constructors
 for multiplicatively closed subsets of multivariate polynomial rings.
 
 ```@docs
-    complement_of_point_ideal(R::MPolyRing, a::Vector)
-    complement_of_prime_ideal(P::MPolyIdeal; check::Bool=false)
-    powers_of_element(f::MPolyRingElem)
+complement_of_point_ideal(R::MPolyRing, a::Vector)
+complement_of_prime_ideal(P::MPolyIdeal; check::Bool=false)
+powers_of_element(f::MPolyRingElem)
 ```
 
 It is also possible to build products of multiplicatively closed sets already given:

--- a/docs/src/DeveloperDocumentation/styleguide.md
+++ b/docs/src/DeveloperDocumentation/styleguide.md
@@ -217,12 +217,12 @@ the user's convenience.
 Let's see an example. Say, you want to implement the characteristic 
 polynomial of a matrix. You could do it as follows:
 ```julia
-  function characteristic_polynomial(A::MatrixElem)
-    kk = base_ring(A)
-    P, x = kk["x"]
-    AP = change_base_ring(P, A)
-    return det(AP - x*one(AP))
-  end
+function characteristic_polynomial(A::MatrixElem)
+  kk = base_ring(A)
+  P, x = kk["x"]
+  AP = change_base_ring(P, A)
+  return det(AP - x*one(AP))
+end
 ```
 You can see that the polynomial ring `P`, i.e. the parent of the output, 
 is newly created in the body of the function. In particular, calling this 
@@ -232,25 +232,25 @@ with different parents. Calling `p + q` will result in an error.
 
 To solve this, we should have implemented the function differently:
 ```julia
-  # Implementation of the recommended keyword argument signature:
-  function characteristic_polynomial(
-      A::MatrixElem;
-      parent::AbstractAlgebra.Ring=polynomial_ring(base_ring(A), :t)[1]
-    )
-    AP = change_base_ring(parent, A)
-    x = first(gens(ring))
-    return det(AP - x*one(AP))
-  end
+# Implementation of the recommended keyword argument signature:
+function characteristic_polynomial(
+    A::MatrixElem;
+    parent::AbstractAlgebra.Ring=polynomial_ring(base_ring(A), :t)[1]
+  )
+  AP = change_base_ring(parent, A)
+  x = first(gens(ring))
+  return det(AP - x*one(AP))
+end
 
-  # Optional second signature to also allow for the specification of the 
-  # output's parent as the first argument:
-  function characteristic_polynomial(
-      P::PolyRing,
-      A::MatrixElem
-    )
-    coefficient_ring(P) === base_ring(A) || error("coefficient rings incompatible")
-    return characteristic_polynomial(A, parent=P)
-  end
+# Optional second signature to also allow for the specification of the 
+# output's parent as the first argument:
+function characteristic_polynomial(
+    P::PolyRing,
+    A::MatrixElem
+  )
+  coefficient_ring(P) === base_ring(A) || error("coefficient rings incompatible")
+  return characteristic_polynomial(A, parent=P)
+end
 ```
 In fact this now allows for two different entry points for the parent ring `P` 
 of the output: First as the required `parent` keyword argument and second 

--- a/docs/src/DeveloperDocumentation/styleguide.md
+++ b/docs/src/DeveloperDocumentation/styleguide.md
@@ -168,7 +168,7 @@ end
     or
     ```julia
     for i in A
-      flag ||continue
+      flag || continue
       ...
     end
     ```

--- a/docs/src/NoncommutativeAlgebra/PBWAlgebras/creation.md
+++ b/docs/src/NoncommutativeAlgebra/PBWAlgebras/creation.md
@@ -37,7 +37,7 @@ Note that any  global monomial ordering on $\text{Mon}_{2n}(x, \partial)$ is adm
 The constructor below returns the algebras equipped with `degrevlex`.
 
 ```@docs
-    weyl_algebra(K::Ring, xs::AbstractVector{<:VarName})
+weyl_algebra(K::Ring, xs::AbstractVector{<:VarName})
 ```
 
 ### Universal Enveloping Algebras of Finite Dimensional Lie Algebras

--- a/docs/src/NoncommutativeAlgebra/PBWAlgebras/quotients.md
+++ b/docs/src/NoncommutativeAlgebra/PBWAlgebras/quotients.md
@@ -38,7 +38,7 @@ modulo the two-sided ideal
 $\langle e_1^2,\dots, e_n^2\rangle.$
 
 ```@docs
-    exterior_algebra
+exterior_algebra
 ```
 
 ## Data Associated to Affine GR-Algebras

--- a/experimental/DoubleAndHyperComplexes/docs/src/user_interface.md
+++ b/experimental/DoubleAndHyperComplexes/docs/src/user_interface.md
@@ -23,13 +23,13 @@ abstract type `AbsDoubleComplexOfMorphisms`. These functions comprise
   getindex(D::AbsDoubleComplexOfMorphisms, i::Int, j::Int) # Get the `(i,j)`-th entry of `D`
 ```
 ```@docs
-    horizontal_map(dc::AbsDoubleComplexOfMorphisms, i::Int, j::Int)
-    vertical_map(dc::AbsDoubleComplexOfMorphisms, i::Int, j::Int)
+horizontal_map(dc::AbsDoubleComplexOfMorphisms, i::Int, j::Int)
+vertical_map(dc::AbsDoubleComplexOfMorphisms, i::Int, j::Int)
 ```
 In which direction the maps in the rows and columns go can be asked with the following methods:
 ```@docs
-    horizontal_direction(dc::AbsDoubleComplexOfMorphisms)
-    vertical_direction(dc::AbsDoubleComplexOfMorphisms)
+horizontal_direction(dc::AbsDoubleComplexOfMorphisms)
+vertical_direction(dc::AbsDoubleComplexOfMorphisms)
 ```
 Double complexes can be bounded or unbounded. It is important to note that even if such 
 bounds exist and are known, this is a priori **not** related to whether or not 
@@ -50,28 +50,28 @@ various generic functionalities.
 For example, computing a total complex is only possible in practice if one has an a priori estimate 
 where the non-zero entries are located. For such purposes, we provide the following functionality:
 ```@docs
-    has_upper_bound(D::AbsDoubleComplexOfMorphisms)
-    has_lower_bound(D::AbsDoubleComplexOfMorphisms)
-    has_right_bound(D::AbsDoubleComplexOfMorphisms)
-    has_left_bound(D::AbsDoubleComplexOfMorphisms)
+has_upper_bound(D::AbsDoubleComplexOfMorphisms)
+has_lower_bound(D::AbsDoubleComplexOfMorphisms)
+has_right_bound(D::AbsDoubleComplexOfMorphisms)
+has_left_bound(D::AbsDoubleComplexOfMorphisms)
 ```
 If they exist, these bounds can be asked for using 
 ```@docs
-    right_bound(D::AbsDoubleComplexOfMorphisms)
-    left_bound(D::AbsDoubleComplexOfMorphisms)
-    upper_bound(D::AbsDoubleComplexOfMorphisms)
-    lower_bound(D::AbsDoubleComplexOfMorphisms)
+right_bound(D::AbsDoubleComplexOfMorphisms)
+left_bound(D::AbsDoubleComplexOfMorphisms)
+upper_bound(D::AbsDoubleComplexOfMorphisms)
+lower_bound(D::AbsDoubleComplexOfMorphisms)
 ```
 It is also possible to query whether or not a double complex 
 is already complete in the sense that it knows about all of its 
 non-zero entries.
 ```@docs
-    is_complete(D::AbsDoubleComplexOfMorphisms)
+is_complete(D::AbsDoubleComplexOfMorphisms)
 ```
 
 ## Generic functionality
 ```@docs
-    total_complex(D::AbsDoubleComplexOfMorphisms)
+total_complex(D::AbsDoubleComplexOfMorphisms)
 ```
 
 ## Constructors

--- a/experimental/ExperimentalTemplate/docs/doc.main
+++ b/experimental/ExperimentalTemplate/docs/doc.main
@@ -5,4 +5,4 @@ You can show docstrings like this:
 ```@docs
 my_access_func(S::ExampleStruct)
 ```
-    
+

--- a/experimental/ExperimentalTemplate/docs/doc.main
+++ b/experimental/ExperimentalTemplate/docs/doc.main
@@ -3,6 +3,6 @@
 This is a sample text to outline the structure of the packages in the `Experimental` folder.
 You can show docstrings like this:
 ```@docs
-    my_access_func(S::ExampleStruct)
+my_access_func(S::ExampleStruct)
 ```
     

--- a/experimental/StandardFiniteFields/docs/src/introduction.md
+++ b/experimental/StandardFiniteFields/docs/src/introduction.md
@@ -7,5 +7,5 @@ end
 
 
 ```@docs
-    standard_finite_field(p::IntegerUnion, n::IntegerUnion)
+standard_finite_field(p::IntegerUnion, n::IntegerUnion)
 ```

--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -471,8 +471,8 @@ case, `n` is NOT the number of moved points, but the degree of `H`.
 If `W` is a wreath product of `G` and `H`, {`g_1`, ..., `g_n`} are elements of
 `G` and `h` in `H`, the element `(g_1, ..., h)` of `W` can be obtained by
 typing
-```
-    W(g_1,...,g_n, h).
+```julia
+W(g_1,...,g_n, h).
 ```
 
 # Examples


### PR DESCRIPTION
IMO at least the first commit should get backported (or at least the parts of it that don't create conflicts) as the resulting HTML looks a bit weird with all code indented.

Preview: tba