### PR TITLE
Update linear algebra documentation to match with AbstractAlgebra again

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 cohomCalg_jll = "5558cf25-a90e-53b0-b813-cadaa3ae7ade"
 
 [compat]
-AbstractAlgebra = "0.44.4"
+AbstractAlgebra = "0.44.5"
 AlgebraicSolving = "0.8.0"
 Distributed = "1.6"
 GAP = "0.13.1"

--- a/docs/doc.main
+++ b/docs/doc.main
@@ -70,9 +70,11 @@
 
   "Linear Algebra" => [
      "LinearAlgebra/intro.md",
-     "Hecke/manual/misc/sparse.md",
      "AbstractAlgebra/matrix.md",
+     "AbstractAlgebra/matrix_spaces.md",
+     "AbstractAlgebra/matrix_implementation.md",
      "AbstractAlgebra/matrix_algebras.md",
+     "Hecke/manual/misc/sparse.md",
      "Modules" => [
         "AbstractAlgebra/module.md",
         "AbstractAlgebra/free_module.md",


### PR DESCRIPTION
I believe this was forgotten after the overhaul by @emikelsons .

cc @thofma @fingolfin 