### PR TITLE
Add `puiseux_expansion`

### DIFF
--- a/docs/doc.main
+++ b/docs/doc.main
@@ -236,6 +236,7 @@
          "AlgebraicGeometry/Curves/ProjectiveCurves.md",
          "AlgebraicGeometry/Curves/ProjectivePlaneCurves.md",
 	 "AlgebraicGeometry/Curves/ParametrizationPlaneCurves.md",
+	 "AlgebraicGeometry/Curves/PuiseuxExpansion.md",
      ],
      "Surfaces" => [
         "AlgebraicGeometry/Surfaces/K3Surfaces.md",

--- a/docs/src/AlgebraicGeometry/Curves/PuiseuxExpansion.md
+++ b/docs/src/AlgebraicGeometry/Curves/PuiseuxExpansion.md
@@ -1,0 +1,11 @@
+```@meta
+CurrentModule = Oscar
+CollapsedDocStrings = true
+DocTestSetup = Oscar.doctestsetup()
+```
+
+# Puiseux expansion 
+For a (possibly singular) plane curve through the origin over `QQ` we have
+```@docs
+puiseux_expansion(f::MPolyRingElem)
+```

--- a/docs/src/AlgebraicGeometry/Curves/PuiseuxExpansion.md
+++ b/docs/src/AlgebraicGeometry/Curves/PuiseuxExpansion.md
@@ -7,5 +7,9 @@ DocTestSetup = Oscar.doctestsetup()
 # Puiseux expansion 
 For a (possibly singular) plane curve through the origin over `QQ` we have
 ```@docs
-puiseux_expansion(f::MPolyRingElem)
+puiseux_expansion(
+    f::MPolyRingElem{T}, 
+    max_ord::Int=10;
+    precision::Int=max_ord
+  ) where {T <: QQFieldElem}
 ```

--- a/src/Rings/Rings.jl
+++ b/src/Rings/Rings.jl
@@ -41,3 +41,6 @@ include("FreeAssociativeAlgebraIdeal.jl")
 include("hilbert.jl")
 include("primary_decomposition_helpers.jl")
 include("resultant.jl")
+
+include("puiseux_wrapper.jl")
+

--- a/src/Rings/puiseux_wrapper.jl
+++ b/src/Rings/puiseux_wrapper.jl
@@ -87,13 +87,11 @@ function puiseux_expansion(
   R = Oscar.parent(f)
   @assert ngens(R) == 2 "polynomial must be bivariate"
   x, y = gens(R)
-  xx = gen(parent)
-  prec = max_precision(parent)
 
   # prepare for the Singular call
   SR = singular_poly_ring(R)
   Sf = SR(f)
-  raw = Singular.LibPuiseuxexpansions.puiseux(Sf, prec, 1)
+  raw = Singular.LibPuiseuxexpansions.puiseux(Sf, precision, 1)
   return reduce(vcat, [_process_result(R, precision, data...) for data in raw])
 end
 

--- a/src/Rings/puiseux_wrapper.jl
+++ b/src/Rings/puiseux_wrapper.jl
@@ -2,22 +2,19 @@
 # Wrapper functionality for `PuiseuxExpansions.lib` in Singular        #
 ########################################################################
 
-# A wrapper for the raw output of `puiseux`.
-# It returns a list of lists. It seems that the outer list contains 
-# only one element. The inner list contains 
+# A wrapper for Singular's `Singular.LibPuiseuxexpansions.puiseux`. 
+# It returns either a list of lists with entries of the following form: 
 #   * a polynomial `h`
 #   * an integer `e`
-#   * more stuff that I can not make sense of at the moment; probably some multiplicities
+#   * more stuff that is returned for internal purposes in the Singular library. 
+#     We discard this information
 # We interpret the result as `h` being the polynomial which evaluates 
 # to the Puiseux expansion of `f` on `y^(1//e)`. 
-function _puiseux(f::MPolyRingElem{T}, max_deg::Int, at_origin::Bool=true) where {T<:FieldElem}
-  P = parent(f)
-  SP = singular_poly_ring(P)
-  Sf = SP(f)
-  raw = Singular.LibPuiseuxexpansions.puiseux(Sf, max_deg, Int(at_origin))
-  @assert length(raw) == 1 "longer list then expected for output"
-  return [_process_result(P, data...) for data in raw]
-end
+#
+# Otherwise, it returns a ring and a dictionary with additional information 
+# on required extension fields for presentation of the result. Which one 
+# of the two cases applies is not foreseeable from the input alone. We 
+# therefore catch it with dispatch on `_process_result`. 
 
 function _process_result(P::MPolyRing, prec::Int, SE::Singular.PolyRing, res::Dict, rest...)
   # create the necesessary field extension on the Oscar side
@@ -66,7 +63,8 @@ end
 
 Compute the Puiseux expansion of `f` up to degree `precision` and returns a list of branches. 
 
-!!! note For the moment we only support bivariate polynomials over `QQ`. Puiseux expansion may produce number fields as coefficient rings for the output. As this is not foreseeable a priori, no guarantee can be given about the parent objects for the output. 
+!!! note 
+    For the moment we only support bivariate polynomials over `QQ`. Puiseux expansion may produce number fields as coefficient rings for the output. As this is not foreseeable a priori, no guarantee can be given about the parent objects for the output. 
 ```jldoctest
 julia> R, (x, y) = QQ[:x, :y]
 (Multivariate polynomial ring in 2 variables over QQ, QQMPolyRingElem[x, y])

--- a/src/Rings/puiseux_wrapper.jl
+++ b/src/Rings/puiseux_wrapper.jl
@@ -15,8 +15,18 @@ function _puiseux(f::MPolyRingElem{T}, max_deg::Int, at_origin::Bool=true) where
   SP = singular_poly_ring(P)
   Sf = SP(f)
   raw = Singular.LibPuiseuxexpansions.puiseux(Sf, max_deg, Int(at_origin))
-  result = Tuple{typeof(f), Int}[(P(h), e) for (h, e, _) in raw]
+  @assert length(raw) == 1 "longer list then expected for output"
+  return _process_result(P, raw[1]...)
 end
+
+function _process_result(P::MPolyRing, SE::Singular.PolyRing, res::Dict, rest...)
+  error("processing of result from Singular is not yet implemented")
+end
+
+function _process_result(P::MPolyRing, h::Singular.spoly, e::Int, rest...)
+  return P(h), e
+end
+
 
 # Method to create the default Oscar parent for the Puiseux expansion of `f`. 
 function _puiseux_parent(f::MPolyRingElem, prec::Int)
@@ -59,9 +69,7 @@ function puiseux_expansion(
   x, y = gens(R)
   xx = gen(parent)
   prec = max_precision(parent)
-  pdat = _puiseux(f, prec, true)
-  @assert isone(length(pdat)) "a longer list was returned than anticipated"
-  h, e = only(pdat)
+  h, e = _puiseux(f, prec, true)
   # h should have no terms involving y^k for k > 0
   hh = evaluate(h, [xx^(1//e), zero(xx)])
   return hh

--- a/src/Rings/puiseux_wrapper.jl
+++ b/src/Rings/puiseux_wrapper.jl
@@ -1,0 +1,6 @@
+function _puiseux(f::MPolyRingElem{T}, max_deg::Int, at_origin::Bool=true) where {T<:FieldElem}
+  P = parent(f)
+  SP = singular_poly_ring(P)
+  Sf = SP(f)
+  return Singular.LibPuiseuxexpansions.puiseux(Sf, max_deg, Int(at_origin))
+end

--- a/src/Rings/puiseux_wrapper.jl
+++ b/src/Rings/puiseux_wrapper.jl
@@ -38,7 +38,7 @@ function _process_result(P::MPolyRing, prec::Int, SE::Singular.PolyRing, res::Di
       push_term!(ctx, kkO(c), v)
     end
     hh = finish(ctx)
-    push!(result, evaluate(hh, [xx^(1//3), zero(xx)]))
+    push!(result, evaluate(hh, [xx^(1//e), zero(xx)]))
   end
   return result
 end
@@ -64,8 +64,9 @@ end
         precision::Int=10
       ) where {T <: FieldElem}
 
-Compute the Puiseux expansion of `f` up to degree `precision`. 
-A parent ring for the return value can be provided if needed.
+Compute the Puiseux expansion of `f` up to degree `precision` and returns a list of branches. 
+
+!!! note For the moment we only support bivariate polynomials over `QQ`. Puiseux expansion may produce number fields as coefficient rings for the output. As this is not foreseeable a priori, no guarantee can be given about the parent objects for the output. 
 ```jldoctest
 julia> R, (x, y) = QQ[:x, :y]
 (Multivariate polynomial ring in 2 variables over QQ, QQMPolyRingElem[x, y])
@@ -73,17 +74,18 @@ julia> R, (x, y) = QQ[:x, :y]
 julia> f = y^3 + x^2 + x^8
 x^8 + x^2 + y^3
 
-julia> h = Oscar.puiseux_expansion(f, 20)
--x^(2//3) - 1//3*x^(20//3) + O(x^(22//3))
+julia> h = Oscar.puiseux_expansion(f, 15)
+1-element Vector{AbstractAlgebra.Generic.PuiseuxSeriesFieldElem{QQFieldElem}}:
+ -x^(2//3) + O(x^(17//3))
 
-julia> evaluate(f, [gen(parent(h)), h])
-O(x^(26//3))
+julia> all(is_zero(evaluate(f, [gen(parent(h)), h])) for h in h)
+true
 ```
 """
 function puiseux_expansion(
     f::MPolyRingElem{T}, 
     precision::Int=10
-  ) where {T <: FieldElem}
+  ) where {T <: QQFieldElem}
   R = Oscar.parent(f)
   @assert ngens(R) == 2 "polynomial must be bivariate"
   x, y = gens(R)

--- a/src/Rings/puiseux_wrapper.jl
+++ b/src/Rings/puiseux_wrapper.jl
@@ -47,14 +47,6 @@ function _process_result(P::MPolyRing, prec::Int, h::Singular.spoly, e::Int, res
 end
 
 
-# Method to create the default Oscar parent for the Puiseux expansion of `f`. 
-function _puiseux_parent(f::MPolyRingElem, prec::Int)
-  R = parent(f)
-  kk = coefficient_ring(R)
-  symbs = symbols(R)
-  return puiseux_series_ring(kk, prec, symbs[1])[1]
-end
-
 @doc raw"""
     function puiseux_expansion(
         f::MPolyRingElem{T},

--- a/src/Rings/puiseux_wrapper.jl
+++ b/src/Rings/puiseux_wrapper.jl
@@ -81,7 +81,6 @@ function puiseux_expansion(
   ) where {T <: QQFieldElem}
   R = Oscar.parent(f)
   @assert ngens(R) == 2 "polynomial must be bivariate"
-  x, y = gens(R)
 
   # prepare for the Singular call
   SR = singular_poly_ring(R)

--- a/src/Rings/puiseux_wrapper.jl
+++ b/src/Rings/puiseux_wrapper.jl
@@ -52,7 +52,7 @@ end
         f::MPolyRingElem{T},
         max_ord::Int=10;
         precision::Int=max_ord
-      ) where {T <: FieldElem}
+      ) where {T <: QQFieldElem}
 
 Compute the Puiseux expansion of `f` up to degree `max_ord` and returns the output 
 in puiseux series rings with the given `precision`. 

--- a/src/Rings/puiseux_wrapper.jl
+++ b/src/Rings/puiseux_wrapper.jl
@@ -1,6 +1,69 @@
+########################################################################
+# Wrapper functionality for `PuiseuxExpansions.lib` in Singular        #
+########################################################################
+
+# A wrapper for the raw output of `puiseux`.
+# It returns a list of lists. It seems that the outer list contains 
+# only one element. The inner list contains 
+#   * a polynomial `h`
+#   * an integer `e`
+#   * more stuff that I can not make sense of at the moment; probably some multiplicities
+# We interpret the result as `h` being the polynomial which evaluates 
+# to the Puiseux expansion of `f` on `y^(1//e)`. 
 function _puiseux(f::MPolyRingElem{T}, max_deg::Int, at_origin::Bool=true) where {T<:FieldElem}
   P = parent(f)
   SP = singular_poly_ring(P)
   Sf = SP(f)
-  return Singular.LibPuiseuxexpansions.puiseux(Sf, max_deg, Int(at_origin))
+  raw = Singular.LibPuiseuxexpansions.puiseux(Sf, max_deg, Int(at_origin))
+  result = Tuple{typeof(f), Int}[(P(h), e) for (h, e, _) in raw]
 end
+
+# Method to create the default Oscar parent for the Puiseux expansion of `f`. 
+function _puiseux_parent(f::MPolyRingElem, prec::Int)
+  R = parent(f)
+  kk = coefficient_ring(R)
+  symbs = symbols(R)
+  return puiseux_series_ring(kk, prec, symbs[1])[1]
+end
+
+@doc raw"""
+    function puiseux_expansion(
+        f::MPolyRingElem{T}, 
+        precision::Int=10;
+        parent = _puiseux_parent(f, precision)
+      ) where {T <: FieldElem}
+
+Compute the Puiseux expansion of `f` up to degree `precision`. 
+A parent ring for the return value can be provided if needed.
+```jldoctest
+julia> R, (x, y) = QQ[:x, :y]
+(Multivariate polynomial ring in 2 variables over QQ, QQMPolyRingElem[x, y])
+
+julia> f = y^3 + x^2 + x^8
+x^8 + x^2 + y^3
+
+julia> h = Oscar.puiseux_expansion(f, 20)
+-x^(2//3) - 1//3*x^(20//3) + O(x^(22//3))
+
+julia> evaluate(f, [gen(parent(h)), h])
+O(x^(26//3))
+```
+"""
+function puiseux_expansion(
+    f::MPolyRingElem{T}, 
+    precision::Int=10;
+    parent = _puiseux_parent(f, precision)
+  ) where {T <: FieldElem}
+  R = Oscar.parent(f)
+  @assert ngens(R) == 2 "polynomial must be bivariate"
+  x, y = gens(R)
+  xx = gen(parent)
+  prec = max_precision(parent)
+  pdat = _puiseux(f, prec, true)
+  @assert isone(length(pdat)) "a longer list was returned than anticipated"
+  h, e = only(pdat)
+  # h should have no terms involving y^k for k > 0
+  hh = evaluate(h, [xx^(1//e), zero(xx)])
+  return hh
+end
+

--- a/src/Rings/puiseux_wrapper.jl
+++ b/src/Rings/puiseux_wrapper.jl
@@ -24,7 +24,7 @@ function _process_result(P::MPolyRing, prec::Int, SE::Singular.PolyRing, res::Di
   L, t = polynomial_ring(QQ, :t; cached=false)
   kkO, alpha = extension_field(L(mmp))
   P_ext, to_P_ext = change_base_ring(kkO, P)
-  Puis, xx = puiseux_series_ring(kkO, prec, symbols(P_ext)[1])
+  Puis, xx = puiseux_series_ring(kkO, prec, symbols(P_ext)[1]; cached=false)
 
   # transfer the polynomials to the oscar side
   result = elem_type(Puis)[]
@@ -42,7 +42,7 @@ end
 
 function _process_result(P::MPolyRing, prec::Int, h::Singular.spoly, e::Int, rest...)
   kk = coefficient_ring(P)
-  Puis, xx = puiseux_series_ring(kk, prec, symbols(P)[1])
+  Puis, xx = puiseux_series_ring(kk, prec, symbols(P)[1]; cached=false)
   return [evaluate(P(h), [xx^(1//e), zero(xx)])]
 end
 

--- a/src/Rings/puiseux_wrapper.jl
+++ b/src/Rings/puiseux_wrapper.jl
@@ -57,11 +57,13 @@ end
 
 @doc raw"""
     function puiseux_expansion(
-        f::MPolyRingElem{T}, 
-        precision::Int=10
+        f::MPolyRingElem{T},
+        max_ord::Int=10;
+        precision::Int=max_ord
       ) where {T <: FieldElem}
 
-Compute the Puiseux expansion of `f` up to degree `precision` and returns a list of branches. 
+Compute the Puiseux expansion of `f` up to degree `max_ord` and returns the output 
+in puiseux series rings with the given `precision`. 
 
 !!! note 
     For the moment we only support bivariate polynomials over `QQ`. Puiseux expansion may produce number fields as coefficient rings for the output. As this is not foreseeable a priori, no guarantee can be given about the parent objects for the output. 
@@ -82,7 +84,8 @@ true
 """
 function puiseux_expansion(
     f::MPolyRingElem{T}, 
-    precision::Int=10
+    max_ord::Int=10;
+    precision::Int=max_ord
   ) where {T <: QQFieldElem}
   R = Oscar.parent(f)
   @assert ngens(R) == 2 "polynomial must be bivariate"
@@ -91,7 +94,7 @@ function puiseux_expansion(
   # prepare for the Singular call
   SR = singular_poly_ring(R)
   Sf = SR(f)
-  raw = Singular.LibPuiseuxexpansions.puiseux(Sf, precision, 1)
+  raw = Singular.LibPuiseuxexpansions.puiseux(Sf, max_ord, 1)
   return reduce(vcat, [_process_result(R, precision, data...) for data in raw])
 end
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1509,6 +1509,7 @@ export prune_with_map
 export pseudo_del_pezzo_polytope
 export pseudovertices
 export pullback
+export puiseux_expansion
 export pushforward_on_algebraic_lattices
 export pyramid
 export quadratic_form

--- a/test/Rings/mpoly.jl
+++ b/test/Rings/mpoly.jl
@@ -706,11 +706,12 @@ end
   @test all(is_zero(evaluate(f, [gen(parent(h)), h])) for h in h)
 
   g = f + y^7
-  hg = Oscar.puiseux_expansion(g, 20; parent=parent(h))
-  h + hg # test parent compatibility 
-  @test all(is_zero(evaluate(g, [gen(parent(hg)), hg])) for g in g)
+  hg = Oscar.puiseux_expansion(g, 20)
+  @test_throws ErrorException h + hg # no parent compatibility 
+  @test all(is_zero(evaluate(g, [gen(parent(hg)), hg])) for hg in hg)
   
   g = y^4 + x^2 + x^8
-  @test all(is_zero(evaluate(g, [gen(parent(hg)), hg])) for g in g)
+  hg = Oscar.puiseux_expansion(g, 20)
+  @test all(is_zero(evaluate(g, [gen(parent(hg)), hg])) for hg in hg)
 end
 

--- a/test/Rings/mpoly.jl
+++ b/test/Rings/mpoly.jl
@@ -706,7 +706,7 @@ end
   @test is_zero(evaluate(f, [gen(parent(h)), h]))
 
   g = f + y^7
-  hg = Oscar.puiseux_expansion(f, 15; parent=parent(h))
+  hg = Oscar.puiseux_expansion(g, 20; parent=parent(h))
   h + hg # test parent compatibility 
   @test is_zero(evaluate(g, [gen(parent(hg)), hg]))
 end

--- a/test/Rings/mpoly.jl
+++ b/test/Rings/mpoly.jl
@@ -703,14 +703,14 @@ end
   R, (x, y) = QQ[:x, :y]
   f = y^3 + x^2 + x^8
   h = Oscar.puiseux_expansion(f, 15)
-  @test is_zero(evaluate(f, [gen(parent(h)), h]))
+  @test all(is_zero(evaluate(f, [gen(parent(h)), h])) for h in h)
 
   g = f + y^7
   hg = Oscar.puiseux_expansion(g, 20; parent=parent(h))
   h + hg # test parent compatibility 
-  @test is_zero(evaluate(g, [gen(parent(hg)), hg]))
+  @test all(is_zero(evaluate(g, [gen(parent(hg)), hg])) for g in g)
   
   g = y^4 + x^2 + x^8
-  @test_throws ErrorException Oscar.puiseux_expansion(g, 20)
+  @test all(is_zero(evaluate(g, [gen(parent(hg)), hg])) for g in g)
 end
 

--- a/test/Rings/mpoly.jl
+++ b/test/Rings/mpoly.jl
@@ -709,5 +709,8 @@ end
   hg = Oscar.puiseux_expansion(g, 20; parent=parent(h))
   h + hg # test parent compatibility 
   @test is_zero(evaluate(g, [gen(parent(hg)), hg]))
+  
+  g = y^4 + x^2 + x^8
+  @test_throws ErrorException Oscar.puiseux_expansion(g, 20)
 end
 

--- a/test/Rings/mpoly.jl
+++ b/test/Rings/mpoly.jl
@@ -702,16 +702,16 @@ end
 @testset "puiseux expansion" begin
   R, (x, y) = QQ[:x, :y]
   f = y^3 + x^2 + x^8
-  h = Oscar.puiseux_expansion(f, 15)
+  h = puiseux_expansion(f, 15)
   @test all(is_zero(evaluate(f, [gen(parent(h)), h])) for h in h)
 
   g = f + y^7
-  hg = Oscar.puiseux_expansion(g, 20)
+  hg = puiseux_expansion(g, 20)
   @test_throws ErrorException h + hg # no parent compatibility 
   @test all(is_zero(evaluate(g, [gen(parent(hg)), hg])) for hg in hg)
   
   g = y^4 + x^2 + x^8
-  hg = Oscar.puiseux_expansion(g, 20)
+  hg = puiseux_expansion(g, 20)
   @test all(is_zero(evaluate(g, [gen(parent(hg)), hg])) for hg in hg)
 end
 

--- a/test/Rings/mpoly.jl
+++ b/test/Rings/mpoly.jl
@@ -699,3 +699,15 @@ end
   @test !is_one(radical(I))
 end
 
+@testset "puiseux expansion" begin
+  R, (x, y) = QQ[:x, :y]
+  f = y^3 + x^2 + x^8
+  h = Oscar.puiseux_expansion(f, 15)
+  @test is_zero(evaluate(f, [gen(parent(h)), h]))
+
+  g = f + y^7
+  hg = Oscar.puiseux_expansion(f, 15; parent=parent(h))
+  h + hg # test parent compatibility 
+  @test is_zero(evaluate(g, [gen(parent(hg)), hg]))
+end
+


### PR DESCRIPTION
This is a first take at wrapping Puiseux expansion from `PuiseuxExpansion.lib` as requested by @simonbrandhorst . 

@jankoboehm : Could you please have a look? I tried to make sense of the output from Singular, but I could only make an educated guess at what we hold in our hands there. There is lots of data being discarded and I'm wondering whether 1. my interpretation of the output is correct so far and 2. whether we want to keep more of the data and make it available in Oscar. 

One particular question: Singular's puiseux command takes an integer value `max_ord`. I am not sure how that relates to the `prec` argument in the constructor `puiseux_series_ring`. So far, I just set them to be equal, i.e. I call Singular's `puiseux` with `max_ord=k` and wrap the output in a `puiseux_series_ring` with `prec=k` for the same `k`. But I'm afraid that this might not be the correct approach. @jankoboehm : If you remember the implementation in Singular, do you see how `max_ord` and `prec` are related? 

Pinging also @YueRen for critical input on this topic. 