### PR TITLE
matroids: fix automorphism for some matroids

### DIFF
--- a/src/Combinatorics/Matroids/matroids.jl
+++ b/src/Combinatorics/Matroids/matroids.jl
@@ -1015,7 +1015,7 @@ Permutation group of degree 4
 """
 function automorphism_group(M::Matroid) 
   @req length(M) > 0 "The matroid should not be empty."
-  I = rank(M) < 1 ? IncidenceMatrix(bases(dual_matroid(M))) : IncidenceMatrix(bases(M))
+  I = rank(M) < 1 ? IncidenceMatrix(bases(Int, dual_matroid(M))) : IncidenceMatrix(bases(Int, M))
   resize!(I, nrows(I), length(M))
   return automorphism_group(I; action=:on_cols)
 end

--- a/test/Combinatorics/Matroids/Matroids.jl
+++ b/test/Combinatorics/Matroids/Matroids.jl
@@ -347,7 +347,12 @@
         @test order(automorphism_group(M)) == 120
         @test automorphism_group(uniform_matroid(0, 2)) == symmetric_group(2)
         U = matroid_from_bases([[1,2],[2,3],[1,3]],5)
-        @test automorphism_group(U) == automorphism_group(dual_matroid(U)) 
+        @test automorphism_group(U) == automorphism_group(dual_matroid(U))
+
+        g = complete_graph(4)
+        rem_edge!(g,1,2)
+        M = cycle_matroid(g)
+        @test degree(automorphism_group(M)) == 5
     end
 
     @testset "matroid quotient" begin


### PR DESCRIPTION
cc: @Sequenzer 

`bases` returns vectors with ground set elements by default but we just need indices here.