### PR TITLE
Fix raising matrix group elements to negative powers

### DIFF
--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -480,7 +480,12 @@ end
 Base.:*(x::MatrixGroupElem, y::MatElem) = matrix(x)*y
 Base.:*(x::MatElem, y::MatrixGroupElem) = x*matrix(y)
 
-Base.:^(x::MatrixGroupElem, n::Int) = MatrixGroupElem(parent(x), matrix(x)^n)
+function Base.:^(x::MatrixGroupElem, n::Int)
+  m = matrix(x)
+  # Raising a `ZZMatrix` to a negative power is not supported.
+  mn = (n < 0) ? inv(m)^(-n) : m^n
+  return MatrixGroupElem(parent(x), mn)
+end
 
 Base.isone(x::MatrixGroupElem) = isone(matrix(x))
 

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -567,6 +567,12 @@ end
 end
 
 @testset "Methods on elements" begin
+   G = GL(2, ZZ)
+   x = gen(G, 1)
+   xi = x^-1
+   n = -1
+   @test xi == x^n
+
    T,t=polynomial_ring(GF(3),:t)
    F,z=finite_field(t^2+1,"z")
 


### PR DESCRIPTION
If the underlying matrix is a `ZZMatrix` then negative exponents are not allowed.

(addresses a problem mentioned in #5550)

Note that the situation is a bit tricky:

```
julia> G = GL(2, ZZ);

julia> x = gen(G, 1);

julia> x^-1;  # this worked already before this pull request

julia> n = -1;

julia> x^n;
ERROR: DomainError with -1:
Exponent must be non-negative
Stacktrace:
 [1] ^(x::ZZMatrix, y::Int64)
   @ Nemo ~/.julia/packages/Nemo/kdloy/src/flint/fmpz_mat.jl:325
 [2] ^(x::MatrixGroupElem{ZZRingElem, ZZMatrix}, n::Int64)
   @ Oscar ~/.julia/packages/Oscar/S0B41/src/Groups/matrices/MatGrp.jl:437
 [3] top-level scope
   @ REPL[6]:1
```

The reason for that is some `literal_pow` magic from AbstractAlgebra.

```
julia> @which x^n
^(x::MatrixGroupElem, n::Int64)
     @ Oscar ~/.julia/packages/Oscar/S0B41/src/Groups/matrices/MatGrp.jl:437

julia> @which x^-1
literal_pow(::typeof(^), g::GroupElem, ::Val{-1})
     @ AbstractAlgebra ~/.julia/packages/AbstractAlgebra/L8iQ0/src/Groups.jl:228
```

We might do the same for `ZZMatrix`.