### PR TITLE
Fix for deserializing certain dicts

### DIFF
--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/qsm_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/qsm_attributes.jl
@@ -75,7 +75,7 @@
 # (2) Attributes regarding the Ci-curves
 ######################################################################
 
-@define_model_attribute_getter((genera_of_ci_curves, Dict{MPolyDecRingElem,Int64}),
+@define_model_attribute_getter((genera_of_ci_curves, Dict{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}, Int64}),
   """
   ```jldoctest; setup = :(Oscar.ensure_qsmdb_installed())
   julia> using Random;
@@ -89,7 +89,7 @@
   """, "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.", genus_ci)
 
 @define_model_attribute_getter(
-  (degrees_of_kbar_restrictions_to_ci_curves, Dict{MPolyDecRingElem,Int64}),
+  (degrees_of_kbar_restrictions_to_ci_curves, Dict{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}, Int64}),
   """
   ```jldoctest; setup = :(Oscar.ensure_qsmdb_installed())
   julia> using Random;

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/qsm_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/qsm_attributes.jl
@@ -84,7 +84,7 @@
   Hypersurface model over a concrete base
 
   julia> typeof(genera_of_ci_curves(qsm_model))
-  Dict{MPolyDecRingElem, Int64}
+  Dict{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}, Int64}
   ```
   """, "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.", genus_ci)
 
@@ -98,7 +98,7 @@
   Hypersurface model over a concrete base
 
   julia> typeof(degrees_of_kbar_restrictions_to_ci_curves(qsm_model))
-  Dict{MPolyDecRingElem, Int64}
+  Dict{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}, Int64}
   ```
   """, "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.",
   degree_of_Kbar_of_tv_restricted_to_ci)

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/qsm_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/qsm_attributes.jl
@@ -75,7 +75,8 @@
 # (2) Attributes regarding the Ci-curves
 ######################################################################
 
-@define_model_attribute_getter((genera_of_ci_curves, Dict{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}, Int64}),
+@define_model_attribute_getter(
+  (genera_of_ci_curves, Dict{MPolyDecRingElem{QQFieldElem,QQMPolyRingElem},Int64}),
   """
   ```jldoctest; setup = :(Oscar.ensure_qsmdb_installed())
   julia> using Random;
@@ -89,7 +90,10 @@
   """, "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.", genus_ci)
 
 @define_model_attribute_getter(
-  (degrees_of_kbar_restrictions_to_ci_curves, Dict{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}, Int64}),
+  (
+    degrees_of_kbar_restrictions_to_ci_curves,
+    Dict{MPolyDecRingElem{QQFieldElem,QQMPolyRingElem},Int64},
+  ),
   """
   ```jldoctest; setup = :(Oscar.ensure_qsmdb_installed())
   julia> using Random;

--- a/experimental/FTheoryTools/src/serialization.jl
+++ b/experimental/FTheoryTools/src/serialization.jl
@@ -178,8 +178,15 @@ end
 ###########################################################################
 
 function _maybe_load(s::DeserializerState, ::Type{T}, key::Symbol, params::Dict) where {S, T <: Dict{String, S}}
-  dict_params = Dict(:key_params => nothing, :value_params => params[key])
-  return haskey(s, key) ? load_object(s, T, dict_params, key) : T()
+  if haskey(s, key)
+    if params[key] isa Dict
+      dict_params = params[key]
+    else
+      dict_params = Dict(:key_params => nothing, :value_params => params[key])
+    end
+    return load_object(s, T, dict_params, key)
+  end
+  return T()
 end
 
 function _load_common_parts(s::DeserializerState, params::Dict)

--- a/experimental/FTheoryTools/src/serialization.jl
+++ b/experimental/FTheoryTools/src/serialization.jl
@@ -194,6 +194,7 @@ function _load_common_parts(s::DeserializerState, params::Dict)
   ))
   def_poly = load_object(s, MPolyDecRingElem, params[ring_key], poly_key)
   @req coordinate_ring(params[:ambient_space]) == parent(def_poly) "Hypersurface equation not in Cox ring of toric ambient space"
+
   explicit_model_sections = _maybe_load(
     s,
     Dict{String,MPolyDecRingElem{QQFieldElem,QQMPolyRingElem}},

--- a/experimental/FTheoryTools/src/serialization.jl
+++ b/experimental/FTheoryTools/src/serialization.jl
@@ -137,9 +137,10 @@ function _fmodel_params(m::Union{WeierstrassModel,GlobalTateModel,HypersurfaceMo
   return filter(!isnothing, params)
 end
 
-type_params(m::T) where {T<:Union{WeierstrassModel,GlobalTateModel,HypersurfaceModel}} = TypeParams(
-  T, _fmodel_params(m)...
-)
+type_params(m::T) where {T<:Union{WeierstrassModel,GlobalTateModel,HypersurfaceModel}} =
+  TypeParams(
+    T, _fmodel_params(m)...
+  )
 
 ###########################################################################
 # (3) Saving

--- a/experimental/FTheoryTools/src/serialization.jl
+++ b/experimental/FTheoryTools/src/serialization.jl
@@ -137,10 +137,9 @@ function _fmodel_params(m::Union{WeierstrassModel,GlobalTateModel,HypersurfaceMo
   return filter(!isnothing, params)
 end
 
-type_params(m::T) where {T<:Union{WeierstrassModel,GlobalTateModel,HypersurfaceModel}} =
-  TypeParams(
-    T, _fmodel_params(m)...
-  )
+type_params(m::T) where {T<:Union{WeierstrassModel,GlobalTateModel,HypersurfaceModel}} = TypeParams(
+  T, _fmodel_params(m)...
+)
 
 ###########################################################################
 # (3) Saving
@@ -177,7 +176,9 @@ end
 # (4) Loading
 ###########################################################################
 
-function _maybe_load(s::DeserializerState, ::Type{T}, key::Symbol, params::Dict) where {S, T <: Dict{String, S}}
+function _maybe_load(
+  s::DeserializerState, ::Type{T}, key::Symbol, params::Dict
+) where {S,T<:Dict{String,S}}
   if haskey(s, key)
     if params[key] isa Dict
       dict_params = params[key]

--- a/experimental/FTheoryTools/src/serialization.jl
+++ b/experimental/FTheoryTools/src/serialization.jl
@@ -177,8 +177,9 @@ end
 # (4) Loading
 ###########################################################################
 
-function _maybe_load(s::DeserializerState, ::Type{T}, key::Symbol, params::Dict) where {T}
-  return haskey(s, key) ? load_object(s, T, params[key], key) : T()
+function _maybe_load(s::DeserializerState, ::Type{T}, key::Symbol, params::Dict) where {S, T <: Dict{String, S}}
+  dict_params = Dict(:key_params => nothing, :value_params => params[key])
+  return haskey(s, key) ? load_object(s, T, dict_params, key) : T()
 end
 
 function _load_common_parts(s::DeserializerState, params::Dict)

--- a/src/Serialization/containers.jl
+++ b/src/Serialization/containers.jl
@@ -534,6 +534,16 @@ end
 
 function load_object(s::DeserializerState,
                      T::Type{<:Dict{S, U}},
+                     params::Dict) where {S <: Union{String, Symbol}, U}
+  dict = T()
+  for k in keys(s.obj)
+    dict[S(k)] = load_object(s, U, params[:value_params], Symbol(k))
+  end
+  return dict
+end
+
+function load_object(s::DeserializerState,
+                     T::Type{<:Dict{S, U}},
                      params::Any) where {S, U}
   if params isa Dict
     if haskey(params, :value_params)

--- a/src/Serialization/containers.jl
+++ b/src/Serialization/containers.jl
@@ -412,8 +412,6 @@ function load_type_params(s::DeserializerState, T::Type{Dict})
         load_type_params(s, decode_type(s))
       end
 
-      isnothing(key_params) && return (S, U), value_params
-      isnothing(key_params) && isnothing(value_params) && return (S, U), nothing
       return (S, U), Dict(:key_params => key_params, :value_params => value_params)
     else
       S, key_params = load_node(s, :key_params) do _

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -865,17 +865,8 @@ _convert_override_params(tp::TypeParams{T, S}) where {T <: Set, S} = _convert_ov
 _convert_override_params(tp::TypeParams{<: NamedTuple, S}) where S = _convert_override_params(values(params(tp)))
 _convert_override_params(tp::TypeParams{<:Array, <:Tuple{Vararg{Pair}}}) = Dict(_convert_override_params(params(tp)))[:subtype_params]
 
-function _convert_override_params(tp::TypeParams{<:Dict, <:Tuple{Vararg{Pair}}})
-  vp_pair = filter(x -> :value_params == x.first, params(tp))
-  kp_pair = filter(x -> :key_params == x.first, params(tp))
-  if !isempty(vp_pair)
-    ov_params = Dict(k => _convert_override_params(v) for (k, v) in params(tp))
-    if type(first(kp_pair).second) <: Union{Symbol, String, Int}
-      return _convert_override_params(first(vp_pair).second)
-    end
-  else
-    return Dict(k => (type(v), _convert_override_params(v)) for (k, v) in params(tp))
-  end
+function _convert_override_params(tp::TypeParams{Dict{S, Any}, <:Tuple{Vararg{Pair}}}) where S <: Union{Int, Symbol, String}
+  return Dict(k => (type(v), _convert_override_params(v)) for (k, v) in params(tp))
 end
 
 _convert_override_params(obj::Any) = obj

--- a/test/Serialization/containers.jl
+++ b/test/Serialization/containers.jl
@@ -170,7 +170,6 @@
     @testset "(de)serialization Dict{Vector, T}" for V in (
       1, [matrix(ZZ, [1 2; 3 4]), matrix(ZZ, [6 5; 3 4])]
       )
-      
       original = Dict([1, 2] => V)
       test_save_load_roundtrip(path, original) do loaded
         @test original == loaded

--- a/test/Serialization/containers.jl
+++ b/test/Serialization/containers.jl
@@ -167,8 +167,11 @@
       end
     end
 
-    @testset "(de)serialization Dict{Vector, Int}" begin
-      original = Dict([1, 2] => 1)
+    @testset "(de)serialization Dict{Vector, T}" for V in (
+      1, [matrix(ZZ, [1 2; 3 4]), matrix(ZZ, [6 5; 3 4])]
+      )
+      
+      original = Dict([1, 2] => V)
       test_save_load_roundtrip(path, original) do loaded
         @test original == loaded
       end


### PR DESCRIPTION
can now load `Dict{Vector{Int}, Vector{Matrix}}` and similar types where the key parameters are nothing but there are value parameters.

Cleaned up  deserialization of Dicts a bit and need to do some rewiring in FTheory tools