### PR TITLE
Fix leading zero bug in `matroid_hex`

### DIFF
--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1059,11 +1059,9 @@ julia> matroid_hex(fano_matroid())
 function matroid_hex(M::Matroid)
   rvlx = min_revlex_basis_encoding(M)
   r,n = rank(M), length(M) 
+  v = zeros(Int, 4*ceil(Int, length(rvlx)/4))
+  v[length(v)-length(rvlx)+1:end] = _revlex_basis_to_vector(rvlx)
 
-  v = _revlex_basis_to_vector(rvlx)
-  for _ in 1:(4-length(v)%4)
-    pushfirst!(v,0)
-  end
   v = reshape(v,4,:)
   v = [string(parse(Int, join(v[:, j]), base=2), base=16) for j in 1:size(v)[2]]
 

--- a/test/Combinatorics/Matroids/Matroids.jl
+++ b/test/Combinatorics/Matroids/Matroids.jl
@@ -422,10 +422,17 @@
   @testset "matroid_hex" begin
     M = fano_matroid() 
     N = uniform_matroid(2, 4)
+    NN = uniform_matroid(1, 4)
 
     M1 = matroid_from_matroid_hex(matroid_hex(M)) 
     N1 = matroid_from_matroid_hex(matroid_hex(N))
+    NN1 = matroid_from_matroid_hex(matroid_hex(NN))
+
     @test is_isomorphic(M, M1)
     @test is_isomorphic(N, N1)
+
+    @test matroid_hex(NN) == "r1n4_f"
+    @test is_isomorphic(NN, NN1)
+
   end
 end


### PR DESCRIPTION
Fixed the bug that

matroid_hex(uniform_matroid(1,4)) == "r1n4_0f"`.

instead of 

matroid_hex(uniform_matroid(1,4)) == "r1n4_f"`.

This does not change the functionality of matroid_hex, but saves memory.