### PR TITLE
[FTheoryTools] Minor improvement

### DIFF
--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
@@ -247,7 +247,7 @@ Create a random ``G_4``-flux on a given F-theory model.
 julia> qsm_model = literature_model(arxiv_id = "1903.00009", model_parameters = Dict("k" => 2021))
 Hypersurface model over a concrete base
 
-julia> rf = random_flux(qsm_model, completeness_check = false, consistency_check = false)
+julia> rf = random_flux(qsm_model, completeness_check = false)
 G4-flux candidate
   - Elementary quantization checks: satisfied
   - Transversality checks: satisfied
@@ -255,7 +255,7 @@ G4-flux candidate
   - Tadpole cancellation check: not computed
 ```
 """
-function random_flux(m::AbstractFTheoryModel; not_breaking::Bool = false, completeness_check::Bool = true, consistency_check::Bool = true)
+function random_flux(m::AbstractFTheoryModel; not_breaking::Bool = false, completeness_check::Bool = true)
   family = special_flux_family(m; not_breaking, completeness_check)
-  return random_flux_instance(family; completeness_check, consistency_check)
+  return random_flux_instance(family, completeness_check = completeness_check, consistency_check = false)
 end

--- a/experimental/FTheoryTools/test/paper_tests.jl
+++ b/experimental/FTheoryTools/test/paper_tests.jl
@@ -243,7 +243,7 @@ mat_rat = matrix_rational(fg)
 end
 
 g4 = random_flux_instance(fg)
-g4_2 = random_flux(qsm_model, completeness_check = false, consistency_check = false)
+g4_2 = random_flux(qsm_model, completeness_check = false)
 fg_not_breaking = special_flux_family(qsm_model, not_breaking = true, completeness_check = false)
 
 @testset "FTheoryToolsPaper Section 5.1 Part 3" begin


### PR DESCRIPTION
Follow-up to https://github.com/oscar-system/Oscar.jl/pull/5214.

We do not need consistency_checks for this G4-flux constructor, as this one uses a family of well-quantized fluxes that pass the transversality constraints. So the result will always come back as true...

cc @apturner @emikelsons 