### PR TITLE
Remove a `sub` method for `MatrixGroup` that is worse than the generic one

### DIFF
--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -1061,27 +1061,6 @@ const SU = special_unitary_group
 
 ########################################################################
 #
-# Subgroups
-#
-########################################################################
-
-function sub(G::MatrixGroup, elements::Vector{S}) where S <: GAPGroupElem
-   @assert elem_type(G) === S
-   elems_in_GAP = GAP.Obj(GapObj[GapObj(x) for x in elements])
-   H = GAP.Globals.Subgroup(GapObj(G),elems_in_GAP)::GapObj
-   #H is the group. I need to return the inclusion map too
-   K,f = _as_subgroup(G, H)
-   L = Vector{elem_type(K)}(undef, length(elements))
-   for i in 1:length(L)
-      L[i] = MatrixGroupElem(K, matrix(elements[i]), elements[i].X)
-   end
-   K.gens = L
-   return K,f
-end
-
-
-########################################################################
-#
 # Conjugation
 #
 ########################################################################

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -296,8 +296,8 @@ end
    y = G([z+1,0,0,z+2])
    @test parent(x)==G
    H,f = sub(G,[x,y])
-   @test isdefined(H,:gens)
    @test gens(H)==[x,y]
+   @test isdefined(H,:gens)
    @test typeof(gens(H)) == Vector{elem_type(H)}
    @test H==SL(2,F)
    @test parent(x)==G

--- a/test/Groups/quotients.jl
+++ b/test/Groups/quotients.jl
@@ -174,8 +174,10 @@ end
    S = matrix(K, [0 0 1; 1 0 0; 0 1 0])
    T = matrix(K, [1 0 0; 0 a 0; 0 0 -a-1])
    H3 = matrix_group(S, T)
-   C, iC = center(H3);
+   Z = matrix(K, [-a-1 0 0; 0 -a-1 0; 0 0 -a-1])
+   C = sub(H3, [H3(Z; check = false)]; check = false)[1]
    @test !has_is_finite(C)
    Q, pQ = quo(H3, C);
    @test has_is_finite(C)
+   @test C == center(H3)[1]
 end


### PR DESCRIPTION
Split off from https://github.com/oscar-system/Oscar.jl/pull/5283, the changes are due to @ThomasBreuer.

I think the generic `sub` method is good enough.
The special method for `MatrixGroup` did not support
the `check` keyword argument.