### PR TITLE
improvements for the group atlas

### DIFF
--- a/src/Groups/libraries/atlasgroups.jl
+++ b/src/Groups/libraries/atlasgroups.jl
@@ -29,7 +29,15 @@ ERROR: ArgumentError: the group atlas does not provide a representation for M
 """
 function atlas_group(name::String)
   G = GAP.Globals.AtlasGroup(GapObj(name))
-  @req (G !== GAP.Globals.fail) "the group atlas does not provide a representation for $name"
+  if G === GAP.Globals.fail
+    # Check whether the table of contents provides a representation.
+    l = GAP.Globals.AGR.MergedTableOfContents(GapObj("all"), GapObj(gapname))::GapObj
+    if length(l) != 0
+      error("cannot access the group atlas, perhaps the download failed")
+    else
+      throw(ArgumentError("the group atlas does not provide a representation for $name"))
+    end
+  end
   return _oscar_group(G)
 end
 
@@ -39,7 +47,22 @@ function atlas_group(::Type{T}, name::String) where T <: Union{PermGroup, Matrix
   else
     G = GAP.Globals.AtlasGroup(GapObj(name), GAP.Globals.IsMatrixGroup, true)::GapObj
   end
-  @req (G !== GAP.Globals.fail) "the group atlas does not provide a representation of type $T for $name"
+
+  if G === GAP.Globals.fail
+    # Check whether the table of contents provides a representation.
+    l = GAP.Globals.AGR.MergedTableOfContents(GapObj("all"), GapObj(gapname))::GapObj
+    permtype = GapObj("perm")::GapObj
+    if T === PermGroup
+      l = filter(x -> x.type == permtype, l)
+    else
+      l = filter(x -> x.type != permtype, l)
+    end
+    if length(l) != 0
+      error("cannot access the group atlas, perhaps the download failed")
+    else
+      throw(ArgumentError("the group atlas does not provide a representation of type $T for $name"))
+    end
+  end
   return _oscar_group(G)
 end
 
@@ -65,10 +88,13 @@ Permutation group of degree 5 and order 60
 function atlas_group(info::Dict)
   gapname = info[:name]
   l = GAP.Globals.AGR.MergedTableOfContents(GapObj("all"), GapObj(gapname))::GapObj
-  pos = findfirst(r -> String(r.repname) == info[:repname], Vector{GapObj}(l))
-  @req (pos !== nothing) "no Atlas group for $info"
+  repname = info[:repname]
+  pos = findfirst(r -> String(r.repname) == repname, Vector{GapObj}(l))
+  @req (pos !== nothing) "no Atlas group for $repname"
   G = GAP.Globals.AtlasGroup(l[pos])
-  @req (G !== GAP.Globals.fail) "the group atlas does not provide a representation for $info"
+  # The table of contents knows about the requested representation.
+  # If the result is `fail` then this is likely due to a download problem.
+  @req (G !== GAP.Globals.fail) "cannot access the representation $repname from the group atlas, perhaps the download failed"
 
   if haskey(info, :base_ring_iso)
     # make sure that the given ring is used
@@ -133,8 +159,15 @@ function atlas_subgroup(G::GAPGroup, nr::Int)
   @req (info.groupname == info.identifier[1]) "$G was not constructed with atlas_group"
   H = GAP.Globals.AtlasSubgroup(GapObj(G), nr)
   if H === GAP.Globals.fail
+    # Check whether the table of contents provides the SLP in question.
+    slp = GAP.Globals.AtlasProgramInfo(info.groupname, GapObj("maxes"), nr)
     name = string(info.groupname)
-    error("the group atlas does not provide the restriction to the $nr-th class of maximal subgroups of $name")
+    if slp === GAP.Globals.fail
+      error("the group atlas does not provide the restriction to the $nr-th class of maximal subgroups of $name")
+    else
+      # This is likely due to a download problem.
+      error("cannot access the slp for the restriction to the $nr-th class of maximal subgroups of $name")
+    end
   end
   return _as_subgroup(G, H)
 end
@@ -310,4 +343,149 @@ function atlas_program(name, paras...)
   else
     error("not yet ...")
   end
+end
+
+
+###################################################################
+# Show overviews of available information.
+###################################################################
+
+"""
+    show_atlas_info()
+    show_atlas_info(groupnames::Vector{String})
+    show_atlas_info(groupname::String)
+
+Print information concerning the group atlas about the groups
+given by the arguments.
+
+If the only argument is a vector `groupnames` of strings then
+print one line about each Atlas group whose name is in `groupnames`,
+showing the available information.
+
+If there are no arguments then the same happens as if the vector of all
+names of Atlas groups were entered as `groupnames`.
+
+If the only argument is a string `groupname`, the name of an Atlas group `G`,
+then print an overview of available representations and straight line
+programs for `G`.
+
+The overview for several groups is shown as a table with the following
+columns.
+
+- `group`:
+  the name of `G`
+
+- `#`:
+  the number of faithful representations stored for `G`
+
+- `maxes`:
+  the number of available straight line programs for computing
+  generators of maximal subgroups of `G`,
+
+- `cl`:
+  a `+` sign if at least one program for computing representatives of
+  conjugacy classes of elements of `G` is stored,
+
+- `cyc`:
+  a `+` sign if at least one program for computing representatives of
+  classes of maximally cyclic subgroups of `G` is stored,
+
+- `out`:
+  descriptions of outer automorphisms of `G` for which at least one
+  program is stored,
+
+- `fnd`:
+  a `+` sign if at least one program is available for finding standard
+  generators,
+
+- `chk`:
+  a `+` sign if at least one program is available for checking whether a
+  set of generators is a set of standard generators, and
+
+- `prs`:
+  a `+` sign if at least one program is available that encodes a
+  presentation.
+
+The overview for a single group is shown in the form of two lists,
+one for available representations, one for available straight line programs.
+
+Each available representation is described by either `G <= Sym(nid)` or
+`G <= GL(nid,descr)`, where the former means a permutation representation
+of degree `n` and the latter means a matrix ring of dimension `n` over a
+base ring described by `descr`; if `descr` is an integer then this means
+a finite field with this cardinality.
+In both cases, `id` is a (perhaps empty) identifier that distinguishes
+different representations with the same `n`.
+If known then information about transitivity, rank, point stabillizers of
+permutation representations and about the character of matrix representations
+is shown as well.
+
+Below the representations, the programs available for `groupname` are listed.
+"""
+show_atlas_info() = show_atlas_info("all")
+
+function show_atlas_info(groupnames::Vector{String})
+  # Set a GAP user preference according to Oscar's unicode setting.
+  AtlasRep = GapObj("AtlasRep")
+  DisplayFunction = GapObj("DisplayFunction")
+  if !is_unicode_allowed()
+    oldDisplayFunction = GAP.Globals.UserPreference(AtlasRep, DisplayFunction)
+    GAP.Globals.SetUserPreference(AtlasRep, DisplayFunction, GapObj("Print"));
+  end
+
+  # Remove the marker of non-core data.
+  AtlasRepMarkNonCoreData = GapObj("AtlasRepMarkNonCoreData")
+  oldmarker = GAP.Globals.UserPreference(AtlasRep, AtlasRepMarkNonCoreData)
+  GAP.Globals.SetUserPreference(AtlasRep, AtlasRepMarkNonCoreData, GapObj(""))
+
+  # Show the info
+  info = GAP.Globals.AGR.StringAtlasInfoOverview(GapObj(groupnames, true),
+             GapObj([])) # unconditional
+  for line in info
+    println(String(line));
+  end
+
+  # Reset the changed values.
+  if !is_unicode_allowed()
+    GAP.Globals.SetUserPreference(AtlasRep, DisplayFunction, oldDisplayFunction)
+  end
+  GAP.Globals.SetUserPreference(AtlasRep, AtlasRepMarkNonCoreData, oldmarker)
+
+  return
+end
+
+function show_atlas_info(groupname::String)
+  # Set a GAP user preference according to Oscar's unicode setting.
+  AtlasRep = GapObj("AtlasRep")
+  DisplayFunction = GapObj("DisplayFunction")
+  if !is_unicode_allowed()
+    oldvalue = GAP.Globals.UserPreference(AtlasRep, DisplayFunction)
+    GAP.Globals.SetUserPreference(AtlasRep, DisplayFunction, GapObj("Print"));
+  end
+
+  # Remove the marker of non-core data.
+  AtlasRepMarkNonCoreData = GapObj("AtlasRepMarkNonCoreData")
+  oldmarker = GAP.Globals.UserPreference(AtlasRep, AtlasRepMarkNonCoreData)
+  GAP.Globals.SetUserPreference(AtlasRep, AtlasRepMarkNonCoreData, GapObj(""))
+
+  # Show the info
+  if groupname == "all"
+    # one-line overview of all supported groups
+    info = GAP.Globals.AGR.StringAtlasInfoOverview(GapObj(groupnames, true),
+               GapObj([])) # unconditional
+  else
+    # detailed overview for one group
+    info = GAP.Globals.AGR.StringAtlasInfoGroup(GapObj([groupname], true))
+  end
+  for line in info
+    println(String(line));
+  end
+
+  # Reset the changed values.
+  if !is_unicode_allowed()
+    GAP.Globals.SetUserPreference(AtlasRep, DisplayFunction, oldvalue)
+  end
+  GAP.Globals.SetUserPreference(AtlasRep, AtlasRepMarkNonCoreData, oldmarker)
+
+  return
 end

--- a/src/Groups/libraries/atlasgroups.jl
+++ b/src/Groups/libraries/atlasgroups.jl
@@ -28,10 +28,11 @@ ERROR: ArgumentError: the group atlas does not provide a representation for M
 ```
 """
 function atlas_group(name::String)
-  G = GAP.Globals.AtlasGroup(GapObj(name))
+  GAPname = GapObj(name)::GapObj
+  G = GAP.Globals.AtlasGroup(GAPname)::GapObj
   if G === GAP.Globals.fail
     # Check whether the table of contents provides a representation.
-    l = GAP.Globals.AGR.MergedTableOfContents(GapObj("all"), GapObj(gapname))::GapObj
+    l = GAP.Globals.AGR.MergedTableOfContents(GapObj("all"), GAPname)::GapObj
     if length(l) != 0
       error("cannot access the group atlas, perhaps the download failed")
     else
@@ -42,20 +43,21 @@ function atlas_group(name::String)
 end
 
 function atlas_group(::Type{T}, name::String) where T <: Union{PermGroup, MatrixGroup}
+  GAPname = GapObj(name)::GapObj
   if T === PermGroup
-    G = GAP.Globals.AtlasGroup(GapObj(name), GAP.Globals.IsPermGroup, true)::GapObj
+    G = GAP.Globals.AtlasGroup(GAPname, GAP.Globals.IsPermGroup, true)::GapObj
   else
-    G = GAP.Globals.AtlasGroup(GapObj(name), GAP.Globals.IsMatrixGroup, true)::GapObj
+    G = GAP.Globals.AtlasGroup(GAPname, GAP.Globals.IsMatrixGroup, true)::GapObj
   end
 
   if G === GAP.Globals.fail
     # Check whether the table of contents provides a representation.
-    l = GAP.Globals.AGR.MergedTableOfContents(GapObj("all"), GapObj(gapname))::GapObj
+    l = GAP.Globals.AGR.MergedTableOfContents(GapObj("all"), GAPname)::GapObj
     permtype = GapObj("perm")::GapObj
     if T === PermGroup
-      l = filter(x -> x.type == permtype, l)
+      l = filter(x -> x.type == permtype, Vector{GapObj}(l))
     else
-      l = filter(x -> x.type != permtype, l)
+      l = filter(x -> x.type != permtype, Vector{GapObj}(l))
     end
     if length(l) != 0
       error("cannot access the group atlas, perhaps the download failed")
@@ -91,14 +93,14 @@ function atlas_group(info::Dict)
   repname = info[:repname]
   pos = findfirst(r -> String(r.repname) == repname, Vector{GapObj}(l))
   @req (pos !== nothing) "no Atlas group for $repname"
-  G = GAP.Globals.AtlasGroup(l[pos])
+  G = GAP.Globals.AtlasGroup(l[pos])::GapObj
   # The table of contents knows about the requested representation.
   # If the result is `fail` then this is likely due to a download problem.
   @req (G !== GAP.Globals.fail) "cannot access the representation $repname from the group atlas, perhaps the download failed"
 
   if haskey(info, :base_ring_iso)
     # make sure that the given ring is used
-    deg = GAP.Globals.DimensionOfMatrixGroup(G)
+    deg = GAP.Globals.DimensionOfMatrixGroup(G)::GAP.Obj
     iso = info[:base_ring_iso]
     ring = domain(iso)
     matgrp = matrix_group(ring, deg)
@@ -154,13 +156,13 @@ Permutation group of degree 11 and order 720
 ```
 """
 function atlas_subgroup(G::GAPGroup, nr::Int)
-  @req GAP.Globals.HasAtlasRepInfoRecord(GapObj(G)) "$G was not constructed with atlas_group"
-  info = GAP.Globals.AtlasRepInfoRecord(GapObj(G))
+  @req GAP.Globals.HasAtlasRepInfoRecord(GapObj(G))::Bool "$G was not constructed with atlas_group"
+  info = GAP.Globals.AtlasRepInfoRecord(GapObj(G))::GapObj
   @req (info.groupname == info.identifier[1]) "$G was not constructed with atlas_group"
-  H = GAP.Globals.AtlasSubgroup(GapObj(G), nr)
+  H = GAP.Globals.AtlasSubgroup(GapObj(G), nr)::GapObj
   if H === GAP.Globals.fail
     # Check whether the table of contents provides the SLP in question.
-    slp = GAP.Globals.AtlasProgramInfo(info.groupname, GapObj("maxes"), nr)
+    slp = GAP.Globals.AtlasProgramInfo(info.groupname, GapObj("maxes"), nr)::GapObj
     name = string(info.groupname)
     if slp === GAP.Globals.fail
       error("the group atlas does not provide the restriction to the $nr-th class of maximal subgroups of $name")
@@ -429,18 +431,18 @@ function show_atlas_info(groupnames::Vector{String})
   AtlasRep = GapObj("AtlasRep")
   DisplayFunction = GapObj("DisplayFunction")
   if !is_unicode_allowed()
-    oldDisplayFunction = GAP.Globals.UserPreference(AtlasRep, DisplayFunction)
+    oldDisplayFunction = GAP.Globals.UserPreference(AtlasRep, DisplayFunction)::GAP.Obj
     GAP.Globals.SetUserPreference(AtlasRep, DisplayFunction, GapObj("Print"));
   end
 
   # Remove the marker of non-core data.
   AtlasRepMarkNonCoreData = GapObj("AtlasRepMarkNonCoreData")
-  oldmarker = GAP.Globals.UserPreference(AtlasRep, AtlasRepMarkNonCoreData)
+  oldmarker = GAP.Globals.UserPreference(AtlasRep, AtlasRepMarkNonCoreData)::GAP.Obj
   GAP.Globals.SetUserPreference(AtlasRep, AtlasRepMarkNonCoreData, GapObj(""))
 
   # Show the info
   info = GAP.Globals.AGR.StringAtlasInfoOverview(GapObj(groupnames, true),
-             GapObj([])) # unconditional
+             GapObj([]))::GapObj # unconditional
   for line in info
     println(String(line));
   end
@@ -459,23 +461,23 @@ function show_atlas_info(groupname::String)
   AtlasRep = GapObj("AtlasRep")
   DisplayFunction = GapObj("DisplayFunction")
   if !is_unicode_allowed()
-    oldvalue = GAP.Globals.UserPreference(AtlasRep, DisplayFunction)
+    oldvalue = GAP.Globals.UserPreference(AtlasRep, DisplayFunction)::GAP.Obj
     GAP.Globals.SetUserPreference(AtlasRep, DisplayFunction, GapObj("Print"));
   end
 
   # Remove the marker of non-core data.
   AtlasRepMarkNonCoreData = GapObj("AtlasRepMarkNonCoreData")
-  oldmarker = GAP.Globals.UserPreference(AtlasRep, AtlasRepMarkNonCoreData)
+  oldmarker = GAP.Globals.UserPreference(AtlasRep, AtlasRepMarkNonCoreData)::GAP.Obj
   GAP.Globals.SetUserPreference(AtlasRep, AtlasRepMarkNonCoreData, GapObj(""))
 
   # Show the info
   if groupname == "all"
     # one-line overview of all supported groups
     info = GAP.Globals.AGR.StringAtlasInfoOverview(GapObj(groupnames, true),
-               GapObj([])) # unconditional
+               GapObj([]))::GapObj # unconditional
   else
     # detailed overview for one group
-    info = GAP.Globals.AGR.StringAtlasInfoGroup(GapObj([groupname], true))
+    info = GAP.Globals.AGR.StringAtlasInfoGroup(GapObj([groupname], true))::GapObj
   end
   for line in info
     println(String(line));

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1509,6 +1509,7 @@ export scalar_product
 export scheme
 export scheme_type
 export schensted
+export show_atlas_info
 export schur_cover
 export schur_index
 export schur_multiplier


### PR DESCRIPTION
- improve the error messages shown by `atlas_group` and `atlas_subgroup` in case of failed downloads of data at runtime (as discussed for Nemocas/Nemo.jl/pull/2054)
- add `show_atlas_info` (as discussed in #1557)

Concerning `show_atlas_info`, now on gets the following, similar to the situation in GAP.

```
julia> show_atlas_info(["M11", "M12", "M22"])
group |  # | maxes | cl | cyc | out | fnd | chk | prs
------+----+-------+----+-----+-----+-----+-----+----
M11   | 45 |     5 |  + |  +  |     |  +  |  +  |  + 
M12   | 58 |    11 |  + |  +  |     |  +  |  +  |  + 
M22   | 58 |     8 |  + |  +  |     |  +  |  +  |  + 

julia> show_atlas_info("M11")
Representations for G = M11:    (all refer to std. generators 1)
----------------------------
 1: G <= Sym(11)                   4-trans., on cosets of A6.2_3 (1st max.)
 2: G <= Sym(12)                   3-trans., on cosets of L2(11) (2nd max.)
 3: G <= Sym(22)                   rank 3, on cosets of A6 < A6.2_3
 4: G <= Sym(55)                   rank 3, on cosets of 3^2:Q8.2 (3rd max.)
 5: G <= Sym(66)                   rank 4, on cosets of S5 (4th max.)
 6: G <= Sym(110)                  rank 4, on cosets of 3^2:8 < 3^2:Q8.2
 7: G <= Sym(144)                  rank 6, on cosets of 11:5 < L2(11)
 8: G <= Sym(165)                  rank 8, on cosets of 2.S4 (5th max.)
 9: G <= GL(10,2)                  character 10a
10: G <= GL(32,2)                  character 16ab
11: G <= GL(44,2)                  character 44a
12: G <= GL(5a,3)                  character 5a
13: G <= GL(5b,3)                  character 5b
14: G <= GL(10a,3)                 character 10a
15: G <= GL(10b,3)                 character 10b
16: G <= GL(10c,3)                 character 10c
17: G <= GL(24,3)                  character 24a
18: G <= GL(45,3)                  character 45a
19: G <= GL(16a,4)                 character 16a
20: G <= GL(16b,4)                 character 16b
21: G <= GL(10a,5)                 character 10a
22: G <= GL(11,5)                  character 11a
23: G <= GL(16a,5)                 character 16a
24: G <= GL(16b,5)                 character 16b
25: G <= GL(20,5)                  character 10bc
26: G <= GL(45,5)                  character 45a
27: G <= GL(55,5)                  character 55a
28: G <= GL(9,11)                  character 9a
29: G <= GL(10a,11)                character 10a
30: G <= GL(10b,11)                character 10b
31: G <= GL(11,11)                 character 11a
32: G <= GL(16,11)                 character 16a
33: G <= GL(44,11)                 character 44a
34: G <= GL(55,11)                 character 55a
35: G <= GL(10b,25)                character 10b
36: G <= GL(10c,25)                character 10c
37: G <= GL(10a,Z)                 character 10a
38: G <= GL(11,Z)                  character 11a
39: G <= GL(20,Z)                  character 10bc
40: G <= GL(32,Z)                  character 16ab
41: G <= GL(44,Z)                  character 44a
42: G <= GL(45,Z)                  character 45a
43: G <= GL(55,Z)                  character 55a
44: G <= GL(10b,Field([Sqrt(-2)])) character 10b
45: G <= GL(10c,Field([Sqrt(-2)])) character 10c

Programs for G = M11:    (all refer to std. generators 1)
---------------------
- presentation                                        
- repr. cyc. subg.                                    
- std. gen. finder                                    
- class repres.:
  (direct)                                            
  (composed)                                          
- maxes (all 5):
  1:  A6.2_3                                          
  1:  A6.2_3                                  (std. 1)
  2:  L2(11)                                          
  2:  L2(11)                                  (std. 1)
  3:  3^2:Q8.2                                        
  4:  S5                                              
  4:  S5                                      (std. 1)
  5:  2.S4                                            
- standardizations of maxes:
  from 1st max., version 1 to A6.2_3, std. 1          
  from 2nd max., version 1 to L2(11), std. 1          
  from 4th max., version 1 to A5.2, std. 1            
- std. gen. checker:
  (check)                                             
  (pres)             
```
(The output is a bit nicer if unicode is allowed.)