### PR TITLE
[ToricVarieties] Introduce Chern classes of tangent bundle

### DIFF
--- a/docs/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses.md
@@ -64,4 +64,6 @@ integrate(c::CohomologyClass; check::Bool = true)
 cohomology_ring(v::NormalToricVarietyType; check::Bool = true)
 volume_form(v::NormalToricVariety)
 intersection_form(v::NormalToricVariety)
+chern_class(v::NormalToricVariety, k::Int; check::Bool = true)
+chern_classes(v::NormalToricVariety; check::Bool = true)
 ```

--- a/experimental/IntersectionTheory/src/IntersectionTheory.jl
+++ b/experimental/IntersectionTheory/src/IntersectionTheory.jl
@@ -8,6 +8,7 @@ import ..Oscar.AbstractAlgebra: combinations
 import ..Oscar.AbstractAlgebra.Generic: FunctionalMap
 import..Oscar: pullback, pushforward, base, OO, product, compose
 import ..Oscar: trivial_line_bundle
+import ..Oscar: chern_class
 
 export a_hat_genus
 export abstract_bundle

--- a/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/special_attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/special_attributes.jl
@@ -169,6 +169,7 @@ function chern_class(v::NormalToricVariety, k::Int; check::Bool = true)
   end
 
   # Ensure that we compute the cohomology ring with the desired by-pass of checks.
+  # Coefficients of the cohomology ring inherited from NormalToricVariety.
   cohomology_ring(v, check = check)
 
   # Compute, set and return the desired Chern class

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -318,6 +318,8 @@ export character_table
 export character_to_rational_function
 export characteristic_subgroups, has_characteristic_subgroups, set_characteristic_subgroups
 export charpoly
+export chern_class
+export chern_classes
 export chief_series, has_chief_series, set_chief_series
 export chow_ring
 export circuits


### PR DESCRIPTION
This PR is inspired by developments in `FTheoryTools`. It aims to provide functionality to compute the Chern classes of the tangent bundle of a simplicial and complete toric variety.