### PR TITLE
Clean up evaluation of `FracFieldElem`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ lib4ti2_jll = "1493ae25-0f90-5c0e-a06c-8c5077d6d66f"
 GAP_lib_jll = "c863536a-3901-11e9-33e7-d5cd0df7b904"
 
 [compat]
-AbstractAlgebra = "0.45.0"
+AbstractAlgebra = "0.45.1"
 AlgebraicSolving = "0.9.0"
 Compat = "4.13.0"
 Distributed = "1.6"

--- a/src/Misc/MoveToAbstractAlgebra.jl
+++ b/src/Misc/MoveToAbstractAlgebra.jl
@@ -11,10 +11,6 @@ function Base.copy(f::MPolyRingElem)
   return finish(g)
 end
 
-function (a::Generic.RationalFunctionFieldElem)(b::RingElem)
-  return divexact(numerator(a)(b), denominator(a)(b))
-end
-
 ########################################################################
 # Part of PR #4706
 function is_equal_as_morphism(f::Map, g::Map)
@@ -25,11 +21,3 @@ function is_equal_as_morphism(f::Map, g::Map)
 end
 # end of changes in PR #4706
 ########################################################################
-
-function evaluate(f::AbstractAlgebra.Generic.FracFieldElem{<:MPolyRingElem}, a::Vector{T}) where {T<:RingElem}
-  return evaluate(numerator(f), a)//evaluate(denominator(f), a)
-end
-
-function evaluate(f::AbstractAlgebra.Generic.FracFieldElem{<:PolyRingElem}, a::RingElem)
-  return evaluate(numerator(f), a)//evaluate(denominator(f), a)
-end


### PR DESCRIPTION
This code should be obsolete, in particular after https://github.com/Nemocas/AbstractAlgebra.jl/pull/2090 is merged. 

This should bump the compat to an AA version that contains https://github.com/Nemocas/AbstractAlgebra.jl/pull/2090.