### PR TITLE
Remove the "old experimental structure"

### DIFF
--- a/docs/src/Experimental/intro.md
+++ b/docs/src/Experimental/intro.md
@@ -22,8 +22,7 @@ brought up to Oscar standard.
 ## Structure
 For an example of the structure for a new project in `experimental` have a look
 at project folders, i.e. `experimental/PROJECT_NAME`, that have subfolders
-`docs`, `src`, and `test` (an example is
-`experimental/FTheoryTools`). The general structure is
+`docs`, `src`, and `test`. The general structure is
 ```
 experimental/PROJECT_NAME/
 ├── README.md
@@ -46,11 +45,6 @@ The file `docs/doc.main` is used for integrating your documentation in the
 Oscar manual under the `Experimental` section. Optionally please provide a
 `README.md` describing your project and its goals, especially if you are
 starting from scratch and don't have any documentation yet.
-
-!!! note
-    There are still older projects in `experimental` from before the
-    introduction of this structure. Thus we mentioned `FTheoryTools`
-    as a project having adopted to the new standard.
 
 ### Useful functions for development
 Apart from the hints in the [Introduction for new developers](@ref), there are some more specialized functions for the structure of the `experimental` folder.

--- a/experimental/Experimental.jl
+++ b/experimental/Experimental.jl
@@ -1,7 +1,3 @@
-# We read experimental and filter out all packages that follow our desired
-# scheme. Remember those packages to avoid doing this all over again for docs
-# and test.
-# We don't want to interfere with existing stuff in experimental though.
 const expdir = joinpath(@__DIR__, "../experimental")
 
 # DEVELOPER OPTION:

--- a/experimental/Experimental.jl
+++ b/experimental/Experimental.jl
@@ -3,8 +3,7 @@
 # and test.
 # We don't want to interfere with existing stuff in experimental though.
 const expdir = joinpath(@__DIR__, "../experimental")
-const oldexppkgs = [
-]
+
 # DEVELOPER OPTION:
 # If an experimental package A depends on another experimental package B, one
 # can add `"B", "A"` to `orderedpkgs` below to ensure that B is loaded before A.
@@ -18,7 +17,7 @@ const orderedpkgs = [
   "Schemes",
   "FTheoryTools"             # must be loaded after Schemes
 ]
-exppkgs = filter(x->isdir(joinpath(expdir, x)) && !(x in oldexppkgs) && !(x in orderedpkgs), readdir(expdir))
+exppkgs = filter(x->isdir(joinpath(expdir, x)) && !(x in orderedpkgs), readdir(expdir))
 append!(exppkgs, orderedpkgs)
 
 # force trigger recompile when folder changes
@@ -30,9 +29,8 @@ include_dependency(".")
 isfile(joinpath(expdir, "NoExperimental_whitelist_.jl")) || error("experimental/NoExperimental_whitelist_.jl is missing")
 if islink(joinpath(expdir, "NoExperimental_whitelist.jl"))
   include(joinpath(expdir, "NoExperimental_whitelist.jl"))
-  issubset(whitelist, union(exppkgs, oldexppkgs)) || error("experimental/NoExperimental_whitelist.jl contains unknown packages")
+  issubset(whitelist, exppkgs) || error("experimental/NoExperimental_whitelist.jl contains unknown packages")
   filter!(in(whitelist), exppkgs)
-  filter!(in(whitelist), oldexppkgs)
 end
 
 # Error if something is incomplete in experimental
@@ -46,15 +44,6 @@ for pkg in exppkgs
   end
   # Load the package
   include(joinpath(expdir, pkg, "src", "$pkg.jl"))
-end
-
-# Force some structure for `oldexppkgs`
-for pkg in oldexppkgs
-  if !isfile(joinpath(expdir, pkg, "$pkg.jl"))
-    error("experimental/$pkg is incomplete: $pkg/$pkg.jl missing. Please fix this or remove $pkg from `oldexppkgs`.")
-  end
-  # Load the package
-  include(joinpath(expdir, pkg, "$pkg.jl"))
 end
 
 # We modify the documentation of the experimental part to attach a warning to

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,7 +79,7 @@ end
 
 testlist = Oscar._gather_tests("test")
 
-for exp in [Oscar.exppkgs; Oscar.oldexppkgs]
+for exp in Oscar.exppkgs
   path = joinpath(Oscar.oscardir, "experimental", exp, "test")
   if isdir(path)
     append!(testlist, Oscar._gather_tests(path))


### PR DESCRIPTION
With https://github.com/oscar-system/Oscar.jl/pull/3837 merged, there are no more experimental projects adhering to the "old standard". So let's remove the workaround for them and adapt the documentation.