### PR TITLE
More bib cleanup

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -114,7 +114,7 @@
 }
 
 @Article{BCL21,
-  author        = {Bies, Martin and Cveti\v{c}, Mirjam and Liu, Muyang},
+  author        = {Bies, Martin and Cvetič, Mirjam and Liu, Muyang},
   title         = {Statistics of limit root bundles relevant for exact matter spectra of F-theory MSSMs},
   journal       = {Phys. Rev. D},
   volume        = {104},
@@ -386,7 +386,7 @@
 
 @Article{Bie24,
   author        = {Bies, Martin},
-  title         = {{Root bundles: Applications to F-theory Standard Models}},
+  title         = {Root bundles: Applications to F-theory Standard Models},
   journal       = {Proc. Symp. Pure Math.},
   volume        = {107},
   pages         = {17--44},
@@ -450,8 +450,8 @@
 }
 
 @Article{CHLLT19,
-  author        = {Cveti\v{c}, Mirjam and Halverson, James and Lin, Ling and Liu, Muyang and Tian, Jiahua},
-  title         = {{Quadrillion $F$-Theory Compactifications with the Exact Chiral Spectrum of the Standard Model}},
+  author        = {Cvetič, Mirjam and Halverson, James and Lin, Ling and Liu, Muyang and Tian, Jiahua},
+  title         = {Quadrillion $F$-Theory Compactifications with the Exact Chiral Spectrum of the Standard Model},
   journal       = {Phys. Rev. Lett.},
   volume        = {123},
   number        = {10},
@@ -801,7 +801,7 @@
   zbl           = {1166.13001},
   series        = {Oberwolfach Semin.},
   volume        = {39},
-  publisher     = {Basel: Birkh{\"a}user},
+  publisher     = {Basel: Birkhäuser},
   year          = {2009},
   fseries       = {Oberwolfach Seminars},
   language      = {English},
@@ -821,7 +821,7 @@
 }
 
 @Article{EFS03,
-  author        = {Eisenbud, David and Fl{\o}ystad, Gunnar and Schreyer, Frank-Olaf},
+  author        = {Eisenbud, David and Fløystad, Gunnar and Schreyer, Frank-Olaf},
   title         = {Sheaf cohomology and free resolutions over exterior algebras},
   zbl           = {1063.14021},
   journal       = {Trans. Am. Math. Soc.},
@@ -896,7 +896,7 @@
 }
 
 @Article{EMSS16,
-  author        = {Er{\"o}cal, Bur{\c{c}}in and Motsak, Oleksandr and Schreyer, Frank-Olaf and Steenpa{\ss}, Andreas},
+  author        = {Eröcal, Burçin and Motsak, Oleksandr and Schreyer, Frank-Olaf and Steenpaß, Andreas},
   title         = {Refined algorithms to compute syzygies},
   zbl           = {1405.14138},
   journal       = {J. Symb. Comput.},
@@ -1303,7 +1303,7 @@
 
 @Article{HT17,
   author        = {Halverson, James and Tian, Jiahua},
-  title         = {{Cost of seven-brane gauge symmetry in a quadrillion F-theory compactifications}},
+  title         = {Cost of seven-brane gauge symmetry in a quadrillion F-theory compactifications},
   journal       = {Phys. Rev. D},
   volume        = {95},
   number        = {2},
@@ -1709,8 +1709,8 @@
 }
 
 @Article{LS13,
-  author        = {Lawrie, Craig and Sch\"afer-Nameki, Sakura},
-  title         = {{The Tate Form on Steroids: Resolution and Higher Codimension Fibers}},
+  author        = {Lawrie, Craig and Schäfer-Nameki, Sakura},
+  title         = {The Tate Form on Steroids: Resolution and Higher Codimension Fibers},
   journal       = {JHEP},
   volume        = {04},
   pages         = {061},
@@ -2036,7 +2036,7 @@
 }
 
 @Article{Rin13,
-  author        = {Rinc{\'o}n, Felipe},
+  author        = {Rincón, Felipe},
   title         = {Computing tropical linear spaces},
   zbl           = {1319.14060},
   journal       = {J. Symb. Comput.},
@@ -2175,7 +2175,7 @@
 @Misc{Stacks,
   bibkey        = {Stacks},
   author        = {{The Stacks Project Authors}},
-  title         = {{S}tacks {P}roject},
+  title         = {Stacks Project},
   howpublished  = {Published electronically},
   url           = {https://stacks.math.columbia.edu/}
 }
@@ -2362,7 +2362,7 @@
 
 @Article{Wit97,
   author        = {Witten, Edward},
-  title         = {{On flux quantization in M theory and the effective action}},
+  title         = {On flux quantization in M theory and the effective action},
   journal       = {J. Geom. Phys.},
   volume        = {22},
   pages         = {1--13},


### PR DESCRIPTION
DocumenterCitations.jl prefers to get unicode. Additional braces to keep casing are not needed as well.

Preview: https://docs.oscar-system.org/previews/PR4118/references/