### PR TITLE
Feature update for action polynomial rings

### DIFF
--- a/experimental/ActionPolyRing/docs/src/action_polynomial_rings.md
+++ b/experimental/ActionPolyRing/docs/src/action_polynomial_rings.md
@@ -210,7 +210,6 @@ evaluate(a::PolyT, vars::Vector{PolyT}, vals::Vector{V}) where {PolyT <: ActionP
 ### Univariate polynomials
 
 ```@docs
-is_univariate(A::ActionPolyRing)
 is_univariate(p::ActionPolyRingElem)
 to_univariate(R::PolyRing{T}, p::ActionPolyRingElem{T}) where {T <: RingElement}
 to_univariate(p::ActionPolyRingElem)

--- a/experimental/ActionPolyRing/docs/src/action_polynomial_rings.md
+++ b/experimental/ActionPolyRing/docs/src/action_polynomial_rings.md
@@ -33,7 +33,7 @@ variables are sorted with respect to a user-defined [ranking](@ref actionpolyran
     The set of valid jet variables of an action polynomial ring depend only on the integers ``m`` and
     ``n`` and are thus known at the time of construction. For reasons of efficiency, we keep the list of
     tracked jet variables as short as possible and track jet variables only, if necessary. The list of
-    currently tracked jet variables is obtained, using
+    currently tracked jet variables is obtained using
     [`gens`](@ref gens(apr::ActionPolyRing)).
 
 Currently, there are two concrete subtypes available, namely `DifferencePolyRing{T}` and
@@ -180,6 +180,33 @@ total_degree(p::ActionPolyRingElem)
 derivative(p::ActionPolyRingElem, i::Int, jet::Vector{Int})
 ```
 
+### [Discriminant and resultant](@id discriminant_resultant_apr)
+
+```@docs
+discriminant(p::ActionPolyRingElem)
+resultant(f::ActionPolyRingElem, g::ActionPolyRingElem, i::Int, jet::Vector{Int})
+```
+
+### [Evaluation](@id evaluation_apr)
+
+The following function allows evaluation of a polynomial at all its variables. The result is always
+in the ring that a product of a coefficient and one of the values belongs to, i.e. if all the values
+are in the coefficient ring, the result of the evaluation will be too.
+
+```@docs
+evaluate(a::ActionPolyRingElem{T}, vals::Vector{V}) where {T <: RingElement, V <: RingElement}
+```
+
+The following functions allow evaluation of a polynomial at some of its variables. Note that the
+result will be a product of values and an element of the polynomial ring, i.e. even if all the
+values are in the coefficient ring and all variables are given values, the result will be a
+constant polynomial, not a coefficient.
+
+```@docs
+evaluate(a::ActionPolyRingElem{T}, vars::Vector{Int}, vals::Vector{V}) where {T <: RingElement, V <: RingElement}
+evaluate(a::PolyT, vars::Vector{PolyT}, vals::Vector{V}) where {PolyT <: ActionPolyRingElem, V <: RingElement}
+```
+
 ### Univariate polynomials
 
 ```@docs
@@ -187,5 +214,6 @@ is_univariate(A::ActionPolyRing)
 is_univariate(p::ActionPolyRingElem)
 to_univariate(R::PolyRing{T}, p::ActionPolyRingElem{T}) where {T <: RingElement}
 to_univariate(p::ActionPolyRingElem)
+univariate_coefficients(p::ActionPolyRingElem, i::Int, jet::Vector{Int})
 ```
 

--- a/experimental/ActionPolyRing/docs/src/difference_polynomial_rings.md
+++ b/experimental/ActionPolyRing/docs/src/difference_polynomial_rings.md
@@ -6,7 +6,7 @@ DocTestSetup = Oscar.doctestsetup()
 
 # [Difference polynomial rings](@id differencepolyring)
 
-A difference polynomial ring over the commutative ring ``R`` is an action polynomial ring ``A`` whose action maps are (injective) endomorphisms of ``A``, i.e. ``R``-linear that maps are also multiplicative.
+A difference polynomial ring over the commutative ring ``R`` is an action polynomial ring ``A`` whose action maps are (injective) endomorphisms of ``A``, i.e. ``R``-linear maps that are also multiplicative.
 
 ## Construction
 

--- a/experimental/ActionPolyRing/docs/src/rankings.md
+++ b/experimental/ActionPolyRing/docs/src/rankings.md
@@ -42,7 +42,7 @@ The way of combining of these two total orderings to obtain a total ordering of 
 ``\underline{m}``, i.e. by grouping the elements of ``\underline{m}`` into blocks. The first block is considered largest and so on.
 See [`partition`](@ref partition(r::ActionPolyRingRanking)).
 
-Consider two elements ``x_1 = (i_1, J_1), x_2 = (i_2, J_2)`` \in ``X``. Then ``x_1 < x_2`` if and only if:
+Consider two elements ``x_1 = (i_1, J_1), x_2 = (i_2, J_2) \in X``. Then ``x_1 < x_2`` if and only if:
 1. The block of ``i_1`` is smaller than the one of ``i_2``.
 2. ``i_1`` and ``i_2`` are in the same block and ``J_1 < J_2`` with respect to the total ordering on ``\mathbb{N}_0^n``.
 3. ``i_1`` and ``i_2`` are in the same block, ``J_1 = J_2`` and ``i_1 < i_2``.

--- a/experimental/ActionPolyRing/src/Content.jl
+++ b/experimental/ActionPolyRing/src/Content.jl
@@ -953,9 +953,7 @@ Return the coefficient vector of `p` regarded as a univariate polynomial in the 
 """
 function univariate_coefficients(r::ActionPolyRingElem, i::Int, jet::Vector{Int})
   d = degree(r, i, jet)
-  if d == 0
-    return [r]
-  end
+  d == 0 && return [r]
   res = [zero(r) for _ in 1:d+1]
   var = __jtv(parent(r))[(i, jet)]
   v_idx = var_index(var)

--- a/experimental/ActionPolyRing/src/Content.jl
+++ b/experimental/ActionPolyRing/src/Content.jl
@@ -903,11 +903,6 @@ function is_univariate_with_data(apre::ActionPolyRingElem)
   return flag, findfirst(==(gen_idx), __perm_for_sort(parent(apre)))
 end
 
-@doc raw"""
-    is_univariate(p::ActionPolyRing)
-
-Return `false`, since an action polynomial ring cannot be univariate.
-"""
 is_univariate(apr::ActionPolyRing) = false
 
 @doc raw"""

--- a/experimental/ActionPolyRing/src/Content.jl
+++ b/experimental/ActionPolyRing/src/Content.jl
@@ -899,9 +899,7 @@ is_univariate(apre::ActionPolyRingElem) = is_univariate(data(apre))
 
 function is_univariate_with_data(apre::ActionPolyRingElem)
   flag, gen_idx = is_univariate_with_data(data(apre))
-  if is_zero(gen_idx)
-    return (flag, gen_idx)
-  end
+  is_zero(gen_idx) && return flag, gen_idx
   return (flag, findfirst(==(gen_idx), __perm_for_sort(parent(apre))))
 end
 

--- a/experimental/ActionPolyRing/src/Content.jl
+++ b/experimental/ActionPolyRing/src/Content.jl
@@ -879,7 +879,7 @@ function discriminant(p::ActionPolyRingElem)
 
   ld = leader(p)
   
-  if degree(p, ld) % 4 in [0,1]
+  if degree(p, ld) % 4 in (0,1)
     return divexact(resultant(p, derivative(p, ld), ld), initial(p))
   end
   

--- a/experimental/ActionPolyRing/src/Content.jl
+++ b/experimental/ActionPolyRing/src/Content.jl
@@ -1008,7 +1008,7 @@ the corresponding jet variables specified by the indices given by the array `var
 multiplication is defined between elements of the coefficient ring of `a` and elements of `vals`.
 """
 function evaluate(a::ActionPolyRingElem{T}, vars::Vector{Int}, vals::Vector{V}) where {T <: RingElement, V <: RingElement}
-    S = parent(a)
+  S = parent(a)
   per = __perm_for_sort(S)
   return S(evaluate(data(a), map(x -> per[x], vars), vals))
 end

--- a/experimental/ActionPolyRing/src/Content.jl
+++ b/experimental/ActionPolyRing/src/Content.jl
@@ -900,7 +900,7 @@ is_univariate(apre::ActionPolyRingElem) = is_univariate(data(apre))
 function is_univariate_with_data(apre::ActionPolyRingElem)
   flag, gen_idx = is_univariate_with_data(data(apre))
   is_zero(gen_idx) && return flag, gen_idx
-  return (flag, findfirst(==(gen_idx), __perm_for_sort(parent(apre))))
+  return flag, findfirst(==(gen_idx), __perm_for_sort(parent(apre)))
 end
 
 @doc raw"""

--- a/experimental/ActionPolyRing/src/Content.jl
+++ b/experimental/ActionPolyRing/src/Content.jl
@@ -873,9 +873,7 @@ resultant(r1::ActionPolyRingElem, r2::ActionPolyRingElem, i::Int) = resultant(r1
 Return the discriminant of `p`.
 """
 function discriminant(p::ActionPolyRingElem)
-  if is_constant(p)
-    return zero(parent(p))
-  end
+  is_constant(p) && return zero(parent(p))
 
   ld = leader(p)
   

--- a/experimental/ActionPolyRing/src/IO.jl
+++ b/experimental/ActionPolyRing/src/IO.jl
@@ -70,9 +70,7 @@ end
 
 function expressify(a::ActionPolyRingElem, x = symbols(parent(a)); context = nothing)
   es = exponents(a)
-  if length(es) == 0
-    return Expr(:call, :+)
-  end
+  length(es) == 0 && return Expr(:call, :+)
 
   # Find index and highest exponent of the leader of a
   ld_ind, cur_exp = (0, 0)

--- a/experimental/ActionPolyRing/src/IO.jl
+++ b/experimental/ActionPolyRing/src/IO.jl
@@ -64,8 +64,8 @@ function __expressify_coeff_monomial!(coeff_prod::Expr, x, e, ld_ind)
       push!(coeff_prod.args, Expr(:call, :^, x[i], e[i]))
     elseif e[i] == 1
       push!(coeff_prod.args, x[i])
-    end 
-  end 
+    end
+  end
 end
 
 function expressify(a::ActionPolyRingElem, x = symbols(parent(a)); context = nothing)

--- a/experimental/ActionPolyRing/src/IO.jl
+++ b/experimental/ActionPolyRing/src/IO.jl
@@ -58,31 +58,74 @@ end
 
 @enable_all_show_via_expressify ActionPolyRingElem
 
-function _expressify_monomial!(prod::Expr, x, e)
-  @inbounds for i in 1:length(e)
-    if e[i] > 1
-      push!(prod.args, Expr(:call, :^, x[i], e[i]))  # deepcopy not needed for immutables
+function __expressify_coeff_monomial!(coeff_prod::Expr, x, e, ld_ind)
+  @inbounds for i in (ld_ind + 1):length(e)
+    if e[i] > 1 
+      push!(coeff_prod.args, Expr(:call, :^, x[i], e[i]))
     elseif e[i] == 1
-      push!(prod.args, x[i])
-    end
-  end
+      push!(coeff_prod.args, x[i])
+    end 
+  end 
 end
 
 function expressify(a::ActionPolyRingElem, x = symbols(parent(a)); context = nothing)
-  sum = Expr(:call, :+)
+  es = exponents(a)
+  if length(es) == 0
+    return Expr(:call, :+)
+  end
 
-  for (c, e) in zip(coefficients(a), exponents(a))
-    if all(zero(eltype(e)) == ei for ei in e)  # constant term
-      push!(sum.args, expressify(c, context = context))
-    else
-      prod = Expr(:call, :*)
-      push!(prod.args, expressify(c, context = context))
-      _expressify_monomial!(prod, x, e)
-      push!(sum.args, prod)
+  # Find index and highest exponent of the leader of a
+  ld_ind, cur_exp = (0, 0)
+  for (i, v) in enumerate(first(es))
+    if v != 0
+      ld_ind, cur_exp = i, v
+      break
     end
   end
 
-  return sum
+  if ld_ind == 0 # a is an element of the base ring
+    return Expr(:call, :+, expressify(coeff(a, 1), context = context))  
+  end
+
+  sum = Expr(:call, :+)
+  ld = x[ld_ind]
+  prev_exp = cur_exp
+  coeff_sum = Expr(:call, :+)
+  for (c, e) in zip(coefficients(a), es)
+    cur_exp = e[ld_ind]
+    coeff_prod = Expr(:call, :*) 
+    push!(coeff_prod.args, expressify(c, context = context))
+    __expressify_coeff_monomial!(coeff_prod, x, e, ld_ind)
+
+    if cur_exp == prev_exp # still part of the coefficient sum
+      push!(coeff_sum.args, coeff_prod)
+      continue
+    end
+      
+    # At this point, coeff_prod is part of the new coeff_sum, so we push the old (with the old exponent) and reset afterwards
+    coeff_ld_exp_prod = Expr(:call, :*, coeff_sum) # Multiply coefficient term and exponent of the leader
+    if prev_exp > 1
+      push!(coeff_ld_exp_prod.args, Expr(:call, :^, ld, prev_exp))
+    elseif prev_exp == 1
+      push!(coeff_ld_exp_prod.args, ld)
+    end
+    push!(sum.args, coeff_ld_exp_prod)
+
+    # Reset
+    prev_exp = cur_exp
+    coeff_sum = Expr(:call, :+, coeff_prod)
+  end 
+
+  # At this point, the last summand is not yet pushed, so we do it manually
+  coeff_ld_exp_prod = Expr(:call, :*, coeff_sum) # Multiply coefficient term and exponent of the leader
+  if cur_exp > 1
+    push!(coeff_ld_exp_prod.args, Expr(:call, :^, ld, cur_exp))
+  elseif cur_exp == 1
+    push!(coeff_ld_exp_prod.args, ld)
+  end
+  push!(sum.args, coeff_ld_exp_prod)
+
+  return sum 
 end
 
 ###############################################################################

--- a/experimental/ActionPolyRing/src/Types.jl
+++ b/experimental/ActionPolyRing/src/Types.jl
@@ -204,3 +204,4 @@ mutable struct ActionPolyRingRanking{PolyT <: ActionPolyRing}
   end
   
 end
+

--- a/experimental/ActionPolyRing/src/exports.jl
+++ b/experimental/ActionPolyRing/src/exports.jl
@@ -19,4 +19,5 @@ export riquier_matrix
 export set_ranking!
 export trailing_monomial
 export trailing_term
+export univariate_coefficients
 

--- a/experimental/ActionPolyRing/test/ActionPolyRing.jl
+++ b/experimental/ActionPolyRing/test/ActionPolyRing.jl
@@ -770,6 +770,95 @@ using Test
           @test is_zero(derivative(g, (2, [10,4,2]))) && ngens(dpr) == 3
         end
 
+        @testset "resultant" begin
+          @test resultant(f, f, (1, [0,0,0])) == 0
+          @test resultant(f, f, (2, [0,0,0])) == 0
+          @test resultant(f, f, (3, [0,0,0])) == 1 
+          @test resultant(f, f, (1, [1,1,1])) == 1
+
+          @test resultant(f, g, 1) == 4*u2^3
+          @test resultant(g, f, 1) == 4*u2^3
+
+          @test resultant(f, g, 2) == -3*u1^3*u3
+          @test resultant(g, f, 2) == 3*u1^3*u3
+
+          @test resultant(f, g, 3) == u1*u2
+          @test resultant(g, f, 3) == u1*u2
+
+          @test resultant(u1^5, dpr(2), u1) == 2^5
+          @test resultant(u1^2 -2*u1 + 1, (u1 - 1)*u2*u3^2, 1) == 0
+
+          @test_throws ArgumentError resultant(u1^5, dpr(2), u1^5)
+          @test_throws ArgumentError resultant(f, g, (0, [1,1,1]))
+          @test_throws ArgumentError resultant(f, g, (1, [1,1,1,1]))
+          @test_throws ArgumentError resultant(f, g, (1, [1,1]))
+          @test_throws ArgumentError resultant(f, g, (1, [1,-1,1]))
+        end
+
+        @testset "discriminant" begin
+          # degree -1
+          @test discriminant(zero(dpr)) == 0
+          
+          # degree 0
+          @test discriminant(one(dpr)) == 0
+          @test discriminant(dpr(-17)) == 0
+          
+          # degree 1
+          @test discriminant(f) == 1
+          @test discriminant(u1) == 1
+          @test discriminant(u1*u2*u3) == 1
+          @test discriminant(-47*u2 + 45*u3 - 2) == 1
+          
+          # degree 2
+          @test discriminant(g) == 48*u2*u3
+          @test discriminant(4*u1^2*u2^2*u3 - 6*u1*u2*u3 + 9*u3) == -108*u2^2*u3^2
+          @test discriminant(4*u1^2*u2^2*u3 - 12*u1*u2*u3 + 9*u3) == 0
+
+          # degree 3
+          h = u2^4*u1^6*u3^8 - 4*u2^3*u1^4*u3^6 - 34*u2^2*u1^6*u3^4 + 4*u2^2*u1^2*u3^4 + 68*u2*u1^4*u3^2 + 289*u1^6
+          @test discriminant(h) == 0
+          @test discriminant(h + 1) == -65536*u2^22*u3^44 - 110592*u2^21*u3^42 + 8866240*u2^20*u3^40 + 16920576*u2^19*u3^38 -
+                                        522385792*u2^18*u3^36 - 1150599168*u2^17*u3^34 + 17424027328*u2^16*u3^32 + 45640433664*u2^15*u3^30 -
+                                        355647746560*u2^14*u3^28 - 1163831058432*u2^13*u3^26 + 4392579194752*u2^12*u3^24 +
+                                        19785127993344*u2^11*u3^22 - 27598930471168*u2^10*u3^20 - 224231450591232*u2^9*u3^18 -
+                                        21358465855616*u2^8*u3^16 + 1633686282878976*u2^7*u3^14 + 1840208095645184*u2^6*u3^12 -
+                                        6943166702235648*u2^5*u3^10 - 14645742262528320*u2^4*u3^8 + 13114870437556224*u2^3*u3^6 +
+                                        55328359658440320*u2^2*u3^4 - 94058211419348544
+        end
+
+        @testset "evaluation" begin
+          @test f(0) == 0
+          @test f(1,1,1) == 1
+          @test f(1,1,2) == 1
+          @test evaluate(f, [1,3], [1,0]) == u2
+          @test evaluate(f, [2,3], [2,3]) == 2*u1
+          @test evaluate(f, [u1, u3], [-5,2]) == -5*u2
+          @test evaluate(f, Int[], Int[]) == f
+          @test evaluate(g, Int[], Int[]) == g
+        end
+
+        @testset "univariate coefficients" begin
+          #f = u1*u2
+          #g = -3*u1^2*u3 + 4*u2
+          @test univariate_coefficients(f, u1) == [zero(dpr), u2]
+          @test univariate_coefficients(f, u2) == [zero(dpr), u1]
+          @test univariate_coefficients(f, u3) == [u1*u2]
+          @test univariate_coefficients(f, (1, [0,0,0])) == [zero(dpr), u2]
+          @test univariate_coefficients(f, (2, [0,0,0])) == [zero(dpr), u1]
+          @test univariate_coefficients(f, (3, [0,0,0])) == [u1*u2]
+          @test univariate_coefficients(f, 1) == [zero(dpr), u2]
+          @test univariate_coefficients(f, 2) == [zero(dpr), u1]
+          @test univariate_coefficients(f, 3) == [u1*u2]
+          @test_throws ArgumentError univariate_coefficients(f, (0, [0,0,0]))
+          @test_throws ArgumentError univariate_coefficients(f, (1, [0,-1,0]))
+          @test_throws ArgumentError univariate_coefficients(f, (1, [0,0,0,0]))
+
+          @test univariate_coefficients(g, 1) == [4*u2, zero(dpr), -3*u3]
+          @test univariate_coefficients(g, 2) == [-3*u1^2*u3, dpr(4)]
+          @test univariate_coefficients(g, 3) == [4*u2, -3*u1^2]
+          @test univariate_coefficients(g, (1, [1,1,1])) == [g]
+        end
+
         @testset "diff action" begin
           if dpr isa DifferencePolyRing
             @test is_zero(diff_action(dpr(), 1))
@@ -843,6 +932,6 @@ using Test
         end
       end #End for loop
     end #End further constructions
-  end #Construction and basic field acces
+  end #Construction and basic field access
 
 end #All tests


### PR DESCRIPTION
This PR adds some basic methods that are still missing for action polynomial rings, including:

-  `evaluate`
-  `resultant`
-  `discriminant`

We also provide tests for these new methods. 
Additionally, action polynomials are now printed as a univariate in their leader (their largest variable) - some doctests were added to check that it works as intended. Finally, we fixed some typos in the documentation, regrouped and shifted all methods regarding univariate polynomials and added the method `univariate_coefficients`.