### PR TITLE
`subgroup_reps` is deprecated

### DIFF
--- a/test/NumberTheory/galthy.jl
+++ b/test/NumberTheory/galthy.jl
@@ -98,7 +98,7 @@ end
   f = w^16 - 32*w^14 - 192*w^12 + 22720*w^10 + 23104*w^8 - 2580480*w^6 + 41287680*w^4 + 106168320*w^2 + 84934656
   g, s = galois_group(f)
   @test order(g) == 1536
-  ss = subgroup_reps(g)
+  ss = map(representative, subgroup_classes(g))
   #should be of order 16, so field of degree 96
   H = ss[1000]
   f = fixed_field(s, H)


### PR DESCRIPTION
The `depwarn=true` CI job fails since #3993 got merged.
