### PR TITLE
Set torusfactor attribute

### DIFF
--- a/experimental/Schemes/src/ToricBlowups/types.jl
+++ b/experimental/Schemes/src/ToricBlowups/types.jl
@@ -70,6 +70,9 @@
       typeof(center_data),
       typeof(center_unnormalized),
     }(bl_toric, position_new_ray, center_data, center_unnormalized)
+    if has_attribute(v, :has_torusfactor)
+      set_attribute!(bl, :has_torusfactor, has_torusfactor(v))
+    end
     return bl
   end
   
@@ -86,6 +89,9 @@
       typeof(center_data),
       IdealSheaf{typeof(v), AbsAffineScheme, Ideal, Map},
     }(bl_toric, position_new_ray, center_data)
+    if has_attribute(v, :has_torusfactor)
+      set_attribute!(bl, :has_torusfactor, has_torusfactor(v))
+    end
     return bl
   end
 end


### PR DESCRIPTION
Blowing up along a ray does not change whether the toric variety has torus factors.