### PR TITLE
Elimination GB handling after f4

### DIFF
--- a/src/Rings/groebner/f4.jl
+++ b/src/Rings/groebner/f4.jl
@@ -65,7 +65,7 @@ function groebner_basis_f4(
       AR = base_ring(I)
     else
       vars = symbols(base_ring(I))[eliminate+1:end]
-      AR,  = polynomial_ring(coefficient_ring(I), vars)
+      AR,  = polynomial_ring(coefficient_ring(I), vars; cached=false)
     end
     ord  = degrevlex(AR)
     if length(AI.gens) == 0

--- a/src/Rings/groebner/f4.jl
+++ b/src/Rings/groebner/f4.jl
@@ -60,14 +60,15 @@ function groebner_basis_f4(
         info_level::Int=0
         )
 
-    AI = AlgebraicSolving.Ideal(oscar_generators(I))
-    vars = gens(base_ring(I))[eliminate+1:end]
-    ord = degrevlex(vars)
+    AI   = AlgebraicSolving.Ideal(oscar_generators(I))
+    vars = base_ring(I).S[eliminate+1:end]
+    AR,  = polynomial_ring(coefficient_ring(I), vars)
+    ord  = degrevlex(AR)
     if length(AI.gens) == 0
-        I.gb[ord]        = IdealGens(base_ring(I), singular_generators(I), complete_reduction)
-        I.gb[ord].ord    = ord
-        I.gb[ord].isGB   = true
-        I.gb[ord].S.isGB = true
+        GB = IdealGens(base_ring(I), singular_generators(I), complete_reduction)
+        GB.ord    = ord
+        GB..isGB  = true
+        GB.S.isGB = true
     else
         AlgebraicSolving.groebner_basis(AI,
                     initial_hts = initial_hts,
@@ -80,9 +81,12 @@ function groebner_basis_f4(
                     truncate_lifting = truncate_lifting,
                     info_level = info_level)
 
-        I.gb[ord] =
-            IdealGens(AI.gb[eliminate], ord, keep_ordering = false, isGB = true)
-        I.gb[ord].isReduced = complete_reduction
+        GB = IdealGens(AR, AI.gb[eliminate], ord, keep_ordering = false,
+                       isGB = true, isReduced = complete_reduction)
     end
-    return I.gb[ord]
+    if eliminate == 0
+      I.gb[ord] = GB
+    end
+
+    return GB
 end

--- a/src/Rings/groebner/f4.jl
+++ b/src/Rings/groebner/f4.jl
@@ -61,8 +61,12 @@ function groebner_basis_f4(
         )
 
     AI   = AlgebraicSolving.Ideal(oscar_generators(I))
-    vars = base_ring(I).S[eliminate+1:end]
-    AR,  = polynomial_ring(coefficient_ring(I), vars)
+    if eliminate == 0
+      AR = base_ring(I)
+    else
+      vars = symbols(base_ring(I))[eliminate+1:end]
+      AR,  = polynomial_ring(coefficient_ring(I), vars)
+    end
     ord  = degrevlex(AR)
     if length(AI.gens) == 0
         GB = IdealGens(base_ring(I), singular_generators(I), complete_reduction)

--- a/test/Rings/groebner.jl
+++ b/test/Rings/groebner.jl
@@ -228,13 +228,14 @@ end
   @test elements(H) == G
   @test isdefined(I, :gb)
   @test Oscar.oscar_generators(I.gb[degrevlex(gens(base_ring(I)))]) == G
+  @test length(I.gb) == 1
   H = groebner_basis_f4(I, eliminate=2);
   G = [x3^2*x4 + 73209671*x3*x4^2 + 260301051*x4^3 + 188447115*x3^2 + 167207272*x3*x4 + 120660383*x4^2 + 210590781*x3 + 109814506*x4
                 x3^3 + 156877866*x3*x4^2 + 59264971*x4^3 + 224858274*x3^2 + 183605206*x3*x4 + 130731555*x4^2 + 110395535*x3 + 158620953*x4
                 x4^4 + 167618101*x3*x4^2 + 102789335*x4^3 + 193931678*x3^2 + 156155981*x3*x4 + 60823186*x4^2 + 239040667*x3 + 127377432*x4
                 x3*x4^3 + 99215126*x3*x4^2 + 261328123*x4^3 + 132228634*x3^2 + 93598185*x3*x4 + 85654356*x4^2 + 3613010*x3 + 240673711*x4]
   @test elements(H) == G
-  @test Oscar.oscar_generators(I.gb[degrevlex(gens(base_ring(I))[3:end])]) == G
+  @test length(I.gb) == 1
 end
 
 @testset "fglm" begin


### PR DESCRIPTION
This solves the tangential issue of #5216: When an elimination ordering is used F4 now behaves as Singular and returns the elimination GB with the monomial ordering having the corresponding variables removed. No `gb` entry for the input ideal is generated.

Note: For the "real issue" of #5216 we prepare a new `msolve_jll` and `AlgebraicSolving.jl` in the next days.