### PR TITLE
Changelog script: Add a general section to release notes for PRs without type labels

### DIFF
--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -265,6 +265,14 @@ which we think might affect some users directly.
                     prs_with_use_title.remove(pr)
                     matches.remove(pr)
                 relnotes_file.write('\n')
+            # Items without a type label
+            if len(matches) > 0:
+                relnotes_file.write("#### General changes\n\n")
+                for pr in matches:
+                    relnotes_file.write(pr_to_md(pr))
+                    prs_with_use_title.remove(pr)
+                relnotes_file.write('\n')
+                
         print(f"Remaining PRs: {totalPRs - countedPRs}")
         # The remaining PRs have no "kind" or "topic" label from the priority list
         # (may have other "kind" or "topic" label outside the priority list).
@@ -302,19 +310,11 @@ which we think might affect some users directly.
         if len(prs_with_use_title) > 0:
             relnotes_file.write(
                 "### **TODO** insufficient labels for automatic classification\n\n"
-                "The following PRs only have a topic label assigned to them, not a PR type. Either "
-                "assign a type label to them (e.g., `enhancement`), or manually move them to the "
-                "general section of the topic section in the changelog.\n\n")
+                "The following PRs have neither a topic label assigned to them, nor a PR type. \n"
+                "**Manual intervention required.**\n\n")
             for pr in prs_with_use_title:
-                for topic in topics:
-                    matches = [pr for pr in prs_with_use_title if has_label(pr, topic)]
-                    if len(matches) == 0:
-                        continue
-                    relnotes_file.write(f'#### {topics[topic]}\n\n')
-                    for match in matches:
-                        relnotes_file.write(pr_to_md(match))
-                        prs_with_use_title.remove(match)
-                    relnotes_file.write('\n')
+                relnotes_file.write(pr_to_md(pr))
+                relnotes_file.write('\n')
             relnotes_file.write('\n')
 
         # remove PRs already handled earlier

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -240,6 +240,7 @@ which we think might affect some users directly.
             matches = [
                 pr for pr in prs_with_use_title if has_label(pr, priorityobject)
             ]
+            original_length = len(matches)
             print("PRs with label '" + priorityobject + "': ", len(matches))
             print(matches)
             countedPRs = countedPRs + len(matches)
@@ -267,7 +268,8 @@ which we think might affect some users directly.
                 relnotes_file.write('\n')
             # Items without a type label
             if len(matches) > 0:
-                relnotes_file.write("#### General changes\n\n")
+                if len(matches) != original_length:
+                    relnotes_file.write("#### Miscellaneous changes\n\n")
                 for pr in matches:
                     relnotes_file.write(pr_to_md(pr))
                     prs_with_use_title.remove(pr)


### PR DESCRIPTION
This introduces a section "General changes" for PRs without a type label. It also accounts for PRs without topic labels and without type labels. Fixes the issue @lgoettgens pointed out in https://github.com/oscar-system/Oscar.jl/pull/5544#discussion_r2519954609 .

General section looks like 

>
> ### Changes related to the package Singular
> 
> #### General changes
> 
> - [#5489](https://github.com/oscar-system/Oscar.jl/pull/5489) Update to Singular.jl 0.27
> 

Leftover section looks like

> 
> ### **TODO** insufficient labels for automatic classification
> 
> The following PRs have neither a topic label assigned to them, nor a PR type. 
> **Manual intervention required.**
> 
> - [#5401](https://github.com/oscar-system/Oscar.jl/pull/5401) Tweak `combination` function
> 
> - [#5492](https://github.com/oscar-system/Oscar.jl/pull/5492) Temporary fix for saturation over quotient rings
> 
