### PR TITLE
Fix LaTeX inline equations in toric blowups docs

### DIFF
--- a/experimental/Schemes/src/ToricBlowups/methods.jl
+++ b/experimental/Schemes/src/ToricBlowups/methods.jl
@@ -12,7 +12,8 @@ strict transform under $f$ of the closed subscheme of $X$ defined by the
 homogeneous ideal $I$ in $R$.
 
 This is implemented under the following assumptions:
-  * $X$ has no torus factors (meaning the rays span $N_{\mathbb{R}}$).
+  * the variety $X$ has no torus factors (meaning the rays span
+    $N_{\mathbb{R}}$).
 
 # Examples
 ```jldoctest
@@ -60,8 +61,9 @@ of the closed subscheme of $X$ defined by the homogeneous ideal $I$ in
 $R$.
 
 This is implemented under the following assumptions:
-  * $X$ has no torus factors (meaning the rays span $N_{\mathbb{R}}$), and
-  * $X$ is an orbifold (meaning its fan is simplicial).
+  * the variety $X$ has no torus factors (meaning the rays span
+    $N_{\mathbb{R}}$), and
+  * the variety $X$ is an orbifold (meaning its fan is simplicial).
 
 # Examples
 ```jldoctest
@@ -103,8 +105,9 @@ and where $k$ is the multiplicity of the total transform along the
 exceptional prime divisor.
 
 This is implemented under the following assumptions:
-  * $X$ has no torus factors (meaning the rays span $N_{\mathbb{R}}$), and
-  * $X$ is smooth.
+  * the variety $X$ has no torus factors (meaning the rays span
+    $N_{\mathbb{R}}$), and
+  * the variety $X$ is smooth.
 
 !!! note
     If the multiplicity $k$ is not needed, we recommend to use

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -378,7 +378,7 @@ Given an point $v$ inside the support of the pointed polyhedral fan $PF$
 where $u_1, \ldots u_n$ are the minimal generators of the rays of $PF$,
 return a vector $(p_1, \ldots, p_n)$ of nonnegative rational numbers
 such that both of the following hold:
-  * $p_1 u_1 + \ldots + p_n u_n = v$, and
+  * the vector $v$ is equal to $p_1 u_1 + \ldots + p_n u_n$, and
   * if $u_i$ is not in minimal supercone containing $v$, then $p_i = 0$.
 
 If $PF$ is simplicial, then $(p_1, \ldots, p_n)$ is unique.


### PR DESCRIPTION
For some reason, the below 
```
This is implemented under the following assumptions:
  * $X$ has no torus factors (meaning the rays span $N_{\mathbb{R}}$).
```
renders "X" as a display equation. 
![X](https://github.com/user-attachments/assets/849dd0f5-9bd8-44ea-aaf0-aabd45ac9d93)