### PR TITLE
Fix some typos around backticks in docstrings

### DIFF
--- a/docs/src/Rings/rational.md
+++ b/docs/src/Rings/rational.md
@@ -270,8 +270,8 @@ ERROR: DivideError: integer division error
 
 * `is_power(a::QQFieldElem, b::Int) -> Bool, QQFieldElem`
 
-Test if ``a`` is an ``n``-th power. If so, return ```true``` and the root,
-```false``` and any rational otherwise.
+Test if ``a`` is an ``n``-th power. If so, return `true` and the root,
+`false` and any rational otherwise.
 
 * `is_perfect_power_with_data(a::QQFieldElem) -> Int, QQFieldElem`
 

--- a/experimental/AlgebraicStatistics/src/CI.jl
+++ b/experimental/AlgebraicStatistics/src/CI.jl
@@ -30,7 +30,7 @@ to ensure consistent comparison and hashing.
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> ci_stmt(["A"], ["B"], ["X"])
 [A _||_ B | X]
 
@@ -78,7 +78,7 @@ are extracted, `ci_stmt` is called.
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> CI"AB|X"
 [A _||_ B | X]
 
@@ -124,7 +124,7 @@ distribution.
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> ci_statements(["A", "B", "X", "Y"])
 24-element Vector{CIStmt}:
  [A _||_ Y | {}]
@@ -183,7 +183,7 @@ above `K` but is always fixed to `K`. Semigaussoids are also known as
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> make_elementary(CI"12,34|56")
 16-element Vector{CIStmt}:
  [1 _||_ 3 | {5, 6}]

--- a/experimental/AlgebraicStatistics/src/GaussianGraphicalModels.jl
+++ b/experimental/AlgebraicStatistics/src/GaussianGraphicalModels.jl
@@ -26,7 +26,7 @@ If `cached` is `true`, the internally generated polynomial ring will be cached.
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> R = gaussian_ring(3)
 Gaussian ring over Rational field in 6 variables
 s[1, 1], s[1, 2], s[1, 3], s[2, 2], s[2, 3], s[3, 3]
@@ -56,7 +56,7 @@ Return the multivariate polynomial ring inside `R`.
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> R = gaussian_ring(3)
 Gaussian ring over Rational field in 6 variables
 s[1, 1], s[1, 2], s[1, 3], s[2, 2], s[2, 3], s[3, 3]
@@ -77,7 +77,7 @@ Return the generators of the multivariate polynomial ring inside the GaussianRin
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> R = gaussian_ring(3)
 Gaussian ring over Rational field in 6 variables
 s[1, 1], s[1, 2], s[1, 3], s[2, 2], s[2, 3], s[3, 3]
@@ -103,7 +103,7 @@ Return the covariance matrix associated to `R` as a matrix over the underlying p
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> R = gaussian_ring(3)
 Gaussian ring over Rational field in 6 variables
 s[1, 1], s[1, 2], s[1, 3], s[2, 2], s[2, 3], s[3, 3]
@@ -135,7 +135,7 @@ If `cached` is `true`, the internally generated polynomial ring will be cached.
 
 ## Examples
 
-``` jldoctest directed_ggm
+```jldoctest
 julia> M = graphical_model(graph_from_edges(Directed, [[1,2], [2,3]]), gaussian_ring(3))
 Gaussian graphical model on a directed graph with edges:
 (1, 2), (2, 3)
@@ -169,7 +169,7 @@ Creates the weighted adjacency matrix $\Lambda$ of a directed graph `G` whose en
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> M = graphical_model(graph_from_edges(Directed, [[1,2], [2,3]]), gaussian_ring(3))
 Gaussian graphical model on a directed graph with edges:
 (1, 2), (2, 3)
@@ -193,7 +193,7 @@ Creates the covariance matrix $ \Omega $ of the independent error terms in a dir
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> M = graphical_model(graph_from_edges(Directed, [[1,2], [2,3]]), gaussian_ring(3))
 Gaussian graphical model on a directed graph with edges:
 (1, 2), (2, 3)
@@ -219,7 +219,7 @@ $(Id - \Lambda)^{-T} \Omega (Id - \Lambda)^{T} \mapsto \Sigma$ where $\Lambda =$
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> M = graphical_model(graph_from_edges(Directed, [[1,2], [2,3]]), gaussian_ring(3))
 Gaussian graphical model on a directed graph with edges:
 (1, 2), (2, 3)
@@ -265,7 +265,7 @@ If `cached` is `true`, the internally generated polynomial ring will be cached.
 
 ## Examples
 
-``` jldoctest undirected_ggm
+```jldoctest
 julia> M = graphical_model(graph_from_edges([[1,2], [2,3]]), gaussian_ring(3))
 Gaussian graphical model on an undirected graph with edges:
 (1, 2), (2, 3)
@@ -300,7 +300,7 @@ whose nonzero entries correspond to the edges of the associated graph.
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> M = graphical_model(graph_from_edges([[1,2], [2,3]]), gaussian_ring(3))
 Gaussian graphical model on an undirected graph with edges:
 (1, 2), (2, 3)
@@ -337,7 +337,7 @@ $ K \mapsto K^{-1}$ where $ K = $  `concentration_matrix(M)` and the entries of 
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> M = graphical_model(graph_from_edges([[1,2], [2,3]]), gaussian_ring(3))
 Gaussian graphical model on an undirected graph with edges:
 (1, 2), (2, 3)
@@ -373,7 +373,7 @@ and then eliminating all variables `k[i,j]` where $ K =$ `concentration_matrix(M
 
 ## Examples
 
-``` jldoctest undirected_ggm
+```jldoctest
 julia> M = graphical_model(graph_from_edges([[1,2], [2,3]]), gaussian_ring(3))
 Gaussian graphical model on an undirected graph with edges:
 (1, 2), (2, 3)

--- a/experimental/AlgebraicStatistics/src/GraphicalModels.jl
+++ b/experimental/AlgebraicStatistics/src/GraphicalModels.jl
@@ -82,7 +82,7 @@ This is done by computing the kernel of the parametrization.
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> M = graphical_model(graph_from_edges(Directed, [[1,2], [2,3]]), gaussian_ring(3))
 Gaussian graphical model on a directed graph with edges:
 (1, 2), (2, 3)

--- a/experimental/AlgebraicStatistics/src/Markov.jl
+++ b/experimental/AlgebraicStatistics/src/Markov.jl
@@ -30,7 +30,7 @@ with the Macaulay2 package `GraphicalModels`.
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> R = markov_ring("A" => 1:2, "B" => 1:2, "X" => 1:2, "Y" => 1:2)
 MarkovRing for random variables A -> {1, 2}, B -> {1, 2}, X -> {1, 2}, Y -> {1, 2} in 16 variables over Rational field
 ```
@@ -67,7 +67,7 @@ Return the multivariate polynomial ring inside `R`.
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> R = markov_ring("A" => 1:2, "B" => 1:2, "X" => 1:2, "Y" => 1:2)
 MarkovRing for random variables A -> {1, 2}, B -> {1, 2}, X -> {1, 2}, Y -> {1, 2} in 16 variables over Rational field
 
@@ -87,7 +87,7 @@ Return the list of random variables used to create the MarkovRing.
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> R = markov_ring("A" => 1:2, "B" => 1:2, "X" => 1:2, "Y" => 1:2)
 MarkovRing for random variables A -> {1, 2}, B -> {1, 2}, X -> {1, 2}, Y -> {1, 2} in 16 variables over Rational field
 
@@ -108,7 +108,7 @@ end
 
 Returns all the `CIStmt` objects which can be formed on the `random_variables(R)`.
 
-``` jldoctest
+```jldoctest
 julia> R = markov_ring("A" => 1:2, "B" => 1:2, "X" => 1:2, "Y" => 1:2)
 MarkovRing for random variables A -> {1, 2}, B -> {1, 2}, X -> {1, 2}, Y -> {1, 2} in 16 variables over Rational field
 
@@ -145,7 +145,7 @@ Return the generators of the polynomial ring.
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> R = markov_ring("A" => 1:2, "B" => 1:2, "X" => 1:2, "Y" => 1:2)
 MarkovRing for random variables A -> {1, 2}, B -> {1, 2}, X -> {1, 2}, Y -> {1, 2} in 16 variables over Rational field
 
@@ -221,7 +221,7 @@ in the ring `R`. The result is an `Iterators.product` iterator unless
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> R = markov_ring("A" => 1:2, "B" => 1:2, "X" => 1:2, "Y" => 1:2)
 MarkovRing for random variables A -> {1, 2}, B -> {1, 2}, X -> {1, 2}, Y -> {1, 2} in 16 variables over Rational field
 
@@ -263,7 +263,7 @@ variables in `R` are summed over their respective state spaces.
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> R = markov_ring("A" => 1:2, "B" => 1:2, "X" => 1:2, "Y" => 1:2)
 MarkovRing for random variables A -> {1, 2}, B -> {1, 2}, X -> {1, 2}, Y -> {1, 2} in 16 variables over Rational field
 
@@ -294,7 +294,7 @@ given by `stmts`.
 
 ## Examples
 
-``` jldoctest
+```jldoctest
 julia> R = markov_ring("A" => 1:2, "B" => 1:2, "X" => 1:2)
 MarkovRing for random variables A -> {1, 2}, B -> {1, 2}, X -> {1, 2} in 8 variables over Rational field
 

--- a/experimental/FTheoryTools/src/TateModels/attributes.jl
+++ b/experimental/FTheoryTools/src/TateModels/attributes.jl
@@ -366,7 +366,7 @@ end
     singular_loci(t::GlobalTateModel)
 
 Return the singular loci of the global Tate model, along with the order of
-vanishing of ``(f, g, \Delta)``` at each locus and the refined Tate fiber type.
+vanishing of ``(f, g, \Delta)`` at each locus and the refined Tate fiber type.
 
 For the time being, we either explicitly or implicitly focus on toric varieties
 as base spaces. Explicitly, in case the user provides such a variety as base space,

--- a/experimental/ModStd/src/ModStdQt.jl
+++ b/experimental/ModStd/src/ModStdQt.jl
@@ -596,7 +596,7 @@ Multivariate polynomial ring in 2 variables X[1], X[2]
 julia> parent(f[2][1])
 Multivariate polynomial ring in 2 variables X[1], X[2]
   over residue field of univariate polynomial ring modulo t^2 + a[1]
-```  
+```
 """
 function Oscar.factor_absolute(f::MPolyRingElem{Generic.FracFieldElem{QQMPolyRingElem}})
   Qtx = parent(f)                 # Q[t1,t2][x1,x2]

--- a/experimental/Schemes/src/DerivedPushforward.jl
+++ b/experimental/Schemes/src/DerivedPushforward.jl
@@ -44,7 +44,7 @@ end
 
 We consider a graded module `M` over a standard graded polynomial ring 
 ``S = A[x₀,…,xₙ]`` as a representative of a coherent sheaf ``ℱ`` on 
-relative projective space ``ℙ ⁿ_A``. Then we compute ``Rπ_* ℱ``` as a
+relative projective space ``ℙ ⁿ_A``. Then we compute ``Rπ_* ℱ`` as a
 complex of ``A``-modules where ``π : ℙ ⁿ_A → Spec(A)`` is the projection 
 to the base. 
 """

--- a/src/AlgebraicGeometry/Surfaces/EllipticSurface/EllipticSurface.jl
+++ b/src/AlgebraicGeometry/Surfaces/EllipticSurface/EllipticSurface.jl
@@ -250,7 +250,7 @@ Return sections ``P_1,\dots P_n`` of the generic fiber, such that together with
 the generators of the algebraic lattice ``A``, they generate
 ```math
 \frac{1}{p} A \cap N
-``` 
+```
 where ``N`` is the numerical lattice of ``X``.
 
 The algorithm proceeds by computing division points in the Mordell-Weil subgroup of `X`


### PR DESCRIPTION
~~This also removes some faulty spaces between triple backticks and `jldoctest` and thus enables many doctests in `experimental/AlgebraicStatistics` (cc @bkholler @taboege @marinagarrote)~~