### PR TITLE
PolyhedralGeometry: make some existing functions for Polyhedron also allow Cone

### DIFF
--- a/src/PolyhedralGeometry/Polyhedron/constructors.jl
+++ b/src/PolyhedralGeometry/Polyhedron/constructors.jl
@@ -20,6 +20,8 @@ struct Polyhedron{T<:scalar_types} <: PolyhedralObject{T} #a real polymake polyh
   Polyhedron{QQFieldElem}(p::Polymake.BigObject) = new{QQFieldElem}(p, QQ)
 end
 
+polyhedron(P::Polyhedron) = P
+
 # default scalar type: guess from input and fall back to `QQFieldElem`
 polyhedron(A, b) = polyhedron(_guess_fieldelem_type(A, b), A, b)
 polyhedron(A) = polyhedron(_guess_fieldelem_type(A), A)

--- a/test/PolyhedralGeometry/polyhedron.jl
+++ b/test/PolyhedralGeometry/polyhedron.jl
@@ -840,3 +840,16 @@ end
   @test !is_archimedean_solid(prism)
   @test !is_johnson_solid(prism)
 end
+
+
+@testset "cone / polyhedron interoperability" begin
+  c = positive_hull(matrix(QQ,[1 0; 0 1]))
+  p = cube(2)
+  @test n_vertices(pyramid(c)) == 2
+  @test n_vertices(bipyramid(c)) == 3
+  @test n_rays(normal_cone(c,1)) == 2
+  @test n_vertices(intersect(c,p)) == 4
+  @test n_vertices(c*p) == 4
+  @test n_vertices(convex_hull(c,p)) == 1
+  @test n_rays(c+p) == 2
+end


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/4813 amongst other things.

Still missing and to be discussed: scalar multiplication.  Is there a ready-made function to negate a cone?