### PR TITLE
fix handle refs for IPCserializer

### DIFF
--- a/src/Serialization/serializers.jl
+++ b/src/Serialization/serializers.jl
@@ -178,6 +178,8 @@ function handle_refs(s::SerializerState)
   end
 end
 
+function handle_refs(s::SerializerState{IPCSerializer}) end
+
 function serializer_close(s::SerializerState)
   finish_writing(s)
 end


### PR DESCRIPTION
Fix regression for not adding refs when using IPCSerializer.

```
julia> Qxy, (x, y) = QQ[:x, :y]
(Multivariate polynomial ring in 2 variables over QQ, QQMPolyRingElem[x, y])

julia> save(stdout, [x, y]; serializer=Oscar.IPCSerializer())
{"_ns":{"Oscar":["https://github.com/oscar-system/Oscar.jl","1.5.0-DEV-7897bcac0143f8e114ae74e2c14e4ee4d8d70832"]},"_type":{"name":"Vector","params":{"name":"MPolyRingElem","params":"58b897f1-5a35-46f2-acad-693299804320"}},"data":[[[["1","0"],"1"]],[[["0","1"],"1"]]]}
j
ulia> save(stdout, [x, y])
{"_ns":{"Oscar":["https://github.com/oscar-system/Oscar.jl","1.5.0-DEV-7897bcac0143f8e114ae74e2c14e4ee4d8d70832"]},"_type":{"name":"Vector","params":{"name":"MPolyRingElem","params":"58b897f1-5a35-46f2-acad-693299804320"}},"data":[[[["1","0"],"1"]],[[["0","1"],"1"]]],"_refs":{"58b897f1-5a35-46f2-acad-693299804320":{"_type":{"name":"MPolyRing","params":{"_type":"QQField"}},"data":{"symbols":["x","y"]}}}}
```