### PR TITLE
Use `universal_poly_ring_type` for action polys

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,7 @@ f4ncgb_jll = "160f184c-7e1a-5d95-af1f-70d62a450302"
 lib4ti2_jll = "1493ae25-0f90-5c0e-a06c-8c5077d6d66f"
 
 [compat]
-AbstractAlgebra = "0.48.0"
+AbstractAlgebra = "0.48.3"
 AlgebraicSolving = "0.10.4"
 CodecZlib = "0.7.8"
 Compat = "4.13.0"

--- a/experimental/ActionPolyRing/src/Content.jl
+++ b/experimental/ActionPolyRing/src/Content.jl
@@ -186,7 +186,7 @@ Return the multiplicitive identity of the action polynomial ring `A`.
 """
 one(apr::ActionPolyRing) = apr(one(base_ring(apr)))
 
-base_ring_type(::Type{<:ActionPolyRing{T}}) where {T} = AbstractAlgebra.Generic.UniversalPolyRing{T}
+base_ring_type(::Type{<:ActionPolyRing{T}}) where {T} = universal_poly_ring_type(T)
 
 coefficient_ring_type(::Type{<:ActionPolyRing{T}}) where {T} = parent_type(T)
 


### PR DESCRIPTION
This is in preparation for https://github.com/Nemocas/AbstractAlgebra.jl/pull/2274 and should be in 1.7.0.