### PR TITLE
Check that all variables are from the same ring when generating an ordering

### DIFF
--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -236,6 +236,7 @@ should be one of `:lex`, `:deglex`, `:degrevlex`, `:invlex`, `:deginvlex`, `:neg
 `:negdeglex`, `:negdegrevlex`, `:neginvlex`.
 """
 function monomial_ordering(v::AbstractVector{<:MPolyRingElem}, s::Symbol)
+  @req all(isequal(parent(first(v))), map(x->parent(x), v)) "Variables must be from the same ring."
   i = _unique_var_indices(v)
   return MonomialOrdering(parent(first(v)), SymbOrdering(s, i))
 end
@@ -281,6 +282,7 @@ function lex(R::MPolyRing)
 end
 
 function lex(v::AbstractVector{<:MPolyRingElem})
+  @req all(isequal(parent(first(v))), map(x->parent(x), v)) "Variables must be from the same ring."
   i = _unique_var_indices(v)
   return MonomialOrdering(parent(first(v)), SymbOrdering(:lex, i))
 end
@@ -345,6 +347,7 @@ function deglex(R::MPolyRing)
 end
 
 function deglex(v::AbstractVector{<:MPolyRingElem})
+  @req all(isequal(parent(first(v))), map(x->parent(x), v)) "Variables must be from the same ring."
   i = _unique_var_indices(v)
   return MonomialOrdering(parent(first(v)), SymbOrdering(:deglex, i))
 end
@@ -417,6 +420,7 @@ function degrevlex(R::MPolyRing)
 end
 
 function degrevlex(v::AbstractVector{<:MPolyRingElem})
+  @req all(isequal(parent(first(v))), map(x->parent(x), v)) "Variables must be from the same ring."
   i = _unique_var_indices(v)
   return MonomialOrdering(parent(first(v)), SymbOrdering(:degrevlex, i))
 end
@@ -489,6 +493,7 @@ function invlex(R::MPolyRing)
 end
 
 function invlex(v::AbstractVector{<:MPolyRingElem})
+  @req all(isequal(parent(first(v))), map(x->parent(x), v)) "Variables must be from the same ring."
   i = _unique_var_indices(v)
   return MonomialOrdering(parent(first(v)), SymbOrdering(:invlex, i))
 end
@@ -554,6 +559,7 @@ function deginvlex(R::MPolyRing)
 end
 
 function deginvlex(v::AbstractVector{<:MPolyRingElem})
+  @req all(isequal(parent(first(v))), map(x->parent(x), v)) "Variables must be from the same ring."
   i = _unique_var_indices(v)
   return MonomialOrdering(parent(first(v)), SymbOrdering(:deginvlex, i))
 end
@@ -628,6 +634,7 @@ function neglex(R::MPolyRing)
 end
 
 function neglex(v::AbstractVector{<:MPolyRingElem})
+  @req all(isequal(parent(first(v))), map(x->parent(x), v)) "Variables must be from the same ring."
   i = _unique_var_indices(v)
   return MonomialOrdering(parent(first(v)), SymbOrdering(:neglex, i))
 end
@@ -692,6 +699,7 @@ function neginvlex(R::MPolyRing)
 end
 
 function neginvlex(v::AbstractVector{<:MPolyRingElem})
+  @req all(isequal(parent(first(v))), map(x->parent(x), v)) "Variables must be from the same ring."
   i = _unique_var_indices(v)
   return MonomialOrdering(parent(first(v)), SymbOrdering(:neginvlex, i))
 end
@@ -756,6 +764,7 @@ function negdegrevlex(R::MPolyRing)
 end
 
 function negdegrevlex(v::AbstractVector{<:MPolyRingElem})
+  @req all(isequal(parent(first(v))), map(x->parent(x), v)) "Variables must be from the same ring."
   i = _unique_var_indices(v)
   return MonomialOrdering(parent(first(v)), SymbOrdering(:negdegrevlex, i))
 end
@@ -828,6 +837,7 @@ function negdeglex(R::MPolyRing)
 end
 
 function negdeglex(v::AbstractVector{<:MPolyRingElem})
+  @req all(isequal(parent(first(v))), map(x->parent(x), v)) "Variables must be from the same ring."
   i = _unique_var_indices(v)
   return MonomialOrdering(parent(first(v)), SymbOrdering(:negdeglex, i))
 end
@@ -878,6 +888,7 @@ vector `w` should be the same length as `v`, and the symbol `s` should be one
 of `:wdeglex`, `:wdegrevlex`, `:negwdeglex`, `:negwdegrevlex`.
 """
 function monomial_ordering(v::AbstractVector{<:MPolyRingElem}, s::Symbol, w::Vector{Int})
+  @req all(isequal(parent(first(v))), map(x->parent(x), v)) "Variables must be from the same ring."
   i = _unique_var_indices(v)
   return MonomialOrdering(parent(first(v)), WSymbOrdering(s, i, w))
 end
@@ -936,6 +947,7 @@ function wdeglex(R::MPolyRing, w::Vector{Int})
 end
 
 function wdeglex(v::AbstractVector{<:MPolyRingElem}, w::Vector{Int})
+  @req all(isequal(parent(first(v))), map(x->parent(x), v)) "Variables must be from the same ring."
   i = _unique_var_indices(v)
   return MonomialOrdering(parent(first(v)), WSymbOrdering(:wdeglex, i, w))
 end
@@ -1005,6 +1017,7 @@ function wdegrevlex(R::MPolyRing, w::Vector{Int})
 end
 
 function wdegrevlex(v::AbstractVector{<:MPolyRingElem}, w::Vector{Int})
+  @req all(isequal(parent(first(v))), map(x->parent(x), v)) "Variables must be from the same ring."
   i = _unique_var_indices(v)
   return MonomialOrdering(parent(first(v)), WSymbOrdering(:wdegrevlex, i, w))
 end
@@ -1074,6 +1087,7 @@ function negwdeglex(R::MPolyRing, w::Vector{Int})
 end
 
 function negwdeglex(v::AbstractVector{<:MPolyRingElem}, w::Vector{Int})
+  @req all(isequal(parent(first(v))), map(x->parent(x), v)) "Variables must be from the same ring."
   i = _unique_var_indices(v)
   return MonomialOrdering(parent(first(v)), WSymbOrdering(:negwdeglex, i, w))
 end
@@ -1143,6 +1157,7 @@ function negwdegrevlex(R::MPolyRing, w::Vector{Int})
 end
 
 function negwdegrevlex(v::AbstractVector{<:MPolyRingElem}, w::Vector{Int})
+  @req all(isequal(parent(first(v))), map(x->parent(x), v)) "Variables must be from the same ring."
   i = _unique_var_indices(v)
   return MonomialOrdering(parent(first(v)), WSymbOrdering(:negwdegrevlex, i, w))
 end
@@ -1239,6 +1254,7 @@ function matrix_ordering(R::MPolyRing, M::Union{Matrix{T}, MatElem{T}}; check::B
 end
 
 function matrix_ordering(v::AbstractVector{<:MPolyRingElem}, M::Union{Matrix{T}, MatElem{T}}; check::Bool = true) where T
+  @req all(isequal(parent(first(v))), map(x->parent(x), v)) "Variables must be from the same ring."
   i = _unique_var_indices(v)
   return MonomialOrdering(parent(first(v)), MatrixOrdering(i, ZZMatrix(M), check))
 end
@@ -1293,7 +1309,7 @@ julia> canonical_matrix(o2)
 ```
 """
 function weight_ordering(w::Vector{<:IntegerUnion}, o::MonomialOrdering)
-  i = _support_indices(o.o)
+  i = sort!(_support_indices(o.o))
   m = ZZMatrix(1, length(w), w)
   return MonomialOrdering(base_ring(o), MatrixOrdering(i, m, false))*o
 end

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -1309,7 +1309,7 @@ julia> canonical_matrix(o2)
 ```
 """
 function weight_ordering(w::Vector{<:IntegerUnion}, o::MonomialOrdering)
-  i = _support_indices(o.o))
+  i = _support_indices(o.o)
   m = ZZMatrix(1, length(w), w)
   return MonomialOrdering(base_ring(o), MatrixOrdering(i, m, false))*o
 end

--- a/src/Rings/orderings.jl
+++ b/src/Rings/orderings.jl
@@ -1309,7 +1309,7 @@ julia> canonical_matrix(o2)
 ```
 """
 function weight_ordering(w::Vector{<:IntegerUnion}, o::MonomialOrdering)
-  i = sort!(_support_indices(o.o))
+  i = _support_indices(o.o))
   m = ZZMatrix(1, length(w), w)
   return MonomialOrdering(base_ring(o), MatrixOrdering(i, m, false))*o
 end

--- a/test/Rings/orderings.jl
+++ b/test/Rings/orderings.jl
@@ -114,6 +114,23 @@
    @test support(lex([x])) == [x]
    @test support(lex([x, y])) == [x,y] || support(lex([x,y])) == [y,x]
    @test 3 == length(support(deglex([x,y])*wdeglex([y,z], [1,2])))
+
+
+   S, (u, v) = polynomial_ring(QQ, 3)
+
+   @test_throws ErrorException lex([x,u])
+   @test_throws ErrorException degrevlex([x,u])
+   @test_throws ErrorException deglex([x,u])
+   @test_throws ErrorException invlex([x,u])
+   @test_throws ErrorException deginvlex([x,u])
+   @test_throws ErrorException neglex([x,u])
+   @test_throws ErrorException neginvlex([x,u])
+   @test_throws ErrorException negdegrevlex([x,u])
+   @test_throws ErrorException negdeglex([x,u])
+   @test_throws ErrorException wdeglex([x,u], [1,1])
+   @test_throws ErrorException wdegrevlex([x,u], [1,1])
+   @test_throws ErrorException negwdeglex([x,u], [1,1])
+   @test_throws ErrorException negwdegrevlex([x,u], [1,1])
 end
 
 @testset "Polynomial Orderings is_total" begin


### PR DESCRIPTION
This PR adds a check that all variables are from the same ring when generating an ordering, see side note in #5590.