### PR TITLE
Some progress around root systems and Weyl groups

### DIFF
--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -28,9 +28,19 @@ function Base.show(io::IO, mime::MIME"text/plain", L::AbstractLieAlgebra)
   @show_special(io, mime, L)
   io = pretty(io)
   println(io, "Abstract Lie algebra")
-  println(io, Indent(), "of dimension $(dim(L))", Dedent())
-  print(io, "over ")
-  print(io, Lowercase(), coefficient_ring(L))
+  if has_root_system(L)
+    rs = root_system(L)
+    if has_root_system_type(rs)
+      type, ord = root_system_type_with_ordering(rs)
+      print(io, Indent(), "of type ", _root_system_type_string(type))
+      if !issorted(ord)
+        print(io, " (non-canonical ordering)")
+      end
+      println(io, Dedent())
+    end
+  end
+  println(io, Indent(), "of dimension ", dim(L), Dedent())
+  print(io, "over ", Lowercase(), coefficient_ring(L))
 end
 
 function Base.show(io::IO, L::AbstractLieAlgebra)
@@ -40,8 +50,18 @@ function Base.show(io::IO, L::AbstractLieAlgebra)
     print(io, "Abstract Lie algebra")
   else
     io = pretty(io)
-    print(io, "Abstract Lie algebra over ", Lowercase())
-    print(terse(io), coefficient_ring(L))
+    print(io, "Abstract Lie algebra")
+    if has_root_system(L)
+      rs = root_system(L)
+      if has_root_system_type(rs)
+        type, ord = root_system_type_with_ordering(rs)
+        print(io, " of type ", _root_system_type_string(type))
+        if !issorted(ord)
+          print(io, " (non-canonical ordering)")
+        end
+      end
+    end
+    print(terse(io), " over ", Lowercase(), coefficient_ring(L))
   end
 end
 

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -281,6 +281,7 @@ For the used notation and the definition of extraspecial pairs, see [CMT04](@cit
 ```jldoctest
 julia> L = lie_algebra(QQ, root_system(:B, 4))
 Abstract Lie algebra
+  of type B4
   of dimension 36
 over rational field
 ```
@@ -459,6 +460,7 @@ The internally used basis of this Lie algebra is the Chevalley basis.
 ```jldoctest
 julia> L = lie_algebra(QQ, :C, 4)
 Abstract Lie algebra
+  of type C4
   of dimension 36
 over rational field
 ```

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -256,6 +256,14 @@ via the kwarg `extraspecial_pair_signs::Vector{Bool}` to specify the concrete Li
 If $(\alpha,\beta)$ is the extraspecial pair for the non-simple root `root(rs, i)`,
 then $\varepsilon_{\alpha,\beta} = 1$ iff `extraspecial_pair_signs[i - n_simple_roots(rs)] = true`.
 For the used notation and the definition of extraspecial pairs, see [CMT04](@cite).
+
+# Examples
+```jldoctest
+julia> L = lie_algebra(QQ, root_system(:B, 4))
+Abstract Lie algebra
+  of dimension 36
+over rational field
+```
 """
 function lie_algebra(
   R::Field,
@@ -426,6 +434,14 @@ end
 Construct a simple Lie algebra over the field `R` with Dynkin type given by `fam` and `rk`.
 See `cartan_matrix(fam::Symbol, rk::Int)` for allowed combinations.
 The internally used basis of this Lie algebra is the Chevalley basis.
+
+# Examples
+```jldoctest
+julia> L = lie_algebra(QQ, :C, 4)
+Abstract Lie algebra
+  of dimension 36
+over rational field
+```
 """
 function lie_algebra(R::Field, S::Symbol, n::Int)
   rs = root_system(S, n)

--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -833,6 +833,33 @@ end
 ###############################################################################
 
 @doc raw"""
+    abelian_lie_algebra(R::Field, n::Int) -> LinearLieAlgebra{elem_type(R)}
+    abelian_lie_algebra(::Type{LinearLieAlgebra}, R::Field, n::Int) -> LinearLieAlgebra{elem_type(R)}
+    abelian_lie_algebra(::Type{AbstractLieAlgebra}, R::Field, n::Int) -> AbstractLieAlgebra{elem_type(R)}
+
+Return the abelian Lie algebra of dimension `n` over the field `R`.
+The first argument can be optionally provided to specify the type of the returned
+Lie algebra.
+
+# Example
+```jldoctest
+julia> abelian_lie_algebra(LinearLieAlgebra, QQ, 3)
+Linear Lie algebra with 3x3 matrices
+  of dimension 3
+over rational field
+
+julia> abelian_lie_algebra(AbstractLieAlgebra, QQ, 3)
+Abstract Lie algebra
+  of dimension 3
+over rational field
+```
+"""
+function abelian_lie_algebra(R::Field, n::Int)
+  @req n >= 0 "Dimension must be non-negative."
+  return abelian_lie_algebra(LinearLieAlgebra, R, n)
+end
+
+@doc raw"""
     lie_algebra(gapL::GapObj, s::Vector{<:VarName}) -> LieAlgebra{elem_type(R)}
 
 Construct a Lie algebra isomorphic to the GAP Lie algebra `gapL`. Its basis element are named by `s`,

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -1445,8 +1445,8 @@ julia> dominant_weights(L, [1, 0, 3])
 7-element Vector{Vector{Int64}}:
  [1, 0, 3]
  [1, 1, 1]
- [2, 0, 1]
  [0, 0, 3]
+ [2, 0, 1]
  [0, 1, 1]
  [1, 0, 1]
  [0, 0, 1]
@@ -1509,10 +1509,10 @@ Dict{Vector{Int64}, Int64} with 10 entries:
   [-1, 1, -1] => 1
   [-2, 2, 0]  => 1
   [1, -1, 1]  => 1
-  [-1, 0, 1]  => 1
   [1, 0, -1]  => 1
-  [2, 0, 0]   => 1
+  [-1, 0, 1]  => 1
   [0, -1, 0]  => 1
+  [2, 0, 0]   => 1
 ```
 """
 function character(L::LieAlgebra, hw::Vector{<:IntegerUnion})

--- a/experimental/LieAlgebras/src/LinearLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LinearLieAlgebra.jl
@@ -188,6 +188,39 @@ given by `s`. The basis elements must be square matrices of size `n`.
 We require `basis` to be linearly independent, and to contain the Lie bracket of any
 two basis elements in its span (this is currently not checked).
 Setting `check=false` disables these checks (once they are in place).
+
+# Examples
+```jldoctest
+julia> e = matrix(QQ, [0 0 1; 0 0 0; 0 0 0]);
+
+julia> f = matrix(QQ, [0 0 0; 0 0 0; 1 0 0]);
+
+julia> h = matrix(QQ, [1 0 0; 0 0 0; 0 0 -1]);
+
+julia> L = lie_algebra(QQ, 3, [e, f, h], [:e, :f, :h])
+Linear Lie algebra with 3x3 matrices
+  of dimension 3
+over rational field
+
+julia> root_system(L);
+
+julia> L
+Linear Lie algebra with 3x3 matrices
+  of dimension 3
+over rational field
+
+julia> basis(L)
+3-element Vector{LinearLieAlgebraElem{QQFieldElem}}:
+ e
+ f
+ h
+
+julia> matrix_repr_basis(L)
+3-element Vector{QQMatrix}:
+ [0 0 1; 0 0 0; 0 0 0]
+ [0 0 0; 0 0 0; 1 0 0]
+ [1 0 0; 0 0 0; 0 0 -1]
+```
 """
 function lie_algebra(
   R::Field,
@@ -213,20 +246,6 @@ function lie_algebra(
   R = coefficient_ring(L)
   s = map(AbstractAlgebra.obj_to_string_wrt_times, basis)
   return lie_algebra(R, L.n, matrix_repr.(basis), s; check)
-end
-
-@doc raw"""
-    abelian_lie_algebra(R::Field, n::Int) -> LinearLieAlgebra{elem_type(R)}
-    abelian_lie_algebra(::Type{LinearLieAlgebra}, R::Field, n::Int) -> LinearLieAlgebra{elem_type(R)}
-    abelian_lie_algebra(::Type{AbstractLieAlgebra}, R::Field, n::Int) -> AbstractLieAlgebra{elem_type(R)}
-
-Return the abelian Lie algebra of dimension `n` over the field `R`.
-The first argument can be optionally provided to specify the type of the returned
-Lie algebra.
-"""
-function abelian_lie_algebra(R::Field, n::Int)
-  @req n >= 0 "Dimension must be non-negative."
-  return abelian_lie_algebra(LinearLieAlgebra, R, n)
 end
 
 function abelian_lie_algebra(::Type{T}, R::Field, n::Int) where {T<:LinearLieAlgebra}

--- a/experimental/LieAlgebras/src/LinearLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LinearLieAlgebra.jl
@@ -44,28 +44,105 @@ function Base.show(io::IO, mime::MIME"text/plain", L::LinearLieAlgebra)
   @show_name(io, L)
   @show_special(io, mime, L)
   io = pretty(io)
-  println(io, _lie_algebra_type_to_string(get_attribute(L, :type, :unknown), L.n))
-  println(io, Indent(), "of dimension $(dim(L))", Dedent())
-  print(io, "over ")
-  print(io, Lowercase(), coefficient_ring(L))
+  type_string = _lie_algebra_type_to_string(get_attribute(L, :type, :unknown), L.n)
+  if !isnothing(type_string)
+    println(io, type_string)
+  else
+    println(io, "Linear Lie algebra with $(L.n)x$(L.n) matrices")
+    if has_root_system(L)
+      rs = root_system(L)
+      if has_root_system_type(rs)
+        type, ord = root_system_type_with_ordering(rs)
+        print(io, Indent(), "of type ", _root_system_type_string(type))
+        if !issorted(ord)
+          print(io, " (non-canonical ordering)")
+        end
+        println(io, Dedent())
+      end
+    end
+  end
+  println(io, Indent(), "of dimension ", dim(L), Dedent())
+  print(io, "over ", Lowercase(), coefficient_ring(L))
 end
 
 function Base.show(io::IO, L::LinearLieAlgebra)
   @show_name(io, L)
   @show_special(io, L)
   if is_terse(io)
-    print(io, _lie_algebra_type_to_compact_string(get_attribute(L, :type, :unknown), L.n))
+    type_string_compact = _lie_algebra_type_to_compact_string(
+      get_attribute(L, :type, :unknown), L.n
+    )
+    if !isnothing(type_string_compact)
+      print(io, type_string_compact)
+    else
+      print(io, "Linear Lie algebra")
+    end
   else
     io = pretty(io)
-    print(
-      io,
-      _lie_algebra_type_to_string(get_attribute(L, :type, :unknown), L.n),
-      " over ",
-      Lowercase(),
-    )
-    print(terse(io), coefficient_ring(L))
+    type_string = _lie_algebra_type_to_string(get_attribute(L, :type, :unknown), L.n)
+    if !isnothing(type_string)
+      print(io, type_string)
+    else
+      print(io, "Linear Lie algebra with $(L.n)x$(L.n) matrices")
+      if has_root_system(L)
+        rs = root_system(L)
+        if has_root_system_type(rs)
+          type, ord = root_system_type_with_ordering(rs)
+          print(io, " of type ", _root_system_type_string(type))
+          if !issorted(ord)
+            print(io, " (non-canonical ordering)")
+          end
+        end
+      end
+    end
+    print(terse(io), " over ", Lowercase(), coefficient_ring(L))
   end
 end
+
+#=
+function Base.show(io::IO, mime::MIME"text/plain", L::AbstractLieAlgebra)
+  @show_name(io, L)
+  @show_special(io, mime, L)
+  io = pretty(io)
+  println(io, "Abstract Lie algebra")
+  if has_root_system(L)
+    rs = root_system(L)
+    if has_root_system_type(rs)
+      type, ord = root_system_type_with_ordering(rs)
+      print(io, Indent(), "of type ", _root_system_type_string(type))
+      if !issorted(ord)
+        print(io, " (non-canonical ordering)")
+      end
+      println(io, Dedent())
+    end
+  end
+  println(io, Indent(), "of dimension ", dim(L), Dedent())
+  print(io, "over ")
+  print(io, Lowercase(), coefficient_ring(L))
+end
+
+function Base.show(io::IO, L::AbstractLieAlgebra)
+  @show_name(io, L)
+  @show_special(io, L)
+  if is_terse(io)
+    print(io, "Abstract Lie algebra")
+  else
+    io = pretty(io)
+    print(io, "Abstract Lie algebra")
+    if has_root_system(L)
+      rs = root_system(L)
+      if has_root_system_type(rs)
+        type, ord = root_system_type_with_ordering(rs)
+        print(io, " of type ", _root_system_type_string(type))
+        if !issorted(ord)
+          print(io, " (non-canonical ordering)")
+        end
+      end
+    end
+    print(terse(io), " over ", Lowercase(), coefficient_ring(L))
+  end
+end
+=#
 
 function _lie_algebra_type_to_string(type::Symbol, n::Int)
   if type == :general_linear
@@ -76,9 +153,8 @@ function _lie_algebra_type_to_string(type::Symbol, n::Int)
     return "Special orthogonal Lie algebra of degree $n"
   elseif type == :symplectic
     return "Symplectic Lie algebra of degree $n"
-  else
-    return "Linear Lie algebra with $(n)x$(n) matrices"
   end
+  return nothing
 end
 
 function _lie_algebra_type_to_compact_string(type::Symbol, n::Int)
@@ -88,9 +164,8 @@ function _lie_algebra_type_to_compact_string(type::Symbol, n::Int)
     return "sl_$n"
   elseif type == :special_orthogonal
     return "so_$n"
-  else
-    return "Linear Lie algebra"
   end
+  return nothing
 end
 
 function symbols(L::LinearLieAlgebra)

--- a/experimental/LieAlgebras/src/LinearLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LinearLieAlgebra.jl
@@ -281,6 +281,7 @@ julia> root_system(L);
 
 julia> L
 Linear Lie algebra with 3x3 matrices
+  of type A1
   of dimension 3
 over rational field
 

--- a/experimental/LieAlgebras/src/RootSystem.jl
+++ b/experimental/LieAlgebras/src/RootSystem.jl
@@ -15,20 +15,16 @@ Passing `detect_type=false` will skip the detection of the root system type.
 # Examples
 ```jldoctest
 julia> root_system([2 -1; -1 2])
-Root system defined by Cartan matrix
-  [ 2   -1]
-  [-1    2]
+Root system of rank 2
+  of type A2
 
 julia> root_system(matrix(ZZ, 2, 2, [2, -1, -1, 2]); detect_type=false)
-Root system defined by Cartan matrix
-  [ 2   -1]
-  [-1    2]
+Root system of rank 2
+  of unknown type
 
 julia> root_system(matrix(ZZ, [2 -1 -2; -1 2 0; -1 0 2]))
-Root system defined by Cartan matrix
-  [ 2   -1   -2]
-  [-1    2    0]
-  [-1    0    2]
+Root system of rank 3
+  of type C3 (with non-canonical ordering of simple roots)
 ```
 """
 function root_system(cartan_matrix::ZZMatrix; check::Bool=true, detect_type::Bool=true)
@@ -47,9 +43,8 @@ Construct the root system of the given type. See `cartan_matrix(fam::Symbol, rk:
 # Examples
 ```jldoctest
 julia> root_system(:A, 2)
-Root system defined by Cartan matrix
-  [ 2   -1]
-  [-1    2]
+Root system of rank 2
+  of type A2
 ```
 """
 function root_system(fam::Symbol, rk::Int)
@@ -67,17 +62,12 @@ Construct the root system of the given type. See `cartan_matrix(fam::Symbol, rk:
 # Examples
 ```jldoctest
 julia> root_system([(:A, 2), (:F, 4)])
-Root system defined by Cartan matrix
-  [ 2   -1    0    0    0    0]
-  [-1    2    0    0    0    0]
-  [ 0    0    2   -1    0    0]
-  [ 0    0   -1    2   -1    0]
-  [ 0    0    0   -2    2   -1]
-  [ 0    0    0    0   -1    2]
+Root system of rank 6
+  of type A2 x F4
 
 julia> root_system(Tuple{Symbol,Int}[])
-Root system defined by Cartan matrix
-  0 by 0 empty matrix
+Root system of rank 0
+  of type []
 ```
 """
 function root_system(type::Vector{Tuple{Symbol,Int}})
@@ -226,8 +216,8 @@ Return the fundamental weights corresponding to the `simple_roots` of `R`.
 ```jldoctest
 julia> fundamental_weights(root_system(:A, 2))
 2-element Vector{WeightLatticeElem}:
- w1
- w2
+ w_1
+ w_2
 ```
 """
 function fundamental_weights(R::RootSystem)
@@ -282,9 +272,9 @@ Also see: `negative_root`.
 ```jldoctest
 julia> negative_roots(root_system(:A, 2))
 3-element Vector{RootSpaceElem}:
- RootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [-1 0])
- RootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [0 -1])
- RootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [-1 -1])
+ -a_1
+ -a_2
+ -a_1 - a_2
 ```
 """
 function negative_roots(R::RootSystem)
@@ -324,9 +314,9 @@ Also see: `negative_coroot`.
 ```jldoctest
 julia> negative_coroots(root_system(:A, 2))
 3-element Vector{DualRootSpaceElem}:
- DualRootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [-1 0])
- DualRootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [0 -1])
- DualRootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [-1 -1])
+ -a^v_1
+ -a^v_2
+ -a^v_1 - a^v_2
 ```
 """
 function negative_coroots(R::RootSystem)
@@ -400,9 +390,9 @@ Also see: `positive_root`, `number_of_positive_roots`.
 ```jldoctest
 julia> positive_roots(root_system(:A, 2))
 3-element Vector{RootSpaceElem}:
- RootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [1 0])
- RootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [0 1])
- RootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [1 1])
+ a_1
+ a_2
+ a_1 + a_2
 ```
 """
 function positive_roots(R::RootSystem)
@@ -442,9 +432,9 @@ Also see: `positive_coroots`.
 ```jldoctest
 julia> positive_coroots(root_system(:A, 2))
 3-element Vector{DualRootSpaceElem}:
- DualRootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [1 0])
- DualRootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [0 1])
- DualRootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [1 1])
+ a^v_1
+ a^v_2
+ a^v_1 + a^v_2
 ```
 """
 function positive_coroots(R::RootSystem)
@@ -606,13 +596,19 @@ Return the Weyl group of `R`.
 # Examples
 ```jldoctest
 julia> weyl_group(root_system([2 -1; -1 2]))
-Weyl group for root system defined by Cartan matrix [2 -1; -1 2]
+Weyl group
+  of root system of rank 2
+    of type A2
 
 julia> weyl_group(root_system(matrix(ZZ, 2, 2, [2, -1, -1, 2]); detect_type=false))
-Weyl group for root system defined by Cartan matrix [2 -1; -1 2]
+Weyl group
+  of root system of rank 2
+    of unknown type
 
 julia> weyl_group(root_system(matrix(ZZ, [2 -1 -2; -1 2 0; -1 0 2])))
-Weyl group for root system defined by Cartan matrix [2 -1 -2; -1 2 0; -1 0 2]
+Weyl group
+  of root system of rank 3
+    of type C3 (with non-canonical ordering of simple roots)
 ```
 """
 function weyl_group(R::RootSystem)

--- a/experimental/LieAlgebras/src/RootSystem.jl
+++ b/experimental/LieAlgebras/src/RootSystem.jl
@@ -696,9 +696,9 @@ function reflect(r::RootSpaceElem, s::Int)
 end
 
 function reflect!(r::RootSpaceElem, s::Int)
-  r.vec -=
-    dot(view(cartan_matrix(root_system(r)), s, :), r.vec) *
-    simple_root(root_system(r), s).vec
+  sub!(
+    Nemo.mat_entry_ptr(r.vec, 1, s), dot(view(cartan_matrix(root_system(r)), s, :), r.vec)
+  )
   return r
 end
 
@@ -1097,7 +1097,7 @@ end
 Reflects the `w` at the `s`-th simple root in place and returns `w`.
 """
 function reflect!(w::WeightLatticeElem, s::Int)
-  addmul!(w.vec, view(cartan_matrix_tr(root_system(w)), s:s, :), -w.vec[s])
+  w.vec = addmul!(w.vec, view(cartan_matrix_tr(root_system(w)), s:s, :), -w.vec[s]) # change to submul! once available
   return w
 end
 

--- a/experimental/LieAlgebras/src/RootSystem.jl
+++ b/experimental/LieAlgebras/src/RootSystem.jl
@@ -11,6 +11,25 @@
 Construct the root system defined by the Cartan matrix.
 If `check` is `true`, checks that `cartan_matrix` is a generalized Cartan matrix.
 Passing `detect_type=false` will skip the detection of the root system type.
+
+# Examples
+```jldoctest
+julia> root_system([2 -1; -1 2])
+Root system defined by Cartan matrix
+  [ 2   -1]
+  [-1    2]
+
+julia> root_system(matrix(ZZ, 2, 2, [2, -1, -1, 2]); detect_type=false)
+Root system defined by Cartan matrix
+  [ 2   -1]
+  [-1    2]
+
+julia> root_system(matrix(ZZ, [2 -1 -2; -1 2 0; -1 0 2]))
+Root system defined by Cartan matrix
+  [ 2   -1   -2]
+  [-1    2    0]
+  [-1    0    2]
+```
 """
 function root_system(cartan_matrix::ZZMatrix; check::Bool=true, detect_type::Bool=true)
   return RootSystem(cartan_matrix; check, detect_type)
@@ -40,6 +59,27 @@ function root_system(fam::Symbol, rk::Int)
   return R
 end
 
+@doc raw"""
+    root_system(type::Vector{Tuple{Symbol,Int}}) -> RootSystem
+
+Construct the root system of the given type. See `cartan_matrix(fam::Symbol, rk::Int)` for allowed combinations of tuples.
+
+# Examples
+```jldoctest
+julia> root_system([(:A, 2), (:F, 4)])
+Root system defined by Cartan matrix
+  [ 2   -1    0    0    0    0]
+  [-1    2    0    0    0    0]
+  [ 0    0    2   -1    0    0]
+  [ 0    0   -1    2   -1    0]
+  [ 0    0    0   -2    2   -1]
+  [ 0    0    0    0   -1    2]
+
+julia> root_system(Tuple{Symbol,Int}[])
+Root system defined by Cartan matrix
+  0 by 0 empty matrix
+```
+"""
 function root_system(type::Vector{Tuple{Symbol,Int}})
   cartan = cartan_matrix(type)
   R = root_system(cartan; check=false, detect_type=false)
@@ -155,6 +195,14 @@ end
     fundamental_weights(R::RootSystem) -> Vector{WeightLatticeElem}
 
 Return the fundamental weights corresponding to the `simple_roots` of `R`.
+
+# Examples
+```jldoctest
+julia> fundamental_weights(root_system(:A, 2))
+2-element Vector{WeightLatticeElem}:
+ w1
+ w2
+```
 """
 function fundamental_weights(R::RootSystem)
   return [fundamental_weight(R, i) for i in 1:rank(R)]
@@ -203,6 +251,15 @@ Also see: `negative_root`.
     This function does not return a copy of the asked for object,
     but the internal field of the root system.
     Mutating the returned object will lead to undefined behavior.
+
+# Examples
+```jldoctest
+julia> negative_roots(root_system(:A, 2))
+3-element Vector{RootSpaceElem}:
+ RootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [-1 0])
+ RootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [0 -1])
+ RootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [-1 -1])
+```
 """
 function negative_roots(R::RootSystem)
   return [-r for r in positive_roots(R)]
@@ -228,14 +285,23 @@ end
 @doc raw"""
     negative_coroot(R::RootSystem, i::Int) -> RootSpaceElem
 
-Returns the coroots corresponding to the negative roots of `R`
+Returns the negative coroots of `R`. The $i$-th element of the returned vector is the negative coroot corresponding to the $i$-th positive coroot.
 
-Also see: `negative_coroots`.
+Also see: `negative_coroot`.
 
 !!! note
     This function does not return a copy of the asked for object,
     but the internal field of the root system.
     Mutating the returned object will lead to undefined behavior.
+
+# Examples
+```jldoctest
+julia> negative_coroots(root_system(:A, 2))
+3-element Vector{DualRootSpaceElem}:
+ DualRootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [-1 0])
+ DualRootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [0 -1])
+ DualRootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [-1 -1])
+```
 """
 function negative_coroots(R::RootSystem)
   return [-r for r in positive_coroots(R)]
@@ -303,6 +369,15 @@ Also see: `positive_root`, `number_of_positive_roots`.
     This function does not return a copy of the asked for object,
     but the internal field of the root system.
     Mutating the returned object will lead to undefined behavior.
+
+# Examples
+```jldoctest
+julia> positive_roots(root_system(:A, 2))
+3-element Vector{RootSpaceElem}:
+ RootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [1 0])
+ RootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [0 1])
+ RootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [1 1])
+```
 """
 function positive_roots(R::RootSystem)
   return R.positive_roots::Vector{RootSpaceElem}
@@ -336,6 +411,15 @@ Also see: `positive_coroots`.
     This function does not return a copy of the asked for object,
     but the internal field of the root system.
     Mutating the returned object will lead to undefined behavior.
+
+# Examples
+```jldoctest
+julia> positive_coroots(root_system(:A, 2))
+3-element Vector{DualRootSpaceElem}:
+ DualRootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [1 0])
+ DualRootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [0 1])
+ DualRootSpaceElem(Root system defined by Cartan matrix [2 -1; -1 2], [1 1])
+```
 """
 function positive_coroots(R::RootSystem)
   return R.positive_coroots::Vector{DualRootSpaceElem}
@@ -496,6 +580,18 @@ end
     weyl_group(R::RootSystem) -> WeylGroup
 
 Return the Weyl group of `R`.
+
+# Examples
+```jldoctest
+julia> weyl_group(root_system([2 -1; -1 2]))
+Weyl group for root system defined by Cartan matrix [2 -1; -1 2]
+
+julia> weyl_group(root_system(matrix(ZZ, 2, 2, [2, -1, -1, 2]); detect_type=false))
+Weyl group for root system defined by Cartan matrix [2 -1; -1 2]
+
+julia> weyl_group(root_system(matrix(ZZ, [2 -1 -2; -1 2 0; -1 0 2])))
+Weyl group for root system defined by Cartan matrix [2 -1 -2; -1 2 0; -1 0 2]
+```
 """
 function weyl_group(R::RootSystem)
   return R.weyl_group::WeylGroup

--- a/experimental/LieAlgebras/src/RootSystem.jl
+++ b/experimental/LieAlgebras/src/RootSystem.jl
@@ -351,16 +351,23 @@ function rank(R::RootSystem)
 end
 
 function root_system_type(R::RootSystem)
-  has_root_system_type(R) || error("Root system type not known and cannot be determined")
+  assure_root_system_type(R)
   return R.type
 end
 
 function root_system_type_with_ordering(R::RootSystem)
+  assure_root_system_type(R)
   return R.type, R.type_ordering
 end
 
 function has_root_system_type(R::RootSystem)
   return isdefined(R, :type) && isdefined(R, :type_ordering)
+end
+
+function assure_root_system_type(R::RootSystem)
+  has_root_system_type(R) && return nothing
+  @req is_finite(weyl_group(R)) "Root system type cannot be determined for infinite Weyl groups"
+  set_root_system_type!(R, cartan_type_with_ordering(cartan_matrix(R))...)
 end
 
 function set_root_system_type!(R::RootSystem, type::Vector{Tuple{Symbol,Int}})

--- a/experimental/LieAlgebras/src/RootSystem.jl
+++ b/experimental/LieAlgebras/src/RootSystem.jl
@@ -635,14 +635,10 @@ function RootSpaceElem(root_system::RootSystem, vec::Vector{<:RationalUnion})
   return RootSpaceElem(root_system, matrix(QQ, 1, length(vec), vec))
 end
 
-function RootSpaceElem(R::RootSystem, w::WeightLatticeElem)
-  @req root_system(w) === R "Root system mismatch"
+function RootSpaceElem(w::WeightLatticeElem)
+  R = root_system(w)
   coeffs = coefficients(w) * cartan_matrix_inv_tr(R)
   return RootSpaceElem(R, matrix(QQ, coeffs))
-end
-
-function RootSpaceElem(w::WeightLatticeElem)
-  return RootSpaceElem(root_system(w), w)
 end
 
 function zero(::Type{RootSpaceElem}, R::RootSystem)
@@ -1048,15 +1044,11 @@ function WeightLatticeElem(R::RootSystem, v::Vector{<:IntegerUnion})
   return WeightLatticeElem(R, matrix(ZZ, 1, rank(R), v))
 end
 
-function WeightLatticeElem(R::RootSystem, r::RootSpaceElem)
-  @req root_system(r) === R "Root system mismatch"
+function WeightLatticeElem(r::RootSpaceElem)
+  R = root_system(r)
   coeffs = coefficients(r) * cartan_matrix_tr(R)
   @req all(is_integer, coeffs) "RootSpaceElem does not correspond to a weight"
   return WeightLatticeElem(R, matrix(ZZ, coeffs))
-end
-
-function WeightLatticeElem(r::RootSpaceElem)
-  return WeightLatticeElem(root_system(r), r)
 end
 
 function zero(::Type{WeightLatticeElem}, R::RootSystem)

--- a/experimental/LieAlgebras/src/Types.jl
+++ b/experimental/LieAlgebras/src/Types.jl
@@ -64,10 +64,10 @@ end
 
 mutable struct WeightLatticeElem
   root_system::RootSystem
-  vec::ZZMatrix # the coordinate (column) vector with respect to the fundamental weights
+  vec::ZZMatrix # the coordinate (row) vector with respect to the fundamental weights
 
   function WeightLatticeElem(root_system::RootSystem, vec::ZZMatrix)
-    @req size(vec) == (rank(root_system), 1) "Invalid dimension"
+    @req size(vec) == (1, rank(root_system)) "Invalid dimension"
     return new(root_system, vec)
   end
 end

--- a/experimental/LieAlgebras/src/Types.jl
+++ b/experimental/LieAlgebras/src/Types.jl
@@ -35,9 +35,7 @@
     )
     R.weyl_group = WeylGroup(finite, refl, R)
 
-    detect_type &&
-      is_finite(weyl_group(R)) &&
-      set_root_system_type!(R, cartan_type_with_ordering(mat)...)
+    detect_type && is_finite(weyl_group(R)) && assure_root_system_type(R)
     return R
   end
 end

--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -92,10 +92,25 @@ function Base.one(W::WeylGroup)
   return W(UInt8[]; normalize=false)
 end
 
+function Base.show(io::IO, mime::MIME"text/plain", W::WeylGroup)
+  @show_name(io, W)
+  @show_special(io, mime, W)
+  io = pretty(io)
+  println(io, LowercaseOff(), "Weyl group")
+  print(io, Indent(), "of ", Lowercase())
+  show(io, mime, root_system(W))
+  print(io, Dedent())
+end
+
 function Base.show(io::IO, W::WeylGroup)
   @show_name(io, W)
   @show_special(io, W)
-  print(pretty(io), LowercaseOff(), "Weyl group for ", Lowercase(), W.root_system)
+  io = pretty(io)
+  if is_terse(io)
+    print(io, LowercaseOff(), "Weyl group")
+  else
+    print(io, LowercaseOff(), "Weyl group of ", Lowercase(), root_system(W))
+  end
 end
 
 function coxeter_matrix(W::WeylGroup)

--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -204,26 +204,26 @@ function Base.:(*)(x::WeylGroupElem, y::WeylGroupElem)
   return p
 end
 
-function Base.:(*)(x::WeylGroupElem, r::RootSpaceElem)
-  @req root_system(parent(x)) === root_system(r) "Incompatible root systems"
+function Base.:(*)(x::WeylGroupElem, rw::Union{RootSpaceElem,WeightLatticeElem})
+  @req root_system(parent(x)) === root_system(rw) "Incompatible root systems"
 
-  r2 = deepcopy(r)
+  rw2 = deepcopy(rw)
   for s in Iterators.reverse(word(x))
-    reflect!(r2, Int(s))
+    reflect!(rw2, Int(s))
   end
 
-  return r2
+  return rw2
 end
 
-function Base.:(*)(x::WeylGroupElem, w::WeightLatticeElem)
-  @req root_system(parent(x)) === root_system(w) "Incompatible root systems"
+function Base.:(*)(rw::Union{RootSpaceElem,WeightLatticeElem}, x::WeylGroupElem)
+  @req root_system(parent(x)) === root_system(rw) "Incompatible root systems"
 
-  w2 = deepcopy(w)
-  for s in Iterators.reverse(word(x))
-    reflect!(w2, Int(s))
+  rw2 = deepcopy(rw)
+  for s in word(x)
+    reflect!(rw2, Int(s))
   end
 
-  return w2
+  return rw2
 end
 
 # to be removed once GroupCore is supported

--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -24,7 +24,9 @@ Returns the Weyl group of the given type. See `cartan_matrix(fam::Symbol, rk::In
 # Examples
 ```jldoctest
 julia> weyl_group(:A, 2)
-Weyl group for root system defined by Cartan matrix [2 -1; -1 2]
+Weyl group
+  of root system of rank 2
+    of type A2
 ```
 """
 function weyl_group(fam::Symbol, rk::Int)

--- a/experimental/LieAlgebras/src/serialization.jl
+++ b/experimental/LieAlgebras/src/serialization.jl
@@ -255,7 +255,7 @@ function save_object(s::SerializerState, R::RootSystem)
     if has_root_system_type(R)
       type, type_ordering = root_system_type_with_ordering(R)
       save_object(s, type, :type)
-      if type_ordering != 1:length(type_ordering) # don't save if it's the default
+      if !issorted(type_ordering) # don't save if it's the default
         save_object(s, type_ordering, :type_ordering)
       end
     end

--- a/experimental/LieAlgebras/test/RootSystem-test.jl
+++ b/experimental/LieAlgebras/test/RootSystem-test.jl
@@ -30,6 +30,10 @@
   end
 
   @testset "property tests" begin
+    Main.equality(a::RootSpaceElem, b::RootSpaceElem) = a == b
+    Main.equality(a::DualRootSpaceElem, b::DualRootSpaceElem) = a == b
+    Main.equality(a::WeightLatticeElem, b::WeightLatticeElem) = a == b
+
     function root_system_property_tests(R::RootSystem, rk::Int, npositive_roots::Int)
       W = weyl_group(R)
 
@@ -136,72 +140,17 @@
         RootSpaceElem, DualRootSpaceElem, WeightLatticeElem
       )
         rk = rank(R)
+        for _ in 1:10
+          a = T(R, rand(-10:10, rk))
+          b = T(R, rand(-10:10, rk))
+          c = T(R, rand(-10:10, rk))
 
-        x1 = T(R, rand(-10:10, rk))
-        x2 = T(R, rand(-10:10, rk))
-        x3 = T(R, rand(-10:10, rk))
-        x1c = deepcopy(x1)
-        x2c = deepcopy(x2)
-        x3c = deepcopy(x3)
+          test_mutating_op_like_zero(zero, zero!, a)
 
-        for (f, f!) in ((zero, zero!),)
-          x1 = f!(x1)
-          @test x1 == f(x1c)
-          x1 = deepcopy(x1c)
-        end
+          test_mutating_op_like_neg(-, neg!, a)
 
-        for (f, f!) in ((-, neg!),)
-          x1 = f!(x1, x2)
-          @test x1 == f(x2c)
-          @test x2 == x2c
-          x1 = deepcopy(x1c)
-          x2 = deepcopy(x2c)
-
-          x1 = f!(x1)
-          @test x1 == f(x1c)
-          x1 = deepcopy(x1c)
-        end
-
-        for (f, f!) in ((+, add!), (-, sub!))
-          x1 = f!(x1, x2, x3)
-          @test x1 == f(x2c, x3c)
-          @test x2 == x2c
-          @test x3 == x3c
-          x1 = deepcopy(x1c)
-          x2 = deepcopy(x2c)
-          x3 = deepcopy(x3c)
-
-          x1 = f!(x1, x1, x2)
-          @test x1 == f(x1c, x2c)
-          @test x2 == x2c
-          x1 = deepcopy(x1c)
-          x2 = deepcopy(x2c)
-
-          x1 = f!(x1, x2, x1)
-          @test x1 == f(x2c, x1c)
-          @test x2 == x2c
-          x1 = deepcopy(x1c)
-          x2 = deepcopy(x2c)
-
-          x1 = f!(x1, x2, x2)
-          @test x1 == f(x2c, x2c)
-          @test x2 == x2c
-          x1 = deepcopy(x1c)
-          x2 = deepcopy(x2c)
-
-          x1 = f!(x1, x1, x1)
-          @test x1 == f(x1c, x1c)
-          x1 = deepcopy(x1c)
-
-          x1 = f!(x1, x2)
-          @test x1 == f(x1c, x2c)
-          @test x2 == x2c
-          x1 = deepcopy(x1c)
-          x2 = deepcopy(x2c)
-
-          x1 = f!(x1, x1)
-          @test x1 == f(x1c, x1c)
-          x1 = deepcopy(x1c)
+          test_mutating_op_like_add(+, add!, a, b)
+          test_mutating_op_like_add(-, sub!, a, b)
         end
       end
 

--- a/experimental/LieAlgebras/test/WeylGroup-test.jl
+++ b/experimental/LieAlgebras/test/WeylGroup-test.jl
@@ -288,9 +288,9 @@ include(
     @test ngens(weyl_group(:F, 4)) == 4
     @test ngens(weyl_group(:G, 2)) == 2
 
-    @test ngens(weyl_group((:A, 2), (:B, 4))) == 6
-    @test ngens(weyl_group((:C, 3), (:E, 7))) == 10
-    @test ngens(weyl_group((:F, 4), (:G, 2))) == 6
+    @test ngens(weyl_group((:A, 2), (:B, 4))) == 2 + 4
+    @test ngens(weyl_group((:C, 3), (:E, 7))) == 3 + 7
+    @test ngens(weyl_group((:F, 4), (:G, 2))) == 4 + 2
   end
 
   @testset "Base.:(*)(x::WeylGroupElem, y::WeylGroupElem)" begin

--- a/experimental/LieAlgebras/test/WeylGroup-test.jl
+++ b/experimental/LieAlgebras/test/WeylGroup-test.jl
@@ -347,18 +347,28 @@ include(
     @test w^-4 == inv(w) * inv(w) * inv(w) * inv(w)
   end
 
-  @testset "Base.:(*)(x::WeylGroupElem, w::RootSpaceElem)" begin
+  @testset "action on RootSpaceElem" begin
     let R = root_system(:A, 2)
       W = weyl_group(R)
 
       a = positive_root(R, n_positive_roots(R)) # highest root
       @test one(W) * a == a
+      @test a * one(W) == a
       @test W([1]) * a == simple_root(R, 2)
+      @test a * W([1]) == simple_root(R, 2)
       @test W([2]) * a == simple_root(R, 1)
+      @test a * W([2]) == simple_root(R, 1)
       @test longest_element(W) * a == -a
+      @test a * longest_element(W) == -a
+      @test W([1, 2]) * a == -simple_root(R, 1)
+      @test a * W([1, 2]) == -simple_root(R, 2)
+      @test W([1, 2]) * a != a * W([1, 2])
 
       a_copy = deepcopy(a)
       b = W([1]) * a
+      @test a != b
+      @test a == a_copy
+      b = a * W([1])
       @test a != b
       @test a == a_copy
       b = reflect(a, 1)
@@ -371,24 +381,42 @@ include(
 
       a = positive_root(R, n_positive_roots(R)) # highest (long) root
       @test one(W) * a == a
+      @test a * one(W) == a
       @test W([1]) * a == a
+      @test a * W([1]) == a
       @test W([2]) * a == simple_root(R, 1)
+      @test a * W([2]) == simple_root(R, 1)
       @test longest_element(W) * a == -a
+      @test a * longest_element(W) == -a
+      @test W([1, 2]) * a == -simple_root(R, 1)
+      @test a * W([1, 2]) == simple_root(R, 1)
+      @test W([1, 2]) * a != a * W([1, 2])
 
       a = simple_root(R, 1)
       @test one(W) * a == a
+      @test a * one(W) == a
       @test W([1]) * a == -a
+      @test a * W([1]) == -a
       @test W([2]) * a == positive_root(R, n_positive_roots(R))
+      @test a * W([2]) == positive_root(R, n_positive_roots(R))
       @test longest_element(W) * a == -a
+      @test a * longest_element(W) == -a
+      @test W([1, 2]) * a == positive_root(R, n_positive_roots(R))
+      @test a * W([1, 2]) == -positive_root(R, n_positive_roots(R))
+      @test W([1, 2]) * a != a * W([1, 2])
     end
   end
 
-  @testset "Base.:(*)(x::WeylGroupElem, w::WeightLatticeElem)" begin
+  @testset "action on WeightLatticeElem" begin
     R = root_system(:A, 2)
     W = weyl_group(R)
 
     rho = weyl_vector(R)
     @test longest_element(W) * rho == -rho
+    @test rho * longest_element(W) == -rho
+
+    x = W([1, 2])
+    @test x * rho != rho * x
   end
 
   @testset "parent(::WeylGroupElem)" begin

--- a/experimental/LieAlgebras/test/setup_tests.jl
+++ b/experimental/LieAlgebras/test/setup_tests.jl
@@ -4,6 +4,14 @@ if !isdefined(Main, :GAPWrap)
   import Oscar: GAPWrap
 end
 
+if !isdefined(Main, :test_mutating_op_like_zero)
+  include(
+    joinpath(
+      pathof(Oscar.Nemo.AbstractAlgebra), "..", "..", "test", "Rings-conformance-tests.jl"
+    ),
+  )
+end
+
 if !isdefined(Main, :lie_algebra_conformance_test) || isinteractive()
   function lie_algebra_conformance_test(
     L::LieAlgebra{C}, parentT::DataType, elemT::DataType; num_random_tests::Int=10


### PR DESCRIPTION
some progress towards https://github.com/oscar-system/Oscar.jl/issues/4263

most important changes:
- coefficient vector of `WeightLatticeElem` is now a row (instead of a column); this is to be consistent with `RootSpaceElem`
- add a right action of Weyl groups on weights and roots
- printing:
  - don't include cartan matrix, do include type (if known) for root systems, Weyl group, and Lie algebras
  - use expressify for `(Dual)RootSpaceElem`