### PR TITLE
Add `isomorphism(::Type{PermGroup}, ::WeylGroup)` for some cases

### DIFF
--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -74,6 +74,7 @@ import ..Oscar:
   ngens,
   order,
   parent_type,
+  permutation_group,
   rank,
   root,
   roots,

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -74,6 +74,8 @@ import ..Oscar:
   ngens,
   order,
   parent_type,
+  perm,
+  permutation_matrix,
   rank,
   root,
   roots,

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -74,8 +74,6 @@ import ..Oscar:
   ngens,
   order,
   parent_type,
-  perm,
-  permutation_matrix,
   rank,
   root,
   roots,

--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -474,36 +474,58 @@ function isomorphism(::Type{FPGroup}, W::WeylGroup; set_properties::Bool=true)
   return MapFromFunc(W, G, iso, isoinv)
 end
 
-function isomorphism(::Type{PermGroup}, W::WeylGroup)
-  coxeter_type, n = root_system_type(root_system(W))[1]
-  @req coxeter_type == :A "Weyl group is not the symmetric group"
-  G = symmetric_group(n + 1)
+function permutation_group(W::WeylGroup; set_properties::Bool=true)
+  return codomain(isomorphism(PermGroup, W; set_properties))
+end
 
-  iso = function (w::WeylGroupElem)
-    reduce(*, [cperm(G, [i, i + 1]) for i in word(w)]; init=cperm(G))
+function isomorphism(::Type{PermGroup}, W::WeylGroup; set_properties::Bool=true)
+  @req is_finite(W) "Weyl group is not finite"
+  R = root_system(W)
+  type, ordering = root_system_type_with_ordering(R)
+
+  if length(type) != 1
+    error("Not implemented (yet)")
+  end
+  if !issorted(ordering)
+    error("Not implemented (yet)")
+  end
+  coxeter_type, n = only(type)
+  if coxeter_type == :A
+    G = symmetric_group(n + 1)
+
+    iso = function (w::WeylGroupElem)
+      reduce(*, [cperm(G, [i, i + 1]) for i in word(w)]; init=cperm(G))
+    end
+
+    isoinv = function (p::PermGroupElem)
+      word = UInt8[]
+      for cycle in cycles(p)
+        transpositions = [
+          sort([c, cycle[i + 1]]) for (i, c) in enumerate(cycle) if i < length(cycle)
+        ]
+        for t in transpositions
+          word = reduce(
+            vcat,
+            [
+              [i for i in t[1]:(t[2] - 1)],
+              [i for i in reverse(t[1]:(t[2] - 2))],
+              word,
+            ],
+          )
+        end
+      end
+      return W(word)
+    end
+  else
+    error("Not implemented (yet)")
   end
 
-  isoinv = function (g::PermGroupElem)
-    word = UInt8[]
-    for cycle in cycles(p)
-      transpositions = [
-        sort([c, cycle[i + 1]]) for (i, c) in enumerate(cycle) if i < length(cycle)]
-      for t in transpositions
-        word = reduce(
-          vcat,
-          [
-            [i for i in t[1]:(t[2] - 1)],
-            [i for i in reverse(t[1]:(t[2] - 2))],
-            word],
-        )
-      end
-    end
-    return W(word)
+  if set_properties
+    set_order(G, order(W))
   end
 
   return MapFromFunc(W, G, iso, isoinv)
 end
-
 
 ###############################################################################
 # ReducedExpressionIterator

--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -474,6 +474,37 @@ function isomorphism(::Type{FPGroup}, W::WeylGroup; set_properties::Bool=true)
   return MapFromFunc(W, G, iso, isoinv)
 end
 
+function isomorphism(::Type{PermGroup}, W::WeylGroup)
+  coxeter_type, n = root_system_type(root_system(W))[1]
+  @req coxeter_type == :A "Weyl group is not the symmetric group"
+  G = symmetric_group(n + 1)
+
+  iso = function (w::WeylGroupElem)
+    reduce(*, [cperm(G, [i, i + 1]) for i in word(w)]; init=cperm(G))
+  end
+
+  isoinv = function (g::PermGroupElem)
+    word = UInt8[]
+    for cycle in cycles(p)
+      transpositions = [
+        sort([c, cycle[i + 1]]) for (i, c) in enumerate(cycle) if i < length(cycle)]
+      for t in transpositions
+        word = reduce(
+          vcat,
+          [
+            [i for i in t[1]:(t[2] - 1)],
+            [i for i in reverse(t[1]:(t[2] - 2))],
+            word],
+        )
+      end
+    end
+    return W(word)
+  end
+
+  return MapFromFunc(W, G, iso, isoinv)
+end
+
+
 ###############################################################################
 # ReducedExpressionIterator
 
@@ -679,37 +710,4 @@ function Base.iterate(iter::WeylOrbitIterator, state::WeylIteratorNoCopyState)
 
   (wt, _), state = it
   return deepcopy(wt), state
-end
-
-################################################################################
-# converting to permutations
-
-function isomorphism(::Type{PermGroup}, W::WeylGroup)
-  coxeter_type, n = root_system_type(root_system(W))[1]
-  @req coxeter_type == :A "Weyl group is not the symmetric group"
-  G = symmetric_group(n + 1)
-
-  iso = function (w::WeylGroupElem)
-    reduce(*, [cperm(G, [i, i + 1]) for i in word(w)]; init=cperm(G))
-  end
-
-  isoinv = function (g::PermGroupElem)
-    word = UInt8[]
-    for cycle in cycles(p)
-      transpositions = [
-        sort([c, cycle[i + 1]]) for (i, c) in enumerate(cycle) if i < length(cycle)]
-      for t in transpositions
-        word = reduce(
-          vcat,
-          [
-            [i for i in t[1]:(t[2] - 1)],
-            [i for i in reverse(t[1]:(t[2] - 2))],
-            word],
-        )
-      end
-    end
-    return W(word)
-  end
-
-  return MapFromFunc(W, G, iso, isoinv)
 end

--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -713,7 +713,3 @@ function isomorphism(::Type{PermGroup}, W::WeylGroup)
 
   return MapFromFunc(W, G, iso, isoinv)
 end
-
-function permutation_matrix(R::Ring, w::WeylGroupElem)
-  permutation_matrix(R, isomorphism(PermGroup, parent(w))(w))
-end

--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -680,3 +680,40 @@ function Base.iterate(iter::WeylOrbitIterator, state::WeylIteratorNoCopyState)
   (wt, _), state = it
   return deepcopy(wt), state
 end
+
+################################################################################
+# converting to permutations
+
+function isomorphism(::Type{PermGroup}, W::WeylGroup)
+  coxeter_type, n = root_system_type(root_system(W))[1]
+  @req coxeter_type == :A "Weyl group is not the symmetric group"
+  G = symmetric_group(n + 1)
+
+  iso = function (w::WeylGroupElem)
+    reduce(*, [cperm(G, [i, i + 1]) for i in word(w)]; init=cperm(G))
+  end
+
+  isoinv = function (g::PermGroupElem)
+    word = UInt8[]
+    for cycle in cycles(p)
+      transpositions = [
+        sort([c, cycle[i + 1]]) for (i, c) in enumerate(cycle) if i < length(cycle)]
+      for t in transpositions
+        word = reduce(
+          vcat,
+          [
+            [i for i in t[1]:(t[2] - 1)],
+            [i for i in reverse(t[1]:(t[2] - 2))],
+            word],
+        )
+      end
+    end
+    return W(word)
+  end
+
+  return MapFromFunc(W, G, iso, isoinv)
+end
+
+function permutation_matrix(R::Ring, w::WeylGroupElem)
+  permutation_matrix(R, isomorphism(PermGroup, parent(w))(w))
+end

--- a/experimental/LieAlgebras/test/WeylGroup-test.jl
+++ b/experimental/LieAlgebras/test/WeylGroup-test.jl
@@ -52,6 +52,7 @@ include(
 
   @testset "WeylGroup Group conformace test for $(Wname)" for (Wname, W) in [
     ("A1", weyl_group(:A, 1)),
+    ("A5", weyl_group(:A, 5)),
     ("B4", weyl_group(root_system(:B, 4))),
     ("D5", weyl_group(cartan_matrix(:D, 5))),
     ("F4+G2", weyl_group((:F, 4), (:G, 2))),
@@ -118,6 +119,41 @@ include(
         end
       end
     end
+
+    if has_root_system_type(root_system(W))
+      type, ordering = root_system_type_with_ordering(root_system(W))
+      if length(type) == 1 && issorted(ordering) && only(type)[1] == :A # only implemented for A_n (yet)
+        @testset "isomorphism(PermGroup, ::WeylGroup; set_properties=$set_properties)" for set_properties in
+                                                                                          [
+            false, true
+          ]
+          G = permutation_group(W; set_properties)
+          if (is_finite(W) && ngens(W) < 6) || set_properties #= for sane runtime =#
+            @test is_finite(G) == is_finite(W)
+            is_finite(W) && @test order(G) == order(W)
+          end
+
+          iso = isomorphism(PermGroup, W; set_properties)
+          @test W == domain(iso)
+          G = codomain(iso)
+          if (is_finite(W) && ngens(W) < 6) || set_properties #= for sane runtime =#
+            @test is_finite(G) == is_finite(W)
+            is_finite(W) && @test order(G) == order(W)
+            if ngens(W) < 10 #= for sane runtime =#
+              for _ in 1:5
+                if is_finite(W) # remove once rand(W) is implemented for infinite groups
+                  w = rand(W)
+                  @test w == inv(iso)(iso(w))
+                end
+                g = rand_pseudo(G)
+                @test g == iso(inv(iso)(g))
+              end
+            end
+          end
+        end
+      end
+    end
+
   end
 
   @testset "<(x::WeylGroupElem, y::WeylGroupElem)" begin

--- a/experimental/LieAlgebras/test/WeylGroup-test.jl
+++ b/experimental/LieAlgebras/test/WeylGroup-test.jl
@@ -112,9 +112,15 @@ include(
             if is_finite(W) # remove once rand(W) is implemented for infinite groups
               w = rand(W)
               @test w == inv(iso)(iso(w))
+              v = rand(W)
+              @test iso(v * w) == iso(v) * iso(w)
+              @test v * w == inv(iso)(iso(v) * iso(w))
             end
             g = rand_pseudo(G)
             @test g == iso(inv(iso)(g))
+            h = rand_pseudo(G)
+            @test inv(iso)(h * g) == inv(iso)(h) * inv(iso)(g)
+            @test h * g == iso(inv(iso)(h) * inv(iso)(g))
           end
         end
       end
@@ -144,9 +150,15 @@ include(
                 if is_finite(W) # remove once rand(W) is implemented for infinite groups
                   w = rand(W)
                   @test w == inv(iso)(iso(w))
+                  v = rand(W)
+                  @test iso(v * w) == iso(v) * iso(w)
+                  @test v * w == inv(iso)(iso(v) * iso(w))
                 end
                 g = rand_pseudo(G)
                 @test g == iso(inv(iso)(g))
+                h = rand_pseudo(G)
+                @test inv(iso)(h * g) == inv(iso)(h) * inv(iso)(g)
+                @test h * g == iso(inv(iso)(h) * inv(iso)(g))
               end
             end
           end

--- a/experimental/LieAlgebras/test/WeylGroup-test.jl
+++ b/experimental/LieAlgebras/test/WeylGroup-test.jl
@@ -124,9 +124,9 @@ include(
       type, ordering = root_system_type_with_ordering(root_system(W))
       if length(type) == 1 && issorted(ordering) && only(type)[1] == :A # only implemented for A_n (yet)
         @testset "isomorphism(PermGroup, ::WeylGroup; set_properties=$set_properties)" for set_properties in
-                                                                                          [
-            false, true
-          ]
+                                                                                           [
+          false, true
+        ]
           G = permutation_group(W; set_properties)
           if (is_finite(W) && ngens(W) < 6) || set_properties #= for sane runtime =#
             @test is_finite(G) == is_finite(W)
@@ -153,7 +153,6 @@ include(
         end
       end
     end
-
   end
 
   @testset "<(x::WeylGroupElem, y::WeylGroupElem)" begin


### PR DESCRIPTION
This PR contains the changes from https://github.com/oscar-system/Oscar.jl/pull/4260 in `experimental/LieAlgebras`, makes them a bit more consistent with the surrounding code, and adds tests.