### PR TITLE
Speed up `stabilizer` methods for the natural action of permutation groups, and the actions on sets, tuples, and vectors of pos. integers

### DIFF
--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -346,6 +346,7 @@ GAP.@wrap SizesCentralizers(x::GapObj)::GapObj
 GAP.@wrap SizesConjugacyClasses(x::GapObj)::GapObj
 GAP.@wrap Source(x::GapObj)::GapObj
 GAP.@wrap Sqrt(x::Int64)::GAP.Obj
+GAP.@wrap Stabilizer(x::GapObj, y::Any, z::GapObj)::GapObj
 GAP.@wrap Stabilizer(v::GapObj, w::Any, x::GapObj, y::GapObj, z::GapObj)::GapObj
 GAP.@wrap StringViewObj(x::Any)::GapObj
 GAP.@wrap StructureConstantsTable(x::GapObj)::GapObj

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -501,7 +501,7 @@ function stabilizer(G::PermGroup, pnt::T) where T <: Oscar.IntegerUnion
         GAP.Globals.OnPoints))  # Do not use GAPWrap.OnPoints!
 end
 
-function stabilizer(G::PermGroup, pnt::Union{Vector{T}, Tuple{Vararg{T}}}) where T <: Oscar.IntegerUnion
+function stabilizer(G::PermGroup, pnt::Union{Vector{T}, Tuple{T, Vararg{T}}}) where T <: Oscar.IntegerUnion
     return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
         GapObj(pnt, recursive = true),
         GAP.Globals.OnTuples))  # Do not use GAPWrap.OnTuples!

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -493,11 +493,25 @@ function stabilizer(G::GAPGroup, pnt::Any, actfun::Function)
 end
 
 # natural stabilizers in permutation groups
-stabilizer(G::PermGroup, pnt::T) where T <: Oscar.IntegerUnion = stabilizer(G, pnt, ^)
+# Construct the arguments on the GAP side such that GAP's method selection
+# can choose the special method.
+function stabilizer(G::PermGroup, pnt::T) where T <: Oscar.IntegerUnion
+    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+        GapObj(pnt),
+        GAP.Globals.OnPoints))  # Do not use GAPWrap.OnPoints!
+end
 
-stabilizer(G::PermGroup, pnt::Vector{T}) where T <: Oscar.IntegerUnion = stabilizer(G, pnt, on_tuples)
+function stabilizer(G::PermGroup, pnt::Union{Vector{T}, Tuple{Vararg{T}}}) where T <: Oscar.IntegerUnion
+    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+        GapObj(pnt, recursive = true),
+        GAP.Globals.OnTuples))  # Do not use GAPWrap.OnTuples!
+end
 
-stabilizer(G::PermGroup, pnt::AbstractSet{T}) where T <: Oscar.IntegerUnion = stabilizer(G, pnt, on_sets)
+function stabilizer(G::PermGroup, pnt::AbstractSet{T}) where T <: Oscar.IntegerUnion
+    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+        GapObj(pnt, recursive = true),
+        GAP.Globals.OnSets))  # Do not use GAPWrap.OnSets!
+end
 
 # natural stabilizers in matrix groups
 stabilizer(G::MatrixGroup{ET,MT}, pnt::AbstractAlgebra.Generic.FreeModuleElem{ET}) where {ET,MT} = stabilizer(G, pnt, *)

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -452,7 +452,7 @@ julia> map(length, orbs)
     stabilizer(Omega::GSet{T,S}, omega::S = representative(Omega); check::Bool = true) where {T,S}
     stabilizer(Omega::GSet{T,S}, omega::Set{S}; check::Bool = true) where {T,S}
     stabilizer(Omega::GSet{T,S}, omega::Vector{S}; check::Bool = true) where {T,S}
-    stabilizer(Omega::GSet{T,S}, omega::Tuple{Vararg{S}}; check::Bool = true) where {T,S}
+    stabilizer(Omega::GSet{T,S}, omega::Tuple{S,Vararg{S}}; check::Bool = true) where {T,S}
 
 Return the subgroup of `G = acting_group(Omega)` that fixes `omega`,
 together with the embedding of this subgroup into `G`.
@@ -515,7 +515,7 @@ function stabilizer(Omega::GSet{T,S}, omega::Vector{S}; check::Bool = true) wher
     return stabilizer(G, omega, derived_fun)
 end
 
-function stabilizer(Omega::GSet{T,S}, omega::Tuple{Vararg{S}}; check::Bool = true) where {T,S}
+function stabilizer(Omega::GSet{T,S}, omega::Tuple{S,Vararg{S}}; check::Bool = true) where {T,S}
     check && @req all(in(Omega), omega) "omega must be a tuple of elements of Omega"
     G = acting_group(Omega)
     gfun = action_function(Omega)
@@ -525,7 +525,7 @@ end
 
 # Construct the arguments on the GAP side such that GAP's method selection
 # can choose the special method.
-function stabilizer(Omega::GSet{PermGroup,S}, omega::Union{Set{S}, Tuple{Vararg{S}}, Vector{S}}; check::Bool = true) where S <: Oscar.IntegerUnion
+function stabilizer(Omega::GSet{PermGroup,S}, omega::Union{Set{S}, Tuple{S,Vararg{S}}, Vector{S}}; check::Bool = true) where S <: Oscar.IntegerUnion
     check && @req all(in(Omega), omega) "omega must be a set of elements of Omega"
     return stabilizer(acting_group(Omega), omega)
 end

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -486,6 +486,13 @@ function stabilizer(Omega::GSet{T,S}, omega::S; check::Bool = true) where {T,S}
     return stabilizer(G, omega, gfun)
 end
 
+# Construct the arguments on the GAP side such that GAP's method selection
+# can choose the special method.
+function stabilizer(Omega::GSet{PermGroup,S}, omega::S; check::Bool = true) where S <: Oscar.IntegerUnion
+    check && @req omega in Omega "omega must be an element of Omega"
+    return stabilizer(acting_group(Omega), omega)
+end
+
 # support `stabilizer` under "derived" actions:
 # If the given point is a set of the element type of the G-set
 # then compute the setwise stabilizer.
@@ -515,6 +522,14 @@ function stabilizer(Omega::GSet{T,S}, omega::Tuple{Vararg{S}}; check::Bool = tru
     derived_fun = function(x, g) return Tuple([gfun(y, g) for y in x]); end
     return stabilizer(G, omega, derived_fun)
 end
+
+# Construct the arguments on the GAP side such that GAP's method selection
+# can choose the special method.
+function stabilizer(Omega::GSet{PermGroup,S}, omega::Union{Set{S}, Tuple{Vararg{S}}, Vector{S}}; check::Bool = true) where S <: Oscar.IntegerUnion
+    check && @req all(in(Omega), omega) "omega must be a set of elements of Omega"
+    return stabilizer(acting_group(Omega), omega)
+end
+
 
 #############################################################################
 ##

--- a/test/Groups/action.jl
+++ b/test/Groups/action.jl
@@ -29,6 +29,14 @@
   @test order(H) == 645120
   @test K == stabilizer(H, 1)[1]
 
+  # larger examples
+  G = symmetric_group(100)
+  S1, _ = stabilizer(G, [1, 2, 3, 4, 5])
+  @test order(S1) == factorial(big(95))
+  S2, _ = stabilizer(G, (1, 2, 3, 4, 5))
+  @test S2 == S1
+  S3, _ = stabilizer(G, Set([1, 2, 3, 4, 5]))
+  @test order(S3) == order(S1) * factorial(5)
 end
 
 @testset "natural stabilizers in matrix groups" begin

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -54,7 +54,18 @@
   @test ! is_regular(Omega)
   @test ! is_semiregular(Omega)
 
+  # larger examples
+  G = symmetric_group(100)
+  Omega = gset(G)
+  S1, _ = stabilizer(Omega, [1, 2, 3, 4, 5])
+  @test order(S1) == factorial(big(95))
+  S2, _ = stabilizer(Omega, (1, 2, 3, 4, 5))
+  @test S2 == S1
+  S3, _ = stabilizer(Omega, Set([1, 2, 3, 4, 5]))
+  @test order(S3) == order(S1) * factorial(big(5))
+
   # constructions by explicit action functions
+  G = symmetric_group(6)
   omega = [0,1,0,1,0,1]
   Omega = gset(G, permuted, [omega, [1,2,3,4,5,6]])
   @test isa(Omega, GSet)


### PR DESCRIPTION
change the code such that the special GAP methods are used for the natural action of permutation groups,
and the actions on sets, tuples, and vectors of pos. integers