### PR TITLE
Allow reseting the variable name of QQAbField

### DIFF
--- a/src/Rings/AbelianClosure.jl
+++ b/src/Rings/AbelianClosure.jl
@@ -57,10 +57,10 @@ be constructed using [`abelian_closure(::QQField)`](@ref).
 """
 @attributes mutable struct QQAbField{T} <: Nemo.Field # union of cyclotomic fields
   fields::Dict{Int, T} # Cache for the cyclotomic fields
-  s::String
+  s::Union{String,Nothing}
 
   function QQAbField{T}(fields::Dict{Int, T}) where T
-    return new(fields)
+    return new(fields, nothing)
   end
 end
 
@@ -178,13 +178,10 @@ base_ring_type(::Type{<:QQAbField}) = typeof(Union{})
 ################################################################################
 
 function _variable(K::QQAbField)
-  if isdefined(K, :s)
-    return K.s
-  elseif Oscar.is_unicode_allowed()
-    return "ζ"
-  else
-    return "zeta"
-  end
+  s = K.s
+  s !== nothing && return s
+  Oscar.is_unicode_allowed() && return "ζ"
+  return "zeta"
 end
 
 _variable(b::QQAbFieldElem{AbsSimpleNumFieldElem}) = Expr(:call, Symbol(_variable(_QQAb)), b.c)
@@ -364,12 +361,13 @@ function Base.show(io::IO, a::QQAbFieldGen)
 end
 
 """
-    set_variable!(K::QQAbField, s::String)
+    set_variable!(K::QQAbField, s::Union{String,Nothing})
 
 Change the printing of the primitive n-th root of the abelian closure of the
 rationals to `s(n)`, where `s` is the supplied string.
+In the case of `s` being `nothing`, the printing is reset to the default value.
 """
-function set_variable!(K::QQAbField, s::String)
+function set_variable!(K::QQAbField, s::Union{String,Nothing})
   ss = _variable(K)
   K.s = s
   return ss

--- a/test/Rings/AbelianClosure.jl
+++ b/test/Rings/AbelianClosure.jl
@@ -95,7 +95,7 @@
     @test isone(a^4) && !isone(a) && !isone(a^2)
 
     # reset variable for any subsequent (doc-)tests
-    @test set_variable!(K, orig) == "ω"
+    @test set_variable!(K, nothing) == "ω"
   end
 
   @testset "Coercion" begin


### PR DESCRIPTION
This is helpful when doing `Oscar.test_module("Rings"; new=false)`
repeatedly.