### PR TITLE
enable broadcasting for `GAPGroupElement`

### DIFF
--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -28,6 +28,9 @@ i.e., if `g` is a `GAPGroupElem`, then `GapObj(g)` is the `GapObj` underlying `g
 """
 abstract type GAPGroupElem{T<:GAPGroup} <: AbstractAlgebra.GroupElem end
 
+## Scalar for broadcasting
+Base.broadcastable(x::GAPGroupElem) = Ref(x)
+
 ## `GapGroupElem` to GAP group element
 GAP.julia_to_gap(obj::GAPGroupElem) = obj.X
 

--- a/test/Groups/conformance.jl
+++ b/test/Groups/conformance.jl
@@ -49,6 +49,10 @@ include(joinpath(dirname(pathof(AbstractAlgebra)), "..", "test", "Groups-conform
       end
    end
 
+   @testset "Broadcast" begin
+      @test g .* gens(G) == [g * x for x in gens(G)]
+   end
+
    @testset "Comparison methods" begin
       if G isa PermGroup
       @test (g==h) isa Bool


### PR DESCRIPTION
(suggested by @fieker)

Should this eventually be moved to `AbstractAlgebra.GroupElem`?
And wouldn't broadcasting be interesting also for `FinGenAbGroupElem` or `AbstractAlgebra.AdditiveGroupElem`?