### PR TITLE
FTheoryTools: Improve documentation

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -1925,21 +1925,6 @@
 @Article{KM-POPR15,
   author        = {Klevers, Denis and Mayorga Pena, Damian Kaloni and Oehlmann, Paul-Konstantin and Piragua, Hernan and
                   Reuter, Jonas},
-  title         = {{F-Theory on all Toric Hypersurface Fibrations and its Higgs Branches}},
-  journal       = {JHEP},
-  volume        = {01},
-  pages         = {142},
-  year          = {2015},
-  doi           = {10.1007/JHEP01(2015)142},
-  eprint        = {1408.4808},
-  archiveprefix = {arXiv},
-  primaryclass  = {hep-th},
-  reportnumber  = {UPR-1264-T, CERN-PH-TH-2014-171, Bonn-TH-2014-13}
-}
-
-@Article{KM-POPR15*1,
-  author        = {Klevers, Denis and Mayorga Pena, Damian Kaloni and Oehlmann, Paul-Konstantin and Piragua, Hernan and
-                  Reuter, Jonas},
   title         = {F-Theory on all Toric Hypersurface Fibrations and its Higgs Branches},
   journal       = {JHEP},
   volume        = {01},
@@ -3037,21 +3022,6 @@
 }
 
 @Article{Wit97,
-  author        = {Witten, Edward},
-  title         = {{On flux quantization in M-theory and the effective action}},
-  journal       = {J. Geom. Physics},
-  volume        = {22},
-  pages         = {1--13},
-  year          = {1997},
-  doi           = {10.1016/S0393-0440(96)00042-3},
-  archiveprefix = {arXiv},
-  eprint        = {hep-th/9609122},
-  primaryclass  = {hep-th},
-  reportnumber  = {IASSNS-HEP-96-96},
-  slaccitation  = {%%CITATION = HEP-TH/9609122;%%}
-}
-
-@Article{Wit97*1,
   author        = {Witten, Edward},
   title         = {On flux quantization in M theory and the effective action},
   journal       = {J. Geom. Phys.},

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -3038,6 +3038,21 @@
 
 @Article{Wit97,
   author        = {Witten, Edward},
+  title         = {{On flux quantization in M-theory and the effective action}},
+  journal       = {J. Geom. Physics},
+  volume        = {22},
+  pages         = {1--13},
+  year          = {1997},
+  doi           = {10.1016/S0393-0440(96)00042-3},
+  archiveprefix = {arXiv},
+  eprint        = {hep-th/9609122},
+  primaryclass  = {hep-th},
+  reportnumber  = {IASSNS-HEP-96-96},
+  slaccitation  = {%%CITATION = HEP-TH/9609122;%%}
+}
+
+@Article{Wit97*1,
+  author        = {Witten, Edward},
   title         = {On flux quantization in M theory and the effective action},
   journal       = {J. Geom. Phys.},
   volume        = {22},

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -395,6 +395,17 @@
   doi           = {10.1016/0097-3165(81)90058-3}
 }
 
+@Article{BMT25,
+  author        = {Bies, Martin and Mi\c{k}elsons, Mi\c{k}elis E. and Turner, Andrew P.},
+  title         = {{FTheoryTools: Advancing Computational Capabilities for F-Theory Research}},
+  journal       = {Preprint},
+  year          = {2025},
+  month         = jun,
+  eprint        = {2506.13849},
+  archiveprefix = {arXiv},
+  primaryclass  = {hep-th}
+}
+
 @Article{BN07,
   author        = {Baker, Matthew and Norine, Serguei},
   title         = {Riemann-{R}och and {A}bel-{J}acobi theory on a finite graph},
@@ -608,6 +619,21 @@
   pages         = {465--469},
   year          = {1997},
   doi           = {10.1006/jsco.1996.0145}
+}
+
+@Article{CKPT15,
+  author        = {Cveti\v{c}, Mirjam and Klevers, Denis and Piragua, Hernan and Taylor, Washington},
+  title         = {{General U(1) x U(1) F-theory compactifications and beyond: geometry of unHiggsings and novel matter
+                  structure}},
+  journal       = {JHEP},
+  volume        = {11},
+  pages         = {204},
+  year          = {2015},
+  doi           = {10.1007/JHEP11(2015)204},
+  eprint        = {1507.05954},
+  archiveprefix = {arXiv},
+  primaryclass  = {hep-th},
+  reportnumber  = {UPR-1274-T, CERN-PH-TH-2015-157, MIT-CTP-4678}
 }
 
 @Book{CLO05,
@@ -1899,6 +1925,21 @@
 @Article{KM-POPR15,
   author        = {Klevers, Denis and Mayorga Pena, Damian Kaloni and Oehlmann, Paul-Konstantin and Piragua, Hernan and
                   Reuter, Jonas},
+  title         = {{F-Theory on all Toric Hypersurface Fibrations and its Higgs Branches}},
+  journal       = {JHEP},
+  volume        = {01},
+  pages         = {142},
+  year          = {2015},
+  doi           = {10.1007/JHEP01(2015)142},
+  eprint        = {1408.4808},
+  archiveprefix = {arXiv},
+  primaryclass  = {hep-th},
+  reportnumber  = {UPR-1264-T, CERN-PH-TH-2014-171, Bonn-TH-2014-13}
+}
+
+@Article{KM-POPR15*1,
+  author        = {Klevers, Denis and Mayorga Pena, Damian Kaloni and Oehlmann, Paul-Konstantin and Piragua, Hernan and
+                  Reuter, Jonas},
   title         = {F-Theory on all Toric Hypersurface Fibrations and its Higgs Branches},
   journal       = {JHEP},
   volume        = {01},
@@ -1921,6 +1962,19 @@
   eprint        = {1106.3854},
   primaryclass  = {hep-th},
   reportnumber  = {UCSB-MATH-2011-09, IPMU11-0107, NSF-KITP-11-110, KCL-MTH-11-13}
+}
+
+@Article{KMW12,
+  author        = {Krause, Sven and Mayrhofer, Christoph and Weigand, Timo},
+  title         = {{$G_4$ flux, chiral matter and singularity resolution in F-theory compactifications}},
+  journal       = {Nucl. Phys. B},
+  volume        = {858},
+  pages         = {1--47},
+  year          = {2012},
+  doi           = {10.1016/j.nuclphysb.2011.12.013},
+  eprint        = {1109.3454},
+  archiveprefix = {arXiv},
+  primaryclass  = {hep-th}
 }
 
 @Misc{KO14,
@@ -2212,6 +2266,20 @@
   year          = {2024},
   month         = jan,
   url           = {https://gap-packages.github.io/tomlib/}
+}
+
+@Article{MP12,
+  author        = {Morrison, David R. and Park, Daniel S.},
+  title         = {{F-Theory and the Mordell-Weil Group of Elliptically-Fibered Calabi-Yau Threefolds}},
+  journal       = {JHEP},
+  volume        = {10},
+  pages         = {128},
+  year          = {2012},
+  doi           = {10.1007/JHEP10(2012)128},
+  eprint        = {1208.2695},
+  archiveprefix = {arXiv},
+  primaryclass  = {hep-th},
+  reportnumber  = {UCSB-MATH-2012-27, MIT-CTP-4388}
 }
 
 @Article{MP82,
@@ -2771,6 +2839,20 @@
   pages         = {499--517},
   year          = {2011},
   doi           = {10.4007/annals.2011.174.1.14}
+}
+
+@Article{TW15,
+  author        = {Taylor, Washington and Wang, Yi-Nan},
+  title         = {{The F-theory geometry with most flux vacua}},
+  journal       = {JHEP},
+  volume        = {12},
+  pages         = {164},
+  year          = {2015},
+  doi           = {10.1007/JHEP12(2015)164},
+  eprint        = {1511.03209},
+  archiveprefix = {arXiv},
+  primaryclass  = {hep-th},
+  reportnumber  = {MIT-CTP-4732}
 }
 
 @Article{TW18,

--- a/experimental/FTheoryTools/docs/src/g4.md
+++ b/experimental/FTheoryTools/docs/src/g4.md
@@ -4,164 +4,242 @@ CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 
-# G4-Fluxes
+# ``G_4``-Fluxes
 
-``G_4`` fluxes are at the heart of F-theory model building.
+In F-theory compactifications on Calabi--Yau 4-folds, **``G_4``-fluxes** are essential ingredients for defining consistent and physically meaningful vacua. They affect various physical aspects, such as the chiral spectrum in the 4D effective theory, tadpole cancellation, and moduli stabilization. This page provides an accessible introduction to working with ``G_4``-fluxes in `FTheoryTools`, including background, construction methods, and available functionality.
 
+---
 
-## Constructors
+## Background: What Is a ``G_4``-Flux?
 
-We currently support the following constructor:
+Let ``\widehat{Y}_4`` be a smooth Calabi--Yau 4-fold obtained via crepant resolution of a singular elliptically fibered 4-fold ``Y_4 \to B_3``. A **``G_4``-flux** is a cohomology class:
+
+$G_4 \in H^{2, 2}(\widehat{Y}_4, \mathbb{R}) \equiv H^{2, 2}(\widehat{Y}_4, \mathbb{C}) \cap H^4(\widehat{Y}_4, \mathbb{R})$
+
+subject to **quantization**, **transversality**, and several additional consistency conditions:
+
+1. **Quantization (cf. [Witten 1997](@cite Wit97)):** ``G_4 + \frac{1}{2} c_2(\widehat{Y}_4) \in H^4(\widehat{Y}_4, \mathbb{Z})``
+
+2. **Transversality:** The flux must be orthogonal to both the base and the fiber in a precise cohomological sense.
+
+3. Additional constraints, such as **D3-tadpole cancellation**, **self-duality**, and **primitivity**, are also typically imposed. One often requires that the ``G_4``-flux preserves the non-abelian gauge symmetry encoded in the fibration.
+
+These conditions ensure compatibility with fundamental physical principles like anomaly cancellation and D3-brane charge quantization.
+
+For further theoretical background, see the exposition in [Weigand 2018](@cite Wei18).
+
+---
+
+## Modeling ``G_4``-Fluxes
+
+In practice, `FTheoryTools` focuses on **candidate ``G_4``-fluxes**: elements of the rational cohomology group ``H^{2,2}(\widehat{Y}_4, \mathbb{Q})``, i.e.
+
+$G_4 \in H^{2, 2}(\widehat{Y}_4, \mathbb{Q}) \equiv H^{2, 2}(\widehat{Y}_4, \mathbb{C}) \cap H^4(\widehat{Y}_4, \mathbb{Q})\,.$
+
+We work with rational coefficients due to both the quantization condition---which implies that valid fluxes must have rational coefficients---and the practical advantages this offers in computation. Currently, `FTheoryTools` cannot fully verify the quantization condition, so we adopt the term **candidate flux**. We elaborate on our approach to the quantization condition below.
+
+The space ``H^{2,2}(\widehat{Y}_4, \mathbb{C})`` admits an orthogonal decomposition:
+
+$H^{2, 2}(\widehat{Y}_4, \mathbb{C}) = H^{2, 2}_\text{hor}(\widehat{Y}_4, \mathbb{C}) \oplus H^{2, 2}_\text{vert}(\widehat{Y}_4, \mathbb{C}) \oplus H^{2, 2}_\text{rem}(\widehat{Y}_4, \mathbb{C})\,.$
+
+- **Horizontal fluxes** arise from variations of the complex structure,
+- **Vertical fluxes** are built from wedge products of (1,1)-forms,
+- **Remainder fluxes** account for the rest.
+
+`FTheoryTools` focuses on the **vertical part**.
+
+### Standing Assumption
+
+`FTheoryTools` assumes that ``\widehat{Y}_4`` is defined as a hypersurface in a complete, smooth toric variety ``X_\Sigma``. (In principle, it would suffice for the hypersurface to be smooth and the ambient space to be simplicial. However, we compute characteristic classes of the ambient space and restrict them to the hypersurface to obtain ``c_2(\widehat{Y}_4)``, and this requires the ambient space to be smooth.)
+
+### Workflow
+
+Under this assumption, we can access a subspace of the vertical cohomology:
+
+$\left. H^{2,2}(X_\Sigma, \mathbb{Q}) \right|_{\widehat{Y}_4} \subseteq H^{2,2}_{\text{vert}}(\widehat{Y}_4, \mathbb{Q}) \,.$
+
+We refer to elements in this subspace as **ambient vertical fluxes**.
+
+Theorem 9.3.2 of [Cox, Little, Schenck 2011](@cite CLS11) states that for complete, simplicial toric varieties, ``H^{p, q}(X_\Sigma, \mathbb{Q}) = 0`` whenever ``p \ne q``. Consequently, ``H^{2, 2}(X_\Sigma, \mathbb{Q}) = H^4(X_\Sigma, \mathbb{Q})``. Furthermore, Theorem 12.4.1 of [Cox, Little, Schenck 2011](@cite CLS11) establishes that ``H^4(X_\Sigma, \mathbb{Q})`` is isomorphic to ``R_{\mathbb{Q}}(\Sigma)_2``, the space of degree-2 monomials (under the standard grading) in the cohomology ring ``R_{\mathbb{Q}}(\Sigma)`` of ``X_\Sigma``. This cohomology ring is the quotient of ``\mathbb{Q}[x_1, \dots, x_r]``, where ``r`` is the number of rays in the polyhedral fan ``\Sigma`` of the toric ambient space ``X_\Sigma``, by the sum of the Stanley--Reisner ideal and the ideal of linear relations.
+
+To construct a generating set of ambient candidate ``G_4``-fluxes, we proceed as follows:
+
+1. Construct the cohomology ring ``R_{\mathbb{Q}}(\Sigma)``.
+2. Identify a basis of degree-2 monomials in ``R_{\mathbb{Q}}(\Sigma)``.
+3. Restrict these monomials to ``\widehat{Y}_4``.
+
+While performing the restriction to ``\widehat{Y}_4``, dependencies may arise:
+
+- Some monomials vanish identically,
+- Others may become linearly dependent.
+
+`FTheoryTools` currently detects *only obviously trivial* restrictions (e.g., cycles whose intersection with ``\widehat{Y}_4`` is empty). It does **not** eliminate all possible dependencies---hence the result is a **generating set**, not a minimal basis. This pragmatic choice enables efficient and scalable construction of vertical flux candidates across a wide range of F-theory geometries.
+
+`FTheoryTools` includes specialized algorithms to perform steps 1 through 3. These algorithms---described in detail in the appendix of [BMT25](@cite BMT25)---are especially effective for large geometries such as those studied in [Taylor, Wang 2015](@cite TW15), where traditional Gröbner basis techniques are computationally impractical. Even for more manageable QSM geometries (cf. [Cvetič, Halverson, Ling, Liu, Tian 2019](@cite CHLLT19)), we observe a significant performance boost.
+
+### Necessary Conditions for Flux Quantization
+
+Verifying the flux quantization condition (cf. [Witten 1997](@cite Wit97)) is generally difficult. In practice, `FTheoryTools` performs necessary consistency checks to gather evidence for (or against) proper quantization.
+
+Let ``H`` denote the hypersurface divisor class defining ``\widehat{Y}_4`` inside the ambient toric variety ``X_\Sigma``. Let ``\{D_i\}`` be a basis for the toric divisor classes of ``X_\Sigma``, and let ``\hat{c}_2 \in H^{2,2}(X_\Sigma, \mathbb{Q})`` be a class whose restriction gives the second Chern class of the Calabi--Yau hypersurface, i.e., ``\left. \hat{c}_2 \right|_{\widehat{Y}_4} = c_2(\widehat{Y}_4)``.
+
+As elaborated above, in `FTheoryTools`, a ``G_4``-flux candidate is modeled by a class ``g \in H^{2,2}(X_\Sigma, \mathbb{Q})``, and its restriction to ``\widehat{Y}_4`` defines the actual flux candidate. A necessary condition for quantization of this flux ``G_4`` --- modelled by ``g \in H^{2,2}(X_\Sigma, \mathbb{Q})`` --- is that, for all pairs of indices ``i``, ``j``, the following integral evaluates to an integer:
+
+$\int_{X_\Sigma}{\left(g + \frac{1}{2} \hat{c}_2 \right) \wedge [H] \wedge [D_i] \wedge [D_j]}\,,$
+
+where $[D]$ indicates the Poincaré dual cohomology class to the divisor ``D``. It is these conditions that we check in `FTheoryTools`.
+
+Even these elementary checks can be computationally expensive on large geometries. Therefore, `FTheoryTools` allows users to **skip quantization checks** during flux construction using the keyword argument `check = false`. This can be useful in early-stage explorations or for performance optimization.
+
+---
+
+## Working with ``G_4``-Fluxes
+
+### Constructing ``G_4``-Fluxes
+
+In `FTheoryTools`, ``G_4``-fluxes are created from cohomology classes associated with a given resolved F-theory model.
 ```@docs
-g4_flux(model::AbstractFTheoryModel, class::CohomologyClass)
+g4_flux(model::AbstractFTheoryModel, class::CohomologyClass; convert::Bool = false)
 ```
-In addition to this generic constructor, we also support the following special constructor.
+For the special class of quadrillion Standard models (QSMs) (cf. [Cvetič, Halverson, Ling, Liu, Tian 2019](@cite CHLLT19)), the chosen flux can be obtained conveniently.
 ```@docs
 qsm_flux(qsm_model::AbstractFTheoryModel)
 ```
 
+### Attributes of ``G_4``-Fluxes
 
+You can inspect a ``G_4``-flux using the following attributes:
 
-## Attributes
-
-We currently support the following attributes:
 ```@docs
 model(gf::G4Flux)
 cohomology_class(gf::G4Flux)
 d3_tadpole_constraint(gf::G4Flux; check::Bool = true)
-g4_flux_family(gf::G4Flux; check::Bool = true)
-```
-Note that such a family of ``G_4``-fluxes expresses its elements
-as linear combinations of the basis elements. Crucially, some
-of the coefficients must only be integers, whilst the remaining
-coefficients can be any rational number. With the following
-methods one can extract those coefficients for a given ``G_4``-flux.
-```@docs
-integral_coefficients(gf::G4Flux)
-rational_coefficients(gf::G4Flux)
 ```
 
+### Properties of ``G_4``-Fluxes
 
-## Methods
+You can check whether a ``G_4``-flux satisfies common physical constraints using:
 
-You can create instances of families of G4-fluxes, i.e. a flux that
-is contained in said family. For this, we support the following:
-```@docs
-flux_instance(fgs::FamilyOfG4Fluxes, int_combination::ZZMatrix, rat_combination::QQMatrix; check::Bool = true)
-random_flux_instance(fgs::FamilyOfG4Fluxes; check::Bool = true)
-```
-For convenience, we also support the following method to create a
-random ``G_4``-flux with prescribed properties on a given F-theory model:
-```@docs
-random_flux(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true)
-```
-
-## Properties
-
-We currently support the following properties:
 ```@docs
 is_well_quantized(gf::G4Flux)
-passes_tadpole_cancellation_check(gf::G4Flux)
 passes_transversality_checks(gf::G4Flux)
+passes_tadpole_cancellation_check(gf::G4Flux)
 breaks_non_abelian_gauge_group(gf::G4Flux)
 ```
 
+---
 
-## Ambient Space Models for G4-Fluxes
+## Working with Families of `G_4`-Fluxes
 
-Focus on 4-dimensional F-theory models ``m``, such that the resolution ``\widehat{Y}_4``
-of the defining singular elliptically fibered CY 4-fold ``Y_4 \twoheadrightarrow B_3``
-is defined as hypersurface in a complete and simplicial toric variety ``X_\Sigma``. In
-such a setup, it is convenient to focus on ``G_4``-fluxes modelled from the restriction
-of elements of ``H^{(2,2)}( X_\Sigma, \mathbb{Q})`` to ``\widehat{Y}_4``. This method
-identifies a basis of ``H^{(2,2)}( X_\Sigma, \mathbb{Q})`` and filters out elements,
-whose restricton to ``\widehat{Y}_4`` is obviously trivial.
+In many F-theory applications, it is useful to study entire families of fluxes rather than individual ones. `FTheoryTools` supports both the construction and analysis of such flux families.
 
-It is important to elaborate a bit more on the meaning of "obviously". To this end, fix a
-basis element of ``H^{(2,2)}( X_\Sigma, \mathbb{Q})``. Let us denote a corresponding algebraic
-cycle by ``A = \mathbb{V}(x_i, x_j) \subset X_\Sigma``, where ``x_i``, ``x_j`` are suitable
-homogeneous coordinates. Furthermore, let ``\widehat{Y}_4 = \mathbb{V}( p ) \subset X_\Sigma``.
-Then of course, we can look at the set-theoretic intersection ``\mathbb{V}( p, x_i, x_j)``.
-Provided that ``p(x_i = 0, x_j = 0)`` is a non-zero constant, this set-theoretic intersection
-is trivial. This is exactly the check conducted by the method `chosen_g4_flux_basis`
-below. However, for reasons of simplicity, this approach is avoid a number of sutleties.
+### Constructing a Flux Family from Parametrization and Offset
 
-Namely, we really have to work out the intersection in the Chow ring, that is we should consider
-the rational equivalence class of the algebraic cycle ``A`` and intersect this class with the
-rational equivalence class of the algebraic cycle ``\mathbb{V}( p )``. In particular, for
-"unlucky" choices of ``i, j``, the algebraic cycles ``\mathbb{V}( p )`` and ``\mathbb{V}(x_i, x_j)``
-may not intersect transversely. This is for instance the case if ``i = j``. Such phenomena are
-addressed in theory by "moving the algebraic cycles into general position", but in practice this
-somewhat tricky. Instances include the following:
-1. ``i = j``: Then apparently, a self-intersection of ``\mathbb{V}(x_i)`` is involved.
-2. ``p(x_i, x_j) \equiv 0``: This is unexpected for dimensional reasons, and indicates a
-non-transverse intersection.
-
-In both instances, one makes use of the linear relations of ``X_\Sigma`` to replace the cycle 
- ``\mathbb{V}(x_i)`` (and/or ``\mathbb{V}(x_j)``) with a rational combination of algebraic cycles
-``R = \sum_{k = 1}^{N}{c_k \cdot A_k}``, such that ``R`` is rationally equivalent to ``\mathbb{V}(x_i)``.
-From experience, it is then rather common that ``R`` and ``\mathbb{V}(x_i)`` intersect transversely.
-And if not, then modify the non-transverse intersections by using the linear relations again to
-replace an involved algebraic cycle.
+You can construct a flux family explicitly by specifying its parametrization in terms of the ambient `G_4`-flux generators:
 
 ```@docs
 chosen_g4_flux_basis(m::AbstractFTheoryModel; check::Bool = true)
-basis_of_h22_ambient(m::AbstractFTheoryModel; check::Bool = true)
-basis_of_h22_hypersurface(m::AbstractFTheoryModel; check::Bool = true)
-basis_of_h22_ambient_indices(m::AbstractFTheoryModel; check::Bool = true)
-basis_of_h22_hypersurface_indices(m::AbstractFTheoryModel; check::Bool = true)
-converter_dict_h22_ambient(m::AbstractFTheoryModel; check::Bool = true)
-converter_dict_h22_hypersurface(m::AbstractFTheoryModel; check::Bool = true)
 ```
 
+(Note: These are technically generators, not a basis.)
 
-## Families of G4-Fluxes
+To define a flux family in this way, you must provide:
 
-### Constructor
+- **Integral coefficients**: Rational combinations of generators whose `\mathbb{Z}`-span lies within the family,
+- **Rational coefficients**: Rational combinations of generators forming the `\mathbb{Q}`-span of the family,
+- **Offset vector**: Typically representing the shift by `\frac{1}{2} c_2(\widehat{Y}_4)` from the quantization condition.
 
-Physics often is interested in families of G4-fluxes, that are expressed in terms of
-integral or rational combinations of the ambient space models of G4-fluxes, that we
-described above. For such families, we currently support the following constructor:
+The constructor is:
 
 ```@docs
 family_of_g4_fluxes(m::AbstractFTheoryModel, mat_int::QQMatrix, mat_rat::QQMatrix, offset::Vector{QQFieldElem}; check::Bool = true)
 ```
 
-### Attributes
+Once a flux family is constructed, you can extract its defining data:
 
-Families of G4-fluxes currently support the following attributes:
 ```@docs
-model(gf::FamilyOfG4Fluxes)
 matrix_integral(gf::FamilyOfG4Fluxes)
 matrix_rational(gf::FamilyOfG4Fluxes)
+offset(gf::FamilyOfG4Fluxes)
+```
+
+### Constructing a Flux Family Based on Physical Conditions
+
+A common use case is to construct the family of all `G_4`-fluxes satisfying key physical constraints:
+
+- Passing the necessary quantization checks (as discussed earlier),
+- Satisfying all transversality conditions,
+- Optionally preserving the non-abelian gauge symmetry.
+
+This method is less flexible than direct parametrization, but very convenient for typical model-building workflows.
+
+!!! warning This operation may be computationally expensive for large or complex geometries.
+
+```@docs
+special_flux_family(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true)
+```
+
+### Attributes of a Flux Family
+
+You can access key data about a flux family using the following attributes:
+
+```@docs
+model(gf::FamilyOfG4Fluxes)
 d3_tadpole_constraint(fgs::FamilyOfG4Fluxes; check::Bool = true)
 ```
 
-### Properties
+### Properties of a Flux Family
 
-Families of G4-fluxes currently support the following properties:
+To test whether a family satisfies standard physical consistency conditions, use:
+
 ```@docs
 is_well_quantized(fgs::FamilyOfG4Fluxes; check::Bool = true)
 passes_transversality_checks(fgs::FamilyOfG4Fluxes; check::Bool = true)
 breaks_non_abelian_gauge_group(fgs::FamilyOfG4Fluxes; check::Bool = true)
 ```
 
+### Constructing Flux Instances from a Flux Family
 
-## Special Families of G4-Fluxes
+You can generate specific fluxes within a family using:
 
-Among the ``G_4``-flux candidates, the physics is interested in the well-quantized fluxes that pass
-the transversality conditions. Regarding the quantization condition, this means that we seek
-those cohomology classes which integrate to an integer against any other 2-cycle in the elliptic
-4-fold ``\widehat{Y}_4``. Even in theory, this is a hard task. In practice, one therefore focuses
-on consistency checks. In the case at hand, we can integrate any ambient space ``G_4``-flux candidate
-against a pair of (algebraic cycles associated to) toric divisors. If for any two toric divisors,
-the result is an integer, then this ``G_4``-flux candidate passes a rather non-trivial and necessary
-test. 
-
-Similarly, we have a method that identifies all fluxes which are well-quantized, pass the
-transversality conditions and in addition to this do not break the non-abelian gauge group.
-For these families, we support the following constructor. Please note that this method may take a long
-time to execute for involved geometries ``\widehat{Y}_4``.
 ```@docs
-special_flux_family(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true)
+flux_instance(fgs::FamilyOfG4Fluxes, int_combination::ZZMatrix, rat_combination::QQMatrix; check::Bool = true)
+random_flux_instance(fgs::FamilyOfG4Fluxes; check::Bool = true)
+```
+
+For convenience, a random physically consistent flux can also be generated directly from a model:
+
+```@docs
+random_flux(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true)
+```
+
+### Recovering a Flux Family from a Flux Instance
+
+Starting from a single `G_4`-flux, you can find the full family of fluxes that share its physical properties:
+
+```@docs
+g4_flux_family(gf::G4Flux; check::Bool = true)
+```
+
+To determine the location of the original flux within that family, retrieve its defining coefficients and offset:
+
+```@docs
+integral_coefficients(gf::G4Flux)
+rational_coefficients(gf::G4Flux)
+offset(gf::G4Flux)
+```
+
+---
+
+## Advanced Methods (typically run in the background)
+
+These methods support internal computations, such as the construction of cohomology bases and dictionary converters. Most users will not need to call these directly.
+
+```@docs
+basis_of_h22_ambient(m::AbstractFTheoryModel; check::Bool = true)
+basis_of_h22_hypersurface(m::AbstractFTheoryModel; check::Bool = true)
+basis_of_h22_ambient_indices(m::AbstractFTheoryModel; check::Bool = true)
+basis_of_h22_hypersurface_indices(m::AbstractFTheoryModel; check::Bool = true)
+converter_dict_h22_ambient(m::AbstractFTheoryModel; check::Bool = true)
+converter_dict_h22_hypersurface(m::AbstractFTheoryModel; check::Bool = true)
 ```

--- a/experimental/FTheoryTools/docs/src/g4.md
+++ b/experimental/FTheoryTools/docs/src/g4.md
@@ -6,7 +6,7 @@ DocTestSetup = Oscar.doctestsetup()
 
 # G4-Fluxes
 
-$G_4$-fluxes are at the heart of F-theory model building.
+``G_4`` fluxes are at the heart of F-theory model building.
 
 
 ## Constructors
@@ -31,11 +31,11 @@ cohomology_class(gf::G4Flux)
 d3_tadpole_constraint(gf::G4Flux; check::Bool = true)
 g4_flux_family(gf::G4Flux; check::Bool = true)
 ```
-Note that such a family of $G_4$-fluxes expresses its elements
+Note that such a family of ``G_4``-fluxes expresses its elements
 as linear combinations of the basis elements. Crucially, some
 of the coefficients must only be integers, whilst the remaining
 coefficients can be any rational number. With the following
-methods one can extract those coefficients for a given $G_4$-flux.
+methods one can extract those coefficients for a given ``G_4``-flux.
 ```@docs
 integral_coefficients(gf::G4Flux)
 rational_coefficients(gf::G4Flux)
@@ -51,7 +51,7 @@ flux_instance(fgs::FamilyOfG4Fluxes, int_combination::ZZMatrix, rat_combination:
 random_flux_instance(fgs::FamilyOfG4Fluxes; check::Bool = true)
 ```
 For convenience, we also support the following method to create a
-random $G_4$-flux with prescribed properties on a given F-theory model:
+random ``G_4``-flux with prescribed properties on a given F-theory model:
 ```@docs
 random_flux(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true)
 ```
@@ -69,38 +69,38 @@ breaks_non_abelian_gauge_group(gf::G4Flux)
 
 ## Ambient Space Models for G4-Fluxes
 
-Focus on 4-dimensional F-theory models $m$, such that the resolution $\widehat{Y}_4$
-of the defining singular elliptically fibered CY 4-fold $\Y_4 \twoheadrightarrow B_3$
-is defined as hypersurface in a complete and simplicial toric variety $X_\Sigma$. In
-such a setup, it is convenient to focus on $G_4$-fluxes modelled from the restriction
-of elements of $H^{(2,2)}( X_\Sigma, \mathbb{Q})$ to $\widehat{Y}_4$. This method
-identifies a basis of $H^{(2,2)}( X_\Sigma, \mathbb{Q})$ and filters out elements,
-whose restricton to $\widehat{Y}_4$ is obviously trivial.
+Focus on 4-dimensional F-theory models ``m``, such that the resolution ``\widehat{Y}_4``
+of the defining singular elliptically fibered CY 4-fold ``Y_4 \twoheadrightarrow B_3``
+is defined as hypersurface in a complete and simplicial toric variety ``X_\Sigma``. In
+such a setup, it is convenient to focus on ``G_4``-fluxes modelled from the restriction
+of elements of ``H^{(2,2)}( X_\Sigma, \mathbb{Q})`` to ``\widehat{Y}_4``. This method
+identifies a basis of ``H^{(2,2)}( X_\Sigma, \mathbb{Q})`` and filters out elements,
+whose restricton to ``\widehat{Y}_4`` is obviously trivial.
 
 It is important to elaborate a bit more on the meaning of "obviously". To this end, fix a
-basis element of $H^{(2,2)}( X_\Sigma, \mathbb{Q})$. Let us denote a corresponding algebraic
-cycle by $A = \mathbb{V}(x_i, x_j) \subset X_\Sigma$, where $x_i$, $x_j$ are suitable
-homogeneous coordinates. Furthermore, let $\widehat{Y}_4 = \mathbb{V}( p ) \subset X_\Sigma$.
-Then of course, we can look at the set-theoretic intersection $\mathbb{V}( p, x_i, x_j)$.
-Provided that $p(x_i = 0, x_j = 0)$ is a non-zero constant, this set-theoretic intersection
+basis element of ``H^{(2,2)}( X_\Sigma, \mathbb{Q})``. Let us denote a corresponding algebraic
+cycle by ``A = \mathbb{V}(x_i, x_j) \subset X_\Sigma``, where ``x_i``, ``x_j`` are suitable
+homogeneous coordinates. Furthermore, let ``\widehat{Y}_4 = \mathbb{V}( p ) \subset X_\Sigma``.
+Then of course, we can look at the set-theoretic intersection ``\mathbb{V}( p, x_i, x_j)``.
+Provided that ``p(x_i = 0, x_j = 0)`` is a non-zero constant, this set-theoretic intersection
 is trivial. This is exactly the check conducted by the method `chosen_g4_flux_basis`
 below. However, for reasons of simplicity, this approach is avoid a number of sutleties.
 
 Namely, we really have to work out the intersection in the Chow ring, that is we should consider
-the rational equivalence class of the algebraic cycle $A$ and intersect this class with the
-rational equivalence class of the algebraic cycle $\mathbb{V}( p )$. In particular, for
-"unlucky" choices of $i, j$, the algebraic cycles $\mathbb{V}( p )$ and $\mathbb{V}(x_i, x_j)$
-may not intersect transversely. This is for instance the case if $i = j$. Such phenomena are
+the rational equivalence class of the algebraic cycle ``A`` and intersect this class with the
+rational equivalence class of the algebraic cycle ``\mathbb{V}( p )``. In particular, for
+"unlucky" choices of ``i, j``, the algebraic cycles ``\mathbb{V}( p )`` and ``\mathbb{V}(x_i, x_j)``
+may not intersect transversely. This is for instance the case if ``i = j``. Such phenomena are
 addressed in theory by "moving the algebraic cycles into general position", but in practice this
 somewhat tricky. Instances include the following:
-1. $i = j$: Then apparently, a self-intersection of $\mathbb{V}(x_i)$ is involved.
-2. $p(x_i, x_j) \equiv 0$: This is unexpected for dimensional reasons, and indicates a
+1. ``i = j``: Then apparently, a self-intersection of ``\mathbb{V}(x_i)`` is involved.
+2. ``p(x_i, x_j) \equiv 0``: This is unexpected for dimensional reasons, and indicates a
 non-transverse intersection.
 
-In both instances, one makes use of the linear relations of $X_\Sigma$ to replace the cycle 
- $\mathbb{V}(x_i)$ (and/or $\mathbb{V}(x_j)$) with a rational combination of algebraic cycles
-$R = \sum_{k = 1}^{N}{c_k \cdot A_k}$, such that $R$ is rationally equivalent to $\mathbb{V}(x_i)$.
-From experience, it is then rather common that $R$ and $\mathbb{V}(x_i)$ intersect transversely.
+In both instances, one makes use of the linear relations of ``X_\Sigma`` to replace the cycle 
+ ``\mathbb{V}(x_i)`` (and/or ``\mathbb{V}(x_j)``) with a rational combination of algebraic cycles
+``R = \sum_{k = 1}^{N}{c_k \cdot A_k}``, such that ``R`` is rationally equivalent to ``\mathbb{V}(x_i)``.
+From experience, it is then rather common that ``R`` and ``\mathbb{V}(x_i)`` intersect transversely.
 And if not, then modify the non-transverse intersections by using the linear relations again to
 replace an involved algebraic cycle.
 
@@ -149,19 +149,19 @@ breaks_non_abelian_gauge_group(fgs::FamilyOfG4Fluxes; check::Bool = true)
 
 ## Special Families of G4-Fluxes
 
-Among the $G_4$-flux candidates, the physics is interested in the well-quantized fluxes that pass
+Among the ``G_4``-flux candidates, the physics is interested in the well-quantized fluxes that pass
 the transversality conditions. Regarding the quantization condition, this means that we seek
 those cohomology classes which integrate to an integer against any other 2-cycle in the elliptic
-4-fold $\widehat{Y}_4$. Even in theory, this is a hard task. In practice, one therefore focuses
-on consistency checks. In the case at hand, we can integrate any ambient space $G_4$-flux candidate
+4-fold ``\widehat{Y}_4``. Even in theory, this is a hard task. In practice, one therefore focuses
+on consistency checks. In the case at hand, we can integrate any ambient space ``G_4``-flux candidate
 against a pair of (algebraic cycles associated to) toric divisors. If for any two toric divisors,
-the result is an integer, then this $G_4$-flux candidate passes a rather non-trivial and necessary
+the result is an integer, then this ``G_4``-flux candidate passes a rather non-trivial and necessary
 test. 
 
 Similarly, we have a method that identifies all fluxes which are well-quantized, pass the
 transversality conditions and in addition to this do not break the non-abelian gauge group.
 For these families, we support the following constructor. Please note that this method may take a long
-time to execute for involved geometries $\widehat{Y}_4$.
+time to execute for involved geometries ``\widehat{Y}_4``.
 ```@docs
 special_flux_family(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true)
 ```

--- a/experimental/FTheoryTools/docs/src/g4.md
+++ b/experimental/FTheoryTools/docs/src/g4.md
@@ -138,10 +138,8 @@ In many F-theory applications, it is useful to study entire families of fluxes r
 You can construct a flux family explicitly by specifying its parametrization in terms of the ambient `G_4`-flux generators:
 
 ```@docs
-chosen_g4_flux_basis(m::AbstractFTheoryModel; check::Bool = true)
+chosen_g4_flux_gens(m::AbstractFTheoryModel; check::Bool = true)
 ```
-
-(Note: These are technically generators, not a basis.)
 
 To define a flux family in this way, you must provide:
 

--- a/experimental/FTheoryTools/docs/src/hypersurface.md
+++ b/experimental/FTheoryTools/docs/src/hypersurface.md
@@ -151,13 +151,17 @@ These models can then be accessed with the following functions:
 weierstrass_model(h::HypersurfaceModel)
 global_tate_model(h::HypersurfaceModel)
 ```
-Provided that the corresponding Weierstrass model is known for a hypersurface
-model, the following functionality is available. It returns the attribute in question
-of the corresponding Weierstrass model.
+Provided that the corresponding Weierstrass model is known for a hypersurface model, we can compute the discriminant locus of this corresponding Weierstrass model:
 ```@docs
 discriminant(h::HypersurfaceModel)
+```
+Even more critical than the discriminant itself is its decomposition into irreducible components. Over each of these components, the singularities of the elliptic fiber are classified. The function below returns the list of irreducible base loci -- arising from the discriminant of the associated Weierstrass model -- along with the corresponding singularity types:
+```@docs
 singular_loci(h::HypersurfaceModel)
 ```
+!!! warning
+    The classification of singularities is performed using a Monte Carlo algorithm, i.e. it involves random sampling. While the implementation has been extensively tested and meets high standards, its probabilistic nature may occasionally yield non-deterministic results.
+
 
 
 ## Methods

--- a/experimental/FTheoryTools/docs/src/introduction.md
+++ b/experimental/FTheoryTools/docs/src/introduction.md
@@ -25,9 +25,10 @@ While *FTheoryTools* does not (yet) resolve all such foundational issues, its ai
 ### Elliptic Fibration Models
 
 You can construct elliptic fibrations using:
-- Weierstrass models,
-- Global Tate models,
-- Hypersurface models.
+- [Weierstrass models](@ref),
+- [Global Tate models](@ref),
+- [Hypersurface models](@ref).
+Since all of these different models encode singular elliptic fibrations mathematically, certain properties, attributes, and methods apply to all models equally. This shared functionality is summarized on the page [Functionality for all F-theory models](@ref).
 
 The base of the fibration may be:
 - A family of abstract base spaces,
@@ -57,6 +58,8 @@ Current database entries include, but are not limited to, models from:
 - [Taylor, Wang 2015](@cite TW15),
 - [CHLLT 2019](@cite CHLLT19).
 
+More details are available on the page [Literature constructions](@ref).
+
 ### ``G_4``-Flux Enumeration
 
 *FTheoryTools* supports enumeration of ``G_4``-fluxes, essential for determining the chiral spectra of F-theory compactifications. As a demonstration of its capabilities, we did enumerate ``G_4``-fluxes for the notoriously difficult *F-theory geometry with the most flux vacua* [Taylor, Wang 2015](@cite TW15), involving:
@@ -66,6 +69,7 @@ Current database entries include, but are not limited to, models from:
 - A resolution via 206 toric blowups (plus 3 additional ones for ambient smoothness).
 We identified a space of candidate vertical ``G_4`` fluxes parametrized by ``\mathbb{Z}^{224} \times \mathbb{Q}^{127}``. Details on this particular computation are available in the publication [BMT25](@cite BMT25).
 
+More details are available on the page [G4-Fluxes](@ref).
 
 ## Tutorials
 

--- a/experimental/FTheoryTools/docs/src/introduction.md
+++ b/experimental/FTheoryTools/docs/src/introduction.md
@@ -95,7 +95,7 @@ FTheoryTools supports the enumeration of vertical ``G_4``-fluxes—important for
 
 The computed flux space: ``\mathbb{Z}^{224} \times \mathbb{Q}^{127}``.
 
-Details are available in [BMT25]\(@cite BMT25). See also: [G4-Fluxes](@ref).
+Details are available in [BMT25](@cite BMT25). See also: [G4-Fluxes](@ref).
 
 ## Tutorials
 

--- a/experimental/FTheoryTools/docs/src/introduction.md
+++ b/experimental/FTheoryTools/docs/src/introduction.md
@@ -94,4 +94,4 @@ Alternatively, you can [raise an issue on github](https://www.oscar-system.org/c
 ## Acknowledgements
 
 We appreciate insightful discussions with [Mirjam Cvetič](https://live-sas-physics.pantheon.sas.upenn.edu/people/standing-faculty/mirjam-cvetic) and 
-[Mohab Safey El Din](https://www.lip6.fr/actualite/personnes-fiche.php?ident=P816#). Martin Bies and Mikelis Mikelsons appreciate support by the TU-Nachwuchsring. The work of Andrew Turner is supported by DOE (HEP) Award DE-SC001352.
+[Mohab Safey El Din](https://www.lip6.fr/actualite/personnes-fiche.php?ident=P816#). The work of Martin Bies and Mikelis Mikelsons is supported by the TU-Nachwuchsring. Andrew Turner appreciates support by DOE (HEP) Award DE-SC001352 and NSF grant PHY-2014086.

--- a/experimental/FTheoryTools/docs/src/introduction.md
+++ b/experimental/FTheoryTools/docs/src/introduction.md
@@ -8,90 +8,99 @@ DocTestSetup = Oscar.doctestsetup()
 
 ## Goal
 
-We aim to automate numerous recurring and, at least in part, tedious computations in F-Theory model building, as
-detailed extensively in [Wei18](@cite). The primary focus of our software is on (complex) elliptic fibrations with
-singularities. Those singularities hold significant importance. In essence, the absence of these singularities
-implies that the geometry encodes trivial or uninteresting physics. Therefore, the smooth case is typically not explored.
+*FTheoryTools* is a computational toolkit designed to automate and simplify many of the intricate and time-consuming computations encountered in F-theory model building. Developed as a submodule of the `OSCAR` computer algebra system, it provides infrastructure to streamline model construction, crepant resolution of singularities, and geometric analysis of singular elliptic fibrations—central objects in F-theory phenomenology.
 
-A substantial amount of information about the physics is encoded in the geometry of this singular fibration. To some
-extent it is clear what geometric quantities are to be considered, to some extent this is an open question. Regardless,
-computing quantities of interest, such as intersection theory and Chern classes, on singular spaces is challenging. However,
-it is possible to link the physics encoded by the singular geometry to the physics encoded by related smooth geometries.
-Consequently, almost all F-Theory studies begin by computing a smooting-out, i.e. a resolution, of the singular geometry in
-question.
+F-theory models encode physical data in the geometry of singular elliptic fibrations. The presence and type of singularities in the fibration are physically meaningful, determining the resulting gauge symmetry and matter content. Smooth fibrations typically correspond to trivial physics and are not the focus of model builders. However, performing computations directly on singular spaces is often impractical. Therefore, F-theory studies usually begin by finding a *crepant resolution* of the singular geometry—one that preserves the Calabi-Yau condition and hence the physical relevance.
 
-In order to easily link the physics on the singular geometry to the physics of one of its resolution, the resolution in question
-must be crepant, i.e. must preserve the Calabi-Yau condition. However, this restriction to crepant resolutions introduces additional challenges:
-1. A crepant resolution cannot resolve all singularities, meaning certain singularities may persist. This is an area of interest in recent F-Theory investigations.
-2. The existence of a crepant resolution is not guaranteed.
-3. Exploring whether different resolutions provide insights into different aspects of the singular geometry poses further questions. However, just as it is unclear whether a single crepant resolution is known, there is currently no way to confirm that all crepant resolutions have been identified.
+The crepant resolution of singularities, especially in higher codimensions or non-toric settings, poses major computational and conceptual challenges:
+1. Not all singularities admit crepant resolutions.
+2. When crepant resolutions exist, they may not resolve all singularities.
+3. Multiple resolutions might exist, offering complementary physical insights.
 
-*FTheoryTools* may not (yet) answer these profound and fundamental questions. Instead, the goal of this suite of computer tools is to streamline and simplify the crepant singularity resolution process as much as possible, as well as the subsequent extraction of geometric
-features of the resolved space.
-
-With *FTheoryTools*, you can create elliptic fibrations using one of the following models:
-* Weierstrass model,
-* Global Tate model,
-* Hypersurface model.
-In each case, the base space can be a family of spaces (as used in the literature when an explicit base is not specified) or a toric space. We anticipate an extension to schemes as bases. The dimension of those bases is not limited to ``1``, ``2``, or ``3``, but of course includes those cases important to the physics.
-
-We also offer a database of models frequently studied in the literature. For those models we use the term 'literature_models.' In essence, you should be able to create a model described in a paper at the click of a button. We anticipate that this feature will greatly simplify future research in F-Theory.
+While *FTheoryTools* does not (yet) resolve all such foundational issues, its aim is to *make the crepant resolution process as accessible, automated, and reproducible as possible*. It also assists in extracting physically relevant geometric features from the resolved space.
 
 
-## Status
+## Key Features
 
-We anticipate the following workflow:
+### Elliptic Fibration Models
 
-### User Input:
-- Create your desired F-Theory model by using one of the methods described above.
-- Choose a resolved phase/crepant resolution.
-- Select generating sections for ``\operatorname{U}(1)`` symmetries.
+You can construct elliptic fibrations using:
+- Weierstrass models,
+- Global Tate models,
+- Hypersurface models.
 
-### Output:
-- (Crepantly) resolved geometry.
-- Singular loci in suitable codimension (e.g., ``1``, ``2``, and ``3`` if the base space has dimension ``3``).
-- Fiber diagrams of the resolved fiber over the originally singular loci, including intersections of ``\operatorname{U}(1)``-sections.
-- Gauge group.
-- Topological data (e.g., Euler number).
+The base of the fibration may be:
+- A family of abstract base spaces,
+- A toric variety (the currently best-supported case),
+- In the future: schemes and more general varieties.
 
-Currently, our primary focus is on the Elephant in the room, that is the crepant resolution. While already functional for numerous setups, especially literature models, it is far from complete. At this point, the largest functionality exists for toric cases, with ongoing work to extend those toric resolution techniques to families of spaces and schemes.
+We do not limit ourselves to base spaces of dimensions 1, 2, or 3, but those are of particular interest for physical applications.
 
-We are also actively expanding our database of supported literature models. At this point, amongst others, our database includes models from the following papers:
-- The Tate Form on Steroids: Resolution and Higher Codimension Fibers [LS13](@cite),
-- F-Theory on all Toric Hypersurface Fibrations and its Higgs Branches [KM-POPR15](@cite),
-- Quadrillion F-Theory Compactifications with the Exact Chiral Spectrum of the Standard Model [CHLLT19](@cite).
+### General Blowups
 
-Consequently, we are already covering infinite families of models (e.g., with ``SU(k)`` gauge group, where ``k \geq 1``).
-Still, the total number of papers in our database is at this point limited to about ``6``. This is to be extended a lot.
+Unlike most traditional approaches which are limited to toric blowups, *FTheoryTools* supports blowups on arbitrary loci, including non-toric ones. This significantly expands the scope of F-theory constructions accessible through our software.
+
+### Literature Models
+
+We provide support for an expanding database of well-known F-theory models, referred to as *literature models*. These models are serialized using the **MaRDI file format**, which is based on JSON and designed in accordance with the FAIR principles --- Findability, Accessibility, Interoperability, and Reusability.
+
+The MaRDI file format is part of a broader effort by the [Mathematical Research Data Initiative (MaRDI)](https://www.mardi4nfdi.de/about/mission), a German consortium focused on establishing standards and developing tools to improve the handling of mathematical research data. While OSCAR's current implementation of the MaRDI format is centered around saving and loading data within the system, the format is designed to be extensible and interoperable with other computer algebra systems such as `SAGE` and `Macaulay2`.
+
+The specification of the **mrdi** file format used in OSCAR can be found on [Zenodo](https://zenodo.org/records/12723387). For a broader discussion of its design and goals, refer to [this article](https://link.springer.com/chapter/10.1007/978-3-031-64529-7_25), as well as the [OSCAR documentation on serialization](https://docs.oscar-system.org/stable/General/serialization/).
+
+Current database entries include, but are not limited to, models from:
+- [Krause, Mayrhofer, Weigand 2011](@cite KMW12),
+- [Morrison, Park 2012](@cite MP12),
+- [Lawrie, Schafer-Nameki 2013](@cite LS13),
+- [Klevers, Mayorga, Damian, Oehlmann, Piragua, Reuter 2015](@cite KM-POPR15),
+- [Cvetič, Klevers, Piragua, Taylor 2015](@cite CKPT15),
+- [Taylor, Wang 2015](@cite TW15),
+- [CHLLT 2019](@cite CHLLT19).
+
+### ``G_4``-Flux Enumeration
+
+*FTheoryTools* supports enumeration of ``G_4``-fluxes, essential for determining the chiral spectra of F-theory compactifications. As a demonstration of its capabilities, we did enumerate ``G_4``-fluxes for the notoriously difficult *F-theory geometry with the most flux vacua* [Taylor, Wang 2015](@cite TW15), involving:
+- 101 toric rays,
+- 198 maximal cones,
+- A defining equation with 355,785 monomials,
+- A resolution via 206 toric blowups (plus 3 additional ones for ambient smoothness).
+We identified a space of candidate vertical ``G_4`` fluxes parametrized by ``\mathbb{Z}^{224} \times \mathbb{Q}^{127}``. Details on this particular computation are available in the publication [BMT25](@cite BMT25).
 
 
-## Tutorial
+## Tutorials
 
-We encourage you to take a look at the tutorials on FTheoryTools, which can be found
-[here](https://www.oscar-system.org/tutorials/FTheoryTools/).
+We encourage you to take a look at the tutorials on FTheoryTools, which can be found at [https://www.oscar-system.org/tutorials/FTheoryTools/](https://www.oscar-system.org/tutorials/FTheoryTools/).
 
 
-## Possible future extensions
+## Installation
 
-Future extensions include, but are not necessarily limited to, the following:
-* Specify a ``G_4``-flux and work out the chiral spectra,
-* Specify a gauge potential and work out (candidates for) the line bundles whose cohomologies encode the vector-like spectra,
-* Other singularity types (non-minimal, terminal, etc.,)
-* Base blowups for singularity resolution.
+To get started with *FTheoryTools*, install [OSCAR](https://www.oscar-system.org/install/).
+
+To benefit from the latest features, improvements, and bug fixes, we recommend keeping OSCAR up to date by following the [upgrade instructions](https://www.oscar-system.org/upgrade/).
+
+
+## Status and Outlook
+
+*FTheoryTools* is an experimental module. Functionality is currently most robust for model based on toric geometries, but support for general families and schemes is actively being developed. Future extensions will include, but are not limited to:
+- Vector-like spectrum computations via line bundle cohomologies,
+- Support for terminal and non-minimal singularities,
+- Automated base blowups.
 
 
 ## Contact
 
-Please direct questions about this part of OSCAR to the following people:
-* [Martin Bies](https://martinbies.github.io/),
-* [Mikelis Emils Mikelsons](https://github.com/emikelsons),
-* [Andrew Turner](https://apturner.net/).
+For questions or feedback, reach out to:
+- [Martin Bies](https://martinbies.github.io/)
+- [Miķelis E. Miķelsons](https://github.com/emikelsons)
+- [Andrew P. Turner](https://apturner.net/)
 
-You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
-Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).
+Or visit:
+- [OSCAR Slack](https://www.oscar-system.org/community/#Slack)
+- [GitHub Issue Tracker](https://www.oscar-system.org/community/#Reporting-Issues)
 
 
 ## Acknowledgements
 
-We appreciate insightful discussions with [Mirjam Cvetič](https://live-sas-physics.pantheon.sas.upenn.edu/people/standing-faculty/mirjam-cvetic) and 
-[Mohab Safey El Din](https://www.lip6.fr/actualite/personnes-fiche.php?ident=P816#). The work of Martin Bies and Mikelis Mikelsons is supported by the TU-Nachwuchsring. Andrew Turner appreciates support by DOE (HEP) Award DE-SC001352 and NSF grant PHY-2014086.
+We thank [Mirjam Cvetič](https://live-sas-physics.pantheon.sas.upenn.edu/people/standing-faculty/mirjam-cvetic) and [Mohab Safey El Din](https://www.lip6.fr/actualite/personnes-fiche.php?ident=P816#) for valuable discussions.
+
+The authors are thankful for the support offered by the [TU-Nachwuchsring](https://rptu.de/en/tu-nachwuchsring-network-for-young-scientists-support/home-page). This work was supported by the [_SFB-TRR 195 Symbolic Tools in Mathematics and their Application_](https://www.computeralgebra.de/sfb/) of the [German Research Foundation (DFG)](https://www.dfg.de/en). Martin Bies acknowledges financial support from the \emph{Forschungsinitiative des Landes Rheinland-Pfalz} through the project [_SymbTools -- Symbolic Tools in Mathematics and their Application_](https://fingolfin.github.io/SymbTools/). Andrew P. Turner acknowledges funding from _DOE (HEP) Award DE-SC0013528_ and NSF grant _PHY-2014086_.

--- a/experimental/FTheoryTools/docs/src/introduction.md
+++ b/experimental/FTheoryTools/docs/src/introduction.md
@@ -6,102 +6,133 @@ DocTestSetup = Oscar.doctestsetup()
 
 # Welcome to FTheoryTools
 
-## Goal
+## Overview
 
-*FTheoryTools* is a computational toolkit designed to automate and simplify many of the intricate and time-consuming computations encountered in F-theory model building. Developed as a submodule of the `OSCAR` computer algebra system, it provides infrastructure to streamline model construction, crepant resolution of singularities, and geometric analysis of singular elliptic fibrations—central objects in F-theory phenomenology.
+**FTheoryTools** is a computational toolkit within the [OSCAR computer algebra system](https://www.oscar-system.org/), designed to assist researchers in working with F-theory models. It focuses on automating and simplifying calculations involving **singular elliptic fibrations**—key geometric objects in F-theory phenomenology.
 
-F-theory models encode physical data in the geometry of singular elliptic fibrations. The presence and type of singularities in the fibration are physically meaningful, determining the resulting gauge symmetry and matter content. Smooth fibrations typically correspond to trivial physics and are not the focus of model builders. However, performing computations directly on singular spaces is often impractical. Therefore, F-theory studies usually begin by finding a *crepant resolution* of the singular geometry—one that preserves the Calabi-Yau condition and hence the physical relevance.
+While the module is tailored for string theorists, it is equally accessible to mathematicians interested in the rich geometry of singular fibrations, even if they are not familiar with F-theory itself.
 
-The crepant resolution of singularities, especially in higher codimensions or non-toric settings, poses major computational and conceptual challenges:
-1. Not all singularities admit crepant resolutions.
-2. When crepant resolutions exist, they may not resolve all singularities.
-3. Multiple resolutions might exist, offering complementary physical insights.
+This page is meant for *end users* of OSCAR, including students and researchers in mathematics and the natural sciences. No background in string theory or theoretical physics is assumed beyond what is needed to understand the geometry of elliptic fibrations. We encourage interested readers to consult the exposition in [Weigand 2018](@cite Wei18) for more background information.
 
-While *FTheoryTools* does not (yet) resolve all such foundational issues, its aim is to *make the crepant resolution process as accessible, automated, and reproducible as possible*. It also assists in extracting physically relevant geometric features from the resolved space.
+## Why Use FTheoryTools?
 
+F-theory encodes physical data into the structure of singular elliptic fibrations. In these models:
+
+- The **type and location** of singularities relate directly to gauge groups and matter content.
+- **Smooth** fibrations typically yield trivial physics and are therefore less interesting for physical applications.
+
+To analyze the geometry effectively, model builders look for a **crepant resolution** of the singular space—one that preserves the Calabi-Yau condition and retains physical meaning. These resolutions are challenging to compute, especially in higher codimension or for non-toric singularities.
+
+FTheoryTools aims to:
+
+- Automate and streamline the crepant resolution process,
+- Make computations more reproducible,
+- Extract physically relevant features from the resolved space,
+- Offer a modular and extensible framework for researchers in both physics and mathematics.
 
 ## Key Features
 
-### Elliptic Fibration Models
+### Constructing Elliptic Fibrations
 
-You can construct elliptic fibrations using:
+FTheoryTools supports construction of elliptic fibrations via:
+
 - [Weierstrass models](@ref),
 - [Global Tate models](@ref),
 - [Hypersurface models](@ref).
-Since all of these different models encode singular elliptic fibrations mathematically, certain properties, attributes, and methods apply to all models equally. This shared functionality is summarized on the page [Functionality for all F-theory models](@ref).
 
-The base of the fibration may be:
-- A family of abstract base spaces,
-- A toric variety (the currently best-supported case),
-- In the future: schemes and more general varieties.
+All of these represent singular elliptic fibrations, so many operations and properties are shared across them. This shared functionality is documented at [Functionality for all F-theory models](@ref).
 
-We do not limit ourselves to base spaces of dimensions 1, 2, or 3, but those are of particular interest for physical applications.
+Fibrations can be defined over various base spaces:
 
-### General Blowups
+- Families of abstract bases,
+- Toric varieties (best supported),
+- (Planned) General schemes and varieties.
 
-Unlike most traditional approaches which are limited to toric blowups, *FTheoryTools* supports blowups on arbitrary loci, including non-toric ones. This significantly expands the scope of F-theory constructions accessible through our software.
+Physically relevant cases often have base dimension 1, 2, or 3, but *FTheoryTools* is not limited to these.
+
+### General Blowups (Beyond Toric)
+
+FTheoryTools enables blowups on arbitrary loci—not just toric centers. This allows users to work with a wider class of singularities, including those without a known toric resolution.
 
 ### Literature Models
 
-We provide support for an expanding database of well-known F-theory models, referred to as *literature models*. These models are serialized using the **MaRDI file format**, which is based on JSON and designed in accordance with the FAIR principles --- Findability, Accessibility, Interoperability, and Reusability.
+*FTheoryTools* includes a curated database of well-known F-theory models from the literature. These models are stored using the **MaRDI file format**, a JSON-based format aligned with FAIR data principles:
 
-The MaRDI file format is part of a broader effort by the [Mathematical Research Data Initiative (MaRDI)](https://www.mardi4nfdi.de/about/mission), a German consortium focused on establishing standards and developing tools to improve the handling of mathematical research data. While OSCAR's current implementation of the MaRDI format is centered around saving and loading data within the system, the format is designed to be extensible and interoperable with other computer algebra systems such as `SAGE` and `Macaulay2`.
+- **Findability**
+- **Accessibility**
+- **Interoperability**
+- **Reusability**
 
-The specification of the **mrdi** file format used in OSCAR can be found on [Zenodo](https://zenodo.org/records/12723387). For a broader discussion of its design and goals, refer to [this article](https://link.springer.com/chapter/10.1007/978-3-031-64529-7_25), as well as the [OSCAR documentation on serialization](https://docs.oscar-system.org/stable/General/serialization/).
+Learn more about the format:
 
-Current database entries include, but are not limited to, models from:
+- [MaRDI project website](https://www.mardi4nfdi.de/about/mission)
+- [MaRDI file specification on Zenodo](https://zenodo.org/records/12723387)
+- [Design paper](https://link.springer.com/chapter/10.1007/978-3-031-64529-7_25)
+- [Serialization docs in OSCAR](https://docs.oscar-system.org/stable/General/serialization/)
+
+Current literature models include:
+
 - [Krause, Mayrhofer, Weigand 2011](@cite KMW12),
 - [Morrison, Park 2012](@cite MP12),
 - [Lawrie, Schafer-Nameki 2013](@cite LS13),
 - [Klevers, Mayorga, Damian, Oehlmann, Piragua, Reuter 2015](@cite KM-POPR15),
 - [Cvetič, Klevers, Piragua, Taylor 2015](@cite CKPT15),
 - [Taylor, Wang 2015](@cite TW15),
-- [CHLLT 2019](@cite CHLLT19).
+- [Cvetič, Halverson, Ling, Liu, Tian 2019](@cite CHLLT19).
 
-More details are available on the page [Literature constructions](@ref).
+More information: [Literature constructions](@ref).
 
 ### ``G_4``-Flux Enumeration
 
-*FTheoryTools* supports enumeration of ``G_4``-fluxes, essential for determining the chiral spectra of F-theory compactifications. As a demonstration of its capabilities, we did enumerate ``G_4``-fluxes for the notoriously difficult *F-theory geometry with the most flux vacua* [Taylor, Wang 2015](@cite TW15), involving:
-- 101 toric rays,
-- 198 maximal cones,
-- A defining equation with 355,785 monomials,
-- A resolution via 206 toric blowups (plus 3 additional ones for ambient smoothness).
-We identified a space of candidate vertical ``G_4`` fluxes parametrized by ``\mathbb{Z}^{224} \times \mathbb{Q}^{127}``. Details on this particular computation are available in the publication [BMT25](@cite BMT25).
+FTheoryTools supports the enumeration of vertical ``G_4``-fluxes—important for understanding chiral spectra in F-theory.
 
-More details are available on the page [G4-Fluxes](@ref).
+#### Example: [Taylor, Wang 2015](@cite TW15)
+
+- 101 toric rays
+- 198 maximal cones
+- Defining equation with 355,785 monomials
+- 206 toric blowups + 3 smoothness blowups
+
+The computed flux space: ``\mathbb{Z}^{224} \times \mathbb{Q}^{127}``.
+
+Details are available in [BMT25]\(@cite BMT25). See also: [G4-Fluxes](@ref).
 
 ## Tutorials
 
-We encourage you to take a look at the tutorials on FTheoryTools, which can be found at [https://www.oscar-system.org/tutorials/FTheoryTools/](https://www.oscar-system.org/tutorials/FTheoryTools/).
+Explore example-driven tutorials at: [https://www.oscar-system.org/tutorials/FTheoryTools/](https://www.oscar-system.org/tutorials/FTheoryTools/)
 
+These walk through:
 
-## Installation
+- Building models
+- Performing blowups
+- Extracting physical/geometric information
 
-To get started with *FTheoryTools*, install [OSCAR](https://www.oscar-system.org/install/).
+## Getting Started
 
-To benefit from the latest features, improvements, and bug fixes, we recommend keeping OSCAR up to date by following the [upgrade instructions](https://www.oscar-system.org/upgrade/).
+1. **Install OSCAR**: [Installation instructions](https://www.oscar-system.org/install/)
+2. **Update regularly**: Stay current with new features via the [upgrade guide](https://www.oscar-system.org/upgrade/)
 
+## Project Status
 
-## Status and Outlook
+FTheoryTools is an **experimental** module. Most features are well-tested for **toric** models, with active development underway for:
 
-*FTheoryTools* is an experimental module. Functionality is currently most robust for model based on toric geometries, but support for general families and schemes is actively being developed. Future extensions will include, but are not limited to:
-- Vector-like spectrum computations via line bundle cohomologies,
-- Support for terminal and non-minimal singularities,
-- Automated base blowups.
+- Support for general base families and schemes
+- Line bundle cohomology for vector-like spectra
+- Support for terminal/non-minimal singularities
+- Base blowup automation
 
+## Contact & Community
 
-## Contact
+For questions, suggestions, or collaboration:
 
-For questions or feedback, reach out to:
 - [Martin Bies](https://martinbies.github.io/)
 - [Miķelis E. Miķelsons](https://github.com/emikelsons)
 - [Andrew P. Turner](https://apturner.net/)
 
-Or visit:
+Community platforms:
+
 - [OSCAR Slack](https://www.oscar-system.org/community/#Slack)
 - [GitHub Issue Tracker](https://www.oscar-system.org/community/#Reporting-Issues)
-
 
 ## Acknowledgements
 

--- a/experimental/FTheoryTools/docs/src/introduction.md
+++ b/experimental/FTheoryTools/docs/src/introduction.md
@@ -33,7 +33,7 @@ With *FTheoryTools*, you can create elliptic fibrations using one of the followi
 * Weierstrass model,
 * Global Tate model,
 * Hypersurface model.
-In each case, the base space can be a family of spaces (as used in the literature when an explicit base is not specified) or a toric space. We anticipate an extension to schemes as bases. The dimension of those bases is not limited to $1$, $2$, or $3$, but of course includes those cases important to the physics.
+In each case, the base space can be a family of spaces (as used in the literature when an explicit base is not specified) or a toric space. We anticipate an extension to schemes as bases. The dimension of those bases is not limited to ``1``, ``2``, or ``3``, but of course includes those cases important to the physics.
 
 We also offer a database of models frequently studied in the literature. For those models we use the term 'literature_models.' In essence, you should be able to create a model described in a paper at the click of a button. We anticipate that this feature will greatly simplify future research in F-Theory.
 
@@ -45,12 +45,12 @@ We anticipate the following workflow:
 ### User Input:
 - Create your desired F-Theory model by using one of the methods described above.
 - Choose a resolved phase/crepant resolution.
-- Select generating sections for $\operatorname{U}(1)$ symmetries.
+- Select generating sections for ``\operatorname{U}(1)`` symmetries.
 
 ### Output:
 - (Crepantly) resolved geometry.
-- Singular loci in suitable codimension (e.g., $1$, $2$, and $3$ if the base space has dimension $3$).
-- Fiber diagrams of the resolved fiber over the originally singular loci, including intersections of $\operatorname{U}(1)$-sections.
+- Singular loci in suitable codimension (e.g., ``1``, ``2``, and ``3`` if the base space has dimension ``3``).
+- Fiber diagrams of the resolved fiber over the originally singular loci, including intersections of ``\operatorname{U}(1)``-sections.
 - Gauge group.
 - Topological data (e.g., Euler number).
 
@@ -61,8 +61,8 @@ We are also actively expanding our database of supported literature models. At t
 - F-Theory on all Toric Hypersurface Fibrations and its Higgs Branches [KM-POPR15](@cite),
 - Quadrillion F-Theory Compactifications with the Exact Chiral Spectrum of the Standard Model [CHLLT19](@cite).
 
-Consequently, we are already covering infinite families of models (e.g., with $SU(k)$ gauge group, where $k \geq 1$).
-Still, the total number of papers in our database is at this point limited to about $6$. This is to be extended a lot.
+Consequently, we are already covering infinite families of models (e.g., with ``SU(k)`` gauge group, where ``k \geq 1``).
+Still, the total number of papers in our database is at this point limited to about ``6``. This is to be extended a lot.
 
 
 ## Tutorial
@@ -74,7 +74,7 @@ We encourage you to take a look at the tutorials on FTheoryTools, which can be f
 ## Possible future extensions
 
 Future extensions include, but are not necessarily limited to, the following:
-* Specify a $G_4$-flux and work out the chiral spectra,
+* Specify a ``G_4``-flux and work out the chiral spectra,
 * Specify a gauge potential and work out (candidates for) the line bundles whose cohomologies encode the vector-like spectra,
 * Other singularity types (non-minimal, terminal, etc.,)
 * Base blowups for singularity resolution.

--- a/experimental/FTheoryTools/docs/src/literature.md
+++ b/experimental/FTheoryTools/docs/src/literature.md
@@ -56,6 +56,9 @@ as the second argument. Such a setter function exists for all of the above. If a
 we also offer a method that adds a new value. For instance, we have a function
 `add_paper_buzzword(m::AbstractFTheoryModel, addition::String)`.
 
+!!! warning
+    Calling `set_description(m::AbstractFTheoryModel, description::String)` overwrites the existing description. This applies similarly to all other setter functions. Use with care, as existing data will be replaced without warning.
+
 In addition, the following attributes are available to access advanced model information:
 ```@docs
 resolutions(m::AbstractFTheoryModel)

--- a/experimental/FTheoryTools/docs/src/tate.md
+++ b/experimental/FTheoryTools/docs/src/tate.md
@@ -171,22 +171,24 @@ fiber ambient space with `fiber_ambient_space`. Recall that `is_base_space_fully
 tell if the model has been constructed over a concrete space (in which case the function returns
 `true`) or a family of spaces (returning `false`).
 
+### Advanced Attributes
 
-### Advanced attributes
-
-The following attributes are currently only supported in a toric setting:
+The following functionality is currently only supported for toric ambient spaces:
 ```@docs
 calabi_yau_hypersurface(t::GlobalTateModel)
 weierstrass_model(t::GlobalTateModel)
 ```
-Note that for applications in F-theory, *singular* elliptic fibrations are key
-(cf. [Wei18](@cite) and references therein). Consequently the discriminant
-locus as well as the singular loci of the fibration in question are of ample
-importance:
+In F-theory, *singular* elliptic fibrations are of central importance (cf. [Wei18](@cite) and references therein). One crucial quantity is the discriminant locus of the fibration, i.e. the locus of the base over which the fibers become singular:
 ```@docs
 discriminant(t::GlobalTateModel)
+```
+Even more critical than the discriminant itself is its decomposition: the discriminant locus may split into several irreducible components. Over each such component, the type of singularity in the elliptic fiber is determined. The following function singular_loci returns this list of irreducible base loci along with the corresponding singularity types:
+```@docs
 singular_loci(t::GlobalTateModel)
 ```
+!!! warning
+    The classification of singularities is performed using a Monte Carlo algorithm, i.e. it involves random sampling. While the implementation has been extensively tested and meets high standards, its probabilistic nature may occasionally yield non-deterministic results.
+
 
 ## Methods
 

--- a/experimental/FTheoryTools/docs/src/weierstrass.md
+++ b/experimental/FTheoryTools/docs/src/weierstrass.md
@@ -156,21 +156,24 @@ fiber ambient space with `fiber_ambient_space`. Recall that `is_base_space_fully
 tell if the model has been constructed over a concrete space (in which case the function returns
 `true`) or a family of spaces (returning `false`).
 
+### Advanced Attributes
 
-### Advanced attributes
-
-The following attributes are currently only supported in a toric setting:
+The following functionality is currently only supported for toric ambient spaces:
 ```@docs
 calabi_yau_hypersurface(w::WeierstrassModel)
 ```
-Note that for applications in F-theory, *singular* elliptic fibrations are key
-(cf. [Wei18](@cite) and references therein). Consequently the discriminant
-locus as well as the singular loci of the fibration in question are of ample
-importance:
+In F-theory, *singular* elliptic fibrations are of central importance (cf. [Wei18](@cite) and references therein). One crucial quantity is the discriminant locus of the fibration, i.e. the locus of the base over which the fibers become singular:
 ```@docs
 discriminant(w::WeierstrassModel)
+```
+Even more critical than the discriminant itself is its decomposition: the discriminant locus may split into several irreducible components. Over each such component, the type of singularity in the elliptic fiber is determined. The following function singular_loci returns this list of irreducible base loci along with the corresponding singularity types:
+```@docs
 singular_loci(w::WeierstrassModel)
 ```
+!!! warning
+    The classification of singularities is performed using a Monte Carlo algorithm, i.e. it involves random sampling. While the implementation has been extensively tested and meets high standards, its probabilistic nature may occasionally yield non-deterministic results.
+
+
 
 ## Methods
 

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/attributes.jl
@@ -1253,11 +1253,11 @@ end
 @doc raw"""
     chern_class(m::AbstractFTheoryModel, k::Int; check::Bool = true)
 
-If the elliptically fibered n-fold $Y_n$ underlying the F-theory model in question is given
-as a hypersurface in a toric ambient space, we can compute a cohomology class $h$ on the
-toric ambient space $X_\Sigma$, such that its restriction to $Y_n$ is the k-th Chern class
-$c_k$ of the tangent bundle of $Y_n$. If those assumptions are satisfied, this method returns
-this very cohomology class $h$, otherwise it raises an error.
+If the elliptically fibered n-fold ``Y_n`` underlying the F-theory model in question is given
+as a hypersurface in a toric ambient space, we can compute a cohomology class ``h`` on the
+toric ambient space ``X_\Sigma``, such that its restriction to ``Y_n`` is the k-th Chern class
+``c_k`` of the tangent bundle of ``Y_n``. If those assumptions are satisfied, this method returns
+this very cohomology class ``h``, otherwise it raises an error.
 
 The theory guarantees that the implemented algorithm works for toric ambient spaces which are
 smooth and complete. The check for completeness can be very time consuming. This check can
@@ -1329,12 +1329,12 @@ end
 @doc raw"""
     chern_classes(m::AbstractFTheoryModel; check::Bool = true)
 
-If the elliptically fibered n-fold $Y_n$ underlying the F-theory model in question is given
-as a hypersurface in a toric ambient space, we can compute a cohomology class $h$ on the
-toric ambient space $X_\Sigma$, such that its restriction to $Y_n$ is the k-th Chern class
-$c_k$ of the tangent bundle of $Y_n$. If those assumptions are satisfied, this method returns
-a vector with the cohomology classes corresponding to all non-trivial Chern classes $c_k$ of
-$Y_n$. Otherwise, this methods raises an error.
+If the elliptically fibered n-fold ``Y_n`` underlying the F-theory model in question is given
+as a hypersurface in a toric ambient space, we can compute a cohomology class ``h`` on the
+toric ambient space ``X_\Sigma``, such that its restriction to ``Y_n`` is the k-th Chern class
+``c_k`` of the tangent bundle of ``Y_n``. If those assumptions are satisfied, this method returns
+a vector with the cohomology classes corresponding to all non-trivial Chern classes ``c_k`` of
+``Y_n``. Otherwise, this methods raises an error.
 
 As of right now, this method is computationally expensive for involved toric ambient spaces,
 such as in the example below.
@@ -1370,7 +1370,7 @@ end
 @doc raw"""
     euler_characteristic(m::AbstractFTheoryModel; check::Bool = true)
 
-If the elliptically fibered n-fold $Y_n$ underlying the F-theory model in question is given
+If the elliptically fibered n-fold ``Y_n`` underlying the F-theory model in question is given
 as a hypersurface in a toric ambient space, we can compute the Euler characteristic. If this
 assumptions is satisfied, this method returns the Euler characteristic, otherwise it raises an
 error.

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/properties.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/properties.jl
@@ -151,12 +151,12 @@ end
     is_calabi_yau(m::AbstractFTheoryModel; check::Bool = true)
 
 Verify if the first Chern class of the tangent bundle of the F-theory geometry
-$Y_n$ vanishes. If so, this confirms that this geometry is indeed Calabi-Yau,
+``Y_n`` vanishes. If so, this confirms that this geometry is indeed Calabi-Yau,
 as required by the reasoning of F-theory.
 
 The implemented algorithm works for hypersurface, Weierstrass and global Tate models,
-which are defined in a toric ambient space. It expresses $c_1(Y_n)$ as the restriction
-of a cohomology class $h$ on the toric ambient space. This in turn requires that the
+which are defined in a toric ambient space. It expresses ``c_1(Y_n)`` as the restriction
+of a cohomology class ``h`` on the toric ambient space. This in turn requires that the
 toric ambient space is simplicial and complete. We provide a switch to turn off 
 these computationally very demanding checks. This is demonstrated in the example below.
 

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/attributes.jl
@@ -5,7 +5,7 @@
 @doc raw"""
     model(gf::FamilyOfG4Fluxes)
 
-Return the F-theory model for which this family of $G_4$-flux candidates is defined.
+Return the F-theory model for which this family of ``G_4``-flux candidates is defined.
 
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
@@ -142,16 +142,16 @@ offset(gf::FamilyOfG4Fluxes) = gf.offset
 @doc raw"""
     d3_tadpole_constraint(fgs::FamilyOfG4Fluxes; check::Bool = true)
 
-Return the d3-tapdole constraint of Family of G4-fluxes. Recall that for a given $G_4$-flux, this constraint
-is $- \frac{1}{2} \cdot G_4^2 + \frac{1}{24} \cdot \chi(\widehat{Y}_4) \stackrel{!}{\geq} 0$.
+Return the d3-tapdole constraint of Family of G4-fluxes. Recall that for a given ``G_4``-flux, this constraint
+is ``- \frac{1}{2} \cdot G_4^2 + \frac{1}{24} \cdot \chi(\widehat{Y}_4) \stackrel{!}{\geq} 0``.
 
 Note that the family of fluxes is specified by linear combination of cohomology classes, some with rational
 and some with integral coefficients. In terms of these coefficients the d3-tadpole constraint is the demand
 that a quadratic polynomial in the coefficients evaluates to a non-negative number. This method returns said
-polynomial in the cofficients. In order to evaluate the D3-tadpole for a particular $G_4$-flux, one has to
-evaluate this polynomial for the numeric coefficient values that correspond to the given $G_4$-flux.
+polynomial in the cofficients. In order to evaluate the D3-tadpole for a particular ``G_4``-flux, one has to
+evaluate this polynomial for the numeric coefficient values that correspond to the given ``G_4``-flux.
 
-We use symbols $a_i$ to indicate integral coefficients and $r_i$ to indicate rational coefficients.
+We use symbols ``a_i`` to indicate integral coefficients and ``r_i`` to indicate rational coefficients.
 
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/constructors.jl
@@ -8,11 +8,11 @@
 Given an F-theory model with a toric ambient space, we can 
 identify ambient space candidates of G4-fluxes. In terms of these
 candidates, we can define a family of G4-fluxes as:
-- $\mathbb{Z}$-linear combinations, provided by a matrix $mat_int$,
-- $\mathbb{Q}$-linear combinations, provided by a matrix $mat_rat$,
-- a shift (invoked for instance by the appearance of $\frac{1}{2} \cdot c_2$ in the quantization condition), provided by a vector $offset$.
+- ``\mathbb{Z}``-linear combinations, provided by a matrix ``mat_int``,
+- ``\mathbb{Q}``-linear combinations, provided by a matrix ``mat_rat``,
+- a shift (invoked for instance by the appearance of ``\frac{1}{2} \cdot c_2`` in the quantization condition), provided by a vector ``offset``.
 
-For convenience we also allow to only provide $mat_int$, $mat_rat$. In this case, the shift is taken to be zero.
+For convenience we also allow to only provide ``mat_int``, ``mat_rat``. In this case, the shift is taken to be zero.
 
 An example is in order.
 

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/constructors.jl
@@ -44,7 +44,7 @@ function family_of_g4_fluxes(m::AbstractFTheoryModel, mat_int::QQMatrix, mat_rat
   @req ambient_space(m) isa NormalToricVariety "Family of G4-flux currently supported only for toric ambient space"
   @req nrows(mat_int) == nrows(mat_rat) "Number of rows in both matrices must coincide"
   @req nrows(mat_int) == length(offset) "Number of rows of integral matrix and length offset must coincide"
-  n_gens = length(chosen_g4_flux_basis(m, check = check))
+  n_gens = length(chosen_g4_flux_gens(m, check = check))
   @req nrows(mat_int) == n_gens "Number of rows in both matrices must agree with the number of ambient space models of G4-fluxes"
   return FamilyOfG4Fluxes(m, mat_int, mat_rat, offset)
 end

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
@@ -203,7 +203,7 @@ end
 @doc raw"""
     random_flux(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true)
 
-Create a random $G_4$-flux on a given F-theory model.
+Create a random ``G_4``-flux on a given F-theory model.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
@@ -79,7 +79,7 @@ function flux_instance(fgs::FamilyOfG4Fluxes, int_combination::ZZMatrix, rat_com
   m1 = matrix_integral(fgs) * int_combination
   m2 = matrix_rational(fgs) * rat_combination
   shift = offset(fgs)
-  gens = chosen_g4_flux_basis(model(fgs), check = check)
+  gens = chosen_g4_flux_gens(model(fgs), check = check)
   c1 = sum(m1[k,1] * gens[k] for k in 1:length(gens))
   c2 = sum(m2[k,1] * gens[k] for k in 1:length(gens))
   c3 = sum(shift[k] * gens[k] for k in 1:length(gens))

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/properties.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/properties.jl
@@ -54,7 +54,7 @@ true
   # TODO: Remove this limitation, i.e. support this functionality for all flux families!
 
   # Extract ambient space model of g4-fluxes, in terms of which we express the generators of the flux family
-  mb = chosen_g4_flux_basis(model(fgs), check = check)
+  mb = chosen_g4_flux_gens(model(fgs), check = check)
   nmb = length(mb)
 
   # Verify that each integral generator is well-quantized
@@ -131,7 +131,7 @@ true
   # TODO: Remove this limitation, i.e. support this functionality for all flux families!
 
   # Extract ambient space model of g4-fluxes, in terms of which we express the generators of the flux family
-  mb = chosen_g4_flux_basis(model(fgs), check = check)
+  mb = chosen_g4_flux_gens(model(fgs), check = check)
   nmb = length(mb)
 
   # Verify that each generator of the flux family is vertical
@@ -206,7 +206,7 @@ false
   # TODO: Remove this limitation, i.e. support this functionality for all flux families!
   
   # Extract ambient space model of g4-fluxes, in terms of which we express the generators of the flux family
-  mb = chosen_g4_flux_basis(model(fgs), check = check)
+  mb = chosen_g4_flux_gens(model(fgs), check = check)
   nmb = length(mb)
 
   # Verify that each generator of the flux family does not break the non-abelian gauge group

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/properties.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/properties.jl
@@ -6,8 +6,8 @@
     is_well_quantized(fgs::FamilyOfG4Fluxes; check::Bool = true)
 
 Executes elementary tests (they are necessary but not sufficient)
-to tell if Family of $G_4$-fluxes is well-quantized. In case
-any of these tests fails, we know that this family of $G_4$-fluxes
+to tell if Family of ``G_4``-fluxes is well-quantized. In case
+any of these tests fails, we know that this family of ``G_4``-fluxes
 is definitely not well-quantized. This method then returns `false`.
 
 In the opposite case that all elementary tests pass, this method
@@ -91,7 +91,7 @@ end
 @doc raw"""
     passes_transversality_checks(fgs::FamilyOfG4Fluxes; check::Bool = true)
 
-Check if the given family of $G_4$-fluxes passes the transversality checks.
+Check if the given family of ``G_4``-fluxes passes the transversality checks.
 If so, this method returns `true` and otherwise `false`.
 
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
@@ -7,7 +7,7 @@ defined as a hypersurface in a simplicial and complete toric ambient space.
 ### Description
 This method models the G4-flux family using the restriction of cohomology classes on the
 toric ambient space to the hypersurface. In the toric ambient space, these classes are vertical,
-meaning they are of the form $a \wedge b$, where $a, b \in H^(1,1)(X_\Sigma)$, with $X_\Sigma$
+meaning they are of the form ``a \wedge b``, where ``a, b \in H^(1,1)(X_\Sigma)``, with ``X_\Sigma``
 denoting the toric ambient space.
 
 The resulting family is subjected to consistency conditions to ensure it satisfies elementary
@@ -16,20 +16,20 @@ space G4-flux candidates that meet these conditions.
 
 ### Optional Arguments
 - `not_breaking = true`: Ensures the flux family preserves the non-abelian gauge group.
-- `check = false`: Skips computational checks for whether the toric ambient space $X_\Sigma$ is complete and simplicial, which can be resource-intensive.
+- `check = false`: Skips computational checks for whether the toric ambient space ``X_\Sigma`` is complete and simplicial, which can be resource-intensive.
 
 ### Notes
 !!! warning
-    This method assumes that $c_2( \widehat{Y}_4)$ is even. No checks or errors are implemented for this condition, so use cautiously.
+    This method assumes that ``c_2( \widehat{Y}_4)`` is even. No checks or errors are implemented for this condition, so use cautiously.
 
 This assumption relates to the quantization condition, which requires verifying if the twist of a
-given $G_4$-flux by $1/2 \cdot c_2( \widehat{Y}_4)$ is even. For many F-theory models, such as
+given ``G_4``-flux by ``1/2 \cdot c_2( \widehat{Y}_4)`` is even. For many F-theory models, such as
 compactifications on smooth Calabi-Yau 4-folds with globally defined Weierstrass models ([CS12](@cite)),
-$c_2( \widehat{Y}_4)$ is known to be even. This also applies to all F-theory QSMs ([CHLLT19](@cite)).
+``c_2( \widehat{Y}_4)`` is known to be even. This also applies to all F-theory QSMs ([CHLLT19](@cite)).
 
 ### Computational Details
 The method internally identifies two matrices related to the family of fluxes:
-1. `matrix_integral`: Specifies rational combinations of ambient space G4-flux candidates that can only form $\mathbb{Z}$-linear combinations without violating elementary flux quantization conditions.
+1. `matrix_integral`: Specifies rational combinations of ambient space G4-flux candidates that can only form ``\mathbb{Z}``-linear combinations without violating elementary flux quantization conditions.
 2. `matrix_rational`: Specifies rational combinations of flux candidates for which any rational linear combination satisfies the elementary flux quantization conditions.
 
 These matrices are accessible for further analysis.
@@ -77,7 +77,7 @@ julia> is_well_quantized(qsm_g4_flux)
 true
 ```
 
-Finally, we demonstrate the computation of the well-quantized $G_4$-fluxes which pass the transversality checks,
+Finally, we demonstrate the computation of the well-quantized ``G_4``-fluxes which pass the transversality checks,
 and which in addition do not break the non-abelian gauge group.
 
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))

--- a/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
@@ -5,25 +5,24 @@
 @doc raw"""
     model(gf::G4Flux)
 
-Return the F-theory model for which this ``G_4``-flux candidate is defined.
+Return the F-theory model used to construct the G_4-flux candidate.
 
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
 
-julia> cohomology_ring(ambient_space(qsm_model), check = false);
-
-julia> g4_class = cohomology_class(anticanonical_divisor_class(ambient_space(qsm_model)))^2;
-
-julia> g4f = g4_flux(qsm_model, g4_class, check = false)
+julia> g4_candidate = qsm_flux(qsm_model)
 G4-flux candidate
-  - Elementary quantization checks: not executed
-  - Transversality checks: not executed
-  - Non-abelian gauge group: breaking pattern not analyzed  
+  - Elementary quantization checks: satisfied
+  - Transversality checks: satisfied
+  - Non-abelian gauge group: unbroken
   - Tadpole cancellation check: not computed
 
-julia> model(g4f)
+julia> model(g4_candidate)
 Hypersurface model over a concrete base
+
+julia> model(g4_candidate) == qsm_model
+true
 ```
 """
 model(gf::G4Flux) = gf.model
@@ -32,7 +31,7 @@ model(gf::G4Flux) = gf.model
 @doc raw"""
     cohomology_class(gf::G4Flux)
 
-Return the cohomology class which defines the ``G_4``-flux candidate.
+Return the ambient space cohomology class which defines the ``G_4``-flux candidate.
 
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
@@ -64,8 +63,8 @@ cohomology_class(gf::G4Flux) = gf.class
 @doc raw"""
     d3_tadpole_constraint(gf::G4Flux; check::Bool = true)
 
-Return the d3-tapdole constraint of a G4-flux, that is compute the quantity
-``- \frac{1}{2} \cdot G_4^2 + \frac{1}{24} \cdot \chi(\widehat{Y}_4) \stackrel{!}{\geq} 0``.
+Return the d3-tapdole of a G4-flux, that is compute and return the quantity
+``- \frac{1}{2} \cdot \int_{\widehat{Y_4}}{G_4 \wedge G_4} + \frac{1}{24} \cdot \chi(\widehat{Y}_4)``.
 
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
@@ -241,4 +240,36 @@ julia> rational_coefficients(g4);
 function rational_coefficients(gf::G4Flux)
   @req has_attribute(gf, :rat_combination) "Rational coefficients not known for the given G4-flux"
   return get_attribute(gf, :rat_combination)::QQMatrix
+end
+
+
+@doc raw"""
+    offset(gf::G4Flux)
+
+Return the offset of a given ``G_4``-flux.
+If this shift is not known, an error is raised.
+
+```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
+julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
+Hypersurface model over a concrete base
+
+julia> gfs = special_flux_family(qsm_model, check = false)
+Family of G4 fluxes:
+  - Elementary quantization checks: satisfied
+  - Transversality checks: satisfied
+  - Non-abelian gauge group: breaking pattern not analyzed
+
+julia> g4 = random_flux_instance(gfs, check = false)
+G4-flux candidate
+  - Elementary quantization checks: satisfied
+  - Transversality checks: satisfied
+  - Non-abelian gauge group: breaking pattern not analyzed
+  - Tadpole cancellation check: not computed
+
+julia> offset(g4);
+```
+"""
+function offset(gf::G4Flux)
+  @req has_attribute(gf, :offset) "Offset not known for the given G4-flux"
+  return get_attribute(gf, :offset)::Vector{QQFieldElem}
 end

--- a/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
@@ -5,7 +5,7 @@
 @doc raw"""
     model(gf::G4Flux)
 
-Return the F-theory model for which this $G_4$-flux candidate is defined.
+Return the F-theory model for which this ``G_4``-flux candidate is defined.
 
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
@@ -32,7 +32,7 @@ model(gf::G4Flux) = gf.model
 @doc raw"""
     cohomology_class(gf::G4Flux)
 
-Return the cohomology class which defines the $G_4$-flux candidate.
+Return the cohomology class which defines the ``G_4``-flux candidate.
 
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
@@ -65,7 +65,7 @@ cohomology_class(gf::G4Flux) = gf.class
     d3_tadpole_constraint(gf::G4Flux; check::Bool = true)
 
 Return the d3-tapdole constraint of a G4-flux, that is compute the quantity
-$- \frac{1}{2} \cdot G_4^2 + \frac{1}{24} \cdot \chi(\widehat{Y}_4) \stackrel{!}{\geq} 0$.
+``- \frac{1}{2} \cdot G_4^2 + \frac{1}{24} \cdot \chi(\widehat{Y}_4) \stackrel{!}{\geq} 0``.
 
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
@@ -150,9 +150,9 @@ end
 @doc raw"""
     g4_flux_family(gf::G4Flux; check::Bool = true)
 
-Return the family of $G_4$-fluxes that possesses, such
+Return the family of ``G_4``-fluxes that possesses, such
 that all fluxes in this family share the following properties
-with the given $G_4$-flux: Transversality and breaking of the
+with the given ``G_4``-flux: Transversality and breaking of the
 non-Abelian gauge group.
 
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -183,7 +183,7 @@ end
 @doc raw"""
     integral_coefficients(gf::G4Flux)
 
-Return the integral coefficients of a given $G_4$-flux.
+Return the integral coefficients of a given ``G_4``-flux.
 If these coefficients are not known, an error is raised.
 
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -215,7 +215,7 @@ end
 @doc raw"""
     rational_coefficients(gf::G4Flux)
 
-Return the integral coefficients of a given $G_4$-flux.
+Return the integral coefficients of a given ``G_4``-flux.
 If these coefficients are not known, an error is raised.
 
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))

--- a/experimental/FTheoryTools/src/G4Fluxes/auxiliary.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/auxiliary.jl
@@ -8,22 +8,22 @@
     converter_dict_h22_ambient(m::AbstractFTheoryModel; check::Bool = true)
 
 By virtue of Theorem 12.4.1 in [CLS11](@cite), one can compute a monomial
-basis of $H^4(X, \mathbb{Q})$ for a simplicial, complete toric variety $X$
-by truncating its cohomology ring to degree $2$. Inspired by this, this
-method identifies a basis of $H^{(2,2)}(X, \mathbb{Q})$ by multiplying
+basis of ``H^4(X, \mathbb{Q})`` for a simplicial, complete toric variety ``X``
+by truncating its cohomology ring to degree ``2``. Inspired by this, this
+method identifies a basis of ``H^{(2,2)}(X, \mathbb{Q})`` by multiplying
 pairs of cohomology classes associated with toric coordinates.
 
-By definition, $H^{(2,2)}(X, \mathbb{Q})$ is a subset of $H^{4}(X, \mathbb{Q})$.
+By definition, ``H^{(2,2)}(X, \mathbb{Q})`` is a subset of ``H^{4}(X, \mathbb{Q})``.
 However, by Theorem 9.3.2 in [CLS11](@cite), for complete and simplicial
-toric varieties and $p \neq q$ it holds $H^{(p,q)}(X, \mathbb{Q}) = 0$. It follows
-that for such varieties $H^{(2,2)}(X, \mathbb{Q}) = H^4(X, \mathbb{Q})$ and the
-vector space dimension of those spaces agrees with the Betti number $b_4(X)$.
+toric varieties and ``p \neq q`` it holds ``H^{(p,q)}(X, \mathbb{Q}) = 0``. It follows
+that for such varieties ``H^{(2,2)}(X, \mathbb{Q}) = H^4(X, \mathbb{Q})`` and the
+vector space dimension of those spaces agrees with the Betti number ``b_4(X)``.
 
 This method computes a dictionary which allows to map any element of
-$H^(2,2)(X, \mathbb{Q})$ into the basis found/chosen for $H^(2,2)(X, \mathbb{Q})$.
+``H^(2,2)(X, \mathbb{Q})`` into the basis found/chosen for ``H^(2,2)(X, \mathbb{Q})``.
 
 Note that it can be computationally very demanding to check if a toric variety
-$X$ is complete (and simplicial). The optional argument `check` can be set
+``X`` is complete (and simplicial). The optional argument `check` can be set
 to `false` to skip these tests.
 
 # Examples
@@ -342,23 +342,23 @@ end
     basis_of_h22_ambient_indices(m::AbstractFTheoryModel; check::Bool = true)
 
 By virtue of Theorem 12.4.1 in [CLS11](@cite), one can compute a monomial
-basis of $H^4(X, \mathbb{Q})$ for a simplicial, complete toric variety $X$
-by truncating its cohomology ring to degree $2$. Inspired by this, this
-method identifies a basis of $H^{(2,2)}(X, \mathbb{Q})$ by multiplying
+basis of ``H^4(X, \mathbb{Q})`` for a simplicial, complete toric variety ``X``
+by truncating its cohomology ring to degree ``2``. Inspired by this, this
+method identifies a basis of ``H^{(2,2)}(X, \mathbb{Q})`` by multiplying
 pairs of cohomology classes associated with toric coordinates.
 
-By definition, $H^{(2,2)}(X, \mathbb{Q})$ is a subset of $H^{4}(X, \mathbb{Q})$.
+By definition, ``H^{(2,2)}(X, \mathbb{Q})`` is a subset of ``H^{4}(X, \mathbb{Q})``.
 However, by Theorem 9.3.2 in [CLS11](@cite), for complete and simplicial
-toric varieties and $p \neq q$ it holds $H^{(p,q)}(X, \mathbb{Q}) = 0$. It follows
-that for such varieties $H^{(2,2)}(X, \mathbb{Q}) = H^4(X, \mathbb{Q})$ and the
-vector space dimension of those spaces agrees with the Betti number $b_4(X)$.
+toric varieties and ``p \neq q`` it holds ``H^{(p,q)}(X, \mathbb{Q}) = 0``. It follows
+that for such varieties ``H^{(2,2)}(X, \mathbb{Q}) = H^4(X, \mathbb{Q})`` and the
+vector space dimension of those spaces agrees with the Betti number ``b_4(X)``.
 
-This method computes a vector of tuples of two integers. The tuple $(a,b)$ states
+This method computes a vector of tuples of two integers. The tuple ``(a,b)`` states
 that the product of the a-th and b-th variables in the Cox ring is an element of
-the basis of $H^(2,2)(X, \mathbb{Q})$, that we have chosen.
+the basis of ``H^(2,2)(X, \mathbb{Q})``, that we have chosen.
 
 Note that it can be computationally very demanding to check if a toric variety
-$X$ is complete (and simplicial). The optional argument `check` can be set
+``X`` is complete (and simplicial). The optional argument `check` can be set
 to `false` to skip these tests.
 
 # Examples
@@ -382,22 +382,22 @@ end
     basis_of_h22_ambient(m::AbstractFTheoryModel; check::Bool = true)
 
 By virtue of Theorem 12.4.1 in [CLS11](@cite), one can compute a monomial
-basis of $H^4(X, \mathbb{Q})$ for a simplicial, complete toric variety $X$
-by truncating its cohomology ring to degree $2$. Inspired by this, this
-method identifies a basis of $H^{(2,2)}(X, \mathbb{Q})$ by multiplying
+basis of ``H^4(X, \mathbb{Q})`` for a simplicial, complete toric variety ``X``
+by truncating its cohomology ring to degree ``2``. Inspired by this, this
+method identifies a basis of ``H^{(2,2)}(X, \mathbb{Q})`` by multiplying
 pairs of cohomology classes associated with toric coordinates.
 
-By definition, $H^{(2,2)}(X, \mathbb{Q})$ is a subset of $H^{4}(X, \mathbb{Q})$.
+By definition, ``H^{(2,2)}(X, \mathbb{Q})`` is a subset of ``H^{4}(X, \mathbb{Q})``.
 However, by Theorem 9.3.2 in [CLS11](@cite), for complete and simplicial
-toric varieties and $p \neq q$ it holds $H^{(p,q)}(X, \mathbb{Q}) = 0$. It follows
-that for such varieties $H^{(2,2)}(X, \mathbb{Q}) = H^4(X, \mathbb{Q})$ and the
-vector space dimension of those spaces agrees with the Betti number $b_4(X)$.
+toric varieties and ``p \neq q`` it holds ``H^{(p,q)}(X, \mathbb{Q}) = 0``. It follows
+that for such varieties ``H^{(2,2)}(X, \mathbb{Q}) = H^4(X, \mathbb{Q})`` and the
+vector space dimension of those spaces agrees with the Betti number ``b_4(X)``.
 
-This method computes a basis of $H^{(2,2)}(X, \mathbb{Q})$ as vector of cohomology
+This method computes a basis of ``H^{(2,2)}(X, \mathbb{Q})`` as vector of cohomology
 classes.
 
 Note that it can be computationally very demanding to check if a toric variety
-$X$ is complete (and simplicial). The optional argument `check` can be set
+``X`` is complete (and simplicial). The optional argument `check` can be set
 to `false` to skip these tests.
 
 # Examples
@@ -428,27 +428,27 @@ end
     basis_of_h22_hypersurface_indices(m::AbstractFTheoryModel; check::Bool = true)
 
 By virtue of Theorem 12.4.1 in [CLS11](@cite), one can compute a monomial
-basis of $H^4(X, \mathbb{Q})$ for a simplicial, complete toric variety $X$
-by truncating its cohomology ring to degree $2$. Inspired by this, this
-method identifies a basis of $H^{(2,2)}(X, \mathbb{Q})$ by multiplying
+basis of ``H^4(X, \mathbb{Q})`` for a simplicial, complete toric variety ``X``
+by truncating its cohomology ring to degree ``2``. Inspired by this, this
+method identifies a basis of ``H^{(2,2)}(X, \mathbb{Q})`` by multiplying
 pairs of cohomology classes associated with toric coordinates.
 
-By definition, $H^{(2,2)}(X, \mathbb{Q})$ is a subset of $H^{4}(X, \mathbb{Q})$.
+By definition, ``H^{(2,2)}(X, \mathbb{Q})`` is a subset of ``H^{4}(X, \mathbb{Q})``.
 However, by Theorem 9.3.2 in [CLS11](@cite), for complete and simplicial
-toric varieties and $p \neq q$ it holds $H^{(p,q)}(X, \mathbb{Q}) = 0$. It follows
-that for such varieties $H^{(2,2)}(X, \mathbb{Q}) = H^4(X, \mathbb{Q})$ and the
-vector space dimension of those spaces agrees with the Betti number $b_4(X)$.
+toric varieties and ``p \neq q`` it holds ``H^{(p,q)}(X, \mathbb{Q}) = 0``. It follows
+that for such varieties ``H^{(2,2)}(X, \mathbb{Q}) = H^4(X, \mathbb{Q})`` and the
+vector space dimension of those spaces agrees with the Betti number ``b_4(X)``.
 
 Once restricted to the hypersurface of the model, these elements are generators of
-a subset $S \subseteq H^(2,2)(Y, \mathbb{Q})$, where $Y$ is the hypersurface of
-interest in $X$. This method computes a vector of tuples, each tuple encodes on
-generator of $S \subseteq H^(2,2)(Y, \mathbb{Q})$. Specifically, the tuple $(a,b)$
-indicates that the product of the $a$-th and the $b$-th variable in the Cox ring
-encodes an element of the cohomology ring of $X$, whose restriction to $Y$ is one
+a subset ``S \subseteq H^(2,2)(Y, \mathbb{Q})``, where ``Y`` is the hypersurface of
+interest in ``X``. This method computes a vector of tuples, each tuple encodes on
+generator of ``S \subseteq H^(2,2)(Y, \mathbb{Q})``. Specifically, the tuple ``(a,b)``
+indicates that the product of the ``a``-th and the ``b``-th variable in the Cox ring
+encodes an element of the cohomology ring of ``X``, whose restriction to ``Y`` is one
 of our generators.
 
 Note that it can be computationally very demanding to check if a toric variety
-$X$ is complete (and simplicial). The optional argument `check` can be set
+``X`` is complete (and simplicial). The optional argument `check` can be set
 to `false` to skip these tests.
 
 # Examples
@@ -512,24 +512,24 @@ end
     basis_of_h22_hypersurface(m::AbstractFTheoryModel; check::Bool = true)
 
 By virtue of Theorem 12.4.1 in [CLS11](@cite), one can compute a monomial
-basis of $H^4(X, \mathbb{Q})$ for a simplicial, complete toric variety $X$
-by truncating its cohomology ring to degree $2$. Inspired by this, this
-method identifies a basis of $H^{(2,2)}(X, \mathbb{Q})$ by multiplying
+basis of ``H^4(X, \mathbb{Q})`` for a simplicial, complete toric variety ``X``
+by truncating its cohomology ring to degree ``2``. Inspired by this, this
+method identifies a basis of ``H^{(2,2)}(X, \mathbb{Q})`` by multiplying
 pairs of cohomology classes associated with toric coordinates.
 
-By definition, $H^{(2,2)}(X, \mathbb{Q})$ is a subset of $H^{4}(X, \mathbb{Q})$.
+By definition, ``H^{(2,2)}(X, \mathbb{Q})`` is a subset of ``H^{4}(X, \mathbb{Q})``.
 However, by Theorem 9.3.2 in [CLS11](@cite), for complete and simplicial
-toric varieties and $p \neq q$ it holds $H^{(p,q)}(X, \mathbb{Q}) = 0$. It follows
-that for such varieties $H^{(2,2)}(X, \mathbb{Q}) = H^4(X, \mathbb{Q})$ and the
-vector space dimension of those spaces agrees with the Betti number $b_4(X)$.
+toric varieties and ``p \neq q`` it holds ``H^{(p,q)}(X, \mathbb{Q}) = 0``. It follows
+that for such varieties ``H^{(2,2)}(X, \mathbb{Q}) = H^4(X, \mathbb{Q})`` and the
+vector space dimension of those spaces agrees with the Betti number ``b_4(X)``.
 
 Once restricted to the hypersurface of the model, these elements are generators of
-a subset $S \subseteq H^(2,2)(Y, \mathbb{Q})$, where $Y$ is the hypersurface of
-interest in $X$. This method computes this generating set in terms of ambient
+a subset ``S \subseteq H^(2,2)(Y, \mathbb{Q})``, where ``Y`` is the hypersurface of
+interest in ``X``. This method computes this generating set in terms of ambient
 space cohomology classes.
 
 Note that it can be computationally very demanding to check if a toric variety
-$X$ is complete (and simplicial). The optional argument `check` can be set
+``X`` is complete (and simplicial). The optional argument `check` can be set
 to `false` to skip these tests.
 
 # Examples
@@ -554,24 +554,24 @@ end
     converter_dict_h22_hypersurface(m::AbstractFTheoryModel; check::Bool = true)
 
 By virtue of Theorem 12.4.1 in [CLS11](@cite), one can compute a monomial
-basis of $H^4(X, \mathbb{Q})$ for a simplicial, complete toric variety $X$
-by truncating its cohomology ring to degree $2$. Inspired by this, this
-method identifies a basis of $H^{(2,2)}(X, \mathbb{Q})$ by multiplying
+basis of ``H^4(X, \mathbb{Q})`` for a simplicial, complete toric variety ``X``
+by truncating its cohomology ring to degree ``2``. Inspired by this, this
+method identifies a basis of ``H^{(2,2)}(X, \mathbb{Q})`` by multiplying
 pairs of cohomology classes associated with toric coordinates.
 
-By definition, $H^{(2,2)}(X, \mathbb{Q})$ is a subset of $H^{4}(X, \mathbb{Q})$.
+By definition, ``H^{(2,2)}(X, \mathbb{Q})`` is a subset of ``H^{4}(X, \mathbb{Q})``.
 However, by Theorem 9.3.2 in [CLS11](@cite), for complete and simplicial
-toric varieties and $p \neq q$ it holds $H^{(p,q)}(X, \mathbb{Q}) = 0$. It follows
-that for such varieties $H^{(2,2)}(X, \mathbb{Q}) = H^4(X, \mathbb{Q})$ and the
-vector space dimension of those spaces agrees with the Betti number $b_4(X)$. Once
-restricted to the hypersurface $Y$ in question, we obtain a generating set of a subset
-$S \subseteq H^{(2,2)}(Y, \mathbb{Q})$.
+toric varieties and ``p \neq q`` it holds ``H^{(p,q)}(X, \mathbb{Q}) = 0``. It follows
+that for such varieties ``H^{(2,2)}(X, \mathbb{Q}) = H^4(X, \mathbb{Q})`` and the
+vector space dimension of those spaces agrees with the Betti number ``b_4(X)``. Once
+restricted to the hypersurface ``Y`` in question, we obtain a generating set of a subset
+``S \subseteq H^{(2,2)}(Y, \mathbb{Q})``.
 
-This method computes a dictionary which allows to map any element of $H^(2,2)(X, \mathbb{Q})$
-into our chosen generating set of $S \subseteq H^{(2,2)}(Y, \mathbb{Q})$.
+This method computes a dictionary which allows to map any element of ``H^(2,2)(X, \mathbb{Q})``
+into our chosen generating set of ``S \subseteq H^{(2,2)}(Y, \mathbb{Q})``.
 
 Note that it can be computationally very demanding to check if a toric variety
-$X$ is complete (and simplicial). The optional argument `check` can be set
+``X`` is complete (and simplicial). The optional argument `check` can be set
 to `false` to skip these tests.
 
 # Examples
@@ -610,12 +610,12 @@ end
     chosen_g4_flux_basis(m::AbstractFTheoryModel; check::Bool = true)::Vector{CohomologyClass}
 
 Given an F-theory model `m` defined as a hypersurface in a simplicial and
-complete toric base, this method computes a basis of $H^{2,2}(X, \mathbb{Q})$
+complete toric base, this method computes a basis of ``H^{2,2}(X, \mathbb{Q})``
 (using the method `basis_of_h22`) and then filters out certain basis elements 
 whose restriction to the hypersurface in question is trivial. The criteria for 
 "certain" elements are explained in the documentation above this method.
 
-Note: Checking whether a toric variety $X$ is complete and simplicial can be
+Note: Checking whether a toric variety ``X`` is complete and simplicial can be
 computationally expensive. The optional argument `check` can be set to `false`
 to skip these tests.
 

--- a/experimental/FTheoryTools/src/G4Fluxes/auxiliary.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/auxiliary.jl
@@ -607,7 +607,7 @@ end
 
 
 @doc raw"""
-    chosen_g4_flux_basis(m::AbstractFTheoryModel; check::Bool = true)::Vector{CohomologyClass}
+    chosen_g4_flux_gens(m::AbstractFTheoryModel; check::Bool = true)::Vector{CohomologyClass}
 
 Given an F-theory model `m` defined as a hypersurface in a simplicial and
 complete toric base, this method computes a basis of ``H^{2,2}(X, \mathbb{Q})``
@@ -632,7 +632,7 @@ Construction over concrete base may lead to singularity enhancement. Consider co
 
 Global Tate model over a concrete base -- SU(5)xU(1) restricted Tate model based on arXiv paper 1109.3454 Eq. (3.1)
 
-julia> g4_basis = chosen_g4_flux_basis(t);
+julia> g4_basis = chosen_g4_flux_gens(t);
 
 julia> length(g4_basis)
 2
@@ -653,7 +653,7 @@ Cohomology class on a normal toric variety given by z^2
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 8))
 Hypersurface model over a concrete base
 
-julia> g4_basis = chosen_g4_flux_basis(qsm_model, check = false);
+julia> g4_basis = chosen_g4_flux_gens(qsm_model, check = false);
 
 julia> cohomology_class(g4_basis[1])
 Cohomology class on a normal toric variety given by x15*e2
@@ -662,7 +662,7 @@ julia> length(g4_basis) == 172
 true
 ```
 """
-chosen_g4_flux_basis(m::AbstractFTheoryModel; check::Bool = true) = [G4Flux(m, c) for c in basis_of_h22_hypersurface(m, check = check)]
+chosen_g4_flux_gens(m::AbstractFTheoryModel; check::Bool = true) = [G4Flux(m, c) for c in basis_of_h22_hypersurface(m, check = check)]
 
 
 

--- a/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
@@ -3,46 +3,17 @@
 ################
 
 @doc raw"""
-    g4_flux(model::AbstractFTheoryModel, class::CohomologyClass; convert::Bool = false)
+    g4_flux(model::AbstractFTheoryModel, class::CohomologyClass; check::Bool = true, convert::Bool = false)
 
-Construct a G4-flux candidate on an F-theory model. This functionality is
-currently limited to
-- Weierstrass models,
-- global Tate models,
-- hypersurface models.
-Furthermore, our functionality requires a concrete geometry. That is,
-the base space as well as the ambient space must be toric varieties.
-In the toric ambient space ``X_\Sigma``, the elliptically fibered space ``Y``
-that defines the F-theory model, is given by a hypersurface (cut out by
-the Weierstrass, Tate or hypersurface polynomial, respectively).
+Construct a candidate ``G_4``-flux for a resolved F-theory model from a given cohomology class on the toric ambient space.
 
-In this setting, we assume that a ``G_4``-flux candidate is represented by a
-cohomology class ``h`` in ``H^{(2,2)} (X_\Sigma)``. The actual ``G_4``-flux candidate
-is then obtained by restricting ``h`` to ``Y``.
+### Requirements
+- The model must be defined via a Weierstrass, global Tate, or hypersurface construction.
+- The ambient space must a smooth and complete toric variety.
 
-It is worth recalling that the ``G_4``-flux candidate is subject to the quantization
-condition ``G_4 + \frac{1}{2} c_2(Y) \in H^{/2,2)}( Y_, \mathbb{Z})`` (see [Wit97](@cite)).
-This condition is very hard to verify. However, it is relatively easy to gather
-evidence for this condition to be satisfied/show that it is violated. To this end, let
-``D_1``, ``D_2`` be two toric divisors in ``X_\Sigma``, then the topological intersection number
-``\left[ h|_Y \right] \cdot \left[ P \right] \cdot \left[ D_1 \right] \cdot \left[ D_2 \right]``
-must be an integer. Even this rather elementary check can be computationally expensive.
-Users can therefore decide to skip this check upon construction by setting the parameter
-`check` to the value `false`.
-
-Another bottleneck can be the computation of the cohomology ring, which is necessary to
-work with cohomology classes on the toric ambient space, which in turn define the G4-flux,
-as explained above. The reason for this is, that by employing the theory explained in
-[CLS11](@cite), we can only work out the cohomology ring of simpicial and complete (i.e. compact)
-toric varieties. However, checking if a toric variety is complete (i.e. compact) can take
-a long time. If the geometry in question is involved and you already know that the variety
-is simplicial and complete, then we recommend to trigger the computation of the cohomology
-ring with `check = false`. This will avoid this time consuming test.
-
-Let us mention that you can also supply the option `convert = true`. This will turn the
-provided cohomology class into the basis chosen internally.
-
-An example is in order.
+### Parameters
+- `check` (default: `true`): Perform basic consistency and necessary quantization checks.
+- `convert` (default: `false`): Express the ``G_4``-flux with the generating set used by `FTheoryTools`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -130,10 +101,13 @@ function g4_flux(m::AbstractFTheoryModel, g4_class::CohomologyClass; check::Bool
 end
 
 
+
 @doc raw"""
     qsm_flux(qsm_model::AbstractFTheoryModel)
 
-For an F-theory QSM [CHLLT19](@cite), this method creates the particularly chosen G4-flux in these models.
+Return the ``G_4``-flux associated with one of the Quadrillion F-theory Standard models, as described in [CHLLT19](@cite CHLLT19).
+
+This flux has been pre-validated to pass essential consistency checks.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))

--- a/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
@@ -12,20 +12,20 @@ currently limited to
 - hypersurface models.
 Furthermore, our functionality requires a concrete geometry. That is,
 the base space as well as the ambient space must be toric varieties.
-In the toric ambient space $X_\Sigma$, the elliptically fibered space $Y$
+In the toric ambient space ``X_\Sigma``, the elliptically fibered space ``Y``
 that defines the F-theory model, is given by a hypersurface (cut out by
 the Weierstrass, Tate or hypersurface polynomial, respectively).
 
-In this setting, we assume that a $G_4$-flux candidate is represented by a
-cohomology class $h$ in $H^{(2,2)} (X_\Sigma)$. The actual $G_4$-flux candidate
-is then obtained by restricting $h$ to $Y$.
+In this setting, we assume that a ``G_4``-flux candidate is represented by a
+cohomology class ``h`` in ``H^{(2,2)} (X_\Sigma)``. The actual ``G_4``-flux candidate
+is then obtained by restricting ``h`` to ``Y``.
 
-It is worth recalling that the $G_4$-flux candidate is subject to the quantization
-condition $G_4 + \frac{1}{2} c_2(Y) \in H^{/2,2)}( Y_, \mathbb{Z})$ (see [Wit97](@cite)).
+It is worth recalling that the ``G_4``-flux candidate is subject to the quantization
+condition ``G_4 + \frac{1}{2} c_2(Y) \in H^{/2,2)}( Y_, \mathbb{Z})`` (see [Wit97](@cite)).
 This condition is very hard to verify. However, it is relatively easy to gather
 evidence for this condition to be satisfied/show that it is violated. To this end, let
-$D_1$, $D_2$ be two toric divisors in $X_\Sigma$, then the topological intersection number
-$\left[ h|_Y \right] \cdot \left[ P \right] \cdot \left[ D_1 \right] \cdot \left[ D_2 \right]$
+``D_1``, ``D_2`` be two toric divisors in ``X_\Sigma``, then the topological intersection number
+``\left[ h|_Y \right] \cdot \left[ P \right] \cdot \left[ D_1 \right] \cdot \left[ D_2 \right]``
 must be an integer. Even this rather elementary check can be computationally expensive.
 Users can therefore decide to skip this check upon construction by setting the parameter
 `check` to the value `false`.

--- a/experimental/FTheoryTools/src/G4Fluxes/properties.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/properties.jl
@@ -6,16 +6,16 @@
     is_well_quantized(gf::G4Flux)
 
 G4-fluxes are subject to the quantization condition
-[Wit97](@cite) $G_4 + \frac{1}{2} c_2(Y) \in H^{(2,2)}(Y, \mathbb{Z})$.
+[Wit97](@cite) ``G_4 + \frac{1}{2} c_2(Y) \in H^{(2,2)}(Y, \mathbb{Z})``.
 It is hard to verify that this condition is met. However,
 we can execute a number of simple consistency checks, by
-verifying that $\int_{Y}{G_4 \wedge [D_1] \wedge [D_2]} \in \mathbb{Z}$
-for any two toric divisors $D_1$, $D_2$. If all of these
+verifying that ``\int_{Y}{G_4 \wedge [D_1] \wedge [D_2]} \in \mathbb{Z}``
+for any two toric divisors ``D_1``, ``D_2``. If all of these
 simple consistency checks are met, this method will return
 `true` and otherwise `false`.
 
 It is worth mentioning that currently (August 2024), we only
-support this check for $G_4$-fluxes defined on Weierstrass,
+support this check for ``G_4``-fluxes defined on Weierstrass,
 global Tate and hypersurface models. If this condition is not
 met, this method will return an error.
 
@@ -140,7 +140,7 @@ end
     passes_tadpole_cancellation_check(gf::G4Flux)
 
 G4-fluxes are subject to the D3-tadpole cancellation condition described in [Wei18](@cite).
-This check verifies that $euler_characteristic(Y)/24 - 1/2 * \int_{Y}{G_4 \wedge G_4}$ is a non-negative integer.
+This check verifies that ``euler_characteristic(Y)/24 - 1/2 * \int_{Y}{G_4 \wedge G_4}`` is a non-negative integer.
 
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -191,7 +191,7 @@ Thereby, you can create this F-theory model including a lot of advanced informat
 (e.g. more than 10.000.000 intersection numbers and explicit descriptions for the
 G4-fluxes on this space) within just a couple of minutes. For comparison, one a
 personal computer we expect that the computation of one resolution of this model
-takes about three to four hours. Identifying also all $G_4$-fluxes (vertical,
+takes about three to four hours. Identifying also all ``G_4``-fluxes (vertical,
 well-quantized and modelled by pullbacks from the toric ambient space) will likely
 take a few hours more. So, this infrastructure provides a very stark performence
 improvement.

--- a/experimental/FTheoryTools/src/exports.jl
+++ b/experimental/FTheoryTools/src/exports.jl
@@ -44,6 +44,7 @@ export calabi_yau_hypersurface
 export chern_class
 export chern_classes
 export chosen_g4_flux_basis
+export chosen_g4_flux_gens
 export classes_of_model_sections
 export classes_of_tunable_sections_in_basis_of_Kbar_and_defining_classes
 export components_of_dual_graph
@@ -251,3 +252,5 @@ export weights
 export zero_section
 export zero_section_class
 export zero_section_index
+
+@deprecate chosen_g4_flux_basis(m::AbstractFTheoryModel; check::Bool = true) chosen_g4_flux_gens(m, check = check)

--- a/experimental/FTheoryTools/test/FTM-1511-03209.jl
+++ b/experimental/FTheoryTools/test/FTM-1511-03209.jl
@@ -8,7 +8,7 @@
   @test n_rays(ambient_space(t)) == 104
   @test n_rays(ambient_space(fully_resolved_big_model)) == 313
   @test typeof(get_attribute(fully_resolved_big_model, :inter_dict)) == Dict{NTuple{4, Int64}, ZZRingElem}
-  @test length(chosen_g4_flux_basis(fully_resolved_big_model)) == 629
+  @test length(chosen_g4_flux_gens(fully_resolved_big_model)) == 629
   @test is_well_quantized(g1) == true
   @test breaks_non_abelian_gauge_group(g2) == false
   @test size(matrix_integral(f1)) == (629, 224)


### PR DESCRIPTION
* Overhaul the wording of the introduction page a lot.
* Overhaul the wording and structure of the G4-flux page a lot. In particular, I added a coherent discussion of what G4-fluxes are and how we model them in FTheoryTools.
* I am convinced that there are still doc strings of specific methods, which explain the story of how we model G4-fluxes in F-theory tools once or twice or even trice more, but did not yet have the time to search for these instances. You can beat me to it, unless you are of the opinion that we should tell this story multiple times.
* I added doc strings for the offset of G4-fluxes and G4-flux families to the documentation. For G4-fluxes, the corresponding method was even missing.
* I found the method `chosen_g4_flux_basis` which is wrong, it must be `chosen_g4_flux_gens` since we compute a generating set and not a basis. However, I believe (please correct me), that we used the function `chosen_g4_flux_basis` in our preprint. As such, I have for now addressed this point with a deprecation. (If we decide to replace the preprint and adjust the name, then we could consider renaming th function. As per usual, this fix becomes active only with the next release tough...)

Please take a look at the preview, so you can get an impression of how the documentation would look after these changes: https://docs.oscar-system.org/previews/PR5009/Experimental/FTheoryTools/

cc @apturner @emikelsons 