### PR TITLE
Fix printing of FreeAssociativeAlgebraIdeals

### DIFF
--- a/src/Rings/FreeAssociativeAlgebraIdeal.jl
+++ b/src/Rings/FreeAssociativeAlgebraIdeal.jl
@@ -26,7 +26,7 @@ mutable struct FreeAssociativeAlgebraIdeal{T} <: Ideal{T}
 end
 
 function Base.show(io::IO, a::FreeAssociativeAlgebraIdeal)
-  print(io, "Ideal of ", base_ring(a), " with ", ItemQuantity(ngens(a), " generator"))
+  print(io, "Ideal of ", base_ring(a), " with ", ItemQuantity(ngens(a), "generator"))
 end
 
 function Base.:(==)(I2::FreeAssociativeAlgebraIdeal, I1::FreeAssociativeAlgebraIdeal)


### PR DESCRIPTION
#4945 introduced a superfluous space between the number of gens and the word "generators". This shouldn't be there as the ItemQuantity show already adds a space there.