### PR TITLE
fix link to page with channels to contact over

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,7 +15,7 @@ instructions](https://www.oscar-system.org/install/) for installing OSCAR.
 
 If you have questions about OSCAR, please have a look at our [Frequently Asked
 Questions](@ref) and feel free to contact us under the channels mentioned on
-[our community page](https://www.oscar-system.org/community/). Our main
+[our contact page](https://www.oscar-system.org/contact-and-support/). Our main
 communication channels are [Slack](https://oscar-system.org/slack)
 and [Github](https://github.com/oscar-system/Oscar.jl).
 


### PR DESCRIPTION
There doesn't seem to be a community page anymore. The best I could find instead is the contact and support page. I changed the link in the documentation to that.