### PR TITLE
bib: add a bunch of DOIs, minor corrections

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -34,7 +34,7 @@
   number        = {1},
   pages         = {3--24},
   year          = {2010},
-  eprint        = {0810.1148}
+  doi           = {10.1070/SM2010v201n01ABEH004063}
 }
 
 @InProceedings{AGK96,
@@ -155,6 +155,7 @@
   booktitle     = {MEGA 2019 - International Conference on Effective Methods in Algebraic Geometry},
   address       = {Madrid, Spain},
   year          = {2019},
+  doi           = {10.1016/j.jsc.2020.07.007},
   archiveprefix = {HAL},
   eprint        = {hal-02912148}
 }
@@ -206,13 +207,17 @@
   location      = {Virtual Event, Russian Federation}
 }
 
-@Misc{BES19,
+@Article{BES23,
   author        = {Backman, Spencer and Eur, Christopher and Simpson, Connor},
   title         = {Simplicial generation of Chow rings of matroids},
-  year          = {2019},
-  eprint        = {1905.07114},
-  archiveprefix = {arXiv},
-  primaryclass  = {math.CO}
+  journal       = {JEMS},
+  fjournal      = {Journal of the European Mathematical Society},
+  volume        = {26},
+  number        = {11},
+  pages         = {4491--4535},
+  year          = {2023},
+  month         = jun,
+  doi           = {10.4171/jems/1350}
 }
 
 @Book{BGV03,
@@ -249,13 +254,15 @@
   doi           = {10.1017/fms.2023.50}
 }
 
-@Misc{BHMPW20,
+@Article{BHMPW22,
   author        = {Braden, Tom and Huh, June and Matherne, Jacob P. and Proudfoot, Nicholas and Wang, Botong},
   title         = {A semi-small decomposition of the Chow ring of a matroid},
-  year          = {2020},
-  eprint        = {2002.03341},
-  archiveprefix = {arXiv},
-  primaryclass  = {math.AG}
+  journal       = {Advances in Mathematics},
+  volume        = {409},
+  pages         = {108646},
+  year          = {2022},
+  month         = nov,
+  doi           = {10.1016/j.aim.2022.108646}
 }
 
 @Book{BHPV-D-V04,
@@ -267,6 +274,7 @@
   publisher     = {Berlin: Springer},
   edition       = {2nd enlarged ed.},
   year          = {2004},
+  doi           = {10.1007/978-3-642-57739-0},
   fseries       = {Ergebnisse der Mathematik und ihrer Grenzgebiete. 3. Folge},
   language      = {English},
   zbmath        = {2008523}
@@ -386,7 +394,8 @@
   volume        = {190},
   address       = {Cambridge},
   publisher     = {Cambridge University Press},
-  year          = {1993}
+  year          = {1993},
+  doi           = {10.1017/CBO9780511565809}
 }
 
 @MastersThesis{Bhm99,
@@ -431,14 +440,15 @@
   doi           = {10.1112/S0025579300011773}
 }
 
-@Book{Bur55,
+@Book{Bur11,
   author        = {Burnside, W.},
   title         = {Theory of groups of finite order},
   mrnumber      = {69818},
   note          = {2d ed},
   publisher     = {Dover Publications, Inc., New York},
   pages         = {xxiv+512},
-  year          = {1955}
+  year          = {1911},
+  doi           = {10.1017/CBO9781139237253}
 }
 
 @Book{C-MLS20,
@@ -655,6 +665,7 @@
   publisher     = {Berlin: Springer},
   pages         = {215--249},
   year          = {2002},
+  doi           = {10.1007/978-3-662-04851-1_9},
   language      = {English},
   zbmath        = {1693054}
 }
@@ -764,7 +775,8 @@
   fjournal      = {Journal of Algebra},
   volume        = {472},
   pages         = {546--572},
-  year          = {2017}
+  year          = {2017},
+  doi           = {10.1016/j.jalgebra.2016.10.042}
 }
 
 @Book{DL06,
@@ -825,6 +837,7 @@
   volume        = {39},
   publisher     = {Basel: Birkhäuser},
   year          = {2009},
+  doi           = {10.1007/978-3-7643-8905-5},
   fseries       = {Oberwolfach Seminars},
   language      = {English},
   zbmath        = {5303649}
@@ -1023,6 +1036,7 @@
   publisher     = {Springer-Verlag},
   pages         = {88--91},
   year          = {2010},
+  doi           = {10.1007/978-3-642-15582-6_18},
   location      = {Kobe, Japan},
   numpages      = {4}
 }
@@ -1072,7 +1086,8 @@
   note          = {With applications to representation theory and geometry},
   publisher     = {Cambridge University Press, Cambridge},
   pages         = {x+260},
-  year          = {1997}
+  year          = {1997},
+  doi           = {10.1017/CBO9780511626241}
 }
 
 @Book{Ful98,
@@ -1109,7 +1124,8 @@
   address       = {Cham},
   publisher     = {Springer International Publishing},
   pages         = {403--410},
-  year          = {2016}
+  year          = {2016},
+  doi           = {10.1007/978-3-319-42432-3_50}
 }
 
 @Article{GIR96,
@@ -1155,7 +1171,8 @@
   booktitle     = {Proceedings of the fifteenth ACM conference on Economics and computation},
   publisher     = {Association for Computing Machinery, New York},
   pages         = {259--276},
-  year          = {2014}
+  year          = {2014},
+  doi           = {10.1145/2600057.2602883}
 }
 
 @Book{GLS07,
@@ -1440,7 +1457,8 @@
   number        = {4},
   publisher     = {SIAM},
   pages         = {711--739},
-  year          = {2022}
+  year          = {2022},
+  doi           = {10.1137/21M1441286}
 }
 
 @Article{JLLT22,
@@ -1544,7 +1562,8 @@
   volume        = {219},
   address       = {Providence, RI},
   publisher     = {American Mathematical Society},
-  year          = {2021}
+  year          = {2021},
+  doi           = {10.1090/gsm/219}
 }
 
 @Article{Jow11,
@@ -1638,7 +1657,8 @@
   volume        = {173},
   publisher     = {Birkhäuser, Basel},
   pages         = {267--285},
-  year          = {1999}
+  year          = {1999},
+  doi           = {10.1007/978-3-0348-8716-8_17}
 }
 
 @Article{Kah10,
@@ -1714,6 +1734,7 @@
   note          = {With a collaboration of Sándor Kovács},
   publisher     = {Cambridge University Press},
   year          = {2013},
+  doi           = {10.1017/CBO9781139547895},
   location      = {Cambridge}
 }
 
@@ -1796,7 +1817,8 @@
   volume        = {77},
   publisher     = {Cambridge University Press, Cambridge},
   pages         = {xi+200},
-  year          = {1984}
+  year          = {1984},
+  doi           = {10.1017/CBO9780511662720}
 }
 
 @Misc{MNP24,
@@ -1856,7 +1878,8 @@
   volume        = {161},
   publisher     = {Providence, RI: American Mathematical Society (AMS)},
   pages         = {xii + 363},
-  year          = {2015}
+  year          = {2015},
+  doi           = {10.1090/gsm/161}
 }
 
 @Book{MS21,
@@ -2034,7 +2057,8 @@
   number        = {6},
   publisher     = {OUP},
   pages         = {1026--1106},
-  year          = {2009}
+  year          = {2009},
+  doi           = {10.1093/imrn/rnn153}
 }
 
 @Article{Pos18,
@@ -2070,13 +2094,14 @@
   doi           = {10.1063/1.3501135}
 }
 
-@Article{RSS03,
+@InBook{RSS03,
   author        = {Rote, Günter and Santos, Francisco and Streinu, Ileana},
   title         = {Expansive motions and the polytope of pointed pseudo-triangulations},
-  journal       = {Discrete and Computational Geometry: The Goodman-Pollack Festschrift},
+  booktitle     = {Discrete and Computational Geometry},
   publisher     = {Springer},
   pages         = {699--736},
-  year          = {2003}
+  year          = {2003},
+  doi           = {10.1007/978-3-642-55566-4_33}
 }
 
 @Article{Rin13,
@@ -2100,6 +2125,7 @@
   volume        = {24},
   publisher     = {Oxford University Press},
   year          = {2003},
+  doi           = {10.1093/oso/9780198509424.001.0001},
   fseries       = {Oxford Lecture Series in Mathematics and its Applications}
 }
 
@@ -2226,7 +2252,8 @@
   volume        = {1},
   number        = {3},
   pages         = {475--511},
-  year          = {1979}
+  year          = {1979},
+  doi           = {10.1090/S0273-0979-1979-14597-X}
 }
 
 @Misc{Stacks,

--- a/docs/src/Groups/tom.md
+++ b/docs/src/Groups/tom.md
@@ -6,7 +6,7 @@ DocTestSetup = Oscar.doctestsetup()
 # Tables of Marks
 
 The concept of a *Table of Marks* was introduced by W. Burnside in his book
-Theory  of Groups of Finite Order [Bur55](@cite).
+Theory  of Groups of Finite Order [Bur11](@cite).
 Therefore a table of marks is sometimes called a *Burnside matrix*.
 The table of marks of a finite group ``G`` is a matrix whose rows and columns
 are labelled by the conjugacy classes of subgroups of ``G`` and where for

--- a/src/Combinatorics/Matroids/ChowRings.jl
+++ b/src/Combinatorics/Matroids/ChowRings.jl
@@ -3,7 +3,7 @@
 
 Return the Chow ring of a matroid, optionally also with the simplicial generators and the polynomial ring.
 
-See [AHK18](@cite) and [BES19](@cite). 
+See [AHK18](@cite) and [BES23](@cite).
 
 # Examples
 The following computes the Chow ring of the Fano matroid.
@@ -141,7 +141,7 @@ end
 @doc raw"""
     augmented_chow_ring(M::Matroid)
 
-Return an augmented Chow ring of a matroid. As described in [BHMPW20](@cite). 
+Return an augmented Chow ring of a matroid. As described in [BHMPW22](@cite).
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
DOIs added via script from <https://tex.stackexchange.com/a/300474>. The DOIs were then checked with <https://www.doi2bib.org> and in a few cases further adjustments were made to the bib data.

Some progress towards https://github.com/oscar-system/Oscar.jl/issues/4214.