### PR TITLE
remove a GAP function that is now provided by GAP

### DIFF
--- a/gap/pkg/OscarInterface/gap/OscarInterface.gi
+++ b/gap/pkg/OscarInterface/gap/OscarInterface.gi
@@ -184,38 +184,3 @@ InstallMethod( IsHandledByNiceMonomorphism,
     fi;
     return false;
     end );
-
-############################################################################
-
-# The following can be removed as soon as the CTblLib package provides it
-# (not yet in CTblLib v1.3.9).
-if not IsBound( IsAtlasCharacterTable ) then
-  DeclareProperty( "IsAtlasCharacterTable", IsNearlyCharacterTable );
-
-  InstallMethod( IsAtlasCharacterTable,
-    [ "IsOrdinaryTable" ],
-    tbl -> PositionSublist( InfoText( tbl ),
-                            "origin: ATLAS of finite groups" ) <> fail );
-
-  InstallMethod( IsAtlasCharacterTable,
-    [ "IsBrauerTable" ],
-    tbl -> IsAtlasCharacterTable( OrdinaryCharacterTable( tbl ) ) );
-
-  AddSet( CTblLib.SupportedAttributes, "IsAtlasCharacterTable" );
-
-  DatabaseAttributeAddX( CTblLib.Data.IdEnumerator, rec(
-    identifier:= "IsAtlasCharacterTable",
-    type:= "values",
-    name:= "IsAtlasCharacterTable",
-    neededAttributes:= [ "InfoText" ],
-    create:= function( attr, id )
-      local infotext;
-
-      infotext:= attr.idenumerator.attributes.InfoText;
-      return PositionSublist( infotext.attributeValue( infotext, id ),
-                              "origin: ATLAS of finite groups" ) <> fail;
-      end,
-  ) );
-
-  CTblLib.ExtendAttributeOfIdEnumeratorExt( "IsAtlasCharacterTable", true );
-fi;


### PR DESCRIPTION
In Oscar.jl v1.6, we have at least GAP.jl v0.16.1. This version provides at least v1.3.10 of the GAP package CTblLib, and this contains the function `IsAtlasCharacterTable`. Before this became available, it had been provided inside Oscar, via the GAP package `OscarInterface`.

Something related:
What is the recommended way to find out which versions of GAP packages are officially available in a given version of Oscar?
Note that GAP is freely choosing newer package versions if they are lying around in the user's personal GAP root directories.
Do we perhaps need gap-system/gap/pull/6057 or something better in order to be on the safe side?
(A cheap temporary change would be to add the minimal requested version numbers of GAP packages to the `GAP.Packages.load` loop in `src/Oscar.jl`.)