### PR TITLE
Make global variables const

### DIFF
--- a/experimental/Experimental.jl
+++ b/experimental/Experimental.jl
@@ -14,7 +14,7 @@ const orderedpkgs = [
   "FTheoryTools",            # must be loaded after Schemes
   "IntersectionTheory",      # must be loaded after Schemes
 ]
-exppkgs = filter(x->isdir(joinpath(expdir, x)) && !(x in orderedpkgs), readdir(expdir))
+const exppkgs = filter(x->isdir(joinpath(expdir, x)) && !(x in orderedpkgs), readdir(expdir))
 append!(exppkgs, orderedpkgs)
 
 # force trigger recompile when folder changes
@@ -50,7 +50,7 @@ end
 # Note that there are functions in the docs of experimental that are not
 # exported. These then also do not get the warning attached.
 using Markdown
-warnexp = Markdown.parse(raw"""
+const warnexp = Markdown.parse(raw"""
 !!! warning "Experimental"
     This function is part of the experimental code in Oscar. Please read
     [here](https://docs.oscar-system.org/v1/Experimental/intro/) for more

--- a/experimental/Schemes/src/SpaceGerms.jl
+++ b/experimental/Schemes/src/SpaceGerms.jl
@@ -12,11 +12,11 @@ abstract type AbsSpaceGerm{BaseRingType<:Ring, RingType<:Ring} <: AbsAffineSchem
 ####################################################################
 ## two short hand definitions for internal use only
 ####################################################################
-GermAtClosedPoint = AffineScheme{<:Field,
+const GermAtClosedPoint = AffineScheme{<:Field,
                          <:AbsLocalizedRing{<:Ring, <:Any,
                                             <:MPolyComplementOfKPointIdeal}
                         }
-GermAtGeometricPoint = AffineScheme{<:Field,
+const GermAtGeometricPoint = AffineScheme{<:Field,
                             <:AbsLocalizedRing{<:Ring, <:Any,
                                                <:MPolyComplementOfPrimeIdeal}
                            }

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Types.jl
@@ -77,5 +77,5 @@ end
 # (3) Auxiliary types
 ###########################################
 
-StdAffineScheme = AbsAffineScheme{<:Ring, <:MPolyQuoLocRing{<:Any, <:Any, <:Any, <:Any, <:MPolyPowersOfElement}}
+const StdAffineScheme = AbsAffineScheme{<:Ring, <:MPolyQuoLocRing{<:Any, <:Any, <:Any, <:Any, <:MPolyPowersOfElement}}
 

--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -541,10 +541,10 @@ function is_homogeneous(el::FreeModElem)
   return isa(el.d, FinGenAbGroupElem)
 end
 
-AnyGradedRingElem = Union{<:MPolyDecRingElem, <:MPolyQuoRingElem{<:MPolyDecRingElem},
-                          <:MPolyLocRingElem{<:Ring, <:RingElem, <:MPolyDecRing},
-                          <:MPolyQuoLocRingElem{<:Ring, <:RingElem, <:MPolyDecRing}
-                         }
+const AnyGradedRingElem = Union{<:MPolyDecRingElem, <:MPolyQuoRingElem{<:MPolyDecRingElem},
+                                <:MPolyLocRingElem{<:Ring, <:RingElem, <:MPolyDecRing},
+                                <:MPolyQuoLocRingElem{<:Ring, <:RingElem, <:MPolyDecRing}
+                               }
 
 @doc raw"""
     degree(f::FreeModElem{T}; check::Bool=true) where {T<:AnyGradedRingElem}

--- a/src/Modules/flattenings.jl
+++ b/src/Modules/flattenings.jl
@@ -4,11 +4,11 @@ function flatten(F::ModuleFP)
   return flatten(base_ring(F))(F)
 end
 
-FlattableRingElemType = Union{<:MPolyRingElem{<:Union{MPolyRingElem, MPolyQuoRingElem, 
-                                                      MPolyQuoLocRingElem, MPolyLocRingElem}},
-                              <:MPolyQuoRingElem{<:MPolyRingElem{<:Union{MPolyRingElem, MPolyQuoRingElem, 
-                                                                         MPolyQuoLocRingElem, MPolyLocRingElem}}}
-                             }
+const FlattableRingElemType = Union{<:MPolyRingElem{<:Union{MPolyRingElem, MPolyQuoRingElem, 
+                                                            MPolyQuoLocRingElem, MPolyLocRingElem}},
+                                    <:MPolyQuoRingElem{<:MPolyRingElem{<:Union{MPolyRingElem, MPolyQuoRingElem, 
+                                                                               MPolyQuoLocRingElem, MPolyLocRingElem}}}
+                                   }
 
 function (flat_map::RingFlattening)(F::FreeMod{T}) where {T <: FlattableRingElemType}
   if !haskey(flat_counterparts(flat_map), F)

--- a/src/Serialization/Groups.jl
+++ b/src/Serialization/Groups.jl
@@ -88,7 +88,7 @@
 
 ##############################################################################
 # `GAPGroupElem` objects get serialized together with their parents.
-GrpElemUnionType = Union{GAPGroupElem, FinGenAbGroupElem}
+const GrpElemUnionType = Union{GAPGroupElem, FinGenAbGroupElem}
 
 function save_type_params(s::SerializerState, p::T) where T <: GrpElemUnionType
   # this has just been more or less copied from the Rings section

--- a/src/Serialization/Upgrades/main.jl
+++ b/src/Serialization/Upgrades/main.jl
@@ -53,7 +53,7 @@ end
                      dict::Dict{Symbol, Any}) = script(u_s)(s, dict)
 
 # The list of all available upgrade scripts
-upgrade_scripts_set = Set{UpgradeScript}()
+const upgrade_scripts_set = Set{UpgradeScript}()
 
 """
     upgrade_data(upgrade::Function, s::UpgradeState, dict::Dict)
@@ -94,7 +94,7 @@ include("0.13.0.jl")
 include("0.15.0.jl")
 include("1.1.0.jl")
 
-upgrade_scripts = collect(upgrade_scripts_set)
+const upgrade_scripts = collect(upgrade_scripts_set)
 sort!(upgrade_scripts; by=version)
 
 ################################################################################

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -315,8 +315,7 @@ function register_serialization_type(ex::Any, str::String, uses_id::Bool, uses_p
       serialize_with_params(T::Type{<:$ex}) = $uses_params
 
       # only extend serialize on non std julia types
-      non_oscar_types = Union{Number, String, Bool, Symbol, Vector, Tuple, Matrix, NamedTuple, Dict, Set}
-      if !($ex <: non_oscar_types)
+      if !($ex <: Union{Number, String, Bool, Symbol, Vector, Tuple, Matrix, NamedTuple, Dict, Set})
         function serialize(s::AbstractSerializer, obj::T) where T <: $ex
           serialize_type(s, T)
           save(s.io, obj; serializer_type=IPCSerializer)


### PR DESCRIPTION
to allow for better type inference and more efficient compiler-generated code