### PR TITLE
Ignore md files in / for CI workflows

### DIFF
--- a/.github/workflows/BibtoolCI.yml
+++ b/.github/workflows/BibtoolCI.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - master
       - 'release-*'
+    paths-ignore:
+      - '*.md'
   pull_request:
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - master
       - 'release-*'
+    paths-ignore:
+      - '*.md'
   pull_request:
+    paths-ignore:
+      - '*.md'
   schedule:
       # Every day at 3:10 AM UTC
       - cron: '10 3 * * *'

--- a/.github/workflows/Docstrings.yml
+++ b/.github/workflows/Docstrings.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - master
       - 'release-*'
+    paths-ignore:
+      - '*.md'
   pull_request:
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/Docu.yml
+++ b/.github/workflows/Docu.yml
@@ -6,7 +6,11 @@ on:
       - master
       - 'release-*'
     tags: '*'
+    paths-ignore:
+      - '*.md'
   pull_request:
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/JuliaFormatterCI.yml
+++ b/.github/workflows/JuliaFormatterCI.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - master
       - 'release-*'
+    paths-ignore:
+      - '*.md'
   pull_request:
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/NoExperimental.yml
+++ b/.github/workflows/NoExperimental.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - master
       - 'release-*'
+    paths-ignore:
+      - '*.md'
   pull_request:
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
 
 # needed to allow julia-actions/cache to delete old caches that it has created


### PR DESCRIPTION
Resolves #4677

I **think** this does what I want it to do. The [official documentation](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-paths) says `'**.js'` is for "all js files in the repository", so, I assume `'*.md'` (with a single `*`) is "all md files in root of this repository, and not recurse into other subdirectories".