### PR TITLE
Incorporate new logo in banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ julia> using Oscar
 | |_| |\__ \| |__  / ^ \ |  ´ /  | Polymake and Singular
  \___/ \___/ \___//_/ \_\|_|\_\  | Type "?Oscar" for more information
 o--------o-----o-----o--------o  | Documentation: https://docs.oscar-system.org
-  S Y M B O L I C   T O O L S    | 1.4.0-DEV
+  S Y M B O L I C   T O O L S    | Version 1.4.0-DEV
 
 julia> k, a = quadratic_field(-5)
 (Imaginary quadratic field defined by x^2 + 5, sqrt(-5))

--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ in the OSCAR manual to learn more on how to contribute to OSCAR.
 
 ```
 julia> using Oscar
-  ___   ____   ____    _    ____
- / _ \ / ___| / ___|  / \  |  _ \   |  Combining ANTIC, GAP, Polymake, Singular
-| | | |\___ \| |     / _ \ | |_) |  |  Type "?Oscar" for more information
-| |_| | ___) | |___ / ___ \|  _ <   |  Manual: https://docs.oscar-system.org
- \___/ |____/ \____/_/   \_\_| \_\  |  Version 1.4.0-DEV
+  ___   ___   ___    _    ____
+ / _ \ / __\ / __\  / \  |  _ \  | Combining and extending ANTIC, GAP,
+| |_| |\__ \| |__  / ^ \ |  ´ /  | Polymake and Singular
+ \___/ \___/ \___//_/ \_\|_|\_\  | Type "?Oscar" for more information
+o--------o-----o-----o--------o  | Documentation: https://docs.oscar-system.org
+  S Y M B O L I C   T O O L S    | 1.4.0-DEV
 
 julia> k, a = quadratic_field(-5)
 (Imaginary quadratic field defined by x^2 + 5, sqrt(-5))

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -53,11 +53,13 @@ function _print_banner(;is_dev = Oscar.is_dev)
 
   if displaysize(stdout)[2] >= 80 
     println(
-      raw"""  ___   ____   ____    _    ____
-             / _ \ / ___| / ___|  / \  |  _ \   |  Combining ANTIC, GAP, Polymake, Singular
-            | | | |\___ \| |     / _ \ | |_) |  |  Type "?Oscar" for more information
-            | |_| | ___) | |___ / ___ \|  _ <   |  Manual: https://docs.oscar-system.org
-             \___/ |____/ \____/_/   \_\_| \_\  |  """ * version_string)
+      raw"""  ___   ___   ___    _    ____
+             / _ \ / __\ / __\  / \  |  _ \  | Combining and extending ANTIC, GAP,
+            | |_| |\__ \| |__  / ^ \ |  ´ /  | Polymake and Singular
+             \___/ \___/ \___//_/ \_\|_|\_\  | Type "?Oscar" for more information""")
+    printstyled(raw"""o--------o-----o-----o--------o""", color = :yellow)
+    println(raw"""  | Documentation: https://docs.oscar-system.org""")
+    println(raw"""  S Y M B O L I C   T O O L S    | """ * version_string)
   else
     println("OSCAR $VERSION_NUMBER  https://docs.oscar-system.org  Type \"?Oscar\" for help")
   end


### PR DESCRIPTION
Revise the banner to incorporate the new logo. This is exactly as wide as the current banner and one line higher.

### Changes:
* New logo, also including a tiny bit of colour
* "Combining" -> "Combining and extending": like before the last banner revision and we now have enough space again
* "Manual" -> "Documentation": Seems to me the more natural word and we have enough space for it

### Version 1 (currently in this pull request):
![1](https://github.com/user-attachments/assets/c4c72a1d-7a05-4e23-9f08-48105952d6ec)

### Version 2 also includes the vertical bars in the letters:
![2](https://github.com/user-attachments/assets/5f6ab32a-94af-466c-9806-bfe61d16e696)

I personally kind of like version 2, but I understand that it looks a bit weird (and possibly requires to much explanation).

Feel free to ask for changes or push them yourselves :)

### Once the design is decided, the following should be done:
- [x] Update Readme (in this pull request) and possibly other places inside Oscar.jl
- [x] Update website (separate pull request after release) https://github.com/oscar-system/oscar-website/pull/504