### PR TITLE
Use `base_ring` in action poly ring

### DIFF
--- a/experimental/ActionPolyRing/src/Types.jl
+++ b/experimental/ActionPolyRing/src/Types.jl
@@ -108,7 +108,7 @@ mutable struct DifferencePolyRingElem{T} <: ActionPolyRingElem{T}
 
   function DifferencePolyRingElem{T}(dpr::DifferencePolyRing{T}, mpre::MPolyRingElem{T}) where {T}
     upr = dpr.upoly_ring
-    @req upr.mpoly_ring === parent(mpre) "The parent does not match"
+    @req base_ring(upr) === parent(mpre) "The parent does not match"
     new{T}(upr(collect(coefficients(mpre)), collect(exponents(mpre))), dpr, false, zeros(Int, length(mpre)))
   end
 
@@ -161,7 +161,7 @@ mutable struct DifferentialPolyRingElem{T} <: ActionPolyRingElem{T}
 
   function DifferentialPolyRingElem{T}(dpr::DifferentialPolyRing{T}, mpre::MPolyRingElem{T}) where {T}
     upr = dpr.upoly_ring
-    @req upr.mpoly_ring === parent(mpre) "The parent does not match"
+    @req base_ring(upr) === parent(mpre) "The parent does not match"
     new{T}(upr(collect(coefficients(mpre)), collect(exponents(mpre))), dpr, false, zeros(Int, length(mpre)))
   end
 


### PR DESCRIPTION
In https://github.com/Nemocas/AbstractAlgebra.jl/pull/2182 @fingolfin suggested to change the name of the field name `mpoly_ring` for universal polynomial rings. This causes a test failure in the action polynomial code. Previously the code directly accessed the field `mpoly_ring` which was a bad idea in the first place. I've now adapted it to call the new `base_ring` method for universal polynomial rings instead. Of course this will break the tests here again since https://github.com/Nemocas/AbstractAlgebra.jl/pull/2182 isn't merged yet. Instead of `base_ring(upr)` we could write something like `parent(data(upr()))` which would serve the same purpose but be compatible with the current AbstractAlgebra release.

@SirToby25 Do you actually need these constructors which currently access the `mpoly_ring` field directly? Note that the current implementations is also rather inefficient.