### PR TITLE
Change `eltype` methods for objects to types

### DIFF
--- a/src/AlgebraicGeometry/Schemes/Covering/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/Covering/Objects/Methods.jl
@@ -190,7 +190,7 @@ function Base.iterate(C::Covering, s::Int=1)
   return U[s], s+1
 end
 
-Base.eltype(C::Covering) = AbsAffineScheme
+Base.eltype(::Type{<:Covering}) = AbsAffineScheme
 
 ########################################################################
 # Building a Covering                                                  #

--- a/src/Combinatorics/EnumerativeCombinatorics/compositions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/compositions.jl
@@ -149,7 +149,7 @@ end
 base(C::CompositionsFixedNumParts) = C.n
 parts(C::CompositionsFixedNumParts) = C.k
 
-Base.eltype(C::CompositionsFixedNumParts{T}) where T = Composition{T}
+Base.eltype(::Type{CompositionsFixedNumParts{T}}) where T = Composition{T}
 
 function Base.show(io::IO, C::CompositionsFixedNumParts)
   print(pretty(io), "Iterator over the compositions of $(base(C)) into ", ItemQuantity(parts(C), "part"))
@@ -210,7 +210,7 @@ end
 
 base(C::Compositions) = C.n
 
-Base.eltype(C::Compositions{T}) where T = Composition{T}
+Base.eltype(::Type{Compositions{T}}) where T = Composition{T}
 
 function Base.show(io::IO, C::Compositions)
   print(pretty(io), "Iterator over the compositions of $(base(C))")
@@ -286,7 +286,7 @@ end
 
 base(C::AscendingCompositions) = C.n
 
-Base.eltype(C::AscendingCompositions{T}) where T = Composition{T}
+Base.eltype(::Type{AscendingCompositions{T}}) where T = Composition{T}
 
 function Base.show(io::IO, C::AscendingCompositions)
   print(pretty(io), "Iterator over the ascending compositions of $(base(C))")

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -125,7 +125,7 @@ end
 
 base(P::Partitions) = P.n
 
-Base.eltype(::Partitions{T}) where T = Partition{T}
+Base.eltype(::Type{Partitions{T}}) where T = Partition{T}
 
 function Base.show(io::IO, ::MIME"text/plain", P::Partitions)
   print(pretty(io), "Iterator over the partitions of $(base(P))")
@@ -137,7 +137,7 @@ Base.length(P::Partitions) = BigInt(number_of_partitions(P.n))
 
 base(P::PartitionsFixedNumParts) = P.n
 
-Base.eltype(::PartitionsFixedNumParts{T}) where T = Partition{T}
+Base.eltype(::Type{PartitionsFixedNumParts{T}}) where T = Partition{T}
 
 function Base.show(io::IO, ::MIME"text/plain", P::PartitionsFixedNumParts)
   print(pretty(io), "Iterator over the partitions of $(base(P)) into ",
@@ -524,7 +524,7 @@ parts_max(P::PartitionsFixedValues) = P.kmax
 values(P::PartitionsFixedValues) = P.v
 multiplicities(P::PartitionsFixedValues) = P.mu
 
-Base.eltype(::PartitionsFixedValues{T}) where T = Partition{T}
+Base.eltype(::Type{PartitionsFixedValues{T}}) where T = Partition{T}
 Base.IteratorSize(::Type{PartitionsFixedValues{T}}) where T = Base.SizeUnknown()
 
 function Base.show(io::IO, ::MIME"text/plain", P::PartitionsFixedValues)
@@ -562,7 +562,7 @@ parts(P::PartitionsFixedNumPartsAndValues) = P.k
 values(P::PartitionsFixedNumPartsAndValues) = P.v
 multiplicities(P::PartitionsFixedNumPartsAndValues) = P.mu
 
-Base.eltype(::PartitionsFixedNumPartsAndValues{T}) where T = Partition{T}
+Base.eltype(::Type{PartitionsFixedNumPartsAndValues{T}}) where T = Partition{T}
 
 function Base.show(io::IO, ::MIME"text/plain", P::PartitionsFixedNumPartsAndValues)
   print(pretty(io), "Iterator over the partitions of $(base(P)) into ",

--- a/src/Combinatorics/EnumerativeCombinatorics/tableaux.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/tableaux.jl
@@ -356,7 +356,7 @@ end
 shape(S::SemiStandardTableaux) = S.shape
 maximal_value(S::SemiStandardTableaux) = S.max_val
 
-Base.eltype(S::SemiStandardTableaux{T}) where T = YoungTableau{T}
+Base.eltype(::Type{SemiStandardTableaux{T}}) where T = YoungTableau{T}
 
 function Base.show(io::IO, S::SemiStandardTableaux)
   print(io, "Iterator over semistandard Young tableaux of shape $(shape(S))")
@@ -454,7 +454,7 @@ end
 box_num(S::SemiStandardTableauxFixedBoxNum) = S.box_num
 maximal_value(S::SemiStandardTableauxFixedBoxNum) = S.max_val
 
-Base.eltype(S::SemiStandardTableauxFixedBoxNum{T}) where T = YoungTableau{T}
+Base.eltype(::Type{SemiStandardTableauxFixedBoxNum{T}}) where T = YoungTableau{T}
 
 function Base.show(io::IO, S::SemiStandardTableauxFixedBoxNum)
   print(pretty(io), "Iterator over semistandard Young tableaux with ",
@@ -503,7 +503,7 @@ end
 shape(S::SemiStandardTableauxFixedShapeAndWeight) = S.shape
 weight(S::SemiStandardTableauxFixedShapeAndWeight) = S.weight
 
-Base.eltype(S::SemiStandardTableauxFixedShapeAndWeight{T}) where T = YoungTableau{T}
+Base.eltype(::Type{SemiStandardTableauxFixedShapeAndWeight{T}}) where T = YoungTableau{T}
 
 function Base.show(io::IO, S::SemiStandardTableauxFixedShapeAndWeight)
   print(pretty(io), "Iterator over semistandard Young tableaux of shape ",
@@ -767,7 +767,7 @@ end
 
 shape(S::StandardTableaux) = S.shape
 
-Base.eltype(S::StandardTableaux{T}) where T = YoungTableau{T}
+Base.eltype(::Type{StandardTableaux{T}}) where T = YoungTableau{T}
 
 function Base.show(io::IO, S::StandardTableaux)
   print(io, "Iterator over standard Young tableaux of shape $(shape(S))")
@@ -874,7 +874,7 @@ end
 
 box_num(S::StandardTableauxFixedBoxNum) = S.box_num
 
-Base.eltype(S::StandardTableauxFixedBoxNum{T}) where T = YoungTableau{T}
+Base.eltype(::Type{StandardTableauxFixedBoxNum{T}}) where T = YoungTableau{T}
 
 function Base.show(io::IO, S::StandardTableauxFixedBoxNum)
   print(pretty(io), "Iterator over standard Young tableaux with ",

--- a/src/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
@@ -102,7 +102,7 @@ end
 base(W::WeakCompositions) = W.n
 parts(W::WeakCompositions) = W.k
 
-Base.eltype(W::WeakCompositions{T}) where T = WeakComposition{T}
+Base.eltype(::Type{WeakCompositions{T}}) where T = WeakComposition{T}
 
 @doc raw"""
     number_of_weak_compositions(n::IntegerUnion, k::IntegerUnion)

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -583,7 +583,7 @@ function Base.iterate(Omega::GSetBySubgroupTransversal, state = 1)
   end
 end
 
-Base.eltype(Omega::GSetBySubgroupTransversal{T, S, E}) where {S, T, E} = GroupCoset{T, E}
+Base.eltype(::Type{GSetBySubgroupTransversal{T, S, E}}) where {S, T, E} = GroupCoset{T, E}
 
 function Base.getindex(Omega::GSetBySubgroupTransversal, i::Int)
   if Omega.side == :right
@@ -798,7 +798,7 @@ function Base.iterate(Omega::GSetByElements, state = 1)
   return (elms[state], state+1)
 end
 
-Base.eltype(Omega::GSetByElements) = eltype(Omega.seeds)
+Base.eltype(::Type{GSetByElements{T,S}}) where {T,S} = S
 
 Base.getindex(Omega::GSetByElements, i::Int) = elements(Omega)[i]
 

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -57,7 +57,7 @@ function AllMonomials(R::MPolyDecRing, d::Int, vars::Vector{Int})
   return AllMonomials{typeof(R)}(R, d, vars)
 end
 
-Base.eltype(AM::AllMonomials) = elem_type(AM.R)
+Base.eltype(::Type{AllMonomials{PolyRingT}}) where {PolyRingT} = elem_type(PolyRingT)
 
 Base.length(AM::AllMonomials) = length(AM.weak_comp_iter)
 
@@ -390,7 +390,9 @@ function iterate_basis_linear_algebra(IR::FinGroupInvarRing, d::Int)
   )
 end
 
-Base.eltype(BI::FinGroupInvarRingBasisIterator) = elem_type(polynomial_ring(BI.R))
+Base.eltype(
+  ::Type{<:FinGroupInvarRingBasisIterator{FinGroupInvarRingT}}
+) where {FinGroupInvarRingT} = dense_poly_type(FinGroupInvarRingT)
 
 Base.length(BI::FinGroupInvarRingBasisIterator) = BI.dim
 
@@ -553,7 +555,7 @@ vector_space_iterator(
 ) where {FieldT,IteratorT} = VectorSpaceIteratorRand(K, basis_iterator, bound)
 
 Base.eltype(
-  VSI::VectorSpaceIterator{FieldT,IteratorT,ElemT}
+  ::Type{<:VectorSpaceIterator{FieldT,IteratorT,ElemT}}
 ) where {FieldT,IteratorT,ElemT} = ElemT
 
 Base.length(VSI::VectorSpaceIteratorFiniteField) =
@@ -708,7 +710,7 @@ end
 
 iterate_partitions(M::MSet) = MSetPartitions(M)
 
-Base.eltype(MSP::MSetPartitions{T}) where {T} = Vector{MSet{T}}
+Base.eltype(::Type{MSetPartitions{T}}) where {T} = Vector{MSet{T}}
 
 function Base.iterate(MSP::MSetPartitions)
   if isempty(MSP.M)

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -390,8 +390,7 @@ function iterate_basis_linear_algebra(IR::FinGroupInvarRing, d::Int)
   )
 end
 
-Base.eltype(BI::FinGroupInvarRingBasisIterator) = elem_type(polynomial_ring(BI.R))
-# TODO: change this to Base.eltype(::Type{<:FinGroupInvarRingBasisIterator{FinGroupInvarRingT}}) where {FinGroupInvarRingT} = ...
+Base.eltype(::Type{<:FinGroupInvarRingBasisIterator{FinGroupInvarRingT, ReynoldsT, IteratorT, PolyRingElemT, MatrixT}}) where {FinGroupInvarRingT, ReynoldsT, IteratorT, PolyRingElemT, MatrixT} = PolyRingElemT
 
 Base.length(BI::FinGroupInvarRingBasisIterator) = BI.dim
 

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -390,7 +390,13 @@ function iterate_basis_linear_algebra(IR::FinGroupInvarRing, d::Int)
   )
 end
 
-Base.eltype(::Type{<:FinGroupInvarRingBasisIterator{FinGroupInvarRingT, ReynoldsT, IteratorT, PolyRingElemT, MatrixT}}) where {FinGroupInvarRingT, ReynoldsT, IteratorT, PolyRingElemT, MatrixT} = PolyRingElemT
+Base.eltype(
+  ::Type{
+    <:FinGroupInvarRingBasisIterator{
+      FinGroupInvarRingT,ReynoldsT,IteratorT,PolyRingElemT,MatrixT
+    },
+  },
+) where {FinGroupInvarRingT,ReynoldsT,IteratorT,PolyRingElemT,MatrixT} = PolyRingElemT
 
 Base.length(BI::FinGroupInvarRingBasisIterator) = BI.dim
 

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -390,9 +390,8 @@ function iterate_basis_linear_algebra(IR::FinGroupInvarRing, d::Int)
   )
 end
 
-Base.eltype(
-  ::Type{<:FinGroupInvarRingBasisIterator{FinGroupInvarRingT}}
-) where {FinGroupInvarRingT} = dense_poly_type(FinGroupInvarRingT)
+Base.eltype(BI::FinGroupInvarRingBasisIterator) = elem_type(polynomial_ring(BI.R))
+# TODO: change this to Base.eltype(::Type{<:FinGroupInvarRingBasisIterator{FinGroupInvarRingT}}) where {FinGroupInvarRingT} = ...
 
 Base.length(BI::FinGroupInvarRingBasisIterator) = BI.dim
 

--- a/src/Modules/FreeModElem-orderings.jl
+++ b/src/Modules/FreeModElem-orderings.jl
@@ -121,7 +121,7 @@ function Base.iterate(a::GeneralPermutedIterator{:coefficients, <:FreeModElem{<:
   return coeff(a.elem[i], j), state
 end
 
-function Base.eltype(a::GeneralPermutedIterator{:coefficients, T}) where T <: FreeModElem{<:MPolyRingElem{C}} where C
+function Base.eltype(::Type{<:GeneralPermutedIterator{:coefficients, T}}) where T <: FreeModElem{<:MPolyRingElem{C}} where C
   return C
 end
 
@@ -142,7 +142,7 @@ function Base.iterate(a::GeneralPermutedIterator{:coefficients_and_exponents, <:
   return (coeff(a.elem[i], j), (exponent_vector(a.elem[i], j), i)), state
 end
 
-function Base.eltype(a::GeneralPermutedIterator{:coefficients_and_exponents, T}) where T <: FreeModElem{<:MPolyRingElem{C}} where C
+function Base.eltype(::Type{<:GeneralPermutedIterator{:coefficients_and_exponents, T}}) where T <: FreeModElem{<:MPolyRingElem{C}} where C
   return Tuple{C, Tuple{Vector{Int}, Int}}
 end
 
@@ -164,7 +164,7 @@ function Base.iterate(a::GeneralPermutedIterator{:exponents, <:FreeModElem{<:MPo
   return (exponent_vector(a.elem[i], j), i), state
 end
 
-function Base.eltype(a::GeneralPermutedIterator{:exponents, T}) where T <: FreeModElem{<:MPolyRingElem}
+function Base.eltype(::Type{<:GeneralPermutedIterator{:exponents, T}}) where T <: FreeModElem{<:MPolyRingElem}
   return Tuple{Vector{Int}, Int}
 end
 
@@ -184,7 +184,7 @@ function Base.iterate(a::GeneralPermutedIterator{:terms, <:FreeModElem{<:MPolyRi
   return FreeModElem(i, term(a.elem[i], j), parent(a.elem)), state
 end
 
-function Base.eltype(a::GeneralPermutedIterator{:terms, T}) where T <: FreeModElem{<:MPolyRingElem}
+function Base.eltype(::Type{<:GeneralPermutedIterator{:terms, T}}) where T <: FreeModElem{<:MPolyRingElem}
   return T
 end
 
@@ -204,7 +204,7 @@ function Base.iterate(a::GeneralPermutedIterator{:monomials, <:FreeModElem{<:MPo
   return FreeModElem(i, monomial(a.elem[i], j), parent(a.elem)), state
 end
 
-function Base.eltype(a::GeneralPermutedIterator{:monomials, T}) where T <: FreeModElem{<:MPolyRingElem}
+function Base.eltype(::Type{<:GeneralPermutedIterator{:monomials, T}}) where T <: FreeModElem{<:MPolyRingElem}
   return T
 end
 

--- a/src/Modules/Iterators.jl
+++ b/src/Modules/Iterators.jl
@@ -18,7 +18,7 @@ function all_monomials(F::FreeMod{T}, d::Int) where {T<:MPolyDecRingElem}
   return AllModuleMonomials(F, d)
 end
 
-Base.eltype(amm::AllModuleMonomials{T}) where {T} = elem_type(T)
+Base.eltype(::Type{AllModuleMonomials{T}}) where {T} = elem_type(T)
 
 function Base.length(amm::AllModuleMonomials)
   F = underlying_module(amm)
@@ -96,7 +96,7 @@ function all_exponents(F::FreeMod{T}, d::Int) where {T<:MPolyDecRingElem}
   return AllModuleExponents(F, d)
 end
 
-Base.eltype(amm::AllModuleExponents{T}) where {T} = Tuple{Vector{Int}, Int}
+Base.eltype(::Type{AllModuleExponents{T}}) where {T} = Tuple{Vector{Int}, Int}
 
 function Base.length(amm::AllModuleExponents)
   F = underlying_module(amm)

--- a/src/Modules/UngradedModules/SubquoModuleElem.jl
+++ b/src/Modules/UngradedModules/SubquoModuleElem.jl
@@ -1016,7 +1016,7 @@ function iterate(F::ModuleGens, i::Int = 1)
     return F[i], i+1
   end
 end
-eltype(::ModuleGens{T}) where {T} = FreeModElem{T}
+Base.eltype(::Type{ModuleGens{T}}) where {T} = FreeModElem{T}
 
 #??? A scalar product....
 function *(a::FreeModElem, b::Vector{FreeModElem})

--- a/src/NumberTheory/GaloisGrp/POSet.jl
+++ b/src/NumberTheory/GaloisGrp/POSet.jl
@@ -75,7 +75,7 @@ function Base.iterate(P::POSet, i::Int)
   return POSetElem(P, i+1), i+1
 end
 
-Base.eltype(P::POSet{T}) where T = POSetElem{T}
+Base.eltype(::Type{POSet{T}}) where T = POSetElem{T}
 
 function Base.isless(e::POSetElem{T}, f::POSetElem{T}) where T
   P = parent(e)

--- a/src/Rings/PBWAlgebra.jl
+++ b/src/Rings/PBWAlgebra.jl
@@ -155,7 +155,7 @@ function Base.length(x::OscarPair{<:PBWAlgRing, <:Singular.SPolyTerms})
    return length(x.second)
 end
 
-function Base.eltype(x::OscarPair{<:PBWAlgRing{T, S}, <:Singular.SPolyTerms}) where {T, S}
+function Base.eltype(::Type{<:OscarPair{<:PBWAlgRing{T, S}, <:Singular.SPolyTerms}}) where {T, S}
    return PBWAlgElem{T, S}
 end
 
@@ -179,7 +179,7 @@ function Base.length(x::OscarPair{<:PBWAlgRing, <:Singular.SPolyMonomials})
    return length(x.second)
 end
 
-function Base.eltype(x::OscarPair{<:PBWAlgRing{T, S}, <:Singular.SPolyMonomials}) where {T, S}
+function Base.eltype(::Type{<:OscarPair{<:PBWAlgRing{T, S}, <:Singular.SPolyMonomials}}) where {T, S}
    return PBWAlgElem{T, S}
 end
 
@@ -203,7 +203,7 @@ function Base.length(x::OscarPair{<:PBWAlgRing, <:Singular.SPolyCoeffs})
    return length(x.second)
 end
 
-function Base.eltype(x::OscarPair{<:PBWAlgRing{T, S}, <:Singular.SPolyCoeffs}) where {T, S}
+function Base.eltype(::Type{<:OscarPair{<:PBWAlgRing{T, S}, <:Singular.SPolyCoeffs}}) where {T, S}
    return T
 end
 

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -322,7 +322,7 @@ function Base.iterate(A::BiPolyArray, s::Int = 1)
   return A[Val(:O), s], s+1
 end
 
-Base.eltype(::BiPolyArray{S}) where S = S
+Base.eltype(::Type{<:BiPolyArray{S}}) where S = S
 
 function Base.getindex(A::IdealGens, ::Val{:S}, i::Int)
   return A.gens[Val(:S), i]
@@ -355,7 +355,7 @@ function Base.iterate(A::IdealGens, s::Int = 1)
   return A[Val(:O), s], s+1
 end
 
-Base.eltype(::IdealGens{S}) where S = S
+Base.eltype(::Type{IdealGens{S}}) where S = S
 
 function gens(I::IdealGens)
   return collect(I)
@@ -1074,7 +1074,7 @@ function Base.iterate(a::GeneralPermutedIterator{:coefficients, <:MPolyRingElem}
   return coeff(a.elem, a.perm[state]), state
 end
 
-function Base.eltype(a::GeneralPermutedIterator{:coefficients, <:MPolyRingElem{C}}) where C
+function Base.eltype(::Type{<:GeneralPermutedIterator{:coefficients, <:MPolyRingElem{C}}}) where C
   return C
 end
 
@@ -1111,7 +1111,7 @@ function Base.iterate(a::GeneralPermutedIterator{:coefficients_and_exponents, <:
   return (coeff(a.elem, a.perm[state]), exponent_vector(a.elem, a.perm[state])), state
 end
 
-function Base.eltype(a::GeneralPermutedIterator{:coefficients_and_exponents, <:MPolyRingElem{C}}) where C
+function Base.eltype(::Type{<:GeneralPermutedIterator{:coefficients_and_exponents, <:MPolyRingElem{C}}}) where C
   return Tuple{C, Vector{Int}}
 end
 
@@ -1131,7 +1131,7 @@ function Base.iterate(a::GeneralPermutedIterator{:exponents, <:MPolyRingElem}, s
   return exponent_vector(a.elem, a.perm[state]), state
 end
 
-function Base.eltype(a::GeneralPermutedIterator{:exponents, <:MPolyRingElem})
+function Base.eltype(::Type{<:GeneralPermutedIterator{:exponents, <:MPolyRingElem}})
   return Vector{Int}
 end
 
@@ -1150,7 +1150,7 @@ function Base.iterate(a::GeneralPermutedIterator{:monomials, <:MPolyRingElem}, s
   return monomial(a.elem, a.perm[state]), state
 end
 
-function Base.eltype(a::GeneralPermutedIterator{:monomials, T}) where T <: MPolyRingElem
+function Base.eltype(::Type{<:GeneralPermutedIterator{:monomials, T}}) where T <: MPolyRingElem
   return T
 end
 
@@ -1169,7 +1169,7 @@ function Base.iterate(a::GeneralPermutedIterator{:terms, <:MPolyRingElem}, state
   return term(a.elem, a.perm[state]), state
 end
 
-function Base.eltype(a::GeneralPermutedIterator{:terms, T}) where T <: MPolyRingElem
+function Base.eltype(::Type{<:GeneralPermutedIterator{:terms, T}}) where T <: MPolyRingElem
   return T
 end
 

--- a/test/PolyhedralGeometry/subdivision_of_points.jl
+++ b/test/PolyhedralGeometry/subdivision_of_points.jl
@@ -14,8 +14,8 @@
     SubdivisionOfPoints
 
   @testset "alternative inputs" begin
-    @test collect(maximal_cells(square_by_incidence)) ==
-      collect(maximal_cells(square_by_weights))
+    @test issetequal(collect(maximal_cells(square_by_incidence)),
+      collect(maximal_cells(square_by_weights)))
     @test min_weights(square_by_cells) == min_weights(square_by_weights)
   end
 


### PR DESCRIPTION
The docstring of `eltype` states
> However the form that accepts a type argument should be defined for new types. 

Chaning this should help julia infer types of iterator constructions like `Iterators.reverse(...)` for these types.