### PR TITLE
Tweak PrincipalOpenSubset to avoid Julia nightly CI hangs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,8 +107,6 @@ jobs:
         if: matrix.julia-version == '1.6' && runner.os == 'Linux'
         run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Run tests"
-        # skip tests for push and pull_request events for short group on julia 1.12-nightly and nightly (see https://github.com/oscar-system/Oscar.jl/issues/4604)
-        if: (github.event_name != 'push' && github.event_name != 'pull_request') || (matrix.julia-version != '1.12-nightly' && matrix.julia-version != 'nightly') || matrix.group != 'short'
         uses: julia-actions/julia-runtest@latest
         with:
           annotate: ${{ matrix.julia-version == '1.10' }}

--- a/src/AlgebraicGeometry/Schemes/PrincipalOpenSubset/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/PrincipalOpenSubset/Objects/Attributes.jl
@@ -18,7 +18,7 @@ function complement_equation(U::PrincipalOpenSubset)
   if !isdefined(U, :h)
     U.h = prod(OO(U).(U.f); init=one(OO(U)))
   end
-  return U.h::elem_type(OO(ambient_scheme(U)))
+  return U.h  # ::elem_type(OO(ambient_scheme(U)))
 end
 
 # An internal getter to get factors of polynomial representatives of the complement equation's numerator.

--- a/src/AlgebraicGeometry/Schemes/PrincipalOpenSubset/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/PrincipalOpenSubset/Objects/Methods.jl
@@ -57,13 +57,11 @@ in the sense that the maximal extension of its restriction
 to ``U`` returns ``a``.
 """
 function generic_fraction(a::MPolyLocRingElem, U::PrincipalOpenSubset)
-  X = ambient_scheme(U)
   parent(a) == OO(U) || error("domains are not compatible")
   return lifted_numerator(a)//lifted_denominator(a)
 end
 
 function generic_fraction(a::MPolyQuoLocRingElem, U::PrincipalOpenSubset)
-  X = ambient_scheme(U)
   parent(a) == OO(U) || error("domains are not compatible")
   return lifted_numerator(a)//lifted_denominator(a)
 end

--- a/src/AlgebraicGeometry/Schemes/PrincipalOpenSubset/Objects/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/PrincipalOpenSubset/Objects/Types.jl
@@ -1,8 +1,8 @@
 ########################################################################
 # Principal open subsets of affine schemes                             #
 ########################################################################
-@attributes mutable struct PrincipalOpenSubset{BRT, RT<:Ring, AmbientType} <: AbsAffineScheme{BRT, RT}
-  X::AmbientType
+@attributes mutable struct PrincipalOpenSubset{BRT, RT<:Ring} <: AbsAffineScheme{BRT, RT}
+  X::AbsAffineScheme
   U::AffineScheme{BRT, RT}
   f::Vector{<:MPolyRingElem} # factors of a representative of the complement equation
   h::RingElem # The equation in the ambient scheme defining the complement of this
@@ -12,13 +12,13 @@
   function PrincipalOpenSubset(X::AbsAffineScheme, f::RingElem)
     parent(f) == OO(X) || error("element does not belong to the correct ring")
     U = hypersurface_complement(X, [f])
-    return new{base_ring_type(X), ring_type(U), typeof(X)}(X, U, [lifted_numerator(f)], f)
+    return new{base_ring_type(X), ring_type(U)}(X, U, [lifted_numerator(f)], f)
   end
 
   function PrincipalOpenSubset(X::AbsAffineScheme, f::Vector{<:RingElem})
     all(x->(parent(x) == OO(X)), f) || return PrincipalOpenSubset(X, OO(X).(f))
     U = hypersurface_complement(X, f)
-    return new{base_ring_type(X), ring_type(U), typeof(X)}(X, U, lifted_numerator.(f), (length(f)>0 ? OO(X)(prod(lifted_numerator.(f))) : one(OO(X))))
+    return new{base_ring_type(X), ring_type(U)}(X, U, lifted_numerator.(f), (length(f)>0 ? OO(X)(prod(lifted_numerator.(f))) : one(OO(X))))
   end
 
   # The following constructors allow to pass a ring as an extra argument.
@@ -28,7 +28,7 @@
     )
     U = spec(R)
     @check U == hypersurface_complement(X, f) "scheme is not isomorphic to the anticipated open subset"
-    return new{base_ring_type(X), ring_type(U), typeof(X)}(X, U, lifted_numerator.(f))
+    return new{base_ring_type(X), ring_type(U)}(X, U, lifted_numerator.(f))
   end
   function PrincipalOpenSubset(X::AbsAffineScheme, R::Ring, f::Vector{T};
       check::Bool=true
@@ -38,7 +38,7 @@
         d = prod(length(f) > 0 ? f : one(OO(X)))
         U == hypersurface_complement(X, d)
     end
-    return new{base_ring_type(X), ring_type(U), typeof(X)}(X, U, lifted_numerator.(f))
+    return new{base_ring_type(X), ring_type(U)}(X, U, lifted_numerator.(f))
   end
   function PrincipalOpenSubset(X::AbsAffineScheme, U::AbsAffineScheme, f::Vector{T};
       check::Bool=true
@@ -47,7 +47,7 @@
         d = prod(length(f) > 0 ? f : one(OO(X)))
         U == hypersurface_complement(X, d)
     end
-    return new{base_ring_type(X), ring_type(U), typeof(X)}(X, U, lifted_numerator.(f))
+    return new{base_ring_type(X), ring_type(U)}(X, U, lifted_numerator.(f))
   end
 end
 


### PR DESCRIPTION
See https://github.com/juliaLang/julia/issues/57098 for background.

Locally this change "works" for me in that it resolves the hang in the code snippet in the linked issue. But I did not test it with the full test suite, so other instances of this issue (or completely other problems) may show up in the CI run for this PR.

Note: I suspect the changes in this PR are beneficial regardless of the Julia regression discussed there: each time a different parametrization for `PrincipalOpenSubset` is used we have to compile new versions of functions that interact with instances of that. This is rather expensive.

