### PR TITLE
Fix Krull dimension of polynomial rings over number fields

### DIFF
--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -1886,6 +1886,7 @@ codim(I::MPolyIdeal{T}) where {T<:MPolyRingElem{<:FieldElem}}= nvars(base_ring(I
 
 
 # Some fixes which were necessary for the above
+dim(R::MPolyRing{<:FieldElem}) = nvars(R) # Needed, because `dim` for number fields implements something different from Krull dimension!
 dim(R::MPolyRing) = dim(base_ring(R)) + nvars(R)
 dim(R::ZZRing) = 1
 

--- a/test/Rings/mpoly.jl
+++ b/test/Rings/mpoly.jl
@@ -666,3 +666,10 @@ end
   @test I2.dim !== nothing
 end
 
+@testset "dimensions over number fields" begin
+  P, t = QQ[:t]
+  kk, i = extension_field(t^2 + 1)
+  R, (x, y) = kk[:x, :y]
+  @test dim(R) == 2
+end
+


### PR DESCRIPTION
`dim` for number fields does not implement the Krull dimension, but the dimension over its base field (or QQ, I don't know). Hence, some of our implementations of Krull dimension for polynomial rings and friends were wrong. This hopefully fixes it. 

Ping @thofma @fieker 