### PR TITLE
Hotfix Oscar.build()

### DIFF
--- a/system/Build.jl
+++ b/system/Build.jl
@@ -3,7 +3,7 @@ oscarpath = dirname(@__DIR__)
 using Pkg
 Pkg.activate(temp=true)
 target = Pkg.project().path
-source = source = "$(Oscar.oscardir)/test/Project.toml"
+source = joinpath(oscarpath, "test", "Project.toml")
 run(`cp -v $(source) $(target)`, wait=true)
 run(`chmod -v +w $(target)`, wait=true)
 Pkg.develop(path="$(oscarpath)")

--- a/system/Build.jl
+++ b/system/Build.jl
@@ -18,8 +18,6 @@ CO = joinpath(tmp, "CompileOscar.jl")
 
 
 write(CO, """
-using Pkg
-Pkg.develop(path="$(oscarpath)")
 using Oscar
 using Test
 Oscar.system("precompile.jl")

--- a/system/Build.jl
+++ b/system/Build.jl
@@ -2,6 +2,10 @@ oscarpath = dirname(@__DIR__)
 
 using Pkg
 Pkg.activate(temp=true)
+target = Pkg.project().path
+source = source = "$(Oscar.oscardir)/test/Project.toml"
+run(`cp -v $(source) $(target)`, wait=true)
+run(`chmod -v +w $(target)`, wait=true)
 Pkg.develop(path="$(oscarpath)")
 using Oscar
 Pkg.add("PackageCompiler")

--- a/system/precompile.jl
+++ b/system/precompile.jl
@@ -1,7 +1,4 @@
 import Pkg
-Pkg.add("Documenter")
-Pkg.add("PrettyTables")
-Pkg.add("JSONSchema")
 Pkg.precompile()
 ENV["OSCAR_TEST_SUBSET"] = "short"
 include(joinpath(pkgdir(Oscar), "test", "runtests.jl"))


### PR DESCRIPTION
Fixes #5421 for now.

John wrote in the issue

> I note that in triage there were some significant-sounding comments from @lgoettgens and from @benlorenz about why a redesign might be needed.

I would love to hear from @lgoettgens and @benlorenz about a better design. My attitude towards `Oscar.build()` has just been to patch things until it works without really thinking about it too much.