### PR TITLE
Add sandbox for heap based sparse linear algebra

### DIFF
--- a/experimental/HeapSparseLA/README.md
+++ b/experimental/HeapSparseLA/README.md
@@ -1,0 +1,13 @@
+# An example template for the experimental section
+
+## Aims
+
+This is an example for a file structure to set up a new package 
+in the experimental section. All files you find here are part of the 
+minimum requirements. See also the official Oscar documentation.
+
+## Status
+
+We plan to also provide a function to automatically copy this template 
+for you to start your own package. 
+

--- a/experimental/HeapSparseLA/README.md
+++ b/experimental/HeapSparseLA/README.md
@@ -1,13 +1,15 @@
-# An example template for the experimental section
+# Sparse linear algebra over rings
 
 ## Aims
 
-This is an example for a file structure to set up a new package 
-in the experimental section. All files you find here are part of the 
-minimum requirements. See also the official Oscar documentation.
+This package explores the possibilities to use heap-based data structures 
+for sparse linear algebra over various rings. The hope is to eventually 
+improve Gauss-like algorithms for simplifications of matrices and 
+complexes of modules.
 
 ## Status
 
-We plan to also provide a function to automatically copy this template 
-for you to start your own package. 
+An experimental version of the data types and the functionality has been 
+implemented. It does not perform too well, yet. As a benchmark one can use 
+the methods of `upper_triangular_form!`. See the documentation for details.
 

--- a/experimental/HeapSparseLA/docs/doc.main
+++ b/experimental/HeapSparseLA/docs/doc.main
@@ -1,0 +1,8 @@
+# An example documentation
+
+This is a sample text to outline the structure of the packages in the `Experimental` folder.
+You can show docstrings like this:
+```@docs
+my_access_func(S::ExampleStruct)
+```
+

--- a/experimental/HeapSparseLA/docs/doc.main
+++ b/experimental/HeapSparseLA/docs/doc.main
@@ -1,8 +1,6 @@
-# An example documentation
+# Gauss algorithm over Euclidean rings
 
-This is a sample text to outline the structure of the packages in the `Experimental` folder.
-You can show docstrings like this:
 ```@docs
-my_access_func(S::ExampleStruct)
+upper_triangular_form!(A::MatElem)
 ```
 

--- a/experimental/HeapSparseLA/src/HeapDictSRow.jl
+++ b/experimental/HeapSparseLA/src/HeapDictSRow.jl
@@ -1,0 +1,192 @@
+# Binary heaps
+
+# comparison for ordering in the heap; to be overwritten eventually
+_binary_heap_leq(a::Any, b::Any) = a <= b
+
+function length(h::BinaryHeap)
+  return length(h.content)
+end
+
+function Base.push!(h::BinaryHeap{T}, v::T) where {T}
+  !h.is_heapified && heapify!(h)
+  n = length(h)
+  push!(h.content, v) # just to make space
+  i = n + 1
+  p = i >> 1
+  while i > 1 && !_binary_heap_leq(h.content[p], v)
+    h.content[i] = h.content[p]
+    i = p
+    p = i >> 1
+  end
+  i <= n && (h.content[i] = v)
+  return h
+end
+
+function Base.pop!(h::BinaryHeap{T}) where T
+  !h.is_heapified && heapify!(h)
+  # move the top node down
+  isempty(h) && return nothing
+  result = first(h.content)
+  i = 1
+  l = i << 1
+  r = l + 1
+  n = length(h)
+  while i <= n
+    l > n && break # we're in a leaf node
+    if r > n # the left child is the only leaf node
+      h.content[i] = h.content[l]
+      i = l
+      break
+    end
+
+    a = h.content[l]
+    b = h.content[r]
+    if _binary_heap_leq(a, b)
+      h.content[i] = a
+      i = l
+      l = i << 1
+      r = l + 1
+    else
+      h.content[i] = b
+      i = r
+      l = i << 1
+      r = l + 1
+    end
+  end
+
+  # move the last element to the gap at i and then up
+  i0 = i
+  v = pop!(h.content) # the last element
+  i == n && return result # nothing to do in this case
+  p = i >> 1
+  while i > 1 && !_binary_heap_leq(h.content[p], v)
+    h.content[i] = h.content[p]
+    i = p
+    p = i >> 1
+  end
+  !isempty(h.content) && (h.content[i] = v)
+  return result
+end
+
+function peek(h::BinaryHeap)
+  !h.is_heapified && heapify!(h)
+  return first(h.content)
+end
+
+function heapify!(h::BinaryHeap{T}) where {T}
+  for q in length(h.content):-1:1
+    i = q
+    p = i >> 1
+    v = h.content[q]
+    while i > 1 && !_binary_heap_leq(h.content[p], v)
+      h.content[i] = h.content[p]
+      i = p
+      p = i >> 1
+    end
+    i < q && (h.content[i] = v)
+  end
+  h.is_heapified = true
+  return h
+end
+
+isempty(h::BinaryHeap) = isempty(h.content)
+
+function copy(h::BinaryHeap)
+  return BinaryHeap(h.content; is_heapified = h.is_heapified)
+end
+
+### sparse rows based on heaps and dictionaries
+function HeapDictSRow(
+    R::NCRing, a::Vector{Tuple{IndexType, T}}
+  ) where {IndexType, T}
+  return HeapDictSRow(R, [i for (i, _) in a], [v for (_, v) in a])
+end
+
+base_ring(v::HeapDictSRow) = v.R
+
+function getindex(v::HeapDictSRow{I, T}, i::I) where {I, T}
+  !haskey(v.coeffs, i) && return zero(base_ring(v))
+  return v.coeffs[i]
+end
+
+function setindex!(v::HeapDictSRow{I, T}, c::T, i::I) where {I, T}
+  !haskey(v.coeffs, i) && push!(v.indices, i)
+  v.coeffs[i] = c
+  return c
+end
+
+function Base.pop!(v::HeapDictSRow)
+  i = pop!(v.indices)
+  c = pop!(v.coeffs, i)
+  return i, c
+end
+
+function isempty(v::HeapDictSRow)
+  return isempty(v.indices)
+end
+
+function length(v::HeapDictSRow)
+  return length(v.indices)
+end
+
+function copy(v::HeapDictSRow)
+  return HeapDictSRow(v)
+end
+
+function add!(v::HeapDictSRow{I, T}, w::HeapDictSRow{I, T}) where {I, T}
+  # TODO: use sizehint to avoid incremental allocations
+  h = v.indices
+  sizehint!(h.content, length(h.content) + length(w.indices.content))
+  m = length(w)
+  n = length(v)
+  new_ind = sizehint!(Vector{I}(), m)
+  old_ind = sizehint!(Vector{I}(), m)
+  for k in keys(w.coeffs)
+    if k in keys(v.coeffs)
+      push!(old_ind, k)
+    else
+      push!(new_ind, k)
+    end
+  end
+  for i in old_ind
+    v.coeffs[i] += pop!(w.coeffs, i)
+  end
+  # TODO: Can we indicate that there are no duplicate keys and get a speedup?
+  v.coeffs = merge!(v.coeffs, w.coeffs)
+  v.indices.content = vcat(v.indices.content, new_ind)
+  v.indices.is_heapified = false
+  heapify!(v.indices)
+  return v
+end
+
+function +(v::HeapDictSRow{I, T}, w::HeapDictSRow{I, T}) where {I, T}
+  return add!(copy(v), copy(w))
+end
+
+*(a::Any, v::HeapDictSRow) = base_ring(a)*v
+
+function *(a::T, v::HeapDictSRow{I, T}) where {I, T}
+  return mul!(a, copy(v))
+end
+
+function mul!(a::T, v::HeapDictSRow{I, T}) where {I, T}
+  for (i, c) in v.coeffs
+    v.coeffs[i] *= a
+  end
+  return v
+end
+
+-(v::HeapDictSRow) = -one(base_ring(v))*v
+
+function Base.show(io::IO, v::HeapDictSRow)
+  h = copy(v.indices)
+  while !isempty(h)
+    i = pop!(h)
+    println(io, "$i => $(v.coeffs[i])")
+  end
+end
+
+function sparse_row(v::HeapDictSRow)
+  return sparse_row(base_ring(v), [(i, c) for (i, c) in v.coeffs])
+end
+

--- a/experimental/HeapSparseLA/src/HeapDictSRow.jl
+++ b/experimental/HeapSparseLA/src/HeapDictSRow.jl
@@ -99,25 +99,31 @@ end
 function HeapDictSRow(
     R::NCRing, a::Vector{Tuple{IndexType, T}}
   ) where {IndexType, T}
+  a = filter!(x->!iszero(x[2]), a)
   return HeapDictSRow(R, [i for (i, _) in a], [v for (_, v) in a])
 end
 
 base_ring(v::HeapDictSRow) = v.R
 
 function getindex(v::HeapDictSRow{I, T}, i::I) where {I, T}
+  @hassert :SparseLA 3 is_sane(v)
   !haskey(v.coeffs, i) && return zero(base_ring(v))
   return v.coeffs[i]
 end
 
 function setindex!(v::HeapDictSRow{I, T}, c::T, i::I) where {I, T}
+  @hassert :SparseLA 3 is_sane(v)
   !haskey(v.coeffs, i) && push!(v.indices, i)
   v.coeffs[i] = c
+  @hassert :SparseLA 3 is_sane(v)
   return c
 end
 
 function Base.pop!(v::HeapDictSRow)
+  @hassert :SparseLA 3 is_sane(v)
   i = pop!(v.indices)
   c = pop!(v.coeffs, i)
+  @hassert :SparseLA 3 is_sane(v)
   return i, c
 end
 
@@ -133,10 +139,77 @@ function copy(v::HeapDictSRow)
   return HeapDictSRow(v)
 end
 
+function Base.delete!(h::BinaryHeap{I}, k::I) where {I}
+  isempty(h) && return h
+  # try to find k
+  i = 1
+  i = find_node_rec(h.content, i, k)
+  i === nothing && error("key not found")
+
+  # move the element down
+  l = i << 1
+  r = l + 1
+  n = length(h)
+  while i <= n
+    l > n && break # we're in a leaf node
+    if r > n # the left child is the only leaf node
+      h.content[i] = h.content[l]
+      i = l
+      break
+    end
+
+    a = h.content[l]
+    b = h.content[r]
+    if _binary_heap_leq(a, b)
+      h.content[i] = a
+      i = l
+      l = i << 1
+      r = l + 1
+    else
+      h.content[i] = b
+      i = r
+      l = i << 1
+      r = l + 1
+    end
+  end
+
+  # move the last element to the gap at i and then up
+  n = length(h.content)
+  v = pop!(h.content) # the last element
+  i == n && return h # nothing to do in this case
+  p = i >> 1
+  while i > 1 && !_binary_heap_leq(h.content[p], v)
+    h.content[i] = h.content[p]
+    i = p
+    p = i >> 1
+  end
+  !isempty(h.content) && (h.content[i] = v)
+  return h
+end
+
+function find_node_rec(c::Vector{I}, i::Int, k::I) where {I}
+  k == c[i] && return i
+  l = i << 1
+  r = l + 1
+  n = length(c)
+
+  if l <= n && _heap_leq(c[l], k)
+    l_res = find_node_rec(c, l, k)
+    l_res !== nothing && return l_res
+  end
+
+  if r <= n && _heap_leq(c[r], k)
+    r_res = find_node_rec(c, r, k)
+    r_res !== nothing && return r_res
+  end
+  return nothing
+end
+
+
+
 function add!(v::HeapDictSRow{I, T}, w::HeapDictSRow{I, T}) where {I, T}
+  @hassert :SparseLA 3 (is_sane(v) && is_sane(w))
   # TODO: use sizehint to avoid incremental allocations
-  h = v.indices
-  sizehint!(h.content, length(h.content) + length(w.indices.content))
   m = length(w)
   n = length(v)
   new_ind = sizehint!(Vector{I}(), m)
@@ -150,12 +223,22 @@ function add!(v::HeapDictSRow{I, T}, w::HeapDictSRow{I, T}) where {I, T}
   end
   for i in old_ind
     v.coeffs[i] += pop!(w.coeffs, i)
+    if iszero(v.coeffs[i]) 
+      delete!(v.coeffs, i)
+      delete!(v.indices, i)
+    end
   end
   # TODO: Can we indicate that there are no duplicate keys and get a speedup?
   v.coeffs = merge!(v.coeffs, w.coeffs)
-  v.indices.content = vcat(v.indices.content, new_ind)
+  # TODO: can we use array-copy functions here?
+  sizehint!(v.indices.content, m + length(new_ind))
+  for j in new_ind
+    push!(v.indices.content, j)
+  end
+  #v.indices.content = vcat(v.indices.content, new_ind)
   v.indices.is_heapified = false
   heapify!(v.indices)
+  @hassert :SparseLA 3 is_sane(v)
   return v
 end
 
@@ -170,9 +253,11 @@ function *(a::T, v::HeapDictSRow{I, T}) where {I, T}
 end
 
 function mul!(a::T, v::HeapDictSRow{I, T}) where {I, T}
+  @hassert :SparseLA 3 is_sane(v)
   for (i, c) in v.coeffs
     v.coeffs[i] *= a
   end
+  @hassert :SparseLA 3 is_sane(v)
   return v
 end
 
@@ -188,5 +273,72 @@ end
 
 function sparse_row(v::HeapDictSRow)
   return sparse_row(base_ring(v), [(i, c) for (i, c) in v.coeffs])
+end
+
+function HeapDictSRow{I, T}(R::NCRing, a::Vector{Tuple{I, T}}) where {I, T}
+  return HeapDictSRow(R, a)
+end
+
+function pivot(v::HeapDictSRow{I, T}) where {I, T}
+  @hassert :SparseLA 3 is_sane(v)
+  isempty(v) && return zero(I), zero(base_ring(v))
+  i = peek(v.indices)
+  return i, v.coeffs[i]
+end
+
+function *(v::HeapDictSRow{I, ET}, A::HeapSMat{ET, HeapDictSRow{I, ET}}) where {I, ET}
+  return mul!(v, A)
+end
+
+function mul!(v::HeapDictSRow{I, ET}, A::HeapSMat{ET, HeapDictSRow{I, ET}}) where {I, ET}
+  @hassert :SparseLA 3 is_sane(v)
+  @hassert :SparseLA 3 all(is_sane(w) for w in A.rows)
+  R = base_ring(v)
+  @assert R === base_ring(A)
+  m = nrows(A)
+  n = ncols(A)
+  result = typeof(v)(R)
+  return sum(c*A[i] for (i, c) in v.coeffs; init=result)
+end
+
+consolidate!(v::HeapDictSRow) = v
+
+function transpose!(A::HeapSMat{ET, T}) where {ET, T<:HeapDictSRow{Int}}
+  @hassert :SparseLA 3 all(is_sane(w) for w in A.rows)
+  m = nrows(A)
+  n = ncols(A)
+  R = base_ring(A)
+  result = typeof(A)(R, 0, m)
+
+  res_list = T[]
+  m = nrows(A)
+  n = ncols(A)
+  for j in 1:n
+    next = Tuple{Int, ET}[]
+    for i in 1:m
+      if j in keys(A[i].coeffs)
+        push!(next, (i, A[i, j]))
+      end
+    end
+    new_line = T(R, next)
+    push!(result, new_line)
+  end
+  @hassert :SparseLA 3 all(is_sane(w) for w in A.rows)
+  @hassert :SparseLA 3 all(is_sane(w) for w in result.rows)
+  return result
+end
+
+function ==(v::T, w::T) where {T <: HeapDictSRow}
+  return v.coeffs == w.coeffs
+end
+
+as_dictionary(v::HeapDictSRow) = copy(v.coeffs)
+
+function is_sane(v::HeapDictSRow)
+  all(x in keys(v.coeffs) for x in v.indices.content) || error("more indices than coefficients")
+  all(x in v.indices.content for x in keys(v.coeffs)) || error("more coefficients than indices")
+  length(v.indices.content) == length(v.coeffs) || error("double indices")
+  any(iszero(x) for x in values(v.coeffs)) && error("zero value found")
+  return true
 end
 

--- a/experimental/HeapSparseLA/src/HeapSparseLA.jl
+++ b/experimental/HeapSparseLA/src/HeapSparseLA.jl
@@ -2,6 +2,7 @@
 # which are big in the sense that copying them around in memory 
 # for sorting is expensive.
 include("Types.jl")
+include("HeapDictSRow.jl")
 
 ### `HeapNode`
 # A minimal data structure for nodes in binary trees holding the data

--- a/experimental/HeapSparseLA/src/HeapSparseLA.jl
+++ b/experimental/HeapSparseLA/src/HeapSparseLA.jl
@@ -1,0 +1,14 @@
+# Add your new types, functions, and methods here.
+
+mutable struct ExampleStruct
+  i::Int
+end
+
+@doc raw"""
+    my_access_func(S::ExampleStruct)
+
+This is a dummy sample function to teach the use of docstrings.
+"""
+function my_access_func(S::ExampleStruct)
+  return S.i
+end

--- a/experimental/HeapSparseLA/src/HeapSparseLA.jl
+++ b/experimental/HeapSparseLA/src/HeapSparseLA.jl
@@ -1,14 +1,113 @@
-# Add your new types, functions, and methods here.
+# A heap based implementation of sparse row vectors for elements
+# which are big in the sense that copying them around in memory 
+# for sorting is expensive.
+#=
+mutable struct HeapNode{T}
+  content::T
+  index::Int
+  left::Union{HeapNode{T}, Nothing}
+  right::Union{HeapNode{T}, Nothing}
 
-mutable struct ExampleStruct
-  i::Int
+  function HeapNode(i::Int, cont::T; 
+        left::Union{HeapNode{T}, Nothing}=nothing, 
+        right::Union{HeapNode{T}, Nothing}=nothing
+      ) where {T}
+    return new{T}(cont, i, left, right)
+  end
 end
 
-@doc raw"""
-    my_access_func(S::ExampleStruct)
+content(n::HeapNode) = n.content
+index(n::HeapNode) = n.i
+has_left_child(n::HeapNode) = (n.left !== nothing)
+has_right_child(n::HeapNode) = (n.right !== nothing)
+is_leaf(n::HeapNode) = !has_left_child(n) && !has_right_child(n)
+left_child(n::HeapNode{T}) where {T} = n.left::T
+right_child(n::HeapNode{T}) where {T} = n.right::T
 
-This is a dummy sample function to teach the use of docstrings.
-"""
-function my_access_func(S::ExampleStruct)
-  return S.i
+
+mutable struct HeapSRow{T}
+  entry_parent::NCRing
+  top::Union{Nothing, HeapNode{T}}
+  is_consolidated::Bool
+
+  function HeapSRow(R::NCRing)
+    return new{elem_type(R)}(R, nothing, true)
+  end
+
+  function HeapSRow(R::NCRing, n::HeapNode{T};
+      is_consolidated::Bool=false
+    ) where {T}
+    return new{T}(R, n, is_consolidated)
+  end
 end
+
+top(v::HeapSRow{T}) where {T} = v.top::HeapNode{T}
+isempty(v::HeapSRow) = v.top === nothing
+
+function is_consolidated(v::HeapSRow) 
+  v.is_consolidated && return true
+  if is_empty(v)
+    v.is_consolidated = true
+    return true
+  end
+
+  n = top(v)
+  result, _ = _has_duplicate(n, Int[])
+  if !result
+    v.result = true
+    return true
+  end
+  return false
+end
+
+function _has_duplicate(n::HeapNode, key_list::Vector{Int})
+  i = index(n)
+  k = searchsortedfirst(key_list, i, rev=true)
+  if key_list[k] != i
+    push!(key_list, i)
+    if has_left_child(n)
+      result, key_list = _has_duplicate(left_child(n), key_list)
+      result && return true, key_list
+    end
+    if has_right_child(n)
+      result, key_list = _has_duplicate(right_child(n), key_list)
+      result && return true, key_list
+    end
+    return false, key_list
+  end
+
+  push!(key_list, i)
+  return true, key_list
+end
+
+function getindex(v::HeapSRow{T}, i::Int)
+  #TODO: Also clean up the heap if there is more than one value for the key i.
+  all_indices = gather_values(top(v), i, is_consolidated(v))
+  return sum(all_indices; init=zero(v.entry_parent))
+end
+
+function gather_values(n::HeapNode{T}, i::Int, is_consolidated::Bool) where {T}
+  result = T[]
+  i > index(n) && return result
+  if i == index(n) 
+    push!(result, content(n))
+    is_consolidated && return result # There can only be one entry for i and it is this one
+  end
+  has_left_child(n) && (result = vcat(result, gather_values(left_child(n), i)))
+  has_right_child(n) && (result = vcat(result, gather_values(right_child(n), i)))
+  return result
+end
+
+function has_index(v::HeapSRow{T}, i::Int)
+  isempty(v) && return false
+  return _has_index(top(v), i)
+end
+
+function _has_index(n::HeapNode, i::Int)
+  index(n) == i && return true
+  has_left_child(n) && _has_index(left_child(n), i) && return true
+  has_right_child(n) && _has_index(right_child(n), i) && return true
+  return false
+end
+
+=#

--- a/experimental/HeapSparseLA/src/HeapSparseLA.jl
+++ b/experimental/HeapSparseLA/src/HeapSparseLA.jl
@@ -1,47 +1,309 @@
 # A heap based implementation of sparse row vectors for elements
 # which are big in the sense that copying them around in memory 
 # for sorting is expensive.
-#=
-mutable struct HeapNode{T}
-  content::T
-  index::Int
-  left::Union{HeapNode{T}, Nothing}
-  right::Union{HeapNode{T}, Nothing}
-
-  function HeapNode(i::Int, cont::T; 
-        left::Union{HeapNode{T}, Nothing}=nothing, 
-        right::Union{HeapNode{T}, Nothing}=nothing
-      ) where {T}
-    return new{T}(cont, i, left, right)
-  end
-end
+include("Types.jl")
 
 content(n::HeapNode) = n.content
-index(n::HeapNode) = n.i
+index(n::HeapNode) = n.index
 has_left_child(n::HeapNode) = (n.left !== nothing)
 has_right_child(n::HeapNode) = (n.right !== nothing)
 is_leaf(n::HeapNode) = !has_left_child(n) && !has_right_child(n)
-left_child(n::HeapNode{T}) where {T} = n.left::T
-right_child(n::HeapNode{T}) where {T} = n.right::T
+left_child(n::HeapNode{T}) where {T} = n.left::HeapNode{T}
+right_child(n::HeapNode{T}) where {T} = n.right::HeapNode{T}
 
+tree_size(n::HeapNode) = (is_leaf(n) ? 1 : 1 + tree_size(n.left) + tree_size(n.right))
+tree_size(n::Nothing) = 0
 
-mutable struct HeapSRow{T}
-  entry_parent::NCRing
-  top::Union{Nothing, HeapNode{T}}
-  is_consolidated::Bool
+function ancestry_depth(n::HeapNode)
+  !has_left_child(n) && !has_right_child(n) && return 0
+  n1 = n2 = 0
+  has_left_child(n) && (n1 = ancestry_depth(left_child(n)))
+  has_right_child(n) && (n2 = ancestry_depth(right_child(n)))
+  return maximum([n1, n2]) + 1
+end
 
-  function HeapSRow(R::NCRing)
-    return new{elem_type(R)}(R, nothing, true)
+# TODO: Overwrite hashing!
+function ==(a::HeapNode, b::HeapNode)
+  return index(a) == index(b) && content(a) == content(b)
+end
+
+### to be overwritten for specified types with a function 
+function leq(a::HeapNode, b::HeapNode)
+  return index(a) <= index(b)
+end
+
+function leq(a::HeapNode, b::Nothing)
+  return true
+end
+
+function leq(a::Nothing, b::HeapNode)
+  return false
+end
+
+function leq(a::Nothing, b::Nothing)
+  return true
+end
+
+function show(io::IO, n::HeapNode; cofactor=1)
+  show_recursive(io, n)
+end
+
+function show_recursive(io::IO, n::HeapNode; indent::Int=0, cofactor=1)
+  new_cof = n.cofactor === nothing ? cofactor : cofactor*n.cofactor
+  offset = prod(" " for i in 1:indent; init = "")
+  println(offset*"$(index(n)) -> $(new_cof*content(n))")
+  has_left_child(n) && show_recursive(io, left_child(n), indent=indent+1, cofactor=new_cof)
+  has_right_child(n) && show_recursive(io, right_child(n), indent=indent+1, cofactor=new_cof)
+end
+
+base_ring(v::HeapSRow) = v.entry_parent
+
+function index_cache(v::HeapSRow{T}) where {T}
+  if !isdefined(v, :index_cache)
+    v.index_cache = Dict{Int, T}()
+  end
+  return v.index_cache
+end
+
+function HeapSRow(R::NCRing, list::Vector{Pair{Int, T}}) where {T}
+  return HeapSRow(R, [(a, b) for (a, b) in list])
+end
+
+function HeapSRow(v::SRow{T}) where {T}
+  result = HeapSRow(base_ring(v))
+  open = HeapNode{T}[]
+  for (i, c) in v
+    n = HeapNode(i, c)
+    k = findfirst(leq(a, n) for a in open)
+    if k === nothing 
+      result.top = n
+      push!(open, n)
+      continue
+    end
+    l = open[k]
+    if l.left !== nothing 
+      l.left = n
+      l.right === nothing || deleteat!(open, k)
+      push!(open, n)
+    else
+      l.right = n
+      deleteat!(open, k)
+      push!(open, n)
+    end
+  end
+  return result
+end
+
+function HeapSRow(R::NCRing, list::Vector{Tuple{Int, T}}) where {T}
+  result = HeapSRow(R)
+  isempty(list) && return result
+  if isone(length(list))
+    i, c = first(list)
+    result.top = HeapNode(i, c)
+    return result
   end
 
-  function HeapSRow(R::NCRing, n::HeapNode{T};
-      is_consolidated::Bool=false
-    ) where {T}
-    return new{T}(R, n, is_consolidated)
+  n = length(list)
+  h = div(n, 2)
+  result = HeapSRow(R, list[1:h]) + HeapSRow(R, list[h+1:end])
+  return result
+end
+
+function pivot(v::HeapSRow)
+  consolidate_top!(v)
+  return index(top_node(v)), content(top_node(v))
+end
+
++(v::HeapSRow, w::HeapSRow) = add!(copy(v), copy(w))
+-(v::HeapSRow, w::HeapSRow) = addmul!(copy(v), copy(w), -one(base_ring(w)))
+add!(v::HeapSRow, w::HeapSRow) = addmul!(v, w, one(base_ring(w)))
+
+function addmul!(v::HeapSRow{T}, w::HeapSRow{T}, a::T) where {T}
+  @assert base_ring(v) === base_ring(w)
+  R = base_ring(v)
+  isempty(v) && return w
+  isempty(w) && return v
+
+  res_tree = merge!(v.top, scale_cofactor!(w.top, a))
+  return HeapSRow(base_ring(v), res_tree)
+  # the top needs to be consolidated
+  consolidate_top!(v)
+  consolidate_top!(w)
+
+  i1, c1 = pivot(v)
+  i2, c2 = pivot(w)
+  n1 = top_node(v)
+  n2 = top_node(w)
+
+  left_tree = merge!(n1.left, n1.right, n1.cofactor)
+  right_tree = merge!(n2.left, n2.right, n2.cofactor)
+  scale_cofactor!(right_tree, a)
+
+  if i1 == i2
+    c = c1 + a*c2
+    if iszero(c)
+      res_tree = merge!(left_tree, right_tree)
+      v.top = nothing
+      w.top = nothing
+      return HeapSRow(base_ring(v), res_tree)
+    else
+      n = HeapNode(i1, c)
+      if leq(n, left_tree) && leq(n, right_tree)
+        n.left = left_tree
+        n.right = right_tree
+        v.top = nothing
+        w.top = nothing
+        return HeapSRow(base_ring(v), n; top_is_consolidated = true)
+      else
+        res_tree = merge!(merge!(left_tree, right_tree), n)
+        v.top = nothing
+        w.top = nothing
+        return HeapSRow(base_ring(v), res_tree)
+      end
+    end
+  else
+    v_i2, rem1 = pop_index!(left_tree, i2)
+    w_i1, rem2 = pop_index!(right_tree, i1)
+
+    cc1 = c1 + w_i1 # the new entry in i1
+    cc2 = c2 + v_i2 # the new entry in i2
+    nn1 = (iszero(cc1) ? nothing : HeapNode(i1, cc1))
+    nn2 = (iszero(cc2) ? nothing : HeapNode(i2, cc2))
+    left_tree = merge!(rem1, nn1, nothing)
+    right_tree = merge!(rem2, nn2)
+    result = merge!(left_tree, right_tree)
+    v.top = nothing
+    w.top = nothing
+    return HeapSRow(R, result; top_is_consolidated = (result === nn1 || result === nn2))
   end
 end
 
-top(v::HeapSRow{T}) where {T} = v.top::HeapNode{T}
+function copy(v::HeapSRow)
+  isempty(v) && return HeapSRow(base_ring(v))
+  n = top_node(v)
+  nn = copy_tree(n)
+  return HeapSRow(base_ring(v), nn)
+end
+
+function copy_tree(n::HeapNode)
+  result = HeapNode(index(n), content(n), cofactor=n.cofactor)
+  result.left = copy_tree(n.left)
+  result.right = copy_tree(n.right)
+  return result
+end
+
+copy_tree(n::Nothing) = nothing
+
+function *(a::T, v::HeapSRow{T}) where {T}
+  return mul!(a, copy(v))
+end
+
+function mul!(a::T, v::HeapSRow{T}) where {T}
+  isempty(v) && return v
+  iszero(a) && return HeapSRow(base_ring(v))
+  isone(a) && return v
+  if v.top.cofactor === nothing
+    v.top.cofactor = a
+  else
+    v.top.cofactor *= a
+  end
+  # clear the cache
+  v.index_cache = Dict{Int, T}()
+  return v
+end
+
+*(a, v::HeapSRow) = base_ring(v)(a)*v
+mul!(a, v::HeapSRow) = mul!(base_ring(v)(a), v)
+
+mult_content_rec_left!(a, n::Nothing) = nothing
+
+function mult_content_rec_left!(a::T, n::HeapNode{T}) where {T}
+  iszero(a) && return nothing
+  isone(a) && return n
+  n.content *= a
+  mult_content_rec_left!(a, n.left)
+  mult_content_rec_left!(a, n.right)
+  is_zero(n.content) && return merge!(n.left, n.right)
+  return n
+end
+
+-(v::HeapSRow, w::HeapSRow) = addmul!(copy(v), copy(w), -one(base_ring(w)))
+-(w::HeapSRow) = -one(base_ring(w))*w
+
+# Remove all entries `i` from `v`, sum them up and return a pair `(c, w)` consisting of the sum `c` and the remainder `w`.
+function pop_index!(v::HeapSRow, i::Int)
+  R = base_ring(v)
+  isempty(v) && return zero(R), v
+  c, n = pop_index!(top(v), i)
+  return c, HeapSRow(R, n)
+end
+
+function pop_index!(n::HeapNode{T}, i::Int) where {T}
+  if index(n) == i
+    result = content(n)
+    a, left = pop_index!(n.left, i)
+    b, right = pop_index!(n.right, i)
+    rem = merge!(left, right)
+    result += a
+    result += b
+    n.cofactor !== nothing && (result *= n.cofactor)
+    return result, scale_cofactor!(rem, n.cofactor)
+  end
+
+  a, rem_left = pop_index!(n.left, i)
+  b, rem_right = pop_index!(n.right, i)
+  result = a + b
+  n.cofactor !== nothing && (result *= n.cofactor)
+  n.left = rem_left
+  n.right = rem_right
+  return result, n
+end
+
+function pop_index!(n::Nothing, i::Int)
+  return 0, nothing
+end
+
+function scale_cofactor!(n::HeapNode{T}, a::T) where T
+  if n.cofactor === nothing 
+    n.cofactor = a
+  else
+    n.cofactor *= a
+  end
+  return n
+end
+
+scale_cofactor!(n::Nothing, a::Any) = nothing
+scale_cofactor!(n::HeapNode, a::Nothing) = n
+
+function consolidate_top!(v::HeapSRow)
+  v.top_is_consolidated && return v
+  isempty(v) && return v
+  n = top_node(v)
+  i = index(n)
+  cof = n.cofactor
+  if n.cofactor !== nothing 
+    n.content *= n.cofactor
+    n.cofactor = nothing
+    scale_cofactor!(n.left, cof)
+    scale_cofactor!(n.right, cof)
+  end
+  a, left = pop_index!(n.left, i)
+  b, right = pop_index!(n.right, i)
+  n.content += a + b
+  n.left = left
+  n.right = right
+
+  if iszero(n.content)
+    v.top = merge!(n.left, n.right)
+    return consolidate_top!(v)
+  end
+
+  v.top_is_consolidated = true
+  return v
+end
+
+
+top_node(v::HeapSRow{T}) where {T} = v.top::HeapNode{T}
 isempty(v::HeapSRow) = v.top === nothing
 
 function is_consolidated(v::HeapSRow) 
@@ -51,7 +313,7 @@ function is_consolidated(v::HeapSRow)
     return true
   end
 
-  n = top(v)
+  n = top_node(v)
   result, _ = _has_duplicate(n, Int[])
   if !result
     v.result = true
@@ -60,47 +322,59 @@ function is_consolidated(v::HeapSRow)
   return false
 end
 
-function _has_duplicate(n::HeapNode, key_list::Vector{Int})
-  i = index(n)
-  k = searchsortedfirst(key_list, i, rev=true)
-  if key_list[k] != i
-    push!(key_list, i)
-    if has_left_child(n)
-      result, key_list = _has_duplicate(left_child(n), key_list)
-      result && return true, key_list
-    end
-    if has_right_child(n)
-      result, key_list = _has_duplicate(right_child(n), key_list)
-      result && return true, key_list
-    end
-    return false, key_list
+function getindex(v::HeapSRow{T}, i::Int) where {T}
+  is_empty(v) && return zero(base_ring(v))
+  haskey(index_cache(v), i) && return index_cache(v)[i]
+  n = top_node(v)
+  v.top_is_consolidated && index(n) == i && return content(n)
+  c, rem = pop_index!(n, i)
+  index_cache(v)[i] = c
+  if iszero(c)
+    v.top = rem
+  else
+    v.top = merge!(rem, HeapNode(i, c))
   end
-
-  push!(key_list, i)
-  return true, key_list
+  return c
 end
 
-function getindex(v::HeapSRow{T}, i::Int)
-  #TODO: Also clean up the heap if there is more than one value for the key i.
-  all_indices = gather_values(top(v), i, is_consolidated(v))
-  return sum(all_indices; init=zero(v.entry_parent))
-end
-
-function gather_values(n::HeapNode{T}, i::Int, is_consolidated::Bool) where {T}
-  result = T[]
-  i > index(n) && return result
-  if i == index(n) 
-    push!(result, content(n))
-    is_consolidated && return result # There can only be one entry for i and it is this one
+function merge!(a::HeapNode{T}, b::HeapNode{T}) where {T}
+  if leq(a, b)
+    # a is the new top
+    a.left = merge!(a.left, a.right)
+    scale_cofactor!(a.left, a.cofactor)
+    if a.cofactor!==nothing
+      a.content *= a.cofactor
+      a.cofactor = nothing
+    end
+    a.right = b
+    return a
+  else
+    b.left = merge!(b.left, b.right)
+    scale_cofactor!(b.left, b.cofactor)
+    if b.cofactor!==nothing
+      b.content *= b.cofactor
+      b.cofactor = nothing
+    end
+    b.right = a
+    return b
   end
-  has_left_child(n) && (result = vcat(result, gather_values(left_child(n), i)))
-  has_right_child(n) && (result = vcat(result, gather_values(right_child(n), i)))
-  return result
 end
 
-function has_index(v::HeapSRow{T}, i::Int)
+function merge!(a::HeapNode, b::Nothing)
+  return a
+end
+
+function merge!(a::Nothing, b::HeapNode)
+  return b
+end
+
+function merge!(a::Nothing, b::Nothing)
+  return nothing
+end
+
+function has_index(v::HeapSRow{T}, i::Int) where {T}
   isempty(v) && return false
-  return _has_index(top(v), i)
+  return _has_index(top_node(v), i)
 end
 
 function _has_index(n::HeapNode, i::Int)
@@ -110,4 +384,68 @@ function _has_index(n::HeapNode, i::Int)
   return false
 end
 
-=#
+function all_indices(v::HeapSRow)
+  isempty(v) && return Int[]
+  return all_indices(top_node(v))
+end
+
+function all_indices(n::HeapNode)
+  is_leaf(n) && return [index(n)]
+  return vcat([index(n)], all_indices(n.left), all_indices(n.right))
+end
+
+all_indices(n::Nothing) = Int[]
+
+function as_dictionary(v::HeapSRow)
+  result = Dict{Int, elem_type(base_ring(v))}()
+  isempty(v) && return result
+  result = as_dictionary(top_node(v), result)
+  v.index_cache = result
+  return result
+end
+
+as_dictionary(n::Nothing, result::Dict{Int, T}, c::Any=nothing) where {T} = result
+
+function as_dictionary(n::HeapNode{T}, result::Dict{Int, T}, cofactor::Nothing=nothing) where {T}
+  new_cof = n.cofactor === nothing ? one(content(n)) : n.cofactor
+  i = index(n)
+  if i in keys(result)
+    result[i] = result[i] + new_cof * content(n)
+  else
+    result[i] = new_cof * content(n)
+  end
+  as_dictionary(n.left, result, n.cofactor)
+  as_dictionary(n.right, result, n.cofactor)
+  return result
+end
+
+function as_dictionary(n::HeapNode{T}, result::Dict{Int, T}, cofactor::T) where {T}
+  new_cof = n.cofactor === nothing ? cofactor : n.cofactor*cofactor
+  i = index(n)
+  if i in keys(result)
+    result[i] = result[i] + new_cof * content(n)
+  else
+    result[i] = new_cof * content(n)
+  end
+  as_dictionary(n.left, result, new_cof)
+  as_dictionary(n.right, result, new_cof)
+  return result
+end
+
+function iszero(v::HeapSRow)
+  isempty(v) && return true
+  return all(iszero(c) for c in values(as_dictionary(v)))
+end
+
+function ==(v::HeapSRow{T}, w::HeapSRow{T}) where {T}
+  consolidate_top!(v)
+  consolidate_top!(w)
+  isempty(v) && return iszero(w)
+  isempty(w) && return iszero(v)
+  top_node(v) == top_node(w) || return false # the easy case
+
+  d1 = as_dictionary(v)
+  d2 = as_dictionary(w)
+  return d1 == d2
+end
+

--- a/experimental/HeapSparseLA/src/Types.jl
+++ b/experimental/HeapSparseLA/src/Types.jl
@@ -37,3 +37,27 @@ mutable struct HeapSRow{T}
   end
 end
 
+mutable struct HeapSMat{T}
+  base_ring::NCRing
+  nrows::Int
+  ncols::Int
+  rows::Vector{HeapSRow{T}}
+  transpose::Union{HeapSMat{T}, Nothing}
+
+  function HeapSMat(R::NCRing, nrows::Int, ncols::Int, rows::Vector{HeapSRow{T}}) where {T}
+    @assert all(base_ring(v) === R for v in rows)
+    @assert nrows >= length(rows)
+    crows = copy(rows)
+    for i in length(rows)+1:nrows
+      push!(crows, HeapSRow(R))
+    end
+    return new{T}(R, nrows, ncols, crows, nothing)
+  end
+
+  function HeapSMat(R::Ring, nrows::Int, ncols::Int)
+    rows = HeapSRow{elem_type(R)}[HeapSRow(R) for i in 1:nrows]
+    return new{elem_type(R)}(R, nrows, ncols, rows, nothing)
+  end
+end
+
+

--- a/experimental/HeapSparseLA/src/Types.jl
+++ b/experimental/HeapSparseLA/src/Types.jl
@@ -60,4 +60,36 @@ mutable struct HeapSMat{T}
   end
 end
 
+mutable struct BinaryHeap{T}
+  content::Vector{T}
+  is_heapified::Bool
+
+  function BinaryHeap(a::Vector{T}; is_heapified::Bool=false) where T
+    result = new{T}(copy(a), is_heapified)
+  end
+end
+
+mutable struct HeapDictSRow{IndexType, T}
+  R::NCRing
+  indices::BinaryHeap{IndexType}
+  coeffs::Dict{IndexType, T}
+
+  function HeapDictSRow(
+      R::NCRing, ind::Vector{IndexType}, vals::Vector{T}
+    ) where {IndexType, T}
+    @assert length(ind) == length(vals)
+    @assert all(parent(x) === R for x in vals)
+    coeffs = Dict{IndexType, T}(i=>v for (i, v) in zip(ind, vals))
+    indices = BinaryHeap(ind)
+    return new{IndexType, T}(R, indices, coeffs)
+  end
+
+  function HeapDictSRow(v::HeapDictSRow{I, T}) where {I, T}
+    result = new{I, T}()
+    result.R = v.R
+    result.indices = copy(v.indices)
+    result.coeffs = copy(v.coeffs)
+    return result
+  end
+end
 

--- a/experimental/HeapSparseLA/src/Types.jl
+++ b/experimental/HeapSparseLA/src/Types.jl
@@ -1,0 +1,39 @@
+
+mutable struct HeapNode{T}
+  content::T
+  index::Int
+  cofactor::Union{T, Nothing} # an element !==nothing here indicates
+                              # that the contents here and all of the 
+                              # following subtree shall be multiplied 
+                              # with `cofactor` to get the actual values.
+  left::Union{HeapNode{T}, Nothing}
+  right::Union{HeapNode{T}, Nothing}
+
+  function HeapNode(i::Int, cont::T; 
+        cofactor::Union{T, Nothing}=nothing,
+        left::Union{HeapNode{T}, Nothing}=nothing, 
+        right::Union{HeapNode{T}, Nothing}=nothing
+      ) where {T}
+    return new{T}(cont, i, cofactor, left, right)
+  end
+end
+
+mutable struct HeapSRow{T}
+  entry_parent::NCRing
+  top::Union{Nothing, HeapNode{T}}
+  top_is_consolidated::Bool
+  is_consolidated::Bool
+  index_cache::Dict{Int, T}
+
+  function HeapSRow(R::NCRing)
+    return new{elem_type(R)}(R, nothing, true, true)
+  end
+
+  function HeapSRow(R::NCRing, n::HeapNode{T};
+      top_is_consolidated::Bool=false,
+      is_consolidated::Bool=false
+    ) where {T}
+    return new{T}(R, n, top_is_consolidated, is_consolidated)
+  end
+end
+

--- a/experimental/HeapSparseLA/test/runtests.jl
+++ b/experimental/HeapSparseLA/test/runtests.jl
@@ -81,3 +81,24 @@ end
   @test Oscar.HeapSMat(S1) == S0
 end
 
+@testset "heap-dict vectors" begin
+  k = 100000
+  i = unique!([rand(1:10*k) for i in 1:k])
+  v = [ZZ(rand(1:10))^10000 for i in 1:length(i)]
+  a = Oscar.HeapDictSRow(ZZ, i, v)
+  aa = sparse_row(a)
+  i = unique!([rand(1:10*k) for i in 1:k])
+  v = [ZZ(rand(1:10))^10000 for i in 1:length(i)]
+  b = Oscar.HeapDictSRow(ZZ, i, v)
+  bb = sparse_row(b)
+
+  # For comparison of timings do 
+  # julia> c = copy(a); @time w = add!(c, b);
+  #   0.042619 seconds (27.40 k allocations: 41.765 MiB, 17.17% gc time)
+  #
+  # julia> cc = copy(aa); @time cc += bb;
+  #   0.226098 seconds (192.12 k allocations: 510.190 MiB, 5.40% gc time)
+
+  aa += bb
+  @test sparse_row(add!(a, b)) == aa
+end

--- a/experimental/HeapSparseLA/test/runtests.jl
+++ b/experimental/HeapSparseLA/test/runtests.jl
@@ -48,3 +48,36 @@ end
   @test Oscar.HeapSMat(S1) == S0
 end
 
+@testset "Gauss algorithm on different matrix types over univariate polynomial rings" begin
+  s = 1
+  m = 10*s
+  n = 20*s
+
+  P, (x,) = polynomial_ring(QQ, [:x])
+  QQt, t = QQ[:t]
+  A = Oscar.HeapSMat(QQt, 0, n)
+  for i in 1:m
+    l = [(rand(1:20*s), evaluate(rand(P, 1:10, 1:10, 1:10), [t])) for i in 1:s];
+    v = Oscar.HeapSRow(QQt, l)
+    push!(A, v)
+  end
+  AA = Oscar.sparse_matrix(A)
+
+  B0, S0, T0 = Oscar.upper_triangular_form!(copy(A))
+  B1, S1, T1 = Oscar.upper_triangular_form!(copy(AA))
+
+  @test S0*A == B0
+  @test T0*B0 == A
+
+  S1 = Oscar.dense_matrix(Oscar.HeapSMat(S1))
+  B1 = Oscar.dense_matrix(Oscar.HeapSMat(B1))
+  T1 = Oscar.dense_matrix(Oscar.HeapSMat(T1))
+  A1 = Oscar.dense_matrix(A)
+  @test S1*A1 == B1
+  @test T1*B1 == A1
+
+  @test Oscar.HeapSMat(B1) == B0
+  @test Oscar.HeapSMat(T1) == T0
+  @test Oscar.HeapSMat(S1) == S0
+end
+

--- a/experimental/HeapSparseLA/test/runtests.jl
+++ b/experimental/HeapSparseLA/test/runtests.jl
@@ -17,3 +17,34 @@
   @test u == 2*v
 end
 
+@testset "Gauss algorithm on different matrix types" begin
+  s = 4
+  m = 10*s
+  n = 20*s
+
+  A = Oscar.HeapSMat(ZZ, 0, n)
+  for i in 1:m
+    l = [(rand(1:20*s), ZZ(rand(-10:10))) for i in 1:s];
+    v = Oscar.HeapSRow(ZZ, l)
+    push!(A, v)
+  end
+  AA = Oscar.sparse_matrix(A)
+
+  B0, S0, T0 = Oscar.upper_triangular_form!(copy(A))
+  B1, S1, T1 = Oscar.upper_triangular_form!(copy(AA))
+
+  @test S0*A == B0
+  @test T0*B0 == A
+
+  S1 = Oscar.dense_matrix(Oscar.HeapSMat(S1))
+  B1 = Oscar.dense_matrix(Oscar.HeapSMat(B1))
+  T1 = Oscar.dense_matrix(Oscar.HeapSMat(T1))
+  A1 = Oscar.dense_matrix(A)
+  @test S1*A1 == B1
+  @test T1*B1 == A1
+
+  @test Oscar.HeapSMat(B1) == B0
+  @test Oscar.HeapSMat(T1) == T0
+  @test Oscar.HeapSMat(S1) == S0
+end
+

--- a/experimental/HeapSparseLA/test/runtests.jl
+++ b/experimental/HeapSparseLA/test/runtests.jl
@@ -22,7 +22,7 @@ end
   m = 10*s
   n = 20*s
 
-  A = Oscar.HeapSMat(ZZ, 0, n)
+  A = Oscar.HeapSMat{ZZRingElem, Oscar.HeapSRow{ZZRingElem}}(ZZ, 0, n)
   for i in 1:m
     l = [(rand(1:20*s), ZZ(rand(-10:10))) for i in 1:s];
     v = Oscar.HeapSRow(ZZ, l)
@@ -55,7 +55,7 @@ end
 
   P, (x,) = polynomial_ring(QQ, [:x])
   QQt, t = QQ[:t]
-  A = Oscar.HeapSMat(QQt, 0, n)
+  A = Oscar.HeapSMat{elem_type(QQt), Oscar.HeapSRow{elem_type(QQt)}}(QQt, 0, n)
   for i in 1:m
     l = [(rand(1:20*s), evaluate(rand(P, 1:10, 1:10, 1:10), [t])) for i in 1:s];
     v = Oscar.HeapSRow(QQt, l)
@@ -102,3 +102,44 @@ end
   aa += bb
   @test sparse_row(add!(a, b)) == aa
 end
+
+@testset "heap-dict sparse matrices over GF(7)[t]" begin
+  s = 3
+  m = 10*s
+  n = 20*s
+
+  P, (x,) = polynomial_ring(GF(7), [:x])
+  QQt, t = GF(7)[:t]
+  A = Oscar.HeapSMat{elem_type(QQt), Oscar.HeapDictSRow{Int, elem_type(QQt)}}(QQt, 0, n)
+  for i in 1:m
+    j = unique!([rand(1:20*s) for i in 1:s])
+    c = [evaluate(rand(P, 1:10, 1:10, 1:10), [t]) for i in 1:length(j)];
+    v = Oscar.HeapDictSRow(QQt, collect(zip(j, c)))
+    push!(A, v)
+  end
+
+  B0, S0, T0 = Oscar.upper_triangular_form!(copy(A))
+
+  @test S0*A == B0
+  @test T0*B0 == A
+end
+
+@testset "heap-dict sparse matrices over QQ" begin
+  s = 10
+  m = 10*s
+  n = 20*s
+
+  A = Oscar.HeapSMat{elem_type(QQ), Oscar.HeapDictSRow{Int, elem_type(QQ)}}(QQ, 0, n)
+  for i in 1:m
+    j = unique!([rand(1:20*s) for i in 1:s])
+    c = [rand(QQ, 1:10) for i in 1:length(j)];
+    v = Oscar.HeapDictSRow(QQ, collect(zip(j, c)))
+    push!(A, v)
+  end
+
+  B0, S0, T0 = Oscar.upper_triangular_form!(copy(A))
+
+  @test S0*A == B0
+  @test T0*B0 == A
+end
+

--- a/experimental/HeapSparseLA/test/runtests.jl
+++ b/experimental/HeapSparseLA/test/runtests.jl
@@ -1,4 +1,19 @@
 @testset "heap based sparse linear algebra" begin
-  S = Oscar.ExampleStruct(5)
-  @test 5 == Oscar.my_access_func(S)
+  n = Oscar.HeapNode(1, ZZ(5))
+  n.left = Oscar.HeapNode(2, ZZ(7))
+  n.right = Oscar.HeapNode(2, ZZ(-3))
+  n.right.right = Oscar.HeapNode(3, ZZ(8))
+  v = Oscar.HeapSRow(ZZ, n)
+  w = Oscar.HeapSRow(ZZ, [1 => ZZ(5), 2 => ZZ(4), 3 => ZZ(11), 3=>ZZ(-3)])
+  @test !isdefined(v, :index_cache)
+  @test v[3] == 8
+  @test isdefined(v, :index_cache) && v.index_cache[3] == 8
+  @test Oscar.tree_size(v.top) == 4
+  @test v[2] == 4
+  @test v.index_cache[2] == 4
+  @test Oscar.tree_size(v.top) == 3
+
+  u = v + w
+  @test u == 2*v
 end
+

--- a/experimental/HeapSparseLA/test/runtests.jl
+++ b/experimental/HeapSparseLA/test/runtests.jl
@@ -1,0 +1,4 @@
+@testset "heap based sparse linear algebra" begin
+  S = Oscar.ExampleStruct(5)
+  @test 5 == Oscar.my_access_func(S)
+end

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -177,6 +177,7 @@ function __init__()
   add_verbosity_scope(:ZZLatWithIsom)
   
   add_assertion_scope(:IdealSheaves)
+  add_assertion_scope(:SparseLA)
 
   # Pkg.is_manifest_current() returns false if the manifest might be out of date
   # (but might return nothing when there is no project_hash)


### PR DESCRIPTION
### What is this about?

Over a coffee break at the ICMS @flenzen and I discussed a bit about sparse linear algebra. He mentioned that in some application in TDA (topological data analysis) there was a data type for sparse vectors based on heaps which had proven to have advantages in various settings where Gauss-like algorithms are applied to simplify complexes (see e.g. [this paper](https://doi.org/10.1016/j.jsc.2016.03.008).) I became interested because of my implementation of `simplify` for complexes of modules: In the computation of derived pushforwards for coherent sheaves, the Gauss algorithm is the bottleneck at the moment. 

I suggested to give it a try together in OSCAR. This PR is our sandbox for collaboration.

### What's the state here?

I couldn't hold myself back and started implementing a naive version of what I understood the architecture to be. As a test-case I am using matrices over the integers and implemented a simple algorithm to determine an upper-triangular form (`upper_triangular_form!`). When running the tests it becomes clear that my naive implementation of heap-based data structures for sparse linear algebra clearly looses against the existing implementation via `SRow` and `SMat`. 

However, I think this PR can still be useful since it provides a blueprint for how to contribute a new experimental section to OSCAR and @flenzen might also have ideas and try to play with and improve the code. 

In fact, he already suggested to me that realizing heaps via linked binary trees is probably a dumb idea. Seems like he was right. But hey: If you know better, let's try it out! We have this code for comparison for the moment to build benchmarks.

**Update:** We now have an implementation of heap-dict based sparse rows as was pointed out by @fingolfin. I also made the `HeapSMat` type generic so that it can be used with arbitrary concrete types of sparse rows. With these new data types I now get slightly better performance in many cases when compared with the classical `SMat` and `SRow`. 

It might still be the case that I'm not using enough in-place operations for the latter, though. Feel free to take a stand for the classical data types and improve their benchmark!

### Should I care?

If you're interested or an expert in sparse linear algebra over rings, feel free to chime in. Comments are welcome! Otherwise, we will notify the relevant people once we get to the point that we feel that we have produced something useful, or just close this PR.
