### PR TITLE
fix access to a `Fac` object

### DIFF
--- a/src/Rings/FinField.jl
+++ b/src/Rings/FinField.jl
@@ -28,7 +28,7 @@ end
 function is_primitive(a::FinFieldElem, f::Fac{ZZRingElem} = factored_order(parent(a)))
   iszero(a) && return false
   n = size(parent(a))-1
-  for p = keys(f.fac)
+  for (p, _) in f
     if a^divexact(n, p) == 1
       return false
     end

--- a/test/Rings/FinField.jl
+++ b/test/Rings/FinField.jl
@@ -1,0 +1,10 @@
+@testset "Finite fields, discrete logarithm" begin
+  F, z = finite_field(2, 4)
+  @test is_primitive(z^2)
+  @test !is_primitive(z^3)
+  @test is_primitive(Oscar.DiscLog.generator(F))
+  @test [disc_log(z, z^i) for i in 1:14] == 1:14
+  @test disc_log(z, z^15) == 0
+  @test disc_log(z^2, z) == 8
+  @test_throws "disc_log failed" disc_log(z, zero(z))
+end


### PR DESCRIPTION
Apparently the `fac` field is (often) not defined. According to the documentation,
it is recommended to use the object as an iterator.