### PR TITLE
Updates AlgebraicSolving to v0.5.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ cohomCalg_jll = "5558cf25-a90e-53b0-b813-cadaa3ae7ade"
 
 [compat]
 AbstractAlgebra = "0.41.3"
-AlgebraicSolving = "0.4.15"
+AlgebraicSolving = "0.5.0"
 Distributed = "1.6"
 GAP = "0.10.2"
 Hecke = "0.32.0"


### PR DESCRIPTION
Should fix #3888.

New features from `AlgebraicSolving` and `msolve` will be made available in Oscar soon.