### PR TITLE
Adapt to conformance test changes in AA

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 cohomCalg_jll = "5558cf25-a90e-53b0-b813-cadaa3ae7ade"
 
 [compat]
-AbstractAlgebra = "0.44.5"
+AbstractAlgebra = "0.44.6"
 AlgebraicSolving = "0.8.0"
 Distributed = "1.6"
 GAP = "0.13.1"

--- a/src/AlgebraicGeometry/Schemes/FunctionField/FunctionFields.jl
+++ b/src/AlgebraicGeometry/Schemes/FunctionField/FunctionFields.jl
@@ -522,3 +522,19 @@ end
 scheme(f::VarietyFunctionFieldElem) = scheme(parent(f))
 variety(f::VarietyFunctionFieldElem) = variety(parent(f))
 
+###############################################################################
+#
+#   Conformance test element generation
+#
+###############################################################################
+
+function ConformanceTests.generate_element(K::VarietyFunctionField)
+  F = representative_field(K)
+  P = base_ring(F)::MPolyRing
+  num = rand(P, 0:5, 0:5, 0:5)
+  den = zero(P)
+  while is_zero(den)
+    den = rand(P, 1:5, 1:5, 1:5)
+  end
+  return K(num, den)
+end

--- a/src/LieTheory/RootSystem.jl
+++ b/src/LieTheory/RootSystem.jl
@@ -1137,6 +1137,8 @@ function root_system(r::RootSpaceElem)
   return r.root_system
 end
 
+ConformanceTests.equality(a::RootSpaceElem, b::RootSpaceElem) = a == b
+
 ###############################################################################
 #
 #   Dual root space elements
@@ -1460,6 +1462,8 @@ Return the root system `r` belongs to.
 function root_system(r::DualRootSpaceElem)
   return r.root_system
 end
+
+ConformanceTests.equality(a::DualRootSpaceElem, b::DualRootSpaceElem) = a == b
 
 ###############################################################################
 # more functions

--- a/src/LieTheory/WeightLattice.jl
+++ b/src/LieTheory/WeightLattice.jl
@@ -488,3 +488,5 @@ function reflect!(w::WeightLatticeElem, beta::RootSpaceElem)
   end
   return w
 end
+
+ConformanceTests.equality(a::WeightLatticeElem, b::WeightLatticeElem) = a == b

--- a/src/Rings/AbelianClosure.jl
+++ b/src/Rings/AbelianClosure.jl
@@ -1307,6 +1307,18 @@ end
 
 #TODO: add reduction to alg. closure as soon as this is available!
 
+###############################################################################
+#
+#   Conformance test element generation
+#
+###############################################################################
+
+function ConformanceTests.generate_element(K::QQAbField)
+  ns = rand(1:8, 3)
+  zs = map(n -> sum(rand(-10:10) * gen(K)(n)^rand(1:n) for j in 1:10), ns)
+  return sum(zs)
+end
+
 end # module AbelianClosure
 
 import .AbelianClosure:

--- a/src/Rings/AlgClosureFp.jl
+++ b/src/Rings/AlgClosureFp.jl
@@ -328,6 +328,12 @@ function has_preimage_with_preimage(mp::MapFromFunc{T, AlgClosure{S}}, elm::AlgC
   return true, preimage(mp, elm)
 end
 
+### Conformance test element generation
+function ConformanceTests.generate_element(K::AlgClosure{T}) where T <: FinField
+  d = rand(1:8)
+  F = ext_of_degree(K, d)
+  return K(rand(F))
+end
 
 end # AlgClosureFp
 

--- a/src/Rings/PBWAlgebraQuo.jl
+++ b/src/Rings/PBWAlgebraQuo.jl
@@ -279,6 +279,12 @@ function (Q::PBWAlgQuo)(a::PBWAlgQuoElem)
   return a
 end
 
+### Conformance test element generation
+function ConformanceTests.generate_element(Q::PBWAlgQuo{QQFieldElem})
+  R = base_ring(Q)
+  return Q(R(rand(base_ring(R), 1:4, 1:4, 1:4)))
+end
+
 #############################################
 ##### Exterior algebras
 #############################################

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -1013,6 +1013,11 @@ function rand(rng::Random.AbstractRNG, W::MPolyLocRing, v1::AbstractUnitRange{In
   return W(rand(rng, base_ring(W), v1, v2, v3), rand(rng, inverted_set(W), v1, v2, v3))
 end
 
+### Conformance test element generation
+function ConformanceTests.generate_element(W::Oscar.MPolyLocRing)
+  return rand(W, 0:3, 0:4, 0:3)
+end
+
 
 ########################################################################
 # Elements of localized polynomial rings                               #

--- a/test/AlgebraicGeometry/Schemes/FunctionFields.jl
+++ b/test/AlgebraicGeometry/Schemes/FunctionFields.jl
@@ -1,19 +1,6 @@
-const rng = Oscar.get_seeded_rng()
-
 if !isdefined(Main, :test_Field_interface)
   import Oscar.AbstractAlgebra
   include(joinpath(pathof(AbstractAlgebra), "..", "..", "test", "Rings-conformance-tests.jl"))
-end
-
-function test_elem(K::VarietyFunctionField)
-  F = representative_field(K)
-  P = base_ring(F)::MPolyRing
-  num = rand(P, 0:5, 0:5, 0:5)
-  den = zero(P)
-  while is_zero(den)
-    den = rand(P, 1:5, 1:5, 1:5)
-  end
-  return K(num, den)
 end
 
 @testset "fraction fields of varieties" begin

--- a/test/AlgebraicGeometry/Schemes/FunctionFields.jl
+++ b/test/AlgebraicGeometry/Schemes/FunctionFields.jl
@@ -1,8 +1,3 @@
-if !isdefined(Main, :test_Field_interface)
-  import Oscar.AbstractAlgebra
-  include(joinpath(pathof(AbstractAlgebra), "..", "..", "test", "Rings-conformance-tests.jl"))
-end
-
 @testset "fraction fields of varieties" begin
   P = projective_space(QQ, 2)
   S = homogeneous_coordinate_ring(P)

--- a/test/AlgebraicGeometry/Schemes/FunctionFields.jl
+++ b/test/AlgebraicGeometry/Schemes/FunctionFields.jl
@@ -23,8 +23,8 @@ end
   Ccov = covered_scheme(C)
   KK = VarietyFunctionField(Ccov)
 
-  test_Field_interface(KK)
-  #test_Field_interface_recursive(KK)  # FIXME: lots of ambiguity errors
+  ConformanceTests.test_Field_interface(KK)
+  #ConformanceTests.test_Field_interface_recursive(KK)  # FIXME: lots of ambiguity errors
 end
 
 @testset "fraction fields of varieties" begin

--- a/test/Groups/conformance.jl
+++ b/test/Groups/conformance.jl
@@ -8,8 +8,8 @@ end
 
 @testset "GAPGroups_interface_conformance $G of type $(typeof(G))" for G in L
 
-   test_Group_interface(G)
-   test_GroupElem_interface(rand(G, 2)...)
+   ConformanceTests.test_Group_interface(G)
+   ConformanceTests.test_GroupElem_interface(rand(G, 2)...)
 
    # TODO: move most of the following to AbstractAlgebra.jl/test/Groups-conformance-tests.jl
 

--- a/test/Groups/conformance.jl
+++ b/test/Groups/conformance.jl
@@ -1,17 +1,11 @@
 L = [ alternating_group(5), cyclic_group(18), SL(3,3), free_group(0), free_group(1), free_group(2) ]
 
-if !isdefined(Main, :test_Group_interface)
-  import Oscar.AbstractAlgebra
-  import Oscar.AbstractAlgebra: Group
-  include(joinpath(dirname(pathof(AbstractAlgebra)), "..", "test", "Groups-conformance-tests.jl"))
-end
-
 @testset "GAPGroups_interface_conformance $G of type $(typeof(G))" for G in L
 
    ConformanceTests.test_Group_interface(G)
    ConformanceTests.test_GroupElem_interface(rand(G, 2)...)
 
-   # TODO: move most of the following to AbstractAlgebra.jl/test/Groups-conformance-tests.jl
+   # TODO: move most of the following to AbstractAlgebra.jl/ext/TestExt/Groups-conformance-tests.jl
 
    g, h = rand(G,2)
 

--- a/test/LieTheory/RootSystem.jl
+++ b/test/LieTheory/RootSystem.jl
@@ -13,10 +13,6 @@
   end
 
   @testset "property tests" begin
-    Main.equality(a::RootSpaceElem, b::RootSpaceElem) = a == b
-    Main.equality(a::DualRootSpaceElem, b::DualRootSpaceElem) = a == b
-    Main.equality(a::WeightLatticeElem, b::WeightLatticeElem) = a == b
-
     function root_system_property_tests(R::RootSystem, rk::Int, npositive_roots::Int)
       W = weyl_group(R)
 
@@ -137,22 +133,30 @@
           b = T(R, rand(-10:10, rk))
           n = rand(-10:10)
 
-          test_mutating_op_like_zero(zero, zero!, a)
+          ConformanceTests.test_mutating_op_like_zero(zero, zero!, a)
 
-          test_mutating_op_like_neg(-, neg!, a)
+          ConformanceTests.test_mutating_op_like_neg(-, neg!, a)
 
-          test_mutating_op_like_add(+, add!, a, b)
-          test_mutating_op_like_add(-, sub!, a, b)
+          ConformanceTests.test_mutating_op_like_add(+, add!, a, b)
+          ConformanceTests.test_mutating_op_like_add(-, sub!, a, b)
 
-          test_mutating_op_like_add(*, mul!, a, n, T)
-          test_mutating_op_like_add(*, mul!, n, a, T)
-          test_mutating_op_like_add(*, mul!, a, ZZ(n), T)
-          test_mutating_op_like_add(*, mul!, ZZ(n), a, T)
+          ConformanceTests.test_mutating_op_like_add(*, mul!, a, n, T)
+          ConformanceTests.test_mutating_op_like_add(*, mul!, n, a, T)
+          ConformanceTests.test_mutating_op_like_add(*, mul!, a, ZZ(n), T)
+          ConformanceTests.test_mutating_op_like_add(*, mul!, ZZ(n), a, T)
 
-          test_mutating_op_like_addmul((a, b, c) -> a + b * c, addmul!, a, b, n, T)
-          test_mutating_op_like_addmul((a, b, c) -> a + b * c, addmul!, a, n, b, T)
-          test_mutating_op_like_addmul((a, b, c) -> a + b * c, addmul!, a, b, ZZ(n), T)
-          test_mutating_op_like_addmul((a, b, c) -> a + b * c, addmul!, a, ZZ(n), b, T)
+          ConformanceTests.test_mutating_op_like_addmul(
+            (a, b, c) -> a + b * c, addmul!, a, b, n, T
+          )
+          ConformanceTests.test_mutating_op_like_addmul(
+            (a, b, c) -> a + b * c, addmul!, a, n, b, T
+          )
+          ConformanceTests.test_mutating_op_like_addmul(
+            (a, b, c) -> a + b * c, addmul!, a, b, ZZ(n), T
+          )
+          ConformanceTests.test_mutating_op_like_addmul(
+            (a, b, c) -> a + b * c, addmul!, a, ZZ(n), b, T
+          )
         end
       end
     end

--- a/test/LieTheory/WeylGroup.jl
+++ b/test/LieTheory/WeylGroup.jl
@@ -94,8 +94,8 @@
     ),
   ]
     # TODO: make this work
-    # test_Group_interface(W)
-    # test_GroupElem_interface(rand(W, 2)...)
+    # ConformanceTests.test_Group_interface(W)
+    # ConformanceTests.test_GroupElem_interface(rand(W, 2)...)
   end
 
   @testset "<(x::WeylGroupElem, y::WeylGroupElem)" begin

--- a/test/LieTheory/setup_tests.jl
+++ b/test/LieTheory/setup_tests.jl
@@ -1,18 +1,3 @@
-if !isdefined(Main, :test_mutating_op_like_zero)
-  import Oscar.AbstractAlgebra
-  include(
-    joinpath(pathof(AbstractAlgebra), "..", "..", "test", "Rings-conformance-tests.jl")
-  )
-end
-
-if !isdefined(Main, :test_Group_interface)
-  import Oscar.AbstractAlgebra
-  import Oscar.AbstractAlgebra: Group
-  include(
-    joinpath(pathof(AbstractAlgebra), "..", "..", "test", "Groups-conformance-tests.jl")
-  )
-end
-
 if !isdefined(Main, :GAPWrap)
   import Oscar: GAPWrap
 end

--- a/test/Rings/AbelianClosure.jl
+++ b/test/Rings/AbelianClosure.jl
@@ -7,7 +7,7 @@ end
 @testset "AbelianClosure" begin
   @testset "Interface" begin
     K, z = abelian_closure(QQ)
-    test_Field_interface(K)
+    ConformanceTests.test_Field_interface(K)
   end
 
   @testset "Creation" begin

--- a/test/Rings/AbelianClosure.jl
+++ b/test/Rings/AbelianClosure.jl
@@ -1,9 +1,3 @@
-function test_elem(K::QQAbField)
-  ns = rand(1:8, 3)
-  zs = map(n -> sum(rand(-10:10) * gen(K)(n)^rand(1:n) for j in 1:10), ns)
-  return sum(zs)
-end
-
 @testset "AbelianClosure" begin
   @testset "Interface" begin
     K, z = abelian_closure(QQ)

--- a/test/Rings/AlgClosureFp.jl
+++ b/test/Rings/AlgClosureFp.jl
@@ -7,7 +7,7 @@ end
 @testset "AlgClosureFp" begin
   @testset "Interface for $F" for F in [GF(3, 1), Nemo.Native.GF(3, 1)]
     K = algebraic_closure(GF(3,1))
-    test_Field_interface(K)
+    ConformanceTests.test_Field_interface(K)
   end
 
   @testset "Creation for $F" for F in [GF(3, 1), Nemo.Native.GF(3, 1)]

--- a/test/Rings/AlgClosureFp.jl
+++ b/test/Rings/AlgClosureFp.jl
@@ -1,9 +1,3 @@
-function test_elem(K::AlgClosure{T}) where T <: FinField
-  d = rand(1:8)
-  F = ext_of_degree(K, d)
-  return K(rand(F))
-end
-
 @testset "AlgClosureFp" begin
   @testset "Interface for $F" for F in [GF(3, 1), Nemo.Native.GF(3, 1)]
     K = algebraic_closure(GF(3,1))
@@ -91,9 +85,9 @@ end
     a = one(K)
     @test isone(inv(a))
     for i in 1:10
-      a = test_elem(K)
-      b = test_elem(K)
-      c = test_elem(K)
+      a = ConformanceTests.generate_element(K)
+      b = ConformanceTests.generate_element(K)
+      c = ConformanceTests.generate_element(K)
       @test iszero(a - a)
       @test iszero(a + (-a))
       @test a * (b + c) == a*b + a*c
@@ -116,7 +110,7 @@ end
   @testset "Ad hoc operations for $F1" for F1 in [GF(3, 1), Nemo.Native.GF(3, 1)]
     K = algebraic_closure(F1)
     for i in 1:10
-      a = test_elem(K)
+      a = ConformanceTests.generate_element(K)
       for T in [Int, BigInt, ZZRingElem]
         b = rand(-10:10)
         @test a * b == a * K(b)

--- a/test/Rings/PBWAlgebraQuo.jl
+++ b/test/Rings/PBWAlgebraQuo.jl
@@ -1,8 +1,3 @@
-function test_elem(Q::PBWAlgQuo{QQFieldElem})
-  R = base_ring(Q)
-  return Q(R(rand(base_ring(R), 1:4, 1:4, 1:4)))
-end
-
 @testset "PBWAlgebraQuo.constructor" begin
   r, (x, y, z) = QQ[:x, :y, :z]
   R, (x, y, z) = pbw_algebra(r, [0 x*y x*z; 0 0 y*z + 1; 0 0 0], deglex(r))

--- a/test/Rings/PBWAlgebraQuo.jl
+++ b/test/Rings/PBWAlgebraQuo.jl
@@ -35,7 +35,7 @@ end
   rel = @pbw_relations(e*f == f*e-h, e*h == h*e+2*e, f*h == h*f-2*f)
   R, (a, h, f, e) = pbw_algebra(r, rel, invlex(r))
   Q, _ = quo(R, two_sided_ideal(R, [h]))
-  test_NCRing_interface(Q; reps = 1)
+  ConformanceTests.test_NCRing_interface(Q; reps = 1)
 end
 
 @testset "PBWAlgebraQuo.conversion" begin

--- a/test/Rings/mpoly-localizations.jl
+++ b/test/Rings/mpoly-localizations.jl
@@ -201,9 +201,9 @@ end
 # T = Oscar.MPolyComplementOfKPointIdeal(R, [kk(125), kk(-45)])
 # U = Oscar.MPolyComplementOfPrimeIdeal(I)
 #
-# test_Ring_interface_recursive(localization(S)[1])
-# test_Ring_interface_recursive(localization(T)[1])
-# test_Ring_interface_recursive(localization(U)[1])
+# ConformanceTests.test_Ring_interface_recursive(localization(S)[1])
+# ConformanceTests.test_Ring_interface_recursive(localization(T)[1])
+# ConformanceTests.test_Ring_interface_recursive(localization(U)[1])
 
 # should be unnecessary: https://github.com/oscar-system/Oscar.jl/pull/1459#issuecomment-1230185617
 #  AbstractAlgebra.promote_rule(::Type{fpMPolyRingElem}, ::Type{ZZRingElem}) = fpMPolyRingElem
@@ -225,9 +225,9 @@ end
   T = Oscar.MPolyComplementOfKPointIdeal(R, [kk(125), kk(-45)])
   U = Oscar.MPolyComplementOfPrimeIdeal(I)
 
-  test_Ring_interface_recursive(localization(S)[1])
-  test_Ring_interface_recursive(localization(T)[1])
-  test_Ring_interface_recursive(localization(U)[1])
+  ConformanceTests.test_Ring_interface_recursive(localization(S)[1])
+  ConformanceTests.test_Ring_interface_recursive(localization(T)[1])
+  ConformanceTests.test_Ring_interface_recursive(localization(U)[1])
 
 # kk = ZZ
 # R, v = kk[:x, :y]
@@ -241,9 +241,9 @@ end
 # S = Oscar.MPolyPowersOfElement(R, d)
 # U = Oscar.MPolyComplementOfPrimeIdeal(I)
 #
-# test_Ring_interface_recursive(localization(S)[1])
-# test_Ring_interface_recursive(localization(T)[1])
-# test_Ring_interface_recursive(localization(U)[1])
+# ConformanceTests.test_Ring_interface_recursive(localization(S)[1])
+# ConformanceTests.test_Ring_interface_recursive(localization(T)[1])
+# ConformanceTests.test_Ring_interface_recursive(localization(U)[1])
 end
 
 @testset "localization_at_orderings_1" begin

--- a/test/Rings/mpoly-localizations.jl
+++ b/test/Rings/mpoly-localizations.jl
@@ -182,11 +182,6 @@ end
   @test psi(U(-1//f))==one(codomain(psi))
 end
 
-function test_elem(W::Oscar.MPolyLocRing) 
-  f = rand(rng, W, 0:3, 0:4, 0:3)
-  return f
-end
-
 @testset "Ring interface for localized polynomial rings" begin
 # kk = QQ
 # R, v = kk[:x, :y]

--- a/test/Rings/setup_tests.jl
+++ b/test/Rings/setup_tests.jl
@@ -1,4 +1,0 @@
-if !isdefined(Main, :test_Field_interface) || !isdefined(Main, :test_NCRing_interface)
-  import Oscar.AbstractAlgebra
-  include(joinpath(pathof(AbstractAlgebra), "..", "..", "test", "Rings-conformance-tests.jl"))
-end


### PR DESCRIPTION
Make use of the new submodule structure and names introduced in https://github.com/Nemocas/AbstractAlgebra.jl/pull/1954.