### PR TITLE
docs: move "Experimental" before "Index"

### DIFF
--- a/docs/doc.main
+++ b/docs/doc.main
@@ -305,10 +305,14 @@
   ],
 
   "Straight Line Programs" => [
-      "StraightLinePrograms/intro.md",
-      "StraightLinePrograms/gapslps.md",
-      "StraightLinePrograms/abstractalgebra.md",
+    "StraightLinePrograms/intro.md",
+    "StraightLinePrograms/gapslps.md",
+    "StraightLinePrograms/abstractalgebra.md",
    ],
+
+  "Experimental: Tools in the Making" => [
+    # rest is populated by code in docs/make_work.jl
+  ],
 
   "References" => "references.md",
   "Index" => "manualindex.md",

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -116,7 +116,8 @@ function doit(
       append!(collected, pkgdocs)
     end
   end
-  push!(doc, ("Experimental" => collected))
+  pos = findfirst(d -> d isa Pair && startswith(d[1], "Experimental"), doc)
+  append!(doc[pos].second, collected)
 
   # Load the bibliography
   bib = CitationBibliography(


### PR DESCRIPTION
This way it is a bit easier to discover: while we don't want to put these too much into the focus, we also don't want to "hide" them behind Index, References and Developer Docs.

During the summer school, some people had trouble finding it and just didn't notice it unless explicitly being guided there.


Perhaps we should also rename this section, e.g. to "Experimental features" or "Experimental capabilities" or so?