### PR TITLE
Fix `symmetric_power` of a dim 0 module

### DIFF
--- a/experimental/LieAlgebras/src/Combinatorics.jl
+++ b/experimental/LieAlgebras/src/Combinatorics.jl
@@ -5,9 +5,7 @@
 function multicombinations(n::Integer, k::Integer)
   return sort!(
     reverse.(
-      Vector.(
-        reduce(vcat, collect(partitions(i, k, 1, n)) for i in 0:(k * n); init=Vector{Int}[])
-      )::Vector{Vector{Int}}
+      reduce(vcat, data.(partitions(i, k, 1, n)) for i in 0:(k * n); init=Vector{Int}[])::Vector{Vector{Int}}
     ),
   )
 end

--- a/experimental/LieAlgebras/src/Combinatorics.jl
+++ b/experimental/LieAlgebras/src/Combinatorics.jl
@@ -5,7 +5,9 @@
 function multicombinations(n::Integer, k::Integer)
   return sort!(
     reverse.(
-      reduce(vcat, data.(partitions(i, k, 1, n)) for i in 0:(k * n); init=Vector{Int}[])::Vector{Vector{Int}}
+      reduce(
+        vcat, data.(partitions(i, k, 1, n)) for i in 0:(k * n); init=Vector{Int}[]
+      )::Vector{Vector{Int}}
     ),
   )
 end

--- a/experimental/LieAlgebras/test/Combinatorics-test.jl
+++ b/experimental/LieAlgebras/test/Combinatorics-test.jl
@@ -2,6 +2,9 @@
   @testset "multicombinations" begin
     multicombinations = Oscar.LieAlgebras.multicombinations
 
+    @test collect(multicombinations(0, 0)) == [Int[]]
+    @test collect(multicombinations(0, 1)) == []
+
     for n in 1:8, k in 1:n
       @test collect(multicombinations(n, k)) == collect(multicombinations(1:n, k))
     end


### PR DESCRIPTION
as that ran into an type assertion error for `Oscar.LieAlgebras.multicombinations(n,k)` where `n = 0` and `k > 0`.