### PR TITLE
Follow-up to #5083: Minor Doc Fixes

### DIFF
--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/basic_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/basic_attributes.jl
@@ -3,6 +3,7 @@
 
 Return the base space of the F-theory model.
 
+# Examples
 ```jldoctest
 julia> m = literature_model(arxiv_id = "1109.3454", equation = "3.1")
 Assuming that the first row of the given grading is the grading under Kbar
@@ -24,6 +25,7 @@ end
 
 Return the ambient space of the F-theory model.
 
+# Examples
 ```jldoctest
 julia> m = literature_model(arxiv_id = "1109.3454", equation = "3.1")
 Assuming that the first row of the given grading is the grading under Kbar
@@ -45,6 +47,7 @@ end
 
 Return the fiber ambient space of an F-theory model.
 
+# Examples
 ```jldoctest
 julia> B3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
@@ -72,6 +75,7 @@ end
 Return database index of a literature model. This index is a unique identifier that can be used to more conveniently construct the model. 
 All models have a model_index and these will not change in the future.
 
+# Examples
 ```jldoctest
 julia> t = literature_model(31)
 Assuming that the first row of the given grading is the grading under Kbar

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/computed_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/computed_attributes.jl
@@ -20,6 +20,7 @@ be switched off by setting the optional argument `check` to the value `false`, a
     Internally, we integrate those ambient space classes against the class of the hypersurface, which automatically
     executes the restriction to the hypersurface.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -93,6 +94,7 @@ The theory guarantees that the implemented algorithm works for toric ambient spa
 simplicial and complete. The check for completeness can be very time consuming. This check can
 be switched off by setting the optional argument `check` to the value `false`, as demonstrated below.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -128,6 +130,7 @@ as a hypersurface in a toric ambient space, we can compute the Euler characteris
 assumptions is satisfied, this method returns the Euler characteristic, otherwise it raises an
 error.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
@@ -504,7 +504,7 @@ end
 @doc raw"""
     add_associated_literature_model(m::AbstractFTheoryModel, addition::String)
 
-Adds a new entry to the list of associated literature models for the F-theory model.
+Add a new entry to the list of associated literature models for the F-theory model.
 If the entry is already present, nothing is changed.
 
 See [Literature Models](@ref literature_models) for more details.
@@ -518,7 +518,7 @@ end
 @doc raw"""
     add_journal_report_number(m::AbstractFTheoryModel, addition::String)
 
-Adds a new entry to the list of journal report numbers for the F-theory model.
+Add a new entry to the list of journal report numbers for the F-theory model.
 If the entry is already present, nothing is changed.
 
 See [Literature Models](@ref literature_models) for more details.
@@ -532,7 +532,7 @@ end
 @doc raw"""
     add_model_parameter(m::AbstractFTheoryModel, addition::String)
 
-Adds a new entry to the list of model parameters for the F-theory model.
+Add a new entry to the list of model parameters for the F-theory model.
 If the entry is already present, nothing is changed.
 
 See [Literature Models](@ref literature_models) for more details.
@@ -546,7 +546,7 @@ end
 @doc raw"""
     add_paper_author(m::AbstractFTheoryModel, addition::String)
 
-Adds a new entry to the list of paper authors for the F-theory model.
+Add a new entry to the list of paper authors for the F-theory model.
 If the entry is already present, nothing is changed.
 
 See [Literature Models](@ref literature_models) for more details.
@@ -560,7 +560,7 @@ end
 @doc raw"""
     add_paper_buzzword(m::AbstractFTheoryModel, addition::String)
 
-Adds a new entry to the list of paper buzzwords for the F-theory model.
+Add a new entry to the list of paper buzzwords for the F-theory model.
 If the entry is already present, nothing is changed.
 
 See [Literature Models](@ref literature_models) for more details.
@@ -574,7 +574,7 @@ end
 @doc raw"""
     add_birational_literature_model(m::AbstractFTheoryModel, addition::String)
 
-Adds a new entry to the list of birational models for the F-theory model.
+Add a new entry to the list of birational models for the F-theory model.
 If the entry is already present, nothing is changed.
 
 See [Literature Models](@ref literature_models) for more details.

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/methods.jl
@@ -8,6 +8,7 @@
 
 Resolve an F-theory model by blowing up a locus in the ambient space.
 
+# Examples
 ```jldoctest
 julia> B3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
@@ -25,6 +26,7 @@ Partially resolved global Tate model over a concrete base -- SU(5)xU(1) restrict
 ```
 Here is an example for a Weierstrass model.
 
+# Examples
 ```jldoctest
 julia> B2 = projective_space(NormalToricVariety, 2)
 Normal toric variety
@@ -53,6 +55,7 @@ end
 
 Resolve an F-theory model by blowing up a locus in the ambient space.
 
+# Examples
 ```jldoctest
 julia> B3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
@@ -109,6 +112,7 @@ end
 Resolve an F-theory model by blowing up a locus in the ambient space.
 For this method, the blowup center is encoded by an ideal sheaf.
 
+# Examples
 ```jldoctest
 julia> B3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
@@ -264,6 +268,7 @@ end
 # Note that there is less functionality for hypersurface models than for Weierstrass or Tate
 # models. For instance, `singular_loci` can (currently) not be computed for hypersurface models.
 
+# # Examples
 # ```jldoctest
 # julia> B3 = projective_space(NormalToricVariety, 3)
 # Normal toric variety
@@ -326,6 +331,7 @@ Put an F-theory model defined over a family of spaces over a concrete base.
 
 Currently, this functionality is limited to Tate and Weierstrass models.
 
+# Examples
 ```jldoctest
 julia> t = literature_model(arxiv_id = "1109.3454", equation = "3.1", completeness_check = false)
 Assuming that the first row of the given grading is the grading under Kbar
@@ -597,6 +603,7 @@ end
 
 Add a known resolution for a model.
 
+# Examples
 ```jldoctest
 julia> m = literature_model(arxiv_id = "1109.3454", equation = "3.1")
 Assuming that the first row of the given grading is the grading under Kbar
@@ -678,6 +685,7 @@ end
 
 Resolve a model with the index-th resolution that is known.
 
+# Examples
 ```jldoctest
 julia> B3 = projective_space(NormalToricVariety, 3)
 Normal toric variety

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/precomputed_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/precomputed_attributes.jl
@@ -44,6 +44,7 @@ Return the cohomology classes of the exceptional toric divisors of a model as a 
 This information is only supported for models over a concrete base that is a normal toric variety, but is always available in this case.
 After a toric blow up this information is updated.
 
+# Examples
 ```jldoctest
 julia> B3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
@@ -77,6 +78,7 @@ Return the indices of the generators of the Cox ring of the ambient space which 
 This information is only supported for models over a concrete base that is a normal toric variety, but is always available in this case.
 After a toric blow up this information is updated.
 
+# Examples
 ```jldoctest
 julia> B3 = projective_space(NormalToricVariety, 3)
 Normal toric variety

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/properties.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/properties.jl
@@ -7,6 +7,7 @@
 
 Return `true` if the F-theory model has a concrete base space and `false` otherwise.
 
+# Examples
 ```jldoctest
 julia> t = literature_model(arxiv_id = "1109.3454", equation = "3.1")
 Assuming that the first row of the given grading is the grading under Kbar
@@ -26,6 +27,7 @@ is_base_space_fully_specified(m::AbstractFTheoryModel) = !(m.base_space isa Fami
 Return `true` if resolution techniques were applied to the F-theory model,
 thereby potentially resolving its singularities. Otherwise, return `false`.
 
+# Examples
 ```jldoctest
 julia> B3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
@@ -65,6 +67,7 @@ If so, this method returns `true`. However, should information be missing, (e.g.
 Hodge numbers), or the dimension of the F-theory model differ form 4, then this method
 raises an error.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -108,6 +111,7 @@ of a cohomology class ``h`` on the toric ambient space. This in turn requires th
 toric ambient space is simplicial and complete. We provide a switch to turn off 
 these computationally very demanding checks. This is demonstrated in the example below.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/qsm_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/qsm_attributes.jl
@@ -7,6 +7,7 @@ This method returns the vertices of the polytope the the base of the F-theory QS
 build from. Note that those vertices are normalized according to the Polymake standard
 to rational numbers.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -31,6 +32,7 @@ end
 Of the 3-dimensional reflexive polytope that the base of this F-theory model is build from,
 this method returns the index within the Kreuzer-Skarke list.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -56,6 +58,7 @@ to provide an answer to this. It returns `true` if one should expect a timely re
 to the attempt to enumerate all (full, regular, star) triangulations. Otherwise, this
 method returns `false`.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -80,6 +83,7 @@ the complexity of this triangulation task is the maximum number of lattice point
 in a facet of the polytope in question. This method returns this maximal number of
 lattice points.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -101,6 +105,7 @@ This method returns an estimate for the number of full, regular, star triangulat
 of the 3-dimensional reflexive polytope, those triangulations define the possible base
 spaces of the F-theory QSM in question.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -125,6 +130,7 @@ Let Kbar denote the anticanonical class of the 3-dimensional base space of the F
 Of ample importance is the triple intersection number of Kbar, i.e. Kbar * Kbar * Kbar.
 This method returns this intersection number.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -145,6 +151,7 @@ end
 This methods return the Hodge number h11 of the elliptically
 fibered 4-fold that defined the F-theory QSM in question.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -165,6 +172,7 @@ end
 This methods return the Hodge number h12 of the elliptically
 fibered 4-fold that defined the F-theory QSM in question.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -185,6 +193,7 @@ end
 This methods return the Hodge number h13 of the elliptically
 fibered 4-fold that defined the F-theory QSM in question.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -205,6 +214,7 @@ end
 This methods return the Hodge number h22 of the elliptically
 fibered 4-fold that defined the F-theory QSM in question.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -232,6 +242,7 @@ QSM hypersurface model in question, and s is a generic
 section of the anticanonical bundle of B3. Consequently,
 we may use the coordinates xi as labels for the curves Ci.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -259,6 +270,7 @@ QSM hypersurface model in question can be restricted to the Ci curves. The
 result of this operation is a line bundle. This method returns the degree of
 this line bundle for every Ci curve.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -284,6 +296,7 @@ end
 The topological intersection numbers among Ci curves are also of ample importance.
 This method returns those intersection numbers in the form of a matrix.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -309,6 +322,7 @@ This method returns the vector of all indices of trivial Ci curves.
 That is, should V(x23, s) be the empty set, then 23 will be included in
 the returned list.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -339,6 +353,7 @@ end
 The topological intersection numbers among the non-trivial Ci curves are used
 frequently. This method returns those intersection numbers in the form of a matrix.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -366,6 +381,7 @@ This method returns the dual graph of the QSM model in question.
 Note that no labels are (currently) attached to the vertices/nodes or edges.
 To understand/read this graph correctly, please use the methods listed below.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -399,6 +415,7 @@ reducible, then we introduce the labels Ci-0, Ci-1, Ci-2 etc. for those irreduci
 components of Ci. If Ci-0 corresponds to the k-th components of the dual graph,
 then the label "Ci-0" appears at position k of the vector returned by this method.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -441,6 +458,7 @@ question can be restricted to the (geometric counterparts of the) nodes/vertices
 the dual graph. The result is a line bundle for each node/vertex. This method returns
 a vector with the degrees of these line bundles.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -461,6 +479,7 @@ end
 This methods returns a vector with the genera of the (geometric
 counterparts of the) nodes/vertices of the dual graph.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -485,6 +504,7 @@ This method returns the simplified dual graph of the QSM model in question.
 Note that no labels are (currently) attached to the vertices/nodes or edges.
 To understand/read this graph correctly, please use the methods listed below.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -506,6 +526,7 @@ end
 This method returns a vector with labels for each node/vertex of the simplified dual graph.
 Otherwise, works identical to `components_of_dual_graph(m::AbstractFTheoryModel)`.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -530,6 +551,7 @@ end
 Same as `degrees_of_kbar_restrictions_to_components_of_dual_graph(m::AbstractFTheoryModel)`,
 but for the simplified dual graph.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -550,6 +572,7 @@ end
 This methods returns a vector with the genera of the (geometric
 counterparts of the) nodes/vertices of the dual graph.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/section_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/section_attributes.jl
@@ -5,6 +5,7 @@ Returns the defining divisor classes of the given F-theory model.
 
 For a detailed explanation of the concept, see [Literature Models](@ref literature_models).
 
+# Examples
 ```jldoctest
 julia> B3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
@@ -35,6 +36,7 @@ Returns the model sections of the given F-theory model.
 
 For a detailed explanation of the concept, see [Literature Models](@ref literature_models).
 
+# Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> m = literature_model(arxiv_id = "1109.3454", equation = "3.1")
 Assuming that the first row of the given grading is the grading under Kbar
@@ -64,6 +66,7 @@ Returns the tunable sections of the given F-theory model.
 
 For a detailed explanation of the concept, see [Literature Models](@ref literature_models).
 
+# Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> m = literature_model(arxiv_id = "1109.3454", equation = "3.1")
 Assuming that the first row of the given grading is the grading under Kbar
@@ -90,6 +93,7 @@ are parametrized by the tunable sections.
 
 For a detailed explanation of the concept, see [Literature Models](@ref literature_models).
 
+# Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> t = literature_model(arxiv_id = "1109.3454", equation = "3.1")
 Assuming that the first row of the given grading is the grading under Kbar
@@ -118,6 +122,7 @@ of the base and the defining classes of the given model.
 
 For a detailed explanation of the concept, see [Literature Models](@ref literature_models).
 
+# Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> m = literature_model(arxiv_id = "1109.3454", equation = "3.1")
 Assuming that the first row of the given grading is the grading under Kbar
@@ -143,6 +148,7 @@ Returns the divisor classes of all model sections of the given F-theory model.
 
 For a detailed explanation of the concept, see [Literature Models](@ref literature_models).
 
+# Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> B3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
@@ -193,6 +199,7 @@ Returns the explicit polynomial expressions for all model sections of the given 
 
 For a detailed explanation of the concept, see [Literature Models](@ref literature_models).
 
+# Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> t = literature_model(arxiv_id = "1109.3454", equation = "3.1")
 Assuming that the first row of the given grading is the grading under Kbar

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/section_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/section_attributes.jl
@@ -1,7 +1,7 @@
 @doc raw"""
     defining_classes(m::AbstractFTheoryModel)
 
-Returns the defining divisor classes of the given F-theory model.
+Return the defining divisor classes of the given F-theory model.
 
 For a detailed explanation of the concept, see [Literature Models](@ref literature_models).
 
@@ -32,7 +32,7 @@ end
 @doc raw"""
     model_sections(m::AbstractFTheoryModel)
 
-Returns the model sections of the given F-theory model.
+Return the model sections of the given F-theory model.
 
 For a detailed explanation of the concept, see [Literature Models](@ref literature_models).
 
@@ -62,7 +62,7 @@ model_sections(m::AbstractFTheoryModel) = collect(keys(explicit_model_sections(m
 @doc raw"""
     tunable_sections(m::AbstractFTheoryModel)
 
-Returns the tunable sections of the given F-theory model.
+Return the tunable sections of the given F-theory model.
 
 For a detailed explanation of the concept, see [Literature Models](@ref literature_models).
 
@@ -88,7 +88,7 @@ julia> tunable_sections(m)
 @doc raw"""
     model_section_parametrization(m::AbstractFTheoryModel)
 
-Returns a dictionary that defines how the structural sections of the given F-theory model
+Return a dictionary that defines how the structural sections of the given F-theory model
 are parametrized by the tunable sections.
 
 For a detailed explanation of the concept, see [Literature Models](@ref literature_models).
@@ -117,7 +117,7 @@ end
 @doc raw"""
     classes_of_tunable_sections_in_basis_of_Kbar_and_defining_classes(m::AbstractFTheoryModel)
 
-Returns the divisor classes of the tunable sections expressed in the basis of the anticanonical divisor
+Return the divisor classes of the tunable sections expressed in the basis of the anticanonical divisor
 of the base and the defining classes of the given model.
 
 For a detailed explanation of the concept, see [Literature Models](@ref literature_models).
@@ -144,7 +144,7 @@ classes_of_tunable_sections_in_basis_of_Kbar_and_defining_classes(m::AbstractFTh
 @doc raw"""
     classes_of_model_sections(m::AbstractFTheoryModel)
 
-Returns the divisor classes of all model sections of the given F-theory model.
+Return the divisor classes of all model sections of the given F-theory model.
 
 For a detailed explanation of the concept, see [Literature Models](@ref literature_models).
 
@@ -195,7 +195,7 @@ end
 @doc raw"""
     explicit_model_sections(m::AbstractFTheoryModel)
 
-Returns the explicit polynomial expressions for all model sections of the given F-theory model.
+Return the explicit polynomial expressions for all model sections of the given F-theory model.
 
 For a detailed explanation of the concept, see [Literature Models](@ref literature_models).
 

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/attributes.jl
@@ -7,6 +7,7 @@
 
 Returns the F-theory model for which this family of ``G_4``-flux candidates is defined.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
@@ -40,6 +41,7 @@ model(gf::FamilyOfG4Fluxes) = gf.model
 Returns the matrix whose columns specify those combinations of ambient space ``G_4``-flux
 candidates, of which integral linear combinations are contained in this family of ``G_4``-fluxes.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
@@ -73,6 +75,7 @@ matrix_integral(gf::FamilyOfG4Fluxes) = gf.mat_int
 Returns the matrix whose columns specify those combinations of ambient space ``G_4``-flux
 candidates, of which rational linear combinations are contained in this family of ``G_4``-fluxes.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
@@ -106,6 +109,7 @@ matrix_rational(gf::FamilyOfG4Fluxes) = gf.mat_rat
 Returns the vector whose entries specify the offset by which fluxes in this family
 of ``G_4``-fluxes are shifted away from the origin.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
@@ -156,6 +160,7 @@ the numerical coefficient values into this polynomial.
 
 The optional keyword argument `check` enables or disables internal consistency checks.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/attributes.jl
@@ -5,7 +5,7 @@
 @doc raw"""
     model(gf::FamilyOfG4Fluxes)
 
-Returns the F-theory model for which this family of ``G_4``-flux candidates is defined.
+Return the F-theory model for which this family of ``G_4``-flux candidates is defined.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -38,7 +38,7 @@ model(gf::FamilyOfG4Fluxes) = gf.model
 @doc raw"""
     matrix_integral(gf::FamilyOfG4Fluxes)
 
-Returns the matrix whose columns specify those combinations of ambient space ``G_4``-flux
+Return the matrix whose columns specify those combinations of ambient space ``G_4``-flux
 candidates, of which integral linear combinations are contained in this family of ``G_4``-fluxes.
 
 # Examples
@@ -72,7 +72,7 @@ matrix_integral(gf::FamilyOfG4Fluxes) = gf.mat_int
 @doc raw"""
     matrix_rational(gf::FamilyOfG4Fluxes)
 
-Returns the matrix whose columns specify those combinations of ambient space ``G_4``-flux
+Return the matrix whose columns specify those combinations of ambient space ``G_4``-flux
 candidates, of which rational linear combinations are contained in this family of ``G_4``-fluxes.
 
 # Examples
@@ -106,7 +106,7 @@ matrix_rational(gf::FamilyOfG4Fluxes) = gf.mat_rat
 @doc raw"""
     offset(gf::FamilyOfG4Fluxes)
 
-Returns the vector whose entries specify the offset by which fluxes in this family
+Return the vector whose entries specify the offset by which fluxes in this family
 of ``G_4``-fluxes are shifted away from the origin.
 
 # Examples
@@ -144,7 +144,7 @@ offset(gf::FamilyOfG4Fluxes) = gf.offset
 @doc raw"""
     d3_tadpole_constraint(fgs::FamilyOfG4Fluxes; check::Bool = true)
 
-Returns the D3-tadpole constraint polynomial for a family of ``G_4``-fluxes.
+Return the D3-tadpole constraint polynomial for a family of ``G_4``-fluxes.
 
 Recall that for a given flux ``G_4``, the D3-tadpole constraint requires
 

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/constructors.jl
@@ -14,6 +14,7 @@ candidates, we can define a family of G4-fluxes as:
 
 For convenience we also allow to only provide ``\text{mat}_{\text{int}}``or ``\text{mat}_{\text{rat}}``. In this case, the shift is taken to be zero.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
@@ -6,7 +6,7 @@
 @doc raw"""
     flux_instance(fgs::FamilyOfG4Fluxes, int_combination::ZZMatrix, rat_combination::QQMatrix; check::Bool = true)
 
-Creates an element of a family of G4-fluxes.
+Create an element of a family of G4-fluxes.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -149,7 +149,7 @@ end
 @doc raw"""
     random_flux_instance(fgs::FamilyOfG4Fluxes; check::Bool = true)
 
-Creates a random element of a family of G4-fluxes.
+Create a random element of a family of G4-fluxes.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -203,7 +203,7 @@ end
 @doc raw"""
     random_flux(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true)
 
-Creates a random ``G_4``-flux on a given F-theory model.
+Create a random ``G_4``-flux on a given F-theory model.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
@@ -8,6 +8,7 @@
 
 Creates an element of a family of G4-fluxes.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
@@ -150,6 +151,7 @@ end
 
 Creates a random element of a family of G4-fluxes.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
@@ -203,6 +205,7 @@ end
 
 Creates a random ``G_4``-flux on a given F-theory model.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/properties.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/properties.jl
@@ -12,6 +12,7 @@ If any test fails, the family is definitely not well-quantized and the method
 returns `false`. If all tests pass, it returns `true`, indicating the fluxes 
 appear well-quantized based on current knowledge, but without guaranteeing it.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
@@ -89,6 +90,7 @@ end
 Checks if the given family of ``G_4``-fluxes passes the transversality conditions.
 Returns `true` if the checks pass, and `false` otherwise.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
@@ -154,6 +156,7 @@ end
 Checks if the given family of ``G_4``-fluxes breaks the non-abelian gauge group.
 Returns `true` if it does, and `false` otherwise.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/properties.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/properties.jl
@@ -87,7 +87,7 @@ end
 @doc raw"""
     passes_transversality_checks(fgs::FamilyOfG4Fluxes; check::Bool = true)
 
-Checks if the given family of ``G_4``-fluxes passes the transversality conditions.
+Check if the given family of ``G_4``-fluxes passes the transversality conditions.
 Return `true` if the checks pass, and `false` otherwise.
 
 # Examples
@@ -153,7 +153,7 @@ end
 @doc raw"""
     breaks_non_abelian_gauge_group(fgs::FamilyOfG4Fluxes; check::Bool = true)
 
-Checks if the given family of ``G_4``-fluxes breaks the non-abelian gauge group.
+Check if the given family of ``G_4``-fluxes breaks the non-abelian gauge group.
 Return `true` if it does, and `false` otherwise.
 
 # Examples

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/properties.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/properties.jl
@@ -88,7 +88,7 @@ end
     passes_transversality_checks(fgs::FamilyOfG4Fluxes; check::Bool = true)
 
 Checks if the given family of ``G_4``-fluxes passes the transversality conditions.
-Returns `true` if the checks pass, and `false` otherwise.
+Return `true` if the checks pass, and `false` otherwise.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -154,7 +154,7 @@ end
     breaks_non_abelian_gauge_group(fgs::FamilyOfG4Fluxes; check::Bool = true)
 
 Checks if the given family of ``G_4``-fluxes breaks the non-abelian gauge group.
-Returns `true` if it does, and `false` otherwise.
+Return `true` if it does, and `false` otherwise.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
@@ -1,7 +1,7 @@
 @doc raw"""
     special_flux_family(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true, algorithm::String = "default")
 
-Computes a family of ``G_4``-fluxes for the F-theory model `m`, defined as a hypersurface
+Compute a family of ``G_4``-fluxes for the F-theory model `m`, defined as a hypersurface
 in a simplicial, complete toric ambient space. The returned fluxes satisfy necessary
 quantization and transversality checks.
 

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
@@ -10,6 +10,7 @@ Optional keyword arguments:
 - `check`: if `false`, skips computational checks of completeness and simplicity of the ambient toric variety for improved performance.
 - `algorithm`: selects the computation method; the default uses Gröbner basis computations in the cohomology ring, while setting `algorithm = "special"` activates a faster variant described in [BMT25](@cite BMT25).
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base

--- a/experimental/FTheoryTools/src/FamilyOfSpaces/attributes.jl
+++ b/experimental/FTheoryTools/src/FamilyOfSpaces/attributes.jl
@@ -7,6 +7,7 @@
 
 Return the coordinate ring of a generic member of the family of spaces.
 
+# Examples
 ```jldoctest
 julia> ring, (f, g, Kbar, u) = QQ[:f, :g, :Kbar, :u]
 (Multivariate polynomial ring in 4 variables over QQ, QQMPolyRingElem[f, g, Kbar, u])
@@ -41,6 +42,7 @@ cox_ring(f::FamilyOfSpaces) = f.coordinate_ring
 
 Return the grading of the coordinate ring of a generic member of the family of spaces.
 
+# Examples
 ```jldoctest
 julia> ring, (f, g, Kbar, u) = QQ[:f, :g, :Kbar, :u]
 (Multivariate polynomial ring in 4 variables over QQ, QQMPolyRingElem[f, g, Kbar, u])
@@ -70,6 +72,7 @@ weights(f::FamilyOfSpaces) = f.grading
 
 Return the dimension of the generic member of the family of spaces.
 
+# Examples
 ```jldoctest
 julia> ring, (f, g, Kbar, u) = QQ[:f, :g, :Kbar, :u]
 (Multivariate polynomial ring in 4 variables over QQ, QQMPolyRingElem[f, g, Kbar, u])
@@ -102,6 +105,7 @@ dim(f::FamilyOfSpaces) = f.dim
 Return the equivalent of the irrelevant ideal
 for the generic member of the family of spaces.
 
+# Examples
 ```jldoctest
 julia> coord_ring, (f, g, Kbar, u) = QQ[:f, :g, :Kbar, :u]
 (Multivariate polynomial ring in 4 variables over QQ, QQMPolyRingElem[f, g, Kbar, u])
@@ -140,6 +144,7 @@ end
 Return the equivalent of the ideal of linear relations
 for the generic member of the family of spaces.
 
+# Examples
 ```jldoctest
 julia> coord_ring, (f, g, Kbar, u) = QQ[:f, :g, :Kbar, :u]
 (Multivariate polynomial ring in 4 variables over QQ, QQMPolyRingElem[f, g, Kbar, u])

--- a/experimental/FTheoryTools/src/FamilyOfSpaces/constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfSpaces/constructors.jl
@@ -26,6 +26,7 @@ Note that the coordinate ring can have strictly more variables than
 the dimension. This is a desired feature for most, if not all,
 F-theory literature constructions.
 
+# Examples
 ```jldoctest
 julia> coord_ring, _ = QQ[:f, :g, :Kbar, :u];
 
@@ -52,6 +53,7 @@ end
 
 Return a family of spaces.
 
+# Examples
 ```jldoctest
 julia> coord_ring, _ = QQ[:f, :g, :Kbar, :u];
 

--- a/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
@@ -5,7 +5,7 @@
 @doc raw"""
     model(gf::G4Flux)
 
-Returns the F-theory model used to construct the ``G_4``-flux candidate.
+Return the F-theory model used to construct the ``G_4``-flux candidate.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -32,7 +32,7 @@ model(gf::G4Flux) = gf.model
 @doc raw"""
     cohomology_class(gf::G4Flux)
 
-Returns the ambient space cohomology class which defines the ``G_4``-flux candidate.
+Return the ambient space cohomology class which defines the ``G_4``-flux candidate.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -64,7 +64,7 @@ cohomology_class(gf::G4Flux) = gf.class
 @doc raw"""
     d3_tadpole_constraint(gf::G4Flux; check::Bool = true)
 
-Returns the d3-tapdole of a G4-flux, that is compute and return the quantity
+Return the d3-tapdole of a G4-flux, that is compute and return the quantity
 ``- \frac{1}{2} \cdot \int_{\widehat{Y_4}}{G_4 \wedge G_4} + \frac{1}{24} \cdot \chi(\widehat{Y}_4)``.
 
 # Examples
@@ -151,7 +151,7 @@ end
 @doc raw"""
     g4_flux_family(gf::G4Flux; check::Bool = true)
 
-Returns the family of ``G_4``-fluxes sharing the following properties
+Return the family of ``G_4``-fluxes sharing the following properties
 with the given ``G_4``-flux: transversality and breaking of the
 non-abelian gauge group.
 
@@ -277,7 +277,7 @@ end
 @doc raw"""
     integral_coefficients(gf::G4Flux)
 
-Returns the integral coefficients of a ``G_4``-flux.
+Return the integral coefficients of a ``G_4``-flux.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -310,7 +310,7 @@ end
 @doc raw"""
     rational_coefficients(gf::G4Flux)
 
-Returns the rational coefficients of a ``G_4``-flux.
+Return the rational coefficients of a ``G_4``-flux.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -343,7 +343,7 @@ end
 @doc raw"""
     offset(gf::G4Flux)
 
-Returns the offset of a ``G_4``-flux.
+Return the offset of a ``G_4``-flux.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))

--- a/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
@@ -7,6 +7,7 @@
 
 Returns the F-theory model used to construct the ``G_4``-flux candidate.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -33,6 +34,7 @@ model(gf::G4Flux) = gf.model
 
 Returns the ambient space cohomology class which defines the ``G_4``-flux candidate.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -65,6 +67,7 @@ cohomology_class(gf::G4Flux) = gf.class
 Returns the d3-tapdole of a G4-flux, that is compute and return the quantity
 ``- \frac{1}{2} \cdot \int_{\widehat{Y_4}}{G_4 \wedge G_4} + \frac{1}{24} \cdot \chi(\widehat{Y}_4)``.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -152,6 +155,7 @@ Returns the family of ``G_4``-fluxes sharing the following properties
 with the given ``G_4``-flux: transversality and breaking of the
 non-abelian gauge group.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
@@ -275,6 +279,7 @@ end
 
 Returns the integral coefficients of a ``G_4``-flux.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -307,6 +312,7 @@ end
 
 Returns the rational coefficients of a ``G_4``-flux.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -339,6 +345,7 @@ end
 
 Returns the offset of a ``G_4``-flux.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base

--- a/experimental/FTheoryTools/src/G4Fluxes/auxiliary.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/auxiliary.jl
@@ -16,6 +16,7 @@ Use `check = false` to skip completeness and simplicity verification.
 
 For mathematical background shared across related methods see [Advanced Methods](@ref "Advanced Methods").
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 283))
 Hypersurface model over a concrete base
@@ -340,6 +341,7 @@ Use `check = false` to skip completeness and simplicity verification.
 
 For mathematical background shared across related methods see [Advanced Methods](@ref "Advanced Methods").
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 283))
 Hypersurface model over a concrete base
@@ -367,6 +369,7 @@ Use `check = false` to skip completeness and simplicity verification.
 
 For mathematical background shared across related methods see [Advanced Methods](@ref "Advanced Methods").
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 283))
 Hypersurface model over a concrete base
@@ -406,6 +409,7 @@ Use `check = false` to skip completeness and simplicity verification.
 
 For mathematical background shared across related methods see [Advanced Methods](@ref "Advanced Methods").
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 283))
 Hypersurface model over a concrete base
@@ -477,6 +481,7 @@ Use `check = false` to skip completeness and simplicity verification.
 
 For mathematical background shared across related methods see [Advanced Methods](@ref "Advanced Methods").
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 283))
 Hypersurface model over a concrete base
@@ -511,6 +516,7 @@ Use `check = false` to skip completeness and simplicity verification.
 
 For mathematical background shared across related methods see [Advanced Methods](@ref "Advanced Methods").
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 283))
 Hypersurface model over a concrete base
@@ -555,6 +561,7 @@ returned by this method.
 
 Use `check = false` to skip completeness and simplicity verification.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir))), filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> B3 = projective_space(NormalToricVariety, 3)
 Normal toric variety

--- a/experimental/FTheoryTools/src/G4Fluxes/auxiliary.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/auxiliary.jl
@@ -7,7 +7,7 @@
 @doc raw"""
     converter_dict_h22_ambient(m::AbstractFTheoryModel; check::Bool = true)
 
-Returns a dictionary that expresses arbitrary elements of ``H^{2,2}(X_\Sigma, \mathbb{Q})`` 
+Return a dictionary that expresses arbitrary elements of ``H^{2,2}(X_\Sigma, \mathbb{Q})`` 
 in terms of the basis computed by `basis_of_h22_ambient`.
 
 This is useful for rewriting cohomology classes in a fixed basis of the toric variety ``X_\Sigma``.
@@ -331,7 +331,7 @@ end
 @doc raw"""
     basis_of_h22_ambient_indices(m::AbstractFTheoryModel; check::Bool = true)
 
-Returns the index pairs of toric cohomology classes whose products span the 
+Return the index pairs of toric cohomology classes whose products span the 
 basis of ``H^{2,2}(X_\Sigma, \mathbb{Q})`` computed by `basis_of_h22_ambient`.
 
 Each entry is a tuple `(a, b)`, indicating that the product of the `a`-th and 
@@ -396,7 +396,7 @@ end
 @doc raw"""
     gens_of_h22_hypersurface_indices(m::AbstractFTheoryModel; check::Bool = true)
 
-Returns a vector of index pairs ``(a, b)``, indicating that the product of the ``a``-th 
+Return a vector of index pairs ``(a, b)``, indicating that the product of the ``a``-th 
 and ``b``-th toric variables defines a cohomology class on the ambient toric variety 
 ``X_\Sigma`` whose restriction to the hypersurface lies in the subspace 
 ``S \subseteq H^{2,2}(\widehat{Y}_4, \mathbb{Q})`` obtained from restricting
@@ -502,7 +502,7 @@ end
 @doc raw"""
     converter_dict_h22_hypersurface(m::AbstractFTheoryModel; check::Bool = true)
 
-Returns a dictionary mapping cohomology classes in ``H^{2,2}(X_\Sigma, \mathbb{Q})``
+Return a dictionary mapping cohomology classes in ``H^{2,2}(X_\Sigma, \mathbb{Q})``
 to linear combinations of generators of ``S \subseteq H^{2,2}(\widehat{Y}_4, \mathbb{Q})``,
 where ``\widehat{Y}_4`` is the (smooth) hypersurface associated to the F-theory model and
 ``S`` the restriction of ``H^{2,2}(X_\Sigma, \mathbb{Q})`` to ``\widehat{Y}_4``.

--- a/experimental/FTheoryTools/src/G4Fluxes/auxiliary.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/auxiliary.jl
@@ -361,7 +361,7 @@ end
 @doc raw"""
     basis_of_h22_ambient(m::AbstractFTheoryModel; check::Bool = true)
 
-Computes a monomial basis for ``H^{2,2}(X_\Sigma, \mathbb{Q})`` for a complete
+Compute a monomial basis for ``H^{2,2}(X_\Sigma, \mathbb{Q})`` for a complete
 and simplicial toric variety ``X_\Sigma`` by multiplying pairs of cohomology classes
 associated with the rays of ``X_\Sigma``.
 
@@ -469,7 +469,7 @@ end
 @doc raw"""
     gens_of_h22_hypersurface(m::AbstractFTheoryModel; check::Bool = true)
 
-Computes a set of cohomology classes in the toric ambient space ``X_\Sigma`` that restrict
+Compute a set of cohomology classes in the toric ambient space ``X_\Sigma`` that restrict
 to generators of the subspace ``S \subseteq H^{2,2}(\widehat{Y}_4, \mathbb{Q})``, where ``\widehat{Y}_4`` 
 is the (smooth) hypersurface in the ambient toric variety ``X_\Sigma`` associated to the F-theory model
 and ``S`` the restriction of ``H^{2,2}(X_\Sigma, \mathbb{Q})`` to ``\widehat{Y}_4``.

--- a/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
@@ -98,7 +98,7 @@ end
 @doc raw"""
     qsm_flux(qsm_model::AbstractFTheoryModel)
 
-Returns the ``G_4``-flux associated with one of the Quadrillion F-theory
+Return the ``G_4``-flux associated with one of the Quadrillion F-theory
 Standard models, as described in [CHLLT19](@cite CHLLT19).
 
 This flux has been pre-validated to pass essential consistency checks.

--- a/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
@@ -5,7 +5,7 @@
 @doc raw"""
     g4_flux(model::AbstractFTheoryModel, class::CohomologyClass; check::Bool = true)
 
-Constructs a candidate ``G_4``-flux for a resolved F-theory model from a given cohomology class
+Construct a candidate ``G_4``-flux for a resolved F-theory model from a given cohomology class
 on the toric ambient space.
 
 By default, `check = true` enables basic consistency and quantization checks. Set `check = false`

--- a/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
@@ -11,6 +11,7 @@ on the toric ambient space.
 By default, `check = true` enables basic consistency and quantization checks. Set `check = false`
 to skip these checks, which can improve performance or allow for exploratory computations.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -102,6 +103,7 @@ Standard models, as described in [CHLLT19](@cite CHLLT19).
 
 This flux has been pre-validated to pass essential consistency checks.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base

--- a/experimental/FTheoryTools/src/G4Fluxes/properties.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/properties.jl
@@ -79,7 +79,7 @@ end
     passes_transversality_checks(gf::G4Flux)
 
 Checks whether the ``G_4``-flux satisfies the transversality conditions
-(cf. [Wei18](@cite)). Returns `true` if all conditions are met, otherwise `false`.
+(cf. [Wei18](@cite)). Return `true` if all conditions are met, otherwise `false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -196,7 +196,7 @@ end
     breaks_non_abelian_gauge_group(gf::G4Flux)
 
 Checks whether the given ``G_4``-flux candidate breaks any non-abelian gauge
-symmetries. Returns `true` if any breaking occurs, and `false` otherwise.
+symmetries. Return `true` if any breaking occurs, and `false` otherwise.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))

--- a/experimental/FTheoryTools/src/G4Fluxes/properties.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/properties.jl
@@ -22,6 +22,7 @@ restricts to ``c_2(\widehat{Y}_4)`` on the hypersurface.
 
 If all these integrals evaluate to integers, this method returns `true`; otherwise, it returns `false`.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -80,6 +81,7 @@ end
 Checks whether the ``G_4``-flux satisfies the transversality conditions
 (cf. [Wei18](@cite)). Returns `true` if all conditions are met, otherwise `false`.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -149,6 +151,7 @@ $\frac{\chi(\widehat{Y}_4)}{24} - \frac{1}{2} \int_{\widehat{Y}_4} G_4 \wedge G_
 
 is a non-negative integer.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -195,6 +198,7 @@ end
 Checks whether the given ``G_4``-flux candidate breaks any non-abelian gauge
 symmetries. Returns `true` if any breaking occurs, and `false` otherwise.
 
+# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base

--- a/experimental/FTheoryTools/src/G4Fluxes/properties.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/properties.jl
@@ -5,7 +5,7 @@
 @doc raw"""
     is_well_quantized(gf::G4Flux)
 
-Checks whether the given ``G_4``-flux candidate satisfies necessary consistency conditions
+Check whether the given ``G_4``-flux candidate satisfies necessary consistency conditions
 for flux quantization as formulated in [Wit97](@cite):
 
 $G_4 + \frac{1}{2} c_2(\widehat{Y}_4) \in H^{(2,2)}(\widehat{Y}_4, \mathbb{Z})\,.$
@@ -78,7 +78,7 @@ end
 @doc raw"""
     passes_transversality_checks(gf::G4Flux)
 
-Checks whether the ``G_4``-flux satisfies the transversality conditions
+Check whether the ``G_4``-flux satisfies the transversality conditions
 (cf. [Wei18](@cite)). Return `true` if all conditions are met, otherwise `false`.
 
 # Examples
@@ -144,7 +144,7 @@ end
 @doc raw"""
     passes_tadpole_cancellation_check(gf::G4Flux)
 
-Checks whether the given ``G_4``-flux satisfies the D3-tadpole cancellation condition. This
+Check whether the given ``G_4``-flux satisfies the D3-tadpole cancellation condition. This
 amounts to verifying that
 
 $\frac{\chi(\widehat{Y}_4)}{24} - \frac{1}{2} \int_{\widehat{Y}_4} G_4 \wedge G_4$
@@ -195,7 +195,7 @@ end
 @doc raw"""
     breaks_non_abelian_gauge_group(gf::G4Flux)
 
-Checks whether the given ``G_4``-flux candidate breaks any non-abelian gauge
+Check whether the given ``G_4``-flux candidate breaks any non-abelian gauge
 symmetries. Return `true` if any breaking occurs, and `false` otherwise.
 
 # Examples

--- a/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
@@ -7,7 +7,7 @@
 @doc raw"""
     hypersurface_equation(h::HypersurfaceModel)
 
-Returns the hypersurface equation of the hypersurface model.
+Return the hypersurface equation of the hypersurface model.
 
 # Examples
 ```jldoctest
@@ -46,7 +46,7 @@ hypersurface_equation(h::HypersurfaceModel) = h.hypersurface_equation
 @doc raw"""
     hypersurface_equation_parametrization(h::HypersurfaceModel)
 
-Returns the parametrization of the hypersurface equation by the model sections.
+Return the parametrization of the hypersurface equation by the model sections.
 
 # Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
@@ -80,7 +80,7 @@ hypersurface_equation_parametrization(h::HypersurfaceModel) = h.hypersurface_equ
 @doc raw"""
     weierstrass_model(h::HypersurfaceModel)
 
-Returns the Weierstrass model corresponding to the given hypersurface model, if known.
+Return the Weierstrass model corresponding to the given hypersurface model, if known.
 
 In the example below, we construct a hypersurface model and its corresponding Weierstrass
 model (see [BMT25](@cite BMT25) for background), and then establish the relationship
@@ -147,7 +147,7 @@ end
 @doc raw"""
     global_tate_model(h::HypersurfaceModel)
 
-Returns the global Tate model corresponding to the given hypersurface model, if known.
+Return the global Tate model corresponding to the given hypersurface model, if known.
 
 In the example below, we construct a hypersurface model and its corresponding global
 Tate model (see [BMT25](@cite BMT25) for background), and then establish the relationship
@@ -233,7 +233,7 @@ end
 @doc raw"""
     calabi_yau_hypersurface(h::HypersurfaceModel)
 
-Returns the Calabi–Yau hypersurface that defines the hypersurface model
+Return the Calabi–Yau hypersurface that defines the hypersurface model
 as a closed subvariety of its toric ambient space.
 
 # Examples
@@ -281,7 +281,7 @@ end
 @doc raw"""
     discriminant(h::HypersurfaceModel)
 
-Returns the discriminant ``\Delta = 4f^3 + 27g^2`` of the Weierstrass model associated
+Return the discriminant ``\Delta = 4f^3 + 27g^2`` of the Weierstrass model associated
 with the given hypersurface model.
 
 Raises an error if no such Weierstrass model is known.
@@ -338,7 +338,7 @@ end
 @doc raw"""
     singular_loci(h::HypersurfaceModel)
 
-Returns the singular loci of the Weierstrass model equivalent to the given hypersurface model,
+Return the singular loci of the Weierstrass model equivalent to the given hypersurface model,
 along with the order of vanishing of ``(f, g, \Delta)`` at each locus and the corresponding
 refined Tate fiber type. See [singular_loci(w::WeierstrassModel)](@ref) for more details.
 

--- a/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
@@ -9,6 +9,7 @@
 
 Returns the hypersurface equation of the hypersurface model.
 
+# Examples
 ```jldoctest
 julia> b = projective_space(NormalToricVariety, 2)
 Normal toric variety
@@ -47,6 +48,7 @@ hypersurface_equation(h::HypersurfaceModel) = h.hypersurface_equation
 
 Returns the parametrization of the hypersurface equation by the model sections.
 
+# Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> h = literature_model(arxiv_id = "1208.2695", equation = "B.5")
 Assuming that the first row of the given grading is the grading under Kbar
@@ -84,6 +86,7 @@ In the example below, we construct a hypersurface model and its corresponding We
 model (see [BMT25](@cite BMT25) for background), and then establish the relationship
 between the two models.
 
+# Examples
 ```jldoctest
 julia> B2 = projective_space(NormalToricVariety, 2)
 Normal toric variety
@@ -150,6 +153,7 @@ In the example below, we construct a hypersurface model and its corresponding gl
 Tate model (see [BMT25](@cite BMT25) for background), and then establish the relationship
 between the two models.
 
+# Examples
 ```jldoctest
 julia> B2 = projective_space(NormalToricVariety, 2)
 Normal toric variety
@@ -232,6 +236,7 @@ end
 Returns the Calabi–Yau hypersurface that defines the hypersurface model
 as a closed subvariety of its toric ambient space.
 
+# Examples
 ```jldoctest
 julia> b = projective_space(NormalToricVariety, 2)
 Normal toric variety
@@ -284,6 +289,7 @@ Raises an error if no such Weierstrass model is known.
 In the example below, we construct a hypersurface model and its corresponding Weierstrass
 model (see [BMT25](@cite BMT25) for background), in order to demonstrate this functionality.
 
+# Examples
 ```jldoctest
 julia> B2 = projective_space(NormalToricVariety, 2)
 Normal toric variety
@@ -345,6 +351,7 @@ model (see [BMT25](@cite BMT25) for background), in order to demonstrate this fu
     The classification of singularities is performed using a Monte Carlo algorithm, involving randomized sampling.
     While reliable in practice, this probabilistic method may occasionally yield non-deterministic results.
 
+# Examples
 ```jldoctest
 julia> B2 = projective_space(NormalToricVariety, 2)
 Normal toric variety

--- a/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
@@ -14,6 +14,7 @@ The hypersurface equation `p` defines a section of the anti-canonical bundle of 
 
 For a full explanation of hypersurface models, see [Hypersurface Models](@ref "Hypersurface Models").
 
+# Examples
 ```jldoctest
 julia> b = projective_space(NormalToricVariety, 2)
 Normal toric variety
@@ -78,6 +79,7 @@ The polynomial `p`, which encodes the hypersurface equation, can also be passed 
 
 For a full explanation of hypersurface models, see [Hypersurface Models](@ref "Hypersurface Models").
 
+# Examples
 ```jldoctest
 julia> b = projective_space(NormalToricVariety, 2)
 Normal toric variety
@@ -203,6 +205,7 @@ For convenience, `fiber_twist_divisor_classes` can also be passed as a `ZZMatrix
 
 For a full explanation of hypersurface models, see [Hypersurface Models](@ref "Hypersurface Models").
 
+# Examples
 ```jldoctest
 julia> auxiliary_base_vars = ["a1", "a21", "a32", "a43", "a65", "w"];
 
@@ -281,6 +284,7 @@ For convenience, `fiber_twist_divisor_classes` can also be provided as `ZZMatrix
 
 For a full explanation of hypersurface models, see [Hypersurface Models](@ref "Hypersurface Models").
 
+# Examples
 ```jldoctest
 julia> auxiliary_base_vars = ["a1", "a21", "a32", "a43", "a65", "w"];
 
@@ -410,4 +414,3 @@ end
 function Base.show(io::IO, h::HypersurfaceModel)
   print(io, "Hypersurface model")
 end
-

--- a/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
@@ -5,7 +5,7 @@
 @doc raw"""
     hypersurface_model(base::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}, p::MPolyRingElem; completeness_check::Bool = true)
 
-Constructs a hypersurface model where fiber coordinates transform as sections of line bundles over the base.
+Construct a hypersurface model where fiber coordinates transform as sections of line bundles over the base.
 
 - If two `fiber_twist_divisor_classes` are provided, they specify the line bundle charges of the **first two** fiber coordinates. All remaining fiber coordinates are treated as base-trivial (i.e., constant over the base).
 - Alternatively, a `fiber_twist_divisor_class` can be given **for each fiber coordinate**, allowing full control over how the entire fiber ambient space twists over the base.
@@ -71,7 +71,7 @@ end
 @doc raw"""
     hypersurface_model(base::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}, indices::Vector{Int}, p::MPolyRingElem; completeness_check::Bool = true)
 
-Constructs a hypersurface model where the two fiber coordinates at the given
+Construct a hypersurface model where the two fiber coordinates at the given
 `indices` transform as sections of the line bundles associated to the specified
 base divisor classes.
 
@@ -180,7 +180,7 @@ end
 @doc raw"""
     hypersurface_model(auxiliary_base_vars::Vector{String}, auxiliary_base_grading::Matrix{Int64}, d::Int, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{Vector{Int64}}, p::MPolyRingElem)
 
-Constructs a hypersurface model over an unspecified base space by defining a **family** of base varieties
+Construct a hypersurface model over an unspecified base space by defining a **family** of base varieties
 via auxiliary data.
 
 The base is represented by:
@@ -263,7 +263,7 @@ end
 @doc raw"""
     hypersurface_model(auxiliary_base_vars::Vector{String}, auxiliary_base_grading::Matrix{Int64}, d::Int, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{Vector{Int64}}, indices::Vector{Int}, p::MPolyRingElem)
 
-Constructs a hypersurface model over an unspecified base space by defining a **family** of base varieties
+Construct a hypersurface model over an unspecified base space by defining a **family** of base varieties
 via auxiliary data.
 
 The base is represented by:

--- a/experimental/FTheoryTools/src/HypersurfaceModels/methods.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/methods.jl
@@ -11,6 +11,7 @@ In the example below, we construct a hypersurface model and its corresponding
 Weierstrass model (see [BMT25](@cite BMT25) for background), and demonstrate how 
 to associate them using this function.
 
+# Examples
 ```jldoctest
 julia> B2 = projective_space(NormalToricVariety, 2)
 Normal toric variety
@@ -59,6 +60,7 @@ In the example below, we construct a hypersurface model and its corresponding
 global Tate model (see [BMT25](@cite BMT25) for background), and demonstrate how 
 to associate them using this function.
 
+# Examples
 ```jldoctest
 julia> B2 = projective_space(NormalToricVariety, 2)
 Normal toric variety
@@ -122,6 +124,7 @@ value to a section that was previously tuned to zero. This is why we keep such
 trivial sections and do not delete them, say from `explicit_model_sections`
 or `classes_of_model_sections`.
 
+# Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> B2 = projective_space(NormalToricVariety, 2)
 Normal toric variety

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -5,7 +5,7 @@
 @doc raw"""
     literature_model(; doi::String="", arxiv_id::String="", version::String="", equation::String="", model_parameters::Dict{String,<:Any} = Dict{String,Any}(), base_space::FTheorySpace = affine_space(NormalToricVariety, 0), model_sections::Dict{String, <:Any} = Dict{String,Any}(), defining_classes::Dict{String, <:Any} = Dict{String,Any}(), completeness_check::Bool = true)
 
-Returns a model from the F-theory literature identified by bibliographic metadata such as arXiv ID, DOI, or equation reference.
+Return a model from the F-theory literature identified by bibliographic metadata such as arXiv ID, DOI, or equation reference.
 Many such models are well-known in the field—e.g., the *U(1)-restricted SU(5)-GUT model
 [Krause, Mayrhofer, Weigand 2011](@cite KMW12)*—and are stored in a curated database accessible through this method.
 

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -296,7 +296,7 @@ end
 # 3. Constructing models over concrete bases
 #######################################################
 
-# Constructs literature model over concrete base
+# Construct literature model over concrete base
 function _construct_literature_model_over_concrete_base(model_dict::Dict{String,Any}, base_space::FTheorySpace, defining_classes::Dict{String, <:Any}, completeness_check::Bool)
 
   # Make list and dict of the defining divisor classes
@@ -442,7 +442,7 @@ end
 # 4. Constructing models over arbitrary bases
 #######################################################
 
-# Constructs literature model over arbitrary base
+# Construct literature model over arbitrary base
 function _construct_literature_model_over_arbitrary_base(model_dict::Dict{String,Any})
   # Construct auxiliary base ring
   @req haskey(model_dict["model_data"], "model_sections") "No base coordinates specified for model"

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -31,6 +31,7 @@ See the [Literature Models](@ref literature_models) documentation page for a dee
 First, notice how you can create the global Tate model from [Krause, Mayrhofer, Weigand 2011](@cite KMW12)
 over an unspecified base:
 
+# Examples
 ```jldoctest
 julia> t = literature_model(arxiv_id = "1109.3454", equation = "3.1")
 Assuming that the first row of the given grading is the grading under Kbar
@@ -51,6 +52,7 @@ Multivariate polynomial ring in 8 variables over QQ graded by
 
 Certainly, this is also possible over a concrete base, provided that the defining classes are provided:
 
+# Examples
 ```jldoctest
 julia> B3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
@@ -66,6 +68,7 @@ Global Tate model over a concrete base -- SU(5)xU(1) restricted Tate model based
 
 Certainly, this can be mimiced for Weierstrass models, e.g. [Morrison, Park 2012](@cite MP12):
 
+# Examples
 ```jldoctest
 julia> B2 = projective_space(NormalToricVariety, 2)
 Normal toric variety
@@ -86,6 +89,7 @@ For convenience, we also support a simplified constructor. Instead of the meta d
 this constructor accepts an integer, which specifies the position of this model in our database.
 Here is how this can be used to create the model [Morrison, Park 2012](@cite MP12):
 
+# Examples
 ```jldoctest
 julia> B2 = projective_space(NormalToricVariety, 2)
 Normal toric variety
@@ -106,6 +110,7 @@ Finally, let us showcase that we also support hypersurface model constructions f
 For this, we stay with [Morrison, Park 2012](@cite MP12), but this time create this model as a
 hypersurface model. This works as follows:
 
+# Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> h = literature_model(arxiv_id = "1208.2695", equation = "B.5")
 Assuming that the first row of the given grading is the grading under Kbar

--- a/experimental/FTheoryTools/src/TateModels/attributes.jl
+++ b/experimental/FTheoryTools/src/TateModels/attributes.jl
@@ -3,6 +3,7 @@
 
 Returns the Tate section ``a_1``.
 
+# Examples
 ```jldoctest
 julia> t = global_tate_model_over_projective_space(2)
 Global Tate model over a concrete base
@@ -19,6 +20,7 @@ tate_section_a1(t::GlobalTateModel) = explicit_model_sections(t)["a1"]
 
 Returns the Tate section ``a_2``.
 
+# Examples
 ```jldoctest
 julia> t = global_tate_model_over_projective_space(2)
 Global Tate model over a concrete base
@@ -35,6 +37,7 @@ tate_section_a2(t::GlobalTateModel) = explicit_model_sections(t)["a2"]
 
 Returns the Tate section ``a_3``.
 
+# Examples
 ```jldoctest
 julia> t = global_tate_model_over_projective_space(2)
 Global Tate model over a concrete base
@@ -51,6 +54,7 @@ tate_section_a3(t::GlobalTateModel) = explicit_model_sections(t)["a3"]
 
 Returns the Tate section ``a_4``.
 
+# Examples
 ```jldoctest
 julia> t = global_tate_model_over_projective_space(2)
 Global Tate model over a concrete base
@@ -67,6 +71,7 @@ tate_section_a4(t::GlobalTateModel) = explicit_model_sections(t)["a4"]
 
 Returns the Tate section ``a_6``.
 
+# Examples
 ```jldoctest
 julia> t = global_tate_model_over_projective_space(2)
 Global Tate model over a concrete base
@@ -85,6 +90,7 @@ Returns the Tate polynomial of the model.
 
 Alias: [`hypersurface_equation(t::GlobalTateModel)`](@ref).
 
+# Examples
 ```jldoctest
 julia> t = global_tate_model_over_projective_space(2)
 Global Tate model over a concrete base
@@ -125,6 +131,7 @@ This method is relevant when the global Tate model cannot be represented by a si
 global polynomial—e.g., after non-toric blowups. In such cases, the model is defined
 locally by an ideal sheaf on each affine patch rather than by a global hypersurface equation.
 
+# Examples
 ```jldoctest
 julia> t = global_tate_model_over_projective_space(2)
 Global Tate model over a concrete base
@@ -164,6 +171,7 @@ end
 Returns the Calabi–Yau hypersurface that defines the global Tate model
 as a closed subvariety of its toric ambient space.
 
+# Examples
 ```jldoctest
 julia> t = global_tate_model_over_projective_space(2)
 Global Tate model over a concrete base
@@ -184,6 +192,7 @@ end
 
 Returns the Weierstrass model which is equivalent to the given global Tate model.
 
+# Examples
 ```jldoctest
 julia> t = global_tate_model_over_projective_space(2)
 Global Tate model over a concrete base
@@ -291,6 +300,7 @@ end
 
 Returns the discriminant ``\Delta = 4 f^3 + 27 g^2`` of the Weierstrass model equivalent to the given global Tate model.
 
+# Examples
 ```jldoctest
 julia> t = global_tate_model_over_projective_space(2)
 Global Tate model over a concrete base
@@ -327,6 +337,7 @@ Hence, there is a Kodaira type ``III`` singularity over the divisor ``{w = 0}``.
 the discriminant ``\Delta`` vanishes to order 3 on ``{w = 0}``, while the Weierstrass
 sections ``f`` and ``g`` vanish to orders 1 and 2, respectively.
 
+# Examples
 ```jldoctest
 julia> auxiliary_base_ring, (a11, a21, a31, a41, a62, w) = QQ[:a10, :a21, :a32, :a43, :a65, :w];
 

--- a/experimental/FTheoryTools/src/TateModels/attributes.jl
+++ b/experimental/FTheoryTools/src/TateModels/attributes.jl
@@ -1,7 +1,7 @@
 @doc raw"""
     tate_section_a1(t::GlobalTateModel)
 
-Returns the Tate section ``a_1``.
+Return the Tate section ``a_1``.
 
 # Examples
 ```jldoctest
@@ -18,7 +18,7 @@ tate_section_a1(t::GlobalTateModel) = explicit_model_sections(t)["a1"]
 @doc raw"""
     tate_section_a2(t::GlobalTateModel)
 
-Returns the Tate section ``a_2``.
+Return the Tate section ``a_2``.
 
 # Examples
 ```jldoctest
@@ -35,7 +35,7 @@ tate_section_a2(t::GlobalTateModel) = explicit_model_sections(t)["a2"]
 @doc raw"""
     tate_section_a3(t::GlobalTateModel)
 
-Returns the Tate section ``a_3``.
+Return the Tate section ``a_3``.
 
 # Examples
 ```jldoctest
@@ -52,7 +52,7 @@ tate_section_a3(t::GlobalTateModel) = explicit_model_sections(t)["a3"]
 @doc raw"""
     tate_section_a4(t::GlobalTateModel)
 
-Returns the Tate section ``a_4``.
+Return the Tate section ``a_4``.
 
 # Examples
 ```jldoctest
@@ -69,7 +69,7 @@ tate_section_a4(t::GlobalTateModel) = explicit_model_sections(t)["a4"]
 @doc raw"""
     tate_section_a6(t::GlobalTateModel)
 
-Returns the Tate section ``a_6``.
+Return the Tate section ``a_6``.
 
 # Examples
 ```jldoctest
@@ -86,7 +86,7 @@ tate_section_a6(t::GlobalTateModel) = explicit_model_sections(t)["a6"]
 @doc raw"""
     tate_polynomial(t::GlobalTateModel)
 
-Returns the Tate polynomial of the model.
+Return the Tate polynomial of the model.
 
 Alias: [`hypersurface_equation(t::GlobalTateModel)`](@ref).
 
@@ -125,7 +125,7 @@ hypersurface_equation(t::GlobalTateModel) = tate_polynomial(t)
 @doc raw"""
     tate_ideal_sheaf(t::GlobalTateModel)
 
-Returns the Tate ideal sheaf of the global Tate model.
+Return the Tate ideal sheaf of the global Tate model.
 
 This method is relevant when the global Tate model cannot be represented by a single
 global polynomial—e.g., after non-toric blowups. In such cases, the model is defined
@@ -168,7 +168,7 @@ end
 @doc raw"""
     calabi_yau_hypersurface(t::GlobalTateModel)
 
-Returns the Calabi–Yau hypersurface that defines the global Tate model
+Return the Calabi–Yau hypersurface that defines the global Tate model
 as a closed subvariety of its toric ambient space.
 
 # Examples
@@ -190,7 +190,7 @@ end
 @doc raw"""
     weierstrass_model(t::GlobalTateModel)
 
-Returns the Weierstrass model which is equivalent to the given global Tate model.
+Return the Weierstrass model which is equivalent to the given global Tate model.
 
 # Examples
 ```jldoctest
@@ -298,7 +298,7 @@ end
 @doc raw"""
     discriminant(t::GlobalTateModel)
 
-Returns the discriminant ``\Delta = 4 f^3 + 27 g^2`` of the Weierstrass model equivalent to the given global Tate model.
+Return the discriminant ``\Delta = 4 f^3 + 27 g^2`` of the Weierstrass model equivalent to the given global Tate model.
 
 # Examples
 ```jldoctest
@@ -318,7 +318,7 @@ end
 @doc raw"""
     singular_loci(t::GlobalTateModel)
 
-Returns the singular loci of the Weierstrass model equivalent to the given Tate model,
+Return the singular loci of the Weierstrass model equivalent to the given Tate model,
 along with the order of vanishing of ``(f, g, \Delta)`` at each locus and the corresponding
 refined Tate fiber type. See [singular_loci(w::WeierstrassModel)](@ref) for more details.
 

--- a/experimental/FTheoryTools/src/TateModels/constructors.jl
+++ b/experimental/FTheoryTools/src/TateModels/constructors.jl
@@ -8,6 +8,7 @@
 This method constructs a global Tate model over a given toric base
 3-fold. The Tate sections ``a_i`` are taken with (pseudo) random coefficients.
 
+# Examples
 ```jldoctest
 julia> t = global_tate_model(projective_space(NormalToricVariety, 2); completeness_check = false)
 Global Tate model over a concrete base
@@ -22,6 +23,7 @@ global_tate_model(base::NormalToricVariety; completeness_check::Bool = true) = g
 This method operates analogously to `global_tate_model(base::NormalToricVarietyType)`.
 The only difference is that the Tate sections ``a_i`` can be specified with non-generic values.
 
+# Examples
 ```jldoctest
 julia> chosen_base = projective_space(NormalToricVariety, 2)
 Normal toric variety
@@ -103,6 +105,7 @@ to this class carries the name "Kbar".
 
 The following code exemplifies this approach.
 
+# Examples
 ```jldoctest
 julia> auxiliary_base_ring, (a10, a21, a32, a43, a65, w) = QQ[:a10, :a21, :a32, :a43, :a65, :w];
 

--- a/experimental/FTheoryTools/src/TateModels/methods.jl
+++ b/experimental/FTheoryTools/src/TateModels/methods.jl
@@ -81,6 +81,7 @@ rather than deleted from attributes like `explicit_model_sections` or `classes_o
 This design choice enables users to later reintroduce nontrivial values for such sections
 without loss of structure.
 
+# Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
 julia> B3 = projective_space(NormalToricVariety, 3)
 Normal toric variety

--- a/experimental/FTheoryTools/src/WeierstrassModels/attributes.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/attributes.jl
@@ -1,7 +1,7 @@
 @doc raw"""
     weierstrass_section_f(w::WeierstrassModel)
 
-Returns the Weierstrass section ``f`` of the Weierstrass model.
+Return the Weierstrass section ``f`` of the Weierstrass model.
 
 # Examples
 ```jldoctest
@@ -17,7 +17,7 @@ weierstrass_section_f(w::WeierstrassModel) = explicit_model_sections(w)["f"]
 @doc raw"""
     weierstrass_section_g(w::WeierstrassModel)
 
-Returns the Weierstrass section ``g`` of the Weierstrass model.
+Return the Weierstrass section ``g`` of the Weierstrass model.
 
 # Examples
 ```jldoctest
@@ -33,7 +33,7 @@ weierstrass_section_g(w::WeierstrassModel) = explicit_model_sections(w)["g"]
 @doc raw"""
     weierstrass_polynomial(w::WeierstrassModel)
 
-Returns the Weierstrass polynomial of the model.
+Return the Weierstrass polynomial of the model.
 
 Alias: [`hypersurface_equation(w::WeierstrassModel)`](@ref).
 
@@ -72,7 +72,7 @@ hypersurface_equation(w::WeierstrassModel) = weierstrass_polynomial(w)
 @doc raw"""
     weierstrass_ideal_sheaf(w::WeierstrassModel)
 
-Returns the Weierstrass ideal sheaf of the Weierstrass model.
+Return the Weierstrass ideal sheaf of the Weierstrass model.
 
 This method is relevant when the Weierstrass model cannot be represented by a single
 global polynomial—e.g., after non-toric blowups. In such cases, the model is defined
@@ -115,7 +115,7 @@ end
 @doc raw"""
     calabi_yau_hypersurface(w::WeierstrassModel)
 
-Returns the Calabi–Yau hypersurface that defines the Weierstrass model
+Return the Calabi–Yau hypersurface that defines the Weierstrass model
 as a closed subvariety of its toric ambient space.
 
 # Examples
@@ -137,7 +137,7 @@ end
 @doc raw"""
     discriminant(w::WeierstrassModel)
 
-Returns the discriminant ``\Delta = 4 f^3 + 27 g^2`` of the Weierstrass model.
+Return the discriminant ``\Delta = 4 f^3 + 27 g^2`` of the Weierstrass model.
 
 # Examples
 ```jldoctest
@@ -156,7 +156,7 @@ end
 @doc raw"""
     singular_loci(w::WeierstrassModel)
 
-Returns the singular loci of the Weierstrass model, along with the order of
+Return the singular loci of the Weierstrass model, along with the order of
 vanishing of ``(f, g, \Delta)`` at each locus and the refined Tate fiber type.
 
 Currently, the method either explicitly or implicitly assumes a toric variety

--- a/experimental/FTheoryTools/src/WeierstrassModels/attributes.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/attributes.jl
@@ -3,6 +3,7 @@
 
 Returns the Weierstrass section ``f`` of the Weierstrass model.
 
+# Examples
 ```jldoctest
 julia> w =  weierstrass_model_over_projective_space(3)
 Weierstrass model over a concrete base
@@ -18,6 +19,7 @@ weierstrass_section_f(w::WeierstrassModel) = explicit_model_sections(w)["f"]
 
 Returns the Weierstrass section ``g`` of the Weierstrass model.
 
+# Examples
 ```jldoctest
 julia> w =  weierstrass_model_over_projective_space(3)
 Weierstrass model over a concrete base
@@ -35,6 +37,7 @@ Returns the Weierstrass polynomial of the model.
 
 Alias: [`hypersurface_equation(w::WeierstrassModel)`](@ref).
 
+# Examples
 ```jldoctest
 julia> w =  weierstrass_model_over_projective_space(3)
 Weierstrass model over a concrete base
@@ -75,6 +78,7 @@ This method is relevant when the Weierstrass model cannot be represented by a si
 global polynomial—e.g., after non-toric blowups. In such cases, the model is defined
 locally by an ideal sheaf on each affine patch rather than by a global hypersurface equation.
 
+# Examples
 ```jldoctest
 julia> w =  weierstrass_model_over_projective_space(2)
 Weierstrass model over a concrete base
@@ -114,6 +118,7 @@ end
 Returns the Calabi–Yau hypersurface that defines the Weierstrass model
 as a closed subvariety of its toric ambient space.
 
+# Examples
 ```jldoctest
 julia> w =  weierstrass_model_over_projective_space(3)
 Weierstrass model over a concrete base
@@ -134,6 +139,7 @@ end
 
 Returns the discriminant ``\Delta = 4 f^3 + 27 g^2`` of the Weierstrass model.
 
+# Examples
 ```jldoctest
 julia> w =  weierstrass_model_over_projective_space(3)
 Weierstrass model over a concrete base
@@ -174,6 +180,7 @@ Advanced technical details are available in [BMT25](@cite BMT25).
     The classification of singularities is based on a Monte Carlo algorithm, which involves random sampling.
     While extensively tested and highly reliable, the method’s probabilistic nature may lead to non-deterministic results in rare cases.
 
+# Examples
 ```jldoctest
 julia> w =  weierstrass_model_over_projective_space(3)
 Weierstrass model over a concrete base

--- a/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
@@ -5,7 +5,7 @@
 @doc raw"""
     weierstrass_model(base::NormalToricVariety; completeness_check::Bool = true)
 
-Constructs a Weierstrass model over a given toric base space. The Weierstrass sections
+Construct a Weierstrass model over a given toric base space. The Weierstrass sections
 ``f`` and ``g`` are automatically generated with (pseudo)random coefficients.
 
 # Examples
@@ -23,7 +23,7 @@ end
 @doc raw"""
     weierstrass_model(base::NormalToricVariety, f::MPolyRingElem, g::MPolyRingElem; completeness_check::Bool = true)
 
-Constructs a Weierstrass model over a given toric base space ``X``. The Weierstrass sections
+Construct a Weierstrass model over a given toric base space ``X``. The Weierstrass sections
 ``f`` and ``g`` are explicitly specified by the user as polynomials in the Cox ring of ``X``.
 
 # Examples
@@ -86,7 +86,7 @@ end
 @doc raw"""
     weierstrass_model(auxiliary_base_ring::MPolyRing, auxiliary_base_grading::Matrix{Int64}, d::Int, weierstrass_f::MPolyRingElem, weierstrass_g::MPolyRingElem)
 
-Constructs a Weierstrass model over an *unspecified* base space.
+Construct a Weierstrass model over an *unspecified* base space.
 
 This method is intended for workflows where the base space is not concretely fixed,
 such as in singularity engineering or symbolic studies. The variables in

--- a/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
@@ -8,6 +8,7 @@
 Constructs a Weierstrass model over a given toric base space. The Weierstrass sections
 ``f`` and ``g`` are automatically generated with (pseudo)random coefficients.
 
+# Examples
 ```jldoctest
 julia> w = weierstrass_model(projective_space(NormalToricVariety, 2); completeness_check = false)
 Weierstrass model over a concrete base
@@ -25,6 +26,7 @@ end
 Constructs a Weierstrass model over a given toric base space ``X``. The Weierstrass sections
 ``f`` and ``g`` are explicitly specified by the user as polynomials in the Cox ring of ``X``.
 
+# Examples
 ```jldoctest
 julia> chosen_base = projective_space(NormalToricVariety, 2)
 Normal toric variety
@@ -100,6 +102,7 @@ To support typical F-theory constructions, a variable `Kbar` representing a sect
 
 Note: This interface is more symbolic and less robust than the constructors for concrete toric bases.
 
+# Examples
 ```jldoctest
 julia> auxiliary_base_ring, (f, g, Kbar, v) = QQ[:f, :g, :Kbar, :u]
 (Multivariate polynomial ring in 4 variables over QQ, QQMPolyRingElem[f, g, Kbar, u])

--- a/experimental/FTheoryTools/src/WeierstrassModels/methods.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/methods.jl
@@ -13,6 +13,7 @@ model’s metadata (such as `explicit_model_sections` or `classes_of_model_secti
 This ensures the ability to later reintroduce non-trivial values for those sections,
 preserving model flexibility and reversibility.
 
+# Examples
 ```jldoctest
 julia> B2 = projective_space(NormalToricVariety, 2)
 Normal toric variety

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -441,6 +441,7 @@ Blow up the toric variety along a toric ideal sheaf.
 !!! warning
     This is an internal method. It is NOT exported.
 
+# Examples
 ```jldoctest
 julia> P3 = projective_space(NormalToricVariety, 3)
 Normal toric variety
@@ -485,6 +486,7 @@ By default, we pick "e" as the name of the homogeneous coordinate for
 the exceptional prime divisor. As third optional argument one can supply
 a custom variable name.
 
+# Examples
 ```jldoctest
 julia> P3 = projective_space(NormalToricVariety, 3)
 Normal toric variety

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -562,7 +562,7 @@ macro define_model_attribute_getter(arg_expr, doc_example="")
   default_doc = """
       $(fname)(m::AbstractFTheoryModel)
 
-  Returns `$(fname)` of the F-theory model if known, otherwise throws an error.
+  Return `$(fname)` of the F-theory model if known, otherwise throws an error.
 
   See [Literature Models](@ref literature_models) for more details.
 

--- a/experimental/FTheoryTools/src/standard_constructions.jl
+++ b/experimental/FTheoryTools/src/standard_constructions.jl
@@ -9,6 +9,7 @@ Constructs a global Tate model over the ``d``-dimensional projective space,
 represented as a toric variety. The Tate sections ``a_i`` are
 automatically generated with pseudorandom coefficients.
 
+# Examples
 ```jldoctest
 julia> global_tate_model_over_projective_space(3)
 Global Tate model over a concrete base
@@ -24,6 +25,7 @@ Constructs a Weierstrass model over the ``d``-dimensional projective space,
 represented as a toric variety. The Weierstrass sections ``f`` and ``g`` are
 automatically generated with pseudorandom coefficients.
 
+# Examples
 ```jldoctest
 julia> weierstrass_model_over_projective_space(3)
 Weierstrass model over a concrete base
@@ -43,6 +45,7 @@ Constructs a global Tate model over the Hirzebruch surface ``F_r``,
 represented as a toric variety. The Tate sections ``a_i`` are
 automatically generated with pseudorandom coefficients.
 
+# Examples
 ```jldoctest
 julia> global_tate_model_over_hirzebruch_surface(1)
 Global Tate model over a concrete base
@@ -58,6 +61,7 @@ Constructs a Weierstrass model over the Hirzebruch surface ``F_r``,
 represented as a toric variety. The Weierstrass sections ``f`` and ``g`` are
 automatically generated with pseudorandom coefficients.
 
+# Examples
 ```jldoctest
 julia> weierstrass_model_over_hirzebruch_surface(1)
 Weierstrass model over a concrete base
@@ -77,6 +81,7 @@ Constructs a global Tate model over the del Pezzo surface ``\text{dP}_b``,
 represented as a toric variety. The Tate sections ``a_i`` are
 automatically generated with pseudorandom coefficients.
 
+# Examples
 ```jldoctest
 julia> global_tate_model_over_del_pezzo_surface(3)
 Global Tate model over a concrete base
@@ -92,6 +97,7 @@ Constructs a Weierstrass model over the del Pezzo surface ``\text{dP}_b``,
 represented as a toric variety. The Weierstrass sections ``f`` and ``g`` are
 automatically generated with pseudorandom coefficients.
 
+# Examples
 ```jldoctest
 julia> weierstrass_model_over_del_pezzo_surface(3)
 Weierstrass model over a concrete base

--- a/experimental/FTheoryTools/src/standard_constructions.jl
+++ b/experimental/FTheoryTools/src/standard_constructions.jl
@@ -5,7 +5,7 @@
 @doc raw"""
     global_tate_model_over_projective_space(d::Int)
 
-Constructs a global Tate model over the ``d``-dimensional projective space,
+Construct a global Tate model over the ``d``-dimensional projective space,
 represented as a toric variety. The Tate sections ``a_i`` are
 automatically generated with pseudorandom coefficients.
 
@@ -21,7 +21,7 @@ global_tate_model_over_projective_space(d::Int) = global_tate_model(projective_s
 @doc raw"""
     weierstrass_model_over_projective_space(d::Int)
 
-Constructs a Weierstrass model over the ``d``-dimensional projective space,
+Construct a Weierstrass model over the ``d``-dimensional projective space,
 represented as a toric variety. The Weierstrass sections ``f`` and ``g`` are
 automatically generated with pseudorandom coefficients.
 
@@ -41,7 +41,7 @@ weierstrass_model_over_projective_space(d::Int) = weierstrass_model(projective_s
 @doc raw"""
     global_tate_model_over_hirzebruch_surface(r::Int)
 
-Constructs a global Tate model over the Hirzebruch surface ``F_r``,
+Construct a global Tate model over the Hirzebruch surface ``F_r``,
 represented as a toric variety. The Tate sections ``a_i`` are
 automatically generated with pseudorandom coefficients.
 
@@ -57,7 +57,7 @@ global_tate_model_over_hirzebruch_surface(r::Int) = global_tate_model(hirzebruch
 @doc raw"""
     weierstrass_model_over_hirzebruch_surface(r::Int)
 
-Constructs a Weierstrass model over the Hirzebruch surface ``F_r``,
+Construct a Weierstrass model over the Hirzebruch surface ``F_r``,
 represented as a toric variety. The Weierstrass sections ``f`` and ``g`` are
 automatically generated with pseudorandom coefficients.
 
@@ -77,7 +77,7 @@ weierstrass_model_over_hirzebruch_surface(r::Int) = weierstrass_model(hirzebruch
 @doc raw"""
     global_tate_model_over_del_pezzo_surface(b::Int)
 
-Constructs a global Tate model over the del Pezzo surface ``\text{dP}_b``,
+Construct a global Tate model over the del Pezzo surface ``\text{dP}_b``,
 represented as a toric variety. The Tate sections ``a_i`` are
 automatically generated with pseudorandom coefficients.
 
@@ -93,7 +93,7 @@ global_tate_model_over_del_pezzo_surface(b::Int) = global_tate_model(del_pezzo_s
 @doc raw"""
     weierstrass_model_over_del_pezzo_surface(b::Int)
 
-Constructs a Weierstrass model over the del Pezzo surface ``\text{dP}_b``,
+Construct a Weierstrass model over the del Pezzo surface ``\text{dP}_b``,
 represented as a toric variety. The Weierstrass sections ``f`` and ``g`` are
 automatically generated with pseudorandom coefficients.
 


### PR DESCRIPTION
* Add `# Examples` to all FTheoryTools docstring examples.
* Enforce imperative in doc strings by renaming `Returns` to `Return` (and friends) in doc strings.

cc @apturner @emikelsons 