### PR TITLE
fix two obvious duplicates in the list of groups with 14 classes

### DIFF
--- a/src/Groups/libraries/VeraLopez.json
+++ b/src/Groups/libraries/VeraLopez.json
@@ -21,7 +21,6 @@
 "The following errors in the papers were fixed. ",
 "- There are 3 not 4 groups of order 100 with 10 classes. ",
 "- For each of the orders 36, 48, 384, one group with 12 classes was missing. ",
-"- For order 288, two groups with 14 classes were missing. ",
 "(Besides these errors, several structure descriptions in the papers are ",
 "wrong, but here we do not care about structure descriptions.)"
 ],[[
@@ -193,8 +192,8 @@
 [336,114],
 [392,38],
 [432,734],
-[720,764],
 [720,763],
+[720,764],
 [1344,814],
 [1344,11686],
 [1512,779],
@@ -364,8 +363,6 @@
 [240,192],
 [288,1025],
 [288,1026],
-[288,1025],
-[288,1026],
 [294,1],
 [294,13],
 [294,14],
@@ -403,6 +400,6 @@
 ["prim",8,6],
 ["prim",56,3],
 ["prim",21,5],
-["prim",56,2],
+["prim",56,4],
 ["prim",50,1]
 ]]]


### PR DESCRIPTION
and change the ordering of two pairs of groups

Meanwhile I have learned that there is [an OEIS entry for the number of groups with a given number of classes](https://oeis.org/A073043).
Currently this entry is wrong, but the history of this entry documents that it is complicated to get errors in the OEIS corrected, thus it will take some time until this happens.
There is also [a related/derived OEIS entry](https://oeis.org/A003061) which is wrong for another reason.

Via the OEIS entry, I have learned that there is [a GAP package that provides the groups with up to 14 classes](https://github.com/stertooy/SmallClassNr). The contents of that package now fits to the list in Oscar.
I think that the more lightweight and more portable approach in Oscar (JSON format data referencing available group databases, compared to explicit GAP format data) is better than that GAP package.