### PR TITLE
Adds missing checks for `vector_space_dim` and `vector_space_basis` for `SubquoModule` over `MPolyLocRing` 

### DIFF
--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -619,6 +619,8 @@ function vector_space_dim(M::SubquoModule{T}
   F = ambient_free_module(M)
   Mq,_ = sub(F,rels(M))
 
+  ambient_representatives_generators(M) == gens(F) || error("not implemented for M/N with non-trivial M")
+
   M_shift,_,_ = shifted_module(Mq)
   o = negdegrevlex(base_ring(M_shift))*lex(ambient_free_module(M_shift))
   LM = leading_module(M_shift,o)
@@ -630,6 +632,8 @@ function vector_space_dim(M::SubquoModule{T},d::Int64
                                <:MPolyComplementOfKPointIdeal}}
   F = ambient_free_module(M)
   Mq,_ = sub(F,rels(M))
+
+  ambient_representatives_generators(M) == gens(F) || error("not implemented for M/N with non-trivial M")
 
   M_shift,_,_ = shifted_module(Mq)
   o = negdegrevlex(base_ring(M_shift))*lex(ambient_free_module(M_shift))
@@ -730,6 +734,8 @@ function vector_space_basis(M::SubquoModule{T}
   F = ambient_free_module(M)
   Mq,_ = sub(F,rels(M))
 
+  ambient_representatives_generators(M) == gens(F) || error("not implemented for M/N with non-trivial M")
+
   M_shift,_,_ = shifted_module(Mq)
   if isdefined(F,:ordering) && is_local(F.ordering)
     o = F.ordering
@@ -746,6 +752,8 @@ function vector_space_basis(M::SubquoModule{T},d::Int64
                                <:MPolyComplementOfKPointIdeal}}
   F = ambient_free_module(M)
   Mq,_ = sub(F,rels(M))
+
+  ambient_representatives_generators(M) == gens(F) || error("not implemented for M/N with non-trivial M")
 
   M_shift,_,_ = shifted_module(Mq)
   if isdefined(F,:ordering) && is_local(F.ordering)


### PR DESCRIPTION
Fixes #5746, by adding the missing checks whether the ambient generators of a `SubquoModule` over a `MPolyLocRing` (localized at a point)  are trivial for the functions `vector_space_dim` and `vector_space_basis` and throws a not-implemented error, if necessary.