### PR TITLE
interface to GAP's group recognition (first attempt)

### DIFF
--- a/docs/doc.main
+++ b/docs/doc.main
@@ -25,6 +25,7 @@
      "Groups/grouplib.md",
      "Hecke/abelian/introduction.md",
      "Groups/group_characters.md",
+     "Groups/recog.md",
   ],
 
   "Rings" => [

--- a/docs/src/Groups/recog.md
+++ b/docs/src/Groups/recog.md
@@ -1,0 +1,27 @@
+```@meta
+CurrentModule = Oscar
+DocTestSetup = Oscar.doctestsetup()
+```
+
+# Group recognition
+
+The idea of constructive group recognition is to compute a *recognition tree*
+for a given (permutation or matrix) group, which describes the structure
+of this group in a recursive way:
+Each non-leaf node of the tree describes an epimorphism such that
+the kernel and the image belong to the two subtrees of the node.
+Each leaf node describes a group for which efficient methods are available
+that allow one to decide whether a group element is an element of this group,
+and if yes to write the element as a word in terms of suitable generators.
+
+The recognition tree has enough information to decide whether a group element
+is an element of the given group,
+and if yes to write the element as a word in terms of suitable generators
+of the given group.
+
+```@docs
+recognize
+is_ready
+nice_gens
+straight_line_program(tree::GroupRecognitionTree, g::GAPGroupElem)
+```

--- a/src/GAP/gap_to_oscar.jl
+++ b/src/GAP/gap_to_oscar.jl
@@ -236,3 +236,11 @@ function matrices_over_field(gapmats::GapObj)
     z = gen(F)
     return result, F, z
 end
+
+## GAP straight line program
+function straight_line_program(slp::GapObj)
+  @req GAP.Globals.IsStraightLineProgram(slp) "slp must be a straight line program in GAP"
+  lines = GAP.gap_to_julia(GAP.Globals.LinesOfStraightLineProgram(slp); recursive = true)
+  n = GAP.Globals.NrInputsOfStraightLineProgram(slp)
+  return SLP.GAPSLProgram(lines, n)
+end

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -105,14 +105,22 @@ GAP.@wrap GroupHomomorphismByFunction(x1, x2, x3)::GapObj
 GAP.@wrap GroupHomomorphismByFunction(x1, x2, x3, x4)::GapObj
 GAP.@wrap GroupHomomorphismByFunction(x1, x2, x3, x4, x5)::GapObj
 GAP.@wrap GroupOfPcgs(x::GapObj)::GapObj
+GAP.@wrap Grp(x::GapObj)::GapObj
 GAP.@wrap HasCharacterParameters(x::GapObj)::Bool
 GAP.@wrap HasClassParameters(x::GapObj)::Bool
+GAP.@wrap HasGrp(x::GapObj)::Bool
+GAP.@wrap HasImageRecogNode(x::GapObj)::Bool
+GAP.@wrap HasIsRecogInfoForAlmostSimpleGroup(x::GapObj)::Bool
+GAP.@wrap HasIsRecogInfoForSimpleGroup(x::GapObj)::Bool
+GAP.@wrap HasKernelRecogNode(x::GapObj)::Bool
 GAP.@wrap HasMaxes(x::GapObj)::Bool
 GAP.@wrap HasMaximalAbelianQuotient(x::Any)::Bool
 GAP.@wrap HasSize(x::Any)::Bool
+GAP.@wrap Hasfhmethsel(x::GapObj)::Bool
 GAP.@wrap Identity(x::GapObj)::GapObj
 GAP.@wrap Image(x::Any)::GapObj
 GAP.@wrap Image(x::Any, y::Any)::GapObj
+GAP.@wrap ImageRecogNode(x::GapObj)::GapObj
 GAP.@wrap ImagesRepresentative(x::GapObj, y::Any)::GAP.Obj
 GAP.@wrap ImagesSource(x::GapObj)::GapObj
 GAP.@wrap ImmutableMatrix(x::GapObj, y::GapObj, z::Bool)::GapObj
@@ -179,6 +187,7 @@ GAP.@wrap IsInnerAutomorphism(x::Any)::Bool
 GAP.@wrap IsInt(x::Any)::Bool
 GAP.@wrap IsIntegers(x::Any)::Bool
 GAP.@wrap IsIrreducibleCharacter(x::Any)::Bool
+GAP.@wrap IsLeaf(x::GapObj)::Bool
 GAP.@wrap IsLetterAssocWordRep(x::Any)::Bool
 GAP.@wrap IsLetterWordsFamily(x::Any)::Bool
 GAP.@wrap IsLieAlgebra(x::Any)::Bool
@@ -211,6 +220,10 @@ GAP.@wrap IsPrimitive(x::Any, y::Any)::Bool
 GAP.@wrap IsQuasisimpleGroup(x::Any)::Bool
 GAP.@wrap IsQuaternionGroup(x::Any)::Bool
 GAP.@wrap IsRationals(x::Any)::Bool
+GAP.@wrap IsReady(x::GapObj)::Bool
+GAP.@wrap IsRecogInfoForSimpleGroup(x::GapObj)::Bool
+GAP.@wrap IsRecogInfoForAlmostSimpleGroup(x::GapObj)::Bool
+GAP.@wrap IsRecord(x::Any)::Bool
 GAP.@wrap IsRegular(x::Any)::Bool
 GAP.@wrap IsRegular(x::Any, y::Any)::Bool
 GAP.@wrap IsSemiRegular(x::Any)::Bool
@@ -220,6 +233,7 @@ GAP.@wrap IsSimpleGroup(x::Any)::Bool
 GAP.@wrap IsSingularForm(x::Any)::Bool
 GAP.@wrap IsSolvableGroup(x::Any)::Bool
 GAP.@wrap IsSporadicSimpleGroup(x::Any)::Bool
+GAP.@wrap IsString(x::Any)::Bool
 GAP.@wrap IsSubgroupFpGroup(x::Any)::Bool
 GAP.@wrap IsSubset(x::Any, y::Any)::Bool
 GAP.@wrap IsSupersolvableGroup(x::Any)::Bool
@@ -238,6 +252,7 @@ GAP.@wrap IsZmodnZObj(x::Any)::Bool
 GAP.@wrap IsZmodnZObjNonprimeCollection(x::Any)::Bool
 GAP.@wrap Iterator(x::Any)::GapObj
 GAP.@wrap KernelOfCharacter(x::GapObj, y::GapObj)::GapObj
+GAP.@wrap KernelRecogNode(x::GapObj)::GapObj
 GAP.@wrap LargestMovedPoint(x::Any)::Int
 GAP.@wrap LeftActingDomain(x::GapObj)::GapObj
 GAP.@wrap LetterRepAssocWord(x::GapObj)::GapObj
@@ -252,6 +267,7 @@ GAP.@wrap mod(x::Any, y::Any)::GAP.Obj
 GAP.@wrap NameFunction(x::GapObj)::GapObj
 GAP.@wrap NamesOfFusionSources(x::GapObj)::GapObj
 GAP.@wrap NextIterator(x::GapObj)::Any
+GAP.@wrap NiceGens(x::GapObj)::GapObj
 GAP.@wrap NormalClosure(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap Normalizer(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap NormalSubgroupClasses(x::GapObj, y::GAP.Obj)::GapObj
@@ -286,12 +302,14 @@ GAP.@wrap PrimitiveElement(x::GapObj)::GapObj
 GAP.@wrap Projection(x::GapObj)::GapObj
 GAP.@wrap Projection(x::GapObj, i::Int)::GapObj
 GAP.@wrap Range(x::GapObj)::GapObj
+GAP.@wrap RecognizeGroup(x::GapObj)::GapObj
 GAP.@wrap ReduceCoeffs(x::GapObj, y::GapObj)
 GAP.@wrap RelatorsOfFpGroup(x::GapObj)::GapObj
 GAP.@wrap Representative(x::GapObj)::GAP.Obj
 GAP.@wrap RepresentativeAction(x::GapObj, y::GapObj, z::GapObj)::GapObj
 GAP.@wrap RestrictedMapping(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap RootSystem(x::GapObj)::GapObj
+GAP.@wrap SLPforElement(x::GapObj, y::GapObj)::GAP.Obj
 GAP.@wrap ScalarProduct(x::GapObj, y::GapObj, z::GapObj)::GAP.Obj
 GAP.@wrap SchurIndexByCharacter(x::GapObj, y::GapObj, z::GapObj)::GAP.Obj
 GAP.@wrap SetMaximalAbelianQuotient(x::Any, y::Any)::Nothing
@@ -323,6 +341,7 @@ GAP.@wrap WeylGroup(x::GapObj)::GapObj
 GAP.@wrap WeylOrbitIterator(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap Z(x::Any)::GAP.Obj
 GAP.@wrap Zero(x::Any)::GAP.Obj
+GAP.@wrap fhmethsel(x::GapObj)::GAP.Obj
 
 # for Int arguments we can sometimes provide better alternatives
 Conductor(x::Int) = 1

--- a/src/Groups/Groups.jl
+++ b/src/Groups/Groups.jl
@@ -17,3 +17,4 @@ include("spinor_norms.jl")
 include("GrpAb.jl")
 include("group_characters.jl")  # needs some Rings functionality
 include("action.jl")  # needs some PolynomialRings functionality
+include("recog.jl")

--- a/src/Groups/recog.jl
+++ b/src/Groups/recog.jl
@@ -1,0 +1,118 @@
+@attributes mutable struct GroupRecognitionNode{T <: GAPGroup}
+  input_group::T
+  gap_node::GapObj
+
+  function GroupRecognitionNode{T}(G::GAPGroup, gap_node::GapObj) where T
+     res = new{T}(G, gap_node)
+     return res
+  end
+end
+
+GapObj(node::GroupRecognitionNode) = node.gap_node
+
+# did the recognition not fail?
+is_ready(node::GroupRecognitionNode) = GAP.Globals.IsReady(node.gap_node)
+
+# does the node describe a leaf?
+is_leaf(node::GroupRecognitionNode) = GAP.Globals.IsLeaf(node.gap_node)
+
+# the group from which `node` was constructed
+input_group(node::GroupRecognitionNode) = node.input_group
+
+# the group stored in `node`, provided that recognition did not fail;
+# the `GapObj`s of its elements store memory information
+function group(node::GroupRecognitionNode)
+  @req is_ready(node) "recognition failed, no group stored"
+  return _oscar_group(GAP.Globals.Grp(node.gap_node))
+end
+
+function Base.show(io::IO, node::GroupRecognitionNode)
+  if is_terse(io)
+    print(io, "Recognition node of a group")
+  else
+    print(io, "Recognition node of ")
+    io = pretty(io)
+    print(terse(io), Lowercase(), group(node))
+  end
+end
+
+function Base.show(io::IO, mode::MIME"text/plain", node::GroupRecognitionNode)
+  io = pretty(io)
+  _show_recursive(io, mode, GapObj(node); toplevel = true)
+end
+
+function _show_recursive(io::IO, mode::MIME"text/plain", gnode::GapObj; toplevel::Bool = true)
+
+  if GAP.Globals.IsReady(gnode)
+    init = "Recognition node:"
+  else
+    init = "Failed recognition node:"
+  end
+  if GAP.hasbangproperty(gnode, :projective) &&
+     GAP.getbangproperty(gnode, :projective)
+    init = "$init (projective)"
+  end
+  if GAP.Globals.Hasfhmethsel(gnode)
+    ms = GAP.Globals.fhmethsel(gnode)
+    if GAP.Globals.IsRecord(ms)
+      if hasproperty(ms, :successMethod)
+        init = "$init $(String(getproperty(ms, :successMethod)))"
+      else
+        init = "$init NO STAMP"
+      end
+    elseif GAP.Globals.IsString(ms)
+      init = "$init $String(ms)"
+    end
+    if GAP.hasbangproperty(gnode, :comment)
+      init = "$init Comment=$(String(GAP.getbangproperty(gnode, :comment)))"
+    end
+  end
+  if GAP.Globals.HasIsRecogInfoForSimpleGroup(gnode) && GAP.Globals.IsRecogInfoForSimpleGroup(gnode)
+    init = "$init Simple"
+  elseif GAP.Globals.HasIsRecogInfoForAlmostSimpleGroup(gnode) && GAP.Globals.IsRecogInfoForAlmostSimpleGroup(gnode)
+    init = "$init AlmostSimple"
+  end
+  if GAP.Globals.HasSize(gnode)
+    init = "$init Size=$(GAP.Globals.Size(gnode))"
+  end
+  if GAP.Globals.HasGrp(gnode) && GAP.Globals.IsMatrixGroup(GAP.Globals.Grp(gnode))
+    init = "$init Dim=$(GAP.getbangproperty(gnode, :dimension)) Field=$(GAP.Globals.Size(GAP.getbangproperty(gnode, :field)))"
+  end
+  if toplevel
+    println(io, init)
+  else
+    println(io, Lowercase(), init)
+  end
+
+  print(io, Indent())
+  if ! GAP.Globals.IsLeaf(gnode)
+    println(io, "F:")
+    print(io, Indent())
+    if GAP.Globals.HasImageRecogNode(gnode)
+      _show_recursive(io, mode, GAP.Globals.ImageRecogNode(gnode); toplevel = false)
+    else
+      println(io, "has no image")
+    end
+    print(io, Dedent())
+    println(io, "K:")
+    print(io, Indent())
+    if GAP.Globals.HasKernelRecogNode(gnode)
+      if GAP.Globals.KernelRecogNode(gnode) === GAP.Globals.fail
+        println(io, "trivial kernel")
+      else
+        _show_recursive(io, mode, GAP.Globals.KernelRecogNode(gnode); toplevel = false)
+      end
+    else
+      println(io, "has no kernel")
+    end
+    print(io, Dedent())
+  end
+  print(io, Dedent())
+end
+
+# call GAP's recognition algorithm
+function recognize(G::Union{PermGroup, MatrixGroup})
+  res = GAP.Globals.RecognizeGroup(GapObj(G))
+  T = typeof(G)
+  return GroupRecognitionNode{T}(G, res)
+end

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -83,7 +83,6 @@ function __init__()
         (GAP.Globals.IsSubgroupFpGroup, FPGroup),
         (GAP.Globals.IsGroupOfAutomorphisms, AutomorphismGroup),
     ])
-  __GAP_info_messages_off()
   # make Oscar module accessible from GAP (it may not be available as
   # `Julia.Oscar` if Oscar is loaded indirectly as a package dependency)
   GAP.Globals.BindGlobal(GapObj("Oscar"), Oscar)
@@ -124,6 +123,7 @@ function __init__()
      ]
     GAP.Packages.load(pkg)
   end
+  __GAP_info_messages_off()
   __init_group_libraries()
 
   add_verbosity_scope(:K3Auto)

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -95,6 +95,7 @@ function __init__()
   # We want newer versions of some GAP packages than the distributed ones.
   # (But we do not complain if the installation fails.)
   for (pkg, version) in [
+     ("recog", "1.4.2"),
      ("repsn", "3.1.1"),
      ]
     GAP.Packages.install(pkg, version, interactive = false, quiet = true)
@@ -109,6 +110,7 @@ function __init__()
      "packagemanager", # has been loaded already by GAP.jl
      "polycyclic", # needed for Oscar's pc groups
      "primgrp",  # primitive groups library
+     "recog",    # group recognition
      "repsn",    # constructing representations of finite groups
      "smallgrp", # small groups library
      "transgrp", # transitive groups library

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1262,6 +1262,7 @@ export reading_word
 export real_projective_plane
 export real_solutions
 export recession_cone
+export recognize
 export reduce
 export reduce_fraction
 export reduce_with_quotients

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -806,6 +806,7 @@ export is_isomorphism
 export is_johnson_solid
 export is_k_separation
 export is_lattice_polytope
+export is_leaf
 export is_left
 export is_linearly_normal
 export is_local
@@ -845,6 +846,7 @@ export is_q_gorenstein
 export is_quasisimple, has_is_quasisimple, set_is_quasisimple
 export is_quaternion_group, has_is_quaternion_group, set_is_quaternion_group
 export is_radical
+export is_ready
 export is_reduced
 export is_regular
 export is_regular_sequence
@@ -1065,6 +1067,7 @@ export neighbors
 export newick
 export newton_polytope
 export newton_subdivision
+export nice_gens
 export nilpotency_class, has_nilpotency_class, set_nilpotency_class
 export noether_normalization
 export non_fano_matroid
@@ -1405,6 +1408,7 @@ export stanley_reisner_ring
 export star_subcomplex
 export star_subdivision
 export star_triangulations
+export straight_line_program
 export strongly_connected_components
 export structure_sheaf
 export sub

--- a/test/GAP/gap_to_oscar.jl
+++ b/test/GAP/gap_to_oscar.jl
@@ -263,3 +263,13 @@ end
     mats = GAP.evalstr("[ [ [ Z(2) ] ], [ [ Z(3) ] ] ]")
     @test_throws ArgumentError Oscar.matrices_over_cyclotomic_field(mats)
 end
+
+@testset "straight line programs" begin
+    l = GapObj([[[1, 2], 3], [[3, 2], 2], [1, 2, 2, 1]], recursive = true)
+    gapslp = GAP.Globals.StraightLineProgram(l, 2)
+    slp = straight_line_program(gapslp)
+    @test evaluate(slp, [2, 3]) == 64
+    @test GAP.Globals.ResultOfStraightLineProgram(gapslp, GapObj([2, 3])) == 64
+
+    @test_throws ArgumentError straight_line_program(l)
+end

--- a/test/Groups/recog.jl
+++ b/test/Groups/recog.jl
@@ -1,0 +1,25 @@
+@testset "group recognition, basic functions" begin
+  @testset for G in [cyclic_group(PermGroup, 1),
+                     symmetric_group(4),
+                     symmetric_group(100),
+                     general_linear_group(3, 2),
+                     general_linear_group(4, 9),
+                     special_linear_group(4, 7),
+                     ]
+    res = recognize(G)
+    @test is_ready(res)
+    x = rand(G)
+    @test x in res
+    if G isa MatrixGroup
+      @test matrix(x) in res
+    end
+    slp = straight_line_program(res, x)
+    ng = nice_gens(res)
+    @test evaluate(slp, ng) == x
+  end
+
+  @test is_leaf(recognize(symmetric_group(4)))
+  @test !is_leaf(recognize(general_linear_group(3, 2)))
+
+  @test_throws MethodError recognize(small_group(12, 1))
+end


### PR DESCRIPTION
This code provided essentially a new type, the `show` methods derived from GAP's `ViewObj` method for its `IsRecogNode` objects, and a few wrappers for functions dealing with the objects.
Let us discuss this basic setup, and how we want to proceed.