### PR TITLE
Add conformance tests for `VarietyFunctionField`, add `base_ring_type` method

### DIFF
--- a/src/AlgebraicGeometry/Schemes/FunctionField/FunctionFields.jl
+++ b/src/AlgebraicGeometry/Schemes/FunctionField/FunctionFields.jl
@@ -354,6 +354,7 @@ function parent_type(::Type{T}) where {ParentType, T<:VarietyFunctionFieldElem{<
 end
 
 base_ring(KK::VarietyFunctionField) = base_ring(representative_field(KK))
+base_ring_type(::Type{T}) where {FracFieldType, T<:VarietyFunctionField{<:Field, FracFieldType}} = base_ring_type(FracFieldType)
 is_domain_type(::Type{T}) where {T<:VarietyFunctionFieldElem} = true
 is_exact_type(::Type{T}) where {T<:VarietyFunctionFieldElem} = true
 

--- a/src/AlgebraicGeometry/Schemes/FunctionField/FunctionFields.jl
+++ b/src/AlgebraicGeometry/Schemes/FunctionField/FunctionFields.jl
@@ -353,8 +353,6 @@ function parent_type(::Type{T}) where {ParentType, T<:VarietyFunctionFieldElem{<
   return ParentType
 end
 
-base_ring(KK::VarietyFunctionField) = base_ring(representative_field(KK))
-base_ring_type(::Type{T}) where {FracFieldType, T<:VarietyFunctionField{<:Field, FracFieldType}} = base_ring_type(FracFieldType)
 is_domain_type(::Type{T}) where {T<:VarietyFunctionFieldElem} = true
 is_exact_type(::Type{T}) where {T<:VarietyFunctionFieldElem} = true
 
@@ -370,7 +368,10 @@ function Base.deepcopy_internal(f::VarietyFunctionFieldElem, dict::IdDict)
 end
 
 (KK::VarietyFunctionField)() = zero(KK)
-(KK::VarietyFunctionField)(a::Integer) = KK(base_ring(KK)(a), one(base_ring(KK)), check=false)
+function (KK::VarietyFunctionField)(a::Integer)
+  R = base_ring(representative_field(KK))
+  KK(R(a), one(R), check=false)
+end
 (KK::VarietyFunctionField)(f::VarietyFunctionFieldElem) = (parent(f) == KK ? f : error("element does not belong to the given field"))
 (KK::VarietyFunctionField)(a::MPolyRingElem) = KK(a, one(parent(a)), check=false)
 canonical_unit(f::VarietyFunctionFieldElem) = f # part of the ring interface that becomes trivial for fields

--- a/src/AlgebraicGeometry/Schemes/FunctionField/FunctionFields.jl
+++ b/src/AlgebraicGeometry/Schemes/FunctionField/FunctionFields.jl
@@ -353,6 +353,9 @@ function parent_type(::Type{T}) where {ParentType, T<:VarietyFunctionFieldElem{<
   return ParentType
 end
 
+base_ring(KK::VarietyFunctionField) = KK.kk
+base_ring_type(::Type{T}) where {R, T<:VarietyFunctionField{R}} = R
+
 is_domain_type(::Type{T}) where {T<:VarietyFunctionFieldElem} = true
 is_exact_type(::Type{T}) where {T<:VarietyFunctionFieldElem} = true
 

--- a/test/AlgebraicGeometry/Schemes/FunctionFields.jl
+++ b/test/AlgebraicGeometry/Schemes/FunctionFields.jl
@@ -4,8 +4,10 @@ function test_elem(K::VarietyFunctionField)
   F = representative_field(K)
   P = base_ring(F)::MPolyRing
   num = rand(P, 0:5, 0:5, 0:5)
-  den = rand(P, 1:5, 1:5, 1:5)
-  is_zero(den) && return test_elem(K) # Try again
+  den = zero(P)
+  while is_zero(den)
+    den = rand(P, 1:5, 1:5, 1:5)
+  end
   return K(num, den)
 end
 
@@ -15,7 +17,6 @@ end
   C = subscheme(P, ideal(S, S[1]*S[2]-S[3]^2))
   Ccov = covered_scheme(C)
   KK = VarietyFunctionField(Ccov)
-  @test base_ring_type(KK) === typeof(base_ring(KK))
 
   test_Field_interface(KK)
   #test_Field_interface_recursive(KK)  # FIXME: lots of ambiguity errors

--- a/test/AlgebraicGeometry/Schemes/FunctionFields.jl
+++ b/test/AlgebraicGeometry/Schemes/FunctionFields.jl
@@ -1,3 +1,18 @@
+function test_elem(K::VarietyFunctionField)
+   return rand([one(K), zero(K),  K(3) // K(2)])
+end
+
+@testset "fraction fields of varieties" begin
+  P = projective_space(QQ, 2)
+  S = homogeneous_coordinate_ring(P)
+  C = subscheme(P, ideal(S, S[1]*S[2]-S[3]^2))
+  Ccov = covered_scheme(C)
+  KK = VarietyFunctionField(Ccov)
+
+  test_Field_interface(KK)
+  #test_Field_interface_recursive(KK)  # FIXME: lots of ambiguity errors
+end
+
 @testset "fraction fields of varieties" begin
   R, (x,y,z) = QQ[:x, :y, :z]
   @test is_irreducible(spec(R))

--- a/test/AlgebraicGeometry/Schemes/FunctionFields.jl
+++ b/test/AlgebraicGeometry/Schemes/FunctionFields.jl
@@ -1,5 +1,12 @@
+const rng = Oscar.get_seeded_rng()
+
 function test_elem(K::VarietyFunctionField)
-   return rand([one(K), zero(K),  K(3) // K(2)])
+  F = representative_field(K)
+  P = base_ring(F)::MPolyRing
+  num = rand(P, 0:5, 0:5, 0:5)
+  den = rand(P, 1:5, 1:5, 1:5)
+  is_zero(den) && return test_elem(K) # Try again
+  return K(num, den)
 end
 
 @testset "fraction fields of varieties" begin

--- a/test/AlgebraicGeometry/Schemes/FunctionFields.jl
+++ b/test/AlgebraicGeometry/Schemes/FunctionFields.jl
@@ -15,6 +15,7 @@ end
   C = subscheme(P, ideal(S, S[1]*S[2]-S[3]^2))
   Ccov = covered_scheme(C)
   KK = VarietyFunctionField(Ccov)
+  @test base_ring_type(KK) === typeof(base_ring(KK))
 
   test_Field_interface(KK)
   #test_Field_interface_recursive(KK)  # FIXME: lots of ambiguity errors


### PR DESCRIPTION
The alternative to removing the `base_ring` method would be to add a `base_ring_type` method (that's what the first commit in this PR does; the second then removes it and `base_ring`).

This would benefit from a better `test_elem` implementation, perhaps @HechtiDerLachs can help out with that.