### PR TITLE
Changelog script: multiple changelog entries for a single PR

### DIFF
--- a/.github/workflows/EnforceLabels.yml
+++ b/.github/workflows/EnforceLabels.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: yogevbd/enforce-label-action@2.2.2
       with:
-        REQUIRED_LABELS_ANY: "release notes: added,release notes: highlight,release notes: not needed,release notes: to be added,release notes: use title"
+        REQUIRED_LABELS_ANY: "release notes: added,release notes: highlight,release notes: not needed,release notes: to be added,release notes: use title,release notes: use body"
         REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label concerning release notes"
         BANNED_LABELS: "breaking,DO NOT MERGE,needs tests,WIP"
         BANNED_LABELS_DESCRIPTION: "A PR should not be merged with `DO NOT MERGE`, `breaking`, `needs tests`, or `WIP` labels"

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -167,10 +167,12 @@ def get_pr_list(date: str, extra: str) -> List[Dict[str, Any]]:
 def pr_to_md(pr: Dict[str, Any]) -> str:
     """Returns markdown string for the PR entry"""
     k = pr["number"]
-    title = pr["title"]
-    mdstring = f"- [#{k}](https://github.com/oscar-system/Oscar.jl/pull/{k}) {title}\n"
+    if has_label(pr, 'release notes: use body'):
+        mdstring = pr['body']
+    else:
+        title = pr["title"]
+        mdstring = f"- [#{k}](https://github.com/oscar-system/Oscar.jl/pull/{k}) {title}\n"
     if has_label(pr,'release notes: use body'):
-        mdstring = body_to_release_notes(pr)
         mdstring = mdstring.replace("- ", f"- [#{k}](https://github.com/oscar-system/Oscar.jl/pull/{k}) ")
     return mdstring
 
@@ -181,7 +183,7 @@ def body_to_release_notes(pr):
         ## not found
         ## complain and return fallback
         print(f"Release notes section not found in PR number {pr['number']}!!")
-        return mdstring
+        return body
     index2 = body.find('---', index1)
     # there are 17 characters from index 1 until the next line
     mdstring = body[index1+17:index2]
@@ -356,7 +358,7 @@ def split_pr_into_changelog(prs: List):
                     cpr['labels'].append({'name': label})
                 mindex = mans.span()[0]
                 line = line[0:mindex]
-                cpr['body'] = f'---\r\n## Release Notes\r\n{line}\r\n---'
+                cpr['body'] = f'{line.strip()}\n'
                 childprlist.append(cpr)
             toremovelist.append(pr)
     prs.extend(childprlist)

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -168,7 +168,7 @@ def pr_to_md(pr: Dict[str, Any]) -> str:
     """Returns markdown string for the PR entry"""
     k = pr["number"]
     if has_label(pr, 'release notes: use body'):
-        mdstring = pr["body"].replace(r'^- ', f"- [#{k}](https://github.com/oscar-system/Oscar.jl/pull/{k}) ")
+        mdstring = re.sub(r'^- ', f"- [#{k}](https://github.com/oscar-system/Oscar.jl/pull/{k}) ", pr["body"])
     else:
         title = pr["title"]
         mdstring = f"- [#{k}](https://github.com/oscar-system/Oscar.jl/pull/{k}) {title}\n"        

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -214,7 +214,7 @@ def changes_overview(
     notice("Writing release notes into file " + newfile)
     with open(newfile, "w", encoding="utf-8") as relnotes_file:
         prs_with_use_title = [
-            pr for pr in prs if has_label(pr, "release notes: use title")
+            pr for pr in prs if has_label(pr, "release notes: use title") or has_label(pr, "release notes: use body")
         ]
         # Write out all PRs with 'use title'
         relnotes_file.write(
@@ -321,6 +321,7 @@ which we think might affect some users directly.
         prs = [pr for pr in prs if not has_label(pr, "release notes: to be added")]
         prs = [pr for pr in prs if not has_label(pr, "release notes: added")]
         prs = [pr for pr in prs if not has_label(pr, "release notes: use title")]
+        prs = [pr for pr in prs if not has_label(pr, "release notes: use body")]
 
         # Report PRs that have neither "to be added" nor "added" or "use title" label
         if len(prs) > 0:

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -182,9 +182,9 @@ def body_to_release_notes(pr):
         ## complain and return fallback
         print(f"Release notes section not found in PR number {pr['number']}!!")
         return body
-    index2 = body.find('---', index1)
-    # there are 17 characters from index 1 until the next line
-    mdstring = body[index1+17:index2]
+    index2 = body.find('\n', index1) + 1 # the first line after the release notes line
+    index3 = body.find('---', index1) # the end of release notes section, mandeted by syntax
+    mdstring = body[index2:index3]
     return mdstring
 
 

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -168,7 +168,7 @@ def pr_to_md(pr: Dict[str, Any]) -> str:
     """Returns markdown string for the PR entry"""
     k = pr["number"]
     if has_label(pr, 'release notes: use body'):
-        mdstring = pr['body'].replace("- ", f"- [#{k}](https://github.com/oscar-system/Oscar.jl/pull/{k}) ")
+        mdstring = pr["body"].replace('- ', f"- [#{k}](https://github.com/oscar-system/Oscar.jl/pull/{k}) ", 1)
     else:
         title = pr["title"]
         mdstring = f"- [#{k}](https://github.com/oscar-system/Oscar.jl/pull/{k}) {title}\n"        

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -352,24 +352,24 @@ def split_pr_into_changelog(prs: List):
             mdlines = mdstring.split('\n')
             pattern = r'\{.*\}$'
             for line in mdlines:
+                cpr = copy.deepcopy(pr)
                 mans = re.search(pattern, line)
-                if not mans:
-                    # maybe actually raise an error instead of just continue
+                if mans:
+                    label_list = mans.group().strip('{').strip('}').split(',')
+                    for label in label_list:
+                        label = label.strip()
+                        if not (label in prtypes or label in topics):
+                            warning(f"PR number #{pr['number']}'s changelog body has label {label}, "
+                                    "which is not a label we recognize ! We are ignoring this label. "
+                                    "This might result in a TODO changelog item!")
+                            continue
+                        cpr['labels'].append({'name': label})
+                    mindex = mans.span()[0]
+                    line = line[0:mindex]
+                    pass
+                else:
                     warning(f"PR number #{pr['number']} is tagged as \"Use Body\", but the body "
                             "does not provide tags! This will result in TODO changelog items!")
-                    continue
-                label_list = mans.group().strip('{').strip('}').split(',')
-                cpr = copy.deepcopy(pr)
-                for label in label_list:
-                    label = label.strip()
-                    if not (label in prtypes or label in topics):
-                        warning(f"PR number #{pr['number']}'s changelog body has label {label}, "
-                                "which is not a label we recognize ! We are ignoring this label. "
-                                "This might result in a TODO changelog item!")
-                        continue
-                    cpr['labels'].append({'name': label})
-                mindex = mans.span()[0]
-                line = line[0:mindex]
                 cpr['body'] = f'{line.strip()}\n'
                 childprlist.append(cpr)
                 if pr not in toremovelist:

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -183,8 +183,18 @@ def body_to_release_notes(pr):
         print(f"Release notes section not found in PR number {pr['number']}!!")
         return body
     index2 = body.find('\n', index1) + 1 # the first line after the release notes line
-    index3 = body.find('---', index1) # the end of release notes section, mandeted by syntax
-    mdstring = body[index2:index3]
+    bodylines = body[index2:].splitlines()
+    mdstring = ""
+    for line in bodylines:
+        line = line.rstrip()
+        if not line:
+            continue
+        elif line.startswith('- '):
+            mdstring = f"{mdstring}\n{line}"
+        else:
+            break
+    if not mdstring:
+        warning(f"Empty release notes section for PR #{pr['number']} !")
     return mdstring
 
 
@@ -339,7 +349,7 @@ def split_pr_into_changelog(prs: List):
     for pr in prs:
         if has_label(pr, 'release notes: use body'):
             mdstring = body_to_release_notes(pr).strip()
-            mdlines = mdstring.split('\r\n')
+            mdlines = mdstring.split('\n')
             pattern = r'\{.*\}$'
             for line in mdlines:
                 mans = re.search(pattern, line)

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -153,7 +153,7 @@ def get_pr_list(date: str, extra: str) -> List[Dict[str, Any]]:
             "--json",
             "number,title,closedAt,labels,mergedAt,body",
             "--limit",
-            "1",
+            "200",
         ],
         check=True,
         capture_output=True,

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -168,12 +168,10 @@ def pr_to_md(pr: Dict[str, Any]) -> str:
     """Returns markdown string for the PR entry"""
     k = pr["number"]
     if has_label(pr, 'release notes: use body'):
-        mdstring = pr['body']
+        mdstring = pr['body'].replace("- ", f"- [#{k}](https://github.com/oscar-system/Oscar.jl/pull/{k}) ")
     else:
         title = pr["title"]
-        mdstring = f"- [#{k}](https://github.com/oscar-system/Oscar.jl/pull/{k}) {title}\n"
-    if has_label(pr,'release notes: use body'):
-        mdstring = mdstring.replace("- ", f"- [#{k}](https://github.com/oscar-system/Oscar.jl/pull/{k}) ")
+        mdstring = f"- [#{k}](https://github.com/oscar-system/Oscar.jl/pull/{k}) {title}\n"        
     return mdstring
 
 def body_to_release_notes(pr):

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -168,7 +168,7 @@ def pr_to_md(pr: Dict[str, Any]) -> str:
     """Returns markdown string for the PR entry"""
     k = pr["number"]
     if has_label(pr, 'release notes: use body'):
-        mdstring = pr["body"].replace('- ', f"- [#{k}](https://github.com/oscar-system/Oscar.jl/pull/{k}) ", 1)
+        mdstring = pr["body"].replace(r'^- ', f"- [#{k}](https://github.com/oscar-system/Oscar.jl/pull/{k}) ")
     else:
         title = pr["title"]
         mdstring = f"- [#{k}](https://github.com/oscar-system/Oscar.jl/pull/{k}) {title}\n"        

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -345,20 +345,25 @@ def split_pr_into_changelog(prs: List):
                 mans = re.search(pattern, line)
                 if not mans:
                     # maybe actually raise an error instead of just continue
+                    warning(f"PR number #{pr['number']} is tagged as \"Use Body\", but the body "
+                            "does not provide tags! This will result in TODO changelog items!")
                     continue
                 label_list = mans.group().strip('{').strip('}').split(',')
                 cpr = copy.deepcopy(pr)
                 for label in label_list:
                     label = label.strip()
                     if not (label in prtypes or label in topics):
-                        # error
-                        exit()
+                        warning(f"PR number #{pr['number']}'s changelog body has label {label}, "
+                                "which is not a label we recognize ! We are ignoring this label. "
+                                "This might result in a TODO changelog item!")
+                        continue
                     cpr['labels'].append({'name': label})
                 mindex = mans.span()[0]
                 line = line[0:mindex]
                 cpr['body'] = f'{line.strip()}\n'
                 childprlist.append(cpr)
-            toremovelist.append(pr)
+                if pr not in toremovelist:
+                    toremovelist.append(pr)
     prs.extend(childprlist)
     prlist = [pr for pr in prs if pr not in toremovelist]
     return prlist

--- a/docs/src/DeveloperDocumentation/changelog.md
+++ b/docs/src/DeveloperDocumentation/changelog.md
@@ -58,12 +58,12 @@ labelled. We have the following labels, along with how they are meant to be appl
 
 #### Release Notes: Use Body
 
-It is possible to manually supply release notes in the body of the PR (the first
-comment in the PR). To do this, make a section in your PR title by putting a
-second level heading named `Release Notes` between two horizontal lines, then
-adding release note entries as a list. This allows for having multiple entries
-in the changelog for a single PR. It is possible to label each of the entries
-with their own topic / pr type labels.
+It is possible to manually supply release notes in the body of the PR (the body of the PR is the
+first comment in the PR, created at the same time as the PR is created; it is also sometimes call
+the "description" of the PR). To do this, make a section in your PR body by putting a second level
+heading named `Release Notes` between two horizontal lines, then adding release note entries as a
+list. This allows for having multiple entries in the changelog for a single PR. It is possible to
+label each of the entries with their own topic / pr type labels.
 
 The syntax is the following :
 

--- a/docs/src/DeveloperDocumentation/changelog.md
+++ b/docs/src/DeveloperDocumentation/changelog.md
@@ -53,7 +53,62 @@ labelled. We have the following labels, along with how they are meant to be appl
 | `release notes: not needed`   | This PR does not warrant an entry in the release notes. Internal only changes, like reorganization of private functions, changes to the test pipeline, etc can be tagged with this |
 | `release notes: use title`    | The release notes for this PR should be based on the title of this PR. The script will turn \$TITLE from the PR to `[#xyz] $TITLE` |
 | `release notes: to be added`  | These PRs will be marked by the script as a prominent TODO item. Check these PRs manually, and after updating them appropriately, relabel these items to either `release notes: added` or `release notes: use title` |
+| `release notes: use body` | The changelog notes for this PR have been supplied in the body of the PR. Check [Release Notes: Use Body](#Release-Notes:-Use-Body) for documentation of the exact syntax. |
 | none of the above             | These PRs will be added to a separate prominent TODO category. Check these PRs manually, and after updating them appropriately, relabel these items to one of `release notes: added`, `release notes: use title`, or `release notes: not needed` |
+
+#### Release Notes: Use Body
+
+It is possible to manually supply release notes in the body of the PR (the first
+comment in the PR). To do this, make a section in your PR title by putting a
+second level heading named `Release Notes` between two horizontal lines, then
+adding release note entries as a list. This allows for having multiple entries
+in the changelog for a single PR. It is possible to label each of the entries
+with their own topic / pr type labels.
+
+The syntax is the following :
+
+```md
+---
+## Release Notes
+- item1 {label1, label2}
+- item2 {label3, label4, label5}
+- item3 {label5}
+
+---
+```
+
+As an example, the following body in the PR is rendered as follows :
+
+```md
+---
+## Release Notes
+- Does abc {package: AbstractAlgebra, renaming}
+- Does 123 {package: Nemo, documentation}
+- Questions 42 {package: Singular, serialization}
+
+---
+```
+
+>
+> ### Changes related to the package AbstractAlgebra
+> 
+> #### Renamings
+> 
+> - [#nnnn](https://github.com/oscar-system/Oscar.jl/pull/nnnn) Does abc
+> 
+> ### Changes related to the package Nemo
+> 
+> #### Improvements or additions to documentation
+> 
+> - [#nnnn](https://github.com/oscar-system/Oscar.jl/pull/nnnn) Does 123
+> 
+> ### Changes related to the package Singular
+> 
+> #### Changes related to serializing data in the MRDI file format
+> 
+> - [#nnnn](https://github.com/oscar-system/Oscar.jl/pull/nnnn) Questions 42
+>
+
 
 ### Secondary Labels: Topic
 

--- a/docs/src/DeveloperDocumentation/changelog.md
+++ b/docs/src/DeveloperDocumentation/changelog.md
@@ -75,7 +75,7 @@ The syntax is the following:
 - item3 {label5}
 ```
 
-As an example, the following body in the PR is rendered as follows :
+As an example, consider the following body of a hypothetical PR with number `nnnn`:
 
 ```md
 ## Release Notes
@@ -83,6 +83,8 @@ As an example, the following body in the PR is rendered as follows :
 - Does 123 {package: Nemo, documentation}
 - Questions 42 {package: Singular, serialization}
 ```
+
+That body would result in the following changelog content:
 
 >
 > ### Changes related to the package AbstractAlgebra

--- a/docs/src/DeveloperDocumentation/changelog.md
+++ b/docs/src/DeveloperDocumentation/changelog.md
@@ -65,7 +65,7 @@ heading named `Release Notes` between two horizontal lines, then adding release 
 list. This allows for having multiple entries in the changelog for a single PR. It is possible to
 label each of the entries with their own topic / pr type labels.
 
-The syntax is the following :
+The syntax is the following:
 
 ```md
 ---

--- a/docs/src/DeveloperDocumentation/changelog.md
+++ b/docs/src/DeveloperDocumentation/changelog.md
@@ -61,32 +61,27 @@ labelled. We have the following labels, along with how they are meant to be appl
 It is possible to manually supply release notes in the body of the PR (the body of the PR is the
 first comment in the PR, created at the same time as the PR is created; it is also sometimes call
 the "description" of the PR). To do this, make a section in your PR body by putting a second level
-heading named `Release Notes` between two horizontal lines, then adding release note entries as a
-list. This allows for having multiple entries in the changelog for a single PR. It is possible to
-label each of the entries with their own topic / pr type labels.
+heading named `Release Notes`, then adding release note entries as a list. This allows for having
+multiple entries in the changelog for a single PR. It is possible to label each of the entries with
+their own topic / pr type labels.
 
 The syntax is the following:
 
 ```md
----
+
 ## Release Notes
 - item1 {label1, label2}
 - item2 {label3, label4, label5}
 - item3 {label5}
-
----
 ```
 
 As an example, the following body in the PR is rendered as follows :
 
 ```md
----
 ## Release Notes
 - Does abc {package: AbstractAlgebra, renaming}
 - Does 123 {package: Nemo, documentation}
 - Questions 42 {package: Singular, serialization}
-
----
 ```
 
 >


### PR DESCRIPTION
Resolves #4673

Requires #5271 , https://github.com/oscar-system/Oscar.jl/pull/5560 (mostly, just for commit https://github.com/oscar-system/Oscar.jl/pull/5560/commits/668c8e9e16488311b872bf64d356cb48d8b1ade2 )

Turns the following body into the even more following changelog entries :

```
---
## Release Notes
- Does abc {package: AbstractAlgebra}
- Does 123 {package: Nemo}
- Questions 42 {package: Singular}
---
```

```
#### Changes related to the package AbstractAlgebra


- [#5271](https://github.com/oscar-system/Oscar.jl/pull/5271) Does abc 

#### Changes related to the package Nemo


- [#5271](https://github.com/oscar-system/Oscar.jl/pull/5271) Does 123 

#### Changes related to the package Singular


- [#5271](https://github.com/oscar-system/Oscar.jl/pull/5271) Questions 42 
```