### PR TITLE
Add exceptional classes and indices

### DIFF
--- a/experimental/FTheoryTools/docs/src/literature.md
+++ b/experimental/FTheoryTools/docs/src/literature.md
@@ -66,6 +66,8 @@ weighted_resolution_zero_sections(m::AbstractFTheoryModel)
 zero_section(m::AbstractFTheoryModel)
 zero_section_class(m::AbstractFTheoryModel)
 zero_section_index(m::AbstractFTheoryModel)
+exceptional_classes(m::AbstractFTheoryModel)
+exceptional_divisor_indices(m::AbstractFTheoryModel)
 torsion_sections(m::AbstractFTheoryModel)
 ```
 

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
@@ -1101,7 +1101,7 @@ end
 
 Return the cohomology classes of the exceptional toric divisors of a model as a vector of cohomology classes in the toric ambient space.
 This information is only supported for models over a concrete base that is a normal toric variety, but is always available in this case.
-After a blow up this information is updated.
+After a toric blow up this information is updated.
 
 ```jldoctest
 julia> B3 = projective_space(NormalToricVariety, 3)
@@ -1134,7 +1134,7 @@ end
 
 Return the indices of the generators of the Cox ring of the ambient space which correspond to exceptional divisors.
 This information is only supported for models over a concrete base that is a normal toric variety, but is always available in this case.
-After a blow up this information is updated.
+After a toric blow up this information is updated.
 
 ```jldoctest
 julia> B3 = projective_space(NormalToricVariety, 3)

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
@@ -1097,6 +1097,72 @@ end
 
 
 @doc raw"""
+    exceptional_classes(m::AbstractFTheoryModel)
+
+Return the cohomology classes of the exceptional toric divisors of a model as a vector of cohomology classes in the toric ambient space.
+This information is only supported for models over a concrete base that is a normal toric variety, but is always available in this case.
+After a blow up this information is updated.
+
+```jldoctest
+julia> B3 = projective_space(NormalToricVariety, 3)
+Normal toric variety
+
+julia> Kbar = anticanonical_divisor_class(B3)
+Divisor class on a normal toric variety
+
+julia> foah11_B3 = literature_model(arxiv_id = "1408.4808", equation = "3.142", type = "hypersurface", base_space = B3, defining_classes = Dict("s7" => Kbar, "s9" => Kbar))
+Construction over concrete base may lead to singularity enhancement. Consider computing singular_loci. However, this may take time!
+
+Hypersurface model over a concrete base
+
+julia> exceptional_classes(foah11_B3)
+4-element Vector{CohomologyClass}:
+ Cohomology class on a normal toric variety given by e1
+ Cohomology class on a normal toric variety given by e2
+ Cohomology class on a normal toric variety given by e3
+ Cohomology class on a normal toric variety given by e4
+```
+"""
+function exceptional_classes(m::AbstractFTheoryModel)
+  @req base_space(m) isa NormalToricVariety "Exceptional divisor classes are only supported for models over a concrete base"
+  return get_attribute(m, :exceptional_classes, Vector{CohomologyClass}())
+end
+
+
+@doc raw"""
+    exceptional_divisor_indices(m::AbstractFTheoryModel)
+
+Return the indices of the generators of the Cox ring of the ambient space which correspond to exceptional divisors.
+This information is only supported for models over a concrete base that is a normal toric variety, but is always available in this case.
+After a blow up this information is updated.
+
+```jldoctest
+julia> B3 = projective_space(NormalToricVariety, 3)
+Normal toric variety
+
+julia> Kbar = anticanonical_divisor_class(B3)
+Divisor class on a normal toric variety
+
+julia> foah11_B3 = literature_model(arxiv_id = "1408.4808", equation = "3.142", type = "hypersurface", base_space = B3, defining_classes = Dict("s7" => Kbar, "s9" => Kbar))
+Construction over concrete base may lead to singularity enhancement. Consider computing singular_loci. However, this may take time!
+
+Hypersurface model over a concrete base
+
+julia> exceptional_divisor_indices(foah11_B3)
+4-element Vector{Int64}:
+  8
+  9
+ 10
+ 11
+```
+"""
+@attr Vector{Int} function exceptional_divisor_indices(m::AbstractFTheoryModel)
+  @req base_space(m) isa NormalToricVariety "Exceptional divisor indices are only supported for models over a concrete base"
+  return get_attribute(m, :exceptional_divisor_indices, Vector{Int}())
+end
+
+
+@doc raw"""
     torsion_sections(m::AbstractFTheoryModel)
 
 Return the torsion sections of the given model.

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
@@ -216,6 +216,25 @@ function blow_up(m::AbstractFTheoryModel, I::AbsIdealSheaf; coordinate_name::Str
   for (key, value) in model_attributes
     set_attribute!(model, key, value)
   end
+
+  # Update exceptional classes and their indices
+  divs = torusinvariant_prime_divisors(ambient_space(model))
+  index = index_of_exceptional_ray(bd)
+  @req index == ngens(cox_ring(ambient_space(model))) "Inconsistency encountered. Contact the authors"
+
+  indices = exceptional_divisor_indices(model)
+  push!(indices, index)
+
+  indets = [lift(g) for g in gens(cohomology_ring(ambient_space(model), check = false))]
+  coeff_ring = coefficient_ring(ambient_space(model))
+  new_e_classes = Vector{CohomologyClass}()
+  for i in indices
+    poly = sum(coeff_ring(coefficients(divs[i])[k]) * indets[k] for k in 1:length(indets))
+    push!(new_e_classes, CohomologyClass(ambient_space(model), cohomology_ring(ambient_space(model), check = false)(poly)))
+  end
+
+  set_attribute!(model, :exceptional_divisor_indices, indices)
+  set_attribute!(model, :exceptional_classes, new_e_classes)
   set_attribute!(model, :partially_resolved, true)
   set_attribute!(model, :blow_down_morphism, bd)
 

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
@@ -43,10 +43,10 @@ julia> blow_up(w, ["x", "y", "x1"]; coordinate_name = "e1")
 Partially resolved Weierstrass model over a concrete base -- U(1) Weierstrass model based on arXiv paper 1208.2695 Eq. (B.19)
 ```
 """
-function blow_up(m::AbstractFTheoryModel, ideal_gens::Vector{String}; coordinate_name::String = "e")
+function blow_up(m::AbstractFTheoryModel, ideal_gens::Vector{String}; coordinate_name::String = "e", nr_of_current_blow_up::Int = 1, nr_blowups_in_sequence::Int = 1)
   R = cox_ring(ambient_space(m))
   I = ideal([eval_poly(k, R) for k in ideal_gens])
-  return blow_up(m, I; coordinate_name = coordinate_name)
+  return blow_up(m, I; coordinate_name = coordinate_name, nr_of_current_blow_up = nr_of_current_blow_up, nr_blowups_in_sequence = nr_blowups_in_sequence)
 end
 
 
@@ -82,8 +82,8 @@ julia> blow_up(t, ideal([x, y, x1]); coordinate_name = "e1")
 Partially resolved global Tate model over a concrete base -- SU(5)xU(1) restricted Tate model based on arXiv paper 1109.3454 Eq. (3.1)
 ```
 """
-function blow_up(m::AbstractFTheoryModel, I::MPolyIdeal; coordinate_name::String = "e")
-  return blow_up(m, ideal_sheaf(ambient_space(m), I); coordinate_name = coordinate_name)
+function blow_up(m::AbstractFTheoryModel, I::MPolyIdeal; coordinate_name::String = "e", nr_of_current_blow_up::Int = 1, nr_blowups_in_sequence::Int = 1)
+  return blow_up(m, ideal_sheaf(ambient_space(m), I); coordinate_name = coordinate_name, nr_of_current_blow_up = nr_of_current_blow_up, nr_blowups_in_sequence = nr_blowups_in_sequence)
 end
 
 function _ideal_sheaf_to_minimal_supercone_coordinates(X::AbsCoveredScheme, I::AbsIdealSheaf; coordinate_name::String = "e")
@@ -156,7 +156,7 @@ julia> blow_up(t, blowup_center; coordinate_name = "e1")
 Partially resolved global Tate model over a concrete base -- SU(5)xU(1) restricted Tate model based on arXiv paper 1109.3454 Eq. (3.1)
 ```
 """
-function blow_up(m::AbstractFTheoryModel, I::AbsIdealSheaf; coordinate_name::String = "e")
+function blow_up(m::AbstractFTheoryModel, I::AbsIdealSheaf; coordinate_name::String = "e", nr_of_current_blow_up::Int = 1, nr_blowups_in_sequence::Int = 1)
   
   # Cannot (yet) blowup if this is not a Tate or Weierstrass model
   entry_test = (m isa GlobalTateModel) || (m isa WeierstrassModel)
@@ -217,26 +217,32 @@ function blow_up(m::AbstractFTheoryModel, I::AbsIdealSheaf; coordinate_name::Str
     set_attribute!(model, key, value)
   end
 
-  # Update exceptional classes and their indices
-  divs = torusinvariant_prime_divisors(ambient_space(model))
-  index = index_of_exceptional_ray(bd)
-  @req index == ngens(cox_ring(ambient_space(model))) "Inconsistency encountered. Contact the authors"
-
-  indices = exceptional_divisor_indices(model)
-  push!(indices, index)
-
-  indets = [lift(g) for g in gens(cohomology_ring(ambient_space(model), check = false))]
-  coeff_ring = coefficient_ring(ambient_space(model))
-  new_e_classes = Vector{CohomologyClass}()
-  for i in indices
-    poly = sum(coeff_ring(coefficients(divs[i])[k]) * indets[k] for k in 1:length(indets))
-    push!(new_e_classes, CohomologyClass(ambient_space(model), cohomology_ring(ambient_space(model), check = false)(poly)))
-  end
-
-  set_attribute!(model, :exceptional_divisor_indices, indices)
-  set_attribute!(model, :exceptional_classes, new_e_classes)
   set_attribute!(model, :partially_resolved, true)
   set_attribute!(model, :blow_down_morphism, bd)
+
+  if ambient_space(model) isa NormalToricVariety
+    index = index_of_exceptional_ray(bd)
+    @req index == ngens(cox_ring(ambient_space(model))) "Inconsistency encountered. Contact the authors"
+    indices = exceptional_divisor_indices(model)
+    push!(indices, index)
+    set_attribute!(model, :exceptional_divisor_indices, indices)
+
+    #Update slow attributes only at the end of a blow up sequence, if possible
+    if nr_of_current_blow_up == nr_blowups_in_sequence
+      # Update exceptional classes and their indices
+      divs = torusinvariant_prime_divisors(ambient_space(model))
+
+      indets = [lift(g) for g in gens(cohomology_ring(ambient_space(model), check = false))]
+      coeff_ring = coefficient_ring(ambient_space(model))
+      new_e_classes = Vector{CohomologyClass}()
+      for i in indices
+        poly = sum(coeff_ring(coefficients(divs[i])[k]) * indets[k] for k in 1:length(indets))
+        push!(new_e_classes, CohomologyClass(ambient_space(model), cohomology_ring(ambient_space(model), check = false)(poly)))
+      end
+
+      set_attribute!(model, :exceptional_classes, new_e_classes)
+    end
+  end
 
   # Return the model
   return model
@@ -883,7 +889,7 @@ function resolve(m::AbstractFTheoryModel, resolution_index::Int)
   # Gather information for resolution
   centers, exceptionals = resolutions(m)[resolution_index]
   nr_blowups = length(centers)
-  
+
   # Resolve the model
   resolved_model = m
   blow_up_chain = []
@@ -902,9 +908,8 @@ function resolve(m::AbstractFTheoryModel, resolution_index::Int)
     # Conduct the blowup
     if ambient_space(resolved_model) isa NormalToricVariety
       # Toric case is easy...
-      resolved_model = blow_up(resolved_model, blow_up_center; coordinate_name = exceptionals[k])
+      resolved_model = blow_up(resolved_model, blow_up_center; coordinate_name = exceptionals[k], nr_of_current_blow_up = k, nr_blowups_in_sequence = nr_blowups)
     else
-      
       # Compute proper transform of center generated by anything but exceptional divisors
       filtered_center = [c for c in blow_up_center if !(c in exceptionals)]
       initial_ambient_space = ambient_space(m)
@@ -963,7 +968,7 @@ function resolve(m::AbstractFTheoryModel, resolution_index::Int)
     # z^2 -> z^2 * m1
     # y * z -> y * z * m1
     as = ambient_space(resolved_model);
-    bl = domain(blow_up(as, [0,0,0,1,0], coordinate_name = "m1"));
+    bl = domain(blow_up(as, [0,0,0,1,0], coordinate_name = "m1", 1, 3));
     f = hypersurface_equation(resolved_model);
     my_mons = collect(monomials(f));
     pos_1 = findfirst(k -> k == "y", [string(a) for a in gens(cox_ring(as))])
@@ -993,7 +998,7 @@ function resolve(m::AbstractFTheoryModel, resolution_index::Int)
     # x^3 -> x^3 * m2^2
     # z^3 -> z^3 * m2
     as = ambient_space(model_bl);
-    bl = domain(blow_up(as, [0,0,0,-2,1], coordinate_name = "m2"));
+    bl = domain(blow_up(as, [0,0,0,-2,1], coordinate_name = "m2", 2, 3));
     f = hypersurface_equation(model_bl);
     my_mons = collect(monomials(f));
     pos_1 = findfirst(k -> k == "x", [string(a) for a in gens(cox_ring(as))])
@@ -1024,7 +1029,7 @@ function resolve(m::AbstractFTheoryModel, resolution_index::Int)
     # m2^2 -> m2^2 * m3
     # z^2 -> z^2 * m3
     as = ambient_space(model_bl2);
-    bl = domain(blow_up(as, [0,0,0,-1,1], coordinate_name = "m3"));
+    bl = domain(blow_up(as, [0,0,0,-1,1], coordinate_name = "m3", 3, 3));
     f = hypersurface_equation(model_bl2);
     my_mons = collect(monomials(f));
     pos_1 = findfirst(k -> k == "m2", [string(a) for a in gens(cox_ring(as))])

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
@@ -677,13 +677,28 @@ function set_zero_section(m::AbstractFTheoryModel, desired_value::Vector{String}
 end
 
 function set_zero_section_class(m::AbstractFTheoryModel, desired_value::String)
+  desired_value = Symbol(desired_value)
   divs = torusinvariant_prime_divisors(ambient_space(m))
   cohomology_ring(ambient_space(m); check=false)
-  cox_gens = string.(gens(cox_ring(ambient_space(m))))
+  cox_gens = symbols(cox_ring(ambient_space(m)))
   @req desired_value in cox_gens "Specified zero section is invalid"
   index = findfirst(==(desired_value), cox_gens)
   set_attribute!(m, :zero_section_index => index::Int)
   set_attribute!(m, :zero_section_class => cohomology_class(divs[index]))
+end
+
+function set_exceptional_classes(m::AbstractFTheoryModel, desired_value::Vector{String})
+  divs = torusinvariant_prime_divisors(ambient_space(m))
+  cohomology_ring(ambient_space(m); check=false)
+  cox_gens = symbols(cox_ring(ambient_space(m)))
+  @req issubset(Symbol.(desired_value), cox_gens) "Specified exceptional classes are invalid"
+  exceptional_divisor_indices = Vector{Int}()
+  for class in desired_value
+      index = findfirst(==(Symbol(class)), cox_gens)
+      push!(exceptional_divisor_indices, index)
+  end
+  set_attribute!(m, :exceptional_divisor_indices => exceptional_divisor_indices::Vector{Int})
+  set_attribute!(m, :exceptional_classes => [cohomology_class(divs[index]) for index in exceptional_divisor_indices])
 end
 
 function set_gauge_algebra(m::AbstractFTheoryModel, algebras::Vector{String})

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
@@ -215,7 +215,7 @@ function special_flux_family_with_default_algorithm(m::AbstractFTheoryModel; not
   ambient_space_flux_candidates_basis_indices = basis_of_h22_hypersurface_indices(m, check = check)
   list_of_divisor_pairs_to_be_considered = Oscar._ambient_space_divisor_pairs_to_be_considered(m)
   S = cox_ring(ambient_space(m))
-  exceptional_divisor_positions = findall(x -> occursin(r"^e\d+(_\d+)?$", x), string.(symbols(S))) # TODO: This line is a bit fragile. Fix it!
+  exceptional_divisor_positions = exceptional_divisor_indices(m)
   tds = torusinvariant_prime_divisors(ambient_space(m))
   cds = [cohomology_class(td) for td in tds]
   pt_class = cohomology_class(anticanonical_divisor_class(ambient_space(m)))
@@ -355,7 +355,7 @@ function special_flux_family_with_special_algorithm(m::AbstractFTheoryModel; not
   ambient_space_flux_candidates_basis_indices = basis_of_h22_hypersurface_indices(m, check = check)
   list_of_divisor_pairs_to_be_considered = Oscar._ambient_space_divisor_pairs_to_be_considered(m)
    # TODO: This line is a bit fragile. Fix it!
-  exceptional_divisor_positions = findall(x -> occursin(r"^e\d+(_\d+)?$", x), string.(symbols(S)))
+  exceptional_divisor_positions = exceptional_divisor_indices(m)
 
 
   # (5) Work out the relevant intersection numbers to tell if a flux passes the transversality constraints & (if desired) if the flux is not breaking the gauge group.

--- a/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
@@ -152,9 +152,7 @@ function qsm_flux(qsm_model::AbstractFTheoryModel)
   @req arxiv_doi(qsm_model) == "10.48550/arXiv.1903.00009" "Can only compute the QSM flux for a QSM model"
   divs = torusinvariant_prime_divisors(ambient_space(qsm_model))
   gens_strings = symbols(cox_ring(ambient_space(qsm_model)))
-  e1 = cohomology_class(divs[findfirst(x -> x == :e1, gens_strings)])
-  e2 = cohomology_class(divs[findfirst(x -> x == :e2, gens_strings)])
-  e4 = cohomology_class(divs[findfirst(x -> x == :e4, gens_strings)])
+  e1, e2, e4 = exceptional_classes(qsm_model)[[1,2,4]]
   u = cohomology_class(divs[findfirst(x -> x == :u, gens_strings)])
   v = cohomology_class(divs[findfirst(x -> x == :v, gens_strings)])
   pb_Kbar = cohomology_class(sum([divs[k] for k in 1:length(gens_strings)-7]))

--- a/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
@@ -152,7 +152,9 @@ function qsm_flux(qsm_model::AbstractFTheoryModel)
   @req arxiv_doi(qsm_model) == "10.48550/arXiv.1903.00009" "Can only compute the QSM flux for a QSM model"
   divs = torusinvariant_prime_divisors(ambient_space(qsm_model))
   gens_strings = symbols(cox_ring(ambient_space(qsm_model)))
-  e1, e2, e4 = exceptional_classes(qsm_model)[[1,2,4]]
+  e1 = cohomology_class(divs[findfirst(x -> x == :e1, gens_strings)])
+  e2 = cohomology_class(divs[findfirst(x -> x == :e2, gens_strings)])
+  e4 = cohomology_class(divs[findfirst(x -> x == :e4, gens_strings)])
   u = cohomology_class(divs[findfirst(x -> x == :u, gens_strings)])
   v = cohomology_class(divs[findfirst(x -> x == :v, gens_strings)])
   pb_Kbar = cohomology_class(sum([divs[k] for k in 1:length(gens_strings)-7]))

--- a/experimental/FTheoryTools/src/G4Fluxes/properties.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/properties.jl
@@ -83,7 +83,7 @@ Hypersurface model over a concrete base
 
 julia> divs = torusinvariant_prime_divisors(ambient_space(qsm_model));
 
-julia> e1, e2, e4 = exceptional_classes(qsm_model)[[1,2,4]];
+julia> e1 = cohomology_class(divs[35]);e2 = cohomology_class(divs[32]);e4 = cohomology_class(divs[34]);
 
 julia> u = cohomology_class(divs[33]);v = cohomology_class(divs[30]);pb_Kbar = cohomology_class(sum([divs[k] for k in 1:29]));
 
@@ -148,7 +148,7 @@ Hypersurface model over a concrete base
 
 julia> divs = torusinvariant_prime_divisors(ambient_space(qsm_model));
 
-julia> e1, e2, e4 = exceptional_classes(qsm_model)[[1,2,4]];
+julia> e1 = cohomology_class(divs[35]);e2 = cohomology_class(divs[32]);e4 = cohomology_class(divs[34]);
 
 julia> u = cohomology_class(divs[33]);v = cohomology_class(divs[30]);pb_Kbar = cohomology_class(sum([divs[k] for k in 1:29]));
 
@@ -196,7 +196,7 @@ Hypersurface model over a concrete base
 
 julia> divs = torusinvariant_prime_divisors(ambient_space(qsm_model));
 
-julia> e1, e2, e4 = exceptional_classes(qsm_model)[[1,2,4]];
+julia> e1 = cohomology_class(divs[35]);e2 = cohomology_class(divs[32]);e4 = cohomology_class(divs[34]);
 
 julia> u = cohomology_class(divs[33]);v = cohomology_class(divs[30]);pb_Kbar = cohomology_class(sum([divs[k] for k in 1:29]));
 
@@ -235,7 +235,7 @@ G4-flux candidate
 
   # Identify the cohomology classes of all exceptional divisors
   gS = gens(cox_ring(ambient_space(m)))
-  exceptional_divisor_positions = findall(x -> occursin(r"^e\d+$", x), string.(symbols(cox_ring(ambient_space(m)))))
+  exceptional_divisor_positions = exceptional_divisor_indices(m)
   exceptional_divisors = torusinvariant_prime_divisors(ambient_space(m))[exceptional_divisor_positions]
   c_ei = [polynomial(cohomology_class(d)) for d in exceptional_divisors]
 

--- a/experimental/FTheoryTools/src/G4Fluxes/properties.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/properties.jl
@@ -83,7 +83,7 @@ Hypersurface model over a concrete base
 
 julia> divs = torusinvariant_prime_divisors(ambient_space(qsm_model));
 
-julia> e1 = cohomology_class(divs[35]);e2 = cohomology_class(divs[32]);e4 = cohomology_class(divs[34]);
+julia> e1, e2, e4 = exceptional_classes(qsm_model)[[1,2,4]];
 
 julia> u = cohomology_class(divs[33]);v = cohomology_class(divs[30]);pb_Kbar = cohomology_class(sum([divs[k] for k in 1:29]));
 
@@ -148,7 +148,7 @@ Hypersurface model over a concrete base
 
 julia> divs = torusinvariant_prime_divisors(ambient_space(qsm_model));
 
-julia> e1 = cohomology_class(divs[35]);e2 = cohomology_class(divs[32]);e4 = cohomology_class(divs[34]);
+julia> e1, e2, e4 = exceptional_classes(qsm_model)[[1,2,4]];
 
 julia> u = cohomology_class(divs[33]);v = cohomology_class(divs[30]);pb_Kbar = cohomology_class(sum([divs[k] for k in 1:29]));
 
@@ -196,7 +196,7 @@ Hypersurface model over a concrete base
 
 julia> divs = torusinvariant_prime_divisors(ambient_space(qsm_model));
 
-julia> e1 = cohomology_class(divs[35]);e2 = cohomology_class(divs[32]);e4 = cohomology_class(divs[34]);
+julia> e1, e2, e4 = exceptional_classes(qsm_model)[[1,2,4]];
 
 julia> u = cohomology_class(divs[33]);v = cohomology_class(divs[30]);pb_Kbar = cohomology_class(sum([divs[k] for k in 1:29]));
 

--- a/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-10.json
+++ b/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-10.json
@@ -63,6 +63,7 @@
         ],
         "hypersurface_equation": "s1*e1^2*e2^4*e3^6*u^3 + s2*e1^2*e2^3*e3^4*u^2*v + s3*e1^2*e2^2*e3^2*u*v^2 + s4*e1^2*e2*v^3 + s5*e1*e2^2*e3^3*u^2*w + s6*e1*e2*e3*u*v*w + s8*u*w^2",
         "zero_section_class": "e3",
+        "exceptional_classes": ["e1", "e2", "e3"],
         "zero_section": ["s4", "1", "1", "1", "-s8", "0"]
     },
     "associated_models": [

--- a/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-11.json
+++ b/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-11.json
@@ -64,6 +64,7 @@
         ],
         "hypersurface_equation": "s1*e1^2*e2^2*e3*e4^4*u^3 + s2*e1*e2^2*e3^2*e4^2*u^2*v + s3*e2^2*e3^3*u*v^2 + s5*e1^2*e2*e4^3*u^2*w + s6*e1*e2*e3*e4*u*v*w + s9*e1*v*w^2",
         "zero_section_class": "v",
+        "exceptional_classes": ["e1", "e2", "e3", "e4"],
         "zero_section": ["1", "0", "s1", "1", "1", "-s5", "1"],
         "generating_sections": [
             ["s9", "1", "1", "-s3", "1", "1", "0"]

--- a/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-12.json
+++ b/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-12.json
@@ -64,6 +64,7 @@
         ],
         "hypersurface_equation": "s1*e1^2*e2^2*e3*e4*u^3 + s2*e1*e2^2*e3^2*u^2*v + s5*e1^2*e2*e4^2*u^2*w + s6*e1*e2*e3*e4*u*v*w + s7*e2*e3^2*v^2*w + s9*e1*e4^2*v*w^2",
         "zero_section_class": "u",
+        "exceptional_classes": ["e1", "e2", "e3", "e4"],
         "zero_section": ["0", "1", "1", "s7", "-s9", "1", "1"],
         "generating_sections": [
             ["1", "s5", "1", "1", "-s9", "0", "1"],

--- a/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-13.json
+++ b/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-13.json
@@ -64,6 +64,7 @@
         ],
         "hypersurface_equation": "s1*e1^2*e2^2*e3*e5^4*u^3 + s2*e1*e2^2*e3^2*e4^2*e5^2*u^2*v + s3*e2^2*e3^3*e4^4*u*v^2 + s6*e1*e2*e3*e4*e5*u*v*w + s9*e1*v*w^2",
         "zero_section_class": "e4",
+        "exceptional_classes": ["e1", "e2", "e3", "e4", "e5"],
         "zero_section": ["1", "s1", "1", "1", "1", "-s9", "0", "1"],
         "torsion_sections": [
             ["s9", "1", "1", "-s3", "1", "1", "1", "0"]

--- a/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-14.json
+++ b/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-14.json
@@ -64,6 +64,7 @@
         ],
         "hypersurface_equation": "s1*e1^2*e2^2*e3*e4*u^3 + s5*e1^2*e2*e4^2*e5^2*u^2*w + s6*e1*e2*e3*e4*e5*u*v*w + s7*e2*e3^2*v^2*w + s9*e1*e4^2*e5^3*v*w^2",
         "zero_section_class": "u",
+        "exceptional_classes": ["e1", "e2", "e3", "e4", "e5"],
         "zero_section": ["0", "1", "1", "s7", "-s9", "1", "1", "1"],
         "generating_sections": [
             ["1", "1", "s1", "1", "1", "1", "-s7", "0"]

--- a/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-15.json
+++ b/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-15.json
@@ -64,6 +64,7 @@
         ],
         "hypersurface_equation": "s2*e1*e2^2*e3^2*u^2*v + s5*e1^2*e2*e4^2*u^2*w + s6*e1*e2*e3*e4*e5*u*v*w + s7*e2*e3^2*e5^2*v^2*w + s9*e1*e4^2*e5^2*v*w^2",
         "zero_section_class": "u",
+        "exceptional_classes": ["e1", "e2", "e3", "e4", "e5"],
         "zero_section": ["0", "1", "1", "s7", "-s9", "1", "1", "1"],
         "generating_sections": [
             ["1", "1", "s2", "-s7", "1", "1", "0", "1"]

--- a/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-16.json
+++ b/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-16.json
@@ -64,6 +64,7 @@
         ],
         "hypersurface_equation": "s1*e1^2*e2^2*e3*e4*u^3 + s6*e1*e2*e3*e4*e5*e6*u*v*w + s7*e2*e3^2*e6^3*v^2*w + s9*e1*e4^2*e5^3*v*w^2",
         "zero_section_class": "u",
+        "exceptional_classes": ["e1", "e2", "e3", "e4", "e5", "e6"],
         "zero_section": ["0", "1", "1", "s7", "-s9", "1", "1", "1", "1"],
         "torsion_sections": [
             ["1", "1", "s1", "1", "1", "1", "-s7", "0", "1"],

--- a/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-3.json
+++ b/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-3.json
@@ -63,6 +63,7 @@
         ],
         "hypersurface_equation": "s1*u^3*e1^2 + s2*u^2*v*e1^2 + s3*u*v^2*e1^2 + s4*v^3*e1^2 + s5*u^2*w*e1 + s6*u*v*w*e1 + s7*v^2*w*e1 + s8*u*w^2 + s9*v*w^2",
         "zero_section_class": "e1",
+        "exceptional_classes": ["e1"],
         "zero_section": ["s9", "-s8", "1", "0"],
         "generating_sections": [
             ["-s9", "s8", "s1 * s9^3 - s4 * s8^3 + s3 * s9 * s8^2 - s2 * s9^2 * s8", "s7 * s8^2 - s6 * s9 * s8 + s5 * s9^2"]

--- a/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-4.json
+++ b/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-4.json
@@ -56,6 +56,7 @@
         "fiber_ambient_space_rays": [[-1, 1], [1, 0], [-1, -1], [-1, 0]],
         "fiber_ambient_space_max_cones": [[1, 2], [2, 3], [3, 4], [1, 4]],
         "fiber_ambient_space_coordinates": ["X", "Z", "Y", "e1"],
+        "exceptional_classes": ["e1"],
         "fiber_ambient_space_name": "P^{F_4}",
         "fiber_twist_matrix": [
             [-1, 0, -1, 0],

--- a/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-5.json
+++ b/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-5.json
@@ -63,6 +63,7 @@
         ],
         "hypersurface_equation": "s1*e2^2*e1^2*u^3 + s2*e2^2*e1*u^2*v + s3*e2^2*u*v^2 + s5*e2*e1^2*u^2*w + s6*e2*e1*u*v*w + s7*e2*v^2*w + s8*e1^2*u*w^2 + s9*e1*v*w^2",
         "zero_section_class": "e2",
+        "exceptional_classes": ["e1", "e2"],
         "zero_section": ["s9", "-s8", "1", "1", "0"],
         "generating_sections": [
             ["s7", "1", "-s3", "0", "1"],

--- a/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-6.json
+++ b/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-6.json
@@ -64,6 +64,7 @@
         ],
         "hypersurface_equation": "s1*e1^2*e2^4*u^3 + s2*e1^2*e2^3*u^2*v + s3*e1^2*e2^2*u*v^2 + s4*e1^2*e2*v^3 + s5*e1*e2^2*u^2*w + s6*e1*e2*u*v*w + s7*e1*v^2*w + s8*u*w^2",
         "zero_section_class": "e2",
+        "exceptional_classes": ["e1", "e2"],
         "zero_section": ["-s7", "1", "s8", "1", "0"],
         "generating_sections": [
             ["0", "1", "s4", "1", "-s7"]

--- a/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-7.json
+++ b/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-7.json
@@ -63,6 +63,7 @@
         ],
         "hypersurface_equation": "s2*e1*e3^2*u^2*v + s3*e2*e3^2*u*v^2 + s5*e1^2*e3*u^2*w + s6*e1*e2*e3*u*v*w + s7*e2^2*e3*v^2*w  + s8*e1^2*e2*u*w^2 + s9*e1*e2^2*w^2*v",
         "zero_section_class": "u",
+        "exceptional_classes": ["e1", "e2", "e3"],
         "zero_section": ["0", "1", "1", "s7", "1", "-s9"],
         "generating_sections": [
             ["s7", "1", "-s3", "0", "1", "1"],

--- a/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-8.json
+++ b/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-8.json
@@ -64,6 +64,7 @@
         ],
         "hypersurface_equation": "s1*e1^2*e2^4*e3^2*u^3 + s2*e1^2*e2^3*e3*u^2*v + s3*e1^2*e2^2*u*v^2 + s5*e1*e2^2*e3^2*u^2*w + s6*e1*e2*e3*u*v*w +  s7*e1*v^2*w + s8*e3^2*u*w^2",
         "zero_section_class": "e2",
+        "exceptional_classes": ["e1", "e2", "e3"],
         "zero_section": ["s7", "1", "1", "-s8", "0", "1"],
         "generating_sections": [
             ["s7", "1", "-s3", "1", "1", "0"]

--- a/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-9.json
+++ b/experimental/FTheoryTools/src/LiteratureModels/Models/model1408_4808-9.json
@@ -64,6 +64,7 @@
         ],
         "hypersurface_equation": "s1*e1^2*e2^2*e3*u^3 + s2*e1*e2^2*e3^2*u^2*v + s3*e2^2*e3^3*u*v^2 + s5*e1^2*e2*u^2*w + s6*e1*e2*e3*u*v*w + s7*e2*e3^2*v^2*w + s9*e1*v*w^2",
         "zero_section_class": "u",
+        "exceptional_classes": ["e1", "e2", "e3"],
         "zero_section": ["0", "1", "1", "s7", "-s9", "1"],
         "generating_sections": [
             ["1", "s5", "1", "1", "-s9", "0"],

--- a/experimental/FTheoryTools/src/LiteratureModels/Models/model1903_00009.json
+++ b/experimental/FTheoryTools/src/LiteratureModels/Models/model1903_00009.json
@@ -60,6 +60,7 @@
     "D1": [0, 0],
     "D2": [0, 0],
     "hypersurface_equation": "s1*e1^2*e2^2*e3*e4^4*u^3+s2*e1*e2^2*e3^2*e4^2*u^2*v+s3*e2^2*e3^3*u*v^2+s5*e1^2*e2*e4^3*u^2*w+s6*e1*e2*e3*e4*u*v*w+s9*e1*v*w^2",
-    "zero_section_class": "v"
+    "zero_section_class": "v",
+    "exceptional_classes": ["e1", "e2", "e3", "e4"]
     }
 }

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -234,6 +234,7 @@ function literature_model(model_dict::Dict{String, Any}; model_parameters::Dict{
     k = model_parameters["k"]
     qsmd_path = artifact"QSMDB"
     qsm_model = load(joinpath(qsmd_path, "$k.mrdi"))
+    set_exceptional_classes(qsm_model, string.(model_dict["model_data"]["exceptional_classes"]))
     # Set meta data attributes
     #cfs = matrix(ZZ, transpose(hcat([[eval_poly(weight, ZZ) for weight in vec] for vec in model_dict["model_data"]["classes_of_tunable_sections_in_basis_of_Kbar_and_defining_classes"]]...)))
     #cfs = vcat([[Int(k) for k in cfs[i:i,:]] for i in 1:nrows(cfs)]...)

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -623,6 +623,13 @@ function _set_all_attributes(model::AbstractFTheoryModel, model_dict::Dict{Strin
     D = Dict{String, Vector{Int}}()
     tun_sections = model_dict["model_data"]["model_sections"]
     M = model_dict["model_data"]["classes_of_tunable_sections_in_basis_of_Kbar_and_defining_classes"]
+    if typeof(M) != Matrix{Int}
+      vars = string.(model_dict["model_data"]["model_sections"])
+      auxiliary_base_ring, _ = polynomial_ring(QQ, vars, cached=false)
+      auxiliary_base_grading = matrix(ZZ, transpose(hcat([[eval_poly(weight, ZZ) for weight in vec] for vec in model_dict["model_data"]["classes_of_tunable_sections_in_basis_of_Kbar_and_defining_classes"]]...)))
+      auxiliary_base_grading = vcat([[Int(k) for k in auxiliary_base_grading[i:i,:]] for i in 1:nrows(auxiliary_base_grading)]...)
+      model_dict["model_data"]["classes_of_tunable_sections_in_basis_of_Kbar_and_defining_classes"] = auxiliary_base_grading
+    end
     for i in 1:length(tun_sections)
       D[tun_sections[i]] = M[:,i]
     end
@@ -657,6 +664,10 @@ function _set_all_attributes(model::AbstractFTheoryModel, model_dict::Dict{Strin
   
   if haskey(model_dict["model_data"], "zero_section_class") && base_space(model) isa NormalToricVariety
     set_zero_section_class(model, string.(model_dict["model_data"]["zero_section_class"]))
+  end
+
+  if haskey(model_dict["model_data"], "exceptional_classes") && base_space(model) isa NormalToricVariety
+    set_exceptional_classes(model, string.(model_dict["model_data"]["exceptional_classes"]))
   end
 
   if haskey(model_dict["model_data"], "generating_sections")

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -627,9 +627,9 @@ function _set_all_attributes(model::AbstractFTheoryModel, model_dict::Dict{Strin
     if typeof(M) != Matrix{Int}
       vars = string.(model_dict["model_data"]["model_sections"])
       auxiliary_base_ring, _ = polynomial_ring(QQ, vars, cached=false)
-      auxiliary_base_grading = matrix(ZZ, transpose(hcat([[eval_poly(weight, ZZ) for weight in vec] for vec in model_dict["model_data"]["classes_of_tunable_sections_in_basis_of_Kbar_and_defining_classes"]]...)))
-      auxiliary_base_grading = vcat([[Int(k) for k in auxiliary_base_grading[i:i,:]] for i in 1:nrows(auxiliary_base_grading)]...)
-      model_dict["model_data"]["classes_of_tunable_sections_in_basis_of_Kbar_and_defining_classes"] = auxiliary_base_grading
+      M = matrix(ZZ, transpose(hcat([[eval_poly(weight, ZZ) for weight in vec] for vec in M]...)))
+      M = vcat([[Int(k) for k in M[i:i,:]] for i in 1:nrows(M)]...)
+      model_dict["model_data"]["classes_of_tunable_sections_in_basis_of_Kbar_and_defining_classes"] = M
     end
     for i in 1:length(tun_sections)
       D[tun_sections[i]] = M[:,i]

--- a/experimental/FTheoryTools/src/exports.jl
+++ b/experimental/FTheoryTools/src/exports.jl
@@ -62,6 +62,8 @@ export dual_graph
 export d3_tadpole_constraint
 export estimated_number_of_triangulations
 export euler_characteristic
+export exceptional_classes
+export exceptional_divisor_indices
 export explicit_model_sections
 export family_of_g4_fluxes
 export family_of_spaces

--- a/experimental/FTheoryTools/test/literature_models.jl
+++ b/experimental/FTheoryTools/test/literature_models.jl
@@ -79,6 +79,7 @@ t2 = resolve(t1, 1)
   @test base_space(t1) == base_space(t2)
   @test length(exceptional_divisor_indices(t2)) == length(exceptional_classes(t2))
   @test length(exceptional_divisor_indices(t2)) == length(exceptional_divisor_indices(t1)) + 5
+  @test length(exceptional_classes(t2)) == length(exceptional_classes(t1)) + 5
 end
 
 add_resolution(t1, [["x", "y"], ["y", "s", "w"], ["s", "e4"], ["s", "e3"], ["s", "e1"]], ["s", "w", "e3", "e1", "e2"])
@@ -595,7 +596,7 @@ end
 
 
 ##########################################################################################################
-# 10: Test weierstrass counterparts of models from F-theory on all toric hypersurfaces over arbitrary base
+# 10: Test Weierstrass counterparts of models from F-theory on all toric hypersurfaces over arbitrary base
 ##########################################################################################################
 
 foah1_weier = literature_model(arxiv_id = "1408.4808", equation = "3.4", type = "weierstrass")
@@ -615,7 +616,7 @@ foah14_weier = literature_model(arxiv_id = "1408.4808", equation = "3.168", type
 foah15_weier = literature_model(arxiv_id = "1408.4808", equation = "3.190", type = "weierstrass")
 foah16_weier = weierstrass_model(foah16)
 
-@testset "Test weierstrass form of models in F-theory on all toric hypersurfaces, defined over arbitrary base" begin
+@testset "Test Weierstrass form of models in F-theory on all toric hypersurfaces, defined over arbitrary base" begin
   @test dim(base_space(foah1_weier)) == 3
   @test dim(base_space(foah2_weier)) == 3
   @test dim(base_space(foah3_weier)) == 3
@@ -685,7 +686,7 @@ end
 
 
 ########################################################################################################
-# 11: Test weierstrass counterparts of models from F-theory on all toric hypersurfaces over concrete base
+# 11: Test Weierstrass counterparts of models from F-theory on all toric hypersurfaces over concrete base
 ########################################################################################################
 
 B3 = projective_space(NormalToricVariety, 3)
@@ -707,7 +708,7 @@ foah14_B3_weier = literature_model(arxiv_id = "1408.4808", equation = "3.168", t
 foah15_B3_weier = literature_model(arxiv_id = "1408.4808", equation = "3.190", type = "weierstrass", base_space = B3, defining_classes = Dict("s7" => Kbar, "s9" => Kbar), completeness_check = false)
 foah16_B3_weier = literature_model(arxiv_id = "1408.4808", equation = "3.203", type = "weierstrass", base_space = B3, defining_classes = Dict("s7" => Kbar, "s9" => Kbar), completeness_check = false)
 
-@testset "Test weierstrass form of models in F-theory on all toric hypersurfaces, defined over concrete base" begin
+@testset "Test Weierstrass form of models in F-theory on all toric hypersurfaces, defined over concrete base" begin
   @test dim(base_space(foah1_B3_weier)) == 3
   @test dim(base_space(foah2_B3_weier)) == 3
   @test dim(base_space(foah3_B3_weier)) == 3

--- a/experimental/FTheoryTools/test/literature_models.jl
+++ b/experimental/FTheoryTools/test/literature_models.jl
@@ -77,6 +77,8 @@ t2 = resolve(t1, 1)
   @test is_smooth(ambient_space(t2)) == false
   @test is_partially_resolved(t2) == true
   @test base_space(t1) == base_space(t2)
+  @test length(exceptional_divisor_indices(t2)) == length(exceptional_classes(t2))
+  @test length(exceptional_divisor_indices(t2)) == length(exceptional_divisor_indices(t1)) + 5
 end
 
 add_resolution(t1, [["x", "y"], ["y", "s", "w"], ["s", "e4"], ["s", "e3"], ["s", "e1"]], ["s", "w", "e3", "e1", "e2"])

--- a/test/book/specialized/bies-turner-string-theory-applications/SU5.jlcon
+++ b/test/book/specialized/bies-turner-string-theory-applications/SU5.jlcon
@@ -61,7 +61,7 @@ julia> t1 = blow_up(t, ["x", "y", "x1"]; coordinate_name = "e1")
 Partially resolved global Tate model over a concrete base
 
 julia> amb1 = ambient_space(t1)
-Normal toric variety
+Normal, simplicial toric variety
 
 julia> cox_ring(amb1)
 Multivariate polynomial ring in 8 variables over QQ graded by


### PR DESCRIPTION
Added the attributes `exceptional_classes` and `exceptional_divisor_indices` for FTheory models for more convenient access to this information. I also made slight improvements to the internal `_set_all_attributes` method.
Before this is merged, I would also like to add changes, that would change the `exceptional_classes` attribute, whenever a blow up is performed. @HereAround @apturner 