### PR TITLE
Remove various `FOO_type` methods

### DIFF
--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
@@ -864,9 +864,6 @@ ring_type(::Type{AffineSchemeType}) where {BRT, RT, AffineSchemeType<:AbsAffineS
 ring_type(X::AbsAffineScheme) = ring_type(typeof(X))
 
 base_ring_type(::Type{AffineSchemeType}) where {BRT, RT, AffineSchemeType<:AbsAffineScheme{BRT, RT}} = BRT
-base_ring_type(X::AbsAffineScheme) = base_ring_type(typeof(X))
-base_ring_elem_type(::Type{AffineSchemeType}) where {BRT, RT, AffineSchemeType<:AbsAffineScheme{BRT, RT}} = elem_type(BRT)
-base_ring_elem_type(X::AbsAffineScheme) = base_ring_elem_type(typeof(X))
 
 poly_type(::Type{AffineSchemeType}) where {BRT, RT<:MPolyRing, AffineSchemeType<:AbsAffineScheme{BRT, RT}} = elem_type(RT)
 poly_type(::Type{AffineSchemeType}) where {BRT, T, RT<:MPolyQuoRing{T}, AffineSchemeType<:AbsAffineScheme{BRT, RT}} = T
@@ -877,5 +874,4 @@ poly_type(X::AbsAffineScheme) = poly_type(typeof(X))
 ring_type(::Type{AffineScheme{BRT, RT}}) where {BRT, RT} = RT
 ring_type(X::AffineScheme) = ring_type(typeof(X))
 base_ring_type(::Type{AffineScheme{BRT, RT}}) where {BRT, RT} = BRT
-base_ring_type(X::AffineScheme) = base_ring_type(typeof(X))
 

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Attributes.jl
@@ -7,7 +7,6 @@
 # Type getters                                                         #
 ########################################################################
 base_ring_type(::Type{T}) where {BRT, T<:AbsCoveredScheme{BRT}} = BRT
-base_ring_type(X::AbsCoveredScheme) = base_ring_type(typeof(X))
 
 ########################################################################
 # Basic getters                                                        #

--- a/src/AlgebraicGeometry/Schemes/Covering/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/Covering/Objects/Attributes.jl
@@ -3,7 +3,6 @@
 # Type getters                                                         #
 ########################################################################
 base_ring_type(::Type{Covering{T}}) where {T} = T
-base_ring_type(C::Covering) = base_ring_type(typeof(C))
 
 ### type constructors
 #covering_type(::Type{T}) where {T<:AffineScheme} = Covering{T, gluing_type(T)}

--- a/src/AlgebraicGeometry/Schemes/Divisors/AlgebraicCycles.jl
+++ b/src/AlgebraicGeometry/Schemes/Divisors/AlgebraicCycles.jl
@@ -17,8 +17,6 @@ scheme_type(D::AbsAlgebraicCycle{S, U}) where {S, U} = S
 scheme_type(::Type{AbsAlgebraicCycle{S, U}}) where {S, U} = S
 coefficient_ring_type(D::AbsAlgebraicCycle{S, U}) where {S, U} = U
 coefficient_ring_type(::Type{AbsAlgebraicCycle{S, U}}) where {S, U} = U
-coefficient_ring_elem_type(D::AbsAlgebraicCycle{S, U}) where {S, U} = elem_type(U)
-coefficient_ring_elem_type(::Type{AbsAlgebraicCycle{S, U}}) where {S, U} = elem_type(U)
 
 ### essential getters and functionality
 

--- a/src/AlgebraicGeometry/Schemes/Divisors/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/Divisors/Types.jl
@@ -80,7 +80,8 @@ ideal sheaves on ``X``.
         dim(X) - dim(D) == 1 || error("components of a divisor must be of codimension one")
       end
     end
-    return new{typeof(X), coefficient_ring_type(C), coefficient_ring_elem_type(C)}(C)
+    CRT = coefficient_ring_type(C)
+    return new{typeof(X), CRT, elem_type(CRT)}(C)
   end
 end
 

--- a/src/AlgebraicGeometry/Schemes/Divisors/WeilDivisor.jl
+++ b/src/AlgebraicGeometry/Schemes/Divisors/WeilDivisor.jl
@@ -9,8 +9,6 @@ scheme_type(D::AbsWeilDivisor{S, U}) where{S, U} = S
 scheme_type(::Type{AbsWeilDivisor{S, U}}) where{S, U} = S
 coefficient_ring_type(D::AbsWeilDivisor{S, U}) where{S, U} = U
 coefficient_ring_type(::Type{AbsWeilDivisor{S, U}}) where{S, U} = U
-coefficient_type(D::AbsWeilDivisor{S, U}) where{S, U} = elem_type(U)
-coefficient_type(::Type{AbsWeilDivisor{S, U}}) where{S, U} = elem_type(U)
 
 @doc raw"""
     WeilDivisor(X::CoveredScheme, R::Ring)

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl
@@ -485,7 +485,6 @@ projective_scheme_type(A::T) where {T<:AbstractAlgebra.Ring} = projective_scheme
 projective_scheme_type(::Type{T}) where {T<:AbstractAlgebra.Ring} =
 ProjectiveScheme{T, mpoly_dec_ring_type(mpoly_ring_type(T))}
 
-base_ring_type(P::ProjectiveScheme) = base_ring_type(typeof(P))
 base_ring_type(::Type{ProjectiveScheme{S, T}}) where {S, T} = S
 
 ring_type(P::ProjectiveScheme) = ring_type(typeof(P))

--- a/src/Modules/Posur.jl
+++ b/src/Modules/Posur.jl
@@ -244,7 +244,7 @@ function base_ring_module(F::FreeMod{T}) where {T<:AbsLocalizedRingElem}
   return get_attribute(F, :base_ring_module)::base_ring_module_type(F)
 end
 
-base_ring_module_type(::Type{FreeMod{T}}) where {T<:AbsLocalizedRingElem} = FreeMod{base_ring_elem_type(T)}
+base_ring_module_type(::Type{FreeMod{T}}) where {T<:AbsLocalizedRingElem} = FreeMod{elem_type(base_ring_type(T))}
 base_ring_module_type(F::FreeMod{T}) where {T<:AbsLocalizedRingElem} = base_ring_module_type(typeof(F))
 
 # for a free module F ≅ Sʳ over a localized ring S = R[U⁻¹] this 
@@ -262,7 +262,7 @@ end
 # which contains all generators and relations for the saturation that have already 
 # been cached. 
 function pre_saturated_module(M::SubquoModule{T}) where {T<:AbsLocalizedRingElem}
-  has_attribute(M, :saturated_module) && return get_attribute(M, :saturated_module)::SubquoModule{base_ring_elem_type(T)}
+  has_attribute(M, :saturated_module) && return get_attribute(M, :saturated_module)::SubquoModule{elem_type(base_ring_type(T))}
   if !has_attribute(M, :pre_saturated_module)
     (A, D) = clear_denominators(generator_matrix(M))
     (B, E) = clear_denominators(relations_matrix(M))
@@ -275,7 +275,7 @@ function pre_saturated_module(M::SubquoModule{T}) where {T<:AbsLocalizedRingElem
     set_attribute!(M, :pre_saturation_data_rels, change_base_ring(S, E))
     set_attribute!(M, :pre_saturated_module, Mb)
   end
-  return get_attribute(M, :pre_saturated_module)::SubquoModule{base_ring_elem_type(T)}
+  return get_attribute(M, :pre_saturated_module)::SubquoModule{elem_type(base_ring_type(T))}
 end
 
 # For a SubquoModule M over a localized ring S = R[U⁻¹] and its current 
@@ -637,7 +637,7 @@ end
 
 function base_ring_module(M::SubquoModule{T}) where {T<:AbsLocalizedRingElem}
   has_attribute(M, :base_ring_module) || error("there is no associated module over the base ring")
-  get_attribute(M, :base_ring_module)::SubquoModule{base_ring_elem_type(T)}
+  get_attribute(M, :base_ring_module)::SubquoModule{elem_type(base_ring_type(T))}
 end
 
 function set_base_ring_module(F::FreeMod{LRET}, N::FreeMod{BRET}) where {LRET<:AbsLocalizedRingElem, BRET<:RingElem}

--- a/src/Modules/UngradedModules/FreeModuleHom.jl
+++ b/src/Modules/UngradedModules/FreeModuleHom.jl
@@ -259,10 +259,6 @@ function morphism_type(::Type{T}, ::Type{U}) where {T<:AbstractFreeMod, U<:Modul
 end
 
 base_ring_type(::Type{ModuleType}) where {T, ModuleType<:ModuleFP{T}} = parent_type(T)
-base_ring_elem_type(::Type{ModuleType}) where {T, ModuleType<:ModuleFP{T}} = T
-
-base_ring_type(M::ModuleType) where {ModuleType<:ModuleFP} = base_ring_type(typeof(M))
-base_ring_elem_type(M::ModuleType) where {ModuleType<:ModuleFP} = base_ring_elem_type(typeof(M))
 
 function morphism_type(F::AbstractFreeMod, G::ModuleFP, h::RingMapType) where {RingMapType}
   return FreeModuleHom{typeof(F), typeof(G), typeof(h)}

--- a/src/Modules/mpolyquo-localizations.jl
+++ b/src/Modules/mpolyquo-localizations.jl
@@ -75,7 +75,7 @@ function has_solution(A::MatrixType, b::MatrixType) where {T<:MPolyQuoLocRingEle
 end
 
 function pre_saturated_module(M::SubquoModule{T}) where {T<:MPolyQuoLocRingElem}
-  has_attribute(M, :saturated_module) && return get_attribute(M, :saturated_module)::SubquoModule{base_ring_elem_type(T)}
+  has_attribute(M, :saturated_module) && return get_attribute(M, :saturated_module)::SubquoModule{elem_type(base_ring_type(T))}
   if !has_attribute(M, :pre_saturated_module)
     S = base_ring(M)
     R = base_ring(S)
@@ -95,7 +95,7 @@ function pre_saturated_module(M::SubquoModule{T}) where {T<:MPolyQuoLocRingElem}
     set_attribute!(M, :pre_saturation_data_rels, change_base_ring(S, E))
     set_attribute!(M, :pre_saturated_module, Mb)
   end
-  return get_attribute(M, :pre_saturated_module)::SubquoModule{base_ring_elem_type(T)}
+  return get_attribute(M, :pre_saturated_module)::SubquoModule{elem_type(base_ring_type(T))}
 end
 
 # The kernel routine has to be overwritten since the base_ring_module of a

--- a/src/Rings/localization_interface.jl
+++ b/src/Rings/localization_interface.jl
@@ -289,11 +289,7 @@ end
 @enable_all_show_via_expressify AbsLocalizedRingElem
 
 # type getters
-base_ring_elem_type(::Type{T}) where {BRT, BRET, T<:AbsLocalizedRingElem{BRT, BRET}} = BRET
 base_ring_type(::Type{T}) where {BRT, BRET, T<:AbsLocalizedRingElem{BRT, BRET}} = BRT
-
-base_ring_elem_type(L::AbsLocalizedRing) = base_ring_elem_type(typeof(L))
-base_ring_type(L::AbsLocalizedRing) = base_ring_type(typeof(L))
 
 
 ########################################################################

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -118,12 +118,8 @@ const MPolyAnyRing = Union{MPolyRing, MPolyQuoRing,
 ### type getters 
 coefficient_ring_type(::Type{MPolyQuoLocRing{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST} = BRT
 coefficient_ring_type(L::MPolyQuoLocRing{BRT, BRET, RT, RET, MST}) where {BRT, BRET, RT, RET, MST} = coefficient_ring_type(typeof(L))
-coefficient_ring_elem_type(::Type{MPolyQuoLocRing{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST} = BRET
-coefficient_ring_elem_type(L::MPolyQuoLocRing{BRT, BRET, RT, RET, MST}) where {BRT, BRET, RT, RET, MST} = coefficient_ring_elem_type(typeof(L))
 
 base_ring_type(::Type{MPolyQuoLocRing{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST} = RT
-base_ring_elem_type(::Type{MPolyQuoLocRing{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST} = RET
-base_ring_elem_type(L::MPolyQuoLocRing{BRT, BRET, RT, RET, MST}) where {BRT, BRET, RT, RET, MST} = base_ring_elem_type(typeof(L))
 
 mult_set_type(::Type{MPolyQuoLocRing{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST} = MST
 mult_set_type(L::MPolyQuoLocRing{BRT, BRET, RT, RET, MST}) where {BRT, BRET, RT, RET, MST} = mult_set_type(typeof(L))
@@ -432,17 +428,12 @@ end
 
 ### type getters
 coefficient_ring_type(::Type{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST} = BRT
-coefficient_ring_type(f::MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}) where {BRT, BRET, RT, RET, MST} = base_ring_type(typeof(f))
-coefficient_ring_elem_type(::Type{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST} = BRET
-coefficient_ring_elem_type(f::MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}) where {BRT, BRET, RT, RET, MST} = base_ring_type(typeof(f))
+coefficient_ring_type(f::MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}) where {BRT, BRET, RT, RET, MST} = coefficient_ring_type(typeof(f))
 
 base_ring_type(::Type{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST} = RT
-base_ring_type(f::MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}) where {BRT, BRET, RT, RET, MST} = base_ring_type(typeof(f))
-base_ring_elem_type(::Type{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST} = RET
-base_ring_elem_type(f::MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}) where {BRT, BRET, RT, RET, MST} = base_ring_type(typeof(f))
 
 mult_set_type(::Type{MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}}) where {BRT, BRET, RT, RET, MST} = MST
-mult_set_type(f::MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}) where {BRT, BRET, RT, RET, MST} = base_ring_type(typeof(f))
+mult_set_type(f::MPolyQuoLocRingElem{BRT, BRET, RT, RET, MST}) where {BRT, BRET, RT, RET, MST} = mult_set_type(typeof(f))
 
 ### required getter functions 
 parent(a::MPolyQuoLocRingElem) = a.L
@@ -1229,7 +1220,7 @@ end
 # Sets up the ring S[c⁻¹] from the Lemma.
 function helper_ring(f::MPolyQuoLocalizedRingHom{<:Any, <:MPolyQuoLocRing})
   if !has_attribute(f, :helper_ring)
-    minimal_denominators = Vector{base_ring_elem_type(domain(f))}()
+    minimal_denominators = Vector{elem_type(base_ring_type(domain(f)))}()
     R = base_ring(domain(f))
     S = base_ring(codomain(f))
     p = one(S)
@@ -1261,7 +1252,7 @@ function helper_images(
   if !has_attribute(f, :helper_images) 
     helper_ring(f)
   end
-  return get_attribute(f, :helper_images)::Vector{base_ring_elem_type(domain(f))}
+  return get_attribute(f, :helper_images)::Vector{elem_type(base_ring_type(domain(f)))}
 end
 
 function minimal_denominators(
@@ -1270,7 +1261,7 @@ function minimal_denominators(
   if !has_attribute(f, :minimal_denominators) 
     helper_ring(f)
   end
-  return get_attribute!(f, :minimal_denominators)::Vector{base_ring_elem_type(domain(f))}
+  return get_attribute!(f, :minimal_denominators)::Vector{elem_type(base_ring_type(domain(f)))}
 end
 
 function helper_eta(
@@ -1297,7 +1288,7 @@ function common_denominator(
   if !has_attribute(f, :minimal_denominators) 
     helper_ring(f)
   end
-  d = get_attribute(f, :minimal_denominators)::Vector{base_ring_elem_type(domain(f))}
+  d = get_attribute(f, :minimal_denominators)::Vector{elem_type(base_ring_type(domain(f)))}
   return (length(d) == 0 ? one(base_ring(codomain(f))) : prod(d))
 end
 
@@ -2814,10 +2805,8 @@ _compose(f::Any, g::Any, dom::Any, cod::Any) = MapFromFunc(dom, cod, x->g(f(x)))
 morphism_type(::Type{DT}, ::Type{CT}) where {DT<:MPolyLocRing, CT<:Ring} = MPolyLocalizedRingHom{DT, CT, morphism_type(base_ring_type(DT), CT)}
 
 base_ring_type(::Type{T}) where {BRT, T<:MPolyLocRing{<:Any, <:Any, BRT}} = BRT
-base_ring_elem_type(::Type{T}) where {BRET, T<:MPolyLocRing{<:Any, <:Any, <:Any, BRET}} = BRET
 
 base_ring_type(::Type{T}) where {BRT, T<:MPolyQuoLocRing{<:Any, <:Any, BRT}} = BRT
-base_ring_elem_type(::Type{T}) where {BRET, T<:MPolyQuoLocRing{<:Any, <:Any, <:Any, BRET}} = BRET
 
 function dim(R::MPolyQuoLocRing)
   return dim(modulus(R))

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -372,7 +372,6 @@ export codomain_covering
 export coefficient_field
 export coefficient_ring
 export coefficient_ring_type
-export coefficient_type
 export coefficients
 export coefficients_and_exponents
 export cohomology

--- a/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
+++ b/test/AlgebraicGeometry/Schemes/AffineSchemes.jl
@@ -200,7 +200,6 @@ end
   @test ambient_coordinate_ring(U) === R
   @test Oscar.ring_type(V) == typeof(OO(V))
   @test Oscar.base_ring_type(typeof(V)) == typeof(QQ)
-  @test Oscar.base_ring_elem_type(V) == QQFieldElem
   @test base_ring(V) == QQ
   @test is_subscheme(V,U)
   @test is_subscheme(U,V)


### PR DESCRIPTION
The following were removed:
- `base_ring_elem_type`: use `elem_type(base_ring_type(x))` instead
- `coefficient_ring_elem_type`: use `elem_type(coefficient_ring_type(x))` instead
- `coefficient_type`: ditto

Also remove some redundant `base_ring_type` methods.

Finally fix several incorrect delegations.