### PR TITLE
Run CI on experimental `*.md` doc files

### DIFF
--- a/docs/documenter_helpers.jl
+++ b/docs/documenter_helpers.jl
@@ -23,3 +23,11 @@ else
     end
   end
 end
+
+# We monkey-patch Base.walkdir to use true as default value for follow_symlinks
+# (normally false is the default), in order to "trick" the Documenter code into
+# following those symlinks.
+# See also:
+# https://github.com/JuliaDocs/Documenter.jl/pull/552
+# https://github.com/JuliaLang/julia/blob/master/doc/make.jl#L19
+Base.walkdir(str::String) = Base.walkdir(str; follow_symlinks=true)

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -112,7 +112,7 @@ function doit(
   doc = eval(Meta.parse(s))
 
   # Link experimental docs to `docs/src` and collect the documentation pages
-  Oscar.link_experimental_docs(Oscar)
+  Oscar.link_experimental_docs()
   collected = Any["Experimental/intro.md"]
   for pkg in Oscar.exppkgs
     pkgdocs = setup_experimental_package(Oscar, pkg)

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -109,22 +109,14 @@ function setup_experimental_package(Oscar::Module, package_name::String)
   return result
 end
 
-function doit(
-  Oscar::Module;
-  warnonly=false,
-  local_build::Bool=false,
-  doctest::Union{Bool,Symbol}=true,
-)
-
+function link_experimental_docs(Oscar::Module)
   # Remove symbolic links from earlier runs
   expdocdir = joinpath(Oscar.oscardir, "docs", "src", "Experimental")
   for x in readdir(expdocdir; join=true)
     islink(x) && rm(x)
   end
 
-  # include the list of pages, performing substitutions
-  s = read(joinpath(Oscar.oscardir, "docs", "doc.main"), String)
-  doc = eval(Meta.parse(s))
+  # Link the experimental documentation to docs/src and collect the pages
   collected = Any["Experimental/intro.md"]
   for pkg in Oscar.exppkgs
     pkgdocs = setup_experimental_package(Oscar, pkg)
@@ -132,6 +124,20 @@ function doit(
       append!(collected, pkgdocs)
     end
   end
+  return collected
+end
+
+function doit(
+  Oscar::Module;
+  warnonly=false,
+  local_build::Bool=false,
+  doctest::Union{Bool,Symbol}=true,
+)
+
+  # include the list of pages, performing substitutions
+  s = read(joinpath(Oscar.oscardir, "docs", "doc.main"), String)
+  doc = eval(Meta.parse(s))
+  collected = link_experimental_docs(Oscar)
   push!(doc, ("Experimental" => collected))
 
   # Load the bibliography

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -26,14 +26,6 @@ include("citation_style.jl")
 # Remove the module prefix
 Base.print(io::IO, b::Base.Docs.Binding) = print(io, b.var)
 
-# We monkey-patch Base.walkdir to use true as default value for follow_symlinks
-# (normally false is the default), in order to "trick" the Documenter code into
-# following those symlinks.
-# See also:
-# https://github.com/JuliaDocs/Documenter.jl/pull/552
-# https://github.com/JuliaLang/julia/blob/master/doc/make.jl#L19
-Base.walkdir(str::String) = Base.walkdir(str; follow_symlinks=true)
-
 # When we read a `doc.main` from an experimental package, we need to equip all
 # its entries with a prefix to fit with our docs. The doc.main of an
 # experimental package will contain paths relative to

--- a/experimental/IntersectionTheory/docs/src/AbstractVarieties.md
+++ b/experimental/IntersectionTheory/docs/src/AbstractVarieties.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = Oscar.doctestsetup()
 ```
 
 # Abstract Varieties

--- a/experimental/IntersectionTheory/docs/src/examples.md
+++ b/experimental/IntersectionTheory/docs/src/examples.md
@@ -43,7 +43,7 @@ julia> Z = dual(tautological_bundles(PF)[1])
 AbstractBundle of rank 1 on AbstractVariety of dim 8
 
 julia> z = chern_class(Z, 1)
-h
+z
 
 julia> integral((2*p + z)^8)
 92

--- a/experimental/MatroidRealizationSpaces/docs/src/introduction.md
+++ b/experimental/MatroidRealizationSpaces/docs/src/introduction.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = Oscar.doctestsetup()
 ```
 
 # Matroid Realization Spaces
@@ -68,8 +69,7 @@ Blowup
 with domain
   scheme over QQ covered with 2 patches
     1a: [(s1//s0), x1, x2]   scheme(-(s1//s0)*x1 + 4*(s1//s0) + x2^2 - 8) \ scheme((x1 - x2)*x2*x1*(x2 - 1)*(x1 - 1)*(x1 + x2^2 - x2)*(x1*x2 - x1 - x2^2))
-    2a: [(s0//s1), x2]       scheme(0) \ scheme(((s0//s1)*x2^2 - 8*(s0//s1) - x2 + 4)*x2*((s0//s1)*x2^2 - 8*(s0//s1) + 4)*(x2 - 1)*((s0//s1)*x2^2 - 8*(s0//s1) + 3)*((s0//s1)*x2^2 - 8*(s0//s1) + x2^2 - x2 + 4)*((
-    s0//s1)*x2^3 - (s0//s1)*x2^2 - 8*(s0//s1)*x2 + 8*(s0//s1) - x2^2 + 4*x2 - 4))
+    2a: [(s0//s1), x2]       scheme(0) \ scheme(((s0//s1)*x2^2 - 8*(s0//s1) - x2 + 4)*x2*((s0//s1)*x2^2 - 8*(s0//s1) + 4)*(x2 - 1)*((s0//s1)*x2^2 - 8*(s0//s1) + 3)*((s0//s1)*x2^2 - 8*(s0//s1) + x2^2 - x2 + 4)*((s0//s1)*x2^3 - (s0//s1)*x2^2 - 8*(s0//s1)*x2 + 8*(s0//s1) - x2^2 + 4*x2 - 4))
 and exceptional divisor
   effective cartier divisor defined by
     sheaf of ideals with restrictions

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -15,7 +15,7 @@
 # Oscar needs some complicated setup to get the printing right. This provides a
 # helper function to set this up consistently.
 function doctestsetup()
-  link_experimental_docs(Oscar)
+  link_experimental_docs()
   return :(using Oscar; Oscar.AbstractAlgebra.set_current_module(@__MODULE__))
 end
 
@@ -237,17 +237,17 @@ end
 
 # Create symbolic links from any documentation directory in `experimental` into
 # `docs/src`
-function link_experimental_docs(Oscar::Module)
+function link_experimental_docs()
   # Remove symbolic links from earlier runs
-  expdocdir = joinpath(Oscar.oscardir, "docs", "src", "Experimental")
+  expdocdir = joinpath(oscardir, "docs", "src", "Experimental")
   for x in readdir(expdocdir; join=true)
     islink(x) && rm(x)
   end
 
-  for pkg in Oscar.exppkgs
+  for pkg in exppkgs
     # Set symlink inside docs/src/experimental
-    symlink_link = joinpath(Oscar.oscardir, "docs/src/Experimental", pkg)
-    symlink_target = joinpath(Oscar.oscardir, "experimental", pkg, "docs", "src")
+    symlink_link = joinpath(oscardir, "docs/src/Experimental", pkg)
+    symlink_target = joinpath(oscardir, "experimental", pkg, "docs", "src")
 
     if !ispath(symlink_target)
       continue

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -14,7 +14,10 @@
 
 # Oscar needs some complicated setup to get the printing right. This provides a
 # helper function to set this up consistently.
-doctestsetup() = :(using Oscar; Oscar.AbstractAlgebra.set_current_module(@__MODULE__))
+function doctestsetup()
+  link_experimental_docs(Oscar)
+  return :(using Oscar; Oscar.AbstractAlgebra.set_current_module(@__MODULE__))
+end
 
 # use tempdir by default to ensure a clean manifest (and avoid modifying the project)
 function doc_init(;path=mktempdir())
@@ -230,4 +233,34 @@ function build_doc(; doctest::Union{Symbol, Bool} = false, warnonly = true, open
   if doctest != false && !versioncheck
     @warn versionwarn
   end
+end
+
+# Create symbolic links from any documentation directory in `experimental` into
+# `docs/src`
+function link_experimental_docs(Oscar::Module)
+  # Remove symbolic links from earlier runs
+  expdocdir = joinpath(Oscar.oscardir, "docs", "src", "Experimental")
+  for x in readdir(expdocdir; join=true)
+    islink(x) && rm(x)
+  end
+
+  for pkg in Oscar.exppkgs
+    # Set symlink inside docs/src/experimental
+    symlink_link = joinpath(Oscar.oscardir, "docs/src/Experimental", pkg)
+    symlink_target = joinpath(Oscar.oscardir, "experimental", pkg, "docs", "src")
+
+    if !ispath(symlink_target)
+      continue
+    end
+
+    if !ispath(symlink_link)
+      symlink(symlink_target, symlink_link)
+    elseif !islink(symlink_link) || readlink(symlink_link) != symlink_target
+      error("""$symlink_link already exists, but is not a symlink to $symlink_target
+      Please investigate the contents of $symlink_link,
+      optionally move them somewhere else and delete the directory once you are done.""")
+    end
+  end
+
+  return nothing
 end

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -241,7 +241,12 @@ function link_experimental_docs()
   # Remove symbolic links from earlier runs
   expdocdir = joinpath(oscardir, "docs", "src", "Experimental")
   for x in readdir(expdocdir; join=true)
-    islink(x) && rm(x)
+    !islink(x) && continue
+    pkg = splitpath(x)[end]
+    if !(pkg in exppkgs)
+      # We don't know this link, let's remove it
+      rm(x)
+    end
   end
 
   for pkg in exppkgs


### PR DESCRIPTION
The CI doctests would not run on the examples included in any `*.md` file inside `experimental` as discovered in https://oscar-system.slack.com/archives/C5B2H11BQ/p1726048480750199 .
This tries to fix this by linking the experimental documentation into `docs/src` as part of the CI runners. Currently, the tests are expected to fail because of missing `DocTestSetup = Oscar.doctestsetup()` lines in some of the previously uncovered files. If this works and people are happy with my changes, I will fix those doctests.
