### PR TITLE
Make GSets better inferreable

### DIFF
--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -1233,6 +1233,8 @@ end
 
 Base.iterate(tbl::GAPGroupCharacterTable, state = 1) = state > nrows(tbl) ? nothing : (tbl[state], state+1)
 
+Base.eltype(::Type{GAPGroupCharacterTable}) = GAPGroupClassFunction
+
 """
     mod(tbl::GAPGroupCharacterTable, p::T) where T <: IntegerUnion
     rem(tbl::GAPGroupCharacterTable, p::T) where T <: IntegerUnion
@@ -2346,6 +2348,8 @@ restrict(chi::GAPGroupClassFunction, H::Union{GAPGroup, FinGenAbGroup}) = restri
 Base.length(chi::GAPGroupClassFunction) = length(GapObj(chi))
 
 Base.iterate(chi::GAPGroupClassFunction, state = 1) = state > length(GapObj(chi)) ? nothing : (chi[state], state+1)
+
+Base.eltype(::Type{GAPGroupClassFunction}) = QQAbFieldElem{AbsSimpleNumFieldElem}
 
 @doc raw"""
     degree(::Type{T} = QQFieldElem, chi::GAPGroupClassFunction)

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -24,7 +24,7 @@ import Hecke.orbit
 
 
 """
-    GSetByElements{T} <: GSet{T}
+    GSetByElements{T,S} <: GSet{T}
 
 Objects of this type represent G-sets that are willing to write down
 orbits and elements lists as vectors.
@@ -33,17 +33,17 @@ These G-sets are created by default by [`gset`](@ref).
 The fields are
 - the group that acts, of type `T`,
 - the Julia function (for example `on_tuples`) that describes the action,
-- the seeds (something iterable) whose closure under the action is the G-set
+- the seeds (something iterable of type `S`) whose closure under the action is the G-set
 - the dictionary used to store attributes (orbits, elements, ...).
 """
-@attributes mutable struct GSetByElements{T} <: GSet{T}
+@attributes mutable struct GSetByElements{T,S} <: GSet{T}
     group::T
     action_function::Function
-    seeds
+    seeds::S
 
-    function GSetByElements(G::T, fun::Function, seeds; closed::Bool = false) where T<:Union{GAPGroup, FinGenAbGroup}
-        @assert ! isempty(seeds)
-        Omega = new{T}(G, fun, seeds, Dict{Symbol,Any}())
+    function GSetByElements(G::T, fun::Function, seeds::S; closed::Bool = false) where {T<:Union{GAPGroup, FinGenAbGroup}, S}
+        @assert !isempty(seeds)
+        Omega = new{T,S}(G, fun, seeds, Dict{Symbol,Any}())
         closed && set_attribute!(Omega, :elements => unique!(collect(seeds)))
         return Omega
     end
@@ -411,9 +411,9 @@ julia> map(collect, orbs)
  [5, 6]
 ```
 """
-@attr Vector{GSetByElements{TG}} function orbits(Omega::T) where T <: GSetByElements{TG} where TG <: Union{GAPGroup, FinGenAbGroup}
+@attr Vector{GSetByElements{T,Vector{eltype(S)}}} function orbits(Omega::GSetByElements{T,S}) where {T <: Union{GAPGroup, FinGenAbGroup},S}
   G = acting_group(Omega)
-  orbs = T[]
+  orbs = GSetByElements{T,Vector{eltype(S)}}[]
   for p in Omega.seeds
     if all(o -> !(p in o), orbs)
       push!(orbs, orbit(Omega, p))
@@ -440,7 +440,7 @@ julia> map(length, orbs)
  2
 ```
 """
-@attr Vector{GSetByElements{PermGroup}} orbits(G::PermGroup) = orbits(gset(G))
+@attr Vector{GSetByElements{PermGroup, Vector{Int}}} orbits(G::PermGroup) = orbits(gset(G))
 
 
 #############################################################################
@@ -449,7 +449,7 @@ julia> map(length, orbs)
 ##  if `:seeds` is known to be closed under the action then
 ##  keep its ordering of points
 
-@attr Any function elements(Omega::GSetByElements)
+@attr Vector{eltype(S)} function elements(Omega::GSetByElements{T,S}) where {T,S}
   orbs = orbits(Omega)
   return union(map(collect, orbs)...)
 end

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -5,8 +5,8 @@
   Omega = gset(G)
   @test AbstractAlgebra.PrettyPrinting.repr_terse(Omega) == "G-set"
   @test isa(Omega, GSet)
-  @test length(Omega) == 6
-  @test length(orbits(Omega)) == 1
+  @test (@inferred length(Omega)) == 6
+  @test (@inferred length(@inferred orbits(Omega))) == 1
   @test is_transitive(Omega)
   @test ! is_regular(Omega)
   @test ! is_semiregular(Omega)
@@ -455,12 +455,12 @@ end
     return galois_conjugate(chi, QQAbAutomorphism(Int(lift(mu(g)))))
   end
 
-  orb = orbit(u, f, t[3])
+  orb = @inferred orbit(u, f, t[3])
   @test length(collect(orb)) == 3
 
-  Omega = gset(u, f, t)
-  orbs = orbits(Omega)
-  @test length(orbs) == 5
+  Omega = @inferred gset(u, f, t)
+  orbs = @inferred orbits(Omega)
+  @test (@inferred length(orbs)) == 5
   @test sort(map(length, orbs)) == [1, 1, 1, 3, 3]
   @test all(o -> conductor(sum(collect(o))) == 1, orbs)
   o = orbs[findfirst(o -> length(o) == 3, orbs)]


### PR DESCRIPTION
By adding a type parameter which represents the element type of the G-set (derived from the eltype of the seed iterator).
This then allows to concretize the return types of `orbits` and `elements` to something concretely that is statically known, i.e. in these two functions there is no dynamic dispatch happening, and they infer their concrete return type.

I noticed this issue while profiling some new functionality in https://github.com/oscar-system/Oscar.jl/pull/4053, since half of the flame graph was filled with dynamic dispatch stuff.