### PR TITLE
[ToricVarieties] Overhaul equality of normal toric varieties

### DIFF
--- a/docs/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties.md
@@ -16,6 +16,46 @@ the affine and non-affine case:
     Transformations for non-standard lattices will have to be done by the user.
 
 
+## Equality of Normal Toric Varieties
+
+!!! warning
+    Equality of normal toric varieties is computationally very demanding.
+    We have therefore made special design decisions for the `==` method.
+
+In OSCAR, the `==` operator is reserved to check if two normal toric varieties are identical,
+meaning their underlying polyhedral fans are the same. However, this check is computationally
+challenging due to several reasons:
+
+- The ray generators might be scaled.
+- The ray generators might be stored in different orders.
+- The maximal (polyhedral) cones of the polyhedral fan might be stored in different orders.
+- If we fall back on polyhedral fan equality, lineality of the cones must also be considered.
+
+To avoid this computational bottleneck, we have specially designed the `==` method.
+It checks if the memory locations of the two objects in question are identical. If 
+so, our `==` method returns `true`. Otherwise, it raise an error.
+
+Note that triple equality `===` (i.e. the check of equal the memory locations) is always
+supported for normal toric varieties. We recommend using it.
+
+However, if you truly need to check for two normal toric varieties to be mathematically
+identical, then you will need to add a custom method. This method could look as follows:
+
+```julia
+function slow_equal(tv1::NormalToricVariety, tv2::NormalToricVariety)
+  tv1 === tv2 && return true
+  ambient_dim(tv1) == ambient_dim(tv2) || return false
+  f_vector(tv1) == f_vector(tv2) || return false
+  return Set(maximal_cones(tv1)) == Set(maximal_cones(tv2))
+end
+```
+
+Please note that this method `slow_equal` is not performant, that we currently (summer 2024)
+have no intentions in adding this function to OSCAR nor to make improvements to its performance.
+Rather, expect this method to be slow, potentially painfully so.
+
+
+
 ## Constructors
 
 ### Affine Toric Varieties

--- a/experimental/Schemes/src/IdealSheaves.jl
+++ b/experimental/Schemes/src/IdealSheaves.jl
@@ -466,7 +466,11 @@ end
 function ==(I::AbsIdealSheaf, J::AbsIdealSheaf)
   I === J && return true
   X = space(I)
-  X == space(J) || return false
+  if X isa NormalToricVariety
+    X === space(J) || return false
+  else
+    X == space(J) || return false
+  end
   for U in basic_patches(default_covering(X))
     is_subset(I(U), J(U)) && is_subset(J(U), I(U)) || return false
   end

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/constructors.jl
@@ -179,6 +179,17 @@ end
 
 
 ######################
+# Equality
+######################
+
+function Base.:(==)(tv1::NormalToricVariety, tv2::NormalToricVariety)
+  tv1 === tv2 && return true
+  error("Equality of normal toric varieties is computationally very demanding. More details in the documentation.")
+end
+
+
+
+######################
 # Display
 ######################
 

--- a/src/AlgebraicGeometry/ToricVarieties/Proj/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/Proj/constructors.jl
@@ -42,7 +42,7 @@ function _projectivization_and_total_space(is_proj::Bool, E::Vector{T}) where T 
 
   is_proj && length(E) == 1 && return v
 
-  @req all(i -> toric_variety(E[i]) == v, eachindex(E)) "The divisors are defined on different toric varieties."
+  @req all(i -> toric_variety(E[i]) === v, eachindex(E)) "The divisors are defined on different toric varieties."
 
   if is_proj
     PF_fiber = normal_fan(simplex(length(E) - 1))

--- a/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/constructors.jl
@@ -190,7 +190,7 @@ end
 ####################################################
 
 function Base.:(==)(tm1::ToricMorphism, tm2::ToricMorphism)
-    return domain(tm1) == domain(tm2) && codomain(tm1) == codomain(tm2) && grid_morphism(tm1) == grid_morphism(tm2)
+    return domain(tm1) === domain(tm2) && codomain(tm1) === codomain(tm2) && grid_morphism(tm1) == grid_morphism(tm2)
 end
 
 function Base.hash(tm::ToricMorphism, h::UInt)

--- a/test/AlgebraicGeometry/ToricVarieties/normal_toric_varieties.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/normal_toric_varieties.jl
@@ -34,4 +34,13 @@
     ntv5 = normal_toric_variety(polarize(polyhedron(Polymake.polytope.rand_sphere(5, 60; seed=42))))
     @test ngens(stanley_reisner_ideal(ntv5)) == 1648
   end
+
+  p2 = projective_space(NormalToricVariety, 2)
+  f2 = hirzebruch_surface(NormalToricVariety, 2)
+
+  @testset "Equality of normal toric varieties" begin
+    @test (p2 === f2) == false
+    @test p2 === p2
+    @test_throws ErrorException("Equality of normal toric varieties is computationally very demanding. More details in the documentation.") p2 == f2
+  end
 end

--- a/test/AlgebraicGeometry/ToricVarieties/toric_blowdowns.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/toric_blowdowns.jl
@@ -51,7 +51,7 @@
     @test grid_morphism(bl + bl) == grid_morphism(2 * bl)
     @test grid_morphism(bl - bl) == grid_morphism(0 * bl)
     @test grid_morphism(bl * toric_identity_morphism(codomain(bl))) == grid_morphism(bl)
-    @test bl != bl2
+    @test bl !== bl2
   end
 
   S = cox_ring(P2)

--- a/test/AlgebraicGeometry/ToricVarieties/toric_morphisms.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/toric_morphisms.jl
@@ -22,7 +22,7 @@
   end
   
   @testset "Basic attributes of toric morphisms" begin
-    @test codomain(tm1) == domain(tm2)
+    @test codomain(tm1) === domain(tm2)
     @test matrix(grid_morphism(tm2)) == matrix(ZZ, [[1, 0], [0, 1]])
     @test morphism_on_torusinvariant_weil_divisor_group(tm2).map == identity_matrix(ZZ, 4)
     @test morphism_on_torusinvariant_cartier_divisor_group(tm2).map == identity_matrix(ZZ, 4)

--- a/test/Serialization/ToricGeometry.jl
+++ b/test/Serialization/ToricGeometry.jl
@@ -16,7 +16,7 @@
       test_save_load_roundtrip(path, vtd) do loaded
         @test coefficients(td0) == coefficients(loaded[1])
         @test coefficients(td1) == coefficients(loaded[2])
-        @test toric_variety(loaded[1]) == toric_variety(loaded[2])
+        @test toric_variety(loaded[1]) === toric_variety(loaded[2])
       end
     end
 
@@ -28,7 +28,7 @@
       test_save_load_roundtrip(path, vtd) do loaded
         @test divisor_class(tdc0) == divisor_class(loaded[1])
         @test divisor_class(tdc1) == divisor_class(loaded[2])
-        @test toric_variety(loaded[1]) == toric_variety(loaded[2])
+        @test toric_variety(loaded[1]) === toric_variety(loaded[2])
       end
     end
 


### PR DESCRIPTION
This PR aims to close https://github.com/oscar-system/Oscar.jl/issues/3934 as follows:

* Overwrite the `==` method: Return true if `===` is true and otherwise raise an error.
* Add documentation which explains why this computation is very demanding.
* Add a (stupid) (as in not very performant) equality method  `slow_equal`. I have not exported this method (exports are hard to revert, we do not want anybody to use this method unless they really, really want to etc.). Still, the method is documented.
* Throughout OSCAR, `==` of two toric varieties was used in a number of places. It seemed reasonable to change some of them to `===`.