### PR TITLE
Remove caching of Lie algebras

### DIFF
--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -477,26 +477,24 @@ end
 ###############################################################################
 
 @doc raw"""
-    lie_algebra(gapL::GapObj, s::Vector{<:VarName}; cached::Bool) -> LieAlgebra{elem_type(R)}
+    lie_algebra(gapL::GapObj, s::Vector{<:VarName}) -> LieAlgebra{elem_type(R)}
 
 Construct a Lie algebra isomorphic to the GAP Lie algebra `gapL`. Its basis element are named by `s`,
 or by `x_i` by default.
 We require `gapL` to be a finite-dimensional GAP Lie algebra. The return type is dependent on
 properties of `gapL`, in particular, whether GAP knows about a matrix representation.
 
-If `cached` is `true`, the constructed Lie algebra is cached.
 """
 function lie_algebra(
   gapL::GapObj,
   s::Vector{<:VarName}=[Symbol("x_$i") for i in 1:GAPWrap.Dimension(gapL)];
-  cached::Bool=true,
 )
-  @req GAPWrap.IsLieAlgebra(gapL) "gapL must be a Lie algebra."
+  @req GAPWrap.IsLieAlgebra(gapL) "input must be a Lie algebra."
   if GAPWrap.IsFiniteDimensional(gapL)
     if GAPWrap.IsLieObjectCollection(gapL)
-      return codomain(_iso_gap_oscar_linear_lie_algebra(gapL, s; cached))
+      return codomain(_iso_gap_oscar_linear_lie_algebra(gapL, s))
     else
-      return codomain(_iso_gap_oscar_abstract_lie_algebra(gapL, s; cached))
+      return codomain(_iso_gap_oscar_abstract_lie_algebra(gapL, s))
     end
   end
   error("Not implemented.")

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -9,7 +9,7 @@ import Oscar: GAPWrap, IntegerUnion, MapHeader
 import Random
 
 # not importet in Oscar
-using AbstractAlgebra: CacheDictType, ProductIterator, get_cached!, ordinal_number_string
+using AbstractAlgebra: ProductIterator, ordinal_number_string
 
 using AbstractAlgebra.PrettyPrinting
 

--- a/experimental/LieAlgebras/src/LinearLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LinearLieAlgebra.jl
@@ -10,30 +10,21 @@
     n::Int,
     basis::Vector{<:MatElem{C}},
     s::Vector{Symbol};
-    cached::Bool=true,
     check::Bool=true,
   ) where {C<:FieldElem}
-    return get_cached!(
-      LinearLieAlgebraDict, (R, n, basis, s), cached
-    ) do
-      @req all(b -> size(b) == (n, n), basis) "Invalid basis element dimensions."
-      @req length(s) == length(basis) "Invalid number of basis element names."
-      L = new{C}(R, n, length(basis), basis, s)
-      if check
-        @req all(b -> all(e -> parent(e) === R, b), basis) "Invalid matrices."
-        # TODO: make work
-        # for xi in basis(L), xj in basis(L)
-        #   @req (xi * xj) in L
-        # end
-      end
-      return L
-    end::LinearLieAlgebra{C}
+    @req all(b -> size(b) == (n, n), basis) "Invalid basis element dimensions."
+    @req length(s) == length(basis) "Invalid number of basis element names."
+    L = new{C}(R, n, length(basis), basis, s)
+    if check
+      @req all(b -> all(e -> parent(e) === R, b), basis) "Invalid matrices."
+      # TODO: make work
+      # for xi in basis(L), xj in basis(L)
+      #   @req (xi * xj) in L
+      # end
+    end
+    return L
   end
 end
-
-const LinearLieAlgebraDict = CacheDictType{
-  Tuple{Field,Int,Vector{<:MatElem},Vector{Symbol}},LinearLieAlgebra
-}()
 
 struct LinearLieAlgebraElem{C<:FieldElem} <: LieAlgebraElem{C}
   parent::LinearLieAlgebra{C}
@@ -195,24 +186,23 @@ end
 ###############################################################################
 
 @doc raw"""
-    lie_algebra(R::Field, n::Int, basis::Vector{<:MatElem{elem_type(R)}}, s::Vector{<:VarName}; cached::Bool) -> LinearLieAlgebra{elem_type(R)}
+    lie_algebra(R::Field, n::Int, basis::Vector{<:MatElem{elem_type(R)}}, s::Vector{<:VarName}; check::Bool=true) -> LinearLieAlgebra{elem_type(R)}
 
 Construct the Lie algebra over the field `R` with basis `basis` and basis element names
 given by `s`. The basis elements must be square matrices of size `n`.
-We require `basis` to be linearly independent, and to contain the Lie bracket of any
-two basis elements in its span.
 
-If `cached` is `true`, the constructed Lie algebra is cached.
+We require `basis` to be linearly independent, and to contain the Lie bracket of any
+two basis elements in its span (this is currently not checked).
+Setting `check=false` disables these checks (once they are in place).
 """
 function lie_algebra(
   R::Field,
   n::Int,
   basis::Vector{<:MatElem{C}},
   s::Vector{<:VarName};
-  cached::Bool=true,
   check::Bool=true,
 ) where {C<:FieldElem}
-  return LinearLieAlgebra{elem_type(R)}(R, n, basis, Symbol.(s); cached)
+  return LinearLieAlgebra{elem_type(R)}(R, n, basis, Symbol.(s); check)
 end
 
 function lie_algebra(

--- a/experimental/LieAlgebras/src/iso_gap_oscar.jl
+++ b/experimental/LieAlgebras/src/iso_gap_oscar.jl
@@ -22,9 +22,8 @@ function _iso_gap_oscar_abstract_lie_algebra(
   LG::GapObj,
   s::Vector{<:VarName}=[Symbol("x_$i") for i in 1:GAPWrap.Dimension(LG)];
   coeffs_iso::Map{GapObj}=Oscar.iso_gap_oscar(GAPWrap.LeftActingDomain(LG)),
-  cached::Bool=true,
 )
-  LO = _abstract_lie_algebra_from_GAP(LG, coeffs_iso, s; cached)
+  LO = _abstract_lie_algebra_from_GAP(LG, coeffs_iso, s)
   finv, f = _iso_oscar_gap_lie_algebra_functions(LO, LG, inv(coeffs_iso))
 
   iso = MapFromFunc(LG, LO, f, finv)
@@ -36,9 +35,8 @@ function _iso_gap_oscar_linear_lie_algebra(
   LG::GapObj,
   s::Vector{<:VarName}=[Symbol("x_$i") for i in 1:GAPWrap.Dimension(LG)];
   coeffs_iso::Map{GapObj}=Oscar.iso_gap_oscar(GAPWrap.LeftActingDomain(LG)),
-  cached::Bool=true,
 )
-  LO = _linear_lie_algebra_from_GAP(LG, coeffs_iso, s; cached)
+  LO = _linear_lie_algebra_from_GAP(LG, coeffs_iso, s)
   finv, f = _iso_oscar_gap_lie_algebra_functions(LO, LG, inv(coeffs_iso))
 
   iso = MapFromFunc(LG, LO, f, finv)
@@ -47,7 +45,7 @@ function _iso_gap_oscar_linear_lie_algebra(
 end
 
 function _abstract_lie_algebra_from_GAP(
-  LG::GapObj, coeffs_iso::Map{GapObj}, s::Vector{<:VarName}; cached::Bool=true
+  LG::GapObj, coeffs_iso::Map{GapObj}, s::Vector{<:VarName}
 )
   RO = codomain(coeffs_iso)
   dimL = GAPWrap.Dimension(LG)
@@ -67,12 +65,12 @@ function _abstract_lie_algebra_from_GAP(
     )
   end
 
-  LO = AbstractLieAlgebra{elem_type(RO)}(RO, struct_consts, Symbol.(s); cached, check=false)
+  LO = AbstractLieAlgebra{elem_type(RO)}(RO, struct_consts, Symbol.(s); check=false)
   return LO
 end
 
 function _linear_lie_algebra_from_GAP(
-  LG::GapObj, coeffs_iso::Map{GapObj}, s::Vector{<:VarName}; cached::Bool=true
+  LG::GapObj, coeffs_iso::Map{GapObj}, s::Vector{<:VarName}
 )
   @req GAPWrap.IsLieObjectCollection(LG) "Input is not a linear Lie algebra."
 
@@ -81,6 +79,6 @@ function _linear_lie_algebra_from_GAP(
     map_entries(coeffs_iso, GAPWrap.UnderlyingRingElement(b)) for b in GAPWrap.Basis(LG)
   ]
   n = size(basis[1])[1]
-  LO = LinearLieAlgebra{elem_type(RO)}(RO, n, basis, Symbol.(s); cached)
+  LO = LinearLieAlgebra{elem_type(RO)}(RO, n, basis, Symbol.(s); check=false)
   return LO
 end


### PR DESCRIPTION
Apart from the usual problems with caching (x-ref e.g. https://github.com/oscar-system/Oscar.jl/issues/2455), I noticed that the caches for Lie algebras have very extended keys: for linear Lie algebras, a whole basis was part of the cache-key, while for abstract lie algebras the structure constant table. Both are IMO too enormous to take as a key here.
Furthermore, I cannot come up with any non-trivial (interactive) example where one really needs this kind of caching.

Aside from this, fixed some minor things in docstrings, and with correct propagation of `check` kwargs.