### PR TITLE
Fix some failures with Julia nightly, add missing `action_homomorphism(Omega::GSetByElements{FinGenAbGroup, S})` method

### DIFF
--- a/gap/pkg/OscarInterface/tst/alnuth/ALNUTH.tst
+++ b/gap/pkg/OscarInterface/tst/alnuth/ALNUTH.tst
@@ -61,8 +61,8 @@ gap> f := UnivariatePolynomial( Rationals, [-4,0,0,1] );
 x_1^3-4
 gap> L := FieldByPolynomial( f );
 <algebraic extension over the Rationals of degree 3>
-gap> FactorsPolynomialAlgExt( L, pol );
-[ !2*x_1, x_1, x_1+a, x_1^2+!1, x_1^2+(-a)*x_1+a^2 ]
+gap> SortedList(FactorsPolynomialAlgExt( L, pol/2 ));
+[ x_1, x_1, x_1+a, x_1^2+(-a)*x_1+a^2, x_1^2+!1 ]
 gap> pol := UnivariatePolynomial( Rationals, [ 1, 3, 2, -1, 2, 3, 1 ] );
 x_1^6+3*x_1^5+2*x_1^4-x_1^3+2*x_1^2+3*x_1+1
 gap> f := UnivariatePolynomial( Rationals,[ 11/64, 59/16, -7/4, 1 ] );

--- a/gap/pkg/OscarInterface/tst/alnuth/manual.tst
+++ b/gap/pkg/OscarInterface/tst/alnuth/manual.tst
@@ -58,7 +58,7 @@ gap> y := RandomGroupElement( elms );;
 gap> z := ImageElm( isom, y );;
 gap> y = PreImagesRepresentative( isom, z );
 true
-gap> FactorsPolynomialAlgExt( F, g );
-[ x_1+(a-2), x_1+(-1/7*a^3+3/7*a^2+31/7*a-40/7), 
-  x_1+(1/7*a^3-3/7*a^2-31/7*a+26/7), x_1+(-a) ]
+gap> SortedList(FactorsPolynomialAlgExt( F, g ));
+[ x_1+(-1/7*a^3+3/7*a^2+31/7*a-40/7), x_1+(a-2), x_1+(-a), 
+  x_1+(1/7*a^3-3/7*a^2-31/7*a+26/7) ]
 gap> STOP_TEST( "manual.tst", 100000);   

--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -314,6 +314,34 @@ function hall_system(G::FinGenAbGroup)
    return result
 end
 
+
+################################################################################
+#
+#   G-Sets of `FinGenAbGroup`s
+#
+################################################################################
+
+function action_homomorphism(Omega::GSetByElements{FinGenAbGroup, S}) where S
+  A = acting_group(Omega)
+
+  # Compute a permutation group `G` isomorphic with `A`.
+  phi = isomorphism(PermGroup, A)
+  G = codomain(phi)
+
+  # Let `G` act on `Omega` as `A` does.
+  phiinv = inv(phi)
+  actfun = action_function(Omega)
+  fun = function(omega::S, g::PermGroupElem)
+    return actfun(omega, phiinv(g))
+  end
+  OmegaG = GSetByElements(G, fun, Omega, closed = true, check = false)
+
+  # Compute the permutation action on `1:length(Omega)`
+  # corresponding to the action of `A` on `Omega`.
+  return compose(phi, action_homomorphism(OmegaG))
+end
+
+
 ################################################################################
 #
 #   Properties

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -577,5 +577,7 @@ end
   @test sort(map(length, orbs)) == [1, 1, 1, 3, 3]
   @test all(o -> conductor(sum(collect(o))) == 1, orbs)
   o = orbs[findfirst(o -> length(o) == 3, orbs)]
-  @test sort([order(permutation(o, x)) for x in gens(u)]) == [1, 3]
+  acthom = action_homomorphism(o)
+  @test describe(image(acthom)[1]) == "C3"
+  @test all(x -> permutation(o, x) == acthom(x), gens(u))
 end

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -577,5 +577,5 @@ end
   @test sort(map(length, orbs)) == [1, 1, 1, 3, 3]
   @test all(o -> conductor(sum(collect(o))) == 1, orbs)
   o = orbs[findfirst(o -> length(o) == 3, orbs)]
-  @test [order(permutation(o, x)) for x in gens(u)] == [1, 3]
+  @test sort([order(permutation(o, x)) for x in gens(u)]) == [1, 3]
 end


### PR DESCRIPTION
The order of generators of the group u changed. It was computed via

    t = character_table("L2(8)")
    N = lcm(map(conductor, t))
    u, mu = unit_group(quo(ZZ, N)[1])

and `mu(u[1])` and `mu(u[2])` are swapped in nightly vs julia stable.

Progress towards #4882