### PR TITLE
LieAlgebras: Serialization for modules

### DIFF
--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -419,18 +419,18 @@ end
 ###############################################################################
 
 function Base.:(==)(V1::LieAlgebraModule{C}, V2::LieAlgebraModule{C}) where {C<:FieldElem}
-  return V1.dim == V2.dim &&
-         V1.s == V2.s &&
-         V1.L == V2.L &&
-         V1.transformation_matrices == V2.transformation_matrices
+  return dim(V1) == dim(V2) &&
+         symbols(V1) == symbols(V2) &&
+         base_lie_algebra(V1) == base_lie_algebra(V2) &&
+         transformation_matrices(V1) == transformation_matrices(V2)
 end
 
 function Base.hash(V::LieAlgebraModule, h::UInt)
   b = 0x28b0c111e3ff8526 % UInt
-  h = hash(V.dim, h)
-  h = hash(V.s, h)
-  h = hash(V.L, h)
-  h = hash(V.transformation_matrices, h)
+  h = hash(dim(V), h)
+  h = hash(symbols(V), h)
+  h = hash(base_lie_algebra(V), h)
+  h = hash(transformation_matrices(V), h)
   return xor(h, b)
 end
 
@@ -478,8 +478,12 @@ function action(x::LieAlgebraElem{C}, v::LieAlgebraModuleElem{C}) where {C<:Fiel
   )
 end
 
+function transformation_matrices(V::LieAlgebraModule{C}) where {C<:FieldElem}
+  return (V.transformation_matrices)::Vector{dense_matrix_type(C)}
+end
+
 function transformation_matrix(V::LieAlgebraModule{C}, i::Int) where {C<:FieldElem}
-  return (V.transformation_matrices[i])::dense_matrix_type(C)
+  return transformation_matrices(V)[i]
 end
 
 ###############################################################################

--- a/experimental/LieAlgebras/src/Types.jl
+++ b/experimental/LieAlgebras/src/Types.jl
@@ -408,7 +408,7 @@ end
 @attributes mutable struct LieAlgebraModule{C<:FieldElem} <: AbstractAlgebra.Set
   L::LieAlgebra{C}
   dim::Int
-  transformation_matrices::Vector{MatElem{C}}
+  transformation_matrices::Vector{<:MatElem{C}} # Vector{dense_matrix_type(C)}
   s::Vector{Symbol}
 
   function LieAlgebraModule{C}(

--- a/experimental/LieAlgebras/src/serialization.jl
+++ b/experimental/LieAlgebras/src/serialization.jl
@@ -136,7 +136,7 @@ end
 #
 ###############################################################################
 
-@register_serialization_type LieAlgebraModule uses_id
+@register_serialization_type LieAlgebraModule uses_id [:_dummy_attribute]
 
 function save_object(s::SerializerState, V::LieAlgebraModule)
   save_data_dict(s) do
@@ -144,11 +144,12 @@ function save_object(s::SerializerState, V::LieAlgebraModule)
     save_object(s, dim(V), :dim)
     save_object(s, transformation_matrices(V), :transformation_matrices)
     save_object(s, symbols(V), :symbols)
+    save_construction_data(s, V)
     save_attrs(s, V)
   end
 end
 
-function load_object(s::DeserializerState, ::Type{LieAlgebraModule})
+function load_object(s::DeserializerState, T::Type{<:LieAlgebraModule})
   L = load_typed_object(s, :lie_algebra)
   R = coefficient_ring(L)
   dim = load_object(s, Int, :dim)
@@ -156,9 +157,62 @@ function load_object(s::DeserializerState, ::Type{LieAlgebraModule})
     s, Vector, (dense_matrix_type(R), matrix_space(R, dim, dim)), :transformation_matrices
   )
   symbs = load_object(s, Vector, Symbol, :symbols)
-  V = abstract_module(L, dim, transformation_matrices, symbs; check=false)
+  V = load_construction_data(s, T)
+  if isnothing(V)
+    V = abstract_module(L, dim, transformation_matrices, symbs; check=false)
+  end
   load_attrs(s, V)
   return V
+end
+
+function save_construction_data(s::SerializerState, V::LieAlgebraModule)
+  :_dummy_attribute in Oscar.attrs_list(s, typeof(V)) || return nothing # attribute saving disabled
+  save_data_dict(s, :construction_data) do
+    if _is_standard_module(V)
+      save_object(s, save_as_ref(s, base_lie_algebra(V)), :is_standard_module)
+    elseif ((fl, W) = _is_dual(V); fl)
+      save_object(s, save_as_ref(s, W), :is_dual)
+    elseif ((fl, Vs) = _is_direct_sum(V); fl)
+      save_object(s, Vs, :is_direct_sum)
+    elseif ((fl, Vs) = _is_tensor_product(V); fl)
+      save_object(s, Vs, :is_tensor_product)
+    elseif ((fl, W, k) = _is_exterior_power(V); fl)
+      save_object(s, (W, k), :is_exterior_power)
+    elseif ((fl, W, k) = _is_symmetric_power(V); fl)
+      save_object(s, (W, k), :is_symmetric_power)
+    elseif ((fl, W, k) = _is_tensor_power(V); fl)
+      save_object(s, (W, k), :is_tensor_power)
+    end
+  end
+end
+
+function load_construction_data(s::DeserializerState, T::Type{<:LieAlgebraModule})
+  V = nothing
+  s.with_attrs && haskey(s, :construction_data) &&
+    load_node(s, :construction_data) do _
+      if haskey(s, :is_standard_module)
+        V = standard_module(load_typed_object(s, :is_standard_module))
+      elseif haskey(s, :is_dual)
+        W = load_typed_object(s, :is_dual)
+        V = dual(W)
+      elseif haskey(s, :is_direct_sum)
+        Vs = load_object(s, Vector, LieAlgebraModule, :is_direct_sum)
+        V = direct_sum(Vs...)
+      elseif haskey(s, :is_tensor_product)
+        Vs = load_object(s, Vector, LieAlgebraModule, :is_tensor_product)
+        V = tensor_product(Vs...)
+      elseif haskey(s, :is_exterior_power)
+        W, k = load_object(s, Tuple, [LieAlgebraModule, Int], :is_exterior_power)
+        V = exterior_power(W, k)[1]
+      elseif haskey(s, :is_symmetric_power)
+        W, k = load_object(s, Tuple, [LieAlgebraModule, Int], :is_symmetric_power)
+        V = symmetric_power(W, k)[1]
+      elseif haskey(s, :is_tensor_power)
+        W, k = load_object(s, Tuple, [LieAlgebraModule, Int], :is_tensor_power)
+        V = tensor_power(W, k)[1]
+      end
+    end
+  return V::Union{T,Nothing}
 end
 
 @register_serialization_type LieAlgebraModuleElem uses_params

--- a/experimental/LieAlgebras/src/serialization.jl
+++ b/experimental/LieAlgebras/src/serialization.jl
@@ -136,7 +136,7 @@ end
 #
 ###############################################################################
 
-@register_serialization_type LieAlgebraModule uses_id [:_dummy_attribute]
+@register_serialization_type LieAlgebraModule uses_id [:__serialize_construction]
 
 function save_object(s::SerializerState, V::LieAlgebraModule)
   save_data_dict(s) do
@@ -166,7 +166,7 @@ function load_object(s::DeserializerState, T::Type{<:LieAlgebraModule})
 end
 
 function save_construction_data(s::SerializerState, V::LieAlgebraModule)
-  :_dummy_attribute in Oscar.attrs_list(s, typeof(V)) || return nothing # attribute saving disabled
+  :__serialize_construction in Oscar.attrs_list(s, typeof(V)) || return nothing # attribute saving disabled
   save_data_dict(s, :construction_data) do
     if _is_standard_module(V)
       save_object(s, save_as_ref(s, base_lie_algebra(V)), :is_standard_module)

--- a/experimental/LieAlgebras/test/setup_tests.jl
+++ b/experimental/LieAlgebras/test/setup_tests.jl
@@ -138,9 +138,15 @@ if !isdefined(Main, :lie_algebra_conformance_test)
           path,
           L;
           with_attrs=true,
-          check_func=loaded ->
-            has_attribute(loaded, :is_abelian) &&
-              get_attribute(loaded, :is_abelian) == get_attribute(L, :is_abelian),
+          check_func=loaded -> all((
+            has_attribute(loaded, :is_abelian),
+            get_attribute(loaded, :is_abelian) == get_attribute(L, :is_abelian),
+            sprint(show, "text/plain", loaded) == sprint(show, "text/plain", L) ||
+              occursin(
+                "cyclotomic field",
+                lowercase(sprint(print, "text/plain", coefficient_ring(L))),
+              ), # cyclotomic fields are printed as number fields after (de)serialization          
+          )),
         ) do loaded
           # nothing, cause `L === loaded` anyway
         end

--- a/experimental/LieAlgebras/test/setup_tests.jl
+++ b/experimental/LieAlgebras/test/setup_tests.jl
@@ -282,7 +282,33 @@ if !isdefined(Main, :lie_algebra_module_conformance_test) || isinteractive()
     if dim(V) <= 50 # for better test runtimes
       @testset "Serialization" begin
         mktempdir() do path
-          test_save_load_roundtrip(path, V) do loaded
+          test_save_load_roundtrip(
+            path,
+            V;
+            with_attrs=false,
+          ) do loaded
+            # nothing, cause `V === loaded` anyway
+          end
+
+          test_save_load_roundtrip(
+            path,
+            V;
+            with_attrs=true,
+            check_func=loaded -> all((
+              sprint(show, "text/plain", loaded) == sprint(show, "text/plain", V) ||
+                occursin(
+                  "cyclotomic field",
+                  lowercase(sprint(print, "text/plain", coefficient_ring(V))),
+                ) # cyclotomic fields are printed as number fields after (de)serialization
+                || Oscar.LieAlgebras._is_standard_module(V)     # TODO: make work
+                || Oscar.LieAlgebras._is_dual(V)[1]             # TODO: make work
+                || Oscar.LieAlgebras._is_direct_sum(V)[1]       # TODO: make work
+                || Oscar.LieAlgebras._is_tensor_product(V)[1]   # TODO: make work
+                || Oscar.LieAlgebras._is_exterior_power(V)[1]   # TODO: make work
+                || Oscar.LieAlgebras._is_symmetric_power(V)[1]  # TODO: make work
+                || Oscar.LieAlgebras._is_tensor_power(V)[1],     # TODO: make work
+            )),
+          ) do loaded
             # nothing, cause `V === loaded` anyway
           end
 

--- a/experimental/LieAlgebras/test/setup_tests.jl
+++ b/experimental/LieAlgebras/test/setup_tests.jl
@@ -4,7 +4,7 @@ if !isdefined(Main, :GAPWrap)
   import Oscar: GAPWrap
 end
 
-if !isdefined(Main, :lie_algebra_conformance_test)
+if !isdefined(Main, :lie_algebra_conformance_test) || isinteractive()
   function lie_algebra_conformance_test(
     L::LieAlgebra{C}, parentT::DataType, elemT::DataType; num_random_tests::Int=10
   ) where {C<:FieldElem}
@@ -172,7 +172,7 @@ if !isdefined(Main, :lie_algebra_conformance_test)
   end
 end
 
-if !isdefined(Main, :lie_algebra_module_conformance_test)
+if !isdefined(Main, :lie_algebra_module_conformance_test) || isinteractive()
   function lie_algebra_module_conformance_test(
     L::LieAlgebra{C},
     V::LieAlgebraModule{C},

--- a/experimental/LieAlgebras/test/setup_tests.jl
+++ b/experimental/LieAlgebras/test/setup_tests.jl
@@ -298,14 +298,7 @@ if !isdefined(Main, :lie_algebra_module_conformance_test) || isinteractive()
                 occursin(
                   "cyclotomic field",
                   lowercase(sprint(print, "text/plain", coefficient_ring(V))),
-                ) # cyclotomic fields are printed as number fields after (de)serialization
-                || Oscar.LieAlgebras._is_standard_module(V)     # TODO: make work
-                || Oscar.LieAlgebras._is_dual(V)[1]             # TODO: make work
-                || Oscar.LieAlgebras._is_direct_sum(V)[1]       # TODO: make work
-                || Oscar.LieAlgebras._is_tensor_product(V)[1]   # TODO: make work
-                || Oscar.LieAlgebras._is_exterior_power(V)[1]   # TODO: make work
-                || Oscar.LieAlgebras._is_symmetric_power(V)[1]  # TODO: make work
-                || Oscar.LieAlgebras._is_tensor_power(V)[1],     # TODO: make work
+                ), # cyclotomic fields are printed as number fields after (de)serialization
             )),
           ) do loaded
             # nothing, cause `V === loaded` anyway

--- a/experimental/LieAlgebras/test/setup_tests.jl
+++ b/experimental/LieAlgebras/test/setup_tests.jl
@@ -278,7 +278,6 @@ if !isdefined(Main, :lie_algebra_module_conformance_test) || isinteractive()
       end
     end
 
-    coefficient_ring(V) isa FqField && return nothing # see https://github.com/oscar-system/Oscar.jl/issues/4064
     if dim(V) <= 50 # for better test runtimes
       @testset "Serialization" begin
         mktempdir() do path

--- a/test/Serialization/setup_tests.jl
+++ b/test/Serialization/setup_tests.jl
@@ -4,7 +4,7 @@ using JSONSchema, Oscar.JSON
 
 # we only need to define this once
 
-if !isdefined(Main, :test_save_load_roundtrip)
+if !isdefined(Main, :test_save_load_roundtrip) || isinteractive()
   mrdi_schema = Schema(JSON.parsefile(joinpath(Oscar.oscardir, "data", "schema.json")))
 
   function test_save_load_roundtrip(func, path, original::T;


### PR DESCRIPTION
Some context for the review:
Most of the module stuff is pretty straightforward to serialize.
If I want to (de)serialize attributes, for a lot of them, I have some problems: They encode how the module was created, e.g. as a tensor product of some other modules. And this includes some not-serializable data, e.g. the pure tensor function that takes a tuple of elements of the tensor factors and returns the corresponding pure tensor in the module. To be able to re-create these things, I just de-serialize the tensor factors and call `tensor_product` in the load function with these, instead of de-serializing the whole module, as this sets up all necessary attributes and properties.
However, this means that I cannot use the usual attribute saving/loading, so I added the functions `{save,load}_construction_data` that deal with that. There are currently some hacks to detect in there if `with_attrs` was set in the surrounding `save/load` call. It would be great if we could refactor this at some time in the future to use a better interface to this, maybe something along the lines of https://github.com/oscar-system/Oscar.jl/pull/4068#issuecomment-2326128105. But I think that we can leave that to some future point.