### PR TITLE
TropicalGeometry: tropical_variety, fixed convention logic

### DIFF
--- a/src/TropicalGeometry/variety_prime.jl
+++ b/src/TropicalGeometry/variety_prime.jl
@@ -29,7 +29,7 @@ function tropical_variety_prime_singular(I::MPolyIdeal, nu::TropicalSemiringMap{
                             "string TropIString = string(TropI);"])
     Singular.call_interpreter(singularCommand)
     TropIString = Singular.lookup_library_symbol("Top", "TropIString")
-    Sigma = gfan_fan_string_to_oscar_complex(TropIString,convention(nu)==max,false)
+    Sigma = gfan_fan_string_to_oscar_complex(TropIString,convention(nu)==min,false)
     TropI = compute_weights_and_construct_tropical_variety(Sigma,I,nu)
     if !weighted_polyhedral_complex_only
         set_attribute!(TropI,:algebraic_ideal,I)

--- a/test/TropicalGeometry/variety.jl
+++ b/test/TropicalGeometry/variety.jl
@@ -61,7 +61,7 @@
     end
 
     # running tropical_variety and all its subroutines
-    @testset "testing tropical_variety" begin
+    @testset "testing tropical_variety basics" begin
         # principal ideals
         R,(x,y,z) = QQ["x","y","z"]
         f = x^2+y^2+z^2+1
@@ -82,4 +82,32 @@
 
         # general ideals, see doctests
     end
+
+    @testset "testing tropical_variety respecting conventions" begin
+        I = grassmann_pluecker_ideal(2, 5)
+        R = base_ring(I)
+        RR, y = polynomial_ring(QQ, length(gens(R)), :y)
+        g = hom(R, RR, gens(RR))
+        II = g(I)
+
+        nuMin = tropical_semiring_map(QQ, min) # works properly
+        nuMax = tropical_semiring_map(QQ, max)
+        Tmin = tropical_variety(II, nuMin; skip_decomposition=true)
+        Tmax = tropical_variety(II, nuMax; skip_decomposition=true)
+
+        Cmin = first(maximal_polyhedra(Tmin))
+        Rmin,_ = rays_modulo_lineality(Cmin)
+        wMin = sum(Rmin)
+        wMin = lcm(denominator.(wMin))*wMin
+
+        Cmax = first(maximal_polyhedra(Tmax))
+        Rmax,_ = rays_modulo_lineality(Cmax)
+        wMax = sum(Rmax)
+        wMax = lcm(denominator.(wMax))*wMax
+
+        @test all(h -> (length(h)>1), initial.(gens(I), Ref(nuMin), Ref(wMin)))
+        @test all(h -> (length(h)>1), initial.(gens(I), Ref(nuMax), Ref(wMax)))
+    end
+
+
 end


### PR DESCRIPTION
This is a quick one-line fix for https://github.com/oscar-system/Oscar.jl/issues/5669 (the rest are just tests).

There was indeed an error in how the convention is handled internally.