### PR TITLE
Speed up orbits of permutation groups on integers

### DIFF
--- a/examples/GSets_timing.jl
+++ b/examples/GSets_timing.jl
@@ -5,7 +5,7 @@
   G = symmetric_group(10)
 
   Omega = gset(G)
-  # @benchmark order(stabilizer(Omega, 1)[1])
+  @benchmark order(stabilizer(Omega, 1)[1])
   @benchmark order(stabilizer(Omega, Set([1, 2]))[1])
   @benchmark order(stabilizer(Omega, [1, 2])[1])
   @benchmark order(stabilizer(Omega, (1, 2))[1])

--- a/examples/GSets_timing.jl
+++ b/examples/GSets_timing.jl
@@ -1,0 +1,42 @@
+# "G-sets of permutation groups"
+
+
+  # natural constructions (determined by the types of the seeds)
+  G = symmetric_group(10)
+
+  Omega = gset(G)
+  # @benchmark order(stabilizer(Omega, 1)[1])
+  @benchmark order(stabilizer(Omega, Set([1, 2]))[1])
+  @benchmark order(stabilizer(Omega, [1, 2])[1])
+  @benchmark order(stabilizer(Omega, (1, 2))[1])
+
+  Omega = gset(G, [Set([1, 2])])  # action on unordered pairs
+  @benchmark order(stabilizer(Omega, Set([1, 2]))[1])
+  @benchmark order(stabilizer(Omega, Set([Set([1, 2]), Set([1, 3])]))[1])
+  @benchmark order(stabilizer(Omega, [Set([1, 2]), Set([1, 3])])[1])
+  @benchmark order(stabilizer(Omega, (Set([1, 2]), Set([1, 3])))[1])
+
+
+  Omega = gset(G, [[1, 2]])  # action on ordered pairs
+  @benchmark order(stabilizer(Omega, [1, 2])[1])
+  @benchmark order(stabilizer(Omega, Set([[1, 2], [1, 3]]))[1])
+  @benchmark order(stabilizer(Omega, [[1, 2], [1, 3]])[1])
+  @benchmark order(stabilizer(Omega, ([1, 2], [1, 3]))[1])
+
+
+  Omega = gset(G, [(1, 2)])  # action on ordered pairs (repres. by tuples)
+  @benchmark order(stabilizer(Omega, (1, 2))[1])
+  @benchmark order(stabilizer(Omega, Set([(1, 2), (1, 3)]))[1])
+  @benchmark order(stabilizer(Omega, [(1, 2), (1, 3)])[1])
+  @benchmark order(stabilizer(Omega, ((1, 2), (1, 3)))[1])
+
+
+  # constructions by explicit action functions
+  G = symmetric_group(6)
+  omega = [0,1,0,1,0,1]
+  Omega = gset(G, permuted, [omega, [1,2,3,4,5,6]])
+
+  @benchmark order(stabilizer(Omega, omega)[1])
+  @benchmark order(stabilizer(Omega, Set([omega, [1,0,0,1,0,1]]))[1])
+  @benchmark order(stabilizer(Omega, [omega, [1,0,0,1,0,1]])[1])
+  @benchmark order(stabilizer(Omega, (omega, [1,0,0,1,0,1]))[1])

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -332,6 +332,17 @@ orbit(G::GAPGroup, omega) = gset_by_type(G, [omega], typeof(omega))
 
 orbit(G::Union{GAPGroup, FinGenAbGroup}, fun::Function, omega) = GSetByElements(G, fun, [omega])
 
+# common code
+function gap_action_function(Omega::GSet)
+  f = action_function(Omega)
+  (f == ^) && return GAP.Globals.OnPoints
+  # f == on_tuples && return GAP.Globals.OnTuples
+  # f == on_sets && return GAP.Globals.OnSets
+  # etc.
+  return GapObj(f) # generic fallback
+end
+
+
 """
     orbit(Omega::GSet, omega)
 
@@ -351,8 +362,9 @@ julia> length(orbit(Omega, 1))
 """
 function orbit(Omega::GSetByElements{<:GAPGroup, S}, omega::S) where S
     G = acting_group(Omega)
-    acts = GapObj(gens(G))
-    gfun = GapObj(action_function(Omega))
+    acts = GapObj(gens(G); recursive=true)
+    gfun = gap_action_function(Omega)
+    # gfun = GapObj(action_function(Omega))
 
     # The following works only because GAP does not check
     # whether the given (dummy) group 'GapObj(G)' fits to the given generators,

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -332,7 +332,7 @@ orbit(G::GAPGroup, omega) = gset_by_type(G, [omega], typeof(omega))
 
 orbit(G::Union{GAPGroup, FinGenAbGroup}, fun::Function, omega) = GSetByElements(G, fun, [omega])
 
-# common code
+
 function gap_action_function(Omega::GSet)
   f = action_function(Omega)
   (f == ^) && return GAP.Globals.OnPoints

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -336,8 +336,8 @@ orbit(G::Union{GAPGroup, FinGenAbGroup}, fun::Function, omega) = GSetByElements(
 function gap_action_function(Omega::GSet)
   f = action_function(Omega)
   (f == ^) && return GAP.Globals.OnPoints
-  # f == on_tuples && return GAP.Globals.OnTuples
-  # f == on_sets && return GAP.Globals.OnSets
+  f == on_tuples && return GAP.Globals.OnTuples
+  f == on_sets && return GAP.Globals.OnSets
   # etc.
   return GapObj(f) # generic fallback
 end
@@ -364,7 +364,6 @@ function orbit(Omega::GSetByElements{<:GAPGroup, S}, omega::S) where S
     G = acting_group(Omega)
     acts = GapObj(gens(G); recursive=true)
     gfun = gap_action_function(Omega)
-    # gfun = GapObj(action_function(Omega))
 
     # The following works only because GAP does not check
     # whether the given (dummy) group 'GapObj(G)' fits to the given generators,

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -361,9 +361,11 @@ julia> length(orbit(Omega, 1))
 ```
 """
 function orbit(Omega::GSetByElements{<:GAPGroup, S}, omega::S) where S
+    # In this generic function, we delegate the loop to GAP, but we act
+    # with Julia group elements on Julia objects via Julia functions.
     G = acting_group(Omega)
     acts = GapObj(gens(G))
-    gfun = gap_action_function(Omega)
+    gfun = GapObj(action_function(Omega))
 
     # The following works only because GAP does not check
     # whether the given (dummy) group 'GapObj(G)' fits to the given generators,
@@ -377,7 +379,8 @@ function orbit(Omega::GSetByElements{<:GAPGroup, S}, omega::S) where S
 end
 #T check whether omega lies in Omega?
 
-# special cases where we convert the objects to GAP,
+# special cases where we convert the objects to GAP
+# (the group elements as well as the objects they act on),
 # in order to use better methods on the GAP side:
 # - orbit of a perm. group on integers
 # - orbit of a perm. group on vectors of integers

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -360,7 +360,9 @@ julia> length(orbit(Omega, 1))
 4
 ```
 """
-function orbit(Omega::GSetByElements{<:GAPGroup, S}, omega::S) where S
+orbit(Omega::GSetByElements{<:GAPGroup, S}, omega::S) where S = _orbit_generic(Omega, omega)
+
+function _orbit_generic(Omega::GSetByElements{<:GAPGroup, S}, omega::S) where S
     # In this generic function, we delegate the loop to GAP, but we act
     # with Julia group elements on Julia objects via Julia functions.
     G = acting_group(Omega)
@@ -382,10 +384,25 @@ end
 # special cases where we convert the objects to GAP
 # (the group elements as well as the objects they act on),
 # in order to use better methods on the GAP side:
-# - orbit of a perm. group on integers
-# - orbit of a perm. group on vectors of integers
-# - orbit of a perm. group on sets of integers
-function orbit(Omega::GSetByElements{PermGroup, S}, omega::S) where S <: Union{IntegerUnion, Vector{<: IntegerUnion}, Set{<: IntegerUnion}}
+# - orbit of a perm. group on integers via `^`
+# - orbit of a perm. group on vectors of integers via `on_tuples`
+# - orbit of a perm. group on sets of integers via `on_sets`
+function orbit(Omega::GSetByElements{PermGroup, S}, omega::S) where S <: IntegerUnion
+    (action_function(Omega) == ^) || return _orbit_generic(Omega, omega)
+    return _orbit_special_GAP(Omega, omega)
+end
+
+function orbit(Omega::GSetByElements{PermGroup, S}, omega::S) where S <: Vector{<: IntegerUnion}
+    action_function(Omega) == on_tuples || return _orbit_generic(Omega, omega)
+    return _orbit_special_GAP(Omega, omega)
+end
+
+function orbit(Omega::GSetByElements{PermGroup, S}, omega::S) where S <: Set{<: IntegerUnion}
+    action_function(Omega) == on_sets || return _orbit_generic(Omega, omega)
+    return _orbit_special_GAP(Omega, omega)
+end
+
+function _orbit_special_GAP(Omega::GSetByElements{<:GAPGroup, S}, omega::S) where S
     G = acting_group(Omega)
     gfun = gap_action_function(Omega)
     orb = Vector{S}(GAP.Globals.Orbit(GapObj(G), GapObj(omega), gfun)::GapObj)

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -366,12 +366,12 @@ end
   orb = orbit(G, f)
   @test length(orb) == 3
 
-
-  e = one(QQBar)
+  F = QQBarField()
+  e = one(F)
   s, c = sincospi(2 * e / 3)
   mat_rot = matrix([c -s; s c])
   G = matrix_group(mat_rot)
-  p = QQBar.([1, 0])
+  p = F.([1, 0])
   orb = orbit(G, *, p)
   @test length(orb) == 3
 

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -367,13 +367,13 @@ end
   @test length(orb) == 3
 
 
-  K = algebraic_closure(QQ)
-  e = one(K)
+  e = one(QQBar)
   s, c = sincospi(2 * e / 3)
   mat_rot = matrix([c -s; s c])
   G = matrix_group(mat_rot)
-  p = K.([1, 0])
+  p = QQBar.([1, 0])
   orb = orbit(G, *, p)
+  @test length(orb) == 3
 
 
 end

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -365,6 +365,17 @@ end
   f = x^2 + y
   orb = orbit(G, f)
   @test length(orb) == 3
+
+
+  K = algebraic_closure(QQ)
+  e = one(K)
+  s, c = sincospi(2 * e / 3)
+  mat_rot = matrix([c -s; s c])
+  G = matrix_group(mat_rot)
+  p = K.([1, 0])
+  orb = orbit(G, *, p)
+
+
 end
 
 @testset "G-sets by right transversals" begin


### PR DESCRIPTION
This aims to address issue #3287 by letting GAP know when we are in certain special cases which have optimized GAP methods for computing orbits.

Computing the orbit of a single point seems to still be slower than calling GAP directly by about a factor of 2, but this is a big improvement to the previous case (where it was about a 6x slowdown).