### PR TITLE
CI: add workaround for new gcc with julia 1.6 on github runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,6 +78,7 @@ jobs:
           # be able to properly deal with PRs / merges
           fetch-depth: 2
       - name: "Set up Julia"
+        id: setup-julia
         uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
@@ -101,7 +102,7 @@ jobs:
         run: echo "OSCAR_TEST_SUBSET=${{matrix.group}}" >> $GITHUB_ENV
       - name: "workaround libstdc++ issue for julia 1.6"
         if: matrix.julia-version == '1.6' && runner.os == 'Linux'
-        run: rm -f /opt/hostedtoolcache/julia/1.6.*/x64/bin/../lib/julia/libstdc++.so.6
+        run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Run tests"
         uses: julia-actions/julia-runtest@latest
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,6 +99,9 @@ jobs:
       - name: "set test subgroup"
         if: ${{ matrix.group }} != ''
         run: echo "OSCAR_TEST_SUBSET=${{matrix.group}}" >> $GITHUB_ENV
+      - name: "workaround libstdc++ issue for julia 1.6"
+        if: matrix.julia-version == '1.6' && runner.os == 'Linux'
+        run: rm -f /opt/hostedtoolcache/julia/1.6.*/x64/bin/../lib/julia/libstdc++.so.6
       - name: "Run tests"
         uses: julia-actions/julia-runtest@latest
         with:


### PR DESCRIPTION
Should fix these errors for julia 1.6:
```
linear programs: Error During Test at /home/runner/work/Oscar.jl/Oscar.jl/test/PolyhedralGeometry/linear_program.jl:32
  Test threw exception
  Expression: solve_lp(LP2) == (-1, [-1, -1])
  Can't load shared module /tmp/poly2182N2_aaaa0004.so: /opt/hostedtoolcache/julia/1.6.7/x64/bin/../lib/julia/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by /tmp/poly2182N2_aaaa0004.so) at /home/runner/.julia/scratchspaces/d720cf60-89b5-51f5-aff5-213f193123e7/polymake_17993036462335189361_1.6_depstree_v2/share/polymake/perllib/Polymake/Core/CPlusPlus.pm line 1785.
```