### PR TITLE
Use `orbit_via_Julia` generically

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ cohomCalg_jll = "5558cf25-a90e-53b0-b813-cadaa3ae7ade"
 lib4ti2_jll = "1493ae25-0f90-5c0e-a06c-8c5077d6d66f"
 
 [compat]
-AbstractAlgebra = "0.46.0"
+AbstractAlgebra = "0.46.2"
 AlgebraicSolving = "0.9.0"
 Compat = "4.13.0"
 Distributed = "1.6"

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -357,7 +357,7 @@ end
         total = ZZ(0)
         for (U, stab) in res
           total = total + index(G, stab)
-          @test_skip length(orbit(stab, U)) == 1
+          @test length(orbit(stab, U)) == 1
         end
         num = ZZ(1)
         for i in 0:(k-1)

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -357,7 +357,7 @@ end
         total = ZZ(0)
         for (U, stab) in res
           total = total + index(G, stab)
-          @test length(orbit(stab, U)) == 1
+          @test_skip length(orbit(stab, U)) == 1
         end
         num = ZZ(1)
         for i in 0:(k-1)


### PR DESCRIPTION
That is, remove the delegation to GAP in `orbit`.

For the moment, some tests are skipped that do not run until the problem from Nemocas/AbstractAlgebra.jl/pull/2139 is fixed. The point is that the `IndexedSet` objects used by `orbit_via_Julia` rely on `hash`, and currently this does not work for the action on vector spaces.

(The currently skipped tests would run into infinite loops:
Starting from one point, the image under a group element is a new object, in the sense of `objectid`. The `IndexedSet` object that does the bookkeeping regards this new object as different from the stored ones if `hash` is implemented via `objectid` (the default), thus the image is always regarded as new in this situation, and it gets added to the orbit.)

addresses #722