### PR TITLE
add a missing `in` method

### DIFF
--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -1312,6 +1312,11 @@ function apply_automorphism(f::GAPGroupElem{AutomorphismGroup{T}}, x::GAPGroupEl
   return typeof(x)(G, GAPWrap.ImagesRepresentative(GapObj(f), GapObj(x)))
 end
 
+# According to the documentation, `hom(x) in A` shall return `false`
+# for an element `x` of `A`.
+# We install a method for that.
+Base.in(::GAPGroupHomomorphism, ::AutomorphismGroup{<: GAPGroup}) = false
+
 Base.:*(f::GAPGroupElem{AutomorphismGroup{T}}, g::GAPGroupHomomorphism) where T = hom(f)*g
 Base.:*(f::GAPGroupHomomorphism, g::GAPGroupElem{AutomorphismGroup{T}}) where T = f*hom(g)
 


### PR DESCRIPTION
According to the documentation, `hom(x) in A` shall return `false` for an element `x` of `A`, where `A` is a group of automorphisms.

With this addition, the proposed change from Nemocas/AbstractAlgebra.jl/pull/1853 should have less problems with the Oscar CI tests.

(There are of course missing `==` methods in the Groups code of Oscar as soon as Nemocas/AbstractAlgebra.jl/pull/1853 becomes available, but I think some discussion is needed concerning how to fix this.)