### PR TITLE
Fix derivative for graded rings

### DIFF
--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -1,4 +1,3 @@
-
 @attributes mutable struct MPolyDecRing{T, S} <: AbstractAlgebra.MPolyRing{T}
   R::S
   D::FinGenAbGroup
@@ -994,6 +993,8 @@ function finish(M::MPolyBuildCtx{<:MPolyDecRingElem})
   f = combine_like_terms!(M.poly.f)
   return parent(M.poly)(f)
 end
+
+derivative(f::MPolyDecRingElem, n::Int) = parent(f)(derivative(forget_grading(f),n))
 
 function jacobian_matrix(f::MPolyDecRingElem)
   R = parent(f)

--- a/test/AlgebraicGeometry/Schemes/ProjectiveSchemes.jl
+++ b/test/AlgebraicGeometry/Schemes/ProjectiveSchemes.jl
@@ -41,6 +41,14 @@
   g = map_on_affine_cones(phi)
 
   #@test is_well_defined(phi) # deprecated
+
+  # This makes sure that `derivative` works correctly
+  I = grassmann_pluecker_ideal(2, 5);
+  S, _ = grade(base_ring(I));
+  I = ideal(S, S.(gens(I)));
+  P = projective_scheme(I);
+  R = ambient_coordinate_ring(P);
+  mat = jacobian_matrix(R, gens(I));
 end
 
 @testset "projective_schemes_2" begin


### PR DESCRIPTION
Fixing a strange bug.

```
julia> I = grassmann_pluecker_ideal(2, 5);

julia> S, _ = grade(base_ring(I));

julia> I = ideal(S, S.(gens(I)));

julia> P = projective_scheme(I);

julia> R = ambient_coordinate_ring(P);

julia> mat = jacobian_matrix(R, gens(I))
ERROR: MethodError: no method matching setcoeff!(::MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}, ::Int64, ::QQFieldElem)
```

Fix due to @simonbrandhorst 