### PR TITLE
CI: dont process+upload coverage for booktests on julia != 1.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -155,10 +155,12 @@ jobs:
           annotate: ${{ matrix.julia-version == '1.10' }}
           coverage: ${{ matrix.julia-version == '1.10' }}
       - name: "Process code coverage"
+        if: matrix.julia-version == '1.10'
         uses: julia-actions/julia-processcoverage@v1
         with:
           directories: src,experimental
       - name: "Upload coverage data to Codecov"
+        if: matrix.julia-version == '1.10'
         continue-on-error: true
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
Probably a copy-paste error when separating the book tests from the main job:
This aligns it with the other jobs and we are disabling coverage generation for the julia process anyway for julia != 1.10 (finding no coverage files at all might be one reason for the error even though on julia 1.11 it doesn't fail like that).