### PR TITLE
Add cross-references to `demazure_character` docstrings

### DIFF
--- a/docs/src/PolyhedralGeometry/Polyhedra/auxiliary.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/auxiliary.md
@@ -55,6 +55,7 @@ all_triangulations
 boundary_lattice_points(P::Polyhedron{QQFieldElem})
 Base.in(v::AbstractVector, P::Polyhedron)
 Base.issubset(P::Polyhedron{T}, Q::Polyhedron{T}) where T<:scalar_types
+demazure_character(lambda::AbstractVector, sigma::PermGroupElem)
 ehrhart_polynomial(P::Polyhedron{QQFieldElem})
 ehrhart_polynomial(R::QQPolyRing, P::Polyhedron{QQFieldElem})
 h_star_polynomial(P::Polyhedron{QQFieldElem})

--- a/experimental/LieAlgebras/src/SSLieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/SSLieAlgebraModule.jl
@@ -618,6 +618,9 @@ or its root system.
 Instead of a Weyl group element `x`, a reduced expression for `x` can be supplied.
 This function may return arbitrary results if the provided expression is not reduced.
 
+For Demazure characters of generalized flag manifolds, as in [PS09](@cite),
+see [`demazure_character(::AbstractVector, ::PermGroupElem)`](@ref).
+
 # Examples
 ```jldoctest
 julia> L = lie_algebra(QQ, :A, 2);

--- a/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
+++ b/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
@@ -1072,6 +1072,10 @@ gelfand_tsetlin_polytope(lambda::AbstractVector) = Polyhedron{QQFieldElem}(
 Construct the Demazure character indexed by a weakly decreasing vector `lambda` and a permutation `sigma`.
 - [PS09](@cite)
 
+For Demazure characters as in [Dem74](@cite),
+i.e. the weights with multiplicities occurring in a Demazure module of a semisimple Lie algebra,
+see [`demazure_character(::LieAlgebra, ::WeightLatticeElem, ::WeylGroupElem)`](@ref).
+
 # Examples
 ```jldoctest
 julia> lambda = partition([3,1,1])


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/4373.

I noticed that the docstring of the polyhedral geometry version was not included in the manual at all, thus making the cross-reference fail. Therefore, I included it at a more or less arbitrary place.
@micjoswig @tbrysiewicz please have a look if this is a suitable place to put it, or if not point me to where else. 

cc @fingolfin 