### PR TITLE
`n_cones` and `cones` now properly consider all cones

### DIFF
--- a/experimental/GITFans/test/runtests.jl
+++ b/experimental/GITFans/test/runtests.jl
@@ -77,7 +77,7 @@
     @test n_rays(fanobj) == 20
     @test dim(fanobj) == 5
     @test n_maximal_cones(fanobj) == 76
-    @test n_cones(fanobj) == 671
+    @test n_cones(fanobj) == 672
     @test !is_complete(fanobj)
     @test is_pointed(fanobj)
     @test !is_regular(fanobj)

--- a/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/constructors.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/constructors.jl
@@ -62,7 +62,7 @@ Rational equivalence class on a normal toric variety represented by 15V(x1,x3)+6
 """
 function rational_equivalence_class(v::NormalToricVarietyType, coefficients::Vector{T}) where {T <: IntegerUnion}
     @req (is_simplicial(v) && is_complete(v)) "Currently, algebraic cycles are only supported for toric varieties that are simplicial and complete"
-    @req length(coefficients) == n_cones(v) "The number of coefficients must match the number of all cones (but the trivial one) in the fan of the toric variety"
+    @req length(coefficients) == n_cones(v; trivial=false) "The number of coefficients must match the number of all cones (but the trivial one) in the fan of the toric variety"
     mons = gens_of_rational_equivalence_classes(v)
     return RationalEquivalenceClass(v, sum(coefficients[i]*mons[i] for i in 1:length(coefficients)))
 end

--- a/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/special_attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/AlgebraicCycles/special_attributes.jl
@@ -89,8 +89,8 @@ julia> gens_of_rational_equivalence_classes(p2)
 @attr Vector{MPolyQuoRingElem{QQMPolyRingElem}} function gens_of_rational_equivalence_classes(v::NormalToricVarietyType)
   cr = chow_ring(v)
   R = base_ring(cr)
-  cs = cones(v)
-  return [simplify(cr(R([1], [Vector{Int}(cs[k,:])]))) for k in 1:n_cones(v)]
+  cs = cones(v; trivial=false)
+  return [simplify(cr(R([1], [Vector{Int}(cs[k,:])]))) for k in 1:nrows(cs)]
 end
 
 
@@ -115,7 +115,7 @@ Dict{QQMPolyRingElem, MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}} with 2 ent
   cr = chow_ring(v)
   R = base_ring(cr)
   co = cox_ring(v)
-  cs = cones(v)
+  cs = cones(v; trivial=false)
   mapping = Dict{QQMPolyRingElem, MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}()
   for k in 1:nrows(cs)
     p1 = simplify(cr(R([1], [Vector{Int}(cs[k,:])]))).f

--- a/src/PolyhedralGeometry/PolyhedralFan/properties.jl
+++ b/src/PolyhedralGeometry/PolyhedralFan/properties.jl
@@ -252,8 +252,7 @@ _incidencematrix(::Val{_cone_of_dim}) = _ray_indices
 @doc raw"""
     cones(PF::PolyhedralFan)
 
-Return the ray indices of all non-zero-dimensional
-cones in a polyhedral fan.
+Return the ray indices of all cones in a polyhedral fan.
 
 # Examples
 ```jldoctest
@@ -261,7 +260,7 @@ julia> PF = face_fan(cube(2))
 Polyhedral fan in ambient dimension 2
 
 julia> cones(PF)
-8×4 IncidenceMatrix
+9×4 IncidenceMatrix
  [1, 3]
  [2, 4]
  [1, 2]
@@ -270,13 +269,15 @@ julia> cones(PF)
  [3]
  [2]
  [4]
+ []
 ```
 """
 function cones(PF::_FanLikeType)
   pmo = pm_object(PF)
+  n_maximal_cones(PF) == 0 && return IncidenceMatrix(0, 0)
   ncones = pmo.HASSE_DIAGRAM.N_NODES
   cones = [Polymake._get_entry(pmo.HASSE_DIAGRAM.FACES, i) for i in 0:(ncones - 1)]
-  cones = filter(x -> !(-1 in x) && length(x) > 0, cones)
+  cones = filter(x -> !(-1 in x), cones)
   cones = [Polymake.to_one_based_indexing(x) for x in cones]
   return IncidenceMatrix([Vector{Int}(x) for x in cones])
 end
@@ -600,7 +601,7 @@ julia> PF = polyhedral_fan(incidence_matrix([[1, 2], [3]]), [1 0; 0 1; -1 -1])
 Polyhedral fan in ambient dimension 2
 
 julia> n_cones(PF)
-4
+5
 ```
 """
 n_cones(PF::_FanLikeType) = nrows(cones(PF))

--- a/test/AlgebraicGeometry/ToricVarieties/toric_blowups.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/toric_blowups.jl
@@ -90,7 +90,7 @@
     # Now blowing up along an existing ray
     g = blow_up(X, 2)
     @test n_rays(domain(g)) == 2
-    @test n_cones(domain(g)) == 3
+    @test n_cones(domain(g)) == 4
 
     # Quadratic cone, blowup along maximal cone
     ray_generators = [[0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1]]
@@ -108,6 +108,6 @@
     # Now blowing up along an existing ray
     g = blow_up(X, 6)
     @test n_rays(domain(g)) == 4
-    @test n_cones(domain(g)) == 11
+    @test n_cones(domain(g)) == 12
   end
 end

--- a/test/book/specialized/boehm-breuer-git-fans/explG25_5.jlcon
+++ b/test/book/specialized/boehm-breuer-git-fans/explG25_5.jlcon
@@ -25,7 +25,7 @@ julia> n_maximal_cones(fanobj)
 76
 
 julia> n_cones(fanobj)
-671
+672
 
 julia> is_pointed(fanobj)
 true


### PR DESCRIPTION
With a keyword argument to suppress the trivial cone.

This is slightly breaking but I consider this a bugfix:

The original docstring for `cones` claimed
> Return the ray indices of all non-zero-dimensional cones in a polyhedral fan.

which was not true since it always excluded the minimal cone even when it has a non-empty lineality space (and thus positive dimension).

For `ncones`:
> Return the number of cones of `PF`.

But this also excluded the trivial cone.

Closes #4815 