### PR TITLE
Prepare serialization code for JSON changes

### DIFF
--- a/src/Serialization/Upgrades/0.11.3.jl
+++ b/src/Serialization/Upgrades/0.11.3.jl
@@ -7,7 +7,7 @@
 
 push!(upgrade_scripts_set, UpgradeScript(
   v"0.11.3", # version this script upgrades to
-  function upgrade_0_11_3(s::UpgradeState, dict::Dict)
+  function upgrade_0_11_3(s::UpgradeState, dict::AbstractDict{Symbol, Any})
     # moves down tree to point where type exists in dict
     # since we are only doing updates based on certain types
     # no :type key implies the dict is data
@@ -63,7 +63,7 @@ push!(upgrade_scripts_set, UpgradeScript(
       # here by dicts, and we do nothing else; if the objects are basic,
       # they are represented by strings, and we'll add the `entry_type`
       # to the vector data below...
-      if upgraded_vector[1] isa Dict
+      if upgraded_vector[1] isa AbstractDict
         upgraded_dict = Dict(
           :type => "Vector",
           :id => dict[:id],
@@ -76,7 +76,7 @@ push!(upgrade_scripts_set, UpgradeScript(
         return upgraded_dict
       end
 
-      upgraded_dict = Dict(
+      upgraded_dict = AbstractDict(
         :type => "Vector",
         :id => dict[:id],
         :data => Dict(

--- a/src/Serialization/Upgrades/0.11.3.jl
+++ b/src/Serialization/Upgrades/0.11.3.jl
@@ -64,10 +64,10 @@ push!(upgrade_scripts_set, UpgradeScript(
       # they are represented by strings, and we'll add the `entry_type`
       # to the vector data below...
       if upgraded_vector[1] isa AbstractDict
-        upgraded_dict = Dict(
+        upgraded_dict = Dict{Symbol, Any}(
           :type => "Vector",
           :id => dict[:id],
-          :data => Dict(
+          :data => Dict{Symbol, Any}(
             :vector => upgraded_vector
           )
         )
@@ -76,10 +76,10 @@ push!(upgrade_scripts_set, UpgradeScript(
         return upgraded_dict
       end
 
-      upgraded_dict = AbstractDict(
+      upgraded_dict = Dict{Symbol, Any}(
         :type => "Vector",
         :id => dict[:id],
-        :data => Dict(
+        :data => Dict{Symbol, Any}(
           :vector => upgraded_vector,
           :entry_type => entry_type
         )
@@ -125,7 +125,7 @@ push!(upgrade_scripts_set, UpgradeScript(
 
 
     upgraded_data = upgrade_0_11_3(s, dict[:data])
-    upgraded_dict = Dict(
+    upgraded_dict = Dict{Symbol, Any}(
       :type => dict_type,
       :data => upgraded_data,
       :id => dict[:id]

--- a/src/Serialization/Upgrades/0.12.0.jl
+++ b/src/Serialization/Upgrades/0.12.0.jl
@@ -56,7 +56,8 @@ push!(upgrade_scripts_set, UpgradeScript(
       s.id_to_dict[Symbol(dict[:id])] = upgraded_dict
     elseif haskey(dict, :id)
       # remove ids for objects that dont require references
-      id = pop!(upgraded_dict, :id)
+      id = upgraded_dict[:id]
+      delete!(upgraded_dict, :id)
       s.id_to_dict[Symbol(id)] = upgraded_dict
     end
 

--- a/src/Serialization/Upgrades/0.12.0.jl
+++ b/src/Serialization/Upgrades/0.12.0.jl
@@ -7,7 +7,7 @@
 
 push!(upgrade_scripts_set, UpgradeScript(
   v"0.12.0",
-  function upgrade_0_12_0(s::UpgradeState, dict::Dict)
+  function upgrade_0_12_0(s::UpgradeState, dict::AbstractDict{Symbol, Any})
     ref_types = ["MPolyRing", "MatSpace", "RationalFunctionField", "MPolyComplementOfPrimeIdeal", "Hecke.RelNonSimpleNumFieldEmbedding", "MPolyPowersOfElement", "PermGroup", "SMatSpace", "Hecke.RelSimpleNumFieldEmbedding", "FPGroup", "FinGenAbGroup", "Hecke.AbsSimpleNumFieldEmbedding", "Hecke.QuadSpace", "HypersurfaceModel", "GlobalTateModel", "FracField", "AbsSimpleNumField", "ZZLaurentSeriesRing", "SubFPGroup", "Hecke.RelSimpleNumField", "MPolyDecRing", "SeriesRing", "EmbeddedNumField", "TropicalCurve", "FreeAssociativeAlgebra", "WeierstrassModel", "Hecke.AbsNonSimpleNumFieldEmbedding", "AffineNormalToricVariety", "Polymake.BigObject", "WeylGroup", "MPolyLocalizedRingHom", "LaurentSeriesField", "MPolyComplementOfKPointIdeal", "UniversalPolyRing", "MPolyQuoLocRing", "GapObj", "AbstractLieAlgebra", "AbsNonSimpleNumField", "Hecke.RelNonSimpleNumField", "fqPolyRepField", "PcGroup", "PolyRing", "NormalToricVariety", "SubPcGroup", "LaurentSeriesRing", "AbstractAlgebra.Generic.LaurentMPolyWrapRing"]
     # moves down tree to point where type exists in dict
     # since we are only doing updates based on certain types
@@ -47,7 +47,7 @@ push!(upgrade_scripts_set, UpgradeScript(
     end
 
     # handle data upgrade (recurse on sub tree)
-    if haskey(dict, :data) && dict[:data] isa Dict
+    if haskey(dict, :data) && dict[:data] isa AbstractDict
       upgraded_dict[:data] = upgrade_0_12_0(s, dict[:data])
     end
 

--- a/src/Serialization/Upgrades/0.12.2.jl
+++ b/src/Serialization/Upgrades/0.12.2.jl
@@ -74,7 +74,7 @@ push!(upgrade_scripts_set, UpgradeScript(
         end
       end
 
-      local_refs = Dict()
+      local_refs = Dict{Symbol, Any}()
       upgraded_parents = []
 
       # using the parent list we attach the refs 
@@ -82,7 +82,7 @@ push!(upgrade_scripts_set, UpgradeScript(
       for parent in parents
         id = parent[:id]
         
-        pushfirst!(upgraded_parents, Dict(:id => id, :type => "#backref"))
+        pushfirst!(upgraded_parents, Dict{Symbol, Any}(:id => id, :type => "#backref"))
         if haskey(local_refs, Symbol(id))
           continue
         end
@@ -93,7 +93,7 @@ push!(upgrade_scripts_set, UpgradeScript(
           base_dict = parent[:data][:base_ring]
 
           if haskey(base_dict, :id)
-            parent[:data][:base_ring] = Dict(:id => base_dict[:id], :type => "#backref")
+            parent[:data][:base_ring] = Dict{Symbol, Any}(:id => base_dict[:id], :type => "#backref")
           end
         end
         local_refs[Symbol(id)] = parent
@@ -129,7 +129,7 @@ push!(upgrade_scripts_set, UpgradeScript(
           exponent += 1
         end
       end
-      upgraded_dict[:data] = Dict(:terms => terms, 
+      upgraded_dict[:data] = Dict{Symbol, Any}(:terms => terms, 
                                   :parents => upgraded_parents)
       merge!(s.id_to_dict, local_refs)
     end

--- a/src/Serialization/Upgrades/0.12.2.jl
+++ b/src/Serialization/Upgrades/0.12.2.jl
@@ -22,7 +22,7 @@
 
 push!(upgrade_scripts_set, UpgradeScript(
   v"0.12.2",
-  function upgrade_0_12_2(s::UpgradeState, dict::Dict)
+  function upgrade_0_12_2(s::UpgradeState, dict::AbstractDict{Symbol, Any})
     s.nested_level += 1
     # moves down tree to point where type exists in dict
     # since we are only doing updates based on certain types
@@ -117,7 +117,7 @@ push!(upgrade_scripts_set, UpgradeScript(
         # to the new terms format
         exponent = 0
         for coeff in upgraded_dict[:data][:coeffs][:data][:vector]
-          if !isa(coeff, Dict)
+          if !isa(coeff, AbstractDict)
             upgraded_coeff = coeff
           elseif haskey(coeff[:data], :polynomial)
             upgraded_coeff = upgrade_0_12_2(s, coeff[:data][:polynomial])[:data][:terms]

--- a/src/Serialization/Upgrades/0.13.0.jl
+++ b/src/Serialization/Upgrades/0.13.0.jl
@@ -38,11 +38,11 @@ end
 
 push!(upgrade_scripts_set, UpgradeScript(
   v"0.13.0",
-  function upgrade_0_13_0(s::UpgradeState, dict::Dict)
+  function upgrade_0_13_0(s::UpgradeState, dict::AbstractDict{Symbol, Any})
     upgraded_dict = dict
     if !haskey(dict, :type)
       # this section deals will PolyRings and MPolyRings
-      if haskey(dict, :base_ring) && dict[:base_ring] isa Dict
+      if haskey(dict, :base_ring) && dict[:base_ring] isa AbstractDict
         if dict[:base_ring][:type] == "#backref"
           upgraded_dict[:base_ring] = dict[:base_ring][:id]
         else
@@ -55,7 +55,7 @@ push!(upgrade_scripts_set, UpgradeScript(
           upgraded_dict[:base_ring][:_type] = dict[:base_ring][:type]
         end
         if haskey(dict, :symbols)
-          if dict[:symbols] isa Dict
+          if dict[:symbols] isa AbstractDict
             upgraded_dict[:symbols] = dict[:symbols][:data][:vector]
           end
         end
@@ -79,7 +79,7 @@ push!(upgrade_scripts_set, UpgradeScript(
     end
 
     # type has already been updated
-    if haskey(dict, :_type) && dict[:_type] isa Dict
+    if haskey(dict, :_type) && dict[:_type] isa AbstractDict
       return dict
     end
     if contains(type_string, "Vector")
@@ -87,7 +87,7 @@ push!(upgrade_scripts_set, UpgradeScript(
       # which was our primary focus, this may be updated upon request
       error("The upgrade script needs an update")
     elseif contains(type_string, "PolyRingElem")
-      if dict[:data] isa Dict && haskey(dict[:data], :parents)
+      if dict[:data] isa AbstractDict && haskey(dict[:data], :parents)
         # this currently only handles one parent
         upgraded_parent = dict[:data][:parents][end]
         params = upgraded_parent[:id]
@@ -126,13 +126,13 @@ push!(upgrade_scripts_set, UpgradeScript(
       end
       upgraded_dict[:data] = upgraded_gens
     elseif contains(type_string, "MPolyRing")
-      if dict[:data][:base_ring] isa Dict
+      if dict[:data][:base_ring] isa AbstractDict
         if dict[:data][:base_ring][:type] == "#backref"
           upgraded_dict[:data][:base_ring] = dict[:data][:base_ring][:id]
         end
       end
       # has already been updated
-      if !(dict[:data][:symbols] isa Dict)
+      if !(dict[:data][:symbols] isa AbstractDict)
         return dict
       end
       upgraded_dict[:data][:symbols] = dict[:data][:symbols][:data][:vector]
@@ -166,7 +166,7 @@ push!(upgrade_scripts_set, UpgradeScript(
     end
 
     if contains(type_string, "Field")
-      if dict[:data] isa Dict &&haskey(dict[:data], :def_pol)
+      if dict[:data] isa AbstractDict && haskey(dict[:data], :def_pol)
         upgraded_dict[:data][:def_pol] = upgrade_0_13_0(s, dict[:data][:def_pol])
       end
     end

--- a/src/Serialization/Upgrades/0.13.0.jl
+++ b/src/Serialization/Upgrades/0.13.0.jl
@@ -98,15 +98,15 @@ push!(upgrade_scripts_set, UpgradeScript(
         error("The upgrade script needs an update")
       end
 
-      upgraded_dict[:_type] = Dict(:name => type_string, :params => params)
+      upgraded_dict[:_type] = Dict{Symbol, Any}(:name => type_string, :params => params)
     elseif contains(type_string, "NamedTuple")
       upgraded_tuple = upgrade_0_13_0(s, dict[:data][:content])
 
-      params = Dict(
+      params = Dict{Symbol, Any}(
         :tuple_params => upgraded_tuple[:_type][:params],
         :names => dict[:data][:keys][:data][:content]
       )
-      upgraded_dict[:_type] = Dict(:name => type_string, :params => params)
+      upgraded_dict[:_type] = Dict{Symbol, Any}(:name => type_string, :params => params)
       upgraded_dict[:data] = upgraded_tuple[:data]
 
     elseif contains(type_string, "Nemo.fpField")
@@ -119,7 +119,7 @@ push!(upgrade_scripts_set, UpgradeScript(
       upgraded_dict[:data] = string(dict[:data][:characteristic])
     elseif contains(type_string, "MPolyIdeal")
       upgraded_parent = upgrade_0_13_0(s, dict[:data][:parent])[:id]
-      upgraded_dict[:_type] = Dict(:name => type_string, :params => upgraded_parent)
+      upgraded_dict[:_type] = Dict{Symbol, Any}(:name => type_string, :params => upgraded_parent)
       upgraded_gens = []
       for gen in dict[:data][:gens][:data][:vector]
         push!(upgraded_gens, upgrade_0_13_0(s, gen)[:data])
@@ -153,11 +153,11 @@ push!(upgrade_scripts_set, UpgradeScript(
           push!(entry_data, dict[:data][:content][i])
         end
       end
-      upgraded_dict[:_type] = Dict(:name => type_string, :params => params)
+      upgraded_dict[:_type] = Dict{Symbol, Any}(:name => type_string, :params => params)
       upgraded_dict[:data] = entry_data
     elseif contains(type_string, "Matrix")
       params = dict[:data][:matrix][1][:data][:entry_type]
-      upgraded_dict[:_type] = Dict(:name => "Matrix", :params => params)
+      upgraded_dict[:_type] = Dict{Symbol, Any}(:name => "Matrix", :params => params)
       matrix_data = []
       for v in dict[:data][:matrix]
         push!(matrix_data, v[:data][:vector])
@@ -172,7 +172,7 @@ push!(upgrade_scripts_set, UpgradeScript(
     end
 
     if haskey(upgraded_dict, :refs)
-      upgraded_refs = Dict()
+      upgraded_refs = Dict{Symbol, Any}()
       for (k, v) in upgraded_dict[:refs]
         upgraded_refs[k] = upgrade_0_13_0(s, v)
       end

--- a/src/Serialization/Upgrades/0.15.0.jl
+++ b/src/Serialization/Upgrades/0.15.0.jl
@@ -4,7 +4,7 @@
 
 push!(upgrade_scripts_set, UpgradeScript(
   v"0.15.0",
-  function upgrade_0_15_0(s::UpgradeState, dict::Dict)
+  function upgrade_0_15_0(s::UpgradeState, dict::AbstractDict{Symbol, Any})
     renamings = Dict{String,String}([
       ("FlintPadicField", "PadicField"),
       ("padic", "PadicFieldElem"),
@@ -30,7 +30,7 @@ push!(upgrade_scripts_set, UpgradeScript(
 
     upgraded_dict = rename_types(dict, renamings)
     
-    if haskey(dict, :data) && dict[:data] isa Dict
+    if haskey(dict, :data) && dict[:data] isa AbstractDict
       upgraded_dict[:data] = upgrade_0_15_0(s, dict[:data])
     end
 

--- a/src/Serialization/Upgrades/0.15.0.jl
+++ b/src/Serialization/Upgrades/0.15.0.jl
@@ -35,7 +35,7 @@ push!(upgrade_scripts_set, UpgradeScript(
     end
 
     if haskey(dict, :_refs)
-      upgraded_refs = Dict()
+      upgraded_refs = Dict{Symbol, Any}()
       for (k, v) in dict[:_refs]
         upgraded_refs[k] = upgrade_0_15_0(s, v)
       end

--- a/src/Serialization/Upgrades/1.1.0.jl
+++ b/src/Serialization/Upgrades/1.1.0.jl
@@ -6,7 +6,7 @@
 
 push!(upgrade_scripts_set, UpgradeScript(
   v"1.1.0",
-  function upgrade_1_1_0(s::UpgradeState, dict::Dict)
+  function upgrade_1_1_0(s::UpgradeState, dict::AbstractDict{Symbol, Any})
 
     upgraded_dict = dict
 
@@ -19,7 +19,7 @@ push!(upgrade_scripts_set, UpgradeScript(
       # In the past, we saved only finite order isometries, but the order
       # was not typed. Now we need to reference the type otherwise we cannot
       # read old files.
-      if !(dict[:data][:ambient_space][:data][:order] isa Dict)
+      if !(dict[:data][:ambient_space][:data][:order] isa AbstractDict)
         n = Base.parse(Int, dict[:data][:ambient_space][:data][:order])
         upgraded_dict[:data][:ambient_space][:data][:order] =
         Dict{Symbol, Any}(:_type => "Base.Int", :data => "$n")

--- a/src/Serialization/Upgrades/1.2.0.jl
+++ b/src/Serialization/Upgrades/1.2.0.jl
@@ -6,7 +6,7 @@
   
 push!(upgrade_scripts_set, UpgradeScript(
   v"1.2.0",
-  function upgrade_1_2_0(s::UpgradeState, dict::Dict)
+  function upgrade_1_2_0(s::UpgradeState, dict::AbstractDict{Symbol, Any})
     renamings = Dict{String,String}([
       ("FreeAssAlgebra", "FreeAssociativeAlgebra"),
       ("FreeAssAlgElem", "FreeAssociativeAlgebraElem"),
@@ -15,7 +15,7 @@ push!(upgrade_scripts_set, UpgradeScript(
 
     upgraded_dict = rename_types(dict, renamings)
 
-    if haskey(dict, :data) && dict[:data] isa Dict
+    if haskey(dict, :data) && dict[:data] isa AbstractDict
       upgraded_dict[:data] = upgrade_1_2_0(s, dict[:data])
     end
 

--- a/src/Serialization/Upgrades/1.3.0.jl
+++ b/src/Serialization/Upgrades/1.3.0.jl
@@ -1,14 +1,14 @@
 push!(upgrade_scripts_set, UpgradeScript(
   v"1.3.0",
-  function upgrade_1_3_0(s::UpgradeState, dict::Dict)
+  function upgrade_1_3_0(s::UpgradeState, dict::AbstractDict{Symbol, Any})
     upgraded_dict = dict
     if haskey(dict, :_type) && dict[:_type] == "FqField"
-      if dict[:data] isa Dict
+      if dict[:data] isa AbstractDict
         if !(haskey(dict[:data], :def_pol))
           upgraded_dict[:data][:def_pol] = copy(dict[:data])
         end
       end
-    elseif haskey(dict, :data) && dict[:data] isa Dict
+    elseif haskey(dict, :data) && dict[:data] isa AbstractDict
       upgraded_dict[:data] = upgrade_1_3_0(s, dict[:data])
     end
     return upgraded_dict

--- a/src/Serialization/Upgrades/1.4.0.jl
+++ b/src/Serialization/Upgrades/1.4.0.jl
@@ -265,7 +265,9 @@ push!(upgrade_scripts_set, UpgradeScript(
         end
       elseif type_name in ["Vector", "Set", "Matrix"]
         subtype = dict[:_type][:params]
-        if dict[:data] isa Vector{String}
+        if isempty(dict[:data])
+          # do nothing
+        elseif all(e -> e isa String, dict[:data])
           dict[:data] = dict[:data]
 
           ref_entry = get(s.id_to_dict, Symbol(dict[:data][1]), nothing)

--- a/src/Serialization/Upgrades/1.4.0.jl
+++ b/src/Serialization/Upgrades/1.4.0.jl
@@ -1,6 +1,6 @@
 push!(upgrade_scripts_set, UpgradeScript(
   v"1.4.0",
-  function upgrade_1_4_0(s::UpgradeState, dict::Dict)
+  function upgrade_1_4_0(s::UpgradeState, dict::AbstractDict{Symbol, Any})
     if haskey(dict, :_refs)
       s.id_to_dict = dict[:_refs]
     end
@@ -10,7 +10,7 @@ push!(upgrade_scripts_set, UpgradeScript(
       end
     end
     if haskey(dict, :_type)
-      if dict[:_type] isa Dict && haskey(dict[:_type], :name)
+      if dict[:_type] isa AbstractDict && haskey(dict[:_type], :name)
         type_name = dict[:_type][:name]
       else
         type_name = dict[:_type]
@@ -159,7 +159,7 @@ push!(upgrade_scripts_set, UpgradeScript(
         )
         dict[:data] = dict[:data][:grading][:data]
       elseif type_name in ["AbsSimpleNumField", "Hecke.RelSimpleNumField"]
-        dict[:_type] isa Dict && haskey(dict[:_type], :params) && return dict
+        dict[:_type] isa AbstractDict && haskey(dict[:_type], :params) && return dict
         dict[:_type] = Dict(
           :name => dict[:_type],
           :params => dict[:data][:def_pol][:_type][:params]
@@ -190,7 +190,7 @@ push!(upgrade_scripts_set, UpgradeScript(
           :_instance => dict[:_type]
         )
 
-        if dict[:data] isa Dict
+        if dict[:data] isa AbstractDict
           dict[:_type][:params] = upgrade_1_4_0(s, dict[:data][:def_pol])[:_type][:params]
           dict[:data] = dict[:data][:def_pol][:data]
         end
@@ -350,7 +350,7 @@ push!(upgrade_scripts_set, UpgradeScript(
         "Polyhedron", "Cone", "PolyhedralComplex", "PolyhedralFan",
         "SubdivisionOfPoints"
         ]
-        if !(dict[:_type][:params] isa Dict) || dict[:_type][:params][:_type] == "QQBarField"
+        if !(dict[:_type][:params] isa AbstractDict) || dict[:_type][:params][:_type] == "QQBarField"
           pm_dict = dict[:data]
           pm_dict[:_type][:params][:key_params] = "Symbol"
           pm_dict[:_type][:params][:_polymake_type] = "String"
@@ -360,7 +360,7 @@ push!(upgrade_scripts_set, UpgradeScript(
           delete!(pm_dict[:_type][:params], :_type)
           delete!(pm_dict[:data], :_type)
 
-          if !(dict[:_type][:params] isa Dict)
+          if !(dict[:_type][:params] isa AbstractDict)
             field = dict[:_type][:params]
           else
             field = Dict(:_type => "QQBarField")
@@ -502,7 +502,7 @@ push!(upgrade_scripts_set, UpgradeScript(
           dict[:data][:ordering][:internal_ordering][:ordering_symbol_as_type] = dict[:data][:ordering][:internal_ordering][:ordering_symbol_as_type][:data]
         end
       elseif type_name == "NormalToricVariety"
-        if dict[:data] isa Dict
+        if dict[:data] isa AbstractDict
           if haskey(dict[:data], :attrs)
             dict[:attrs] = dict[:data][:attrs]
             dict[:data] = dict[:data][:pm_data]
@@ -535,7 +535,7 @@ push!(upgrade_scripts_set, UpgradeScript(
           :modulus => dict[:data][:modulus][:data]
         )
       end
-    elseif haskey(dict, :data) && dict[:data] isa Dict
+    elseif haskey(dict, :data) && dict[:data] isa AbstractDict
       dict[:data] = upgrade_1_4_0(s, dict[:data])
     end
 

--- a/src/Serialization/Upgrades/1.4.0.jl
+++ b/src/Serialization/Upgrades/1.4.0.jl
@@ -22,11 +22,11 @@ push!(upgrade_scripts_set, UpgradeScript(
         if dict[:data] isa String
           # do nothing
         else
-          dict[:_type] = Dict(
+          dict[:_type] = Dict{Symbol, Any}(
             :name => dict[:_type],
             :params => dict[:data][:base_ring] isa String ? dict[:data][:base_ring] : upgrade_1_4_0(s, dict[:data][:base_ring])
           )
-          dict[:data] = Dict(
+          dict[:data] = Dict{Symbol, Any}(
             :symbols => dict[:data][:symbols],
           )
         end
@@ -34,9 +34,9 @@ push!(upgrade_scripts_set, UpgradeScript(
         upgraded_hs = upgrade_1_4_0(s, dict[:data][:hs_model])
         upgraded_genus_ci = upgrade_1_4_0(s, dict[:data][:genus_ci])
         upgraded_degree_of_Kbar_of_tv_restricted_to_ci = upgrade_1_4_0(s, dict[:data][:degree_of_Kbar_of_tv_restricted_to_ci])
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => dict[:_type],
-          :params => Dict(
+          :params => Dict{Symbol, Any}(
             :hs_model => upgraded_hs,
             :genus_ci => upgraded_genus_ci[:_type],
             :degree_of_Kbar_of_tv_restricted_to_ci => upgraded_degree_of_Kbar_of_tv_restricted_to_ci[:_type]
@@ -46,10 +46,10 @@ push!(upgrade_scripts_set, UpgradeScript(
       elseif type_name in ["GlobalTateModel", "HypersurfaceModel", "WeierstrassModel"]
 
         upgraded_attr_dict = upgrade_1_4_0(s, dict[:data][:__attrs])
-        dict[:attrs] = Dict()
+        dict[:attrs] = Dict{Symbol, Any}()
         for k in keys(upgraded_attr_dict[:_type][:params])
           k == :key_params && continue
-          dict[:attrs][k] = Dict(:_type => upgraded_attr_dict[:_type][:params][k], :data => upgraded_attr_dict[:data][k])
+          dict[:attrs][k] = Dict{Symbol, Any}(:_type => upgraded_attr_dict[:_type][:params][k], :data => upgraded_attr_dict[:data][k])
         end
 
         if haskey(dict[:data], :explicit_model_sections)
@@ -71,7 +71,7 @@ push!(upgrade_scripts_set, UpgradeScript(
         end
 
       elseif type_name == "LieAlgebraModule"
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => dict[:_type],
           :params => Dict{Symbol, Any}(
             :lie_algebra => dict[:data][:lie_algebra]
@@ -79,48 +79,48 @@ push!(upgrade_scripts_set, UpgradeScript(
         )
         const_data = dict[:data][:construction_data]
         if haskey(const_data, :is_standard_module)
-          dict[:_type][:params][:_is_standard_module] = Dict(:_type=>"Bool", :data => "true")
+          dict[:_type][:params][:_is_standard_module] = Dict{Symbol, Any}(:_type=>"Bool", :data => "true")
         elseif haskey(const_data, :is_dual)
           dict[:_type][:params][:_is_dual] = const_data[:is_dual]
         elseif haskey(const_data, :is_tensor_power)
-          dict[:_type][:params][:_is_tensor_power] = [const_data[:is_tensor_power][1], Dict(:_type => "Base.Int", :data => const_data[:is_tensor_power][2])]
+          dict[:_type][:params][:_is_tensor_power] = [const_data[:is_tensor_power][1], Dict{Symbol, Any}(:_type => "Base.Int", :data => const_data[:is_tensor_power][2])]
         elseif haskey(const_data, :is_direct_sum)
           dict[:_type][:params][:_is_direct_sum] = const_data[:is_direct_sum]
         elseif haskey(const_data, :is_symmetric_power)
-          dict[:_type][:params][:_is_symmetric_power] = [const_data[:is_symmetric_power][1], Dict(:_type => "Base.Int", :data => const_data[:is_symmetric_power][2])]
+          dict[:_type][:params][:_is_symmetric_power] = [const_data[:is_symmetric_power][1], Dict{Symbol, Any}(:_type => "Base.Int", :data => const_data[:is_symmetric_power][2])]
         elseif haskey(const_data, :is_tensor_product)
           dict[:_type][:params][:_is_tensor_product] = const_data[:is_tensor_product]
         elseif haskey(const_data, :is_exterior_power)
-          dict[:_type][:params][:_is_exterior_power] = [const_data[:is_exterior_power][1], Dict(:_type => "Base.Int", :data => const_data[:is_exterior_power][2])]
+          dict[:_type][:params][:_is_exterior_power] = [const_data[:is_exterior_power][1], Dict{Symbol, Any}(:_type => "Base.Int", :data => const_data[:is_exterior_power][2])]
         elseif !isempty(const_data)
           error("missed construction data")
         end
       elseif type_name == "LinearLieAlgebra"
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => dict[:_type],
-          :params => Dict(
+          :params => Dict{Symbol, Any}(
             :base_ring => dict[:data][:base_ring]
           ))
       elseif type_name == "DirectSumLieAlgebra"
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => dict[:_type],
-          :params => Dict(
+          :params => Dict{Symbol, Any}(
             :base_ring => dict[:data][:base_ring],
             :summands => dict[:data][:summands]
           ))
       elseif type_name == "AbstractLieAlgebra"
         if haskey(dict[:data], :root_system)
-          dict[:_type] = Dict(
+          dict[:_type] = Dict{Symbol, Any}(
           :name => dict[:_type],
-          :params => Dict(
+          :params => Dict{Symbol, Any}(
             :base_ring => dict[:data][:base_ring],
             :root_system => dict[:data][:root_system]
 
           ))
         else
-          dict[:_type] = Dict(
+          dict[:_type] = Dict{Symbol, Any}(
             :name => dict[:_type],
-            :params => Dict(
+            :params => Dict{Symbol, Any}(
               :base_ring => dict[:data][:base_ring]
             ))
         end
@@ -128,31 +128,31 @@ push!(upgrade_scripts_set, UpgradeScript(
       elseif type_name in [
         "FracField", "LaurentSeriesField", "SeriesRing", "LaurentSeriesRing"
         ]
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => dict[:_type],
           :params => dict[:data][:base_ring]
         )
         delete!(dict, :base_ring)
         dict[:data] = dict[:data]
       elseif type_name in ["MatSpace", "SMatSpace"]
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => type_name,
           :params => dict[:data][:base_ring]
         )
-        dict[:data] = Dict(
+        dict[:data] = Dict{Symbol, Any}(
           :ncols => dict[:data][:ncols],
           :nrows => dict[:data][:nrows]
         )
       elseif type_name == "fqPolyRepField"
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => dict[:_type],
           :params => dict[:data][:def_pol][:_type][:params]
         )
         dict[:data] = dict[:data][:def_pol][:data]
       elseif type_name == "MPolyDecRing"
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => dict[:_type],
-          :params => Dict(
+          :params => Dict{Symbol, Any}(
             :ring => dict[:data][:ring],
             :grading_group => dict[:data][:grading][:_type][:params]
           )
@@ -160,32 +160,32 @@ push!(upgrade_scripts_set, UpgradeScript(
         dict[:data] = dict[:data][:grading][:data]
       elseif type_name in ["AbsSimpleNumField", "Hecke.RelSimpleNumField"]
         dict[:_type] isa AbstractDict && haskey(dict[:_type], :params) && return dict
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => dict[:_type],
           :params => dict[:data][:def_pol][:_type][:params]
         )
-        dict[:data] = Dict(
+        dict[:data] = Dict{Symbol, Any}(
           :var => dict[:data][:var],
           :def_pol => dict[:data][:def_pol][:data]
         )
       elseif type_name in ["AbsNonSimpleNumField", "Hecke.RelNonSimpleNumField"]
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => dict[:_type],
           :params => dict[:data][:def_pols][:_type][:params]
         )
-        dict[:data] = Dict(
+        dict[:data] = Dict{Symbol, Any}(
           :vars => dict[:data][:vars],
           :def_pols => dict[:data][:def_pols][:data]
         )
 
       elseif type_name == "EmbeddedNumField"
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => dict[:_type],
           :params => dict[:data][:embedding]
         )
         dict[:data] = []
       elseif type_name == "FqField"
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => "FiniteField",
           :_instance => dict[:_type]
         )
@@ -195,13 +195,13 @@ push!(upgrade_scripts_set, UpgradeScript(
           dict[:data] = dict[:data][:def_pol][:data]
         end
       elseif type_name in ["fpField", "Nemo.fpField"]
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => "FiniteField",
           :_instance => "fpField"
             )
         dict[:data] = dict[:data]
       elseif type_name in ["FpField", "Nemo.FpField"]
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => "FiniteField",
           :_instance => "FpField"
             )
@@ -222,19 +222,19 @@ push!(upgrade_scripts_set, UpgradeScript(
             key_params = dict[:_type][:params][:key_type]
           end
 
-          dict[:_type][:params] = Dict(
+          dict[:_type][:params] = Dict{Symbol, Any}(
             :value_params => value_params,
             :key_params => key_params
           )
         else
-          d = Dict()
+          d = Dict{Symbol, Any}()
           for (k, v) in dict[:_type][:params]
             if k == :key_type || k == :key_params
               d[k] = v
             elseif k == :_coeff 
               
             else
-              d[k] = upgrade_1_4_0(s, Dict(
+              d[k] = upgrade_1_4_0(s, Dict{Symbol, Any}(
                 :_type => dict[:_type][:params][k],
                 :data => dict[:data][k]
               ))
@@ -242,15 +242,15 @@ push!(upgrade_scripts_set, UpgradeScript(
           end
 
           if haskey(dict, :_refs)
-            dict = Dict(
-              :_type => Dict(:name => "Dict", :params=>Dict()),
-              :data => Dict(),
+            dict = Dict{Symbol, Any}(
+              :_type => Dict{Symbol, Any}(:name => "Dict", :params=>Dict{Symbol, Any}()),
+              :data => Dict{Symbol, Any}(),
               :_refs => dict[:_refs]
             )
           else
-            dict = Dict(
-              :_type => Dict(:name => "Dict", :params=>Dict()),
-              :data => Dict(),
+            dict = Dict{Symbol, Any}(
+              :_type => Dict{Symbol, Any}(:name => "Dict", :params=>Dict{Symbol, Any}()),
+              :data => Dict{Symbol, Any}(),
             )
           end
 
@@ -276,7 +276,7 @@ push!(upgrade_scripts_set, UpgradeScript(
         else
           upgraded_entries = []
           for entry in dict[:data]
-            push!(upgraded_entries, upgrade_1_4_0(s, Dict(
+            push!(upgraded_entries, upgrade_1_4_0(s, Dict{Symbol, Any}(
               :_type => subtype,
               :data => entry
             )))
@@ -298,7 +298,7 @@ push!(upgrade_scripts_set, UpgradeScript(
       elseif type_name == "Tuple"
         upgraded_subtypes = Dict[]
         for (i, subtype) in enumerate(dict[:_type][:params])
-          push!(upgraded_subtypes, upgrade_1_4_0(s, Dict(
+          push!(upgraded_subtypes, upgrade_1_4_0(s, Dict{Symbol, Any}(
             :_type => subtype,
             :data => dict[:data][i]
           )))
@@ -306,18 +306,18 @@ push!(upgrade_scripts_set, UpgradeScript(
         dict[:_type][:params] = [subdict[:_type] for subdict in upgraded_subtypes]
         dict[:data] = [subdict[:data] for subdict in upgraded_subtypes]
       elseif type_name == "ZZLat"
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => type_name,
-          :params => Dict(
+          :params => Dict{Symbol, Any}(
             :basis => dict[:data][:basis][:_type],
             :ambient_space => dict[:data][:ambient_space]
           )
         )
         dict[:data] = dict[:data][:basis][:data]
       elseif type_name == "QuadSpaceWithIsom"
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => type_name,
-          :params => Dict(
+          :params => Dict{Symbol, Any}(
             :order => dict[:data][:order][:_type],
             :isom => dict[:data][:isom][:_type],
             :quad_space => dict[:data][:quad_space]
@@ -330,9 +330,9 @@ push!(upgrade_scripts_set, UpgradeScript(
         
       elseif type_name == "ZZLatWithIsom"
         quad_space = upgrade_1_4_0(s, dict[:data][:ambient_space])
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => type_name,
-          :params => Dict(
+          :params => Dict{Symbol, Any}(
             :ambient_space => quad_space,
             :basis => dict[:data][:basis][:_type],
           )
@@ -363,14 +363,14 @@ push!(upgrade_scripts_set, UpgradeScript(
           if !(dict[:_type][:params] isa AbstractDict)
             field = dict[:_type][:params]
           else
-            field = Dict(:_type => "QQBarField")
+            field = Dict{Symbol, Any}(:_type => "QQBarField")
           end
 
           pm_dict = upgrade_1_4_0(s, pm_dict)
 
-          dict[:_type] = Dict(
+          dict[:_type] = Dict{Symbol, Any}(
             :name => type_name,
-            :params => Dict(
+            :params => Dict{Symbol, Any}(
               :field => field,
               :pm_params => pm_dict[:_type]
             )
@@ -380,9 +380,9 @@ push!(upgrade_scripts_set, UpgradeScript(
       elseif type_name in [
         "Hecke.RelSimpleNumFieldEmbedding", "Hecke.RelNonSimpleNumFieldEmbedding"
         ]
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => type_name,
-          :params => Dict(
+          :params => Dict{Symbol, Any}(
             :num_field => dict[:data][:num_field],
             :base_field_emb => dict[:data][:base_field_emb]
           )
@@ -391,7 +391,7 @@ push!(upgrade_scripts_set, UpgradeScript(
       elseif type_name in  [
         "Hecke.AbsSimpleNumFieldEmbedding", "Hecke.AbsNonSimpleNumFieldEmbedding"
         ]
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => type_name,
           :params => dict[:data][:num_field]
         )
@@ -399,25 +399,25 @@ push!(upgrade_scripts_set, UpgradeScript(
                 
       elseif type_name in ["FPGroup", "SubFPGroup"]
         if dict[:data][:X] isa String
-          dict[:_type] = Dict(
+          dict[:_type] = Dict{Symbol, Any}(
             :name => type_name,
             :params => dict[:data][:X]
           )
         elseif haskey(dict[:data][:X], :freeGroup)
-          dict[:_type] = Dict(
+          dict[:_type] = Dict{Symbol, Any}(
             :name => type_name,
             :params => dict[:data][:X][:freeGroup]
           )
         elseif haskey(dict[:data][:X], :wholeGroup)
-          dict[:_type] = Dict(
+          dict[:_type] = Dict{Symbol, Any}(
             :name => type_name,
             :params => dict[:data][:X][:wholeGroup]
           )
 
         else
-          dict[:_type] = Dict(
+          dict[:_type] = Dict{Symbol, Any}(
             :name => type_name,
-            :params => Dict(
+            :params => Dict{Symbol, Any}(
               :_type => "GapObj",
               :data => dict[:data][:X]
             )
@@ -426,19 +426,19 @@ push!(upgrade_scripts_set, UpgradeScript(
         end
       elseif type_name in ["PcGroup", "SubPcGroup"]
         if dict[:data][:X] isa String
-          dict[:_type] = Dict(
+          dict[:_type] = Dict{Symbol, Any}(
             :name => type_name,
             :params => dict[:data][:X]
           )
         elseif haskey(dict[:data][:X], :fullGroup)
-          dict[:_type] = Dict(
+          dict[:_type] = Dict{Symbol, Any}(
             :name => type_name,
             :params => dict[:data][:X][:fullGroup]
           )
         else
-          dict[:_type] = Dict(
+          dict[:_type] = Dict{Symbol, Any}(
             :name => type_name,
-            :params => Dict(
+            :params => Dict{Symbol, Any}(
               :_type => "GapObj",
               :data => dict[:data][:X]
             )
@@ -451,46 +451,46 @@ push!(upgrade_scripts_set, UpgradeScript(
         if dict[:data] isa String
           #do nothing
         elseif haskey(dict[:data], :freeGroup)
-          dict[:_type] = Dict(
+          dict[:_type] = Dict{Symbol, Any}(
             :name => "GapObj",
             :params => dict[:data][:freeGroup]
           )
         elseif haskey(dict[:data], :fullGroup)
-          dict[:_type] = Dict(
+          dict[:_type] = Dict{Symbol, Any}(
             :name => "GapObj",
             :params => dict[:data][:fullGroup]
           )
 
         elseif haskey(dict[:data], :wholeGroup)
-          dict[:_type] = Dict(
+          dict[:_type] = Dict{Symbol, Any}(
             :name => "GapObj",
             :params => dict[:data][:wholeGroup]
           )
         end
       elseif type_name == "TropicalCurve"
         if haskey(dict[:data], :graph)
-          dict[:_type] = Dict(
+          dict[:_type] = Dict{Symbol, Any}(
             :name => type_name,
-            :params => Dict(:_type => String, :data => "graph")
+            :params => Dict{Symbol, Any}(:_type => String, :data => "graph")
           )
           dict[:data][:graph] = dict[:data][:graph][:data]
         else
-          dict[:_type] = Dict(
+          dict[:_type] = Dict{Symbol, Any}(
             :name => type_name,
             :params => dict[:data][:polyhedral_complex][:_type]
           )
           dict[:data][:polyhedral_complex] = dict[:data][:polyhedral_complex][:data]
         end
       elseif type_name == "TropicalHypersurface"
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => type_name,
           :params => dict[:data][:tropical_polynomial][:_type][:params]
         )
         dict[:data] = dict[:data][:tropical_polynomial][:data]
       elseif type_name == "IdealGens"
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => "IdealGens",
-          :params => Dict(
+          :params => Dict{Symbol, Any}(
             :base_ring => dict[:_type][:params],
             :ordering_type => dict[:data][:ordering][:internal_ordering][:_type]
           )
@@ -509,20 +509,20 @@ push!(upgrade_scripts_set, UpgradeScript(
           end
         end
       elseif type_name == "CohomologyClass"
-        dict = Dict(
+        dict = Dict{Symbol, Any}(
           :_type => dict[:_type],
           :data => dict[:data][:polynomial]
         )
       elseif type_name in ["WeightLattice", "WeylGroup"]
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => type_name,
           :params => dict[:data][:root_system]
         )
       elseif type_name == "MPolyQuoRing"
         ord_data = dict[:data][:ordering]
-        dict[:_type] = Dict(
+        dict[:_type] = Dict{Symbol, Any}(
           :name => type_name,
-          :params => Dict(
+          :params => Dict{Symbol, Any}(
             :base_ring => ord_data[:_type][:params],
             :ordering => ord_data[:_type][:name]
           )
@@ -530,7 +530,7 @@ push!(upgrade_scripts_set, UpgradeScript(
         ord_data[:data][:internal_ordering] = ord_data[:data][:internal_ordering][:data]
         ord_data[:data][:internal_ordering][:vars] = ord_data[:data][:internal_ordering][:vars][:data]
         ord_data[:data][:internal_ordering][:ordering_symbol_as_type] = ord_data[:data][:internal_ordering][:ordering_symbol_as_type][:data]
-        dict[:data] = Dict(
+        dict[:data] = Dict{Symbol, Any}(
           :ordering => ord_data[:data],
           :modulus => dict[:data][:modulus][:data]
         )

--- a/src/Serialization/Upgrades/1.6.0-1.jl
+++ b/src/Serialization/Upgrades/1.6.0-1.jl
@@ -1,11 +1,11 @@
 push!(upgrade_scripts_set, UpgradeScript(
   v"1.6.0-1",
-  function upgrade_1_6_0_1(s::UpgradeState, dict::Dict)
+  function upgrade_1_6_0_1(s::UpgradeState, dict::AbstractDict{Symbol, Any})
     # recurse upgrade on containers
     upgrade_containers(upgrade_1_6_0_1, s, dict)
 
     # Upgrades
-    if dict[:_type] isa Dict && get(dict[:_type], :name, "") == "RationalFunctionField"
+    if dict[:_type] isa AbstractDict && get(dict[:_type], :name, nothing) == "RationalFunctionField"
       if dict[:data][:symbols] isa String
         dict[:data][:symbol] = dict[:data][:symbols]
         delete!(dict[:data], :symbols)

--- a/src/Serialization/Upgrades/1.6.0.jl
+++ b/src/Serialization/Upgrades/1.6.0.jl
@@ -6,14 +6,14 @@ push!(upgrade_scripts_set, UpgradeScript(
 
     # Upgrades 
     if dict[:_type] == "PhylogeneticTree"
-      dict[:_type] = Dict(
+      dict[:_type] = Dict{Symbol, Any}(
         :name => "PhylogeneticTree",
-        :params => Dict(
+        :params => Dict{Symbol, Any}(
           :_type => dict[:data][:_type] == "graph::PhylogeneticTree<Float>" ? "Floats" : "QQField"
         )
       )
       n_vertices = length(dict[:data][:LABELS])
-      dict[:data] = Dict(
+      dict[:data] = Dict{Symbol, Any}(
         :pm_tree => dict[:data],
         :vertex_perm => string.(collect(1:n_vertices))
       )

--- a/src/Serialization/Upgrades/1.6.0.jl
+++ b/src/Serialization/Upgrades/1.6.0.jl
@@ -1,6 +1,6 @@
 push!(upgrade_scripts_set, UpgradeScript(
   v"1.6.0",
-  function upgrade_1_6_0(s::UpgradeState, dict::Dict)
+  function upgrade_1_6_0(s::UpgradeState, dict::AbstractDict{Symbol, Any})
     # recurse upgrade on containers
     upgrade_containers(upgrade_1_6_0, s, dict)
 

--- a/src/Serialization/Upgrades/main.jl
+++ b/src/Serialization/Upgrades/main.jl
@@ -252,13 +252,13 @@ sort!(upgrade_scripts; by=version)
 const backref_sym = Symbol("#backref")
 
 @doc raw"""
-    upgrade(format_version::VersionNumber, dict::Dict)
+    upgrade(format_version::VersionNumber, dict::AbstractDict{Symbol, Any})
 
 Find the first version where an upgrade can be applied and then incrementally
 upgrades to each intermediate version until the structure of the current version
 has been achieved.
 """
-function upgrade(format_version::VersionNumber, dict::Dict)
+function upgrade(format_version::VersionNumber, dict::AbstractDict{Symbol, Any})
   upgraded_dict = dict
   for upgrade_script in upgrade_scripts
     script_version = version(upgrade_script)

--- a/src/Serialization/Upgrades/main.jl
+++ b/src/Serialization/Upgrades/main.jl
@@ -22,7 +22,7 @@ deprecations.
 ```
 push!(upgrade_scripts_set, UpgradeScript(
   v"0.13.0",
-  function upgrade_0_13_0(s::UpgradeState, dict::Dict)
+  function upgrade_0_13_0(s::UpgradeState, dict::AbstractDict{Symbol, Any})
       ...
   end
 ))
@@ -57,12 +57,12 @@ end
 const upgrade_scripts_set = Set{UpgradeScript}()
 
 """
-    upgrade_data(upgrade::Function, s::UpgradeState, dict::Dict)
+    upgrade_data(upgrade::Function, s::UpgradeState, dict::AbstractDict)
 
 `upgrade_data` is a helper function that provides functionality for
 recursing on the tree structure. Used for upgrades up to 0.12.2.
 """
-function upgrade_data(upgrade::Function, s::UpgradeState, dict::Dict)
+function upgrade_data(upgrade::Function, s::UpgradeState, dict::AbstractDict)
   s.nested_level += 1
   # file comes from polymake
   haskey(dict, :_ns) && haskey(dict[:_ns], :polymake) && return dict
@@ -71,7 +71,7 @@ function upgrade_data(upgrade::Function, s::UpgradeState, dict::Dict)
   for (key, dict_value) in dict
     if dict_value isa String || dict_value isa Int64 || dict_value isa Bool
       upgraded_dict[key] = dict_value
-    elseif dict_value isa Dict
+    elseif dict_value isa AbstractDict
       s.nested_level += 1
       upgraded_dict[key] = upgrade(s, dict_value)
       s.nested_level -= 1
@@ -94,12 +94,12 @@ function upgrade_data(upgrade::Function, s::UpgradeState, dict::Dict)
 end
 
 """
-    rename_types(dict::Dict, renamings::Dict{String, String})
+    rename_types(dict::AbstractDict, renamings::Dict{String, String})
 
 Provides functionality for recursing on the tree structure of `dict`
 and replace all type names that occur as keys in renamings with the values. 
 """
-function rename_types(dict::Dict, renamings::Dict{String, String})
+function rename_types(dict::AbstractDict, renamings::Dict{String, String})
   function upgrade_type(d::String)
     return get(renamings, d, d)
   end
@@ -108,7 +108,7 @@ function rename_types(dict::Dict, renamings::Dict{String, String})
     return map(upgrade_type, v)
   end
   
-  function upgrade_type(d::Dict)
+  function upgrade_type(d::AbstractDict)
     upg_d = d
 
     if haskey(d, :name)
@@ -118,7 +118,7 @@ function rename_types(dict::Dict, renamings::Dict{String, String})
       return upg_d
     end
     
-    if d[:params] isa Dict
+    if d[:params] isa AbstractDict
       if haskey(d[:params], :_type)
         upg_d[:params][:_type] = upgrade_type(d[:params][:_type])
       else
@@ -138,7 +138,7 @@ function rename_types(dict::Dict, renamings::Dict{String, String})
   return dict
 end
 
-function upgrade_containers(upgrade::Function, s::UpgradeState, dict::Dict)
+function upgrade_containers(upgrade::Function, s::UpgradeState, dict::AbstractDict)
   # all containers have a Dict for their type description
   # with a name and a params key
   dict[:_type] isa String && return dict
@@ -151,10 +151,10 @@ function upgrade_containers(upgrade::Function, s::UpgradeState, dict::Dict)
   end
   if dict[:_type][:name] in ["Vector", "Set", "Matrix"] 
     subtype = dict[:_type][:params]
-    upgraded_entries = Dict[]
+    upgraded_entries = Dict{Symbol, Any}[]
     upgraded_entry = nothing
     for entry in dict[:data]
-      upgraded_entry = upgrade(s, Dict(:_type => subtype, :data => entry))
+      upgraded_entry = upgrade(s, Dict{Symbol, Any}(:_type => subtype, :data => entry))
       push!(upgraded_entries, upgraded_entry)
     end
     if !isnothing(upgraded_entry)
@@ -163,10 +163,10 @@ function upgrade_containers(upgrade::Function, s::UpgradeState, dict::Dict)
     dict[:data] = [u_e[:data] for u_e in upgraded_entries]
   elseif dict[:_type][:name] == "MultiDimArray"
     subtype = dict[:_type][:params][:subtype_params]
-    upgraded_entries = Dict[]
+    upgraded_entries = Dict{Symbol, Any}[]
     upgraded_entry = nothing
     for entry in dict[:data]
-      upgraded_entry = upgrade(s, Dict(:_type => subtype, :data => entry))
+      upgraded_entry = upgrade(s, Dict{Symbol, Any}(:_type => subtype, :data => entry))
       push!(upgraded_entries, upgraded_entry)
     end
     if !isnothing(upgraded_entry)
@@ -175,20 +175,20 @@ function upgrade_containers(upgrade::Function, s::UpgradeState, dict::Dict)
     dict[:data] = [u_e[:data] for u_e in upgraded_entries]
 
   elseif dict[:_type][:name] == "Tuple"
-    upgraded_entries = Dict[]
+    upgraded_entries = Dict{Symbol, Any}[]
     upgraded_entry = nothing
     for (type, entry) in zip(dict[:_type][:params], dict[:data])
-      upgraded_entry = upgrade(s, Dict(:_type => type, :data => entry))
+      upgraded_entry = upgrade(s, Dict{Symbol, Any}(:_type => type, :data => entry))
       push!(upgraded_entries, upgraded_entry)
     end
     dict[:_type][:params] = [u_e[:_type] for u_e in upgraded_entries]
     dict[:data] = [u_e[:data] for u_e in upgraded_entries]
 
   elseif dict[:_type][:name] == "NamedTuple"
-    upgraded_entries = Dict[]
+    upgraded_entries = Dict{Symbol, Any}[]
     upgraded_entry = nothing
     for (type, entry) in zip(dict[:_type][:params][:tuple_params], dict[:data])
-      upgraded_entry = upgrade(s, Dict(:_type => type, :data => entry))
+      upgraded_entry = upgrade(s, Dict{Symbol, Any}(:_type => type, :data => entry))
       push!(upgraded_entries, upgraded_entry)
     end
     dict[:_type][:params][:tuple_params] = [u_e[:_type] for u_e in upgraded_entries]
@@ -201,13 +201,13 @@ function upgrade_containers(upgrade::Function, s::UpgradeState, dict::Dict)
       upgraded_entry = nothing
       upgraded_pairs = Tuple[]
       for (k, v) in dict[:data]
-        upgraded_v = upgrade(s, Dict(:_type => value_params, :data => v))
-        upgraded_k = upgrade(s, Dict(:_type => key_params, :data => k))
+        upgraded_v = upgrade(s, Dict{Symbol, Any}(:_type => value_params, :data => v))
+        upgraded_k = upgrade(s, Dict{Symbol, Any}(:_type => key_params, :data => k))
         push!(upgraded_pairs, (upgraded_k, upgraded_v))
       end
 
       if key_params in ["Symbol", "Int", "String"]
-        dict[:data] = Dict()
+        dict[:data] = Dict{Symbol, Any}()
         for (upgraded_k, upgraded_v) in upgraded_pairs
           dict[:data][upgraded_k[:data]] = upgraded_v[:data]
         end
@@ -222,7 +222,7 @@ function upgrade_containers(upgrade::Function, s::UpgradeState, dict::Dict)
       end
     else
       for entry in dict[:data]
-        upgraded_entry = upgrade(s, Dict(:_type => dict[:_type][:params][entry.first],
+        upgraded_entry = upgrade(s, Dict{Symbol, Any}(:_type => dict[:_type][:params][entry.first],
                                          :data => entry.second))
         dict[:data][entry.first] = upgraded_entry[:data]
         dict[:_type][:params][entry.first] = upgraded_entry[:_type]

--- a/src/Serialization/Upgrades/main.jl
+++ b/src/Serialization/Upgrades/main.jl
@@ -142,7 +142,7 @@ function upgrade_containers(upgrade::Function, s::UpgradeState, dict::AbstractDi
   # all containers have a Dict for their type description
   # with a name and a params key
   dict[:_type] isa String && return dict
-  if dict[:data] isa Vector{String}
+  if !isempty(dict[:data]) && all(e -> e isa String, dict[:data])
     ref_entry = get(s.id_to_dict, Symbol(dict[:data][1]), nothing)
     if !isnothing(ref_entry)
       ref_entry = upgrade(s, ref_entry)

--- a/src/Serialization/Upgrades/main.jl
+++ b/src/Serialization/Upgrades/main.jl
@@ -51,7 +51,7 @@ function UpgradeState()
 end
 
 (u_s::UpgradeScript)(s::UpgradeState,
-                     dict::Dict{Symbol}) = script(u_s)(s, dict)
+                     dict::AbstractDict{Symbol, Any}) = script(u_s)(s, dict)
 
 # The list of all available upgrade scripts
 const upgrade_scripts_set = Set{UpgradeScript}()

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -60,9 +60,6 @@ end
 function serialization_version_info(obj::AbstractDict{Symbol, Any})
   ns = obj[:_ns]
   version_info = ns[:Oscar][2]
-  if version_info isa JSON.Object
-    return version_number(Dict(version_info))
-  end
   return version_number(version_info)
 end
 
@@ -71,7 +68,7 @@ function version_number(v_number::String)
 end
 
 # needed for older versions
-function version_number(dict::Dict)
+function version_number(dict::AbstractDict)
   return VersionNumber(dict[:major], dict[:minor], dict[:patch])
 end
 

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -57,10 +57,10 @@ end
 ################################################################################
 # Serialization info
 
-function serialization_version_info(obj::Union{JSON3.Object, Dict})
+function serialization_version_info(obj::AbstractDict{String, Any})
   ns = obj[:_ns]
   version_info = ns[:Oscar][2]
-  if version_info isa JSON3.Object
+  if version_info isa JSON.Object
     return version_number(Dict(version_info))
   end
   return version_number(version_info)

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -57,7 +57,7 @@ end
 ################################################################################
 # Serialization info
 
-function serialization_version_info(obj::AbstractDict{String, Any})
+function serialization_version_info(obj::AbstractDict{Symbol, Any})
   ns = obj[:_ns]
   version_info = ns[:Oscar][2]
   if version_info isa JSON.Object

--- a/src/Serialization/serializers.jl
+++ b/src/Serialization/serializers.jl
@@ -200,9 +200,9 @@ mutable struct DeserializerState{T <: OscarSerializer}
   # or perhaps Dict{Int,Any} to be resilient against corrupts/malicious files using huge ids
   # the values of refs are objects to be deserialized
   serializer::T
-  obj::Union{Dict{Symbol, Any}, JSON.Object{String, Any}, Vector, JSON3.Object, JSON3.Array, BasicTypeUnion}
+  obj::Union{AbstractDict{Symbol, Any}, Vector, JSON3.Array, BasicTypeUnion}
   key::Union{Symbol, Int, Nothing}
-  refs::Union{Dict{Symbol, Any}, JSON3.Object, Nothing}
+  refs::Union{AbstractDict{Symbol, Any}, Nothing}
   with_attrs::Bool
 end
 


### PR DESCRIPTION
This PR should contain all changes from https://github.com/oscar-system/Oscar.jl/pull/5451 that are independent of the underlying json backend (aka they should make sense both with `JSON3` and `JSON`).
That way, we make https://github.com/oscar-system/Oscar.jl/pull/5451 a lot smaller and thus make it easier to track down the perfomance issues noticed in https://github.com/oscar-system/Oscar.jl/pull/5451.

cc @benlorenz @antonydellavecchia 