### PR TITLE
Temporarily disable extra-long test content

### DIFF
--- a/experimental/FTheoryTools/test/FTM-1511-03209.jl
+++ b/experimental/FTheoryTools/test/FTM-1511-03209.jl
@@ -1,4 +1,5 @@
 @testset "Test Downloading Artifact and elementary properties" begin
+  #=
   t = literature_model(arxiv_id = "1511.03209")
   t_resolved = resolve(t, 1)
   f1 = special_flux_family(t_resolved, check = false)
@@ -20,4 +21,5 @@
   @test size(matrix_rational(f2)) == (629, 127)
   @test size(matrix_integral(f3)) == (629, 1)
   @test size(matrix_rational(f3)) == (629, 127)
+  =#
 end


### PR DESCRIPTION
A temporary step in response to https://github.com/oscar-system/Oscar.jl/issues/4699: Disable the affected tests.

More solid improvements will arrive hopefully within the week, as I work on the FTheoryTools changes needed to comply with the serialization overhaul. 

cc @apturner @emikelsons 