### PR TITLE
Improvements for sparse modules from #4951

### DIFF
--- a/src/Modules/ExteriorPowers/FreeModules.jl
+++ b/src/Modules/ExteriorPowers/FreeModules.jl
@@ -65,27 +65,25 @@ function exterior_power(F::FreeMod, p::Int; cached::Bool=true)
 
   # Set the variable names for printing
   orig_symb = String.(symbols(F))
-  new_symb = Symbol[]
-  if iszero(p)
-    new_symb = [Symbol("1")]
-  else
-    for ind in combinations(n, p)
-      symb_str = orig_symb[ind[1]]
-      for i in 2:p
-        symb_str = symb_str * (is_unicode_allowed() ? "∧" : "^") * orig_symb[ind[i]]
+  result.S = function _get_koszul_symbols()
+    new_symb = Symbol[]
+    if iszero(p)
+      new_symb = [Symbol("1")]
+    else
+      for ind in combinations(n, p)
+        symb_str = orig_symb[ind[1]]
+        for i in 2:p
+          symb_str = symb_str * (is_unicode_allowed() ? "∧" : "^") * orig_symb[ind[i]]
+        end
+        push!(new_symb, Symbol(symb_str))
       end
-      push!(new_symb, Symbol(symb_str))
     end
+    return new_symb
   end
-  result.S = new_symb
 
   set_attribute!(result, :show => show_exterior_product)
 
   return result, mult_map
-end
-
-function symbols(F::FreeMod)
-  return F.S
 end
 
 

--- a/src/Modules/ExteriorPowers/FreeModules.jl
+++ b/src/Modules/ExteriorPowers/FreeModules.jl
@@ -77,8 +77,8 @@ function exterior_power(F::FreeMod, p::Int; cached::Bool=true)
         end
         push!(new_symb, Symbol(symb_str))
       end
+      return new_symb
     end
-    return new_symb
   end
 
   set_attribute!(result, :show => show_exterior_product)

--- a/src/Modules/ExteriorPowers/FreeModules.jl
+++ b/src/Modules/ExteriorPowers/FreeModules.jl
@@ -65,11 +65,11 @@ function exterior_power(F::FreeMod, p::Int; cached::Bool=true)
 
   # Set the variable names for printing
   orig_symb = String.(symbols(F))
-  result.S = function _get_koszul_symbols()
-    new_symb = Symbol[]
-    if iszero(p)
-      new_symb = [Symbol("1")]
-    else
+  if iszero(p)
+    result.S = [Symbol("1")]
+  else
+    result.S = function _get_koszul_symbols()
+      new_symb = Symbol[]
       for ind in combinations(n, p)
         symb_str = orig_symb[ind[1]]
         for i in 2:p

--- a/src/Modules/ExteriorPowers/SubQuo.jl
+++ b/src/Modules/ExteriorPowers/SubQuo.jl
@@ -15,7 +15,7 @@ function exterior_power(M::SubquoModule, p::Int; cached::Bool=true)
     C = presentation(M)
     phi = map(C, 1)
     codomain(phi).S = function _get_symbol()
-      return [Symbol"$e") for e in gens(M)]
+      return [Symbol("$e") for e in gens(M)]
     end
     result, mm = _exterior_power(phi, p)
   end

--- a/src/Modules/ExteriorPowers/SubQuo.jl
+++ b/src/Modules/ExteriorPowers/SubQuo.jl
@@ -15,7 +15,7 @@ function exterior_power(M::SubquoModule, p::Int; cached::Bool=true)
     C = presentation(M)
     phi = map(C, 1)
     codomain(phi).S = function _get_symbol()
-      return Symbol.(["$e" for e in gens(M)])
+      return [Symbol"$e") for e in gens(M)]
     end
     result, mm = _exterior_power(phi, p)
   end

--- a/src/Modules/ExteriorPowers/SubQuo.jl
+++ b/src/Modules/ExteriorPowers/SubQuo.jl
@@ -14,7 +14,9 @@ function exterior_power(M::SubquoModule, p::Int; cached::Bool=true)
   else
     C = presentation(M)
     phi = map(C, 1)
-    codomain(phi).S = Symbol.(["$e" for e in gens(M)])
+    codomain(phi).S = function _get_symbol()
+      return Symbol.(["$e" for e in gens(M)])
+    end
     result, mm = _exterior_power(phi, p)
   end
 

--- a/src/Modules/FreeModElem-orderings.jl
+++ b/src/Modules/FreeModElem-orderings.jl
@@ -81,7 +81,7 @@ end
 function expressify(a::OscarPair{<:FreeModElem{<:MPolyRingElem}, Vector{Tuple{Int, Int}}}; context = nothing)
   f = a.first
   x = symbols(base_ring(parent(f)))
-  e = generator_symbols(parent(f))
+  e = symbols(parent(f))
   s = Expr(:call, :+)
   for (i, j) in a.second
     prod = Expr(:call, :*)

--- a/src/Modules/ModuleTypes.jl
+++ b/src/Modules/ModuleTypes.jl
@@ -228,11 +228,11 @@ generate the submodule) (computed via `generator_matrix()`) are cached.
   groebner_basis::Dict{ModuleOrdering, ModuleGens{T}}
   gens::ModuleGens{T}
   default_ordering::ModuleOrdering
-  dummy_gb::ModuleGens{T} # A field to store the first groebner basis ever computed.
-                          # Lookups in the above dictionary is tentatively expensive. 
-                          # So this field stores any gb for cases where the actual 
-                          # ordering does not matter. Then this field here can be used. 
-  dummy_gb_with_transition::ModuleGens{T} # The same but for one with transition matrix
+  any_gb::ModuleGens{T} # A field to store the first groebner basis ever computed.
+                        # Lookups in the above dictionary is tentatively expensive. 
+                        # So this field stores any gb for cases where the actual 
+                        # ordering does not matter. Then this field here can be used. 
+  any_gb_with_transition::ModuleGens{T} # The same but for one with transition matrix
   matrix::MatElem
   is_graded::Bool
 

--- a/src/Modules/ModuleTypes.jl
+++ b/src/Modules/ModuleTypes.jl
@@ -80,7 +80,9 @@ option is set in suitable functions.
 @attributes mutable struct FreeMod{T <: AdmissibleModuleFPRingElem} <: AbstractFreeMod{T}
   R::NCRing
   n::Int
-  S::Vector{Symbol}
+  S::Union{Function, Vector{Symbol}} # The symbols for printing. This is either a 
+                                     # ready-made list, or a function to provide them 
+                                     # in a lazy way. 
   d::Union{Vector{FinGenAbGroupElem}, Nothing}
   default_ordering::ModuleOrdering
 
@@ -104,6 +106,18 @@ option is set in suitable functions.
     r.n = n
     r.R = R
     r.S = S
+    r.d = nothing
+
+    r.incoming = WeakKeyIdDict{ModuleFP, Tuple{SMat, Any}}()
+    r.outgoing = WeakKeyIdDict{ModuleFP, Tuple{SMat, Any}}()
+    return r
+  end
+  
+  function FreeMod{T}(n::Int, R::AdmissibleModuleFPRing, symbol_fun::Function) where T <: AdmissibleModuleFPRingElem
+    r = new{elem_type(R)}()
+    r.n = n
+    r.R = R
+    r.S = symbol_fun
     r.d = nothing
 
     r.incoming = WeakKeyIdDict{ModuleFP, Tuple{SMat, Any}}()

--- a/src/Modules/ModuleTypes.jl
+++ b/src/Modules/ModuleTypes.jl
@@ -114,11 +114,7 @@ option is set in suitable functions.
   end
   
   function FreeMod{T}(n::Int, R::AdmissibleModuleFPRing, symbol_fun::Function) where T <: AdmissibleModuleFPRingElem
-    r = new{elem_type(R)}()
-    r.n = n
-    r.R = R
-    r.S = symbol_fun
-    r.d = nothing
+    r = new{elem_type(R)}(R, n, symbol_fun, nothing)
 
     r.incoming = WeakKeyIdDict{ModuleFP, Tuple{SMat, Any}}()
     r.outgoing = WeakKeyIdDict{ModuleFP, Tuple{SMat, Any}}()

--- a/src/Modules/ModuleTypes.jl
+++ b/src/Modules/ModuleTypes.jl
@@ -225,18 +225,20 @@ generate the submodule) (computed via `generator_matrix()`) are cached.
 """
 @attributes mutable struct SubModuleOfFreeModule{T <: AdmissibleModuleFPRingElem} <: ModuleFP{T}
   F::FreeMod{T}
-  gens::ModuleGens{T}
   groebner_basis::Dict{ModuleOrdering, ModuleGens{T}}
+  gens::ModuleGens{T}
   default_ordering::ModuleOrdering
+  dummy_gb::ModuleGens{T} # A field to store the first groebner basis ever computed.
+                          # Lookups in the above dictionary is tentatively expensive. 
+                          # So this field stores any gb for cases where the actual 
+                          # ordering does not matter. Then this field here can be used. 
+  dummy_gb_with_transition::ModuleGens{T} # The same but for one with transition matrix
   matrix::MatElem
   is_graded::Bool
 
   function SubModuleOfFreeModule{R}(F::FreeMod{R}) where {R}
     # this does not construct a valid SubModuleOfFreeModule
-    r = new{R}()
-    r.F = F
-    r.groebner_basis = Dict()
-    return r
+    return new{R}(F, Dict{ModuleOrdering, ModuleGens{R}}())
   end
 end
 

--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -727,7 +727,7 @@ end
 # Graded Free Module homomorphisms functions
 ###############################################################################
 
-function set_grading(f::FreeModuleHom{T1, T2}; check::Bool=true) where {T1 <: FreeMod, T2 <: Union{FreeMod, SubquoModule, Oscar.SubModuleOfFreeModule}}
+function set_grading(f::FreeModuleHom{T1, T2}; check::Bool=true) where {T1 <: FreeMod, T2 <: Union{FreeMod, SubquoModule, SubModuleOfFreeModule}}
   if !is_graded(domain(f)) || !is_graded(codomain(f))
       return f
   end
@@ -2291,12 +2291,12 @@ end
 
 
 @doc raw"""
-    generator_symbols(F::FreeMod_dec)
+    symbols(F::FreeMod_dec)
 
 Return the list of symbols of the standard unit vectors.
 """
-function generator_symbols(F::FreeMod_dec)
-  return generator_symbols(forget_decoration(F))
+function symbols(F::FreeMod_dec)
+  return symbols(forget_decoration(F))
 end
 @enable_all_show_via_expressify FreeModElem_dec
 

--- a/src/Modules/UngradedModules/DirectSum.jl
+++ b/src/Modules/UngradedModules/DirectSum.jl
@@ -34,10 +34,12 @@ function direct_product(F::Vector{<:FreeMod{T}}; task::Symbol = :prod) where T
     push!(ranges, i+1:j)
     i = j
   end
-  G.S = vcat([Symbol[Symbol("("*join(vcat(["0" for k in 1:j-1], 
+  G.S = function _direct_sum_symbols()
+          return vcat([Symbol[Symbol("("*join(vcat(["0" for k in 1:j-1], 
                                           [string(F[j].S[i])], 
                                           ["0" for k in j+1:length(F)]), ", ")
                             *")") for i in 1:ngens(F[j])] for j in 1:length(F)]...)
+         end
   set_attribute!(G, :projection_morphisms => projection_dictionary, :injection_morphisms => injection_dictionary, :ranges => ranges)
   i = 0
   for f = F

--- a/src/Modules/UngradedModules/DirectSum.jl
+++ b/src/Modules/UngradedModules/DirectSum.jl
@@ -36,7 +36,7 @@ function direct_product(F::Vector{<:FreeMod{T}}; task::Symbol = :prod) where T
   end
   G.S = function _direct_sum_symbols()
           return vcat([Symbol[Symbol("("*join(vcat(["0" for k in 1:j-1], 
-                                          [string(F[j].S[i])], 
+                                                   [string(symbol(F[j], i))], 
                                           ["0" for k in j+1:length(F)]), ", ")
                             *")") for i in 1:ngens(F[j])] for j in 1:length(F)]...)
          end

--- a/src/Modules/UngradedModules/FreeMod.jl
+++ b/src/Modules/UngradedModules/FreeMod.jl
@@ -207,16 +207,16 @@ function (==)(F::FreeMod, G::FreeMod)
   # TODO it this enough or e.g. stored morphisms also be considered?
   is_graded(F) == is_graded(G) || return false
   if is_graded(F) && is_graded(G) 
-    return F.R == G.R && F.d == G.d #&& F.S == G.S
+    return F.R == G.R && F.d == G.d && symbols(F) == symbols(G)
   end
-  return F.R == G.R && rank(F) == rank(G) #&& F.S == G.S
+  return F.R == G.R && rank(F) == rank(G) && symbols(F) == symbols(G)
 end
 
 function hash(F::FreeMod, h::UInt)
   b = is_graded(F) ? (0x2d55d561d3f7e215 % UInt) : (0x62ca4181ff3a12f4 % UInt)
   h = hash(base_ring(F), h)
   h = hash(rank(F), h)
-  #h = hash(F.S, h)
+  h = hash(symbols(F), h)
   is_graded(F) && (h = hash(F.d, h))
   return xor(h, b)
 end

--- a/src/Modules/UngradedModules/FreeMod.jl
+++ b/src/Modules/UngradedModules/FreeMod.jl
@@ -404,6 +404,18 @@ function syzygy_generators(
   return elem_type(F)[F(s[i]) for i=1:Singular.ngens(s)]
 end
 
+# access to the symbols for printing of `F`
+#
+# Creating the symbols turns out to be rather expensive in some edge cases; for 
+# instance for direct products with many (>1000) summands. Therefore, we lazyfied 
+# this process and a given `FreeMod` will usually not store the symbols themselves 
+# in its field `.S`, but a function to compute them. 
+#
+# If the user needs the concrete symbols, then a lookup is done: Do we have them already? 
+# Or do we need to compute them? This lookup is decided by dispatch on the contents of 
+# the field `.S` with the internal functions below. If the field is filled with a list 
+# of symbols, then these are returned. If not, then the function stored in `.S` is 
+# called and the result stored in `.S`, instead. 
 function symbols(F::FreeMod)
   return _get_symbols!(F, F.S)
 end
@@ -421,4 +433,6 @@ function _get_symbols!(F::FreeMod, symbol_fun::Function)
   return F.S::Vector{Symbol}
 end
 
+# an alias for backwards compatibility
+generator_symbols(F::FreeMod) = symbols(F)
 

--- a/src/Modules/UngradedModules/FreeMod.jl
+++ b/src/Modules/UngradedModules/FreeMod.jl
@@ -417,8 +417,8 @@ function _get_symbols!(F::FreeMod, S::Vector{Symbol})
 end
 
 function _get_symbols!(F::FreeMod, symbol_fun::Function)
-  F.S = symbol_fun()::Vector{Symbol}
-  return F.S
+  F.S = symbol_fun()
+  return F.S::Vector{Symbol}
 end
 
 

--- a/src/Modules/UngradedModules/FreeMod.jl
+++ b/src/Modules/UngradedModules/FreeMod.jl
@@ -207,16 +207,16 @@ function (==)(F::FreeMod, G::FreeMod)
   # TODO it this enough or e.g. stored morphisms also be considered?
   is_graded(F) == is_graded(G) || return false
   if is_graded(F) && is_graded(G) 
-    return F.R == G.R && F.d == G.d && F.S == G.S
+    return F.R == G.R && F.d == G.d #&& F.S == G.S
   end
-  return F.R == G.R && rank(F) == rank(G) && F.S == G.S
+  return F.R == G.R && rank(F) == rank(G) #&& F.S == G.S
 end
 
 function hash(F::FreeMod, h::UInt)
   b = is_graded(F) ? (0x2d55d561d3f7e215 % UInt) : (0x62ca4181ff3a12f4 % UInt)
   h = hash(base_ring(F), h)
   h = hash(rank(F), h)
-  h = hash(F.S, h)
+  #h = hash(F.S, h)
   is_graded(F) && (h = hash(F.d, h))
   return xor(h, b)
 end
@@ -403,4 +403,18 @@ function syzygy_generators(
   @assert rank(s) == length(a)
   return elem_type(F)[F(s[i]) for i=1:Singular.ngens(s)]
 end
+
+function symbols(F::FreeMod)
+  return _get_symbols!(F, F.S)
+end
+
+function _get_symbols!(F::FreeMod, S::Vector{Symbol})
+  return S
+end
+
+function _get_symbols!(F::FreeMod, symbol_fun::Function)
+  F.S = symbol_fun()::Vector{Symbol}
+  return F.S
+end
+
 

--- a/src/Modules/UngradedModules/FreeMod.jl
+++ b/src/Modules/UngradedModules/FreeMod.jl
@@ -408,6 +408,10 @@ function symbols(F::FreeMod)
   return _get_symbols!(F, F.S)
 end
 
+function symbol(F::FreeMod, i::Int)
+  return symbols(F)[i]
+end
+
 function _get_symbols!(F::FreeMod, S::Vector{Symbol})
   return S
 end

--- a/src/Modules/UngradedModules/FreeModElem.jl
+++ b/src/Modules/UngradedModules/FreeModElem.jl
@@ -125,15 +125,11 @@ end
 elem_type(::Type{FreeMod{T}}) where {T} = FreeModElem{T}
 parent_type(::Type{FreeModElem{T}}) where {T} = FreeMod{T}
 
-function generator_symbols(F::FreeMod)
-  return F.S
-end
-
 function expressify(e::AbstractFreeModElem; context = nothing)
   sum = Expr(:call, :+)
   for (pos, val) in coordinates(e)
-     # assuming generator_symbols(parent(e)) is an array of strings/symbols
-     push!(sum.args, Expr(:call, :*, expressify(val, context = context), generator_symbols(parent(e))[pos]))
+     # assuming symbols(parent(e)) is an array of strings/symbols
+     push!(sum.args, Expr(:call, :*, expressify(val, context = context), symbols(parent(e))[pos]))
   end
   return sum
 end

--- a/src/Modules/UngradedModules/FreeModuleHom.jl
+++ b/src/Modules/UngradedModules/FreeModuleHom.jl
@@ -372,7 +372,9 @@ function hom(F::FreeMod, G::FreeMod)
   else
     GH = FreeMod(F.R, rank(F) * rank(G))
   end
-  GH.S = [Symbol("($i -> $j)") for i = F.S for j = G.S]
+  GH.S = function _get_hom_symbols() 
+    return [Symbol("($i -> $j)") for i = symbols(F) for j = symbols(G)]
+  end
 
   #list is g1 - f1, g2-f1, g3-f1, ...
   X = Hecke.MapParent(F, G, "homomorphisms")

--- a/src/Modules/UngradedModules/FreeModuleHom.jl
+++ b/src/Modules/UngradedModules/FreeModuleHom.jl
@@ -584,7 +584,7 @@ represented as subquotient with no relations -> G)
 
 ```
 """
-function image(h::FreeModuleHom)
+@attr Tuple{<:SubquoModule, <:SubQuoHom} function image(h::FreeModuleHom)
   si = filter(!iszero, images_of_generators(h))
   s = sub_object(codomain(h), si)
   phi = hom(s, codomain(h), si, check=false)

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -400,7 +400,7 @@ function change_base_ring(f::Map{DomType, CodType}, F::FreeMod) where {DomType<:
   domain(f) == base_ring(F) || error("ring map not compatible with the module")
   S = codomain(f)
   r = ngens(F)
-  FS = is_graded(F) ? graded_free_module(S, degrees_of_generators(F)) : FreeMod(S, F.S) # the symbols of F
+  FS = is_graded(F) ? graded_free_module(S, degrees_of_generators(F)) : FreeMod(S, symbols(F))
   map = hom(F, FS, gens(FS), f)
   return FS, map
 end

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -391,7 +391,6 @@ end
 function change_base_ring(S::Ring, F::FreeMod)
   R = base_ring(F)
   r = ngens(F)
-  FreeMod{elem_type(S)}(ngens(F), S, F.S)
   FS = is_graded(F) ? graded_free_module(S, degrees_of_generators(F)) : FreeMod{elem_type(S)}(ngens(F), S, F.S) # the symbols of F
   map = hom(F, FS, gens(FS), MapFromFunc(R, S, S))
   return FS, map
@@ -401,7 +400,7 @@ function change_base_ring(f::Map{DomType, CodType}, F::FreeMod) where {DomType<:
   domain(f) == base_ring(F) || error("ring map not compatible with the module")
   S = codomain(f)
   r = ngens(F)
-  FS = is_graded(F) ? graded_free_module(S, degrees_of_generators(F)) : FreeMod(S, symbols(F))
+  FS = is_graded(F) ? graded_free_module(S, degrees_of_generators(F)) : FreeMod{elem_type(S)}(ngens(F), S, F.S)
   map = hom(F, FS, gens(FS), f)
   return FS, map
 end

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -391,7 +391,8 @@ end
 function change_base_ring(S::Ring, F::FreeMod)
   R = base_ring(F)
   r = ngens(F)
-  FS = is_graded(F) ? graded_free_module(S, degrees_of_generators(F)) : FreeMod(S, F.S) # the symbols of F
+  FreeMod{elem_type(S)}(ngens(F), S, F.S)
+  FS = is_graded(F) ? graded_free_module(S, degrees_of_generators(F)) : FreeMod{elem_type(S)}(ngens(F), S, F.S) # the symbols of F
   map = hom(F, FS, gens(FS), MapFromFunc(R, S, S))
   return FS, map
 end

--- a/src/Modules/UngradedModules/ModuleGens.jl
+++ b/src/Modules/UngradedModules/ModuleGens.jl
@@ -370,17 +370,19 @@ Compute a sparse row `r` such that `a = sum([r[i]*gen(M,i) for i in 1:ngens(M)])
 If no such `r` exists, an exception is thrown.
 """
 function coordinates_via_transform(a::FreeModElem{T}, generators::ModuleGens{T}) where T
-  A = get_attribute(generators, :transformation_matrix)
-  A === nothing && error("No transformation matrix in the Gröbner basis.")
-  if iszero(a)
-    return sparse_row(base_ring(parent(a)))
+  iszero(a) && return sparse_row(base_ring(parent(a)))
+  SA = get_attribute!(generators, :sparse_transformation_matrix) do
+    A = get_attribute(generators, :transformation_matrix)
+    A === nothing && error("No transformation matrix in the Gröbner basis.")
+    sparse_matrix(A)
   end
+
   @assert generators.isGB
-  if base_ring(generators) isa Union{MPolyQuoRing,MPolyRing}
-    if !is_global(generators.ordering)
-      error("Ordering is not global")
-    end
-  end
+# if base_ring(generators) isa Union{MPolyQuoRing,MPolyRing}
+#   if !is_global(generators.ordering)
+#     error("Ordering is not global")
+#   end
+# end
 
   S = singular_generators(generators)
   S.isGB = generators.isGB
@@ -392,7 +394,7 @@ function coordinates_via_transform(a::FreeModElem{T}, generators::ModuleGens{T})
   Rx = base_ring(generators)
   coords_wrt_groebner_basis = sparse_row(Rx, s[1], 1:ngens(generators))
 
-  return coords_wrt_groebner_basis * sparse_matrix(A)
+  return coords_wrt_groebner_basis * SA
 end
 
 @doc raw"""

--- a/src/Modules/UngradedModules/ModuleGens.jl
+++ b/src/Modules/UngradedModules/ModuleGens.jl
@@ -378,11 +378,11 @@ function coordinates_via_transform(a::FreeModElem{T}, generators::ModuleGens{T})
   end
 
   @assert generators.isGB
-# if base_ring(generators) isa Union{MPolyQuoRing,MPolyRing}
-#   if !is_global(generators.ordering)
-#     error("Ordering is not global")
-#   end
-# end
+  if base_ring(generators) isa Union{MPolyQuoRing,MPolyRing}
+    if !is_global(generators.ordering)
+      error("Ordering is not global")
+    end
+  end
 
   S = singular_generators(generators)
   S.isGB = generators.isGB

--- a/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
+++ b/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
@@ -171,8 +171,8 @@ function standard_basis(
     submod::SubModuleOfFreeModule; 
     ordering::ModuleOrdering = default_ordering(submod)
   )
-  if isdefined(submod, :dummy_gb) 
-    ordering === default_ordering(submod.dummy_gb) && return submod.dummy_gb
+  if isdefined(submod, :any_gb) 
+    ordering === submod.any_gb.ordering && return submod.any_gb
   end
 
   @req is_exact_type(elem_type(base_ring(submod))) "This functionality is only supported over exact fields."
@@ -181,11 +181,11 @@ function standard_basis(
   end::ModuleGens
 
   # Cache a newly computed groebner basis 
-  if !isdefined(submod, :dummy_gb)
-    submod.dummy_gb = gb
+  if !isdefined(submod, :any_gb)
+    submod.any_gb = gb
   end
-  if !isdefined(submod, :dummy_gb_with_transition) && !isnothing(get_attribute(gb, :transformation_matrix))
-    submod.dummy_gb_with_transition = gb
+  if !isdefined(submod, :any_gb_with_transition) && !isnothing(get_attribute(gb, :transformation_matrix))
+    submod.any_gb_with_transition = gb
   end
   return gb
 end
@@ -214,11 +214,11 @@ function reduced_groebner_basis(submod::SubModuleOfFreeModule, ordering::ModuleO
   end::ModuleGens
   @assert gb.is_reduced
   # Cache a newly computed groebner basis 
-  if !isdefined(submod, :dummy_gb)
-    submod.dummy_gb = gb
+  if !isdefined(submod, :any_gb)
+    submod.any_gb = gb
   end
-  if !isdefined(submod, :dummy_gb_with_transition) && !isnothing(get_attribute(gb, :transformation_matrix))
-    submod.dummy_gb_with_transition = gb
+  if !isdefined(submod, :any_gb_with_transition) && !isnothing(get_attribute(gb, :transformation_matrix))
+    submod.any_gb_with_transition = gb
   end
   return gb
 end
@@ -445,8 +445,8 @@ end
 Base.:+(M::SubModuleOfFreeModule, N::SubModuleOfFreeModule) = sum(M, N)
 
 function lift_std(M::SubModuleOfFreeModule)
-  if isdefined(M, :dummy_gb_with_transition)
-    return M.dummy_gb_with_transition, get_attribute(M.dummy_gb_with_transition, :transformation_matrix)::MatrixElem
+  if isdefined(M, :any_gb_with_transition)
+    return M.any_gb_with_transition, get_attribute(M.any_gb_with_transition, :transformation_matrix)::MatrixElem
   end
 
   for (ord, gb) in M.groebner_basis
@@ -457,8 +457,8 @@ function lift_std(M::SubModuleOfFreeModule)
   end
   gb, transform = lift_std(M.gens, default_ordering(M))
   M.groebner_basis[default_ordering(M)] = gb
-  if !isdefined(M, :dummy_gb_with_transition)
-    M.dummy_gb_with_transition = gb
+  if !isdefined(M, :any_gb_with_transition)
+    M.any_gb_with_transition = gb
   end
   return gb, transform
 end

--- a/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
+++ b/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
@@ -168,16 +168,18 @@ Compute a standard basis of `submod` with respect to the given `ordering`.
 The return type is `ModuleGens`.
 """
 function standard_basis(submod::SubModuleOfFreeModule; ordering::Union{ModuleOrdering, Nothing} = default_ordering(submod))
+  _ordering = isnothing(ordering) ? default_ordering(submod) : ordering
+
   # This is to circumvent hashing of the ordering in the obviously avoidable cases
-  if ordering===default_ordering(submod)
+  if _ordering===default_ordering(submod)
     for (ord, gb) in submod.groebner_basis
-      ord === ordering && return gb
+      ord === default_ordering(submod) && return gb
     end
   end
     
   @req is_exact_type(elem_type(base_ring(submod))) "This functionality is only supported over exact fields."
-  gb = get!(submod.groebner_basis, ordering) do
-    return compute_standard_basis(submod, ordering)
+  gb = get!(submod.groebner_basis, _ordering) do
+    return compute_standard_basis(submod, _ordering)
   end::ModuleGens
   return gb
 end
@@ -475,7 +477,7 @@ end
 
 function in_atomic(a::FreeModElem{T}, M::SubModuleOfFreeModule) where {S<:Union{ZZRingElem,FieldElem}, T<:MPolyRingElem{S}}
   F = ambient_free_module(M)
-  return iszero(reduce(a, standard_basis(M, ordering=default_ordering(F))))
+  return iszero(reduce(a, standard_basis(M, ordering=nothing)))
 end
 
 @attr Any function solve_ctx(M::SubModuleOfFreeModule)

--- a/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
+++ b/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
@@ -432,14 +432,7 @@ end
 Base.:+(M::SubModuleOfFreeModule, N::SubModuleOfFreeModule) = sum(M, N)
 
 function lift_std(M::SubModuleOfFreeModule)
-  if haskey(M.groebner_basis, default_ordering(M))
-    gb = M.groebner_basis[default_ordering(M)]
-    transform = get_attribute(gb, :transformation_matrix)
-    if transform !== nothing
-      return gb, transform
-    end
-  end
-  for gb in values(M.groebner_basis)
+  for (ord, gb) in M.groebner_basis
     transform = get_attribute(gb, :transformation_matrix)
     if transform !== nothing
       return gb, transform

--- a/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
+++ b/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
@@ -162,34 +162,22 @@ function set_default_ordering!(M::SubModuleOfFreeModule, ord::ModuleOrdering)
 end
 
 @doc raw"""
-    standard_basis(submod::SubModuleOfFreeModule; ordering::Union{ModuleOrdering, Nothing} = default_ordering(submod))
+    standard_basis(submod::SubModuleOfFreeModule; ordering::ModuleOrdering = default_ordering(submod))
 
 Compute a standard basis of `submod` with respect to the given `ordering`.
 The return type is `ModuleGens`.
-
-!!! note
-
-    If the keyword argument `ordering` is set to `nothing`, a standard basis with respect to any monomial ordering will be returned. 
 """
 function standard_basis(
     submod::SubModuleOfFreeModule; 
-    ordering::Union{ModuleOrdering, Nothing} = default_ordering(submod)
+    ordering::ModuleOrdering = default_ordering(submod)
   )
-  if isnothing(ordering)
-    isdefined(submod, :dummy_gb) && return submod.dummy_gb
+  if isdefined(submod, :dummy_gb) 
+    ordering === default_ordering(submod.dummy_gb) && return submod.dummy_gb
   end
-  _ordering = isnothing(ordering) ? default_ordering(submod) : ordering
 
-  # This is to circumvent hashing of the ordering in the obviously avoidable cases
-  if _ordering===default_ordering(submod)
-    for (ord, gb) in submod.groebner_basis
-      ord === default_ordering(submod) && return gb
-    end
-  end
-    
   @req is_exact_type(elem_type(base_ring(submod))) "This functionality is only supported over exact fields."
-  gb = get!(submod.groebner_basis, _ordering) do
-    compute_standard_basis(submod, _ordering)
+  gb = get!(submod.groebner_basis, ordering) do
+    compute_standard_basis(submod, ordering)
   end::ModuleGens
 
   # Cache a newly computed groebner basis 
@@ -507,7 +495,7 @@ end
 
 function in_atomic(a::FreeModElem{T}, M::SubModuleOfFreeModule) where {S<:Union{ZZRingElem,FieldElem}, T<:MPolyRingElem{S}}
   F = ambient_free_module(M)
-  return iszero(reduce(a, standard_basis(M, ordering=nothing)))
+  return iszero(reduce(a, standard_basis(M)))
 end
 
 @attr Any function solve_ctx(M::SubModuleOfFreeModule)

--- a/src/Modules/UngradedModules/SubQuoHom.jl
+++ b/src/Modules/UngradedModules/SubQuoHom.jl
@@ -757,7 +757,7 @@ function kernel(h::SubQuoHom)
   @assert domain(inc_K) === K
   @assert codomain(inc_K) === F
   v = gens(D)
-  imgs = Vector{elem_type(D)}(filter(!iszero, [sum(a*v[i] for (i, a) in coordinates(g); init=zero(D)) for g in images_of_generators(inc_K)]))
+  imgs = filter!(!iszero, elem_type(D)[sum(a*v[i] for (i, a) in coordinates(g); init=zero(D)) for g in images_of_generators(inc_K)])
   k = sub_object(D, imgs)
   return k, hom(k, D, imgs, check=false)
 end

--- a/src/Modules/UngradedModules/SubquoModule.jl
+++ b/src/Modules/UngradedModules/SubquoModule.jl
@@ -2179,3 +2179,14 @@ function (==)(F::FreeMod, G::SubquoModule)
   all(in(G), gens(F)) || return false
   return true
 end
+
+is_known(::typeof(is_zero), F::FreeMod) = true
+
+function is_known(::typeof(is_zero), M::SubquoModule)
+  has_attribute(M, :is_zero) && return true
+  is_zero(ambient_free_module(M)) && return true
+  is_zero(ngens(M)) && return true
+  is_zero(M.quo) && return true
+  return false
+end
+

--- a/src/Modules/UngradedModules/SubquoModule.jl
+++ b/src/Modules/UngradedModules/SubquoModule.jl
@@ -1564,15 +1564,15 @@ function intersect(M::SubquoModule{T}, N::SubquoModule{T}) where T
     phi = FreeModuleHom(F1,F2,vcat(gens(M.sub),gens(N.sub),gens(M_quo)); check=false)
     K,i = kernel(phi)
 
-    intersection_gens_array_with_zeros = [sum([repres(k)[i]*M.sub[i] for i=1:ngens(M.sub)]; init=zero(ambient_free_module(M))) for k in gens(K)]
+    intersection_gens_array_with_zeros = elem_type(ambient_free_module(M))[sum([repres(k)[i]*M.sub[i] for i=1:ngens(M.sub)]; init=zero(ambient_free_module(M))) for k in gens(K)]
     iszero_array = map(!iszero, intersection_gens_array_with_zeros)
 
     intersection_gens = SubModuleOfFreeModule(ambient_free_module(M), intersection_gens_array_with_zeros[iszero_array] )
     SQ = SubquoModule(intersection_gens,M_quo)
 
     m = ngens(M)
-    M_hom = SubQuoHom(SQ,M,[sum([repres(k)[i]*M[i] for i=1:m]; init=zero(M)) for k in gens(K)][iszero_array]; check=false)
-    N_hom = SubQuoHom(SQ,N,[sum([repres(k)[i]*N[i-m] for i=m+1:m+ngens(N)]; init=zero(N)) for k in gens(K)][iszero_array]; check=false)
+    M_hom = SubQuoHom(SQ,M,elem_type(M)[sum([repres(k)[i]*M[i] for i=1:m]; init=zero(M)) for k in gens(K)][iszero_array]; check=false)
+    N_hom = SubQuoHom(SQ,N,elem_type(N)[sum([repres(k)[i]*N[i-m] for i=m+1:m+ngens(N)]; init=zero(N)) for k in gens(K)][iszero_array]; check=false)
 
     register_morphism!(M_hom)
     register_morphism!(N_hom)

--- a/src/Modules/UngradedModules/SubquoModuleElem.jl
+++ b/src/Modules/UngradedModules/SubquoModuleElem.jl
@@ -982,7 +982,7 @@ julia> is_zero(M)
 false
 ```
 """
-function is_zero(M::SubquoModule)
+@attr Bool function is_zero(M::SubquoModule)
   return all(iszero, gens(M))
 end
 

--- a/src/Modules/UngradedModules/Tensor.jl
+++ b/src/Modules/UngradedModules/Tensor.jl
@@ -15,10 +15,10 @@ function tensor_product(G::FreeMod...; task::Symbol = :none)
   if !all(gs) && !all(!x for x in gs)
     error("All factors must either be graded or all must be ungraded.")
   end
-  s = G[1].S
+  s = symbols(G[1])
   t = [[x] for x = 1:ngens(G[1])]
   for H = G[2:end]
-    s = [Symbol("$x \\otimes $y") for x = s  for y = H.S]
+    s = [Symbol("$x \\otimes $y") for x = s  for y = symbols(H)]
     t = [push!(deepcopy(x), y) for x = t  for y = 1:ngens(H)]
   end
 

--- a/src/Modules/UngradedModules/Tensor.jl
+++ b/src/Modules/UngradedModules/Tensor.jl
@@ -22,7 +22,7 @@ function tensor_product(G::FreeMod...; task::Symbol = :none)
 
   F = FreeMod(G[1].R, prod([rank(g) for g in G]))
   F.S = function _get_tensor_symbols()
-    return Symbol.([join(["$(symbol(G[k], i[k]))" for k in 1:length(G)], " \\otimes ") for i in AbstractAlgebra.ProductIterator([1:ngens(g) for g in G])])
+    return Symbol.([join(["$(symbol(G[k], i[length(G)-k+1]))" for k in 1:length(G)], " \\otimes ") for i in AbstractAlgebra.ProductIterator([1:ngens(g) for g in reverse(G)])])
   end
 
   set_attribute!(F, :show => Hecke.show_tensor_product, :tensor_product => G)

--- a/src/Modules/UngradedModules/Tensor.jl
+++ b/src/Modules/UngradedModules/Tensor.jl
@@ -15,15 +15,16 @@ function tensor_product(G::FreeMod...; task::Symbol = :none)
   if !all(gs) && !all(!x for x in gs)
     error("All factors must either be graded or all must be ungraded.")
   end
-  s = symbols(G[1])
   t = [[x] for x = 1:ngens(G[1])]
   for H = G[2:end]
-    s = [Symbol("$x \\otimes $y") for x = s  for y = symbols(H)]
     t = [push!(deepcopy(x), y) for x = t  for y = 1:ngens(H)]
   end
 
   F = FreeMod(G[1].R, prod([rank(g) for g in G]))
-  F.S = s
+  F.S = function _get_tensor_symbols()
+    return Symbol.([join(["$(symbol(G[k], i[k]))" for k in 1:length(G)], " \\otimes ") for i in AbstractAlgebra.ProductIterator([1:ngens(g) for g in G])])
+  end
+
   set_attribute!(F, :show => Hecke.show_tensor_product, :tensor_product => G)
 
   function pure(g::FreeModElem...)

--- a/src/Modules/deRhamComplexes.jl
+++ b/src/Modules/deRhamComplexes.jl
@@ -14,8 +14,10 @@ function kaehler_differentials(R::Union{MPolyRing, MPolyLocRing}; cached::Bool=t
   end
   n = ngens(R)
   result = FreeMod(R, n)
-  symb = symbols(R)
-  result.S = [Symbol(:d, symb[i]) for i in 1:n]
+  S = symbols(R)
+  result.S = function _get_symbols() 
+    return [Symbol(:d, S[i]) for i in 1:n]
+  end
   set_attribute!(result, :show, show_kaehler_differentials)
 
   cached && (_kaehler_differentials(R)[1] = result)

--- a/src/Rings/MPolyMap/flattenings.jl
+++ b/src/Rings/MPolyMap/flattenings.jl
@@ -551,7 +551,7 @@ function coordinates(
                                  }
           }
   phi = flatten(parent(x))
-  return change_base_ring(inverse(phi), (coordinates(phi(x), phi(I))))
+  return map_entries(inverse(phi), (coordinates(phi(x), phi(I))))
 end
 
 ########################################################################


### PR DESCRIPTION
This turned out to be a bottleneck in the buildup to #4951 . To demonstrate the effect, try the following:
```julia
R, (x, y) = QQ[:x, :y]
F = free_module(R, 1)
@time G, _ = direct_sum([F for _ in 1:10000]);
```
Before: 
```
julia> @time G, _ = direct_sum([F for _ in 1:10000]);
  2.458533 seconds (1.01 M allocations: 2.785 GiB, 52.62% gc time, 1.06% compilation time)
```
After:
```
julia> @time G, _ = direct_sum([F for _ in 1:10000]);
  0.043270 seconds (627.92 k allocations: 31.499 MiB, 61.40% compilation time)
```
Edit: This now contains further patches for bottlenecks snooped up during work on #4951 . Some of these are rather hotfixes and should still be pulled straight at some point. But everything works for the moment! 

Controversial things to be discussed:

 * So far, symbols decided over equality of modules and were included in hashing. ~~This would have to go if we lazify them.~~ Changed back to using symbols for comparison and hashing.  This can probably still be sped up according to @fingolfin 's comment below. 
 * ~~`generator_symbols` was replaced by `symbols`. This is not super necessary, but I was unaware of the existence of `generator_symbols` and started working with the other function.~~ `generator_symbols` is now left as an alias for `symbols`. 
 * Use of sparse matrices for the transformation matrices in `lift_std` (see below and #4925 ).