### PR TITLE
Don't use AbstractAlgebra internals

### DIFF
--- a/experimental/ModStd/src/ModStdNF.jl
+++ b/experimental/ModStd/src/ModStdNF.jl
@@ -174,7 +174,7 @@ end
 function homogenize(f::MPolyRingElem, S::MPolyRing)
   d = total_degree(f)
   g = MPolyBuildCtx(S)
-  for (c, e) = Base.Iterators.zip(Generic.MPolyCoeffs(f), Generic.MPolyExponentVectors(f))
+  for (c, e) = Base.Iterators.zip(AbstractAlgebra.coefficients(f), AbstractAlgebra.exponent_vectors(f))
     push_term!(g, c, push!(e, d-sum(e)))
   end
   return finish(g)

--- a/experimental/ModStd/src/ModStdQt.jl
+++ b/experimental/ModStd/src/ModStdQt.jl
@@ -322,7 +322,7 @@ function exp_groebner_assure(I::Oscar.MPolyIdeal{<:Generic.MPoly{<:Generic.FracF
       @vprint :ModStdQt 2 "using evaluation point $pt\n"
       @vtime :ModStdQt 2 for g = gens(I)
         G = MPolyBuildCtx(Qy)
-        for (c, e) = zip(Generic.MPolyCoeffs(g), Generic.MPolyExponentVectors(g))
+        for (c, e) = zip(AbstractAlgebra.coefficients(g), AbstractAlgebra.exponent_vectors(g))
           push_term!(G, evaluate(c, pt, error_tolerant = true), e)
         end
         push!(gens_J, finish(G))
@@ -335,7 +335,7 @@ function exp_groebner_assure(I::Oscar.MPolyIdeal{<:Generic.MPoly{<:Generic.FracF
         for _g = gJ
           g = inv(AbstractAlgebra.leading_coefficient(_g))*_g
           f = []
-          for (c, e) = zip(Generic.MPolyCoeffs(g), Generic.MPolyExponentVectors(g))
+          for (c, e) = zip(AbstractAlgebra.coefficients(g), AbstractAlgebra.exponent_vectors(g))
             push!(f, (e, Vals(Vector{T}[[c]])))
           end
           push!(lst, f)
@@ -346,7 +346,7 @@ function exp_groebner_assure(I::Oscar.MPolyIdeal{<:Generic.MPoly{<:Generic.FracF
           g = gJ[ig]
           g *= inv(AbstractAlgebra.leading_coefficient(g))
           jg = 1
-          for (c, e) = zip(Generic.MPolyCoeffs(g), Generic.MPolyExponentVectors(g))
+          for (c, e) = zip(AbstractAlgebra.coefficients(g), AbstractAlgebra.exponent_vectors(g))
             if lst[ig][jg][1] != e #TODO: sort and match
               @assert lst[ig][jg][1] == e
 #              @show ig, jg

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -295,7 +295,7 @@ function on_indeterminates(f::MPolyRingElem, s::PermGroupElem)
   @assert ngens(parent(f)) == degree(G)
 
   g = Generic.MPolyBuildCtx(parent(f))
-  for (c, e) = Base.Iterators.zip(Generic.MPolyCoeffs(f), Generic.MPolyExponentVectors(f))
+  for (c, e) = Base.Iterators.zip(AbstractAlgebra.coefficients(f), AbstractAlgebra.exponent_vectors(f))
     s_e = zeros(Int, degree(G))
     for i=1:degree(G)
       s_e[s(i)] = e[i]

--- a/src/Misc/MoveToAbstractAlgebra.jl
+++ b/src/Misc/MoveToAbstractAlgebra.jl
@@ -5,7 +5,7 @@
 function Base.copy(f::MPolyRingElem)
   Ox = parent(f)
   g = MPolyBuildCtx(Ox)
-  for (c, e) in Base.Iterators.zip(MPolyCoeffs(f), MPolyExponentVectors(f))
+  for (c, e) in Base.Iterators.zip(AbstractAlgebra.coefficients(f), AbstractAlgebra.exponent_vectors(f))
     push_term!(g, c, e)
   end
   return finish(g)

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -981,8 +981,8 @@ function singular_poly_ring(R::MPolyDecRing; keep_ordering::Bool = false)
   return singular_poly_ring(forget_decoration(R); keep_ordering)
 end
 
-MPolyCoeffs(f::MPolyDecRingElem) = MPolyCoeffs(forget_decoration(f))
-MPolyExponentVectors(f::MPolyDecRingElem) = MPolyExponentVectors(forget_decoration(f))
+AbstractAlgebra.coefficients(f::MPolyDecRingElem) = AbstractAlgebra.coefficients(forget_decoration(f))
+AbstractAlgebra.exponent_vectors(f::MPolyDecRingElem) = AbstractAlgebra.exponent_vectors(forget_decoration(f))
 
 function push_term!(M::MPolyBuildCtx{<:MPolyDecRingElem{T, S}}, c::T, expv::Vector{Int}) where {T <: RingElement, S}
   if iszero(c)
@@ -1106,7 +1106,7 @@ function degree(a::MPolyDecRingElem; check::Bool=true)
   w = W.D[0]
   first = true
   d = W.d
-  for c = MPolyExponentVectors(forget_decoration(a))
+  for c in AbstractAlgebra.exponent_vectors(forget_decoration(a))
     u = W.D[0]
     for i=1:length(c)
       u += c[i]*d[i]
@@ -1180,7 +1180,7 @@ function is_homogeneous(F::MPolyDecRingElem)
   d = parent(F).d
   S = nothing
   u = zero(D)
-  for c = MPolyExponentVectors(forget_decoration(F))
+  for c in AbstractAlgebra.exponent_vectors(forget_decoration(F))
     u = zero!(u)
     for i=1:length(c)
       u = addmul_delayed_reduction!(u, d[i], c[i])

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -767,7 +767,7 @@ end
 function im_func(f::MPolyRingElem, S::MPolyRing, i::Vector{Int})
   O = base_ring(S)
   g = MPolyBuildCtx(S)
-  for (c, e) = Base.Iterators.zip(MPolyCoeffs(f), MPolyExponentVectors(f))
+  for (c, e) = Base.Iterators.zip(AbstractAlgebra.coefficients(f), AbstractAlgebra.exponent_vectors(f))
     f = zeros(Int, nvars(S))
     for j=1:length(e)
       if i[j] == 0

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -83,8 +83,6 @@ import AbstractAlgebra:
   Generic.finish,
   Generic.interreduce!,
   Generic.MPolyBuildCtx,
-  Generic.MPolyCoeffs,
-  Generic.MPolyExponentVectors,
   Generic.push_term!,
   gens,
   get_attribute,

--- a/test/Rings/mpoly-graded.jl
+++ b/test/Rings/mpoly-graded.jl
@@ -128,7 +128,7 @@ end
 
         for k in 1:length(polys[4])
           @test coeff(polys[4],k) * Oscar.monomial(polys[4], k) ==
-                finish(push_term!(MPolyBuildCtx(RR), collect(Oscar.MPolyCoeffs(polys[4]))[k], collect(Oscar.MPolyExponentVectors(polys[4]))[k]))
+                finish(push_term!(MPolyBuildCtx(RR), collect(AbstractAlgebra.coefficients(polys[4]))[k], collect(AbstractAlgebra.exponent_vectors(polys[4]))[k]))
         end
 
         hom_polys = _homogeneous_polys(polys)


### PR DESCRIPTION
Avoid unnecessary access to internal AbstractAlgebra types.
There is no immediate problem with this, but I noticed this while working on https://github.com/Nemocas/AbstractAlgebra.jl/pull/2196 .
