### PR TITLE
Add a new constructor for toric affine space

### DIFF
--- a/docs/src/AlgebraicGeometry/Schemes/AffineSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/AffineSchemes.md
@@ -30,7 +30,7 @@ See [`inclusion_morphism(::AbsAffineScheme, ::AbsAffineScheme)`](@ref) for a way
 
 ```@docs
 affine_space(kk::BRT, n::Int; variable_name="x") where {BRT<:Ring}
-affine_space(kk::BRT, var_symbols::Vector{Symbol}) where {BRT<:Ring}
+affine_space(kk::BRT, var_names::AbstractVector{<:VarName}) where {BRT<:Ring}
 ```
 
 ### Closed subschemes

--- a/docs/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties.md
@@ -174,8 +174,8 @@ method `coefficient_ring(v::NormalToricVarietyType)` always return
 the field of rational numbers. For the coordinate names, we provide the
 following setter functions:
 ```@docs
-set_coordinate_names(v::NormalToricVarietyType, coordinate_names::Vector{String})
-set_coordinate_names_of_torus(v::NormalToricVarietyType, coordinate_names::Vector{String})
+set_coordinate_names(v::NormalToricVarietyType, coordinate_names::AbstractVector{<:VarName})
+set_coordinate_names_of_torus(v::NormalToricVarietyType, coordinate_names::AbstractVector{<:VarName})
 ```
 The following methods allow to etract the chosen coordinates:
 ```@docs

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Constructors.jl
@@ -159,7 +159,7 @@ Base.deepcopy_internal(X::AffineScheme, dict::IdDict) = AffineScheme(deepcopy_in
     affine_space(kk::BRT, n::Int; variable_name="x") where {BRT<:Ring}
 
 The ``n``-dimensional affine space over a ring ``kk`` is created
-by this method. By default, the variable names are chosen as $x_1$, $x_2$
+by this method. By default, the variable names are chosen as `x1`, `x2`
 and so on. This choice can be overwritten with a third optional argument.
 
 # Examples
@@ -198,7 +198,7 @@ with coordinates [y1, z2, a]
 """
 function affine_space(kk::BRT, var_symbols::Vector{Symbol}) where {BRT<:Ring}
   R, _ = polynomial_ring(kk, var_symbols)
-  return variety(spec(R), check=false)
+  return spec(R)
 end
 
 function affine_space(kk::BRT, n::Int; variable_name="x") where {BRT<:Field}

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Constructors.jl
@@ -182,7 +182,7 @@ end
 
 
 @doc raw"""
-    affine_space(kk::BRT, var_symbols::Vector{Symbol}) where {BRT<:Ring}
+    affine_space(kk::BRT, var_names::AbstractVector{<:VarName}) where {BRT<:Ring}
 
 Create the ``n``-dimensional affine space over a ring ``kk``,
 but allows more flexibility in the choice of variable names.
@@ -190,14 +190,24 @@ The following example demonstrates this.
 
 # Examples
 ```jldoctest
-julia> affine_space(QQ,[:y1,:z2,:a])
+julia> affine_space(QQ, [:x, :y, :z])
 Affine space of dimension 3
   over rational field
-with coordinates [y1, z2, a]
+with coordinates [x, y, z]
+
+julia> affine_space(QQ, ['x', 'y', 'z'])
+Affine space of dimension 3
+  over rational field
+with coordinates [x, y, z]
+
+julia> affine_space(QQ, ["x", "y", "z"])
+Affine space of dimension 3
+  over rational field
+with coordinates [x, y, z]
 ```
 """
-function affine_space(kk::BRT, var_symbols::Vector{Symbol}) where {BRT<:Ring}
-  R, _ = polynomial_ring(kk, var_symbols)
+function affine_space(kk::BRT, var_names::AbstractVector{<:VarName}) where {BRT<:Ring}
+  R, _ = polynomial_ring(kk, var_names)
   return spec(R)
 end
 
@@ -206,8 +216,8 @@ function affine_space(kk::BRT, n::Int; variable_name="x") where {BRT<:Field}
   return variety(spec(R), check=false)
 end
 
-function affine_space(kk::BRT, var_symbols::Vector{Symbol}) where {BRT<:Field}
-  R, _ = polynomial_ring(kk, var_symbols)
+function affine_space(kk::BRT, var_names::AbstractVector{<:VarName}) where {BRT<:Field}
+  R, _ = polynomial_ring(kk, var_names)
   return variety(spec(R), check=false)
 end
 

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -143,7 +143,7 @@ end
 
 
 @doc raw"""
-    set_coordinate_names_of_torus(v::NormalToricVarietyType, coordinate_names::Vector{String})
+    set_coordinate_names_of_torus(v::NormalToricVarietyType, coordinate_names::AbstractVector{<:VarName})
 
 Allows to set the names of the coordinates of the torus.
 
@@ -159,12 +159,12 @@ julia> coordinate_names_of_torus(F3)
  "v"
 ```
 """
-function set_coordinate_names_of_torus(v::NormalToricVarietyType, coordinate_names::Vector{String})
+function set_coordinate_names_of_torus(v::NormalToricVarietyType, coordinate_names::coordinate_names::AbstractVector{<:VarName})
     if is_finalized(v)
         error("The coordinate names of the torus cannot be modified since the toric variety is finalized")
     end
     @req length(coordinate_names) == ambient_dim(v) "The provided list of coordinate names must match the ambient dimension of the fan"
-    set_attribute!(v, :coordinate_names_of_torus, coordinate_names)
+    set_attribute!(v, :coordinate_names_of_torus, string.(coordinate_names))
 end
 
 

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -159,7 +159,7 @@ julia> coordinate_names_of_torus(F3)
  "v"
 ```
 """
-function set_coordinate_names_of_torus(v::NormalToricVarietyType, coordinate_names::coordinate_names::AbstractVector{<:VarName})
+function set_coordinate_names_of_torus(v::NormalToricVarietyType, coordinate_names::AbstractVector{<:VarName})
     if is_finalized(v)
         error("The coordinate names of the torus cannot be modified since the toric variety is finalized")
     end

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -103,7 +103,7 @@ end
 
 
 @doc raw"""
-    set_coordinate_names(v::NormalToricVarietyType, coordinate_names::Vector{String})
+    set_coordinate_names(v::NormalToricVarietyType, coordinate_names::AbstractVector{<:VarName})
 
 Allows to set the names of the homogeneous coordinates as long as the toric variety in
 question is not yet finalized (cf. [`is_finalized(v::NormalToricVarietyType)`](@ref)).
@@ -114,19 +114,31 @@ julia> C = Oscar.positive_hull([1 0]);
 
 julia> antv = affine_normal_toric_variety(C);
 
-julia> set_coordinate_names(antv, ["u"])
+julia> set_coordinate_names(antv, [:u])
 
 julia> coordinate_names(antv)
 1-element Vector{String}:
  "u"
+
+julia> set_coordinate_names(antv, ["v"])
+
+julia> coordinate_names(antv)
+1-element Vector{String}:
+ "v"
+
+julia> set_coordinate_names(antv, ['w'])
+
+julia> coordinate_names(antv)
+1-element Vector{String}:
+ "w"
 ```
 """
-function set_coordinate_names(v::NormalToricVarietyType, coordinate_names::Vector{String})
+function set_coordinate_names(v::NormalToricVarietyType, coordinate_names::AbstractVector{<:VarName})
     if is_finalized(v)
         error("The coordinate names cannot be modified since the toric variety is finalized")
     end
     @req length(coordinate_names) == n_rays(v) "The provided list of coordinate names must match the number of rays in the fan"
-    set_attribute!(v, :coordinate_names, coordinate_names)
+    set_attribute!(v, :coordinate_names, string.(coordinate_names))
 end
 
 

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/standard_constructions.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/standard_constructions.jl
@@ -18,7 +18,7 @@ end
 
 
 @doc raw"""
-    affine_space(::Type{NormalToricVariety}, var_symbols::Vector{Symbol}) -> NormalToricVariety
+    affine_space(::Type{NormalToricVariety}, var_symbols::AbstractVector{<:VarName}) -> NormalToricVariety
 
 Construct a (toric) affine space, specifying the variable names.
 
@@ -26,11 +26,17 @@ Construct a (toric) affine space, specifying the variable names.
 ```jldoctest
 julia> affine_space(NormalToricVariety, [:x, :y, :z])
 Normal toric variety
+
+julia> affine_space(NormalToricVariety, ["x", "y", "z"])
+Normal toric variety
+
+julia> affine_space(NormalToricVariety, ['x', 'y', 'z'])
+Normal toric variety
 ```
 """
-function affine_space(::Type{NormalToricVariety}, var_symbols::Vector{Symbol})
-  variety = affine_space(NormalToricVariety, length(var_symbols))
-  set_coordinate_names(variety, String.(var_symbols))
+function affine_space(::Type{NormalToricVariety}, var_names::AbstractVector{<:VarName})
+  variety = affine_space(NormalToricVariety, length(var_names))
+  set_coordinate_names(variety, var_names)
   return variety
 end
 

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/standard_constructions.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/standard_constructions.jl
@@ -18,7 +18,7 @@ end
 
 
 @doc raw"""
-    affine_space(::Type{NormalToricVariety}, var_symbols::AbstractVector{<:VarName}) -> NormalToricVariety
+    affine_space(::Type{NormalToricVariety}, var_symbols::AbstractVector{<:VarName})
 
 Construct a (toric) affine space, specifying the variable names.
 

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/standard_constructions.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/standard_constructions.jl
@@ -18,6 +18,24 @@ end
 
 
 @doc raw"""
+    affine_space(::Type{NormalToricVariety}, var_symbols::Vector{Symbol}) -> NormalToricVariety
+
+Construct a (toric) affine space, specifying the variable names.
+
+# Examples
+```jldoctest
+julia> affine_space(NormalToricVariety, [:x, :y, :z])
+Normal toric variety
+```
+"""
+function affine_space(::Type{NormalToricVariety}, var_symbols::Vector{Symbol})
+  variety = affine_space(NormalToricVariety, length(var_symbols))
+  set_coordinate_names(variety, String.(var_symbols))
+  return variety
+end
+
+
+@doc raw"""
     projective_space(::Type{NormalToricVariety}, d::Int)
 
 Construct the projective space of dimension `d`.


### PR DESCRIPTION
This allows specifying the variable names, just as in the method
```
function affine_space(kk::BRT, var_symbols::Vector{Symbol}) where {BRT<:Ring}
```

Also:
  * small docstring change from $x_1$ to `x1`
  * fix `affine_space(ZZ, [:x, :y])`