### PR TITLE
Try to fix the failing `MPolyAnyMap` doctest on nightly

### DIFF
--- a/src/Rings/MPolyMap/MPolyRing.jl
+++ b/src/Rings/MPolyMap/MPolyRing.jl
@@ -46,7 +46,7 @@ to `S`, if such a homomorphism exists, and throw an error, otherwise.
     
 
 # Examples
-```jldoctest
+```jldoctest; filter = r"\#\d+" => "#"
 julia> K, a = finite_field(2, 2, "a");
 
 julia> R, (x, y) = polynomial_ring(K, ["x", "y"]);


### PR DESCRIPTION
Around 3 days ago, an error in the nightly doctests was introduced, somewhere between 1.12.0-DEV.1160 and 1.12.0-DEV.1167. I suppose this is due to https://github.com/JuliaLang/julia/commit/0c9c1e25b7d017250fd5b64255c683b74a168a9b.

This PR tries to address this by masking the non-deterministic printing of the coefficient map behind a doctestfilter.

Please only merge if the nightly doctests succeed.