### PR TITLE
Replace `JSON3.write` by `JSON.json`

### DIFF
--- a/src/Serialization/Combinatorics.jl
+++ b/src/Serialization/Combinatorics.jl
@@ -15,7 +15,7 @@ end
 
 
 function load_object(s::DeserializerState, g::Type{Graph{T}}) where T <: Union{Directed, Undirected}
-  smallobj = Polymake.call_function(:common, :deserialize_json_string, JSON3.write(s.obj))
+  smallobj = Polymake.call_function(:common, :deserialize_json_string, JSON.json(s.obj))
   return g(smallobj)
 end
 
@@ -58,7 +58,7 @@ function save_object(s::SerializerState, IM::IncidenceMatrix)
 end
 
 function load_object(s::DeserializerState, ::Type{<: IncidenceMatrix})
-  IM = Polymake.call_function(:common, :deserialize_json_string, JSON3.write(s.obj))
+  IM = Polymake.call_function(:common, :deserialize_json_string, JSON.json(s.obj))
   return IM
 end
 
@@ -73,7 +73,7 @@ function save_object(s::SerializerState, K::SimplicialComplex)
 end
 
 function load_object(s::DeserializerState, K::Type{SimplicialComplex})
-  bigobject = Polymake.call_function(:common, :deserialize_json_string, JSON3.write(s.obj))
+  bigobject = Polymake.call_function(:common, :deserialize_json_string, JSON.json(s.obj))
   return K(bigobject)
 end
 

--- a/src/Serialization/PolyhedralGeometry.jl
+++ b/src/Serialization/PolyhedralGeometry.jl
@@ -22,7 +22,7 @@ end
 
 function load_object(s::DeserializerState, ::Type{Polymake.BigObject})
   dict = Dict{Symbol, Any}(s.obj)
-  bigobject = Polymake.call_function(:common, :deserialize_json_string, JSON3.write(dict))
+  bigobject = Polymake.call_function(:common, :deserialize_json_string, JSON.json(dict))
   return bigobject
 end
 

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -669,7 +669,7 @@ function save(io::IO, obj::T; metadata::Union{MetaData, Nothing}=nothing,
     handle_refs(s)
 
     if !isnothing(metadata)
-      save_json(s, JSON3.write(metadata), :meta)
+      save_json(s, JSON.json(metadata), :meta)
     end
   end
   serializer_close(s)
@@ -786,7 +786,7 @@ function load(io::IO; params::Any = nothing, type::Any = nothing,
     # we need a mutable dictionary
     jsondict = copy(s.obj)
     jsondict = upgrade(file_version, jsondict)
-    jsondict_str = JSON3.write(jsondict)
+    jsondict_str = JSON.json(jsondict)
     s = deserializer_open(IOBuffer(jsondict_str),
                           serializer,
                           with_attrs)

--- a/src/Serialization/polymake.jl
+++ b/src/Serialization/polymake.jl
@@ -8,12 +8,12 @@
 Load a graph stored in JSON format, given the filename as input.
 """
 function load_from_polymake(::Type{Graph{T}}, jsondict::Dict{Symbol, Any}) where {T <: Union{Directed, Undirected}}
-  polymake_object = Polymake.call_function(:common, :deserialize_json_string, JSON3.write(jsondict))
+  polymake_object = Polymake.call_function(:common, :deserialize_json_string, JSON.json(jsondict))
   return Graph{T}(polymake_object)
 end
 
 function load_from_polymake(::Type{PhylogeneticTree{T}}, jsondict::Dict{Symbol, Any}) where {T <: Union{Float64, Int, QQFieldElem}}
-  polymake_object = Polymake.call_function(:common, :deserialize_json_string, JSON3.write(jsondict))
+  polymake_object = Polymake.call_function(:common, :deserialize_json_string, JSON.json(jsondict))
   return PhylogeneticTree{T}(polymake_object)
 end
 
@@ -35,7 +35,7 @@ const polymake2OscarTypes = Dict{String, Type}([
 function load_from_polymake(::Type{T}, jsondict::Dict{Symbol, Any}) where {
   T<:Union{Cone{<:scalar_types}, Polyhedron{<:scalar_types}, PolyhedralFan{<:scalar_types}, 
            PolyhedralComplex{<:scalar_types}, SubdivisionOfPoints{<:scalar_types}, SimplicialComplex, Polymake.BigObject}}
-  inner_object = Polymake.call_function(:common, :deserialize_json_string, JSON3.write(jsondict))
+  inner_object = Polymake.call_function(:common, :deserialize_json_string, JSON.json(jsondict))
   if T <: Polymake.BigObject
     return inner_object
   end
@@ -57,7 +57,7 @@ function load_from_polymake(jsondict::Dict{Symbol, Any})
     return load_from_polymake(oscar_type, jsondict)
   else 
     # We just try to default to something from Polymake.jl
-    deserialized = Polymake.call_function(:common, :deserialize_json_string, JSON3.write(jsondict))
+    deserialized = Polymake.call_function(:common, :deserialize_json_string, JSON.json(jsondict))
     if !isa(deserialized, Polymake.BigObject)
       @warn "No function for converting the deserialized Polymake type to Oscar type: $(typeof(deserialized))"
       return deserialized


### PR DESCRIPTION
Another split-off from https://github.com/oscar-system/Oscar.jl/pull/5451. This time, it is all about writing json. These cases should be fine to change, as there is no laziness involved.