### PR TITLE
Use TagBot config to paste changelog into GitHub release description

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -35,7 +35,7 @@ jobs:
             {{ custom }}
             {% else %}
             There was no changelog provided when registering this version.
-            Please wait for a maintainer to update the release description at {% version_url %}.
+            Please wait for a maintainer to update the release description.
             {% endif %}
 
             {% if previous_release %}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -29,3 +29,15 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}
+          changelog: |
+            ## {{ package }} {{ version }}
+            {% if custom %}
+            {{ custom }}
+            {% else %}
+            There was no changelog provided when registering this version.
+            Please wait for a maintainer to update the release description at {% version_url %}.
+            {% endif %}
+
+            {% if previous_release %}
+            [Full diff since {{ previous_release }}]({{ compare_url }})
+            {% endif %}

--- a/docs/src/DeveloperDocumentation/release.md
+++ b/docs/src/DeveloperDocumentation/release.md
@@ -58,7 +58,7 @@ Release notes:
 
 <copy the content of CHANGELOG.md for version X.Y.0 here (wihout the heading, but including the introductory sentence)>
 ```
-In this case TagBot will create the corresponding release, but preferably recheck and clean up the list of changes since unfortunately TagBot currently does not take the branch into account and will show all PRs that have been merged to master.
+In this case TagBot will create the corresponding release.
 
 Consider deploying a released version at [zenodo](https://zenodo.org/).
 

--- a/docs/src/DeveloperDocumentation/release.md
+++ b/docs/src/DeveloperDocumentation/release.md
@@ -50,7 +50,15 @@ For OSCAR 1.0.0 we plan to have one or two release candidates but unlike julia a
 Just before making the release, `CHANGELOG.md` should be updated.
 See [Updating `CHANGELOG.md`](@ref) for details.
 
-Once the version is at X.Y.0, the version can be registered in the julia registry with `@JuliaRegistrator register()`. In this case TagBot will create the corresponding release, but preferably recheck and clean up the list of changes since unfortunately TagBot currently does not take the branch into account and will show all PRs that have been merged to master.
+Once the version is at X.Y.0, the version can be registered in the julia registry with
+```
+@JuliaRegistrator register
+
+Release notes:
+
+<copy the content of CHANGELOG.md for version X.Y.0 here (wihout the heading, but including the introductory sentence)>
+```
+In this case TagBot will create the corresponding release, but preferably recheck and clean up the list of changes since unfortunately TagBot currently does not take the branch into account and will show all PRs that have been merged to master.
 
 Consider deploying a released version at [zenodo](https://zenodo.org/).
 


### PR DESCRIPTION
Resolves the Oscar part of https://github.com/oscar-system/Oscar.jl/issues/5694.
Once this is in, I will provide analogous PRs to our other packages that keep a changelog.

Please see https://github.com/oscar-system/Oscar.jl/issues/5694 for the motivation behind this.

The only difference in workflow is that the person doing the release has to copy the changelog into the comment calling the JuliaRegistrator instead of afterwards manually editing the auto-generated github release. (ping @benlorenz @aaruni96 since this changes the registration workflow)