### PR TITLE
Ideals: remove some type piracy & redundant `Ideal` method

### DIFF
--- a/experimental/InjectiveResolutions/src/MonoidAlgebra.jl
+++ b/experimental/InjectiveResolutions/src/MonoidAlgebra.jl
@@ -526,20 +526,6 @@ end
 dim(I::MonoidAlgebraIdeal) = krull_dim(underlying_ideal(I))
 krull_dim(I::MonoidAlgebraIdeal) = krull_dim(underlying_ideal(I))
 
-# some generic functionality which should probably be elsewhere
-function is_subset(I::T, J::T) where {T<:Ideal}
-  return all(x in J for x in gens(I))
-end
-
-function Base.:(==)(I::T, J::T) where {T <: Ideal}
-  return is_subset(I, J) && is_subset(J, I)
-end
-
-function Base.:*(I::T, J::T) where {T<:Ideal}
-  @assert base_ring(I) === base_ring(J)
-  return ideal(base_ring(I), [x*y for x in gens(I) for y in gens(J)])
-end
-
 # user facing constructor
 ideal(A::MonoidAlgebra, v::Vector) = MonoidAlgebraIdeal(A, elem_type(A)[A(x) for x in v])
 

--- a/src/Rings/localization_interface.jl
+++ b/src/Rings/localization_interface.jl
@@ -493,30 +493,7 @@ function ideal_membership(
   error("`ideal_membership(f, I)` has not been implemented for `f` of type $(typeof(f)) and `I` of type $(typeof(I))")
 end
 
-function issubset(I::IdealType, J::IdealType) where {IdealType<:AbsLocalizedIdeal}
-  return all(x->(x in J), gens(I))
-end
-
-function ==(I::IdealType, J::IdealType) where {IdealType<:AbsLocalizedIdeal}
-  return issubset(I, J) && issubset(J, I)
-end
-
 ### A catchall implementation for the ideal arithmetic
-# Return the product of the ideals `I` and `J`.
-function Base.:*(I::T, J::T) where {T<:AbsLocalizedIdeal}
-  W = base_ring(I)
-  W == base_ring(J) || error("the given ideals do not belong to the same ring")
-  new_gens = [ f*g for f in gens(I) for g in gens(J)]
-  return ideal(W, new_gens)
-end
-
-# Return the sum of the ideals `I` and `J`.
-function Base.:+(I::T, J::T) where {T<:AbsLocalizedIdeal}
-  W = base_ring(I)
-  W == base_ring(J) || error("the given ideals do not belong to the same ring")
-  return ideal(W, vcat(gens(I), gens(J)))
-end
-
 function Base.:^(I::T, k::IntegerUnion) where {T<:AbsLocalizedIdeal}
   k >= 0 || error("exponent must be non-negative")
   R = base_ring(I)

--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -2534,13 +2534,6 @@ function flag_pluecker_ideal(ring::MPolyRing{<: FieldElem}, dimensions::Vector{I
                    isGB=true))
 end
 
-# Since most ideals implement `==`, they have to implement the hash function.
-# See issue #4143 for problems entailed. Interestingly, this does not yet fix
-# the failure of unique! on lists of ideals.
-function hash(I::Ideal, c::UInt)
-  return hash(base_ring(I), c)
-end
-
 # Recognition of principal ideals
 function is_known(::typeof(is_principal), I::MPolyIdeal)
   is_one(ngens(I)) && return true

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -1927,24 +1927,6 @@ function ideal(
   return MPolyLocalizedIdeal(W, W.(gens(I)))
 end
 
-### additional functionality
-function issubset(I::IdealType, J::IdealType) where {IdealType<:MPolyLocalizedIdeal}
-  base_ring(I) == base_ring(J) || error("ideals do not belong to the same ring")
-  for g in gens(I)
-    g in J || return false
-  end
-  return true
-end
-
-function ==(I::IdealType, J::IdealType) where {IdealType<:MPolyLocalizedIdeal}
-  I === J && return true
-  (issubset(I, J) && issubset(J, I))
-end
-
-function +(I::IdealType, J::IdealType) where {IdealType<:MPolyLocalizedIdeal}
-  return ideal(base_ring(I), vcat(gens(I), gens(J)))
-end
-
 # TODO: The following method can probably be fine tuned for specific localizations.
 function intersect(I::IdealType, J::IdealType) where {IdealType<:MPolyLocalizedIdeal}
   return base_ring(I)(intersect(pre_saturated_ideal(I), pre_saturated_ideal(J)))


### PR DESCRIPTION
... for compat with a future AbstractAlgebra release containing https://github.com/Nemocas/AbstractAlgebra.jl/pull/2108