### PR TITLE
Rename variable in an example

### DIFF
--- a/docs/src/Groups/fpgroup.md
+++ b/docs/src/Groups/fpgroup.md
@@ -48,13 +48,13 @@ then one chooses these defining relators, and then calls
 [`quo(G::T, elements::Vector{S}) where T <: GAPGroup where S <: GAPGroupElem`](@ref).
 
 ```jldoctest fpgroupxpl
-julia> rels = [f1^2, f2^3, f1*f2*f1*f2^2]
+julia> rela = [f1^2, f2^3, f1*f2*f1*f2^2]
 3-element Vector{FPGroupElem}:
  f1^2
  f2^3
  (f1*f2)^2*f2
 
-julia> G, epi = quo(F, rels)
+julia> G, epi = quo(F, rela)
 (Finitely presented group, Hom: F -> G)
 
 julia> gens(G)

--- a/docs/src/Groups/fpgroup.md
+++ b/docs/src/Groups/fpgroup.md
@@ -48,13 +48,13 @@ then one chooses these defining relators, and then calls
 [`quo(G::T, elements::Vector{S}) where T <: GAPGroup where S <: GAPGroupElem`](@ref).
 
 ```jldoctest fpgroupxpl
-julia> rela = [f1^2, f2^3, f1*f2*f1*f2^2]
+julia> rel = [f1^2, f2^3, f1*f2*f1*f2^2]
 3-element Vector{FPGroupElem}:
  f1^2
  f2^3
  (f1*f2)^2*f2
 
-julia> G, epi = quo(F, rela)
+julia> G, epi = quo(F, rel)
 (Finitely presented group, Hom: F -> G)
 
 julia> gens(G)


### PR DESCRIPTION
`rels` is a function, a better name would be for example `rel`