### PR TITLE
Optimize `permuted(pnt, ::PermGroupElem)`

### DIFF
--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -246,12 +246,12 @@ permuted(pnt::GapObj, x::PermGroupElem) = GAPWrap.Permuted(pnt, GapObj(x))
 
 function permuted(pnt::Vector{T}, x::PermGroupElem) where T
    invx = inv(x)
-   return pnt[[i^invx for i in 1:length(pnt)]]
+   return [pnt[i^invx] for i in 1:length(pnt)]
 end
 
-function permuted(pnt::T, x::PermGroupElem) where T <: Tuple
+function permuted(pnt::T, x::PermGroupElem) where T <: NTuple
    invx = inv(x)
-   return T(pnt[[i^invx for i in 1:length(pnt)]])
+   return T(pnt[i^invx] for i in 1:length(pnt))::T
 end
 
 


### PR DESCRIPTION
This avoids allocating a vector of permuted indices into `pnt`, resulting in the following improvements:
```julia
julia> n = 10;

julia> pnt = collect(1:100:100n);

julia> x = rand_pseudo(symmetric_group(n));

julia> @b permuted(pnt, x)
306.289 ns (4 allocs: 288 bytes) # master
226.464 ns (2 allocs: 144 bytes) # this PR

julia> pnt = Tuple(collect(1:100:100n));

julia> @b permuted(pnt, x)
847.185 ns (9 allocs: 448 bytes) # master
220.061 ns (3 allocs: 240 bytes) # this PR

julia> n = 1000;

julia> pnt = collect(1:100:100n);

julia> x = rand_pseudo(symmetric_group(n));

julia> @b permuted(pnt, x)
20.657 μs (495 allocs: 23.406 KiB) # master
15.850 μs (492 allocs: 15.523 KiB) # this PR

julia> pnt = Tuple(collect(1:100:100n));

julia> @b permuted(pnt, x)
67.465 μs (1491 allocs: 54.750 KiB) # master
57.113 μs (1489 allocs: 54.742 KiB) # this PR
```
While at it, I furthermore made the variant for tuples type-stable.

In my large, out-of-scope example, this simple change got rid of 17% of allocations, 27% of allocated memory, and 19% of runtime.