### PR TITLE
Fix and generalize (co)domain_type

### DIFF
--- a/experimental/Schemes/src/CoveredScheme.jl
+++ b/experimental/Schemes/src/CoveredScheme.jl
@@ -83,17 +83,6 @@ end
 
 affine_refinements(C::Covering) = C.affine_refinements
 
-### type getters
-# Not required at the moment; should eventually be deleted.
-#base_morphism_type(::Type{T}) where {DT, CT, BMT, T<:CoveringMorphism{DT, CT, BMT}} = BMT
-#base_morphism_type(C::Covering) = base_morphism_type(typeof(C))
-
-#domain_type(::Type{T}) where {DT, CT, BMT, T<:CoveringMorphism{DT, CT, BMT}} = DT
-#domain_type(C::Covering) = domain_type(typeof(C))
-
-#codomain_type(::Type{T}) where {DT, CT, BMT, T<:CoveringMorphism{DT, CT, BMT}} = CT
-#codomain_type(C::Covering) = codomain_type(typeof(C))
-
 ########################################################################
 # Constructors for standard schemes (Projective space, etc.)           #
 ########################################################################

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Morphisms/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Morphisms/Attributes.jl
@@ -292,10 +292,6 @@ end
 ### Type getters
 pullback_type(::Type{T}) where {DomType, CodType, PbType, T<:AbsAffineSchemeMor{DomType, CodType, PbType}} = PbType
 pullback_type(f::AbsAffineSchemeMor) = pullback_type(typeof(f))
-domain_type(::Type{T}) where {DomType, CodType, PbType, T<:AbsAffineSchemeMor{DomType, CodType, PbType}} = DomType
-domain_type(f::AbsAffineSchemeMor) = domain_type(typeof(f))
-codomain_type(::Type{T}) where {DomType, CodType, PbType, T<:AbsAffineSchemeMor{DomType, CodType, PbType}} = CodType
-codomain_type(f::AbsAffineSchemeMor) = codomain_type(typeof(f))
 
 function morphism_type(::Type{AffineSchemeType1}, ::Type{AffineSchemeType2}) where {AffineSchemeType1<:AbsAffineScheme, AffineSchemeType2<:AbsAffineScheme}
   return AffineSchemeMor{AffineSchemeType1, AffineSchemeType2, morphism_type(ring_type(AffineSchemeType2), ring_type(AffineSchemeType1))}

--- a/src/Misc/MoveToAbstractAlgebra.jl
+++ b/src/Misc/MoveToAbstractAlgebra.jl
@@ -21,3 +21,9 @@ function is_equal_as_morphism(f::Map, g::Map)
 end
 # end of changes in PR #4706
 ########################################################################
+
+
+domain_type(::Type{Map{D, C}}) where {D, C} = D
+domain_type(f::Map) = domain_type(typeof(f))
+codomain_type(::Type{Map{D, C}}) where {D, C} = C
+codomain_type(f::Map) = codomain_type(typeof(f))

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -1030,10 +1030,6 @@ constructor takes as input the triple
 end
 
 ### type getters 
-domain_type(::Type{Map{D, C}}) where {D, C} = D
-domain_type(f::Map) = domain_type(typeof(f))
-codomain_type(::Type{Map{D, C}}) where {D, C} = C
-codomain_type(f::Map) = codomain_type(typeof(f))
 restricted_map_type(::Type{MPolyQuoLocalizedRingHom{D, C, M}}) where {D, C, M} = M
 restricted_map_type(f::MPolyQuoLocalizedRingHom) = restricted_map_type(typeof(f))
 

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -1030,12 +1030,12 @@ constructor takes as input the triple
 end
 
 ### type getters 
-domain_type(::Type{MPolyQuoLocalizedRingHom{D, C, M}}) where {D, C, M} = D
-domain_type(f::MPolyQuoLocalizedRingHom) = domain_type(typeof(f))
-codomain_type(::Type{MPolyQuoLocalizedRingHom{D, C, M}}) where {D, C, M} = C
-codomain_type(f::MPolyQuoLocalizedRingHom) = domain_type(typeof(f))
+domain_type(::Type{Map{D, C}}) where {D, C} = D
+domain_type(f::Map) = domain_type(typeof(f))
+codomain_type(::Type{Map{D, C}}) where {D, C} = C
+codomain_type(f::Map) = codomain_type(typeof(f))
 restricted_map_type(::Type{MPolyQuoLocalizedRingHom{D, C, M}}) where {D, C, M} = M
-restricted_map_type(f::MPolyQuoLocalizedRingHom) = domain_type(typeof(f))
+restricted_map_type(f::MPolyQuoLocalizedRingHom) = restricted_map_type(typeof(f))
 
 morphism_type(::Type{R}, ::Type{S}) where {R<:MPolyQuoLocRing, S<:Ring} = MPolyQuoLocalizedRingHom{R, S, morphism_type(base_ring_type(R), S)}
 morphism_type(L::MPolyQuoLocRing, S::Ring) = morphism_type(typeof(L), typeof(S))


### PR DESCRIPTION
Define them for all `Map` subtypes. (I'd suggest to move this to AA, except that `domain_type` is confusing because we also have the entirely unrelated `is_domain_type`).

Note that the `codomain_type(::MPolyQuoLocalizedRingHom)` and `restricted_map_type(::MPolyQuoLocalizedRingHom)` had incorrect implementations which delegated to `domain_type` (copy&paste -- blessing and a curse :-) ).