### PR TITLE
Run CI both on 1.12 and 1.13 nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,6 +59,9 @@ jobs:
           - julia-version: '1.10'
             group: 'book'
             os: [Linux, RPTU, normal-memory] # runs on self-hosted runner
+          - julia-version: 'pre'
+            group: 'book'
+            os: [Linux, RPTU, normal-memory] # runs on self-hosted runner
           - julia-version: 'nightly'
             group: 'book'
             os: [Linux, RPTU, normal-memory] # runs on self-hosted runner

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,7 @@ jobs:
           - '1.6'
           - '1.10'
           - '1.11'
+          - '1.12-nightly'
           - 'nightly'
         group: [ 'short', 'long' ]
         os: [Linux]
@@ -59,6 +60,9 @@ jobs:
             group: 'book'
             os: [Linux, RPTU, normal-memory] # runs on self-hosted runner
           - julia-version: 'nightly'
+            group: 'book'
+            os: [Linux, RPTU, normal-memory] # runs on self-hosted runner
+          - julia-version: '1.12-nightly'
             group: 'book'
             os: [Linux, RPTU, normal-memory] # runs on self-hosted runner
           # nightly on macos is disabled for now since the macos jobs take too long
@@ -150,6 +154,7 @@ jobs:
         julia-version:
           - '1.10'
           - '1.11'
+          - '1.12-nightly'
           - 'nightly'
         os:
           - [Linux, RPTU, normal-memory]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,9 +62,6 @@ jobs:
           - julia-version: 'nightly'
             group: 'book'
             os: [Linux, RPTU, normal-memory] # runs on self-hosted runner
-          - julia-version: '1.12-nightly'
-            group: 'book'
-            os: [Linux, RPTU, normal-memory] # runs on self-hosted runner
           # nightly on macos is disabled for now since the macos jobs take too long
           # with just 5 runners
           #- julia-version: 'nightly'


### PR DESCRIPTION
Julia master is version 1.13.0-DEV as of https://github.com/JuliaLang/julia/pull/56970 (this morning). 
Failures there are expected at least until all our binaries are rebuilt against a new libjulia.

We should however continue to test against 1.12 pre-releases.