### PR TITLE
singular_assure: if I.isGB is set then I.ord must also be set

### DIFF
--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -623,7 +623,7 @@ function singular_assure(I::IdealGens)
     I.gens.f = g
     I.gens.S = Singular.Ideal(I.gens.Sx, elem_type(I.gens.Sx)[g(x) for x in oscar_generators(I)])
   end
-  if I.isGB && (!isdefined(I, :ord) || I.ord == monomial_ordering(base_ring(I), internal_ordering(I.gens.Sx)))
+  if I.isGB && (I.ord == monomial_ordering(base_ring(I), internal_ordering(I.gens.Sx)))
     I.gens.S.isGB = true
   end
 end


### PR DESCRIPTION
... as discussed during triage. This my require at least PR #5006 to pass, and possibly further changes, in case anything violates the new requirement.