### PR TITLE
Rename MatrixGroup arg from x to G

### DIFF
--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -153,11 +153,11 @@ change_base_ring(R::Ring, G::MatrixGroup) = map_entries(R, G)
 #
 ########################################################################
 
-function _print_matrix_group_desc(io::IO, x::MatrixGroup)
+function _print_matrix_group_desc(io::IO, G::MatrixGroup)
   io = pretty(io)
-  R = base_ring(x)
-  print(io, LowercaseOff(), string(x.descr), "(", degree(x) ,",")
-  if x.descr==:GU || x.descr==:SU
+  R = base_ring(G)
+  print(io, LowercaseOff(), string(G.descr), "(", degree(G) ,",")
+  if G.descr==:GU || G.descr==:SU
     print(io, characteristic(R)^(div(degree(R),2)),")")
   elseif R isa Field && is_finite(R)
     print(io, order(R),")")
@@ -167,24 +167,24 @@ function _print_matrix_group_desc(io::IO, x::MatrixGroup)
   end
 end
 
-function Base.show(io::IO, ::MIME"text/plain", x::MatrixGroup)
-  isdefined(x, :descr) && return _print_matrix_group_desc(io, x)
-  println(io, "Matrix group of degree ", degree(x))
+function Base.show(io::IO, ::MIME"text/plain", G::MatrixGroup)
+  isdefined(G, :descr) && return _print_matrix_group_desc(io, G)
+  println(io, "Matrix group of degree ", degree(G))
   io = pretty(io)
   print(io, Indent())
-  print(io, "over ", Lowercase(), base_ring(x))
+  print(io, "over ", Lowercase(), base_ring(G))
   print(io, Dedent())
 end
 
-function Base.show(io::IO, x::MatrixGroup)
-  @show_name(io, x)
-  @show_special(io, x)
-  isdefined(x, :descr) && return _print_matrix_group_desc(io, x)
+function Base.show(io::IO, G::MatrixGroup)
+  @show_name(io, G)
+  @show_special(io, G)
+  isdefined(G, :descr) && return _print_matrix_group_desc(io, G)
   print(io, "Matrix group")
   if !is_terse(io)
-    print(io, " of degree ", degree(x))
+    print(io, " of degree ", degree(G))
     io = pretty(io)
-    print(terse(io), " over ", Lowercase(), base_ring(x))
+    print(terse(io), " over ", Lowercase(), base_ring(G))
   end
 end
 


### PR DESCRIPTION
This is purely a renaming (modulo mistakes) and thus should have no effect on anything -- but the code was rather confusing as in all (?) other methods in that file, `x` was/is a `MatrixGroupElem` not a `MatrixGroup`.

Since later commits in PR #2878 modify this code, it will be easier to read it there with this renaming merged before.