### PR TITLE
[FTheoryTools] Overhaul Serialization

### DIFF
--- a/experimental/FTheoryTools/src/Serialization/hypersurface_models.jl
+++ b/experimental/FTheoryTools/src/Serialization/hypersurface_models.jl
@@ -1,35 +1,22 @@
 @register_serialization_type HypersurfaceModel uses_params
 
-
-
-###########################################################################
+############################################################################
 # This function saves the types of the data that define a hypersurface model
-###########################################################################
+############################################################################
 
 function save_type_params(s::SerializerState, h::HypersurfaceModel)
   save_data_dict(s) do
     save_object(s, encode_type(HypersurfaceModel), :name)
-    base = base_space(h)
-    ambient = ambient_space(h)
-    fiber_amb_space = fiber_ambient_space(h)
-    hypersurface_equation_ring = parent(hypersurface_equation(h))
-    hypersurface_equation_parametrization_ring = parent(h.hypersurface_equation_parametrization)
-    explicit_model_section_ring = parent(hypersurface_equation(h))
-    explicit_model_section_keys = collect(keys(h.explicit_model_sections))
-    if length(explicit_model_section_keys) > 0
-      explicit_model_section_ring = parent(explicit_model_sections(h)[explicit_model_section_keys[1]])
-    end
-
     save_data_dict(s, :params) do
-      save_typed_object(s, base, :base_space)
-      save_typed_object(s, ambient, :ambient_space)
-      save_typed_object(s, fiber_amb_space, :fiber_ambient_space)
-      save_typed_object(s, hypersurface_equation_ring, :hypersurface_equation_ring)
-      save_typed_object(s, hypersurface_equation_parametrization_ring, :hypersurface_equation_parametrization_ring)
-      save_typed_object(s, explicit_model_section_ring, :explicit_model_section_ring)
+      save_typed_object(s, base_space(h), :base_space)
+      save_typed_object(s, ambient_space(h), :ambient_space)
+      save_typed_object(s, fiber_ambient_space(h), :fiber_ambient_space)
+      save_typed_object(s, parent(hypersurface_equation(h)), :hypersurface_equation_ring)
+      save_typed_object(s, parent(hypersurface_equation_parametrization(h)), :hypersurface_equation_parametrization_ring)
     end
   end
 end
+
 
 ############################################################################
 # This function loads the types of the data that define a hypersurface model
@@ -41,71 +28,47 @@ function load_type_params(s::DeserializerState, ::Type{<: HypersurfaceModel})
     load_typed_object(s, :ambient_space),
     load_typed_object(s, :fiber_ambient_space),
     load_typed_object(s, :hypersurface_equation_ring),
-    load_typed_object(s, :hypersurface_equation_parametrization_ring),
-    load_typed_object(s, :explicit_model_section_ring)
+    load_typed_object(s, :hypersurface_equation_parametrization_ring)
   )
 end
+
 
 ##########################################
 # This function saves a hypersurface model
 ##########################################
 
 function save_object(s::SerializerState, h::HypersurfaceModel)
-  # Currently, only serialize hypersurface models with toric defining data
   @req base_space(h) isa NormalToricVariety "Currently, we only serialize hypersurface models defined over a toric base space"
   @req ambient_space(h) isa NormalToricVariety "Currently, we only serialize hypersurface models defined within a toric ambient space"
 
-  # Save information
   save_data_dict(s) do
-
-    # hypersurace equation and parametrization
+    for (data, key) in [
+        (explicit_model_sections(h), :explicit_model_sections),
+        (defining_classes(h), :defining_classes)
+        ]
+      !isempty(data) && save_typed_object(s, data, key)
+    end
     save_object(s, hypersurface_equation(h), :hypersurface_equation)
     save_object(s, hypersurface_equation_parametrization(h), :hypersurface_equation_parametrization)
-
-    # Save keys of explicit_model_sections
-    save_data_array(s, :explicit_model_section_keys) do
-      for (key, value) in explicit_model_sections(h)
-        save_object(s, key)
-      end
-    end
-
-    # Save values of explicit_model_sections
-    save_data_array(s, :explicit_model_section_values) do
-      for (key, value) in explicit_model_sections(h)
-        save_object(s, value)
-      end
-    end
-
-    # Boolean values, that are always known for Tate models
     save_data_array(s, :boolean_data) do
       save_object(s, is_partially_resolved(h))
     end
   end
 end
 
+
 ##########################################
 # This function loads a hypersurface model
 ##########################################
 
-function load_object(s::DeserializerState, ::Type{<: HypersurfaceModel}, params::Tuple{NormalToricVariety, NormalToricVariety, NormalToricVariety, <:MPolyRing, <:MPolyRing, <:MPolyRing})
-  # load basic data
-  base_space = params[1]
-  ambient_space = params[2]
-  fiber_ambient_space = params[3]
-  defining_equation = load_object(s, MPolyRingElem, params[4], :hypersurface_equation)
-  defining_equation_parametrization = load_object(s, MPolyRingElem, params[5], :hypersurface_equation_parametrization)
-
-  # Extract explicit_model_sections
-  values = load_object(s, Vector, params[6], :explicit_model_section_values)
-  keys = load_object(s, Vector, String, :explicit_model_section_keys)
-  explicit_model_sections = Dict{String, MPolyRingElem}()
-  for i in 1:length(keys)
-    explicit_model_sections[keys[i]] = values[i]
-  end
-
-  # create and return model
+function load_object(s::DeserializerState, ::Type{<: HypersurfaceModel}, params::Tuple{NormalToricVariety, NormalToricVariety, NormalToricVariety, <:MPolyRing, <:MPolyRing})
+  base_space, ambient_space, fiber_ambient_space, R1, R2 = params
+  defining_equation = load_object(s, MPolyRingElem, R1, :hypersurface_equation)
+  defining_equation_parametrization = load_object(s, MPolyRingElem, R2, :hypersurface_equation_parametrization)
+  explicit_model_sections = haskey(s, :explicit_model_sections) ? load_typed_object(s, :explicit_model_sections) : Dict{String, MPolyRingElem}()
+  defining_classes = haskey(s, :defining_classes) ? load_typed_object(s, :defining_classes) : Dict{String, ToricDivisorClass}()
   model = HypersurfaceModel(explicit_model_sections, defining_equation_parametrization, defining_equation, base_space, ambient_space, fiber_ambient_space)
-  bools = load_object(s, Vector, Bool, :boolean_data)
-  set_attribute!(model, :partially_resolved, bools[1])
+  model.defining_classes = defining_classes
+  set_attribute!(model, :partially_resolved, load_object(s, Vector{Bool}, :boolean_data)[1])
   return model
 end

--- a/experimental/FTheoryTools/src/Serialization/tate_models.jl
+++ b/experimental/FTheoryTools/src/Serialization/tate_models.jl
@@ -1,7 +1,5 @@
 @register_serialization_type GlobalTateModel uses_params
 
-
-
 ###########################################################################
 # This function saves the types of the data that define a global Tate model
 ###########################################################################
@@ -9,56 +7,20 @@
 function save_type_params(s::SerializerState, gtm::GlobalTateModel)
   save_data_dict(s) do
     save_object(s, encode_type(GlobalTateModel), :name)
-    base = base_space(gtm)
-    ambient = ambient_space(gtm)
-    tate_polynomial_ring = parent(tate_polynomial(gtm))
-    explicit_model_section_ring = parent(gtm.explicit_model_sections["a1"])
-    parametrizing_sections = collect(keys(gtm.defining_section_parametrization))
-    if length(parametrizing_sections) > 0
-      defining_section_parametrization_ring = parent(gtm.defining_section_parametrization[parametrizing_sections[1]])
-    else
-      defining_section_parametrization_ring = explicit_model_section_ring
-    end
+    base, ambient, tp_ring = base_space(gtm), ambient_space(gtm), parent(tate_polynomial(gtm))
 
     save_data_dict(s, :params) do
-      if serialize_with_id(base)
-        parent_ref = save_as_ref(s, base)
-        save_object(s, parent_ref, :base_space)
-      else
-        save_typed_object(s, base, :base_space)
+      for (obj, key) in [(base, :base_space), (ambient, :ambient_space), (tp_ring, :tate_polynomial_ring)]
+        if serialize_with_id(obj)
+          save_object(s, save_as_ref(s, obj), key)
+        else
+          save_typed_object(s, obj, key)
+        end
       end
-
-      if serialize_with_id(ambient)
-        parent_ref = save_as_ref(s, ambient)
-        save_object(s, parent_ref, :ambient_space)
-      else
-        save_typed_object(s, ambient, :ambient_space)
-      end
-
-      if serialize_with_id(tate_polynomial_ring)
-        parent_ref = save_as_ref(s, tate_polynomial_ring)
-        save_object(s, parent_ref, :tate_polynomial_ring)
-      else
-        save_typed_object(s, tate_polynomial_ring, :tate_polynomial_ring)
-      end
-
-      if serialize_with_id(explicit_model_section_ring)
-        parent_ref = save_as_ref(s, explicit_model_section_ring)
-        save_object(s, parent_ref, :explicit_model_section_ring)
-      else
-        save_typed_object(s, explicit_model_section_ring, :explicit_model_section_ring)
-      end
-
-      if serialize_with_id(defining_section_parametrization_ring)
-        parent_ref = save_as_ref(s, defining_section_parametrization_ring)
-        save_object(s, parent_ref, :defining_section_parametrization_ring)
-      else
-        save_typed_object(s, defining_section_parametrization_ring, :defining_section_parametrization_ring)
-      end
-
     end
   end
 end
+
 
 ###########################################################################
 # This function loads the types of the data that define a global Tate model
@@ -68,98 +30,47 @@ function load_type_params(s::DeserializerState, ::Type{<: GlobalTateModel})
   return (
     load_typed_object(s, :base_space),
     load_typed_object(s, :ambient_space),
-    load_typed_object(s, :tate_polynomial_ring),
-    load_typed_object(s, :explicit_model_section_ring),
-    load_typed_object(s, :defining_section_parametrization_ring)
+    load_typed_object(s, :tate_polynomial_ring)
   )
 end
+
 
 #########################################
 # This function saves a global Tate model
 #########################################
 
 function save_object(s::SerializerState, gtm::GlobalTateModel)
-  # Currently, only serialize Tate models with toric defining data
   @req base_space(gtm) isa NormalToricVariety "Currently, we only serialize Tate models defined over a toric base space"
   @req ambient_space(gtm) isa NormalToricVariety "Currently, we only serialize Tate models defined within a toric ambient space"
 
-  # Save information
   save_data_dict(s) do
-
-    # Save keys of explicit_model_sections
-    save_data_array(s, :explicit_model_section_keys) do
-      for (key, value) in explicit_model_sections(gtm)
-        save_object(s, key)
-      end
+    for (data, key) in [
+        (explicit_model_sections(gtm), :explicit_model_sections),
+        (defining_section_parametrization(gtm), :defining_section_parametrization),
+        (defining_classes(gtm), :defining_classes)
+        ]
+      !isempty(data) && save_typed_object(s, data, key)
     end
-
-    # Save values of explicit_model_sections
-    save_data_array(s, :explicit_model_section_values) do
-      for (key, value) in explicit_model_sections(gtm)
-        save_object(s, value)
-      end
-    end
-
-    # Save keys of defining_section_parametrization
-    save_data_array(s, :defining_section_parametrization_keys) do
-      for (key, value) in defining_section_parametrization(gtm)
-        save_object(s, key)
-      end
-    end
-
-    # Save keys of defining_section_parametrization
-    save_data_array(s, :defining_section_parametrization_values) do
-      for (key, value) in defining_section_parametrization(gtm)
-        save_object(s, value)
-      end
-    end
-
-    # Tate polynomial
     save_object(s, tate_polynomial(gtm), :tate_polynomial)
-
-    # Boolean values, that are always known for Tate models
     save_data_array(s, :boolean_data) do
       save_object(s, is_partially_resolved(gtm))
     end
   end
 end
 
+
 #########################################
 # This function loads a global Tate model
 #########################################
 
-function load_object(s::DeserializerState, ::Type{<: GlobalTateModel}, params::Tuple{NormalToricVariety, NormalToricVariety, MPolyDecRing, MPolyDecRing, <:MPolyRing})
-
-  # Extract base and ambient space
-  base_space = params[1]
-  ambient_space = params[2]
-
-  # Extract Tate polynomial
-  pt = load_object(s, MPolyDecRingElem, params[3], :tate_polynomial)
-
-  # Extract explicit_model_sections
-  values = load_object(s, Vector, params[4], :explicit_model_section_values)
-  keys = load_object(s, Vector, String, :explicit_model_section_keys)
-  explicit_model_sections = Dict{String, MPolyRingElem}()
-  for i in 1:length(keys)
-    explicit_model_sections[keys[i]] = values[i]
-  end
-
-  # Extract defining_section_parametrization
-  values = load_object(s, Vector, params[5], :defining_section_parametrization_values)
-  keys = load_object(s, Vector, String, :defining_section_parametrization_keys)
-  defining_section_parametrization = Dict{String, MPolyRingElem}()
-  for i in 1:length(keys)
-    defining_section_parametrization[keys[i]] = values[i]
-  end
-
-  # Construct the model
+function load_object(s::DeserializerState, ::Type{<: GlobalTateModel}, params::Tuple{NormalToricVariety, NormalToricVariety, MPolyDecRing})
+  base_space, ambient_space, tp_ring = params
+  pt = load_object(s, MPolyDecRingElem, tp_ring, :tate_polynomial)
+  explicit_model_sections = haskey(s, :explicit_model_sections) ? load_typed_object(s, :explicit_model_sections) : Dict{String, MPolyRingElem}()
+  defining_section_parametrization = haskey(s, :defining_section_parametrization) ? load_typed_object(s, :defining_section_parametrization) : Dict{String, MPolyRingElem}()
+  defining_classes = haskey(s, :defining_classes) ? load_typed_object(s, :defining_classes) : Dict{String, ToricDivisorClass}()
   model = GlobalTateModel(explicit_model_sections, defining_section_parametrization, pt, base_space, ambient_space)
-
-  # Set boolean attributes
-  bools = load_object(s, Vector, Bool, :boolean_data)
-  set_attribute!(model, :partially_resolved, bools[1])
-
-  # Return the loaded model
+  model.defining_classes = defining_classes
+  set_attribute!(model, :partially_resolved, load_object(s, Vector{Bool}, :boolean_data)[1])
   return model
 end

--- a/experimental/FTheoryTools/src/Serialization/weierstrass_models.jl
+++ b/experimental/FTheoryTools/src/Serialization/weierstrass_models.jl
@@ -1,7 +1,5 @@
 @register_serialization_type WeierstrassModel uses_params
 
-
-
 ###########################################################################
 # This function saves the types of the data that define a Weierstrass model
 ###########################################################################
@@ -9,157 +7,70 @@
 function save_type_params(s::SerializerState, w::WeierstrassModel)
   save_data_dict(s) do
     save_object(s, encode_type(WeierstrassModel), :name)
-    base = base_space(w)
-    ambient = ambient_space(w)
-    weierstrass_polynomial_ring = parent(weierstrass_polynomial(w))
-    explicit_model_section_ring = parent(w.explicit_model_sections["f"])
-    parametrizing_sections = collect(keys(defining_section_parametrization(w)))
-    if length(parametrizing_sections) > 0
-      defining_section_parametrization_ring = parent(w.defining_section_parametrization[parametrizing_sections[1]])
-    else
-      defining_section_parametrization_ring = explicit_model_section_ring
-    end
+    base, ambient, wp_ring = base_space(w), ambient_space(w), parent(weierstrass_polynomial(w))
 
     save_data_dict(s, :params) do
-      if serialize_with_id(base)
-        parent_ref = save_as_ref(s, base)
-        save_object(s, parent_ref, :base_space)
-      else
-        save_typed_object(s, base, :base_space)
+      for (obj, key) in [(base, :base_space), (ambient, :ambient_space), (wp_ring, :weierstrass_polynomial_ring)]
+        if serialize_with_id(obj)
+          save_object(s, save_as_ref(s, obj), key)
+        else
+          save_typed_object(s, obj, key)
+        end
       end
-
-      if serialize_with_id(ambient)
-        parent_ref = save_as_ref(s, ambient)
-        save_object(s, parent_ref, :ambient_space)
-      else
-        save_typed_object(s, ambient, :ambient_space)
-      end
-
-      if serialize_with_id(weierstrass_polynomial_ring)
-        parent_ref = save_as_ref(s, weierstrass_polynomial_ring)
-        save_object(s, parent_ref, :weierstrass_polynomial_ring)
-      else
-        save_typed_object(s, weierstrass_polynomial_ring, :weierstrass_polynomial_ring)
-      end
-
-      if serialize_with_id(explicit_model_section_ring)
-        parent_ref = save_as_ref(s, explicit_model_section_ring)
-        save_object(s, parent_ref, :explicit_model_section_ring)
-      else
-        save_typed_object(s, explicit_model_section_ring, :explicit_model_section_ring)
-      end
-
-      if serialize_with_id(defining_section_parametrization_ring)
-        parent_ref = save_as_ref(s, defining_section_parametrization_ring)
-        save_object(s, parent_ref, :defining_section_parametrization_ring)
-      else
-        save_typed_object(s, defining_section_parametrization_ring, :defining_section_parametrization_ring)
-      end
-
     end
   end
 end
 
+
 ###########################################################################
-# This function loads the types of the data that define a global Tate model
+# This function loads the types of the data that define a Weierstrass model
 ###########################################################################
 
 function load_type_params(s::DeserializerState, ::Type{<: WeierstrassModel})
   return (
     load_typed_object(s, :base_space),
     load_typed_object(s, :ambient_space),
-    load_typed_object(s, :weierstrass_polynomial_ring),
-    load_typed_object(s, :explicit_model_section_ring),
-    load_typed_object(s, :defining_section_parametrization_ring)
+    load_typed_object(s, :weierstrass_polynomial_ring)
   )
 end
 
+
 #########################################
-# This function saves a global Tate model
+# This function saves a Weierstrass model
 #########################################
 
 function save_object(s::SerializerState, w::WeierstrassModel)
-  # Currently, only serialize Tate models with toric defining data
-  @req base_space(w) isa NormalToricVariety "Currently, we only serialize Weierstrass models defined over a toric base space"
-  @req ambient_space(w) isa NormalToricVariety "Currently, we only serialize Weierstrass models defined within a toric ambient space"
+  @req base_space(w) isa NormalToricVariety "We only serialize Weierstrass models defined over a toric base space"
+  @req ambient_space(w) isa NormalToricVariety "We only serialize Weierstrass models defined within a toric ambient space"
 
-  # Save information
   save_data_dict(s) do
-
-    # Save keys of explicit_model_sections
-    save_data_array(s, :explicit_model_section_keys) do
-      for (key, value) in explicit_model_sections(w)
-        save_object(s, key)
-      end
+    for (data, key) in [
+        (explicit_model_sections(w), :explicit_model_sections),
+        (defining_section_parametrization(w), :defining_section_parametrization),
+        (defining_classes(w), :defining_classes)
+        ]
+      !isempty(data) && save_typed_object(s, data, key)
     end
-
-    # Save values of explicit_model_sections
-    save_data_array(s, :explicit_model_section_values) do
-      for (key, value) in explicit_model_sections(w)
-        save_object(s, value)
-      end
-    end
-
-    # Save keys of defining_section_parametrization
-    save_data_array(s, :defining_section_parametrization_keys) do
-      for (key, value) in defining_section_parametrization(w)
-        save_object(s, key)
-      end
-    end
-
-    # Save keys of defining_section_parametrization
-    save_data_array(s, :defining_section_parametrization_values) do
-      for (key, value) in defining_section_parametrization(w)
-        save_object(s, value)
-      end
-    end
-
-    # Tate polynomial
     save_object(s, weierstrass_polynomial(w), :weierstrass_polynomial)
-
-    # Boolean values, that are always known for Tate models
     save_data_array(s, :boolean_data) do
       save_object(s, is_partially_resolved(w))
     end
   end
 end
 
+
 #########################################
-# This function loads a global Tate model
+# This function loads a Weierstrass model
 #########################################
 
-function load_object(s::DeserializerState, ::Type{<: WeierstrassModel}, params::Tuple{NormalToricVariety, NormalToricVariety, MPolyDecRing, MPolyDecRing, <:Union{MPolyDecRing, MPolyRing}})
-
-  # Extract base and ambient space
-  base_space = params[1]
-  ambient_space = params[2]
-
-  # Extract Tate polynomial
-  pw = load_object(s, MPolyDecRingElem, params[3], :weierstrass_polynomial)
-
-  # Extract explicit_model_sections
-  values = load_object(s, Vector, params[4], :explicit_model_section_values)
-  keys = load_object(s, Vector, String, :explicit_model_section_keys)
-  explicit_model_sections = Dict{String, MPolyRingElem}()
-  for i in 1:length(keys)
-    explicit_model_sections[keys[i]] = values[i]
-  end
-
-  # Extract defining_section_parametrization
-  values = load_object(s, Vector, params[5], :defining_section_parametrization_values)
-  keys = load_object(s, Vector, String, :defining_section_parametrization_keys)
-  defining_section_parametrization = Dict{String, MPolyRingElem}()
-  for i in 1:length(keys)
-    defining_section_parametrization[keys[i]] = values[i]
-  end
-
-  # Construct the model
+function load_object(s::DeserializerState, ::Type{<: WeierstrassModel}, params::Tuple{NormalToricVariety, NormalToricVariety, MPolyDecRing})
+  base_space, ambient_space, wp_ring = params
+  pw = load_object(s, MPolyDecRingElem, wp_ring, :weierstrass_polynomial)
+  explicit_model_sections = haskey(s, :explicit_model_sections) ? load_typed_object(s, :explicit_model_sections) : Dict{String, MPolyRingElem}()
+  defining_section_parametrization = haskey(s, :defining_section_parametrization) ? load_typed_object(s, :defining_section_parametrization) : Dict{String, MPolyRingElem}()
+  defining_classes = haskey(s, :defining_classes) ? load_typed_object(s, :defining_classes) : Dict{String, ToricDivisorClass}()
   model = WeierstrassModel(explicit_model_sections, defining_section_parametrization, pw, base_space, ambient_space)
-
-  # Set boolean attributes
-  bools = load_object(s, Vector, Bool, :boolean_data)
-  set_attribute!(model, :partially_resolved, bools[1])
-
-  # Return the loaded model
+  model.defining_classes = defining_classes
+  set_attribute!(model, :partially_resolved, load_object(s, Vector{Bool}, :boolean_data)[1])
   return model
 end

--- a/experimental/FTheoryTools/src/Serialization/weierstrass_models.jl
+++ b/experimental/FTheoryTools/src/Serialization/weierstrass_models.jl
@@ -52,9 +52,13 @@ function save_object(s::SerializerState, w::WeierstrassModel)
       !isempty(data) && save_typed_object(s, data, key)
     end
     save_object(s, weierstrass_polynomial(w), :weierstrass_polynomial)
-    save_data_array(s, :boolean_data) do
-      save_object(s, is_partially_resolved(w))
+    attrs_dict = Dict{Symbol, Any}()
+    for (key, value) in w.__attrs
+      if value isa String || value isa Vector{String} || value isa Bool
+        attrs_dict[key] = value
+      end
     end
+    !isempty(attrs_dict) && save_typed_object(s, attrs_dict, :__attrs)
   end
 end
 
@@ -71,6 +75,9 @@ function load_object(s::DeserializerState, ::Type{<: WeierstrassModel}, params::
   defining_classes = haskey(s, :defining_classes) ? load_typed_object(s, :defining_classes) : Dict{String, ToricDivisorClass}()
   model = WeierstrassModel(explicit_model_sections, defining_section_parametrization, pw, base_space, ambient_space)
   model.defining_classes = defining_classes
-  set_attribute!(model, :partially_resolved, load_object(s, Vector{Bool}, :boolean_data)[1])
+  attrs_data = haskey(s, :__attrs) ? load_typed_object(s, :__attrs) : Dict{Symbol, Any}()
+  for (key, value) in attrs_data
+    set_attribute!(model, Symbol(key), value)
+  end
   return model
 end

--- a/experimental/FTheoryTools/src/types.jl
+++ b/experimental/FTheoryTools/src/types.jl
@@ -62,7 +62,9 @@ end
                              base_space::FTheorySpace,
                              ambient_space::FTheorySpace,
                              fiber_ambient_space::AbsCoveredScheme)
-    return new(explicit_model_sections, hypersurface_equation_parametrization, hypersurface_equation, base_space, ambient_space, fiber_ambient_space)
+    result = new(explicit_model_sections, hypersurface_equation_parametrization, hypersurface_equation, base_space, ambient_space, fiber_ambient_space)
+    result.defining_classes = Dict{String, ToricDivisorClass}()
+    return result
   end
 end
 
@@ -87,6 +89,7 @@ end
     result.base_space = base_space
     result.ambient_space = ambient_space
     result.fiber_ambient_space = weighted_projective_space(NormalToricVariety, [2,3,1])
+    result.defining_classes = Dict{String, ToricDivisorClass}()
     return result
   end
 
@@ -100,6 +103,7 @@ end
     result.base_space = base_space
     result.ambient_space = ambient_space
     result.fiber_ambient_space = weighted_projective_space(NormalToricVariety, [2,3,1])
+    result.defining_classes = Dict{String, ToricDivisorClass}()
     return result
   end
 
@@ -126,6 +130,7 @@ end
     result.base_space = base_space
     result.ambient_space = ambient_space
     result.fiber_ambient_space = weighted_projective_space(NormalToricVariety, [2,3,1])
+    result.defining_classes = Dict{String, ToricDivisorClass}()
     return result
   end
 
@@ -139,6 +144,7 @@ end
     result.base_space = base_space
     result.ambient_space = ambient_space
     result.fiber_ambient_space = weighted_projective_space(NormalToricVariety, [2,3,1])
+    result.defining_classes = Dict{String, ToricDivisorClass}()
     return result
   end
 

--- a/experimental/FTheoryTools/test/hypersurface_models.jl
+++ b/experimental/FTheoryTools/test/hypersurface_models.jl
@@ -46,17 +46,21 @@ end
 Kbar = anticanonical_divisor(B3)
 foah1_B3 = literature_model(arxiv_id = "1408.4808", equation = "3.4", type = "hypersurface", base_space = B3, defining_classes = Dict("s7" => Kbar, "s9" => Kbar), completeness_check = false)
 
-@testset "Saving and loading hypersurface literature model" begin
+@testset "Saving and loading hypersurface literature model and some of their attributes" begin
   mktempdir() do path
     test_save_load_roundtrip(path, foah1_B3) do loaded
       @test hypersurface_equation(foah1_B3) == hypersurface_equation(loaded)
       @test base_space(foah1_B3) == base_space(loaded)
+      @test is_base_space_fully_specified(foah1_B3) == is_base_space_fully_specified(loaded)
       @test ambient_space(foah1_B3) == ambient_space(loaded)
       @test fiber_ambient_space(foah1_B3) == fiber_ambient_space(loaded)
-      @test is_base_space_fully_specified(foah1_B3) == is_base_space_fully_specified(loaded)
-      @test is_partially_resolved(foah1_B3) == is_partially_resolved(loaded)
       @test explicit_model_sections(foah1_B3) == explicit_model_sections(loaded)
       @test defining_classes(foah1_B3) == defining_classes(loaded)
+      for (key, value) in foah1_B3.__attrs
+        if value isa String || value isa Vector{String} || value isa Bool
+          @test foah1_B3.__attrs[key] == loaded.__attrs[key]
+        end
+      end
     end
   end
 end

--- a/experimental/FTheoryTools/test/hypersurface_models.jl
+++ b/experimental/FTheoryTools/test/hypersurface_models.jl
@@ -37,6 +37,26 @@ end
       @test fiber_ambient_space(h) == fiber_ambient_space(loaded)
       @test is_base_space_fully_specified(h) == is_base_space_fully_specified(loaded)
       @test is_partially_resolved(h) == is_partially_resolved(loaded)
+      @test explicit_model_sections(h) == explicit_model_sections(loaded)
+      @test defining_classes(h) == defining_classes(loaded)
+    end
+  end
+end
+
+Kbar = anticanonical_divisor(B3)
+foah1_B3 = literature_model(arxiv_id = "1408.4808", equation = "3.4", type = "hypersurface", base_space = B3, defining_classes = Dict("s7" => Kbar, "s9" => Kbar), completeness_check = false)
+
+@testset "Saving and loading hypersurface literature model" begin
+  mktempdir() do path
+    test_save_load_roundtrip(path, foah1_B3) do loaded
+      @test hypersurface_equation(foah1_B3) == hypersurface_equation(loaded)
+      @test base_space(foah1_B3) == base_space(loaded)
+      @test ambient_space(foah1_B3) == ambient_space(loaded)
+      @test fiber_ambient_space(foah1_B3) == fiber_ambient_space(loaded)
+      @test is_base_space_fully_specified(foah1_B3) == is_base_space_fully_specified(loaded)
+      @test is_partially_resolved(foah1_B3) == is_partially_resolved(loaded)
+      @test explicit_model_sections(foah1_B3) == explicit_model_sections(loaded)
+      @test defining_classes(foah1_B3) == defining_classes(loaded)
     end
   end
 end

--- a/experimental/FTheoryTools/test/tate_models.jl
+++ b/experimental/FTheoryTools/test/tate_models.jl
@@ -36,7 +36,7 @@ B3 = projective_space(NormalToricVariety, 3)
 w = torusinvariant_prime_divisors(B3)[1]
 t2 = literature_model(arxiv_id = "1109.3454", equation = "3.1", base_space = B3, defining_classes = Dict("w" => w), completeness_check = false)
 
-@testset "Saving and loading global Tate models over concrete base space" begin
+@testset "Saving and loading global Tate model over concrete base space" begin
   mktempdir() do path
     test_save_load_roundtrip(path, t2) do loaded
       @test tate_polynomial(t2) == tate_polynomial(loaded)
@@ -49,6 +49,28 @@ t2 = literature_model(arxiv_id = "1109.3454", equation = "3.1", base_space = B3,
       @test ambient_space(t2) == ambient_space(loaded)
       @test is_base_space_fully_specified(t2) == is_base_space_fully_specified(loaded)
       @test is_partially_resolved(t2) == is_partially_resolved(loaded)
+    end
+  end
+end
+
+t2_copy = global_tate_model(sample_toric_variety(); completeness_check = false)
+
+@testset "Saving and loading another global Tate model over concrete base space" begin
+  mktempdir() do path
+    test_save_load_roundtrip(path, t2_copy) do loaded
+      @test tate_polynomial(t2_copy) == tate_polynomial(loaded)
+      @test tate_section_a1(t2_copy) == tate_section_a1(loaded)
+      @test tate_section_a2(t2_copy) == tate_section_a2(loaded)
+      @test tate_section_a3(t2_copy) == tate_section_a3(loaded)
+      @test tate_section_a4(t2_copy) == tate_section_a4(loaded)
+      @test tate_section_a6(t2_copy) == tate_section_a6(loaded)
+      @test base_space(t2_copy) == base_space(loaded)
+      @test ambient_space(t2_copy) == ambient_space(loaded)
+      @test is_base_space_fully_specified(t2_copy) == is_base_space_fully_specified(loaded)
+      @test is_partially_resolved(t2_copy) == is_partially_resolved(loaded)
+      @test explicit_model_sections(t2_copy) == explicit_model_sections(loaded)
+      @test defining_section_parametrization(t2_copy) == defining_section_parametrization(loaded)
+      @test defining_classes(t2_copy) == defining_classes(loaded)
     end
   end
 end

--- a/experimental/FTheoryTools/test/tate_models.jl
+++ b/experimental/FTheoryTools/test/tate_models.jl
@@ -48,7 +48,11 @@ t2 = literature_model(arxiv_id = "1109.3454", equation = "3.1", base_space = B3,
       @test base_space(t2) == base_space(loaded)
       @test ambient_space(t2) == ambient_space(loaded)
       @test is_base_space_fully_specified(t2) == is_base_space_fully_specified(loaded)
-      @test is_partially_resolved(t2) == is_partially_resolved(loaded)
+      for (key, value) in t2.__attrs
+        if value isa String || value isa Vector{String} || value isa Bool
+          @test t2.__attrs[key] == loaded.__attrs[key]
+        end
+      end
     end
   end
 end

--- a/experimental/FTheoryTools/test/weierstrass_models.jl
+++ b/experimental/FTheoryTools/test/weierstrass_models.jl
@@ -34,7 +34,7 @@ B2 = projective_space(NormalToricVariety, 2)
 b = torusinvariant_prime_divisors(B2)[1]
 w3 = literature_model(arxiv_id = "1208.2695", equation = "B.19", base_space = B2, defining_classes = Dict("b" => b), completeness_check = false)
 
-@testset "Saving and loading Weierstrass models over concrete base space" begin
+@testset "Saving and loading Weierstrass model over concrete base space" begin
   mktempdir() do path
     test_save_load_roundtrip(path, w3) do loaded
       @test weierstrass_polynomial(w3) == weierstrass_polynomial(loaded)
@@ -44,6 +44,28 @@ w3 = literature_model(arxiv_id = "1208.2695", equation = "B.19", base_space = B2
       @test ambient_space(w3) == ambient_space(loaded)
       @test is_base_space_fully_specified(w3) == is_base_space_fully_specified(loaded)
       @test is_partially_resolved(w3) == is_partially_resolved(loaded)
+      @test explicit_model_sections(w3) == explicit_model_sections(loaded)
+      @test defining_section_parametrization(w3) == defining_section_parametrization(loaded)
+      @test defining_classes(w3) == defining_classes(loaded)
+    end
+  end
+end
+
+w3_copy = weierstrass_model(sample_toric_variety(); completeness_check = false)
+
+@testset "Saving and loading another Weierstrass model over concrete base space" begin
+  mktempdir() do path
+    test_save_load_roundtrip(path, w3_copy) do loaded
+      @test weierstrass_polynomial(w3_copy) == weierstrass_polynomial(loaded)
+      @test weierstrass_section_f(w3_copy) == weierstrass_section_f(loaded)
+      @test weierstrass_section_g(w3_copy) == weierstrass_section_g(loaded)
+      @test base_space(w3_copy) == base_space(loaded)
+      @test ambient_space(w3_copy) == ambient_space(loaded)
+      @test is_base_space_fully_specified(w3_copy) == is_base_space_fully_specified(loaded)
+      @test is_partially_resolved(w3_copy) == is_partially_resolved(loaded)
+      @test explicit_model_sections(w3_copy) == explicit_model_sections(loaded)
+      @test defining_section_parametrization(w3_copy) == defining_section_parametrization(loaded)
+      @test defining_classes(w3_copy) == defining_classes(loaded)
     end
   end
 end

--- a/experimental/FTheoryTools/test/weierstrass_models.jl
+++ b/experimental/FTheoryTools/test/weierstrass_models.jl
@@ -43,10 +43,14 @@ w3 = literature_model(arxiv_id = "1208.2695", equation = "B.19", base_space = B2
       @test base_space(w3) == base_space(loaded)
       @test ambient_space(w3) == ambient_space(loaded)
       @test is_base_space_fully_specified(w3) == is_base_space_fully_specified(loaded)
-      @test is_partially_resolved(w3) == is_partially_resolved(loaded)
       @test explicit_model_sections(w3) == explicit_model_sections(loaded)
       @test defining_section_parametrization(w3) == defining_section_parametrization(loaded)
       @test defining_classes(w3) == defining_classes(loaded)
+      for (key, value) in w3.__attrs
+        if value isa String || value isa Vector{String} || value isa Bool
+          @test w3.__attrs[key] == loaded.__attrs[key]
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
* Use existing dict serialization for FTheory models.
* Clean up serialization code.
* Extend serialization of FTheory models to more of their associated data - anything that is currently stored as string, list of strings or boolean values is remembered by the serialization, once this PR is merged.

[I initially hoped to push this so that some of the JSON-files - that currently specify models - can be replaced by their mardi counterparts. This is not possible. Some of the data associated to the models cannot yet be serialized. For instance Lie algebras. I have not checked if there are other data types that we use and lack serialization (for instance graphs, as used for the QSMs. So I postpone this for now.]

cc @antonydellavecchia @apturner @emikelsons 