### PR TITLE
Include existing elliptic curves docu

### DIFF
--- a/docs/doc.main
+++ b/docs/doc.main
@@ -111,7 +111,6 @@
      "Elliptic Curves" => [
         "Hecke/manual/elliptic_curves/intro.md",
         "Hecke/manual/elliptic_curves/basics.md",
-        "Hecke/manual/elliptic_curves/number_fields.md",
         "Hecke/manual/elliptic_curves/finite_fields.md"
      ],
      "NumberTheory/abelian_closure.md",

--- a/docs/doc.main
+++ b/docs/doc.main
@@ -108,6 +108,12 @@
         "Hecke/manual/orders/ideals.md",
         "Hecke/manual/orders/frac_ideals.md",
      ],
+     "Elliptic Curves" => [
+        "Hecke/manual/elliptic_curves/intro.md",
+        "Hecke/manual/elliptic_curves/basics.md",
+        "Hecke/manual/elliptic_curves/number_fields.md",
+        "Hecke/manual/elliptic_curves/finite_fields.md"
+     ],
      "NumberTheory/abelian_closure.md",
      "NumberTheory/galois.md",
   ],


### PR DESCRIPTION
Includes the elliptic curves documentation already existing under Hecke to be included into doc/main (and then also the search results).

Fixes #4187 

As a note, this doesn't build on my local machine. I have the same problem I had in the other PR : https://github.com/oscar-system/Oscar.jl/pull/4292#issuecomment-2464790878 , the search index is never created, and then the patching step errors out.

```julia
[ Info: Patching search index.
sed: can't read /home/aaruni/Programs/git/GitHub/Oscar.jl/docs/build/search_index.js: No such file or directory
ERROR: LoadError: failed process: Process(`sed -n '2p;3q' /home/aaruni/Programs/git/GitHub/Oscar.jl/docs/build/search_index.js`, ProcessExited(2)) [2]
```

It should still work, in principle. Lets see what the CI says.