### PR TITLE
doc: no setdocmeta warnings when re-running Oscar.build_doc

### DIFF
--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -172,10 +172,10 @@ function doit(
   singularrev = get_rev(Base.PkgId(Oscar.Singular).uuid)
 
   cd(joinpath(oscardir, "docs")) do
-    DocMeta.setdocmeta!(Oscar, :DocTestSetup, Oscar.doctestsetup(); recursive=true)
-    DocMeta.setdocmeta!(Oscar.Hecke, :DocTestSetup, :(using Hecke); recursive=true)
-    DocMeta.setdocmeta!(Oscar.AbstractAlgebra, :DocTestSetup, :(using AbstractAlgebra); recursive=true)
-    DocMeta.setdocmeta!(Oscar.Nemo, :DocTestSetup, :(using Nemo); recursive=true)
+    DocMeta.setdocmeta!(Oscar, :DocTestSetup, Oscar.doctestsetup(); recursive=true, warn=false)
+    DocMeta.setdocmeta!(Oscar.Hecke, :DocTestSetup, :(using Hecke); recursive=true, warn=false)
+    DocMeta.setdocmeta!(Oscar.AbstractAlgebra, :DocTestSetup, :(using AbstractAlgebra); recursive=true, warn=false)
+    DocMeta.setdocmeta!(Oscar.Nemo, :DocTestSetup, :(using Nemo); recursive=true, warn=false)
 
     if doctest !== false
       Documenter.doctest(Oscar; fix = doctest === :fix, doctestfilters=Oscar.doctestfilters())


### PR DESCRIPTION
This avoids loads of warnings being printed when re-running `Oscar.build_doc()` in the same session.