### PR TITLE
fix `show` for `AutomorphismGroup`

### DIFF
--- a/src/Groups/abelian_aut.jl
+++ b/src/Groups/abelian_aut.jl
@@ -32,8 +32,7 @@ Automorphism group of
 function automorphism_group(G::FinGenAbGroup)
   Ggap, to_gap, to_oscar = _isomorphic_gap_group(G)
   AutGAP = GAPWrap.AutomorphismGroup(Ggap.X)
-  aut = AutomorphismGroup(AutGAP, G)
-  aut.is_known_to_be_full = true
+  aut = AutomorphismGroup(AutGAP, G, true)
   set_attribute!(aut, :to_gap => to_gap, :to_oscar => to_oscar)
   return aut
 end

--- a/src/Groups/abelian_aut.jl
+++ b/src/Groups/abelian_aut.jl
@@ -33,6 +33,7 @@ function automorphism_group(G::FinGenAbGroup)
   Ggap, to_gap, to_oscar = _isomorphic_gap_group(G)
   AutGAP = GAPWrap.AutomorphismGroup(Ggap.X)
   aut = AutomorphismGroup(AutGAP, G)
+  aut.is_known_to_be_full = true
   set_attribute!(aut, :to_gap => to_gap, :to_oscar => to_oscar)
   return aut
 end

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -1446,9 +1446,7 @@ GAPGroupHomomorphism{PermGroup, PermGroup}
 """
 function automorphism_group(G::GAPGroup)
   AutGAP = GAPWrap.AutomorphismGroup(GapObj(G))
-  aut = AutomorphismGroup(AutGAP, G)
-  aut.is_known_to_be_full = true
-  return aut
+  return AutomorphismGroup(AutGAP, G, true)
 end
 
 function Base.show(io::IO,  ::MIME"text/plain", A::AutomorphismGroup{T}) where T <: Union{FinGenAbGroup, GAPGroup}

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -1453,25 +1453,18 @@ end
 
 function Base.show(io::IO,  ::MIME"text/plain", A::AutomorphismGroup{T}) where T <: Union{FinGenAbGroup, GAPGroup}
   io = pretty(io)
-  if hasproperty(A, :is_known_to_be_full) && A.is_known_to_be_full
-    println(io, "Automorphism group of", Indent())
-  else
-    println(io, "Group of automorphisms of", Indent())
-  end
+  str = A.is_known_to_be_full ? "Automorphism group" : "Group of automorphisms"
+  println(io, "$str of", Indent())
   print(io, Lowercase(), A.G, Dedent())
 end
 
 function Base.show(io::IO, A::AutomorphismGroup{T}) where T <: Union{FinGenAbGroup, GAPGroup}
-  if hasproperty(A, :is_known_to_be_full) && A.is_known_to_be_full
-    str = "Automorphism group"
-  else
-    str = "Group of automorphisms"
-  end
+  str = A.is_known_to_be_full ? "Automorphism group" : "Group of automorphisms"
   if is_terse(io)
     print(io, str)
   else
     io = pretty(io)
-    print(io, str, " of ", Lowercase(), A.G)
+    print(io, "$str of ", Lowercase(), A.G)
   end
 end
 

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -1298,6 +1298,7 @@ Return the full automorphism group of `G`. If `f` is an object of type
 return the embedding of `f` in `A`.
 
 Groups of automorphisms over a group `G` have parametric type `AutomorphismGroup{T}`, where `T` is the type of `G`. 
+
 # Examples
 ```jldoctest
 julia> S = symmetric_group(3)
@@ -1311,6 +1312,13 @@ Automorphism group of
   symmetric group of degree 3
 
 julia> typeof(A)
+AutomorphismGroup{PermGroup}
+
+julia> D = derived_subgroup(A)[1]
+Group of automorphisms of
+  symmetric group of degree 3
+
+julia> typeof(D)
 AutomorphismGroup{PermGroup}
 ```
 
@@ -1437,22 +1445,33 @@ GAPGroupHomomorphism{PermGroup, PermGroup}
 ```
 """
 function automorphism_group(G::GAPGroup)
-  AutGAP = GAP.Globals.AutomorphismGroup(GapObj(G))::GapObj
-  return AutomorphismGroup(AutGAP, G)
+  AutGAP = GAPWrap.AutomorphismGroup(GapObj(G))
+  aut = AutomorphismGroup(AutGAP, G)
+  aut.is_known_to_be_full = true
+  return aut
 end
 
 function Base.show(io::IO,  ::MIME"text/plain", A::AutomorphismGroup{T}) where T <: Union{FinGenAbGroup, GAPGroup}
   io = pretty(io)
-  println(io, "Automorphism group of", Indent())
+  if hasproperty(A, :is_known_to_be_full) && A.is_known_to_be_full
+    println(io, "Automorphism group of", Indent())
+  else
+    println(io, "Group of automorphisms of", Indent())
+  end
   print(io, Lowercase(), A.G, Dedent())
 end
 
 function Base.show(io::IO, A::AutomorphismGroup{T}) where T <: Union{FinGenAbGroup, GAPGroup}
+  if hasproperty(A, :is_known_to_be_full) && A.is_known_to_be_full
+    str = "Automorphism group"
+  else
+    str = "Group of automorphisms"
+  end
   if is_terse(io)
-    print(io, "Automorphism group")
+    print(io, str)
   else
     io = pretty(io)
-    print(io, "Automorphism group of ", Lowercase(), A.G)
+    print(io, str, " of ", Lowercase(), A.G)
   end
 end
 

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -527,15 +527,15 @@ Group of automorphisms over a group of type `T`. It can be defined via the funct
   G::T
   is_known_to_be_full::Bool
 
-  function AutomorphismGroup{T}(G::GapObj, H::T) where T
+  function AutomorphismGroup{T}(G::GapObj, H::T, full::Bool = false) where T
     @assert GAPWrap.IsGroupOfAutomorphisms(G)
-    z = new{T}(G, H)
+    z = new{T}(G, H, full)
     return z
   end
 end
 
-function AutomorphismGroup(G::GapObj, H::T) where T
-  return AutomorphismGroup{T}(G, H)
+function AutomorphismGroup(G::GapObj, H::T, full::Bool = false) where T
+  return AutomorphismGroup{T}(G, H, full)
 end
 
 (aut::AutomorphismGroup{T} where T)(x::GapObj) = group_element(aut,x)

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -525,6 +525,7 @@ Group of automorphisms over a group of type `T`. It can be defined via the funct
 @attributes mutable struct AutomorphismGroup{T} <: GAPGroup
   X::GapObj
   G::T
+  is_known_to_be_full::Bool
 
   function AutomorphismGroup{T}(G::GapObj, H::T) where T
     @assert GAPWrap.IsGroupOfAutomorphisms(G)


### PR DESCRIPTION
Print `Automorphism group of ...` only if the group knows that it is the *full* automorphism group of the group in question. Otherwise print `Group of automorphisms of ...`.