### PR TITLE
Free resolutions: correct length function

### DIFF
--- a/src/Modules/UngradedModules/FreeResolutions.jl
+++ b/src/Modules/UngradedModules/FreeResolutions.jl
@@ -779,6 +779,14 @@ julia> B = R[x^2; x*y; y^2; z^4];
 
 julia> M = SubquoModule(A, B);
 
+julia> fr = free_resolution(M, length = 2)
+Free resolution of M
+R^2 <---- R^6 <---- R^6
+0         1         2
+
+julia> length(fr)
+2
+
 julia> fr = free_resolution(M)
 Free resolution of M
 R^2 <---- R^6 <---- R^6 <---- R^2 <---- 0
@@ -791,7 +799,7 @@ julia> length(fr)
 """
 function length(F::FreeResolution)
   if !is_complete(F.C)
-    idx = findfirst(is_zero(domain(phi)) for phi in F.C.maps)
+    idx = findfirst(is_zero(F.C[i]) for i = 0:first(map_range(F.C)))-2
     isnothing(idx) && return first(map_range(F.C))
     return idx::Int
   end

--- a/src/Modules/UngradedModules/FreeResolutions.jl
+++ b/src/Modules/UngradedModules/FreeResolutions.jl
@@ -799,7 +799,7 @@ julia> length(fr)
 """
 function length(F::FreeResolution)
   if !is_complete(F.C)
-    idx = findfirst(is_zero(F.C[i]) for i = 0:first(map_range(F.C)))
+    idx = findfirst(i -> is_zero(F.C[i]), 0:first(map_range(F.C)))
     isnothing(idx) && return first(map_range(F.C))
     return idx-2::Int
   end

--- a/src/Modules/UngradedModules/FreeResolutions.jl
+++ b/src/Modules/UngradedModules/FreeResolutions.jl
@@ -799,9 +799,9 @@ julia> length(fr)
 """
 function length(F::FreeResolution)
   if !is_complete(F.C)
-    idx = findfirst(is_zero(F.C[i]) for i = 0:first(map_range(F.C)))-2
+    idx = findfirst(is_zero(F.C[i]) for i = 0:first(map_range(F.C)))
     isnothing(idx) && return first(map_range(F.C))
-    return idx::Int
+    return idx-2::Int
   end
   # complex is complete
   length(F.C.maps)-3

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -328,6 +328,15 @@ end
   FM3 = free_resolution(M, length = 2, algorithm = :nres)
   FM3[4]
   @test all(iszero, homology(FM3))
+
+  R, (v, w, x, y, z) = polynomial_ring(QQ, [:v, :w, :x, :y, :z]);
+  U = complement_of_point_ideal(R, [0, 0, 0, 0, 0]);
+  RL, _ = localization(R, U);
+  I = ideal(RL, [v, w,x, y, z])
+  MI = ideal_as_module(I)
+  FMI = free_resolution_via_kernels(MI)
+  @test !is_complete(FMI) # Caveat: If this will change, add another test for length using a free resolution function not setting the complete key.
+  @test length(FMI) == 4
 end
 
 @testset "Prune With Map" begin


### PR DESCRIPTION
This corrects be559c6. The problem occurs when a resolution function does not set the complete key to true when appropriate. I think that we should not have such functions. Opinions? For now, I have added a test using the `free_resolution_via_kernels` function.  While writing the test I found that this function is also buggy. I will repair this with my next PR.