### PR TITLE
Add `ensure_efficient_setup_is_done(::MatrixGroup)`

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -57,6 +57,18 @@ function (G::GAPGroup)(x::BasicGAPGroupElem{T}) where T<:GAPGroup
    return group_element(G, GapObj(x))
 end
 
+function ensure_efficient_setup_is_done(_::Group)
+   # currently a groups in general
+   return
+end
+
+function ensure_efficient_setup_is_done(G::MatrixGroup)
+   if is_infinite(base_ring(G))
+      is_finite(G) # force computation of a nice mono
+   end
+   return
+end
+
 """
     is_finite(G::GAPGroup) -> Bool
 
@@ -684,12 +696,7 @@ julia> length(small_generating_set(abelian_group(PermGroup, [2,3,4])))
 ```
 """
 @gapattribute function small_generating_set(G::GAPGroup)
-   # We claim that the finiteness check is cheap in Oscar.
-   # This does not hold in GAP,
-   # and GAP's method selection benefits from the known finiteness flag.
-   if G isa MatrixGroup && is_infinite(base_ring(G))
-     is_finite(G)
-   end
+   ensure_efficient_setup_is_done(G)
 
    L = GAP.Globals.SmallGeneratingSet(GapObj(G))::GapObj
    res = Vector{elem_type(G)}(undef, length(L))
@@ -2664,9 +2671,7 @@ function describe(G::GAPGroup)
    is_finitely_generated(G) || return "a non-finitely generated group"
 
    # force some checks in some cases
-   if G isa MatrixGroup && is_infinite(base_ring(G))
-      is_finite(G)
-   end
+   ensure_efficient_setup_is_done(G)
 
    # handle groups whose finiteness is known
    if has_is_finite(G)


### PR DESCRIPTION
This addresses one point in https://github.com/oscar-system/Oscar.jl/issues/5348, namely that we should factor out a function that currently creates a nice mono on the gap side, but can be changed to also do other things.

I called this function in the places where we currently do a similar thing manually. More places can be easily added later on.