### PR TITLE
Use Zenodo data as artifact

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -120,6 +120,27 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  extra-large-test:
+    # Extra large tests
+    # Only happen during the nightly run, trigerred by cron
+    if: github.event_name == 'schedule'
+    runs-on: [Linux, RPTU, normal-memory]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: "Set up Julia"
+        id: setup-julia
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: "1.10"
+      - name: "Build package"
+        uses: julia-actions/julia-buildpkg@v1
+      - name: "set test subgroup"
+        run: echo "OSCAR_TEST_SUBSET=extra-long" >> $GITHUB_ENV
+      - name: "Run tests"
+        uses: julia-actions/julia-runtest@latest
+
   doctest:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 150

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -120,9 +120,9 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  extra-large-test:
-    # Extra large tests
-    # Only happens during the daily run, trigerred by cron
+  extra-long-test:
+    # Extra long tests
+    # Only happens during the daily run, triggered by schedule
     if: github.event_name == 'schedule'
     runs-on: [Linux, RPTU, normal-memory]
     steps:
@@ -137,7 +137,7 @@ jobs:
       - name: "Build package"
         uses: julia-actions/julia-buildpkg@v1
       - name: "set test subgroup"
-        run: echo "OSCAR_TEST_SUBSET=extra-long" >> $GITHUB_ENV
+        run: echo "OSCAR_TEST_SUBSET=extra_long" >> $GITHUB_ENV
       - name: "Run tests"
         uses: julia-actions/julia-runtest@latest
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -122,7 +122,7 @@ jobs:
 
   extra-large-test:
     # Extra large tests
-    # Only happen during the nightly run, trigerred by cron
+    # Only happens during the daily run, trigerred by cron
     if: github.event_name == 'schedule'
     runs-on: [Linux, RPTU, normal-memory]
     steps:

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -4,7 +4,7 @@ lazy = true
 
     [[FTM-1511-03209.download]]
     sha256 = "77f85f1e4a2c3b71963bea169b929dd8c1d9b3cf9b28b616f2c91486636acc22"
-    url = "https://zenodo.org/records/14611045/files/1511-03209.tar.gz?download=1"
+    url = "https://zenodo.org/records/14611045/files/1511-03209.tar.gz"
 
 [QSMDB]
 git-tree-sha1 = "52686066016440cf2e6e286a923aed887658543c"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,3 +1,11 @@
+[FTM-1511-03209]
+git-tree-sha1 = "ba4c659df6bba8d746d85628bfedf8b77b77047c"
+lazy = true
+
+    [[FTM-1511-03209.download]]
+    sha256 = "77f85f1e4a2c3b71963bea169b929dd8c1d9b3cf9b28b616f2c91486636acc22"
+    url = "https://zenodo.org/records/14611045/files/1511-03209.tar.gz?download=1"
+
 [QSMDB]
 git-tree-sha1 = "52686066016440cf2e6e286a923aed887658543c"
 lazy = true

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
@@ -793,6 +793,13 @@ Partially resolved global Tate model over a concrete base -- SU(5)xU(1) restrict
 ```
 """
 function resolve(m::AbstractFTheoryModel, resolution_index::Int)
+
+  # For model 1511.03209 and resolution_index = 1, a particular resolution is available from an artifact
+  if resolution_index == 1 && arxiv_id(m) == "1511.03209"
+    model_data_path = artifact"FTM-1511-03209"
+    return load(joinpath(model_data_path, "1511-03209-resolved.mrdi"))
+  end
+
   # To be extended to hypersurface models...
   entry_test = (m isa GlobalTateModel) || (m isa WeierstrassModel)
   @req entry_test "Resolve currently supported only for Weierstrass and Tate models"

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
@@ -796,8 +796,8 @@ function resolve(m::AbstractFTheoryModel, resolution_index::Int)
 
   # For model 1511.03209 and resolution_index = 1, a particular resolution is available from an artifact
   if resolution_index == 1 && arxiv_id(m) == "1511.03209"
-    model_data_path = artifact"FTM-1511-03209"
-    return load(joinpath(model_data_path, "1511-03209-resolved.mrdi"))
+    model_data_path = artifact"FTM-1511-03209/1511-03209-resolved.mrdi"
+    return load(model_data_path)
   end
 
   # To be extended to hypersurface models...

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -249,8 +249,8 @@ function literature_model(model_dict::Dict{String, Any}; model_parameters::Dict{
   # (2b) The F-theory model with the largest number of flux vacua needs special attention
   if model_dict["arxiv_data"]["id"] == "1511.03209"
 
-    model_data_path = artifact"FTM-1511-03209"
-    return load(joinpath(model_data_path, "1511-03209.mrdi"))
+    model_data_path = artifact"FTM-1511-03209/1511-03209.mrdi"
+    return load(model_data_path)
 
     # Old code to create this model from scratch. I leave this here, so we can go back if needed.
     #=

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -248,12 +248,20 @@ function literature_model(model_dict::Dict{String, Any}; model_parameters::Dict{
 
   # (2b) The F-theory model with the largest number of flux vacua needs special attention
   if model_dict["arxiv_data"]["id"] == "1511.03209"
+
+    model_data_path = artifact"FTM-1511-03209"
+    return load(joinpath(model_data_path, "1511-03209.mrdi"))
+
+    # Old code to create this model from scratch. I leave this here, so we can go back if needed.
+    #=
     directory = joinpath(@__DIR__, "Models/1511_03209/1511-03209-base-space.mrdi")
     base_space = load(directory)
     set_attribute!(base_space, :coordinate_names, ["w$i" for i in 0:100])
     model = global_tate_model(base_space, completeness_check = false)
     _set_all_attributes(model, model_dict, model_parameters)
     return model
+    =#
+    
   end
 
   # (3) Construct the model over concrete or arbitrary base

--- a/experimental/FTheoryTools/test/FTM-1511-03209.jl
+++ b/experimental/FTheoryTools/test/FTM-1511-03209.jl
@@ -1,7 +1,7 @@
-h = literature_model(arxiv_id = "1511.03209")
-h_resolved = resolve(h, 1)
-
 @testset "Test Downloading Artifact and elementary properties" begin
+  h = literature_model(arxiv_id = "1511.03209")
+  h_resolved = resolve(h, 1)
+
   @test n_rays(ambient_space(h)) == 104
   @test n_rays(ambient_space(h_resolved)) == 310
 end

--- a/experimental/FTheoryTools/test/FTM-1511-03209.jl
+++ b/experimental/FTheoryTools/test/FTM-1511-03209.jl
@@ -1,0 +1,7 @@
+h = literature_model(arxiv_id = "1511.03209")
+h_resolved = resolve(h, 1)
+
+@testset "Test Downloading Artifact and elementary properties" begin
+  @test n_rays(ambient_space(h)) == 104
+  @test n_rays(ambient_space(h_resolved)) == 310
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,10 +92,10 @@ Random.shuffle!(Oscar.get_seeded_rng(), testlist)
 
 # tests with the highest number of allocations / runtime / compilation time
 # more or less sorted by allocations are in `long`
-# tests that should not be run for pull request CI are in `extra_large`
+# tests that should not be run for pull request CI are in `extra_long`
 # (these are run on a custom schedule only)
 test_subsets = Dict(
-              :extra_large => [
+               :extra_long => [
                                "experimental/FTheoryTools/test/FTM-1511-03209.jl",
                               ],
 
@@ -138,8 +138,8 @@ if test_subset == :short
 elseif haskey(test_subsets, test_subset)
   filter!(x-> in(relpath(x, Oscar.oscardir), test_subsets[test_subset]), testlist)
 elseif test_subset == :default
-  # no extra large by default
-  filter!(x-> !in(relpath(x, Oscar.oscardir), test_subsets[:extra_large]), testlist)
+  # no extra long by default
+  filter!(x-> !in(relpath(x, Oscar.oscardir), test_subsets[:extra_long]), testlist)
   if !(Sys.islinux() && v"1.10" <= VERSION < v"1.11.0-DEV")
     # and book tests only on 1.10 and linux
     @info "Skipping Oscar book tests"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,55 +91,60 @@ sort!(testlist)
 Random.shuffle!(Oscar.get_seeded_rng(), testlist)
 
 # tests with the highest number of allocations / runtime / compilation time
-# more or less sorted by allocations
-test_extra_large = [
-              "experimental/FTheoryTools/test/FTM-1511-03209.jl",
-             ]
+# more or less sorted by allocations are in `large`
+# tests that should not be run for pull request CI are in `extra_large`
+# (these are run on a custom schedule only)
+test_subsets = Dict(
+              :extra_large => [
+                               "experimental/FTheoryTools/test/FTM-1511-03209.jl",
+                              ],
 
-test_large = [
-              "test/Aqua.jl",
-              "experimental/FTheoryTools/test/weierstrass.jl",
-              "test/PolyhedralGeometry/timing.jl",
-              "experimental/GITFans/test/runtests.jl",
-              "test/AlgebraicGeometry/ToricVarieties/toric_schemes.jl",
-              "test/AlgebraicGeometry/Schemes/WeilDivisor.jl",
-              "test/Rings/NumberField.jl",
-              "test/Serialization/PolynomialsSeries.jl",
-              "test/AlgebraicGeometry/Schemes/K3.jl",
-              "test/Groups/forms.jl",
-              "test/Modules/UngradedModules.jl",
-              "test/GAP/oscarinterface.jl",
-              "test/AlgebraicGeometry/Schemes/CoveredProjectiveSchemes.jl",
-              "test/AlgebraicGeometry/Schemes/CoveredScheme.jl",
-              "test/AlgebraicGeometry/Schemes/DerivedPushforward.jl",
-              "test/AlgebraicGeometry/Schemes/MorphismFromRationalFunctions.jl",
-              "experimental/QuadFormAndIsom/test/runtests.jl",
-              "experimental/GModule/test/runtests.jl",
-              "experimental/LieAlgebras/test/LieAlgebraModule-test.jl",
-              "test/Modules/ModulesGraded.jl",
-              "test/AlgebraicGeometry/Schemes/EllipticSurface.jl",
-             ]
-test_book = [
-             "test/book/test.jl",
-            ]
+                    :large => [
+                               "test/Aqua.jl",
+                               "experimental/FTheoryTools/test/weierstrass.jl",
+                               "test/PolyhedralGeometry/timing.jl",
+                               "experimental/GITFans/test/runtests.jl",
+                               "test/AlgebraicGeometry/ToricVarieties/toric_schemes.jl",
+                               "test/AlgebraicGeometry/Schemes/WeilDivisor.jl",
+                               "test/Rings/NumberField.jl",
+                               "test/Serialization/PolynomialsSeries.jl",
+                               "test/AlgebraicGeometry/Schemes/K3.jl",
+                               "test/Groups/forms.jl",
+                               "test/Modules/UngradedModules.jl",
+                               "test/GAP/oscarinterface.jl",
+                               "test/AlgebraicGeometry/Schemes/CoveredProjectiveSchemes.jl",
+                               "test/AlgebraicGeometry/Schemes/CoveredScheme.jl",
+                               "test/AlgebraicGeometry/Schemes/DerivedPushforward.jl",
+                               "test/AlgebraicGeometry/Schemes/MorphismFromRationalFunctions.jl",
+                               "experimental/QuadFormAndIsom/test/runtests.jl",
+                               "experimental/GModule/test/runtests.jl",
+                               "experimental/LieAlgebras/test/LieAlgebraModule-test.jl",
+                               "test/Modules/ModulesGraded.jl",
+                               "test/AlgebraicGeometry/Schemes/EllipticSurface.jl",
+                              ],
+                     :book => [
+                               "test/book/test.jl",
+                              ]
+                   )
 
-test_subset = get(ENV, "OSCAR_TEST_SUBSET", "")
+test_subset = Symbol(get(ENV, "OSCAR_TEST_SUBSET", "default"))
 if haskey(ENV, "JULIA_PKGEVAL")
-  test_subset = "short"
+  test_subset = :short
 end
 
-if test_subset == "short"
-  filter!(x-> !in(relpath(x, Oscar.oscardir), [test_large; test_book]), testlist)
-elseif test_subset == "long"
-  filter!(x-> in(relpath(x, Oscar.oscardir), test_large), testlist)
-elseif test_subset == "book"
-  filter!(x-> in(relpath(x, Oscar.oscardir), test_book), testlist)
-elseif test_subset == "extra_long"
-  filter!(x-> in(relpath(x, Oscar.oscardir), test_extra_large), testlist)
-elseif test_subset == "" && !(Sys.islinux() && v"1.10" <= VERSION < v"1.11.0-DEV")
-  # book tests only on 1.10 and linux
-  @info "Skipping Oscar book tests"
-  filter!(x-> !in(relpath(x, Oscar.oscardir), test_book), testlist)
+if test_subset == :short
+  # short are all files not in a specific group
+  filter!(x-> !in(relpath(x, Oscar.oscardir), reduce(vcat, values(test_subsets))), testlist)
+elseif haskey(test_subsets, test_subset)
+  filter!(x-> in(relpath(x, Oscar.oscardir), test_subsets[test_subset]), testlist)
+elseif test_subset == :default
+  # no extra large by default
+  filter!(x-> !in(relpath(x, Oscar.oscardir), test_subsets[:extra_large]), testlist)
+  if !(Sys.islinux() && v"1.10" <= VERSION < v"1.11.0-DEV")
+    # and book tests only on 1.10 and linux
+    @info "Skipping Oscar book tests"
+    filter!(x-> !in(relpath(x, Oscar.oscardir), test_subsets[:book]), testlist)
+  end
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,6 +92,10 @@ Random.shuffle!(Oscar.get_seeded_rng(), testlist)
 
 # tests with the highest number of allocations / runtime / compilation time
 # more or less sorted by allocations
+test_extra_large = [
+              "experimental/FTheoryTools/test/FTM-1511-03209.jl",
+             ]
+
 test_large = [
               "test/Aqua.jl",
               "experimental/FTheoryTools/test/weierstrass.jl",
@@ -130,6 +134,8 @@ elseif test_subset == "long"
   filter!(x-> in(relpath(x, Oscar.oscardir), test_large), testlist)
 elseif test_subset == "book"
   filter!(x-> in(relpath(x, Oscar.oscardir), test_book), testlist)
+elseif test_subset == "extra_long"
+  filter!(x-> in(relpath(x, Oscar.oscardir), test_extra_large), testlist)
 elseif test_subset == "" && !(Sys.islinux() && v"1.10" <= VERSION < v"1.11.0-DEV")
   # book tests only on 1.10 and linux
   @info "Skipping Oscar book tests"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,7 +91,7 @@ sort!(testlist)
 Random.shuffle!(Oscar.get_seeded_rng(), testlist)
 
 # tests with the highest number of allocations / runtime / compilation time
-# more or less sorted by allocations are in `large`
+# more or less sorted by allocations are in `long`
 # tests that should not be run for pull request CI are in `extra_large`
 # (these are run on a custom schedule only)
 test_subsets = Dict(
@@ -99,7 +99,7 @@ test_subsets = Dict(
                                "experimental/FTheoryTools/test/FTM-1511-03209.jl",
                               ],
 
-                    :large => [
+                    :long  => [
                                "test/Aqua.jl",
                                "experimental/FTheoryTools/test/weierstrass.jl",
                                "test/PolyhedralGeometry/timing.jl",
@@ -145,6 +145,8 @@ elseif test_subset == :default
     @info "Skipping Oscar book tests"
     filter!(x-> !in(relpath(x, Oscar.oscardir), test_subsets[:book]), testlist)
   end
+else
+  error("invalid test subset specified via `OSCAR_TEST_SUBSET` environment variable")
 end
 
 


### PR DESCRIPTION
The tar ball provided at https://zenodo.org/records/14611045 (version 2) can be downloaded. It contains two .mrdi files, which are the OSCAR serialization of two F-theory models. Creating these two models by loading in the .mrdi files takes about 5 to 10 minutes, each. Computing these models from scratch takes probably half an hour/3-4 hours, respectively. A stark improvement, that we must use.

@benlorenz The tar ball at zenodo is about 400MB in size. I would love to add a test for this artifact/creating the model. However, it seems to me, that this would burn too many resources. Any idea/suggestion?

cc @emikelsons @apturner 