### PR TITLE
editorconfig: explicitly disable trim_trailing_whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ charset = utf-8
 end_of_line = lf
 indent_style = space
 insert_final_newline = true
-#trim_trailing_whitespace = true  # as long as we don't enforce this, this option causes more trouble than it helps
+trim_trailing_whitespace = false
 
 [*.jl]
 indent_size = 2


### PR DESCRIPTION
... for the reasons described [here](https://github.com/oscar-system/Oscar.jl/pull/3757/files#r1612405431) and discussed previously on multiple occasions. But in a nutshell: don't add or remove whitespace in dozens of unrelated locations just because you fix a typo in a file, as otherwise you cause extra work for other people with no good justification, and will ultimately discourage some people from contributing.

We could perhaps one day turn this one, assuming we first remove all trailing whitespace everywhere (but even then I am not sure it's a good idea as not everyone will have their editor set up to honor `.editorconfig`, and so these will be re-introduced over time. Anyway, that's a future discussion as far as I am concerned, for perhaps after the Begehung).

Pinging all other project leads (@fieker @micjoswig @simonbrandhorst @thofma @wdecker), as I was told in private that there is "disagreement among OSCAR leaders" about this, so y'all should have a chance to object (or agree).


Closes #3757