### PR TITLE
Allow general subquotient modules as input to `vector_space_dimension` and friends.

### DIFF
--- a/experimental/Schemes/src/Tjurina.jl
+++ b/experimental/Schemes/src/Tjurina.jl
@@ -782,7 +782,7 @@ by submodule with 7 generators
   7: x*y*e[2]
 
 julia> vector_space_basis(T)
-5-element Vector{FreeModElem{QQMPolyRingElem}}:
+5-element Vector{SubquoModuleElem{QQMPolyRingElem}}:
  e[1]
  e[2]
  y*e[1]

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -539,6 +539,47 @@ end
 ##########################################################################
 ## Functionality for modules happening to be finite dimensional vector
 ## spaces
+#
+# The general user facing signature is 
+#
+#   vector_space[_dimension/_basis](kk::Field, M::ModuleFP; check::Bool)
+#
+# where we assume that either 1) the `base_ring` of `M` is already the 
+# field `kk`, or 2) the `base_ring` `R` of `M` is an algebra over the 
+# field `kk`. Other cases are possible, but must be caught and delegated 
+# to a custom implementation. 
+#
+# For convenience we also allow 
+#
+#   vector_space[_dimension/_basis](M::ModuleFP; check::Bool, cached::Bool=true)
+#
+# which picks the field `kk` according to the above assumptions. Note 
+# that this has the default option to cache the result (as it does not depend 
+# on a second argument `kk` anymore).
+#
+# Internally we need to first make sure that the module is finitely presented, 
+# i.e. that its `.sub` part is actually the whole `ambient_free_module`. Thus 
+# the generic code passes to a presentation and converts the result back if 
+# necessary. 
+#
+# Once we are sure that the module is presented, we delegate to respective 
+# internal methods 
+#
+#   _vector_space[_dimension/_basis](kk::Field, M::ModuleFP; check::Bool)
+#
+# These might still do internal checks, like e.g. finiteness over `kk`.
+#
+# For the non-graded polynomial case there are methods to filter out a 
+# graded part w.r.t the total degree via 
+#
+#   vector_space[_dimension/_basis](kk::Field, M::ModuleFP, d::Int; check::Bool)
+#
+# These will eventually be deprecated to internal methods, but they are part of 
+# the system for now. In the graded case we aim to have 
+#   
+#   vector_space[_dimension/_basis](kk::Field, M::ModuleFP, d::FinGenAbGroupElem; check::Bool)
+#
+# for which there are stubs at the moment, but only partial implementations.
 ##########################################################################
 @doc raw"""
     vector_space_dim(M::SubquoModule)

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -675,7 +675,7 @@ end
 
 Return a list of elements in `M` which form a basis of `M` as a vector space over `kk`.
 """
-function vector_space_basis(kk::Field, M::SubquoModule)
+function vector_space_basis(kk::Field, M::SubquoModule; check::Bool=true)
   R = base_ring(M)
   # At the moment we do not support vector space dimensions for modules 
   # in cases different from ``kk`` being the `base_ring` of the `base_ring`
@@ -689,30 +689,31 @@ function vector_space_basis(kk::Field, M::SubquoModule)
   if !((ngens(M) == ngens(F)) && all(repres(v) == e for (v, e) in zip(gens(M), gens(F))))
     pres = presentation(M)
     MM = cokernel(map(pres, 1))
-    B = _vector_space_basis(kk, MM)
+    B = _vector_space_basis(kk, MM; check)
     aug = map(pres, 0)
     return elem_type(M)[aug(pres[0](coordinates(v))) for v in B]
   end
   
   # If execution gets here, `M` is presented.
-  result = is_graded(M) ? _vector_space_basis_graded(kk, M) : _vector_space_basis(kk, M)
+  result = is_graded(M) ? _vector_space_basis_graded(kk, M; check) : _vector_space_basis(kk, M; check)
   return result
 end
 
 # compute a vector space basis over the `base_ring` of the `base_ring`
-function _vector_space_basis(kk::Field, M::SubquoModule)
+function _vector_space_basis(kk::Field, M::SubquoModule; check::Bool=true)
   error("not implemented for modules of type $(typeof(M))")
 end
 
-function _vector_space_basis_graded(kk::Field, M::SubquoModule)
+function _vector_space_basis_graded(kk::Field, M::SubquoModule; check::Bool=true)
   error("not implemented for modules of type $(typeof(M))")
 end
 
 ### the ungraded case of polynomial rings over fields
 # This is an internal method which assumes `M` to be presented.
-function _vector_space_basis(kk::Field, M::SubquoModule{T}) where {T <: MPolyRingElem{<:FieldElem}}
+function _vector_space_basis(kk::Field, M::SubquoModule{T}; check::Bool=true) where {T <: MPolyRingElem{<:FieldElem}}
   R = base_ring(M)
   @assert kk === coefficient_ring(R) "not implemented for other fields than the coefficients of the polynomial ring"
+  @check _is_finite(kk, M) "module is not finite over the given field"
   F = ambient_free_module(M)
   if !isdefined(M, :quo)
     is_zero(M) || error("vector space basis of an infinite dimensional module can not be computed")
@@ -725,13 +726,13 @@ function _vector_space_basis(kk::Field, M::SubquoModule{T}) where {T <: MPolyRin
   LM = leading_module(I, o)
   
   d = 0
-  inc = _vector_space_basis(M, 0)
+  inc = _vector_space_basis(kk, M, 0)
   result = elem_type(M)[]
 
   while !isempty(inc)
     result = vcat(result, inc)
     d = d + 1
-    inc = _vector_space_basis(M, d)
+    inc = _vector_space_basis(kk, M, d)
   end
   return result
 end
@@ -741,7 +742,7 @@ function vector_space_dim(M::SubquoModule, d::Union{FinGenAbGroupElem, Int64})
 end
 
 @doc raw"""
-    vector_space_basis(M::SubquoModule, d::Union{FinGenAbGroupElem, Int64})
+    vector_space_basis(M::SubquoModule, d::Union{FinGenAbGroupElem, Int64}; check::Bool=true)
 
 Let ``R`` be the ring over which ``M`` is defined. We assume ``R`` to be 
 a ``kk``-algebra over some field ``kk``. 
@@ -781,21 +782,22 @@ julia> vector_space_basis(M)
 
 ```
 """
-function vector_space_basis(M::SubquoModule, d::Union{FinGenAbGroupElem, Int64})
+function vector_space_basis(M::SubquoModule, d::Union{FinGenAbGroupElem, Int64}; check::Bool=true)
   kk = base_ring(base_ring(M))
-  return is_graded(M) ? _vector_space_basis_graded(kk, M, d) : _vector_space_basis(kk, M, d)
+  return is_graded(M) ? _vector_space_basis_graded(kk, M, d; check) : _vector_space_basis(kk, M, d; check)
 end
 
-function vector_space_basis(M::SubquoModule{T}, d::Union{FinGenAbGroupElem, Int64}) where {T<:FieldElem}
+function vector_space_basis(M::SubquoModule{T}, d::Union{FinGenAbGroupElem, Int64}; check::Bool=true) where {T<:FieldElem}
   kk = base_ring(M)
-  return is_graded(M) ? _vector_space_basis_graded(kk, M, d) : _vector_space_basis(kk, M, d)
+  return is_graded(M) ? _vector_space_basis_graded(kk, M, d; check) : _vector_space_basis(kk, M, d; check)
 end
 
-function _vector_space_basis(kk::Field, M::SubquoModule, d::FinGenAbGroupElem)
+function _vector_space_basis(kk::Field, M::SubquoModule, d::FinGenAbGroupElem; check::Bool=true)
   error("module needs to be graded")
 end
 
-function _vector_space_basis(kk::Field, M::SubquoModule{T}, d::Int64) where {T <: MPolyRingElem{<:FieldElem}}
+function _vector_space_basis(kk::Field, M::SubquoModule{T}, d::Int64; check::Bool=true) where {T <: MPolyRingElem{<:FieldElem}}
+  @check _is_finite(kk, M) "module is not finite over the given field"
   R = base_ring(M)
   F = ambient_free_module(M)
   Mq,_ = sub(F,rels(M))
@@ -807,11 +809,11 @@ function _vector_space_basis(kk::Field, M::SubquoModule{T}, d::Int64) where {T <
   return [M(mon) for mon in mons if !(mon in LM)]
 end
   
-function _vector_space_basis_graded(kk::Field, M::SubquoModule, d::FinGenAbGroupElem)
+function _vector_space_basis_graded(kk::Field, M::SubquoModule, d::FinGenAbGroupElem; check::Bool=true)
   error("not implemented")
 end
 
-function _vector_space_basis_graded(kk::Field, M::SubquoModule, d::Int64)
+function _vector_space_basis_graded(kk::Field, M::SubquoModule, d::Int64; check::Bool=true)
   error("not implemented")
 end
   
@@ -829,7 +831,9 @@ function vector_space_dim(M::SubquoModule{T}
   return vector_space_dim(quo_object(ambient_free_module(LM),gens(LM)))
 end
 
-function vector_space_dim(M::SubquoModule{T}, d::Int64
+function vector_space_dim(
+    M::SubquoModule{T}, d::Int64;
+    check::Bool=true
   ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, 
                                <:MPolyComplementOfKPointIdeal}}
   F = ambient_free_module(M)
@@ -843,7 +847,7 @@ function vector_space_dim(M::SubquoModule{T}, d::Int64
   return vector_space_dim(quo_object(ambient_free_module(LM),gens(LM)),d)
 end
 
-function vector_space_dim(M::SubquoModule{T}
+function vector_space_dim(M::SubquoModule{T}; check::Bool=true
   ) where {T<:MPolyLocRingElem}
   error("only available in global case and for localization at a point")
 end

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -745,16 +745,16 @@ julia> F = free_module(R,2);
 julia> M,_ = quo(F,[1*gen(F,1),x^2*gen(F,2),y^3*gen(F,2),z*gen(F,2),w*gen(F,2)]);
 
 julia> vector_space_basis(M,2)
-2-element Vector{FreeModElem{QQMPolyRingElem}}:
+2-element Vector{SubquoModuleElem{QQMPolyRingElem}}:
  x*y*e[2]
  y^2*e[2]
 
 julia> vector_space_basis(M,0)
-1-element Vector{FreeModElem{QQMPolyRingElem}}:
+1-element Vector{SubquoModuleElem{QQMPolyRingElem}}:
  e[2]
 
 julia> vector_space_basis(M)
-6-element Vector{FreeModElem{QQMPolyRingElem}}:
+6-element Vector{SubquoModuleElem{QQMPolyRingElem}}:
  e[2]
  x*e[2]
  y*e[2]

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -709,6 +709,7 @@ function _vector_space_basis_graded(kk::Field, M::SubquoModule)
 end
 
 ### the ungraded case of polynomial rings over fields
+# This is an internal method which assumes `M` to be presented.
 function _vector_space_basis(kk::Field, M::SubquoModule{T}) where {T <: MPolyRingElem{<:FieldElem}}
   R = base_ring(M)
   @assert kk === coefficient_ring(R) "not implemented for other fields than the coefficients of the polynomial ring"
@@ -781,14 +782,20 @@ julia> vector_space_basis(M)
 ```
 """
 function vector_space_basis(M::SubquoModule, d::Union{FinGenAbGroupElem, Int64})
-  return is_graded(M) ? _vector_space_basis_graded(M, d) : _vector_space_basis(M, d)
+  kk = base_ring(base_ring(M))
+  return is_graded(M) ? _vector_space_basis_graded(kk, M, d) : _vector_space_basis(kk, M, d)
 end
 
-function _vector_space_basis(M::SubquoModule, d::FinGenAbGroupElem)
+function vector_space_basis(M::SubquoModule{T}, d::Union{FinGenAbGroupElem, Int64}) where {T<:FieldElem}
+  kk = base_ring(M)
+  return is_graded(M) ? _vector_space_basis_graded(kk, M, d) : _vector_space_basis(kk, M, d)
+end
+
+function _vector_space_basis(kk::Field, M::SubquoModule, d::FinGenAbGroupElem)
   error("module needs to be graded")
 end
 
-function _vector_space_basis(M::SubquoModule{T}, d::Int64) where {T <: MPolyRingElem{<:FieldElem}}
+function _vector_space_basis(kk::Field, M::SubquoModule{T}, d::Int64) where {T <: MPolyRingElem{<:FieldElem}}
   R = base_ring(M)
   F = ambient_free_module(M)
   Mq,_ = sub(F,rels(M))
@@ -800,11 +807,11 @@ function _vector_space_basis(M::SubquoModule{T}, d::Int64) where {T <: MPolyRing
   return [M(mon) for mon in mons if !(mon in LM)]
 end
   
-function _vector_space_basis_graded(M::SubquoModule, d::FinGenAbGroupElem)
+function _vector_space_basis_graded(kk::Field, M::SubquoModule, d::FinGenAbGroupElem)
   error("not implemented")
 end
 
-function _vector_space_basis_graded(M::SubquoModule, d::Int64)
+function _vector_space_basis_graded(kk::Field, M::SubquoModule, d::Int64)
   error("not implemented")
 end
   
@@ -845,41 +852,6 @@ function vector_space_dim(M::SubquoModule{T}, d::Int64
   ) where {T<:MPolyLocRingElem}
   error("only available in global case and for localization at a point")
 end
-
-#=
-function _vector_space_basis(M::SubquoModule{T}, d::Int) where {T<:MPolyRingElem{<:FieldElem}}
-  R = base_ring(M)
-  F = ambient_free_module(M)
-  Mq,_ = sub(F,rels(M))
-
-  o = default_ordering(M)
-  LM = leading_module(Mq,o)
-
-  d = 0
-  vdim = _vector_space_dim(M)
-  all_mons = vector_space_basis(M,0)
-
-  while length(all_mons) < vdim
-    d += 1
-    append!(all_mons, vector_space_basis(M,d))
-  end
-
-  return all_mons
-end
-
-function vector_space_basis(M::SubquoModule,d::Int64)
-  R = base_ring(M)
-  F = ambient_free_module(M)
-  Mq,_ = sub(F,rels(M))
-
-  ambient_representatives_generators(M) == gens(F) || error("not implemented for M/N with non-trivial M")
-
-  o = default_ordering(M)
-  LM = leading_module(Mq,o)
-
-  return [x*e for x in monomials_of_degree(R, d) for e in gens(F) if !(x*e in LM)]
-end
-=#
 
 function vector_space_basis(M::SubquoModule{T}
   ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, 

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -617,18 +617,18 @@ function vector_space_dim(M::SubquoModule; check::Bool=true, cached::Bool=true)
   R = base_ring(M)
   @assert base_ring(R) isa Field "`base_ring` of the ring over which the module is defined is not a field"
   cached && has_attribute(M, :vector_space_dimension) && return get_attribute(M, :vector_space_dimension)::Union{Int, PosInf}
-  res = vector_space_dim(base_ring(R), M)
+  res = vector_space_dim(base_ring(R), M; check)
   cached && set_attribute!(M, :vector_space_dimension=>res)
   return res
 end
 
 # If the module's ring is already a field, we compute the dimension over that.
 function vector_space_dim(M::SubquoModule{T}; check::Bool=true, cached::Bool=true) where {T <: FieldElem}
-  return vector_space_dim(base_ring(M), M)
+  return vector_space_dim(base_ring(M), M; check)
 end
 
 # Syntax to be coherent with other methods for `vector_space_dim`.
-function vector_space_dim(kk::Field, M::SubquoModule)
+function vector_space_dim(kk::Field, M::SubquoModule; check::Bool=true)
   R = base_ring(M)
   kk === R || kk === base_ring(R) || error("not implemented over fields different from the ground ring or the `base_ring` thereof")
 
@@ -638,19 +638,19 @@ function vector_space_dim(kk::Field, M::SubquoModule)
   if !((ngens(M) == ngens(F)) && all(repres(v) == e for (v, e) in zip(gens(M), gens(F))))
     pres = presentation(M)
     MM = cokernel(map(pres, 1))
-    return _vector_space_dim(kk, MM)
+    return _vector_space_dim(kk, MM; check)
   end
   # At this point we may assume `M` to be presented
-  return _vector_space_dim(kk, M)
+  return _vector_space_dim(kk, M; check)
 end
 
 # Assumes `M` to be presented
-function _vector_space_dim(kk::Field, M::SubquoModule)
+function _vector_space_dim(kk::Field, M::SubquoModule; check::Bool=true)
   _is_finite(kk, M) || return inf
 
   # The generic implementation just takes the length of a basis. 
   # This might not be efficient, so consider overwriting it in specific cases.
-  return length(vector_space_basis(kk, M))
+  return length(vector_space_basis(kk, M; check))
 end
 
 @doc raw"""
@@ -684,28 +684,28 @@ Assume `M` to be defined over a `kk`-algebra `R` which is not a field.
 Return a list of elements in `M` which form a basis for `M` when considered 
 as a vector space over the `base_ring` `kk` of its `base_ring` `R`.
 """
-function vector_space_basis(M::SubquoModule; cached::Bool=true)
+function vector_space_basis(M::SubquoModule; cached::Bool=true, check::Bool=true)
   cached && has_attribute(M, :vector_space_basis) && return get_attribute(M, :vector_space_basis)::Vector{elem_type(M)}
   R = base_ring(M)
   kk = base_ring(R)
-  result = vector_space_basis(kk, M)
+  result = vector_space_basis(kk, M; check)
   if cached
     set_attribute!(M, :vector_space_basis=>result)
   end
   return result
 end
 
-function vector_space_basis(M::SubquoModule{<:FieldElem}; cached::Bool=true)
+function vector_space_basis(M::SubquoModule{<:FieldElem}; cached::Bool=true, check::Bool=true)
   cached && has_attribute(M, :vector_space_basis) && return get_attribute(M, :vector_space_basis)::Vector{elem_type(M)}
   kk = base_ring(M)
-  result = vector_space_basis(kk, M)
+  result = vector_space_basis(kk, M; check)
   if cached
     set_attribute!(M, :vector_space_basis=>result)
   end
   return result
 end
 
-function vector_space_basis(kk::Field, M::SubquoModule{<:FieldElem})
+function vector_space_basis(kk::Field, M::SubquoModule{<:FieldElem}; check::Bool=true)
   kk === base_ring(M) || error("not implemented for other fields than the `base_ring` of the module")
   # TODO: look up the existing implementations of rank and put the relevant things here.
   error("not implemented")

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -604,7 +604,7 @@ function vector_space_dim(kk::Field, M::SubquoModule)
 end
 
 # Assumes `M` to be presented
-function vector_space_dim(kk::Field, M::SubquoModule)
+function _vector_space_dim(kk::Field, M::SubquoModule)
   _is_finite(kk, M) || return inf
 
   # The generic implementation just takes the length of a basis. 

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -550,7 +550,7 @@ the one of each generator of the ambient free module of ``M`` as zero.
 
     vector_space_dim(M::SubquoModule)
 
-If ``M`` happens to be finite-dimensional as a ``k``-vectorspace, return its dimension; otherwise, return -1.
+If ``M`` happens to be finite-dimensional as a ``k``-vectorspace, return its dimension; otherwise, return ``\infty``.  
 
 # Examples:
 ```jldoctest
@@ -585,7 +585,7 @@ function vector_space_dim(M::SubquoModule)
   o = default_ordering(M)
   LM = leading_module(Mq,o)
 
-  has_monomials_on_all_axes(LM) || return Int64(-1)
+  has_monomials_on_all_axes(LM) || return inf
   
   d = 0
   sum_dim = 0
@@ -878,7 +878,7 @@ function _vector_space_basis(M::SubquoModule{T}) where {T<:MPolyRingElem{<:Field
   # TODO: This should call Singular's `kbase` instead. But that is not yet available.
   I = M.quo
   lead_I = leading_module(I)
-  has_monomials_on_all_axes(lead_I) || return Int64(-1)
+  has_monomials_on_all_axes(lead_I) || return inf
   result = elem_type(M)[]
   for i in 1:ngens(F)
     d = 0 # Iterate through the graded parts for the standard grading.

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -1084,3 +1084,19 @@ function vector_space(
   return M, identity_map(M)
 end
 
+### functionality for modules over quotient rings
+function _vector_space_basis(kk::Field, M::SubquoModule{T}; check::Bool=true) where {T <: MPolyQuoRingElem{<:MPolyRingElem{<:FieldElem}}}
+  R = base_ring(M)
+  @assert kk === coefficient_ring(R) "not implemented for other fields than the coefficients of the underlying polynomial ring"
+  @check _is_finite(kk, M) "module is not finite over the given field"
+  B = _vector_space_basis(kk, _as_poly_module(M), check=false)
+  is_empty(B) && return elem_type(M)[]
+  iota = _iso_with_poly_module(M)
+  return iota.(B)
+end
+
+function _is_finite(kk::Field, M::SubquoModule{T}) where {T<:MPolyQuoRingElem{<:MPolyRingElem{<:FieldElem}}}
+  @assert kk === coefficient_ring(base_ring(M)) "not implemented for fields other than the `coefficient_ring` of the `base_ring` of the module"
+  return _is_finite(kk, _as_poly_module(M))
+end
+

--- a/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
+++ b/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
@@ -196,7 +196,7 @@ Compute a Gröbner of `submod` with respect to the given `ordering`.
 The ordering must be global. The return type is `ModuleGens`.
 """
 function groebner_basis(submod::SubModuleOfFreeModule, ordering::ModuleOrdering = default_ordering(submod))
-  @assert is_global(ordering)
+  @assert ordering === default_ordering(submod) || is_global(ordering) # The former is always global and thus provides a shortcut.
   return standard_basis(submod, ordering=ordering)
 end
 

--- a/src/Modules/mpolyquo.jl
+++ b/src/Modules/mpolyquo.jl
@@ -145,8 +145,8 @@ end
 @attr SubquoModule{T} function _as_poly_module(M::SubquoModule{MPolyQuoRingElem{T}}) where {T}
   F = ambient_free_module(M) 
   FP = _poly_module(F)
-  v = [_lifting_map(F)(g) for g in ambient_representatives_generators(M)] 
-  w = [f*e for e in gens(FP) for f in gens(modulus(base_ring(M)))]
+  v = elem_type(FP)[_lifting_map(F)(g) for g in ambient_representatives_generators(M)] 
+  w = elem_type(FP)[f*e for e in gens(FP) for f in gens(modulus(base_ring(M)))]
   w_ext = vcat(w, elem_type(FP)[_lifting_map(F)(g) for g in relations(M)])
   MP = SubquoModule(FP, v, w_ext)
   return MP

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -1963,7 +1963,7 @@ end
   IF, _ = I*F
   I2F, _ = I^2*F
   M, _ = quo(IF, I2F)
-  B = Oscar._vector_space_basis(M)
+  B = vector_space_basis(M)
   @test length(B) == 2
   @test x*F[1] in repres.(B)
   @test y*F[1] in repres.(B)

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -1955,3 +1955,17 @@ end
   @test O + M != O
   @test M + O == M
 end
+
+@testset "vector space basis for modules" begin
+  R, (x, y) = GF(101)[:x, :y]
+  F = free_module(R, 1)
+  I = ideal(R, gens(R))
+  IF, _ = I*F
+  I2F, _ = I^2*F
+  M, _ = quo(IF, I2F)
+  B = Oscar._vector_space_basis(M)
+  @test length(B) == 2
+  @test x*F[1] in B
+  @test y*F[1] in B
+end
+

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -1965,7 +1965,13 @@ end
   M, _ = quo(IF, I2F)
   B = Oscar._vector_space_basis(M)
   @test length(B) == 2
-  @test x*F[1] in B
-  @test y*F[1] in B
+  @test x*F[1] in repres.(B)
+  @test y*F[1] in repres.(B)
+  
+  #=
+  V, inc = vector_space(M)
+  @test dim(V) == 2
+  @test inc.(gens(V)) == B
+  =#
 end
 

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -1973,5 +1973,11 @@ end
   @test vector_space_dimension(V) == 2
   @test inc.(gens(V)) == B
   @test vector_space(V)[1] === V
+
+  R, (x,y) = QQ[:x,:y]
+  F = free_module(R, 2)
+  S = SubquoModule(F, gens(F), [F[1]])
+  # not a finite module over `QQ`
+  @test_throws ErrorException vector_space_basis(S)
 end
 

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -1968,10 +1968,10 @@ end
   @test x*F[1] in repres.(B)
   @test y*F[1] in repres.(B)
   
-  #=
   V, inc = vector_space(M)
-  @test dim(V) == 2
+  @test V isa FreeMod
+  @test vector_space_dimension(V) == 2
   @test inc.(gens(V)) == B
-  =#
+  @test vector_space(V)[1] === V
 end
 

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -1970,7 +1970,7 @@ end
   
   V, inc = vector_space(M)
   @test V isa FreeMod
-  @test vector_space_dimension(V) == 2
+  @test vector_space_dim(V) == 2
   @test inc.(gens(V)) == B
   @test vector_space(V)[1] === V
 


### PR DESCRIPTION
This is an attempt to introduce `vector_space_basis` for `SubquoModule`s over polynomial rings over a field. It is an analogue of Singular's `kbase` command. I would have been happy to use that since I expect it to be significantly faster, but I only found the version for ideals available. Does anyone but @hannes14 know how to bring `kbase` for modules to the foreground? 

It's not super urgent since this here works. But if this can easily be resolved, then we might try. 

Ping @jankoboehm .

Edit: There are some points which we might want to discuss about this. 
 * I made this an internal function for the moment. But if we agree on the format, then I suggest we make this a method of the already existing `vector_space_basis`.
 * If people like it in general, then let's extend this to `vector_space` and `vector_space_dimension`, too. 
 * As said above: If it's feasible to wrap Singular's `kbase`, let's do that
 * One reason why this is slow is that the `reduce(a::ModuleFPElem, gb)` has an `@assert is_global` on the monomial ordering in `src/Modules/UngradedModules/SubModuleOfFreeModule.jl`, line `552`. This showed up during profiling, so this test seems expensive. We could either cache that property in the monomial ordering, or hide the check behind an `@check`. Further, we might consider using/introducing a method which reduces a whole vector and not only single elements. 