### PR TITLE
Improve performance of strict transform under toric blowups

### DIFF
--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
@@ -157,7 +157,7 @@ function blow_up(m::AbstractFTheoryModel, I::AbsIdealSheaf; coordinate_name::Str
   # Construct the new model
   if m isa GlobalTateModel
     if isdefined(m, :tate_polynomial) && new_ambient_space isa NormalToricVariety
-      new_tate_polynomial = _strict_transform(bd, tate_polynomial(m))
+      new_tate_polynomial = cox_ring_module_homomorphism(bd, tate_polynomial(m))
       model = GlobalTateModel(explicit_model_sections(m), defining_section_parametrization(m), new_tate_polynomial, base_space(m), new_ambient_space)
     else
       new_tate_ideal_sheaf = _strict_transform(bd, tate_ideal_sheaf(m))
@@ -165,7 +165,7 @@ function blow_up(m::AbstractFTheoryModel, I::AbsIdealSheaf; coordinate_name::Str
     end
   else
     if isdefined(m, :weierstrass_polynomial) && new_ambient_space isa NormalToricVariety
-      new_weierstrass_polynomial = _strict_transform(bd, weierstrass_polynomial(m))
+      new_weierstrass_polynomial = cox_ring_module_homomorphism(bd, weierstrass_polynomial(m))
       model = WeierstrassModel(explicit_model_sections(m), defining_section_parametrization(m), new_weierstrass_polynomial, base_space(m), new_ambient_space)
     else
       new_weierstrass_ideal_sheaf = _strict_transform(bd, weierstrass_ideal_sheaf(m))

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -463,43 +463,6 @@ eval_poly(n::Number, R) = R(n)
 _strict_transform(bd::AbsCoveredSchemeMorphism, II::AbsIdealSheaf) = strict_transform(bd, II)
 
 function _strict_transform(bd::ToricBlowupMorphism, II::ToricIdealSheafFromCoxRingIdeal)
-  center_ideal = ideal_in_cox_ring(center_unnormalized(bd))
-  if (ngens(ideal_in_cox_ring(II)) != 1) || (all(in(gens(base_ring(center_ideal))), gens(center_ideal)) == false)
-    return strict_transform(bd, II)
-  end
-  S = cox_ring(domain(bd))
-  _e = gen(S, index_of_exceptional_ray(bd))
-  images = MPolyRingElem[]
-  g_list = gens(S)
-  g_center = [string(k) for k in symbols(ideal_in_cox_ring(center_unnormalized(bd)))]
-  for v in g_list
-    v == _e && continue
-    if string(v) in g_center
-      push!(images, v * _e)
-    else
-      push!(images, v)
-    end
-  end
-  ring_map = hom(cox_ring(codomain(bd)), S, images)
-  total_transform = ring_map(ideal_in_cox_ring(II))
-  exceptional_ideal = total_transform + ideal([_e])
-  strict_transform, exceptional_factor = saturation_with_index(total_transform, exceptional_ideal)
-  return ideal_sheaf(domain(bd), strict_transform)
-end
-
-function _strict_transform(bd::ToricBlowupMorphism, tate_poly::MPolyRingElem)
-  S = cox_ring(domain(bd))
-  _e = gen(S, index_of_exceptional_ray(bd))
-  g_list = string.(symbols(S))
-  g_center = [string(k) for k in gens(ideal_in_cox_ring(center_unnormalized(bd)))]
-  position_of_center_variables = [findfirst(==(g), g_list) for g in g_center]
-  pos_of_e = findfirst(==(string(_e)), g_list)
-  C = MPolyBuildCtx(S)
-  for m in terms(tate_poly)
-    exps = collect(exponents(m))[1]
-    insert!(exps, pos_of_e, sum(exps[position_of_center_variables]))
-    push_term!(C, collect(coefficients(m))[1], exps)
-  end
-  f = finish(C)
-  return remove(f, _e)[2]
+  transf = strict_transform(bd, ideal_in_cox_ring(II))
+  return ideal_sheaf(domain(bd), transf)
 end

--- a/experimental/Schemes/src/ToricBlowups/methods.jl
+++ b/experimental/Schemes/src/ToricBlowups/methods.jl
@@ -190,7 +190,6 @@ x1*e^2 + x2*e^3
 cox_ring_module_homomorphism
 
 function cox_ring_module_homomorphism(f::ToricBlowupMorphism, g::MPolyDecRingElem)
-  # We assume the i-th variable of `R` is the i-th variable of `S`
   @req parent(g) === cox_ring(codomain(f)) "g must be an element of the Cox ring of the codomain of f"
   R = cox_ring(codomain(f))
   S = cox_ring(domain(f))
@@ -203,12 +202,15 @@ function cox_ring_module_homomorphism(f::ToricBlowupMorphism, g::MPolyDecRingEle
   end
   exceptional_var = S[index_of_exceptional_ray(f)]
   C = MPolyBuildCtx(S)
+
+  # Core loop
   for m in terms(g)
-    exps = collect(exponents(m))[1]
+    exps = first(exponents(m))
     exceptional_exp = ceil(Int64, sum(ps_fast.*exps))
-    insert!(exps, index_of_exceptional_ray(f), exceptional_exp)
-    push_term!(C, collect(coefficients(m))[1], exps)
+    exps = [exps; exceptional_exp]
+    push_term!(C, first(coefficients(m)), exps)
   end
+
   h = finish(C)
   return h
 end

--- a/experimental/Schemes/test/runtests.jl
+++ b/experimental/Schemes/test/runtests.jl
@@ -97,4 +97,23 @@ end
   J_strict = strict_transform(f, I)
   @test J_strict == ideal(S, [x_ + y_*z_^2*u])
   @test ideal_sheaf(Y, J_strict) == strict_transform(f, ideal_sheaf(X, I))
+
+  # Quadratic cone, blowup along non-Cartier divisor
+  ray_generators = [[0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1]]
+  max_cones = IncidenceMatrix([[1, 2, 3, 4]])
+  PF = polyhedral_fan(max_cones, ray_generators)
+  X = normal_toric_variety(PF)
+  set_coordinate_names(X, ["x", "y", "z", "w"])
+  R = cox_ring(X)
+  x, y, z, w = gens(R)
+  f = blow_up_along_minimal_supercone_coordinates(X, [1, 0, 0, 0]; coordinate_name="u")
+  Y = domain(f)
+  S = cox_ring(Y)
+  x_, y_, z_, w_ = gens(S)
+
+  ## Subscheme is a curve
+  I = ideal(R, [x + z^2*y])
+  J_strict = strict_transform(f, I)
+  @test J_strict == ideal(S, [x_ + y_*z_^2])
+  @test ideal_sheaf(Y, J_strict) == strict_transform(f, ideal_sheaf(X, I))
 end


### PR DESCRIPTION
I improved the speed of `strict_transform` for an arbitrary toric blowup. More precisely, I improved `cox_ring_module_homomorphism`, which is used for `strict_transform`, `total_transform` and `strict_transform_with_index`. The main time-saving techniques:

* using `MPolyBuildCtx` to create the polynomial, instead of iteratively adding terms to a polynomial,
* using `Vector{Rational{Int64}}` instead of `Vector{QQFieldElem}` for the vector `ps`,
* using `Vector{Int64}` for the vector `ps` in the special case where the denominators are 1.

Some small other improvements in the core loop:

* using `first(exponents(g))` instead of `collect(exponents(g))[1]`,
* using `exps = [exps; exceptional_exp]` instead of `push!(exps, exceptional_exp)` reduces allocated memory by about 35% --- I am puzzled why there is a difference here.

The function `strict_transform` now seems to be faster than the specialized `_strict_transform` in FTheoryTools that could compute strict transform only under blowups along smooth cones. So I removed the specialized function.

Also, I added a test for computing the strict transform when blowing up along an existing ray.

# Benchmarks

I used the F-Theory computations from @HereAround . Namely, I first commented out lines 797--803 of `experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl`

```
  # For model 1511.03209 and resolution_index = 1, a particular resolution is available from an artifact
#   if has_attribute(m, :arxiv_id)
#     if resolution_index == 1 && arxiv_id(m) == "1511.03209"
#       model_data_path = artifact"FTM-1511-03209/1511-03209-resolved.mrdi"
#       return load(model_data_path)
#     end
#   end
```

and edited line 821 of the same file from `for k in 1:nr_blowups` to `for k in 1:5` to have a faster test.

Then ran

```
h = literature_model(arxiv_id = "1511.03209")
@btime h_5 = resolve(h, 1)
```

## Results

Previously:

```
julia> @btime h_5 = resolve(h, 1)
  190.106 s (44395903 allocations: 10.13 GiB)
Partially resolved global Tate model over a concrete base -- The F-theory geometry with most flux vacua based on arXiv paper 1511.03209 Eq. (2.11)
```

Now:

```
julia> @btime h_5 = resolve(h, 1)
  188.573 s (38064085 allocations: 6.42 GiB)
Partially resolved global Tate model over a concrete base -- The F-theory geometry with most flux vacua based on arXiv paper 1511.03209 Eq. (2.11)
```

## Improvements

* time is roughly the same (the exact time changes by a few seconds every run),
* there are now 14% fewer allocation instances compared to the specialized function in FTheoryTools,
* 37% less memory used for allocations than the specialized function in FTheoryTools.