### PR TITLE
add `_irred_abelian(G::Oscar.GAPGroup, F::FinField)`

### DIFF
--- a/experimental/GModule/src/GModule.jl
+++ b/experimental/GModule/src/GModule.jl
@@ -821,11 +821,10 @@ function _irred_abelian(G::Oscar.GAPGroup)
     f = mR(r)
     C, z = cyclotomic_field(Int(o); cached = false)
     F = free_module(QQ, degree(C); cached = false)
-    m = representation_matrix(z)
 
     function conv(r)
       e = r.elt::QQFieldElem
-      return (m^Int(divexact(o, denominator(e))))^Int(numerator(e))
+      return representation_matrix(z^Int(divexact(o, denominator(e))*numerator(e)))
     end
 
     push!(all, gmodule(G, [hom(F, F, conv(f(mA(g)))) for g = gens(G)]))

--- a/experimental/GModule/test/runtests.jl
+++ b/experimental/GModule/test/runtests.jl
@@ -340,15 +340,15 @@ end
 @testset "_irred_abelian" begin
   G = abelian_group(PcGroup, [3, 3, 5])
   reps = Oscar.GModuleFromGap._irred_abelian(G, GF(2))
-  @test multiplicities(map(dim, reps)) == [1 => 1, 2 => 4, 4 => 9]
-  reps = Oscar.GModuleFromGap._irred_abelian(G, GF(4))
-  @test multiplicities(map(dim, reps)) == [1 => 9, 2 => 18]
-  reps = Oscar.GModuleFromGap._irred_abelian(G, GF(16))
-  @test multiplicities(map(dim, reps)) == [1 => 45]
+  @test multiset(map(dim, reps)) == multiset(Dict(1 => 1, 2 => 4, 4 => 9))
+  reps = Oscar.GModuleFromGap._irred_abelian(G, GF(2, 2))
+  @test multiset(map(dim, reps)) == multiset(Dict(1 => 9, 2 => 18))
+  reps = Oscar.GModuleFromGap._irred_abelian(G, GF(2, 4))
+  @test multiset(map(dim, reps)) == multiset(Dict(1 => 45))
   reps = Oscar.GModuleFromGap._irred_abelian(G, GF(3))
-  @test multiplicities(map(dim, reps)) == [1 => 1, 4 => 1]
-  reps = Oscar.GModuleFromGap._irred_abelian(G, GF(9))
-  @test multiplicities(map(dim, reps)) == [1 => 1, 2 => 2]
-  reps = Oscar.GModuleFromGap._irred_abelian(G, GF(81))
-  @test multiplicities(map(dim, reps)) == [1 => 5]
+  @test multiset(map(dim, reps)) == multiset(Dict(1 => 1, 4 => 1))
+  reps = Oscar.GModuleFromGap._irred_abelian(G, GF(3, 2))
+  @test multiset(map(dim, reps)) == multiset(Dict(1 => 1, 2 => 2))
+  reps = Oscar.GModuleFromGap._irred_abelian(G, GF(3, 4))
+  @test multiset(map(dim, reps)) == multiset(Dict(1 => 5))
 end

--- a/experimental/GModule/test/runtests.jl
+++ b/experimental/GModule/test/runtests.jl
@@ -336,3 +336,19 @@ end
   C, _ = Oscar.GModuleFromGap.ghom(C, C)
   @test dim(C) == 49
 end
+
+@testset "_irred_abelian" begin
+  G = abelian_group(PcGroup, [3, 3, 5])
+  reps = Oscar.GModuleFromGap._irred_abelian(G, GF(2))
+  @test multiplicities(map(dim, reps)) == [1 => 1, 2 => 4, 4 => 9]
+  reps = Oscar.GModuleFromGap._irred_abelian(G, GF(4))
+  @test multiplicities(map(dim, reps)) == [1 => 9, 2 => 18]
+  reps = Oscar.GModuleFromGap._irred_abelian(G, GF(16))
+  @test multiplicities(map(dim, reps)) == [1 => 45]
+  reps = Oscar.GModuleFromGap._irred_abelian(G, GF(3))
+  @test multiplicities(map(dim, reps)) == [1 => 1, 4 => 1]
+  reps = Oscar.GModuleFromGap._irred_abelian(G, GF(9))
+  @test multiplicities(map(dim, reps)) == [1 => 1, 2 => 2]
+  reps = Oscar.GModuleFromGap._irred_abelian(G, GF(81))
+  @test multiplicities(map(dim, reps)) == [1 => 5]
+end


### PR DESCRIPTION
This is analogous to the available `_irred_abelian(G::Oscar.GAPGroup)` which computes the `QQ`-irreducibles of finite abelian groups.

(The functionality will be mentioned in a forthcoming paper.)