### PR TITLE
docs: add more doctest helpers

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, Oscar
 
 include(normpath(joinpath(Oscar.oscardir, "docs", "make_work.jl")))
 
-BuildDoc.doit(Oscar; warnonly=false, local_build=false, doctest=false)
+Base.invokelatest(BuildDoc.doit, Oscar; warnonly=false, local_build=false, doctest=false)
 
 should_push_preview = true
 if get(ENV, "GITHUB_ACTOR", "") == "dependabot[bot]"

--- a/docs/src/DeveloperDocumentation/documentation.md
+++ b/docs/src/DeveloperDocumentation/documentation.md
@@ -52,6 +52,14 @@ them some code that they can copy-paste and manipulate, and, as a bonus,
 provides a testcase as well.
 
 
+The docstrings can be tested separately by function or path name substring; or all at once:
+
+```@docs
+doctest(f::Function; set_meta::Bool = false, doctest = true)
+doctest(path::String; set_meta::Bool = false, doctest = true)
+doctest(; doctest = true)
+```
+
 ## The folder `docs`
 
 The folder `docs/src` contains the OSCAR documentation website. Most of the

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -77,6 +77,7 @@ page: ../src/PolyhedralGeometry/Polyhedron/standard_constructions.jl:202-207
   0.020471 seconds (69.71 k allocations: 1.828 MiB)
 """
 macro doc_init()
+  isdefined(Oscar, :docsproject) && isdefined(Main, :Documenter) && return nothing
   doc_init()
   return :(using Documenter)
 end

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -51,25 +51,46 @@ function doc_init(;path=mktempdir())
   Pkg.activate(docsproject) do
     # we dev all "our" packages with the paths from where they are currently
     # loaded
-    for pkg in [AbstractAlgebra, Nemo, Hecke, Singular, GAP, Polymake]
-      Pkg.develop(path=Base.pkgdir(pkg))
-    end
+    pkglist = [AbstractAlgebra, Nemo, Hecke, Singular, GAP, Polymake]
+    Pkg.develop([PackageSpec(path=Base.pkgdir(pkg)) for pkg in pkglist])
     Pkg.develop(path=oscardir)
     Pkg.instantiate()
     Base.include(Main, joinpath(oscardir, "docs", "make_work.jl"))
   end
+  docsproject in Base.LOAD_PATH || pushfirst!(Base.LOAD_PATH, docsproject)
+  return nothing
 end
 
-function get_document(set_meta::Bool)
+"""
+    @doc_init
+
+Initialize a new temporary project with Documenter and Oscar for doctesting.
+Adds that project to the load path and runs `using Documenter` in the calling module.
+
+# Examples
+```julia
+julia> Oscar.@doc_init
+<...>
+
+julia> Oscar.doctest(cube)
+page: ../src/PolyhedralGeometry/Polyhedron/standard_constructions.jl:202-207
+  0.020471 seconds (69.71 k allocations: 1.828 MiB)
+"""
+macro doc_init()
+  doc_init()
+  return :(using Documenter)
+end
+
+function get_document(set_meta::Bool; doctest=:fix)
   if !isdefined(Main, :Documenter)
-    error("you need to do `using Documenter` first")
+    error("you need to do `using Documenter` or `Oscar.@doc_init` first")
   end
   Documenter = Main.Documenter
   if pkgversion(Documenter) < v"1-"
     error("you need to use Documenter.jl version 1.0.0 or later")
   end
 
-  doc = Documenter.Document(root = joinpath(oscardir, "docs"); doctest = :fix, doctestfilters=Oscar.doctestfilters())
+  doc = Documenter.Document(root = joinpath(oscardir, "docs"); doctest = doctest, doctestfilters=Oscar.doctestfilters())
 
   if Documenter.DocMeta.getdocmeta(Oscar, :DocTestSetup) === nothing || set_meta
     Documenter.DocMeta.setdocmeta!(Oscar, :DocTestSetup, Oscar.doctestsetup(); recursive=true)
@@ -89,9 +110,16 @@ The following call fixes all doctests for the function `symmetric_group`:
 julia> Oscar.doctest_fix(symmetric_group)
 ```
 """
-function doctest_fix(f::Function; set_meta::Bool = false)
+doctest_fix(f::Function; set_meta::Bool = false) = doctest(f; set_meta = set_meta, doctest = :fix)
+
+"""
+    doctest(f::Function; set_meta::Bool = false)
+
+Run all doctests for the given function `f`.
+"""
+function doctest(f::Function; set_meta::Bool = false, doctest = true)
   S = Symbol(f)
-  doc, doctest = get_document(set_meta)
+  doc, doctest = get_document(set_meta; doctest=doctest)
 
   withenv("COLUMNS"=>80, "LINES"=>24) do
     with_unicode(false) do
@@ -119,8 +147,17 @@ called `Rings` (or a subdirectory thereof), so e.g. everything in `src/Rings/`:
 julia> Oscar.doctest_fix("/Rings/")
 ```
 """
-function doctest_fix(path::String; set_meta::Bool=false)
-  doc, doctest = get_document(set_meta)
+doctest_fix(path::String; set_meta::Bool = false) = doctest(path; set_meta = set_meta, doctest = :fix)
+
+
+"""
+    doctest(path::String; set_meta::Bool = false)
+
+Run all doctests for all files in Oscar where
+`path` occurs in the full pathname.
+"""
+function doctest(path::String; set_meta::Bool = false, doctest = true)
+  doc, doctest = get_document(set_meta; doctest = doctest)
 
   withenv("COLUMNS"=>80, "LINES"=>24) do
     with_unicode(false) do
@@ -138,6 +175,13 @@ function doctest_fix(path::String; set_meta::Bool=false)
     end
   end
 end
+
+"""
+    doctest()
+
+Run all doctests for Oscar, calls [`build_doc`](@ref) with `doctest=true`.
+"""
+doctest(; doctest = true) = build_doc(; doctest = doctest, warnonly = false, open_browser = false, start_server = false)
 
 # copied from JuliaTesting/Aqua.jl
 function walkmodules(f, x::Module)


### PR DESCRIPTION
While working on #4912 I noticed that we do have `doctest_fix` for single files and functions but we didn't have a way to just run the doctests for a single function.
So I changed the fix functions to take an argument and created wrappers for the `_fix` variants.

I also added a macro to simplify the `doc_init` call:

Basically one can now do:
```julia
julia> using Oscar
<...>
julia> Oscar.@doc_init
<...>
julia> Oscar.doctest(cube)
page: ../src/PolyhedralGeometry/Polyhedron/standard_constructions.jl:202-207
  0.020471 seconds (69.71 k allocations: 1.828 MiB)
```
The macro adds the temporary docsproject to `Base.LOAD_PATH` and returns `:(using Documenter)` to run this in the REPL.