### PR TITLE
Introduce `GAPGroupEmbedding` maps

### DIFF
--- a/docs/src/Groups/grouphom.md
+++ b/docs/src/Groups/grouphom.md
@@ -6,118 +6,73 @@ DocTestSetup = Oscar.doctestsetup()
 
 # Group homomorphisms
 
-In OSCAR, a group homomorphism from `G` to `H` is an object of parametric type `GAPGroupHomomorphism{S,T}`, where `S` and `T` are the types of `G` and `H` respectively.
+A *group homomorphism* from a group $G$ to a group $H$ is a map $f$ with
+domain $G$ and codomain $H$ that respects the group structure,
+that is, $(g*h)^f = g^f * h^f$ and $(g^{-1})^f = (g^f)^{-1}$ hold for
+all $g, h \in G$.
 
-A homomorphism from `G` to `H` can be defined in two ways.
+## Creation of group homomorphisms
 
-* Writing explicitly the images of the generators of `G`:
-```julia
-f = hom(G,H,[x1,x2,...],[y1,y2,...])
-```
-Here, `[x1,x2,...]` must be a generating set for `G` (not necessarily minimal) and `[y1,y2,...]` is a vector of elements of `H` of the same length of `[x1,x2,...]`. This assigns to `f` the value of the group homomorphism sending `x_i` into `y_i`.
+A homomorphism from $G$ to $H$ can be defined
+by prescribing the images of some generators of $G$
+(see [`hom(G::GAPGroup, H::GAPGroup, gensG::Vector, imgs::Vector)`](@ref)
+or by prescribing a Julia function that maps the elements as required
+(see [`hom(G::GAPGroup, H::GAPGroup, img::Function)`](@ref).
 
-An exception is thrown if such a homomorphism does not exist.
+For homomorphisms to permutation groups that are defined by the action
+of $G$ on a set, see [`action_homomorphism`](@ref).
 
-* Taking an existing function `g` satisfying the group homomorphism properties:
-```julia
-f = hom(G,H,g)
-```
-An exception is thrown if the function `g` does not define a group homomorphism.
+For the special cases of an identity mapping between groups
+or the mapping whose image is a trivial group,
+use [`id_hom(G::GAPGroup)`](@ref)
+and [`trivial_morphism(G::GAPGroup, H::GAPGroup = G)`](@ref),
+respectively.
 
-  **Example:**
-The following procedures define the same homomorphism (conjugation by `x`) in the two ways explained above.
-```jldoctest
-julia> S = symmetric_group(4)
-Symmetric group of degree 4
-
-julia> x = S[1]
-(1,2,3,4)
-
-julia> f = hom(S, S, [S[1]^x, S[2]^x])
-Group homomorphism
-  from symmetric group of degree 4
-  to symmetric group of degree 4
-
-julia> g = hom(S, S, y -> y^x)
-Group homomorphism
-  from symmetric group of degree 4
-  to symmetric group of degree 4
-
-julia> f == g
-true
-```
+The restriction of a homomorphism to a subgroup of its domain is given by
+[`restrict_homomorphism(f::GAPGroupHomomorphism, H::GAPGroup)`](@ref),
 
 ```@docs
 hom(G::GAPGroup, H::GAPGroup, img::Function)
 hom(G::GAPGroup, H::GAPGroup, gensG::Vector, imgs::Vector)
-image(f::GAPGroupHomomorphism, x::GAPGroupElem)
-preimage(f::GAPGroupHomomorphism, x::GAPGroupElem)
+id_hom(G::GAPGroup)
+trivial_morphism(G::GAPGroup, H::GAPGroup = G)
 restrict_homomorphism(f::GAPGroupHomomorphism, H::GAPGroup)
 ```
 
-OSCAR has also the following standard homomorphism.
+## Applying group homomorphisms
+
+Group homomorphisms can be used to compute images and preimages of
+elements and subgroups.
+
+For a group homomorphism `f` and a group element `x`,
+the image of `x` under `f` can be computed as
+[`image(f::GAPGroupHomomorphism, x::GAPGroupElem)`](@ref)
+or `f(x)` or `x^f`,
+and the preimage of an element `y` in the image can be computed as
+[`preimage(f::GAPGroupHomomorphism, x::GAPGroupElem)`](@ref).
+
 ```@docs
-id_hom(G::GAPGroup)
-trivial_morphism(G::GAPGroup, H::GAPGroup = G)
-```
-
-To evaluate the homomorphism `f` in the element `x` of `G`, it is possible to use the instruction
-```julia
-image(f,x)
-```
-or the more compact notations `f(x)` and `x^f`.
-
-  **Example:**
-```jldoctest
-julia> S = symmetric_group(4)
-Symmetric group of degree 4
-
-julia> f = hom(S, S, x->x^S[1])
-Group homomorphism
-  from symmetric group of degree 4
-  to symmetric group of degree 4
-
-julia> x = cperm(S, [1,2])
-(1,2)
-
-julia> image(f, x)
-(2,3)
-
-julia> f(x)
-(2,3)
-
-julia> x^f
-(2,3)
-```
-
-A sort of "inverse" of the evaluation is the following
-```@docs
+image(f::GAPGroupHomomorphism, x::GAPGroupElem)
+preimage(f::Union{GAPGroupHomomorphism, GAPGroupEmbedding}, x::GAPGroupElem)
 has_preimage_with_preimage(f::GAPGroupHomomorphism, x::GAPGroupElem; check::Bool = true)
-```
-  **Example:**
-```jldoctest
-julia> S=symmetric_group(4);
-
-julia> f=hom(S,S,x->x^S[1]);
-
-julia> x=cperm(S,[1,2]);
-
-julia> has_preimage_with_preimage(f,x)
-(true, (1,4))
 ```
 
 ## Operations on homomorphisms
 
 OSCAR supports the following operations on homomorphisms.
 
-* `inv(f)` = the inverse of `f`.
+* `inv(f)` is the inverse of `f`.
   An exception is thrown if `f` is not bijective.
-* `f^n` = the homomorphism `f` composed `n` times with itself.
+* `f^n` is the homomorphism `f` composed `n` times with itself.
   An exception is thrown if the domain and the codomain of `f` do not coincide
-  (unless `n=1`). If `n` is negative, the result is the inverse of `f` composed `n` times with itself.
-* `compose(f, g)` = composition of `f` and `g`. This works only if the codomain of `f` coincides with the domain of `g`. Shorter equivalent expressions are `f*g` and `g(f)`.
+  (unless `n=1`).
+  If `n` is negative, the result is the inverse of `f` composed `n` times
+  with itself.
+* `compose(f, g)` is the composition of `f` and `g`.
+  This works only if the codomain of `f` coincides with the domain of `g`.
+  A shorter equivalent expressions is `f*g`.
 
-  **Example:**
+### Examples
 ```jldoctest
 julia> S = symmetric_group(4)
 Symmetric group of degree 4
@@ -188,4 +143,11 @@ isomorphic_subgroups(H::GAPGroup, G::GAPGroup)
 ```@docs
 isomorphism(::Type{T}, G::Group) where T <: Group
 isomorphism(::Type{FinGenAbGroup}, G::GAPGroup)
+```
+
+## Technicalities
+
+```@docs
+GAPGroupHomomorphism
+GAPGroupEmbedding
 ```

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -30,6 +30,7 @@ GAP.@wrap BasisNC(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap BrauerCharacterValue(x::GapObj)::GAP.Obj
 GAP.@wrap CanonicalBasis(x::GapObj)::GapObj
 GAP.@wrap CentralCharacter(x::GapObj)::GapObj
+GAP.@wrap Centralizer(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap CentreOfCharacter(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap CF(x::Any)::GapObj
 GAP.@wrap CF(x::Any, y::Any)::GapObj

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -407,7 +407,7 @@ That means, given a ``G``-set ``\Omega`` with action function ``f: \Omega \times
 and a homomorphism ``\phi: H \to G``, construct the ``H``-set ``\Omega'`` with action function
 $\Omega' \times H \to \Omega', (\omega, h) \mapsto f(\omega, \phi(h))$.
 """
-function induce(Omega::GSetByElements{T, S}, phi::GAPGroupHomomorphism{U, T}) where {T<:Group, U<:Group, S}
+function induce(Omega::GSetByElements{T, S}, phi::Union{GAPGroupHomomorphism{U, T}, GAPGroupEmbedding{U, T}}) where {T<:Group, U<:Group, S}
   return _induce(Omega, phi)
 end
 
@@ -927,7 +927,7 @@ function induced_action_function(Omega::GSetBySubgroupTransversal{TG, TH, S}, ph
   return induced_action(action_function(Omega), phi)
 end
 
-function induce(Omega::GSetBySubgroupTransversal{TG, TH, S}, phi::GAPGroupHomomorphism{U, TG}) where {TG<:Group, TH<:Group, U<:Group, S}
+function induce(Omega::GSetBySubgroupTransversal{TG, TH, S}, phi::Union{GAPGroupHomomorphism{U, TG}, GAPGroupEmbedding{U, TG}}) where {TG<:Group, TH<:Group, U<:Group, S}
   @req acting_group(Omega) == codomain(phi) "acting group of Omega must be the codomain of phi"
   return GSetByElements(domain(phi), induced_action_function(Omega, phi), Omega; closed=true, check=false)
 end

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -205,7 +205,7 @@ julia> S = symmetric_group(4);
 
 julia> x = S[1];
 
-julia> f = hom(S, S, [y^x for y in gens(S)]
+julia> f = hom(S, S, [y^x for y in gens(S)])
 Group homomorphism
   from symmetric group of degree 4
   to symmetric group of degree 4

--- a/src/Groups/matrices/linear_centralizer.jl
+++ b/src/Groups/matrices/linear_centralizer.jl
@@ -442,9 +442,6 @@ end
     centralizer(G::MatrixGroup{T}, x::MatrixGroupElem{T})
 
 Return (`C`,`f`), where `C` is the centralizer of `x` in `C` and `f` is the embedding of `C` into `G`.
-If `G` = `GL(n,F)` or `SL(n,F)`, then `f` = `nothing`.
-In this case, use `is_subgroup(C, G)[2]` to get the embedding homomorphism
-of `C` into `G`.
 
 # Examples
 ```jldoctest
@@ -462,8 +459,11 @@ function centralizer(G::MatrixGroup{T}, x::MatrixGroupElem{T}) where T <: FinFie
       V,card = G.descr==:GL ? _centralizer_GL(matrix(x)) : _centralizer_SL(matrix(x))
       H = matrix_group(base_ring(G), degree(G), V)
       set_attribute!(H, :order => ZZRingElem(card))
-      return H, nothing          # do not return the embedding of the centralizer into G to do not compute G.X
+      # Compute the embedding *without* `is_subset` check,
+      # in particular without creating `GapObj(H)`.
+      _, emb = is_subgroup(H, G; check = false)
+      return H, emb
    end
-   C = GAP.Globals.Centralizer(GapObj(G), GapObj(x))
+   C = GAPWrap.Centralizer(GapObj(G), GapObj(x))
    return _as_subgroup(G, C)
 end

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -8,9 +8,10 @@ function _as_subgroup_bare(G::T, H::GapObj) where T <: GAPGroup
   return _oscar_subgroup(H, G)
 end
 
+# Note that `_as_subgroup` does *not* check whether `H` is a subset of `G`.
 function _as_subgroup(G::GAPGroup, H::GapObj)
   H1 = _as_subgroup_bare(G, H)
-  return H1, hom(H1, G, x -> group_element(G, GapObj(x)), x -> group_element(H1, GapObj(x)); is_known_to_be_bijective = false)
+  return H1, GAPGroupEmbedding(H1, G)
 end
 
 """
@@ -71,24 +72,20 @@ function is_subset(H::GAPGroup, G::GAPGroup)
 end
 
 """
-    is_subgroup(H::GAPGroup, G::GAPGroup)
+    is_subgroup(H::GAPGroup, G::GAPGroup; check::Bool = true)
 
 Return (`true`,`f`) if `H` is a subgroup of `G`, where `f` is the embedding
 homomorphism of `H` into `G`, otherwise return (`false`,`nothing`).
 
+If `check` is `false` then it is not checked whether `H` is a subset of `G`.
+
 If you do not need the embedding then better call
 [`is_subset(H::GAPGroup, G::GAPGroup)`](@ref).
 """
-function is_subgroup(H::GAPGroup, G::GAPGroup)
-   if !is_subset(H, G)
-      return (false, nothing)
-   else
-      # We do not call `_as_subgroup` because we want to store `H`.
-      return (true, hom(H, G,
-                        x -> group_element(G, GapObj(x)),
-                        x -> group_element(H, GapObj(x));
-                        is_known_to_be_bijective = false))
-   end
+function is_subgroup(H::GAPGroup, G::GAPGroup; check::Bool = true)
+   check && !is_subset(H, G) && return (false, nothing)
+   # We do not call `_as_subgroup` because we want to store `H`.
+   return (true, GAPGroupEmbedding(H, G))
 end
 
 """

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -1,11 +1,12 @@
 @testset "embeddings" begin
    @testset for G in [symmetric_group(5), small_group(24, 12), general_linear_group(2, 3)]
-     G = symmetric_group(5)
      H, emb = sylow_subgroup(G, 2)
      x = gen(H, 1)
      y = image(emb, x)
      @test preimage(emb, y) == x
      @test any(g -> ! has_preimage_with_preimage(emb, g)[1], gens(G))
+     @test id_hom(H) * emb == emb
+     @test emb * id_hom(G) == emb
    end
 end
 
@@ -83,7 +84,7 @@ end
    @test g(f(x))==z
    @test (f*g)(x)==z
    @test (f*g)^-1 == g^-1*f^-1
-   @test_throws AssertionError g*f
+   @test_throws ErrorException g*f
    ty = trivial_morphism(Hy,Hy)
    @test f*ty==trivial_morphism(Hx,Hy)
    @test ty*g==trivial_morphism(Hy,Hz)

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -671,6 +671,24 @@ end
    @test length(@inferred maximal_subgroup_classes(G))==3
 end
 
+@testset "centralizers in matrix groups" begin
+   # Oscar computes the centralizer and its order
+   G = GL(6, 2)
+   x = gen(G, 1)
+   C, emb = centralizer(G, x)
+   @test emb isa Oscar.GAPGroupEmbedding
+   @test order(C) == 10321920
+   @test !isdefined(C, :X)
+
+   # GAP computes the centralizer
+   U, _ = sylow_subgroup(GL(4, 2), 2)
+   x = gen(U, 1)
+   C, emb = centralizer(U, x)
+   @test emb isa Oscar.GAPGroupEmbedding
+   @test isdefined(C, :X)
+   @test order(C) == 16
+end
+
 @testset "Jordan structure" begin
    F = GF(3, 1)
    R,t = polynomial_ring(F,:t)


### PR DESCRIPTION
- introduce a new type of group homomorphisms, which avoids computations on the GAP side whenever possible
- use this type for  the maps returned by `is_subgroup` and `_as_subgroup`
- fix `centralizer` for matrix groups, now it returns always the embedding
- improved documentation of group homomorphisms