### PR TITLE
booktests: fix incorrect memset C types

### DIFF
--- a/test/book/introduction/introduction/julia.jlcon
+++ b/test/book/introduction/introduction/julia.jlcon
@@ -28,7 +28,7 @@ julia> ccall(:sin, Float64, (Float64,), 1.0)
 
 julia> u = Int64[1,2,3,4,5,6];
 
-julia> ccall(:memset, Cvoid, (Ptr{Int}, Int, UInt), u, 0, length(u)*sizeof(Int64))
+julia> ccall(:memset, Cvoid, (Ptr{Int64}, Cint, Csize_t), u, 0, length(u)*sizeof(Int64))
 
 julia> show(u)
 [0, 0, 0, 0, 0, 0]


### PR DESCRIPTION
This should fix one error for the nightly booktests:
```
    julia.jlcon: broken
Unreachable reached at 0x7f0ea1dff244
[4355] signal 4 (2): Illegal instruction
```
(Note that the `broken` only means the test is run but the output is ignored)

The value for `memset` must be a C `int` instead of a julia `Int` (usually `int64_t`).

The other two types are correct on 64 bit systems but I adjusted them for correctness anyway.
