### PR TITLE
serialization of more group attributes

### DIFF
--- a/src/Serialization/Groups.jl
+++ b/src/Serialization/Groups.jl
@@ -110,57 +110,22 @@ function load_type_params(s::DeserializerState, ::Type{<:GrpElemUnionType})
 end
 
 
-#############################################################################
-# attributes handling
-const GAPGroup_attributes = [
-  :order, :is_abelian, :is_nilpotent, :is_perfect, :is_simple, :is_solvable
-]
-
-function save_attrs(s::SerializerState, G::T) where T <: GAPGroup
-  save_data_dict(s, :attrs) do 
-    for attr in attrs_list(s, T)
-      func = Symbol(string("has_", attr))
-      if @eval $func($G)
-        attr_value = @eval $attr($G)
-        save_typed_object(s, attr_value, attr)
-      end
-    end
-  end
-end
-
-function load_attrs(s::DeserializerState, G::T) where T <: GAPGroup
-  !with_attrs(s) && return
-  haskey(s, :attrs) && load_node(s, :attrs) do d
-    for attr in attrs_list(s, T)
-      if haskey(d, attr)
-        func = Symbol(string("set_", attr))
-        attr_value = load_typed_object(s, attr)
-        @eval $func($G, $attr_value)
-      end
-    end
-  end
-end
-
 ##############################################################################
 # PermGroup
 
-@register_serialization_type PermGroup uses_id [GAPGroup_attributes;]
+@register_serialization_type PermGroup uses_id
 
 function save_object(s::SerializerState, G::PermGroup)
   n = degree(G)
   save_data_dict(s) do
     save_object(s, n, :degree)
-    save_object(s, [Vector{Int}(GAPWrap.ListPerm(GapObj(x))) for x in gens(G)], :gens)
-    save_attrs(s, G)
+    save_typed_object(s, GapObj(G), :X)
   end
 end
 
 function load_object(s::DeserializerState, ::Type{PermGroup})
   n = load_object(s, Int, :degree)
-  generators = load_object(s, Vector, (Vector{Int}, Int), :gens)
-  G = permutation_group(n, [perm(x) for x in generators])
-  load_attrs(s, G)
-  return G
+  return PermGroup(load_typed_object(s, :X), n)
 end
 
 

--- a/test/Serialization/Groups.jl
+++ b/test/Serialization/Groups.jl
@@ -2,6 +2,12 @@
   mktempdir() do path
     @testset "Permutation groups" begin
       G = symmetric_group(5)
+      is_finite(G)
+      is_abelian(G)
+      is_nilpotent(G)
+      is_perfect(G)
+      is_simple(G)
+      is_solvable(G)
 
       # single element
       x = gen(G, 1)
@@ -43,6 +49,14 @@
       Oscar.reset_global_serializer_state()
       loadedv = load(filenamev)
       @test parent(loadedv[1]) === loadedv[3]
+      loadedG = loadedv[3]
+      @test has_order(loadedG) && order(loadedG) == order(G)
+      @test has_is_finite(G) && is_finite(loadedG) == is_finite(G)
+      @test has_is_abelian(G) && is_abelian(loadedG) == is_abelian(G)
+      @test has_is_nilpotent(G) && is_nilpotent(loadedG) == is_nilpotent(G)
+      @test has_is_perfect(G) && is_perfect(loadedG) == is_perfect(G)
+      @test has_is_simple(G) && is_simple(loadedG) == is_simple(G)
+      @test has_is_solvable(G) && is_solvable(loadedG) == is_solvable(G)
 
       loadedw = load(filenamew)
       @test parent(loadedw[1]) === parent(loadedw[2])
@@ -172,6 +186,9 @@
       paras = [(1, 1), (5, 1), (24, 12)]
       for (n, i) in paras
         G = small_group(n, i)
+        order(G)
+#       center(G)
+#TODO: problem with cyclic references
 
         # single element
         x = rand(G)
@@ -212,9 +229,12 @@
         # simulate loading into a fresh Julia session
         Oscar.reset_global_serializer_state()
         loadedv = load(filenamev)
-        @test parent(loadedv[1]) === loadedv[3]
+        loadedG = loadedv[3]
+        @test parent(loadedv[1]) === loadedG
         @test parent(loadedv[2]) === loadedv[4]
-        @test is_subgroup(loadedv[4], loadedv[3])[1]
+        @test is_subgroup(loadedv[4], loadedG)[1]
+        @test has_order(loadedG)
+#       @test has_center(loadedG) && order(center(loadedG)[1]) == order(center(G)[1])
 
         loadedw = load(filenamew)
         @test parent(loadedv[1]) === parent(loadedw[2])


### PR DESCRIPTION
The idea is to implement serializations directly for the underlying GAP objects, instead of implementing them for the Oscar objects.

For boolean and numeric attributes, the two alternatives do not really differ, but for attributes whose values are themselves groups, for example `center(g)`, we can simply serialize `GAP.Globals.Center(GapObj(g))`, together with its attributes, instead of first creating `center(g)` anew and then serializing its first component.

Another advantage is that this way, it will be easier to deal with "Oscar attributes" of groups that do not rely on GAP's attribute mechanism.

(The serialization of permutation groups gets changed with this approach; if we proceed like this then a fallback must be provided, in order to deal with the deserialization of files containing permutation groups that were serialized with the old method.)

Currently there is a problem with cyclic references, and the handling of attribute values that are GAP lists is not yet supported.

Here is an example for the cyclic reference problem:
```
julia> g = small_group(4, 1);

julia> path = mktempdir();  filenamev = joinpath(path, "v");

julia> save(filenamev, g)

julia> Oscar.reset_global_serializer_state();

julia> loadedv = load(filenamev);

julia> has_center(g)
false

julia> center(g);

julia> save(filenamev, g)

julia> Oscar.reset_global_serializer_state()
Dict{Base.UUID, Any}()

julia> loadedv = load(filenamev)
Internal error: encountered unexpected error during compilation of showerror:
StackOverflowError()
```