### PR TITLE
Revert "Set `OMP_NUM_THREADS=1` unconditionally (bandaid for #4806) (#4811)"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -93,7 +93,7 @@ jobs:
       - name: "Build package"
         uses: julia-actions/julia-buildpkg@v1
       - name: "limit OpenMP threads"
-        # if: runner.os == 'macOS' # commented out as bandaid for #4806
+        if: runner.os == 'macOS'
         # restrict number of openMP threads on macOS due to oversubscription
         run: echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
       - name: "Use multiple processes for self-hosted macOS runners"
@@ -248,7 +248,7 @@ jobs:
       - name: "Build package"
         uses: julia-actions/julia-buildpkg@v1
       - name: "limit OpenMP threads"
-        # if: runner.os == 'macOS' # commented out as bandaid for #4806
+        if: runner.os == 'macOS'
         # restrict number of openMP threads on macOS due to oversubscription
         run: echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
       - name: "Setup package"


### PR DESCRIPTION
Reverts oscar-system/Oscar.jl#4811. Resolves https://github.com/oscar-system/Oscar.jl/issues/4806.

Now that https://github.com/JuliaLang/julia/pull/58202 is released as part of julia 1.11.6, we can try to revert the workaround.