### PR TITLE
Remove generic coercion from Singular to arbitrary rings

### DIFF
--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -563,10 +563,6 @@ function Oscar.singular_coeff_ring(F::AbstractAlgebra.Ring)
   return Singular.CoefficientRing(F)
 end
 
-#??? needs to coerce into b? assert parent?
-function (b::AbstractAlgebra.Ring)(a::Singular.n_unknown)
-  Singular.libSingular.julia(Singular.libSingular.cast_number_to_void(a.ptr))::elem_type(b)
-end
 
 ##############################################################################
 #


### PR DESCRIPTION
I made this last may and then forgot... I expect it will break stuff but I'd like to know what; ultimately it'd be good to get rid of this.