### PR TITLE
TropicalGeometry: fixed initials w.r.t. t-adic valuation

### DIFF
--- a/src/TropicalGeometry/semiring_map.jl
+++ b/src/TropicalGeometry/semiring_map.jl
@@ -254,5 +254,5 @@ function initial(c::Union{RingElem,Integer,Rational}, nu::TropicalSemiringMap{Kt
     c = valued_field(nu)(c)
     iszero(c) && return zero(residue_field(nu)) # if c is zero, return 0
     c *= valued_field(nu)(uniformizer(nu))^(-t_adic_valuation(c,uniformizer(nu)))
-    return residue_field(nu)(c)
+    return evaluate(numerator(c),0)
 end


### PR DESCRIPTION
Fixes the following error (old code tried to convert elements of the rational function field with denominator `1` to the coefficient field, their numerators should be evaluated at `0` instead):

```
julia> K,t = rational_function_field(QQ,"t")
(Rational function field over QQ, t)

julia> nu = tropical_semiring_map(K,t)
Map into Min tropical semiring encoding the t-adic valuation on Rational function field over QQ

julia> initial(1+t,nu)
ERROR: InexactError: QQFieldElem(t + 1)
Stacktrace:
 [1] (::QQField)(x::AbstractAlgebra.Generic.FracFieldElem{QQPolyRingElem})
   @ Oscar ~/.julia/dev/Oscar/src/Rings/FunctionField.jl:71
 [2] QQField
   @ ~/.julia/dev/Oscar/src/Rings/FunctionField.jl:76 [inlined]
 [3] initial(c::AbstractAlgebra.Generic.RationalFunctionFieldElem{…}, nu::TropicalSemiringMap{…})
   @ Oscar ~/.julia/dev/Oscar/src/TropicalGeometry/semiring_map.jl:257
 [4] top-level scope
   @ REPL[291]:1
Some type information was truncated. Use `show(err)` to see complete types.

```