### PR TITLE
Repair simplification for free resolutions

### DIFF
--- a/experimental/DoubleAndHyperComplexes/src/Morphisms/Types.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Morphisms/Types.jl
@@ -133,7 +133,8 @@ original_complex(c::SimplifiedComplex) = c.original_complex
   # to be set by the external constructor.
   function SimpleFreeResolution(
       M::T,
-      complex::AbsHyperComplex{ChainType, MorphismType},
+      complex::AbsHyperComplex{ChainType, MorphismType};
+      initial_length::Union{Nothing, Int}=nothing
     ) where {ChainType, MorphismType, T}
     return new{ChainType, MorphismType, T}(M, complex)
   end

--- a/experimental/DoubleAndHyperComplexes/src/Morphisms/free_resolutions.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Morphisms/free_resolutions.jl
@@ -1,13 +1,14 @@
 struct ResolutionModuleFactory{ChainType, MapType} <: HyperComplexChainFactory{ChainType}
   orig_mod::SubquoModule
   map_cache::Vector{MapType}
+  initial_length::Union{Nothing, Int}
 
-  function ResolutionModuleFactory(M::SubquoModule)
+  function ResolutionModuleFactory(M::SubquoModule; initial_length::Union{Nothing, Int}=nothing)
     R = base_ring(M)
     ChainType = FreeMod{elem_type(R)}
     MapType = FreeModuleHom{ChainType, ChainType, Nothing}
     map_cache = MapType[]
-    return new{ChainType, MapType}(M, map_cache)
+    return new{ChainType, MapType}(M, map_cache, initial_length)
   end
 end
 
@@ -62,9 +63,7 @@ function (fac::ResolutionModuleFactory{ChainType})(
 
   if is_empty(fac.map_cache)
     # start the resolution from scratch
-    # It turns out to usually be better to compute the full Schreyer resolution at once 
-    # instead of incrementally.
-    res = free_resolution(fac.orig_mod; algorithm=:fres)
+    res = free_resolution(fac.orig_mod; algorithm=:fres, length=isnothing(fac.initial_length) ? 0 : maximum([fac.initial_length::Int, i]))
     phi = map(res, 1)
     F = c[0] # caught above
     id = hom(codomain(phi), F, gens(F))
@@ -73,7 +72,24 @@ function (fac::ResolutionModuleFactory{ChainType})(
     for j in 2:r
       push!(fac.map_cache, map(res, j))
     end
-    @assert is_zero(domain(last(fac.map_cache)))
+    #@assert is_zero(domain(last(fac.map_cache)))
+  end
+
+  m = length(fac.map_cache)
+  i == 0 && return codomain(first(fac.map_cache))
+  i <= m && return domain(fac.map_cache[i])
+
+  last_map = last(fac.map_cache)
+  if !is_zero(domain(last_map))
+    # extend the resolution
+    delta = i - m - 1
+    K, inc_K = kernel(last_map)
+    res_ext = free_resolution(K; algorithm=:fres, length=delta)
+    push!(fac.map_cache, compose(map(res_ext, 0), inc_K))
+    r = first(range(res_ext.C)) # the index of the last module
+    for j in 2:r
+      push!(fac.map_cache, map(res_ext, j))
+    end
   end
 
   m = length(fac.map_cache)
@@ -121,11 +137,14 @@ function (fac::ResolutionMapFactory)(c::AbsHyperComplex, p::Int, I::Tuple)
 end
 
 
-function free_resolution(::Type{T}, M::SubquoModule{RET}) where {T<:SimpleFreeResolution, RET}
+function free_resolution(
+    ::Type{T}, M::SubquoModule{RET};
+    initial_length::Union{Int, Nothing}=nothing
+  ) where {T<:SimpleFreeResolution, RET}
   ChainType = FreeMod{RET}
   MorphismType = FreeModuleHom{ChainType, ChainType, Nothing}
 
-  chain_fac = ResolutionModuleFactory(M)
+  chain_fac = ResolutionModuleFactory(M; initial_length)
   map_fac = ResolutionMapFactory{MorphismType}()
 
   R = base_ring(M)
@@ -143,12 +162,15 @@ function free_resolution(::Type{T}, M::SubquoModule{RET}) where {T<:SimpleFreeRe
   return result, aug_map_comp
 end
 
-function free_resolution(::Type{T}, F::FreeMod{RET}) where {T<:SimpleFreeResolution, RET}
+function free_resolution(
+    ::Type{T}, F::FreeMod{RET};
+    initial_length::Union{Nothing, Int}=nothing
+  ) where {T<:SimpleFreeResolution, RET}
   ChainType = FreeMod{RET}
   MorphismType = FreeModuleHom{ChainType, ChainType, Nothing}
 
   M = SubquoModule(F, gens(F), elem_type(F)[])
-  chain_fac = ResolutionModuleFactory(M)
+  chain_fac = ResolutionModuleFactory(M; initial_length)
   map_fac = ResolutionMapFactory{MorphismType}()
 
   R = base_ring(M)
@@ -157,7 +179,7 @@ function free_resolution(::Type{T}, F::FreeMod{RET}) where {T<:SimpleFreeResolut
                                   upper_bounds = [upper_bound], 
                                   lower_bounds = [0]
                                  )
-  result = SimpleFreeResolution(M, internal_complex)
+  result = SimpleFreeResolution(M, internal_complex; initial_length)
   FC = ZeroDimensionalComplex(F)[0:0] # Wrap FC as a 1-dimensional complex concentrated in degree 0
   aug_map = hom(result[(0,)], F, gens(F); check=false) # The actual augmentation map
   aug_map.generators_map_to_generators = true
@@ -166,17 +188,23 @@ function free_resolution(::Type{T}, F::FreeMod{RET}) where {T<:SimpleFreeResolut
   return result, aug_map_comp
 end
 
-function free_resolution(::Type{T}, I::Ideal{RET}) where {T<:SimpleFreeResolution, RET}
+function free_resolution(
+    ::Type{T}, I::Ideal{RET};
+    initial_length::Union{Nothing, Int}=nothing
+  ) where {T<:SimpleFreeResolution, RET}
   R = base_ring(I)
   F = (!is_graded(R) ? FreeMod(R, 1) : graded_free_module(R, [zero(grading_group(R))]))
   M, _ = I*F
   if is_graded(R)
     @assert is_graded(M)
   end
-  return free_resolution(T, M)
+  return free_resolution(T, M; initial_length)
 end
 
-function free_resolution(::Type{T}, A::MPolyQuoRing) where {T<:SimpleFreeResolution}
+function free_resolution(
+    ::Type{T}, A::MPolyQuoRing;
+    initial_length::Union{Nothing, Int}=nothing
+  ) where {T<:SimpleFreeResolution}
   R = base_ring(A)
   I = modulus(A)
   F = (!is_graded(R) ? FreeMod(R, 1) : graded_free_module(R, [zero(grading_group(R))]))
@@ -185,7 +213,7 @@ function free_resolution(::Type{T}, A::MPolyQuoRing) where {T<:SimpleFreeResolut
   if is_graded(R)
     @assert is_graded(M)
   end
-  return free_resolution(T, AA)
+  return free_resolution(T, AA; initial_length)
 end
 
 ### Additional getters

--- a/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
@@ -356,7 +356,15 @@ function simplify(c::FreeResolution{T}) where T
     end
     last(cc.maps)
   end
-  return FreeResolution(result)
+  final_res = FreeResolution(result)
+  final_res.length = length(c)
+  return final_res
+end
+
+# An alias to cater for the common phrasing of the CA community. 
+function minimize(c::FreeResolution)
+  @assert is_graded(c[-1]) "complex does not consist of graded modules"
+  return simplify(c)
 end
 
 function simplify(c::ComplexOfMorphisms)

--- a/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
@@ -340,11 +340,8 @@ end
 # differently.
 =#
 function simplify(c::FreeResolution{T}) where T
-  i = 0
-  while !is_zero(c[i])
-    i += 1
-  end
-  simp = simplify(SimpleComplexWrapper(c.C[0:i]))
+  cut_off = length(c.C.maps)-2
+  simp = simplify(SimpleComplexWrapper(c.C[0:cut_off]))
   phi = map_to_original_complex(simp)
   result = Hecke.ComplexOfMorphisms(T, morphism_type(T)[map(c, -1)]; seed=-2)
   result.fill = function _fill(cc::ComplexOfMorphisms, i::Int)
@@ -354,10 +351,10 @@ function simplify(c::FreeResolution{T}) where T
     else
       pushfirst!(cc.maps, map(simp, i))
     end
-    last(cc.maps)
+    first(cc.maps)
   end
   final_res = FreeResolution(result)
-  final_res.length = length(c)
+  final_res.length = cut_off
   return final_res
 end
 

--- a/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
@@ -350,9 +350,9 @@ function simplify(c::FreeResolution{T}) where T
   result.fill = function _fill(cc::ComplexOfMorphisms, i::Int)
     cc[i-1] # make sure cache is up to date
     if is_zero(i)
-      push!(cc.maps, compose(phi[0], map(c, 0)))
+      pushfirst!(cc.maps, compose(phi[0], map(c, 0)))
     else
-      push!(cc.maps, map(simp, i))
+      pushfirst!(cc.maps, map(simp, i))
     end
     last(cc.maps)
   end

--- a/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
@@ -354,7 +354,6 @@ function simplify(c::FreeResolution{T}) where T
     first(cc.maps)
   end
   final_res = FreeResolution(result)
-  final_res.length = cut_off
   return final_res
 end
 

--- a/src/AlgebraicGeometry/Surfaces/AdjunctionProcess/AdjunctionProcess.jl
+++ b/src/AlgebraicGeometry/Surfaces/AdjunctionProcess/AdjunctionProcess.jl
@@ -149,9 +149,10 @@ julia> I = ideal(R, [x[1]*x[6] - x[2]*x[5] + x[3]*x[4]]);
 julia> GRASSMANNIAN = variety(I);
 
 julia> Omega = canonical_bundle(GRASSMANNIAN)
-Graded submodule of R^1 with 1 generator
+Graded subquotient of graded submodule of R^1 with 1 generator
   1: e[1]
-represented as subquotient with no relations
+by graded submodule of R^1 with 1 generator
+  1: (x[1]*x[6] - x[2]*x[5] + x[3]*x[4])*e[1]
 
 julia> degrees_of_generators(Omega)
 1-element Vector{FinGenAbGroupElem}:

--- a/src/AlgebraicGeometry/Surfaces/AdjunctionProcess/AdjunctionProcess.jl
+++ b/src/AlgebraicGeometry/Surfaces/AdjunctionProcess/AdjunctionProcess.jl
@@ -198,7 +198,7 @@ function canonical_bundle(X::AbsProjectiveVariety)
   A = homogeneous_coordinate_ring(X)
   n = ngens(Pn)-1
   c = codim(X)
-  FA = free_resolution(A, algorithm = :fres)
+  FA, _ = free_resolution(SimpleFreeResolution, A)
   C_simp = simplify(FA)
   C_shift = shift(C_simp, c)
   OmegaPn = graded_free_module(Pn, [n+1])

--- a/src/Modules/ModuleTypes.jl
+++ b/src/Modules/ModuleTypes.jl
@@ -763,11 +763,14 @@ Data structure for free resolutions.
 """
 mutable struct FreeResolution{T}
     C::Hecke.ComplexOfMorphisms
+    length::Union{Nothing, Int}
 
     function FreeResolution(C::Hecke.ComplexOfMorphisms{T}) where {T}
-        FR = new{T}()
+        FR = new{T}(C, nothing)
         FR.C = C
-
+        if C.complete
+          FR.length = length(C.maps)-3
+        end
         return FR
     end
 end

--- a/src/Modules/ModuleTypes.jl
+++ b/src/Modules/ModuleTypes.jl
@@ -763,14 +763,11 @@ Data structure for free resolutions.
 """
 mutable struct FreeResolution{T}
     C::Hecke.ComplexOfMorphisms
-    length::Union{Nothing, Int}
 
     function FreeResolution(C::Hecke.ComplexOfMorphisms{T}) where {T}
-        FR = new{T}(C, nothing)
+        FR = new{T}()
         FR.C = C
-        if C.complete
-          FR.length = length(C.maps)-3
-        end
+
         return FR
     end
 end

--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -2561,7 +2561,7 @@ Betti table of the minimal free resolution arising from `F`.
     The algorithm proceeds without actually minimizing the resolution.
 
 !!! note
-    In the case of a non-complete free resolution, the minimal Betti table is computed only up to the second last known non-zero entry. To look further, the resolution must first be extended.
+    In the case of a non-complete free resolution, the minimal Betti table is computed only up to the second last known non-zero module. To look further, the resolution must first be extended.
 
 # Examples
 ```jldoctest

--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -1477,7 +1477,7 @@ function betti_table(F::FreeResolution; project::Union{FinGenAbGroupElem, Nothin
   @assert is_graded(F) "resolution must be graded"
   generator_count = Dict{Tuple{Int, Any}, Int}()
   C = F.C
-  n = isnothing(F.length) ? first(Hecke.map_range(C)) : F.length::Int
+  n = first(Hecke.map_range(C))
   for i in 0:n
     module_degrees = F[i].d
     for degree in module_degrees

--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -1477,8 +1477,7 @@ function betti_table(F::FreeResolution; project::Union{FinGenAbGroupElem, Nothin
   @assert is_graded(F) "resolution must be graded"
   generator_count = Dict{Tuple{Int, Any}, Int}()
   C = F.C
-  rng = Hecke.map_range(C)
-  n = first(rng)
+  n = isnothing(F.length) ? first(Hecke.map_range(C)) : F.length::Int
   for i in 0:n
     module_degrees = F[i].d
     for degree in module_degrees

--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -2602,6 +2602,13 @@ function minimal_betti_table(res::FreeResolution{T}; check::Bool=true) where {T<
   C = complex(res)
   rng = range(C)
   res_length = length(res)
+  # If the resolution is complete, then we can print the full 
+  # Betti table, including the last inclusion of the zero-module.
+  # If not, then we must stop earlier in order to not trigger 
+  # the computation of another step.
+  if is_complete(res)
+    res_length += 1
+  end
   offsets = Dict{FinGenAbGroupElem, Int}()
   betti_hash_table = Dict{Tuple{Int, Any}, Int}()
   for i in 1:res_length

--- a/src/Modules/UngradedModules/FreeResolutions.jl
+++ b/src/Modules/UngradedModules/FreeResolutions.jl
@@ -760,8 +760,5 @@ julia> length(fr)
 
 ```
 """
-function length(F::FreeResolution)
-  isnothing(F.length) && error("length is not known (resolution is probably lazy and not computed)")
-  return F.length::Int
-end
+length(F::FreeResolution) = length(F.C.maps)-3
 

--- a/src/Modules/UngradedModules/FreeResolutions.jl
+++ b/src/Modules/UngradedModules/FreeResolutions.jl
@@ -760,5 +760,13 @@ julia> length(fr)
 
 ```
 """
-length(F::FreeResolution) = length(F.C.maps)-3
+function length(F::FreeResolution)
+  if !is_complete(F.C)
+    idx = findfirst(is_zero(domain(phi)) for phi in F.C.maps)
+    isnothing(idx) && return first(map_range(F.C))
+    return idx::Int
+  end
+  # complex is complete
+  length(F.C.maps)-3
+end
 

--- a/src/Modules/UngradedModules/FreeResolutions.jl
+++ b/src/Modules/UngradedModules/FreeResolutions.jl
@@ -173,47 +173,6 @@ function _extend_free_resolution(cc::Hecke.ComplexOfMorphisms, idx::Int)
     return map(cc, first(r))
   end
 
-  # The code further below is incorrect, see #4998. Until we can provide a 
-  # reasonable fix using a continuation of Schreyer's ordering, we 
-  # provide a patch with new initiation of kernel computations.
-
-  phi = first(cc.maps)
-  K, inc_K = kernel(phi)
-  R = base_ring(K)
-  F = ambient_free_module(K)
-  SF = singular_module(F)
-  SK = singular_generators(algorithm == :fres ? groebner_basis(K) : K.sub.gens) # We need to start with a gb for `fres`.
-  
-  if algorithm == :fres
-    res = Singular.fres(SK, len_missing-1, "complete")
-  elseif algorithm == :lres
-    error("LaScala's method is not yet available in Oscar.")
-  elseif algorithm == :mres
-    res = Singular.mres(SK, len_missing-1)
-  elseif algorithm == :nres
-    res = Singular.nres(SK, len_missing-1)
-  else
-    error("Unsupported algorithm $algorithm")
-  end
-
-  for j in 1:Singular.length(res)
-    cod = domain(first(cc.maps))
-    I = SubModuleOfFreeModule(cod, res[j]) # convert to an Oscar module
-    phi = is_graded(cod) ? graded_map(cod, gens(I); check=false) : hom(free_module(R, ngens(I)), cod, gens(I))
-    pushfirst!(cc.maps, phi)
-    if is_zero(I)
-      cc.complete = true
-      return first(cc.maps)
-    end
-  end
-  if is_zero(res[Singular.length(res)+1])
-    cod = domain(first(cc.maps))
-    pushfirst!(cc.maps, is_graded(cod) ? graded_map(cod, elem_type(cod)[]; check=false) : hom(free_module(R, 0), cod, elem_type(cod)[]))
-    cc.complete = true
-  end
-  return first(cc.maps)
-
-  #=
   kernel_entry          = image(cc.maps[1])[1]
   br                    = base_ring(kernel_entry)
   singular_free_module  = singular_module(ambient_free_module(kernel_entry))
@@ -270,7 +229,6 @@ function _extend_free_resolution(cc::Hecke.ComplexOfMorphisms, idx::Int)
   set_attribute!(cc, :show => Hecke.pres_show)
   maxidx = min(idx, first(Hecke.map_range(cc)))
   return map(cc, maxidx)
-  =#
 end
 
 @doc raw"""

--- a/src/Modules/UngradedModules/FreeResolutions.jl
+++ b/src/Modules/UngradedModules/FreeResolutions.jl
@@ -760,5 +760,8 @@ julia> length(fr)
 
 ```
 """
-length(F::FreeResolution) = length(F.C.maps)-3
+function length(F::FreeResolution)
+  isnothing(F.length) && error("length is not known (resolution is probably lazy and not computed)")
+  return F.length::Int
+end
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1190,6 +1190,7 @@ export minimal_primes
 export minimal_size_generating_set, has_minimal_size_generating_set, set_minimal_size_generating_set
 export minimal_subalgebra_generators
 export minimal_supercone_coordinates, minimal_supercone_indices, is_minimal_supercone_coordinate_vector
+export minimize
 export minkowski_sum
 export minor
 export module_syzygies


### PR DESCRIPTION
A first attempt to work towards some requests of @wdecker .

Test code:
```julia
R, (x, y, z) = QQ[:x, :y, :z]
F = free_module(R, 2)
I, inc = sub(F, vcat([x*F[1] for x in gens(R)], [x*F[1], F[2]]))
M, pr = quo(F, I)

res_I = free_resolution(I)
res_M = free_resolution(M)

simplify(res_I) # note that this prints as empty because of lazy evaluation!
simplify(res_M)

# the following did everything as expected already:
res_I_alt, aug_I = free_resolution(Oscar.SimpleFreeResolution, I)
res_M_alt, aug_M = free_resolution(Oscar.SimpleFreeResolution, M)
```