### PR TITLE
Make ring flattening a tiny bit more type stable

### DIFF
--- a/src/Rings/MPolyMap/flattenings.jl
+++ b/src/Rings/MPolyMap/flattenings.jl
@@ -458,19 +458,19 @@ end
 function flatten(R::MPolyRing; cached::Bool=false)
   return get_attribute!(R, :flatten) do
     RingFlattening(R; cached)
-  end::RingFlattening
+  end::RingFlattening{typeof(R)}
 end
 
 function flatten(R::MPolyQuoRing; cached::Bool=false)
   return get_attribute!(R, :flatten) do
     RingFlattening(R; cached)
-  end::RingFlattening
+  end::RingFlattening{typeof(R)}
 end
 
 function (phi::RingFlattening)(I::MPolyIdeal)
   return get!(flat_counterparts(phi), I) do
     return ideal(codomain(phi), elem_type(codomain(phi))[phi(g) for g in gens(I)])
-  end::Any  # TODO: add better type annotation
+  end::ideal_type(codomain(phi))
 end
 
 function preimage(phi::RingFlattening, x::RingElem)


### PR DESCRIPTION
Follow-up to PR #4467: actually use `ideal_type`