### PR TITLE
Remove leftover line in serialization

### DIFF
--- a/src/Serialization/Rings.jl
+++ b/src/Serialization/Rings.jl
@@ -95,7 +95,6 @@ end
 @register_serialization_type AbstractAlgebra.Generic.LaurentMPolyWrapRing uses_id
 
 function save_object(s::SerializerState, R::PolyRingUnionType)
-  base = base_ring(R)
   save_data_dict(s) do
     save_object(s, symbols(R), :symbols)
   end


### PR DESCRIPTION
While trying to find some errors with https://github.com/Nemocas/AbstractAlgebra.jl/pull/2184 I found a leftover line in the serialization code for polynomials which apparently didn't do anything useful.