### PR TITLE
booktests: small fix for nightly

### DIFF
--- a/test/book/test.jl
+++ b/test/book/test.jl
@@ -124,7 +124,7 @@ isdefined(Main, :FakeTerminals) || include(joinpath(pkgdir(REPL),"test","FakeTer
       mockdule = Module(sym)
       # make it accessible from Main
       @eval Main global $sym::Module
-      setproperty!(Main, sym, mockdule)
+      invokelatest(setproperty!, Main, sym, mockdule)
       Core.eval(mockdule, :(eval(x) = Core.eval($(mockdule), x)))
       Core.eval(mockdule, :(include(x) = Base.include($(mockdule), abspath(x))))
 


### PR DESCRIPTION
fixes an error in the nightly booktests:
```
Global Main.__274 does not exist and cannot be assigned.
Note: Julia 1.9 and 1.10 inadvertently omitted this error check (#56933).
Hint: Declare it using `global __274` inside `Main` before attempting assignment.
```
The error is slightly wrong, it was already defined with `@eval` and `global` but without invokelatest `setproperty!` doesn't work anymore after some recent changes on nightly.

Note: This wont fix the nightly booktests, but change the error. They are still failing due to https://github.com/JuliaLang/julia/issues/56950.