### PR TITLE
Convert a `@repl` block to a `jldoctest`

### DIFF
--- a/experimental/QuadFormAndIsom/docs/src/introduction.md
+++ b/experimental/QuadFormAndIsom/docs/src/introduction.md
@@ -84,14 +84,35 @@ helping to reconstruct your example. This can help the reviewers to understand
 your issue and assist you. We have implemented a method `to_oscar` which
 prints few lines of codes for reconstructing your example.
 
-```@repl 2
-using Oscar # hide
-V = quadratic_space(QQ, 2);
-Vf = quadratic_space_with_isometry(V, neg = true)
-Oscar.to_oscar(Vf)
+```jldoctest
+julia> V = quadratic_space(QQ, 2);
 
-Lf = lattice(Vf)
-Oscar.to_oscar(Lf)
+julia> Vf = quadratic_space_with_isometry(V, neg = true)
+Quadratic space of dimension 2
+  with isometry of finite order 2
+  given by
+  [-1    0]
+  [ 0   -1]
+
+julia> Oscar.to_oscar(Vf)
+G = matrix(QQ, 2, 2, [1 0; 0 1]);
+V = quadratic_space(QQ, G);
+f = matrix(QQ, 2, 2, [-1 0; 0 -1]);
+Vf = quadratic_space_with_isometry(V, f);
+
+julia> Lf = lattice(Vf)
+Integer lattice of rank 2 and degree 2
+  with isometry of finite order 2
+  given by
+  [-1    0]
+  [ 0   -1]
+
+julia> Oscar.to_oscar(Lf)
+B = matrix(QQ, 2, 2, [1 0; 0 1]);
+G = matrix(QQ, 2, 2, [1 0; 0 1]);
+L = integer_lattice(B, gram = G);
+f = matrix(QQ, 2, 2, [-1 0; 0 -1]);
+Lf = integer_lattice_with_isometry(L, f);
 ```
 
 ## Make the code more talkative


### PR DESCRIPTION
...to reduce the time needed for documentation building. The way the documentation page looks is completely identical.

Every time one runs `Oscar.build_doc`, all `@repl` blocks in the documentation are run to put their output on the docs page. Overall, this is a considerable amount of the processing time of `Oscar.build_doc`, which gets very annoying over time if one debugs some documentation weirdnesses which means re-building the documentation over and over again.

This block here needs to compile a considerable amount of code. All other occurrences of `@repl` blocks in Oscar itself are calls to `Oscar.versioninfo()` or similar, aka very cheap-to-run functions whose output constantly changes. (There are a few more `@repl` blocks in copied over docs pages from AA/Nemo/Hecke that should be treated similarly.)

cc @StevellM 