### PR TITLE
Printing of free resolutions

### DIFF
--- a/docs/src/CommutativeAlgebra/affine_algebras.md
+++ b/docs/src/CommutativeAlgebra/affine_algebras.md
@@ -350,8 +350,10 @@ refer to `A` and `S`, respectively.  Given ring homomorphisms `F` : `A` $\to$ `B
 ## Homomorphisms of Affine Algebras
 
 The OSCAR homomorphism type `AffAlgHom` models ring homomorphisms `R` $\to$ `S` such that
-the type of both `R` and `S`  is a subtype of `Union{MPolyRing{T}, MPolyQuoRing{U}}`, where `T <: FieldElem` and
-`U <: MPolyRingElem{T}`. Functionality for these homomorphism is discussed in what follows.
+the types of `R` and `S`  are subtypes of `Union{MPolyRing{T}, MPolyQuoRing{U1}}` and
+`Union{MPolyRing{T}, MPolyQuoRing{U2}}`, respectively. Here, `T <: FieldElem` and
+`U1 <: MPolyRingElem{T}`, `U2 <: MPolyRingElem{T}`.
+Functionality for these homomorphism is discussed in what follows.
 
 ### Data Associated to Homomorphisms of Affine Algebras
 

--- a/docs/src/CommutativeAlgebra/homological_algebra.md
+++ b/docs/src/CommutativeAlgebra/homological_algebra.md
@@ -32,12 +32,35 @@ present_as_cokernel(M::SubquoModule, task::Symbol = :none)
 
 ## Free Resolutions
 
+### Types
+
+The OSCAR type for the free resolutions discussed in this section is of parametrized form `FreeResolution{T}`.
+
+### Constructors
+
 ```@docs
-free_resolution(M::SubquoModule{<:MPolyRingElem}; 
-    ordering::ModuleOrdering = default_ordering(M),
-    length::Int=0, algorithm::Symbol=:fres
-  )
+free_resolution(M::SubquoModule{T};
+    length::Int = 0,
+    algorithm::Symbol = T <: MPolyRingElem ? :fres : :sres) where {T <: Union{MPolyRingElem, MPolyQuoRingElem}}
 ```
+
+```@docs
+free_resolution(I::MPolyIdeal; length::Int = 0, algorithm::Symbol = :fres)
+```
+
+```@docs
+free_resolution(Q::MPolyQuoRing; length::Int = 0, algorithm::Symbol = :fres)
+```
+### Data Associated to Free Resolutions
+
+```@docs
+augmented_complex(F::FreeResolution)
+```
+
+```@docs
+length(F::FreeResolution)
+```
+
 
 ## Betti Tables
 

--- a/docs/src/CommutativeAlgebra/rings.md
+++ b/docs/src/CommutativeAlgebra/rings.md
@@ -580,7 +580,8 @@ Given a ring homomorphism `F` from `R` to `S` as above, `domain(F)` and `codomai
 refer to `R` and `S`, respectively.
 
 !!! note
-    The OSCAR homomorphism type `AffAlgHom` models ring homomorphisms `R` $\to$ `S` such that
-    the type of both `R` and `S`  is a subtype of `Union{MPolyRing{T}, MPolyQuoRing{U}}`, where `T <: FieldElem` and
-    `U <: MPolyRingElem{T}`. Functionality for these homomorphism is discussed in the section on [affine algebras](@ref affine_algebras).
-
+    Homomorphisms from quotients of multivariate rings are discussed in the section on [affine algebras](@ref affine_algebras).
+    In particular, in the same section, we introduce the OSCAR homomorphism type `AffAlgHom` which addresses ring homomorphisms
+    `R` $\to$ `S` such that the types of `R` and `S`  are subtypes of `Union{MPolyRing{T}, MPolyQuoRing{U1}}` and
+    `Union{MPolyRing{T}, MPolyQuoRing{U2}}`, respectively. Here, `T <: FieldElem` and
+    `U1 <: MPolyRingElem{T}`, `U2 <: MPolyRingElem{T}`.

--- a/src/Modules/ModuleTypes.jl
+++ b/src/Modules/ModuleTypes.jl
@@ -774,11 +774,6 @@ end
 
 Base.getindex(FR::FreeResolution, i::Int) = FR.C[i]
 
-function Base.show(io::IO, FR::FreeResolution)
-    C = FR.C
-    show(io, C)
-end
-
 mutable struct BettiTable
   B::Dict{Tuple{Int, Any}, Int}
   project::Union{FinGenAbGroupElem, Nothing}

--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -2505,7 +2505,7 @@ end
     minimal_betti_table(I::MPolyIdeal{T}) where {T<:MPolyDecRingElem} 
 
 Given a finitely presented graded module `M` over a standard $\mathbb Z$-graded 
-multivariate polynomial ring with coefficients in a field, return the Betti Table
+multivariate polynomial ring with coefficients in a field, return the Betti table
 of the minimal free resolution of `M`. Similarly for `A` and `I`.
 
 # Examples

--- a/src/Modules/UngradedModules/FreeResolutions.jl
+++ b/src/Modules/UngradedModules/FreeResolutions.jl
@@ -2,7 +2,8 @@ function map(FR::FreeResolution, i::Int)
   return map(FR.C, i)
 end
 
-function free_show(io::IO, C::ComplexOfMorphisms)
+function Base.show(io::IO, FR::FreeResolution)
+  C = FR.C
   name_mod = String[]
   rank_mod = Int[]
 
@@ -72,7 +73,7 @@ methods and have no effect on the computation.
 """
 function free_resolution(F::FreeMod; length::Int=0, algorithm::Symbol=:fres)
   res = presentation(F)
-  set_attribute!(res, :show => free_show, :free_res => F)
+  set_attribute!(res, :show => Hecke.pres_show, :free_res => F)
   return FreeResolution(res)
 end
 
@@ -225,15 +226,15 @@ function _extend_free_resolution(cc::Hecke.ComplexOfMorphisms, idx::Int)
     pushfirst!(cc, hom(Z, domain(cc.maps[1]), Vector{elem_type(domain(cc.maps[1]))}(); check=false))
     cc.complete = true
   end
-  set_attribute!(cc, :show => free_show)
+  set_attribute!(cc, :show => Hecke.pres_show)
   maxidx = min(idx, first(Hecke.map_range(cc)))
   return map(cc, maxidx)
 end
 
 @doc raw"""
     free_resolution(M::SubquoModule{T}; 
-        length::Int=0,
-        algorithm::Symbol = T <:MPolyRingElem ? :fres : :sres) where {T <: Union{MPolyRingElem, MPolyQuoRingElem}}
+        length::Int = 0,
+        algorithm::Symbol = T <: MPolyRingElem ? :fres : :sres) where {T <: Union{MPolyRingElem, MPolyQuoRingElem}}
 
 Return a free resolution of `M`.
 
@@ -246,18 +247,20 @@ polynomial rings and `:sres` for modules over quotients of polynomial rings.
     higher syzygy modules.
 
 !!! note
-    - If `algorithm == mres`, and `M` is positively graded, a minimal free resolution is returned.
-    - If `algorithm == nres`, and `M` is positively graded, the function proceeds as above except 
+    - If `algorithm == mres`, and `M` is positively graded, then a minimal free resolution is returned.
+    - If `algorithm == nres`, and `M` is positively graded, then the function proceeds as above except
       that it starts by computing a presentation which is not necessarily minimal.
-    In both cases, if `M` is not (positively) graded, the function still aims at returning an ''improved'' resolution.
+    In both cases, if `M` is not (positively) graded, then the function still aims at returning an ''improved'' resolution.
 
 !!! note
-    If `algorithm == fres`, the function relies on an enhanced version of Schreyer's algorithm 
-    [EMSS16](@cite). Typically, this is more efficient than the approaches above, but the 
-    resulting resolution is far from being minimal.
+    If `algorithm == fres`, then the function relies on an enhanced version of Schreyer's algorithm
+    [EMSS16](@cite). Typically, this is more efficient than the approaches above, but the
+    resulting resolution is far from being minimal. If `algorithm == sres` in the case of modules
+    over quotients of polynomial rings (this is currently the only option available for that case),
+    then again a version of Schreyer's approach is used.
 
 !!! note
-    If `M` is a module over a quotient of a polynomial ring then the `length` keyword must
+    If `M` is a module over a quotient of a polynomial ring, then the `length` keyword must
     be set to a nonzero value.
 
 # Examples
@@ -398,8 +401,8 @@ julia> matrix(map(FM3, 1))
 iterative kernel computation.
 """
 function free_resolution(M::SubquoModule{T}; 
-                         length::Int=0,
-                         algorithm::Symbol = T <:MPolyRingElem ? :fres : :sres) where {T <: Union{MPolyRingElem, MPolyQuoRingElem}}
+                         length::Int = 0,
+                         algorithm::Symbol = T <: MPolyRingElem ? :fres : :sres) where {T <: Union{MPolyRingElem, MPolyQuoRingElem}}
 
   coefficient_ring(base_ring(M)) isa AbstractAlgebra.Field ||
       error("Must be defined over a field.")
@@ -494,9 +497,8 @@ function free_resolution(M::SubquoModule{T};
   cc = Hecke.ComplexOfMorphisms(Oscar.ModuleFP, maps, check = false, seed = -2)
   cc.fill     = _extend_free_resolution
   cc.complete = cc_complete
-  set_attribute!(cc, :show => free_show, :free_res => M)
+  set_attribute!(cc, :show => Hecke.pres_show, :free_res => M)
   set_attribute!(cc, :algorithm, algorithm)
-
   return FreeResolution(cc)
 end
 
@@ -570,22 +572,44 @@ function free_resolution_via_kernels(M::SubquoModule, limit::Int = -1)
   end
   C = Hecke.ComplexOfMorphisms(ModuleFP, mp, check = false, seed = -2)
   #set_attribute!(C, :show => free_show, :free_res => M) # doesn't work
+  set_attribute!(C, :show => Hecke.pres_show, :free_res => M)
   return FreeResolution(C)
 end
 
 @doc raw"""
-    free_resolution(I::MPolyIdeal; length::Int=0, algorithm::Symbol=:fres)
+    free_resolution(I::MPolyIdeal; length::Int = 0, algorithm::Symbol = :fres)
 
-Compute a free resolution of `I`.
+Consider `I` as a subquotient module over its base ring, and return a free resolution of that module.
 
 If `length != 0`, the free resolution is only computed up to the `length`-th free module.
-At the moment, options for `algorithm` are `:fres`, `:mres` and `:nres`. With `:mres` or `:nres`,
-minimal free resolutions are returned.
+At the moment, options for `algorithm` are `:fres`, `nres`, and `:mres`. With `:mres`,
+in the positively graded case, a minimal free resolution is returned.
 
 # Examples
+```jldoctest
+julia> R, (x, y) = polynomial_ring(QQ, [:x, :y]);
+
+julia> I = ideal(R, [x, y])^2;
+
+julia> fI = free_resolution(I)
+Free resolution of I
+R^3 <---- R^2 <---- 0
+0         1         2
+
+julia> AC = augmented_complex(fI)
+0 <---- I <---- R^3 <---- R^2 <---- 0
+
+julia> AC[-1]
+Submodule with 3 generators
+  1: x^2*e[1]
+  2: x*y*e[1]
+  3: y^2*e[1]
+represented as subquotient with no relations
+
+```
 """
 function free_resolution(I::MPolyIdeal;
-                         length::Int=0, algorithm::Symbol=:fres)
+                         length::Int = 0, algorithm::Symbol = :fres)
   S = ideal_as_module(I)
   n = AbstractAlgebra.get_name(I)
   if n !== nothing
@@ -595,18 +619,42 @@ function free_resolution(I::MPolyIdeal;
 end
 
 @doc raw"""
-    free_resolution(Q::MPolyQuoRing; length::Int=0, algorithm::Symbol=:fres)
+    free_resolution(Q::MPolyQuoRing; length::Int = 0, algorithm::Symbol = :fres)
 
-Compute a free resolution of `Q`.
+Consider `Q` as a subquotient module over its base ring, and return a free resolution of that module.
 
 If `length != 0`, the free resolution is only computed up to the `length`-th free module.
-At the moment, options for `algorithm` are `:fres`, `:mres` and `:nres`. With `:mres` or `:nres`,
-minimal free resolutions are returned.
+At the moment, options for `algorithm` are `:fres`, `:nres`, and `:mres`. With `:nres` or `:mres`,
+in the positively graded case, a minimal free resolution is returned.
 
 # Examples
+```jldoctest
+julia> R, (x, y) = polynomial_ring(QQ, [:x, :y]);
+
+julia> I = ideal(R, [x, y])^2;
+
+julia> Q, _ = quo(R, I);
+
+julia> fQ = free_resolution(Q)
+Free resolution of Q
+R^1 <---- R^3 <---- R^2 <---- 0
+0         1         2         3
+
+julia> AC = augmented_complex(fQ)
+0 <---- Q <---- R^1 <---- R^3 <---- R^2 <---- 0
+
+julia> AC[-1]
+Subquotient of submodule with 1 generator
+  1: e[1]
+by submodule with 3 generators
+  1: x^2*e[1]
+  2: x*y*e[1]
+  3: y^2*e[1]
+
+```
 """
 function free_resolution(Q::MPolyQuoRing;
-                         length::Int=0, algorithm::Symbol=:fres)
+                         length::Int = 0, algorithm::Symbol = :fres)
   q = quotient_ring_as_module(Q)
   n = AbstractAlgebra.get_name(Q)
   if n !== nothing
@@ -614,3 +662,59 @@ function free_resolution(Q::MPolyQuoRing;
   end
   return free_resolution(q, length = length, algorithm = algorithm)
 end
+
+@doc raw"""
+    augmented_complex(F::FreeResolution)
+
+Return the augmented complex of `F`.
+
+# Examples
+```jldoctest
+julia> R, (x, y, z) = polynomial_ring(QQ, [:x, :y, :z]);
+
+julia> A = R[x; y];
+
+julia> B = R[x^2; x*y; y^2; z^4];
+
+julia> M = SubquoModule(A, B);
+
+julia> fr = free_resolution(M)
+Free resolution of M
+R^2 <---- R^6 <---- R^6 <---- R^2 <---- 0
+0         1         2         3         4
+
+julia> augmented_complex(fr)
+0 <---- M <---- R^2 <---- R^6 <---- R^6 <---- R^2 <---- 0
+
+```
+"""
+augmented_complex(F::FreeResolution) = F.C
+
+
+@doc raw"""
+    length(F::FreeResolution)
+
+Return the length of `F`.
+
+# Examples
+```jldoctest
+julia> R, (x, y, z) = polynomial_ring(QQ, [:x, :y, :z]);
+
+julia> A = R[x; y];
+
+julia> B = R[x^2; x*y; y^2; z^4];
+
+julia> M = SubquoModule(A, B);
+
+julia> fr = free_resolution(M)
+Free resolution of M
+R^2 <---- R^6 <---- R^6 <---- R^2 <---- 0
+0         1         2         3         4
+
+julia> length(fr)
+3
+
+```
+"""
+length(F::FreeResolution) = length(F.C.maps)-3
+

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -638,7 +638,7 @@ Fields:
       oscar_assure(B)
       R = B.gens.Ox
       if is_graded(R)
-        @req all(is_homogeneous, B.gens.O) "The generators of the ideal must be homogeneous"
+        @req all(is_homogeneous, B.gens.O) "The generators of an ideal in a graded ring must be homogeneous"
       end
     end
     r = new{T}()

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -299,6 +299,7 @@ export atlas_irrationality
 export atlas_program
 export atlas_subgroup
 export augmented_chow_ring
+export augmented_complex
 export aut
 export automorphism_group
 export barycentric_subdivision


### PR DESCRIPTION
- The printing of free resolutions should be associated to the free resolution and not to its augmented complex.
- Add getter functions for the augmented complex and the length of the free resolution.
- Make sure that the augmented complex is printed as it should.
- Document further functionality via examples, some corrections to docu.