### PR TITLE
Custom printing for FPGroupElem

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -412,7 +412,25 @@ Return the identity of the parent group of `x`.
 """
 Base.one(x::GAPGroupElem) = one(parent(x))
 
-Base.show(io::IO, x::GAPGroupElem) = print(io, String(GAPWrap.StringViewObj(GapObj(x))))
+function Base.show(io::IO, x::GAPGroupElem)
+  print(io, String(GAPWrap.StringViewObj(GapObj(x))))
+end
+
+function Base.show(io::IO, x::FPGroupElem)
+  s = String(GAPWrap.StringViewObj(GapObj(x)))
+  if get(io, :limit, false)::Bool
+    screenheight, screenwidth = displaysize(io)::Tuple{Int,Int}
+    screenwidth -= 3 # leave some space for indentation
+    if length(s) > screenwidth
+      if is_unicode_allowed()
+        s = s[1:screenwidth-1] * "…"
+      else
+        s = s[1:screenwidth-3] * "..."
+      end
+    end
+  end
+  print(io, s)
+end
 
 # Printing GAP groups
 function Base.show(io::IO, G::GAPGroup)

--- a/test/Groups/elements.jl
+++ b/test/Groups/elements.jl
@@ -1,3 +1,72 @@
+Oscar.@_AuxDocTest "show and print fp group elements", (fix = false),
+raw"""
+common setup
+
+```jldoctest FPGroupElem.show
+julia> using Oscar
+
+julia> F = free_group('a':'z');
+
+julia> long_word = prod(gens(F))*prod(inv.(gens(F)));
+```
+
+default `show` without unicode
+
+```jldoctest FPGroupElem.show
+julia> old = allow_unicode(false; temporary=true);
+
+julia> withenv("LINES" => 30, "COLUMNS" => 80) do
+         show(stdout, long_word)
+       end
+a*b*c*d*e*f*g*h*i*j*k*l*m*n*o*p*q*r*s*t*u*v*w*x*y*z*a^-1*b^-1*c^-1*d^-1*e^-1*f^-1*g^-1*h^-1*i^-1*j^-1*k^-1*l^-1*m^-1*n^-1*o^-1*p^-1*q^-1*r^-1*s^-1*t^-1*u^-1*v^-1*w^-1*x^-1*y^-1*z^-1
+
+julia> withenv("LINES" => 30, "COLUMNS" => 80) do
+         show(stdout, MIME("text/plain"), long_word)
+       end
+a*b*c*d*e*f*g*h*i*j*k*l*m*n*o*p*q*r*s*t*u*v*w*x*y*z*a^-1*b^-1*c^-1*d^-1*e^-1*f^-1*g^-1*h^-1*i^-1*j^-1*k^-1*l^-1*m^-1*n^-1*o^-1*p^-1*q^-1*r^-1*s^-1*t^-1*u^-1*v^-1*w^-1*x^-1*y^-1*z^-1
+
+julia> withenv("LINES" => 30, "COLUMNS" => 80) do
+         show(IOContext(stdout, :limit => true), long_word)
+       end
+a*b*c*d*e*f*g*h*i*j*k*l*m*n*o*p*q*r*s*t*u*v*w*x*y*z*a^-1*b^-1*c^-1*d^-1*e^...
+
+julia> withenv("LINES" => 30, "COLUMNS" => 80) do
+         show(IOContext(stdout, :limit => true), MIME("text/plain"), long_word)
+       end
+a*b*c*d*e*f*g*h*i*j*k*l*m*n*o*p*q*r*s*t*u*v*w*x*y*z*a^-1*b^-1*c^-1*d^-1*e^...
+
+julia> allow_unicode(old; temporary=true);
+```
+
+default `show` with unicode
+
+```jldoctest FPGroupElem.show
+julia> old = allow_unicode(true; temporary=true);
+
+julia> withenv("LINES" => 30, "COLUMNS" => 80) do
+         show(stdout, long_word)
+       end
+a*b*c*d*e*f*g*h*i*j*k*l*m*n*o*p*q*r*s*t*u*v*w*x*y*z*a^-1*b^-1*c^-1*d^-1*e^-1*f^-1*g^-1*h^-1*i^-1*j^-1*k^-1*l^-1*m^-1*n^-1*o^-1*p^-1*q^-1*r^-1*s^-1*t^-1*u^-1*v^-1*w^-1*x^-1*y^-1*z^-1
+
+julia> withenv("LINES" => 30, "COLUMNS" => 80) do
+         show(stdout, MIME("text/plain"), long_word)
+       end
+a*b*c*d*e*f*g*h*i*j*k*l*m*n*o*p*q*r*s*t*u*v*w*x*y*z*a^-1*b^-1*c^-1*d^-1*e^-1*f^-1*g^-1*h^-1*i^-1*j^-1*k^-1*l^-1*m^-1*n^-1*o^-1*p^-1*q^-1*r^-1*s^-1*t^-1*u^-1*v^-1*w^-1*x^-1*y^-1*z^-1
+
+julia> withenv("LINES" => 30, "COLUMNS" => 80) do
+         show(IOContext(stdout, :limit => true), long_word)
+       end
+a*b*c*d*e*f*g*h*i*j*k*l*m*n*o*p*q*r*s*t*u*v*w*x*y*z*a^-1*b^-1*c^-1*d^-1*e^-1…
+
+julia> withenv("LINES" => 30, "COLUMNS" => 80) do
+         show(IOContext(stdout, :limit => true), MIME("text/plain"), long_word)
+       end
+a*b*c*d*e*f*g*h*i*j*k*l*m*n*o*p*q*r*s*t*u*v*w*x*y*z*a^-1*b^-1*c^-1*d^-1*e^-1…
+
+julia> allow_unicode(old; temporary=true);
+```
+"""
+
 @testset "Permutations" begin
   for n = 10:13
     G=symmetric_group(n)


### PR DESCRIPTION
Abbreviate long words to fit into one screen line. Will be useful when e.g. printing relators for FP groups.

The current algorithm is very naive and just operates on a string level so it may cut off in "bad" places. But at least the algorithm is simple this way, and hopefully "good enough" (if someone wants something more fancy, I'll be happy to review their follow-up PR).

This was extracted from PR #2878. That PR has been stalled for a long time and I am now trying to extract smaller bits of it and getting them merged.