### PR TITLE
Use oscar-system/should-i-notify action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -303,7 +303,7 @@ jobs:
         id: get-branch
         run: echo "branch=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: Determine whether CI status changed
-        uses: gap-actions/should-i-notify-action@v1
+        uses: aaruni96/should-i-notify-action@v1
         id: should_notify
         with:
           branch: ${{ steps.get-branch.outputs.branch }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -309,7 +309,7 @@ jobs:
           branch: ${{ steps.get-branch.outputs.branch }}
           needs_context: ${{ toJson(needs) }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          notify_on_changed_status: ''
+          notify_on_changed_status: '' # notify each time on failure, and also once when the status changes to success
           event: ${{ github.event_name }}
       - name: Send slack notification
         uses: act10ns/slack@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -303,13 +303,13 @@ jobs:
         id: get-branch
         run: echo "branch=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: Determine whether CI status changed
-        uses: aaruni96/should-i-notify-action@v1
+        uses: oscar-system/should-i-notify-action@v1
         id: should_notify
         with:
           branch: ${{ steps.get-branch.outputs.branch }}
           needs_context: ${{ toJson(needs) }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          notify_on_changed_status: true
+          notify_on_changed_status: ''
           event: ${{ github.event_name }}
       - name: Send slack notification
         uses: act10ns/slack@v2


### PR DESCRIPTION
Use ~aaruni96/should-i-notify-action~ oscar-system/should-i-notify-action instead of gap-actions/should-i-notify-action . This action has been modified from the GAP version to fit OSCAR's needs (earlier, we tried and failed to patch this in place, because GAP's requirements proved to be different).

Currently, this notifies if and only if there is a status change (success -> fail, or, fail -> success), and will not repeat notifications on many failures in a row.

To change this behaviour, switch `notify_on_changed_status` on line 312 to ~false~ empty (`''`). Then, it will notify repeatedly on failures, once when a status change from failure to success occurs, and will stay silent on repeated successes.