### PR TITLE
Tweak printing of free groups of unknown rank

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -435,8 +435,12 @@ function Base.show(io::IO, G::Union{FPGroup, SubFPGroup})
   @show_special(io, G)
   if GAPWrap.IsFreeGroup(GapObj(G))
     print(io, "Free group")
-    if !is_terse(io) && GAP.Globals.HasRankOfFreeGroup(GapObj(G))::Bool
-      print(io, " of rank ", GAP.Globals.RankOfFreeGroup(GapObj(G))::Int)
+    if !is_terse(io)
+      if GAP.Globals.HasRankOfFreeGroup(GapObj(G))::Bool
+        print(io, " of rank ", GAP.Globals.RankOfFreeGroup(GapObj(G))::Int)
+      else
+        print(io, " of unknown rank")
+      end
     end
   else
     T = typeof(G) == FPGroup ? "Finitely presented group" : "Sub-finitely presented group"
@@ -594,7 +598,7 @@ julia> has_gens(F)
 true
 
 julia> H = derived_subgroup(F)[1]
-Free group
+Free group of unknown rank
 
 julia> has_gens(H)
 false
@@ -1891,7 +1895,7 @@ julia> is_finitely_generated(F)
 true
 
 julia> H = derived_subgroup(F)[1]
-Free group
+Free group of unknown rank
 
 julia> is_finitely_generated(H)
 false


### PR DESCRIPTION
This was extracted from PR #2878. That PR has been stalled for a long time and I am now trying to extract smaller bits of it and getting them merged.

Here the idea is that for free groups where the rank has (not yet) been computed, it may be better state that the rank is unknown than not printing any rank -- otherwise it can be confusing why one free group prints its rank and the other does not.

So this is meant to encourage the user to try to compute the rank.

Caveat: I guess a user might mistake the proposed printing as "Free group of unknown rank" as meaning "unknowable rank". Perhaps "Free group with uncomputed rank" or so would be clearer, but also seems clunkier.
