### PR TITLE
Add `ree_group` and `suzuki_group` constructors

### DIFF
--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -317,6 +317,52 @@ function mathieu_group(n::Int)
   return PermGroup(GAP.Globals.MathieuGroup(n), n)
 end
 
+@doc raw"""
+    ree_group(q::IntegerUnion)
+
+Return a group that is isomorphic to the Ree group of type $^2G_2(q)$,
+where `q` is of the form $3^{2k+1}$ for a positive integer $k$.
+
+The group is represented as a matrix group.
+
+# Examples
+```jldoctest
+julia> g = ree_group(27)
+Matrix group TODO
+
+julia> order(g)
+10073444472
+```
+"""
+function ree_group(q::IntegerUnion)
+  v, c = remove(q, 3)
+  @req isone(c) && isodd(v) && is_positive(v) "q must be of the form 3^(2k+1) for a positive integer k"
+  return MatrixGroup(GAP.Globals.ReeGroup(GAP.Int(q)))
+end
+
+@doc raw"""
+    suzuki_group(q::IntegerUnion)
+
+Return a the Suzuki group $Sz(q),
+where `q` is of the form $2^{2k+1}$ for a positive integer $k$.
+
+The group is represented as a matrix group.
+
+# Examples
+```jldoctest
+julia> g = suzuki_group(8)
+Matrix group TODO
+
+julia> order(g)
+29120
+```
+"""
+function suzuki_group(q::IntegerUnion)
+  v, c = remove(q, 2)
+  @req isone(c) && isodd(v) && is_positive(v) "q must be of the form 2^(2k+1) for a positive integer k"
+  return MatrixGroup(GAP.Globals.SuzukiGroup(GAP.Int(q)))
+end
+
 
 ################################################################################
 #

--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -328,7 +328,8 @@ The group is represented as a matrix group.
 # Examples
 ```jldoctest
 julia> g = ree_group(27)
-Matrix group TODO
+Matrix group of degree 7
+  over finite field of degree 3 and characteristic 3
 
 julia> order(g)
 10073444472
@@ -353,7 +354,8 @@ The group is represented as a matrix group.
 # Examples
 ```jldoctest
 julia> g = suzuki_group(8)
-Matrix group TODO
+Matrix group of degree 4
+  over finite field of degree 3 and characteristic 2
 
 julia> order(g)
 29120

--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -337,13 +337,15 @@ julia> order(g)
 function ree_group(q::IntegerUnion)
   v, c = remove(q, 3)
   @req isone(c) && isodd(v) && is_positive(v) "q must be of the form 3^(2k+1) for a positive integer k"
-  return MatrixGroup(GAP.Globals.ReeGroup(GAP.Int(q)))
+  G = matrix_group(GF(q), 7)
+  G.X = GAP.Globals.ReeGroup(Int(q))
+  return G
 end
 
 @doc raw"""
     suzuki_group(q::IntegerUnion)
 
-Return a the Suzuki group $Sz(q),
+Return a group that is isomorphic to the Suzuki group of type $^2B_2(q)$,
 where `q` is of the form $2^{2k+1}$ for a positive integer $k$.
 
 The group is represented as a matrix group.
@@ -360,7 +362,9 @@ julia> order(g)
 function suzuki_group(q::IntegerUnion)
   v, c = remove(q, 2)
   @req isone(c) && isodd(v) && is_positive(v) "q must be of the form 2^(2k+1) for a positive integer k"
-  return MatrixGroup(GAP.Globals.SuzukiGroup(GAP.Int(q)))
+  G = matrix_group(GF(q), 4)
+  G.X = GAP.Globals.SuzukiGroup(GAP.Int(q))
+  return G
 end
 
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1564,6 +1564,7 @@ export reduced_expressions
 export reduced_groebner_basis
 export reduced_scheme
 export reducible_fibers
+export ree_group
 export reflect, reflect!
 export reflection
 export register_morphism!
@@ -1749,6 +1750,7 @@ export subquotient
 export subscheme
 export subsystem
 export support_function
+export suzuki_group
 export syllables
 export sylow_subgroup
 export sylow_system, has_sylow_system, set_sylow_system


### PR DESCRIPTION
I decided to just allow the default matrix group representation. If wished for, I can also add the perm group variant (other filters seem to throw an error on the gap side).

Note that this does not work yet due to https://github.com/oscar-system/Oscar.jl/issues/5637#issuecomment-3636171802