### PR TITLE
Docs: Add some contact info for matroid developers

### DIFF
--- a/docs/src/Combinatorics/matroids.md
+++ b/docs/src/Combinatorics/matroids.md
@@ -136,6 +136,7 @@ quantum_automorphism_group(M::Matroid, structure::Symbol)
 ## Contact
 
 Please direct questions about this part of OSCAR to the following people:
+* [Dan Corey](https://www.danieljcorey.com/)
 * [Lukas Kühne](https://www.math.uni-bielefeld.de/~lkuehne/)
 * [Dante Luber](https://sites.google.com/view/dantelubermath/home)
 * [Benjamin Schröter](https://people.kth.se/~schrot/)

--- a/docs/src/Combinatorics/matroids.md
+++ b/docs/src/Combinatorics/matroids.md
@@ -132,3 +132,16 @@ augmented_chow_ring(M::Matroid)
 quantum_symmetric_group(n::Int)
 quantum_automorphism_group(M::Matroid, structure::Symbol)
 ```
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Lukas Kühne](https://www.math.uni-bielefeld.de/~lkuehne/)
+* [Dante Luber](https://sites.google.com/view/dantelubermath/home)
+* [Benjamin Schröter](https://people.kth.se/~schrot/)
+* [Marcel Wack](https://page.math.tu-berlin.de/~wack/)
+
+You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
+
+Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).
+


### PR DESCRIPTION
I added some developers contact info for the matroid part of Oscar, as these are not very active on slack, so that questions may reach them directly.

ping: @Sequenzer @danteluber @LukasKuehne @bschroter 

Please let me know if you don't want to be on there, but I think at least the original designers of this part should be here. Those that also wrote the book chapter on matroids.

Also ping @ulthiel since this was triggered by your question. ;)