### PR TITLE
No longer export misleading `@perm_str` from AA

### DIFF
--- a/docs/src/StraightLinePrograms/intro.md
+++ b/docs/src/StraightLinePrograms/intro.md
@@ -188,7 +188,7 @@ return: true
 julia> SLP.evaluate(p1 & p2, [X, Y])
 test((xy^2), 2) & test(y, 4)
 
-julia> using AbstractAlgebra; perm1, perm2 = perm"(1, 4)", perm"(1, 3, 4, 2)";
+julia> perm1, perm2 = AbstractAlgebra.perm"(1, 4)", AbstractAlgebra.perm"(1, 3, 4, 2)";
 
 julia> SLP.evaluate(p1 & p2, [perm1, perm2])
 true

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -182,6 +182,7 @@ import Nemo:
 # By default we import everything exported by Hecke, and then also re-export
 # it -- with the exception of identifiers listed in `exclude_hecke` below:
 let exclude_hecke = [
+    Symbol("@perm_str"), # see https://github.com/oscar-system/Oscar.jl/issues/4963
     :change_uniformizer,
     :coefficients,
     :exponent_vectors,

--- a/test/StraightLinePrograms/atlas.jl
+++ b/test/StraightLinePrograms/atlas.jl
@@ -139,7 +139,7 @@ end
 end
 
 @testset "AtlasSLDecision evaluate /compile" begin
-    p = perm"(1, 2)(3, 4)"
+    p = AbstractAlgebra.perm"(1, 2)(3, 4)"
     q = Perm([1, 4, 2, 3])
     pq = [p, q]
 

--- a/test/StraightLinePrograms/gap.jl
+++ b/test/StraightLinePrograms/gap.jl
@@ -159,7 +159,7 @@ end
 end
 
 @testset "GAPSLDecision evaluate / compile!" begin
-    p = perm"(1, 2)(3, 4)"
+    p = AbstractAlgebra.perm"(1, 2)(3, 4)"
     q = Perm([1, 4, 2, 3])
     pq = [p, q]
 


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/4963.