### PR TITLE
Add functionality for pc groups and their elements: `hirsch_length`, `depth`, `relative_order`, `exponent_vector`, `leading_exponent`

### DIFF
--- a/docs/src/Groups/pcgroup.md
+++ b/docs/src/Groups/pcgroup.md
@@ -122,6 +122,10 @@ Pc group of order 24
 ```@docs
 letters(g::Union{PcGroupElem, SubPcGroupElem})
 syllables(g::Union{PcGroupElem, SubPcGroupElem})
+depth(g::Union{PcGroupElem,SubPcGroupElem})
+relative_order(g::Union{PcGroupElem,SubPcGroupElem})
+exponent_vector(g::Union{PcGroupElem,SubPcGroupElem})
+leading_exponent(g::Union{PcGroupElem,SubPcGroupElem})
 map_word(g::Union{PcGroupElem, SubPcGroupElem}, genimgs::Vector; genimgs_inv::Vector = Vector(undef, length(genimgs)), init = nothing)
 ```
 
@@ -129,6 +133,7 @@ map_word(g::Union{PcGroupElem, SubPcGroupElem}, genimgs::Vector; genimgs_inv::Ve
 
 ```@docs
 relators(G::PcGroup)
+hirsch_length(G::PcGroup)
 ```
 
 The function

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -351,8 +351,8 @@ GAP.@wrap Random(x::GapObj, y::GapObj)::GAP.Obj
 GAP.@wrap Range(x::GapObj)::GapObj
 GAP.@wrap RecognizeGroup(x::GapObj)::GapObj
 GAP.@wrap ReduceCoeffs(x::GapObj, y::GapObj)
-GAP.@wrap RelativeOrder(x::GapObj)::Int
-GAP.@wrap RelativeOrderOfPcElement(x::GapObj, y::GapObj)::Int
+GAP.@wrap RelativeOrder(x::GapObj)::GapInt
+GAP.@wrap RelativeOrderOfPcElement(x::GapObj, y::GapObj)::GapInt
 GAP.@wrap RelativeOrders(x::GapObj)::GapObj
 GAP.@wrap RelatorsOfFpGroup(x::GapObj)::GapObj
 GAP.@wrap Representative(x::GapObj)::GAP.Obj

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -78,6 +78,8 @@ GAP.@wrap DefiningPolynomial(x::GapObj)::GapObj
 GAP.@wrap DegreeFFE(x::Any)::Int
 GAP.@wrap DegreeOfLaurentPolynomial(x::GapObj)::GapInt
 GAP.@wrap DegreeOverPrimeField(x::GapObj)::Int
+GAP.@wrap Depth(x::GapObj)::Int
+GAP.@wrap DepthOfPcElement(x::GapObj, y::GapObj)::Int
 GAP.@wrap DenominatorCyc(x::Any)::GapInt
 GAP.@wrap DenominatorRat(x::Any)::GapInt
 GAP.@wrap DescriptionOfRootOfUnity(x::Any)::GapObj
@@ -137,6 +139,7 @@ GAP.@wrap HasKernelRecogNode(x::GapObj)::Bool
 GAP.@wrap HasMaxes(x::GapObj)::Bool
 GAP.@wrap HasMaximalAbelianQuotient(x::Any)::Bool
 GAP.@wrap HasSize(x::Any)::Bool
+GAP.@wrap HirschLength(x::GapObj)::Int
 GAP.@wrap Identifier(x::GapObj)::GapObj
 GAP.@wrap Identity(x::GapObj)::GapObj
 GAP.@wrap Image(x::Any)::GapObj
@@ -283,6 +286,8 @@ GAP.@wrap Iterator(x::Any)::GapObj
 GAP.@wrap KernelOfCharacter(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap KernelRecogNode(x::GapObj)::GapObj
 GAP.@wrap LargestMovedPoint(x::Any)::Int
+GAP.@wrap LeadingExponent(x::GapObj)::GapInt
+GAP.@wrap LeadingExponentOfPcElement(x::GapObj, y::GapObj)::GapInt
 GAP.@wrap LeftActingDomain(x::GapObj)::GapObj
 GAP.@wrap LetterRepAssocWord(x::GapObj)::GapObj
 GAP.@wrap LibInfoCharacterTable(x::GapObj)::GapObj
@@ -346,6 +351,8 @@ GAP.@wrap Random(x::GapObj, y::GapObj)::GAP.Obj
 GAP.@wrap Range(x::GapObj)::GapObj
 GAP.@wrap RecognizeGroup(x::GapObj)::GapObj
 GAP.@wrap ReduceCoeffs(x::GapObj, y::GapObj)
+GAP.@wrap RelativeOrder(x::GapObj)::Int
+GAP.@wrap RelativeOrderOfPcElement(x::GapObj, y::GapObj)::Int
 GAP.@wrap RelativeOrders(x::GapObj)::GapObj
 GAP.@wrap RelatorsOfFpGroup(x::GapObj)::GapObj
 GAP.@wrap Representative(x::GapObj)::GAP.Obj

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -2173,7 +2173,7 @@ function map_word(g::Union{PcGroupElem, SubPcGroupElem}, genimgs::Vector; genimg
     @req init !== nothing "use '; init =...' if there are no generators"
     return init
   end
-  l = _exponent_vector(g)
+  l = exponent_vector(g)
   @assert length(l) == length(genimgs)
   ll = Pair{Int, Int}[i => l[i] for i in 1:length(l)]
   return map_word(ll, genimgs, genimgs_inv = genimgs_inv, init = init)
@@ -2291,17 +2291,6 @@ julia> syllables(epi(F1^5*F2^-3))
 function syllables(g::Union{FPGroupElem, SubFPGroupElem})
   l = GAPWrap.ExtRepOfObj(GapObj(g))
   return Pair{Int, ZZRingElem}[l[i] => l[i+1] for i in 1:2:length(l)]
-end
-
-function _exponent_vector(g::Union{PcGroupElem, SubPcGroupElem})
-  gX = GapObj(g)
-  G = parent(g)
-  GX = GapObj(G)
-  if GAPWrap.IsPcGroup(GX)
-    return Vector{ZZRingElem}(GAPWrap.ExponentsOfPcElement(GAPWrap.FamilyPcgs(GX), gX))
-  else  # GAP.Globals.IsPcpGroup(GapObj(G))
-    return Vector{ZZRingElem}(GAP.Globals.Exponents(gX)::GapObj)
-  end
 end
 
 function exponents_of_abelianization(g::Union{FPGroupElem, SubFPGroupElem})

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -907,7 +907,7 @@ function isomorphism(::Type{PcGroup}, A::FinGenAbGroup; on_gens::Bool=false)
          return group_element(G, GAPWrap.PcpElementByExponentsNC(C, exps))
        end
 
-       finv = g -> A2_to_A(A2(_exponent_vector(g)))
+       finv = g -> A2_to_A(A2(exponent_vector(g)))
      else
 #TODO: As soon as https://github.com/gap-packages/polycyclic/issues/88 is fixed,
 #      we can change the code to create a `PcpGroup` in GAP also if the group
@@ -946,7 +946,7 @@ function isomorphism(::Type{PcGroup}, A::FinGenAbGroup; on_gens::Bool=false)
          return group_element(G, GAPWrap.LinearCombinationPcgs(Gpcgs, GapObj(v, true)))
        end
 
-       finv = g -> A2_to_A(A2(_exponent_vector(g) * M))
+       finv = g -> A2_to_A(A2(exponent_vector(g) * M))
      end
 
      return GroupIsomorphismFromFunc(A, G, f, finv)

--- a/src/Groups/pcgroup.jl
+++ b/src/Groups/pcgroup.jl
@@ -473,6 +473,211 @@ function pc_group(c::GAP_Collector)
 end
 
 """
+    exponent_vector(g::Union{PcGroupElem,SubPcGroupElem})
+
+Return the exponent vector of `g` as a list of integers, each entry corresponding to
+a group generator.
+
+# Examples
+
+```jldoctest
+julia> g = abelian_group(PcGroup, [0, 5])
+Pc group of infinite order
+
+julia> x = g[1]^-3 * g[2]^-3
+g1^-3*g2^2
+
+julia> exponent_vector(x)
+2-element Vector{Int64}:
+ -3
+  2
+```
+
+```jldoctest
+julia> gg = small_group(6, 1)
+Pc group of order 6
+
+julia> x = gg[1]^5*gg[2]^-4
+f1*f2^2
+
+julia> exponent_vector(x)
+2-element Vector{Int64}:
+ 1
+ 2
+```
+"""
+function exponent_vector(g::Union{PcGroupElem,SubPcGroupElem})
+  # check if we have a PcpGroup element
+  gObj = GapObj(g)
+  exp = if GAPWrap.IsPcpElement(gObj)
+    GAPWrap.Exponents(gObj)
+  else # finite PcGroup
+    pcgs = GAPWrap.FamilyPcgs(GapObj(parent(g)))
+    GAPWrap.ExponentsOfPcElement(pcgs, gObj)
+  end
+
+  return Vector{Int}(exp)
+end
+
+"""
+    relative_order(g::Union{PcGroupElem,SubPcGroupElem})
+
+Return the relative order of `g` as an integer, with respect to the defining generators.
+
+# Examples
+
+```jldoctest
+julia> g = abelian_group(PcGroup, [0, 5])
+Pc group of infinite order
+
+julia> x = g[1]^-3 * g[2]^-3
+g1^-3*g2^2
+
+julia> relative_order(x)
+0
+```
+
+```jldoctest
+julia> gg = small_group(6, 1)
+Pc group of order 6
+
+julia> x = gg[1]^5*gg[2]^-4
+f1*f2^2
+
+julia> relative_order(x)
+2
+```
+"""
+function relative_order(g::Union{PcGroupElem,SubPcGroupElem})
+  # check if we have a PcpGroup element
+  gObj = GapObj(g)
+  rel = if GAPWrap.IsPcpElement(gObj)
+    GAPWrap.RelativeOrder(gObj)
+  else # finite PcGroup
+    pcgs = GAPWrap.FamilyPcgs(GapObj(parent(g)))
+    GAPWrap.RelativeOrderOfPcElement(pcgs, gObj)
+  end
+
+  return rel
+end
+
+"""
+    depth(g::Union{PcGroupElem,SubPcGroupElem})
+
+Return the depth of `g` as integer, relative to the defining generators.
+
+# Examples
+
+```jldoctest
+julia> g = abelian_group(PcGroup, [0, 5])
+Pc group of infinite order
+
+julia> x = g[1]^-3 * g[2]^-3
+g1^-3*g2^2
+
+julia> depth(x)
+1
+```
+
+```jldoctest
+julia> gg = small_group(6, 1)
+Pc group of order 6
+
+julia> x = gg[1]^5*gg[2]^-4
+f1*f2^2
+
+julia> depth(x)
+1
+```
+"""
+function depth(g::Union{PcGroupElem,SubPcGroupElem})
+  # check if we have a PcpGroup element
+  gObj = GapObj(g)
+  dep = if GAPWrap.IsPcpElement(gObj)
+    GAPWrap.Depth(gObj)
+  else # finite PcGroup
+    GAPWrap.DepthOfPcElement(GAPWrap.FamilyPcgs(GapObj(parent(g))), gObj)
+  end
+
+  return dep
+end
+
+"""
+    leading_exponent(g::Union{PcGroupElem,SubPcGroupElem})
+
+Return the leading exponent of `g` as an integer, relative to the defining generators.
+If `g` is the identity, we return `nothing`.
+
+# Examples
+
+```jldoctest
+julia> g = abelian_group(PcGroup, [0, 5])
+Pc group of infinite order
+
+julia> x = g[1]^-3 * g[2]^-3
+g1^-3*g2^2
+
+julia> leading_exponent(x)
+-3
+```
+
+```jldoctest
+julia> gg = small_group(6, 1)
+Pc group of order 6
+
+julia> x = gg[1]^5*gg[2]^-4
+f1*f2^2
+
+julia> leading_exponent(x)
+1
+```
+"""
+function leading_exponent(g::Union{PcGroupElem,SubPcGroupElem})
+  # check if we have a PcpGroup element
+  gObj = GapObj(g)
+  exp = if GAPWrap.IsPcpElement(gObj)
+    GAPWrap.LeadingExponent(gObj)
+  else # finite PcGroup
+    GAPWrap.LeadingExponentOfPcElement(GAPWrap.FamilyPcgs(GapObj(parent(g))), gObj)
+  end
+
+  # if GAP returns fail, return nothing otherwise exp
+  return exp == GAP.Globals.fail ? nothing : exp
+end
+
+"""
+    hirsch_length(G::PcGroup)
+
+Return the Hirsch length of `G`. If `G` is a finite PcGroup, we return 0.
+
+# Examples
+
+```jldoctest
+julia> g = abelian_group(PcGroup, [0, 5])
+Pc group of infinite order
+
+julia> hirsch_length(g)
+1
+```
+
+```jldoctest
+julia> gg = small_group(6, 1)
+Pc group of order 6
+
+julia> hirsch_length(gg)
+0
+```
+"""
+function hirsch_length(G::PcGroup)
+  GG = GapObj(G)
+  if GAPWrap.IsPcpGroup(GG)
+    return GAPWrap.HirschLength(GG)
+  else # finite PcGroup
+    return 0
+  end
+end
+
+"""
     letters(g::Union{PcGroupElem, SubPcGroupElem})
 
 Return the letters of `g` as a list of integers, each entry corresponding to

--- a/src/Groups/pcgroup.jl
+++ b/src/Groups/pcgroup.jl
@@ -609,7 +609,7 @@ end
     leading_exponent(::Type{T} = ZZRingElem, g::Union{PcGroupElem,SubPcGroupElem})
 
 Return the leading exponent of `g` as an instance of the type `T`,
-relative to the defining generators.
+relative to the defining generators. Throws an error if `g` is the neutral element.
 
 # Examples
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -118,15 +118,15 @@ export MPolyComplementOfPrimeIdeal
 export MPolyDecRing
 export MPolyDecRingElem
 export MPolyIdeal
-export MPolyLocalizedIdeal
 export MPolyLocRing
 export MPolyLocRingElem
+export MPolyLocalizedIdeal
 export MPolyPowersOfElement
 export MPolyProductOfMultSets
 export MPolyQuoIdeal
-export MPolyQuoLocalizedIdeal
 export MPolyQuoLocRing
 export MPolyQuoLocRingElem
+export MPolyQuoLocalizedIdeal
 export MPolyQuoRing
 export MPolyQuoRingElem
 export MPolyRingElem
@@ -229,7 +229,6 @@ export action_function
 export action_homomorphism
 export add_edge!
 export add_gluing!
-export label!
 export add_vertex!
 export add_vertices!
 export adjacency_matrix
@@ -421,11 +420,11 @@ export coloops
 export column
 export combinations
 export combinatorial_symmetries
-export comparability_graph
 export comm
 export comm!
 export common_components
 export common_refinement
+export comparability_graph
 export complement
 export complement_classes
 export complement_equation
@@ -574,10 +573,10 @@ export dwarfed_product_polygons
 export edges
 export effective_cartier_divisor
 export ehrhart_polynomial
+export element
 export element_to_homomorphism
 export elementary_abelian_group
 export elementary_symmetric
-export element
 export elements
 export elements_of_rank
 export eliminate
@@ -674,6 +673,7 @@ export generalized_jordan_block
 export generalized_jordan_form
 export generating_system
 export generator_matrix
+export generic_enriques_surface
 export generic_fiber
 export generic_fraction
 export generic_fractions
@@ -750,6 +750,7 @@ export hilbert_polynomial
 export hilbert_series
 export hilbert_series_expanded
 export hilbert_series_reduced
+export hirsch_length
 export hirzebruch_surface
 export hom
 export hom_product
@@ -1052,6 +1053,7 @@ export isomorphic_subgroups
 export isomorphism
 export isomorphism_classes_elliptic_fibrations
 export isomorphism_classes_polarizations
+export isomorphism_from_generic_fibers
 export isone
 export isotropic_rays
 export isqrtrem
@@ -1075,6 +1077,7 @@ export known_class_fusions
 export koszul_complex
 export koszul_homology
 export koszul_matrix
+export label!
 export labeled_matrix_formatted
 export labelings
 export laplacian_matrix
@@ -1084,7 +1087,6 @@ export lattice_of_flats
 export lattice_of_one_parameter_subgroups
 export lattice_points
 export lattice_volume
-export least_element
 export leading_coefficient
 export leading_coefficient_and_exponent
 export leading_exponent
@@ -1092,6 +1094,7 @@ export leading_ideal
 export leading_module
 export leading_monomial
 export leading_term
+export least_element
 export lecture_hall_simplex
 export left_acting_group
 export left_coset
@@ -1118,7 +1121,6 @@ export linear_symmetries
 export linear_system
 export link_subcomplex
 export load
-export generic_enriques_surface
 export load_lp
 export load_mps
 export local_schur_indices
@@ -1131,8 +1133,8 @@ export low_index_subgroups
 export lower_central_series, has_lower_central_series, set_lower_central_series
 export lower_triangular_matrix
 export map
-export map_from_func
 export map_from_character_lattice_to_torusinvariant_weil_divisor_group
+export map_from_func
 export map_from_picard_group_to_class_group
 export map_from_torusinvariant_cartier_divisor_group_to_class_group
 export map_from_torusinvariant_cartier_divisor_group_to_picard_group
@@ -1511,6 +1513,7 @@ export relations
 export relative_ambient_dimension
 export relative_interior_point
 export relative_invariants
+export relative_order
 export relators
 export rem_edge!
 export rem_vertex!
@@ -1538,8 +1541,6 @@ export reverse_direction!
 export revlex_basis_encoding
 export reynolds_operator
 export right_acting_group
-export translation_morphism
-export isomorphism_from_generic_fibers
 export right_coset
 export right_coset_action
 export right_cosets
@@ -1567,7 +1568,6 @@ export scalar_product
 export scheme
 export scheme_type
 export schensted
-export show_atlas_info
 export schur_cover
 export schur_index
 export schur_multiplier
@@ -1601,6 +1601,7 @@ export sheaf_cohomology
 export sheaf_of_rings
 export short_right_transversal
 export shortest_path_dijkstra
+export show_atlas_info
 export show_morphism
 export show_morphism_as_map
 export show_subquo
@@ -1714,6 +1715,7 @@ export transform_to_weierstrass
 export transitive_group
 export transitive_group_identification, has_transitive_group_identification
 export transitivity
+export translation_morphism
 export transport
 export transportation_polytope
 export triangular_decomposition
@@ -1729,8 +1731,8 @@ export tropical_matrix
 export tropical_median_consensus
 export tropical_pluecker_vector
 export tropical_polynomial
-export tropical_variety
 export tropical_prevariety
+export tropical_variety
 export truncate
 export turn_denominator_into_polyhedron
 export tutte_connectivity


### PR DESCRIPTION
This PR adds functionality for the methods listed in #4939.