### PR TITLE
provide `has_GapObj_with_GapObj`

### DIFF
--- a/src/GAP/oscar_to_gap.jl
+++ b/src/GAP/oscar_to_gap.jl
@@ -26,3 +26,12 @@ GAP.@install function GapObj(obj::AbstractAlgebra.Generic.MatSpaceElem{AbsSimple
     mat = [GapObj(obj[i,j]) for i in 1:nrows(obj), j in 1:ncols(obj)]
     return GapObj(mat)
 end
+
+function has_GapObj_with_GapObj(input; recursive::Bool = false)
+  try
+    res = GapObj(input, recursive = recursive)
+    return true, res
+  catch e
+    return false, GAP.Globals.fail
+  end
+end

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -41,7 +41,7 @@ function sub(G::GAPGroup, gens::AbstractVector{<: GAPGroupElem}; check::Bool = t
   flag, GapG = has_GapObj_with_GapObj(G)
   flag || return matrix_group(base_ring(G), degree(G), gens)
   elems_in_GAP = GapObj(gens; recursive = true)
-  H = GAP.Globals.SubgroupNC(GapObj(G), elems_in_GAP)::GapObj
+  H = GAP.Globals.SubgroupNC(GapG, elems_in_GAP)::GapObj
   return _as_subgroup(G, H)
 end
 

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -38,6 +38,8 @@ function sub(G::GAPGroup, gens::AbstractVector{<: GAPGroupElem}; check::Bool = t
   if check
     @req all(x -> parent(x) === G || x in G, gens) "not all elements of gens lie in G"
   end
+  flag, GapG = has_GapObj_with_GapObj(G)
+  flag || return matrix_group(base_ring(G), degree(G), gens)
   elems_in_GAP = GapObj(gens; recursive = true)
   H = GAP.Globals.SubgroupNC(GapObj(G), elems_in_GAP)::GapObj
   return _as_subgroup(G, H)

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -249,6 +249,13 @@ end
    @test_throws ErrorException G[1]
    G = SO(3, residue_ring(ZZ, 9)[1])
    @test nrows(G[1]) == 3
+
+   G = GL(2, QQ)
+   @test_throws ErrorException GapObj(G)
+   S = sub(G, [G(QQ[0 -1; 1 0])])
+   @test order(S) == 4
+   S = sub(G, [G(QQ[1 2; 5 6])])
+   @test ! is_finite(S)
 end
 
 @testset "Type operations" begin


### PR DESCRIPTION
addresses #5742

If we proceed like this then `has_GapObj_with_GapObj` should be moved to GAP.jl