### PR TITLE
LatticesWithIsometry up to local equivalence.

### DIFF
--- a/src/NumberTheory/QuadFormAndIsom/embeddings.jl
+++ b/src/NumberTheory/QuadFormAndIsom/embeddings.jl
@@ -1914,6 +1914,7 @@ function admissible_equivariant_primitive_extensions(
     q::IntegerUnion = p;
     check::Bool=true,
     test_type::Bool=true,
+    _local::Bool=false
   )
   # p and q can be equal, and they will be most of the time
   @req is_prime(p) && is_prime(q) "p and q must be prime numbers"
@@ -1940,9 +1941,9 @@ function admissible_equivariant_primitive_extensions(
   qA, fqA = discriminant_group(A)
   qB, fqB = discriminant_group(B)
   qC = discriminant_group(lattice(C))
-  GA, _ = image_centralizer_in_Oq(A)
+  GA, _ = image_centralizer_in_Oq(A;_local)
   @hassert :ZZLatWithIsom 1 fqA in GA
-  GB, _ = image_centralizer_in_Oq(B)
+  GB, _ = image_centralizer_in_Oq(B;_local)
   @hassert :ZZLatWithIsom 1 fqB in GB
 
   # this is where we will perform the gluing

--- a/src/NumberTheory/QuadFormAndIsom/embeddings.jl
+++ b/src/NumberTheory/QuadFormAndIsom/embeddings.jl
@@ -1717,6 +1717,7 @@ function equivariant_primitive_extensions(
     classification::Symbol=:subsub,
     compute_bar_Gf::Bool=true,
     first_fitting_isometry::Bool=false,
+    _local::Bool=false
   ) where T <: Hecke.IntegerUnion
   @req classification in Symbol[:none, :first, :embemb, :subsub, :subemb, :embsub] "Wrong classification method"
 
@@ -1724,19 +1725,19 @@ function equivariant_primitive_extensions(
   if classification == :embsub || classification == :embemb
     GM = Oscar._orthogonal_group(qM, ZZMatrix[matrix(id_hom(qM))]; check=false)
   else
-    GM, _ = image_centralizer_in_Oq(M)
+    GM, _ = image_centralizer_in_Oq(M; _local)
   end
 
   qN, fqN = discriminant_group(N)
   if classification == :subemb || classification == :embemb
     GN = Oscar._orthogonal_group(qN, ZZMatrix[matrix(id_hom(qN))]; check=false)
   else
-    GN, _ = image_centralizer_in_Oq(N)
+    GN, _ = image_centralizer_in_Oq(N; _local)
   end
 
   if compute_bar_Gf
-    OqfM, _ = image_centralizer_in_Oq(M)
-    OqfN, _ = image_centralizer_in_Oq(N)
+    OqfM, _ = image_centralizer_in_Oq(M; _local)
+    OqfN, _ = image_centralizer_in_Oq(N; _local)
   else
     OqfM = Oscar._orthogonal_group(qM, ZZMatrix[matrix(id_hom(qM))]; check=false)
     OqfN = Oscar._orthogonal_group(qN, ZZMatrix[matrix(id_hom(qN))]; check=false)

--- a/src/NumberTheory/QuadFormAndIsom/enumeration.jl
+++ b/src/NumberTheory/QuadFormAndIsom/enumeration.jl
@@ -2077,6 +2077,7 @@ end
       root_test::Bool=false,
       keep_partial_result::Bool=false,
       discriminant_annihilator::Union{ZZPolyRingElem, ZZMPolyRingElem, MPolyIdeal{ZZMPolyRingElem}}=_discriminant_annihilator(L),
+      _local::Bool=false
     ) -> Vector{ZZLatWithIsom}
 
 Given an even integer lattice $L$, return a complete set of representatives
@@ -2122,6 +2123,10 @@ keyword argument `eiglat_cond`.
       that the annihilator of $D_g$, for every lattices with isometry `(M,g)`
       in output, contains ``I``. If ``I`` is prinicipal, one can also give a
       generator as input.
+    - `_local` -- if `true` return only a single genus representative 
+      of each genus of lattices with isometry matching the given conditions.
+      This keyword argument is not considered as part of the interface and 
+      may change in future versions.
 
 # Examples
 ```jldoctest

--- a/src/NumberTheory/QuadFormAndIsom/enumeration.jl
+++ b/src/NumberTheory/QuadFormAndIsom/enumeration.jl
@@ -2546,7 +2546,7 @@ function oscar_genus_representatives(
   save_partial::Bool=false,
   save_path::Union{IO, String, Nothing}=nothing,
   stop_after::IntExt=1000,
-  max_lat::IntExt=inf,
+  max_lat::IntExt=1,
   genusDB::Union{Nothing, Dict{ZZGenus, Vector{ZZLat}}}=nothing,
   root_test::Bool=false,
   info_depth::Int=1,

--- a/src/NumberTheory/QuadFormAndIsom/enumeration.jl
+++ b/src/NumberTheory/QuadFormAndIsom/enumeration.jl
@@ -2048,7 +2048,7 @@ function splitting(
     for i in 1:l
       N = popfirst!(Ns)
       for M in Ms
-        ok, _Es = equivariant_primitive_extensions(N, M; form_over=TorQuadModule[first(discriminant_group(Lq))],_local)
+        ok, _Es = equivariant_primitive_extensions(N, M; form_over=TorQuadModule[first(discriminant_group(Lq))], _local)
         !ok && continue
         Es = first.(_Es)
         filter!(T -> is_of_type(T^p, type(Lq)), Es)
@@ -2377,7 +2377,7 @@ function _conditions_from_input(
       jp = findfirst(a -> a[1] == n, pos_sigs)
       pn = isnothing(jp) ? -1 : pos_sigs[jp][2]
       jn = findfirst(a -> a[1] == n, neg_sigs)
-      nn = isnothing(jp) ? -1 : neg_sigs[jp][2]
+      nn = isnothing(jn) ? -1 : neg_sigs[jn][2]
       eiglat_cond[n] = Int[rn, pn, nn]
     end
     # For the other eigenlattices, we know that the rank is 0 so we

--- a/src/NumberTheory/QuadFormAndIsom/lattices_with_isometry.jl
+++ b/src/NumberTheory/QuadFormAndIsom/lattices_with_isometry.jl
@@ -1610,9 +1610,9 @@ function image_centralizer_in_Oq(Lf::ZZLatWithIsom; _local::Bool=false)
       qL,fqL = discriminant_group(Lf)
       OqL = orthogonal_group(qL)
       C = centralizer(OqL, OqL(matrix(fqL)))
-      return C::T
+      return C
     end
-  end
+  end::T
   
   return get_attribute!(Lf, :image_centralizer_in_Oq) do
     if is_unimodular(L)
@@ -1620,10 +1620,10 @@ function image_centralizer_in_Oq(Lf::ZZLatWithIsom; _local::Bool=false)
       # discriminant group is trivial
       qL = discriminant_group(L)
       OqL = orthogonal_group(qL)
-      return (OqL, id_hom(OqL))::T
+      return (OqL, id_hom(OqL))
     elseif (n in [1, -1]) || (isometry(Lf) == -identity_matrix(QQ, rank(L)))
       # Trivial cases: the lattice has rank 0 or 1, or it is endowed with +- identity
-      return image_in_Oq(L)::T
+      return image_in_Oq(L)
     elseif rank(L) == degree(chi)
       # Hermitian type with hermitian structure of rank 1
       # The image consists of -id and multiplication by a primitive element on the
@@ -1631,7 +1631,7 @@ function image_centralizer_in_Oq(Lf::ZZLatWithIsom; _local::Bool=false)
       qL, fqL = discriminant_group(Lf)
       OqL = orthogonal_group(qL)
       UL = elem_type(OqL)[OqL(m; check=false) for m in ZZMatrix[-matrix(one(OqL)), matrix(fqL)]]
-      return sub(OqL, unique!(UL))::T
+      return sub(OqL, unique!(UL))
     elseif is_of_hermitian_type(Lf)
       if is_definite(L) || rank(L) == 2
         # If L is definite or of rank 2 and we use the correspondence between
@@ -1648,7 +1648,7 @@ function image_centralizer_in_Oq(Lf::ZZLatWithIsom; _local::Bool=false)
         @hassert :ZZLatWithIsom 1 all(g -> g*f == f*g, geneUL)
         UL = matrix_group(unique!(geneUL))
         disc = discriminant_representation(L, UL; check=false, ambient_representation=false)
-        return image(disc)::T
+        return image(disc)
       else
         @req is_even(Lf) "Hermitian Miranda-Morrison currently available only for even lattices"
         # If L is indefinite of rank >=3, then we use the hermitian version of
@@ -1657,7 +1657,7 @@ function image_centralizer_in_Oq(Lf::ZZLatWithIsom; _local::Bool=false)
         dets, j = Oscar._local_determinants_morphism(Lf)
         _, jj = kernel(dets)
         jj = compose(jj, j)
-        return image(jj)::T
+        return image(jj)
       end
     else
       # For this last case, we cut our lattice into two orthogonal parts and we
@@ -1676,9 +1676,9 @@ function image_centralizer_in_Oq(Lf::ZZLatWithIsom; _local::Bool=false)
 
       M = kernel_lattice(Lf, psi)
       N = orthogonal_submodule(Lf, basis_matrix(M))
-      return _glue_stabilizers(Lf, M, N)::T
+      return _glue_stabilizers(Lf, M, N)
     end
-  end
+  end::T
 end
 
 # Given an isometry $g$ of a hermitian space $W$, and given a map of

--- a/src/NumberTheory/QuadFormAndIsom/lattices_with_isometry.jl
+++ b/src/NumberTheory/QuadFormAndIsom/lattices_with_isometry.jl
@@ -1615,7 +1615,7 @@ function image_centralizer_in_Oq(Lf::ZZLatWithIsom; _local::Bool=false)
   T = Tuple{AutomorphismGroup{TorQuadModule}, GAPGroupHomomorphism{AutomorphismGroup{TorQuadModule}, AutomorphismGroup{TorQuadModule}}}
   
   if _local 
-    return get_attribute!(Lf, :image_centralizer_in_Oq_local)::T do
+    return get_attribute!(Lf, :image_centralizer_in_Oq_local) do
       qL,fqL = discriminant_group(Lf)
       OqL = orthogonal_group(qL)
       C = centralizer(OqL, OqL(matrix(fqL)))

--- a/src/NumberTheory/QuadFormAndIsom/lattices_with_isometry.jl
+++ b/src/NumberTheory/QuadFormAndIsom/lattices_with_isometry.jl
@@ -1515,17 +1515,8 @@ function discriminant_group(Lf::ZZLatWithIsom)
   f = ambient_isometry(Lf)
   q = discriminant_group(L)
   
-  Ld = cover(q)
-  L = relations(q)
-  fL = lattice_in_same_ambient_space(L,basis_matrix(L)*f)
-  T = torsion_quadratic_module(fL+Ld, L+fL; modulus=0,modulus_qf=0)
-  iso = hom(q,T,[T(lift(i)) for i in gens(q)])
-  f = hom(T, T, [T(lift(i)) for i in gens(q)], elem_type(T)[T(lift(t)*f) for t in gens(q)])
-  f = iso*f*inv(iso)
+  f = hom(q, q, elem_type(q)[q(lift(t)*f) for t in gens(q)])
   fq = gens(Oscar._orthogonal_group(q, ZZMatrix[matrix(f)]; check=false))[1]
-
-  # f = hom(q, q, elem_type(q)[q(lift(t)*f) for t in gens(q)])
-  #fq = gens(Oscar._orthogonal_group(q, ZZMatrix[matrix(f)]; check=false))[1]
   return q, fq
 end
 

--- a/src/NumberTheory/QuadFormAndIsom/lattices_with_isometry.jl
+++ b/src/NumberTheory/QuadFormAndIsom/lattices_with_isometry.jl
@@ -1611,8 +1611,8 @@ function image_centralizer_in_Oq(Lf::ZZLatWithIsom; _local::Bool=false)
       OqL = orthogonal_group(qL)
       C = centralizer(OqL, OqL(matrix(fqL)))
       return C
-    end
-  end::T
+    end::T
+  end
   
   return get_attribute!(Lf, :image_centralizer_in_Oq) do
     if is_unimodular(L)

--- a/src/NumberTheory/QuadFormAndIsom/lattices_with_isometry.jl
+++ b/src/NumberTheory/QuadFormAndIsom/lattices_with_isometry.jl
@@ -1606,12 +1606,27 @@ julia> order(G)
 2
 ```
 """
-@attr Tuple{AutomorphismGroup{TorQuadModule}, GAPGroupHomomorphism{AutomorphismGroup{TorQuadModule}, AutomorphismGroup{TorQuadModule}}} function image_centralizer_in_Oq(Lf::ZZLatWithIsom)
+function image_centralizer_in_Oq(Lf::ZZLatWithIsom; _local::Bool=false)
   @req is_integral(Lf) "Underlying lattice must be integral"
   n = order_of_isometry(Lf)
   L = lattice(Lf)
   f = isometry(Lf)
   chi = minpoly(Lf)
+  T = Tuple{AutomorphismGroup{TorQuadModule}, GAPGroupHomomorphism{AutomorphismGroup{TorQuadModule}, AutomorphismGroup{TorQuadModule}}}
+
+  
+  if _local 
+    if has_attribute(Lf, :image_centralizer_in_Oq_local)
+      return get_attribute(Lf, :image_centralizer_in_Oq_local)::T
+    end
+    qL,fqL = discriminant_group(Lf)
+    OqL = orthogonal_group(qL)
+    C = centralizer(OqL, OqL(matrix(fqL)))
+    set_attribute!(Lf, :image_centralizer_in_Oq_local, C)
+    return C::T
+  end
+  get_attribute!(Lf, :image_centralizer_in_Oq) do
+  
   if is_unimodular(L)
     # If L is unimodular we do not have to do any wizard's trick since the
     # discriminant group is trivial
@@ -1674,6 +1689,7 @@ julia> order(G)
     M = kernel_lattice(Lf, psi)
     N = orthogonal_submodule(Lf, basis_matrix(M))
     return _glue_stabilizers(Lf, M, N)
+  end
   end
 end
 

--- a/src/NumberTheory/QuadFormAndIsom/lattices_with_isometry.jl
+++ b/src/NumberTheory/QuadFormAndIsom/lattices_with_isometry.jl
@@ -1520,7 +1520,7 @@ function discriminant_group(Lf::ZZLatWithIsom)
   fL = lattice_in_same_ambient_space(L,basis_matrix(L)*f)
   T = torsion_quadratic_module(fL+Ld, L+fL; modulus=0,modulus_qf=0)
   iso = hom(q,T,[T(lift(i)) for i in gens(q)])
-  f = hom(T, T, elem_type(T)[T(lift(t)*f) for t in gens(q)])
+  f = hom(T, T, [T(lift(i)) for i in gens(q)], elem_type(T)[T(lift(t)*f) for t in gens(q)])
   f = iso*f*inv(iso)
   fq = gens(Oscar._orthogonal_group(q, ZZMatrix[matrix(f)]; check=false))[1]
 

--- a/src/NumberTheory/QuadFormAndIsom/lattices_with_isometry.jl
+++ b/src/NumberTheory/QuadFormAndIsom/lattices_with_isometry.jl
@@ -1514,8 +1514,18 @@ function discriminant_group(Lf::ZZLatWithIsom)
   L = lattice(Lf)
   f = ambient_isometry(Lf)
   q = discriminant_group(L)
-  f = hom(q, q, elem_type(q)[q(lift(t)*f) for t in gens(q)])
+  
+  Ld = cover(q)
+  L = relations(q)
+  fL = lattice_in_same_ambient_space(L,basis_matrix(L)*f)
+  T = torsion_quadratic_module(fL+Ld, L+fL; modulus=0,modulus_qf=0)
+  iso = hom(q,T,[T(lift(i)) for i in gens(q)])
+  f = hom(T, T, elem_type(T)[T(lift(t)*f) for t in gens(q)])
+  f = iso*f*inv(iso)
   fq = gens(Oscar._orthogonal_group(q, ZZMatrix[matrix(f)]; check=false))[1]
+
+  # f = hom(q, q, elem_type(q)[q(lift(t)*f) for t in gens(q)])
+  #fq = gens(Oscar._orthogonal_group(q, ZZMatrix[matrix(f)]; check=false))[1]
   return q, fq
 end
 

--- a/test/NumberTheory/QuadFormAndIsom.jl
+++ b/test/NumberTheory/QuadFormAndIsom.jl
@@ -251,6 +251,11 @@ end
   r = enumerate_classes_of_lattices_with_isometry(L, 30; char_poly=(x-1)^2*cyclotomic(30, x))
   @test length(r) == 1
   @test det(invariant_lattice(r[1])) == -1
+  
+  r_local = enumerate_classes_of_lattices_with_isometry(L,2;char_poly=(x-1)^4*(x+1)^6,fix_root=5,_local=true)
+  r_global = enumerate_classes_of_lattices_with_isometry(L,2;char_poly=(x-1)^4*(x+1)^6,fix_root=5,_local=false)
+  @test length(r_local)==9
+  @test length(r_global)==11
 
   M = direct_sum(U, U, U, U, U)[1]
   r = enumerate_classes_of_lattices_with_isometry(M, 4; min_poly=(x^2-1)*cyclotomic(4,x), pos_sigs=[(1,2), (2,1), (4,2)], neg_sigs=[(2,0)], fix_root=4)

--- a/test/NumberTheory/QuadFormAndIsom.jl
+++ b/test/NumberTheory/QuadFormAndIsom.jl
@@ -252,8 +252,11 @@ end
   @test length(r) == 1
   @test det(invariant_lattice(r[1])) == -1
   
-  r_local = enumerate_classes_of_lattices_with_isometry(L, 2; char_poly=(x-1)^4*(x+1)^6, _local=true)
-  r_global = enumerate_classes_of_lattices_with_isometry(L, 2; char_poly=(x-1)^4*(x+1)^6, _local=false)
+  B = matrix(QQ, 10, 10 ,[2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3//2, 1//2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1//2, 1//2, 1//2, 1//2, 1, 0, 0, 0, 0, 0, 3//2, 1, 0, 1//2, 1//2, 1//2, 0, 0, 0, 0, 1//2, 1, 0, 1//2, 0, 0, 1//2, 0, 0, 0, 1, 1//2, 1//2, 0, 0, 0, 0, 1//2]);
+  G = matrix(QQ, 10, 10 ,[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0,   0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -10]);
+  M = integer_lattice(B, gram = G);
+  r_local = enumerate_classes_of_lattices_with_isometry(M, 2; char_poly=(x-1)^4*(x+1)^6, _local=true)
+  r_global = enumerate_classes_of_lattices_with_isometry(M, 2; char_poly=(x-1)^4*(x+1)^6, _local=false)
   @test length(r_local)==9
   @test length(r_global)==11
 

--- a/test/NumberTheory/QuadFormAndIsom.jl
+++ b/test/NumberTheory/QuadFormAndIsom.jl
@@ -252,8 +252,8 @@ end
   @test length(r) == 1
   @test det(invariant_lattice(r[1])) == -1
   
-  r_local = enumerate_classes_of_lattices_with_isometry(L,2;char_poly=(x-1)^4*(x+1)^6,fix_root=5,_local=true)
-  r_global = enumerate_classes_of_lattices_with_isometry(L,2;char_poly=(x-1)^4*(x+1)^6,fix_root=5,_local=false)
+  r_local = enumerate_classes_of_lattices_with_isometry(L, 2; char_poly=(x-1)^4*(x+1)^6, _local=true)
+  r_global = enumerate_classes_of_lattices_with_isometry(L, 2; char_poly=(x-1)^4*(x+1)^6, _local=false)
   @test length(r_local)==9
   @test length(r_global)==11
 


### PR DESCRIPTION
Allows to enumerate only local equivalence classes of lattices with isometry by adding a keyword argument _local to the enumeration functions
