### PR TITLE
doc fix: remove extra 'we' in design_decisions.md

### DIFF
--- a/docs/src/DeveloperDocumentation/design_decisions.md
+++ b/docs/src/DeveloperDocumentation/design_decisions.md
@@ -90,7 +90,7 @@ software frameworks on a lower level:
  - Gap
 
 So: Please use it. It is safe to assume all can be improved, however, if we try
-to perfect every single line of code again and again, we we won't get anywhere;
+to perfect every single line of code again and again, we won't get anywhere;
 there is a balance to be found.
 For preference: 
 ```


### PR DESCRIPTION
This PR aims to remove extra 'we' in the `designdecision.md` documentation. 

The extra 'we' is located in https://docs.oscar-system.org/stable/DeveloperDocumentation/design_decisions/#What-Do-We-Have. 

Hopefully, this sounds good. 
