### PR TITLE
Fix indent in AlgebraicCycles.md

### DIFF
--- a/docs/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles.md
@@ -30,26 +30,30 @@ the variety in question.
 For complete and simplicial toric varieties, many things are
 known about the Chow ring and algebraic cycles (cf. section 12.5
 in [CLS11](@cite):
-* By therorem 12.5.3 of [CLS11](@cite), there is an isomorphism
-  among the Chow ring and the cohomology ring. Note that the
-  cohomology ring is naturally graded (cf. last paragraph
-  on page 593 in [CLS11](@cite)). However, the Chow ring
-  is usually considered as a non-graded ring. To match this general
-  convention, and in particular the implementation of the Chow ring
-  for matroids in OSCAR, the toric Chow ring is constructed as a
-  non-graded ring.
-* By therorem 12.5.3 of [CLS11](@cite), the Chow ring is isomorphic
-  to the quotient of the non-graded Cox ring and a certain ideal.
-  Specifically, the ideal in question is the sum of the ideal of
-  linear relations and the Stanley-Reisner ideal.
-* It is worth noting that the ideal of linear relations is not
-  homogeneous with respect to the class group grading of the Cox ring.
-  In order to construct the cohomology ring, one can introduce a
-  $\mathbb{Z}$-grading on the Cox ring such that the ideal of linear
-  relations and the Stanley-Reißner ideal are homogeneous.
-* Finally, by lemma 12.5.1 of [CLS11](@cite), generators of the
-  rational equivalence classes of algebraic cycles are one-to-one to
-  the cones in the fan of the toric variety.
+
+  * By therorem 12.5.3 of [CLS11](@cite), there is an isomorphism
+    among the Chow ring and the cohomology ring. Note that the
+    cohomology ring is naturally graded (cf. last paragraph
+    on page 593 in [CLS11](@cite)). However, the Chow ring
+    is usually considered as a non-graded ring. To match this general
+    convention, and in particular the implementation of the Chow ring
+    for matroids in OSCAR, the toric Chow ring is constructed as a
+    non-graded ring.
+
+  * By therorem 12.5.3 of [CLS11](@cite), the Chow ring is isomorphic
+    to the quotient of the non-graded Cox ring and a certain ideal.
+    Specifically, the ideal in question is the sum of the ideal of
+    linear relations and the Stanley-Reisner ideal.
+
+  * It is worth noting that the ideal of linear relations is not
+    homogeneous with respect to the class group grading of the Cox ring.
+    In order to construct the cohomology ring, one can introduce a
+    $\mathbb{Z}$-grading on the Cox ring such that the ideal of linear
+    relations and the Stanley-Reißner ideal are homogeneous.
+
+  * Finally, by lemma 12.5.1 of [CLS11](@cite), generators of the
+    rational equivalence classes of algebraic cycles are one-to-one to
+    the cones in the fan of the toric variety.
 
 
 ## Constructors

--- a/docs/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles.md
@@ -31,25 +31,25 @@ For complete and simplicial toric varieties, many things are
 known about the Chow ring and algebraic cycles (cf. section 12.5
 in [CLS11](@cite):
 * By therorem 12.5.3 of [CLS11](@cite), there is an isomorphism
-among the Chow ring and the cohomology ring. Note that the
-cohomology ring is naturally graded (cf. last paragraph
-on page 593 in [CLS11](@cite)). However, the Chow ring
-is usually considered as a non-graded ring. To match this general
-convention, and in particular the implementation of the Chow ring
-for matroids in OSCAR, the toric Chow ring is constructed as a
-non-graded ring.
+  among the Chow ring and the cohomology ring. Note that the
+  cohomology ring is naturally graded (cf. last paragraph
+  on page 593 in [CLS11](@cite)). However, the Chow ring
+  is usually considered as a non-graded ring. To match this general
+  convention, and in particular the implementation of the Chow ring
+  for matroids in OSCAR, the toric Chow ring is constructed as a
+  non-graded ring.
 * By therorem 12.5.3 of [CLS11](@cite), the Chow ring is isomorphic
-to the quotient of the non-graded Cox ring and a certain ideal.
-Specifically, the ideal in question is the sum of the ideal of
-linear relations and the Stanley-Reisner ideal.
+  to the quotient of the non-graded Cox ring and a certain ideal.
+  Specifically, the ideal in question is the sum of the ideal of
+  linear relations and the Stanley-Reisner ideal.
 * It is worth noting that the ideal of linear relations is not
-homogeneous with respect to the class group grading of the Cox ring.
-In order to construct the cohomology ring, one can introduce a
-$\mathbb{Z}$-grading on the Cox ring such that the ideal of linear
-relations and the Stanley-Reißner ideal are homogeneous.
+  homogeneous with respect to the class group grading of the Cox ring.
+  In order to construct the cohomology ring, one can introduce a
+  $\mathbb{Z}$-grading on the Cox ring such that the ideal of linear
+  relations and the Stanley-Reißner ideal are homogeneous.
 * Finally, by lemma 12.5.1 of [CLS11](@cite), generators of the
-rational equivalence classes of algebraic cycles are one-to-one to
-the cones in the fan of the toric variety.
+  rational equivalence classes of algebraic cycles are one-to-one to
+  the cones in the fan of the toric variety.
 
 
 ## Constructors


### PR DESCRIPTION
It looks correct on GitHub but is incorrect in https://docs.oscar-system.org/dev/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/