### PR TITLE
Add dedicated `stabilizer` methods for matrix groups for improved performance

### DIFF
--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -348,6 +348,7 @@ GAP.@wrap RightTransversal(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap RootSystem(x::GapObj)::GapObj
 GAP.@wrap ScalarProduct(x::GapObj, y::GapObj, z::GapObj)::GAP.Obj
 GAP.@wrap SchurIndexByCharacter(x::GapObj, y::GapObj, z::GapObj)::GAP.Obj
+GAP.@wrap Set(x::GapObj)::GapObj
 GAP.@wrap SetMaximalAbelianQuotient(x::Any, y::Any)::Nothing
 GAP.@wrap SetSize(x::Any, y::Any)::Nothing
 GAP.@wrap ShrinkRowVector(x::GapObj)::Nothing

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -564,7 +564,7 @@ function stabilizer(G::PermGroup, pnt::T, actfun::Function) where T <: IntegerUn
     return (actfun == ^) ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
 end
 
-function stabilizer(G::PermGroup, pnt::Vector{T}, actfun::Function) where T <: IntegerUnion
+function stabilizer(G::PermGroup, pnt::Union{Vector{T},Tuple{T,Vararg{T}}}, actfun::Function) where T <: IntegerUnion
     return actfun == on_tuples ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
 end
 
@@ -573,12 +573,73 @@ function stabilizer(G::PermGroup, pnt::AbstractSet{T}, actfun::Function) where T
 end
 
 # natural stabilizers in matrix groups
-stabilizer(G::MatrixGroup{ET,MT}, pnt::AbstractAlgebra.Generic.FreeModuleElem{ET}) where {ET,MT} = stabilizer(G, pnt, *)
+# Construct the arguments on the GAP side such that GAP's method selection
+# can choose the special method.
+# - stabilizer in a matrix group (over a finite field)
+#   of a `FreeModuleElem` via `*` (or `^`)
+# - stabilizer in a matrix group (over a finite field)
+#   of a vector or tuple of `FreeModuleElem`s via `on_tuples`
+# - stabilizer in a matrix group (over a finite field)
+#   of a `Set` of `FreeModuleElem`s via `on_sets`
+function stabilizer(G::MatrixGroup{ET,MT}, pnt::AbstractAlgebra.Generic.FreeModuleElem{ET}) where {ET,MT}
+    iso = Oscar.iso_oscar_gap(base_ring(parent(pnt)))
+    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+        map_entries(iso, AbstractAlgebra.Generic._matrix(pnt)),
+        GAP.Globals.OnRight))
+end
 
-stabilizer(G::MatrixGroup{ET,MT}, pnt::Vector{AbstractAlgebra.Generic.FreeModuleElem{ET}}) where {ET,MT} = stabilizer(G, pnt, on_tuples)
+function stabilizer(G::MatrixGroup{ET,MT}, pnt::Vector{AbstractAlgebra.Generic.FreeModuleElem{ET}}) where {ET,MT}
+    length(pnt) == 0 && return G
+    iso = Oscar.iso_oscar_gap(base_ring(parent(pnt[1])))
+    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+        GapObj([GapObj(map_entries(iso, AbstractAlgebra.Generic._matrix(v)))[1] for v in pnt]),
+        GAP.Globals.OnTuples))
+end
 
-stabilizer(G::MatrixGroup{ET,MT}, pnt::AbstractSet{AbstractAlgebra.Generic.FreeModuleElem{ET}}) where {ET,MT} = stabilizer(G, pnt, on_sets)
+function stabilizer(G::MatrixGroup{ET,MT}, pnt::Tuple{AbstractAlgebra.Generic.FreeModuleElem{ET},Vararg{AbstractAlgebra.Generic.FreeModuleElem{ET}}}) where {ET,MT}
+    length(pnt) == 0 && return G
+    iso = Oscar.iso_oscar_gap(base_ring(parent(pnt[1])))
+    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+        GapObj([GapObj(map_entries(iso, AbstractAlgebra.Generic._matrix(v)))[1] for v in pnt]),
+        GAP.Globals.OnTuples))
+end
 
+function stabilizer(G::MatrixGroup{ET,MT}, pnt::AbstractSet{AbstractAlgebra.Generic.FreeModuleElem{ET}}) where {ET,MT}
+    length(pnt) == 0 && return G
+    iso = Oscar.iso_oscar_gap(base_ring(parent(iterate(pnt)[1])))
+    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+        GAPWrap.Set(GapObj([GapObj(map_entries(iso, AbstractAlgebra.Generic._matrix(v)))[1] for v in pnt])),
+        GAP.Globals.OnSets))
+end
+
+# now the same with given action function,
+# these calls may come from delegations from G-sets
+function stabilizer(G::MatrixGroup{ET,MT}, pnt::AbstractAlgebra.Generic.FreeModuleElem{ET}, actfun::Function) where {ET,MT}
+    return (actfun == *) ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
+end
+
+function stabilizer(G::MatrixGroup{ET,MT}, pnt::Vector{AbstractAlgebra.Generic.FreeModuleElem{ET}}, actfun::Function) where {ET,MT}
+    return (actfun == on_tuples) ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
+end
+
+function stabilizer(G::MatrixGroup{ET,MT}, pnt::Tuple{AbstractAlgebra.Generic.FreeModuleElem{ET},Vararg{AbstractAlgebra.Generic.FreeModuleElem{ET}}}, actfun::Function) where {ET,MT}
+    return (actfun == on_tuples) ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
+end
+
+function stabilizer(G::MatrixGroup{ET,MT}, pnt::AbstractSet{AbstractAlgebra.Generic.FreeModuleElem{ET}}, actfun::Function) where {ET,MT}
+    return (actfun == on_sets) ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
+end
+
+# stabilizer in a matrix group (over a finite field)
+# of a row reduced matrix via `on_echelon_form_mats`
+function stabilizer(G::MatrixGroup{ET,<:MT}, pnt::MatElem{<:MT}, actfun::Function) where {ET,MT}
+    (actfun === on_echelon_form_mats) || return _stabilizer_generic(G, pnt, actfun)
+    nrows(pnt) == 0 && return (G, identity_map(G))
+    iso = Oscar.iso_oscar_gap(base_ring(pnt))
+    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+        map_entries(iso, pnt),
+        GAP.Globals.OnSubspacesByCanonicalBasis))
+end
 
 """
     right_coset_action(G::GAPGroup, U::GAPGroup)

--- a/test/Groups/action.jl
+++ b/test/Groups/action.jl
@@ -1,16 +1,27 @@
 @testset "natural stabilizers in permutation groups" begin
 
   G = symmetric_group(5)
-  S = stabilizer(G, 1)
+  # stabilizer of a vector of integers
+  pt = 1
+  S = stabilizer(G, pt)
   @test order(S[1]) == 24
-  @test S[1] == stabilizer(G, 1, ^)[1]
+  @test S[1] == stabilizer(G, pt, ^)[1]
+  # stabilizer of a vector of integers
   pt = [1, 2]
   S = stabilizer(G, pt)
   @test order(S[1]) == 6
   @test S[1] == stabilizer(G, pt, on_tuples)[1]
-  S = stabilizer(G, Set(pt))
+  # stabilizer of a tuple of integers
+  pt = (1, 2)
+  S = stabilizer(G, pt)
+  @test order(S[1]) == 6
+  @test S[1] == stabilizer(G, pt, on_tuples)[1]
+  # stabilizer of a set of integers
+  pt = Set([1, 2])
+  S = stabilizer(G, pt)
   @test order(S[1]) == 12
-  @test S[1] == stabilizer(G, Set(pt), on_sets)[1]
+  @test S[1] == stabilizer(G, pt, on_sets)[1]
+  # stabilizer under permutation action on vectors
   l = [1, 1, 2, 2, 3]
   S = stabilizer(G, l, permuted)
   @test order(S[1]) == 4
@@ -44,17 +55,39 @@ end
   F = GF(2)
   G = general_linear_group(n, F)
   V = free_module(F, n)
+  # stabilizer of a vector
   v = gen(V, 1)
   S = stabilizer(G, v)
   @test order(S[1]) == 24
   @test S[1] == stabilizer(G, v, *)[1]
+  @test S[1] == Oscar._stabilizer_generic(G, v, *)[1]
+  # stabilizer of a vector of vectors
   S = stabilizer(G, gens(V))
   @test order(S[1]) == 1
   @test S[1] == stabilizer(G, gens(V), on_tuples)[1]
+  @test S[1] == Oscar._stabilizer_generic(G, gens(V), on_tuples)[1]
+  # stabilizer of a set of vectors
   S = stabilizer(G, Set(gens(V)))
   @test order(S[1]) == 6
   @test S[1] == stabilizer(G, Set(gens(V)), on_sets)[1]
-
+  @test S[1] == Oscar._stabilizer_generic(G, Set(gens(V)), on_sets)[1]
+  # stabilizer of a tuple of vectors
+  w = (gen(V, 1), gen(V, 2))
+  S = stabilizer(G, w)
+  @test order(S[1]) == 4
+  @test S[1] == stabilizer(G, w, on_tuples)[1]
+  @test S[1] == Oscar._stabilizer_generic(G, w, on_tuples)[1]
+  # stabilizer of an echelonized matrix
+  W, embW = sub(V, [gen(V,1), gen(V,3)])
+  m = matrix(embW)
+  S = stabilizer(G, m, on_echelon_form_mats)
+  @test order(S[1]) == 24
+  @test S[1] == Oscar._stabilizer_generic(G, m, on_echelon_form_mats)[1]
+  W, embW = sub(V, [])
+  m = matrix(embW)
+  S = stabilizer(G, m, on_echelon_form_mats)
+  @test S[1] == G
+  @test S[1] == Oscar._stabilizer_generic(G, m, on_echelon_form_mats)[1]
 end
 
 @testset "action on multivariate polynomials: permutations" begin


### PR DESCRIPTION
The idea is to call `GAPWrap.Stabilizer` with GAP objects and a GAP action function where this is possible.