### PR TITLE
Forbid `IdealGens` and `BiPolyArray` with bad types; fix `base_ring_type(:: MPolyQuoRing)`

### DIFF
--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -64,7 +64,7 @@ gens(Q::MPolyQuoRing) = [Q(x) for x = gens(base_ring(Q))]
 number_of_generators(Q::MPolyQuoRing) = number_of_generators(base_ring(Q))
 gen(Q::MPolyQuoRing, i::Int) = Q(gen(base_ring(Q), i))
 base_ring(Q::MPolyQuoRing) = base_ring(Q.I)
-base_ring_type(::Type{MPolyQuoRing{S}}) where {S} = base_ring_type(S)
+base_ring_type(::Type{MPolyQuoRing{S}}) where {S} = parent_type(S)
 coefficient_ring(Q::MPolyQuoRing) = coefficient_ring(base_ring(Q))
 modulus(Q::MPolyQuoRing) = Q.I
 oscar_groebner_basis(Q::MPolyQuoRing) = _groebner_basis(Q) && return oscar_generators(Q.I.gb[Q.ordering])

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -156,26 +156,28 @@ mutable struct BiPolyArray{S}
   f #= isomorphism Ox -> Sx =#
   S::Singular.sideal
 
-  function BiPolyArray(O::Vector{T}) where {T <: NCRingElem}
+  function BiPolyArray(Ox::T) where {T <: NCRing}
+    if T <: MPolyQuoRing
+      return new{elem_type(base_ring_type(T))}(Ox)
+    end
+    return new{elem_type(T)}(Ox)
+  end
+
+  function BiPolyArray(O::Vector{<: NCRingElem})
     return BiPolyArray(parent(O[1]), O)
   end
 
-  function BiPolyArray(Ox::NCRing, O::Vector{T}) where {T <: NCRingElem}
-    r = new{T}(Ox, O)
+  function BiPolyArray(Ox::NCRing, O::Vector{<: NCRingElem})
+    r = BiPolyArray(Ox)
+    r.O = O
     return r
   end
 
   function BiPolyArray(Ox::T, S::Singular.sideal) where {T <: NCRing}
-      Sx = base_ring(S)
-      if T <: MPolyQuoRing
-          r = new{typeof(Ox).parameters[1]}()
-      else
-          r = new{elem_type(T)}()
-      end
-      r.Sx = Sx
-      r.S = S
-      r.Ox = Ox
-      return r
+    r = BiPolyArray(Ox)
+    r.Sx = base_ring(S)
+    r.S = S
+    return r
   end
 end
 
@@ -186,6 +188,11 @@ mutable struct IdealGens{S}
   ord::Orderings.MonomialOrdering
   keep_ordering::Bool
 
+  # internal constructor
+  function IdealGens(B::BiPolyArray{S}, isGB::Bool, isReduced::Bool) where S
+    return new{S}(B, isGB, isReduced)
+  end
+
   function IdealGens(O::Vector{T}; keep_ordering::Bool = true) where {T <: NCRingElem}
     return IdealGens(parent(O[1]), O; keep_ordering = keep_ordering)
   end
@@ -195,36 +202,27 @@ mutable struct IdealGens{S}
   end
 
   function IdealGens(Ox::NCRing, O::Vector{T}, ordering::Orderings.MonomialOrdering; keep_ordering::Bool = true, isGB::Bool = false, isReduced::Bool = false) where {T <: NCRingElem}
-    r = new{T}(BiPolyArray(Ox, O))
+    r = IdealGens(BiPolyArray(Ox, O), isGB, isReduced)
     r.ord = ordering
-    r.isGB = isGB
-    r.isReduced = isReduced
     r.keep_ordering = keep_ordering
     return r
   end
 
   function IdealGens(Ox::NCRing, O::Vector{T}; keep_ordering::Bool = true) where {T <: NCRingElem}
-    r = new{T}(BiPolyArray(Ox, O))
-    r.isGB = false
+    r = IdealGens(BiPolyArray(Ox, O), false, false)
     r.keep_ordering = keep_ordering
     return r
   end
 
   function IdealGens(Ox::T, S::Singular.sideal, isReduced::Bool = false) where {T <: NCRing}
-      if T <: MPolyQuoRing
-          r = new{typeof(Ox).parameters[1]}()
-          r.ord = Ox.ordering
-      else
-          r = new{elem_type(T)}()
-      end
-      r.gensBiPolyArray = BiPolyArray(Ox, S)
-      r.isGB = S.isGB
-      r.isReduced = isReduced
-      if T <: MPolyRing
-          r.ord = monomial_ordering(Ox, Singular.ordering(base_ring(S)))
-      end
-      r.keep_ordering = true
-      return r
+    r = IdealGens(BiPolyArray(Ox, S), S.isGB, isReduced)
+    if T <: MPolyQuoRing
+      r.ord = Ox.ordering
+    else
+      r.ord = monomial_ordering(Ox, Singular.ordering(base_ring(S)))
+    end
+    r.keep_ordering = true
+    return r
   end
 end
 

--- a/test/Rings/MPolyQuo.jl
+++ b/test/Rings/MPolyQuo.jl
@@ -1,3 +1,15 @@
+function ConformanceTests.generate_element(Q::MPolyQuoRing)
+  return Q(ConformanceTests.generate_element(base_ring(Q)))
+end
+
+@testset "MPolyQuoRing.conformance" begin
+  R, (x,y) = polynomial_ring(QQ, [:x, :y])
+  f = y^2+y+x^2
+  C = ideal(R, [f])
+  Q, = quo(R, C)
+  ConformanceTests.test_Ring_interface_recursive(Q; reps = 3)
+end
+
 @testset "MPolyQuoRing" begin
   R, (x,y) = polynomial_ring(QQ, [:x, :y])
   f = y^2+y+x^2


### PR DESCRIPTION
The IdealGens and BiPolyArray constructors were rather lax and slightly off input made it possible to generate instances where the type parameter `S` was wrong.

Prevent this by ensuring all constructors go to through just one or two central constructors which ensure the type params are appropriate. While at it, get rid of nasty hacks relyingJulia type system  internals (no more `typeof(Ox).parameters[1]`).

Also fix `base_ring_type` for `MPolyQuoRing`, it was plain wrong. To catch similar issues, run conformance tests for `MPolyQuoRing`.


Motived by PR #5518 (CC @Sequenzer). This PR here is not a replacement, more a complement. This PR here should make certain kinds of weird and confusing bugs impossible. It does not try to make it easier for the user in any way, just will error out earlier (and hopefully in a somewhat more helpful way)