### PR TITLE
Change `root_of_unity(K::QQAbField, n::Int)` to return always the root corresponding to $\exp(2\pi i/n)$

### DIFF
--- a/docs/src/NumberTheory/abelian_closure.md
+++ b/docs/src/NumberTheory/abelian_closure.md
@@ -6,12 +6,15 @@ DocTestSetup = Oscar.doctestsetup()
 
 # Abelian closure of the rationals
 
-The abelian closure $\mathbf{Q}^\text{ab}$ is the maximal abelian extension of $\mathbf{Q}$
-inside a fixed algebraic closure and can explicitly described as
+The abelian closure $\mathbf{Q}^\text{ab}$ is the maximal abelian extension
+of $\mathbf{Q}$ inside a fixed algebraic closure
+and can explicitly described as
 ```math
 \mathbf{Q}^{\mathrm{ab}} = \mathbf{Q}(\zeta_n \mid n \in \mathbf{N}),
 ```
-the union of all cyclotomic extensions. Here for $n \in \mathbf{N}$ we denote by $\zeta_n$ a primitive $n$-th root of unity.
+the union of all cyclotomic extensions.
+Here for $n \in \mathbf{N}$ we denote by $\zeta_n$ the primitive $n$-th root
+of unity that corresponds to $\exp(2\pi i/n)$.
 
 ## Creation of the abelian closure and elements
 

--- a/src/Rings/AbelianClosure.jl
+++ b/src/Rings/AbelianClosure.jl
@@ -249,7 +249,7 @@ julia> root_of_unity(K, 6) == z(6)
 true
 ```
 """
-function root_of_unity(K::QQAbField{AbsSimpleNumField}, n::Int)
+function root_of_unity(K::QQAbField, n::Int)
   # Represent the root in the smallest possible cyclotomic field.
   if n % 2 == 0 && n % 4 != 0
     c = div(n, 2)
@@ -260,21 +260,7 @@ function root_of_unity(K::QQAbField{AbsSimpleNumField}, n::Int)
   if c != n
     z = -z^div(c+1, 2)
   end
-  return QQAbFieldElem{AbsSimpleNumFieldElem}(z, c)
-end
-
-function root_of_unity(K::QQAbField{AbsNonSimpleNumField}, n::Int)
-  # Represent the root in the smallest possible cyclotomic field.
-  if n % 2 == 0 && n % 4 != 0
-    c = div(n, 2)
-  else
-    c = n
-  end
-  K, z = cyclotomic_field(K, c)
-  if c != n
-    z = -z^div(c+1, 2)
-  end
-  return QQAbFieldElem{AbsNonSimpleNumFieldElem}(z, c)
+  return QQAbFieldElem(z, c)
 end
 
 function root_of_unity2(K::QQAbField, c::Int)

--- a/src/Rings/AbelianClosure.jl
+++ b/src/Rings/AbelianClosure.jl
@@ -100,6 +100,9 @@ const _QQAbGen_sparse = QQAbFieldGen(_QQAb_sparse)
 Return a pair `(K, z)` consisting of the abelian closure `K` of the rationals
 and a generator `z` that can be used to construct primitive roots of unity in
 `K`.
+For each positive  integer `n`, `z(n)` is the primitive `n`-th root of unity
+that corresponds to the complex number $\exp(2\pi i/n)$.
+In particular, we have `z(n)^m = z(div(n, m))`, for all divisors `m` of `n`.
 
 An optional keyword argument `sparse` can be set to `true` to switch to a 
 sparse representation. Depending on the application this can be much faster
@@ -233,40 +236,51 @@ Hecke.data(a::QQAbFieldElem) = a.data
 #
 ################################################################################
 
-# This function finds a primitive root of unity in our field, note this is
-# not always e^(2*pi*i)/n
+@doc raw"""
+    root_of_unity(K::QQAbField, n::Int)
 
+Return the root of unity $\exp(2\pi i/n)$ as an element of `K`.
+
+# Examples
+```jldocstring
+julia> K, z = abelian_closure(QQ);
+
+julia> root_of_unity(K, 6) == z(6)
+true
+```
+"""
 function root_of_unity(K::QQAbField{AbsSimpleNumField}, n::Int)
+  # Represent the root in the smallest possible cyclotomic field.
   if n % 2 == 0 && n % 4 != 0
     c = div(n, 2)
   else
     c = n
   end
   K, z = cyclotomic_field(K, c)
-  if c == n
-    return QQAbFieldElem{AbsSimpleNumFieldElem}(z, c)
-  else
-    return QQAbFieldElem{AbsSimpleNumFieldElem}(-z, c)
+  if c != n
+    z = -z^div(c+1, 2)
   end
+  return QQAbFieldElem{AbsSimpleNumFieldElem}(z, c)
 end
 
 function root_of_unity(K::QQAbField{AbsNonSimpleNumField}, n::Int)
+  # Represent the root in the smallest possible cyclotomic field.
   if n % 2 == 0 && n % 4 != 0
     c = div(n, 2)
   else
     c = n
   end
   K, z = cyclotomic_field(K, c)
-  if c == n
-    return QQAbFieldElem{AbsNonSimpleNumFieldElem}(z, c)
-  else
-    return QQAbFieldElem{AbsNonSimpleNumFieldElem}(-z, c)
+  if c != n
+    z = -z^div(c+1, 2)
   end
+  return QQAbFieldElem{AbsNonSimpleNumFieldElem}(z, c)
 end
 
-
 function root_of_unity2(K::QQAbField, c::Int)
-  # This function returns the primitive root of unity e^(2*pi*i/n)
+  # This function returns the primitive root of unity e^(2*pi*i/c),
+  # as an element of the `c`-th cyclotomic field,
+  # also if `mod(c, 4 ) = 2` holds.
   K, z = cyclotomic_field(K, c)
   return QQAbFieldElem(z, c)
 end

--- a/test/Rings/AbelianClosure.jl
+++ b/test/Rings/AbelianClosure.jl
@@ -156,6 +156,14 @@
     @test is_negative(b)
     @test_throws DomainError x < n
     @test_throws DomainError y < F(n)
+
+    # compatibility of roots of unity in `K` and `F`
+    i = F(z(4))
+    for n in 1:20
+      @test z(n) == root_of_unity(K, n)
+      @test all(d -> z(n)^d == z(div(n, d)), divisors(n))
+      @test F(z(n)) == cospi(F(2)/n) + i*sinpi(F(2)/n)
+    end
   end
 
   @testset "Conversion to Float64 and ComplexF64" begin


### PR DESCRIPTION
The result shall correspond to $\exp(2\pi i/n)$, also if `mod(n, 4) = 2` holds, in order to be consistent with roots in the algebraic closure of `QQ`.

This change is breaking in the sense that `root_of_unity` (and `z`) return different elements than before.

resolves #5069

As far as I understand, the idea of the old code was to create the `n`-th root in the minimal possible cyclotomic field,
which is the `n/2`-th cyclotomic field if `mod(n, 4) = 2` holds. (This idea is kept also in the current pull request.)
Under this assumption, one has to compute some power in order to get the root that corresponds to $\exp(2\pi i/n)$;
perhaps the idea was to avoid this powering; in order to get *some* primitive `n`-th root of unity, it is enough to negate a given primitive `n/2`-th root of unity.