### PR TITLE
`small_group_identification` works if the group stores it already

### DIFF
--- a/src/Groups/libraries/smallgroups.jl
+++ b/src/Groups/libraries/smallgroups.jl
@@ -116,7 +116,7 @@ ERROR: ArgumentError: identification is not available for groups of order 243290
 """
 function small_group_identification(G::GAPGroup)
    @req is_finite(G) "group is not finite"
-   @req has_small_group_identification(order(G)) "identification is not available for groups of order $(order(G))"
+   @req GAP.Globals.HasIdGroup(GapObj(G)) || has_small_group_identification(order(G)) "identification is not available for groups of order $(order(G))"
    res = GAP.Globals.IdGroup(GapObj(G))
    return Tuple{ZZRingElem,ZZRingElem}(res)
 end

--- a/test/Groups/libraries.jl
+++ b/test/Groups/libraries.jl
@@ -158,6 +158,7 @@ end
    @test length(all_small_groups(order => 16, !is_abelian))==9
    @test number_of_small_groups(16)==14
    @test number_of_small_groups(17)==1
+   @test small_group_identification(small_group(512, 1)) == (512, 1)
 
    @test_throws ArgumentError small_group(1, 2)
 end


### PR DESCRIPTION
This is the behaviour which we have also in GAP.