### PR TITLE
Fix `BoundError` in `weights(hook_lengths(...))`

### DIFF
--- a/src/Combinatorics/EnumerativeCombinatorics/tableaux.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/tableaux.jl
@@ -48,7 +48,7 @@ young_tableau
 
 function young_tableau(::Type{T}, v::Vector{Vector{TT}}; check::Bool = true) where {T <: IntegerUnion, TT <: IntegerUnion}
   if check
-    @req _defines_partition(map(length, v)) "The input does not define a Young tableau"
+    @req _defines_partition(map(length, v)) "The input does not define a Young tableau: lengths of rows must be weakly decreasing"
   end
   return YoungTableau{T}(v)
 end
@@ -222,20 +222,24 @@ Return the shape of the tableau `tab`, i.e. the partition given by the lengths
 of the rows of the tableau.
 """
 function shape(tab::YoungTableau{T}) where T
-  return partition(T[ length(tab[i]) for i = 1:length(tab) ], check = false)
+  # Line below DOES NOT CHECK that the lengths of the rows are weakly decreasing
+  return partition(T[ length(tab[i]) for i = 1:length(tab) ]; check = false)
 end
 
 @doc raw"""
     weight(tab::YoungTableau)
 
-Return the weight of the tableau `tab` as an array whose `i`-th element gives
-the number of times the integer `i` appears in the tableau.
+Return the weight sequence of the tableau `tab` as an array whose `i`-th element
+gives the number of times the integer `i` appears in the tableau.
 """
 function weight(tab::YoungTableau)
+  @req  is_semistandard(tab)  "Tableau must be (semi-)standard"
+  
   if isempty(tab)
     return Int[]
   end
 
+  # Computation of max must be changed if we want to permit non-semi-standard YT
   max = 0
   for i = 1:length(tab)
     if max < tab[i][end]

--- a/test/Combinatorics/EnumerativeCombinatorics/tableaux.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/tableaux.jl
@@ -6,7 +6,7 @@
   @test reading_word(young_tableau(Array{Int,1}[])) == Int[]
 
   # weight
-  @test weight(young_tableau([[1,2,3],[1,2],[1]])) == [3,2,1]
+  @test weight(young_tableau([[1,2,3],[2,3],[3]])) == [1,2,3]
   @test weight(young_tableau([[1,2,3,4,5]])) == [1,1,1,1,1]
   @test_throws  ArgumentError  weight(young_tableau([[1],[1],[1]]))
   @test weight(young_tableau(Array{Int,1}[])) == Int[]

--- a/test/Combinatorics/EnumerativeCombinatorics/tableaux.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/tableaux.jl
@@ -8,7 +8,7 @@
   # weight
   @test weight(young_tableau([[1,2,3],[1,2],[1]])) == [3,2,1]
   @test weight(young_tableau([[1,2,3,4,5]])) == [1,1,1,1,1]
-  @test weight(young_tableau([[1],[1],[1]])) == [3]
+  @test_throws  ArgumentError  weight(young_tableau([[1],[1],[1]]))
   @test weight(young_tableau(Array{Int,1}[])) == Int[]
 
   # is_standard


### PR DESCRIPTION
The `weight` function now checks that its arg is semi-standard, and gives a helpful error if not.

The proposed name change discussed in issue #4230  (replace `weight` by `weight_sequence`) has **not** been implemented.

Resolves #4230.