### PR TITLE
Remove toric blowup arithmetic documentation

### DIFF
--- a/docs/src/AlgebraicGeometry/ToricVarieties/BlowupMorphisms.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/BlowupMorphisms.md
@@ -86,12 +86,3 @@ that takes homogeneous ideals to homogeneous ideals:
 ```@docs
 cox_ring_module_homomorphism
 ```
-
-
-## Arithmetics
-
-Toric blowups can be added, subtracted and multiplied by rational
-numbers. The results of such operations will not be toric morphisms,
-i.e. they no longer correspond to the blowup of a certain closed
-subscheme. Arithmetics among toric blowups and general toric morphisms
-is also supported, as well as equality for toric blowups.


### PR DESCRIPTION
It is incorrect as written and does not belong to the toric blowup section.