### PR TITLE
Avoid `base_ring` for universal polynomial rings in `ActionPolyRing`

### DIFF
--- a/experimental/ActionPolyRing/src/Content.jl
+++ b/experimental/ActionPolyRing/src/Content.jl
@@ -225,7 +225,7 @@ factor(apr::ActionPolyRingElem) = __wrap_factorization_apr(factor(data(apr)), pa
 
 ##### Rings #####
 
-base_ring(apr::ActionPolyRing) = base_ring(__upr(apr))
+base_ring(apr::ActionPolyRing) = coefficient_ring(__upr(apr))
 
 @doc raw"""
     n_elementary_symbols(A::ActionPolyRing) -> Int


### PR DESCRIPTION
In my mission to completing https://github.com/Nemocas/AbstractAlgebra.jl/pull/2182 I discovered that the experimental `ActionPolyRing` uses the universal polynomial rings. With this AbstractAlgebra PR the meaning of `base_ring` for universal polynomial rings will change and `coefficient_ring` should be used instead. Perhaps `coefficient_ring` should be implemented for the `ActionPolyRing` as well? (See: #1505 and https://github.com/Nemocas/AbstractAlgebra.jl/issues/1207)

@SirToby25 I'm pinging you as you are mentioned in the docs of the `ActionPolyRing`.