### PR TITLE
Documentation: `vertices_and_rays` and `maximal_polyhedra` (tropical variety)

### DIFF
--- a/docs/src/TropicalGeometry/hypersurface.md
+++ b/docs/src/TropicalGeometry/hypersurface.md
@@ -1,3 +1,7 @@
+```@meta
+CurrentModule = Oscar
+DocTestSetup = Oscar.doctestsetup()
+```
 # Tropical hypersurfaces
 
 ## Introduction
@@ -25,10 +29,6 @@ dual_subdivision(TropH::TropicalHypersurface)
 ```
 
 ## Example
-```@meta
-CurrentModule = Oscar
-DocTestSetup = Oscar.doctestsetup()
-```
 The following code sets up an example and prints the vertices and rays of the tropical hypersurface (in no particular order).
 ```jldoctest exampleHypersurface
 julia> TRing = tropical_semiring();

--- a/docs/src/TropicalGeometry/hypersurface.md
+++ b/docs/src/TropicalGeometry/hypersurface.md
@@ -25,8 +25,12 @@ dual_subdivision(TropH::TropicalHypersurface)
 ```
 
 ## Example
+```@meta
+CurrentModule = Oscar
+DocTestSetup = Oscar.doctestsetup()
+```
 The following code sets up an example and prints the vertices and rays of the tropical hypersurface (in no particular order).
-```jldoctest
+```jldoctest exampleHypersurface
 julia> TRing = tropical_semiring();
 
 julia> Tx,(x1,x2) = polynomial_ring(TRing, 2);
@@ -44,7 +48,7 @@ julia> vertRays = vertices_and_rays(THg)
  [1//2, -1//2]
 ```
 By broadcasting the `typeof()` command, we can see, which are vertices, and which are rays.
-```jldoctest
+```jldoctest exampleHypersurface
 julia> typeof.(vertRays)
 5-element Vector{DataType}:
  RayVector{QQFieldElem}
@@ -54,7 +58,7 @@ julia> typeof.(vertRays)
  PointVector{QQFieldElem}
 ```
 The maximal polyhedra of our tropical hypersurface is simply the edges (both bounded and unbounded). The command `maximal_polyhedra()` gives us a list of these edges (in no particular order).
-```jldoctest
+```jldoctest exampleHypersurface
 julia> maxPolTg = maximal_polyhedra(THg)
 5-element SubObjectIterator{Polyhedron{QQFieldElem}}:
  Polyhedron in ambient dimension 2
@@ -64,7 +68,7 @@ julia> maxPolTg = maximal_polyhedra(THg)
  Polyhedron in ambient dimension 2
 ```
 The polyhedrons are the unbounded edges, and the polytopes are the bounded edges. This is also made clear if we ask for the vertices of each of the maximal polyhedra (the bounded edges have a vertex at each end, while the unbounded only have one vertex).
-```jldoctest
+```jldoctest exampleHypersurface
 julia> vertices.(maxPolTg)
 5-element Vector{SubObjectIterator{PointVector{QQFieldElem}}}:
  [[-1//2, 1//2]]
@@ -74,7 +78,7 @@ julia> vertices.(maxPolTg)
  [[1//2, -1//2]]
 ```
 Instead of being between two vertices, the unbounded edges are defined by a vertex and a ray.
-```jldoctest
+```jldoctest exampleHypersurface
 julia> rays.(maxPolTg)
 5-element Vector{SubObjectIterator{RayVector{QQFieldElem}}}:
  [[-1, -1]]

--- a/docs/src/TropicalGeometry/hypersurface.md
+++ b/docs/src/TropicalGeometry/hypersurface.md
@@ -23,3 +23,6 @@ algebraic_polynomial(TropH::TropicalHypersurface)
 tropical_polynomial(TropH::TropicalHypersurface)
 dual_subdivision(TropH::TropicalHypersurface)
 ```
+
+## Examples
+I am working on creating some examples.

--- a/docs/src/TropicalGeometry/hypersurface.md
+++ b/docs/src/TropicalGeometry/hypersurface.md
@@ -31,15 +31,15 @@ dual_subdivision(TropH::TropicalHypersurface)
 ## Example
 The following code sets up an example and prints the vertices and rays of the tropical hypersurface (in no particular order).
 ```jldoctest exampleHypersurface
-julia> TRing = tropical_semiring();
+julia> T = tropical_semiring();
 
-julia> Tx,(x1,x2) = polynomial_ring(TRing, 2);
+julia> Tx,(x1,x2) = polynomial_ring(T, 2);
 
 julia> g = 1 + 2*x1^2 + 2*x2^2 + 1*x1*x2;
 
-julia> THg = tropical_hypersurface(g);
+julia> TropH = tropical_hypersurface(g);
 
-julia> vertRays = vertices_and_rays(THg)
+julia> vertRays = vertices_and_rays(TropH)
 5-element SubObjectIterator{Union{PointVector{QQFieldElem}, RayVector{QQFieldElem}}}:
  [-1, -1]
  [1, 0]
@@ -59,7 +59,7 @@ julia> typeof.(vertRays)
 ```
 The maximal polyhedra of our tropical hypersurface is simply the edges (both bounded and unbounded). The command `maximal_polyhedra()` gives us a list of these edges (in no particular order).
 ```jldoctest exampleHypersurface
-julia> maxPolTg = maximal_polyhedra(THg)
+julia> maxPol = maximal_polyhedra(TropH)
 5-element SubObjectIterator{Polyhedron{QQFieldElem}}:
  Polyhedron in ambient dimension 2
  Polyhedron in ambient dimension 2
@@ -69,7 +69,7 @@ julia> maxPolTg = maximal_polyhedra(THg)
 ```
 The polyhedrons are the unbounded edges, and the polytopes are the bounded edges. This is also made clear if we ask for the vertices of each of the maximal polyhedra (the bounded edges have a vertex at each end, while the unbounded only have one vertex).
 ```jldoctest exampleHypersurface
-julia> vertices.(maxPolTg)
+julia> vertices.(maxPol)
 5-element Vector{SubObjectIterator{PointVector{QQFieldElem}}}:
  [[-1//2, 1//2]]
  [[1//2, -1//2]]
@@ -79,7 +79,7 @@ julia> vertices.(maxPolTg)
 ```
 Instead of being between two vertices, the unbounded edges are defined by a vertex and a ray.
 ```jldoctest exampleHypersurface
-julia> rays.(maxPolTg)
+julia> rays.(maxPol)
 5-element Vector{SubObjectIterator{RayVector{QQFieldElem}}}:
  [[-1, -1]]
  [[-1, -1]]

--- a/docs/src/TropicalGeometry/hypersurface.md
+++ b/docs/src/TropicalGeometry/hypersurface.md
@@ -26,7 +26,7 @@ dual_subdivision(TropH::TropicalHypersurface)
 
 ## Example
 The following code sets up an example and prints the vertices and rays of the tropical hypersurface (in no particular order).
-```julia-repl
+```jldoctest
 julia> TRing = tropical_semiring();
 
 julia> Tx,(x1,x2) = polynomial_ring(TRing, 2);
@@ -44,7 +44,7 @@ julia> vertRays = vertices_and_rays(THg)
  [1//2, -1//2]
 ```
 By broadcasting the `typeof()` command, we can see, which are vertices, and which are rays.
-```julia-repl
+```jldoctest
 julia> typeof.(vertRays)
 5-element Vector{DataType}:
  RayVector{QQFieldElem}
@@ -54,7 +54,7 @@ julia> typeof.(vertRays)
  PointVector{QQFieldElem}
 ```
 The maximal polyhedra of our tropical hypersurface is simply the edges (both bounded and unbounded). The command `maximal_polyhedra()` gives us a list of these edges (in no particular order).
-```julia-repl
+```jldoctest
 julia> maxPolTg = maximal_polyhedra(THg)
 5-element SubObjectIterator{Polyhedron{QQFieldElem}}:
  Polyhedron in ambient dimension 2
@@ -64,7 +64,7 @@ julia> maxPolTg = maximal_polyhedra(THg)
  Polyhedron in ambient dimension 2
 ```
 The polyhedrons are the unbounded edges, and the polytopes are the bounded edges. This is also made clear if we ask for the vertices of each of the maximal polyhedra (the bounded edges have a vertex at each end, while the unbounded only have one vertex).
-```julia-repl
+```jldoctest
 julia> vertices.(maxPolTg)
 5-element Vector{SubObjectIterator{PointVector{QQFieldElem}}}:
  [[-1//2, 1//2]]
@@ -74,7 +74,7 @@ julia> vertices.(maxPolTg)
  [[1//2, -1//2]]
 ```
 Instead of being between two vertices, the unbounded edges are defined by a vertex and a ray.
-```julia-repl
+```jldoctest
 julia> rays.(maxPolTg)
 5-element Vector{SubObjectIterator{RayVector{QQFieldElem}}}:
  [[-1, -1]]

--- a/docs/src/TropicalGeometry/hypersurface.md
+++ b/docs/src/TropicalGeometry/hypersurface.md
@@ -67,7 +67,20 @@ julia> maxPol = maximal_polyhedra(TropH)
  Polytope in ambient dimension 2
  Polyhedron in ambient dimension 2
 ```
-The polyhedrons are the unbounded edges, and the polytopes are the bounded edges. This is also made clear if we ask for the vertices of each of the maximal polyhedra (the bounded edges have a vertex at each end, while the unbounded only have one vertex).
+The polyhedrons are the unbounded edges, and the polytopes are the bounded edges.
+
+The incidence matrix of the maximal polyhedra is a list of the relations between the elements of `vertices_and_rays(TropH)`. 
+From these relations, we can draw the hypersurface. However, one should be careful, as there is no distinction between vertices and rays in the incidence matrix.
+```jldoctest exampleHypersurface
+julia> IncidenceMatrix(maxPol)
+5×5 IncidenceMatrix
+[1, 4]
+[1, 5]
+[3, 4]
+[4, 5]
+[2, 5]
+```
+This is made clearer if we ask for the vertices of each of the maximal polyhedra (the bounded edges have a vertex at each end, while the unbounded only have one vertex).
 ```jldoctest exampleHypersurface
 julia> vertices.(maxPol)
 5-element Vector{SubObjectIterator{PointVector{QQFieldElem}}}:
@@ -77,7 +90,7 @@ julia> vertices.(maxPol)
  [[-1//2, 1//2], [1//2, -1//2]]
  [[1//2, -1//2]]
 ```
-Instead of being between two vertices, the unbounded edges are defined by a vertex and a ray.
+Instead of being between two vertices, the unbounded edges are defined by a vertex and a ray. These rays can be seen in the following way.
 ```jldoctest exampleHypersurface
 julia> rays.(maxPol)
 5-element Vector{SubObjectIterator{RayVector{QQFieldElem}}}:

--- a/docs/src/TropicalGeometry/hypersurface.md
+++ b/docs/src/TropicalGeometry/hypersurface.md
@@ -25,4 +25,61 @@ dual_subdivision(TropH::TropicalHypersurface)
 ```
 
 ## Examples
-I am working on creating some examples.
+The following code sets up an example and prints the vertices and rays of the tropical hypersurface (in no particular order).
+```julia-repl
+julia> TRing = tropical_semiring();
+
+julia> Tx,(x1,x2) = polynomial_ring(TRing, 2);
+
+julia> g = 1 + 2*x1^2 + 2*x2^2 + 1*x1*x2;
+
+julia> THg = tropical_hypersurface(g);
+
+julia> vertRays = vertices_and_rays(THg)
+5-element SubObjectIterator{Union{PointVector{QQFieldElem}, RayVector{QQFieldElem}}}:
+ [-1, -1]
+ [1, 0]
+ [0, 1]
+ [-1//2, 1//2]
+ [1//2, -1//2]
+```
+By broadcasting the `typeof()` command, we can see, which are vertices, and which are rays.
+```julia-repl
+julia> typeof.(vertRays)
+5-element Vector{DataType}:
+ RayVector{QQFieldElem}
+ RayVector{QQFieldElem}
+ RayVector{QQFieldElem}
+ PointVector{QQFieldElem}
+ PointVector{QQFieldElem}
+```
+The maximal polyhedra of our tropical hypersurface is simply the edges (both bounded and unbounded). The command `maximal_polyhedra()` gives us a list of these edges (in no particular order).
+```julia-repl
+julia> maxPolTg = maximal_polyhedra(THg)
+5-element SubObjectIterator{Polyhedron{QQFieldElem}}:
+ Polyhedron in ambient dimension 2
+ Polyhedron in ambient dimension 2
+ Polyhedron in ambient dimension 2
+ Polytope in ambient dimension 2
+ Polyhedron in ambient dimension 2
+```
+The polyhedrons are the unbounded edges, and the polytopes are the bounded edges. This is also made clear if we ask for the vertices of each of the maximal polyhedra (the bounded edges have a vertex at each end, while the unbounded only have one vertex).
+```julia-repl
+julia> vertices.(maxPolTg)
+5-element Vector{SubObjectIterator{PointVector{QQFieldElem}}}:
+ [[-1//2, 1//2]]
+ [[1//2, -1//2]]
+ [[-1//2, 1//2]]
+ [[-1//2, 1//2], [1//2, -1//2]]
+ [[1//2, -1//2]]
+```
+Instead of being between two vertices, the unbounded edges are defined by a vertex and a ray.
+```julia-repl
+julia> rays.(maxPolTg)
+5-element Vector{SubObjectIterator{RayVector{QQFieldElem}}}:
+ [[-1, -1]]
+ [[-1, -1]]
+ [[0, 1]]
+ 0-element SubObjectIterator{RayVector{QQFieldElem}}
+ [[1, 0]]
+```

--- a/docs/src/TropicalGeometry/hypersurface.md
+++ b/docs/src/TropicalGeometry/hypersurface.md
@@ -24,7 +24,7 @@ tropical_polynomial(TropH::TropicalHypersurface)
 dual_subdivision(TropH::TropicalHypersurface)
 ```
 
-## Examples
+## Example
 The following code sets up an example and prints the vertices and rays of the tropical hypersurface (in no particular order).
 ```julia-repl
 julia> TRing = tropical_semiring();

--- a/docs/src/TropicalGeometry/variety.md
+++ b/docs/src/TropicalGeometry/variety.md
@@ -38,3 +38,6 @@ vertices_and_rays(TropV::TropicalVariety)
 vertices(TropV::TropicalVariety)
 visualize(TropV::TropicalVariety)
 ```
+
+## Examples
+I am working on creating some examples.

--- a/docs/src/TropicalGeometry/variety.md
+++ b/docs/src/TropicalGeometry/variety.md
@@ -38,6 +38,3 @@ vertices_and_rays(TropV::TropicalVariety)
 vertices(TropV::TropicalVariety)
 visualize(TropV::TropicalVariety)
 ```
-
-## Examples
-I am working on creating some examples.


### PR DESCRIPTION
See [discussion](https://github.com/oscar-system/Oscar.jl/discussions/3915#discussioncomment-9965489).

I am working on adding some examples to the online documentation in the tropical geometry section. These examples aim to make the commands `vertices_and_rays` and `maximal_polyhedra` easier to understand, as well as the relation between them.

Following was added as a comment, when sent to review:
Comment for reviewer: I have now added an example of a tropical hypersurface. The example is rather rudimentary and quite spelled out, and I am of course willing to correct/change things, if it should not be as spelled out in the documentation. However, as a Master's student, who only recently got into tropical geometry, this is what I believe would have helped me, when I was learning to use these tools.