### PR TITLE
Fix `R()` when `R` is a `BoundedRing`

### DIFF
--- a/src/NumberTheory/GaloisGrp/GaloisGrp.jl
+++ b/src/NumberTheory/GaloisGrp/GaloisGrp.jl
@@ -102,7 +102,7 @@ Oscar.elem_type(::Type{BoundRing{T}}) where T = BoundRingElem{T}
 
 (R::BoundRing{T})(a::ZZRingElem) where T = BoundRingElem{T}(R.map(abs(a)), R)
 (R::BoundRing{T})(a::Integer) where T = BoundRingElem{T}(ZZRingElem(a), R)
-(R::BoundRing{T})() where T = BoundRingElem{T}(ZZRingElem(0), R)
+(R::BoundRing{T})() where T = zero(R)
 (R::BoundRing{T})(a::T) where T = BoundRingElem{T}(a, R)
 (R::BoundRing{T})(a::BoundRingElem{T}) where T = a
 Oscar.one(R::BoundRing) = R(1)


### PR DESCRIPTION
Before:
```
julia> B
(x <= (11, 0, 1//3))

julia> parent(B)()
ERROR: MethodError: Cannot `convert` an object of type ZZRingElem to an object of type Tuple{ZZRingElem, Int64, QQFieldElem}
The function `convert` exists, but no method is defined for this combination of argument types.
[...]

Stacktrace:
 [1] Oscar.GaloisGrp.BoundRingElem{Tuple{…}}(val::ZZRingElem, p::Oscar.GaloisGrp.BoundRing{Tuple{…}})
   @ Oscar.GaloisGrp ~/blabla/Oscar.jl/src/NumberTheory/GaloisGrp/GaloisGrp.jl:56
```

The Galois group code uses univariate evaluation, which we want to change in https://github.com/Nemocas/AbstractAlgebra.jl/pull/1948 to use inplace operation like `addmul!`, which will call `R()`. 