### PR TITLE
Add input check for `FreeModuleHom`s

### DIFF
--- a/experimental/DoubleAndHyperComplexes/src/Objects/induced_ENC.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/induced_ENC.jl
@@ -62,9 +62,6 @@ function (fac::InducedENCMapFactory)(self::AbsHyperComplex, p::Int, I::Tuple)
   # TODO: This can probably be sped up by lifting directly on the exterior powers.
   img_gens = elem_type(cod)[]
   ambient_map = map(enc, i)
-  @show i
-  @show domain(ambient_map)
-  @show ambient_free_module(dom)
   @assert domain(ambient_map) === ambient_free_module(dom)
   for g in gens(dom)
     rep = repres(g)

--- a/experimental/DoubleAndHyperComplexes/src/Objects/induced_ENC.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/induced_ENC.jl
@@ -27,7 +27,7 @@ function (fac::InducedENCChainFactory)(self::AbsHyperComplex, ind::Tuple)
   end
   Ip, _ = sub(amb_ext_power, new_gens)
   fac.ext_powers[i] = Ip
-  result = tensor_product(_symmetric_power(enc, i), Ip)
+  result = tensor_product(_symmetric_power(enc, i), Ip; ambient_tensor_product=enc[i])
   return result
 end
 
@@ -62,6 +62,10 @@ function (fac::InducedENCMapFactory)(self::AbsHyperComplex, p::Int, I::Tuple)
   # TODO: This can probably be sped up by lifting directly on the exterior powers.
   img_gens = elem_type(cod)[]
   ambient_map = map(enc, i)
+  @show i
+  @show domain(ambient_map)
+  @show ambient_free_module(dom)
+  @assert domain(ambient_map) === ambient_free_module(dom)
   for g in gens(dom)
     rep = repres(g)
     image_g = ambient_map(rep)

--- a/src/Modules/UngradedModules/FreeModuleHom.jl
+++ b/src/Modules/UngradedModules/FreeModuleHom.jl
@@ -75,7 +75,7 @@ function matrix(f::FreeModuleHom)
 end
 
 function (h::FreeModuleHom)(a::AbstractFreeModElem)
-  @assert parent(a) === domain(h)
+  @req parent(a) === domain(h) "invalid input"
   image(h, a)
 end
 

--- a/src/Modules/UngradedModules/FreeModuleHom.jl
+++ b/src/Modules/UngradedModules/FreeModuleHom.jl
@@ -74,7 +74,10 @@ function matrix(f::FreeModuleHom)
   return f.matrix
 end
 
-(h::FreeModuleHom)(a::AbstractFreeModElem) = image(h, a)
+function (h::FreeModuleHom)(a::AbstractFreeModElem)
+  @assert parent(a) === domain(h)
+  image(h, a)
+end
 
 @doc raw"""
     hom(F::FreeMod, M::ModuleFP{T}, V::Vector{<:ModuleFPElem{T}}) where T

--- a/src/Modules/UngradedModules/Tensor.jl
+++ b/src/Modules/UngradedModules/Tensor.jl
@@ -116,7 +116,7 @@ x*y*e[1] \otimes e[1]
 ```
 """
 function tensor_product(G::ModuleFP...; 
-    ambient_tensor_product::FreeMod=tensor_product([ambient_free_module(x) for x = G]..., task = :none),
+    ambient_tensor_product::FreeMod=tensor_product((ambient_free_module(x) for x in G)..., task = :none),
     task::Symbol = :none
   )
   F = ambient_tensor_product

--- a/src/Modules/UngradedModules/Tensor.jl
+++ b/src/Modules/UngradedModules/Tensor.jl
@@ -115,8 +115,12 @@ julia> t((M[1], M[2]))
 x*y*e[1] \otimes e[1]
 ```
 """
-function tensor_product(G::ModuleFP...; task::Symbol = :none)
-  F, mF = tensor_product([ambient_free_module(x) for x = G]..., task = :map)
+function tensor_product(G::ModuleFP...; 
+    ambient_tensor_product::FreeMod=tensor_product([ambient_free_module(x) for x = G]..., task = :none),
+    task::Symbol = :none
+  )
+  F = ambient_tensor_product
+  mF = tensor_pure_function(ambient_tensor_product)
   # We want to store a dict where the keys are tuples of indices and the values
   # are the corresponding pure vectors (i.e. a tuple (2,1,5) represents the 
   # 2nd, 1st and 5th generator of the 1st, 2nd and 3rd module, which we are 


### PR DESCRIPTION
I discovered that the input check for `FreeModuleHom`s was not active. Activating it revealed some further deficiencies down the road which should eventually be fixed. 