### PR TITLE
Fix printing of `RootSystem` and `WeylGroup`

### DIFF
--- a/experimental/LieAlgebras/src/RootSystem.jl
+++ b/experimental/LieAlgebras/src/RootSystem.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-mutable struct RootSystem
+@attributes mutable struct RootSystem
   cartan_matrix::ZZMatrix # (generalized) Cartan matrix
   #fw::QQMatrix # fundamental weights as linear combination of simple roots
   positive_roots::Vector #::Vector{RootSpaceElem} (cyclic reference)
@@ -57,7 +57,9 @@ Construct the root system of the given type. See `cartan_matrix(fam::Symbol, rk:
 # Examples
 ```jldoctest
 julia> root_system(:A, 2)
-ERROR: attributes storage not supported for type RootSystem
+Root system defined by Cartan matrix
+  [ 2   -1]
+  [-1    2]
 ```
 """
 function root_system(fam::Symbol, rk::Int)

--- a/experimental/LieAlgebras/src/RootSystem.jl
+++ b/experimental/LieAlgebras/src/RootSystem.jl
@@ -53,6 +53,12 @@ end
     root_system(fam::Symbol, rk::Int) -> RootSystem
 
 Construct the root system of the given type. See `cartan_matrix(fam::Symbol, rk::Int)` for allowed combinations.
+
+# Examples
+```jldoctest
+julia> root_system(:A, 2)
+ERROR: attributes storage not supported for type RootSystem
+```
 """
 function root_system(fam::Symbol, rk::Int)
   cartan = cartan_matrix(fam, rk)

--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -55,6 +55,12 @@ end
     weyl_group(fam::Symbol, rk::Int) -> WeylGroup
 
 Returns the Weyl group of the given type. See `cartan_matrix(fam::Symbol, rk::Int)` for allowed combinations.
+
+# Examples
+```jldoctest
+julia> weyl_group(:A, 2)
+ERROR: attributes storage not supported for type WeylGroup
+```
 """
 function weyl_group(fam::Symbol, rk::Int)
   return weyl_group(root_system(fam, rk))

--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -59,7 +59,7 @@ Returns the Weyl group of the given type. See `cartan_matrix(fam::Symbol, rk::In
 # Examples
 ```jldoctest
 julia> weyl_group(:A, 2)
-Weyl group for Root system defined by Cartan matrix [2 -1; -1 2]
+Weyl group for root system defined by Cartan matrix [2 -1; -1 2]
 ```
 """
 function weyl_group(fam::Symbol, rk::Int)
@@ -130,7 +130,7 @@ end
 function Base.show(io::IO, W::WeylGroup)
   @show_name(io, W)
   @show_special(io, W)
-  print(pretty(io), LowercaseOff(), "Weyl group for $(W.root_system)")
+  print(pretty(io), LowercaseOff(), "Weyl group for ", Lowercase(), W.root_system)
 end
 
 function coxeter_matrix(W::WeylGroup)

--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -7,7 +7,7 @@
 #
 ###############################################################################
 
-struct WeylGroup <: AbstractAlgebra.Group
+@attributes mutable struct WeylGroup <: AbstractAlgebra.Group
   finite::Bool              # finite indicates whether the Weyl group is finite
   refl::Matrix{UInt}        # see positive_roots_and_reflections
   root_system::RootSystem   # root_system is the RootSystem from which the Weyl group was constructed
@@ -59,7 +59,7 @@ Returns the Weyl group of the given type. See `cartan_matrix(fam::Symbol, rk::In
 # Examples
 ```jldoctest
 julia> weyl_group(:A, 2)
-ERROR: attributes storage not supported for type WeylGroup
+Weyl group for Root system defined by Cartan matrix [2 -1; -1 2]
 ```
 """
 function weyl_group(fam::Symbol, rk::Int)


### PR DESCRIPTION
https://github.com/oscar-system/Oscar.jl/pull/3781 used the magic printing macros, but these two types didn't have attribute storage enabled. Since there was no doctest at all exercising the printing, I didn't notice.
This PR adds two trivial doctests that just create an object and print it to prevent future breakage, and enabled attribute storage for the two types.

Thanks @felix-roehrich for finding this.