### PR TITLE
CI: switch some jobs to using ubuntu-slim

### DIFF
--- a/.github/workflows/BibtoolCI.yml
+++ b/.github/workflows/BibtoolCI.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   check-standard-refs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - name: Install bibtool

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -368,7 +368,7 @@ jobs:
     needs:
       - extra-long-test
     if: "!cancelled() && github.event_name == 'schedule'"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Get branch name

--- a/.github/workflows/EnforceLabels.yml
+++ b/.github/workflows/EnforceLabels.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   enforce-labels:
     name: Check for blocking labels
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
     - uses: yogevbd/enforce-label-action@2.2.2

--- a/.github/workflows/EnforceLabels.yml
+++ b/.github/workflows/EnforceLabels.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   enforce-labels:
     name: Check for blocking labels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 2
     steps:
     - uses: yogevbd/enforce-label-action@2.2.2

--- a/.github/workflows/JuliaFormatterCI.yml
+++ b/.github/workflows/JuliaFormatterCI.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   check-consistent-formatting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v6
     - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   update-changelog:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
 
     steps:
     # Checkout the repository


### PR DESCRIPTION
See <https://github.blog/changelog/2026-01-22-1-vcpu-linux-runner-now-generally-available-in-github-actions/>. So this is meant to conserve resources.

Assuming we decide this is a good idea, similar changes should be applied to our other repos.