### PR TITLE
show methods: lower case halfspaces and hyperplanes

### DIFF
--- a/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
@@ -26,13 +26,13 @@ julia> P = polyhedron(([-1 0; 1 0], [0,1]), ([0 1], [0]))
 Polyhedron in ambient dimension 2
 
 julia> facets(P)
-2-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^2 described by:
+2-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the halfspaces of R^2 described by:
 -x_1 <= 0
 x_1 <= 1
 
 
 julia> affine_hull(P)
-1-element SubObjectIterator{AffineHyperplane{QQFieldElem}} over the Hyperplanes of R^2 described by:
+1-element SubObjectIterator{AffineHyperplane{QQFieldElem}} over the hyperplanes of R^2 described by:
 x_2 = 0
 
 

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -559,7 +559,7 @@ compute_order(G::GAPGroup) = ZZRingElem(GAPWrap.Size(G.X))
 
 function compute_order(G::MatrixGroup{T}) where {T <: Union{AbsSimpleNumFieldElem, QQFieldElem}}
   #=
-    - For a matrix group G over the Rationals or over a number field,
+    - For a matrix group G over the rationals or over a number field,
     the GAP group G.X does usually not store the flag `IsHandledByNiceMonomorphism`.
     - If we know a reasonable ("nice") faithful permutation action of `G` in advance,
     we can set this flag in `G.X` to true and store the action homomorphism in `G.X`,

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -543,7 +543,7 @@ julia> c = positive_hull([1 0 0; 0 1 0; 1 1 1])
 Polyhedral cone in ambient dimension 3
 
 julia> f = facets(Halfspace, c)
-3-element SubObjectIterator{LinearHalfspace{QQFieldElem}} over the Halfspaces of R^3 described by:
+3-element SubObjectIterator{LinearHalfspace{QQFieldElem}} over the halfspaces of R^3 described by:
 -x_3 <= 0
 -x_1 + x_3 <= 0
 -x_2 + x_3 <= 0
@@ -616,7 +616,7 @@ $H = \{ (x_1, x_2, x_3) | x_3 = 0 \}$.
 julia> c = positive_hull([1 0 0; 0 1 0]);
 
 julia> linear_span(c)
-1-element SubObjectIterator{LinearHyperplane{QQFieldElem}} over the Hyperplanes of R^3 described by:
+1-element SubObjectIterator{LinearHyperplane{QQFieldElem}} over the hyperplanes of R^3 described by:
 x_3 = 0
 ```
 """

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -510,7 +510,7 @@ julia> facets(Polyhedron, C)
  Polytope in ambient dimension 3
 
 julia> facets(Halfspace, C)
-6-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^3 described by:
+6-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the halfspaces of R^3 described by:
 -x_1 <= 1
 x_1 <= 1
 -x_2 <= 1
@@ -593,7 +593,7 @@ We can retrieve the six facets of the 3-dimensional cube this way:
 julia> C = cube(3);
 
 julia> facets(C)
-6-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^3 described by:
+6-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the halfspaces of R^3 described by:
 -x_1 <= 1
 x_1 <= 1
 -x_2 <= 1
@@ -998,7 +998,7 @@ $P = \{ (x_1, x_2, x_3, x_4) | x_3 = 2 ∧ x_4 = 5 \}$.
 julia> t = convex_hull([0 0 2 5; 1 0 2 5; 0 1 2 5]);
 
 julia> affine_hull(t)
-2-element SubObjectIterator{AffineHyperplane{QQFieldElem}} over the Hyperplanes of R^4 described by:
+2-element SubObjectIterator{AffineHyperplane{QQFieldElem}} over the hyperplanes of R^4 described by:
 x_3 = 2
 x_4 = 5
 ```
@@ -1831,7 +1831,7 @@ function Base.show(io::IO, H::SubObjectIterator{<:Halfspace})
   print(io, "$s-element $t")
   if !isempty(H)
     n = length(normal_vector(H[1]))
-    print(io, " over the Halfspaces of R^$n described by:\n")
+    print(io, " over the halfspaces of R^$n described by:\n")
     if s < d
       print_constraints(io, H)
     else
@@ -1854,7 +1854,7 @@ function Base.show(io::IO, H::SubObjectIterator{<:Hyperplane})
   print(io, "$s-element $t")
   if !isempty(H)
     n = length(normal_vector(H[1]))
-    print(io, " over the Hyperplanes of R^$n described by:\n")
+    print(io, " over the hyperplanes of R^$n described by:\n")
     if s < d
       print_constraints(io, H)
     else

--- a/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
+++ b/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
@@ -618,7 +618,7 @@ julia> s = simplex(7)
 Polytope in ambient dimension 7
 
 julia> facets(s)
-8-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^7 described by:
+8-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the halfspaces of R^7 described by:
 -x_1 <= 0
 -x_2 <= 0
 -x_3 <= 0
@@ -632,7 +632,7 @@ julia> t = simplex(7, 5)
 Polytope in ambient dimension 7
 
 julia> facets(t)
-8-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^7 described by:
+8-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the halfspaces of R^7 described by:
 -x_1 <= 0
 -x_2 <= 0
 -x_3 <= 0
@@ -674,7 +674,7 @@ julia> C = cross_polytope(3)
 Polytope in ambient dimension 3
 
 julia> facets(C)
-8-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^3 described by:
+8-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the halfspaces of R^3 described by:
 x_1 + x_2 + x_3 <= 1
 -x_1 + x_2 + x_3 <= 1
 x_1 - x_2 + x_3 <= 1
@@ -688,7 +688,7 @@ julia> D = cross_polytope(3, 2)
 Polytope in ambient dimension 3
 
 julia> facets(D)
-8-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^3 described by:
+8-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the halfspaces of R^3 described by:
 x_1 + x_2 + x_3 <= 2
 -x_1 + x_2 + x_3 <= 2
 x_1 - x_2 + x_3 <= 2
@@ -1408,7 +1408,7 @@ julia> vertices(A)
  [4, 1, 10, 6]
 
 julia> facets(A)
-5-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^4 described by:
+5-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the halfspaces of R^4 described by:
 -x_1 <= -1
 -2*x_1 - 2*x_2 <= -10
 -x_2 <= -1
@@ -1637,14 +1637,14 @@ julia> G = hypersimplex(3,4,no_facets=true)
 Polytope in ambient dimension 4
 
 julia> facets(G)
-4-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^4 described by:
+4-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the halfspaces of R^4 described by:
 x_4 <= 1
 x_3 <= 1
 -x_1 - x_3 - x_4 <= -2
 x_1 <= 1
 
 julia> facets(H)
-4-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^4 described by:
+4-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the halfspaces of R^4 described by:
 x_4 <= 1
 x_3 <= 1
 -x_1 - x_3 - x_4 <= -2
@@ -2253,7 +2253,7 @@ julia> vertices(a)
  [0, 3, 4, 15, 16]
 
 julia> facets(a) 
-9-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^5 described by:
+9-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the halfspaces of R^5 described by:
 x_1 - x_2 <= -1
 x_1 - x_3 <= -4
 x_1 - x_4 <= -9

--- a/test/book/cornerstones/polyhedral-geometry/pentagon.jlcon
+++ b/test/book/cornerstones/polyhedral-geometry/pentagon.jlcon
@@ -4,7 +4,7 @@ julia> P = convex_hull(points)
 Polyhedron in ambient dimension 2
 
 julia> facets(P)
-5-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the Halfspaces of R^2 described by:
+5-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the halfspaces of R^2 described by:
 -x_1 <= 1
 -x_1 + x_2 <= 1
 x_1 - 2*x_2 <= 1


### PR DESCRIPTION
Grammatically these should be lowercase, that would also be consistent with how we do things elsewhere.

But perhaps there is a deeper reason why this should stay as it is?