### PR TITLE
Speed up `_overlattice_stabilizer` over fields

### DIFF
--- a/src/Groups/matrices/isometry_group.jl
+++ b/src/Groups/matrices/isometry_group.jl
@@ -375,7 +375,7 @@ function _overlattice_stabilizer(G::MatrixGroup{ZZRingElem,ZZMatrix}, S::ZZLat, 
     mats = GapObj([GapObj(x) for x in gens(G)])
     Gnice = GAP.Globals.NiceObject(GapObj(G))
     # FIXME: direct conversion from fpMatrix to GAP matrix seems to be missing?
-    BLmod_gap = GapObj(lift(BLmod)) * GAP.Globals.Z(GapObj(p))
+    BLmod_gap = GapObj(lift(BLmod)) * GAP.Globals.Z(GapObj(p))^0
     GAP.Globals.ConvertToMatrixRep(BLmod_gap)
     st = GAP.Globals.Stabilizer(Gnice, BLmod_gap, GAP.Globals.GeneratorsOfGroup(Gnice), mats, GAP.Globals.OnSubspacesByCanonicalBasis)
 

--- a/src/Groups/matrices/isometry_group.jl
+++ b/src/Groups/matrices/isometry_group.jl
@@ -394,7 +394,12 @@ function on_howell_form(M::zzModMatrix, g::MatrixGroupElem{ZZRingElem,ZZMatrix})
   return on_howell_form(M, matrix(base_ring(M), matrix(g)))
 end
 
-function on_howell_form(M::zzModMatrix, g::Union{ZZMatrix,zzModMatrix})
+function on_howell_form(M::zzModMatrix, g::ZZMatrix)
+  _g = map_entries(base_ring(M), g)
+  return on_howell_form(M, g)
+end
+
+function on_howell_form(M::zzModMatrix, g::zzModMatrix)
   Mg = M * g
   howell_form!(Mg)
   return Mg

--- a/src/Groups/matrices/isometry_group.jl
+++ b/src/Groups/matrices/isometry_group.jl
@@ -362,10 +362,9 @@ function _overlattice_stabilizer(G::MatrixGroup{ZZRingElem,ZZMatrix}, S::ZZLat, 
     # trivial nothing to do
     return G, hom(G,G,gens(G);check=false)
   end
-  BL = zero_matrix(ZZ, nrows(_BL), ncols(_BL))
-  BL = mul!(BL, _BL, n)
+  BL = numerator(_BL)
   if is_prime(n)
-    # up to 20% fewer allocations and slightly faster
+    # Fewer allocations and slightly faster
     p = n
     R = fpField(UInt(p))
     BLmod = change_base_ring(R, BL)

--- a/src/Groups/matrices/isometry_group.jl
+++ b/src/Groups/matrices/isometry_group.jl
@@ -357,41 +357,65 @@ end
 # stabilizer of L in G < O(L)
 function _overlattice_stabilizer(G::MatrixGroup{ZZRingElem,ZZMatrix}, S::ZZLat, L::ZZLat)
   _BL = coordinates(basis_matrix(L),S)
-  n = denominator(_BL) 
+  n = denominator(_BL)
   if n == 1
     # trivial nothing to do
     return G, hom(G,G,gens(G);check=false)
   end
+  BL = zero_matrix(ZZ, nrows(_BL), ncols(_BL))
+  BL = mul!(BL, _BL, n)
   if is_prime(n)
     # up to 20% fewer allocations and slightly faster
     p = n
-    BL = ZZ.(n*_BL)
     R = fpField(UInt(p))
     BLmod = change_base_ring(R, BL)
     r = rref!(BLmod)
     BLmod = BLmod[1:r,:]
-    stab = stabilizer(G, BLmod, on_rref)
-  else 
-    BL = ZZ.(n*_BL)
+
+    mats = GapObj([GapObj(x) for x in gens(G)])
+    Gnice = GAP.Globals.NiceObject(GapObj(G))
+    # FIXME: direct conversion from fpMatrix to GAP matrix seems to be missing?
+    BLmod_gap = GapObj(lift(BLmod)) * GAP.Globals.Z(GapObj(p))
+    GAP.Globals.ConvertToMatrixRep(BLmod_gap)
+    st = GAP.Globals.Stabilizer(Gnice, BLmod_gap, GAP.Globals.GeneratorsOfGroup(Gnice), mats, GAP.Globals.OnSubspacesByCanonicalBasis)
+
+    mono = GAP.Globals.NiceMonomorphism(GapObj(G))
+    st_mat = GAP.Globals.PreImage(mono, st)
+    stab = _as_subgroup(G, st_mat)
+  else
     R,iR = residue_ring(ZZ, Int(n))
     BLmod = change_base_ring(R, BL)
     howell_form!(BLmod)
     stab = stabilizer(G, BLmod, on_howell_form)
-  end 
+  end
   return stab
-end 
+end
 
 function on_howell_form(M::zzModMatrix, g::MatrixGroupElem{ZZRingElem,ZZMatrix})
-  Mg = M*matrix(g)
+  return on_howell_form(M, matrix(base_ring(M), matrix(g)))
+end
+
+function on_howell_form(M::zzModMatrix, g::ZZMatrix)
+  Mg = M * g
   howell_form!(Mg)
   return Mg
-end 
+end
 
 function on_rref(M::fpMatrix, g::MatrixGroupElem{ZZRingElem,ZZMatrix})
-  Mg = M*matrix(g)
+  Mg = M * matrix(base_ring(M), matrix(g))
   rref!(Mg)
   return Mg
-end 
+end
+
+function on_rref(M::fpMatrix, g::MatrixGroupElem{fpFieldElem, fpMatrix})
+  return on_rref(M, matrix(g))
+end
+
+function on_rref(M::fpMatrix, g::fpMatrix)
+  Mg = M * g
+  rref!(Mg)
+  return Mg
+end
 
 
 automorphism_group(L::Hecke.AbstractLat; kwargs...) = isometry_group(L; kwargs...)

--- a/src/Groups/matrices/isometry_group.jl
+++ b/src/Groups/matrices/isometry_group.jl
@@ -394,7 +394,7 @@ function on_howell_form(M::zzModMatrix, g::MatrixGroupElem{ZZRingElem,ZZMatrix})
   return on_howell_form(M, matrix(base_ring(M), matrix(g)))
 end
 
-function on_howell_form(M::zzModMatrix, g::ZZMatrix)
+function on_howell_form(M::zzModMatrix, g::Union{ZZMatrix,zzModMatrix})
   Mg = M * g
   howell_form!(Mg)
   return Mg


### PR DESCRIPTION
This is a draft because there are still bits at the end that need to cleaned up or even reverted (e.g. once <https://github.com/Nemocas/Nemo.jl/pull/2210> is in a Nemo release). Some of those changes may not be needed anymore at all, and were from various stages of experimentation, but I did not yet have time to untangle them again.

Also, there is still room for improvement.

----

Before:

    julia> L = integer_lattice(gram=ZZ[2 1 -1 1 -1 -1 0 0 0 0 0 0 0 0 0 1; 1 2 -1 1 -1 0 0 0 0 0 0 0 0 0 0 1; -1 -1 2 0 1 0 0 0 0 0 0 0 0 0 0 -1; 1 1 0 2 -1 0 0 0 0 0 0 0 0 0 0 0; -1 -1 1 -1 2 0 0 0 0 0 0 0 0 0 0 0; -1 0 0 0 0 2 0 0 0 0 0 0 0 0 0 -1; 0 0 0 0 0 0 2 1 -1 1 -1 -1 -2 -1 -2 -1; 0 0 0 0 0 0 1 2 -1 1 -1 -1 -2 -1 -2 -1; 0 0 0 0 0 0 -1 -1 2 0 0 0 2 0 2 1; 0 0 0 0 0 0 1 1 0 2 -1 -1 -1 -1 -1 0; 0 0 0 0 0 0 -1 -1 0 -1 2 1 1 1 2 1; 0 0 0 0 0 0 -1 -1 0 -1 1 2 1 1 1 1; 0 0 0 0 0 0 -2 -2 2 -1 1 1 4 1 3 2; 0 0 0 0 0 0 -1 -1 0 -1 1 1 1 2 0 0; 0 0 0 0 0 0 -2 -2 2 -1 2 1 3 0 6 3; 1 1 -1 0 0 -1 -1 -1 1 0 1 1 2 0 3 4]);

    julia> G,_ = Oscar._isometry_group_via_decomposition(L);

    julia> S1,S2,_ = Hecke._shortest_vectors_sublattice(L);

    julia> Oscar.set_seed!(235) ; @time Oscar._overlattice_stabilizer(G, S1,S2);
      4.449402 seconds (5.96 M allocations: 204.601 MiB, 3.14% gc time)

After

    julia> L = integer_lattice(gram=ZZ[2 1 -1 1 -1 -1 0 0 0 0 0 0 0 0 0 1; 1 2 -1 1 -1 0 0 0 0 0 0 0 0 0 0 1; -1 -1 2 0 1 0 0 0 0 0 0 0 0 0 0 -1; 1 1 0 2 -1 0 0 0 0 0 0 0 0 0 0 0; -1 -1 1 -1 2 0 0 0 0 0 0 0 0 0 0 0; -1 0 0 0 0 2 0 0 0 0 0 0 0 0 0 -1; 0 0 0 0 0 0 2 1 -1 1 -1 -1 -2 -1 -2 -1; 0 0 0 0 0 0 1 2 -1 1 -1 -1 -2 -1 -2 -1; 0 0 0 0 0 0 -1 -1 2 0 0 0 2 0 2 1; 0 0 0 0 0 0 1 1 0 2 -1 -1 -1 -1 -1 0; 0 0 0 0 0 0 -1 -1 0 -1 2 1 1 1 2 1; 0 0 0 0 0 0 -1 -1 0 -1 1 2 1 1 1 1; 0 0 0 0 0 0 -2 -2 2 -1 1 1 4 1 3 2; 0 0 0 0 0 0 -1 -1 0 -1 1 1 1 2 0 0; 0 0 0 0 0 0 -2 -2 2 -1 2 1 3 0 6 3; 1 1 -1 0 0 -1 -1 -1 1 0 1 1 2 0 3 4]);

    julia> G,_ = Oscar._isometry_group_via_decomposition(L);

    julia> S1,S2,_ = Hecke._shortest_vectors_sublattice(L);

    julia> Oscar.set_seed!(235) ; @time Oscar._overlattice_stabilizer(G, S1,S2);
      0.444009 seconds (1.71 M allocations: 143.068 MiB, 16.66% gc time)

Multiple things are changed; and some of the changes may now be redundant:

- compute `BL` with less overhead (doesn't matter overall, though)
- compute stabilizer in a permutation group (via nice monomorphism)
- convert all matrices to GAP matrices, then perform the computation entirely on the GAP side (this avoids constant conversion between GAP and OSCAR matrices)

Another change is that instead of multiplying ZZMatrix with a zzModMatrix or fpMatrix, it is currently better to first convert the ZZMatrix then perform the multiplication. A proper fix for this  already has been submitted as a Nemo PR https://github.com/Nemocas/Nemo.jl/pull/2210.

But even that is suboptimal: one should not constantly convert the same ZZMatrix into zzModMatrix; instead this should be done once per generator, and then the result kept and reused. The GAP functions for orbits, stabilizers etc. have an API for that: in addition to specifying a list of generators `gens`, and an action function `act`, one can also specify a second list `acts` matching `gens`; then when the algorithms want to compute the action of, say, `act(v, gens[i])` they instead compute `act(v, acts[i])`. So in our context, `gens` would be a `Vector{ZZMatrix}` while `acts` might be a `Vector{zzModMatrix}`.

I think we should extend the OSCAR API for orbit/stabilizer to allow something equivalent. The result would still be very slightly less efficient than driving everything "directly", but it would be general enough to be used by someone without learning GAP first.

Alas, I can't write such a method here right now because of an annoying issue in the GAP library code. Basically, it requires in one spot that the list `acts` consists of objects which are valid inputs for the GAP function `Group`, which our matrices are not. But I think we can fix that, but it'll require some more work.

For the non-prime case, not over a field, we really need this, as GAP doesn't implement the Howell form.
