### PR TITLE
Add `natural_gset` to group action documentation

### DIFF
--- a/docs/src/Groups/action.md
+++ b/docs/src/Groups/action.md
@@ -60,6 +60,7 @@ Note that the explicit elements of a G-set `Omega` can be obtained using
 
 ```@docs
 gset(G::Union{GAPGroup, FinGenAbGroup}, fun::Function, Omega)
+natural_gset
 permutation
 acting_group(Omega::GSetByElements)
 action_function(Omega::GSetByElements)


### PR DESCRIPTION
This was missing from #4987. Once this PR is merged, this closes #4938.