### PR TITLE
cartan_type_with_ordering: Fix ref in doc

### DIFF
--- a/src/LieTheory/CartanMatrix.jl
+++ b/src/LieTheory/CartanMatrix.jl
@@ -283,7 +283,7 @@ of the roots in the Dynkin diagram.
 
 If `check=true` the function will verify that `gcm` is indeed a Cartan matrix.
 
-See also: [`root_system_type_with_ordering(::RootSystem)`].
+See also: [`root_system_type_with_ordering(::RootSystem)`](@ref).
 
 !!! note
     The order of returned components is, in general, not unique and might change between versions.

--- a/src/LieTheory/RootSystem.jl
+++ b/src/LieTheory/RootSystem.jl
@@ -268,7 +268,7 @@ This can be checked with [`has_root_system_type(::RootSystem)`](@ref).
 
 If the type is not known, it is determined and stored in `R`.
 
-See also: [`root_system_type(::RootSystem)`](@ref), [`cartan_type_with_ordering(::ZZMatrix)`].
+See also: [`root_system_type(::RootSystem)`](@ref), [`cartan_type_with_ordering(::ZZMatrix)`](@ref).
 
 !!! warning
     This function will error if the type is not known yet and the Weyl group is infinite.


### PR DESCRIPTION
I forgot to add `(@ref)` in #4477.