### PR TITLE
return -inf instead of -1 for the empty projective scheme (issue #5090)

### DIFF
--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl
@@ -503,7 +503,7 @@ projective_scheme_type(::Type{T}) where {T<:AbsAffineScheme} = projective_scheme
 
 @attr Union{Int, NegInf} function dim(P::AbsProjectiveScheme{<:Field})
   d = dim(defining_ideal(P))
-  return d > 0 ? dim(defining_ideal(P)) - 1 : -inf
+  return d > 0 ? d - 1 : -inf
 end
 
 @attr Union{Int, NegInf} function codim(P::AbsProjectiveScheme{<:Field})

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Attributes.jl
@@ -502,7 +502,8 @@ projective_scheme_type(::Type{T}) where {T<:AbsAffineScheme} = projective_scheme
 ########################################################################
 
 @attr Union{Int, NegInf} function dim(P::AbsProjectiveScheme{<:Field})
-  return dim(defining_ideal(P))-1
+  d = dim(defining_ideal(P))
+  return d > 0 ? dim(defining_ideal(P)) - 1 : -inf
 end
 
 @attr Union{Int, NegInf} function codim(P::AbsProjectiveScheme{<:Field})


### PR DESCRIPTION
return `-inf` instead of -1 for the empty projective scheme