### PR TITLE
Fix printing for automorphism groups of `FinGenAbGroup` and `TorQuadModule`

### DIFF
--- a/src/Groups/abelian_aut.jl
+++ b/src/Groups/abelian_aut.jl
@@ -154,13 +154,21 @@ function _orthogonal_group(T::TorQuadModule, gensOT::Vector{ZZMatrix}; check::Bo
   return aut
 end
 
-function Base.show(io::IO, aut::AutomorphismGroup{TorQuadModule})
-  T = domain(aut)
+function Base.show(io::IO,  ::MIME"text/plain", OT::AutomorphismGroup{TorQuadModule})
   io = pretty(io)
-  n = ngens(aut)
-  print(IOContext(io, :compact => true), "Group of isometries of ", Lowercase(), T, " with ", ItemQuantity(n, "generator"))
+  println(io, "Orthogonal group of", Indent())
+  println(io, Lowercase(), OT.G)
+  print(io, Dedent(), "with ", ItemQuantity(ngens(OT), "generator"))
 end
-
+                                                                                                                                                                                        
+function Base.show(io::IO, OT::AutomorphismGroup{TorQuadModule})
+  if is_terse(io)
+    print(io, "Orthogonal group")
+  else
+    io = pretty(io)
+    print(io, "Orthogonal group of ", Lowercase(), OT.G)
+  end
+end 
 
 @doc raw"""
     matrix(f::AutomorphismGroupElem{TorQuadModule}) -> ZZMatrix
@@ -195,14 +203,18 @@ function defines_automorphism(G::TorQuadModule, M::ZZMatrix)
   return true
 end
 
-function Base.show(io::IO, ::MIME"text/plain", f::AutomorphismGroupElem{T}) where T<:TorQuadModule
+function Base.show(io::IO, ::MIME"text/plain", f::AutomorphismGroupElem{TorQuadModule})
   D = domain(parent(f))
   io = pretty(io)
-  println(IOContext(io, :compact => true), "Isometry of ", Lowercase(), D, " defined by")
-  print(io, Indent(), matrix(f), Dedent())
+  println(io, "Isometry of")
+  println(IOContext(io, :compact => true), Indent(), Lowercase(), D, Dedent())
+  println(io, "with matrix representation")
+  print(io, Indent())
+  show(io, MIME"text/plain"(), matrix(f))
+  print(io, Dedent())
 end
 
-function Base.show(io::IO, f::AutomorphismGroupElem{T}) where T<:TorQuadModule
+function Base.show(io::IO, f::AutomorphismGroupElem{TorQuadModule})
   print(io, matrix(f))
 end
 
@@ -434,7 +446,9 @@ Gram matrix quadratic form:
 [4//15]
 
 julia> OT = orthogonal_group(T)
-Group of isometries of finite quadratic module: Z/15 -> Q/2Z with 2 generators
+Orthogonal group of
+  finite quadratic module: Z/15 -> Q/2Z
+with 2 generators
 
 julia> T3inT = primary_part(T, 3)[2]
 Map
@@ -476,7 +490,9 @@ of the codomain of `i`.
 julia> T = torsion_quadratic_module(matrix(QQ, 2, 2, [2//3 0; 0 2//5]));
 
 julia> OT = orthogonal_group(T)
-Group of isometries of finite quadratic module: Z/15 -> Q/2Z with 2 generators
+Orthogonal group of
+  finite quadratic module: Z/15 -> Q/2Z
+with 2 generators
 
 julia> T3inT = primary_part(T, 3)[2]
 Map
@@ -484,7 +500,7 @@ Map
   to finite quadratic module: Z/15 -> Q/2Z
 
 julia> S, _ = stabilizer(OT, T3inT)
-(Group of isometries of finite quadratic module: Z/15 -> Q/2Z with 2 generators, Hom: group of isometries of finite quadratic module with 2 generators -> group of isometries of finite quadratic module with 2 generators)
+(Orthogonal group of finite quadratic module: Z/15 -> Q/2Z, Hom: orthogonal group -> orthogonal group)
 
 julia> order(S)
 4

--- a/src/Groups/abelian_aut.jl
+++ b/src/Groups/abelian_aut.jl
@@ -95,7 +95,7 @@ Map
 julia> T = torsion_quadratic_module(matrix(QQ, 2, 2, [2//3 0; 0 2//9]));
 
 julia> OT = orthogonal_group(T)
-Orthogonal group of
+Group of isometries of
   finite quadratic module: Z/3 x Z/9 -> Q/2Z
 with 3 generators
 
@@ -229,17 +229,17 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", OT::AutomorphismGroup{TorQuadModule})
   io = pretty(io)
-  println(io, "Orthogonal group of", Indent())
+  println(io, "Group of isometries of", Indent())
   println(io, Lowercase(), OT.G)
   print(io, Dedent(), "with ", ItemQuantity(ngens(OT), "generator"))
 end
                                                                                                                                                                                         
 function Base.show(io::IO, OT::AutomorphismGroup{TorQuadModule})
   if is_terse(io)
-    print(io, "Orthogonal group")
+    print(io, "Group of isometries")
   else
     io = pretty(io)
-    print(io, "Orthogonal group of ", Lowercase(), OT.G)
+    print(io, "Group of isometries of ", Lowercase(), OT.G)
   end
 end 
 
@@ -253,7 +253,7 @@ Return a matrix inducing `f`.
 julia> T = torsion_quadratic_module(matrix(QQ, 2, 2, [1//12 0; 0 2//9]));
 
 julia> OT = orthogonal_group(T)
-Orthogonal group of
+Group of isometries of
   finite quadratic module: Z/3 x Z/36 -> Q/2Z
 with 4 generators
 
@@ -331,7 +331,7 @@ Gram matrix quadratic form:
 [1//2   3//4]
 
 julia> OT = orthogonal_group(T)
-Orthogonal group of
+Group of isometries of
   finite quadratic module: (Z/4)^2 -> Q/2Z
 with 2 generators
 
@@ -561,7 +561,7 @@ Gram matrix quadratic form:
 [4//15]
 
 julia> OT = orthogonal_group(T)
-Orthogonal group of
+Group of isometries of
   finite quadratic module: Z/15 -> Q/2Z
 with 2 generators
 
@@ -605,7 +605,7 @@ of the codomain of `i`.
 julia> T = torsion_quadratic_module(matrix(QQ, 2, 2, [2//3 0; 0 2//5]));
 
 julia> OT = orthogonal_group(T)
-Orthogonal group of
+Group of isometries of
   finite quadratic module: Z/15 -> Q/2Z
 with 2 generators
 
@@ -615,7 +615,7 @@ Map
   to finite quadratic module: Z/15 -> Q/2Z
 
 julia> S, _ = stabilizer(OT, T3inT)
-(Orthogonal group of finite quadratic module: Z/15 -> Q/2Z, Hom: orthogonal group -> orthogonal group)
+(Group of isometries of finite quadratic module: Z/15 -> Q/2Z, Hom: group of isometries -> group of isometries)
 
 julia> order(S)
 4

--- a/src/Groups/abelian_aut.jl
+++ b/src/Groups/abelian_aut.jl
@@ -69,11 +69,29 @@ end
 
 @doc raw"""
     hom(f::AutomorphismGroupElem{FinGenAbGroup}) -> FinGenAbGroupHom
+    hom(f::AutomorphismGroupElem{TorQuadModule}) -> TorQuadModuleMap
 
-Return the element `f` of type `FinGenAbGroupHom`.
+Return the underlying homomorphism of ``f``.
 
 # Examples
 ```jldoctest
+julia> A = abelian_group([2, 3, 4]);
+
+julia> G = automorphism_group(A);
+
+julia> f = first(gens(G))
+Automorphism of
+  finitely generated abelian group with 3 generators and 3 relations
+with matrix representation
+  [1   0   0]
+  [0   1   0]
+  [0   0   1]
+
+julia> hom(f)
+Map
+  from finitely generated abelian group with 3 generators and 3 relations
+  to finitely generated abelian group with 3 generators and 3 relations
+
 julia> T = torsion_quadratic_module(matrix(QQ, 2, 2, [2//3 0; 0 2//9]));
 
 julia> OT = orthogonal_group(T)

--- a/src/Groups/abelian_aut.jl
+++ b/src/Groups/abelian_aut.jl
@@ -154,7 +154,7 @@ function _orthogonal_group(T::TorQuadModule, gensOT::Vector{ZZMatrix}; check::Bo
   return aut
 end
 
-function Base.show(io::IO,  ::MIME"text/plain", OT::AutomorphismGroup{TorQuadModule})
+function Base.show(io::IO, ::MIME"text/plain", OT::AutomorphismGroup{TorQuadModule})
   io = pretty(io)
   println(io, "Orthogonal group of", Indent())
   println(io, Lowercase(), OT.G)

--- a/src/Groups/abelian_aut.jl
+++ b/src/Groups/abelian_aut.jl
@@ -13,6 +13,21 @@ end
     automorphism_group(G::FinGenAbGroup) -> AutomorphismGroup{FinGenAbGroup}
 
 Return the automorphism group of `G`.
+
+# Examples
+```jldoctest
+julia> A = abelian_group([2, 3, 4, 4, 4]);
+
+julia> automorphism_group(A)
+Automorphism group of
+  finitely generated abelian group with 5 generators and 5 relations
+
+julia> S, _ = snf(A);
+
+julia> automorphism_group(S)
+Automorphism group of
+  Z/2 x (Z/4)^2 x Z/12
+```
 """
 function automorphism_group(G::FinGenAbGroup)
   Ggap, to_gap, to_oscar = _isomorphic_gap_group(G)
@@ -21,7 +36,6 @@ function automorphism_group(G::FinGenAbGroup)
   set_attribute!(aut, :to_gap => to_gap, :to_oscar => to_oscar)
   return aut
 end
-
 
 function apply_automorphism(f::AutGrpAbTorElem, x::AbTorElem, check::Bool=true)
   aut = parent(f)
@@ -57,6 +71,28 @@ end
     hom(f::AutomorphismGroupElem{FinGenAbGroup}) -> FinGenAbGroupHom
 
 Return the element `f` of type `FinGenAbGroupHom`.
+
+# Examples
+```jldoctest
+julia> T = torsion_quadratic_module(matrix(QQ, 2, 2, [2//3 0; 0 2//9]));
+
+julia> OT = orthogonal_group(T)
+Orthogonal group of
+  finite quadratic module: Z/3 x Z/9 -> Q/2Z
+with 3 generators
+
+julia> f = first(gens(OT))
+Isometry of
+  finite quadratic module: Z/3 x Z/9 -> Q/2Z
+with matrix representation
+  [2   0]
+  [0   1]
+
+julia> hom(f)
+Map
+  from finite quadratic module: Z/3 x Z/9 -> Q/2Z
+  to finite quadratic module: Z/3 x Z/9 -> Q/2Z
+```
 """
 function hom(f::AutGrpAbTorElem)
   A = domain(f)
@@ -64,8 +100,7 @@ function hom(f::AutGrpAbTorElem)
   return hom(A, A, imgs)
 end
 
-
-function (aut::AutGrpAbTor)(f::Union{FinGenAbGroupHom,TorQuadModuleMap};check::Bool=true)
+function (aut::AutGrpAbTor)(f::Union{FinGenAbGroupHom,TorQuadModuleMap}; check::Bool=true)
   !check || (domain(f) === codomain(f) === domain(aut) && is_bijective(f)) || error("Map does not define an automorphism of the abelian group.")
   to_gap = get_attribute(aut, :to_gap)
   to_oscar = get_attribute(aut, :to_oscar)
@@ -82,7 +117,6 @@ function (aut::AutGrpAbTor)(f::Union{FinGenAbGroupHom,TorQuadModuleMap};check::B
   !check || fgap in aut.X || error("Map does not define an element of the group")
   return aut(fgap)
 end
-
 
 function (aut::AutGrpAbTor)(M::ZZMatrix; check::Bool=true)
   !check || defines_automorphism(domain(aut),M) || error("Matrix does not define an automorphism of the abelian group.")
@@ -104,6 +138,26 @@ end
     matrix(f::AutomorphismGroupElem{FinGenAbGroup}) -> ZZMatrix
 
 Return the underlying matrix of `f` as a module homomorphism.
+
+# Examples
+```jldoctest
+julia> A = abelian_group([3, 9, 12]);
+
+julia> G = automorphism_group(A);
+
+julia> f = first(gens(G))
+Automorphism of
+  finitely generated abelian group with 3 generators and 3 relations
+with matrix representation
+  [1   0   0]
+  [0   1   0]
+  [0   0   7]
+
+julia> matrix(f)
+[1   0   0]
+[0   1   0]
+[0   0   7]
+```
 """
 matrix(f::AutomorphismGroupElem{FinGenAbGroup}) = matrix(hom(f))
 
@@ -111,9 +165,10 @@ matrix(f::AutomorphismGroupElem{FinGenAbGroup}) = matrix(hom(f))
 @doc raw"""
     defines_automorphism(G::FinGenAbGroup, M::ZZMatrix) -> Bool
 
-If `M` defines an endomorphism of `G`, return `true` if `M` defines an automorphism of `G`, else `false`.
+If `M` defines an endomorphism of `G`, return `true` if `M` defines an
+automorphism of `G`, else `false`.
 """
-defines_automorphism(G::FinGenAbGroup, M::ZZMatrix) = is_bijective(hom(G,G,M))
+defines_automorphism(G::FinGenAbGroup, M::ZZMatrix) = is_bijective(hom(G, G, M))
 
 ################################################################################
 #
@@ -174,6 +229,27 @@ end
     matrix(f::AutomorphismGroupElem{TorQuadModule}) -> ZZMatrix
 
 Return a matrix inducing `f`.
+
+# Examples
+```jldoctest
+julia> T = torsion_quadratic_module(matrix(QQ, 2, 2, [1//12 0; 0 2//9]));
+
+julia> OT = orthogonal_group(T)
+Orthogonal group of
+  finite quadratic module: Z/3 x Z/36 -> Q/2Z
+with 4 generators
+
+julia> f = first(gens(OT))
+Isometry of
+  finite quadratic module: Z/3 x Z/36 -> Q/2Z
+with matrix representation
+  [1    0]
+  [0   19]
+
+julia> matrix(f)
+[1    0]
+[0   19]
+```
 """
 matrix(f::AutomorphismGroupElem{TorQuadModule}) = matrix(hom(f))
 
@@ -223,6 +299,27 @@ end
     orthogonal_group(T::TorQuadModule)  -> AutomorphismGroup{TorQuadModule}
 
 Return the full orthogonal group of this torsion quadratic module.
+
+# Examples
+```jldoctest
+julia> T = torsion_quadratic_module(matrix(QQ, 2, 2, [1//4 1//2; 1//2 3//4]))
+Finite quadratic module
+  over integer ring
+Abelian group: (Z/4)^2
+Bilinear value module: Q/Z
+Quadratic value module: Q/2Z
+Gram matrix quadratic form:
+[1//4   1//2]
+[1//2   3//4]
+
+julia> OT = orthogonal_group(T)
+Orthogonal group of
+  finite quadratic module: (Z/4)^2 -> Q/2Z
+with 2 generators
+
+julia> order(OT)
+4
+```
 """
 @attr AutomorphismGroup{TorQuadModule} function orthogonal_group(T::TorQuadModule)
   if is_trivial(abelian_group(T))

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -1441,13 +1441,13 @@ function automorphism_group(G::GAPGroup)
   return AutomorphismGroup(AutGAP, G)
 end
 
-function Base.show(io::IO,  ::MIME"text/plain", A::AutomorphismGroup{T}) where T <: GAPGroup
+function Base.show(io::IO,  ::MIME"text/plain", A::AutomorphismGroup{T}) where T <: Union{FinGenAbGroup, GAPGroup}
   io = pretty(io)
   println(io, "Automorphism group of", Indent())
   print(io, Lowercase(), A.G, Dedent())
 end
 
-function Base.show(io::IO, A::AutomorphismGroup{T}) where T <: GAPGroup
+function Base.show(io::IO, A::AutomorphismGroup{T}) where T <: Union{FinGenAbGroup, GAPGroup}
   if is_terse(io)
     print(io, "Automorphism group")
   else

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -541,8 +541,19 @@ end
 
 const AutomorphismGroupElem{T} = BasicGAPGroupElem{AutomorphismGroup{T}} where T
 
-function Base.show(io::IO, AGE::AutomorphismGroupElem{FinGenAbGroup}) 
-    print(io, "Automorphism of ", FinGenAbGroup, " with matrix representation ", matrix(AGE))
+function Base.show(io::IO, ::MIME"text/plain", f::AutomorphismGroupElem{FinGenAbGroup})
+  D = domain(parent(f))
+  io = pretty(io)
+  println(io, "Automorphism of")
+  println(io, Indent(), Lowercase(), D, Dedent())
+  println(io, "with matrix representation")
+  print(io, Indent())
+  show(io, MIME"text/plain"(), matrix(f))
+  print(io, Dedent())
+end
+
+function Base.show(io::IO, f::AutomorphismGroupElem{FinGenAbGroup})
+  print(io, matrix(f))
 end
 
 ################################################################################

--- a/src/NumberTheory/QuadFormAndIsom/lattices_with_isometry.jl
+++ b/src/NumberTheory/QuadFormAndIsom/lattices_with_isometry.jl
@@ -1489,7 +1489,9 @@ Gram matrix quadratic form:
 [5//6]
 
 julia> qf
-Isometry of finite quadratic module: Z/6 -> Q/2Z defined by
+Isometry of
+  finite quadratic module: Z/6 -> Q/2Z
+with matrix representation
   [1]
 
 julia> f = matrix(QQ, 5, 5, [ 1  0  0  0  0;
@@ -1501,7 +1503,9 @@ julia> f = matrix(QQ, 5, 5, [ 1  0  0  0  0;
 julia> Lf = integer_lattice_with_isometry(L, f);
 
 julia> discriminant_group(Lf)[2]
-Isometry of finite quadratic module: Z/6 -> Q/2Z defined by
+Isometry of
+  finite quadratic module: Z/6 -> Q/2Z
+with matrix representation
   [5]
 ```
 """


### PR DESCRIPTION
- Use the general `show` method of `AutomorphismGroup{T} where T <: GapGroup` for groups of type `FinGenAbGroup`;
- Improve the printing for `AutomorphismGroupElem{FinGenAbGroup}` which cannot rely on GAP-printing (make it consistent with the printing of `AutomorphismGroupElem{TorQuadModule}` where we give a matrix representation of the automorphism);
- Improve the printing of `AutomorphismGroup{TorQuadModule}` and `AutomorphismGroupElem{TorQuadModule}` (for the former, use the terminology "Orthogonal group" instead of "Group of isometries");
- Print the matrices for `AutomorphismGroupElem{T} where T <: Union{FinGenAbGroup, TorQuadModule}` in expended format, like we do for Gram matrices of lattices.

No strong opinion, I am open to change if there are some suggestions of improvement.