### PR TITLE
CommutativeAlgebra: added keys(::IdealGens)

### DIFF
--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -318,6 +318,10 @@ end
 
 Base.eltype(::Type{IdealGens{S}}) where S = S
 
+function Base.keys(A::IdealGens)
+  return 1:length(A)
+end
+
 function gens(I::IdealGens)
   return collect(I)
 end


### PR DESCRIPTION
Required for `findfirst` (amongst other things):

```
julia> I = grassmann_pluecker_ideal(2, 5) # argument 1
Ideal generated by
  x[[1, 2]]*x[[3, 4]] - x[[1, 3]]*x[[2, 4]] + x[[1, 4]]*x[[2, 3]]
  x[[1, 2]]*x[[3, 5]] - x[[1, 3]]*x[[2, 5]] + x[[1, 5]]*x[[2, 3]]
  x[[1, 2]]*x[[4, 5]] - x[[1, 4]]*x[[2, 5]] + x[[1, 5]]*x[[2, 4]]
  x[[1, 3]]*x[[4, 5]] - x[[1, 4]]*x[[3, 5]] + x[[1, 5]]*x[[3, 4]]
  x[[2, 3]]*x[[4, 5]] - x[[2, 4]]*x[[3, 5]] + x[[2, 5]]*x[[3, 4]]

julia> G = groebner_basis(I)
Gröbner basis with elements
  1: x[[1, 4]]*x[[2, 3]] - x[[1, 3]]*x[[2, 4]] + x[[1, 2]]*x[[3, 4]]
  2: x[[1, 5]]*x[[2, 3]] - x[[1, 3]]*x[[2, 5]] + x[[1, 2]]*x[[3, 5]]
  3: x[[1, 5]]*x[[2, 4]] - x[[1, 4]]*x[[2, 5]] + x[[1, 2]]*x[[4, 5]]
  4: x[[1, 5]]*x[[3, 4]] - x[[1, 4]]*x[[3, 5]] + x[[1, 3]]*x[[4, 5]]
  5: x[[2, 5]]*x[[3, 4]] - x[[2, 4]]*x[[3, 5]] + x[[2, 3]]*x[[4, 5]]
with respect to the ordering
  degrevlex([x[[1, 2]], x[[1, 3]], x[[1, 4]], x[[1, 5]], x[[2, 3]], x[[2, 4]], x[[2, 5]], x[[3  , 4]], x[[3, 5]], x[[4, 5]]])

julia> findfirst(!iszero,G) # <- didn't work before
1
```