### PR TITLE
[FTheoryTools] Some docstring fixes

### DIFF
--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
@@ -1113,7 +1113,7 @@ The computation of the cohomology ring verifies if the toric variety is simplici
 complete. The check for it to be complete can be very time consuming. This can be switched
 off by setting the optional argument `check` to the value `false`, as in the example below.
 
-```jldoctest
+```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
 
@@ -1172,7 +1172,7 @@ The computation of the cohomology ring verifies if the toric variety is simplici
 complete. The check for it to be complete can be very time consuming. This can be switched
 off by setting the optional argument `check` to the value `false`, as in the example below.
 
-```jldoctest
+```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
 

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
@@ -815,6 +815,7 @@ end
     model_index(m::AbstractFTheoryModel)
 Return database index of a literature model. This index is a unique identifier that can be used to more conveniently construct the model. 
 All models have a model_index and these will not change in the future.
+
 ```jldoctest
 julia> t = literature_model(31)
 Assuming that the first row of the given grading is the grading under Kbar
@@ -1071,10 +1072,12 @@ end
 
 @doc raw"""
     global_gauge_quotients(m::AbstractFTheoryModel)
-Return list of lists of matrices, where each list of matrices corresponds to a gauge factor of the same index given by gauge_algebra(m).
+
+Return list of lists of matrices, where each list of matrices corresponds to a gauge factor of the same index given by `gauge_algebra(m)`.
 These matrices are elements of the center of the corresponding gauge factor and quotienting by them replicates the action of some discrete group on the center of the lie algebra.
-This list combined with gauge_algebra(m) completely determines the gauge group of the model.
+This list combined with `gauge_algebra(m)` completely determines the gauge group of the model.
 If no gauge quotients are known, an error is raised.
+
 ```jldoctest
 julia> t = literature_model(arxiv_id = "1408.4808", equation = "3.190", type = "hypersurface")
 Assuming that the first row of the given grading is the grading under Kbar

--- a/experimental/FTheoryTools/src/FamilyOfSpaces/constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfSpaces/constructors.jl
@@ -10,17 +10,17 @@ families of F-theory models, defined by using a family of
 base spaces for an elliptic fibration. It is specified by
 the following data:
 * A polynomial ring. This may be thought of as the coordinate
-ring of the generic member in this family of spaces.
+  ring of the generic member in this family of spaces.
 * A grading for this polynomial ring. This may be thought of as
-specifying certain line bundles on the generic member in this
-family of spaces. Of particular interest for F-theory is always
-the canonical bundle. For this reason, the first row is always
-thought of as grading the coordinate ring with regard to the
-canonical bundle. Or put differently, if a variable shares the
-weight 1 in the first row, then this means that we should think
-of this coordinate as a section of 1 times the canonical bundle.
+  specifying certain line bundles on the generic member in this
+  family of spaces. Of particular interest for F-theory is always
+  the canonical bundle. For this reason, the first row is always
+  thought of as grading the coordinate ring with regard to the
+  canonical bundle. Or put differently, if a variable shares the
+  weight 1 in the first row, then this means that we should think
+  of this coordinate as a section of 1 times the canonical bundle.
 * An integer, which specifies the dimension of the generic member
-within this family of spaces.
+  within this family of spaces.
 
 Note that the coordinate ring can have strictly more variables than
 the dimension. This is a desired feature for most, if not all,


### PR DESCRIPTION
The first commit removes some randomness from docstring CI jobs, see e.g. https://github.com/oscar-system/Oscar.jl/actions/runs/10177764583/job/28149948856?pr=3980#step:8:636. Almost all doctests handling the qsm model had this setup already, but two were missing.

The second commit contains some trivial formatting fixes of issues I found while looking for all places where `ensure_artifact_installed` is missing.