### PR TITLE
Remove some unreachable code `Schemes/` and `MPolyQuo.jl`

### DIFF
--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Attributes.jl
@@ -277,14 +277,6 @@ function ideal_sheaf_of_singular_locus(
   return get_attribute!(X, :ideal_sheaf_of_singular_locus) do
     SingularLocusIdealSheaf(X; focus)
   end::SingularLocusIdealSheaf
-  D = IdDict{AbsAffineScheme, Ideal}()
-  covering = get_attribute(X, :simplified_covering, default_covering(X))
-  for U in covering
-    _, inc_sing = singular_locus(U)
-    D[U] = radical(image_ideal(inc_sing))
-  end
-  Ising = IdealSheaf(X, D, check=false)
-  return Ising
 end
 
 function simplified_covering(X::AbsCoveredScheme)

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -1898,25 +1898,6 @@ function small_generating_set(
     # Temporary workaround, see #3499
     unique!(filter!(!iszero, Q.(small_generating_set(saturated_ideal(I); algorithm))))
   end::Vector{elem_type(base_ring(I))}
-
-  @req coefficient_ring(Q) isa Field "The coefficient ring must be a field"
-
-  # in the ungraded case, mstd's heuristic returns smaller gens when recomputing gb
-  sing_gb, sing_min = Singular.mstd(singular_generators(I.gens))
-  if !isdefined(I, :gb)
-    I.gb = IdealGens(I.gens.Ox, sing_gb, true)
-    I.gb.gens.S.isGB = I.gb.isGB = true
-  end
-
-  # we do not have a notion of minimal generating set in this context!
-  # If we are unlucky, mstd can even produce a larger generating set
-  # than the original one!!!
-  return_value = filter(!iszero, (Q).(gens(sing_min)))
-  if length(return_value) <= ngens(I)
-    return return_value
-  else
-    return gens(I)
-  end
 end
 
 # in the graded case, reusing a cached gb makes sense, so use minimal_generating set there


### PR DESCRIPTION
The return statement right above the first removed piece of code got added in https://github.com/oscar-system/Oscar.jl/pull/3672 by @HechtiDerLachs.
The return statement right above the second removed piece of code got added in https://github.com/oscar-system/Oscar.jl/pull/3609 by @HechtiDerLachs.


Removing this code has no semantic changes whatsoever.