### PR TITLE
Use `Set` for `GSet` block systems

### DIFF
--- a/docs/src/Groups/action.md
+++ b/docs/src/Groups/action.md
@@ -79,7 +79,6 @@ is_semiregular(Omega::GSet)
 
 If we have a G-set $\Omega$, a *block system* of $\Omega$ is a partition that is invariant under the action of the associated group.
 The group action on $\Omega$ induces a natural action on such a partition.
-If the action is not transitive, then the orbits naturally form a block system.
 
 When calling these methods with a `GSet` as the argument, we require that the group action is transitive.
 The blocks are returned as Julia `Set` objects.

--- a/docs/src/Groups/action.md
+++ b/docs/src/Groups/action.md
@@ -81,7 +81,7 @@ If we have a G-set $\Omega$, a *block system* of $\Omega$ is a partition that is
 The group action on $\Omega$ induces a natural action on such a partition.
 If the action is not transitive, then the orbits naturally form a block system.
 
-When calling these methods with a `Gset` as the argument, we require that the group action is transitive.
+When calling these methods with a `GSet` as the argument, we require that the group action is transitive.
 The blocks are returned as Julia `Set` objects.
 Note that this is in contrast to the return type when calling the methods with a `PermGroup` as the argument, in which case the blocks are sorted vectors of integers.
 

--- a/docs/src/Groups/action.md
+++ b/docs/src/Groups/action.md
@@ -69,13 +69,27 @@ orbit(G::PermGroup, omega)
 orbits(Omega::T) where T <: GSetByElements{TG} where TG <: GAPGroup
 is_transitive(Omega::GSet)
 transitivity(Omega::GSet)
+rank_action(Omega::GSet)
+is_primitive(Omega::GSet)
+is_regular(Omega::GSet)
+is_semiregular(Omega::GSet)
+```
+
+## Block systems of a G-set
+
+If we have a G-set $\Omega$, a *block system* of $\Omega$ is a partition that is invariant under the action of the associated group.
+The group action on $\Omega$ induces a natural action on such a partition.
+If the action is not transitive, then the orbits naturally form a block system.
+
+When calling these methods with a `Gset` as the argument, we require that the group action is transitive.
+The blocks are returned as Julia `Set` objects.
+Note that this is in contrast to the return type when calling the methods with a `PermGroup` as the argument, in which case the blocks are sorted vectors of integers.
+
+```@docs
 blocks(Omega::GSet)
 maximal_blocks(Omega::GSet)
 minimal_block_reps(Omega::GSet)
 all_blocks(Omega::GSet)
-rank_action(Omega::GSet)
-is_regular(Omega::GSet)
-is_semiregular(Omega::GSet)
 ```
 
 

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -988,7 +988,7 @@ function maximal_blocks(Omega::GSet)
   L = moved_points(G)
   bl = Vector{Vector{Int}}(GAP.Globals.MaximalBlocks(GapObj(G), GapObj(L))::GapObj)
   # NOTE convert to action of `acting_group(Omega)` on subsets of Omega using `action_function`
-  bl = map(A -> map(x -> Omega[x], A), bl)
+  bl = map(A -> Set(map(x -> Omega[x], A)), bl)
   return gset(acting_group(Omega), on_sets, bl; closed = true)
 end
 
@@ -1022,7 +1022,7 @@ function minimal_block_reps(Omega::GSet)
   L = moved_points(G)
   bl =  Vector{Vector{Int}}(GAP.Globals.RepresentativesMinimalBlocks(GapObj(G), GapObj(L))::GapObj)
 
-  return map(A -> map(x -> Omega[x], A), bl)
+  return map(A -> Set(map(x -> Omega[x], A)), bl)
 end
 
 """
@@ -1057,7 +1057,7 @@ function all_blocks(Omega::GSet)
   G = image(action_homomorphism(Omega))[1]
   bl = Vector{Vector{Int}}(GAP.Globals.AllBlocks(GapObj(G)))
 
-  return map(A -> map(x -> Omega[x], A), bl)
+  return map(A -> Set(map(x -> Omega[x], A)), bl)
 end
 
 """

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -955,7 +955,7 @@ function blocks(Omega::GSet)
   L = moved_points(G)
   bl = Vector{Vector{Int}}(GAP.Globals.Blocks(GapObj(G), GapObj(L))::GapObj)
   # NOTE convert to action of `acting_group(Omega)` on subsets of Omega using `action_function`
-  bl = map(A -> map(x -> Omega[x], A), bl)
+  bl = map(A -> Set(map(x -> Omega[x], A)), bl)
   return gset(acting_group(Omega), on_sets, bl; closed = true)
 end
 

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -944,9 +944,9 @@ G-set of
   with seeds 1:4
 
 julia> collect(blocks(Omega))
-2-element Vector{Vector{Int64}}:
- [1, 2]
- [3, 4]
+2-element Vector{Set{Int64}}:
+ Set([2, 1])
+ Set([4, 3])
 ```
 """
 function blocks(Omega::GSet)
@@ -977,9 +977,9 @@ G-set of
   with seeds 1:8
 
 julia> collect(maximal_blocks(Omega))
-2-element Vector{Vector{Int64}}:
- [1, 2, 3, 8]
- [4, 5, 6, 7]
+2-element Vector{Set{Int64}}:
+ Set([2, 8, 3, 1])
+ Set([5, 4, 6, 7])
 ```
 """
 function maximal_blocks(Omega::GSet)
@@ -1010,10 +1010,10 @@ G-set of
   with seeds 1:8
 
 julia> minimal_block_reps(Omega)
-3-element Vector{Vector{Int64}}:
- [1, 3]
- [1, 5]
- [1, 7]
+3-element Vector{Set{Int64}}:
+ Set([3, 1])
+ Set([5, 1])
+ Set([7, 1])
 ```
 """
 function minimal_block_reps(Omega::GSet)
@@ -1043,13 +1043,13 @@ G-set of
   with seeds 1:8
 
 julia> all_blocks(Omega)
-6-element Vector{Vector{Int64}}:
- [1, 2, 3, 8]
- [1, 5]
- [1, 3, 5, 7]
- [1, 3]
- [1, 3, 4, 6]
- [1, 7]
+6-element Vector{Set{Int64}}:
+ Set([2, 8, 3, 1])
+ Set([5, 1])
+ Set([5, 7, 3, 1])
+ Set([3, 1])
+ Set([4, 6, 3, 1])
+ Set([7, 1])
 ```
 """
 function all_blocks(Omega::GSet)

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -457,7 +457,7 @@ end
   @test Oscar.action_function(Omega)(x, rep[2]) == y
 end
 
-@testset "General G-set action"
+@testset "General G-set action" begin
   gen_up    = @perm 48 ( 1, 3, 8, 6)( 2, 5, 7, 4)( 9,33,25,17)(10,34,26,18)(11,35,27,19);
   gen_left  = @perm 48 ( 9,11,16,14)(10,13,15,12)( 1,17,41,40)( 4,20,44,37)( 6,22,46,35);
   gen_front = @perm 48 (17,19,24,22)(18,21,23,20)( 6,25,43,16)( 7,28,42,13)( 8,30,41,11);

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -457,6 +457,29 @@ end
   @test Oscar.action_function(Omega)(x, rep[2]) == y
 end
 
+@testset "General G-set action"
+  gen_up    = @perm 48 ( 1, 3, 8, 6)( 2, 5, 7, 4)( 9,33,25,17)(10,34,26,18)(11,35,27,19);
+  gen_left  = @perm 48 ( 9,11,16,14)(10,13,15,12)( 1,17,41,40)( 4,20,44,37)( 6,22,46,35);
+  gen_front = @perm 48 (17,19,24,22)(18,21,23,20)( 6,25,43,16)( 7,28,42,13)( 8,30,41,11);
+  gen_right = @perm 48 (25,27,32,30)(26,29,31,28)( 3,38,43,19)( 5,36,45,21)( 8,33,48,24);
+  gen_back  = @perm 48 (33,35,40,38)(34,37,39,36)( 3, 9,46,32)( 2,12,47,29)( 1,14,48,27);
+  gen_down  = @perm 48 (41,43,48,46)(42,45,47,44)(14,22,30,38)(15,23,31,39)(16,24,32,40);
+  cube = permutation_group(48, [gen_up, gen_left, gen_front, gen_right, gen_back, gen_down]);
+
+  orbs = orbits(cube);
+  @test length(orbs) == 2
+  @test length(orbs[1]) == length(orbs[2]) == 24
+
+  bl = blocks(orbs[1]);
+  @test length(bl) == 8
+
+  h = action_homomorphism(bl);
+  @test order(domain(h)) == 43252003274489856000
+  @test order(image(h)[1]) == 40320
+end
+
+
+
 @testset "G-sets by left transversals" begin
   G = symmetric_group(5)
   H = sylow_subgroup(G, 2)[1]


### PR DESCRIPTION
When we ask for a block system for a `PermGroup` (using the methods `blocks`, `maximal_blocks`, `minimal_block_reps`, or `all_blocks`), the natural `GSet` is the set of integers from 1 to n, this is delegated to GAP and the blocks are returned as sorted vectors of integers, as a `GSet` with the GAP action `on_sets`. 

When we call these methods using a `GSet` as an argument, we want to convert these integers back to elements of the original `GSet` - however in some cases, it means the vectors we have are no longer sorted and so we end up with an error when trying to define the group action `on_sets`. In addition, because of the generality allowed in defining a `GSet`, it may not even be possible to sort these vectors.

To address this, we convert the blocks returned by GAP into Julia `Set` objects. This does create a discrepancy in return types between the `PermGroup` and `GSet` methods, but using `Set` feels natural from a mathematical point of view, and allows us to effectively work with`GSets` in a very general way.

Fixes #4756 