### PR TITLE
GModule: Move exports around

### DIFF
--- a/experimental/GModule/src/GModule.jl
+++ b/experimental/GModule/src/GModule.jl
@@ -1,3 +1,17 @@
+export extension_of_scalars
+export factor_set
+export ghom
+export indecomposition
+export irreducible_modules
+export is_decomposable
+export is_G_hom
+export restriction_of_scalars
+export trivial_gmodule
+export natural_gmodule
+export regular_gmodule
+export gmodule_minimal_field
+export gmodule_over
+
 include("Cohomology.jl")
 include("Types.jl")
 include("GaloisCohomology.jl")
@@ -2035,20 +2049,6 @@ end
 end #module GModuleFromGap
 
 using .GModuleFromGap
-
-export extension_of_scalars
-export factor_set
-export ghom
-export indecomposition
-export irreducible_modules
-export is_decomposable
-export is_G_hom
-export restriction_of_scalars
-export trivial_gmodule
-export natural_gmodule
-export regular_gmodule
-export gmodule_minimal_field
-export gmodule_over
 
 include("Brueckner.jl")
 


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/4576. Alternative to and thus closes https://github.com/oscar-system/Oscar.jl/pull/4580.

I don't know *why* this works, but it does work locally. The global `Oscar` module includes all exports before including files with genuine code, so I thought why don't try this here as well, and it resolves the issue.