### PR TITLE
Serialize `:cyclo` attribute for `AbsSimpleNumField`

### DIFF
--- a/src/Serialization/Fields.jl
+++ b/src/Serialization/Fields.jl
@@ -74,7 +74,7 @@ end
 # SimpleNumField
 
 @register_serialization_type Hecke.RelSimpleNumField uses_id
-@register_serialization_type AbsSimpleNumField uses_id
+@register_serialization_type AbsSimpleNumField uses_id [:cyclo]
 const SimNumFieldTypeUnion = Union{AbsSimpleNumField, Hecke.RelSimpleNumField}
 
 type_params(obj::T) where T <: SimpleNumField = TypeParams(T, parent(defining_polynomial(obj)))

--- a/test/Serialization/Fields.jl
+++ b/test/Serialization/Fields.jl
@@ -39,5 +39,12 @@
         @test loaded isa QQBarField
       end
     end
+
+    @testset "Cyclotomic fields" begin
+      K, _ = cyclotomic_field(3)
+      test_save_load_roundtrip(path, K; check_func = x -> Hecke.is_cyclotomic_type(x)[1]) do loaded
+        @test loaded == K
+      end
+    end
   end
 end


### PR DESCRIPTION
Since so far there was no big outcry, this implements the solution I proposed in #5466 .
~Unfortunately, I don't see how this can be tested; if one saves and loads a cyclotomic field *in the same session* then the "cyclotomic-ness" is remembered also without this pull request.~
