### PR TITLE
Fix `leading_coefficient` for zero polynomials

### DIFF
--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -1014,6 +1014,9 @@ end
 Return the leading coefficient of `f` with respect to the order `ordering`.
 """
 function leading_coefficient(f::MPolyRingElem; ordering::MonomialOrdering = default_ordering(parent(f)))
+  if is_zero(f)
+    return zero(base_ring(f))
+  end
   return coeff(f, index_of_leading_term(f, ordering))
 end
 


### PR DESCRIPTION
Currently, the Oscar implementation of leading_coefficient for zero MPolys is inconsistent with AbstractAlgebra. In AbstractAlgebra it is zero but in Oscar an error is raised. Additionally, this is neither the case for univariate zero polynomials nor any trailing coefficients.

```julia

julia> R, x = polynomial_ring(QQ, :x)
(Univariate polynomial ring in x over QQ, x)

julia> S, (a, b, c) = polynomial_ring(QQ, 3);

julia> leading_coefficient(zero(R))
0

julia> trailing_coefficient(zero(R))
0

julia> leading_coefficient(zero(S))
ERROR: ArgumentError: zero polynomial does not have a leading term
Stacktrace:
 [1] macro expansion
   @ ~/.julia/packages/AbstractAlgebra/M1vfh/src/Assertions.jl:602 [inlined]
 [2] index_of_leading_term(f::QQMPolyRingElem, ord::MonomialOrdering{QQMPolyRing})
   @ Oscar.Orderings ~/software/Oscar/src/Rings/orderings.jl:2075
 [3] #leading_coefficient#98
   @ ~/software/Oscar/src/Rings/mpoly.jl:1017 [inlined]
 [4] leading_coefficient(f::QQMPolyRingElem)
   @ Oscar ~/software/Oscar/src/Rings/mpoly.jl:1016
 [5] top-level scope
   @ REPL[14]:1

julia> trailing_coefficient(zero(S))
0
```

This pull request should fix this.