### PR TITLE
FTheoryTools: Improve kwargs

### DIFF
--- a/experimental/FTheoryTools/docs/src/g4.md
+++ b/experimental/FTheoryTools/docs/src/g4.md
@@ -155,7 +155,7 @@ You can inspect a ``G_4``-flux using the following attributes:
 ```@docs
 model(gf::G4Flux)
 cohomology_class(gf::G4Flux)
-d3_tadpole_constraint(gf::G4Flux; check::Bool = true)
+d3_tadpole_constraint(gf::G4Flux)
 ```
 
 ### Properties of ``G_4``-Fluxes

--- a/experimental/FTheoryTools/docs/src/g4.md
+++ b/experimental/FTheoryTools/docs/src/g4.md
@@ -194,7 +194,7 @@ To define a flux family in this way, you must provide:
 The constructor is:
 
 ```@docs
-family_of_g4_fluxes(m::AbstractFTheoryModel, mat_int::QQMatrix, mat_rat::QQMatrix, offset::Vector{QQFieldElem}; check::Bool = true)
+family_of_g4_fluxes(m::AbstractFTheoryModel, mat_int::QQMatrix, mat_rat::QQMatrix, offset::Vector{QQFieldElem})
 ```
 
 ### Constructing a Flux Family Based on Physical Conditions

--- a/experimental/FTheoryTools/docs/src/g4.md
+++ b/experimental/FTheoryTools/docs/src/g4.md
@@ -223,7 +223,7 @@ model(gf::FamilyOfG4Fluxes)
 matrix_integral(gf::FamilyOfG4Fluxes)
 matrix_rational(gf::FamilyOfG4Fluxes)
 offset(gf::FamilyOfG4Fluxes)
-d3_tadpole_constraint(fgs::FamilyOfG4Fluxes; check::Bool = true)
+d3_tadpole_constraint(fgs::FamilyOfG4Fluxes)
 ```
 
 ### Properties of a Flux Family

--- a/experimental/FTheoryTools/docs/src/g4.md
+++ b/experimental/FTheoryTools/docs/src/g4.md
@@ -231,9 +231,9 @@ d3_tadpole_constraint(fgs::FamilyOfG4Fluxes; check::Bool = true)
 To test whether a family satisfies standard physical consistency conditions, use:
 
 ```@docs
-is_well_quantized(fgs::FamilyOfG4Fluxes; check::Bool = true)
-passes_transversality_checks(fgs::FamilyOfG4Fluxes; check::Bool = true)
-breaks_non_abelian_gauge_group(fgs::FamilyOfG4Fluxes; check::Bool = true)
+is_well_quantized(fgs::FamilyOfG4Fluxes)
+passes_transversality_checks(fgs::FamilyOfG4Fluxes)
+breaks_non_abelian_gauge_group(fgs::FamilyOfG4Fluxes)
 ```
 
 ### Constructing Flux Instances from a Flux Family

--- a/experimental/FTheoryTools/docs/src/g4.md
+++ b/experimental/FTheoryTools/docs/src/g4.md
@@ -211,7 +211,7 @@ This method is less flexible than direct parametrization, but very convenient fo
     This operation may be computationally expensive for large or complex geometries.
 
 ```@docs
-special_flux_family(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true, algorithm::String = "default")
+special_flux_family(m::AbstractFTheoryModel)
 ```
 
 ### Attributes of a Flux Family

--- a/experimental/FTheoryTools/docs/src/g4.md
+++ b/experimental/FTheoryTools/docs/src/g4.md
@@ -290,7 +290,7 @@ The following method computes a basis for ``H^{2,2}(X_\Sigma, \mathbb{Q})`` by m
 associated with toric coordinates:
 
 ```@docs
-basis_of_h22_ambient(m::AbstractFTheoryModel; check::Bool = true)
+basis_of_h22_ambient(m::AbstractFTheoryModel)
 ```
 
 By default, the method checks if the toric variety is complete and simplicial, but these checks can be skipped by
@@ -299,13 +299,13 @@ setting `check=false`.
 To identify which pairs of classes were used to compute the basis, use:
 
 ```@docs
-basis_of_h22_ambient_indices(m::AbstractFTheoryModel; check::Bool = true)
+basis_of_h22_ambient_indices(m::AbstractFTheoryModel)
 ```
 
 A dictionary mapping any element of ``H^{2,2}(X_\Sigma, \mathbb{Q})`` into this basis is available via:
 
 ```@docs
-converter_dict_h22_ambient(m::AbstractFTheoryModel; check::Bool = true)
+converter_dict_h22_ambient(m::AbstractFTheoryModel)
 ```
 
 ---
@@ -321,17 +321,17 @@ to see if elements vanish upon restriction. No advanced vanishing checks or rela
 The resulting list of generators is available with:
 
 ```@docs
-gens_of_h22_hypersurface(m::AbstractFTheoryModel; check::Bool = true)
+gens_of_h22_hypersurface(m::AbstractFTheoryModel)
 ```
 
 The corresponding index pairs used for multiplication are available via:
 
 ```@docs
-gens_of_h22_hypersurface_indices(m::AbstractFTheoryModel; check::Bool = true)
+gens_of_h22_hypersurface_indices(m::AbstractFTheoryModel)
 ```
 
 To map classes from ``H^{2,2}(X_\Sigma, \mathbb{Q})`` into the hypersurface basis, we use the following dictionary:
 
 ```@docs
-converter_dict_h22_hypersurface(m::AbstractFTheoryModel; check::Bool = true)
+converter_dict_h22_hypersurface(m::AbstractFTheoryModel)
 ```

--- a/experimental/FTheoryTools/docs/src/g4.md
+++ b/experimental/FTheoryTools/docs/src/g4.md
@@ -256,7 +256,7 @@ random_flux(m::AbstractFTheoryModel; not_breaking::Bool = false)
 Starting from a single ``G_4``-flux, you can find the full family of fluxes that share its physical properties:
 
 ```@docs
-g4_flux_family(gf::G4Flux; check::Bool = true)
+g4_flux_family(gf::G4Flux)
 ```
 
 To determine the location of the original flux within that family, retrieve its defining coefficients and offset:

--- a/experimental/FTheoryTools/docs/src/g4.md
+++ b/experimental/FTheoryTools/docs/src/g4.md
@@ -138,7 +138,7 @@ In `FTheoryTools`, ``G_4``-fluxes are created from cohomology classes associated
 model.
 
 ```@docs
-g4_flux(model::AbstractFTheoryModel, class::CohomologyClass; check::Bool = true)
+g4_flux(model::AbstractFTheoryModel, class::CohomologyClass)
 ```
 
 For the special class of quadrillion Standard models (QSMs) (cf. [Cvetič, Halverson, Ling, Liu, Tian 2019](@cite CHLLT19)),
@@ -182,7 +182,7 @@ You can construct a flux family explicitly by specifying its parametrization in 
 ``G_4``-flux generators:
 
 ```@docs
-chosen_g4_flux_gens(m::AbstractFTheoryModel; check::Bool = true)
+chosen_g4_flux_gens(m::AbstractFTheoryModel)
 ```
 
 To define a flux family in this way, you must provide:

--- a/experimental/FTheoryTools/docs/src/g4.md
+++ b/experimental/FTheoryTools/docs/src/g4.md
@@ -241,14 +241,14 @@ breaks_non_abelian_gauge_group(fgs::FamilyOfG4Fluxes)
 You can generate specific fluxes within a family using:
 
 ```@docs
-flux_instance(fgs::FamilyOfG4Fluxes, int_combination::ZZMatrix, rat_combination::QQMatrix; check::Bool = true)
-random_flux_instance(fgs::FamilyOfG4Fluxes; check::Bool = true)
+flux_instance(fgs::FamilyOfG4Fluxes, int_combination::ZZMatrix, rat_combination::QQMatrix)
+random_flux_instance(fgs::FamilyOfG4Fluxes)
 ```
 
 For convenience, a random physically consistent flux can also be generated directly from a model:
 
 ```@docs
-random_flux(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true)
+random_flux(m::AbstractFTheoryModel; not_breaking::Bool = false)
 ```
 
 ### Recovering a Flux Family from a Flux Instance

--- a/experimental/FTheoryTools/docs/src/generalities.md
+++ b/experimental/FTheoryTools/docs/src/generalities.md
@@ -111,10 +111,10 @@ This number is of ample importance to the F-theory QSMs introduced in [CHLLT19](
 These methods allow the user to modify tunable sections or instantiate a model over a concrete base.
 
 ```@docs
-put_over_concrete_base(m::AbstractFTheoryModel, concrete_data::Dict{String, <:Any}; completeness_check::Bool = true)
-tune(w::WeierstrassModel, special_section_choices::Dict{String, <:MPolyRingElem}; completeness_check::Bool = true)
-tune(t::GlobalTateModel, special_ai_choices::Dict{String, <:Any}; completeness_check::Bool = true)
-tune(h::HypersurfaceModel, input_sections::Dict{String, <:Any}; completeness_check::Bool = true)
+put_over_concrete_base(m::AbstractFTheoryModel, concrete_data::Dict{String, <:Any})
+tune(w::WeierstrassModel, special_section_choices::Dict{String, <:MPolyRingElem})
+tune(t::GlobalTateModel, special_ai_choices::Dict{String, <:Any})
+tune(h::HypersurfaceModel, input_sections::Dict{String, <:Any})
 ```
 
 ---

--- a/experimental/FTheoryTools/docs/src/generalities.md
+++ b/experimental/FTheoryTools/docs/src/generalities.md
@@ -52,8 +52,8 @@ The Chern classes of the variety can be computed—or retrieved if precomputed (
 [Literature Models](@ref literature_models))—using:
 
 ```@docs
-chern_class(m::AbstractFTheoryModel, k::Int; check::Bool = true)
-chern_classes(m::AbstractFTheoryModel; check::Bool = true)
+chern_class(m::AbstractFTheoryModel, k::Int)
+chern_classes(m::AbstractFTheoryModel)
 ```
 
 These classes allow for a consistency check on the Calabi–Yau condition:
@@ -65,7 +65,7 @@ is_calabi_yau(m::AbstractFTheoryModel; check::Bool = true)
 The Euler characteristic is obtained by integrating the top Chern class:
 
 ```@docs
-euler_characteristic(m::AbstractFTheoryModel; check::Bool = true)
+euler_characteristic(m::AbstractFTheoryModel)
 ```
 
 ---

--- a/experimental/FTheoryTools/docs/src/generalities.md
+++ b/experimental/FTheoryTools/docs/src/generalities.md
@@ -59,7 +59,7 @@ chern_classes(m::AbstractFTheoryModel)
 These classes allow for a consistency check on the Calabi–Yau condition:
 
 ```@docs
-is_calabi_yau(m::AbstractFTheoryModel; check::Bool = true)
+is_calabi_yau(m::AbstractFTheoryModel)
 ```
 
 The Euler characteristic is obtained by integrating the top Chern class:
@@ -88,7 +88,7 @@ Once algorithmic computation is implemented, these same functions will trigger i
 If Hodge numbers are available, they can be used to verify the Euler characteristic independently:
 
 ```@docs
-verify_euler_characteristic_from_hodge_numbers(m::AbstractFTheoryModel; check::Bool = true)
+verify_euler_characteristic_from_hodge_numbers(m::AbstractFTheoryModel)
 ```
 
 ---

--- a/experimental/FTheoryTools/docs/src/hypersurface.md
+++ b/experimental/FTheoryTools/docs/src/hypersurface.md
@@ -77,8 +77,8 @@ However, the obtained space ``A`` is guaranteed to be consistent with the fibrat
 Users can construct hypersurface models over such concrete toric bases with the following constructor:
 
 ```@docs
-hypersurface_model(base::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}, p::MPolyRingElem; completeness_check::Bool = true)
-hypersurface_model(base::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}, indices::Vector{Int}, p::MPolyRingElem; completeness_check::Bool = true)
+hypersurface_model(base::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}, p::MPolyRingElem)
+hypersurface_model(base::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}, indices::Vector{Int}, p::MPolyRingElem)
 ```
 
 ### Famous Hypersurface Models

--- a/experimental/FTheoryTools/docs/src/tate.md
+++ b/experimental/FTheoryTools/docs/src/tate.md
@@ -148,8 +148,8 @@ elliptic fibration structure.
 Users can construct global Tate models over such concrete toric bases with the following constructors:
 
 ```@docs
-global_tate_model(base::NormalToricVariety; completeness_check::Bool = true)
-global_tate_model(base::NormalToricVariety, ais::Vector{T}; completeness_check::Bool = true) where {T<:MPolyRingElem}
+global_tate_model(base::NormalToricVariety)
+global_tate_model(base::NormalToricVariety, ais::Vector{T}) where {T<:MPolyRingElem}
 ```
 
 For convenience—ideal for quick experiments and educational use—we also support constructors for global Tate models

--- a/experimental/FTheoryTools/docs/src/weierstrass.md
+++ b/experimental/FTheoryTools/docs/src/weierstrass.md
@@ -122,8 +122,8 @@ used in the F-theory literature, but it is guaranteed to be compatible with the 
 Users can construct Weierstrass models over such concrete toric bases with the following constructors:
 
 ```@docs
-weierstrass_model(base::NormalToricVariety; completeness_check::Bool = true)
-weierstrass_model(base::NormalToricVariety, f::MPolyRingElem, g::MPolyRingElem; completeness_check::Bool = true)
+weierstrass_model(base::NormalToricVariety)
+weierstrass_model(base::NormalToricVariety, f::MPolyRingElem, g::MPolyRingElem)
 ```
 
 For convenience—ideal for quick experiments and educational use—we also support constructors for Weierstrass

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/basic_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/basic_attributes.jl
@@ -125,26 +125,26 @@ end
 ### Attributes for flux families (not exported, rather for serialization overhaul)
 ######################################################################################
 
-@attr QQMatrix function matrix_integral_quant_transverse(m::AbstractFTheoryModel; check::Bool = true)
-  return matrix_integral(special_flux_family(m, check = check))
+@attr QQMatrix function matrix_integral_quant_transverse(m::AbstractFTheoryModel; completeness_check::Bool = true)
+  return matrix_integral(special_flux_family(m, completeness_check))
 end
 
-@attr QQMatrix function matrix_rational_quant_transverse(m::AbstractFTheoryModel; check::Bool = true)
-  return matrix_rational(special_flux_family(m, check = check))
+@attr QQMatrix function matrix_rational_quant_transverse(m::AbstractFTheoryModel; completeness_check::Bool = true)
+  return matrix_rational(special_flux_family(m, completeness_check))
 end
 
-@attr Vector{QQFieldElem} function offset_quant_transverse(m::AbstractFTheoryModel; check::Bool = true)
-  return offset(special_flux_family(m, check = check))
+@attr Vector{QQFieldElem} function offset_quant_transverse(m::AbstractFTheoryModel; completeness_check::Bool = true)
+  return offset(special_flux_family(m, completeness_check))
 end
 
-@attr QQMatrix function matrix_integral_quant_transverse_nobreak(m::AbstractFTheoryModel; check::Bool = true)
-  return matrix_integral(special_flux_family(m, not_breaking = true; check = check))
+@attr QQMatrix function matrix_integral_quant_transverse_nobreak(m::AbstractFTheoryModel; completeness_check::Bool = true)
+  return matrix_integral(special_flux_family(m, not_breaking = true; completeness_check))
 end
 
-@attr QQMatrix function matrix_rational_quant_transverse_nobreak(m::AbstractFTheoryModel; check::Bool = true)
-  return matrix_rational(special_flux_family(m, not_breaking = true; check = check))
+@attr QQMatrix function matrix_rational_quant_transverse_nobreak(m::AbstractFTheoryModel; completeness_check::Bool = true)
+  return matrix_rational(special_flux_family(m, not_breaking = true; completeness_check))
 end
 
-@attr Vector{QQFieldElem} function offset_quant_transverse_nobreak(m::AbstractFTheoryModel; check::Bool = true)
-  return offset(special_flux_family(m, not_breaking = true; check = check))
+@attr Vector{QQFieldElem} function offset_quant_transverse_nobreak(m::AbstractFTheoryModel; completeness_check::Bool = true)
+  return offset(special_flux_family(m, not_breaking = true; completeness_check))
 end

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/computed_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/computed_attributes.jl
@@ -37,10 +37,12 @@ function chern_class(m::AbstractFTheoryModel, k::Int; completeness_check::Bool =
   @req (m isa WeierstrassModel || m isa GlobalTateModel || m isa HypersurfaceModel) "Chern class of F-theory model supported for Weierstrass, global Tate and hypersurface models only"
   @req base_space(m) isa NormalToricVariety "Chern class of F-theory model currently supported only for toric base"
   @req ambient_space(m) isa NormalToricVariety "Chern class of F-theory model currently supported only for toric ambient space"
-
-  # Consistency checks
   @req k >= 0 "Chern class index must be non-negative"
   @req k <= dim(ambient_space(m)) - 1 "Chern class index must not exceed dimension of the space"
+  @req is_smooth(ambient_space(m)) "Chern classes require a smooth and complete ambient space"
+  if completeness_check
+    @req is_complete(ambient_space(m)) "Chern classes require a smooth and complete ambient space"
+  end
 
   # If thus far, no non-trivial Chern classes have been computed for this toric variety, add an "empty" vector
   coho_R = cohomology_ring(ambient_space(m); completeness_check)
@@ -62,13 +64,7 @@ function chern_class(m::AbstractFTheoryModel, k::Int; completeness_check::Bool =
   if haskey(cs, k)
     return cs[k]
   end
-
-  # Check if we can compute the Chern classes for the toric ambient space
-  @req is_smooth(ambient_space(m)) "Chern classes require a smooth and complete ambient space"
-  if completeness_check
-    @req is_complete(ambient_space(m)) "Chern classes require a smooth and complete ambient space"
-  end
-
+  
   # Chern class is not known, so compute and return it...
   tdc = toric_divisor_class(ambient_space(m), degree(leading_term(hypersurface_equation(m))))
   cy = cohomology_class(tdc; completeness_check)

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/computed_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/computed_attributes.jl
@@ -159,5 +159,5 @@ julia> h = euler_characteristic(qsm_model; completeness_check = false)
   cy = cohomology_class(toric_divisor_class(ambient_space(m), degree(hypersurface_equation(m))))
 
   # Compute the Euler characteristic
-  return Int(integrate(chern_class(m, 4; check) * cy; completeness_check))
+  return Int(integrate(chern_class(m, 4; completeness_check) * cy; completeness_check))
 end

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/computed_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/computed_attributes.jl
@@ -1,5 +1,5 @@
 @doc raw"""
-    chern_class(m::AbstractFTheoryModel, k::Int; check::Bool = true)
+    chern_class(m::AbstractFTheoryModel, k::Int)
 
 If the elliptically fibered n-fold ``Y_n`` underlying the F-theory model in question is given
 as a hypersurface in a toric ambient space, we can compute a cohomology class ``h`` on the
@@ -7,9 +7,11 @@ toric ambient space ``X_\Sigma``, such that its restriction to ``Y_n`` is the k-
 ``c_k`` of the tangent bundle of ``Y_n``. If those assumptions are satisfied, this method returns
 this very cohomology class ``h``, otherwise it raises an error.
 
-The theory guarantees that the implemented algorithm works for toric ambient spaces which are
-smooth and complete. The check for completeness can be very time consuming. This check can
-be switched off by setting the optional argument `check` to the value `false`, as demonstrated below.
+!!! note "Completeness check"
+    The implemented algorithm is guaranteed to work only for toric ambient spaces
+    that are smooth and **complete**. Verifying completeness can be very time 
+    consuming. To skip this check, pass the optional keyword argument 
+    `completeness_check=false`.
 
 !!!warning
     This method works ONLY for F-theory models which are hypersurfaces in a toric ambient space.
@@ -25,13 +27,13 @@ be switched off by setting the optional argument `check` to the value `false`, a
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
 
-julia> h = chern_class(qsm_model, 4; check = false);
+julia> h = chern_class(qsm_model, 4; completeness_check = false);
 
 julia> is_trivial(h)
 false
 ```
 """
-function chern_class(m::AbstractFTheoryModel, k::Int; check::Bool = true)
+function chern_class(m::AbstractFTheoryModel, k::Int; completeness_check::Bool = true)
   @req (m isa WeierstrassModel || m isa GlobalTateModel || m isa HypersurfaceModel) "Chern class of F-theory model supported for Weierstrass, global Tate and hypersurface models only"
   @req base_space(m) isa NormalToricVariety "Chern class of F-theory model currently supported only for toric base"
   @req ambient_space(m) isa NormalToricVariety "Chern class of F-theory model currently supported only for toric ambient space"
@@ -41,12 +43,12 @@ function chern_class(m::AbstractFTheoryModel, k::Int; check::Bool = true)
   @req k <= dim(ambient_space(m)) - 1 "Chern class index must not exceed dimension of the space"
 
   # If thus far, no non-trivial Chern classes have been computed for this toric variety, add an "empty" vector
-  coho_R = cohomology_ring(ambient_space(m), completeness_check = check)
+  coho_R = cohomology_ring(ambient_space(m); completeness_check)
   if !has_attribute(m, :chern_classes)
     cs = Dict{Int64, CohomologyClass}()
-    cs[0] = cohomology_class(ambient_space(m), one(coho_R), completeness_check = check)
+    cs[0] = cohomology_class(ambient_space(m), one(coho_R); completeness_check)
     diff = degree(leading_term(hypersurface_equation(m))) - sum(coordinate_ring(ambient_space(m)).d)
-    cs[1] = cohomology_class(toric_divisor_class(ambient_space(m), diff), completeness_check = check)
+    cs[1] = cohomology_class(toric_divisor_class(ambient_space(m), diff); completeness_check)
     set_attribute!(m, :chern_classes, cs)
     if k == 0
       return cs[0]
@@ -62,24 +64,25 @@ function chern_class(m::AbstractFTheoryModel, k::Int; check::Bool = true)
   end
 
   # Check if we can compute the Chern classes for the toric ambient space
-  if check
-    @req is_smooth(ambient_space(m)) && is_complete(ambient_space(m)) "The Chern classes of the tangent bundle of the toric ambient space are only supported if the toric ambient space is smooth and complete"
+  @req is_smooth(ambient_space(m)) "Chern classes require a smooth and complete ambient space"
+  if completeness_check
+    @req is_complete(ambient_space(m)) "Chern classes require a smooth and complete ambient space"
   end
 
   # Chern class is not known, so compute and return it...
   tdc = toric_divisor_class(ambient_space(m), degree(leading_term(hypersurface_equation(m))))
-  cy = cohomology_class(tdc, completeness_check = check)
-  ck_ambient = chern_class(ambient_space(m), k, completeness_check = check)
-  ckm1 = chern_class(m, k-1, check = check)
+  cy = cohomology_class(tdc; completeness_check)
+  ck_ambient = chern_class(ambient_space(m), k; completeness_check)
+  ckm1 = chern_class(m, k-1; completeness_check)
   new_poly = lift(polynomial(ck_ambient)) - lift(polynomial(cy)) * lift(polynomial(ckm1))
-  cs[k] = cohomology_class(ambient_space(m), coho_R(new_poly), completeness_check = check)
+  cs[k] = cohomology_class(ambient_space(m), coho_R(new_poly); completeness_check)
   set_attribute!(m, :chern_classes, cs)
   return cs[k]
 end
 
 
 @doc raw"""
-    chern_classes(m::AbstractFTheoryModel; check::Bool = true)
+    chern_classes(m::AbstractFTheoryModel)
 
 If the elliptically fibered n-fold ``Y_n`` underlying the F-theory model in question is given
 as a hypersurface in a toric ambient space, we can compute a cohomology class ``h`` on the
@@ -91,16 +94,18 @@ a vector with the cohomology classes corresponding to all non-trivial Chern clas
 As of right now, this method is computationally expensive for involved toric ambient spaces,
 such as in the example below.
 
-The theory guarantees that the implemented algorithm works for toric ambient spaces which are
-simplicial and complete. The check for completeness can be very time consuming. This check can
-be switched off by setting the optional argument `check` to the value `false`, as demonstrated below.
+!!! note "Completeness check"
+    The implemented algorithm is guaranteed to work only for toric ambient spaces
+    that are simplicial and **complete**. Verifying completeness can be very time 
+    consuming. To skip this check, pass the optional keyword argument 
+    `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
 
-julia> h = chern_classes(qsm_model; check = false);
+julia> h = chern_classes(qsm_model; completeness_check = false);
 
 julia> is_one(polynomial(h[0]))
 true
@@ -112,45 +117,51 @@ julia> is_trivial(h[2])
 false
 ```
 """
-function chern_classes(m::AbstractFTheoryModel; check::Bool = true)
+function chern_classes(m::AbstractFTheoryModel; completeness_check::Bool = true)
   @req (m isa WeierstrassModel || m isa GlobalTateModel || m isa HypersurfaceModel) "Chern class of F-theory model supported for Weierstrass, global Tate and hypersurface models only"
   @req base_space(m) isa NormalToricVariety "Chern class of F-theory model currently supported only for toric base"
   @req ambient_space(m) isa NormalToricVariety "Chern class of F-theory model currently supported only for toric ambient space"
   for k in 0:dim(ambient_space(m))-1
-    chern_class(m, k; check = check)
+    chern_class(m, k; completeness_check)
   end
   return get_attribute(m, :chern_classes)::Dict{Int64, CohomologyClass}
 end
 
 
 @doc raw"""
-    euler_characteristic(m::AbstractFTheoryModel; check::Bool = true)
+    euler_characteristic(m::AbstractFTheoryModel)
 
 If the elliptically fibered n-fold ``Y_n`` underlying the F-theory model in question is given
 as a hypersurface in a toric ambient space, we can compute the Euler characteristic. If this
 assumptions is satisfied, this method returns the Euler characteristic, otherwise it raises an
 error.
 
+!!! note "Completeness check"
+    The implemented algorithm is guaranteed to work only for toric ambient spaces
+    that are smooth and **complete**. Verifying completeness can be very time 
+    consuming. To skip this check, pass the optional keyword argument 
+    `completeness_check=false`.
+
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
 
-julia> h = euler_characteristic(qsm_model; check = false)
+julia> h = euler_characteristic(qsm_model; completeness_check = false)
 378
 ```
 """
-@attr Int function euler_characteristic(m::AbstractFTheoryModel; check::Bool = true)
+@attr Int function euler_characteristic(m::AbstractFTheoryModel; completeness_check::Bool = true)
   @req (m isa WeierstrassModel || m isa GlobalTateModel || m isa HypersurfaceModel) "Euler characteristic of F-theory model supported for Weierstrass, global Tate and hypersurface models only"
   @req base_space(m) isa NormalToricVariety "Euler characteristic of F-theory model currently supported only for toric base"
   @req ambient_space(m) isa NormalToricVariety "Euler characteristic of F-theory model currently supported only for toric ambient space"
 
   # Trigger potential short-cut computation of cohomology ring
-  cohomology_ring(ambient_space(m), completeness_check = check)
+  cohomology_ring(ambient_space(m); completeness_check)
 
   # Compute the cohomology class corresponding to the hypersurface equation
   cy = cohomology_class(toric_divisor_class(ambient_space(m), degree(hypersurface_equation(m))))
 
   # Compute the Euler characteristic
-  return Int(integrate(chern_class(m, 4; check) * cy, completeness_check = check))
+  return Int(integrate(chern_class(m, 4; check) * cy; completeness_check))
 end

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/put_over_concrete_base.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/put_over_concrete_base.jl
@@ -1,9 +1,14 @@
 @doc raw"""
-    put_over_concrete_base(m::AbstractFTheoryModel, concrete_data::Dict{String, <:Any}; completeness_check::Bool = true)
+    put_over_concrete_base(m::AbstractFTheoryModel, concrete_data::Dict{String, <:Any})
 
 Put an F-theory model defined over a family of spaces over a concrete base.
 
 Currently, this functionality is limited to Tate and Weierstrass models.
+
+!!! note "Complete toric base"
+    This function assumes that the toric base space is **complete**.
+    Checking completeness may take a long time. To skip this check,
+    pass the **optional keyword argument** `completeness_check=false`.
 
 # Examples
 ```jldoctest

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Properties/properties.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Properties/properties.jl
@@ -55,13 +55,19 @@ is_partially_resolved(m::AbstractFTheoryModel) = get_attribute(m, :partially_res
 ##########################################
 
 @doc raw"""
-    verify_euler_characteristic_from_hodge_numbers(m::AbstractFTheoryModel; check::Bool = true)
+    verify_euler_characteristic_from_hodge_numbers(m::AbstractFTheoryModel)
 
 Verify if the Euler characteristic, as computed from integrating the 4-th Chern class,
 agrees with the results obtained from using the alternating sum of the Hodge numbers.
 If so, this method returns `true`. However, should information be missing, (e.g. some
 Hodge numbers), or the dimension of the F-theory model differ form 4, then this method
 raises an error.
+
+!!! note "Completeness check"
+    The implemented algorithm is guaranteed to work only for toric ambient spaces
+    that are smooth and **complete**. Verifying completeness can be very time 
+    consuming. To skip this check, pass the optional keyword argument 
+    `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -72,7 +78,7 @@ julia> verify_euler_characteristic_from_hodge_numbers(qsm_model; check = false)
 true
 ```
 """
-@attr Bool function verify_euler_characteristic_from_hodge_numbers(m::AbstractFTheoryModel; check::Bool = true)
+@attr Bool function verify_euler_characteristic_from_hodge_numbers(m::AbstractFTheoryModel; completeness_check::Bool = true)
   @req (m isa WeierstrassModel || m isa GlobalTateModel || m isa HypersurfaceModel) "Verification of Euler characteristic of F-theory model supported for Weierstrass, global Tate and hypersurface models only"
   @req base_space(m) isa NormalToricVariety "Verification of Euler characteristic of F-theory model currently supported only for toric base"
   @req ambient_space(m) isa NormalToricVariety "Verification of Euler characteristic of F-theory model currently supported only for toric ambient space"
@@ -84,7 +90,7 @@ true
   @req has_attribute(m, :h22) "Verification of Euler characteristic of F-theory model requires h22"
 
   # Computer Euler characteristic from integrating c4
-  ec = euler_characteristic(m; check)
+  ec = euler_characteristic(m; completeness_check)
 
   # Compute Euler characteristic from adding Hodge numbers
   ec2 = 4 + 2 * hodge_h11(m) - 4 * hodge_h12(m) + 2 * hodge_h13(m) + hodge_h22(m)
@@ -95,7 +101,7 @@ end
 
 
 @doc raw"""
-    is_calabi_yau(m::AbstractFTheoryModel; check::Bool = true)
+    is_calabi_yau(m::AbstractFTheoryModel)
 
 Verify if the first Chern class of the tangent bundle of the F-theory geometry
 ``Y_n`` vanishes. If so, this confirms that this geometry is indeed Calabi-Yau,
@@ -104,8 +110,13 @@ as required by the reasoning of F-theory.
 The implemented algorithm works for hypersurface, Weierstrass and global Tate models,
 which are defined in a toric ambient space. It expresses ``c_1(Y_n)`` as the restriction
 of a cohomology class ``h`` on the toric ambient space. This in turn requires that the
-toric ambient space is simplicial and complete. We provide a switch to turn off 
-these computationally very demanding checks. This is demonstrated in the example below.
+toric ambient space is smooth and complete.
+
+!!! note "Completeness check"
+    The implemented algorithm is guaranteed to work only for toric ambient spaces
+    that are smooth and **complete**. Verifying completeness can be very time 
+    consuming. To skip this check, pass the optional keyword argument 
+    `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -116,9 +127,9 @@ julia> is_calabi_yau(qsm_model, check = false)
 true
 ```
 """
-@attr Bool function is_calabi_yau(m::AbstractFTheoryModel; check::Bool = true)
+@attr Bool function is_calabi_yau(m::AbstractFTheoryModel; completeness_check::Bool = true)
   @req (m isa WeierstrassModel || m isa GlobalTateModel || m isa HypersurfaceModel) "Verification of Euler characteristic of F-theory model supported for Weierstrass, global Tate and hypersurface models only"
   @req base_space(m) isa NormalToricVariety "Verification of Euler characteristic of F-theory model currently supported only for toric base"
   @req ambient_space(m) isa NormalToricVariety "Verification of Euler characteristic of F-theory model currently supported only for toric ambient space"
-  return is_trivial(chern_class(m, 1; check))
+  return is_trivial(chern_class(m, 1; completeness_check))
 end

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Properties/properties.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Properties/properties.jl
@@ -74,7 +74,7 @@ raises an error.
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
 
-julia> verify_euler_characteristic_from_hodge_numbers(qsm_model; check = false)
+julia> verify_euler_characteristic_from_hodge_numbers(qsm_model; completeness_check = false)
 true
 ```
 """
@@ -123,7 +123,7 @@ toric ambient space is smooth and complete.
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
 
-julia> is_calabi_yau(qsm_model, check = false)
+julia> is_calabi_yau(qsm_model, completeness_check = false)
 true
 ```
 """

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/attributes.jl
@@ -22,7 +22,7 @@ julia> mat_rat[2,1] = 1;
 
 julia> shift = [zero(QQ) for k in 1:37];
 
-julia> f_gs = family_of_g4_fluxes(qsm_model, mat_int, mat_rat, shift, check = false)
+julia> f_gs = family_of_g4_fluxes(qsm_model, mat_int, mat_rat, shift, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
@@ -56,7 +56,7 @@ julia> mat_rat[2,1] = 1;
 
 julia> shift = [zero(QQ) for k in 1:37];
 
-julia> f_gs = family_of_g4_fluxes(qsm_model, mat_int, mat_rat, shift, check = false)
+julia> f_gs = family_of_g4_fluxes(qsm_model, mat_int, mat_rat, shift, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
@@ -90,7 +90,7 @@ julia> mat_rat[2,1] = 1;
 
 julia> shift = [zero(QQ) for k in 1:37];
 
-julia> f_gs = family_of_g4_fluxes(qsm_model, mat_int, mat_rat, shift, check = false)
+julia> f_gs = family_of_g4_fluxes(qsm_model, mat_int, mat_rat, shift, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
@@ -124,7 +124,7 @@ julia> mat_rat[2,1] = 1;
 
 julia> shift = [zero(QQ) for k in 1:37];
 
-julia> f_gs = family_of_g4_fluxes(qsm_model, mat_int, mat_rat, shift, check = false)
+julia> f_gs = family_of_g4_fluxes(qsm_model, mat_int, mat_rat, shift, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
@@ -169,7 +169,7 @@ the numerical coefficient values into this polynomial.
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
 
-julia> fgs = special_flux_family(qsm_model, check = false)
+julia> fgs = special_flux_family(qsm_model, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/attributes.jl
@@ -142,7 +142,7 @@ offset(gf::FamilyOfG4Fluxes) = gf.offset
 #####################################################
 
 @doc raw"""
-    d3_tadpole_constraint(fgs::FamilyOfG4Fluxes; check::Bool = true)
+    d3_tadpole_constraint(fgs::FamilyOfG4Fluxes)
 
 Return the D3-tadpole constraint polynomial for a family of ``G_4``-fluxes.
 
@@ -158,7 +158,11 @@ method returns the quadratic polynomial in these coefficients that encodes the
 ``D3``-tadpole constraint. To evaluate the constraint for a specific flux, substitute
 the numerical coefficient values into this polynomial.
 
-The optional keyword argument `check` enables or disables internal consistency checks.
+!!! note "Completeness check"
+  The implemented algorithm is guaranteed to work only for toric ambient spaces
+  that are smooth and **complete**. Verifying completeness can be very time 
+  consuming. To skip this check, pass the optional keyword argument 
+  `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -174,7 +178,7 @@ Family of G4 fluxes:
 julia> d3_tadpole_constraint(fgs);
 ```
 """
-@attr QQMPolyRingElem function d3_tadpole_constraint(fgs::FamilyOfG4Fluxes; check::Bool = true)
+@attr QQMPolyRingElem function d3_tadpole_constraint(fgs::FamilyOfG4Fluxes; completeness_check::Bool = true)
 
   # Entry checks
   m = model(fgs)
@@ -182,9 +186,9 @@ julia> d3_tadpole_constraint(fgs);
   @req dim(ambient_space(m)) == 5 "Computation of D3-tadpole constraint only supported for 5-dimensional toric ambient spaces"
   @req all(==(0), offset(fgs)) "Currently, the D3-tadpole can only be computed for flux families with trivial offset"
   # TODO: Remove this limitation, i.e. support this functionality for all flux families!
-  if check
+  @req is_smooth(ambient_space(m)) "Computation of D3-tadpole constraint only supported for smooth toric ambient space"
+  if completeness_check
     @req is_complete(ambient_space(m)) "Computation of D3-tadpole constraint only supported for complete toric ambient spaces"
-    @req is_simplicial(ambient_space(m)) "Computation of D3-tadpole constraint only supported for simplicial toric ambient space"
   end
 
   # Are intersection numbers known?
@@ -222,8 +226,8 @@ julia> d3_tadpole_constraint(fgs);
   amb_ring, my_gens = polynomial_ring(QQ, "a#" => 1:numb_int_parameters, "r#" => 1: numb_rat_parameters)
 
   # Extract ambient space basis of G4-flux candidates used to express flux family in
-  basis = gens_of_h22_hypersurface(m, check = check)
-  basis_indices = gens_of_h22_hypersurface_indices(m, check = check)
+  basis = gens_of_h22_hypersurface(m; completeness_check)
+  basis_indices = gens_of_h22_hypersurface_indices(m; completeness_check)
 
   # Use MPolyBuildCtx to compute the tadpole constraint.
   C = MPolyBuildCtx(amb_ring)
@@ -259,7 +263,7 @@ julia> d3_tadpole_constraint(fgs);
             change = sophisticated_intersection_product(ambient_space(m), my_tuple, hypersurface_equation(m), inter_dict, s_inter_dict, data)
           else
             change = get!(inter_dict, my_tuple) do
-              return QQ(integrate(cohomology_class(ambient_space(m), polynomial(basis[l1]) * polynomial(basis[l2]) * cy); completeness_check = check))
+              return QQ(integrate(cohomology_class(ambient_space(m), polynomial(basis[l1]) * polynomial(basis[l2]) * cy); completeness_check))
             end
           end
 
@@ -282,7 +286,7 @@ julia> d3_tadpole_constraint(fgs);
     end
   end
   tadpole_constraint_polynomial = finish(C)
-  tadpole_constraint_polynomial = -1//2 * tadpole_constraint_polynomial + 1//24 * euler_characteristic(m, check = check)
+  tadpole_constraint_polynomial = -1//2 * tadpole_constraint_polynomial + 1//24 * euler_characteristic(m; completeness_check)
 
   # Update the computed intersection numbers
   set_attribute!(m, :inter_dict, inter_dict)

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/constructors.jl
@@ -35,7 +35,7 @@ julia> mat_rat[2,1] = 1;
 
 julia> shift = [zero(QQ) for k in 1:37];
 
-julia> family_of_g4_fluxes(qsm_model, mat_int, mat_rat, shift, check = false)
+julia> family_of_g4_fluxes(qsm_model, mat_int, mat_rat, shift, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: not executed
   - Transversality checks: not executed

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/constructors.jl
@@ -3,7 +3,7 @@
 ################
 
 @doc raw"""
-    family_of_g4_fluxes(m::AbstractFTheoryModel, mat_int::QQMatrix, mat_rat::QQMatrix; check::Bool = true)
+    family_of_g4_fluxes(m::AbstractFTheoryModel, mat_int::QQMatrix, mat_rat::QQMatrix)
 
 Given an F-theory model with a toric ambient space, we can 
 identify ambient space candidates of G4-fluxes. In terms of these
@@ -13,6 +13,12 @@ candidates, we can define a family of G4-fluxes as:
 - a shift—resembling the appearance of ``\frac{1}{2} \cdot c_2`` in the flux quantization condition—provided by a vector ``\text{offset}``.
 
 For convenience we also allow to only provide ``\text{mat}_{\text{int}}``or ``\text{mat}_{\text{rat}}``. In this case, the shift is taken to be zero.
+
+!!! note "Completeness check"
+    The implemented algorithm is guaranteed to work only for toric ambient spaces
+    that are simplicial and **complete**. Verifying completeness can be very time 
+    consuming. To skip this check, pass the optional keyword argument 
+    `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -36,19 +42,19 @@ Family of G4 fluxes:
   - Non-abelian gauge group: breaking pattern not analyzed
 ```
 """
-function family_of_g4_fluxes(m::AbstractFTheoryModel, mat_int::QQMatrix, mat_rat::QQMatrix, offset::Vector{QQFieldElem}; check::Bool = true)
+function family_of_g4_fluxes(m::AbstractFTheoryModel, mat_int::QQMatrix, mat_rat::QQMatrix, offset::Vector{QQFieldElem}; completeness_check::Bool = true)
   @req (m isa WeierstrassModel || m isa GlobalTateModel || m isa HypersurfaceModel) "Family of G4-fluxes only supported for Weierstrass, global Tate and hypersurface models"
   @req base_space(m) isa NormalToricVariety "Family of G4-flux currently supported only for toric base"
   @req ambient_space(m) isa NormalToricVariety "Family of G4-flux currently supported only for toric ambient space"
   @req nrows(mat_int) == nrows(mat_rat) "Number of rows in both matrices must coincide"
   @req nrows(mat_int) == length(offset) "Number of rows of integral matrix and length offset must coincide"
-  n_gens = length(chosen_g4_flux_gens(m, check = check))
+  n_gens = length(chosen_g4_flux_gens(m; completeness_check))
   @req nrows(mat_int) == n_gens "Number of rows in both matrices must agree with the number of ambient space models of G4-fluxes"
   return FamilyOfG4Fluxes(m, mat_int, mat_rat, offset)
 end
 
-function family_of_g4_fluxes(m::AbstractFTheoryModel, mat_int::QQMatrix, mat_rat::QQMatrix; check::Bool = true)
-  return family_of_g4_fluxes(m, mat_int, mat_rat, fill(QQ(0), nrows(mat_int)), check = check)
+function family_of_g4_fluxes(m::AbstractFTheoryModel, mat_int::QQMatrix, mat_rat::QQMatrix; completeness_check::Bool = true)
+  return family_of_g4_fluxes(m, mat_int, mat_rat, fill(QQ(0), nrows(mat_int)); completeness_check)
 end
 
 

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
@@ -192,7 +192,7 @@ julia> mat_rat[2,1] = 1;
 
 julia> shift = [zero(QQ) for k in 1:37];
 
-julia> fgs = family_of_g4_fluxes(qsm_model, mat_int, mat_rat, shift, check = false)
+julia> fgs = family_of_g4_fluxes(qsm_model, mat_int, mat_rat, shift, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
@@ -256,6 +256,6 @@ G4-flux candidate
 ```
 """
 function random_flux(m::AbstractFTheoryModel; not_breaking::Bool = false, completeness_check::Bool = true, consistency_check::Bool = true)
-  family = special_flux_family(m, not_breaking = not_breaking, check = completeness_check)
+  family = special_flux_family(m; not_breaking, completeness_check)
   return random_flux_instance(family; completeness_check, consistency_check)
 end

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
@@ -4,9 +4,20 @@
 
 
 @doc raw"""
-    flux_instance(fgs::FamilyOfG4Fluxes, int_combination::ZZMatrix, rat_combination::QQMatrix; check::Bool = true)
+    flux_instance(fgs::FamilyOfG4Fluxes, int_combination::ZZMatrix, rat_combination::QQMatrix)
 
 Create an element of a family of G4-fluxes.
+
+!!! note "Completeness check"
+  The implemented algorithm is guaranteed to work only for toric ambient spaces
+  that are smooth and **complete**. Verifying completeness can be very time 
+  consuming. To skip this check, pass the optional keyword argument 
+  `completeness_check=false`.
+
+!!! note "Consistency check"
+  G4-fluxes must always be properly quantized and pass the transversality checks.
+  Verifying those properties can be very time consuming. To skip these consistency checks,
+  pass the optional keyword argument `consistency_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -23,7 +34,7 @@ julia> mat_rat[2,1] = 1;
 
 julia> shift = [zero(QQ) for k in 1:37];
 
-julia> fgs = family_of_g4_fluxes(qsm_model, mat_int, mat_rat, shift, check = false)
+julia> fgs = family_of_g4_fluxes(qsm_model, mat_int, mat_rat, shift, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
@@ -35,35 +46,35 @@ julia> int_combination = matrix(ZZ, [[3]])
 julia> rat_combination = matrix(QQ, [[5//2]])
 [5//2]
 
-julia> flux_instance(fgs, int_combination, rat_combination, check = false)
+julia> flux_instance(fgs, int_combination, rat_combination, completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
   - Non-abelian gauge group: breaking pattern not analyzed
   - Tadpole cancellation check: not computed
 
-julia> flux_instance(fgs, Int[], [], check = false)
+julia> flux_instance(fgs, Int[], [], completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
   - Non-abelian gauge group: breaking pattern not analyzed
   - Tadpole cancellation check: not computed
 
-julia> flux_instance(fgs, [3], [], check = false)
+julia> flux_instance(fgs, [3], [], completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
   - Non-abelian gauge group: breaking pattern not analyzed
   - Tadpole cancellation check: not computed
 
-julia> flux_instance(fgs, [], [5//2], check = false)
+julia> flux_instance(fgs, [], [5//2], completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
   - Non-abelian gauge group: breaking pattern not analyzed
   - Tadpole cancellation check: not computed
 
-julia> flux_instance(fgs, [3], [5//2], check = false)
+julia> flux_instance(fgs, [3], [5//2], completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
@@ -71,7 +82,7 @@ G4-flux candidate
   - Tadpole cancellation check: not computed
 ```
 """
-function flux_instance(fgs::FamilyOfG4Fluxes, int_combination::ZZMatrix, rat_combination::QQMatrix; check::Bool = true)
+function flux_instance(fgs::FamilyOfG4Fluxes, int_combination::ZZMatrix, rat_combination::QQMatrix; completeness_check::Bool = true, consistency_check::Bool = true)
   @req ncols(int_combination) == 1 "int_combination is expected to be a single column vector"
   @req ncols(rat_combination) == 1 "rat_combination is expected to be a single column vector"
   @req nrows(int_combination) == ncols(matrix_integral(fgs)) "Number of specified integers must match the number of integral combinations in G4-flux family"
@@ -79,7 +90,7 @@ function flux_instance(fgs::FamilyOfG4Fluxes, int_combination::ZZMatrix, rat_com
   m1 = matrix_integral(fgs) * int_combination
   m2 = matrix_rational(fgs) * rat_combination
   shift = offset(fgs)
-  gens = chosen_g4_flux_gens(model(fgs), check = check)
+  gens = chosen_g4_flux_gens(model(fgs); completeness_check)
   c1 = sum(m1[k,1] * gens[k] for k in 1:length(gens))
   c2 = sum(m2[k,1] * gens[k] for k in 1:length(gens))
   c3 = sum(shift[k] * gens[k] for k in 1:length(gens))
@@ -103,16 +114,19 @@ function flux_instance(fgs::FamilyOfG4Fluxes, int_combination::ZZMatrix, rat_com
       set_attribute!(flux, :breaks_non_abelian_gauge_group, false)
     end
   end
+  if consistency_check
+    @req (is_well_quantized(flux) && passes_transversality_checks(flux)) "G4-flux candidate violates quantization and/or transversality condition"
+  end
   return flux
 end
 
 
-function flux_instance(fgs::FamilyOfG4Fluxes, int_coeffs::Vector{Int}, rat_coeffs::Vector{Rational{Int}}; check::Bool = true)
+function flux_instance(fgs::FamilyOfG4Fluxes, int_coeffs::Vector{Int}, rat_coeffs::Vector{Rational{Int}}; completeness_check::Bool = true, consistency_check::Bool = true)
   if length(int_coeffs) == 0 && length(rat_coeffs) == 0
     m = model(fgs)
-    r = cohomology_ring(ambient_space(m), completeness_check = check)
-    tcc = cohomology_class(ambient_space(m), zero(r), completeness_check = check)
-    return g4_flux(m, tcc, check = check)
+    r = cohomology_ring(ambient_space(m); completeness_check)
+    tcc = cohomology_class(ambient_space(m), zero(r); completeness_check)
+    return g4_flux(m, tcc; completeness_check, consistency_check)
   end
   @req all(x -> x isa Int, int_coeffs) "Provided integral coefficient is not an integer"
   @req all(x -> x isa Rational{Int64}, rat_coeffs) "Provided integral coefficient is not an integer"
@@ -131,26 +145,37 @@ function flux_instance(fgs::FamilyOfG4Fluxes, int_coeffs::Vector{Int}, rat_coeff
   if length(rat_coeffs) > 0
     @req length(rat_coeffs) == ncols(matrix_rational(fgs)) "Number of specified rationals must match the number of rational combinations in G4-flux family"
   end
-  return flux_instance(fgs, m_int, m_rat, check = check)
+  return flux_instance(fgs, m_int, m_rat; completeness_check, consistency_check)
 end
 
-function flux_instance(fgs::FamilyOfG4Fluxes, int_coeffs::Vector{Any}, rat_coeffs::Vector{Rational{Int}}; check::Bool = true)
-  return flux_instance(fgs, Vector{Int}(int_coeffs), rat_coeffs, check = check)
+function flux_instance(fgs::FamilyOfG4Fluxes, int_coeffs::Vector{Any}, rat_coeffs::Vector{Rational{Int}}; completeness_check::Bool = true, consistency_check::Bool = true)
+  return flux_instance(fgs, Vector{Int}(int_coeffs), rat_coeffs; completeness_check, consistency_check)
 end
 
-function flux_instance(fgs::FamilyOfG4Fluxes, int_coeffs::Vector{Int}, rat_coeffs::Vector{Any}; check::Bool = true)
-  return flux_instance(fgs, int_coeffs, Vector{Rational{Int}}(rat_coeffs), check = check)
+function flux_instance(fgs::FamilyOfG4Fluxes, int_coeffs::Vector{Int}, rat_coeffs::Vector{Any}; completeness_check::Bool = true, consistency_check::Bool = true)
+  return flux_instance(fgs, int_coeffs, Vector{Rational{Int}}(rat_coeffs); completeness_check, consistency_check)
 end
 
-function flux_instance(fgs::FamilyOfG4Fluxes, int_coeffs::Vector{Any}, rat_coeffs::Vector{Any}; check::Bool = true)
-  return flux_instance(fgs, Vector{Int}(int_coeffs), Vector{Rational{Int}}(rat_coeffs), check = check)
+function flux_instance(fgs::FamilyOfG4Fluxes, int_coeffs::Vector{Any}, rat_coeffs::Vector{Any}; completeness_check::Bool = true, consistency_check::Bool = true)
+  return flux_instance(fgs, Vector{Int}(int_coeffs), Vector{Rational{Int}}(rat_coeffs); completeness_check, consistency_check)
 end
 
 
 @doc raw"""
-    random_flux_instance(fgs::FamilyOfG4Fluxes; check::Bool = true)
+    random_flux_instance(fgs::FamilyOfG4Fluxes)
 
 Create a random element of a family of G4-fluxes.
+
+!!! note "Completeness check"
+  The implemented algorithm is guaranteed to work only for toric ambient spaces
+  that are smooth and **complete**. Verifying completeness can be very time 
+  consuming. To skip this check, pass the optional keyword argument 
+  `completeness_check=false`.
+
+!!! note "Consistency check"
+  G4-fluxes must always be properly quantized and pass the transversality checks.
+  Verifying those properties can be very time consuming. To skip these consistency checks,
+  pass the optional keyword argument `consistency_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -173,7 +198,7 @@ Family of G4 fluxes:
   - Transversality checks: not executed
   - Non-abelian gauge group: breaking pattern not analyzed
 
-julia> random_flux_instance(fgs, check = false)
+julia> random_flux_instance(fgs, completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
@@ -181,7 +206,7 @@ G4-flux candidate
   - Tadpole cancellation check: not computed
 ```
 """
-function random_flux_instance(fgs::FamilyOfG4Fluxes; check::Bool = true)
+function random_flux_instance(fgs::FamilyOfG4Fluxes; completeness_check::Bool = true, consistency_check::Bool = true)
   int_combination = zero_matrix(ZZ, ncols(matrix_integral(fgs)), 1)
   rat_combination = zero_matrix(QQ, ncols(matrix_rational(fgs)), 1)
   for i in 1:ncols(matrix_integral(fgs))
@@ -192,7 +217,7 @@ function random_flux_instance(fgs::FamilyOfG4Fluxes; check::Bool = true)
     denominator = rand(1:100)
     rat_combination[i] = numerator // denominator
   end
-  return flux_instance(fgs, int_combination, rat_combination, check = check)
+  return flux_instance(fgs, int_combination, rat_combination; completeness_check, consistency_check)
 end
 
 
@@ -202,16 +227,27 @@ end
 ##########################################
 
 @doc raw"""
-    random_flux(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true)
+    random_flux(m::AbstractFTheoryModel)
 
 Create a random ``G_4``-flux on a given F-theory model.
+
+!!! note "Completeness check"
+  The implemented algorithm is guaranteed to work only for toric ambient spaces
+  that are smooth and **complete**. Verifying completeness can be very time 
+  consuming. To skip this check, pass the optional keyword argument 
+  `completeness_check=false`.
+
+!!! note "Consistency check"
+  G4-fluxes must always be properly quantized and pass the transversality checks.
+  Verifying those properties can be very time consuming. To skip these consistency checks,
+  pass the optional keyword argument `consistency_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
 
-julia> rf = random_flux(qsm_model, check = false)
+julia> rf = random_flux(qsm_model, completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied
@@ -219,7 +255,7 @@ G4-flux candidate
   - Tadpole cancellation check: not computed
 ```
 """
-function random_flux(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true)
-  family = special_flux_family(m, not_breaking = not_breaking, check = check)
-  return random_flux_instance(family, check = check)
+function random_flux(m::AbstractFTheoryModel; not_breaking::Bool = false, completeness_check::Bool = true, consistency_check::Bool = true)
+  family = special_flux_family(m, not_breaking = not_breaking, check = completeness_check)
+  return random_flux_instance(family; completeness_check, consistency_check)
 end

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/properties.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/properties.jl
@@ -23,7 +23,7 @@ appear well-quantized based on current knowledge, but without guaranteeing it.
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
 
-julia> gf = special_flux_family(qsm_model, check = false)
+julia> gf = special_flux_family(qsm_model, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied
@@ -36,7 +36,7 @@ julia> m1 = matrix_integral(gf);
 
 julia> m2 = matrix_rational(gf);
 
-julia> gf2 = family_of_g4_fluxes(qsm_model, m1, m2, check = false)
+julia> gf2 = family_of_g4_fluxes(qsm_model, m1, m2, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
@@ -107,7 +107,7 @@ Return `true` if the checks pass, and `false` otherwise.
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
 
-julia> gf = special_flux_family(qsm_model, check = false)
+julia> gf = special_flux_family(qsm_model, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied
@@ -120,7 +120,7 @@ julia> m1 = matrix_integral(gf);
 
 julia> m2 = matrix_rational(gf);
 
-julia> gf3 = family_of_g4_fluxes(qsm_model, m1, m2, check = false)
+julia> gf3 = family_of_g4_fluxes(qsm_model, m1, m2, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
@@ -179,7 +179,7 @@ Return `true` if it does, and `false` otherwise.
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
 
-julia> gf = special_flux_family(qsm_model, check = false)
+julia> gf = special_flux_family(qsm_model, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied
@@ -188,7 +188,7 @@ Family of G4 fluxes:
 julia> breaks_non_abelian_gauge_group(gf)
 true
 
-julia> gf3 = special_flux_family(qsm_model, not_breaking = true, check = false)
+julia> gf3 = special_flux_family(qsm_model, not_breaking = true, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied
@@ -201,7 +201,7 @@ julia> m1 = matrix_integral(gf3);
 
 julia> m2 = matrix_rational(gf3);
 
-julia> gf4 = family_of_g4_fluxes(qsm_model, m1, m2, check = false)
+julia> gf4 = family_of_g4_fluxes(qsm_model, m1, m2, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: not executed
   - Transversality checks: not executed

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/properties.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/properties.jl
@@ -3,7 +3,7 @@
 #####################################################
 
 @doc raw"""
-    is_well_quantized(fgs::FamilyOfG4Fluxes; check::Bool = true)
+    is_well_quantized(fgs::FamilyOfG4Fluxes)
 
 Performs elementary necessary (but not sufficient) tests to check if the 
 family of ``G_4``-fluxes is well-quantized.
@@ -11,6 +11,12 @@ family of ``G_4``-fluxes is well-quantized.
 If any test fails, the family is definitely not well-quantized and the method 
 returns `false`. If all tests pass, it returns `true`, indicating the fluxes 
 appear well-quantized based on current knowledge, but without guaranteeing it.
+
+!!! note "Completeness check"
+    The implemented algorithm is guaranteed to work only for toric ambient spaces
+    that are smooth and **complete**. Verifying completeness can be very time 
+    consuming. To skip this check, pass the optional keyword argument 
+    `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -36,11 +42,11 @@ Family of G4 fluxes:
   - Transversality checks: not executed
   - Non-abelian gauge group: breaking pattern not analyzed
 
-julia> is_well_quantized(gf2, check = false)
+julia> is_well_quantized(gf2, completeness_check = false)
 true
 ```
 """
-@attr Bool function is_well_quantized(fgs::FamilyOfG4Fluxes; check::Bool = true)
+@attr Bool function is_well_quantized(fgs::FamilyOfG4Fluxes; completeness_check::Bool = true)
   # Entry checks
   m = model(fgs)
   @req (m isa WeierstrassModel || m isa GlobalTateModel || m isa HypersurfaceModel) "Elementary quantization check only supported for Weierstrass, global Tate and hypersurface models"
@@ -50,7 +56,7 @@ true
   # TODO: Remove this limitation, i.e. support this functionality for all flux families!
 
   # Extract ambient space model of g4-fluxes, in terms of which we express the generators of the flux family
-  mb = chosen_g4_flux_gens(model(fgs), check = check)
+  mb = chosen_g4_flux_gens(model(fgs); completeness_check)
   nmb = length(mb)
 
   # Verify that each integral generator is well-quantized
@@ -68,10 +74,10 @@ true
   my_mat = matrix_rational(fgs)
   for k in 1:ncols(my_mat)
     gen_k = sum(my_mat[l,k] * mb[l] for l in 1:nmb)
-    twist_g4 = polynomial(gen_k + 1//2 * chern_class(m, 2; check = false))
+    twist_g4 = polynomial(gen_k + 1//2 * chern_class(m, 2; completeness_check))
     for i in 1:length(c_ds)
       for j in i:length(c_ds)
-        numb = integrate(cohomology_class(ambient_space(m), twist_g4 * c_ds[i] * c_ds[j] * cy); check = false)
+        numb = integrate(cohomology_class(ambient_space(m), twist_g4 * c_ds[i] * c_ds[j] * cy); completeness_check)
         if !is_zero(numb)
           return false    
         end
@@ -85,10 +91,16 @@ end
 
 
 @doc raw"""
-    passes_transversality_checks(fgs::FamilyOfG4Fluxes; check::Bool = true)
+    passes_transversality_checks(fgs::FamilyOfG4Fluxes)
 
 Check if the given family of ``G_4``-fluxes passes the transversality conditions.
 Return `true` if the checks pass, and `false` otherwise.
+
+!!! note "Completeness check"
+    The implemented algorithm is guaranteed to work only for toric ambient spaces
+    that are simplicial and **complete**. Verifying completeness can be very time 
+    consuming. To skip this check, pass the optional keyword argument 
+    `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -101,7 +113,7 @@ Family of G4 fluxes:
   - Transversality checks: satisfied
   - Non-abelian gauge group: breaking pattern not analyzed
 
-julia> passes_transversality_checks(gf, check = false)
+julia> passes_transversality_checks(gf, completeness_check = false)
 true
 
 julia> m1 = matrix_integral(gf);
@@ -118,7 +130,7 @@ julia> passes_transversality_checks(gf3)
 true
 ```
 """
-@attr Bool function passes_transversality_checks(fgs::FamilyOfG4Fluxes; check::Bool = true)
+@attr Bool function passes_transversality_checks(fgs::FamilyOfG4Fluxes; completeness_check::Bool = true)
   # Entry checks
   m = model(fgs)
   @req (m isa WeierstrassModel || m isa GlobalTateModel || m isa HypersurfaceModel) "Transversality checks supported only for Weierstrass, global Tate and hypersurface models"
@@ -128,7 +140,7 @@ true
   # TODO: Remove this limitation, i.e. support this functionality for all flux families!
 
   # Extract ambient space model of g4-fluxes, in terms of which we express the generators of the flux family
-  mb = chosen_g4_flux_gens(model(fgs), check = check)
+  mb = chosen_g4_flux_gens(model(fgs); completeness_check)
   nmb = length(mb)
 
   # Verify that each generator of the flux family is vertical
@@ -151,10 +163,16 @@ end
 
 
 @doc raw"""
-    breaks_non_abelian_gauge_group(fgs::FamilyOfG4Fluxes; check::Bool = true)
+    breaks_non_abelian_gauge_group(fgs::FamilyOfG4Fluxes)
 
 Check if the given family of ``G_4``-fluxes breaks the non-abelian gauge group.
 Return `true` if it does, and `false` otherwise.
+
+!!! note "Completeness check"
+  The implemented algorithm is guaranteed to work only for toric ambient spaces
+  that are simplicial and **complete**. Verifying completeness can be very time 
+  consuming. To skip this check, pass the optional keyword argument 
+  `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -189,11 +207,11 @@ Family of G4 fluxes:
   - Transversality checks: not executed
   - Non-abelian gauge group: breaking pattern not analyzed
 
-julia> breaks_non_abelian_gauge_group(gf4, check = false)
+julia> breaks_non_abelian_gauge_group(gf4, completeness_check = false)
 false
 ```
 """
-@attr Bool function breaks_non_abelian_gauge_group(fgs::FamilyOfG4Fluxes; check::Bool = true)
+@attr Bool function breaks_non_abelian_gauge_group(fgs::FamilyOfG4Fluxes; completeness_check::Bool = true)
   # Entry checks
   m = model(fgs)
   @req (m isa WeierstrassModel || m isa GlobalTateModel || m isa HypersurfaceModel) "Gauge group breaking check only supported for Weierstrass, global Tate and hypersurface models"
@@ -203,7 +221,7 @@ false
   # TODO: Remove this limitation, i.e. support this functionality for all flux families!
   
   # Extract ambient space model of g4-fluxes, in terms of which we express the generators of the flux family
-  mb = chosen_g4_flux_gens(model(fgs), check = check)
+  mb = chosen_g4_flux_gens(model(fgs); completeness_check)
   nmb = length(mb)
 
   # Verify that each generator of the flux family does not break the non-abelian gauge group

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
@@ -15,7 +15,7 @@ Optional keyword arguments:
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
 
-julia> fg = special_flux_family(qsm_model, check = false)
+julia> fg = special_flux_family(qsm_model, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
@@ -51,9 +51,9 @@ function special_flux_family(m::AbstractFTheoryModel; not_breaking::Bool = false
   # (1) Is result known?
   if !not_breaking
     if has_attribute(m, :matrix_integral_quant_transverse) && has_attribute(m, :matrix_rational_quant_transverse) && has_attribute(m, :offset_quant_transverse)
-      fgs_m_int = matrix_integral_quant_transverse(m, check = completeness_check)
-      fgs_m_rat = matrix_rational_quant_transverse(m, check = completeness_check)
-      fgs_offset = offset_quant_transverse(m, check = completeness_check)
+      fgs_m_int = matrix_integral_quant_transverse(m; completeness_check)
+      fgs_m_rat = matrix_rational_quant_transverse(m; completeness_check)
+      fgs_offset = offset_quant_transverse(m; completeness_check)
       fgs = family_of_g4_fluxes(m, fgs_m_int, fgs_m_rat, fgs_offset; completeness_check)
       set_attribute!(fgs, :is_well_quantized, true)
       set_attribute!(fgs, :passes_transversality_checks, true)
@@ -61,9 +61,9 @@ function special_flux_family(m::AbstractFTheoryModel; not_breaking::Bool = false
     end
   else
     if has_attribute(m, :matrix_integral_quant_transverse_nobreak) && has_attribute(m, :matrix_rational_quant_transverse_nobreak) && has_attribute(m, :offset_quant_transverse_nobreak)
-      fgs_m_int = matrix_integral_quant_transverse_nobreak(m, check = completeness_check)
-      fgs_m_rat = matrix_rational_quant_transverse_nobreak(m, check = completeness_check)
-      fgs_offset = offset_quant_transverse_nobreak(m, check = completeness_check)
+      fgs_m_int = matrix_integral_quant_transverse_nobreak(m; completeness_check)
+      fgs_m_rat = matrix_rational_quant_transverse_nobreak(m; completeness_check)
+      fgs_offset = offset_quant_transverse_nobreak(m; completeness_check)
       fgs = family_of_g4_fluxes(m, fgs_m_int, fgs_m_rat, fgs_offset; completeness_check)
       set_attribute!(fgs, :is_well_quantized, true)
       set_attribute!(fgs, :passes_transversality_checks, true)

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
@@ -1,5 +1,5 @@
 @doc raw"""
-    special_flux_family(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true, algorithm::String = "default")
+    special_flux_family(m::AbstractFTheoryModel)
 
 Compute a family of ``G_4``-fluxes for the F-theory model `m`, defined as a hypersurface
 in a simplicial, complete toric ambient space. The returned fluxes satisfy necessary
@@ -7,7 +7,7 @@ quantization and transversality checks.
 
 Optional keyword arguments:
 - `not_breaking`: if `true`, restricts to fluxes preserving the non-abelian gauge group.
-- `check`: if `false`, skips computational checks of completeness and simplicity of the ambient toric variety for improved performance.
+- `completeness_check`: if `false`, skips completeness check of the ambient toric variety for improved performance.
 - `algorithm`: selects the computation method; the default uses Gröbner basis computations in the cohomology ring, while setting `algorithm = "special"` activates a faster variant described in [BMT25](@cite BMT25).
 
 # Examples
@@ -21,20 +21,20 @@ Family of G4 fluxes:
   - Transversality checks: satisfied
   - Non-abelian gauge group: breaking pattern not analyzed
 
-julia> fg = special_flux_family(qsm_model, not_breaking = true, check = false)
+julia> fg = special_flux_family(qsm_model, not_breaking = true, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied
   - Non-abelian gauge group: unbroken
 
-julia> g4_tester = random_flux_instance(fg, check = false)
+julia> g4_tester = random_flux_instance(fg, completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied
   - Non-abelian gauge group: unbroken
   - Tadpole cancellation check: not computed
 
-julia> g4_tester_double = g4_flux(qsm_model, cohomology_class(g4_tester), check = false);
+julia> g4_tester_double = g4_flux(qsm_model, cohomology_class(g4_tester), completeness_check = false, consistency_check = false);
 
 julia> is_well_quantized(g4_tester_double)
 true
@@ -46,25 +46,25 @@ julia> breaks_non_abelian_gauge_group(g4_tester_double)
 false
 ```
 """
-function special_flux_family(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true, algorithm::String = "default")
+function special_flux_family(m::AbstractFTheoryModel; not_breaking::Bool = false, completeness_check::Bool = true, algorithm::String = "default")
 
   # (1) Is result known?
   if !not_breaking
     if has_attribute(m, :matrix_integral_quant_transverse) && has_attribute(m, :matrix_rational_quant_transverse) && has_attribute(m, :offset_quant_transverse)
-      fgs_m_int = matrix_integral_quant_transverse(m, check = check)
-      fgs_m_rat = matrix_rational_quant_transverse(m, check = check)
-      fgs_offset = offset_quant_transverse(m, check = check)
-      fgs = family_of_g4_fluxes(m, fgs_m_int, fgs_m_rat, fgs_offset)
+      fgs_m_int = matrix_integral_quant_transverse(m, check = completeness_check)
+      fgs_m_rat = matrix_rational_quant_transverse(m, check = completeness_check)
+      fgs_offset = offset_quant_transverse(m, check = completeness_check)
+      fgs = family_of_g4_fluxes(m, fgs_m_int, fgs_m_rat, fgs_offset; completeness_check)
       set_attribute!(fgs, :is_well_quantized, true)
       set_attribute!(fgs, :passes_transversality_checks, true)
       return fgs
     end
   else
     if has_attribute(m, :matrix_integral_quant_transverse_nobreak) && has_attribute(m, :matrix_rational_quant_transverse_nobreak) && has_attribute(m, :offset_quant_transverse_nobreak)
-      fgs_m_int = matrix_integral_quant_transverse_nobreak(m, check = check)
-      fgs_m_rat = matrix_rational_quant_transverse_nobreak(m, check = check)
-      fgs_offset = offset_quant_transverse_nobreak(m, check = check)
-      fgs = family_of_g4_fluxes(m, fgs_m_int, fgs_m_rat, fgs_offset)
+      fgs_m_int = matrix_integral_quant_transverse_nobreak(m, check = completeness_check)
+      fgs_m_rat = matrix_rational_quant_transverse_nobreak(m, check = completeness_check)
+      fgs_offset = offset_quant_transverse_nobreak(m, check = completeness_check)
+      fgs = family_of_g4_fluxes(m, fgs_m_int, fgs_m_rat, fgs_offset; completeness_check)
       set_attribute!(fgs, :is_well_quantized, true)
       set_attribute!(fgs, :passes_transversality_checks, true)
       set_attribute!(fgs, :breaks_non_abelian_gauge_group, false)
@@ -78,18 +78,18 @@ function special_flux_family(m::AbstractFTheoryModel; not_breaking::Bool = false
   end
   @req base_space(m) isa NormalToricVariety "Computation of well-quantized and transversal G4-fluxes only supported for toric base and ambient spaces"
   @req dim(ambient_space(m)) == 5 "Computation of well-quantized and transversal G4-fluxes only supported for 5-dimensional toric ambient spaces"
-  if check
+  @req is_smooth(ambient_space(m)) "Computation of well-quantized and transversal G4-fluxes only supported for smooth toric ambient space"
+  if completeness_check
     @req is_complete(ambient_space(m)) "Computation of well-quantized and transversal G4-fluxes only supported for complete toric ambient spaces"
-    @req is_simplicial(ambient_space(m)) "Computation of well-quantized and transversal G4-fluxes only supported for simplicial toric ambient space"
   end  
   
   # (3) Result not known, compute it!
   final_shift = Vector{QQFieldElem}()
   res = Vector{ZZMatrix}()
   if algorithm == "special"
-    final_shift, res = special_flux_family_with_special_algorithm(m::AbstractFTheoryModel; not_breaking = not_breaking, check = check)
+    final_shift, res = special_flux_family_with_special_algorithm(m::AbstractFTheoryModel; not_breaking, completeness_check)
   else
-    final_shift, res = special_flux_family_with_default_algorithm(m::AbstractFTheoryModel; not_breaking = not_breaking, check = check)
+    final_shift, res = special_flux_family_with_default_algorithm(m::AbstractFTheoryModel; not_breaking, completeness_check)
   end
 
   # (4) Set attributes accordingly, and return result
@@ -111,7 +111,7 @@ function special_flux_family(m::AbstractFTheoryModel; not_breaking::Bool = false
 end
 
 
-function special_flux_family_with_default_algorithm(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true)  
+function special_flux_family_with_default_algorithm(m::AbstractFTheoryModel; not_breaking::Bool = false, completeness_check::Bool = true)  
   
   # (1) Are intersection numbers known?
   # These instructions appear twice, once in the default and once in the special algorithnm. Code duplication? Improve it!
@@ -124,9 +124,9 @@ function special_flux_family_with_default_algorithm(m::AbstractFTheoryModel; not
 
 
   # (2) Obtain critical information - this may take significant time!
-  ambient_space_flux_candidates_basis = gens_of_h22_hypersurface(m, check = check)
+  ambient_space_flux_candidates_basis = gens_of_h22_hypersurface(m; completeness_check)
   list_of_base_divisor_pairs_to_be_considered = Oscar._ambient_space_base_divisor_pairs_to_be_considered(m)
-  ambient_space_flux_candidates_basis_indices = gens_of_h22_hypersurface_indices(m, check = check)
+  ambient_space_flux_candidates_basis_indices = gens_of_h22_hypersurface_indices(m; completeness_check)
   list_of_divisor_pairs_to_be_considered = Oscar._ambient_space_divisor_pairs_to_be_considered(m)
   S = coordinate_ring(ambient_space(m))
   exceptional_divisor_positions = exceptional_divisor_indices(m)
@@ -199,7 +199,7 @@ function special_flux_family_with_default_algorithm(m::AbstractFTheoryModel; not
   end
   C = transpose(matrix(ZZ, quant_constraint_matrix))
   # TODO: We currently do not remember any intersection numbers computed from this operation. Improve.
-  offset = 1//2 * chern_class(m, 2, check = check)
+  offset = 1//2 * chern_class(m, 2; completeness_check)
   for j in 1:length(list_of_divisor_pairs_to_be_considered)
     class = offset * cds[list_of_divisor_pairs_to_be_considered[j][1]] * cds[list_of_divisor_pairs_to_be_considered[j][2]] * pt_class
     push!(offset_vector, QQ(integrate(class)))
@@ -236,7 +236,7 @@ function special_flux_family_with_default_algorithm(m::AbstractFTheoryModel; not
 end
 
 
-function special_flux_family_with_special_algorithm(m::AbstractFTheoryModel; not_breaking::Bool = false, check::Bool = true)
+function special_flux_family_with_special_algorithm(m::AbstractFTheoryModel; not_breaking::Bool = false, completeness_check::Bool = true)
   
   # (1) Compute data, that is frequently used by the sophisticated intersection product below
   S = coordinate_ring(ambient_space(m))
@@ -264,9 +264,9 @@ function special_flux_family_with_special_algorithm(m::AbstractFTheoryModel; not
 
 
   # (4) Obtain critical information - this may take significant time!
-  ambient_space_flux_candidates_basis = gens_of_h22_hypersurface(m, check = check)
+  ambient_space_flux_candidates_basis = gens_of_h22_hypersurface(m; completeness_check)
   list_of_base_divisor_pairs_to_be_considered = Oscar._ambient_space_base_divisor_pairs_to_be_considered(m)
-  ambient_space_flux_candidates_basis_indices = gens_of_h22_hypersurface_indices(m, check = check)
+  ambient_space_flux_candidates_basis_indices = gens_of_h22_hypersurface_indices(m; completeness_check)
   list_of_divisor_pairs_to_be_considered = Oscar._ambient_space_divisor_pairs_to_be_considered(m)
    # TODO: This line is a bit fragile. Fix it!
   exceptional_divisor_positions = exceptional_divisor_indices(m)
@@ -321,7 +321,7 @@ function special_flux_family_with_special_algorithm(m::AbstractFTheoryModel; not
     push!(quant_constraint_matrix, condition)
   end
   C = transpose(matrix(ZZ, quant_constraint_matrix))
-  c2 = lift(polynomial(chern_class(m, 2, check = check)))
+  c2 = lift(polynomial(chern_class(m, 2; completeness_check)))
   coeffs = collect(coefficients(c2))
   M = collect(exponents(lift(c2)))
   non_zero_exponents = Vector{Tuple{Int64, Int64}}()

--- a/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
@@ -38,7 +38,7 @@ Hypersurface model over a concrete base
 
 julia> g4_class = cohomology_class(anticanonical_divisor_class(ambient_space(qsm_model)), completeness_check = false)^2;
 
-julia> g4f = g4_flux(qsm_model, g4_class, check = false)
+julia> g4f = g4_flux(qsm_model, g4_class, completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
@@ -95,7 +95,7 @@ julia> d3_tadpole_constraint(g4, completeness_check = false)
   end
   # Opt for (potentially?) quicker algorithm when possible
   if has_attribute(gf, :int_combination) && has_attribute(gf, :rat_combination)
-    gfs = g4_flux_family(gf, check = false)
+    gfs = g4_flux_family(gf; completeness_check)
     if has_attribute(gfs, :d3_tadpole_constraint)
       values_to_evaluate_at = vcat(matrix(QQ, get_attribute(gf, :int_combination)), get_attribute(gf, :rat_combination))
       values_to_evaluate_at = values_to_evaluate_at[:, 1]
@@ -259,13 +259,13 @@ Return the integral coefficients of a ``G_4``-flux.
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
 
-julia> gfs = special_flux_family(qsm_model, check = false, algorithm = "special")
+julia> gfs = special_flux_family(qsm_model, completeness_check = false, algorithm = "special")
 Family of G4 fluxes:
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied
   - Non-abelian gauge group: breaking pattern not analyzed
 
-julia> g4 = random_flux_instance(gfs, check = false)
+julia> g4 = random_flux_instance(gfs, completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied
@@ -292,13 +292,13 @@ Return the rational coefficients of a ``G_4``-flux.
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
 Hypersurface model over a concrete base
 
-julia> gfs = special_flux_family(qsm_model, check = false, algorithm = "special")
+julia> gfs = special_flux_family(qsm_model, completeness_check = false, algorithm = "special")
 Family of G4 fluxes:
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied
   - Non-abelian gauge group: breaking pattern not analyzed
 
-julia> g4 = random_flux_instance(gfs, check = false)
+julia> g4 = random_flux_instance(gfs, completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied
@@ -325,13 +325,13 @@ Return the offset of a ``G_4``-flux.
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
 
-julia> gfs = special_flux_family(qsm_model, check = false)
+julia> gfs = special_flux_family(qsm_model, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied
   - Non-abelian gauge group: breaking pattern not analyzed
 
-julia> g4 = random_flux_instance(gfs, check = false)
+julia> g4 = random_flux_instance(gfs, completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied

--- a/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
@@ -118,11 +118,17 @@ end
 #####################################################
 
 @doc raw"""
-    g4_flux_family(gf::G4Flux; check::Bool = true)
+    g4_flux_family(gf::G4Flux)
 
 Return the family of ``G_4``-fluxes sharing the following properties
 with the given ``G_4``-flux: transversality and breaking of the
 non-abelian gauge group.
+
+!!! note "Completeness check"
+  The implemented algorithm is guaranteed to work only for toric ambient spaces
+  that are smooth and **complete**. Verifying completeness can be very time 
+  consuming. To skip this check, pass the optional keyword argument 
+  `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -136,16 +142,16 @@ G4-flux candidate
   - Non-abelian gauge group: unbroken
   - Tadpole cancellation check: not computed
 
-julia> g4_flux_family(g4, check = false)
+julia> g4_flux_family(g4, completeness_check = false)
 Family of G4 fluxes:
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied
   - Non-abelian gauge group: unbroken
 ```
 """
-@attr FamilyOfG4Fluxes function g4_flux_family(gf::G4Flux; check::Bool = true)
+@attr FamilyOfG4Fluxes function g4_flux_family(gf::G4Flux; completeness_check::Bool = true)
   nb = breaks_non_abelian_gauge_group(gf)
-  gfs = special_flux_family(model(gf), not_breaking = !nb, check = check)
+  gfs = special_flux_family(model(gf), not_breaking = !nb, completeness_check = completeness_check)
   return gfs
 end
 

--- a/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
@@ -57,10 +57,16 @@ cohomology_class(gf::G4Flux) = gf.class
 #####################################################
 
 @doc raw"""
-    d3_tadpole_constraint(gf::G4Flux; check::Bool = true)
+    d3_tadpole_constraint(gf::G4Flux)
 
 Return the d3-tapdole of a G4-flux, that is compute and return the quantity
 ``- \frac{1}{2} \cdot \int_{\widehat{Y_4}}{G_4 \wedge G_4} + \frac{1}{24} \cdot \chi(\widehat{Y}_4)``.
+
+!!! note "Completeness check"
+  The implemented algorithm is guaranteed to work only for toric ambient spaces
+  that are simplicial and **complete**. Verifying completeness can be very time 
+  consuming. To skip this check, pass the optional keyword argument 
+  `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -74,34 +80,34 @@ G4-flux candidate
   - Non-abelian gauge group: unbroken
   - Tadpole cancellation check: not computed
 
-julia> d3_tadpole_constraint(g4, check = false)
+julia> d3_tadpole_constraint(g4, completeness_check = false)
 12
 ```
 """
-@attr QQFieldElem function d3_tadpole_constraint(gf::G4Flux; check::Bool = true)
+@attr QQFieldElem function d3_tadpole_constraint(gf::G4Flux; completeness_check::Bool = true)
   m = model(gf)
   @req (m isa WeierstrassModel || m isa GlobalTateModel || m isa HypersurfaceModel) "Tadpole cancellation checks for G4-fluxes only supported for Weierstrass, global Tate and hypersurface models"
   @req base_space(m) isa NormalToricVariety "Tadpole cancellation checks for G4-flux currently supported only for toric base"
   @req ambient_space(m) isa NormalToricVariety "Tadpole cancellation checks for G4-flux currently supported only for toric ambient space"
-  if check
+  @req is_simplicial(ambient_space(m)) "Computation of D3-tadpole constraint only supported for simplicial toric ambient space"
+  if completeness_check
     @req is_complete(ambient_space(m)) "Computation of D3-tadpole constraint only supported for complete toric ambient spaces"
-    @req is_simplicial(ambient_space(m)) "Computation of D3-tadpole constraint only supported for simplicial toric ambient space"
   end
   # Opt for (potentially?) quicker algorithm when possible
   if has_attribute(gf, :int_combination) && has_attribute(gf, :rat_combination)
-    gfs = g4_flux_family(gf, check = check)
+    gfs = g4_flux_family(gf, check = false)
     if has_attribute(gfs, :d3_tadpole_constraint)
       values_to_evaluate_at = vcat(matrix(QQ, get_attribute(gf, :int_combination)), get_attribute(gf, :rat_combination))
       values_to_evaluate_at = values_to_evaluate_at[:, 1]
       return evaluate(d3_tadpole_constraint(gfs), values_to_evaluate_at)
     end
   end
-  tcc = cohomology_class(toric_divisor_class(ambient_space(m), degree(hypersurface_equation(m))), completeness_check = check)
+  tcc = cohomology_class(toric_divisor_class(ambient_space(m), degree(hypersurface_equation(m))); completeness_check)
   cy = polynomial(tcc)
   poly_of_offset_class = polynomial(cohomology_class(gf)) * polynomial(cohomology_class(gf)) * cy
-  class_of_offset = cohomology_class(ambient_space(m), poly_of_offset_class, completeness_check = check)
-  offset = 1//2* QQ(integrate(class_of_offset, completeness_check = check))
-  numb = QQ(euler_characteristic(m; check = check)//24) - offset
+  class_of_offset = cohomology_class(ambient_space(m), poly_of_offset_class; completeness_check)
+  offset = 1//2* QQ(integrate(class_of_offset; completeness_check))
+  numb = QQ(euler_characteristic(m; completeness_check)//24) - offset
   set_attribute!(gf, :passes_tadpole_cancellation_check, (numb >= 0 && is_integer(numb)))
   return numb::QQFieldElem
 end

--- a/experimental/FTheoryTools/src/G4Fluxes/auxiliary.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/auxiliary.jl
@@ -430,7 +430,7 @@ For mathematical background shared across related methods see [Advanced Methods]
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 283))
 Hypersurface model over a concrete base
 
-julia> length(gens_of_h22_hypersurface_indices(qsm_model, check = false))
+julia> length(gens_of_h22_hypersurface_indices(qsm_model, completeness_check = false))
 25
 ```
 """

--- a/experimental/FTheoryTools/src/G4Fluxes/auxiliary.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/auxiliary.jl
@@ -5,36 +5,40 @@
 
 
 @doc raw"""
-    converter_dict_h22_ambient(m::AbstractFTheoryModel; check::Bool = true)
+    converter_dict_h22_ambient(m::AbstractFTheoryModel)
 
 Return a dictionary that expresses arbitrary elements of ``H^{2,2}(X_\Sigma, \mathbb{Q})`` 
 in terms of the basis computed by `basis_of_h22_ambient`.
 
 This is useful for rewriting cohomology classes in a fixed basis of the toric variety ``X_\Sigma``.
 
-Use `check = false` to skip completeness and simplicity verification.
-
 For mathematical background shared across related methods see [Advanced Methods](@ref advanced_g4_methods).
+
+!!! note "Completeness check"
+    The implemented algorithm is guaranteed to work only for toric ambient spaces
+    that are simplicial and **complete**. Verifying completeness can be very time 
+    consuming. To skip this check, pass the optional keyword argument 
+    `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 283))
 Hypersurface model over a concrete base
 
-julia> cdh22 = converter_dict_h22_ambient(qsm_model, check = false);
+julia> cdh22 = converter_dict_h22_ambient(qsm_model, completeness_check = false);
 
 julia> length(collect(keys(cdh22)))
 81
 ```
 """
-@attr Dict{Tuple{Int64, Int64}, Vector{Tuple{QQFieldElem, Tuple{Int64, Int64}}}} function converter_dict_h22_ambient(m::AbstractFTheoryModel; check::Bool = true)
+@attr Dict{Tuple{Int64, Int64}, Vector{Tuple{QQFieldElem, Tuple{Int64, Int64}}}} function converter_dict_h22_ambient(m::AbstractFTheoryModel; completeness_check::Bool = true)
 
   # (1) Entry checks
   @req base_space(m) isa NormalToricVariety "Computation of converter_dict_h22_ambient only supported for toric base and ambient spaces"
   @req dim(ambient_space(m)) == 5 "Computation of converter_dict_h22_ambient only supported for 5-dimensional toric ambient spaces"
-  if check
+  @req is_simplicial(ambient_space(m)) "Computation of converter_dict_h22_ambient only supported for simplicial toric ambient space"
+  if completeness_check
     @req is_complete(ambient_space(m)) "Computation of converter_dict_h22_ambient only supported for complete toric ambient spaces"
-    @req is_simplicial(ambient_space(m)) "Computation of converter_dict_h22_ambient only supported for simplicial toric ambient space"
   end
 
 
@@ -329,7 +333,7 @@ end
 
 
 @doc raw"""
-    basis_of_h22_ambient_indices(m::AbstractFTheoryModel; check::Bool = true)
+    basis_of_h22_ambient_indices(m::AbstractFTheoryModel)
 
 Return the index pairs of toric cohomology classes whose products span the 
 basis of ``H^{2,2}(X_\Sigma, \mathbb{Q})`` computed by `basis_of_h22_ambient`.
@@ -337,51 +341,59 @@ basis of ``H^{2,2}(X_\Sigma, \mathbb{Q})`` computed by `basis_of_h22_ambient`.
 Each entry is a tuple `(a, b)`, indicating that the product of the `a`-th and 
 `b`-th variables in the Cox ring contributes to the chosen basis.
 
-Use `check = false` to skip completeness and simplicity verification.
-
 For mathematical background shared across related methods see [Advanced Methods](@ref advanced_g4_methods).
+
+!!! note "Completeness check"
+    The implemented algorithm is guaranteed to work only for toric ambient spaces
+    that are simplicial and **complete**. Verifying completeness can be very time 
+    consuming. To skip this check, pass the optional keyword argument 
+    `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 283))
 Hypersurface model over a concrete base
 
-julia> bhi = basis_of_h22_ambient_indices(qsm_model, check = false);
+julia> bhi = basis_of_h22_ambient_indices(qsm_model, completeness_check = false);
 
 julia> length(bhi) == betti_number(ambient_space(qsm_model), 4)
 true
 ```
 """
-@attr Vector{Tuple{Int64, Int64}} function basis_of_h22_ambient_indices(m::AbstractFTheoryModel; check::Bool = true)
-  cdh22 = converter_dict_h22_ambient(m, check = check)
+@attr Vector{Tuple{Int64, Int64}} function basis_of_h22_ambient_indices(m::AbstractFTheoryModel; completeness_check::Bool = true)
+  cdh22 = converter_dict_h22_ambient(m; completeness_check)
   return unique(vcat([[u[2] for u in k] for k in filter(x -> x != 0, collect(values(cdh22)))]...))
 end
 
 
 @doc raw"""
-    basis_of_h22_ambient(m::AbstractFTheoryModel; check::Bool = true)
+    basis_of_h22_ambient(m::AbstractFTheoryModel)
 
 Compute a monomial basis for ``H^{2,2}(X_\Sigma, \mathbb{Q})`` for a complete
 and simplicial toric variety ``X_\Sigma`` by multiplying pairs of cohomology classes
 associated with the rays of ``X_\Sigma``.
 
-Use `check = false` to skip completeness and simplicity verification.
-
 For mathematical background shared across related methods see [Advanced Methods](@ref advanced_g4_methods).
+
+!!! note "Completeness check"
+    The implemented algorithm is guaranteed to work only for toric ambient spaces
+    that are simplicial and **complete**. Verifying completeness can be very time 
+    consuming. To skip this check, pass the optional keyword argument 
+    `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 283))
 Hypersurface model over a concrete base
 
-julia> length(basis_of_h22_ambient(qsm_model, check = false)) == betti_number(ambient_space(qsm_model), 4)
+julia> length(basis_of_h22_ambient(qsm_model, completeness_check = false)) == betti_number(ambient_space(qsm_model), 4)
 true
 ```
 """
-@attr Vector{CohomologyClass} function basis_of_h22_ambient(m::AbstractFTheoryModel; check::Bool = true)
-  basis_indices = basis_of_h22_ambient_indices(m, check = false)
+@attr Vector{CohomologyClass} function basis_of_h22_ambient(m::AbstractFTheoryModel; completeness_check::Bool = true)
+  basis_indices = basis_of_h22_ambient_indices(m; completeness_check)
   v = ambient_space(m)
-  S = cohomology_ring(v, completeness_check = check)
+  S = cohomology_ring(v; completeness_check)
   c_ds = [lift(k) for k in gens(S)]
   return [cohomology_class(v, MPolyQuoRingElem(c_ds[mt[1]]*c_ds[mt[2]], S)) for mt in basis_indices]
 end
@@ -394,7 +406,7 @@ end
 ###########################################################################################################################
 
 @doc raw"""
-    gens_of_h22_hypersurface_indices(m::AbstractFTheoryModel; check::Bool = true)
+    gens_of_h22_hypersurface_indices(m::AbstractFTheoryModel)
 
 Return a vector of index pairs ``(a, b)``, indicating that the product of the ``a``-th 
 and ``b``-th toric variables defines a cohomology class on the ambient toric variety 
@@ -405,9 +417,13 @@ and ``b``-th toric variables defines a cohomology class on the ambient toric var
 This symbolic representation can be used to reconstruct cohomology class generators 
 via Cox ring monomials. For the actual cohomology class generators, see `gens_of_h22_hypersurface`.
 
-Use `check = false` to skip completeness and simplicity verification.
-
 For mathematical background shared across related methods see [Advanced Methods](@ref advanced_g4_methods).
+
+!!! note "Completeness check"
+    The implemented algorithm is guaranteed to work only for toric ambient spaces
+    that are simplicial and **complete**. Verifying completeness can be very time 
+    consuming. To skip this check, pass the optional keyword argument 
+    `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
@@ -418,9 +434,9 @@ julia> length(gens_of_h22_hypersurface_indices(qsm_model, check = false))
 25
 ```
 """
-@attr Vector{Tuple{Int64, Int64}} function gens_of_h22_hypersurface_indices(m::AbstractFTheoryModel; check::Bool = true)
+@attr Vector{Tuple{Int64, Int64}} function gens_of_h22_hypersurface_indices(m::AbstractFTheoryModel; completeness_check::Bool = true)
 
-  filtered_h22_basis_indices = deepcopy(basis_of_h22_ambient_indices(m, check = check))
+  filtered_h22_basis_indices = deepcopy(basis_of_h22_ambient_indices(m; completeness_check))
   gS = gens(coordinate_ring(ambient_space(m)))
   mnf = Oscar._minimal_nonfaces(ambient_space(m))
   sr_ideal_pos = [Vector{Int}(Polymake.row(mnf, i)) for i in 1:Polymake.nrows(mnf)]
@@ -467,7 +483,7 @@ julia> length(gens_of_h22_hypersurface_indices(qsm_model, check = false))
 end
 
 @doc raw"""
-    gens_of_h22_hypersurface(m::AbstractFTheoryModel; check::Bool = true)
+    gens_of_h22_hypersurface(m::AbstractFTheoryModel)
 
 Compute a set of cohomology classes in the toric ambient space ``X_\Sigma`` that restrict
 to generators of the subspace ``S \subseteq H^{2,2}(\widehat{Y}_4, \mathbb{Q})``, where ``\widehat{Y}_4`` 
@@ -477,30 +493,34 @@ and ``S`` the restriction of ``H^{2,2}(X_\Sigma, \mathbb{Q})`` to ``\widehat{Y}_
 These classes are obtained by restricting the ambient ``H^{2,2}(X_\Sigma, \mathbb{Q})`` 
 basis (constructed from toric coordinate products) to the hypersurface ``\widehat{Y}_4``.
 
-Use `check = false` to skip completeness and simplicity verification.
-
 For mathematical background shared across related methods see [Advanced Methods](@ref advanced_g4_methods).
+
+!!! note "Completeness check"
+    The implemented algorithm is guaranteed to work only for toric ambient spaces
+    that are simplicial and **complete**. Verifying completeness can be very time 
+    consuming. To skip this check, pass the optional keyword argument 
+    `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 283))
 Hypersurface model over a concrete base
 
-julia> length(gens_of_h22_hypersurface(qsm_model, check = false))
+julia> length(gens_of_h22_hypersurface(qsm_model, completeness_check = false))
 25
 ```
 """
-@attr Vector{CohomologyClass} function gens_of_h22_hypersurface(m::AbstractFTheoryModel; check::Bool = true)
-  basis_indices = gens_of_h22_hypersurface_indices(m, check = false)
+@attr Vector{CohomologyClass} function gens_of_h22_hypersurface(m::AbstractFTheoryModel; completeness_check::Bool = true)
+  basis_indices = gens_of_h22_hypersurface_indices(m; completeness_check)
   v = ambient_space(m)
-  S = cohomology_ring(v, completeness_check = check)
+  S = cohomology_ring(v; completeness_check)
   c_ds = [lift(k) for k in gens(S)]
   return [cohomology_class(v, MPolyQuoRingElem(c_ds[mt[1]]*c_ds[mt[2]], S)) for mt in basis_indices]
 end
 
 
 @doc raw"""
-    converter_dict_h22_hypersurface(m::AbstractFTheoryModel; check::Bool = true)
+    converter_dict_h22_hypersurface(m::AbstractFTheoryModel)
 
 Return a dictionary mapping cohomology classes in ``H^{2,2}(X_\Sigma, \mathbb{Q})``
 to linear combinations of generators of ``S \subseteq H^{2,2}(\widehat{Y}_4, \mathbb{Q})``,
@@ -512,26 +532,30 @@ and this converter enables expressing any ambient class in terms of these restri
 
 For the analogous map in the ambient toric variety, see `converter_dict_h22_ambient`.
 
-Use `check = false` to skip completeness and simplicity verification.
-
 For mathematical background shared across related methods see [Advanced Methods](@ref advanced_g4_methods).
+
+!!! note "Completeness check"
+    The implemented algorithm is guaranteed to work only for toric ambient spaces
+    that are simplicial and **complete**. Verifying completeness can be very time 
+    consuming. To skip this check, pass the optional keyword argument 
+    `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir)))
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 283))
 Hypersurface model over a concrete base
 
-julia> cdh22 = converter_dict_h22_hypersurface(qsm_model, check = false);
+julia> cdh22 = converter_dict_h22_hypersurface(qsm_model, completeness_check = false);
 
 julia> length(collect(keys(cdh22)))
 81
 ```
 """
-@attr Dict{Tuple{Int64, Int64}, Vector{Tuple{QQFieldElem, Tuple{Int64, Int64}}}} function converter_dict_h22_hypersurface(m::AbstractFTheoryModel; check::Bool = true)
-  non_trivial_indices = gens_of_h22_hypersurface_indices(m, check = check)
-  old_indices = basis_of_h22_ambient_indices(m, check = check)
+@attr Dict{Tuple{Int64, Int64}, Vector{Tuple{QQFieldElem, Tuple{Int64, Int64}}}} function converter_dict_h22_hypersurface(m::AbstractFTheoryModel; completeness_check::Bool = true)
+  non_trivial_indices = gens_of_h22_hypersurface_indices(m; completeness_check)
+  old_indices = basis_of_h22_ambient_indices(m; completeness_check)
   to_be_deleted = setdiff(old_indices, non_trivial_indices)
-  new_converter = deepcopy(converter_dict_h22_ambient(m, check = check))
+  new_converter = deepcopy(converter_dict_h22_ambient(m; completeness_check))
   for k in 1:length(to_be_deleted)
     for (key, value) in new_converter
       tuple_list = [a[2] for a in value]
@@ -549,7 +573,7 @@ end
 
 
 @doc raw"""
-    chosen_g4_flux_gens(m::AbstractFTheoryModel; check::Bool = true)::Vector{CohomologyClass}
+    chosen_g4_flux_gens(m::AbstractFTheoryModel)
 
 Given an F-theory model `m` defined as a hypersurface in a simplicial and
 complete toric space ``X_\Sigma``, this method computes a basis of
@@ -559,7 +583,11 @@ elements whose restriction to the hypersurface in question is non-trivial. The
 list of these basis elements—cast into ``G_4``-flux ambient space candidates—is then
 returned by this method.
 
-Use `check = false` to skip completeness and simplicity verification.
+!!! note "Completeness check"
+    The implemented algorithm is guaranteed to work only for toric ambient spaces
+    that are simplicial and **complete**. Verifying completeness can be very time 
+    consuming. To skip this check, pass the optional keyword argument 
+    `completeness_check=false`.
 
 # Examples
 ```jldoctest; setup = :(Oscar.LazyArtifacts.ensure_artifact_installed("QSMDB", Oscar.LazyArtifacts.find_artifacts_toml(Oscar.oscardir))), filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
@@ -593,7 +621,7 @@ Cohomology class on a normal toric variety given by z^2
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 8))
 Hypersurface model over a concrete base
 
-julia> g4_basis = chosen_g4_flux_gens(qsm_model, check = false);
+julia> g4_basis = chosen_g4_flux_gens(qsm_model, completeness_check = false);
 
 julia> cohomology_class(g4_basis[1])
 Cohomology class on a normal toric variety given by x15*e2
@@ -602,8 +630,8 @@ julia> length(g4_basis) == 172
 true
 ```
 """
-@attr Vector{G4Flux} function chosen_g4_flux_gens(m::AbstractFTheoryModel; check::Bool = true)
-  gens = [G4Flux(m, c) for c in gens_of_h22_hypersurface(m, check = check)]
+@attr Vector{G4Flux} function chosen_g4_flux_gens(m::AbstractFTheoryModel; completeness_check::Bool = true)
+  gens = [G4Flux(m, c) for c in gens_of_h22_hypersurface(m; completeness_check)]
   for k in 1:length(gens)
     set_attribute!(gens[k], :offset, zeros(Int, length(gens)))
     flux_coords = zeros(Int, length(gens))

--- a/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
@@ -26,7 +26,7 @@ Hypersurface model over a concrete base
 
 julia> g4_class = cohomology_class(anticanonical_divisor_class(ambient_space(qsm_model)), completeness_check = false)^2;
 
-julia> g4f = g4_flux(qsm_model, g4_class, check = false)
+julia> g4f = g4_flux(qsm_model, g4_class, completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: not executed
   - Transversality checks: not executed

--- a/experimental/FTheoryTools/src/G4Fluxes/properties.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/properties.jl
@@ -185,7 +185,7 @@ G4-flux candidate
   @req (m isa WeierstrassModel || m isa GlobalTateModel || m isa HypersurfaceModel) "Tadpole cancellation checks for G4-fluxes only supported for Weierstrass, global Tate and hypersurface models"
   @req base_space(m) isa NormalToricVariety "Tadpole cancellation checks for G4-flux currently supported only for toric base"
   @req ambient_space(m) isa NormalToricVariety "Tadpole cancellation checks for G4-flux currently supported only for toric ambient space"
-  numb = d3_tadpole_constraint(g4, check = false)
+  numb = d3_tadpole_constraint(g4, completeness_check = false)
   return numb >= 0 && is_integer(numb)
 end
 

--- a/experimental/FTheoryTools/src/G4Fluxes/properties.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/properties.jl
@@ -29,7 +29,7 @@ Hypersurface model over a concrete base
 
 julia> g4_class = cohomology_class(anticanonical_divisor_class(ambient_space(qsm_model)), completeness_check = false)^2;
 
-julia> g4 = g4_flux(qsm_model, g4_class, check = false)
+julia> g4 = g4_flux(qsm_model, g4_class, completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
@@ -60,7 +60,7 @@ G4-flux candidate
   c_ds = [polynomial(cohomology_class(d)) for d in torusinvariant_prime_divisors(ambient_space(m))]
 
   # explicitly switched off an expensive test in the following line
-  twist_g4 = polynomial(cohomology_class(g4) + 1//2 * chern_class(m, 2; check = false))
+  twist_g4 = polynomial(cohomology_class(g4) + 1//2 * chern_class(m, 2; completeness_check = false))
 
   # now execute elementary checks of the quantization condition
   for i in 1:length(c_ds)
@@ -92,7 +92,7 @@ julia> u = cohomology_class(divs[33]);v = cohomology_class(divs[30]);pb_Kbar = c
 
 julia> g4_class = (-3) // kbar3(qsm_model) * (5 * e1 * e4 + pb_Kbar * (-3 * e1 - 2 * e2 - 6 * e4 + pb_Kbar - 4 * u + v));
 
-julia> g4 = g4_flux(qsm_model, g4_class, check = false)
+julia> g4 = g4_flux(qsm_model, g4_class, completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
@@ -162,7 +162,7 @@ julia> u = cohomology_class(divs[33]);v = cohomology_class(divs[30]);pb_Kbar = c
 
 julia> g4_class = (-3) // kbar3(qsm_model) * (5 * e1 * e4 + pb_Kbar * (-3 * e1 - 2 * e2 - 6 * e4 + pb_Kbar - 4 * u + v));
 
-julia> g4 = g4_flux(qsm_model, g4_class, check = false)
+julia> g4 = g4_flux(qsm_model, g4_class, completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: not executed
   - Transversality checks: not executed
@@ -209,7 +209,7 @@ julia> u = cohomology_class(divs[33]);v = cohomology_class(divs[30]);pb_Kbar = c
 
 julia> g4_class = (-3) // kbar3(qsm_model) * (5 * e1 * e4 + pb_Kbar * (-3 * e1 - 2 * e2 - 6 * e4 + pb_Kbar - 4 * u + v));
 
-julia> g4 = g4_flux(qsm_model, g4_class, check = false)
+julia> g4 = g4_flux(qsm_model, g4_class, completeness_check = false, consistency_check = false)
 G4-flux candidate
   - Elementary quantization checks: not executed
   - Transversality checks: not executed

--- a/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
@@ -3,7 +3,7 @@
 ################################################
 
 @doc raw"""
-    hypersurface_model(base::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}, p::MPolyRingElem; completeness_check::Bool = true)
+    hypersurface_model(base::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}, p::MPolyRingElem)
 
 Construct a hypersurface model where fiber coordinates transform as sections of line bundles over the base.
 
@@ -13,6 +13,11 @@ Construct a hypersurface model where fiber coordinates transform as sections of 
 The hypersurface equation `p` defines a section of the anti-canonical bundle of the total ambient space and may also be passed as a string for convenience.
 
 For a full explanation of hypersurface models, see [Hypersurface Models](@ref hypersurface_models).
+
+!!! note "Complete toric base"
+    This function assumes that the toric base space is **complete**.
+    Checking completeness may take a long time. To skip this check,
+    pass the **optional keyword argument** `completeness_check=false`.
 
 # Examples
 ```jldoctest
@@ -31,23 +36,23 @@ Hypersurface model over a concrete base
 ```
 """
 function hypersurface_model(bs::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}, p::MPolyRingElem; completeness_check::Bool = true)  
-  return hypersurface_model(bs, fiber_ambient_space, fiber_twist_divisor_classes, string(p); completeness_check = completeness_check)
+  return hypersurface_model(bs, fiber_ambient_space, fiber_twist_divisor_classes, string(p); completeness_check)
 end
 
 function hypersurface_model(bs::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}, p::String; completeness_check::Bool = true)
   @req all(toric_variety(c) == bs for c in fiber_twist_divisor_classes) "All fiber divisor classes must belong to be base space"
   if length(fiber_twist_divisor_classes) == n_rays(fiber_ambient_space)
-    return _build_hypersurface_model(bs, fiber_ambient_space, fiber_twist_divisor_classes, p; completeness_check = completeness_check)
+    return _build_hypersurface_model(bs, fiber_ambient_space, fiber_twist_divisor_classes, p; completeness_check)
   end
   @req length(fiber_twist_divisor_classes) == 2 "Exactly two fiber twist divisor classes must be provided"
   @req n_rays(fiber_ambient_space) >= 2 "The fiber ambient space must have at least 2 rays"
   new_fiber_twist_divisor_classes = vcat(fiber_twist_divisor_classes, [trivial_divisor_class(bs) for k in 1:(n_rays(fiber_ambient_space) - length(fiber_twist_divisor_classes))])
-  return _build_hypersurface_model(bs, fiber_ambient_space, new_fiber_twist_divisor_classes, p; completeness_check = completeness_check)
+  return _build_hypersurface_model(bs, fiber_ambient_space, new_fiber_twist_divisor_classes, p; completeness_check)
 end
 
 
 @doc raw"""
-    hypersurface_model(base::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}, indices::Vector{Int}, p::MPolyRingElem; completeness_check::Bool = true)
+    hypersurface_model(base::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}, indices::Vector{Int}, p::MPolyRingElem)
 
 Construct a hypersurface model where the two fiber coordinates at the given
 `indices` transform as sections of the line bundles associated to the specified
@@ -56,6 +61,11 @@ base divisor classes.
 The polynomial `p`, which encodes the hypersurface equation, can also be passed as a string.
 
 For a full explanation of hypersurface models, see [Hypersurface Models](@ref hypersurface_models).
+
+!!! note "Complete toric base"
+    This function assumes that the toric base space is **complete**.
+    Checking completeness may take a long time. To skip this check,
+    pass the **optional keyword argument** `completeness_check=false`.
 
 # Examples
 ```jldoctest
@@ -74,7 +84,7 @@ Hypersurface model over a concrete base
 ```
 """
 function hypersurface_model(bs::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}, indices::Vector{Int}, p::MPolyRingElem; completeness_check::Bool = true)
-  return hypersurface_model(bs, fiber_ambient_space, fiber_twist_divisor_classes, indices, string(p); completeness_check = completeness_check)
+  return hypersurface_model(bs, fiber_ambient_space, fiber_twist_divisor_classes, indices, string(p); completeness_check)
 end
 
 function hypersurface_model(bs::NormalToricVariety, fiber_ambient_space::NormalToricVariety, fiber_twist_divisor_classes::Vector{ToricDivisorClass}, indices::Vector{Int}, p::String; completeness_check::Bool = true)

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -629,7 +629,8 @@ function _set_all_attributes(model::AbstractFTheoryModel, model_dict::Dict{Strin
       @req desired_value in cox_gens "Specified zero section is invalid"
       index = findfirst(==(desired_value), cox_gens)
       set_attribute!(model, :zero_section_index => index::Int)
-      set_attribute!(model, :zero_section_class => cohomology_class(divs[index]))
+      # For performance, do not execute completeness_check when creating zero section
+      set_attribute!(model, :zero_section_class => cohomology_class(divs[index], completeness_check = false))
     end
 
     if haskey(model_dict["model_data"], "exceptional_classes") && base_space(model) isa NormalToricVariety

--- a/experimental/FTheoryTools/src/TateModels/constructors.jl
+++ b/experimental/FTheoryTools/src/TateModels/constructors.jl
@@ -3,10 +3,15 @@
 ################################################
 
 @doc raw"""
-    global_tate_model(base::NormalToricVariety; completeness_check::Bool = true)
+    global_tate_model(base::NormalToricVariety)
 
 This method constructs a global Tate model over a given toric base
 3-fold. The Tate sections ``a_i`` are taken with (pseudo) random coefficients.
+
+!!! note "Complete toric base"
+    This function assumes that the toric base space is **complete**.
+    Checking completeness may take a long time. To skip this check,
+    pass the **optional keyword argument** `completeness_check=false`.
 
 # Examples
 ```jldoctest
@@ -14,14 +19,19 @@ julia> t = global_tate_model(projective_space(NormalToricVariety, 2); completene
 Global Tate model over a concrete base
 ```
 """
-global_tate_model(base::NormalToricVariety; completeness_check::Bool = true) = global_tate_model(base, _tate_sections(base); completeness_check = completeness_check)
+global_tate_model(base::NormalToricVariety; completeness_check::Bool = true) = global_tate_model(base, _tate_sections(base); completeness_check)
 
 
 @doc raw"""
-    global_tate_model(base::NormalToricVariety, ais::Vector{T}; completeness_check::Bool = true) where {T<:MPolyRingElem}
+    global_tate_model(base::NormalToricVariety, ais::Vector{T}) where {T<:MPolyRingElem}
 
 This method operates analogously to `global_tate_model(base::NormalToricVarietyType)`.
 The only difference is that the Tate sections ``a_i`` can be specified with non-generic values.
+
+!!! note "Complete toric base"
+    This function assumes that the toric base space is **complete**.
+    Checking completeness may take a long time. To skip this check,
+    pass the **optional keyword argument** `completeness_check=false`.
 
 # Examples
 ```jldoctest
@@ -44,7 +54,7 @@ Global Tate model over a concrete base
 """
 function global_tate_model(base::NormalToricVariety, ais::Vector{T}; completeness_check::Bool = true) where {T<:MPolyRingElem}
   @req length(ais) == 5 "All the Tate sections a1, a2, a3, a4, a6 must be provided"
-  return global_tate_model(base, Dict("a1" => ais[1], "a2" => ais[2], "a3" => ais[3], "a4" => ais[4], "a6" => ais[5]), Dict{String, MPolyRingElem}(); completeness_check = completeness_check)
+  return global_tate_model(base, Dict("a1" => ais[1], "a2" => ais[2], "a3" => ais[3], "a4" => ais[4], "a6" => ais[5]), Dict{String, MPolyRingElem}(); completeness_check)
 end
 
 function global_tate_model(base::NormalToricVariety,

--- a/experimental/FTheoryTools/src/TunedModels/constructors.jl
+++ b/experimental/FTheoryTools/src/TunedModels/constructors.jl
@@ -1,5 +1,5 @@
 @doc raw"""
-    tune(w::WeierstrassModel, input_sections::Dict{String, <:Any}; completeness_check::Bool = true)
+    tune(w::WeierstrassModel, input_sections::Dict{String, <:Any})
 
 Takes a Weierstrass model `w` and returns a new model in which the tunable
 sections have been fixed to specific values provided by the user.
@@ -12,6 +12,11 @@ Importantly, even if a section is tuned to zero, it is **not removed** from the
 model’s metadata (such as `explicit_model_sections` or `classes_of_model_sections`).
 This ensures the ability to later reintroduce non-trivial values for those sections,
 preserving model flexibility and reversibility.
+
+!!! note "Complete toric base"
+    This function assumes that the toric base space is **complete**.
+    Checking completeness may take a long time. To skip this check,
+    pass the **optional keyword argument** `completeness_check=false`.
 
 # Examples
 ```jldoctest
@@ -164,7 +169,7 @@ end
 
 
 @doc raw"""
-    tune(t::GlobalTateModel, input_sections::Dict{String, <:Any}; completeness_check::Bool = true)
+    tune(t::GlobalTateModel, input_sections::Dict{String, <:Any})
 
 Tunes a global Tate model by specifying values for some of its defining sections.
 
@@ -173,6 +178,11 @@ to engineer enhanced singularities. Note that trivial (zero) sections are retain
 rather than deleted from attributes like `explicit_model_sections` or `classes_of_model_sections`.
 This design choice enables users to later reintroduce nontrivial values for such sections
 without loss of structure.
+
+!!! note "Complete toric base"
+    This function assumes that the toric base space is **complete**.
+    Checking completeness may take a long time. To skip this check,
+    pass the **optional keyword argument** `completeness_check=false`.
 
 # Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
@@ -329,7 +339,7 @@ end
 
 
 @doc raw"""
-    tune(h::HypersurfaceModel, input_sections::Dict{String, <:Any}; completeness_check::Bool = true)
+    tune(h::HypersurfaceModel, input_sections::Dict{String, <:Any})
 
 Tune a hypersurface model by fixing a special choice for the model sections.
 Note that it is in particular possible to set a section to zero. We anticipate
@@ -337,6 +347,11 @@ that people might want to be able to come back from this by assigning a non-triv
 value to a section that was previously tuned to zero. This is why we keep such
 trivial sections and do not delete them, say from `explicit_model_sections`
 or `classes_of_model_sections`.
+
+!!! note "Complete toric base"
+    This function assumes that the toric base space is **complete**.
+    Checking completeness may take a long time. To skip this check,
+    pass the **optional keyword argument** `completeness_check=false`.
 
 # Examples
 ```jldoctest; filter = Main.Oscar.doctestfilter_hash_changes_in_1_13()
@@ -405,6 +420,9 @@ function tune(h::HypersurfaceModel, input_sections::Dict{String, <:Any}; complet
   secs_names = tunable_sections(h)
   tuned_secs_names = collect(keys(input_sections))
   @req all(in(secs_names), tuned_secs_names) "Provided section names are not among the tunable sections of the model"
+  if completeness_check
+    @req is_complete(base_space(h)) "Base space must be complete"
+  end
 
   # 1. Tune model sections
   explicit_secs = deepcopy(explicit_model_sections(h))

--- a/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
@@ -8,6 +8,11 @@
 Construct a Weierstrass model over a given toric base space. The Weierstrass sections
 ``f`` and ``g`` are automatically generated with (pseudo)random coefficients.
 
+!!! note "Complete toric base"
+    This function assumes that the toric base space is **complete**.
+    Checking completeness may take a long time. To skip this check,
+    pass the **optional keyword argument** `completeness_check=false`.
+
 # Examples
 ```jldoctest
 julia> w = weierstrass_model(projective_space(NormalToricVariety, 2); completeness_check = false)
@@ -16,7 +21,7 @@ Weierstrass model over a concrete base
 """
 function weierstrass_model(base::NormalToricVariety; completeness_check::Bool = true)
   (f, g) = _weierstrass_sections(base)
-  return weierstrass_model(base, f, g; completeness_check = completeness_check)
+  return weierstrass_model(base, f, g; completeness_check)
 end
 
 
@@ -25,6 +30,11 @@ end
 
 Construct a Weierstrass model over a given toric base space ``X``. The Weierstrass sections
 ``f`` and ``g`` are explicitly specified by the user as polynomials in the Cox ring of ``X``.
+
+!!! note "Complete toric base"
+    This function assumes that the toric base space is **complete**.
+    Checking completeness may take a long time. To skip this check,
+    pass the **optional keyword argument** `completeness_check=false`.
 
 # Examples
 ```jldoctest
@@ -40,7 +50,7 @@ Weierstrass model over a concrete base
 ```
 """
 function weierstrass_model(base::NormalToricVariety, f::MPolyRingElem, g::MPolyRingElem; completeness_check::Bool = true)
-  return weierstrass_model(base, Dict("f" => f, "g" => g), Dict{String, MPolyRingElem}(); completeness_check = completeness_check)
+  return weierstrass_model(base, Dict("f" => f, "g" => g), Dict{String, MPolyRingElem}(); completeness_check)
 end
 
 function weierstrass_model(base::NormalToricVariety,

--- a/experimental/FTheoryTools/src/exports.jl
+++ b/experimental/FTheoryTools/src/exports.jl
@@ -176,7 +176,3 @@ export weights
 export zero_section
 export zero_section_class
 export zero_section_index
-
-@deprecate chosen_g4_flux_basis(m::AbstractFTheoryModel; check::Bool = true) chosen_g4_flux_gens(m, check = check)
-@deprecate basis_of_h22_hypersurface(m::AbstractFTheoryModel; check::Bool = true) gens_of_h22_hypersurface(m, check = check)
-@deprecate basis_of_h22_hypersurface_indices(m::AbstractFTheoryModel; check::Bool = true) gens_of_h22_hypersurface_indices(m, check = check)

--- a/experimental/FTheoryTools/src/exports.jl
+++ b/experimental/FTheoryTools/src/exports.jl
@@ -35,8 +35,6 @@ export associated_literature_models
 export base_space
 export basis_of_h22_ambient
 export basis_of_h22_ambient_indices
-export basis_of_h22_hypersurface
-export basis_of_h22_hypersurface_indices
 export gens_of_h22_hypersurface
 export gens_of_h22_hypersurface_indices
 export birational_literature_models
@@ -45,7 +43,6 @@ export breaks_non_abelian_gauge_group
 export calabi_yau_hypersurface
 export chern_class
 export chern_classes
-export chosen_g4_flux_basis
 export chosen_g4_flux_gens
 export classes_of_model_sections
 export classes_of_tunable_sections_in_basis_of_Kbar_and_defining_classes

--- a/experimental/FTheoryTools/test/FTM-1511-03209.jl
+++ b/experimental/FTheoryTools/test/FTM-1511-03209.jl
@@ -5,10 +5,10 @@
 @testset "Test Downloading Artifact and elementary properties" begin
   t = literature_model(arxiv_id = "1511.03209")
   fully_resolved_big_model = resolve(t, 1)
-  f1 = special_flux_family(fully_resolved_big_model, check = false)
-  g1 = random_flux_instance(f1, check = false)
-  f2 = special_flux_family(fully_resolved_big_model, not_breaking = true, check = false)
-  g2 = random_flux_instance(f2, check = false)
+  f1 = special_flux_family(fully_resolved_big_model, completeness_check = false)
+  g1 = random_flux_instance(f1, completeness_check = false, consistency_check = false)
+  f2 = special_flux_family(fully_resolved_big_model, not_breaking = true, completeness_check = false)
+  g2 = random_flux_instance(f2, completeness_check = false, consistency_check = false)
   @test n_rays(ambient_space(t)) == 104
   @test n_rays(ambient_space(fully_resolved_big_model)) == 313
   @test typeof(get_attribute(fully_resolved_big_model, :inter_dict)) == Dict{NTuple{4, Int64}, ZZRingElem}

--- a/experimental/FTheoryTools/test/QSMs.jl
+++ b/experimental/FTheoryTools/test/QSMs.jl
@@ -20,7 +20,7 @@ cy = cohomology_class(toric_divisor_class(as, degree(hypersurface_equation(qsm_m
 c2_B = cohomology_class(as, 4*x4*x6 + 8*x5*x6 + 14*x6*x7 + 5*x7^2)
 Kbar = cohomology_class(ambient_space(qsm_model), x1+x2+x3+x4+x5+x6+x7)
 Kbar3 = kbar3(qsm_model)
-fg_not_breaking = special_flux_family(qsm_model, not_breaking = true, check = false)
+fg_not_breaking = special_flux_family(qsm_model, not_breaking = true, completeness_check = false)
 g4_exp = flux_instance(fg_not_breaking, [3], [])
 
 @testset "Test properties of the QSM" begin
@@ -32,7 +32,7 @@ end
 
 @testset "Advanced intersection theory and QSM-fluxes" begin
   qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 4))
-  h22_converter_dict = converter_dict_h22_ambient(qsm_model, check = false)
+  h22_converter_dict = converter_dict_h22_ambient(qsm_model, completeness_check = false)
   coh_ring = cohomology_ring(ambient_space(qsm_model), completeness_check = false)
   coh_ring_gens = gens(coh_ring)
   for (key, value) in h22_converter_dict
@@ -41,7 +41,7 @@ end
     @test obj1 == obj2
   end
   qsm_g4_flux = qsm_flux(qsm_model)
-  h22_basis = gens_of_h22_hypersurface_indices(qsm_model, check = false)
+  h22_basis = gens_of_h22_hypersurface_indices(qsm_model, completeness_check = false)
   flux_poly_str = string(polynomial(cohomology_class(qsm_g4_flux)))
   ring = base_ring(parent(polynomial(cohomology_class(qsm_g4_flux))))
   flux_poly = Oscar.eval_poly(flux_poly_str, ring)
@@ -54,7 +54,7 @@ end
     flux_vector[idx] = coeffs[i]
   end
   flux_vector = transpose(matrix(QQ, [flux_vector]))
-  fg = special_flux_family(qsm_model; not_breaking = true, check = false, algorithm = "special")
+  fg = special_flux_family(qsm_model; not_breaking = true, completeness_check = false, algorithm = "special")
   @test ncols(matrix_integral(fg)) == 1
   @test nrows(matrix_integral(fg)) == nrows(matrix_rational(fg))
   @test unique(offset(fg)) == [0]

--- a/experimental/FTheoryTools/test/long_QSMs.jl
+++ b/experimental/FTheoryTools/test/long_QSMs.jl
@@ -5,7 +5,7 @@
 @testset "Advanced intersection theory and QSM-fluxes" begin
   for k in 1:5000
     qsm_model = try literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => k)) catch e continue end
-    h22_converter_dict = converter_dict_h22_ambient(qsm_model, check = false)
+    h22_converter_dict = converter_dict_h22_ambient(qsm_model, completeness_check = false)
     coh_ring = cohomology_ring(ambient_space(qsm_model), completeness_check = false)
     coh_ring_gens = gens(coh_ring)
     for (key, value) in h22_converter_dict
@@ -14,7 +14,7 @@
       @test obj1 == obj2
     end
     qsm_g4_flux = qsm_flux(qsm_model)
-    h22_basis = gens_of_h22_hypersurface_indices(qsm_model, check = false)
+    h22_basis = gens_of_h22_hypersurface_indices(qsm_model, completeness_check = false)
     flux_poly_str = string(polynomial(cohomology_class(qsm_g4_flux)))
     ring = base_ring(parent(polynomial(cohomology_class(qsm_g4_flux))))
     flux_poly = Oscar.eval_poly(flux_poly_str, ring)
@@ -27,7 +27,7 @@
       flux_vector[idx] = coeffs[i]
     end
     flux_vector = transpose(matrix(QQ, [flux_vector]))
-    fg = special_flux_family(qsm_model; not_breaking = true, check = false, algorithm = "special")
+    fg = special_flux_family(qsm_model; not_breaking = true, completeness_check = false, algorithm = "special")
     @test ncols(matrix_integral(fg)) == 1
     @test nrows(matrix_integral(fg)) == nrows(matrix_rational(fg))
     @test unique(offset(fg)) == [0]

--- a/experimental/FTheoryTools/test/paper_tests.jl
+++ b/experimental/FTheoryTools/test/paper_tests.jl
@@ -233,7 +233,7 @@ g4_gens = chosen_g4_flux_gens(qsm_model)
   @test parent(polynomial(cohomology_class(g4_gens[1]))) == cohomology_ring(ambient_space(qsm_model))
 end
 
-fg = special_flux_family(qsm_model, check = false)
+fg = special_flux_family(qsm_model, completeness_check = false)
 mat_int = matrix_integral(fg)
 mat_rat = matrix_rational(fg)
 
@@ -243,8 +243,8 @@ mat_rat = matrix_rational(fg)
 end
 
 g4 = random_flux_instance(fg)
-g4_2 = random_flux(qsm_model, check = false)
-fg_not_breaking = special_flux_family(qsm_model, not_breaking = true, check = false)
+g4_2 = random_flux(qsm_model, completeness_check = false, consistency_check = false)
+fg_not_breaking = special_flux_family(qsm_model, not_breaking = true, completeness_check = false)
 
 @testset "FTheoryToolsPaper Section 5.1 Part 3" begin
   @test size(matrix_integral(fg_not_breaking)) == (25,1)
@@ -268,7 +268,7 @@ u = cohomology_class(divs[11])
 v = cohomology_class(divs[8])
 pb_Kbar = cohomology_class(sum(divs[1:7]))
 g4_class = (-3) // kbar3(qsm_model) * (5 * e1 * e4 + pb_Kbar * (-3 * e1 - 2 * e2 - 6 * e4 + pb_Kbar - 4 * u + v))
-g4_sample2 = g4_flux(qsm_model, g4_class, check = false)
+g4_sample2 = g4_flux(qsm_model, g4_class, completeness_check = false, consistency_check = false)
 cohomology_class(g4_sample2)
 
 @testset "FTheoryToolsPaper Section 5.1 Part 5" begin
@@ -294,9 +294,9 @@ t = literature_model(arxiv_id = "1511.03209")
 t_res = resolve(t, 1)
 amb = ambient_space(t_res)
 cohomology_ring(amb, completeness_check = false)
-g4_amb_candidates = chosen_g4_flux_gens(t_res, check = false)
-fg_quant = special_flux_family(t_res, check = false)
-fg_quant_no_break = special_flux_family(t_res, not_breaking = true, check = false)
+g4_amb_candidates = chosen_g4_flux_gens(t_res, completeness_check = false)
+fg_quant = special_flux_family(t_res, completeness_check = false)
+fg_quant_no_break = special_flux_family(t_res, not_breaking = true, completeness_check = false)
 
 @testset "FTheoryToolsPaper Section 5.2" begin
   @test betti_number(amb, 4) == 1109

--- a/experimental/FTheoryTools/test/paper_tests.jl
+++ b/experimental/FTheoryTools/test/paper_tests.jl
@@ -228,7 +228,7 @@ g4_gens = chosen_g4_flux_gens(qsm_model)
 @testset "FTheoryToolsPaper Section 5.1 Part 1" begin
   @test ngens(stanley_reisner_ideal(ambient_space(qsm_model))) == 20
   @test betti_number(ambient_space(qsm_model), 4) == 25
-  @test length(basis_of_h22_ambient(qsm_model, check = false)) == 25
+  @test length(basis_of_h22_ambient(qsm_model, completeness_check = false)) == 25
   @test length(g4_gens) == 25
   @test parent(polynomial(cohomology_class(g4_gens[1]))) == cohomology_ring(ambient_space(qsm_model))
 end


### PR DESCRIPTION
## Release notes/content of this PR

* [#5214](https://github.com/oscar-system/Oscar.jl/pull/5214) **breaking** Kwarg `check` renamed according to the role it plays/adjusting its role when needed. In most places, it was renamed to `completeness_check`. For constructors of G4-fluxes, we introduced the kwarg `consistency_check` (is the flux properly quantized? does it pass the transversality constraints?).
* [#5214](https://github.com/oscar-system/Oscar.jl/pull/5214) Support for kwarg `completeness_check` extended. For instance, it is now allowed as input to `is_well_quantized`, `passes_transversality_checks`, `d3_tadpole` for individual G4-fluxes. But it is also used internally in many more places.
* [#5214](https://github.com/oscar-system/Oscar.jl/pull/5214) Kwargs `completeness_check` and `consistency_check` are described in docstrings.
* [#5214](https://github.com/oscar-system/Oscar.jl/pull/5214) **breaking** Stop support for `chosen_g4_flux_basis`, `basis_of_h22_hypersurface` and `basis_of_h22_hypersurface_indices`.

## Preview of updated documentation

Preview:  https://docs.oscar-system.org/previews/PR5214/Experimental/FTheoryTools/introduction/

## Early discussion/thoughts

* ~~For various toric methods, the optional argument `check` exists. It always disables a completeness check, but also some related smoothness or simpliciality checks. Maybe we should always execute the smoothness/simpliciality check and use check exclusively to switch of completeness checks? That would make the use more consistent, while increasing the reliability of OSCAR at the cost of almost no loss of performance? Any thoughts @apturner, @emikelsons, @lkastner? One could in this case also rename the keyword to `completeness_check`, which would make its meaning immediately clear (cf. next bullet point). Not sure if this requires deprecation, as this affects accepted input to functionality in OSCAR's source. Either way, I have added documentation to explain what the keyword currently does.~~
* ~~In FTheoryTools, we have the keyword `completeness_check`. This is used exclusively to test if a base space of an FTheory model is complete (toric variety). While more transparent, the name is not in tandem with the key word argument used in toric varieties. I believe this would be desirable, so users do not have to "learn" new commands for new math areas. With this in mind, I have for now renamed the FTheoryTools keyword `completeness_check` to `check`. And of course, I have added docstring which clearly explain what this keyword does.~~

## Update

* After thinking this over, and discussing with @apturner and @emikelsons I realized that `completeness_check` is a great name for an optional argument, as it immediately makes its purpose clear. As such, have reverted/adjusted my changes, so that we keep this optional argument. I have also put it to use in the toric varieties code (including deprecating the old calls).
* A related change was to make sure that this optional argument truly only switches the completeness check off, and no other checks.
* And of course, as advertised in the title/above, the documentation was extended to explain the use of this optional argument.

## Update 2

* I decided to split the changes here into at least 2 PRs.
* Will work on https://github.com/oscar-system/Oscar.jl/pull/5234 first, and then come back to the optional argument counterparts that reside in FTheoryTools.

## Update 3

* https://github.com/oscar-system/Oscar.jl/issues/5256 just got fixed.
* I am thus hopeful that https://github.com/oscar-system/Oscar.jl/pull/5254 and https://github.com/oscar-system/Oscar.jl/pull/5234 can be merged shortly (today?).
* This PR is now based on both #5234 and #5254.

## Update 4

Just rebased, since #5234 and #5254 are merged now.

## Update 5

Ready for review.