### PR TITLE
booktests: fix version spec for pkg add to allow patch releases

### DIFF
--- a/test/book/specialized/holt-ren-tropical-geometry/auxiliary_code/main.jl
+++ b/test/book/specialized/holt-ren-tropical-geometry/auxiliary_code/main.jl
@@ -1,5 +1,5 @@
 using Pkg
-Pkg.add(name="MixedSubdivisions", version=v"1.1"; io=devnull)
+Pkg.add(name="MixedSubdivisions", version="1.1"; io=devnull)
 
 import LibGit2
 repo = LibGit2.clone("https://github.com/isaacholt100/generic_root_count", "generic_root_count");


### PR DESCRIPTION
final step to fix #4087 

_Edit_: No depwarn anymore: https://github.com/oscar-system/Oscar.jl/actions/runs/10980220808/job/30485739069?pr=4131#step:9:390