### PR TITLE
[ToricVarieties] Shorthands for hirzebruch surface and del Pezzo surface

### DIFF
--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/standard_constructions.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/standard_constructions.jl
@@ -115,6 +115,7 @@ function hirzebruch_surface(::Type{NormalToricVariety}, r::Int)
   return variety
 end
 
+hirzebruch_surface(r::Int) = hirzebruch_surface(NormalToricVariety, r)
 
 @doc raw"""
     del_pezzo_surface(::Type{NormalToricVariety}, b::Int)
@@ -169,6 +170,8 @@ function del_pezzo_surface(::Type{NormalToricVariety}, b::Int)
   set_coordinate_names(variety, vars[1:(3 + b)])
   return variety
 end
+
+del_pezzo_surface(r::Int) = del_pezzo_surface(NormalToricVariety, r)
 
 @doc raw"""
     Base.:*(v::NormalToricVarietyType, w::NormalToricVarietyType)


### PR DESCRIPTION
As pointed out by @micjoswig in https://github.com/oscar-system/Oscar.jl/pull/3996, for the current constructor `hirzebruch_surface(::Type{NormalToricVariety}, r::Int)`, the first argument is currently obsolete. This PR introduces a shorthand `hirzebruch_surface(r::Int)`.

A similar situation exists for `del_pezzo_surface`, and I have taken the liberty to propose a similar short hand.

We also have the following specialized constructors:
* `affine_space(::Type{NormalToricVariety}, var_names::AbstractVector{<:VarName})`
* `affine_space(::Type{NormalToricVariety}, d::Int)`
* `projective_space(::Type{NormalToricVariety}, d::Int)`
* `weighted_projective_space(::Type{NormalToricVariety}, w::Vector{T}) where {T <: IntegerUnion}`

I could not find instances, where those constructors are called with a first argument different from `NormalToricVariety`. (But of course, I could have overlooked those instances...) In https://github.com/oscar-system/Oscar.jl/pull/3996, I was therefore carried away to propose short hands for all of these constructors. This is (at least not yet) done in this PR, as this seems to require discussion and so I removed this proposed change after being alerted to this by @lgoettgens .

This PR aims to clarify the situation and to resolve it.