### PR TITLE
Fix isGB in FGLM

### DIFF
--- a/src/Rings/groebner/fglm.jl
+++ b/src/Rings/groebner/fglm.jl
@@ -46,7 +46,7 @@ with respect to the ordering
 """
 function _fglm(G::IdealGens, ordering::MonomialOrdering)
   (G.isGB == true && G.isReduced == true) || error("Input must be a reduced Gröbner basis.")
-  SG = singular_generators(G)
+  SG = singular_generators(G, G.ord)
   Singular.dimension(SG) == 0 || error("Dimension of corresponding ideal must be zero.")
   Sx = base_ring(SG)
   SR_destination, = Singular.polynomial_ring(base_ring(Sx), symbols(Sx); ordering = singular(ordering))

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -340,7 +340,7 @@ function singular_generators(B::IdealGens, monorder::MonomialOrdering=default_or
     B.gensBiPolyArray.f = g
     B.gensBiPolyArray.S = Singular.Ideal(B.gensBiPolyArray.Sx, elem_type(B.gensBiPolyArray.Sx)[g(x) for x in oscar_generators(B)])
   end
-  if B.isGB && B.ord == monomial_ordering(base_ring(B), internal_ordering(B.gensBiPolyArray.Sx))
+  if B.isGB && isdefined(B, :ord) && B.ord == monomial_ordering(base_ring(B), internal_ordering(B.gensBiPolyArray.Sx))
     B.gensBiPolyArray.S.isGB = true
   end
 

--- a/test/Rings/groebner.jl
+++ b/test/Rings/groebner.jl
@@ -141,6 +141,8 @@
     I = ideal(R,[x^2+x*y+y,x+y^2])
     G = standard_basis(I, ordering=lex(R), complete_reduction=true)
     @test G.ord == lex(R)
+    SG = Oscar.singular_generators(G, G.ord)
+    @test SG.isGB
 end
 
 @testset "normal form graded" begin


### PR DESCRIPTION
This fixes the setting for `isGB` in FGLM if the start ordering is not the default ordering.