### PR TITLE
Improve conversion between GAP and OSCAR finite fields

### DIFF
--- a/src/GAP/iso_oscar_gap.jl
+++ b/src/GAP/iso_oscar_gap.jl
@@ -121,20 +121,25 @@ function _iso_oscar_gap_field_finite_functions(FO::Union{FqPolyRepField, FqField
 
      if FO isa FqField
        f = function(x)
-         v = [GAP.Obj(Nemo._coeff(x, i)) for i in 0:(d - 1)]
-         return sum([v[i]*basis_FG[i] for i in 1:d])
+         return sum([GAP.Obj(Nemo._coeff(x, i-1))*basis_FG[i] for i in 1:d])
        end
      else
        f = function(x)
-         v = [GAP.Obj(coeff(x, i)) for i in 0:(d - 1)]
-         return sum([v[i]*basis_FG[i] for i in 1:d])
+         return sum([GAP.Obj(coeff(x, i-1))*basis_FG[i] for i in 1:d])
        end
      end
-
-     finv = function(x::GAP.Obj)
-       v = GAPWrap.Coefficients(basis_FG, x)
-       v_int = [ZZRingElem(GAPWrap.IntFFE(v[i])) for i = 1:d]
-       return sum([v_int[i]*basis_F[i] for i = 1:d])
+     if p < 2^60
+       finv = function(x::GAP.Obj)
+         v = GAPWrap.Coefficients(basis_FG, x)
+         v_int = [GAPWrap.IntFFE(v[i])::Int for i = 1:d]
+         return FO(v_int)
+       end
+     else
+       finv = function(x::GAP.Obj)
+         v = GAPWrap.Coefficients(basis_FG, x)
+         v_int = [ZZRingElem(GAPWrap.IntFFE(v[i]))::ZZRingElem for i = 1:d]
+         return FO(v_int)
+       end
      end
    else
      # Create an Oscar field `FO2` that is compatible with `FG`
@@ -149,21 +154,19 @@ function _iso_oscar_gap_field_finite_functions(FO::Union{FqPolyRepField, FqField
      if FO isa FqField
        f = function(x)
          y = preimage(emb, x)
-         v = [GAP.Obj(Nemo._coeff(y, i)) for i in 0:(d - 1)]
-         return sum([v[i]*basis_FG[i] for i in 1:d])
+         return sum([GAP.Obj(Nemo._coeff(y, i-1))*basis_FG[i] for i in 1:d])
        end
      else
        f = function(x)
          y = preimage(emb, x)
-         v = [GAP.Obj(coeff(y, i)) for i in 0:(d - 1)]
-         return sum([v[i]*basis_FG[i] for i in 1:d])
+         return sum([GAP.Obj(coeff(y, i-1))*basis_FG[i] for i in 1:d])
        end
      end
 
      finv = function(x::GAP.Obj)
        v = GAPWrap.Coefficients(basis_FG, x)
        v_int = [ZZRingElem(GAPWrap.IntFFE(v[i])) for i = 1:d]
-       return emb(sum([v_int[i]*basis_F[i] for i = 1:d]))
+       return emb(FO2(v_int))
      end
    end
 


### PR DESCRIPTION
This is a change I started last April and never finished. I am resurrecting it now after a discussion with @mjrodgers and @ThomasBreuer 

I wanted to refactor and possibly optimize the conversion between GAP and OSCAR finite field elements. While I got some modest improvements in one case, another got slightly slower. I also realized that there are some serious bottlenecks in Nemo that we probably should take care of. More on that below.

For now, some (old) timiings:

Before:

    julia> FO = GF(3,4); FG = GAP.Globals.GF(3,4);

    julia> f, finv = Oscar._iso_oscar_gap_field_finite_functions(FO, FG);

    julia> e = one(FO) ; @btime f(e);
      1.875 μs (28 allocations: 832 bytes)

    julia> e = one(FG) ; @btime finv(e);
      3.594 μs (38 allocations: 1.62 KiB)

After:

    julia> FO = GF(3,4); FG = GAP.Globals.GF(3,4);

    julia> f, finv = Oscar._iso_oscar_gap_field_finite_functions(FO, FG);

    julia> e = one(FO) ; @btime f(e);
      1.429 μs (24 allocations: 624 bytes)

    julia> e = one(FG) ; @btime finv(e);
      2.991 μs (39 allocations: 1.64 KiB)


One limitation is the conversion from a list of coefficients into an Nemo FFE (finite 
field element). It looks like this:
```
function (a::FqField)(b::Vector{<:IntegerUnion})
  da = degree(a)
  db = length(b)
  da == db || error("Coercion impossible")
  return a(parent(defining_polynomial(a))(b))
end
```
So we take an integer vector, convert that into a polynomial, and feed that into C code which then copies the coefficients out of the polynomial, and then we discard the polynomial.

Perhaps @mjrodgers can file an issue at Nemo.jl about this, so we don't forget to improve this at some point.