### PR TITLE
Name examples section in docstrings consistently

### DIFF
--- a/experimental/BasisLieHighestWeight/src/UserFunctions.jl
+++ b/experimental/BasisLieHighestWeight/src/UserFunctions.jl
@@ -6,7 +6,7 @@ together with their index.
 Operators $f_\alpha$ of negative roots are shown as the coefficients of the corresponding positive root.
 w.r.t. the simple roots $\alpha_i$.
 
-# Example
+# Examples
 ```jldoctest
 julia> basis_lie_highest_weight_operators(:B, 2)
 4-element Vector{Tuple{Int64, Vector{QQFieldElem}}}:
@@ -407,7 +407,7 @@ A birational sequence of type `Vector{Vector{Int}}` is a sequence of weights in 
 `monomial_ordering` describes the monomial ordering used for the basis.
 If this is a weighted ordering, the height of the corresponding root is used as weight.
 
-# Example
+# Examples
 ```jldoctest
 julia> bases = basis_coordinate_ring_kodaira(:G, 2, [1,0], 6; monomial_ordering = :invlex)
 6-element Vector{Tuple{MonomialBasis, Vector{ZZMPolyRingElem}}}:
@@ -510,7 +510,7 @@ The the birational sequence used consists of all operators in descening height o
 
 The monomial ordering is fixed to `degrevlex`. 
 
-# Example
+# Examples
 ```jldoctest
 julia> bases = basis_coordinate_ring_kodaira_ffl(:G, 2, [1,0], 6)
 6-element Vector{Tuple{MonomialBasis, Vector{ZZMPolyRingElem}}}:

--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -854,7 +854,7 @@ Return the abelian Lie algebra of dimension `n` over the field `R`.
 The first argument can be optionally provided to specify the type of the returned
 Lie algebra.
 
-# Example
+# Examples
 ```jldoctest
 julia> abelian_lie_algebra(LinearLieAlgebra, QQ, 3)
 Linear Lie algebra with 3x3 matrices

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -1412,7 +1412,7 @@ Compute the dimension of the simple module of the Lie algebra `L` with highest w
 using Weyl's dimension formula.
 The return value is of type `T`.
 
-# Example
+# Examples
 ```jldoctest
 julia> L = lie_algebra(QQ, :A, 3);
 
@@ -1445,7 +1445,7 @@ sorted ascendingly by the total height of roots needed to reach them from `hw`.
 
 See [MP82](@cite) for details and the implemented algorithm.
 
-# Example
+# Examples
 ```jldoctest
 julia> L = lie_algebra(QQ, :B, 3);
 
@@ -1477,7 +1477,7 @@ together with their multiplicities.
 
 This function uses an optimized version of the Freudenthal formula, see [MP82](@cite) for details.
 
-# Example
+# Examples
 ```jldoctest
 julia> L = lie_algebra(QQ, :A, 3);
 
@@ -1513,7 +1513,7 @@ Computes all weights occurring in the simple module of the Lie algebra `L` with 
 together with their multiplicities.
 This is achieved by acting with the Weyl group on the [`dominant_character`](@ref dominant_character(::LieAlgebra, ::Vector{<:IntegerUnion})).
 
-# Example
+# Examples
 ```jldoctest
 julia> L = lie_algebra(QQ, :A, 3);
 
@@ -1557,7 +1557,7 @@ This function uses Klimyk's formula (see [Hum72; Exercise 24.9](@cite)).
 
 The return type may change in the future.
 
-# Example
+# Examples
 ```jldoctest
 julia> L = lie_algebra(QQ, :A, 2);
 
@@ -1599,7 +1599,7 @@ with extremal weight `x*w`, together with their multiplicities.
 Instead of a Weyl group element `x`, a reduced expression for `x` can be supplied.
 This function may return arbitrary results if the provided expression is not reduced.
 
-# Example
+# Examples
 ```jldoctest
 julia> L = lie_algebra(QQ, :A, 2);
 

--- a/experimental/LieAlgebras/src/RootSystem.jl
+++ b/experimental/LieAlgebras/src/RootSystem.jl
@@ -1468,7 +1468,7 @@ Compute the dimension of the simple module of the Lie algebra defined by the roo
 with highest weight `hw` using Weyl's dimension formula.
 The return value is of type `T`.
 
-# Example
+# Examples
 ```jldoctest
 julia> R = root_system(:B, 2);
 
@@ -1512,7 +1512,7 @@ sorted ascendingly by the total height of roots needed to reach them from `hw`.
 
 See [MP82](@cite) for details and the implemented algorithm.
 
-# Example
+# Examples
 ```jldoctest
 julia> R = root_system(:B, 3);
 
@@ -1575,7 +1575,7 @@ with highest weight `hw`, together with their multiplicities.
 
 This function uses an optimized version of the Freudenthal formula, see [MP82](@cite) for details.
 
-# Example
+# Examples
 ```jldoctest
 julia> R = root_system(:B, 3);
 
@@ -1667,7 +1667,7 @@ Computes all weights occurring in the simple module of the Lie algebra defined b
 with highest weight `hw`, together with their multiplicities.
 This is achieved by acting with the Weyl group on the [`dominant_character`](@ref dominant_character(::RootSystem, ::WeightLatticeElem)).
 
-# Example
+# Examples
 ```jldoctest
 julia> R = root_system(:B, 3);
 
@@ -1720,7 +1720,7 @@ This function uses Klymik's formula.
 
 The return type may change in the future.
 
-# Example
+# Examples
 ```jldoctest
 julia> R = root_system(:B, 2);
 
@@ -1845,7 +1845,7 @@ with extremal weight `x*w`, together with their multiplicities.
 Instead of a Weyl group element `x`, a reduced expression for `x` can be supplied.
 This function may return arbitrary results if the provided expression is not reduced.
 
-# Example
+# Examples
 ```jldoctest
 julia> R = root_system(:B, 3);
 

--- a/experimental/MatrixGroups/src/MatrixGroups.jl
+++ b/experimental/MatrixGroups/src/MatrixGroups.jl
@@ -19,7 +19,7 @@ end
 
 Compute the JuliaMatrixRep of `m` in GAP.
 
-# Example
+# Examples
 ```jldoctest
 julia> m = matrix(ZZ, [0 1 ; -1 0]);
 
@@ -43,7 +43,7 @@ A nice monomorphism from `G` to a GAP matrix group `G2` over a finite field
 is stored in `G`, such that calculations in `G` can be handled automatically
 by transferring them to `G2`.
 
-# Example
+# Examples
 ```jldoctest
 julia> m1 = matrix(QQ, [0 1 ; -1 0]);
 

--- a/experimental/Schemes/src/Resolution_structure.jl
+++ b/experimental/Schemes/src/Resolution_structure.jl
@@ -55,7 +55,7 @@ end
 Return a `CartierDivisor` on the `domain` of `f` which is the
 exceptional divisor of the sequence of blow-ups `f`.
 
-# Example
+# Examples
 ```jldoctest
 julia> R,(x,y) = polynomial_ring(QQ,2);
 
@@ -90,7 +90,7 @@ end
 Return a `WeilDivisor` on the `domain` of `f` which is the
 exceptional divisor of the sequence of blow-ups `f`.
 
-# Example
+# Examples
 ```jldoctest
 julia> R,(x,y) = polynomial_ring(QQ,2);
 

--- a/experimental/Schemes/src/Resolution_tools.jl
+++ b/experimental/Schemes/src/Resolution_tools.jl
@@ -19,7 +19,7 @@ Return a tuple `M`, `v`, `M2`, `m` where
 !!! note
   The intersection matrix referred to in textbooks is `M2`, as these usually restrict to the case of algebraically closed fields, but computations are usually performed over suitable subfields, e.g. `QQ` instead of `CC`. 
 
-# Example
+# Examples
 ```jldoctest
 julia> R,(x,y,z) = polynomial_ring(QQ,3);
 

--- a/src/AlgebraicGeometry/Schemes/CoveredProjectiveScheme/CoveredProjectiveScheme.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredProjectiveScheme/CoveredProjectiveScheme.jl
@@ -132,7 +132,7 @@ end
 Given a ring `R`, return the empty relative projective scheme over the
 empty covered scheme over `R`.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x,y,z) = QQ[:x, :y, :z];
 

--- a/src/AlgebraicGeometry/Schemes/Divisors/WeilDivisor.jl
+++ b/src/AlgebraicGeometry/Schemes/Divisors/WeilDivisor.jl
@@ -67,7 +67,7 @@ end
 Given an ideal sheaf `I` of pure codimension ``1``, return the weil divisor $D = 1 ⋅ I$ with
 coefficients in the integer ring.
 
-# Example
+# Examples
 ```jldoctest
 julia> P, (x, y, z) = graded_polynomial_ring(QQ, [:x, :y, :z]);
 

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl
@@ -24,7 +24,7 @@ base_scheme(P::AbsProjectiveScheme) =base_scheme(underlying_scheme(P))
 On a projective scheme ``P = Proj(S)`` for a standard
 graded finitely generated algebra ``S`` this returns ``S``.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, _ = grade(QQ[:x, :y, :z][1]);
 
@@ -52,7 +52,7 @@ homogeneous_coordinate_ring(P::AbsProjectiveScheme) = homogeneous_coordinate_rin
 
 On ``X ⊂ ℙʳ_A`` this returns ``r``.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, _ = grade(QQ[:x, :y, :z][1]);
 
@@ -89,7 +89,7 @@ On a projective scheme ``P = Proj(S)`` with ``S = P/I``
 for a standard graded polynomial ring ``P`` and a
 homogeneous ideal ``I`` this returns ``P``.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, _ = grade(QQ[:x, :y, :z][1])
 (Graded multivariate polynomial ring in 3 variables over QQ, MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}[x, y, z])
@@ -133,7 +133,7 @@ end
 
 On ``X ⊂ ℙʳ_A`` this returns ``ℙʳ_A``.
 
-# Example
+# Examples
 ```jldoctest
 julia> S, _ = grade(QQ[:x, :y, :z][1]);
 
@@ -229,7 +229,7 @@ end
 On ``X ⊂ ℙʳ_A`` this returns the homogeneous
 ideal ``I ⊂ A[s₀,…,sᵣ]`` defining ``X``.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (u, v) = QQ[:u, :v];
 
@@ -265,7 +265,7 @@ from the `homogeneous_coordinate_ring` to the `coordinate_ring` of the affine co
 
 
 Note that if the base scheme is not affine, then the affine cone is not affine.
-# Example
+# Examples
 ```jldoctest
 julia> R, (u, v) = QQ[:u, :v];
 
@@ -388,7 +388,7 @@ On ``X ⊂ ℙʳ_A`` this returns a vector with the homogeneous
 coordinates ``[s₀,…,sᵣ]`` as entries where each one of the
 ``sᵢ`` is a function on the `affine cone` of ``X``.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (u, v) = QQ[:u, :v];
 

--- a/src/AlgebraicGeometry/Surfaces/duValSing.jl
+++ b/src/AlgebraicGeometry/Surfaces/duValSing.jl
@@ -3,7 +3,7 @@
 
 Return whether the given ``X`` has at most du Val (surface) singularities.
 
-# Example:
+# Examples
 ```jldoctest
 julia> R,(x,y,z,w) = QQ[:x, :y, :z, :w]
 (Multivariate polynomial ring in 4 variables over QQ, QQMPolyRingElem[x, y, z, w])
@@ -67,7 +67,7 @@ Return whether the given ``X`` has at most du Val (surface) singularities at the
 
 **Note**: For the ideal ``I`` in a ring ``R``, `dim(R/I) = 0` is asserted
 
-# Example:
+# Examples
 ```jldoctest
 julia> R,(x,y,z,w) = QQ[:x, :y, :z, :w]
 (Multivariate polynomial ring in 4 variables over QQ, QQMPolyRingElem[x, y, z, w])
@@ -147,7 +147,7 @@ If ``X`` has a least one singularity which is not du Val, the returned vector co
 
 **Note**: For the ideal ``I`` in a ring ``R``, `dim(R/I) = 0` is asserted
 
-# Example:
+# Examples
 ```jldoctest
 julia> R,(x,y,z,w) = QQ[:x, :y, :z, :w]
 (Multivariate polynomial ring in 4 variables over QQ, QQMPolyRingElem[x, y, z, w])

--- a/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/partitions.jl
@@ -489,7 +489,7 @@ order.
 
 The implemented algorithm is "partb" in [RJ76](@cite).
 
-# Example
+# Examples
 The number of partitions of 100 where the parts are from {1, 2, 5, 10, 20, 50}:
 ```jldoctest
 julia> length(collect(partitions(100, [1, 2, 5, 10, 20, 50])))

--- a/src/Combinatorics/Matroids/quantum_automorphism_groups.jl
+++ b/src/Combinatorics/Matroids/quantum_automorphism_groups.jl
@@ -10,7 +10,7 @@ The relations are:
   - idempotent relations: `n^2` relations
   - relations of type `u[i,j]*u[i,k]` and `u[j,i]*u[k,i]` for `k != j`: `2*n*n*(n-1)` relations
 
-# Example
+# Examples
 
 ```jldoctest
 julia> S4 = quantum_symmetric_group(4);

--- a/src/PolyhedralGeometry/Cone/properties.jl
+++ b/src/PolyhedralGeometry/Cone/properties.jl
@@ -379,7 +379,7 @@ lineality_dim(C::Cone) = pm_object(C).LINEALITY_DIM::Int
 Facet degrees of the cone. The degree of a facet is the number of adjacent facets. 
 In particular a general $2$-dimensional cone has two facets (rays) that meet at the origin. 
 
-# Example
+# Examples
 Produce the facet degrees of a cone over a square and a cone over a square pyramid. 
 ```jldoctest
 julia> c = positive_hull([1 1 0; 1 -1 0; 1 0 1; 1 0 -1])

--- a/src/PolyhedralGeometry/Polyhedron/properties.jl
+++ b/src/PolyhedralGeometry/Polyhedron/properties.jl
@@ -900,7 +900,7 @@ codim(P::Polyhedron) = ambient_dim(P) - dim(P)
 
 Number of vertices in each facet. 
 
-# Example
+# Examples
 ```jldoctest
 julia> p = johnson_solid(4) 
 Polytope in ambient dimension 3 with EmbeddedAbsSimpleNumFieldElem type coefficients
@@ -929,7 +929,7 @@ end
 
 Number of incident facets for each vertex.
 
-# Example
+# Examples
 ```jldoctest
 julia> vertex_sizes(bipyramid(simplex(2)))
 5-element Vector{Int64}:

--- a/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
+++ b/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
@@ -1353,7 +1353,7 @@ $(n+1)$-space. SIM-bodies are defined in [GK14](@cite), but the input needs to
 be descending instead of ascending, as used in [JKS22](@cite), i.e. `alpha` has parameters
 $(a_1,\dots,a_n)$ such that $a_1 \geq \dots \geq a_n \geq 0$.  
 
-# Example
+# Examples
 To produce a $2$-dimensional SIM-body, use for example the following code. 
 Note that the polytope lives in $3$-space, so we project it down to $2$-space 
 by eliminating the last coordinate. 
@@ -1392,7 +1392,7 @@ We use the facet description given in section 9.2. of [Zie95](@cite).
 Note that in polymake, this function has an optional Boolean parameter `group`, to
 also construct the symmetry group of the polytope. For details, see [CSZ15](@cite).
 
-# Example
+# Examples
 Produce the $2$-dimensional associahedron is a polygon in $\mathbb{R}⁴$ having $5$ vertices
 and $5$ facets.
 ```jldoctest
@@ -1455,7 +1455,7 @@ binary_markov_graph_polytope(observation::AbstractVector{<:Base.Integer}) =
 
 Produce the $d$-dimensional dwarfed cube as defined in [ABS97](@cite). 
 
-# Example
+# Examples
 The $3$-dimensional dwarfed cube is illustrated in [Jos03](@cite).
 
 ```jldoctest
@@ -1487,7 +1487,7 @@ end
 Produce a $d$-dimensional dwarfed product of polygons of size $s$ as defined in [ABS97](@cite).
 It must be $d\geq4$ and even as well as $s\geq 3$.
 
-# Example
+# Examples
 ```jldoctest
 julia> p = dwarfed_product_polygons(4,3)
 Polytope in ambient dimension 4
@@ -1522,7 +1522,7 @@ as defined in [SS12](@cite).
 Note that in polymake, this function has an optional Boolean parameter `group`, to
 also construct the symmetry group of the simplex.  
 
-# Example
+# Examples
 The $3$-dimensional lecture hall simplex:
 ```jldoctest
 julia> S = lecture_hall_simplex(3) 
@@ -1576,7 +1576,7 @@ Produce a $d$-dimensional cyclic polytope with $n$ points. Clearly $n\geq d$ is 
 It is a prototypical example of a neighborly polytope whose combinatorics completely known 
 due to Gale's evenness criterion. The coordinates are chosen on the trigonometric moment curve.
 
-# Example
+# Examples
 ```jldoctest
 julia> C= cyclic_caratheodory_polytope(4,5)
 Polytope in ambient dimension 4
@@ -1628,7 +1628,7 @@ Produce the hypersimplex $\Delta(k,d)$, that is the the convex hull of all $0/1$
 - `no_facets::Bool`: If set equal to `true`, facets of the underlying `polymake` object are not computed.
 - `no_vif::Bool`: If set equal to `true`, vertices in facets of the underlying `polymake` object are not computed.
 
-# Example
+# Examples
 ```jldoctest
 julia> H = hypersimplex(3,4)
 Polytope in ambient dimension 4
@@ -1714,7 +1714,7 @@ Here we use the description as a deformed product due to [AZ99](@cite).
 For $g=0$ we obtain a Klee-Minty cube, 
 in particular for $e=g=0$ we obtain the standard cube. 
 
-# Example
+# Examples
 The following produces a $3$-dimensional Klee-Minty cube for $e=\frac{1}{3}$.
 ```jldoctest
 julia> c = goldfarb_cube(3,1//3,0)
@@ -1785,7 +1785,7 @@ Produce a $d$-dimensional hypertruncated cube with symmetric linear objective fu
 - `k`: cutoff parameter
 - `lambda`: scaling of extra vertex
 
-# Example
+# Examples
 ```jldoctest
 julia> H = hypertruncated_cube(3,2,3)
 Polytope in ambient dimension 3
@@ -1823,7 +1823,7 @@ Warning: Some of the $k-$cyclic polytopes are not simplicial.
 Since the components are rounded, this function might output a polytope which is 
 not a $k-$cyclic polytope! More information see [Sch95](@cite).
 
-# Example
+# Examples
 To produce a (not exactly) regular pentagon, type this:
 ```jldoctest
 julia> p = k_cyclic_polytope(5,[1])
@@ -1873,7 +1873,7 @@ Produce a `d`-dimensional polytope of maximal Gomory-Chvatal rank $\Omega(d/\log
 integrally infeasible. With symmetric linear objective function $(1,1..,1)$. 
 Construction due to Pokutta and Schulz, see [PS11](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> c = max_GC_rank_polytope(3)
 Polytope in ambient dimension 3
@@ -1936,7 +1936,7 @@ end
 
 Create an $8$-dimensional polytope without rational realizations due to Perles. See [Gru03](@cite).
 
-# Example
+# Examples
 ```jldoctest
 julia> perles_nonrational_8_polytope()
 Polytope in ambient dimension 8 with EmbeddedAbsSimpleNumFieldElem type coefficients
@@ -2013,7 +2013,7 @@ pitman_stanley_polytope(y::AbstractVector{<:IntegerUnion}) = pitman_stanley_poly
 Produce a `d`-dimensional del-Pezzo polytope, which is the convex hull of the cross polytope 
 together with the all-ones vector. All coordinates are plus or minus one.
 
-# Example
+# Examples
 ```jldoctest
 julia> DP = pseudo_del_pezzo_polytope(4)
 Polytope in ambient dimension 4
@@ -2039,7 +2039,7 @@ Produce a `d`-dimensional $0/1$-polytope with `n` random vertices. Uniform distr
 # Optional Argument
 -`seed::Int`: Seed for random number generation
 
-# Example
+# Examples
 ```jldoctest
 julia> s = rand01_polytope(2, 4; seed=3)
 Polytope in ambient dimension 2
@@ -2074,7 +2074,7 @@ points in the cube $[0,\texttt{b}]^{\texttt{d}}$.
 # Optional Argument
 -`seed`: Seed for random number generation.
 
-# Example
+# Examples
 ```jldoctest
 julia> r = rand_box_polytope(3, 10, 3, seed=1)
 Polyhedron in ambient dimension 3
@@ -2192,7 +2192,7 @@ normally distributed in the unit ball.
 -`seed`: controls the outcome of the random number generator; fixing a seed number guarantees the same outcome
 -`precision`: number of bits for MPFR sphere approximation
 
-# Example
+# Examples
 ```jldoctest
 julia> rnp = rand_normal_polytope(2,4; seed=42, precision=4)
 Polytope in ambient dimension 2
@@ -2421,7 +2421,7 @@ Construct the vertex figure of the vertex `n` of a bounded polytope. The vertex 
   Value $0$ would let the hyperplane go through the chosen vertex, thus degenerating the vertex figure to a single point. 
   Value $1$ would let the hyperplane touch the nearest neighbor vertex of a polyhedron. Default value is $\frac{1}{2}$. 
 
-# Example
+# Examples
 To produce a triangular vertex figure of a $3$-dimensional cube in the positive orthant, do: 
 ```jldoctest
 julia> T = vertex_figure(cube(3), 8) 

--- a/src/Serialization/Upgrades/main.jl
+++ b/src/Serialization/Upgrades/main.jl
@@ -18,7 +18,7 @@ from any Oscar code and should rely solely on `julia` core
 functionality so to avoid conflicts with any future Oscar code
 deprecations.
 
-# Example
+# Examples
 ```
 push!(upgrade_scripts_set, UpgradeScript(
   v"0.13.0",

--- a/src/TropicalGeometry/groebner_basis.jl
+++ b/src/TropicalGeometry/groebner_basis.jl
@@ -209,7 +209,7 @@ end
 
 Return an integer vector `wSim` so that the (tropical) Groebner basis of an ideal `I` with respect to `w` corresponds to the standard basis of its simulation with respect to `wSim`.  If `perturbation!=nothing`, also returns a corresponding `perturbationSim`.
 
-# Example
+# Examples
 ```jldoctest
 julia> nuMin = tropical_semiring_map(QQ,2);
 
@@ -305,7 +305,7 @@ end
 
 Given a weight vector `wSim` on the simulation ring, return weight vector `w` on the original polynomial ring so that a standard basis with respect to `wSim` corresponds to a (tropical) Groebner basis with respect to `w`.
 
-# Example
+# Examples
 ```jldoctest
 julia> nuMin = tropical_semiring_map(QQ,2);
 

--- a/src/TropicalGeometry/semiring_map.jl
+++ b/src/TropicalGeometry/semiring_map.jl
@@ -59,7 +59,7 @@ polynomial_rings_for_initial(nu::TropicalSemiringMap) = nu.polynomial_rings_for_
 
 Return a map `nu` from `K` to the min (default) or max tropical semiring `T` such that `nu(0)=zero(T)` and `nu(c)=one(T)` for `c` non-zero.  In other words, `nu` extends the trivial valuation on `K`.
 
-# Example
+# Examples
 ```jldoctest
 julia> nu = tropical_semiring_map(QQ) # arbitrary rings possible
 Map into Min tropical semiring encoding the trivial valuation on Rational field
@@ -122,7 +122,7 @@ end
 
 Return a map `nu` from `QQ` to the min (default) or max tropical semiring `T` such that `nu(0)=zero(T)` and `nu(c)=+/-val(c)` for `c` non-zero, where `val` denotes the `p`-adic valuation.  Requires `p` to be a prime.
 
-# Example
+# Examples
 ```jldoctest
 julia> nu_2 = tropical_semiring_map(QQ,2)
 Map into Min tropical semiring encoding the 2-adic valuation on Rational field
@@ -192,7 +192,7 @@ end
 
 Return a map `nu` from rational function field `Kt` to the min (default) or max tropical semiring `T` such that `nu(0)=zero(T)` and `nu(c)=+/-val(c)` for `c` non-zero, where `val` denotes the `t`-adic valuation with uniformizer `t`.  Requires `t` to be non-constant and have denominator `1`.
 
-# Example
+# Examples
 ```jldoctest
 julia> Kt,t = rational_function_field(QQ,"t");
 

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -60,7 +60,7 @@ end
 
 Fixes all doctests for the given function `f`.
 
-# Example
+# Examples
 The following call fixes all doctests for the function `symmetric_group`:
 ```julia
 julia> Oscar.doctest_fix(symmetric_group)
@@ -89,7 +89,7 @@ end
 Fixes all doctests for all files in Oscar where
 `path` occurs in the full pathname.
 
-# Example
+# Examples
 The following call fixes all doctests in files that live in a directory
 called `Rings` (or a subdirectory thereof), so e.g. everything in `src/Rings/`:
 ```julia


### PR DESCRIPTION
The Julia style guide suggest to use '# Examples' uniformly, even if
there is just one example.
