### PR TITLE
Avoid "base =" in doctests

### DIFF
--- a/experimental/FTheoryTools/src/TateModels/constructors.jl
+++ b/experimental/FTheoryTools/src/TateModels/constructors.jl
@@ -25,20 +25,20 @@ The only difference is that the Tate sections ``a_i`` can be specified with non-
 
 # Examples
 ```jldoctest
-julia> base = sample_toric_variety()
+julia> chosen_base = sample_toric_variety()
 Normal toric variety
 
-julia> a1 = generic_section(anticanonical_bundle(base));
+julia> a1 = generic_section(anticanonical_bundle(chosen_base));
 
-julia> a2 = generic_section(anticanonical_bundle(base)^2);
+julia> a2 = generic_section(anticanonical_bundle(chosen_base)^2);
 
-julia> a3 = generic_section(anticanonical_bundle(base)^3);
+julia> a3 = generic_section(anticanonical_bundle(chosen_base)^3);
 
-julia> a4 = generic_section(anticanonical_bundle(base)^4);
+julia> a4 = generic_section(anticanonical_bundle(chosen_base)^4);
 
-julia> a6 = generic_section(anticanonical_bundle(base)^6);
+julia> a6 = generic_section(anticanonical_bundle(chosen_base)^6);
 
-julia> t = global_tate_model(base, [a1, a2, a3, a4, a6]; completeness_check = false)
+julia> t = global_tate_model(chosen_base, [a1, a2, a3, a4, a6]; completeness_check = false)
 Global Tate model over a concrete base
 ```
 """

--- a/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
@@ -29,14 +29,14 @@ The only difference is that the Weierstrass sections ``f`` and ``g`` can be spec
 
 # Examples
 ```jldoctest
-julia> base = sample_toric_variety()
+julia> chosen_base = sample_toric_variety()
 Normal toric variety
 
-julia> f = generic_section(anticanonical_bundle(base)^4);
+julia> f = generic_section(anticanonical_bundle(chosen_base)^4);
 
-julia> g = generic_section(anticanonical_bundle(base)^6);
+julia> g = generic_section(anticanonical_bundle(chosen_base)^6);
 
-julia> w = weierstrass_model(base, f, g; completeness_check = false)
+julia> w = weierstrass_model(chosen_base, f, g; completeness_check = false)
 Weierstrass model over a concrete base
 ```
 """

--- a/experimental/FTheoryTools/test/FTM-1511-03209.jl
+++ b/experimental/FTheoryTools/test/FTM-1511-03209.jl
@@ -11,7 +11,7 @@
   @test n_rays(ambient_space(t)) == 104
   @test n_rays(ambient_space(t_resolved)) == 310
   @test typeof(get_attribute(t_resolved, :inter_dict)) == Dict{NTuple{4, Int64}, ZZRingElem}
-  @test length(chosen_g4_flux_basis(h2)) == 629
+  @test length(chosen_g4_flux_basis(t_resolved)) == 629
   @test passes_elementary_quantization_checks(g1) == true
   @test passes_verticality_checks(g2) == true
   @test breaks_non_abelian_gauge_group(g3) == false


### PR DESCRIPTION
* Avoid "base =" in doctests (code snippet will not execute in repl)
* Fix the extra-long tests (undefined variable `h2`)

cc @apturner @emikelsons 