### PR TITLE
Docs: added resource flag to bibtool command

### DIFF
--- a/.bibtoolrsc
+++ b/.bibtoolrsc
@@ -1,7 +1,7 @@
 # This is a config file for bibtool, see
 #    http://www.gerd-neugebauer.de/software/TeX/BibTool/en/
 # To use it, invoke bibtool as follows:
-#   bibtool docs/oscar_references.bib -o docs/oscar_references.bib
+#   bibtool -r .bibtoolrsc docs/oscar_references.bib -o docs/oscar_references.bib
 
 sort = on
 

--- a/docs/src/DeveloperDocumentation/documentation.md
+++ b/docs/src/DeveloperDocumentation/documentation.md
@@ -123,7 +123,7 @@ existing entries. An easy way to do that is to add your new BibTeX entry,
 then run [bibtool](http://www.gerd-neugebauer.de/software/TeX/BibTool/en/)
 by invoking it as follows from the root directory of the Oscar.jl repository:
 
-    bibtool docs/oscar_references.bib -o docs/oscar_references.bib
+    bibtool -r .bibtoolrsc docs/oscar_references.bib -o docs/oscar_references.bib
 
 For every pull request on github, the CI checks if running `bibtool` leads to
 changes in the bibliography. If so, this test fails and indicates that the


### PR DESCRIPTION
I believe there is a bug in `bibtool v2.68`.  It is supposed to prioritize the `.bibtoolrsc` in the folder it is run in, however on my system it prioritizes the `.bibtoolrsc` in my home folder.  You can verify it as follows:
1. Save [this](https://github.com/user-attachments/files/18394030/bibtoolrsc.txt) as `~/.bibtoolrsc`
2. Run `bibtool docs/oscar_references.bib -o docs/oscar_references.bib` as per the current instructions
3. Notice it messing up `docs/oscar_references.bib` 

The change in the pull request should force `bibtool` to use the `.bibtoolsrc` in the main folder of Oscar.

edit, small correction: `bibtool` prioritizing `.bibtoolrsc` in the home folder over the `.bibtoolrsc` in the current folder is actually intended behavior.  I think we should change the command in the docu nonetheless just to be safe.