### PR TITLE
`QuadFormAndIsom`: fix permutation of signatures

### DIFF
--- a/experimental/QuadFormAndIsom/test/runtests.jl
+++ b/experimental/QuadFormAndIsom/test/runtests.jl
@@ -283,6 +283,11 @@ end
   rht = @inferred representatives_of_hermitian_type(G, chi)
   @test !isempty(rht)
   @test all(N -> !is_finite(order_of_isometry(N)), rht)
+
+  # Fix signatures filtration
+  E, _ = cyclotomic_field_as_cm_extension(7; cached=false)
+  signs = Oscar._possible_signatures(12, E, 3, true)
+  @test length(signs) == 4
 end
 
 @testset "Primitive extensions and embeddings" begin


### PR DESCRIPTION
We want to identify signatures of hermitian forms over a given cyclotomic field which are identical up to changing a "fixed root of unity". The set of corresponding permutations of places is not equal to the full symmetric group (of appropriate degree). In the previous version of the code, I was identifying all signatures which were similar under any permutation of the real places, which was mathematically wrong. This fixes this issue.

Thanks to @thofma for the help and the snippet of code in `_permutations_of_places`.