### PR TITLE
Move doctests back to github hosted runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -157,12 +157,12 @@ jobs:
           - '1.12-nightly'
           - 'nightly'
         os:
-          - [Linux, RPTU, normal-memory]
+          - 'ubuntu-latest'
         depwarn: [ '' ]
         include:
           # Add a single job with deprecation errors on the most recent stable julia version
           - julia-version: '1.10'
-            os: [Linux, RPTU, normal-memory]
+            os: 'ubuntu-latest'
             depwarn: 'depwarn=error'
           # Add macOS jobs (not too many, the number we can run in parallel is limited)
           - julia-version: '1.10'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   test:
     runs-on: ["${{ matrix.os }}", "${{ matrix.group == 'short' && 'high-memory' || 'normal-memory'}}", RPTU]
-    timeout-minutes: 150
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -147,7 +147,7 @@ jobs:
 
   doctest:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 150
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
As suggested on Slack, moves doctests back to github hosted CI runners, to ease some load on the RPTU runners