### PR TITLE
changelog: check more subprocess exit codes, full checkout to get tags and history

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -22,6 +22,8 @@ jobs:
     # Checkout the repository
     - name: Checkout Repository
       uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
 
     # Run the update script
     - name: Run python script

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -302,7 +302,7 @@ def main(new_version: str) -> None:
             "git",
             "merge-base",
             basetag,
-            "master"
+            "HEAD"
         ], shell=False, check=True, capture_output=True).stdout.decode().strip()
         timestamp = subprocess.run([
             "git",

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -42,6 +42,7 @@ def is_existing_tag(tag: str) -> bool:
             f""".[] | select(.name | contains("{tag.strip()}"))"""
         ],
         shell=False,
+        check=False, # this subprocess is allowed to fail
         capture_output=True
     )
     return res.stdout.decode() != ""
@@ -130,6 +131,7 @@ def get_tag_date(tag: str) -> str:
                 "--json=createdAt"
             ],
             shell=False,
+            check=True,
             capture_output=True
         )
         res = json.loads(res.stdout.decode())
@@ -301,14 +303,14 @@ def main(new_version: str) -> None:
             "merge-base",
             basetag,
             "master"
-        ], shell=False, capture_output=True).stdout.decode().strip()
+        ], shell=False, check=True, capture_output=True).stdout.decode().strip()
         timestamp = subprocess.run([
             "git",
             "show",
             "-s",
             "--format=\"%cI\"",
             shared_commit
-        ], shell=False, capture_output=True).stdout.decode().strip().replace('"', '')
+        ], shell=False, check=True, capture_output=True).stdout.decode().strip().replace('"', '')
         # date is first 10 characters of timestamp
         startdate = timestamp[0:10]
     print("Base tag is", basetag)
@@ -338,6 +340,7 @@ if __name__ == "__main__":
                 ".[] | select(.isLatest == true)"
             ],
             shell=False,
+            check=True,
             capture_output=True
         )
         itag = json.loads(itag.stdout.decode())["name"][1:]


### PR DESCRIPTION
Tags and history are probably needed for merge-base command, and `check` might help debugging such issues.

x-ref: https://github.com/oscar-system/Oscar.jl/pull/5243#issuecomment-3244605931