### PR TITLE
Fix bug in comparison function in module orderings

### DIFF
--- a/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
@@ -164,7 +164,7 @@ julia> collect(terms(f))
  2*y*e[2]
  3*e[1]
 
-julia> collect(terms(f, ordering = lex(F)*lex(R)))
+julia> collect(terms(f, ordering = invlex(F)*lex(R)))
 6-element Vector{FreeModElem{QQMPolyRingElem}}:
  5*x*y^2*e[1]
  -y^10*e[1]
@@ -179,7 +179,7 @@ julia> tail(f)
 julia> leading_exponent(f)
 ([0, 10], 1)
 
-julia> leading_exponent(f, ordering = lex(F)*lex(R))
+julia> leading_exponent(f, ordering = invlex(F)*lex(R))
 ([1, 2], 1)
 ```
 

--- a/docs/src/CommutativeAlgebra/GroebnerBases/orderings.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/orderings.md
@@ -399,8 +399,8 @@ $x^\alpha e_i >  x^\beta e_j \iff i > j \;\text{ or }\; (i = j\;\text{ and } x^\
 Alternatively, we may wish to use $i < j$ instead of $i > j$ in this definition.
 
 In other words, these orderings are obtained by concatenating a monomial ordering on the monomials of $R$
-with a way of ordering the basis vectors of $F$ or vice versa. In OSCAR, we refer to the $i < j$ ordering on the
-basis vectors as *lex*, and to the $i > j$ ordering as *invlex*. And, we use the `*` operator for concatenation. 
+with a way of ordering the basis vectors of $F$ or vice versa. In OSCAR, we refer to the $i > j$ ordering on the
+basis vectors as *lex*, and to the $i < j$ ordering as *invlex*. And, we use the `*` operator for concatenation.
 
 ##### Examples
 

--- a/src/Modules/FreeModElem-orderings.jl
+++ b/src/Modules/FreeModElem-orderings.jl
@@ -23,10 +23,10 @@ julia> R, (x, y) = polynomial_ring(QQ, [:x, :y]);
 
 julia> F = FreeMod(R, 3);
 
-julia> cmp(lex(R)*lex(F), x*F[2], y*F[1])
+julia> cmp(lex(R)*invlex(F), x*F[2], y*F[1])
 1
 
-julia> cmp(lex(F)*lex(R), x*F[2], y*F[1])
+julia> cmp(invlex(F)*lex(R), x*F[2], y*F[1])
 -1
 
 julia> cmp(lex(F)*lex(R), x*F[1], x*F[1])

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -1581,7 +1581,7 @@ julia> cmp(lex([x,y,z]), z, one(R))
 julia> F = free_module(R, 2)
 Free module of rank 2 over R
 
-julia> cmp(lex(R)*invlex(F), F[1], F[2])
+julia> cmp(lex(R)*lex(F), F[1], F[2])
 -1
 ```
 """

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -1863,9 +1863,9 @@ function _cmp_vector_monomials(
   n::Int, g::MPolyRingElem, l::Int,
   o::ModOrdering)
 
-  if o.ord == :lex
+  if o.ord == :invlex
     return m < n ? 1 : m > n ? -1 : 0
-  elseif o.ord == :invlex
+  elseif o.ord == :lex
     return m > n ? 1 : m < n ? -1 : 0
   else
     error("oops")

--- a/test/Modules/FreeModElem-orderings.jl
+++ b/test/Modules/FreeModElem-orderings.jl
@@ -5,7 +5,7 @@
 
   @test length(string(terms(a))) > 2
 
-  o = lex(R)*lex(F)
+  o = lex(R)*invlex(F)
 
   @test collect(coefficients(a; ordering = o)) ==
     [2, 2, 3, 3, 4, 4, 5, 5, 1, 1]
@@ -41,10 +41,10 @@
   t = tail(a)
   @test a == leading_term(a) + t
 
-  @test collect(terms(a; ordering = lex([w,x])*invlex(F)*lex([y,z]))) ==
+  @test collect(terms(a; ordering = lex([w,x])*lex(F)*lex([y,z]))) ==
     [2*w*F[2], 2*w*F[1], 3*x*F[2], 3*x*F[1],
      4*y*F[2], 5*z*F[2], F[2], 4*y*F[1], 5*z*F[1], F[1]]
 
-  @test_throws ErrorException induced_ring_ordering(invlex(F))
-  @test induced_ring_ordering(lex([w,x])*invlex(F)*lex([y,z])) == lex([w,x,y,z])
+  @test_throws ErrorException induced_ring_ordering(lex(F))
+  @test induced_ring_ordering(lex([w,x])*lex(F)*lex([y,z])) == lex([w,x,y,z])
 end

--- a/test/Rings/orderings.jl
+++ b/test/Rings/orderings.jl
@@ -356,6 +356,8 @@ end
    @test string(singular(O4)) == "ordering_M([1 1 0 1 0; 0 -1 0 -1 0; 0 0 0 -1 0; 0 0 1 0 1; 0 0 0 0 -1])"
 
    K = free_module(R, 4)
+   @test cmp(lex(K), gen(K,1), gen(K,2)) == -1
+   @test cmp(invlex(K), gen(K,1), gen(K,2)) == 1
 
    O5 = invlex(gens(K))*degrevlex(gens(R))
    @test monomial_ordering(R, singular(O5)) == degrevlex(gens(R))

--- a/test/book/specialized/decker-schmitt-invariant-theory/H3.jlcon
+++ b/test/book/specialized/decker-schmitt-invariant-theory/H3.jlcon
@@ -60,9 +60,9 @@ julia> L = syzygy_generators([hessian(G), F, hessian(F)]);
 
 julia> collect(coefficients(L[1]))
 3-element Vector{AbstractAlgebra.Generic.FracFieldElem{QQPolyRingElem}}:
- -1
- -279936*t
  t^3 + 93312
+ -279936*t
+ -1
 
 julia> C, iC = center(H3);
 


### PR DESCRIPTION
This should fix #4303. (@Syz-MS, @afkafkafk13):

The problem for the above issue was not the connection between Oscar and Singular, but the wrong implementation of the comparison function for `lex` and `invlex` for modules (which was accidently also described in this wrong way in the Oscar docu).

Maybe we need to adjust some tests, we will see.