### PR TITLE
fix: product of polyhedra with lineality

### DIFF
--- a/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
+++ b/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
@@ -467,7 +467,7 @@ function product(P::Polyhedron{T}, Q::Polyhedron{U}) where {T<:scalar_types,U<:s
   n = ambient_dim(P)
   m = ambient_dim(Q)
   LPQ = block_diagonal_matrix([matrix(K, LP), matrix(K, LQ)])
-  PQlin = convex_hull(zero_matrix(K, 1, n + m), zero_matrix(K, 0, n + m), LPQ)
+  PQlin = convex_hull(zero_matrix(K, 1, n + m), zero_matrix(K, 0, n + m), LPQ; non_redundant=true)
 
   return PQmod + PQlin
 end

--- a/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
+++ b/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
@@ -466,8 +466,7 @@ function product(P::Polyhedron{T}, Q::Polyhedron{U}) where {T<:scalar_types,U<:s
   # Construct the product of the linealities
   n = ambient_dim(P)
   m = ambient_dim(Q)
-  LPQ = vcat(Vector{elem_type(K)}[vcat(lp, zeros(elem_type(K), m)) for lp in LP],
-    Vector{elem_type(K)}[vcat(zeros(elem_type(K), n), lq) for lq in LQ])
+  LPQ = block_diagonal_matrix([matrix(K, LP), matrix(K, LQ)])
   PQlin = convex_hull(zero_matrix(K, 1, n + m), zero_matrix(K, 0, n + m), LPQ)
 
   return PQmod + PQlin

--- a/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
+++ b/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
@@ -475,7 +475,7 @@ end
 function peel_lineality(P::Polyhedron)
   V, L = minimal_faces(P)
   R, _ = rays_modulo_lineality(P)
-  Q = convex_hull(V, R)
+  Q = convex_hull(V, R; non_redundant=true)
   return Q, L
 end
 

--- a/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
+++ b/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
@@ -461,14 +461,14 @@ function product(P::Polyhedron{T}, Q::Polyhedron{U}) where {T<:scalar_types,U<:s
   Pmod, LP = peel_lineality(P)
   Qmod, LQ = peel_lineality(Q)
   PQmod = product(Pmod, Qmod)
-  TU = scalar_type(PQmod)
+  K = coefficient_field(PQmod)
 
   # Construct the product of the linealities
   n = ambient_dim(P)
   m = ambient_dim(Q)
-  LPQ = vcat(Vector{TU}[vcat(lp, zeros(TU, m)) for lp in LP],
-    Vector{TU}[vcat(zeros(TU, n), lq) for lq in LQ])
-  PQlin = convex_hull(zeros(TU, 1, n + m), zeros(TU, 0, n + m), LPQ)
+  LPQ = vcat(Vector{elem_type(K)}[vcat(lp, zeros(elem_type(K), m)) for lp in LP],
+    Vector{elem_type(K)}[vcat(zeros(elem_type(K), n), lq) for lq in LQ])
+  PQlin = convex_hull(zero_matrix(K, 1, n + m), zero_matrix(K, 0, n + m), LPQ)
 
   return PQmod + PQlin
 end

--- a/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
+++ b/src/PolyhedralGeometry/Polyhedron/standard_constructions.jl
@@ -467,7 +467,9 @@ function product(P::Polyhedron{T}, Q::Polyhedron{U}) where {T<:scalar_types,U<:s
   n = ambient_dim(P)
   m = ambient_dim(Q)
   LPQ = block_diagonal_matrix([matrix(K, LP), matrix(K, LQ)])
-  PQlin = convex_hull(zero_matrix(K, 1, n + m), zero_matrix(K, 0, n + m), LPQ; non_redundant=true)
+  PQlin = convex_hull(
+    zero_matrix(K, 1, n + m), zero_matrix(K, 0, n + m), LPQ; non_redundant=true
+  )
 
   return PQmod + PQlin
 end

--- a/test/PolyhedralGeometry/polyhedron.jl
+++ b/test/PolyhedralGeometry/polyhedron.jl
@@ -591,6 +591,19 @@
     end
   end
 
+  @testset "Products of polyhedra" begin
+    pt = convex_hull(T,[[0]])
+    ray = polyhedron(T,[[1]],[0])
+    line = polyhedron(T,[[0]],[0])
+
+    @test dim(pt*pt) == 0 && lineality_dim(pt*pt) == 0
+    @test dim(pt*ray) == 1 && lineality_dim(pt*ray) == 0
+    @test dim(pt*line) == 1 && lineality_dim(pt*line) == 1
+    @test dim(ray*ray) == 2 && lineality_dim(ray*ray) == 0
+    @test dim(ray*line) == 2 && lineality_dim(ray*line) == 1
+    @test dim(line*line) == 2 && lineality_dim(line*line) == 2
+  end
+
   if T == EmbeddedNumFieldElem{AbsSimpleNumFieldElem}
     @testset "Dodecahedron" begin
       D = polyhedron(Polymake.polytope.dodecahedron())

--- a/test/PolyhedralGeometry/polyhedron.jl
+++ b/test/PolyhedralGeometry/polyhedron.jl
@@ -592,16 +592,16 @@
   end
 
   @testset "Products of polyhedra" begin
-    pt = convex_hull(T,[[0]])
-    ray = polyhedron(T,[[1]],[0])
-    line = polyhedron(T,[[0]],[0])
+    pt = convex_hull(T, [[0]])
+    ray = polyhedron(T, [[1]], [0])
+    line = polyhedron(T, [[0]], [0])
 
-    @test dim(pt*pt) == 0 && lineality_dim(pt*pt) == 0
-    @test dim(pt*ray) == 1 && lineality_dim(pt*ray) == 0
-    @test dim(pt*line) == 1 && lineality_dim(pt*line) == 1
-    @test dim(ray*ray) == 2 && lineality_dim(ray*ray) == 0
-    @test dim(ray*line) == 2 && lineality_dim(ray*line) == 1
-    @test dim(line*line) == 2 && lineality_dim(line*line) == 2
+    @test dim(pt * pt) == 0 && lineality_dim(pt * pt) == 0
+    @test dim(pt * ray) == 1 && lineality_dim(pt * ray) == 0
+    @test dim(pt * line) == 1 && lineality_dim(pt * line) == 1
+    @test dim(ray * ray) == 2 && lineality_dim(ray * ray) == 0
+    @test dim(ray * line) == 2 && lineality_dim(ray * line) == 1
+    @test dim(line * line) == 2 && lineality_dim(line * line) == 2
   end
 
   if T == EmbeddedNumFieldElem{AbsSimpleNumFieldElem}

--- a/test/PolyhedralGeometry/polyhedron.jl
+++ b/test/PolyhedralGeometry/polyhedron.jl
@@ -88,6 +88,7 @@
     @test intersect(Ps...) == Q0
     @test minkowski_sum(Q0, Q0) == convex_hull(f, 2 * pts)
     @test Q0 + Q0 == minkowski_sum(Q0, Q0)
+    @test Q1 * Q2 == product(Q1, Q2)
     @test f_vector(Pos) == [1, 3, 3]
     @test f_vector(L) == [0, 1, 2]
     @test codim(square) == 0

--- a/test/PolyhedralGeometry/polyhedron.jl
+++ b/test/PolyhedralGeometry/polyhedron.jl
@@ -592,9 +592,9 @@
   end
 
   @testset "Products of polyhedra" begin
-    pt = convex_hull(T, [[0]])
-    ray = polyhedron(T, [[1]], [0])
-    line = polyhedron(T, [[0]], [0])
+    pt = convex_hull(f, [[0]])
+    ray = polyhedron(f, [[1]], [0])
+    line = polyhedron(f, [[0]], [0])
 
     @test dim(pt * pt) == 0 && lineality_dim(pt * pt) == 0
     @test dim(pt * ray) == 1 && lineality_dim(pt * ray) == 0


### PR DESCRIPTION
This is a quick julia-side fix for https://github.com/oscar-system/Oscar.jl/issues/5370

There are probably more efficient ways to implement it in polymake proper (especially when the polyhedra are given in H representation).