### PR TITLE
Make the `@perm` macro more powerful by supporting more argument variants and increased consistency

### DIFF
--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -928,27 +928,6 @@ function _perm_format(::Val{:tuple}, n_or_G, res)
   end
 end
 
-#=
-macro perm(n,gens)
-
-    ores = Expr[]
-    for ex in gens.args
-        res = _perm_helper(ex)
-        push!(ores, esc(:(  [$(res...)]  )))
-    end
-
-    return quote
-       let n = $(esc(n)), g = n isa Int ? symmetric_group(n) : n
-           [ cperm(g, pi...) for pi in [$(ores...)] ]
-       end
-    end
-end
-
-macro perm(ex)
-  res = _perm_helper(ex)
-  return esc(:(Oscar.cperm($(res...))))
-end
-=#
 
 @doc raw"""
     permutation_group(n::IntegerUnion, perms::Vector{PermGroupElem})

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -801,17 +801,15 @@ raise an error if the permutations are not elements of `G`.
 If an integer `n` is provided, the permutations are created as elements of the
 symmetric group of degree `n`, i.e., `symmetric_group(n)`.
 
-Input a list of permutations in cycle notation, created as elements of the
-symmetric group of degree `n`, i.e., `symmetric_group(n)`, by invoking
-[`cperm`](@ref) suitably.
-
 In the remaining case, the parent group is inferred to be the symmetric group
 with a degree of the highest integer referenced in `expr`. This may result in
-evalutating the expressions in the cycle entries multiple times, so it is
+evaluating the expressions in the cycle entries multiple times, so it is
 recommended to provide the parent group explicitly in cases of complex expressions.
 
 The actual work is done by [`cperm`](@ref). Thus, for the time being,
 cycles which are *not* disjoint actually are supported.
+
+See also [`cperm`](@ref) and [`perm`](@ref) for other ways to create permutations.
 
 # Examples
 ```jldoctest

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -818,10 +818,14 @@ end
 #
 @doc raw"""
     @perm n gens
+    @perm G gens
     
 Input a list of permutations in cycle notation, created as elements of the
 symmetric group of degree `n`, i.e., `symmetric_group(n)`, by invoking
 [`cperm`](@ref) suitably.
+
+Instead of the degree `n`, one can also provide the parent permutation group `G`.
+This macro will raise an error if the permutations are not elements of `G`.
 
 # Examples
 ```jldoctest
@@ -860,7 +864,7 @@ macro perm(n,gens)
     end
 
     return quote
-       let g = symmetric_group($n)
+       let n = $(esc(n)), g = n isa Int ? symmetric_group(n) : n
            [ cperm(g, pi...) for pi in [$(ores...)] ]
        end
     end

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -815,7 +815,6 @@ cycles which are *not* disjoint actually are supported.
 
 # Examples
 ```jldoctest
-```jldoctest
 julia> x = @perm (1,2,3)(4,5)(factorial(3),7,8)
 (1,2,3)(4,5)(6,7,8)
 
@@ -872,7 +871,7 @@ end
 
 function _perm_parse(expr::Expr)
   # case: expr is a non-empty vector
-  if expr.head == :vect
+  if expr.head == :vect || expr.head == :vcat
     @req length(expr.args) > 0 "empty vector not allowed"
     return Val(:vector), [esc(:([$(_perm_helper(arg)...)])) for arg in expr.args]
   end

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -779,20 +779,45 @@ end
 
 ################################################################################
 #
-#   perm
+#   @perm
 #
+macro perm(ex)
+    res = _perm_helper(ex)
+    return esc(:(Oscar.cperm($(res...))))
+end
+
+
 @doc raw"""
-    @perm ex
-    
-Input a permutation in cycle notation. Supports arbitrary expressions for
-generating the integer entries of the cycles. The parent group is inferred 
-to be the symmetric group with a degree of the highest integer referenced 
-in the permutation.
+    @perm expr
+    @perm n expr
+    @perm G expr
+
+Input a permutation or a non-empty list of permutations in cycle notation.
+
+Supports arbitrary expressions for generating the integer entries of the cycles.
+
+`expr` may either be a single permutation, a non-empty list of permutations,
+or a non-empty tuple of permutations. **Note:** `@perm ()` denotes the identity
+permutation, NOT the empty tuple of permutations.
+
+If a group `G` is provided, the permutations are created as elements of `G`. This will
+raise an error if the permutations are not elements of `G`.
+
+If an integer `n` is provided, the permutations are created as elements of the
+symmetric group of degree `n`, i.e., `symmetric_group(n)`.
+
+Input a list of permutations in cycle notation, created as elements of the
+symmetric group of degree `n`, i.e., `symmetric_group(n)`, by invoking
+[`cperm`](@ref) suitably.
+
+In the remaining case, the parent group is inferred to be the symmetric group
+with a degree of the highest integer referenced in `expr`.
 
 The actual work is done by [`cperm`](@ref). Thus, for the time being,
 cycles which are *not* disjoint actually are supported.
 
 # Examples
+```jldoctest
 ```jldoctest
 julia> x = @perm (1,2,3)(4,5)(factorial(3),7,8)
 (1,2,3)(4,5)(6,7,8)
@@ -800,43 +825,18 @@ julia> x = @perm (1,2,3)(4,5)(factorial(3),7,8)
 julia> parent(x)
 Sym(8)
 
-julia> y = cperm([1,2,3],[4,5],[6,7,8])
-(1,2,3)(4,5)(6,7,8)
-
-julia> x == y
+julia> x == @perm 8 (1,2,3)(4,5)(factorial(3),7,8)
 true
 
-julia> z = perm(symmetric_group(8),[2,3,1,5,4,7,8,6])
-(1,2,3)(4,5)(6,7,8)
+julia> x == cperm([1,2,3],[4,5],[6,7,8])
+true
 
-julia> x == z
+julia> x == perm(symmetric_group(8),[2,3,1,5,4,7,8,6])
 true
 ```
-"""
-macro perm(ex)
-    res = _perm_helper(ex)
-    return esc(:(Oscar.cperm($(res...))))
-end
 
-
-################################################################################
-#
-#   perm(n,gens)
-#
-@doc raw"""
-    @perm n gens
-    @perm G gens
-    
-Input a list of permutations in cycle notation, created as elements of the
-symmetric group of degree `n`, i.e., `symmetric_group(n)`, by invoking
-[`cperm`](@ref) suitably.
-
-Instead of the degree `n`, one can also provide the parent permutation group `G`.
-This macro will raise an error if the permutations are not elements of `G`.
-
-# Examples
 ```jldoctest
-julia> gens = @perm 14 [
+julia> gens = @perm [
               (1,10)
               (2,11)
               (3,12)

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -740,7 +740,7 @@ end
 #
 # The following code implements a new way to input permutations in Julia. For example
 # it is possible to create a permutation as follow
-# pi = Oscar.Permutations.@perm (1,2,3)(4,5)(6,7,8)
+# pi = @perm (1,2,3)(4,5)(6,7,8)
 # > (1,2,3)(4,5)(6,7,8)
 # For this we use macros to modify the syntax tree of (1,2,3)(4,5)(6,7,8) such that
 # Julia can deal with the expression.
@@ -757,7 +757,7 @@ function _perm_helper(ex::Expr)
                 Please refer to the docstring of @perm for more information.""")
     end
 
-    res = []
+    res = Expr[]
     while ex isa Expr && ex.head == :call
         push!(res, Expr(:vect, ex.args[2:end]...))
         ex = ex.args[1]
@@ -767,7 +767,7 @@ function _perm_helper(ex::Expr)
         error("Input is not a permutation.")
     end
 
-    push!(res, Expr(:vect,ex.args...))
+    push!(res, Expr(:vect, ex.args...))
 
     # reverse `res` to match the original order; this ensures
     # the evaluation order is as the user expects
@@ -903,11 +903,7 @@ function _perm_max_entry(::Val{:single}, res)
   return :(mapreduce(maximum, max, [$(res...)]; init=1))
 end
 
-function _perm_max_entry(::Val{:vector}, res)
-  return :(mapreduce(x -> mapreduce(maximum, max, x; init=1), max, [$(res...)]; init=1))
-end
-
-function _perm_max_entry(::Val{:tuple}, res)
+function _perm_max_entry(::Union{Val{:vector}, Val{:tuple}}, res)
   return :(mapreduce(x -> mapreduce(maximum, max, x; init=1), max, [$(res...)]; init=1))
 end
 

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -750,6 +750,13 @@ function _perm_helper(ex::Expr)
     ex == :( () ) && return []
     ex isa Expr || error("Input is not a permutation expression")
 
+    if ex.head == :tuple && any(x -> x isa Expr && x.head == :macrocall && x.args[1] == Symbol("@perm"), ex.args)
+        error("""Encountered @perm macro inside of permutation expression.
+                Either set explicit parentheses for each @perm call (e.g. `@perm((1,2)), @perm((3,4))`),
+                or use the @perm variant that takes a list of permutations (e.g. `@perm n [(1,2), (3,4)]`).
+                Please refer to the docstring of @perm for more information.""")
+    end
+
     res = []
     while ex isa Expr && ex.head == :call
         push!(res, Expr(:vect, ex.args[2:end]...))

--- a/test/Groups/Permutations.jl
+++ b/test/Groups/Permutations.jl
@@ -1,3 +1,7 @@
+if VERSION < v"1.11.0-DEV.1562"
+  import Compat: allequal
+end
+
 @testset "Examples.Permutations" begin
   p = @perm (1,2)(3,4)(5,6)
   @test p == cperm([1,2],[3,4],[5,6])

--- a/test/Groups/Permutations.jl
+++ b/test/Groups/Permutations.jl
@@ -11,8 +11,6 @@
   @test p == cperm()
   
   @test_throws ArgumentError @perm (-1, 1)
-  @test_throws LoadError @eval @perm "bla"
-  @test_throws LoadError @eval @perm 1 + 1
   
   gens = @perm 14 [
          (1,10)
@@ -51,6 +49,16 @@
   p, = @perm A [(1,2,3)]
   @test parent(p) == A
   @test_throws ArgumentError @perm A [(1,2,3,4)]
+
+  @static if VERSION >= v"1.7"
+    # the following tests need the improved `@macroexpand` from Julia 1.7
+    @test_throws MethodError @macroexpand @perm "bla"
+    @test_throws ErrorException @macroexpand @perm 1 + 1
+    @test_throws ErrorException @macroexpand [@perm (1,2), @perm (3,4), @perm (5,6)]
+    @test_throws ErrorException @macroexpand [@perm (1,2)(3,4), @perm (5,6)(7,8)]
+    @test_throws ErrorException @macroexpand p1, p2, p3 = @perm (1,2), @perm (3,4), @perm (5,6)
+    @test_throws ErrorException @macroexpand p1, p2 = @perm (1,2)(3,4), @perm (5,6)(7,8)
+  end
 end
 
 @testset "permutation_group" begin

--- a/test/Groups/Permutations.jl
+++ b/test/Groups/Permutations.jl
@@ -42,6 +42,15 @@
   
   G = sub(G,gens)[1]
   @test order(G) == 645120
+
+  n = 4
+  p, = @perm n+1 [(1,2,3,4)]
+  @test degree(parent(p)) == n+1
+
+  A = alternating_group(4)
+  p, = @perm A [(1,2,3)]
+  @test parent(p) == A
+  @test_throws ArgumentError @perm A [(1,2,3,4)]
 end
 
 @testset "permutation_group" begin

--- a/test/Groups/Permutations.jl
+++ b/test/Groups/Permutations.jl
@@ -9,9 +9,7 @@
   @test p == cperm([1,5,2],[3,4])
   p = @perm ()
   @test p == cperm()
-  
-  @test_throws ArgumentError @perm (-1, 1)
-  
+    
   gens = @perm 14 [
          (1,10)
         (2,11)
@@ -35,20 +33,239 @@
   p[8] = cperm(G,[1,2,3,4,5,6,7],[8,9,10,11,12,13,14])
   p[9] = cperm(G,[1,2],[10,11])
   @test gens == p
-  
-  @test_throws ArgumentError @perm 10 [(1,11)]
-  
+    
   G = sub(G,gens)[1]
   @test order(G) == 645120
+end
 
-  n = 4
-  p, = @perm n+1 [(1,2,3,4)]
-  @test degree(parent(p)) == n+1
+@testset "@perm" begin
+  @testset "@perm <...> cycles" begin
+    @testset "@perm cycles" begin
+      p = @perm (1,2,6)(4,5)
+      @test p isa PermGroupElem
+      G = parent(p)
+      @test degree(G) == 6
+      @test is_natural_symmetric_group(G)
+      @test order(p) == 6
+  
+      p = @perm ()
+      @test p isa PermGroupElem
+      G = parent(p)
+      @test degree(G) == 1
+      @test is_natural_symmetric_group(G)
+      @test order(p) == 1
+  
+      @test_throws ArgumentError @perm (-1,1)
+    end
 
-  A = alternating_group(4)
-  p, = @perm A [(1,2,3)]
-  @test parent(p) == A
-  @test_throws ArgumentError @perm A [(1,2,3,4)]
+    @testset "@perm n cycles" begin
+      n = 7
+
+      p = @perm n (1,2,6)(4,5)
+      @test p isa PermGroupElem
+      G = parent(p)
+      @test degree(G) == n
+      @test is_natural_symmetric_group(G)
+      @test order(p) == 6
+
+      p = @perm n ()
+      @test p isa PermGroupElem
+      G = parent(p)
+      @test degree(G) == n
+      @test is_natural_symmetric_group(G)
+      @test order(p) == 1
+
+      @test_throws ArgumentError @perm 10 (1,11)
+      @test_throws ArgumentError @perm 5 (-1,1)
+    end
+
+    @testset "@perm G cycles" begin
+      S = symmetric_group(7)
+      p = @perm S (1,2,6)(4,5)
+      @test p isa PermGroupElem
+      @test parent(p) == S
+      @test order(p) == 6
+      p = @perm S ()
+      @test p isa PermGroupElem
+      @test parent(p) == S
+      @test order(p) == 1
+
+      @test_throws ArgumentError @perm S (-1,1)
+      @test_throws ArgumentError @perm S (2,5,8)
+
+      A = alternating_group(7)
+      p = @perm A (1,6)(4,5)
+      @test p isa PermGroupElem
+      @test parent(p) == A
+      @test order(p) == 2
+      p = @perm A ()
+      @test p isa PermGroupElem
+      @test parent(p) == A
+      @test order(p) == 1
+
+      # perms with negative sign
+      @test_throws ArgumentError @perm A (3,5) 
+      @test_throws ArgumentError @perm A (1,2,3,4) 
+      @test_throws ArgumentError @perm A (2,5)(4,1,3) 
+    end
+  end
+
+  @testset "@perm <...> vector" begin
+    let n = 7
+      S = symmetric_group(n)
+      @static if VERSION >= v"1.7"
+        # the following tests need the improved `@macroexpand` from Julia 1.7
+        @test_throws ArgumentError @macroexpand @perm []
+        @test_throws ArgumentError @macroexpand @perm n []
+        @test_throws ArgumentError @macroexpand @perm S []
+      end
+    end
+
+    @testset "@perm vector" begin
+      ps = @perm [(1,4)(2,3)(6,5)]
+      @test ps isa Vector{PermGroupElem}
+      G = parent(ps[1])
+      @test degree(G) == 6
+      @test is_natural_symmetric_group(G)
+      @test ps == [@perm(G, (1,4)(2,3)(6,5))]
+      
+      ps = @perm [(1,2,3)(4,5), (6,2,3,1), (), (2,)(1,4)]
+      @test ps isa Vector{PermGroupElem}
+      @test allequal(parent, ps)
+      G = parent(ps[1])
+      @test degree(G) == 6
+      @test is_natural_symmetric_group(G)
+      @test ps == [@perm(G, (1,2,3)(4,5)), @perm(G, (6,2,3,1)), @perm(G, ()), @perm(G, (2,)(1,4))]
+  
+      @test_throws ArgumentError @perm [(1,-2)]
+    end
+
+    @testset "@perm n vector" begin
+      n = 7
+      ps = @perm n [(1,4)(2,3)(6,5)]
+      @test ps isa Vector{PermGroupElem}
+      G = parent(ps[1])
+      @test degree(G) == n
+      @test is_natural_symmetric_group(G)
+      @test ps == [@perm(n, (1,4)(2,3)(6,5))]
+      
+      ps = @perm n [(1,2,3)(4,5), (6,2,3,1), (), (2,)(1,4)]
+      @test ps isa Vector{PermGroupElem}
+      @test allequal(parent, ps)
+      G = parent(ps[1])
+      @test degree(G) == n
+      @test is_natural_symmetric_group(G)
+      @test ps == [@perm(n, (1,2,3)(4,5)), @perm(n, (6,2,3,1)), @perm(n, ()), @perm(n, (2,)(1,4))]
+
+      @test_throws ArgumentError @perm 10 [(1,11)]
+      @test_throws ArgumentError @perm 5 [(1,-2)]
+    end
+
+    @testset "@perm G vector" begin
+      S = symmetric_group(7)
+      A = alternating_group(7)
+      
+      ps = @perm S [(1,4)(2,3)(6,5)]
+      @test ps isa Vector{PermGroupElem}
+      @test parent(ps[1]) == S
+      @test ps == [@perm(S, (1,4)(2,3)(6,5))]
+      
+      ps = @perm S [(1,2,3)(4,5), (6,2,3,1), (), (2,)(1,4)]
+      @test ps isa Vector{PermGroupElem}
+      @test all(p -> parent(p) == S, ps)
+      @test ps == [@perm(S, (1,2,3)(4,5)), @perm(S, (6,2,3,1)), @perm(S, ()), @perm(S, (2,)(1,4))]
+
+      @test_throws ArgumentError @perm S [(1,11)]
+      @test_throws ArgumentError @perm S [(1,-2)]
+
+      ps = @perm A [(1,4)(6,5)]
+      @test ps isa Vector{PermGroupElem}
+      @test parent(ps[1]) == A
+      @test ps == [@perm(A, (1,4)(6,5))]
+      
+      ps = @perm A [(1,2,3)(4,5,7), (6,2,3,1,5), (), (2,)(1,4,5)]
+      @test ps isa Vector{PermGroupElem}
+      @test all(p -> parent(p) == A, ps)
+      @test ps == [@perm(A, (1,2,3)(4,5,7)), @perm(A, (6,2,3,1,5)), @perm(A, ()), @perm(A, (2,)(1,4,5))]
+
+      @test_throws ArgumentError @perm A [(1,4)(2,3)(6,5)]
+    end
+  end
+
+  @testset "@perm <...> tuple" begin
+    # the empty tuple does not throw an error as it denotes the identity permutation
+    @testset "@perm tuple" begin
+      ps = @perm ((1,4)(2,3)(6,5),)
+      @test ps isa NTuple{1, PermGroupElem}
+      G = parent(ps[1])
+      @test degree(G) == 6
+      @test is_natural_symmetric_group(G)
+      @test ps == (@perm(G, (1,4)(2,3)(6,5)),)
+      
+      ps = @perm ((1,2,3)(4,5), (6,2,3,1), (), (2,)(1,4))
+      @test ps isa NTuple{4, PermGroupElem}
+      @test allequal(parent, ps)
+      G = parent(ps[1])
+      @test degree(G) == 6
+      @test is_natural_symmetric_group(G)
+      @test ps == (@perm(G, (1,2,3)(4,5)), @perm(G, (6,2,3,1)), @perm(G, ()), @perm(G, (2,)(1,4)))
+
+      @test_throws ArgumentError @perm ((1,-2),)
+    end
+
+    @testset "@perm n tuple" begin
+      n = 7
+
+      ps = @perm n ((1,4)(2,3)(6,5),)
+      @test ps isa NTuple{1, PermGroupElem}
+      G = parent(ps[1])
+      @test degree(G) == n
+      @test is_natural_symmetric_group(G)
+      @test ps == (@perm(n, (1,4)(2,3)(6,5)),)
+      
+      ps = @perm n ((1,2,3)(4,5), (6,2,3,1), (), (2,)(1,4))
+      @test ps isa NTuple{4, PermGroupElem}
+      @test allequal(parent, ps)
+      G = parent(ps[1])
+      @test degree(G) == n
+      @test is_natural_symmetric_group(G)
+      @test ps == (@perm(n, (1,2,3)(4,5)), @perm(n, (6,2,3,1)), @perm(n, ()), @perm(n, (2,)(1,4)))
+
+      @test_throws ArgumentError @perm 10 ((1,11),)
+      @test_throws ArgumentError @perm 5 ((1,-2),)
+    end
+
+    @testset "@perm G tuple" begin
+      S = symmetric_group(7)
+      A = alternating_group(7)
+
+      ps = @perm S ((1,4)(2,3)(6,5),)
+      @test ps isa NTuple{1, PermGroupElem}
+      @test parent(ps[1]) == S
+      @test ps == (@perm(S, (1,4)(2,3)(6,5)),)
+      
+      ps = @perm S ((1,2,3)(4,5), (6,2,3,1), (), (2,)(1,4))
+      @test ps isa NTuple{4, PermGroupElem}
+      @test all(p -> parent(p) == S, ps)
+      @test ps == (@perm(S, (1,2,3)(4,5)), @perm(S, (6,2,3,1)), @perm(S, ()), @perm(S, (2,)(1,4)))
+
+      @test_throws ArgumentError @perm S ((1,11),)
+      @test_throws ArgumentError @perm S ((1,-2),)
+
+      ps = @perm A ((1,4)(6,5),)
+      @test ps isa NTuple{1, PermGroupElem}
+      @test parent(ps[1]) == A
+      @test ps == (@perm(A, (1,4)(6,5)),)
+      
+      ps = @perm A ((1,2,3)(4,5,7), (6,2,3,5,1), (), (2,)(1,4,5))
+      @test ps isa NTuple{4, PermGroupElem}
+      @test all(p -> parent(p) == A, ps)
+      @test ps == (@perm(A, (1,2,3)(4,5,7)), @perm(A, (6,2,3,5,1)), @perm(A, ()), @perm(A, (2,)(1,4,5)))
+
+      @test_throws ArgumentError @perm A ((1,4)(2,3)(6,5),)
+    end
+  end
+
 
   @static if VERSION >= v"1.7"
     # the following tests need the improved `@macroexpand` from Julia 1.7

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
@@ -12,6 +13,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8.2"
+Compat = "4.13.0"
 DeepDiffs = "1.2.0"
 Distributed = "1.6"
 Documenter = "0.27, 1.0"


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/3010.

- `@perm n+1 [....]` works now; the docstring always stated it would, but some macro hygiene thing messed up the use of local variables inside the degree expression.
- `@perm G [(1,2,3,4)]` creates a list of perms with fixed parent `G`.
- `[@perm (1,2), @perm(3,4)]` and similar constructions (where julia infers weird scopes of things) now raise an explicit error.
- Complete feature parity for different versions. There are now 9 combinations based on the parent group (detect parent / given group / given degree of symmetric group) and the expression (single permutation, non-empty vector, non-empty tuple). The only ambiguity would be with the empty tuple, so we explicitly restrict vectors and tuple to be non-empty.

The release notes could include a compressed version of this list.