### PR TITLE
Fix multiplication of group cosets with group elements

### DIFF
--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -169,11 +169,11 @@ function Base.:*(c::GroupCoset, y::GAPGroupElem)
 end
 
 function Base.:*(y::GAPGroupElem, c::GroupCoset)
-   @assert y in c.G "element not in the group"
+   yy = c.G(y)
    if is_left(c)
-      return left_coset(c.H, y*representative(c))
+      return left_coset(c.H, yy*representative(c))
    else
-      return right_coset(c.H^(y^-1), y*representative(c))
+      return right_coset(c.H^(y^-1), yy*representative(c))
    end
 end
 

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -160,11 +160,11 @@ Base.:*(H::GAPGroup, g::GAPGroupElem) = right_coset(H,g)
 Base.:*(g::GAPGroupElem, H::GAPGroup) = left_coset(H,g)
 
 function Base.:*(c::GroupCoset, y::GAPGroupElem)
-   @assert y in c.G "element not in the group"
+   yy = c.G(y)
    if is_right(c)
-      return right_coset(c.H, representative(c)*y)
+      return right_coset(c.H, representative(c)*yy)
    else
-      return left_coset(c.H^y, representative(c)*y)
+      return left_coset(c.H^y, representative(c)*yy)
    end
 end
 

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -183,7 +183,7 @@ end
    @test_throws ArgumentError right_transversal(H, G)
    @test_throws ArgumentError left_transversal(H, G)
 
-   G = symmetric_group(5)
+   G, _ = stabilizer(symmetric_group(6), 6)  # smaller than the natural parent
    @testset "set comparison for cosets in PermGroup" begin
       x = G(cperm([1,2,3]))
       y = G(cperm([1,4,5]))
@@ -199,6 +199,7 @@ end
       lc = left_coset(H,x)
       dc = double_coset(H,x,K)
       @test rc==H*x
+      @test rc == rc * one(H)
       @test lc==x*H
       @test dc==H*x*K
       @test acting_group(rc) == H

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -201,6 +201,7 @@ end
       @test rc==H*x
       @test rc == rc * one(H)
       @test lc==x*H
+      @test lc == one(H) * lc
       @test dc==H*x*K
       @test acting_group(rc) == H
       @test acting_group(lc) == H
@@ -255,7 +256,7 @@ end
    end
    rc = L[1]
    r = representative(rc)
-   rc1 = right_coset(H, H[1]*r)
+   rc1 = right_coset(H, G(H[1])*r)
    @test representative(rc1) != representative(rc)
    @test rc1 == rc
    L = left_cosets(G,H)
@@ -273,7 +274,7 @@ end
    end
    lc = L[1]
    r = representative(lc)
-   lc1 = left_coset(H, r*H[1])
+   lc1 = left_coset(H, r*G(H[1]))
    @test representative(lc1) != representative(lc)
    @test lc1 == lc
    K = sub(G, gens(symmetric_group(3)) )[1]


### PR DESCRIPTION
In the result, the parent of the representative must be equal to the parent of the representative of the given coset, otherwise the equality test for cosets does not work as expected.

The problem has been noticed by @fieker.

(The problem had not been noticed up to now because the relevant tests used symmetric groups,
and the product of two permutation group elements with different parents gets a symmetric group as a parent.)