### PR TITLE
CI: always run notify action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -367,7 +367,7 @@ jobs:
     name: Send Slack notification on status change
     needs:
       - extra-long-test
-    if: github.event_name == 'schedule'
+    if: "!cancelled() && github.event_name == 'schedule'"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
same as https://github.com/oscar-system/GAP.jl/pull/1306
makes sure the notify step is run even when the required steps failed
(still running only for the scheduled job)

cc: @aaruni96 

the extra-long tests failed yesterday but the notification step was skipped:
https://github.com/oscar-system/Oscar.jl/actions/runs/21018945181/job/60434004555
but the notification that it succeeded today was sent
https://github.com/oscar-system/Oscar.jl/actions/runs/21054843959/job/60553257989