### PR TITLE
Allow `oscar_worker_pool` to accept abstract cluster managers

### DIFF
--- a/experimental/Parallel/src/Parallel.jl
+++ b/experimental/Parallel/src/Parallel.jl
@@ -58,9 +58,9 @@ Create an `OscarWorkerPool` with `n` separate processes running Oscar.
 There is also the option to use an `OscarWorkerPool` within a context,
 such that closing down the processes happens automatically.
 
-The `kw` will get passed to `addprocs` when initializing the workers,
-for example use the `exeflags` for specify settings on the worker processes.
-When passing a `manager`, the `project` will determine which project to activate on the machines in the cluster.
+Keyword arguments will get passed to `addprocs` when initializing the workers,
+for example use `exeflags` to specify settings for the worker processes.
+When passing a `manager`, the `project` argument will determine which project to activate on the machines in the cluster.
 The default is to use `Base.active_project()` mimicking the local setting, passing nothing won't activate any project.
 
 # Example

--- a/experimental/Parallel/src/Parallel.jl
+++ b/experimental/Parallel/src/Parallel.jl
@@ -36,7 +36,7 @@ mutable struct OscarWorkerPool <: AbstractWorkerPool
     wp = WorkerPool(wids)
     # @everywhere can only be used on top-level, so have to do `remotecall_eval` here.
     if !isnothing(project)
-      remotecall_eval(Main, wids, :(using Pkg; Pkg.activate(project); Pkg.instantiate()))
+      remotecall_eval(Main, wids, :(using Pkg; Pkg.activate($project); Pkg.instantiate()))
     end
     remotecall_eval(Main, wids, :(using Oscar))
 

--- a/experimental/Parallel/src/Parallel.jl
+++ b/experimental/Parallel/src/Parallel.jl
@@ -26,7 +26,9 @@ mutable struct OscarWorkerPool <: AbstractWorkerPool
     wids = addprocs(n; kw...)
     wp = WorkerPool(wids)
     # @everywhere can only be used on top-level, so have to do `remotecall_eval` here.
-    remotecall_eval(Main, wids, :(using Oscar))
+    asyncmap(wids) do wid
+      remotecall_eval(Main, wid, :(using Oscar))
+    end
 
     return new(wp, wp.channel, wp.workers, wids, Dict{Int, RemoteChannel}())
   end

--- a/experimental/Parallel/src/Parallel.jl
+++ b/experimental/Parallel/src/Parallel.jl
@@ -68,7 +68,7 @@ The following code will start up 3 processes with Oscar,
 run a parallel computation over each element in an array and
 then shutdown the processes.
 ```
-results = oscar_worker_pool(3) do wp
+results = oscar_worker_pool(3; exeflags="--heap-size-hint=8G") do wp
   Qxy, (x, y) = QQ[:x, :y]
   pmap(z -> z^2, wp, [x^2, x*y, x*y^2])
 end

--- a/experimental/Parallel/src/Parallel.jl
+++ b/experimental/Parallel/src/Parallel.jl
@@ -131,9 +131,8 @@ end
 close!(wp::OscarWorkerPool) = rmprocs(workers(wp)...)
 
 # extend functionality so that `pmap` works with Oscar stuff
-
 function put_type_params(wp::OscarWorkerPool, a::Any)
-  for id in wp.wids
+  asyncmap(wp.wids) do id
     put_type_params(get_channel(wp, id), a)
   end
 end

--- a/experimental/Parallel/src/Parallel.jl
+++ b/experimental/Parallel/src/Parallel.jl
@@ -1,5 +1,5 @@
 using Distributed: RemoteChannel, Future, remotecall, @everywhere, WorkerPool, AbstractWorkerPool, addprocs, rmprocs, remotecall_eval, nworkers
-import Distributed: remotecall, workers, remotecall_fetch, pmap
+import Distributed: remotecall, workers, remotecall_fetch, pmap, ClusterManager
 
 import .Serialization: put_type_params
 

--- a/experimental/Parallel/src/Parallel.jl
+++ b/experimental/Parallel/src/Parallel.jl
@@ -33,7 +33,7 @@ mutable struct OscarWorkerPool <: AbstractWorkerPool
     return new(wp, wp.channel, wp.workers, wids, Dict{Int, RemoteChannel}())
   end
 
-  function OscarWorkerPool(manager::ClusterManager; project=nothing, kw...)
+  function OscarWorkerPool(manager::ClusterManager; project=Base.active_project(), kw...)
     wids = addprocs(manager; kw...)
     wp = WorkerPool(wids)
     # @everywhere can only be used on top-level, so have to do `remotecall_eval` here.

--- a/experimental/Parallel/src/Parallel.jl
+++ b/experimental/Parallel/src/Parallel.jl
@@ -31,10 +31,13 @@ mutable struct OscarWorkerPool <: AbstractWorkerPool
     return new(wp, wp.channel, wp.workers, wids, Dict{Int, RemoteChannel}())
   end
 
-  function OscarWorkerPool(manager::ClusterManager; kw...)
+  function OscarWorkerPool(manager::ClusterManager; project=nothing, kw...)
     wids = addprocs(manager; kw...)
     wp = WorkerPool(wids)
     # @everywhere can only be used on top-level, so have to do `remotecall_eval` here.
+    if !isnothing(project)
+      remotecall_eval(Main, wids, :(using Pkg; Pkg.activate(project); Pkg.instantiate()))
+    end
     remotecall_eval(Main, wids, :(using Oscar))
 
     return new(wp, wp.channel, wp.workers, wids, Dict{Int, RemoteChannel}())

--- a/experimental/Parallel/src/Parallel.jl
+++ b/experimental/Parallel/src/Parallel.jl
@@ -53,12 +53,15 @@ end
 @doc raw"""
      oscar_worker_pool(n::Int; kw...)
      oscar_worker_pool(f::Function, n::Int; kw...)
-     oscar_worker_pool(manager::ClusterManager; kw...)
+     oscar_worker_pool(manager::ClusterManager; project=Base.active_project(), kw...)
 Create an `OscarWorkerPool` with `n` separate processes running Oscar.
 There is also the option to use an `OscarWorkerPool` within a context,
 such that closing down the processes happens automatically.
 
-Will also accept a `manager` as an argument, `kw` will get passed to `addprocs` when initializing the workers.
+The `kw` will get passed to `addprocs` when initializing the workers,
+for example use the `exeflags` for specify settings on the worker processes.
+When passing a `manager`, the `project` will determine which project to activate on the machines in the cluster.
+The default is to use `Base.active_project()` mimicking the local setting, passing nothing won't activate any project.
 
 # Example
 The following code will start up 3 processes with Oscar,

--- a/experimental/Parallel/src/Parallel.jl
+++ b/experimental/Parallel/src/Parallel.jl
@@ -31,8 +31,8 @@ mutable struct OscarWorkerPool <: AbstractWorkerPool
     return new(wp, wp.channel, wp.workers, wids, Dict{Int, RemoteChannel}())
   end
 
-  function OscarWorkerPool(manager::ClusterManager, n::Int; kw...)
-    wids = addprocs(manager, n; kw...)
+  function OscarWorkerPool(manager::ClusterManager; kw...)
+    wids = addprocs(manager; kw...)
     wp = WorkerPool(wids)
     # @everywhere can only be used on top-level, so have to do `remotecall_eval` here.
     remotecall_eval(Main, wids, :(using Oscar))
@@ -44,7 +44,7 @@ end
 @doc raw"""
      oscar_worker_pool(n::Int; kw...)
      oscar_worker_pool(f::Function, n::Int; kw...)
-     oscar_worker_pool(manager::ClusterManager, n::Int; kw...)
+     oscar_worker_pool(manager::ClusterManager; kw...)
 Create an `OscarWorkerPool` with `n` separate processes running Oscar.
 There is also the option to use an `OscarWorkerPool` within a context,
 such that closing down the processes happens automatically.
@@ -63,7 +63,7 @@ end
 ```
 """
 oscar_worker_pool(n::Int; kw...) = OscarWorkerPool(n; kw...)
-oscar_worker_pool(manager::ClusterManager, n::Int; kw...) = OscarWorkerPool(manager, n; kw...)
+oscar_worker_pool(manager::ClusterManager; kw...) = OscarWorkerPool(manager; kw...)
 
 function oscar_worker_pool(f::Function, args...; kw...)
   wp = OscarWorkerPool(args...; kw...)

--- a/experimental/Parallel/src/Parallel.jl
+++ b/experimental/Parallel/src/Parallel.jl
@@ -23,7 +23,7 @@ mutable struct OscarWorkerPool <: AbstractWorkerPool
   oscar_channels::Dict{Int, <:RemoteChannel} # channels for sending `type_params` to the workers
 
   function OscarWorkerPool(n::Int; kw...)
-    wids = addprocs(n, kw...)
+    wids = addprocs(n; kw...)
     wp = WorkerPool(wids)
     # @everywhere can only be used on top-level, so have to do `remotecall_eval` here.
     remotecall_eval(Main, wids, :(using Oscar))

--- a/experimental/Parallel/src/Parallel.jl
+++ b/experimental/Parallel/src/Parallel.jl
@@ -42,12 +42,14 @@ mutable struct OscarWorkerPool <: AbstractWorkerPool
 end
 
 @doc raw"""
-     oscar_worker_pool(n::Int)
-     oscar_worker_pool(f::Function, n::Int)
-
+     oscar_worker_pool(n::Int; kw...)
+     oscar_worker_pool(f::Function, n::Int; kw...)
+     oscar_worker_pool(manager::ClusterManager, n::Int; kw...)
 Create an `OscarWorkerPool` with `n` separate processes running Oscar.
 There is also the option to use an `OscarWorkerPool` within a context,
 such that closing down the processes happens automatically.
+
+Will also accept a `manager` as an argument, `kw` will get passed to `addprocs` when initializing the workers.
 
 # Example
 The following code will start up 3 processes with Oscar,


### PR DESCRIPTION
Allow cluster managers.
Also propagates keyword args to addprocs which can be useful for setting up configurations of workers.
