### PR TITLE
Internal and documentation improvements

### DIFF
--- a/experimental/FTheoryTools/docs/src/g4.md
+++ b/experimental/FTheoryTools/docs/src/g4.md
@@ -32,7 +32,11 @@ is contained in said family. For this, we support the following:
 flux_instance(fgs::FamilyOfG4Fluxes, int_combination::ZZMatrix, rat_combination::QQMatrix; check::Bool = true)
 random_flux_instance(fgs::FamilyOfG4Fluxes; check::Bool = true)
 ```
-
+For convenience, we also support the following method to create a
+random $G_4$-flux with prescribed properties on a given F-theory model:
+```@docs
+random_flux(m::AbstractFTheoryModel; vert::Bool = false, not_breaking::Bool = false, check::Bool = true)
+```
 
 ## Properties
 

--- a/experimental/FTheoryTools/docs/src/literature.md
+++ b/experimental/FTheoryTools/docs/src/literature.md
@@ -63,6 +63,10 @@ resolution_zero_sections(m::AbstractFTheoryModel)
 weighted_resolutions(m::AbstractFTheoryModel)
 weighted_resolution_generating_sections(m::AbstractFTheoryModel)
 weighted_resolution_zero_sections(m::AbstractFTheoryModel)
+zero_section(m::AbstractFTheoryModel)
+zero_section_class(m::AbstractFTheoryModel)
+zero_section_index(m::AbstractFTheoryModel)
+torsion_sections(m::AbstractFTheoryModel)
 ```
 
 One can check if a model has a particular set of information. This is achieved with the
@@ -102,6 +106,7 @@ following methods:
 * `has_weighted_resolution_zero_sections(m::AbstractFTheoryModel)`,
 * `has_zero_section(m::AbstractFTheoryModel)`,
 * `has_zero_section_class(m::AbstractFTheoryModel)`,
+* `has_torsion_sections(m::AbstractFTheoryModel)`,
 * `has_gauge_algebra(m::AbstractFTheoryModel)`,
 * `has_global_gauge_quotients(m::AbstractFTheoryModel)`.
 

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
@@ -1092,6 +1092,34 @@ end
 
 
 @doc raw"""
+    torsion_sections(m::AbstractFTheoryModel)
+
+Return the torsion sections of the given model.
+If no torsion sections are known, an error is raised.
+
+```jldoctest
+julia> B3 = projective_space(NormalToricVariety, 3)
+Normal toric variety
+
+julia> Kbar = anticanonical_divisor_class(B3)
+Divisor class on a normal toric variety
+
+julia> foah15_B3 = literature_model(arxiv_id = "1408.4808", equation = "3.190", type = "hypersurface", base_space = B3, defining_classes = Dict("s7" => Kbar, "s9" => Kbar))
+Construction over concrete base may lead to singularity enhancement. Consider computing singular_loci. However, this may take time!
+
+Hypersurface model over a concrete base
+
+julia> length(torsion_sections(foah15_B3))
+1
+```
+"""
+function torsion_sections(m::AbstractFTheoryModel)
+  @req has_torsion_sections(m) "No torsion sections stored for this model"
+  return get_attribute(m, :torsion_sections)
+end
+
+
+@doc raw"""
     gauge_algebra(m::AbstractFTheoryModel)
 
 Return the gauge algebra of the given model.

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
@@ -160,7 +160,11 @@ function blow_up(m::AbstractFTheoryModel, I::AbsIdealSheaf; coordinate_name::Str
       new_tate_polynomial = cox_ring_module_homomorphism(bd, tate_polynomial(m))
       model = GlobalTateModel(explicit_model_sections(m), defining_section_parametrization(m), new_tate_polynomial, base_space(m), new_ambient_space)
     else
-      new_tate_ideal_sheaf = _strict_transform(bd, tate_ideal_sheaf(m))
+      if bd isa ToricBlowupMorphism
+        new_tate_ideal_sheaf = ideal_sheaf(domain(bd), strict_transform(bd, ideal_in_cox_ring(tate_ideal_sheaf(m))))
+      else
+        new_tate_ideal_sheaf = strict_transform(bd, tate_ideal_sheaf(m))
+      end
       model = GlobalTateModel(explicit_model_sections(m), defining_section_parametrization(m), new_tate_ideal_sheaf, base_space(m), new_ambient_space)
     end
   else
@@ -168,7 +172,11 @@ function blow_up(m::AbstractFTheoryModel, I::AbsIdealSheaf; coordinate_name::Str
       new_weierstrass_polynomial = cox_ring_module_homomorphism(bd, weierstrass_polynomial(m))
       model = WeierstrassModel(explicit_model_sections(m), defining_section_parametrization(m), new_weierstrass_polynomial, base_space(m), new_ambient_space)
     else
-      new_weierstrass_ideal_sheaf = _strict_transform(bd, weierstrass_ideal_sheaf(m))
+      if bd isa ToricBlowupMorphism
+        new_weierstrass_ideal_sheaf = ideal_sheaf(domain(bd), strict_transform(bd, ideal_in_cox_ring(weierstrass_ideal_sheaf(m))))
+      else
+        new_weierstrass_ideal_sheaf = strict_transform(bd, weierstrass_ideal_sheaf(m))
+      end
       model = WeierstrassModel(explicit_model_sections(m), defining_section_parametrization(m), new_weierstrass_ideal_sheaf, base_space(m), new_ambient_space)
     end
   end

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/properties.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/properties.jl
@@ -98,6 +98,7 @@ has_weighted_resolution_generating_sections(m::AbstractFTheoryModel) = has_attri
 has_weighted_resolution_zero_sections(m::AbstractFTheoryModel) = has_attribute(m, :weighted_resolution_zero_sections)
 has_zero_section(m::AbstractFTheoryModel) = has_attribute(m, :zero_section)
 has_zero_section_class(m::AbstractFTheoryModel) = has_attribute(m, :zero_section_class)
+has_torsion_sections(m::AbstractFTheoryModel) = has_attribute(m, :torsion_sections)
 has_gauge_algebra(m::AbstractFTheoryModel) = has_attribute(m, :gauge_algebra)
 has_global_gauge_quotients(m::AbstractFTheoryModel) = has_attribute(m, :global_gauge_quotients)
 

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -453,16 +453,3 @@ eval_poly(n::Number, R) = R(n)
 #
 # julia> eval_poly("-x1 - 3//5*x2^3 + 5 - 3", Qx)
 # -x1 - 3//5*x2^3 + 2
-
-
-
-##########################################
-### 10 strict_transform helpers
-##########################################
-
-_strict_transform(bd::AbsCoveredSchemeMorphism, II::AbsIdealSheaf) = strict_transform(bd, II)
-
-function _strict_transform(bd::ToricBlowupMorphism, II::ToricIdealSheafFromCoxRingIdeal)
-  transf = strict_transform(bd, ideal_in_cox_ring(II))
-  return ideal_sheaf(domain(bd), transf)
-end

--- a/experimental/FTheoryTools/src/exports.jl
+++ b/experimental/FTheoryTools/src/exports.jl
@@ -213,6 +213,7 @@ export tate_section_a4
 export tate_section_a6
 export topological_intersection_numbers_among_ci_curves
 export topological_intersection_numbers_among_nontrivial_ci_curves
+export torsion_sections
 export tune
 export verify_euler_characteristic_from_hodge_numbers
 export weierstrass_ideal_sheaf

--- a/experimental/FTheoryTools/src/exports.jl
+++ b/experimental/FTheoryTools/src/exports.jl
@@ -153,6 +153,7 @@ export passes_tadpole_cancellation_check
 export passes_verticality_checks
 export polytope_index
 export put_over_concrete_base
+export random_flux
 export random_flux_instance
 export resolution_generating_sections
 export resolution_zero_sections


### PR DESCRIPTION
* Remove auxiliary function `_strict_transform` (no longer needed thx to https://github.com/oscar-system/Oscar.jl/pull/4484).
* Allow users to access `torsion_sections` and add its documentation.
* I found that the documentation of more functions was not linked/visible on the website.
* Convenience method to compute a random flux with prescribed properties for an F-theory model.

I did not (yet) check in detail if all our docstrings are also quote in the docs folder/explained there. Note that those docstring that do not appear in the docs folder do not appear on the website. Maybe @emikelsons could verify if more is missing?

Modulo this (minor) caveat, the above should be ready for review.