### PR TITLE
Fix show method for `FreeMod_dec`

### DIFF
--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -2046,7 +2046,7 @@ julia> R, (x,y) = graded_polynomial_ring(QQ, [:x, :y])
 (Graded multivariate polynomial ring in 2 variables over QQ, MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}[x, y])
 
 julia> free_module_dec(R,3)
-Decorated free module of rank 3 over RR^3([0])
+Decorated free module of rank 3 over R
 
 ```
 """
@@ -2107,23 +2107,9 @@ function show(io::IO, F::FreeMod_dec)
   @show_special(io, F)
 
   io = terse(io)
+  io = pretty(io)
   print(io, "Decorated free module of rank $(rank(F)) over ")
-  print(IOContext(io, :compact => true), base_ring(F))
-
-  i = 1
-  while i < dim(F)
-    d = F.d[i]
-    j = 1
-    while i+j <= dim(F) && d == F.d[i+j]
-      j += 1
-    end
-    print(IOContext(io, :compact => true), base_ring(F), "^$j")
-    print(IOContext(io, :compact => true), "(", -d, ")")
-    if i+j < dim(F)
-      print(io, " + ")
-    end
-    i += j
-  end
+  print(IOContext(io, :compact => true), Lowercase(), base_ring(F))
 end
 
 # Generic specialized show methods (formerly in Hecke)


### PR DESCRIPTION
Perhaps this should be different and reuse the removed code for e.g. terse or compact printing or whatever. But the current behavior is clearly wrong (and it was since day 1 when this code was merged). And at the same time it's not clear to me whether anyone is even *using* `FreeMod_dec` objects.... So I propose we merge this now, and if someone using this type, and is unhappy how it is printed, they can propose a better way, and we can fix it *then*.