### PR TITLE
Implement more shortcuts and remove code duplication.

### DIFF
--- a/src/Modules/UngradedModules/ModuleGens.jl
+++ b/src/Modules/UngradedModules/ModuleGens.jl
@@ -263,47 +263,44 @@ Convert a Singular vector to a free module element.
 """
 function (F::FreeMod{<:MPolyRingElem})(s::Singular.svector)
   Rx = base_ring(F)
-  R = coefficient_ring(Rx)
-  ctx = MPolyBuildCtx(Rx)
-  
-  # shortcut in order not to allocate the dictionary
-  if isone(length(s))
-    (i, e, c) = first(s)
-    push_term!(ctx, R(c), e)
-    return FreeModElem(sparse_row(Rx, [(i, finish(ctx))]), F)
-  end
-
-  cache = IdDict{Int, typeof(ctx)}()
-  for (i, e, c) in s
-    ctx = get!(cache, i) do
-      MPolyBuildCtx(Rx)
-    end
-    push_term!(ctx, R(c), e)
-  end
-  return FreeModElem(sparse_row(Rx, [(i, finish(ctx)) for (i, ctx) in cache]), F)
+  row = _build_sparse_row(Rx, s)
+  return FreeModElem(row, F)
 end
 
 function (F::FreeMod{<:MPolyQuoRingElem})(s::Singular.svector)
+  is_zero(s) && return zero(F) # `map_entries` throws for empty vectors
   Qx = base_ring(F)::MPolyQuoRing
   Rx = base_ring(Qx)::MPolyRing
+  row = _build_sparse_row(Rx, s)
+  return FreeModElem(map_entries(Qx, row), F)
+end
+
+function _build_sparse_row(Rx::Ring, s::Singular.svector)
   R = coefficient_ring(Rx)
   ctx = MPolyBuildCtx(Rx)
 
-  # shortcut in order not to allocate the dictionary
+  # shortcuts in order not to allocate the dictionary
+  is_zero(length(s)) && return sparse_row(Rx)
   if isone(length(s))
     (i, e, c) = first(s)
     push_term!(ctx, R(c), e)
-    return FreeModElem(sparse_row(Qx, [(i, Qx(finish(ctx)))]), F)
+    return sparse_row(Rx, [(i, finish(ctx))])
   end
 
   cache = IdDict{Int, typeof(ctx)}()
+  last_index = 0
   for (i, e, c) in s
+    if i == last_index
+      push_term!(ctx, R(c), e)
+      continue
+    end
+    last_index = i
     ctx = get!(cache, i) do
       MPolyBuildCtx(Rx)
     end
     push_term!(ctx, R(c), e)
   end
-  return FreeModElem(sparse_row(Qx, [(i, Qx(finish(ctx))) for (i, ctx) in cache]), F)
+  return sparse_row(Rx, [(i, finish(ctx)) for (i, ctx) in cache])
 end
 
 # After creating the required infrastruture in Singular,


### PR DESCRIPTION
I wanted to push some more things for the conversion which I had in mind. 

Running `@time Oscar.test_module("test/Modules/", new=false)`
Before:
```
41.459414 seconds (185.33 M allocations: 9.765 GiB, 20.17% gc time, 22.57% compilation time)
```
after:
```
 36.911680 seconds (184.97 M allocations: 9.754 GiB, 20.81% gc time, 21.16% compilation time)
```
Not too significant, but at least we get rid of the code duplication. ~If there was some in-place version of `map_entries`, for `SRow`s, then we could probably get some more gain.~ 