### PR TITLE
Drop support for some old functionality that is no longer used

### DIFF
--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/analyze_fibers.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/analyze_fibers.jl
@@ -38,6 +38,7 @@ function analyze_fibers(model::GlobalTateModel, centers::Vector{<:Vector{<:Integ
   base_to_ambient_ring_map = hom(base_coords, ambient_coords, gens(ambient_coords)[1:end-3])
   
   # Resolved model
+  # NOTE: _blowup_global_sequence was removed on September 4, 2025. This entire function needs to be rewritten!
   strict_transform, exceptionals, crepant, res_irr, res_sri, res_lin, res_S, res_S_gens, res_ring_map = _blowup_global_sequence(hypersurface_ideal, centers, irr, sri, lin)
   if !crepant
       @warn "The given sequence of blowups is not crepant"

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/blowups.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/blowups.jl
@@ -1,85 +1,8 @@
-##################################################################
-# 1: Blowups (old helper function, to be used for family of bases)
-##################################################################
-
-function _blowup_global(id::MPolyIdeal{QQMPolyRingElem}, center::MPolyIdeal{QQMPolyRingElem}, irr::MPolyIdeal{QQMPolyRingElem}, sri::MPolyIdeal{QQMPolyRingElem}, lin::MPolyIdeal{<:MPolyRingElem}; index::Integer = 1)
-  # @warn "The function _blowup_global is experimental; absence of bugs and proper results are not guaranteed"
-  
-  R = base_ring(id)
-  center_size = ngens(center)
-  
-  # Various sanity checks
-  @req (!is_zero(center)) "The blowup center must be non-empty"
-  
-  # @req is_subset(id, center) "The ideal of the blowup center must contain the ideal to be blown up"
-  @req base_ring(irr) == R "The given irrelevant ideal must share the base ring of the ideal to be blown up"
-  @req base_ring(sri) == R "The given Stanley–Reisner ideal must share the base ring of the ideal to be blown up"
-  @req ngens(base_ring(lin)) == ngens(R) "The base ring of ideal of linear relations must have the same number of generators as the base ring of the ideal to be blown up"
-  
-  # Make sure the ideal of linear relations has the same base ring as the others
-  lin = ideal(map(hom(base_ring(lin), R, collect(1:ngens(R))), gens(lin)))
-  
-  # Create new base ring for the blown up ideal and a map between the rings
-  S, S_gens = polynomial_ring(QQ, [Symbol("e_", index); [Symbol("b_", index, "_", i) for i in 1:center_size]; symbols(R)], cached = false)
-  (_e, new_coords...) = S_gens[1:center_size + 1]
-  ring_map = hom(R, S, S_gens[center_size + 2:end])
-  
-  # Compute the total transform
-  center_gens_S = map(ring_map, gens(center))
-  total_transform = ideal(map(ring_map, gens(id))) + ideal([new_coords[i] * _e - center_gens_S[i] for i in 1:center_size])
-  
-  # Compute the exceptional locus and strict transform, checking for crepancy
-  # Could alternatively replace _e with center_gens_S in the exceptional locus here, then take the
-  # primary decomposition and remove parts whose saturation by the irrelevant ideal is the whole ring
-  exceptional_ideal = total_transform + ideal([_e])
-  strict_transform, exceptional_factor = saturation_with_index(total_transform, exceptional_ideal)
-  crepant = (exceptional_factor == center_size - 1)
-  
-  # Compute the new irrelevant ideal, SRI, and ideal of linear relations
-  # These may need to be changed after reintroducing e
-  new_irr = ideal(map(ring_map, gens(irr))) * ideal(new_coords)
-  new_sri = ideal(map(ring_map, gens(sri))) + ideal([prod(new_coords)])
-  new_lin = ideal(map(ring_map, gens(lin))) + ideal([g - new_coords[end] for g in new_coords[1:end - 1]])
-  
-  return total_transform, strict_transform, exceptional_ideal, crepant, new_irr, new_sri, new_lin, S, S_gens, ring_map
-end
-_blowup_global(id::T, center::T, irr::T, sri::T, lin::T; index::Integer = 1) where {T<:MPolyIdeal{<:MPolyRingElem}} = _blowup_global(ideal(map(g -> lift(g), gens(id))), ideal(map(g -> lift(g), gens(center))), ideal(map(g -> lift(g), gens(irr))), ideal(map(g -> lift(g), gens(sri))), lin, index = index)
-
-
-function _blowup_global_sequence(id::MPolyIdeal{QQMPolyRingElem}, centers::Vector{<:Vector{<:Integer}}, irr::MPolyIdeal{QQMPolyRingElem}, sri::MPolyIdeal{QQMPolyRingElem}, lin::MPolyIdeal{<:MPolyRingElem}; index::Integer = 1)
-  # @warn "The function _blowup_global_sequence is experimental; absence of bugs and proper results are not guaranteed"
-  
-  (cur_strict_transform, cur_irr, cur_sri, cur_lin, cur_S, cur_S_gens, cur_index) = (id, irr, sri, lin, base_ring(id), gens(base_ring((id))), index)
-  crepant = true
-  ring_map = hom(cur_S, cur_S, cur_S_gens) # Identity map
-  
-  exceptionals = MPolyIdeal{<:MPolyRingElem}[]
-  for center in centers
-    @req all(ind -> 1 <= ind <= length(cur_S_gens), center) "The given indices for the center generators are out of bounds"
-    
-    (_, cur_strict_transform, cur_ex, cur_crep, cur_irr, cur_sri, cur_lin, cur_S, cur_S_gens, cur_ring_map) = _blowup_global(cur_strict_transform, ideal(map(ind -> cur_S_gens[ind], center)), cur_irr, cur_sri, cur_lin, index = cur_index)
-    
-    map!(cur_ring_map, exceptionals, exceptionals)
-    push!(exceptionals, cur_ex)
-    
-    crepant = crepant && cur_crep
-    
-    ring_map = compose(ring_map, cur_ring_map)
-    
-    cur_index += 1
-  end
-  
-  return cur_strict_transform, exceptionals, crepant, cur_irr, cur_sri, cur_lin, cur_S, cur_S_gens, ring_map
-end
-_blowup_global_sequence(id::T, centers::Vector{<:Vector{<:Integer}}, irr::T, sri::T, lin::T; index::Integer = 1) where {T<:MPolyIdeal{<:MPolyRingElem}} = _blowup_global_sequence(ideal(map(g -> lift(g), gens(id))), centers, ideal(map(g -> lift(g), gens(irr))), ideal(map(g -> lift(g), gens(sri))), lin, index = index)
-
-
-
 ###########################################################################
-# 2: Convenience functions for blowups
-# 2: FOR INTERNAL USE ONLY (as of Feb 1, 2025 and PR 4523)
-# 2: They are not in use (as of Feb 1, 2025 and PR 4523)
-# 2: Gauge in the future if they are truly needed!
+# 1: Convenience functions for blowups
+# 1: FOR INTERNAL USE ONLY (as of Feb 1, 2025 and PR 4523)
+# 1: They are not in use (as of Feb 1, 2025 and PR 4523)
+# 1: Gauge in the future if they are truly needed!
 ###########################################################################
 
 @doc raw"""
@@ -184,7 +107,7 @@ end
 
 
 ##################################################################
-# 3: Currently used blowup functionality
+# 2: Currently used blowup functionality
 ##################################################################
 
 @doc raw"""

--- a/experimental/FTheoryTools/src/exports.jl
+++ b/experimental/FTheoryTools/src/exports.jl
@@ -6,7 +6,6 @@ export FamilyOfSpaces
 export GlobalTateModel
 export HypersurfaceModel
 export WeierstrassModel
-export _is_nontrivial
 export add_associated_literature_model!
 export add_generating_section!
 export add_journal_report_number!

--- a/experimental/FTheoryTools/src/exports.jl
+++ b/experimental/FTheoryTools/src/exports.jl
@@ -6,8 +6,6 @@ export FamilyOfSpaces
 export GlobalTateModel
 export HypersurfaceModel
 export WeierstrassModel
-export _blowup_global
-export _blowup_global_sequence
 export _is_nontrivial
 export add_associated_literature_model!
 export add_generating_section!


### PR DESCRIPTION
# Release notes

- [#5269](https://github.com/oscar-system/Oscar.jl/pull/5269) **breaking** Stop support for `_blowup_global`
- [#5269](https://github.com/oscar-system/Oscar.jl/pull/5269) **breaking** Stop support for `_blowup_global_sequence`
- [#5269](https://github.com/oscar-system/Oscar.jl/pull/5269) **breaking** Stop exporting `_is_nontrivial`