### PR TITLE
Use `InfiniteDimensionError`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ f4ncgb_jll = "160f184c-7e1a-5d95-af1f-70d62a450302"
 lib4ti2_jll = "1493ae25-0f90-5c0e-a06c-8c5077d6d66f"
 
 [compat]
-AbstractAlgebra = "0.47.3"
+AbstractAlgebra = "0.47.4"
 AlgebraicSolving = "0.10.0"
 Compat = "4.13.0"
 Distributed = "1.6"

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -1732,8 +1732,8 @@ function homogeneous_component(W::MPolyQuoRing{<:MPolyDecRingElem}, d::FinGenAbG
   H, mH = try
     homogeneous_component(R, d)
   catch e
-    if e isa ArgumentError && e.msg == "The considered graded component is infinite-dimensional"
-      rethrow(ArgumentError("The preimage of the considered graded component in the underlying polynomial ring is not finite-dimensional"))
+    if e isa AbstractAlgebra.InfiniteDimensionError
+      rethrow(AbstractAlgebra.InfiniteDimensionError("The preimage of the considered graded component in the underlying polynomial ring is not finite-dimensional"))
     else
       rethrow(e)
     end

--- a/src/Rings/mpoly-affine-algebras.jl
+++ b/src/Rings/mpoly-affine-algebras.jl
@@ -195,8 +195,8 @@ function monomial_basis(A::MPolyQuoRing, g::FinGenAbGroupElem)
   L = try
     monomial_basis(R, g)
   catch e
-    if e isa ArgumentError && e.msg == "The considered graded component is infinite-dimensional"
-      rethrow(ArgumentError("The preimage of the considered graded component in the underlying polynomial ring is not finite-dimensional"))
+    if e isa AbstractAlgebra.InfiniteDimensionError
+      rethrow(AbstractAlgebra.InfiniteDimensionError("The preimage of the considered graded component in the underlying polynomial ring is not finite-dimensional"))
     else
       rethrow(e)
     end

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -493,7 +493,7 @@ false
   try
     homogeneous_component(R, zero(G))
   catch e
-    if e isa ArgumentError && e.msg == "The considered graded component is infinite-dimensional"
+    if e isa AbstractAlgebra.InfiniteDimensionError
       return false
     else
       rethrow(e)
@@ -1464,7 +1464,7 @@ function monomial_basis(W::MPolyDecRing, d::FinGenAbGroupElem)
        solve_mixed(transpose(A), transpose(d.coeff), C)
      catch e
        if e isa ErrorException && e.msg == "Polyhedron not bounded"
-         rethrow(ArgumentError("The considered graded component is infinite-dimensional"))
+         rethrow(AbstractAlgebra.InfiniteDimensionError("The considered graded component is infinite-dimensional"))
        else
          rethrow(e)
        end


### PR DESCRIPTION
Use `AbstractAlgebra.InfiniteDimensionError` in some cases introduced in #5507 to avoid checking the precise error message.

~This needs https://github.com/Nemocas/AbstractAlgebra.jl/pull/2203 ; I just open it now to not forget about it.~
