### PR TITLE
gitignore: also ignore Manifest-vX.Y.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 profile.pb.gz
 alloc-profile.pb.gz
 LocalPreferences.toml
-Manifest.toml
+Manifest*.toml
 .DS_Store
 *~
 *.swp


### PR DESCRIPTION
avoids accidentally checking in new versioned manifest files like `Manifest-v1.11.toml`.