### PR TITLE
Iteratorify some tableaux

### DIFF
--- a/src/Combinatorics/EnumerativeCombinatorics/tableaux.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/tableaux.jl
@@ -500,29 +500,29 @@ function semistandard_tableaux(s::Vector{T}, weight::Vector{T}) where T <: Integ
   n_max = sum(s)
   @req n_max == sum(weight) "sum(s) == sum(weight) required"
 
-  tabs = Vector{YoungTableau}()
+  tabs = Vector{YoungTableau{T}}()
   if isempty(s)
-    push!(tabs, young_tableau(Vector{Int}[], check = false))
+    push!(tabs, young_tableau(Vector{T}[], check = false))
     return (t for t in tabs)
   end
   ls = length(s)
 
-  tab = young_tableau([ [0 for j = 1:s[i]] for i = 1:length(s)], check = false)
-  sub_s = zeros(Integer, length(s))
+  tab = young_tableau([ T[0 for j = 1:s[i]] for i = 1:length(s)], check = false)
+  sub_s = zeros(Int, length(s))
 
   #tracker_row = zeros(Integer, n_max)
 
-  function rec_sst!(n::Integer)
+  function rec_sst!(n::Int)
 
     #fill the remaining boxes if possible, else set them to 0
     if n == length(weight)
       for i = 1:ls
         for j = sub_s[i] + 1:s[i]
-          tab[i][j] = n
+          tab[i][j] = T(n)
           if i != 1 && tab[i - 1][j] == n
             for k = 1:i
               for l = sub_s[k] + 1:s[k]
-                tab[i][j] = 0
+                tab[i][j] = T(0)
               end
             end
             return
@@ -540,7 +540,7 @@ function semistandard_tableaux(s::Vector{T}, weight::Vector{T}) where T <: Integ
     end
 
     #here starts the main part of the function
-    tracker_row = zeros(Integer, weight[n])
+    tracker_row = zeros(Int, weight[n])
     i = 1
     while sub_s[i] == s[i]
       i += 1
@@ -551,7 +551,7 @@ function semistandard_tableaux(s::Vector{T}, weight::Vector{T}) where T <: Integ
     while m >= 0
       if m == weight[n]   # jump to next recursive step
         rec_sst!(n + 1)
-        tab[tracker_row[m]][sub_s[tracker_row[m]]] = 0
+        tab[tracker_row[m]][sub_s[tracker_row[m]]] = T(0)
         i = tracker_row[m] + 1
         if i <= ls
           j = sub_s[i] + 1
@@ -563,7 +563,7 @@ function semistandard_tableaux(s::Vector{T}, weight::Vector{T}) where T <: Integ
         if m == 0
           return
         else
-          tab[tracker_row[m]][sub_s[tracker_row[m]]] = 0
+          tab[tracker_row[m]][sub_s[tracker_row[m]]] = T(0)
           i = tracker_row[m] + 1
           if i <= ls
             j = sub_s[i] + 1
@@ -574,7 +574,7 @@ function semistandard_tableaux(s::Vector{T}, weight::Vector{T}) where T <: Integ
 
       elseif j <= s[i] && (i == 1 || (j <= sub_s[i - 1] && n > tab[i - 1][j]))  #add an entry
         m += 1
-        tab[i][j] = n
+        tab[i][j] = T(n)
         sub_s[i] += 1
         tracker_row[m] = i
         j += 1

--- a/src/Combinatorics/EnumerativeCombinatorics/tableaux.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/tableaux.jl
@@ -806,12 +806,6 @@ Base.IteratorSize(::Type{<: StandardTableauxFixedBoxNum}) = Base.SizeUnknown()
   next_part === nothing && return nothing
   Sp = standard_tableaux(next_part[1])
   next_tab = iterate(Sp)
-  while next_tab === nothing
-    next_part = iterate(P, next_part[2])
-    next_part === nothing && return nothing
-    Sp = standard_tableaux(next_part[1])
-    next_tab = iterate(Sp)
-  end
   return next_tab[1], (P, next_part[2], Sp, next_tab[2])
 end
 

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -298,3 +298,24 @@ See [`young_tableau`](@ref) for the user-facing constructor and an example.
 struct YoungTableau{T<:IntegerUnion} <: AbstractVector{AbstractVector{T}}
   t::Vector{Vector{T}}
 end
+
+# Iterator type: all semistandard tableaux of a given shape
+struct SemiStandardTableaux{T<:IntegerUnion}
+  shape::Partition{T}
+  max_val::T
+
+  function SemiStandardTableaux(p::Partition{T}, max_val::T) where {T <: IntegerUnion}
+    return new{T}(p, max_val)
+  end
+end
+
+# Iterator type: all semistandard tableaux with a given number of boxes
+struct SemiStandardTableauxFixedBoxNum{T<:IntegerUnion}
+  box_num::T
+  max_val::T
+
+  function SemiStandardTableauxFixedBoxNum(box_num::T, max_val::T) where {T <: IntegerUnion}
+    @req box_num >= 0 "box_num >= 0 required"
+    return new{T}(box_num, max_val)
+  end
+end

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -315,7 +315,36 @@ struct SemiStandardTableauxFixedBoxNum{T<:IntegerUnion}
   max_val::T
 
   function SemiStandardTableauxFixedBoxNum(box_num::T, max_val::T) where {T <: IntegerUnion}
-    @req box_num >= 0 "box_num >= 0 required"
+    @req box_num >= 0 "Number of boxes must be non-negative"
     return new{T}(box_num, max_val)
+  end
+end
+
+# Iterator type: all standard tableaux of a given shape
+struct StandardTableaux{T<:IntegerUnion}
+  shape::Partition{T}
+
+  function StandardTableaux(p::Partition{T}) where {T <: IntegerUnion}
+    return new{T}(p)
+  end
+end
+
+# Internal type: state of the iterator
+mutable struct StandardTableauxState{T<:IntegerUnion}
+  n::Int
+  i::Int
+  j::Int
+  tab::YoungTableau{T}
+  sub_s::Vector{Int}
+  tracker_row::Vector{Int}
+end
+
+# Iterator type: all standard tableaux with a given number of boxes
+struct StandardTableauxFixedBoxNum{T<:IntegerUnion}
+  box_num::T
+
+  function StandardTableauxFixedBoxNum(box_num::T) where {T <: IntegerUnion}
+    @req box_num >= 0 "Number of boxes must be non-negative"
+    return new{T}(box_num)
   end
 end

--- a/test/Combinatorics/EnumerativeCombinatorics/tableaux.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/tableaux.jl
@@ -31,101 +31,108 @@
   @test is_semistandard(young_tableau([[1,2,1],[2,4]])) == false
   @test is_semistandard(young_tableau([[-1]])) == true
 
-  # semistandard_tableaux(shape::Array{T,1}, max_val=sum(shape)::Integer)
-  shapes = [[3,2,1],[3,3,1],[2,2,2]]
-  for s in shapes
-    SST = collect(semistandard_tableaux(s))
-    #check that all tableaux are distinct
-    @test SST == unique(SST)
-
-    #check that all tableaux are semistandard_tableaux
-    for tab in SST
-      @test is_semistandard(tab)
-    end
-  end
-  @test isempty(semistandard_tableaux([3,2,1],2))
-
-  # semistandard_tableaux(s::Array{T,1}, weight::Array{T,1})
-  shapes = [[5,3,1,1],[4,3,2,1],[2,2,2,2,2]]
-  weights = [[1,1,1,1,1,1,1,1,1,1],[3,0,2,0,0,5],[4,3,2,1]]
-  for s in shapes
-    for w in weights
-      SST = collect(semistandard_tableaux(s, w))
+  @testset "Generating tableaux with integer type $T" for T in [Int8, Int]
+    # semistandard_tableaux(shape::Array{T,1}, max_val=sum(shape)::Integer)
+    shapes = [T[3, 2, 1], T[3, 3, 1], T[2, 2, 2]]
+    for s in shapes
+      SST = @inferred collect(semistandard_tableaux(s))
+      @test SST isa Vector{Oscar.YoungTableau{T}}
       #check that all tableaux are distinct
       @test SST == unique(SST)
+
       #check that all tableaux are semistandard_tableaux
       for tab in SST
         @test is_semistandard(tab)
       end
-      #check that all tableaux have the correct shape
-      for tab in SST
-        @test shape(tab) == s
-      end
-      #check that all tableaux have the correct weight
-      for tab in SST
-        @test weight(tab) == w
-      end
     end
-  end
-  @test collect(semistandard_tableaux(Int[], Int[])) == [young_tableau(Array{Int,1}[])]
+    @test isempty(semistandard_tableaux(T[3, 2, 1], T(2)))
 
-  #semistandard_tableaux(box_num, max_val)
-  BoxNum = 0:5
-  MaxVal = 1:6
-  for box_num in BoxNum
-    for max_val in MaxVal
-      SST = collect(semistandard_tableaux(box_num, max_val))
-      #check that all tableaux are distinct
-      @test SST == unique(SST)
-      #check that all tableaux are semistandard_tableaux
-      for tab in SST
-        @test is_semistandard(tab)
-      end
-      #check that all tableaux have box_num boxes
-      for tab in SST
-        @test sum(shape(tab)) == box_num
-      end
-      #check that all tableaux have values ≤ max_val
-      for tab in SST
-        for i in 1:length(tab)
-          @test tab[i][end] <= max_val
+    # semistandard_tableaux(s::Array{T,1}, weight::Array{T,1})
+    shapes = [T[5, 3, 1, 1], T[4, 3, 2, 1], T[2, 2, 2, 2, 2]]
+    weights = [T[1, 1, 1, 1, 1, 1, 1, 1, 1, 1], T[3, 0, 2, 0, 0, 5], T[4, 3, 2, 1]]
+    for s in shapes
+      for w in weights
+        SST = @inferred collect(semistandard_tableaux(s, w))
+        @test SST isa Vector{Oscar.YoungTableau{T}}
+        #check that all tableaux are distinct
+        @test SST == unique(SST)
+        #check that all tableaux are semistandard_tableaux
+        for tab in SST
+          @test is_semistandard(tab)
+        end
+        #check that all tableaux have the correct shape
+        for tab in SST
+          @test shape(tab) == s
+        end
+        #check that all tableaux have the correct weight
+        for tab in SST
+          @test weight(tab) == w
         end
       end
     end
-  end
+    @test collect(semistandard_tableaux(T[], T[])) == [young_tableau(Vector{T}[])]
 
-  # number_of_standard_tableaux
-  # standard_tableaux(s::Partition)
-  for i = 1:10
-    for s in partitions(i)
-      ST = collect(standard_tableaux(s))
+    #semistandard_tableaux(box_num, max_val)
+    BoxNum = T(0):T(5)
+    MaxVal = T(1):T(6)
+    for box_num in BoxNum
+      for max_val in MaxVal
+        SST = @inferred collect(semistandard_tableaux(box_num, max_val))
+        @test SST isa Vector{Oscar.YoungTableau{T}}
+        #check that all tableaux are distinct
+        @test SST == unique(SST)
+        #check that all tableaux are semistandard_tableaux
+        for tab in SST
+          @test is_semistandard(tab)
+        end
+        #check that all tableaux have box_num boxes
+        for tab in SST
+          @test sum(shape(tab)) == box_num
+        end
+        #check that all tableaux have values ≤ max_val
+        for tab in SST
+          for i in 1:length(tab)
+            @test tab[i][end] <= max_val
+          end
+        end
+      end
+    end
+
+    # number_of_standard_tableaux
+    # standard_tableaux(s::Partition)
+    for i = 1:10
+      for s in partitions(T(i))
+        ST = @inferred collect(standard_tableaux(s))
+        @test ST isa Vector{Oscar.YoungTableau{T}}
+        #check that all tableaux are distinct
+        @test ST == unique(ST)
+        #check that all tableaux are standard_tableaux
+        for tab in ST
+          @test is_standard(tab)
+        end
+        #check that all tableaux where found
+        @test length(ST) == number_of_standard_tableaux(s)
+      end
+    end
+    @test collect(standard_tableaux(partition(T[]))) == [young_tableau(Vector{T}[])]
+    @test collect(standard_tableaux(T[3, 2, 1])) == collect(standard_tableaux(partition(T[3, 2, 1])))
+
+    # standard_tableaux(n::Integer)
+    for n = 0:10
+      ST = @inferred collect(standard_tableaux(T(n)))
+      @test ST isa Vector{Oscar.YoungTableau{T}}
       #check that all tableaux are distinct
       @test ST == unique(ST)
       #check that all tableaux are standard_tableaux
       for tab in ST
         @test is_standard(tab)
       end
-      #check that all tableaux where found
-      @test length(ST) == number_of_standard_tableaux(s)
+      #check that all tableaux have n boxes
+      for tab in ST
+        @test sum(shape(tab)) == n
+      end
     end
-  end
-  @test collect(standard_tableaux(partition(Int[]))) == [young_tableau(Array{Int,1}[])]
-  @test collect(standard_tableaux([3, 2, 1])) == collect(standard_tableaux(partition([3, 2, 1])))
-
-  # standard_tableaux(n::Integer)
-  for n = 0:10
-    ST = collect(standard_tableaux(n))
-    #check that all tableaux are distinct
-    @test ST == unique(ST)
-    #check that all tableaux are standard_tableaux
-    for tab in ST
-      @test is_standard(tab)
-    end
-    #check that all tableaux have n boxes
-    for tab in ST
-      @test sum(shape(tab)) == n
-    end
-  end
+  end # testest "Generating tableaux"
 
   # hook_length
   @test hook_length(partition([1]),1,1) == 1


### PR DESCRIPTION
Turn `semistandard_tableaux(shape)` and `standard_tableaux` into an actual iterator internally.
Also adds tests/fixes for different `Integer` types. `ZZRingElem` doesn't work in general because the entries are often used as indices.

The only function left, which still first fills an array internally and then iterates the entries, is `semistandard_tableaux(shape, weight)`.
This function is unfortunately implemented recursively, so it would need to be reimplemented completely. There is no reference for the used algorithm given; I assume it was implemented by a Bachelor's student in JuLie originally. @ulthiel Is there a reference for this algorithm?

