### PR TITLE
phylogenetic trees: doc update

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -610,6 +610,19 @@
   doi           = {10.1112/S1461157000000115}
 }
 
+@Article{CJ24,
+  author        = {Com\u{a}neci, Andrei and Joswig, Michael},
+  title         = {Tropical medians by transportation},
+  mrnumber      = {4728892},
+  journal       = {Math. Program.},
+  fjournal      = {Mathematical Programming},
+  volume        = {205},
+  number        = {1-2},
+  pages         = {813--839},
+  year          = {2024},
+  doi           = {10.1007/s10107-023-01996-8}
+}
+
 @Article{CKM97,
   author        = {Collart, S. and Kalkbrener, M. and Mall, D.},
   title         = {Converting Bases with the Gröbner Walk},

--- a/docs/src/Combinatorics/phylogenetic_trees.md
+++ b/docs/src/Combinatorics/phylogenetic_trees.md
@@ -9,12 +9,15 @@ DocTestSetup = Oscar.doctestsetup()
 ## Introduction
 
 Phylogenetic trees represent the evolutionary history of some species of consideration.
-Here we consider phylogenetic trees with branch lengths as defined in [SS03](@cite).
+Here we consider phylogenetic (rooted) trees with branch lengths as defined in [SS03](@cite).
+
+The construction of tropical median consensus trees is one of the nontrivial algorithm here.
 
 ## Construction
 
 ```@docs
 phylogenetic_tree
+tropical_median_consensus
 ```
 
 ## Some Helpful Functions
@@ -25,5 +28,4 @@ is_equidistant
 cophenetic_matrix
 taxa
 newick
-tropical_median_consensus
 ```

--- a/src/Combinatorics/PhylogeneticTrees.jl
+++ b/src/Combinatorics/PhylogeneticTrees.jl
@@ -238,8 +238,14 @@ end
 @doc raw"""
     tropical_median_consensus(arr::Vector{PhylogeneticTree{T}})
 
-Compute the tropical median consensus tree of the phylogenetic trees from
-the vector `arr`.
+Compute the tropical median consensus tree of the equidistant
+phylogenetic trees from the vector `arr`.  The output is then
+equidistant, too.  The method is robust (ie., the consensus tree
+dpends continuosuly on the input), and it is Pareto and co-Pareto on
+rooted triplets.
+
+The algorithm, based on tropical convexity and optimal transport, is
+explained in [CJ24](@cite).
 
 # Examples
 Compute the tropical median consensus of three trees and print one of its


### PR DESCRIPTION
Reference added for tropical consensus tree method; docs slightly expanded.

No code has been touched.

Some time soon we need to decide how to combine the functions concerning phylogenetic trees in Combinatorics with those in Experimental/AlgebraicStatistics.  Maybe adding cross references in the docs for now? 