### PR TITLE
Use `coefficient_ring` in `type_params` for `UniversalPolyRing`

### DIFF
--- a/src/Serialization/Rings.jl
+++ b/src/Serialization/Rings.jl
@@ -47,7 +47,7 @@ type_params(x::T) where T <: IdealUnionType = TypeParams(T, base_ring(x))
 # exclude from ring union
 type_params(::ZZRing) = TypeParams(ZZRing, nothing)
 type_params(::ZZRingElem) = TypeParams(ZZRingElem, nothing)
-type_params(R::UniversalPolyRing) = TypeParams(UniversalPolyRing, coefficient_ring(R))
+type_params(R::T) where T <: PolyRingUnionType = TypeParams(T, coefficient_ring(R))
 type_params(R::T) where T <: ModRingUnion = TypeParams(T, nothing)
 
 ################################################################################

--- a/src/Serialization/Rings.jl
+++ b/src/Serialization/Rings.jl
@@ -47,6 +47,7 @@ type_params(x::T) where T <: IdealUnionType = TypeParams(T, base_ring(x))
 # exclude from ring union
 type_params(::ZZRing) = TypeParams(ZZRing, nothing)
 type_params(::ZZRingElem) = TypeParams(ZZRingElem, nothing)
+type_params(R::UniversalPolyRing) = TypeParams(UniversalPolyRing, coefficient_ring(R))
 type_params(R::T) where T <: ModRingUnion = TypeParams(T, nothing)
 
 ################################################################################


### PR DESCRIPTION
I've found another instance of `base_ring` for universal polynomials which will break after https://github.com/Nemocas/AbstractAlgebra.jl/pull/2182. It took me quite some time to pinpoint the error I was seeing in the tests as the reported problem was just that a `1` (what ever its meaning was) was now of type `Char` and not `String` anymore.

@antonydellavecchia  I don't fully understand the serialization code so I'm not sure if it might be worth it to add more of these "exclude from ring union" for multivariate polynomials or univariate polynomials, just to be more in line with the universal polynomials.

