### PR TITLE
Disable anonymous functions in gluings

### DIFF
--- a/experimental/Schemes/src/Auxiliary.jl
+++ b/experimental/Schemes/src/Auxiliary.jl
@@ -254,7 +254,7 @@ struct InheritGluingData
   Y::AbsAffineScheme
 end
 
-function _compute_inherited_gluing(gd::InheritGluingData)
+function _compute_gluing(gd::InheritGluingData)
   X = gd.X
   Y = gd.Y
   C = gd.orig
@@ -363,7 +363,6 @@ function inherit_gluings!(ref::Covering, orig::Covering)
     for V in patches(ref)
       if !haskey(gluings(ref), (U, V))
         gluings(ref)[(U, V)] = LazyGluing(U, V, 
-                                            _compute_inherited_gluing,
                                             InheritGluingData(orig, U, V)
                                            )
       end

--- a/experimental/Schemes/src/CoveredProjectiveSchemes.jl
+++ b/experimental/Schemes/src/CoveredProjectiveSchemes.jl
@@ -942,7 +942,7 @@ end
     U === V && continue
     for UW in affine_charts(parts[U])
       for VW in affine_charts(parts[V])
-        GGG = LazyGluing(UW, VW, _compute_gluing,
+        GGG = LazyGluing(UW, VW, 
                          ProjectiveGluingData(U, V, UW, VW, C, P)
                         )
         result_gluings[(UW, VW)] = GGG

--- a/experimental/Schemes/src/Schemes.jl
+++ b/experimental/Schemes/src/Schemes.jl
@@ -68,7 +68,6 @@ export is_contact_equivalent
 
 
 # Deprecated after 0.15
-Base.@deprecate_binding _compute_inherited_glueing _compute_inherited_gluing
 Base.@deprecate_binding base_glueing base_gluing
 Base.@deprecate_binding inherit_glueings! inherit_gluings!
 Base.@deprecate_binding AbsProjectiveGlueing AbsProjectiveGluing

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Morphisms/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Morphisms/Constructors.jl
@@ -75,7 +75,7 @@ function CoveredClosedEmbedding(X::AbsCoveredScheme, I::AbsIdealSheaf;
     U = codomain(mor_dict[Unew])
     for Vnew in keys(mor_dict)
       V = codomain(mor_dict[Vnew])
-      gluing_dict[(Unew, Vnew)] = LazyGluing(Unew, Vnew, _compute_restriction,
+      gluing_dict[(Unew, Vnew)] = LazyGluing(Unew, Vnew, 
                                                RestrictionDataClosedEmbedding(covering[U, V], Unew, Vnew)
                                               )
     end

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Methods.jl
@@ -333,11 +333,11 @@ function _normalization_integral(
   data = NormalizationIntegralGluingData(G, X_1_norm_output, X_2_norm_output, check)
   X_1_norm = X_1_norm_output[1]
   X_2_norm = X_2_norm_output[1]
-  return LazyGluing(X_1_norm, X_2_norm, _compute_normalization_integral, data)
+  return LazyGluing(X_1_norm, X_2_norm, data)
 end
 
 # Warning: assume patches irreducible
-function _compute_normalization_integral(
+function _compute_gluing(
     data::NormalizationIntegralGluingData
   )
   # Initialize the variables

--- a/src/AlgebraicGeometry/Schemes/Covering/Morphisms/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/Covering/Morphisms/Methods.jl
@@ -33,7 +33,7 @@ function simplify(C::Covering)
     iY, jY = identification_maps(Ysimp)
     G = GD[(X, Y)]
     #new_gluings[(Xsimp, Ysimp)] = restrict(G, jX, jY, check=false)
-    new_gluings[(Xsimp, Ysimp)] = LazyGluing(Xsimp, Ysimp, _compute_restriction, _compute_domains,
+    new_gluings[(Xsimp, Ysimp)] = LazyGluing(Xsimp, Ysimp,
                                                RestrictionDataIsomorphism(G, jX, jY)
                                               )
   end

--- a/src/AlgebraicGeometry/Schemes/Covering/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/Covering/Objects/Methods.jl
@@ -247,9 +247,14 @@ true
 function add_gluing!(C::Covering, G::AbsGluing)
   (X, Y) = patches(G)
   C.gluings[(X, Y)] = G
-  C.gluings[(Y, X)] = LazyGluing(Y, X, inverse, G)
+  C.gluings[(Y, X)] = LazyGluing(Y, X, G)
   return C
 end
+
+# This implements the _compute_gluing for the case of a lazy gluing where 
+# we only need the inverse. The gluing data is just the original gluing in 
+# this case.
+_compute_gluing(G::AbsGluing) = inverse(G)
 
 ########################################################################
 # Printing                                                             #

--- a/src/AlgebraicGeometry/Schemes/Gluing/LazyGluing/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/Gluing/LazyGluing/Types.jl
@@ -12,23 +12,15 @@
   X::LeftAffineSchemeType
   Y::RightAffineSchemeType
   GD::GluingDataType
-  compute_function::Function
-  compute_gluing_domains::Function
   gluing_domains::Union{Tuple{PrincipalOpenSubset, PrincipalOpenSubset},
                          Tuple{AffineSchemeOpenSubscheme, AffineSchemeOpenSubscheme}}
   G::AbsGluing
 
-  function LazyGluing(X::AbsAffineScheme, Y::AbsAffineScheme, 
-      compute_function::Function, GD::GluingDataType
-    ) where {GluingDataType}
-    return new{typeof(X), typeof(Y), GluingDataType}(X, Y, GD, compute_function)
-  end
-  function LazyGluing(X::AbsAffineScheme, Y::AbsAffineScheme, 
-      compute_function::Function, compute_gluing_domains::Function, 
+  function LazyGluing(
+      X::AbsAffineScheme, Y::AbsAffineScheme, 
       GD::GluingDataType
     ) where {GluingDataType}
-    return new{typeof(X), typeof(Y), GluingDataType}(X, Y, GD, compute_function, 
-                                                      compute_gluing_domains)
+    return new{typeof(X), typeof(Y), GluingDataType}(X, Y, GD)
   end
 end
 

--- a/src/AlgebraicGeometry/Schemes/Gluing/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/Gluing/Methods.jl
@@ -199,7 +199,7 @@ struct BaseChangeGluingData{T1, T2}
   patch_change2::AbsAffineSchemeMor
 end
 
-function _compute_gluing_base_change(gd::BaseChangeGluingData)
+function _compute_gluing(gd::BaseChangeGluingData)
   # extraction of the gluing data
   G = gd.G
   pc1 = gd.patch_change1
@@ -231,6 +231,6 @@ function base_change(phi::Any, G::AbsGluing;
     patch_change2::AbsAffineSchemeMor=base_change(phi, gluing_domains(G)[2])[2]  # the two gluing patches
   )
   gd = BaseChangeGluingData{typeof(phi), typeof(G)}(phi, G, patch_change1, patch_change2)
-  return LazyGluing(domain(patch_change1), domain(patch_change2), _compute_gluing_base_change, gd)
+  return LazyGluing(domain(patch_change1), domain(patch_change2), gd)
 end
 

--- a/src/AlgebraicGeometry/Schemes/PrincipalOpenSubset/Objects/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/PrincipalOpenSubset/Objects/Types.jl
@@ -33,8 +33,21 @@
   function PrincipalOpenSubset(X::AbsAffineScheme, R::Ring, f::Vector{T};
       check::Bool=true
     ) where {T<:RingElem}
-    d = prod(length(f) > 0 ? f : one(OO(X)))
-    return PrincipalOpenSubset(X, R, lifted_numerator.(f), d, check=check)
+    @check begin
+        d = prod(length(f) > 0 ? f : one(OO(X)))
+        U = spec(R)
+        U == hypersurface_complement(X, d)
+    end
+    return new{base_ring_type(X), ring_type(U), typeof(X)}(X, U, lifted_numerator.(f))
+  end
+  function PrincipalOpenSubset(X::AbsAffineScheme, U::AbsAffineScheme, f::Vector{T};
+      check::Bool=true
+    ) where {T<:RingElem}
+    @check begin
+        d = prod(length(f) > 0 ? f : one(OO(X)))
+        U == hypersurface_complement(X, d)
+    end
+    return new{base_ring_type(X), ring_type(U), typeof(X)}(X, U, lifted_numerator.(f))
   end
 end
 

--- a/src/AlgebraicGeometry/Schemes/Sheaves/IdealSheaves.jl
+++ b/src/AlgebraicGeometry/Schemes/Sheaves/IdealSheaves.jl
@@ -322,10 +322,9 @@ function subscheme(I::AbsIdealSheaf; covering::Covering=default_covering(scheme(
     for (V, Vnew) in new_patches
       (U, V) in keys(gluings(C)) || continue # No gluing before, no gluing after.
       old_glue = C[U, V]
-      new_gluings[(Unew, Vnew)] = LazyGluing(Unew, Vnew, _compute_restriction,
+      new_gluings[(Unew, Vnew)] = LazyGluing(Unew, Vnew,
                                              RestrictionDataClosedEmbedding(C[U, V], Unew, Vnew)
                                             )
-      #new_gluings[(Vnew, Unew)] = LazyGluing(Vnew, Unew, inverse, new_gluings[(Unew, Vnew)])
     end
   end
   Cnew = Covering(collect(values(new_patches)), new_gluings, check=false)

--- a/src/AlgebraicGeometry/ToricVarieties/ToricSchemes/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricSchemes/attributes.jl
@@ -127,7 +127,7 @@ struct ToricGluingData
 # j::Int
 end
 
-function _compute_toric_gluing(gd::ToricGluingData)
+function _compute_gluing(gd::ToricGluingData)
   X = gd.X
   U = gd.U
   V = gd.V
@@ -237,7 +237,7 @@ with default covering
       X = patch_list[i]
       Y = patch_list[j]
       gd = ToricGluingData(Z, X, Y)
-      add_gluing!(cov, LazyGluing(X, Y, _compute_toric_gluing, gd))
+      add_gluing!(cov, LazyGluing(X, Y, gd))
       continue
       facet = intersect(cone(X), cone(Y))
       (dim(facet) == dim(cone(X)) - 1) || continue

--- a/test/AlgebraicGeometry/Schemes/Gluing.jl
+++ b/test/AlgebraicGeometry/Schemes/Gluing.jl
@@ -132,30 +132,3 @@ end
   @test underlying_gluing(GG) isa SimpleGluing
 end
 
-@testset "extra lazy gluing domains" begin
-  P3 = projective_space(QQ, 3)
-  S = homogeneous_coordinate_ring(P3)
-  (x, y, z, w) = gens(S)
-  I = ideal(S, [x*z - y*w, x^4 + y^4 + z^4 + w^4])
-  Y = covered_scheme(P3)
-  II = ideal_sheaf(P3, I)
-  pr = blow_up(II)
-  X = domain(pr)
-
-  for G in values(gluings(Oscar.simplified_covering(X)))
-    @test !isdefined(G, :G)
-    gluing_domains(G)
-    @test !isdefined(G, :G)
-    @test isdefined(G, :gluing_domains)
-  end
-
-  for G in values(gluings(Oscar.simplified_covering(X)))
-    @test !isdefined(G, :G)
-    underlying_gluing(G)
-    @test isdefined(G, :G)
-    @test isdefined(G, :gluing_domains)
-    @test (G.gluing_domains[1] === gluing_domains(underlying_gluing(G))[1])
-    @test (G.gluing_domains[2] === gluing_domains(underlying_gluing(G))[2])
-  end
-end
-


### PR DESCRIPTION
This is some independent work carried out on #4110 .

It removes the anonymous functions inside the `LazyGluing`s. These are not necessary and they don't serialize nicely. So I took them out. 

In the course of this I disabled the possibility to "cheaply" compute only the gluing domains. This turned out not to be useful and it just made things more complicated. 