### PR TITLE
support group extensions of matrix groups

### DIFF
--- a/docs/src/Groups/pcgroup.md
+++ b/docs/src/Groups/pcgroup.md
@@ -14,6 +14,7 @@ map_word(g::Union{PcGroupElem, SubPcGroupElem}, genimgs::Vector; genimgs_inv::Ve
 Julia has the following functions that allow to generate polycyclic groups:
 ```@docs
 abelian_group(::Type{T}, v::Vector{Int}) where T <: GAPGroup
+elementary_abelian_group
 cyclic_group
 dihedral_group
 quaternion_group

--- a/experimental/GModule/src/Cohomology.jl
+++ b/experimental/GModule/src/Cohomology.jl
@@ -1705,10 +1705,10 @@ returns (I, q), (hom(Z[G], C), B)
 function dimension_shift(C::GModule)
   G = C.G
   if isa(C.M, FinGenAbGroup)
-    zg, ac, em = Oscar.GModuleFromGap.natural_gmodule(FinGenAbGroup, G, ZZ)
+    zg, ac, em = regular_gmodule(FinGenAbGroup, G, ZZ)
     Z = Hecke.zero_obj(zg.M)
   elseif isa(C.M, AbstractAlgebra.FPModule{<:FieldElem})
-    zg, ac, em = Oscar.GModuleFromGap.natural_gmodule(G, base_ring(C))
+    zg, ac, em = regular_gmodule(G, base_ring(C))
     Z = free_module(base_ring(C), 0)
   else
     error("unsupported module")
@@ -1751,10 +1751,10 @@ end
 function dimension_shift_left(C::GModule)
   G = C.G
   if isa(C.M, FinGenAbGroup)
-    zg, ac, em = Oscar.GModuleFromGap.natural_gmodule(FinGenAbGroup, G, ZZ)
+    zg, ac, em = regular_gmodule(FinGenAbGroup, G, ZZ)
     Z = Hecke.zero_obj(zg.M)
   elseif isa(C.M, AbstractAlgebra.FPModule{<:FieldElem})
-    zg, ac, em = Oscar.GModuleFromGap.natural_gmodule(G, base_ring(C))
+    zg, ac, em = regular_gmodule(G, base_ring(C))
     Z = free_module(base_ring(C), 0)
   else
     error("unsupported module")

--- a/experimental/GModule/src/Cohomology.jl
+++ b/experimental/GModule/src/Cohomology.jl
@@ -184,22 +184,9 @@ function inv_action(C::GModule)
 end
 
 function fp_group_with_isomorphism(C::GModule)
-  #TODO: better for PcGroup!!!
-  G = group(C)
   if !isdefined(C, :F)
-    if (!isa(G, FPGroup)) && is_trivial(G)
-      C.F = free_group(0)
-      C.mF = hom(G, C.F, elem_type(G)[], elem_type(C.F)[])
-    elseif isa(group(C), PcGroup) && GAP.Globals.GeneratorsOfGroup(G.X) == GAP.Globals.Pcgs(G.X)
-      X = GAPWrap.IsomorphismFpGroupByPcgs(GAP.Globals.InducedPcgsWrtFamilyPcgs(G.X), GAP.julia_to_gap("a"))
-
-      C.F = FPGroup(GAPWrap.Range(X))
-      C.mF = GAPGroupHomomorphism(G, C.F, X)
-      return C.F, C.mF
-    else
-      C.F, C.mF = fp_group_with_isomorphism(gens(G))
-#      C.mF = GAPGroupHomomorphism(C.F, group(C), GAP.Globals.InverseGeneralMapping(C.mF.map))
-    end
+    iso = isomorphism(FPGroup, group(C), on_gens=true)
+    C.F, C.mF = codomain(iso), iso
   end
   return C.F, C.mF
 end
@@ -551,17 +538,6 @@ Oscar.group(C::GModule) = C.G
 ###########################################################
 
 """
-Compute an fp-presentation of the common parent 'G' of 'g'
-and return both the group and the map from 'G' to the new group.
-"""
-function fp_group_with_isomorphism(g::Vector{<:Oscar.GAPGroupElem})
-  G = parent(g[1])
-  @assert all(x->parent(x) == G, g)
-  iso = isomorphism(FPGroup, G, on_gens=true)
-  return codomain(iso), iso
-end
-
-"""
 For an element of an fp-group, return a corresponding word as a sequence
 of integers. A positive integers indicates the corresponding generator,
 a negative one the inverse.
@@ -572,39 +548,18 @@ function word(y::FPGroupElem)
 end
 
 """
-The relations defining 'F' as an array of pairs.
+The relations defining 'G' as an array of pairs.
 """
-function _relations_by_generators(G::Oscar.GAPGroup)
-   f = GAPWrap.IsomorphismFpGroupByGenerators(GapObj(G), GAPWrap.GeneratorsOfGroup(GapObj(G)))
-   @req f != GAP.Globals.fail "Could not convert group into a group of type FPGroup"
-   H = FPGroup(GAPWrap.Image(f))
-   return relations(H)
+function Oscar.relations(G::Oscar.GAPGroup)
+  rels = relators(G)
+  if length(rels) == 0
+    T = eltype(rels)
+    return Tuple{T,T}[]
+  end
+  z = one(parent(rels[1]))
+  return [(x, z) for x in rels]
 end
 
-Oscar.relations(G::Oscar.GAPGroup) = _relations_by_generators(G)
-
-function Oscar.relations(F::Union{FPGroup, SubFPGroup})
-  Oscar._is_full_fp_group(GapObj(F)) || return _relations_by_generators(F)
-  R = relators(F)
-  z = one(free_group(F))
-  return [(x, z) for x = R]
-end
-
-function Oscar.relators(F::PcGroup)
-  #TODO: do it properly!!!!
-  return [x[1] for x = relations(F)]
-end
-
-function Oscar.relations(G::PcGroup)
-   # Call `GAPWrap.IsomorphismFpGroupByPcgs` only if `gens(G)` is a pcgs.
-   Ggens = GAPWrap.GeneratorsOfGroup(GapObj(G))
-   Gpcgs = GAPWrap.Pcgs(GapObj(G))
-   Ggens == Gpcgs || return _relations_by_generators(G)
-   f = GAPWrap.IsomorphismFpGroupByPcgs(Gpcgs, GAP.Obj("g"))
-   @req f != GAP.Globals.fail "Could not convert group into a group of type FPGroup"
-   H = FPGroup(GAPWrap.Image(f))
-   return relations(H)
-end
 
 ######################################################
 #
@@ -1853,12 +1808,12 @@ function cohomology_group(C::GModule, i::Int; Tate::Bool = false)
   error("only H^0, H^1 and H^2 are supported")
 end
 
-# return an f.p. group `F` and an isomorphism `M -> F`
+# better use `isomorphism` directly
 function fp_group_with_isomorphism(M::AbstractAlgebra.FPModule{<:FinFieldElem})
-  p, mp = pc_group_with_isomorphism(M, refine = false)
-  mf = isomorphism(FPGroup, p)
-  return codomain(mf), mf*mp
+  iso = isomorphism(FPGroup, M, on_gens=true)
+  return codomain(iso), iso
 end
+
 
 #########################################################
 function Oscar.matrix(M::FreeModuleHom{FreeMod{QQAbFieldElem}, FreeMod{QQAbFieldElem}})
@@ -1973,81 +1928,12 @@ function pc_group_with_isomorphism(M::FinGenAbGroup; refine::Bool = true)
     x->image(mM, gap_to_julia(GapObj(x))))
 end
 
+# `refine` is irrelevant because `M` is elementary abelian.
 function pc_group_with_isomorphism(M::AbstractAlgebra.FPModule{<:FinFieldElem}; refine::Bool = true)
-  k = base_ring(M)
-  p = characteristic(k)
-
-  G = free_group(degree(k)*dim(M))
-
-  C = GAP.Globals.CombinatorialCollector(GapObj(G),
-                  GAP.Obj([p for i=1:ngens(G)]; recursive = true))
-  F = GAP.Globals.FamilyObj(GAP.Globals.Identity(GapObj(G)))
-
-  # Note that we have specified all relative orders as `p`.
-  # Missing commutator and power relators are interpreted as trivial,
-  # thus `C` describes an elementary abelian group.
-  B = PcGroup(GAP.Globals.GroupByRws(C))
-  @assert is_abelian(B)
-  @assert order(B) == order(M)
-
-  FB = GAP.Globals.FamilyObj(GAP.Globals.Identity(GapObj(B)))
-
-  function Julia_to_gap(a::AbstractAlgebra.FPModuleElem{<:Union{fpFieldElem, FpFieldElem, FqFieldElem}})
-    F = base_ring(parent(a))
-    @assert absolute_degree(F) == 1
-    r = ZZRingElem[]
-    for i=1:ngens(M)
-      if !iszero(a[i])
-        push!(r, i)
-        push!(r, lift(ZZ, a[i]))
-      end
-    end
-    g = GAP.Globals.ObjByExtRep(FB, GAP.Obj(r; recursive = true))
-    return g
-  end
-
-  function Julia_to_gap(a::AbstractAlgebra.FPModuleElem{<:Union{FqPolyRepFieldElem, fqPolyRepFieldElem}})
-    r = ZZRingElem[]
-    for i=1:ngens(M)
-      if !iszero(a[i])
-        for j=0:degree(k)-1
-          if !iszero(coeff(a[i], j))
-            push!(r, (i-1)*degree(k)+j+1)
-            push!(r, ZZ(coeff(a[i], j)))
-          end
-        end
-      end
-    end
-    g = GAP.Globals.ObjByExtRep(FB, GAP.Obj(r; recursive = true))
-    return g
-  end
-
-
-  gap_to_julia = function(a::GapObj)
-    e = GAPWrap.ExtRepOfObj(a)
-    z = zeros(ZZRingElem, ngens(M)*degree(k))
-    for i=1:2:length(e)
-      if !iszero(e[i+1])
-        z[e[i]] = e[i+1]
-      end
-    end
-    c = elem_type(k)[]
-    for i=1:dim(M)
-      push!(c, k(z[(i-1)*degree(k)+1:i*degree(k)]))
-    end
-    return M(c)
-  end
-
-  return B, MapFromFunc(
-    M, B,
-    y->PcGroupElem(B, Julia_to_gap(y)),
-    x->gap_to_julia(GapObj(x)))
+  iso = isomorphism(PcGroup, M, on_gens=true)
+  return codomain(iso), iso
 end
 
-
-function underlying_word(g::FPGroupElem)
-  return FPGroupElem(free_group(parent(g)), GAPWrap.UnderlyingElement(GapObj(g)))
-end
 
 """
 Given a 2-cocycle, return the corresponding group extension, ie. the large
@@ -2061,7 +1947,7 @@ If the gmodule is defined via a pc-group and the 1st argument is the
 function extension(c::CoChain{2,<:Oscar.GAPGroupElem})
   C = c.C
   G = Group(C)
-  F, _ = fp_group_with_isomorphism(gens(G))
+  F = codomain(isomorphism(FPGroup, G, on_gens=true))
   M = Module(C)
   ac = action(C)
   iac = inv_action(C)

--- a/experimental/GModule/src/Cohomology.jl
+++ b/experimental/GModule/src/Cohomology.jl
@@ -759,14 +759,14 @@ end
 Evaluate a 2-cochain, a 2-cochain is a map from pairs of group elements
 into the module
 """
-function (C::CoChain{2})(g::Oscar.BasicGAPGroupElem, h::Oscar.BasicGAPGroupElem)
+function (C::CoChain{2})(g::Oscar.GAPGroupElem, h::Oscar.GAPGroupElem)
   if haskey(C.d, (g,h))
     return C.d[(g,h)]
   end
   @assert isdefined(C, :D)
   return C.d[(g,h)] = C.D((g, h))
 end
-(C::CoChain{2})(g::NTuple{2, <:Oscar.BasicGAPGroupElem}) = C(g[1], g[2])
+(C::CoChain{2})(g::NTuple{2, <:Oscar.GAPGroupElem}) = C(g[1], g[2])
 
 #TODO: re-write to get the maps! To support Q/Z as well
 """

--- a/experimental/GModule/test/runtests.jl
+++ b/experimental/GModule/test/runtests.jl
@@ -81,6 +81,46 @@ end
   @test length(Oscar.RepPc.brueckner(mq)) == 6
 end
 
+@testset "Experimental.gmodule natural G-modules" begin
+  # for permutation groups
+  G = symmetric_group(3)
+  M = natural_gmodule(G, GF(2))
+  cf = composition_factors_with_multiplicity(M)
+  @test sort([dim(x[1]) for x in cf]) == [1, 2]
+
+  # for matrix groups
+  G = SL(2, 3)
+  M = natural_gmodule(G)
+  cf = composition_factors_with_multiplicity(M)
+  @test length(cf) == 1 && cf[1][2] == 1
+end
+
+@testset "Experimental.gmodule regular G-modules" begin
+  # for permutation groups
+  G = symmetric_group(3)
+  R = GF(2)
+  M, f, g = regular_gmodule(G, R)
+  cf = composition_factors_with_multiplicity(M)
+  @test sort([dim(x[1]) for x in cf]) == [1, 2]
+  @test [x[2] for x in cf] == [2, 2]
+  N = natural_gmodule(G, R)
+  F = f(N)
+  V = M.M
+  @test all(i -> F(gen(V, Int(g(gen(G, i))))).matrix == matrix(N.ac[i]), 1:ngens(G))
+
+  @test map(g, collect(G)) == 1:order(G)
+  @test [preimage(g, i) for i in 1:order(G)] == collect(G)
+
+  # for pc groups
+  G = dihedral_group(8)
+  M, f, g = regular_gmodule(G, GF(3))
+  cf = composition_factors_with_multiplicity(M)
+  @test sort([dim(x[1]) for x in cf]) == [1, 1, 1, 1, 2]
+  @test all(x -> dim(x[1]) == x[2], cf)
+  @test map(g, collect(G)) == 1:order(G)
+  @test [preimage(g, i) for i in 1:order(G)] == collect(G)
+end
+
 @testset "Experimental.gmodule extension for matrix group" begin
   G = SL(2,3)
   F = GF(3)

--- a/experimental/GModule/test/runtests.jl
+++ b/experimental/GModule/test/runtests.jl
@@ -11,6 +11,7 @@
   F = FPGroup(G)
   @test testrels(F)             # full f.p. group
   @test testrels(center(F)[1])  # subgroup of full f.p. group
+  @test testrels(free_group(2)) # free group (empty relations)
   @test testrels(PermGroup(G))  # nothing of the above
 end
 
@@ -76,7 +77,7 @@ end
   z = irreducible_modules(ZZ, G)
   @test length(Oscar.GModuleFromGap.invariant_lattice_classes(z[3])) == 2
 
-  G = Oscar.GrpCoh.fp_group_with_isomorphism(gens(G))[1]
+  G = codomain(isomorphism(FPGroup, G, on_gens=true))
   q, mq = maximal_abelian_quotient(PcGroup, G)
   @test length(Oscar.RepPc.brueckner(mq)) == 6
 end

--- a/experimental/GModule/test/runtests.jl
+++ b/experimental/GModule/test/runtests.jl
@@ -81,6 +81,20 @@ end
   @test length(Oscar.RepPc.brueckner(mq)) == 6
 end
 
+@testset "Experimental.gmodule extension for matrix group" begin
+  G = SL(2,3)
+  F = GF(3)
+  m = free_module(F, 2)
+  M = GModule(m, G, [hom(m, m, matrix(a)) for a in gens(G)])
+  H2 = Oscar.GrpCoh.cohomology_group(M, 2)
+  x = collect(H2[1])[1]
+  c = H2[2](x)
+  e = extension(c)
+  GG = e[1]
+  @test order(GG) == 216
+  @test GG isa FPGroup
+end
+
 @testset "Experimental.gmodule SL(2,5)" begin
   G = SL(2, 5)
   T = character_table(G)

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1928,6 +1928,29 @@ function relators(G::FPGroup)
   return [group_element(F, L[i]::GapObj) for i in 1:length(L)]
 end
 
+function relators(G::PcGroup)
+  gapG = GapObj(G)
+  Ggens = GAPWrap.GeneratorsOfGroup(gapG)
+  Gpcgs = GAPWrap.Pcgs(gapG)
+  if Ggens == Gpcgs
+    # The generators form a pcgs, compute w.r.t. this pcgs.
+    f = GAPWrap.IsomorphismFpGroupByPcgs(Gpcgs, GapObj("g"))
+    @req f != GAP.Globals.fail "Could not convert group into a group of type FPGroup"
+    return relators(FPGroup(GAPWrap.Image(f)))
+  else
+    return _relators_by_generators(FPGroup(GAPWrap.Image(f)))
+  end
+end
+
+relators(G::GAPGroup) = _relators_by_generators(G)
+
+function _relators_by_generators(G::GAPGroup)
+  gapG = GapObj(G)
+  f = GAPWrap.IsomorphismFpGroupByGenerators(gapG, GAPWrap.GeneratorsOfGroup(gapG))
+  @req f != GAP.Globals.fail "Could not convert group into a group of type FPGroup"
+  return relators(FPGroup(GAPWrap.Image(f)))
+end
+
 
 @doc raw"""
     map_word(g::Union{FPGroupElem, SubFPGroupElem}, genimgs::Vector; genimgs_inv::Vector = Vector(undef, length(genimgs)), init = nothing)

--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -220,6 +220,44 @@ that is, $x*y = y*x$ holds for all elements $x, y$ in `G`.
 """
 @gapattribute is_abelian(G::GAPGroup) = GAP.Globals.IsAbelian(GapObj(G))::Bool
 
+
+@doc raw"""
+    elementary_abelian_group(::Type{T} = PcGroup, n::S) where T <: Group where S <: IntegerUnion
+
+Return the elementary abelian group group of order `n`, as an instance of `T`.
+Here, `T` must be one of `PermGroup`, `FPGroup`, `SubFPGroup`, `PcGroup`,
+`SubPcGroup`, or `FinGenAbGroup`.
+
+# Examples
+```jldoctest
+julia> g = elementary_abelian_group(27)
+Pc group of order 27
+
+julia> g = elementary_abelian_group(PermGroup, 27)
+Permutation group of degree 9 and order 27
+```
+"""
+elementary_abelian_group(n::IntegerUnion) = elementary_abelian_group(PcGroup, n)
+
+function elementary_abelian_group(::Type{T}, n::S) where T <: GAPGroup where S <: IntegerUnion
+  flag, e, p = is_prime_power_with_data(n)
+  @req flag "n must be a prime power"
+  return T(GAP.Globals.ElementaryAbelianGroup(_gap_filter(T), GAP.Obj(n))::GapObj)
+end
+
+# Delegating to the GAP constructor via `_gap_filter` does not work here.
+function elementary_abelian_group(::Type{T}, n::S) where T <: Union{PcGroup, SubPcGroup} where S <: IntegerUnion
+  flag, e, p = is_prime_power_with_data(n)
+  @req flag "n must be a prime power"
+  return T(GAP.Globals.ElementaryAbelianGroup(GAP.Globals.IsPcGroup, GAP.Obj(n))::GapObj)
+end
+
+function elementary_abelian_group(::Type{FinGenAbGroup}, n::S) where S <: IntegerUnion
+  flag, e, p = is_prime_power_with_data(n)
+  @req flag "n must be a prime power"
+  return abelian_group(fill(p, e))
+end
+
 @doc raw"""
     is_elementary_abelian(G::Group)
 
@@ -241,6 +279,12 @@ false
 ```
 """
 @gapattribute is_elementary_abelian(G::GAPGroup) = GAP.Globals.IsElementaryAbelian(GapObj(G))::Bool
+
+function is_elementary_abelian(G::FinGenAbGroup)
+  e = exponent(G)
+  return e == 1 || is_prime(e)
+end
+
 
 function mathieu_group(n::Int)
   @req 9 <= n <= 12 || 21 <= n <= 24 "n must be a 9-12 or 21-24"

--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -243,18 +243,19 @@ Permutation group of degree 9 and order 27
 elementary_abelian_group(n::IntegerUnion) = elementary_abelian_group(PcGroup, n)
 
 function elementary_abelian_group(::Type{T}, n::S) where T <: GAPGroup where S <: IntegerUnion
-  @req (n == 1 || is_prime_power_with_data(n)[1]) "n must be a prime power"
+  @req (n == 1 || is_prime_power_with_data(n)[1]) "n must be a prime power or 1"
   return T(GAP.Globals.ElementaryAbelianGroup(_gap_filter(T), GAP.Obj(n))::GapObj)
 end
 
 # Delegating to the GAP constructor via `_gap_filter` does not work here.
 function elementary_abelian_group(::Type{T}, n::S) where T <: Union{PcGroup, SubPcGroup} where S <: IntegerUnion
-  @req (n == 1 || is_prime_power_with_data(n)[1]) "n must be a prime power"
+  @req (n == 1 || is_prime_power_with_data(n)[1]) "n must be a prime power or 1"
   return T(GAP.Globals.ElementaryAbelianGroup(GAP.Globals.IsPcGroup, GAP.Obj(n))::GapObj)
 end
 
 function elementary_abelian_group(::Type{FinGenAbGroup}, n::S) where S <: IntegerUnion
-  @req (n == 1 || is_prime_power_with_data(n)[1]) "n must be a prime power"
+  flag, e, p = is_prime_power_with_data(n)
+  @req (n == 1 || flag) "n must be a prime power or 1"
   return abelian_group(fill(p, e))
 end
 

--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -226,7 +226,10 @@ that is, $x*y = y*x$ holds for all elements $x, y$ in `G`.
 
 Return the elementary abelian group group of order `n`, as an instance of `T`.
 Here, `T` must be one of `PermGroup`, `FPGroup`, `SubFPGroup`, `PcGroup`,
-`SubPcGroup`, or `FinGenAbGroup`.
+`SubPcGroup`, or `FinGenAbGroup`,
+and `n` must be a prime power or 1.
+
+The `gens` vector of the result has minimal length.
 
 # Examples
 ```jldoctest
@@ -240,21 +243,18 @@ Permutation group of degree 9 and order 27
 elementary_abelian_group(n::IntegerUnion) = elementary_abelian_group(PcGroup, n)
 
 function elementary_abelian_group(::Type{T}, n::S) where T <: GAPGroup where S <: IntegerUnion
-  flag, e, p = is_prime_power_with_data(n)
-  @req flag "n must be a prime power"
+  @req (n == 1 || is_prime_power_with_data(n)[1]) "n must be a prime power"
   return T(GAP.Globals.ElementaryAbelianGroup(_gap_filter(T), GAP.Obj(n))::GapObj)
 end
 
 # Delegating to the GAP constructor via `_gap_filter` does not work here.
 function elementary_abelian_group(::Type{T}, n::S) where T <: Union{PcGroup, SubPcGroup} where S <: IntegerUnion
-  flag, e, p = is_prime_power_with_data(n)
-  @req flag "n must be a prime power"
+  @req (n == 1 || is_prime_power_with_data(n)[1]) "n must be a prime power"
   return T(GAP.Globals.ElementaryAbelianGroup(GAP.Globals.IsPcGroup, GAP.Obj(n))::GapObj)
 end
 
 function elementary_abelian_group(::Type{FinGenAbGroup}, n::S) where S <: IntegerUnion
-  flag, e, p = is_prime_power_with_data(n)
-  @req flag "n must be a prime power"
+  @req (n == 1 || is_prime_power_with_data(n)[1]) "n must be a prime power"
   return abelian_group(fill(p, e))
 end
 
@@ -592,8 +592,26 @@ end
 # for the definition of group modulo relations, see the quo function in the sub.jl section
 
 function free_group(G::FPGroup)
-   return FPGroup(GAPWrap.FreeGroupOfFpGroup(GapObj(G))::GapObj)
+  gapG = GapObj(G)::GapObj
+  gapF = GAPWrap.FreeGroupOfFpGroup(gapG)
+  if gapF === gapG
+    # G is itself a free group
+    return G
+  else
+    return FPGroup(gapF)
+  end
 end
+
+function underlying_word(g::FPGroupElem)
+  G = parent(g)
+  F = free_group(G)
+  if F === G
+    return g
+  else
+    return FPGroupElem(F, GAPWrap.UnderlyingElement(GapObj(g)))
+  end
+end
+
 
 ################################################################################
 #

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -479,6 +479,35 @@ end
 #
 ################################################################################
 
+function _isomorphism_same_type(G::T, on_gens::Bool) where T <: GAPGroup
+   # Known isomorphisms are cached in the attribute `:isomorphisms`.
+   isos = get_attribute!(Dict{Tuple{Type, Bool}, Any}, G, :isomorphisms)::Dict{Tuple{Type, Bool}, Any}
+   return get!(isos, (T, on_gens)) do
+     return id_hom(G)
+   end::GAPGroupHomomorphism{T, T}
+end
+
+for T in [PermGroup, SubFPGroup, SubPcGroup]
+  @eval begin
+    isomorphism(::Type{$T}, G::$T) = _isomorphism_same_type(G, false)
+  end
+end
+
+for T in [FPGroup, PcGroup]
+  @eval begin
+    isomorphism(::Type{$T}, G::$T; on_gens::Bool = false) = _isomorphism_same_type(G, on_gens)
+  end
+end
+
+function isomorphism(::Type{FinGenAbGroup}, A::FinGenAbGroup)
+   # Known isomorphisms are cached in the attribute `:isomorphisms`.
+   isos = get_attribute!(Dict{Tuple{Type, Bool}, Any}, A, :isomorphisms)::Dict{Tuple{Type, Bool}, Any}
+   return get!(isos, (FinGenAbGroup, false)) do
+     return identity_map(A)
+   end::AbstractAlgebra.Generic.IdentityMap{FinGenAbGroup}
+end
+
+
 _get_iso_function(::Type{PermGroup}) = GAP.Globals.IsomorphismPermGroup
 
 # We use `GAP.Globals.IsomorphismPcGroup` as the `_get_iso_function` value
@@ -542,30 +571,28 @@ function isomorphism(::Type{FPGroup}, G::GAPGroup; on_gens::Bool=false)
    # Known isomorphisms are cached in the attribute `:isomorphisms`.
    isos = get_attribute!(Dict{Tuple{Type, Bool}, Any}, G, :isomorphisms)::Dict{Tuple{Type, Bool}, Any}
    return get!(isos, (FPGroup, on_gens)) do
-     if on_gens
-       Ggens = GAPWrap.GeneratorsOfGroup(GapObj(G))
-       if length(Ggens) == 0
+     if is_trivial(G)
 # TODO: remove this special treatment as soon as the change from
 #       https://github.com/gap-system/gap/pull/5700 is available in Oscar
 #       (not yet in GAP 4.13.0)
-         f = GAP.Globals.GroupHomomorphismByImages(GapObj(G), GAP.Globals.FreeGroup(0), GAP.Obj([]), GAP.Obj([]))
-         GAP.Globals.SetIsBijective(f, true)
-       else
-         # The computations are easy if `Ggens` is a pcgs,
-         # otherwise GAP will call `CoKernel`.
-         if GAP.Globals.HasFamilyPcgs(GapObj(G))
-           pcgs = GAP.Globals.InducedPcgsWrtFamilyPcgs(GapObj(G))
-           if pcgs == Ggens
-             # `pcgs` fits *and* is an object in `GAP.Globals.IsPcgs`,
-             # for which a special `GAPWrap.IsomorphismFpGroupByGenerators`
-             # method is applicable.
-             # (Currently the alternative is a cokernel computation.
-             # It might be useful to improve this on the GAP side.)
-             Ggens = pcgs
-           end
+       f = GAP.Globals.GroupHomomorphismByImages(GapObj(G), GAP.Globals.FreeGroup(0), GAP.Obj([]), GAP.Obj([]))
+       GAP.Globals.SetIsBijective(f, true)
+     elseif on_gens
+       Ggens = GAPWrap.GeneratorsOfGroup(GapObj(G))
+       # The computations are easy if `Ggens` is a pcgs,
+       # otherwise GAP will call `CoKernel`.
+       if GAP.Globals.HasFamilyPcgs(GapObj(G))
+         pcgs = GAP.Globals.InducedPcgsWrtFamilyPcgs(GapObj(G))
+         if pcgs == Ggens
+           # `pcgs` fits *and* is an object in `GAP.Globals.IsPcgs`,
+           # for which a special `GAPWrap.IsomorphismFpGroupByGenerators`
+           # method is applicable.
+           # (Currently the alternative is a cokernel computation.
+           # It might be useful to improve this on the GAP side.)
+           Ggens = pcgs
          end
-         f = GAPWrap.IsomorphismFpGroupByGenerators(GapObj(G), Ggens)
        end
+       f = GAPWrap.IsomorphismFpGroupByGenerators(GapObj(G), Ggens)
      else
        f = GAPWrap.IsomorphismFpGroup(GapObj(G))
      end
@@ -850,59 +877,110 @@ end
 
 ####
 
-function isomorphism(::Type{FinGenAbGroup}, A::FinGenAbGroup)
-   # Known isomorphisms are cached in the attribute `:isomorphisms`.
-   isos = get_attribute!(Dict{Tuple{Type, Bool}, Any}, A, :isomorphisms)::Dict{Tuple{Type, Bool}, Any}
-   return get!(isos, (FinGenAbGroup, false)) do
-     return identity_map(A)
-   end::AbstractAlgebra.Generic.IdentityMap{FinGenAbGroup}
-end
-
 # We need not find independent generators in order to create
 # a presentation of a fin. gen. abelian group.
 function isomorphism(::Type{FPGroup}, A::FinGenAbGroup)
    # Known isomorphisms are cached in the attribute `:isomorphisms`.
    isos = get_attribute!(Dict{Tuple{Type, Bool}, Any}, A, :isomorphisms)::Dict{Tuple{Type, Bool}, Any}
    return get!(isos, (FPGroup, false)) do
-      G = free_group(ngens(A); eltype = :syllable)
+      n = ngens(A)
+      G = free_group(n; eltype = :syllable)
       R = rels(A)
-      s = vcat(elem_type(G)[i*j*inv(i)*inv(j) for i = gens(G) for j = gens(G) if i != j],
-           elem_type(G)[prod([gen(G, i)^R[j,i] for i=1:ngens(A) if !iszero(R[j,i])], init = one(G)) for j=1:nrows(R)])
+      gG = gens(G)
+      gGi = map(inv, gG)
+      s = vcat(elem_type(G)[gG[i]*gG[j]*gGi[i]*gGi[j] for i in 1:n for j in (i+1):n],
+           elem_type(G)[prod([gen(G, i)^R[j,i] for i=1:n if !iszero(R[j,i])], init = one(G)) for j=1:nrows(R)])
       F, mF = quo(G, s)
       set_is_abelian(F, true)
       set_is_finite(F, is_finite(A))
       is_finite(A) && set_order(F, order(A))
       return MapFromFunc(
         A, F,
-        y->F([i => y[i] for i=1:ngens(A)]),
+        y->F([i => y[i] for i=1:n]),
         x->sum([w.second*gen(A, w.first) for w = syllables(x)], init = zero(A)))
    end::MapFromFunc{FinGenAbGroup, FPGroup}
 end
 
 
 # We need not find independent generators in order to create
-# a presentation of a vector space.
+# a presentation of a `FPModule` over a finite field.
+# Note that additively, the given module is an elementary abelian p-group
+# where p is the characteristic.
+# The function guarantees always a correspondence of `gens(M)` and the `gens`
+# value of the codomain of the result,
+# that is, the value of `on_gens` is irrelevant.
 # (This method is needed in the construction of group extensions
 # from information computed by `cohomology_group`.)
-function isomorphism(::Type{FPGroup}, A::AbstractAlgebra.Generic.FreeModule{FqFieldElem})
-   # Known isomorphisms are cached in the attribute `:isomorphisms`.
-   isos = get_attribute!(Dict{Tuple{Type, Bool}, Any}, A, :isomorphisms)::Dict{Tuple{Type, Bool}, Any}
-   return get!(isos, (FPGroup, false)) do
-      R = base_ring(A)
-      p = order(R)
-      @req is_prime(p) "A must be a free module over a prime field"
-      G = free_group(ngens(A); eltype = :syllable)
-      s = vcat(elem_type(G)[i*j*inv(i)*inv(j) for i = gens(G) for j = gens(G) if i != j],
-           elem_type(G)[gen(G, i)^p for i=1:ngens(A)])
-      F, mF = quo(G, s)
-      set_is_abelian(F, true)
-      set_is_finite(F, true)
-      set_order(F, order(A))
-      return MapFromFunc(
-        A, F,
-        y->F([i => lift(ZZ, y[i]) for i=1:ngens(A)]),
-        x->sum([w.second*gen(A, w.first) for w = syllables(x)], init = zero(A)))
-   end::MapFromFunc{AbstractAlgebra.Generic.FreeModule{FqFieldElem}, FPGroup}
+function isomorphism(::Type{T}, M::S; on_gens::Bool=true) where T <: Union{FPGroup, PcGroup} where S <: AbstractAlgebra.FPModule{<:FinFieldElem}
+  # Known isomorphisms are cached in the attribute `:isomorphisms`.
+  isos = get_attribute!(Dict{Tuple{Type, Bool}, Any}, M, :isomorphisms)::Dict{Tuple{Type, Bool}, Any}
+    return get!(isos, (T, false)) do
+      k = base_ring(M)
+      p = characteristic(k)
+      B = elementary_abelian_group(T, order(M))
+      FB = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(GapObj(B)))
+
+      # module to group
+      function Julia_to_gap(a::AbstractAlgebra.FPModuleElem{<:Union{fpFieldElem, FpFieldElem}})
+        F = base_ring(parent(a))
+        @assert absolute_degree(F) == 1
+        r = ZZRingElem[]
+        for i=1:ngens(M)
+          if !iszero(a[i])
+            push!(r, i)
+            push!(r, lift(ZZ, a[i]))
+          end
+        end
+        return GapObj(r; recursive = true)
+      end
+
+      function Julia_to_gap(a::AbstractAlgebra.FPModuleElem{<:Union{FqPolyRepFieldElem, fqPolyRepFieldElem, FqFieldElem}})
+        r = ZZRingElem[]
+        for i=1:ngens(M)
+          if !iszero(a[i])
+            for j=0:degree(k)-1
+              if !iszero(coeff(a[i], j))
+                push!(r, (i-1)*degree(k)+j+1)
+                push!(r, lift(ZZ, coeff(a[i], j)))
+              end
+            end
+          end
+        end
+        return GapObj(r; recursive = true)
+      end
+
+      # group to module
+      gap_to_julia = function(a::GapObj)
+        e = GAPWrap.ExtRepOfObj(a)
+        z = zeros(ZZRingElem, ngens(M)*degree(k))
+        for i=1:2:length(e)
+          if !iszero(e[i+1])
+            z[e[i]] = e[i+1]
+          end
+        end
+        c = elem_type(k)[]
+        for i=1:dim(M)
+          push!(c, k(z[(i-1)*degree(k)+1:i*degree(k)]))
+        end
+        return M(c)
+      end
+
+      if T === PcGroup
+        return MapFromFunc(
+          M, B,
+          y -> PcGroupElem(B, GAPWrap.ObjByExtRep(FB, Julia_to_gap(y))),
+          x -> gap_to_julia(GapObj(x)))
+      else
+        # We need an indirection: First create the word in the free group,
+        # then wrap it into an element of the f.p. group.
+        FR = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(GAPWrap.FreeGroupOfFpGroup(GapObj(B))))
+
+        return MapFromFunc(
+          M, B,
+          y -> FPGroupElem(B, GAPWrap.ElementOfFpGroup(FB, GAPWrap.ObjByExtRep(FR, Julia_to_gap(y)))),
+          x -> gap_to_julia(GapObj(x)))
+      end
+   end::MapFromFunc{S, T}
 end
 
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1497,6 +1497,7 @@ export twist
 export two_sided_ideal
 export underlying_gluing
 export underlying_quotient
+export underlying_word
 export uniform_matroid
 export unit
 export unitary_group

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -495,6 +495,7 @@ export dwarfed_product_polygons
 export edges
 export ehrhart_polynomial
 export element_to_homomorphism
+export elementary_abelian_group
 export elementary_symmetric
 export elements
 export eliminate

--- a/test/Groups/GrpAb.jl
+++ b/test/Groups/GrpAb.jl
@@ -39,6 +39,7 @@ end
 
     # properties
     @test is_abelian(G1) == is_abelian(G2)
+    @test is_elementary_abelian(G1) == is_elementary_abelian(G2)
     @test is_finite(G1) == is_finite(G2)
     @test is_finitely_generated(G1) == is_finitely_generated(G2)
     @test is_perfect(G1) == is_perfect(G2)

--- a/test/Groups/constructors.jl
+++ b/test/Groups/constructors.jl
@@ -78,9 +78,16 @@ end
 
   @test_throws ArgumentError cyclic_generator(symmetric_group(3))
 
+  @test isa(elementary_abelian_group(27), PcGroup)
+  @test isa(elementary_abelian_group(PermGroup, 27), PermGroup)
+  @test isa(elementary_abelian_group(FinGenAbGroup, 27), FinGenAbGroup)
+  @test_throws ArgumentError elementary_abelian_group(6)
+  @test_throws ArgumentError elementary_abelian_group(PermGroup, 6)
+
   for p in [1, next_prime(2^62), next_prime(ZZRingElem(2)^66)]
     g = cyclic_group(p)
     @test is_cyclic(g)
+    @test is_elementary_abelian(g)
     @test order(cyclic_generator(g)) == order(g)
     @test !is_dihedral_group(g)
     @test is_finite(g)
@@ -93,6 +100,14 @@ end
     @test !is_cyclic(g)
     #@test is_dihedral_group(g)
     @test is_finite(g)
+    @test order(g) == n
+
+    n = p^2
+    g = elementary_abelian_group(n)
+    @test is_abelian(g)
+    @test is_finite(g)
+    @test !is_cyclic(g)
+    @test exponent(g) == p
     @test order(g) == n
   end
 

--- a/test/Groups/elements.jl
+++ b/test/Groups/elements.jl
@@ -199,4 +199,12 @@ end
    g1 = codomain(isomorphism(FPGroup, L[1]))
    g2 = codomain(isomorphism(FPGroup, L[2]))
    @test_throws ArgumentError one(g1) * one(g2)
+
+   g = free_group(2)
+   x, y = gens(g)
+   f, epi = quo(g, [x, y^2])
+   @test free_group(g) === g
+   @test free_group(f) == g
+   @test underlying_word(x) === x
+   @test underlying_word(epi(x)) == x
 end

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -301,18 +301,18 @@ end
       iso = @inferred isomorphism(FinGenAbGroup, A)
    end
 
-   @testset "Vector space to FPGroup" begin
-      V = free_module(GF(2), 0)
-      iso = isomorphism(FPGroup, V)
-      x = zero(V)
-      @test preimage(iso, iso(x)) == x
-
-      V = free_module(GF(2), 3)
-      iso = isomorphism(FPGroup, V)
-      x = gen(V, 1)
-      @test preimage(iso, iso(x)) == x
-
-      @test_throws ArgumentError isomorphism(FPGroup, free_module(GF(4), 3))
+   @testset "Vector space to FPGroup or PcGroup" begin
+      for (F, n) in [(GF(2), 0), (GF(3), 2), (GF(4), 2),
+                     (Nemo.Native.GF(2), 0),
+                     (Nemo.Native.GF(3), 2)]
+        V = free_module(F, n)
+        for T in [FPGroup, PcGroup]
+          iso = @inferred isomorphism(T, V)
+          for x in [zero(V), rand(V)]
+            @test preimage(iso, iso(x)) == x
+          end
+        end
+      end
    end
 
    @testset "MultTableGroup to GAPGroups" begin

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -301,6 +301,20 @@ end
       iso = @inferred isomorphism(FinGenAbGroup, A)
    end
 
+   @testset "Vector space to FPGroup" begin
+      V = free_module(GF(2), 0)
+      iso = isomorphism(FPGroup, V)
+      x = zero(V)
+      @test preimage(iso, iso(x)) == x
+
+      V = free_module(GF(2), 3)
+      iso = isomorphism(FPGroup, V)
+      x = gen(V, 1)
+      @test preimage(iso, iso(x)) == x
+
+      @test_throws ArgumentError isomorphism(FPGroup, free_module(GF(4), 3))
+   end
+
    @testset "MultTableGroup to GAPGroups" begin
       for G in [Hecke.small_group(64, 14, DB = Hecke.DefaultSmallGroupDB()),
                 Hecke.small_group(20, 3, DB = Hecke.DefaultSmallGroupDB())]

--- a/test/Groups/quotients.jl
+++ b/test/Groups/quotients.jl
@@ -87,6 +87,38 @@ end
    @test abelian_invariants(small_group(8, 5)) == [2, 2, 2]
 end
 
+@testset "Relators" begin
+   # free group
+   F = free_group(2)
+   @test relators(F) == []
+
+   # f.p. group
+   x, y = gens(F)
+   rels = [x^3, y^2, comm(x, y)]
+   G, epi = quo(F, rels)
+   @test relators(G) == rels
+
+   # sub-f.p. group
+   G = sylow_subgroup(G, 2)[1]
+   rels = relators(G)
+   @test is_isomorphic(G, quo(parent(rels[1]), rels)[1])
+
+   # pc group
+   G = dihedral_group(12)
+   rels = relators(G)
+   @test is_isomorphic(G, quo(parent(rels[1]), rels)[1])
+
+   # sub-pc group
+   G = sylow_subgroup(G, 2)[1]
+   rels = relators(G)
+   @test is_isomorphic(G, quo(parent(rels[1]), rels)[1])
+
+   # perm. group
+   G = symmetric_group(3)
+   rels = relators(G)
+   @test is_isomorphic(G, quo(parent(rels[1]), rels)[1])
+end
+
 @testset "Finitely presented groups" begin
    F = free_group(2)
    x,y = gens(F)
@@ -96,8 +128,7 @@ end
    @test relators(F) == FPGroupElem[]
    S = sub(F, [gen(F, 1)])[1]
    @test ! Oscar._is_full_fp_group(GapObj(S))
-   @test_throws MethodError relators(S)
-   
+
    n=5
    G,f = quo(F, [x^2,y^n,(x*y)^2] )           # dihedral group D(2n)
    @test is_finite(G)
@@ -125,7 +156,6 @@ end
    @test relators(G)==[x^n,y^n,comm(x,y)]
    S = sub(G, [gen(G, 1)])[1]
    @test ! Oscar._is_full_fp_group(GapObj(S))
-   @test_throws MethodError relators(S)
    @test_throws ArgumentError quo(S, gens(S))
 
    @test G([1 => 2, 2 => -3]) == G[1]^2 * G[2]^-3


### PR DESCRIPTION
- admit `Oscar.GAPGroupElem` not only `Oscar.BasicGAPGroupElem` in evaluating 2-cochains (we need in particular `Oscar.MatrixGroupElem`)

- add a `isomorphism(::Type{FPGroup}, A::AbstractAlgebra.Generic.FreeModule)` method, which is needed by `extension` if we want to support G-modules created from matrix groups acting on vector spaces

- add tests