### PR TITLE
Small changes to experimental docs

### DIFF
--- a/docs/src/Experimental/intro.md
+++ b/docs/src/Experimental/intro.md
@@ -14,29 +14,29 @@ brought up to Oscar standard.
 
 !!! danger "Dependencies"
     - Code from `src` must never use code from `experimental`
-    - Say there are two packages `A` and `B` in `experimental`, and `B` depends
+    - Say there are two projects `A` and `B` in `experimental`, and `B` depends
       on `A`. That means that `B` cannot be moved to `src` before `A`. Worse:
       If `A` gets abandoned, `B` might share that fate. So please consider
       carefully in such situations.
 
 ## Structure
 For an example of the structure for a new project in `experimental` have a look
-at project folders, i.e. `experimental/PACKAGE_NAME`, that have subfolders
+at project folders, i.e. `experimental/PROJECT_NAME`, that have subfolders
 `docs`, `src`, and `test` (an example is
 `experimental/FTheoryTools`). The general structure is
 ```
-experimental/PACKAGE_NAME/
+experimental/PROJECT_NAME/
 ├── README.md
 ├── docs
 │   ├── doc.main
 │   └── src
 │       └── DOCUMENTATION.md
 ├── src
-│   └── PACKAGE_NAME.jl
+│   └── PROJECT_NAME.jl
 └── test
     └── *.jl
 ```
-The file `src/PACKAGE_NAME.jl` and at least one `.jl` file in the `test/`
+The file `src/PROJECT_NAME.jl` and at least one `.jl` file in the `test/`
 directory are mandatory and are used by Oscar.jl to find your code and tests.
 If there is a `test/runtests.jl` then only this file is executed during
 testing, otherwise all `.jl` files will be run automatically (in a random

--- a/docs/src/Experimental/intro.md
+++ b/docs/src/Experimental/intro.md
@@ -22,8 +22,8 @@ brought up to Oscar standard.
 ## Structure
 For an example of the structure for a new project in `experimental` have a look
 at project folders, i.e. `experimental/PACKAGE_NAME`, that have subfolders
-`docs`, `src`, and `test` (The first two examples are
-`experimental/{FTheoryTools, PlaneCurve}`). The general structure is
+`docs`, `src`, and `test` (an example is
+`experimental/FTheoryTools`). The general structure is
 ```
 experimental/PACKAGE_NAME/
 ├── README.md
@@ -49,8 +49,8 @@ starting from scratch and don't have any documentation yet.
 
 !!! note
     There are still older projects in `experimental` from before the
-    introduction of this structure. Thus we mentioned `FTheoryTools` and
-    `PlaneCurve` as projects having adopted to the new standard.
+    introduction of this structure. Thus we mentioned `FTheoryTools`
+    as a project having adopted to the new standard.
 
 ### Useful functions for development
 Apart from the hints in the [Introduction for new developers](@ref), there are some more specialized functions for the structure of the `experimental` folder.


### PR DESCRIPTION
* The introduction to `Experimental` mentioned the `PlaneCurves` directory that was removed in #3179.
* I replaced the word "package" by "project". I always found it weird that we talk about experimental packages because they are not packages in the Julia sense (or behave like packages in GAP for example) and apparently it leads to confusion as in #3821.
