### PR TITLE
Improve usability of `abelian_closure(QQ)`, e.g. for elements representing real values allow comparisons and conversion to `Float64`

### DIFF
--- a/docs/src/NumberTheory/abelian_closure.md
+++ b/docs/src/NumberTheory/abelian_closure.md
@@ -25,6 +25,43 @@ atlas_irrationality
 atlas_description
 ```
 
+## Natural embedding
+
+Oscar assumes a natural embedding of the field
+`K = abelian_closure(QQ)` into the algebraic closure `F` of `QQ`,
+which is given by mapping the `n`-th root of unity returned by `gen(K)(n)`
+to `root_of_unity(F, n)`.
+Both roots of unity correspond to the complex number $\exp(2 \pi i / n)$.
+
+We can convert elements of `K` to elements of `F` as follows.
+
+```jldoctest naturalembedding
+julia> K, z = abelian_closure(QQ)
+(Abelian closure of Q, Generator of abelian closure of Q)
+
+julia> F = QQBarField()
+Field of algebraic numbers
+
+julia> x = z(5)
+z(5)
+
+julia> y = F(x)
+Root 0.309017 + 0.951057*im of x^4 + x^3 + x^2 + x + 1
+
+julia> y^5
+Root 1.00000 of x - 1
+```
+
+Real elements of `K` can be compared with `<` and `>`.
+
+```jldoctest naturalembedding
+julia> a = x + x^4
+-z(5)^3 - z(5)^2 - 1
+
+julia> a > 0
+true
+```
+
 ## Printing
 
 The n-th primitive root of the abelian closure of will by default be printed as

--- a/docs/src/NumberTheory/abelian_closure.md
+++ b/docs/src/NumberTheory/abelian_closure.md
@@ -40,11 +40,11 @@ We can convert elements of `K` to elements of `F` as follows.
 julia> K, z = abelian_closure(QQ)
 (Abelian closure of Q, Generator of abelian closure of Q)
 
-julia> F = QQBarField()
+julia> F = algebraic_closure(QQ)
 Field of algebraic numbers
 
 julia> x = z(5)
-z(5)
+zeta(5)
 
 julia> y = F(x)
 Root 0.309017 + 0.951057*im of x^4 + x^3 + x^2 + x + 1
@@ -57,7 +57,7 @@ Real elements of `K` can be compared with `<` and `>`.
 
 ```jldoctest naturalembedding
 julia> a = x + x^4
--z(5)^3 - z(5)^2 - 1
+-zeta(5)^3 - zeta(5)^2 - 1
 
 julia> a > 0
 true

--- a/docs/src/NumberTheory/abelian_closure.md
+++ b/docs/src/NumberTheory/abelian_closure.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+DocTestSetup = Oscar.doctestsetup()
 ```
 
 # Abelian closure of the rationals

--- a/docs/src/NumberTheory/abelian_closure.md
+++ b/docs/src/NumberTheory/abelian_closure.md
@@ -28,9 +28,9 @@ atlas_description
 
 ## Natural embedding
 
-Oscar assumes a natural embedding of the field
-`K = abelian_closure(QQ)` into the algebraic closure `F` of `QQ`,
-which is given by mapping the `n`-th root of unity returned by `gen(K)(n)`
+Oscar assumes a natural embedding of the field `K` produced by
+`K, z = abelian_closure(QQ)` into `F = algebraic_closure(QQ)`,
+which is given by mapping the `n`-th root of unity returned by `z(n)`
 to `root_of_unity(F, n)`.
 Both roots of unity correspond to the complex number $\exp(2 \pi i / n)$.
 

--- a/test/Rings/AbelianClosure.jl
+++ b/test/Rings/AbelianClosure.jl
@@ -113,9 +113,9 @@ end
     @test_throws Hecke.NotImplemented Oscar.AbelianClosure.coerce_down(Hecke.rationals_as_number_field()[1], 1, z(2))
   end
 
-  @testset "Conversion" begin
+  @testset "Conversion to ZZRingElem and QQFieldElem" begin
     K, z = abelian_closure(QQ)
-    x  = z(5)
+    x = z(5)
     y = ZZ(x^5)
     @test y isa ZZRingElem
     @test y == 1
@@ -124,6 +124,42 @@ end
     @test y == 1
     @test_throws ErrorException ZZ(x)
     @test_throws ErrorException QQ(x)
+  end
+
+  @testset "Conversion to QQBarFieldElem" begin
+    K, z = abelian_closure(QQ)
+    F = QQBarField()
+    x = z(5)
+    y = F(x)
+    @test F(x) == QQBarFieldElem(x)
+    @test F(x^2) == y^2
+    @test y == root_of_unity(F, 5)
+    @test is_one(y^5)
+    a = x + x^4
+    b = x^2 + x^3
+    n = zero(K)
+    @test a > n && F(a) > F(n)
+    @test a > 0
+    @test a > ZZ(0)
+    @test a > QQ(0)
+    @test b < n && F(b) < F(n)
+    @test b < 0
+    @test b < ZZ(0)
+    @test b < QQ(0)
+    @test b < a && F(b) < F(a)
+    @test is_positive(a)
+    @test is_negative(b)
+    @test_throws DomainError x < n
+    @test_throws DomainError y < F(n)
+  end
+
+  @testset "Conversion to Float64 and ComplexF64" begin
+    K, z = abelian_closure(QQ)
+    x = z(5)
+    a = x + x^4
+    @test Float64(a) > 0
+    @test_throws InexactError Float64(x)
+    @test is_one(ComplexF64(one(K)))
   end
 
   @testset "Promote rule" begin

--- a/test/Rings/AbelianClosure.jl
+++ b/test/Rings/AbelianClosure.jl
@@ -140,10 +140,14 @@ end
     n = zero(K)
     @test a > n && F(a) > F(n)
     @test a > 0
+    @test a > BigInt(0)
+    @test a > 0 // 1
     @test a > ZZ(0)
     @test a > QQ(0)
     @test b < n && F(b) < F(n)
     @test b < 0
+    @test b < BigInt(0)
+    @test b < 0 // 1
     @test b < ZZ(0)
     @test b < QQ(0)
     @test b < a && F(b) < F(a)


### PR DESCRIPTION
resolves #3976