### PR TITLE
Fix loading of empty tuples

### DIFF
--- a/src/Serialization/containers.jl
+++ b/src/Serialization/containers.jl
@@ -257,6 +257,7 @@ function save_type_params(s::SerializerState, tp::TypeParams{T}) where T <: Tupl
 end
 
 function load_type_params(s::DeserializerState, T::Type{Tuple})
+  !haskey(s, :params) && return T{}, nothing
   subtype, params = load_node(s, :params) do _
     tuple_params = load_array_node(s) do _
       U = decode_type(s)

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -427,7 +427,6 @@ end
 # parameters before loading its data, if so a type tree is traversed
 function load_typed_object(s::DeserializerState; override_params::Any = nothing)
   T = decode_type(s)
-  Base.issingletontype(T) && return T()
   if !isnothing(override_params)
     T, _ = load_type_params(s, T, type_key)
     params = override_params
@@ -435,6 +434,7 @@ function load_typed_object(s::DeserializerState; override_params::Any = nothing)
     s.obj isa String && !isnothing(tryparse(UUID, s.obj)) && return load_ref(s)
     T, params = load_type_params(s, T, type_key)
   end
+  Base.issingletontype(T) && return T()
   obj = load_node(s, :data) do _
     return load_object(s, T, params)
   end

--- a/test/Serialization/containers.jl
+++ b/test/Serialization/containers.jl
@@ -11,6 +11,11 @@
         @test t == loaded
       end
 
+      et = Tuple{}([])
+      test_save_load_roundtrip(path, et) do loaded
+        @test et == loaded
+      end
+
       nt = (a = v, b = t)
       test_save_load_roundtrip(path, nt) do loaded
         @test nt == loaded


### PR DESCRIPTION
Empty tuples have no params, and since
```
julia> Base.issingletontype(Tuple)
false

julia> Base.issingletontype(Tuple{})
true
```
we need to delay the singleton check until after checking for params.

fixes: #5671 