### PR TITLE
[FTheoryTools] Improve computation of refined Tate fiber types

### DIFF
--- a/experimental/FTheoryTools/docs/src/introduction.md
+++ b/experimental/FTheoryTools/docs/src/introduction.md
@@ -90,4 +90,5 @@ Alternatively, you can [raise an issue on github](https://www.oscar-system.org/c
 
 ## Acknowledgements
 
-We appreciate insightful discussions with [Mirjam Cvetič](https://live-sas-physics.pantheon.sas.upenn.edu/people/standing-faculty/mirjam-cvetic). Martin Bies and Mikelis Mikelsons appreciate support by the TU-Nachwuchsring. The work of Andrew Turner is supported by DOE (HEP) Award DE-SC001352.
+We appreciate insightful discussions with [Mirjam Cvetič](https://live-sas-physics.pantheon.sas.upenn.edu/people/standing-faculty/mirjam-cvetic) and 
+[Mohab Safey El Din](https://www.lip6.fr/actualite/personnes-fiche.php?ident=P816#). Martin Bies and Mikelis Mikelsons appreciate support by the TU-Nachwuchsring. The work of Andrew Turner is supported by DOE (HEP) Award DE-SC001352.

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
@@ -303,6 +303,7 @@ function put_over_concrete_base(m::AbstractFTheoryModel, concrete_data::Dict{Str
   # Conduct elementary entry checks
   @req base_space(m) isa FamilyOfSpaces "The model must be defined over a family of spaces"
   @req haskey(concrete_data, "base") "The base space must be specified"
+  @req (concrete_data["base"] isa NormalToricVariety) "Currently, models over families of spaces can only be put over toric bases"
   @req ((m isa WeierstrassModel) || (m isa GlobalTateModel)) "Currently, only Tate or Weierstrass models can be put on a concrete base"
   
   # Work out the Weierstrass/Tate sections
@@ -362,7 +363,7 @@ function put_over_concrete_base(m::AbstractFTheoryModel, concrete_data::Dict{Str
 
       if haskey(parametrization, "g")
         new_sec = mapper(parametrization["g"])
-        if is_zero(new_sec) == false
+        if !is_zero(new_sec)
           @req degree(new_sec) == degree(generic_section(anticanonical_bundle(concrete_data["base"])^6)) "Degree mismatch"
         end
         new_model_secs["g"] = new_sec
@@ -374,7 +375,7 @@ function put_over_concrete_base(m::AbstractFTheoryModel, concrete_data::Dict{Str
 
       if haskey(parametrization, "a1")
         new_sec = mapper(parametrization["a1"])
-        if is_zero(new_sec) == false
+        if !is_zero(new_sec)
           @req degree(new_sec) == degree(generic_section(anticanonical_bundle(concrete_data["base"]))) "Degree mismatch"
         end
         new_model_secs["a1"] = new_sec
@@ -384,7 +385,7 @@ function put_over_concrete_base(m::AbstractFTheoryModel, concrete_data::Dict{Str
 
       if haskey(parametrization, "a2")
         new_sec = mapper(parametrization["a2"])
-        if is_zero(new_sec) == false
+        if !is_zero(new_sec)
           @req degree(new_sec) == degree(generic_section(anticanonical_bundle(concrete_data["base"])^2)) "Degree mismatch"
         end
         new_model_secs["a2"] = new_sec
@@ -394,7 +395,7 @@ function put_over_concrete_base(m::AbstractFTheoryModel, concrete_data::Dict{Str
 
       if haskey(parametrization, "a3")
         new_sec = mapper(parametrization["a3"])
-        if is_zero(new_sec) == false
+        if !is_zero(new_sec)
           @req degree(new_sec) == degree(generic_section(anticanonical_bundle(concrete_data["base"])^3)) "Degree mismatch"
         end
         new_model_secs["a3"] = new_sec
@@ -404,7 +405,7 @@ function put_over_concrete_base(m::AbstractFTheoryModel, concrete_data::Dict{Str
 
       if haskey(parametrization, "a4")
         new_sec = mapper(parametrization["a4"])
-        if is_zero(new_sec) == false
+        if !is_zero(new_sec)
           @req degree(new_sec) == degree(generic_section(anticanonical_bundle(concrete_data["base"])^4)) "Degree mismatch"
         end
         new_model_secs["a4"] = new_sec
@@ -414,7 +415,7 @@ function put_over_concrete_base(m::AbstractFTheoryModel, concrete_data::Dict{Str
 
       if haskey(parametrization, "a6")
         new_sec = mapper(parametrization["a6"])
-        if is_zero(new_sec) == false
+        if !is_zero(new_sec)
           @req degree(new_sec) == degree(generic_section(anticanonical_bundle(concrete_data["base"])^6)) "Degree mismatch"
         end
         new_model_secs["a6"] = new_sec

--- a/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
@@ -65,7 +65,7 @@ hypersurface_equation_parametrization(h::HypersurfaceModel) = h.hypersurface_equ
     weierstrass_model(h::HypersurfaceModel)
 
 Return the Weierstrass model corresponding to the
-hypersurface model, provided that the latter is known.
+hypersurface model, provided that the former is known.
 
 ```jldoctest
 julia> t = literature_model(14)

--- a/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
@@ -176,6 +176,6 @@ at each locus. Also the refined Tate fiber type is returned.
 """
 @attr Vector{<:Tuple{<:MPolyIdeal{<:MPolyRingElem}, Tuple{Int64, Int64, Int64}, String}} function singular_loci(h::HypersurfaceModel)
   @req base_space(h) isa NormalToricVariety "Singular loci currently only supported for toric varieties as base space"
-  @req has_attribute(h, :weierstrass_model) "No corresponding Weierstrass model is known"
-  return singular_loci(weierstrass_model(h))
+  @req has_attribute(h, :weierstrass_model) || has_attribute(h, :global_tate_model) "No corresponding Weierstrass model or global Tate model is known"
+  return has_attribute(h, :weierstrass_model) ? singular_loci(weierstrass_model(h)) : singular_loci(global_tate_model(h))
 end

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -1,6 +1,6 @@
 ########################################################## DESCRIPTION OF TERMINOLOGY ###########################################################
 # The definitions here SHOULD apply throughout FTheoryTools!
-#                                                defining_classes: This should be a dictionary that includes specifies the divisor classes
+#                                                defining_classes: This should be a dictionary that specifies the divisor classes
 #                                                                  of any parameters used to tune the model beyond the fully generic
 #                                                                  Weierstrass/Tate/etc polynomial. For example, a Tate SU(5) Model
 #                                                                  may be tuned by setting

--- a/experimental/FTheoryTools/src/WeierstrassModels/attributes.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/attributes.jl
@@ -266,7 +266,7 @@ julia> length(singular_loci(w))
     g_order = !isnothing(g_index) ? saturation_with_index(g_primes[g_index][1], d_prime[2])[2] : 0
     d_order = saturation_with_index(d_prime[1], d_prime[2])[2]
     ords = (f_order, g_order, d_order)
-    push!(kodaira_types, (d_prime[2], ords, _kodaira_type(d_prime[2], weierstrass_section_f(w), weierstrass_section_g(w), discriminant(w), ords, is_base_space_fully_specified(w))))
+    push!(kodaira_types, (d_prime[2], ords, _kodaira_type(d_prime[2], ords, w)))
   end
   
   return kodaira_types

--- a/experimental/FTheoryTools/src/WeierstrassModels/attributes.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/attributes.jl
@@ -266,7 +266,7 @@ julia> length(singular_loci(w))
     g_order = !isnothing(g_index) ? saturation_with_index(g_primes[g_index][1], d_prime[2])[2] : 0
     d_order = saturation_with_index(d_prime[1], d_prime[2])[2]
     ords = (f_order, g_order, d_order)
-    push!(kodaira_types, (d_prime[2], ords, _kodaira_type(d_prime[2], weierstrass_section_f(w), weierstrass_section_g(w), discriminant(w), ords)))
+    push!(kodaira_types, (d_prime[2], ords, _kodaira_type(d_prime[2], weierstrass_section_f(w), weierstrass_section_g(w), discriminant(w), ords, is_base_space_fully_specified(w))))
   end
   
   return kodaira_types

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -149,7 +149,7 @@ _count_factors(poly::QQMPolyRingElem) = mapreduce(p -> p[end], +, absolute_prima
 
 _string_from_factor_count(poly::QQMPolyRingElem, string_list::Vector{String}) = string_list[_count_factors(poly)]
 
-function _kodaira_type(id::MPolyIdeal{T}, f::T, g::T, d::T, ords::Tuple{Int64, Int64, Int64}, concrete_base::Bool) where {T<:MPolyRingElem}
+function _kodaira_type(id::MPolyIdeal{<:MPolyRingElem}, ords::Tuple{Int64, Int64, Int64}, w::WeierstrassModel; rand_seed::Union{Int64, Nothing} = nothing)
   f_ord = ords[1]
   g_ord = ords[2]
   d_ord = ords[3]
@@ -169,116 +169,123 @@ function _kodaira_type(id::MPolyIdeal{T}, f::T, g::T, d::T, ords::Tuple{Int64, I
     kod_type = "II^*"
   elseif d_ord >= 12 && f_ord >= 4 && g_ord >= 6
     kod_type = "Non-minimal"
+  elseif d_ord == 6 && f_ord >= 2 && g_ord >= 3
+    # For type I_0^* singularities, we have to rely on the old method for now,
+    # which is not always dependable
+
+    f = weierstrass_section_f(w)
+    g = weierstrass_section_g(w)
+    d = discriminant(w)
+
+    # Create new ring with auxiliary variable to construct the monodromy polynomial
+    R = parent(f)
+    S, (_psi, ) = polynomial_ring(QQ, ["_psi"; [string(v) for v in gens(R)]], cached = false)
+    ring_map = hom(R, S, gens(S)[2:end])
+    poly_f = ring_map(f)
+    poly_g = ring_map(g)
+    locus = ring_map(gens(id)[1])
+
+    f_quotient = divrem(div(poly_f, locus^2), locus)[2]
+    g_quotient = divrem(div(poly_g, locus^3), locus)[2]
+    
+    monodromy_poly = _psi^3 + _psi * f_quotient + g_quotient
+    kod_type = _string_from_factor_count(monodromy_poly, ["Non-split I^*_0", "Semi-split I^*_0", "Split I^*_0"])
   else
-    if concrete_base
-      # Over concrete bases, we reduce to only two variables
-      # so that the computation is faster
-      num_gens = length(gens(parent(f)))
-      first_coord_inds = collect(1:num_gens - 2)
-      last_coord_inds = collect(3:num_gens)
-      rand_ints_ab2 = rand(-100:100, num_gens - 2)
-      w_first_2 = evaluate(forget_decoration(gens(id)[1]), last_coord_inds, rand_ints_ab2)
-      f_first_2 = evaluate(forget_decoration(f), last_coord_inds, rand_ints_ab2)
-      g_first_2 = evaluate(forget_decoration(g), last_coord_inds, rand_ints_ab2)
-      d_first_2 = evaluate(forget_decoration(d), last_coord_inds, rand_ints_ab2)
-      w_last_2 = evaluate(forget_decoration(gens(id)[1]), first_coord_inds, rand_ints_ab2)
-      f_last_2 = evaluate(forget_decoration(f), first_coord_inds, rand_ints_ab2)
-      g_last_2 = evaluate(forget_decoration(g), first_coord_inds, rand_ints_ab2)
-      d_last_2 = evaluate(forget_decoration(d), first_coord_inds, rand_ints_ab2)
+    # If the base is arbitrary, we tune the model over projective space of the
+    # appropriate dimension. This allows us to use the same algorithm for all
+    # cases. The choice of projective space here is an attempt to minimize the
+    # chances of accidental gauge enhancement
+    if !is_base_space_fully_specified(w)
+      # Build the new concrete base, and get the anticanonical and hyperplane
+      # bundles. We choose the hyperplane bundle for all gauge loci over the
+      # concrete base as an additional measure to avoid accidental gauge
+      # enhancement
+      concrete_base = projective_space(NormalToricVariety, dim(base_space(w)))
+      KBar = anticanonical_bundle(concrete_base)
+      hyperplane_bundle = toric_line_bundle(torusinvariant_prime_divisors(concrete_base)[1])
 
-      # Check monodromy conditions for remaining cases
-      if f_ord == 0 && g_ord == 0
-        q_first = quotient(ideal([9 * g_first_2, w_first_2]), ideal([2 * f_first_2, w_first_2]))
-        q_last = quotient(ideal([9 * g_last_2, w_last_2]), ideal([2 * f_last_2, w_last_2]))
+      # Get the grading matrix and the coordinates of the arbitrary base
+      grading = weights(base_space(w))
+      base_coords = gens(coordinate_ring(base_space(w)))
+      @req (length(base_coords) == length(grading[1, :])) "The number of columns in the weight matrix does not match the number of base cooordinates"
 
-        kod_type = if (is_radical(q_first) && is_radical(q_last)) "Non-split I_$d_ord" else "Split I_$d_ord" end
-      elseif d_ord == 4 && g_ord == 2 && f_ord >= 2
-        q_first = quotient(ideal([g_first_2]), ideal([w_first_2^2])) + ideal([w_first_2])
-        q_last = quotient(ideal([g_last_2]), ideal([w_last_2^2])) + ideal([w_last_2])
+      # Choose explicit sections for all parameters of the model,
+      # and then put the model over the concrete base using these data
+      concrete_data = merge(Dict(string(base_coords[i]) => generic_section(KBar^grading[1, i] * prod(hyperplane_bundle^grading[j, i] for j in 2:length(grading[:, 1]))) for i in eachindex(base_coords)), Dict("base" => concrete_base))
+      w = put_over_concrete_base(w, concrete_data)
 
-        kod_type = if (is_radical(q_first) && is_radical(q_last)) "Non-split IV" else "Split IV" end
-      elseif d_ord == 6 && f_ord >= 2 && g_ord >= 3
-        # For type I_0^* singularities, we have to rely on the old method for now,
-        # which is not always dependable
+      # We also need to determine the gauge locus over the new base
+      # by using the explicit forms of all of the sections chosen above
+      list_of_sections = [concrete_data[string(base_coords[i])] for i in eachindex(base_coords)]
+      id = ideal([evaluate(p, list_of_sections) for p in gens(id)])
+    end
 
-        # Create new ring with auxiliary variable to construct the monodromy polynomial
-        R = parent(f)
-        S, (_psi, ) = polynomial_ring(QQ, ["_psi"; [string(v) for v in gens(R)]], cached = false)
-        ring_map = hom(R, S, gens(S)[2:end])
-        poly_f = ring_map(f)
-        poly_g = ring_map(g)
-        locus = ring_map(gens(id)[1])
+    f = weierstrass_section_f(w)
+    g = weierstrass_section_g(w)
+    d = discriminant(w)
 
-        f_quotient = divrem(div(poly_f, locus^2), locus)[2]
-        g_quotient = divrem(div(poly_g, locus^3), locus)[2]
-        
-        monodromy_poly = _psi^3 + _psi * f_quotient + g_quotient
-        kod_type = _string_from_factor_count(monodromy_poly, ["Non-split I^*_0", "Semi-split I^*_0", "Split I^*_0"])
-      elseif f_ord == 2 && g_ord == 3 && d_ord >= 7
-        if d_ord % 2 == 0
-          q_first = quotient(ideal([4 // 81 * (d_first_2 * f_first_2^2) / w_first_2^(d_ord + 4), w_first_2]), ideal([g_first_2^2 / w_first_2^6, w_first_2]))
-          q_last = quotient(ideal([4 // 81 * (d_last_2 * f_last_2^2) / w_last_2^(d_ord + 4), w_last_2]), ideal([g_last_2^2 / w_last_2^6, w_last_2]))
-        else
-          q_first = quotient(ideal([2 // 729 * (d_first_2 * f_first_2^3) / w_first_2^(d_ord + 6), w_first_2]), ideal([g_first_2^3 / w_first_2^9, w_first_2]))
-          q_last = quotient(ideal([2 // 729 * (d_last_2 * f_last_2^3) / w_last_2^(d_ord + 6), w_last_2]), ideal([g_last_2^3 / w_last_2^9, w_last_2]))
+    # For now, we explicitly require that the gauge ideal is principal
+    @req (length(gens(id)) == 1) "Gauge ideal is not principal"
+
+    # Over concrete bases, we randomly reduce the polynomials defining the gauge
+    # divisor to only two variables so that the is_radical check is faster. This
+    # could give an incorrect result (radical or not), so we actually try this
+    # five times and see if we get agreement among all of the results
+    num_gens = length(gens(parent(f)))
+    gauge2s, f2s, g2s, d2s = [], [], [], []
+    if rand_seed != nothing
+      Random.seed!(rand_seed)
+    end
+    for _ in 1:5
+      coord_inds = randperm(num_gens)[1:end-2]
+      rand_ints = rand(-100:100, num_gens - 2)
+
+      push!(gauge2s, evaluate(forget_decoration(gens(id)[1]), coord_inds, rand_ints))
+      push!(f2s, evaluate(forget_decoration(f), coord_inds, rand_ints))
+      push!(g2s, evaluate(forget_decoration(g), coord_inds, rand_ints))
+      push!(d2s, evaluate(forget_decoration(d), coord_inds, rand_ints))
+    end
+
+    # Check monodromy conditions for remaining cases.
+    # Default to split when there is disagreement among the five attempts,
+    # because this approach seems to skew toward accidentally identifying
+    # a singularity as non-split
+    if f_ord == 0 && g_ord == 0
+      quotients = []
+      for i in eachindex(gauge2s)
+        push!(quotients, quotient(ideal([9 * g2s[i], gauge2s[i]]), ideal([2 * f2s[i], gauge2s[i]])))
+      end
+
+      kod_type = if all(q -> is_radical(q), quotients) "Non-split I_$d_ord" else "Split I_$d_ord" end
+    elseif d_ord == 4 && g_ord == 2 && f_ord >= 2
+      quotients = []
+      for i in eachindex(gauge2s)
+        push!(quotients, quotient(ideal([g2s[i]]), ideal([gauge2s[i]^2])) + ideal([gauge2s[i]]))
+      end
+
+      kod_type = if all(q -> is_radical(q), quotients) "Non-split IV" else "Split IV" end
+    elseif f_ord == 2 && g_ord == 3 && d_ord >= 7
+      quotients = []
+      if d_ord % 2 == 0
+        for i in eachindex(gauge2s)
+          push!(quotients, quotient(ideal([4 // 81 * (d2s[i] * f2s[i]^2) / gauge2s[i]^(d_ord + 4), gauge2s[i]]), ideal([g2s[i]^2 / gauge2s[i]^6, gauge2s[i]])))
         end
-
-        kod_type = if (is_radical(q_first) && is_radical(q_last)) "Non-split I^*_$(d_ord - 6)" else "Split I^*_$(d_ord - 6)" end
-      elseif d_ord == 8 && g_ord == 4 && f_ord >= 3
-        q_first = quotient(ideal([g_first_2]), ideal([w_first_2^4])) + ideal([w_first_2])
-        q_last = quotient(ideal([g_last_2]), ideal([w_last_2^4])) + ideal([w_last_2])
-
-        kod_type = if (is_radical(q_first) && is_radical(q_last)) "Non-split IV^*" else "Split IV^*" end
       else
-        kod_type = "Unrecognized"
+        for i in eachindex(gauge2s)
+          push!(quotients, quotient(ideal([2 // 729 * (d2s[i] * f2s[i]^3) / gauge2s[i]^(d_ord + 6), gauge2s[i]]), ideal([g2s[i]^3 / gauge2s[i]^9, gauge2s[i]])))
+        end
       end
+
+      kod_type = if all(q -> is_radical(q), quotients) "Non-split I^*_$(d_ord - 6)" else "Split I^*_$(d_ord - 6)" end
+    elseif d_ord == 8 && g_ord == 4 && f_ord >= 3
+      quotients = []
+      for i in eachindex(gauge2s)
+        push!(quotients, quotient(ideal([g2s[i]]), ideal([gauge2s[i]^4])) + ideal([gauge2s[i]]))
+      end
+
+      kod_type = if all(q -> is_radical(q), quotients) "Non-split IV^*" else "Split IV^*" end
     else
-      # Create new ring with auxiliary variable to construct the monodromy polynomial
-      R = parent(f)
-      S, (_psi, ) = polynomial_ring(QQ, ["_psi"; [string(v) for v in gens(R)]], cached = false)
-      ring_map = hom(R, S, gens(S)[2:end])
-      poly_f = ring_map(f)
-      poly_g = ring_map(g)
-      poly_d = ring_map(d)
-      locus = ring_map(gens(id)[1])
-      
-      # Compute monodromy polynomial and check factorization for remaining cases
-      if f_ord == 0 && g_ord == 0
-        g_quotient = divrem(9 * poly_g, locus)[2]
-        f_quotient = divrem(2 * poly_f, locus)[2]
-        quotient_val = div(g_quotient, f_quotient)
-  
-        monodromy_poly = _psi^2 + quotient_val
-        kod_type = _string_from_factor_count(monodromy_poly, ["Non-split I_$d_ord", "Split I_$d_ord"])
-      elseif d_ord == 4 && g_ord == 2 && f_ord >= 2
-        g_quotient = divrem(div(poly_g, locus^2), locus)[2]
-  
-        monodromy_poly = _psi^2 - g_quotient
-        kod_type = _string_from_factor_count(monodromy_poly, ["Non-split IV", "Split IV"])
-      elseif d_ord == 6 && f_ord >= 2 && g_ord >= 3
-        f_quotient = divrem(div(poly_f, locus^2), locus)[2]
-        g_quotient = divrem(div(poly_g, locus^3), locus)[2]
-        
-        monodromy_poly = _psi^3 + _psi * f_quotient + g_quotient
-        kod_type = _string_from_factor_count(monodromy_poly, ["Non-split I^*_0", "Semi-split I^*_0", "Split I^*_0"])
-      elseif f_ord == 2 && g_ord == 3 && d_ord >= 7
-        d_quotient = div(poly_d, locus^d_ord)
-        f_quotient = div(2 * poly_f, locus^2)
-        g_quotient = div(9 * poly_g, locus^3)
-        num_quotient = divrem(d_quotient * f_quotient^(2 + d_ord % 2), locus)[2]
-        den_quotient = divrem(4 * g_quotient^(2 + d_ord % 2), locus)[2]
-        quotient_val = div(num_quotient, den_quotient)
-  
-        monodromy_poly = _psi^2 + quotient_val
-        kod_type = _string_from_factor_count(monodromy_poly, ["Non-split I^*_$(d_ord - 6)", "Split I^*_$(d_ord - 6)"])
-      elseif d_ord == 8 && g_ord == 4 && f_ord >= 3
-        g_quotient = divrem(div(poly_g, locus^4), locus)[2]
-  
-        monodromy_poly = _psi^2 - g_quotient
-        kod_type = _string_from_factor_count(monodromy_poly, ["Non-split IV^*", "Split IV^*"])
-      else
-        kod_type = "Unrecognized"
-      end
+      kod_type = "Unrecognized"
     end
   end
   

--- a/experimental/FTheoryTools/test/literature_models.jl
+++ b/experimental/FTheoryTools/test/literature_models.jl
@@ -783,4 +783,44 @@ foah16_B3_weier = literature_model(arxiv_id = "1408.4808", equation = "3.203", t
   @test parent(explicit_model_sections(foah14_B3_weier)["s7"]) == cox_ring(base_space(foah14_B3_weier))
   @test parent(explicit_model_sections(foah15_B3_weier)["s7"]) == cox_ring(base_space(foah15_B3_weier))
   @test parent(explicit_model_sections(foah16_B3_weier)["s7"]) == cox_ring(base_space(foah16_B3_weier))
+  @test length(singular_loci(foah1_B3_weier)) == 1
+  @test length(singular_loci(foah2_B3_weier)) == 1
+  @test length(singular_loci(foah3_B3_weier)) == 1
+  @test length(singular_loci(foah4_B3_weier)) == 2
+  @test length(singular_loci(foah5_B3_weier)) == 1
+  @test length(singular_loci(foah6_B3_weier)) == 2
+  @test length(singular_loci(foah7_B3_weier)) == 1
+  @test length(singular_loci(foah8_B3_weier)) == 3
+  @test length(singular_loci(foah9_B3_weier)) == 2
+  @test length(singular_loci(foah10_B3_weier)) == 3
+  @test length(singular_loci(foah11_B3_weier)) == 3
+  @test length(singular_loci(foah12_B3_weier)) == 3
+  @test length(singular_loci(foah13_B3_weier)) == 4
+  @test length(singular_loci(foah14_B3_weier)) == 4
+  @test length(singular_loci(foah15_B3_weier)) == 5
+  @test length(singular_loci(foah16_B3_weier)) == 4
+  @test singular_loci(foah4_B3_weier)[2][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah6_B3_weier)[2][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah8_B3_weier)[2][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah8_B3_weier)[3][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah9_B3_weier)[2][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah10_B3_weier)[2][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah10_B3_weier)[3][2:3] == ((0, 0, 3), "Split I_3")
+  @test singular_loci(foah11_B3_weier)[2][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah11_B3_weier)[3][2:3] == ((0, 0, 3), "Split I_3")
+  @test singular_loci(foah12_B3_weier)[2][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah12_B3_weier)[3][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah13_B3_weier)[2][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah13_B3_weier)[3][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah13_B3_weier)[4][2:3] == ((0, 0, 4), "Split I_4")
+  @test singular_loci(foah14_B3_weier)[2][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah14_B3_weier)[3][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah14_B3_weier)[4][2:3] == ((0, 0, 3), "Split I_3")
+  @test singular_loci(foah15_B3_weier)[2][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah15_B3_weier)[3][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah15_B3_weier)[4][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah15_B3_weier)[5][2:3] == ((0, 0, 2), "Non-split I_2")
+  @test singular_loci(foah16_B3_weier)[2][2:3] == ((0, 0, 3), "Split I_3")
+  @test singular_loci(foah16_B3_weier)[3][2:3] == ((0, 0, 3), "Split I_3")
+  @test singular_loci(foah16_B3_weier)[4][2:3] == ((0, 0, 3), "Split I_3")
 end

--- a/experimental/FTheoryTools/test/tate_models.jl
+++ b/experimental/FTheoryTools/test/tate_models.jl
@@ -128,39 +128,39 @@ istar0_s_auxiliary_base_ring, (a1pp, a2pp, a3pp, a4pp, a6pp, vp, wp, mp) = QQ["a
 tate_auxiliary_base_ring, (a1p, a2p, a3p, a4p, a6p, v, w) = QQ["a1p", "a2p", "a3p", "a4p", "a6p", "v", "w"];
 
 # construct Tate models over arbitrary base
-t_istar0_s = global_tate_model(istar0_s_auxiliary_base_ring, [1 2 3 4 6 0 2; -1 -2 -2 -3 -4 1 -1], 3, [a1pp * (vp^2 + wp)^1, mp * (vp^2 + wp)^1 + a2pp * (vp^2 + wp)^2, a3pp * (vp^2 + wp)^2, mp^2 * (vp^2 + wp)^2 + a4pp * (vp^2 + wp)^3, a6pp * (vp^2 + wp)^4]);
-t_i1 = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; 0 0 -1 -1 -1 1], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^0, a3p * (v^2 + w)^1, a4p * (v^2 + w)^1, a6p * (v^2 + w)^1]);
-t_i2_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; 0 0 -1 -1 -2 1], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^0, a3p * (v^2 + w)^1, a4p * (v^2 + w)^1, a6p * (v^2 + w)^2]);
-t_i2_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; 0 -1 -1 -1 -2 1], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^1, a3p * (v^2 + w)^1, a4p * (v^2 + w)^1, a6p * (v^2 + w)^2]);
-t_i3_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; 0 0 -2 -2 -3 1], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^0, a3p * (v^2 + w)^2, a4p * (v^2 + w)^2, a6p * (v^2 + w)^3]);
-t_i3_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; 0 -1 -1 -2 -3 1], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^1, a3p * (v^2 + w)^1, a4p * (v^2 + w)^2, a6p * (v^2 + w)^3]);
-t_i4_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; 0 0 -2 -2 -4 1], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^0, a3p * (v^2 + w)^2, a4p * (v^2 + w)^2, a6p * (v^2 + w)^4]);
-t_i4_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; 0 -1 -2 -2 -4 1], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^1, a3p * (v^2 + w)^2, a4p * (v^2 + w)^2, a6p * (v^2 + w)^4]);
-t_i5_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; 0 0 -3 -3 -5 1], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^0, a3p * (v^2 + w)^3, a4p * (v^2 + w)^3, a6p * (v^2 + w)^5]);
-t_i5_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; 0 -1 -2 -3 -5 1], 3, [a1p * v^0, a2p * v^1, a3p * v^2, a4p * v^3, a6p * v^5]);
-t_i6_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; 0 0 -3 -3 -6 1], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^0, a3p * (v^2 + w)^3, a4p * (v^2 + w)^3, a6p * (v^2 + w)^6]);
-t_i6_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; 0 -1 -3 -3 -6 1], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^1, a3p * (v^2 + w)^3, a4p * (v^2 + w)^3, a6p * (v^2 + w)^6]);
-t_i7_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; 0 0 -4 -4 -7 1], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^0, a3p * (v^2 + w)^4, a4p * (v^2 + w)^4, a6p * (v^2 + w)^7]);
-t_i7_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; 0 -1 -3 -4 -7 1], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^1, a3p * (v^2 + w)^3, a4p * (v^2 + w)^4, a6p * (v^2 + w)^7]);
-t_ii = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -1 -1 -1 -1 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^1, a4p * (v^2 + w)^1, a6p * (v^2 + w)^1]);
-t_iii = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -1 -1 -1 -2 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^1, a4p * (v^2 + w)^1, a6p * (v^2 + w)^2]);
-t_iv_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -1 -1 -2 -2 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^1, a4p * (v^2 + w)^2, a6p * (v^2 + w)^2]);
-t_iv_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -1 -1 -2 -3 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^1, a4p * (v^2 + w)^2, a6p * (v^2 + w)^3]);
-t_istar0_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -1 -2 -2 -3 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^2, a4p * (v^2 + w)^2, a6p * (v^2 + w)^3]);
-t_istar0_ss = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -1 -2 -2 -4 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^2, a4p * (v^2 + w)^2, a6p * (v^2 + w)^4]);
-t_istar1_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -1 -2 -3 -4 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^2, a4p * (v^2 + w)^3, a6p * (v^2 + w)^4]);
-t_istar1_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -1 -2 -3 -5 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^2, a4p * (v^2 + w)^3, a6p * (v^2 + w)^5]);
-t_istar2_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -1 -3 -3 -5 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^3, a4p * (v^2 + w)^3, a6p * (v^2 + w)^5]);
-t_istar2_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -1 -3 -3 -6 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^3, a4p * (v^2 + w)^3, a6p * (v^2 + w)^6]);
-t_istar3_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -1 -3 -4 -6 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^3, a4p * (v^2 + w)^4, a6p * (v^2 + w)^6]);
-t_istar3_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -1 -3 -4 -7 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^3, a4p * (v^2 + w)^4, a6p * (v^2 + w)^7]);
-t_istar4_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -1 -4 -4 -7 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^4, a4p * (v^2 + w)^4, a6p * (v^2 + w)^7]);
-t_istar4_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -1 -4 -4 -8 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^4, a4p * (v^2 + w)^4, a6p * (v^2 + w)^8]);
-t_ivstar_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -2 -2 -3 -4 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^2, a3p * (v^2 + w)^2, a4p * (v^2 + w)^3, a6p * (v^2 + w)^4]);
-t_ivstar_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -2 -2 -3 -5 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^2, a3p * (v^2 + w)^2, a4p * (v^2 + w)^3, a6p * (v^2 + w)^5]);
-t_iiistar = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -2 -3 -3 -5 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^2, a3p * (v^2 + w)^3, a4p * (v^2 + w)^3, a6p * (v^2 + w)^5]);
-t_iistar = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -2 -3 -4 -5 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^2, a3p * (v^2 + w)^3, a4p * (v^2 + w)^4, a6p * (v^2 + w)^5]);
-t_nm = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -2 -3 -4 -6 1], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^2, a3p * (v^2 + w)^3, a4p * (v^2 + w)^4, a6p * (v^2 + w)^6]);
+t_istar0_s = global_tate_model(istar0_s_auxiliary_base_ring, [1 2 3 4 6 0 0 2; -2 -4 -4 -6 -8 1 2 -2], 3, [a1pp * (vp^2 + wp)^1, mp * (vp^2 + wp)^1 + a2pp * (vp^2 + wp)^2, a3pp * (vp^2 + wp)^2, mp^2 * (vp^2 + wp)^2 + a4pp * (vp^2 + wp)^3, a6pp * (vp^2 + wp)^4]);
+t_i1 = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; 0 0 -2 -2 -2 1 2], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^0, a3p * (v^2 + w)^1, a4p * (v^2 + w)^1, a6p * (v^2 + w)^1]);
+t_i2_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; 0 0 -2 -2 -4 1 2], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^0, a3p * (v^2 + w)^1, a4p * (v^2 + w)^1, a6p * (v^2 + w)^2]);
+t_i2_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; 0 -2 -2 -2 -4 1 2], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^1, a3p * (v^2 + w)^1, a4p * (v^2 + w)^1, a6p * (v^2 + w)^2]);
+t_i3_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; 0 0 -4 -4 -6 1 2], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^0, a3p * (v^2 + w)^2, a4p * (v^2 + w)^2, a6p * (v^2 + w)^3]);
+t_i3_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; 0 -2 -2 -4 -6 1 2], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^1, a3p * (v^2 + w)^1, a4p * (v^2 + w)^2, a6p * (v^2 + w)^3]);
+t_i4_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; 0 0 -4 -4 -8 1 2], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^0, a3p * (v^2 + w)^2, a4p * (v^2 + w)^2, a6p * (v^2 + w)^4]);
+t_i4_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; 0 -2 -4 -4 -8 1 2], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^1, a3p * (v^2 + w)^2, a4p * (v^2 + w)^2, a6p * (v^2 + w)^4]);
+t_i5_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; 0 0 -6 -6 -10 1 2], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^0, a3p * (v^2 + w)^3, a4p * (v^2 + w)^3, a6p * (v^2 + w)^5]);
+t_i5_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; 0 -1 -2 -3 -5 1 2], 3, [a1p * v^0, a2p * v^1, a3p * v^2, a4p * v^3, a6p * v^5]);
+t_i6_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; 0 0 -6 -6 -12 1 2], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^0, a3p * (v^2 + w)^3, a4p * (v^2 + w)^3, a6p * (v^2 + w)^6]);
+t_i6_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; 0 -2 -6 -6 -12 1 2], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^1, a3p * (v^2 + w)^3, a4p * (v^2 + w)^3, a6p * (v^2 + w)^6]);
+t_i7_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; 0 0 -8 -8 -14 1 2], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^0, a3p * (v^2 + w)^4, a4p * (v^2 + w)^4, a6p * (v^2 + w)^7]);
+t_i7_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; 0 -2 -6 -8 -14 1 2], 3, [a1p * (v^2 + w)^0, a2p * (v^2 + w)^1, a3p * (v^2 + w)^3, a4p * (v^2 + w)^4, a6p * (v^2 + w)^7]);
+t_ii = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -2 -2 -2 -2 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^1, a4p * (v^2 + w)^1, a6p * (v^2 + w)^1]);
+t_iii = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -2 -2 -2 -4 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^1, a4p * (v^2 + w)^1, a6p * (v^2 + w)^2]);
+t_iv_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -2 -2 -4 -4 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^1, a4p * (v^2 + w)^2, a6p * (v^2 + w)^2]);
+t_iv_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -2 -2 -4 -6 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^1, a4p * (v^2 + w)^2, a6p * (v^2 + w)^3]);
+t_istar0_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -2 -4 -4 -6 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^2, a4p * (v^2 + w)^2, a6p * (v^2 + w)^3]);
+t_istar0_ss = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -2 -4 -4 -8 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^2, a4p * (v^2 + w)^2, a6p * (v^2 + w)^4]);
+t_istar1_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -2 -4 -6 -8 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^2, a4p * (v^2 + w)^3, a6p * (v^2 + w)^4]);
+t_istar1_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -2 -4 -6 -10 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^2, a4p * (v^2 + w)^3, a6p * (v^2 + w)^5]);
+t_istar2_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -2 -6 -6 -10 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^3, a4p * (v^2 + w)^3, a6p * (v^2 + w)^5]);
+t_istar2_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -2 -6 -6 -12 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^3, a4p * (v^2 + w)^3, a6p * (v^2 + w)^6]);
+t_istar3_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -2 -6 -8 -12 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^3, a4p * (v^2 + w)^4, a6p * (v^2 + w)^6]);
+t_istar3_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -2 -6 -8 -14 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^3, a4p * (v^2 + w)^4, a6p * (v^2 + w)^7]);
+t_istar4_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -2 -8 -8 -14 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^4, a4p * (v^2 + w)^4, a6p * (v^2 + w)^7]);
+t_istar4_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -2 -8 -8 -16 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^1, a3p * (v^2 + w)^4, a4p * (v^2 + w)^4, a6p * (v^2 + w)^8]);
+t_ivstar_ns = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -4 -4 -6 -8 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^2, a3p * (v^2 + w)^2, a4p * (v^2 + w)^3, a6p * (v^2 + w)^4]);
+t_ivstar_s = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -4 -4 -6 -10 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^2, a3p * (v^2 + w)^2, a4p * (v^2 + w)^3, a6p * (v^2 + w)^5]);
+t_iiistar = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -4 -6 -6 -10 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^2, a3p * (v^2 + w)^3, a4p * (v^2 + w)^3, a6p * (v^2 + w)^5]);
+t_iistar = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -4 -6 -8 -10 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^2, a3p * (v^2 + w)^3, a4p * (v^2 + w)^4, a6p * (v^2 + w)^5]);
+t_nm = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; -2 -4 -6 -8 -12 1 2], 3, [a1p * (v^2 + w)^1, a2p * (v^2 + w)^2, a3p * (v^2 + w)^3, a4p * (v^2 + w)^4, a6p * (v^2 + w)^6]);
 
 @testset "Attributes of global Tate models over generic base space" begin
   @test parent(tate_section_a1(t_i5_s)) == coordinate_ring(base_space(t_i5_s))
@@ -177,9 +177,9 @@ t_nm = global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; -1 -2 -3 -4 -6 
 end
 
 @testset "Error messages in global Tate models over generic base space" begin
-  @test_throws ArgumentError global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; 0 -1 -2 -3 -5 1], 3, [a1p])
-  @test_throws ArgumentError global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; 0 -1 -2 -3 -5 1], 3, [a1p * v^0, a2p * v^1, a3p * v^2, a4p * v^3, sec_a6])
-  @test_throws ArgumentError global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0; 0 -1 -2 -3 -5 1], -1, [a1p * v^0, a2p * v^1, a3p * v^2, a4p * v^3, a6p * v^5])
+  @test_throws ArgumentError global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; 0 -1 -2 -3 -5 1 2], 3, [a1p])
+  @test_throws ArgumentError global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; 0 -1 -2 -3 -5 1 2], 3, [a1p * v^0, a2p * v^1, a3p * v^2, a4p * v^3, sec_a6])
+  @test_throws ArgumentError global_tate_model(tate_auxiliary_base_ring, [1 2 3 4 6 0 0; 0 -1 -2 -3 -5 1 2], -1, [a1p * v^0, a2p * v^1, a3p * v^2, a4p * v^3, a6p * v^5])
   @test_throws ArgumentError tune(t_i5_s, Dict("a2" => basis_of_global_sections(other_Kbar)[1]))
   @test_throws ArgumentError tune(t_i5_s, basis_of_global_sections(other_Kbar)[1])
 end


### PR DESCRIPTION
This adds Mohab's proposed calculation method, except in the case of Type I_0^* fibers, addressing the issue that models over concrete bases are often too complicated and seem "accidentally nonsplit". However, models over arbitrary bases are typically too simple and appear "accidentally split", so the code currently checks if the base is concrete are not and then decides whether to use the old or the new version of the calculation. This is not ideal.

Tests should also be added to more thoroughly check this.

@HereAround, @emikelsons