### PR TITLE
Add documentation for graph visualization using Graphviz

### DIFF
--- a/docs/src/Combinatorics/graphs.md
+++ b/docs/src/Combinatorics/graphs.md
@@ -110,6 +110,15 @@ src(e::Edge)
 ```@docs
 visualize(G::Graph{Union{Polymake.Directed, Polymake.Undirected}}; backend::Symbol=:threejs, filename::Union{Nothing, String}=nothing, kwargs...)
 ```
+#### Visualization using Graphviz
+[Graphviz](https://graphviz.org/) is an open source graph visualization software. To visualize
+graphs using Graphviz, use `backend=:graphviz`. It requires that both Graphviz and a postscript
+viewer are installed. In case Graphviz is installed and OSCAR is unable to find it (e.g., because
+Graphviz was installed after OSCAR), please run
+```
+Polymake.shell_execute("""application("graph")->reconfigure("graphviz.rules");""");
+```
+
 ## Saving and loading
 
 Objects of type `Graph` can be saved to a file and loaded with the methods

--- a/docs/src/Combinatorics/graphs.md
+++ b/docs/src/Combinatorics/graphs.md
@@ -110,14 +110,6 @@ src(e::Edge)
 ```@docs
 visualize(G::Graph{Union{Polymake.Directed, Polymake.Undirected}}; backend::Symbol=:threejs, filename::Union{Nothing, String}=nothing, kwargs...)
 ```
-#### Visualization using Graphviz
-[Graphviz](https://graphviz.org/) is an open source graph visualization software. To visualize
-graphs using Graphviz, use `backend=:graphviz`. It requires that both Graphviz and a postscript
-viewer are installed. In case Graphviz is installed and OSCAR is unable to find it (e.g., because
-Graphviz was installed after OSCAR), please run
-```julia
-Polymake.shell_execute("""application("graph")->reconfigure("graphviz.rules");""");
-```
 
 ## Saving and loading
 

--- a/docs/src/Combinatorics/graphs.md
+++ b/docs/src/Combinatorics/graphs.md
@@ -115,7 +115,7 @@ visualize(G::Graph{Union{Polymake.Directed, Polymake.Undirected}}; backend::Symb
 graphs using Graphviz, use `backend=:graphviz`. It requires that both Graphviz and a postscript
 viewer are installed. In case Graphviz is installed and OSCAR is unable to find it (e.g., because
 Graphviz was installed after OSCAR), please run
-```
+```julia
 Polymake.shell_execute("""application("graph")->reconfigure("graphviz.rules");""");
 ```
 

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -1323,22 +1323,25 @@ end
 @doc raw"""
     visualize(G::Graph{<:Union{Polymake.Directed, Polymake.Undirected}}; backend::Symbol=:threejs, filename::Union{Nothing, String}=nothing, kwargs...)
 
-Visualize a graph, see [`visualize`](@ref Oscar.visualize(::Union{SimplicialComplex, Cone{<:Union{Float64, FieldElem}}, Graph, PolyhedralComplex{<:Union{Float64, FieldElem}}, PolyhedralFan{<:Union{Float64, FieldElem}}, Polyhedron, SubdivisionOfPoints{<:Union{Float64, FieldElem}}})) for details on the keyword arguments.
+Visualize graph `G`.
 
-The `backend` keyword argument allows the user to pick between a Three.js visualization by default,
-or passing `:tikz` for a TikZ visualization, or passing `:graphviz` for a
-[Graphviz](https://graphviz.org/) visualization (requires Graphviz, see [Visualization using Graphviz](@ref)).
+The `backend` keyword argument allows the user to pick between
+- `:threejs`: a Three.js visualization (default),
+- `:tikz`: a TikZ visualization, or
+- `:graphviz`: a [Graphviz](https://graphviz.org/) visualization.
+The Graphviz visualization requires loading the julia package `Graphviz_jll`
+first, and a postscript reader.
 
-The `filename` keyword argument will write visualization code to the `filename` location, this will
-be html for `:threejs` backend or TikZ code for `:tikz`.
+If `filename` is specified, OSCAR will write visualization code to `filename`
+(html for `:threejs`, TikZ code for `:tikz`, dot for `:graphviz`).
 
-If the graph `G` has a labeling `:color` (see [`label!`](@ref)) then the visualization will use
-these colors to color the graph.
-Possible color labelings include RGB values of the form `"255 0 255"` or `"#ff00ff"`, as well as the
-following named colors as strings: `polymakeorange`, `polymakegreen`, `white`, `purple`, `cyan`,
-`darkolivegreen`, `indianred`, `plum1`, `red`, `lightslategrey`, `yellow`, `orange`, `salmon1`,
-`azure`, `green`, `gray`, `midnightblue`, `pink`, `magenta`, `blue`, `lavenderblush`, `chocolate1`,
-`lightgreen`, `black`.
+If `G` has a labeling `:color` (see [`label!`](@ref)) then the visualization
+will use these colors to color the graph.  Possible color labelings include RGB
+values of the form `"255 0 255"` or `"#ff00ff"`, as well as the following named
+colors as strings: `polymakeorange`, `polymakegreen`, `white`, `purple`, `cyan`,
+`darkolivegreen`, `indianred`, `plum1`, `red`, `lightslategrey`, `yellow`,
+`orange`, `salmon1`, `azure`, `green`, `gray`, `midnightblue`, `pink`,
+`magenta`, `blue`, `lavenderblush`, `chocolate1`, `lightgreen`, `black`.
 
 """
 function visualize(G::Graph{T};

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -1325,12 +1325,20 @@ end
 
 Visualize a graph, see [`visualize`](@ref Oscar.visualize(::Union{SimplicialComplex, Cone{<:Union{Float64, FieldElem}}, Graph, PolyhedralComplex{<:Union{Float64, FieldElem}}, PolyhedralFan{<:Union{Float64, FieldElem}}, Polyhedron, SubdivisionOfPoints{<:Union{Float64, FieldElem}}})) for details on the keyword arguments.
 
-The `backend` keyword argument allows the user to pick between a Three.js visualization by default, or passing `:tikz` for a TikZ visualization.
-The `filename` keyword argument will write visualization code to the `filename` location, this will be html for `:threejs` backend or TikZ code for `:tikz`.
-If the graph `G` has a labeling `:color` (see [`label!`](@ref)) then the visualization will use these colors to color the graph.
+The `backend` keyword argument allows the user to pick between a Three.js visualization by default,
+or passing `:tikz` for a TikZ visualization, or passing `:graphviz` for a
+[Graphviz](https://graphviz.org/) visualization (requires Graphviz, see documentation).
 
-Possible color labelings include RGB values of the form `"255 0 255"` or `"#ff00ff"`, as well as the following named colors as strings: `polymakeorange`, `polymakegreen`,
-`white`, `purple`, `cyan`, `darkolivegreen`, `indianred`, `plum1`, `red`, `lightslategrey`, `yellow`, `orange`, `salmon1`, `azure`, `green`, `gray`, `midnightblue`, `pink`, `magenta`, `blue`, `lavenderblush`, `chocolate1`, `lightgreen`, `black`.
+The`filename` keyword argument will write visualization code to the `filename` location, this will
+be html for `:threejs` backend or TikZ code for `:tikz`.
+
+If the graph `G` has a labeling `:color` (see [`label!`](@ref)) then the visualization will use
+these colors to color the graph.
+Possible color labelings include RGB values of the form `"255 0 255"` or `"#ff00ff"`, as well as the
+following named colors as strings: `polymakeorange`, `polymakegreen`, `white`, `purple`, `cyan`,
+`darkolivegreen`, `indianred`, `plum1`, `red`, `lightslategrey`, `yellow`, `orange`, `salmon1`,
+`azure`, `green`, `gray`, `midnightblue`, `pink`, `magenta`, `blue`, `lavenderblush`, `chocolate1`,
+`lightgreen`, `black`.
 
 """
 function visualize(G::Graph{T};

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -1329,8 +1329,7 @@ The `backend` keyword argument allows the user to pick between
 - `:threejs`: a Three.js visualization (default),
 - `:tikz`: a TikZ visualization, or
 - `:graphviz`: a [Graphviz](https://graphviz.org/) visualization.
-The Graphviz visualization requires loading the julia package `Graphviz_jll`
-first, and a postscript reader.
+The Graphviz visualization requires a postscript reader and loading the julia package `Graphviz_jll` before OSCAR.
 
 If `filename` is specified, OSCAR will write visualization code to `filename`
 (html for `:threejs`, TikZ code for `:tikz`, dot for `:graphviz`).

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -1329,7 +1329,8 @@ The `backend` keyword argument allows the user to pick between
 - `:threejs`: a Three.js visualization (default),
 - `:tikz`: a TikZ visualization, or
 - `:graphviz`: a [Graphviz](https://graphviz.org/) visualization.
-The Graphviz visualization requires a postscript reader and loading the julia package `Graphviz_jll` before OSCAR.
+The Graphviz visualization requires a postscript reader and loading the julia
+package `Graphviz_jll` before OSCAR.
 
 If `filename` is specified, OSCAR will write visualization code to `filename`
 (html for `:threejs`, TikZ code for `:tikz`, dot for `:graphviz`).

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -1329,7 +1329,7 @@ The `backend` keyword argument allows the user to pick between a Three.js visual
 or passing `:tikz` for a TikZ visualization, or passing `:graphviz` for a
 [Graphviz](https://graphviz.org/) visualization (requires Graphviz, see [Visualization using Graphviz](@ref)).
 
-The`filename` keyword argument will write visualization code to the `filename` location, this will
+The `filename` keyword argument will write visualization code to the `filename` location, this will
 be html for `:threejs` backend or TikZ code for `:tikz`.
 
 If the graph `G` has a labeling `:color` (see [`label!`](@ref)) then the visualization will use

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -1327,7 +1327,7 @@ Visualize a graph, see [`visualize`](@ref Oscar.visualize(::Union{SimplicialComp
 
 The `backend` keyword argument allows the user to pick between a Three.js visualization by default,
 or passing `:tikz` for a TikZ visualization, or passing `:graphviz` for a
-[Graphviz](https://graphviz.org/) visualization (requires Graphviz, see documentation).
+[Graphviz](https://graphviz.org/) visualization (requires Graphviz, see [Visualization using Graphviz](@ref)).
 
 The`filename` keyword argument will write visualization code to the `filename` location, this will
 be html for `:threejs` backend or TikZ code for `:tikz`.


### PR DESCRIPTION
Related to https://github.com/oscar-system/Oscar.jl/issues/5166

- added a half sentence on Graphviz to the `visualize(::Graph)` docstring
- added a paragraph on reconfiguring polymake to find Graphviz to the docu