### PR TITLE
Speed up `degree(::GAPGroupClassFunction)`

### DIFF
--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -2850,7 +2850,7 @@ function Base.:^(chi::GAPGroupClassFunction, g::Union{GAPGroupElem, FinGenAbGrou
     ccl = conjugacy_classes(tbl)
     reps = [representative(c) for c in ccl]
     pi = [findfirst(x -> x^g in c, reps) for c in ccl]
-    return class_function(tbl, values(chi)[pi])
+    return class_function(tbl, chi[pi])
 end
 
 @doc raw"""

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -2654,11 +2654,11 @@ Return `chi[1]`, as an instance of `T`.
 """
 Nemo.degree(chi::GAPGroupClassFunction) = Nemo.degree(QQFieldElem, chi)::QQFieldElem
 
-Nemo.degree(::Type{QQFieldElem}, chi::GAPGroupClassFunction) = Nemo.coeff(values(chi)[1].data, 0)::QQFieldElem
+Nemo.degree(::Type{QQFieldElem}, chi::GAPGroupClassFunction) = Nemo.coeff(chi[1].data, 0)::QQFieldElem
 
-Nemo.degree(::Type{ZZRingElem}, chi::GAPGroupClassFunction) = ZZ(Nemo.coeff(values(chi)[1].data, 0))::ZZRingElem
+Nemo.degree(::Type{ZZRingElem}, chi::GAPGroupClassFunction) = ZZ(Nemo.coeff(chi[1].data, 0))::ZZRingElem
 
-Nemo.degree(::Type{QQAbFieldElem}, chi::GAPGroupClassFunction) = values(chi)[1]::QQAbFieldElem{AbsSimpleNumFieldElem}
+Nemo.degree(::Type{QQAbFieldElem}, chi::GAPGroupClassFunction) = chi[1]::QQAbFieldElem{AbsSimpleNumFieldElem}
 
 Nemo.degree(::Type{T}, chi::GAPGroupClassFunction) where T <: IntegerUnion = T(Nemo.degree(ZZRingElem, chi))::T
 

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -2671,7 +2671,7 @@ end
 # access character values by positions
 function Base.getindex(chi::GAPGroupClassFunction, v::AbstractVector{Int})
   vals = GAPWrap.ValuesOfClassFunction(GapObj(chi))
-  return [QQAbFieldElem(x) for x in vals]
+  return [QQAbFieldElem(vals[i]) for i in v]
 end
 
 # access character values by class name


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/5112.

With this change, only the actually used entries of the character are converted from GAP to Oscar, instead of all of them.

Speed comparison:
```julia
julia> T = character_table(small_group(512, 1));

julia> @time degree(chi);
  0.258867 seconds (26.98 k allocations: 22.903 MiB, 89.76% gc time) # master
  0.000072 seconds (17 allocations: 752 bytes) # this PR

julia> @time map(degree, T);
  7.928418 seconds (13.34 M allocations: 7.742 GiB, 5.83% gc time) # master
  0.001854 seconds (9.22 k allocations: 388.109 KiB) # this PR
```

cc @thofma 