### PR TITLE
Fix JuliaFormatter version to 1.x to avoid breaking changes of 2.x for now

### DIFF
--- a/etc/test_formatting.jl
+++ b/etc/test_formatting.jl
@@ -1,7 +1,7 @@
 using Pkg
 Pkg.activate(; temp=true)
 Pkg.add("Test")
-Pkg.add("JuliaFormatter")
+Pkg.add(name="JuliaFormatter", version="1")
 using Test
 using JuliaFormatter
 


### PR DESCRIPTION
Basically @benlorenz  fixed this.