### PR TITLE
Tensor product cleanup

### DIFF
--- a/experimental/DoubleAndHyperComplexes/src/Objects/eagon_northcott_complex.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/eagon_northcott_complex.jl
@@ -27,7 +27,7 @@ function (fac::ENCChainFactory)(self::AbsHyperComplex, I::Tuple)
   if is_zero(i)
     return is_graded(R) ? graded_free_module(R, [zero(grading_group(R))]) : FreeMod(R, 1)
   end
-  Sd = is_graded(R) ? graded_free_module(R, [zero(grading_group(R)) for _ in 1:length(fac.exps[i])]) : FreeMod(R, length(fac.exps[i]))
+  Sd = is_graded(R) ? graded_free_module(R, [zero(grading_group(R)) for _ in 1:length(fac.exps[i])], "s") : FreeMod(R, length(fac.exps[i]), "s")
   n = ncols(fac.A)
   k = nrows(fac.A)
   wedge_power, _ = exterior_power(fac.F, k + i - 1)
@@ -146,7 +146,7 @@ function eagon_northcott_complex(
     A::MatrixElem{T};
     F::FreeMod{T}=begin
       R = base_ring(A)
-      F = is_graded(R) ? graded_free_module(R, [zero(grading_group(R)) for _ in 1:ncols(A)]) : FreeMod(R, ncols(A))
+      F = is_graded(R) ? graded_free_module(R, [zero(grading_group(R)) for _ in 1:ncols(A)], "f") : FreeMod(R, ncols(A), "f")
     end
   ) where {T}
   return EagonNorthcottComplex(A; F)

--- a/experimental/DoubleAndHyperComplexes/src/Objects/new_koszul_complexes.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/new_koszul_complexes.jl
@@ -49,7 +49,7 @@ function (fac::HomogKoszulComplexMapFactory)(self::AbsHyperComplex, p::Int, I::T
   cfac = chain_factory(self)
   n = length(cfac.seq)
   dom = self[I]
-  cod = self[i+1]
+  cod = self[i-1]
   img_gens = elem_type(cod)[]
   for omi in combinations(n, i)
     img = zero(cod)
@@ -67,7 +67,7 @@ end
 
 function can_compute(fac::HomogKoszulComplexMapFactory, self::AbsHyperComplex, p::Int, i::Tuple)
   isone(p) || return false
-  return 0 <= first(i) < length(chain_factory(self).seq)
+  return 0 < first(i) <= length(chain_factory(self).seq)
 end
 
 ### The concrete struct

--- a/experimental/DoubleAndHyperComplexes/src/Objects/new_koszul_complexes.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Objects/new_koszul_complexes.jl
@@ -29,7 +29,7 @@ function (fac::HomogKoszulComplexChainFactory)(self::AbsHyperComplex, I::Tuple)
   G = grading_group(fac.S)
   is_zero(i) && return graded_free_module(fac.S, [zero(G)])
   n = length(fac.seq)
-  degs = elem_type(G)[-sum(fac.degs[data(omi)]; init=zero(G)) for omi in combinations(n, i)]
+  degs = elem_type(G)[sum(fac.degs[data(omi)]; init=zero(G)) for omi in combinations(n, i)]
   result = graded_free_module(fac.S, degs)
 end
 
@@ -51,14 +51,14 @@ function (fac::HomogKoszulComplexMapFactory)(self::AbsHyperComplex, p::Int, I::T
   dom = self[I]
   cod = self[i+1]
   img_gens = elem_type(cod)[]
-  inds = [Combination([k]) for k in 1:n]
   for omi in combinations(n, i)
     img = zero(cod)
-    for (m, v) in zip(inds, cfac.seq)
-      sign, mult_ind = _wedge(omi, m)
-      is_zero(sign) && continue
-      res_ind = Oscar.linear_index(mult_ind, n)
-      img += sign*v*cod[res_ind]
+    inds = data(omi)::Vector{Int}
+    sign = 1
+    for (k, i) in enumerate(inds)
+      truncated_idx = vcat(inds[1:k-1], inds[k+1:end])
+      img += sign*cfac.seq[i]*cod[linear_index(Combination(truncated_idx), n)]
+      sign *= -1
     end
     push!(img_gens, img)
   end

--- a/experimental/DoubleAndHyperComplexes/test/koszul_complexes.jl
+++ b/experimental/DoubleAndHyperComplexes/test/koszul_complexes.jl
@@ -55,7 +55,9 @@ end
   kosz = Oscar.HomogKoszulComplex(R, [x, y])
   @test [ngens(kosz[i]) for i in 0:2] == [1, 2, 1]
   G = grading_group(R)
-  @test [degrees_of_generators(kosz[i]) for i in 0:2] == [[zero(G)], [-G[1], -G[1]], [-2*G[1]]]
-  [map(kosz, i) for i in 0:1]
+  @test [degrees_of_generators(kosz[i]) for i in 0:2] == [[zero(G)], [G[1], G[1]], [2*G[1]]]
+  @test !is_zero(map(kosz, 2))
+  @test !is_zero(map(kosz, 1))
+  @test is_zero(compose(map(kosz, 2), map(kosz, 1)))
 end
 

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -150,7 +150,7 @@ julia> Oscar.linear_index(C, 7)
 ```
 """
 function linear_index(C::Combination, n::IntegerUnion)
-  @req C[end] <= n "Combination must be bounded by n"
+  @req is_empty(C) || C[end] <= n "Combination must be bounded by n"
   k = length(C)
   iszero(k) && return 1
   isone(k) && return Int(C[1])

--- a/src/Modules/UngradedModules/Tensor.jl
+++ b/src/Modules/UngradedModules/Tensor.jl
@@ -144,7 +144,10 @@ function tensor_product(G::ModuleFP...; task::Symbol = :none)
   end
   
   decompose_generator = function(v::SubquoModuleElem)
-    w = canonical_projection(tot[0], 1)(preimage(pr_res, v))
+    ind = findfirst(==(v), images_of_generators(pr_res))
+    isnothing(ind) && error("the given element is not the image of a generator under the projection map")
+    vv = gen(tot[0], ind::Int)
+    w = canonical_projection(tot[0], 1)(vv)
     w_dec = tensor_generator_decompose_function(res_prod[z])(w)
     return Tuple([augs[i](x) for (i, x) in enumerate(w_dec)])
   end


### PR DESCRIPTION
There was a silent assumtion on the `preimage` functionality for projection maps made in the fix for tensor products. This hopefully "generifies" the code again and fixes up the induced Eagon-Northcott complexes.

Moreover, I straighten out some issues with the "homogeneous Koszul complexes" after the recent switch to `Combinations`. 