### PR TITLE
Use GenericCharacterTables 0.7.1 for book tests

### DIFF
--- a/test/book/cornerstones/groups/auxiliary_code/main.jl
+++ b/test/book/cornerstones/groups/auxiliary_code/main.jl
@@ -1,3 +1,3 @@
 import Pkg
-Pkg.add(name="GenericCharacterTables", version="0.4"; io=devnull)
+Pkg.add(name="GenericCharacterTables", version="0.7"; io=devnull)
 using GenericCharacterTables

--- a/test/book/cornerstones/groups/auxiliary_code/main.jl
+++ b/test/book/cornerstones/groups/auxiliary_code/main.jl
@@ -1,3 +1,3 @@
 import Pkg
-Pkg.add(name="GenericCharacterTables", version="0.7"; io=devnull)
+Pkg.add(name="GenericCharacterTables", version="0.7.1"; io=devnull)
 using GenericCharacterTables

--- a/test/book/cornerstones/groups/genchar-v1.13.jlcon
+++ b/test/book/cornerstones/groups/genchar-v1.13.jlcon
@@ -6,7 +6,7 @@ Generic character table SL3.n1
   with parameters (a, b, m, n)
 
 julia> T[4,4]
-exp(2π𝑖((-2*a*n)//(q - 1))) + (q + 1)*exp(2π𝑖((a*n)//(q - 1)))
+E(q - 1)^(-2*a*n) + (q + 1)*E(q - 1)^(a*n)
 
 julia> h = T[2] * T[2];
 

--- a/test/book/cornerstones/groups/genchar.jlcon
+++ b/test/book/cornerstones/groups/genchar.jlcon
@@ -6,7 +6,7 @@ Generic character table SL3.n1
   with parameters (a, b, m, n)
 
 julia> T[4,4]
-(q + 1)*exp(2π𝑖((a*n)//(q - 1))) + exp(2π𝑖((-2*a*n)//(q - 1)))
+(q + 1)*E(q - 1)^(a*n) + E(q - 1)^(-2*a*n)
 
 julia> h = T[2] * T[2];
 


### PR DESCRIPTION
To make the book tests compatible with https://github.com/Nemocas/AbstractAlgebra.jl/pull/2182 we need use GenericCharacterTables 0.7.0.