### PR TITLE
Tweak printing of `abelian_closure(QQ)`

### DIFF
--- a/docs/src/NumberTheory/abelian_closure.md
+++ b/docs/src/NumberTheory/abelian_closure.md
@@ -45,7 +45,7 @@ julia> z(4)
 z(4)
 
 julia> ζ = gen(K, "ζ")
-Generator of abelian closure of Q
+Generator of abelian closure of QQ
 
 julia> ζ(5) + ζ(3)
 ζ(15)^5 + ζ(15)^3

--- a/experimental/GModule/src/GaloisCohomology.jl
+++ b/experimental/GModule/src/GaloisCohomology.jl
@@ -1614,7 +1614,7 @@ SL(2,5)
 julia> T = character_table(G);
 
 julia> R = gmodule(T[9])
-G-module for G acting on vector space of dimension 6 over abelian closure of Q
+G-module for G acting on vector space of dimension 6 over abelian closure of QQ
 
 julia> S = gmodule(CyclotomicField, R)
 G-module for G acting on vector space of dimension 6 over cyclotomic field of order 5

--- a/src/Rings/AbelianClosure.jl
+++ b/src/Rings/AbelianClosure.jl
@@ -38,6 +38,8 @@ import ..Oscar: AbstractAlgebra, add!, base_ring, base_ring_type, characteristic
                 has_preimage_with_preimage, is_root_of_unity, is_unit, mul!, neg!, parent,
                 parent_type, promote_rule, root, root_of_unity, roots, @req
 
+import Oscar: pretty, Lowercase
+
 using Hecke
 import Hecke: conductor, data
 
@@ -350,19 +352,15 @@ end
 ################################################################################
 
 function Base.show(io::IO, a::QQAbField{AbsNonSimpleNumField})
-  print(io, "(Sparse) abelian closure of Q")
+  print(pretty(io), "Sparse abelian closure of ", Lowercase(), QQ)
 end
 
 function Base.show(io::IO, a::QQAbField{AbsSimpleNumField})
-  print(io, "Abelian closure of Q")
+  print(pretty(io), "Abelian closure of ", Lowercase(), QQ)
 end
 
 function Base.show(io::IO, a::QQAbFieldGen)
-  if isa(a.K, QQAbField{AbsSimpleNumField})
-    print(io, "Generator of abelian closure of Q")
-  else
-    print(io, "Generator of sparse abelian closure of Q")
-  end
+  print(pretty(io), "Generator of ", Lowercase(), a.K)
 end
 
 """

--- a/src/Rings/AlgClosureFp.jl
+++ b/src/Rings/AlgClosureFp.jl
@@ -300,7 +300,7 @@ cached in `K`.
 
 # Examples
 ```jldoctest; setup = :(using Oscar)
-julia> K = algebraic_closure(GF(3, 1));
+julia> K = algebraic_closure(GF(3));
 
 julia> F2 = ext_of_degree(K, 2);
 

--- a/test/Rings/AbelianClosure.jl
+++ b/test/Rings/AbelianClosure.jl
@@ -59,7 +59,14 @@ end
 
   @testset "Printing" begin
     K, z = abelian_closure(QQ)
-    @test sprint(show, "text/plain", K) == "Abelian closure of Q"
+
+    @test AbstractAlgebra.PrettyPrinting.detailed(K) == "Abelian closure of rational field"
+    @test AbstractAlgebra.PrettyPrinting.oneline(K) == "Abelian closure of rational field"
+    @test AbstractAlgebra.PrettyPrinting.supercompact(K) == "Abelian closure of QQ"
+
+    @test AbstractAlgebra.PrettyPrinting.detailed(z) == "Generator of abelian closure of rational field"
+    @test AbstractAlgebra.PrettyPrinting.oneline(z) == "Generator of abelian closure of rational field"
+    @test AbstractAlgebra.PrettyPrinting.supercompact(z) == "Generator of abelian closure of QQ"
 
     orig = get_variable(K)
     @test orig == "zeta"

--- a/test/Rings/AlgClosureFp.jl
+++ b/test/Rings/AlgClosureFp.jl
@@ -55,9 +55,13 @@ end
   @testset "Printing for $F" for F in [GF(3, 1), Nemo.Native.GF(3, 1)]
     K = algebraic_closure(F)
     if F isa FqField
-      @test sprint(show, "text/plain", K) == "Algebraic closure of prime field of characteristic 3"
+      @test AbstractAlgebra.PrettyPrinting.detailed(K) == "Algebraic closure of prime field of characteristic 3"
+      @test AbstractAlgebra.PrettyPrinting.oneline(K) == "Algebraic closure of prime field of characteristic 3"
+      @test AbstractAlgebra.PrettyPrinting.supercompact(K) == "Algebraic closure of GF(3)"
     elseif F isa fqPolyRepField
-      @test sprint(show, "text/plain", K) == "Algebraic closure of finite field of degree 1 over GF(3)"
+      @test AbstractAlgebra.PrettyPrinting.detailed(K) == "Algebraic closure of finite field of degree 1 over GF(3)"
+      @test AbstractAlgebra.PrettyPrinting.oneline(K) == "Algebraic closure of finite field of degree 1 over GF(3)"
+      @test AbstractAlgebra.PrettyPrinting.supercompact(K) == "Algebraic closure of GF(3)"
     else
       error("unreachable")
     end

--- a/test/book/cornerstones/groups/cohomology.jlcon
+++ b/test/book/cornerstones/groups/cohomology.jlcon
@@ -1,8 +1,8 @@
 julia> irreducible_modules(symmetric_group(3))
 3-element Vector{GModule}:
- G-module for Sym(3) acting on vector space of dimension 1 over abelian closure of Q
- G-module for Sym(3) acting on vector space of dimension 1 over abelian closure of Q
- G-module for Sym(3) acting on vector space of dimension 2 over abelian closure of Q
+ G-module for Sym(3) acting on vector space of dimension 1 over abelian closure of QQ
+ G-module for Sym(3) acting on vector space of dimension 1 over abelian closure of QQ
+ G-module for Sym(3) acting on vector space of dimension 2 over abelian closure of QQ
 
 julia> G = symmetric_group(3);
 

--- a/test/book/cornerstones/groups/explSL25.jlcon
+++ b/test/book/cornerstones/groups/explSL25.jlcon
@@ -21,7 +21,7 @@ X_8  5                 .                 .  5                  .                
 X_9  6                -1                -1 -6                  1                  1  .  .  .
 
 julia> R = gmodule(T[end])
-G-module for G acting on vector space of dimension 6 over abelian closure of Q
+G-module for G acting on vector space of dimension 6 over abelian closure of QQ
 
 julia> S = gmodule(CyclotomicField, R)
 G-module for G acting on vector space of dimension 6 over cyclotomic field of order 5


### PR DESCRIPTION
Instead of "Abelian closure of Q" now print "Abelian closure of Q" resp. (in terse mode) "Abelian closure of QQ".

The old printing was a bit jarring in that it differed from how algebraic closures of finite fields are printed ("Algebraic closure of prime field of characteristic 5" resp. "Algebraic closure of GF(5)"), and also the use of "Q" to represent the rationals is not used anywhere (?) else in OSCAR.

(Note that `algebraic_closure(QQ)` print yet differently, as "Field of algebraic numbers" -- I am preparing a Nemo PR to change that as well).

This modifies some book test outputs (CC @benlorenz)

This interacts with PR #4585 by @ThomasBreuer, as that adds docstrings which include the result of printing `abelian_closure(QQ)`. Thus we must be careful to not merge those two simultaneously (each might pass their CI tests but together we'd get a failure). In other words: we should merge one, then afterwards adjust the other before merging it.