### PR TITLE
Add an iterator of subspaces of finite vector spaces

### DIFF
--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -1627,19 +1627,15 @@ ZZRingElem[12, 12, 16]
 ```
 """
 function orbit_representatives_and_stabilizers(G::MatrixGroup{E}, k::Int) where E <: FinFieldElem
-  F = base_ring(G)
   n = degree(G)
-  q = GAP.Obj(order(F))
-  V = vector_space(F, n)
+  V = vector_space(base_ring(G), n)
   k == 0 && return [(sub(V, [])[1], G)]
-  # Note that GAP anyhow unpacks all subspaces.
-  l = GAP.Globals.AsSSortedList(GAP.Globals.Subspaces(GAPWrap.GF(q)^n, k))::GapObj
-  ll = GAP.Globals.List(l,
-         GAP.UnwrapJuliaFunc(x -> GAP.Globals.BasisVectors(GAP.Globals.CanonicalBasis(x))))
-  orbs = GAP.Globals.Orbits(GapObj(G), ll, GAP.Globals.OnSubspacesByCanonicalBasis)::GapObj
+
+  Omega = gset(G, on_echelon_form_mats, Oscar.bases_of_subspaces(V, k))
+  orbs = orbits(Omega)
   orbreps = [orb[1] for orb in orbs]
-  stabs = [_as_subgroup_bare(G, GAP.Globals.Stabilizer(GapObj(G), v, GAP.Globals.OnSubspacesByCanonicalBasis)) for v in orbreps]::Vector{typeof(G)}
-  orbreps1 = [[[F(x) for x in v] for v in bas] for bas in orbreps]::Vector{Vector{Vector{elem_type(F)}}}
-  orbreps2 = [sub(V, [V(v) for v in bas])[1] for bas in orbreps1]
+  orbreps_gap = [map_entries(_ring_iso(G), omega) for omega in orbreps]
+  orbreps2 = [sub(V, [V([M[i,j] for j in 1:n]) for i in 1:k])[1] for M in orbreps]
+  stabs = [_as_subgroup_bare(G, GAP.Globals.Stabilizer(GapObj(G), v, GAP.Globals.OnSubspacesByCanonicalBasis)) for v in orbreps_gap]::Vector{typeof(G)}
   return [(orbreps2[i], stabs[i]) for i in 1:length(stabs)]
 end

--- a/src/Groups/subspaces.jl
+++ b/src/Groups/subspaces.jl
@@ -10,8 +10,7 @@ Return an iterator of the matrices that are echelonized bases of the
 
 # Examples
 ```jldoctest
-julia> V = vector_space(GF(2), 3)
-Vector space of dimension 3 over F
+julia> V = vector_space(GF(2), 3);
 
 julia> for b in Oscar.bases_of_subspaces(V, 2) println(b); end
 [1 0 0; 0 1 0]

--- a/src/Groups/subspaces.jl
+++ b/src/Groups/subspaces.jl
@@ -1,0 +1,131 @@
+#############################################################################
+##
+##  Bases of subspaces of a finite vector space
+
+@doc raw"""
+    bases_of_subspaces(V::AbstractAlgebra.Generic.FreeModule{T}, k::Int) where T <: FinFieldElem
+
+Return an iterator of the matrices that are echelonized bases of the
+`k`-dimensional subspaces of `V`.
+
+# Examples
+```jldoctest
+julia> V = vector_space(GF(2), 3)
+Vector space of dimension 3 over F
+
+julia> for b in Oscar.bases_of_subspaces(V, 2) println(b); end
+[1 0 0; 0 1 0]
+[1 0 1; 0 1 0]
+[1 0 0; 0 1 1]
+[1 0 1; 0 1 1]
+[1 0 0; 0 0 1]
+[1 1 0; 0 0 1]
+[0 1 0; 0 0 1]
+```
+"""
+function bases_of_subspaces(V::AbstractAlgebra.Generic.FreeModule{T}, k::Int) where T <: FinFieldElem
+  return SubspacesIterator{T}(V, k)
+end
+
+# For an iterator of `k`-dimensional subspaces in an `n`-dimensional space
+# over the field with `q` elements,
+# the state is `(comb_iter, choice, prod_iter, values)`
+# where
+# - `comb_iter` is the iterator `combinations(1:n, k)`,
+# - `choice` is the current state of `comb_iter`,
+#   a vector that denotes the `k` pivot column positions in the matrix,
+# - `prod_iter` is an iterator of vectors, where the current vector
+#   corresponds to those entries in the not necessarily zero positions
+#   of the matrix that are not pivots, and
+# - `values` is the current state ot `prod_iter`.
+
+struct SubspacesIterator{T <: FinFieldElem}
+  V::AbstractAlgebra.Generic.AbstractAlgebra.Generic.FreeModule{T}
+  k::Int
+
+  function SubspacesIterator{T}(V, k) where T
+    @req 0 <= k <= vector_space_dim(V) "wrong dimension"
+    return new(V, k)
+  end
+end
+
+eltype(::SubspacesIterator{T}) where T = dense_matrix_type(T)
+
+function length(S::SubspacesIterator{T}) where T
+  n = vector_space_dim(S.V)
+  if n < 2 * S.k
+    k = n - S.k
+  else
+    k = S.k
+  end
+  q = order(base_ring(S.V))
+  size = one(q)
+  qn = q^n
+  qd = q
+  for i in 1:k
+    size = div(size * (qn-1), (qd-1))
+    qn = div(qn, q)
+    qd = qd * q
+  end
+  return BigInt(size)
+end
+
+function _matrix_for_subspaces_iterator(F, k, n, choice, values)
+  mat = zero_matrix(F, k, n)
+  o = one(F)
+  pos = 1
+  for i in 1:k
+    mat[i, choice[i]] = o
+    for j in (choice[i]+1):n
+      if !(j in choice)
+        mat[i,j] = values[pos]
+        pos = pos + 1
+      end
+    end
+  end
+  return mat
+end
+
+function Base.iterate(S::SubspacesIterator{T}) where T <: FinFieldElem
+  F = base_ring(S.V)
+  n = vector_space_dim(S.V)
+  k = S.k
+
+  comb = combinations(1:n, k)
+  choice, stat_comb = iterate(comb)
+
+  N = n*k - div(k*(k-1), 2) - sum(choice)
+  proditer = Base.Iterators.ProductIterator(Tuple([F for i in 1:N]))
+  prodval, prodstate = iterate(proditer)
+
+  mat = _matrix_for_subspaces_iterator(F, k, n, choice, prodval)
+  return mat, (comb, stat_comb, proditer, prodstate)
+end
+
+function Base.iterate(S::SubspacesIterator{T}, status::Tuple{Oscar.Combinations{UnitRange{Int}}, Vector{Int}, <:Base.Iterators.ProductIterator, <:Union{Tuple, Bool}}) where T <: FinFieldElem
+  F = base_ring(S.V)
+  n = vector_space_dim(S.V)
+  k = S.k
+
+  comb = status[1]
+  stat_comb = status[2]
+  choice = stat_comb
+  proditer = status[3]
+  prodstate = status[4]
+
+  next = iterate(proditer, prodstate)
+  if next === nothing
+    next = iterate(comb, choice)
+    next === nothing && return nothing
+    choice, stat_comb = next
+
+    N = n*k - div(k*(k-1), 2) - sum(choice)
+    proditer = Base.Iterators.ProductIterator(Tuple([F for i in 1:N]))
+    prodval, prodstate = iterate(proditer)
+  else
+    prodval, prodstate = next
+  end
+
+  mat = _matrix_for_subspaces_iterator(F, k, n, choice, prodval)
+  return mat, (comb, stat_comb, proditer, prodstate)
+end

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -275,6 +275,7 @@ include("Combinatorics/PartiallyOrderedSet/structs.jl")
 include("Combinatorics/PartiallyOrderedSet/functions.jl")
 
 include("PolyhedralGeometry/visualization.jl") # needs SimplicialComplex
+include("Groups/subspaces.jl") # needs EnumerativeCombinatorics
 
 include("StraightLinePrograms/StraightLinePrograms.jl")
 include("Rings/lazypolys.jl") # uses StraightLinePrograms

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -345,14 +345,27 @@ end
 
 end
 
+@testset "subspaces iterator" begin
+
+  @testset for F in [ GF(2), GF(3), GF(2,2) ], n in 2:4
+    V = vector_space(F, n)
+    for k in 0:n
+      itr = @inferred Oscar.bases_of_subspaces(V, k)
+      @test length(itr) == length(@inferred collect(itr))
+    end
+    @test_throws ArgumentError Oscar.bases_of_subspaces(V, n+1)
+  end
+
+end
+
 @testset "orbits of matrix groups over finite fields" begin
 
   @testset for F in [ GF(2), GF(3), GF(2,2) ], n in 2:4
     q = order(F)
     V = vector_space(F, n)
-    GL = general_linear_group(n, F)
-    S = sylow_subgroup(GL, 2)[1]
-    for G in [GL, S]
+    gl = general_linear_group(n, F)
+    S = sylow_subgroup(gl, 2)[1]
+    for G in [gl, S]
       for k in 0:n
         res = orbit_representatives_and_stabilizers(G, k)
         total = ZZ(0)


### PR DESCRIPTION
and change `orbit_representatives_and_stabilizers` such that the subspaces are computed using the new iterator (not using `GAP.Globals.Subspaces`)
and the orbits are computed in Julia (not in GAP)

This is a first step towards translating some computations with GAP's Fining package to Oscar; this was discussed during the recent GAP Days in Koper.

Possible changes:
- Logically, the code that implements the iterator could be moved to AbstractAlgebra, but the underlying iterator of combinations belongs to Oscar.
- We could change the code of the iterator to create only one matrix and to change it in place.
- The new `orbit_representatives_and_stabilizers` is not much faster than the old version that uses GAP; we have to improve this.

(addresses #4595)