### PR TITLE
Drop some `AbstractAlgebra.Generic.` in action poly code

### DIFF
--- a/experimental/ActionPolyRing/src/Content.jl
+++ b/experimental/ActionPolyRing/src/Content.jl
@@ -196,7 +196,7 @@ end
 
 ### Union ###
 (apr::ActionPolyRing)() = elem_type(apr)(apr)
-(apr::ActionPolyRing)(upre::AbstractAlgebra.Generic.UniversalPolyRingElem) = elem_type(apr)(apr, upre)
+(apr::ActionPolyRing)(upre::AbstractAlgebra.UniversalPolyRingElem) = elem_type(apr)(apr, upre)
 (apr::ActionPolyRing)(mpre::MPolyRingElem) = elem_type(apr)(apr, mpre)
 (apr::ActionPolyRing)(a::T) where {T<:RingElement} = apr(base_ring(apr)(a))
 

--- a/experimental/ActionPolyRing/src/Types.jl
+++ b/experimental/ActionPolyRing/src/Types.jl
@@ -17,8 +17,8 @@ abstract type ActionPolyRingElem{T} <: RingElem end
  #   __perm_for_sort(R::MyActionPolyRing) -> Vector{Int}
  #   __perm_for_sort_poly(x::MyActionPolyRingElem) -> Vector{Int}
  #   __vtj(R::MyActionPolyRing) -> Dict{MyActionPolyRingElem{T}, Tuple{Int, Vector{Int}}}
- #   base_ring(R::MyActionPolyRing) -> AbstractAlgebra.Generic.UniversalPolyRing{T}
- #   data(x::MyActionPolyRingElem) -> AbstractAlgebra.Generic.UnivPoly{T}
+ #   base_ring(R::MyActionPolyRing) -> AbstractAlgebra.UniversalPolyRing{T}
+ #   data(x::MyActionPolyRingElem) -> AbstractAlgebra.UniversalPolyRingElem{T}
  #   elem_type(::Type{MyActionPolyRing{T}}) = MyActionPolyRingElem{T} 
  #   elementary_symbols(R::MyActionPolyRing) -> Vector{Symbols}
  #   n_action_maps(R::MyActionPolyRing) -> Int
@@ -63,7 +63,7 @@ abstract type ActionPolyRingElem{T} <: RingElem end
 
 ### Difference ###
 mutable struct DifferencePolyRing{T} <: ActionPolyRing{T}
-  upoly_ring::AbstractAlgebra.Generic.UniversalPolyRing{T}
+  upoly_ring::AbstractAlgebra.UniversalPolyRing{T}
   elementary_symbols::Vector{Symbol}
   n_action_maps::Int
   are_perms_up_to_date::Bool
@@ -94,14 +94,14 @@ mutable struct DifferencePolyRing{T} <: ActionPolyRing{T}
 end
 
 mutable struct DifferencePolyRingElem{T} <: ActionPolyRingElem{T}
-  p::AbstractAlgebra.Generic.UniversalPolyRingElem{T}
+  p::AbstractAlgebra.UniversalPolyRingElem{T}
   parent::DifferencePolyRing{T}
   is_perm_up_to_date::Bool
   permutation::Vector{Int}
 
   DifferencePolyRingElem{T}(dpr::DifferencePolyRing{T}) where {T} = new{T}(zero(dpr.upoly_ring), dpr, true, Int[])
 
-  function DifferencePolyRingElem{T}(dpr::DifferencePolyRing{T}, upre::AbstractAlgebra.Generic.UniversalPolyRingElem{T}) where {T}
+  function DifferencePolyRingElem{T}(dpr::DifferencePolyRing{T}, upre::AbstractAlgebra.UniversalPolyRingElem{T}) where {T}
     @req dpr.upoly_ring === parent(upre) "The parent does not match"
     new{T}(upre, dpr, false, zeros(Int, length(upre)))
   end
@@ -110,7 +110,7 @@ end
 
 ### Differential ###
 mutable struct DifferentialPolyRing{T} <: ActionPolyRing{T}
-  upoly_ring::AbstractAlgebra.Generic.UniversalPolyRing{T}
+  upoly_ring::AbstractAlgebra.UniversalPolyRing{T}
   elementary_symbols::Vector{Symbol}
   n_action_maps::Int
   are_perms_up_to_date::Bool
@@ -141,14 +141,14 @@ mutable struct DifferentialPolyRing{T} <: ActionPolyRing{T}
 end
 
 mutable struct DifferentialPolyRingElem{T} <: ActionPolyRingElem{T}
-  p::AbstractAlgebra.Generic.UniversalPolyRingElem{T}
+  p::AbstractAlgebra.UniversalPolyRingElem{T}
   parent::DifferentialPolyRing{T}
   is_perm_up_to_date::Bool
   permutation::Vector{Int}
 
   DifferentialPolyRingElem{T}(dpr::DifferentialPolyRing{T}) where {T} = new{T}(zero(dpr.upoly_ring), dpr, true, Int[])
 
-  function DifferentialPolyRingElem{T}(dpr::DifferentialPolyRing{T}, upre::AbstractAlgebra.Generic.UniversalPolyRingElem{T}) where {T}
+  function DifferentialPolyRingElem{T}(dpr::DifferentialPolyRing{T}, upre::AbstractAlgebra.UniversalPolyRingElem{T}) where {T}
     @req dpr.upoly_ring === parent(upre) "The parent does not match"
     new{T}(upre, dpr, false, zeros(Int, length(upre)))
   end


### PR DESCRIPTION
In order to allow merging `AbstractAlgebra.UniversalPolyRingElem` and `AbstractAlgebra.Generic.UnivPoly` and their parent types (as @lgoettgens  suggested in https://github.com/Nemocas/AbstractAlgebra.jl/pull/2274), I think it is useful to drop some of the explicit `Generic.` types in this code. Most of them are completely redundant as `AbstractAlgebra.Generic.UniversalPolyRingElem === AbstractAlgebra.UniversalPolyRingElem`.

@SirToby25