### PR TITLE
[FTheoryTools] Add some missing `ensure_artifact_installed` to doctests

### DIFF
--- a/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
@@ -7,7 +7,7 @@
 
 Return the F-theory model for which this $G_4$-flux candidate is defined.
 
-```jldoctest
+```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
 
@@ -30,7 +30,7 @@ model(gf::G4Flux) = gf.model
 
 Return the cohomology class which defines the $G_4$-flux candidate.
 
-```jldoctest
+```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
 

--- a/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
@@ -42,7 +42,7 @@ ring with `check = false`. This will avoid this time consuming test.
 An example is in order.
 
 # Examples
-```jldoctest
+```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
 

--- a/experimental/FTheoryTools/src/G4Fluxes/properties.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/properties.jl
@@ -19,7 +19,7 @@ support this check for $G_4$-fluxes defined on Weierstrass,
 global Tate and hypersurface models. If this condition is not
 met, this method will return an error.
 
-```jldoctest
+```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
 


### PR DESCRIPTION
that were forgotten in #3965, but now sometimes result in doctest failures, e.g. https://github.com/oscar-system/Oscar.jl/actions/runs/10614389904/job/29420203302?pr=4050#step:8:650