### PR TITLE
Filter hash changes in nightly doctests

### DIFF
--- a/docs/src/NumberTheory/galois.md
+++ b/docs/src/NumberTheory/galois.md
@@ -83,7 +83,7 @@ galois_group(f::PolyRingElem{<:FieldElem})
 ```
 
 Over the rational function field, we can also compute the monodromy group:
-```jldoctest galqt; setup = :(using Oscar, Random ; Random.seed!(1))
+```jldoctest galqt; setup = :(using Oscar, Random ; Random.seed!(1)), filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> Qt, t = rational_function_field(QQ, "t");
 
 julia> Qtx, x = Qt[:x];
@@ -195,7 +195,7 @@ of `s[1]+s[3]` evaluated at the roots.
 Once the orbit is known, the coefficients of the minimal polynomial are just the elementary
 symmetric functions evaluated at the roots: 
 
-```jldoctest galois1
+```jldoctest galois1; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> o = collect(orbit(G, s[1]+s[3]))
 4-element Vector{ZZMPolyRingElem}:
  x1 + x3

--- a/docs/src/Rings/integer.md
+++ b/docs/src/Rings/integer.md
@@ -564,7 +564,7 @@ false
 Return a factorisation of the given integer. The return value is a special
 factorisation struct which can be manipulated using the functions below.
 
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> factor(ZZ(-6000361807272228723606))
 -1 * 2 * 229^3 * 43669^3 * 3
 
@@ -576,7 +576,7 @@ ERROR: ArgumentError: Argument is not non-zero
 
 * `unit(F::Fac) -> ZZRingElem`
 
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> F = factor(ZZ(-12))
 -1 * 2^2 * 3
 
@@ -589,7 +589,7 @@ julia> unit(F)
 
 Once created, a factorisation is iterable:
 
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> F = factor(ZZ(-60))
 -1 * 5 * 2^2 * 3
 
@@ -604,7 +604,7 @@ The pairs `(p, e)` in a factorisation represent the prime power factors
 ``p^e`` of the non-unit part of the factorisation. They can be placed in an
 array using `collect`:
 
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> F = factor(ZZ(-60))
 -1 * 5 * 2^2 * 3
 
@@ -625,7 +625,7 @@ is not in a factorisation is requested, an exception is raised.
 For convenience, a `Int` can be used instead of an OSCAR integer for this
 functionality.
 
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> F = factor(ZZ(-60))
 -1 * 5 * 2^2 * 3
 

--- a/experimental/AlgebraicShifting/src/PartialShift.jl
+++ b/experimental/AlgebraicShifting/src/PartialShift.jl
@@ -268,7 +268,7 @@ If the field is not given then `QQ` is used during the computation.
 If `w` is not given then `longest_element(weyl_group(:A, n_vertices(K) - 1))` is used
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> K = real_projective_plane()
 Abstract simplicial complex of dimension 2 on 6 vertices
 

--- a/experimental/AlgebraicShifting/src/PartialShiftGraph.jl
+++ b/experimental/AlgebraicShifting/src/PartialShiftGraph.jl
@@ -24,7 +24,7 @@ and discoverable from elements in `W`.
 Return a `Vector{SimplicialCompplex}` ordered lexicographically.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> K = simplicial_complex([[1, 2], [2, 3], [3, 4]])
 Abstract simplicial complex of dimension 1 on 4 vertices
 
@@ -131,7 +131,7 @@ See [D-VJL24](@cite) for background.
 
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> gamma(n,k,l) = uniform_hypergraph.(subsets(subsets(n, k), l), n)
 gamma (generic function with 1 method)
 
@@ -266,7 +266,7 @@ There is an edge from `s` to `t`  in `CG` whenever there is an edge from `i` to 
 See [D-VJL24](@cite) for background.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> gamma(n,k,l) = uniform_hypergraph.(subsets(subsets(n, k), l), n)
 gamma (generic function with 1 method)
 

--- a/experimental/AlgebraicStatistics/src/GaussianGraphicalModels.jl
+++ b/experimental/AlgebraicStatistics/src/GaussianGraphicalModels.jl
@@ -77,7 +77,7 @@ Return the generators of the multivariate polynomial ring inside the GaussianRin
 
 ## Examples
 
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> R = gaussian_ring(3)
 Gaussian ring over Rational field in 6 variables
 s[1, 1], s[1, 2], s[1, 3], s[2, 2], s[2, 3], s[3, 3]

--- a/experimental/AlgebraicStatistics/src/Markov.jl
+++ b/experimental/AlgebraicStatistics/src/Markov.jl
@@ -145,7 +145,7 @@ Return the generators of the polynomial ring.
 
 ## Examples
 
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> R = markov_ring("A" => 1:2, "B" => 1:2, "X" => 1:2, "Y" => 1:2)
 MarkovRing for random variables A -> {1, 2}, B -> {1, 2}, X -> {1, 2}, Y -> {1, 2} in 16 variables over Rational field
 

--- a/experimental/AlgebraicStatistics/src/PhylogeneticParametrization.jl
+++ b/experimental/AlgebraicStatistics/src/PhylogeneticParametrization.jl
@@ -54,7 +54,7 @@ Create a parametrization for a `PhylogeneticModel` of type `Dictionary`.
 Iterate through all possible states of the leaf random variables and calculates their corresponding probabilities using the root distribution and laws of conditional independence. Return a dictionary of polynomials indexed by the states. Use auxiliary function `monomial_parametrization(pm::PhylogeneticModel, states::Dict{Int, Int})` and `probability_parametrization(pm::PhylogeneticModel, leaves_states::Vector{Int})`. 
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> pm = jukes_cantor_model(graph_from_edges(Directed,[[4,1],[4,2],[4,3]]));
 
 julia> p = probability_map(pm)
@@ -131,7 +131,7 @@ Create a parametrization for a `GroupBasedPhylogeneticModel` of type `Dictionary
 Iterate through all possible states of the leaf random variables and calculates their corresponding probabilities using group actions and laws of conditional independence. Return a dictionary of polynomials indexed by the states. Use auxiliary function `monomial_fourier(pm::GroupBasedPhylogeneticModel, leaves_states::Vector{Int})` and `fourier_parametrization(pm::GroupBasedPhylogeneticModel, leaves_states::Vector{Int})`. 
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> pm = jukes_cantor_model(graph_from_edges(Directed,[[4,1],[4,2],[4,3]]));
 
 julia> q = fourier_map(pm)
@@ -178,7 +178,7 @@ end
 Given the parametrization of a `PhylogeneticModel`, cancel all duplicate entries and return equivalence classes of states which are attached the same probabilities.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> pm = jukes_cantor_model(graph_from_edges(Directed,[[4,1],[4,2],[4,3]]));
 
 julia> p = probability_map(pm);
@@ -239,7 +239,7 @@ end
 Take the output of the function `compute_equivalent_classes` for `PhylogeneticModel` and multiply by a factor to obtain probabilities as specified on the original small trees database.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> pm = jukes_cantor_model(graph_from_edges(Directed,[[4,1],[4,2],[4,3]]));
 
 julia> p = probability_map(pm);

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
@@ -72,7 +72,7 @@ Return the model sections in explicit form, that is as polynomials
 of the base space coordinates. The set of keys of the returned
 dictionary matches the output of `model_sections`. 
 
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> t = literature_model(arxiv_id = "1109.3454", equation = "3.1")
 Assuming that the first row of the given grading is the grading under Kbar
 
@@ -104,7 +104,7 @@ Return a dictionary that defines how the "default" parameters of
 the given model type are defined in terms of the tunable sections
 (those returned by `tunable_sections`).
 
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> t = literature_model(arxiv_id = "1109.3454", equation = "3.1")
 Assuming that the first row of the given grading is the grading under Kbar
 
@@ -131,7 +131,7 @@ Return the divisor classes of all model sections. The set
 of keys of the returned dictionary matches the output
 of `model_sections`.
 
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> B3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
 
@@ -1408,7 +1408,7 @@ end
 Return a vector containing all sections that can be tuned.
 This is a list of the names of all parameters appearing in the model.
 
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> m = literature_model(arxiv_id = "1109.3454", equation = "3.1")
 Assuming that the first row of the given grading is the grading under Kbar
 
@@ -1434,7 +1434,7 @@ This includes the sections returned by `tunable_sections` and all sections param
 them (the keys of the dictionary returned by `model_section_parametrization`). These are
 the keys of the dictionaries returned by of `explicit_model_sections` and `classes_of_model_sections`.
 
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> m = literature_model(arxiv_id = "1109.3454", equation = "3.1")
 Assuming that the first row of the given grading is the grading under Kbar
 
@@ -1463,7 +1463,7 @@ Returns a dictionary giving the classes of all parameters (tunable sections)
 in terms of Kbar and the defining classes. Each value gives the divisor
 class of the corresponding section/key in this basis. This information is currently only available for literature models.
 
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> m = literature_model(arxiv_id = "1212.2949", equation = "3.2", model_parameters = Dict("k" => 5))
 Assuming that the first row of the given grading is the grading under Kbar
 

--- a/experimental/FTheoryTools/src/G4Fluxes/auxiliary.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/auxiliary.jl
@@ -620,7 +620,7 @@ computationally expensive. The optional argument `check` can be set to `false`
 to skip these tests.
 
 # Examples
-```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
+```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir))), filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> B3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
 

--- a/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
@@ -33,7 +33,7 @@ hypersurface_equation(h::HypersurfaceModel) = h.hypersurface_equation
 Return the parametrization of the hypersurface
 equation by the model sections.
 
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> h = literature_model(arxiv_id = "1208.2695", equation = "B.5")
 Assuming that the first row of the given grading is the grading under Kbar
 

--- a/experimental/FTheoryTools/src/HypersurfaceModels/methods.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/methods.jl
@@ -37,7 +37,7 @@ trivial sections and do not delete them, say from `explicit_model_sections`
 or `classes_of_model_sections`.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> B2 = projective_space(NormalToricVariety, 2)
 Normal toric variety
 

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -155,7 +155,7 @@ julia> length(singular_loci(w))
 1
 ```
 Similarly, also hypersurface models are supported:
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> h = literature_model(arxiv_id = "1208.2695", equation = "B.5")
 Assuming that the first row of the given grading is the grading under Kbar
 
@@ -704,7 +704,7 @@ end
 
 Displays all literature models that satisfy the model_fields criteria. The fields currently supported are those occurring in index.json.
 
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> display_all_literature_models(Dict("gauge_algebra" => ["u(1)", "su(2)", "su(3)"]))
 Model 33:
 Dict{String, Any}("journal_section" => "3", "arxiv_page" => "67", "arxiv_id" => "1408.4808", "gauge_algebra" => Any["su(3)", "su(2)", "u(1)"], "arxiv_version" => "2", "journal_equation" => "3.141", "journal_page" => "67", "arxiv_equation" => "3.142", "journal_doi" => "10.1007/JHEP01(2015)142", "arxiv_section" => "3", "journal" => "JHEP", "file" => "model1408_4808-11-WSF.json", "arxiv_doi" => "10.48550/arXiv.1408.4808", "model_index" => "33", "type" => "weierstrass")

--- a/experimental/FTheoryTools/src/TateModels/methods.jl
+++ b/experimental/FTheoryTools/src/TateModels/methods.jl
@@ -87,7 +87,7 @@ trivial sections and do not delete them, say from `explicit_model_sections`
 or `classes_of_model_sections`.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> B3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
 

--- a/experimental/LieAlgebras/src/SSLieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/SSLieAlgebraModule.jl
@@ -200,7 +200,7 @@ or its root system.
 This function uses an optimized version of the Freudenthal formula, see [MP82](@cite) for details.
 
 # Examples
-```jldoctest
+```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
 julia> L = lie_algebra(QQ, :A, 3);
 
 julia> dominant_character(L, [2, 1, 0])
@@ -211,7 +211,7 @@ Dict{WeightLatticeElem, Int64} with 4 entries:
   2*w_1 + w_2 => 1
 ```
 
-```jldoctest
+```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
 julia> R = root_system(:B, 3);
 
 julia> dominant_character(R, 2 * fundamental_weight(R, 1) + fundamental_weight(R, 3))
@@ -336,7 +336,7 @@ or its root system.
 This is achieved by acting with the Weyl group on the [`dominant_character`](@ref dominant_character(::LieAlgebra, ::WeightLatticeElem)).
 
 # Examples
-```jldoctest
+```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
 julia> L = lie_algebra(QQ, :A, 3);
 
 julia> character(L, [2, 0, 0])
@@ -353,7 +353,7 @@ Dict{WeightLatticeElem, Int64} with 10 entries:
   -w_2             => 1
 ```
 
-```jldoctest
+```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
 julia> R = root_system(:B, 3);
 
 julia> character(R, fundamental_weight(R, 3))
@@ -427,7 +427,7 @@ This function uses Klimyk's formula (see [Hum72; Exercise 24.9](@cite)).
 The return type may change in the future.
 
 # Examples
-```jldoctest
+```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
 julia> L = lie_algebra(QQ, :A, 2);
 
 julia> tensor_product_decomposition(L, [1, 0], [0, 1])
@@ -444,7 +444,7 @@ MSet{Vector{Int64}} with 6 elements:
   [0, 3]
 ```
 
-```jldoctest
+```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
 julia> R = root_system(:B, 2);
 
 julia> tensor_product_decomposition(R, fundamental_weight(R, 1), fundamental_weight(R, 2))
@@ -563,7 +563,7 @@ where $P$ denotes the additive group of the weight lattice.
 If a single weight lattice element `w` is supplied, this is interpreted as `Dict(w => 1)`.
 
 # Examples
-```jldoctest
+```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
 julia> R = root_system(:A, 3);
 
 julia> pos_r = positive_root(R, 4)
@@ -622,7 +622,7 @@ For Demazure characters of generalized flag manifolds, as in [PS09](@cite),
 see [`demazure_character(::AbstractVector, ::PermGroupElem)`](@ref).
 
 # Examples
-```jldoctest
+```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
 julia> L = lie_algebra(QQ, :A, 2);
 
 julia> demazure_character(L, [1, 1], [2, 1])
@@ -634,7 +634,7 @@ Dict{WeightLatticeElem, Int64} with 5 entries:
   -2*w_1 + w_2 => 1
 ```
 
-```jldoctest
+```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
 julia> R = root_system(:B, 3);
 
 julia> demazure_character(R, fundamental_weight(R, 2), weyl_group(R)([1, 2, 3]))

--- a/experimental/LieAlgebras/src/SSLieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/SSLieAlgebraModule.jl
@@ -200,7 +200,7 @@ or its root system.
 This function uses an optimized version of the Freudenthal formula, see [MP82](@cite) for details.
 
 # Examples
-```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> L = lie_algebra(QQ, :A, 3);
 
 julia> dominant_character(L, [2, 1, 0])
@@ -211,7 +211,7 @@ Dict{WeightLatticeElem, Int64} with 4 entries:
   2*w_1 + w_2 => 1
 ```
 
-```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> R = root_system(:B, 3);
 
 julia> dominant_character(R, 2 * fundamental_weight(R, 1) + fundamental_weight(R, 3))
@@ -336,7 +336,7 @@ or its root system.
 This is achieved by acting with the Weyl group on the [`dominant_character`](@ref dominant_character(::LieAlgebra, ::WeightLatticeElem)).
 
 # Examples
-```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> L = lie_algebra(QQ, :A, 3);
 
 julia> character(L, [2, 0, 0])
@@ -353,7 +353,7 @@ Dict{WeightLatticeElem, Int64} with 10 entries:
   -w_2             => 1
 ```
 
-```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> R = root_system(:B, 3);
 
 julia> character(R, fundamental_weight(R, 3))
@@ -427,7 +427,7 @@ This function uses Klimyk's formula (see [Hum72; Exercise 24.9](@cite)).
 The return type may change in the future.
 
 # Examples
-```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> L = lie_algebra(QQ, :A, 2);
 
 julia> tensor_product_decomposition(L, [1, 0], [0, 1])
@@ -444,7 +444,7 @@ MSet{Vector{Int64}} with 6 elements:
   [0, 3]
 ```
 
-```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> R = root_system(:B, 2);
 
 julia> tensor_product_decomposition(R, fundamental_weight(R, 1), fundamental_weight(R, 2))
@@ -563,7 +563,7 @@ where $P$ denotes the additive group of the weight lattice.
 If a single weight lattice element `w` is supplied, this is interpreted as `Dict(w => 1)`.
 
 # Examples
-```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> R = root_system(:A, 3);
 
 julia> pos_r = positive_root(R, 4)
@@ -622,7 +622,7 @@ For Demazure characters of generalized flag manifolds, as in [PS09](@cite),
 see [`demazure_character(::AbstractVector, ::PermGroupElem)`](@ref).
 
 # Examples
-```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> L = lie_algebra(QQ, :A, 2);
 
 julia> demazure_character(L, [1, 1], [2, 1])
@@ -634,7 +634,7 @@ Dict{WeightLatticeElem, Int64} with 5 entries:
   -2*w_1 + w_2 => 1
 ```
 
-```jldoctest; filter = :(Oscar.doctestfilter_hash_changes_in_1_13())
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> R = root_system(:B, 3);
 
 julia> demazure_character(R, fundamental_weight(R, 2), weyl_group(R)([1, 2, 3]))

--- a/experimental/SetPartitions/src/LinearPartition.jl
+++ b/experimental/SetPartitions/src/LinearPartition.jl
@@ -170,7 +170,7 @@ end
 Return the tensor product of `p` and `q`.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> S, d = polynomial_ring(QQ, :d)
 (Univariate polynomial ring in d over QQ, d)
 

--- a/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/special_attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/special_attributes.jl
@@ -102,7 +102,7 @@ ring to monomials in the Cox ring. This dictionary involves
 a choice, i.e. is not unique.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> p2 = projective_space(NormalToricVariety, 2);
 
 julia> map_gens_of_chow_ring_to_cox_ring(p2)

--- a/src/Combinatorics/SimplicialComplexes.jl
+++ b/src/Combinatorics/SimplicialComplexes.jl
@@ -38,7 +38,7 @@ Abstract simplicial complex of dimension -1 on 0 vertices
 ```
 
 The original vertices can be recovered:
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> L = simplicial_complex([[0,2,17],[2,17,90]]);
 
 julia> facets(L)
@@ -248,7 +248,7 @@ cohomology(K::SimplicialComplex, i::Int) = _convert_finitely_generated_abelian_g
 Return the minimal non-faces of the abstract simplicial complex `K`.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> K = simplicial_complex([[1,2,3],[2,3,4]]);
 
 julia> minimal_nonfaces(K)
@@ -620,7 +620,7 @@ end
 Remove the given face and all the faces containing it from an abstract simplicial complex `K`.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> K = simplicial_complex([[1, 2, 3], [2, 3, 4]]);
 
 julia> K_with_deletion = deletion(K, Set([1, 2]));
@@ -676,7 +676,7 @@ Given a simplicial complex `K` return the simplicial complex corresponding
 to a permutation on it's vertices given by `g`.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> K = simplicial_complex([[1, 2, 3], [2, 3, 4]])
 Abstract simplicial complex of dimension 2 on 4 vertices
 
@@ -704,7 +704,7 @@ end
 Given simplicial complexes `K1` and `K2` return their simplicial product.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> K1 = simplicial_complex([[1, 2], [2, 3]])
 Abstract simplicial complex of dimension 1 on 3 vertices
 
@@ -754,7 +754,7 @@ end
 Given simplicial complex `K` returns its barycentric subdivision.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> K = simplicial_complex([[1, 2, 3]])
 Abstract simplicial complex of dimension 2 on 3 vertices
 

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -155,7 +155,7 @@ of `set`, and then turning the result into a sorted vector/tuple or a set,
 respectively.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> g = symmetric_group(3);  g[1]
 (1,2,3)
 

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -938,7 +938,7 @@ Here, the action on `Omega` must be transitive.
 An exception is thrown if this action is not transitive.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> Omega = gset(sylow_subgroup(symmetric_group(4), 2)[1])
 G-set of
   permutation group of degree 4 and order 8
@@ -971,7 +971,7 @@ Here, the action on `Omega` must be transitive.
 An exception is thrown if this action is not transitive.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> Omega = gset(transitive_group(8, 2))
 G-set of
   permutation group of degree 8
@@ -1004,7 +1004,7 @@ Here, the action on `Omega` must be transitive.
 An exception is thrown if this action is not transitive.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> Omega = gset(transitive_group(8, 2))
 G-set of
   permutation group of degree 8
@@ -1037,7 +1037,7 @@ Here, the action on `Omega` must be transitive.
 An exception is thrown if this action is not transitive.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> Omega = gset(transitive_group(8, 2))
 G-set of
   permutation group of degree 8

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -873,7 +873,7 @@ is_simplicial(PF::_FanLikeType) = pm_object(PF).SIMPLICIAL::Bool
 Return the primitive collections of a polyhedral fan.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> primitive_collections(normal_fan(simplex(3)))
 1-element Vector{Set{Int64}}:
  Set([4, 2, 3, 1])

--- a/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/standard_constructions.jl
@@ -334,7 +334,7 @@ arrangement_polynomial(...  ; hyperplanes=:in_cols)
 ```
 
 # Example using standard ring and then custom ring.
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> A = matrix(QQ,[1 2 5//2; 0 0 1; 2 3 2; 1//2 3 5; 3 1 2; 7 8 1])
 [   1   2   5//2]
 [   0   0      1]
@@ -354,7 +354,7 @@ julia> factor(arrangement_polynomial(R, A))
 ```
 
 To use the columns instead, proceed in the following way:
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> A = matrix(QQ,[1 0 2 1//2 3 7;2 0 3 3 1 8;5//2 1 2 5 2 1]);
 
 julia> factor(arrangement_polynomial(A; hyperplanes=:in_cols))

--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -136,7 +136,7 @@ number_of_columns(A::Polymake.Matrix) = Polymake.ncols(A)
 Return the indices where the `n`-th row of `i` is `true`, as a `Set{Int}`.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> IM = incidence_matrix([[1,2,3],[4,5,6]])
 2×6 IncidenceMatrix
  [1, 2, 3]

--- a/src/Rings/AbelianClosure.jl
+++ b/src/Rings/AbelianClosure.jl
@@ -106,7 +106,7 @@ sparse representation. Depending on the application this can be much faster
 or slower.
 
 # Examples
-```jldoctest; setup = :(using Oscar)
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> K, z = abelian_closure(QQ);
 
 julia> z(36)

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -1522,7 +1522,7 @@ end
 Given an element `f` of a graded affine algebra, return the homogeneous components of `f`.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> R, (x, y, z) = graded_polynomial_ring(QQ, [:x, :y, :z]);
 
 julia> A, p = quo(R, ideal(R, [y-x, z^3-x^3]));

--- a/src/Rings/mpoly-affine-algebras.jl
+++ b/src/Rings/mpoly-affine-algebras.jl
@@ -258,7 +258,7 @@ See also `hilbert_series_reduced`.
     ignored for certain backends.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> R, (w, x, y, z) = graded_polynomial_ring(QQ, [:w, :x, :y, :z]);
 
 julia> A, _ = quo(R, ideal(R, [w*y-x^2, w*z-x*y, x*z-y^2]));
@@ -302,7 +302,7 @@ $A$ as a rational function written in lowest terms.
 See also `hilbert_series`.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> R, (w, x, y, z) = graded_polynomial_ring(QQ, [:w, :x, :y, :z]);
 
 julia> A, _ = quo(R, ideal(R, [w*y-x^2, w*z-x*y, x*z-y^2]));
@@ -525,7 +525,7 @@ Return the Hilbert series of the graded affine algebra `A`.
     see the code for details.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> W = [1 1 1; 0 0 -1];
 
 julia> R, x = graded_polynomial_ring(QQ, :x => 1:3, W)

--- a/src/Rings/solving.jl
+++ b/src/Rings/solving.jl
@@ -78,7 +78,7 @@ is greater than zero an empty array is returned.
 - `precision::Int=32`: bit precision for the computed solutions.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> R,(x1,x2,x3) = polynomial_ring(QQ, [:x1,:x2,:x3])
 (Multivariate polynomial ring in 3 variables over QQ, QQMPolyRingElem[x1, x2, x3])
 
@@ -136,7 +136,7 @@ end
 Given a zero-dimensional ideal, return all rational elements of the vanishing
 set.
 
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> R, (x1,x2,x3) = polynomial_ring(QQ, [:x1,:x2,:x3]);
 
 julia> I = ideal(R, [x1+2*x2+2*x3-1, x1^2+2*x2^2+2*x3^2-x1, 2*x1*x2+2*x2*x3-x2]);

--- a/src/TropicalGeometry/variety.jl
+++ b/src/TropicalGeometry/variety.jl
@@ -330,7 +330,7 @@ Internal function for computing zero-dimensional tropical varieties over p-adic 
 finite precision Eigenvalue computation.  Assumes without test that `I` is zero-dimensional.
 
 # Examples
-```jldoctest
+```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> R,(x1,x2,x3) = polynomial_ring(QQ,3);
 
 julia> I = ideal([28*x3^2 - 1*x3 - 1,

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -30,6 +30,18 @@ function doctestfilters()
   ]
 end
 
+# https://github.com/JuliaLang/julia/pull/57509 changed hashing for many base types.
+# We thus filter doctestoutputs that show Sets, Dicts, etc. for julia versions with
+# this change to still have the doctests passing.
+function doctestfilter_hash_changes_in_1_13()
+  if VERSION >= v"1.13.0-DEV.570"
+    # The filter in place here checks that the number of lines in the output matches the input.
+    [r".*"]
+  else
+    return []
+  end
+end
+
 # use tempdir by default to ensure a clean manifest (and avoid modifying the project)
 function doc_init(;path=mktempdir())
   global docsproject = path


### PR DESCRIPTION
Progress towards https://github.com/oscar-system/Oscar.jl/issues/4882 by filtering failing doctests.

This currently just applies to a very limited set of doctests with dicts as I first want to figure out how to get this working, before copying it around.

@benlorenz is this what you meant?