### PR TITLE
Don't export internal helpers `singular`, `singular_assure`, `singular_coeff_ring`, `singular_poly_ring` (they were never meant to be exported)

### DIFF
--- a/experimental/ModStd/src/ModStdQ.jl
+++ b/experimental/ModStd/src/ModStdQ.jl
@@ -207,7 +207,7 @@ function groebner_basis_with_transform_inner(I::MPolyIdeal{QQMPolyRingElem}, ord
             end
             if ord == I.gens.ord && !isdefined(I, :gb)
               I.gb[ord] = IdealGens(gd[1:length_gc], keep_ordering = false, isGB = true)
-              singular_assure(I.gb[ord])
+              Oscar.singular_assure(I.gb[ord])
             end
             return G, T
           else

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1614,12 +1614,8 @@ export simplify!
 export simplify_light
 export simplify_with_same_ambient_free_module
 export simulate_valuation
-export singular
-export singular_assure
-export singular_coeff_ring
 export singular_locus
 export singular_locus_reduced
-export singular_poly_ring
 export slpoly_ring
 export small_generating_set, has_small_generating_set, set_small_generating_set
 export small_group

--- a/test/Rings/FunctionField.jl
+++ b/test/Rings/FunctionField.jl
@@ -32,7 +32,7 @@
       @test_throws ArgumentError F3(a) # wrong char
 
       R, (x, y) = polynomial_ring(F, [:x, :y])
-      @test singular_poly_ring(R) isa Singular.PolyRing{Singular.n_transExt}
+      @test Oscar.singular_poly_ring(R) isa Singular.PolyRing{Singular.n_transExt}
 
       @test k(F(1)) isa elem_type(k)
       @test_throws InexactError k(a)

--- a/test/Rings/MPolyQuo.jl
+++ b/test/Rings/MPolyQuo.jl
@@ -127,7 +127,7 @@ end
 
   I = ideal(Q, [x^2*y-x+y,y+1])
   simplify(I)
-  SQ = singular_poly_ring(Q)
+  SQ = Oscar.singular_poly_ring(Q)
   SI = I.gens.gens.S
   @test SI[1] == SQ(-x+y) && SI[2] == SQ(y+1)
   J = ideal(Q, [x+y+1,y+1])

--- a/test/Rings/orderings.jl
+++ b/test/Rings/orderings.jl
@@ -326,8 +326,8 @@ end
              neglex([x,y,s])*neginvlex([t,u]),
              negdeglex([x,y,s])*negdegrevlex([t,u]),
              negwdeglex([x,y,s],[1,2,3])*negwdegrevlex([t,u],[1,2]))
-      @test O == monomial_ordering(R, singular(O))
-      @test O == monomial_ordering(R, Singular.ordering(singular_poly_ring(R, O)))
+      @test O == monomial_ordering(R, Oscar.singular(O))
+      @test O == monomial_ordering(R, Singular.ordering(Oscar.singular_poly_ring(R, O)))
    end
 
    @test_throws ErrorException monomial_ordering(R, Singular.ordering_lp(4))
@@ -337,55 +337,55 @@ end
 
    O1 = degrevlex(gens(R))
    test_opposite_ordering(O1)
-   @test monomial_ordering(R, singular(O1)) == O1
+   @test monomial_ordering(R, Oscar.singular(O1)) == O1
    @test length(string(O1)) > 2
-   @test string(singular(O1)) == "ordering_dp(5)"
+   @test string(Oscar.singular(O1)) == "ordering_dp(5)"
 
    O2 = lex([x, y])*deglex([s, t, u])
    test_opposite_ordering(O2)
-   @test monomial_ordering(R, singular(O2)) == O2
+   @test monomial_ordering(R, Oscar.singular(O2)) == O2
    @test length(string(O2)) > 2
-   @test string(singular(O2)) == "ordering_lp(2) * ordering_Dp(3)"
+   @test string(Oscar.singular(O2)) == "ordering_lp(2) * ordering_Dp(3)"
 
    O3 = wdeglex(gens(R), [2, 3, 5, 7, 3])
    test_opposite_ordering(O3)
-   @test monomial_ordering(R, singular(O3)) == O3
+   @test monomial_ordering(R, Oscar.singular(O3)) == O3
    @test length(string(O3)) > 2
-   @test string(singular(O3)) == "ordering_Wp([2, 3, 5, 7, 3])"
+   @test string(Oscar.singular(O3)) == "ordering_Wp([2, 3, 5, 7, 3])"
 
    O4 = deglex([x, y, t]) * deglex([y, s, u])
    test_opposite_ordering(O4)
-   @test monomial_ordering(R, singular(O4)) == O4
+   @test monomial_ordering(R, Oscar.singular(O4)) == O4
    @test length(string(O4)) > 2
-   @test string(singular(O4)) == "ordering_M([1 1 0 1 0; 0 -1 0 -1 0; 0 0 0 -1 0; 0 0 1 0 1; 0 0 0 0 -1])"
+   @test string(Oscar.singular(O4)) == "ordering_M([1 1 0 1 0; 0 -1 0 -1 0; 0 0 0 -1 0; 0 0 1 0 1; 0 0 0 0 -1])"
 
    K = free_module(R, 4)
    @test cmp(lex(K), gen(K,1), gen(K,2)) == -1
    @test cmp(invlex(K), gen(K,1), gen(K,2)) == 1
 
    O5 = invlex(gens(K))*degrevlex(gens(R))
-   @test monomial_ordering(R, singular(O5)) == degrevlex(gens(R))
+   @test monomial_ordering(R, Oscar.singular(O5)) == degrevlex(gens(R))
    @test length(string(O5)) > 2
-   @test string(singular(O5)) == "ordering_c() * ordering_dp(5)"
+   @test string(Oscar.singular(O5)) == "ordering_c() * ordering_dp(5)"
 
    a = matrix_ordering([x, y], matrix(ZZ, 2, 2, [1 2; 3 4]))
    b = wdeglex([s, t, u], [1, 2, 3])
    O6 = a * lex(gens(K)) * b
-   @test monomial_ordering(R, singular(O6)) == a * b
+   @test monomial_ordering(R, Oscar.singular(O6)) == a * b
    @test length(string(O6)) > 2
-   @test string(singular(O6)) == "ordering_M([1 2; 3 4]) * ordering_C() * ordering_Wp([1, 2, 3])"
+   @test string(Oscar.singular(O6)) == "ordering_M([1 2; 3 4]) * ordering_C() * ordering_Wp([1, 2, 3])"
 
    O7 = weight_ordering([-1,2,0,2,0], degrevlex(gens(R)))
-   @test monomial_ordering(R, singular(O7)) == O7
+   @test monomial_ordering(R, Oscar.singular(O7)) == O7
    @test length(string(O7)) > 2
-   @test string(singular(O7)) == "ordering_a([-1, 2, 0, 2, 0]) * ordering_dp(5)"
+   @test string(Oscar.singular(O7)) == "ordering_a([-1, 2, 0, 2, 0]) * ordering_dp(5)"
 
    O8 = lex([gen(K,1), gen(K,3), gen(K,4), gen(K,2)]) * degrevlex(gens(R))
-   @test_throws ErrorException singular(O8)
+   @test_throws ErrorException Oscar.singular(O8)
 
    O9 = matrix_ordering([x, y], [1 2; 1 2]; check = false) * lex(gens(R))
-   @test monomial_ordering(R, singular(O9)) == O9
-   @test singular(O9) isa Singular.sordering
+   @test monomial_ordering(R, Oscar.singular(O9)) == O9
+   @test Oscar.singular(O9) isa Singular.sordering
 end
 
 @testset "Polynomial Ordering misc bugs" begin


### PR DESCRIPTION
... as discussed in triage: these functions should never have been exported.

I guess technically one could argue this is a breaking change, but I'd argue this is internals that were accidentally exported and the name and functionality should have made this clear; any experts using this should be able to adapt. Thoughts?

That said, I do think it should be mentioned in the manual, just in case, so from that point of view I don't think there is a problem marking this as "breaking" as long as we understand this as meaning "should be mentioned prominently in the release notes for 1.5.0" and not "should be delayed for 2.0"