### PR TITLE
booktest: merge comment into one line to avoid #4402

### DIFF
--- a/test/book/cornerstones/number-theory/galoismod.jlcon
+++ b/test/book/cornerstones/number-theory/galoismod.jlcon
@@ -4,8 +4,7 @@ julia> Qx, x = QQ["x"];
 
 julia> K, a = number_field(x^4 + 4*x^2 + 2, "a");
 
-julia> b = rand(K, -10:10) # random element with coefficients
-                           # between -10 and 10
+julia> b = rand(K, -10:10) # random element with coefficients between -10 and 10
 5*a^3 - 7*a^2 + 8*a - 8
 
 julia> A, mA = automorphism_group(K);


### PR DESCRIPTION
I think we can just join the comment lines to avoid the paste issue with the comment. We can keep #4402 open until the julia issue is fixed and revert this change later.