### PR TITLE
Make `RootSpaceElem`, `DualRootSpaceElem` and `WeightLatticeElem` immutable

### DIFF
--- a/src/LieTheory/RootSystem.jl
+++ b/src/LieTheory/RootSystem.jl
@@ -829,50 +829,42 @@ function Base.:-(r::RootSpaceElem)
 end
 
 function zero!(r::RootSpaceElem)
-  r.vec = zero!(r.vec)
-  return r
-end
-
-function add!(rr::RootSpaceElem, r1::RootSpaceElem, r2::RootSpaceElem)
-  @req root_system(rr) === root_system(r1) === root_system(r2) "parent root system mismatch"
-  rr.vec = add!(rr.vec, r1.vec, r2.vec)
-  return rr
+  return RootSpaceElem(root_system(r), zero!(r.vec))
 end
 
 function neg!(rr::RootSpaceElem, r::RootSpaceElem)
   @req root_system(rr) === root_system(r) "parent root system mismatch"
-  rr.vec = neg!(rr.vec, r.vec)
-  return rr
+  return RootSpaceElem(root_system(rr), neg!(rr.vec, r.vec))
+end
+
+function add!(rr::RootSpaceElem, r1::RootSpaceElem, r2::RootSpaceElem)
+  @req root_system(rr) === root_system(r1) === root_system(r2) "parent root system mismatch"
+  return RootSpaceElem(root_system(rr), add!(rr.vec, r1.vec, r2.vec))
 end
 
 function sub!(rr::RootSpaceElem, r1::RootSpaceElem, r2::RootSpaceElem)
   @req root_system(rr) === root_system(r1) === root_system(r2) "parent root system mismatch"
-  rr.vec = sub!(rr.vec, r1.vec, r2.vec)
-  return rr
+  return RootSpaceElem(root_system(rr), sub!(rr.vec, r1.vec, r2.vec))
 end
 
 function mul!(rr::RootSpaceElem, r::RootSpaceElem, q::RationalUnionOrPtr)
   @req root_system(rr) === root_system(r) "parent root system mismatch"
-  rr.vec = mul!(rr.vec, r.vec, q)
-  return rr
+  return RootSpaceElem(root_system(rr), mul!(rr.vec, r.vec, q))
 end
 
 function mul!(rr::RootSpaceElem, q::RationalUnionOrPtr, r::RootSpaceElem)
   @req root_system(rr) === root_system(r) "parent root system mismatch"
-  rr.vec = mul!(rr.vec, q, r.vec)
-  return rr
+  return RootSpaceElem(root_system(rr), mul!(rr.vec, q, r.vec))
 end
 
 function addmul!(rr::RootSpaceElem, r::RootSpaceElem, q::RationalUnionOrPtr)
   @req root_system(rr) === root_system(r) "parent root system mismatch"
-  rr.vec = addmul!(rr.vec, r.vec, q)
-  return rr
+  return RootSpaceElem(root_system(rr), addmul!(rr.vec, r.vec, q))
 end
 
 function addmul!(rr::RootSpaceElem, q::RationalUnionOrPtr, r::RootSpaceElem)
   @req root_system(rr) === root_system(r) "parent root system mismatch"
-  rr.vec = addmul!(rr.vec, q, r.vec)
-  return rr
+  return RootSpaceElem(root_system(rr), addmul!(rr.vec, q, r.vec))
 end
 
 # ignore temp storage
@@ -881,14 +873,12 @@ addmul!(rr::RootSpaceElem, q::RationalUnionOrPtr, r::RootSpaceElem, t) = addmul!
 
 function submul!(rr::RootSpaceElem, r::RootSpaceElem, q::RationalUnionOrPtr)
   @req root_system(rr) === root_system(r) "parent root system mismatch"
-  rr.vec = submul!(rr.vec, r.vec, q)
-  return rr
+  return RootSpaceElem(root_system(rr), submul!(rr.vec, r.vec, q))
 end
 
 function submul!(rr::RootSpaceElem, q::RationalUnionOrPtr, r::RootSpaceElem)
   @req root_system(rr) === root_system(r) "parent root system mismatch"
-  rr.vec = submul!(rr.vec, q, r.vec)
-  return rr
+  return RootSpaceElem(root_system(rr), submul!(rr.vec, q, r.vec))
 end
 
 # ignore temp storage

--- a/src/LieTheory/RootSystem.jl
+++ b/src/LieTheory/RootSystem.jl
@@ -1235,50 +1235,42 @@ function Base.:-(r::DualRootSpaceElem)
 end
 
 function zero!(r::DualRootSpaceElem)
-  r.vec = zero!(r.vec)
-  return r
+  return DualRootSpaceElem(root_system(r), zero!(r.vec))
 end
 
 function add!(rr::DualRootSpaceElem, r1::DualRootSpaceElem, r2::DualRootSpaceElem)
   @req root_system(rr) === root_system(r1) === root_system(r2) "parent root system mismatch"
-  rr.vec = add!(rr.vec, r1.vec, r2.vec)
-  return rr
+  return DualRootSpaceElem(root_system(rr), add!(rr.vec, r1.vec, r2.vec))
 end
 
 function neg!(rr::DualRootSpaceElem, r::DualRootSpaceElem)
   @req root_system(rr) === root_system(r) "parent root system mismatch"
-  rr.vec = neg!(rr.vec, r.vec)
-  return rr
+  return DualRootSpaceElem(root_system(rr), neg!(rr.vec, r.vec))
 end
 
 function sub!(rr::DualRootSpaceElem, r1::DualRootSpaceElem, r2::DualRootSpaceElem)
   @req root_system(rr) === root_system(r1) === root_system(r2) "parent root system mismatch"
-  rr.vec = sub!(rr.vec, r1.vec, r2.vec)
-  return rr
+  return DualRootSpaceElem(root_system(rr), sub!(rr.vec, r1.vec, r2.vec))
 end
 
 function mul!(rr::DualRootSpaceElem, r::DualRootSpaceElem, q::RationalUnionOrPtr)
   @req root_system(rr) === root_system(r) "parent root system mismatch"
-  rr.vec = mul!(rr.vec, r.vec, q)
-  return rr
+  return DualRootSpaceElem(root_system(rr), mul!(rr.vec, r.vec, q))
 end
 
 function mul!(rr::DualRootSpaceElem, q::RationalUnionOrPtr, r::DualRootSpaceElem)
   @req root_system(rr) === root_system(r) "parent root system mismatch"
-  rr.vec = mul!(rr.vec, q, r.vec)
-  return rr
+  return DualRootSpaceElem(root_system(rr), mul!(rr.vec, q, r.vec))
 end
 
 function addmul!(rr::DualRootSpaceElem, r::DualRootSpaceElem, q::RationalUnionOrPtr)
   @req root_system(rr) === root_system(r) "parent root system mismatch"
-  rr.vec = addmul!(rr.vec, r.vec, q)
-  return rr
+  return DualRootSpaceElem(root_system(rr), addmul!(rr.vec, r.vec, q))
 end
 
 function addmul!(rr::DualRootSpaceElem, q::RationalUnionOrPtr, r::DualRootSpaceElem)
   @req root_system(rr) === root_system(r) "parent root system mismatch"
-  rr.vec = addmul!(rr.vec, q, r.vec)
-  return rr
+  return DualRootSpaceElem(root_system(rr), addmul!(rr.vec, q, r.vec))
 end
 
 # ignore temp storage
@@ -1289,14 +1281,12 @@ addmul!(rr::DualRootSpaceElem, q::RationalUnionOrPtr, r::DualRootSpaceElem, t) =
 
 function submul!(rr::DualRootSpaceElem, r::DualRootSpaceElem, q::RationalUnionOrPtr)
   @req root_system(rr) === root_system(r) "parent root system mismatch"
-  rr.vec = submul!(rr.vec, r.vec, q)
-  return rr
+  return DualRootSpaceElem(root_system(rr), submul!(rr.vec, r.vec, q))
 end
 
 function submul!(rr::DualRootSpaceElem, q::RationalUnionOrPtr, r::DualRootSpaceElem)
   @req root_system(rr) === root_system(r) "parent root system mismatch"
-  rr.vec = submul!(rr.vec, q, r.vec)
-  return rr
+  return DualRootSpaceElem(root_system(rr), submul!(rr.vec, q, r.vec))
 end
 
 # ignore temp storage

--- a/src/LieTheory/Types.jl
+++ b/src/LieTheory/Types.jl
@@ -76,7 +76,7 @@ end
 
 Type for coroots and linear combinations thereof.
 """
-mutable struct DualRootSpaceElem
+struct DualRootSpaceElem
   root_system::RootSystem
   vec::QQMatrix # the coordinate (row) vector with respect to the simple coroots
 
@@ -87,9 +87,9 @@ mutable struct DualRootSpaceElem
 
   `vec` must be a row vector of the same length as the rank of `R`.
   """
-  function DualRootSpaceElem(root_system::RootSystem, vec::QQMatrix)
-    @req size(vec) == (1, rank(root_system)) "Invalid dimension"
-    return new(root_system, vec)
+  function DualRootSpaceElem(R::RootSystem, vec::QQMatrix)
+    @req size(vec) == (1, rank(R)) "Invalid dimension"
+    return new(R, vec)
   end
 end
 

--- a/src/LieTheory/Types.jl
+++ b/src/LieTheory/Types.jl
@@ -54,7 +54,7 @@ end
 
 Type for roots and linear combinations thereof.
 """
-mutable struct RootSpaceElem
+struct RootSpaceElem
   root_system::RootSystem
   vec::QQMatrix # the coordinate (row) vector with respect to the simple roots
 

--- a/src/LieTheory/Types.jl
+++ b/src/LieTheory/Types.jl
@@ -117,7 +117,7 @@ end
 
 Type for weights and linear combinations thereof, elem type of `WeightLattice`.
 """
-mutable struct WeightLatticeElem <: AbstractAlgebra.AdditiveGroupElem
+struct WeightLatticeElem <: AbstractAlgebra.AdditiveGroupElem
   parent_lat::WeightLattice
   vec::ZZMatrix # the coordinate (row) vector with respect to the fundamental weights
 

--- a/src/LieTheory/WeightLattice.jl
+++ b/src/LieTheory/WeightLattice.jl
@@ -485,7 +485,9 @@ This is a mutating version of [`reflect(::WeightLatticeElem, ::Int)`](@ref).
 """
 function reflect!(w::WeightLatticeElem, s::Int)
   # the scalar `w.vec[s]` needs to be implicitly copied as it otherwise gets mutated by `submul!`
-  return WeightLatticeElem(parent(w), submul!(w.vec, view(cartan_matrix_tr(root_system(w)), s:s, :), w.vec[s]))
+  return WeightLatticeElem(
+    parent(w), submul!(w.vec, view(cartan_matrix_tr(root_system(w)), s:s, :), w.vec[s])
+  )
 end
 
 @doc raw"""

--- a/src/LieTheory/WeightLattice.jl
+++ b/src/LieTheory/WeightLattice.jl
@@ -196,50 +196,42 @@ function Base.:-(w::WeightLatticeElem)
 end
 
 function zero!(w::WeightLatticeElem)
-  w.vec = zero!(w.vec)
-  return w
-end
-
-function add!(wr::WeightLatticeElem, w1::WeightLatticeElem, w2::WeightLatticeElem)
-  @req parent(wr) === parent(w1) === parent(w2) "parent mismatch"
-  wr.vec = add!(wr.vec, w1.vec, w2.vec)
-  return wr
+  return WeightLatticeElem(parent(w), zero!(w.vec))
 end
 
 function neg!(wr::WeightLatticeElem, w::WeightLatticeElem)
   @req parent(wr) === parent(w) "parent mismatch"
-  wr.vec = neg!(wr.vec, w.vec)
-  return wr
+  return WeightLatticeElem(parent(wr), neg!(wr.vec, w.vec))
+end
+
+function add!(wr::WeightLatticeElem, w1::WeightLatticeElem, w2::WeightLatticeElem)
+  @req parent(wr) === parent(w1) === parent(w2) "parent mismatch"
+  return WeightLatticeElem(parent(wr), add!(wr.vec, w1.vec, w2.vec))
 end
 
 function sub!(wr::WeightLatticeElem, w1::WeightLatticeElem, w2::WeightLatticeElem)
   @req parent(wr) === parent(w1) === parent(w2) "parent mismatch"
-  wr.vec = sub!(wr.vec, w1.vec, w2.vec)
-  return wr
+  return WeightLatticeElem(parent(wr), sub!(wr.vec, w1.vec, w2.vec))
 end
 
 function mul!(wr::WeightLatticeElem, w::WeightLatticeElem, n::IntegerUnionOrPtr)
   @req parent(wr) === parent(w) "parent mismatch"
-  wr.vec = mul!(wr.vec, w.vec, n)
-  return wr
+  return WeightLatticeElem(parent(wr), mul!(wr.vec, w.vec, n))
 end
 
 function mul!(wr::WeightLatticeElem, n::IntegerUnionOrPtr, w::WeightLatticeElem)
   @req parent(wr) === parent(w) "parent mismatch"
-  wr.vec = mul!(wr.vec, n, w.vec)
-  return wr
+  return WeightLatticeElem(parent(wr), mul!(wr.vec, n, w.vec))
 end
 
 function addmul!(wr::WeightLatticeElem, w::WeightLatticeElem, n::IntegerUnionOrPtr)
   @req parent(wr) === parent(w) "parent mismatch"
-  wr.vec = addmul!(wr.vec, w.vec, n)
-  return wr
+  return WeightLatticeElem(parent(wr), addmul!(wr.vec, w.vec, n))
 end
 
 function addmul!(wr::WeightLatticeElem, n::IntegerUnionOrPtr, w::WeightLatticeElem)
   @req parent(wr) === parent(w) "parent mismatch"
-  wr.vec = addmul!(wr.vec, n, w.vec)
-  return wr
+  return WeightLatticeElem(parent(wr), addmul!(wr.vec, n, w.vec))
 end
 
 # ignore temp storage
@@ -250,14 +242,12 @@ addmul!(wr::WeightLatticeElem, n::IntegerUnionOrPtr, w::WeightLatticeElem, t) =
 
 function submul!(wr::WeightLatticeElem, w::WeightLatticeElem, n::IntegerUnionOrPtr)
   @req parent(wr) === parent(w) "parent mismatch"
-  wr.vec = submul!(wr.vec, w.vec, n)
-  return wr
+  return WeightLatticeElem(parent(wr), submul!(wr.vec, w.vec, n))
 end
 
 function submul!(wr::WeightLatticeElem, n::IntegerUnionOrPtr, w::WeightLatticeElem)
   @req parent(wr) === parent(w) "parent mismatch"
-  wr.vec = submul!(wr.vec, n, w.vec)
-  return wr
+  return WeightLatticeElem(parent(wr), submul!(wr.vec, n, w.vec))
 end
 
 # ignore temp storage
@@ -495,8 +485,7 @@ This is a mutating version of [`reflect(::WeightLatticeElem, ::Int)`](@ref).
 """
 function reflect!(w::WeightLatticeElem, s::Int)
   # the scalar `w.vec[s]` needs to be implicitly copied as it otherwise gets mutated by `submul!`
-  w.vec = submul!(w.vec, view(cartan_matrix_tr(root_system(w)), s:s, :), w.vec[s])
-  return w
+  return WeightLatticeElem(parent(w), submul!(w.vec, view(cartan_matrix_tr(root_system(w)), s:s, :), w.vec[s]))
 end
 
 @doc raw"""


### PR DESCRIPTION
BTW the two types look virtually identical. How about merging the two implementations into a single type `GenRootSpaceElem{dual}` where `dual` is a bool, and then have
```julia
const RootSpaceElem = GenRootSpaceElem{false}
const DualRootSpaceElem = GenRootSpaceElem{true}
```
