### PR TITLE
Include correct doc string

### DIFF
--- a/docs/src/AlgebraicGeometry/Schemes/RationalPointsProjective.md
+++ b/docs/src/AlgebraicGeometry/Schemes/RationalPointsProjective.md
@@ -12,7 +12,7 @@ using Oscar
 AbsProjectiveRationalPoint
 ProjectiveRationalPoint
 coordinates(P::ProjectiveRationalPoint)
-ideal(P::ProjectiveRationalPoint)
+ideal(P::AbsProjectiveRationalPoint)
 scheme(P::ProjectiveRationalPoint)
 normalize!(a::AbsProjectiveRationalPoint{<:FieldElem})
 normalize!(a::AbsProjectiveRationalPoint{ZZRingElem})


### PR DESCRIPTION
Without this, Documenter seems to include every `ideal` doc string.

Same as #4003 but now with a branch in oscar-system so that there is a preview: https://docs.oscar-system.org/previews/PR4005/AlgebraicGeometry/Schemes/RationalPointsProjective/ .
