### PR TITLE
Remove custom non-conformant `Base.:/` method for `MPolyLocRingElem`

### DIFF
--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -1161,10 +1161,6 @@ function Base.:(/)(a::ZZRingElem, b::T) where {T<:MPolyLocRingElem}
   return (parent(b))(a//fraction(b))
 end
 
-function Base.:(/)(a::T, b::T) where {T<:MPolyLocRingElem}
-  return divexact(a, b)
-end
-
 function ==(a::T, b::T) where {T<:MPolyLocRingElem}
   parent(a) == parent(b) || error("the arguments do not have the same parent ring")
   return fraction(a) == fraction(b)

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -1162,12 +1162,7 @@ function Base.:(/)(a::ZZRingElem, b::T) where {T<:MPolyLocRingElem}
 end
 
 function Base.:(/)(a::T, b::T) where {T<:MPolyLocRingElem}
-  parent(a) == parent(b) || error("the arguments do not have the same parent ring")
-  g = gcd(numerator(a), numerator(b))
-  c = divexact(numerator(a), g)
-  d = divexact(numerator(b), g)
-  numerator(fraction(b)) in inverted_set(parent(b)) || error("the second argument is not a unit in this local ring")
-  return (parent(a))(fraction(a) // fraction(b), check=false)
+  return divexact(a, b)
 end
 
 function ==(a::T, b::T) where {T<:MPolyLocRingElem}


### PR DESCRIPTION
This is to address the inconsistency pointed out by @simonbrandhorst in #1885.