### PR TITLE
Add `natural_gset` method for permutation, matrix & Weyl groups

### DIFF
--- a/examples/BlockSys.jl
+++ b/examples/BlockSys.jl
@@ -206,7 +206,7 @@ function block_klueners(C::Oscar.GaloisGrp.GaloisCtx{Hecke.qAdicRootCtx},d) # ch
   cyc = gap_perm([findfirst(y -> y == x, Rts) for x = map(frobenius,Rts)])
   n = degree(C.f)
   divexact(n,d) # catch errors fast
-  Cyc = map(collect,orbits(gset(sub(symmetric_group(n),[cyc])[1]))) 
+  Cyc = map(collect,orbits(natural_gset(sub(symmetric_group(n),[cyc])[1]))) 
   l = length(Cyc)
   Z_values = Dict(zip([i for i in 1:l],length.(Cyc)))
   T = Tree(0)

--- a/examples/GSets_timing.jl
+++ b/examples/GSets_timing.jl
@@ -4,7 +4,7 @@
   # natural constructions (determined by the types of the seeds)
   G = symmetric_group(10)
 
-  Omega = gset(G)
+  Omega = natural_gset(G)
   @benchmark order(stabilizer(Omega, 1)[1])
   @benchmark order(stabilizer(Omega, Set([1, 2]))[1])
   @benchmark order(stabilizer(Omega, [1, 2])[1])

--- a/experimental/LieAlgebras/src/LieAlgebras.jl
+++ b/experimental/LieAlgebras/src/LieAlgebras.jl
@@ -75,6 +75,7 @@ import ..Oscar:
   kernel,
   lower_central_series,
   matrix,
+  natural_gset,
   normalizer,
   number_of_generators,
   ngens,

--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -604,8 +604,8 @@ Return the G-set `Omega` that consists of the closure of root space elements
 under the natural action of `W`.
 
 !!! warning
-    roots(R) will currently return the minimal roots of the root system. 
-    This may only be sane for finite types and that there may be changes for infinite root systems in the future.
+    Currently the seeds are the minimal roots of the root system. 
+    This may only be sane for finite types and there may be changes for infinite root systems in the future.
 
 # Examples
 ```jldoctest

--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -597,6 +597,26 @@ end
 ###############################################################################
 # G-set functionality (can get moved to src/ once `isomorphism(PermGroup, ::WeylGroup)` gets moved)
 
+"""
+    natural_gset(W::WeylGroup)
+
+Return the G-set `Omega` that consists of the closure of root space elements
+under the natural action of `W`.
+
+!!! warning
+    roots(R) will currently return the minimal roots of the root system. 
+    This may only be sane for finite types and that there may be changes for infinite root systems in the future.
+
+# Examples
+```jldoctest
+julia> W = weyl_group(:A, 2);
+
+julia> length(natural_gset(W))
+6
+```
+"""
+natural_gset(W::WeylGroup) = gset(W, *, roots(root_system(W)); closed=is_finite(W))
+
 Base.:^(rw::Union{RootSpaceElem,WeightLatticeElem}, x::WeylGroupElem) = rw * x
 
 function gset_by_type(W::WeylGroup, Omega, ::Type{RootSpaceElem}; closed::Bool=false)

--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -604,7 +604,7 @@ Return the G-set `Omega` that consists of the closure of root space elements
 under the natural action of `W`.
 
 !!! warning
-    Currently the seeds are the minimal roots of the root system. 
+    Currently the seeds are the minimal roots of the root system.
     This may only be sane for finite types and there may be changes for infinite root systems in the future.
 
 # Examples
@@ -615,7 +615,10 @@ julia> length(natural_gset(W))
 6
 ```
 """
-natural_gset(W::WeylGroup) = gset(W, *, roots(root_system(W)); closed=is_finite(W))
+function natural_gset(W::WeylGroup)
+  @req is_finite(W) "Weyl group is not finite"
+  return gset(W, *, roots(root_system(W)); closed=true)
+end
 
 Base.:^(rw::Union{RootSpaceElem,WeightLatticeElem}, x::WeylGroupElem) = rw * x
 

--- a/experimental/LieAlgebras/src/WeylGroup.jl
+++ b/experimental/LieAlgebras/src/WeylGroup.jl
@@ -603,9 +603,8 @@ end
 Return the G-set `Omega` that consists of the closure of root space elements
 under the natural action of `W`.
 
-!!! warning
-    Currently the seeds are the minimal roots of the root system.
-    This may only be sane for finite types and there may be changes for infinite root systems in the future.
+!!! note
+    This function is only implemented for finite Weyl groups, that is root systems of classical type.
 
 # Examples
 ```jldoctest
@@ -616,8 +615,8 @@ julia> length(natural_gset(W))
 ```
 """
 function natural_gset(W::WeylGroup)
-  @req is_finite(W) "Weyl group is not finite"
-  return gset(W, *, roots(root_system(W)); closed=true)
+  @req is_finite(W) "only implemented for finite Weyl groups"
+  return gset(W, roots(root_system(W)); closed=true)
 end
 
 Base.:^(rw::Union{RootSpaceElem,WeightLatticeElem}, x::WeylGroupElem) = rw * x

--- a/experimental/LieAlgebras/test/WeylGroup-test.jl
+++ b/experimental/LieAlgebras/test/WeylGroup-test.jl
@@ -422,8 +422,7 @@
     @test is_semiregular(Omega)
 
     W = weyl_group([(:A, 2), (:B, 3)])
-    pts = roots(root_system(W))
-    Omega = gset(W, pts)
+    Omega = natural_gset(W)
     @test length(Omega) == 24
     @test length(orbits(Omega)) == 3
     @test !is_transitive(Omega)
@@ -446,29 +445,27 @@
 
     # orbit
     W = weyl_group([(:A, 2), (:B, 3)])
-    pts = roots(root_system(W))
-    Omega = gset(W, pts)
+    Omega = natural_gset(W)
     orbs = orbits(Omega)
     @test length(orbs) == 3
-    @test length(orbit(Omega, pts[2])) == 6
+    @test length(orbit(Omega, Omega[2])) == 6
     @test sort(map(length, orbs)) == [6, 6, 12]
 
     # action homomorphism
     W = weyl_group(:A, 2)
-    pts = roots(root_system(W))
-    Omega = gset(W, pts)
+    Omega = natural_gset(W)
     acthom = action_homomorphism(Omega)
     @test order(image(acthom)[1]) == order(W)
 
     # all_blocks
     bl = all_blocks(Omega)
     @test length(bl) == 4
-    @test Set([pts[1], pts[5]]) in bl
+    @test Set([Omega[1], Omega[5]]) in bl
 
     # blocks
     bl = blocks(Omega)
     @test length(bl) == 3
-    @test elements(bl) == map(Set, [[pts[1], pts[4]], [pts[6], pts[3]], [pts[5], pts[2]]])
+    @test elements(bl) == map(Set, [[Omega[1], Omega[4]], [Omega[5], Omega[2]], [Omega[6], Omega[3]]])
     @test length(orbits(bl)) == 1
   end
 end

--- a/experimental/LieAlgebras/test/WeylGroup-test.jl
+++ b/experimental/LieAlgebras/test/WeylGroup-test.jl
@@ -465,7 +465,8 @@
     # blocks
     bl = blocks(Omega)
     @test length(bl) == 3
-    @test elements(bl) == map(Set, [[Omega[1], Omega[4]], [Omega[5], Omega[2]], [Omega[6], Omega[3]]])
+    @test elements(bl) ==
+      map(Set, [[Omega[1], Omega[4]], [Omega[5], Omega[2]], [Omega[6], Omega[3]]])
     @test length(orbits(bl)) == 1
   end
 end

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -226,7 +226,7 @@ end
 """
     natural_gset(G::PermGroup)
 
-Return the G-set `Omega` that consists of the closure of integers 1, ..., degree
+Return the G-set `Omega` that consists of integers 1, ..., degree
 under the natural action of `G`.
 
 # Examples
@@ -242,8 +242,8 @@ natural_gset(G::PermGroup) = gset(G, 1:G.deg; closed = true)
 """
     natural_gset(G::MatrixGroup{T, MT}) where {MT, T <: FinFieldElem}
 
-Return the G-set `Omega` that consists of the closure of vectors
-under the natural action of `G` over a finite field.
+Return the G-set `Omega` that consists of vectors under the 
+natural action of `G` over a finite field.
 
 # Examples
 ```jldoctest
@@ -541,7 +541,7 @@ Return the vector of transitive G-sets in `Omega`.
 julia> G = sylow_subgroup(symmetric_group(6), 2)[1]
 Permutation group of degree 6 and order 16
 
-julia> orbs = orbits(gset(G));
+julia> orbs = orbits(natural_gset(G));
 
 julia> map(collect, orbs)
 2-element Vector{Vector{Int64}}:

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -219,13 +219,43 @@ end
 
 ## (add more such actions: on sets of sets, on sets of tuples, ...)
 
-## natural action of a permutation group on the integers 1, ..., degree
-gset(G::PermGroup) = gset(G, 1:G.deg; closed = true)
+#############################################################################
+##
+##  natural method with implicit action function
 
-## natural action of a matrix group over a finite field on vectors
-function gset(G::MatrixGroup{T, MT}) where T <: FinFieldElem where MT
-    V = free_module(base_ring(G), degree(G))
-    return gset(G, collect(V); closed = true)
+"""
+    natural_gset(G::PermGroup)
+
+Return the G-set `Omega` that consists of the closure of integers 1, ..., degree
+under the natural action of `G`.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(4);
+
+julia> length(natural_gset(G))
+4
+```
+"""
+natural_gset(G::PermGroup) = gset(G, 1:G.deg; closed = true)
+
+"""
+    natural_gset(G::MatrixGroup{T, MT}) where {MT, T <: FinFieldElem}
+
+Return the G-set `Omega` that consists of the closure of vectors
+under the natural action of `G` over a finite field.
+
+# Examples
+```jldoctest
+julia> G = matrix_group(GF(2), 2);
+
+julia> length(natural_gset(G))
+4
+```
+"""
+function natural_gset(G::MatrixGroup{T, MT}) where {MT, T <: FinFieldElem}
+  V = free_module(base_ring(G), degree(G))
+  return gset(G, collect(V); closed = true)
 end
 
 

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -578,7 +578,7 @@ julia> map(length, orbs)
  2
 ```
 """
-@attr Vector{GSetByElements{PermGroup, Int}} orbits(G::PermGroup) = orbits(gset(G))
+@attr Vector{GSetByElements{PermGroup, Int}} orbits(G::PermGroup) = orbits(natural_gset(G))
 
 
 """
@@ -600,7 +600,7 @@ If `check` is `false` then it is not checked whether `omega` is in `Omega`.
 
 # Examples
 ```jldoctest
-julia> Omega = gset(symmetric_group(4));
+julia> Omega = natural_gset(symmetric_group(4));
 
 julia> stabilizer(Omega)
 (Permutation group of degree 4 and order 6, Hom: permutation group -> Sym(4))
@@ -940,7 +940,7 @@ To also obtain a conjugating element use [`is_conjugate_with_data`](@ref).
 julia> G = sylow_subgroup(symmetric_group(6), 2)[1]
 Permutation group of degree 6 and order 16
 
-julia> Omega = gset(G);
+julia> Omega = natural_gset(G);
 
 julia> is_conjugate(Omega, 1, 2)
 true
@@ -966,7 +966,7 @@ If the conjugating element `g` is not needed, use [`is_conjugate`](@ref).
 julia> G = sylow_subgroup(symmetric_group(6), 2)[1]
 Permutation group of degree 6 and order 16
 
-julia> Omega = gset(G);
+julia> Omega = natural_gset(G);
 
 julia> is_conjugate_with_data(Omega, 1, 2)
 (true, (1,2))
@@ -1026,7 +1026,7 @@ An exception is thrown if this action is not transitive.
 
 # Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
-julia> Omega = gset(sylow_subgroup(symmetric_group(4), 2)[1])
+julia> Omega = natural_gset(sylow_subgroup(symmetric_group(4), 2)[1])
 G-set of
   permutation group of degree 4 and order 8
   with seeds 1:4
@@ -1059,7 +1059,7 @@ An exception is thrown if this action is not transitive.
 
 # Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
-julia> Omega = gset(transitive_group(8, 2))
+julia> Omega = natural_gset(transitive_group(8, 2))
 G-set of
   permutation group of degree 8
   with seeds 1:8
@@ -1092,7 +1092,7 @@ An exception is thrown if this action is not transitive.
 
 # Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
-julia> Omega = gset(transitive_group(8, 2))
+julia> Omega = natural_gset(transitive_group(8, 2))
 G-set of
   permutation group of degree 8
   with seeds 1:8
@@ -1125,7 +1125,7 @@ An exception is thrown if this action is not transitive.
 
 # Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
-julia> Omega = gset(transitive_group(8, 2))
+julia> Omega = natural_gset(transitive_group(8, 2))
 G-set of
   permutation group of degree 8
   with seeds 1:8
@@ -1161,10 +1161,10 @@ An exception is thrown if the group action is not transitive on `Omega`.
 
 # Examples
 ```jldoctest
-julia> G = symmetric_group(4); Omega = gset(G); rank_action(Omega)  # 4-transitive
+julia> G = symmetric_group(4); Omega = natural_gset(G); rank_action(Omega)  # 4-transitive
 2
 
-julia> G = dihedral_group(PermGroup, 8); Omega = gset(G); rank_action(Omega)  # not 2-transitive
+julia> G = dihedral_group(PermGroup, 8); Omega = natural_gset(G); rank_action(Omega)  # not 2-transitive
 3
 ```
 """
@@ -1187,10 +1187,10 @@ The output is `0` if the group acts intransitively on `Omega`.
 
 # Examples
 ```jldoctest
-julia> G = mathieu_group(24); Omega = gset(G); transitivity(Omega)
+julia> G = mathieu_group(24); Omega = natural_gset(G); transitivity(Omega)
 5
 
-julia> G = symmetric_group(4); Omega = gset(G); transitivity(Omega)
+julia> G = symmetric_group(4); Omega = natural_gset(G); transitivity(Omega)
 4
 ```
 """
@@ -1211,7 +1211,7 @@ In other word, this tests if `Omega` consists of precisely one orbit.
 julia> G = sylow_subgroup(symmetric_group(6), 2)[1]
 Permutation group of degree 6 and order 16
 
-julia> Omega = gset(G);
+julia> Omega = natural_gset(G);
 
 julia> is_transitive(Omega)
 false
@@ -1238,9 +1238,9 @@ julia> G = symmetric_group(6);
 julia> H = sub(G, [G([2, 3, 4, 5, 6, 1])])[1]
 Permutation group of degree 6
 
-julia> OmegaG = gset(G);
+julia> OmegaG = natural_gset(G);
 
-julia> OmegaH = gset(H);
+julia> OmegaH = natural_gset(H);
 
 julia> is_regular(OmegaH)
 true
@@ -1264,7 +1264,7 @@ julia> G = symmetric_group(6);
 julia> H = sub(G, [G([2, 3, 1, 5, 6, 4])])[1]
 Permutation group of degree 6
 
-julia> OmegaH = gset(H);
+julia> OmegaH = natural_gset(H);
 
 julia> is_semiregular(H)
 true
@@ -1286,14 +1286,14 @@ the action is transitive and admits no nontrivial block systems.
 
 # Examples
 ```jldoctest
-julia> G = symmetric_group(4); Omega = gset(G);
+julia> G = symmetric_group(4); Omega = natural_gset(G);
 
 julia> is_primitive(Omega)
 true
 
 julia> H, _ = sub(G, [cperm([2, 3, 4])]);
 
-julia> is_primitive(gset(H))
+julia> is_primitive(natural_gset(H))
 false
 ```
 """

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -153,3 +153,6 @@ Base.@deprecate_binding in_linear_system is_in_linear_system
 @deprecate acting_domain(C::GroupCoset) acting_group(C)
 @deprecate acting_domain(Omega::GSet) acting_group(Omega)
 @deprecate grid_morphism lattice_homomorphism
+
+@deprecate gset(G::PermGroup) natural_gset(G)
+@deprecate gset(G::MatrixGroup{T, MT}) where {MT, T <: FinFieldElem} natural_gset(G)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -154,5 +154,6 @@ Base.@deprecate_binding in_linear_system is_in_linear_system
 @deprecate acting_domain(Omega::GSet) acting_group(Omega)
 @deprecate grid_morphism lattice_homomorphism
 
+# deprecated for 1.4
 @deprecate gset(G::PermGroup) natural_gset(G)
 @deprecate gset(G::MatrixGroup{T, MT}) where {MT, T <: FinFieldElem} natural_gset(G)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1242,6 +1242,7 @@ export n_vertices
 export name
 export names_of_fusion_sources
 export natural_character
+export natural_gset
 export nef_cone
 export negative_coroot
 export negative_coroots

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -2,7 +2,7 @@
 
   # natural constructions (determined by the types of the seeds)
   G = symmetric_group(6)
-  Omega = gset(G)
+  Omega = natural_gset(G)
   @test AbstractAlgebra.PrettyPrinting.repr_terse(Omega) == "G-set"
   @test isa(Omega, GSet)
   @test (@inferred length(Omega)) == 6
@@ -60,7 +60,7 @@
 
   # larger examples
   G = symmetric_group(100)
-  Omega = gset(G)
+  Omega = natural_gset(G)
   S1, _ = stabilizer(Omega, [1, 2, 3, 4, 5])
   @test order(S1) == factorial(big(95))
   S2, _ = stabilizer(Omega, (1, 2, 3, 4, 5))
@@ -258,9 +258,9 @@ end
 
   # transitivity
   @test transitivity(G8) == 1
-  @test transitivity(gset(G8)) == 1
+  @test transitivity(natural_gset(G8)) == 1
   @test transitivity(S4) == 4
-  @test transitivity(gset(S4)) == 4
+  @test transitivity(natural_gset(S4)) == 4
   @test_throws ArgumentError transitivity(S4, 1:3)
   @test transitivity(S4, 1:4) == 4
   @test transitivity(S4, 1:5) == 0
@@ -273,7 +273,7 @@ end
   G = general_linear_group(2, 3)
   V = free_module(base_ring(G), degree(G))
   v = gen(V, 1)
-  Omega = gset(G)
+  Omega = natural_gset(G)
   @test isa(Omega, GSet)
   @test length(Omega) == 9
   @test order(stabilizer(Omega, v)[1]) * length(orbit(Omega, v)) == order(G)
@@ -311,31 +311,31 @@ end
   @test is_semiregular(Omega)
 
   # orbit
-  Omega = gset(G)
+  Omega = natural_gset(G)
   v = gen(V, 1)
   @test length(orbit(Omega, v)) == length(Oscar.orbit_via_Julia(Omega, v))
 
   # permutation
-  Omega = gset(G)
+  Omega = natural_gset(G)
   g = gen(G, 1)
   pi = permutation(Omega, g)
   @test order(pi) == order(g)
   @test degree(parent(pi)) == length(Omega)
 
   # action homomorphism
-  Omega = gset(G)
+  Omega = natural_gset(G)
   acthom = action_homomorphism(Omega)
   @test pi == g^acthom
   @test has_preimage_with_preimage(acthom, pi)[1]
   @test order(image(acthom)[1]) == 48
 
   # is_conjugate
-  Omega = gset(G)
+  Omega = natural_gset(G)
   @test is_conjugate(Omega, gen(V, 1), gen(V, 2))
   @test ! is_conjugate(Omega, zero(V), gen(V, 1))
 
   # is_conjugate_with_data
-  Omega = gset(G)
+  Omega = natural_gset(G)
   rep = is_conjugate_with_data(Omega, gens(V)...)
   @test rep[1]
   @test gen(V, 1) * rep[2] == gen(V, 2)


### PR DESCRIPTION
This PR implements `natural_gset` for permutation, matrix and Weyl groups for #4938.

We deprecate `gset(::PermGroup)` and `gset(::MatrixGroup)` and let it point towards the corresponding `natural_gset`.