### PR TITLE
no need anymore to install the GAP package ferret at runtime

### DIFF
--- a/src/NumberTheory/GaloisGrp/GaloisGrp.jl
+++ b/src/NumberTheory/GaloisGrp/GaloisGrp.jl
@@ -22,8 +22,6 @@ export valuation_of_roots
 import Hecke: orbit, fixed_field, extension_field
 
 function __init__()
-  GAP.Packages.load("ferret"; install=true)
-
   Hecke.add_verbosity_scope(:GaloisGroup)
   Hecke.add_assertion_scope(:GaloisGroup)
   Hecke.add_verbosity_scope(:GaloisInvariant)
@@ -1671,16 +1669,9 @@ function starting_group(GC::GaloisCtx, K::T; useSubfields::Bool = true) where T 
     #partition is the largest possible group...
     #code from Max...
 
-    #TODO: wrap this properly
-    if hasproperty(GAP.Globals, :ConStabilize)
-      tmp = [GAP.Globals.ConStabilize(GAP.Obj(sort(o), recursive=true), GAP.Globals.OnSetsSets) for o in O]
-      H = GAP.Globals.Solve(GAP.Obj(vcat(GAP.Globals.ConInGroup(GapObj(G)), tmp)))
-      G = Oscar._as_subgroup(G, H)[1]
-    else
-      #TODO: fallback if ferret wasn't loaded for some reason; this should be removed
-      # once we have GAP_pkg_ferret
-      G = intersect([stabilizer(G, sort(o), on_sets_sets)[1] for o=O]...)[1]
-    end
+    tmp = [GAP.Globals.ConStabilize(GAP.Obj(sort(o), recursive=true), GAP.Globals.OnSetsSets) for o in O]
+    H = GAP.Globals.Solve(GAP.Obj(vcat(GAP.Globals.ConInGroup(GapObj(G)), tmp)))
+    G = Oscar._as_subgroup(G, H)[1]
   end
 
   si = G(si)

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -87,12 +87,10 @@ function __init__()
   # `Julia.Oscar` if Oscar is loaded indirectly as a package dependency)
   GAP.Globals.BindGlobal(GapObj("Oscar"), Oscar)
 
-  withenv("TERMINFO_DIRS" => joinpath(GAP.GAP_jll.Readline_jll.Ncurses_jll.find_artifact_dir(), "share", "terminfo")) do
-    GAP.Packages.load("browse"; install=true) # needed for all_character_table_names doctest
-  end
   # We need some GAP packages (currently with unspecified versions).
   for pkg in [
      "atlasrep",
+     "browse",   # needed for all_character_table_names doctest
      "ctbllib",  # character tables
      "crisp",    # faster normal subgroups, socles, p-socles for finite solvable groups
      "ferret",   # backtrack in permutation groups


### PR DESCRIPTION
A precompiled binary of the GAP package `ferret` is available in GAP.jl 0.13.0, and the package gets loaded on Oscar startup.

The fallback code for the case that `ferret` is not available has now been removed.

(The same holds for the `browse` package, it need not be installed at runtime, it can be loaded at Oscar startup like other GAP packages.)