### PR TITLE
doctests: use [...] to indicate omitted stacktraces in error messages

### DIFF
--- a/docs/src/Rings/integer.md
+++ b/docs/src/Rings/integer.md
@@ -243,9 +243,11 @@ julia> divexact(ZZ(6), ZZ(3))
 
 julia> divexact(ZZ(6), ZZ(0))
 ERROR: DivideError: integer division error
+[...]
 
 julia> divexact(ZZ(6), ZZ(5))
 ERROR: ArgumentError: Not an exact division
+[...]
 
 julia> divexact(ZZ(6), 2)
 3
@@ -325,6 +327,7 @@ julia> rem(ZZ(4), ZZ(3))
 
 julia> div(ZZ(2), ZZ(0))
 ERROR: DivideError: integer division error
+[...]
 
 ```
 
@@ -357,6 +360,7 @@ julia> mod(ZZ(4), ZZ(3))
 
 julia> mod(ZZ(2), ZZ(0))
 ERROR: DivideError: integer division error
+[...]
 
 ```
 
@@ -468,6 +472,7 @@ julia> isqrt(ZZ(5))
 julia> isqrt(ZZ(-3))
 ERROR: DomainError with -3:
 Argument must be non-negative
+[...]
 
 ```
 
@@ -501,10 +506,12 @@ julia> root(ZZ(16), 4)
 julia> root(ZZ(-5), 2)
 ERROR: DomainError with (-5, 2):
 Argument `x` must be positive if exponent `n` is even
+[...]
 
 julia> root(ZZ(12), -2)
 ERROR: DomainError with -2:
 Exponent must be positive
+[...]
 ```
 
 ## Conversions
@@ -532,6 +539,7 @@ is raised.
 ```jldoctest
 julia> Int(ZZ(12348732648732648763274868732687324))
 ERROR: InexactError: convert(Int64, 12348732648732648763274868732687324)
+[...]
 
 ```
 
@@ -561,6 +569,7 @@ julia> factor(ZZ(-6000361807272228723606))
 
 julia> factor(ZZ(0))
 ERROR: ArgumentError: Argument is not non-zero
+[...]
 
 ```
 
@@ -633,6 +642,7 @@ julia> F[3]
 
 julia> F[ZZ(7)]
 ERROR: 7 is not a factor of -1 * 5 * 2^2 * 3
+[...]
 
 ```
 

--- a/docs/src/Rings/rational.md
+++ b/docs/src/Rings/rational.md
@@ -66,6 +66,7 @@ julia> QQ(2//3)
 
 julia> ZZ(3)//0
 ERROR: DivideError: integer division error
+[...]
 
 ```
 One can also construct the rational number ``0`` with the empty constructor:
@@ -222,6 +223,7 @@ julia> divexact(QQ(2, 3), QQ(3, 5))
 
 julia> divexact(QQ(1, 3), ZZ(0))
 ERROR: DivideError: integer division error
+[...]
 
 julia> divexact(QQ(3, 4), ZZ(5))
 3//20
@@ -265,6 +267,7 @@ julia> QQ(0)^0
 ```jldoctest
 julia> QQ(0)^-2
 ERROR: DivideError: integer division error
+[...]
 
 ```
 

--- a/experimental/SetPartitions/src/ColoredPartition.jl
+++ b/experimental/SetPartitions/src/ColoredPartition.jl
@@ -250,6 +250,7 @@ julia> compose_count_loops(colored_partition([1, 1], [2], [1, 1], [0]), colored_
 
 julia> compose_count_loops(colored_partition([1], [1, 2], [0], [1, 0]), colored_partition([1], [2, 2], [0], [0, 1]))
 ERROR: ArgumentError: upper and lower colors are different
+[...]
 ```
 """
 function compose_count_loops(p::ColoredPartition, q::ColoredPartition)

--- a/experimental/SetPartitions/src/SetPartition.jl
+++ b/experimental/SetPartitions/src/SetPartition.jl
@@ -295,6 +295,7 @@ julia> compose_count_loops(set_partition([1, 1], [2]), set_partition([1], [2, 2]
 
 julia> compose_count_loops(set_partition([1], [1, 2]), set_partition([1], [2, 2]))
 ERROR: ArgumentError: number of points mismatch
+[...]
 ```
 """
 function compose_count_loops(p::SetPartition, q::SetPartition)

--- a/experimental/SetPartitions/src/SpatialPartition.jl
+++ b/experimental/SetPartitions/src/SpatialPartition.jl
@@ -209,6 +209,7 @@ julia> compose_count_loops(spatial_partition([1, 1], [2, 2], 2), spatial_partiti
 
 julia> compose_count_loops(spatial_partition([1, 2], [2, 1], 2), spatial_partition([1, 2], [1, 1], 1))
 ERROR: ArgumentError: p and q have different levels
+[...]
 ```
 """
 function compose_count_loops(p::SpatialPartition, q::SpatialPartition)

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1799,9 +1799,11 @@ julia> prime_of_pgroup(UInt16, quaternion_group(8))
 
 julia> prime_of_pgroup(symmetric_group(1))
 ERROR: ArgumentError: only supported for non-trivial p-groups
+[...]
 
 julia> prime_of_pgroup(symmetric_group(3))
 ERROR: ArgumentError: only supported for non-trivial p-groups
+[...]
 
 ```
 """
@@ -2357,6 +2359,7 @@ julia> length(one(F))
 
 julia> length(one(quo(F, [F1])[1]))
 ERROR: ArgumentError: the element does not lie in a free group
+[...]
 ```
 """
 function length(g::Union{FPGroupElem, SubFPGroupElem})

--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -782,6 +782,7 @@ Pc group of infinite order
 
 julia> dihedral_group(7)
 ERROR: ArgumentError: n must be a positive even integer or infinity
+[...]
 ```
 """
 dihedral_group(n::Union{IntegerUnion,PosInf}) = dihedral_group(PcGroup, n)

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -1230,6 +1230,7 @@ julia> rank_action(K, 2:4)  # 2-transitive
 
 julia> rank_action(K, 3:5)
 ERROR: ArgumentError: the group is not transitive
+[...]
 ```
 """
 function rank_action(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))
@@ -1262,6 +1263,7 @@ julia> transitivity(symmetric_group(6), 1:7)
 
 julia> transitivity(symmetric_group(6), 1:5)
 ERROR: ArgumentError: the group does not act
+[...]
 ```
 """
 function transitivity(G::PermGroup, L::AbstractVector{Int} = 1:degree(G))

--- a/src/Groups/libraries/atlasgroups.jl
+++ b/src/Groups/libraries/atlasgroups.jl
@@ -24,6 +24,7 @@ Permutation group of degree 11 and order 7920
 
 julia> atlas_group("M")  # Monster group M
 ERROR: ArgumentError: the group atlas does not provide a representation for M
+[...]
 ```
 """
 function atlas_group(name::String)

--- a/src/Groups/libraries/fewclassesgroups.jl
+++ b/src/Groups/libraries/fewclassesgroups.jl
@@ -59,6 +59,7 @@ julia> number_of_groups_with_class_number(8)
 
 julia> number_of_groups_with_class_number(50)
 ERROR: ArgumentError: the number of groups with 50 classes is not available
+[...]
 ```
 """
 function number_of_groups_with_class_number(n::IntegerUnion)
@@ -88,6 +89,7 @@ julia> describe(group_with_class_number(5, 8))
 
 julia> group_with_class_number(5, 12)
 ERROR: ArgumentError: there are only 8 groups with 5 classes, not 12
+[...]
 ```
 """
 function group_with_class_number(::Type{T}, n::IntegerUnion, i::IntegerUnion) where T

--- a/src/Groups/libraries/perfectgroups.jl
+++ b/src/Groups/libraries/perfectgroups.jl
@@ -115,6 +115,7 @@ julia> gens(ans)
 
 julia> perfect_group(60, 2)
 ERROR: ArgumentError: there are only 1 perfect groups of order 60
+[...]
 ```
 """
 function perfect_group(::Type{T}, n::IntegerUnion, k::IntegerUnion) where T <: GAPGroup

--- a/src/Groups/libraries/primitivegroups.jl
+++ b/src/Groups/libraries/primitivegroups.jl
@@ -71,6 +71,7 @@ julia> number_of_primitive_groups(10)
 
 julia> number_of_primitive_groups(4096)
 ERROR: ArgumentError: the number of primitive permutation groups of degree 4096 is not available
+[...]
 ```
 """
 function number_of_primitive_groups(deg::Int)
@@ -92,6 +93,7 @@ Permutation group of degree 10 and order 60
 
 julia> primitive_group(10,10)
 ERROR: ArgumentError: there are only 9 primitive permutation groups of degree 10, not 10
+[...]
 ```
 """
 function primitive_group(deg::Int, i::Int)
@@ -135,11 +137,13 @@ true
 
 julia> primitive_group_identification(symmetric_group(4096))
 ERROR: ArgumentError: identification of primitive permutation groups of degree 4096 is not available
+[...]
 
 julia> S = sub(G, [perm([1,3,4,5,2,7,6])])[1];
 
 julia> primitive_group_identification(S)
 ERROR: ArgumentError: group is not primitive on its moved points
+[...]
 ```
 """
 function primitive_group_identification(G::PermGroup)

--- a/src/Groups/libraries/smallgroups.jl
+++ b/src/Groups/libraries/smallgroups.jl
@@ -111,6 +111,7 @@ julia> small_group_identification(alternating_group(5))
 
 julia> small_group_identification(symmetric_group(20))
 ERROR: ArgumentError: identification is not available for groups of order 2432902008176640000
+[...]
 ```
 """
 function small_group_identification(G::GAPGroup)
@@ -133,6 +134,7 @@ julia> number_of_small_groups(8)
 
 julia> number_of_small_groups(4096)
 ERROR: ArgumentError: the number of groups of order 4096 is not available
+[...]
 
 julia> number_of_small_groups(next_prime(ZZRingElem(2)^64))
 1

--- a/src/Groups/libraries/transitivegroups.jl
+++ b/src/Groups/libraries/transitivegroups.jl
@@ -67,6 +67,7 @@ julia> number_of_transitive_groups(30)
 
 julia> number_of_transitive_groups(64)
 ERROR: ArgumentError: the number of transitive groups of degree 64 is not available
+[...]
 ```
 """
 function number_of_transitive_groups(deg::Int)
@@ -88,6 +89,7 @@ Alt(5)
 
 julia> transitive_group(5,6)
 ERROR: ArgumentError: there are only 5 transitive groups of degree 5, not 6
+[...]
 ```
 """
 function transitive_group(deg::Int, i::Int)
@@ -131,11 +133,13 @@ true
 
 julia> transitive_group_identification(symmetric_group(64))
 ERROR: ArgumentError: identification of transitive groups of degree 64 are not available
+[...]
 
 julia> S = sub(G, [perm([1,3,4,5,2,7,6])])[1];
 
 julia> transitive_group_identification(S)
 ERROR: ArgumentError: group is not transitive on its moved points
+[...]
 ```
 """
 function transitive_group_identification(G::PermGroup)

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -384,6 +384,7 @@ julia> jennings_series(dihedral_group(16))
 
 julia> jennings_series(dihedral_group(10))
 ERROR: ArgumentError: group must be a p-group
+[...]
 ```
 """
 @gapattribute function jennings_series(G::GAPGroup)
@@ -412,6 +413,7 @@ julia> p_central_series(alternating_group(4), 3)
 
 julia> p_central_series(alternating_group(4), 4)
 ERROR: ArgumentError: p must be a prime
+[...]
 ```
 """
 function p_central_series(G::GAPGroup, p::IntegerUnion)
@@ -508,6 +510,7 @@ julia> nilpotency_class(dihedral_group(8))
 
 julia> nilpotency_class(dihedral_group(12))
 ERROR: ArgumentError: The group is not nilpotent.
+[...]
 ```
 """
 @gapattribute function nilpotency_class(G::GAPGroup)
@@ -546,6 +549,7 @@ false
 
 julia> is_maximal_subgroup(sylow_subgroup(G, 3)[1], sylow_subgroup(G, 2)[1])
 ERROR: ArgumentError: H is not a subgroup of G
+[...]
 ```
 """
 function is_maximal_subgroup(H::GAPGroup, G::GAPGroup; check::Bool = true)
@@ -646,6 +650,7 @@ false
 
 julia> is_characteristic_subgroup(sylow_subgroup(G, 3)[1], sylow_subgroup(G, 2)[1])
 ERROR: ArgumentError: H is not a subgroup of G
+[...]
 ```
 """
 function is_characteristic_subgroup(H::GAPGroup, G::GAPGroup; check::Bool = true)


### PR DESCRIPTION
Together with https://github.com/JuliaDocs/Documenter.jl/pull/2642 (assuming that gets merged and put into a Documenter release...) this allows one.

But even now, I can use my modified Documenter.jl behind that PR to run `doctest=:fix` which is MUUUCH more useful (I don't have to discard dozens of unwanted stacktraces each time, carefully avoiding to get them all but not discard any of the changes I actually need).

I also think for a user reading our doctests it may actually be helpful to see an indicator that the actual error message is longer.