### PR TITLE
add selfprojecting to the docs

### DIFF
--- a/experimental/OscarDB/docs/doc.main
+++ b/experimental/OscarDB/docs/doc.main
@@ -1,5 +1,6 @@
 [
    "OscarDB" => [
-      "introduction.md"
+     "introduction.md",
+     "selfprojecting.md"
    ],
 ]


### PR DESCRIPTION
missing line to add self projecting realization spaces to OscarDB documentation.