### PR TITLE
check the result type of `GAP.Globals.PermutationOp`

### DIFF
--- a/docs/src/Groups/grouplib.md
+++ b/docs/src/Groups/grouplib.md
@@ -157,4 +157,5 @@ number_of_atlas_groups
 all_atlas_group_infos
 atlas_group
 atlas_subgroup
+show_atlas_info
 ```

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -611,6 +611,7 @@ function permutation(Omega::GSetByElements{T}, g::Union{GAPGroupElem, FinGenAbGr
     # The following works only because GAP does not check
     # whether the given group element 'g' is a group element.
     pi = GAP.Globals.PermutationOp(g, omega_list, gfun)
+    @req pi !== GAP.Globals.fail "no permutation is induced by $g"
 
     return group_element(action_range(Omega), pi)
 end

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -158,12 +158,13 @@
   @test orbits(orb) == [orb]
 
   # permutation
-  G = symmetric_group(6)
+  G = alternating_group(6)
   Omega = gset(G, permuted, [[0,1,0,1,0,1], [1,2,3,4,5,6]])
   g = gen(G, 1)
   pi = permutation(Omega, g)
   @test order(pi) == order(g)
   @test degree(parent(pi)) == length(Omega)
+  @test_throws ArgumentError permutation(Omega, cperm([2,1]))
 
   # action homomorphism
   G = symmetric_group(6)

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -170,6 +170,8 @@
   G = symmetric_group(6)
   Omega = gset(G, permuted, [[0,1,0,1,0,1], [1,2,3,4,5,6]])
   acthom = action_homomorphism(Omega)
+  g = gen(G, 1)
+  pi = permutation(Omega, g)
   @test pi == g^acthom
   @test has_preimage_with_preimage(acthom, pi)[1]
   @test order(image(acthom)[1]) == 720


### PR DESCRIPTION
Throw an exception if the result is `GAP.Globals.fail`, instead of creating a corrupted group element from it.

(And add `show_atlas_info` to the manual.)