### PR TITLE
cleanup 3 instances of dim(spec(R)) to dim(R)

### DIFF
--- a/experimental/Schemes/src/SpaceGerms.jl
+++ b/experimental/Schemes/src/SpaceGerms.jl
@@ -89,9 +89,7 @@ A complete intersection germ ``(X,O_{(X,x)}``, i.e. a ringed space with underlyi
     R = base_ring(modulus(OO(X)))
     all(x->parent(x) == R, v) || error("base_rings do not coincide")
     @check begin
-## TODO: change dim(spec(R)) to dim(R) as soon as the fixes for dim have
-## been moved to the algebra side!!!!
-      length(v) == dim(spec(R)) - dim(X) || error("not a complete intersection")
+      length(v) == dim(R) - dim(X) || error("not a complete intersection")
       modulus(OO(X)) == ideal(R,v) || error("given tuple does not generate modulus")
     end
     return new{typeof(base_ring(X)), typeof(OO(X)), typeof(X)}(X,v)
@@ -103,7 +101,7 @@ A complete intersection germ ``(X,O_{(X,x)}``, i.e. a ringed space with underlyi
     R = base_ring(OO(X))
     all(x->parent(x) == R, v) || error("base_rings do not coincide")
     @check begin
-      length(v) == dim(spec(R)) - dim(X) || error("not a complete intersection")
+      length(v) == dim(R) - dim(X) || error("not a complete intersection")
       modulus(OO(X)) == ideal(R,v) || error("given tuple does not generate modulus")
     end
     return new{typeof(base_ring(X)), typeof(OO(X)), typeof(X)}(X,v)
@@ -562,10 +560,7 @@ function CompleteIntersectionGerm(X::AbsAffineScheme, a::Vector{T}) where T<:Uni
   U = MPolyComplementOfKPointIdeal(R,b)
   L,_ = localization(OO(X), U)
   mingens = minimal_generating_set(modulus(L))
-## TODO: Should be dim(L) and not dim(spec(L)), but dim for localized
-## quotients is only repaired on the geometric side as of now!!!
-  AffineSchemeL = spec(L)
-  length(mingens) == dim(R) - dim(AffineSchemeL) || error("not a complete intersection")
+  length(mingens) == dim(R) - dim(L) || error("not a complete intersection")
   w = mingens
   Y = CompleteIntersectionGerm(AffineSchemeL,w)
   set_attribute!(Y,:representative,X)

--- a/experimental/Schemes/src/SpaceGerms.jl
+++ b/experimental/Schemes/src/SpaceGerms.jl
@@ -562,7 +562,7 @@ function CompleteIntersectionGerm(X::AbsAffineScheme, a::Vector{T}) where T<:Uni
   mingens = minimal_generating_set(modulus(L))
   length(mingens) == dim(R) - dim(L) || error("not a complete intersection")
   w = mingens
-  Y = CompleteIntersectionGerm(AffineSchemeL,w)
+  Y = CompleteIntersectionGerm(spec(L),w)
   set_attribute!(Y,:representative,X)
   return Y
 end


### PR DESCRIPTION
After dim has found its place in Commutative Algebra and Algebraic Geometry only points to it, the dimension of the ring can bei used directly here. (following @simonbrandhorst 's comment in #2771 )