### PR TITLE
Add accessors `group` and `subgroup` for `SubgroupTransversal`

### DIFF
--- a/docs/src/Groups/subgroups.md
+++ b/docs/src/Groups/subgroups.md
@@ -122,6 +122,9 @@ is_right(C::GroupCoset)
 is_left(C::GroupCoset)
 right_cosets(G::GAPGroup, H::GAPGroup; check::Bool=true)
 left_cosets(G::GAPGroup, H::GAPGroup; check::Bool=true)
+SubgroupTransversal
+group(T::SubgroupTransversal)
+acting_group(T::SubgroupTransversal)
 right_transversal(G::T1, H::T2; check::Bool=true) where T1 <: GAPGroup where T2 <: GAPGroup
 left_transversal(G::T1, H::T2; check::Bool=true) where T1 <: GAPGroup where T2 <: GAPGroup
 is_bicoset(C::GroupCoset)

--- a/docs/src/Groups/subgroups.md
+++ b/docs/src/Groups/subgroups.md
@@ -124,7 +124,7 @@ right_cosets(G::GAPGroup, H::GAPGroup; check::Bool=true)
 left_cosets(G::GAPGroup, H::GAPGroup; check::Bool=true)
 SubgroupTransversal
 group(T::SubgroupTransversal)
-acting_group(T::SubgroupTransversal)
+subgroup(T::SubgroupTransversal)
 right_transversal(G::T1, H::T2; check::Bool=true) where T1 <: GAPGroup where T2 <: GAPGroup
 left_transversal(G::T1, H::T2; check::Bool=true) where T1 <: GAPGroup where T2 <: GAPGroup
 is_bicoset(C::GroupCoset)

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -376,6 +376,10 @@ Type of left/right transversals of subgroups in groups.
 Objects of this type are created by [`right_transversal`](@ref) and
 [`left_transversal`](@ref).
 
+- [`group(T::SubgroupTransversal)`](@ref) returns $G$.
+
+- [`acting_group(T::SubgroupTransversal)`](@ref) returns $H$.
+
 # Note for developers
 
 The elements are encoded via a right transversal object in GAP.

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -382,7 +382,7 @@ Objects of this type are created by [`right_transversal`](@ref) and
 
 - [`group(T::SubgroupTransversal)`](@ref) returns $G$.
 
-- [`acting_group(T::SubgroupTransversal)`](@ref) returns $H$.
+- [`subgroup(T::SubgroupTransversal)`](@ref) returns $H$.
 
 # Note for developers
 
@@ -470,7 +470,7 @@ true
 group(T::SubgroupTransversal) = T.G
 
 """
-    acting_group(T::SubgroupTransversal)
+    subgroup(T::SubgroupTransversal)
 
 Return the group `H` such that `T` is a (left or right)
 transversal of `H`.
@@ -488,11 +488,11 @@ Right transversal of length 20 of
   Sym(3) in
   Sym(5)
 
-julia> acting_group(T) == H
+julia> subgroup(T) == H
 true
 ```
 """
-acting_group(T::SubgroupTransversal) = T.H
+subgroup(T::SubgroupTransversal) = T.H
 
 """
     right_transversal(G::GAPGroup, H::GAPGroup; check::Bool=true)

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -436,6 +436,55 @@ function Base.keys(T::SubgroupTransversal)
     return keys(1:length(T))
 end
 
+"""
+    group(T::SubgroupTransversal)
+
+Return the group `G` that contains all of the elements in `T`.
+That is, `T` is a left or right transversal of a subgroup of `G`.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(5)
+Sym(5)
+
+julia> H = sylow_subgroup(G, 2)[1]
+Permutation group of degree 5 and order 8
+
+julia> T = right_transversal(G, H)
+Right transversal of length 15 of
+  permutation group of degree 5 and order 8 in
+  Sym(5)
+
+julia> group(T) == G
+true
+```
+"""
+group(T::SubgroupTransversal) = T.G
+
+"""
+    acting_group(T::SubgroupTransversal)
+
+Return the group `H` such that `T` is a (left or right)
+transversal of `H`.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(5)
+Sym(5)
+
+julia> H = symmetric_group(3)
+Sym(3)
+
+julia> T = right_transversal(G, H)
+Right transversal of length 20 of
+  Sym(3) in
+  Sym(5)
+
+julia> acting_group(T) == H
+true
+```
+"""
+acting_group(T::SubgroupTransversal) = T.H
 
 """
     right_transversal(G::GAPGroup, H::GAPGroup; check::Bool=true)

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -373,9 +373,9 @@ end
 
 Type of left/right transversals of subgroups in groups.
 
-For a group $G$ and a subgroup $H$ of $G$, the collection of right
-(resp. left) cosets of $H$ in $G$ is called a right (resp. left)
-transversal for $H$ in $G$.
+For a group $G$ and a subgroup $H$ of $G$, $T$ is a right
+(resp. left) transversal for $H$ in $G$ if $T$ contains
+precisely one element of each right (resp. left) cosets of $H$ in $G$.
 
 Objects of this type are created by [`right_transversal`](@ref) and
 [`left_transversal`](@ref).

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -373,6 +373,10 @@ end
 
 Type of left/right transversals of subgroups in groups.
 
+For a group $G$ and a subgroup $H$ of $G$, the collection of right
+(resp. left) cosets of $H$ in $G$ is called a right (resp. left)
+transversal for $H$ in $G$.
+
 Objects of this type are created by [`right_transversal`](@ref) and
 [`left_transversal`](@ref).
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1269,7 +1269,7 @@ export number_of_standard_tableaux
 export number_of_transitive_groups, has_number_of_transitive_groups
 export number_of_weak_compositions
 export numerator
-export numerical_lattice 
+export numerical_lattice
 export numerical_lattice_of_K3_cover
 export objective_function
 export omega_group
@@ -1620,6 +1620,7 @@ export sub
 export sub_object
 export subalgebra_membership
 export subalgebra_membership_homogeneous
+export subgroup
 export subgroup_classes
 export subquo_type
 export subquotient


### PR DESCRIPTION
We add the following accessors for `T::SubgroupTransversal` a (left or right) transversal of a subgroup `H` in `G`:
- `group(T)` for `T.G`
- ~~`acting_group(T)`~~ `subgroup(T)` for `T.H`
along with docstrings that are easy to find in the main documentation.

~~These accessor names are consistent with those for a `GroupCoset`.~~

Closes #4296 