### PR TITLE
Use singular modules directly over quotient rings

### DIFF
--- a/test/Modules/MPolyQuo.jl
+++ b/test/Modules/MPolyQuo.jl
@@ -3,11 +3,7 @@
   I = ideal(P, x)
   R, _ = quo(P, I)
   FR = FreeMod(R, 2, cached=false)
-  M = Oscar._as_poly_module(FR)
-  @test M isa SubquoModule{<:MPolyRingElem}
   @test FR isa FreeMod{<:MPolyQuoRingElem}
-  FP = Oscar._poly_module(FR)
-  @test FP isa FreeMod{<:MPolyRingElem}
 
   M = FreeMod(R, 1, cached=false)
   psi = hom(FR, M, [2*M[1], M[1]])


### PR DESCRIPTION
These are changes similar to the latest ones pushed to #4100 , but to make modules over quotient rings run by directly translating to the singular side of the `ModuleGens`. 

There are still some design issues to be addressed; mostly about monomial orderings and related caching. I would like to expose the current workarounds here so that the problems become clearly visible. We should then discuss a clean interface which specifies which methods exactly have to be overwritten so that modules work via a layer which "fills out the singular side". 

Another reason to do this PR is that I would like to see which other tests might be failing. 

IMHO, the changes in #4100 can stay untouched for the moment, since they are for `MonoidAlgebras` only. Once this PR has evolved to some maturity, #4100 can then be adjusted. 