### PR TITLE
Link to website in README for "How to cite OSCAR"

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,39 +112,8 @@ pm::Array<topaz::HomologyGroup<pm::Integer> >
 
 ## Citing OSCAR
 
-If you have used OSCAR in the preparation of a paper please cite it as described below, preferably including both citations:
-
-    [OSCAR]
-        OSCAR -- Open Source Computer Algebra Research system, Version 1.5.0-DEV,
-        The OSCAR Team, 2025. (https://www.oscar-system.org)
-    [OSCAR-book]
-        Wolfram Decker, Christian Eder, Claus Fieker, Max Horn, Michael Joswig, eds.
-        The Computer Algebra System OSCAR: Algorithms and Examples,
-        Algorithms and Computation in Mathematics, Springer, 2025.
-
-If you are using BibTeX, you can use the following BibTeX entries:
-
-    @misc{OSCAR,
-      key          = {OSCAR},
-      organization = {The OSCAR Team},
-      title        = {{OSCAR} -- {O}pen {S}ource {C}omputer {A}lgebra {R}esearch system,
-                      {V}ersion 1.5.0-DEV},
-      year         = {2025},
-      url          = {https://www.oscar-system.org},
-      }
-
-    @book{OSCAR-book,
-      editor = {Decker, Wolfram and Eder, Christian and Fieker, Claus and Horn, Max and Joswig, Michael},
-      title = {The {C}omputer {A}lgebra {S}ystem {OSCAR}: {A}lgorithms and {E}xamples},
-      year = {2025},
-      publisher = {Springer},
-      series = {Algorithms and {C}omputation in {M}athematics},
-      volume = {32},
-      edition = {1},
-      url = {https://link.springer.com/book/9783031621260},
-      issn = {1431-1550},
-      doi = {10.1007/978-3-031-62127-7},
-    }
+If you have used OSCAR in the preparation of a paper please cite it as described
+on [our website](https://www.oscar-system.org/credits/Citing-OSCAR/).
 
 ## Funding
 

--- a/docs/src/General/faq.md
+++ b/docs/src/General/faq.md
@@ -140,7 +140,7 @@ background. Please read our page on [Complex Algorithms](@ref).
 
 **Q: How do I cite OSCAR?**
 
-Please see [here](https://github.com/oscar-system/Oscar.jl?tab=readme-ov-file#citing-oscar).
+Please see [our website](https://www.oscar-system.org/credits/Citing-OSCAR/).
 
 ---
 ## Windows specific

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -47,7 +47,9 @@ our [Introduction for new developers](@ref).
 
 ## How to cite?
 
-If you have used OSCAR in the preparation of a paper, please cite it as described [here](https://github.com/oscar-system/Oscar.jl?tab=readme-ov-file#citing-oscar).
+If you have used OSCAR in the preparation of a paper please cite it as described
+on [our website](https://www.oscar-system.org/credits/Citing-OSCAR/).
+
 
 ## Acknowledgements
 


### PR DESCRIPTION
Right now, we have the same information on how to cite OSCAR in the Readme and on the website. Whenever something is changed, both need to be updated.
I propose to only keep the information on the website and link there from the Readme.
