### PR TITLE
[ToricVarieties] Limit coefficient values in generic sections

### DIFF
--- a/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles/attributes.jl
@@ -232,5 +232,5 @@ function generic_section(l::ToricLineBundle)
   if length(basis_of_global_sections(l)) == 0
     return zero(cox_ring(toric_variety(l)))
   end
-  return sum([rand(Int) * b for b in basis_of_global_sections(l)])
+  return sum([rand(-10000:10000) * b for b in basis_of_global_sections(l)])
 end


### PR DESCRIPTION
Currently, this uses `rand(Int)`. @apturner let me know that this makes his analysis very hard. This may ultimately also cause limitations in other areas (say we define a singular subvariety in a toric variety as the vanishing locus of certain generic sections, and then want to infer its properties, blow it up etc.)

So... this PR simply limits the coefficient values to the range of -10.000 to +10.000.