### PR TITLE
Remove compat for `GAP_lib_jll`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,16 +27,12 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 cohomCalg_jll = "5558cf25-a90e-53b0-b813-cadaa3ae7ade"
 lib4ti2_jll = "1493ae25-0f90-5c0e-a06c-8c5077d6d66f"
 
-[extras]
-GAP_lib_jll = "de1ad85e-c930-5cd4-919d-ccd3fcafd1a3"
-
 [compat]
 AbstractAlgebra = "0.45.1"
 AlgebraicSolving = "0.9.0"
 Compat = "4.13.0"
 Distributed = "1.6"
-GAP = "0.13.1"
-GAP_lib_jll = "~400.1400.4" # remove again once GAP.jl requires this version
+GAP = "0.13.4"
 Hecke = "0.36.0"
 JSON = "^0.20, ^0.21"
 JSON3 = "1.13.2"


### PR DESCRIPTION
As `GAP.jl v0.13.4` requires this by default due to https://github.com/oscar-system/GAP.jl/pull/1180.
