### PR TITLE
Add `@attr` types in simple cases

### DIFF
--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -82,7 +82,7 @@ end
 #
 ###############################################################################
 
-@attr function is_abelian(L::AbstractLieAlgebra)
+@attr Bool function is_abelian(L::AbstractLieAlgebra)
   return all(iszero, _struct_consts(L))
 end
 

--- a/experimental/LieAlgebras/src/DirectSumLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/DirectSumLieAlgebra.jl
@@ -98,7 +98,7 @@ end
 #
 ###############################################################################
 
-@attr function is_abelian(L::DirectSumLieAlgebra)
+@attr Bool function is_abelian(L::DirectSumLieAlgebra)
   return all(is_abelian, L.summands)
 end
 

--- a/experimental/QuadFormAndIsom/src/lattices_with_isometry.jl
+++ b/experimental/QuadFormAndIsom/src/lattices_with_isometry.jl
@@ -1484,7 +1484,7 @@ julia> is_of_hermitian_type(coinvariant_lattice(Lf))
 true
 ```
 """
-@attr function is_of_hermitian_type(Lf::ZZLatWithIsom)
+@attr Bool function is_of_hermitian_type(Lf::ZZLatWithIsom)
   @req rank(Lf) > 0 "Underlying lattice must have positive rank"
   chi = minimal_polynomial(Lf)
   !is_irreducible(chi) && return false
@@ -2225,7 +2225,7 @@ julia> genus(invariant_lattice(Lf)) == t[1][1]
 true
 ```
 """
-@attr function type(Lf::ZZLatWithIsom)
+@attr Dict{Integer, Tuple} function type(Lf::ZZLatWithIsom)
   L = lattice(Lf)
   f = isometry(Lf)
   n = order_of_isometry(Lf)

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Properties.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Properties.jl
@@ -14,7 +14,7 @@ Return the boolean value whether a covered scheme `X` is empty.
 
 """
 is_empty(X::AbsCoveredScheme) = is_empty(underlying_scheme(X))
-@attr function is_empty(X::CoveredScheme)
+@attr Bool function is_empty(X::CoveredScheme)
   if !isdefined(X, :coverings)
     return true
   end
@@ -31,7 +31,7 @@ Return the boolean value whether a covered scheme `X` is smooth.
 """
 is_smooth(X::AbsCoveredScheme) = is_smooth(underlying_scheme(X))
 
-@attr function is_smooth(X::CoveredScheme)
+@attr Bool function is_smooth(X::CoveredScheme)
   if !isdefined(X, :coverings)
     return true
   end
@@ -76,7 +76,7 @@ end
 Return the boolean value whether a covered scheme `X` is integral.
 
 """
-@attr function is_integral(X::AbsCoveredScheme)
+@attr Bool function is_integral(X::AbsCoveredScheme)
   !is_empty(X) || return false
   return is_reduced(X) && is_irreducible(X)
 end
@@ -95,7 +95,7 @@ covering of the scheme X is connected.
     This function is designed to ignore empty patches, which may arise e.g. upon creation of subschemes of covered schemes,
 
 """
-@attr function is_connected_gluing(X::AbsCoveredScheme)
+@attr Bool function is_connected_gluing(X::AbsCoveredScheme)
   return is_connected(pruned_gluing_graph(default_covering(X)))
 end
 
@@ -108,7 +108,7 @@ end
 Return the boolean value whether a covered scheme `X` is connected.
 
 """
-@attr function is_connected(X::AbsCoveredScheme)
+@attr Bool function is_connected(X::AbsCoveredScheme)
   is_connected_gluing(X) || return false
   # note for future implementation: expensive property
   # 1) do primary decomposition
@@ -125,7 +125,7 @@ end
 Return the boolean value whether a covered scheme `X` is reduced.
 
 """
-@attr function is_reduced(X::AbsCoveredScheme)
+@attr Bool function is_reduced(X::AbsCoveredScheme)
   return all(is_reduced, affine_charts(X))
 end
 
@@ -138,7 +138,7 @@ end
 Return the boolean value whether a covered scheme `X` is irreducible.
 
 """
-@attr function is_irreducible(X::AbsCoveredScheme)
+@attr Bool function is_irreducible(X::AbsCoveredScheme)
   is_connected_gluing(X) || return false
   !is_empty(X) || return false
   v=findall(!is_empty, affine_charts(X))  ## only check non-empty patches

--- a/src/AlgebraicGeometry/ToricVarieties/cohomCalg/special_attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/cohomCalg/special_attributes.jl
@@ -7,14 +7,14 @@
 
 Compute the vanishing sets of an abstract toric variety `v` by use of the cohomCalg algorithm.
 """
-@attr function vanishing_sets(variety::NormalToricVarietyType)
+@attr Vector{ToricVanishingSet} function vanishing_sets(variety::NormalToricVarietyType)
     denominator_contributions = contributing_denominators(variety)
     vs = ToricVanishingSet[]
     for i in 1:length(denominator_contributions)
         list_of_polyhedra = Polyhedron{QQFieldElem}[turn_denominator_into_polyhedron(variety, m) for m in denominator_contributions[i]]
         push!(vs, ToricVanishingSet(variety, list_of_polyhedra, [i-1]))
     end
-    return vs::Vector{ToricVanishingSet}
+    return vs
 end
 
 

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -158,7 +158,7 @@ julia> characteristic(tbl % 2)
 characteristic(tbl::GAPGroupCharacterTable) = characteristic(Int, tbl)
 
 function characteristic(::Type{T}, tbl::GAPGroupCharacterTable) where T <: IntegerUnion
-    return T(tbl.characteristic)
+    return T(tbl.characteristic)::T
 end
 
 

--- a/src/Groups/spinor_norms.jl
+++ b/src/Groups/spinor_norms.jl
@@ -434,7 +434,7 @@ end
 
 
 @doc raw"""
-    image_in_Oq(L::ZZLat) -> AutomorphismGroup{Hecke.TorQuadModule}, GAPGroupHomomorphism
+    image_in_Oq(L::ZZLat) -> AutomorphismGroup{TorQuadModule}, GAPGroupHomomorphism
 
 Return the image of $O(L) \to O(L^\vee / L)$.
 
@@ -466,7 +466,7 @@ julia> order(Oq)
 12
 ```
 """
-@attr function image_in_Oq(L::ZZLat)::Tuple{AutomorphismGroup{Hecke.TorQuadModule}, GAPGroupHomomorphism{AutomorphismGroup{Hecke.TorQuadModule}, AutomorphismGroup{Hecke.TorQuadModule}}}
+@attr Tuple{AutomorphismGroup{TorQuadModule}, GAPGroupHomomorphism{AutomorphismGroup{TorQuadModule}, AutomorphismGroup{TorQuadModule}}} function image_in_Oq(L::ZZLat)
   @req is_integral(L) "L must be integral"
   flag = is_even(L)
 
@@ -490,7 +490,7 @@ julia> order(Oq)
   return sub(Oq, unique!([Oq(g; check = false) for g in gens(G)]))
 end
 
-@attr function image_in_Oq_signed(L::ZZLat)::Tuple{AutomorphismGroup{Hecke.TorQuadModule}, GAPGroupHomomorphism{AutomorphismGroup{Hecke.TorQuadModule}, AutomorphismGroup{Hecke.TorQuadModule}}}
+@attr Tuple{AutomorphismGroup{TorQuadModule}, GAPGroupHomomorphism{AutomorphismGroup{TorQuadModule}, AutomorphismGroup{TorQuadModule}}} function image_in_Oq_signed(L::ZZLat)
   @req is_integral(L) "L must be integral"
   @req rank(L) > 2 && !is_definite(L) "L must be indefinite of rank at least 3"
   flag = is_even(L)

--- a/src/Modules/local_rings.jl
+++ b/src/Modules/local_rings.jl
@@ -3,7 +3,7 @@ function length(M::ModuleFP{RingElemType}) where {RingElemType<:AbsLocalizedRing
   return length(composition_series(M))
 end
 
-@attr function composition_series(
+@attr Vector{elem_type(M)} function composition_series(
     M::ModuleFP{RingElemType}
   ) where {RingElemType<:AbsLocalizedRingElem{<:Any, <:Any, <:MPolyComplementOfPrimeIdeal}}
   if iszero(M) 

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -542,7 +542,7 @@ end
 (::Colon)(a::MPolyQuoIdeal, b::MPolyQuoIdeal) = quotient(a, b)
 
 # TODO: replace by a more efficient method!
-@attr function is_prime(I::MPolyQuoIdeal)
+@attr Bool function is_prime(I::MPolyQuoIdeal)
   return is_prime(saturated_ideal(I))
 end
 
@@ -1878,7 +1878,7 @@ function AbstractAlgebra.promote_rule(::Type{MPolyQuoRingElem{S}}, ::Type{T}) wh
   end
 end
 
-@attr function _is_integral_domain(A::MPolyQuoRing)
+@attr Bool function _is_integral_domain(A::MPolyQuoRing)
   return is_prime(modulus(A))
 end
 

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -1326,7 +1326,7 @@ function ideal_membership(a::RingElem, I::MPolyLocalizedIdeal)
 end
 
 # TODO: Also add a special dispatch for localizations at 𝕜-points
-@attr function is_prime(I::MPolyLocalizedIdeal)
+@attr Bool function is_prime(I::MPolyLocalizedIdeal)
   return is_prime(saturated_ideal(I))
 end
 
@@ -2650,15 +2650,15 @@ true
   return ideal(base_ring(I), [g for g in R.(gens(radical(J))) if !is_zero(g)])
 end
 
-@attr function dim(I::MPolyLocalizedIdeal{RT}) where {RT<:MPolyLocRing{<:Ring, <:RingElem, <:MPolyRing, <:MPolyRingElem, <:MPolyPowersOfElement}}
+@attr Int function dim(I::MPolyLocalizedIdeal{RT}) where {RT<:MPolyLocRing{<:Ring, <:RingElem, <:MPolyRing, <:MPolyRingElem, <:MPolyPowersOfElement}}
   return dim(saturated_ideal(I))
 end
 
-@attr function dim(I::MPolyLocalizedIdeal{RT}) where {RT<:MPolyLocRing{<:Ring, <:RingElem, <:MPolyRing, <:MPolyRingElem, <:MPolyComplementOfPrimeIdeal}}
+@attr Int function dim(I::MPolyLocalizedIdeal{RT}) where {RT<:MPolyLocRing{<:Ring, <:RingElem, <:MPolyRing, <:MPolyRingElem, <:MPolyComplementOfPrimeIdeal}}
   return dim(saturated_ideal(I)) - dim(prime_ideal(inverted_set(base_ring(I))))
 end
 
-@attr function dim(I::MPolyLocalizedIdeal{RT}) where {RT<:MPolyLocRing{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, <:MPolyComplementOfKPointIdeal}}
+@attr Int function dim(I::MPolyLocalizedIdeal{RT}) where {RT<:MPolyLocRing{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, <:MPolyComplementOfKPointIdeal}}
   J = shifted_ideal(I)
   # TODO: Is there a more conceptual way to do this???
   oo = negdegrevlex(gens(base_ring(J)))

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -2019,11 +2019,11 @@ function jacobian_matrix(g::Vector{<:MPolyQuoLocRingElem})
   return matrix(L, n, length(g), [derivative(x, i) for i=1:n for x = g])
 end
 
-@attr function is_prime(I::MPolyQuoLocalizedIdeal)
+@attr Bool function is_prime(I::MPolyQuoLocalizedIdeal)
   return is_prime(saturated_ideal(I))
 end
 
-@attr function _is_integral_domain(W::MPolyQuoLocRing)
+@attr Bool function _is_integral_domain(W::MPolyQuoLocRing)
   return is_prime(modulus(W))
 end
 
@@ -2050,7 +2050,7 @@ end
   return ideal(R, restricted_map(iso_inv).(lifted_numerator.(gens(pre_result))))
 end
 
-@attr function dim(I::MPolyQuoLocalizedIdeal)
+@attr Int function dim(I::MPolyQuoLocalizedIdeal)
   return dim(pre_image_ideal(I))
 end
 


### PR DESCRIPTION
If one only adds `@attr` to a function without giving a type, one shadows all inference of this function for callers of this function as the `@attr` code changes the inference result to `Any`. This PR thus adds types there, where it was obvious to me what the return type is, or where the compiler was able to prove a concrete return type (if one removes the `@attr` to allow for real inference).

The commits are partitioned by the area they touch. Let me ping some people in the different areas here to make them aware / get a review.
- Lie algebras -> myself, no review needed
- lattices -> @StevellM or maybe @ThomasBreuer ?
- schemes -> @afkafkafk13 @HechtiDerLachs 
- rings -> @jankoboehm @HechtiDerLachs 
- groups -> @ThomasBreuer 