### PR TITLE
Don't cache polynomial rings

### DIFF
--- a/src/AlgebraicGeometry/Schemes/CoveredProjectiveScheme/CoveredProjectiveScheme.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredProjectiveScheme/CoveredProjectiveScheme.jl
@@ -236,7 +236,7 @@ function blow_up_chart(W::AbsAffineScheme{<:Field, <:MPolyRing}, I::MPolyIdeal;
     R = base_ring(I)
     x = gens(R)
     kk = coefficient_ring(R)
-    A, x_ext = polynomial_ring(kk, vcat(symbols(R), [:t]))
+    A, x_ext = polynomial_ring(kk, vcat(symbols(R), [:t]), cached=false)
     t = last(x_ext)
     inc = hom(R, A, x_ext[1:end-1], check=false)
     phi = hom(OO(CIPW), A, vcat([inc(g[i])*t for i in 1:r+1], x_ext[1:end-1], ), check=false) # the homogeneous variables come first
@@ -291,7 +291,7 @@ function blow_up_chart(W::AbsAffineScheme{<:Field, <:RingType}, I::Ideal;
 
   # It follows the generic Proj construction
   R = OO(W)
-  T, (t,) = polynomial_ring(R, [:t])
+  T, (t,) = polynomial_ring(R, [:t], cached=false)
   S, s = graded_polynomial_ring(R, [Symbol(var_name, i-1) for i in 1:ngens(I)])
   phi = hom(S, T, [t*g for g in gens(I)], check=false)
   K = kernel(phi)
@@ -384,7 +384,7 @@ end
 #
 #  # some internal function
 #  function _add_variables(R::RingType, v::Vector{Symbol}) where {RingType<:MPolyRing}
-#    ext_R, _ = polynomial_ring(coefficient_ring(R), vcat(symbols(R), v))
+#    ext_R, _ = polynomial_ring(coefficient_ring(R), vcat(symbols(R), v), cached=false)
 #    n = ngens(R)
 #    phi = AlgebraHomomorphism(R, ext_R, gens(ext_R)[1:n])
 #    return ext_R, phi, gens(ext_R)[(ngens(R)+1):ngens(ext_R)]

--- a/src/AlgebraicGeometry/Surfaces/EllipticSurface/NeighborStep.jl
+++ b/src/AlgebraicGeometry/Surfaces/EllipticSurface/NeighborStep.jl
@@ -57,7 +57,7 @@ function _prop217(E::EllipticCurve, P::EllipticCurvePoint, k)
   B = coefficient_ring(Bt)
 
   R,ab = polynomial_ring(base,vcat([Symbol(:a,i) for i in 0:dega],[Symbol(:b,i) for i in 0:degb]),cached=false)
-  Rt, t1 = polynomial_ring(R,:t)
+  Rt, t1 = polynomial_ring(R, :t, cached=false)
   a = reduce(+,(ab[i+1]*t1^i for i in 0:dega), init=zero(Rt))
   b = reduce(+,(ab[2+dega+j]*t1^j for j in 0:degb), init=zero(Rt))
   c = a*xn(t1) - b*yn(t1)

--- a/src/Rings/mpoly-affine-algebras.jl
+++ b/src/Rings/mpoly-affine-algebras.jl
@@ -686,7 +686,7 @@ end
 #   else
 #      VAR = ["t[$i]" for i = 1:m]
 #   end
-#   S, _ = polynomial_ring(ZZ, VAR)
+#   S, _ = polynomial_ring(ZZ, VAR, cached=false)
 #   q = one(S)
 #   for i = 1:n
 #      e = [Int(MI[i, :][j]) for j = 1:m]
@@ -1383,7 +1383,7 @@ function _conv_normalize_data(A::MPolyQuoRing, l, br)
   return [
     begin
       newSR = l[1][i][1]::Singular.PolyRing
-      newOR, _ = polynomial_ring(br, symbols(newSR))
+      newOR, _ = polynomial_ring(br, symbols(newSR), cached=false)
       newA, newAmap = quo(newOR, ideal(newOR, newOR.(gens(l[1][i][2][:norid]))))
       set_attribute!(newA, :is_normal=>true)
       newgens = newOR.(gens(l[1][i][2][:normap]))

--- a/src/TropicalGeometry/poly.jl
+++ b/src/TropicalGeometry/poly.jl
@@ -251,7 +251,7 @@ function tropical_polynomial(f::Union{<:MPolyRingElem,<:PolyRingElem}, nu::Union
     isnothing(nu) && (nu = tropical_semiring_map(coefficient_ring(f)))
 
     T = tropical_semiring(nu)
-    Tx,x = polynomial_ring(T,[repr(x) for x in gens(parent(f))])
+    Tx,x = polynomial_ring(T, [repr(x) for x in gens(parent(f))], cached=false)
     tropf = inf(T)
 
     for (c,alpha) in zip(coefficients(f), exponents(f))
@@ -385,7 +385,7 @@ end
 #     s=-1
 #   end
 
-#   Tx,x = polynomial_ring(T,[repr(x) for x in gens(parent(f))])
+#   Tx,x = polynomial_ring(T, [repr(x) for x in gens(parent(f))], cached=false)
 #   tropf = inf(T)
 
 #   if base_ring(parent(f)) isa NonArchLocalField


### PR DESCRIPTION
Adds `cached=false` to some more `polynomial_ring` calls. This should now be all of them...

Closes #2455
