### PR TITLE
Use `coefficient_ring` in serialization

### DIFF
--- a/src/Serialization/Rings.jl
+++ b/src/Serialization/Rings.jl
@@ -144,7 +144,7 @@ end
 # elements
 function save_object(s::SerializerState, p::Union{UniversalPolyRingElem, MPolyRingElem})
   # we use this line instead of typeof(coeff(p, 1)) to catch the 0 polynomial
-  coeff_type = elem_type(base_ring(parent(p)))
+  coeff_type = elem_type(coefficient_ring(p))
   save_data_array(s) do
     for i in 1:length(p)
       save_data_array(s) do 


### PR DESCRIPTION
As mentioned [here](https://github.com/Nemocas/AbstractAlgebra.jl/pull/2182#issuecomment-3373513518) this change is necessary to make Oscar compatible with https://github.com/Nemocas/AbstractAlgebra.jl/pull/2182.