### PR TITLE
Add lattice of one-parameter subgroups

### DIFF
--- a/docs/src/AlgebraicGeometry/ToricVarieties/BlowupMorphisms.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/BlowupMorphisms.md
@@ -66,7 +66,7 @@ exceptional_prime_divisor(bl::ToricBlowupMorphism)
 ```
 Based on `underlying_morphism`, also the following attributes of toric
 morphisms are supported for toric blowups:
-- `grid_morphism(bl::ToricBlowupMorphism)`,
+- `lattice_homomorphism(bl::ToricBlowupMorphism)`,
 - `morphism_on_torusinvariant_weil_divisor_group(bl::ToricBlowupMorphism)`,
 - `morphism_on_torusinvariant_cartier_divisor_group(bl::ToricBlowupMorphism)`,
 - `morphism_on_class_group(bl::ToricBlowupMorphism)`,

--- a/docs/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms.md
@@ -26,7 +26,7 @@ morphisms are exactly the toric morphisms.
 
 ```@docs
 toric_morphism(domain::NormalToricVarietyType, mapping_matrix::ZZMatrix, codomain::NormalToricVarietyType; check=true)
-toric_morphism(domain::NormalToricVarietyType, grid_morphism::FinGenAbGroupHom, codomain::NormalToricVarietyType; check=true)
+toric_morphism(domain::NormalToricVarietyType, lattice_homomorphism::FinGenAbGroupHom, codomain::NormalToricVarietyType; check=true)
 ```
 
 ### Special constructors
@@ -44,7 +44,7 @@ toric_identity_morphism(variety::NormalToricVarietyType)
 domain(tm::ToricMorphism)
 image(tm::ToricMorphism)
 codomain(tm::ToricMorphism)
-grid_morphism(tm::ToricMorphism)
+lattice_homomorphism(tm::ToricMorphism)
 morphism_on_torusinvariant_weil_divisor_group(tm::ToricMorphism)
 morphism_on_torusinvariant_cartier_divisor_group(tm::ToricMorphism)
 morphism_on_class_group(tm::ToricMorphism)

--- a/experimental/Schemes/src/ToricBlowups/attributes.jl
+++ b/experimental/Schemes/src/ToricBlowups/attributes.jl
@@ -155,7 +155,7 @@ end
 #########################################################################
 # Forwarding attributes of toric morphisms based on `underlying_morphism`
 #########################################################################
-grid_morphism(bl::ToricBlowupMorphism) = grid_morphism(underlying_morphism(bl))
+lattice_homomorphism(bl::ToricBlowupMorphism) = lattice_homomorphism(underlying_morphism(bl))
 morphism_on_torusinvariant_weil_divisor_group(bl::ToricBlowupMorphism) = morphism_on_torusinvariant_weil_divisor_group(underlying_morphism(bl))
 morphism_on_torusinvariant_cartier_divisor_group(bl::ToricBlowupMorphism) = morphism_on_torusinvariant_cartier_divisor_group(underlying_morphism(bl))
 morphism_on_class_group(bl::ToricBlowupMorphism) = morphism_on_class_group(underlying_morphism(bl))
@@ -164,7 +164,7 @@ morphism_on_picard_group(bl::ToricBlowupMorphism) = morphism_on_picard_group(und
 
 
 #=
-For the future, if traits seem better to forward methods as the ones immediately above (grid_morphism, morphism_on_torusinvariant_weil_divisor_group, etc.):
+For the future, if traits seem better to forward methods as the ones immediately above (lattice_homomorphism, morphism_on_torusinvariant_weil_divisor_group, etc.):
 
 ########################################################################
 # Enabling the HasToricSubObjectTrait for ToricBlowupMorphism        #
@@ -176,11 +176,11 @@ toric_sub_object(bl::ToricBlowupMorphism) = underlying_morphism(bl)
 ########################################################################
 # Enabling the functionality in general                                #
 ########################################################################
-function grid_morphism(phi::Any)
-  return _grid_morphism(HasToricSubObjectTrait(phi), phi)
+function lattice_homomorphism(phi::Any)
+  return _lattice_homomorphism(HasToricSubObjectTrait(phi), phi)
 end
 
-function _grid_morphism(::HasToricSubObject, phi)
-  return grid_morphism(toric_sub_object(phi))
+function _lattice_homomorphism(::HasToricSubObject, phi)
+  return lattice_homomorphism(toric_sub_object(phi))
 end
 =#

--- a/experimental/Schemes/src/ToricBlowups/types.jl
+++ b/experimental/Schemes/src/ToricBlowups/types.jl
@@ -114,18 +114,18 @@ end
 function Base.:+(tm1::ToricBlowupMorphism, tm2::ToricBlowupMorphism)
   @req domain(tm1) === domain(tm2) "The morphisms must have identical domains"
   @req codomain(tm1) === codomain(tm2) "The morphisms must have identical codomains"
-  return toric_morphism(domain(tm1), grid_morphism(tm1) + grid_morphism(tm2), codomain(tm1))
+  return toric_morphism(domain(tm1), lattice_homomorphism(tm1) + lattice_homomorphism(tm2), codomain(tm1))
 end
 
 function Base.:-(tm1::ToricBlowupMorphism, tm2::ToricBlowupMorphism)
   @req domain(tm1) === domain(tm2) "The morphisms must have identical domains"
   @req codomain(tm1) === codomain(tm2) "The morphisms must have identical codomains"
-  return toric_morphism(domain(tm1), grid_morphism(tm1) - grid_morphism(tm2), codomain(tm1))
+  return toric_morphism(domain(tm1), lattice_homomorphism(tm1) - lattice_homomorphism(tm2), codomain(tm1))
 end
 
 function Base.:*(c::T, tm::ToricBlowupMorphism) where T <: IntegerUnion
-new_grid_morphism = hom(domain(grid_morphism(tm)), codomain(grid_morphism(tm)), c * matrix(grid_morphism(tm)))
-return toric_morphism(domain(tm), new_grid_morphism, codomain(tm))
+new_lattice_homomorphism = hom(domain(lattice_homomorphism(tm)), codomain(lattice_homomorphism(tm)), c * matrix(lattice_homomorphism(tm)))
+return toric_morphism(domain(tm), new_lattice_homomorphism, codomain(tm))
 end
 
 Base.:+(tm1::ToricBlowupMorphism, tm2::ToricMorphism) = underlying_morphism(tm1) + tm2
@@ -141,7 +141,7 @@ Base.:-(tm1::ToricMorphism, tm2::ToricBlowupMorphism) = tm1 - underlying_morphis
 
 function Base.:*(tm1::ToricBlowupMorphism, tm2::ToricBlowupMorphism)
   @req codomain(tm1) === domain(tm2) "The codomain of the first morphism must be identically the same as the domain of the second morphism"
-  return toric_morphism(domain(tm1), grid_morphism(tm1) * grid_morphism(tm2), codomain(tm2))
+  return toric_morphism(domain(tm1), lattice_homomorphism(tm1) * lattice_homomorphism(tm2), codomain(tm2))
 end
 
 Base.:*(tm1::ToricMorphism, tm2::ToricBlowupMorphism) = tm1 * underlying_morphism(tm2)
@@ -154,14 +154,14 @@ Base.:*(tm1::ToricBlowupMorphism, tm2::ToricMorphism) = underlying_morphism(tm1)
 ####################################################
 
 function Base.:(==)(tm1::ToricBlowupMorphism, tm2::ToricBlowupMorphism)
-  return domain(tm1) == domain(tm2) && codomain(tm1) == codomain(tm2) && grid_morphism(tm1) == grid_morphism(tm2)
+  return domain(tm1) == domain(tm2) && codomain(tm1) == codomain(tm2) && lattice_homomorphism(tm1) == lattice_homomorphism(tm2)
 end
 
 function Base.hash(tm::ToricBlowupMorphism, h::UInt)
   b = 0x1a66f927cae2d409 % UInt
   h = hash(domain(tm), h)
   h = hash(codomain(tm), h)
-  h = hash(grid_morphism(tm), h)
+  h = hash(lattice_homomorphism(tm), h)
   return xor(h, b)
 end
 

--- a/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties/attributes.jl
@@ -652,6 +652,22 @@ Z^2
 
 
 @doc raw"""
+    lattice_of_one_parameter_subgroups(v::NormalToricVarietyType)
+
+Return the lattice of one parameter subgroups of a normal toric variety `v`.
+
+# Examples
+```jldoctest
+julia> p2 = projective_space(NormalToricVariety, 2);
+
+julia> lattice_of_one_parameter_subgroups(p2)
+Z^2
+```
+"""
+@attr FinGenAbGroup lattice_of_one_parameter_subgroups(v::NormalToricVarietyType) = free_abelian_group(ambient_dim(v))
+
+
+@doc raw"""
     torusinvariant_weil_divisor_group(v::NormalToricVarietyType)
 
 Return the torusinvariant divisor group of a normal toric variety `v`.

--- a/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/attributes.jl
@@ -33,22 +33,22 @@ codomain(tm::ToricMorphism) = tm.codomain
 
 
 @doc raw"""
-    grid_morphism(tm::ToricMorphism)
+    lattice_homomorphism(tm::ToricMorphism)
 
-Return the underlying grid morphism of the toric morphism `tm`.
+Return the underlying homomorphism of lattices of one parameter subgroups of the toric morphism `tm` as in Definition 3.3.1 of [CLS11](@cite).
 
 # Examples
 ```jldoctest
 julia> F4 = hirzebruch_surface(NormalToricVariety, 4)
 Normal toric variety
 
-julia> grid_morphism(toric_identity_morphism(F4))
+julia> lattice_homomorphism(toric_identity_morphism(F4))
 Map
   from Z^2
   to Z^2
 ```
 """
-grid_morphism(tm::ToricMorphism) = tm.grid_morphism
+lattice_homomorphism(tm::ToricMorphism) = tm.lattice_homomorphism
 
 
 @doc raw"""
@@ -72,7 +72,7 @@ Map
     d = domain(tm)
     cod = codomain(tm)
     cod_rays = matrix(ZZ, rays(cod))
-    images = matrix(ZZ, rays(d)) * matrix(grid_morphism(tm))
+    images = matrix(ZZ, rays(d)) * matrix(lattice_homomorphism(tm))
     mapping_matrix = matrix(ZZ, zeros(ZZ, torsion_free_rank(torusinvariant_weil_divisor_group(cod)), 0))
     for i in 1:nrows(images)
       v = [images[i,k] for k in 1:ncols(images)]
@@ -219,7 +219,7 @@ Covering
   # Find the image cones
   codomain_cones = maximal_cones(Y)
   domain_cones = maximal_cones(X)
-  A = matrix(grid_morphism(f))
+  A = matrix(lattice_homomorphism(f))
   image_cones = [positive_hull(matrix(ZZ, rays(c)) * A) for c in domain_cones]
 
   # construct the corresponding morphism of rings

--- a/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms/constructors.jl
@@ -13,10 +13,10 @@
                                  ToricMorphism
                                 }
   domain::NormalToricVarietyType
-  grid_morphism::FinGenAbGroupHom
+  lattice_homomorphism::FinGenAbGroupHom
   codomain::NormalToricVarietyType
-  function ToricMorphism(domain, grid_morphism, codomain)
-    result = new{typeof(domain), typeof(codomain), Nothing}(domain, grid_morphism, codomain)
+  function ToricMorphism(domain, lattice_homomorphism, codomain)
+    result = new{typeof(domain), typeof(codomain), Nothing}(domain, lattice_homomorphism, codomain)
   end
 end
 
@@ -56,7 +56,7 @@ Toric morphism
 """
 function toric_morphism(domain::NormalToricVarietyType, mapping_matrix::ZZMatrix, codomain::NormalToricVarietyType; check=true)
   @req (nrows(mapping_matrix) > 0 && ncols(mapping_matrix) > 0) "The mapping matrix must not be empty"
-  return toric_morphism(domain, hom(character_lattice(domain), character_lattice(codomain), mapping_matrix), codomain; check=check)
+  return toric_morphism(domain, hom(lattice_of_one_parameter_subgroups(domain), lattice_of_one_parameter_subgroups(codomain), mapping_matrix), codomain; check=check)
 end
 toric_morphism(domain::NormalToricVarietyType, mapping_matrix::Matrix{T}, codomain::NormalToricVarietyType; check=true) where {T <: IntegerUnion} =
   toric_morphism(domain, matrix(ZZ, mapping_matrix), codomain; check=check)
@@ -64,7 +64,7 @@ toric_morphism(domain::NormalToricVarietyType, mapping_matrix::Vector{Vector{T}}
   toric_morphism(domain, matrix(ZZ, mapping_matrix), codomain; check=check)
 function toric_morphism(domain::NormalToricVarietyType, mapping_matrix::ZZMatrix) 
   @req (nrows(mapping_matrix) > 0 && ncols(mapping_matrix) > 0) "The mapping matrix must not be empty"
-  return toric_morphism(domain, hom(character_lattice(domain), free_abelian_group(ncols(mapping_matrix)), mapping_matrix))
+  return toric_morphism(domain, hom(lattice_of_one_parameter_subgroups(domain), free_abelian_group(ncols(mapping_matrix)), mapping_matrix))
 end
 toric_morphism(domain::NormalToricVarietyType, mapping_matrix::Matrix{T}) where {T <: IntegerUnion} =
   toric_morphism(domain, matrix(ZZ, mapping_matrix))
@@ -73,10 +73,11 @@ toric_morphism(domain::NormalToricVarietyType, mapping_matrix::Vector{Vector{T}}
 
 
 @doc raw"""
-    toric_morphism(domain::NormalToricVarietyType, grid_morphism::FinGenAbGroupHom, codomain::NormalToricVarietyType; check=true)
+    toric_morphism(domain::NormalToricVarietyType, lattice_homomorphism::FinGenAbGroupHom, codomain::NormalToricVarietyType; check=true)
 
-Construct the toric morphism from the `domain` to the `codomain` with map given
-by the `grid_morphism`.
+Construct the toric morphism from `domain` to `codomain` induced by the
+homomomorphism of lattices of one-parameter subgroups
+`lattice_homomorphism` as in Definition 3.3.1 of [CLS11](@cite).
 
 If the codomain is left out, it will be determined whether the image of the
 domain fan is itself a polyhedral fan. In that case the codomain is assumed to
@@ -95,36 +96,36 @@ Normal toric variety
 julia> mapping_matrix = matrix(ZZ, [[0, 1]])
 [0   1]
 
-julia> grid_morphism = hom(character_lattice(domain), character_lattice(codomain), mapping_matrix)
+julia> lattice_homomorphism = hom(lattice_of_one_parameter_subgroups(domain), lattice_of_one_parameter_subgroups(codomain), mapping_matrix)
 Map
   from Z
   to Z^2
 
-julia> toric_morphism(domain, grid_morphism, codomain)
+julia> toric_morphism(domain, lattice_homomorphism, codomain)
 Toric morphism
 ```
 """
-function toric_morphism(domain::NormalToricVarietyType, grid_morphism::FinGenAbGroupHom, codomain::NormalToricVarietyType; check=true)
+function toric_morphism(domain::NormalToricVarietyType, lattice_homomorphism::FinGenAbGroupHom, codomain::NormalToricVarietyType; check=true)
     # avoid empty mapping
-    @req (nrows(matrix(grid_morphism)) > 0 && ncols(matrix(grid_morphism)) > 0) "The mapping matrix must not be empty"
+    @req (nrows(matrix(lattice_homomorphism)) > 0 && ncols(matrix(lattice_homomorphism)) > 0) "The mapping matrix must not be empty"
 
     # check for a well-defined map
-    @req nrows(matrix(grid_morphism)) == torsion_free_rank(character_lattice(domain)) "The number of rows of the mapping matrix must match the rank of the character lattice of the domain toric variety"
+    @req nrows(matrix(lattice_homomorphism)) == torsion_free_rank(lattice_of_one_parameter_subgroups(domain)) "The number of rows of the mapping matrix must match the rank of the lattice of one-parameter subgroups of the domain toric variety"
 
     # compute the morphism
-    @req ncols(matrix(grid_morphism)) == torsion_free_rank(character_lattice(codomain)) "The number of columns of the mapping matrix must match the rank of the character lattice of the codomain toric variety"
+    @req ncols(matrix(lattice_homomorphism)) == torsion_free_rank(lattice_of_one_parameter_subgroups(codomain)) "The number of columns of the mapping matrix must match the rank of the lattice of one-parameter subgroups of the codomain toric variety"
     if check
       codomain_cones = maximal_cones(codomain)
-      image_cones = [positive_hull(matrix(ZZ, rays(c)) * matrix(grid_morphism)) for c in maximal_cones(domain)]
+      image_cones = [positive_hull(matrix(ZZ, rays(c)) * matrix(lattice_homomorphism)) for c in maximal_cones(domain)]
       for c in image_cones
         @req any(cc -> issubset(c, cc), codomain_cones) "Toric morphism not well-defined"
       end
     end
-    return ToricMorphism(domain, grid_morphism, codomain)
+    return ToricMorphism(domain, lattice_homomorphism, codomain)
 end
-function toric_morphism(domain::NormalToricVarietyType, grid_morphism::FinGenAbGroupHom; check=true)
-  image = transform(domain, matrix(grid_morphism); check=check)
-  return ToricMorphism(domain, grid_morphism, image)
+function toric_morphism(domain::NormalToricVarietyType, lattice_homomorphism::FinGenAbGroupHom; check=true)
+  image = transform(domain, matrix(lattice_homomorphism); check=check)
+  return ToricMorphism(domain, lattice_homomorphism, image)
 end
 
 
@@ -144,10 +145,13 @@ Toric morphism
 ```
 """
 function toric_identity_morphism(variety::NormalToricVarietyType)
-    r = torsion_free_rank(character_lattice(variety))
+    r = torsion_free_rank(lattice_of_one_parameter_subgroups(variety))
     identity_matrix = matrix(ZZ, [[if i==j 1 else 0 end for j in 1:r] for i in 1:r])
-    grid_morphism = hom(character_lattice(variety), character_lattice(variety), identity_matrix)
-    return ToricMorphism(variety, grid_morphism, variety)
+    
+    # Despite the notation, the homomorphism is between lattices of
+    # one-parameter subgroups
+    lattice_homomorphism = hom(lattice_of_one_parameter_subgroups(variety), lattice_of_one_parameter_subgroups(variety), identity_matrix)
+    return ToricMorphism(variety, lattice_homomorphism, variety)
 end
 
 
@@ -158,20 +162,20 @@ end
 function Base.:+(tm1::ToricMorphism, tm2::ToricMorphism)
     @req domain(tm1) === domain(tm2) "The toric morphisms must have identical domains"
     @req codomain(tm1) === codomain(tm2) "The toric morphisms must have identical codomains"
-    return toric_morphism(domain(tm1), grid_morphism(tm1) + grid_morphism(tm2), codomain(tm1))
+    return toric_morphism(domain(tm1), lattice_homomorphism(tm1) + lattice_homomorphism(tm2), codomain(tm1))
 end
 
 
 function Base.:-(tm1::ToricMorphism, tm2::ToricMorphism)
     @req domain(tm1) === domain(tm2) "The toric morphisms must have identical domains"
     @req codomain(tm1) === codomain(tm2) "The toric morphisms must have identical codomains"
-    return toric_morphism(domain(tm1), grid_morphism(tm1) - grid_morphism(tm2), codomain(tm1))
+    return toric_morphism(domain(tm1), lattice_homomorphism(tm1) - lattice_homomorphism(tm2), codomain(tm1))
 end
 
 
 function Base.:*(c::T, tm::ToricMorphism) where T <: IntegerUnion
-  new_grid_morphism = hom(domain(grid_morphism(tm)), codomain(grid_morphism(tm)), c * matrix(grid_morphism(tm)))
-  return toric_morphism(domain(tm), new_grid_morphism, codomain(tm))
+  new_lattice_homomorphism = hom(domain(lattice_homomorphism(tm)), codomain(lattice_homomorphism(tm)), c * matrix(lattice_homomorphism(tm)))
+  return toric_morphism(domain(tm), new_lattice_homomorphism, codomain(tm))
 end
 
 
@@ -181,7 +185,7 @@ end
 
 function Base.:*(tm1::ToricMorphism, tm2::ToricMorphism)
     @req codomain(tm1) === domain(tm2) "The codomain of the first toric morphism must be identically the same as the domain of the second morphism"
-    return toric_morphism(domain(tm1), grid_morphism(tm1) * grid_morphism(tm2), codomain(tm2))
+    return toric_morphism(domain(tm1), lattice_homomorphism(tm1) * lattice_homomorphism(tm2), codomain(tm2))
 end
 
 
@@ -190,14 +194,14 @@ end
 ####################################################
 
 function Base.:(==)(tm1::ToricMorphism, tm2::ToricMorphism)
-    return domain(tm1) === domain(tm2) && codomain(tm1) === codomain(tm2) && grid_morphism(tm1) == grid_morphism(tm2)
+    return domain(tm1) === domain(tm2) && codomain(tm1) === codomain(tm2) && lattice_homomorphism(tm1) == lattice_homomorphism(tm2)
 end
 
 function Base.hash(tm::ToricMorphism, h::UInt)
     b = 0x1a66f927cae2d409 % UInt
     h = hash(domain(tm), h)
     h = hash(codomain(tm), h)
-    h = hash(grid_morphism(tm), h)
+    h = hash(lattice_homomorphism(tm), h)
     return xor(h, b)
 end
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -152,3 +152,4 @@ Base.@deprecate_binding in_linear_system is_in_linear_system
 # deprecated for 1.3
 @deprecate acting_domain(C::GroupCoset) acting_group(C)
 @deprecate acting_domain(Omega::GSet) acting_group(Omega)
+@deprecate grid_morphism lattice_homomorphism

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1022,6 +1022,8 @@ export koszul_homology
 export koszul_matrix
 export labeled_matrix_formatted
 export laplacian_matrix
+export lattice_homomorphism
+export lattice_of_one_parameter_subgroups
 export lattice_points
 export lattice_volume
 export leading_coefficient

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -671,7 +671,6 @@ export graph
 export graph_from_adjacency_matrix
 export graph_from_edges
 export grassmann_pluecker_ideal
-export grid_morphism
 export groebner_basis
 export groebner_basis_f4
 export groebner_basis_hilbert_driven

--- a/test/AlgebraicGeometry/ToricVarieties/toric_blowups.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/toric_blowups.jl
@@ -45,8 +45,8 @@
   bl = blow_up(P2, [1, 1])
   
   @testset "Basic tests for simple toric blowup" begin
-    @test torsion_free_rank(domain(grid_morphism(bl))) == 2
-    @test torsion_free_rank(codomain(grid_morphism(bl))) == 2
+    @test torsion_free_rank(domain(lattice_homomorphism(bl))) == 2
+    @test torsion_free_rank(codomain(lattice_homomorphism(bl))) == 2
     @test rank(matrix(morphism_on_torusinvariant_weil_divisor_group(bl))) == 3
     @test matrix(morphism_on_torusinvariant_cartier_divisor_group(bl)) == matrix(morphism_on_torusinvariant_weil_divisor_group(bl))
   end
@@ -54,9 +54,9 @@
   bl2 = blow_up(P2, [-1, 0])
 
   @testset "Arithmetics, comparison and composition" begin
-    @test grid_morphism(bl + bl) == grid_morphism(2 * bl)
-    @test grid_morphism(bl - bl) == grid_morphism(0 * bl)
-    @test grid_morphism(bl * toric_identity_morphism(codomain(bl))) == grid_morphism(bl)
+    @test lattice_homomorphism(bl + bl) == lattice_homomorphism(2 * bl)
+    @test lattice_homomorphism(bl - bl) == lattice_homomorphism(0 * bl)
+    @test lattice_homomorphism(bl * toric_identity_morphism(codomain(bl))) == lattice_homomorphism(bl)
     @test bl !== bl2
   end
 

--- a/test/AlgebraicGeometry/ToricVarieties/toric_morphisms.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/toric_morphisms.jl
@@ -23,10 +23,10 @@
   
   @testset "Basic attributes of toric morphisms" begin
     @test codomain(tm1) === domain(tm2)
-    @test matrix(grid_morphism(tm2)) == matrix(ZZ, [[1, 0], [0, 1]])
+    @test matrix(lattice_homomorphism(tm2)) == matrix(ZZ, [[1, 0], [0, 1]])
     @test morphism_on_torusinvariant_weil_divisor_group(tm2).map == identity_matrix(ZZ, 4)
     @test morphism_on_torusinvariant_cartier_divisor_group(tm2).map == identity_matrix(ZZ, 4)
-    @test grid_morphism(morphism_from_cox_variety(source)).map == matrix(ZZ, [[1], [-1]])
+    @test lattice_homomorphism(morphism_from_cox_variety(source)).map == matrix(ZZ, [[1], [-1]])
     @test is_affine(cox_variety(source)) == false
     @test matrix(morphism_on_class_group(tm3)) == matrix(ZZ, [[1, 0], [0, 1]])
     @test matrix(morphism_on_picard_group(tm3)) == matrix(ZZ, [[1, 0], [0, 1]])

--- a/test/AlgebraicGeometry/ToricVarieties/toric_schemes.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/toric_schemes.jl
@@ -89,8 +89,8 @@
   II = IdealSheaf(IP2, I)
 
   @testset "Blowups that leave the toric setting" begin
-    @test is_surjective(grid_morphism(Oscar.underlying_morphism(bl)))
-    @test is_injective(grid_morphism(Oscar.underlying_morphism(bl)))
+    @test is_surjective(lattice_homomorphism(Oscar.underlying_morphism(bl)))
+    @test is_injective(lattice_homomorphism(Oscar.underlying_morphism(bl)))
     @test length(Oscar.maximal_associated_points(pullback(bl,II))) == 3
     @test length(Oscar.maximal_associated_points(strict_transform(bl, II))) == 2
   end


### PR DESCRIPTION
In toric geometry, the character lattice and the lattice of one-parameter subgroups are dual to each other. Confusingly, sometimes the character lattice was used where the lattice of one-parameter subgroups should have been used. This pull request fixes this.