### PR TITLE
Rewrite scalar type guessing for polyhedral input

### DIFF
--- a/src/PolyhedralGeometry/helpers.jl
+++ b/src/PolyhedralGeometry/helpers.jl
@@ -605,36 +605,67 @@ function _check_field_polyhedral(::Type{T}) where {T}
   @req hasmethod(isless, (T, T)) "Field must be ordered and have `isless` method."
 end
 
-_find_elem_type(x::Nothing) = Any
-_find_elem_type(x::Any) = typeof(x)
-_find_elem_type(x::Type) = x
-_find_elem_type(x::Polymake.Rational) = QQFieldElem
-_find_elem_type(x::Polymake.Integer) = ZZRingElem
-_find_elem_type(x::AbstractArray) = collect(reshape(_find_elem_type.(x), :))
-_find_elem_type(x::Tuple) = reduce(vcat, _find_elem_type.(x))
-_find_elem_type(x::AbstractArray{<:AbstractArray}) =
-  reduce(vcat, _find_elem_type.(x); init=[])
-_find_elem_type(x::MatElem) = [elem_type(base_ring(x))]
-_find_elem_type(x::SMat) = [elem_type(base_ring(x))]
+# Constructors such as `convex_hull` accept a wild mix of input: julia arrays and
+# matrices, Oscar matrices, `SubObjectIterator`s of existing polyhedral objects,
+# single (field) elements, and tuples resp. nested arrays of all of these. If the
+# caller does not name a coefficient field, `_guess_fieldelem_type` picks a single
+# scalar type `T <: Union{FieldElem,Float64}` that all of the input can be
+# converted to; `_determine_parent_and_scalar` then turns `T` into a parent field.
+# In practice that yields `QQFieldElem`, `Float64`, `QQBarFieldElem` or an
+# embedded number field element type, but nothing here is restricted to those.
+#
+# Oscar code should not rely on this guessing and pass the coefficient field
+# explicitly; it exists for the convenience of interactive users.
+#
+# `_find_elem_type` maps one argument to its candidate scalar type, with `Any`
+# meaning "carries no type information". Whenever the candidate is determined by
+# the argument's type alone -- the common case -- the method takes a `Type`, so
+# that the guess is constant folded by the compiler instead of computed at runtime.
 
-function _guess_fieldelem_type(x...)
-  types = filter(!=(Any), _find_elem_type(x))
+_find_elem_type(x) = _find_elem_type(typeof(x))
+_find_elem_type(::Type{T}) where {T} = T
+_find_elem_type(::Type{Nothing}) = Any
+_find_elem_type(::Type{<:Polymake.Rational}) = QQFieldElem
+_find_elem_type(::Type{<:Polymake.Integer}) = ZZRingElem
+_find_elem_type(::Type{T}) where {T<:Union{MatElem,SMat}} = elem_type(base_ring_type(T))
+_find_elem_type(::Type{<:AbstractArray{T}}) where {T} = _find_elem_type(T)
+
+function _find_elem_type(x::AbstractArray)
+  # if the element type alone pins down a concrete candidate we are done;
+  # otherwise (`Vector{Any}` and friends) the entries have to be inspected
+  T = _find_elem_type(typeof(x))
+  isconcretetype(T) && return T
+  return _reduce_elem_types(x)
+end
+
+_find_elem_type(x::Tuple) = _reduce_elem_types(x)
+
+# Merge the candidate types of the entries of `xs` into a single scalar type.
+#
+# `promote_type` is of little use here: for most Oscar field element types it
+# only yields the abstract `FieldElem`. So instead of promoting we keep the
+# largest field seen so far, using `promote_type` merely to recognize the
+# integer/rational types that fit into every field we support.
+function _reduce_elem_types(xs)
   T = QQFieldElem
-  for t in types
-    if t == Float64
-      return Float64
-    elseif promote_type(t, T) != T
-      T = t
-    end
+  for x in xs
+    S = _find_elem_type(x)
+    S === Any && continue
+    # inexact arithmetic poisons everything else
+    S === Float64 && return Float64
+    (promote_type(S, T) === T || promote_type(S, QQFieldElem) === QQFieldElem) && continue
+    T = S
   end
   return T
 end
+
+_guess_fieldelem_type(x...) = _reduce_elem_types(x)
 
 _parent_or_coefficient_field(::Type{Float64}, x...) = AbstractAlgebra.Floats{Float64}()
 _parent_or_coefficient_field(::Type{ZZRingElem}, x...) = ZZ
 
 _parent_or_coefficient_field(r::Base.RefValue{<:Union{FieldElem,ZZRingElem}}, x...) =
-  parent(r.x)
+  parent(r[])
 _parent_or_coefficient_field(v::AbstractArray{T}) where {T<:Union{FieldElem,ZZRingElem}} =
   _parent_or_coefficient_field(T, v)
 

--- a/src/PolyhedralGeometry/iterators.jl
+++ b/src/PolyhedralGeometry/iterators.jl
@@ -48,7 +48,6 @@ for (T, _t) in ((:PointVector, :point_vector), (:RayVector, :ray_vector))
 
     _parent_or_coefficient_field(::Type{TT}, po::$T{<:TT}) where {TT<:FieldElem} =
       coefficient_field(po)
-    _find_elem_type(po::$T) = elem_type(coefficient_field(po))
 
     function Base.similar(
       bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{$T}},
@@ -188,7 +187,7 @@ Return the `$($Hlin)` `H(a)`, which is given by a vector `a` such that
 
     coefficient_field(h::$Habs) = base_ring(h.a)
 
-    _find_elem_type(h::$Habs) = elem_type(coefficient_field(h))
+    _find_elem_type(::Type{<:$Habs{T}}) where {T} = T
     _parent_or_coefficient_field(::Type{T}, h::$Habs{<:T}) where {T<:FieldElem} =
       coefficient_field(h)
   end

--- a/test/PolyhedralGeometry/scalar_types.jl
+++ b/test/PolyhedralGeometry/scalar_types.jl
@@ -293,3 +293,61 @@
     @test Polymake.unwrap(Oscar.pm_object(cs).VOLUME) isa QQBarFieldElem
   end
 end
+
+@testset "_guess_fieldelem_type" begin
+  guess = Oscar._guess_fieldelem_type
+
+  NF, sr2 = quadratic_field(2)
+  E, e2 = Hecke.embedded_field(NF, real_embeddings(NF)[2])
+  ENFElem = elem_type(E)
+  qb = sqrt(QQBar(2))
+
+  # integers and rationals in any shape default to the rationals
+  @test guess([0 0; 1 0; 1 1]) == QQFieldElem
+  @test guess([1, 2, 3]) == QQFieldElem
+  @test guess(matrix(ZZ, [1 2; 3 4])) == QQFieldElem
+  @test guess(matrix(QQ, [1 2; 3 4])) == QQFieldElem
+  @test guess(sparse_matrix(QQ, [1 2; 3 4])) == QQFieldElem
+  @test guess(Polymake.Matrix{Polymake.Rational}(2, 2)) == QQFieldElem
+  @test guess(Polymake.Integer(2)) == QQFieldElem
+  @test guess([[1, 2], [3, 4]]) == QQFieldElem
+
+  # no input at all, or input without any type information
+  @test guess() == QQFieldElem
+  @test guess(nothing) == QQFieldElem
+  @test guess(Int[]) == QQFieldElem
+  @test guess(Any[]) == QQFieldElem
+
+  # a larger field wins over the rationals, independently of the argument order
+  @test guess(QQBarFieldElem[1 2; 3 qb]) == QQBarFieldElem
+  @test guess(QQBarFieldElem[1 qb], [1 2]) == QQBarFieldElem
+  @test guess([1 2], QQBarFieldElem[1 qb]) == QQBarFieldElem
+  @test guess(QQBarFieldElem[1 qb], matrix(QQ, [1 2])) == QQBarFieldElem
+  @test guess(QQBarFieldElem[1 qb], matrix(ZZ, [1 2])) == QQBarFieldElem
+  @test guess(matrix(E, [1 2; 3 4])) == ENFElem
+  @test guess([e2, E(1)], [1, 2]) == ENFElem
+
+  # containers without a useful element type are inspected entry by entry
+  @test guess(Any[qb, QQ(1)]) == QQBarFieldElem
+  @test guess(Any[QQ(1), qb]) == QQBarFieldElem
+  @test guess(Vector{Any}[[1, qb], [3, 4]]) == QQBarFieldElem
+  @test guess(([1, 2], [qb, 3])) == QQBarFieldElem
+
+  # inexact input wins over everything else
+  @test guess([1.0 2.0]) == Float64
+  @test guess([1.0], [qb]) == Float64
+  @test guess([qb], [1.0]) == Float64
+
+  # polyhedral objects carry their coefficient field
+  @test guess(vertices(cube(3))) == QQFieldElem
+  @test guess(point_vector(QQ, [1, 2])) == QQFieldElem
+  @test guess(halfspace([1, 2], 3)) == QQFieldElem
+  @test guess(halfspace(E, [e2, 2], 3)) == ENFElem
+  @test guess(vertices(convex_hull(E, [0 0; 1 0; e2 1]))) == ENFElem
+
+  # the common cases are decided by the compiler, without touching any entry
+  let a = [0 0; 1 0; 1 1; 0 1]
+    @test @inferred(guess(a, a, a)) == QQFieldElem
+    @test @allocated(guess(a, a, a)) == 0
+  end
+end


### PR DESCRIPTION
When a polyhedral constructor is called without a coefficient field, `_guess_fieldelem_type` has to pick one from the input. The old `_find_elem_type` collected the types of *all* entries of the given arrays and matrices into a vector, which allocates and scales with the input size. It now maps each argument to a single candidate type, derived from the argument's type alone whenever possible, so the usual cases are constant folded by the compiler.

Along the way this fixes how the candidates are folded together. As @benlorenz pointed out, `promote_type` is of little use for the field element types involved -- it mostly yields the abstract `FieldElem`. The old code therefore replaced the current candidate whenever the new one was not absorbed, which made the result depend on the argument order:

```julia
julia> a = QQBarFieldElem[1 2; 3 sqrt(QQBar(2))];

julia> Oscar._guess_fieldelem_type(a, matrix(QQ, [1 2; 3 4]))
QQFieldElem

julia> Oscar._guess_fieldelem_type(a, [1 2; 3 4])
Int64
```

Integer and rational types are now recognized as such and never override a larger field; both examples return `QQBarFieldElem`.

There were no tests for this at all, so this adds a testset covering the argument shapes that occur in practice, plus `@inferred` and `@allocated` checks for the common case.

The header comment now spells out what the whole thing is for and that Oscar code should pass the coefficient field explicitly rather than rely on guessing.

Before:

```julia
julia> a = [0 0; 1 0; 1 1; 0 1];

julia> @b Oscar._guess_fieldelem_type($a)
1.367 μs (5 allocs: 352 bytes)

julia> @b Oscar._guess_fieldelem_type($a, $a)
6.167 μs (27 allocs: 1.344 KiB)

julia> @b Oscar._guess_fieldelem_type($a, $a, $a)
8.750 μs (40 allocs: 2.125 KiB)
```

After:

```julia
julia> @b Oscar._guess_fieldelem_type($a)
1.374 ns

julia> @b Oscar._guess_fieldelem_type($a, $a)
2.749 ns

julia> @b Oscar._guess_fieldelem_type($a, $a, $a)
3.075 ns
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
