### PR TITLE
Implement `syllables`, `letters` and their inverse for `WeylGroup` and `WeylGroupElem`

### DIFF
--- a/src/LieTheory/WeylGroup.jl
+++ b/src/LieTheory/WeylGroup.jl
@@ -514,9 +514,94 @@ end
 Return `x` as a list of indices of simple reflections, in reduced form.
 
 This function is right inverse to calling `(W::WeylGroup)(word::Vector{<:Integer})`.
+
+# Examples
+
+```jldoctest
+julia> W = weyl_group(:A, 2)
+Weyl group
+  of root system of rank 2
+    of type A2
+
+julia> x = longest_element(W)
+s1 * s2 * s1
+
+julia> wd = word(x)
+3-element Vector{UInt8}:
+ 0x01
+ 0x02
+ 0x01
+
+julia> W(wd) == x
+true
+```
 """
 function word(x::WeylGroupElem)
   return x.word
+end
+
+@doc raw"""
+    letters(x::WeylGroupElem) -> Vector{UInt8}
+
+Return `x` as a list of indices of simple reflections, in reduced form.
+
+This function is right inverse to calling `(W::WeylGroup)(word::Vector{<:Integer})`.
+
+# Examples
+
+```jldoctest
+julia> W = weyl_group(:A, 2)
+Weyl group
+  of root system of rank 2
+    of type A2
+
+julia> x = longest_element(W)
+s1 * s2 * s1
+
+julia> l = letters(x)
+3-element Vector{UInt8}:
+ 0x01
+ 0x02
+ 0x01
+
+julia> W(l) == x
+true
+```
+"""
+function letters(x::WeylGroupElem)
+  return x.word
+end
+
+@doc raw"""
+    syllables(x::WeylGroupElem) -> Vector{Pair{UInt8, <:Integer}}
+
+Return `x` as a list of pairs, each entry corresponding to indices of simple reflections and its exponent.
+
+This function is right inverse to calling `(W::WeylGroup)(sylls::Vector{Pair{UInt8, <:Integer}})`.
+
+# Examples
+
+```jldoctest
+julia> W = weyl_group(:A, 2)
+Weyl group
+  of root system of rank 2
+    of type A2
+
+julia> x = longest_element(W)
+s1 * s2 * s1
+
+julia> s = syllables(w)
+3-element Vector{Pair{UInt8, <:Integer}}:
+ 0x01 => 1
+ 0x02 => 1
+ 0x01 => 1
+
+julia> W(s) == x
+true
+```
+"""
+function syllables(x::WeylGroupElem)
+  return Pair{UInt8, <:Integer}[i => 1 for i in x.word]
 end
 
 @doc raw"""

--- a/src/LieTheory/WeylGroup.jl
+++ b/src/LieTheory/WeylGroup.jl
@@ -80,6 +80,23 @@ function (W::WeylGroup)(word::Vector{<:Integer}; normalize::Bool=true)
   return WeylGroupElem(W, word; normalize)
 end
 
+@doc raw"""
+    (W::WeylGroup)(sylls::Vector{Pair{<:Integer, <:Integer}}) -> WeylGroupElem
+
+Construct a Weyl group element from the given syllables.
+
+The syllables must be a list of pairs, where each entry is the index of a simple reflection and its exponent.
+"""
+function (W::WeylGroup)(sylls::Vector{Pair{T, T}}; normalize::Bool=true) where T <: Integer
+  res = zeros(Int, length(sylls))
+  
+  for (idx, pair) in enumerate(sylls)
+    res[idx] = pair.first
+  end
+
+  return WeylGroupElem(W, res; normalize)
+end
+
 function Base.IteratorSize(::Type{WeylGroup})
   return Base.SizeUnknown()
 end

--- a/src/LieTheory/WeylGroup.jl
+++ b/src/LieTheory/WeylGroup.jl
@@ -81,17 +81,13 @@ function (W::WeylGroup)(word::Vector{<:Integer}; normalize::Bool=true)
 end
 
 @doc raw"""
-    (W::WeylGroup)(sylls::Vector{Pair{<:Integer, <:Integer}}) -> WeylGroupElem
+    (W::WeylGroup)(sylls::AbstractVector{Pair{T, S}}; normalize::Bool=true) where {T <: Integer, S <: IntegerUnion} -> WeylGroupElem
 
 Construct a Weyl group element from the given syllables.
 
 The syllables must be a list of pairs, where each entry is the index of a simple reflection and its exponent.
 """
-function (W::WeylGroup)(sylls::Vector{Pair{T, T}}; normalize::Bool=true) where T <: Integer
-  res = zeros(Int, length(sylls))
-  
-  for (idx, pair) in enumerate(sylls)
-    res[idx] = pair.first
+function (W::WeylGroup)(sylls::AbstractVector{Pair{T, S}}; normalize::Bool=true) where {T <: Integer, S <: IntegerUnion}
   end
 
   return WeylGroupElem(W, res; normalize)
@@ -590,11 +586,11 @@ function letters(x::WeylGroupElem)
 end
 
 @doc raw"""
-    syllables(x::WeylGroupElem) -> Vector{Pair{UInt8, <:Integer}}
+    syllables(x::WeylGroupElem) -> Vector{Pair{UInt8, <:IntegerUnion}}
 
 Return `x` as a list of pairs, each entry corresponding to indices of simple reflections and its exponent.
 
-This function is right inverse to calling `(W::WeylGroup)(sylls::Vector{Pair{UInt8, <:Integer}})`.
+This function is right inverse to calling `(W::WeylGroup)(sylls::Vector{Pair{UInt8, <:IntegerUnion}})`.
 
 # Examples
 
@@ -607,8 +603,8 @@ Weyl group
 julia> x = longest_element(W)
 s1 * s2 * s1
 
-julia> s = syllables(w)
-3-element Vector{Pair{UInt8, <:Integer}}:
+julia> s = syllables(x)
+3-element Vector{Pair{UInt8, ZZRingElem}}:
  0x01 => 1
  0x02 => 1
  0x01 => 1
@@ -618,7 +614,7 @@ true
 ```
 """
 function syllables(x::WeylGroupElem)
-  return Pair{UInt8, <:Integer}[i => 1 for i in x.word]
+  return Pair{UInt8, ZZRingElem}[i => 1 for i in x.word]
 end
 
 @doc raw"""

--- a/src/LieTheory/WeylGroup.jl
+++ b/src/LieTheory/WeylGroup.jl
@@ -75,6 +75,17 @@ Construct a Weyl group element from the given word.
 The word must be a list of integers, where each integer is the index of a simple reflection.
 
 If the word is known to be in short lex normal form, the normalization can be skipped by setting `normalize=false`.
+
+# Examples
+```jldoctest
+julia> W = weyl_group(:A, 2);  wrd = [1, 2, 1];
+
+julia> x = W(wrd)
+s1 * s2 * s1
+
+julia> word(x) == wrd
+true
+```
 """
 function (W::WeylGroup)(word::Vector{<:Integer}; normalize::Bool=true)
   return WeylGroupElem(W, word; normalize)
@@ -86,6 +97,19 @@ end
 Construct a Weyl group element from the given syllables.
 
 The syllables must be a list of pairs, where each entry is the index of a simple reflection and its exponent.
+
+If the syllables describe a word in short lex normal form, the normalization can be skipped by setting `normalize=false`.
+
+# Examples
+```jldoctest
+julia> W = weyl_group(:A, 2);  pairs = [1 => 1, 2 => 1];
+
+julia> x = W(pairs)
+s1 * s2
+
+julia> syllables(x) == pairs
+true
+```
 """
 function (W::WeylGroup)(sylls::AbstractVector{Pair{T, S}}; normalize::Bool=true) where {T <: Integer, S <: IntegerUnion}
   n = ngens(W)

--- a/src/LieTheory/WeylGroup.jl
+++ b/src/LieTheory/WeylGroup.jl
@@ -89,7 +89,7 @@ function (W::WeylGroup)(word::Vector{<:Integer}; normalize::Bool=true)
 end
 
 @doc raw"""
-    (W::WeylGroup)(sylls::AbstractVector{Pair{T, S}}; normalize::Bool=true) where {T <: Integer, S <: IntegerUnion} -> WeylGroupElem
+    (W::WeylGroup)(sylls::AbstractVector{Pair{<:Integer,<:IntegerUnion}}; normalize::Bool=true) -> WeylGroupElem
 
 Construct a Weyl group element from the given syllables.
 
@@ -105,8 +105,10 @@ julia> x = W([1 => 1, 2 => 1])
 s1 * s2
 ```
 """
-function (W::WeylGroup)(sylls::AbstractVector{Pair{T, S}}; normalize::Bool=true) where {T <: Integer, S <: IntegerUnion}
-  res = T[pair.first for pair in sylls if isodd(pair.second)]
+function (W::WeylGroup)(
+  sylls::AbstractVector{Pair{<:Integer,<:IntegerUnion}}; normalize::Bool=true
+)
+  res = [pair.first for pair in sylls if isodd(pair.second)]
   return WeylGroupElem(W, res; normalize)
 end
 

--- a/src/LieTheory/WeylGroup.jl
+++ b/src/LieTheory/WeylGroup.jl
@@ -78,13 +78,10 @@ If the word is known to be in short lex normal form, the normalization can be sk
 
 # Examples
 ```jldoctest
-julia> W = weyl_group(:A, 2);  wrd = [1, 2, 1];
+julia> W = weyl_group(:A, 2);
 
-julia> x = W(wrd)
+julia> x = W([1, 2, 1])
 s1 * s2 * s1
-
-julia> word(x) == wrd
-true
 ```
 """
 function (W::WeylGroup)(word::Vector{<:Integer}; normalize::Bool=true)
@@ -102,26 +99,14 @@ If the syllables describe a word in short lex normal form, the normalization can
 
 # Examples
 ```jldoctest
-julia> W = weyl_group(:A, 2);  pairs = [1 => 1, 2 => 1];
+julia> W = weyl_group(:A, 2);
 
-julia> x = W(pairs)
+julia> x = W([1 => 1, 2 => 1])
 s1 * s2
-
-julia> syllables(x) == pairs
-true
 ```
 """
 function (W::WeylGroup)(sylls::AbstractVector{Pair{T, S}}; normalize::Bool=true) where {T <: Integer, S <: IntegerUnion}
-  n = ngens(W)
-  res = Vector{T}()
-  
-  for pair in sylls
-    @req 0 < pair.first && pair.first <= n "generator number is at most $n"
-    if pair.second != 0
-      push!(res, pair.first)
-    end
-  end
-
+  res = T[pair.first for pair in sylls if isodd(pair.second)]
   return WeylGroupElem(W, res; normalize)
 end
 
@@ -563,22 +548,16 @@ This function is right inverse to calling `(W::WeylGroup)(word::Vector{<:Integer
 # Examples
 
 ```jldoctest
-julia> W = weyl_group(:A, 2)
-Weyl group
-  of root system of rank 2
-    of type A2
+julia> W = weyl_group(:A, 2);
 
 julia> x = longest_element(W)
 s1 * s2 * s1
 
-julia> wd = word(x)
+julia> word(x)
 3-element Vector{UInt8}:
  0x01
  0x02
  0x01
-
-julia> W(wd) == x
-true
 ```
 """
 function word(x::WeylGroupElem)
@@ -595,26 +574,20 @@ This function is right inverse to calling `(W::WeylGroup)(word::Vector{<:Integer
 # Examples
 
 ```jldoctest
-julia> W = weyl_group(:A, 2)
-Weyl group
-  of root system of rank 2
-    of type A2
+julia> W = weyl_group(:A, 2);
 
 julia> x = longest_element(W)
 s1 * s2 * s1
 
-julia> l = letters(x)
-3-element Vector{UInt8}:
- 0x01
- 0x02
- 0x01
-
-julia> W(l) == x
-true
+julia> letters(x)
+3-element Vector{Int64}:
+ 1
+ 2
+ 1
 ```
 """
 function letters(x::WeylGroupElem)
-  return x.word
+  return Int.(x.word)
 end
 
 @doc raw"""
@@ -627,26 +600,20 @@ This function is right inverse to calling `(W::WeylGroup)(sylls::Vector{Pair{UIn
 # Examples
 
 ```jldoctest
-julia> W = weyl_group(:A, 2)
-Weyl group
-  of root system of rank 2
-    of type A2
+julia> W = weyl_group(:A, 2);
 
 julia> x = longest_element(W)
 s1 * s2 * s1
 
-julia> s = syllables(x)
-3-element Vector{Pair{UInt8, ZZRingElem}}:
- 0x01 => 1
- 0x02 => 1
- 0x01 => 1
-
-julia> W(s) == x
-true
+julia> syllables(x)
+3-element Vector{Pair{Int64, ZZRingElem}}:
+ 1 => 1
+ 2 => 1
+ 1 => 1
 ```
 """
 function syllables(x::WeylGroupElem)
-  return Pair{UInt8, ZZRingElem}[i => 1 for i in x.word]
+  return Pair{Int,ZZRingElem}[i => 1 for i in x.word]
 end
 
 @doc raw"""

--- a/src/LieTheory/WeylGroup.jl
+++ b/src/LieTheory/WeylGroup.jl
@@ -89,7 +89,7 @@ function (W::WeylGroup)(word::Vector{<:Integer}; normalize::Bool=true)
 end
 
 @doc raw"""
-    (W::WeylGroup)(sylls::AbstractVector{Pair{<:Integer,<:IntegerUnion}}; normalize::Bool=true) -> WeylGroupElem
+    (W::WeylGroup)(sylls::AbstractVector{<:Pair{<:Integer,<:IntegerUnion}}; normalize::Bool=true) -> WeylGroupElem
 
 Construct a Weyl group element from the given syllables.
 
@@ -106,7 +106,7 @@ s1 * s2
 ```
 """
 function (W::WeylGroup)(
-  sylls::AbstractVector{Pair{<:Integer,<:IntegerUnion}}; normalize::Bool=true
+  sylls::AbstractVector{<:Pair{<:Integer,<:IntegerUnion}}; normalize::Bool=true
 )
   res = [pair.first for pair in sylls if isodd(pair.second)]
   return WeylGroupElem(W, res; normalize)

--- a/src/LieTheory/WeylGroup.jl
+++ b/src/LieTheory/WeylGroup.jl
@@ -88,6 +88,14 @@ Construct a Weyl group element from the given syllables.
 The syllables must be a list of pairs, where each entry is the index of a simple reflection and its exponent.
 """
 function (W::WeylGroup)(sylls::AbstractVector{Pair{T, S}}; normalize::Bool=true) where {T <: Integer, S <: IntegerUnion}
+  n = ngens(W)
+  res = Vector{T}()
+  
+  for pair in sylls
+    @req 0 < pair.first && pair.first <= n "generator number is at most $n"
+    if pair.second != 0
+      push!(res, pair.first)
+    end
   end
 
   return WeylGroupElem(W, res; normalize)

--- a/test/LieTheory/WeylGroup.jl
+++ b/test/LieTheory/WeylGroup.jl
@@ -187,9 +187,13 @@
   end
 
   b3_w0 = UInt8[1, 2, 1, 3, 2, 1, 3, 2, 3]
+  b3_s0 = [1=>1, 2=>1, 1=>1, 3=>1, 2=>1, 1=>1, 3=>1, 2=>1, 3=>1]
   b4_w0 = UInt8[1, 2, 1, 3, 2, 1, 4, 3, 2, 1, 4, 3, 2, 4, 3, 4]
+  b4_s0 = [1=>1, 2=>1, 1=>1, 3=>1, 2=>1, 1=>1, 4=>1, 3=>1, 2=>1, 1=>1, 4=>1, 3=>1, 2=>1, 4=>1, 3=>1, 4=>1]
   f4_w0 = UInt8[1, 2, 1, 3, 2, 1, 3, 2, 3, 4, 3, 2, 1, 3, 2, 3, 4, 3, 2, 1, 3, 2, 3, 4]
+  f4_s0 = [1=>1, 2=>1, 1=>1, 3=>1, 2=>1, 1=>1, 3=>1, 2=>1, 3=>1, 4=>1, 3=>1, 2=>1, 1=>1, 3=>1, 2=>1, 3=>1, 4=>1, 3=>1, 2=>1, 1=>1, 3=>1, 2=>1, 3=>1, 4=>1]
   g2_w0 = UInt8[1, 2, 1, 2, 1, 2]
+  g2_s0 = [1=>1, 2=>1, 1=>1, 2=>1, 1=>1, 2=>1]
 
   @testset "longest_element(W::WeylGroup)" begin
     # A1
@@ -203,30 +207,40 @@
     w0 = longest_element(W)
     @test is_in_normal_form(w0)
     @test word(w0) == UInt8[1, 2, 1]
+    @test letters(w0) == UInt8[1, 2, 1]
+    @test syllables(w0) == [1 => 1, 2 => 1, 1 => 1]
 
     # B2
     W = weyl_group(:B, 2)
     w0 = longest_element(W)
     @test is_in_normal_form(w0)
     @test word(w0) == UInt8[1, 2, 1, 2]
+    @test letters(w0) == UInt8[1, 2, 1, 2]
+    @test syllables(w0) == [0x01 => 1, 0x02 => 1, 0x01 => 1, 0x02 => 1]
 
     # B3
     W = weyl_group(:B, 3)
     w0 = longest_element(W)
     @test is_in_normal_form(w0)
     @test word(w0) == b3_w0
+    @test letters(w0) == b3_w0
+    @test syllables(w0) == b3_s0
 
     # F4
     W = weyl_group(:F, 4)
     w0 = longest_element(W)
     @test is_in_normal_form(w0)
     @test word(w0) == f4_w0
+    @test letters(w0) == f4_w0
+    @test syllables(w0) == f4_s0
 
     # G2
     W = weyl_group(:G, 2)
     w0 = longest_element(W)
     @test is_in_normal_form(w0)
     @test word(w0) == g2_w0
+    @test letters(w0) == g2_w0
+    @test syllables(w0) == g2_s0
   end
 
   @testset "ngens(W::WeylGroup)" begin
@@ -351,6 +365,10 @@
     @test parent(x) isa WeylGroup
 
     x = W([1, 3, 5, 4, 2])
+    @test parent(x) === x.parent
+    @test parent(x) isa WeylGroup
+
+    x = W([3 => 1, 5 => 1])
     @test parent(x) === x.parent
     @test parent(x) isa WeylGroup
   end

--- a/test/LieTheory/WeylGroup.jl
+++ b/test/LieTheory/WeylGroup.jl
@@ -187,13 +187,9 @@
   end
 
   b3_w0 = UInt8[1, 2, 1, 3, 2, 1, 3, 2, 3]
-  b3_s0 = [1=>1, 2=>1, 1=>1, 3=>1, 2=>1, 1=>1, 3=>1, 2=>1, 3=>1]
   b4_w0 = UInt8[1, 2, 1, 3, 2, 1, 4, 3, 2, 1, 4, 3, 2, 4, 3, 4]
-  b4_s0 = [1=>1, 2=>1, 1=>1, 3=>1, 2=>1, 1=>1, 4=>1, 3=>1, 2=>1, 1=>1, 4=>1, 3=>1, 2=>1, 4=>1, 3=>1, 4=>1]
   f4_w0 = UInt8[1, 2, 1, 3, 2, 1, 3, 2, 3, 4, 3, 2, 1, 3, 2, 3, 4, 3, 2, 1, 3, 2, 3, 4]
-  f4_s0 = [1=>1, 2=>1, 1=>1, 3=>1, 2=>1, 1=>1, 3=>1, 2=>1, 3=>1, 4=>1, 3=>1, 2=>1, 1=>1, 3=>1, 2=>1, 3=>1, 4=>1, 3=>1, 2=>1, 1=>1, 3=>1, 2=>1, 3=>1, 4=>1]
   g2_w0 = UInt8[1, 2, 1, 2, 1, 2]
-  g2_s0 = [1=>1, 2=>1, 1=>1, 2=>1, 1=>1, 2=>1]
 
   @testset "longest_element(W::WeylGroup)" begin
     # A1
@@ -206,41 +202,43 @@
     W = weyl_group(:A, 2)
     w0 = longest_element(W)
     @test is_in_normal_form(w0)
-    @test word(w0) == UInt8[1, 2, 1]
-    @test letters(w0) == UInt8[1, 2, 1]
-    @test syllables(w0) == [1 => 1, 2 => 1, 1 => 1]
+    a2_w0_word = UInt8[1, 2, 1]
+    @test word(w0) == a2_w0_word
+    @test letters(w0) == Int.(a2_w0_word)
+    @test syllables(w0) == [Int(i) => 1 for i in a2_w0_word]
 
     # B2
     W = weyl_group(:B, 2)
     w0 = longest_element(W)
     @test is_in_normal_form(w0)
-    @test word(w0) == UInt8[1, 2, 1, 2]
-    @test letters(w0) == UInt8[1, 2, 1, 2]
-    @test syllables(w0) == [0x01 => 1, 0x02 => 1, 0x01 => 1, 0x02 => 1]
+    b2_w0_word = UInt8[1, 2, 1, 2]
+    @test word(w0) == b2_w0_word
+    @test letters(w0) == Int.(b2_w0_word)
+    @test syllables(w0) == [Int(i) => 1 for i in b2_w0_word]
 
     # B3
     W = weyl_group(:B, 3)
     w0 = longest_element(W)
     @test is_in_normal_form(w0)
     @test word(w0) == b3_w0
-    @test letters(w0) == b3_w0
-    @test syllables(w0) == b3_s0
+    @test letters(w0) == Int.(b3_w0)
+    @test syllables(w0) == [Int(i) => 1 for i in b3_w0]
 
     # F4
     W = weyl_group(:F, 4)
     w0 = longest_element(W)
     @test is_in_normal_form(w0)
     @test word(w0) == f4_w0
-    @test letters(w0) == f4_w0
-    @test syllables(w0) == f4_s0
+    @test letters(w0) == Int.(f4_w0)
+    @test syllables(w0) == [Int(i) => 1 for i in f4_w0]
 
     # G2
     W = weyl_group(:G, 2)
     w0 = longest_element(W)
     @test is_in_normal_form(w0)
     @test word(w0) == g2_w0
-    @test letters(w0) == g2_w0
-    @test syllables(w0) == g2_s0
+    @test letters(w0) == Int.(g2_w0)
+    @test syllables(w0) == [Int(i) => 1 for i in g2_w0]
   end
 
   @testset "ngens(W::WeylGroup)" begin


### PR DESCRIPTION
This PR adds `syllables` and `letters` for `WeylGroupElem` and their corresponding "inverse" method to construct an element using a `WeylGroup`.

This PR implements parts of #4150.