### PR TITLE
Patch search index

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,9 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
 Documenter = "1.1"
 DocumenterCitations = "~1.3.4"
+JSON = "0.21.4"

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -218,15 +218,29 @@ function doit(
   run(pipeline(`sed -n '2p;3q' $(joinpath(docspath, "build", "search_index.js"))`, stdout=(joinpath(docspath, "build", "search_index.json")))) # imperfect file, but JSON parses it
   
   # extract paths from doc.main
-  run(pipeline(pipeline(`cat $(joinpath(docspath, "doc.main"))`, `grep ".md"`, `sed "s/^.*=>//"`, `sed 's/^\s*"//'`, `sed 's/..$//'`, `sed 's/.md/.html/'`), stdout=joinpath(docspath, "filelist.txt")))
-    
+  filelist=String[]
+  docmain = include(joinpath(docspath, "doc.main"))
+  while !isempty(docmain)
+    n = pop!(docmain)
+    if n isa Pair
+      push!(docmain, last(n))
+    elseif n isa String
+      push!(filelist, n)
+    elseif n isa Array{String}
+      append!(filelist,n)
+    elseif n isa Array
+      append!(docmain,n)
+    else
+      error("err: $(typeof(n))")
+    end
+  end
+  suffix = local_build ? ".html" : "/"
+  filelist = replace.(filelist, r"\.md$"=>suffix)
+
   # read these files
   iosearchindex = open(joinpath(docspath, "build", "search_index.json"), "r")
   searchindex = JSON.parse(iosearchindex)
   close(iosearchindex)
-  iofilelist = open(joinpath(docspath, "filelist.txt"))
-  filelist = readlines(iofilelist)
-  close(iofilelist)
   
   newsearchindex = []
   
@@ -245,7 +259,6 @@ function doit(
   close(ionewsearchindex)
 
   # clean up
-  rm(joinpath(docspath, "filelist.txt"))
   rm(joinpath(docspath, "build", "search_index.json"))
 end
 

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -4,7 +4,7 @@
 #
 module BuildDoc
 
-using Documenter, DocumenterCitations
+using Documenter, DocumenterCitations, JSON
 
 include("documenter_helpers.jl")
 include("citation_style.jl")
@@ -210,6 +210,43 @@ function doit(
     dstbase = normpath(Oscar.oscardir, "docs", "src", string(nameof(pkg)))
     rm(dstbase; recursive=true, force=true)
   end
+  
+  # postprocessing, for the search index
+  docspath = normpath(joinpath(Oscar.oscardir, "docs"))
+  @info "Patching search index."
+  # extract valid json from search_index.js
+  run(pipeline(`sed -n '2p;3q' $(joinpath(docspath, "build", "search_index.js"))`, stdout=(joinpath(docspath, "build", "search_index.json")))) # imperfect file, but JSON parses it
+  
+  # extract paths from doc.main
+  run(pipeline(pipeline(`cat $(joinpath(docspath, "doc.main"))`, `grep ".md"`, `sed "s/^.*=>//"`, `sed 's/^\s*"//'`, `sed 's/..$//'`, `sed 's/.md/.html/'`), stdout=joinpath(docspath, "filelist.txt")))
+    
+  # read these files
+  iosearchindex = open(joinpath(docspath, "build", "search_index.json"), "r")
+  searchindex = JSON.parse(iosearchindex)
+  close(iosearchindex)
+  iofilelist = open(joinpath(docspath, "filelist.txt"))
+  filelist = readlines(iofilelist)
+  close(iofilelist)
+  
+  newsearchindex = []
+  
+  for item in searchindex
+    if split(item["location"], "#")[1] in filelist
+      push!(newsearchindex, item)
+    end
+  end
+  
+  
+  # combine this to valid javascript again, and overwrite input
+  ionewsearchindex = open(joinpath(docspath, "build", "search_index.js"), "w")
+  write(ionewsearchindex, """var documenterSearchIndex = {"docs":\n""")
+  JSON.print(ionewsearchindex, newsearchindex)
+  write(ionewsearchindex, "\n}")
+  close(ionewsearchindex)
+
+  # clean up
+  rm(joinpath(docspath, "filelist.txt"))
+  rm(joinpath(docspath, "build", "search_index.json"))
 end
 
 end # module BuildDoc

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -165,6 +165,8 @@ function start_doc_preview_server(;open_browser::Bool = true, port::Int = 8000)
   return nothing
 end
 
+using JSON
+
 @doc raw"""
     build_doc(; doctest=false, warnonly=true, open_browser=true, start_server=false)
 
@@ -239,6 +241,42 @@ function build_doc(; doctest::Union{Symbol, Bool} = false, warnonly = true, open
   if doctest != false && !versioncheck
     @warn versionwarn
   end
+  docspath = normpath(joinpath(Oscar.oscardir, "docs"))
+  @info "Patching search index."
+  # postprocessing, for the search index
+  # extract valid json from search_index.js
+  run(pipeline(`sed -n '2p;3q' $(joinpath(docspath, "build", "search_index.js"))`, stdout=(joinpath(docspath, "build", "search_index.json")))) # imperfect file, but JSON parses it
+  
+  # extract paths from doc.main
+  run(pipeline(pipeline(`cat $(joinpath(docspath, "doc.main"))`, `grep ".md"`, `sed "s/^.*=>//"`, `sed 's/^\s*"//'`, `sed 's/..$//'`, `sed 's/.md/.html/'`), stdout=joinpath(docspath, "filelist.txt")))
+    
+  # read these files
+  iosearchindex = open(joinpath(docspath, "build", "search_index.json"), "r")
+  searchindex = JSON.parse(iosearchindex)
+  close(iosearchindex)
+  iofilelist = open(joinpath(docspath, "filelist.txt"))
+  filelist = readlines(iofilelist)
+  close(iofilelist)
+  
+  newsearchindex = []
+  
+  for item in searchindex
+    if split(item["location"], "#")[1] in filelist
+      push!(newsearchindex, item)
+    end
+  end
+  
+  
+  # combine this to valid javascript again, and overwrite input
+  ionewsearchindex = open(joinpath(docspath, "build", "search_index.js"), "w")
+  write(ionewsearchindex, """var documenterSearchIndex = {"docs":\n""")
+  JSON.print(ionewsearchindex, newsearchindex)
+  write(ionewsearchindex, "\n}")
+  close(ionewsearchindex)
+
+  # clean up
+  rm(joinpath(docspath, "filelist.txt"))
+  rm(joinpath(docspath, "build", "search_index.json"))
 end
 
 # Create symbolic links from any documentation directory in `experimental` into


### PR DESCRIPTION
This removes anything in search index that is not also present in doc.main. That is, the search function will not return "hidden" pages, which are not available via normal navigation. This was easier than trying to make Documenter make a nice search index to begin with which needed more digging into ( https://github.com/JuliaDocs/Documenter.jl/pull/2517 )

Address @lgoettgens comment from #3816 :
> Can you maybe just disable all results from files that are not contained in the doc.main file, i.e. the list of files reachable via the menu?

Replaces #4290 