### PR TITLE
Resolve unbound type parameters

### DIFF
--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/module_operations.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/module_operations.md
@@ -27,11 +27,11 @@ cokernel(a::ModuleFPHom)
 ## Direct Sums and Products
 
 ```@docs
-direct_sum(M::ModuleFP{T}...; task::Symbol = :sum) where T
+direct_sum(M::ModuleFP{T}, Ms::ModuleFP{T}...; task::Symbol = :sum) where T
 ```
 
 ```@docs
-direct_product(M::ModuleFP{T}...; task::Symbol = :prod) where T
+direct_product(M::ModuleFP{T}, Ms::ModuleFP{T}...; task::Symbol = :prod) where T
 ```
 
 ## Truncation

--- a/experimental/DoubleAndHyperComplexes/src/Objects/tensor_products.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/tensor_products.jl
@@ -353,14 +353,12 @@ function tensor_product(factors::Vector{<:AbsHyperComplex})
   return HCTensorProductComplex(factors)
 end
 
-function tensor_product(c::AbsHyperComplex...)
-  return tensor_product(collect(c))
+function tensor_product(c::AbsHyperComplex, cs::AbsHyperComplex...)
+  return tensor_product([c, cs...])
 end
 
-function tensor_product(M::ModuleFP{T}...) where {U<:MPolyComplementOfPrimeIdeal, T<:MPolyLocRingElem{<:Any, <:Any, <:Any, <:Any, U}}
-  R = base_ring(first(M))
-  @assert all(N->base_ring(N)===R, M) "modules must be defined over the same ring"
-  return tensor_product([free_resolution(SimpleFreeResolution, N)[1] for N in M]...)
+function tensor_product(M::ModuleFP{T}, Ms::ModuleFP{T}...) where {U<:MPolyComplementOfPrimeIdeal, T<:MPolyLocRingElem{<:Any, <:Any, <:Any, <:Any, U}}
+  R = base_ring(M)
+  @assert all(N->base_ring(N)===R, Ms) "modules must be defined over the same ring"
+  return tensor_product([free_resolution(SimpleFreeResolution, N)[1] for N in (M, Ms...)])
 end
-
-

--- a/experimental/GModule/src/Cohomology.jl
+++ b/experimental/GModule/src/Cohomology.jl
@@ -469,7 +469,7 @@ import Hecke.⊗
 function Oscar.tensor_product(F::AbstractAlgebra.FPModule{T}, Fs::AbstractAlgebra.FPModule{T}...; task = :none) where {T}
   return Oscar.tensor_product([F, Fs...]; task)
 end
-function Oscar.tensor_product(F::Vector{AbstractAlgebra.FPModule{T}}; task = :none) where {T}
+function Oscar.tensor_product(F::Vector{<:AbstractAlgebra.FPModule{T}}; task = :none) where {T}
   @assert all(x->base_ring(x) == base_ring(F[1]), F)
   d = prod(dim(x) for x = F)
   G = free_module(base_ring(F[1]), d)

--- a/experimental/GModule/src/Cohomology.jl
+++ b/experimental/GModule/src/Cohomology.jl
@@ -445,7 +445,7 @@ function Oscar.tensor_product(C::GModule{<:Any, FinGenAbGroup}...; task::Symbol 
 end
 
 function Oscar.tensor_product(C::U, Cs::U...; task::Symbol = :map) where {S <: Oscar.GAPGroup, U <: GModule{S, <:AbstractAlgebra.FPModule{<:Any}}}
-  return Oscar.tensor_product([C, Cs...])
+  return Oscar.tensor_product([C, Cs...]; task)
 end
 function Oscar.tensor_product(C::Vector{U}; task::Symbol = :map) where {S <: Oscar.GAPGroup, U <: GModule{S, <:AbstractAlgebra.FPModule{<:Any}}}
   @assert all(x->x.G == C[1].G, C)
@@ -467,7 +467,7 @@ import Hecke.⊗
 
 
 function Oscar.tensor_product(F::AbstractAlgebra.FPModule{T}, Fs::AbstractAlgebra.FPModule{T}...; task = :none) where {T}
-  return Oscar.tensor_product([F, Fs...])
+  return Oscar.tensor_product([F, Fs...]; task)
 end
 function Oscar.tensor_product(F::Vector{AbstractAlgebra.FPModule{T}}; task = :none) where {T}
   @assert all(x->base_ring(x) == base_ring(F[1]), F)

--- a/experimental/GModule/src/Cohomology.jl
+++ b/experimental/GModule/src/Cohomology.jl
@@ -444,7 +444,10 @@ function Oscar.tensor_product(C::GModule{<:Any, FinGenAbGroup}...; task::Symbol 
   end
 end
 
-function Oscar.tensor_product(C::GModule{S, <:AbstractAlgebra.FPModule{<:Any}}...; task::Symbol = :map) where S <: Oscar.GAPGroup
+function Oscar.tensor_product(C::U, Cs::U...; task::Symbol = :map) where {S <: Oscar.GAPGroup, U <: GModule{S, <:AbstractAlgebra.FPModule{<:Any}}}
+  return Oscar.tensor_product([C, Cs...])
+end
+function Oscar.tensor_product(C::Vector{U}; task::Symbol = :map) where {S <: Oscar.GAPGroup, U <: GModule{S, <:AbstractAlgebra.FPModule{<:Any}}}
   @assert all(x->x.G == C[1].G, C)
   @assert all(x->base_ring(x) == base_ring(C[1]), C)
 
@@ -463,7 +466,10 @@ import Hecke.⊗
 ⊗(C::GModule...) = Oscar.tensor_product(C...; task = :none)
 
 
-function Oscar.tensor_product(F::AbstractAlgebra.FPModule{T}...; task = :none) where {T}
+function Oscar.tensor_product(F::AbstractAlgebra.FPModule{T}, Fs::AbstractAlgebra.FPModule{T}...; task = :none) where {T}
+  return Oscar.tensor_product([F, Fs...])
+end
+function Oscar.tensor_product(F::Vector{AbstractAlgebra.FPModule{T}}; task = :none) where {T}
   @assert all(x->base_ring(x) == base_ring(F[1]), F)
   d = prod(dim(x) for x = F)
   G = free_module(base_ring(F[1]), d)

--- a/experimental/GModule/src/Cohomology.jl
+++ b/experimental/GModule/src/Cohomology.jl
@@ -4,8 +4,8 @@ using Oscar
 import Oscar: action
 import Oscar: induce
 import Oscar: word
-import Oscar: GAPWrap, pc_group, fp_group, direct_product, direct_sum
-import AbstractAlgebra: Group, Module
+import Oscar: GAPWrap, pc_group, fp_group, direct_product, direct_sum, GAPGroup
+import AbstractAlgebra: Group, Module, FPModule
 import Base: parent
 
 import Oscar: pretty, Lowercase, @show_name, @show_special
@@ -444,10 +444,10 @@ function Oscar.tensor_product(C::GModule{<:Any, FinGenAbGroup}...; task::Symbol 
   end
 end
 
-function Oscar.tensor_product(C::U, Cs::U...; task::Symbol = :map) where {S <: Oscar.GAPGroup, U <: GModule{S, <:AbstractAlgebra.FPModule{<:Any}}}
-  return Oscar.tensor_product([C, Cs...]; task)
+function Oscar.tensor_product(C::GModule{T, <:FPModule}, Cs::GModule{T, <:FPModule}...; task::Symbol = :map) where {T <: GAPGroup}
+  return Oscar.tensor_product(GModule{T, <:FPModule}[C, Cs...]; task)
 end
-function Oscar.tensor_product(C::Vector{U}; task::Symbol = :map) where {S <: Oscar.GAPGroup, U <: GModule{S, <:AbstractAlgebra.FPModule{<:Any}}}
+function Oscar.tensor_product(C::Vector{<:GModule{<:GAPGroup, <:FPModule}}; task::Symbol = :map)
   @assert all(x->x.G == C[1].G, C)
   @assert all(x->base_ring(x) == base_ring(C[1]), C)
 
@@ -466,10 +466,10 @@ import Hecke.⊗
 ⊗(C::GModule...) = Oscar.tensor_product(C...; task = :none)
 
 
-function Oscar.tensor_product(F::AbstractAlgebra.FPModule{T}, Fs::AbstractAlgebra.FPModule{T}...; task = :none) where {T}
+function Oscar.tensor_product(F::FPModule{T}, Fs::FPModule{T}...; task = :none) where {T}
   return Oscar.tensor_product([F, Fs...]; task)
 end
-function Oscar.tensor_product(F::Vector{<:AbstractAlgebra.FPModule{T}}; task = :none) where {T}
+function Oscar.tensor_product(F::Vector{<:FPModule{T}}; task = :none) where {T}
   @assert all(x->base_ring(x) == base_ring(F[1]), F)
   d = prod(dim(x) for x = F)
   G = free_module(base_ring(F[1]), d)

--- a/src/AlgebraicGeometry/Schemes/Sheaves/CoherentSheaves.jl
+++ b/src/AlgebraicGeometry/Schemes/Sheaves/CoherentSheaves.jl
@@ -574,8 +574,8 @@ Coherent sheaf of modules
     1: [(y//x)]   affine 1-space
     2: [(x//y)]   affine 1-space
 with restrictions
-  1: direct sum of (Multivariate polynomial ring in 1 variable over GF(7)^1, Multivariate polynomial ring in 1 variable over GF(7)^1)
-  2: direct sum of (Multivariate polynomial ring in 1 variable over GF(7)^1, Multivariate polynomial ring in 1 variable over GF(7)^1)
+  1: direct sum of FreeMod{FqMPolyRingElem}[Multivariate polynomial ring in 1 variable over GF(7)^1, Multivariate polynomial ring in 1 variable over GF(7)^1]
+  2: direct sum of FreeMod{FqMPolyRingElem}[Multivariate polynomial ring in 1 variable over GF(7)^1, Multivariate polynomial ring in 1 variable over GF(7)^1]
 
 julia> typeof(W)
 DirectSumSheaf{CoveredScheme{FqField}, AbsAffineScheme, ModuleFP, Map}

--- a/src/Modules/UngradedModules/DirectSum.jl
+++ b/src/Modules/UngradedModules/DirectSum.jl
@@ -148,10 +148,10 @@ Additionally, return
 - two vectors containing the canonical injections and projections, respectively, if `task = :both`,
 - none of the above maps if `task = :none`.
 """
-function direct_sum(M::ModuleFP{T}, Ms::ModuleFP{T}...; task::Symbol = :prod) where T
+function direct_sum(M::ModuleFP{T}, Ms::ModuleFP{T}...; task::Symbol = :sum) where T
   return direct_sum([M, Ms...]; task)
 end
-function direct_sum(M::Vector{<:ModuleFP{T}}; task::Symbol = :prod) where T
+function direct_sum(M::Vector{<:ModuleFP{T}}; task::Symbol = :sum) where T
   res = direct_product(M...; task)
   if task == :sum || task == :prod
     ds, f = res

--- a/src/Modules/UngradedModules/DirectSum.jl
+++ b/src/Modules/UngradedModules/DirectSum.jl
@@ -17,7 +17,7 @@ function direct_product(M::FreeMod{T}, Ms::FreeMod{T}...; task::Symbol = :prod) 
 end
 function direct_product(F::Vector{<:FreeMod{T}}; task::Symbol = :prod) where T
   R = base_ring(F[1])
-  G = FreeMod(R, sum([rank(f) for f = F]))
+  G = FreeMod(R, sum(rank, F))
   all_graded = all(is_graded, F)
   if all_graded
     G.d = vcat([f.d for f in F]...)

--- a/src/Modules/UngradedModules/DirectSum.jl
+++ b/src/Modules/UngradedModules/DirectSum.jl
@@ -12,7 +12,10 @@ Additionally, return
 - two vectors containing the canonical projections and injections, respectively, if `task = :both`,
 - none of the above maps if `task = :none`.
 """
-function direct_product(F::FreeMod{T}...; task::Symbol = :prod) where {T}
+function direct_product(M::FreeMod{T}, Ms::FreeMod{T}...; task::Symbol = :prod) where T
+  return direct_product([M, Ms...]; task)
+end
+function direct_product(M::Vector{<:FreeMod{T}}; task::Symbol = :prod) where T
   R = base_ring(F[1])
   G = FreeMod(R, sum([rank(f) for f = F]))
   all_graded = all(is_graded, F)
@@ -70,7 +73,10 @@ Additionally, return
 - two vectors containing the canonical projections and injections, respectively, if `task = :both`,
 - none of the above maps if `task = :none`.
 """
-function direct_product(M::ModuleFP{T}...; task::Symbol = :prod) where T
+function direct_product(M::ModuleFP{T}, Ms::ModuleFP{T}...; task::Symbol = :prod) where T
+  return direct_product([M, Ms...]; task)
+end
+function direct_product(M::Vector{<:ModuleFP{T}}; task::Symbol = :prod) where T
   F, pro, mF = direct_product([ambient_free_module(x) for x = M]..., task = :both)
   s, emb_sF = sub(F, vcat([elem_type(F)[mF[i](y) for y = ambient_representatives_generators(M[i])] for i=1:length(M)]...))
   q::Vector{elem_type(F)} = vcat([elem_type(F)[mF[i](y) for y = rels(M[i])] for i=1:length(M)]...)
@@ -127,6 +133,7 @@ function direct_product(M::ModuleFP{T}...; task::Symbol = :prod) where T
     end
   end
 end
+
 ##################################################
 # direct sum
 ##################################################
@@ -141,7 +148,10 @@ Additionally, return
 - two vectors containing the canonical injections and projections, respectively, if `task = :both`,
 - none of the above maps if `task = :none`.
 """
-function direct_sum(M::ModuleFP{T}...; task::Symbol = :sum) where {T}
+function direct_sum(M::ModuleFP{T}, Ms::ModuleFP{T}...; task::Symbol = :prod) where T
+  return direct_sum([M, Ms...]; task)
+end
+function direct_sum(M::Vector{<:ModuleFP{T}}; task::Symbol = :prod) where T
   res = direct_product(M...; task)
   if task == :sum || task == :prod
     ds, f = res

--- a/src/Modules/UngradedModules/DirectSum.jl
+++ b/src/Modules/UngradedModules/DirectSum.jl
@@ -77,7 +77,7 @@ function direct_product(M::ModuleFP{T}, Ms::ModuleFP{T}...; task::Symbol = :prod
   return direct_product([M, Ms...]; task)
 end
 function direct_product(M::Vector{<:ModuleFP{T}}; task::Symbol = :prod) where T
-  F, pro, mF = direct_product([ambient_free_module(x) for x = M]..., task = :both)
+  F, pro, mF = direct_product([ambient_free_module(x) for x = M], task = :both)
   s, emb_sF = sub(F, vcat([elem_type(F)[mF[i](y) for y = ambient_representatives_generators(M[i])] for i=1:length(M)]...))
   q::Vector{elem_type(F)} = vcat([elem_type(F)[mF[i](y) for y = rels(M[i])] for i=1:length(M)]...)
   pro_quo = nothing

--- a/src/Modules/UngradedModules/DirectSum.jl
+++ b/src/Modules/UngradedModules/DirectSum.jl
@@ -15,7 +15,7 @@ Additionally, return
 function direct_product(M::FreeMod{T}, Ms::FreeMod{T}...; task::Symbol = :prod) where T
   return direct_product([M, Ms...]; task)
 end
-function direct_product(M::Vector{<:FreeMod{T}}; task::Symbol = :prod) where T
+function direct_product(F::Vector{<:FreeMod{T}}; task::Symbol = :prod) where T
   R = base_ring(F[1])
   G = FreeMod(R, sum([rank(f) for f = F]))
   all_graded = all(is_graded, F)

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -4,11 +4,9 @@ using Aqua
   Aqua.test_all(
     Oscar;
     ambiguities=false,      # TODO: fix ambiguities
-    unbound_args=false,     # TODO: fix unbound type parameters
     piracies=false,         # TODO: check the reported methods to be moved upstream
     # Aqua persistent task does not work properly with developed dependencies
     # thus we disable these tests when running in OscarCI:
     persistent_tasks=!haskey(ENV, "oscar_run_tests"),
   )
-  @test length(Aqua.detect_unbound_args_recursively(Oscar)) <= 16
 end


### PR DESCRIPTION
This also removes some of the ambiguities for direct_product,
direct_sum, tensor_product with empty argument list.

Re-enable Aqua test for unbound type parameters.
