### PR TITLE
banner: avoid error without git info

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -50,7 +50,7 @@ function _print_banner(;is_dev = Oscar.is_dev)
   version_string = string(VERSION_NUMBER)
   if is_dev
     gitinfo = _get_oscar_git_info()
-    version_string = version_string * " #$(gitinfo[:branch]) $(gitinfo[:commit][1:7]) $(gitinfo[:date][1:10])"
+    version_string = version_string * " " * _short_git_info(gitinfo)
   else
     version_string = "Version " * version_string
   end

--- a/src/utils/versioninfo.jl
+++ b/src/utils/versioninfo.jl
@@ -63,6 +63,17 @@ function _format_git_info(info::Dict; branch=true, commit=false)
   return length(val) > 0 ? " - $(join(val, ", "))" : ""
 end
 
+function _short_git_info(info::Dict)
+  val = String[]
+  if haskey(info, :branch)
+    push!(val, "#$(info[:branch])")
+  end
+  if haskey(info, :commit)
+    push!(val, "$(info[:commit][1:7]) $(info[:date][1:10])")
+  end
+  return join(val, " ")
+end
+
 function _print_dependency_versions(io::IO, deps::AbstractArray{<:AbstractString}; padding="    ", suffix="", branch=false, commit=false)
   width = maximum(length.(deps))+length(suffix)+2
   deps = filter(d->d.name in deps, collect(values(Pkg.dependencies())))


### PR DESCRIPTION
From slack:
```julia
julia> using Oscar
ERROR: InitError: KeyError: key :branch not found
Stacktrace:
  [1] getindex(h::Dict{Symbol, String}, key::Symbol)
    @ Base ./dict.jl:477
  [2] _print_banner(; is_dev::Bool)
    @ Oscar ~/.julia/dev/Oscar/src/Oscar.jl:53
  [3] _print_banner
    @ ~/.julia/dev/Oscar/src/Oscar.jl:48 [inlined]
  [4] __init__()
    @ Oscar ~/.julia/dev/Oscar/src/Oscar.jl:81
```

I think this can only happen when there is no git client installed since git will just print `HEAD` when there is no branch.

It will now just print this when no git client is available:
```
...
  S Y M B O L I C   T O O L S    | 1.7.0-DEV 
```

cc: @simonbrandhorst 