### PR TITLE
set `NiceMonomorphism` info on the GAP side

### DIFF
--- a/src/Groups/matrices/iso_nf_fq.jl
+++ b/src/Groups/matrices/iso_nf_fq.jl
@@ -102,12 +102,14 @@ function _isomorphic_group_over_finite_field(G::MatrixGroup{T}; min_char::Int = 
   Gap_G = GapObj(G)
   Gap_Gp = GapObj(Gp)
   if !GAP.Globals.HasNiceMonomorphism(Gap_G)
+    risoG = _ring_iso(G)
+    risoGp = _ring_iso(Gp)
 
     # map from Gap_G to Gap_Gp
-    fun = x -> GapObj(img(G(preimage_matrix(_ring_iso(G), x))))
+    fun = x -> GapObj(img(G(preimage_matrix(risoG, x); check=false)))
 
     # map from Gap_Gp to Gap_G
-    invfun = x -> GapObj(preimg(Gp(preimage_matrix(_ring_iso(Gp), x))))
+    invfun = x -> GapObj(preimg(Gp(preimage_matrix(risoGp, x); check=false)))
 
     Gap_mp = GAP.Globals.GroupHomomorphismByFunction(Gap_G, Gap_Gp, fun, invfun)
     GAP.Globals.SetNiceMonomorphism(Gap_G, Gap_mp)

--- a/src/Groups/matrices/iso_nf_fq.jl
+++ b/src/Groups/matrices/iso_nf_fq.jl
@@ -94,7 +94,27 @@ function _isomorphic_group_over_finite_field(G::MatrixGroup{T}; min_char::Int = 
                                   GapObj(gen))
   end
 
-  return Gp, MapFromFunc(G, Gp, img, preimg)
+  has_order(Gp) && set_order(G, order(Gp))
+
+  mp = MapFromFunc(G, Gp, img, preimg)
+
+  # try to improve `GapObj(G)`
+  Gap_G = GapObj(G)
+  Gap_Gp = GapObj(Gp)
+  if !GAP.Globals.HasNiceMonomorphism(Gap_G)
+
+    # map from Gap_G to Gap_Gp
+    fun = x -> GapObj(img(G(preimage_matrix(_ring_iso(G), x))))
+
+    # map from Gap_Gp to Gap_G
+    invfun = x -> GapObj(preimg(Gp(preimage_matrix(_ring_iso(Gp), x))))
+
+    Gap_mp = GAP.Globals.GroupHomomorphismByFunction(Gap_G, Gap_Gp, fun, invfun)
+    GAP.Globals.SetNiceMonomorphism(Gap_G, Gap_mp)
+    GAP.Globals.SetIsHandledByNiceMonomorphism(Gap_G, true)
+  end
+
+  return Gp, mp
 end
 
 function isomorphic_group_over_finite_field(G::MatrixGroup{T}; min_char::Int = 3) where T <: Union{ZZRingElem, QQFieldElem, AbsSimpleNumFieldElem}

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -123,9 +123,9 @@ end
      G0 = matrix_group(mats)
      G, g = Oscar.isomorphic_group_over_finite_field(G0)
 
-     @test !has_order(G0)
-     order(G0)
+     @test has_order(G)
      @test has_order(G0)
+     @test order(G0) == order(G)
 
      for i in 1:10
        x, y = rand(G), rand(G)
@@ -137,6 +137,13 @@ end
      f = GAP.Globals.GroupHomomorphismByImages(GapObj(G), H)
      @test GAP.Globals.IsBijective(f)
      @test order(G) == GAP.Globals.Order(H)
+
+     Gap_G0 = GapObj(G0)
+     @test GAP.Globals.HasNiceMonomorphism(GapObj(G0))
+     iso = GAP.Globals.NiceMonomorphism(Gap_G0)
+     x = GAP.Globals.GeneratorsOfGroup(Gap_G0)[1]
+     img = GAP.Globals.ImagesRepresentative(iso, x)
+     @test x == GAP.Globals.PreImagesRepresentative(iso, img)
    end
 
    G = matrix_group(QQ, 2, dense_matrix_type(QQ)[])

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -141,7 +141,7 @@ end
      Gap_G0 = GapObj(G0)
      @test GAP.Globals.HasNiceMonomorphism(GapObj(G0))
      iso = GAP.Globals.NiceMonomorphism(Gap_G0)
-     x = GAP.Globals.GeneratorsOfGroup(Gap_G0)[1]
+     x = GAP.Globals.Product(GAP.Globals.GeneratorsOfGroup(Gap_G0))
      img = GAP.Globals.ImagesRepresentative(iso, x)
      @test x == GAP.Globals.PreImagesRepresentative(iso, img)
    end


### PR DESCRIPTION
Once a `isomorphic_group_over_finite_field` has been computed, the mapping between the two Oscar groups can now be used for the underlying GAP groups.
For that, we store it as a `NiceMonomorphism` in the characteristic zero GAP group.

I have changed the test behaviour a little:
`isomorphic_group_over_finite_field` computes already the group order for the isomorphic group over the finite field.
Therefore it does not make sense to test that the group in characteristic zero does not know its `order` value before an explicit `order` call. Instead we set now the order already in `isomorphic_group_over_finite_field`.
(The situation was not really bad before, the `order` call triggered `isomorphic_group_over_finite_field` again, but the value was already cached.)

This addresses an item in the discussion of #1779.