### PR TITLE
More type stability for GSets

### DIFF
--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -36,7 +36,7 @@ The fields are
 - the seeds (something iterable of eltype `S`) whose closure under the action is the G-set
 - the dictionary used to store attributes (orbits, elements, ...).
 """
-@attributes mutable struct GSetByElements{T,S} <: GSet{T}
+@attributes mutable struct GSetByElements{T,S} <: GSet{T,S}
     group::T
     action_function::Function
     seeds
@@ -229,7 +229,7 @@ end
 #TODO: Compute membership without writing down all elements,
 #      using what is called `RepresentativeAction` in GAP.
 
-function Base.in(omega, Omega::GSetByElements)
+function Base.in(omega::S, Omega::GSetByElements{T,S}) where {T,S}
     omega in Omega.seeds && return true
     return omega in elements(Omega)
 end
@@ -256,12 +256,12 @@ as_gset(G::T, Omega) where T<:Union{GAPGroup,FinGenAbGroup} = as_gset(G, ^, Omeg
 ##    not via the action function stored in the G-set,
 ##  - write something like `orbit(omega)`, `stabilizer(omega)`.
 
-struct ElementOfGSet
-    gset::GSet
-    obj::Any
+struct ElementOfGSet{T, S, G <: GSet{T, S}}
+    gset::G
+    obj::S
 end
 
-function (Omega::GSet)(obj::Any)
+function (Omega::GSet{T, S})(obj::S) where {T, S}
     return ElementOfGSet(Omega, obj)
 end
 
@@ -509,7 +509,7 @@ The fields are
 - the (left or right) transversal, of type `SubgroupTransversal{T, S, E}`,
 - the dictionary used to store attributes (orbits, elements, ...).
 """
-@attributes mutable struct GSetBySubgroupTransversal{T, S, E} <: GSet{T}
+@attributes mutable struct GSetBySubgroupTransversal{T, S, E} <: GSet{T,GroupCoset{T, E}}
     group::T
     subgroup::S
     side::Symbol

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -478,7 +478,7 @@ end
 
 ################################################################################
 
-abstract type GSet{T} end
+abstract type GSet{T,S} end
 
 
 ################################################################################
@@ -493,7 +493,7 @@ abstract type GSet{T} end
 It can be either the conjugacy class of an element or of a subgroup of type `S`
 in a group `G` of type `T`.
 """
-abstract type GroupConjClass{T, S} <: GSet{T} end
+abstract type GroupConjClass{T,S} <: GSet{T,S} end
 
 
 ################################################################################


### PR DESCRIPTION
...by adding a second type variable for the element type.

In particular, this parameterized `ElementOfGSet` and makes the field access inferrable.