### PR TITLE
Fix `show` for `Oscar.Serialization.type_params`

### DIFF
--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -18,6 +18,8 @@ using ..Oscar: _grading,
   scalar_types,
   VERSION_NUMBER
 
+using ..Oscar: is_terse, Lowercase, pretty, terse
+
 using Distributed: RemoteChannel
 
 # This type should not be exported and should be before serializers


### PR DESCRIPTION
With this:
```julia-repl
julia> Oscar.Serialization.type_params(ZZ)
Type parameter for ZZRing nothing
```
Without this patch this runs into an error.