### PR TITLE
Use OSCAR<->GAP isomorphism of group in `stabilizer`

### DIFF
--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -557,9 +557,9 @@ julia> S = stabilizer(G, [1, 1, 2, 2, 3], permuted);  order(S[1])
 stabilizer(G::GAPGroup, pnt::Any, actfun::Function) = _stabilizer_generic(G, pnt, actfun)
 
 function _stabilizer_generic(G::GAPGroup, pnt::Any, actfun::Function)
-    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G), pnt,
-        GapObj(gens(G), recursive = true), GapObj(gens(G)),
-        GapObj(actfun)))
+  return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G), pnt,
+    GapObj(gens(G), recursive = true), GapObj(gens(G)),
+    GapObj(actfun)))
 end
 
 # natural stabilizers in permutation groups
@@ -569,35 +569,35 @@ end
 # - stabilizer in a perm. group of a vector of integers via `on_tuples`
 # - stabilizer in a perm. group of a set of integers via `on_sets`
 function stabilizer(G::PermGroup, pnt::T) where T <: IntegerUnion
-    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
-        GapObj(pnt),
-        GAP.Globals.OnPoints))  # Do not use GAPWrap.OnPoints!
+  return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+    GapObj(pnt),
+    GAP.Globals.OnPoints))  # Do not use GAPWrap.OnPoints!
 end
 
 function stabilizer(G::PermGroup, pnt::Union{Vector{T}, Tuple{T, Vararg{T}}}) where T <: Oscar.IntegerUnion
-    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
-        GapObj(pnt, recursive = true),
-        GAP.Globals.OnTuples))  # Do not use GAPWrap.OnTuples!
+  return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+    GapObj(pnt, recursive = true),
+    GAP.Globals.OnTuples))  # Do not use GAPWrap.OnTuples!
 end
 
 function stabilizer(G::PermGroup, pnt::AbstractSet{T}) where T <: Oscar.IntegerUnion
-    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
-        GapObj(pnt, recursive = true),
-        GAP.Globals.OnSets))  # Do not use GAPWrap.OnSets!
+  return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+    GapObj(pnt, recursive = true),
+    GAP.Globals.OnSets))  # Do not use GAPWrap.OnSets!
 end
 
 # now the same with given action function,
 # these calls may come from delegations from G-sets
 function stabilizer(G::PermGroup, pnt::T, actfun::Function) where T <: IntegerUnion
-    return (actfun == ^) ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
+  return (actfun == ^) ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
 end
 
 function stabilizer(G::PermGroup, pnt::Union{Vector{T},Tuple{T,Vararg{T}}}, actfun::Function) where T <: IntegerUnion
-    return actfun == on_tuples ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
+  return actfun == on_tuples ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
 end
 
 function stabilizer(G::PermGroup, pnt::AbstractSet{T}, actfun::Function) where T <: IntegerUnion
-    return actfun == on_sets ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
+  return actfun == on_sets ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
 end
 
 # natural stabilizers in matrix groups
@@ -610,63 +610,63 @@ end
 # - stabilizer in a matrix group (over a finite field)
 #   of a `Set` of `FreeModuleElem`s via `on_sets`
 function stabilizer(G::MatrixGroup{ET,MT}, pnt::AbstractAlgebra.Generic.FreeModuleElem{ET}) where {ET,MT}
-    iso = _ring_iso(G)
-    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
-        map_entries(iso, AbstractAlgebra.Generic._matrix(pnt)),
-        GAP.Globals.OnRight))
+  iso = _ring_iso(G)
+  return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+    map_entries(iso, AbstractAlgebra.Generic._matrix(pnt)),
+    GAP.Globals.OnRight))
 end
 
 function stabilizer(G::MatrixGroup{ET,MT}, pnt::Vector{AbstractAlgebra.Generic.FreeModuleElem{ET}}) where {ET,MT}
-    length(pnt) == 0 && return G
-    iso = _ring_iso(G)
-    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
-        GapObj([GapObj(map_entries(iso, AbstractAlgebra.Generic._matrix(v)))[1] for v in pnt]),
-        GAP.Globals.OnTuples))
+  length(pnt) == 0 && return G
+  iso = _ring_iso(G)
+  return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+    GapObj([GapObj(map_entries(iso, AbstractAlgebra.Generic._matrix(v)))[1] for v in pnt]),
+    GAP.Globals.OnTuples))
 end
 
 function stabilizer(G::MatrixGroup{ET,MT}, pnt::Tuple{AbstractAlgebra.Generic.FreeModuleElem{ET},Vararg{AbstractAlgebra.Generic.FreeModuleElem{ET}}}) where {ET,MT}
-    length(pnt) == 0 && return G
-    iso = _ring_iso(G)
-    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
-        GapObj([GapObj(map_entries(iso, AbstractAlgebra.Generic._matrix(v)))[1] for v in pnt]),
-        GAP.Globals.OnTuples))
+  length(pnt) == 0 && return G
+  iso = _ring_iso(G)
+  return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+    GapObj([GapObj(map_entries(iso, AbstractAlgebra.Generic._matrix(v)))[1] for v in pnt]),
+    GAP.Globals.OnTuples))
 end
 
 function stabilizer(G::MatrixGroup{ET,MT}, pnt::AbstractSet{AbstractAlgebra.Generic.FreeModuleElem{ET}}) where {ET,MT}
-    length(pnt) == 0 && return G
-    iso = _ring_iso(G)
-    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
-        GAPWrap.Set(GapObj([GapObj(map_entries(iso, AbstractAlgebra.Generic._matrix(v)))[1] for v in pnt])),
-        GAP.Globals.OnSets))
+  length(pnt) == 0 && return G
+  iso = _ring_iso(G)
+  return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+    GAPWrap.Set(GapObj([GapObj(map_entries(iso, AbstractAlgebra.Generic._matrix(v)))[1] for v in pnt])),
+    GAP.Globals.OnSets))
 end
 
 # now the same with given action function,
 # these calls may come from delegations from G-sets
 function stabilizer(G::MatrixGroup{ET,MT}, pnt::AbstractAlgebra.Generic.FreeModuleElem{ET}, actfun::Function) where {ET,MT}
-    return (actfun == *) ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
+  return (actfun == *) ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
 end
 
 function stabilizer(G::MatrixGroup{ET,MT}, pnt::Vector{AbstractAlgebra.Generic.FreeModuleElem{ET}}, actfun::Function) where {ET,MT}
-    return (actfun == on_tuples) ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
+  return (actfun == on_tuples) ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
 end
 
 function stabilizer(G::MatrixGroup{ET,MT}, pnt::Tuple{AbstractAlgebra.Generic.FreeModuleElem{ET},Vararg{AbstractAlgebra.Generic.FreeModuleElem{ET}}}, actfun::Function) where {ET,MT}
-    return (actfun == on_tuples) ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
+  return (actfun == on_tuples) ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
 end
 
 function stabilizer(G::MatrixGroup{ET,MT}, pnt::AbstractSet{AbstractAlgebra.Generic.FreeModuleElem{ET}}, actfun::Function) where {ET,MT}
-    return (actfun == on_sets) ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
+  return (actfun == on_sets) ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
 end
 
 # stabilizer in a matrix group (over a finite field)
 # of a row reduced matrix via `on_echelon_form_mats`
 function stabilizer(G::MatrixGroup{ET,<:MT}, pnt::MatElem{<:MT}, actfun::Function) where {ET,MT}
-    (actfun === on_echelon_form_mats) || return _stabilizer_generic(G, pnt, actfun)
-    nrows(pnt) == 0 && return (G, identity_map(G))
-    iso = _ring_iso(G)
-    return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
-        map_entries(iso, pnt),
-        GAP.Globals.OnSubspacesByCanonicalBasis))
+  (actfun === on_echelon_form_mats) || return _stabilizer_generic(G, pnt, actfun)
+  nrows(pnt) == 0 && return (G, identity_map(G))
+  iso = _ring_iso(G)
+  return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+    map_entries(iso, pnt),
+    GAP.Globals.OnSubspacesByCanonicalBasis))
 end
 
 """

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -610,7 +610,7 @@ end
 # - stabilizer in a matrix group (over a finite field)
 #   of a `Set` of `FreeModuleElem`s via `on_sets`
 function stabilizer(G::MatrixGroup{ET,MT}, pnt::AbstractAlgebra.Generic.FreeModuleElem{ET}) where {ET,MT}
-    iso = Oscar.iso_oscar_gap(base_ring(parent(pnt)))
+    iso = _ring_iso(G)
     return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
         map_entries(iso, AbstractAlgebra.Generic._matrix(pnt)),
         GAP.Globals.OnRight))
@@ -618,7 +618,7 @@ end
 
 function stabilizer(G::MatrixGroup{ET,MT}, pnt::Vector{AbstractAlgebra.Generic.FreeModuleElem{ET}}) where {ET,MT}
     length(pnt) == 0 && return G
-    iso = Oscar.iso_oscar_gap(base_ring(parent(pnt[1])))
+    iso = _ring_iso(G)
     return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
         GapObj([GapObj(map_entries(iso, AbstractAlgebra.Generic._matrix(v)))[1] for v in pnt]),
         GAP.Globals.OnTuples))
@@ -626,7 +626,7 @@ end
 
 function stabilizer(G::MatrixGroup{ET,MT}, pnt::Tuple{AbstractAlgebra.Generic.FreeModuleElem{ET},Vararg{AbstractAlgebra.Generic.FreeModuleElem{ET}}}) where {ET,MT}
     length(pnt) == 0 && return G
-    iso = Oscar.iso_oscar_gap(base_ring(parent(pnt[1])))
+    iso = _ring_iso(G)
     return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
         GapObj([GapObj(map_entries(iso, AbstractAlgebra.Generic._matrix(v)))[1] for v in pnt]),
         GAP.Globals.OnTuples))
@@ -634,7 +634,7 @@ end
 
 function stabilizer(G::MatrixGroup{ET,MT}, pnt::AbstractSet{AbstractAlgebra.Generic.FreeModuleElem{ET}}) where {ET,MT}
     length(pnt) == 0 && return G
-    iso = Oscar.iso_oscar_gap(base_ring(parent(iterate(pnt)[1])))
+    iso = _ring_iso(G)
     return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
         GAPWrap.Set(GapObj([GapObj(map_entries(iso, AbstractAlgebra.Generic._matrix(v)))[1] for v in pnt])),
         GAP.Globals.OnSets))
@@ -663,7 +663,7 @@ end
 function stabilizer(G::MatrixGroup{ET,<:MT}, pnt::MatElem{<:MT}, actfun::Function) where {ET,MT}
     (actfun === on_echelon_form_mats) || return _stabilizer_generic(G, pnt, actfun)
     nrows(pnt) == 0 && return (G, identity_map(G))
-    iso = Oscar.iso_oscar_gap(base_ring(pnt))
+    iso = _ring_iso(G)
     return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
         map_entries(iso, pnt),
         GAP.Globals.OnSubspacesByCanonicalBasis))

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -659,6 +659,7 @@ function _oscar_group(G::GapObj)
         ring = codomain(iso)
         matgrp = matrix_group(ring, deg)
         matgrp.ring_iso = inv(iso)
+        set_attribute!(ring, :iso_oscar_gap, matgrp.ring_iso)
         matgrp.X = G
         return matgrp
       elseif pair[2] == AutomorphismGroup

--- a/test/Groups/action.jl
+++ b/test/Groups/action.jl
@@ -88,6 +88,21 @@ end
   S = stabilizer(G, m, on_echelon_form_mats)
   @test S[1] == G
   @test S[1] == Oscar._stabilizer_generic(G, m, on_echelon_form_mats)[1]
+
+  # An issue with mismatched OSCAR<->GAP isomorphisms fixed in PR 5150
+  E = Oscar.GAPWrap.E
+  G_gap = Oscar.GAPWrap.Group(GapObj([
+            GapObj([GapObj([1, 0]), GapObj([0, -1])]),
+            GapObj(1//2)*GapObj([
+              GapObj([ E(24) - E(24)^16 + E(24)^19, E(3)^2 ]),
+              GapObj([ -E(3)^2, -E(24) - E(24)^16 - E(24)^19 ])
+            ])
+          ]))
+  G_oscar = Oscar._oscar_group(G_gap)
+  K = base_ring(G_oscar)
+  V = free_module(K, 2)
+  S, _ = stabilizer(G_oscar, [V[1]])
+  @test order(S) == 2
 end
 
 @testset "action on multivariate polynomials: permutations" begin


### PR DESCRIPTION
Use the `ring_iso` of the matrix group in `stabilizer` instead of `iso_oscar_gap` of the vectors, on which the group acts.
(The relevant changes are in the first commit, the second one only adjusts indentation.)

This solves the following subtle problem:
I have a matrix group in GAP (originally from CHEVIE...), which can be constructed in OSCAR via:
```
julia> E = Oscar.GAPWrap.E;

julia> G_gap = Oscar.GAPWrap.Group(GapObj([GapObj([GapObj([1, 0]), GapObj([0, -1])]), (GapObj(1//2))*GapObj([ GapObj([ E(24) - E(24)^16 + E(24)^19, E(3)^2 ]), GapObj([ -E(3)^2, -E(24) - E(24)^16 - E(24)^19 ]) ])]));
```
Now we work the OSCAR<->GAP magic:
```
julia> G_oscar = Oscar._oscar_group(G_gap);
```
This sets an isomorphism:
```
julia> G_oscar.ring_iso
Map defined by a julia-function with inverse
  from number field of degree 4 over QQ
  to GAP: NF(24,[ 1, 19 ])
```
Now the following fails:
```
julia> K = base_ring(G_oscar);

julia> V = free_module(K, 2);

julia> stabilizer(G_oscar, [V[1]])
ERROR: Error thrown by GAP: Error, no method found!
[...]
```
The reason is that `stabilizer` uses `Oscar.iso_oscar_gap(K)`, but this is different from `G_oscar.ring_iso`:
```
julia> Oscar.iso_oscar_gap(K)
Map defined by a julia-function with inverse
  from number field of degree 4 over QQ
  to GAP: <algebraic extension over the Rationals of degree 4>
```

I fix this here by using `_ring_iso(G)` in `stabilizer`.

I don't know whether this is the 'right' fix (maybe the tests will already answer this question).

Two more oddities / questions:
* Without this change one could mix base fields, as long as the type coincides:
```
julia> Q, _ = Oscar.rationals_as_number_field();

julia> G = matrix_group(Q[-1 0; 0 -1]);

julia> K, a = cyclotomic_field(3, :a);

julia> V = free_module(K, 2);

julia> stabilizer(G, [V[1]])
(Matrix group of degree 2 over Q, Hom: matrix group -> G)
```
Is this bug or feature? (One can probably also do this with this PR, but this particular example doesn't work anymore.)
* Should `_oscar_group` cache the isomorphism on the field? `iso_oscar_gap` seems to do that. EDIT: This is done now.

CC @fingolfin @ThomasBreuer 