### PR TITLE
Implement ambient space models for G4-flux candidates

### DIFF
--- a/experimental/FTheoryTools/docs/src/g4.md
+++ b/experimental/FTheoryTools/docs/src/g4.md
@@ -32,9 +32,44 @@ passes_elementary_quantization_checks(gf::G4Flux)
 ```
 
 
-## Auxiliary
+## Ambient Space Models for G4-Fluxes
 
-The following methods are relevant to the discussion and study of $G_4$-fluxes:
+Focus on 4-dimensional F-theory models $m$, such that the resolution $\widehat{Y}_4$
+of the defining singular elliptically fibered CY 4-fold $\Y_4 \twoheadrightarrow B_3$
+is defined as hypersurface in a complete and simplicial toric variety $X_\Sigma$. In
+such a setup, it is convenient to focus on $G_4$-fluxes modelled from the restriction
+of elements of $H^{(2,2)}( X_\Sigma, \mathbb{Q})$ to $\widehat{Y}_4$. This method
+identifies a basis of $H^{(2,2)}( X_\Sigma, \mathbb{Q})$ and filters out elements,
+whose restricton to $\widehat{Y}_4$ is obviously trivial.
+
+It is important to elaborate a bit more on the meaning of "obviously". To this end, fix a
+basis element of $H^{(2,2)}( X_\Sigma, \mathbb{Q})$. Let us denote a corresponding algebraic
+cycle by $A = \mathbb{V}(x_i, x_j) \subset X_\Sigma$, where $x_i$, $x_j$ are suitable
+homogeneous coordinates. Furthermore, let $\widehat{Y}_4 = \mathbb{V}( p ) \subset X_\Sigma$.
+Then of course, we can look at the set-theoretic intersection $\mathbb{V}( p, x_i, x_j)$.
+Provided that $p(x_i = 0, x_j = 0)$ is a non-zero constant, this set-theoretic intersection
+is trivial. This is exactly the check conducted by the method `ambient_space_models_of_g4_fluxes`
+below. However, for reasons of simplicity, this approach is avoid a number of sutleties.
+
+Namely, we really have to work out the intersection in the Chow ring, that is we should consider
+the rational equivalence class of the algebraic cycle $A$ and intersect this class with the
+rational equivalence class of the algebraic cycle $\mathbb{V}( p )$. In particular, for
+"unlucky" choices of $i, j$, the algebraic cycles $\mathbb{V}( p )$ and $\mathbb{V}(x_i, x_j)$
+may not intersect transversely. This is for instance the case if $i = j$. Such phenomena are
+addressed in theory by "moving the algebraic cycles into general position", but in practice this
+somewhat tricky. Instances include the following:
+1. $i = j$: Then apparently, a self-intersection of $\mathbb{V}(x_i)$ is involved.
+2. $p(x_i, x_j) \equiv 0$: This is unexpected for dimensional reasons, and indicates a
+non-transverse intersection.
+
+In both instances, one makes use of the linear relations of $X_\Sigma$ to replace the cycle 
+ $\mathbb{V}(x_i)$ (and/or $\mathbb{V}(x_j)$) with a rational combination of algebraic cycles
+$R = \sum_{k = 1}^{N}{c_k \cdot A_k}$, such that $R$ is rationally equivalent to $\mathbb{V}(x_i)$.
+From experience, it is then rather common that $R$ and $\mathbb{V}(x_i)$ intersect transversely.
+And if not, then modify the non-transverse intersections by using the linear relations again to
+replace an involved algebraic cycle.
+
 ```@docs
+ambient_space_models_of_g4_fluxes(m::AbstractFTheoryModel; check::Bool = true)
 basis_of_h22(v::NormalToricVariety; check::Bool = true)
 ```

--- a/experimental/FTheoryTools/src/G4Fluxes/special_attributes.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/special_attributes.jl
@@ -133,16 +133,17 @@ function basis_of_h22(v::NormalToricVariety; check::Bool = true)::Vector{Cohomol
 
   end
 
-  # (9) Convert relations into matrix
-  remaining_relations_matrix = matrix(QQ, remaining_relations)
-
-  # (10) Now identify those variables that we can remove with those remaining relations
-  r, new_mat = rref(remaining_relations_matrix)
-  @req r == nrows(remaining_relations_matrix) "Cannot remove a variable via linear relations - weird!"
-  new_bad_positions = [findfirst(!iszero, row) for row in eachrow(new_mat)]
-  new_good_positions = setdiff(1:N_filtered_quadratic_elements, new_bad_positions)
-
-  # (11) Return the basis elements in terms of cohomology classes
+  # (9) Identify variables that we can remove with the remaining relations
+  new_good_positions = 1:N_filtered_quadratic_elements
+  if length(remaining_relations) != 0
+    remaining_relations_matrix = matrix(QQ, remaining_relations)
+    r, new_mat = rref(remaining_relations_matrix)
+    @req r == nrows(remaining_relations_matrix) "Cannot remove a variable via linear relations - weird!"
+    new_bad_positions = [findfirst(!iszero, row) for row in eachrow(new_mat)]
+    new_good_positions = setdiff(1:N_filtered_quadratic_elements, new_bad_positions)
+  end
+  
+  # (10) Return the basis elements in terms of cohomology classes
   S = cohomology_ring(v, check = check)
   c_ds = [k.f for k in gens(S)]
   final_list_of_tuples = []
@@ -152,7 +153,7 @@ function basis_of_h22(v::NormalToricVariety; check::Bool = true)::Vector{Cohomol
     end
   end
   basis_of_h22 = [cohomology_class(v, MPolyQuoRingElem(c_ds[my_tuple[1]]*c_ds[my_tuple[2]], S)) for my_tuple in final_list_of_tuples]
-  set_attribute!(v, :basis_of_h22, basis_of_h22)
+  #set_attribute!(v, :basis_of_h22, basis_of_h22)
   return basis_of_h22
 
 end
@@ -173,6 +174,22 @@ to `false` to skip these tests.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
+julia> B3 = projective_space(NormalToricVariety, 3)
+Normal toric variety
+
+julia> Kbar = anticanonical_divisor_class(B3)
+Divisor class on a normal toric variety
+
+julia> t = literature_model(arxiv_id = "1109.3454", equation = "3.1", base_space = B3, defining_classes = Dict("w"=>Kbar))
+Construction over concrete base may lead to singularity enhancement. Consider computing singular_loci. However, this may take time!
+
+Global Tate model over a concrete base -- SU(5)xU(1) restricted Tate model based on arXiv paper 1109.3454 Eq. (3.1)
+
+julia> g4_amb_list = ambient_space_models_of_g4_fluxes(t)
+2-element Vector{CohomologyClass}:
+ Cohomology class on a normal toric variety given by z^2
+ Cohomology class on a normal toric variety given by y^2
+
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 8))
 Hypersurface model over a concrete base
 

--- a/experimental/FTheoryTools/src/G4Fluxes/special_attributes.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/special_attributes.jl
@@ -41,8 +41,7 @@ julia> betti_number(Y, 4) == length(h22_basis)
 true
 ```
 """
-function basis_of_h22(v::NormalToricVariety; check::Bool = true)
-#function basis_of_h22(v::NormalToricVariety; check::Bool = true)::Vector{CohomologyClass}
+function basis_of_h22(v::NormalToricVariety; check::Bool = true)::Vector{CohomologyClass}
 
   # (0) Some initial checks
   if check

--- a/experimental/FTheoryTools/src/exports.jl
+++ b/experimental/FTheoryTools/src/exports.jl
@@ -23,6 +23,7 @@ export add_weighted_resolution
 export add_weighted_resolution_generating_section
 export add_weighted_resolution_zero_section
 export ambient_space
+export ambient_space_models_of_g4_fluxes
 export analyze_fibers
 export arxiv_doi
 export arxiv_id


### PR DESCRIPTION
See the doc string for more details. Hopefully, this is sufficiently clear.

I have taken the liberty to profile this new function a lot, since we want to showcase this very soon (or so I believe). For the doctest example `g4_amb_list = ambient_space_models_of_g4_fluxes(qsm_model, check = false);` I found:
* My first working implementation: About 1.5 * 10^6 allocs.
* Current implementation: Only about 24,000 allocs.

The main improvement came from a more efficient identification of `remaining_vars_list`, but there were quite a number of other tricks I employed. Overall, I am very happy with these improvements.

@apturner @emikelsons You may find it entertaining that for "the" big model,  I expect that `ambient_space_models_of_g4_fluxes` completes in no more than 10 minutes on most personal computers. On mine, even only about 5 to 6 minutes. (The first run will of course always be somewhat slower...)

