### PR TITLE
Add group conversion docstrings

### DIFF
--- a/docs/src/Groups/fpgroup.md
+++ b/docs/src/Groups/fpgroup.md
@@ -107,7 +107,7 @@ Group homomorphism
 ```
 
 It is possible, if desired, to convert a group of another type into
-a finitely presented group using [`isomorphism`](@ref) or `fp_group`:
+a finitely presented group using [`isomorphism`](@ref isomorphism(::Type{T}, G::Group) where T <: Group) or `fp_group`:
 
 ```@docs
 fp_group

--- a/docs/src/Groups/fpgroup.md
+++ b/docs/src/Groups/fpgroup.md
@@ -106,6 +106,13 @@ Group homomorphism
   to permutation group of degree 5 and order 6
 ```
 
+It is possible, if desired, to convert a group of another type into
+a finitely presented group using [`isomorphism`](@ref) or `fp_group`:
+
+```@docs
+fp_group
+```
+
 ## Functions for elements of (subgroups of) finitely presented groups
 
 ```@docs
@@ -120,7 +127,6 @@ map_word(g::Union{FPGroupElem, SubFPGroupElem}, genimgs::Vector; genimgs_inv::Ve
 ```@docs
 free_group
 @free_group
-fp_group
 full_group(G::Union{SubFPGroup, SubPcGroup})
 relators(G::FPGroup)
 simplified_fp_group(G::FPGroup)

--- a/docs/src/Groups/fpgroup.md
+++ b/docs/src/Groups/fpgroup.md
@@ -120,6 +120,7 @@ map_word(g::Union{FPGroupElem, SubFPGroupElem}, genimgs::Vector; genimgs_inv::Ve
 ```@docs
 free_group
 @free_group
+fp_group
 full_group(G::Union{SubFPGroup, SubPcGroup})
 relators(G::FPGroup)
 simplified_fp_group(G::FPGroup)

--- a/docs/src/Groups/pcgroup.md
+++ b/docs/src/Groups/pcgroup.md
@@ -89,7 +89,7 @@ julia> describe(gg)
 ```
 
 Alternatively, one can convert another type of group into a pc group,
-either via [`isomorphism`](@ref) or using the `pc_group` command:
+either via [`isomorphism`](@ref isomorphism(::Type{T}, G::Group) where T <: Group) or using the `pc_group` command:
 
 ```@docs
 pc_group(G::T) where T <: Union{Group, FinGenAbGroup}

--- a/docs/src/Groups/pcgroup.md
+++ b/docs/src/Groups/pcgroup.md
@@ -132,6 +132,7 @@ map_word(g::Union{PcGroupElem, SubPcGroupElem}, genimgs::Vector; genimgs_inv::Ve
 ## Functions for (subgroups of) pc groups
 
 ```@docs
+pc_group(G::T) where T <: Union{Group, FinGenAbGroup}
 relators(G::PcGroup)
 hirsch_length(G::PcGroup)
 ```

--- a/docs/src/Groups/pcgroup.md
+++ b/docs/src/Groups/pcgroup.md
@@ -95,9 +95,7 @@ and let OSCAR compute a pc presentation for it.
 julia> g = symmetric_group(4)
 Symmetric group of degree 4
 
-julia> iso = isomorphism(PcGroup, g);
-
-julia> h = codomain(iso)
+julia> h = pc_group(g)
 Pc group of order 24
 ```
 

--- a/docs/src/Groups/pcgroup.md
+++ b/docs/src/Groups/pcgroup.md
@@ -88,8 +88,12 @@ julia> describe(gg)
 "S3"
 ```
 
-Alternatively, one can take a polycyclic group,
-and let OSCAR compute a pc presentation for it.
+Alternatively, one can convert another type of group into a pc group,
+either via `isomorphism` or using the `pc_group` command:
+
+```@docs
+pc_group(G::T) where T <: Union{Group, FinGenAbGroup}
+```
 
 ```jldoctest
 julia> g = symmetric_group(4)
@@ -130,7 +134,6 @@ map_word(g::Union{PcGroupElem, SubPcGroupElem}, genimgs::Vector; genimgs_inv::Ve
 ## Functions for (subgroups of) pc groups
 
 ```@docs
-pc_group(G::T) where T <: Union{Group, FinGenAbGroup}
 relators(G::PcGroup)
 hirsch_length(G::PcGroup)
 ```

--- a/docs/src/Groups/pcgroup.md
+++ b/docs/src/Groups/pcgroup.md
@@ -89,7 +89,7 @@ julia> describe(gg)
 ```
 
 Alternatively, one can convert another type of group into a pc group,
-either via `isomorphism` or using the `pc_group` command:
+either via [`isomorphism`](@ref) or using the `pc_group` command:
 
 ```@docs
 pc_group(G::T) where T <: Union{Group, FinGenAbGroup}


### PR DESCRIPTION
We have (for a bit) had methods for `permutation_group`, `pc_group`, `fp_group` that take a group and return an isomorphic group of the appropriate type. But their docstrings were not so far added to the manual.

Closes #3228 