### PR TITLE
Add explanatory remark in  groebner_bases.md

### DIFF
--- a/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
@@ -308,6 +308,9 @@ standard_basis_with_transformation_matrix(I::MPolyIdeal;
     complete_reduction::Bool=false)
 ```
 
+!!! note
+The strategy behind the `groebner_basis` function and the strategy behind the function `groebner_basis_with_transformation_matrix` differ. As a consequence, the computed generators may differ. Even if `complete_reduction` is set to `true`, the generators might still only agree up to multiplication by units.
+
 ### Gröbner Basis Conversion Algorithms
 
 The performance of Buchberger's Gröbner basis algorithm is sensitive to the choice of monomial ordering.


### PR DESCRIPTION
explicitly mention that groebner_basis and groebner_basis_with_transformation_matrix may return different results