### PR TITLE
Fix experimental not showing up in search

### DIFF
--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -217,9 +217,9 @@ function doit(
   # extract valid json from search_index.js
   run(pipeline(`sed -n '2p;3q' $(joinpath(docspath, "build", "search_index.js"))`, stdout=(joinpath(docspath, "build", "search_index.json")))) # imperfect file, but JSON parses it
   
-  # extract paths from doc.main
+  # extract paths from doc
   filelist=String[]
-  docmain = include(joinpath(docspath, "doc.main"))
+  docmain = doc
   while !isempty(docmain)
     n = pop!(docmain)
     if n isa Pair


### PR DESCRIPTION
Previously, I built a list by reading `doc.main` on my own, which didn't include experimental docs.

 I didn't realise the work is already done in the code above mine, including experimental, and stored in the variable `doc`.

Should fix #4542 .

[skip ci] , ci doesn't build docs anyway if not already on the official repository.