### PR TITLE
Add tropical linear spaces from graphs

### DIFF
--- a/docs/src/TropicalGeometry/linear_space.md
+++ b/docs/src/TropicalGeometry/linear_space.md
@@ -16,7 +16,7 @@ In addition to converting from `TropicalVariety`, objects of type `TropicalLinea
 1. Pluecker vectors over a tropical semiring: uses a low-level implementation in `polymake`
 2. Pluecker vectors over a field and a tropical semiring map: computes coordinatewise valuation and uses constructor (1.)
 3. matrices over a tropical semiring: computes tropical minors and uses constructor (1.)
-4. matrices over a field and a tropical semiring map.
+4. matrices over a field and a tropical semiring map
     - if matrix over `QQ` and tropical semiring map is trivial, uses an implementation of Rincon's algorithm [Rin13](@cite) in `polymake`
     - for general input, computes minors and uses constructor (2.)
 5. graphs

--- a/docs/src/TropicalGeometry/linear_space.md
+++ b/docs/src/TropicalGeometry/linear_space.md
@@ -6,7 +6,8 @@ A tropical linear space is a balanced polyhedral complex supported on a finite i
 - Chapter 10 in [Jos21](@cite)
 
 #### Note:
-- Unlike in [MS15](@cite) and [Jos21](@cite), tropical linear spaces in OSCAR are polyhedral complexes in euclidean space that are invariant under translation by the ones vector.  They are not polyhedral complexes in the tropical torus.
+- Tropical linear spaces in OSCAR are polyhedral complexes in euclidean space that are invariant under translation by the ones vector.  Unlike in [MS15](@cite) and [Jos21](@cite), they are not polyhedral complexes in the tropical torus.
+- Tropical linear spaces constructed with respect to a trivial valuation are also known as Bergman fans.  Bergman fans can have several possible polyhedral structures, though their support always remains the same.  In OSCAR, which structure is being used depends on how it was constructed.
 - Objects of type `TropicalLinearSpace` need to be embedded, abstract tropical linear spaces are currently not supported.
 - The type `TropicalLinearSpace` can be thought of as subtype of `TropicalVariety` in the sense that it should have all properties and features of the latter.
 

--- a/docs/src/TropicalGeometry/linear_space.md
+++ b/docs/src/TropicalGeometry/linear_space.md
@@ -6,6 +6,7 @@ A tropical linear space is a balanced polyhedral complex supported on a finite i
 - Chapter 10 in [Jos21](@cite)
 
 #### Note:
+- Unlike in [MS15](@cite) and [Jos21](@cite), tropical linear spaces in OSCAR are polyhedral complexes in euclidean space that are invariant under translation by the ones vector.  They are not polyhedral complexes in the tropical torus.
 - Objects of type `TropicalLinearSpace` need to be embedded, abstract tropical linear spaces are currently not supported.
 - The type `TropicalLinearSpace` can be thought of as subtype of `TropicalVariety` in the sense that it should have all properties and features of the latter.
 

--- a/docs/src/TropicalGeometry/linear_space.md
+++ b/docs/src/TropicalGeometry/linear_space.md
@@ -18,6 +18,7 @@ In addition to converting from `TropicalVariety`, objects of type `TropicalLinea
 4. matrices over a field and a tropical semiring map.
     - if matrix over `QQ` and tropical semiring map is trivial, uses an implementation of Rincon's algorithm [Rin13](@cite) in `polymake`
     - for general input, computes minors and uses constructor (2.)
+5. graphs
 ```@docs
 tropical_linear_space
 ```

--- a/src/TropicalGeometry/linear_space.jl
+++ b/src/TropicalGeometry/linear_space.jl
@@ -319,8 +319,8 @@ function basis_of_vanishing_of_linear_ideal(I::MPolyIdeal)
 
     x = gens(base_ring(I))
     G = gens(I)
-    macaulayMatrix = matrix([[coeff(g,xi) for xi in x] for g in G])
-    A = transpose(kernel(macaulayMatrix, side = :right))
+    coefficientMatrix = matrix([[coeff(g,xi) for xi in x] for g in G])
+    A = transpose(kernel(coefficientMatrix, side = :right))
 
     return A
 end

--- a/src/TropicalGeometry/linear_space.jl
+++ b/src/TropicalGeometry/linear_space.jl
@@ -460,8 +460,13 @@ end
 Return the tropical matrix used to construct `TropL`.  Raises an error, if it is not cached.
 """
 function tropical_matrix(TropL::TropicalLinearSpace{minOrMax}) where minOrMax
-    @req has_attribute(TropL,:tropical_matrix) "no tropical matrix cached"
-    return get_attribute(TropL, :tropical_matrix)::dense_matrix_type(TropicalSemiringElem{minOrMax})
+    if has_attribute(TropL,:tropical_matrix)
+        return get_attribute(TropL, :tropical_matrix)::dense_matrix_type(TropicalSemiringElem{minOrMax})
+    end
+    @req has_attribute(TropL,:algebraic_matrix) && has_attribute(TropL,:tropical_semiring_map) "neither tropical matrix nor algebraic matrix and tropical semiring map cached"
+    A = algebraic_matrix(TropL)
+    nu = tropical_semiring_map(TropL)
+    return nu.(A)
 end
 
 

--- a/src/TropicalGeometry/linear_space.jl
+++ b/src/TropicalGeometry/linear_space.jl
@@ -163,10 +163,7 @@ Min tropical linear space
 
 ```
 """
-function tropical_linear_space(plueckerIndices::Vector{Vector{Int}}, plueckerVector::Vector, nu::Union{Nothing,TropicalSemiringMap}=nothing; weighted_polyhedral_complex_only::Bool=false)
-    # if nu unspecified, initialize as the trivial valuation + min convention
-    isnothing(nu) && (nu=tropical_semiring_map(parent(first(plueckerVector))))
-
+function tropical_linear_space(plueckerIndices::Vector{Vector{Int}}, plueckerVector::Vector, nu::TropicalSemiringMap=tropical_semiring_map(parent(first(plueckerVector))); weighted_polyhedral_complex_only::Bool=false)
     TropL = tropical_linear_space(plueckerIndices,
                                   nu.(plueckerVector),
                                   weighted_polyhedral_complex_only=weighted_polyhedral_complex_only)
@@ -195,10 +192,7 @@ Min tropical linear space
 
 ```
 """
-function tropical_linear_space(k::Int, n::Int, plueckerVector::Vector, nu::Union{Nothing,TropicalSemiringMap}=nothing; weighted_polyhedral_complex_only::Bool=false)
-    # if nu unspecified, initialize as the trivial valuation + min convention
-    isnothing(nu) && (nu=tropical_semiring_map(parent(first(plueckerVector))))
-
+function tropical_linear_space(k::Int, n::Int, plueckerVector::Vector, nu::TropicalSemiringMap=tropical_semiring_map(parent(first(plueckerVector))); weighted_polyhedral_complex_only::Bool=false)
     TropL = tropical_linear_space(AbstractAlgebra.combinations(1:n,k), nu.(plueckerVector), weighted_polyhedral_complex_only=weighted_polyhedral_complex_only)
 
     if !weighted_polyhedral_complex_only
@@ -275,7 +269,7 @@ Min tropical linear space
 
 ```
 """
-function tropical_linear_space(A::MatElem, nu::Union{Nothing,TropicalSemiringMap}=nothing; weighted_polyhedral_complex_only::Bool=false)
+function tropical_linear_space(A::MatElem, nu::TropicalSemiringMap=tropical_semiring_map(base_ring(A)); weighted_polyhedral_complex_only::Bool=false)
     # compute reduced row echelon form of A
     # and remove all zero rows so that matrix is of full rank
     _,A = rref(A)
@@ -291,7 +285,7 @@ function tropical_linear_space(A::MatElem, nu::Union{Nothing,TropicalSemiringMap
     end
     return TropL
 end
-function tropical_linear_space(A::Matrix, nu::Union{Nothing,TropicalSemiringMap}=nothing; weighted_polyhedral_complex_only::Bool=false)
+function tropical_linear_space(A::Matrix, nu::TropicalSemiringMap=tropical_semiring_map(parent(first(A))); weighted_polyhedral_complex_only::Bool=false)
     return tropical_linear_space(matrix(parent(first(A)),A), nu, weighted_polyhedral_complex_only=weighted_polyhedral_complex_only)
 end
 
@@ -353,7 +347,7 @@ Min tropical linear space
 
 ```
 """
-function tropical_linear_space(I::MPolyIdeal, nu::Union{Nothing,TropicalSemiringMap}=nothing; weighted_polyhedral_complex_only::Bool=false)
+function tropical_linear_space(I::MPolyIdeal, nu::TropicalSemiringMap=tropical_semiring_map(coefficient_ring(I)); weighted_polyhedral_complex_only::Bool=false)
     A = basis_of_vanishing_of_linear_ideal(I)
     TropL = tropical_linear_space(A,nu,
                                   weighted_polyhedral_complex_only=weighted_polyhedral_complex_only)
@@ -381,10 +375,7 @@ Min tropical linear space
 
 ```
 """
-function tropical_linear_space(G::Graph, nu::Union{Nothing,TropicalSemiringMap}=nothing; weighted_polyhedral_complex_only::Bool=false)
-    # if nu unspecified, initialize as the trivial valuation on QQ + min convention
-    isnothing(nu) && (nu=tropical_semiring_map(QQ))
-
+function tropical_linear_space(G::Graph, nu::TropicalSemiringMap=tropical_semiring_map(QQ); weighted_polyhedral_complex_only::Bool=false)
     M = matrix(QQ,signed_incidence_matrix(G))
     TropG = tropical_linear_space(M,nu;weighted_polyhedral_complex_only=weighted_polyhedral_complex_only)
     if !weighted_polyhedral_complex_only

--- a/src/TropicalGeometry/linear_space.jl
+++ b/src/TropicalGeometry/linear_space.jl
@@ -476,6 +476,10 @@ end
 Return the matrix over a valued field used to construct `TropL`.
 """
 @attr MatElem function algebraic_matrix(TropL::TropicalLinearSpace)
+    if has_attribute(TropL,:algebraic_matrix)
+        return get_attribute(TropL, :algebraic_matrix)::MatElem
+    end
+    @req has_attribute(TropL,:algebraic_ideal) "neither algebraic matrix nor algebraic ideal cached"
     I = algebraic_ideal(TropL)
     return basis_of_vanishing_of_linear_ideal(I)
 end

--- a/src/TropicalGeometry/linear_space.jl
+++ b/src/TropicalGeometry/linear_space.jl
@@ -382,6 +382,9 @@ Min tropical linear space
 ```
 """
 function tropical_linear_space(G::Graph, nu::Union{Nothing,TropicalSemiringMap}=nothing; weighted_polyhedral_complex_only::Bool=false)
+    # if nu unspecified, initialize as the trivial valuation on QQ + min convention
+    isnothing(nu) && (nu=tropical_semiring_map(QQ))
+
     M = matrix(QQ,signed_incidence_matrix(G))
     TropG = tropical_linear_space(M,nu;weighted_polyhedral_complex_only=weighted_polyhedral_complex_only)
     if !weighted_polyhedral_complex_only

--- a/src/TropicalGeometry/linear_space.jl
+++ b/src/TropicalGeometry/linear_space.jl
@@ -145,7 +145,7 @@ end
 
 
 @doc raw"""
-    tropical_linear_space(Lambda::Vector{Vector{Int}}, p::Vector, nu::TropicalSemiringMap; weighted_polyhedral_complex_only::Bool=false)
+    tropical_linear_space(Lambda::Vector{Vector{Int}}, p::Vector[, nu::TropicalSemiringMap]; weighted_polyhedral_complex_only::Bool=false)
 
 Return a tropical linear space from a tropical Pluecker vector with indices `Lambda` and values `nu(p)`.  If `weighted_polyhedral_complex==true`, will not cache any extra information.
 
@@ -180,7 +180,7 @@ end
 
 
 @doc raw"""
-    tropical_linear_space(k::Int, n::Int, p::Vector, nu::TropicalSemiringMap; weighted_polyhedral_complex_only::Bool=false)
+    tropical_linear_space(k::Int, n::Int, p::Vector[, nu::TropicalSemiringMap]; weighted_polyhedral_complex_only::Bool=false)
 
 Return a tropical linear space from a tropical Pluecker vector with indices `AbstractAlgebra.combinations(1:n,k)` and values `nu(p)`.  If `weighted_polyhedral_complex==true`, will not cache any extra information.
 
@@ -332,7 +332,7 @@ function basis_of_vanishing_of_linear_ideal(I::MPolyIdeal)
 end
 
 @doc raw"""
-    tropical_linear_space(I::MPolyIdeal, nu::TropicalSemiringMap; weighted_polyhedral_complex_only::Bool=false)
+    tropical_linear_space(I::MPolyIdeal[, nu::TropicalSemiringMap]; weighted_polyhedral_complex_only::Bool=false)
 
 Return the tropicalization of the vanishing set of `I` with respect to the tropical semiring map `nu`.  Requires the generators of `I` to be linear and homogeneous.  If `weighted_polyhedral_complex==true`, will not cache any extra information.
 
@@ -366,7 +366,7 @@ end
 
 
 @doc raw"""
-    tropical_linear_space(G::Graph, nu::TropicalSemiringMap; weighted_polyhedral_complex_only::Bool=false)
+    tropical_linear_space(G::Graph[, nu::TropicalSemiringMap]; weighted_polyhedral_complex_only::Bool=false)
 
 Return the Bergman fan of the graphic matroid of `G` as a tropical linear space, the tropical semiring map `nu` is used to fix the convention.  If `weighted_polyhedral_complex_only` is true, will not cache any extra information.
 

--- a/src/TropicalGeometry/linear_space.jl
+++ b/src/TropicalGeometry/linear_space.jl
@@ -368,7 +368,7 @@ end
 @doc raw"""
     tropical_linear_space(G::Graph, nu::TropicalSemiringMap; weighted_polyhedral_complex_only::Bool=false)
 
-Return the Bergman fan of the graphic matroid of `G` as a tropical linear space, the tropical semiring map `nu` is used to fix the convention.  If `weighted_polyhedral_complex==true`, will not cache any extra information.
+Return the Bergman fan of the graphic matroid of `G` as a tropical linear space, the tropical semiring map `nu` is used to fix the convention.  If `weighted_polyhedral_complex_only` is true, will not cache any extra information.
 
 # Examples
 ```jldoctest

--- a/src/TropicalGeometry/linear_space.jl
+++ b/src/TropicalGeometry/linear_space.jl
@@ -365,6 +365,30 @@ function tropical_linear_space(I::MPolyIdeal, nu::Union{Nothing,TropicalSemiring
 end
 
 
+@doc raw"""
+    tropical_linear_space(G::Graph, nu::TropicalSemiringMap; weighted_polyhedral_complex_only::Bool=false)
+
+Return the Bergman fan of the graphic matroid of `G` as a tropical linear space, the tropical semiring map `nu` is used to fix the convention.  If `weighted_polyhedral_complex==true`, will not cache any extra information.
+
+# Examples
+```jldoctest
+julia> G = complete_graph(4)
+Undirected graph with 4 nodes and the following edges:
+(2, 1)(3, 1)(3, 2)(4, 1)(4, 2)(4, 3)
+
+julia> tropical_linear_space(G)
+Min tropical linear space
+
+```
+"""
+function tropical_linear_space(G::Graph, nu::Union{Nothing,TropicalSemiringMap}=nothing; weighted_polyhedral_complex_only::Bool=false)
+    M = matrix(QQ,signed_incidence_matrix(G))
+    TropG = tropical_linear_space(M,nu;weighted_polyhedral_complex_only=weighted_polyhedral_complex_only)
+    if !weighted_polyhedral_complex_only
+        set_attribute!(TropG,:graph,G)
+    end
+    return TropG
+end
 
 ###############################################################################
 #

--- a/test/TropicalGeometry/linear_space.jl
+++ b/test/TropicalGeometry/linear_space.jl
@@ -15,7 +15,7 @@
     end
 
     @testset "tropical linear space attributes" begin
-        R,(w,x,y,z) = QQ[:w, :x, :y, :z]
+        R,(w,x,y,z) = GF(2)[:w, :x, :y, :z]
         I = ideal([w+x+y+z])
         TropL = tropical_linear_space(I)
         @test has_attribute(TropL, :tropical_pluecker_vector)

--- a/test/TropicalGeometry/linear_space.jl
+++ b/test/TropicalGeometry/linear_space.jl
@@ -32,4 +32,10 @@
         @test issetequal(plueckerVector,tropical_pluecker_vector(TropL))
     end
 
+    @testset "tropical linear space from graphs" begin
+        G = complete_graph(3)
+        TropG = tropical_linear_space(G)
+        @test f_vector(TropG) == [0,1,3]
+    end
+
 end


### PR DESCRIPTION
This pull requests adds a new constructor for tropical linear spaces from graphs.  Useful (for me) for example for graph rigidity questions (see e.g. [here](https://arxiv.org/abs/2201.00533)).