### PR TITLE
Revise `type_param` delegation

### DIFF
--- a/experimental/LieAlgebras/src/serialization.jl
+++ b/experimental/LieAlgebras/src/serialization.jl
@@ -127,8 +127,6 @@ end
 @register_serialization_type LinearLieAlgebraElem
 @register_serialization_type DirectSumLieAlgebraElem
 
-type_params(x::T) where {T<:LieAlgebraElem} = TypeParams(T, parent(x))
-
 function save_object(s::SerializerState, x::LieAlgebraElem)
   save_object(s, coefficients(x))
 end
@@ -221,8 +219,6 @@ function load_construction_data(L::LieAlgebra, T::Type{<:LieAlgebraModule}, d::D
 end
 
 @register_serialization_type LieAlgebraModuleElem
-
-type_params(x::T) where {T<:LieAlgebraModuleElem} = TypeParams(T, parent(x))
 
 function save_object(s::SerializerState, x::LieAlgebraModuleElem)
   save_object(s, coefficients(x))

--- a/src/Serialization/Algebras.jl
+++ b/src/Serialization/Algebras.jl
@@ -4,6 +4,8 @@
 # Free associative algebra serialization
 @register_serialization_type FreeAssociativeAlgebra uses_id
 
+type_params(R::T) where T <: FreeAssociativeAlgebra = TypeParams(T, coefficient_ring(R))
+
 function save_object(s::SerializerState, A::FreeAssociativeAlgebra)
   save_data_dict(s) do
     save_object(s, symbols(A), :symbols)

--- a/src/Serialization/Fields.jl
+++ b/src/Serialization/Fields.jl
@@ -5,13 +5,6 @@
 ################################################################################
 # field of rationals (singleton type)
 @register_serialization_type QQField
-# exclude from ring union definition
-type_params(::QQField) = TypeParams(QQField, nothing)
-type_params(::QQFieldElem) = TypeParams(QQFieldElem, nothing)
-type_params(::fpField) = TypeParams(fpField, nothing)
-type_params(::FpField) = TypeParams(FpField, nothing)
-type_params(::QQBarField) = TypeParams(QQBarField, nothing)
-type_params(::PadicField) = TypeParams(PadicField, nothing)
 
 ################################################################################
 # type_params for field extension types
@@ -244,6 +237,8 @@ end
 
 @register_serialization_type FracField uses_id
 
+type_params(R::T) where T <: FracField = TypeParams(T, base_ring(R))
+
 const FracUnionTypes = Union{MPolyRingElem, PolyRingElem, UniversalPolyRingElem}
 # we use the union to prevent QQField from using these save methods
 
@@ -281,6 +276,8 @@ end
 # RationalFunctionField
 
 @register_serialization_type AbstractAlgebra.Generic.RationalFunctionField "RationalFunctionField" uses_id
+
+type_params(R::T) where T <: AbstractAlgebra.Generic.RationalFunctionField = TypeParams(T, base_ring(R))
 
 function save_object(s::SerializerState,
                      RF::AbstractAlgebra.Generic.RationalFunctionField{<: FieldElem, <: MPolyRingElem})

--- a/src/Serialization/Groups.jl
+++ b/src/Serialization/Groups.jl
@@ -90,8 +90,6 @@ using Oscar: GAPGroup, _coeff
 # `GAPGroupElem` objects get serialized together with their parents.
 const GrpElemUnionType = Union{GAPGroupElem, FinGenAbGroupElem}
 
-type_params(p::T) where T <: GrpElemUnionType = TypeParams(T, parent(p))
-
 #############################################################################
 # attributes handling
 const GAPGroup_attributes = [

--- a/src/Serialization/LieTheory.jl
+++ b/src/Serialization/LieTheory.jl
@@ -74,8 +74,6 @@ end
 
 @register_serialization_type WeightLatticeElem
 
-type_params(w::WeightLatticeElem) = TypeParams(WeightLatticeElem, parent(w))
-
 function save_object(s::SerializerState, w::WeightLatticeElem)
   save_object(s, _vec(coefficients(w)))
 end
@@ -106,8 +104,6 @@ function load_object(s::DeserializerState, ::Type{WeylGroup}, R::RootSystem)
 end
 
 @register_serialization_type WeylGroupElem
-
-type_params(w::WeylGroupElem) = TypeParams(WeylGroupElem, parent(w))
 
 function save_object(s::SerializerState, x::WeylGroupElem)
   save_object(s, word(x))

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -167,11 +167,16 @@ struct TypeParams{T, S}
   type::Type{T}
   params::S
 
-  function TypeParams(T::Type, args::Pair...)
-    return new{T, typeof(args)}(T, args)
+  function TypeParams(T::Type, params)
+    if Base.issingletontype(T)
+      return new{T, Nothing}(T, nothing)
+    else
+      return new{T, typeof(params)}(T, params)
+    end
   end
-  TypeParams(T::Type, obj) = new{T, typeof(obj)}(T, obj)
 end
+
+TypeParams(T::Type, args::Pair...) = TypeParams(T, args)
 
 params(tp::TypeParams) = tp.params
 type(tp::TypeParams) = tp.type

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -419,7 +419,7 @@ function load_typed_object(s::DeserializerState, key::Symbol; override_params::A
 end
 
 # The load mechanism first checks if the type needs to load necessary
-# parameters before loading it's data, if so a type tree is traversed
+# parameters before loading its data, if so a type tree is traversed
 function load_typed_object(s::DeserializerState; override_params::Any = nothing)
   T = decode_type(s)
   Base.issingletontype(T) && return T()
@@ -702,7 +702,7 @@ Load the object stored in the given io stream
 respectively in the file `filename`.
 
 If `params` is specified, then the root object of the loaded data
-either will attempt a load using these parameters. In the case of Rings this
+either will attempt a load using these parameters. In the case of rings this
 results in setting its parent, or in the case of a container of ring types such as
 `Vector` or `Tuple`, then the parent of the entries will be set using their
  `params`.


### PR DESCRIPTION
Roughly use these "rules"
- For elements (i.e. objects whose type is a subtype of `SetElem`; plus some others like `SMat`), use "type plus parent"
   - although we actually really *only* need the parent here: if we are willing to change the format we could omit it, as the parent and its type uniquely determine the type of these elements!
   - Doing that would actually also be the first step towards the optimization I suggested at <https://github.com/oscar-system/Oscar.jl/issues/4558#issuecomment-3435763442>
- For "parents" such as rings, group, default to just the type.
- For ideals, matrix space, polynomial rings, the documentation makes it clear that the base resp. coefficient ring is the correct reference object.

---

I believe these rules are on the long run simpler than what we currently have, and will be easier to document and understand. We should probably also use `coefficient_ring` for more ring types (resp. *implement* it first for more) -- it is semantic versus the generally unspecified behaviour of `base_ring`, and for a serialization format I believe that we should use the semantic option.

So e.g. for `SeriesRing` on the long run we should ideally use `coefficient_ring` instead of `base_ring`, but we currently can't. Luckily @SoongNoonien has already been working on this in https://github.com/Nemocas/AbstractAlgebra.jl/pull/2185


