### PR TITLE
BasisLieHighestWeight: Allow internal monomial ordering types

### DIFF
--- a/experimental/BasisLieHighestWeight/src/BasisLieHighestWeight.jl
+++ b/experimental/BasisLieHighestWeight/src/BasisLieHighestWeight.jl
@@ -2,8 +2,12 @@ module BasisLieHighestWeight
 
 using ..Oscar
 using ..Oscar: IntegerUnion
-using ..Oscar: _is_weighted
 using ..Oscar: _root_system_type_string
+
+using ..Oscar.Orderings: _is_weighted
+using ..Oscar.Orderings: AbsGenOrdering
+using ..Oscar.Orderings: SymbOrdering
+using ..Oscar.Orderings: WSymbOrdering
 
 using Oscar.LieAlgebras: lie_algebra_simple_module_struct_consts_gap
 

--- a/experimental/BasisLieHighestWeight/src/MainAlgorithm.jl
+++ b/experimental/BasisLieHighestWeight/src/MainAlgorithm.jl
@@ -1,7 +1,7 @@
 function basis_lie_highest_weight_compute(
   V::ModuleData,
   operators::Vector{RootSpaceElem},     # monomial x_i is corresponds to f_operators[i]
-  monomial_ordering_symb::Symbol,
+  monomial_ordering_input::Union{AbsGenOrdering,Symbol},
 )
   # Pseudocode:
 
@@ -37,7 +37,12 @@ function basis_lie_highest_weight_compute(
   birational_seq = birational_sequence(operators, root_system(base_lie_algebra(V)))
 
   ZZx, _ = polynomial_ring(ZZ, length(operators)) # for our monomials
-  monomial_ordering = get_monomial_ordering(monomial_ordering_symb, ZZx, operators)
+  if monomial_ordering_input isa Symbol
+    abs_monomial_ordering = construct_abs_gen_ordering(monomial_ordering_input, operators)
+  else
+    abs_monomial_ordering = monomial_ordering_input
+  end
+  monomial_ordering = MonomialOrdering(ZZx, abs_monomial_ordering)
 
   # save computations from recursions
   calc_highest_weight = Dict{WeightLatticeElem,Set{ZZMPolyRingElem}}(
@@ -87,7 +92,7 @@ function basis_coordinate_ring_kodaira_compute(
   V::SimpleModuleData,
   degree::Int,
   operators::Vector{RootSpaceElem},     # monomial x_i is corresponds to f_operators[i]
-  monomial_ordering_symb::Symbol,
+  monomial_ordering_input::Union{AbsGenOrdering,Symbol},
 )
   # Pseudocode:
 
@@ -105,7 +110,12 @@ function basis_coordinate_ring_kodaira_compute(
   birational_seq = birational_sequence(operators, root_system(base_lie_algebra(V)))
 
   ZZx, _ = polynomial_ring(ZZ, length(operators)) # for our monomials
-  monomial_ordering = get_monomial_ordering(monomial_ordering_symb, ZZx, operators)
+  if monomial_ordering_input isa Symbol
+    abs_monomial_ordering = construct_abs_gen_ordering(monomial_ordering_input, operators)
+  else
+    abs_monomial_ordering = monomial_ordering_input
+  end
+  monomial_ordering = MonomialOrdering(ZZx, abs_monomial_ordering)
 
   # save computations from recursions
   calc_highest_weight = Dict{WeightLatticeElem,Set{ZZMPolyRingElem}}(

--- a/experimental/BasisLieHighestWeight/src/MonomialOrder.jl
+++ b/experimental/BasisLieHighestWeight/src/MonomialOrder.jl
@@ -3,7 +3,11 @@ function construct_abs_gen_ordering(
   operators::Vector{RootSpaceElem},
 )
   if _is_weighted(symb_monomial_ordering)
-    return WSymbOrdering(symb_monomial_ordering, 1:length(operators), [Int(height(alpha)) for alpha in operators])
+    return WSymbOrdering(
+      symb_monomial_ordering,
+      1:length(operators),
+      [Int(height(alpha)) for alpha in operators],
+    )
   else
     return SymbOrdering(symb_monomial_ordering, 1:length(operators))
   end

--- a/experimental/BasisLieHighestWeight/src/MonomialOrder.jl
+++ b/experimental/BasisLieHighestWeight/src/MonomialOrder.jl
@@ -1,14 +1,10 @@
-function get_monomial_ordering(
-  ordering_input::Union{Symbol,Function},
-  ZZx::ZZMPolyRing,
+function construct_abs_gen_ordering(
+  symb_monomial_ordering::Symbol,
   operators::Vector{RootSpaceElem},
 )
-  if _is_weighted(ordering_input)
-    choosen_monomial_order = monomial_ordering(
-      ZZx, ordering_input, [Int(height(alpha)) for alpha in operators]
-    )
+  if _is_weighted(symb_monomial_ordering)
+    return WSymbOrdering(symb_monomial_ordering, 1:length(operators), [Int(height(alpha)) for alpha in operators])
   else
-    choosen_monomial_order = monomial_ordering(ZZx, ordering_input)
+    return SymbOrdering(symb_monomial_ordering, 1:length(operators))
   end
-  return choosen_monomial_order
 end

--- a/experimental/BasisLieHighestWeight/src/UserFunctions.jl
+++ b/experimental/BasisLieHighestWeight/src/UserFunctions.jl
@@ -122,7 +122,8 @@ over Lie algebra of type C3
 ```
 """
 function basis_lie_highest_weight(
-  type::Symbol, rank::Int, highest_weight::Vector{Int}; monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex
+  type::Symbol, rank::Int, highest_weight::Vector{Int};
+  monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
 )
   L = lie_algebra(QQ, type, rank)
   V = SimpleModuleData(L, highest_weight)

--- a/experimental/BasisLieHighestWeight/src/UserFunctions.jl
+++ b/experimental/BasisLieHighestWeight/src/UserFunctions.jl
@@ -122,7 +122,7 @@ over Lie algebra of type C3
 ```
 """
 function basis_lie_highest_weight(
-  type::Symbol, rank::Int, highest_weight::Vector{Int}; monomial_ordering::Symbol=:degrevlex
+  type::Symbol, rank::Int, highest_weight::Vector{Int}; monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex
 )
   L = lie_algebra(QQ, type, rank)
   V = SimpleModuleData(L, highest_weight)
@@ -135,7 +135,7 @@ function basis_lie_highest_weight(
   rank::Int,
   highest_weight::Vector{Int},
   birational_sequence::Vector{Int};
-  monomial_ordering::Symbol=:degrevlex,
+  monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
 )
   L = lie_algebra(QQ, type, rank)
   V = SimpleModuleData(L, highest_weight)
@@ -148,7 +148,7 @@ function basis_lie_highest_weight(
   rank::Int,
   highest_weight::Vector{Int},
   birational_sequence::Vector{Vector{Int}};
-  monomial_ordering::Symbol=:degrevlex,
+  monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
 )
   L = lie_algebra(QQ, type, rank)
   V = SimpleModuleData(L, highest_weight)
@@ -461,7 +461,7 @@ function basis_coordinate_ring_kodaira(
   rank::Int,
   highest_weight::Vector{Int},
   degree::Int;
-  monomial_ordering::Symbol=:degrevlex,
+  monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
 )
   L = lie_algebra(QQ, type, rank)
   V = SimpleModuleData(L, highest_weight)
@@ -477,7 +477,7 @@ function basis_coordinate_ring_kodaira(
   highest_weight::Vector{Int},
   degree::Int,
   birational_sequence::Vector{Int};
-  monomial_ordering::Symbol=:degrevlex,
+  monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
 )
   L = lie_algebra(QQ, type, rank)
   V = SimpleModuleData(L, highest_weight)
@@ -493,7 +493,7 @@ function basis_coordinate_ring_kodaira(
   highest_weight::Vector{Int},
   degree::Int,
   birational_sequence::Vector{Vector{Int}};
-  monomial_ordering::Symbol=:degrevlex,
+  monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
 )
   L = lie_algebra(QQ, type, rank)
   V = SimpleModuleData(L, highest_weight)
@@ -608,7 +608,7 @@ function basis_lie_demazure(
   rank::Int,
   highest_weight::Vector{Int},
   weyl_group_elem::Vector{Int};
-  monomial_ordering::Symbol=:degrevlex,
+  monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
 )
   L = lie_algebra(QQ, type, rank)
   V = DemazureModuleData(L, highest_weight, weyl_group_elem)
@@ -622,7 +622,7 @@ function basis_lie_demazure(
   highest_weight::Vector{Int},
   weyl_group_elem::Vector{Int},
   birational_sequence::Vector{Int};
-  monomial_ordering::Symbol=:degrevlex,
+  monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
 )
   L = lie_algebra(QQ, type, rank)
   V = DemazureModuleData(L, highest_weight, weyl_group_elem)
@@ -636,7 +636,7 @@ function basis_lie_demazure(
   highest_weight::Vector{Int},
   weyl_group_elem::Vector{Int},
   birational_sequence::Vector{Vector{Int}};
-  monomial_ordering::Symbol=:degrevlex,
+  monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
 )
   L = lie_algebra(QQ, type, rank)
   V = DemazureModuleData(L, highest_weight, weyl_group_elem)


### PR DESCRIPTION
@imkhln please check if this suits your needs.
An example call using this is `basis_lie_highest_weight(:A, 3, [2, 2, 3]; monomial_ordering=Oscar.Orderings.WSymbOrdering(:wdeglex, 1:6, [1 for _ in 1:6]))`.

This uses a lot of internals, and is not user-friendly. Thus, I did not add this to any docstring (to make it possible to remove it again once we have a better way). How this could look like can be discussed in https://github.com/oscar-system/Oscar.jl/issues/5414.