### PR TITLE
Minor changes to Groebner basis docu

### DIFF
--- a/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
@@ -44,6 +44,10 @@ The *leading monomial* $\text{LM}_>(f)$, the *leading exponent* $\text{LE}_>(f)$
     the above notation extends naturally to elements of  $K[x]^p$ and $K[x]_>^p$, respectively. There is one particularity:
     Given an element $f = K[x]^p\setminus \{0\}$ with leading term $\text{LT}(f) = x^\alpha e_i$, we write $\text{LE}_>(f) = (\alpha, i)$.
 
+!!! note
+    See the previous section on "Monomial Orderings" for details on how to implement monomial
+    orderings in OSCAR, with particular emphasis on default orderings in OSCAR.
+
 ## [Monomials, Terms, and More](@id monomials_terms_more)
 
 Here are examples which indicate how to recover monomials, terms, and

--- a/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
@@ -80,11 +80,6 @@ julia> default_ordering(S)
 wdegrevlex([x, y, z], [1, 2, 3])
 ```
 
-Expert users may temporarily choose a different default ordering for a given ring.
-```@docs
-with_ordering
-```
-
 ## [Monomials, Terms, and More](@id monomials_terms_more)
 
 Here are examples which indicate how to recover monomials, terms, and
@@ -417,3 +412,9 @@ We refer to the section on [modules](@ref modules_multivariate) for more on syzy
 syzygy_generators(G::Vector{<:MPolyRingElem})
 ```
 
+## Changing Default Orderings
+
+Expert users may temporarily choose a different default ordering for a given ring.
+```@docs
+with_ordering
+```

--- a/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
@@ -45,8 +45,8 @@ The *leading monomial* $\text{LM}_>(f)$, the *leading exponent* $\text{LE}_>(f)$
     Given an element $f = K[x]^p\setminus \{0\}$ with leading term $\text{LT}(f) = x^\alpha e_i$, we write $\text{LE}_>(f) = (\alpha, i)$.
 
 !!! note
-    See the previous section on "Monomial Orderings" for details on how to implement monomial
-    orderings in OSCAR, with particular emphasis on default orderings in OSCAR.
+    See the previous section on [Monomial Orderings](@ref monomial_orderings) for details on how to
+    implement monomial orderings in OSCAR, with particular emphasis on default orderings in OSCAR.
 
 ## [Monomials, Terms, and More](@id monomials_terms_more)
 

--- a/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
@@ -44,42 +44,6 @@ The *leading monomial* $\text{LM}_>(f)$, the *leading exponent* $\text{LE}_>(f)$
     the above notation extends naturally to elements of  $K[x]^p$ and $K[x]_>^p$, respectively. There is one particularity:
     Given an element $f = K[x]^p\setminus \{0\}$ with leading term $\text{LT}(f) = x^\alpha e_i$, we write $\text{LE}_>(f) = (\alpha, i)$.
 
-## Default Orderings
-
-!!! note
-    The OSCAR functions discussed in this section depend on a monomial `ordering` which is entered as a keyword argument.
-    Given a polynomial ring $R$, the `default_ordering` for this is `degrevlex` except if $R$ is $\mathbb Z$-graded with
-    positive weights. Then the corresponding `wdegrevlex` ordering is used. Given a free $R$-module $F$, the
-    `default_ordering` is `default_ordering(R)*lex(gens(F))`.
-
-```@docs
-default_ordering(::MPolyRing)
-```
-
-Here are some illustrating OSCAR examples:
-
-##### Examples
-
-```jldoctest
-julia> R, (x, y, z) = polynomial_ring(QQ, [:x, :y, :z])
-(Multivariate polynomial ring in 3 variables over QQ, QQMPolyRingElem[x, y, z])
-
-julia> default_ordering(R)
-degrevlex([x, y, z])
-
-julia> F = free_module(R, 2)
-Free module of rank 2 over R
-
-julia> default_ordering(F)
-degrevlex([x, y, z])*lex([gen(1), gen(2)])
-
-julia> S, _ = grade(R, [1, 2, 3])
-(Graded multivariate polynomial ring in 3 variables over QQ, MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}[x, y, z])
-
-julia> default_ordering(S)
-wdegrevlex([x, y, z], [1, 2, 3])
-```
-
 ## [Monomials, Terms, and More](@id monomials_terms_more)
 
 Here are examples which indicate how to recover monomials, terms, and
@@ -410,11 +374,4 @@ We refer to the section on [modules](@ref modules_multivariate) for more on syzy
 
 ```@docs
 syzygy_generators(G::Vector{<:MPolyRingElem})
-```
-
-## Changing Default Orderings
-
-Expert users may temporarily choose a different default ordering for a given ring.
-```@docs
-with_ordering
 ```

--- a/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases.md
@@ -310,7 +310,7 @@ standard_basis_with_transformation_matrix(I::MPolyIdeal;
 ```
 
 !!! note
-The strategy behind the `groebner_basis` function and the strategy behind the function `groebner_basis_with_transformation_matrix` differ. As a consequence, the computed generators may differ. Even if `complete_reduction` is set to `true`, the generators might still only agree up to multiplication by units.
+    The strategy behind the `groebner_basis` function and the strategy behind the function `groebner_basis_with_transformation_matrix` differ. As a consequence, the computed generators may differ. Even if `complete_reduction` is set to `true`, the generators might still only agree up to multiplication by units.
 
 ### Gröbner Basis Conversion Algorithms
 

--- a/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases_integers.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases_integers.md
@@ -4,7 +4,7 @@ CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 
-# Gröbner/Standard Bases Over $\mathbb Z$
+# [Gröbner/Standard Bases Over $\mathbb Z$](@id gb_integers)
 
 In this section, we consider a polynomial ring
 $\mathbb Z[x] = \mathbb Z[x_1, \dots, x_n]$ over the integers. As in the previous section

--- a/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases_integers.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases_integers.md
@@ -14,6 +14,10 @@ $f \in \mathbb Z[x]_>$, the notions *leading term*, *leading monomial*, *leading
 *leading coefficient*, and *tail*  of $f$ are defined as before.
 
 !!! note
+    See the previous section on "Monomial Orderings" for details on how to implement monomial
+    orderings in OSCAR, with particular emphasis on default orderings in OSCAR.
+
+!!! note
     Over $\mathbb Z$, the basic idea of multivariate polynomial division with remainder in OSCAR is as follows:
     If $ax^\alpha$ is the leading term of the intermediate dividend, $f_i$
     is *some* divisor whose leading monomial equals $x^\alpha$, say

--- a/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases_integers.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/groebner_bases_integers.md
@@ -14,8 +14,8 @@ $f \in \mathbb Z[x]_>$, the notions *leading term*, *leading monomial*, *leading
 *leading coefficient*, and *tail*  of $f$ are defined as before.
 
 !!! note
-    See the previous section on "Monomial Orderings" for details on how to implement monomial
-    orderings in OSCAR, with particular emphasis on default orderings in OSCAR.
+    See the previous section on [Monomial Orderings](@ref monomial_orderings) for details on how to
+    implement monomial orderings in OSCAR, with particular emphasis on default orderings in OSCAR.
 
 !!! note
     Over $\mathbb Z$, the basic idea of multivariate polynomial division with remainder in OSCAR is as follows:

--- a/docs/src/CommutativeAlgebra/GroebnerBases/orderings.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/orderings.md
@@ -448,10 +448,12 @@ The comparison function `cmp` as well as the tests `is_global`, `is_local`, and 
 ## Default Orderings
 
 !!! note
-    The OSCAR functions discussed in this section depend on a monomial `ordering` which is entered as a keyword argument.
-    Given a polynomial ring $R$, the `default_ordering` for this is `degrevlex` except if $R$ is $\mathbb Z$-graded with
-    positive weights. Then the corresponding `wdegrevlex` ordering is used. Given a free $R$-module $F$, the
-    `default_ordering` is `default_ordering(R)*lex(gens(F))`.
+    The OSCAR functions discussed in the following sections depend on a monomial
+    `ordering` which is entered as a keyword argument.  Given a polynomial ring $R$,
+    the `default_ordering` for this is `degrevlex` except if $R$ is $\mathbb
+    Z$-graded with positive weights. Then the corresponding `wdegrevlex` ordering is
+    used. Given a free $R$-module $F$, the `default_ordering` is
+    `default_ordering(R)*lex(gens(F))`.
 
 ```@docs
 default_ordering(::MPolyRing)

--- a/docs/src/CommutativeAlgebra/GroebnerBases/orderings.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/orderings.md
@@ -444,3 +444,44 @@ induced_ring_ordering(ord::ModuleOrdering)
 ```
 
 The comparison function `cmp` as well as the tests `is_global`, `is_local`, and `is_mixed` are also available for module orderings.
+
+## Default Orderings
+
+!!! note
+    The OSCAR functions discussed in this section depend on a monomial `ordering` which is entered as a keyword argument.
+    Given a polynomial ring $R$, the `default_ordering` for this is `degrevlex` except if $R$ is $\mathbb Z$-graded with
+    positive weights. Then the corresponding `wdegrevlex` ordering is used. Given a free $R$-module $F$, the
+    `default_ordering` is `default_ordering(R)*lex(gens(F))`.
+
+```@docs
+default_ordering(::MPolyRing)
+```
+
+Here are some illustrating OSCAR examples:
+
+##### Examples
+
+```jldoctest
+julia> R, (x, y, z) = polynomial_ring(QQ, [:x, :y, :z])
+(Multivariate polynomial ring in 3 variables over QQ, QQMPolyRingElem[x, y, z])
+
+julia> default_ordering(R)
+degrevlex([x, y, z])
+
+julia> F = free_module(R, 2)
+Free module of rank 2 over R
+
+julia> default_ordering(F)
+degrevlex([x, y, z])*lex([gen(1), gen(2)])
+
+julia> S, _ = grade(R, [1, 2, 3])
+(Graded multivariate polynomial ring in 3 variables over QQ, MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}[x, y, z])
+
+julia> default_ordering(S)
+wdegrevlex([x, y, z], [1, 2, 3])
+```
+
+Expert users may temporarily choose a different default ordering for a given ring.
+```@docs
+with_ordering
+```

--- a/docs/src/CommutativeAlgebra/GroebnerBases/orderings.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/orderings.md
@@ -448,7 +448,9 @@ The comparison function `cmp` as well as the tests `is_global`, `is_local`, and 
 ## Default Orderings
 
 !!! note
-    The OSCAR functions discussed in the following sections depend on a monomial
+    The OSCAR functions discussed in the sections 
+    [Gröbner/Standard Bases Over Fields](@ref gb_fields) and 
+    [Gröbner/Standard Bases Over $\mathbb Z$](@ref gb_integers) depend on a monomial
     `ordering` which is entered as a keyword argument.  Given a polynomial ring $R$,
     the `default_ordering` for this is `degrevlex` except if $R$ is $\mathbb
     Z$-graded with positive weights. Then the corresponding `wdegrevlex` ordering is

--- a/docs/src/CommutativeAlgebra/GroebnerBases/orderings.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/orderings.md
@@ -445,7 +445,7 @@ induced_ring_ordering(ord::ModuleOrdering)
 
 The comparison function `cmp` as well as the tests `is_global`, `is_local`, and `is_mixed` are also available for module orderings.
 
-## Default Orderings
+## Default Orderings in OSCAR
 
 !!! note
     The OSCAR functions discussed in the sections 

--- a/docs/src/CommutativeAlgebra/GroebnerBases/orderings.md
+++ b/docs/src/CommutativeAlgebra/GroebnerBases/orderings.md
@@ -457,30 +457,6 @@ The comparison function `cmp` as well as the tests `is_global`, `is_local`, and 
 default_ordering(::MPolyRing)
 ```
 
-Here are some illustrating OSCAR examples:
-
-##### Examples
-
-```jldoctest
-julia> R, (x, y, z) = polynomial_ring(QQ, [:x, :y, :z])
-(Multivariate polynomial ring in 3 variables over QQ, QQMPolyRingElem[x, y, z])
-
-julia> default_ordering(R)
-degrevlex([x, y, z])
-
-julia> F = free_module(R, 2)
-Free module of rank 2 over R
-
-julia> default_ordering(F)
-degrevlex([x, y, z])*lex([gen(1), gen(2)])
-
-julia> S, _ = grade(R, [1, 2, 3])
-(Graded multivariate polynomial ring in 3 variables over QQ, MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}[x, y, z])
-
-julia> default_ordering(S)
-wdegrevlex([x, y, z], [1, 2, 3])
-```
-
 Expert users may temporarily choose a different default ordering for a given ring.
 ```@docs
 with_ordering

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -69,6 +69,27 @@ using .Orderings
 Return the monomial ordering that is used for computations with ideals in `R`
 if no other ordering is specified -- either directly by the user or by
 requirements of a specific algorithm.
+
+# Example
+```jldoctest
+julia> R, (x, y, z) = polynomial_ring(QQ, [:x, :y, :z])
+(Multivariate polynomial ring in 3 variables over QQ, QQMPolyRingElem[x, y, z])
+
+julia> default_ordering(R)
+degrevlex([x, y, z])
+
+julia> F = free_module(R, 2)
+Free module of rank 2 over R
+
+julia> default_ordering(F)
+degrevlex([x, y, z])*lex([gen(1), gen(2)])
+
+julia> S, _ = grade(R, [1, 2, 3])
+(Graded multivariate polynomial ring in 3 variables over QQ, MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}[x, y, z])
+
+julia> default_ordering(S)
+wdegrevlex([x, y, z], [1, 2, 3])
+```
 """
 @attr MonomialOrdering{T} function default_ordering(R::T) where {T<:MPolyRing}
   return degrevlex(R)

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -70,7 +70,7 @@ Return the monomial ordering that is used for computations with ideals in `R`
 if no other ordering is specified -- either directly by the user or by
 requirements of a specific algorithm.
 
-# Example
+# Examples
 ```jldoctest
 julia> R, (x, y, z) = polynomial_ring(QQ, [:x, :y, :z])
 (Multivariate polynomial ring in 3 variables over QQ, QQMPolyRingElem[x, y, z])


### PR DESCRIPTION
- added missing indentation necessary for "Note" block.
- moved `with_ordering` function to the bottom of the page.  As per its own documentation, `with_ordering` is a function only advanced users should use.  Hence it shouldn't be the second function beginning students read when they try to figure out how Groebner Basis work in OSCAR.  This has caused temporary confusion in Durham.