### PR TITLE
add `induce` for `GSetBySubgroupTransversal`

### DIFF
--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -500,7 +500,7 @@ end
 
 Return the action function that is obtained by inducing `actfun` along `phi`.
 
-That means, given a groups ``G`` and ``H``, a set ``\Omega`` with action function ``f: \Omega \times G \to \Omega``
+That means, given groups ``G`` and ``H``, a set ``\Omega`` with action function ``f: \Omega \times G \to \Omega``
 and a homomorphism ``\phi: H \to G``, construct the action function
 $\Omega \times H \to \Omega, (\omega, h) \mapsto f(\omega, \phi(h))$.
 """

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -73,6 +73,7 @@ end
 
 """
     acting_group(Omega::GSetByElements)
+    acting_group(Omega::GSetBySubgroupTransversal)
 
 Return the group `G` acting on `Omega`.
 
@@ -171,7 +172,6 @@ end
 
 gset(G::T, seeds; closed::Bool = false) where T<:Group = gset_by_type(G, seeds, eltype(seeds); closed = closed)
 
-
 ## natural action of permutations on positive integers
 function gset_by_type(G::PermGroup, Omega, ::Type{T}; closed::Bool = false) where T<:IntegerUnion
   return GSetByElements(G, ^, Omega; closed = closed, check = false)
@@ -218,6 +218,16 @@ function gset_by_type(G::MatrixGroup{E, M}, Omega, ::Type{T}; closed::Bool = fal
 end
 
 ## (add more such actions: on sets of sets, on sets of tuples, ...)
+
+## another situation:
+## If a `G`-set `Omega` is given then view it as a `H`-set for a given group,
+## w.r.t. the action function of `Omega`.
+## For that, require that `H` is a subgroup of `G` in the sense of `is_subset`.
+
+function gset(H::T, Omega::GSet) where T<:Group
+  @req is_subset(H, acting_group(Omega)) "H must be a subgroup of acting_group(Omega)"
+  return gset(H, action_function(Omega), Omega; closed = true)
+end
 
 #############################################################################
 ##

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -315,6 +315,7 @@ end
 
 @doc raw"""
     induce(Omega::GSetByElements{T, S}, phi::GAPGroupHomomorphism{U, T}) where {T<:Group, U<:Group, S}
+    induce(Omega::GSetBySubgroupTransversal{TG, TH, S}, phi::GAPGroupHomomorphism{U, TG}) where {TG<:Group, TH<:Group, U<:Group, S}
 
 Return the G-set that is obtained by inducing the G-set `Omega` along `phi`.
 
@@ -847,6 +848,20 @@ end
   return GAPGroupHomomorphism(G, action_range(Omega), acthom)
 end
 
+############################################################################
+##
+##  For restricting a `GSetBySubgroupTransversal` via a group homomorphism,
+##  construct a `GSetByElements` from it.
+
+function induced_action_function(Omega::GSetBySubgroupTransversal{TG, TH, S}, phi::Map{U, TG}) where {TG<:Group, TH<:Group, U<:Group, S}
+  @req acting_group(Omega) == codomain(phi) "acting group of Omega must be the codomain of phi"
+  return induced_action(action_function(Omega), phi)
+end
+
+function induce(Omega::GSetBySubgroupTransversal{TG, TH, S}, phi::GAPGroupHomomorphism{U, TG}) where {TG<:Group, TH<:Group, U<:Group, S}
+  @req acting_group(Omega) == codomain(phi) "acting group of Omega must be the codomain of phi"
+  return GSetByElements(domain(phi), induced_action_function(Omega, phi), Omega; closed=true, check=false)
+end
 
 ############################################################################
 ##

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -396,7 +396,7 @@ end
 
 @testset "G-sets by right transversals" begin
   G = symmetric_group(5)
-  H = sylow_subgroup(G, 2)[1]
+  H, emb = sylow_subgroup(G, 2)
   Omega = right_cosets(G, H)
   @test AbstractAlgebra.PrettyPrinting.repr_terse(Omega) == "Right cosets of groups"
   @test isa(Omega, GSet)
@@ -458,6 +458,10 @@ end
   @test rep[1]
   @test x * rep[2] == y
   @test Oscar.action_function(Omega)(x, rep[2]) == y
+
+  # restrict to a subgroup (creates G-sets of a different type)
+  rest = induce(Omega, emb)
+  @test sort!(map(length, orbits(rest))) == [1, 2, 4, 8]
 end
 
 @testset "General G-set action" begin

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -462,6 +462,12 @@ end
   # restrict to a subgroup (creates G-sets of a different type)
   rest = induce(Omega, emb)
   @test sort!(map(length, orbits(rest))) == [1, 2, 4, 8]
+
+  # a "natural" way to restrict to a subgroup (less general than `induce`,
+  # internally represented in a different way than the `induce` result)
+  rest2 = gset(H, Omega)
+  @test sort!(map(length, orbits(rest2))) == [1, 2, 4, 8]
+  @test_throws ArgumentError gset(symmetric_group(6), Omega)
 end
 
 @testset "General G-set action" begin


### PR DESCRIPTION
Up to now, we had `induce` only for `GSetByElements`, but we want to restrict also a `GSetBySubgroupTransversal` to a subgroup:

```
G = symmetric_group(5);
H, emb = sylow_subgroup(G, 2);
Omega = right_cosets(G, H)
rest = induce(Omega, emb)
```

Note that the idea is to use the embedding map in the `induce` call, which means that the returned G-set is defined w.r.t. the function `induced_action_function(Omega, emb)`.

It might be of interest to support also a "direct" restriction to the subgroup `H` where this makes sense, i.e., something like `restrict(Omega, H)`.