### PR TITLE
Restrict `is_global`, `is_local` to total monomial orderings, add `is_(global|local)_block`

### DIFF
--- a/docs/src/CommutativeAlgebra/GroebnerBases/orderings.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/orderings.md
@@ -67,7 +67,7 @@ julia> R, (w, x, y, z) = polynomial_ring(QQ, [:w, :x, :y, :z])
 julia> o1 = degrevlex([w, x])
 degrevlex([w, x])
 
-julia> is_global(o1)
+julia> is_global_block(o1)
 true
 
 julia> canonical_matrix(o1)
@@ -77,7 +77,7 @@ julia> canonical_matrix(o1)
 julia> o2 = neglex([y, z])
 neglex([y, z])
 
-julia> is_local(o2)
+julia> is_local_block(o2)
 true
 
 julia> canonical_matrix(o2)

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -1475,6 +1475,7 @@ true
 ```
 """
 function is_global(ord::MonomialOrdering)
+  !is_total(ord) && error("The monomial ordering must be defined on all variables.")
   M = matrix(ord)
   for i in _support_indices(ord.o)
     if _cmp_var(M, i) <= 0
@@ -1501,6 +1502,7 @@ true
 ```
 """
 function is_local(ord::MonomialOrdering)
+  !is_total(ord) && error("The monomial ordering must be defined on all variables.")
   M = matrix(ord)
   for i in _support_indices(ord.o)
     if _cmp_var(M, i) >= 0

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -17,7 +17,9 @@ export deginvlex
 export invlex
 export is_elimination_ordering
 export is_global
+export is_global_block
 export is_local
+export is_local_block
 export is_mixed
 export is_total
 export _is_weighted
@@ -1459,9 +1461,35 @@ function _cmp_var(M, j::Int)
 end
 
 @doc raw"""
-    is_global(ord::MonomialOrdering)
+    is_global_block(ord::MonomialOrdering)
 
 Return `true` if `ord` is global, `false` otherwise.
+
+# Examples
+```jldoctest
+julia> R, (x, y) = polynomial_ring(QQ, [:x, :y, :z]);
+
+julia> o = lex([x,y])
+lex([x, y])
+
+julia> is_global_block(o)
+true
+```
+"""
+function is_global_block(ord::MonomialOrdering)
+  M = matrix(ord)
+  for i in _support_indices(ord.o)
+    if _cmp_var(M, i) <= 0
+      return false
+    end
+  end
+  return true
+end
+
+@doc raw"""
+    is_global(ord::MonomialOrdering)
+
+Return `true` if `ord` is a total global ordering, `false` otherwise.
 
 # Examples
 ```jldoctest
@@ -1476,9 +1504,29 @@ true
 """
 function is_global(ord::MonomialOrdering)
   !is_total(ord) && error("The monomial ordering must be defined on all variables.")
+  return is_global_block(ord);
+end
+
+@doc raw"""
+    is_local_block(ord::MonomialOrdering)
+
+Return `true` if `ord` is local, `false` otherwise.
+
+# Examples
+```jldoctest
+julia> R, (x, y) = polynomial_ring(QQ, [:x, :y, :z]);
+
+julia> o = neglex([x,y])
+neglex([x, y])
+
+julia> is_local_block(o)
+true
+```
+"""
+function is_local_block(ord::MonomialOrdering)
   M = matrix(ord)
   for i in _support_indices(ord.o)
-    if _cmp_var(M, i) <= 0
+    if _cmp_var(M, i) >= 0
       return false
     end
   end
@@ -1488,7 +1536,7 @@ end
 @doc raw"""
     is_local(ord::MonomialOrdering)
 
-Return `true` if `ord` is local, `false` otherwise.
+Return `true` if `ord` is a total local ordering, `false` otherwise.
 
 # Examples
 ```jldoctest
@@ -1503,13 +1551,7 @@ true
 """
 function is_local(ord::MonomialOrdering)
   !is_total(ord) && error("The monomial ordering must be defined on all variables.")
-  M = matrix(ord)
-  for i in _support_indices(ord.o)
-    if _cmp_var(M, i) >= 0
-      return false
-    end
-  end
-  return true
+  return is_local_block(ord)
 end
 
 @doc raw"""

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -904,6 +904,7 @@ export is_fundamental_weight_with_index
 export is_geometrically_integral
 export is_geometrically_reduced
 export is_global
+export is_global_block
 export is_gorenstein
 export is_graded
 export is_groebner_basis
@@ -931,6 +932,7 @@ export is_leaf
 export is_left
 export is_linearly_normal
 export is_local
+export is_local_block
 export is_locally_free
 export is_loopless
 export is_manifold

--- a/test/Rings/orderings.jl
+++ b/test/Rings/orderings.jl
@@ -91,6 +91,8 @@
    # issue 1697
    @test_throws ErrorException is_global(lex([x,y]))
    @test_throws ErrorException is_local(neglex([x,y]))
+   @test is_global_block(lex([x,y]))
+   @test is_local_block(neglex([x,y]))
 
    @test_throws ArgumentError monomial_ordering(gens(R), :foo)
    @test_throws ArgumentError monomial_ordering(gens(R), :lex, ones(Int, ngens(R)+1))

--- a/test/Rings/orderings.jl
+++ b/test/Rings/orderings.jl
@@ -51,16 +51,16 @@
                                   collect(monomials(f; ordering = deglex(R)))
 
    a = lex([x, y])
-   @test is_global(a)
-   @test !is_local(a)
+   @test is_global_block(a)
+   @test !is_local_block(a)
    @test !is_mixed(a)
    @test cmp(a, x, one(R)) > 0
    @test cmp(a, y, one(R)) > 0
    @test_throws ErrorException cmp(a, z, one(R))
 
    a = neglex([y, z])
-   @test !is_global(a)
-   @test is_local(a)
+   @test !is_global_block(a)
+   @test is_local_block(a)
    @test !is_mixed(a)
    @test_throws ErrorException cmp(a, x, one(R))
    @test cmp(a, y, one(R)) < 0
@@ -91,8 +91,6 @@
    # issue 1697
    @test_throws ErrorException is_global(lex([x,y]))
    @test_throws ErrorException is_local(neglex([x,y]))
-   @test is_global_block(lex([x,y]))
-   @test is_local_block(neglex([x,y]))
 
    @test_throws ArgumentError monomial_ordering(gens(R), :foo)
    @test_throws ArgumentError monomial_ordering(gens(R), :lex, ones(Int, ngens(R)+1))

--- a/test/Rings/orderings.jl
+++ b/test/Rings/orderings.jl
@@ -88,6 +88,10 @@
    @test !is_local(a)
    @test is_mixed(a)
 
+   # issue 1697
+   @test_throws ErrorException is_global(lex([x,y]))
+   @test_throws ErrorException is_local(neglex([x,y]))
+
    @test_throws ArgumentError monomial_ordering(gens(R), :foo)
    @test_throws ArgumentError monomial_ordering(gens(R), :lex, ones(Int, ngens(R)+1))
    @test_throws ArgumentError monomial_ordering(gens(R), :foo, ones(Int, ngens(R)))


### PR DESCRIPTION
Adds checks to `is_global` and `is_local` is a given monomial ordering is total, i.e. is defined on all variables of the corresponding ring. If the ordering is not total, a corresponding error message is printed.

This should fix #1697.