### PR TITLE
doc: add suggestions on formulations in changelog

### DIFF
--- a/docs/src/DeveloperDocumentation/changelog.md
+++ b/docs/src/DeveloperDocumentation/changelog.md
@@ -85,6 +85,10 @@ labels, and the release notes script will organize them appropriately:
 
 ## Suggestions for formulations
 
+
+In general the description of each change should start with a verb in present
+tense. Here are some more concrete suggestions.
+
 | Change                        | Example |
 |-------------------------------|--------------------|
 | move from experimental to src/ | Graduate bla from experimental to officially supported |

--- a/docs/src/DeveloperDocumentation/changelog.md
+++ b/docs/src/DeveloperDocumentation/changelog.md
@@ -83,6 +83,17 @@ labels, and the release notes script will organize them appropriately:
 | `package: Polymake`           | Changes related to the package Polymake |
 | `package: Singular`           | Changes related to the package Singular |
 
+## Suggestions for formulations
+
+| Change                        | Example |
+|-------------------------------|--------------------|
+| move from experimental to src/ | Graduate bla from experimental to officially supported |
+| feature added                 | Add `bla` for `blub `/ Support `bla` for `blub` / Implement `bla`
+| renaming things               | Rename `bla` to `blub`
+| bug fix                       | Fix `bla` in `blub`
+| improvements                  | Improve (performance) of `blub`
+| experimental feature          | Experimental: add support for `bla`
+
 
 ## Updating the changelog
 


### PR DESCRIPTION
Found it helpful when preparing descriptions for the changelog. In particular for things like `experimental` -> `src`, which look nicer when done consistent. I don't think we should be super strict, so these are just suggestions.

The examples are coming from the current changelog and can of course be adjusted.