### PR TITLE
Encapsulate `groebner_assure` & friends in `PBWAlgebra(Quo).jl`

### DIFF
--- a/src/Rings/PBWAlgebraQuo.jl
+++ b/src/Rings/PBWAlgebraQuo.jl
@@ -128,8 +128,7 @@ function simplify(a::PBWAlgQuoElem)
         return a   # short-cut for impls with reducing arithmetic (e.g. exterior algebras)
     end
     I = parent(a).I
-    groebner_assure!(I)
-    a.data.sdata = Singular.reduce(a.data.sdata, I.gb)
+    a.data.sdata = Singular.reduce(a.data.sdata, singular_groebner_basis(I))
     return a
 end
 


### PR DESCRIPTION
Replaced `_assure` functions by caching getters.  See issue #1920 