### PR TITLE
Change base_ring_type for QQAbField, drop base_ring method

### DIFF
--- a/src/Rings/AbelianClosure.jl
+++ b/src/Rings/AbelianClosure.jl
@@ -168,8 +168,7 @@ elem_type(::Type{QQAbField{AbsNonSimpleNumField}}) = QQAbFieldElem{AbsNonSimpleN
 parent_type(::Type{QQAbFieldElem{AbsNonSimpleNumFieldElem}}) = QQAbField{AbsNonSimpleNumField}
 parent(::QQAbFieldElem{AbsNonSimpleNumFieldElem}) = _QQAb_sparse
 
-base_ring(::QQAbField) = Union{}
-base_ring_type(::Type{<:QQAbField}) = typeof(Union{})
+base_ring_type(::Type{<:QQAbField}) = Union{}
 
 ################################################################################
 #


### PR DESCRIPTION
This adjusts to changes that started to roll out in AbstractAlgebra some time ago.

See also https://github.com/Nemocas/AbstractAlgebra.jl/pull/2144 and https://github.com/Nemocas/Nemo.jl/pull/2148 