### PR TITLE
Add `in(::Int, ::Edge)`, `signed_incidence_matrix(::Graph{Undirected})`, `connectivity(::Graph{Undirected})`

### DIFF
--- a/docs/src/Combinatorics/graphs.md
+++ b/docs/src/Combinatorics/graphs.md
@@ -54,6 +54,7 @@ rem_vertices!(g::Graph{T}, a::AbstractVector{Int64}) where {T <: Union{Directed,
 adjacency_matrix(g::Graph)
 all_neighbors(g::Graph{T}, v::Int64) where {T <: Union{Directed, Undirected}}
 automorphism_group_generators(g::Graph{T}) where {T <: Union{Directed, Undirected}}
+connectivity(g::Graph{Undirected})
 complete_graph(n::Int64)
 complete_bipartite_graph(n::Int64, m::Int64)
 degree(g::Graph, v::Int)
@@ -67,6 +68,7 @@ inneighbors(g::Graph{T}, v::Int64) where {T <: Union{Directed, Undirected}}
 neighbors(g::Graph{T}, v::Int64) where {T <: Union{Directed, Undirected}}
 outneighbors(g::Graph{T}, v::Int64) where {T <: Union{Directed, Undirected}}
 shortest_path_dijkstra
+signed_incidence_matrix(g::Graph)
 is_isomorphic(g1::Graph{T}, g2::Graph{T}) where {T <: Union{Directed, Undirected}}
 is_isomorphic_with_permutation(G1::Graph, G2::Graph)
 ```

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -791,7 +791,7 @@ julia> connectivity(g)
 0
 ```
 """
-connectivity(g::Graph{Undirected}) = Polymake.graph.connectivity(g)
+connectivity(g::Graph{Undirected}) = Polymake.graph.connectivity(g)::Int
 
 @doc raw"""
     is_connected(g::Graph{Undirected})

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -316,6 +316,8 @@ Vector{Int}(e::Edge) = [src(e), dst(e)]
 
 Base.isless(a::Edge, b::Edge) = Base.isless(Vector{Int}(a), Vector{Int}(b))
 
+Base.in(i::Int, a::Edge) = (i==src(a) || i==dst(a))
+
 rem_edge!(g::Graph{T}, e::Edge) where {T <: Union{Directed, Undirected}} =
   rem_edge!(g, src(e), dst(e))
 

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -643,9 +643,9 @@ function incidence_matrix(g::Graph{T}) where {T <: Union{Directed, Undirected}}
 end
 
 @doc raw"""
-    signed_incidence_matrix(g::Graph{Directed})
+    signed_incidence_matrix(g::Graph)
 
-Return a signed incidence matrix representing a directed graph `g`.
+Return a signed incidence matrix representing a graph `g`.  If `g` is directed, sources will have sign `-1` and targest will have sign `+1`.  If `g` is undirected, vertices of larger index will have sign `-1` and vertices of smaller index will have sign `+1`.
 
 # Examples
 ```jldoctest
@@ -660,9 +660,22 @@ julia> signed_incidence_matrix(g)
   0   1  -1   0   0
   0   0   1  -1   0
   0   0   0   1  -1
+
+julia> g = Graph{Undirected}(5);
+
+julia> add_edge!(g,1,2); add_edge!(g,2,3); add_edge!(g,3,4); add_edge!(g,4,5); add_edge!(g,5,1);
+
+julia> signed_incidence_matrix(g)
+5×5 Matrix{Int64}:
+  1   0   0   1   0
+ -1   1   0   0   0
+  0  -1   1   0   0
+  0   0  -1   0   1
+  0   0   0  -1  -1
+
 ```
 """
-signed_incidence_matrix(g::Graph{Directed}) = convert(Matrix{Int}, Polymake.graph.signed_incidence_matrix(pm_object(g)))
+signed_incidence_matrix(g::Graph) = convert(Matrix{Int}, Polymake.graph.signed_incidence_matrix(pm_object(g)))
 
 ################################################################################
 ################################################################################

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -769,6 +769,31 @@ function shortest_path_dijkstra(g::Graph{T}, s::Int64, t::Int64; reverse::Bool=f
 end
 
 @doc raw"""
+    connectivity(g::Graph{Undirected})
+
+Return the connectivity of the undirected graph `g`.
+
+# Examples
+```jldoctest
+julia> g = complete_graph(3);
+
+julia> connectivity(g)
+2
+
+julia> rem_edge!(g, 2, 3);
+
+julia> connectivity(g)
+1
+
+julia> rem_edge!(g, 1, 3);
+
+julia> connectivity(g)
+0
+```
+"""
+connectivity(g::Graph{Undirected}) = Polymake.graph.connectivity(g)
+
+@doc raw"""
     is_connected(g::Graph{Undirected})
 
 Checks if the undirected graph `g` is connected.

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -432,6 +432,7 @@ export conjugate_group
 export conjugate_transpose
 export connected_components
 export connected_sum
+export connectivity
 export connectivity_function
 export contains
 export continued_fraction_hirzebruch_jung

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -132,6 +132,7 @@
 
         g = Graph{Undirected}(5)
         @test !is_connected(g)
+        @test connectivity(g) == 0
         @test length(connected_components(g)) == 5
 
         add_edge!(g, 1, 2)
@@ -139,10 +140,12 @@
         add_edge!(g, 1, 3)
         add_edge!(g, 4, 5)
         @test !is_connected(g)
+        @test connectivity(g) == 0
         @test length(connected_components(g)) == 2
 
         add_edge!(g, 3, 5)
         @test is_connected(g)
+        @test connectivity(g) == 1
         @test length(connected_components(g)) == 1
         @test diameter(g) == 3
     end

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -27,6 +27,11 @@
         add_edge!(g, 2, 3)
         add_edge!(g, 3, 1)
         @test signed_incidence_matrix(g) == Matrix([-1 0 1; 1 -1 0; 0 1 -1; 0 0 0])
+
+        e = Edge(1,2)
+        @test 1 in e
+        @test 2 in e
+        @test !(3 in e)
     end
 
     triangle = simplex(2)
@@ -42,7 +47,7 @@
     egpos = vertex_edge_graph(pos)
     egpl = vertex_edge_graph(pl)
     egplc = vertex_edge_graph(pl, modulo_lineality=true)
-    
+
     @testset "graphs from polytopes" begin
         @test n_vertices(egtriangle) == 3
         @test n_edges(egtriangle) == 3
@@ -153,7 +158,7 @@
 
         @test n_vertices(G1) == 12
         @test n_edges(G1) == 3
-      
+
         x2 = [[11,3],[3,5],[4,5],[2,4],[2,3]]
         G2 = graph_from_edges(Undirected, x2, 13)
 


### PR DESCRIPTION
- `in(::Int, ::Edge)` is self-explanatory
- `signed_incidence_matrix(::Graph{Undirected})` and `connectivity(::Graph{Undirected})` for undirected graphs should work exactly as in polymake (I just relaxed the signature of the julia function)