### PR TITLE
Fix is_very_ample

### DIFF
--- a/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/properties.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/properties.jl
@@ -155,7 +155,7 @@ false
 """
 @attr Bool function is_very_ample(td::ToricDivisor)
   @req is_complete(toric_variety(td)) "Very ampleness test is only implemented for complete toric varieties. ([Def 6.1.9 CLS11])"
-  pm_object(td).VERY_AMPLE
+  return pm_object(td).VERY_AMPLE
 end
 
 

--- a/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/properties.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/properties.jl
@@ -155,7 +155,7 @@ false
 """
 @attr Bool function is_very_ample(td::ToricDivisor)
   @req is_complete(toric_variety(td)) "Very ampleness test is only implemented for complete toric varieties. ([Def 6.1.9 CLS11])"
-  return pm_object(td).VERY_AMPLE
+  return pm_object(td).VERY_AMPLE::Bool
 end
 
 

--- a/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/properties.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/properties.jl
@@ -131,7 +131,7 @@ false
 ```
 """
 @attr Bool function is_ample(td::ToricDivisor)
-  @req is_complete(toric_variety(td)) "Definition of ample divisor requires underlying toric variety to be complete. ([Def 6.1.9 CLS11])"
+  @req is_complete(toric_variety(td)) "Ampleness test is only implemented for complete toric varieties. ([Def 6.1.9 CLS11])"
   @req is_cartier(td) "Definition of ample divisor requires divisor to be Cartier. ([Def 6.1.9 CLS11])"
   return pm_object(td).AMPLE::Bool
 end
@@ -153,7 +153,10 @@ julia> is_very_ample(td)
 false
 ```
 """
-@attr Bool is_very_ample(td::ToricDivisor) = pm_object(td).VERY_AMPLE
+@attr Bool function is_very_ample(td::ToricDivisor)
+  @req is_complete(toric_variety(td)) "Very ampleness test is only implemented for complete toric varieties. ([Def 6.1.9 CLS11])"
+  pm_object(td).VERY_AMPLE
+end
 
 
 @doc raw"""


### PR DESCRIPTION
The function `is_very_ample` was giving `false` when the variety was not complete.

```
julia> X = affine_space(NormalToricVariety, 2)
Normal toric variety

julia> D = divisor_of_character(X, [1, 0])
Torus-invariant, prime divisor on a normal toric variety

julia> is_very_ample(D)
false
```