### PR TITLE
request recursive GAP to Julia conversion where necessary

### DIFF
--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -891,7 +891,7 @@ function Base.show(io::IO, ::MIME"text/plain", tbl::GAPGroupCharacterTable)
 
     # Compute display format for power maps.
     names = class_names(tbl)
-    pmaps = Vector{Any}(GAPWrap.ComputedPowerMaps(gaptbl))
+    pmaps = Vector{Any}(GAPWrap.ComputedPowerMaps(gaptbl), recursive = true)
     power_maps_primes = String[]
     power_maps_strings = Vector{String}[]
     for i in 2:length(pmaps)


### PR DESCRIPTION
Recursive conversion used to be the default for the direction from GAP to Julia, but this may get changed in GAP.jl, see oscar-system/GAP.jl/pull/1238.
With the proposed change, the default becomes irrelevant.