### PR TITLE
Update `jll_deps`; make `lib4ti2_jll` an explicit dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,6 +24,7 @@ Singular = "bcd08a7b-43d2-5ff7-b6d4-c458787f915c"
 TOPCOM_jll = "36f60fef-b880-50dc-9289-4aaecee93cc3"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 cohomCalg_jll = "5558cf25-a90e-53b0-b813-cadaa3ae7ade"
+lib4ti2_jll = "1493ae25-0f90-5c0e-a06c-8c5077d6d66f"
 
 [compat]
 AbstractAlgebra = "0.44.4"
@@ -47,3 +48,4 @@ TOPCOM_jll = "0.17.8"
 UUIDs = "1.6"
 cohomCalg_jll = "0.32.0"
 julia = "1.6"
+lib4ti2_jll = "1.6.10"

--- a/src/Rings/binomial_ideals.jl
+++ b/src/Rings/binomial_ideals.jl
@@ -1,5 +1,3 @@
-import Oscar.Singular.lib4ti2_jll
-
 @doc raw"""
     is_binomial(f::MPolyRingElem)
 

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -207,3 +207,4 @@ if !isdefined(Hecke, :torsion_free_rank)
 end
 
 import cohomCalg_jll
+import lib4ti2_jll

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -1,7 +1,7 @@
 const cornerstones = String["AbstractAlgebra", "GAP", "Hecke", "Nemo", "Polymake", "Singular"];
-const jll_deps = String["Antic_jll", "Arb_jll", "Calcium_jll", "FLINT_jll", "GAP_jll",
+const jll_deps = String["FLINT_jll", "GAP_jll", "GAP_lib_jll",
                         "libpolymake_julia_jll", "libsingular_julia_jll",
-                        "polymake_jll", "Singular_jll"];
+                        "polymake_jll", "polymake_oscarnumber_jll", "Singular_jll"];
 const aadir = Base.pkgdir(AbstractAlgebra)
 const nemodir = Base.pkgdir(Nemo)
 const heckedir = Base.pkgdir(Hecke)


### PR DESCRIPTION
It is an implementation detail of `Singular.jl` to have `lib4ti2_jll` as a symbol, so better to add it as an explicit dependency of Oscar.
And I noticed that the `jll_deps` global is a bit outdated, the removed jlls are gone since the switch to FLINT v3. Instead, I added two other jlls which may help in bug reports. 