### PR TITLE
Avoid bottlenecks in variable matching.

### DIFF
--- a/src/Rings/MPolyMap/Types.jl
+++ b/src/Rings/MPolyMap/Types.jl
@@ -35,11 +35,14 @@ const _DomainTypes = Union{MPolyRing, MPolyQuoRing}
     # can safely be disabled.
     if check_for_mapping_of_vars && all(_is_gen, img_gens) && _allunique(img_gens)
       gens_codomain = gens(codomain)
-      result.variable_indices = [findfirst(==(x), gens_codomain) for x in img_gens]
+      result.variable_indices = [findfirst(_cmp_reps(x), gens_codomain) for x in img_gens]
     end
     return result
   end
 end
+
+# This can be overwritten in order to avoid making the above check a bottleneck.
+_cmp_reps(a) = ==(a)
 
 function MPolyAnyMap(d::D, c::C, cm::U, ig::Vector{V}) where {D, C, U, V}
   return MPolyAnyMap{D, C, U, V}(d, c, cm, ig)

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -2804,3 +2804,8 @@ _exponents(x::MPolyQuoRingElem) = AbstractAlgebra.exponent_vectors(lift(x))
 _exponents(x::MPolyLocRingElem) = AbstractAlgebra.exponent_vectors(numerator(x))
 _exponents(x::MPolyQuoLocRingElem) = AbstractAlgebra.exponent_vectors(lifted_numerator(x))
 
+# overwriting the comparison method to avoid computing saturations and groebner bases.
+_cmp_reps(a::MPolyQuoRingElem) = y->(lift(y) == lift(a))
+_cmp_reps(a::MPolyLocRingElem) = y->(fraction(y) == fraction(a))
+_cmp_reps(a::MPolyQuoLocRingElem) = y->(fraction(y) == fraction(a))
+

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -2805,7 +2805,6 @@ _exponents(x::MPolyLocRingElem) = AbstractAlgebra.exponent_vectors(numerator(x))
 _exponents(x::MPolyQuoLocRingElem) = AbstractAlgebra.exponent_vectors(lifted_numerator(x))
 
 # overwriting the comparison method to avoid computing saturations and groebner bases.
-_cmp_reps(a::MPolyQuoRingElem) = y->(lift(y) == lift(a))
 _cmp_reps(a::MPolyLocRingElem) = y->(fraction(y) == fraction(a))
 _cmp_reps(a::MPolyQuoLocRingElem) = y->(fraction(y) == fraction(a))
 


### PR DESCRIPTION
Unfortunately I already ran into the first encounter where my recent "speedup" actually led to a regression. This should fix it. 