### PR TITLE
Replace remaining `base_ring` calls for universal polynomials

### DIFF
--- a/src/Serialization/Rings.jl
+++ b/src/Serialization/Rings.jl
@@ -208,13 +208,13 @@ function load_object(s::DeserializerState, ::Type{<: PolyRingElem},
       push!(exponents, e)
     end
     degree = max(exponents...)
-    base = base_ring(parent_ring)
-    loaded_terms = zeros(base, degree)
-    coeff_type = elem_type(base)
+    coeff_ring = coefficient_ring(parent_ring)
+    loaded_terms = zeros(coeff_ring, degree)
+    coeff_type = elem_type(coeff_ring)
     for (i, exponent) in enumerate(exponents)
       load_node(s, i) do _
         load_node(s, 2) do _
-          loaded_terms[exponent] = load_object(s, coeff_type, base)
+          loaded_terms[exponent] = load_object(s, coeff_type, coeff_ring)
         end
       end
     end
@@ -228,12 +228,12 @@ function load_object(s::DeserializerState,
                      parent_ring::PolyRingUnionType)
   load_node(s) do terms
     exponents = [term[1] for term in terms]
-    base = base_ring(parent_ring)
+    coeff_ring = coefficient_ring(parent_ring)
     polynomial = MPolyBuildCtx(parent_ring)
-    coeff_type = elem_type(base)
+    coeff_type = elem_type(coeff_ring)
     for (i, e) in enumerate(exponents)
       load_node(s, i) do _
-        c = load_object(s, coeff_type, base, 2)
+        c = load_object(s, coeff_type, coeff_ring, 2)
         e_int = load_array_node(s, 1) do _
           load_object(s, Int)
         end


### PR DESCRIPTION
In #5420 I missed some calls to `base_ring`. Now the "Serialization/upgrades" tests, which are still failing in https://github.com/Nemocas/AbstractAlgebra.jl/pull/2182, run fine on my machine with the respective AbstractAblgebra version for the PR.