### PR TITLE
Bump `serialization-upgrade-tests`

### DIFF
--- a/test/Serialization/upgrades/setup_tests.jl
+++ b/test/Serialization/upgrades/setup_tests.jl
@@ -6,7 +6,7 @@ if !isdefined(Main, :serialization_upgrade_test_path) ||
   !isdir(Main.serialization_upgrade_test_path) ||
   !isfile(joinpath(Main.serialization_upgrade_test_path, "LICENSE.md"))
 
-  serialization_upgrade_test_path = let commit_hash = "0b7ff9e5e1135ddeaf83bd20313946183522e0ae"
+  serialization_upgrade_test_path = let commit_hash = "90c84f6b03d22d60cee6db5a55879456d7def9c2"
     tarball = Downloads.download("https://github.com/oscar-system/serialization-upgrade-tests/archive/$(commit_hash).tar.gz")
 
     destpath = open(CodecZlib.GzipDecompressorStream, tarball) do io


### PR DESCRIPTION
To include https://github.com/oscar-system/serialization-upgrade-tests/pull/10