### PR TITLE
Support optional "inplace" iteration for combinations and multicombinations

### DIFF
--- a/docs/src/Combinatorics/EnumerativeCombinatorics/combinations.md
+++ b/docs/src/Combinatorics/EnumerativeCombinatorics/combinations.md
@@ -4,7 +4,7 @@ CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 
-# Combinations and multicombinations
+# Combinations
 
 A **combination** from a set $S$ is a selection $\lambda_1, \lambda_2 \dots \lambda_r$ of elements of $S$ taken without repetition; the order of the elements is considered not to matter. A $k$-combination is a combination consisting of $k$ elements.
 A general reference on combinations is [Knu11](@cite), Section 7.2.1.3.

--- a/docs/src/Combinatorics/EnumerativeCombinatorics/combinations.md
+++ b/docs/src/Combinatorics/EnumerativeCombinatorics/combinations.md
@@ -4,7 +4,7 @@ CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 
-# Combinations
+# Combinations and multicombinations
 
 A **combination** from a set $S$ is a selection $\lambda_1, \lambda_2 \dots \lambda_r$ of elements of $S$ taken without repetition; the order of the elements is considered not to matter. A $k$-combination is a combination consisting of $k$ elements.
 A general reference on combinations is [Knu11](@cite), Section 7.2.1.3.
@@ -69,8 +69,9 @@ julia> C[1]
 ```
 
 
-## Generating
+## Generating and counting
 
 ```@docs
 combinations
+number_of_combinations
 ```

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -66,9 +66,22 @@ combinations(v::AbstractVector, k::IntegerUnion) = Combinations(v, k)
   return c, state
 end
 
-Base.length(C::Combinations) = binomial(Int(C.n), Int(C.k))
-
 Base.eltype(::Type{<:Combinations{T}}) where {T} = Combination{eltype(T)}
+
+@doc raw"""
+    number_of_multicombinations(n::IntegerUnion, k::IntegerUnion)
+
+Return the number of $k$-combinations of ${1, \ldots, n}$.
+If `n < 0` or `k < 0`, return `0`.
+"""
+function number_of_combinations(n::IntegerUnion, k::IntegerUnion)
+  if n < 0 || k < 0
+    return ZZ(0)
+  end
+  return binomial(ZZ(n), ZZ(k))
+end
+
+Base.length(C::Combinations) = BigInt(number_of_combinations(C.n, C.k))
 
 function Base.show(io::IO, C::Combinations{<:Base.OneTo})
   print(io, "Iterator over the ", C.k, "-combinations of ", 1:C.n)

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -7,6 +7,9 @@ lexicographically ascending order.
 If `inplace` is `true`, the elements of the iterator may share their memory. This
 means that an element returned by the iterator may be overwritten 'in place' in
 the next iteration step. This may result in significantly fewer memory allocations.
+However, using the in-place version is only meaningful
+if just one element of the iterator is needed at any time.
+For example, calling `collect` on thisiterator will not give useful results.
 
 # Examples
 

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -18,7 +18,7 @@ julia> collect(C)
  [2, 3, 4]
 ```
 """
-combinations(n::T, k::T) where T<:IntegerUnion = Combinations(Base.oneto(n), n, k)
+combinations(n::T, k::T; inplace::Bool = false) where T<:IntegerUnion = Combinations(Base.oneto(n), n, k, inplace)
 
 @doc raw"""
     combinations(v::AbstractVector, k::IntegerUnion)
@@ -41,8 +41,6 @@ julia> collect(C)
 ```
 """
 combinations(v::AbstractVector, k::IntegerUnion) = Combinations(v, k)
-
-Combinations(v::AbstractArray, k::T) where {T<:IntegerUnion} = Combinations(v, T(length(v)), k)
 
 @inline function Base.iterate(C::Combinations{<:AbstractVector{T}, U}, state::Vector{U} = U[min(C.k - 1, i) for i in Base.oneto(C.k)]) where {T, U<:IntegerUnion}
   if is_zero(C.k) # special case to generate 1 result for k = 0

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -9,7 +9,7 @@ means that an element returned by the iterator may be overwritten 'in place' in
 the next iteration step. This may result in significantly fewer memory allocations.
 However, using the in-place version is only meaningful
 if just one element of the iterator is needed at any time.
-For example, calling `collect` on thisiterator will not give useful results.
+For example, calling `collect` on this iterator will not give useful results.
 
 # Examples
 

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -62,7 +62,8 @@ combinations(v::AbstractVector, k::IntegerUnion) = Combinations(v, k)
   if state[1] > C.n - C.k + 1
     return nothing
   end
-  return Combination{T}(C.v[state]), state
+  c = C.inplace ? Combination{T}(state) : Combination{T}(C.v[state])
+  return c, state
 end
 
 Base.length(C::Combinations) = binomial(Int(C.n), Int(C.k))

--- a/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -1,8 +1,12 @@
 @doc raw"""
-    combinations(n::IntegerUnion, k::IntegerUnion)
+    combinations(n::IntegerUnion, k::IntegerUnion; inplace::Bool=false)
 
 Return an iterator over all $k$-combinations of ${1,...,n}$, produced in
 lexicographically ascending order.
+
+If `inplace` is `true`, the elements of the iterator may share their memory. This
+means that an element returned by the iterator may be overwritten 'in place' in
+the next iteration step. This may result in significantly fewer memory allocations.
 
 # Examples
 

--- a/src/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
@@ -24,7 +24,7 @@ julia> collect(C)
  [4, 4]
 ```
 """
-multicombinations(n::T, k::T) where T<:IntegerUnion = MultiCombinations(Base.oneto(n), n, k)
+multicombinations(n::T, k::T; inplace::Bool = false) where T<:IntegerUnion = MultiCombinations(Base.oneto(n), n, k, inplace)
 
 
 @doc raw"""
@@ -46,8 +46,6 @@ julia> collect(multicombinations(['a', 'b', 'c'], 2))
 ```
 """
 multicombinations(v::AbstractVector, k::IntegerUnion) = MultiCombinations(v, k)
-
-MultiCombinations(v::AbstractArray, k::T) where {T<:IntegerUnion} = MultiCombinations(v, T(length(v)), k)
 
 
 @inline function Base.iterate(C::MultiCombinations{<:AbstractVector{T}, U}, state::Vector{U} = C.k == 0 ? U[] : (s = ones(U, C.k); s[Int(C.k)] = U(0); s)) where {T, U<:IntegerUnion}

--- a/src/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
@@ -1,8 +1,12 @@
 @doc raw"""
-    multicombinations(n::IntegerUnion, k::IntegerUnion)
+    multicombinations(n::IntegerUnion, k::IntegerUnion; inplace::Bool=false)
 
 Return an iterator over all $k$-combinations of ${1,...,n}$ with repetition,
 produced in lexicographically ascending order.
+
+If `inplace` is `true`, the elements of the iterator may share their memory. This
+means that an element returned by the iterator may be overwritten 'in place' in
+the next iteration step. This may result in significantly fewer memory allocations.
 
 # Examples
 

--- a/src/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
@@ -9,7 +9,7 @@ means that an element returned by the iterator may be overwritten 'in place' in
 the next iteration step. This may result in significantly fewer memory allocations.
 However, using the in-place version is only meaningful
 if just one element of the iterator is needed at any time.
-For example, calling `collect` on thisiterator will not give useful results.
+For example, calling `collect` on this iterator will not give useful results.
 
 # Examples
 

--- a/src/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
@@ -68,7 +68,9 @@ multicombinations(v::AbstractVector, k::IntegerUnion) = MultiCombinations(v, k)
   if state[1] > C.n
     return nothing
   end
-  return Combination{T}(C.v[state]), state
+
+  c = C.inplace ? Combination{T}(state) : Combination{T}(C.v[state])
+  return c, state
 end
 
 Base.length(C::MultiCombinations) = binomial(Int(C.n)+Int(C.k)-1, Int(C.k))

--- a/src/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
@@ -73,9 +73,22 @@ multicombinations(v::AbstractVector, k::IntegerUnion) = MultiCombinations(v, k)
   return c, state
 end
 
-Base.length(C::MultiCombinations) = binomial(Int(C.n)+Int(C.k)-1, Int(C.k))
-
 Base.eltype(::Type{<:MultiCombinations{T}}) where {T} = Combination{eltype(T)}
+
+@doc raw"""
+    number_of_multicombinations(n::IntegerUnion, k::IntegerUnion)
+
+Return the number of $k$-combinations of ${1, \ldots, n}$.
+If `n < 0` or `k < 0`, return `0`.
+"""
+function number_of_multicombinations(n::IntegerUnion, k::IntegerUnion)
+  if n < 0 || k < 0
+    return ZZ(0)
+  end
+  return binomial(ZZ(n) + ZZ(k) - 1, ZZ(k))
+end
+
+Base.length(C::MultiCombinations) = BigInt(number_of_multicombinations(C.n, C.k))
 
 function Base.show(io::IO, C::MultiCombinations{<:Base.OneTo})
   print(io, "Iterator over the ", C.k, "-combinations of ", 1:C.n, " with repetition")

--- a/src/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
@@ -7,6 +7,9 @@ produced in lexicographically ascending order.
 If `inplace` is `true`, the elements of the iterator may share their memory. This
 means that an element returned by the iterator may be overwritten 'in place' in
 the next iteration step. This may result in significantly fewer memory allocations.
+However, using the in-place version is only meaningful
+if just one element of the iterator is needed at any time.
+For example, calling `collect` on thisiterator will not give useful results.
 
 # Examples
 

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -401,24 +401,44 @@ end
 #
 ################################################################################
 
-struct Combinations{T, U<:IntegerUnion}
-  v::T
-  n::U
-  k::U
-end
-
 struct Combination{T} <: AbstractVector{T}
   v::Vector{T}
 end
 
+# Iterator type: all combinations of k elements from the vector v
+struct Combinations{T, U<:IntegerUnion}
+  v::T
+  n::U
+  k::U
+
+  inplace::Bool # Whether all generated combinations share the same array in
+                # memory
+
+  function Combinations(v::T, k::U, k::U, inplace::Bool = false) where {T, U<:IntegerUnion}
+    return new{T}(v, n, k, inplace)
+  end
+end
+
+
+Combinations(v::AbstractArray, k::T) where {T<:IntegerUnion} = Combinations(v, T(length(v)), k)
 ################################################################################
 #
 #  Multicombination(s)
 #
 ################################################################################
 
+# Iterator type: all combinations of k elements from the vector v with repetition
 struct MultiCombinations{T, U<:IntegerUnion}
   v::T
   n::U
   k::U
+
+  inplace::Bool # Whether all generated combinations share the same array in
+                # memory
+
+  function MultiCombinations(v::T, k::U, k::U, inplace::Bool = false) where {T, U<:IntegerUnion}
+    return new{T}(v, n, k, inplace)
+  end
 end
+
+MultiCombinations(v::AbstractArray, k::T) where {T<:IntegerUnion} = MultiCombinations(v, T(length(v)), k)

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -421,6 +421,7 @@ end
 
 
 Combinations(v::AbstractArray, k::T) where {T<:IntegerUnion} = Combinations(v, T(length(v)), k)
+
 ################################################################################
 #
 #  Multicombination(s)

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -415,7 +415,7 @@ struct Combinations{T, U<:IntegerUnion}
                 # memory
 
   function Combinations(v::T, k::U, k::U, inplace::Bool = false) where {T, U<:IntegerUnion}
-    return new{T}(v, n, k, inplace)
+    return new{T,U}(v, n, k, inplace)
   end
 end
 
@@ -437,7 +437,7 @@ struct MultiCombinations{T, U<:IntegerUnion}
                 # memory
 
   function MultiCombinations(v::T, k::U, k::U, inplace::Bool = false) where {T, U<:IntegerUnion}
-    return new{T}(v, n, k, inplace)
+    return new{T,U}(v, n, k, inplace)
   end
 end
 

--- a/src/Combinatorics/EnumerativeCombinatorics/types.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/types.jl
@@ -414,7 +414,7 @@ struct Combinations{T, U<:IntegerUnion}
   inplace::Bool # Whether all generated combinations share the same array in
                 # memory
 
-  function Combinations(v::T, k::U, k::U, inplace::Bool = false) where {T, U<:IntegerUnion}
+  function Combinations(v::T, n::U, k::U, inplace::Bool = false) where {T, U<:IntegerUnion}
     return new{T,U}(v, n, k, inplace)
   end
 end
@@ -436,7 +436,7 @@ struct MultiCombinations{T, U<:IntegerUnion}
   inplace::Bool # Whether all generated combinations share the same array in
                 # memory
 
-  function MultiCombinations(v::T, k::U, k::U, inplace::Bool = false) where {T, U<:IntegerUnion}
+  function MultiCombinations(v::T, n::U, k::U, inplace::Bool = false) where {T, U<:IntegerUnion}
     return new{T,U}(v, n, k, inplace)
   end
 end

--- a/src/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
@@ -82,6 +82,9 @@ Using a smaller integer type for `n` (e.g. `Int8`) may increase performance.
 If `inplace` is `true`, the elements of the iterator may share their memory. This
 means that an element returned by the iterator may be overwritten 'in place' in
 the next iteration step. This may result in significantly fewer memory allocations.
+However, using the in-place version is only meaningful
+if just one element of the iterator is needed at any time.
+For example, calling `collect` on thisiterator will not give useful results.
 
 By a weak composition of `n` into `k` parts we mean a sequence of `k` non-negative
 integers whose sum is `n`.

--- a/src/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
@@ -84,7 +84,7 @@ means that an element returned by the iterator may be overwritten 'in place' in
 the next iteration step. This may result in significantly fewer memory allocations.
 However, using the in-place version is only meaningful
 if just one element of the iterator is needed at any time.
-For example, calling `collect` on thisiterator will not give useful results.
+For example, calling `collect` on this iterator will not give useful results.
 
 By a weak composition of `n` into `k` parts we mean a sequence of `k` non-negative
 integers whose sum is `n`.

--- a/src/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
+++ b/src/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
@@ -73,11 +73,15 @@ end
 ################################################################################
 
 @doc raw"""
-    weak_compositions(n::IntegerUnion, k::IntegerUnion)
+    weak_compositions(n::IntegerUnion, k::IntegerUnion; inplace::Bool=false)
 
 Return an iterator over all weak compositions of a non-negative integer `n` into
 `k` parts, produced in lexicographically *descending* order.
 Using a smaller integer type for `n` (e.g. `Int8`) may increase performance.
+
+If `inplace` is `true`, the elements of the iterator may share their memory. This
+means that an element returned by the iterator may be overwritten 'in place' in
+the next iteration step. This may result in significantly fewer memory allocations.
 
 By a weak composition of `n` into `k` parts we mean a sequence of `k` non-negative
 integers whose sum is `n`.

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1338,6 +1338,7 @@ export normalized_volume
 export normalizer
 export nullity
 export number_of_atlas_groups
+export number_of_combinations
 export number_of_complement_equations
 export number_of_compositions
 export number_of_conjugacy_classes, has_number_of_conjugacy_classes, set_number_of_conjugacy_classes
@@ -1346,6 +1347,7 @@ export number_of_fixed_points
 export number_of_generators
 export number_of_groups_with_class_number, has_number_of_groups_with_class_number
 export number_of_moved_points, has_number_of_moved_points, set_number_of_moved_points
+export number_of_multicombinations
 export number_of_multipartitions
 export number_of_partitions
 export number_of_patches

--- a/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -54,12 +54,7 @@
   @testset "inplace iteration" begin
     Ci = combinations(5,3, inplace=true)
     Cf = combinations(5,3)
-    si = sf = nothing
-    for i in 1:number_of_combinations(5,3)
-      ci, si = iterate(Ci, si)
-      cf, sf = iterate(Cf, sf)
-      @test ci == cf
-    end
+		@test all(splat(==), zip(Ci, Cf))
   end
 
   @testset "ranking/unranking" begin

--- a/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -55,7 +55,7 @@
     Ci = combinations(5,3, inplace=true)
     Cf = combinations(5,3)
     si = sf = nothing
-    for i in 1:binomial(5,3)
+    for i in 1:number_of_combinations(5,3)
       ci, si = iterate(Ci, si)
       cf, sf = iterate(Cf, sf)
       @test ci == cf

--- a/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/combinations.jl
@@ -51,6 +51,17 @@
 
   @test collect(combinations(0, 0)) == [Int[]]
 
+  @testset "inplace iteration" begin
+    Ci = combinations(5,3, inplace=true)
+    Cf = combinations(5,3)
+    si = sf = nothing
+    for i in 1:binomial(5,3)
+      ci, si = iterate(Ci, si)
+      cf, sf = iterate(Cf, sf)
+      @test ci == cf
+    end
+  end
+
   @testset "ranking/unranking" begin
     @test Oscar.combination(0,0,1) == Combination([])
     @test Oscar.combination(3,3,1) == Combination(collect(1:3))

--- a/test/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
@@ -86,7 +86,7 @@
     Ci = multicombinations(5,3, inplace=true)
     Cf = multicombinations(5,3)
     si = sf = nothing
-    for i in 1:binomial(7,3)
+    for i in 1:number_of_multicombinations(5,3)
       ci, si = iterate(Ci, si)
       cf, sf = iterate(Cf, sf)
       @test ci == cf

--- a/test/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
@@ -82,4 +82,15 @@
   @test collect(multicombinations(0, 0)) == [Int[]]
   @test collect(multicombinations(0, 1)) == []
 
+  @testset "inplace iteration" begin
+    Ci = multicombinations(5,3, inplace=true)
+    Cf = multicombinations(5,3)
+    si = sf = nothing
+    for i in 1:binomial(7,3)
+      ci, si = iterate(Ci, si)
+      cf, sf = iterate(Cf, sf)
+      @test ci == cf
+    end
+  end
+
 end

--- a/test/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/multicombinations.jl
@@ -85,12 +85,7 @@
   @testset "inplace iteration" begin
     Ci = multicombinations(5,3, inplace=true)
     Cf = multicombinations(5,3)
-    si = sf = nothing
-    for i in 1:number_of_multicombinations(5,3)
-      ci, si = iterate(Ci, si)
-      cf, sf = iterate(Cf, sf)
-      @test ci == cf
-    end
+    @test all(splat(==), zip(Ci, Cf))
   end
 
 end

--- a/test/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
@@ -11,12 +11,7 @@
   @testset "inplace iteration" begin
     Ci = weak_compositions(T(5),T(3), inplace=true)
     Cf = weak_compositions(T(5),T(3))
-    si = sf = nothing
-    for i in 1:number_of_weak_compositions(5,3)
-      ci, si = iterate(Ci, si)
-      cf, sf = iterate(Cf, sf)
-      @test ci == cf
-    end
+    @test all(splat(==), zip(Ci, Cf))
   end
 
   l = @inferred collect(weak_compositions(T(5), T(3)))

--- a/test/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
@@ -8,6 +8,17 @@
   @test length(weak_compositions(T(0), T(3))) == 1
   @test @inferred collect(weak_compositions(T(0), T(3))) == [weak_composition(T[0, 0, 0])]
 
+  @testset "inplace iteration" begin
+    Ci = weak_compositions(T(5),T(3), inplace=true)
+    Cf = weak_compositions(T(5),T(3))
+    si = sf = nothing
+    for i in 1:number_of_compositions(5,3)
+      ci, si = iterate(Ci, si)
+      cf, sf = iterate(Cf, sf)
+      @test ci == cf
+    end
+  end
+
   l = @inferred collect(weak_compositions(T(5), T(3)))
   @test length(l) == 21
   @test all(x -> sum(x) == 5, l)

--- a/test/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
+++ b/test/Combinatorics/EnumerativeCombinatorics/weak_compositions.jl
@@ -12,7 +12,7 @@
     Ci = weak_compositions(T(5),T(3), inplace=true)
     Cf = weak_compositions(T(5),T(3))
     si = sf = nothing
-    for i in 1:number_of_compositions(5,3)
+    for i in 1:number_of_weak_compositions(5,3)
       ci, si = iterate(Ci, si)
       cf, sf = iterate(Cf, sf)
       @test ci == cf


### PR DESCRIPTION
For use cases that benefit, we provide an option to have inplace versions of the iterators for `combinations(n,k)` and `multicombinations(n,k)` using an optional `inplace` keyword.

Closes #4993