### PR TITLE
Fix degree bound for ideal in quantum_symmetric_group

### DIFF
--- a/src/Combinatorics/Matroids/quantum_automorphism_groups.jl
+++ b/src/Combinatorics/Matroids/quantum_automorphism_groups.jl
@@ -134,6 +134,7 @@ function quantum_symmetric_group(n::Int; reduced_gb::Bool=true)
   end
   
   I = ideal(relations)
+  I.deg_bound=-1
 
   if n >= 5
     gb = _quantum_symmetric_group_groebner_basis(n; u=u)


### PR DESCRIPTION
Set degree bound for ideal to -1. This should fix the randomly failing tests.