### PR TITLE
Don't import non-existent `free_show`

### DIFF
--- a/experimental/InjectiveResolutions/src/InjectiveResolutions.jl
+++ b/experimental/InjectiveResolutions/src/InjectiveResolutions.jl
@@ -50,8 +50,7 @@ import ..Oscar:
   oscar_generators,
   singular_poly_ring,
   _simple_kernel,
-  _extend_free_resolution, 
-  free_show
+  _extend_free_resolution
 
 
 import ..Oscar.Singular: 


### PR DESCRIPTION
See https://github.com/oscar-system/Oscar.jl/pull/4926#issuecomment-2915818434

The method `free_show` does not exist.

CC @lgoettgens @HechtiDerLachs
