### PR TITLE
Make some group tests more future-proof

### DIFF
--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -38,6 +38,9 @@ GAP.@wrap CharacterParameters(x::GapObj)::GapObj
 GAP.@wrap CharacterTable(x::GapObj)::GapObj
 GAP.@wrap CharacterTable(x::GapObj, y::GAP.Obj)::GapObj
 GAP.@wrap CharacterTableFactorGroup(x::GapObj, y::GapObj)::GapObj
+GAP.@wrap CharacterTableWithSortedCharacters(x::GapObj, y::GapObj)::GapObj
+GAP.@wrap CharacterTableWithSortedCharacters(x::GapObj)::GapObj
+GAP.@wrap CharacterTableWithSortedClasses(x::GapObj)::GapObj
 GAP.@wrap CharacterTableWreathSymmetric(x::GapObj, y::GapInt)::GapObj
 GAP.@wrap CHAR_FFE_DEFAULT(x::Any)::GapInt
 GAP.@wrap ClassFunction(x::GapObj, y::GapObj)::GapObj
@@ -383,6 +386,7 @@ GAP.@wrap SizesCentralizers(x::GapObj)::GapObj
 GAP.@wrap SizesConjugacyClasses(x::GapObj)::GapObj
 GAP.@wrap SLPforElement(x::GapObj, y::GapObj)::GAP.Obj
 GAP.@wrap SmallestMovedPoint(x::Any)::GapInt
+GAP.@wrap SortingPerm(x::GapObj)::GapObj
 GAP.@wrap Source(x::GapObj)::GapObj
 GAP.@wrap Sqrt(x::Int64)::GAP.Obj
 GAP.@wrap Stabilizer(v::GapObj, w::Any, x::GapObj, y::GapObj, z::GapObj)::GapObj

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -1000,15 +1000,21 @@ end
 
 ##############################################################################
 #
-#  for tests: sort a given character table heuristically,
-#  in order to achieve a more stable ordering of rows and columns
+#  only for tests:
+#  Sort a given character table heuristically,
+#  in order to achieve a more stable ordering of rows and columns.
+#  Note that the ordering of columns depends on the method that was chosen
+#  for computing the conjugacy classes of the group,
+#  and the ordering of rows depends on the method that was chosen to compute
+#  the irreducible characters.
 #
-function _sort(tbl::GAPGroupCharacterTable)
+function _sort_for_stable_tests(tbl::GAPGroupCharacterTable)
   @req is_zero(characteristic(tbl)) "only for ordinary character tables"
-  sorttbl = GAP.Globals.CharacterTableWithSortedClasses(GapObj(tbl))::GapObj
-  pi = GAP.Globals.SortingPerm(GAP.Globals.Irr(sorttbl))::GapObj
-  sorttbl = GAP.Globals.CharacterTableWithSortedCharacters(sorttbl, pi)::GapObj
-  sorttbl = GAP.Globals.CharacterTableWithSortedCharacters(sorttbl)::GapObj
+  sorttbl = GAPWrap.CharacterTableWithSortedClasses(GapObj(tbl))
+  pi = GAPWrap.SortingPerm(GAPWrap.Irr(sorttbl))
+  sorttbl = GAPWrap.CharacterTableWithSortedCharacters(sorttbl, pi)
+  # The trivial character shall be at the first position.
+  sorttbl = GAPWrap.CharacterTableWithSortedCharacters(sorttbl)
 
   res = GAPGroupCharacterTable(sorttbl, 0)
   if isdefined(tbl, :group)

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -1000,6 +1000,28 @@ end
 
 ##############################################################################
 #
+#  for tests: sort a given character table heuristically,
+#  in order to achieve a more stable ordering of rows and columns
+#
+function _sort(tbl::GAPGroupCharacterTable)
+  @req is_zero(characteristic(tbl)) "only for ordinary character tables"
+  sorttbl = GAP.Globals.CharacterTableWithSortedClasses(GapObj(tbl))::GapObj
+  pi = GAP.Globals.SortingPerm(GAP.Globals.Irr(sorttbl))::GapObj
+  sorttbl = GAP.Globals.CharacterTableWithSortedCharacters(sorttbl, pi)::GapObj
+  sorttbl = GAP.Globals.CharacterTableWithSortedCharacters(sorttbl)::GapObj
+
+  res = GAPGroupCharacterTable(sorttbl, 0)
+  if isdefined(tbl, :group)
+    res.group = tbl.group
+    res.isomorphism = tbl.isomorphism
+  end
+
+  return res
+end
+
+
+##############################################################################
+#
 length(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(GapObj(tbl))::Int
 number_of_rows(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(GapObj(tbl))::Int
 number_of_columns(tbl::GAPGroupCharacterTable) = GAPWrap.NrConjugacyClasses(GapObj(tbl))::Int
@@ -1081,7 +1103,7 @@ stored on these tables.
 julia> println(maxes(character_table("M11")))
 ["A6.2_3", "L2(11)", "3^2:Q8.2", "A5.2", "2.S4"]
 
-julia> maxes(character_table("M")) === nothing  # not (yet) known
+julia> maxes(character_table("O12+(3)")) === nothing  # not (yet) known
 true
 ```
 """
@@ -2863,7 +2885,7 @@ the values of `chi`.
 
 # Examples
 ```jldoctest
-julia> tbl = character_table(alternating_group(4));
+julia> tbl = character_table("A4");
 
 julia> println([findfirst(==(conj(x)), tbl) for x in tbl])
 [1, 3, 2, 4]

--- a/src/Groups/libraries/primitivegroups.jl
+++ b/src/Groups/libraries/primitivegroups.jl
@@ -11,7 +11,7 @@ Currently the number of primitive permutation groups is available up to degree 4
 julia> has_number_of_primitive_groups(50)
 true
 
-julia> has_number_of_primitive_groups(5000)
+julia> has_number_of_primitive_groups(10000)
 false
 ```
 """

--- a/src/Groups/libraries/primitivegroups.jl
+++ b/src/Groups/libraries/primitivegroups.jl
@@ -30,7 +30,7 @@ Currently identification is available for all primitive permutation groups up to
 julia> has_primitive_group_identification(50)
 true
 
-julia> has_primitive_group_identification(5000)
+julia> has_primitive_group_identification(10000)
 false
 ```
 """
@@ -49,7 +49,7 @@ Currently all primitive permutation groups up to degree 4095 are available.
 julia> has_primitive_groups(50)
 true
 
-julia> has_primitive_groups(5000)
+julia> has_primitive_groups(10000)
 false
 ```
 """
@@ -69,8 +69,8 @@ up to permutation isomorphism.
 julia> number_of_primitive_groups(10)
 9
 
-julia> number_of_primitive_groups(4096)
-ERROR: ArgumentError: the number of primitive permutation groups of degree 4096 is not available
+julia> number_of_primitive_groups(10000)
+ERROR: ArgumentError: the number of primitive permutation groups of degree 10000 is not available
 [...]
 ```
 """
@@ -135,8 +135,8 @@ julia> m = primitive_group_identification(S)
 julia> order(primitive_group(m...)) == order(S)
 true
 
-julia> primitive_group_identification(symmetric_group(4096))
-ERROR: ArgumentError: identification of primitive permutation groups of degree 4096 is not available
+julia> primitive_group_identification(symmetric_group(10000))
+ERROR: ArgumentError: identification of primitive permutation groups of degree 10000 is not available
 [...]
 
 julia> S = sub(G, [perm([1,3,4,5,2,7,6])])[1];

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -9,9 +9,9 @@ raw"""
 ```jldoctest group_characters.test
 julia> using Oscar
 
-julia> t_a4 = character_table(alternating_group(4));
+julia> t_a4 = Oscar._sort(character_table(alternating_group(4)));
 
-julia> t_a5 = character_table("A5");
+julia> t_a5 = Oscar._sort(character_table("A5"));
 
 julia> t_a4_2 = mod(t_a4, 2);
 

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -9,9 +9,9 @@ raw"""
 ```jldoctest group_characters.test
 julia> using Oscar
 
-julia> t_a4 = Oscar._sort(character_table(alternating_group(4)));
+julia> t_a4 = Oscar._sort_for_stable_tests(character_table(alternating_group(4)));
 
-julia> t_a5 = Oscar._sort(character_table("A5"));
+julia> t_a5 = Oscar._sort_for_stable_tests(character_table("A5"));
 
 julia> t_a4_2 = mod(t_a4, 2);
 

--- a/test/book/specialized/boehm-breuer-git-fans/explG25_5.jlcon
+++ b/test/book/specialized/boehm-breuer-git-fans/explG25_5.jlcon
@@ -7,8 +7,8 @@ ZZRingElem[20, 110, 240, 225, 76]
 julia> c = cones(fanobj, 5)[1]
 Polyhedral cone in ambient dimension 5
 
-julia> rays(c)
-5-element SubObjectIterator{RayVector{QQFieldElem}}:
+julia> sort(rays(c))
+5-element Vector{RayVector{QQFieldElem}}:
  [0, 1, 0, 0, -1]
  [1, 0, 1, 1, 0]
  [1, 1, 0, 0, 0]

--- a/test/book/specialized/boehm-breuer-git-fans/explG25_5.jlcon
+++ b/test/book/specialized/boehm-breuer-git-fans/explG25_5.jlcon
@@ -7,8 +7,8 @@ ZZRingElem[20, 110, 240, 225, 76]
 julia> c = cones(fanobj, 5)[1]
 Polyhedral cone in ambient dimension 5
 
-julia> sort(rays(c))
-5-element Vector{RayVector{QQFieldElem}}:
+julia> rays(c)
+5-element SubObjectIterator{RayVector{QQFieldElem}}:
  [0, 1, 0, 0, -1]
  [1, 0, 1, 1, 0]
  [1, 1, 0, 0, 0]


### PR DESCRIPTION
Make tests more robust against changed orderings on the GAP side, due to a new version of GAP (cf https://github.com/oscar-system/GAP.jl/pull/1244#issuecomment-3270461010)

And remove a special `sub` method for `MatrixGroup`, which was worse than the generic method.