### PR TITLE
runtests: keep worker pool to avoid issues with extra processes from parallel tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -160,11 +160,11 @@ if test_subset == :long || test_subset == :default
   println("Starting tests for Serialization/IPC.jl")
   push!(stats, Oscar._timed_include("Serialization/IPC.jl", Main))
 
-  # if "Parallel" in Oscar.exppkgs
-  #   path = joinpath(Oscar.oscardir, "experimental", "Parallel", "test", "runtests.jl")
-  #   println("Starting tests for $path")
-  #   push!(stats, Oscar._timed_include(path, Main))
-  # end
+  if "Parallel" in Oscar.exppkgs
+    path = joinpath(Oscar.oscardir, "experimental", "Parallel", "test", "runtests.jl")
+    println("Starting tests for $path")
+    push!(stats, Oscar._timed_include(path, Main))
+  end
 end
 
 # if many workers, distribute tasks across them

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,8 @@ if numprocs >= 2
   println("Adding worker processes")
   addprocs(numprocs)
 end
+# keep custom worker pool to avoid issues from extra processes in parallel tests
+worker_pool = WorkerPool(workers())
 
 if haskey(ENV, "JULIA_PKGEVAL") ||
   get(ENV, "CI", "") == "true" ||
@@ -167,7 +169,7 @@ end
 
 # if many workers, distribute tasks across them
 # otherwise, is essentially a serial loop
-merge!(stats, reduce(merge, pmap(testlist) do x
+merge!(stats, reduce(merge, pmap(worker_pool, testlist) do x
                               println("Starting tests for $x")
                               Oscar.test_module(x; new=false, timed=true, tempproject=false)
                             end))


### PR DESCRIPTION
This should fix #4799 and reverts #4800 (re-enables the `Parallel` tests).

When adding and removing multiple workers (from `IPC.jl` and `Parallel`) some state in the default worker pool is not completely cleared in julia 1.10 which causes the subsequent pmap to run with with multiple async tasks. We can avoid this by keeping an explicit WorkerPool (which seems like a good idea anyway).

cc: @antonydellavecchia @thofma 