### PR TITLE
CI: clean polymake scratchspace on self-hosted runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,6 +95,9 @@ jobs:
         with:
           cache-name: julia-cache;workflow=${{ github.workflow }};julia=${{ matrix.julia-version }};arch=${{ runner.arch }}
           include-matrix: false
+      - name: "Clean polymake scratchspace for self-hosted macOS runners"
+        if: runner.environment == 'self-hosted'
+        run: rm -rf $JULIA_DEPOT_PATH/scratchspaces/d720cf60-89b5-51f5-aff5-213f193123e7
       - name: "Build package"
         uses: julia-actions/julia-buildpkg@v1
       - name: "limit OpenMP threads"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -254,6 +254,9 @@ jobs:
         with:
           cache-name: julia-cache;workflow=${{ github.workflow }};julia=${{ matrix.julia-version }};arch=${{ runner.arch }}
           include-matrix: false
+      - name: "Clean polymake scratchspace for self-hosted macOS runners"
+        if: runner.environment == 'self-hosted'
+        run: rm -rf $JULIA_DEPOT_PATH/scratchspaces/d720cf60-89b5-51f5-aff5-213f193123e7
       - name: "Build package"
         uses: julia-actions/julia-buildpkg@v1
       - name: "limit OpenMP threads"


### PR DESCRIPTION
Should avoid issues when switching back and forth between versions using new and old dependencies.

(The files in that directory are rewritten on load anyway.)