### PR TITLE
Git blame ignores formatting toric varieties code

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -10,3 +10,6 @@ e71dcb305491f26d13225c0339e2e22129bb27f3
 
 # Reformatting after option change
 38d9450f0514b307ed9358999e71e9b1929f532e
+
+# Formatting the toric varieties code
+4545aa1075c482d02bc42c0d11cff248231c5b94


### PR DESCRIPTION
As requested in https://github.com/oscar-system/Oscar.jl/pull/5308 by @lgoettgens .