### PR TITLE
Ordering of simple roots: Documentation

### DIFF
--- a/src/LieTheory/CartanMatrix.jl
+++ b/src/LieTheory/CartanMatrix.jl
@@ -283,6 +283,8 @@ of the roots in the Dynkin diagram.
 
 If `check=true` the function will verify that `gcm` is indeed a Cartan matrix.
 
+See also: [`root_system_type_with_ordering(::RootSystem)`].
+
 !!! note
     The order of returned components is, in general, not unique and might change between versions.
     But we guarantee that if this function is called with the output of [`cartan_matrix(::Vector{Tuple{Symbol,Int}})`](@ref cartan_matrix(type::Vector{Tuple{Symbol,Int}})),
@@ -295,6 +297,15 @@ If `check=true` the function will verify that `gcm` is indeed a Cartan matrix.
 ```jldoctest
 julia> cartan_type_with_ordering(cartan_matrix(:E, 6))
 ([(:E, 6)], [1, 2, 3, 4, 5, 6])
+
+julia> cartan_matrix(:B, 3)
+[ 2   -1    0]
+[-1    2   -1]
+[ 0   -2    2]
+
+# ZZ[2 0 -2; 0 2 -1; -1 -1 2] is obtained from cartan_matrix(:B, 3) by permuting rows and columns according to perm([2, 3, 1])
+julia> cartan_type_with_ordering(ZZ[2 0 -2; 0 2 -1; -1 -1 2])
+([(:B, 3)], [2, 3, 1])
 
 julia> cartan_type_with_ordering(ZZ[2 0 -1 0; 0 2 0 -2; -2 0 2 0; 0 -1 0 2])
 ([(:B, 2), (:C, 2)], [1, 3, 2, 4])

--- a/src/LieTheory/CartanMatrix.jl
+++ b/src/LieTheory/CartanMatrix.jl
@@ -298,13 +298,7 @@ See also: [`root_system_type_with_ordering(::RootSystem)`].
 julia> cartan_type_with_ordering(cartan_matrix(:E, 6))
 ([(:E, 6)], [1, 2, 3, 4, 5, 6])
 
-julia> cartan_matrix(:B, 3)
-[ 2   -1    0]
-[-1    2   -1]
-[ 0   -2    2]
-
-# ZZ[2 0 -2; 0 2 -1; -1 -1 2] is obtained from cartan_matrix(:B, 3) by permuting rows and columns according to perm([2, 3, 1])
-julia> cartan_type_with_ordering(ZZ[2 0 -2; 0 2 -1; -1 -1 2])
+julia> cartan_type_with_ordering(ZZ[2 0 -2; 0 2 -1; -1 -1 2]) # type B_3, with rows and columns permuted with perm([2, 3, 1])
 ([(:B, 3)], [2, 3, 1])
 
 julia> cartan_type_with_ordering(ZZ[2 0 -1 0; 0 2 0 -2; -2 0 2 0; 0 -1 0 2])

--- a/src/LieTheory/RootSystem.jl
+++ b/src/LieTheory/RootSystem.jl
@@ -261,14 +261,14 @@ end
 @doc raw"""
     root_system_type_with_ordering(R::RootSystem) -> Vector{Tuple{Symbol,Int}}, Vector{Int}
 
-Return the Cartan type of `R`, together with the ordering of the simple roots.
+Return the Cartan type of `R`, together with a vector `ordering` such that [`simple_roots`](@ref)`(R)[ordering]` is a canonical ordering of the simple roots.
 
 If the type is already known, it is returned directly.
 This can be checked with [`has_root_system_type(::RootSystem)`](@ref).
 
 If the type is not known, it is determined and stored in `R`.
 
-See also: [`root_system_type(::RootSystem)`](@ref).
+See also: [`root_system_type(::RootSystem)`](@ref), [`cartan_type_with_ordering(::ZZMatrix)`].
 
 !!! warning
     This function will error if the type is not known yet and the Weyl group is infinite.


### PR DESCRIPTION
I am often confused what precisely the ordering vector returned by `root_system_type_with_ordering` and `cartan_type_with_ordering` means. Specifically, I often mix up whether it describes the permutation which transforms the canonical ordering into the given ordering or the other way around. Hence I added the following to the documentation:
1. An additional clarification in `root_system_type_with_ordering`.
2. An additional example in `cartan_type_with_ordering`. Note that the new example arises from a permutation which is not of order 2, so that it makes a difference whether we go from the canonical ordering to the given one or the other way around.
3. The two docs now reference each other.