### PR TITLE
Remove `NoExperimentalCI/docs` job

### DIFF
--- a/.github/workflows/NoExperimental.yml
+++ b/.github/workflows/NoExperimental.yml
@@ -85,19 +85,3 @@ jobs:
               using Oscar
               DocMeta.setdocmeta!(Oscar, :DocTestSetup, Oscar.doctestsetup(); recursive = true)
               doctest(Oscar)'
-
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: '1.10'
-      - name: "Symlink NoExperimental_whitelist.jl"
-        run: ln -s NoExperimental_whitelist_.jl experimental/NoExperimental_whitelist.jl
-      - name: Build package
-        uses: julia-actions/julia-buildpkg@v1
-      - name: Install dependencies
-        run: julia --project=. --color=yes -e 'using Oscar; Oscar.doc_init(; path="docs/")'
-      - name: Build
-        run: julia --project=docs/ --color=yes docs/make.jl

--- a/experimental/ExteriorAlgebra/test/runtests.jl
+++ b/experimental/ExteriorAlgebra/test/runtests.jl
@@ -80,3 +80,11 @@
     @test is_zero(prod21 * fac2)
   end
 end
+
+@testset "PBWAlgebraQuo.conversion (#3133)" begin
+  # PBWAlgebraQuo with special singular sring had incorrect parent objects
+  E, _ = exterior_algebra(QQ, 3)
+  @test E() == E(0)
+  three = QQFieldElem(3)
+  @test E(three) == E(3)
+end

--- a/experimental/NoExperimental_whitelist_.jl
+++ b/experimental/NoExperimental_whitelist_.jl
@@ -2,10 +2,7 @@
 # Eventually, this list should be empty.
 whitelist = String[
   "DoubleAndHyperComplexes",    # `MethodError: no method matching simplify(::SubquoModule{MPolyQuoRingElem{MPolyDecRingElem{FqMPolyRingElem, AbstractAlgebra.Generic.MPoly{FqMPolyRingElem}}}})`
-  "ExteriorAlgebra",            # `undefined binding 'exterior_algebra' in `@docs` block in src/NoncommutativeAlgebra/PBWAlgebras/quotients.md:40-42` and `Error During Test at /home/runner/work/Oscar.jl/Oscar.jl/test/Rings/PBWAlgebraQuo.jl:41`
-  "GaloisGrp",                  # `no docs found for 'fixed_field(C::Oscar.GaloisGrp.GaloisCtx, s::Vector{PermGroup})' in `@docs` block in src/NumberTheory/galois.md:275-278`
   "GModule",                    # `MethodError: no method matching (::FinGenAbGroup)(::FinGenAbGroupElem)`
-  "InvariantTheory",            # `undefined binding 'linearly_reductive_group' in `@docs` block in src/InvariantTheory/reductive_groups.md:53-55` and more docs errors`
   "ModStd",                     # `MethodError: no method matching monomial(::QQMPolyRing, ::Vector{Int64})` and many similar errors
   "Schemes",                    # TODO: untangle src/AlgebraicGeometry/Schemes/ and experimental/Schemes/
 ]

--- a/experimental/NoExperimental_whitelist_.jl
+++ b/experimental/NoExperimental_whitelist_.jl
@@ -2,6 +2,7 @@
 # Eventually, this list should be empty.
 whitelist = String[
   "DoubleAndHyperComplexes",    # `MethodError: no method matching simplify(::SubquoModule{MPolyQuoRingElem{MPolyDecRingElem{FqMPolyRingElem, AbstractAlgebra.Generic.MPoly{FqMPolyRingElem}}}})`
+  "ExteriorAlgebra",            # `test/Modules/PBWModules.jl` calls `exterior_algebra(::Field, ::Int)`
   "GModule",                    # `MethodError: no method matching (::FinGenAbGroup)(::FinGenAbGroupElem)`
   "ModStd",                     # `MethodError: no method matching monomial(::QQMPolyRing, ::Vector{Int64})` and many similar errors
   "Schemes",                    # TODO: untangle src/AlgebraicGeometry/Schemes/ and experimental/Schemes/

--- a/test/Rings/PBWAlgebraQuo.jl
+++ b/test/Rings/PBWAlgebraQuo.jl
@@ -33,11 +33,3 @@ end
   ConformanceTests.test_NCRing_interface(Q; reps = 1)
 end
 
-@testset "PBWAlgebraQuo.conversion" begin
-  # [2023-12-21] Used to have incorrect parent object
-  E,_ = exterior_algebra(QQ,3)
-  @test  E() == E(0)
-  three = QQFieldElem(3)
-  @test  E(three) == E(3)
-end
-


### PR DESCRIPTION
This CI job was introduced in https://github.com/oscar-system/Oscar.jl/pull/3525 together with three other ones that run short tests, long tests, and doctests (respectively) without most parts of the experimental folder present.

While I still think that this is good to have for testing, I don't see that big of a reason for building the docs.
There are already multiple instances where docs pages reference experimental parts (headers, or references to docstrings) to make the reader aware of similar features, applications, etc. I don't think that we should restrict ourselves in giving such hints, just because the reference target is on an experimental docs page. Experimental docstrings are clearly distinguishable due to the warning added in https://github.com/oscar-system/Oscar.jl/pull/3709.

The current occurrences are:
- https://github.com/oscar-system/Oscar.jl/blob/ed67b2fcfe6debd8eb8d95a2218f4b686f5277cd/docs/src/NoncommutativeAlgebra/PBWAlgebras/quotients.md#L39
- https://github.com/oscar-system/Oscar.jl/blob/6238fc7d7c1f67155959fdba2b5b978afb556117/docs/src/NumberTheory/galois.md#L275
- https://github.com/oscar-system/Oscar.jl/blob/5ea63d166bd0c43f190e3c8d9c2f0e594da57026/docs/src/InvariantTheory/reductive_groups.md#L54

These current occurrences are whitelisted for the `NoExperimentalCI`, thus also blocking running the testsuite without them.

Main motivation: https://github.com/oscar-system/Oscar.jl/pull/4637 introduces cross-references between two docstrings for `demazure_character`, one in `src/PolyhedralGeometry` and the other one in `experimental/LieAlgebras`. This CI job disallows the reference from the former to the latter.

For this to be able to get merged, someone needs to adapt the list of required CI jobs (deleting this one here).

pinging some random people that might have an opinion here @benlorenz @lkastner @fingolfin , also tagging triage to mention this tomorrow