### PR TITLE
Add `divexact` for `MPolyQuoRingElem`

### DIFF
--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -1294,6 +1294,13 @@ function divides(a::MPolyQuoRingElem, b::MPolyQuoRingElem)
   return true, Q(sparse_matrix(base_ring(Q), s, 1:1, length(J):length(J))[1, length(J)])
 end
 
+function divexact(a::MPolyQuoRingElem, b::MPolyQuoRingElem; check::Bool=true)
+  check_parent(a, b)
+  b, q = divides(a, b)
+  !b && error("Division is not exact in divexact")
+  return q
+end
+
 ### 
 # The following two functions below provide a hotfix to make sure that the preferred 
 # ordering provided to the constructor of the quotient ring is actually used for the 

--- a/test/Rings/MPolyQuo.jl
+++ b/test/Rings/MPolyQuo.jl
@@ -50,6 +50,7 @@ end
   Q, q = quo(R,I)
   f = q(x*y)
   @test divides(one(Q), f) == (false, one(Q))
+  @test_throws ErrorException divexact(one(Q), f)
 
   A, _ = quo(R, 2*x^2-5*y^3)
   (x, y) = (A(x), A(y))
@@ -60,7 +61,9 @@ end
 
   @test !divides(x, y)[1]
   @test divides(x, x) == (true, one(A))
+  @test divexact(x, x) == one(A)
   @test divides(zero(A), x) == (true, zero(A))
+  @test divexact(zero(A), x) == zero(A)
 
   # promote rule
   K = GF(2)


### PR DESCRIPTION
Closes #4861

(Since `divides` was already there, there is not much to do here.)
