### PR TITLE
Remove some unreachable code

### DIFF
--- a/src/Modules/Iterators.jl
+++ b/src/Modules/Iterators.jl
@@ -50,16 +50,6 @@ function Base.length(amm::AllModuleMonomials{<:FreeMod, FinGenAbGroupElem})
   R = base_ring(F)
   d = degree(amm)::FinGenAbGroupElem
   return sum(length(get!(amm.exp_cache, d - degree(g; check=false), all_exponents(R, d - degree(g)))) for g in gens(F); init=0)
-  result = 0
-  for i in 1:r
-    d_loc = d - degree(F[i]; check=false)
-    any(Int(d_loc[i]) < 0 for i in 1:ngens(parent(d)))&& continue
-    exps = get!(amm.exp_cache, d_loc) do
-      return all_exponents(R, d_loc)
-    end
-    result = result + length(exps)
-  end
-  return result
 end
   
 function Base.iterate(amm::AllModuleMonomials{<:FreeMod, Int}, state::Nothing = nothing)


### PR DESCRIPTION
The `return` in the previous line was introduced by @HechtiDerLachs in https://github.com/oscar-system/Oscar.jl/pull/4951, making this part of the code unreachable.