### PR TITLE
Tweak `combination` function

### DIFF
--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -70,32 +70,7 @@ Combinations(v::AbstractArray{T}, k::IntegerUnion) where T = Combinations(v, len
 end
 
 
-@inline function Base.iterate(C::Combinations{Base.OneTo{T}}, state::Nothing = nothing) where T
-  if C.k == 0 # special case to generate 1 result for k = 0
-    return Combination(eltype(C.v)[]), T[0]
-  end
-  n = T(C.n)
-  k = T(C.k)
-  st = T[min(k - 1, i) for i in 1:k]
-
-  for i in k:-1:1
-    st[i] += 1
-    if st[i] > (n - (k - i))
-      continue
-    end
-    for j in i+1:k
-      st[j] = st[j - 1] + 1
-    end
-    break
-  end
-  if st[1] > n - k + 1
-    return nothing
-  end
-  return Combination(st), st
-end
-
-
-@inline function Base.iterate(C::Combinations{Base.OneTo{T}}, state::Vector{T}) where T
+@inline function Base.iterate(C::Combinations{Base.OneTo{T}}, state::Vector{T} = T[min(C.k - 1, i) for i in 1:C.k]) where T
   if C.k == 0 # special case to generate 1 result for k = 0
     if isempty(state)
       return Combination(T[]), T[0]
@@ -359,30 +334,7 @@ Combinations2(v::AbstractArray, k::T) where {T<:IntegerUnion} = Combinations2(v,
 end
 
 
-@inline function Base.iterate(C::Combinations2{Base.OneTo{T}, T}, state::Nothing = nothing) where {T<:IntegerUnion}
-  if C.k == 0 # special case to generate 1 result for k = 0
-    return Combination{T}(T[]), T[0]
-  end
-  st = T[min(C.k - 1, i) for i in 1:C.k]
-
-  for i in C.k:-1:1
-    st[i] += 1
-    if st[i] > (C.n - (C.k - i))
-      continue
-    end
-    for j in i+1:C.k
-      st[j] = st[j - 1] + 1
-    end
-    break
-  end
-  if st[1] > C.n - C.k + 1
-    return nothing
-  end
-  return Combination{T}(st), st
-end
-
-
-@inline function Base.iterate(C::Combinations2{Base.OneTo{T}, T}, state::Vector{T}) where {T<:IntegerUnion}
+@inline function Base.iterate(C::Combinations2{Base.OneTo{T}, T}, state::Vector{T} = T[min(C.k - 1, i) for i in 1:C.k]) where {T<:IntegerUnion}
   if C.k == 0 # special case to generate 1 result for k = 0
     if isempty(state)
       return Combination{T}(T[]), T[0]

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -326,19 +326,19 @@ end
 
 # for timing tests
 
-combinations2(n::T, k::T) where T<:IntegerUnion = Combinations2(Base.OneTo(n), k)
+combinations2(n::T, k::IntegerUnion) where T<:IntegerUnion = Combinations2(Base.OneTo(n), T(k))
 
-function combinations2(v::AbstractVector{T}, k::IntegerUnion) where T
+function combinations2(v::AbstractVector, k::IntegerUnion)
   return Combinations2(v, k)
 end
 
-Combinations2(v::AbstractArray{T}, k::U) where {T, U<:IntegerUnion} = Combinations2(v, U(length(v)), k)
+Combinations2(v::AbstractArray, k::T) where {T<:IntegerUnion} = Combinations2(v, T(length(v)), k)
 
 
-@inline function Base.iterate(C::Combinations2, state = [min(C.k - 1, i) for i in 1:C.k])
+@inline function Base.iterate(C::Combinations2{<:AbstractVector{T}}, state = [min(C.k - 1, i) for i in 1:C.k]) where T
   if C.k == 0 # special case to generate 1 result for k = 0
     if isempty(state)
-      return Combination(eltype(C.v)[]), [0]
+      return Combination{T}(T[]), [0]
     end
     return nothing
   end
@@ -355,13 +355,13 @@ Combinations2(v::AbstractArray{T}, k::U) where {T, U<:IntegerUnion} = Combinatio
   if state[1] > C.n - C.k + 1
     return nothing
   end
-  return Combination(C.v[state]), state
+  return Combination{T}(C.v[state]), state
 end
 
 
 @inline function Base.iterate(C::Combinations2{Base.OneTo{T}, T}, state::Nothing = nothing) where {T<:IntegerUnion}
   if C.k == 0 # special case to generate 1 result for k = 0
-    return Combination(T[]), T[0]
+    return Combination{T}(T[]), T[0]
   end
   st = T[min(C.k - 1, i) for i in T(1):C.k]
 
@@ -378,14 +378,14 @@ end
   if st[1] > C.n - C.k + T(1)
     return nothing
   end
-  return Combination(st), st
+  return Combination{T}(st), st
 end
 
 
 @inline function Base.iterate(C::Combinations2{Base.OneTo{T}, T}, state::Vector{T}) where {T<:IntegerUnion}
   if C.k == 0 # special case to generate 1 result for k = 0
     if isempty(state)
-      return Combination(T[]), T[0]
+      return Combination{T}(T[]), T[0]
     end
     return nothing
   end
@@ -403,7 +403,7 @@ end
     return nothing
   end
 
-  return Combination(state), state
+  return Combination{T}(state), state
 end
 
 Base.length(C::Combinations2) = binomial(Int(C.n), Int(C.k))
@@ -424,7 +424,7 @@ end
 #
 ################################################################################
 
-
+# these won't work without fixing signature of `combination(n,k,i)`
 function Base.getindex(C::Combinations2{Base.OneTo}, i::IntegerUnion)
   return Oscar.combination(C.n, C.k, i)
 end

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -69,6 +69,56 @@ Combinations(v::AbstractArray{T}, k::IntegerUnion) where T = Combinations(v, len
   return Combination(C.v[state]), state
 end
 
+
+@inline function Base.iterate(C::Combinations{Base.OneTo{T}}, state::Nothing = nothing) where T
+  if C.k == 0 # special case to generate 1 result for k = 0
+    return Combination(eltype(C.v)[]), T[0]
+  end
+  n = T(C.n)
+  k = T(C.k)
+  st = T[min(k - 1, i) for i in 1:k]
+
+  for i in k:-1:1
+    st[i] += 1
+    if st[i] > (n - (k - i))
+      continue
+    end
+    for j in i+1:k
+      st[j] = st[j - 1] + 1
+    end
+    break
+  end
+  if st[1] > n - k + 1
+    return nothing
+  end
+  return Combination(st), st
+end
+
+
+@inline function Base.iterate(C::Combinations{Base.OneTo{T}}, state::Vector{T}) where T
+  if C.k == 0 # special case to generate 1 result for k = 0
+    if isempty(state)
+      return Combination(eltype(C.v)[]), T[0]
+    end
+    return nothing
+  end
+  for i in C.k:-1:1
+    state[i] += 1
+    if state[i] > (C.n - (C.k - i))
+      continue
+    end
+    for j in i+1:C.k
+      state[j] = state[j - 1] + 1
+    end
+    break
+  end
+  if state[1] > C.n - C.k + 1
+    return nothing
+  end
+
+  return Combination(state), state
+end
+
 Base.length(C::Combinations) = binomial(C.n, C.k)
 
 Base.eltype(::Type{Combinations{T}}) where {T} = Combination{eltype(T)}

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -40,9 +40,7 @@ julia> collect(C)
  ['b', 'c', 'd']
 ```
 """
-function combinations(v::AbstractVector{T}, k::IntegerUnion) where T
-  return Combinations(v, k)
-end
+combinations(v::AbstractVector, k::IntegerUnion) = Combinations(v, k)
 
 Combinations(v::AbstractArray, k::T) where {T<:IntegerUnion} = Combinations(v, T(length(v)), k)
 
@@ -135,16 +133,16 @@ function Base.getindex(C::Combination, i::IntegerUnion)
   return getindex(data(C), Int(i))
 end
 
-function Base.copy(C::Combination)
-  return Combination(copy(data(C)))
+function Base.copy(C::Combination{T})
+  return Combination{T}(copy(data(C)))
 end
 
 function Base.getindex(C::Combinations{Base.OneTo}, i::IntegerUnion)
-  return Oscar.combination(C.n, C.k, i)
+  return combination(C.n, C.k, i)
 end
 
 function Base.getindex(C::Combinations, i::IntegerUnion)
-  c = Oscar.combination(C.n, C.k, i)
+  c = combination(C.n, C.k, i)
   return C.v[data(c)]
 end
 

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -360,7 +360,7 @@ end
 
 Base.length(C::Combinations2) = binomial(Int(C.n), Int(C.k))
 
-Base.eltype(::Type{Combinations2{T}}) where {T} = Combination{eltype(T)}
+Base.eltype(::Type{<:Combinations2{T}}) where {T} = Combination{eltype(T)}
 
 function Base.show(io::IO, C::Combinations2{<:Base.OneTo})
   print(io, "Iterator over the ", C.k, "-combinations of ", 1:C.n)

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -98,21 +98,23 @@ end
 @inline function Base.iterate(C::Combinations{Base.OneTo{T}}, state::Vector{T}) where T
   if C.k == 0 # special case to generate 1 result for k = 0
     if isempty(state)
-      return Combination(eltype(C.v)[]), T[0]
+      return Combination(T[]), T[0]
     end
     return nothing
   end
-  for i in C.k:-1:1
+  n = T(C.n)
+  k = T(C.k)
+  for i in k:-1:1
     state[i] += 1
-    if state[i] > (C.n - (C.k - i))
+    if state[i] > (n - (k - i))
       continue
     end
-    for j in i+1:C.k
+    for j in i+1:k
       state[j] = state[j - 1] + 1
     end
     break
   end
-  if state[1] > C.n - C.k + 1
+  if state[1] > n - k + 1
     return nothing
   end
 

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -93,7 +93,7 @@ end
     return nothing
   end
 
-  return Combination(state), state
+  return Combination(copy(state)), state
 end
 
 Base.length(C::Combinations) = binomial(C.n, C.k)
@@ -355,7 +355,7 @@ end
     return nothing
   end
 
-  return Combination{T}(state), state
+  return Combination{T}(copy(state)), state
 end
 
 Base.length(C::Combinations2) = binomial(Int(C.n), Int(C.k))

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -133,7 +133,7 @@ function Base.getindex(C::Combination, i::IntegerUnion)
   return getindex(data(C), Int(i))
 end
 
-function Base.copy(C::Combination{T})
+function Base.copy(C::Combination{T}) where T
   return Combination{T}(copy(data(C)))
 end
 

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -363,19 +363,19 @@ end
   if C.k == 0 # special case to generate 1 result for k = 0
     return Combination{T}(T[]), T[0]
   end
-  st = T[min(C.k - 1, i) for i in T(1):C.k]
+  st = T[min(C.k - 1, i) for i in 1:C.k]
 
   for i in C.k:-1:1
-    st[i] += T(1)
-    if st[i] > (C.n - (C.k - T(i)))
+    st[i] += 1
+    if st[i] > (C.n - (C.k - i))
       continue
     end
     for j in i+1:C.k
-      st[j] = st[j - 1] + T(1)
+      st[j] = st[j - 1] + 1
     end
     break
   end
-  if st[1] > C.n - C.k + T(1)
+  if st[1] > C.n - C.k + 1
     return nothing
   end
   return Combination{T}(st), st
@@ -390,16 +390,16 @@ end
     return nothing
   end
   for i in C.k:-1:1
-    state[i] += T(1)
+    state[i] += 1
     if state[i] > (C.n - (C.k - i))
       continue
     end
     for j in i+1:C.k
-      state[j] = state[j - 1] + T(1)
+      state[j] = state[j - 1] + 1
     end
     break
   end
-  if state[1] > C.n - C.k + T(1)
+  if state[1] > C.n - C.k + 1
     return nothing
   end
 

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -212,7 +212,7 @@ function combination(n::T, k::IntegerUnion, r::IntegerUnion) where T<:IntegerUni
   n == k && return Combination{T}(collect(T(1):n))
 
   C = zeros(T, k)
-  r = binomial(n,k) - r
+  r = binomial(Int(n),Int(k)) - r
   j = T(1)
   for i in 1:k
     b = binomial(Int(n) - j, Int(k) - i + 1)
@@ -274,7 +274,7 @@ end
 function _wedge(a::Combination{T}, b::Combination{T}) where {T}
   c, sign = merge_sorted_with_sign(data(a), data(b))
   sign == 0 && return sign, c
-  return sign, Combination(c)
+  return sign, Combination{T}(c)
 end
 
 

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -401,19 +401,12 @@ end
 #
 ################################################################################
 
-struct Combinations{T}
+struct Combinations{T, U<:IntegerUnion}
   v::T
-  n::Int
-  k::Int
+  n::U
+  k::U
 end
 
 struct Combination{T} <: AbstractVector{T}
   v::Vector{T}
-end
-
-# for timing tests
-struct Combinations2{T, U<:IntegerUnion}
-  v::T
-  n::U
-  k::U
 end

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -408,7 +408,12 @@ struct Combinations{T}
 end
 
 struct Combination{T} <: AbstractVector{T}
-  v::Vector{T} 
+  v::Vector{T}
 end
 
-
+# for timing tests
+struct Combinations2{T, U<:IntegerUnion}
+  v::T
+  n::U
+  k::U
+end

--- a/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -12,6 +12,14 @@
     C = combinations(4, 5)
     @test length(C) == 0
 
+    C = combinations(Int16(4), 3)
+    @test length(C) == 4
+    @test collect(C) == [[1, 2, 3],
+                         [1, 2, 4],
+                         [1, 3, 4],
+                         [2, 3, 4]]
+    @test eltype(C) === Combination{Int16}
+
     C = combinations('a':'d', 3)
     @test length(C) == 4
     @test collect(C) == [['a', 'b', 'c'],
@@ -56,11 +64,7 @@
     @test length(c) == binomial(n,k)
     @test all(x->c[Oscar.linear_index(x, n)] == x, combinations(n,k))
     @test all(i->C[i] == c[i], 1:length(c))
-
   end
-
-
-
 
 
   @testset "wedge products" begin
@@ -89,5 +93,4 @@
     @test ind == I
     @test sign == -1
   end
-
 end


### PR DESCRIPTION
Testing some things to improve `combinations`.

~~Main thing at the moment is a custom iterator for `Combinations{Base.OneTo}` which gives a huge speedup :~~
False alarm, no big speedup. I was mutating the state vector in place and trying to use it directly for the `Combination`s...

The main change here is to allow different `IntegerUnion` types as the argument for `combinations(n,k)` and variants, this involves a change in the struct (previously `n` and `k` had to be `Int`s). Assuming everything passes tests, this just cleans up the code a bit and makes it a bit nicer to use for the user.