### PR TITLE
fixes regression for persistent uuids across multiple sessions

### DIFF
--- a/src/Serialization/serializers.jl
+++ b/src/Serialization/serializers.jl
@@ -148,6 +148,7 @@ function load_ref(s::DeserializerState)
     s.obj = s.refs[Symbol(id)]
     loaded_ref = load_typed_object(s)
     global_serializer_state.id_to_obj[UUID(id)] = loaded_ref
+    global_serializer_state.obj_to_id[loaded_ref] = UUID(id)
   end
   return loaded_ref
 end


### PR DESCRIPTION
Fixes regression with persisten UUIDs.

Saving an element in one session, loading and saving again will keep the same uuids for the parent.