### PR TITLE
Improve the handling of matrix groups over number fields

### DIFF
--- a/experimental/MatrixGroups/src/MatrixGroups.jl
+++ b/experimental/MatrixGroups/src/MatrixGroups.jl
@@ -50,7 +50,12 @@ GAP: <group with 2 generators>
 """
 function matrix_group(matrices::Vector{<:MatrixElem{T}}; check::Bool = true) where T <: Union{ZZRingElem, QQFieldElem, AbsSimpleNumFieldElem}
      # Compute the reduction map to a matrix group over a finite field `F`.
-     G, G_to_fin_pres, F, OtoFq = Oscar._isomorphic_group_over_finite_field(matrices, check = check)
+     flag, res = Oscar._isomorphic_group_over_finite_field(matrices, check = check)
+
+     if !flag
+       error("Group is not finite")
+     end
+     G, _, F, OtoFq = res
 
      # Map the generating matrices over `F` to GAP matrices, create a GAP group.
      matrices_Fq = [matrix(x) for x in gens(G)]  # Oscar matrices over F

--- a/gap/pkg/OscarInterface/gap/OscarInterface.gi
+++ b/gap/pkg/OscarInterface/gap/OscarInterface.gi
@@ -156,6 +156,37 @@ Perform( Oscar_jl.Serialization._GAP_deserializations,
 
 ############################################################################
 
+# Oscar provides the reduction of a finite matrix group over a number field
+# to one over a finite field,
+# hence these groups can be handled via nice monomorphisms.
+#
+# In the construction of the `GapObj` of a matrix group over a number field,
+# we store the Oscar group in the attribute `JuliaData` and set the flag
+# `MayBeHandledByNiceMonomorphism`.
+# GAP operations that have a special method for groups in the filter
+# `IsHandledByNiceMonomorphism` have also a method for groups in
+# `MayBeHandledByNiceMonomorphism`.
+# The latter method calls `IsHandledByNiceMonomorphism`,
+# and we provide the following method for matrix groups that are in
+# `MayBeHandledByNiceMonomorphism` and that store an Oscar group.
+
+InstallMethod( IsHandledByNiceMonomorphism,
+    [ "IsMatrixGroup and MayBeHandledByNiceMonomorphism and HasJuliaData" ],
+    RankFilter( IsCyclotomicCollCollColl ), # above `IsCyclotomicMatrixGroup`
+    function( G )
+    if Oscar.is_finite( JuliaData( G ) ) then
+      # The `is_finite` call already triggers the computation
+      # of the reduction, without error in the case of an infinite group.
+      # Make sure that the reduction really gets computed.
+      Oscar.isomorphic_group_over_finite_field( JuliaData( G ) );
+      Assert( 0, HasNiceMonomorphism( G ) );
+      return true;
+    fi;
+    return false;
+    end );
+
+############################################################################
+
 # The following can be removed as soon as the CTblLib package provides it
 # (not yet in CTblLib v1.3.9).
 if not IsBound( IsAtlasCharacterTable ) then

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -102,6 +102,15 @@ matrix_group(V::Union{MatElem,MatrixGroupElem}...; check::Bool=true) = matrix_gr
 matrix_group(m::Int, R::Ring) = matrix_group(R, m)
 matrix_group(m::Int, R::Ring, V; check::Bool = true) = matrix_group(R, m, V, check = check)
 
+# the natural place to set additional information in the `GapObj`
+# of a matrix group for which `_isomorphic_group_over_finite_field` works
+function Base.setproperty!(G::MatrixGroup{T, S}, X::Symbol, GapG::GapObj) where {T <: Union{ZZRingElem, QQFieldElem, AbsSimpleNumFieldElem, QQAbFieldElem}, S}
+  setfield!(G, X, GapG)
+  X === :X || return
+  # set the flag and the info in GapG
+  GAP.Globals.SetJuliaData(GapG, G)
+  GAP.Globals.SetFilterObj(GapG, GAP.Globals.MayBeHandledByNiceMonomorphism)
+end
 
 # `MatrixGroup`: compare types, dimensions, and coefficient rings
 function check_parent(G::T, g::GAPGroupElem) where T <: MatrixGroup
@@ -714,6 +723,17 @@ function order(::Type{T}, G::MatrixGroup) where T <: IntegerUnion
    end::ZZRingElem
    return T(res)::T
 end
+
+# Use the reduction to a finite field as a finiteness test.
+function is_finite(G::MatrixGroup{T}) where {T <: Union{AbsSimpleNumFieldElem, QQFieldElem}}
+  try
+    compute_order(G)
+  catch e
+    return false
+  end
+  return true
+end
+
 
 """
     map_entries(f, G::MatrixGroup)

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -729,7 +729,10 @@ function is_finite(G::MatrixGroup{T}) where {T <: Union{AbsSimpleNumFieldElem, Q
   try
     compute_order(G)
   catch e
-    return false
+    if e isa InfiniteOrderError
+      return false
+    end
+    rethrow()
   end
   return true
 end

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -107,7 +107,10 @@ end
 @testset "faithful reduction from char. zero to finite fields" begin
 
    M = matrix(QQ, [ 2 0; 0 2 ])
-   @test_throws ErrorException Oscar.isomorphic_group_over_finite_field(matrix_group([M]))
+   G = matrix_group([M])
+   @test !has_is_finite(G)
+   @test_throws InfiniteOrderError Oscar.isomorphic_group_over_finite_field(G)
+   @test has_is_finite(G)
 
    K, a = cyclotomic_field(5, "a")
    L, b = cyclotomic_field(3, "b")
@@ -121,8 +124,10 @@ end
 
    @testset "... over ring $(base_ring(mats[1]))" for mats in inputs
      G0 = matrix_group(mats)
+     @test !has_is_finite(G0)
      G, g = Oscar.isomorphic_group_over_finite_field(G0)
 
+     @test has_is_finite(G0)
      @test has_order(G)
      @test has_order(G0)
      @test order(G0) == order(G)


### PR DESCRIPTION
These changes are intended to solve the problems described in the discussion #4749.
(They require the GAP changes from gap-system/gap/pull/5970.)

The idea is to set the GAP filter `MayBeHandledByNiceMonomorphism` in the `GapObj` of an Oscar matrix group over a number field, and to store the corresponding Oscar group in the attribute `JuliaData` of the GAP group, in order to give GAP access to the Oscar group.

As soon as the Oscar group asks its `GapObj` for a computation that may benefit from a "nice monomorphism",
the GAP group is asked for its `IsHandledByNiceMonomorphism` value. This question triggers the `is_finite` computation for the Oscar group. If the answer is `false` then "nice monomorphisms" do not help, and if the answer is `true` then an isomorphism from the Oscar group to a matrix group over a finite field has been computed, which is used to create a "nice monomorphism"  for the GAP group.

For that, a `IsHandledByNiceMonomorphism` method for the GAP group is needed, which makes an `is_finite` test.
Note that up to now, `is_finite` for matrix groups simply delegated the work to GAP,
which eventually computes a "nice monomorphism" in a different way, and then the reduction provided by Oscar does not help. Now we use a special `is_finite` method that triggers the computation of the reduction to a matrix group over a finite field. Since the reduction functions throw an error exception if (and only if) the matrix group in question is not finite, we use `try`/`catch`. Perhaps this setup should better be changed, in the sense that the return value of `_isomorphic_group_over_finite_field` indicates whether the given matrices generate a finite group or not.