### PR TITLE
Add label checking CI job

### DIFF
--- a/.github/workflows/EnforceLabels.yml
+++ b/.github/workflows/EnforceLabels.yml
@@ -1,0 +1,19 @@
+name: Enforce PR labels
+
+permissions:
+  contents: read
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, reopened, edited, synchronize]
+jobs:
+  enforce-labels:
+    name: Check for blocking labels
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+    - uses: yogevbd/enforce-label-action@2.2.2
+      with:
+        REQUIRED_LABELS_ANY: "release notes: added,release notes: highlight,release notes: not needed,release notes: to be added,release notes: use title"
+        REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label concerning release notes"
+        BANNED_LABELS: "breaking,DO NOT MERGE,needs tests,WIP"
+        BANNED_LABELS_DESCRIPTION: "A PR should not be merged with `DO NOT MERGE`, `breaking`, `needs tests`, or `WIP` labels"


### PR DESCRIPTION
Taken essentially from https://github.com/JuliaTesting/Aqua.jl/blob/master/.github/workflows/enforce-labels.yml.

This job requires one of the release note labels to be set, as IMO the author and/or commiter of a PR are usually better in deciding that than the people preparing a release. With this change, we force them to think of this *before* merging.

And since the action already supports that anyway, the job will block all PRs with a label that suggest it should not be merged right now (like `DO NOT MERGE` and `WIP`, see changes for complete list).

Of course, this new job must be marked as `required` in the branch protection rules.