### PR TITLE
Rename blowdown to blowup

### DIFF
--- a/docs/doc.main
+++ b/docs/doc.main
@@ -211,7 +211,7 @@
         "AlgebraicGeometry/ToricVarieties/ToricMorphisms.md",
         "AlgebraicGeometry/ToricVarieties/ToricSchemes.md",
         "AlgebraicGeometry/ToricVarieties/ToricIdealSheaves.md",
-        "AlgebraicGeometry/ToricVarieties/BlowdownMorphisms.md",
+        "AlgebraicGeometry/ToricVarieties/BlowupMorphisms.md",
      ],
      "Miscellaneous" => [
        "AlgebraicGeometry/Miscellaneous/miscellaneous.md",

--- a/docs/src/AlgebraicGeometry/ToricVarieties/BlowupMorphisms.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/BlowupMorphisms.md
@@ -66,23 +66,23 @@ blow_up(m::NormalToricVariety, I::ToricIdealSheafFromCoxRingIdeal; coordinate_na
 ## Attributes
 
 ```@docs
-underlying_morphism(bl::ToricBlowdownMorphism)
-index_of_new_ray(bl::ToricBlowdownMorphism)
-center_data(bl::ToricBlowdownMorphism)
-center_unnormalized(bl::ToricBlowdownMorphism)
-exceptional_prime_divisor(bl::ToricBlowdownMorphism)
+underlying_morphism(bl::ToricBlowupMorphism)
+index_of_new_ray(bl::ToricBlowupMorphism)
+center_data(bl::ToricBlowupMorphism)
+center_unnormalized(bl::ToricBlowupMorphism)
+exceptional_prime_divisor(bl::ToricBlowupMorphism)
 ```
 Based on `underlying_morphism`, also the following attributes of toric
 morphisms are supported for toric blowups:
-- `grid_morphism(bl::ToricBlowdownMorphism)`,
-- `morphism_on_torusinvariant_weil_divisor_group(bl::ToricBlowdownMorphism)`,
-- `morphism_on_torusinvariant_cartier_divisor_group(bl::ToricBlowdownMorphism)`,
-- `morphism_on_class_group(bl::ToricBlowdownMorphism)`,
-- `morphism_on_picard_group(bl::ToricBlowdownMorphism)`.
+- `grid_morphism(bl::ToricBlowupMorphism)`,
+- `morphism_on_torusinvariant_weil_divisor_group(bl::ToricBlowupMorphism)`,
+- `morphism_on_torusinvariant_cartier_divisor_group(bl::ToricBlowupMorphism)`,
+- `morphism_on_class_group(bl::ToricBlowupMorphism)`,
+- `morphism_on_picard_group(bl::ToricBlowupMorphism)`.
 The total and strict transform of ideal sheaves along blowups, not
 necessarily toric, can be computed:
 ```@docs
-total_transform(f::AbsSimpleBlowdownMorphism, II::AbsIdealSheaf)
+total_transform(f::AbsSimpleBlowupMorphism, II::AbsIdealSheaf)
 ```
 
 

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -462,7 +462,7 @@ eval_poly(n::Number, R) = R(n)
 
 _strict_transform(bd::AbsCoveredSchemeMorphism, II::AbsIdealSheaf) = strict_transform(bd, II)
 
-function _strict_transform(bd::ToricBlowdownMorphism, II::ToricIdealSheafFromCoxRingIdeal)
+function _strict_transform(bd::ToricBlowupMorphism, II::ToricIdealSheafFromCoxRingIdeal)
   center_ideal = ideal_in_cox_ring(center_unnormalized(bd))
   if (ngens(ideal_in_cox_ring(II)) != 1) || (all(in(gens(base_ring(center_ideal))), gens(center_ideal)) == false)
     return strict_transform(bd, II)
@@ -487,7 +487,7 @@ function _strict_transform(bd::ToricBlowdownMorphism, II::ToricIdealSheafFromCox
   return ideal_sheaf(domain(bd), strict_transform)
 end
 
-function _strict_transform(bd::ToricBlowdownMorphism, tate_poly::MPolyRingElem)
+function _strict_transform(bd::ToricBlowupMorphism, tate_poly::MPolyRingElem)
   S = cox_ring(domain(bd))
   _e = gen(S, index_of_new_ray(bd))
   g_list = string.(gens(S))

--- a/experimental/Schemes/src/BlowupMorphism.jl
+++ b/experimental/Schemes/src/BlowupMorphism.jl
@@ -7,12 +7,12 @@ export projection
     AbsDesingMor{
                                   DomainType<:AbsCoveredScheme,
                                   CodomainType<:AbsCoveredScheme,
-                                  BlowdownMorphismType
+                                  BlowupMorphismType
        } <: AbsCoveredSchemeMorphism{
                                  DomainType,
                                  CodomainType,
                                  Nothing,
-                                 BlowdownMorphismType
+                                 BlowupMorphismType
                                 }
 Abstract type for desingularizations ``f : X -> Y `` of schemes where
 
@@ -24,55 +24,55 @@ Abstract type for desingularizations ``f : X -> Y `` of schemes where
 abstract type AbsDesingMor{
                            DomainType<:AbsCoveredScheme,
                            CodomainType<:AbsCoveredScheme,
-                           BlowdownMorphismType
+                           BlowupMorphismType
                           } <: AbsCoveredSchemeMorphism{
                                                         DomainType,
                                                         CodomainType,
                                                         Nothing,
-                                                        BlowdownMorphismType
+                                                        BlowupMorphismType
                                                        }
 end
 
 ########################################################################
-# An abstract type for blowdown morphisms.
+# An abstract type for blowup morphisms.
 #
 # This should also comprise sequences of simple blowups leading
 # to a partial or full resolution of singularities. The interface
 # is specified below.
 ########################################################################
-abstract type AbsBlowdownMorphism{DomainType<:AbsCoveredScheme,
+abstract type AbsBlowupMorphism{DomainType<:AbsCoveredScheme,
                                   CodomainType<:AbsCoveredScheme,
-                                  BlowdownMorphismType
-                                 } <: AbsDesingMor{DomainType, CodomainType, BlowdownMorphismType}
+                                  BlowupMorphismType
+                                 } <: AbsDesingMor{DomainType, CodomainType, BlowupMorphismType}
 end
 
 # The interface inherits all functionality from AbsCoveredSchemeMorphism.
 # This is extended by the following:
 @doc raw"""
-    exceptional_divisor(f::AbsBlowdownMorphism)
+    exceptional_divisor(f::AbsBlowupMorphism)
 
 Return a `CartierDivisor` on the `domain` of `f` which is the
 preimage of the vanishing locus of the `center` of `f`.
 
 !!! note If `f` is not a classical blowup, but, for instance, a small contraction, then the exceptional locus need not be a divisor. See `exceptional_locus` for such cases.
 """
-function exceptional_divisor(f::AbsBlowdownMorphism)
+function exceptional_divisor(f::AbsBlowupMorphism)
   error("not implemented")
 end
 
 @doc raw"""
-    exceptional_locus(f::AbsBlowdownMorphism)
+    exceptional_locus(f::AbsBlowupMorphism)
 
 Return an `AbsAlgebraicCycle` on the `domain` of `f` which is the preimage
 of the `center` of `f` in a reasonable sense. In particular, `f` is an isomorphism
 onto its image outside the support of its `exceptional_locus`. See also `exceptional_divisor`.
 """
-function exceptional_locus(f::AbsBlowdownMorphism)
+function exceptional_locus(f::AbsBlowupMorphism)
   error("not implemented")
 end
 
 @doc raw"""
-    center(f::AbsBlowdownMorphism)
+    center(f::AbsBlowupMorphism)
 
 Return an `AbsIdealSheaf` on the `codomain` of `f` such that on the complement
 of the vanishing locus of that ideal sheaf `f` is an isomorphism.
@@ -81,12 +81,12 @@ locus of the pullback of the `center`.
 
 !!! note For classical blowup constructions this will be the center which has been blown up. For more exotic blowups, however, this might be more special.
 """
-function center(f::AbsBlowdownMorphism)
+function center(f::AbsBlowupMorphism)
   error("not implemented")
 end
 
 @doc raw"""
-    strict_transform(f::AbsBlowdownMorphism, a::Any)
+    strict_transform(f::AbsBlowupMorphism, a::Any)
 
 Take the closure of the `pullback` of `a` along `f` on the complement
 of the `exceptional_locus` in a mathematically reasonable sense.
@@ -94,12 +94,12 @@ Depending on `a` this either returns the corresponding object on
 the `domain` of `f`, or a tuple consisting of the object and eventually
 induced maps.
 """
-function strict_transform(f::AbsBlowdownMorphism, a::Any)
+function strict_transform(f::AbsBlowupMorphism, a::Any)
   error("not implemented")
 end
 
 @doc raw"""
-    total_transform(f::AbsBlowdownMorphism, a::Any)
+    total_transform(f::AbsBlowupMorphism, a::Any)
 
 Take the `pullback` or preimage of `a` along `f` in a mathematically
 reasonable sense.
@@ -107,7 +107,7 @@ Depending on `a` this either returns the corresponding object on
 the `domain` of `f`, or a tuple consisting of the object and eventually
 induced maps.
 """
-function total_transform(f::AbsBlowdownMorphism, a::Any)
+function total_transform(f::AbsBlowupMorphism, a::Any)
   error("not implemented")
 end
 
@@ -117,47 +117,47 @@ end
 # This can either be a BlowupMorphism as below, but also a special
 # toric morphism induced by fan subdivisions.
 ########################################################################
-abstract type AbsSimpleBlowdownMorphism{DomainType<:AbsCoveredScheme,
+abstract type AbsSimpleBlowupMorphism{DomainType<:AbsCoveredScheme,
                                      CodomainType<:AbsCoveredScheme,
-                                     BlowdownMorphismType
-    } <: AbsBlowdownMorphism{
+                                     BlowupMorphismType
+    } <: AbsBlowupMorphism{
                              DomainType,
                              CodomainType,
-                             BlowdownMorphismType
+                             BlowupMorphismType
                             }
 end
 
 @doc raw"""
-    exceptional_divisor(f::AbsSimpleBlowdownMorphism)
+    exceptional_divisor(f::AbsSimpleBlowupMorphism)
 
 Return a `CartierDivisor` on the `domain` of `f` which coincides
 with the pullback of the `center` of `f`.
 """
-function exceptional_divisor(f::AbsSimpleBlowdownMorphism)
+function exceptional_divisor(f::AbsSimpleBlowupMorphism)
   error("not implemented")
 end
 
 @doc raw"""
-    exceptional_locus(f::AbsBlowdownMorphism)
+    exceptional_locus(f::AbsBlowupMorphism)
 
 Return the `WeilDivisor` of the `exceptional_divisor`.
 """
-function exceptional_locus(f::AbsSimpleBlowdownMorphism)
+function exceptional_locus(f::AbsSimpleBlowupMorphism)
   error("not implemented")
 end
 
 @doc raw"""
-    center(f::AbsSimpleBlowdownMorphism)
+    center(f::AbsSimpleBlowupMorphism)
 
 Return an `AbsIdealSheaf` on the `codomain` of `f` the blowup of which
 leads to `f`.
 """
-function center(f::AbsSimpleBlowdownMorphism)
+function center(f::AbsSimpleBlowupMorphism)
   error("not implemented")
 end
 
 @doc raw"""
-    strict_transform(f::AbsSimpleBlowdownMorphism, a::Any)
+    strict_transform(f::AbsSimpleBlowupMorphism, a::Any)
 
 Take the closure of the `pullback` of `a` along `f` on the complement
 of the `exceptional_divisor` in a mathematically reasonable sense.
@@ -166,12 +166,12 @@ Depending on `a` this either returns the corresponding object on
 the `domain` of `f`, or a tuple consisting of the object and eventually
 induced maps.
 """
-function strict_transform(f::AbsSimpleBlowdownMorphism, a::Any)
+function strict_transform(f::AbsSimpleBlowupMorphism, a::Any)
   error("not implemented")
 end
 
 @doc raw"""
-    total_transform(f::AbsSimpleBlowdownMorphism, a::Any)
+    total_transform(f::AbsSimpleBlowupMorphism, a::Any)
 
 Take the `pullback` or preimage of `a` along `f` in a mathematically
 reasonable sense.
@@ -180,12 +180,12 @@ Depending on `a` this either returns the corresponding object on
 the `domain` of `f`, or a tuple consisting of the object and eventually
 induced maps.
 """
-function total_transform(f::AbsSimpleBlowdownMorphism, a::Any)
+function total_transform(f::AbsSimpleBlowupMorphism, a::Any)
   error("not implemented")
 end
 
 @doc raw"""
-    controlled_transform(f::AbsSimpleBlowdownMorphism, a::Any, k::Int)
+    controlled_transform(f::AbsSimpleBlowupMorphism, a::Any, k::Int)
 
 Take the `pullback` or preimage of `a` along `f` saturated by `k` times
 the `exceptional_divisor` of `f` in a mathematically reasonable sense.
@@ -194,7 +194,7 @@ Depending on `a` this either returns the corresponding object on
 the `domain` of `f`, or a tuple consisting of the object and eventually
 induced maps.
 """
-function controlled_transform(f::AbsSimpleBlowdownMorphism, a::Any, k::Int)
+function controlled_transform(f::AbsSimpleBlowupMorphism, a::Any, k::Int)
   error("not implemented")
 end
 
@@ -272,7 +272,7 @@ with restriction
 @attributes mutable struct BlowupMorphism{
      DomainType<:AbsCoveredScheme, # Not a concrete type in general because this is lazy
      CodomainType<:AbsCoveredScheme,
-   } <: AbsSimpleBlowdownMorphism{
+   } <: AbsSimpleBlowupMorphism{
                                   DomainType,
                                   CodomainType,
                                   BlowupMorphism{DomainType, CodomainType}
@@ -347,7 +347,7 @@ For a `BlowupMorphism` ``p : Y → X`` and a `CoveredClosedEmbedding`
 return a triple ``(Z', j, π)`` containing the `CoveredClosedEmbedding`
 ``j : Z' ↪ Y`` and the induced projection ``π : Z' → Z``.
 """
-function strict_transform(p::AbsSimpleBlowdownMorphism, inc::CoveredClosedEmbedding)
+function strict_transform(p::AbsSimpleBlowupMorphism, inc::CoveredClosedEmbedding)
   Y = domain(p)
   X = codomain(p)
   Z = domain(inc)
@@ -428,7 +428,7 @@ end
 For a `BlowupMorphism`  ``p : Y → X`` and an `AbsIdealSheaf` ``I`` on ``X`` return the
 strict transform of ``I`` on ``Y``.
 """
-function strict_transform(p::AbsSimpleBlowdownMorphism, I::AbsIdealSheaf)
+function strict_transform(p::AbsSimpleBlowupMorphism, I::AbsIdealSheaf)
   return StrictTransformIdealSheaf(p, I)
   Istrict,_ =_do_transform(p, I, -1)
   return Istrict
@@ -441,7 +441,7 @@ For a `BlowupMorphism`  ``p : Y → X`` and an `AbsIdealSheaf` ``I`` on ``X`` re
 weak transform ``J`` of ``I`` on ``Y``, i.e. an `AbsIdealSheaf` satisfying ``E^m J = p^*I`` with ``m``
 maximal and ``E`` the 'AbsIdealSheaf' of the exceptional divisor of ``p``.
 """
-function weak_transform(p::AbsSimpleBlowdownMorphism, I::AbsIdealSheaf)
+function weak_transform(p::AbsSimpleBlowupMorphism, I::AbsIdealSheaf)
   Iweak,_ =_do_transform(p,I,0)
   return Iweak
 end
@@ -454,7 +454,7 @@ weak transform ``J`` of ``I`` on ``Y`` and the multiplicity ``m`` of the excepti
 the maximal ``m`` such that ``E^m J = p^*I``, where ``E`` denotes the `AbsIdealSheaf` of the exceptional
 divisor of ``p``.
 """
-function weak_transform_with_multiplicity(p::AbsSimpleBlowdownMorphism, I::AbsIdealSheaf)
+function weak_transform_with_multiplicity(p::AbsSimpleBlowupMorphism, I::AbsIdealSheaf)
   Iweak, multi = _do_transform(p,I,0)
   return Iweak,multi
 end
@@ -466,7 +466,7 @@ For a `BlowupMorphism`  ``p : Y → X`` and an `AbsIdealSheaf` ``I`` on ``X`` re
 controlled transform of ``I`` on ``Y`` with control ``b``,i.e. an `AbsIdealSheaf` ``J`` such that
 ``E^b J = p^*I`` where ``E``denotes the `AbsIdealSheaf` of the exceptional divisor.
 """
-function controlled_transform(p::AbsSimpleBlowdownMorphism, I::AbsIdealSheaf, b::Int)
+function controlled_transform(p::AbsSimpleBlowupMorphism, I::AbsIdealSheaf, b::Int)
   Icontrol,_ = _do_transform(p,I,b)
   return Icontrol
 end
@@ -474,7 +474,7 @@ end
 ##########################################################################################################
 ## central internal method for strict, weak and controlled transforms of AbsIdealSheafs and subschemes
 ##########################################################################################################
-function _do_transform(p::AbsSimpleBlowdownMorphism, I::AbsIdealSheaf, method::Int=-1)
+function _do_transform(p::AbsSimpleBlowupMorphism, I::AbsIdealSheaf, method::Int=-1)
 ## method: -1  strict transform
 ##          0  weak transform
 ##         b>0  controlled transform with control b>0
@@ -545,11 +545,11 @@ end
 For a `BlowupMorphism`  ``p : Y → X`` and an `EffectiveCartierDivisor` ``C`` on ``X`` return the
 strict transform of ``C`` on ``Y``.
 """
-function strict_transform(p::AbsSimpleBlowdownMorphism, C::EffectiveCartierDivisor)
+function strict_transform(p::AbsSimpleBlowupMorphism, C::EffectiveCartierDivisor)
   return strict_transform_with_multiplicity(p,C)[1]
 end
 
-function strict_transform_with_multiplicity(p::AbsSimpleBlowdownMorphism, C::EffectiveCartierDivisor)
+function strict_transform_with_multiplicity(p::AbsSimpleBlowupMorphism, C::EffectiveCartierDivisor)
   X = scheme(C)
   Y = domain(p)
   X === codomain(p) || error("cartier divisor is not defined on the codomain of the morphism")
@@ -608,7 +608,7 @@ function strict_transform_with_multiplicity(p::AbsSimpleBlowdownMorphism, C::Eff
   return C_strict,multEInC
 end
 
-function strict_transform(p::AbsSimpleBlowdownMorphism, C::CartierDivisor)
+function strict_transform(p::AbsSimpleBlowupMorphism, C::CartierDivisor)
   X = codomain(p)
   Y = domain(p)
   X === scheme(C) || error("cartier divisor not defined on the codomain of the map")
@@ -692,7 +692,7 @@ end
 ##############################################################################
 # show functions for Blowup morphisms
 ##############################################################################
-function Base.show(io::IO, Bl::AbsSimpleBlowdownMorphism)
+function Base.show(io::IO, Bl::AbsSimpleBlowupMorphism)
   io = pretty(io)
   if is_terse(io)
     print(io, "Blowup morphism")
@@ -702,7 +702,7 @@ function Base.show(io::IO, Bl::AbsSimpleBlowdownMorphism)
   end
 end
 
-function show(io::IO, ::MIME"text/plain", Bl::AbsSimpleBlowdownMorphism)
+function show(io::IO, ::MIME"text/plain", Bl::AbsSimpleBlowupMorphism)
   ## data of the original scheme
   X0 = codomain(Bl)
   C0 = get_attribute(X0, :simplified_covering, default_covering(X0))
@@ -820,15 +820,15 @@ end
   error("attribute not found; this needs to be set manually in general")
 end
 
-function compose(f::AbsSimpleBlowdownMorphism, g::AbsSimpleBlowdownMorphism)
+function compose(f::AbsSimpleBlowupMorphism, g::AbsSimpleBlowupMorphism)
   return composite_map(f, g)
 end
 
-function compose(f::AbsSimpleBlowdownMorphism, g::AbsCoveredSchemeMorphism)
+function compose(f::AbsSimpleBlowupMorphism, g::AbsCoveredSchemeMorphism)
   return composite_map(f, g)
 end
 
-function compose(f::AbsCoveredSchemeMorphism, g::AbsSimpleBlowdownMorphism)
+function compose(f::AbsCoveredSchemeMorphism, g::AbsSimpleBlowupMorphism)
   return composite_map(f, g)
 end
 
@@ -850,7 +850,7 @@ end
 @attributes mutable struct BlowUpSequence{
                                           DomainType<:AbsCoveredScheme,
                                           CodomainType<:AbsCoveredScheme
-                                         }<:AbsBlowdownMorphism{
+                                         }<:AbsBlowupMorphism{
                                                                 DomainType, CodomainType, 
                                                                 BlowUpSequence{DomainType, CodomainType}
                                                                }
@@ -919,12 +919,12 @@ end
                                                                        SpaceType, OpenType,
                                                                        OutputType, RestrictionType
                                                                       }
-  morphism::AbsSimpleBlowdownMorphism
+  morphism::AbsSimpleBlowupMorphism
   orig::AbsIdealSheaf
   underlying_presheaf::AbsPreSheaf
 
   function StrictTransformIdealSheaf(
-      f::AbsSimpleBlowdownMorphism,
+      f::AbsSimpleBlowupMorphism,
       J::AbsIdealSheaf
     )
     @assert scheme(J) === codomain(f)
@@ -949,7 +949,7 @@ function produce_object_on_affine_chart(I::StrictTransformIdealSheaf, U::AbsAffi
   Y = codomain(f)
   J = original_ideal_sheaf(I)
   @assert any(x->x===U, affine_charts(X))
-  if f isa ToricBlowdownMorphism
+  if f isa ToricBlowupMorphism
     # This is not actually an exceptional divisor of a blowup along an ideal sheaf.
     # This is the prime Weil divisor corresponding to the added/chosen ray.
     # This is the exceptional divisor of a blowup along a certain Rees algebra.

--- a/experimental/Schemes/src/BlowupMorphism.jl
+++ b/experimental/Schemes/src/BlowupMorphism.jl
@@ -697,7 +697,7 @@ function Base.show(io::IO, Bl::AbsSimpleBlowupMorphism)
   if is_terse(io)
     print(io, "Blowup morphism")
   else
-    print(io, "Blow-down: ", Lowercase(), domain(Bl))
+    print(io, "Blow-up: ", Lowercase(), domain(Bl))
     print(io, " -> ", Lowercase(), codomain(Bl))
   end
 end

--- a/experimental/Schemes/src/Resolution_structure.jl
+++ b/experimental/Schemes/src/Resolution_structure.jl
@@ -1384,7 +1384,7 @@ function common_refinement(list::Vector{<:Covering}, def_cov::Covering)
                      )
 end
 
-function strict_transform(bl::AbsSimpleBlowdownMorphism, inc::ClosedEmbedding)
+function strict_transform(bl::AbsSimpleBlowupMorphism, inc::ClosedEmbedding)
   B = codomain(bl)
   @assert length(affine_charts(B)) == 1 && first(affine_charts(B)) === codomain(inc)
   inc_cov = CoveredClosedEmbedding(inc, codomain=B)

--- a/experimental/Schemes/src/ToricBlowups/attributes.jl
+++ b/experimental/Schemes/src/ToricBlowups/attributes.jl
@@ -3,7 +3,7 @@ export center_unnormalized
 export exceptional_prime_divisor
 
 @doc raw"""
-    underlying_morphism(bl::ToricBlowdownMorphism)
+    underlying_morphism(bl::ToricBlowupMorphism)
 
 Return the underlying toric morphism of a toric blowup. Access to other
 attributes such as `domain`, `codomain`, `covering_morphism` are
@@ -15,18 +15,18 @@ julia> P3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
 
 julia> f = blow_up(P3, [0, 1, 1])
-Toric blowdown morphism
+Toric blowup morphism
 
 julia> Oscar.underlying_morphism(f)
 Toric morphism
 ```
 """
-underlying_morphism(bl::ToricBlowdownMorphism) = bl.toric_morphism
+underlying_morphism(bl::ToricBlowupMorphism) = bl.toric_morphism
 
 
 
 @doc raw"""
-    index_of_new_ray(bl::ToricBlowdownMorphism)
+    index_of_new_ray(bl::ToricBlowupMorphism)
 
 Return the index of the new ray used in the construction of the toric
 blowup.
@@ -37,17 +37,17 @@ julia> P3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
 
 julia> f = blow_up(P3, [0, 1, 1])
-Toric blowdown morphism
+Toric blowup morphism
 
 julia> index_of_new_ray(f)
 5
 ```
 """
-index_of_new_ray(bl::ToricBlowdownMorphism) = bl.index_of_new_ray
+index_of_new_ray(bl::ToricBlowupMorphism) = bl.index_of_new_ray
 
 
 @doc raw"""
-    center_data(bl::ToricBlowdownMorphism)
+    center_data(bl::ToricBlowupMorphism)
 
 Returns the ideal, ideal sheaf or ray that was used to construct the
 morphism.
@@ -58,7 +58,7 @@ julia> P3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
 
 julia> f = blow_up(P3, [0, 2, 3])
-Toric blowdown morphism
+Toric blowup morphism
 
 julia> center_data(f)
 3-element Vector{Int64}:
@@ -67,13 +67,13 @@ julia> center_data(f)
  3
 ```
 """
-function center_data(bl::ToricBlowdownMorphism)
+function center_data(bl::ToricBlowupMorphism)
   return bl.center_data
 end
 
 
 @doc raw"""
-    center_unnormalized(bl::ToricBlowdownMorphism)
+    center_unnormalized(bl::ToricBlowupMorphism)
 
 Returns an ideal sheaf `I` such that the normalization of the blowup
 along `I` gives the morphism `bl`.
@@ -84,7 +84,7 @@ julia> P3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
 
 julia> f = blow_up(P3, [0, 2, 3])
-Toric blowdown morphism
+Toric blowup morphism
 
 julia> center_unnormalized(f)
 Sheaf of ideals
@@ -96,7 +96,7 @@ with restrictions
   4: Ideal (1)
 ```
 """
-function center_unnormalized(bl::ToricBlowdownMorphism)
+function center_unnormalized(bl::ToricBlowupMorphism)
   if !isdefined(bl, :center_unnormalized)
     # TODO: The implementation below is highly inefficient. Improve it if you know how.
     X = domain(bl)
@@ -114,7 +114,7 @@ end
 
 
 @doc raw"""
-    exceptional_prime_divisor(bl::ToricBlowdownMorphism)
+    exceptional_prime_divisor(bl::ToricBlowupMorphism)
 
 Return the exceptional prime Weil divisor (as a toric divisor) of the
 ray used to construct the toric blowup. Note that this divisor need not
@@ -127,7 +127,7 @@ julia> P3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
 
 julia> f = blow_up(P3, [0, 2, 3])
-Toric blowdown morphism
+Toric blowup morphism
 
 julia> E = exceptional_prime_divisor(f)
 Torus-invariant, prime divisor on a normal toric variety
@@ -136,7 +136,7 @@ julia> is_cartier(E)
 false
 ```
 """
-function exceptional_prime_divisor(bl::ToricBlowdownMorphism)
+function exceptional_prime_divisor(bl::ToricBlowupMorphism)
   if !isdefined(bl, :exceptional_prime_divisor)
     X = domain(bl)
     S = cox_ring(X)
@@ -155,11 +155,11 @@ end
 #########################################################################
 # Forwarding attributes of toric morphisms based on `underlying_morphism`
 #########################################################################
-grid_morphism(bl::ToricBlowdownMorphism) = grid_morphism(underlying_morphism(bl))
-morphism_on_torusinvariant_weil_divisor_group(bl::ToricBlowdownMorphism) = morphism_on_torusinvariant_weil_divisor_group(underlying_morphism(bl))
-morphism_on_torusinvariant_cartier_divisor_group(bl::ToricBlowdownMorphism) = morphism_on_torusinvariant_cartier_divisor_group(underlying_morphism(bl))
-morphism_on_class_group(bl::ToricBlowdownMorphism) = morphism_on_class_group(underlying_morphism(bl))
-morphism_on_picard_group(bl::ToricBlowdownMorphism) = morphism_on_picard_group(underlying_morphism(bl))
+grid_morphism(bl::ToricBlowupMorphism) = grid_morphism(underlying_morphism(bl))
+morphism_on_torusinvariant_weil_divisor_group(bl::ToricBlowupMorphism) = morphism_on_torusinvariant_weil_divisor_group(underlying_morphism(bl))
+morphism_on_torusinvariant_cartier_divisor_group(bl::ToricBlowupMorphism) = morphism_on_torusinvariant_cartier_divisor_group(underlying_morphism(bl))
+morphism_on_class_group(bl::ToricBlowupMorphism) = morphism_on_class_group(underlying_morphism(bl))
+morphism_on_picard_group(bl::ToricBlowupMorphism) = morphism_on_picard_group(underlying_morphism(bl))
 
 
 
@@ -167,11 +167,11 @@ morphism_on_picard_group(bl::ToricBlowdownMorphism) = morphism_on_picard_group(u
 For the future, if traits seem better to forward methods as the ones immediately above (grid_morphism, morphism_on_torusinvariant_weil_divisor_group, etc.):
 
 ########################################################################
-# Enabling the HasToricSubObjectTrait for ToricBlowdownMorphism        #
+# Enabling the HasToricSubObjectTrait for ToricBlowupMorphism        #
 ########################################################################
-HasToricSubObjectTrait(::Type{T}) where {T<:ToricBlowdownMorphism} = HasToricSubObjectTrait{ToricMorphism}()
+HasToricSubObjectTrait(::Type{T}) where {T<:ToricBlowupMorphism} = HasToricSubObjectTrait{ToricMorphism}()
 
-toric_sub_object(bl::ToricBlowdownMorphism) = underlying_morphism(bl)
+toric_sub_object(bl::ToricBlowupMorphism) = underlying_morphism(bl)
 
 ########################################################################
 # Enabling the functionality in general                                #

--- a/experimental/Schemes/src/ToricBlowups/constructors.jl
+++ b/experimental/Schemes/src/ToricBlowups/constructors.jl
@@ -106,7 +106,7 @@ julia> P3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
 
 julia> f = blow_up(P3, [0, 2, 3])
-Toric blowdown morphism
+Toric blowup morphism
 
 julia> bP3 = domain(f)
 Normal toric variety
@@ -145,7 +145,7 @@ julia> v = normal_toric_variety(max_cones, rs)
 Normal toric variety
 
 julia> f = blow_up(v, [0, 1])
-Toric blowdown morphism
+Toric blowup morphism
 
 julia> center_unnormalized(f)
 Sheaf of ideals
@@ -161,20 +161,20 @@ function blow_up(v::NormalToricVarietyType, new_ray::AbstractVector{<:IntegerUni
   coordinate_name = _find_blowup_coordinate_name(v, coordinate_name)
   new_variety = normal_toric_variety(star_subdivision(v, new_ray))
   if is_smooth(v) == false
-    return ToricBlowdownMorphism(v, new_variety, coordinate_name, new_ray, new_ray)
+    return ToricBlowupMorphism(v, new_variety, coordinate_name, new_ray, new_ray)
   end
   inx = _get_maximal_cones_containing_vector(polyhedral_fan(v), new_ray)
   old_rays = matrix(ZZ, rays(v))
   cone_generators = matrix(ZZ, [old_rays[i,:] for i in 1:nrows(old_rays) if ray_indices(maximal_cones(v))[inx[1], i]])
   powers = solve_non_negative(ZZMatrix, transpose(cone_generators), transpose(matrix(ZZ, [new_ray])))
   if nrows(powers) != 1
-    return ToricBlowdownMorphism(v, new_variety, coordinate_name, new_ray, new_ray)
+    return ToricBlowupMorphism(v, new_variety, coordinate_name, new_ray, new_ray)
   end
   gens_S = gens(cox_ring(v))
   variables = [gens_S[i] for i in 1:nrows(old_rays) if ray_indices(maximal_cones(v))[inx[1], i]]
   list_of_gens = [variables[i]^powers[i] for i in 1:length(powers) if powers[i] != 0]
   center_unnormalized = ideal_sheaf(v, ideal([variables[i]^powers[i] for i in 1:length(powers) if powers[i] != 0]))
-  return ToricBlowdownMorphism(v, new_variety, coordinate_name, new_ray, new_ray, center_unnormalized)
+  return ToricBlowupMorphism(v, new_variety, coordinate_name, new_ray, new_ray, center_unnormalized)
 end
 
 @doc raw"""
@@ -194,7 +194,7 @@ julia> P3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
 
 julia> f = blow_up(P3, 5)
-Toric blowdown morphism
+Toric blowup morphism
 
 julia> bP3 = domain(f)
 Normal toric variety
@@ -215,7 +215,7 @@ function blow_up(v::NormalToricVarietyType, n::Int; coordinate_name::Union{Strin
   new_variety = normal_toric_variety(star_subdivision(v, n))
   rays_of_variety = matrix(ZZ, rays(v))
   new_ray = vec(sum([rays_of_variety[i, :] for i in 1:number_of_rays(v) if cones(v)[n, i]]))
-  return ToricBlowdownMorphism(v, new_variety, coordinate_name, new_ray, new_ray, center_unnormalized)
+  return ToricBlowupMorphism(v, new_variety, coordinate_name, new_ray, new_ray, center_unnormalized)
 end
 
 
@@ -278,7 +278,7 @@ function blow_up(v::NormalToricVarietyType, I::MPolyIdeal; coordinate_name::Unio
     new_ray = new_ray ./ gcd(new_ray)
     new_variety = normal_toric_variety(star_subdivision(v, new_ray))
     center_unnormalized = ideal_sheaf(v, I)
-    return ToricBlowdownMorphism(v, new_variety, coordinate_name, new_ray, I, center_unnormalized)
+    return ToricBlowupMorphism(v, new_variety, coordinate_name, new_ray, I, center_unnormalized)
   else
     return _generic_blow_up(v, I)
   end

--- a/experimental/Schemes/src/ToricBlowups/methods.jl
+++ b/experimental/Schemes/src/ToricBlowups/methods.jl
@@ -1,5 +1,5 @@
 @doc raw"""
-    total_transform(f::AbsSimpleBlowdownMorphism, II::IdealSheaf)
+    total_transform(f::AbsSimpleBlowupMorphism, II::IdealSheaf)
 
 Computes the total transform of an ideal sheaf along a blowup.
 
@@ -13,7 +13,7 @@ julia> P2 = projective_space(NormalToricVariety, 2)
 Normal toric variety
 
 julia> bl = blow_up(P2, [1, 1])
-Toric blowdown morphism
+Toric blowup morphism
 
 julia> S = cox_ring(P2);
 
@@ -37,10 +37,10 @@ with restrictions
   4: Ideal (x_1_4)
 ```
 """
-function total_transform(f::AbsSimpleBlowdownMorphism, II::AbsIdealSheaf)
+function total_transform(f::AbsSimpleBlowupMorphism, II::AbsIdealSheaf)
   return pullback(f, II)
 end
 
-function total_transform(f::AbsBlowdownMorphism, II::AbsIdealSheaf)
+function total_transform(f::AbsBlowupMorphism, II::AbsIdealSheaf)
   return pullback(f, II)
 end

--- a/experimental/Schemes/src/ToricBlowups/types.jl
+++ b/experimental/Schemes/src/ToricBlowups/types.jl
@@ -2,7 +2,7 @@
 # Type definition                                                      #
 ########################################################################
 
-@attributes mutable struct ToricBlowdownMorphism{
+@attributes mutable struct ToricBlowupMorphism{
   DomainType <: NormalToricVarietyType, 
   CodomainType <: NormalToricVarietyType,
   CenterDataType <: Union{
@@ -15,7 +15,7 @@
     ToricIdealSheafFromCoxRingIdeal,
     IdealSheaf,
   },
-} <: AbsSimpleBlowdownMorphism{DomainType, CodomainType, ToricBlowdownMorphism}
+} <: AbsSimpleBlowupMorphism{DomainType, CodomainType, ToricBlowupMorphism}
 
   toric_morphism::ToricMorphism
   index_of_new_ray::Integer
@@ -23,7 +23,7 @@
   center_unnormalized::CenterUnnormalizedType
   exceptional_prime_divisor::ToricDivisor
 
-  function _toric_blowdown_morphism(v::NormalToricVarietyType, new_variety::NormalToricVarietyType, coordinate_name::String, new_ray::AbstractVector{<:IntegerUnion}, center_data::CenterDataType) where CenterDataType <: Union{
+  function _toric_blowup_morphism(v::NormalToricVarietyType, new_variety::NormalToricVarietyType, coordinate_name::String, new_ray::AbstractVector{<:IntegerUnion}, center_data::CenterDataType) where CenterDataType <: Union{
     AbstractVector{<:IntegerUnion},
     MPolyIdeal,
     ToricIdealSheafFromCoxRingIdeal,
@@ -57,13 +57,13 @@
     return bl_toric, position_new_ray, center_data
   end
   
-  function ToricBlowdownMorphism(v::NormalToricVarietyType, new_variety::NormalToricVarietyType, coordinate_name::String, new_ray::AbstractVector{<:IntegerUnion}, center_data::CenterDataType, center_unnormalized::ToricIdealSheafFromCoxRingIdeal) where CenterDataType <: Union{
+  function ToricBlowupMorphism(v::NormalToricVarietyType, new_variety::NormalToricVarietyType, coordinate_name::String, new_ray::AbstractVector{<:IntegerUnion}, center_data::CenterDataType, center_unnormalized::ToricIdealSheafFromCoxRingIdeal) where CenterDataType <: Union{
     AbstractVector{<:IntegerUnion},
     MPolyIdeal,
     ToricIdealSheafFromCoxRingIdeal,
     IdealSheaf,
   }
-    bl_toric, position_new_ray, center_data = _toric_blowdown_morphism(v, new_variety, coordinate_name, new_ray, center_data)
+    bl_toric, position_new_ray, center_data = _toric_blowup_morphism(v, new_variety, coordinate_name, new_ray, center_data)
     bl = new{
       typeof(domain(bl_toric)),
       typeof(codomain(bl_toric)),
@@ -73,13 +73,13 @@
     return bl
   end
   
-  function ToricBlowdownMorphism(v::NormalToricVarietyType, new_variety::NormalToricVarietyType, coordinate_name::String, new_ray::AbstractVector{<:IntegerUnion}, center_data::CenterDataType) where CenterDataType <: Union{
+  function ToricBlowupMorphism(v::NormalToricVarietyType, new_variety::NormalToricVarietyType, coordinate_name::String, new_ray::AbstractVector{<:IntegerUnion}, center_data::CenterDataType) where CenterDataType <: Union{
     AbstractVector{<:IntegerUnion},
     MPolyIdeal,
     ToricIdealSheafFromCoxRingIdeal,
     IdealSheaf,
   }
-    bl_toric, position_new_ray, center_data = _toric_blowdown_morphism(v, new_variety, coordinate_name, new_ray, center_data)
+    bl_toric, position_new_ray, center_data = _toric_blowup_morphism(v, new_variety, coordinate_name, new_ray, center_data)
     bl = new{
       typeof(domain(bl_toric)),
       typeof(codomain(bl_toric)),
@@ -93,56 +93,56 @@ end
 
 
 ########################################################################
-# Arithmetic for toric blowdown moprhism and toric morphisms           #
+# Arithmetic for toric blowup moprhism and toric morphisms           #
 ########################################################################
 
-function Base.:+(tm1::ToricBlowdownMorphism, tm2::ToricBlowdownMorphism)
+function Base.:+(tm1::ToricBlowupMorphism, tm2::ToricBlowupMorphism)
   @req domain(tm1) === domain(tm2) "The morphisms must have identical domains"
   @req codomain(tm1) === codomain(tm2) "The morphisms must have identical codomains"
   return toric_morphism(domain(tm1), grid_morphism(tm1) + grid_morphism(tm2), codomain(tm1))
 end
 
-function Base.:-(tm1::ToricBlowdownMorphism, tm2::ToricBlowdownMorphism)
+function Base.:-(tm1::ToricBlowupMorphism, tm2::ToricBlowupMorphism)
   @req domain(tm1) === domain(tm2) "The morphisms must have identical domains"
   @req codomain(tm1) === codomain(tm2) "The morphisms must have identical codomains"
   return toric_morphism(domain(tm1), grid_morphism(tm1) - grid_morphism(tm2), codomain(tm1))
 end
 
-function Base.:*(c::T, tm::ToricBlowdownMorphism) where T <: IntegerUnion
+function Base.:*(c::T, tm::ToricBlowupMorphism) where T <: IntegerUnion
 new_grid_morphism = hom(domain(grid_morphism(tm)), codomain(grid_morphism(tm)), c * matrix(grid_morphism(tm)))
 return toric_morphism(domain(tm), new_grid_morphism, codomain(tm))
 end
 
-Base.:+(tm1::ToricBlowdownMorphism, tm2::ToricMorphism) = underlying_morphism(tm1) + tm2
-Base.:-(tm1::ToricBlowdownMorphism, tm2::ToricMorphism) = underlying_morphism(tm1) - tm2
-Base.:+(tm1::ToricMorphism, tm2::ToricBlowdownMorphism) = tm1 + underlying_morphism(tm2)
-Base.:-(tm1::ToricMorphism, tm2::ToricBlowdownMorphism) = tm1 - underlying_morphism(tm2)
+Base.:+(tm1::ToricBlowupMorphism, tm2::ToricMorphism) = underlying_morphism(tm1) + tm2
+Base.:-(tm1::ToricBlowupMorphism, tm2::ToricMorphism) = underlying_morphism(tm1) - tm2
+Base.:+(tm1::ToricMorphism, tm2::ToricBlowupMorphism) = tm1 + underlying_morphism(tm2)
+Base.:-(tm1::ToricMorphism, tm2::ToricBlowupMorphism) = tm1 - underlying_morphism(tm2)
 
 
 
 ######################################################
-# Composition of toric blowdowns and toric morphisms #
+# Composition of toric blowups and toric morphisms #
 ######################################################
 
-function Base.:*(tm1::ToricBlowdownMorphism, tm2::ToricBlowdownMorphism)
+function Base.:*(tm1::ToricBlowupMorphism, tm2::ToricBlowupMorphism)
   @req codomain(tm1) === domain(tm2) "The codomain of the first morphism must be identically the same as the domain of the second morphism"
   return toric_morphism(domain(tm1), grid_morphism(tm1) * grid_morphism(tm2), codomain(tm2))
 end
 
-Base.:*(tm1::ToricMorphism, tm2::ToricBlowdownMorphism) = tm1 * underlying_morphism(tm2)
-Base.:*(tm1::ToricBlowdownMorphism, tm2::ToricMorphism) = underlying_morphism(tm1) * tm2
+Base.:*(tm1::ToricMorphism, tm2::ToricBlowupMorphism) = tm1 * underlying_morphism(tm2)
+Base.:*(tm1::ToricBlowupMorphism, tm2::ToricMorphism) = underlying_morphism(tm1) * tm2
 
 
 
 ####################################################
-# Equality and hash of toric blowdowns             #
+# Equality and hash of toric blowups             #
 ####################################################
 
-function Base.:(==)(tm1::ToricBlowdownMorphism, tm2::ToricBlowdownMorphism)
+function Base.:(==)(tm1::ToricBlowupMorphism, tm2::ToricBlowupMorphism)
   return domain(tm1) == domain(tm2) && codomain(tm1) == codomain(tm2) && grid_morphism(tm1) == grid_morphism(tm2)
 end
 
-function Base.hash(tm::ToricBlowdownMorphism, h::UInt)
+function Base.hash(tm::ToricBlowupMorphism, h::UInt)
   b = 0x1a66f927cae2d409 % UInt
   h = hash(domain(tm), h)
   h = hash(codomain(tm), h)
@@ -156,5 +156,5 @@ end
 # Display            #
 ######################
 
-Base.show(io::IO, tbdm::ToricBlowdownMorphism) = print(io, "Toric blowdown morphism")
-Base.show(io::IO, ::MIME"text/plain", tbdm::ToricBlowdownMorphism) = Base.show(pretty(io), tbdm)
+Base.show(io::IO, tbdm::ToricBlowupMorphism) = print(io, "Toric blowup morphism")
+Base.show(io::IO, ::MIME"text/plain", tbdm::ToricBlowupMorphism) = Base.show(pretty(io), tbdm)

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Morphisms/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Morphisms/Constructors.jl
@@ -127,7 +127,7 @@ julia> inc_E = Oscar.CoveredClosedEmbedding(domain(pr), JJ);
 julia> comp = Oscar.composite_map(inc_E, pr)
 Composite morphism of
   Hom: scheme over QQ covered with 2 patches -> scheme over QQ covered with 2 patches
-  Blow-down: scheme over QQ covered with 2 patches -> scheme over QQ covered with 1 patch
+  Blow-up: scheme over QQ covered with 2 patches -> scheme over QQ covered with 1 patch
 
 julia> Oscar.maps(comp)[1] === inc_E
 true

--- a/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/attributes.jl
@@ -174,7 +174,7 @@ end
 
 For a given toric morphism `tm`, we can compute the corresponding
 morphism of covered schemes. The following demonstrates this for the
-blow-down morphism of a blow-up of the projective space.
+blow-up morphism of a blow-up of the projective space.
 
 # Examples
 ```jldoctest
@@ -211,7 +211,7 @@ Covering
 ```
 """
 @attr CoveringMorphism function covering_morphism(f::ToricMorphism)
-  # TODO: If f is a blowdown morphism, we can simplify 
+  # TODO: If f is a blowup morphism, we can simplify 
   # the matchings of cones below.
   X = domain(f)
   Y = codomain(f)

--- a/test/AlgebraicGeometry/ToricVarieties/toric_blowups.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/toric_blowups.jl
@@ -1,4 +1,4 @@
-@testset "Toric blowdowns" begin
+@testset "Toric blowups" begin
   
   P2 = projective_space(NormalToricVariety, 2)
   BP2 = domain(blow_up(P2, 1; coordinate_name = "e"))
@@ -38,7 +38,7 @@
   P2 = projective_space(NormalToricVariety, 2)
   bl = blow_up(P2, [1, 1])
   
-  @testset "Basic tests for simple toric blowdown" begin
+  @testset "Basic tests for simple toric blowup" begin
     @test torsion_free_rank(domain(grid_morphism(bl))) == 2
     @test torsion_free_rank(codomain(grid_morphism(bl))) == 2
     @test matrix(morphism_on_torusinvariant_weil_divisor_group(bl)) == matrix(ZZ, [1 0 0; 0 1 0; 0 0 1; 1 1 0])
@@ -61,7 +61,7 @@
   E = exceptional_prime_divisor(bl)
   H = toric_divisor(domain(bl), [1, 2, 3, 4]) + E
   
-  @testset "Strict, total transform and exceptional divisor for simple toric blowdown" begin
+  @testset "Strict, total transform and exceptional divisor for simple toric blowup" begin
     @test issubset(ideal_sheaf(H), ideal_sheaf(E))
     @test issubset(pbJ, pbJ_str)
     @test issubset(pbJ, ideal_sheaf(E))
@@ -72,9 +72,9 @@
   bl2 = blow_up(P2, I)
   II = IdealSheaf(P2, I)
   
-  @testset "Properties of toric blowdown defined by ideal" begin
+  @testset "Properties of toric blowup defined by ideal" begin
     @test II == center_unnormalized(bl)
-    @test bl2 isa Oscar.ToricBlowdownMorphism
+    @test bl2 isa Oscar.ToricBlowupMorphism
     @test center_unnormalized(bl2) == II
   end
 end

--- a/test/AlgebraicGeometry/ToricVarieties/toric_schemes.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/toric_schemes.jl
@@ -57,7 +57,7 @@
   pb_I = pullback(bl, I)
   pb_J = pullback(bl, J)
 
-  @testset "Toric blowdown morphism as morphism of covered schemes" begin
+  @testset "Toric blowup morphism as morphism of covered schemes" begin
     @test scheme(I) === IP2
     @test length(Oscar.maximal_associated_points(I)) == 2
     @test length(Oscar.maximal_associated_points(pb_I)) == 3

--- a/test/book/specialized/bies-kastner-toric-geometry/starsubdivision.jlcon
+++ b/test/book/specialized/bies-kastner-toric-geometry/starsubdivision.jlcon
@@ -19,7 +19,7 @@ julia> rays(maximal_cones(v)[1])
  [-1, 1]
 
 julia> bu = blow_up(v, [0,1])
-Toric blowdown morphism
+Toric blowup morphism
 
 julia> v2 = domain(bu)
 Normal toric variety


### PR DESCRIPTION
Command used:
```
sed --follow-symlinks -i \
-e "s;blowdown;blowup;g" \
-e "s;blow-down;blow-up;g" \
-e "s;Blow-down;Blow-up;g" \
-e "s;Blowdown;Blowup;g" \
-e "s;BlowDown;BlowUp;g" \
$(git ls-files)

mv "./test/AlgebraicGeometry/ToricVarieties/toric_blowdowns.jl" "./test/AlgebraicGeometry/ToricVarieties/toric_blowups.jl"
mv "./docs/src/AlgebraicGeometry/ToricVarieties/BlowdownMorphisms.md" "./docs/src/AlgebraicGeometry/ToricVarieties/BlowupMorphisms.md"
```