### PR TITLE
TropicalGeometry + PolyhedralGeometry: fixing references in documentation

### DIFF
--- a/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
@@ -19,8 +19,8 @@ polyhedron(::Oscar.scalar_type_or_field, A::AnyVecOrMat, b::AbstractVector)
 polyhedron(::Oscar.scalar_type_or_field, I::Union{Nothing, AbstractCollection[AffineHalfspace]}, E::Union{Nothing, AbstractCollection[AffineHyperplane]} = nothing)
 ```
 
-The complete $H$-representation can be retrieved using [`facets`](@ref facets)
-and [`affine_hull`](@ref affine_hull):
+The complete $H$-representation can be retrieved using [`facets`](@ref facets(as::Type{T}, P::Polyhedron{S}) where {S<:scalar_types,T<:Union{AffineHalfspace{S},Pair{R,S} where R,Polyhedron{S}}})
+and [`affine_hull`](@ref affine_hull(P::Polyhedron{T}) where {T<:scalar_types}):
 ```jldoctest
 julia> P = polyhedron(([-1 0; 1 0], [0,1]), ([0 1], [0]))
 Polyhedron in ambient dimension 2
@@ -68,7 +68,7 @@ julia> halfspace_matrix_pair(facets(T))
 ```
 
 The complete $V$-representation can be retrieved using [`minimal_faces`](@ref
-minimal_faces), [`rays_modulo_lineality`](@ref rays_modulo_lineality) and [`lineality_space`](@ref lineality_space):
+minimal_faces(P::Polyhedron{T}) where {T<:scalar_types}), [`rays_modulo_lineality`](@ref rays_modulo_lineality(P::Polyhedron{T}) where {T<:scalar_types}) and [`lineality_space`](@ref lineality_space(P::Polyhedron{T}) where {T<:scalar_types}):
 
 ```jldoctest; filter = r"^polymake: +WARNING.*\n|^"
 julia> P = convex_hull([0 0], [1 0], [0 1])

--- a/docs/src/PolyhedralGeometry/polyhedral_complexes.md
+++ b/docs/src/PolyhedralGeometry/polyhedral_complexes.md
@@ -48,6 +48,6 @@ n_vertices(PC::PolyhedralComplex)
 polyhedra_of_dim
 rays(PC::PolyhedralComplex{T}) where T<:scalar_types
 rays_modulo_lineality(PC::PolyhedralComplex{T}) where T<:scalar_types
-vertices(PC::PolyhedralComplex)
+vertices(as::Type{PointVector{T}}, PC::PolyhedralComplex{T}) where {T<:scalar_types}
 vertices_and_rays(PC::PolyhedralComplex{T}) where T<:scalar_types
 ```

--- a/docs/src/PolyhedralGeometry/polyhedral_complexes.md
+++ b/docs/src/PolyhedralGeometry/polyhedral_complexes.md
@@ -35,6 +35,10 @@ codim(PC::PolyhedralComplex)
 dim(PC::PolyhedralComplex)
 f_vector(PC::PolyhedralComplex)
 is_embedded(PC::PolyhedralComplex)
+is_pure(PC::PolyhedralComplex)
+is_simplicial(PC::PolyhedralComplex)
+lineality_dim(PC::PolyhedralComplex)
+lineality_space(PC::PolyhedralComplex{T}) where T<:scalar_types
 maximal_polyhedra(PC::PolyhedralComplex{T}) where T<:scalar_types
 minimal_faces(PC::PolyhedralComplex{T}) where T<:scalar_types
 n_maximal_polyhedra(PC::PolyhedralComplex)
@@ -47,4 +51,3 @@ rays_modulo_lineality(PC::PolyhedralComplex{T}) where T<:scalar_types
 vertices(PC::PolyhedralComplex)
 vertices_and_rays(PC::PolyhedralComplex{T}) where T<:scalar_types
 ```
-

--- a/docs/src/TropicalGeometry/curve.md
+++ b/docs/src/TropicalGeometry/curve.md
@@ -1,11 +1,10 @@
-```@meta
-CurrentModule = Oscar
-```
-
 # Tropical curves
 
 ## Introduction
 A tropical curve is a graph with multiplicities on its edges.  If embedded, it is a polyhedral complex of dimension (at most) one.
+
+#### Note:
+- The type `TropicalCurve` can be thought of as subtype of `TropicalVariety` in the sense that it should have all properties and features of the latter.
 
 ## Construction
 In addition to converting from `TropicalVariety`, objects of type `TropicalCurve` can be constructed from:

--- a/docs/src/TropicalGeometry/hypersurface.md
+++ b/docs/src/TropicalGeometry/hypersurface.md
@@ -5,7 +5,10 @@ A tropical hypersurface is a balanced polyhedral complex of codimension one.  It
 - Chapter 3.1 in [MS15](@cite)
 - Chapter 1 in [Jos21](@cite)
 
-Objects of type `TropicalHypersurface` need to be embedded, abstract tropical hypersurfaces are currently not supported.
+#### Note:
+- Objects of type `TropicalHypersurface` need to be embedded, abstract tropical hypersurfaces are currently not supported.
+- The type `TropicalHypersurface` can be thought of as subtype of `TropicalVariety` in the sense that it should have all properties and features of the latter.
+
 
 ## Constructors
 In addition to converting from `TropicalVariety`, objects of type `TropicalHypersurface` can be constructed from:

--- a/docs/src/TropicalGeometry/linear_space.md
+++ b/docs/src/TropicalGeometry/linear_space.md
@@ -5,7 +5,9 @@ A tropical linear space is a balanced polyhedral complex supported on a finite i
 - Chapter 4.4 in [MS15](@cite)
 - Chapter 10 in [Jos21](@cite)
 
-Objects of type `TropicalLinearSpace` need to be embedded, abstract tropical linear spaces are currently not supported.
+#### Note:
+- Objects of type `TropicalLinearSpace` need to be embedded, abstract tropical linear spaces are currently not supported.
+- The type `TropicalLinearSpace` can be thought of as subtype of `TropicalVariety` in the sense that it should have all properties and features of the latter.
 
 
 ## Constructors

--- a/docs/src/TropicalGeometry/variety.md
+++ b/docs/src/TropicalGeometry/variety.md
@@ -5,7 +5,10 @@ Tropial varieties (in OSCAR) are weighted polyhedral complexes.  They may arise 
 - Chapter 3 in [MS15](@cite)
 - Chapter 2.8 in [Jos21](@cite)
 
-Objects of type `TropicalVariety` need to be embedded, abstract tropical varieties are currently not supported.  The type `TropicalVariety` can be thought of as supertype of `TropicalHypersurface`, `TropicalCurve`, and `TropicalLinearSpace` in the sense that the latter three inherit all properties and features of the former.
+#### Note:
+- Objects of type `TropicalVariety` need to be embedded, abstract tropical varieties are currently not supported.
+- The type `TropicalVariety` can be thought of as supertype of `TropicalHypersurface`, `TropicalCurve`, and `TropicalLinearSpace` in the sense that the latter three should have all properties and features of the former.
+- Embedded tropical varieties are polyhedral complexes with multiplicities and should have all properties of polyhedral complexes
 
 ## Constructor
 Objects of type `TropicalVariety` can be constructed as follows:

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -26,7 +26,7 @@ _rays(::Type{<:RayVector}, C::Cone{T}) where {T<:scalar_types} = _rays(RayVector
 Return the rays of `C` in the format defined by `as`. The rays are defined to be the
 one-dimensional faces, so if `C` has lineality, there are no rays.
 
-See also [`rays_modulo_lineality`](@ref).
+See also [`rays_modulo_lineality`](@ref rays_modulo_lineality(C::Cone{T}) where {T<:scalar_types}).
 
 Optional arguments for `as` include
 * `RayVector`.
@@ -85,7 +85,7 @@ iterators. If `C` has lineality `L`, then the iterator `rays_modulo_lineality`
 iterates over representatives of the rays of `C/L`. The iterator
 `lineality_basis` gives a basis of the lineality space `L`.
 
-See also [`rays`](@ref) and [`lineality_space`](@ref).
+See also [`rays`](@ref rays(C::Cone{T}) where {T<:scalar_types}) and [`lineality_space`](@ref lineality_space(C::Cone{T}) where {T<:scalar_types}).
 
 # Examples
 For a pointed cone, with two generators, we get the usual rays:

--- a/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
@@ -34,7 +34,7 @@ Return an iterator over the vertices of `PC` in the format defined by `as`. The
 vertices are defined to be the zero-dimensional faces, so if `P` has lineality,
 there are no vertices, only minimal faces.
 
-See also [`minimal_faces`](@ref) and [`rays`](@ref).
+See also [`minimal_faces`](@ref minimal_faces(PC::PolyhedralComplex{T}) where {T<:scalar_types}) and [`rays`](@ref rays(PC::PolyhedralComplex{T}) where {T<:scalar_types}).
 
 Optional arguments for `as` include
 * `PointVector`.
@@ -135,7 +135,7 @@ _vertices(
     vertices_and_rays(PC::PolyhedralComplex)
 
 Return the vertices and rays of `PC` as a combined set, up to lineality. This
-function is mainly a helper function for [`maximal_polyhedra`](@ref).
+function is mainly a helper function for [`maximal_polyhedra`](@ref maximal_polyhedra(PC::PolyhedralComplex{T}) where {T<:scalar_types}).
 
 # Examples
 ```jldoctest
@@ -187,7 +187,7 @@ with two iterators. If `PC` has lineality `L`, then the iterator
 `rays_modulo_lineality` iterates over representatives of the rays of `PC/L`.
 The iterator `lineality_basis` gives a basis of the lineality space `L`.
 
-See also [`rays`](@ref) and [`lineality_space`](@ref).
+See also [`rays`](@ref rays(PC::PolyhedralComplex{T}) where {T<:scalar_types}) and [`lineality_space`](@ref lineality_space(PC::PolyhedralComplex{T}) where {T<:scalar_types}).
 
 # Examples
 ```jldoctest
@@ -310,7 +310,7 @@ Return the rays of `PC`. The rays are defined to be the far vertices, i.e. the
 one-dimensional faces of the recession cones of its polyhedra, so if `PC` has
 lineality, there are no rays.
 
-See also [`rays_modulo_lineality`](@ref) and [`vertices(as::Type{PointVector{T}}, PC::PolyhedralComplex{T}) where {T<:scalar_types}`](@ref).
+See also [`rays_modulo_lineality`](@ref rays_modulo_lineality(PC::PolyhedralComplex{T}) where {T<:scalar_types}) and [`vertices`](@ref vertices(as::Type{PointVector{T}}, PC::PolyhedralComplex{T}) where {T<:scalar_types}).
 
 Optional arguments for `as` include
 * `RayVector`.
@@ -394,7 +394,7 @@ Return the maximal polyhedra of `PC`
 
 Optionally `IncidenceMatrix` can be passed as a first argument to return the
 incidence matrix specifying the maximal polyhedra of `PC`. The indices returned
-refer to the output of [`vertices_and_rays`](@ref).
+refer to the output of [`vertices_and_rays`](@ref vertices_and_rays(PC::PolyhedralComplex{T}) where {T<:scalar_types}).
 
 # Examples
 ```jldoctest

--- a/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
@@ -253,7 +253,7 @@ translation `p+L`, where `p` is only unique modulo `L`. The return type is a
 dict, the key `:base_points` gives an iterator over such `p`, and the key
 `:lineality_basis` lets one access a basis for the lineality space `L` of `PC`.
 
-See also [`vertices(as::Type{PointVector{T}}, PC::PolyhedralComplex{T}) where {T<:scalar_types}`](@ref) and [`lineality_space`](@ref).
+See also [`vertices`](@ref vertices(as::Type{PointVector{T}}, PC::PolyhedralComplex{T}) where {T<:scalar_types}) and [`lineality_space`](@ref).
 
 # Examples
 ```jldoctest

--- a/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
@@ -253,7 +253,7 @@ translation `p+L`, where `p` is only unique modulo `L`. The return type is a
 dict, the key `:base_points` gives an iterator over such `p`, and the key
 `:lineality_basis` lets one access a basis for the lineality space `L` of `PC`.
 
-See also [`vertices`](@ref) and [`lineality_space`](@ref).
+See also [`vertices(as::Type{PointVector{T}}, PC::PolyhedralComplex{T}) where {T<:scalar_types}`](@ref) and [`lineality_space`](@ref).
 
 # Examples
 ```jldoctest
@@ -310,7 +310,7 @@ Return the rays of `PC`. The rays are defined to be the far vertices, i.e. the
 one-dimensional faces of the recession cones of its polyhedra, so if `PC` has
 lineality, there are no rays.
 
-See also [`rays_modulo_lineality`](@ref) and [`vertices`](@ref).
+See also [`rays_modulo_lineality`](@ref) and [`vertices(as::Type{PointVector{T}}, PC::PolyhedralComplex{T}) where {T<:scalar_types}`](@ref).
 
 Optional arguments for `as` include
 * `RayVector`.

--- a/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/properties.jl
@@ -587,6 +587,29 @@ function _ith_polyhedron(
   )
 end
 
+@doc raw"""
+    lineality_space(PC::PolyhedralComplex)
+
+Return the lineality space of `PC`.
+
+# Examples
+```jldoctest
+julia> VR = [0 0 0; 1 0 0; 0 1 0; -1 0 0];
+
+julia> IM = IncidenceMatrix([[1,2,3],[1,3,4]]);
+
+julia> far_vertices = [2,3,4];
+
+julia> L = [0 0 1];
+
+julia> PC = polyhedral_complex(IM, VR, far_vertices, L)
+Polyhedral complex in ambient dimension 3
+
+julia> lineality_space(PC)
+1-element SubObjectIterator{RayVector{QQFieldElem}}:
+ [0, 0, 1]
+```
+"""
 lineality_space(PC::PolyhedralComplex{T}) where {T<:scalar_types} =
   SubObjectIterator{RayVector{T}}(PC, _lineality_complex, lineality_dim(PC))
 
@@ -604,6 +627,28 @@ _generator_matrix(::Val{_lineality_complex}, PC::PolyhedralComplex; homogenized=
 
 _matrix_for_polymake(::Val{_lineality_complex}) = _generator_matrix
 
+@doc raw"""
+    lineality_dim(PC::PolyhedralComplex)
+
+Return the lineality dimension of `PC`.
+
+# Examples
+```jldoctest
+julia> VR = [0 0 0; 1 0 0; 0 1 0; -1 0 0];
+
+julia> IM = IncidenceMatrix([[1,2,3],[1,3,4]]);
+
+julia> far_vertices = [2,3,4];
+
+julia> L = [0 0 1];
+
+julia> PC = polyhedral_complex(IM, VR, far_vertices, L)
+Polyhedral complex in ambient dimension 3
+
+julia> lineality_dim(PC)
+1
+```
+"""
 lineality_dim(PC::PolyhedralComplex) = pm_object(PC).LINEALITY_DIM::Int
 
 @doc raw"""

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -5,12 +5,12 @@
 ###############################################################################
 
 @doc raw"""
-    rays[as::Type{T} = RayVector,] (PF::PolyhedralFan)
+    rays([as::Type{T} = RayVector,] PF::PolyhedralFan)
 
 Return the rays of `PF`. The rays are defined to be the
 one-dimensional faces of its cones, so if `PF` has lineality, there are no rays.
 
-See also [`rays_modulo_lineality`](@ref).
+See also [`rays_modulo_lineality`](@ref rays_modulo_lineality(F::_FanLikeType)).
 
 Optional arguments for `as` include
 * `RayVector`.
@@ -83,15 +83,15 @@ _matrix_for_polymake(::Val{_ray_fan}) = _vector_matrix
 _maximal_cone(::Type{Cone{T}}, PF::_FanLikeType, i::Base.Integer) where {T<:scalar_types} =
   Cone{T}(Polymake.fan.cone(pm_object(PF), i - 1), coefficient_field(PF))
 
-@doc raw"""                                                 
+@doc raw"""
     rays_modulo_lineality(as, F::PolyhedralFan)
-                         
+
 Return the rays of the polyhedral fan `F` up to lineality as a `NamedTuple`
 with two iterators. If `F` has lineality `L`, then the iterator
 `rays_modulo_lineality` iterates over representatives of the rays of `F/L`.
 The iterator `lineality_basis` gives a basis of the lineality space `L`.
 
-See also [`rays`](@ref) and [`lineality_space`](@ref).
+See also [`rays`](@ref rays(PF::_FanLikeType)) and [`lineality_space`](@ref lineality_space(PF::_FanLikeType)).
 
 # Examples
 ```jldoctest
@@ -149,7 +149,7 @@ Return the maximal cones of `PF`.
 
 Optionally `IncidenceMatrix` can be passed as a first argument to return the
 incidence matrix specifying the maximal cones of `PF`. In that case, the
-indices refer to the output of [`rays_modulo_lineality(Cone)`](@ref).
+indices refer to the output of [`rays_modulo_lineality(Cone)`](@ref rays_modulo_lineality(F::_FanLikeType)).
 
 # Examples
 Here we ask for the the number of rays for each maximal cone of the face fan of

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -177,7 +177,7 @@ where `p` is only unique modulo `L`. The return type is a dict, the key
 `:base_points` gives an iterator over such `p`, and the key `:lineality_basis`
 lets one access a basis for the lineality space `L` of `P`.
 
-See also [`vertices`](@ref) and [`lineality_space`](@ref).
+See also [`vertices`](@ref vertices(as::Type{PointVector{T}}, P::Polyhedron{T}) where {T<:scalar_types}) and [`lineality_space`](@ref lineality_space(P::Polyhedron{T}) where {T<:scalar_types}).
 
 # Examples
 The polyhedron `P` is just a line through the origin:
@@ -223,7 +223,7 @@ with two iterators. If `P` has lineality `L`, then the iterator
 `rays_modulo_lineality` iterates over representatives of the rays of `P/L`.
 The iterator `lineality_basis` gives a basis of the lineality space `L`.
 
-See also [`rays`](@ref) and [`lineality_space`](@ref).
+See also [`rays`](@ref rays(as::Type{RayVector{T}}, P::Polyhedron{T}) where {T<:scalar_types}) and [`lineality_space`](@ref lineality_space(P::Polyhedron{T}) where {T<:scalar_types}).
 
 # Examples
 ```jldoctest
@@ -269,7 +269,7 @@ Return an iterator over the vertices of `P` in the format defined by `as`. The
 vertices are defined to be the zero-dimensional faces, so if `P` has lineality,
 there are no vertices, only minimal faces.
 
-See also [`minimal_faces`](@ref) and [`rays`](@ref).
+See also [`minimal_faces`](@ref minimal_faces(P::Polyhedron{T}) where {T<:scalar_types}) and [`rays`](@ref rays(as::Type{RayVector{T}}, P::Polyhedron{T}) where {T<:scalar_types}).
 
 Optional arguments for `as` include
 * `PointVector`.
@@ -401,7 +401,7 @@ Return a minimal set of generators of the cone of unbounded directions of `P`
 one-dimensional faces of the recession cone, so if `P` has lineality, there
 are no rays.
 
-See also [`rays_modulo_lineality`](@ref), [`recession_cone`](@ref) and [`vertices`](@ref).
+See also [`rays_modulo_lineality`](@ref rays_modulo_lineality(P::Polyhedron{T}) where {T<:scalar_types}), [`recession_cone`](@ref recession_cone(P::Polyhedron{T}) where {T<:scalar_types}) and [`vertices`](@ref vertices(as::Type{PointVector{T}}, P::Polyhedron{T}) where {T<:scalar_types}).
 
 Optional arguments for `as` include
 * `RayVector`.
@@ -1336,7 +1336,7 @@ is_fulldimensional(P::Polyhedron) = pm_object(P).FULL_DIM::Bool
 
 Check whether `P` is a Johnson solid, i.e., a $3$-dimensional polytope with regular faces that is not vertex transitive.
 
-See also [`johnson_solid`](@ref).
+See also [`johnson_solid`](@ref johnson_solid(index::Int)).
 
 !!! note
     This will only recognize algebraically precise solids, i.e. no solids with approximate coordinates.
@@ -1346,7 +1346,7 @@ See also [`johnson_solid`](@ref).
 julia> J = johnson_solid(37)
 Polytope in ambient dimension 3 with EmbeddedAbsSimpleNumFieldElem type coefficients
 
-julia> is_johnson_solid(J) 
+julia> is_johnson_solid(J)
 true
 ```
 """
@@ -1358,7 +1358,7 @@ is_johnson_solid(P::Polyhedron) = _is_3d_pol_reg_facets(P) && !is_vertex_transit
 Check whether `P` is an Archimedean solid, i.e., a $3$-dimensional vertex
 transitive polytope with regular facets, but not a prism or antiprism.
 
-See also [`archimedean_solid`](@ref).
+See also [`archimedean_solid`](@ref archimedean_solid(s::String)).
 
 !!! note
     This will only recognize algebraically precise solids, i.e. no solids with approximate coordinates.
@@ -1387,7 +1387,7 @@ is_archimedean_solid(P::Polyhedron) =
 
 Check whether `P` is a Platonic solid.
 
-See also [`platonic_solid`](@ref).
+See also [`platonic_solid`](@ref platonic_solid(s::String)).
 
 !!! note
     This will only recognize algebraically precise solids, i.e. no solids with approximate coordinates.

--- a/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
+++ b/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
@@ -259,7 +259,7 @@ A Johnson solid is a 3-polytope whose facets are regular polygons, of various go
 It is proper if it is not an Archimedean solid.  Up to scaling there are exactly 92 proper Johnson solids.
   See the [Polytope Wiki](https://polytope.miraheze.org/wiki/List_of_Johnson_solids)
 
-See also [`is_johnson_solid`](@ref).
+See also [`is_johnson_solid`](@ref is_johnson_solid(P::Polyhedron)).
 """
 function johnson_solid(index::Int)
   if index in _johnson_indexes_from_oscar
@@ -720,7 +720,7 @@ cross_polytope(d::Int64) = cross_polytope(QQFieldElem, d)
 Construct a Platonic solid with the name given by String `s` from the list
 below.
 
-See also [`is_platonic_solid`](@ref).
+See also [`is_platonic_solid`](@ref is_platonic_solid(P::Polyhedron)).
 
 # Arguments
 - `s::String`: The name of the desired Platonic solid.
@@ -755,7 +755,7 @@ const _archimedean_strings_from_oscar = Set{String}(["snub_cube", "snub_dodecahe
 Construct an Archimedean solid with the name given by String `s` from the list
 below.
 
-See also [`is_archimedean_solid`](@ref).
+See also [`is_archimedean_solid`](@ref is_archimedean_solid(P::Polyhedron)).
 
 # Arguments
 - `s::String`: The name of the desired Archimedean solid.
@@ -824,7 +824,7 @@ end
 Construct the snub cube, an Archimedean solid.
 See the [Polytope Wiki](https://polytope.miraheze.org/wiki/Snub_cube)
 
-See also [`archimedean_solid`](@ref).
+See also [`archimedean_solid`](@ref archimedean_solid(s::String)).
 """
 function snub_cube()
   return archimedean_solid("snub_cube")
@@ -836,7 +836,7 @@ end
 Construct the snub dodecahedron, an Archimedean solid.
 See the [Polytope Wiki](https://polytope.miraheze.org/wiki/Snub_dodecahedron)
 
-See also [`archimedean_solid`](@ref).
+See also [`archimedean_solid`](@ref archimedean_solid(s::String)).
 """
 function snub_dodecahedron()
   return archimedean_solid("snub_dodecahedron")
@@ -917,7 +917,7 @@ end
 Construct the pentagonal icositetrahedron, a Catalan solid.
 See the [Wikipedia entry](https://en.wikipedia.org/wiki/Pentagonal_icositetrahedron)
 
-See also [`catalan_solid`](@ref).
+See also [`catalan_solid`](@ref catalan_solid(s::String)).
 """
 function pentagonal_icositetrahedron()
   return catalan_solid("pentagonal_icositetrahedron")
@@ -929,7 +929,7 @@ end
 Construct the pentagonal hexecontahedron, a Catalan solid.
 See the [Visual Polyhedra entry](https://dmccooey.com/polyhedra/LpentagonalIcositetrahedron.html)
 
-See also [`catalan_solid`](@ref).
+See also [`catalan_solid`](@ref catalan_solid(s::String)).
 """
 function pentagonal_hexecontahedron()
   return catalan_solid("pentagonal_hexecontahedron")

--- a/src/TropicalGeometry/hypersurface.jl
+++ b/src/TropicalGeometry/hypersurface.jl
@@ -142,9 +142,6 @@ end
 
 Construct the tropical hypersurface dual to a regular subdivision `Delta` in convention `minOrMax`. To be precise, the tropical hypersurface of the tropical polynomial with exponent vectors `points(Delta)` and coefficients `min_weight(Delta)` (min-convention) or `-min_weight(Delta)` (max-convention).  If `weighted_polyhedral_complex==true`, will not cache any extra information.
 
-!!! warning
-    There is a known bug when the subdivision is too simple, e.g., `tropical_hypersurface(subdivision_of_points(simplex(2),[0,0,1]))` see issue 2628.
-
 # Examples
 ```jldoctest
 julia> Delta = subdivision_of_points([0 0; 1 0; 0 1; 2 0],[0,0,0,1])

--- a/src/TropicalGeometry/variety_supertype.jl
+++ b/src/TropicalGeometry/variety_supertype.jl
@@ -43,7 +43,7 @@ end
 @doc raw"""
     ambient_dim(TropV::TropicalVariety)
 
-See [`ambient_dim(::PolyhedralComplex)`](@ref).
+See [`ambient_dim(::PolyhedralComplex)`](@ref ambient_dim(PC::PolyhedralComplex)).
 """
 function ambient_dim(TropV::TropicalVarietySupertype{minOrMax,true}) where minOrMax
     return ambient_dim(TropV.polyhedralComplex)
@@ -53,7 +53,7 @@ end
 @doc raw"""
     codim(TropV::TropicalVariety)
 
-See [`codim(::PolyhedralComplex)`](@ref).
+See [`codim(::PolyhedralComplex)`](@ref codim(PC::PolyhedralComplex)).
 """
 function codim(TropV::TropicalVarietySupertype{minOrMax,true}) where minOrMax
     return codim(TropV.polyhedralComplex)
@@ -71,7 +71,7 @@ end
 @doc raw"""
     dim(TropV::TropicalVariety)
 
-See [`dim(::PolyhedralComplex)`](@ref).
+See [`dim(::PolyhedralComplex)`](@ref dim(PC::PolyhedralComplex)).
 """
 function dim(TropV::TropicalVarietySupertype)
     return dim(TropV.polyhedralComplex)
@@ -81,7 +81,7 @@ end
 @doc raw"""
     f_vector(TropV::TropicalVariety)
 
-See [`f_vector(::PolyhedralComplex)`](@ref).
+See [`f_vector(::PolyhedralComplex)`](@ref f_vector(PC::PolyhedralComplex)).
 """
 function f_vector(TropV::TropicalVarietySupertype)
     return f_vector(TropV.polyhedralComplex)
@@ -91,7 +91,7 @@ end
 @doc raw"""
     lineality_dim(TropV::TropicalVariety)
 
-See [`lineality_dim(::PolyhedralComplex)`](@ref).
+See [`lineality_dim(::PolyhedralComplex)`](@ref lineality_dim(PC::PolyhedralComplex)).
 """
 function lineality_dim(TropV::TropicalVarietySupertype)
     return lineality_dim(TropV.polyhedralComplex)
@@ -101,7 +101,7 @@ end
 @doc raw"""
     lineality_space(TropV::TropicalVariety)
 
-See [`lineality_space(::PolyhedralComplex)`](@ref).
+See [`lineality_space(::PolyhedralComplex)`](@ref lineality_space(PC::PolyhedralComplex{T}) where {T<:scalar_types}).
 """
 function lineality_space(TropV::TropicalVarietySupertype)
     return lineality_space(TropV.polyhedralComplex)
@@ -111,7 +111,7 @@ end
 @doc raw"""
     maximal_polyhedra(TropV::TropicalVariety)
 
-See [`maximal_polyhedra(::PolyhedralComplex)`](@ref).
+See [`maximal_polyhedra(::PolyhedralComplex)`](@ref maximal_polyhedra(PC::PolyhedralComplex{T}) where {T<:scalar_types}).
 """
 function maximal_polyhedra(TropV::TropicalVarietySupertype)
     return maximal_polyhedra(TropV.polyhedralComplex)
@@ -154,7 +154,7 @@ end
 @doc raw"""
     minimal_faces(TropV::TropicalVariety)
 
-See [`minimal_faces(::PolyhedralComplex)`](@ref).
+See [`minimal_faces(::PolyhedralComplex)`](@ref minimal_faces(PC::PolyhedralComplex{T})  where {T<:scalar_types}).
 """
 function minimal_faces(TropV::TropicalVarietySupertype)
     return minimal_faces(TropV.polyhedralComplex)
@@ -196,7 +196,7 @@ end
 @doc raw"""
     n_maximal_polyhedra(TropV::TropicalVariety)
 
-See [`n_maximal_polyhedra(::PolyhedralComplex)`](@ref).
+See [`n_maximal_polyhedra(::PolyhedralComplex)`](@ref n_maximal_polyhedra(PC::PolyhedralComplex)).
 """
 function n_maximal_polyhedra(TropV::TropicalVarietySupertype)
     return n_maximal_polyhedra(TropV.polyhedralComplex)
@@ -206,7 +206,7 @@ end
 @doc raw"""
     n_polyhedra(TropV::TropicalVariety)
 
-See [`n_polyhedra(::PolyhedralComplex)`](@ref).
+See [`n_polyhedra(::PolyhedralComplex)`](@ref n_polyhedra(PC::PolyhedralComplex)).
 """
 function n_polyhedra(TropV::TropicalVarietySupertype)
     return n_polyhedra(TropV.polyhedralComplex)
@@ -216,7 +216,7 @@ end
 @doc raw"""
     n_vertices(TropV::TropicalVariety)
 
-See [`n_vertices(::PolyhedralComplex)`](@ref).
+See [`n_vertices(::PolyhedralComplex)`](@ref n_vertices(PC::PolyhedralComplex)).
 """
 function n_vertices(TropV::TropicalVarietySupertype)
     return n_vertices(TropV.polyhedralComplex)
@@ -226,7 +226,7 @@ end
 @doc raw"""
     is_pure(TropV::TropicalVariety)
 
-See [`is_pure(::PolyhedralComplex)`](@ref).
+See [`is_pure(::PolyhedralComplex)`](@ref is_pure(PC::PolyhedralComplex)).
 """
 function is_pure(TropV::TropicalVarietySupertype)
     return is_pure(TropV.polyhedralComplex)
@@ -236,7 +236,7 @@ end
 @doc raw"""
     is_simplicial(TropV::TropicalVariety)
 
-See [`is_simplicial(::PolyhedralComplex)`](@ref).
+See [`is_simplicial(::PolyhedralComplex)`](@ref is_simplicial(PC::PolyhedralComplex)).
 """
 function is_simplicial(TropV::TropicalVarietySupertype)
     return is_simplicial(TropV.polyhedralComplex)
@@ -246,7 +246,7 @@ end
 @doc raw"""
     rays(TropV::TropicalVariety)
 
-See [`rays(::PolyhedralComplex)`](@ref).
+See [`rays(::PolyhedralComplex)`](@ref rays(PC::PolyhedralComplex{T}) where {T<:scalar_types}).
 """
 function rays(as::Type{RayVector{S}}, TropV::TropicalVarietySupertype{minOrMax,isEmbedded}) where {S,minOrMax,isEmbedded}
     return rays(as,TropV.polyhedralComplex)
@@ -259,7 +259,7 @@ end
 @doc raw"""
     rays_modulo_lineality(TropV::TropicalVariety)
 
-See [`rays_modulo_lineality(::PolyhedralComplex)`](@ref).
+See [`rays_modulo_lineality(::PolyhedralComplex)`](@ref rays_modulo_lineality(PC::PolyhedralComplex{T}) where {T<:scalar_types}).
 """
 function rays_modulo_lineality(as::Type{RayVector{S}}, TropV::TropicalVarietySupertype{minOrMax,isEmbedded}) where {S,minOrMax,isEmbedded}
     return rays_modulo_lineality(as,TropV.polyhedralComplex)
@@ -272,7 +272,7 @@ end
 @doc raw"""
     vertices_and_rays(TropV::TropicalVariety)
 
-See [`vertices_and_rays(::PolyhedralComplex)`](@ref).
+See [`vertices_and_rays(::PolyhedralComplex)`](@ref vertices_and_rays(PC::PolyhedralComplex{T}) where {T<:scalar_types}).
 """
 function vertices_and_rays(TropV::TropicalVarietySupertype)
     return vertices_and_rays(TropV.polyhedralComplex)
@@ -282,7 +282,7 @@ end
 @doc raw"""
     vertices(TropV::TropicalVariety)
 
-See [`vertices(::PolyhedralComplex)`](@ref).
+See [`vertices(::PolyhedralComplex)`](@ref vertices(as::Type{PointVector{T}}, PC::PolyhedralComplex{T}) where {T<:scalar_types}).
 """
 function vertices(as::Type{PointVector{S}}, TropV::TropicalVarietySupertype{minOrMax,isEmbedded}) where {S,minOrMax,isEmbedded}
     return vertices(as,TropV.polyhedralComplex)

--- a/src/TropicalGeometry/variety_supertype.jl
+++ b/src/TropicalGeometry/variety_supertype.jl
@@ -164,7 +164,7 @@ end
 @doc raw"""
     multiplicities(TropV::TropicalVariety)
 
-Return the multiplicities of `TropV`.
+Return the multiplicities of `TropV`.  Order is the same as `maximal_polyhedra`.
 
 # Examples
 ```jldoctest

--- a/src/TropicalGeometry/variety_supertype.jl
+++ b/src/TropicalGeometry/variety_supertype.jl
@@ -43,7 +43,7 @@ end
 @doc raw"""
     ambient_dim(TropV::TropicalVariety)
 
-Return the ambient dimension of `TropV`.  Requires `TropV` to be embedded.
+See [`ambient_dim(::PolyhedralComplex)`](@ref).
 """
 function ambient_dim(TropV::TropicalVarietySupertype{minOrMax,true}) where minOrMax
     return ambient_dim(TropV.polyhedralComplex)
@@ -53,7 +53,7 @@ end
 @doc raw"""
     codim(TropV::TropicalVariety)
 
-Return the codimension of `TropV`.  Requires `TropV` to be embedded.
+See [`codim(::PolyhedralComplex)`](@ref).
 """
 function codim(TropV::TropicalVarietySupertype{minOrMax,true}) where minOrMax
     return codim(TropV.polyhedralComplex)
@@ -71,7 +71,7 @@ end
 @doc raw"""
     dim(TropV::TropicalVariety)
 
-Return the dimension of `TropV`.
+See [`dim(::PolyhedralComplex)`](@ref).
 """
 function dim(TropV::TropicalVarietySupertype)
     return dim(TropV.polyhedralComplex)
@@ -81,7 +81,7 @@ end
 @doc raw"""
     f_vector(TropV::TropicalVariety)
 
-Return the f-Vector of `TropV`.
+See [`f_vector(::PolyhedralComplex)`](@ref).
 """
 function f_vector(TropV::TropicalVarietySupertype)
     return f_vector(TropV.polyhedralComplex)
@@ -91,7 +91,7 @@ end
 @doc raw"""
     lineality_dim(TropV::TropicalVariety)
 
-Return the dimension of the lineality space of `TropV`.
+See [`lineality_dim(::PolyhedralComplex)`](@ref).
 """
 function lineality_dim(TropV::TropicalVarietySupertype)
     return lineality_dim(TropV.polyhedralComplex)
@@ -101,7 +101,7 @@ end
 @doc raw"""
     lineality_space(TropV::TropicalVariety)
 
-Return the lineality space of `TropV`.
+See [`lineality_space(::PolyhedralComplex)`](@ref).
 """
 function lineality_space(TropV::TropicalVarietySupertype)
     return lineality_space(TropV.polyhedralComplex)
@@ -111,7 +111,7 @@ end
 @doc raw"""
     maximal_polyhedra(TropV::TropicalVariety)
 
-Return the maximal polyhedra of `TropV`.
+See [`maximal_polyhedra(::PolyhedralComplex)`](@ref).
 """
 function maximal_polyhedra(TropV::TropicalVarietySupertype)
     return maximal_polyhedra(TropV.polyhedralComplex)
@@ -121,7 +121,29 @@ end
 @doc raw"""
     maximal_polyhedra_and_multiplicities(TropV::TropicalVariety)
 
-Return the maximal polyhedra of `TropV`.
+Return the maximal polyhedra and multiplicities of `TropV`.
+
+# Examples
+```jldoctest
+julia> R,(x1,x2) = polynomial_ring(QQ,4);
+
+julia> nu = tropical_semiring_map(QQ,2);
+
+julia> f = 2*x1^2+x1*x2+x2^2+1
+2*x1^2 + x1*x2 + x2^2 + 1
+
+julia> TropH = tropical_hypersurface(f,nu)
+Min tropical hypersurface
+
+julia> maximal_polyhedra_and_multiplicities(TropH)
+5-element Vector{Tuple{Polyhedron{QQFieldElem}, ZZRingElem}}:
+ (Polyhedron in ambient dimension 4, 1)
+ (Polyhedron in ambient dimension 4, 1)
+ (Polyhedron in ambient dimension 4, 2)
+ (Polyhedron in ambient dimension 4, 1)
+ (Polyhedron in ambient dimension 4, 2)
+
+```
 """
 function maximal_polyhedra_and_multiplicities(TropV::TropicalVarietySupertype)
     TropVmults = multiplicities(TropV)
@@ -132,7 +154,7 @@ end
 @doc raw"""
     minimal_faces(TropV::TropicalVariety)
 
-Return the minimal faces of `TropV`.
+See [`minimal_faces(::PolyhedralComplex)`](@ref).
 """
 function minimal_faces(TropV::TropicalVarietySupertype)
     return minimal_faces(TropV.polyhedralComplex)
@@ -143,6 +165,28 @@ end
     multiplicities(TropV::TropicalVariety)
 
 Return the multiplicities of `TropV`.
+
+# Examples
+```jldoctest
+julia> R,(x1,x2) = polynomial_ring(QQ,4);
+
+julia> nu = tropical_semiring_map(QQ,2);
+
+julia> f = 2*x1^2+x1*x2+x2^2+1
+2*x1^2 + x1*x2 + x2^2 + 1
+
+julia> TropH = tropical_hypersurface(f,nu)
+Min tropical hypersurface
+
+julia> multiplicities(TropH)
+5-element Vector{ZZRingElem}:
+ 1
+ 1
+ 2
+ 1
+ 2
+
+```
 """
 function multiplicities(TropV::TropicalVarietySupertype)
     return TropV.multiplicities
@@ -152,7 +196,7 @@ end
 @doc raw"""
     n_maximal_polyhedra(TropV::TropicalVariety)
 
-Return the number of maximal polyhedra of `TropV`.
+See [`n_maximal_polyhedra(::PolyhedralComplex)`](@ref).
 """
 function n_maximal_polyhedra(TropV::TropicalVarietySupertype)
     return n_maximal_polyhedra(TropV.polyhedralComplex)
@@ -162,7 +206,7 @@ end
 @doc raw"""
     n_polyhedra(TropV::TropicalVariety)
 
-Return the number of polyhedra of `TropV`.
+See [`n_polyhedra(::PolyhedralComplex)`](@ref).
 """
 function n_polyhedra(TropV::TropicalVarietySupertype)
     return n_polyhedra(TropV.polyhedralComplex)
@@ -172,7 +216,7 @@ end
 @doc raw"""
     n_vertices(TropV::TropicalVariety)
 
-Return the number of vertices of `TropV`.
+See [`n_vertices(::PolyhedralComplex)`](@ref).
 """
 function n_vertices(TropV::TropicalVarietySupertype)
     return n_vertices(TropV.polyhedralComplex)
@@ -182,7 +226,7 @@ end
 @doc raw"""
     is_pure(TropV::TropicalVariety)
 
-Return `true` if `TropV` is pure as a polyhedral complex, `false` otherwise.
+See [`is_pure(::PolyhedralComplex)`](@ref).
 """
 function is_pure(TropV::TropicalVarietySupertype)
     return is_pure(TropV.polyhedralComplex)
@@ -192,7 +236,7 @@ end
 @doc raw"""
     is_simplicial(TropV::TropicalVariety)
 
-Return `true` if `TropV` is simplicial as a polyhedral complex, `false` otherwise.
+See [`is_simplicial(::PolyhedralComplex)`](@ref).
 """
 function is_simplicial(TropV::TropicalVarietySupertype)
     return is_simplicial(TropV.polyhedralComplex)
@@ -202,7 +246,7 @@ end
 @doc raw"""
     rays(TropV::TropicalVariety)
 
-Return the rays of `TropV`.
+See [`rays(::PolyhedralComplex)`](@ref).
 """
 function rays(as::Type{RayVector{S}}, TropV::TropicalVarietySupertype{minOrMax,isEmbedded}) where {S,minOrMax,isEmbedded}
     return rays(as,TropV.polyhedralComplex)
@@ -215,7 +259,7 @@ end
 @doc raw"""
     rays_modulo_lineality(TropV::TropicalVariety)
 
-Return the rays modulo the lineality space of `TropV`.
+See [`rays_modulo_lineality(::PolyhedralComplex)`](@ref).
 """
 function rays_modulo_lineality(as::Type{RayVector{S}}, TropV::TropicalVarietySupertype{minOrMax,isEmbedded}) where {S,minOrMax,isEmbedded}
     return rays_modulo_lineality(as,TropV.polyhedralComplex)
@@ -228,7 +272,7 @@ end
 @doc raw"""
     vertices_and_rays(TropV::TropicalVariety)
 
-Return the vertices and rays of `TropV`.
+See [`vertices_and_rays(::PolyhedralComplex)`](@ref).
 """
 function vertices_and_rays(TropV::TropicalVarietySupertype)
     return vertices_and_rays(TropV.polyhedralComplex)
@@ -238,7 +282,7 @@ end
 @doc raw"""
     vertices(TropV::TropicalVariety)
 
-Return the vertices of `TropV`.
+See [`vertices(::PolyhedralComplex)`](@ref).
 """
 function vertices(as::Type{PointVector{S}}, TropV::TropicalVarietySupertype{minOrMax,isEmbedded}) where {S,minOrMax,isEmbedded}
     return vertices(as,TropV.polyhedralComplex)
@@ -251,7 +295,7 @@ end
 @doc raw"""
     visualize(TropV::TropicalVariety)
 
-Visualize `TropV`.
+See [`visualize(::PolyhedralComplex)`](@ref).
 """
 function visualize(TropV::TropicalVarietySupertype)
     return visualize(TropV.polyhedralComplex)


### PR DESCRIPTION
Beginning fixing some documentation as discussed in https://github.com/oscar-system/Oscar.jl/discussions/3915

Does anybody know how to correctly add a reference to the function `rays` for polyhedral complexes?  Currently, ``[`rays(::PolyhedralComplex)`](@ref)`` links to `rays` for `K3Chamber`.