### PR TITLE
Skip docs preview for dependabot PRs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,12 +4,18 @@ include(normpath(joinpath(Oscar.oscardir, "docs", "make_work.jl")))
 
 BuildDoc.doit(Oscar; warnonly=false, local_build=false, doctest=false)
 
+should_push_preview = true
+if get(ENV, "GITHUB_ACTOR", "") == "dependabot[bot]"
+  # skip preview for dependabot PRs as they fail due to lack of permissions
+  should_push_preview = false
+end
+
 deploydocs(
    repo   = "github.com/oscar-system/Oscar.jl.git",
 #  deps = Deps.pip("pymdown-extensions", "pygments", "mkdocs", "python-markdown-math", "mkdocs-material", "mkdocs-cinder"),
    deps = nothing,
    target = "build",
-   push_preview = true,
+   push_preview = should_push_preview,
 #  make = () -> run(`mkdocs build`),
    make = nothing,
    forcepush = true


### PR DESCRIPTION
> Unlike workflows triggered by other actors, this means [workflows triggered by dependabot] receive a read-only GITHUB_TOKEN and do not have access to any secrets that are normally available. This will cause any workflows that attempt to write to the repository to fail when they are triggered by Dependabot.
(https://docs.github.com/en/code-security/dependabot/troubleshooting-dependabot/troubleshooting-dependabot-on-github-actions#troubleshooting-failures-when-dependabot-triggers-existing-workflows)

This means that pushing the documentation preview will fail for dependabot PRs (see e.g. https://github.com/oscar-system/Oscar.jl/actions/runs/13183920804/job/36809531604?pr=4550#step:6:622). Thus, we should skip the preview in these cases.