### PR TITLE
[FTheoryTools] Overhaul the QSM documentation

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -1980,6 +1980,19 @@
   year          = {2005}
 }
 
+@Article{KS98,
+  author        = {Kreuzer, Maximilian and Skarke, Harald},
+  title         = {{Classification of reflexive polyhedra in three-dimensions}},
+  journal       = {Adv. Theor. Math. Phys.},
+  volume        = {2},
+  pages         = {853--871},
+  year          = {1998},
+  doi           = {10.4310/ATMP.1998.v2.n4.a5},
+  eprint        = {hep-th/9805190},
+  archiveprefix = {arXiv},
+  reportnumber  = {UTTG-07-98, TUW-98-13}
+}
+
 @InCollection{KS99,
   author        = {Kemper, Gregor and Steel, Allan},
   title         = {Some algorithms in invariant theory of finite groups},

--- a/experimental/FTheoryTools/docs/src/generalities.md
+++ b/experimental/FTheoryTools/docs/src/generalities.md
@@ -37,6 +37,24 @@ global_gauge_group_quotient(m::AbstractFTheoryModel)
 
 ---
 
+## [Not Yet Computed Advanced Mathematical Attributes](@id non_yet_algorithmic_advanced_attributes)
+
+In principle, the following can be computed, but we do not compute
+them yet. So they are only currently available only if the information
+has been stored for a literature model.
+
+The following methods return the Hodge numbers of the elliptically
+fibered 4-fold that defines the F-theory model in question.
+
+```@docs
+hodge_h11(m::AbstractFTheoryModel)
+hodge_h12(m::AbstractFTheoryModel)
+hodge_h13(m::AbstractFTheoryModel)
+hodge_h22(m::AbstractFTheoryModel)
+```
+
+---
+
 ## Tuning Singularities
 
 Often, one may wish to start with an existing model and modify some of its parameters—specifically its

--- a/experimental/FTheoryTools/docs/src/qsm_models.md
+++ b/experimental/FTheoryTools/docs/src/qsm_models.md
@@ -4,83 +4,265 @@ CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 
-# [The Quadrillion F-Theory Standard Models (QSMs)](@id qsm_models)
+# [The F-Theory QSMs](@id qsm_models)
 
-A yet more special instance of literature models are the Quadrillion F-theory Standard Models
-(F-theory QSMs) [CHLLT19](@cite). Those hypersurface models come in 708 different families.
+The **Quadrillion F-Theory Standard Models (QSMs)** were introduced in [CHLLT19](@cite)
+as a large class of compactifications within F-theory that exhibit promising features for
+particle physics model building. Due to their richness and physical relevance, these models
+have been extensively studied; see for example [Bie24](@cite) and the references therein.
 
-The base geometry of an F-theory QSM is obtained from triangulating one of 708 reflexive 3-dimensional
-polytopes. The models, whose bases are obtained from triangulations of the same polytope form a family.
-The following information on the polytope in question and its triangulations is available within our database:
+The detailed geometric and physical properties of the QSMs are captured within `FTheoryTools`
+through the framework of [Literature Models](@ref literature_models), enabling computations
+and explorations of their characteristics.
+
+---
+
+## What are the QSM?
+
+The QSMs correspond to a vast ensemble of F-theory compactifications constructed on elliptically
+fibered Calabi–Yau fourfolds with carefully chosen base geometries. Their defining feature is that
+they yield low-energy effective theories closely resembling the Standard Model of particle physics,
+including realistic gauge groups and chiral matter spectra.
+
+The geometries arise from systematically classifying certain favorable base threefolds, often toric,
+and then carefully engineering elliptic fibrations that produce the Standard Model gauge group and
+chiral matter spectrum.
+
+In `FTheoryTools`, we focus on the QSMs built over toric base spaces. It turned out that there are
+exactly 708 families of such QSM geometries. Each family corresponds to the fine, regular, star
+triangulation of one reflexive 3-dimensional polytope. Since the number of such triangulations can
+be astronomical — more specifically, the largest such number is a quadrillion (``10^{15}``), which gives
+this family of F-theory models its name — in `FTheoryTools` one such triangulation is chosen. In
+other words, we could read this as a chosen representative for each family, that can be constructed
+via the framework of [Literature Models](@ref literature_models).
+
+---
+
+## Constructing QSMs
+
+The construction of QSMs happens via the literature model constructor. Here is an example:
+
+```julia
+julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
+Hypersurface model over a concrete base
+```
+
+The value assigned to the model parameter `k` must be altered to construct different QSMs.
+Recall that there are exactly 708 distinct classes of QSMs, each family corresponding to the
+fine, regular, star triangulations of the k-th reflexive polytope in the Kreuzer-Skarke list
+(cf. [KS98](@cite)).
+
+Accordingly, `k` corresponds exactly to the index of the polytopes as they appear in the
+Kreuzer-Skarke list. The "first" QSM is associated with the 4th polytope, and the last one with
+index `k = 4291`. Between these, 706 other values correspond to QSMs. If a given `k` does not
+correspond to a QSM, the constructor raises an error.
+
+---
+
+## [The Underlying Polytope](@id qsm_polytope)
+
+Each QSM corresponds to a family of models associated with the fine regular star triangulations
+of a reflexive 3-dimensional polytope. The following methods provide detailed information about
+the underlying polytope and its triangulations.
+
+### Vertices
+
+Return the vertices of the underlying polytope. Vertices are normalized to rational numbers following the Polymake standard.
 
 ```@docs
 vertices(m::AbstractFTheoryModel)
+```
+
+### Polytope Index
+
+Return the index of the underlying polytope within the Kreuzer-Skarke list ([KS98](@cite)).
+
+```@docs
 polytope_index(m::AbstractFTheoryModel)
+```
+
+### Quick Triangulation Feasibility
+
+Enumerating all full, regular, star triangulations of a 3-dimensional reflexive polytope can be extremely time-consuming. This method returns `true` if enumerating all such triangulations is expected to complete in a reasonable time (e.g., within 5 minutes on a personal computer), and `false` otherwise.
+
+```@docs
 has_quick_triangulation(m::AbstractFTheoryModel)
+```
+
+### Maximal Number of Lattice Points in a Facet
+
+To enumerate all full, regular, star triangulations of the underlying polytope, one can first work out the corresponding triangulations of all facets [HT17](@cite). A rough estimate for the complexity of finding all triangulations of a facet is its number of lattice points. This method returns the maximal number of lattice points over all facets of the underlying polytope.
+
+```@docs
 max_lattice_pts_in_facet(m::AbstractFTheoryModel)
+```
+
+### Estimated Number of Triangulations
+
+Provide an estimate of the total number of full, regular, star triangulations of the underlying polytope.
+
+```@docs
 estimated_number_of_triangulations(m::AbstractFTheoryModel)
 ```
 
-Beyond the polytope and its triangulations, a number of other integers are of key importance. The following
-are supported in our database.
+---
+
+## [Topological Data of a QSM](@id qsm_top_data)
+
+In addition to the polytope data, several topological invariants play a central role in analyzing
+the geometry of a QSM.
+
+The following method returns the triple self-intersection number of the anticanonical class
+``\overline{K}_{B_3}`` of the 3-dimensional base:
 
 ```@docs
 kbar3(m::AbstractFTheoryModel)
-hodge_h11(m::AbstractFTheoryModel)
-hodge_h12(m::AbstractFTheoryModel)
-hodge_h13(m::AbstractFTheoryModel)
-hodge_h22(m::AbstractFTheoryModel)
 ```
 
-More recently, a research program estimated the exact massless spectra of the F-theory QSMs
-(cf. [Bie24](@cite)). These studies require yet more information about the F-theory QSM geometries,
-which are supported by our database.
+The Hodge numbers of the elliptically fibered Calabi–Yau 4-fold are also available. For details, see
+[Functionality for all F-theory models](@ref functionality_for_all_f_theory_models).
 
-First, recall that (currently), the base of an F-theory QSM is a 3-dimensional toric variety B3.
-Let s in H^0(B3, Kbar_B3), then V(s) is a K3-surface. Moreover, let xi be the coordinates
-of the Cox ring of B3. Then V(xi) is a divisor in B3. Consequently, Ci = V(xi) cap V(s)
-is a divisor in the K3-surface V(s). For the root bundle counting program, these curves Ci are
-of ample importance (cf. [Bie24](@cite)). We support the following information on these curves:
+---
+
+## [The Nodal Curve](@id qsm_nodal_curve)
+
+Recent studies (see [Bie24](@cite)) have refined the exact massless spectrum estimates for F-theory QSMs.
+These developments rely on deeper geometric data, much of which is accessible via the `FTheoryTools` database.
+
+Recall that for `FTheoryTools`, the base of a QSM is a 3-dimensional toric variety ``B_3``. Let
+``s \in H^0(B_3, \bar{K}_{B_3})`` be a generic section of the anticanonical bundle. Then ``V(s) \subset B_3``
+defines a K3 surface. Additionally, each homogeneous coordinate ``x_i`` of the Cox ring of ``B_3`` defines
+a divisor ``V(x_i) \subset B_3``, and we define the curve:
+
+$C_i := V(x_i) \cap V(s)\,.$
+
+Collectively, the curves ``C_i`` form a nodal curve, which plays a crucial role in the exact massless spectrum
+estimates (see [Bie24](@cite) and references therein).
+
+The following quantities associated to the curves ``C_i`` are supported.
+
+### Genera of the Curves ``C_i``
+
+Return the genera of all ``C_i = V(x_i, s)``, labeled by their respective Cox ring coordinate indices.
 
 ```@docs
 genera_of_ci_curves(m::AbstractFTheoryModel)
+```
+
+### Degrees of ``\bar{K}_{B_3}|_{C_i}``
+
+Compute the degree of the restriction of the anticanonical bundle ``\bar{K}_{B_3}`` to each curve ``C_i``.
+
+```@docs
 degrees_of_kbar_restrictions_to_ci_curves(m::AbstractFTheoryModel)
+```
+
+### Topological Intersection Numbers Among All ``C_i``
+
+Returns the intersection matrix among the ``C_i`` curves.
+
+```@docs
 topological_intersection_numbers_among_ci_curves(m::AbstractFTheoryModel)
+```
+
+### Indices of Trivial Curves
+
+Some intersections ``V(x_i, s)`` may be empty. This function returns the list of all indices ``i`` such that ``C_i = \emptyset``.
+
+```@docs
 indices_of_trivial_ci_curves(m::AbstractFTheoryModel)
+```
+
+### Intersection Matrix of Non-trivial Curves
+
+Returns the intersection matrix among the non-trivial ``C_i``.
+
+```@docs
 topological_intersection_numbers_among_nontrivial_ci_curves(m::AbstractFTheoryModel)
 ```
 
-The collection of the Ci-curves form a nodal curve. To every nodal curve one can associate a
-(dual) graph. In this graph, every irreducible component of the nodal curve becomes a node/vertex
-of the dual graph, and every nodal singularity of the nodal curve turns into an edge of the dual
-graph. In the case at hand, this is rather simple.
+---
 
-The Ci-curves turn into the irreducible components of the nodel curve. Certainly, we only need
-to focus on the non-trivial Ci-curves. A non-trivial Ci-curve can split into multiple irreducible
-components. This is taken into account when the nodes/vertices of the dual graph are constructed.
+## [The Dual Graph](@id qsm_dual_graph)
 
-The topological intersection numbers among the Ci-curves (or rather, their irreducible components)
-tells us how many nodal singularities link the Ci-curves (or rather, their irreducible components)
-in question. Hence, if the topological intersection numbers is zero, there is no edge between the
-corresponding nodes. Otherwise, if the topological intersection number is positive - say n -, then
-there are exactly n edges between the nodes in question.
+The collection of ``C_i``-curves described above forms a nodal curve. To such a curve, one can associate a **dual graph**:
 
-The following functions access/create the so-obtained dual graph:
+- Each **irreducible component** of the nodal curve corresponds to a **vertex** (or node) in the graph.
+- Each **nodal intersection** (i.e. a singular point where two components meet) becomes an **edge**.
+
+Only **non-trivial** ``C_i = V(x_i, s)`` curves are included in this graph. If a curve ``C_i`` is reducible,
+its irreducible components each get their own vertex. The number of edges between any two vertices is determined
+by the **topological intersection number** of their corresponding components.
+
+The following methods allow access to this graph and its associated data.
+
+### The Dual Graph
+
+Returns the unlabelled, undirected dual graph for the given QSM. Each node corresponds to an irreducible component of a non-trivial ``C_i`` curve.
 
 ```@docs
 dual_graph(m::AbstractFTheoryModel)
+```
+
+### Component Labels
+
+Returns the labels — each a string — for each node in the dual graph, indicating the geometric origin of the corresponding irreducible component. If ``C_i`` is irreducible, the label is `"Ci"`. If ``C_i`` is reducible, its components are labeled as `"Ci-0"`, `"Ci-1"`, etc.
+
+```@docs
 components_of_dual_graph(m::AbstractFTheoryModel)
+```
+
+### Degrees of the restriction of ``\bar{K}_{B_3}`` to the Components
+
+Computes the degree of the anticanonical bundle ``\bar{K}_{B_3}`` when restricted to each component (node) of the dual graph.
+
+```@docs
 degrees_of_kbar_restrictions_to_components_of_dual_graph(m::AbstractFTheoryModel)
+```
+
+### Genera of the Components
+
+Returns the genus of each irreducible component represented by a node in the dual graph.
+
+```@docs
 genera_of_components_of_dual_graph(m::AbstractFTheoryModel)
 ```
 
-The dual graph is essential in counting root bundles (cf. [BCL21](@cite)). It turns out, that one
-can simplify this graph so that the computations at hand can be conducted on a simpler graph
-instead. The following functionality exists to access this simplified dual graph.
+---
+
+## [The Simplified Dual Graph](@id qsm_simple_dual_graph)
+
+The estimates for the exact massless spectrum of the QSMs are based on root bundle counting
+(cf. [BCL21](@cite)). This in turn employs the **dual graph** described in the previous section.
+However, it turns out, that the **dual graph** can often be simplified without loss of relevant
+information for the root bundle counting. This leads to a **reduced** version of the graph on
+which the root bundle computations are easier to perform. The following functions provide access
+to this **simplified dual graph**.
 
 ```@docs
 simplified_dual_graph(m::AbstractFTheoryModel)
+```
+
+### Component Labels
+
+Returns the labels — each a string — for each vertex in the simplified dual graph. These labels correspond to irreducible components of non-trivial ``C_i = V(x_i, s)`` curves.
+
+```@docs
 components_of_simplified_dual_graph(m::AbstractFTheoryModel)
+```
+
+### Degrees of ``\bar{K}_{B_3}`` on the Components
+
+Returns the degrees of the anticanonical bundle ``\bar{K}_{B_3}`` restricted to the components (nodes) of the simplified dual graph.
+
+```@docs
 degrees_of_kbar_restrictions_to_components_of_simplified_dual_graph(m::AbstractFTheoryModel)
+```
+
+### Genera of the Components
+
+Returns the genus of each irreducible component corresponding to a node in the simplified dual graph.
+
+```@docs
 genera_of_components_of_simplified_dual_graph(m::AbstractFTheoryModel)
 ```

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/not_yet_computed_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/not_yet_computed_attributes.jl
@@ -1,0 +1,46 @@
+@define_model_attribute_getter((hodge_h11, Int),
+"""
+```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
+julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
+Hypersurface model over a concrete base
+
+julia> hodge_h11(qsm_model)
+31
+```
+""", "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details.", h11)
+
+
+@define_model_attribute_getter((hodge_h12, Int),
+"""
+```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
+julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
+Hypersurface model over a concrete base
+
+julia> hodge_h12(qsm_model)
+10
+```
+""", "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details.", h12)
+
+
+@define_model_attribute_getter((hodge_h13, Int),
+"""
+```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
+julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
+Hypersurface model over a concrete base
+
+julia> hodge_h13(qsm_model)
+34
+```
+""", "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details.", h13)
+
+
+@define_model_attribute_getter((hodge_h22, Int),
+"""
+```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
+julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
+Hypersurface model over a concrete base
+
+julia> hodge_h22(qsm_model)
+284
+```
+""", "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details.", h22)

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/qsm_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/qsm_attributes.jl
@@ -1,13 +1,9 @@
-### (1) Attributes regarding the polytope in the Kreuzer-Skarke database
+######################################################################
+# (1) Attributes regarding the polytope in the Kreuzer-Skarke database
+######################################################################
 
-@doc raw"""
-    vertices(m::AbstractFTheoryModel)
-
-This method returns the vertices of the polytope the the base of the F-theory QSM is
-build from. Note that those vertices are normalized according to the Polymake standard
-to rational numbers.
-
-# Examples
+@define_model_attribute_getter((vertices, Vector{Vector{QQFieldElem}}),
+"""
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -19,20 +15,11 @@ julia> vertices(qsm_model)
  [-1, 2, -1]
  [-1, -1, 5]
 ```
+""", "See [Underlying Polytope](@ref qsm_polytope) for more details.")
+
+
+@define_model_attribute_getter((polytope_index, Int),
 """
-function vertices(m::AbstractFTheoryModel)
-  @req has_attribute(m, :vertices) "No vertices known for this model"
-  return get_attribute(m, :vertices)::Vector{Vector{QQFieldElem}}
-end
-
-
-@doc raw"""
-    polytope_index(m::AbstractFTheoryModel)
-
-Of the 3-dimensional reflexive polytope that the base of this F-theory model is build from,
-this method returns the index within the Kreuzer-Skarke list.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -40,25 +27,11 @@ Hypersurface model over a concrete base
 julia> polytope_index(qsm_model)
 4
 ```
+""", "See [Underlying Polytope](@ref qsm_polytope) for more details.", poly_index)
+
+
+@define_model_attribute_getter((has_quick_triangulation, Bool),
 """
-function polytope_index(m::AbstractFTheoryModel)
-  @req has_attribute(m, :poly_index) "No polytope index known for this model"
-  return get_attribute(m, :poly_index)::Int
-end
-
-
-@doc raw"""
-    has_quick_triangulation(m::AbstractFTheoryModel)
-
-For a 3-dimensional reflexive polytope in the Kreuzer-Skarke list, the list of
-full (sometimes also called fine), regular, star triangulations can be extremely
-large. Consequently, one may wonder if the triangulations can be enumerated in a
-somewhat reasonable time (say 5 minutes on a personal computer). This method tries
-to provide an answer to this. It returns `true` if one should expect a timely response
-to the attempt to enumerate all (full, regular, star) triangulations. Otherwise, this
-method returns `false`.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -66,24 +39,11 @@ Hypersurface model over a concrete base
 julia> has_quick_triangulation(qsm_model)
 true
 ```
+""", "See [Underlying Polytope](@ref qsm_polytope) for more details.", triang_quick)
+
+
+@define_model_attribute_getter((max_lattice_pts_in_facet, Int),
 """
-function has_quick_triangulation(m::AbstractFTheoryModel)
-  @req has_attribute(m, :triang_quick) "It is not known if the base of this model can be triangulated quickly"
-  return get_attribute(m, :triang_quick)::Bool
-end
-
-
-@doc raw"""
-    max_lattice_pts_in_facet(m::AbstractFTheoryModel)
-
-In order to enumerate the number of full, regular, star triangulations of a
-3-dimensional reflexive polytope, it is possible to first find the corresponding
-triangulations of all facets of the polytope [HT17](@cite). A first indication for
-the complexity of this triangulation task is the maximum number of lattice points
-in a facet of the polytope in question. This method returns this maximal number of
-lattice points.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -91,21 +51,11 @@ Hypersurface model over a concrete base
 julia> max_lattice_pts_in_facet(qsm_model)
 16
 ```
+""", "See [Underlying Polytope](@ref qsm_polytope) for more details.")
+
+
+@define_model_attribute_getter((estimated_number_of_triangulations, Int),
 """
-function max_lattice_pts_in_facet(m::AbstractFTheoryModel)
-  @req has_attribute(m, :max_lattice_pts_in_facet) "Maximal number of lattice points of facets not known for this model"
-  return get_attribute(m, :max_lattice_pts_in_facet)::Int
-end
-
-
-@doc raw"""
-    estimated_number_of_triangulations(m::AbstractFTheoryModel)
-
-This method returns an estimate for the number of full, regular, star triangulations
-of the 3-dimensional reflexive polytope, those triangulations define the possible base
-spaces of the F-theory QSM in question.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -113,24 +63,16 @@ Hypersurface model over a concrete base
 julia> estimated_number_of_triangulations(qsm_model)
 212533333333
 ```
+""", "See [Underlying Polytope](@ref qsm_polytope) for more details.")
+
+
+
+######################################################################
+# (2) Topological properties
+######################################################################
+
+@define_model_attribute_getter((kbar3, Int),
 """
-function estimated_number_of_triangulations(m::AbstractFTheoryModel)
-  @req has_attribute(m, :estimated_number_of_triangulations) "Estimated number of (full, regular, star) triangulation not known for this model"
-  return get_attribute(m, :estimated_number_of_triangulations)::Int
-end
-
-
-### (2) Attributes regarding the polytope in the Kreuzer-Skarke database
-
-
-@doc raw"""
-    kbar3(m::AbstractFTheoryModel)
-
-Let Kbar denote the anticanonical class of the 3-dimensional base space of the F-theory QSM.
-Of ample importance is the triple intersection number of Kbar, i.e. Kbar * Kbar * Kbar.
-This method returns this intersection number.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -138,111 +80,16 @@ Hypersurface model over a concrete base
 julia> kbar3(qsm_model)
 6
 ```
+""", "See [Topological Data of a `QSM`](@ref qsm_top_data) for more details.", Kbar3)
+
+
+
+######################################################################
+# (3) Attributes regarding the Ci-curves
+######################################################################
+
+@define_model_attribute_getter((genera_of_ci_curves, Dict{MPolyDecRingElem, Int64}),
 """
-function kbar3(m::AbstractFTheoryModel)
-  @req has_attribute(m, :Kbar3) "Kbar3 not known for this model"
-  return get_attribute(m, :Kbar3)::Int
-end
-
-
-@doc raw"""
-    hodge_h11(m::AbstractFTheoryModel)
-
-This methods return the Hodge number h11 of the elliptically
-fibered 4-fold that defined the F-theory QSM in question.
-
-# Examples
-```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
-julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
-Hypersurface model over a concrete base
-
-julia> hodge_h11(qsm_model)
-31
-```
-"""
-function hodge_h11(m::AbstractFTheoryModel)
-  @req has_attribute(m, :h11) "Hodge number h11 of ambient space not known for this model"
-  return get_attribute(m, :h11)::Int
-end
-
-
-@doc raw"""
-    hodge_h12(m::AbstractFTheoryModel)
-
-This methods return the Hodge number h12 of the elliptically
-fibered 4-fold that defined the F-theory QSM in question.
-
-# Examples
-```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
-julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
-Hypersurface model over a concrete base
-
-julia> hodge_h12(qsm_model)
-10
-```
-"""
-function hodge_h12(m::AbstractFTheoryModel)
-  @req has_attribute(m, :h12) "Hodge number h12 of ambient space not known for this model"
-  return get_attribute(m, :h12)::Int
-end
-
-
-@doc raw"""
-    hodge_h13(m::AbstractFTheoryModel)
-
-This methods return the Hodge number h13 of the elliptically
-fibered 4-fold that defined the F-theory QSM in question.
-
-# Examples
-```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
-julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
-Hypersurface model over a concrete base
-
-julia> hodge_h13(qsm_model)
-34
-```
-"""
-function hodge_h13(m::AbstractFTheoryModel)
-  @req has_attribute(m, :h13) "Hodge number h13 of ambient space not known for this model"
-  return get_attribute(m, :h13)::Int
-end
-
-
-@doc raw"""
-    hodge_h22(m::AbstractFTheoryModel)
-
-This methods return the Hodge number h22 of the elliptically
-fibered 4-fold that defined the F-theory QSM in question.
-
-# Examples
-```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
-julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
-Hypersurface model over a concrete base
-
-julia> hodge_h22(qsm_model)
-284
-```
-"""
-function hodge_h22(m::AbstractFTheoryModel)
-  @req has_attribute(m, :h22) "Hodge number h22 of ambient space not known for this model"
-  return get_attribute(m, :h22)::Int
-end
-
-
-### (3) Attributes regarding the Ci-curves
-
-
-@doc raw"""
-    genera_of_ci_curves(m::AbstractFTheoryModel)
-
-This methods return the genera of the Ci curves.
-Recall that Ci = V(xi, s), where xi is a homogeneous
-coordinate of the 3-dimensional toric base space B3 of the
-QSM hypersurface model in question, and s is a generic
-section of the anticanonical bundle of B3. Consequently,
-we may use the coordinates xi as labels for the curves Ci.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -255,22 +102,11 @@ x7
 julia> genera_of_ci_curves(qsm_model)[my_key]
 0
 ```
+""", "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.", genus_ci)
+
+
+@define_model_attribute_getter((degrees_of_kbar_restrictions_to_ci_curves, Dict{MPolyDecRingElem, Int64}),
 """
-function genera_of_ci_curves(m::AbstractFTheoryModel)
-  @req has_attribute(m, :genus_ci) "Genera of Ci curves not known for this model"
-  return get_attribute(m, :genus_ci)
-end
-
-
-@doc raw"""
-    degrees_of_kbar_restrictions_to_ci_curves(m::AbstractFTheoryModel)
-
-The anticanonical divisor of the 3-dimensional toric base space B3 of the
-QSM hypersurface model in question can be restricted to the Ci curves. The
-result of this operation is a line bundle. This method returns the degree of
-this line bundle for every Ci curve.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -283,20 +119,11 @@ x7
 julia> degrees_of_kbar_restrictions_to_ci_curves(qsm_model)[my_key]
 0
 ```
+""", "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.", degree_of_Kbar_of_tv_restricted_to_ci)
+
+
+@define_model_attribute_getter((topological_intersection_numbers_among_ci_curves, Matrix{Int64}),
 """
-function degrees_of_kbar_restrictions_to_ci_curves(m::AbstractFTheoryModel)
-  @req has_attribute(m, :degree_of_Kbar_of_tv_restricted_to_ci) "Degree of Kbar restriction to Ci curves not known for this model"
-  return get_attribute(m, :degree_of_Kbar_of_tv_restricted_to_ci)
-end
-
-
-@doc raw"""
-    topological_intersection_numbers_among_ci_curves(m::AbstractFTheoryModel)
-
-The topological intersection numbers among Ci curves are also of ample importance.
-This method returns those intersection numbers in the form of a matrix.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -307,22 +134,11 @@ julia> n_rows(topological_intersection_numbers_among_ci_curves(qsm_model))
 julia> n_columns(topological_intersection_numbers_among_ci_curves(qsm_model))
 29
 ```
+""", "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.", intersection_number_among_ci_cj)
+
+
+@define_model_attribute_getter((indices_of_trivial_ci_curves, Vector{Int64}),
 """
-function topological_intersection_numbers_among_ci_curves(m::AbstractFTheoryModel)
-  @req has_attribute(m, :intersection_number_among_ci_cj) "Topological intersection numbers among Ci curves not known for this model"
-  return get_attribute(m, :intersection_number_among_ci_cj)
-end
-
-
-@doc raw"""
-    indices_of_trivial_ci_curves(m::AbstractFTheoryModel)
-
-Some of the Ci curves are trivial, in that V(xi, s) is the empty set.
-This method returns the vector of all indices of trivial Ci curves.
-That is, should V(x23, s) be the empty set, then 23 will be included in
-the returned list.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -340,20 +156,11 @@ julia> indices_of_trivial_ci_curves(qsm_model)
  12
  15
 ```
+""", "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.", index_facet_interior_divisors)
+
+
+@define_model_attribute_getter((topological_intersection_numbers_among_nontrivial_ci_curves, Matrix{Int64}),
 """
-function indices_of_trivial_ci_curves(m::AbstractFTheoryModel)
-  @req has_attribute(m, :index_facet_interior_divisors) "Degree of Kbar restriction to Ci curves not known for this model"
-  return get_attribute(m, :index_facet_interior_divisors)::Vector{Int}
-end
-
-
-@doc raw"""
-    topological_intersection_numbers_among_nontrivial_ci_curves(m::AbstractFTheoryModel)
-
-The topological intersection numbers among the non-trivial Ci curves are used
-frequently. This method returns those intersection numbers in the form of a matrix.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -364,24 +171,16 @@ julia> n_rows(topological_intersection_numbers_among_nontrivial_ci_curves(qsm_mo
 julia> n_columns(topological_intersection_numbers_among_nontrivial_ci_curves(qsm_model))
 19
 ```
+""", "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.", intersection_number_among_nontrivial_ci_cj)
+
+
+
+######################################################################
+# (4) Attributes regarding the dual graph
+######################################################################
+
+@define_model_attribute_getter((dual_graph, Graph{Undirected}),
 """
-function topological_intersection_numbers_among_nontrivial_ci_curves(m::AbstractFTheoryModel)
-  @req has_attribute(m, :intersection_number_among_nontrivial_ci_cj) "Topological intersection numbers among non-trivial Ci curves not known for this model"
-  return get_attribute(m, :intersection_number_among_nontrivial_ci_cj)
-end
-
-
-### (4) Attributes regarding the dual graph
-
-
-@doc raw"""
-    dual_graph(m::AbstractFTheoryModel)
-
-This method returns the dual graph of the QSM model in question.
-Note that no labels are (currently) attached to the vertices/nodes or edges.
-To understand/read this graph correctly, please use the methods listed below.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -390,32 +189,11 @@ julia> dual_graph(qsm_model)
 Undirected graph with 21 nodes and the following edges:
 (5, 1)(6, 5)(7, 6)(8, 7)(9, 4)(9, 8)(10, 1)(11, 4)(12, 3)(12, 10)(13, 3)(13, 11)(14, 1)(15, 4)(16, 3)(17, 3)(18, 2)(18, 14)(19, 2)(19, 15)(20, 2)(20, 16)(21, 2)(21, 17)
 ```
+""", "See [The Dual Graph](@ref qsm_dual_graph) for more details.")
+
+
+@define_model_attribute_getter((components_of_dual_graph, Vector{String}),
 """
-function dual_graph(m::AbstractFTheoryModel)
-  @req has_attribute(m, :dual_graph) "Dual graph not known for this model"
-  return get_attribute(m, :dual_graph)
-end
-
-
-@doc raw"""
-    components_of_dual_graph(m::AbstractFTheoryModel)
-
-This method returns a vector with labels for each node/vertex of the dual graph of the QSM
-model in question. Those labels allow to understand the geometric origin of the node/vertex.
-
-Specifically, recall that those nodes are associated to the Ci-curves, which are in turn
-given by Ci = V(xi, s). xi is a homogeneous coordinate of the 3-dimensional toric base space
-B3 of the QSM in question, and s is a generic section of the anticanonical bundle of B3.
-
-Only non-trivial Ci = V(xi, s) correspond to vertices/nodes of the dual graph.
-
-If Ci = V(xi, s) is irreducible and corresponds to the k-th component, then the label "Ci"
-appears at position k of the vector returned by this method. However, if Ci = V(xi, s) is
-reducible, then we introduce the labels Ci-0, Ci-1, Ci-2 etc. for those irreducible
-components of Ci. If Ci-0 corresponds to the k-th components of the dual graph,
-then the label "Ci-0" appears at position k of the vector returned by this method.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -443,22 +221,11 @@ julia> components_of_dual_graph(qsm_model)
  "C28-0"
  "C28-1"
 ```
+""", "See [The Dual Graph](@ref qsm_dual_graph) for more details.")
+
+
+@define_model_attribute_getter((degrees_of_kbar_restrictions_to_components_of_dual_graph, Dict{String, Int64}),
 """
-function components_of_dual_graph(m::AbstractFTheoryModel)
-  @req has_attribute(m, :components_of_dual_graph) "Components of dual graph not known for this model"
-  return get_attribute(m, :components_of_dual_graph)
-end
-
-
-@doc raw"""
-    degrees_of_kbar_restrictions_to_components_of_dual_graph(m::AbstractFTheoryModel)
-
-The anticanonical bundle of the toric 3-dimensional base space of the F-theory QSM in
-question can be restricted to the (geometric counterparts of the) nodes/vertices of
-the dual graph. The result is a line bundle for each node/vertex. This method returns
-a vector with the degrees of these line bundles.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -466,20 +233,11 @@ Hypersurface model over a concrete base
 julia> degrees_of_kbar_restrictions_to_components_of_dual_graph(qsm_model)["C28-1"]
 0
 ```
+""", "See [The Dual Graph](@ref qsm_dual_graph) for more details.", degree_of_Kbar_of_tv_restricted_to_components_of_dual_graph)
+
+
+@define_model_attribute_getter((genera_of_components_of_dual_graph, Dict{String, Int64}),
 """
-function degrees_of_kbar_restrictions_to_components_of_dual_graph(m::AbstractFTheoryModel)
-  @req has_attribute(m, :degree_of_Kbar_of_tv_restricted_to_components_of_dual_graph) "Degree of Kbar restricted to components of dual graph not known for this model"
-  return get_attribute(m, :degree_of_Kbar_of_tv_restricted_to_components_of_dual_graph)
-end
-
-
-@doc raw"""
-    genera_of_components_of_dual_graph(m::AbstractFTheoryModel)
-
-This methods returns a vector with the genera of the (geometric
-counterparts of the) nodes/vertices of the dual graph.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -487,24 +245,15 @@ Hypersurface model over a concrete base
 julia> genera_of_components_of_dual_graph(qsm_model)["C28-1"]
 0
 ```
+""", "See [The Dual Graph](@ref qsm_dual_graph) for more details.", genus_of_components_of_dual_graph)
+
+
+######################################################################
+# (5) Attributes regarding the simplified dual graph
+######################################################################
+
+@define_model_attribute_getter((simplified_dual_graph, Graph{Undirected}),
 """
-function genera_of_components_of_dual_graph(m::AbstractFTheoryModel)
-  @req has_attribute(m, :genus_of_components_of_dual_graph) "Genera of components of dual graph not known for this model"
-  return get_attribute(m, :genus_of_components_of_dual_graph)
-end
-
-
-### (5) Attributes regarding the simplified dual graph
-
-
-@doc raw"""
-    simplified_dual_graph(m::AbstractFTheoryModel)
-
-This method returns the simplified dual graph of the QSM model in question.
-Note that no labels are (currently) attached to the vertices/nodes or edges.
-To understand/read this graph correctly, please use the methods listed below.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -513,20 +262,11 @@ julia> simplified_dual_graph(qsm_model)
 Undirected graph with 4 nodes and the following edges:
 (2, 1)(3, 1)(3, 2)(4, 1)(4, 2)(4, 3)
 ```
+""", "See [The Simplified Dual Graph](@ref qsm_simple_dual_graph) for more details.")
+
+
+@define_model_attribute_getter((components_of_simplified_dual_graph, Vector{String}),
 """
-function simplified_dual_graph(m::AbstractFTheoryModel)
-  @req has_attribute(m, :simplified_dual_graph) "Simplified dual graph not known for this model"
-  return get_attribute(m, :simplified_dual_graph)
-end
-
-
-@doc raw"""
-    components_of_simplified_dual_graph(m::AbstractFTheoryModel)
-
-This method returns a vector with labels for each node/vertex of the simplified dual graph.
-Otherwise, works identical to `components_of_dual_graph(m::AbstractFTheoryModel)`.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -538,20 +278,11 @@ julia> components_of_simplified_dual_graph(qsm_model)
  "C2"
  "C3"
 ```
+""", "See [The Simplified Dual Graph](@ref qsm_simple_dual_graph) for more details.")
+
+
+@define_model_attribute_getter((degrees_of_kbar_restrictions_to_components_of_simplified_dual_graph, Dict{String, Int64}),
 """
-function components_of_simplified_dual_graph(m::AbstractFTheoryModel)
-  @req has_attribute(m, :components_of_simplified_dual_graph) "Components of simplified dual graph not known for this model"
-  return get_attribute(m, :components_of_simplified_dual_graph)
-end
-
-
-@doc raw"""
-    degrees_of_kbar_restrictions_to_components_of_simplified_dual_graph(m::AbstractFTheoryModel)
-
-Same as `degrees_of_kbar_restrictions_to_components_of_dual_graph(m::AbstractFTheoryModel)`,
-but for the simplified dual graph.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -559,20 +290,11 @@ Hypersurface model over a concrete base
 julia> degrees_of_kbar_restrictions_to_components_of_simplified_dual_graph(qsm_model)["C2"]
 2
 ```
+""", "See [The Simplified Dual Graph](@ref qsm_simple_dual_graph) for more details.", degree_of_Kbar_of_tv_restricted_to_components_of_simplified_dual_graph)
+
+
+@define_model_attribute_getter((genera_of_components_of_simplified_dual_graph, Dict{String, Int64}),
 """
-function degrees_of_kbar_restrictions_to_components_of_simplified_dual_graph(m::AbstractFTheoryModel)
-  @req has_attribute(m, :degree_of_Kbar_of_tv_restricted_to_components_of_simplified_dual_graph) "Degree of Kbar restricted to components of simplified dual graph not known for this model"
-  return get_attribute(m, :degree_of_Kbar_of_tv_restricted_to_components_of_simplified_dual_graph)
-end
-
-
-@doc raw"""
-    genera_of_components_of_simplified_dual_graph(m::AbstractFTheoryModel)
-
-This methods returns a vector with the genera of the (geometric
-counterparts of the) nodes/vertices of the dual graph.
-
-# Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
@@ -580,8 +302,4 @@ Hypersurface model over a concrete base
 julia> genera_of_components_of_simplified_dual_graph(qsm_model)["C2"]
 0
 ```
-"""
-function genera_of_components_of_simplified_dual_graph(m::AbstractFTheoryModel)
-  @req has_attribute(m, :genus_of_components_of_simplified_dual_graph) "Genera of components of simplified dual graph not known for this model"
-  return get_attribute(m, :genus_of_components_of_simplified_dual_graph)
-end
+""", "See [The Simplified Dual Graph](@ref qsm_simple_dual_graph) for more details.", genus_of_components_of_simplified_dual_graph)

--- a/experimental/FTheoryTools/src/FTheoryTools.jl
+++ b/experimental/FTheoryTools/src/FTheoryTools.jl
@@ -8,9 +8,9 @@ include("FamilyOfSpaces/attributes.jl")
 include("AbstractFTheoryModels/basic_attributes.jl")
 include("AbstractFTheoryModels/section_attributes.jl")
 include("AbstractFTheoryModels/precomputed_attributes.jl")
+include("AbstractFTheoryModels/not_yet_computed_attributes.jl")
 include("AbstractFTheoryModels/computed_attributes.jl")
 include("AbstractFTheoryModels/qsm_attributes.jl")
-
 include("AbstractFTheoryModels/properties.jl")
 include("AbstractFTheoryModels/methods.jl")
 

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -548,7 +548,7 @@ end
 # 11: Macro for function generation
 ###########################################################################
 
-macro define_model_attribute_getter(arg_expr, doc_example="", doc_link="")
+macro define_model_attribute_getter(arg_expr, doc_example="", doc_link="", attr_name=nothing)
   if !(arg_expr isa Expr && arg_expr.head == :tuple && length(arg_expr.args) == 2)
     error("Expected input like: (function_name, ReturnType)")
   end
@@ -556,7 +556,11 @@ macro define_model_attribute_getter(arg_expr, doc_example="", doc_link="")
   fname_expr = arg_expr.args[1]
   rettype_expr = arg_expr.args[2]
   fname = fname_expr isa Symbol ? fname_expr : error("function_name is not a symbol")
-  sym = QuoteNode(fname)
+
+  # Determine attribute name symbol: use attr_name if provided, else function name
+  attr_sym = attr_name === nothing ? fname : (attr_name isa Symbol ? attr_name : error("attr_name must be a Symbol if provided"))
+  sym = QuoteNode(attr_sym)  
+  
   msg = "No $(replace(string(fname), '_' => ' ')) known for this model"
 
   # Conditionally build doc section


### PR DESCRIPTION
Based on https://github.com/oscar-system/Oscar.jl/pull/5147 for my convenience.

* This overhauls the documentation for the F-theory QSMs.
* Hodge numbers are not an attribute that is special to the QSMs, so moved to the generics page.
* Used the macro to streamline the generation of the QSM attribute getters. This required a slight extension of the macro.

Preview: https://docs.oscar-system.org/previews/PR5148/Experimental/FTheoryTools/introduction/

cc @apturner @emikelsons 