### PR TITLE
Rename `minimal_generating_set` for groups to `minimal_size_generating_set`

### DIFF
--- a/docs/src/Groups/basics.md
+++ b/docs/src/Groups/basics.md
@@ -21,6 +21,7 @@ has_gens(::GAPGroup)
 number_of_generators(G::GAPGroup)
 gen(::GAPGroup, i::Int)
 small_generating_set(G::GAPGroup)
+minimal_size_generating_set(G::GAPGroup)
 Base.rand(G::GAPGroup)
 rand_pseudo(G::GAPGroup)
 ```

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -700,9 +700,6 @@ julia> minimal_size_generating_set(symmetric_group(5))
    return res
 end
 
-# keep the perhaps misleading old name
-minimal_generating_set(G::GAPGroup) = minimal_size_generating_set(G)
-
 
 ################################################################################
 #

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -673,25 +673,25 @@ julia> length(small_generating_set(abelian_group(PermGroup, [2,3,4])))
 end
 
 """
-    minimal_generating_set(G::GAPGroup)
+    minimal_size_generating_set(G::GAPGroup)
 
 Return a vector of minimal length of elements in `G` that generate `G`.
 
 # Examples
 ```jldoctest
-julia> length(minimal_generating_set(abelian_group(SubPcGroup, [2,3,4])))
+julia> length(minimal_size_generating_set(abelian_group(SubPcGroup, [2,3,4])))
 2
 
-julia> length(minimal_generating_set(abelian_group(PermGroup, [2,3,4])))
+julia> length(minimal_size_generating_set(abelian_group(PermGroup, [2,3,4])))
 2
 
-julia> minimal_generating_set(symmetric_group(5))
+julia> minimal_size_generating_set(symmetric_group(5))
 2-element Vector{PermGroupElem}:
  (1,2,3,4,5)
  (1,2)
 ```
 """
-@gapattribute function minimal_generating_set(G::GAPGroup)
+@gapattribute function minimal_size_generating_set(G::GAPGroup)
    L = GAP.Globals.MinimalGeneratingSet(GapObj(G))::GapObj
    res = Vector{elem_type(G)}(undef, length(L))
    for i = 1:length(res)
@@ -699,6 +699,9 @@ julia> minimal_generating_set(symmetric_group(5))
    end
    return res
 end
+
+# keep the perhaps misleading old name
+minimal_generating_set(G::GAPGroup) = minimal_size_generating_set(G)
 
 
 ################################################################################
@@ -1852,7 +1855,7 @@ end
 #  if is_free(G) || (has_is_finite(G) && is_finite(G) && is_pgroup(G))
 #    return GAP.Globals.Rank(GapObj(G))::Int
 #  end
-#  has_is_finite(G) && is_finite(G) && return length(minimal_generating_set(G))
+#  has_is_finite(G) && is_finite(G) && return length(minimal_size_generating_set(G))
 #  error("not yet supported")
 #end
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -143,3 +143,7 @@ Base.@deprecate_binding in_linear_system is_in_linear_system
 @deprecate scheme(W::AbsAlgebraicCycle) ambient_scheme(W)
 @deprecate scheme(W::CartierDivisor) ambient_scheme(W)
 @deprecate scheme(W::EffectiveCartierDivisor) ambient_scheme(W)
+
+@deprecate minimal_generating_set(G::GAPGroup) minimal_size_generating_set(G)
+@deprecate has_minimal_generating_set(G::GAPGroup) has_minimal_size_generating_set(G)
+@deprecate set_minimal_generating_set(G::GAPGroup, v) set_minimal_size_generating_set(G, v)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1054,7 +1054,8 @@ export min_weights
 export minimal_betti_table
 export minimal_block_reps
 export minimal_faces
-export minimal_generating_set, has_minimal_generating_set, set_minimal_generating_set
+export minimal_generating_set
+export minimal_size_generating_set, has_minimal_size_generating_set, set_minimal_size_generating_set
 export minimal_nonfaces
 export minimal_normal_subgroups, has_minimal_normal_subgroups, set_minimal_normal_subgroups
 export minimal_primes


### PR DESCRIPTION
and
- document `minimal_size_generating_set` for groups (`minimal_generating_set` was not documented for groups),
- keep the function `minimal_generating_set` for groups (backwards compatibility)

resolves #4181