### PR TITLE
Add `characteristic` for multivariate quotient rings over fields

### DIFF
--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -79,6 +79,14 @@ oscar_origin_ring(Q::MPolyQuoRing) = base_ring(Q)
 
 default_ordering(Q::MPolyQuoRing) = default_ordering(base_ring(Q))
 
+# Only for fields for now because of things like char(ZZ[x, y]/<2>) = 2
+function characteristic(Q::MPolyQuoRing{<:MPolyRingElem{T}}) where {T <: FieldElement}
+  if is_zero(one(Q))
+    return 1
+  end
+  return characteristic(coefficient_ring(Q))
+end
+
 ##############################################################################
 #
 # Quotient ring elements

--- a/test/Rings/MPolyQuo.jl
+++ b/test/Rings/MPolyQuo.jl
@@ -36,6 +36,12 @@
 
   B,q = quo(R, x^3+y,y^2; ordering=lex(R))
   @test A.I == B.I
+
+  @test characteristic(quo(R, ideal(x))[1]) == 0
+  @test characteristic(quo(R, ideal(R, 1))[1]) == 1
+
+  S, (s, t) = GF(5)[:s, :t]
+  @test characteristic(quo(S, ideal([s, t]))[1]) == 5
 end
 
 @testset "MpolyQuo.manipulation" begin


### PR DESCRIPTION
Addresses #4239 for fields. The `is_zero` call needs a Gröbner basis which uses a cached basis, if one was already computed.
