### PR TITLE
Add option to endow tensor product with product ordering

### DIFF
--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -1885,36 +1885,50 @@ symbols(A::MPolyQuoRing) = symbols(base_ring(A))
 # Tensor products of rings
 ########################################################################
 
-function tensor_product(A::MPolyRing, B::MPolyRing)
+function tensor_product(A::MPolyRing, B::MPolyRing; use_product_ordering::Bool = false)
   kk = coefficient_ring(A)
   @assert kk === coefficient_ring(B) "coefficient rings do not coincide"
   res, a, b = polynomial_ring(kk, symbols(A), symbols(B); cached=false)
+  if use_product_ordering
+    o = induce(gens(res)[1:ngens(A)], default_ordering(A))*induce(gens(res)[ngens(A) + 1:end], default_ordering(B))
+    set_default_ordering!(res, o)
+  end
   return res, hom(A, res, a), hom(B, res, b)
 end
 
-function tensor_product(A::MPolyRing, B::MPolyQuoRing)
+function tensor_product(A::MPolyRing, B::MPolyQuoRing; use_product_ordering::Bool = false)
   R = base_ring(B)
   AR, inc_A, inc_R = tensor_product(A, R)
   I = ideal(AR, inc_R.(gens(modulus(B))))
-  res, pr = quo(R, I)
-  return res, compose(inc_A, pr), hom(B, res, pr.(inc_R.(gens(R))))
+  res, pr = quo(AR, I)
+  if use_product_ordering
+    o = induce(gens(AR)[1:ngens(A)], default_ordering(A))*induce(gens(AR)[ngens(A) + 1:end], default_ordering(B))
+    set_default_ordering!(AR, o)
+  end
+  return res, hom(A, res, pr.(inc_A.(gens(A))); check = false), hom(B, res, pr.(inc_R.(gens(R))); check = false)
 end
 
-function tensor_product(A::MPolyQuoRing, B::MPolyQuoRing)
+function tensor_product(A::MPolyQuoRing, B::MPolyQuoRing; use_product_ordering::Bool = false)
   RA = base_ring(A)
   RB = base_ring(B)
   P, inc_A, inc_B = tensor_product(RA, RB)
   I = ideal(P, inc_A.(gens(modulus(A)))) + ideal(P, inc_B.(gens(modulus(B))))
-  res, pr = quo(R, I)
+  res, pr = quo(P, I)
+  if use_product_ordering
+    o = induce(gens(P)[1:ngens(A)], default_ordering(A))*induce(gens(P)[ngens(A) + 1:end], default_ordering(B))
+    set_default_ordering!(P, o)
+  end
   return res, hom(A, res, pr.(inc_A.(gens(RA))); check=false), hom(B, res, pr.(inc_B.(gens(RB))); check=false)
 end
 
-function tensor_product(A::MPolyQuoRing, B::MPolyRing)
+function tensor_product(A::MPolyQuoRing, B::MPolyRing; use_product_ordering::Bool = false)
   RA = base_ring(A)
   P, inc_A, inc_B = tensor_product(RA, B)
   I = ideal(P, inc_A.(gens(modulus(A))))
-  res, pr = quo(R, I)
-  return res, hom(A, res, pr.(inc_A.(gens(RA))); check=false), compose(inc_B, pr)
+  res, pr = quo(P, I)
+  if use_product_ordering
+    o = induce(gens(P)[1:ngens(A)], default_ordering(A))*induce(gens(P)[ngens(A) + 1:end], default_ordering(B))
+    set_default_ordering!(P, o)
+  end
+  return res, hom(A, res, pr.(inc_A.(gens(RA))); check=false), hom(B, res, pr.(inc_B.(gens(B))); check = false)
 end
-
-

--- a/test/Rings/MPolyQuo.jl
+++ b/test/Rings/MPolyQuo.jl
@@ -336,3 +336,29 @@ end
   @test Oscar.HasGroebnerAlgorithmTrait(R1) isa Oscar.HasRingFlattening
   @test Oscar.HasGroebnerAlgorithmTrait(one(R1)) isa Oscar.HasRingFlattening
 end
+
+@testset "Tensor product" begin
+  R, x = polynomial_ring(QQ, 3, "x")
+  S, y = polynomial_ring(QQ, 4, "y")
+
+  @test_throws AssertionError tensor_product(R, GF(3)["x", "y"][1])
+
+  I = ideal(R, [x[1]])
+  J = ideal(S, [y[1]])
+  for A in [R, quo(R, I)[1]]
+    for B in [S, quo(S, J)[1]]
+      T, AtoT, BtoT = tensor_product(A, B)
+
+      @test ngens(T) == 7
+      @test is_zero(kernel(AtoT))
+      @test is_zero(kernel(BtoT))
+
+      v = append!(AtoT.(gens(A)), BtoT.(gens(B)))
+      @test v == gens(T)
+
+      T, _, _ = tensor_product(A, B, use_product_ordering = true)
+      @test default_ordering(T).o isa Oscar.Orderings.ProdOrdering
+      @test cmp(default_ordering(T), lift(gen(T, ngens(A))), lift(gen(T, ngens(A) + 1))) == 1
+    end
+  end
+end


### PR DESCRIPTION
@wdecker this is what we talked about: I added a keyword argument `use_product_ordering` to `tensor_product`.

Also fixes some typos in the implementation and adds very basic tests.
