### PR TITLE
refactor vertex-edge graph and dual graph of a polyhedron

### DIFF
--- a/docs/src/Combinatorics/graphs.md
+++ b/docs/src/Combinatorics/graphs.md
@@ -33,8 +33,8 @@ allow for easier integration elsewhere.
 
 ```@docs
 Graph{T}(nverts::Int64) where {T <: Union{Directed, Undirected}}
-dualgraph(p::Polyhedron)
-edgegraph(p::Polyhedron)
+dual_graph(p::Polyhedron)
+vertex_edge_graph(p::Polyhedron; modulo_lineality=false)
 graph_from_adjacency_matrix
 graph_from_edges
 ```
@@ -46,6 +46,7 @@ add_vertices!(g::Graph{T}, n::Int64) where {T <: Union{Directed, Undirected}}
 add_vertex!(g::Graph{T}) where {T <: Union{Directed, Undirected}}
 rem_edge!(g::Graph{T}, s::Int64, t::Int64) where {T <: Union{Directed, Undirected}}
 rem_vertex!(g::Graph{T}, v::Int64) where {T <: Union{Directed, Undirected}}
+rem_vertices!(g::Graph{T}, a::AbstractVector{Int64}) where {T <: Union{Directed, Undirected}}
 ```
 
 ## Auxiliary functions

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -112,6 +112,7 @@ end
 
 @doc raw"""
     rem_edge!(g::Graph{T}, s::Int64, t::Int64) where {T <: Union{Directed, Undirected}}
+    rem_edge!(g::Graph{T}, e::Edge) where {T <: Union{Directed, Undirected}}
 
 Remove edge `(s,t)` from the graph `g`.
 Return `true` if there was an edge from `s` to `t` and it got removed, `false`
@@ -175,6 +176,8 @@ end
 
 Remove the vertex `v` from the graph `g`. Return `true` if node `v` existed and
 was actually removed, `false` otherwise.
+Please note that this will shift the indices of the vertices with index larger than `v`,
+but it will preserve the vertex ordering.
 
 # Examples
 ```jldoctest
@@ -199,6 +202,35 @@ function rem_vertex!(g::Graph{T}, v::Int64) where {T <: Union{Directed, Undirect
   return n_vertices(g) + 1 == old_nvertices
 end
 
+@doc raw"""
+    rem_vertices!(g::Graph{T}, a::AbstractArray{Int64}) where {T <: Union{Directed, Undirected}}
+
+Remove the vertices in `a` from the graph `g`. Return `true` if at least one vertex was removed.
+Please note that this will shift the indices of some of the remaining vertices, but it will preserve the vertex ordering.
+
+# Examples
+```jldoctest
+julia> g = Graph{Directed}(2);
+
+julia> n_vertices(g)
+2
+
+julia> rem_vertices!(g, [1, 2])
+true
+
+julia> n_vertices(g)
+0
+```
+"""
+function rem_vertices!(g::Graph{T}, a::AbstractVector{Int64}) where {T <: Union{Directed, Undirected}}
+  pmg = pm_object(g)
+  old_nvertices = n_vertices(g)
+  for v in a
+    0 < v <= old_nvertices && Polymake._rem_vertex(pmg, v-1)
+  end
+  Polymake._squeeze(pmg)
+  return n_vertices(g) < old_nvertices
+end
 
 @doc raw"""
     add_vertices!(g::Graph{T}, n::Int64) where {T <: Union{Directed, Undirected}}
@@ -284,6 +316,8 @@ Vector{Int}(e::Edge) = [src(e), dst(e)]
 
 Base.isless(a::Edge, b::Edge) = Base.isless(Vector{Int}(a), Vector{Int}(b))
 
+rem_edge!(g::Graph{T}, e::Edge) where {T <: Union{Directed, Undirected}} =
+  rem_edge!(g, src(e), dst(e))
 
 @doc raw"""
     reverse(e::Edge)
@@ -344,7 +378,7 @@ The edge graph of the cube has eight vertices, just like the cube itself.
 ```jldoctest
 julia> c = cube(3);
 
-julia> g = edgegraph(c);
+julia> g = vertex_edge_graph(c);
 
 julia> n_vertices(g)
 8
@@ -364,7 +398,7 @@ The edge graph of the cube has 12 edges just like the cube itself.
 ```jldoctest
 julia> c = cube(3);
 
-julia> g = edgegraph(c);
+julia> g = vertex_edge_graph(c);
 
 julia> n_edges(g)
 12
@@ -384,7 +418,7 @@ A triangle has three edges.
 ```jldoctest
 julia> triangle = simplex(2);
 
-julia> g = edgegraph(triangle);
+julia> g = vertex_edge_graph(triangle);
 
 julia> collect(edges(g))
 3-element Vector{Edge}:
@@ -408,7 +442,7 @@ Check for the edge $1\to 2$ in the edge graph of a triangle.
 ```jldoctest
 julia> triangle = simplex(2);
 
-julia> g = edgegraph(triangle);
+julia> g = vertex_edge_graph(triangle);
 
 julia> has_edge(g, 1, 2)
 true
@@ -433,7 +467,7 @@ The edge graph of a triangle only has 3 vertices.
 ```jldoctest
 julia> triangle = simplex(2);
 
-julia> g = edgegraph(triangle);
+julia> g = vertex_edge_graph(triangle);
 
 julia> has_vertex(g, 1)
 true
@@ -845,10 +879,10 @@ Checks if the graph `g1` is isomorphic to the graph `g2`.
 
 # Examples
 ```jldoctest
-julia> is_isomorphic(edgegraph(simplex(3)), dualgraph(simplex(3)))
+julia> is_isomorphic(vertex_edge_graph(simplex(3)), dual_graph(simplex(3)))
 true
 
-julia> is_isomorphic(edgegraph(cube(3)), dualgraph(cube(3)))
+julia> is_isomorphic(vertex_edge_graph(cube(3)), dual_graph(cube(3)))
 false
 ```
 """
@@ -862,7 +896,7 @@ of the nodes of `G1` such that both graphs agree.
 
 # Examples
 ```jldoctest
-julia> is_isomorphic_with_permutation(edgegraph(simplex(3)), dualgraph(simplex(3)))
+julia> is_isomorphic_with_permutation(vertex_edge_graph(simplex(3)), dual_graph(simplex(3)))
 (true, [1, 2, 3, 4])
 
 ```
@@ -902,12 +936,13 @@ end
 ################################################################################
 ################################################################################
 @doc raw"""
-    edgegraph(p::Polyhedron)
+    vertex_edge_graph(p::Polyhedron)
 
 Return the edge graph of a `Polyhedron`, vertices of the graph correspond to
 vertices of the polyhedron, there is an edge between two vertices if the
 polyhedron has an edge between the corresponding vertices. The resulting graph
 is `Undirected`.
+The keyword argument can be used to consider the polyhedron modulo its lineality space.
 
 # Examples
 Construct the edge graph of the cube. Like the cube it has 8 vertices and 12
@@ -915,7 +950,7 @@ edges.
 ```jldoctest
 julia> c = cube(3);
 
-julia> g = edgegraph(c);
+julia> g = vertex_edge_graph(c);
 
 julia> n_vertices(g)
 8
@@ -924,13 +959,15 @@ julia> n_edges(g)
 12
 ```
 """
-function edgegraph(p::Polyhedron)
-    pmg = pm_object(p).GRAPH.ADJACENCY
-    return Graph{Undirected}(pmg)
+function vertex_edge_graph(p::Polyhedron; modulo_lineality=false)
+  lineality_dim(p) != 0 && !modulo_lineality && return Graph{Undirected}(0)
+  og = Graph{Undirected}(pm_object(p).GRAPH.ADJACENCY)
+  is_bounded(p) || rem_vertices!(og, _ray_indices(pm_object(p)))
+  return og
 end
 
 @doc raw"""
-    dualgraph(p::Polyhedron)
+    dual_graph(p::Polyhedron)
 
 Return the dual graph of a `Polyhedron`, vertices of the graph correspond to
 facets of the polyhedron and there is an edge between two vertices if the
@@ -946,7 +983,7 @@ octahedron, so it has 6 vertices and 12 edges.
 ```jldoctest
 julia> c = cube(3);
 
-julia> g = dualgraph(c);
+julia> g = dual_graph(c);
 
 julia> n_vertices(g)
 6
@@ -955,9 +992,22 @@ julia> n_edges(g)
 12
 ```
 """
-function dualgraph(p::Polyhedron)
-    pmg = pm_object(p).DUAL_GRAPH.ADJACENCY
-    return Graph{Undirected}(pmg)
+function dual_graph(p::Polyhedron)
+  pop = pm_object(p)
+  og = Graph{Undirected}(pop.DUAL_GRAPH.ADJACENCY)
+  fai = _facet_at_infinity(pop)
+  if fai <= n_vertices(og)
+    rem_vertex!(og, fai)
+  elseif !is_bounded(p)
+    f = facets(IncidenceMatrix, p)
+    farface = _ray_indices(pop)
+    for e in edges(og)
+      if is_subset(intersect(row(f, src(e)), row(f, dst(e))), farface)
+        rem_edge!(og, e)
+      end
+    end
+  end
+  return og
 end
 
 

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -942,7 +942,8 @@ Return the edge graph of a `Polyhedron`, vertices of the graph correspond to
 vertices of the polyhedron, there is an edge between two vertices if the
 polyhedron has an edge between the corresponding vertices. The resulting graph
 is `Undirected`.
-The keyword argument can be used to consider the polyhedron modulo its lineality space.
+If the polyhedron has lineality, then it has no vertices or bounded edges, so the `vertex_edge_graph` will be the empty graph.
+In this case, the keyword argument can be used to consider the polyhedron modulo its lineality space.
 
 # Examples
 Construct the edge graph of the cube. Like the cube it has 8 vertices and 12

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -1482,14 +1482,14 @@ function _is_prismic_or_antiprismic(P::Polyhedron)
   # P has to have exactly n vertices and
   # the amount of squares needs to be n or the amount of triangles needs to be 2n
   2n == n_vertices(P) && (5 - m) * n == nvfs[b][2] || return false
-  dg = dualgraph(P)
+  dg = dual_graph(P)
   ngon_is = findall(x -> x == n, nvf)
   has_edge(dg, ngon_is...) && return false
   rem_vertex!(dg, ngon_is[2])
   rem_vertex!(dg, ngon_is[1])
   degs = [length(neighbors(dg, i)) for i in 1:n_vertices(dg)]
   degs == fill(2, n_vertices(dg)) && is_connected(dg) || return false
-  dg = dualgraph(P)
+  dg = dual_graph(P)
   if m == 3
     bigdg = Polymake.graph.Graph(; ADJACENCY=dg.pm_graph)
     return bigdg.BIPARTITE
@@ -1870,29 +1870,3 @@ function Base.show(io::IO, H::SubObjectIterator{<:Hyperplane})
     end
   end
 end
-
-@doc raw"""
-    vertex_edge_graph(P::Polyhedron)
-
-Return the vertex-edge graph of `P` as an abstract graph.
-
-```jldoctest
-julia> G = vertex_edge_graph(cube(2))
-Undirected graph with 4 nodes and the following edges:
-(2, 1)(3, 1)(4, 2)(4, 3)
-```
-"""
-vertex_edge_graph(P::Polyhedron) = Graph(P.pm_polytope.GRAPH.ADJACENCY)
-
-@doc raw"""
-    dual_graph(P::Polyhedron)
-
-Return the dual graph of `P` as an abstract graph.
-
-```jldoctest
-julia> G = Oscar.dual_graph(cross_polytope(3))
-Undirected graph with 8 nodes and the following edges:
-(2, 1)(3, 1)(4, 2)(4, 3)(5, 1)(6, 2)(6, 5)(7, 3)(7, 5)(8, 4)(8, 6)(8, 7)
-```
-"""
-dual_graph(P::Polyhedron) = Graph(P.pm_polytope.DUAL_GRAPH.ADJACENCY)

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -1871,7 +1871,6 @@ function Base.show(io::IO, H::SubObjectIterator{<:Hyperplane})
   end
 end
 
-
 @doc raw"""
     vertex_edge_graph(P::Polyhedron)
 
@@ -1885,7 +1884,6 @@ Undirected graph with 4 nodes and the following edges:
 """
 vertex_edge_graph(P::Polyhedron) = Graph(P.pm_polytope.GRAPH.ADJACENCY)
 
-
 @doc raw"""
     dual_graph(P::Polyhedron)
 
@@ -1898,5 +1896,3 @@ Undirected graph with 8 nodes and the following edges:
 ```
 """
 dual_graph(P::Polyhedron) = Graph(P.pm_polytope.DUAL_GRAPH.ADJACENCY)
-
-

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -1870,3 +1870,33 @@ function Base.show(io::IO, H::SubObjectIterator{<:Hyperplane})
     end
   end
 end
+
+
+@doc raw"""
+    vertex_edge_graph(P::Polyhedron)
+
+Return the vertex-edge graph of `P` as an abstract graph.
+
+```jldoctest
+julia> G = vertex_edge_graph(cube(2))
+Undirected graph with 4 nodes and the following edges:
+(2, 1)(3, 1)(4, 2)(4, 3)
+```
+"""
+vertex_edge_graph(P::Polyhedron) = Graph(P.pm_polytope.GRAPH.ADJACENCY)
+
+
+@doc raw"""
+    dual_graph(P::Polyhedron)
+
+Return the dual graph of `P` as an abstract graph.
+
+```jldoctest
+julia> G = Oscar.dual_graph(cross_polytope(3))
+Undirected graph with 8 nodes and the following edges:
+(2, 1)(3, 1)(4, 2)(4, 3)(5, 1)(6, 2)(6, 5)(7, 3)(7, 5)(8, 4)(8, 6)(8, 7)
+```
+"""
+dual_graph(P::Polyhedron) = Graph(P.pm_polytope.DUAL_GRAPH.ADJACENCY)
+
+

--- a/src/aliases.jl
+++ b/src/aliases.jl
@@ -14,6 +14,8 @@ function n_points end
 function n_polyhedra end
 function n_rays end
 function n_vertices end
+function dual_graph end
+function vertex_edge_graph end
 
 function number_of_compositions end
 function number_of_partitions end
@@ -48,3 +50,7 @@ function number_of_weak_compositions end
 @alias n_generators ngens
 @alias n_rows nrows
 @alias n_variables nvars
+
+# for backwards compatibility
+@alias dualgraph dual_graph
+@alias edgegraph vertex_edge_graph

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -487,10 +487,8 @@ export dual_continued_fraction_hirzebruch_jung
 export dual_graph
 export dual_matroid
 export dual_subdivision
-export dualgraph
 export dwarfed_cube
 export dwarfed_product_polygons
-export edgegraph
 export edges
 export ehrhart_polynomial
 export element_to_homomorphism
@@ -1284,6 +1282,7 @@ export relative_invariants
 export relators
 export rem_edge!
 export rem_vertex!
+export rem_vertices!
 export renest
 export repres
 export representative

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -484,6 +484,7 @@ export double_cosets
 export double_dual
 export dst
 export dual_continued_fraction_hirzebruch_jung
+export dual_graph
 export dual_matroid
 export dual_subdivision
 export dualgraph
@@ -1495,6 +1496,7 @@ export vector_matrix
 export vector_space_basis
 export vector_space_dimension
 export vertex_and_ray_indices
+export vertex_edge_graph
 export vertex_figure
 export vertex_indices
 export vertex_sizes

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -19,6 +19,8 @@
         @test !has_vertex(g, 6)
         @test add_vertices!(g, 5) == 5
         @test n_vertices(g) == 10
+        @test rem_vertices!(g, [2, 4, 6, 11])
+        @test n_vertices(g) == 7
 
         g = Graph{Directed}(4)
         add_edge!(g, 1, 2)
@@ -30,11 +32,16 @@
     triangle = simplex(2)
     c = cube(3)
     cr = cross_polytope(3)
-    egtriangle = edgegraph(triangle)
-    dgtriangle = dualgraph(triangle)
-    egcube = edgegraph(c)
-    dgcube = dualgraph(c)
-    egcr = edgegraph(cr)
+    pos = convex_hull([0 0 0; 1 0 0], [0 1 0; 0 0 1])
+    pl = convex_hull([0 0 0; 1 0 0], nothing, [0 1 1])
+    egtriangle = vertex_edge_graph(triangle)
+    dgtriangle = dual_graph(triangle)
+    egcube = vertex_edge_graph(c)
+    dgcube = dual_graph(c)
+    egcr = vertex_edge_graph(cr)
+    egpos = vertex_edge_graph(pos)
+    egpl = vertex_edge_graph(pl)
+    egplc = vertex_edge_graph(pl, modulo_lineality=true)
     
     @testset "graphs from polytopes" begin
         @test n_vertices(egtriangle) == 3
@@ -51,7 +58,22 @@
         @test is_isomorphic(egcr, dgcube)
         @test !is_isomorphic(egcr, egcube)
 
+        # unbounded examples
+        @test n_vertices(egpos) == 2
+        @test n_edges(egpos) == 1
+
+        @test n_vertices(egpl) == 0
+        @test n_edges(egpl) == 0
+        @test n_vertices(egplc) == 2
+        @test n_edges(egplc) == 1
+
         @test incidence_matrix(egtriangle) == IncidenceMatrix([[1,2],[1,3],[2,3]])
+
+        @test is_isomorphic(dual_graph(convex_hull([0 0 0; 1 0 0], nothing, [0 1 0])), Graph{Undirected}(2))
+        @test is_isomorphic(dual_graph(convex_hull([0 0 0], [0 0 1; 0 1 0; 1 0 0])), complete_graph(3))
+        g = dual_graph(convex_hull([0 0 0; 1 0 0], [0 0 1; 0 1 0]))
+        @test n_vertices(g) == 4
+        @test n_edges(g) == 5
     end
 
     @testset "isomorphic" begin


### PR DESCRIPTION
This is the obvious minimal implementation for vertex edge graphs and dual graphs of polyhedra; taken from polymake.

The question is how to deal with unbounded polyhedra, in particular those with a nontrivial lineality space.  The functions will work in these cases, too.  However, the behavior might be unexpected.  polymake considers the projectivized quotient modulo linealities, which is always a polytope.  Oscar, on the other hand, follows a more naive semantics.

Opinions?