### PR TITLE
fix a doctest and a statement

### DIFF
--- a/docs/src/NumberTheory/abelian_closure.md
+++ b/docs/src/NumberTheory/abelian_closure.md
@@ -92,7 +92,7 @@ julia> ζ(5) + ζ(3)
 julia> z(4)
 "ζ"
 
-julia> set_variable!(K, "zeta");  # try to reset to the default value
+julia> set_variable!(K, "zeta");
 
 julia> z(4)
 zeta(4)

--- a/docs/src/NumberTheory/abelian_closure.md
+++ b/docs/src/NumberTheory/abelian_closure.md
@@ -66,7 +66,7 @@ true
 ## Printing
 
 The n-th primitive root of the abelian closure of will by default be printed as
-`z(n)`. The printing can be manipulated using the following functions:
+`zeta(n)`. The printing can be manipulated using the following functions:
 
 ```@docs
 gen(::QQAbField, ::String)
@@ -76,11 +76,11 @@ get_variable(::QQAbField)
 
 ### Examples
 
-```@jldoctest
+```jldoctest
 julia> K, z = abelian_closure(QQ);
 
 julia> z(4)
-z(4)
+zeta(4)
 
 julia> ζ = gen(K, "ζ")
 Generator of abelian closure of Q

--- a/docs/src/NumberTheory/abelian_closure.md
+++ b/docs/src/NumberTheory/abelian_closure.md
@@ -87,6 +87,12 @@ Generator of abelian closure of Q
 
 julia> ζ(5) + ζ(3)
 ζ(15)^5 + ζ(15)^3
+
+julia> set_variable!(K, "zeta")  # reset to the default value
+"ζ"
+
+julia> z(4)
+zeta(4)
 ```
 
 ## Reduction to characteristic ``p``

--- a/docs/src/NumberTheory/abelian_closure.md
+++ b/docs/src/NumberTheory/abelian_closure.md
@@ -65,8 +65,9 @@ true
 
 ## Printing
 
-The n-th primitive root of the abelian closure of will by default be printed as
-`zeta(n)`. The printing can be manipulated using the following functions:
+The n-th primitive root of the abelian closure of $\mathbf{Q}$
+will by default be printed as `zeta(n)`.
+The printing can be manipulated using the following functions:
 
 ```@docs
 gen(::QQAbField, ::String)
@@ -76,7 +77,7 @@ get_variable(::QQAbField)
 
 ### Examples
 
-```jldoctest
+```
 julia> K, z = abelian_closure(QQ);
 
 julia> z(4)
@@ -88,8 +89,10 @@ Generator of abelian closure of Q
 julia> ζ(5) + ζ(3)
 ζ(15)^5 + ζ(15)^3
 
-julia> set_variable!(K, "zeta")  # reset to the default value
+julia> z(4)
 "ζ"
+
+julia> set_variable!(K, "zeta");  # try to reset to the default value
 
 julia> z(4)
 zeta(4)


### PR DESCRIPTION
By default, `gen(abelian_closure(QQ)[1])(5)` is printed as `zeta(5)`. However, a statement and a doctest in a `.md` file claimed that `z(5)` is printed.

(This doctest was not executed in `Oscar.build_doc(doctest=true)` because it was marked as `@jldoctest` not as `jldoctest` --it took me some time until I understood the problem.)

This fix was suggested by @thofma in #4585.