### PR TITLE
posets: fix elements for flipped internal polymake representation

### DIFF
--- a/src/Combinatorics/PartiallyOrderedSet/functions.jl
+++ b/src/Combinatorics/PartiallyOrderedSet/functions.jl
@@ -757,9 +757,23 @@ Poset element <[2, 4]>
 ```
 """
 function element(p::PartiallyOrderedSet, i::Int)
-  @req _bottom_node(p) + p.artificial_bottom <= i <= _top_node(p) - p.artificial_top "invalid node id"
+  @req i in _element_ids(p) "invalid node id"
   return PartiallyOrderedSetElement(p, i)
 end
+
+# some posets are upside down in polymake
+function _element_ids(p::PartiallyOrderedSet)
+  bot = _bottom_node(p)
+  top = _top_node(p)
+  dir = top > bot ? 1 : -1
+  top -= dir*p.artificial_top
+  bot += dir*p.artificial_bottom
+  if dir == -1
+    bot, top = top, bot
+  end
+  return (bot:top)
+end
+
 
 @doc raw"""
     elements(p::PartiallyOrderedSet)
@@ -776,9 +790,7 @@ julia> length(elements(pos))
 ```
 """
 elements(p::PartiallyOrderedSet) =
-  PartiallyOrderedSetElement.(
-    Ref(p), (_bottom_node(p) + p.artificial_bottom):(_top_node(p) - p.artificial_top)
-  )
+  PartiallyOrderedSetElement.(Ref(p), _element_ids(p))
 
 @doc raw"""
     elements_of_rank(p::PartiallyOrderedSet, rk::Int)

--- a/test/Combinatorics/Posets.jl
+++ b/test/Combinatorics/Posets.jl
@@ -40,6 +40,7 @@
 
   poscube = face_poset(cube(3))
   @test length(poscube) == 28
+  @test length(elements(poscube)) == 28
 
   possq = face_poset(cube(2))
   @test length(possq) == 10
@@ -55,6 +56,12 @@
 
   posmr = maximal_ranked_poset([2,4,3])
   @test length(posmr) == 11
+
+  posrpp = face_poset(real_projective_plane())
+  @test length(posrpp) == 32
+  @test length(elements(posrpp)) == 32
+  @test_throws ArgumentError element(posrpp, Oscar._top_node(posrpp)) # artificial top
+  @test data(element(posrpp, Oscar._bottom_node(posrpp))) == Int[] # bottom
 
   @testset "basics" begin
     @test rank(pos1) == 2


### PR DESCRIPTION
cc: @antonydellavecchia 