### PR TITLE
Changelog script, split PR

### DIFF
--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -84,38 +84,38 @@ def warning(s):
 # the given label is put into the corresponding section; each PR is put into only one section, the first one
 # one from this list it fits in.
 # See also <https://github.com/gap-system/gap/issues/4257>.
-topics = [
-    ["release notes: highlight",    "Highlights"],
-    ["topic: algebraic geometry",   "Algebraic Geometry"],
-    ["topic: combinatorics",        "Combinatorics"],
-    ["topic: commutative algebra",  "Commutative Algebra"],
-    ["topic: FTheoryTools",         "F-Theory Tools"],
-    ["topic: groups",               "Groups"],
-    ["topic: lie theory",           "Lie Theory"],
-    ["topic: number theory",        "Number Theory"],
-    ["topic: polyhedral geometry",  "Polyhedral Geometry"],
-    ["topic: toric geometry",       "Toric Geometry"],
-    ["topic: tropical geometry",    "Tropical Geometry"],
-    ["package: AbstractAlgebra",    "Changes related to the package AbstractAlgebra"],
-    ["package: AlgebraicSolving",   "Changes related to the package AlgebraicSolving"],
-    ["package: GAP",                "Changes related to the package GAP"],
-    ["package: Hecke",              "Changes related to the package Hecke"],
-    ["package: Nemo",               "Changes related to the package Nemo"],
-    ["package: Polymake",           "Changes related to the package Polymake"],
-    ["package: Singular",           "Changes related to the package Singular"],
-]
-prtypes = [
-    ["renaming",                    "Renamings"],
-    ["serialization",               "Changes related to serializing data in the MRDI file format"],
-    ["enhancement",                 "New features or extended functionality"],
-    ["experimental",                "Only changes experimental parts of OSCAR"],
-    ["optimization",                "Performance improvements or improved testing"],
-    ["bug: wrong result",           "Fixed bugs that returned incorrect results"],
-    ["bug: crash",                  "Fixed bugs that could lead to crashes"],
-    ["bug: unexpected error",       "Fixed bugs that resulted in unexpected errors"],
-    ["bug",                         "Other fixed bugs"],
-    ["documentation",               "Improvements or additions to documentation"],
-]
+topics = {
+    "release notes: highlight":    "Highlights",
+    "topic: algebraic geometry":   "Algebraic Geometry",
+    "topic: combinatorics":        "Combinatorics",
+    "topic: commutative algebra":  "Commutative Algebra",
+    "topic: FTheoryTools":         "F-Theory Tools",
+    "topic: groups":               "Groups",
+    "topic: lie theory":           "Lie Theory",
+    "topic: number theory":        "Number Theory",
+    "topic: polyhedral geometry":  "Polyhedral Geometry",
+    "topic: toric geometry":       "Toric Geometry",
+    "topic: tropical geometry":    "Tropical Geometry",
+    "package: AbstractAlgebra":    "Changes related to the package AbstractAlgebra",
+    "package: AlgebraicSolving":   "Changes related to the package AlgebraicSolving",
+    "package: GAP":                "Changes related to the package GAP",
+    "package: Hecke":              "Changes related to the package Hecke",
+    "package: Nemo":               "Changes related to the package Nemo",
+    "package: Polymake":           "Changes related to the package Polymake",
+    "package: Singular":           "Changes related to the package Singular",
+}
+prtypes = {
+    "renaming":                    "Renamings",
+    "serialization":               "Changes related to serializing data in the MRDI file format",
+    "enhancement":                 "New features or extended functionality",
+    "experimental":                "Only changes experimental parts of OSCAR",
+    "optimization":                "Performance improvements or improved testing",
+    "bug: wrong result":           "Fixed bugs that returned incorrect results",
+    "bug: crash":                  "Fixed bugs that could lead to crashes",
+    "bug: unexpected error":       "Fixed bugs that resulted in unexpected errors",
+    "bug":                         "Other fixed bugs",
+    "documentation":               "Improvements or additions to documentation",
+}
 
 
 def get_tag_date(tag: str) -> str:
@@ -209,28 +209,28 @@ which we think might affect some users directly.
         countedPRs = 0
         for priorityobject in topics:
             matches = [
-                pr for pr in prs_with_use_title if has_label(pr, priorityobject[0])
+                pr for pr in prs_with_use_title if has_label(pr, priorityobject)
             ]
-            print("PRs with label '" + priorityobject[0] + "': ", len(matches))
+            print("PRs with label '" + priorityobject + "': ", len(matches))
             print(matches)
             countedPRs = countedPRs + len(matches)
             if len(matches) == 0:
                 continue
-            relnotes_file.write("### " + priorityobject[1] + "\n\n")
-            if priorityobject[1] == 'Highlights':
+            relnotes_file.write("### " + topics[priorityobject] + "\n\n")
+            if topics[priorityobject] == 'Highlights':
                 itervar = topics
             else:
                 itervar = prtypes
             for typeobject in itervar:
-                if typeobject[1] == priorityobject[1]:
+                if typeobject == priorityobject:
                     continue
                 matches_type = [
-                    pr for pr in matches if has_label(pr, typeobject[0])
+                    pr for pr in matches if has_label(pr, typeobject)
                 ]
-                print("PRs with label '" + priorityobject[0] + "' and type '" + typeobject[0] + "': ", len(matches_type))
+                print("PRs with label '" + priorityobject + "' and type '" + typeobject + "': ", len(matches_type))
                 if len(matches_type) == 0:
                     continue
-                relnotes_file.write(f"#### {typeobject[1]}\n\n")
+                relnotes_file.write(f"#### {itervar[typeobject]}\n\n")
                 for pr in matches_type:
                     relnotes_file.write(pr_to_md(pr))
                     prs_with_use_title.remove(pr)
@@ -244,15 +244,14 @@ which we think might affect some users directly.
         if len(prs_with_use_title) > 0:
             relnotes_file.write("### Other changes\n\n")
             for typeobject in prtypes:
-                print(typeobject)
                 matches_type = [
-                    pr for pr in prs_with_use_title if has_label(pr, typeobject[0])
+                    pr for pr in prs_with_use_title if has_label(pr, typeobject)
                 ]
                 len(matches_type)
-                print("PRs with label '" + priorityobject[0] + "' and type '" + typeobject[0] + "': ", len(matches_type))
+                print("PRs with label '" + priorityobject + "' and type '" + typeobject + "': ", len(matches_type))
                 if len(matches_type) == 0:
                     continue
-                relnotes_file.write("#### " + typeobject[1] + "\n\n")
+                relnotes_file.write("#### " + prtypes[typeobject] + "\n\n")
 
                 for pr in matches_type:
                     relnotes_file.write(pr_to_md(pr))
@@ -280,10 +279,10 @@ which we think might affect some users directly.
                 "general section of the topic section in the changelog.\n\n")
             for pr in prs_with_use_title:
                 for topic in topics:
-                    matches = [pr for pr in prs_with_use_title if has_label(pr, topic[0])]
+                    matches = [pr for pr in prs_with_use_title if has_label(pr, topic)]
                     if len(matches) == 0:
                         continue
-                    relnotes_file.write(f'#### {topic[1]}\n\n')
+                    relnotes_file.write(f'#### {topics[topic]}\n\n')
                     for match in matches:
                         relnotes_file.write(pr_to_md(match))
                         prs_with_use_title.remove(match)

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -174,7 +174,7 @@ def has_label(pr: Dict[str, Any], label: str) -> bool:
 
 
 def changes_overview(
-    prs: List[Dict[str, Any]], timestamp: str, new_version: str
+    prs: List[Dict[str, Any]], new_version: str
 ) -> None:
     """Writes files with information for release notes."""
 
@@ -364,7 +364,7 @@ def main(new_version: str) -> None:
     
     subprocess.run(f'git checkout -- {finalfile}'.split(), check=True)
 
-    changes_overview(prs, timestamp, new_version)
+    changes_overview(prs, new_version)
 
 
 if __name__ == "__main__":

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -247,7 +247,7 @@ which we think might affect some users directly.
                     pr for pr in prs_with_use_title if has_label(pr, typeobject)
                 ]
                 len(matches_type)
-                print("PRs with label '" + priorityobject + "' and type '" + typeobject + "': ", len(matches_type))
+                print("PRs with type '" + typeobject + "': ", len(matches_type))
                 if len(matches_type) == 0:
                     continue
                 relnotes_file.write("#### " + prtypes[typeobject] + "\n\n")

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -174,7 +174,7 @@ def has_label(pr: Dict[str, Any], label: str) -> bool:
 
 
 def changes_overview(
-    prs: List[Dict[str, Any]], startdate: str, new_version: str
+    prs: List[Dict[str, Any]], timestamp: str, new_version: str
 ) -> None:
     """Writes files with information for release notes."""
 
@@ -338,7 +338,7 @@ def main(new_version: str) -> None:
         extra = f'label:"backport {major}.{minor}.x done"'
 
     if release_type == 2:
-        startdate = get_tag_date(basetag)
+        timestamp = get_tag_date(basetag)
     else:
         # Find the timestamp of the last shared commit
         shared_commit = subprocess.run([
@@ -354,20 +354,18 @@ def main(new_version: str) -> None:
             "--format=\"%cI\"",
             shared_commit
         ], shell=False, check=True, capture_output=True).stdout.decode().strip().replace('"', '')
-        # date is first 10 characters of timestamp
-        startdate = timestamp[0:10]
     print("Base tag is", basetag)
-    print("Last common commit at ", startdate)
+    print("Last common commit at ", timestamp)
 
     print("Downloading filtered PR list")
-    prs = get_pr_list(startdate, extra)
+    prs = get_pr_list(timestamp, extra)
     # print(json.dumps(prs, sort_keys=True, indent=4))
 
     # reset changelog file to state tracked in git
     
     subprocess.run(f'git checkout -- {finalfile}'.split(), check=True)
 
-    changes_overview(prs, startdate, new_version)
+    changes_overview(prs, timestamp, new_version)
 
 
 if __name__ == "__main__":

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -235,7 +235,6 @@ which we think might affect some users directly.
                     relnotes_file.write(pr_to_md(pr))
                     prs_with_use_title.remove(pr)
                     matches.remove(pr)
-                    matches_type.remove(pr)
                 relnotes_file.write('\n')
         print(f"Remaining PRs: {totalPRs - countedPRs}")
         # The remaining PRs have no "kind" or "topic" label from the priority list


### PR DESCRIPTION
This is a PR to split off changes to the changelog script which I unwisely added to #5279 , which makes reviewing the "multiple entries" related changes in #5279 hard to review.