### PR TITLE
Fix construction of an `sideal` in `_fglm` to use a concrete type parameter

### DIFF
--- a/src/Rings/groebner/fglm.jl
+++ b/src/Rings/groebner/fglm.jl
@@ -51,7 +51,8 @@ function _fglm(G::IdealGens, ordering::MonomialOrdering)
   SR_destination, = Singular.polynomial_ring(base_ring(G.gensBiPolyArray.Sx), symbols(G.gensBiPolyArray.Sx); ordering = singular(ordering))
 
   ptr = Singular.libSingular.fglmzero(SG.ptr, G.gensBiPolyArray.Sx.ptr, SR_destination.ptr)
-  return IdealGens(base_ring(G), Singular.sideal{Singular.spoly}(SR_destination, ptr, true))
+  T = typeof(SG)  # Singular.sideal{Singular.spoly}
+  return IdealGens(base_ring(G), T(SR_destination, ptr, true))
 end
 
 @doc raw"""

--- a/src/Rings/groebner/fglm.jl
+++ b/src/Rings/groebner/fglm.jl
@@ -48,9 +48,10 @@ function _fglm(G::IdealGens, ordering::MonomialOrdering)
   (G.isGB == true && G.isReduced == true) || error("Input must be a reduced Gröbner basis.")
   SG = singular_generators(G)
   Singular.dimension(SG) == 0 || error("Dimension of corresponding ideal must be zero.")
-  SR_destination, = Singular.polynomial_ring(base_ring(G.gensBiPolyArray.Sx), symbols(G.gensBiPolyArray.Sx); ordering = singular(ordering))
+  Sx = base_ring(SG)
+  SR_destination, = Singular.polynomial_ring(base_ring(Sx), symbols(Sx); ordering = singular(ordering))
 
-  ptr = Singular.libSingular.fglmzero(SG.ptr, G.gensBiPolyArray.Sx.ptr, SR_destination.ptr)
+  ptr = Singular.libSingular.fglmzero(SG.ptr, Sx.ptr, SR_destination.ptr)
   T = typeof(SG)  # Singular.sideal{Singular.spoly}
   return IdealGens(base_ring(G), T(SR_destination, ptr, true))
 end


### PR DESCRIPTION
Previously this constructed an `sideal{spoly}`. Now the type is e.g. `sideal{spoly{n_Q}`. Currently both work but future Singular.jl versions will (hopefully) be more strict about this, in order to make its code less type unstable.

The second commit also replaces some uses of `gensBiPolyArray`.


This is needed for https://github.com/oscar-system/Singular.jl/pull/892.