### PR TITLE
fix Lloyd's problem - kind off

### DIFF
--- a/src/NumberTheory/GaloisGrp/GaloisGrp.jl
+++ b/src/NumberTheory/GaloisGrp/GaloisGrp.jl
@@ -25,6 +25,7 @@ function __init__()
   GAP.Packages.load("ferret"; install=true)
 
   Hecke.add_verbosity_scope(:GaloisGroup)
+  Hecke.add_assertion_scope(:GaloisGroup)
   Hecke.add_verbosity_scope(:GaloisInvariant)
   Hecke.add_assertion_scope(:GaloisInvariant)
 end
@@ -2232,7 +2233,7 @@ function find_transformation(r, I::Vector{<:SLPoly}; RNG::AbstractRNG = Random.d
       cnt += 1
       cnt > 20 && error("no Tschirni found")
       ts = rand(RNG, Zx, 2:rand(2:max(2, length(r))), -4:4) #TODO: try smaller degrees stronger
-      if degree(ts) > 0
+      if degree(ts) > 0 
         break
       end
     end
@@ -2346,7 +2347,6 @@ function fixed_field(GC::GaloisCtx, U::PermGroup, extra::Int = 5)
   ps = [val]
   d = copy(conj)
   while length(ps) < m
-#    @show length(ps)
     @vtime :GaloisGroup 2 d .*= conj
     fl, val = isinteger(GC, B, sum(d))
     @assert fl

--- a/src/NumberTheory/GaloisGrp/RelGalois.jl
+++ b/src/NumberTheory/GaloisGrp/RelGalois.jl
@@ -14,6 +14,12 @@ function galois_group(mkK::Map{AbsSimpleNumField, AbsSimpleNumField})
   return image(h)[1]
 end
 
+mutable struct recoCtx
+  Ml::ZZMatrix
+  pMr::Tuple{ZZMatrix, ZZRingElem, Hecke.fmpz_preinvn_struct}
+  pM::Tuple{ZZMatrix, ZZRingElem}
+end
+
 function GaloisCtx(f::PolyRingElem{AbsSimpleNumFieldElem}, P::AbsSimpleNumFieldOrderIdeal)
   k = base_ring(f)
   @assert k == Hecke.nf(order(P))
@@ -39,14 +45,20 @@ function GaloisCtx(f::PolyRingElem{AbsSimpleNumFieldElem}, P::AbsSimpleNumFieldO
   else
     den = derivative(defining_polynomial(k))(gen(k))
   end
-  C.data = [mC, 1, mCD, Hecke.norm_change_const(zk), den]
+  C.data = [mC, 1, mCD, Hecke.norm_change_const(zk), den, Dict{Int, recoCtx}()]
   #data:
   # [1] map into the completion. Careful, currently Q_p is returned and used as a deg-1 extension (ie. Qq)
   #     use only coeff(, 0)
   # [2] the current precision of the roots
   # [3] the embedding of completion of k into completion of K
-  # [4] as the namse suggest
+  # [4] as the name suggest
   # [5] the denominator used, f'(alpha), the Kronnecker rep
+  #     careful: there is (might be) a den from the non-monic poly. This
+  #     is "dealt with" in roots: the roots are automatically scaled by this
+  #     so they are mathematically integral
+  #     the den here is from any order to max order used to recognize 
+  #     integral elements in isinteger
+  # [6] Dict: mapping precision to reco data
 
   C.B = add_ring()(maximum([iroot(ceil(ZZRingElem, length(x)), 2)+1 for x = coefficients(f)]))
   return C
@@ -157,16 +169,31 @@ function Base.show(io::IO, C::GaloisCtx{Hecke.vanHoeijCtx})
   print(io, "GaloisCtx for computations modulo $(C.C.P)")
 end
 
-function Oscar.roots(C::GaloisCtx{Hecke.vanHoeijCtx}, pr::Int = 5; raw::Bool = true)
+function Oscar.roots(C::GaloisCtx{Hecke.vanHoeijCtx}, pr::Int = 5; raw::Bool = false)
   #TODO: deal with raw and denominators.
   if pr > C.data[2]
     setprecision!(codomain(C.data[1]), pr)
     setprecision!(codomain(C.data[3]), pr)
     C.C.H.f = map_coefficients(x->C.data[3](C.data[1](x)), C.f)
     Hecke.grow_prec!(C.C, pr)
+    C.data[6][pr] = recoCtx(C.C.Ml, C.C.pMr, C.C.pM)
     C.data[2] = pr
   end
-  return roots(C.C)
+  if pr < 0.8*C.data[2]
+    if false && !isone(C.data[5]) && !raw
+      d = setprecision(coeff(C.data[1](C.data[5]), 0), pr)
+      return [d*setprecision(x, pr) for x = roots(C.C)]
+    else
+      return [setprecision(x, pr) for x = roots(C.C)]
+    end
+  end
+  if false && !isone(C.data[5]) && !raw
+    d = coeff(C.data[1](C.data[5]), 0)
+    return [d*x for x = roots(C.C)]
+  else
+    r = roots(C.C)
+    return roots(C.C)
+  end
 end
   
 
@@ -182,10 +209,26 @@ function isinteger(C::GaloisCtx{Hecke.vanHoeijCtx}, y::BoundRingElem{ZZRingElem}
   @assert parent(x) == d
   P = C.C.P
   zk = order(P)
-  x *= map_coeff(C, C.data[5]) #the den
-  a = Hecke.nf(zk)(Hecke.reco(zk(preimage(mkc, c(coeff(x, 0)))), C.C.Ml, C.C.pMr))
+
+  x *= map_coeff(C, C.data[5]) #the den of any in max order
+  pr = precision(x)
+  if !haskey(C.data[6], pr)
+    #copied from grow_prec! in Hecke
+    # I think the preinvn is not used
+    @vtime :PolyFactor 2 X1 = C.C.P^pr
+    @vtime :PolyFactor 2 X2 = basis_matrix(X1)
+    @vtime :PolyFactor 2 Ml = lll(X2)
+    @vtime :PolyFactor 2 F = Hecke.FakeFmpqMat(pseudo_inv(Ml))
+    #(M*B)^-1 = B^-1 * M^-1, so I need basis_mat_inv(zk) * pM
+    pMr = (F.num, F.den, Hecke.fmpz_preinvn_struct(2*F.den))
+    C.data[6][pr] = recoCtx(Ml, pMr, (F.num, F.den))
+  end
+
+  r = C.data[6][pr]
+  a = Hecke.nf(zk)(Hecke.reco(zk(preimage(mkc, c(coeff(x, 0)))), r.Ml, r.pMr))
   a = a*inv(C.data[5])
   if ceil(ZZRingElem, length(a)) <= value(y)^2
+    @hassert :GaloisGroup 2 is_integral(a)
     return true, a
   else
     return false, a
@@ -197,7 +240,7 @@ function map_coeff(C::GaloisCtx{Hecke.vanHoeijCtx}, x)
   return coeff(C.data[1](x), 0)
 end
 
-function bound_to_precision(C::GaloisCtx{Hecke.vanHoeijCtx}, y::BoundRingElem{ZZRingElem}, extra::Int = 0)
+function bound_to_precision(C::GaloisCtx{Hecke.vanHoeijCtx}, y::BoundRingElem{ZZRingElem}, extra::Int = 10)
   #the bound is a bound on the sqrt(T_2(x)). This needs to be used with the norm_change stuff
   #and possible denominators and such. Possibly using Kronecker...
   c1, c2 = C.data[4] # the norm-change-const
@@ -208,11 +251,14 @@ function bound_to_precision(C::GaloisCtx{Hecke.vanHoeijCtx}, y::BoundRingElem{ZZ
   #needs to be coordinated with isinteger
 
   #step 2: copy the precision estimate from NumField/NfAbs/PolyFactor.jl
+  #step 3: be careful: x*den being integral (and small enough) does not mean x
+  #        is correct. Using extra makes this virtually certain though
+  #        otherwise, the minpoly (or charpoly) is called for
   P = C.C.P
   zk = order(P)
   k = Hecke.nf(zk)
   N = ceil(Int, degree(k)/2/log(norm(P))*(log(c1*c2) + 2*log(v)))
-  return N
+  return N + extra
 end
 
 function galois_group(f::PolyRingElem{AbsSimpleNumFieldElem}, ::QQField)
@@ -249,7 +295,5 @@ function galois_group(f::PolyRingElem{AbsSimpleNumFieldElem}, ::QQField)
     error("should not happen")
   end
 
-  global last_N = N
-  @show N
   return galois_group(N)
 end

--- a/test/NumberTheory/galthy.jl
+++ b/test/NumberTheory/galthy.jl
@@ -90,15 +90,17 @@ sample_cycle_structures(G::PermGroup) = Set(cycle_structure(rand_pseudo(G)) for 
   end
 end
 
-@testset "Lloyd" begin
-  R, s = Oscar.polynomial_ring(Oscar.QQ, "s")
-  K, q = Oscar.number_field(s^2 - 2, "q")
-  commutvPolyRing, w = Oscar.polynomial_ring(K, "w")
+@testset "Galois group issue" begin
+  # Contributed by "Lloyd" on slack
+  R, s = QQ["s"]
+  K, q = number_field(s^2 - 2, "q")
+  Kw, w = polynomial_ring(K, "w")
   f = w^16 - 32*w^14 - 192*w^12 + 22720*w^10 + 23104*w^8 - 2580480*w^6 + 41287680*w^4 + 106168320*w^2 + 84934656
   g, s = galois_group(f)
   @test order(g) == 1536
   ss = subgroup_reps(g)
   #should be of order 16, so field of degree 96
-  f = fixed_field(s, ss[1000])
-  @test degree(f) == order(g)//order(ss[1000])
+  H = ss[1000]
+  f = fixed_field(s, H)
+  @test degree(f) == order(g)//order(H)
 end

--- a/test/NumberTheory/galthy.jl
+++ b/test/NumberTheory/galthy.jl
@@ -89,3 +89,16 @@ sample_cycle_structures(G::PermGroup) = Set(cycle_structure(rand_pseudo(G)) for 
     @test small_group_identification(G) == (4, 2)
   end
 end
+
+@testset "Lloyd" begin
+  R, s = Oscar.polynomial_ring(Oscar.QQ, "s")
+  K, q = Oscar.number_field(s^2 - 2, "q")
+  commutvPolyRing, w = Oscar.polynomial_ring(K, "w")
+  f = w^16 - 32*w^14 - 192*w^12 + 22720*w^10 + 23104*w^8 - 2580480*w^6 + 41287680*w^4 + 106168320*w^2 + 84934656
+  g, s = galois_group(f)
+  @test order(g) == 1536
+  ss = subgroup_reps(g)
+  #should be of order 16, so field of degree 96
+  f = fixed_field(s, ss[1000])
+  @test degree(f) == order(g)//order(ss[1000])
+end


### PR DESCRIPTION
He reported problems with fixed_field, however the galois group was wrong...
Problem(s)
 - isinteger uses the reco stuff from poly factor in Hecke. It assumes that the precision is strictly increasing and that only the max precision is used, Galois needs to jump down (at least for eficiency)
 - if the reco for a huge precisino is used on a small element, it will always succeed, being mapped to identity in this case
 - the extra bits of precision were ignored
 - the test for isinteger should possibly actually call is_integer in the end to use the minpoly test Alternatively: extra precision is used here
 - there are 2 different denominators involved here:
   - to make the roots of the poly algebraic integers
   - the difference bewtween any_order and the ring of integers Currently, the rel galois code will fails for non-monic polys - I think