### PR TITLE
Cleanup `action_homomorphism` for `WeylGroup`s

### DIFF
--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -612,16 +612,9 @@ function action_homomorphism(Omega::GSetByElements{WeylGroup,S}) where {S}
 
   # Compute a permutation group `G` isomorphic with `W`.
   phi = isomorphism(PermGroup, W)
-  G = codomain(phi) # permutation group
 
   # Let `G` act on `Omega` as `W` does.
-  phiinv = inv(phi)
-  actfun = action_function(Omega)
-  fun = function (omega::S, g::PermGroupElem)
-    return actfun(omega, phiinv(g))
-  end
-
-  OmegaG = GSetByElements(G, fun, Omega; closed=true, check=false)
+  OmegaG = induce(Omega, inv(phi))
 
   # Compute the permutation action on `1:length(Omega)`
   # corresponding to the action of `W` on `Omega`.

--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -610,10 +610,10 @@ end
 function action_homomorphism(Omega::GSetByElements{WeylGroup,S}) where {S}
   W = acting_group(Omega) # our base group
 
-  # Compute a permutation group `G` isomorphic with `W`.
+  # Compute a permutation group isomorphic with `W`.
   phi = isomorphism(PermGroup, W)
 
-  # Let `G` act on `Omega` as `W` does.
+  # Let the image of `phi` act on `Omega` as `W` does.
   OmegaG = induce(Omega, inv(phi))
 
   # Compute the permutation action on `1:length(Omega)`

--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -326,7 +326,6 @@ function action_homomorphism(Omega::GSetByElements{FinGenAbGroup, S}) where S
 
   # Compute a permutation group `G` isomorphic with `A`.
   phi = isomorphism(PermGroup, A)
-  G = codomain(phi)
 
   # Let `G` act on `Omega` as `A` does.
   OmegaG = induce(Omega, inv(phi))

--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -324,10 +324,10 @@ end
 function action_homomorphism(Omega::GSetByElements{FinGenAbGroup, S}) where S
   A = acting_group(Omega)
 
-  # Compute a permutation group `G` isomorphic with `A`.
+  # Compute a permutation group isomorphic with `A`.
   phi = isomorphism(PermGroup, A)
 
-  # Let `G` act on `Omega` as `A` does.
+  # Let the image of `phi` act on `Omega` as `A` does.
   OmegaG = induce(Omega, inv(phi))
 
   # Compute the permutation action on `1:length(Omega)`


### PR DESCRIPTION
As mentioned in #4921, this PR cleans up the current construction to use the new `induce` function.