### PR TITLE
Fix `bracket` for `LieSubalgebra`s (the return value had the wrong type)

### DIFF
--- a/experimental/LieAlgebras/src/LieSubalgebra.jl
+++ b/experimental/LieAlgebras/src/LieSubalgebra.jl
@@ -192,7 +192,7 @@ end
 ###############################################################################
 
 @doc raw"""
-    bracket(S1::LieSubalgebra, S2::LieSubalgebra) -> LieAlgebraIdeal
+    bracket(S1::LieSubalgebra, S2::LieSubalgebra) -> LieSubalgebra
 
 Return $[S_1, S_2]$.
 """
@@ -200,14 +200,14 @@ function bracket(
   S1::LieSubalgebra{C,LieT}, S2::LieSubalgebra{C,LieT}
 ) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
   @req base_lie_algebra(S1) === base_lie_algebra(S2) "Incompatible Lie algebras."
-  return ideal(base_lie_algebra(S1), [x * y for x in gens(S1) for y in gens(S2)])
+  return sub(base_lie_algebra(S1), [x * y for x in gens(S1) for y in gens(S2)])
 end
 
 function bracket(
   L::LieAlgebra{C}, S::LieSubalgebra{C,LieT}
 ) where {C<:FieldElem,LieT<:LieAlgebraElem{C}}
   @req L === base_lie_algebra(S) "Incompatible Lie algebras."
-  return bracket(ideal(L), S)
+  return sub(sub(L), S)
 end
 
 ###############################################################################

--- a/experimental/LieAlgebras/test/LieSubalgebra-test.jl
+++ b/experimental/LieAlgebras/test/LieSubalgebra-test.jl
@@ -46,4 +46,14 @@
       @test normalizer(n) == b
     end
   end
+
+  @testset "#4676" begin
+    L = special_linear_lie_algebra(QQ, 2)
+    e,f,h = basis(L)
+    sub1 = sub(L, e)
+    sub2 = sub(L, f)
+    sub3 = bracket(sub1, sub2)
+    @test sub3 isa LieSubalgebra
+    @test dim(sub3) < dim(L)
+  end
 end


### PR DESCRIPTION
Reported by @willemdegraaf on slack.

> 4) In the file LieSubalgebra.jl there is a function "bracket" for subalgebras.
However, what is returned is an ideal of the base_lie_algebra, which in general
is wrong. (Take a subalgebra K of a simple Lie algebra L, this function
will return L as the value of [K,K].)