### PR TITLE
Remove an useless doctestfilter

### DIFF
--- a/docs/src/NumberTheory/galois.md
+++ b/docs/src/NumberTheory/galois.md
@@ -83,9 +83,6 @@ galois_group(f::PolyRingElem{<:FieldElem})
 ```
 
 Over the rational function field, we can also compute the monodromy group:
-```@meta
-DocTestFilters = r"Galois context\(.*\]\)"
-```
 ```jldoctest galqt; setup = :(using Oscar, Random ; Random.seed!(1))
 julia> Qt, t = rational_function_field(QQ, "t");
 
@@ -113,9 +110,6 @@ over `C(t)` is only of degree `3`. Here the group collapses to a cyclic group
 of degree `3`, the algebraic closure of `Q` in the splitting field is the
 quadratic field returned last. It can be seen to be isomorphic to a cyclotomic field:
 
-```@meta
-DocTestFilters = nothing
-```
 ```jldoctest galqt
 julia> is_isomorphic(k, cyclotomic_field(3)[1])
 true


### PR DESCRIPTION
This filter did not match anything (for at least 2 years) due to the spurious `\]` in the regex.

The problem with randomness that this filter tried to work around seems to have been fixed by #1299 already by fixing a random seed.