### PR TITLE
Allow loading matrices with non-commutative entries

### DIFF
--- a/src/Serialization/Rings.jl
+++ b/src/Serialization/Rings.jl
@@ -337,7 +337,7 @@ function save_object(s::SerializerState, obj::SMatSpace)
   end
 end
 
-function load_object(s::DeserializerState, ::Type{MatSpace}, base_ring::Ring)
+function load_object(s::DeserializerState, ::Type{MatSpace}, base_ring::NCRing)
   ncols = load_object(s, Int, :ncols)
   nrows = load_object(s, Int, :nrows)
   return matrix_space(base_ring, nrows, ncols)

--- a/src/Serialization/containers.jl
+++ b/src/Serialization/containers.jl
@@ -132,7 +132,7 @@ function load_object(s::DeserializerState, T::Type{<:Matrix{S}}) where S
   end
 end
 
-function load_object(s::DeserializerState, T::Type{<:Matrix{S}}, params::Ring) where S
+function load_object(s::DeserializerState, T::Type{<:Matrix{S}}, params::NCRing) where S
   load_node(s) do entries
     if isempty(entries)
       return T(undef, 0, 0)
@@ -542,7 +542,7 @@ function save_object(s::SerializerState, obj::SRow)
   end
 end
 
-function load_object(s::DeserializerState, ::Type{<:SRow}, params::Ring)
+function load_object(s::DeserializerState, ::Type{<:SRow}, params::NCRing)
   pos = Int[]
   entry_type = elem_type(params)
   values = entry_type[]

--- a/test/Serialization/Matrices.jl
+++ b/test/Serialization/Matrices.jl
@@ -5,13 +5,15 @@ Z7 = residue_ring(ZZ, 7)[1]
 Z7t, t = polynomial_ring(GF(7), :t)
 Fin, d = finite_field(t^2 + t + 3)
 Frac = fraction_field(R)
+A, (f,g) = free_associative_algebra(K, [:f, :g])
 
 cases = [
   (QQ, [1 2; 3 4//5]),
   (Z7, [1 3; 4 2]),
   (K, [a a + 1; a - 1 0]),
   (Fin, [d d^3; d^2 0]),
-  (Frac, [1 // x x^2; 3 0])
+  (Frac, [1 // x x^2; 3 0]),
+  (A, [(f^3 + g^2) f^2; g (a*f + 1)]),
 ]
 
 @testset "Matrices" begin
@@ -35,14 +37,16 @@ cases = [
         end
       end
 
-      @testset "Sparse Matrices over $(case[1])" begin
-        m = sparse_matrix(case[1], case[2])
-        test_save_load_roundtrip(path, m) do loaded
-          @test loaded == m
-        end
+      if case[1] isa Ring
+        @testset "Sparse Matrices over $(case[1])" begin
+          m = sparse_matrix(case[1], case[2])
+          test_save_load_roundtrip(path, m) do loaded
+            @test loaded == m
+          end
 
-        test_save_load_roundtrip(path, m; params=parent(m)) do loaded
-          @test loaded == m
+          test_save_load_roundtrip(path, m; params=parent(m)) do loaded
+            @test loaded == m
+          end
         end
       end
     end


### PR DESCRIPTION
The matrices support non-commutative entries, as does the saving. But the loading had a too tight type constraint.

Same thing for sparse rows. Sparse matrices however only support commutative rings, so nothing to do for them.