### PR TITLE
Allow inducing G-sets along group homomorphisms

### DIFF
--- a/docs/src/Groups/action.md
+++ b/docs/src/Groups/action.md
@@ -74,6 +74,7 @@ rank_action(Omega::GSet)
 is_primitive(Omega::GSet)
 is_regular(Omega::GSet)
 is_semiregular(Omega::GSet)
+induce(Omega::GSetByElements{T, S}, phi::GAPGroupHomomorphism{U, T}) where {T<:Group, U<:Group, S}
 ```
 
 ## Block systems of a G-set

--- a/docs/src/Groups/action.md
+++ b/docs/src/Groups/action.md
@@ -43,6 +43,7 @@ on_indeterminates
 on_lines
 on_echelon_form_mats
 on_subgroups
+induced_action(::Function, ::GAPGroupHomomorphism)
 ```
 
 
@@ -75,6 +76,7 @@ is_primitive(Omega::GSet)
 is_regular(Omega::GSet)
 is_semiregular(Omega::GSet)
 induce(Omega::GSetByElements{T, S}, phi::GAPGroupHomomorphism{U, T}) where {T<:Group, U<:Group, S}
+induced_action_function(Omega::GSetByElements{T, S}, phi::GAPGroupHomomorphism{U, T}) where {T<:Group, U<:Group, S}
 ```
 
 ## Block systems of a G-set

--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -329,12 +329,7 @@ function action_homomorphism(Omega::GSetByElements{FinGenAbGroup, S}) where S
   G = codomain(phi)
 
   # Let `G` act on `Omega` as `A` does.
-  phiinv = inv(phi)
-  actfun = action_function(Omega)
-  fun = function(omega::S, g::PermGroupElem)
-    return actfun(omega, phiinv(g))
-  end
-  OmegaG = GSetByElements(G, fun, Omega, closed = true, check = false)
+  OmegaG = induce(Omega, inv(phi))
 
   # Compute the permutation action on `1:length(Omega)`
   # corresponding to the action of `A` on `Omega`.

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -494,6 +494,32 @@ function on_echelon_form_mats(m::MatElem{T}, x::MatrixGroupElem) where T <: FinF
 end
 
 @doc raw"""
+    induced_action(actfun::Function, phi::GAPGroupHomomorphism)
+
+Return the action function that is obtained by inducing `actfun` along `phi`.
+
+That means, given a groups ``G`` and ``H``, a set ``\Omega`` with action function ``f: \Omega \times G \to \Omega``
+and a homomorphism ``\phi: H \to G``, construct the action function
+$\Omega \times H \to \Omega, (\omega, h) \mapsto f(\omega, \phi(h))$.
+"""
+function induced_action(actfun::Function, phi::GAPGroupHomomorphism)
+  return _induced_action(actfun, phi)
+end
+
+# This method is not documented as we need `phi` to be a group homomorphism, but in many cases
+# there is no dedicated type for this (WeylGroup, FinGenAbGroup, etc.).
+# This should be restricted to group homomorphisms once we have a type for them.
+function induced_action(actfun::Function, phi::Map{<:Union{Group,FinGenAbGroup}, <:Union{Group,FinGenAbGroup}})
+  return _induced_action(actfun, phi)
+end
+
+function _induced_action(actfun::Function, phi::Map{<:Union{Group,FinGenAbGroup}, <:Union{Group,FinGenAbGroup}})
+  return function (omega, g)
+    return actfun(omega, phi(g))
+  end
+end
+
+@doc raw"""
     stabilizer(G::GAPGroup, pnt::Any[, actfun::Function])
 
 Return `S, emb` where `S` is the subgroup of `G` that consists of

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -280,7 +280,7 @@ function _induce(Omega::GSetByElements{T, S}, phi::Map{U, T}) where {T<:Union{Gr
   fun = function (omega::S, g)
     return Omega_fun(omega, phi(g))
   end
-  return GSetByElements(domain(phi), fun, Omega.seeds; check=false)
+  return GSetByElements(domain(phi), fun, Omega; closed=true, check=false)
 end
 
 #############################################################################

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -262,6 +262,9 @@ Return the action function of the G-set that is obtained by inducing the G-set `
 That means, given a ``G``-set ``\Omega`` with action function ``f: \Omega \times G \to \Omega``
 and a homomorphism ``\phi: H \to G``, construct the action function
 $\Omega \times H \to \Omega, (\omega, h) \mapsto f(\omega, \phi(h))$.
+
+This function is semantically equivalent to `action_function(induce(Omega, phi))`,
+but it is more efficient as it avoids the construction of the induced G-set.
 """
 function induced_action_function(Omega::GSetByElements{T, S}, phi::GAPGroupHomomorphism{U, T}) where {T<:Group, U<:Group, S}
   return _induced_action_function(Omega, phi)

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -264,6 +264,17 @@ and a homomorphism ``\phi: H \to G``, construct the ``H``-set ``\Omega'`` with a
 $\Omega' \times H \to \Omega', (\omega, h) \mapsto f(\omega, \phi(h))$.
 """
 function induce(Omega::GSetByElements{T, S}, phi::GAPGroupHomomorphism{U, T}) where {T<:Group, U<:Group, S}
+  return _induce(Omega, phi)
+end
+
+# This method is not documented as we need `phi` to be a group homomorphism, but in many cases
+# there is no dedicated type for this (WeylGroup, FinGenAbGroup, etc.).
+# This should be restricted to group homomorphisms once we have a type for them.
+function induce(Omega::GSetByElements{T, S}, phi::Map{U, T}) where {T<:Union{Group,FinGenAbGroup}, U<:Union{Group,FinGenAbGroup}, S}
+  return _induce(Omega, phi)
+end
+
+function _induce(Omega::GSetByElements{T, S}, phi::Map{U, T}) where {T<:Union{Group,FinGenAbGroup}, U<:Union{Group,FinGenAbGroup}, S}
   @req acting_group(Omega) == codomain(phi) "acting group of Omega must be the codomain of phi"
   Omega_fun = action_function(Omega)
   fun = function (omega::S, g)

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -252,6 +252,28 @@ as_gset(G::T, Omega) where T<:Union{GAPGroup,FinGenAbGroup} = as_gset(G, ^, Omeg
 
 #############################################################################
 ##
+##  induce G-sets along homomorphisms
+
+@doc raw"""
+    induce(Omega::GSetByElements{T, S}, phi::GAPGroupHomomorphism{U, T}) where {T<:Group, U<:Group, S}
+
+Return the G-set that is obtained by inducing the G-set `Omega` along `phi`.
+
+That means, given a ``G``-set ``\Omega`` with action function ``f: \Omega \times G \to \Omega``
+and a homomorphism ``\phi: H \to G``, construct the ``H``-set ``\Omega'`` with action function
+$\Omega' \times H \to \Omega', (\omega, h) \mapsto f(\omega, \phi(h))$.
+"""
+function induce(Omega::GSetByElements{T, S}, phi::GAPGroupHomomorphism{U, T}) where {T<:Group, U<:Group, S}
+  @req acting_group(Omega) == codomain(phi) "acting group of Omega must be the codomain of phi"
+  Omega_fun = action_function(Omega)
+  fun = function (omega::S, g)
+    return Omega_fun(omega, phi(g))
+  end
+  return GSetByElements(domain(phi), fun, Omega.seeds; check=false)
+end
+
+#############################################################################
+##
 ##  wrapper objects for elements of G-sets,
 ##  with fields `gset` (the G-set) and `objects` (the unwrapped object)
 ##

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -788,6 +788,8 @@ export index_of_leading_term
 export indicator
 export induce
 export induce_shift
+export induced_action
+export induced_action_function
 export induced_automorphism
 export induced_cyclic
 export induced_map_on_exterior_power

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -587,6 +587,16 @@ end
   Omega = gset(G, permuted, [[1,1,2,3]])
   H = permutation_group(8, [cperm([1,3], [2,4]), cperm([1,5], [2,6], [3,7], [4,8])])
   phi = hom(H, G, [cperm([1,2]), cperm([1,3], [2,4])])
+
+  @test induced_action_function(Omega, phi) == induced_action(action_function(Omega), phi)
+
+  orb = orbit(H, induced_action_function(Omega, phi), [1,1,2,3])
+  @test acting_group(orb) == H
+  @test length(orb) == 4
+  stab = stabilizer(orb)[1]
+  @test order(stab) == 2
+  @test cperm([1,3], [2,4]) in stab
+
   Omega2 = induce(Omega, phi)
   @test acting_group(Omega2) == H
   @test elements(Omega2) == elements(Omega)

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -588,8 +588,10 @@ end
   H = permutation_group(8, [cperm([1,3], [2,4]), cperm([1,5], [2,6], [3,7], [4,8])])
   phi = hom(H, G, [cperm([1,2]), cperm([1,3], [2,4])])
   Omega2 = induce(Omega, phi)
-  @test length(orbits(Omega2)) == 1
-  @test length(only(orbits(Omega2))) == 4
+  @test acting_group(Omega2) == H
+  @test elements(Omega2) == elements(Omega)
+  @test length(orbits(Omega2)) == 2
+  @test issetequal(length.(orbits(Omega2)), [4, 8])
   stab2 = stabilizer(Omega2)[1]
   @test order(stab2) == 2
   @test cperm([1,3], [2,4]) in stab2

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -581,3 +581,16 @@ end
   @test describe(image(acthom)[1]) == "C3"
   @test all(x -> permutation(o, x) == acthom(x), gens(u))
 end
+
+@testset "inducing G-sets" begin
+  G = symmetric_group(4)
+  Omega = gset(G, permuted, [[1,1,2,3]])
+  H = permutation_group(8, [cperm([1,3], [2,4]), cperm([1,5], [2,6], [3,7], [4,8])])
+  phi = hom(H, G, [cperm([1,2]), cperm([1,3], [2,4])])
+  Omega2 = induce(Omega, phi)
+  @test length(orbits(Omega2)) == 1
+  @test length(only(orbits(Omega2))) == 4
+  stab2 = stabilizer(Omega2)[1]
+  @test order(stab2) == 2
+  @test cperm([1,3], [2,4]) in stab2
+end

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -588,6 +588,8 @@ end
   H = permutation_group(8, [cperm([1,3], [2,4]), cperm([1,5], [2,6], [3,7], [4,8])])
   phi = hom(H, G, [cperm([1,2]), cperm([1,3], [2,4])])
 
+  # This check is a bit surprising that it works, but it does.
+  # We just need that the two functions are same as mathematical functions, not as objects.
   @test induced_action_function(Omega, phi) == induced_action(action_function(Omega), phi)
 
   orb = orbit(H, induced_action_function(Omega, phi), [1,1,2,3])


### PR DESCRIPTION
As discussed earlier today with @ThomasBreuer. I tried to align the name and argument order with the methods for `GAPClassFunction` and `GModule`.
Due to not all group types having usable morphism types, I added an undocumented method for general maps between groups, which should get adapted once we have proper group homes.

@jamesnohilly this allows for a similar cleanup of `action_homomorphism` in #4609 as for`FinGenAbGroup`s in this PR. Depending on the order these two PRs get merged, the later one should perform the cleanup.