### PR TITLE
added coefficient_ring

### DIFF
--- a/experimental/ActionPolyRing/src/Content.jl
+++ b/experimental/ActionPolyRing/src/Content.jl
@@ -188,6 +188,8 @@ one(apr::ActionPolyRing) = apr(one(__upr(apr)))
 
 base_ring_type(::Type{<:ActionPolyRing{T}}) where {T} = parent_type(T)
 
+coefficient_ring_type(::Type{<:ActionPolyRing{T}}) where {T} = parent_type(T)
+
 is_square(apre::ActionPolyRingElem) = is_square(data(apre))
 
 Base.sqrt(apre::ActionPolyRingElem; check::Bool = true) = parent(apre)(sqrt(data(apre); check = check))
@@ -226,6 +228,8 @@ factor(apr::ActionPolyRingElem) = __wrap_factorization_apr(factor(data(apr)), pa
 ##### Rings #####
 
 base_ring(apr::ActionPolyRing) = base_ring(__upr(apr))
+
+coefficient_ring(apr::ActionPolyRing) = coefficient_ring(__upr(apr))
 
 @doc raw"""
     n_elementary_symbols(A::ActionPolyRing) -> Int
@@ -353,7 +357,7 @@ function to_univariate(apre::ActionPolyRingElem)
   end
   apr = parent(apre)
   x = symbols(apr)[var]
-  R, _ = base_ring(apr)[x]
+  R, _ = coefficient_ring(apr)[x]
   return to_univariate(R, apre)
 end
 
@@ -948,7 +952,7 @@ Base.iterate(x::ActionPolyTerms, state=0) = __iter_helper(term, x.poly, state)
 
 Base.length(x::Union{ActionPolyCoeffs, ActionPolyExponentVectors, ActionPolyMonomials, ActionPolyTerms}) = length(x.poly)
 
-Base.eltype(::Type{ActionPolyCoeffs{PolyT}}) where {PolyT<:ActionPolyRingElem} = elem_type(base_ring_type(PolyT))
+Base.eltype(::Type{ActionPolyCoeffs{PolyT}}) where {PolyT<:ActionPolyRingElem} = elem_type(coefficient_ring_type(PolyT))
 Base.eltype(::Type{ActionPolyExponentVectors{PolyT}}) where {PolyT<:ActionPolyRingElem} = Vector{Int}
 Base.eltype(::Type{ActionPolyMonomials{PolyT}}) where {PolyT<:ActionPolyRingElem} = PolyT
 Base.eltype(::Type{ActionPolyTerms{PolyT}}) where {PolyT<:ActionPolyRingElem} = PolyT

--- a/experimental/ActionPolyRing/src/IO.jl
+++ b/experimental/ActionPolyRing/src/IO.jl
@@ -13,7 +13,7 @@ function Base.show(io::IO, ::MIME"text/plain", dpr::DifferencePolyRing)
   print(io, "\n")
   print(io, "with $(n_action_maps(dpr)) commuting endomorphisms\n")
   print(io, Indent())
-  print(io, "over ", Lowercase(), base_ring(dpr))
+  print(io, "over ", Lowercase(), coefficient_ring(dpr))
   print(io, Dedent())
 end
 
@@ -23,7 +23,7 @@ function Base.show(io::IO, dpr::DifferencePolyRing)
     print(io, "Difference polynomial ring")
   else
     print(io, "Difference polynomial ring in $(n_elementary_symbols(dpr)) elementary symbols over ")
-    print(terse(io), Lowercase(), base_ring(dpr))
+    print(terse(io), Lowercase(), coefficient_ring(dpr))
   end
 end
 
@@ -36,7 +36,7 @@ function Base.show(io::IO, ::MIME"text/plain", dpr::DifferentialPolyRing)
   print(io, "\n")
   print(io, "with $(n_action_maps(dpr)) commuting derivations\n")
   print(io, Indent())
-  print(io, "over ", Lowercase(), base_ring(dpr))
+  print(io, "over ", Lowercase(), coefficient_ring(dpr))
   print(io, Dedent())
 end
 
@@ -46,7 +46,7 @@ function Base.show(io::IO, dpr::DifferentialPolyRing)
     print(io, "Differential polynomial ring")
   else
     print(io, "Differential polynomial ring in $(n_elementary_symbols(dpr)) elementary symbols over ")
-    print(terse(io), Lowercase(), base_ring(dpr))
+    print(terse(io), Lowercase(), coefficient_ring(dpr))
   end
 end
 

--- a/experimental/ActionPolyRing/test/ActionPolyRing.jl
+++ b/experimental/ActionPolyRing/test/ActionPolyRing.jl
@@ -28,11 +28,11 @@ using Test
   
   @testset "Check types" begin
     
-    @test base_ring_type(DifferencePolyRing{QQFieldElem}) == QQField
+    @test coefficient_ring_type(DifferencePolyRing{QQFieldElem}) == QQField
     @test elem_type(DifferencePolyRing{QQFieldElem}) == DifferencePolyRingElem{QQFieldElem}
     @test parent_type(DifferencePolyRingElem{QQFieldElem}) == DifferencePolyRing{QQFieldElem}
     
-    @test base_ring_type(DifferentialPolyRing{QQFieldElem}) == QQField
+    @test coefficient_ring_type(DifferentialPolyRing{QQFieldElem}) == QQField
     @test elem_type(DifferentialPolyRing{QQFieldElem}) == DifferentialPolyRingElem{QQFieldElem}
     @test parent_type(DifferentialPolyRingElem{QQFieldElem}) == DifferentialPolyRing{QQFieldElem}
 
@@ -164,8 +164,8 @@ using Test
         end
         
         @testset "Check public fields at construction" begin
-          @test base_ring(dpr) == ZZ
-          @test all(var -> base_ring(var) == ZZ, vars)
+          @test coefficient_ring(dpr) == ZZ
+          @test all(var -> coefficient_ring(var) == ZZ, vars)
           @test elementary_symbols(dpr) == [:u1, :u2, :u3]
           @test n_action_maps(dpr) == 3
           @test n_elementary_symbols(dpr) == 3
@@ -267,8 +267,8 @@ using Test
           end
         
           @testset "Check public fields after adding variables" begin
-            @test base_ring(dpr) == ZZ
-            @test all(var -> base_ring(var) == ZZ, vars)
+            @test coefficient_ring(dpr) == ZZ
+            @test all(var -> coefficient_ring(var) == ZZ, vars)
             @test elementary_symbols(dpr) == [:u1, :u2, :u3]
             @test n_action_maps(dpr) == 3
             @test n_elementary_symbols(dpr) == 3
@@ -525,8 +525,8 @@ using Test
           end
         
           @testset "Check public fields after changing ranking" begin
-            @test base_ring(dpr) == ZZ
-            @test all(var -> base_ring(var) == ZZ, vars)
+            @test coefficient_ring(dpr) == ZZ
+            @test all(var -> coefficient_ring(var) == ZZ, vars)
             @test elementary_symbols(dpr) == [:u1, :u2, :u3]
             @test n_action_maps(dpr) == 3
             @test n_elementary_symbols(dpr) == 3


### PR DESCRIPTION
This PR adds `coefficient_ring` and replaces the functionality of `base_ring` for action polynomial rings as a follow-up to the discussion in #5427. 