### PR TITLE
Fix unescaped dollar sign in docs

### DIFF
--- a/docs/src/DeveloperDocumentation/changelog.md
+++ b/docs/src/DeveloperDocumentation/changelog.md
@@ -45,7 +45,7 @@ labelled. We have the following labels, along with how they are meant to be appl
 |-------|---------|
 | `release notes: added`        | The release notes for this PR were manually added to the changelog, and should be ignored by the script |
 | `release notes: not needed`   | This PR does not warrant an entry in the release notes. Internal only changes, like reorganization of private functions, changes to the test pipeline, etc can be tagged with this |
-| `release notes: use title`    | The release notes for this PR should be based on the title of this PR. The script will turn $TITLE from the PR to `[#xyz] $TITLE` |
+| `release notes: use title`    | The release notes for this PR should be based on the title of this PR. The script will turn \$TITLE from the PR to `[#xyz] $TITLE` |
 | `release notes: to be added`  | These PRs will be marked by the script as a prominent TODO item. Check these PRs manually, and after updating them appropriately, relabel these items to either `release notes: added` or `release notes: use title` |
 | none of the above             | These PRs will be added to a separate prominent TODO category. Check these PRs manually, and after updating them appropriately, relabel these items to one of `release notes: added`, `release notes: use title`, or `release notes: not needed` |
 


### PR DESCRIPTION
Resolves the following warning that is in every documentation building log.

```julia
[ Info: HTMLWriter: rendering HTML pages.
┌ Warning: Unexpected Julia interpolation in the Markdown. This probably means that you
│ have an unbalanced or un-escaped $ in the text.
│ 
│ To write the dollar sign, escape it with `\$`
│ 
│ We don't have the file or line number available, but we got given the value:
│ 
│ `TITLE` which is of type `Symbol`
└ @ Documenter.HTMLWriter ~/.julia/packages/Documenter/QLA7E/src/html/HTMLWriter.jl:2312
```

visual change:
master:
![image](https://github.com/user-attachments/assets/c4fe6ada-600c-4175-8a6e-b8a5beb3b234)


this PR:
![image](https://github.com/user-attachments/assets/60490307-f70d-44fa-af8d-6f95c6142a45)
