### PR TITLE
Fix number theory booktest

### DIFF
--- a/test/book/cornerstones/number-theory/sym.jlcon
+++ b/test/book/cornerstones/number-theory/sym.jlcon
@@ -8,7 +8,7 @@ Permutation group of degree 4
 julia> describe(G)
 "C2 x C2"
 
-julia> phi = m(first(Iterators.filter(x -> 1^x == 3, G)))
+julia> phi = m(G(@perm (1, 3)(2, 4)))
 Map
   from number field of degree 4 over QQ
   to number field of degree 4 over QQ

--- a/test/book/cornerstones/number-theory/sym.jlcon
+++ b/test/book/cornerstones/number-theory/sym.jlcon
@@ -8,14 +8,14 @@ Permutation group of degree 4
 julia> describe(G)
 "C2 x C2"
 
-julia> m(G[1])
+julia> phi = m(first(Iterators.filter(x -> 1^x == 3, G)))
 Map
   from number field of degree 4 over QQ
   to number field of degree 4 over QQ
 defined by
   a -> -1//4*a^3 + 13//4*a
 
-julia> m(G[1])(a)
+julia> phi(a)
 -1//4*a^3 + 13//4*a
 
 julia> preimage(m, hom(K, K, -a))


### PR DESCRIPTION
The order of the generators of G changes with recent Julia versions (see issue #4882), so enforce that we pick the same group element across all versions by selecting it based on one of its properties. Of course this still relies on the order of the roots to stay fixed, but for now this seems to be sufficient.

This will hopefully unbreak the booktests.

CC @fieker and @thofma as this is their example, and they may prefer a different fix...