### PR TITLE
Fix #4039

### DIFF
--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -898,19 +898,24 @@ Multivariate polynomial ring in 2 variables over number field graded by
   y -> [1]
 ```
 """
-@attr Any function absolute_primary_decomposition(I::MPolyIdeal{<:MPolyRingElem{QQFieldElem}})
+@attr Vector{Tuple{typeof(I), typeof(I), ideal_type(change_base_ring(rationals_as_number_field()[1], base_ring(I))[1]), Int64}} function absolute_primary_decomposition(I::MPolyIdeal{<:MPolyRingElem{QQFieldElem}})
   R = base_ring(I)
+  K, _ = rationals_as_number_field()
+  RK, _ = change_base_ring(K, R)
   if is_zero(I)
-     return [(ideal(R, zero(R)), ideal(R, zero(R)), ideal(R, zero(R)), 1)]
+    return [(ideal(R, zero(R)), ideal(R, zero(R)), ideal(RK, zero(RK)), 1)]
   end
   (S, d) = Singular.LibPrimdec.absPrimdecGTZ(singular_polynomial_ring(I), singular_generators(I))
+  if isempty(d)
+    return Vector{Tuple{typeof(I), typeof(I), ideal_type(RK), Int64}}()
+  end
   decomp = d[:primary_decomp]
   absprimes = d[:absolute_primes]
   @assert length(decomp) == length(absprimes)
   V =  [(_map_last_var(R, decomp[i][1], 1, one(QQ))) for i in 1:length(decomp)]
   if length(V) == 1 && is_one(gen(V[1], 1))
-    return Tuple{MPolyIdeal{QQMPolyRingElem}, MPolyIdeal{QQMPolyRingElem}, MPolyIdeal{AbstractAlgebra.Generic.MPoly{AbsSimpleNumFieldElem}}, Int64}[]
-  end 
+    return Vector{Tuple{typeof(I), typeof(I), ideal_type(RK), Int64}}()
+  end
   return [(V[i], _map_last_var(R, decomp[i][2], 1, one(QQ)),
          _map_to_ext(R, absprimes[i][1]),
          absprimes[i][2]::Int)

--- a/test/Rings/mpoly.jl
+++ b/test/Rings/mpoly.jl
@@ -216,6 +216,12 @@ end
   d = @inferred absolute_primary_decomposition(I)
   @test length(d) == 5
 
+  d = @inferred absolute_primary_decomposition(ideal(R()))
+  @test length(d) == 1
+
+  d = @inferred absolute_primary_decomposition(ideal(R(1)))
+  @test isempty(d)
+
   # Issue 4039
   R, (x, y) = polynomial_ring(QQ, ["x", "y"])
   I = ideal(R, [x + 1, y + 1, y])

--- a/test/Rings/mpoly.jl
+++ b/test/Rings/mpoly.jl
@@ -208,13 +208,19 @@ end
   # absolute_primary_decomposition
   R,(x,y,z) = polynomial_ring(QQ, ["x", "y", "z"])
   I = ideal(R, [(z+1)*(z^2+1)*(z^3+2)^2, x-y*z^2])
-  d = absolute_primary_decomposition(I)
+  d = @inferred absolute_primary_decomposition(I)
   @test length(d) == 3
 
   R,(x,y,z) = graded_polynomial_ring(QQ, ["x", "y", "z"])
   I = ideal(R, [(z+y)*(z^2+y^2)*(z^3+2*y^3)^2, x^3-y*z^2])
-  d = absolute_primary_decomposition(I)
+  d = @inferred absolute_primary_decomposition(I)
   @test length(d) == 5
+
+  # Issue 4039
+  R, (x, y) = polynomial_ring(QQ, ["x", "y"])
+  I = ideal(R, [x + 1, y + 1, y])
+  d = @inferred absolute_primary_decomposition(I)
+  @test isempty(d)
 
   # is_prime
   R, (x, y) = polynomial_ring(QQ, ["x", "y"])


### PR DESCRIPTION
The fix for the Singular bug in #4039 arrived in OSCAR with the latest Singular.jll

This closes #4039 by handling the empty dictionary that is now returned by Singular in the example.
