### PR TITLE
BasisLieHighestWeight: Rename some variables in doctests

### DIFF
--- a/experimental/BasisLieHighestWeight/src/UserFunctions.jl
+++ b/experimental/BasisLieHighestWeight/src/UserFunctions.jl
@@ -409,7 +409,7 @@ If this is a weighted ordering, the height of the corresponding root is used as 
 
 # Examples
 ```jldoctest
-julia> bases = basis_coordinate_ring_kodaira(:G, 2, [1,0], 6; monomial_ordering = :invlex)
+julia> mon_bases = basis_coordinate_ring_kodaira(:G, 2, [1,0], 6; monomial_ordering = :invlex)
 6-element Vector{Tuple{MonomialBasis, Vector{ZZMPolyRingElem}}}:
  (Monomial basis of a highest weight module with highest weight [1, 0] over Lie algebra of type G2, [1, x1, x3, x1*x3, x1^2*x3, x3*x4, x1*x3*x4])
  (Monomial basis of a highest weight module with highest weight [2, 0] over Lie algebra of type G2, [x4, x1*x4, x4^2, x3*x4^2, x1*x3*x4^2])
@@ -418,7 +418,7 @@ julia> bases = basis_coordinate_ring_kodaira(:G, 2, [1,0], 6; monomial_ordering 
  (Monomial basis of a highest weight module with highest weight [5, 0] over Lie algebra of type G2, [x1^2*x4^6, x4^7, x1*x4^7, x2*x4^3*x5, x1*x2*x4^3*x5, x2*x3*x4^3*x5, x1*x2*x3*x4^3*x5, x1^2*x2*x3*x4^3*x5, x2*x3^2*x4^3*x5, x1*x2*x3^2*x4^3*x5, x1^2*x2*x3^2*x4^3*x5, x2*x4^4*x5])
  (Monomial basis of a highest weight module with highest weight [6, 0] over Lie algebra of type G2, [x4^9, x1*x3*x4^4*x5, x2*x4^5*x5, x3*x4^5*x5, x3^2*x4^5*x5, x2*x3^2*x4^5*x5, x1*x2*x3^2*x4^5*x5, x3^4*x4*x5^2])
 
-julia> [length(basis[2]) for basis in bases]
+julia> [length(mon_basis[2]) for mon_basis in mon_bases]
 6-element Vector{Int64}:
   7
   5
@@ -427,7 +427,7 @@ julia> [length(basis[2]) for basis in bases]
  12
   8
 
-julia> bases[end][1]
+julia> mon_bases[end][1]
 Monomial basis of a highest weight module
   of highest weight [6, 0]
   of dimension 714
@@ -512,7 +512,7 @@ The monomial ordering is fixed to `degrevlex`.
 
 # Examples
 ```jldoctest
-julia> bases = basis_coordinate_ring_kodaira_ffl(:G, 2, [1,0], 6)
+julia> mon_bases = basis_coordinate_ring_kodaira_ffl(:G, 2, [1,0], 6)
 6-element Vector{Tuple{MonomialBasis, Vector{ZZMPolyRingElem}}}:
  (Monomial basis of a highest weight module with highest weight [1, 0] over Lie algebra of type G2, [1, x6, x4, x3, x2, x1, x1*x6])
  (Monomial basis of a highest weight module with highest weight [2, 0] over Lie algebra of type G2, [])
@@ -521,7 +521,7 @@ julia> bases = basis_coordinate_ring_kodaira_ffl(:G, 2, [1,0], 6)
  (Monomial basis of a highest weight module with highest weight [5, 0] over Lie algebra of type G2, [])
  (Monomial basis of a highest weight module with highest weight [6, 0] over Lie algebra of type G2, [])
 
-julia> [length(basis[2]) for basis in bases]
+julia> [length(mon_basis[2]) for mon_basis in mon_bases]
 6-element Vector{Int64}:
  7
  0
@@ -530,7 +530,7 @@ julia> [length(basis[2]) for basis in bases]
  0
  0
 
-julia> bases[end][1]
+julia> mon_bases[end][1]
 Monomial basis of a highest weight module
   of highest weight [6, 0]
   of dimension 714


### PR DESCRIPTION
As per request of @gfourier.

The previous code raised the following error when copy-pasted in a session after `using Oscar`:
```julia
ERROR: cannot assign a value to imported variable Oscar.bases from module Main
Stacktrace:
 [1] top-level scope
   @ REPL[13]:1
```
Renaming the local variable gets rid of this issue and makes it easier for people to play around with the code