### PR TITLE
Add space after comma in printing of `GL(n, q)` etc.

### DIFF
--- a/docs/src/Groups/matgroup.md
+++ b/docs/src/Groups/matgroup.md
@@ -66,13 +66,13 @@ one can start with [a classical matrix group](@ref "Classical groups").
 
 ```jldoctest matgroupxpl
 julia> g = GL(3, GF(2))
-GL(3,2)
+GL(3, 2)
 
 julia> F = GF(4)
 Finite field of degree 2 and characteristic 2
 
 julia> G = GL(3, F)
-GL(3,4)
+GL(3, 4)
 
 julia> is_subset(g, G)
 false

--- a/experimental/GModule/src/GaloisCohomology.jl
+++ b/experimental/GModule/src/GaloisCohomology.jl
@@ -1710,7 +1710,7 @@ and explicit 2-cochains.
 
 ```jldoctest
 julia> G = SL(2,5)
-SL(2,5)
+SL(2, 5)
 
 julia> T = character_table(G);
 

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1499,7 +1499,7 @@ julia> (length(h), order(representative(h[1])))
 (1, 6)
 
 julia> g = GL(3, 2)
-GL(3,2)
+GL(3, 2)
 
 julia> h = hall_subgroup_classes(g, [2, 3]);
 

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -1615,7 +1615,7 @@ where `G` is a subgroup of `general_linear_group(F, n)`.
 # Examples
 ```jldoctest
 julia> G = orthogonal_group(1, 4, GF(3))
-GO+(4,3)
+GO+(4, 3)
 
 julia> res = orbit_representatives_and_stabilizers(G, 1);
 

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -737,7 +737,7 @@ julia> F = GF(7)
 Prime field of characteristic 7
 
 julia> H = general_linear_group(2, F)
-GL(2,7)
+GL(2, 7)
 
 julia> gens(H)
 2-element Vector{MatrixGroupElem{FqFieldElem, FqMatrix}}:
@@ -773,7 +773,7 @@ julia> F = GF(7)
 Prime field of characteristic 7
 
 julia> H = special_linear_group(2, F)
-SL(2,7)
+SL(2, 7)
 
 julia> gens(H)
 2-element Vector{MatrixGroupElem{FqFieldElem, FqMatrix}}:
@@ -811,7 +811,7 @@ julia> F = GF(7)
 Prime field of characteristic 7
 
 julia> H = symplectic_group(2, F)
-Sp(2,7)
+Sp(2, 7)
 
 julia> gens(H)
 2-element Vector{MatrixGroupElem{FqFieldElem, FqMatrix}}:
@@ -851,7 +851,7 @@ julia> F = GF(7)
 Prime field of characteristic 7
 
 julia> H = orthogonal_group(1, 2, F)
-GO+(2,7)
+GO+(2, 7)
 
 julia> gens(H)
 2-element Vector{MatrixGroupElem{FqFieldElem, FqMatrix}}:
@@ -906,7 +906,7 @@ julia> F = GF(7)
 Prime field of characteristic 7
 
 julia> H = special_orthogonal_group(1, 2, F)
-SO+(2,7)
+SO+(2, 7)
 
 julia> gens(H)
 3-element Vector{MatrixGroupElem{FqFieldElem, FqMatrix}}:
@@ -962,7 +962,7 @@ julia> F = GF(7)
 Prime field of characteristic 7
 
 julia> H = omega_group(1, 2, F)
-Omega+(2,7)
+Omega+(2, 7)
 
 julia> gens(H)
 1-element Vector{MatrixGroupElem{FqFieldElem, FqMatrix}}:
@@ -1008,7 +1008,7 @@ Return the unitary group of dimension `n` over the field `GF(q^2)`.
 # Examples
 ```jldoctest
 julia> H = unitary_group(2,3)
-GU(2,3)
+GU(2, 3)
 
 julia> gens(H)
 2-element Vector{MatrixGroupElem{FqFieldElem, FqMatrix}}:
@@ -1034,7 +1034,7 @@ elements.
 # Examples
 ```jldoctest
 julia> H = special_unitary_group(2,3)
-SU(2,3)
+SU(2, 3)
 
 julia> gens(H)
 2-element Vector{MatrixGroupElem{FqFieldElem, FqMatrix}}:

--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -156,7 +156,7 @@ change_base_ring(R::Ring, G::MatrixGroup) = map_entries(R, G)
 function _print_matrix_group_desc(io::IO, G::MatrixGroup)
   io = pretty(io)
   R = base_ring(G)
-  print(io, LowercaseOff(), string(G.descr), "(", degree(G) ,",")
+  print(io, LowercaseOff(), string(G.descr), "(", degree(G) ,", ")
   if G.descr==:GU || G.descr==:SU
     print(io, characteristic(R)^(div(degree(R),2)),")")
   elseif R isa Field && is_finite(R)

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -727,7 +727,7 @@ Test the case where a group has a custom name where the first character
 should not be turned into lowercase
 ```jldoctest group_characters.test
 julia> character_table(SL(2,2))
-Character table of SL(2,2)
+Character table of SL(2, 2)
 
   2  1  1  .
   3  1  .  1

--- a/test/Groups/tom.jl
+++ b/test/Groups/tom.jl
@@ -243,7 +243,7 @@ Test the case where a group has a custom name where the first character
 should not be turned into lowercase
 ```jldoctest tables_of_marks.test
 julia> table_of_marks(SL(2,2))
-Table of marks of SL(2,2)
+Table of marks of SL(2, 2)
 
 1: 6      
 2: 3 1    

--- a/test/book/cornerstones/groups/explSL25.jlcon
+++ b/test/book/cornerstones/groups/explSL25.jlcon
@@ -1,8 +1,8 @@
 julia> G = SL(2, 5)
-SL(2,5)
+SL(2, 5)
 
 julia> T = character_table(G)
-Character table of SL(2,5)
+Character table of SL(2, 5)
 
   2  3                 1                 1  3                  1                  1  1  1  2
   3  1                 .                 .  1                  .                  .  1  1  .


### PR DESCRIPTION
This feels obvious to me, but I can't guess how controversial it is.
I like spaces after commas and I think that it especially improves the printing of, for example, `GL(2, QQ)`.
A downside might be that the output of `describe` still prints things like `SL(2,5)` without space.
