### PR TITLE
polyhedral: use dehomogenize from polymake

### DIFF
--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -294,8 +294,7 @@ homogenized_matrix(x::AbstractVector, val::Number) = permutedims(homogenize(x, v
 homogenized_matrix(x::AbstractVector{<:AbstractVector}, val::Number) =
   stack((homogenize(x[i], val) for i in 1:length(x))...)
 
-dehomogenize(vec::AbstractVector) = vec[2:end]
-dehomogenize(mat::AbstractMatrix) = mat[:, 2:end]
+dehomogenize(vm::AbstractVecOrMat) = Polymake.call_function(:polytope, :dehomogenize, vm)
 
 unhomogenized_matrix(x::AbstractVector) = assure_matrix_polymake(stack(x))
 unhomogenized_matrix(x::AbstractMatrix) = assure_matrix_polymake(x)

--- a/src/PolyhedralGeometry/linear_program.jl
+++ b/src/PolyhedralGeometry/linear_program.jl
@@ -98,7 +98,7 @@ The allowed values for `as` are
 function objective_function(lp::LinearProgram{T}; as::Symbol=:pair) where {T<:scalar_types}
   if as == :pair
     cf = coefficient_field(lp)
-    return T[cf(x) for x in dehomogenize(lp.polymake_lp.LINEAR_OBJECTIVE)],
+    return T[cf(x) for x in lp.polymake_lp.LINEAR_OBJECTIVE[2:end]],
     cf.(lp.polymake_lp.LINEAR_OBJECTIVE[1])
   elseif as == :function
     (c, k) = objective_function(lp; as=:pair)

--- a/src/PolyhedralGeometry/mixed_integer_linear_program.jl
+++ b/src/PolyhedralGeometry/mixed_integer_linear_program.jl
@@ -77,7 +77,7 @@ pm_object(milp::MixedIntegerLinearProgram) = milp.polymake_milp
 ###############################################################################
 ###############################################################################
 function describe(io::IO, MILP::MixedIntegerLinearProgram)
-  c = dehomogenize(MILP.polymake_milp.LINEAR_OBJECTIVE)
+  c = MILP.polymake_milp.LINEAR_OBJECTIVE[2:end]
   k = MILP.polymake_milp.LINEAR_OBJECTIVE[1]
   print(io, "The mixed integer linear program\n")
   if MILP.convention == :max
@@ -128,7 +128,7 @@ function objective_function(
   milp::MixedIntegerLinearProgram{T}; as::Symbol=:pair
 ) where {T<:scalar_types}
   if as == :pair
-    return Vector{T}(dehomogenize(milp.polymake_milp.LINEAR_OBJECTIVE)),
+    return Vector{T}(milp.polymake_milp.LINEAR_OBJECTIVE[2:end]),
     convert(T, milp.polymake_milp.LINEAR_OBJECTIVE[1])
   elseif as == :function
     (c, k) = objective_function(milp; as=:pair)

--- a/test/PolyhedralGeometry/polyhedron.jl
+++ b/test/PolyhedralGeometry/polyhedron.jl
@@ -236,6 +236,12 @@
     @test n_rays(Q1) == 1
     @test lineality_dim(Q2) == 1
     @test relative_interior_point(Q0) == [1//3, 1//3]
+
+    # issue #4024
+    let op = Polyhedron{T}(Polymake.polytope.Polytope(REL_INT_POINT=f.([1//3, -1, -2, -4//3])), f)
+      @test relative_interior_point(op) == f.([-3, -6, -4])
+    end
+
     @test facet_sizes(Q0)[1] == 2
     @test sum(facet_sizes(Q1)) == 6
     @test facet_sizes(Q2)[1] == 1

--- a/test/PolyhedralGeometry/polyhedron.jl
+++ b/test/PolyhedralGeometry/polyhedron.jl
@@ -238,7 +238,7 @@
     @test relative_interior_point(Q0) == [1//3, 1//3]
 
     # issue #4024
-    let op = Polyhedron{T}(Polymake.polytope.Polytope{Polymake.OscarNumber}(REL_INT_POINT=f.([1//3, -1, -2, -4//3]), CONE_AMBIENT_DIM=4), f)
+    let op = Polyhedron{T}(Polymake.polytope.Polytope{Oscar._scalar_type_to_polymake(T)}(REL_INT_POINT=f.([1//3, -1, -2, -4//3]), CONE_AMBIENT_DIM=4), f)
       @test relative_interior_point(op) == point_vector(f, [-3,-6,-4])
     end
 

--- a/test/PolyhedralGeometry/polyhedron.jl
+++ b/test/PolyhedralGeometry/polyhedron.jl
@@ -238,8 +238,8 @@
     @test relative_interior_point(Q0) == [1//3, 1//3]
 
     # issue #4024
-    let op = Polyhedron{T}(Polymake.polytope.Polytope(REL_INT_POINT=f.([1//3, -1, -2, -4//3])), f)
-      @test relative_interior_point(op) == f.([-3, -6, -4])
+    let op = Polyhedron{T}(Polymake.polytope.Polytope{Polymake.OscarNumber}(REL_INT_POINT=f.([1//3, -1, -2, -4//3]), CONE_AMBIENT_DIM=4), f)
+      @test relative_interior_point(op) == point_vector(f, [-3,-6,-4])
     end
 
     @test facet_sizes(Q0)[1] == 2


### PR DESCRIPTION
- this is (I think) used only for polymake types anyway
- it properly takes care of the homogenization entry
- directly use vector entries for linear objective (since this is not a point/ray)
- test for dehomogenized rel_int_point with non-normalized first coordinate

fixes #4024:
```julia
julia> T = tropical_semiring()
Min tropical semiring

julia> R,(x,y,z) = T["x","y","z"]
(Multivariate polynomial ring in 3 variables over min tropical semiring, AbstractAlgebra.Generic.MPoly{TropicalSemiringElem{typeof(min)}}[x, y, z])

julia> g = T(3)*x + T(6)*y + T(5)*z + T(1)
(3)*x + (6)*y + (5)*z + (1)

julia> TropL = tropical_hypersurface(g)
Min tropical hypersurface

julia> sigma = first(maximal_polyhedra(TropL))
Polyhedron in ambient dimension 3

julia> w = relative_interior_point(sigma)
3-element PointVector{QQFieldElem}:
 -3
 -6
 -4

julia> w in sigma # returns false, should be true
true
```