### PR TITLE
[ToricVarieties] Assert coordinate names from cox ring

### DIFF
--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
@@ -1052,7 +1052,7 @@ julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = 
 Hypersurface model over a concrete base
 
 julia> zero_section_class(qsm_model)
-Cohomology class on a normal toric variety given by x32 + 2*x33 + 3*x34 + x35 - x36
+Cohomology class on a normal toric variety given by e2 + 2*u + 3*e4 + e1 - w
 ```
 """
 function zero_section_class(m::AbstractFTheoryModel)

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -211,7 +211,7 @@ julia> coordinate_names(antv)
 """
 @attr Vector{String} function coordinate_names(v::NormalToricVarietyType)
   if has_attribute(v, :cox_ring)
-    return string.(gens(cox_ring(v)))
+    return string.(symbols(cox_ring(v)))
   end
   return ["x$(i)" for i in 1:torsion_free_rank(torusinvariant_weil_divisor_group(v))]
 end

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -210,7 +210,10 @@ julia> coordinate_names(antv)
 ```
 """
 @attr Vector{String} function coordinate_names(v::NormalToricVarietyType)
-    return ["x$(i)" for i in 1:torsion_free_rank(torusinvariant_weil_divisor_group(v))]
+  if has_attribute(v, :cox_ring)
+    return string.(gens(cox_ring(v)))
+  end
+  return ["x$(i)" for i in 1:torsion_free_rank(torusinvariant_weil_divisor_group(v))]
 end
 
 

--- a/test/Serialization/ToricGeometry.jl
+++ b/test/Serialization/ToricGeometry.jl
@@ -8,16 +8,19 @@
       test_save_load_roundtrip(path, pp; with_attrs=false, check_func=!check) do loaded
         @test rays(pp) == rays(loaded)
         @test ray_indices(maximal_cones(pp)) == ray_indices(maximal_cones(loaded))
+        @test coordinate_names(pp) == coordinate_names(loaded)
       end
       
       test_save_load_roundtrip(path, pp; with_attrs=true, check_func=check) do loaded
         @test rays(pp) == rays(loaded)
         @test ray_indices(maximal_cones(pp)) == ray_indices(maximal_cones(loaded))
+        @test coordinate_names(pp) == coordinate_names(loaded)
       end
 
       test_save_load_roundtrip(path, pp; check_func=check) do loaded
         @test rays(pp) == rays(loaded)
         @test ray_indices(maximal_cones(pp)) == ray_indices(maximal_cones(loaded))
+        @test coordinate_names(pp) == coordinate_names(loaded)
       end
     end
 


### PR DESCRIPTION
The serialization of toric varieties remembers the Cox ring, but not the coordinate names. This leads to unexpected/inconsistent behavior. Here is an example:

```julia
julia> p3 = projective_space(NormalToricVariety, 3);

julia> set_coordinate_names(p3, ["u1", "u2", "u3", "u4"]);

julia> cox_ring(p3)
Multivariate polynomial ring in 4 variables over QQ graded by
  u1 -> [1]
  u2 -> [1]
  u3 -> [1]
  u4 -> [1]

julia> ideal_of_linear_relations(p3)
Ideal generated by
  u1 - u4
  u2 - u4
  u3 - u4

julia> save("/tmp/test.mrdi", p3)
```

CRUCIAL: Close your julia session and then proceed as follows:

```julia
julia> p3_2 = load("/tmp/test.mrdi")

julia> cox_ring(p3_2)
Multivariate polynomial ring in 4 variables over QQ graded by
  u1 -> [1]
  u2 -> [1]
  u3 -> [1]
  u4 -> [1]

julia> ideal_of_linear_relations(p3_2)
Ideal generated by
  x1 - x4
  x2 - x4
  x3 - x4
```

The ideal of linear relations is not homogeneous w.r.t. the grading of the Cox ring and so does not "live" in the Cox ring. Yet, the geometric meaning of the ideal of linear relations makes it beneficial to employ the same variables names as used in the Cox ring.

You can see that the root cause for this behavior is the call to `coordinate_names` in the implementation of `ideal_of_linear_relations`:

```julia
@attr MPolyIdeal function ideal_of_linear_relations(v::NormalToricVarietyType)
    R, _ = graded_polynomial_ring(coefficient_ring(v), coordinate_names(v); cached=false)
    return ideal_of_linear_relations(R, v)
end

function ideal_of_linear_relations(R::MPolyRing, v::NormalToricVarietyType)
    @req is_simplicial(v) "The ideal of linear relations is only supported for simplicial toric varieties"
    @req ngens(R) == n_rays(v) "The given polynomial ring must have exactly as many indeterminates as rays for the toric variety"
    return ideal(transpose(matrix(ZZ, rays(v))) * gens(R))
end
```

I propose to fix this by checking in the `coordinate_names` function if the attribute `cox_ring` is known for the toric variety, and if so to use the names of the indeterminates of `cox_ring` as return value for `coordinate_names`.

Certainly, we could also serialize the `coordinate_names` for any toric variety. This have its benefits, but there are has at least two draw-backs:
1. Larger file sizes (although this is likely super minor).
2. I would have to overhaul the QSM database again (which I would really like to avoid).

What are your thoughts @lkastner @antonydellavecchia?