### PR TITLE
avoid calling `GAP.Packages.install` if possible

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -94,7 +94,13 @@ function __init__()
      ("recog", "1.4.2"),
      ("repsn", "3.1.1"),
      ]
-    GAP.Packages.install(pkg, version, interactive = false, quiet = true)
+    # Avoid downloading something if the requested version is already loaded.
+#TODO: Remove this check as soon as GAP.jl contains it,
+#      see https://github.com/oscar-system/GAP.jl/pull/1019.
+    info = GAP.Globals.GAPInfo.PackagesLoaded
+    if !(hasproperty(info, pkg) && version == string(getproperty(info, pkg)[2]))
+      GAP.Packages.install(pkg, version, interactive = false, quiet = true)
+    end
   end
 
   withenv("TERMINFO_DIRS" => joinpath(GAP.GAP_jll.Readline_jll.Ncurses_jll.find_artifact_dir(), "share", "terminfo")) do


### PR DESCRIPTION
This addresses #3875, but the change is a improvement independent of that isssue.
Eventually it will become part of GAP.jl, see oscar-system/GAP.jl/pull/1019.