### PR TITLE
fix creation of `class_function` objects

### DIFF
--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -2182,7 +2182,10 @@ group(chi::GAPGroupClassFunction) = group(parent(chi))
 characteristic(chi::GAPGroupClassFunction) = characteristic(parent(chi))
 
 function class_function(tbl::GAPGroupCharacterTable, values::GapObj)
-    @req GAPWrap.IsClassFunction(values) "values must be a class function"
+    if ! GAPWrap.IsClassFunction(values)
+      @req (GAPWrap.IsList(values) && GAPWrap.IsCyclotomicCollection(values)) "values must be a GAP class function or list"
+      values = GAPWrap.ClassFunction(GapObj(tbl), values)
+    end
     return GAPGroupClassFunction(tbl, values)
 end
 
@@ -2192,8 +2195,7 @@ function class_function(tbl::GAPGroupCharacterTable, values::Vector{<:Union{Inte
 end
 
 function class_function(G::GAPGroup, values::GapObj)
-    @req GAPWrap.IsClassFunction(values) "values must be a class function"
-    return GAPGroupClassFunction(character_table(G), values)
+    return class_function(character_table(G), values)
 end
 
 function class_function(G::GAPGroup, values::Vector{<:Union{Integer, ZZRingElem, Rational, QQFieldElem, QQAbFieldElem}})

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -753,7 +753,7 @@ end
 @testset "create class functions" begin
   g = symmetric_group(3)
   tbl = character_table(g)
-  n = number_conjugacy_classes(tbl)
+  n = number_of_conjugacy_classes(tbl)
   triv = trivial_character(tbl)
   for X in [tbl, g]
     @test triv == Oscar.class_function(X, [1 for i in 1:n])

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -750,6 +750,20 @@ X_3  1  1  1
   @test character_table(alternating_group(5), 2) === nothing
 end
 
+@testset "create class functions" begin
+  g = symmetric_group(3)
+  tbl = character_table(g)
+  n = number_conjugacy_classes(tbl)
+  triv = trivial_character(tbl)
+  for X in [tbl, g]
+    @test triv == Oscar.class_function(X, [1 for i in 1:n])
+    @test triv == Oscar.class_function(X, GapObj(triv))
+    @test triv == Oscar.class_function(X, GapObj([1 for i in 1:n]))
+    @test_throws ArgumentError Oscar.class_function(X, GapObj([true]))
+    @test_throws ErrorException Oscar.class_function(X, GapObj([1 for i in 1:2*n]))
+  end
+end
+
 @testset "access fields in character tables" begin
   # table without group
   t = character_table("A5")


### PR DESCRIPTION
Some GAP functions may return plain lists where class functions are expected.
Eventually this will get fixed in GAP but here is an Oscar fix for the moment.