### PR TITLE
Update 1.4.1 release date in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 tries to adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.4.1](https://github.com/oscar-system/Oscar.jl/releases/tag/v1.4.1) - 2025-06-06
+## [1.4.1](https://github.com/oscar-system/Oscar.jl/releases/tag/v1.4.1) - 2025-06-07
 
 The following gives an overview of the changes compared to the previous release. This list is not
 complete, many more internal or minor changes were made, but we tried to only list those changes


### PR DESCRIPTION
If 1.4.1 doesn't get released today (which does not seem so with waiting for the registration etc), we should update the release date in the changelog to the actual release date, both on master and release-1.4.

@benlorenz please adapt this PR to the current date once you are ready to do the release, and then undraft and merge