### PR TITLE
Adds algorithm option :modular for Gröbner basis computations

### DIFF
--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -123,6 +123,7 @@ Return a standard basis of `I` with respect to `ordering`.
 
 The keyword `algorithm` can be set to
 - `:buchberger` (implementation of Buchberger's algorithm in *Singular*),
+- `:modular` (implementation of multi-modular approach, if applicable),
 - `:f4` (implementation of Faugère's F4 algorithm in the *msolve* package),
 - `:fglm` (implementation of the FGLM algorithm in *Singular*),
 - `:hc` (implementation of Buchberger's algorithm in *Singular* trying to first compute the highest corner modulo some prime), and
@@ -162,6 +163,16 @@ function standard_basis(I::MPolyIdeal; ordering::MonomialOrdering = default_orde
       I.gb[ordering] = _compute_standard_basis(I.gens, ordering, complete_reduction)
     elseif complete_reduction == true
       I.gb[ordering] = _compute_standard_basis(I.gb[ordering], ordering, complete_reduction)
+    end
+  elseif algorithm == :modular
+    if is_f4_applicable(I, ordering)
+      #  since msolve v0.7.0 is most of the time more efficient
+      #  to compute a reduced GB by default
+      groebner_basis_f4(I, complete_reduction=true)
+    elseif base_ring(I) isa QQMPolyRing
+      groebner_basis_modular(I, ordering=ordering)
+    else
+      error("Modular option not applicable in this setting.")
     end
   elseif algorithm == :fglm
     _compute_groebner_basis_using_fglm(I, ordering)
@@ -217,6 +228,7 @@ If `ordering` is global, return a Gröbner basis of `I` with respect to `orderin
 
 The keyword `algorithm` can be set to
 - `:buchberger` (implementation of Buchberger's algorithm in *Singular*),
+- `:modular` (implementation of multi-modular approach, if applicable),
 - `:hilbert` (implementation of a Hilbert driven Gröbner basis computation in *Singular*),
 - `:fglm` (implementation of the FGLM algorithm in *Singular*), and
 - `:f4` (implementation of Faugère's F4 algorithm in the *msolve* package).

--- a/src/Rings/groebner.jl
+++ b/src/Rings/groebner.jl
@@ -343,7 +343,7 @@ function is_f4_applicable(I::MPolyIdeal, ordering::MonomialOrdering)
             && ((coefficient_ring(I) isa FqField
                  && absolute_degree(coefficient_ring(I)) == 1
                  && characteristic(coefficient_ring(I)) < 2^31)
-                || coefficient_ring(I) == QQ))
+                || base_ring(I) isa QQMPolyRing))
 end
 
 @doc raw"""

--- a/test/Rings/groebner.jl
+++ b/test/Rings/groebner.jl
@@ -11,6 +11,22 @@
     @test leading_ideal(I, ordering=degrevlex(gens(R))) == ideal(R,[x*y^2, x^4, y^5])
     @test leading_ideal(I) == ideal(R,[x*y^2, x^4, y^5])
     @test leading_ideal(I, ordering=lex(gens(R))) == ideal(R,[y^7, x*y^2, x^3])
+
+    # algorithm = :modular option
+    R = @polynomial_ring(QQ, [:x, :y])
+    I = ideal(R, [x^2+y,y*x-1])
+    # uses f4 in msolve/AlgebraicSolving
+    groebner_basis(I, ordering=degrevlex(R), algorithm=:modular)
+    @test gens(I.gb[degrevlex(R)]) == QQMPolyRingElem[x + y^2, x*y - 1, x^2 + y]
+    # uses multi-modular implementation in Oscar applying Singular finite field
+    # computations
+    groebner_basis(I, ordering=lex(R), algorithm=:modular)
+    @test gens(I.gb[lex(R)]) == QQMPolyRingElem[y^3 + 1, x + y^2]
+    T = @polynomial_ring(QQ, :t)
+    R = @polynomial_ring(T, [:x, :y])
+    I = ideal(R, [x^2+y,y*x-1])
+    @test_throws ErrorException groebner_basis(I, ordering=lex(R), algorithm=:modular)
+
     # issue 3665
     kt,t = polynomial_ring(GF(2),:t)
     Ft = fraction_field(kt)


### PR DESCRIPTION
This PR is a first step for enabling multi-modular Gröbner basis computations. It adds the algorithm option `:modular` and applies (if possible) either a multi-modular f4 from AlgebraicSolving or a multi-modular Buchberger based on Singular.

Following this PR, further implementations in other applicable settings for the multi-modular Buchberger need to be moved from `experimental`. Also, discussions about default options need to be discussed and are not part of this PR.