### PR TITLE
Update assigning File versions

### DIFF
--- a/docs/src/DeveloperDocumentation/serialization.md
+++ b/docs/src/DeveloperDocumentation/serialization.md
@@ -320,7 +320,10 @@ Oscar.Serialization.upgrade_data
 
 All upgrade scripts should be contained in a file named after the version
 they upgrade to. For example a script that upgrades to OSCAR version 0.13.0
-should be named `0.13.0.jl`.
+should be named `0.13.0.jl`. 
+There is also the possibility to have multiple upgrade scripts per version, this is to accommodate file serialized with DEV versions.
+In this case the upgrades should be named `1.6.0-n.jl` where `n` is the `n`th upgrade in the sequence of upgrades that will upgrade a file to the `1.6.0` version.
+To guarantee that upgrades occur in the correct order it is important that they are included (`include("/path/to/upgrade")`) in the correct order in `src/Serialization/Upgrades/main.jl`.
 
 ```@docs
 Oscar.Serialization.UpgradeScript

--- a/src/Serialization/Upgrades/main.jl
+++ b/src/Serialization/Upgrades/main.jl
@@ -138,6 +138,7 @@ function rename_types(dict::Dict, renamings::Dict{String, String})
   return dict
 end
 
+# following order is the order in which upgrades will happen
 include("0.11.3.jl")
 include("0.12.0.jl")
 include("0.12.2.jl")

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -80,8 +80,13 @@ function get_oscar_serialization_version()
     return oscar_serialization_version[]
   end
   if Oscar.is_dev
+    next_version = "$(VERSION_NUMBER.major).$(VERSION_NUMBER.minor).$(VERSION_NUMBER.patch)"
+    n_upgrades = count(x -> contains(x, next_version),
+                       readdir(joinpath(@__DIR__, "Upgrades")))
+
+
     commit_hash = get(Oscar._get_oscar_git_info(), :commit, "unknown")
-    version_info = "$VERSION_NUMBER-$commit_hash"
+    version_info = iszero(n_upgrades) ? "$VERSION_NUMBER-$commit_hash" : "$VERSION_NUMBER-$n_upgrades-$commit_hash"
     result = Dict{Symbol, Any}(
       :Oscar => ["https://github.com/oscar-system/Oscar.jl", version_info]
     )

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -81,7 +81,7 @@ function get_oscar_serialization_version()
   end
   if Oscar.is_dev
     next_version = "$(VERSION_NUMBER.major).$(VERSION_NUMBER.minor).$(VERSION_NUMBER.patch)"
-    n_upgrades = count(x -> contains(x, next_version),
+    n_upgrades = count(x -> startswith(x, next_version) && endswith(x, ".jl"),
                        readdir(joinpath(@__DIR__, "Upgrades")))
 
 


### PR DESCRIPTION
Serializing with while using a dev version of Oscar will assign an additional number to the file corresponding to how many upgrades there currently are for the upcoming release.

This will allow us to assess which intermediate upgrades to apply to serialized dev files