### PR TITLE
[FTheoryTools] More on serialization of FTheoryTools

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,10 +1,10 @@
 [QSMDB]
-git-tree-sha1 = "5c82e5ff3aa99f2aa660c9ffb3caa57ee535cc21"
+git-tree-sha1 = "52686066016440cf2e6e286a923aed887658543c"
 lazy = true
 
      [[QSMDB.download]]
-     sha256 = "3f69aae0fca02d74764f709c622388c564e6e144a8b11347dadef5725a65b0a2"
-     url = "https://github.com/oscar-system/Oscar.jl/releases/download/archive-tag-1/qsmdb.tar.gz"     
+     sha256 = "2b0a368c07d368f3973352b7f6e856214e25383d2cc3a78c70415afe247a997e"
+     url = "https://github.com/oscar-system/Oscar.jl/releases/download/archive-tag-1/QSMDB-2.tar.gz"     
 
 [gap_extraperfect]
 git-tree-sha1 = "084fa12573e5089ceb3299f9d341f244b415da52"

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
@@ -1741,7 +1741,7 @@ end
 
 
 @doc raw"""
-    simplified dual_graph(m::AbstractFTheoryModel)
+    simplified_dual_graph(m::AbstractFTheoryModel)
 
 This method returns the simplified dual graph of the QSM model in question.
 Note that no labels are (currently) attached to the vertices/nodes or edges.

--- a/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
@@ -72,7 +72,7 @@ function hypersurface_model(base::NormalToricVariety, fiber_ambient_space::Norma
   @req length(ds) == 1 "Inconsistency in determining the degree of the hypersurface equation"
   @req ds[1] == divisor_class(anticanonical_divisor_class(ambient_space)).coeff "Degree of hypersurface equation differs from anticanonical bundle"
   explicit_model_sections = Dict{String, MPolyRingElem}()
-  gens_S = gens(cox_ring(ambient_space))
+  gens_S = gens(cox_ring(base))
   for k in 1:length(gens_S)
     explicit_model_sections[string(gens_S[k])] = gens_S[k]
   end

--- a/experimental/FTheoryTools/src/Serialization/hypersurface_models.jl
+++ b/experimental/FTheoryTools/src/Serialization/hypersurface_models.jl
@@ -66,16 +66,17 @@ end
 ##########################################
 
 function load_object(s::DeserializerState, ::Type{<:HypersurfaceModel}, params::Tuple{NormalToricVariety, NormalToricVariety, NormalToricVariety, <:MPolyRing, <:MPolyRing})
-  base_space, ambient_space, fiber_ambient_space, R1, R2 = params
+  base_space, amb_space, fiber_ambient_space, R1, R2 = params
   defining_equation = load_object(s, MPolyRingElem, R1, :hypersurface_equation)
   defining_equation_parametrization = load_object(s, MPolyRingElem, R2, :hypersurface_equation_parametrization)
   explicit_model_sections = haskey(s, :explicit_model_sections) ? load_typed_object(s, :explicit_model_sections) : Dict{String, MPolyRingElem}()
   defining_classes = haskey(s, :defining_classes) ? load_typed_object(s, :defining_classes) : Dict{String, ToricDivisorClass}()
-  model = HypersurfaceModel(explicit_model_sections, defining_equation_parametrization, defining_equation, base_space, ambient_space, fiber_ambient_space)
+  model = HypersurfaceModel(explicit_model_sections, defining_equation_parametrization, defining_equation, base_space, amb_space, fiber_ambient_space)
   model.defining_classes = defining_classes
   attrs_data = haskey(s, :__attrs) ? load_typed_object(s, :__attrs) : Dict{Symbol, Any}()
   for (key, value) in attrs_data
     set_attribute!(model, Symbol(key), value)
   end
+  @req cox_ring(ambient_space(model)) == parent(hypersurface_equation(model)) "Hypersurface polynomial not in Cox ring of toric ambient space"
   return model
 end

--- a/experimental/FTheoryTools/src/Serialization/qsm_models.jl
+++ b/experimental/FTheoryTools/src/Serialization/qsm_models.jl
@@ -72,11 +72,11 @@ function load_object(s::DeserializerState, ::Type{QSMModel})
     :genus_of_components_of_simplified_dual_graph
   )
 
-  h = hypersurface_equation(hs_model)
-  S = cox_ring(ambient_space(hs_model))
-  var_names = symbols(parent(h))
-  S.R.S = var_names
-  hs_model.hypersurface_equation = Oscar.eval_poly(string(h), S)
+  #h = hypersurface_equation(hs_model)
+  #S = cox_ring(ambient_space(hs_model))
+  #var_names = symbols(parent(h))
+  #S.R.S = var_names
+  #hs_model.hypersurface_equation = Oscar.eval_poly(string(h), S)
 
   return QSMModel(vertices,
                   poly_index,

--- a/experimental/FTheoryTools/src/Serialization/tate_models.jl
+++ b/experimental/FTheoryTools/src/Serialization/tate_models.jl
@@ -8,7 +8,6 @@ function save_type_params(s::SerializerState, gtm::GlobalTateModel)
   save_data_dict(s) do
     save_object(s, encode_type(GlobalTateModel), :name)
     base, ambient, tp_ring = base_space(gtm), ambient_space(gtm), parent(tate_polynomial(gtm))
-
     save_data_dict(s, :params) do
       for (obj, key) in [(base, :base_space), (ambient, :ambient_space), (tp_ring, :tate_polynomial_ring)]
         if serialize_with_id(obj)
@@ -68,16 +67,17 @@ end
 #########################################
 
 function load_object(s::DeserializerState, ::Type{<: GlobalTateModel}, params::Tuple{NormalToricVariety, NormalToricVariety, MPolyDecRing})
-  base_space, ambient_space, tp_ring = params
+  base_space, amb_space, tp_ring = params
   pt = load_object(s, MPolyDecRingElem, tp_ring, :tate_polynomial)
   explicit_model_sections = haskey(s, :explicit_model_sections) ? load_typed_object(s, :explicit_model_sections) : Dict{String, MPolyRingElem}()
   defining_section_parametrization = haskey(s, :defining_section_parametrization) ? load_typed_object(s, :defining_section_parametrization) : Dict{String, MPolyRingElem}()
   defining_classes = haskey(s, :defining_classes) ? load_typed_object(s, :defining_classes) : Dict{String, ToricDivisorClass}()
-  model = GlobalTateModel(explicit_model_sections, defining_section_parametrization, pt, base_space, ambient_space)
+  model = GlobalTateModel(explicit_model_sections, defining_section_parametrization, pt, base_space, amb_space)
   model.defining_classes = defining_classes
   attrs_data = haskey(s, :__attrs) ? load_typed_object(s, :__attrs) : Dict{Symbol, Any}()
   for (key, value) in attrs_data
     set_attribute!(model, Symbol(key), value)
   end
+  @req cox_ring(ambient_space(model)) == parent(tate_polynomial(model)) "Tate polynomial not in Cox ring of toric ambient space"
   return model
 end

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -749,7 +749,14 @@ Map
 @attr FinGenAbGroupHom function map_from_torusinvariant_weil_divisor_group_to_class_group(v::NormalToricVarietyType)
     map1 = cokernel(map_from_character_lattice_to_torusinvariant_weil_divisor_group(v))[2]
     map2 = inv(snf(codomain(map1))[2])
-    return map1*map2
+    # we cannot call class_group unless the attribute exists
+    # but we need to make sure to have the correct codomain if it does exist
+    if has_attribute(v, :class_group)
+      cg = class_group(v)
+      return map1*map2*hom(codomain(map2), cg, gens(cg))
+    else
+      return map1*map2
+    end
 end
 
 

--- a/src/Serialization/ToricGeometry.jl
+++ b/src/Serialization/ToricGeometry.jl
@@ -2,7 +2,7 @@
 # Toric varieties
 @register_serialization_type AffineNormalToricVariety uses_id
 
-@register_serialization_type NormalToricVariety uses_id [:cox_ring]
+@register_serialization_type NormalToricVariety uses_id [:cox_ring, :class_group]
 
 
 function save_object(s::SerializerState, ntv::T) where T <: NormalToricVarietyType


### PR DESCRIPTION
 As mentioned in the other PRs, it seemed natural to group all the different serialization discussions we had in one PR. For this, I need your help @antonydellavecchia whenever you are ready (not urgent).

Points to be addressed in this PR include (but are not necessarily limited to the following):
* The coordinates of the base space and ambient space should be remembered upon serialization. I will try to add a first step towards this goal in this PR/draft. As I see it, this requires that we add a list of strings (or symbols?) to the serialization of the models. An update of the QSM model artifacts is then needed.

The below points were initially meant to be fixed in this PR, but we (@antonydellavecchia and I) decided that it will be better to deal with them in separate PRs.

* Along these lines, we could also consider serialzing G4-fluxes (a.k.a. cohomology classes on toric spaces). At least for the QSMs, there is each time a specifically chosen G4-fluxes (cf. https://arxiv.org/pdf/2102.10115, equ. 2.25).
* Maybe wait for https://github.com/oscar-system/Oscar.jl/pull/3980 and include the Lie algebras of the FTheoryModels in the serialization. In particular, this should be also applied to the QSM models.
* Add an artifact for the model discussed in https://github.com/oscar-system/Oscar.jl/pull/3978. I have the corresponding .mrdi files and will be happy to share e.g. in slack or email. (This cannot be added here as github does not seem to support .mrdi files yet. And then, the files are about 0.5GB in size. So maybe best not to add them here.)
* Make use of the attribute saver that @antonydellavecchia is working on (cf. https://github.com/oscar-system/Oscar.jl/pull/4020). For instance, currently the known resolutions are not saved for FTheory models.

cc @antonydellavecchia @emikelsons @apturner 