### PR TITLE
Remove Base.getproperty methods for MatrixGroup(Elem) and SesquilinearForm

### DIFF
--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -180,7 +180,7 @@ end
 #
 function isomorphism_to_GAP_group(G::GAPGroup)
     finv = function(x::GAP.Obj) return group_element(G, x); end
-    return MapFromFunc(G, G.X, GapObj, finv)
+    return MapFromFunc(G, GapObj(G), GapObj, finv)
 end
 
 function isomorphism_to_GAP_group(G::FinGenAbGroup)
@@ -189,9 +189,9 @@ function isomorphism_to_GAP_group(G::FinGenAbGroup)
     iso = isomorphism(SubPcGroup, G)
     C = codomain(iso)
     @assert C isa GAPGroup
-    f = function(x) return iso(x).X; end
+    f = function(x) return GapObj(iso(x)) end
     finv = function(x::GAP.Obj) return preimage(iso, group_element(C, x)); end
-    return MapFromFunc(G, C.X, f, finv)
+    return MapFromFunc(G, GapObj(C), f, finv)
 end
 
 function isomorphism_to_GAP_group(tbl::GAPGroupCharacterTable)

--- a/src/Groups/matrices/form_group.jl
+++ b/src/Groups/matrices/form_group.jl
@@ -555,13 +555,13 @@ end
 # return the GAP matrix of the form preserved by the GAP standard group
 function _standard_form(descr::Symbol, e::Int, n::Int, q::Int)
    if descr==:quadratic
-      return GAP.Globals.InvariantQuadraticForm(GO(e,n,q).X).matrix
+      return GAP.Globals.InvariantQuadraticForm(GapObj(GO(e,n,q))).matrix
    elseif descr==:symmetric #|| descr==:alternating
-      return GAP.Globals.InvariantBilinearForm(GO(e,n,q).X).matrix
+      return GAP.Globals.InvariantBilinearForm(GapObj(GO(e,n,q))).matrix
    elseif descr==:hermitian
-      return GAP.Globals.InvariantSesquilinearForm(GU(n,q).X).matrix
+      return GAP.Globals.InvariantSesquilinearForm(GapObj(GU(n,q))).matrix
    elseif descr==:alternating
-      return GAP.Globals.InvariantBilinearForm(Sp(n,q).X).matrix
+      return GAP.Globals.InvariantBilinearForm(GapObj(Sp(n,q))).matrix
    else
       error("unsupported description")
    end      

--- a/src/Groups/matrices/forms.jl
+++ b/src/Groups/matrices/forms.jl
@@ -311,22 +311,6 @@ GAP.@install function GapObj(f::SesquilinearForm)
   return f.X
 end
 
-function Base.getproperty(f::SesquilinearForm, sym::Symbol)
-
-   if isdefined(f,sym) return getfield(f,sym) end
-
-   if sym == :X
-      if !isdefined(f, :X)
-         assign_from_description(f)
-      end
-
-   end
-
-   return getfield(f, sym)
-
-end
-
-
 
 ########################################################################
 #

--- a/src/Groups/matrices/transform_form.jl
+++ b/src/Groups/matrices/transform_form.jl
@@ -394,8 +394,8 @@ function is_congruent(f::SesquilinearForm{T}, g::SesquilinearForm{T}) where T <:
 
    if f.descr==:quadratic
       if iseven(characteristic(F))            # in this case we use the GAP algorithms
-         Bg = preimage_matrix(_ring_iso(g), GAP.Globals.BaseChangeToCanonical(g.X))
-         Bf = preimage_matrix(_ring_iso(f), GAP.Globals.BaseChangeToCanonical(f.X))
+         Bg = preimage_matrix(_ring_iso(g), GAP.Globals.BaseChangeToCanonical(GapObj(g)))
+         Bf = preimage_matrix(_ring_iso(f), GAP.Globals.BaseChangeToCanonical(GapObj(f)))
 
          UTf = _upper_triangular_version(Bf*gram_matrix(f)*transpose(Bf))
          UTg = _upper_triangular_version(Bg*gram_matrix(g)*transpose(Bg))


### PR DESCRIPTION
Should have been done in May after PR #3671 and friends but it seems we forgot about it.

Just was cleaning out old branches locally and stumbled over this. As such I don't remember if this was 100% complete but CI will tell.