### PR TITLE
`FreeResolution` as hypercomplex

### DIFF
--- a/experimental/DoubleAndHyperComplexes/src/DoubleAndHyperComplexes.jl
+++ b/experimental/DoubleAndHyperComplexes/src/DoubleAndHyperComplexes.jl
@@ -1,4 +1,7 @@
 include("Objects/Types.jl")
+### Modified FreeResolution
+include("FreeResolutionTypes.jl")
+
 include("Objects/Attributes.jl")
 include("Objects/tensor_products.jl")
 include("Objects/tor.jl")
@@ -22,3 +25,7 @@ include("Morphisms/linear_strands.jl")
 include("Morphisms/methods.jl")
 include("Objects/Methods.jl")
 include("Exports.jl")
+
+### Modified FreeResolution
+include("FreeResolutions.jl")
+

--- a/experimental/DoubleAndHyperComplexes/src/FreeResolutionTypes.jl
+++ b/experimental/DoubleAndHyperComplexes/src/FreeResolutionTypes.jl
@@ -1,0 +1,35 @@
+########################################################################
+# FreeResolution -- type declarations
+########################################################################
+#
+@doc raw"""
+    FreeResolution{T}
+
+Data structure for free resolutions.
+"""
+mutable struct FreeResolution{ChainType, MorphismType} <: AbsHyperComplex{ChainType, MorphismType}
+    C::Hecke.ComplexOfMorphisms
+    underlying_complex::SimpleComplexWrapper{ChainType, MorphismType}
+
+    function FreeResolution(C::Hecke.ComplexOfMorphisms{T}) where {T}
+        FR = new{T, morphism_type(T)}()
+        FR.C = C
+
+        return FR
+    end
+end
+
+Base.getindex(FR::FreeResolution, i::Int) = FR.C[i]
+
+function Base.show(io::IO, FR::FreeResolution)
+    C = FR.C
+    show(io, C)
+end
+
+function underlying_complex(res::FreeResolution)
+  if !isdefined(res, :underlying_complex)
+    res.underlying_complex = SimpleComplexWrapper(res.C)
+  end
+  return res.underlying_complex
+end
+

--- a/experimental/DoubleAndHyperComplexes/src/Objects/Types.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/Types.jl
@@ -134,7 +134,7 @@ upper_bound(C::AbsHyperComplex) = (isone(dim(C)) ? upper_bound(C, 1) : error("co
 lower_bound(C::AbsSimpleComplex) = lower_bound(C, 1)
 lower_bound(C::AbsHyperComplex) = (isone(dim(C)) ? lower_bound(C, 1) : error("complex must be one-dimensional"))
 Base.range(C::AbsHyperComplex) = (direction(C) == :chain ? (upper_bound(C):-1:lower_bound(C)) : (lower_bound(C):upper_bound(C)))
-map_range(C::AbsHyperComplex) = (direction(C) == :chain ? (upper_bound(C):-1:lower_bound(C)+1) : (lower_bound(C):upper_bound(C)-1))
+Hecke.map_range(C::AbsHyperComplex) = (direction(C) == :chain ? (upper_bound(C):-1:lower_bound(C)+1) : (lower_bound(C):upper_bound(C)-1))
 
 underlying_complex(C::AbsSimpleComplex) = error("underlying_complex not implemented for $C")
 

--- a/experimental/DoubleAndHyperComplexes/src/Objects/tensor_products.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/tensor_products.jl
@@ -196,6 +196,15 @@ function tensor_product(list::Vector{T}) where {T<:ComplexOfMorphisms}
                      )
 end
 
+function tensor_product(M::ModuleFP, comp::AbsHyperComplex{T}) where {T<:ModuleFP}
+  return tensor_product([ZeroDimensionalComplex(M), comp])
+end
+
+function tensor_product(comp::AbsHyperComplex{T}, M::ModuleFP) where {T<:ModuleFP}
+  return tensor_product([comp, ZeroDimensionalComplex(M)])
+end
+
+
 ########################################################################
 # Tensor products of hypercomplexes                                    #
 ########################################################################
@@ -222,7 +231,7 @@ function (fac::HCTensorProductChainFactory{ChainType})(c::AbsHyperComplex, I::Tu
     k = k + dim(f)
   end
   factors = [fac.factors[k][Tuple(a)] for (k, a) in enumerate(j)]
-  any(iszero, factors) && return zero_object(first(factors))[1]
+  #any(iszero, factors) && return zero_object(first(factors))[1] # Breaks the property of being a tensor product for the returned module, hence disabled
   tmp_res = _tensor_product(factors...)
   @assert tmp_res isa Tuple{<:ChainType, <:Map} "the output of `tensor_product` does not have the anticipated format; see the source code for details"
   # If you got here because of the error message above:

--- a/experimental/DoubleAndHyperComplexes/test/HyperComplexes.jl
+++ b/experimental/DoubleAndHyperComplexes/test/HyperComplexes.jl
@@ -32,7 +32,7 @@
   HCz = Oscar.SimpleComplexWrapper(Cz, auto_extend=true)
 
   @test range(HCx) == range(Cx)
-  @test map_range(HCx) == map_range(Cx)
+  @test Hecke.map_range(HCx) == Hecke.map_range(Cx)
   @test HCx[0] === R1
   @test HCx[1] === R1
   @test map(HCx, 1)(R1[1]) == x*R1[1]

--- a/experimental/DoubleAndHyperComplexes/test/vector_spaces.jl
+++ b/experimental/DoubleAndHyperComplexes/test/vector_spaces.jl
@@ -33,9 +33,9 @@
   end
 
   tot = total_complex(D)
-  for i in map_range(tot)
-    i == last(map_range(tot)) && continue
-    if i != first(map_range(tot)) && i != last(map_range(tot)) + 1
+  for i in Hecke.map_range(tot)
+    i == last(Hecke.map_range(tot)) && continue
+    if i != first(Hecke.map_range(tot)) && i != last(Hecke.map_range(tot)) + 1
       @test !iszero(map(tot, i)) || !iszero(map(tot, i-1))
     end
     @test iszero(compose(map(tot, i), map(tot, i-1)))

--- a/src/Modules/ModuleTypes.jl
+++ b/src/Modules/ModuleTypes.jl
@@ -741,29 +741,6 @@ struct FreeModuleHom_dec{
   end
 end
 
-@doc raw"""
-    FreeResolution{T}
-
-Data structure for free resolutions.
-"""
-mutable struct FreeResolution{T}
-    C::Hecke.ComplexOfMorphisms
-
-    function FreeResolution(C::Hecke.ComplexOfMorphisms{T}) where {T}
-        FR = new{T}()
-        FR.C = C
-
-        return FR
-    end
-end
-
-Base.getindex(FR::FreeResolution, i::Int) = FR.C[i]
-
-function Base.show(io::IO, FR::FreeResolution)
-    C = FR.C
-    show(io, C)
-end
-
 mutable struct BettiTable
   B::Dict{Tuple{Int, Any}, Int}
   project::Union{FinGenAbGroupElem, Nothing}

--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -1454,13 +1454,13 @@ total: 1  3  2
 ```
 """
 function betti_table(F::FreeResolution; project::Union{FinGenAbGroupElem, Nothing} = nothing, reverse_direction::Bool=false)
-  @assert is_graded(F) "resolution must be graded"
   generator_count = Dict{Tuple{Int, Any}, Int}()
   C = F.C
   rng = Hecke.map_range(C)
   n = first(rng)
   for i in 0:n
     module_degrees = F[i].d
+    module_degrees === nothing && error("One of the modules in the graded free resolution is not graded.")
     for degree in module_degrees
       idx = (i, degree)
       generator_count[idx] = get(generator_count, idx, 0) + 1
@@ -1558,6 +1558,7 @@ function Base.show(io::IO, b::BettiTable)
           print(io, " "^(column_widths[i_total] - ndigits(sum_row)-1))
         end
       end
+      print(io, "\n")
     end
   else
     parent(b.project) == parent(x[1][2]) || error("projection vector has wrong type")
@@ -2572,6 +2573,7 @@ julia> betti_table(FA)
 2    : -  -  1  1  
 ------------------
 total: 1  5  6  2  
+
 
 julia> minimal_betti_table(FA)
        0  1  2  3  

--- a/src/Modules/UngradedModules/HomologicalAlgebra.jl
+++ b/src/Modules/UngradedModules/HomologicalAlgebra.jl
@@ -151,9 +151,9 @@ function tensor_product(P::ModuleFP, C::Hecke.ComplexOfMorphisms{ModuleFP})
   return Hecke.ComplexOfMorphisms(ModuleFP, tensor_chain, seed=C.seed, typ=C.typ)
 end
 
-function tensor_product(M::ModuleFP, F::FreeResolution)
-  return tensor_product(M, F.C)
-end
+#function tensor_product(M::ModuleFP, F::FreeResolution)
+#  return tensor_product(M, F.C)
+#end
 
 
 @doc raw"""
@@ -180,9 +180,9 @@ function tensor_product(C::Hecke.ComplexOfMorphisms{<:ModuleFP}, P::ModuleFP)
   return Hecke.ComplexOfMorphisms(ModuleFP, tensor_chain, seed=C.seed, typ=C.typ)
 end
 
-function tensor_product(F::FreeResolution, M::ModuleFP)
-  return tensor_product(F.C, M)
-end
+#function tensor_product(F::FreeResolution, M::ModuleFP)
+#  return tensor_product(F.C, M)
+#end
 
 @doc raw"""
     tor(M::ModuleFP, N::ModuleFP, i::Int)
@@ -316,9 +316,9 @@ function hom(P::ModuleFP, C::Hecke.ComplexOfMorphisms{ModuleFP})
   return Hecke.ComplexOfMorphisms(ModuleFP, hom_chain, seed=C.seed, typ=C.typ)
 end
 
-function hom(M::ModuleFP, F::FreeResolution)
-  return hom(M, F.C)
-end
+#function hom(M::ModuleFP, F::FreeResolution)
+#  return hom(M, F.C)
+#end
 
 @doc raw"""
     hom(C::ComplexOfMorphisms{ModuleFP}, M::ModuleFP)
@@ -374,9 +374,9 @@ function hom(C::Hecke.ComplexOfMorphisms{T}, P::ModuleFP) where {T<:ModuleFP}
   return Hecke.ComplexOfMorphisms(ModuleFP, reverse(hom_chain), seed=seed, typ=typ)
 end
 
-function hom(F::FreeResolution, M::ModuleFP)
-  return hom(F.C, M)
-end
+#function hom(F::FreeResolution, M::ModuleFP)
+#  return hom(F.C, M)
+#end
 
 @doc raw"""
     hom_without_reversing_direction(C::ComplexOfMorphisms{ModuleFP}, M::ModuleFP)
@@ -431,10 +431,6 @@ function hom_without_reversing_direction(C::Hecke.ComplexOfMorphisms{ModuleFP}, 
   return Hecke.ComplexOfMorphisms(ModuleFP, reverse(hom_chain), seed=-first(chain_range(C)), typ=C.typ)
 end
 
-function hom_without_reversing_direction(F::FreeResolution, M::ModuleFP)
-  return hom_without_reversing_direction(F.C, M)
-end
-
 
 #############################
 @doc raw"""
@@ -478,10 +474,6 @@ by Submodule with 2 generators
 """
 function homology(C::Hecke.ComplexOfMorphisms{<:ModuleFP})
   return [homology(C,i) for i in Hecke.range(C)]
-end
-
-function homology(C::FreeResolution)
-  return homology(C.C)
 end
 
 

--- a/src/Modules/UngradedModules/UngradedModules.jl
+++ b/src/Modules/UngradedModules/UngradedModules.jl
@@ -6,7 +6,7 @@ include("SubModuleOfFreeModule.jl")
 include("SubquoModule.jl")
 include("SubquoModuleElem.jl")
 include("Presentation.jl")
-include("FreeResolutions.jl")
+#include("FreeResolutions.jl") # moved to experimental/DoubleAndHyperComplexes/ due to dependencies.
 include("HomologicalAlgebra.jl")
 include("SubQuoHom.jl")
 include("Methods.jl")

--- a/src/Modules/flattenings.jl
+++ b/src/Modules/flattenings.jl
@@ -81,36 +81,6 @@ function coordinates(
   return map_entries(inverse(flat), c)
 end
 
-function free_resolution(
-    M::SubquoModule{T}
-  ) where {T <: FlattableRingElemType}
-  flat = flatten(base_ring(M))
-  M_flat, iso_M, iso_M_inv = flat(M)
-  comp = free_resolution(M_flat) # assuming that this is potentially cached
-  if !haskey(flat_counterparts(flat), comp)
-    res_obj = ModuleFP[]
-    isos = ModuleFPHom[]
-    push!(res_obj, M)
-    push!(isos, iso_M_inv)
-    res_maps = Map[]
-    for i in 0:first(chain_range(comp))
-      F_flat = comp[i]
-      @assert F_flat === domain(map(comp, i))
-      @assert domain(last(isos)) === codomain(map(comp, i))
-      F, iso_F_inv = _change_base_ring_and_preserve_gradings(inverse(flat), F_flat)
-      iso_F = hom(F, F_flat, gens(F_flat), flat; check=false)
-      push!(res_maps, hom(F, last(res_obj), last(isos).(map(comp, i).(iso_F.(gens(F)))); check=false))
-      push!(res_obj, F)
-      push!(isos, iso_F_inv)
-    end
-    comp_up = ComplexOfMorphisms(ModuleFP, reverse(res_maps), typ=:chain, seed=-1, check=false)
-    comp_up.complete = true
-    result = FreeResolution(comp_up)
-    flat_counterparts(flat)[comp] = result
-  end
-  return flat_counterparts(flat)[comp]::FreeResolution
-end
-
 function (phi::RingFlattening)(f::ModuleFPHom)
   if !haskey(flat_counterparts(phi), f)
     dom = domain(f)

--- a/test/Modules/ModulesGraded.jl
+++ b/test/Modules/ModulesGraded.jl
@@ -646,16 +646,18 @@ end
     end
     N = SubquoModule(F1, Rg[x*y+2*x^2; x+y], Rg[z^4; x^2-y*z])
     hom_resolution = hom(free_res,N)
-    @test last(chain_range(hom_resolution)) == first(chain_range(free_res))
-    @test first(chain_range(hom_resolution)) == last(chain_range(free_res))
-    for i in Hecke.map_range(hom_resolution)
-        f = map(free_res,i+1)         #f[i]: M[i] -> M[i-1]
-        hom_f = map(hom_resolution,i) #f[i]: M[i] -> M[i+1]
-        hom_M_i_N = domain(hom_f)
-        for v in gens(hom_M_i_N)
-            @test element_to_homomorphism(hom_f(v)) == f*element_to_homomorphism(v)
-        end
-    end
+    #@test last(chain_range(hom_resolution)) == first(chain_range(free_res))
+    #@test first(chain_range(hom_resolution)) == last(chain_range(free_res))
+    # Tests below need to be adjusted as hom does not reverse direction anymore. 
+    #for i in Hecke.map_range(hom_resolution)
+    #    i == first(Hecke.map_range(hom_resolution)) && continue
+    #    f = map(free_res,i+1)         #f[i]: M[i] -> M[i-1]
+    #    hom_f = map(hom_resolution,-i) #f[i]: M[i] -> M[i+1]
+    #    hom_M_i_N = domain(hom_f)
+    #    for v in gens(hom_M_i_N)
+    #        @test element_to_homomorphism(hom_f(v)) == f*element_to_homomorphism(v)
+    #    end
+    #end
     hom_hom_resolution = hom(hom_resolution,N)
     @test chain_range(hom_hom_resolution) == chain_range(free_res)
 end
@@ -670,6 +672,7 @@ end
     F1 = graded_free_module(Rg, 1)
     N = SubquoModule(F1, Rg[x*y+2*x^2; x+y], Rg[z^4;])
     hom_resolution = hom(free_res,N)
+    #= Disabled for the moment; need to be adjusted!
     @test last(chain_range(hom_resolution)) == first(chain_range(free_res))
     @test first(chain_range(hom_resolution)) == last(chain_range(free_res))
     for i in Hecke.map_range(hom_resolution)
@@ -680,11 +683,13 @@ end
         @test element_to_homomorphism(hom_f(v)) == f*element_to_homomorphism(v)
       end
     end
+    =#
     hom_hom_resolution = hom(hom_resolution,N)
-    @test chain_range(hom_hom_resolution) == chain_range(free_res)
+    #@test chain_range(hom_hom_resolution) == chain_range(free_res)
     hom_resolution = hom_without_reversing_direction(free_res,N)
-    @test last(chain_range(hom_resolution)) == -first(chain_range(free_res))
-    @test first(chain_range(hom_resolution)) == -last(chain_range(free_res))
+    #@test last(chain_range(hom_resolution)) == -first(chain_range(free_res))
+    #@test first(chain_range(hom_resolution)) == -last(chain_range(free_res))
+    #= Disabled for the moment; need to be adjusted!
     for i in Hecke.map_range(hom_resolution)
       f = map(free_res,-i+1)
       hom_f = map(hom_resolution,i)
@@ -693,6 +698,7 @@ end
         @test element_to_homomorphism(hom_f(v)) == f*element_to_homomorphism(v)
       end
     end
+    =#
     hom_hom_resolution = hom_without_reversing_direction(hom_resolution,N)
     @test chain_range(hom_hom_resolution) == chain_range(free_res)
 end

--- a/test/Modules/ModulesGraded.jl
+++ b/test/Modules/ModulesGraded.jl
@@ -646,18 +646,17 @@ end
     end
     N = SubquoModule(F1, Rg[x*y+2*x^2; x+y], Rg[z^4; x^2-y*z])
     hom_resolution = hom(free_res,N)
+    # indexing changed! 
     #@test last(chain_range(hom_resolution)) == first(chain_range(free_res))
     #@test first(chain_range(hom_resolution)) == last(chain_range(free_res))
-    # Tests below need to be adjusted as hom does not reverse direction anymore. 
-    #for i in Hecke.map_range(hom_resolution)
-    #    i == first(Hecke.map_range(hom_resolution)) && continue
-    #    f = map(free_res,i+1)         #f[i]: M[i] -> M[i-1]
-    #    hom_f = map(hom_resolution,-i) #f[i]: M[i] -> M[i+1]
-    #    hom_M_i_N = domain(hom_f)
-    #    for v in gens(hom_M_i_N)
-    #        @test element_to_homomorphism(hom_f(v)) == f*element_to_homomorphism(v)
-    #    end
-    #end
+    for i in Hecke.map_range(hom_resolution)
+        f = map(free_res, -i+1)         #f[i]: M[i] -> M[i-1]
+        hom_f = map(hom_resolution, i) #f[i]: M[i] -> M[i+1]
+        hom_M_i_N = domain(hom_f)
+        for v in gens(hom_M_i_N)
+            @test element_to_homomorphism(hom_f(v)) == f*element_to_homomorphism(v)
+        end
+    end
     hom_hom_resolution = hom(hom_resolution,N)
     @test chain_range(hom_hom_resolution) == chain_range(free_res)
 end
@@ -672,24 +671,22 @@ end
     F1 = graded_free_module(Rg, 1)
     N = SubquoModule(F1, Rg[x*y+2*x^2; x+y], Rg[z^4;])
     hom_resolution = hom(free_res,N)
-    #= Disabled for the moment; need to be adjusted!
-    @test last(chain_range(hom_resolution)) == first(chain_range(free_res))
-    @test first(chain_range(hom_resolution)) == last(chain_range(free_res))
+    # indexing changed!
+    #@test last(chain_range(hom_resolution)) == first(chain_range(free_res))
+    #@test first(chain_range(hom_resolution)) == last(chain_range(free_res))
     for i in Hecke.map_range(hom_resolution)
-      f = map(free_res,i+1)         #f[i]: M[i] -> M[i-1]
+      f = map(free_res,-i+1)         #f[i]: M[i] -> M[i-1]
       hom_f = map(hom_resolution,i) #f[i]: M[i] -> M[i+1]
       hom_M_i_N = domain(hom_f)
       for v in gens(hom_M_i_N)
         @test element_to_homomorphism(hom_f(v)) == f*element_to_homomorphism(v)
       end
     end
-    =#
     hom_hom_resolution = hom(hom_resolution,N)
     #@test chain_range(hom_hom_resolution) == chain_range(free_res)
     hom_resolution = hom_without_reversing_direction(free_res,N)
     #@test last(chain_range(hom_resolution)) == -first(chain_range(free_res))
     #@test first(chain_range(hom_resolution)) == -last(chain_range(free_res))
-    #= Disabled for the moment; need to be adjusted!
     for i in Hecke.map_range(hom_resolution)
       f = map(free_res,-i+1)
       hom_f = map(hom_resolution,i)
@@ -698,7 +695,6 @@ end
         @test element_to_homomorphism(hom_f(v)) == f*element_to_homomorphism(v)
       end
     end
-    =#
     hom_hom_resolution = hom_without_reversing_direction(hom_resolution,N)
     @test chain_range(hom_hom_resolution) == chain_range(free_res)
 end

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -240,6 +240,7 @@ end
 
   N = SubquoModule(R[x+2*x^2; x+y], R[z^4; x^2-y*z])
   hom_resolution = hom(free_res,N)
+  #= tests temporarily disabled; the ranges need to be adjusted!
   @test last(chain_range(hom_resolution)) == first(chain_range(free_res))
   @test first(chain_range(hom_resolution)) == last(chain_range(free_res))
   for i in Hecke.map_range(hom_resolution)
@@ -250,11 +251,13 @@ end
       @test element_to_homomorphism(hom_f(v)) == f*element_to_homomorphism(v)
     end
   end
+  =#
 
   hom_hom_resolution = hom(hom_resolution,N)
   @test chain_range(hom_hom_resolution) == chain_range(free_res)
 
   hom_resolution = hom_without_reversing_direction(free_res,N)
+  #= tests temporarily disabled; the ranges need to be adjusted!
   @test last(chain_range(hom_resolution)) == -first(chain_range(free_res))
   @test first(chain_range(hom_resolution)) == -last(chain_range(free_res))
   for i in Hecke.map_range(hom_resolution)
@@ -265,6 +268,7 @@ end
       @test element_to_homomorphism(hom_f(v)) == f*element_to_homomorphism(v)
     end
   end
+  =#
   hom_hom_resolution = hom_without_reversing_direction(hom_resolution,N)
   @test chain_range(hom_hom_resolution) == chain_range(free_res)
 

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -240,26 +240,25 @@ end
 
   N = SubquoModule(R[x+2*x^2; x+y], R[z^4; x^2-y*z])
   hom_resolution = hom(free_res,N)
-  #= tests temporarily disabled; the ranges need to be adjusted!
-  @test last(chain_range(hom_resolution)) == first(chain_range(free_res))
-  @test first(chain_range(hom_resolution)) == last(chain_range(free_res))
+  # indexing changed
+  #@test last(chain_range(hom_resolution)) == first(chain_range(free_res))
+  #@test first(chain_range(hom_resolution)) == last(chain_range(free_res))
   for i in Hecke.map_range(hom_resolution)
-                f = map(free_res,i+1)         #f[i]: M[i] -> M[i-1]
+                f = map(free_res, -i+1)         #f[i]: M[i] -> M[i-1]
                 hom_f = map(hom_resolution,i) #f[i]: M[i] -> M[i+1]
     hom_M_i_N = domain(hom_f)
     for v in gens(hom_M_i_N)
       @test element_to_homomorphism(hom_f(v)) == f*element_to_homomorphism(v)
     end
   end
-  =#
 
   hom_hom_resolution = hom(hom_resolution,N)
   @test chain_range(hom_hom_resolution) == chain_range(free_res)
 
   hom_resolution = hom_without_reversing_direction(free_res,N)
-  #= tests temporarily disabled; the ranges need to be adjusted!
-  @test last(chain_range(hom_resolution)) == -first(chain_range(free_res))
-  @test first(chain_range(hom_resolution)) == -last(chain_range(free_res))
+  # indexing changed 
+  #@test last(chain_range(hom_resolution)) == -first(chain_range(free_res))
+  #@test first(chain_range(hom_resolution)) == -last(chain_range(free_res))
   for i in Hecke.map_range(hom_resolution)
     f = map(free_res,-i+1)
     hom_f = map(hom_resolution,i)
@@ -268,7 +267,7 @@ end
       @test element_to_homomorphism(hom_f(v)) == f*element_to_homomorphism(v)
     end
   end
-  =#
+
   hom_hom_resolution = hom_without_reversing_direction(hom_resolution,N)
   @test chain_range(hom_hom_resolution) == chain_range(free_res)
 


### PR DESCRIPTION
This is a prototype for how `FreeResolution` could be turned into a hypercomplex with minimal effort. 

I made the PR so that this approach can be discussed and tried out. Nothing of this needs to be done/decided urgently! I just wanted to have a concrete suggestion on the table so that everyone can get an impression about the implications. 

Some tests have been disabled for the time being. This is mostly due to the fact that for hypercomplexes the functor `hom(-, M)` takes
```
   0        1        2
   A  <---  B  <---  C
```
to 
```
    -2            -1            0
  Hom(C, M) <-- Hom(B, M) <-- Hom(A, M)
```
rather than 
```
    0            1              2
  Hom(A, M) --> Hom(B, M) --> Hom(C, M)
```
I would very much prefer not to change this convention. 

If this behaviour is disliked for `FreeResolution`s, there are still some things we can adjust for the particular type. Feel free to try it out and let me know your preferences whenever it is convenient. 