### PR TITLE
Adjust metioning of documentation preview in documentation

### DIFF
--- a/docs/src/DeveloperDocumentation/documentation.md
+++ b/docs/src/DeveloperDocumentation/documentation.md
@@ -162,8 +162,3 @@ Please follow the additional guidelines below, that are not checked by bibtool:
 - If a DOI is available for your reference, please add it as a `doi` field to the BibTeX entry. In this case, please refrain from adding an additional `url` field.
 - If your reference has no DOI or the paper is not open-access, but is available as an arXiv preprint, you can add the arXiv link as a `eprint` field (even additionally to a `doi` field). For other preprint servers (e.g. HAL), please refer to the [DocumenterCitations.jl docs](https://juliadocs.org/DocumenterCitations.jl/stable/syntax/#Preprint-support).
 - Documents available only as an arXiv preprint should be added as `@Misc` entries with the arXiv-ID in the `eprint` field, e.g., `archiveprefix = {arXiv}` and `eprint = {2008.12651}`.
-
-## Documentation preview
-
-For pull requests coming from a branch of the main Oscar repository, a preview of the documentation can be found under
-https://docs.oscar-system.org/previews/PRX/ where "X" is the PR number.

--- a/docs/src/DeveloperDocumentation/documentation.md
+++ b/docs/src/DeveloperDocumentation/documentation.md
@@ -82,10 +82,8 @@ include your new page in the appropriate place.
     Once you have created a pull request it is possible to preview the
     documentation on github using the link
     https://docs.oscar-system.org/previews/PR<prnumber>/
-    where you insert the number of your PR for `prnumber`. Alternatively you
-    can look at the github actions tab of your PR and click the details link
-    next to the `documenter/deploy` action. There are a few conditions for this 
-    to work:
+    where you insert the number of your PR for `<prnumber>`.
+    There are a few conditions for this to work:
     - No conflicts with the master branch.
     - Documentation action is successful, i.e. no doctest errors.
     - The branch for the PR is in the main `oscar-system/Oscar.jl` repository.


### PR DESCRIPTION
I realized that the piece of information added to the documentation in #5187 was already there.
I also removed the information about the `documenter/deploy` button because that is gone, if I understood correctly.

CC @thofma @lgoettgens
