### PR TITLE
Fix a bug in the computation of matroid realization spaces with saturated defining ideal

### DIFF
--- a/experimental/MatroidRealizationSpaces/src/realization_space.jl
+++ b/experimental/MatroidRealizationSpaces/src/realization_space.jl
@@ -410,7 +410,7 @@ function realization_space(
   end
 
   if saturate
-    RS.defining_ideal = stepwise_saturation(def_ideal, ineqs)
+    RS.defining_ideal = stepwise_saturation(RS.defining_ideal, RS.inequations)
     if isone(RS.defining_ideal)
       set_attribute!(RS, :is_realizable, :false)
       return RS

--- a/experimental/MatroidRealizationSpaces/test/runtests.jl
+++ b/experimental/MatroidRealizationSpaces/test/runtests.jl
@@ -141,3 +141,11 @@ end
   U = PrincipalOpenSubset(X, f)
   @test U isa AbsAffineScheme
 end
+
+@testset "saturation of realization space" begin
+    s = "0******0******0**********0********0*******0*********************0*****************0*************0***********0***************************0*******************0*****************************0************0**0************0****"
+    MD = matroid_from_revlex_basis_encoding(s,3,12)
+    RS = realization_space(MD, char = 0, saturate = true)
+    @test is_reduced(RS) == false
+end
+


### PR DESCRIPTION
Thanks to @danteluber for finding this issue.