### PR TITLE
Pass `Oscar.doctestfilters()` to all `doctest` invocations

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -264,7 +264,7 @@ jobs:
               include("docs/documenter_helpers.jl")
               using Oscar
               DocMeta.setdocmeta!(Oscar, :DocTestSetup, Oscar.doctestsetup(); recursive = true)
-              doctest(Oscar)'
+              doctest(Oscar; doctestfilters=Oscar.doctestfilters())'
       - name: "Process code coverage"
         if: matrix.julia-version == '1.10' && matrix.depwarn != 'depwarn=error'
         uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/NoExperimental.yml
+++ b/.github/workflows/NoExperimental.yml
@@ -98,7 +98,7 @@ jobs:
               include("docs/documenter_helpers.jl")
               using Oscar
               DocMeta.setdocmeta!(Oscar, :DocTestSetup, Oscar.doctestsetup(); recursive = true)
-              doctest(Oscar)'
+              doctest(Oscar; doctestfilters=Oscar.doctestfilters())'
       - name: Save Julia depot cache on cancel or failure
         id: julia-cache-save
         if: cancelled() || failure()

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -168,7 +168,7 @@ function doit(
     DocMeta.setdocmeta!(Oscar.Nemo, :DocTestSetup, :(using Nemo); recursive=true)
 
     if doctest !== false
-      Documenter.doctest(Oscar, fix = doctest === :fix)
+      Documenter.doctest(Oscar; fix = doctest === :fix, doctestfilters=Oscar.doctestfilters())
     end
 
     makedocs(;

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -22,7 +22,8 @@ end
 function doctestfilters()
   # this returns a list of doctest filters that should be passed to all doctest invocations
   return [
-    r"0-element SubObjectIterator{(.*)}" => s"\1[]", # due to JuliaLang/julia#57898, oscar-system/Oscar.jl#4872
+    r"0-element SubObjectIterator{RayVector{QQFieldElem}}|RayVector{QQFieldElem}\[\]" => "RayVector{QQFieldElem}[]", # due to JuliaLang/julia#57898, oscar-system/Oscar.jl#4872
+    r"0-element SubObjectIterator{PointVector{QQFieldElem}}|PointVector{QQFieldElem}\[\]" => "PointVector{QQFieldElem}[]", # due to JuliaLang/julia#57898, oscar-system/Oscar.jl#4872
   ]
 end
 

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -22,8 +22,11 @@ end
 function doctestfilters()
   # this returns a list of doctest filters that should be passed to all doctest invocations
   return [
-    r"0-element SubObjectIterator{RayVector{QQFieldElem}}|RayVector{QQFieldElem}\[\]" => "RayVector{QQFieldElem}[]", # due to JuliaLang/julia#57898, oscar-system/Oscar.jl#4872
-    r"0-element SubObjectIterator{PointVector{QQFieldElem}}|PointVector{QQFieldElem}\[\]" => "PointVector{QQFieldElem}[]", # due to JuliaLang/julia#57898, oscar-system/Oscar.jl#4872
+    # due to JuliaLang/julia#57898, oscar-system/Oscar.jl#4872:
+    r"^0-element SubObjectIterator{RayVector{QQFieldElem}}|^RayVector{QQFieldElem}\[\]"m => "RayVector{QQFieldElem}[]",
+    r"^0-element SubObjectIterator{PointVector{QQFieldElem}}|^PointVector{QQFieldElem}\[\]"m => "PointVector{QQFieldElem}[]",
+    r"^ 0-element SubObjectIterator{RayVector{QQFieldElem}}|^ \[\]"m => " []",
+    r"^ 0-element SubObjectIterator{PointVector{QQFieldElem}}|^ \[\]"m => " []",
   ]
 end
 

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -19,6 +19,13 @@ function doctestsetup()
   return :(using Oscar; Oscar.AbstractAlgebra.set_current_module(@__MODULE__))
 end
 
+function doctestfilters()
+  # this returns a list of doctest filters that should be passed to all doctest invocations
+  return [
+    r"0-element SubObjectIterator{(.*)}" => s"\1[]", # due to JuliaLang/julia#57898, oscar-system/Oscar.jl#4872
+  ]
+end
+
 # use tempdir by default to ensure a clean manifest (and avoid modifying the project)
 function doc_init(;path=mktempdir())
   global docsproject = path
@@ -46,7 +53,7 @@ function get_document(set_meta::Bool)
     error("you need to use Documenter.jl version 1.0.0 or later")
   end
 
-  doc = Documenter.Document(root = joinpath(oscardir, "docs"), doctest = :fix)
+  doc = Documenter.Document(root = joinpath(oscardir, "docs"); doctest = :fix, doctestfilters=Oscar.doctestfilters())
 
   if Documenter.DocMeta.getdocmeta(Oscar, :DocTestSetup) === nothing || set_meta
     Documenter.DocMeta.setdocmeta!(Oscar, :DocTestSetup, Oscar.doctestsetup(); recursive=true)

--- a/src/utils/tests.jl
+++ b/src/utils/tests.jl
@@ -151,6 +151,7 @@ macro _AuxDocTest(data::Expr)
           fix=$(fix),
           testset=$(testset),
           doctestfilters=[
+            Oscar.doctestfilters()...,
             r"(?:^.*Warning: .* is deprecated, use .* instead.\n.*\n.*Core.*\n)?"m,  # removes deprecation warnings
           ],
         )

--- a/test/book/test.jl
+++ b/test/book/test.jl
@@ -59,6 +59,24 @@ isdefined(Main, :FakeTerminals) || include(joinpath(pkgdir(REPL),"test","FakeTer
       result = replace(result, r"^(.* @ \w* ?)~?/[\w/.-]*(Nemo|Hecke|AbstractAlgebra|Polymake)(?:\.jl)?/[\w\d]+/.*\.jl:\d+"m => s"\1 \2")
       lafter = length(result)
     end
+
+    # apply doctestfilters. this is heavily inspired by https://github.com/JuliaDocs/Documenter.jl/blob/9b27810d5e1875124a92f7a735a36ecd52c9ea42/src/doctests.jl#L309
+    # but we don't require a filter to match on both in- and output to be applied
+    for rs in Oscar.doctestfilters()
+      # If a doctest filter is just a string or regex, everything that matches gets
+      # removed before comparing the inputs and outputs of a doctest. However, it can
+      # also be a regex => substitution pair in which case the match gets replaced by
+      # the substitution string.
+      r, s = if isa(rs, Pair{Regex, T} where {T <: AbstractString})
+        rs
+      elseif isa(rs, Regex) || isa(rs, AbstractString)
+        rs, ""
+      else
+        error("Invalid doctest filter:\n$rs :: $(typeof(rs))")
+      end
+      result = replace(result, r => s)
+    end
+
     return strip(result)
   end
 


### PR DESCRIPTION
This is an attempt to resolve https://github.com/oscar-system/Oscar.jl/issues/4872.
Furthermore, the booktests now also apply the doctestfilters to their sample and real output