### PR TITLE
Construct Lie algebras from root system

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -466,6 +466,19 @@
   doi           = {10.4171/dm/220}
 }
 
+@Article{CMT04,
+  author        = {Cohen, Arjeh M. and Murray, Scott H. and Taylor, D. E.},
+  title         = {Computing in groups of Lie type},
+  mrnumber      = {2047097},
+  journal       = {Math. Comp.},
+  fjournal      = {Mathematics of Computation},
+  volume        = {73},
+  number        = {247},
+  pages         = {1477--1498},
+  year          = {2004},
+  doi           = {10.1090/S0025-5718-03-01582-5}
+}
+
 @Book{CS99,
   author        = {Conway, J. H. and Sloane, N. J. A.},
   title         = {Sphere packings, lattices and groups},

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -21,21 +21,17 @@
       @req all(
         r -> all(e -> parent(last(e)) === R, r), struct_consts
       ) "Invalid structure constants."
+      @req all(iszero, struct_consts[i, i] for i in 1:dimL) "Not anti-symmetric."
       @req all(
-        iszero, struct_consts[i, i][k] for i in 1:dimL, k in 1:dimL
-      ) "Not anti-symmetric."
-      @req all(
-        iszero,
-        struct_consts[i, j][k] + struct_consts[j, i][k] for i in 1:dimL, j in 1:dimL,
-        k in 1:dimL
+        iszero, struct_consts[i, j] + struct_consts[j, i] for i in 1:dimL, j in 1:dimL
       ) "Not anti-symmetric."
       @req all(
         iszero,
         sum(
-          struct_consts[i, j][k] * struct_consts[k, l][m] +
-          struct_consts[j, l][k] * struct_consts[k, i][m] +
-          struct_consts[l, i][k] * struct_consts[k, j][m] for k in 1:dimL
-        ) for i in 1:dimL, j in 1:dimL, l in 1:dimL, m in 1:dimL
+          struct_consts[i, j][k] * struct_consts[k, l] +
+          struct_consts[j, l][k] * struct_consts[k, i] +
+          struct_consts[l, i][k] * struct_consts[k, j] for k in 1:dimL
+        ) for i in 1:dimL, j in 1:dimL, l in 1:dimL
       ) "Jacobi identity does not hold."
     end
     return new{C}(R, dimL, struct_consts, s)

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -325,7 +325,7 @@ function _struct_consts(R::Field, rs::RootSystem, extraspecial_pair_signs)
   N = _N_matrix(rs, extraspecial_pair_signs)
 
   struct_consts = Matrix{SRow{elem_type(R)}}(undef, n, n)
-  for i in 1:nroots, j in 1:nroots
+  for i in 1:nroots, j in i:nroots
     if i == j
       # [e_βi, e_βi] = 0
       struct_consts[i, j] = sparse_row(R)
@@ -353,7 +353,7 @@ function _struct_consts(R::Field, rs::RootSystem, extraspecial_pair_signs)
     end
 
     # # [e_βj, e_βi] = -[e_βi, e_βj]
-    # struct_consts[j, i] = -struct_consts[i, j]
+    struct_consts[j, i] = -struct_consts[i, j]
   end
   for i in 1:nsimp, j in 1:nroots
     # [h_i, e_βj] = <β_j, α_i> e_βj

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -297,7 +297,7 @@ The experienced user may supply a boolean vector of length `n_positive_roots(rs)
 via the kwarg `extraspecial_pair_signs::Vector{Bool}` to specify the concrete Lie algebra to be constructed.
 If $(\alpha,\beta)$ is the extraspecial pair for the non-simple root `root(rs, i)`,
 then $\varepsilon_{\alpha,\beta} = 1$ iff `extraspecial_pair_signs[i - n_simple_roots(rs)] = true`.
-For the used notation and the definition of extraspecial pairs, see [CMT04](cite).
+For the used notation and the definition of extraspecial pairs, see [CMT04](@cite).
 """
 function lie_algebra(
   R::Field,

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -171,7 +171,7 @@ end
 @doc raw"""
     lie_algebra(R::Field, struct_consts::Matrix{SRow{elem_type(R)}}, s::Vector{<:VarName}; check::Bool) -> AbstractLieAlgebra{elem_type(R)}
 
-Construct the Lie algebra over the ring `R` with structure constants `struct_consts`
+Construct the Lie algebra over the field `R` with structure constants `struct_consts`
 and with basis element names `s`.
 
 The Lie bracket on the newly constructed Lie algebra `L` is determined by the structure
@@ -197,7 +197,7 @@ end
 @doc raw"""
     lie_algebra(R::Field, struct_consts::Array{elem_type(R),3}, s::Vector{<:VarName}; check::Bool) -> AbstractLieAlgebra{elem_type(R)}
 
-Construct the Lie algebra over the ring `R` with structure constants `struct_consts`
+Construct the Lie algebra over the field `R` with structure constants `struct_consts`
 and with basis element names `s`.
 
 The Lie bracket on the newly constructed Lie algebra `L` is determined by the structure
@@ -291,8 +291,14 @@ end
 @doc raw"""
     lie_algebra(R::Field, rs::RootSystem) -> AbstractLieAlgebra{elem_type(R)}
 
-Construct the simple Lie algebra over the ring `R` with the given root system `rs`.
+Construct a simple Lie algebra over the field `R` with the root system `rs`.
 The internally used basis of this Lie algebra is the Chevalley basis.
+
+The experienced user may supply a boolean vector of length `n_positive_roots(rs) - n_simple_roots(rs)`
+via the kwarg `extraspecial_pair_signs::Vector{Bool}` to specify the concrete Lie algebra to be constructed.
+If $(\alpha,\beta)$ is the extraspecial pair for the non-simple root `root(rs, i)`,
+then $\varepsilon_{\alpha,\beta} = 1$ iff `extraspecial_pair_signs[i - n_simple_roots(rs)] = true`.
+For the used notation and the definition of extraspecial pairs, see [CMT04](@ref).
 """
 function lie_algebra(
   R::Field,
@@ -374,6 +380,7 @@ function _struct_consts(R::Field, rs::RootSystem, extraspecial_pair_signs)
 end
 
 function _N_matrix(rs::RootSystem, extraspecial_pair_signs::Vector{Bool})
+  # computes the matrix N_αβ from CTM04 Ch. 3 indexed by root indices
   nroots = n_roots(rs)
   npos = n_positive_roots(rs)
   nsimp = n_simple_roots(rs)
@@ -426,7 +433,7 @@ function _N_matrix(rs::RootSystem, extraspecial_pair_signs::Vector{Bool})
       while is_root_with_index(beta_j - p * alpha_i)[1]
         p += 1
       end
-      N[i, j] = Int(sign(t1 - t2) * sign(N[l, l_comp]) * p) # typo in paper
+      N[i, j] = Int(sign(t1 - t2) * sign(N[l, l_comp]) * p) # typo in CMT04
       N[j, i] = -N[i, j]
     end
   end
@@ -451,7 +458,7 @@ end
 @doc raw"""
     lie_algebra(R::Field, fam::Symbol, rk::Int) -> AbstractLieAlgebra{elem_type(R)}
 
-Construct the simple Lie algebra over the ring `R` with Dynkin type given by `fam` and `rk`.
+Construct a simple Lie algebra over the field `R` with Dynkin type given by `fam` and `rk`.
 See `cartan_matrix(fam::Symbol, rk::Int)` for allowed combinations.
 The internally used basis of this Lie algebra is the Chevalley basis.
 """

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -306,7 +306,7 @@ function lie_algebra(
     [Symbol("h_$i") for i in 1:n_simple_roots(rs)]
   ]
 
-  L = lie_algebra(R, struct_consts, s; check=true) # TODO: remove check
+  L = lie_algebra(R, struct_consts, s; check=false)
   L.root_system = rs
   return L
 end

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -287,7 +287,6 @@ function lie_algebra(
   return lie_algebra(R, struct_consts, s; check)
 end
 
-
 @doc raw"""
     lie_algebra(R::Field, rs::RootSystem) -> AbstractLieAlgebra{elem_type(R)}
 
@@ -325,7 +324,7 @@ function _struct_consts(R::Field, rs::RootSystem, extraspecial_pair_signs)
   nroots = n_roots(rs)
   npos = n_positive_roots(rs)
   nsimp = n_simple_roots(rs)
-  
+
   n = 2 * npos + nsimp
 
   N = _N_matrix(rs, extraspecial_pair_signs)
@@ -453,7 +452,6 @@ function _N_matrix(rs::RootSystem, extraspecial_pair_signs::Vector{Bool})
   end
   return N
 end
-
 
 @doc raw"""
     lie_algebra(R::Field, fam::Symbol, rk::Int) -> AbstractLieAlgebra{elem_type(R)}

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -297,7 +297,7 @@ The experienced user may supply a boolean vector of length `n_positive_roots(rs)
 via the kwarg `extraspecial_pair_signs::Vector{Bool}` to specify the concrete Lie algebra to be constructed.
 If $(\alpha,\beta)$ is the extraspecial pair for the non-simple root `root(rs, i)`,
 then $\varepsilon_{\alpha,\beta} = 1$ iff `extraspecial_pair_signs[i - n_simple_roots(rs)] = true`.
-For the used notation and the definition of extraspecial pairs, see [CMT04](@ref).
+For the used notation and the definition of extraspecial pairs, see [CMT04](cite).
 """
 function lie_algebra(
   R::Field,

--- a/experimental/LieAlgebras/src/iso_oscar_gap.jl
+++ b/experimental/LieAlgebras/src/iso_oscar_gap.jl
@@ -35,7 +35,7 @@ function _iso_oscar_gap(LO::LinearLieAlgebra)
   return MapFromFunc(LO, LG, f, finv)
 end
 
-function _iso_oscar_gap(LO::AbstractLieAlgebra)
+function _iso_oscar_gap(LO::AbstractLieAlgebra; set_attributes::Bool=true)
   coeffs_iso = Oscar.iso_oscar_gap(coefficient_ring(LO))
   sc_table_G = [
     [
@@ -55,6 +55,38 @@ function _iso_oscar_gap(LO::AbstractLieAlgebra)
   )
 
   f, finv = _iso_oscar_gap_lie_algebra_functions(LO, LG, coeffs_iso)
+
+  if set_attributes && has_root_system(LO)
+    # we need to construct the root system in GAP as otherwise it may detect a different order of simple roots
+    RO = root_system(LO)
+    RG = GAP.Globals.Objectify(
+      GAP.Globals.NewType(
+        GAP.Globals.NewFamily(GAP.Obj("RootSystemFam"), GAP.Globals.IsObject),
+        GAP.evalstr("IsAttributeStoringRep and IsRootSystemFromLieAlgebra")),
+      GAP.GapObj(Dict{Symbol,Any}()))
+    GAP.Globals.SetUnderlyingLieAlgebra(RG, LG)
+
+    cartan_trO = transpose(cartan_matrix(RO))
+    transform_root(r::RootSpaceElem) = GAP.Obj(coefficients(r) * cartan_trO)[1]
+    GAP.Globals.SetPositiveRoots(RG, GAP.Obj(transform_root.(positive_roots(RO))))
+    GAP.Globals.SetNegativeRoots(RG, GAP.Obj(transform_root.(negative_roots(RO))))
+    GAP.Globals.SetSimpleSystem(RG, GAP.Obj(transform_root.(simple_roots(RO))))
+    can_basisG = GAP.Globals.CanonicalBasis(LG)
+    pos_root_vectorsG = can_basisG[1:n_positive_roots(RO)]
+    neg_root_vectorsG = can_basisG[(n_positive_roots(RO) + 1):(2 * n_positive_roots(RO))]
+    csa_basisG = can_basisG[(2 * n_positive_roots(RO) + 1):end]
+    GAP.Globals.SetPositiveRootVectors(RG, pos_root_vectorsG)
+    GAP.Globals.SetNegativeRootVectors(RG, neg_root_vectorsG)
+    GAP.Globals.SetCanonicalGenerators(
+      RG, GAP.Obj([pos_root_vectorsG, neg_root_vectorsG, csa_basisG])
+    )
+    GAP.Globals.SetChevalleyBasis(
+      LG, GAP.Obj([pos_root_vectorsG, neg_root_vectorsG, csa_basisG])
+    )
+
+    GAP.Globals.SetCartanMatrix(RG, GAP.Obj(cartan_trO))
+    GAP.Globals.SetRootSystem(LG, RG)
+  end
 
   return MapFromFunc(LO, LG, f, finv)
 end

--- a/experimental/LieAlgebras/test/AbstractLieAlgebra-test.jl
+++ b/experimental/LieAlgebras/test/AbstractLieAlgebra-test.jl
@@ -121,8 +121,11 @@
       L = lie_algebra(R, struct_consts; check=true)
       @test true # count the number of testcases
       if !isnothing(gap_type)
-        @test String(GAP.Globals.SemiSimpleType(codomain(Oscar.iso_oscar_gap(L)))) in
-          gap_type
+        @test String(
+          GAP.Globals.SemiSimpleType(
+            codomain(Oscar._iso_oscar_gap(L; set_attributes=false)) # let GAP infer the type
+          ),
+        ) in gap_type
       end
     end
 

--- a/experimental/LieAlgebras/test/AbstractLieAlgebra-test.jl
+++ b/experimental/LieAlgebras/test/AbstractLieAlgebra-test.jl
@@ -76,4 +76,130 @@
       )
     end
   end
+
+  @testset "Lie algebra from root system" begin
+    function test_lie_algebras_from_root_system(rs::RootSystem; repeats::Union{Oscar.IntegerUnion, Symbol}=:all, gap_type::Union{Vector{String}, Nothing} = nothing)
+      test_lie_algebras_from_root_system(QQ, rs; repeats, gap_type)
+    end
+  
+    function test_lie_algebras_from_root_system(R::Field, rs::RootSystem; repeats::Union{Oscar.IntegerUnion, Symbol}=:all, gap_type::Union{Vector{String}, Nothing} = nothing)
+      @req (repeats isa Oscar.IntegerUnion && repeats >= 0) || repeats == :all "`repeats` must be a positive integer or :all"
+      n_freedom_degs = n_positive_roots(rs) - n_simple_roots(rs)
+      if n_freedom_degs == 0
+        signs = Bool[]
+        test_lie_algebra_from_root_system(R, rs, signs; gap_type)
+      elseif repeats == :all
+        for signs in AbstractAlgebra.ProductIterator([true,false], n_freedom_degs)
+          test_lie_algebra_from_root_system(R, rs, signs; gap_type)
+        end
+      else
+        for _ in 1:repeats
+          signs = rand(Bool, n_freedom_degs)
+          test_lie_algebra_from_root_system(R, rs, signs; gap_type)
+        end
+      end
+      return nothing
+    end
+
+    function test_lie_algebra_from_root_system(R::Field, rs::RootSystem, signs::Vector{Bool}; gap_type::Union{Vector{String}, Nothing} = nothing)
+      struct_consts = Oscar.LieAlgebras._struct_consts(R, rs, signs)
+      # `check=true`` is slow but tests if the structure constants define a Lie algebra, in particular if they satisfy the Jacobi identity
+      L = lie_algebra(R, struct_consts; check=true)
+      @test true # count the number of testcases
+      if !isnothing(gap_type)
+        @test String(GAP.Globals.SemiSimpleType(codomain(Oscar._iso_oscar_gap(L)))) in gap_type
+      end
+    end
+
+    testcases_fast = Tuple{String, RootSystem, Vector{String}, Union{Oscar.IntegerUnion, Symbol}}[
+      ("A1", root_system(:A, 1), ["A1"], :all), # 1
+      ("A2", root_system(:A, 2), ["A2"], :all), # 2
+      ("A3", root_system(:A, 3), ["A3"], :all), # 8
+      ("A4", root_system(:A, 4), ["A4"], 5),
+      ("A5", root_system(:A, 5), ["A5"], 1),
+      ("A6", root_system(:A, 6), ["A6"], 1),
+      ("B2", root_system(:B, 2), ["B2", "C2"], :all), # 4
+      ("B3", root_system(:B, 3), ["B3"], 8),
+      ("B4", root_system(:B, 4), ["B4"], 1),
+      ("B5", root_system(:B, 5), ["B5"], 1),
+      ("C2", root_system(:C, 2), ["B2", "C2"], :all), # 4
+      ("C3", root_system(:C, 3), ["C3"], 8),
+      ("C4", root_system(:C, 4), ["C4"], 1),
+      ("C5", root_system(:C, 5), ["C5"], 1),
+      ("D4", root_system(:D, 4), ["D4"], 8),
+      ("D5", root_system(:D, 5), ["D5"], 1),
+      ("F4", root_system(:F, 4), ["F4"], 1),
+      ("G2", root_system(:G, 2), ["G2"], :all), # 16
+      ("A2 + B2", root_system((:A, 2), (:B, 2)), ["A2 B2", "B2 A2"], :all), # 8
+      ("A3 + B2, shuffled",
+        root_system([
+          2 0 0 0 -1;
+          0 2 -2 0 0;
+          0 -1 2 0 0;
+          0 0 0 2 -1;
+          -1 0 0 -1 2]), ["A3 B2", "B2 A3"], 5),
+    ]
+
+    testcases_indepth = Tuple{String, RootSystem, Vector{String}, Union{Oscar.IntegerUnion, Symbol}}[
+      ("A1", root_system(:A, 1), ["A1"], :all), # 1
+      ("A2", root_system(:A, 2), ["A2"], :all), # 2
+      ("A3", root_system(:A, 3), ["A3"], :all), # 8
+      ("A4", root_system(:A, 4), ["A4"], :all), # 64
+      ("A5", root_system(:A, 5), ["A5"], 10),
+      ("A6", root_system(:A, 6), ["A6"], 5),
+      ("A7", root_system(:A, 7), ["A7"], 3),
+      ("B2", root_system(:B, 2), ["B2", "C2"], :all), # 4
+      ("B3", root_system(:B, 3), ["B3"], :all), # 64
+      ("B4", root_system(:B, 4), ["B4"], 20),
+      ("B5", root_system(:B, 5), ["B5"], 5),
+      ("C2", root_system(:C, 2), ["B2", "C2"], :all), # 4
+      ("C3", root_system(:C, 3), ["C3"], :all), # 64
+      ("C4", root_system(:C, 4), ["C4"], 20),
+      ("C5", root_system(:C, 5), ["C5"], 5),
+      ("D4", root_system(:D, 4), ["D4"], 50),
+      ("D5", root_system(:D, 5), ["D5"], 5),
+      ("D6", root_system(:D, 6), ["D6"], 2),
+      ("E6", root_system(:E, 6), ["E6"], 1),
+      ("F4", root_system(:F, 4), ["F4"], 5),
+      ("F4 again", root_system(transpose(cartan_matrix(:F, 4))), ["F4"], 3),
+      ("G2", root_system(:G, 2), ["G2"], :all), # 16
+      ("A2 + B3", root_system((:A, 2), (:B, 3)), ["A2 B3", "B3 A2"], 50),
+      ("A3 + B2, shuffled",
+        root_system([
+          2 0 0 0 -1;
+          0 2 -2 0 0;
+          0 -1 2 0 0;
+          0 0 0 2 -1;
+          -1 0 0 -1 2]), ["A3 B2", "B2 A3"], :all), # 32
+      ("B3 + G2, shuffled",
+        root_system([
+          2 -2 0 0 0;
+          -1 2 0 -1 0;
+          0 0 2 0 -1;
+          0 -1 0 2 0;
+          0 0 -3 0 2
+        ]), ["B3 G2", "G2 B3"], 20),
+    ]
+
+    # After changing the function, verify that the tests still pass with `testcases_indepth`,
+    # but this is too slow for the CI
+    for (name, rs, gap_type, repeats) in testcases_fast
+      @testset "$name" begin
+        test_lie_algebras_from_root_system(rs; repeats, gap_type)
+      end
+    end
+
+    @testset "other fields" begin
+      @testset "$R" for R in [cyclotomic_field(4)[1], GF(3), GF(2, 3), algebraic_closure(QQ)]
+        test_lie_algebras_from_root_system(R, root_system(:A, 3); repeats=1)
+        test_lie_algebras_from_root_system(R, root_system(:B, 3); repeats=1)
+        test_lie_algebras_from_root_system(R, root_system(:C, 3); repeats=1)
+        test_lie_algebras_from_root_system(R, root_system(:D, 4); repeats=1)
+        test_lie_algebras_from_root_system(R, root_system(:F, 4); repeats=1)
+        test_lie_algebras_from_root_system(R, root_system(:G, 2); repeats=1)
+      end
+    end
+  end
+
+  
 end

--- a/experimental/LieAlgebras/test/AbstractLieAlgebra-test.jl
+++ b/experimental/LieAlgebras/test/AbstractLieAlgebra-test.jl
@@ -78,18 +78,27 @@
   end
 
   @testset "Lie algebra from root system" begin
-    function test_lie_algebras_from_root_system(rs::RootSystem; repeats::Union{Oscar.IntegerUnion, Symbol}=:all, gap_type::Union{Vector{String}, Nothing} = nothing)
+    function test_lie_algebras_from_root_system(
+      rs::RootSystem;
+      repeats::Union{Oscar.IntegerUnion,Symbol}=:all,
+      gap_type::Union{Vector{String},Nothing}=nothing,
+    )
       test_lie_algebras_from_root_system(QQ, rs; repeats, gap_type)
     end
-  
-    function test_lie_algebras_from_root_system(R::Field, rs::RootSystem; repeats::Union{Oscar.IntegerUnion, Symbol}=:all, gap_type::Union{Vector{String}, Nothing} = nothing)
+
+    function test_lie_algebras_from_root_system(
+      R::Field,
+      rs::RootSystem;
+      repeats::Union{Oscar.IntegerUnion,Symbol}=:all,
+      gap_type::Union{Vector{String},Nothing}=nothing,
+    )
       @req (repeats isa Oscar.IntegerUnion && repeats >= 0) || repeats == :all "`repeats` must be a positive integer or :all"
       n_freedom_degs = n_positive_roots(rs) - n_simple_roots(rs)
       if n_freedom_degs == 0
         signs = Bool[]
         test_lie_algebra_from_root_system(R, rs, signs; gap_type)
       elseif repeats == :all
-        for signs in AbstractAlgebra.ProductIterator([true,false], n_freedom_degs)
+        for signs in AbstractAlgebra.ProductIterator([true, false], n_freedom_degs)
           test_lie_algebra_from_root_system(R, rs, signs; gap_type)
         end
       else
@@ -101,17 +110,25 @@
       return nothing
     end
 
-    function test_lie_algebra_from_root_system(R::Field, rs::RootSystem, signs::Vector{Bool}; gap_type::Union{Vector{String}, Nothing} = nothing)
+    function test_lie_algebra_from_root_system(
+      R::Field,
+      rs::RootSystem,
+      signs::Vector{Bool};
+      gap_type::Union{Vector{String},Nothing}=nothing,
+    )
       struct_consts = Oscar.LieAlgebras._struct_consts(R, rs, signs)
       # `check=true`` is slow but tests if the structure constants define a Lie algebra, in particular if they satisfy the Jacobi identity
       L = lie_algebra(R, struct_consts; check=true)
       @test true # count the number of testcases
       if !isnothing(gap_type)
-        @test String(GAP.Globals.SemiSimpleType(codomain(Oscar._iso_oscar_gap(L)))) in gap_type
+        @test String(GAP.Globals.SemiSimpleType(codomain(Oscar._iso_oscar_gap(L)))) in
+          gap_type
       end
     end
 
-    testcases_fast = Tuple{String, RootSystem, Vector{String}, Union{Oscar.IntegerUnion, Symbol}}[
+    testcases_fast = Tuple{
+      String,RootSystem,Vector{String},Union{Oscar.IntegerUnion,Symbol}
+    }[
       ("A1", root_system(:A, 1), ["A1"], :all), # 1
       ("A2", root_system(:A, 2), ["A2"], :all), # 2
       ("A3", root_system(:A, 3), ["A3"], :all), # 8
@@ -140,7 +157,9 @@
           -1 0 0 -1 2]), ["A3 B2", "B2 A3"], 5),
     ]
 
-    testcases_indepth = Tuple{String, RootSystem, Vector{String}, Union{Oscar.IntegerUnion, Symbol}}[
+    testcases_indepth = Tuple{
+      String,RootSystem,Vector{String},Union{Oscar.IntegerUnion,Symbol}
+    }[
       ("A1", root_system(:A, 1), ["A1"], :all), # 1
       ("A2", root_system(:A, 2), ["A2"], :all), # 2
       ("A3", root_system(:A, 3), ["A3"], :all), # 8
@@ -190,7 +209,8 @@
     end
 
     @testset "other fields" begin
-      @testset "$R" for R in [cyclotomic_field(4)[1], GF(3), GF(2, 3), algebraic_closure(QQ)]
+      @testset "$R" for R in
+                        [cyclotomic_field(4)[1], GF(3), GF(2, 3), algebraic_closure(QQ)]
         test_lie_algebras_from_root_system(R, root_system(:A, 3); repeats=1)
         test_lie_algebras_from_root_system(R, root_system(:B, 3); repeats=1)
         test_lie_algebras_from_root_system(R, root_system(:C, 3); repeats=1)
@@ -200,6 +220,4 @@
       end
     end
   end
-
-  
 end

--- a/experimental/LieAlgebras/test/AbstractLieAlgebra-test.jl
+++ b/experimental/LieAlgebras/test/AbstractLieAlgebra-test.jl
@@ -121,7 +121,7 @@
       L = lie_algebra(R, struct_consts; check=true)
       @test true # count the number of testcases
       if !isnothing(gap_type)
-        @test String(GAP.Globals.SemiSimpleType(codomain(Oscar._iso_oscar_gap(L)))) in
+        @test String(GAP.Globals.SemiSimpleType(codomain(Oscar.iso_oscar_gap(L)))) in
           gap_type
       end
     end

--- a/experimental/LieAlgebras/test/AbstractLieAlgebra-test.jl
+++ b/experimental/LieAlgebras/test/AbstractLieAlgebra-test.jl
@@ -137,15 +137,12 @@
       ("A3", root_system(:A, 3), ["A3"], :all), # 8
       ("A4", root_system(:A, 4), ["A4"], 5),
       ("A5", root_system(:A, 5), ["A5"], 1),
-      ("A6", root_system(:A, 6), ["A6"], 1),
       ("B2", root_system(:B, 2), ["B2", "C2"], :all), # 4
-      ("B3", root_system(:B, 3), ["B3"], 8),
+      ("B3", root_system(:B, 3), ["B3"], 5),
       ("B4", root_system(:B, 4), ["B4"], 1),
-      ("B5", root_system(:B, 5), ["B5"], 1),
       ("C2", root_system(:C, 2), ["B2", "C2"], :all), # 4
-      ("C3", root_system(:C, 3), ["C3"], 8),
+      ("C3", root_system(:C, 3), ["C3"], 5),
       ("C4", root_system(:C, 4), ["C4"], 1),
-      ("C5", root_system(:C, 5), ["C5"], 1),
       ("D4", root_system(:D, 4), ["D4"], 8),
       ("D5", root_system(:D, 5), ["D5"], 1),
       ("F4", root_system(:F, 4), ["F4"], 1),

--- a/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
@@ -726,7 +726,7 @@
     @test (@inferred dim_of_simple_module(
       ZZRingElem, lie_algebra(QQ, :E, 6), [6, 5, 4, 3, 2, 1]
     )) == ZZ(53947263633682628459250)
-    @test_skip (@inferred dim_of_simple_module(
+    @test (@inferred dim_of_simple_module(
       ZZRingElem, lie_algebra(QQ, :F, 4), [2, 4, 1, 2]
     )) == ZZ(5989283015625)
     @test (@inferred dim_of_simple_module(lie_algebra(QQ, :G, 2), [2, 2])) == 729


### PR DESCRIPTION
Adds a constructor `lie_algebra(::Field, ::RootSystem)`, and redirects the constructors given a Dynkin type to this instead of transforming a `GAP.Globals.SimpleLieAlgebra`.
(@HereAround @emikelsons this allows the construction of F4)

To the reviewers: Please don't try to understand the algorithm nor the concrete implementation, I've already spent way to much time doing that myself. And there are pretty comprehensive tests that check that the resulting Lie algebras satisfy the Jacobi identity, and that GAP can detect the Dynkin type again.
Note to GAP: The `iso_oscar_gap` method had to be adapted, because GAP by default decided to take a different Chevalley basis and in particular a different order of simple roots, which made functions like `HighestWeightModule` and `DominantCharacter` (that take a weight in terms of fundamental weights) behave unexpectedly. As a workaround, we now construct and pass a GAP root system.
I am aware of some optimizations in `_struct_consts` and `_N_matrix`, in particular w.r.t. the number of calls to `is_root_with_index` etc. That's something I plan to optimize in the future, but I would be happy to have this already merged prior to that. If you see any other obvious performance improvements, please let me know.