### PR TITLE
Fix `is_smooth` for projective space

### DIFF
--- a/docs/src/AlgebraicGeometry/Schemes/ProjectiveSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/ProjectiveSchemes.md
@@ -89,7 +89,7 @@ homogenization_map(P::AbsProjectiveScheme, U::AbsAffineScheme)
 
 Further properties of projective schemes:
 ```@docs
-is_smooth(P::AbsProjectiveScheme)
+is_smooth(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}; algorithm=:default)
 ```
 ```julia
 is_empty(P::AbsProjectiveScheme{<:Field})

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Properties.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Properties.jl
@@ -53,7 +53,8 @@ function _jacobian_criterion(X::CoveredScheme{<:Field})
 
   dec_info = decomposition_info(default_covering(X))
   for (V, fs) in dec_info
-    R = base_ring(OO(V))
+    R_quotient = OO(V)
+    typeof(R_quotient)<:MPolyQuoRing ? R = base_ring(R_quotient) : R = R_quotient
     I = saturated_ideal(defining_ideal(V))
     mat = jacobian_matrix(R, gens(I))
     sing_locus = ideal(R, fs) + ideal(R, minors(mat, codim(V)))

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Properties.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Properties.jl
@@ -54,7 +54,7 @@ function _jacobian_criterion(X::CoveredScheme{<:Field})
   dec_info = decomposition_info(default_covering(X))
   for (V, fs) in dec_info
     R_quotient = OO(V)
-    typeof(R_quotient)<:MPolyQuoRing ? R = base_ring(R_quotient) : R = R_quotient
+    R_quotient isa MPolyQuoRing ? R = base_ring(R_quotient) : R = R_quotient
     I = saturated_ideal(defining_ideal(V))
     mat = jacobian_matrix(R, gens(I))
     sing_locus = ideal(R, fs) + ideal(R, minors(mat, codim(V)))

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Properties.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Properties.jl
@@ -54,7 +54,7 @@ function _jacobian_criterion(X::CoveredScheme{<:Field})
   dec_info = decomposition_info(default_covering(X))
   for (V, fs) in dec_info
     R_quotient = OO(V)
-    R_quotient isa MPolyQuoRing ? R = base_ring(R_quotient) : R = R_quotient
+    R = R_quotient isa MPolyRing ? R_quotient : base_ring(R_quotient)
     I = saturated_ideal(defining_ideal(V))
     mat = jacobian_matrix(R, gens(I))
     sing_locus = ideal(R, fs) + ideal(R, minors(mat, codim(V)))

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Properties.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Properties.jl
@@ -135,7 +135,7 @@ function _projective_jacobian_criterion(P::AbsProjectiveScheme{<:Ring, <:MPolyQu
   R = ambient_coordinate_ring(P)
   I = defining_ideal(P)
   mat = jacobian_matrix(R, gens(I))
-  sing_locus = ideal(R, minors(mat, codim(P)))
+  sing_locus = ideal(R, minors(mat, codim(P))) + I
   irrelevant_ideal = ideal(R, gens(R))
   return is_one(saturation(sing_locus, irrelevant_ideal))
 end

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Properties.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Properties.jl
@@ -58,7 +58,9 @@ julia> is_smooth(C; algorithm=:covered_jacobian)
 false
 ```
 """
-function is_smooth(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}; algorithm=:default)
+is_smooth(P::AbsProjectiveScheme; algorithm::Symbol=:default)
+
+function is_smooth(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}; algorithm::Symbol=:default)
   get_attribute!(P, :is_smooth) do
     if is_empty(P)
       return true
@@ -120,8 +122,8 @@ function is_smooth(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}; algorithm=:def
   end
 end
 
-is_smooth(P::AbsProjectiveScheme{<:Ring, <:MPolyRing}; algorithm=:default) = true
-is_smooth(P::AbsProjectiveScheme{<:Ring, <:MPolyLocRing}; algorithm=:default) = true
+is_smooth(P::AbsProjectiveScheme{<:Ring, <:MPolyRing}; algorithm::Symbol=:default) = true
+is_smooth(P::AbsProjectiveScheme{<:Ring, <:MPolyLocRing}; algorithm::Symbol=:default) = true
 
 function _projective_jacobian_criterion(P::AbsProjectiveScheme{<:Ring, <:MPolyQuoRing})
   if !(is_equidimensional(P))

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Properties.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Properties.jl
@@ -17,7 +17,7 @@ end
 end
 
 @doc raw"""
-    is_smooth(P::AbsProjectiveScheme; algorithm=:default) -> Bool
+    is_smooth(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}; algorithm=:default) -> Bool
 
 Check whether the scheme `P` is smooth.
 

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Properties.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Properties.jl
@@ -59,7 +59,7 @@ julia> is_smooth(C; algorithm=:covered_jacobian)
 false
 ```
 """
-function is_smooth(P::AbsProjectiveScheme; algorithm=:default)
+function is_smooth(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}; algorithm=:default)
   get_attribute!(P, :is_smooth) do
     if is_empty(P)
       return true
@@ -101,7 +101,10 @@ function is_smooth(P::AbsProjectiveScheme; algorithm=:default)
   end
 end
 
-function _projective_jacobian_criterion(P::AbsProjectiveScheme)
+is_smooth(P::AbsProjectiveScheme{<:Any, <:MPolyRing}; algorithm=:default) = true
+is_smooth(P::AbsProjectiveScheme{<:Any, <:MPolyLocRing}; algorithm=:default) = true
+
+function _projective_jacobian_criterion(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing})
   if !(base_ring(P) isa Field)
     throw(NotImplementedError(
       :is_smooth,

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Properties.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Properties.jl
@@ -26,20 +26,19 @@ Check whether the scheme `P` is smooth.
 There are three possible algorithms for checking smoothness, determined
 by the value of the keyword argument `algorithm`:
   * `:projective_jacobian` - uses the Jacobian criterion for projective
-    varieties, see Exercise 4.2.10 of [Liu06](@cite),
+    schemes, see Exercise 4.2.10 of [Liu06](@cite),
   * `:covered_jacobian` - uses covered version of the Jacobian criterion,
   * `:affine_cone` - checks that the affine cone is smooth outside the origin.
 
 The `:projective_jacobian` and the `:covered` algorithms only work for equidimensional schemes. The algorithms first check for equidimensionality, which can be expensive.
-
-By default, if the base ring is a field, then we first compute whether the scheme is equidimensional. If yes, then the `:projective_jacobian` algorithm is used. Otherwise, the `:affine_cone` algorithm is used.
-
 If you already know that the scheme is equidimensional, then you can
 avoid recomputing that by writing
   `set_attribute!(P, :is_equidimensional, true)`
 before checking for smoothness.
 
-We explain why the algorithm of `:affine_cone` works for arbitrary schemes over arbitrary base schemes. By Remark 13.38(1) of [GW20](@cite), the morphism from the pointed affine cone to $P$ is locally the morphism $\mathbb{A}_U^1 \setminus \{0\} \to U$, where $U$ is an affine open of $P$ and $\mathbb{A}_U^1$ is the relative affine 1-space over $U$. By Definition 6.14(1) of [GW20](@cite), the Jacobian matrix for $U$ differs from the Jacobian matrix for $P$ only by a column containing zeros, implying that the ranks of the Jacobian matrices are the same. Therefore, $P$ is smooth if and only if the affine cone is smooth outside the origin.
+The algorithms `:covered_jacobian` and `:affine_cone` only work when the base ring is a field.
+
+The default algorithm is `:projective_jacobian` if the scheme is equidimensional, otherwise it is `:affine_cone`.
 
 # Examples
 ```jldoctest
@@ -66,13 +65,17 @@ function is_smooth(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}; algorithm=:def
     end
 
     if algorithm == :default
-      if (
-        base_ring(P) isa Field
-        && is_equidimensional(P)
-      )
+      if is_equidimensional(P)
         algorithm = :projective_jacobian
-      else
+      elseif base_ring(P) isa Field
         algorithm = :affine_cone
+      else
+        if !(base_ring(P) isa Field)
+          throw(NotImplementedError(
+            :is_smooth,
+            "is_smooth only implemented when the scheme is equidimensional or the base ring is a field"
+          ))
+        end
       end
     end
 
@@ -89,8 +92,24 @@ function is_smooth(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}; algorithm=:def
     end
 
     if algorithm == :covered_jacobian
+      if !(base_ring(P) isa Field)
+        throw(NotImplementedError(
+          :is_smooth,
+          "Algorithm `:covered_jacobian` only implemented when the base ring is a field"
+          # because this algorithm uses `is_smooth` for affine schemes, and `is_smooth` is not implemented for affine schemes over a non-field base ring
+        ))
+      end
       return _jacobian_criterion(covered_scheme(P))
     elseif algorithm == :affine_cone
+      if !(base_ring(P) isa Field)
+        throw(NotImplementedError(
+          :is_smooth,
+          "Algorithm `:affine_cone` only implemented when the base ring is a field"
+          # because this algorithm uses `is_smooth` for affine schemes, and `is_smooth` is not implemented for affine schemes over a non-field base ring
+        ))
+      end
+#       TODO: Implement `is_smooth` for affine schemes. Then, this algorithm would work for arbitrary schemes. A similar algorithm can be used for quasismoothness of subschemes of toric varieties.
+#       We explain why the algorithm of `:affine_cone` works for arbitrary schemes over arbitrary base schemes. By Remark 13.38(1) of [GW20](@cite), the morphism from the pointed affine cone to $P$ is locally the morphism $\mathbb{A}_U^1 \setminus \{0\} \to U$, where $U$ is an affine open of $P$ and $\mathbb{A}_U^1$ is the relative affine 1-space over $U$. By Definition 6.14(1) of [GW20](@cite), the Jacobian matrix for $U$ differs from the Jacobian matrix for $P$ only by a column containing zeros, implying that the ranks of the Jacobian matrices are the same. Therefore, $P$ is smooth if and only if the affine cone is smooth outside the origin.
       aff, _ = affine_cone(P)
       sing, _ = singular_locus(aff)
       origin = ideal(gens(ambient_coordinate_ring(sing)))
@@ -101,27 +120,22 @@ function is_smooth(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}; algorithm=:def
   end
 end
 
-is_smooth(P::AbsProjectiveScheme{<:Any, <:MPolyRing}; algorithm=:default) = true
-is_smooth(P::AbsProjectiveScheme{<:Any, <:MPolyLocRing}; algorithm=:default) = true
+is_smooth(P::AbsProjectiveScheme{<:Ring, <:MPolyRing}; algorithm=:default) = true
+is_smooth(P::AbsProjectiveScheme{<:Ring, <:MPolyLocRing}; algorithm=:default) = true
 
-function _projective_jacobian_criterion(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing})
-  if !(base_ring(P) isa Field)
-    throw(NotImplementedError(
-      :is_smooth,
-      "projective Jacobian criterion only implemented when base ring is a field"
-    ))
-  end
+function _projective_jacobian_criterion(P::AbsProjectiveScheme{<:Ring, <:MPolyQuoRing})
   if !(is_equidimensional(P))
     throw(NotImplementedError(
       :is_smooth,
       "projective Jacobian criterion only implemented when scheme is equidimensional"
     ))
   end
-  R = base_ring(homogeneous_coordinate_ring(P))
+  R = ambient_coordinate_ring(P)
   I = defining_ideal(P)
   mat = jacobian_matrix(R, gens(I))
   sing_locus = ideal(R, minors(mat, codim(P)))
-  return dim(sing_locus + I) <= 0
+  irrelevant_ideal = ideal(R, gens(R))
+  return is_one(saturation(sing_locus, irrelevant_ideal))
 end
 
 @attr Bool function is_irreducible(P::AbsProjectiveScheme)

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Properties.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Properties.jl
@@ -17,7 +17,7 @@ end
 end
 
 @doc raw"""
-    is_smooth(P::AbsProjectiveScheme{<:Any, <:MPolyQuoRing}; algorithm=:default) -> Bool
+    is_smooth(P::AbsProjectiveScheme; algorithm::Symbol=:default) -> Bool
 
 Check whether the scheme `P` is smooth.
 


### PR DESCRIPTION
Previously, taking `base_ring` from a quotient ring $S = R/I$ gave the ring $R$, but if $S$ was not a quotient ring, then it gave the base field of $S$, introducing an error in case the argument of `is_smooth` is the projective space.