### PR TITLE
Adapt Lie algebras to `vector_space_dim`

### DIFF
--- a/experimental/BasisLieHighestWeight/src/BasisLieHighestWeight.jl
+++ b/experimental/BasisLieHighestWeight/src/BasisLieHighestWeight.jl
@@ -15,6 +15,7 @@ import Oscar: dim
 import Oscar: monomial_ordering
 import Oscar: monomials
 import Oscar: root_system
+import Oscar: vector_space_dim
 
 import Base: length
 

--- a/experimental/BasisLieHighestWeight/src/ModuleData.jl
+++ b/experimental/BasisLieHighestWeight/src/ModuleData.jl
@@ -1,10 +1,14 @@
 abstract type ModuleData{C<:FieldElem,LieT<:LieAlgebraElem{C}} end
 
+function dim(V::ModuleData)
+  return vector_space_dim(V)
+end
+
 # To be implemented by subtypes:
 # Mandatory:
 #   base_lie_algebra(V::MyModuleData) -> LieAlgebra
 #   highest_weight(V::MyModuleData) -> WeightLatticeElem
-#   dim(V::MyModuleData) -> ZZRingElem
+#   vector_space_dim(V::MyModuleData) -> ZZRingElem
 #   character(V::MyModuleData) -> Dict{WeightLatticeElem,ZZRingElem}
 
 mutable struct SimpleModuleData{C<:FieldElem,LieT<:LieAlgebraElem{C}} <: ModuleData{C,LieT}
@@ -36,7 +40,7 @@ function highest_weight(V::SimpleModuleData)
   return V.highest_weight
 end
 
-function dim(V::SimpleModuleData)
+function vector_space_dim(V::SimpleModuleData)
   if !isdefined(V, :dim)
     V.dim = dim_of_simple_module(ZZRingElem, base_lie_algebra(V), highest_weight(V))
   end

--- a/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/AbstractLieAlgebra.jl
@@ -12,7 +12,7 @@ parent(x::AbstractLieAlgebraElem) = x.parent
 
 coefficient_ring(L::AbstractLieAlgebra{C}) where {C<:FieldElem} = L.R::parent_type(C)
 
-dim(L::AbstractLieAlgebra) = L.dim
+vector_space_dim(L::AbstractLieAlgebra) = L.dim
 
 _struct_consts(L::AbstractLieAlgebra{C}) where {C<:FieldElem} =
   L.struct_consts::Matrix{sparse_row_type(C)}

--- a/experimental/LieAlgebras/src/DirectSumLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/DirectSumLieAlgebra.jl
@@ -13,7 +13,7 @@ parent(x::DirectSumLieAlgebraElem) = x.parent
 
 coefficient_ring(L::DirectSumLieAlgebra{C}) where {C<:FieldElem} = L.R::parent_type(C)
 
-dim(L::DirectSumLieAlgebra) = L.dim
+vector_space_dim(L::DirectSumLieAlgebra) = L.dim
 
 ###############################################################################
 #

--- a/experimental/LieAlgebras/src/LieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LieAlgebra.jl
@@ -4,7 +4,7 @@
 #   elem_type(::Type{MyLieAlgebra{C}}) = MyLieAlgebraElem{C}
 #   parent(x::MyLieAlgebraElem{C}) -> MyLieAlgebra{C}
 #   coefficient_ring(L::MyLieAlgebra{C}) -> parent_type(C)
-#   dim(L::MyLieAlgebra) -> Int
+#   vector_space_dim(L::MyLieAlgebra) -> Int
 #   symbols(L::MyLieAlgebra) -> Vector{Symbol}
 #   bracket(x::MyLieAlgebraElem{C}, y::MyLieAlgebraElem{C}) -> MyLieAlgebraElem{C}
 #   Base.show(io::IO, x::MyLieAlgebra)
@@ -32,7 +32,8 @@ gen(L::LieAlgebra, i::Int) = basis(L, i)
 
 Return the dimension of the Lie algebra `L`.
 """
-dim(_::LieAlgebra) = error("Should be implemented by subtypes.")
+dim(L::LieAlgebra) = vector_space_dim(L)
+vector_space_dim(_::LieAlgebra) = error("Should be implemented by subtypes.")
 
 @doc raw"""
     basis(L::LieAlgebra{C}) -> Vector{LieAlgebraElem{C}}

--- a/experimental/LieAlgebras/src/LieAlgebraIdeal.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraIdeal.jl
@@ -48,7 +48,8 @@ end
 
 Return the dimension of the ideal `I`.
 """
-dim(I::LieAlgebraIdeal) = length(basis(I))
+dim(I::LieAlgebraIdeal) = vector_space_dim(I)
+vector_space_dim(I::LieAlgebraIdeal) = length(basis(I))
 
 coefficient_ring(I::LieAlgebraIdeal) = coefficient_ring(base_lie_algebra(I))
 

--- a/experimental/LieAlgebras/src/LieAlgebraModule.jl
+++ b/experimental/LieAlgebras/src/LieAlgebraModule.jl
@@ -36,7 +36,8 @@ gen(L::LieAlgebraModule, i::Int) = basis(L, i)
 
 Return the dimension of the Lie algebra module `V`.
 """
-dim(V::LieAlgebraModule) = V.dim
+dim(V::LieAlgebraModule) = vector_space_dim(V)
+vector_space_dim(V::LieAlgebraModule) = V.dim
 
 @doc raw"""
     basis(V::LieAlgebraModule{C}) -> Vector{LieAlgebraModuleElem{C}}

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -86,6 +86,7 @@ import ..Oscar:
   symbols,
   symmetric_power,
   tensor_product,
+  vector_space_dim,
   zero_map,
   ⊕,
   ⊗

--- a/experimental/LieAlgebras/src/LieSubalgebra.jl
+++ b/experimental/LieAlgebras/src/LieSubalgebra.jl
@@ -46,7 +46,8 @@ end
 
 Return the dimension of the Lie subalgebra `S`.
 """
-dim(S::LieSubalgebra) = length(basis(S))
+dim(S::LieSubalgebra) = vector_space_dim(S)
+vector_space_dim(S::LieSubalgebra) = length(basis(S))
 
 coefficient_ring(S::LieSubalgebra) = coefficient_ring(base_lie_algebra(S))
 

--- a/experimental/LieAlgebras/src/LinearLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LinearLieAlgebra.jl
@@ -12,7 +12,7 @@ parent(x::LinearLieAlgebraElem) = x.parent
 
 coefficient_ring(L::LinearLieAlgebra{C}) where {C<:FieldElem} = L.R::parent_type(C)
 
-dim(L::LinearLieAlgebra) = L.dim
+vector_space_dim(L::LinearLieAlgebra) = L.dim
 
 @doc raw"""
     matrix_repr_basis(L::LinearLieAlgebra{C}) -> Vector{MatElem{C}}


### PR DESCRIPTION
I got a bit lost in the dim discussion. For Lie algebras and their modules, `dim` should always be the vector space dimension. Is this change everything that is required for that to be expressed?

ping @emikelsons @fingolfin as you guys worked on the `dim` stuff