### PR TITLE
Remove calls to `groebner_assure`

### DIFF
--- a/src/Rings/NumberField.jl
+++ b/src/Rings/NumberField.jl
@@ -193,10 +193,7 @@ function assert_has_gb(K::NfNSGen)
     return nothing
   end
   I = defining_ideal(K)
-  groebner_assure(I, degrevlex(gens(base_ring(I))))
-  GI = first(values(I.gb))
-  singular_assure(GI)
-  GI.S.isGB = true
+  standard_basis(I, ordering=degrevlex(gens(base_ring(I))))
   return nothing
 end
 

--- a/src/Rings/groebner/fglm.jl
+++ b/src/Rings/groebner/fglm.jl
@@ -155,7 +155,7 @@ function _compute_groebner_basis_using_fglm(I::MPolyIdeal,
   isa(coefficient_ring(I), AbstractAlgebra.Field) || error("The FGLM algorithm requires a coefficient ring that is a field.")
   haskey(I.gb, destination_ordering) && return I.gb[destination_ordering]
   is_global(destination_ordering) || error("Destination ordering must be global.")
-  G = groebner_assure(I, true, true)
+  G = groebner_basis(I, complete_reduction=true)
   start_ordering = G.ord
   dim(I) == 0 || error("Dimension of ideal must be zero.")
   I.gb[destination_ordering] = _fglm(G, destination_ordering)

--- a/src/Rings/groebner/general.jl
+++ b/src/Rings/groebner/general.jl
@@ -114,7 +114,7 @@ function standard_basis(I::MPolyIdeal; ordering::MonomialOrdering = default_orde
       R = base_ring(I)
       K = iszero(characteristic(R)) && !haskey(I.gb, degrevlex(R)) ? _mod_rand_prime(I) : I
       S = base_ring(K)
-      gb = groebner_assure(K, degrevlex(S))
+      gb = standard_basis(K, ordering=degrevlex(S))
       # 2024-02-09 Next lines "blindly" updated to use new homogenization UI
       H = homogenizer(S, "w")
       K_hom = H(K)

--- a/src/Rings/groebner/hilbert-driven.jl
+++ b/src/Rings/groebner/hilbert-driven.jl
@@ -110,7 +110,7 @@ function groebner_basis_hilbert_driven(I::MPolyIdeal{P};
     if characteristic(base_ring(I)) > 0 && ordering == wdegrevlex(base_ring(I), weights)
       return G
     end
-    h = Singular.hilbert_series(singular_generators(G), weights)
+    h = Singular.hilbert_series(singular_generators(G, G.ord), weights)
 
   else
     # Quoting from the documentation of Singular.hilbert_series:

--- a/src/Rings/groebner/hilbert-driven.jl
+++ b/src/Rings/groebner/hilbert-driven.jl
@@ -102,16 +102,15 @@ function groebner_basis_hilbert_driven(I::MPolyIdeal{P};
   if isnothing(hilbert_numerator)
     if isempty(I.gb)
       J = iszero(characteristic(base_ring(I))) ? _mod_rand_prime(I) : I
-      G = groebner_assure(J, wdegrevlex(base_ring(J), weights))
+      G = standard_basis(J, ordering=wdegrevlex(base_ring(J), weights))
     else
-      G = groebner_assure(I)
+      G = standard_basis(I)
     end
 
     if characteristic(base_ring(I)) > 0 && ordering == wdegrevlex(base_ring(I), weights)
       return G
     end
-    singular_assure(G)
-    h = Singular.hilbert_series(G.S, weights)
+    h = Singular.hilbert_series(singular_generators(G), weights)
 
   else
     # Quoting from the documentation of Singular.hilbert_series:

--- a/test/Rings/groebner.jl
+++ b/test/Rings/groebner.jl
@@ -139,8 +139,7 @@
 
     R, (x, y) = polynomial_ring(QQ, [:x, :y])
     I = ideal(R,[x^2+x*y+y,x+y^2])
-    standard_basis(I, ordering=lex(R), complete_reduction=true)
-    G = Oscar.groebner_assure(I, true, true)
+    G = standard_basis(I, ordering=lex(R), complete_reduction=true)
     @test G.ord == lex(R)
 end
 


### PR DESCRIPTION
Removes some of the `singular_assure` and `groebner_assure` calls discussed at triage today. See also #1920 .