### PR TITLE
Replace some uses of '@attr Any'

### DIFF
--- a/src/AlgebraicGeometry/Schemes/PrincipalOpenSubset/Objects/Properties.jl
+++ b/src/AlgebraicGeometry/Schemes/PrincipalOpenSubset/Objects/Properties.jl
@@ -1,7 +1,7 @@
 ########################################################################
 # Properties of PrincipalOpenSubsets                                   #
 ########################################################################
-@attr Any function is_dense(U::PrincipalOpenSubset)
+@attr Bool function is_dense(U::PrincipalOpenSubset)
   return !is_zero_divisor(complement_equation(U))
 end
 

--- a/src/AlgebraicGeometry/Schemes/Sheaves/IdealSheaves.jl
+++ b/src/AlgebraicGeometry/Schemes/Sheaves/IdealSheaves.jl
@@ -728,7 +728,7 @@ Return whether ``I`` is prime.
 We say that a sheaf of ideals is prime if its support is irreducible and
 ``I`` is locally prime. (Note that the empty set is not irreducible.)
 """
-@attr Any function is_prime(I::AbsIdealSheaf)
+@attr Bool function is_prime(I::AbsIdealSheaf)
   is_locally_prime(I) || return false
   # TODO: this can be made more efficient
   PD = maximal_associated_points(I)

--- a/src/Modules/mpolyquo.jl
+++ b/src/Modules/mpolyquo.jl
@@ -86,7 +86,7 @@ end
 
 ### To a free module over R = P/I, return the free module over R 
 # in the same number of generators
-@attr Any function _poly_module(F::FreeMod{T}) where {T<:MPolyQuoRingElem}
+@attr FreeMod{T} function _poly_module(F::FreeMod{MPolyQuoRingElem{T}}) where {T}
   R = base_ring(F)
   P = base_ring(R) # the polynomial ring
   r = rank(F)
@@ -96,7 +96,7 @@ end
 
 ### Return the canonical projection FP -> F from the P-module FP to the 
 # R-module F.
-@attr Any function _poly_module_restriction(F::FreeMod{T}) where {T<:MPolyQuoRingElem}
+@attr FreeModuleHom{FreeMod{T}, FreeMod{MPolyQuoRingElem{T}}, MPolyQuoRing{T}} function _poly_module_restriction(F::FreeMod{MPolyQuoRingElem{T}}) where {T}
   R = base_ring(F)
   P = base_ring(R)
   FP = _poly_module(F)
@@ -104,7 +104,7 @@ end
 end
 
 ### Return the same module, but as a SubquoModule over the polynomial ring
-@attr Any function _as_poly_module(F::FreeMod{T}) where {T<:MPolyQuoRingElem}
+@attr SubquoModule{T} function _as_poly_module(F::FreeMod{MPolyQuoRingElem{T}}) where {T}
   R = base_ring(F)
   P = base_ring(R)
   I = modulus(R)
@@ -143,7 +143,7 @@ end
   return MP
 end
 
-@attr Any function _as_poly_module(M::SubquoModule{T}) where {T<:MPolyQuoRingElem}
+@attr SubquoModule{T} function _as_poly_module(M::SubquoModule{MPolyQuoRingElem{T}}) where {T}
   F = ambient_free_module(M) 
   FP = _poly_module(F)
   v = [_lifting_map(F)(g) for g in ambient_representatives_generators(M)] 
@@ -153,7 +153,7 @@ end
   return MP
 end
 
-@attr Any function _iso_with_poly_module(F::SubquoModule{T}) where {T<:MPolyQuoRingElem}
+@attr SubQuoHom{SubquoModule{T}, SubquoModule{MPolyQuoRingElem{T}}, MPolyQuoRing{T}} function _iso_with_poly_module(F::SubquoModule{MPolyQuoRingElem{T}}) where {T}
   M = _as_poly_module(F)
   return hom(M, F, gens(F), base_ring(F))
 end


### PR DESCRIPTION
These always lead to type unstable code in anything calling them.

We still have 65 of these left in our code base. In some cases getting rid of this in a sensible way (i.e. by inserting a *concrete* type) may be difficult because they return functions / closures... We probably should replace those by functor objects anyway. I've meant to do such a conversion for some GAP<->OSCAR conversion ode anyway (though that code does not involve `@attr Any`) which then could perhaps serve as a blueprint for converting other places... We'll see.

```
experimental/GModule/src/GModule.jl:876:@attr Any function _character(C::GModule{<:Any, <:AbstractAlgebra.FPModule{<:AbstractAlgebra.FieldElem}})
experimental/GModule/src/GModule.jl:974:@attr Any function _character_field(C::GModule{<:Any, <:AbstractAlgebra.FPModule{AbsSimpleNumFieldElem}})
experimental/Schemes/src/CoveredScheme.jl:242:@attr Any function standard_covering(X::AbsProjectiveScheme{CRT, <:Union{<:MPolyDecRing, <:MPolyQuoRing}}) where {CRT<:Union{<:MPolyQuoLocRing, <:MPolyLocRing, <:MPolyRing, <:MPolyQuoRing}}
experimental/Schemes/src/Resolution_tools.jl:60:@attr Any function intersection_matrix(phi::Union{BlowUpSequence,MixedBlowUpSequence})
src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl:53:@attr Any function total_ring_of_fractions(X::AbsAffineScheme)
src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl:199:@attr Any function ambient_space(X::AffineScheme{BRT,RT}) where {BRT<:Field, RT <: Union{MPolyQuoRing,MPolyLocRing,MPolyQuoLocRing}}
src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl:203:@attr Any function ambient_space(X::AffineScheme{BRT,RT}) where {BRT, RT <: Union{MPolyQuoRing,MPolyLocRing,MPolyQuoLocRing}}
src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl:207:@attr Any function ambient_space(X::AbsAffineScheme{BRT,RT}) where {BRT, RT <: Union{MPolyQuoRing,MPolyLocRing,MPolyQuoLocRing}}
src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl:536:@attr Any function reduced_scheme(X::AbsAffineScheme{<:Field, <:MPolyQuoLocRing})
src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl:548:@attr Any function reduced_scheme(X::AbsAffineScheme{<:Field, <:MPolyQuoRing})
src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl:560:@attr Any function reduced_scheme(X::AbsAffineScheme{<:Field, <:MPAnyNonQuoRing})
src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl:836:@attr Any defining_ideal(X::AbsAffineScheme{<:Any, <:MPolyRing}) = ideal(OO(X), [zero(OO(X))])
src/AlgebraicGeometry/Schemes/CoveredProjectiveScheme/CoveredProjectiveScheme.jl:755:@attr Any function covered_scheme(P::CoveredProjectiveScheme)
src/AlgebraicGeometry/Schemes/CoveredProjectiveScheme/CoveredProjectiveScheme.jl:829:@attr Any function covered_projection_to_base(P::CoveredProjectiveScheme)
src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Attributes.jl:191:@attr Any function singular_locus_reduced(X::AbsCoveredScheme)
src/AlgebraicGeometry/Schemes/CoveredSchemes/Objects/Attributes.jl:258:@attr Any function singular_locus(
src/AlgebraicGeometry/Schemes/Gluing/Attributes.jl:47:@attr Any function inverse(G::AbsGluing)
src/AlgebraicGeometry/Schemes/Gluing/Attributes.jl:60:@attr Any function inverse(G::Gluing)
src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Methods.jl:18:@attr Any function covered_scheme_morphism(
src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Morphisms/Methods.jl:117:@attr Any function covered_scheme_morphism(
src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl:153:@attr Any function ambient_space(X::AbsProjectiveScheme)
src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl:216:@attr Any function covered_projection_to_base(X::AbsProjectiveScheme{<:Union{<:MPolyQuoLocRing, <:MPolyLocRing, <:MPolyQuoRing, <:MPolyRing}})
src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl:287:@attr Any function affine_cone(
src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl:299:@attr Any function affine_cone(
src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl:313:@attr Any function affine_cone(
src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl:323:@attr Any function affine_cone(
src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl:350:@attr Any function affine_cone(
src/AlgebraicGeometry/Surfaces/EllipticSurface/EllipticSurface.jl:806:@attr Any function algebraic_lattice(X::EllipticSurface)
src/AlgebraicGeometry/Surfaces/EllipticSurface/EllipticSurface.jl:1036:@attr Any function _trivial_lattice(X::EllipticSurface; reducible_singular_fibers_in_PP1=_reducible_fibers_disc(X))
src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/special_attributes.jl:18:@attr Any function cohomology_ring(v::NormalToricVarietyType; check::Bool = true)
src/AlgebraicGeometry/ToricVarieties/CohomologyClasses/special_attributes.jl:57:@attr Any function _intersection_form_via_exponents(v::NormalToricVariety)
src/AlgebraicGeometry/ToricVarieties/ToricSchemes/attributes.jl:224:@attr Any function underlying_scheme(Z::NormalToricVariety)
src/AlgebraicGeometry/ToricVarieties/cohomCalg/special_attributes.jl:59:@attr Any function immaculate_line_bundles(variety::NormalToricVarietyType)
src/Groups/group_characters.jl:243:@attr Any function conjugacy_classes(tbl::GAPGroupCharacterTable)
src/Modules/UngradedModules/FreeModuleHom.jl:473:@attr Any function kernel_ctx(h::FreeModuleHom{<:FreeMod{T}, <:FreeMod{T}, Nothing}) where {T<:Union{ZZRingElem, FieldElem}}
src/Modules/UngradedModules/Presentation.jl:591:@attr Any function presentation_ctx(M::SubquoModule{ZZRingElem})
src/Modules/UngradedModules/Presentation.jl:607:@attr Any function presentation_ctx(M::SubquoModule{T}) where {T<:FieldElem}
src/Modules/UngradedModules/SubModuleOfFreeModule.jl:488:@attr Any function solve_ctx(M::SubModuleOfFreeModule)
src/Modules/mpoly-localizations.jl:126:@attr Any function shifted_module(
src/Modules/mpoly-localizations.jl:135:@attr Any function base_ring_shifts(
src/Modules/mpoly-localizations.jl:159:@attr Any function shifted_module(
src/Modules/mpoly-localizations.jl:190:@attr Any function shifted_module(
src/Modules/mpolyquo.jl:7:@attr Any function kernel(
src/Modules/mpolyquo.jl:63:@attr Any function _lifting_iso(F::FreeMod{T}) where {T<:MPolyQuoRingElem}
src/Modules/mpolyquo.jl:76:@attr Any function _lifting_map(F::FreeMod{T}) where {T<:MPolyQuoRingElem}
src/Modules/mpolyquo.jl:130:@attr Any function _iso_with_poly_module(F::FreeMod{T}) where {T<:MPolyQuoRingElem}
src/Modules/mpolyquo.jl:137:@attr Any function _poly_module(M::SubModuleOfFreeModule{T}) where {T<:MPolyQuoRingElem}
src/Modules/mpolyquo.jl:161:@attr Any function _lifting_iso(F::SubquoModule{T}) where {T<:MPolyQuoRingElem}
src/Rings/MPolyMap/AffineAlgebras.jl:28:@attr Any _singular_ring_domain(f::MPolyAnyMap) = singular_poly_ring(domain(f))
src/Rings/MPolyMap/AffineAlgebras.jl:30:@attr Any _singular_ring_codomain(f::MPolyAnyMap) = singular_poly_ring(codomain(f))
src/Rings/MPolyMap/AffineAlgebras.jl:32:@attr Any function _singular_algebra_morphism(f::MPolyAnyMap{<:MPolyRing, <:Union{MPolyRing, MPolyQuoRing}, Nothing})
src/Rings/MPolyMap/AffineAlgebras.jl:51:@attr Any function kernel(f::AffAlgHom) # TODO: need some ideal_type(domain(f)) here :)
src/Rings/MPolyMap/flattenings.jl:478:@attr Any function flatten(
src/Rings/MPolyMap/flattenings.jl:496:@attr Any function flatten(
src/Rings/MPolyQuo.jl:558:@attr Any function saturated_ideal(I::MPolyQuoIdeal)
src/Rings/mpoly-ideals.jl:1050:@attr Any function absolute_primary_decomposition(
src/Rings/mpoly-ideals.jl:1387:@attr Any function equidimensional_decomposition_radical(I::MPolyIdeal)
src/Rings/mpoly-ideals.jl:1414:@attr Any function equidimensional_decomposition_radical(
src/Rings/mpoly-localizations.jl:1277:@attr Any function base_ring_shifts(L::MPolyLocRing{<:Any, <:Any, <:Any, <:Any, <:MPolyComplementOfKPointIdeal}) 
src/Rings/mpoly-localizations.jl:1961:@attr Any function shifted_ideal(
src/Rings/primary_decomposition_helpers.jl:133:@attr Any function equidimensional_decomposition_weak(I::MPolyQuoIdeal)
src/Rings/primary_decomposition_helpers.jl:142:@attr Any function equidimensional_decomposition_radical(I::MPolyQuoIdeal)
src/Rings/primary_decomposition_helpers.jl:150:@attr Any function equidimensional_hull(I::MPolyQuoIdeal)
src/Rings/primary_decomposition_helpers.jl:158:@attr Any function equidimensional_hull_radical(I::MPolyQuoIdeal)
src/Rings/primary_decomposition_helpers.jl:166:@attr Any function absolute_primary_decomposition(I::MPolyQuoIdeal)
```