### PR TITLE
cleanup in the GAP package OscarInterface

### DIFF
--- a/gap/pkg/OscarInterface/gap/OscarInterface.gi
+++ b/gap/pkg/OscarInterface/gap/OscarInterface.gi
@@ -42,10 +42,10 @@ end );
 
 # Install the methods for `IsoGapOscar`,
 # in order to make Oscar's `iso_gap_oscar` work.
-Perform( Oscar._iso_gap_oscar_methods,
+Perform( Oscar_jl._iso_gap_oscar_methods,
          function( pair )
            InstallMethod( IsoGapOscar, [ JuliaToGAP( IsString, pair[1] ) ],
-               Oscar.GAP.WrapJuliaFunc( pair[2] ) );
+               GAP_jl.WrapJuliaFunc( pair[2] ) );
          end );
 
 ############################################################################
@@ -86,7 +86,7 @@ end );
 
 ############################################################################
 
-BindGlobal("_OSCAR_GroupElem", Oscar.AbstractAlgebra.GroupElem);
+BindGlobal("_OSCAR_GroupElem", Oscar_jl.AbstractAlgebra.GroupElem);
 
 # the following code ensures that `GAP.Globals.Group` accepts a GAP list
 # of Oscar group elements, as there is a GAP `OrbitStabilizerAlgorithm` method
@@ -127,21 +127,21 @@ InstallMethod( GroupGeneratorsDefinePresentation,
 ############################################################################
 
 
-Perform( Oscar._GAP_type_params,
+Perform( Oscar_jl._GAP_type_params,
          function( entry )
            InstallMethod( SerializationInOscarDependentObjects,
              [ JuliaToGAP( IsString, entry[1] ) ],
              GAP_jl.WrapJuliaFunc( entry[2] ) );
          end );
 
-Perform( Oscar._GAP_serializations,
+Perform( Oscar_jl._GAP_serializations,
          function( entry )
            InstallMethod( SerializeInOscar,
              [ JuliaToGAP( IsString, entry[1] ), "IsObject" ],
              GAP_jl.WrapJuliaFunc( entry[2] ) );
          end );
 
-Perform( Oscar._GAP_deserializations,
+Perform( Oscar_jl._GAP_deserializations,
          function( entry )
            if entry[3] then
              InstallMethod( DeserializeInOscar,

--- a/gap/pkg/OscarInterface/gap/QQBar.gi
+++ b/gap/pkg/OscarInterface/gap/QQBar.gi
@@ -3,8 +3,7 @@ BindGlobal( "QQBarFieldElementFam",
 
 SetIsUFDFamily( QQBarFieldElementFam, true );
 
-DeclareRepresentation( "IsQQBarFieldElementRep",
-  IsJuliaWrapper and IsAttributeStoringRep );
+DeclareRepresentation( "IsQQBarFieldElementRep", IsAttributeStoringRep );
 
 BindGlobal( "QQBarFieldType",
   NewType( QQBarFieldElementFam,

--- a/gap/pkg/OscarInterface/gap/alnuth.gi
+++ b/gap/pkg/OscarInterface/gap/alnuth.gi
@@ -9,7 +9,6 @@ BindGlobal("_PolyRingIso", IsoGapOscar(PolynomialRing(Rationals)));
 
 # given a GAP number field, compute an isomorphic Oscar number field f
 # TODO: also store the isomorphism
-# TODO: turn this into an attribute resp. a method for JuliaWrapper / JuliaData ???
 BindGlobal("_OscarField", function(F)
   local f;
   if not IsBound(F!.oscarField) then

--- a/gap/pkg/OscarInterface/tst/QQBar.tst
+++ b/gap/pkg/OscarInterface/tst/QQBar.tst
@@ -49,6 +49,8 @@ gap> x = x / 1;
 true
 gap> AbsoluteValue( -r ) = r;
 true
+gap> r = QQBarFieldElement( Sqrt( 2 ) );
+true
 
 #
 gap> Sqrt(-x) = QQBarFieldElement(E(4));
@@ -64,6 +66,14 @@ gap> MinimalPolynomial( M );
 x_1^2+(<Root -2.00000 of x + 2>)
 gap> Eigenvalues( F, M );
 [ <Root 1.41421 of x^2 - 2>, <Root -1.41421 of x^2 - 2> ]
+gap> Display( M );
+2x2 matrix over QQBarField:
+                         . <Root 1.41421 of x^2 - 2>
+ <Root 1.41421 of x^2 - 2>                         .
+gap> Display( M : short );
+2x2 matrix over QQBarField:
+       . 1.41421
+ 1.41421       .
 
 #
 gap> r:= Sqrt( QQBarFieldElement( 2 ) );;


### PR DESCRIPTION
- in GAP code, use `Oscar_jl` instead of `Oscar`, `GAP_jl` instead of `Oscar.GAP`, `IsoGapOscar` instead of `Oscar.iso_gap_oscar`
- do not rely on the "`JuliaPointer` magic" that automatically replaces a GAP object with a stored `JuliaPointer` value by this value when the object is accessed from the Julia side
- add a `Display` method for GAP matrices over `QQBarField` (Heiko had asked for that)