### PR TITLE
Print generators for (Sub)FPGroup, (Sub)PcGroup; for FPGroup also print number of (defining) relators

### DIFF
--- a/docs/src/Groups/fpgroup.md
+++ b/docs/src/Groups/fpgroup.md
@@ -30,7 +30,7 @@ it has an empty vector of defining relators.
 
 ```jldoctest fpgroupxpl
 julia> F = free_group(2)
-Free group of rank 2
+Free group of rank 2 with 2 generators f1, f2
 
 julia> gens(F)
 2-element Vector{FPGroupElem}:

--- a/docs/src/Groups/pcgroup.md
+++ b/docs/src/Groups/pcgroup.md
@@ -82,7 +82,7 @@ julia> set_relative_orders!(c, [2, 3])
 julia> set_conjugate!(c, 2, 1, [2 => 2])
 
 julia> gg = pc_group(c)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> describe(gg)
 "S3"
@@ -98,7 +98,7 @@ Symmetric group of degree 4
 julia> iso = isomorphism(PcGroup, g);
 
 julia> h = codomain(iso)
-Pc group of order 24
+Pc group of order 24 with 4 generators f1, f2, f3, f4
 ```
 
 For certain series of groups, one can
@@ -106,7 +106,7 @@ For certain series of groups, one can
 
 ```jldoctest
 julia> dihedral_group(8)
-Pc group of order 8
+Pc group of order 8 with 3 generators f1, f2, f3
 ```
 
 And the groups from [the small groups library](@ref "Groups of small order")
@@ -114,7 +114,7 @@ are represented by pc groups whenever they are solvable.
 
 ```jldoctest
 julia> small_group(24, 12)
-Pc group of order 24
+Pc group of order 24 with 4 generators f1, f2, f3, f4
 ```
 
 ## Functions for elements of (subgroups of) pc groups

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -437,7 +437,7 @@ be a subgroup of the domain of `g`.
 # Examples
 ```jldoctest
 julia> C = cyclic_group(20)
-Pc group of order 20
+Pc group of order 20 with 3 generators f1, f2, f3
 
 julia> S = automorphism_group(C)
 Automorphism group of

--- a/src/Groups/directproducts.jl
+++ b/src/Groups/directproducts.jl
@@ -367,10 +367,10 @@ where `f` is a group homomorphism from `H` to the automorphism group of `N`.
 # Examples
 ```jldoctest
 julia> Q = quaternion_group(8)
-Pc group of order 8
+Pc group of order 8 with 3 generators x, y, y2
 
 julia> C = cyclic_group(2)
-Pc group of order 2
+Pc group of order 2 with 1 generator f1
 
 julia> A = automorphism_group(Q)
 Automorphism group of
@@ -533,7 +533,7 @@ W(g_1,...,g_n, h).
 # Examples
 ```jldoctest
 julia> G = cyclic_group(3)
-Pc group of order 3
+Pc group of order 3 with 1 generator f1
 
 julia> H = symmetric_group(2)
 Symmetric group of degree 2
@@ -598,7 +598,7 @@ Return `G`, where `W` is the wreath product of `G` and `H`.
 # Examples
 ```jldoctest
 julia> G = cyclic_group(3)
-Pc group of order 3
+Pc group of order 3 with 1 generator f1
 
 julia> H = symmetric_group(2)
 Symmetric group of degree 2
@@ -609,7 +609,7 @@ Wreath product with
   top group: symmetric group of degree 2
 
 julia> normal_subgroup(W)
-Pc group of order 3
+Pc group of order 3 with 1 generator f1
 ```
 """
 normal_subgroup(W::WreathProductGroup) = W.G
@@ -622,7 +622,7 @@ Return `H`, where `W` is the wreath product of `G` and `H`.
 # Examples
 ```jldoctest
 julia> G = cyclic_group(3)
-Pc group of order 3
+Pc group of order 3 with 1 generator f1
 
 julia> H = symmetric_group(2)
 Symmetric group of degree 2

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -3433,7 +3433,7 @@ julia> phi[1], n, m
 (3, 2, 3)
 
 julia> G = quaternion_group(8)
-Pc group of order 8
+Pc group of order 8 with 3 generators x, y, y2
 
 julia> t = character_table(G);
 

--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -111,13 +111,13 @@ Return the cyclic group of order `n`, as an instance of type `T`.
 # Examples
 ```jldoctest
 julia> G = cyclic_group(5)
-Pc group of order 5
+Pc group of order 5 with 1 generator f1
 
 julia> G = cyclic_group(PermGroup, 5)
 Permutation group of degree 5 and order 5
 
 julia> G = cyclic_group(PosInf())
-Pc group of infinite order
+Pc group of infinite order with 1 generator g1
 
 ```
 """
@@ -244,7 +244,7 @@ The `gens` vector of the result has minimal length.
 # Examples
 ```jldoctest
 julia> g = elementary_abelian_group(27)
-Pc group of order 27
+Pc group of order 27 with 3 generators f1, f2, f3
 
 julia> g = elementary_abelian_group(PermGroup, 27)
 Permutation group of degree 9 and order 27
@@ -575,7 +575,7 @@ representation by a vector of integers is chosen in the default case of
 # Examples
 ```jldoctest
 julia> F = free_group(:a, :b)
-Free group of rank 2
+Free group of rank 2 with 2 generators a, b
 
 julia> w = F[1]^3 * F[2]^F[1] * F[-2]^2
 a^2*b*a*b^-2
@@ -662,7 +662,7 @@ its generators as Julia variables into the current scope.
 # Examples
 ```jldoctest
 julia> F = @free_group(:a, :b)
-Free group of rank 2
+Free group of rank 2 with 2 generators a, b
 
 julia> a^2*b*a*b^-2
 a^2*b*a*b^-2
@@ -772,13 +772,13 @@ where `T` is in {`PcGroup`, `SubPcGroup`, `PermGroup`, `FPGroup`, `SubFPGroup`}.
 # Examples
 ```jldoctest
 julia> dihedral_group(6)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> dihedral_group(PermGroup, 6)
 Permutation group of degree 3
 
 julia> dihedral_group(PosInf())
-Pc group of infinite order
+Pc group of infinite order with 2 generators g1, g2
 
 julia> dihedral_group(7)
 ERROR: ArgumentError: n must be a positive even integer or infinity
@@ -837,13 +837,13 @@ and `T` is a suitable group type such as
 # Examples
 ```jldoctest
 julia> g = dicyclic_group(8)
-Pc group of order 8
+Pc group of order 8 with 3 generators x, y, y2
 
 julia> dicyclic_group(PermGroup, 8)
 Permutation group of degree 8
 
 julia> g = dicyclic_group(FPGroup, 8)
-Finitely presented group of order 8
+Finitely presented group of order 8 with 2 generators r, s and 3 relators
 
 julia> relators(g)
 3-element Vector{FPGroupElem}:
@@ -949,7 +949,7 @@ of order 8 and one quaternion group of order 8 if `p` is 2.
 # Examples
 ```jldoctest
 julia> extraspecial_group(3, 2, :-)
-Pc group of order 243
+Pc group of order 243 with 5 generators f1, f2, f3, f4, f5
 
 julia> describe(extraspecial_group(2, 1, :+))
 "D8"

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -1164,7 +1164,7 @@ can be used instead.
 # Examples
 ```jldoctest
 julia> G = dihedral_group(6)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> iso = isomorphism(PermGroup, G)
 Group homomorphism
@@ -1268,13 +1268,13 @@ generators, the number of relators, and the relator lengths.
 # Examples
 ```jldoctest
 julia> F = free_group(3)
-Free group of rank 3
+Free group of rank 3 with 3 generators f1, f2, f3
 
 julia> G = quo(F, [gen(F,1)])[1]
-Finitely presented group of infinite order
+Finitely presented group of infinite order with 3 generators f1, f2, f3 and 1 relator
 
 julia> simplified_fp_group(G)[1]
-Finitely presented group of infinite order
+Finitely presented group of infinite order with 2 generators f2, f3
 ```
 """
 function simplified_fp_group(G::FPGroup)

--- a/src/Groups/libraries/perfectgroups.jl
+++ b/src/Groups/libraries/perfectgroups.jl
@@ -106,7 +106,7 @@ julia> gens(ans)
  (2,3,4)
 
 julia> perfect_group(FPGroup, 60, 1)
-Finitely presented group of order 60
+Finitely presented group of order 60 with 2 generators a, b and 3 relators
 
 julia> gens(ans)
 2-element Vector{FPGroupElem}:

--- a/src/Groups/libraries/smallgroups.jl
+++ b/src/Groups/libraries/smallgroups.jl
@@ -73,13 +73,13 @@ solvable, otherwise it will be of type `PermGroup`.
 # Examples
 ```jldoctest
 julia> small_group(60, 4)
-Pc group of order 60
+Pc group of order 60 with 4 generators f1, f2, f3, f4
 
 julia> small_group(60, 5)
 Permutation group of degree 5 and order 60
 
 julia> small_group(PcGroup, 60, 4)
-Pc group of order 60
+Pc group of order 60 with 4 generators f1, f2, f3, f4
 ```
 """
 function small_group(::Type{T}, n::IntegerUnion, m::IntegerUnion) where T
@@ -188,17 +188,17 @@ List all abelian non-cyclic groups of order 12:
 ```jldoctest
 julia> all_small_groups(12, !is_cyclic, is_abelian)
 1-element Vector{PcGroup}:
- Pc group of order 12
+ Pc group of order 12 with 3 generators f1, f2, f3
 ```
 
 List groups of order 1 to 10 which are not abelian:
 ```jldoctest
 julia> all_small_groups(1:10, !is_abelian)
 4-element Vector{PcGroup}:
- Pc group of order 6
- Pc group of order 8
- Pc group of order 8
- Pc group of order 10
+ Pc group of order 6 with 2 generators f1, f2
+ Pc group of order 8 with 3 generators f1, f2, f3
+ Pc group of order 8 with 3 generators f1, f2, f3
+ Pc group of order 10 with 2 generators f1, f2
 ```
 """
 function all_small_groups(L...)

--- a/src/Groups/pcgroup.jl
+++ b/src/Groups/pcgroup.jl
@@ -42,7 +42,7 @@ It describes a free abelian group of rank `n`.
 # Examples
 ```jldoctest
 julia> G = pc_group(collector(2))
-Pc group of infinite order
+Pc group of infinite order with 2 generators g1, g2
 
 julia> is_abelian(G)
 true
@@ -447,7 +447,7 @@ julia> Oscar.set_relative_orders!(c, [2, 3])
 julia> Oscar.set_conjugate!(c, 2, 1, [2 => 2])
 
 julia> gg = pc_group(c)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> describe(gg)
 "S3"
@@ -482,7 +482,7 @@ each entry corresponding to a group generator.
 
 ```jldoctest
 julia> g = abelian_group(PcGroup, [0, 5])
-Pc group of infinite order
+Pc group of infinite order with 2 generators g1, g2
 
 julia> x = g[1]^-3 * g[2]^-3
 g1^-3*g2^2
@@ -495,7 +495,7 @@ julia> exponent_vector(x)
 
 ```jldoctest
 julia> gg = small_group(6, 1)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> x = gg[1]^5*gg[2]^-4
 f1*f2^2
@@ -531,7 +531,7 @@ with respect to the defining generators. For generators with infinite order, we 
 
 ```jldoctest
 julia> g = abelian_group(PcGroup, [0, 5])
-Pc group of infinite order
+Pc group of infinite order with 2 generators g1, g2
 
 julia> x = g[1]^-3 * g[2]^-3
 g1^-3*g2^2
@@ -542,7 +542,7 @@ julia> relative_order(x)
 
 ```jldoctest
 julia> gg = small_group(6, 1)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> x = gg[1]^5*gg[2]^-4
 f1*f2^2
@@ -575,7 +575,7 @@ Return the depth of `g` as integer, relative to the defining generators.
 
 ```jldoctest
 julia> g = abelian_group(PcGroup, [0, 5])
-Pc group of infinite order
+Pc group of infinite order with 2 generators g1, g2
 
 julia> x = g[1]^-3 * g[2]^-3
 g1^-3*g2^2
@@ -586,7 +586,7 @@ julia> depth(x)
 
 ```jldoctest
 julia> gg = small_group(6, 1)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> x = gg[1]^5*gg[2]^-4
 f1*f2^2
@@ -615,7 +615,7 @@ relative to the defining generators. Throws an error if `g` is the neutral eleme
 
 ```jldoctest
 julia> g = abelian_group(PcGroup, [0, 5])
-Pc group of infinite order
+Pc group of infinite order with 2 generators g1, g2
 
 julia> x = g[1]^-3 * g[2]^-3
 g1^-3*g2^2
@@ -626,7 +626,7 @@ julia> leading_exponent(x)
 
 ```jldoctest
 julia> gg = small_group(6, 1)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> x = gg[1]^5*gg[2]^-4
 f1*f2^2
@@ -661,7 +661,7 @@ Return the Hirsch length of `G`.
 
 ```jldoctest
 julia> g = abelian_group(PcGroup, [0, 5])
-Pc group of infinite order
+Pc group of infinite order with 2 generators g1, g2
 
 julia> hirsch_length(g)
 1
@@ -669,7 +669,7 @@ julia> hirsch_length(g)
 
 ```jldoctest
 julia> gg = small_group(6, 1)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> hirsch_length(gg)
 0
@@ -701,7 +701,7 @@ See also [`syllables(::Union{PcGroupElem, SubPcGroupElem})`](@ref).
 
 ```jldoctest
 julia> g = abelian_group(PcGroup, [0, 5])
-Pc group of infinite order
+Pc group of infinite order with 2 generators g1, g2
 
 julia> x = g[1]^-3 * g[2]^-3
 g1^-3*g2^2
@@ -717,7 +717,7 @@ julia> letters(x)
 
 ```jldoctest
 julia> gg = small_group(6, 1)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> x = gg[1]^5*gg[2]^-4
 f1*f2^2
@@ -758,7 +758,7 @@ See also [`letters(::Union{PcGroupElem, SubPcGroupElem})`](@ref).
 
 ```jldoctest
 julia> gg = small_group(6, 1)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> x = gg[1]^5*gg[2]^-4
 f1*f2^2
@@ -777,7 +777,7 @@ true
 
 ```jldoctest
 julia> g = abelian_group(PcGroup, [5, 0])
-Pc group of infinite order
+Pc group of infinite order with 2 generators g1, g2
 
 julia> x = g[1]^-3 * g[2]^-3
 g1^2*g2^-3
@@ -862,12 +862,12 @@ Return a collector object for `G`.
 # Examples
 ```jldoctest
 julia> g = small_group(12, 3)
-Pc group of order 12
+Pc group of order 12 with 3 generators f1, f2, f3
 
 julia> c = collector(g);
 
 julia> gc = pc_group(c)
-Pc group of order 12
+Pc group of order 12 with 3 generators f1, f2, f3
 
 julia> is_isomorphic(g, gc)
 true

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -180,12 +180,12 @@ julia> normal_subgroups(symmetric_group(5))
 
 julia> normal_subgroups(quaternion_group(8))
 6-element Vector{SubPcGroup}:
- Sub-pc group of order 8
- Sub-pc group of order 4
- Sub-pc group of order 4
- Sub-pc group of order 4
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 8 with 3 generators x, y, y2
+ Sub-pc group of order 4 with 2 generators y, y2
+ Sub-pc group of order 4 with 2 generators x*y*y2, y2
+ Sub-pc group of order 4 with 2 generators x, y2
+ Sub-pc group of order 2 with 1 generator y2
+ Sub-pc group of order 1 with 0 generators
 ```
 """
 @gapattribute normal_subgroups(G::GAPGroup) =
@@ -206,9 +206,9 @@ julia> maximal_normal_subgroups(symmetric_group(4))
 
 julia> maximal_normal_subgroups(quaternion_group(8))
 3-element Vector{SubPcGroup}:
- Sub-pc group of order 4
- Sub-pc group of order 4
- Sub-pc group of order 4
+ Sub-pc group of order 4 with 2 generators y2, x
+ Sub-pc group of order 4 with 2 generators y2, y
+ Sub-pc group of order 4 with 2 generators y2, x*y
 ```
 """
 @gapattribute maximal_normal_subgroups(G::GAPGroup) =
@@ -229,7 +229,7 @@ julia> minimal_normal_subgroups(symmetric_group(4))
 
 julia> minimal_normal_subgroups(quaternion_group(8))
 1-element Vector{SubPcGroup}:
- Sub-pc group of order 2
+ Sub-pc group of order 2 with 1 generator y2
 ```
 """
 @gapattribute minimal_normal_subgroups(G::GAPGroup) =
@@ -251,9 +251,9 @@ julia> characteristic_subgroups(symmetric_group(3))
 
 julia> characteristic_subgroups(quaternion_group(8))
 3-element Vector{SubPcGroup}:
- Sub-pc group of order 8
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 8 with 3 generators x, y, y2
+ Sub-pc group of order 2 with 1 generator y2
+ Sub-pc group of order 1 with 0 generators
 ```
 """
 @gapattribute characteristic_subgroups(G::GAPGroup) =
@@ -344,10 +344,10 @@ julia> chief_series(alternating_group(4))
 
 julia> chief_series(quaternion_group(8))
 4-element Vector{SubPcGroup}:
- Sub-pc group of order 8
- Sub-pc group of order 4
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 8 with 3 generators x, y, y2
+ Sub-pc group of order 4 with 2 generators y, y2
+ Sub-pc group of order 2 with 1 generator y2
+ Sub-pc group of order 1 with 0 generators
 ```
 """
 @gapattribute chief_series(G::GAPGroup) = _as_subgroups(G, GAP.Globals.ChiefSeries(GapObj(G)))
@@ -373,10 +373,10 @@ julia> composition_series(alternating_group(4))
 
 julia> composition_series(quaternion_group(8))
 4-element Vector{SubPcGroup}:
- Sub-pc group of order 8
- Sub-pc group of order 4
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 8 with 3 generators x, y, y2
+ Sub-pc group of order 4 with 2 generators y, y2
+ Sub-pc group of order 2 with 1 generator y2
+ Sub-pc group of order 1 with 0 generators
 ```
 """
 @gapattribute composition_series(G::GAPGroup) = _as_subgroups(G, GAP.Globals.CompositionSeries(GapObj(G)))
@@ -394,11 +394,11 @@ An exception is thrown if $G$ is not a $p$-group.
 ```jldoctest
 julia> jennings_series(dihedral_group(16))
 5-element Vector{SubPcGroup}:
- Sub-pc group of order 16
- Sub-pc group of order 4
- Sub-pc group of order 2
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 16 with 4 generators f1, f2, f3, f4
+ Sub-pc group of order 4 with 2 generators f3, f4
+ Sub-pc group of order 2 with 1 generator f4
+ Sub-pc group of order 2 with 1 generator f4
+ Sub-pc group of order 1 with 1 generator <identity> of ...
 
 julia> jennings_series(dihedral_group(10))
 ERROR: ArgumentError: group must be a p-group
@@ -457,14 +457,14 @@ See also [`upper_central_series`](@ref) and [`nilpotency_class`](@ref).
 ```jldoctest
 julia> lower_central_series(dihedral_group(8))
 3-element Vector{SubPcGroup}:
- Sub-pc group of order 8
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 8 with 3 generators f1, f2, f3
+ Sub-pc group of order 2 with 1 generator f3
+ Sub-pc group of order 1 with 1 generator <identity> of ...
 
 julia> lower_central_series(dihedral_group(12))
 2-element Vector{SubPcGroup}:
- Sub-pc group of order 12
- Sub-pc group of order 3
+ Sub-pc group of order 12 with 3 generators f1, f2, f3
+ Sub-pc group of order 3 with 1 generator f3
 
 julia> lower_central_series(symmetric_group(4))
 2-element Vector{PermGroup}:
@@ -493,14 +493,14 @@ See also [`lower_central_series`](@ref) and [`nilpotency_class`](@ref).
 ```jldoctest
 julia> upper_central_series(dihedral_group(8))
 3-element Vector{SubPcGroup}:
- Sub-pc group of order 8
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 8 with 3 generators f3, f1, f2
+ Sub-pc group of order 2 with 1 generator f3
+ Sub-pc group of order 1 with 0 generators
 
 julia> upper_central_series(dihedral_group(12))
 2-element Vector{SubPcGroup}:
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 2 with 1 generator f2*f3
+ Sub-pc group of order 1 with 0 generators
 
 julia> upper_central_series(symmetric_group(4))
 1-element Vector{PermGroup}:
@@ -1012,7 +1012,7 @@ julia> schur_multiplier(symmetric_group(4))
 Z/2
 
 julia> schur_multiplier(PcGroup, alternating_group(6))
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> schur_multiplier(abelian_group([2, 12]))
 Z/2
@@ -1151,9 +1151,9 @@ julia> derived_series(symmetric_group(5))
 
 julia> derived_series(dihedral_group(8))
 3-element Vector{SubPcGroup}:
- Sub-pc group of order 8
- Sub-pc group of order 2
- Sub-pc group of order 1
+ Sub-pc group of order 8 with 3 generators f1, f2, f3
+ Sub-pc group of order 2 with 1 generator f3
+ Sub-pc group of order 1 with 0 generators
 ```
 """
 @gapattribute derived_series(G::GAPGroup) = _as_subgroups(G, GAP.Globals.DerivedSeriesOfGroup(GapObj(G)))

--- a/test/book/cornerstones/groups/actions.jlcon
+++ b/test/book/cornerstones/groups/actions.jlcon
@@ -6,7 +6,7 @@ G-set of
 julia> G = dihedral_group(6);
 
 julia> U = sub(G, [g for g in gens(G) if order(g) == 2])[1]
-Sub-pc group of order 2
+Sub-pc group of order 2 with 1 generator f1
 
 julia> r = right_cosets(G, U)
 Right cosets of
@@ -14,7 +14,7 @@ Right cosets of
   pc group of order 6
 
 julia> acting_group(r)
-Pc group of order 6
+Pc group of order 6 with 2 generators f1, f2
 
 julia> collect(r)
 3-element Vector{GroupCoset{PcGroup, SubPcGroup, PcGroupElem}}:
@@ -49,7 +49,7 @@ julia> function optimal_transitive_perm_rep(G)
        end;
 
 julia> U = dihedral_group(8)
-Pc group of order 8
+Pc group of order 8 with 3 generators f1, f2, f3
 
 julia> optimal_transitive_perm_rep(U)
 Group homomorphism

--- a/test/book/cornerstones/groups/intro.jlcon
+++ b/test/book/cornerstones/groups/intro.jlcon
@@ -81,7 +81,7 @@ julia> is_isomorphic(ans, G_perm)
 true
 
 julia> G_fp = fp_group(G_perm)
-Finitely presented group of order 10
+Finitely presented group of order 10 with 2 generators F1, F2 and 3 relators
 
 julia> gens(G_fp)
 2-element Vector{FPGroupElem}:
@@ -95,7 +95,7 @@ julia> relators(G_fp)
  F2^5
 
 julia> F = free_group(2)
-Free group of rank 2
+Free group of rank 2 with 2 generators f1, f2
 
 julia> G_cox, _ = quo(F, [F[1]^2, F[2]^2, (F[1]*F[2])^5])
 (Finitely presented group, Hom: F -> G_cox)
@@ -133,7 +133,7 @@ julia> describe(quo(H, H2)[1])
 "(C3 x C3) : C2"
 
 julia> dihedral_group(10)
-Pc group of order 10
+Pc group of order 10 with 2 generators f1, f2
 
 julia> dihedral_group(PermGroup, 10)
 Permutation group of degree 5


### PR DESCRIPTION
Yet another set of changes taken from PR #/2878 which we can discuss here independently.

This is the first one close to the original goal of PR #2878 in that it prints information about generators -- but restricted to the possibly least controversial cases. The ones for permutation resp. matrix groups will come in separate future PRs (and can thus be accepted or rejected independently from these changes here)