### PR TITLE
Rename IdealGens member 'gens' to 'gensBiPolyArray'

### DIFF
--- a/experimental/ModStd/src/ModStdNF.jl
+++ b/experimental/ModStd/src/ModStdNF.jl
@@ -34,10 +34,10 @@ function exp_groebner_basis(B::IdealGens{zzModMPolyRingElem}, h::HilbertData; or
     i = stdhilb(Singular.Ideal(R, [convert(R, x) for x = B]), hdata, complete_reduction = complete_reduction)
     return IdealGens(base_ring(B), i)
   end
-  if !isdefined(B.gens, :S)
-    B.gens.S = Singular.Ideal(B.gens.Sx, [convert(B.Sgens.x, x) for x in oscar_generators(B)])
+  if !isdefined(B.gensBiPolyArray, :S)
+    B.gensBiPolyArray.S = Singular.Ideal(B.gensBiPolyArray.Sx, [convert(B.gensBiPolyArray.Sx, x) for x in oscar_generators(B)])
   end 
-  return IdealGens(base_ring(B), stdhilb(B.gens.S, h.data, complete_reduction = complete_reduction), keep_ordering = false, isGB = true)
+  return IdealGens(base_ring(B), stdhilb(B.gensBiPolyArray.S, h.data, complete_reduction = complete_reduction), keep_ordering = false, isGB = true)
 end
 
 #TODO (to dream)

--- a/experimental/Schemes/src/Tjurina.jl
+++ b/experimental/Schemes/src/Tjurina.jl
@@ -501,7 +501,7 @@ function sharper_determinacy_bound(f::MPolyLocRingElem, equivalence::Symbol = :c
     I = m*a + m^2*jacobian_ideal(a)
   end
   G = standard_basis(I, ordering = negdeglex(parent(a)))
-  h = Singular.highcorner(G.gens.S)
+  h = Singular.highcorner(G.gensBiPolyArray.S)   # TODO: should this use singular_generators(G)?
   l = total_degree(R(h))  
   ## m^(l+1) \subseteq I  
   ## char. 0: l
@@ -703,7 +703,7 @@ function is_contact_equivalent(f::MPolyLocRingElem, g::MPolyLocRingElem)
   a = numerator(f_poly)
   I = m*a + m^2*jacobian_ideal(a)
   G = standard_basis(I, ordering = negdeglex(parent(a)))
-  h = Singular.highcorner(G.gens.S)
+  h = Singular.highcorner(G.gensBiPolyArray.S)   # TODO: should this use singular_generators(G)?
   k = 2*(total_degree(R(h)) + 1 - ord_f)
   ## check k-th tjurina number
   tjurina_number(f_poly, k) == tjurina_number(g_poly, k) || return false

--- a/src/InvariantTheory/fundamental_invariants.jl
+++ b/src/InvariantTheory/fundamental_invariants.jl
@@ -59,7 +59,7 @@ function fundamental_invariants_via_king(RG::FinGroupInvarRing, beta::Int=0)
       I = ideal(R, GO)
       GO = gens(groebner_basis(I; ordering=ordR))
       if is_zero(dim(I))
-        mons = gens(ideal(R, Singular.kbase(I.gb[ordR].gens.S)))
+        mons = gens(ideal(R, Singular.kbase(I.gb[ordR].gensBiPolyArray.S)))
         dmax = maximum(total_degree(f) for f in mons)
         d > dmax ? break : nothing
       end

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -69,7 +69,7 @@ coefficient_ring(Q::MPolyQuoRing) = coefficient_ring(base_ring(Q))
 modulus(Q::MPolyQuoRing) = Q.I
 oscar_groebner_basis(Q::MPolyQuoRing) = _groebner_basis(Q) && return oscar_generators(Q.I.gb[Q.ordering])
 singular_quotient_groebner_basis(Q::MPolyQuoRing) = _groebner_basis(Q) && return Q.SQRGB
-singular_origin_groebner_basis(Q::MPolyQuoRing) = _groebner_basis(Q) && Q.I.gb[Q.ordering].gens.S
+singular_origin_groebner_basis(Q::MPolyQuoRing) = _groebner_basis(Q) && Q.I.gb[Q.ordering].gensBiPolyArray.S
 singular_quotient_ring(Q::MPolyQuoRing) = _groebner_basis(Q) && Q.SQR
 singular_poly_ring(Q::MPolyQuoRing; keep_ordering::Bool = false) = singular_quotient_ring(Q)
 singular_poly_ring(Q::MPolyQuoRing, ordering::MonomialOrdering) = singular_quotient_ring(Q)
@@ -247,7 +247,7 @@ HasGroebnerAlgorithmTrait(::Type{zzModRing}) = HasSingularGroebnerAlgorithm()
    @req singular_quotient_ring(Ox) == base_ring(si) "base rings must match"
    r = new{T}(IdealGens(Ox, si), nothing)
    R = base_ring(Ox)
-   r.gens.gens.O = [R(g) for g in gens(r.gens.gens.S)]
+   r.gens.gensBiPolyArray.O = [R(g) for g in gens(r.gens.gensBiPolyArray.S)]
    B = r.gens
    if length(B) >= 1 && is_graded(R)
      @req all(is_homogeneous, oscar_generators(B)) "The generators of the ideal must be homogeneous"
@@ -305,14 +305,14 @@ function _groebner_basis(a::MPolyQuoIdeal)
   # Make sure that a has a Groebner basis?
   if !isdefined(a, :gb)
     a.gb = IdealGens(base_ring(a), Singular.std(singular_generators(a.gens)))
-    a.gb.gens.S.isGB = a.gb.isGB = true
+    a.gb.gensBiPolyArray.S.isGB = a.gb.isGB = true
   end
 end
 
 function singular_groebner_generators(a::MPolyQuoIdeal)
   _groebner_basis(a)
 
-  return a.gb.gens.S
+  return a.gb.gensBiPolyArray.S
 end
 
 @doc raw"""
@@ -762,8 +762,8 @@ function simplify(a::MPolyQuoIdeal)
   red  = reduce(singular_generators(a.gens), singular_quotient_groebner_basis(Q))
   SQ   = singular_poly_ring(Q)
   si   = Singular.Ideal(SQ, unique!(gens(red)))
-  a.gens.gens.S = si
-  a.gens.gens.O = [R(g) for g in gens(si)]
+  a.gens.gensBiPolyArray.S = si
+  a.gens.gensBiPolyArray.O = [R(g) for g in gens(si)]
   return a
 end
 
@@ -1852,7 +1852,7 @@ function minimal_generating_set(I::MPolyQuoIdeal{<:MPolyDecRingElem})
   else
     sing_gb, sing_min = Singular.mstd(singular_generators(I.gens))
     I.gb = IdealGens(base_ring(I), sing_gb, true)
-    I.gb.gens.S.isGB = I.gb.isGB = true
+    I.gb.gensBiPolyArray.S.isGB = I.gb.isGB = true
     return filter(!iszero, (Q).(gens(sing_min)))
   end
 end

--- a/src/Rings/groebner/fglm.jl
+++ b/src/Rings/groebner/fglm.jl
@@ -46,10 +46,11 @@ with respect to the ordering
 """
 function _fglm(G::IdealGens, ordering::MonomialOrdering)
   (G.isGB == true && G.isReduced == true) || error("Input must be a reduced Gröbner basis.")
-  Singular.dimension(singular_generators(G)) == 0 || error("Dimension of corresponding ideal must be zero.")
-  SR_destination, = Singular.polynomial_ring(base_ring(G.gens.Sx), symbols(G.gens.Sx); ordering = singular(ordering))
+  SG = singular_generators(G)
+  Singular.dimension(SG) == 0 || error("Dimension of corresponding ideal must be zero.")
+  SR_destination, = Singular.polynomial_ring(base_ring(G.gensBiPolyArray.Sx), symbols(G.gensBiPolyArray.Sx); ordering = singular(ordering))
 
-  ptr = Singular.libSingular.fglmzero(G.gens.S.ptr, G.gens.Sx.ptr, SR_destination.ptr)
+  ptr = Singular.libSingular.fglmzero(SG.ptr, G.gensBiPolyArray.Sx.ptr, SR_destination.ptr)
   return IdealGens(base_ring(G), Singular.sideal{Singular.spoly}(SR_destination, ptr, true))
 end
 

--- a/src/Rings/groebner/hilbert-driven.jl
+++ b/src/Rings/groebner/hilbert-driven.jl
@@ -127,8 +127,8 @@ function groebner_basis_hilbert_driven(I::MPolyIdeal{P};
   GB = IdealGens(base_ring(I), i, complete_reduction)
   GB.isGB = true
   GB.ord = ordering
-  if isdefined(GB.gens, :S)
-    GB.gens.S.isGB  = true
+  if isdefined(GB.gensBiPolyArray, :S)
+    GB.gensBiPolyArray.S.isGB  = true
   end
   I.gb[destination_ordering] = GB
   return GB

--- a/src/Rings/groebner/modular.jl
+++ b/src/Rings/groebner/modular.jl
@@ -114,20 +114,15 @@ end
 
 function _certify_modular_groebner_basis(I::MPolyIdeal, ordering::MonomialOrdering)
   @req haskey(I.gb, ordering) "There exists no standard basis w.r.t. the given ordering."
-  ctr = 0
   singular_generators(I.gb[ordering])
-  SR = I.gb[ordering].gens.Sx
-  SG = I.gb[ordering].gens.S
+  SR = I.gb[ordering].gensBiPolyArray.Sx
+  SG = I.gb[ordering].gensBiPolyArray.S
 
   #= test if I is included in <G> =#
   for f in I.gens
     if Singular.reduce(SR(f), SG) != 0
-      break
+      return false
     end
-    ctr += 1
-  end
-  if ctr != ngens(I)
-    return false
   end
 
   #= test if G is a standard basis of <G> w.r.t. ordering =#

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -2725,7 +2725,7 @@ julia> minimal_generating_set(I)
     # use available gb for shifted ideal is available
     G = first(values(I_shift.gb))
     is_local(G.ord) || error("inconsistent data: local ring, but global ordering for I_shift")
-    G.gens.S.isGB = true
+    G.gensBiPolyArray.S.isGB = true
     _, I_shift_min = Singular.mstd(singular_generators(G, G.ord))
   else
 

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -159,7 +159,7 @@ mutable struct BiPolyArray{S}
 end
 
 mutable struct IdealGens{S}
-  gens::BiPolyArray{S}
+  gensBiPolyArray::BiPolyArray{S}
   isGB::Bool
   isReduced::Bool
   ord::Orderings.MonomialOrdering
@@ -196,7 +196,7 @@ mutable struct IdealGens{S}
       else
           r = new{elem_type(T)}()
       end
-      r.gens = BiPolyArray(Ox, S)
+      r.gensBiPolyArray = BiPolyArray(Ox, S)
       r.isGB = S.isGB
       r.isReduced = isReduced
       if T <: MPolyRing
@@ -283,11 +283,11 @@ Base.getindex(A::IdealGens, i::Int) = gen(A, i)
 
 
 function Base.length(A::IdealGens)
-  return length(A.gens)
+  return length(A.gensBiPolyArray)
 end
 
 function base_ring(A::IdealGens)
-  return A.gens.Ox
+  return A.gensBiPolyArray.Ox
 end
 
 function Base.iterate(A::IdealGens, s::Int = 1)
@@ -319,23 +319,23 @@ function set_ordering!(G::IdealGens, monord::MonomialOrdering)
 end
 
 function singular_generators(B::IdealGens, monorder::MonomialOrdering=default_ordering(base_ring(B)))
-  if !isdefined(B.gens, :S)
+  if !isdefined(B.gensBiPolyArray, :S)
     g = iso_oscar_singular_poly_ring(base_ring(B); keep_ordering = B.keep_ordering)
-    B.gens.Sx = codomain(g)
-    B.gens.f = g
-    B.gens.S = Singular.Ideal(B.gens.Sx, elem_type(B.gens.Sx)[g(x) for x in oscar_generators(B)])
+    B.gensBiPolyArray.Sx = codomain(g)
+    B.gensBiPolyArray.f = g
+    B.gensBiPolyArray.S = Singular.Ideal(B.gensBiPolyArray.Sx, elem_type(B.gensBiPolyArray.Sx)[g(x) for x in oscar_generators(B)])
   end
-  if B.isGB && B.ord == monomial_ordering(base_ring(B), internal_ordering(B.gens.Sx))
-    B.gens.S.isGB = true
+  if B.isGB && B.ord == monomial_ordering(base_ring(B), internal_ordering(B.gensBiPolyArray.Sx))
+    B.gensBiPolyArray.S.isGB = true
   end
 
   # in case of quotient rings, monomial ordering is ignored so far in singular_poly_ring
-  isa(base_ring(B), MPolyQuoRing) && return B.gens.S
-  isdefined(B, :ord) && B.ord == monorder && monomial_ordering(base_ring(B), Singular.ordering(base_ring(B.gens.S))) == B.ord && return B.gens.S
+  isa(base_ring(B), MPolyQuoRing) && return B.gensBiPolyArray.S
+  isdefined(B, :ord) && B.ord == monorder && monomial_ordering(base_ring(B), Singular.ordering(base_ring(B.gensBiPolyArray.S))) == B.ord && return B.gensBiPolyArray.S
   g = iso_oscar_singular_poly_ring(base_ring(B), monorder)
   SR = codomain(g)
-  f = Singular.AlgebraHomomorphism(B.gens.Sx, SR, gens(SR))
-  S = Singular.map_ideal(f, B.gens.S)
+  f = Singular.AlgebraHomomorphism(B.gensBiPolyArray.Sx, SR, gens(SR))
+  S = Singular.map_ideal(f, B.gensBiPolyArray.S)
   if isdefined(B, :ord) && B.ord == monorder
     S.isGB = B.isGB
   end
@@ -388,7 +388,7 @@ function Base.:(==)(G1::IdealGens, G2::IdealGens)
   if isdefined(G1, :ord) && G1.ord != G2.ord
       return false
   end
-  return G1.gens == G2.gens
+  return G1.gensBiPolyArray == G2.gensBiPolyArray
 end
 
 function Base.hash(G::IdealGens, h::UInt)
@@ -397,7 +397,7 @@ function Base.hash(G::IdealGens, h::UInt)
   if isdefined(G, :ord)
     h = hash(h, G.ord)
   end
-  h = hash(G.gens, h)
+  h = hash(G.gensBiPolyArray, h)
   return h
 end
 
@@ -623,7 +623,7 @@ end
 
 oscar_generators(I::MPolyIdeal) = oscar_generators(I.gens)
 
-oscar_generators(IG::IdealGens) = oscar_generators(IG.gens)
+oscar_generators(IG::IdealGens) = oscar_generators(IG.gensBiPolyArray)
 
 function oscar_generators(B::BiPolyArray)
   if !isdefined(B, :O)

--- a/test/Rings/MPolyQuo.jl
+++ b/test/Rings/MPolyQuo.jl
@@ -128,7 +128,7 @@ end
   I = ideal(Q, [x^2*y-x+y,y+1])
   simplify(I)
   SQ = Oscar.singular_poly_ring(Q)
-  SI = I.gens.gens.S
+  SI = Oscar.singular_generators(I.gens)
   @test SI[1] == SQ(-x+y) && SI[2] == SQ(y+1)
   J = ideal(Q, [x+y+1,y+1])
   @test issubset(J, I) == true


### PR DESCRIPTION
... to make it easy to grep for. Could also serve as preparation for merging `BiPolyArray` into `IdealGens`. But even without that it's useful when reading the code (`I.gens.gens.S` makes my eyes bleed ;-) )


Contains PR #5003 for now, will rebase on that is merged.