### PR TITLE
Move a function to MoveToAbstractAlgebra.jl

### DIFF
--- a/src/Misc/MoveToAbstractAlgebra.jl
+++ b/src/Misc/MoveToAbstractAlgebra.jl
@@ -55,3 +55,7 @@ function Base.copy(f::MPolyRingElem)
   end
   return finish(g)
 end
+
+function (a::Generic.RationalFunctionFieldElem)(b::RingElem)
+  return divexact(numerator(a)(b), denominator(a)(b))
+end

--- a/src/NumberTheory/GaloisGrp/Qt.jl
+++ b/src/NumberTheory/GaloisGrp/Qt.jl
@@ -669,10 +669,6 @@ function isinteger(G::GaloisCtx, B::BoundRingElem{Tuple{ZZRingElem, Int, QQField
   return true, f(gen(parent(f))-G.data[2]) #.. and unshift
 end
 
-function (a::Generic.RationalFunctionFieldElem)(b::RingElem)
-  return divexact(numerator(a)(b), denominator(a)(b))
-end
-
 function Hecke.newton_polygon(f::Generic.Poly{<:Generic.RationalFunctionFieldElem{QQFieldElem}})
   pt = Tuple{Int, Int}[]
   for i=0:degree(f)


### PR DESCRIPTION
Evaluating a rational function seems natural enough, but
implementing it here is type piracy.
