### PR TITLE
`.bibtoolsrc`: Canonicalize `month` fields, delete `abstract` fields

### DIFF
--- a/.bibtoolrsc
+++ b/.bibtoolrsc
@@ -82,3 +82,19 @@ check.error.rule { doi "\://" "\@ \$: doi field should not be a URL" }
 
 # Check that the url field is not a DOI
 check.error.rule { url "doi\.org/" "\@ \$: url field should not contain a doi. Use the doi field instead" }
+
+# Normalize the month field to e.g. `jan` (without braces), see https://github.com/ge-ne/bibtool/issues/66#issuecomment-577283871
+rewrite.case.sensitive = Off
+rewrite.rule { month "{\([^#]*\)}" "\1"}
+rewrite.rule { month "^ *\(1\|Jan.*\|jan.+\) *$" "jan" }
+rewrite.rule { month "^ *\(2\|Feb.*\|feb.+\) *$" "feb" }
+rewrite.rule { month "^ *\(3\|Mar.*\|mar.+\) *$" "mar" }
+rewrite.rule { month "^ *\(4\|Apr.*\|apr.+\) *$" "apr" }
+rewrite.rule { month "^ *\(5\|May.*\|may.+\) *$" "may" }
+rewrite.rule { month "^ *\(6\|Jun.*\|jun.+\) *$" "jun" }
+rewrite.rule { month "^ *\(7\|Jul.*\|jul.+\) *$" "jul" }
+rewrite.rule { month "^ *\(8\|Aug.*\|aug.+\) *$" "aug" }
+rewrite.rule { month "^ *\(9\|Sep.*\|sep.+\) *$" "sep" }
+rewrite.rule { month "^ *\(10\|Oct.*\|oct.+\) *$" "oct" }
+rewrite.rule { month "^ *\(11\|Nov.*\|nov.+\) *$" "nov" }
+rewrite.rule { month "^ *\(12\|Dec.*\|dec.+\) *$" "dec" }

--- a/.bibtoolrsc
+++ b/.bibtoolrsc
@@ -63,14 +63,14 @@ key.format =
 }
 
 # Enforce "{...}" around fields
-rewrite.rule {"^\"\([^#]*\)\"$" "{\1}"}
-rewrite.rule {"^ *\([0-9]*\) *$" "{\1}"}
+rewrite.rule { "^\"\([^#]*\)\"$" "{\1}" }
+rewrite.rule { "^ *\([0-9]*\) *$" "{\1}" }
 
 # Remove empty fields
-rewrite.rule {"^{ *}$"}
+rewrite.rule { "^{ *}$" }
 
 # Unify page range separator
-rewrite.rule {pages "\([0-9]+\) *\(-\|---\|–\) *\([0-9]+\)" "\1--\3"}
+rewrite.rule { pages "\([0-9]+\) *\(-\|---\|–\) *\([0-9]+\)" "\1--\3" }
 
 # Check that 1800<=year<=2029
 check.rule { year "^[\"{]1[89][0-9][0-9][\"}]$" }

--- a/.bibtoolrsc
+++ b/.bibtoolrsc
@@ -38,6 +38,7 @@ preserve.key.case = on
 sort.cased = off
 print.use.tab = off
 
+delete.field = { abstract }
 delete.field = { hal_id }
 delete.field = { hal_version }
 delete.field = { isbn }

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -121,7 +121,7 @@
   publisher     = {American Physical Society},
   pages         = {L061903},
   year          = {2021},
-  month         = {Sep},
+  month         = sep,
   doi           = {10.1103/PhysRevD.104.L061903},
   issue         = {6},
   numpages      = {8}
@@ -190,7 +190,7 @@
   title         = {SmallGrp, The GAP Small Groups Library, Version 1.5.3},
   note          = {GAP package},
   year          = {2023},
-  month         = {5},
+  month         = may,
   url           = {https://gap-packages.github.io/smallgrp/}
 }
 
@@ -289,7 +289,7 @@
   publisher     = {AIP Publishing},
   pages         = {103525},
   year          = {2010},
-  month         = {Oct},
+  month         = oct,
   doi           = {10.1063/1.3501132}
 }
 
@@ -311,7 +311,7 @@
   publisher     = {AIP Publishing},
   pages         = {012302},
   year          = {2012},
-  month         = {Jan},
+  month         = jan,
   doi           = {10.1063/1.3677646}
 }
 
@@ -410,7 +410,7 @@
   author        = {Bies, Martin},
   title         = {Cohomologies of coherent sheaves and massless spectra in {F}-theory},
   year          = {2018},
-  month         = {2},
+  month         = feb,
   doi           = {10.11588/heidok.00024045},
   school        = {Heidelberg U.}
 }
@@ -1064,7 +1064,7 @@
   publisher     = {Mathematical Sciences Publishers},
   pages         = {235--303},
   year          = {2017},
-  month         = {Oct},
+  month         = oct,
   doi           = {10.2140/gt.2018.22.235}
 }
 
@@ -1118,7 +1118,7 @@
   publisher     = {Springer Science and Business Media {LLC}},
   pages         = {515--536},
   year          = {2004},
-  month         = {mar},
+  month         = mar,
   doi           = {10.1007/s00222-003-0327-2}
 }
 
@@ -1426,7 +1426,7 @@
   title         = {PrimGrp, GAP Primitive Permutation Groups Library, Version 3.4.4},
   note          = {GAP package},
   year          = {2023},
-  month         = {2},
+  month         = feb,
   url           = {https://gap-packages.github.io/primgrp/}
 }
 
@@ -1493,7 +1493,7 @@
   title         = {TransGrp, Transitive Groups Library, Version 3.6.5},
   note          = {GAP package},
   year          = {2023},
-  month         = {12},
+  month         = dec,
   url           = {https://www.math.colostate.edu/~hulpke/transgrp}
 }
 
@@ -1667,7 +1667,7 @@
   publisher     = {AIP Publishing},
   pages         = {033506},
   year          = {2011},
-  month         = {Mar},
+  month         = mar,
   doi           = {10.1063/1.3562523}
 }
 
@@ -1948,7 +1948,7 @@
   title         = {TomLib, The GAP Library of Tables of Marks, Version 1.2.11},
   note          = {GAP package},
   year          = {2024},
-  month         = {1},
+  month         = jan,
   url           = {https://gap-packages.github.io/tomlib/}
 }
 
@@ -2135,7 +2135,7 @@
   title         = {SOTGrps, Constructing and identifying groups of small order type, Version 1.2},
   note          = {GAP package},
   year          = {2023},
-  month         = {6},
+  month         = jun,
   url           = {https://gap-packages.github.io/sotgrps/}
 }
 
@@ -2145,7 +2145,7 @@
   note          = {Refereed by Prof. Dr. Eva Maria Feichtner and Dr. Emanuele Delucchi},
   address       = {Faculty of Mathematics},
   year          = {2014},
-  month         = {9},
+  month         = sep,
   school        = {University of Bremen}
 }
 
@@ -2212,7 +2212,7 @@
   publisher     = {AIP Publishing},
   pages         = {103520},
   year          = {2010},
-  month         = {Oct},
+  month         = oct,
   doi           = {10.1063/1.3501135}
 }
 
@@ -2551,7 +2551,7 @@
   title         = {SglPPow, Database of groups of prime-power order for some prime-powers, Version 2.3},
   note          = {GAP package},
   year          = {2022},
-  month         = {11},
+  month         = nov,
   url           = {https://gap-packages.github.io/sglppow/}
 }
 


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/4320.

According to https://github.com/ge-ne/bibtool/issues/66#issuecomment-577283871, months should be input with three lowercase letters without braces as this is a macro that is converted to a nice string by the bibtex parser. I verified that `Bibliography.jl` (the parser used by `DocumenterCitations.jl`) indeed does that. But all of that doesn't *really* matter here, as our bibliography on https://docs.oscar-system.org/dev/references/ doesn't show any months at all.