### PR TITLE
LieAlgebras: Add section with Dynkin diagrams to docs

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -440,6 +440,16 @@
   doi           = {10.1112/S0025579300011773}
 }
 
+@Book{Bou02,
+  author        = {Bourbaki, Nicolas},
+  title         = {Lie Groups and Lie Algebras: Chapters 4--6},
+  series        = {Elements of Mathematics},
+  note          = {Original French edition published with the title: Éléments de Matematique, Groupes et Algèbres de
+                  Lie 4, 5, e 6, 1968. Translated by Pressley},
+  publisher     = {Springer},
+  year          = {2002}
+}
+
 @Book{Bur11,
   author        = {Burnside, W.},
   title         = {Theory of groups of finite order},

--- a/experimental/LieAlgebras/docs/src/cartan_matrix.md
+++ b/experimental/LieAlgebras/docs/src/cartan_matrix.md
@@ -38,6 +38,65 @@ cartan_bilinear_form(::ZZMatrix)
 
 ## Cartan types
 
+Cartan types and, in particular, the ordering of simple roots are used differently in the literature.
+OSCAR follows the conventions of [Bourbaki](@cite), i.e. we consider the following Dynkin diagrams
+for the Cartan types (where the ordering of simple roots is given by the numbering of the vertices):
+
+- ``A_n`` (for ``n \geq 1``):
+  ```
+  1 - 2 - 3 - ... - n-1 - n
+  ```
+
+- ``B_n`` (for ``n \geq 2``):
+  ```
+  1 - 2 - 3 - ... - n-1 >=> n
+  ```
+
+- ``C_n`` (for ``n \geq 2``):
+  ```
+  1 - 2 - 3 - ... - n-1 <=< n
+  ```
+
+- ``D_n`` (for ``n \geq 4``):
+  ```
+                        n-1
+                      /
+  1 - 2 - 3 - ... - n-2
+                      \
+                        n
+  ```
+
+- ``E_6``:
+  ```
+  1 - 3 - 4 - 5 - 6
+          |
+          2
+  ```
+
+- ``E_7``:
+  ```
+  1 - 3 - 4 - 5 - 6 - 7
+          |
+          2
+  ```
+
+- ``E_8``:
+  ```
+  1 - 3 - 4 - 5 - 6 - 7 - 8
+          |
+          2
+  ```
+
+- ``F_4``:
+  ```
+  1 - 2 >=> 3 - 4
+  ```
+
+- ``G_2``:
+  ```
+  1 <<< 2
+  ```
+
 The following function is used to verify the validity of a Cartan type, and is thus used in input sanitization.
 ```@docs
 is_cartan_type(::Symbol, ::Int)

--- a/experimental/LieAlgebras/docs/src/cartan_matrix.md
+++ b/experimental/LieAlgebras/docs/src/cartan_matrix.md
@@ -42,7 +42,7 @@ cartan_bilinear_form(::ZZMatrix)
 ## Cartan types
 
 Cartan types and, in particular, the ordering of simple roots are used differently in the literature.
-OSCAR follows the conventions of [Bourbaki](@cite), i.e. we consider the following Dynkin diagrams
+OSCAR follows the conventions of [Bou02; Plates I-IX](@cite) and [Hum72; Thm 11.4](@cite), i.e. we consider the following Dynkin diagrams
 for the Cartan types (where the ordering of simple roots is given by the numbering of the vertices):
 
 - ``A_n`` (for ``n \geq 1``):

--- a/experimental/LieAlgebras/docs/src/cartan_matrix.md
+++ b/experimental/LieAlgebras/docs/src/cartan_matrix.md
@@ -12,6 +12,9 @@ Many functions taking a Cartan matrix as input (like [`root_system`](@ref) and [
 !!! note
     The convention for Cartan matrices in OSCAR is $(a_{ij}) = (\langle \alpha_i^\vee, \alpha_j \rangle)$ for simple roots $\alpha_i$.
 
+!!! note
+    See [Cartan types](@ref) for our conventions on Cartan types and ordering of simple roots.
+
 ## Table of contents
 
 ```@contents

--- a/experimental/LieAlgebras/docs/src/introduction.md
+++ b/experimental/LieAlgebras/docs/src/introduction.md
@@ -6,7 +6,7 @@ DocTestSetup = Oscar.doctestsetup()
 # Introduction
 
 This project aims to provide functionality for Lie algebras and their representations.
-It aims to provide the computational tools to work with the concepts defined in [Hum72](@cite).
+It aims to provide the computational tools to work with the concepts defined in [Hum72](@cite) and [Bou02](@cite).
 
 ## Status
 

--- a/experimental/LieAlgebras/docs/src/root_systems.md
+++ b/experimental/LieAlgebras/docs/src/root_systems.md
@@ -16,6 +16,9 @@ The relevant types around root systems are:
     Most functionality around root systems is currently only intended to be used with root systems of finite type.
     For root systems of affine type, some documentation may be ill-phrased or incorrect, and some functions may not work as intended.
 
+!!! note
+    See [Cartan types](@ref) for our conventions on Cartan types and ordering of simple roots.
+
 ## Table of contents
 
 ```@contents

--- a/experimental/LieAlgebras/docs/src/weight_lattices.md
+++ b/experimental/LieAlgebras/docs/src/weight_lattices.md
@@ -9,6 +9,8 @@ Weight lattices are represented by objects of type `WeightLattice <: AdditiveGro
 
 They are introduced to have a formal parent object of all weights that correspond to a common given root system.
 
+!!! note
+    See [Cartan types](@ref) for our conventions on Cartan types and ordering of simple roots.
 
 ## Table of contents
 

--- a/experimental/LieAlgebras/docs/src/weyl_groups.md
+++ b/experimental/LieAlgebras/docs/src/weyl_groups.md
@@ -12,6 +12,9 @@ Weyl groups are represented by objects of type `WeylGroup <: Group`, and their e
     Note however, that this may differ from the literature, but is to stay
     consistent with the conventions in the rest of OSCAR.
 
+!!! note
+    See [Cartan types](@ref) for our conventions on Cartan types and ordering of simple roots.
+
 ## Table of contents
 
 ```@contents

--- a/experimental/LieAlgebras/src/CartanMatrix.jl
+++ b/experimental/LieAlgebras/src/CartanMatrix.jl
@@ -1,7 +1,7 @@
 ###############################################################################
 #
 #   Cartan Matrix Functionality
-#   - Cartan matrices (and root orderings) are taken from Bourbaki
+#   - Cartan matrices (and root orderings) are taken from Bou02 Plates I-IX
 #
 ###############################################################################
 

--- a/experimental/LieAlgebras/src/DynkinDiagram.jl
+++ b/experimental/LieAlgebras/src/DynkinDiagram.jl
@@ -64,12 +64,12 @@ function show_dynkin_diagram(fam::Symbol, rk::Int)
 end
 
 @doc raw"""
-    show_dynkin_diagram(fam::Symbol, rk::Int, labels::Vector{Int}) -> Nothing
+    show_dynkin_diagram(fam::Symbol, rk::Int, labels::Vector) -> Nothing
 
 Prints a string representation of the Dynkin diagram of the root system of
 the given cartan type, where the $i$-th node is labeled by `labels[i]`.
 """
-function show_dynkin_diagram(fam::Symbol, rk::Int, labels::AbstractVector{Int})
+function show_dynkin_diagram(fam::Symbol, rk::Int, labels::AbstractVector)
   @req is_cartan_type(fam, rk) "Invalid cartan type"
   @req length(labels) == rk "Invalid number of labels"
   D = ""


### PR DESCRIPTION
preview: https://docs.oscar-system.org/previews/PR4390/Experimental/LieAlgebras/cartan_matrix/

~~The bib-entry for the Bourbaki is still missing (ping @felix-roehrich).~~