### PR TITLE
Use GenericCharacterTables 0.7.2 for book tests

### DIFF
--- a/test/book/cornerstones/groups/auxiliary_code/main.jl
+++ b/test/book/cornerstones/groups/auxiliary_code/main.jl
@@ -1,3 +1,3 @@
 import Pkg
-Pkg.add(name="GenericCharacterTables", version="0.7.1"; io=devnull)
+Pkg.add(name="GenericCharacterTables", version="0.7.2"; io=devnull)
 using GenericCharacterTables


### PR DESCRIPTION
This uses a GenericCharacterTables version compatible with #5168 for the book tests.