### PR TITLE
CI: check for jldoctest end markers and unknown admonitions

### DIFF
--- a/.github/workflows/Docstrings.yml
+++ b/.github/workflows/Docstrings.yml
@@ -1,0 +1,29 @@
+name: docstring test
+
+on:
+  push:
+    branches:
+      - master
+      - 'release-*'
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  check-docstrings:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: julia-actions/setup-julia@v2
+    - uses: julia-actions/cache@v2
+    - name: Build package
+      uses: julia-actions/julia-buildpkg@v1
+    - name: 'Check issues in docstrings'
+      run: |
+        julia --project=. -e 'using Oscar; include("etc/check_docstrings.jl")'

--- a/etc/check_docstrings.jl
+++ b/etc/check_docstrings.jl
@@ -43,7 +43,7 @@ function find_docstr_src(docs)
   res = docs.meta[:results]
   for i in 1:length(docs.content)
     msg = has_broken_doctest(docs.content[i])
-    if msg != nothing
+    if msg !== nothing
       file = res[i].data[:path]
       line = res[i].data[:linenumber]
       mod = res[i].data[:module]
@@ -81,7 +81,7 @@ function get_broken_docstrings(m::Module)
     elseif !isnothing(memberobj)
       docs = Base.Docs.doc(memberobj)
       if docs isa Markdown.MD
-        if has_broken_doctest(docs) != nothing && !(memberobj in broken)
+        if has_broken_doctest(docs) !== nothing && !(memberobj in broken)
           loc = find_docstr_src(docs)
           push!(broken, memberobj)
           # we could filter out docs from other packages via startswith(x, pkgdir(m))

--- a/etc/check_docstrings.jl
+++ b/etc/check_docstrings.jl
@@ -1,0 +1,98 @@
+using Markdown
+
+admonition_types = string.((:note, :info, :tip, :danger, :warning, :compat, :todo, :details))
+
+# this might not catch all broken jldoctests but seems to work for now
+function has_broken_doctest(md::Markdown.MD)
+  todo = copy(md.content)
+  while !isempty(todo)
+    elem = popfirst!(todo)
+    # nested
+    if elem isa Markdown.MD
+      append!(todo, elem.content)
+    else
+      # proper docstrings are in a Markdown.Code block
+      if elem isa Markdown.Paragraph
+        for block in elem.content
+          # unterminated jldoctests seem to end up inside some string in a Paragraph block
+          if contains(string(block),"```jldoctest")
+            return "Unterminated jldoctest: $(string(block))"
+          end
+        end
+      elseif elem isa Markdown.Admonition
+        if !(elem.category in admonition_types)
+          return "Unknown admonition category: $(string(elem.category))"
+        end
+      end
+    end
+  end
+  return nothing
+end
+
+function find_docstr_src(docs)
+  locs = []
+  res = docs.meta[:results]
+  for i in 1:length(docs.content)
+    msg = has_broken_doctest(docs.content[i])
+    if msg != nothing
+      file = res[i].data[:path]
+      line = res[i].data[:linenumber]
+      mod = res[i].data[:module]
+      push!(locs, (mod, file, line, msg))
+    end
+  end
+  return locs
+end
+
+function get_broken_docstrings(m::Module)
+  allpairs = collect(zip(Iterators.repeated(m), names(m; all=true, imported=false)));
+  broken = []
+  locs = []
+  done = [m]
+
+  while !isempty(allpairs)
+    (src, name) = popfirst!(allpairs)
+    memberobj = try
+      getfield(src,name)
+    catch
+      nothing
+    end
+    if memberobj isa Module
+      if !(memberobj in done)
+        push!(done, memberobj)
+        # we only want to consider one pkg
+        # but note that we still seem to pick up some reexported names
+        # even though imported=false and the check below
+        if (pkgdir(memberobj) == pkgdir(m))
+          newnames = names(memberobj; all=true, imported=false)
+          filter!(x->!((memberobj, x) in allpairs || x in done), newnames)
+          append!(allpairs, collect(zip(Iterators.repeated(memberobj), newnames)))
+        end
+      end
+    elseif !isnothing(memberobj)
+      docs = Base.Docs.doc(memberobj)
+      if docs isa Markdown.MD
+        if has_broken_doctest(docs) != nothing && !(memberobj in broken)
+          loc = find_docstr_src(docs)
+          push!(broken, memberobj)
+          # we could filter out docs from other packages via startswith(x, pkgdir(m))
+          append!(locs, loc)
+        end
+      end
+    end
+  end
+  return locs
+end
+
+function (@main)(args)
+  modnames = length(args) > 0 ? args : ["Oscar"]
+  mod = getfield.(Ref(Main), Symbol.(modnames))
+  locs = reduce(vcat, get_broken_docstrings.(mod))
+  isempty(locs) && exit(0)
+  for (mod, file, line, msg) in locs
+    dir = joinpath(pkgdir(mod),"") # add trailing /
+    relfile = replace(file, dir => "")
+    println("::error file=$relfile,line=$line,title=$(string(mod))::$msg")
+  end
+  exit(-1)
+end

--- a/etc/check_docstrings.jl
+++ b/etc/check_docstrings.jl
@@ -1,3 +1,12 @@
+# this can be run from the command line with:
+# > julia --project=. -e 'using Oscar; include("etc/check_docstrings.jl")'
+#
+# it is also possible to test more packages at once (as long as Main.X exists)
+# > julia --project=. -e 'using Oscar; include("etc/check_docstrings.jl")' Nemo Singular Hecke Polymake GAP Oscar
+#
+# note: the @main function requires julia 1.11 or newer
+
+
 using Markdown
 
 admonition_types = string.((:note, :info, :tip, :danger, :warning, :compat, :todo, :details))

--- a/experimental/BasisLieHighestWeight/src/UserFunctions.jl
+++ b/experimental/BasisLieHighestWeight/src/UserFunctions.jl
@@ -406,7 +406,7 @@ with highest weight `highest_weight` for a simple Lie algebra $L$ of type `type`
 Furthermore, for each degree, return the monomials that are not contained in the Minkowski sum
 of the bases of the lower degrees.
 
-!!! warn
+!!! warning
     Currently, this function expects $-w_0(\lambda)$ instead of $\lambda$ as the `highest_weight` input.
     This might change in a minor release.
     
@@ -515,7 +515,7 @@ with highest weight `highest_weight` for a simple Lie algebra $L$ of type `type`
 Furthermore, for each degree, return the monomials that are not contained in the Minkowski sum
 of the bases of the lower degrees.
 
-!!! warn
+!!! warning
     Currently, this function expects $-w_0(\lambda)$ instead of $\lambda$ as the `highest_weight` input.
     This might change in a minor release.
 


### PR DESCRIPTION
x-ref: #4321
cc: @fingolfin @lgoettgens 

_Edit:_ errors look like here: https://github.com/oscar-system/Oscar.jl/actions/runs/11879378622
The error should link to the corresponding docstring. Unfortunately I could not figure out how to find the exact line inside the docstring for the jldoctest / admonition.

If the errors are triggered from new changes these should show up as annotations in the `Files changed` tab as well.