### PR TITLE
Set version to 1.2.0-DEV

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oscar"
 uuid = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
 authors = ["The OSCAR Team <oscar@oscar-system.org>"]
-version = "1.1.0-DEV"
+version = "1.2.0-DEV"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ julia> using Oscar
  / _ \ / ___| / ___|  / \  |  _ \   |  Combining ANTIC, GAP, Polymake, Singular
 | | | |\___ \| |     / _ \ | |_) |  |  Type "?Oscar" for more information
 | |_| | ___) | |___ / ___ \|  _ <   |  Manual: https://docs.oscar-system.org
- \___/ |____/ \____/_/   \_\_| \_\  |  Version 1.1.0-DEV
-
+ \___/ |____/ \____/_/   \_\_| \_\  |  Version 1.2.0-DEV
 julia> k, a = quadratic_field(-5)
 (Imaginary quadratic field defined by x^2 + 5, sqrt(-5))
 
@@ -120,7 +119,7 @@ pm::Array<topaz::HomologyGroup<pm::Integer> >
 If you have used OSCAR in the preparation of a paper please cite it as described below:
 
     [OSCAR]
-        OSCAR -- Open Source Computer Algebra Research system, Version 1.0.0,
+        OSCAR -- Open Source Computer Algebra Research system, Version 1.2.0-DEV,
         The OSCAR Team, 2024. (https://www.oscar-system.org)
     [OSCAR-book]
         Wolfram Decker, Christian Eder, Claus Fieker, Max Horn, Michael Joswig, eds.
@@ -133,7 +132,7 @@ If you are using BibTeX, you can use the following BibTeX entries:
       key          = {OSCAR},
       organization = {The OSCAR Team},
       title        = {OSCAR -- Open Source Computer Algebra Research system,
-                      Version 1.0.0},
+                      Version 1.2.0-DEV},
       year         = {2024},
       url          = {https://www.oscar-system.org},
       }

--- a/gap/OscarInterface/PackageInfo.g
+++ b/gap/OscarInterface/PackageInfo.g
@@ -10,8 +10,8 @@ SetPackageInfo( rec(
 
 PackageName := "OscarInterface",
 Subtitle := "GAP interface to OSCAR",
-Version := "1.1.0-DEV",
-Date := "16/02/2024", # dd/mm/yyyy format
+Version := "1.2.0-DEV",
+Date := "18/06/2024", # dd/mm/yyyy format
 License := "GPL-2.0-or-later",
 
 Persons := [

--- a/src/AlgebraicGeometry/Surfaces/AdjunctionProcess/AdjunctionProcess.jl
+++ b/src/AlgebraicGeometry/Surfaces/AdjunctionProcess/AdjunctionProcess.jl
@@ -54,7 +54,6 @@ with a general linear subspace of $\mathbb P^n$ of dimension $c+1$.
 # Examples
 ```jldoctest
 julia> X = bordiga()
-[ Info: upgrading serialized data....
 Projective variety
   in projective 4-space over GF(31991) with coordinates [x, y, z, u, v]
 defined by ideal with 4 generators
@@ -95,7 +94,6 @@ Return `true` if `X` is linearly normal, and `false` otherwise.
 # Examples
 ```jldoctest
 julia> X = bordiga()
-[ Info: upgrading serialized data....
 Projective variety
   in projective 4-space over GF(31991) with coordinates [x, y, z, u, v]
 defined by ideal with 4 generators
@@ -181,7 +179,6 @@ julia> degrees_of_generators(Omega)
 
 ```jldoctest
 julia> X = bordiga()
-[ Info: upgrading serialized data....
 Projective variety
   in projective 4-space over GF(31991) with coordinates [x, y, z, u, v]
 defined by ideal with 4 generators
@@ -246,7 +243,6 @@ which are obtained by blowing down the exceptional $(-1)$-lines on $X^{(i)}$.
 # Examples
 ```jldoctest
 julia> X = bordiga()
-[ Info: upgrading serialized data....
 Projective variety
   in projective 4-space over GF(31991) with coordinates [x, y, z, u, v]
 defined by ideal with 4 generators
@@ -284,7 +280,6 @@ julia> degree(L[3][1])
 
 ```
 julia> X = rational_d9_pi7();
-[ Info: upgrading serialized data....
 
 julia> L = adjunction_process(X);
 

--- a/src/AlgebraicGeometry/Surfaces/ParaRatSurfaces/ParametrizationSurfaces.jl
+++ b/src/AlgebraicGeometry/Surfaces/ParaRatSurfaces/ParametrizationSurfaces.jl
@@ -22,7 +22,6 @@ Given a smooth rational surface `X` which is linearly normal in the given embedd
 # Examples
 ```jldoctest
 julia> X = bordiga()
-[ Info: upgrading serialized data....
 Projective variety
   in projective 4-space over GF(31991) with coordinates [x, y, z, u, v]
 defined by ideal with 4 generators

--- a/src/Serialization/Upgrades/main.jl
+++ b/src/Serialization/Upgrades/main.jl
@@ -115,8 +115,8 @@ function upgrade(format_version::VersionNumber, dict::Dict)
     if format_version < script_version
       # TODO: use a macro from Hecke that will allow user to suppress
       # such a message
-      @info("upgrading serialized data....",
-            maxlog=1)
+      @debug("upgrading serialized data....",
+             maxlog=1)
 
       upgrade_state = UpgradeState()
       # upgrading large files needs a work around since the new load


### PR DESCRIPTION
@antonydellavecchia I changed the `upgrading serialized data` to `@debug`, since by now many functions use this internally this mostly confuses the users and causes issues with the doctests.

Maybe we could add an internal keyword to suppress this message when `load` is used from internal functions. But for now hiding the message should be fine.