### PR TITLE
Implement `transitivity` and `rank_action` for G-sets

### DIFF
--- a/docs/src/Groups/action.md
+++ b/docs/src/Groups/action.md
@@ -68,6 +68,8 @@ orbit(Omega::GSetByElements{<:GAPGroup, S}, omega::S) where S
 orbit(G::PermGroup, omega)
 orbits(Omega::T) where T <: GSetByElements{TG} where TG <: GAPGroup
 is_transitive(Omega::GSet)
+transitivity(Omega::GSet)
+rank_action(Omega::GSet)
 is_regular(Omega::GSet)
 is_semiregular(Omega::GSet)
 ```

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -960,7 +960,7 @@ function rank_action(Omega::GSet)
 end
 
 """
-    transitivity(G::Omega)
+    transitivity(Omega::GSet)
 
 Return the maximum `k` such that group action associated with `Omega`
 acts `k`-transitively on `Omega`,

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -980,7 +980,7 @@ julia> G = symmetric_group(4); Omega = gset(G); transitivity(Omega)
 """
 function transitivity(Omega::GSet)
   acthom = action_homomorphism(Omega)
-  transitivity(image(acthom)[1])
+  return transitivity(image(acthom)[1])
 end
 
 

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -933,6 +933,58 @@ all_blocks(G::GSet) = error("not implemented")
 
 
 """
+    rank_action(Omega::GSet)
+
+Return the rank of the transitive group action associated with `Omega`.
+This is defined as the number of orbits in the action on ordered pairs
+of points in `Omega`,
+and is equal to the number of orbits of the stabilizer of a point in `Omega`
+on `Omega`, see [Cam99](@cite) Section 1.11.
+
+An exception is thrown if the group action is not transitive on `Omega`.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(4); Omega = gset(G); rank_action(Omega)  # 4-transitive
+2
+
+julia> G = dihedral_group(PermGroup, 8); Omega = gset(G); rank_action(Omega)  # not 2-transitive
+3
+```
+"""
+function rank_action(Omega::GSet)
+  @req is_transitive(Omega) "the group is not transitive"
+  @req length(Omega) != 0 "the action domain is empty"
+  H = stabilizer(Omega)[1]
+  return length(orbits(H))
+end
+
+"""
+    transitivity(G::Omega)
+
+Return the maximum `k` such that group action associated with `Omega`
+acts `k`-transitively on `Omega`,
+that is, every `k`-tuple of points in `Omega` can be mapped simultaneously
+to every other `k`-tuple by an element of the group.
+
+The output is `0` if the group acts intransitively on `Omega`.
+
+# Examples
+```jldoctest
+julia> G = mathieu_group(24); Omega = gset(G); transitivity(Omega)
+5
+
+julia> G = symmetric_group(4); Omega = gset(G); transitivity(Omega)
+4
+```
+"""
+function transitivity(Omega::GSet)
+  acthom = action_homomorphism(Omega)
+  transitivity(image(acthom))
+end
+
+
+"""
     is_transitive(Omega::GSet)
 
 Return whether the group action associated with `Omega` is transitive.

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -954,7 +954,7 @@ julia> G = dihedral_group(PermGroup, 8); Omega = gset(G); rank_action(Omega)  # 
 """
 function rank_action(Omega::GSet)
   @req is_transitive(Omega) "the group is not transitive"
-  @req length(Omega) != 0 "the action domain is empty"
+  @req !isempty(Omega) "the action domain is empty"
   H = stabilizer(Omega)[1]
   return length(orbits(H))
 end

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -939,7 +939,7 @@ Return the rank of the transitive group action associated with `Omega`.
 This is defined as the number of orbits in the action on ordered pairs
 of points in `Omega`,
 and is equal to the number of orbits of the stabilizer of a point in `Omega`
-on `Omega`, see [Cam99](@cite) Section 1.11.
+on `Omega`, see [Cam99; Section 1.11](@cite).
 
 An exception is thrown if the group action is not transitive on `Omega`.
 

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -980,7 +980,7 @@ julia> G = symmetric_group(4); Omega = gset(G); transitivity(Omega)
 """
 function transitivity(Omega::GSet)
   acthom = action_homomorphism(Omega)
-  transitivity(image(acthom))
+  transitivity(image(acthom)[1])
 end
 
 

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -260,7 +260,6 @@ end
   @test transitivity(S4, 1:4) == 4
   @test transitivity(S4, 1:5) == 0
 
-
 end
 
 @testset "G-sets of matrix groups over finite fields" begin

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -84,6 +84,8 @@
   @test ! is_primitive(Omega)
   @test ! is_regular(Omega)
   @test ! is_semiregular(Omega)
+  @test transitivity(Omega) == 0
+  @test_throws ArgumentError rank_action(Omega)
   @test_throws ArgumentError gset(G, permuted, omega)
 
   R, x = polynomial_ring(QQ, [:x1, :x2, :x3]);
@@ -98,6 +100,8 @@
   @test is_primitive(Omega)
   @test ! is_regular(Omega)
   @test ! is_semiregular(Omega)
+  @test transitivity(Omega) == 3
+  @test rank_action(Omega) == 2
 
   # seeds can be anything iterable
   G = symmetric_group(6)
@@ -249,10 +253,13 @@ end
 
   # transitivity
   @test transitivity(G8) == 1
+  @test transitivity(gset(G8)) == 1
   @test transitivity(S4) == 4
+  @test transitivity(gset(S4)) == 4
   @test_throws ArgumentError transitivity(S4, 1:3)
   @test transitivity(S4, 1:4) == 4
   @test transitivity(S4, 1:5) == 0
+
 
 end
 


### PR DESCRIPTION
Here we add some missing `GSet` functionality, namely for determining the `transitivity` and `rank_action` of a group acting on a `GSet`.