### PR TITLE
Fix docs build with julia 1.12

### DIFF
--- a/experimental/ActionPolyRing/docs/doc.main
+++ b/experimental/ActionPolyRing/docs/doc.main
@@ -7,4 +7,3 @@
       "rankings.md"
    ],  
 ]
-


### PR DESCRIPTION
Resolves the issue observed in the CI of https://github.com/JuliaDocs/Documenter.jl/pull/2777.

I propose to force-merge this once the docs job has finished to unblock the Documenter.jl release.

@benlorenz @fingolfin would it make sense to have another CI job that tries to build the docs with julia `"1"` (aka the latest stable release) to notice such things earlier?