### PR TITLE
Remove some uses of gap_to_julia

### DIFF
--- a/experimental/GModule/src/Cohomology.jl
+++ b/experimental/GModule/src/Cohomology.jl
@@ -1904,7 +1904,7 @@ function pc_group_with_isomorphism(M::FinGenAbGroup; refine::Bool = true)
   B = pc_group(C)
   FB = GAP.Globals.FamilyObj(GAP.Globals.Identity(GapObj(B)))
 
-  Julia_to_gap = function(a::FinGenAbGroupElem)
+  function Julia_to_gap(a::FinGenAbGroupElem)
     r = ZZRingElem[]
     for i=1:ngens(M)
       if !iszero(a[i])
@@ -1915,7 +1915,7 @@ function pc_group_with_isomorphism(M::FinGenAbGroup; refine::Bool = true)
     return GAP.Globals.ObjByExtRep(FB, GAP.Obj(r; recursive = true))
   end
 
-  gap_to_julia = function(a::GapObj)
+  function Gap_to_julia(a::GapObj)
     e = GAPWrap.ExtRepOfObj(a)
     z = zeros(ZZRingElem, ngens(M))
     for i=1:2:length(e)
@@ -1931,7 +1931,7 @@ function pc_group_with_isomorphism(M::FinGenAbGroup; refine::Bool = true)
   return B, MapFromFunc(
     codomain(mM), B,
     y->PcGroupElem(B, Julia_to_gap(preimage(mM, y))),
-    x->image(mM, gap_to_julia(GapObj(x))))
+    x->image(mM, Gap_to_julia(GapObj(x))))
 end
 
 # `refine` is irrelevant because `M` is elementary abelian.

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -1143,7 +1143,7 @@ function isomorphism(::Type{T}, M::S; on_gens::Bool=true) where T <: Union{FPGro
       end
 
       # group to module
-      gap_to_julia = function(a::GapObj)
+      function Gap_to_julia(a::GapObj)
         e = GAPWrap.ExtRepOfObj(a)
         z = zeros(ZZRingElem, ngens(M)*degree(k))
         for i=1:2:length(e)
@@ -1162,7 +1162,7 @@ function isomorphism(::Type{T}, M::S; on_gens::Bool=true) where T <: Union{FPGro
         return MapFromFunc(
           M, B,
           y -> PcGroupElem(B, GAPWrap.ObjByExtRep(FB, Julia_to_gap(y))),
-          x -> gap_to_julia(GapObj(x)))
+          x -> Gap_to_julia(GapObj(x)))
       else
         # We need an indirection: First create the word in the free group,
         # then wrap it into an element of the f.p. group.
@@ -1171,7 +1171,7 @@ function isomorphism(::Type{T}, M::S; on_gens::Bool=true) where T <: Union{FPGro
         return MapFromFunc(
           M, B,
           y -> FPGroupElem(B, GAPWrap.ElementOfFpGroup(FB, GAPWrap.ObjByExtRep(FR, Julia_to_gap(y)))),
-          x -> gap_to_julia(GapObj(x)))
+          x -> Gap_to_julia(GapObj(x)))
       end
    end::MapFromFunc{S, T}
 end

--- a/src/Groups/pcgroup.jl
+++ b/src/Groups/pcgroup.jl
@@ -628,6 +628,18 @@ end
 
 # Create an Oscar collector from a GAP collector.
 
+const SCP_UNDERLYING_FAMILY = GAP.Globals.SCP_UNDERLYING_FAMILY             # = 1 - the family of our free grp elms
+const SCP_RWS_GENERATORS = GAP.Globals.SCP_RWS_GENERATORS                   # = 2 - the free grp generators used
+const SCP_NUMBER_RWS_GENERATORS = GAP.Globals.SCP_NUMBER_RWS_GENERATORS     # = 3 - number of generators
+const SCP_DEFAULT_TYPE = GAP.Globals.SCP_DEFAULT_TYPE                       # = 4 - default type of the result
+const SCP_IS_DEFAULT_TYPE = GAP.Globals.SCP_IS_DEFAULT_TYPE                 # = 5 - tester for default type
+const SCP_RELATIVE_ORDERS = GAP.Globals.SCP_RELATIVE_ORDERS                 # = 6 - list of relative orders
+const SCP_POWERS = GAP.Globals.SCP_POWERS                                   # = 7 - list of power rhs
+const SCP_CONJUGATES = GAP.Globals.SCP_CONJUGATES                           # = 8 - list of list of conjugates rhs
+const SCP_INVERSES = GAP.Globals.SCP_INVERSES                               # = 9 - list of inverses of the gens
+const SCP_COLLECTOR = GAP.Globals.SCP_COLLECTOR                             # = 10 - collector to use
+const SCP_AVECTOR = GAP.Globals.SCP_AVECTOR                                 # = 11 - avector
+
 """
     collector([::Type{T} = ZZRingElem, ]G::PcGroup) where T <: IntegerUnion
 
@@ -651,12 +663,12 @@ function collector(::Type{T}, G::PcGroup) where T <: IntegerUnion
   Fam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(GapObj(G)))
   GapC = GAP.getbangproperty(Fam, :rewritingSystem)::GapObj
 
-  n = GAP.getbangindex(GapC, 3)::Int
+  n = GAP.getbangindex(GapC, SCP_NUMBER_RWS_GENERATORS)::Int
   c = collector(n, T)
 
-  c.relorders = Vector{T}(GAP.getbangindex(GapC, 6)::GapObj)
+  c.relorders = Vector{T}(GAP.getbangindex(GapC, SCP_RELATIVE_ORDERS)::GapObj)
 
-  Gap_powers = GAP.gap_to_julia(GAP.getbangindex(GapC, 7)::GapObj, recursive = false)
+  Gap_powers = Vector{Union{Nothing, GapObj}}(GAP.getbangindex(GapC, SCP_POWERS)::GapObj, recursive = false)
   for i in 1:length(Gap_powers)
     if Gap_powers[i] !== nothing
       l = GAPWrap.ExtRepOfObj(Gap_powers[i])
@@ -664,12 +676,11 @@ function collector(::Type{T}, G::PcGroup) where T <: IntegerUnion
     end
   end
 
-  Gap_conj = GAP.gap_to_julia(GAP.getbangindex(GapC, 8)::GapObj, recursive = false)
+  Gap_conj = Vector{Vector{Union{Nothing, GapObj}}}(GAP.getbangindex(GapC, SCP_CONJUGATES)::GapObj)
   for i in 1:length(Gap_conj)
-    Gap_conj_i = GAP.gap_to_julia(Gap_conj[i]::GapObj, recursive = false)
-    for j in 1:length(Gap_conj_i)
-      if Gap_conj_i[j] !== nothing
-        l = GAPWrap.ExtRepOfObj(Gap_conj_i[j])
+    for j in 1:length(Gap_conj[i])
+      if Gap_conj[i][j] !== nothing
+        l = GAPWrap.ExtRepOfObj(Gap_conj[i][j])
         c.conjugates[j,i] = Pair{Int,T}[l[k-1] => T(l[k]) for k in 2:2:length(l)]
       end
     end


### PR DESCRIPTION
Also rename a couple functions called gap_to_julia to Gap_to_julia to avoid confusion.

Ideally I'd like to phase out `gap_to_julia` in a future (breaking) GAP.jl release. Getting rid of all callers to it is an obvious first step (we already achieved this for `julia_to_gap`).