### PR TITLE
Experimental: Add support for reducible types in `isomorphism(PermGroup, ::WeylGroup)`

### DIFF
--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -138,8 +138,8 @@ function _isomorphic_group_on_gens(::Type{PermGroup}, W::WeylGroup)
     factors_as_perm = [_isomorphic_group_on_gens(PermGroup, factor) for factor in factors]
     G = inner_direct_product(factors_as_perm; morphisms=false)
     # gens(G) corresponds to gens(W)[ordering], so
-    # gens(G)[sortperm(ordering)] corresponds to gens(W)
-    G_sorted, _ = sub(G, gens(G)[sortperm(ordering)])
+    # gens(G)[invperm(ordering)] corresponds to gens(W)
+    G_sorted, _ = sub(G, gens(G)[invperm(ordering)])
     return G_sorted
   end
 
@@ -184,9 +184,9 @@ function _isomorphic_group_on_gens(::Type{PermGroup}, W::WeylGroup)
 
   # Reorder generators
   # (Details: simple_roots(R)[ordering] is in canonical ordering.
-  # s = sortperm(ordering) is the inverse of the corresponding permutation.
+  # s = invperm(ordering) is the inverse of the corresponding permutation.
   # Hence (gen_G[s])[i] is the image of gen(W, i).)
-  gen_G = gen_G[sortperm(ordering)]
+  gen_G = gen_G[invperm(ordering)]
   G, _ = sub(Sym, gen_G)
   return G
 end

--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -132,7 +132,15 @@ function _isomorphic_group_on_gens(::Type{PermGroup}, W::WeylGroup)
   type, ordering = root_system_type_with_ordering(R)
 
   if length(type) != 1
-    error("Not implemented (yet)")
+    # Apply recursion to the irreducible factors
+    # Note that the gens of each irreducible factor are in canonical ordering
+    factors = irreducible_factors(W; morphisms=false)
+    factors_as_perm = [_isomorphic_group_on_gens(PermGroup, factor) for factor in factors]
+    G = inner_direct_product(factors_as_perm; morphisms=false)
+    # gens(G) corresponds to gens(W)[ordering], so
+    # gens(G)[sortperm(ordering)] corresponds to gens(W)
+    G_sorted, _ = sub(G, gens(G)[sortperm(ordering)])
+    return G_sorted
   end
 
   # Compute generators of the permutation group to which the simple reflections are mapped.

--- a/experimental/LieAlgebras/test/WeylGroup-test.jl
+++ b/experimental/LieAlgebras/test/WeylGroup-test.jl
@@ -103,45 +103,43 @@
 
     if has_root_system_type(root_system(W))
       type, ordering = root_system_type_with_ordering(root_system(W))
-      if length(type) == 1
-        @testset "isomorphism(PermGroup, ::WeylGroup)" begin
-          if is_finite(W) && ngens(W) < 6 #= for sane runtime =#
-            G = _isomorphic_group_on_gens(PermGroup, W)
-            @test is_finite(G) == is_finite(W)
-            is_finite(W) && @test order(G) == order(W)
-          end
-
-          G = permutation_group(W)
+      @testset "isomorphism(PermGroup, ::WeylGroup)" begin
+        if is_finite(W) && ngens(W) < 6 #= for sane runtime =#
+          G = _isomorphic_group_on_gens(PermGroup, W)
           @test is_finite(G) == is_finite(W)
           is_finite(W) && @test order(G) == order(W)
+        end
 
-          iso = isomorphism(PermGroup, W)
-          @test W === domain(iso)
-          @test G === codomain(iso)
-          @test iso === isomorphism(PermGroup, W) # test caching
+        G = permutation_group(W)
+        @test is_finite(G) == is_finite(W)
+        is_finite(W) && @test order(G) == order(W)
 
-          # test mapping of gens
-          @test ngens(W) == ngens(G)
-          @test iso.(gens(W)) == gens(G)
-          @test inv(iso).(gens(G)) == gens(W)
+        iso = isomorphism(PermGroup, W)
+        @test W === domain(iso)
+        @test G === codomain(iso)
+        @test iso === isomorphism(PermGroup, W) # test caching
 
-          # test general mapping
-          if ngens(W) < 10 #= for sane runtime =#
-            for _ in 1:5
-              if is_finite(W) # remove once rand(W) is implemented for infinite groups
-                w = rand(W)
-                @test w == inv(iso)(iso(w))
-                v = rand(W)
-                @test iso(v * w) == iso(v) * iso(w)
-                @test v * w == inv(iso)(iso(v) * iso(w))
-              end
-              g = rand_pseudo(G)
-              @test is_in_normal_form(inv(iso)(g))
-              @test g == iso(inv(iso)(g))
-              h = rand_pseudo(G)
-              @test inv(iso)(h * g) == inv(iso)(h) * inv(iso)(g)
-              @test h * g == iso(inv(iso)(h) * inv(iso)(g))
+        # test mapping of gens
+        @test ngens(W) == ngens(G)
+        @test iso.(gens(W)) == gens(G)
+        @test inv(iso).(gens(G)) == gens(W)
+
+        # test general mapping
+        if ngens(W) < 10 #= for sane runtime =#
+          for _ in 1:5
+            if is_finite(W) # remove once rand(W) is implemented for infinite groups
+              w = rand(W)
+              @test w == inv(iso)(iso(w))
+              v = rand(W)
+              @test iso(v * w) == iso(v) * iso(w)
+              @test v * w == inv(iso)(iso(v) * iso(w))
             end
+            g = rand_pseudo(G)
+            @test is_in_normal_form(inv(iso)(g))
+            @test g == iso(inv(iso)(g))
+            h = rand_pseudo(G)
+            @test inv(iso)(h * g) == inv(iso)(h) * inv(iso)(g)
+            @test h * g == iso(inv(iso)(h) * inv(iso)(g))
           end
         end
       end

--- a/experimental/LieAlgebras/test/WeylGroup-test.jl
+++ b/experimental/LieAlgebras/test/WeylGroup-test.jl
@@ -7,9 +7,6 @@
 
   # TODO: merge with conformance tests in test/LieTheory/WeylGroup.jl once this is moved to src
   @testset "WeylGroup Group isomorphism test for $(Wname)" for (Wname, W) in [
-    # Some test cases can be removed as soon as isomorphism has support for reducible types.
-    # (Then nearly everything is covered by complicated case 1 and 2.)
-    # Until then, all irreducible types and some explicit non-canonical orderings should be tested.
     ("A1", weyl_group(:A, 1)),
     (
       "A3 with non-canonical ordering of simple roots",


### PR DESCRIPTION
Continues #4478. This function should now be done.

Nothing actually changed in the test file except that I remove `if length(type) == 1` and changed the indentation accordingly.

Maybe there is a better way of re-ordering the generators of a group than using `sub`.

Labels: `release notes: use title`, `topic: lie theory`, `enhancement`, `experimental`.