### PR TITLE
Enhance signature for `complement_of_prime_ideal`

### DIFF
--- a/src/AlgebraicGeometry/Schemes/Sheaves/IdealSheaves.jl
+++ b/src/AlgebraicGeometry/Schemes/Sheaves/IdealSheaves.jl
@@ -1245,18 +1245,6 @@ function (phi::MPolyAnyMap{D, C})(I::MPolyQuoIdeal) where {D<:MPolyQuoRing, C<:R
   return ideal(S, phi.(gens(I)))
 end
 
-function complement_of_prime_ideal(P::MPolyQuoIdeal)
-  return complement_of_prime_ideal(saturated_ideal(P))
-end
-
-function complement_of_prime_ideal(P::MPolyQuoLocalizedIdeal)
-  return complement_of_prime_ideal(saturated_ideal(P))
-end
-
-function complement_of_prime_ideal(P::MPolyLocalizedIdeal)
-  return complement_of_prime_ideal(saturated_ideal(P))
-end
-
 radical(I::PrimeIdealSheafFromChart) = I
 
 # TODO: This function should be removed for ideal sheaves! 

--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -285,6 +285,11 @@ complement_of_point_ideal(R::MPolyRing, a::Vector) = MPolyComplementOfKPointIdea
 Given a prime ideal ``P`` of a multivariate polynomial ring ``R``, say,
 return the multiplicatively closed subset ``R\setminus P.``
 
+Note that for other rings such as quotients and/or localizations of multivariate polynomial 
+rings `complement_of_prime_ideal` will return a multiplicative set in the 
+underlying polynomial ring. This is due to our choice to keep localizations "flat" 
+and to always localize from the top-level polynomial ring. 
+
 !!! note
     If  `check` is set to `true` (default), the function checks whether ``P`` is indeed a prime ideal. 
 

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -2999,3 +2999,20 @@ function is_known(::typeof(is_one),
 end
 
 
+# Some additional methods for `complement_of_prime_ideal`
+#
+# Note that these give an object in the `base_ring`, rather than 
+# the ring of the ideal itself, due to the general philosophy to 
+# always flatten the localizations. 
+function complement_of_prime_ideal(P::MPolyQuoIdeal; check::Bool=true)
+  return complement_of_prime_ideal(saturated_ideal(P); check)
+end
+
+function complement_of_prime_ideal(P::MPolyQuoLocalizedIdeal; check::Bool=true)
+  return complement_of_prime_ideal(saturated_ideal(P); check)
+end
+
+function complement_of_prime_ideal(P::MPolyLocalizedIdeal; check::Bool=true)
+  return complement_of_prime_ideal(saturated_ideal(P); check)
+end
+


### PR DESCRIPTION
This is a small enhancement following up the discussions with "Lloyd" on Slack. It basically adds the optional `check` argument to more methods of `complement_of_prime_ideal` and adds an explanation to the docstring. 