### PR TITLE
orbit_representatives_and_stabilizers via permutation groups

### DIFF
--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -1664,7 +1664,20 @@ julia> print(sort([index(G, stab) for (U, stab) in res]))
 ZZRingElem[12, 12, 16]
 ```
 """
-function orbit_representatives_and_stabilizers(G::MatrixGroup{E}, k::Int) where E <: FinFieldElem
+function orbit_representatives_and_stabilizers(G::MatrixGroup{E}, k::Int; algorithm=:default) where E <: FinFieldElem
+  if algorithm==:default 
+    algorithm=:perm 
+  end
+  if algorithm==:gset
+    return _orbit_representatives_and_stabilizers_gset_gap(G, k)
+  elseif algorithm==:perm
+    return _orbit_representatives_and_stabilizers_perm(G, k)
+  else 
+    error("unknown algorithm")
+  end
+end
+
+function _orbit_representatives_and_stabilizers_gset_gap(G::MatrixGroup{E}, k::Int) where E <: FinFieldElem
   n = degree(G)
   V = vector_space(base_ring(G), n)
   k == 0 && return [(sub(V, [])[1], G)]
@@ -1677,3 +1690,51 @@ function orbit_representatives_and_stabilizers(G::MatrixGroup{E}, k::Int) where 
   stabs = [_as_subgroup_bare(G, GAP.Globals.Stabilizer(GapObj(G), v, GAP.Globals.OnSubspacesByCanonicalBasis)) for v in orbreps_gap]::Vector{typeof(G)}
   return [(orbreps2[i], stabs[i]) for i in 1:length(stabs)]
 end
+
+function _orbit_representatives_and_stabilizers_perm(G::T, k::Int; do_stab::Bool=true) where {T<:MatrixGroup{<:FinFieldElem}}
+  gl = general_linear_group(degree(G), base_ring(G))
+  rep_gl, stab_gl = _orbit_representatives_and_stabilizers_GLn(base_ring(G), degree(G), k)
+  to_perm = isomorphism(PermGroup, gl)
+  gl_perm = codomain(to_perm)
+  from_perm = inv(to_perm)
+  Gperm,_ = to_perm(G)
+  reps = Tuple{dense_matrix_type(base_ring(G)),T}[]
+  stab_perm_gl, _ = to_perm(sub(gl, gl.(stab_gl))[1])
+  dc = double_cosets(gl_perm, stab_perm_gl, Gperm)
+  for SxG in dc
+    xp = representative(SxG)
+    x = preimage(to_perm, xp)
+    Hx = rep_gl*matrix(x)
+    if do_stab
+      stab_G_perm,i1,i2 = intersect(stab_perm_gl^xp, Gperm)
+      stab = from_perm(i2(stab_G_perm)[1])
+      push!(reps, (Hx, stab[1]))
+    else
+      push!(reps, (Hx, G))
+    end
+  end
+  return reps
+end
+
+function _orbit_representatives_and_stabilizers_GLn(K::T, n::Int, k::Int) where T <: FinField 
+  # Representative of the unique GL_n(K) orbit of rank k
+  rep = zero_matrix(K, k, n)
+  for i in 1:k 
+    rep[i,i] = 1
+  end 
+  E = identity_matrix(K, n)
+  _gens = dense_matrix_type(T)[] 
+  for g in gens(GL(k, K))
+    EE = deepcopy(E) 
+    EE[1:k,1:k] = matrix(g)
+    push!(_gens, EE)
+  end 
+  for g in gens(GL(n - k, K))
+    EE = deepcopy(E) 
+    EE[k+1:end,k+1:end] = matrix(g)
+    push!(_gens, EE)
+  end
+  E[k+1,1] = 1
+  push!(_gens, E)
+  return rep, _gens
+end 

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -1671,7 +1671,11 @@ function orbit_representatives_and_stabilizers(G::MatrixGroup{E}, k::Int; algori
   if algorithm==:gset
     return _orbit_representatives_and_stabilizers_gset_gap(G, k)
   elseif algorithm==:perm
-    return _orbit_representatives_and_stabilizers_perm(G, k)
+    n = degree(G)
+    V = vector_space(base_ring(G), n)
+    k == 0 && return [(sub(V, [])[1], G)]
+    _repstab = _orbit_representatives_and_stabilizers_perm(G, k)
+    return [(sub(V, [V([M[i,j] for j in 1:n]) for i in 1:k])[1],S) for (M,S) in _repstab]
   else 
     error("unknown algorithm")
   end
@@ -1723,18 +1727,24 @@ function _orbit_representatives_and_stabilizers_GLn(K::T, n::Int, k::Int) where 
     rep[i,i] = 1
   end 
   E = identity_matrix(K, n)
-  _gens = dense_matrix_type(T)[] 
-  for g in gens(GL(k, K))
-    EE = deepcopy(E) 
-    EE[1:k,1:k] = matrix(g)
-    push!(_gens, EE)
+  _gens = dense_matrix_type(T)[]
+  if k>0
+    for g in gens(GL(k, K))
+      EE = deepcopy(E) 
+      EE[1:k,1:k] = matrix(g)
+      push!(_gens, EE)
+    end
   end 
-  for g in gens(GL(n - k, K))
-    EE = deepcopy(E) 
-    EE[k+1:end,k+1:end] = matrix(g)
-    push!(_gens, EE)
+  if k < n
+    for g in gens(GL(n - k, K))
+      EE = deepcopy(E) 
+      EE[k+1:end,k+1:end] = matrix(g)
+      push!(_gens, EE)
+    end
+  end 
+  if 0<k<n 
+    E[k+1,1] = 1
+    push!(_gens, E)
   end
-  E[k+1,1] = 1
-  push!(_gens, E)
   return rep, _gens
 end 


### PR DESCRIPTION
A small speedup for rank 2 subspaces
```
julia> G = change_base_ring(GF(2),orthogonal_group(root_lattice(:E,8)))
Matrix group of degree 8
  over prime field of characteristic 2

julia> @time orbit_representatives_and_stabilizers(G,2;algorithm=:gset)
  3.178908 seconds (17.17 M allocations: 993.945 MiB, 18.43% gc time, 24.56% compilation time)

julia> @time orbit_representatives_and_stabilizers(G,2;algorithm=:perm);
  1.992775 seconds (4.83 M allocations: 1.516 GiB, 56.67% gc time, 3.23% compilation time: 100% of which was recompilation)
```
A factor of `8` for larger ones.
```
julia> @time orbit_representatives_and_stabilizers(G,3;algorithm=:perm)
 16.631597 seconds (69.24 M allocations: 16.612 GiB, 23.58% gc time)

julia> @time orbit_representatives_and_stabilizers(G,3;algorithm=:gset)
138.655206 seconds (181.72 M allocations: 9.750 GiB, 2.63% gc time, 0.42% compilation time)
```
Magma is still faster by a factor of `10`. (using MagmaCall.jl)
```
julia> @time Oscar.orbit_representatives_and_stabilizers_magma(G,3)
  0.196962 seconds (74.12 k allocations: 4.044 MiB)

julia> @time Oscar.orbit_representatives_and_stabilizers_magma(G,4)
  0.455924 seconds (99.45 k allocations: 6.118 MiB)
```
And can do stuff that won't terminate in Oscar:
```
julia> G = change_base_ring(GF(3),orthogonal_group(root_lattice(:E,8)))
Matrix group of degree 8
  over prime field of characteristic 3

julia> @time Oscar.orbit_representatives_and_stabilizers_magma(G,2);
  1.319443 seconds (127.67 k allocations: 11.775 MiB)

julia> @time Oscar.orbit_representatives_and_stabilizers_magma(G,3)
 62.540479 seconds (220.21 k allocations: 24.219 MiB)

julia> @time Oscar.orbit_representatives_and_stabilizers_magma(G,4)
320.437118 seconds (1.06 M allocations: 141.158 MiB, 0.08% gc time, 0.01% compilation time)
```
If we use a bit of extra knowledge (i.e. a tighter ambient group (GO instead of GL)), we get something usable. 
Which is sometimes faster sometimes slower than magma between `1/2` and `120`.
But this requires a field of odd prime order because I was lazy (and even characteristic is a nightmare).
```
julia> G2,_ = image_in_Oq(rescale(root_lattice(:E,8),3));

julia> T = domain(G2); O = orthogonal_group(T);

julia> phi = hom(G2,O,O.(gens(G2));check=false);

julia> @time Oscar._subspaces_representatives_and_stabilizers_elementary_odd(T,phi, 2)
124.235973 seconds (453.92 M allocations: 125.493 GiB, 25.23% gc time)

julia> @time Oscar._subspaces_representatives_and_stabilizers_elementary_odd(T,phi, 3)
118.189768 seconds (373.98 M allocations: 143.048 GiB, 27.61% gc time)

julia> @time Oscar._subspaces_representatives_and_stabilizers_elementary_odd(T,phi, 4; do_stab=true)
165.048095 seconds (467.02 M allocations: 185.208 GiB, 24.27% gc time)
``` 