### PR TITLE
Patch search index

### DIFF
--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -165,6 +165,8 @@ function start_doc_preview_server(;open_browser::Bool = true, port::Int = 8000)
   return nothing
 end
 
+using JSON
+
 @doc raw"""
     build_doc(; doctest=false, warnonly=true, open_browser=true, start_server=false)
 
@@ -239,6 +241,42 @@ function build_doc(; doctest::Union{Symbol, Bool} = false, warnonly = true, open
   if doctest != false && !versioncheck
     @warn versionwarn
   end
+  docspath = normpath(joinpath(Oscar.oscardir, "docs"))
+  @info "Patching search index."
+  # postprocessing, for the search index
+  # extract valid json from search_index.js
+  run(pipeline(`sed -n '2p;3q' $(joinpath(docspath, "build", "search_index.js"))`, stdout=(joinpath(docspath, "build", "search_index.json")))) # imperfect file, but JSON parses it
+  
+  # extract paths from doc.main
+  run(pipeline(pipeline(`cat $(joinpath(docspath, "doc.main"))`, `grep ".md"`, `sed "s/^.*=>//"`, `sed 's/^\s*"//'`, `sed 's/..$//'`, `sed 's/.md/.html/'`), stdout=joinpath(docspath, "filelist.txt")))
+    
+  # read these files
+  iosearchindex = open(joinpath(docspath, "build", "search_index.json"), "r")
+  searchindex = JSON.parse(iosearchindex)
+  close(iosearchindex)
+  iofilelist = open(joinpath(docspath, "filelist.txt"))
+  filelist = readlines(iofilelist)
+  close(iofilelist)
+  
+  newsearchindex = []
+  
+  for item in searchindex
+    if split(item["location"], "#")[1] in filelist
+      push!(newsearchindex, item)
+    end
+  end
+  
+  
+  # combine this to valid javascript again, and overwrite input
+  ionewsearchindex = open(joinpath(docspath, "build", "search_index.js"), "w")
+  write(ionewsearchindex, """var documenterSearchIndex = {"docs":\n""")
+  JSON.print(ionewsearchindex, newsearchindex)
+  write(ionewsearchindex, "\n}")
+  close(ionewsearchindex)
+
+  # clean up
+  rm(joinpath(docspath, "filelist.txt"))
+  rm(joinpath(docspath, "build", "search_index.json"))
 end
 
 # Create symbolic links from any documentation directory in `experimental` into


### PR DESCRIPTION
This removes anything in search index that is not also present in doc.main. That is, the search function will not return "hidden" pages, which are not available via normal navigation. This was easier than trying to make Documenter make a nice search index to begin with which needed more digging into ( https://github.com/JuliaDocs/Documenter.jl/pull/2517 )

Address @lgoettgens comment from #3816 :
> Can you maybe just disable all results from files that are not contained in the doc.main file, i.e. the list of files reachable via the menu?