### PR TITLE
Fixes groebner_assure

### DIFF
--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -40,8 +40,8 @@ function groebner_assure(I::MPolyIdeal, complete_reduction::Bool = false, need_g
       complete_reduction || return G
       if !G.isReduced
         I.gb[G.ord] = _compute_standard_basis(G, G.ord, true)
-        return I.gb[G.ord]
       end
+      return I.gb[G.ord]
     end
   end
   ord = default_ordering(base_ring(I))

--- a/test/Rings/groebner.jl
+++ b/test/Rings/groebner.jl
@@ -120,6 +120,12 @@
     standard_basis_highest_corner(I, ordering=negdeglex(R))
     @test elements(I.gb[negdeglex(R)]) == H
     @test_throws ArgumentError standard_basis_highest_corner(I)
+
+    R, (x, y) = polynomial_ring(QQ, ["x", "y"])
+    I = ideal(R,[x^2+x*y+y,x+y^2])
+    standard_basis(I, ordering=lex(R), complete_reduction=true)
+    G = Oscar.groebner_assure(I, true, true)
+    @test G.ord == lex(R)
 end
 
 @testset "normal form graded" begin


### PR DESCRIPTION
This fixes loop breaking in `groebner_assure` for the situation when a reduced GB is requested and also available in the ideal's GB cache.