### PR TITLE
Checking for product orderings

### DIFF
--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -1796,7 +1796,11 @@ end
 
 function _embedded_ring_ordering(o::ModProdOrdering)
   ea = _embedded_ring_ordering(o.a)
-  shift = maximum(ea.vars)
+  if ea isa ProdOrdering
+    shift = maximum([ea.a.vars;ea.b.vars])
+  else
+    shift = maximum(ea.vars)
+  end
   eb = _embedded_ring_ordering(o.b)
   eb.vars .+= shift 
   return ea*eb

--- a/test/Rings/orderings.jl
+++ b/test/Rings/orderings.jl
@@ -398,6 +398,17 @@ end
    test_opposite_ordering(a)
    @test canonical_matrix(a) == matrix(ZZ, 3, 3, [4 2 3; 0 1 0; 0 0 1])
    @test simplify(a) isa MonomialOrdering
+
+   #issue 3870
+   D, (w, x, y, z) = polynomial_ring(QQ, ["w", "x", "y", "z"]);
+   C, (s,t) = polynomial_ring(QQ, ["s", "t"]);
+   T, _ = tensor_product(C, D, use_product_ordering = true);
+   F = free_module(T, 2);
+   G = gens(T);
+   S, _ = sub(F, [G[1]*gens(F)[1]]);
+   u = Oscar.Orderings._embedded_ring_ordering(default_ordering(S))
+   o = default_ordering(T)
+   @test [u.a.a.vars;u.a.b.vars] == [o.o.a.vars;o.o.b.vars]
 end
 
 @testset "Polynomial Ordering elimination" begin


### PR DESCRIPTION
This fixes issue #3870. It checks if an embedded ring ordering in a module ordering is a product ordering and handles this case correspondingly.

@RafaelDavidMohr: Please have a look if this is the correct way to fix this issue.