### PR TITLE
Add some minor improvements for finitely presented modules and cache representatives of inverses in quotient rings

### DIFF
--- a/src/AlgebraicGeometry/Schemes/BlowupMorphism/Types.jl
+++ b/src/AlgebraicGeometry/Schemes/BlowupMorphism/Types.jl
@@ -94,8 +94,8 @@ Blowup
 with domain
   scheme over QQ covered with 3 patches
     1a: [(s1//s0), (s2//s0), x]   scheme(0, 0, 0)
-    2a: [(s0//s1), (s2//s1), y]   scheme(0, 0, 0)
-    3a: [(s0//s2), (s1//s2), z]   scheme(0, 0, 0)
+    2a: [(s0//s1), (s2//s1), y]   scheme(0, 0)
+    3a: [(s0//s2), (s1//s2), z]   scheme(0, 0)
 and exceptional divisor
   effective cartier divisor defined by
     sheaf of ideals with restrictions
@@ -107,8 +107,8 @@ julia> E = exceptional_divisor(bl)
 Effective cartier divisor
   on scheme over QQ covered with 3 patches
     1: [(s1//s0), (s2//s0), x]   scheme(0, 0, 0)
-    2: [(s0//s1), (s2//s1), y]   scheme(0, 0, 0)
-    3: [(s0//s2), (s1//s2), z]   scheme(0, 0, 0)
+    2: [(s0//s1), (s2//s1), y]   scheme(0, 0)
+    3: [(s0//s2), (s1//s2), z]   scheme(0, 0)
 defined by
   sheaf of ideals with restrictions
     1: Ideal (x)

--- a/src/AlgebraicGeometry/Schemes/Covering/Objects/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/Covering/Objects/Constructors.jl
@@ -38,7 +38,9 @@ function Covering(patches::Vector{<:AbsAffineScheme})
     f = identity_map(U)
     g[X,X] = SimpleGluing(X, X, f, f, check=false)
   end
-  return Covering(patches, g, check=false)
+  cov = Covering(patches, g, check=false)
+  set_decomposition_info!(cov, IdDict{AbsAffineScheme, Vector{<:RingElem}}(U => elem_type(OO(U))[] for U in patches))
+  return cov
 end
 
 ### Turns an affine scheme into a trivial covering

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
@@ -350,8 +350,8 @@ function _homogenization_map(P::AbsProjectiveScheme{<:MPolyAnyRing, <:MPolyQuoRi
     qq = evaluate(q, v)
 
     # homogenize numerator and denominator
-    pp = sum([c*m*ss^(deg_p - total_degree(m)) for (c, m) in zip(coefficients(lift(pp)), monomials(lift(pp)))])
-    qq = sum([c*m*ss^(deg_q - total_degree(m)) for (c, m) in zip(coefficients(lift(qq)), monomials(lift(qq)))])
+    pp = sum(c*m*ss^(deg_p - total_degree(m)) for (c, m) in zip(coefficients(lift(pp)), monomials(lift(pp))); init=zero(S))
+    qq = sum(c*m*ss^(deg_q - total_degree(m)) for (c, m) in zip(coefficients(lift(qq)), monomials(lift(qq))); init=zero(S))
 
     if deg_a > 0
       return (pp, qq*ss^deg_a)

--- a/src/AlgebraicGeometry/Schemes/Sheaves/Sheaves.jl
+++ b/src/AlgebraicGeometry/Schemes/Sheaves/Sheaves.jl
@@ -182,9 +182,9 @@ morphism ``ρ : F(U) → F(V)``, this method stores the map `rho` in the interna
 the restriction map for `F` from `U` to `V`.
 """
 function add_incoming_restriction!(F::AbsPreSheaf{<:Any, OpenType, OutputType, RestrictionType},
-    U::OpenType,
-    M::OutputType,
-    rho::RestrictionType
+    U::AbsAffineScheme,
+    M::Any,
+    rho::Any
   ) where {OpenType, OutputType, RestrictionType}
   # First, look up the incoming restriction maps for F(V).
   # This will create the dictionary, if necessary.
@@ -210,15 +210,12 @@ The values of the dictionary are precisely those restriction maps for the respec
 """
 function incoming_restrictions(
     F::AbsPreSheaf{<:Any, OpenType, OutputType, RestrictionType},
-    M::OutputType
+    M::Any
   ) where {OpenType, OutputType, RestrictionType}
   hasfield(typeof(M), :__attrs) || return nothing # M has to be attributable to allow for caching!
-  if !has_attribute(M, :incoming_restrictions)
-    D = IdDict{OpenType, RestrictionType}()
-    set_attribute!(M, :incoming_restrictions, D)
-    return D
-  end
-  return get_attribute(M, :incoming_restrictions)::IdDict{OpenType, RestrictionType}
+  return get_attribute!(M, :incoming_restrictions) do
+    IdDict{OpenType, RestrictionType}()
+  end::IdDict{OpenType, RestrictionType}
 end
 
 ########################################################################

--- a/src/Modules/ExteriorPowers/Generic.jl
+++ b/src/Modules/ExteriorPowers/Generic.jl
@@ -198,6 +198,10 @@ function exterior_power(phi::ModuleFPHom{<:ModuleFP, <:ModuleFP, Nothing}, p::In
     domain::ModuleFP=exterior_power(domain(phi), p)[1],
     codomain::ModuleFP=exterior_power(codomain(phi), p)[1]
   )
+  if ngens(Oscar.domain(phi)) == ngens(Oscar.codomain(phi)) == p
+    return hom(domain, codomain, [det(matrix(phi))*codomain[1]]; check=false)
+  end
+
   orig_img_gens = images_of_generators(phi)
   dec = wedge_generator_decompose_function(domain)
   dom_gens_dec = Vector{elem_type(Oscar.domain(phi))}[collect(dec(g)) for g in gens(domain)]
@@ -210,6 +214,9 @@ function exterior_power(phi::ModuleFPHom{<:ModuleFP, <:ModuleFP}, p::Int;
     domain::ModuleFP=exterior_power(domain(phi), p)[1],
     codomain::ModuleFP=exterior_power(codomain(phi), p)[1]
   )
+  if ngens(Oscar.domain(phi)) == ngens(Oscar.codomain(phi)) == p
+    return hom(domain, codomain, [det(matrix(phi))*codomain[1]], base_ring_map(phi))
+  end
   orig_img_gens = images_of_generators(phi)
   dec = wedge_generator_decompose_function(domain)
   dom_gens_dec = Vector{elem_type(Oscar.domain(phi))}[collect(dec(g)) for g in gens(domain)]

--- a/src/Modules/ExteriorPowers/Generic.jl
+++ b/src/Modules/ExteriorPowers/Generic.jl
@@ -193,3 +193,27 @@ function hom(M::FreeMod, N::FreeMod, phi::FreeModuleHom)
   @req p == q "exponents must agree"
   return induced_map_on_exterior_power(phi, p; domain=M, codomain=N)
 end
+
+function exterior_power(phi::ModuleFPHom{<:ModuleFP, <:ModuleFP, Nothing}, p::Int; 
+    domain::ModuleFP=exterior_power(domain(phi), p)[1],
+    codomain::ModuleFP=exterior_power(codomain(phi), p)[1]
+  )
+  orig_img_gens = images_of_generators(phi)
+  dec = wedge_generator_decompose_function(domain)
+  dom_gens_dec = Vector{elem_type(Oscar.domain(phi))}[collect(dec(g)) for g in gens(domain)]
+  img_gens = elem_type(codomain)[wedge(phi.(v); parent=codomain) for v in dom_gens_dec]
+  return hom(domain, codomain, img_gens)
+end
+
+# with coefficient map
+function exterior_power(phi::ModuleFPHom{<:ModuleFP, <:ModuleFP}, p::Int; 
+    domain::ModuleFP=exterior_power(domain(phi), p)[1],
+    codomain::ModuleFP=exterior_power(codomain(phi), p)[1]
+  )
+  orig_img_gens = images_of_generators(phi)
+  dec = wedge_generator_decompose_function(domain)
+  dom_gens_dec = Vector{elem_type(Oscar.domain(phi))}[collect(dec(g)) for g in gens(domain)]
+  img_gens = elem_type(codomain)[wedge(phi.(v); parent=codomain) for v in dom_gens_dec]
+  return hom(domain, codomain, img_gens, base_ring_map(phi))
+end
+

--- a/src/Modules/ExteriorPowers/Generic.jl
+++ b/src/Modules/ExteriorPowers/Generic.jl
@@ -194,33 +194,3 @@ function hom(M::FreeMod, N::FreeMod, phi::FreeModuleHom)
   return induced_map_on_exterior_power(phi, p; domain=M, codomain=N)
 end
 
-function exterior_power(phi::ModuleFPHom{<:ModuleFP, <:ModuleFP, Nothing}, p::Int; 
-    domain::ModuleFP=exterior_power(domain(phi), p)[1],
-    codomain::ModuleFP=exterior_power(codomain(phi), p)[1]
-  )
-  if ngens(Oscar.domain(phi)) == ngens(Oscar.codomain(phi)) == p
-    return hom(domain, codomain, [det(matrix(phi))*codomain[1]]; check=false)
-  end
-
-  orig_img_gens = images_of_generators(phi)
-  dec = wedge_generator_decompose_function(domain)
-  dom_gens_dec = Vector{elem_type(Oscar.domain(phi))}[collect(dec(g)) for g in gens(domain)]
-  img_gens = elem_type(codomain)[wedge(phi.(v); parent=codomain) for v in dom_gens_dec]
-  return hom(domain, codomain, img_gens)
-end
-
-# with coefficient map
-function exterior_power(phi::ModuleFPHom{<:ModuleFP, <:ModuleFP}, p::Int; 
-    domain::ModuleFP=exterior_power(domain(phi), p)[1],
-    codomain::ModuleFP=exterior_power(codomain(phi), p)[1]
-  )
-  if ngens(Oscar.domain(phi)) == ngens(Oscar.codomain(phi)) == p
-    return hom(domain, codomain, [det(matrix(phi))*codomain[1]], base_ring_map(phi))
-  end
-  orig_img_gens = images_of_generators(phi)
-  dec = wedge_generator_decompose_function(domain)
-  dom_gens_dec = Vector{elem_type(Oscar.domain(phi))}[collect(dec(g)) for g in gens(domain)]
-  img_gens = elem_type(codomain)[wedge(phi.(v); parent=codomain) for v in dom_gens_dec]
-  return hom(domain, codomain, img_gens, base_ring_map(phi))
-end
-

--- a/src/Modules/ExteriorPowers/SubQuo.jl
+++ b/src/Modules/ExteriorPowers/SubQuo.jl
@@ -14,8 +14,10 @@ function exterior_power(M::SubquoModule, p::Int; cached::Bool=true)
   else
     C = presentation(M)
     phi = map(C, 1)
-    codomain(phi).S = function _get_symbol()
-      return [Symbol("$e") for e in gens(M)]
+    if codomain(phi) !== ambient_free_module(M) # if this was not the case, we get infinite recursion here! 
+      codomain(phi).S = function _get_symbol()
+        return [Symbol("$e") for e in gens(M)]
+      end
     end
     result, mm = _exterior_power(phi, p)
   end

--- a/src/Modules/ModuleTypes.jl
+++ b/src/Modules/ModuleTypes.jl
@@ -674,7 +674,7 @@ When computed, the corresponding matrix (via `matrix()`) and inverse isomorphism
       for (i, b) in coordinates(x)
         pre_res = Hecke.add_scaled_row!(coordinates(a[i]), pre_res, h(b))
       end
-      return FreeModElem(pre_res, G)
+      return G(pre_res)
     end
     function pr_func(x)
       @assert parent(x) === G

--- a/src/Modules/Posur.jl
+++ b/src/Modules/Posur.jl
@@ -618,17 +618,6 @@ function (F::FreeMod{T})(a::FreeModElem) where {T<:AbsLocalizedRingElem}
   return sum([a*e for (a, e) in zip(c, gens(F))])
 end
 
-function (M::SubquoModule{T})(f::FreeModElem; check::Bool = true) where {T<:AbsLocalizedRingElem}
-  F = ambient_free_module(M)
-  base_ring(parent(f)) == base_ring(base_ring(M)) && return M(F(f))
-  parent(f) == F || error("ambient free modules are not compatible")
-  (check && represents_element(f, M)) || error("not a representative of a module element")
-  v = coordinates(f, M) # This is not the cheapest way, but the only one for which 
-                        # the constructors in the module code are sufficiently generic.
-                        # Clean this up!
-  return sum([a*M[i] for (i, a) in v]; init=zero(M))
-end
-
 function base_ring_module(M::SubquoModule{T}) where {T<:AbsLocalizedRingElem}
   has_attribute(M, :base_ring_module) || error("there is no associated module over the base ring")
   get_attribute(M, :base_ring_module)::SubquoModule{elem_type(base_ring_type(T))}

--- a/src/Modules/Posur.jl
+++ b/src/Modules/Posur.jl
@@ -438,7 +438,8 @@ function cokernel(
     DomType<:FreeMod{T},
     CodType<:FreeMod{T}
   }
-  return quo(codomain(f), representing_matrix(f))
+  I, inc = image(f)
+  return quo(codomain(f), I)
 end
 
 function image(
@@ -448,7 +449,7 @@ function image(
     DomType<:FreeMod{T},
     CodType<:FreeMod{T}
   }
-  return sub(codomain(f), representing_matrix(f))
+  return sub(codomain(f), images_of_generators(f))
 end
 
 function coordinates(u::FreeModElem{T}, M::SubquoModule{T}) where {T<:AbsLocalizedRingElem}

--- a/src/Modules/UngradedModules/FreeModuleHom.jl
+++ b/src/Modules/UngradedModules/FreeModuleHom.jl
@@ -528,6 +528,22 @@ function is_welldefined(H::SubQuoHom{<:SubquoModule})
   F0 = pres[0]
   N = codomain(H)
   # the induced map phi : F0 --> N
+  phi = hom(F0, N, elem_type(N)[H(eps(v)) for v in gens(F0)], ring_map(H); check=false)
+  # now phi ∘ g : F1 --> N has to be zero.
+  return iszero(compose(g, phi))
+end
+
+function is_welldefined(H::SubQuoHom{<:SubquoModule, <:ModuleFP, Nothing})
+  M = domain(H)
+  pres = presentation(M)
+  # is a short exact sequence with maps
+  # M <--eps-- F0 <--g-- F1
+  # and H : M -> N
+  eps = map(pres, 0)
+  g = map(pres, 1)
+  F0 = pres[0]
+  N = codomain(H)
+  # the induced map phi : F0 --> N
   phi = hom(F0, N, elem_type(N)[H(eps(v)) for v in gens(F0)]; check=false)
   # now phi ∘ g : F1 --> N has to be zero.
   return iszero(compose(g, phi))

--- a/src/Modules/UngradedModules/HomologicalAlgebra.jl
+++ b/src/Modules/UngradedModules/HomologicalAlgebra.jl
@@ -600,25 +600,26 @@ julia> ext(M, M, 0)
 Subquotient of submodule with 1 generator
   1: (e[1] -> e[1])
 by submodule with 2 generators
-  1: y*(e[1] -> e[1])
-  2: x*(e[1] -> e[1])
+  1: x*(e[1] -> e[1])
+  2: y*(e[1] -> e[1])
 
 julia> ext(M, M, 1)
 Subquotient of submodule with 2 generators
   1: (e[1] -> e[1])
   2: (e[2] -> e[1])
 by submodule with 4 generators
-  1: y*(e[1] -> e[1])
-  2: x*(e[1] -> e[1])
-  3: y*(e[2] -> e[1])
-  4: x*(e[2] -> e[1])
+  1: x*(e[1] -> e[1])
+  2: y*(e[1] -> e[1])
+  3: x*(e[2] -> e[1])
+  4: y*(e[2] -> e[1])
 
 julia> ext(M, M, 2)
 Subquotient of submodule with 1 generator
   1: (e[1] -> e[1])
-by submodule with 2 generators
-  1: y*(e[1] -> e[1])
-  2: x*(e[1] -> e[1])
+by submodule with 3 generators
+  1: x*(e[1] -> e[1])
+  2: y*(e[1] -> e[1])
+  3: -x*(e[1] -> e[1])
 
 julia> ext(M, M, 3)
 Submodule with 0 generators

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -417,7 +417,7 @@ function change_base_ring(S::Ring, M::SubquoModule)
 end
 
 function change_base_ring(f::Map{DomType, CodType}, M::SubquoModule) where {DomType<:Ring, CodType<:Ring}
-  domain(f) == base_ring(M) || error("ring map not compatible with the module")
+  domain(f) === base_ring(M) || error("ring map not compatible with the module")
   S = codomain(f)
   F = ambient_free_module(M)
   R = base_ring(M)

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -373,7 +373,7 @@ function hom_matrices(M::SubquoModule{T},N::SubquoModule{T},simplify_task=true) 
     to_subquotient_elem = function(H::ModuleFPHom)
       m = length(matrix(H))
       v = copy_and_reshape(matrix(H),1,m)
-      v = FreeModElem(sparse_row(v), FreeMod(R, length(v)))
+      v = FreeModElem(sparse_row(v), ambient_free_module(SQ))
       return SQ(v)
     end
     to_homomorphism = function(elem::SubquoModuleElem{T})

--- a/src/Modules/UngradedModules/Presentation.jl
+++ b/src/Modules/UngradedModules/Presentation.jl
@@ -141,7 +141,7 @@ function _presentation_simple(SQ::SubquoModule)
   F = ambient_free_module(SQ)
   if all(repres(v) == g for (v, g) in zip(gens(SQ), gens(F)))
     rels = relations(SQ)
-    F1 = free_module(R, length(rels))
+    F1 = FreeMod(R, length(rels))
     phi = hom(F1, F, rels)
     aug = hom(F, SQ, gens(SQ))
     # prepare the end of the presentation

--- a/src/Modules/UngradedModules/Presentation.jl
+++ b/src/Modules/UngradedModules/Presentation.jl
@@ -139,7 +139,7 @@ function _presentation_simple(SQ::SubquoModule)
   R = base_ring(SQ)
 
   F = ambient_free_module(SQ)
-  if all(repres(v) == g for (v, g) in zip(gens(SQ), gens(F)))
+  if ngens(SQ) == ngens(F) && all(repres(v) == g for (v, g) in zip(gens(SQ), gens(F)))
     rels = relations(SQ)
     F1 = FreeMod(R, length(rels))
     phi = hom(F1, F, rels)

--- a/src/Modules/UngradedModules/Presentation.jl
+++ b/src/Modules/UngradedModules/Presentation.jl
@@ -138,6 +138,22 @@ end
 function _presentation_simple(SQ::SubquoModule)
   R = base_ring(SQ)
 
+  F = ambient_free_module(SQ)
+  if all(repres(v) == g for (v, g) in zip(gens(SQ), gens(F)))
+    rels = relations(SQ)
+    F1 = free_module(R, length(rels))
+    phi = hom(F1, F, rels)
+    aug = hom(F, SQ, gens(SQ))
+    # prepare the end of the presentation
+    Z = FreeMod(R, 0)
+    SQ_to_Z = hom(SQ, Z, elem_type(Z)[zero(Z) for i in 1:ngens(SQ)]; check=false)
+
+    # compile the presentation complex
+    M = Hecke.ComplexOfMorphisms(ModuleFP, ModuleFPHom[phi, aug, SQ_to_Z], check=false, seed = -2)
+    set_attribute!(M, :show => Hecke.pres_show)
+    return M
+  end
+
   # Create the free module for the presentation
   F0 = FreeMod(R, length(gens(SQ)))
   F0_to_SQ = hom(F0, SQ, gens(SQ); check=false)

--- a/src/Modules/UngradedModules/SubQuoHom.jl
+++ b/src/Modules/UngradedModules/SubQuoHom.jl
@@ -1023,11 +1023,11 @@ end
 
 If `a` is bijective, return its inverse.
 """
-function inv(H::ModuleFPHom)
+function inv(H::ModuleFPHom; check::Bool=true)
   if isdefined(H, :inverse_isomorphism)
     return H.inverse_isomorphism
   end
-  @assert is_bijective(H)
+  @check is_bijective(H) "morphism is not bijective"
   N = domain(H)
   M = codomain(H)
 

--- a/src/Modules/UngradedModules/SubQuoHom.jl
+++ b/src/Modules/UngradedModules/SubQuoHom.jl
@@ -522,7 +522,7 @@ Return the image $a(m)$.
 """
 function image(f::SubQuoHom, a::SubquoModuleElem)
   @assert a.parent === domain(f)
-  iszero(a) && return zero(codomain(f))
+  #iszero(a) && return zero(codomain(f))
   # The code in the comment below was an attempt to make
   # evaluation of maps faster. However, it turned out that
   # for the average use case the comparison was more expensive

--- a/src/Modules/UngradedModules/SubQuoHom.jl
+++ b/src/Modules/UngradedModules/SubQuoHom.jl
@@ -522,7 +522,15 @@ Return the image $a(m)$.
 """
 function image(f::SubQuoHom, a::SubquoModuleElem)
   @assert a.parent === domain(f)
+  # simplifying the element to be mapped before mapping it (e.g. through an `is_zero` check) 
+  # can be beneficial to speed up mapping. However, over general rings, we must expect this 
+  # check to be rather expensive. For instance for localizations of quotient rings
+  # at prime ideals this triggers a Groebner basis computation every time. Therefore, 
+  # we do not do this check in the generic code. Should it turn out to be beneficial 
+  # in particular cases, we invite overwriting this function for the specific case 
+  # and reintroducing some version of the line below again. 
   #iszero(a) && return zero(codomain(f))
+
   # The code in the comment below was an attempt to make
   # evaluation of maps faster. However, it turned out that
   # for the average use case the comparison was more expensive

--- a/src/Modules/UngradedModules/SubquoModuleElem.jl
+++ b/src/Modules/UngradedModules/SubquoModuleElem.jl
@@ -435,6 +435,8 @@ function (==)(a::SubquoModuleElem, b::SubquoModuleElem)
   if parent(a) !== parent(b)
     return false
   end
+  a === b && return true
+  repres(a) == repres(b) && return true
   return iszero(a-b)
 end
 

--- a/src/Modules/UngradedModules/SubquoModuleElem.jl
+++ b/src/Modules/UngradedModules/SubquoModuleElem.jl
@@ -313,12 +313,9 @@ parent(b::SubquoModuleElem) = b.parent
 Given an element `f` of the ambient free module of `M` which represents an element of `M`,
 return the represented element.
 """
-function (M::SubquoModule{T})(f::FreeModElem{T}) where T
-  coords = coordinates(f, M)
-  if coords === nothing
-    error("not in the module")
-  end
-  return SubquoModuleElem(coords, M)
+function (M::SubquoModule{T})(f::FreeModElem{T}; check::Bool=true) where T
+  @check !isnothing(coordinates(f, M)) "free module element does not represent an element in the subquotient"
+  return SubquoModuleElem(f, M)
 end
 
 @doc raw"""

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -844,7 +844,8 @@ function isone(a::MPolyQuoLocRingElem)
 end
 
 function iszero(a::MPolyQuoLocRingElem)
-  return lift(a) in modulus(parent(a))
+  is_zero(lifted_numerator(a)) && return true
+  return lifted_numerator(a) in modulus(parent(a))
 end
 
 function iszero(a::MPolyQuoLocRingElem{<:Any, <:Any, <:Any, <:Any, <:MPolyComplementOfPrimeIdeal})

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -1605,8 +1605,8 @@ function simplify(L::MPolyQuoRing)
 end
 
 function simplify(L::MPolyQuoRing{<:MPolyRingElem{T}}) where {T<:FieldElem}
-  J = modulus(L)
   R = base_ring(L)
+  J = ideal(R, small_generating_set(modulus(L)))
   is_zero(ngens(R)) && return L, id_hom(L), id_hom(L)
   SR = singular_poly_ring(R)
   SJ = singular_generators(J)


### PR DESCRIPTION
During my stay in Cuernavaca we have been working on several different projects. This lead to the discovery of several small bugs for which we found fixes and/or improvements. This is a first chunk of those. 

I would like to first massage this to make the tests pass. Or add individual tests. Once I see the whole PR and how it shapes up, we may also discuss further splitting. For the time being, I make this a draft. 

Edit: Update from triage
  - Caching representatives of inverses is not disputed anymore. @fieker 's comment still stands that we might want to look into specializing linear algebra routines for `MPolyQuoRing`s, but that's an independent matter.
  - @jankoboehm and I will discuss the changes for the modules. 