### PR TITLE
SetPartitions: properly import join

### DIFF
--- a/experimental/SetPartitions/src/SetPartitions.jl
+++ b/experimental/SetPartitions/src/SetPartitions.jl
@@ -9,6 +9,7 @@ import Base:
     deepcopy,
     deepcopy_internal,
     hash,
+    join,
     size
     
 import Oscar:
@@ -27,7 +28,6 @@ import Oscar:
     elem_type,
     involution,
     iszero,
-    join,
     parent,
     parent_type,
     tensor_product


### PR DESCRIPTION
There is no `join` function in Oscar to import (it is from Base).
This leads to a StackOverflowError on julia nightly (https://github.com/JuliaLang/julia/issues/57343), while julia 1.11 silently uses `Base.join`.