### PR TITLE
Nicer show for GAPGroupClassFunction

### DIFF
--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -1902,7 +1902,7 @@ GAP.julia_to_gap(chi::GAPGroupClassFunction) = chi.values
 parent(chi::GAPGroupClassFunction) = chi.table
 
 function Base.show(io::IO, chi::GAPGroupClassFunction)
-    print(io, "class_function($(parent(chi)), $(values(chi)))")
+    print(io, "class_function($(parent(chi)), [", join(values(chi), ", "), "])")
 end
 
 function values(chi::GAPGroupClassFunction)

--- a/src/InvariantTheory/invariant_rings.jl
+++ b/src/InvariantTheory/invariant_rings.jl
@@ -401,7 +401,7 @@ julia> x = gens(R);
 julia> F = abelian_closure(QQ)[1];
 
 julia> chi = Oscar.class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
-class_function(character table of S2, QQAbFieldElem{AbsSimpleNumFieldElem}[1, -1])
+class_function(character table of S2, [1, -1])
 
 julia> reynolds_operator(IR, x[1], chi)
 1//2*x[1] - 1//2*x[2]
@@ -535,7 +535,7 @@ julia> R = invariant_ring(QQ, S2);
 julia> F = abelian_closure(QQ)[1];
 
 julia> chi = Oscar.class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
-class_function(character table of group Sym( [ 1 .. 2 ] ), QQAbFieldElem{AbsSimpleNumFieldElem}[1, -1])
+class_function(character table of group Sym( [ 1 .. 2 ] ), [1, -1])
 
 julia> basis(R, 3, chi)
 2-element Vector{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}:
@@ -679,7 +679,7 @@ julia> IR = invariant_ring(QQ, S2);
 julia> F = abelian_closure(QQ)[1];
 
 julia> chi = Oscar.class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
-class_function(character table of S2, QQAbFieldElem{AbsSimpleNumFieldElem}[1, -1])
+class_function(character table of S2, [1, -1])
 
 julia> molien_series(IR)
 1//(t^3 - t^2 - t + 1)

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -279,7 +279,7 @@ julia> R = invariant_ring(QQ, S2);
 julia> F = abelian_closure(QQ)[1];
 
 julia> chi = Oscar.class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
-class_function(character table of S2, QQAbFieldElem{AbsSimpleNumFieldElem}[1, -1])
+class_function(character table of S2, [1, -1])
 
 julia> B = iterate_basis(R, 3, chi)
 Iterator over a basis of the component of degree 3

--- a/src/InvariantTheory/secondary_invariants.jl
+++ b/src/InvariantTheory/secondary_invariants.jl
@@ -444,7 +444,7 @@ julia> RS2 = invariant_ring(S2);
 julia> F = abelian_closure(QQ)[1];
 
 julia> chi = Oscar.class_function(S2, [ F(sign(representative(c))) for c in conjugacy_classes(S2) ])
-class_function(character table of S2, QQAbFieldElem{AbsSimpleNumFieldElem}[1, -1])
+class_function(character table of S2, [1, -1])
 
 julia> semi_invariants(RS2, chi)
 1-element Vector{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}:

--- a/test/book/cornerstones/groups/reps.jlcon
+++ b/test/book/cornerstones/groups/reps.jlcon
@@ -63,7 +63,7 @@ julia> pushfirst!(im, hom(FF, FF, matrix(C, [0 1; 1 0])));
 julia> phi = gmodule(G, im);
 
 julia> character(phi)
-class_function(character table of G, QQAbFieldElem{AbsSimpleNumFieldElem}[2, 0, -1, 2, 0])
+class_function(character table of G, [2, 0, -1, 2, 0])
 
 julia> schur_index(ans)
 1


### PR DESCRIPTION
Always printing the redundant `QQAbFieldElem{AbsSimpleNumFieldElem}` seems pointless.