### PR TITLE
Get rid of trivial anonymous functions (part 1)

### DIFF
--- a/examples/Reynolds.jl
+++ b/examples/Reynolds.jl
@@ -241,7 +241,7 @@ function action_on_monomials(R::MPolyRing, d::Int, A::Vector{QQMatrix})
       b = zeros(QQ, length(m))
       y = evaluate(x, h)
       for (c,v) = zip(AbstractAlgebra.coefficients(y), AbstractAlgebra.monomials(y))
-        b[findfirst(l -> l==v, m)] = c
+        b[findfirst(==(v), m)] = c
       end
       push!(bb, b)
     end

--- a/experimental/AlgebraicStatistics/src/PhylogeneticAuxiliary.jl
+++ b/experimental/AlgebraicStatistics/src/PhylogeneticAuxiliary.jl
@@ -24,13 +24,13 @@ end
 function interior_nodes(graph::Graph)
   big_graph = Polymake.graph.Graph(ADJACENCY = pm_object(graph))
   degrees = big_graph.NODE_DEGREES
-  return findall(x -> x > 1, degrees)
+  return findall(>(1), degrees)
 end
 
 function leaves(graph::Graph)
   big_graph = Polymake.graph.Graph(ADJACENCY = pm_object(graph))
   degrees = big_graph.NODE_DEGREES
-  return findall(x -> x == 1, degrees)
+  return findall(==(1), degrees)
 end
 
 function vertex_descendants(v::Int, gr::Graph, desc::Vector{Any})

--- a/experimental/AlgebraicStatistics/src/PhylogeneticParametrization.jl
+++ b/experimental/AlgebraicStatistics/src/PhylogeneticParametrization.jl
@@ -216,7 +216,7 @@ Dict{Tuple{Vararg{Int64}}, QQMPolyRingElem} with 5 entries:
 """
 function compute_equivalent_classes(parametrization::Dict{Tuple{Vararg{Int64}}, QQMPolyRingElem})
   polys = unique(collect(values(parametrization)))
-  polys = polys[findall(x -> x!=0, polys)]
+  polys = polys[findall(!is_zero, polys)]
 
   equivalent_keys = []
   for value in polys

--- a/experimental/DoubleAndHyperComplexes/src/Morphisms/ext.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Morphisms/ext.jl
@@ -219,7 +219,7 @@ function (fac::InterpretationMorphismFactory)(self::AbsHyperComplexMorphism, I::
     pr = projections_dom[k]
     for (l, L) in enumerate(indices_cod)
       KL = Tuple(vcat(-collect(K), collect(L)))
-      kl = findfirst(x->x==KL, indices_tot)
+      kl = findfirst(==(KL), indices_tot)
       kl === nothing && error("index not found")
       v_loc = (projections_tot[kl])(fac.v)
       phi_loc = element_to_homomorphism(v_loc)

--- a/experimental/DoubleAndHyperComplexes/src/Morphisms/linear_strands.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Morphisms/linear_strands.jl
@@ -124,7 +124,7 @@ function (fac::LinearStrandComplementChainFactory)(self::AbsHyperComplex, i::Tup
   min_ind = [k for k in 1:rank(F_full) if degree(F_full[k]) == offset]
   comp = [k for k in 1:rank(F_full) if !(k in min_ind)]
   F = graded_free_module(S, elem_type(G)[degree(F_full[k]) for k in comp])
-  map = hom(F_full, F, elem_type(F)[(k in comp ? F[findfirst(i->i==k, comp)] : zero(F)) for k in 1:rank(F_full)])
+  map = hom(F_full, F, elem_type(F)[(k in comp ? F[findfirst(==(k), comp)] : zero(F)) for k in 1:rank(F_full)])
   fac.maps_from_original[i] = map
   return F
 end

--- a/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
@@ -228,7 +228,7 @@ function (fac::SimplifiedChainFactory)(d::AbsHyperComplex, Ind::Tuple)
       w = Tinv[i]
       new_entries = Vector{Tuple{Int, elem_type(base_ring(w))}}()
       for (real_j, b) in w
-        j = findfirst(k->k==real_j, J)
+        j = findfirst(==(real_j), J)
         j === nothing && continue
         push!(new_entries, (j, b))
       end

--- a/experimental/DoubleAndHyperComplexes/src/Objects/Types.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/Types.jl
@@ -585,7 +585,7 @@ end
     ranges = [(k, u) for (k, u) in v if u isa UnitRange]
     d = length(ranges)
     all_ind = [k for (k, u) in v if u isa UnitRange]
-    @assert all(k->k in all_ind, 1:d) "matching of ranges is not unique"
+    @assert all(in(all_ind), 1:d) "matching of ranges is not unique"
 
     mapping_matrix = [0 for i in 1:dim(c), j in 1:d]
     new_ranges = Dict(v)

--- a/experimental/DoubleAndHyperComplexes/src/Objects/total_complexes.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/total_complexes.jl
@@ -124,7 +124,7 @@ function (fac::TotalComplexMapFactory)(c::AbsHyperComplex, p::Int, I::Tuple)
     for k in 1:dim(orig)
       target = collect(J) + (direction(orig, k) == :chain ? -1 : 1)*[(l == k ? 1 : 0) for l in 1:dim(orig)]
       T = Tuple(target)
-      index_in_cod = findfirst(t->t == T, index_cache(chain_fac)[next])
+      index_in_cod = findfirst(==(T), index_cache(chain_fac)[next])
       index_in_cod === nothing && continue
       phi = map(orig, k, J)
       @assert codomain(phi) === orig[T]
@@ -228,7 +228,7 @@ end
 function injection(tot::TotalComplex, i::Tuple)
   d = sum(i)
   v = indices_in_summand(tot, d)
-  k = findfirst(k->k==i, v)
+  k = findfirst(==(i), v)
   k === nothing && return nothing
   return injections_for_summand(tot, d)[k]
 end
@@ -236,7 +236,7 @@ end
 function projection(tot::TotalComplex, i::Tuple)
   d = sum(i)
   v = indices_in_summand(tot, d)
-  k = findfirst(k->k==i, v)
+  k = findfirst(==(i), v)
   k === nothing && return nothing
   return projections_for_summand(tot, d)[k]
 end

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
@@ -333,7 +333,7 @@ function put_over_concrete_base(m::AbstractFTheoryModel, concrete_data::Dict{Str
     all_appearing_monomials = vcat([collect(monomials(p)) for p in polys]...)
     all_appearing_exponents = hcat([collect(exponents(m))[1] for m in all_appearing_monomials]...)
     for k in 1:nrows(all_appearing_exponents)
-      if any(x -> x != 0, all_appearing_exponents[k,:])
+      if any(!is_zero, all_appearing_exponents[k,:])
         gen_name = string(gens(parent(polys[1]))[k])
         @req haskey(concrete_data, gen_name) "Required base section $gen_name not specified"
         @req parent(concrete_data[gen_name]) == cox_ring(concrete_data["base"]) "Specified sections must reside in Cox ring of given base"
@@ -646,7 +646,7 @@ function set_zero_section_class(m::AbstractFTheoryModel, desired_value::String)
   cohomology_ring(ambient_space(m); check=false)
   cox_gens = string.(gens(cox_ring(ambient_space(m))))
   @req desired_value in cox_gens "Specified zero section is invalid"
-  index = findfirst(x -> x==desired_value, cox_gens)
+  index = findfirst(==(desired_value), cox_gens)
   set_attribute!(m, :zero_section_class => cohomology_class(divs[index]))
 end
 
@@ -840,7 +840,7 @@ function resolve(m::AbstractFTheoryModel, resolution_index::Int)
 
       # Compute strict transform of ideal sheaves appearing in blowup center
       exceptional_center = [c for c in blow_up_center if (c in exceptionals)]
-      positions = [findfirst(x -> x == l, exceptionals) for l in exceptional_center]
+      positions = [findfirst(==(l), exceptionals) for l in exceptional_center]
       exceptional_divisors = [exceptional_divisor(get_attribute(blow_up_chain[l], :blow_down_morphism)) for l in positions]
       exceptional_ideal_sheafs = [ideal_sheaf(d) for d in exceptional_divisors]
       for l in 1:length(positions)

--- a/experimental/FTheoryTools/src/HypersurfaceModels/methods.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/methods.jl
@@ -104,7 +104,7 @@ function tune(h::HypersurfaceModel, input_sections::Dict{String, <:Any}; complet
   isempty(input_sections) && return h
   secs_names = collect(keys(explicit_model_sections(h)))
   tuned_secs_names = collect(keys(input_sections))
-  @req all(x -> x in secs_names, tuned_secs_names) "Provided section name not recognized"
+  @req all(in(secs_names), tuned_secs_names) "Provided section name not recognized"
 
   # 1. Tune model sections
   explicit_secs = deepcopy(explicit_model_sections(h))

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -297,7 +297,7 @@ end
 #######################################################
 
 function _find_model(doi::String, arxiv_id::String, version::String, equation::String, type::String)
-  @req any(s -> s != "", [doi, arxiv_id, version, equation]) "No information provided; cannot perform look-up"
+  @req any(!isempty, [doi, arxiv_id, version, equation]) "No information provided; cannot perform look-up"
   file_index = JSON.parsefile(joinpath(@__DIR__, "index.json"))
   candidate_files = Vector{String}()
   for k in 1:length(file_index)

--- a/experimental/FTheoryTools/src/LiteratureModels/create_index.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/create_index.jl
@@ -23,7 +23,7 @@
 function _create_literature_model_index()
   model_directory = joinpath(@__DIR__, "Models/")
   models = readdir(model_directory)
-  filter!(s -> startswith(s, "model"), models)
+  filter!(startswith("model"), models)
 
   index = Vector{Dict{String,Union{String,Vector{Any}}}}()
   model_indices = JSON.parsefile(joinpath(@__DIR__, "model_indices.json"))

--- a/experimental/FTheoryTools/src/TateModels/constructors.jl
+++ b/experimental/FTheoryTools/src/TateModels/constructors.jl
@@ -59,7 +59,7 @@ function global_tate_model(base::NormalToricVariety,
   @req haskey(explicit_model_sections, "a4") "Tate section a4 must be specified"
   @req haskey(explicit_model_sections, "a6") "Tate section a6 must be specified"
   vs2 = collect(keys(defining_section_parametrization))
-  @req all(x -> x in ["a1", "a2", "a3", "a4", "a6"], vs2) "Only the Tate sections a1, a2, a3, a4, a6 must be parametrized"
+  @req all(in(["a1", "a2", "a3", "a4", "a6"]), vs2) "Only the Tate sections a1, a2, a3, a4, a6 must be parametrized"
   
   gens_base_names = [string(g) for g in gens(cox_ring(base))]
   if ("x" in gens_base_names) || ("y" in gens_base_names) || ("z" in gens_base_names)

--- a/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
@@ -53,7 +53,7 @@ function weierstrass_model(base::NormalToricVariety,
   @req haskey(explicit_model_sections, "f") "Weierstrass section f must be specified"
   @req haskey(explicit_model_sections, "g") "Weierstrass section g must be specified"
   vs2 = collect(keys(defining_section_parametrization))
-  @req all(x -> x in ["f", "g"], vs2) "Only the Weierstrass sections f, g must be parametrized"
+  @req all(in(("f", "g")), vs2) "Only the Weierstrass sections f, g must be parametrized"
 
   gens_base_names = [string(g) for g in gens(cox_ring(base))]
   if ("x" in gens_base_names) || ("y" in gens_base_names) || ("z" in gens_base_names)

--- a/experimental/FTheoryTools/src/WeierstrassModels/methods.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/methods.jl
@@ -86,7 +86,7 @@ function tune(w::WeierstrassModel, input_sections::Dict{String, <:Any}; complete
   isempty(input_sections) && return w
   secs_names = collect(keys(explicit_model_sections(w)))
   tuned_secs_names = collect(keys(input_sections))
-  @req all(x -> x in secs_names, tuned_secs_names) "Provided section name not recognized"
+  @req all(in(secs_names), tuned_secs_names) "Provided section name not recognized"
 
   # 0. Prepare for computation by setting up some information
   explicit_secs = deepcopy(explicit_model_sections(w))
@@ -143,7 +143,7 @@ function tune(w::WeierstrassModel, input_sections::Dict{String, <:Any}; complete
   # 5. After removing some sections, we must go over the parametrization again and adjust the ring in which the parametrization is given.
   if !isempty(def_secs_param)
     naive_vars = string.(gens(parent(first(values(def_secs_param)))))
-    filtered_vars = filter(x -> x in keys(explicit_secs), naive_vars)
+    filtered_vars = filter(x -> haskey(explicit_secs, x), naive_vars)
     desired_ring, _ = polynomial_ring(QQ, filtered_vars, cached = false)
     for (key, value) in def_secs_param
       def_secs_param[key] = eval_poly(string(value), desired_ring)

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -256,14 +256,14 @@ function _kodaira_type(id::MPolyIdeal{<:MPolyRingElem}, ords::Tuple{Int64, Int64
         push!(quotients, quotient(ideal([9 * g2s[i], gauge2s[i]]), ideal([2 * f2s[i], gauge2s[i]])))
       end
 
-      kod_type = if all(q -> is_radical(q), quotients) "Non-split I_$d_ord" else "Split I_$d_ord" end
+      kod_type = if all(is_radical, quotients) "Non-split I_$d_ord" else "Split I_$d_ord" end
     elseif d_ord == 4 && g_ord == 2 && f_ord >= 2
       quotients = []
       for i in eachindex(gauge2s)
         push!(quotients, quotient(ideal([g2s[i]]), ideal([gauge2s[i]^2])) + ideal([gauge2s[i]]))
       end
 
-      kod_type = if all(q -> is_radical(q), quotients) "Non-split IV" else "Split IV" end
+      kod_type = if all(is_radical, quotients) "Non-split IV" else "Split IV" end
     elseif f_ord == 2 && g_ord == 3 && d_ord >= 7
       quotients = []
       if d_ord % 2 == 0
@@ -276,14 +276,14 @@ function _kodaira_type(id::MPolyIdeal{<:MPolyRingElem}, ords::Tuple{Int64, Int64
         end
       end
 
-      kod_type = if all(q -> is_radical(q), quotients) "Non-split I^*_$(d_ord - 6)" else "Split I^*_$(d_ord - 6)" end
+      kod_type = if all(is_radical, quotients) "Non-split I^*_$(d_ord - 6)" else "Split I^*_$(d_ord - 6)" end
     elseif d_ord == 8 && g_ord == 4 && f_ord >= 3
       quotients = []
       for i in eachindex(gauge2s)
         push!(quotients, quotient(ideal([g2s[i]]), ideal([gauge2s[i]^4])) + ideal([gauge2s[i]]))
       end
 
-      kod_type = if all(q -> is_radical(q), quotients) "Non-split IV^*" else "Split IV^*" end
+      kod_type = if all(is_radical, quotients) "Non-split IV^*" else "Split IV^*" end
     else
       kod_type = "Unrecognized"
     end
@@ -464,7 +464,7 @@ _strict_transform(bd::AbsCoveredSchemeMorphism, II::AbsIdealSheaf; coordinate_na
 
 function _strict_transform(bd::ToricBlowdownMorphism, II::ToricIdealSheafFromCoxRingIdeal; coordinate_name = "e")
   center_ideal = ideal_in_cox_ring(center_unnormalized(bd))
-  if (ngens(ideal_in_cox_ring(II)) != 1) || (all(x -> x in gens(base_ring(center_ideal)), gens(center_ideal)) == false)
+  if (ngens(ideal_in_cox_ring(II)) != 1) || (all(in(gens(base_ring(center_ideal))), gens(center_ideal)) == false)
     return strict_transform(bd, II)
   end
   S = cox_ring(domain(bd))

--- a/experimental/GITFans/src/GITFans.jl
+++ b/experimental/GITFans/src/GITFans.jl
@@ -132,8 +132,7 @@ function orbit_cones(I::MPolyIdeal, Q::Matrix{Int}, G::PermGroup = symmetric_gro
                 # computing rays and facets.
                 facets(cone)
                 rays(cone)
-                if ! any(j -> j == cone,
-                      collector_cones)
+                if !any(==(cone), collector_cones)
                     push!(collector_cones, cone)
                 end
             end
@@ -333,7 +332,7 @@ function orbit_cone_orbits(cones::Vector{Cone{T}}, ghom::GAPGroupHomomorphism) w
         # the heavy lifting of computing rays and facets.
         rays(c)
         facets(c)
-        if all(o -> all(x -> c != x, o), result)
+        if all(o -> all(!=(c), o), result)
             push!(result, orbit(c, matgens, act, Base.:(==)))
         end
     end
@@ -472,7 +471,7 @@ function fan_traversal(orbit_list::Vector{Vector{Cone{T}}}, q_cone::Cone{T}, per
         for i in neighbor_hashes
             if i in hash_list
                 # perhaps we have found a new incidence
-                push!(edges, sort!([findfirst(x->x == i, hash_list), current_pos]))
+                push!(edges, sort!([findfirst(==(i), hash_list), current_pos]))
             else
                 # new representative found
                 push!(hash_list, i)
@@ -511,12 +510,12 @@ function hashes_to_polyhedral_fan(orbit_list::Vector{Vector{Cone{T}}}, hash_list
     allrays = sort!(unique(vcat(rays_maxcones...)))
 
     # the indices of rays that belong to each maximal cone (0-based)
-    index_maxcones = [sort([findfirst(x -> x == v, allrays)-1
+    index_maxcones = [sort([findfirst(==(v), allrays)-1
                             for v in rays])
                       for rays in rays_maxcones]
 
     # the indices of rays that belong to each repres. cone
-    index_result_cones = [sort([findfirst(x -> x == v, allrays)
+    index_result_cones = [sort([findfirst(==(v), allrays)
                             for v in rays])
                       for rays in rays_result_cones]
 

--- a/experimental/GModule/src/Brueckner.jl
+++ b/experimental/GModule/src/Brueckner.jl
@@ -69,7 +69,7 @@ function reps(K, G::Oscar.PcGroup)
           X = l[1]
           Xp = X^p
           #Brueckner: C*Xp == Y for some scalar C
-          ii = findfirst(x->!iszero(x), Xp)
+          ii = findfirst(!is_zero, Xp)
           @assert !iszero(Y[ii])
           C = divexact(Y[ii], Xp[ii])
           @assert C*Xp == Y

--- a/experimental/GModule/src/Cohomology.jl
+++ b/experimental/GModule/src/Cohomology.jl
@@ -348,7 +348,7 @@ function induce(C::GModule{<:Oscar.GAPGroup}, h::Map, D = nothing, mDC = nothing
   for s = gens(G)
     sigma = ra(s)
     u = [ g[i]*s*g[i^sigma]^-1 for i=1:length(g)]
-    @assert all(x->x in iU, u)
+    @assert all(in(iU), u)
     im_q = []
     for q = gens(indC)
       push!(im_q, sum(inj[i^sigma](action(C, preimage(h, u[i]), pro[i](q))) for i=1:length(g)))
@@ -358,7 +358,7 @@ function induce(C::GModule{<:Oscar.GAPGroup}, h::Map, D = nothing, mDC = nothing
     s = inv(s)
     sigma = ra(s)
     u = [ g[i]*s*g[i^sigma]^-1 for i=1:length(g)]
-    @assert all(x->x in iU, u)
+    @assert all(in(iU), u)
     im_q = []
     for q = gens(indC)
       push!(im_q, sum(inj[i^sigma](action(C, preimage(h, u[i]), pro[i](q))) for i=1:length(g)))

--- a/experimental/GModule/src/GModule.jl
+++ b/experimental/GModule/src/GModule.jl
@@ -1177,7 +1177,7 @@ function _two_cocycle(mA::Map, C::GModule{<:Any, <:AbstractAlgebra.FPModule{AbsS
       elseif isone(h)
         sigma[(g, h)] = (one(K))
       else
-        lf = findfirst(x->!iszero(x), X[g*h])
+        lf = findfirst(!is_zero, X[g*h])
         sigma[(g, h)] = (X[g*h][lf]//(map_entries(mA(h), X[g])*X[h])[lf])
 #        sigma[(g, h)] = MK(X[g*h][lf]//(X[h]*map_entries(mA(h), X[g]))[lf])
       end

--- a/experimental/GModule/src/GaloisCohomology.jl
+++ b/experimental/GModule/src/GaloisCohomology.jl
@@ -868,7 +868,7 @@ function idele_class_gmodule(k::AbsSimpleNumField, s::Vector{Int} = Int[]; redo:
   @vprint :GaloisCohomology 2 " .. S-units (for all) ..\n"
   U, mU = sunit_group_fac_elem(S)
   I.mU = mU
-  z = MapFromFunc(codomain(mU), k, x->evaluate(x), y->FacElem(y))
+  z = MapFromFunc(codomain(mU), k, evaluate, FacElem)
   E = gmodule(G, mU, mG)
   Hecke.assure_has_hnf(E.M)
   @hassert :GaloisCohomology -1 is_consistent(E)
@@ -1641,7 +1641,7 @@ function relative_brauer_group(K::AbsSimpleNumField, k::Union{QQField, AbsSimple
     G = s
     mG = ms*mG
   else
-    mp = MapFromFunc(QQ, K, x -> K(x), y-> QQ(y))
+    mp = MapFromFunc(QQ, K, K, QQ)
   end
   B = RelativeBrauerGroup(mp)
   B.mG = mG
@@ -1673,7 +1673,7 @@ function relative_brauer_group(K::AbsSimpleNumField, k::Union{QQField, AbsSimple
     S, mS = sunit_group(lP)
 
     MC = Oscar.GrpCoh.MultGrp(K)
-    mMC = MapFromFunc(K, MC, x->MC(x), y->y.data)
+    mMC = MapFromFunc(K, MC, MC, y->y.data)
 
     mG = B.mG
     G = domain(mG)
@@ -1724,8 +1724,8 @@ function relative_brauer_group(K::AbsSimpleNumField, k::Union{QQField, AbsSimple
   end
 
   B.map =  MapFromFunc(B, Oscar.GrpCoh.AllCoChains{2, PermGroupElem, Oscar.GrpCoh.MultGrpElem{AbsSimpleNumFieldElem}}(),
-                       x->elem_to_cocycle(x), 
-                       y->cocycle_to_elem(y))
+                       elem_to_cocycle, 
+                       cocycle_to_elem)
   return B, B.map
 end
 

--- a/experimental/GaloisGrp/src/Solve.jl
+++ b/experimental/GaloisGrp/src/Solve.jl
@@ -562,7 +562,7 @@ function Oscar.solve(f::ZZPolyRingElem; max_prec::Int=typemax(Int), show_radical
   K = number_field(fld_arr[length(pp)+1])[1]
   i = length(pp)+2
   if K == QQ
-    h = MapFromFunc(K, K, x->x, y->y)
+    h = MapFromFunc(K, K, identity, identity)
   else
     h = hom(K, K, gen(K))
   end

--- a/experimental/GaloisGrp/src/Subfields.jl
+++ b/experimental/GaloisGrp/src/Subfields.jl
@@ -7,7 +7,7 @@ import Oscar.GaloisGrp: POSet, POSetElem, GaloisCtx, find_prime,
 
 
 function embedding_hom(k, K)
-  return MapFromFunc(k, K, x->K(x))
+  return MapFromFunc(k, K, K)
 end
 
 const BlockSystem_t = Vector{Vector{Int}}
@@ -124,7 +124,7 @@ function Base.intersect(A::SubfieldLatticeElem, B::SubfieldLatticeElem)
   while true
     n = length(ds[1])
     for d=ds
-      i = findall(x->any(y->y in d, x), cs)
+      i = findall(x->any(in(d), x), cs)
       x = Set(d)
       union!(x, cs[i]...)
       empty!(d)
@@ -137,7 +137,7 @@ function Base.intersect(A::SubfieldLatticeElem, B::SubfieldLatticeElem)
     end
     n = length(ds[1])
     for d=ds
-      i = findall(x->any(y->y in d, x), bs)
+      i = findall(x->any(in(d), x), bs)
       x = Set(d)
       union!(x, bs[i]...)
       empty!(d)
@@ -362,7 +362,7 @@ function _subfields(K::AbsSimpleNumField; pStart = 2*degree(K)+1, prime = 0)
   r = roots(G, 1, raw = true)
 
   d = map(frobenius, r)
-  si = symmetric_group(degree(K))([findfirst(y->y==x, r) for x = d])
+  si = symmetric_group(degree(K))([findfirst(==(x), r) for x = d])
 
   F, mF = residue_field(parent(r[1]))
   r = map(mF, r)

--- a/experimental/IntersectionTheory/src/Bott.jl
+++ b/experimental/IntersectionTheory/src/Bott.jl
@@ -195,7 +195,7 @@ end
 function tn_flag_variety(dims::Vector{Int}; weights = :int)
   n, l = dims[end], length(dims)
   ranks = pushfirst!([dims[i+1]-dims[i] for i in 1:l-1], dims[1])
-  @assert all(r->r>0, ranks)
+  @assert all(>(0), ranks)
   d = sum(ranks[i] * sum(dims[end]-dims[i]) for i in 1:l-1)
   function enum(i::Int, rest::Vector{Int})
     i == l && return [[rest]]

--- a/experimental/IntersectionTheory/src/Main.jl
+++ b/experimental/IntersectionTheory/src/Main.jl
@@ -2211,7 +2211,7 @@ end
 function abs_flag(dims::Vector{Int}; base::Ring=QQ, symbol::String="c")
   n, l = dims[end], length(dims)
   ranks = pushfirst!([dims[i+1]-dims[i] for i in 1:l-1], dims[1])
-  @assert all(r->r>0, ranks)
+  @assert all(>(0), ranks)
   d = sum(ranks[i] * sum(dims[end]-dims[i]) for i in 1:l-1)
   syms = vcat([_parse_symbol(symbol, i, 1:r) for (i,r) in enumerate(ranks)]...)
   # FIXME ordering
@@ -2302,7 +2302,7 @@ function abstract_flag_bundle(F::AbstractBundle, dims::Vector{Int}; symbol::Stri
   
   l = length(dims)
   ranks = pushfirst!([dims[i+1]-dims[i] for i in 1:l-1], dims[1])
-  @assert all(r->r>0, ranks) && dims[end] <= n
+  @assert all(>(0), ranks) && dims[end] <= n
   if dims[end] < n # the last dim can be omitted
     dims = vcat(dims, [n])
     push!(ranks, n-dims[l])

--- a/experimental/InvariantTheory/src/TorusInvariantsFast.jl
+++ b/experimental/InvariantTheory/src/TorusInvariantsFast.jl
@@ -319,7 +319,7 @@ function torus_invariants_fast(W::Vector{Vector{ZZRingElem}}, R::MPolyRing)
     index_0 = 0
     for point in C
         if is_zero(point)
-            index_0 = findfirst(item -> item == point, C)
+            index_0 = findfirst(==(point), C)
         end
         c = true
         for i in 1:n
@@ -347,7 +347,7 @@ function torus_invariants_fast(W::Vector{Vector{ZZRingElem}}, R::MPolyRing)
                     u = m*gen(R,i)
                     v = w + W[i]
                     if v in C
-                        index = findfirst(item -> item == v, C)
+                        index = findfirst(==(v), C)
                         c = true
                         for elem in S[index]
                             if is_divisible_by(u, elem)
@@ -361,7 +361,7 @@ function torus_invariants_fast(W::Vector{Vector{ZZRingElem}}, R::MPolyRing)
                         end
                     end
                 end
-                deleteat!(U[j], findall(item -> item == m, U[j]))
+                deleteat!(U[j], findall(==(m), U[j]))
             else
                 count += 1
             end

--- a/experimental/LieAlgebras/src/Combinatorics.jl
+++ b/experimental/LieAlgebras/src/Combinatorics.jl
@@ -67,7 +67,7 @@ function multicombinations(v::AbstractVector{T}, k::Integer) where {T}
 end
 
 function permutations(n::Integer)
-  return map(p -> Vector{Int}(p), AbstractAlgebra.SymmetricGroup(n))
+  return map(Vector{Int}, AbstractAlgebra.SymmetricGroup(n))
 end
 
 @doc raw"""

--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -525,7 +525,7 @@ function any_non_ad_nilpotent_element(L::LieAlgebra{C}) where {C<:FieldElem}
     while dim(K) < dim(L)
       # find an element b in L \ K with [b,K]⊆K
       N = normalizer(L, K)
-      b = basis(N, findfirst(b -> !(b in K), basis(N)))
+      b = basis(N, findfirst(!in(K), basis(N)))
       !is_ad_nilpotent(b) && return b
       K = sub(L, [basis(K); b]; is_basis=true)
     end

--- a/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
+++ b/experimental/LieAlgebras/test/LieAlgebraModule-test.jl
@@ -788,7 +788,7 @@
       domchar = @inferred dominant_character(LR, hw)
       @test domchar[Int.(hw)] == 1
       @test issetequal(keys(domchar), dominant_weights(Vector{Int}, LR, hw))
-      @test all(w -> is_dominant_weight(w), keys(domchar))
+      @test all(is_dominant_weight, keys(domchar))
       @test all(>=(1), values(domchar))
       return domchar
     end

--- a/experimental/LieAlgebras/test/setup_tests.jl
+++ b/experimental/LieAlgebras/test/setup_tests.jl
@@ -129,7 +129,7 @@ if !isdefined(Main, :lie_algebra_conformance_test) || isinteractive()
           @test length(chev[1]) == length(chev[2])
           @test dim(L) == sum(length, chev; init=0)
           H = cartan_subalgebra(L)
-          @test all(h -> h in H, chev[3])
+          @test all(in(H), chev[3])
           @test all(xs -> bracket(xs...) in H, zip(chev[1], chev[2]))
         end
       end

--- a/experimental/MatroidRealizationSpaces/src/realization_space.jl
+++ b/experimental/MatroidRealizationSpaces/src/realization_space.jl
@@ -554,7 +554,7 @@ function realization(RS::MatroidRealizationSpace)
 
   if dim(Inew) == 0
     for p in minimal_primes(Inew)
-      if !any(i -> i in p, RS.inequations)
+      if !any(in(p), RS.inequations)
         Inew = p
         break
       end
@@ -643,7 +643,7 @@ end
 # v is replaced by t in f
 function sub_map(v::RingElem, t::RingElem, R::MPolyRing, xs::Vector{<:RingElem})
   xs_v = map(x -> x == v ? t : x, xs)
-  return hom(R, fraction_field(R), a -> a, xs_v)
+  return hom(R, fraction_field(R), identiy, xs_v)
 end
 
 # replace v by t in f, only return the numerator.

--- a/experimental/MatroidRealizationSpaces/src/realization_space.jl
+++ b/experimental/MatroidRealizationSpaces/src/realization_space.jl
@@ -643,7 +643,7 @@ end
 # v is replaced by t in f
 function sub_map(v::RingElem, t::RingElem, R::MPolyRing, xs::Vector{<:RingElem})
   xs_v = map(x -> x == v ? t : x, xs)
-  return hom(R, fraction_field(R), identiy, xs_v)
+  return hom(R, fraction_field(R), identity, xs_v)
 end
 
 # replace v by t in f, only return the numerator.

--- a/experimental/MatroidRealizationSpaces/test/runtests.jl
+++ b/experimental/MatroidRealizationSpaces/test/runtests.jl
@@ -59,13 +59,13 @@
     f = 2*(x^2+y)^2*(x+y*z)^4
     
     @testset "poly_2_prime_divisors" begin
-      @test all(e -> e in [x^2+y, x+y*z], Oscar.poly_2_prime_divisors(f))
+      @test all(in([x^2+y, x+y*z]), Oscar.poly_2_prime_divisors(f))
     end
 
     Sgens = [2*(x^2+y)^2*(x+y*z)^4, 3*x^2*(x+y*z)^5] 
 
     @testset "gens_2_prime_divisors" begin
-      @test all(e-> e in Oscar.gens_2_prime_divisors(Sgens), [x^2+y, x+y*z, x])
+      @test all(in(Oscar.gens_2_prime_divisors(Sgens)), [x^2+y, x+y*z, x])
     end
     
     I = ideal(R, [x^2*(y+z), y^3*(y+z), z*(y+z)])

--- a/experimental/ModStd/src/ModStdNF.jl
+++ b/experimental/ModStd/src/ModStdNF.jl
@@ -106,7 +106,7 @@ function exp_groebner_assure(I::MPolyIdeal{Generic.MPoly{AbsSimpleNumFieldElem}}
       end
 #      @show gd
     else
-      new_idx = [any(x -> any(x->!iszero(x), Hecke.modular_proj(x, me)), AbstractAlgebra.coefficients(gd[i] - IP[i])) for i=1:length(gc)]
+      new_idx = [any(x -> any(!is_zero, Hecke.modular_proj(x, me)), AbstractAlgebra.coefficients(gd[i] - IP[i])) for i=1:length(gc)]
       @vprint :ModStdNF 1 "new information in $new_idx\n"
       push!(R, ZZRingElem(p), lift(Zx, me.ce.pr[end]))
       fl = !any(new_idx)

--- a/experimental/ModStd/src/ModStdQt.jl
+++ b/experimental/ModStd/src/ModStdQt.jl
@@ -790,7 +790,7 @@ function afact(g::QQMPolyRingElem, a::Vector{Int}; int::Bool = false)
         push!(pres, Qt(res[i:i+j]))
         i += j+1
       end
-      d = findfirst(x->x == maximum(degs), degs)
+      d = findfirst(==(maximum(degs)), degs)
       co = []
       for i=1:length(pres)
         push!(co, lift(pres[d], pres[i], coeff(fac, d), coeff(fac, i), fpt))

--- a/experimental/OrthogonalDiscriminants/src/data.jl
+++ b/experimental/OrthogonalDiscriminants/src/data.jl
@@ -69,7 +69,7 @@ julia> orthogonal_discriminant(t2[4])
 """
 function orthogonal_discriminant(chi::Oscar.GAPGroupClassFunction)
   tbl = parent(chi)
-  pos = findfirst(x -> x === chi, tbl)
+  pos = findfirst(===(chi), tbl)
   pos === nothing && return ""
   p = characteristic(tbl)
   if p == 0
@@ -456,8 +456,7 @@ function all_od_infos(L...)
       names = [ids]
     elseif ids isa Vector{String}
       if names !== nothing
-        names = filter(x -> x in names,
-                       [(OD_simple_names[x], x) for x in ids])
+        names = filter(in(names), [(OD_simple_names[x], x) for x in ids])
       else
         names = [(OD_simple_names[x], x) for x in ids]
       end

--- a/experimental/OrthogonalDiscriminants/src/data.jl
+++ b/experimental/OrthogonalDiscriminants/src/data.jl
@@ -69,7 +69,7 @@ julia> orthogonal_discriminant(t2[4])
 """
 function orthogonal_discriminant(chi::Oscar.GAPGroupClassFunction)
   tbl = parent(chi)
-  pos = findfirst(===(chi), tbl)
+  pos = findfirst(x -> x === chi, tbl)
   pos === nothing && return ""
   p = characteristic(tbl)
   if p == 0

--- a/experimental/OrthogonalDiscriminants/src/utils.jl
+++ b/experimental/OrthogonalDiscriminants/src/utils.jl
@@ -146,13 +146,13 @@ function possible_permutation_characters_from_sylow_subgroup(tbl::Oscar.GAPGroup
   q = p^q
 
   # Perhaps the Sylow `p`-subgroup is cyclic.
-  pos = findfirst(x -> x == q, orders_class_representatives(tbl))
+  pos = findfirst(==(q), orders_class_representatives(tbl))
   pos != nothing && return [induced_cyclic(tbl, [pos])[1]]
 
   # Do we have the table of marks?
   tom = GAP.Globals.TableOfMarks(GapObj(tbl))
   if tom != GAP.Globals.fail
-    pos = findfirst(x -> x == q, Vector{Int}(GAP.Globals.OrdersTom(tom)))
+    pos = findfirst(==(q), Vector{Int}(GAP.Globals.OrdersTom(tom)))
     return [Oscar.class_function(tbl, GAP.Globals.PermCharsTom(GapObj(tbl), tom)[pos])]
   end
 

--- a/experimental/OrthogonalDiscriminants/test/theoretical.jl
+++ b/experimental/OrthogonalDiscriminants/test/theoretical.jl
@@ -53,10 +53,10 @@ end
 @testset "p-groups" begin
   rx = r"syl\((?<p>\d+)\)"
   info = all_od_infos(characteristic => 0,
-                 comment_matches => (x -> any(y -> startswith(y, "syl"), x)))
+                 comment_matches => (x -> any(startswith("syl"), x)))
   for entry in info[1:100]
     chi = Oscar.OrthogonalDiscriminants.character_of_entry(entry)
-    c = filter(x -> startswith(x, "syl"), entry[:comment])
+    c = filter(startswith("syl"), entry[:comment])
     for e in c
       p = parse(Int, match(rx, e)[:p])
       (flag, valstring) = Oscar.OrthogonalDiscriminants.od_from_p_subgroup(chi, p)

--- a/experimental/QuadFormAndIsom/src/embeddings.jl
+++ b/experimental/QuadFormAndIsom/src/embeddings.jl
@@ -1671,7 +1671,7 @@ function admissible_equivariant_primitive_extensions(A::ZZLatWithIsom,
   # Requirements for [BH23]
   same_ambient = ambient_space(lattice(A)) === ambient_space(lattice(B)) === ambient_space(lattice(C))
   if check
-    @req all(L -> is_integral(L), [A, B, C]) "Underlying lattices must be integral"
+    @req all(is_integral(L), [A, B, C]) "Underlying lattices must be integral"
     chiA = minimal_polynomial(A)
     chiB = minimal_polynomial(parent(chiA), isometry(B))
     @req gcd(chiA, chiB) == 1 "Minimal irreducible polynomials must be relatively coprime"

--- a/experimental/QuadFormAndIsom/src/embeddings.jl
+++ b/experimental/QuadFormAndIsom/src/embeddings.jl
@@ -1671,7 +1671,7 @@ function admissible_equivariant_primitive_extensions(A::ZZLatWithIsom,
   # Requirements for [BH23]
   same_ambient = ambient_space(lattice(A)) === ambient_space(lattice(B)) === ambient_space(lattice(C))
   if check
-    @req all(is_integral(L), [A, B, C]) "Underlying lattices must be integral"
+    @req all(is_integral, [A, B, C]) "Underlying lattices must be integral"
     chiA = minimal_polynomial(A)
     chiB = minimal_polynomial(parent(chiA), isometry(B))
     @req gcd(chiA, chiB) == 1 "Minimal irreducible polynomials must be relatively coprime"

--- a/experimental/QuadFormAndIsom/src/enumeration.jl
+++ b/experimental/QuadFormAndIsom/src/enumeration.jl
@@ -134,7 +134,7 @@ function is_admissible_triple(A::ZZGenus, B::ZZGenus, C::ZZGenus, p::IntegerUnio
   end
 
   # A+B and C must agree locally at every primes except p
-  for q in filter(qq -> qq != p, union!(ZZRingElem[2], primes(AperpB), primes(C)))
+  for q in filter(!=(p), union!(ZZRingElem[2], primes(AperpB), primes(C)))
     if local_symbol(AperpB, q) != local_symbol(C, q)
       return false
     end
@@ -432,7 +432,7 @@ function _possible_signatures(s2::IntegerUnion, E::Field, rk::IntegerUnion)
     parts = Vector{Int}[]
     l = divexact(s2-l, 2)
     for v in AllParts(l)
-      if any(i -> i > rk, v)
+      if any(>(rk), v)
         continue
       end
       if length(v) > s

--- a/experimental/QuadFormAndIsom/src/hermitian_miranda_morrison.jl
+++ b/experimental/QuadFormAndIsom/src/hermitian_miranda_morrison.jl
@@ -115,7 +115,7 @@ function _get_quotient_ramified(P::Hecke.RelNumFieldOrderIdeal, i::Int)
 
   if i < e
     S = abelian_group()
-    return S, x -> one(E), x -> id(S)
+    return S, _ -> one(E), _ -> id(S)
   end
 
   t = e-1

--- a/experimental/QuadFormAndIsom/src/lattices_with_isometry.jl
+++ b/experimental/QuadFormAndIsom/src/lattices_with_isometry.jl
@@ -1791,10 +1791,10 @@ function _real_kernel_signatures(L::ZZLat, M::MatElem)
   diag = Hecke._gram_schmidt(diag, C)[1]
   diag = diagonal(diag)
 
-  @hassert :ZZLatWithIsom 1 all(z -> isreal(z), diag)
-  @hassert :ZZLatWithIsom 1 all(z -> !iszero(z), diag)
+  @hassert :ZZLatWithIsom 1 all(isreal, diag)
+  @hassert :ZZLatWithIsom 1 all(!iszero, diag)
 
-  k1 = count(z -> z > 0, diag)
+  k1 = count(>(0), diag)
   k2 = length(diag) - k1
 
   return k1, k2

--- a/experimental/SetPartitions/src/ColoredPartition.jl
+++ b/experimental/SetPartitions/src/ColoredPartition.jl
@@ -13,9 +13,9 @@ struct ColoredPartition <: AbstractPartition
                               color_upper_points::Vector{Int},
                               color_lower_points::Vector{Int})
 
-        @req all(x -> x in (0, 1), color_upper_points) "upper coloring has to be binary in {0, 1}"
+        @req all(in((0, 1)), color_upper_points) "upper coloring has to be binary in {0, 1}"
         @req number_of_upper_points(partition) == length(color_upper_points) "upper coloring format does not match upper points format"
-        @req all(x -> x in (0, 1), color_lower_points) "lower coloring has to be binary in {0, 1}"
+        @req all(in((0, 1)), color_lower_points) "lower coloring has to be binary in {0, 1}"
         @req number_of_lower_points(partition) == length(color_lower_points) "lower coloring format does not match and lower points format"
 
         return new(partition, color_upper_points, color_lower_points)

--- a/experimental/SetPartitions/src/PartitionProperties.jl
+++ b/experimental/SetPartitions/src/PartitionProperties.jl
@@ -28,7 +28,7 @@ function is_pair(p::AbstractPartition)
             end
         end
     end
-    return all(i -> i == 2, values(block_to_size))
+    return all(==(2), values(block_to_size))
 end
 
 """

--- a/experimental/StandardFiniteFields/src/StandardFiniteFields.jl
+++ b/experimental/StandardFiniteFields/src/StandardFiniteFields.jl
@@ -484,7 +484,7 @@ function standard_finite_field(p::IntegerUnion, n::IntegerUnion)
     d = divexact(nK, n1)
     b = element_from_steinitz_number(
       K,
-      p^(findfirst(x -> x == d, standard_monomial_degrees(nK)) - 1),
+      p^(findfirst(==(d), standard_monomial_degrees(nK)) - 1),
     )
 
     return _extension_with_tower_basis(K, m, c, b)

--- a/experimental/SymmetricIntersections/src/elevators.jl
+++ b/experimental/SymmetricIntersections/src/elevators.jl
@@ -11,7 +11,7 @@
 function _iterate_size(lbs::Vector{Int}, ubs::Vector{Int}, d::Int)
   is_empty(lbs) && return 0
   if d == 0
-    return any(bb -> bb > 0, lbs) ? 0 : 1
+    return any(>(0), lbs) ? 0 : 1
   end
 
   @assert length(lbs) == length(ubs)
@@ -37,7 +37,7 @@ function _iterate_size_no_lbs(ubs::Vector{Int}, d::Int)
     return d <= ubs[1] ? 1 : 0
   end
 
-  if all(k -> k >= d, ubs)
+  if all(>=(d), ubs)
     return binomial(d+length(ubs)-1, d)
   end
 
@@ -195,9 +195,9 @@ function elevator(L::Vector{T}, f::U, d::Int; lbs::Vector{Int} = Int[0 for i in 
   fL = f.(L)
   @req issorted(fL) "L is not sorted with respect to f"
   @req length(lbs) == length(L) "Bounds conditions must have the same length as the entry list"
-  @req all(i -> i >= 0, lbs) "Bounds conditions must consist of non negative integers"
+  @req all(>=(0), lbs) "Bounds conditions must consist of non negative integers"
 
-  no_ubs = any(i -> i < 0, ubs)
+  no_ubs = any(<(0), ubs)
 
   _fL = unique(fL)
   _lbs = Int[sum([lbs[i] for i in 1:length(lbs) if fL[i] == _fL[j]]) for j in 1:length(_fL)]
@@ -235,7 +235,7 @@ elevator(L::Vector{Int}, d::Int; lbs::Vector{Int} = [0 for i in 1:length(L)], ub
 # default is the lexicographic order
 function _first(EC::ElevCtx, sumtype::Vector{ZZRingElem})
   @assert sum(sumtype) == degree_of_elevations(EC)
-  @assert any(s -> s == sumtype, _possible_sums(EC))
+  @assert any(==(sumtype), _possible_sums(EC))
   lbs, ubs  = associated_bounds(EC)
   L = underlying_list(EC)
   f = associated_function(EC)
@@ -273,7 +273,7 @@ function _first_homog(lbs::Vector{Int}, ubs::Vector{Int}, d::Int)
 
   i = 1
   while length(s) != d
-    if count(j -> j == i, s) < ubs[i]
+    if count(==(i), s) < ubs[i]
       push!(s, i)
     else
       i += 1
@@ -328,7 +328,7 @@ function _last_homog(lbs::Vector{Int}, ubs::Vector{Int}, d::Int)
 
   i = length(lbs)
   while length(s) != d
-    if count(j -> j == i, s) < ubs[i]
+    if count(==(i), s) < ubs[i]
       push!(s, i)
     else
       i -= 1
@@ -424,7 +424,7 @@ function _next_homog_no_lbs(ubs::Vector{Int}, elhn::Vector{Int})
   _ubs = deepcopy(ubs)
   _ubs[elhn[end]] -= 1
   s = _next_homog_no_lbs(_ubs, elhn[1:end-1])
-  nb = count(j -> j == s[end], s)
+  nb = count(==(s[end]), s)
   j = findfirst(j -> (j == s[end] && ubs[j] > nb) || (j > s[end] && ubs[j] != 0), 1:length(ubs))
   push!(s, j)
   return s

--- a/experimental/SymmetricIntersections/src/representations.jl
+++ b/experimental/SymmetricIntersections/src/representations.jl
@@ -847,7 +847,7 @@ end
 
 function _same_support(v::Vector{T}, w::Vector{T}) where T
   @req length(v) == length(w) "Tensor must have the same number of components"
-  return all(cv -> any(cw -> cv == cw, w), v)
+  return issetequal(v, w)
 end
 
 function _div(v::Vector{T}, w::Vector{T}; symmetric = false) where T
@@ -855,7 +855,7 @@ function _div(v::Vector{T}, w::Vector{T}; symmetric = false) where T
   if symmetric
     return 1
   else
-    return sign(perm(Int[findfirst(vv -> vv == ww, v) for ww in w]))
+    return sign(perm(Int[findfirst(==(ww), v) for ww in w]))
   end
 end
 

--- a/experimental/SymmetricIntersections/src/symmetric_grassmannians.jl
+++ b/experimental/SymmetricIntersections/src/symmetric_grassmannians.jl
@@ -517,7 +517,7 @@ function _intersection_with_grassmannian(V::Vector{T}, n::Int, t::Int;
   ideal_PV = ideal(S, vec(collect(matrix(S, 1, nvars(S), gens(S))*K)))
   PV = subscheme(X, ideal_PV)
   _J = modulus(OO(intersect(affine_cone(Grtn)[1], affine_cone(PV)[1])))
-  J = ideal(S, elem_type(S)[map_coefficients(x -> F(x), p; parent = S) for p in gens(_J)])
+  J = ideal(S, elem_type(S)[map_coefficients(F, p; parent = S) for p in gens(_J)])
   J = saturation(J)
   return J::ideal_type(S)
 end

--- a/experimental/SymmetricIntersections/test/runtests.jl
+++ b/experimental/SymmetricIntersections/test/runtests.jl
@@ -32,14 +32,14 @@ end
   @test base_field(RR) isa AbsSimpleNumField
   @test underlying_group(RR) === E
   @test order(Oscar.character_table_underlying_group(RR)) == 8
-  @test all(chi -> is_irreducible(chi), Oscar.irreducible_characters_underlying_group(RR))
-  @test all(h -> h in E, Oscar.generators_underlying_group(RR))
+  @test all(is_irreducible, Oscar.irreducible_characters_underlying_group(RR))
+  @test all(in(E), Oscar.generators_underlying_group(RR))
 
   chis = @inferred all_characters(RR, 2)
   @test length(chis) == 11
 
   RR, reps = @inferred all_irreducible_representations(E)
-  @test all(r -> is_irreducible(r), reps)
+  @test all(is_irreducible, reps)
   chis = Oscar.irreducible_characters_underlying_group(RR)
   @test length(reps) == 5
   @test all(i -> character_representation(RR, representation_mapping(reps[i])) == chis[i], 1:length(chis))


### PR DESCRIPTION
(Splitting this up to try to prevent too many conflicts.

This should increase compilation times, in particular re-compilation.

The problem of anonymous functions is that each one of them has its own type. If we now pass it to a function (or even worse, to a parameterized type), all functions below have to get re-compiled for this new type.
This PR only touches really trivial cases, where readability of the code should still be similar as before.