### PR TITLE
Use inplace operators in `map_word`

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -2291,6 +2291,7 @@ function map_word(v::Union{Vector{Int}, Vector{Pair{Int, Int}}, Vector{Any}}, ge
     @req length(genimgs) != 0 "no `init` given in `map_word` without generators"
     return one(genimgs[1])
   end
+  @assert length(genimgs) !== 0
   res = init !== nothing ? deepcopy(init) : one(genimgs[1])
   for i in v
     res = mul!(res, _map_word_syllable(i, genimgs, genimgs_inv))
@@ -2308,6 +2309,7 @@ function map_word(v::Union{Vector{Int}, Vector{Pair{Int, Int}}, Vector{Any}}, ge
     @req length(genimgs) != 0 "no `init` given in `map_word` without generators"
     return zero(parent(genimgs[1]))
   end
+  @assert length(genimgs) !== 0
   res = init !== nothing ? deepcopy(init) : zero(parent(genimgs[1]))
   for i in v
     res = add!(res, _map_word_syllable_additive(i, genimgs, genimgs_inv))

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -2321,8 +2321,7 @@ function _map_word_syllable(vi::Int, genimgs::Vector, genimgs_inv::Vector)
   vi = -vi
   @assert vi <= length(genimgs)
   isassigned(genimgs_inv, vi) && return genimgs_inv[vi]
-  genimgs_inv[vi] = one(genimgs[1])
-  genimgs_inv[vi] = inv!(genimgs_inv[vi], genimgs[vi])
+  genimgs_inv[vi] = inv(genimgs[vi])
   return genimgs_inv[vi]
 end
 
@@ -2331,13 +2330,11 @@ function _map_word_syllable(vi::Pair{Int, Int}, genimgs::Vector, genimgs_inv::Ve
   @assert (x > 0 && x <= length(genimgs))
   e = vi[2]
   e == 1 && return genimgs[x]
-  res = one(genimgs[1])
-  e > 1 && return pow!(res, genimgs[x], e)
+  e > 1 && return pow(genimgs[x], e)
   isassigned(genimgs_inv, x) && return pow!(res, genimgs_inv[x], -e)
-  genimgs_inv[x] = one(genimgs[1])
-  genimgs_inv[x] = inv!(genimgs_inv[x], genimgs[x])
+  genimgs_inv[x] = inv(genimgs[x])
   e == -1 && return genimgs_inv[x]
-  return pow!(res, genimgs_inv[x], -e)
+  return pow(genimgs_inv[x], -e)
 end
 
 

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -2341,10 +2341,8 @@ function _map_word_syllable_additive(vi::Int, genimgs::Vector, genimgs_inv::Vect
   vi > 0 && (@assert vi <= length(genimgs); return genimgs[vi])
   vi = -vi
   @assert vi <= length(genimgs)
-  isassigned(genimgs_inv, vi) && return genimgs_inv[vi]
-  res = -genimgs[vi]
-  genimgs_inv[vi] = res
-  return res
+  isassigned(genimgs_inv, vi) || genimgs_inv[vi] = -genimgs[vi]
+  return genimgs_inv[vi]
 end
 
 function _map_word_syllable_additive(vi::Pair{Int, Int}, genimgs::Vector, genimgs_inv::Vector)
@@ -2353,11 +2351,9 @@ function _map_word_syllable_additive(vi::Pair{Int, Int}, genimgs::Vector, genimg
   e = vi[2]
   e > 1 && return e * genimgs[x]
   e == 1 && return genimgs[x]
-  isassigned(genimgs_inv, x) && return (-e) * genimgs_inv[x]
-  res = -genimgs[x]
-  genimgs_inv[x] = res
-  e == -1 && return res
-  return (-e) * res
+  isassigned(genimgs_inv, x) || genimgs_inv[x] =  -genimgs[x]
+  e == -1 && return genimgs_inv[x]
+  return (-e) * genimgs_inv[x]
 end
 
 

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -2320,8 +2320,7 @@ function _map_word_syllable(vi::Int, genimgs::Vector, genimgs_inv::Vector)
   vi > 0 && (@assert vi <= length(genimgs); return genimgs[vi])
   vi = -vi
   @assert vi <= length(genimgs)
-  isassigned(genimgs_inv, vi) && return genimgs_inv[vi]
-  genimgs_inv[vi] = inv(genimgs[vi])
+  isassigned(genimgs_inv, vi) || (genimgs_inv[vi] = inv(genimgs[vi]))
   return genimgs_inv[vi]
 end
 
@@ -2331,7 +2330,7 @@ function _map_word_syllable(vi::Pair{Int, Int}, genimgs::Vector, genimgs_inv::Ve
   e = vi[2]
   e == 1 && return genimgs[x]
   e > 1 && return genimgs[x] ^ e
-  isassigned(genimgs_inv, x) || genimgs_inv[x] = inv(genimgs[x])
+  isassigned(genimgs_inv, x) || (genimgs_inv[x] = inv(genimgs[x]))
   e == -1 && return genimgs_inv[x]
   return genimgs_inv[x] ^ -e
 end
@@ -2341,7 +2340,7 @@ function _map_word_syllable_additive(vi::Int, genimgs::Vector, genimgs_inv::Vect
   vi > 0 && (@assert vi <= length(genimgs); return genimgs[vi])
   vi = -vi
   @assert vi <= length(genimgs)
-  isassigned(genimgs_inv, vi) || genimgs_inv[vi] = -genimgs[vi]
+  isassigned(genimgs_inv, vi) || (genimgs_inv[vi] = -genimgs[vi])
   return genimgs_inv[vi]
 end
 
@@ -2351,7 +2350,7 @@ function _map_word_syllable_additive(vi::Pair{Int, Int}, genimgs::Vector, genimg
   e = vi[2]
   e > 1 && return e * genimgs[x]
   e == 1 && return genimgs[x]
-  isassigned(genimgs_inv, x) || genimgs_inv[x] =  -genimgs[x]
+  isassigned(genimgs_inv, x) || (genimgs_inv[x] =  -genimgs[x])
   e == -1 && return genimgs_inv[x]
   return (-e) * genimgs_inv[x]
 end

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -2291,7 +2291,7 @@ function map_word(v::Union{Vector{Int}, Vector{Pair{Int, Int}}, Vector{Any}}, ge
     @req length(genimgs) != 0 "no `init` given in `map_word` without generators"
     return one(genimgs[1])
   end
-  res = init !== nothing ? init : one(genimgs[1])
+  res = init !== nothing ? deepcopy(init) : one(genimgs[1])
   for i in v
     res = mul!(res, _map_word_syllable(i, genimgs, genimgs_inv))
   end
@@ -2308,7 +2308,7 @@ function map_word(v::Union{Vector{Int}, Vector{Pair{Int, Int}}, Vector{Any}}, ge
     @req length(genimgs) != 0 "no `init` given in `map_word` without generators"
     return zero(parent(genimgs[1]))
   end
-  res = init !== nothing ? init : zero(parent(genimgs[1]))
+  res = init !== nothing ? deepcopy(init) : zero(parent(genimgs[1]))
   for i in v
     res = add!(res, _map_word_syllable_additive(i, genimgs, genimgs_inv))
   end

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -2293,7 +2293,7 @@ function map_word(v::Union{Vector{Int}, Vector{Pair{Int, Int}}, Vector{Any}}, ge
   end
   res = init !== nothing ? init : one(genimgs[1])
   for i in v
-    res *= _map_word_syllable(i, genimgs, genimgs_inv)
+    res = mul!(res, _map_word_syllable(i, genimgs, genimgs_inv))
   end
   return res
 end
@@ -2310,7 +2310,7 @@ function map_word(v::Union{Vector{Int}, Vector{Pair{Int, Int}}, Vector{Any}}, ge
   end
   res = init !== nothing ? init : zero(parent(genimgs[1]))
   for i in v
-    res += _map_word_syllable_additive(i, genimgs, genimgs_inv)
+    res = add!(res, _map_word_syllable_additive(i, genimgs, genimgs_inv))
   end
   return res
 end

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -2330,11 +2330,10 @@ function _map_word_syllable(vi::Pair{Int, Int}, genimgs::Vector, genimgs_inv::Ve
   @assert (x > 0 && x <= length(genimgs))
   e = vi[2]
   e == 1 && return genimgs[x]
-  e > 1 && return pow(genimgs[x], e)
-  isassigned(genimgs_inv, x) && return pow!(res, genimgs_inv[x], -e)
-  genimgs_inv[x] = inv(genimgs[x])
+  e > 1 && return genimgs[x] ^ e
+  isassigned(genimgs_inv, x) || genimgs_inv[x] = inv(genimgs[x])
   e == -1 && return genimgs_inv[x]
-  return pow(genimgs_inv[x], -e)
+  return genimgs_inv[x] ^ -e
 end
 
 

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -2321,22 +2321,23 @@ function _map_word_syllable(vi::Int, genimgs::Vector, genimgs_inv::Vector)
   vi = -vi
   @assert vi <= length(genimgs)
   isassigned(genimgs_inv, vi) && return genimgs_inv[vi]
-  res = inv(genimgs[vi])
-  genimgs_inv[vi] = res
-  return res
+  genimgs_inv[vi] = one(genimgs[1])
+  genimgs_inv[vi] = inv!(genimgs_inv[vi], genimgs[vi])
+  return genimgs_inv[vi]
 end
 
 function _map_word_syllable(vi::Pair{Int, Int}, genimgs::Vector, genimgs_inv::Vector)
   x = vi[1]
   @assert (x > 0 && x <= length(genimgs))
   e = vi[2]
-  e > 1 && return genimgs[x]^e
   e == 1 && return genimgs[x]
-  isassigned(genimgs_inv, x) && return genimgs_inv[x]^-e
-  res = inv(genimgs[x])
-  genimgs_inv[x] = res
-  e == -1 && return res
-  return res^-e
+  res = one(genimgs[1])
+  e > 1 && return pow!(res, genimgs[x], e)
+  isassigned(genimgs_inv, x) && return pow!(res, genimgs_inv[x], -e)
+  genimgs_inv[x] = one(genimgs[1])
+  genimgs_inv[x] = inv!(genimgs_inv[x], genimgs[x])
+  e == -1 && return genimgs_inv[x]
+  return pow!(res, genimgs_inv[x], -e)
 end
 
 

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -2291,7 +2291,7 @@ function map_word(v::Union{Vector{Int}, Vector{Pair{Int, Int}}, Vector{Any}}, ge
     @req length(genimgs) != 0 "no `init` given in `map_word` without generators"
     return one(genimgs[1])
   end
-  res = init !== nothing? init : one(genimgs[1])
+  res = init !== nothing ? init : one(genimgs[1])
   for i in v
     res *= _map_word_syllable(i, genimgs, genimgs_inv)
   end
@@ -2308,7 +2308,7 @@ function map_word(v::Union{Vector{Int}, Vector{Pair{Int, Int}}, Vector{Any}}, ge
     @req length(genimgs) != 0 "no `init` given in `map_word` without generators"
     return zero(parent(genimgs[1]))
   end
-  res = init !== nothing? init : zero(parent(genimgs[1]))
+  res = init !== nothing ? init : zero(parent(genimgs[1]))
   for i in v
     res += _map_word_syllable_additive(i, genimgs, genimgs_inv)
   end

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -2291,9 +2291,9 @@ function map_word(v::Union{Vector{Int}, Vector{Pair{Int, Int}}, Vector{Any}}, ge
     @req length(genimgs) != 0 "no `init` given in `map_word` without generators"
     return one(genimgs[1])
   end
-  res = prod(i -> _map_word_syllable(i, genimgs, genimgs_inv), v)
-  if init !== nothing
-    res = init * res
+  res = init !== nothing? init : one(genimgs[1])
+  for i in v
+    res *= _map_word_syllable(i, genimgs, genimgs_inv)
   end
   return res
 end
@@ -2308,9 +2308,9 @@ function map_word(v::Union{Vector{Int}, Vector{Pair{Int, Int}}, Vector{Any}}, ge
     @req length(genimgs) != 0 "no `init` given in `map_word` without generators"
     return zero(parent(genimgs[1]))
   end
-  res = sum(i -> _map_word_syllable_additive(i, genimgs, genimgs_inv), v)
-  if init !== nothing
-    res = init + res
+  res = init !== nothing? init : zero(parent(genimgs[1]))
+  for i in v
+    res += _map_word_syllable_additive(i, genimgs, genimgs_inv)
   end
   return res
 end


### PR DESCRIPTION
Closes #4880 

So far a use of `prod` and `sum` have been converted to use inplace operators in a loop.

I think more optimization can be done with `map_word_syllable` but it seems we want to cache the inverse values and save them in `genimgs_inv` so I'm not really sure how to dodge around making an allocation for this. Any advice is helpful.