### PR TITLE
Support `character_field` for a vector of characters

### DIFF
--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -101,6 +101,7 @@ GAP.@wrap FamilyObj(x::GAP.Obj)::GapObj
 GAP.@wrap FamilyPcgs(x::GAP.Obj)::GapObj
 GAP.@wrap fhmethsel(x::GapObj)::GAP.Obj
 GAP.@wrap Field(x::Any)::GapObj
+GAP.@wrap Flat(x::GapObj)::GapObj
 GAP.@wrap FreeAbelianGroup(x::Int)::GapObj
 GAP.@wrap FreeGeneratorsOfFpGroup(x::GapObj)::GapObj
 GAP.@wrap FreeGroupOfFpGroup(x::GapObj)::GapObj

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -828,6 +828,10 @@ end
   @test tr == t[end]
   @test tr == trivial_character(g)
   @test !is_faithful(tr)
+  @test 2 * tr == tr + tr
+  @test ZZ(2) * tr == tr + tr
+  @test tr^2 == tr
+  @test tr^ZZ(2) == tr
   re = regular_character(g)
   @test coordinates(re) == degree.(t)
   re = regular_character(t)
@@ -1052,6 +1056,7 @@ end
   tbl = character_table("A5")
   @test [degree(character_field(chi)[1]) for chi in tbl] == [1, 2, 2, 1, 1]
   @test characteristic(character_field(tbl[1])[1]) == 0
+  @test degree(character_field(collect(tbl))[1]) == 2
 
   for id in [ "C5", "A5" ]   # cyclotomic and non-cyclotomic number fields
     for chi in character_table(id)
@@ -1108,6 +1113,7 @@ end
   @test [order(character_field(chi)[1]) for chi in modtbl] == [2, 4, 4, 2]
   @test order_field_of_definition(Int, modtbl[1]) isa Int
   @test_throws ArgumentError order_field_of_definition(ordtbl[1])
+  @test degree(character_field(collect(modtbl))[1]) == 2
 end
 
 @testset "Schur index" begin


### PR DESCRIPTION
This feature turned out to be useful in the computations with S-characters.