### PR TITLE
changes to the `check` argument in `matroid_from_matrix_columns`

### DIFF
--- a/src/Combinatorics/Matroids/matroids.jl
+++ b/src/Combinatorics/Matroids/matroids.jl
@@ -278,9 +278,9 @@ function matroid_from_hyperplanes(hyperplanes::Union{AbstractVector{T},AbstractS
 end
 
 @doc raw"""
-    matroid_from_matrix_columns(A::MatrixElem)
+    matroid_from_matrix_columns(A::MatrixElem; check::Bool=true)
 
-A matroid represented by the column vectors of a matrix `A`.
+A matroid represented by the column vectors of a matrix `A`. The value of `check` is currently ignored.
 
 See Section 1.1 of [Oxl11](@cite).
 
@@ -310,13 +310,13 @@ function matroid_from_matrix_columns(A::MatrixElem; check::Bool=true)
         end
     end
 
-    return matroid_from_bases(bases, ncols(A); check=check)
+    return matroid_from_bases(bases, ncols(A); check=false)
 end
 
 @doc raw"""
-    matroid_from_matrix_columns(A::MatrixElem)
+    matroid_from_matrix_rows(A::MatrixElem, check::Bool=true)
 
-A matroid represented by the row vectors of a matrix.
+A matroid represented by the row vectors of a matrix. The value of `check` is currently ignored.
 
 See Section 1.1 of [Oxl11](@cite).
 


### PR DESCRIPTION
I added documentation for the matroid_from_matrix_columns check flag.

Internally i removed the default behaviour of the function to check the selected set of bases if they satisfy the bases axioms. Now it simply never checks the arguments, as I believe they are fulfilled by construction.

The current implementation makes this function unusable for larger matrices. Especially since the check flag isn't documented.

@benlorenz  suggested keeping the check argument for consistency, even though it's not used. 

This was an issue raised by @dcorey2814.
