### PR TITLE
Allow sorting w.r.t. monomial orderings / module orderings

### DIFF
--- a/experimental/BasisLieHighestWeight/src/MainAlgorithm.jl
+++ b/experimental/BasisLieHighestWeight/src/MainAlgorithm.jl
@@ -58,7 +58,7 @@ function basis_lie_highest_weight_compute(
     calc_highest_weight,
     no_minkowski,
   )
-  # monomials = sort(collect(monomials); lt=((m1, m2) -> cmp(monomial_ordering, m1, m2) < 0))
+  # monomials = sort(collect(monomials); order=monomial_ordering)
   minkowski_gens = sort(
     collect(no_minkowski);
     by=(gen -> (sum(coefficients(gen)), reverse(Oscar._vec(coefficients(gen))))),
@@ -139,7 +139,7 @@ function basis_coordinate_ring_kodaira_compute(
       monomials_new = setdiff(monomials, monomials_minkowski_sum)
       @vprintln :BasisLieHighestWeight "for $(Int.(i * highest_weight)) we added $(length(monomials_new)) monomials "
 
-      # monomials = sort(collect(monomials); lt=((m1, m2) -> cmp(monomial_ordering, m1, m2) < 0))
+      # monomials = sort(collect(monomials); order=monomial_ordering)
       minkowski_gens = sort(
         collect(no_minkowski);
         by=(gen -> (sum(coefficients(gen)), reverse(Oscar._vec(coefficients(gen))))),
@@ -151,7 +151,7 @@ function basis_coordinate_ring_kodaira_compute(
     )
     set_attribute!(mb, :algorithm => basis_coordinate_ring_kodaira_compute)
     monomials_new_sorted = sort(
-      collect(monomials_new); lt=((m1, m2) -> cmp(monomial_ordering, m1, m2) < 0)
+      collect(monomials_new); order=monomial_ordering
     )
     if isempty(monomials_new)
       set_attribute!(
@@ -291,9 +291,7 @@ function add_new_monomials!(
     ),
   )
   isempty(poss_mon_in_weightspace) && error("The input seems to be invalid.")
-  poss_mon_in_weightspace = sort(
-    poss_mon_in_weightspace; lt=((m1, m2) -> cmp(monomial_ordering, m1, m2) < 0)
-  )
+  poss_mon_in_weightspace = sort(poss_mon_in_weightspace; order=monomial_ordering)
 
   # check which monomials should get added to the basis
   i = 0

--- a/src/Rings/mpoly-affine-algebras.jl
+++ b/src/Rings/mpoly-affine-algebras.jl
@@ -1123,7 +1123,7 @@ function _subalgebra_membership_homogeneous_internal(f::MPolyDecRingElem, RtoT::
   # f is in the subalgebra iff nf does not involve the variables
   # gen(T, 1), ..., gen(T, ngens(R)), that is, iff LM(nf) is strictly smaller
   # than gen(T, ngens(R)) w.r.t. the block ordering o.
-  if isone(cmp(o, gen(T, ngens(R)), leading_monomial(nf, ordering = o)))
+  if cmp(o, gen(T, ngens(R)), leading_monomial(nf, ordering = o)) > 0
     return true, TtoS(nf)
   else
     return false, zero(S)

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -496,7 +496,7 @@ function eliminate(I::MPolyIdeal, l::AbstractVector{Int})
 end
 function eliminate(I::MPolyIdeal, o::MonomialOrdering, l::Int)
   R = base_ring(I)
-  R_gens = sort(gens(R); lt = (x, y) -> cmp(o, x, y) > 0)[1:l]
+  R_gens = sort(gens(R); order=o, rev=true)[1:l]
   @req is_elimination_ordering(o, R_gens) "Given ordering is not an elimination ordering"
   gb = get(I.gb, o, nothing)
   isnothing(gb) && return eliminate(I, R_gens)

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -178,7 +178,7 @@ end
 """
 Orderings actually applied to polynomial rings (as opposed to variable indices)
 """
-mutable struct MonomialOrdering{S}
+mutable struct MonomialOrdering{S} <: Base.Order.Ordering
   R::S
   o::AbsGenOrdering
   is_total::Bool
@@ -197,6 +197,8 @@ end
 base_ring(a::MonomialOrdering) = a.R
 
 base_ring_type(::Type{MonomialOrdering{S}}) where {S} = S
+
+Base.lt(ord::MonomialOrdering, a, b) = cmp(ord, a, b) < 0
 
 @doc raw"""
     support(o::MonomialOrdering)
@@ -1566,7 +1568,7 @@ and `1` for `a > b` and `0` for `a == b`. An error is thrown if `ord` is
 a partial ordering that does not distinguish `a` from `b`.
 
 Sorting some vector `v` of monomials with respect to `ord` can be done with
-`sort(v; lt=((m1, m2) -> cmp(o, m1, m2) < 0))`.
+`sort(v; order=ord)`.
 
 # Examples
 ```jldoctest
@@ -1764,7 +1766,7 @@ struct ModOrdering{T <: AbstractVector{Int}} <: AbsModOrdering
   ord::Symbol
 end
 
-mutable struct ModuleOrdering{S}
+mutable struct ModuleOrdering{S} <: Base.Order.Ordering
   M::S
   o::AbsModOrdering # must allow gen*mon or mon*gen product ordering
 
@@ -1778,6 +1780,8 @@ end
 base_ring(a::ModuleOrdering) = a.M
 
 base_ring_type(::Type{ModuleOrdering{S}}) where {S} = S
+
+Base.lt(ord::ModuleOrdering, a, b) = cmp(ord, a, b) < 0
 
 struct ModProdOrdering{A <: AbsOrdering, B <: AbsOrdering} <: AbsModOrdering
   a::A

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -1565,6 +1565,9 @@ Compare monomials `a` and `b` with regard to the ordering `ord`: Return `-1` for
 and `1` for `a > b` and `0` for `a == b`. An error is thrown if `ord` is
 a partial ordering that does not distinguish `a` from `b`.
 
+Sorting some vector `v` of monomials with respect to `ord` can be done with
+`sort(v; lt=((m1, m2) -> cmp(o, m1, m2) < 0))`.
+
 # Examples
 ```jldoctest
 julia> R, (x, y, z) = polynomial_ring(QQ, [:x, :y, :z]);

--- a/src/TropicalGeometry/groebner_fan.jl
+++ b/src/TropicalGeometry/groebner_fan.jl
@@ -294,7 +294,7 @@ function interreduce(G::Vector{<:MPolyRingElem}, ord::MonomialOrdering)
     # then reduce G[i] by G[1:i-1] for i=length(G),...,2
     sort!(G,
           by=g->leading_monomial(g,ordering=ord),
-          lt=(f,g)->(cmp(ord,f,g)<0))
+          order=ord)
     for i in 2:length(G)
         G[i] = reduce(G[i],G[1:i-1],ordering=ord,complete_reduction=true)
     end


### PR DESCRIPTION
From slack:

> @fingolfin : hmmm... should we perhaps define something like `isless(ord) = (m1, m2) -> cmp(o, m1, m2) < 0` to make such things more convenient? So one can write `sort(G; lt=isless(o))` But perhaps I am over-engineering again :slightly_smiling_face:

> @lgoettgens : That could break a lot of generic julia code, as that may expect isless to compare its arguments directly. So we would need a different name for that. But what we definitely could do, is add this line of code to the docstring of cmp

I opened this to not forget. If people have ideas what to do here, please chime in. (tagging triage to ask there for ideas)