### PR TITLE
Add `character_degrees` for a given group or character table, or for given invariants of a finite abelian group and finite field

### DIFF
--- a/docs/src/Groups/group_characters.md
+++ b/docs/src/Groups/group_characters.md
@@ -131,6 +131,7 @@ order_field_of_definition(chi::GAPGroupClassFunction)
 
 ```@docs
 block_distribution
+character_degrees
 character_parameters
 class_names(tbl::GAPGroupCharacterTable)
 class_parameters

--- a/experimental/GModule/src/GModule.jl
+++ b/experimental/GModule/src/GModule.jl
@@ -871,18 +871,18 @@ function _irred_abelian(G::Oscar.GAPGroup, F::FinField)
 
     # `orblen` is the length of the Galois orbit over `F`.
     # Compute `L, K, z` where
-    # `L` is the smallest field that contains `F` and a prim. `o`-th root,
+    # `L` is the smallest field in char. `p` that contains a prim. `o`-th root,
     # `K` is the intersection of `L` and `F`,
     # and `z` is an element of order `o` in `L`.
     # These values depend only on `o`.
     # (The irred. `F`-repres. of `G` live already over `K`,
     # we work over `K` and later write the matrices over `F`.)
-    L, K, z = get(rootinfo, o) do
-      m = k * orblen
+    L, K, z = get!(rootinfo, o) do
+      m = modord(p, o) # Note: `orblen == modord(q, o)` divides `m`
       L = GF(p, m)
       return L,
              GF(p, gcd(k, m)),
-             Oscar.DiscLog.generator(L)^divexact(p^m-1, o)
+             Oscar.DiscLog.element_of_given_order(L, o)
     end
 
     mp = embed(K, L)

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -34,6 +34,7 @@ GAP.@wrap CentreOfCharacter(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap CF(x::Any)::GapObj
 GAP.@wrap CF(x::Any, y::Any)::GapObj
 GAP.@wrap Characteristic(x::Any)::GapInt
+GAP.@wrap CharacterDegrees(x::GapObj)::GapObj
 GAP.@wrap CharacterParameters(x::GapObj)::GapObj
 GAP.@wrap CharacterTable(x::GapObj)::GapObj
 GAP.@wrap CharacterTable(x::GapObj, y::GAP.Obj)::GapObj

--- a/src/Rings/FinField.jl
+++ b/src/Rings/FinField.jl
@@ -45,6 +45,17 @@ end
   return a
 end
 
+function element_of_given_order(K::T, o::ZZRingElem) where {T <: FinField}
+  @req is_positive(o) "order must be positive"
+  q = order(K)
+  e = divexact(q-1, o)
+  lp = [divexact(o, p) for (p,k) in factor(o)]
+  while true
+    a = rand(K)^e
+    (!is_zero(a) && all(!isone(a^x) for x in lp)) && return a
+  end
+end
+
 function disc_log(a::FinFieldElem, b::FinFieldElem)
   Nemo.check_parent(a, b)
   da = disc_log(a)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -378,6 +378,7 @@ export chain_polytope
 export chain_range
 export chamber
 export chamber_invariants
+export character_degrees
 export character_field
 export character_lattice
 export character_parameters

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -1382,3 +1382,23 @@ end
   chi = t[2]
   @test_throws ArgumentError stabilizer(g, chi)
 end
+
+@testset "character degrees" begin
+  # for character tables
+  D = character_degrees(character_table("S5"))
+  @test sort(collect(D)) == [1, 1, 4, 4, 5, 5, 6]
+  @test D isa MSet{ZZRingElem}
+  D2 = character_degrees(Int, character_table("S5"))
+  @test sort(collect(D)) == sort(collect(D2))
+  @test D2 isa MSet{Int}
+  @test sort(collect(character_degrees(character_table("S5", 2)))) == [1, 4, 4]
+
+  # for groups
+  @test sort(collect(character_degrees(symmetric_group(5)))) == sort(collect(D))
+
+  # for invariant lists of abelian groups, and order of a finite field
+  D = character_degrees([3, 3, 5], 2)
+  @test sort(collect(D)) == sort(collect(MSet([1, 2, 4], [1, 4, 9])))
+  D = character_degrees([2, 4, 8], 3)
+  @test sort(collect(D)) == sort(collect(MSet([1, 2], [8, 28])))
+end

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -1386,19 +1386,20 @@ end
 @testset "character degrees" begin
   # for character tables
   D = character_degrees(character_table("S5"))
-  @test sort(collect(D)) == [1, 1, 4, 4, 5, 5, 6]
+  @test D == MSet(ZZRingElem[1, 4, 5, 6], [2, 2, 2, 1])
   @test D isa MSet{ZZRingElem}
   D2 = character_degrees(Int, character_table("S5"))
   @test sort(collect(D)) == sort(collect(D2))
+  @test_throws ArgumentError D == D2
   @test D2 isa MSet{Int}
-  @test sort(collect(character_degrees(character_table("S5", 2)))) == [1, 4, 4]
+  @test character_degrees(character_table("S5", 2)) == MSet(ZZRingElem[1, 4], [1, 2])
 
   # for groups
-  @test sort(collect(character_degrees(symmetric_group(5)))) == sort(collect(D))
+  @test character_degrees(symmetric_group(5)) == D
 
   # for invariant lists of abelian groups, and order of a finite field
-  D = character_degrees([3, 3, 5], 2)
-  @test sort(collect(D)) == sort(collect(MSet([1, 2, 4], [1, 4, 9])))
-  D = character_degrees([2, 4, 8], 3)
-  @test sort(collect(D)) == sort(collect(MSet([1, 2], [8, 28])))
+  @test character_degrees([3, 3, 5], 2) == MSet(ZZRingElem[1, 2, 4], [1, 4, 9])
+  @test character_degrees([3, 3, 5], 4) == MSet(ZZRingElem[1, 2], [9, 18])
+  @test character_degrees([3, 3, 5], 16) == MSet(ZZRingElem[1, 45])
+  @test character_degrees([2, 4, 8], 3) == MSet(ZZRingElem[1, 2], [8, 28])
 end

--- a/test/Groups/group_characters.jl
+++ b/test/Groups/group_characters.jl
@@ -1386,20 +1386,20 @@ end
 @testset "character degrees" begin
   # for character tables
   D = character_degrees(character_table("S5"))
-  @test D == MSet(ZZRingElem[1, 4, 5, 6], [2, 2, 2, 1])
+  @test D == multiset(ZZRingElem[1, 4, 5, 6], [2, 2, 2, 1])
   @test D isa MSet{ZZRingElem}
   D2 = character_degrees(Int, character_table("S5"))
   @test sort(collect(D)) == sort(collect(D2))
   @test_throws ArgumentError D == D2
   @test D2 isa MSet{Int}
-  @test character_degrees(character_table("S5", 2)) == MSet(ZZRingElem[1, 4], [1, 2])
+  @test character_degrees(character_table("S5", 2)) == multiset(ZZRingElem[1, 4], [1, 2])
 
   # for groups
   @test character_degrees(symmetric_group(5)) == D
 
   # for invariant lists of abelian groups, and order of a finite field
-  @test character_degrees([3, 3, 5], 2) == MSet(ZZRingElem[1, 2, 4], [1, 4, 9])
-  @test character_degrees([3, 3, 5], 4) == MSet(ZZRingElem[1, 2], [9, 18])
-  @test character_degrees([3, 3, 5], 16) == MSet(ZZRingElem[1, 45])
-  @test character_degrees([2, 4, 8], 3) == MSet(ZZRingElem[1, 2], [8, 28])
+  @test character_degrees([3, 3, 5], 2) == multiset(ZZRingElem[1, 2, 4], [1, 4, 9])
+  @test character_degrees([3, 3, 5], 4) == multiset(ZZRingElem[1, 2], [9, 18])
+  @test character_degrees([3, 3, 5], 16) == multiset(ZZRingElem[1], [45])
+  @test character_degrees([2, 4, 8], 3) == multiset(ZZRingElem[1, 2], [8, 28])
 end

--- a/test/Rings/FinField.jl
+++ b/test/Rings/FinField.jl
@@ -7,4 +7,13 @@
   @test disc_log(z, z^15) == 0
   @test disc_log(z^2, z) == 8
   @test_throws "disc_log failed" disc_log(z, zero(z))
+
+  for o in divisors(order(F)-1)
+    a = Oscar.DiscLog.element_of_given_order(F, o)
+    @test is_one(a^o)
+  end
+  @test is_primitive(Oscar.DiscLog.element_of_given_order(F, order(F)-1))
+  @test_throws ArgumentError Oscar.DiscLog.element_of_given_order(F, order(F))
+  @test_throws ArgumentError Oscar.DiscLog.element_of_given_order(F, ZZ(0))
+  @test_throws ArgumentError Oscar.DiscLog.element_of_given_order(F, ZZ(-3))
 end


### PR DESCRIPTION
add `character_degrees`:
- for a given group or character table, delegate to GAP,
- for given invariants of a finite abelian group and finite field, use Julia code.

and improve `_irred_abelian`:
- add `Oscar.DiscLog.element_of_given_order`, as suggested by Claus, and use this function in `_irred_abelian(G::Oscar.GAPGroup, F::FinField)`,
- work with a smaller field `L` (somehow this idea had been lost in the previous version)