### PR TITLE
Actually use `default_ordering` member of `SubModuleOfFreeModule`

### DIFF
--- a/src/Modules/ModuleTypes.jl
+++ b/src/Modules/ModuleTypes.jl
@@ -227,7 +227,7 @@ generate the submodule) (computed via `generator_matrix()`) are cached.
   F::FreeMod{T}
   groebner_basis::Dict{ModuleOrdering, ModuleGens{T}}
   gens::ModuleGens{T}
-  default_ordering::ModuleOrdering
+  default_ordering::ModuleOrdering{FreeMod{T}}
   any_gb::ModuleGens{T} # A field to store the first groebner basis ever computed.
                         # Lookups in the above dictionary is tentatively expensive. 
                         # So this field stores any gb for cases where the actual 

--- a/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
+++ b/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
@@ -143,7 +143,6 @@ end
 Get the default ordering of `M`.
 """
 function default_ordering(M::SubModuleOfFreeModule)
-  return default_ordering(ambient_free_module(M))
   if !isdefined(M, :default_ordering)
     ord = default_ordering(ambient_free_module(M))
     set_default_ordering!(M, ord)


### PR DESCRIPTION
This partially reverts a change by @HechtiDerLachs made in PR #4116 -- this may be wrong!

That PR inserted a `return ...` line which this PR deletes, and which basically deleted the code afterwards.

Perhaps reverting this is *wrong* (hopefully CI and/or @HechtiDerLachs will tell us). But in that case, we need another PR, because right now we have a `.default_ordering` member in `SubModuleOfFreeModule` that can be set via `set_default_ordering!` method, but is not used. If that's intentionally, we should remove it, and also remove the `set_default_ordering!` method (or turn it into an explicit error that indicates what went wrong and what the user should do instead).

(But note that `set_default_ordering!` for `SubquoModule` does `set_default_ordering!(M.sub, ord)` among other things...)