### PR TITLE
TropicalGeometry: stable_intersection, added perturbation check

### DIFF
--- a/docs/src/TropicalGeometry/variety.md
+++ b/docs/src/TropicalGeometry/variety.md
@@ -43,7 +43,7 @@ is_pure(TropV::TropicalVariety)
 is_simplicial(TropV::TropicalVariety)
 rays(TropV::TropicalVariety)
 rays_modulo_lineality(TropV::TropicalVariety)
-stable_intersection(::Union{Tuple{minOrMax}, Tuple{Oscar.TropicalVarietySupertype{minOrMax, true}, Oscar.TropicalVarietySupertype{minOrMax, true}}, Tuple{Oscar.TropicalVarietySupertype{minOrMax, true}, Oscar.TropicalVarietySupertype{minOrMax, true}, Union{Nothing, Vector{Int64}}}} where minOrMax)
+stable_intersection(::TropicalVarietySupertype{minOrMax, true}, ::TropicalVarietySupertype{minOrMax, true}) where {minOrMax<:Union{typeof(max), typeof(min)}}
 tropical_prevariety
 vertices_and_rays(TropV::TropicalVariety)
 vertices(TropV::TropicalVariety)

--- a/src/TropicalGeometry/intersection.jl
+++ b/src/TropicalGeometry/intersection.jl
@@ -116,8 +116,8 @@ function intersect_after_lex_perturbation_with_intersection(sigma1::Polyhedron{Q
     V2, L2 = minimal_faces(sigma2)
     R1, _ = rays_modulo_lineality(sigma1)
     R2, _ = rays_modulo_lineality(sigma2)
-    V1p = Ref(p) .- V1
-    V2p = Ref(p) .- V2
+    V1p = V1 .- Ref(p)
+    V2p = V2 .- Ref(p)
     Cp12 = positive_hull(vcat(V1p,-V2p,R1,-R2), vcat(L1,L2))
 
     # and check whether u is contained in C_0(sigma1-sigma2) by checking that it

--- a/src/TropicalGeometry/intersection.jl
+++ b/src/TropicalGeometry/intersection.jl
@@ -103,9 +103,9 @@ function intersect_after_lex_perturbation_with_intersection(sigma1::Polyhedron{Q
     #   sigma1 and sigma2 (the correctness of this test requires sigma1 and
     #   sigma2 spannig the entire space)
     p = relative_interior_point(sigma12)
-    # if contains_in_interior(sigma1, p) && contains_in_interior(sigma2, p)
-    #     return true, sigma12
-    # end
+    if contains_in_interior(sigma1, p) && contains_in_interior(sigma2, p)
+        return true, sigma12
+    end
 
     ###
     # Actual test: check that u := ε¹·e₁+...+εⁿ·eₙ is in the tangent cone


### PR DESCRIPTION
Fixes a bug caused by the perturbation chosen for the stable intersection not being checked for genericity (meaning the perturbed polyhedral complexes intersect in too high dimension).  Bug found by @ac2368.