### PR TITLE
add two missing doctest end markers

### DIFF
--- a/experimental/SetPartitions/src/SetPartition.jl
+++ b/experimental/SetPartitions/src/SetPartition.jl
@@ -84,6 +84,7 @@ julia> lower_points(set_partition([2, 4], [4, 99]))
 2-element Vector{Int64}:
  2
  3
+```
 """
 function lower_points(p::SetPartition)
     return p.lower_points

--- a/src/Groups/pcgroup.jl
+++ b/src/Groups/pcgroup.jl
@@ -174,6 +174,7 @@ julia> get_relative_orders(c)
 2-element Vector{ZZRingElem}:
  2
  0
+```
 """
 function get_relative_orders(c::Collector{T}) where T <: IntegerUnion
   return c.relorders


### PR DESCRIPTION
Reminded by https://github.com/oscar-system/Oscar.jl/pull/4202#discussion_r1843973091 I ran my script from https://github.com/oscar-system/Oscar.jl/pull/2083#issuecomment-1475024846 again and found two unterminated doctests.

Maybe I should add this to CI at some point.