### PR TITLE
Cache parents for permutations in `perm`, `cperm` and `@perm`

### DIFF
--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -40,6 +40,16 @@ function symmetric_group(n::Int)
   return PermGroup(GAP.Globals.SymmetricGroup(n)::GapObj)
 end
 
+# for functions like perm, cperm or macros like @perm provide a cached
+# version of symmetric_group to reduce the overhead for these functions.
+const SymmetricGroupID = AbstractAlgebra.CacheDictType{Int, PermGroup}()
+
+function _symmetric_group_cached(n::Int)
+  Base.get!(SymmetricGroupID, n) do
+    symmetric_group(n)
+  end
+end
+
 """
     is_natural_symmetric_group(G::GAPGroup)
 


### PR DESCRIPTION
... and generally in functions which create a permutation without taking a parent as argument.

Before:

    julia> g = symmetric_group(4); v = [1,2]; w = [3,4];

    julia> @b cperm($g,$v,$w)
    888.889 ns (14 allocs: 352 bytes)

    julia> @b cperm($v,$w)
    12.500 μs (196 allocs: 16.242 KiB)

After:

    julia> g = symmetric_group(4); v = [1,2]; w = [3,4];

    julia> @b cperm($g,$v,$w)
    822.600 ns (14 allocs: 352 bytes)

    julia> @b cperm($v,$w)
    909.700 ns (14 allocs: 352 bytes)