### PR TITLE
Allow `ideal(f)` for a single element `f`

### DIFF
--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -45,8 +45,9 @@ function ideal(I::IdealGens{T}) where {T <: MPolyRingElem}
   return MPolyIdeal(I)
 end
 
-# TODO: Can we make this the default?
-# (Or maybe remove ideal(...) without a ring completely?)
+function ideal(x::MPolyRingElem{T}) where T <: RingElem
+  return ideal([x])
+end
 
 function ideal(Qxy::MPolyRing{T}, x::MPolyRingElem{T}) where T <: RingElem
   return ideal(Qxy, [x])


### PR DESCRIPTION
Ideally, the change should be done in abstract algebra. This is a quick fix to make it work for only `MPolyIdeal`s.