### PR TITLE
Introduce various variants of `halfspace_matrix_pair(ZZ, ...)` for polyhedral objects to access facets etc as matrices

### DIFF
--- a/src/PolyhedralGeometry/type_functions.jl
+++ b/src/PolyhedralGeometry/type_functions.jl
@@ -72,7 +72,7 @@ function halfspace_matrix_pair(
       Polyhedron{QQFieldElem},
       Cone{QQFieldElem},
       Pair{Matrix{QQFieldElem},QQFieldElem},
-    }
+    },
   };
   integral_bias::Bool=true,
 )

--- a/test/PolyhedralGeometry/polyhedron.jl
+++ b/test/PolyhedralGeometry/polyhedron.jl
@@ -171,6 +171,43 @@
         @test hmp.A == matrix(f, [-1 0 0; 0 -1 0; 0 0 -1])
         @test hmp.b == f.([0, 0, 0])
       end
+      if T == QQFieldElem
+        p = polyhedron([1//3 1; 1 -2; -1 -1//5], [1//2, 1//2, 0])
+        for (hmp, fA, tA, fb, tb, A, b) in (
+          (
+            halfspace_matrix_pair(facets(S, p)),
+            QQ,
+            QQMatrix,
+            QQ,
+            QQFieldElem,
+            [1//3 1; 1 -2; -1 -1//5],
+            [1//2, 1//2, 0],
+          ),
+          (
+            halfspace_matrix_pair(ZZ, facets(S, p)),
+            ZZ,
+            ZZMatrix,
+            ZZ,
+            ZZRingElem,
+            [2 6; 2 -4; -5 -1],
+            [3, 1, 0],
+          ),
+          (
+            halfspace_matrix_pair(ZZ, facets(S, p); integral_bias=false),
+            ZZ,
+            ZZMatrix,
+            QQ,
+            QQFieldElem,
+            [1 3; 1 -2; -5 -1],
+            [3//2, 1//2, 0],
+          ))
+          @test hmp isa NamedTuple{
+            (:A, :b),Tuple{tA,Vector{tb}}
+          }
+          @test hmp.A == matrix(fA, A)
+          @test hmp.b == fb.(b)
+        end
+      end
       @test _check_im_perm_rows(ray_indices(facets(S, Pos)), [[2, 3], [1, 3], [1, 2]])
       @test _check_im_perm_rows(
         vertex_and_ray_indices(facets(S, Pos)), [[2, 3, 4], [1, 3, 4], [1, 2, 4]]


### PR DESCRIPTION
With `halfspace_matrix_pair(ZZ, ...)` we can ask for integral representations of its content. This resolves #4682 .

In the following example we compare the default case to  the integral case and the semi-integral case (i.e. b is not required to be integral, only A):

```
julia> p = polyhedron([1//3 1; 1 -2; -1 -1//5], [1//2, 1//2, 0])
Polyhedron in ambient dimension 2

julia> f = facets(p)
3-element SubObjectIterator{AffineHalfspace{QQFieldElem}} over the halfspaces of R^2 described by:
1//3*x_1 + x_2 <= 1//2
x_1 - 2*x_2 <= 1//2
-x_1 - 1//5*x_2 <= 0


julia> halfspace_matrix_pair(f)
(A = [1//3 1; 1 -2; -1 -1//5], b = QQFieldElem[1//2, 1//2, 0])

julia> halfspace_matrix_pair(ZZ, f)
(A = [2 6; 2 -4; -5 -1], b = ZZRingElem[3, 1, 0])

julia> halfspace_matrix_pair(ZZ, f; integral_bias = false)
(A = [1 3; 1 -2; -5 -1], b = QQFieldElem[3//2, 1//2, 0])
```

@lkastner can you play around and see if this meets your expactations? Also, from what I have tested this seemed to work properly for cones. Still, I did not like having to call `halfspace_matrix_pair` which gives us the redundant information that b is a zero vector. Do you think we should define a method of `matrix` for this context? I guess this should not conflict with any other definition of `matrix`, but if it does we could still find some appropriate function name.