### PR TITLE
Fix race conditions in documentation deployment

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,4 +14,5 @@ deploydocs(
    repo   = "github.com/oscar-system/Oscar.jl.git",
    deploy_repo = "github.com/oscar-system/OscarDocumentation",
    push_preview = should_push_preview,
+   forcepush = true,
 )


### PR DESCRIPTION
This resolves the problem @fingolfin sent me via slack. I somehow dropped this setting in https://github.com/oscar-system/Oscar.jl/pull/5086, but it seems we should keep it.