### PR TITLE
CI: allow running extra-long tests via label / dispatch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,11 @@ on:
       # Every day at 3:10 AM UTC
       - cron: '10 3 * * *'
   workflow_dispatch:
+    inputs:
+      extralong:
+        type: boolean
+        default: false
+        description: Run extra long test set
 
 # needed to allow julia-actions/cache to delete old caches that it has created
 permissions:
@@ -187,7 +192,7 @@ jobs:
   extra-long-test:
     # Extra long tests
     # Only happens during the daily run, triggered by schedule
-    if: github.event_name == 'schedule'
+    if: ${{ github.event_name == 'schedule' || ( github.event_name == 'workflow_dispatch' && inputs.extralong ) || ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'extra-long') ) }}
     runs-on: [Linux, RPTU, normal-memory]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This should add a checkbox for the extra long tests to the manual `workflow_dispatch` and should automatically include these tests in the PR CI when the `extra-long` label is set.

![extralong](https://github.com/user-attachments/assets/b3fec058-b8bf-4b64-8495-ec5590a9c36f)
