### PR TITLE
ToricVarieties: Speedup

### DIFF
--- a/docs/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses.md
@@ -12,6 +12,15 @@ DocTestSetup = Oscar.doctestsetup()
 
 ### General constructors
 
+Cohomology classes are elements of the cohomology ring, which is a quotient ring (for normal toric varieties that
+are simplicial and complete). All of the following methods accept an optional argument `quick` (default: `false`).  
+When set to `true`, computations are performed in the base ring of the cohomology ring to improve performance.  
+This is especially useful when constructing cohomology classes on large toric varieties, where operations
+in the quotient ring - such as Gröbner basis computations - can be computationally expensive.
+
+**Caveat:** When `quick = true`, the method will not detect whether the resulting cohomology class is trivial.
+Use this option when faster computations are preferred and triviality checks are not required.
+
 ```@docs
 cohomology_class(v::NormalToricVarietyType, p::MPolyQuoRingElem)
 cohomology_class(d::ToricDivisor)

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
@@ -1295,7 +1295,7 @@ function chern_class(m::AbstractFTheoryModel, k::Int; check::Bool = true)
     coeffs_list = coefficients(toric_divisor(toric_divisor_class(ambient_space(m), diff)))
     indets = [lift(g) for g in gens(cohomology_ring(ambient_space(m), check = check))]
     poly = sum(QQ(coeffs_list[k]) * indets[k] for k in 1:length(indets))
-    cs[2] = CohomologyClass(ambient_space(m), cohomology_ring(ambient_space(m), check = check)(poly))
+    cs[2] = CohomologyClass(ambient_space(m), cohomology_ring(ambient_space(m), check = check)(poly), true)
     set_attribute!(m, :chern_classes, cs)
   end
 
@@ -1316,11 +1316,11 @@ function chern_class(m::AbstractFTheoryModel, k::Int; check::Bool = true)
   indets = [lift(g) for g in gens(cohomology_ring(ambient_space(m), check = check))]
   coeff_ring = coefficient_ring(ambient_space(m))
   poly = sum(coeff_ring(coefficients(d)[k]) * indets[k] for k in 1:length(indets))
-  cy = CohomologyClass(ambient_space(m), cohomology_ring(ambient_space(m), check = check)(poly))
+  cy = CohomologyClass(ambient_space(m), cohomology_ring(ambient_space(m), check = check)(poly), true)
   ck_ambient = chern_class(ambient_space(m), k, check = check)
   ckm1 = chern_class(m, k-1, check = check)
   new_poly = lift(polynomial(ck_ambient)) - lift(polynomial(cy)) * lift(polynomial(ckm1))
-  cs[k+1] = CohomologyClass(ambient_space(m), cohomology_ring(ambient_space(m), check = check)(new_poly))
+  cs[k+1] = CohomologyClass(ambient_space(m), cohomology_ring(ambient_space(m), check = check)(new_poly), true)
   set_attribute!(m, :chern_classes, cs)
   return cs[k+1]
 end

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
@@ -237,7 +237,7 @@ function blow_up(m::AbstractFTheoryModel, I::AbsIdealSheaf; coordinate_name::Str
       new_e_classes = Vector{CohomologyClass}()
       for i in indices
         poly = sum(coeff_ring(coefficients(divs[i])[k]) * indets[k] for k in 1:length(indets))
-        push!(new_e_classes, CohomologyClass(ambient_space(model), cohomology_ring(ambient_space(model), check = false)(poly)))
+        push!(new_e_classes, CohomologyClass(ambient_space(model), cohomology_ring(ambient_space(model), check = false)(poly), true))
       end
 
       set_attribute!(model, :exceptional_classes, new_e_classes)

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
@@ -111,7 +111,7 @@ function flux_instance(fgs::FamilyOfG4Fluxes, int_coeffs::Vector{Int}, rat_coeff
   if length(int_coeffs) == 0 && length(rat_coeffs) == 0
     m = model(fgs)
     r = cohomology_ring(ambient_space(m), check = check)
-    return G4Flux(m, CohomologyClass(ambient_space(m), zero(r)))
+    return G4Flux(m, CohomologyClass(ambient_space(m), zero(r), true))
   end
   @req all(x -> x isa Int, int_coeffs) "Provided integral coefficient is not an integer"
   @req all(x -> x isa Rational{Int64}, rat_coeffs) "Provided integral coefficient is not an integer"

--- a/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
@@ -115,7 +115,7 @@ function g4_flux(m::AbstractFTheoryModel, g4_class::CohomologyClass; check::Bool
       end
     end
     converted_poly = cohomology_ring(ambient_space(m), check = check)(converted_poly)
-    converted_class = CohomologyClass(ambient_space(m), converted_poly)
+    converted_class = CohomologyClass(ambient_space(m), converted_poly, true)
     
   end
 
@@ -207,7 +207,7 @@ function Base.:+(g1::G4Flux, g2::G4Flux)
   @req model(g1) === model(g2) "The G4-fluxes must be defined on the same model"
   R = parent(polynomial(cohomology_class(g1)))
   new_poly = R(polynomial(cohomology_class(g1)).f + polynomial(cohomology_class(g2)).f)
-  new_cohomology_class = CohomologyClass(ambient_space(model(g1)), new_poly)
+  new_cohomology_class = CohomologyClass(ambient_space(model(g1)), new_poly, true)
   return G4Flux(model(g1), new_cohomology_class)
 end
 
@@ -218,7 +218,7 @@ Base.:-(g::G4Flux) = (-1) * g
 function Base.:*(c::T, g::G4Flux) where {T <: Union{IntegerUnion, QQFieldElem, Rational{Int64}}}
   R = parent(polynomial(cohomology_class(g)))
   new_poly = R(c * polynomial(cohomology_class(g)).f)
-  new_cohomology_class = CohomologyClass(ambient_space(model(g)), new_poly)
+  new_cohomology_class = CohomologyClass(ambient_space(model(g)), new_poly, true)
   return G4Flux(model(g), new_cohomology_class)
 end
 

--- a/experimental/FTheoryTools/test/FTM-1511-03209.jl
+++ b/experimental/FTheoryTools/test/FTM-1511-03209.jl
@@ -79,7 +79,7 @@ end
       sampled_dict[non_zero_entries[i][1]] = non_zero_entries[i][2]
     end
     for (k,v) in sampled_dict
-      desired_class = CohomologyClass(ambient_space(qsm_model), coho_R(gs[k[1]] * gs[k[2]] * gs[k[3]] * gs[k[4]] * kbar_poly))
+      desired_class = CohomologyClass(ambient_space(qsm_model), coho_R(gs[k[1]] * gs[k[2]] * gs[k[3]] * gs[k[4]] * kbar_poly), true)
       @test v == integrate(desired_class, check = false)
     end
   end

--- a/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/attributes.jl
@@ -250,4 +250,4 @@ julia> cohomology_class(ac)
 Cohomology class on a normal toric variety given by 6*x3 + e1 + 7*e2
 ```
 """
-@attr CohomologyClass cohomology_class(ac::RationalEquivalenceClass) = CohomologyClass(toric_variety(ac), polynomial(cohomology_ring(toric_variety(ac)),ac))
+@attr CohomologyClass cohomology_class(ac::RationalEquivalenceClass) = CohomologyClass(toric_variety(ac), polynomial(cohomology_ring(toric_variety(ac)),ac), true)

--- a/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/constructors.jl
@@ -156,7 +156,7 @@ julia> (x1, x2, x3) = gens(cohomology_ring(P2))
  x2
  x3
 
-julia> cc = CohomologyClass(P2, x1+x2)
+julia> cc = cohomology_class(P2, x1+x2)
 Cohomology class on a normal toric variety given by x1 + x2
 
 julia> rational_equivalence_class(cc)

--- a/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/constructors.jl
@@ -5,7 +5,7 @@
 @attributes mutable struct CohomologyClass
     v::NormalToricVarietyType
     p::MPolyQuoRingElem
-    function CohomologyClass(v::NormalToricVarietyType, p::MPolyQuoRingElem; quick::Bool = false)
+    function CohomologyClass(v::NormalToricVarietyType, p::MPolyQuoRingElem, quick::Bool)
         @req parent(p) == cohomology_ring(v, check = quick) "The polynomial must reside in the cohomology ring of the toric variety"
         return new(v, p)
     end
@@ -59,12 +59,12 @@ function cohomology_class(d::ToricDivisor; quick::Bool = false)
     indets = gens(cohomology_ring(toric_variety(d)))
     coeff_ring = coefficient_ring(toric_variety(d))
     poly = sum(coeff_ring(coefficients(d)[k]) * indets[k] for k in 1:length(indets))
-    return CohomologyClass(toric_variety(d), poly)
+    return CohomologyClass(toric_variety(d), poly, false)
   end
   indets = gens(parent(cohomology_ring(toric_variety(d), check = false)))
   coeff_ring = coefficient_ring(toric_variety(d))
   poly = cohomology_ring(toric_variety(d))(sum(coeff_ring(coefficients(d)[k]) * indets[k] for k in 1:length(indets)))
-  return CohomologyClass(toric_variety(d), poly, quick = quick)
+  return CohomologyClass(toric_variety(d), poly, true)
 end
 
 

--- a/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/constructors.jl
@@ -6,7 +6,7 @@
     v::NormalToricVarietyType
     p::MPolyQuoRingElem
     function CohomologyClass(v::NormalToricVarietyType, p::MPolyQuoRingElem, quick::Bool)
-        @req parent(p) == cohomology_ring(v, check = quick) "The polynomial must reside in the cohomology ring of the toric variety"
+        @req parent(p) == cohomology_ring(v, check = !quick) "The polynomial must reside in the cohomology ring of the toric variety"
         return new(v, p)
     end
 end
@@ -33,7 +33,7 @@ julia> c = cohomology_class(P2, gens(cohomology_ring(P2))[1])
 Cohomology class on a normal toric variety given by x1
 ```
 """
-cohomology_class(v::NormalToricVarietyType, p::MPolyQuoRingElem; quick::Bool = false) = CohomologyClass(v, p; quick = quick)
+cohomology_class(v::NormalToricVarietyType, p::MPolyQuoRingElem; quick::Bool = false) = CohomologyClass(v, p, quick)
 
 
 @doc raw"""
@@ -118,7 +118,7 @@ function Base.:+(cc1::CohomologyClass, cc2::CohomologyClass)
     @req toric_variety(cc1) === toric_variety(cc2) "The cohomology classes must be defined on the same toric variety"
     ring = cohomology_ring(toric_variety(cc1))
     poly = polynomial(ring, cc1) + polynomial(ring, cc2)
-    return CohomologyClass(toric_variety(cc1), poly)
+    return CohomologyClass(toric_variety(cc1), poly, true)
 end
 
 
@@ -126,13 +126,13 @@ function Base.:-(cc1::CohomologyClass, cc2::CohomologyClass)
     @req toric_variety(cc1) === toric_variety(cc2) "The cohomology classes must be defined on the same toric variety"
     ring = cohomology_ring(toric_variety(cc1))
     poly = polynomial(ring, cc1) - polynomial(ring, cc2)
-    return CohomologyClass(toric_variety(cc1), poly)
+    return CohomologyClass(toric_variety(cc1), poly, true)
 end
 
 
-Base.:*(c::QQFieldElem, cc::CohomologyClass) = CohomologyClass(toric_variety(cc), coefficient_ring(toric_variety(cc))(c) * polynomial(cc))
-Base.:*(c::Rational{Int64}, cc::CohomologyClass) = CohomologyClass(toric_variety(cc), coefficient_ring(toric_variety(cc))(c) * polynomial(cc))
-Base.:*(c::T, cc::CohomologyClass) where {T <: IntegerUnion} = CohomologyClass(toric_variety(cc), coefficient_ring(toric_variety(cc))(c) * polynomial(cc))
+Base.:*(c::QQFieldElem, cc::CohomologyClass) = CohomologyClass(toric_variety(cc), coefficient_ring(toric_variety(cc))(c) * polynomial(cc), true)
+Base.:*(c::Rational{Int64}, cc::CohomologyClass) = CohomologyClass(toric_variety(cc), coefficient_ring(toric_variety(cc))(c) * polynomial(cc), true)
+Base.:*(c::T, cc::CohomologyClass) where {T <: IntegerUnion} = CohomologyClass(toric_variety(cc), coefficient_ring(toric_variety(cc))(c) * polynomial(cc), true)
 
 
 #################################
@@ -141,13 +141,13 @@ Base.:*(c::T, cc::CohomologyClass) where {T <: IntegerUnion} = CohomologyClass(t
 
 function Base.:*(cc1::CohomologyClass, cc2::CohomologyClass)
     @req toric_variety(cc1) === toric_variety(cc2) "The cohomology classes must be defined on the same toric variety"
-    ring = cohomology_ring(toric_variety(cc1))
+    ring = cohomology_ring(toric_variety(cc1), check = false)
     poly = polynomial(ring, cc1) * polynomial(ring, cc2)
-    return CohomologyClass(toric_variety(cc1), poly)
+    return CohomologyClass(toric_variety(cc1), poly, true)
 end
 
 
-Base.:^(cc::CohomologyClass, p::T) where {T <: IntegerUnion} = CohomologyClass(toric_variety(cc), polynomial(cc)^p)
+Base.:^(cc::CohomologyClass, p::T) where {T <: IntegerUnion} = CohomologyClass(toric_variety(cc), polynomial(cc)^p, true)
 
 
 ########################

--- a/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/constructors.jl
@@ -5,8 +5,8 @@
 @attributes mutable struct CohomologyClass
     v::NormalToricVarietyType
     p::MPolyQuoRingElem
-    function CohomologyClass(v::NormalToricVarietyType, p::MPolyQuoRingElem)
-        @req parent(p) == cohomology_ring(v) "The polynomial must reside in the cohomology ring of the toric variety"
+    function CohomologyClass(v::NormalToricVarietyType, p::MPolyQuoRingElem; quick::Bool = false)
+        @req parent(p) == cohomology_ring(v, check = quick) "The polynomial must reside in the cohomology ring of the toric variety"
         return new(v, p)
     end
 end
@@ -33,7 +33,7 @@ julia> c = cohomology_class(P2, gens(cohomology_ring(P2))[1])
 Cohomology class on a normal toric variety given by x1
 ```
 """
-cohomology_class(v::NormalToricVarietyType, p::MPolyQuoRingElem) = CohomologyClass(v, p)
+cohomology_class(v::NormalToricVarietyType, p::MPolyQuoRingElem; quick::Bool = false) = CohomologyClass(v, p; quick = quick)
 
 
 @doc raw"""
@@ -54,11 +54,17 @@ julia> cohomology_class(d)
 Cohomology class on a normal toric variety given by 6*x3
 ```
 """
-function cohomology_class(d::ToricDivisor)
+function cohomology_class(d::ToricDivisor; quick::Bool = false)
+  if quick == false
     indets = gens(cohomology_ring(toric_variety(d)))
     coeff_ring = coefficient_ring(toric_variety(d))
     poly = sum(coeff_ring(coefficients(d)[k]) * indets[k] for k in 1:length(indets))
     return CohomologyClass(toric_variety(d), poly)
+  end
+  indets = gens(parent(cohomology_ring(toric_variety(d), check = false)))
+  coeff_ring = coefficient_ring(toric_variety(d))
+  poly = cohomology_ring(toric_variety(d))(sum(coeff_ring(coefficients(d)[k]) * indets[k] for k in 1:length(indets)))
+  return CohomologyClass(toric_variety(d), poly, quick = quick)
 end
 
 
@@ -80,7 +86,7 @@ julia> cohomology_class(tdc)
 Cohomology class on a normal toric variety given by 2*x3
 ```
 """
-cohomology_class(c::ToricDivisorClass) = cohomology_class(toric_divisor(c))
+cohomology_class(c::ToricDivisorClass; quick::Bool = false) = cohomology_class(toric_divisor(c), quick = quick)
 
 
 @doc raw"""
@@ -101,7 +107,7 @@ julia> polynomial(cohomology_class(l))
 2*x3
 ```
 """
-cohomology_class(l::ToricLineBundle) = cohomology_class(toric_divisor(l))
+cohomology_class(l::ToricLineBundle; quick::Bool = false) = cohomology_class(toric_divisor(l), quick = quick)
 
 
 #################################

--- a/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/special_attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/special_attributes.jl
@@ -50,7 +50,7 @@ julia> polynomial(volume_form(hirzebruch_surface(NormalToricVariety, 5)))
     indets = gens(cohomology_ring(v))
     poly = prod(indets[k]^exponents[k] for k in 1:length(exponents))
     @req !iszero(poly) && degree(poly)[1] == dim(v) "The volume class does not exist"
-    return CohomologyClass(v, poly)
+    return CohomologyClass(v, poly, true)
 end
 
 
@@ -178,7 +178,7 @@ function chern_class(v::NormalToricVariety, k::Int; check::Bool = true)
     push_term!(my_builder, one(QQ), exps)
   end
   desired_class = finish(my_builder)
-  cs[k+1] = CohomologyClass(v, cohomology_ring(v, check = check)(desired_class))
+  cs[k+1] = CohomologyClass(v, cohomology_ring(v, check = check)(desired_class), true)
   set_attribute!(v, :chern_classes, cs)
   return cs[k+1]
 end

--- a/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricDivisors/constructors.jl
@@ -122,24 +122,28 @@ end
 # 6: Display
 ######################s
 
+function Base.show(io::IO, td::ToricDivisor)
+  # initiate properties string
+  properties_string = ["Torus-invariant"]
+  
+  q_car_cb!(a, b) = push_attribute_if_exists!(a, b, :is_q_cartier, "q_cartier")
+  push_attribute_if_exists!(properties_string, td, :is_cartier, "cartier"; callback=q_car_cb!)
+  push_attribute_if_exists!(properties_string, td, :is_principal, "principal")
+  push_attribute_if_exists!(properties_string, td, :is_basepoint_free, "basepoint-free")
+  push_attribute_if_exists!(properties_string, td, :is_effective, "effective")
+  push_attribute_if_exists!(properties_string, td, :is_integral, "integral")
+  
+  ample_cb!(a, b) = push_attribute_if_exists!(a, b, :is_ample, "ample")
+  push_attribute_if_exists!(properties_string, td, :is_very_ample, "very-ample"; callback=ample_cb!)
+  
+  push_attribute_if_exists!(properties_string, td, :is_nef, "nef")
+  push_attribute_if_exists!(properties_string, td, :is_prime, "prime")
+  
+  # print
+  push!(properties_string, "divisor on a normal toric variety")
+  join(io, properties_string, ", ", " ")
+end
+
 function Base.show(io::IO, ::MIME"text/plain", td::ToricDivisor)
-    # initiate properties string
-    properties_string = ["Torus-invariant"]
-    
-    q_car_cb!(a, b) = push_attribute_if_exists!(a, b, :is_q_cartier, "q_cartier")
-    push_attribute_if_exists!(properties_string, td, :is_cartier, "cartier"; callback=q_car_cb!)
-    push_attribute_if_exists!(properties_string, td, :is_principal, "principal")
-    push_attribute_if_exists!(properties_string, td, :is_basepoint_free, "basepoint-free")
-    push_attribute_if_exists!(properties_string, td, :is_effective, "effective")
-    push_attribute_if_exists!(properties_string, td, :is_integral, "integral")
-    
-    ample_cb!(a, b) = push_attribute_if_exists!(a, b, :is_ample, "ample")
-    push_attribute_if_exists!(properties_string, td, :is_very_ample, "very-ample"; callback=ample_cb!)
-    
-    push_attribute_if_exists!(properties_string, td, :is_nef, "nef")
-    push_attribute_if_exists!(properties_string, td, :is_prime, "prime")
-    
-    # print
-    push!(properties_string, "divisor on a normal toric variety")
-    join(io, properties_string, ", ", " ")
+  show(io, td)
 end


### PR DESCRIPTION
Printing vector of toric divisors is currently very slow. MWE
```julia
B3 = projective_space(NormalToricVariety, 3)
torusinvariant_prime_divisors(B3*B3)
```
This PR aims to speed this up.

Similarly, constructing cohomology classes on big toric varieties can be slow, due to quotient ring gymnastics. Introduce an optional argument to circumvent computations in the quotient ring, and thus construct cohomology classes faster. This comes at the price that the fast computation will not be able to detect if a cohomology class is trivial.

cc @lkastner 