### PR TITLE
Remove a fishy line in the non-commutative Gröbner basis code

### DIFF
--- a/src/Rings/FreeAssociativeAlgebraIdeal.jl
+++ b/src/Rings/FreeAssociativeAlgebraIdeal.jl
@@ -218,7 +218,6 @@ function groebner_basis(g::IdealGens{<:FreeAssociativeAlgebraElem},
   probabilistic::Bool = false
   )
   gb = groebner_basis(collect(g), deg_bound; ordering=ordering, protocol=protocol, interreduce=interreduce, algorithm=algorithm, probabilistic=probabilistic)
-  gb = Generic.FreeAssociativeAlgebraElem{QQFieldElem}[x for x in gb]
   return IdealGens(gb)
 end
 


### PR DESCRIPTION
I tried this example posted recently on Slack:
```
K = GF(3)
(R,(λ₁,λ₂,λ₃,λ₄,λ₅,λ₆,λ₇,λ₈,λ₉,v₀,v₁,v₂,v₃)) = free_associative_algebra(K,[:λ₁,:λ₂,:λ₃,:λ₄,:λ₅,:λ₆,:λ₇,:λ₈,:λ₉,:v₀,:v₁,:v₂,:v₃])
rels = [v₀*v₁-v₁*v₀]
G = groebner_basis(ideal(R,rels))
```
and got:
```
ERROR: MethodError: Cannot `convert` an object of type
  AbstractAlgebra.Generic.FreeAssociativeAlgebraElem{FqFieldElem} to an object of type
  AbstractAlgebra.Generic.FreeAssociativeAlgebraElem{QQFieldElem}
The function `convert` exists, but no method is defined for this combination of argument types.
[...]
```

From what I can see, the line attempting this conversion is unnecessary because `gb` is already a `Vector` of `Generic.FreeAssociativeAlgebraElem`s before. And it is obviously wrong, if the algebra does not happen to live over $\mathbb Q$.

Of course, somebody who knows about non-commutative Gröbner bases should review this carefully and possibly give me an example I can add to the tests.
