### PR TITLE
Use `MPolyBuildCtx` in `homogeneous_component`

### DIFF
--- a/experimental/IntersectionTheory/src/IntersectionTheory.jl
+++ b/experimental/IntersectionTheory/src/IntersectionTheory.jl
@@ -10,6 +10,7 @@ import ..Oscar: intersection_matrix
 import ..Oscar: chern_class
 import ..Oscar: IntegerUnion
 import ..Oscar: localization
+import ..Oscar: _homogeneous_components
 import ..AbstractAlgebra: polynomial
 
 

--- a/experimental/IntersectionTheory/src/Misc.jl
+++ b/experimental/IntersectionTheory/src/Misc.jl
@@ -38,13 +38,8 @@ function Base.getindex(x::MPolyDecRingOrQuoElem, d::Int)
 end
 
 function Base.getindex(x::MPolyDecRingOrQuoElem, degs::Vector{FinGenAbGroupElem})
-  R = parent(x)
-  comps = homogeneous_components(x)
-  ans = typeof(x)[]
-  for d in degs
-    push!(ans, d in keys(comps) ? R(comps[d]) : R())
-  end
-  ans
+  comps = _homogeneous_components(x, degs)
+  return collect(values(comps))
 end
 
 function Base.getindex(x::MPolyDecRingOrQuoElem, I::AbstractUnitRange)

--- a/experimental/IntersectionTheory/src/Misc.jl
+++ b/experimental/IntersectionTheory/src/Misc.jl
@@ -38,8 +38,8 @@ function Base.getindex(x::MPolyDecRingOrQuoElem, d::Int)
 end
 
 function Base.getindex(x::MPolyDecRingOrQuoElem, degs::Vector{FinGenAbGroupElem})
-  comps = _homogeneous_components(x, degs)
-  return collect(values(comps))
+  comp_dict = _homogeneous_components(x, degs)
+  return [comp_dict[d] for d in degs]
 end
 
 function Base.getindex(x::MPolyDecRingOrQuoElem, I::AbstractUnitRange)

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -1525,8 +1525,12 @@ Dict{FinGenAbGroupElem, MPolyQuoRingElem{MPolyDecRingElem{QQFieldElem, QQMPolyRi
 ```
 """
 function homogeneous_components(a::MPolyQuoRingElem{<:MPolyDecRingElem})
+  return _homogeneous_components(a, nothing)
+end
+
+function _homogeneous_components(a::MPolyQuoRingElem{<:MPolyDecRingElem}, degs::Union{Nothing, Vector{<:FinGenAbGroupElem}})
   simplify(a)
-  h = homogeneous_components(a.f)
+  h = _homogeneous_components(a.f, degs)
   return Dict{keytype(h), typeof(a)}(x => parent(a)(y) for (x, y) in h)
 end
 

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -1350,19 +1350,24 @@ z
 """
 function homogeneous_component(a::MPolyDecRingElem, g::FinGenAbGroupElem)
   R = forget_decoration(parent(a))
-  r = R(0)
+  D = grading_group(parent(a))
   d = parent(a).d
-  for (c, m) = Base.Iterators.zip(MPolyCoeffs(forget_decoration(a)), Generic.MPolyMonomials(forget_decoration(a)))
-    e = exponent_vector(m, 1)
-    u = parent(a).D[0]
-    for i=1:length(e)
-      u += e[i]*d[i]
+  dmat = reduce(vcat, [d[i].coeff for i in 1:length(d)])
+  tmat = zero_matrix(ZZ, 1, nvars(R))
+  res_mat = zero_matrix(ZZ, 1, ncols(dmat))
+  aa = forget_decoration(a)
+  ctx = MPolyBuildCtx(R)
+  for (c, e) in Base.Iterators.zip(AbstractAlgebra.coefficients(aa), AbstractAlgebra.exponent_vectors(aa))
+    for i in 1:length(e)
+      tmat[1, i] = e[i]
     end
+    mul!(res_mat, tmat, dmat)
+    u = FinGenAbGroupElem(D, res_mat)
     if u == g
-      r += c*m
+      push_term!(ctx, c, e)
     end
   end
-  return parent(a)(r)
+  return parent(a)(finish(ctx))
 end
 
 function homogeneous_component(a::MPolyDecRingElem, g::IntegerUnion)


### PR DESCRIPTION
Related to #5483.
Using the huge polynomial from the issue, I get the following timings:

Before
```
julia> @time inv_c[1];
 36.323587 seconds (550.49 M allocations: 19.290 GiB, 41.88% gc time)
```
After
```
julia> @time inv_c[1];
  2.965286 seconds (28.97 M allocations: 1.727 GiB, 39.47% gc time)
```

~There is now quite some duplication of code between `homogeneous_component` and `homogeneous_components`, but I don't see how one could call the other in an "efficient" way. I am open for suggestions.~
