### PR TITLE
feat: make _canonical_matrix faster

### DIFF
--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -130,7 +130,7 @@ function _canonical_matrix(w)
     nw = view(w, i:i, :)
     c = content(nw)
     if !isone(c)
-      nw = divexact!(nw, nw, c)
+      divexact!(nw, nw, c)
     end
     for j in 1:k
       h = piv[j]
@@ -141,7 +141,7 @@ function _canonical_matrix(w)
     if !iszero(nw)
       c = content(nw)
       if !isone(c)
-        nw = divexact!(nw, nw, c)
+        divexact!(nw, nw, c)
       end
       ww[(k + 1):(k + 1), :] = nw
       push!(piv, findfirst(x -> !is_zero_entry(nw, 1, x), 1:ncols(w)))

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -87,35 +87,6 @@ struct MatrixOrdering <: AbsGenOrdering
   end
 end
 
-function __canonical_matrix(w)
-  ww = matrix(ZZ, 0, ncols(w), [])
-  for i in 1:nrows(w)
-    if is_zero_row(w, i)
-      continue
-    end
-    nw = w[i:i, :]
-    c = content(nw)
-    if !isone(c)
-      nw = divexact(nw, c)
-    end
-    for j in 1:nrows(ww)
-      h = findfirst(x->ww[j, x] != 0, 1:ncols(w))
-      if !iszero(nw[1, h])
-        nw = abs(ww[j, h])*nw - sign(ww[j, h])*nw[1, h]*ww[j:j, :]
-      end
-    end
-    if !iszero(nw)
-      c = content(nw)
-      if !isone(c)
-        nw = divexact(nw, c)
-      end
-      ww = vcat(ww, nw)
-    end
-  end
-  @assert nrows(ww) <= ncols(ww)
-  return ww
-end
-
 function _canonical_matrix(w)
   # we store the results in ww and keep track of the "real" number of rows
   # in k

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -87,7 +87,7 @@ struct MatrixOrdering <: AbsGenOrdering
   end
 end
 
-function _canonical_matrix(w)
+function __canonical_matrix(w)
   ww = matrix(ZZ, 0, ncols(w), [])
   for i in 1:nrows(w)
     if is_zero_row(w, i)
@@ -112,6 +112,43 @@ function _canonical_matrix(w)
       ww = vcat(ww, nw)
     end
   end
+  @assert nrows(ww) <= ncols(ww)
+  return ww
+end
+
+function _canonical_matrix(w)
+  # we store the results in ww and keep track of the "real" number of rows
+  # in k
+  ww = zero_matrix(ZZ, nrows(w), ncols(w))
+  k = 0
+  piv = Int[]
+  # piv[i] stores the column index of the first non-zero entry in row i of ww
+  for i in 1:nrows(w)
+    if is_zero_row(w, i)
+      continue
+    end
+    nw = view(w, i:i, :)
+    c = content(nw)
+    if !isone(c)
+      nw = divexact!(nw, nw, c)
+    end
+    for j in 1:k
+      h = piv[j]
+      if !is_zero_entry(nw, 1, h)
+        nw = abs(ww[j, h])*nw - sign(ww[j, h])*nw[1, h]*view(ww, j:j, :)
+      end
+    end
+    if !iszero(nw)
+      c = content(nw)
+      if !isone(c)
+        nw = divexact!(nw, nw, c)
+      end
+      ww[(k + 1):(k + 1), :] = nw
+      push!(piv, findfirst(x -> !is_zero_entry(nw, 1, x), 1:ncols(w)))
+      k += 1
+    end
+  end
+  ww = view(ww, 1:k, :)
   @assert nrows(ww) <= ncols(ww)
   return ww
 end


### PR DESCRIPTION
Some low-hanging fruit.

Before:
```
julia> @time Oscar.Orderings._canonical_matrix(w);
  1.322101 seconds (21.72 M allocations: 826.664 MiB, 14.43% gc time)
```
After:
```
julia> @time Oscar.Orderings._canonical_matrix(w);
  0.021654 seconds (3.57 k allocations: 2.066 MiB)
```
There is still some room for improvement.