### PR TITLE
Revert "tests: disable 'Additional rational_solutions tests' until #5623 is solved (#5628)"

### DIFF
--- a/test/Rings/solving.jl
+++ b/test/Rings/solving.jl
@@ -112,8 +112,6 @@ end
   @test length(v) == 5
 end
 
-#= FIXME: disabled until #5623 is fixed in msolve
-
 @testset "Additional rational_solutions tests" begin
   let
     K = algebraic_closure(QQ)
@@ -248,4 +246,3 @@ end
     @test length(pts) > 0 && length(pts) == 1
   end
 end
-=#


### PR DESCRIPTION
msolve 0.9.4 is available now and should fix this.

No failures in a loop with these tests re-enabled (500 iterations so far).

Can you remove the debug output below in the next release?
```
Restarting with another random linear form
Restarting with a non-random linear form
Restarting with another random linear form
Restarting with a non-random linear form
Restarting with another random linear form
Restarting with a non-random linear formTest Summary:                       | Pass  Total  Time
Additional rational_solutions tests |   14     14  0.3s
```
cc: @ederc 

reverts: #5628
fixes #5623 