### PR TITLE
Add serialization of `FinGenAbGroupHom`

### DIFF
--- a/src/Serialization/Groups.jl
+++ b/src/Serialization/Groups.jl
@@ -276,6 +276,24 @@ function load_object(s::DeserializerState, ::Type{FinGenAbGroupElem}, G::FinGenA
   return G(vec(load_object(s, Matrix{ZZRingElem})))
 end
 
+# homomorphisms
+@register_serialization_type FinGenAbGroupHom uses_id
+
+type_params(X::FinGenAbGroupHom) = TypeParams(
+  FinGenAbGroupHom,
+  :domain => domain(X),
+  :codomain => codomain(X)
+)
+
+function save_object(s::SerializerState, h::FinGenAbGroupHom)
+  save_object(s, matrix(h))
+end
+
+function load_object(s::DeserializerState, ::Type{FinGenAbGroupHom}, params::Dict)
+  map_matrix = load_object(s, Matrix{ZZRingElem})
+  return hom(params[:domain], params[:codomain], matrix(ZZ, map_matrix))
+end
+
 ##############################################################################
 # MatrixGroup
 

--- a/test/Serialization/Groups.jl
+++ b/test/Serialization/Groups.jl
@@ -110,6 +110,19 @@
        @test parent(loadedw[1]) === parent(loadedv[1])
     end
 
+    @testset "Finitely generated abelian groups and their homomorphisms" begin
+      dom = free_abelian_group(2)
+      codom = free_abelian_group(3)
+      test_save_load_roundtrip(path, dom) do loaded
+        @test dom == loaded
+      end
+      map = matrix(ZZ, [[1,2,3], [2,3,4]])
+      h = hom(dom, codom, map)
+      test_save_load_roundtrip(path, h) do loaded
+        @test h == loaded
+      end
+    end
+
     @testset "Finitely presented groups and their subgroups" begin
       F = free_group(2)
       x1 = gen(F, 1)


### PR DESCRIPTION
cc @antonydellavecchia: Splitting-off changes in https://github.com/oscar-system/Oscar.jl/pull/5064 as discussed.