### PR TITLE
Fix zero-dimensional cone in `cones` in PolyhedralGeometry

### DIFF
--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -214,9 +214,14 @@ function cones(PF::_FanLikeType, cone_dim::Int)
   l = cone_dim - length(lineality_space(PF))
   t = Cone{_get_scalar_type(PF)}
   l < 0 && return _empty_subobjectiterator(t, PF)
-  l == 0 && length(lineality_space(PF)) == 0 && return SubObjectIterator{t}(
-    PF, (_, _, _) -> cone(zeros(Int, ambient_dim(PF))), 1, NamedTuple()
-  )
+
+  if l == 0
+    if length(lineality_space(PF)) == 0
+      return SubObjectIterator{t}(
+        PF, (_, _, _) -> cone(zeros(Int, ambient_dim(PF))), 1, NamedTuple()
+      )
+    end
+  end
 
   # The function `lineality_space` returns a ray even in the case where
   # the lineality space is actually a line.

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -213,7 +213,7 @@ julia> cones(PF, 2)
 function cones(PF::_FanLikeType, cone_dim::Int)
   l = cone_dim - length(lineality_space(PF))
   t = Cone{_get_scalar_type(PF)}
-  l < 0 && return _empty_subobjectiterator(t, PF)
+  (l < 0 || dim(PF) == -1) && return _empty_subobjectiterator(t, PF)
 
   if l == 0
     if length(lineality_space(PF)) == 0

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -216,11 +216,9 @@ function cones(PF::_FanLikeType, cone_dim::Int)
   (l < 0 || dim(PF) == -1) && return _empty_subobjectiterator(t, PF)
 
   if l == 0
-    if length(lineality_space(PF)) == 0
-      return SubObjectIterator{t}(
-        PF, (_, _, _) -> cone(zeros(Int, ambient_dim(PF))), 1, NamedTuple()
-      )
-    end
+    return SubObjectIterator{t}(
+      PF, (_, _, _) -> positive_hull(coefficient_field(PF), zeros(Int, ambient_dim(PF)), lineality_space(PF)), 1, NamedTuple()
+    )
   end
 
   # The function `lineality_space` returns a ray even in the case where

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -217,10 +217,14 @@ function cones(PF::_FanLikeType, cone_dim::Int)
 
   if l == 0
     return SubObjectIterator{t}(
-      PF, (_, _, _) -> positive_hull(coefficient_field(PF), zeros(Int, ambient_dim(PF)), lineality_space(PF)), 1, NamedTuple()
+      PF,
+      (_, _, _) -> positive_hull(
+        coefficient_field(PF), zeros(Int, ambient_dim(PF)), lineality_space(PF)
+      ),
+      1,
+      NamedTuple(),
     )
   end
-
 
   return SubObjectIterator{t}(
     PF, _cone_of_dim, size(Polymake.fan.cones_of_dim(pm_object(PF), l), 1), (c_dim=l,)

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -221,9 +221,6 @@ function cones(PF::_FanLikeType, cone_dim::Int)
     )
   end
 
-  # The function `lineality_space` returns a ray even in the case where
-  # the lineality space is actually a line.
-  l == 0 && length(lineality_space(PF)) > 0 && return error("Not implemented.")
 
   return SubObjectIterator{t}(
     PF, _cone_of_dim, size(Polymake.fan.cones_of_dim(pm_object(PF), l), 1), (c_dim=l,)

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -212,8 +212,17 @@ julia> cones(PF, 2)
 """
 function cones(PF::_FanLikeType, cone_dim::Int)
   l = cone_dim - length(lineality_space(PF))
-  l < 1 && return nothing
-  return SubObjectIterator{Cone{_get_scalar_type(PF)}}(
+  t = Cone{_get_scalar_type(PF)}
+  l < 0 && return _empty_subobjectiterator(t, PF)
+  l == 0 && length(lineality_space(PF)) == 0 && return SubObjectIterator{t}(
+    PF, (_, _, _) -> cone(zeros(Int, ambient_dim(PF))), 1, NamedTuple()
+  )
+
+  # The function `lineality_space` returns a ray even in the case where
+  # the lineality space is actually a line.
+  l == 0 && length(lineality_space(PF)) > 0 && return error("Not implemented.")
+
+  return SubObjectIterator{t}(
     PF, _cone_of_dim, size(Polymake.fan.cones_of_dim(pm_object(PF), l), 1), (c_dim=l,)
   )
 end

--- a/test/PolyhedralGeometry/polyhedral_fan.jl
+++ b/test/PolyhedralGeometry/polyhedral_fan.jl
@@ -58,10 +58,17 @@
     @test size(cones(F2, 2)) == (2,)
     @test lineality_space(cones(F2, 2)[1]) == [[0, 1, 0]]
     @test rays.(cones(F2, 2)) == [[], []]
-    @test isnothing(cones(F2, 1))
     @test _check_im_perm_rows(ray_indices(cones(F1, 2)), incidence1)
     @test _check_im_perm_rows(incidence_matrix(cones(F1, 2)), incidence1)
     @test _check_im_perm_rows(cones(IncidenceMatrix, F1, 2), incidence1)
+
+    A3 = affine_space(NormalToricVariety, 3)
+    @test length(cones(A3, 1)) == 3
+    @test length(cones(A3, 0)) == 1
+    @test length(cones(A3, -1)) == 0
+    @test cones(A3, 1) isa SubObjectIterator{Cone{QQFieldElem}}
+    @test cones(A3, 0) isa SubObjectIterator{Cone{QQFieldElem}}
+    @test cones(A3, -1) isa SubObjectIterator{Cone{QQFieldElem}}
 
     II = ray_indices(maximal_cones(NFsquare))
     NF0 = polyhedral_fan(II, rays(NFsquare))


### PR DESCRIPTION
By Definition 1.2.1 in `[CLS11](@cite)`, the set {0} is a cone.
The function `cones(X, 0)` now returns an iterator that returns the zero-dimensional cone, provided the lineality space has length zero, fixing a bug.
If `n` is negative, then `cones(X, n)` now returns an empty iterator, fixing the type instability.