### PR TITLE
Add `decompose_wreath_product_element`

### DIFF
--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -549,14 +549,26 @@ function (W::WreathProductGroup)(
   d = GAP.Globals.NrMovedPoints(GAPWrap.Image(W.a.map))
   @req length(L) == d + 1 "Wrong number of arguments"
   for i in 1:d
-    @req L[i] in W.G "Wrong input"
+    @req L[i] in normal_subgroup(W) "Wrong input"
   end
-  @req L[d + 1] in W.H "Wrong input"
+  @req L[d + 1] in acting_subgroup(W) "Wrong input"
   # simply put parent(L[d+1])==W.H does not work. Example: if I want to write explicitly a permutation in H proper subgroup of Sym(n).
-  arr = [GAPWrap.Image(GAPWrap.Embedding(W.Xfull, i),GapObj(L[i])) for i in 1:length(L)]
-  xgap = prod(arr)
+  list = GapObj(L; recursive = true)
+  xgap = GAP.Globals.WreathProductElementList(W.Xfull, list) # something does not work here
   @req xgap in GapObj(W) "Element not in the group"
   return group_element(W, xgap)
+end
+
+# TODO: come up with a better name, add docstring, put into manual
+function decompose_wreath_product_element(x::GAPGroupElem{WreathProductGroup})
+  W = parent(x)
+  G = normal_subgroup(W)
+  H = acting_subgroup(W)
+  list = GAP.Globals.ListWreathProductElement(W.Xfull, GapObj(x))
+  @assert length(list) == GAP.Globals.NrMovedPoints(GAPWrap.Image(W.a.map)) + 1
+  gs = [group_element(G, g) for g in list[1:end-1]]
+  h = canonical_projection(W)(x) # group_element(H, list[end]) does not work if MovedPoints(Image(W.a.map)) has holes
+  return gs, h
 end
 
 """

--- a/test/Groups/directproducts.jl
+++ b/test/Groups/directproducts.jl
@@ -176,6 +176,9 @@ end
    @test is_full_wreath_product(W)
    @test W==sub(W,gens(W))[1]
    @test permutation_group(W) isa PermGroup
+   x = rand(W)
+   gs, h = Oscar.decompose_wreath_product_element(x)
+   @test x == W(gs..., h)
 
    H = sub(cperm([1,2,4]))[1]
    W = wreath_product(C,H)
@@ -186,6 +189,7 @@ end
    @test rand(W) isa elem_type(WreathProductGroup)
    f1 = C[1]
    x = W(f1,one(C),f1,one(C),cperm([1,4,2]))
+   @test Oscar.decompose_wreath_product_element(x) == ([f1,one(C),f1,one(C)], cperm([1,4,2]))
    @test canonical_injection(W,1)(f1)==W(f1,one(C),one(C),one(C),one(H))
    @test canonical_injection(W,4)(f1)==W(one(C),one(C),one(C),f1,one(H))
    @test_throws ArgumentError canonical_injection(W,7)(f1) in W
@@ -203,6 +207,9 @@ end
    @test is_cyclic(K)
    @test index(W,K)==8
    @test_throws ArgumentError canonical_injection(K,1)(f1) in K
+   x = rand(K)
+   gs, h = Oscar.decompose_wreath_product_element(x)
+   @test x == K(gs..., h)
 
    C = cyclic_group(3)
    a = hom(C,H,[C[1]],[cperm([1,2,4])])
@@ -216,4 +223,7 @@ end
    @test W(C[1],one(C),one(C),C[1]) isa elem_type(WreathProductGroup)
    @test image(canonical_projection(W))[1]==C
    @test_throws ArgumentError canonical_injection(W,5)(C[1])
+   x = rand(W)
+   gs, h = Oscar.decompose_wreath_product_element(x)
+   @test x == W(gs..., h)
 end


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/4830.

Names are up to discussion.

The code does not work in the case where `H` is not a PermGroup, the action hom `a` is supplied, and `MovedPoints(Image(W.a.map))` has holes.
The problem in this case is that Gap changes the acting symmetric group in the wreath product constructor (https://github.com/gap-system/gap/blob/2a7cf16d52aed873cd70aabc9c98e2bc925711ca/lib/gprd.gi#L834-L837), and then uses this new group as the input/output of `WreathProductElementList`/`ListWreathProductElement`. The easiest solution would probably to use `GAP.Globals.WreathProductInfo(GapObj(W)).alpha` for translation instead of `W.a`.

Or do you have any other ideas?