### PR TITLE
Make `isomorphism(PcGroup, A)` for infinite abelian `A` work

### DIFF
--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -265,14 +265,10 @@ end
    end
 
    @testset "Finite FinGenAbGroup to GAPGroup" begin
-#     @testset for Agens in [Int[], [2, 4, 8], [2, 3, 4], [2, 12],
-#T problem with GAP's `AbelianGroup`;
-#T see https://github.com/gap-system/gap/issues/5430
-      @testset for Agens in [[2, 4, 8], [2, 3, 4], [2, 12],
+      @testset for Agens in [Int[], [2, 4, 8], [2, 3, 4], [2, 12],
                              [1, 6], matrix(ZZ, 2, 2, [2, 3, 2, 6])]
          A = abelian_group(Agens)
-#        for T in [FPGroup, PcGroup, PermGroup]
-         for T in [FPGroup, SubPcGroup, PermGroup]
+         for T in [FPGroup, PcGroup, SubPcGroup, PermGroup]
             iso = @inferred isomorphism(T, A)
             for x in gens(A), y in gens(A)
                z = x+y
@@ -284,14 +280,15 @@ end
    end
 
    @testset "Infinite FinGenAbGroup to GAPGroup" begin
-      Agens = matrix(ZZ, 2, 2, [2, 3, 0, 0])
-      A = abelian_group(Agens)
-      for T in [FPGroup]
-         iso = @inferred isomorphism(T, A)
-         for x in gens(A), y in gens(A)
-            z = x+y
-            @test iso(x) * iso(y) == iso(z)
-            @test all(a -> preimage(iso, iso(a)) == a, [x, y, z])
+      @testset for Agens in [matrix(ZZ, 2, 2, [2, 3, 0, 0]), [6, 0]]
+         A = abelian_group(Agens)
+         for T in [FPGroup, PcGroup]
+            iso = @inferred isomorphism(T, A)
+            for x in gens(A), y in gens(A)
+               z = x+y
+               @test iso(x) * iso(y) == iso(z)
+               @test all(a -> preimage(iso, iso(a)) == a, [x, y, z])
+            end
          end
       end
    end


### PR DESCRIPTION
The documentation claimed that this is not supported, but in fact GAP's pcp groups can deal with this case.

The code looks horrible,
due to the fact that GAP supports the decomposition of elements in abelian groups w.r.t. independent generators only for special such generating sets.
(This happens for abelian permutation groups.)

Note that this is generic code.
Perhaps we should add special methods for the case that we ask for a `FPGroup` or a `PcGroup`, then also the functions for computing (pre)images can be more efficient.

resolves #4318