### PR TITLE
CI: stop testing against Julia 1.11

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,7 +45,6 @@ jobs:
       matrix:
         julia-version:
           - '1.10'
-          - '1.11'
           - '1.12'
           - '1.13-nightly'
           - 'nightly'
@@ -222,7 +221,6 @@ jobs:
       matrix:
         julia-version:
           - '1.10'
-          - '1.11'
           - '1.12'
           - '1.13-nightly'
           - 'nightly'
@@ -307,7 +305,6 @@ jobs:
       matrix:
         julia-version:
           - '1.10'
-          - '1.11'
           - '1.12'
           - '1.13-nightly'
           - 'nightly'


### PR DESCRIPTION
This will allow us to free up ~135 GB on our action runner in Kaiserslautern.

Also, it will reduce load on CI, as we'll run fewer tests.

Usually, if things work in 1.10 and 1.12 they should also work in 1.11. There can be exception, but so be it. I'd expect people to either use the latest Julia or the LTS version anyway.