### PR TITLE
docs: try to adjust to modified docs project by developing all projects at once

### DIFF
--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -52,8 +52,9 @@ function doc_init(;path=mktempdir())
     # we dev all "our" packages with the paths from where they are currently
     # loaded
     pkglist = [AbstractAlgebra, Nemo, Hecke, Singular, GAP, Polymake]
-    Pkg.develop([PackageSpec(path=Base.pkgdir(pkg)) for pkg in pkglist])
-    Pkg.develop(path=oscardir)
+    paths = [PackageSpec(path=Base.pkgdir(pkg)) for pkg in pkglist]
+    push!(paths, PackageSpec(path=oscardir))
+    Pkg.develop(paths)
     Pkg.instantiate()
     Base.include(Main, joinpath(oscardir, "docs", "make_work.jl"))
   end


### PR DESCRIPTION
@fingolfin @lgoettgens 

I just had a look at the log for the docbuild after #5381 and it looks like this might cause issues once the compat entries of the latest Oscar release and the dev version diverge:
```
Run julia --project=. --color=yes -e 'using Oscar; Oscar.doc_init(; path="docs/")'

   Resolving package versions...
   Installed msolve_jll ─────── v0.800.1+0
   Installed AlgebraicSolving ─ v0.9.2
   Installed Oscar ──────────── v1.5.0
    Updating `~/work/Oscar.jl/Oscar.jl/docs/Project.toml`
  [c3fe647b] + AbstractAlgebra v0.47.3 `~/.julia/packages/AbstractAlgebra/T6WZD`
  [e30172f5] + Documenter v1.14.1
⌅ [daee34ce] + DocumenterCitations v1.3.7
  [c863536a] + GAP v0.15.3 `~/.julia/packages/GAP/rBIpJ`
  [3e1990a7] + Hecke v0.38.6 `~/.julia/packages/Hecke/e3v2R`
  [682c06a0] + JSON v0.21.4
  [2edaba10] + Nemo v0.52.1 `~/.julia/packages/Nemo/IYwMw`
  [f1435218] + Oscar v1.5.0
  [d720cf60] + Polymake v0.13.2 `~/.julia/packages/Polymake/3ALS3`
  [bcd08a7b] + Singular v0.26.0 `~/.julia/packages/Singular/mSn49`
...
   Resolving package versions...
    Updating `~/work/Oscar.jl/Oscar.jl/docs/Project.toml`
  [f1435218] ~ Oscar v1.5.0 ⇒ v1.6.0-DEV `~/work/Oscar.jl/Oscar.jl`
```
https://github.com/oscar-system/Oscar.jl/actions/runs/18030785975/job/51306551662?pr=5381#step:6:20

The code is trying to activate the docs-project, then adds various dependencies in the exact versions that are currently loaded and will then add Oscar from the current path.

But with the new Oscar entries in the Project.toml this will always try to include a released Oscar version (v1.5.0 in the log above) when the code was supposed to just add the dependencies, this will fail when dev needs different dependencies. (docs build happens with julia 1.10)
I adjusted it to `dev Oscar` in the same call which should hopefully avoid this.

Note that the default operation of `build_doc` is to copy the `Project.toml` for the docs to a temporary directory, which makes `..` useless, but it doesn't matter since the path is fixed by the develop call anyway. The reason for that is that way too often people were having issues building the docs because of an outdated manifest in the docs folder.

#### Alternative

While looking at this I think we could get rid of all the develop stuff (and the Oscar entry in the deps) and maybe avoid some issues with outdated manifests if we use stacked environments.
Basically we could make sure the docs project only has Documenter in it and put something like this at the top of `docs/make.jl`:
```
using Pkg
path = @__DIR__
Pkg.activate(path) do
	Pkg.instantiate()
end
path in Base.LOAD_PATH || pushfirst!(Base.LOAD_PATH, path)
```
Then this could be run with the Oscar project as active project and doesn't need any extra resolving:
```
julia --project=. docs/make.jl
```
Similarly `build_doc` would just need to make sure the project is instantiated and push it to the load path (as it currently does) but we could remove all Oscar related packages from that project.

The advantage would be that the Manifest for the docs only contains documenter related packages which are a lot less likely to be outdated and cause resolve errors.