### PR TITLE
Serialize cohomology classes

### DIFF
--- a/src/Serialization/ToricGeometry.jl
+++ b/src/Serialization/ToricGeometry.jl
@@ -2,7 +2,7 @@
 # Toric varieties
 @register_serialization_type AffineNormalToricVariety uses_id
 
-@register_serialization_type NormalToricVariety uses_id [:cox_ring, :class_group]
+@register_serialization_type NormalToricVariety uses_id [:cox_ring, :class_group, :cohomology_ring]
 
 
 function save_object(s::SerializerState, ntv::T) where T <: NormalToricVarietyType
@@ -92,4 +92,30 @@ function load_object(s::DeserializerState, ::Type{ToricDivisorClass}, tv::Normal
   end
   pmdiv = Polymake._lookup_multi(pm_object(tv), "DIVISOR", index-1)
   return toric_divisor_class(ToricDivisor(pmdiv, tv, coeffs))
+end
+
+################################################################################
+# Cohomology classes on toric varieties
+@register_serialization_type CohomologyClass uses_params
+
+function save_type_params(s::SerializerState, obj::CohomologyClass)
+  save_data_dict(s) do
+    save_object(s, encode_type(CohomologyClass), :name)
+    save_typed_object(s, obj.v, :params)
+  end
+end
+
+function load_type_params(s::DeserializerState, ::Type{<:CohomologyClass})
+  return load_typed_object(s)
+end
+
+function save_object(s::SerializerState, cc::CohomologyClass)
+  save_data_dict(s) do
+    save_typed_object(s, polynomial(cc).f, :polynomial)
+  end
+end
+
+function load_object(s::DeserializerState, ::Type{CohomologyClass}, tv::NormalToricVarietyType)
+  poly = load_object(s, MPolyDecRingElem, base_ring(cohomology_ring(tv)), :polynomial)
+  return cohomology_class(tv, MPolyQuoRingElem(poly, cohomology_ring(tv)))
 end

--- a/src/Serialization/ToricGeometry.jl
+++ b/src/Serialization/ToricGeometry.jl
@@ -111,7 +111,7 @@ end
 
 function save_object(s::SerializerState, cc::CohomologyClass)
   save_data_dict(s) do
-    save_typed_object(s, polynomial(cc).f, :polynomial)
+    save_object(s, lift(polynomial(cc)), :polynomial)
   end
 end
 

--- a/test/Serialization/ToricGeometry.jl
+++ b/test/Serialization/ToricGeometry.jl
@@ -48,5 +48,15 @@
       end
     end
 
+    @testset "ToricDivisorClass" begin
+      pp = projective_space(NormalToricVariety, 2)
+      cc = volume_form(pp)
+      cc_list = [cc]
+      test_save_load_roundtrip(path, cc_list) do loaded
+        @test cc == loaded[1]
+        @test toric_variety(cc) === toric_variety(loaded[1])
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This PR aims to serialize cohomology classes on toric varieties. This boils down to saving a polynomial, and ensuring that it resides in the cohomology ring of the toric variety (= a quotient ring)/the base ring of this quotient ring. Sadly I cannot get the code to work. The line:

`poly = load_object(s, MPolyDecRingElem, base_ring(cohomology_ring(tv)), :polynomial)`

raises the error:

`ERROR: KeyError: key Symbol("1") not found`

I am out of ideas how to fix this. Any ideas @antonydellavecchia? Help appreciated.

Here is a MWE, based on this PR:
```julia
p4 = projective_space(NormalToricVariety, 4)
cc = volume_form(p4)
save("/tmp/test.mrdi", cc)
load("/tmp/test.mrdi")
```

