### PR TITLE
Optimize MatrixGroupElem over QQ and ZZ

### DIFF
--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -570,6 +570,13 @@ function matrix(x::MatrixGroupElem)
   return x.elm
 end
 
+function matrix(x::MatrixGroupElem{T}) where {T <: Union{ZZRingElem, QQFieldElem}}
+  if !isdefined(x, :elm)
+    x.elm = matrix(base_ring(x), GapObj(x))
+  end
+  return x.elm
+end
+
 Base.getindex(x::MatrixGroupElem, i::Int, j::Int) = matrix(x)[i,j]
 
 """


### PR DESCRIPTION
Faster conversion of the underlying GAP matrix to OSCAR.

Progress for issue #5549. Before this PR:
```julia-repl
julia> @b act_func(g)
53.209 μs (7 allocs: 4.594 KiB)

julia> @b fG(g)
67.166 μs (89 allocs: 8.219 KiB)
```
After this PR:
```julia-repl
julia> @b act_func(g)
53.208 μs (7 allocs: 4.594 KiB)

julia> @b fG(g)
54.875 μs (10 allocs: 5.172 KiB)
```