### PR TITLE
Skip stalling CI jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,6 +107,8 @@ jobs:
         if: matrix.julia-version == '1.6' && runner.os == 'Linux'
         run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Run tests"
+        # skip tests for push and pull_request events for short group on julia 1.12-nightly and nightly (see https://github.com/oscar-system/Oscar.jl/issues/4604)
+        if: (github.event_name != 'push' && github.event_name != 'pull_request') || (matrix.julia-version != '1.12-nightly' && matrix.julia-version != 'nightly') || matrix.group != 'short'
         uses: julia-actions/julia-runtest@latest
         with:
           annotate: ${{ matrix.julia-version == '1.10' }}


### PR DESCRIPTION
As discussed on slack.

Skip the short testgroup CI jobs with julia 1.12-nightly and nightly, but only for pull_request and push events.
Once https://github.com/oscar-system/Oscar.jl/issues/4604 is fixed, this should get reverted.

One can unfortunately not exclude any jobs from a matrix based on event type, so skipping the one heavy part of the job is the only way to do this. It will make these two jobs show as successful after a very short run of < 1 min.