### PR TITLE
fix `GAP.julia_to_gap(T::SubgroupTransversal)`

### DIFF
--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -317,7 +317,7 @@ struct SubgroupTransversal{T<: GAPGroup, S<: GAPGroup, E<: GAPGroupElem} <: Abst
    X::GapObj               # underlying *right* transversal in GAP
 end
 
-GAP.julia_to_gap(T::SubgroupTransversal) = T.X
+GAP.julia_to_gap(T::SubgroupTransversal, d::IdDict{Any,Any} = IdDict(); recursive::Bool = false) = T.X
 
 function Base.show(io::IO, ::MIME"text/plain", x::SubgroupTransversal)
   side = x.side === :left ? "Left" : "Right"


### PR DESCRIPTION
The problem arose from the improvement in https://github.com/oscar-system/GAP.jl/pull/989:
Right transversal objects are `AbstractVector`s, and now a three argument method for these objects is available in GAP.jl, which is not the method one wants.

The fix is preliminary, things will become better again as soon as `julia_to_gap` gets reworked, see https://github.com/oscar-system/GAP.jl/issues/1025.