### PR TITLE
Fix `minimal_generating_set` for ideals created by a f4 groebner basis

### DIFF
--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -2567,7 +2567,6 @@ function minimal_generating_set(I::MPolyIdeal{<:MPolyDecRingElem})
     # make sure to not recompute a GB from scratch on the singular
     # side if we have one
     G = first(values(I.gb))
-    G.gens.S.isGB = true
     _, sing_min = Singular.mstd(singular_generators(G, G.ord))
     return filter(!iszero, (R).(gens(sing_min)))
   else

--- a/test/Rings/mpoly-graded.jl
+++ b/test/Rings/mpoly-graded.jl
@@ -588,3 +588,11 @@ end
   @test d isa ZZRingElem
 end
 
+@testset "issue #4949" begin
+  for F in [QQ, GF(7)]
+    R, (x,y) = graded_polynomial_ring(F, [:x, :y])
+    I = ideal([x,y])
+    gb = groebner_basis_f4(I)
+    @test issetequal(minimal_generating_set(ideal(gb)), [x, y])
+  end
+end


### PR DESCRIPTION
Resolves #4949.

There used to be a `singular_assure` in the line before the one I edited, but that was removed by @ederc in #2829.

After looking into it for a moment longer, it seems that this line isn't needed at all, as the flag will be set by the `singular_generators` call in the next line anyway, see
https://github.com/oscar-system/Oscar.jl/blob/feee19f9df4d3dc52376a01037a260025ff8d61e/src/Rings/mpoly.jl#L389-L391