### PR TITLE
Allow `TropicalSemiringMap` to not have a valued field

### DIFF
--- a/src/TropicalGeometry/groebner_basis.jl
+++ b/src/TropicalGeometry/groebner_basis.jl
@@ -379,6 +379,9 @@ julia> groebner_basis(I,nu,w)
 ```
 """
 function groebner_basis(I::MPolyIdeal, nu::TropicalSemiringMap, w::AbstractVector{<:Union{QQFieldElem,ZZRingElem,Rational,Integer}})
+    @req !isnothing(valued_field(nu)) "valuation must be defined on a field"
+    @req valued_field(nu)==coefficient_ring(I) "coefficient ring of ideal does not match valued field of valuation"
+
     G = gens(I)
     # Principal ideal shortcut, return G
     if isone(length(G))

--- a/src/TropicalGeometry/groebner_basis.jl
+++ b/src/TropicalGeometry/groebner_basis.jl
@@ -22,7 +22,7 @@
 #
 ################################################################################
 function get_polynomial_ring_for_groebner_simulation(R::MPolyRing, nu::TropicalSemiringMap)
-    @req coefficient_ring(R)==valued_field(nu) "coefficient ring is not valued field"
+    @req coefficient_ring(R)==domain(nu) "coefficient ring is not valued field"
 
     if !has_attribute(R, :tropical_geometry_polynomial_rings_for_groebner)
         set_attribute!(R, :tropical_geometry_polynomial_rings_for_groebner, Dict{TropicalSemiringMap,MPolyRing}())
@@ -34,7 +34,7 @@ end
 
 # special function for trivial valuation to ensure reusing original ring
 function get_polynomial_ring_for_groebner_simulation(R::MPolyRing, nu::TropicalSemiringMap{K,Nothing,minOrMax}) where {K<:Field, minOrMax<:Union{typeof(min),typeof(max)}}
-    @req coefficient_ring(R)==valued_field(nu) "coefficient ring is not valued field"
+    @req coefficient_ring(R)==domain(nu) "coefficient ring is not valued field"
     return R
 end
 
@@ -290,7 +290,7 @@ function desimulate_valuation(sG::AbstractVector{<:MPolyRingElem}, nu::TropicalS
 
     # map everything from simulation ring to the specified polynomial ring
     # whilst substituting first variable tsim by uniformizer
-    desimulation_map = hom(S, R, valued_field(nu), vcat(uniformizer_field(nu),gens(R)))
+    desimulation_map = hom(S, R, domain(nu), vcat(uniformizer_field(nu),gens(R)))
     G = desimulation_map.(sG)
     # filter for nonzero elements
     G = filter(!iszero,G)
@@ -383,8 +383,8 @@ julia> groebner_basis(I,nu,w)
 ```
 """
 function groebner_basis(I::MPolyIdeal, nu::TropicalSemiringMap, w::AbstractVector{<:Union{QQFieldElem,ZZRingElem,Rational,Integer}})
-    @req !isnothing(valued_field(nu)) "valuation must be defined on a field"
-    @req valued_field(nu)==coefficient_ring(I) "coefficient ring of ideal does not match valued field of valuation"
+    @req domain(nu) isa Field "valuation must be defined on a field"
+    @req domain(nu)==coefficient_ring(I) "coefficient ring of ideal does not match valued field of valuation"
 
     G = gens(I)
     if isone(length(G)) # for principal ideals, just return generator

--- a/src/TropicalGeometry/groebner_basis.jl
+++ b/src/TropicalGeometry/groebner_basis.jl
@@ -14,7 +14,11 @@
 
 ################################################################################
 #
-#  Caching of polynomial rings over valued rings
+#  Caching of polynomial rings
+#
+#  Tropical Groebner basis computations are done via standard basis computations
+#  in a different polynomial ring (that depends on the valuation). We cache
+#  these polynomial rings as a dictionary in the original polynomial ring
 #
 ################################################################################
 function get_polynomial_ring_for_groebner_simulation(R::MPolyRing, nu::TropicalSemiringMap)
@@ -383,8 +387,7 @@ function groebner_basis(I::MPolyIdeal, nu::TropicalSemiringMap, w::AbstractVecto
     @req valued_field(nu)==coefficient_ring(I) "coefficient ring of ideal does not match valued field of valuation"
 
     G = gens(I)
-    # Principal ideal shortcut, return G
-    if isone(length(G))
+    if isone(length(G)) # for principal ideals, just return generator
         return G
     end
 

--- a/src/TropicalGeometry/groebner_basis.jl
+++ b/src/TropicalGeometry/groebner_basis.jl
@@ -184,7 +184,7 @@ t*x2 + (s^2 + s + 1)*x1 + x3
 ```
 """
 function tighten_simulation(f::MPolyRingElem, nu::TropicalSemiringMap)
-    # substitute first variable tsim by uniformizer_ring
+    # substitute first variable tsim by uniformizer_in_ring
     # so that all monomials have distinct x-monomials
     f = evaluate(f,[1],[uniformizer(nu)])
 
@@ -290,7 +290,7 @@ function desimulate_valuation(sG::AbstractVector{<:MPolyRingElem}, nu::TropicalS
 
     # map everything from simulation ring to the specified polynomial ring
     # whilst substituting first variable tsim by uniformizer
-    desimulation_map = hom(S, R, domain(nu), vcat(uniformizer_field(nu),gens(R)))
+    desimulation_map = hom(S, R, domain(nu), vcat(uniformizer_in_field(nu),gens(R)))
     G = desimulation_map.(sG)
     # filter for nonzero elements
     G = filter(!iszero,G)

--- a/src/TropicalGeometry/hypersurface.jl
+++ b/src/TropicalGeometry/hypersurface.jl
@@ -124,6 +124,8 @@ Min tropical hypersurface
 function tropical_hypersurface(f::MPolyRingElem, nu::TropicalSemiringMap=tropical_semiring_map(coefficient_ring(f));
                                weighted_polyhedral_complex_only::Bool=false)
 
+    @req (coefficient_ring(f) isa Field) "coefficient ring of polynomial must be a field"
+
     tropf = tropical_polynomial(f,nu)
     TropH = tropical_hypersurface(tropf,weighted_polyhedral_complex_only=weighted_polyhedral_complex_only)
 

--- a/src/TropicalGeometry/hypersurface.jl
+++ b/src/TropicalGeometry/hypersurface.jl
@@ -121,10 +121,8 @@ Min tropical hypersurface
 
 ```
 """
-function tropical_hypersurface(f::MPolyRingElem, nu::Union{Nothing,TropicalSemiringMap}=nothing;
+function tropical_hypersurface(f::MPolyRingElem, nu::TropicalSemiringMap=tropical_semiring_map(coefficient_ring(f));
                                weighted_polyhedral_complex_only::Bool=false)
-    # initialize nu as the trivial valuation if not specified by user
-    isnothing(nu) && (nu=tropical_semiring_map(coefficient_ring(f)))
 
     tropf = tropical_polynomial(f,nu)
     TropH = tropical_hypersurface(tropf,weighted_polyhedral_complex_only=weighted_polyhedral_complex_only)

--- a/src/TropicalGeometry/initial.jl
+++ b/src/TropicalGeometry/initial.jl
@@ -13,7 +13,7 @@
 #
 ################################################################################
 function get_polynomial_ring_for_initial(R::MPolyRing, nu::TropicalSemiringMap)
-    @req coefficient_ring(R)==valued_field(nu) "coefficient ring is not valued field"
+    @req coefficient_ring(R)==domain(nu) "coefficient ring of polynomials is not domain of tropical semiring map"
 
     polynomialRingsForInitial = get_attribute!(R, :tropical_geometry_polynomial_rings_for_initial) do
         return Dict{TropicalSemiringMap,MPolyRing}()
@@ -23,7 +23,7 @@ end
 
 # special function for trivial valuation to ensure reusing original ring
 function get_polynomial_ring_for_initial(R::MPolyRing, nu::TropicalSemiringMap{K,Nothing,minOrMax}) where {K<:Field, minOrMax<:Union{typeof(min),typeof(max)}}
-    @req coefficient_ring(R)==valued_field(nu) "coefficient ring is not valued field"
+    @req coefficient_ring(R)==domain(nu) "coefficient ring of polynomials is not domain of tropical semiring map"
     return R
 end
 

--- a/src/TropicalGeometry/semiring_map.jl
+++ b/src/TropicalGeometry/semiring_map.jl
@@ -153,14 +153,14 @@ end
 
 # Print string
 function Base.show(io::IO, nu::TropicalSemiringMap{K,Nothing,minOrMax} where {K<:Ring, minOrMax<:Union{typeof(min),typeof(max)}})
-    print(io, "Map into $(tropical_semiring(nu)) encoding the trivial valuation on $(valued_field(nu))")
+    print(io, "Map into $(tropical_semiring(nu)) encoding the trivial valuation on $(domain(nu))")
 end
 
 # Mapping an element of the valued field or ring to the tropical semiring
 function (nu::TropicalSemiringMap{K,Nothing,minOrMax})(c::Union{RingElem,Integer,Rational}) where {K<:Field, minOrMax<:Union{typeof(min),typeof(max)}}
     # return tropical zero if c is zero
     #   and tropical one otherwise
-    return (iszero(valued_field(nu)(c)) ? zero(tropical_semiring(nu)) : one(tropical_semiring(nu)))
+    return (iszero(domain(nu)(c)) ? zero(tropical_semiring(nu)) : one(tropical_semiring(nu)))
 end
 
 # Mapping an element of the valued field or ring to the residue field
@@ -215,12 +215,12 @@ end
 
 # Print string
 function Base.show(io::IO, nu::TropicalSemiringMap{QQField,ZZRingElem,minOrMax}) where {minOrMax<:Union{typeof(min),typeof(max)}}
-    print(io, "Map into $(tropical_semiring(nu)) encoding the $(uniformizer(nu))-adic valuation on $(valued_field(nu))")
+    print(io, "Map into $(tropical_semiring(nu)) encoding the $(uniformizer(nu))-adic valuation on $(domain(nu))")
 end
 
 # Mapping an element of the valued field or ring to the tropical semiring
 function (nu::TropicalSemiringMap{QQField,ZZRingElem,minOrMax})(c::Union{RingElem,Integer,Rational}) where minOrMax<:Union{typeof(min),typeof(max)}
-    c = valued_field(nu)(c)
+    c = domain(nu)(c)
     # return tropical zero if c is zero
     #   and p-adic valuation otherwise
     # preserve_ordering ensures that valuation is negated if convention(nu)==max
@@ -230,7 +230,7 @@ end
 
 # Mapping an element of the valued field or ring to the residue field
 function initial(c::Union{RingElem,Integer,Rational}, nu::TropicalSemiringMap{QQField,ZZRingElem,minOrMax}) where minOrMax<:Union{typeof(min),typeof(max)}
-    c = valued_field(nu)(c)
+    c = domain(nu)(c)
     # return residue field zero if c is zero
     #   and the correct non-zero residue otherwise
     iszero(c) && return zero(residue_field(nu)) # if c is zero, return 0
@@ -290,7 +290,7 @@ end
 
 # Print String
 function Base.show(io::IO, nu::TropicalSemiringMap{Kt,t,minOrMax}) where {Kt<:Generic.RationalFunctionField, t<:PolyRingElem, minOrMax<:Union{typeof(min),typeof(max)}}
-    print(io, "Map into $(tropical_semiring(nu)) encoding the $(uniformizer(nu))-adic valuation on $(valued_field(nu))")
+    print(io, "Map into $(tropical_semiring(nu)) encoding the $(uniformizer(nu))-adic valuation on $(domain(nu))")
 end
 
 # Mapping an element of the valued field or ring to the tropical semiring
@@ -299,7 +299,7 @@ function t_adic_valuation(c::Generic.RationalFunctionFieldElem, t::PolyRingElem)
 end
 
 function (nu::TropicalSemiringMap{Kt,t,minOrMax})(c::Union{RingElem,Integer,Rational}) where {Kt<:Generic.RationalFunctionField, t<:PolyRingElem, minOrMax<:Union{typeof(min),typeof(max)}}
-    c = valued_field(nu)(c)
+    c = domain(nu)(c)
     # return tropical zero if c is zero
     #   and p-adic valuation otherwise
     # preserve_ordering ensures that valuation is negated if convention(nu)==max
@@ -309,7 +309,7 @@ end
 
 # Mapping an element of the valued field or ring to the residue field
 function initial(c::Union{RingElem,Integer,Rational}, nu::TropicalSemiringMap{Kt,t,minOrMax}) where {Kt<:Generic.RationalFunctionField, t<:PolyRingElem, minOrMax<:Union{typeof(min),typeof(max)}}
-    c = valued_field(nu)(c)
+    c = domain(nu)(c)
     # return residue field zero if c is zero
     #   and the correct non-zero residue otherwise
     iszero(c) && return zero(residue_field(nu)) # if c is zero, return 0

--- a/src/TropicalGeometry/semiring_map.jl
+++ b/src/TropicalGeometry/semiring_map.jl
@@ -18,11 +18,11 @@ semiring, encoding a valuation and a choice of min- or max-convention.
 
 # Fields
 - `valued_field`: the valued field. can be `nothing` if valued field unspecified
-- `uniformizer_field`: the uniformizer as element in the valued field
+- `uniformizer_in_field`: the uniformizer as element in the valued field
     can be `nothing` if valued field unspecified or valuation trivial
 - `valued_ring`: the valued ring, either specified by user or
     inferred from the valued field specified by user
-- `uniformizer_ring`: the uniformizer as element in the valued ring specified by user
+- `uniformizer_in_ring`: the uniformizer as element in the valued ring specified by user
     can be `nothing` if valuation trivial
 - `residue_field`: the residue field, inferred from fields above
 - `tropical_semiring`: either `tropical_semiring(min)` or `tropical_semiring(max)`
@@ -30,9 +30,9 @@ semiring, encoding a valuation and a choice of min- or max-convention.
 """
 struct TropicalSemiringMap{DomainType, UniformizerType, MinOrMax}
     valued_field::Union{Nothing,Field}
-    uniformizer_field::Union{Nothing,FieldElem}
+    uniformizer_in_field::Union{Nothing,FieldElem}
     valued_ring::Ring
-    uniformizer_ring::Union{Nothing,RingElem}
+    uniformizer_in_ring::Union{Nothing,RingElem}
     residue_field::Field
     tropical_semiring::TropicalSemiring{MinOrMax}
 
@@ -84,15 +84,15 @@ end
 #
 ################################################################################
 valued_field(nu::TropicalSemiringMap) = nu.valued_field
-uniformizer_field(nu::TropicalSemiringMap) = nu.uniformizer_field
+uniformizer_in_field(nu::TropicalSemiringMap) = nu.uniformizer_in_field
 valued_ring(nu::TropicalSemiringMap) = nu.valued_ring
-uniformizer_ring(nu::TropicalSemiringMap) = nu.uniformizer_ring
+uniformizer_in_ring(nu::TropicalSemiringMap) = nu.uniformizer_in_ring
 residue_field(nu::TropicalSemiringMap) = nu.residue_field
 tropical_semiring(nu::TropicalSemiringMap) = nu.tropical_semiring
 
 domain(nu::TropicalSemiringMap) = isnothing(valued_field(nu)) ? valued_ring(nu) : valued_field(nu)
 codomain(nu::TropicalSemiringMap) = tropical_semiring(nu)
-uniformizer(nu::TropicalSemiringMap) = uniformizer_ring(nu)
+uniformizer(nu::TropicalSemiringMap) = uniformizer_in_ring(nu)
 
 convention(::TropicalSemiringMap{typeofValuedField,typeofUniformizer,typeof(min)}) where {typeofValuedField,typeofUniformizer} = min
 convention(::TropicalSemiringMap{typeofValuedField,typeofUniformizer,typeof(max)}) where {typeofValuedField,typeofUniformizer} = max
@@ -232,7 +232,7 @@ function initial(c::Union{RingElem,Integer,Rational}, nu::TropicalSemiringMap{QQ
     # return residue field zero if c is zero
     #   and the correct non-zero residue otherwise
     iszero(c) && return zero(residue_field(nu)) # if c is zero, return 0
-    c *= uniformizer_field(nu)^(-valuation(c,uniformizer(nu)))
+    c *= uniformizer_in_field(nu)^(-valuation(c,uniformizer(nu)))
     return residue_field(nu)(c)
 end
 
@@ -311,6 +311,6 @@ function initial(c::Union{RingElem,Integer,Rational}, nu::TropicalSemiringMap{Kt
     # return residue field zero if c is zero
     #   and the correct non-zero residue otherwise
     iszero(c) && return zero(residue_field(nu)) # if c is zero, return 0
-    c *= uniformizer_field(nu)^(-t_adic_valuation(c,uniformizer(nu)))
+    c *= uniformizer_in_field(nu)^(-t_adic_valuation(c,uniformizer(nu)))
     return evaluate(numerator(c),0)
 end

--- a/src/TropicalGeometry/semiring_map.jl
+++ b/src/TropicalGeometry/semiring_map.jl
@@ -115,7 +115,9 @@ polynomial_rings_for_initial(nu::TropicalSemiringMap) = nu.polynomial_rings_for_
 @doc raw"""
     tropical_semiring_map(K::Field, minOrMax::Union{typeof(min),typeof(max)}=min)
 
-Return a map `nu` from `K` to the min (default) or max tropical semiring `T` such that `nu(0)=zero(T)` and `nu(c)=one(T)` for `c` non-zero.  In other words, `nu` extends the trivial valuation on `K`.
+Return a map `nu` from `K` to the min (default) or max tropical semiring `T`
+such that `nu(0)=zero(T)` and `nu(c)=one(T)` for `c` non-zero.  In other words,
+`nu` represents the trivial valuation on `K`.
 
 # Examples
 ```jldoctest

--- a/src/TropicalGeometry/semiring_map.jl
+++ b/src/TropicalGeometry/semiring_map.jl
@@ -87,9 +87,12 @@ valued_field(nu::TropicalSemiringMap) = nu.valued_field
 uniformizer_field(nu::TropicalSemiringMap) = nu.uniformizer_field
 valued_ring(nu::TropicalSemiringMap) = nu.valued_ring
 uniformizer_ring(nu::TropicalSemiringMap) = nu.uniformizer_ring
-uniformizer(nu::TropicalSemiringMap) = uniformizer_ring(nu)
 residue_field(nu::TropicalSemiringMap) = nu.residue_field
 tropical_semiring(nu::TropicalSemiringMap) = nu.tropical_semiring
+
+domain(nu::TropicalSemiringMap) = isnothing(valued_field(nu)) ? valued_ring(nu) : valued_field(nu)
+codomain(nu::TropicalSemiringMap) = tropical_semiring(nu)
+uniformizer(nu::TropicalSemiringMap) = uniformizer_ring(nu)
 
 convention(::TropicalSemiringMap{typeofValuedField,typeofUniformizer,typeof(min)}) where {typeofValuedField,typeofUniformizer} = min
 convention(::TropicalSemiringMap{typeofValuedField,typeofUniformizer,typeof(max)}) where {typeofValuedField,typeofUniformizer} = max

--- a/src/TropicalGeometry/semiring_map.jl
+++ b/src/TropicalGeometry/semiring_map.jl
@@ -55,18 +55,8 @@ struct TropicalSemiringMap{DomainType, UniformizerType, MinOrMax}
         @req !isnothing(uniformizerRing) || isnothing(uniformizerField) "uniformizerRing / uniformizerField mismatch"
 
         # if no valued field specified, first parameter captures the valued ring
-        if isnothing(valuedField)
-            return new{typeof(valuedRing),typeof(uniformizerRing),MinOrMax}(
-                valuedField,
-                uniformizerField,
-                valuedRing,
-                uniformizerRing,
-                residueField,
-                tropicalSemiring)
-        end
-
         # otherwise, first parameter captures the valued field
-        return new{typeof(valuedField),typeof(uniformizerRing),MinOrMax}(
+        return new{isnothing(valuedField) ? typeof(valuedRing) : typeof(valuedField), typeof(uniformizerRing),MinOrMax}(
             valuedField,
             uniformizerField,
             valuedRing,


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/5510

Due to new use-cases on the horizon, it is necessary to allow `TropicalSemiringMap` to be constructed without a valued field and with a valued ring only.  (**Reminder:** the fact that both field and ring are stored separately is because there is a lot of doing between them in tropical GB computations)

This is purely a technical change in the constructor of `TropicalSemiringMap`.  It is currently not supported in OSCAR, meaning there are no user-facing functions for constructing such a `TropicalSemiringMap`.  However, other projects that I am working on require either
(a) change the constructor of `TropicalSemiringMap` to allow not having a valued field, or
(b) not use `TropicalSemiringMap` at all and have a separate parallel system instead.

And I think (a) is the better option, especially since it means I don't have to reimplement many functions because their implemention in OSCAR will work for such a `TropicalSemiringMap`.