### PR TITLE
BookTests: Use julia-version-specific testfile if available

### DIFF
--- a/test/book/cornerstones/algebraic-geometry/circlepar-v1.13.jlcon
+++ b/test/book/cornerstones/algebraic-geometry/circlepar-v1.13.jlcon
@@ -1,0 +1,25 @@
+julia> R, (x, y, t) = polynomial_ring(QQ, ["x", "y", "t"]);
+
+julia> I = ideal(R, [x^2 + y^2 - 1, y - t*x - 1]);
+
+julia> Gy = groebner_basis(I, ordering = lex([y, x, t]), complete_reduction=true)
+Gröbner basis with elements
+  1: x^2*t^2 + x^2 + 2*x*t
+  2: y - x*t - 1
+with respect to the ordering
+  lex([y, x, t])
+
+julia> factor(Gy[1])
+1 * (x*t^2 + x + 2*t) * x
+
+julia> Gx = groebner_basis(I, ordering = lex([x, y, t]), complete_reduction=true)
+Gröbner basis with elements
+  1: y^2*t^2 + y^2 - 2*y - t^2 + 1
+  2: x*t - y + 1
+  3: x*y - x + y^2*t - t
+  4: x^2 + y^2 - 1
+with respect to the ordering
+  lex([x, y, t])
+
+julia> factor(Gx[1])
+1 * (y*t^2 + y + t^2 - 1) * (y - 1)

--- a/test/book/cornerstones/groups/genchar-v1.13.jlcon
+++ b/test/book/cornerstones/groups/genchar-v1.13.jlcon
@@ -1,0 +1,66 @@
+julia> T = generic_character_table("SL3.n1")
+Generic character table SL3.n1
+  of order q^8 - q^6 - q^5 + q^3
+  with 8 irreducible character types
+  with 8 class types
+  with parameters (a, b, m, n)
+
+julia> T[4,4]
+(q + 1)*exp(2π𝑖((a*n)//(q - 1))) + exp(2π𝑖((-2*a*n)//(q - 1)))
+
+julia> h = T[2] * T[2];
+
+julia> scalar_product(T[4], h)
+0
+With exceptions:
+  2*n1 ∈ (q - 1)ℤ
+
+julia> for i in 1:8 println("<$i, h> = ", scalar_product(T[i], h)) end
+<1, h> = 1
+<2, h> = 2
+<3, h> = 2
+<4, h> = 0
+With exceptions:
+  2*n1 ∈ (q - 1)ℤ
+<5, h> = 0
+With exceptions:
+  2*n1 ∈ (q - 1)ℤ
+<6, h> = 0
+With exceptions:
+  2*m1 - n1 ∈ (q - 1)ℤ
+  m1 - 2*n1 ∈ (q - 1)ℤ
+  m1 + n1 ∈ (q - 1)ℤ
+  m1 ∈ (q - 1)ℤ
+  m1 - n1 ∈ (q - 1)ℤ
+  n1 ∈ (q - 1)ℤ
+<7, h> = 0
+With exceptions:
+  n1 ∈ (q - 1)ℤ
+<8, h> = 0
+With exceptions:
+  q*n1 ∈ (q^2 + q + 1)ℤ
+  q*n1 + n1 ∈ (q^2 + q + 1)ℤ
+  n1 ∈ (q^2 + q + 1)ℤ
+
+julia> degree(linear_combination([1,2,2],[T[1],T[2],T[3]]))
+2*q^3 + 2*q^2 + 2*q + 1
+
+julia> degree(h)
+q^4 + 2*q^3 + q^2
+
+julia> parameters(T[4])
+n ∈ {1,…, q - 1} except n ∈ (q - 1)ℤ
+
+julia> T2 = set_congruence(T; remainder=0, modulus=2);
+
+julia> (q, (a, b, m, n)) = parameters(T2);
+
+julia> x = parameter(T2, "x");  # create an additional "free" variable
+
+julia> s = specialize(T2[6], m, -n + (q-1)*x);  # force m = -n (mod q-1)
+
+julia> scalar_product(s, T2(h))
+1
+With exceptions:
+  3*n1 ∈ (q - 1)ℤ
+  2*n1 ∈ (q - 1)ℤ

--- a/test/book/cornerstones/number-theory/intro-v1.13.jlcon
+++ b/test/book/cornerstones/number-theory/intro-v1.13.jlcon
@@ -1,0 +1,90 @@
+julia> Qx, x = QQ["x"];
+
+julia> K, a = number_field(x^2 - 235, "a")
+(Number field of degree 2 over QQ, a)
+
+julia> a^2 - 235 # confirm that a is a root of x^2 - 235
+0
+
+julia> b = 2 + 1//3 * a
+1//3*a + 2
+
+julia> coordinates(b)
+2-element Vector{QQFieldElem}:
+ 2
+ 1//3
+
+julia> K(x^3 + x + 2) # map the polynomial x^3 + x + 2 to K
+236*a + 2
+
+julia> degree(K)
+2
+
+julia> trace(a)
+0
+
+julia> norm(a)
+-235
+
+julia> OK = ring_of_integers(K);
+
+julia> basis(OK)
+2-element Vector{AbsSimpleNumFieldOrderElem}:
+ 1
+ a
+
+julia> discriminant(OK)
+940
+
+julia> prime_ideals_over(OK, 7)
+2-element Vector{AbsSimpleNumFieldOrderIdeal}:
+ <7, a + 2>
+ <7, a + 5>
+
+julia> factor(change_coefficient_ring(GF(7), x^2 - 235))
+1 * (x + 2) * (x + 5)
+
+julia> factor(a * OK)
+Dict{AbsSimpleNumFieldOrderIdeal, Int64} with 2 entries:
+  <47, a> => 1
+  <5, a>  => 1
+
+julia> A, m = class_group(OK);
+
+julia> A
+Z/6
+
+julia> m(zero(A)) # apply m to the neutral element of A
+Ideal of maximal order of number field of degree 2 over QQ
+  of norm 1
+  of minimum 1
+with generator 1
+
+julia> P = prime_ideals_over(OK, 2)[1]
+Ideal of maximal order of number field of degree 2 over QQ
+  of norm 2
+  of minimum 2
+with 2-normal generators [2, a + 1]
+
+julia> preimage(m, P)
+Abelian group element [3]
+
+julia> is_principal_with_data(P^2)
+(true, 2)
+
+julia> P^2 == 2*OK
+true
+
+julia> U, mU = unit_group(OK);
+
+julia> U
+Z/2 x Z
+
+julia> mU(U[1]), mU(U[2])
+(-1, 3*a + 46)
+
+julia> preimage(mU, -214841715*a - 3293461126)
+Abelian group element [1, 5]
+
+julia> -214841715*a - 3293461126 == (-1)^1 * (3a + 46)^5
+true

--- a/test/book/specialized/boehm-breuer-git-fans/explG25_4-v1.13.jlcon
+++ b/test/book/specialized/boehm-breuer-git-fans/explG25_4-v1.13.jlcon
@@ -1,0 +1,10 @@
+julia> q_cone = positive_hull(Q)
+Polyhedral cone in ambient dimension 5
+
+julia> (hash_list, edges) = GITFans.fan_traversal(orbit_list, q_cone, perm_actions);
+
+julia> length(hash_list)
+6
+
+julia> println(edges)
+Set([[3, 4], [2, 3], [1, 2], [3, 5], [4, 6]])

--- a/test/book/specialized/kuehne-schroeter-matroids/ChowRings-v1.13.jlcon
+++ b/test/book/specialized/kuehne-schroeter-matroids/ChowRings-v1.13.jlcon
@@ -1,0 +1,97 @@
+julia> M = cycle_matroid(complete_graph(4))
+Matroid of rank 3 on 6 elements
+
+julia> tutte_polynomial(M)
+x^3 + 3*x^2 + 4*x*y + 2*x + y^3 + 3*y^2 + 2*y
+
+julia> char_poly = characteristic_polynomial(M)
+q^3 - 6*q^2 + 11*q - 6
+
+julia> factor(char_poly)
+1 * (q - 3) * (q - 2) * (q - 1)
+
+julia> A = chow_ring(M);
+
+julia> GR, _ = graded_polynomial_ring(QQ,symbols(base_ring(A)));
+
+julia> AA = chow_ring(M,ring=GR);
+
+julia> vol_map = volume_map(M,AA)
+#3605 (generic function with 1 method)
+
+julia> e = matroid_groundset(M)[1];
+
+julia> proper_flats = flats(M)[2:length(flats(M))-1];
+
+julia> a = sum([AA[i] for i in 1:length(proper_flats) if e in proper_flats[i]])
+x_{Edge(2, 1)} + x_{Edge(2, 1),Edge(3, 1),Edge(3, 2)} + x_{Edge(2, 1),Edge(4, 1),Edge(4, 2)} + x_{Edge(2, 1),Edge(4, 3)}
+
+julia> b = sum([AA[i] for i in 1:length(proper_flats) if !(e in proper_flats[i])])
+x_{Edge(3, 1)} + x_{Edge(3, 2)} + x_{Edge(4, 1)} + x_{Edge(4, 2)} + x_{Edge(4, 3)} + x_{Edge(3, 1),Edge(4, 2)} + x_{Edge(3, 1),Edge(4, 1),Edge(4, 3)} + x_{Edge(3, 2),Edge(4, 1)} + x_{Edge(3, 2),Edge(4, 2),Edge(4, 3)}
+
+julia> k = 1
+1
+
+julia> R = base_ring(AA);
+
+julia> g = grading_group(R)[1];
+
+julia> PD1, mapPD1 = homogeneous_component(AA,k*g);
+
+julia> basis_PD1 = [mapPD1(x) for x in gens(PD1)];
+
+julia> PD2, mapPD2 = homogeneous_component(AA,(rank(M)-k-1)*g);
+
+julia> basis_PD2 = [mapPD2(x) for x in gens(PD2)];
+
+julia> Mat1 = matrix(QQ,[[vol_map(b1*b2) for b1 in basis_PD1] for b2 in basis_PD2])
+[-1    0    0    0    0    0    0    1]
+[ 0   -1    0    0    0    0    0    0]
+[ 0    0   -1    0    0    0    0    1]
+[ 0    0    0   -1    0    0    0    0]
+[ 0    0    0    0   -1    0    0    1]
+[ 0    0    0    0    0   -1    0    0]
+[ 0    0    0    0    0    0   -1    0]
+[ 1    0    1    0    1    0    0   -2]
+
+julia> Mat2 = matrix(QQ,[[vol_map(b1*b^(rank(M)-2k-1)*b2) for b1 in basis_PD1] for b2 in basis_PD1]);
+
+julia> Mat1 == Mat2
+true
+
+julia> RR, _ = graded_polynomial_ring(QQ,"y_#" => 1:length(basis_PD1));
+
+julia> map = hom(RR,AA,basis_PD1);
+
+julia> K = kernel(hom(RR,AA,[b^(rank(M)-2k)*b3 for b3 in basis_PD1]));
+
+julia> basis_HR = [map(h) for h in gens(K) if degree(h).coeff==k*g.coeff]
+7-element Vector{MPolyQuoRingElem{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}}:
+ x_{Edge(4, 3)}
+ -x_{Edge(2, 1),Edge(3, 1),Edge(3, 2)} + x_{Edge(2, 1),Edge(4, 1),Edge(4, 2)}
+ -x_{Edge(2, 1),Edge(3, 1),Edge(3, 2)} + 2*x_{Edge(2, 1),Edge(4, 3)}
+ -x_{Edge(2, 1),Edge(3, 1),Edge(3, 2)} + 2*x_{Edge(3, 1),Edge(4, 2)}
+ -x_{Edge(2, 1),Edge(3, 1),Edge(3, 2)} + x_{Edge(3, 1),Edge(4, 1),Edge(4, 3)}
+ -x_{Edge(2, 1),Edge(3, 1),Edge(3, 2)} + 2*x_{Edge(3, 2),Edge(4, 1)}
+ -x_{Edge(2, 1),Edge(3, 1),Edge(3, 2)} + x_{Edge(3, 2),Edge(4, 2),Edge(4, 3)}
+
+julia> Mat3 = matrix(QQ,[[(-1)^k*vol_map(b1*b^(rank(M)-2k-1)*b2) for b1 in basis_HR] for b2 in basis_HR])
+[ 2   0   -2   0   -1   0   -1]
+[ 0   2    1   1    1   1    1]
+[-2   1    5   1    1   1    1]
+[ 0   1    1   5    1   1    1]
+[-1   1    1   1    2   1    1]
+[ 0   1    1   1    1   5    1]
+[-1   1    1   1    1   1    2]
+
+julia> is_positive_definite(matrix(ZZ,[ZZ(i) for i in Mat3]))
+true
+
+julia> reduced_characteristic_polynomial(M)
+q^2 - 5*q + 6
+
+julia> [vol_map(a^(rank(M)-j-1)*b^j) for j in range(0,rank(M)-1)]
+3-element Vector{QQFieldElem}:
+ 1
+ 5
+ 6

--- a/test/book/test.jl
+++ b/test/book/test.jl
@@ -276,7 +276,7 @@ isdefined(Main, :FakeTerminals) || include(joinpath(pkgdir(REPL),"test","FakeTer
               full_file_path_versioned = join(splitext(full_file_path), "-v$(VERSION.major).$(VERSION.minor)")
               has_versioned_file = isfile(joinpath(Oscar.oscardir, "test", "book", full_file_path_versioned))
               println("    $example$(full_file_path in skipped ? ": skip" :
-                                     full_file_path in broken ? ": broken" : "")$(has_versioned_file ? "version-specific" : "")")
+                                     full_file_path in broken ? ": broken" : "")$(has_versioned_file ? " version-specific" : "")")
               filetype = endswith(example, "jlcon") ? :jlcon :
                          endswith(example, "jl") ? :jl : :unknown
               content = read(joinpath(Oscar.oscardir, "test", "book", has_versioned_file ? full_file_path_versioned : full_file_path), String)


### PR DESCRIPTION
Implements the proposal from https://github.com/oscar-system/Oscar.jl/issues/4882#issuecomment-2943913935.

Furthermore, this already adds 1.13-specific test files for the cases where the change is obviously correct (e.g. changes in the printing of a `Set` or the result of `factor`). There will be some failures left, but in these cases we need to take a closer look into if the changes required still make sense for the example.