### PR TITLE
Support for Linear Sets

### DIFF
--- a/experimental/LinearSets/README.md
+++ b/experimental/LinearSets/README.md
@@ -1,0 +1,8 @@
+# LinearSets.jl
+
+This module provides support in OSCAR for working with linear sets.
+These are collections of points in a projective space over a field of order $q$,
+which are induced by a subspace over some subfield of order $q'$.
+
+
+## References

--- a/experimental/LinearSets/docs/doc.main
+++ b/experimental/LinearSets/docs/doc.main
@@ -1,0 +1,5 @@
+[
+   "Linear Sets" => [
+      "introduction.md",
+   ],
+]

--- a/experimental/LinearSets/docs/src/introduction.md
+++ b/experimental/LinearSets/docs/src/introduction.md
@@ -1,0 +1,9 @@
+```@meta
+CurrentModule = Oscar
+DocTestSetup = Oscar.doctestsetup()
+```
+
+
+```@docs
+
+```

--- a/experimental/LinearSets/src/LinearSets.jl
+++ b/experimental/LinearSets/src/LinearSets.jl
@@ -5,7 +5,7 @@ using Oscar
 
 # Need collection of normalized vectors
 # needs tweaking if order(base_ring(V)) is not prime....
-function _points(V::AbstractAlgebra.FreeModule{T}) where T <: FinFieldElem
+function _points(V::AbstractAlgebra.Generic.FreeModule{<:FinFieldElem})
     p = order(base_ring(V))
     @req is_prime(p) "Currently only works for V over a prime field"
 
@@ -13,18 +13,19 @@ function _points(V::AbstractAlgebra.FreeModule{T}) where T <: FinFieldElem
     n = length(B)
 
     # TODO : should convert these to linear combinations of B instead of raw conversion.
-    [V(digits(p^s + j, base = p, pad = n)) for s in 1:n for j in 0:(p^(s-1)-1)]
+    # But this creates overhead, maybe only do this if B is nonstandard...
+    [V(reverse(digits(p^s + j, base = Int(p), pad = n))) for s in 0:(n-1) for j in 0:(p^s - 1)]
 end
 
 # want to represent field E as a vector space over a subfield.
-function _vector_space(E::FiniteField, phi::Map)
+function _vector_space(E::FinField, phi::Map)
     k = domain(phi)
     @req is_prime(order(k)) "Currently only works for V over a prime field"
     n = degree(E)
     V = vector_space(k,n)
-    phi = map_from_func(a -> V(absolute_coordinates(a)), E, k)
+    rho = map_from_func(a -> V(absolute_coordinates(a)), E, V)
 
-    return V, phi
+    return V, rho
 end
 
 # need to store:
@@ -33,12 +34,12 @@ end
 #     3. set S = Points((Fq)^n) as elements of E
 # TODO decide: Second argument- subfield k, or an embedding k -> E ?
 # NOTE at the moment, we only support F = prime field...
-function linear_set_field_attributes!(K::FinField, phi::Map)
+function linear_set_field_attributes!(E::FinField, phi::Map)
     k = domain(phi)
+    V, rho = _vector_space(E, phi)
     n = divexact(absolute_degree(K), absolute_degree(k))
-    phi = absolute_coordinates
-    S =
-end function
+    S = _points(V)
+end
 
 
 # nu = first(x for x in E if (x != 0 && !is_square(-x) && is_square(-x-1)))

--- a/experimental/LinearSets/src/LinearSets.jl
+++ b/experimental/LinearSets/src/LinearSets.jl
@@ -1,4 +1,4 @@
-module StandardFiniteFields
+module LinearSets
 
 using Oscar
 

--- a/experimental/LinearSets/src/LinearSets.jl
+++ b/experimental/LinearSets/src/LinearSets.jl
@@ -1,0 +1,48 @@
+module StandardFiniteFields
+
+using Oscar
+
+
+# Need collection of normalized vectors
+# needs tweaking if order(base_ring(V)) is not prime....
+function _points(V::AbstractAlgebra.FreeModule{T}) where T <: FinFieldElem
+    p = order(base_ring(V))
+    @req is_prime(p) "Currently only works for V over a prime field"
+
+    B = basis(V)
+    n = length(B)
+
+    # TODO : should convert these to linear combinations of B instead of raw conversion.
+    [V(digits(p^s + j, base = p, pad = n)) for s in 1:n for j in 0:(p^(s-1)-1)]
+end
+
+# want to represent field E as a vector space over a subfield.
+function _vector_space(E::FiniteField, phi::Map)
+    k = domain(phi)
+    @req is_prime(order(k)) "Currently only works for V over a prime field"
+    n = degree(E)
+    V = vector_space(k,n)
+    phi = map_from_func(a -> V(absolute_coordinates(a)), E, k)
+
+    return V, phi
+end
+
+# need to store:
+#     1. base field F_q so E = F_q^n
+#     2. map phi from E -> (Fq)^n
+#     3. set S = Points((Fq)^n) as elements of E
+# TODO decide: Second argument- subfield k, or an embedding k -> E ?
+# NOTE at the moment, we only support F = prime field...
+function linear_set_field_attributes!(K::FinField, phi::Map)
+    k = domain(phi)
+    n = divexact(absolute_degree(K), absolute_degree(k))
+    phi = absolute_coordinates
+    S =
+end function
+
+
+# nu = first(x for x in E if (x != 0 && !is_square(-x) && is_square(-x-1)))
+#
+# M = matrix(E, 3, 3 [0 1 0])
+
+end

--- a/experimental/LinearSets/test/runtests.jl
+++ b/experimental/LinearSets/test/runtests.jl
@@ -1,0 +1,1 @@
+GAP.Packages.load("LinearSets")

--- a/experimental/LinearSets/test/runtests.jl
+++ b/experimental/LinearSets/test/runtests.jl
@@ -1,1 +1,0 @@
-GAP.Packages.load("LinearSets")


### PR DESCRIPTION
We are aiming here to add support of linear sets. This is still in early stages.

A rank k linear set in a finite projective space PG(n,q) is a subset of the points that arises from a k-dimensional subpace over GF(q') < GF(q). To look at this, we need to consider the underlying vector space (F_q)^(n+1)  as (F_q')^(e*(n+1)), where q = (q')^e.  Thus adding support for these sets will also add some nice new tools for working with vector spaces over finite fields.