### PR TITLE
Support `kernel` of maps with Laurent polynomials as codomain

### DIFF
--- a/src/Rings/MPolyMap/AffineAlgebras.jl
+++ b/src/Rings/MPolyMap/AffineAlgebras.jl
@@ -284,6 +284,11 @@ function preimage(
   return ideal(domain(f), help_map.(gens(K)))
 end
 
+@attr Any function kernel(f::MPolyAnyMap{<:Union{MPolyRing, MPolyQuoRing}, <:Generic.LaurentMPolyWrapRing, <:Any, <:Any})
+  C = codomain(f)
+  return preimage(f, ideal(C, [zero(C)]))
+end
+
 # Let F: K[x]/I_1 -> K[y]/I_2, x_i \mapsto f_i .
 # Construct the polynomial ring K[y, x], the natural maps K[x] -> K[y, x]
 # and K[y, x] -> K[y], and the ideal I_2 + (y_i - f_i) in it.

--- a/src/Rings/Rings.jl
+++ b/src/Rings/Rings.jl
@@ -13,7 +13,9 @@ include("oscar_singular.jl")
 
 include("special_ideals.jl")
 
+
 include("MPolyMap/Types.jl")
+include("Laurent.jl")
 include("MPolyMap/MPolyAnyMap.jl")
 include("MPolyMap/MPolyRing.jl")
 include("MPolyMap/MPolyQuo.jl")
@@ -32,7 +34,6 @@ include("NumberField.jl")
 include("FunctionField.jl")
 include("AbelianClosure.jl")
 include("AlgClosureFp.jl")
-include("Laurent.jl")
 include("binomial_ideals.jl")
 
 include("PBWAlgebra.jl")

--- a/test/Rings/MPolyAnyMap/AffineAlgebras.jl
+++ b/test/Rings/MPolyAnyMap/AffineAlgebras.jl
@@ -83,3 +83,14 @@ end
   phi = hom(Q, A, gens(A))
   @test iszero(kernel(phi))
 end
+
+@testset "Laurent codomain" begin
+  R, = polynomial_ring(QQ, 4)
+  S, (x1, x2) = laurent_polynomial_ring(QQ, 2)
+  f = hom(R, S, [x1, x2, x1^-2*x2^5, x1^-1*x2^3])
+  K = kernel(f)
+  @test all(is_zero, f.(gens(K)))
+  Q, = quo(R, K)
+  g = hom(Q, S, [x1, x2, x1^-2*x2^5, x1^-1*x2^3])
+  @test is_zero(kernel(g))
+end


### PR DESCRIPTION
@lkastner this allows:
```
julia> Hmat = matrix(ZZ, H)
[ 1   0]
[ 0   1]
[-2   5]
[-1   3]

julia> R,_ = polynomial_ring(QQ,nrows(Hmat));

julia> S,x = laurent_polynomial_ring(QQ, ncols(Hmat));

julia> f = hom(R, S, [prod(x.^Hmat[i,:]) for i in (1:nrows(Hmat))])
Ring homomorphism
  from multivariate polynomial ring in 4 variables over QQ
  to multivariate Laurent polynomial ring in 2 variables over QQ
defined by
  x1 -> x1
  x2 -> x2
  x3 -> x1^-2*x2^5
  x4 -> x1^-1*x2^3

julia> kernel(f)
Ideal generated by
  x2*x3 - x4^2
  -x1*x3 + x2^2*x4
  -x1*x4 + x2^3
  -x1*x3^2 + x2*x4^3
  -x1*x3^3 + x4^5
```