### PR TITLE
Speed up `cperm`

### DIFF
--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -226,22 +226,27 @@ end
 # takes as input a list of vectors (not necessarily disjoint)
 @doc raw"""
     cperm(L::AbstractVector{<:T}...) where T <: IntegerUnion
+    cperm(L::AbstractVector{<:AbstractVector{T}}) where T <: IntegerUnion
     cperm(G::PermGroup, L::AbstractVector{<:T}...)
-    cperm(L::Vector{Vector{T}}) where T <: IntegerUnion
-    cperm(g::PermGroup,L::Vector{Vector{T}}) where T <: IntegerUnion
+    cperm(G::PermGroup, L::AbstractVector{<:AbstractVector{T}}) where T <: IntegerUnion
 
 For given lists $[a_1, a_2, \ldots, a_n], [b_1, b_2, \ldots , b_m], \ldots$
 of positive integers, return the
 permutation $x = (a_1, a_2, \ldots, a_n) * (b_1, b_2, \ldots, b_m) * \ldots$.
 Arrays of the form `[n, n+1, ..., n+k]` can be replaced by `n:n+k`.
 
-The parent of $x$ is `G`.
-If `G` is not specified then the parent of $x$ is set to
-[`symmetric_group`](@ref)$(n)$,
-where $n$ is the largest integer that occurs in an entry of `L`.
+The parent of $x$ is `G`. If `G` is not specified then the parent of $x$ is
+set to [`symmetric_group`](@ref)$(n)$, where $n$ is the largest integer that
+occurs in an entry of `L`.
+However this incurs non-trivial overhead and so it is generally better
+to provide `G` explicitly.
 
-An exception is thrown if $x$ is not contained in `G`
-or one of the given vectors is empty or contains duplicates.
+An exception is thrown if $x$ is not contained in `G`,
+if one of the given vectors is empty or contains duplicates, or
+if the cycles are not disjoint.
+
+See also [`perm`](@ref) and [`@perm`](@ref) for other ways to create
+permutations.
 
 # Examples
 ```jldoctest
@@ -249,7 +254,7 @@ julia> cperm([1,2,3],4:7)
 (1,2,3)(4,5,6,7)
 
 julia> cperm([1,2],[2,3])
-(1,3,2)
+ERROR: ArgumentError: cycles are not disjoint
 
 julia> cperm()
 ()
@@ -261,7 +266,8 @@ julia> degree(p)
 7
 ```
 
-Two permutations coincide if, and only if, they move the same points and their parent groups have the same degree.
+Two permutations coincide if, and only if, they move the same points and their
+parent groups have the same degree.
 ```jldoctest
 julia> G=symmetric_group(5);
 
@@ -280,9 +286,11 @@ true
 julia> x==z
 false
 ```
-In the example above, `x` and `y` are equal because both act on a set of cardinality `5`, while `x` and `z` are different because `x` belongs to `Sym(5)` and `z` belongs to `Sym(3)`.
+In the example above, `x` and `y` are equal because both act on a set of
+cardinality `5`, while `x` and `z` are different because `x` belongs to
+`Sym(5)` and `z` belongs to `Sym(3)`.
 
-cperm can also handle cycles passed in inside of a vector
+`cperm` can also handle cycles passed in inside of a vector
 ```jldoctest
 julia> x = cperm([[1,2],[3,4]])
 (1,2)(3,4)
@@ -293,69 +301,39 @@ julia> y = cperm([1,2],[3,4])
 julia> x == y
 true
 ```
-
-```jldoctest
-julia> G=symmetric_group(5)
-Sym(5)
-
-julia> x = cperm(G,[[1,2],[3,4]])
-(1,2)(3,4)
-
-julia> parent(x)
-Sym(5)
-```
-
-Equivalent permutations can be created using [`perm`](@ref) and [`@perm`](@ref):
-```jldoctest
-julia> x = cperm([1,2,3],[4,5],[6,7,8])
-(1,2,3)(4,5)(6,7,8)
-
-julia> y = perm(symmetric_group(8),[2,3,1,5,4,7,8,6])
-(1,2,3)(4,5)(6,7,8)
-
-julia> x == y
-true
-
-julia> z = @perm (1,2,3)(4,5)(6,7,8)
-(1,2,3)(4,5)(6,7,8)
-
-julia> x == z
-true
-```
-
-At the moment, the input vectors of the function `cperm` need not be disjoint.
-
 """
-function cperm()
-  return one(symmetric_group(1))
+cperm() = one(symmetric_group(1))
+
+cperm(L::AbstractVector{T}, Ls::AbstractVector{T}...) where T <: IntegerUnion = _cperm((L,Ls...))
+
+cperm(L::AbstractVector{<:AbstractVector{<:IntegerUnion}}) = _cperm(L)
+
+cperm(g::PermGroup, L::AbstractVector{<: IntegerUnion}...) = _cperm(g, L)
+
+cperm(g::PermGroup, L::AbstractVector{<:AbstractVector{<:IntegerUnion}}) = _cperm(g, L)
+
+function _cperm(L)
+  # L is something like a Vector{Vector{Int}}, describing a sequence of cycles
+  # figure out the maximal entry occurring in there
+  deg = mapreduce(maximum, max, L; init=1)
+  return _cperm(symmetric_group(deg), L)
 end
 
-function cperm(L1::AbstractVector{T}, L::AbstractVector{T}...) where T <: IntegerUnion
-  cycles = [L1, L...]
-  n = maximum(map(maximum, cycles))
-  return prod([PermGroupElem(symmetric_group(n), GAPWrap.CycleFromList(GAP.Obj([Int(k) for k in y]))) for y in cycles])
-  #TODO: better create the product of GAP permutations?
-end
-
-# cperm stays for "cycle permutation", but we can change name if we want
-# takes as input a list of vectors (not necessarily disjoint)
-# WARNING: we allow e.g. PermList([2,3,1,4,5,6]) in Sym(3)
-function cperm(g::PermGroup)
-  return one(g)
-end
-
-function cperm(g::PermGroup, L1::AbstractVector{T}, L::AbstractVector{T}...) where T <: IntegerUnion
-  x = prod(y -> GAPWrap.CycleFromList(GAP.Obj([Int(k) for k in y])), [L1, L...])
-  @req x in GapObj(g) "the element does not embed in the group"
-  return PermGroupElem(g, x)
-end
-
-function cperm(L::Vector{Vector{T}}) where T <: IntegerUnion
-    return cperm(L...)
-end
-
-function cperm(g::PermGroup,L::Vector{Vector{T}}) where T <: IntegerUnion
-    return cperm(g,L...)
+function _cperm(g::PermGroup, L)
+  isempty(L) && return one(g)
+  deg = degree(g)
+  l = collect(1:deg)
+  for y in L
+    isempty(y) && continue
+    prev = last(y)
+    for i in y
+      @req 1 <= prev <= deg "the element does not embed in the group"
+      @req l[prev] == prev "cycles are not disjoint"
+      l[prev] = i
+      prev = i
+    end
+  end
+  return perm(g, l)
 end
 
 @doc raw"""

--- a/test/Groups/Permutations.jl
+++ b/test/Groups/Permutations.jl
@@ -5,12 +5,12 @@
   @test p == cperm([1,2],[3,4,5],[7,8,9])
 
   a=1;b=2;f=x->3*x + 2;
-  p = @perm (a,f(a),b)(a+1,b*2)
-  @test p == cperm([1,5,4,2])
+  p = @perm (a,f(a),b)(a+2,b*2)
+  @test p == cperm([1,5,2],[3,4])
   p = @perm ()
   @test p == cperm()
   
-  @test_throws ErrorException @perm (-1, 1)
+  @test_throws ArgumentError @perm (-1, 1)
   @test_throws LoadError @eval @perm "bla"
   @test_throws LoadError @eval @perm 1 + 1
   
@@ -25,21 +25,22 @@
         (1,2,3,4,5,6,7)(8,9,10,11,12,13,14)
         (1,2)(10,11)
        ]
+  G = symmetric_group(14)
   p = Vector{PermGroupElem}(undef,9)
-  p[1] = cperm(symmetric_group(14),[1,10])
-  p[2] = cperm(symmetric_group(14),[2,11])
-  p[3] = cperm(symmetric_group(14),[3,12])
-  p[4] = cperm(symmetric_group(14),[4,13])
-  p[5] = cperm(symmetric_group(14),[5,14])
-  p[6] = cperm(symmetric_group(14),[6,8])
-  p[7] = cperm(symmetric_group(14),[7,9])
-  p[8] = cperm(symmetric_group(14),[1,2,3,4,5,6,7],[8,9,10,11,12,13,14])
-  p[9] = cperm(symmetric_group(14),[1,2],[10,11])
+  p[1] = cperm(G,[1,10])
+  p[2] = cperm(G,[2,11])
+  p[3] = cperm(G,[3,12])
+  p[4] = cperm(G,[4,13])
+  p[5] = cperm(G,[5,14])
+  p[6] = cperm(G,[6,8])
+  p[7] = cperm(G,[7,9])
+  p[8] = cperm(G,[1,2,3,4,5,6,7],[8,9,10,11,12,13,14])
+  p[9] = cperm(G,[1,2],[10,11])
   @test gens == p
   
   @test_throws ArgumentError @perm 10 [(1,11)]
   
-  G = sub(symmetric_group(14),gens)[1]
+  G = sub(G,gens)[1]
   @test order(G) == 645120
 end
 
@@ -69,7 +70,7 @@ end
   @test order(@permutation_group(5, (1,2,3)(4,5), (1,2,3,4))) == 120
 
   @test_throws ArgumentError @permutation_group(1, (1,2))
-  @test_throws ErrorException @permutation_group(1, (1,0))
+  @test_throws ArgumentError @permutation_group(1, (1,0))
 end
 
 @testset "parent coercion for permutation groups" begin

--- a/test/Groups/action.jl
+++ b/test/Groups/action.jl
@@ -65,7 +65,7 @@ end
   iso = Oscar.iso_oscar_gap(R)
   img = iso(f)
 
-  for p in [g(cperm(1:3)), g(cperm(1:2))]
+  for p in [cperm(g,1:3), cperm(g,1:2)]
     @test f^p == evaluate(f, permuted(vars, p^-1))
     @test on_indeterminates(img, p) == iso(f^p)
   end
@@ -88,7 +88,7 @@ end
   (x1, x2, x3) = vars
   f = x1*x2 + x2*x3
 
-  for p in [g(cperm(1:3)), g(cperm(1:2))]
+  for p in [cperm(g,1:3), cperm(g,1:2)]
     @test f^p == evaluate(f, permuted(vars, p^-1))
   end
 

--- a/test/Groups/conjugation.jl
+++ b/test/Groups/conjugation.jl
@@ -104,7 +104,7 @@
   @test length(CC)==3
   @test Set([order(Int, representative(l)) for l in CC])==Set([6,8,12])
 
-  x = G(cperm([1,2,3,4]))
+  x = cperm(G,[1,2,3,4])
   H = sub(G,[x])[1]
   @test normalizer(G,H)==normalizer(G,x)
 

--- a/test/Groups/elements.jl
+++ b/test/Groups/elements.jl
@@ -50,6 +50,13 @@
   @test_throws ArgumentError perm(G,[2,3,4,5,6,7,1])
   @test_throws ArgumentError perm(G, [1,1])
   @test one(G)==cperm(G,Int64[])
+
+  G=alternating_group(6)
+  @test_throws ArgumentError cperm(G, [1,2])
+  @test cperm(G, [1,2],[3,4]) == perm(G,[2,1,4,3,5,6])
+  @test cperm(G, [1,2],[2,3]) == cperm(G, [1,3,2])
+  @test cperm(G, [1,2],[2,3]) == perm(G,[3,1,2,4,5,6])
+
 end
 
 @testset "Change of parent" begin


### PR DESCRIPTION
Also adjust the docstring. Point out that omitting the parent group is not advisable, and change uses of cperm in tests to provide a parent.

Before:

    julia> g = symmetric_group(15);

    julia> @btime cperm($g, 1:4,5:6,7:15);
      5.007 μs (69 allocations: 3.05 KiB)

After:

    julia> g = symmetric_group(15);

    julia> @btime cperm($g, 1:4,5:6,7:15);
      1.238 μs (6 allocations: 416 bytes)


There is actually some more space for improvement by adding some low level primitives for accessing and creating GAP permutations, but that's for a future PR. In the meantime this already improves things and I don't want to rebase this once again.

This was created as part of work with @Pascalonyy on Origamis from 1 year ago, for AG Weitze-Schmithüsen in Saarbrücken. Sadly that never went anywhere as far as I know, but I can at least salvage some of the bits I provided to make things much faster there.