### PR TITLE
Collapse docstrings in documentation to allow for easier navigation

### DIFF
--- a/docs/src/AlgebraicGeometry/AlgebraicSets/AffineAlgebraicSet.md
+++ b/docs/src/AlgebraicGeometry/AlgebraicSets/AffineAlgebraicSet.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/AlgebraicGeometry/AlgebraicSets/ProjectiveAlgebraicSet.md
+++ b/docs/src/AlgebraicGeometry/AlgebraicSets/ProjectiveAlgebraicSet.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/AlgebraicGeometry/AlgebraicVarieties/AffineVariety.md
+++ b/docs/src/AlgebraicGeometry/AlgebraicVarieties/AffineVariety.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/AlgebraicGeometry/AlgebraicVarieties/ProjectiveVariety.md
+++ b/docs/src/AlgebraicGeometry/AlgebraicVarieties/ProjectiveVariety.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/AlgebraicGeometry/Curves/AffinePlaneCurves.md
+++ b/docs/src/AlgebraicGeometry/Curves/AffinePlaneCurves.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Affine plane curves

--- a/docs/src/AlgebraicGeometry/Curves/ParametrizationPlaneCurves.md
+++ b/docs/src/AlgebraicGeometry/Curves/ParametrizationPlaneCurves.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Rational Parametrizations of Rational Plane Curves

--- a/docs/src/AlgebraicGeometry/Curves/ProjectiveCurves.md
+++ b/docs/src/AlgebraicGeometry/Curves/ProjectiveCurves.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Projective Curves

--- a/docs/src/AlgebraicGeometry/Curves/ProjectivePlaneCurves.md
+++ b/docs/src/AlgebraicGeometry/Curves/ProjectivePlaneCurves.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 # Projective Plane Curves
 ```@docs

--- a/docs/src/AlgebraicGeometry/FrameWorks/ArchitectureOfAffineSchemes.md
+++ b/docs/src/AlgebraicGeometry/FrameWorks/ArchitectureOfAffineSchemes.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 

--- a/docs/src/AlgebraicGeometry/Miscellaneous/miscellaneous.md
+++ b/docs/src/AlgebraicGeometry/Miscellaneous/miscellaneous.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Some Special Ideals

--- a/docs/src/AlgebraicGeometry/Schemes/AffineSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/AffineSchemes.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 

--- a/docs/src/AlgebraicGeometry/Schemes/CoveredSchemeMorphisms.md
+++ b/docs/src/AlgebraicGeometry/Schemes/CoveredSchemeMorphisms.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Morphisms of covered schemes

--- a/docs/src/AlgebraicGeometry/Schemes/CoveredSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/CoveredSchemes.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Covered schemes

--- a/docs/src/AlgebraicGeometry/Schemes/CoveringsAndGluings.md
+++ b/docs/src/AlgebraicGeometry/Schemes/CoveringsAndGluings.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Coverings

--- a/docs/src/AlgebraicGeometry/Schemes/Cycles.md
+++ b/docs/src/AlgebraicGeometry/Schemes/Cycles.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Cycles and divisors 

--- a/docs/src/AlgebraicGeometry/Schemes/GeneralSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/GeneralSchemes.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # General schemes

--- a/docs/src/AlgebraicGeometry/Schemes/MorphismsOfAffineSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/MorphismsOfAffineSchemes.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 

--- a/docs/src/AlgebraicGeometry/Schemes/MorphismsOfProjectiveSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/MorphismsOfProjectiveSchemes.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Morphisms of projective schemes

--- a/docs/src/AlgebraicGeometry/Schemes/ProjectiveSchemes.md
+++ b/docs/src/AlgebraicGeometry/Schemes/ProjectiveSchemes.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 

--- a/docs/src/AlgebraicGeometry/Schemes/RationalPointsAffine.md
+++ b/docs/src/AlgebraicGeometry/Schemes/RationalPointsAffine.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/AlgebraicGeometry/Schemes/RationalPointsProjective.md
+++ b/docs/src/AlgebraicGeometry/Schemes/RationalPointsProjective.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/AlgebraicGeometry/Schemes/Sheaves.md
+++ b/docs/src/AlgebraicGeometry/Schemes/Sheaves.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Sheaves on covered schemes

--- a/docs/src/AlgebraicGeometry/Schemes/intro.md
+++ b/docs/src/AlgebraicGeometry/Schemes/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Introduction

--- a/docs/src/AlgebraicGeometry/SheafCohomology/sheaf_cohomology.md
+++ b/docs/src/AlgebraicGeometry/SheafCohomology/sheaf_cohomology.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/AlgebraicGeometry/Surfaces/AdjunctionProcess.md
+++ b/docs/src/AlgebraicGeometry/Surfaces/AdjunctionProcess.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Adjunction Process for Surfaces

--- a/docs/src/AlgebraicGeometry/Surfaces/EllipticSurface.md
+++ b/docs/src/AlgebraicGeometry/Surfaces/EllipticSurface.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Elliptic Surfaces

--- a/docs/src/AlgebraicGeometry/Surfaces/EnriquesSurfaces.md
+++ b/docs/src/AlgebraicGeometry/Surfaces/EnriquesSurfaces.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Borcherds' method for Enriques surfaces

--- a/docs/src/AlgebraicGeometry/Surfaces/K3Surfaces.md
+++ b/docs/src/AlgebraicGeometry/Surfaces/K3Surfaces.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Automorphism Groups of  K3 surfaces

--- a/docs/src/AlgebraicGeometry/Surfaces/ParametrizationSurfaces.md
+++ b/docs/src/AlgebraicGeometry/Surfaces/ParametrizationSurfaces.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Rational Parametrization of Rational Surfaces

--- a/docs/src/AlgebraicGeometry/Surfaces/SurfacesP4.md
+++ b/docs/src/AlgebraicGeometry/Surfaces/SurfacesP4.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/AlgebraicGeometry/Surfaces/duValSing.md
+++ b/docs/src/AlgebraicGeometry/Surfaces/duValSing.md
@@ -1,6 +1,7 @@
 
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Classifier/identifier specifically for du Val singularities

--- a/docs/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # The Chow ring

--- a/docs/src/AlgebraicGeometry/ToricVarieties/BlowupMorphisms.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/BlowupMorphisms.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Toric Blowups (Experimental)

--- a/docs/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 

--- a/docs/src/AlgebraicGeometry/ToricVarieties/CyclicQuotientSingularities.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/CyclicQuotientSingularities.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Cyclic Quotient Singularities

--- a/docs/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/NormalToricVarieties.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Normal Toric Varieties

--- a/docs/src/AlgebraicGeometry/ToricVarieties/Subvarieties.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/Subvarieties.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 

--- a/docs/src/AlgebraicGeometry/ToricVarieties/ToricDivisorClasses.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/ToricDivisorClasses.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 

--- a/docs/src/AlgebraicGeometry/ToricVarieties/ToricDivisors.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/ToricDivisors.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 

--- a/docs/src/AlgebraicGeometry/ToricVarieties/ToricIdealSheaves.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/ToricIdealSheaves.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 

--- a/docs/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 

--- a/docs/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/ToricMorphisms.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # ToricMorphisms

--- a/docs/src/AlgebraicGeometry/ToricVarieties/ToricSchemes.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/ToricSchemes.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Toric Schemes

--- a/docs/src/AlgebraicGeometry/ToricVarieties/cohomCalg.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/cohomCalg.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 

--- a/docs/src/AlgebraicGeometry/ToricVarieties/intro.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 

--- a/docs/src/AlgebraicGeometry/intro.md
+++ b/docs/src/AlgebraicGeometry/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Introduction

--- a/docs/src/Combinatorics/EnumerativeCombinatorics/partitions.md
+++ b/docs/src/Combinatorics/EnumerativeCombinatorics/partitions.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Combinatorics/graphs.md
+++ b/docs/src/Combinatorics/graphs.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Graphs

--- a/docs/src/Combinatorics/intro.md
+++ b/docs/src/Combinatorics/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Introduction

--- a/docs/src/Combinatorics/matroids.md
+++ b/docs/src/Combinatorics/matroids.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Matroids

--- a/docs/src/Combinatorics/phylogenetic_trees.md
+++ b/docs/src/Combinatorics/phylogenetic_trees.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Phylogenetic Trees

--- a/docs/src/Combinatorics/simplicialcomplexes.md
+++ b/docs/src/Combinatorics/simplicialcomplexes.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Simplicial Complexes

--- a/docs/src/CommutativeAlgebra/FrameWorks/module_localizations.md
+++ b/docs/src/CommutativeAlgebra/FrameWorks/module_localizations.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Localizations of modules over computable rings

--- a/docs/src/CommutativeAlgebra/FrameWorks/ring_localizations.md
+++ b/docs/src/CommutativeAlgebra/FrameWorks/ring_localizations.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases_integers.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases_integers.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/CommutativeAlgebra/GroebnerBases/orderings.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/orderings.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/CommutativeAlgebra/Miscellaneous/binomial_ideals.md
+++ b/docs/src/CommutativeAlgebra/Miscellaneous/binomial_ideals.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/complexes.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/complexes.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/free_modules.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/free_modules.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/hom_operations.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/hom_operations.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Operations on Module Maps

--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/ideals_quorings_as_modules.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/ideals_quorings_as_modules.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Ideals and Quotient Rings as Modules

--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/intro.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # [Introduction](@id modules_multivariate)

--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/module_operations.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/module_operations.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Operations on Modules

--- a/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/subquotients.md
+++ b/docs/src/CommutativeAlgebra/ModulesOverMultivariateRings/subquotients.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/CommutativeAlgebra/affine_algebras.md
+++ b/docs/src/CommutativeAlgebra/affine_algebras.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/CommutativeAlgebra/homological_algebra.md
+++ b/docs/src/CommutativeAlgebra/homological_algebra.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/CommutativeAlgebra/ideals.md
+++ b/docs/src/CommutativeAlgebra/ideals.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/CommutativeAlgebra/intro.md
+++ b/docs/src/CommutativeAlgebra/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # [Introduction](@id commutative_algebra)

--- a/docs/src/CommutativeAlgebra/localizations.md
+++ b/docs/src/CommutativeAlgebra/localizations.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/CommutativeAlgebra/rings.md
+++ b/docs/src/CommutativeAlgebra/rings.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/DeveloperDocumentation/caching.md
+++ b/docs/src/DeveloperDocumentation/caching.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/DeveloperDocumentation/parallel.md
+++ b/docs/src/DeveloperDocumentation/parallel.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Experimental/Singularities/intro.md
+++ b/docs/src/Experimental/Singularities/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Introduction

--- a/docs/src/Experimental/Singularities/space_germs.md
+++ b/docs/src/Experimental/Singularities/space_germs.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Space Germs

--- a/docs/src/Fields/algebraic_closure_fp.md
+++ b/docs/src/Fields/algebraic_closure_fp.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Fields/intro.md
+++ b/docs/src/Fields/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/General/architecture.md
+++ b/docs/src/General/architecture.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/General/faq.md
+++ b/docs/src/General/faq.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Groups/action.md
+++ b/docs/src/Groups/action.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Groups/autgroup.md
+++ b/docs/src/Groups/autgroup.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Groups/basics.md
+++ b/docs/src/Groups/basics.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Groups/fpgroup.md
+++ b/docs/src/Groups/fpgroup.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Groups/group_characters.md
+++ b/docs/src/Groups/group_characters.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Groups/grouphom.md
+++ b/docs/src/Groups/grouphom.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Groups/grouplib.md
+++ b/docs/src/Groups/grouplib.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Groups/intro.md
+++ b/docs/src/Groups/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Groups/matgroup.md
+++ b/docs/src/Groups/matgroup.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Groups/pcgroup.md
+++ b/docs/src/Groups/pcgroup.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Groups/permgroup.md
+++ b/docs/src/Groups/permgroup.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Groups/products.md
+++ b/docs/src/Groups/products.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Groups/quotients.md
+++ b/docs/src/Groups/quotients.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Groups/recog.md
+++ b/docs/src/Groups/recog.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Groups/subgroups.md
+++ b/docs/src/Groups/subgroups.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Groups/tom.md
+++ b/docs/src/Groups/tom.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/InvariantTheory/finite_groups.md
+++ b/docs/src/InvariantTheory/finite_groups.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/InvariantTheory/intro.md
+++ b/docs/src/InvariantTheory/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # [Introduction](@id invariant_theory)

--- a/docs/src/InvariantTheory/reductive_groups.md
+++ b/docs/src/InvariantTheory/reductive_groups.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Invariants of Linearly Reductive Groups

--- a/docs/src/InvariantTheory/tori.md
+++ b/docs/src/InvariantTheory/tori.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Invariants of Tori

--- a/docs/src/LieTheory/cartan_matrix.md
+++ b/docs/src/LieTheory/cartan_matrix.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/LieTheory/intro.md
+++ b/docs/src/LieTheory/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/LieTheory/root_systems.md
+++ b/docs/src/LieTheory/root_systems.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/LieTheory/weight_lattices.md
+++ b/docs/src/LieTheory/weight_lattices.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/LieTheory/weyl_groups.md
+++ b/docs/src/LieTheory/weyl_groups.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/LinearAlgebra/intro.md
+++ b/docs/src/LinearAlgebra/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/NoncommutativeAlgebra/PBWAlgebras/creation.md
+++ b/docs/src/NoncommutativeAlgebra/PBWAlgebras/creation.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/NoncommutativeAlgebra/PBWAlgebras/ideals.md
+++ b/docs/src/NoncommutativeAlgebra/PBWAlgebras/ideals.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/NoncommutativeAlgebra/PBWAlgebras/intro.md
+++ b/docs/src/NoncommutativeAlgebra/PBWAlgebras/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/NoncommutativeAlgebra/PBWAlgebras/quotients.md
+++ b/docs/src/NoncommutativeAlgebra/PBWAlgebras/quotients.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/NoncommutativeAlgebra/free_associative_algebra.md
+++ b/docs/src/NoncommutativeAlgebra/free_associative_algebra.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Free Associative Algebras

--- a/docs/src/NoncommutativeAlgebra/intro.md
+++ b/docs/src/NoncommutativeAlgebra/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Introduction

--- a/docs/src/NumberTheory/abelian_closure.md
+++ b/docs/src/NumberTheory/abelian_closure.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/NumberTheory/galois.md
+++ b/docs/src/NumberTheory/galois.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/NumberTheory/intro.md
+++ b/docs/src/NumberTheory/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # [Introduction](@id number_theory)

--- a/docs/src/NumberTheory/vinberg.md
+++ b/docs/src/NumberTheory/vinberg.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/PolyhedralGeometry/Optimization/linear_programs.md
+++ b/docs/src/PolyhedralGeometry/Optimization/linear_programs.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/PolyhedralGeometry/Optimization/mixed_integer_linear_programs.md
+++ b/docs/src/PolyhedralGeometry/Optimization/mixed_integer_linear_programs.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Mixed Integer Linear Programs

--- a/docs/src/PolyhedralGeometry/Polyhedra/auxiliary.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/auxiliary.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Auxiliary functions

--- a/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/constructions.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/PolyhedralGeometry/Polyhedra/intro.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Introduction

--- a/docs/src/PolyhedralGeometry/Polyhedra/polymake.md
+++ b/docs/src/PolyhedralGeometry/Polyhedra/polymake.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/PolyhedralGeometry/cones.md
+++ b/docs/src/PolyhedralGeometry/cones.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/PolyhedralGeometry/fans.md
+++ b/docs/src/PolyhedralGeometry/fans.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/PolyhedralGeometry/intro.md
+++ b/docs/src/PolyhedralGeometry/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/PolyhedralGeometry/polyhedral_complexes.md
+++ b/docs/src/PolyhedralGeometry/polyhedral_complexes.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Polyhedral Complexes

--- a/docs/src/PolyhedralGeometry/subdivisions_of_points.md
+++ b/docs/src/PolyhedralGeometry/subdivisions_of_points.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Rings/integer.md
+++ b/docs/src/Rings/integer.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Rings/intro.md
+++ b/docs/src/Rings/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/Rings/rational.md
+++ b/docs/src/Rings/rational.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/docs/src/StraightLinePrograms/intro.md
+++ b/docs/src/StraightLinePrograms/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 

--- a/docs/src/TropicalGeometry/hypersurface.md
+++ b/docs/src/TropicalGeometry/hypersurface.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 # Tropical hypersurfaces

--- a/docs/src/TropicalGeometry/intro.md
+++ b/docs/src/TropicalGeometry/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 ```
 
 # Introduction

--- a/experimental/AlgebraicShifting/docs/src/exterior_shifting.md
+++ b/experimental/AlgebraicShifting/docs/src/exterior_shifting.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/AlgebraicShifting/docs/src/introduction.md
+++ b/experimental/AlgebraicShifting/docs/src/introduction.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/AlgebraicShifting/docs/src/partial_shift_graph.md
+++ b/experimental/AlgebraicShifting/docs/src/partial_shift_graph.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/AlgebraicStatistics/docs/src/ci.md
+++ b/experimental/AlgebraicStatistics/docs/src/ci.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/AlgebraicStatistics/docs/src/gaussian_graphical_models.md
+++ b/experimental/AlgebraicStatistics/docs/src/gaussian_graphical_models.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/AlgebraicStatistics/docs/src/graphical_models.md
+++ b/experimental/AlgebraicStatistics/docs/src/graphical_models.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/AlgebraicStatistics/docs/src/introduction.md
+++ b/experimental/AlgebraicStatistics/docs/src/introduction.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/AlgebraicStatistics/docs/src/markov.md
+++ b/experimental/AlgebraicStatistics/docs/src/markov.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/AlgebraicStatistics/docs/src/phylogenetics.md
+++ b/experimental/AlgebraicStatistics/docs/src/phylogenetics.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/BasisLieHighestWeight/docs/src/introduction.md
+++ b/experimental/BasisLieHighestWeight/docs/src/introduction.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/BasisLieHighestWeight/docs/src/user_functions.md
+++ b/experimental/BasisLieHighestWeight/docs/src/user_functions.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/DoubleAndHyperComplexes/docs/src/advice_for_the_programmer.md
+++ b/experimental/DoubleAndHyperComplexes/docs/src/advice_for_the_programmer.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/DoubleAndHyperComplexes/docs/src/user_interface.md
+++ b/experimental/DoubleAndHyperComplexes/docs/src/user_interface.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/FTheoryTools/docs/src/g4.md
+++ b/experimental/FTheoryTools/docs/src/g4.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/FTheoryTools/docs/src/generalities.md
+++ b/experimental/FTheoryTools/docs/src/generalities.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/FTheoryTools/docs/src/hypersurface.md
+++ b/experimental/FTheoryTools/docs/src/hypersurface.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/FTheoryTools/docs/src/introduction.md
+++ b/experimental/FTheoryTools/docs/src/introduction.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/FTheoryTools/docs/src/literature.md
+++ b/experimental/FTheoryTools/docs/src/literature.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/FTheoryTools/docs/src/tate.md
+++ b/experimental/FTheoryTools/docs/src/tate.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/FTheoryTools/docs/src/weierstrass.md
+++ b/experimental/FTheoryTools/docs/src/weierstrass.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/GroebnerWalk/docs/src/introduction.md
+++ b/experimental/GroebnerWalk/docs/src/introduction.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/GroebnerWalk/docs/src/special-ideals.md
+++ b/experimental/GroebnerWalk/docs/src/special-ideals.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/IntersectionTheory/docs/src/AbstractBundles.md
+++ b/experimental/IntersectionTheory/docs/src/AbstractBundles.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/IntersectionTheory/docs/src/AbstractVarieties.md
+++ b/experimental/IntersectionTheory/docs/src/AbstractVarieties.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/IntersectionTheory/docs/src/AbstractVarietyMaps.md
+++ b/experimental/IntersectionTheory/docs/src/AbstractVarietyMaps.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/IntersectionTheory/docs/src/BlowUps.md
+++ b/experimental/IntersectionTheory/docs/src/BlowUps.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/IntersectionTheory/docs/src/BottFormulas.md
+++ b/experimental/IntersectionTheory/docs/src/BottFormulas.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/IntersectionTheory/docs/src/examples.md
+++ b/experimental/IntersectionTheory/docs/src/examples.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/IntersectionTheory/docs/src/intro.md
+++ b/experimental/IntersectionTheory/docs/src/intro.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/IntersectionTheory/docs/src/schubert.md
+++ b/experimental/IntersectionTheory/docs/src/schubert.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/LieAlgebras/docs/src/ideals_and_subalgebras.md
+++ b/experimental/LieAlgebras/docs/src/ideals_and_subalgebras.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/LieAlgebras/docs/src/introduction.md
+++ b/experimental/LieAlgebras/docs/src/introduction.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/LieAlgebras/docs/src/lie_algebra_homs.md
+++ b/experimental/LieAlgebras/docs/src/lie_algebra_homs.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/LieAlgebras/docs/src/lie_algebras.md
+++ b/experimental/LieAlgebras/docs/src/lie_algebras.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/LieAlgebras/docs/src/module_homs.md
+++ b/experimental/LieAlgebras/docs/src/module_homs.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/LieAlgebras/docs/src/modules.md
+++ b/experimental/LieAlgebras/docs/src/modules.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/LieAlgebras/docs/src/weyl_groups_experimental.md
+++ b/experimental/LieAlgebras/docs/src/weyl_groups_experimental.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/LinearQuotients/docs/src/cox_rings.md
+++ b/experimental/LinearQuotients/docs/src/cox_rings.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/LinearQuotients/docs/src/introduction.md
+++ b/experimental/LinearQuotients/docs/src/introduction.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/LinearQuotients/docs/src/linear_quotients.md
+++ b/experimental/LinearQuotients/docs/src/linear_quotients.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/MatroidRealizationSpaces/docs/src/introduction.md
+++ b/experimental/MatroidRealizationSpaces/docs/src/introduction.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/OrthogonalDiscriminants/docs/src/access.md
+++ b/experimental/OrthogonalDiscriminants/docs/src/access.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar.OrthogonalDiscriminants
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/OrthogonalDiscriminants/docs/src/compute.md
+++ b/experimental/OrthogonalDiscriminants/docs/src/compute.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar.OrthogonalDiscriminants
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/OrthogonalDiscriminants/docs/src/introduction.md
+++ b/experimental/OrthogonalDiscriminants/docs/src/introduction.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/OrthogonalDiscriminants/docs/src/misc.md
+++ b/experimental/OrthogonalDiscriminants/docs/src/misc.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar.OrthogonalDiscriminants
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/PartitionedPermutations/docs/src/introduction.md
+++ b/experimental/PartitionedPermutations/docs/src/introduction.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/QuadFormAndIsom/docs/src/enumeration.md
+++ b/experimental/QuadFormAndIsom/docs/src/enumeration.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/QuadFormAndIsom/docs/src/introduction.md
+++ b/experimental/QuadFormAndIsom/docs/src/introduction.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/QuadFormAndIsom/docs/src/latwithisom.md
+++ b/experimental/QuadFormAndIsom/docs/src/latwithisom.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/QuadFormAndIsom/docs/src/primembed.md
+++ b/experimental/QuadFormAndIsom/docs/src/primembed.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/QuadFormAndIsom/docs/src/spacewithisom.md
+++ b/experimental/QuadFormAndIsom/docs/src/spacewithisom.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 

--- a/experimental/StandardFiniteFields/docs/src/introduction.md
+++ b/experimental/StandardFiniteFields/docs/src/introduction.md
@@ -1,5 +1,6 @@
 ```@meta
 CurrentModule = Oscar
+CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 


### PR DESCRIPTION
I noticed that with collapsed docstrings (by default) the pages look much clearer if single docstrings are long (because of examples). There is a button to do it at the top right corner, but l add it here directly, so that we can compare it easier.

Collapsed by default: https://docs.oscar-system.org/previews/PR4758/CommutativeAlgebra/ideals/
Current verion: https://docs.oscar-system.org/dev/CommutativeAlgebra/ideals/
