### PR TITLE
improvements around character fields

### DIFF
--- a/experimental/OrthogonalDiscriminants/src/data.jl
+++ b/experimental/OrthogonalDiscriminants/src/data.jl
@@ -198,7 +198,7 @@ function orthogonal_discriminants(tbl::Oscar.GAPGroupCharacterTable)
                 res[i] = "-1"
               else
                 # Check whether -1 is a square in the character field.
-                if mod(p-1, 4) == 0 || mod(degree(character_field(chi)[1]), 2) == 0
+                if mod(p-1, 4) == 0 || mod(degree_of_character_field(chi), 2) == 0
                   res[i] = "O+"
                 else
                   res[i] = "O-"

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -932,12 +932,7 @@ function Base.show(io::IO, ::MIME"text/plain", tbl::GAPGroupCharacterTable)
     # Compute the degrees of the character fields if applicable.
     field_degrees = get(io, :character_field, false)::Bool
     if field_degrees
-      p = characteristic(tbl)
-      if p == 0
-        field_degrees = [[string(degree(character_field(x)[1])) for x in tbl]]
-      else
-        field_degrees = [[string(collect(factor(order_field_of_definition(x)))[1][2]) for x in tbl]]
-      end
+      field_degrees = [[string(degree_of_character_field(x)) for x in tbl]]
       field_label = ["d"]
       push!(emptycor, "")
     else
@@ -3083,6 +3078,10 @@ If a nonempty vector `l` of characters is given then `(F, phi)` is returned
 such that `F` is the smallest field that contains the character fields
 of the entries of `l`.
 
+If only the degree of the character field is needed then better call
+[`degree_of_character_field`](@ref),
+this avoids the construction of the field.
+
 # Examples
 ```jldoctest
 julia> t = character_table("A5");
@@ -3150,7 +3149,7 @@ function _character_field(gapfield::GapObj)
       gappol = GAPWrap.MinimalPolynomial(GAP.Globals.Rationals, gapgens[1])
       gapcoeffs = GAPWrap.CoefficientsOfUnivariatePolynomial(gappol)
       v = Vector{QQFieldElem}(gapcoeffs)
-      R, = polynomial_ring(QQ, :x; cached=false)
+      R, = polynomial_ring(QQ, :x; cached = true)
       f = R(v)
       F, _ = number_field(f, "z"; cached = true, check = false)
       nfelm = QQAbFieldElem(gapgens[1])
@@ -3307,10 +3306,10 @@ but the values of `psi` need not be rationals.
 ```jldoctest
 julia> t = character_table("A5");
 
-julia> println([degree(character_field(x)[1]) for x in t])
+julia> println([degree_of_character_field(x) for x in t])
 [1, 2, 2, 1, 1]
 
-julia> println([degree(character_field(galois_orbit_sum(x))[1]) for x in t])
+julia> println([degree_of_character_field(galois_orbit_sum(x)) for x in t])
 [1, 1, 1, 1, 1]
 ```
 """
@@ -3342,8 +3341,12 @@ end
 
 Return `phi, n, m` where `phi` is an absolutely irreducible constituent
 of the rational ordinary character `chi` and `n`, `m` are positive
-`ZZRingElem`s such that `phi` has `n` Galois conjugates
+`ZZRingElem`s such that `n` is the degree of the character field of `phi`
+(`phi` has `n` Galois conjugates)
 and `chi` is `m` times the sum of these Galois conjugates.
+If `chi` is the character of a rational *representation* that is irreducible
+over the rationals then `m` is equal to the Schur index of `phi`,
+see [`schur_index(chi::GAPGroupClassFunction)`](@ref).
 
 If `check` is `true` then an exception is thrown if `chi` is not rational
 or not an ordinary character or not a multiple of a Galois sum of an
@@ -3361,6 +3364,17 @@ julia> phi, n, m = galois_representative_and_multiplicity(chi);
 
 julia> phi[1], n, m
 (3, 2, 3)
+
+julia> G = quaternion_group(8)
+Pc group of order 8
+
+julia> t = character_table(G);
+
+julia> chi = t[5]
+class_function(character table of G, [2, 0, 0, -2, 0])
+
+julia> galois_representative_and_multiplicity(chi)
+(class_function(character table of G, [2, 0, 0, -2, 0]), 1, 1)
 ```
 """
 function galois_representative_and_multiplicity(chi::GAPGroupClassFunction; check::Bool = true)

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -283,6 +283,15 @@ julia> center(quaternion_group(8))
 Return the centralizer of `H` in `G`, i.e.,
 the subgroup of all $g$ in `G` such that $g h$ equals $h g$ for every $h$
 in `H`, together with its embedding morphism into `G`.
+
+# Examples
+```jldoctest
+julia> g = symmetric_group(5);  h = sylow_subgroup(g, 3)[1]
+Permutation group of degree 5 and order 3
+
+julia> centralizer(g, h)
+(Permutation group of degree 5 and order 6, Hom: permutation group -> g)
+```
 """
 function centralizer(G::GAPGroup, H::GAPGroup)
   _check_compatible(G, H)
@@ -295,6 +304,15 @@ end
 Return the centralizer of `x` in `G`, i.e.,
 the subgroup of all $g$ in `G` such that $g$ `x` equals `x` $g$,
 together with its embedding morphism into `G`.
+
+# Examples
+```jldoctest
+julia> g = symmetric_group(4);  x = gen(g, 2)
+(1,2)
+
+julia> centralizer(g, x)
+(Permutation group of degree 4 and order 4, Hom: permutation group -> g)
+```
 """
 function centralizer(G::GAPGroup, x::GAPGroupElem)
   return _as_subgroup(G, GAP.Globals.Centralizer(GapObj(G), GapObj(x)))

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -1080,6 +1080,7 @@ end
   degrees = [degree_of_character_field(chi) for chi in tbl]
   @test degrees == [degree(character_field(chi)[1]) for chi in tbl]
   @test degrees == [1, 2, 2, 1, 1]
+  @test character_field(tbl[2])[1] === character_field(tbl[3])[1] # caching
   @test characteristic(character_field(tbl[1])[1]) == 0
   deg = degree_of_character_field(collect(tbl))
   @test deg == degree(character_field(collect(tbl))[1])
@@ -1136,6 +1137,7 @@ end
 @testset "character fields of Brauer characters" begin
   ordtbl = character_table("A5")
   modtbl = mod(ordtbl, 2)
+  @test character_field(modtbl[2])[1] === character_field(modtbl[3])[1] # caching
   @test [order_field_of_definition(chi) for chi in modtbl] == [2, 4, 4, 2]
   @test [order(character_field(chi)[1]) for chi in modtbl] == [2, 4, 4, 2]
   @test order_field_of_definition(Int, modtbl[1]) isa Int


### PR DESCRIPTION
- improve documentation of `galois_representative_and_multiplicity`
- cache character fields (when two characters have the same character field then the fields are identical)
- prefer `degree_of_character_field(x)` to `degree(character_field(x)[1])`
- (add some doctests for `centralizer`, which I wanted to commit already earlier)