### PR TITLE
Replace wrong helper function is nmbthy tests

### DIFF
--- a/test/NumberTheory/nmbthy.jl
+++ b/test/NumberTheory/nmbthy.jl
@@ -1,16 +1,12 @@
 using Oscar
 using Test
 
-function evalu(x::Fac)
-  return x.unit * prod(p*k for (p,k) = x.fac)
-end
-
 @testset "factorizations" begin
   k, a = quadratic_field(-5)
   zk = maximal_order(k)
   f = factorizations(zk(6))
   @test length(f) == 2
-  @test all(x -> evalu(x) == 6, f)
+  @test all(x -> evaluate(x) == 6, f)
   @test !is_irreducible(zk(6))
 end
 


### PR DESCRIPTION
it should have been `p^k` instead of `p*k`, but we have a dedicated function for this, so why not use it here.