### PR TITLE
Revert "load the GAP packages sotgrps and sglppow"

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -127,8 +127,6 @@ function __init__()
   # We want some GAP packages. (It is no error if they cannot be loaded.)
   for pkg in [
      "ferret",   # backtrack in permutation groups
-     "sotgrps",  # extend the small groups library
-     "sglppow",  # extend the small groups library
      ]
     GAP.Packages.load(pkg)
   end


### PR DESCRIPTION
This reverts PR #3517 / commit 55ea9572354c55fec4d74b4b1a09067620f7f1d3.

We can reland it as soon as the underlying issue is fixed, but for now this brings relieve to people who are affected by issue #4136.