### PR TITLE
Replace `OrderedMultiIndex` with `Combination`

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -2128,6 +2128,18 @@
   school        = {Technische Universität Kaiserslautern}
 }
 
+@Article{Lie97,
+  author        = {Liebehenschel, Jens},
+  title         = {Ranking and unranking of lexicographically ordered words: an average-case analysis},
+  journal       = {J. Autom. Lang. Comb.},
+  fjournal      = {Journal of Automata, Languages, and Combinatorics},
+  volume        = {2},
+  number        = {4},
+  pages         = {227--268},
+  year          = {1997},
+  doi           = {10.25596/jalc-1997-227}
+}
+
 @Book{Liu06,
   author        = {Liu, Qing},
   title         = {Algebraic geometry and arithmetic curves. Transl. by Reinie Erné},

--- a/experimental/DoubleAndHyperComplexes/src/Objects/Methods.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/Methods.jl
@@ -364,7 +364,7 @@ function _contract(
     for j in 1:p
       I = deleteat!(copy(data(ind)), j)
       new_ind = Combination(I)
-      result = result + (-1)^j * v[i] * phi[ind[j]] * parent[linear_index(new_ind, n)]
+      result = result + (-1)^j * v[i] * phi[ind[j]] * parent[Oscar.linear_index(new_ind, n)]
     end
   end
   return result

--- a/experimental/DoubleAndHyperComplexes/src/Objects/Methods.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/Methods.jl
@@ -2,10 +2,10 @@
 @doc raw"""
     total_complex(D::AbsDoubleComplexOfMorphisms)
 
-Construct the total complex of the double complex `D`. 
+Construct the total complex of the double complex `D`.
 
 Note that `D` needs to be reasonably bounded for this to work so that the strands
-``⨁ ᵢ₊ⱼ₌ₖ Dᵢⱼ`` are finite for every `k`. Moreover, the generic code uses the internal 
+``⨁ ᵢ₊ⱼ₌ₖ Dᵢⱼ`` are finite for every `k`. Moreover, the generic code uses the internal
 function `_direct_sum`. See the docstring of that function to learn more.
 """
 function total_complex(D::AbsDoubleComplexOfMorphisms)
@@ -87,7 +87,7 @@ is_complete(C::ComplexOfMorphisms) = C.complete
 ### cached homology
 
 function kernel(c::HyperComplex{ChainType}, p::Int, i::Tuple) where {ChainType <: ModuleFP}
-  if !isdefined(c, :kernel_cache) 
+  if !isdefined(c, :kernel_cache)
     c.kernel_cache = Dict{Tuple{Tuple, Int}, Map}()
   end
   if haskey(c.kernel_cache, (i, p))
@@ -112,7 +112,7 @@ function boundary(c::HyperComplex{ChainType}, p::Int, i::Tuple) where {ChainType
   prev = I + (direction(c, p) == :chain ? 1 : -1)*[k==p ? 1 : 0 for k in 1:dim(c)]
   Prev = Tuple(prev)
 
-  if !isdefined(c, :boundary_cache) 
+  if !isdefined(c, :boundary_cache)
     c.boundary_cache = Dict{Tuple{Tuple, Int}, Map}()
   end
   if haskey(c.boundary_cache, (i, p))
@@ -120,7 +120,7 @@ function boundary(c::HyperComplex{ChainType}, p::Int, i::Tuple) where {ChainType
     return domain(inc), inc
   end
 
-  if !can_compute_map(c, p, Prev) 
+  if !can_compute_map(c, p, Prev)
     !can_compute_index(c, Prev) || error("map can not be computed")
     Im, inc = sub(c[i], elem_type(c[i])[])
     @assert codomain(inc) === c[i]
@@ -135,7 +135,7 @@ function boundary(c::HyperComplex{ChainType}, p::Int, i::Tuple) where {ChainType
 end
 
 function homology(c::HyperComplex{ChainType}, p::Int, i::Tuple) where {ChainType <: ModuleFP}
-  if !isdefined(c, :homology_cache) 
+  if !isdefined(c, :homology_cache)
     c.homology_cache = Dict{Tuple{Tuple, Int}, Map}()
   end
   if haskey(c.homology_cache, (i, p))
@@ -150,7 +150,7 @@ end
 
 #function Base.show(io::IO, ::MIME"text/plain", c::AbsHyperComplex)
 function Base.show(io::IO, c::AbsHyperComplex)
-  if dim(c) == 1 
+  if dim(c) == 1
     return _print_standard_complex(io, c)
   end
   print(io, "Hyper complex of dimension $(dim(c))")
@@ -201,13 +201,13 @@ function _print_standard_complex(io::IO, c::AbsHyperComplex)
     while !can_compute_index(c, lb)
       lb = lb+1
     end
-    str = "$(c[lb])" 
+    str = "$(c[lb])"
     for i in lb+1:ub
       !can_compute_index(c, i) && break
       if direction(c, 1) == :chain
-        str = str * " <-- " 
+        str = str * " <-- "
       else
-        str = str * " --> " 
+        str = str * " --> "
       end
       str = str * "$(c[i])"
     end
@@ -242,7 +242,7 @@ function _print_standard_complex(io::IO, c::AbsHyperComplex)
     println(io, str)
     return
   end
-  
+
   if has_upper_bound(c, 1)
     ub = upper_bound(c, 1)
     while !can_compute_index(c, ub)
@@ -273,9 +273,9 @@ function _print_standard_complex(io::IO, c::AbsHyperComplex)
 
   # If no bounds are known, we do not know where to start printing, so we give up.
   print(io, "Hyper complex of dimension $(dim(c)) with no known bounds")
-  return 
+  return
 end
- 
+
 function Base.show(io::IO, c::ZeroDimensionalComplex)
   print(io, "Zero-dimensional complex given by $(c[()])")
 end
@@ -298,7 +298,7 @@ function _free_show(io::IO, C::AbsHyperComplex)
   if isnothing(R_name)
     R_name = "($R)"
   end
- 
+
   for i=reverse(rng)
     M = C[i]
     M_name = AbstractAlgebra.get_name(M)
@@ -318,7 +318,7 @@ function _free_show(io::IO, C::AbsHyperComplex)
 
   pos = 0
   pos_mod = Int[]
-  
+
   for i=1:length(name_mod)
     print(io, name_mod[i])
     push!(pos_mod, pos)
@@ -341,13 +341,13 @@ function _free_show(io::IO, C::AbsHyperComplex)
 end
 
 ### Koszul contraction
-# Given a free `R`-module `F`, a morphism φ: F → R, and an element `v` in ⋀ ᵖ F, 
+# Given a free `R`-module `F`, a morphism φ: F → R, and an element `v` in ⋀ ᵖ F,
 # compute the contraction φ(v) ∈ ⋀ ᵖ⁻¹ F.
 # Note: For this internal method φ is only represented as a dense (column) vector.
-# Warning: If the user provides their own parent, they need to make sure that things 
+# Warning: If the user provides their own parent, they need to make sure that things
 #          are compatible. As this is an internal function, no sanity checks are done.
 function _contract(
-    v::FreeModElem{T}, phi::Vector{T}; 
+    v::FreeModElem{T}, phi::Vector{T};
     parent::FreeMod{T}=begin
       success, F0, p = _is_exterior_power(Oscar.parent(v))
       @req success "parent is not an exterior power"
@@ -359,15 +359,13 @@ function _contract(
   @assert length(phi) == ngens(F0) "lengths are incompatible"
   result = zero(parent)
   n = ngens(F0)
-  for (i, ind) in enumerate(OrderedMultiIndexSet(p, n))
+  for (i, ind) in enumerate(combinations(n, p))
     is_zero(v[i]) && continue
     for j in 1:p
-      I = deleteat!(copy(indices(ind)), j)
-      new_ind = OrderedMultiIndex(I, n)
-      result = result + (-1)^j * v[i] * phi[ind[j]] * parent[linear_index(new_ind)]
+      I = deleteat!(copy(data(ind)), j)
+      new_ind = Combination(I)
+      result = result + (-1)^j * v[i] * phi[ind[j]] * parent[linear_index(new_ind, n)]
     end
   end
   return result
 end
-
-

--- a/experimental/DoubleAndHyperComplexes/src/Objects/eagon_northcott_complex.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/eagon_northcott_complex.jl
@@ -43,7 +43,7 @@ function can_compute(fac::ENCChainFactory, self::AbsHyperComplex, I::Tuple)
   return i <= ncols(fac.A) - nrows(fac.A) + 1
 end
 
-### Production of the morphisms 
+### Production of the morphisms
 struct ENCMapFactory{MorphismType} <: HyperComplexMapFactory{MorphismType}
   function ENCMapFactory()
     return new{FreeModuleHom}()
@@ -62,7 +62,7 @@ function (fac::ENCMapFactory)(self::AbsHyperComplex, p::Int, I::Tuple)
 
   if isone(i)
     # TODO: Do we need to take signs into account?
-    dets = [det(A[:, indices(ind)]) for ind in OrderedMultiIndexSet(k, n)]
+    dets = [det(A[:, data(ind)]) for ind in combinations(n, k)]
     return hom(dom, cod, [a*cod[1] for a in dets])
   end
 
@@ -104,7 +104,7 @@ function can_compute(fac::ENCMapFactory, self::AbsHyperComplex, p::Int, I::Tuple
 end
 
 ### The concrete struct
-@attributes mutable struct EagonNorthcottComplex{ChainType, MorphismType} <: AbsHyperComplex{ChainType, MorphismType} 
+@attributes mutable struct EagonNorthcottComplex{ChainType, MorphismType} <: AbsHyperComplex{ChainType, MorphismType}
   internal_complex::HyperComplex{ChainType, MorphismType}
 
   function EagonNorthcottComplex(
@@ -135,11 +135,11 @@ matrix(c::EagonNorthcottComplex) = chain_factory(c).A
 @doc raw"""
     eagon_northcott_complex(A::MatrixElem{T}; F::FreeMod{T}) where {T}
 
-Given an ``m \times n``-matrix ``A`` over a commutative ring ``R``, construct 
+Given an ``m \times n``-matrix ``A`` over a commutative ring ``R``, construct
 the Eagon-Northcott complex associated to it [EN62](@cite).
 
-A free module ``F`` over the same ring as ``A`` can be passed so that the rows 
-of ``A`` are interpreted as elements in the dual of ``F`` in the construction 
+A free module ``F`` over the same ring as ``A`` can be passed so that the rows
+of ``A`` are interpreted as elements in the dual of ``F`` in the construction
 of the complex.
 """
 function eagon_northcott_complex(
@@ -162,4 +162,3 @@ function _symmetric_power(c::EagonNorthcottComplex, i::Int)
   c[i] # fill the cache
   return chain_factory(c).sym_powers[i]
 end
-

--- a/experimental/DoubleAndHyperComplexes/src/Objects/induced_ENC.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/induced_ENC.jl
@@ -22,8 +22,8 @@ function (fac::InducedENCChainFactory)(self::AbsHyperComplex, ind::Tuple)
   k + i - 1 > ngens(I0) && return sub(enc[i], elem_type(enc[i])[])[1]
   amb_ext_power = _exterior_power(enc, i)
   new_gens = elem_type(amb_ext_power)[]
-  for a in OrderedMultiIndexSet(k+i-1, ngens(I0))
-    push!(new_gens, wedge([repres(gen(I0, i)) for i in indices(a)]; parent=amb_ext_power))
+  for a in combinations(ngens(IO), k+i-1)
+    push!(new_gens, wedge([repres(gen(I0, i)) for i in a]; parent=amb_ext_power))
   end
   Ip, _ = sub(amb_ext_power, new_gens)
   fac.ext_powers[i] = Ip
@@ -35,7 +35,7 @@ function can_compute(fac::InducedENCChainFactory, self::AbsHyperComplex, i::Tupl
   return can_compute_index(fac.enc, i)
 end
 
-### Production of the morphisms 
+### Production of the morphisms
 struct InducedENCMapFactory{MorphismType} <: HyperComplexMapFactory{MorphismType}
   function InducedENCMapFactory(enc::EagonNorthcottComplex, I::SubquoModule)
     return new{SubQuoHom}()
@@ -55,7 +55,7 @@ function (fac::InducedENCMapFactory)(self::AbsHyperComplex, p::Int, I::Tuple)
     I0 = chain_factory(self).I
     B = matrix_space(R, ncols(A), ngens(I0))([repres(g)[i] for i in 1:ncols(A), g in gens(I0)])
     C = A*B
-    dets = [det(C[:, indices(ind)]) for ind in OrderedMultiIndexSet(nrows(C), ncols(C))]
+    dets = [det(C[:, data(ind)]) for ind in combinations(ncols(C), nrows(C))]
     return hom(dom, cod, [a*cod[1] for a in dets])
   end
 
@@ -75,7 +75,7 @@ function can_compute(fac::InducedENCMapFactory, self::AbsHyperComplex, p::Int, i
 end
 
 ### The concrete struct
-@attributes mutable struct InducedENC{ChainType, MorphismType} <: AbsHyperComplex{ChainType, MorphismType} 
+@attributes mutable struct InducedENC{ChainType, MorphismType} <: AbsHyperComplex{ChainType, MorphismType}
   internal_complex::HyperComplex{ChainType, MorphismType}
 
   function InducedENC(enc::EagonNorthcottComplex, I::SubquoModule)
@@ -94,13 +94,13 @@ end
 @doc raw"""
     induced_eagon_northcott_complex(enc::EagonNorthcottComplex, I::SubquoModule)
 
-Given an Eagon-Northcott complex `enc` for a matrix ``A`` on a free ``R``-module ``F`` 
-there is a natural induced complex for any submodule ``I ⊂ F``. 
+Given an Eagon-Northcott complex `enc` for a matrix ``A`` on a free ``R``-module ``F``
+there is a natural induced complex for any submodule ``I ⊂ F``.
 
-Namely, if ``v`` is one of the rows of ``A``, interpreted as an element of ``Hom(F, R¹)``, 
-then contraction with ``v`` provides natural maps ``⋀ ᵖ F → ⋀ ᵖ⁻¹ F`` which restrict 
-to the submodules ``⋀ ᵖ I → ⋀ ᵖ⁻¹ I``. As the Eagon-Northcott complex is build up from 
-such contractions, we obtain a natural restricted complex which is constructed by this 
+Namely, if ``v`` is one of the rows of ``A``, interpreted as an element of ``Hom(F, R¹)``,
+then contraction with ``v`` provides natural maps ``⋀ ᵖ F → ⋀ ᵖ⁻¹ F`` which restrict
+to the submodules ``⋀ ᵖ I → ⋀ ᵖ⁻¹ I``. As the Eagon-Northcott complex is build up from
+such contractions, we obtain a natural restricted complex which is constructed by this
 method.
 """
 function induced_eagon_northcott_complex(enc::EagonNorthcottComplex, I::SubquoModule)
@@ -109,4 +109,3 @@ end
 
 ### Implementing the AbsHyperComplex interface via `underlying_complex`
 underlying_complex(c::InducedENC) = c.internal_complex
-

--- a/experimental/DoubleAndHyperComplexes/src/Objects/induced_ENC.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/induced_ENC.jl
@@ -22,8 +22,8 @@ function (fac::InducedENCChainFactory)(self::AbsHyperComplex, ind::Tuple)
   k + i - 1 > ngens(I0) && return sub(enc[i], elem_type(enc[i])[])[1]
   amb_ext_power = _exterior_power(enc, i)
   new_gens = elem_type(amb_ext_power)[]
-  for a in combinations(ngens(I0), k+i-1)
-    push!(new_gens, wedge([repres(gen(I0, i)) for i in a]; parent=amb_ext_power))
+  for as in combinations(gens(I0), k+i-1)
+    push!(new_gens, wedge([repres(a) for a in as]; parent=amb_ext_power))
   end
   Ip, _ = sub(amb_ext_power, new_gens)
   fac.ext_powers[i] = Ip

--- a/experimental/DoubleAndHyperComplexes/src/Objects/induced_ENC.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/induced_ENC.jl
@@ -22,7 +22,7 @@ function (fac::InducedENCChainFactory)(self::AbsHyperComplex, ind::Tuple)
   k + i - 1 > ngens(I0) && return sub(enc[i], elem_type(enc[i])[])[1]
   amb_ext_power = _exterior_power(enc, i)
   new_gens = elem_type(amb_ext_power)[]
-  for a in combinations(ngens(IO), k+i-1)
+  for a in combinations(ngens(I0), k+i-1)
     push!(new_gens, wedge([repres(gen(I0, i)) for i in a]; parent=amb_ext_power))
   end
   Ip, _ = sub(amb_ext_power, new_gens)

--- a/experimental/DoubleAndHyperComplexes/src/Objects/new_koszul_complexes.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/new_koszul_complexes.jl
@@ -2,14 +2,14 @@
 # Homogeneous Koszul complexes
 #
 # Given a graded ring R and homogeneous elements a₁,…,aₙ ∈ R of degrees
-# dᵢ = deg aᵢ one wishes to build the Koszul complex 
+# dᵢ = deg aᵢ one wishes to build the Koszul complex
 #
-# R¹ ← R[-d₁] ⊕ … ⊕ R[-dᵢ] ← R[-d₁-d₂] ⊕ R[-d₁-d₃] ⊕ … 
+# R¹ ← R[-d₁] ⊕ … ⊕ R[-dᵢ] ← R[-d₁-d₂] ⊕ R[-d₁-d₃] ⊕ …
 #
-# which is homogeneous with all differentials of relative degree zero. 
-# 
-# The construction via exterior multiplication with ∑ᵢaᵢ⋅eᵢ ∈ Rⁿ does 
-# not provide this. So we introduce an extra method here. 
+# which is homogeneous with all differentials of relative degree zero.
+#
+# The construction via exterior multiplication with ∑ᵢaᵢ⋅eᵢ ∈ Rⁿ does
+# not provide this. So we introduce an extra method here.
 ########################################################################
 
 ### Production of the chains
@@ -29,7 +29,7 @@ function (fac::HomogKoszulComplexChainFactory)(self::AbsHyperComplex, I::Tuple)
   G = grading_group(fac.S)
   is_zero(i) && return graded_free_module(fac.S, [zero(G)])
   n = length(fac.seq)
-  degs = elem_type(G)[-sum(fac.degs[indices(omi)]; init=zero(G)) for omi in OrderedMultiIndexSet(i, n)]
+  degs = elem_type(G)[-sum(fac.degs[data(omi)]; init=zero(G)) for omi in combinations(n, i)]
   result = graded_free_module(fac.S, degs)
 end
 
@@ -37,7 +37,7 @@ function can_compute(fac::HomogKoszulComplexChainFactory, self::AbsHyperComplex,
   return 0 <= first(i) <= length(fac.seq)
 end
 
-### Production of the morphisms 
+### Production of the morphisms
 struct HomogKoszulComplexMapFactory{MorphismType} <: HyperComplexMapFactory{MorphismType}
   function HomogKoszulComplexMapFactory(S::Ring)
     return new{FreeModuleHom}()
@@ -51,13 +51,13 @@ function (fac::HomogKoszulComplexMapFactory)(self::AbsHyperComplex, p::Int, I::T
   dom = self[I]
   cod = self[i+1]
   img_gens = elem_type(cod)[]
-  inds = [OrderedMultiIndex([k], n) for k in 1:n]
-  for omi in OrderedMultiIndexSet(i, n)
+  inds = [Combination([k]) for k in 1:n]
+  for omi in combinations(n, i)
     img = zero(cod)
     for (m, v) in zip(inds, cfac.seq)
       sign, mult_ind = _wedge(omi, m)
       is_zero(sign) && continue
-      res_ind = linear_index(mult_ind)
+      res_ind = linear_index(mult_ind, n)
       img += sign*v*cod[res_ind]
     end
     push!(img_gens, img)
@@ -71,7 +71,7 @@ function can_compute(fac::HomogKoszulComplexMapFactory, self::AbsHyperComplex, p
 end
 
 ### The concrete struct
-@attributes mutable struct HomogKoszulComplex{ChainType, MorphismType} <: AbsHyperComplex{ChainType, MorphismType} 
+@attributes mutable struct HomogKoszulComplex{ChainType, MorphismType} <: AbsHyperComplex{ChainType, MorphismType}
   internal_complex::HyperComplex{ChainType, MorphismType}
 
   function HomogKoszulComplex(R::Ring, seq::Vector{<:RingElem}; check::Bool=true)
@@ -92,4 +92,3 @@ end
 
 ### Implementing the AbsHyperComplex interface via `underlying_complex`
 underlying_complex(c::HomogKoszulComplex) = c.internal_complex
-

--- a/experimental/DoubleAndHyperComplexes/src/Objects/new_koszul_complexes.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/new_koszul_complexes.jl
@@ -57,7 +57,7 @@ function (fac::HomogKoszulComplexMapFactory)(self::AbsHyperComplex, p::Int, I::T
     for (m, v) in zip(inds, cfac.seq)
       sign, mult_ind = _wedge(omi, m)
       is_zero(sign) && continue
-      res_ind = linear_index(mult_ind, n)
+      res_ind = Oscar.linear_index(mult_ind, n)
       img += sign*v*cod[res_ind]
     end
     push!(img_gens, img)

--- a/experimental/Schemes/src/Resolution_structure.jl
+++ b/experimental/Schemes/src/Resolution_structure.jl
@@ -872,10 +872,10 @@ function find_refinement_with_local_system_of_params(W::AbsAffineScheme; check::
   for (i, j) in non_zero_indices
     h_ij = M_ext[i, j]
     U_ij = PrincipalOpenSubset(W, OO(W)(h_ij))
-    I = ordered_multi_index(i, codim, n)
-    J = ordered_multi_index(j, codim, r)
+    I = combination(n, codim, i)
+    J = combination(r, codim, j)
     push!(ref_patches, U_ij)
-    minor_dict[U_ij] = (indices(I), indices(J), M_ext[i, j])
+    minor_dict[U_ij] = (data(I), data(J), M_ext[i, j])
   end
   res_cov = Covering(ref_patches)
   inherit_gluings!(res_cov, Covering(W))

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -18,7 +18,7 @@ julia> collect(C)
  [2, 3, 4]
 ```
 """
-combinations(n::Int, k::Int) = Combinations(1:n, k)
+combinations(n::Int, k::Int) = Combinations(range(; length=n), k)
 
 @doc raw"""
     combinations(v::AbstractVector, k::Int)
@@ -73,6 +73,10 @@ Base.length(C::Combinations) = binomial(C.n, C.k)
 
 Base.eltype(::Type{Combinations{T}}) where {T} = Combination{eltype(T)}
 
+function Base.show(io::IO, C::Combinations{Base.OneTo})
+  print(io, "Iterator over the ", C.k, "-combinations of ", 1:C.n)
+end
+
 function Base.show(io::IO, C::Combinations)
   print(io, "Iterator over the ", C.k, "-combinations of ", C.v)
 end
@@ -112,6 +116,10 @@ end
 
 function Base.copy(C::Combination)
   return Combination(copy(data(C)))
+end
+
+function Base.getindex(C::Combinations{Base.OneTo}, i::IntegerUnion)
+  return combination(C.n, C.k, i)
 end
 
 function Base.getindex(C::Combinations, i::IntegerUnion)

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -203,24 +203,11 @@ end
 #
 ################################################################################
 
-# _mult is currently identical to _wedge aside from return type
-# (Vector{T} vs Combination{T})
-# so leaving unimplemented.
-# function _mult(a::Combination{T}, b::Combination{T}) where {T}
-#   # @assert bound(a) == bound(b) "combinations must have the same bounds"
-#
-#   # in case of a double index return zero
-#   any(in(b), a) && return 0, data(a)
-#
-#   result, sign = merge_sorted_with_sign(data(a),data(b))
-#
-#   return sign, result_indices
-# end
-
-
 # merge sort vcat(a,b) and keep track of the sign of permutation.
 # requires that a and b are both sorted, and contain no common elements.
 function merge_sorted_with_sign(a::Vector{T}, b::Vector{T}) where T<:IntegerUnion
+  is_disjoint(a,b) || return 0, nothing
+
   result = zeros(T, length(a)+length(b))
   p = length(a)
   q = length(b)
@@ -247,16 +234,15 @@ end
 
 
 # For two combinations a = [i₁, i₂, …, iₚ] and b = [j₁, j₂, …, jᵣ]
-# the result is a pair `(sign, c)` with a a new combination,
+# the result is a pair `(sign, c)` with `c` a new combination,
 # and `sign` either 0 in the case that
 # iₖ = jₗ for some k and l, or ±1 depending on the number of transpositions
 # needed to put [i₁, …, iₚ, j₁, …, jᵣ] into a strictly increasing order
-# to produce `c`.
+# to produce `c`. If the combinations are not disjoint,
+# then we return `nothing` for `c`.
 function _wedge(a::Combination{T}, b::Combination{T}) where {T}
-  # if combinations are not disjoint, return 0
-  isdisjoint(a, b) || return 0, a
-
   c, sign = merge_sorted_with_sign(data(a), data(b))
+  sign == 0 && return sign, c
   return sign, Combination(c)
 end
 

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -121,13 +121,28 @@ end
 #
 ################################################################################
 
-# For a combination C containing k elements from 1:n,
-# return the index i so that C occurs as the ith element in the
-# iteration over all such combinations (which are lexicographically ordered).
-# NOTE We use the method described in J. Liebehenschel - Ranking and unranking of lexicographically ordered words: an average-case analysis. Journal of Automata, Languages, and Combinatorics (1997).
-# NOTE we have added an extra argument, since this info is not stored with
-# a Combination as it is with an OrderedMultiIndex
+
+@doc raw"""
+    linear_index(C::Combination, n::IntegerUnion)
+
+For a combination C containing k elements from 1:n,
+return the index i so that C occurs as the ith element in the
+iteration over all such combinations (in lexicographic order).
+
+The algorithm is as described in [Lie97; Section 3.3](@cite).
+
+# Examples
+
+```jldoctest
+julia> C = Combination([1, 3, 5, 7])
+[1, 3, 5, 7]
+
+julia> linear_index(C, 7)
+15
+```
+"""
 function linear_index(C::Combination, n::IntegerUnion)
+  @req C[end] <= n "Combination must be bounded by n"
   k = length(C)
   iszero(k) && return 1
   isone(k) && return Int(C[1])
@@ -142,9 +157,23 @@ function linear_index(C::Combination, n::IntegerUnion)
   return r
 end
 
-# Return the rth combination in the iteration over combinations(n,k)
-# NOTE We use the method described in J. Liebehenschel - Ranking and unranking of lexicographically ordered words: an average-case analysis. Journal of Automata, Languages, and Combinatorics (1997).
-# NOTE arguments are reordered to match combinatorial conventions
+@doc raw"""
+    combination(n::Int, k::Int, r::Int)
+
+Return the rth combination in the iteration over combinations(n,k).
+
+The algorithm is as described in [Lie97; Section 3.3](@cite).
+
+# Examples
+
+```jldoctest
+julia> C1 = collect(combinations(15, 3))[13]
+[1, 2, 15]
+
+julia> C1 = combination(15, 3, 13)
+[1, 2, 15]
+```
+"""
 function combination(n::Int, k::Int, r::Int)
   @req 1 <= r <= binomial(n, k) "index out of range"
   iszero(k) && return Combination(Int[])

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -146,7 +146,7 @@ end
 # NOTE We use the method described in J. Liebehenschel - Ranking and unranking of lexicographically ordered words: an average-case analysis. Journal of Automata, Languages, and Combinatorics (1997).
 # NOTE arguments are reordered to match combinatorial conventions
 function combination(n::Int, k::Int, r::Int)
-  (r < 1 || r > binomial(n, k)) && error("index out of range")
+  @req 1 <= r <= binomial(n, k) "index out of range"
   iszero(k) && return Combination(Int[])
   isone(k) && return Combination([r])
   n == k && return Combination(collect(1:n))

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -115,11 +115,11 @@ function Base.copy(C::Combination)
 end
 
 function Base.getindex(C::Combinations{Base.OneTo}, i::IntegerUnion)
-  return combination(C.n, C.k, i)
+  return Oscar.combination(C.n, C.k, i)
 end
 
 function Base.getindex(C::Combinations, i::IntegerUnion)
-  c = combination(C.n, C.k, i)
+  c = Oscar.combination(C.n, C.k, i)
   return C.v[data(c)]
 end
 
@@ -178,7 +178,7 @@ The algorithm is as described in [Lie97; Section 3.3](@cite).
 julia> C1 = collect(combinations(15, 3))[13]
 [1, 2, 15]
 
-julia> C1 = combination(15, 3, 13)
+julia> C1 = Oscar.combination(15, 3, 13)
 [1, 2, 15]
 ```
 """

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -150,6 +150,6 @@ function combination(n::Int, k::Int, i::Int)
     return Combination(pushfirst!(data(prev_res).+k2, k2))
   else
     prev_res = combination(n - c1, k-1, i - bin + binomial(n - c1 + 1, k))
-    return Combination(pushfirst!(data(prev_res).+i1, i1))
+    return Combination(pushfirst!(data(prev_res).+c1, c1))
   end
 end

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -125,8 +125,8 @@ end
 @doc raw"""
     linear_index(C::Combination, n::IntegerUnion)
 
-For a combination C containing k elements from 1:n,
-return the index i so that C occurs as the ith element in the
+For a combination `C` containing `k` elements from `1:n`,
+return the index `i` so that `C` occurs as the `i`th element in the
 iteration over all such combinations (in lexicographic order).
 
 The algorithm is as described in [Lie97; Section 3.3](@cite).

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -160,7 +160,7 @@ end
 @doc raw"""
     combination(n::Int, k::Int, r::Int)
 
-Return the rth combination in the iteration over combinations(n,k).
+Return the `r`th combination in the iteration over `combinations(n,k)`.
 
 The algorithm is as described in [Lie97; Section 3.3](@cite).
 

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -73,7 +73,7 @@ Base.length(C::Combinations) = binomial(C.n, C.k)
 
 Base.eltype(::Type{Combinations{T}}) where {T} = Combination{eltype(T)}
 
-function Base.show(io::IO, C::Combinations{Base.OneTo})
+function Base.show(io::IO, C::Combinations{<:Base.OneTo})
   print(io, "Iterator over the ", C.k, "-combinations of ", 1:C.n)
 end
 

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -110,10 +110,6 @@ function Base.getindex(C::Combination, i::IntegerUnion)
   return getindex(data(C), Int(i))
 end
 
-function Base.setindex!(C::Combination, x::IntegerUnion, i::IntegerUnion)
-  return setindex!(data(C), x, i)
-end
-
 function Base.copy(C::Combination)
   return Combination(copy(data(C)))
 end

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -206,7 +206,7 @@ end
 # merge sort vcat(a,b) and keep track of the sign of permutation.
 # requires that a and b are both sorted, and contain no common elements.
 function merge_sorted_with_sign(a::Vector{T}, b::Vector{T}) where T<:IntegerUnion
-  is_disjoint(a,b) || return 0, nothing
+  isdisjoint(a,b) || return 0, nothing
 
   result = zeros(T, length(a)+length(b))
   p = length(a)

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -156,7 +156,7 @@ function combination(n::Int, k::Int, r::Int)
   j = 1
   for i in 1:k
     b = binomial(n - j, k - i + 1)
-    while b >= r
+    while b > r
       j += 1
       b = binomial(n - j, k - i + 1)
     end

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -114,6 +114,10 @@ function Base.copy(C::Combination)
   return Combination(copy(data(C)))
 end
 
+function Base.getindex(C::Combinations, i::IntegerUnion)
+  c = combination(C.n, C.k, i)
+  return C.v[data(c)]
+end
 
 ################################################################################
 #
@@ -206,7 +210,7 @@ end
 # merge sort vcat(a,b) and keep track of the sign of permutation.
 # requires that a and b are both sorted, and contain no common elements.
 function merge_sorted_with_sign(a::Vector{T}, b::Vector{T}) where T<:IntegerUnion
-  isdisjoint(a,b) || return nothing, sign
+  isdisjoint(a,b) || return nothing, 0
 
   result = zeros(T, length(a)+length(b))
   p = length(a)

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -18,7 +18,7 @@ julia> collect(C)
  [2, 3, 4]
 ```
 """
-combinations(n::Int, k::Int) = Combinations(range(; length=n), k)
+combinations(n::Int, k::Int) = Combinations(Base.OneTo(n), k)
 
 @doc raw"""
     combinations(v::AbstractVector, k::Int)

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -206,7 +206,7 @@ end
 # merge sort vcat(a,b) and keep track of the sign of permutation.
 # requires that a and b are both sorted, and contain no common elements.
 function merge_sorted_with_sign(a::Vector{T}, b::Vector{T}) where T<:IntegerUnion
-  isdisjoint(a,b) || return 0, nothing
+  isdisjoint(a,b) || return nothing, sign
 
   result = zeros(T, length(a)+length(b))
   p = length(a)

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -225,7 +225,7 @@ end
 # to produce `c`.
 function _wedge(a::Combination{T}, b::Combination{T}) where {T}
   # if combinations are not disjoint, return 0
-  any(in(b), a) && return 0, a
+  isdisjoint(a, b) || return 0, a
 
   c, sign = merge_sorted_with_sign(data(a), data(b))
   return sign, Combination(c)

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -234,7 +234,7 @@ end
 
 # # This could be optimized, but don't think it is currently used anywhere so leaving it for now.
 function _wedge(a::Vector{T}) where {T <: Combination}
-  isempty(a) && error("list must not be empty")
+  @req !isempty(a) "list must not be empty"
   isone(length(a)) && return 1, first(a)
   k = div(length(a), 2)
   b = a[1:k]

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -145,7 +145,7 @@ The algorithm is as described in [Lie97; Section 3.3](@cite).
 julia> C = Combination([1, 3, 5, 7])
 [1, 3, 5, 7]
 
-julia> linear_index(C, 7)
+julia> Oscar.linear_index(C, 7)
 15
 ```
 """

--- a/src/Modules/ExteriorPowers/FreeModules.jl
+++ b/src/Modules/ExteriorPowers/FreeModules.jl
@@ -48,7 +48,6 @@ function exterior_power(F::FreeMod, p::Int; cached::Bool=true)
     k = findfirst(==(u), gens(result))
     @req !isnothing(k) "element must be a generator of the module"
     ind = combination(n, p, k)
-    e = gens(F)
     return Tuple(e[i] for i in ind)
   end
 

--- a/src/Modules/ExteriorPowers/FreeModules.jl
+++ b/src/Modules/ExteriorPowers/FreeModules.jl
@@ -24,8 +24,8 @@ function exterior_power(F::FreeMod, p::Int; cached::Bool=true)
   result = if is_graded(F)
     G = grading_group(F)
     weights = elem_type(G)[]
-    for ind in combinations(n, p)
-      push!(weights, sum(_degree_fast(F[i]) for i in ind; init=zero(G)))
+    for fs in combinations(F, p)
+      push!(weights, sum(_degree_fast(f) for f in fs; init=zero(G)))
     end
     grade(result_, weights)
   else

--- a/src/Modules/ExteriorPowers/FreeModules.jl
+++ b/src/Modules/ExteriorPowers/FreeModules.jl
@@ -176,7 +176,7 @@ function koszul_duals(v::Vector{T}; cached::Bool=true) where {T<:FreeModElem}
   any(isnothing, k) && error("elements must be generators of the module")
   ind = [combination(n, p, r) for r in k]
   comp = [Combination([i for i in 1:n if !(i in I)]) for I in ind]
-  lin_ind = linear_index.(comp, Ref(n))
+  lin_ind = Oscar.linear_index.(comp, Ref(n))
   F_dual = koszul_dual(F, cached=cached)
   results = [F_dual[j] for j in lin_ind]
   for r in 1:length(v)

--- a/src/Modules/ExteriorPowers/FreeModules.jl
+++ b/src/Modules/ExteriorPowers/FreeModules.jl
@@ -24,7 +24,7 @@ function exterior_power(F::FreeMod, p::Int; cached::Bool=true)
   result = if is_graded(F)
     G = grading_group(F)
     weights = elem_type(G)[]
-    for fs in combinations(F, p)
+    for fs in combinations(gens(F), p)
       push!(weights, sum(_degree_fast(f) for f in fs; init=zero(G)))
     end
     grade(result_, weights)

--- a/src/Modules/ExteriorPowers/FreeModules.jl
+++ b/src/Modules/ExteriorPowers/FreeModules.jl
@@ -2,9 +2,9 @@
 # Exterior powers of free modules
 #
 # For F = Rⁿ we provide methods to create ⋀ ᵖF for arbitrary 0 ≤ p ≤ n.
-# These modules are cached in F and know that they are an exterior 
-# power of F. This allows us to implement the wedge product of their 
-# elements. 
+# These modules are cached in F and know that they are an exterior
+# power of F. This allows us to implement the wedge product of their
+# elements.
 ########################################################################
 
 # User facing constructor for ⋀ ᵖ F.
@@ -20,12 +20,12 @@ function exterior_power(F::FreeMod, p::Int; cached::Bool=true)
   n = rank(F)
   result_ = FreeMod(R, binomial(n, p))
 
-  # In case F was graded, we have to take an extra detour. 
+  # In case F was graded, we have to take an extra detour.
   result = if is_graded(F)
     G = grading_group(F)
     weights = elem_type(G)[]
-    for ind in OrderedMultiIndexSet(p, n)
-      push!(weights, sum(_degree_fast(F[i]) for i in indices(ind); init=zero(G)))
+    for ind in combinations(n, p)
+      push!(weights, sum(_degree_fast(F[i]) for i in ind; init=zero(G)))
     end
     grade(result_, weights)
   else
@@ -47,9 +47,9 @@ function exterior_power(F::FreeMod, p::Int; cached::Bool=true)
     @req parent(u) === result "element does not belong to the correct module"
     k = findfirst(==(u), gens(result))
     @req !isnothing(k) "element must be a generator of the module"
-    ind = ordered_multi_index(k, p, n)
+    ind = combination(n, p, k)
     e = gens(F)
-    return Tuple(e[i] for i in indices(ind))
+    return Tuple(e[i] for i in ind)
   end
 
   mult_map = MapFromFunc(Hecke.TupleParent(Tuple([zero(F) for f in 1:p])), result, my_mult, my_decomp)
@@ -70,7 +70,7 @@ function exterior_power(F::FreeMod, p::Int; cached::Bool=true)
   if iszero(p)
     new_symb = [Symbol("1")]
   else
-    for ind in OrderedMultiIndexSet(p, n)
+    for ind in combinations(n, p)
       symb_str = orig_symb[ind[1]]
       for i in 2:p
         symb_str = symb_str * (is_unicode_allowed() ? "∧" : "^") * orig_symb[ind[i]]
@@ -175,20 +175,18 @@ function koszul_duals(v::Vector{T}; cached::Bool=true) where {T<:FreeModElem}
   success || error("element must be an exterior product")
   k = [findfirst(==(u), gens(F)) for u in v]
   any(isnothing, k) && error("elements must be generators of the module")
-  ind = [ordered_multi_index(r, p, n) for r in k]
-  comp = [ordered_multi_index([i for i in 1:n if !(i in indices(I))], n) for I in ind]
-  lin_ind = linear_index.(comp)
+  ind = [combination(n, p, r) for r in k]
+  comp = [Combination([i for i in 1:n if !(i in I)]) for I in ind]
+  lin_ind = linear_index.(comp, Ref(n))
   F_dual = koszul_dual(F, cached=cached)
   results = [F_dual[j] for j in lin_ind]
   for r in 1:length(v)
     sign, _ = _wedge(ind[r], comp[r])
     isone(sign) || (results[r] = -results[r])
   end
-  return results 
+  return results
 end
 
 function koszul_dual(v::FreeModElem; cached::Bool=true)
   return first(koszul_duals([v], cached=cached))
 end
-
-

--- a/src/Modules/ExteriorPowers/FreeModules.jl
+++ b/src/Modules/ExteriorPowers/FreeModules.jl
@@ -48,7 +48,7 @@ function exterior_power(F::FreeMod, p::Int; cached::Bool=true)
     k = findfirst(==(u), gens(result))
     @req !isnothing(k) "element must be a generator of the module"
     ind = combination(n, p, k)
-    return Tuple(e[i] for i in ind)
+    return Tuple(gen(F, i) for i in ind)
   end
 
   mult_map = MapFromFunc(Hecke.TupleParent(Tuple([zero(F) for f in 1:p])), result, my_mult, my_decomp)

--- a/src/Modules/ExteriorPowers/Generic.jl
+++ b/src/Modules/ExteriorPowers/Generic.jl
@@ -51,17 +51,17 @@ function wedge_generator_decompose_function(M::ModuleFP)
   return get_attribute(M, :wedge_generator_decompose_function)::Map
 end
 
-# Given two exterior powers F = ⋀ ᵖM and G = ⋀ ʳM and an element 
-# v ∈ ⋀ ʳ⁻ᵖ M this constructs the module homomorphism associated 
-# to 
+# Given two exterior powers F = ⋀ ᵖM and G = ⋀ ʳM and an element
+# v ∈ ⋀ ʳ⁻ᵖ M this constructs the module homomorphism associated
+# to
 #
 #   v ∧ - : F → G,  u ↦ v ∧ u.
 #
-# We also allow v ∈ M considered as ⋀ ¹M and the same holds in 
+# We also allow v ∈ M considered as ⋀ ¹M and the same holds in
 # the cases p = 1 and r = 1.
 function wedge_multiplication_map(F::ModuleFP, G::ModuleFP, v::ModuleFPElem)
   success, orig_mod, p = _is_exterior_power(F)
-  if !success 
+  if !success
     Fwedge1, _ = exterior_power(F, 1)
     id = hom(F, Fwedge1, gens(Fwedge1); check=false)
     tmp = wedge_multiplication_map(Fwedge1, G, v)
@@ -90,17 +90,17 @@ function wedge_multiplication_map(F::ModuleFP, G::ModuleFP, v::ModuleFPElem)
   success || error("element is not an exterior product")
   orig_mod_2 === orig_mod || error("element is not an exterior product for the correct module")
   p + r == q || error("powers are incompatible")
-  
+
   # map the generators
   img_gens = [wedge(v, e, parent=G) for e in gens(F)]
   return hom(F, G, img_gens; check=false)
 end
 
 # The wedge product of two or more elements.
-function wedge(u::ModuleFPElem, v::ModuleFPElem; 
+function wedge(u::ModuleFPElem, v::ModuleFPElem;
     parent::ModuleFP=begin
       success, F, p = _is_exterior_power(Oscar.parent(u))
-      if !success 
+      if !success
         F = Oscar.parent(u)
         p = 1
       end
@@ -111,14 +111,14 @@ function wedge(u::ModuleFPElem, v::ModuleFPElem;
   )
   success1, F1, p = _is_exterior_power(Oscar.parent(u))
   if !success1
-    F = Oscar.parent(u) 
+    F = Oscar.parent(u)
     Fwedge1, _ = exterior_power(F1, 1)
     return wedge(Fwedge1(coordinates(u)), v, parent=parent)
   end
 
   success2, F2, q = _is_exterior_power(Oscar.parent(v))
   if !success2
-    F = Oscar.parent(v) 
+    F = Oscar.parent(v)
     Fwedge1, _ = exterior_power(F1, 1)
     return wedge(u, Fwedge1(coordinates(v)), parent=parent)
   end
@@ -128,12 +128,12 @@ function wedge(u::ModuleFPElem, v::ModuleFPElem;
 
   result = zero(parent)
   for (i, a) in coordinates(u)
-    ind_i = ordered_multi_index(i, p, n)
+    ind_i = combination(n, p, i)
     for (j, b) in coordinates(v)
-      ind_j = ordered_multi_index(j, q, n)
+      ind_j = combination(n, q, j)
       sign, k = _wedge(ind_i, ind_j)
       iszero(sign) && continue
-      result = result + sign * a * b * parent[linear_index(k)]
+      result = result + sign * a * b * parent[linear_index(k, n)]
     end
   end
   return result
@@ -146,7 +146,7 @@ function wedge(u::Vector{T};
       F = Oscar.parent(first(u)) # initialize variable
       for v in u
         success, F, p = _is_exterior_power(Oscar.parent(v))
-        if !success 
+        if !success
           F = Oscar.parent(v)
           p = 1
         end
@@ -178,7 +178,7 @@ function induced_map_on_exterior_power(phi::FreeModuleHom{<:FreeMod, <:FreeMod, 
   is_zero(p) && return hom(domain, codomain, gens(codomain); check=false) # Isomorphism of R^1
 
   imgs = phi.(gens(F))
-  img_gens = [wedge(imgs[indices(ind)], parent=codomain) for ind in OrderedMultiIndexSet(p, m)]
+  img_gens = [wedge(imgs[data(ind)], parent=codomain) for ind in combinations(m, p)]
   return hom(domain, codomain, img_gens; check=false)
 end
 
@@ -193,5 +193,3 @@ function hom(M::FreeMod, N::FreeMod, phi::FreeModuleHom)
   @req p == q "exponents must agree"
   return induced_map_on_exterior_power(phi, p; domain=M, codomain=N)
 end
-
-

--- a/src/Modules/ExteriorPowers/Generic.jl
+++ b/src/Modules/ExteriorPowers/Generic.jl
@@ -133,7 +133,7 @@ function wedge(u::ModuleFPElem, v::ModuleFPElem;
       ind_j = combination(n, q, j)
       sign, k = _wedge(ind_i, ind_j)
       iszero(sign) && continue
-      result = result + sign * a * b * parent[linear_index(k, n)]
+      result = result + sign * a * b * parent[Oscar.linear_index(k, n)]
     end
   end
   return result

--- a/src/Modules/ExteriorPowers/Generic.jl
+++ b/src/Modules/ExteriorPowers/Generic.jl
@@ -178,7 +178,7 @@ function induced_map_on_exterior_power(phi::FreeModuleHom{<:FreeMod, <:FreeMod, 
   is_zero(p) && return hom(domain, codomain, gens(codomain); check=false) # Isomorphism of R^1
 
   imgs = phi.(gens(F))
-  img_gens = [wedge(imgs[data(ind)], parent=codomain) for ind in combinations(m, p)]
+  img_gens = [wedge(data(c), parent=codomain) for c in combinations(imgs, p)]
   return hom(domain, codomain, img_gens; check=false)
 end
 

--- a/src/Modules/ExteriorPowers/SubQuo.jl
+++ b/src/Modules/ExteriorPowers/SubQuo.jl
@@ -33,7 +33,6 @@ function exterior_power(M::SubquoModule, p::Int; cached::Bool=true)
     k = findfirst(==(u), gens(result))
     @req !isnothing(k) "element must be a generator of the module"
     ind = combination(n, p, k)
-    e = gens(M)
     return Tuple(gen(M, i) for i in ind)
   end
 

--- a/src/Modules/ExteriorPowers/SubQuo.jl
+++ b/src/Modules/ExteriorPowers/SubQuo.jl
@@ -32,9 +32,9 @@ function exterior_power(M::SubquoModule, p::Int; cached::Bool=true)
     @req parent(u) === result "element does not belong to the correct module"
     k = findfirst(==(u), gens(result))
     @req !isnothing(k) "element must be a generator of the module"
-    ind = ordered_multi_index(k, p, n)
+    ind = combination(n, p, k)
     e = gens(M)
-    return Tuple(e[i] for i in indices(ind))
+    return Tuple(e[i] for i in ind)
   end
 
   mult_map = MapFromFunc(Hecke.TupleParent(Tuple([zero(M) for f in 1:p])), result, my_mult, my_decomp)
@@ -53,7 +53,7 @@ function exterior_power(M::SubquoModule, p::Int; cached::Bool=true)
   if iszero(p)
     new_symb = [Symbol("1")]
   else
-    for ind in OrderedMultiIndexSet(p, n)
+    for ind in combinations(n, p)
       symb_str = orig_symb[ind[1]]
       for i in 2:p
         symb_str = symb_str * (is_unicode_allowed() ? "∧" : "^") * orig_symb[ind[i]]
@@ -78,4 +78,3 @@ function _exterior_power(phi::FreeModuleHom, p::Int)
   # TODO: the `cokernel` command does not have consistent output over all types of rings.
   return (base_ring(codomain(phi)) isa Union{MPolyLocRing, MPolyQuoLocRing} ? cokernel(psi)[1] : cokernel(psi)), mult_map
 end
-

--- a/src/Modules/ExteriorPowers/SubQuo.jl
+++ b/src/Modules/ExteriorPowers/SubQuo.jl
@@ -34,7 +34,7 @@ function exterior_power(M::SubquoModule, p::Int; cached::Bool=true)
     @req !isnothing(k) "element must be a generator of the module"
     ind = combination(n, p, k)
     e = gens(M)
-    return Tuple(e[i] for i in ind)
+    return Tuple(gen(M, i) for i in ind)
   end
 
   mult_map = MapFromFunc(Hecke.TupleParent(Tuple([zero(M) for f in 1:p])), result, my_mult, my_decomp)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -404,7 +404,6 @@ export cokernel
 export collector
 export coloops
 export column
-export combination
 export combinations
 export combinatorial_symmetries
 export comm
@@ -1080,7 +1079,6 @@ export lifted_numerator
 export lineality_dim
 export lineality_space
 export linear_characters
-export linear_index
 export linear_equation_matrix
 export linear_halfspace
 export linear_hyperplane

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -404,6 +404,7 @@ export cokernel
 export collector
 export coloops
 export column
+export combination
 export combinations
 export combinatorial_symmetries
 export comm
@@ -1079,6 +1080,7 @@ export lifted_numerator
 export lineality_dim
 export lineality_space
 export linear_characters
+export linear_index
 export linear_equation_matrix
 export linear_halfspace
 export linear_hyperplane
@@ -1273,7 +1275,7 @@ export number_of_standard_tableaux
 export number_of_transitive_groups, has_number_of_transitive_groups
 export number_of_weak_compositions
 export numerator
-export numerical_lattice 
+export numerical_lattice
 export numerical_lattice_of_K3_cover
 export objective_function
 export omega_group

--- a/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -47,10 +47,11 @@
     n = 5
     k = 3
 
-    c = collect(combinations(n,k))
+    C = combinations(n,k)
+    c = collect(C)
     @test length(c) == binomial(n,k)
     @test all(x->c[Oscar.linear_index(x, n)] == x, combinations(n,k))
-    @test all(i->Oscar.combination(n,k,i) == c[i], 1:length(c))
+    @test all(i->C[i] == c[i], 1:length(c))
 
   end
 

--- a/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -61,16 +61,4 @@
 
   end
 
-  # @testset "wedge products" begin
-  #   n = 5
-  #   k = 3
-  #
-  #   I = Combination([1, 2, 5])
-  #   I1 = Combination([1])
-  #   I2 = Combination([2])
-  #   I5 = Combination([5])
-  #   J = Combination([3, 4])
-  #   K = Combination([2, 4])
-  # end
-
 end

--- a/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -50,7 +50,7 @@
     c = collect(combinations(n,k))
     @test length(c) == binomial(n,k)
     @test all(x->c[Oscar.linear_index(x, n)] == x, combinations(n,k))
-    @test all(i->Oscar.combinations(n,k,i) == c[i], 1:length(c))
+    @test all(i->Oscar.combination(n,k,i) == c[i], 1:length(c))
 
   end
 

--- a/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -54,4 +54,31 @@
 
   end
 
+  @testset "wedge products" begin
+    n = 5
+    k = 3
+
+    I = Combination([1, 2, 5])
+    I1 = Combination([1])
+    I2 = Combination([2])
+    I5 = Combination([5])
+    J = Combination([3, 4])
+    K = Combination([2, 4])
+
+    sign, ind = Oscar._wedge(I, K)
+    @test sign == 0
+    sign, ind = Oscar._wedge(I, J)
+    @test sign == 1
+    ind == Combination(collect(1:5))
+    sign, ind = Oscar._wedge(J, K)
+    @test sign == 0
+
+    sign, ind = Oscar._wedge([I2, I5, I1])
+    @test ind == I
+    @test sign == 1
+    sign, ind = Oscar._wedge([I2, I1, I5])
+    @test ind == I
+    @test sign == -1
+  end
+
 end

--- a/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -47,13 +47,6 @@
     n = 5
     k = 3
 
-    I = Combination([1, 2, 5])
-    I1 = Combination([1])
-    I2 = Combination([2])
-    I5 = Combination([5])
-    J = Combination([3, 4])
-    K = Combination([2, 4])
-
     c = collect(combinations(n,k))
     @test length(c) == binomial(n,k)
     @test all(x->c[Oscar.linear_index(x, n)] == x, combinations(n,k))

--- a/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -42,4 +42,35 @@
   @test allunique(v)
 
   @test collect(combinations(0, 0)) == [Int[]]
+
+  @testset "ranking/unranking" begin
+    n = 5
+    k = 3
+
+    I = Combination([1, 2, 5])
+    I1 = Combination([1])
+    I2 = Combination([2])
+    I5 = Combination([5])
+    J = Combination([3, 4])
+    K = Combination([2, 4])
+
+    c = collect(combinations(n,k))
+    @test length(c) == binomial(n,k)
+    @test all(x->c[Oscar.linear_index(x, n)] == x, combinations(n,k))
+    @test all(i->combinations(n,k,i) == c[i], 1:length(c))
+
+  end
+
+  # @testset "wedge products" begin
+  #   n = 5
+  #   k = 3
+  #
+  #   I = Combination([1, 2, 5])
+  #   I1 = Combination([1])
+  #   I2 = Combination([2])
+  #   I5 = Combination([5])
+  #   J = Combination([3, 4])
+  #   K = Combination([2, 4])
+  # end
+
 end

--- a/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -44,6 +44,10 @@
   @test collect(combinations(0, 0)) == [Int[]]
 
   @testset "ranking/unranking" begin
+    @test Oscar.combination(0,0,1) == Combination([])
+    @test Oscar.combination(3,3,1) == Combination(collect(1:3))
+    @test all(x->Oscar.combination(3,1,x) == Combination([x]), 1:3)
+
     n = 5
     k = 3
 
@@ -54,6 +58,10 @@
     @test all(i->C[i] == c[i], 1:length(c))
 
   end
+
+
+
+
 
   @testset "wedge products" begin
     n = 5

--- a/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -50,7 +50,7 @@
     c = collect(combinations(n,k))
     @test length(c) == binomial(n,k)
     @test all(x->c[Oscar.linear_index(x, n)] == x, combinations(n,k))
-    @test all(i->combinations(n,k,i) == c[i], 1:length(c))
+    @test all(i->Oscar.combinations(n,k,i) == c[i], 1:length(c))
 
   end
 

--- a/test/Modules/ExteriorPowers.jl
+++ b/test/Modules/ExteriorPowers.jl
@@ -78,18 +78,18 @@ end
 
   phi_2 = Oscar.induced_map_on_exterior_power(phi, 2)
 
-  for ind in Oscar.OrderedMultiIndexSet(2, 5)
-    imgs = [phi(R5[i]) for i in Oscar.indices(ind)]
+  for ind in combinations(5, 2)
+    imgs = [phi(R5[i]) for i in ind]
     img = Oscar.wedge(imgs)
-    @test img == phi_2(domain(phi_2)[Oscar.linear_index(ind)])
+    @test img == phi_2(domain(phi_2)[Oscar.linear_index(ind, 5)])
   end
 
   phi_3 = Oscar.induced_map_on_exterior_power(phi, 3)
 
   A3 = matrix(phi_3)
-  for ind1 in Oscar.OrderedMultiIndexSet(3, 5)
-    for ind2 in Oscar.OrderedMultiIndexSet(3, 4)
-      @test A3[Oscar.linear_index(ind1), Oscar.linear_index(ind2)] == det(A[Oscar.indices(ind1), Oscar.indices(ind2)])
+  for ind1 in combinations(5, 3)
+    for ind2 in combinations(4, 3)
+      @test A3[Oscar.linear_index(ind1, 5), Oscar.linear_index(ind2, 4)] == det(A[data(ind1), data(ind2)])
     end
   end
 


### PR DESCRIPTION
There are a few things that need to be adapted to make this replacement, namely we need

- [x]  a ranking method to get the index of a given `Combination` C in `Combinations(n,k)`
- [x] an unranking method to get the ith `Combination` C appearing in `Combinations(n,k)` directly
- [x] adapt `_wedge(a,b)` for a and b combinations that returns `sign, c` where, if a and b contain a common element, `sign = 0`, or else `sign` is +/-1 depending on the sign of the required to order `vcat(a,b)`, and `c` is the new `Combination` obtained through this
- [x] make a version of `_wedge` that takes a vector of `Combination` (I don't think this is used anywhere though?)
- [x] make some optimizations of the above methods

Once this is complete, we can replace the use of `OrderedMultiIndex` in
- [x]  `src/Modules/ExteriorPowers`, and 
- [x] `experimental/DoubleAndHyperComplexes`
- [x] `experimental/Schemes/src/Resolution_structure.jl`