### PR TITLE
Require simplicial, projective toric varieties in the current cohomCalg implementation; update input tests.

### DIFF
--- a/docs/src/AlgebraicGeometry/ToricVarieties/cohomCalg.md
+++ b/docs/src/AlgebraicGeometry/ToricVarieties/cohomCalg.md
@@ -10,6 +10,12 @@ DocTestSetup = Oscar.doctestsetup()
 We employ the cohomCalg algorithm [BJRR10*1](@cite)
 to compute the dimension of line bundle cohomologies as well as vanishing sets.
 
+!!! note "Simplicial and Projective Toric Varieties"
+    In theory, the cohomCalg algorithm works for all smooth, complete as well as all
+    simplicial, projective toric varieties [RR10](@cite), [Jow11](@cite). However, the implementation in [BJRR10*1](@cite) is limited to the
+    simplicial, projective case due to its handling of the secondary cohomologies. As such, all
+    functions that rely on calls to cohomCalg are limited to **simplicial, projective toric varieties**.
+
 
 ## Dimensions of line bundle cohomology
 

--- a/src/AlgebraicGeometry/ToricVarieties/cohomCalg/VanishingSets/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/cohomCalg/VanishingSets/attributes.jl
@@ -19,7 +19,7 @@ julia> vs = vanishing_sets(dP1)
  Toric vanishing set for cohomology indices [2]
 
 julia> toric_variety(vs[3])
-Normal, 2-dimensional toric variety without torusfactor
+Normal, simplicial, projective, 2-dimensional toric variety without torusfactor
 ```
 """
 toric_variety(tvs::ToricVanishingSet) = tvs.toric_variety


### PR DESCRIPTION
## Release notes

* [#5287](https://github.com/oscar-system/Oscar.jl/pull/5287) **breaking** Require simplicial, projective toric varieties in the current cohomCalg implementation; update input tests.

## Comments

* Based on https://github.com/oscar-system/Oscar.jl/pull/5284 for my convenience.
* Preview: https://docs.oscar-system.org/previews/PR5287

cc @emikelsons 