### PR TITLE
Fix `rational_solutions` to not produce an error on certain zero dimensional ideals

### DIFF
--- a/src/Rings/solving.jl
+++ b/src/Rings/solving.jl
@@ -153,36 +153,48 @@ julia> map(r->map(p->evaluate(p, r), gens(I)), rat_sols)
 ```
 """
 function rational_solutions(I::MPolyIdeal{<:MPolyRingElem})
-  gb = groebner_basis(I, ordering = lex(base_ring(I)))
   R = base_ring(I)
   K = base_ring(R)
-  if 1 in gb
-    return elem_type(base_ring(R))[]
-  end
   @req dim(I) == 0 "Dimension must be zero"
-  @assert length(gb) == ngens(base_ring(I))
-  R = base_ring(I)
-  Qx, _ = polynomial_ring(base_ring(R); cached = false)
-  rts = [elem_type(Qx)[zero(Qx) for i = gens(R)]]
-  i = ngens(R)
-  for f in gb
-    sts = Vector{elem_type(Qx)}[]
+  # note that what follows does not assume shape position of the points any more
+  G = groebner_basis(I; ordering = lex(R))
+  if 1 in G
+    return elem_type(K)[]
+  end
+  xs = collect(gens(R))
+  n  = length(xs)
+  Qx, t = polynomial_ring(K; cached = false)
+  occurs_only_from_i(f, i) = all(degree(f, xs[j]) == 0 for j in 1:(i-1))
+  Gslices = [ [ f for f in G if occurs_only_from_i(f, i) ] for i in 1:n ]
+  rts = [elem_type(Qx)[zero(Qx) for _ in 1:n]]
+  for i in n:-1:1
+    Gi = Gslices[i]
+    isempty(Gi) && error("Elimination slice empty at step $i (unexpected for dim 0).")
+    new_rts = Vector{Vector{elem_type(Qx)}}()
     for r in rts
-      r[i] = gen(Qx)
-      g = evaluate(f, r)
-      rt = roots(g)
-      for x in rt
-        r[i] = Qx(x)
-        push!(sts, copy(r))
+      r[i] = t
+      first = true
+      h = zero(Qx)
+      for f in Gi
+        p = evaluate(f, r)
+        if first
+          h = p; first = false
+        else
+          h = gcd(h, p)
+        end
+      end
+      h == 0 && error("Unexpected zero polynomial")
+      for a in roots(h)
+        r[i] = Qx(a)
+        push!(new_rts, copy(r))
       end
     end
-    rts = sts
-    i -= 1
+    rts = new_rts
   end
-  #for technical reasons (evaluation) the points are actually at this
-  #point constant polynomials, hence:
-  return Vector{elem_type(K)}[elem_type(K)[constant_coefficient(x) for x in r] for r in rts]
+  sols = [elem_type(K)[constant_coefficient(x) for x in r] for r in rts]
+  return unique(sols)
 end
+
 
 @doc raw"""
     rational_solutions(K::Field, I::MPolyIdeal) -> Vector{Vector}

--- a/test/Rings/solving.jl
+++ b/test/Rings/solving.jl
@@ -103,3 +103,11 @@ end
     @test length(rational_solutions(algebraic_closure(QQ), i)) == 2
   end
 end
+
+@testset "Jacobian" begin
+  R,(x,y) = polynomial_ring(algebraic_closure(QQ), [:x,:y])
+  g = (x^2+y^2-1)*y*(x-3*y)
+  si = ideal([g]) + jacobi_ideal(g)
+  v=rational_solutions(si)
+  @test length(v) == 5
+end

--- a/test/Rings/solving.jl
+++ b/test/Rings/solving.jl
@@ -107,7 +107,7 @@ end
 @testset "Jacobian" begin
   R,(x,y) = polynomial_ring(algebraic_closure(QQ), [:x,:y])
   g = (x^2+y^2-1)*y*(x-3*y)
-  si = ideal([g]) + jacobi_ideal(g)
+  si = ideal([g]) + jacobian_ideal(g)
   v=rational_solutions(si)
   @test length(v) == 5
 end


### PR DESCRIPTION
Work towards resolving the bug in `rational_solutions` from #5465 due to assuming shape position and radical.