### PR TITLE
fix typo in matroid doc

### DIFF
--- a/src/Combinatorics/Matroids/matroids.jl
+++ b/src/Combinatorics/Matroids/matroids.jl
@@ -764,7 +764,7 @@ end
     free_extension(M::Matroid, e::ElementType)
 The `free extension M +_E e` of a matroid `M` where the element `e`.
 
-See ``principal_extension`` and Section 7.2 of [Oxl11](@cite).
+See [`principal_extension`]@ref and Section 7.2 of [Oxl11](@cite).
 
 # Examples
 To add `5` freely to the uniform matroid `U_{3,4}` do

--- a/src/Combinatorics/Matroids/matroids.jl
+++ b/src/Combinatorics/Matroids/matroids.jl
@@ -764,7 +764,7 @@ end
     free_extension(M::Matroid, e::ElementType)
 The `free extension M +_E e` of a matroid `M` where the element `e`.
 
-See [`principal_extension`]@ref and Section 7.2 of [Oxl11](@cite).
+See [`principal_extension`](@ref) and Section 7.2 of [Oxl11](@cite).
 
 # Examples
 To add `5` freely to the uniform matroid `U_{3,4}` do


### PR DESCRIPTION
The function name was displayed in math mode. Now it is a reference.
