### PR TITLE
Fix loading `FreeAssociativeAlgebraElem`s

### DIFF
--- a/src/Serialization/Algebras.jl
+++ b/src/Serialization/Algebras.jl
@@ -39,7 +39,7 @@ function load_object(s::DeserializerState, ::Type{<:FreeAssociativeAlgebraElem},
   elem = MPolyBuildCtx(parent_algebra)
 
   load_array_node(s) do _
-    loaded_coeff = load_object(s, coeff_type, 2)
+    loaded_coeff = load_object(s, coeff_type, base_ring(parent_algebra), 2)
     loaded_term = parent_algebra(loaded_coeff)
     e = load_array_node(s, 1) do _
       load_object(s, Int)

--- a/test/Serialization/Algebras.jl
+++ b/test/Serialization/Algebras.jl
@@ -1,6 +1,10 @@
 cases = [
   (QQ, QQ(1//2), QQ(3//4), "Rational Coefficients"),
   (ZZ, ZZ(5), ZZ(7), "Integers Coefficients"),
+  begin
+    F, i = cyclotomic_field(4)
+    (F, i, F(1//2), "Cyclotomic Field Coefficients")
+  end,
 ]
 
 @testset "Serialization.Algebras" begin


### PR DESCRIPTION
This only used to work for singleton base rings.