### PR TITLE
Correct variable permutation for rational solutions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,7 +34,7 @@ lib4ti2_jll = "1493ae25-0f90-5c0e-a06c-8c5077d6d66f"
 
 [compat]
 AbstractAlgebra = "0.48.0"
-AlgebraicSolving = "0.10.3"
+AlgebraicSolving = "0.10.4"
 CodecZlib = "0.7.8"
 Compat = "4.13.0"
 Distributed = "1.6"

--- a/test/Rings/solving.jl
+++ b/test/Rings/solving.jl
@@ -131,6 +131,15 @@ end
     @test issetequal(pts_swapped, [K.([0, 1]), K.([0, -1]), K.([2, 1]), K.([2, -1])])
   end
 
+  # issue 5741
+  let
+     P, (x,y,z) = polynomial_ring(QQ, [:x,:y,:z])
+     I = ideal(P,[(x-1)*x, y-2, z-3])
+     rat_sols = rational_solutions(I)
+     @test isequal(map(point -> map(gen -> evaluate(gen, point), gens(I)), rat_sols),
+                   [QQFieldElem[0,0,0],[0,0,0]])
+  end
+
   let
     K = algebraic_closure(QQ)
     R, (x, y) = polynomial_ring(K, [:x, :y])


### PR DESCRIPTION
Fixes #5741 via enforcing `AlgebraicSolving.jl v0.10.4` which implements correct variable permutation for `rational_solutions()`. Corresponding bug from #5741 is added as test case.