### PR TITLE
Set `OMP_NUM_THREADS=1` unconditionally (bandaid for #4806)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,7 +88,7 @@ jobs:
       - name: "Build package"
         uses: julia-actions/julia-buildpkg@v1
       - name: "limit OpenMP threads"
-        if: runner.os == 'macOS'
+        # if: runner.os == 'macOS' # commented out as bandaid for #4806
         # restrict number of openMP threads on macOS due to oversubscription
         run: echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
       - name: "Use multiple processes for self-hosted macOS runners"
@@ -228,7 +228,7 @@ jobs:
       - name: "Build package"
         uses: julia-actions/julia-buildpkg@v1
       - name: "limit OpenMP threads"
-        if: runner.os == 'macOS'
+        # if: runner.os == 'macOS' # commented out as bandaid for #4806
         # restrict number of openMP threads on macOS due to oversubscription
         run: echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
       - name: "Setup package"


### PR DESCRIPTION
This does not fix the underlying issue (which still occurs for me locally on Linux), but should make CI green again until we have a proper fix. Eventually, this should get reverted.

cc @benlorenz 