### PR TITLE
request recursive GAP to Julia conversion (in another place)

### DIFF
--- a/src/GAP/gap_to_oscar.jl
+++ b/src/GAP/gap_to_oscar.jl
@@ -155,7 +155,7 @@ end
 ## GAP straight line program
 function straight_line_program(slp::GapObj)
   @req GAP.Globals.IsStraightLineProgram(slp) "slp must be a straight line program in GAP"
-  lines = Vector{Any}(GAP.Globals.LinesOfStraightLineProgram(slp))
+  lines = Vector{Any}(GAP.Globals.LinesOfStraightLineProgram(slp); recursive = true)
   n = GAP.Globals.NrInputsOfStraightLineProgram(slp)
   return SLP.GAPSLProgram(lines, n)
 end


### PR DESCRIPTION
follow-up of #5303

(I do not understand why I had overlooked this case, I had checked for `Vector.*Any.*(` conversions in Oscar code.)