### PR TITLE
tests: disable 'Additional rational_solutions tests' until #5623 is solved

### DIFF
--- a/test/Rings/solving.jl
+++ b/test/Rings/solving.jl
@@ -112,6 +112,8 @@ end
   @test length(v) == 5
 end
 
+#= FIXME: disabled until #5623 is fixed in msolve
+
 @testset "Additional rational_solutions tests" begin
   let
     K = algebraic_closure(QQ)
@@ -246,3 +248,4 @@ end
     @test length(pts) > 0 && length(pts) == 1
   end
 end
+=#


### PR DESCRIPTION
Not sure which of all these tests might cause errors so I disabled the whole testset until a fix is available via msolve.

see: #5623