### PR TITLE
Add transformations for polyhedral fans and complexes

### DIFF
--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -132,9 +132,7 @@ end
 +(v::Vector{Int}, Sigma::PolyhedralComplex) = QQ.(v)+Sigma
 
 +(Sigma::PolyhedralComplex, v::Vector{QQFieldElem}) = v+Sigma
-+(Sigma::PolyhedralComplex, v::Vector{ZZRingElem}) = QQ.(v)+Sigma
-+(Sigma::PolyhedralComplex, v::Vector{Rational}) = QQ.(v)+Sigma
-+(Sigma::PolyhedralComplex, v::Vector{Int}) = QQ.(v)+Sigma
++(Sigma::PolyhedralComplex, v::Vector{<:RationalUnion}) = QQ.(v)+Sigma
 
 # Vector addition for polyhedral fans
 +(Sigma::PolyhedralFan, v::Vector) = polyhedral_complex(Sigma)+v

--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -165,7 +165,8 @@ function +(v::Vector{<:scalar_types_extended}, Sigma::PolyhedralComplex)
     SigmaIncidence,
     translate.(SigmaVertsAndRays, Ref(v)),
     SigmaRayIndices,
-    SigmaLineality,
+    SigmaLineality;
+    non_redundant=true
   )
 end
 +(Sigma::PolyhedralComplex, v::Vector{<:scalar_types_extended}) = v + Sigma

--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -103,10 +103,8 @@ _empty_complex(cf, dim) = polyhedral_complex(cf, incidence_matrix(0, 0), zero_ma
 _origin_complex(cf, dim) = polyhedral_complex(cf, incidence_matrix(1, 1, [[1]]), zero_matrix(cf, 1, dim); non_redundant=true)
 
 function *(c::scalar_types_extended, Sigma::PolyhedralComplex)
-  # if scalar is zero, return polyhedral complex consisting only of the origin
-  if iszero(c)
-    return polyhedral_complex(convex_hull(zero_matrix(QQ, 1, ambient_dim(Sigma))))
-  end
+  n_maximal_polyhedra(Sigma) == 0 && return _empty_complex(coefficient_field(Sigma), ambient_dim(Sigma))
+  iszero(c) && return _origin_complex(coefficient_field(Sigma), ambient_dim(Sigma))
 
   # if scalar is non-zero, multiple all vertices and rays by said scalar
   SigmaVertsAndRays = vertices_and_rays(Sigma)

--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -93,8 +93,8 @@ function *(c::QQFieldElem, Sigma::PolyhedralComplex)
     SigmaIncidence = maximal_polyhedra(IncidenceMatrix,Sigma)
     return polyhedral_complex(SigmaIncidence, multiply_by_nonzero_scalar.(SigmaVertsAndRays,c), SigmaRayIndices, SigmaLineality)
 end
-*(c::Union{ZZRingElem,Rational,Int}, Sigma::PolyhedralComplex) = QQ(c)*Sigma
-*(Sigma::PolyhedralComplex, c::Union{QQFieldElem,ZZRingElem,Rational,Int}) = c*Sigma
+*(c::RationalUnion, Sigma::PolyhedralComplex) = QQ(c)*Sigma
+*(Sigma::PolyhedralComplex, c::RationalUnion) = c*Sigma
 
 
 ###############################################################################

--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -90,14 +90,19 @@ function scale(
 )
   is_positive(c) && return u
   is_negative(c) && return -u
-  return 0*u
+  return 0 * u
 end
 
-_empty_complex(cf, dim) = polyhedral_complex(cf, incidence_matrix(0, 0), zero_matrix(cf, 0, dim); non_redundant=true)
-_origin_complex(cf, dim) = polyhedral_complex(cf, incidence_matrix(1, 1, [[1]]), zero_matrix(cf, 1, dim); non_redundant=true)
+_empty_complex(cf, dim) = polyhedral_complex(
+  cf, incidence_matrix(0, 0), zero_matrix(cf, 0, dim); non_redundant=true
+)
+_origin_complex(cf, dim) = polyhedral_complex(
+  cf, incidence_matrix(1, 1, [[1]]), zero_matrix(cf, 1, dim); non_redundant=true
+)
 
 function *(c::scalar_types_extended, Sigma::PolyhedralComplex)
-  n_maximal_polyhedra(Sigma) == 0 && return _empty_complex(coefficient_field(Sigma), ambient_dim(Sigma))
+  n_maximal_polyhedra(Sigma) == 0 &&
+    return _empty_complex(coefficient_field(Sigma), ambient_dim(Sigma))
   iszero(c) && return _origin_complex(coefficient_field(Sigma), ambient_dim(Sigma))
 
   # if scalar is non-zero, multiple all vertices and rays by said scalar
@@ -108,10 +113,10 @@ function *(c::scalar_types_extended, Sigma::PolyhedralComplex)
   return polyhedral_complex(
     coefficient_field(Sigma),
     SigmaIncidence,
-    scale.(SigmaVertsAndRays,c),
+    scale.(SigmaVertsAndRays, c),
     SigmaRayIndices,
     SigmaLineality;
-    non_redundant=true
+    non_redundant=true,
   )
 end
 *(Sigma::PolyhedralComplex, c::scalar_types_extended) = c * Sigma
@@ -121,13 +126,15 @@ end
 ###############################################################################
 
 function -(Sigma::PolyhedralComplex)
-  n_maximal_polyhedra(Sigma) == 0 && return _empty_complex(coefficient_field(Sigma), ambient_dim(Sigma))
+  n_maximal_polyhedra(Sigma) == 0 &&
+    return _empty_complex(coefficient_field(Sigma), ambient_dim(Sigma))
   SigmaVertsAndRays = vertices_and_rays(Sigma)
   SigmaRayIndices = findall(vr -> vr isa RayVector, SigmaVertsAndRays)
   SigmaLineality = lineality_space(Sigma)
   SigmaIncidence = maximal_polyhedra(IncidenceMatrix, Sigma)
   return polyhedral_complex(
-    coefficient_field(Sigma), SigmaIncidence, -SigmaVertsAndRays, SigmaRayIndices, SigmaLineality; non_redundant=true
+    coefficient_field(Sigma), SigmaIncidence, -SigmaVertsAndRays, SigmaRayIndices,
+    SigmaLineality; non_redundant=true,
   )
 end
 
@@ -150,7 +157,8 @@ function translate(
 end
 function +(v::AbstractVector{<:scalar_types_extended}, Sigma::PolyhedralComplex)
   @req length(v) == ambient_dim(Sigma) "ambient dimension mismatch"
-  n_maximal_polyhedra(Sigma) == 0 && return _empty_complex(coefficient_field(Sigma), ambient_dim(Sigma))
+  n_maximal_polyhedra(Sigma) == 0 &&
+    return _empty_complex(coefficient_field(Sigma), ambient_dim(Sigma))
   SigmaVertsAndRays = vertices_and_rays(Sigma)
   SigmaRayIndices = findall(vr -> vr isa RayVector, SigmaVertsAndRays)
   SigmaLineality = lineality_space(Sigma)
@@ -161,7 +169,7 @@ function +(v::AbstractVector{<:scalar_types_extended}, Sigma::PolyhedralComplex)
     translate.(SigmaVertsAndRays, Ref(v)),
     SigmaRayIndices,
     SigmaLineality;
-    non_redundant=true
+    non_redundant=true,
   )
 end
 +(Sigma::PolyhedralComplex, v::AbstractVector{<:scalar_types_extended}) = v + Sigma

--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -127,6 +127,7 @@ end
 ###############################################################################
 
 function -(Sigma::PolyhedralComplex)
+  n_maximal_polyhedra(Sigma) == 0 && return _empty_complex(coefficient_field(Sigma), ambient_dim(Sigma))
   SigmaVertsAndRays = vertices_and_rays(Sigma)
   SigmaRayIndices = findall(vr -> vr isa RayVector, SigmaVertsAndRays)
   SigmaLineality = lineality_space(Sigma)

--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -131,7 +131,7 @@ function -(Sigma::PolyhedralComplex)
   SigmaLineality = lineality_space(Sigma)
   SigmaIncidence = maximal_polyhedra(IncidenceMatrix, Sigma)
   return polyhedral_complex(
-    SigmaIncidence, -SigmaVertsAndRays, SigmaRayIndices, SigmaLineality
+    coefficient_field(Sigma), SigmaIncidence, -SigmaVertsAndRays, SigmaRayIndices, SigmaLineality; non_redundant=true
   )
 end
 

--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -170,4 +170,4 @@ function +(v::AbstractVector{<:scalar_types_extended}, Sigma::PolyhedralComplex)
     non_redundant=true
   )
 end
-+(Sigma::PolyhedralComplex, v::Vector{<:scalar_types_extended}) = v + Sigma
++(Sigma::PolyhedralComplex, v::AbstractVector{<:scalar_types_extended}) = v + Sigma

--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -154,7 +154,7 @@ function translate(
 )
   return u
 end
-function +(v::Vector{<:scalar_types_extended}, Sigma::PolyhedralComplex)
+function +(v::AbstractVector{<:scalar_types_extended}, Sigma::PolyhedralComplex)
   @req length(v) == ambient_dim(Sigma) "ambient dimension mismatch"
   n_maximal_polyhedra(Sigma) == 0 && return _empty_complex(coefficient_field(Sigma), ambient_dim(Sigma))
   SigmaVertsAndRays = vertices_and_rays(Sigma)

--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -171,7 +171,3 @@ function +(v::Vector{<:scalar_types_extended}, Sigma::PolyhedralComplex)
   )
 end
 +(Sigma::PolyhedralComplex, v::Vector{<:scalar_types_extended}) = v + Sigma
-
-# Vector addition for polyhedral fans
-+(Sigma::PolyhedralFan, v::Vector{<:scalar_types_extended}) = polyhedral_complex(Sigma) + v
-+(v::Vector{<:scalar_types_extended}, Sigma::PolyhedralFan) = v + polyhedral_complex(Sigma)

--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -82,12 +82,12 @@ end
 # helper functions to ensure that point and ray vectors scale differently:
 # - point vectors represent points in space and should be scaled normally
 # - ray vectors represent directions and they should only be scaled by 0 or +/-1
-function scale_by_scalar(
+function scale(
   u::PointVector{<:scalar_types_extended}, c::scalar_types_extended
 )
   return u * c
 end
-function scale_by_scalar(
+function scale(
   u::RayVector{<:scalar_types_extended}, c::scalar_types_extended
 )
   if is_positive(c)
@@ -113,7 +113,7 @@ function *(c::scalar_types_extended, Sigma::PolyhedralComplex)
   return polyhedral_complex(
     coefficient_field(Sigma),
     SigmaIncidence,
-    scale_by_scalar.(SigmaVertsAndRays,c),
+    scale.(SigmaVertsAndRays,c),
     SigmaRayIndices,
     SigmaLineality,
   )
@@ -141,13 +141,13 @@ end
 # helper functions to ensure that point and ray vectors are translated differently:
 # - point vectors represent points in space and should be translated normally
 # - ray vectors represent directions and they should not change at all
-function translate_by_vector(
-  u::PointVector{<:scalar_types_extended}, v::Vector{<:scalar_types_extended}
+function translate(
+  u::PointVector{<:scalar_types_extended}, v::AbstractVector{<:scalar_types_extended}
 )
   return u + v
 end
-function translate_by_vector(
-  u::RayVector{<:scalar_types_extended}, ::Vector{<:scalar_types_extended}
+function translate(
+  u::RayVector{<:scalar_types_extended}, ::AbstractVector{<:scalar_types_extended}
 )
   return u
 end
@@ -160,7 +160,7 @@ function +(v::Vector{<:scalar_types_extended}, Sigma::PolyhedralComplex)
   return polyhedral_complex(
     coefficient_field(Sigma),
     SigmaIncidence,
-    translate_by_vector.(SigmaVertsAndRays, Ref(v)),
+    translate.(SigmaVertsAndRays, Ref(v)),
     SigmaRayIndices,
     SigmaLineality,
   )

--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -82,11 +82,9 @@ end
 # helper functions to ensure that point and ray vectors scale differently:
 # - point vectors represent points in space and should be scaled normally
 # - ray vectors represent directions and they should only be scaled by 0 or +/-1
-function scale(
+scale(
   u::PointVector{<:scalar_types_extended}, c::scalar_types_extended
-)
-  return u * c
-end
+) = u * c
 function scale(
   u::RayVector{<:scalar_types_extended}, c::scalar_types_extended
 )

--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -90,12 +90,8 @@ end
 function scale(
   u::RayVector{<:scalar_types_extended}, c::scalar_types_extended
 )
-  if is_positive(c)
-    return u
-  end
-  if is_negative(c)
-    return -u
-  end
+  is_positive(c) && return u
+  is_negative(c) && return -u
   return 0*u
 end
 

--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -155,6 +155,7 @@ function translate(
 end
 function +(v::Vector{<:scalar_types_extended}, Sigma::PolyhedralComplex)
   @req length(v) == ambient_dim(Sigma) "ambient dimension mismatch"
+  n_maximal_polyhedra(Sigma) == 0 && return _empty_complex(coefficient_field(Sigma), ambient_dim(Sigma))
   SigmaVertsAndRays = vertices_and_rays(Sigma)
   SigmaRayIndices = findall(vr -> vr isa RayVector, SigmaVertsAndRays)
   SigmaLineality = lineality_space(Sigma)

--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -115,7 +115,8 @@ function *(c::scalar_types_extended, Sigma::PolyhedralComplex)
     SigmaIncidence,
     scale.(SigmaVertsAndRays,c),
     SigmaRayIndices,
-    SigmaLineality,
+    SigmaLineality;
+    non_redundant=true
   )
 end
 *(Sigma::PolyhedralComplex, c::scalar_types_extended) = c * Sigma

--- a/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralComplex/standard_constructions.jl
@@ -99,6 +99,9 @@ function scale(
   return 0*u
 end
 
+_empty_complex(cf, dim) = polyhedral_complex(cf, incidence_matrix(0, 0), zero_matrix(cf, 0, dim); non_redundant=true)
+_origin_complex(cf, dim) = polyhedral_complex(cf, incidence_matrix(1, 1, [[1]]), zero_matrix(cf, 1, dim); non_redundant=true)
+
 function *(c::scalar_types_extended, Sigma::PolyhedralComplex)
   # if scalar is zero, return polyhedral complex consisting only of the origin
   if iszero(c)

--- a/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
@@ -405,3 +405,40 @@ function arrangement_polynomial(
   F = parent(first(A))
   return arrangement_polynomial(ring, matrix(F, A); hyperplanes)
 end
+
+###############################################################################
+## Scalar multiplication
+###############################################################################
+
+function multiply_by_nonzero_scalar(u::PointVector{QQFieldElem}, c::QQFieldElem)
+  return u .* c
+end
+function multiply_by_nonzero_scalar(u::RayVector{QQFieldElem}, c::QQFieldElem)
+  return (c<0 ? -u : u)
+end
+
+function *(c::QQFieldElem, Sigma::PolyhedralFan)
+  # if scalar is zero, return polyhedral complex consisting only of the origin
+  if iszero(c)
+    return polyhedral_complex(convex_hull(zero_matrix(QQ,1,ambient_dim(Sigma))))
+  end
+
+  # if scalar is non-zero, multiple all vertices and rays by said scalar
+  SigmaRays = first(rays_modulo_lineality(Sigma))
+  SigmaLineality = lineality_space(Sigma)
+  SigmaIncidence = maximal_cones(IncidenceMatrix,Sigma)
+  return polyhedral_fan(SigmaIncidence, multiply_by_nonzero_scalar.(SigmaRays,c), SigmaLineality)
+end
+*(c::Union{ZZRingElem,Rational,Int}, Sigma::PolyhedralFan) = QQ(c)*Sigma
+*(Sigma::PolyhedralFan,c::Union{QQFieldElem,ZZRingElem,Rational,Int}) = c*Sigma
+
+###############################################################################
+## Negation
+###############################################################################
+
+function -(Sigma::PolyhedralFan)
+  SigmaRays = first(rays_modulo_lineality(Sigma))
+  SigmaLineality = lineality_space(Sigma)
+  SigmaIncidence = maximal_cones(IncidenceMatrix,Sigma)
+  return polyhedral_fan(SigmaIncidence, -SigmaRays, SigmaLineality)
+end

--- a/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
@@ -414,12 +414,8 @@ _empty_fan(cf, dim) = polyhedral_fan(cf, incidence_matrix(0, 0), zero_matrix(cf,
 _origin_fan(cf, dim) = polyhedral_fan(cf, incidence_matrix(1, 0), zero_matrix(cf, 0, dim); non_redundant=true)
 
 function *(c::scalar_types_extended, Sigma::PolyhedralFan)
-  # if scalar is zero, return polyhedral fan consisting only of the origin
-  if iszero(c)
-    return polyhedral_fan(
-      positive_hull(zero_matrix(coefficient_field(Sigma), 1, ambient_dim(Sigma)))
-    )
-  end
+  n_maximal_cones(Sigma) == 0 && return _empty_fan(coefficient_field(Sigma), ambient_dim(Sigma))
+  iszero(c) && return _origin_fan(coefficient_field(Sigma), ambient_dim(Sigma))
 
   # if scalar is non-zero, multiple all rays by said scalar
   SigmaRays = first(rays_modulo_lineality(Sigma))

--- a/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
@@ -429,8 +429,8 @@ function *(c::QQFieldElem, Sigma::PolyhedralFan)
   SigmaIncidence = maximal_cones(IncidenceMatrix,Sigma)
   return polyhedral_fan(SigmaIncidence, multiply_by_nonzero_scalar.(SigmaRays,c), SigmaLineality)
 end
-*(c::Union{ZZRingElem,Rational,Int}, Sigma::PolyhedralFan) = QQ(c)*Sigma
-*(Sigma::PolyhedralFan,c::Union{QQFieldElem,ZZRingElem,Rational,Int}) = c*Sigma
+*(c::RationalUnion, Sigma::PolyhedralFan) = QQ(c)*Sigma
+*(Sigma::PolyhedralFan,c::RationalUnion) = c*Sigma
 
 ###############################################################################
 ## Negation

--- a/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
@@ -422,7 +422,7 @@ function *(c::scalar_types_extended, Sigma::PolyhedralFan)
   SigmaLineality = lineality_space(Sigma)
   SigmaIncidence = maximal_cones(IncidenceMatrix, Sigma)
   return polyhedral_fan(
-    coefficient_field(Sigma), SigmaIncidence, SigmaRays .* c, SigmaLineality
+    coefficient_field(Sigma), SigmaIncidence, SigmaRays .* c, SigmaLineality; non_redundant=true
   )
 end
 *(Sigma::PolyhedralFan, c::scalar_types_extended) = c * Sigma

--- a/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
@@ -410,35 +410,32 @@ end
 ## Scalar multiplication
 ###############################################################################
 
-function multiply_by_nonzero_scalar(u::PointVector{QQFieldElem}, c::QQFieldElem)
-  return u .* c
-end
-function multiply_by_nonzero_scalar(u::RayVector{QQFieldElem}, c::QQFieldElem)
-  return (c<0 ? -u : u)
-end
-
-function *(c::QQFieldElem, Sigma::PolyhedralFan)
-  # if scalar is zero, return polyhedral complex consisting only of the origin
+function *(c::scalar_types_extended, Sigma::PolyhedralFan)
+  # if scalar is zero, return polyhedral fan consisting only of the origin
   if iszero(c)
-    return polyhedral_complex(convex_hull(zero_matrix(QQ,1,ambient_dim(Sigma))))
+    return polyhedral_fan(
+      positive_hull(zero_matrix(coefficient_field(Sigma), 1, ambient_dim(Sigma)))
+    )
   end
 
-  # if scalar is non-zero, multiple all vertices and rays by said scalar
+  # if scalar is non-zero, multiple all rays by said scalar
   SigmaRays = first(rays_modulo_lineality(Sigma))
   SigmaLineality = lineality_space(Sigma)
-  SigmaIncidence = maximal_cones(IncidenceMatrix,Sigma)
-  return polyhedral_fan(SigmaIncidence, multiply_by_nonzero_scalar.(SigmaRays,c), SigmaLineality)
+  SigmaIncidence = maximal_cones(IncidenceMatrix, Sigma)
+  return polyhedral_fan(
+    coefficient_field(Sigma), SigmaIncidence, SigmaRays .* c, SigmaLineality
+  )
 end
-*(c::RationalUnion, Sigma::PolyhedralFan) = QQ(c)*Sigma
-*(Sigma::PolyhedralFan,c::RationalUnion) = c*Sigma
+*(Sigma::PolyhedralFan, c::scalar_types_extended) = c * Sigma
 
 ###############################################################################
 ## Negation
 ###############################################################################
 
 function -(Sigma::PolyhedralFan)
-  SigmaRays = first(rays_modulo_lineality(Sigma))
-  SigmaLineality = lineality_space(Sigma)
-  SigmaIncidence = maximal_cones(IncidenceMatrix,Sigma)
-  return polyhedral_fan(SigmaIncidence, -SigmaRays, SigmaLineality)
+  SigmaRays, SigmaLineality = first(rays_modulo_lineality(Sigma))
+  SigmaIncidence = maximal_cones(IncidenceMatrix, Sigma)
+  return polyhedral_fan(
+    coefficient_field(Sigma), SigmaIncidence, -SigmaRays, SigmaLineality
+  )
 end

--- a/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
@@ -436,6 +436,6 @@ function -(Sigma::PolyhedralFan)
   SigmaRays, SigmaLineality = rays_modulo_lineality(Sigma)
   SigmaIncidence = maximal_cones(IncidenceMatrix, Sigma)
   return polyhedral_fan(
-    coefficient_field(Sigma), SigmaIncidence, -SigmaRays, SigmaLineality
+    coefficient_field(Sigma), SigmaIncidence, -SigmaRays, SigmaLineality; non_redundant=true
   )
 end

--- a/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
@@ -407,27 +407,6 @@ function arrangement_polynomial(
 end
 
 ###############################################################################
-## Scalar multiplication
-###############################################################################
-
-_empty_fan(cf, dim) = polyhedral_fan(cf, incidence_matrix(0, 0), zero_matrix(cf, 0, dim); non_redundant=true)
-_origin_fan(cf, dim) = polyhedral_fan(cf, incidence_matrix(1, 0), zero_matrix(cf, 0, dim); non_redundant=true)
-
-function *(c::scalar_types_extended, Sigma::PolyhedralFan)
-  n_maximal_cones(Sigma) == 0 && return _empty_fan(coefficient_field(Sigma), ambient_dim(Sigma))
-  iszero(c) && return _origin_fan(coefficient_field(Sigma), ambient_dim(Sigma))
-
-  # if scalar is non-zero, multiple all rays by said scalar
-  SigmaRays = first(rays_modulo_lineality(Sigma))
-  SigmaLineality = lineality_space(Sigma)
-  SigmaIncidence = maximal_cones(IncidenceMatrix, Sigma)
-  return polyhedral_fan(
-    coefficient_field(Sigma), SigmaIncidence, SigmaRays .* c, SigmaLineality; non_redundant=true
-  )
-end
-*(Sigma::PolyhedralFan, c::scalar_types_extended) = c * Sigma
-
-###############################################################################
 ## Negation
 ###############################################################################
 
@@ -439,3 +418,19 @@ function -(Sigma::PolyhedralFan)
     coefficient_field(Sigma), SigmaIncidence, -SigmaRays, SigmaLineality; non_redundant=true
   )
 end
+
+
+###############################################################################
+## Scalar multiplication
+###############################################################################
+
+_empty_fan(cf, dim) = polyhedral_fan(cf, incidence_matrix(0, 0), zero_matrix(cf, 0, dim); non_redundant=true)
+_origin_fan(cf, dim) = polyhedral_fan(cf, incidence_matrix(1, 0), zero_matrix(cf, 0, dim); non_redundant=true)
+
+function *(c::scalar_types_extended, Sigma::PolyhedralFan)
+  n_maximal_cones(Sigma) == 0 && return _empty_fan(coefficient_field(Sigma), ambient_dim(Sigma))
+  iszero(c) && return _origin_fan(coefficient_field(Sigma), ambient_dim(Sigma))
+  is_positive(c) && return Sigma
+  return -Sigma
+end
+*(Sigma::PolyhedralFan, c::scalar_types_extended) = c * Sigma

--- a/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
@@ -410,6 +410,9 @@ end
 ## Scalar multiplication
 ###############################################################################
 
+_empty_fan(cf, dim) = polyhedral_fan(cf, incidence_matrix(0, 0), zero_matrix(cf, 0, dim); non_redundant=true)
+_origin_fan(cf, dim) = polyhedral_fan(cf, incidence_matrix(1, 0), zero_matrix(cf, 0, dim); non_redundant=true)
+
 function *(c::scalar_types_extended, Sigma::PolyhedralFan)
   # if scalar is zero, return polyhedral fan consisting only of the origin
   if iszero(c)

--- a/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
@@ -433,7 +433,7 @@ end
 ###############################################################################
 
 function -(Sigma::PolyhedralFan)
-  SigmaRays, SigmaLineality = first(rays_modulo_lineality(Sigma))
+  SigmaRays, SigmaLineality = rays_modulo_lineality(Sigma)
   SigmaIncidence = maximal_cones(IncidenceMatrix, Sigma)
   return polyhedral_fan(
     coefficient_field(Sigma), SigmaIncidence, -SigmaRays, SigmaLineality

--- a/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
@@ -432,6 +432,7 @@ end
 ###############################################################################
 
 function -(Sigma::PolyhedralFan)
+  n_maximal_cones(Sigma) == 0 && return _empty_fan(coefficient_field(Sigma), ambient_dim(Sigma))
   SigmaRays, SigmaLineality = rays_modulo_lineality(Sigma)
   SigmaIncidence = maximal_cones(IncidenceMatrix, Sigma)
   return polyhedral_fan(

--- a/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
@@ -411,7 +411,8 @@ end
 ###############################################################################
 
 function -(Sigma::PolyhedralFan)
-  n_maximal_cones(Sigma) == 0 && return _empty_fan(coefficient_field(Sigma), ambient_dim(Sigma))
+  n_maximal_cones(Sigma) == 0 &&
+    return _empty_fan(coefficient_field(Sigma), ambient_dim(Sigma))
   SigmaRays, SigmaLineality = rays_modulo_lineality(Sigma)
   SigmaIncidence = maximal_cones(IncidenceMatrix, Sigma)
   return polyhedral_fan(
@@ -419,16 +420,18 @@ function -(Sigma::PolyhedralFan)
   )
 end
 
-
 ###############################################################################
 ## Scalar multiplication
 ###############################################################################
 
-_empty_fan(cf, dim) = polyhedral_fan(cf, incidence_matrix(0, 0), zero_matrix(cf, 0, dim); non_redundant=true)
-_origin_fan(cf, dim) = polyhedral_fan(cf, incidence_matrix(1, 0), zero_matrix(cf, 0, dim); non_redundant=true)
+_empty_fan(cf, dim) =
+  polyhedral_fan(cf, incidence_matrix(0, 0), zero_matrix(cf, 0, dim); non_redundant=true)
+_origin_fan(cf, dim) =
+  polyhedral_fan(cf, incidence_matrix(1, 0), zero_matrix(cf, 0, dim); non_redundant=true)
 
 function *(c::scalar_types_extended, Sigma::PolyhedralFan)
-  n_maximal_cones(Sigma) == 0 && return _empty_fan(coefficient_field(Sigma), ambient_dim(Sigma))
+  n_maximal_cones(Sigma) == 0 &&
+    return _empty_fan(coefficient_field(Sigma), ambient_dim(Sigma))
   iszero(c) && return _origin_fan(coefficient_field(Sigma), ambient_dim(Sigma))
   is_positive(c) && return Sigma
   return -Sigma

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -513,7 +513,7 @@ const scalar_type_to_oscar = Dict{String,Type}([
   ("Float", Float64),
 ])
 
-const scalar_types_extended = Union{scalar_types,ZZRingElem}
+const scalar_types_extended = Union{scalar_types,IntegerUnion}
 
 const scalar_type_or_field = Union{Type{<:scalar_types},Field}
 

--- a/src/PolyhedralGeometry/iterators.jl
+++ b/src/PolyhedralGeometry/iterators.jl
@@ -51,8 +51,7 @@ for (T, _t) in ((:PointVector, :point_vector), (:RayVector, :ray_vector))
     _find_elem_type(po::$T) = elem_type(coefficient_field(po))
 
     function Base.similar(
-      bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{$T}}, ::Type{ElType}
-    ) where {ElType<:scalar_types_extended}
+      bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{$T}}, ::Type{<:Union{scalar_types,ZZRingElem}})
       e = bc.f(first.(bc.args)...)
       return $_t(parent(e), axes(bc)...)
     end

--- a/src/PolyhedralGeometry/iterators.jl
+++ b/src/PolyhedralGeometry/iterators.jl
@@ -51,7 +51,8 @@ for (T, _t) in ((:PointVector, :point_vector), (:RayVector, :ray_vector))
     _find_elem_type(po::$T) = elem_type(coefficient_field(po))
 
     function Base.similar(
-      bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{$T}}, ::Type{<:Union{scalar_types,ZZRingElem}})
+      bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{$T}},
+      ::Type{<:Union{scalar_types,ZZRingElem}})
       e = bc.f(first.(bc.args)...)
       return $_t(parent(e), axes(bc)...)
     end

--- a/test/PolyhedralGeometry/polyhedral_complex.jl
+++ b/test/PolyhedralGeometry/polyhedral_complex.jl
@@ -159,7 +159,7 @@
     @test ambient_dim(PCshifted) == ambient_dim(PC)
     @test lineality_dim(PCshifted) == lineality_dim(PC)
     @test issetequal(rays(PCshifted), rays(PC))
-    @test n_maximal_polyhedra(PCshifted) == n_maximal_cones(PC)
+    @test n_maximal_polyhedra(PCshifted) == n_maximal_polyhedra(PC)
 
     PCscaled = PCshifted*2
     @test dim(PCscaled) == dim(PCshifted)

--- a/test/PolyhedralGeometry/polyhedral_complex.jl
+++ b/test/PolyhedralGeometry/polyhedral_complex.jl
@@ -161,7 +161,7 @@
     @test issetequal(rays(PCshifted), rays(PC))
     @test n_maximal_polyhedra(PCshifted) == n_maximal_polyhedra(PC)
 
-    PCscaled = PCshifted*2
+    PCscaled = PCshifted * 2
     @test dim(PCscaled) == dim(PCshifted)
     @test ambient_dim(PCscaled) == ambient_dim(PCshifted)
     @test lineality_dim(PCscaled) == lineality_dim(PCshifted)

--- a/test/PolyhedralGeometry/polyhedral_complex.jl
+++ b/test/PolyhedralGeometry/polyhedral_complex.jl
@@ -151,4 +151,28 @@
       @test n_maximal_polyhedra(vrep) == n_maximal_polyhedra(hrep)
     end
   end
+
+  @testset "Operators" begin
+    PC = normal_fan(cube(2))
+    PCshifted = PC + [1, 1]
+    @test dim(PCshifted) == dim(PC)
+    @test ambient_dim(PCshifted) == ambient_dim(PC)
+    @test lineality_dim(PCshifted) == lineality_dim(PC)
+    @test issetequal(rays(PCshifted), rays(PC))
+    @test n_maximal_polyhedra(PCshifted) == n_maximal_cones(PC)
+
+    PCscaled = PCshifted*2
+    @test dim(PCscaled) == dim(PCshifted)
+    @test ambient_dim(PCscaled) == ambient_dim(PCshifted)
+    @test lineality_dim(PCscaled) == lineality_dim(PCshifted)
+    @test issetequal(rays(PCscaled), rays(PCshifted))
+    @test n_maximal_polyhedra(PCscaled) == n_maximal_polyhedra(PCshifted)
+
+    PCnegated = -PCshifted
+    @test dim(PCnegated) == dim(PCshifted)
+    @test ambient_dim(PCnegated) == ambient_dim(PCshifted)
+    @test lineality_dim(PCnegated) == lineality_dim(PCshifted)
+    @test issetequal(rays(PCnegated), rays(PCshifted))
+    @test n_maximal_polyhedra(PCnegated) == n_maximal_polyhedra(PCshifted)
+  end
 end

--- a/test/PolyhedralGeometry/polyhedral_complex.jl
+++ b/test/PolyhedralGeometry/polyhedral_complex.jl
@@ -152,9 +152,9 @@
     end
   end
 
-  @testset "Operators" begin
-    PC = polyhedral_complex(normal_fan(cube(2)))
-    PCshifted = PC + [1, 1]
+  @testset "Transformations" for P in (cube(2), dodecahedron(), n_gon(5))
+    PC = polyhedral_complex(normal_fan(P))
+    PCshifted = PC + fill(1, dim(P))
     @test dim(PCshifted) == dim(PC)
     @test ambient_dim(PCshifted) == ambient_dim(PC)
     @test lineality_dim(PCshifted) == lineality_dim(PC)
@@ -172,7 +172,7 @@
     @test dim(PCnegated) == dim(PCshifted)
     @test ambient_dim(PCnegated) == ambient_dim(PCshifted)
     @test lineality_dim(PCnegated) == lineality_dim(PCshifted)
-    @test issetequal(rays(PCnegated), rays(PCshifted))
+    @test issetequal(rays(PCnegated), -1 .* rays(PCshifted))
     @test n_maximal_polyhedra(PCnegated) == n_maximal_polyhedra(PCshifted)
   end
 end

--- a/test/PolyhedralGeometry/polyhedral_complex.jl
+++ b/test/PolyhedralGeometry/polyhedral_complex.jl
@@ -153,7 +153,7 @@
   end
 
   @testset "Operators" begin
-    PC = normal_fan(cube(2))
+    PC = polyhedral_complex(normal_fan(cube(2)))
     PCshifted = PC + [1, 1]
     @test dim(PCshifted) == dim(PC)
     @test ambient_dim(PCshifted) == ambient_dim(PC)

--- a/test/PolyhedralGeometry/polyhedral_fan.jl
+++ b/test/PolyhedralGeometry/polyhedral_fan.jl
@@ -220,7 +220,9 @@ end
   sff1 = star_subdivision(ff, w1)
   @test number_of_maximal_cones(sff0) == 2
   @test number_of_maximal_cones(sff1) == 3
+end
 
+@testset "Operations" begin
   f = normal_fan(cube(2))
   fMinus = -f
   @test n_rays(fMinus) == n_rays(f)

--- a/test/PolyhedralGeometry/polyhedral_fan.jl
+++ b/test/PolyhedralGeometry/polyhedral_fan.jl
@@ -220,6 +220,15 @@ end
   sff1 = star_subdivision(ff, w1)
   @test number_of_maximal_cones(sff0) == 2
   @test number_of_maximal_cones(sff1) == 3
+
+  f = normal_fan(cube(2))
+  fMinus = -f
+  @test n_rays(fMinus) == n_rays(f)
+  @test n_maximal_cones(fMinus) == n_maximal_cones(f)
+
+  fMinus = -1*f
+  @test n_rays(fMinus) == n_rays(f)
+  @test n_maximal_cones(fMinus) == n_maximal_cones(f)
 end
 
 @testset "Defining polynomial of hyperplane arrangement from matrix" begin

--- a/test/PolyhedralGeometry/polyhedral_fan.jl
+++ b/test/PolyhedralGeometry/polyhedral_fan.jl
@@ -222,8 +222,8 @@ end
   @test number_of_maximal_cones(sff1) == 3
 end
 
-@testset "Operations" begin
-  f = normal_fan(cube(2))
+@testset "Transformations" for P in (cube(2), dodecahedron(), n_gon(5))
+  f = normal_fan(P)
   fMinus = -f
   @test n_rays(fMinus) == n_rays(f)
   @test n_maximal_cones(fMinus) == n_maximal_cones(f)

--- a/test/PolyhedralGeometry/polyhedral_fan.jl
+++ b/test/PolyhedralGeometry/polyhedral_fan.jl
@@ -228,7 +228,7 @@ end
   @test n_rays(fMinus) == n_rays(f)
   @test n_maximal_cones(fMinus) == n_maximal_cones(f)
 
-  fMinus = -1*f
+  fMinus = -1 * f
   @test n_rays(fMinus) == n_rays(f)
   @test n_maximal_cones(fMinus) == n_maximal_cones(f)
 end


### PR DESCRIPTION
This draft pull request comes from the Leipzig Workshop aims to add the following new operations:

- `Scalar` * `PolyhedralFan` and `PolyhedralFan` * `Scalar` 
- `Scalar` * `PolyhedralComplex` and `PolyhedralFan` * `Scalar`
- -`PolyhedralFan`
- -`PolyhedralComplex`
- `Vector` + `PolyhedralFan` and `PolyhedralFan` + `Vector`
- `Vector` + `PolyhedralComplex` and `PolyhedralComplex` + `Vector`

Questions:

1. Do we want these functions?  My collaborators and I need it for various reasons:
- negation is useful to construct the negated Bergman fan of a matroid (arises for example [here](https://arxiv.org/abs/2212.08173))
- translation is useful to see how the initial ideals of the tropical intersection points vary (relevant for example for [this](https://arxiv.org/abs/2408.15719))

(If yes, I will add the relevant operators for `Cone`, the operators for `Polyhedron` already exist)

2. Is the implementation okay (in particular, I wasn't 100% sure where to put the functions)?