### PR TITLE
Optimize printing for ideals with many generators

### DIFF
--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -1932,13 +1932,23 @@ function Base.show(io::IO, ::MIME"text/plain", I::MPolyAnyIdeal)
 end
 
 function _get_generators_string_one_line(I::MPolyAnyIdeal, character_limit::Int = 100)
-  # Try a full list of generators if it fits $character_limit characters
+  # Try a full list of generators if it fits $character_limit characters, otherwise
+  # print `default`
+  default = "with $(ItemQuantity(ngens(I), "generator"))"
+
+  if ngens(I)*3 > character_limit
+    # We need at least 3 characters (generator, comma, space) per generator, so
+    # we don't need to build the whole string
+    return default
+  end
+
+  # Generate the full string
   gen_string = "("*join(gens(I), ", ")*")"
   if length(gen_string) <= character_limit
     return gen_string
   end
 
-  return "with $(ItemQuantity(ngens(I), "generator"))"
+  return default
 end
 
 function Base.show(io::IO, I::MPolyAnyIdeal)

--- a/test/Rings/mpolyquo-localizations.jl
+++ b/test/Rings/mpolyquo-localizations.jl
@@ -503,3 +503,10 @@ end
   @test modulus(Al3) == Il3
 end
 
+@testset "MPolyAnyIdeal printing" begin
+  R, x = polynomial_ring(QQ, 100, "x")
+  @test Oscar._get_generators_string_one_line(ideal(R, [x[1]])) == "(x1)"
+  @test Oscar._get_generators_string_one_line(ideal(R, [x[1], x[2]])) == "(x1, x2)"
+  @test Oscar._get_generators_string_one_line(ideal(R, x)) == "with 100 generators"
+  @test Oscar._get_generators_string_one_line(ideal(R, [sum(x)])) == "with 1 generator"
+end


### PR DESCRIPTION
I managed to create an ideal with ~9000 generators, for which the `oneline` printing took several seconds (to eventually just put `Ideal with 9000 generators`).
This should make the printing faster in this case.
