### PR TITLE
Enable more checks in documentation build

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,7 +5,7 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Oscar = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
 
 [compat]
-Documenter = "1.9.0"
+Documenter = "1.16.0"
 DocumenterCitations = "~1.3.4"
 JSON = "1.0.1"
 

--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -195,6 +195,7 @@ function doit(
       clean=true,
       doctest=false,
       warnonly=warnonly,
+      treat_markdown_warnings_as_error=!warnonly,
       checkdocs=:none,
       pages=doc,
       remotes=Dict(


### PR DESCRIPTION
Make use of https://github.com/JuliaDocs/Documenter.jl/pull/2792, which is now available with Documenter 1.16.0.

This needs https://github.com/oscar-system/Oscar.jl/pull/5548 to be merged first.