### PR TITLE
Remove Oscar.aadir, .nemodir, .heckedir, .singulardir

### DIFF
--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -116,11 +116,7 @@ function doit(
   )
 
   # Copy documentation from Hecke, Nemo, AbstractAlgebra
-  other_packages = [
-    (Oscar.Hecke, Oscar.heckedir),
-    (Oscar.Nemo, Oscar.nemodir),
-    (Oscar.AbstractAlgebra, Oscar.aadir),
-  ]
+  other_packages = [Oscar.Hecke, Oscar.Nemo, Oscar.AbstractAlgebra]
   for (pkg, pkgdir) in other_packages
     srcbase = normpath(pkgdir, "docs", "src")
     dstbase = normpath(Oscar.oscardir, "docs", "src", string(nameof(pkg)))
@@ -193,10 +189,10 @@ function doit(
       checkdocs=:none,
       pages=doc,
       remotes=Dict(
-        Oscar.aadir => (Remotes.GitHub("Nemocas", "AbstractAlgebra.jl"), aarev),
-        Oscar.nemodir => (Remotes.GitHub("Nemocas", "Nemo.jl"), nemorev),
-        Oscar.heckedir => (Remotes.GitHub("thofma", "Hecke.jl"), heckerev),
-        Oscar.singulardir => (Remotes.GitHub("oscar-system", "Singular.jl"), singularrev),
+        Base.pkgdir(Oscar.AbstractAlgebra) => (Remotes.GitHub("Nemocas", "AbstractAlgebra.jl"), aarev),
+        Base.pkgdir(Oscar.Nemo) => (Remotes.GitHub("Nemocas", "Nemo.jl"), nemorev),
+        Base.pkgdir(Oscar.Hecke) => (Remotes.GitHub("thofma", "Hecke.jl"), heckerev),
+        Base.pkgdir(Oscar.Singular) => (Remotes.GitHub("oscar-system", "Singular.jl"), singularrev),
       ),
       plugins=[bib],
     )

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -117,8 +117,8 @@ function doit(
 
   # Copy documentation from Hecke, Nemo, AbstractAlgebra
   other_packages = [Oscar.Hecke, Oscar.Nemo, Oscar.AbstractAlgebra]
-  for (pkg, pkgdir) in other_packages
-    srcbase = normpath(pkgdir, "docs", "src")
+  for pkg in other_packages
+    srcbase = normpath(Base.pkgdir(pkg), "docs", "src")
     dstbase = normpath(Oscar.oscardir, "docs", "src", string(nameof(pkg)))
 
     # clear the destination directory first
@@ -199,7 +199,7 @@ function doit(
   end
 
   # remove the copied documentation again
-  for (pkg, pkgdir) in other_packages
+  for pkg in other_packages
     dstbase = normpath(Oscar.oscardir, "docs", "src", string(nameof(pkg)))
     rm(dstbase; recursive=true, force=true)
   end

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -2,10 +2,6 @@ const cornerstones = String["AbstractAlgebra", "GAP", "Hecke", "Nemo", "Polymake
 const jll_deps = String["FLINT_jll", "GAP_jll", "GAP_lib_jll",
                         "libpolymake_julia_jll", "libsingular_julia_jll",
                         "polymake_jll", "polymake_oscarnumber_jll", "Singular_jll"];
-const aadir = Base.pkgdir(AbstractAlgebra)
-const nemodir = Base.pkgdir(Nemo)
-const heckedir = Base.pkgdir(Hecke)
-const singulardir = Base.pkgdir(Singular)
 
 include("versioninfo.jl")
 include("docs.jl")


### PR DESCRIPTION
I could not see any reason why they might be beneficial. They certainly make some code non-local, so harder to reason about for both humans and tools like JET (not that it matters for JET here, as they are used only for building the documentation).

(Disclaimer: it's my fault those exist in the first place, as I introduced them in 43ea5fd52bfe611c03ee798deed4a0268f5dd480)