### PR TITLE
Fix a bib entry

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -683,12 +683,13 @@
   doi           = {10.1090/gsm/063}
 }
 
-@Article{D-VJL24,
+@Misc{D-VJL24,
   author        = {Della Vecchia, Antony and Joswig, Michael and Lenzen, Fabian},
   title         = {Partial Algebraic Shifting},
   year          = {2024},
   eprint        = {2410.24044},
-  archiveprefix = {arXiv}
+  archiveprefix = {arXiv},
+  primaryclass  = {math.CO}
 }
 
 @InCollection{DE02,


### PR DESCRIPTION
Building the documentation currently prints the following error:
```
┌ Error: Entry D-VJL24 is missing the journal field(s).
└ @ BibInternal ~/.julia/packages/BibInternal/2EG8G/src/bibtex.jl:89
```
This is resolved here by following the last bullet point of https://docs.oscar-system.org/dev/DeveloperDocumentation/documentation/#Updating-the-bibliography, i.e. arxiv-only references need to be of type `@Misc` instead of `@Article`.