### PR TITLE
Include correct doc string

### DIFF
--- a/docs/src/AlgebraicGeometry/Schemes/RationalPointsProjective.md
+++ b/docs/src/AlgebraicGeometry/Schemes/RationalPointsProjective.md
@@ -12,7 +12,7 @@ using Oscar
 AbsProjectiveRationalPoint
 ProjectiveRationalPoint
 coordinates(P::ProjectiveRationalPoint)
-ideal(P::ProjectiveRationalPoint)
+ideal(P::AbsProjectiveRationalPoint)
 scheme(P::ProjectiveRationalPoint)
 normalize!(a::AbsProjectiveRationalPoint{<:FieldElem})
 normalize!(a::AbsProjectiveRationalPoint{ZZRingElem})


### PR DESCRIPTION
Without this, Documenter seems to include every `ideal` doc string, see https://docs.oscar-system.org/stable/AlgebraicGeometry/Schemes/RationalPointsProjective .
