### PR TITLE
test/PolyhedralGeometry: remove some prefer blocks

### DIFF
--- a/test/PolyhedralGeometry/linear_program.jl
+++ b/test/PolyhedralGeometry/linear_program.jl
@@ -7,12 +7,7 @@
   C1 = cube(f, 2, 0, 1)
   Pos = polyhedron(f, [-1 0 0; 0 -1 0; 0 0 -1], [0, 0, 0])
   L = polyhedron(f, [-1 0 0; 0 -1 0], [0, 0])
-  point = convex_hull(f, [0 1 0])
   empty = polyhedron(f, [1 0 0; -1 0 0], [0, -1])
-  # this is to make sure the order of some matrices below doesn't change
-  Polymake.prefer("beneath_beyond") do
-    affine_hull(point)
-  end
   s = simplex(f, 2)
   rsquare = cube(f, 2, QQFieldElem(-3, 2), QQFieldElem(3, 2))
 

--- a/test/PolyhedralGeometry/polyhedron.jl
+++ b/test/PolyhedralGeometry/polyhedron.jl
@@ -13,10 +13,6 @@
   L = polyhedron(f, [-1 0 0; 0 -1 0], [0, 0])
   full = polyhedron(f, zero_matrix(f, 0, 3), [])
   point = convex_hull(f, [0 1 0])
-  # this is to make sure the order of some matrices below doesn't change
-  Polymake.prefer("beneath_beyond") do
-    affine_hull(point)
-  end
   s = simplex(f, 2)
   R, x = polynomial_ring(QQ, :x)
   v = T[f(1), f(1)]


### PR DESCRIPTION
Even though these should be scoped, they do seem to have some side-effects (to be investigated...). They should not really be necessary so lets try removing them.

x-ref #4348.

**Note:** this currently based on the `lg/weight-lattice` branch and targets this branch, but we can also rebase and merge it to master once it ran successful for this branch, as it seems the same error also appeared on #4286.