### PR TITLE
LieAlgebras: reduce allocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /docs/src/Nemo/
 /docs/src/Experimental/
 profile.pb.gz
+alloc-profile.pb.gz
 LocalPreferences.toml
 Manifest.toml
 .DS_Store

--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -49,7 +49,9 @@ Return the `i`-th basis element of the Lie algebra `L`.
 function basis(L::LieAlgebra, i::Int)
   @req 1 <= i <= dim(L) "Index out of bounds."
   R = coefficient_ring(L)
-  return L([(j == i ? one(R) : zero(R)) for j in 1:dim(L)])
+  v = zero_matrix(R, 1, dim(L))
+  v[1, i] = one(R)
+  return L(v)
 end
 
 @doc raw"""

--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -455,10 +455,12 @@ end
 
 function adjoint_matrix(x::LieAlgebraElem{C}) where {C<:FieldElem}
   L = parent(x)
-  return sum(
-    c * g for (c, g) in zip(coefficients(x), adjoint_matrices(L));
-    init=zero_matrix(coefficient_ring(L), dim(L), dim(L)),
-  )
+  mat = zero_matrix(coefficient_ring(L), dim(L), dim(L))
+  tmp = zero(mat)
+  for (c, g) in zip(coefficients(x), adjoint_matrices(L))
+    mat = addmul!(mat, g, c, tmp)
+  end
+  return mat
 end
 
 function _adjoint_matrix(S::LieSubalgebra{C}, x::LieAlgebraElem{C}) where {C<:FieldElem}

--- a/experimental/LieAlgebras/src/LieAlgebraIdeal.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraIdeal.jl
@@ -270,7 +270,7 @@ where `L` is the Lie algebra where `I` lives in.
 function lie_algebra(I::LieAlgebraIdeal)
   LI = lie_algebra(basis(I))
   L = base_lie_algebra(I)
-  emb = hom(LI, L, basis(I))
+  emb = hom(LI, L, basis(I); check=false)
   return LI, emb
 end
 

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -53,7 +53,9 @@ Return the `i`-th basis element of the Lie algebra module `V`.
 function basis(V::LieAlgebraModule, i::Int)
   @req 1 <= i <= dim(V) "Index out of bounds."
   R = coefficient_ring(V)
-  return V([(j == i ? one(R) : zero(R)) for j in 1:dim(V)])
+  v = zero_matrix(R, 1, dim(V))
+  v[1, i] = one(R)
+  return V(v)
 end
 
 @doc raw"""

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -84,6 +84,7 @@ import ..Oscar:
   tensor_product,
   weyl_vector,
   word,
+  zero!,
   zero_map,
   ⊕,
   ⊗

--- a/experimental/LieAlgebras/src/LieSubalgebra.jl
+++ b/experimental/LieAlgebras/src/LieSubalgebra.jl
@@ -301,7 +301,7 @@ where `L` is the Lie algebra where `S` lives in.
 function lie_algebra(S::LieSubalgebra)
   LS = lie_algebra(basis(S))
   L = base_lie_algebra(S)
-  emb = hom(LS, L, basis(S))
+  emb = hom(LS, L, basis(S); check=false)
   return LS, emb
 end
 

--- a/experimental/LieAlgebras/src/LinearLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LinearLieAlgebra.jl
@@ -21,7 +21,7 @@ Return the basis `basis(L)` of the Lie algebra `L` in the underlying matrix
 representation.
 """
 function matrix_repr_basis(L::LinearLieAlgebra{C}) where {C<:FieldElem}
-  return Vector{dense_matrix_type(C)}(L.basis)
+  return L.basis::Vector{dense_matrix_type(C)}
 end
 
 @doc raw"""
@@ -31,7 +31,7 @@ Return the `i`-th element of the basis `basis(L)` of the Lie algebra `L` in the
 underlying matrix representation.
 """
 function matrix_repr_basis(L::LinearLieAlgebra{C}, i::Int) where {C<:FieldElem}
-  return (L.basis[i])::dense_matrix_type(C)
+  return matrix_repr_basis(L)[i]
 end
 
 ###############################################################################
@@ -130,10 +130,12 @@ Return the Lie algebra element `x` in the underlying matrix representation.
 """
 function Generic.matrix_repr(x::LinearLieAlgebraElem)
   L = parent(x)
-  return sum(
-    c * b for (c, b) in zip(_matrix(x), matrix_repr_basis(L));
-    init=zero_matrix(coefficient_ring(L), L.n, L.n),
-  )
+  mat = zero_matrix(coefficient_ring(L), L.n, L.n)
+  tmp = zero(mat)
+  for (c, b) in zip(coefficients(x), matrix_repr_basis(L))
+    mat = addmul!(mat, b, c, tmp)
+  end
+  return mat
 end
 
 function bracket(

--- a/experimental/LieAlgebras/src/RootSystem.jl
+++ b/experimental/LieAlgebras/src/RootSystem.jl
@@ -524,6 +524,14 @@ function RootSpaceElem(w::WeightLatticeElem)
   return RootSpaceElem(root_system(w), w)
 end
 
+function zero(::Type{RootSpaceElem}, R::RootSystem)
+  return RootSpaceElem(R, zero_matrix(QQ, 1, rank(R)))
+end
+
+function zero(r::RootSpaceElem)
+  return zero(RootSpaceElem, root_system(r))
+end
+
 function Base.:*(q::RationalUnion, r::RootSpaceElem)
   return RootSpaceElem(root_system(r), q * r.vec)
 end
@@ -542,6 +550,29 @@ end
 
 function Base.:-(r::RootSpaceElem)
   return RootSpaceElem(root_system(r), -r.vec)
+end
+
+function zero!(r::RootSpaceElem)
+  r.vec = zero!(r.vec)
+  return r
+end
+
+function add!(rr::RootSpaceElem, r1::RootSpaceElem, r2::RootSpaceElem)
+  @req root_system(rr) === root_system(r1) === root_system(r2) "parent root system mismatch"
+  rr.vec = add!(rr.vec, r1.vec, r2.vec)
+  return rr
+end
+
+function neg!(rr::RootSpaceElem, r::RootSpaceElem)
+  @req root_system(rr) === root_system(r) "parent root system mismatch"
+  rr.vec = neg!(rr.vec, r.vec)
+  return rr
+end
+
+function sub!(rr::RootSpaceElem, r1::RootSpaceElem, r2::RootSpaceElem)
+  @req root_system(rr) === root_system(r1) === root_system(r2) "parent root system mismatch"
+  rr.vec = sub!(rr.vec, r1.vec, r2.vec)
+  return rr
 end
 
 function Base.:(==)(r::RootSpaceElem, r2::RootSpaceElem)
@@ -682,6 +713,14 @@ function DualRootSpaceElem(root_system::RootSystem, vec::Vector{<:RationalUnion}
   return DualRootSpaceElem(root_system, matrix(QQ, 1, length(vec), vec))
 end
 
+function zero(::Type{DualRootSpaceElem}, R::RootSystem)
+  return DualRootSpaceElem(R, zero_matrix(QQ, 1, rank(R)))
+end
+
+function zero(r::DualRootSpaceElem)
+  return zero(DualRootSpaceElem, root_system(r))
+end
+
 function Base.:*(q::RationalUnion, r::DualRootSpaceElem)
   return DualRootSpaceElem(root_system(r), q * r.vec)
 end
@@ -700,6 +739,29 @@ end
 
 function Base.:-(r::DualRootSpaceElem)
   return DualRootSpaceElem(root_system(r), -r.vec)
+end
+
+function zero!(r::DualRootSpaceElem)
+  r.vec = zero!(r.vec)
+  return r
+end
+
+function add!(rr::DualRootSpaceElem, r1::DualRootSpaceElem, r2::DualRootSpaceElem)
+  @req root_system(rr) === root_system(r1) === root_system(r2) "parent root system mismatch"
+  rr.vec = add!(rr.vec, r1.vec, r2.vec)
+  return rr
+end
+
+function neg!(rr::DualRootSpaceElem, r::DualRootSpaceElem)
+  @req root_system(rr) === root_system(r) "parent root system mismatch"
+  rr.vec = neg!(rr.vec, r.vec)
+  return rr
+end
+
+function sub!(rr::DualRootSpaceElem, r1::DualRootSpaceElem, r2::DualRootSpaceElem)
+  @req root_system(rr) === root_system(r1) === root_system(r2) "parent root system mismatch"
+  rr.vec = sub!(rr.vec, r1.vec, r2.vec)
+  return rr
 end
 
 function Base.:(==)(r::DualRootSpaceElem, r2::DualRootSpaceElem)
@@ -839,18 +901,26 @@ function WeightLatticeElem(r::RootSpaceElem)
   return WeightLatticeElem(root_system(r), r)
 end
 
+function zero(::Type{WeightLatticeElem}, R::RootSystem)
+  return WeightLatticeElem(R, zero_matrix(ZZ, rank(R), 1))
+end
+
+function zero(r::WeightLatticeElem)
+  return zero(WeightLatticeElem, root_system(r))
+end
+
 function Base.:*(n::IntegerUnion, w::WeightLatticeElem)
   return WeightLatticeElem(root_system(w), n * w.vec)
 end
 
 function Base.:+(w::WeightLatticeElem, w2::WeightLatticeElem)
-  @req root_system(w) === root_system(w2) "parent weight lattics mismatch"
+  @req root_system(w) === root_system(w2) "parent root system mismatch"
 
   return WeightLatticeElem(root_system(w), w.vec + w2.vec)
 end
 
 function Base.:-(w::WeightLatticeElem, w2::WeightLatticeElem)
-  @req root_system(w) === root_system(w2) "parent weight lattics mismatch"
+  @req root_system(w) === root_system(w2) "parent root system mismatch"
 
   return WeightLatticeElem(root_system(w), w.vec - w2.vec)
 end
@@ -859,24 +929,28 @@ function Base.:-(w::WeightLatticeElem)
   return WeightLatticeElem(root_system(w), -w.vec)
 end
 
-function add!(wr::WeightLatticeElem, w1::WeightLatticeElem, w2::WeightLatticeElem)
-  add!(wr.vec, w1.vec, w2.vec)
-  return wr
-end
-
-add!(w1::WeightLatticeElem, w2::WeightLatticeElem) = add!(w1, w1, w2)
-
-function neg!(w::WeightLatticeElem)
-  neg!(w.vec)
+function zero!(w::WeightLatticeElem)
+  w.vec = zero!(w.vec)
   return w
 end
 
-function sub!(wr::WeightLatticeElem, w1::WeightLatticeElem, w2::WeightLatticeElem)
-  sub!(wr.vec, w1.vec, w2.vec)
+function add!(wr::WeightLatticeElem, w1::WeightLatticeElem, w2::WeightLatticeElem)
+  @req root_system(wr) === root_system(w1) === root_system(w2) "parent root system mismatch"
+  wr.vec = add!(wr.vec, w1.vec, w2.vec)
   return wr
 end
 
-sub!(w1::WeightLatticeElem, w2::WeightLatticeElem) = sub!(w1, w1, w2)
+function neg!(wr::WeightLatticeElem, w::WeightLatticeElem)
+  @req root_system(wr) === root_system(w) "parent root system mismatch"
+  wr.vec = neg!(wr.vec, w.vec)
+  return wr
+end
+
+function sub!(wr::WeightLatticeElem, w1::WeightLatticeElem, w2::WeightLatticeElem)
+  @req root_system(wr) === root_system(w1) === root_system(w2) "parent root system mismatch"
+  wr.vec = sub!(wr.vec, w1.vec, w2.vec)
+  return wr
+end
 
 function Base.:(==)(w::WeightLatticeElem, w2::WeightLatticeElem)
   return w.root_system === w2.root_system && w.vec == w2.vec
@@ -983,7 +1057,7 @@ function conjugate_dominant_weight_with_elem!(w::WeightLatticeElem)
 end
 
 function dot(w1::WeightLatticeElem, w2::WeightLatticeElem)
-  @req root_system(w1) === root_system(w2) "parent weight lattices mismatch"
+  @req root_system(w1) === root_system(w2) "parent root system mismatch"
   R = root_system(w1)
 
   return dot(

--- a/experimental/LieAlgebras/src/RootSystem.jl
+++ b/experimental/LieAlgebras/src/RootSystem.jl
@@ -1300,8 +1300,8 @@ end
 function positive_roots_and_reflections(cartan_matrix::ZZMatrix)
   rank, _ = size(cartan_matrix)
 
-  roots = [[l == s ? 1 : 0 for l in 1:rank] for s in 1:rank]
-  coroots = [[l == s ? 1 : 0 for l in 1:rank] for s in 1:rank]
+  roots = [[l == s ? one(ZZ) : zero(ZZ) for l in 1:rank] for s in 1:rank]
+  coroots = [[l == s ? one(ZZ) : zero(ZZ) for l in 1:rank] for s in 1:rank]
   rootidx = Dict(roots[s] => s for s in 1:rank)
   refl = Dict((s, s) => 0 for s in 1:rank)
 
@@ -1312,12 +1312,11 @@ function positive_roots_and_reflections(cartan_matrix::ZZMatrix)
         continue
       end
 
-      pairing = let i = i
-        sum(roots[i][l] * cartan_matrix[s, l] for l in 1:rank; init=zero(ZZ))
-      end
-      copairing = let i = i
-        sum(coroots[i][l] * cartan_matrix[l, s] for l in 1:rank; init=zero(ZZ))
-      end
+      # pairing = dot(roots[i], view(cartan_matrix, s, :)) # currently the below is faster
+      pairing = only(view(cartan_matrix, s:s, :) * roots[i])
+      # copairing = dot(coroots[i], view(cartan_matrix, :, s)) # currently the below is faster
+      copairing = only(coroots[i] * view(cartan_matrix, :, s:s))
+
       if pairing * copairing >= 4
         refl[s, i] = 0
         continue

--- a/experimental/LieAlgebras/src/RootSystem.jl
+++ b/experimental/LieAlgebras/src/RootSystem.jl
@@ -616,7 +616,10 @@ end
 function dot(r1::RootSpaceElem, r2::RootSpaceElem)
   @req root_system(r1) === root_system(r2) "parent root system mismatch"
 
-  return dot(coefficients(r1) * _bilinear_form_QQ(root_system(r1)), coefficients(r2))
+  # return dot(coefficients(r1) * _bilinear_form_QQ(root_system(r1)), coefficients(r2)) # currently the below is faster
+  return only(
+    coefficients(r1) * _bilinear_form_QQ(root_system(r1)) * transpose(coefficients(r2))
+  )
 end
 
 @doc raw"""
@@ -1114,6 +1117,18 @@ end
 
 function dot(w::WeightLatticeElem, r::RootSpaceElem)
   return dot(r, w)
+end
+
+# computes the maximum `p` such that `beta - p*alpha` is still a root
+# beta is assumed to be a root
+function _root_string_length_down(alpha::RootSpaceElem, beta::RootSpaceElem)
+  p = 0
+  beta_sub_p_alpha = beta - alpha
+  while is_root(beta_sub_p_alpha)
+    p += 1
+    beta_sub_p_alpha = sub!(beta_sub_p_alpha, alpha)
+  end
+  return p
 end
 
 @doc raw"""

--- a/experimental/LieAlgebras/src/RootSystem.jl
+++ b/experimental/LieAlgebras/src/RootSystem.jl
@@ -115,6 +115,11 @@ Returns the `i`-th coroot of `R`, i.e. the `i`-th root of the dual root system o
 This is a more efficient version for `coroots(R)[i]`.
 
 Also see: `coroots`.
+
+!!! note
+    This function does not return a copy of the asked for object,
+    but the internal field of the root system.
+    Mutating the returned object will lead to undefined behavior.
 """
 function coroot(R::RootSystem, i::Int)
   if i <= n_positive_roots(R)
@@ -131,6 +136,11 @@ Returns the coroots of `R`, starting with the coroots of positive roots and then
 in the order of `positive_coroots` and `negative_coroots`.
 
 Also see: `coroot`.
+
+!!! note
+    This function does not return a copy of the asked for object,
+    but the internal field of the root system.
+    Mutating the returned object will lead to undefined behavior.
 """
 function coroots(R::RootSystem)
   return [[r for r in positive_coroots(R)]; [-r for r in positive_coroots(R)]]
@@ -172,6 +182,11 @@ Returns the `i`-th negative root of `R`.
 This is a more efficient version for `negative_roots(R)[i]`.
 
 Also see: `negative_roots`.
+
+!!! note
+    This function does not return a copy of the asked for object,
+    but the internal field of the root system.
+    Mutating the returned object will lead to undefined behavior.
 """
 function negative_root(R::RootSystem, i::Int)
   return -(R.positive_roots::Vector{RootSpaceElem})[i]
@@ -183,6 +198,11 @@ end
 Returns the negative roots of `R`. The $i$-th element of the returned vector is the negative root corresponding to the $i$-th positive root.
 
 Also see: `negative_root`.
+
+!!! note
+    This function does not return a copy of the asked for object,
+    but the internal field of the root system.
+    Mutating the returned object will lead to undefined behavior.
 """
 function negative_roots(R::RootSystem)
   return [-r for r in positive_roots(R)]
@@ -195,6 +215,11 @@ Returns the coroot corresponding to the `i`-th negative root of `R`
 This is a more efficient version for `negative_coroots(R)[i]`.
 
 Also see: `negative_coroots`.
+
+!!! note
+    This function does not return a copy of the asked for object,
+    but the internal field of the root system.
+    Mutating the returned object will lead to undefined behavior.
 """
 function negative_coroot(R::RootSystem, i::Int)
   return -(R.positive_coroots::Vector{DualRootSpaceElem})[i]
@@ -206,6 +231,11 @@ end
 Returns the coroots corresponding to the negative roots of `R`
 
 Also see: `negative_coroots`.
+
+!!! note
+    This function does not return a copy of the asked for object,
+    but the internal field of the root system.
+    Mutating the returned object will lead to undefined behavior.
 """
 function negative_coroots(R::RootSystem)
   return [-r for r in positive_coroots(R)]
@@ -251,6 +281,11 @@ Returns the `i`-th positive root of `R`.
 This is a more efficient version for `positive_roots(R)[i]`.
 
 Also see: `positive_roots`.
+
+!!! note
+    This function does not return a copy of the asked for object,
+    but the internal field of the root system.
+    Mutating the returned object will lead to undefined behavior.
 """
 function positive_root(R::RootSystem, i::Int)
   return (R.positive_roots::Vector{RootSpaceElem})[i]
@@ -263,6 +298,11 @@ Returns the positive roots of `R`, starting with the simple roots in the order o
 and then increasing in height.
 
 Also see: `positive_root`, `number_of_positive_roots`.
+
+!!! note
+    This function does not return a copy of the asked for object,
+    but the internal field of the root system.
+    Mutating the returned object will lead to undefined behavior.
 """
 function positive_roots(R::RootSystem)
   return R.positive_roots::Vector{RootSpaceElem}
@@ -275,6 +315,11 @@ Returns the coroot corresponding to the `i`-th positive root of `R`
 This is a more efficient version for `positive_coroots(R)[i]`.
 
 Also see: `positive_coroots`.
+
+!!! note
+    This function does not return a copy of the asked for object,
+    but the internal field of the root system.
+    Mutating the returned object will lead to undefined behavior.
 """
 function positive_coroot(R::RootSystem, i::Int)
   return (R.positive_coroots::Vector{DualRootSpaceElem})[i]
@@ -286,6 +331,11 @@ end
 Returns the coroots corresponding to the positive roots of `R`
 
 Also see: `positive_coroots`.
+
+!!! note
+    This function does not return a copy of the asked for object,
+    but the internal field of the root system.
+    Mutating the returned object will lead to undefined behavior.
 """
 function positive_coroots(R::RootSystem)
   return R.positive_coroots::Vector{DualRootSpaceElem}
@@ -336,6 +386,11 @@ Returns the `i`-th root of `R`.
 This is a more efficient version for `roots(R)[i]`.
 
 Also see: `roots`.
+
+!!! note
+    This function does not return a copy of the asked for object,
+    but the internal field of the root system.
+    Mutating the returned object will lead to undefined behavior.
 """
 function root(R::RootSystem, i::Int)
   if i <= n_positive_roots(R)
@@ -352,6 +407,11 @@ Returns the roots of `R`, starting with the positive roots and then the negative
 in the order of `positive_roots` and `negative_roots`.
 
 Also see: `root`.
+
+!!! note
+    This function does not return a copy of the asked for object,
+    but the internal field of the root system.
+    Mutating the returned object will lead to undefined behavior.
 """
 function roots(R::RootSystem)
   return [[r for r in positive_roots(R)]; [-r for r in positive_roots(R)]]
@@ -364,6 +424,11 @@ Returns the `i`-th simple root of `R`.
 This is a more efficient version for `simple_roots(R)[i]`.
 
 Also see: `simple_roots`.
+
+!!! note
+    This function does not return a copy of the asked for object,
+    but the internal field of the root system.
+    Mutating the returned object will lead to undefined behavior.
 """
 function simple_root(R::RootSystem, i::Int)
   @req 1 <= i <= rank(R) "Invalid index"
@@ -376,6 +441,11 @@ end
 Returns the simple roots of `R`.
 
 Also see: `simple_root`.
+
+!!! note
+    This function does not return a copy of the asked for object,
+    but the internal field of the root system.
+    Mutating the returned object will lead to undefined behavior.
 """
 function simple_roots(R::RootSystem)
   return positive_roots(R)[1:rank(R)]
@@ -388,6 +458,11 @@ Returns the coroot corresponding to the `i`-th simple root of `R`
 This is a more efficient version for `simple_coroots(R)[i]`.
 
 Also see: `simple_coroots`.
+
+!!! note
+    This function does not return a copy of the asked for object,
+    but the internal field of the root system.
+    Mutating the returned object will lead to undefined behavior.
 """
 function simple_coroot(R::RootSystem, i::Int)
   @req 1 <= i <= rank(R) "Invalid index"
@@ -400,6 +475,11 @@ end
 Returns the coroots corresponding to the simple roots of `R`
 
 Also see: `simple_coroots`.
+
+!!! note
+    This function does not return a copy of the asked for object,
+    but the internal field of the root system.
+    Mutating the returned object will lead to undefined behavior.
 """
 function simple_coroots(R::RootSystem)
   return positive_coroots(R)[1:rank(R)]

--- a/experimental/LieAlgebras/src/Types.jl
+++ b/experimental/LieAlgebras/src/Types.jl
@@ -180,11 +180,19 @@ abstract type LieAlgebraElem{C<:FieldElem} <: AbstractAlgebra.SetElem end
       ) "Not anti-symmetric."
       @req all(
         iszero,
-        sum(
-          struct_consts[i, j][k] * struct_consts[k, l] +
-          struct_consts[j, l][k] * struct_consts[k, i] +
-          struct_consts[l, i][k] * struct_consts[k, j] for k in 1:dimL; init=sparse_row(R)
-        ) for i in 1:dimL, j in 1:dimL, l in 1:dimL
+        begin
+          row = sparse_row(R)
+          for (k, k_val) in struct_consts[i, j]
+            Hecke.add_scaled_row!(struct_consts[k, l], row, k_val)
+          end
+          for (k, k_val) in struct_consts[j, l]
+            Hecke.add_scaled_row!(struct_consts[k, i], row, k_val)
+          end
+          for (k, k_val) in struct_consts[l, i]
+            Hecke.add_scaled_row!(struct_consts[k, j], row, k_val)
+          end
+          row
+        end for i in 1:dimL, j in 1:dimL, l in 1:dimL
       ) "Jacobi identity does not hold."
     end
     return new{C}(R, dimL, struct_consts, s)

--- a/experimental/LieAlgebras/src/Types.jl
+++ b/experimental/LieAlgebras/src/Types.jl
@@ -227,6 +227,7 @@ end
   ) where {C<:FieldElem}
     @req all(b -> size(b) == (n, n), basis) "Invalid basis element dimensions."
     @req length(s) == length(basis) "Invalid number of basis element names."
+    @req eltype(basis) == dense_matrix_type(R) "Invalid basis element type."
     L = new{C}(R, n, length(basis), basis, s)
     if check
       @req all(b -> all(e -> parent(e) === R, b), basis) "Invalid matrices."

--- a/experimental/LieAlgebras/src/Util.jl
+++ b/experimental/LieAlgebras/src/Util.jl
@@ -14,16 +14,17 @@ function coefficient_vector(M::MatElem{T}, basis::Vector{<:MatElem{T}}) where {T
   (nr, nc) = size(M)
   all(b -> size(b) == (nr, nc), basis) ||
     throw(DimensionMismatch("The matrices in B must have the same size as M."))
-  lgs = similar(M, nr * nc, length(basis))
+  @req all(b -> base_ring(b) == base_ring(M), basis) "Incompatible base rings"
+  lgs = zero(M, length(basis), nr * nc)
   for (k, b) in enumerate(basis)
-    for i in 1:nr, j in 1:nc
-      lgs[(i - 1) * nc + j, k] = b[i, j]
+    for i in 1:nr
+      lgs[k, (i - 1) * nc .+ (1:nc)] = view(b, i:i, :)
     end
   end
-  rhs = similar(M, nr * nc, 1)
-  for i in 1:nr, j in 1:nc
-    rhs[(i - 1) * nc + j, 1] = M[i, j]
+  rhs = similar(M, 1, nr * nc)
+  for i in 1:nr
+    rhs[1, (i - 1) * nc .+ (1:nc)] = view(M, i:i, :)
   end
-  sol = solve(lgs, rhs; side=:right)
-  return transpose(sol)
+  sol = solve(lgs, rhs; side=:left)
+  return sol
 end

--- a/experimental/LieAlgebras/test/LinearLieAlgebra-test.jl
+++ b/experimental/LieAlgebras/test/LinearLieAlgebra-test.jl
@@ -17,7 +17,7 @@
 
   @testset "conformance tests" begin
     @testset "0-dim Lie algebra /QQ" begin
-      L = lie_algebra(QQ, 0, MatElem{QQFieldElem}[], Symbol[])
+      L = lie_algebra(QQ, 0, QQMatrix[], Symbol[])
       lie_algebra_conformance_test(
         L, LinearLieAlgebra{QQFieldElem}, LinearLieAlgebraElem{QQFieldElem}
       )

--- a/experimental/LieAlgebras/test/RootSystem-test.jl
+++ b/experimental/LieAlgebras/test/RootSystem-test.jl
@@ -132,6 +132,79 @@
         )
       end
 
+      @testset "Mutating arithmetics for $T" for T in (
+        RootSpaceElem, DualRootSpaceElem, WeightLatticeElem
+      )
+        rk = rank(R)
+
+        x1 = T(R, rand(-10:10, rk))
+        x2 = T(R, rand(-10:10, rk))
+        x3 = T(R, rand(-10:10, rk))
+        x1c = deepcopy(x1)
+        x2c = deepcopy(x2)
+        x3c = deepcopy(x3)
+
+        for (f, f!) in ((zero, zero!),)
+          x1 = f!(x1)
+          @test x1 == f(x1c)
+          x1 = deepcopy(x1c)
+        end
+
+        for (f, f!) in ((-, neg!),)
+          x1 = f!(x1, x2)
+          @test x1 == f(x2c)
+          @test x2 == x2c
+          x1 = deepcopy(x1c)
+          x2 = deepcopy(x2c)
+
+          x1 = f!(x1)
+          @test x1 == f(x1c)
+          x1 = deepcopy(x1c)
+        end
+
+        for (f, f!) in ((+, add!), (-, sub!))
+          x1 = f!(x1, x2, x3)
+          @test x1 == f(x2c, x3c)
+          @test x2 == x2c
+          @test x3 == x3c
+          x1 = deepcopy(x1c)
+          x2 = deepcopy(x2c)
+          x3 = deepcopy(x3c)
+
+          x1 = f!(x1, x1, x2)
+          @test x1 == f(x1c, x2c)
+          @test x2 == x2c
+          x1 = deepcopy(x1c)
+          x2 = deepcopy(x2c)
+
+          x1 = f!(x1, x2, x1)
+          @test x1 == f(x2c, x1c)
+          @test x2 == x2c
+          x1 = deepcopy(x1c)
+          x2 = deepcopy(x2c)
+
+          x1 = f!(x1, x2, x2)
+          @test x1 == f(x2c, x2c)
+          @test x2 == x2c
+          x1 = deepcopy(x1c)
+          x2 = deepcopy(x2c)
+
+          x1 = f!(x1, x1, x1)
+          @test x1 == f(x1c, x1c)
+          x1 = deepcopy(x1c)
+
+          x1 = f!(x1, x2)
+          @test x1 == f(x1c, x2c)
+          @test x2 == x2c
+          x1 = deepcopy(x1c)
+          x2 = deepcopy(x2c)
+
+          x1 = f!(x1, x1)
+          @test x1 == f(x1c, x1c)
+          x1 = deepcopy(x1c)
+        end
+      end
+
       @testset "Serialization" begin
         mktempdir() do path
           test_save_load_roundtrip(path, R) do loaded


### PR DESCRIPTION
some representative workload comparisons between 4a5b96d (two days old master) and this PR branch

```julia
  ___   ____   ____    _    ____
 / _ \ / ___| / ___|  / \  |  _ \   |  Combining ANTIC, GAP, Polymake, Singular
| | | |\___ \| |     / _ \ | |_) |  |  Type "?Oscar" for more information
| |_| | ___) | |___ / ___ \|  _ <   |  Manual: https://docs.oscar-system.org
 \___/ |____/ \____/_/   \_\_| \_\  |  1.2.0-DEV #master 4a5b96d 2024-09-28
 \___/ |____/ \____/_/   \_\_| \_\  |  1.2.0-DEV #lg/Lie-allocs ed5c5dd 2024-09-30
 
julia> using BenchmarkTools

julia> @btime basis($(special_linear_lie_algebra(QQ, 7)));
  79.304 μs (2497 allocations: 134.00 KiB)	# master
  7.550 μs (193 allocations: 42.50 KiB)		# this PR

julia> @btime root_system([(:D, 12), (:E, 6)]);
  7.043 ms (314018 allocations: 5.89 MiB)	# master
  3.032 ms (47004 allocations: 2.53 MiB)	# this PR

julia> @btime lie_algebra(QQ, $(Oscar.LieAlgebras._struct_consts(QQ, root_system(:F, 4), fill(true, 20))), check=true); # this is heavily used in testing
  6.746 s (88755679 allocations: 3.65 GiB)	# master
  37.229 ms (1103389 allocations: 37.98 MiB)	# this PR

julia> @btime lie_algebra(QQ, $(root_system(:B, 10)));
  60.045 ms (1213748 allocations: 66.03 MiB)	# master
  47.319 ms (623167 allocations: 40.60 MiB)	# this PR

julia> @btime Oscar.LieAlgebras._cartan_subalgebra($(special_linear_lie_algebra(QQ, 7))); # internal function to circumvent caching
  3.072 s (9245963 allocations: 1.41 GiB)	# master
  386.819 ms (1110135 allocations: 217.34 MiB)  # this PR

julia> @btime Oscar.LieAlgebras._root_system_and_chevalley_basis($(special_linear_lie_algebra(QQ, 7))); # internal function to circumvent caching
  3.137 s (11603843 allocations: 1.73 GiB)	# master
  884.441 ms (2280864 allocations: 451.74 MiB) 	# this PR
```

the release of https://github.com/Nemocas/Nemo.jl/pull/1872 will reduce allocations in some cases even further