### PR TITLE
Remove `refs_key`

### DIFF
--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -27,7 +27,7 @@ const BasicTypeUnion = Union{String, QQFieldElem, Symbol,
 include("serializers.jl")
 
 const type_key = :_type
-const refs_key = :_refs
+
 ################################################################################
 # Meta Data
 

--- a/src/Serialization/serializers.jl
+++ b/src/Serialization/serializers.jl
@@ -165,7 +165,7 @@ end
 
 function handle_refs(s::SerializerState)
   if !isempty(s.refs) 
-    save_data_dict(s, refs_key) do
+    save_data_dict(s, :_refs) do
       for id in s.refs
         ref_obj = global_serializer_state.id_to_obj[id]
         s.key = Symbol(id)
@@ -257,10 +257,7 @@ end
 
 function deserializer_open(io::IO, serializer::OscarSerializer, with_attrs::Bool)
   obj = JSON3.read(io)
-  refs = nothing
-  if haskey(obj, refs_key)
-    refs = obj[refs_key]
-  end
+  refs = get(obj, :_refs, nothing)
   
   return DeserializerState(serializer, obj, nothing, refs, with_attrs)
 end


### PR DESCRIPTION
Having a constant that is only used in two places seems like overkill.
