### PR TITLE
pushforward flag bundles; independently: more examples

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -2097,6 +2097,16 @@
   primaryclass  = {cs.DS}
 }
 
+@Article{KP07,
+  author        = {Albrecht Klemm and Rahul Pandharipande},
+  title         = {Enumerative Geometry of Calabi-Yau 4-Folds},
+  journal       = {Communications in Mathematical Physics},
+  volume        = {281},
+  pages         = {621--653},
+  year          = {2007},
+  url           = {https://api.semanticscholar.org/CorpusID:16952616}
+}
+
 @Book{KR05,
   author        = {Kreuzer, Martin and Robbiano, Lorenzo},
   title         = {Computational commutative algebra. II},

--- a/experimental/IntersectionTheory/docs/src/examples.md
+++ b/experimental/IntersectionTheory/docs/src/examples.md
@@ -9,8 +9,16 @@ DocTestSetup = Oscar.doctestsetup()
 #### How Many Lines in $\mathbb P^3$ Meet Four General Lines in $\mathbb P^3$?
 
 ```jldoctest
-julia> G = abstract_grassmannian(2,4)
+julia> G = abstract_grassmannian(2, 4)
 AbstractVariety of dim 4
+
+julia> schubert_classes(G)
+5-element Vector{Vector{MPolyQuoRingElem{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}}}}:
+ [1]
+ [-c[1]]
+ [c[1]^2 - c[2], c[2]]
+ [-c[1]*c[2]]
+ [c[2]^2]
 
 julia> s1 = schubert_class(G, 1)
 -c[1]
@@ -20,35 +28,49 @@ julia> integral(s1^4)
 
 ```
 
-#### How Many Conics in $\mathbb P^3$ Meet Eight General Lines in $\mathbb P^3$?
+#### How many lines in $\mathbb P^3$ are secant to two General Twisted Cubic Curves in $\mathbb P^3$?
 
 ```jldoctest
-julia> G = abstract_grassmannian(3, 4)
-AbstractVariety of dim 3
+julia> G = abstract_grassmannian(2, 4)
+AbstractVariety of dim 4
 
-julia> USBd = dual(tautological_bundles(G)[1])
-AbstractBundle of rank 3 on AbstractVariety of dim 3
+julia> s2 = schubert_class(G, 2)
+c[1]^2 - c[2]
 
-julia> F = symmetric_power(USBd, 2)
-AbstractBundle of rank 6 on AbstractVariety of dim 3
+julia> s11 = schubert_class(G, [1, 1])
+c[2]
 
-julia> PF = projective_bundle(F) # the parameter space of conics in P3
-AbstractVariety of dim 8
+julia> integral((s2+3*s11)^2)
+10
 
-julia> UQB = tautological_bundles(G)[2]
-AbstractBundle of rank 1 on AbstractVariety of dim 3
+```
 
-julia> p = pullback(structure_map(PF), chern_class(UQB, 1))
+#### How Many Lines in $\mathbb P^4$ Meet six General Planes in $\mathbb P^4$?
+
+```jldoctest
+julia> G = abstract_grassmannian(2, 5)
+
+AbstractVariety of dim 6
+
+julia> s1 = schubert_class(G, 1)
 -c[1]
 
-julia> Z = dual(tautological_bundles(PF)[1])
-AbstractBundle of rank 1 on AbstractVariety of dim 8
+julia> integral(s1^6)
+5
 
-julia> z = chern_class(Z, 1)
-z
+```
 
-julia> integral((2*p + z)^8)
-92
+#### How Many Planes in $\mathbb P^4$ Meet six General Lines in $\mathbb P^4$?
+
+```jldoctest
+julia> G = abstract_grassmannian(3, 5)
+AbstractVariety of dim 6
+
+julia> s1 = schubert_class(G, 1)
+-c[1]
+
+julia> integral(s1^6)
+5
 
 ```
 
@@ -83,6 +105,76 @@ julia> integral((6*HBl-2*e)^5)
 
 ```
 
+#### How Many Conics Meet Eight General Lines in $\mathbb P^3$?
+
+```jldoctest
+julia> G = abstract_grassmannian(3, 4)
+AbstractVariety of dim 3
+
+julia> USBd = dual(tautological_bundles(G)[1])
+AbstractBundle of rank 3 on AbstractVariety of dim 3
+
+julia> F = symmetric_power(USBd, 2)
+AbstractBundle of rank 6 on AbstractVariety of dim 3
+
+julia> PF = projective_bundle(F) # the parameter space of conics in P3
+AbstractVariety of dim 8
+
+julia> UQB = tautological_bundles(G)[2]
+AbstractBundle of rank 1 on AbstractVariety of dim 3
+
+julia> p = pullback(structure_map(PF), chern_class(UQB, 1))
+-c[1]
+
+julia> Z = dual(tautological_bundles(PF)[1])
+AbstractBundle of rank 1 on AbstractVariety of dim 8
+
+julia> z = chern_class(Z, 1)
+z
+
+julia> integral((2*p + z)^8)
+92
+
+```
+
+#### How Many Conics lie on the General Cubic Surface and meet a General Line in $\mathbb P^3$?
+
+```jldoctest
+julia> G = abstract_grassmannian(3, 4)
+AbstractVariety of dim 3
+
+julia> USBd = dual(tautological_bundles(G)[1])
+AbstractBundle of rank 3 on AbstractVariety of dim 3
+
+julia> F = symmetric_power(USBd, 2)
+AbstractBundle of rank 6 on AbstractVariety of dim 3
+
+julia> PF = projective_bundle(F)
+AbstractVariety of dim 8
+
+julia> UQB = tautological_bundles(G)[2]
+AbstractBundle of rank 1 on AbstractVariety of dim 3
+
+julia> p = pullback(structure_map(PF), chern_class(UQB, 1))
+-c[1]
+
+julia> Z = dual(tautological_bundles(PF)[1])
+AbstractBundle of rank 1 on AbstractVariety of dim 8
+
+julia> z = chern_class(Z, 1)
+z
+
+julia> E = symmetric_power(USBd , 3)-USBd*OO(PF, -1)
+AbstractBundle of rank 7 on AbstractVariety of dim 8
+
+julia> C = top_chern_class(E)
+27*z^5*c[2] - 135*z^4*c[3]
+
+julia> integral(C*(2*p + z))
+81
+
+```
+
 #### How Many Conics lie on the General Quintic Hypersurface in $\mathbb P^4$?
 
 ```jldoctest
@@ -106,8 +198,27 @@ julia> integral(top_chern_class(A))
 
 ```
 
+#### How Many Elliptic Cubics lie on the General Sextic Hypersurface in $\mathbb P^5$?
 
+See [KP07](@cite).
 
+```jldoctest
+julia> G = abstract_grassmannian(3, 6);
 
+julia> USBd = dual(tautological_bundles(G)[1])
+AbstractBundle of rank 3 on AbstractVariety of dim 9
 
+julia> F = symmetric_power(USBd, 3)
+AbstractBundle of rank 10 on AbstractVariety of dim 9
+
+julia> PF = projective_bundle(F)
+AbstractVariety of dim 18
+
+julia> E = symmetric_power(USBd, 6)-F*OO(PF, -1)
+AbstractBundle of rank 18 on AbstractVariety of dim 18
+
+julia> integral(top_chern_class(E))
+2734099200
+
+```
 

--- a/experimental/IntersectionTheory/docs/src/examples.md
+++ b/experimental/IntersectionTheory/docs/src/examples.md
@@ -49,7 +49,6 @@ julia> integral((s2+3*s11)^2)
 
 ```jldoctest
 julia> G = abstract_grassmannian(2, 5)
-
 AbstractVariety of dim 6
 
 julia> s1 = schubert_class(G, 1)

--- a/experimental/IntersectionTheory/src/schubert.jl
+++ b/experimental/IntersectionTheory/src/schubert.jl
@@ -29,6 +29,8 @@ julia> s21 = schubert_class(G, [2, 1])
 julia> s22 = schubert_class(G, [2, 2])
 c[2]^2
 
+julia> # Pieri's formula:
+
 julia> s1*s1 == s2+s11
 true
 
@@ -57,6 +59,8 @@ julia> chern_class(Q, 3)
 -c[1]^3 + 2*c[1]*c[2]
 
 ```
+
+*Number of Lines in $\mathbb P^3$ Meeting Four General Lines in $\mathbb P^3$*
 
 ```jldoctest
 julia> G = abstract_grassmannian(2,4)


### PR DESCRIPTION
This offers another way of computing pushforwards along the structure map of a flag bundle. It is meant to be a basis for further discussions on the subject and for creating examples.