### PR TITLE
improve documentation, mainly for f.p. groups

### DIFF
--- a/docs/src/Groups/fpgroup.md
+++ b/docs/src/Groups/fpgroup.md
@@ -105,15 +105,24 @@ Group homomorphism
   to permutation group of degree 5 and order 6
 ```
 
-## Functions for (subgroups of) finitely presented groups and their elements
+## Functions for elements of (subgroups of) finitely presented groups
+
+```@docs
+letters(g::Union{FPGroupElem, SubFPGroupElem})
+syllables(g::Union{FPGroupElem, SubFPGroupElem})
+length(g::Union{FPGroupElem, SubFPGroupElem})
+map_word(g::Union{FPGroupElem, SubFPGroupElem}, genimgs::Vector; genimgs_inv::Vector = Vector(undef, length(genimgs)), init = nothing)
+```
+
+## Functions for (subgroups of) finitely presented groups
 
 ```@docs
 free_group
 @free_group
 full_group(G::Union{SubFPGroup, SubPcGroup})
 relators(G::FPGroup)
-length(g::Union{FPGroupElem, SubFPGroupElem})
-map_word(g::Union{FPGroupElem, SubFPGroupElem}, genimgs::Vector; genimgs_inv::Vector = Vector(undef, length(genimgs)), init = nothing)
+simplified_fp_group(G::FPGroup)
+epimorphism_from_free_group(G::GAPGroup)
 ```
 
 ## Technicalities

--- a/docs/src/Groups/grouphom.md
+++ b/docs/src/Groups/grouphom.md
@@ -48,8 +48,8 @@ restrict_homomorphism(f::GAPGroupHomomorphism, H::GAPGroup)
 
 OSCAR has also the following standard homomorphism.
 ```@docs
-id_hom
-trivial_morphism
+id_hom(G::GAPGroup)
+trivial_morphism(G::GAPGroup, H::GAPGroup = G)
 ```
 
 To evaluate the homomorphism `f` in the element `x` of `G`, it is possible to use the instruction
@@ -167,11 +167,4 @@ isomorphic_subgroups(H::GAPGroup, G::GAPGroup)
 ```@docs
 isomorphism(::Type{T}, G::GAPGroup) where T <: Union{SubPcGroup, PermGroup}
 isomorphism(::Type{FinGenAbGroup}, G::GAPGroup)
-simplified_fp_group(G::FPGroup)
-```
-
-## Other homomorphisms
-
-```@docs
-epimorphism_from_free_group(G::GAPGroup)
 ```

--- a/docs/src/Groups/pcgroup.md
+++ b/docs/src/Groups/pcgroup.md
@@ -116,17 +116,24 @@ julia> small_group(24, 12)
 Pc group of order 24
 ```
 
-## Functions for (subgroups of) pc groups and their elements
+## Functions for elements of (subgroups of) pc groups
+
+```@docs
+letters(g::Union{PcGroupElem, SubPcGroupElem})
+syllables(g::Union{PcGroupElem, SubPcGroupElem})
+map_word(g::Union{PcGroupElem, SubPcGroupElem}, genimgs::Vector; genimgs_inv::Vector = Vector(undef, length(genimgs)), init = nothing)
+```
+
+## Functions for (subgroups of) pc groups
 
 ```@docs
 relators(G::PcGroup)
-map_word(g::Union{PcGroupElem, SubPcGroupElem}, genimgs::Vector; genimgs_inv::Vector = Vector(undef, length(genimgs)), init = nothing)
 ```
 
 The function
 [`full_group(G::T) where T <: Union{SubFPGroup, SubPcGroup}`](@ref)
-for finitely presented groups is applicable to polycyclicly presented groups
-as well.
+for (subgroups of) finitely presented groups is applicable to
+(subgroups of) polycyclicly presented groups as well.
 
 ## Series of polycyclic groups
 

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -2046,7 +2046,7 @@ Thus the intended value for the empty word must be specified as `init`
 whenever it is possible that the elements in `genimgs` do not support `one`.
 
 See also: [`map_word(::Union{PcGroupElem, SubPcGroupElem}, ::Vector)`](@ref),
-[`map_word(::WeylGroupElem, ::Vector)](@ref).
+[`map_word(::WeylGroupElem, ::Vector)`](@ref).
 
 # Examples
 ```jldoctest
@@ -2130,7 +2130,7 @@ and $R_j =$ `genimgs[`$i_j$`]`$^{e_j}$.
 If `init` is different from `nothing`, return $x g_{i_1}^{e_1} g_{i_2}^{e_2} \cdots g_{i_n}^{e_n}$ where $x =$ `init`.
 
 See also: [`map_word(::Union{FPGroupElem, SubFPGroupElem}, ::Vector)`](@ref),
-[`map_word(::WeylGroupElem, ::Vector)](@ref).
+[`map_word(::WeylGroupElem, ::Vector)`](@ref).
 
 # Examples
 ```jldoctest
@@ -2245,6 +2245,8 @@ end
 Return the syllables of `g` as a list of pairs `gen => exp` where
 `gen` is the index of a generator and `exp` is an exponent.
 
+See also [`letters(::Union{FPGroupElem, SubFPGroupElem})`](@ref).
+
 # Examples
 ```jldoctest
 julia> F = @free_group(:F1, :F2);
@@ -2290,11 +2292,13 @@ function exponents_of_abelianization(g::Union{FPGroupElem, SubFPGroupElem})
 end
 
 @doc raw"""
-    letters(g::FPGroupElem)
+    letters(g::Union{FPGroupElem, SubFPGroupElem})
 
 Return the letters of `g` as a list of integers, each entry corresponding to
 a group generator. Inverses of the generators are represented by negative
 numbers.
+
+See also [`syllables(::Union{FPGroupElem, SubFPGroupElem})`](@ref).
 
 # Examples
 ```jldoctest
@@ -2328,7 +2332,7 @@ julia> letters(epi(F1^5*F2^-3))
  -2
 ```
 """
-function letters(g::FPGroupElem)
+function letters(g::Union{FPGroupElem, SubFPGroupElem})
   w = GAPWrap.UnderlyingElement(GapObj(g))
   return Vector{Int}(GAPWrap.LetterRepAssocWord(w))
 end

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -14,7 +14,6 @@
 
 # character values are elements from QQAbField
 
-
 #############################################################################
 ##
 ##  Atlas irrationalities
@@ -2645,7 +2644,7 @@ Return `true` if `chi` is an irreducible character, and `false` otherwise.
 A character is irreducible if it cannot be written as the sum of two
 characters.
 For ordinary characters this can be checked using the scalar product of
-class functions (see [`scalar_product`](@ref).
+class functions (see [`scalar_product`](@ref)).
 For Brauer characters there is no generic method for checking irreducibility.
 
 # Examples

--- a/src/Groups/pcgroup.jl
+++ b/src/Groups/pcgroup.jl
@@ -540,6 +540,8 @@ end
 Return the syllables of `g` as a list of pairs of integers, each entry corresponding to
 a group generator and its exponent.
 
+See also [`letters(::Union{PcGroupElem, SubPcGroupElem})`](@ref).
+
 # Examples
 
 ```jldoctest


### PR DESCRIPTION
- add `letters`, `syllables` to the manual (f.p. groups and pc groups)
- move `simplified_fp_group` and `epimorphism_from_free_group` to the f.p. groups section
- fix some signatures in a `@docs` block
- add some cross-references
- fix the syntax of some cross-references
- allow `letters(g::SubFPGroupElem)`

resolves #3471