### PR TITLE
Remove `singular_assure`

### DIFF
--- a/experimental/ModStd/src/ModStdQ.jl
+++ b/experimental/ModStd/src/ModStdQ.jl
@@ -207,7 +207,6 @@ function groebner_basis_with_transform_inner(I::MPolyIdeal{QQMPolyRingElem}, ord
             end
             if ord == I.gens.ord && !isdefined(I, :gb)
               I.gb[ord] = IdealGens(gd[1:length_gc], keep_ordering = false, isGB = true)
-              Oscar.singular_assure(I.gb[ord])
             end
             return G, T
           else

--- a/src/Modules/mpolyquo.jl
+++ b/src/Modules/mpolyquo.jl
@@ -119,9 +119,8 @@ end
   gb = G.quo.gens
   ord = default_ordering(M.quo)
   gb.ordering = ord
-  singular_assure(gb)
   gb.isGB = true
-  gb.S.isGB = true
+  singular_generators(gb).isGB = true
   M.quo.groebner_basis[ord] = gb
   return M
 end

--- a/src/Rings/groebner/general.jl
+++ b/src/Rings/groebner/general.jl
@@ -8,7 +8,7 @@
 Given an `IdealGens` `B` and optional parameters `ordering` for a monomial ordering and `complete_reduction`
 this function computes a Gröbner basis (if `complete_reduction = true` the reduced Gröbner basis) of the
 ideal spanned by the elements in `B` w.r.t. the given monomial ordering `ordering`. The Gröbner basis is then
-returned in `B.S`.
+returned as a new `IdealGens`.
 
 # Examples
 ```jldoctest

--- a/src/Rings/groebner/generators.jl
+++ b/src/Rings/groebner/generators.jl
@@ -7,8 +7,8 @@
 Given an ideal `I` in a multivariate polynomial ring this function assures that a
 Gröbner basis w.r.t. the given monomial ordering is attached to `I` in `I.gb`.
 It *currently* also ensures that the basis is defined on the Singular side in
-`I.gb.S`, but this should not be relied upon: use `singular_assure(I.gb)` before
-accessing `I.gb.S`.
+`I.gb.S`, but this should not be relied upon: use `singular_generators(I.gb)`
+instead of accessing `I.gb.S` directly.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
This almost takes care of #1920 -- now only `groebner_assure` is left (well and a function `exp_groebner_assure`)