### PR TITLE
allow `==` for two groups/group elements in fewer cases

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -373,7 +373,7 @@ end
 Base.:*(x::GAPGroupElem, y::GAPGroupElem) = _prod(x, y)
 
 function ==(x::GAPGroup, y::GAPGroup)
-  _check_compatible(x, y; error = false) || throw(ArgumentError("x and y are not compatible"))
+  _check_compatible(x, y)
   return GapObj(x) == GapObj(y)
 end
 
@@ -382,7 +382,7 @@ end
 # in the sense of `_check_compatible`,
 # and compare the `GapObj`s if this is the case.
 function ==(x::BasicGAPGroupElem, y::BasicGAPGroupElem)
-  _check_compatible(parent(x), parent(y); error = false) || throw(ArgumentError("parents of x and y are not compatible"))
+  _check_compatible(parent(x), parent(y))
   return GapObj(x) == GapObj(y)
 end
 

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -372,9 +372,26 @@ end
 
 Base.:*(x::GAPGroupElem, y::GAPGroupElem) = _prod(x, y)
 
-==(x::GAPGroup, y::GAPGroup) = GapObj(x) == GapObj(y)
+function ==(x::GAPGroup, y::GAPGroup)
+  _check_compatible(x, y; error = false) || throw(ArgumentError("x and y are not compatible"))
+  return GapObj(x) == GapObj(y)
+end
 
-==(x::BasicGAPGroupElem, y::BasicGAPGroupElem ) = GapObj(x) == GapObj(y)
+# For two `BasicGAPGroupElem`s,
+# we allow the question for equality if their parents fit together
+# in the sense of `_check_compatible`,
+# and compare the `GapObj`s if this is the case.
+function ==(x::BasicGAPGroupElem, y::BasicGAPGroupElem)
+  _check_compatible(parent(x), parent(y); error = false) || throw(ArgumentError("parents of x and y are not compatible"))
+  return GapObj(x) == GapObj(y)
+end
+
+# For two `GAPGroupElem`s,
+# if no specialized method is applicable then no `==` comparison is allowed.
+function ==(x::GAPGroupElem, y::GAPGroupElem)
+  _check_compatible(parent(x), parent(y); error = false) || throw(ArgumentError("parents of x and y are not compatible"))
+  throw(ArgumentError("== is not implemented for the given types"))
+end
 
 """
     one(G::GAPGroup) -> elem_type(G)

--- a/test/Groups/conformance.jl
+++ b/test/Groups/conformance.jl
@@ -60,6 +60,10 @@ include(joinpath(dirname(pathof(AbstractAlgebra)), "..", "test", "Groups-conform
       @test g>h || g==h || g<h
       @test isequal(g,h) || isless(g,h) || isless(h,g)
       end
+
+      F = free_group(1)
+      @test_throws ArgumentError F == G
+      @test_throws ArgumentError gen(F, 1) == g
    end
 
    @testset "Group operations" begin


### PR DESCRIPTION
If `_check_compatible` for the two groups in question returns `false` then throw an exception.
Note that the result is not based only on the types of the arguments but also on the groups.

This addresses one of the questions from #4191.