### PR TITLE
Enhancement: Adds `vector_space_dim` and friends for subquotient modules over a MPoly(Quo)LocRing localized at a point

### DIFF
--- a/experimental/Schemes/src/Tjurina.jl
+++ b/experimental/Schemes/src/Tjurina.jl
@@ -782,7 +782,7 @@ by submodule with 7 generators
   7: x*y*e[2]
 
 julia> vector_space_basis(T)
-5-element Vector{SubquoModuleElem{QQMPolyRingElem}}:
+5-element Vector{SubquoModuleElem{MPolyLocRingElem{QQField, QQFieldElem, QQMPolyRing, QQMPolyRingElem, MPolyComplementOfKPointIdeal{QQField, QQFieldElem, QQMPolyRing, QQMPolyRingElem}}}}:
  e[1]
  e[2]
  y*e[1]

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -633,7 +633,6 @@ function vector_space_dim(kk::Field, M::SubquoModule; check::Bool=true)
   R = base_ring(M)
   kk === R || kk === coefficient_ring(R) || error("not implemented over fields different from the ground ring or the `coefficient_ring` thereof")
 
-  S = base_ring(M)
   F = ambient_free_module(M)
   # We need `M` to be presented  
   if !((ngens(M) == ngens(F)) && all(repres(v) == e for (v, e) in zip(gens(M), gens(F))))
@@ -725,7 +724,6 @@ function vector_space_basis(kk::Field, M::SubquoModule; check::Bool=true)
   # to a respective internal method. 
   kk === coefficient_ring(R) || error("`vector_space_basis` not implemented over fields other than the `coefficient_ring` of the ring over which the module is defined")
 
-  S = base_ring(M)
   F = ambient_free_module(M)
   # We need `M` to be presented  
   if !((ngens(M) == ngens(F)) && all(repres(v) == e for (v, e) in zip(gens(M), gens(F))))
@@ -756,16 +754,10 @@ function _vector_space_basis(kk::Field, M::SubquoModule{T}; check::Bool=true) wh
   R = base_ring(M)
   @assert kk === coefficient_ring(R) "not implemented for other fields than the coefficients of the polynomial ring"
   @check _is_finite(kk, M) "module is not finite over the given field"
-  F = ambient_free_module(M)
   if !isdefined(M, :quo)
     is_zero(M) || error("vector space basis of an infinite dimensional module can not be computed")
     return elem_type(M)[]
   end
-
-  I = M.quo
-
-  o = default_ordering(M)
-  LM = leading_module(I, o)
   
   d = 0
   inc = _vector_space_basis(kk, M, 0; check)
@@ -851,14 +843,15 @@ function vector_space_basis(M::SubquoModule{T}, d::Union{FinGenAbGroupElem, Int6
 end
 
 function vector_space_basis(kk::Field, M::SubquoModule{T}, d::Union{FinGenAbGroupElem, Int64}; check::Bool=true) where {T<:FieldElem}
-  @assert kk === base_ring(M) "not implemented for fields other than the `baser_ring` of the module" 
+  @assert kk === base_ring(M) "not implemented for fields other than the `base_ring` of the module" 
   return is_graded(M) ? _vector_space_basis_graded(kk, M, d; check) : _vector_space_basis(kk, M, d; check)
 end
 
-function _vector_space_basis(kk::Field, M::SubquoModule, d::FinGenAbGroupElem; check::Bool=true)
+function _vector_space_basis(kk::Field, M::SubquoModule, d::Union{FinGenAbGroupElem, Int64}; check::Bool=true)
   error("module needs to be graded")
 end
 
+# This is an internal method which assumes `M` to be presented.
 function _vector_space_basis(kk::Field, M::SubquoModule{T}, d::Int64; check::Bool=true) where {T <: MPolyRingElem{<:FieldElem}}
   R = base_ring(M)
   F = ambient_free_module(M)
@@ -1086,17 +1079,22 @@ function vector_space(
 end
 
 ### functionality for modules over quotient rings
-function _vector_space_basis(kk::Field, M::SubquoModule{T}; check::Bool=true) where {T <: MPolyQuoRingElem{<:MPolyRingElem{<:FieldElem}}}
-  R = base_ring(M)
-  @assert kk === coefficient_ring(R) "not implemented for other fields than the coefficients of the underlying polynomial ring"
+function _vector_space_basis(
+    kk::Field, M::SubquoModule{T}; check::Bool=true
+  ) where {T <: MPolyQuoRingElem{<:MPolyRingElem{<:FieldElem}}}
+
+  @assert kk === coefficient_ring(base_ring(M)) "not implemented for other fields than the coefficients of the underlying polynomial ring"
   @check _is_finite(kk, M) "module is not finite over the given field"
-  B = _vector_space_basis(kk, _as_poly_module(M), check=false)
+  B = _vector_space_basis(kk, _as_poly_module(M), check=false) # check=false, since `_is_finite` has already been checked, if check=true
   is_empty(B) && return elem_type(M)[]
   iota = _iso_with_poly_module(M)
   return iota.(B)
 end
 
-function _is_finite(kk::Field, M::SubquoModule{T}) where {T<:MPolyQuoRingElem{<:MPolyRingElem{<:FieldElem}}}
+function _is_finite(
+    kk::Field, M::SubquoModule{T}
+  ) where {T<:MPolyQuoRingElem{<:MPolyRingElem{<:FieldElem}}}
+
   @assert kk === coefficient_ring(base_ring(M)) "not implemented for fields other than the `coefficient_ring` of the `base_ring` of the module"
   return _is_finite(kk, _as_poly_module(M))
 end

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -750,9 +750,15 @@ end
 
 ### the ungraded case of polynomial rings over fields
 # This is an internal method which assumes `M` to be presented.
-function _vector_space_basis(kk::Field, M::SubquoModule{T}; check::Bool=true) where {T <: MPolyRingElem{<:FieldElem}}
+function _vector_space_basis(
+    kk::Field, M::SubquoModule{T}; check::Bool=true
+  ) where {T <: Union{MPolyRingElem{<:FieldElem}, 
+                      MPolyLocRingElem{<:Field, <:FieldElem, 
+                                       <:MPolyRing, <:MPolyRingElem,
+                                       <:MPolyComplementOfKPointIdeal}
+                      }}
   R = base_ring(M)
-  @assert kk === coefficient_ring(R) "not implemented for other fields than the coefficients of the polynomial ring"
+  @assert kk === coefficient_ring(R) "not implemented for other fields than the coefficients of the underlying polynomial ring"
   @check _is_finite(kk, M) "module is not finite over the given field"
   if !isdefined(M, :quo)
     is_zero(M) || error("vector space basis of an infinite dimensional module can not be computed")
@@ -1052,33 +1058,12 @@ end
 # The change of coordinates puts the rational point at which the localization 
 # happens at the origin. This has the advantage that one can work with local 
 # orderings. 
-function _vector_space_basis(
-    kk::Field, M::SubquoModule{T}; check::Bool=true
-  ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem, 
-                               <:MPolyRing, <:MPolyRingElem,
-                               <:MPolyComplementOfKPointIdeal
-                              }}
-  @assert kk === coefficient_ring(base_ring(M)) "not implemented for other fields than the coefficients of the underlying polynomial ring"
-  @check _is_finite(kk, M) "module is not finite over the given field"
 
-  if !isdefined(M, :quo) # exists to prevent an infinite runtime for a submodule `M` when called with check=false
-    is_zero(M) || error("vector space basis of an infinite dimensional module can not be computed")
-    return elem_type(M)[]
-  end
 
-  F = ambient_free_module(M)
-  F_shift_poly, _, back_shift = shifted_module(F)
-  M_shift, _, _ = shifted_module(M)
-  o = negdegrevlex(base_ring(M_shift))*lex(F_shift_poly)
-  LMq = leading_module(M_shift.quo, o)
-  # TODO: Do we really need to recreate the module from the leading module here???
-  B = _vector_space_basis(kk, quo_object(F_shift_poly, gens(LMq)), check=false) # check=false, since `_is_finite` has already been checked, if check=true
-  is_empty(B) && return elem_type(M)[]
-  # move basis elements back to M
-  iota = base_ring_module_map(F)
-  # LMq(shifted) -> F_poly(shifted) -> F_poly -> F -> M
-  return M.(iota.(back_shift.(ambient_representative.(B))))
-end
+# The function for computing the entire `vector_space_basis` of `M` is 
+# implemented in the `MPolyRing` section above, since it is the same, 
+# reducing to computing the `vector_space_bases` for all non-zero 
+#
 
 function _is_finite(
     kk::Field, M::SubquoModule{T}
@@ -1095,28 +1080,38 @@ function _is_finite(
 end
 
 # This is an internal method which assumes `M` to be presented. 
-# It exists purely for back backwards compatibility.
 # The difference compared to the method above is that a degree `d` 
 # is specified so that the basis w.r.t this graded piece for the 
 # grading by total degree is computed. 
+# It exists for two reasons:
+#   1.) for backwards compatibility and 
+#   2.) for being able to compute `vector_space_basis` for `M`
+#       graded piece by graded piece.
 function _vector_space_basis(
     kk::Field, M::SubquoModule{T}, d::Int64 ; check::Bool=true
   ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem,
                                <:MPolyRing, <:MPolyRingElem,
                                <:MPolyComplementOfKPointIdeal
                               }}
-  is_zero(M) && return elem_type(M)[]
-  F = ambient_free_module(M)  
-  F_shift_poly,_,back_shift = shifted_module(F)
-  M_shift,_,_ = shifted_module(M)
-  o = negdegrevlex(base_ring(M_shift))*lex(F_shift_poly)
-  LMq = leading_module(M_shift.quo, o)      # M_shift.quo is always defined after using `shifted_module`, even when M_shift.quo == 0
-  B = _vector_space_basis(kk, quo_object(F_shift_poly, gens(LMq)), d; check)
-  is_empty(B) && return elem_type(M)[]
-  # move basis elements back to M
+  L = base_ring(M)
+  R = base_ring(L)
+  F = ambient_free_module(M)
+  
+  F_shift, _, back_shift = shifted_module(F)
   iota = base_ring_module_map(F)
-  # LMq(shifted & poly) -> F_shift_poly -> F_poly -> F -> M
-  return M.(iota.(back_shift.(ambient_representative.(B))))  
+  
+  mons = elem_type(F_shift)[a*e for (a, e) in Iterators.product(monomials_of_degree(R, d), gens(F_shift))]
+  
+  if !isdefined(M, :quo) || is_zero(M.quo)  # exists to prevent a undefined field access
+    return M.(iota.(back_shift.(vec(mons))))
+  end
+  
+  M_shift, _, _ = shifted_module(M)
+  o = negdegrevlex(base_ring(M_shift))*lex(F_shift)
+  LMq = leading_module(M_shift.quo, o)
+
+  B = elem_type(F_shift)[mon for mon in mons if !(mon in LMq)]
+  return M.(iota.(back_shift.(B)))
 end
 
 ### functionality for modules over quotients of localized polynomial rings at a point

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -890,94 +890,6 @@ function _vector_space_basis_graded(kk::Field, M::SubquoModule, d::Int64; check:
   error("not implemented")
 end
   
-function vector_space_dim(M::SubquoModule{T}
-  ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, 
-                               <:MPolyComplementOfKPointIdeal}}
-  F = ambient_free_module(M)
-  Mq,_ = sub(F,rels(M))
-
-  ambient_representatives_generators(M) == gens(F) || error("not implemented for M/N with non-trivial M")
-
-  M_shift,_,_ = shifted_module(Mq)
-  o = negdegrevlex(base_ring(M_shift))*lex(ambient_free_module(M_shift))
-  LM = leading_module(M_shift,o)
-  return vector_space_dim(quo_object(ambient_free_module(LM),gens(LM)))
-end
-
-function vector_space_dim(
-    M::SubquoModule{T}, d::Int64;
-    check::Bool=true
-  ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, 
-                               <:MPolyComplementOfKPointIdeal}}
-  F = ambient_free_module(M)
-  Mq,_ = sub(F,rels(M))
-
-  ambient_representatives_generators(M) == gens(F) || error("not implemented for M/N with non-trivial M")
-
-  M_shift,_,_ = shifted_module(Mq)
-  o = negdegrevlex(base_ring(M_shift))*lex(ambient_free_module(M_shift))
-  LM = leading_module(M_shift,o)
-  return vector_space_dim(quo_object(ambient_free_module(LM),gens(LM)),d)
-end
-
-function vector_space_dim(M::SubquoModule{T}; check::Bool=true
-  ) where {T<:MPolyLocRingElem}
-  error("only available in global case and for localization at a point")
-end
-
-function vector_space_dim(M::SubquoModule{T}, d::Int64
-  ) where {T<:MPolyLocRingElem}
-  error("only available in global case and for localization at a point")
-end
-
-function vector_space_basis(M::SubquoModule{T}
-  ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, 
-                               <:MPolyComplementOfKPointIdeal}}
-  F = ambient_free_module(M)
-  Mq,_ = sub(F,rels(M))
-
-  ambient_representatives_generators(M) == gens(F) || error("not implemented for M/N with non-trivial M")
-
-  M_shift,_,_ = shifted_module(Mq)
-  if isdefined(F,:ordering) && is_local(F.ordering)
-    o = F.ordering
-  else
-    o = negdegrevlex(base_ring(M_shift))*lex(ambient_free_module(M_shift))
-  end
-  LM = leading_module(M_shift,o)
-
-  return vector_space_basis(quo_object(ambient_free_module(LM),gens(LM)))
-end
-
-function vector_space_basis(M::SubquoModule{T},d::Int64
-  ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem, <:MPolyRing, <:MPolyRingElem, 
-                               <:MPolyComplementOfKPointIdeal}}
-  F = ambient_free_module(M)
-  Mq,_ = sub(F,rels(M))
-
-  ambient_representatives_generators(M) == gens(F) || error("not implemented for M/N with non-trivial M")
-
-  M_shift,_,_ = shifted_module(Mq)
-  if isdefined(F,:ordering) && is_local(F.ordering)
-    o = F.ordering
-  else
-    o = negdegrevlex(base_ring(M_shift))*lex(ambient_free_module(M_shift))
-  end
-  LM = leading_module(M_shift,o)
-
-  return vector_space_basis(quo_object(ambient_free_module(LM),gens(LM)),d)
-end
-
-function vector_space_basis(M::SubquoModule{T}
-  ) where {T<:MPolyLocRingElem}
-  error("only available in global case and for localization at a point")
-end
-
-function vector_space_basis(M::SubquoModule{T},d::Int64
-  ) where {T<:MPolyLocRingElem}
-  error("only available in global case and for localization at a point")
-end
-
 @doc raw"""
     _has_monomials_on_all_axes(M::SubquoModule)
 
@@ -1117,3 +1029,107 @@ function _is_finite(
   return _is_finite(kk, _as_poly_module(M))
 end
 
+### functionality for modules over localized polynomial rings at a point
+function _vector_space_basis(
+    kk::Field, M::SubquoModule{T}; check::Bool=true
+  ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem, 
+                               <:MPolyRing, <:MPolyRingElem,
+                               <:MPolyComplementOfKPointIdeal
+                              }}
+  @assert kk === coefficient_ring(base_ring(M)) "not implemented for other fields than the coefficients of the underlying polynomial ring"
+  @check _is_finite(kk, M) "module is not finite over the given field"
+
+  if !isdefined(M, :quo) # exists to prevent an infinite runtime for a submodule `M` when called with check=false
+    is_zero(M) || error("vector space basis of an infinite dimensional module can not be computed")
+    return elem_type(M)[]
+  end
+
+  F = ambient_free_module(M)
+  F_shift_poly,_,back_shift = shifted_module(F)
+  M_shift,_,_ = shifted_module(M)
+  o = negdegrevlex(base_ring(M_shift))*lex(F_shift_poly)
+  LMq = leading_module(M_shift.quo, o)
+  B = _vector_space_basis(kk, quo_object(F_shift_poly, gens(LMq)), check=false) # check=false, since `_is_finite` has already been checked, if check=true
+  is_empty(B) && return elem_type(M)[]
+  # move basis elements back to M
+  iota = base_ring_module_map(F)
+  # LMq(shifted) -> F_poly(shifted) -> F_poly -> F -> M
+  return M.(iota.(back_shift.(ambient_representative.(B))))
+end
+
+function _is_finite(
+    kk::Field, M::SubquoModule{T}
+  ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem,
+                               <:MPolyRing, <:MPolyRingElem,
+                               <:MPolyComplementOfKPointIdeal
+                              }}
+  @assert kk === coefficient_ring(base_ring(M)) "not implemented for fields other than the `coefficient_ring` of the `base_ring` of the module"
+  is_zero(M) && return true
+  !isdefined(M, :quo) && return false
+  M_shift,_,_ = shifted_module(M)
+  o = negdegrevlex(base_ring(M_shift))*lex(ambient_free_module(M_shift))
+  return _has_monomials_on_all_axes(leading_module(M_shift.quo, o))
+end
+
+# This is an internal method which assumes `M` to be presented. It exists purely for back backwards compatibility.
+function _vector_space_basis(
+    kk::Field, M::SubquoModule{T}, d::Int64 ; check::Bool=true
+  ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem,
+                               <:MPolyRing, <:MPolyRingElem,
+                               <:MPolyComplementOfKPointIdeal
+                              }}
+  is_zero(M) && return elem_type(M)[]
+  F = ambient_free_module(M)  
+  F_shift_poly,_,back_shift = shifted_module(F)
+  M_shift,_,_ = shifted_module(M)
+  o = negdegrevlex(base_ring(M_shift))*lex(F_shift_poly)
+  LMq = leading_module(M_shift.quo, o)      # M_shift.quo is always defined after using `shifted_module`, even when M_shift.quo == 0
+  B = _vector_space_basis(kk, quo_object(F_shift_poly, gens(LMq)), d; check)
+  is_empty(B) && return elem_type(M)[]
+  # move basis elements back to M
+  iota = base_ring_module_map(F)
+  # LMq(shifted & poly) -> F_shift_poly -> F_poly -> F -> M
+  return M.(iota.(back_shift.(ambient_representative.(B))))  
+end
+
+### functionality for modules over quotients of localized polynomial rings at a point
+
+function _vector_space_basis(
+    kk::Field, M::SubquoModule{T}; check::Bool=true
+  ) where {T<:MPolyQuoLocRingElem{<:Field, <:FieldElem,
+                                  <:MPolyRing, <:MPolyRingElem,
+                                  <:MPolyComplementOfKPointIdeal
+                                 }}
+  LQ = base_ring(M)
+  @assert kk === coefficient_ring(LQ) "not implemented for other fields than the coefficients of the underlying polynomial ring"
+  @check _is_finite(kk, M) "module is not finite over the given field"
+  M_poly = pre_saturated_module(M)
+  #TODO: refactor when infrastructure for caching GB-basis is available in this setting
+  shift, back_shift = base_ring_shifts(localized_ring(LQ))
+  Mq,_ = sub(ambient_free_module(M_poly), relations(M_poly))
+  Mq_shift,_ = change_base_ring(shift, Mq)
+  o = negdegrevlex(base_ring(Mq_shift))*lex(ambient_free_module(Mq_shift))
+  LMq = leading_module(Mq_shift, o)
+  B = _vector_space_basis(kk, quo_object(ambient_free_module(LMq), gens(LMq)), check=false) # check=false, since `_is_finite` has already been checked, if check=true
+  is_empty(B) && return elem_type(M)[]
+  iota_ring = hom(base_ring(LQ), LQ, elem_type(LQ)[LQ(x) for x in images_of_generators(back_shift)])
+  iota = hom(parent(B[1]), M, gens(M), iota_ring)
+  return iota.(B)
+end
+
+function _is_finite(
+    kk::Field, M::SubquoModule{T}
+  ) where {T<:MPolyQuoLocRingElem{<:Field, <:FieldElem,
+                                  <:MPolyRing, <:MPolyRingElem, 
+                                  <:MPolyComplementOfKPointIdeal
+                                 }}
+  @assert kk === coefficient_ring(base_ring(M)) "not implemented for fields other than the `coefficient_ring` of the `base_ring` of the module"
+  M_poly = pre_saturated_module(M)
+  #TODO: refactor when infrastructure for caching GB-basis is available in this setting
+  shift,_ = base_ring_shifts(localized_ring(base_ring(M)))
+  Mq,_ = sub(ambient_free_module(M_poly), relations(M_poly))
+  Mq_shift,_ = change_base_ring(shift, Mq)
+  o = negdegrevlex(base_ring(Mq_shift))*lex(ambient_free_module(Mq_shift))
+  LMq = leading_module(Mq_shift, o)
+  return _is_finite(kk, quo_object(ambient_free_module(LMq), gens(LMq)))
+end

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -834,6 +834,20 @@ end
 
 function vector_space_basis(kk::Field, M::SubquoModule, d::Union{FinGenAbGroupElem, Int64}; check::Bool=true)
   @assert kk === coefficient_ring(base_ring(M)) "not implemented for fields other than the `coefficient_ring` of the `base_ring` of the module"
+  is_zero(M) && return elem_type(M)[]
+  F = ambient_free_module(M)
+  # We need `M` to be presented  
+  if !((ngens(M) == ngens(F)) && all(repres(v) == e for (v, e) in zip(gens(M), gens(F))))
+    pres = presentation(M)
+    MM = cokernel(map(pres, 1))
+    B = is_graded(MM) ? _vector_space_basis_graded(kk, MM, d; check) : error("not implemented for M/N with non-trivial M") 
+    # _vector_space_basis(kk, MM, d; check)
+    
+    aug = map(pres, 0)
+    return elem_type(M)[aug(pres[0](coordinates(v))) for v in B]
+  end
+  
+  # If execution gets here, `M` is presented.
   return is_graded(M) ? _vector_space_basis_graded(kk, M, d; check) : _vector_space_basis(kk, M, d; check)
 end
 

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -669,7 +669,7 @@ function _is_finite(kk::Field, M::SubquoModule{T}) where {T<:MPolyRingElem{<:Fie
   @assert kk === coefficient_ring(base_ring(M)) "not implemented for fields other than the `coefficient_ring` of the `base_ring` of the module"
   is_zero(M) && return true
   !isdefined(M, :quo) && return false
-  return has_monomials_on_all_axes(leading_module(M.quo, default_ordering(M)))
+  return _has_monomials_on_all_axes(leading_module(M.quo, default_ordering(M)))
 end
 
 function _is_finite(kk::Field, M::SubquoModule{<:FieldElem})
@@ -961,16 +961,16 @@ function vector_space_basis(M::SubquoModule{T},d::Int64
 end
 
 @doc raw"""
-    has_monomials_on_all_axes(M::SubquoModule)
+    _has_monomials_on_all_axes(M::SubquoModule)
 
-Internal function to test whether M is finite-dimensional vector space. Do not use directly
+Internal function to test for a submodule `M` of a free module `F` whether the quotient `F/M` is a finite-dimensional vector space. Do not use directly.
 """
-function has_monomials_on_all_axes(M::SubquoModule)
+function _has_monomials_on_all_axes(M::SubquoModule)
   length(rels(M)) == 0 || error("not implemented for quotients")
-  return has_monomials_on_all_axes(M.sub)
+  return _has_monomials_on_all_axes(M.sub)
 end
 
-function has_monomials_on_all_axes(M::SubModuleOfFreeModule)
+function _has_monomials_on_all_axes(M::SubModuleOfFreeModule)
   R = base_ring(M)
   
   ambient_rank = ngens(ambient_free_module(M))

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -614,7 +614,7 @@ julia> vector_space_dim(M)
 """
 function vector_space_dim(M::SubquoModule; check::Bool=true, cached::Bool=true)
   # Per default we assume that the user means the vector space dimension 
-  # over the `base_ring` of the ring on which `M` is defined.
+  # over the `coefficient_ring` of the `base_ring` on which `M` is defined.
   R = base_ring(M)
   @assert coefficient_ring(R) isa Field "`coefficient_ring` of the ring over which the module is defined is not a field"
   cached && has_attribute(M, :vector_space_dimension) && return get_attribute(M, :vector_space_dimension)::Union{Int, PosInf}
@@ -841,8 +841,6 @@ function vector_space_basis(kk::Field, M::SubquoModule, d::Union{FinGenAbGroupEl
     pres = presentation(M)
     MM = cokernel(map(pres, 1))
     B = is_graded(MM) ? _vector_space_basis_graded(kk, MM, d; check) : error("not implemented for M/N with non-trivial M") 
-    # _vector_space_basis(kk, MM, d; check)
-    
     aug = map(pres, 0)
     return elem_type(M)[aug(pres[0](coordinates(v))) for v in B]
   end
@@ -870,7 +868,7 @@ function _vector_space_basis(kk::Field, M::SubquoModule{T}, d::Int64; check::Boo
   R = base_ring(M)
   F = ambient_free_module(M)
 
-  mons = [a*e for (a, e) in Iterators.product(monomials_of_degree(R, d), gens(F))]
+  mons = elem_type(F)[a*e for (a, e) in Iterators.product(monomials_of_degree(R, d), gens(F))]
 
   if !isdefined(M, :quo) || is_zero(M.quo)  # exists to prevent a undefined field access
     return M.(vec(mons))
@@ -879,7 +877,7 @@ function _vector_space_basis(kk::Field, M::SubquoModule{T}, d::Int64; check::Boo
   o = default_ordering(M)
   LM = leading_module(M.quo, o)
 
-  return [M(mon) for mon in mons if !(mon in LM)]
+  return elem_type(M)[M(mon) for mon in mons if !(mon in LM)]
 end
   
 function _vector_space_basis_graded(kk::Field, M::SubquoModule, d::FinGenAbGroupElem; check::Bool=true)
@@ -909,7 +907,7 @@ function _has_monomials_on_all_axes(M::SubModuleOfFreeModule)
   for x in genlist
     tempexp = leading_exponent(x)
     tempdeg = sum(tempexp[1])
-    push!(explist,(tempexp[1],tempexp[2],tempdeg))
+    push!(explist, (tempexp[1], tempexp[2], tempdeg))
   end
   for i in 1:ngens(R), j in 1:ambient_rank
     if !any(x -> (x[1][i] == x[3] && x[2]==j), explist)
@@ -977,6 +975,22 @@ function vector_space(
   return vector_space(ResType, kk, M; check)
 end
 
+@doc raw"""
+    vector_space(::Type{ResType}, kk::Field, M::SubquoModule; check::Bool=false) where ResType
+
+Return `M` as a vector space over the field `kk` as an object of type `ResType`, 
+together with a map identifying the two objects.
+
+For the user's convenience there exist various shortcut methods for which the 
+return type or the field does not need to be specified, but chosen from context. 
+"""
+function vector_space(
+    ::Type{ResType}, kk::Field, M::SubquoModule; 
+    check::Bool=false
+  ) where ResType
+  error("not implemented for return type $ResType")
+end
+
 function vector_space(
     ::Type{ResType}, kk::Field, M::SubquoModule; 
     check::Bool=false
@@ -1009,6 +1023,9 @@ function vector_space(
 end
 
 ### functionality for modules over quotient rings
+# This uses the internal methods for conversion into a module over the 
+# underlying polynomial ring. We can think about how to do this directly 
+# with Singular's quotient rings. 
 function _vector_space_basis(
     kk::Field, M::SubquoModule{T}; check::Bool=true
   ) where {T <: MPolyQuoRingElem{<:MPolyRingElem{<:FieldElem}}}
@@ -1030,6 +1047,11 @@ function _is_finite(
 end
 
 ### functionality for modules over localized polynomial rings at a point
+# This uses the `shifted_module` which is a module over the underlying 
+# polynomial ring `P` which localizes to `M` under a change of coordinates. 
+# The change of coordinates puts the rational point at which the localization 
+# happens at the origin. This has the advantage that one can work with local 
+# orderings. 
 function _vector_space_basis(
     kk::Field, M::SubquoModule{T}; check::Bool=true
   ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem, 
@@ -1045,10 +1067,11 @@ function _vector_space_basis(
   end
 
   F = ambient_free_module(M)
-  F_shift_poly,_,back_shift = shifted_module(F)
-  M_shift,_,_ = shifted_module(M)
+  F_shift_poly, _, back_shift = shifted_module(F)
+  M_shift, _, _ = shifted_module(M)
   o = negdegrevlex(base_ring(M_shift))*lex(F_shift_poly)
   LMq = leading_module(M_shift.quo, o)
+  # TODO: Do we really need to recreate the module from the leading module here???
   B = _vector_space_basis(kk, quo_object(F_shift_poly, gens(LMq)), check=false) # check=false, since `_is_finite` has already been checked, if check=true
   is_empty(B) && return elem_type(M)[]
   # move basis elements back to M
@@ -1071,7 +1094,11 @@ function _is_finite(
   return _has_monomials_on_all_axes(leading_module(M_shift.quo, o))
 end
 
-# This is an internal method which assumes `M` to be presented. It exists purely for back backwards compatibility.
+# This is an internal method which assumes `M` to be presented. 
+# It exists purely for back backwards compatibility.
+# The difference compared to the method above is that a degree `d` 
+# is specified so that the basis w.r.t this graded piece for the 
+# grading by total degree is computed. 
 function _vector_space_basis(
     kk::Field, M::SubquoModule{T}, d::Int64 ; check::Bool=true
   ) where {T<:MPolyLocRingElem{<:Field, <:FieldElem,
@@ -1093,6 +1120,8 @@ function _vector_space_basis(
 end
 
 ### functionality for modules over quotients of localized polynomial rings at a point
+# This uses the `pre_saturated_module` in the background, together 
+# with a change of coordinates which puts the point of localization to the origin.
 
 function _vector_space_basis(
     kk::Field, M::SubquoModule{T}; check::Bool=true
@@ -1133,3 +1162,4 @@ function _is_finite(
   LMq = leading_module(Mq_shift, o)
   return _is_finite(kk, quo_object(ambient_free_module(LMq), gens(LMq)))
 end
+

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -869,12 +869,16 @@ end
 function _vector_space_basis(kk::Field, M::SubquoModule{T}, d::Int64; check::Bool=true) where {T <: MPolyRingElem{<:FieldElem}}
   R = base_ring(M)
   F = ambient_free_module(M)
-  Mq,_ = sub(F,rels(M))
-
-  o = default_ordering(M)
-  LM = leading_module(Mq,o)
 
   mons = [a*e for (a, e) in Iterators.product(monomials_of_degree(R, d), gens(F))]
+
+  if !isdefined(M, :quo) || is_zero(M.quo)  # exists to prevent a undefined field access
+    return M.(vec(mons))
+  end
+
+  o = default_ordering(M)
+  LM = leading_module(M.quo, o)
+
   return [M(mon) for mon in mons if !(mon in LM)]
 end
   

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -845,7 +845,7 @@ function vector_space_basis(kk::Field, M::SubquoModule, d::Union{FinGenAbGroupEl
   # We need `M` to be presented  
   if !((ngens(M) == ngens(F)) && all(repres(v) == e for (v, e) in zip(gens(M), gens(F))))
     pres = presentation(M)
-    MM = cokernel(map(pres, 1))
+    MM, _ = cokernel(map(pres, 1))
     B = is_graded(MM) ? _vector_space_basis_graded(kk, MM, d; check) : error("not implemented for M/N with non-trivial M") 
     aug = map(pres, 0)
     return elem_type(M)[aug(pres[0](coordinates(v))) for v in B]

--- a/src/Modules/UngradedModules/Methods.jl
+++ b/src/Modules/UngradedModules/Methods.jl
@@ -1061,9 +1061,9 @@ end
 
 
 # The function for computing the entire `vector_space_basis` of `M` is 
-# implemented in the `MPolyRing` section above, since it is the same, 
-# reducing to computing the `vector_space_bases` for all non-zero 
-#
+# implemented in the `MPolyRing` section above, since it is the same: 
+# reducing the computation to computing the `vector_space_bases` for 
+# all non-zero homogeneous components of `M` w.r.t. total degree.
 
 function _is_finite(
     kk::Field, M::SubquoModule{T}

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -136,6 +136,8 @@ base_ring(L::MPolyQuoLocRing) = L.R
 inverted_set(L::MPolyQuoLocRing) = L.S
 
 ### additional getter functions
+coefficient_ring(L::MPolyQuoLocRing) = coefficient_ring(base_ring(L))
+
 @doc raw"""
     modulus(L::MPolyQuoLocRing)
 

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -1981,9 +1981,32 @@ end
 
   R, (x,y) = QQ[:x,:y]
   F = free_module(R, 2)
+
+  # different presentations of the zero module
+  O1 = quo_object(F, gens(F))
+  @test vector_space_dim(O1) == 0
+  @test vector_space_basis(O1) == elem_type(O1)[]
+  @test typeof(vector_space_basis(O1)) == typeof(elem_type(O1)[])
+
+  O2 = SubquoModule(F, elem_type(F)[])
+  @test vector_space_dim(O2) == 0
+  @test vector_space_basis(O2) == elem_type(O2)[]
+  @test typeof(vector_space_basis(O2)) == typeof(elem_type(O2)[])
+
+  # computing basis for infinite dimensional vector space throws error
   S = SubquoModule(F, gens(F), [F[1]])
   # not a finite module over `QQ`
   @test_throws ErrorException vector_space_basis(S)
+  # for pure submodules this is always checked, even with ckeck=false
+  S2 = SubquoModule(F, gens(F))
+  @test_throws ErrorException vector_space_basis(S2; check=false)
+
+  #test ungraded total degree "graded" case
+  @test vector_space_dim(O2, 3) == 0
+  @test vector_space_basis(O2, 3) == elem_type(O2)[]
+  F_subquo,_ = sub(F, gens(F))
+  @test vector_space_dim(F_subquo, 2) == 6 
+  @test vector_space_basis(F_subquo, 2) == F_subquo.([x^2*F[1], x*y*F[1], y^2*F[1], x^2*F[2], x*y*F[2], y^2*F[2]])
 end
 
 @testset "vector space functions for modules over a MPolyQuoRing" begin
@@ -1991,6 +2014,7 @@ end
   I = ideal(R, [x^3+y^2+z^2, x*y])
   Q,_ = quo(R, I)
   F = free_module(Q, 2)
+
   # different presentations of the zero module
   O1 = quo_object(F, gens(F))
   @test vector_space_dim(O1) == 0

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -1979,6 +1979,7 @@ end
   @test inc.(gens(V)) == B
   @test vector_space(V)[1] === V
 
+
   R, (x,y) = QQ[:x,:y]
   F = free_module(R, 2)
 
@@ -2054,6 +2055,118 @@ end
   I = ideal(R, x*y)
   Q,_ = quo(R, I)
   F = free_module(Q, 2)
+  S = SubquoModule(F, gens(F), [F[1]])
+  # not a finite module over `QQ`
+  @test_throws ErrorException vector_space_basis(S)
+end
+
+@testset "vector space functions for modules over a MPolyLocRing" begin
+  R, (x,y,z) = QQ[:x,:y,:z]
+  L,_ =  localization(R, complement_of_point_ideal(R, [1,2,3]))
+  F = free_module(L, 2)
+
+  # different presentations of the zero module
+  O1 = quo_object(F, gens(F))
+  @test vector_space_dim(O1) == 0
+  @test vector_space_basis(O1) == elem_type(O1)[]
+  @test typeof(vector_space_basis(O1)) == typeof(elem_type(O1)[])
+
+  O2 = SubquoModule(F, elem_type(F)[])
+  @test vector_space_dim(O2) == 0
+  @test vector_space_basis(O2) == elem_type(O2)[]
+  @test typeof(vector_space_basis(O2)) == typeof(elem_type(O2)[])
+
+  #test ungraded total degree "graded" case
+  @test vector_space_dim(O2, 3) == 0
+  @test vector_space_basis(O2, 3) == elem_type(O2)[]
+  F_subquo,_ = sub(F, gens(F))
+  @test vector_space_dim(F_subquo, 1) == 6 
+  @test vector_space_basis(F_subquo, 1) == F_subquo.([(x-1)*F[1], (y-2)*F[1], (z-3)*F[1], (x-1)*F[2], (y-2)*F[2], (z-3)*F[2]])
+
+  # quotient of free_module (S_6 space_curve with singularity translated to (1,2,3))
+  rels = [
+    ((x-1)^3+(y-2)^2+(z-3)^2)*F[1], ((x-1)*(y-2))*F[1],
+    ((x-1)^3+(y-2)^2+(z-3)^2)*F[2], ((x-1)*(y-2))*F[2],
+    3*(x-1)^2*F[1] + (y-2)*F[2],
+    2*(y-2)*F[1] + (x-1)*F[2],
+    2*(z-3)*F[1]
+  ]
+  S = SubquoModule(F, [F[1], F[2]], rels)
+  @test vector_space_dim(S) == 6
+  B = vector_space_basis(S)
+  @test length(B) == 6
+  @test all(b -> parent(b) === S, B)
+  #the computed basis depends on the default monomial order of R
+  @test all(b -> b in repres.(B), [F[1], F[2], (x-1)*F[1], (x-1)^2*F[1], (y-2)*F[1], (z-3)*F[2]]) 
+
+  # quotient of a submodule 
+  T = SubquoModule(F, [(x-1)*F[1], (y-2)*F[2]], rels)
+  @test vector_space_dim(T) == 2
+  C = vector_space_basis(T)
+  @test length(C) == 2
+  @test all(c -> parent(c) === T, C)
+  @test all(c -> c in repres.(C), [(x-1)*F[1], (x-1)^2*F[1]])
+
+  # computing basis for infinite dimensional vector space throws error
+  T1 = SubquoModule(F, gens(F), [F[1]])
+  # not a finite module over `QQ`
+  @test_throws ErrorException vector_space_basis(T1)
+  # for pure submodules this is always checked, even with ckeck=false
+  T2 = SubquoModule(F, gens(F))
+  @test_throws ErrorException vector_space_basis(T2; check=false)
+
+  #testing if computation is actually local
+  R, (x,y) = QQ[:x, :y]
+  L,_ =  localization(R, complement_of_point_ideal(R, [0,0]))
+  F = free_module(L, 2)
+  # I = [x*y*(y-1)]
+  rels = [x*y*(y-1)*F[1], y*(y-1)*F[1], x*(2*y-1)*F[1], F[2]]
+  M = SubquoModule(F, gens(F), rels)
+  @test vector_space_dim(M) == 1
+  @test vector_space_dim(Oscar.pre_saturated_module(M)) == 2
+end
+
+@testset "vector space functions for modules over a MPolyQuoLocRing" begin
+  R, (x,y,z) = QQ[:x,:y,:z]
+  I = ideal(R, [(x-1)^3+(y-2)^2+(z-3)^2, (x-1)*(y-2)])
+  Q,_ = quo(R, I)
+  LQ,_ =  localization(Q, complement_of_point_ideal(R, [1,2,3]))
+  F = free_module(LQ, 2)
+
+  # different presentations of the zero module
+  O1 = quo_object(F, gens(F))
+  @test vector_space_dim(O1) == 0
+  @test vector_space_basis(O1) == elem_type(O1)[]
+  @test typeof(vector_space_basis(O1)) == typeof(elem_type(O1)[])
+
+  O2 = SubquoModule(F, elem_type(F)[])
+  @test vector_space_dim(O2) == 0
+  @test vector_space_basis(O2) == elem_type(O2)[]
+  @test typeof(vector_space_basis(O2)) == typeof(elem_type(O2)[])
+
+  # quotient of free_module (S_6 space_curve with singularity translated to (1,2,3))
+  rels = [
+    3*(x-1)^2*F[1] + (y-2)*F[2],
+    2*(y-2)*F[1] + (x-1)*F[2],
+    2*(z-3)*F[1]
+  ]
+  S = SubquoModule(F, [F[1], F[2]], rels)
+  @test vector_space_dim(S) == 6
+  B = vector_space_basis(S)
+  @test length(B) == 6
+  @test all(b -> parent(b) === S, B)
+  #the computed basis depends on the default monomial order of R
+  @test all(b -> b in repres.(B), [F[1], F[2], (x-1)*F[1], (x-1)^2*F[1], (y-2)*F[1], (z-3)*F[2]]) 
+
+  # quotient of a submodule 
+  T = SubquoModule(F, [(x-1)*F[1], (y-2)*F[2]], rels)
+  @test vector_space_dim(T) == 2
+  C = vector_space_basis(T)
+  @test length(C) == 2
+  @test all(c -> parent(c) === T, C)
+  @test all(c -> c in repres.(C), [(x-1)*F[1], (x-1)^2*F[1]])
+
+  # computing basis for infinite dimensional vector space throws error
   S = SubquoModule(F, gens(F), [F[1]])
   # not a finite module over `QQ`
   @test_throws ErrorException vector_space_basis(S)


### PR DESCRIPTION
This PR is build on top of the changes in #5729 and rebased onto the `cokernel` changes in #5787.

TODOs: 
- ~fix wrong results for total degree "graded"  case for ungraded  SubquoModules with true sub-part over an `MPoly(Loc)Ring`~
- ~add a test where the vector_space_dim is localized different than in the global case~  
Summing up the changes in this PR:

## Release notes

- Add full support for `vector_space_dim` and friends for ungraded `SubquoModule` over a `MPolyQuoLocRing` localized at a point

- Refactor the existing code for ungraded modules over a `MPolyLocRing` localized at a point to the new code structure and extend the functionality to modules with true sub-part

- Improve performance for `vector_space[_dim/basis]` by using `M.quo` and its cached `groebner_basis` instead of creating the submodule of relations and computing its `groebner_basis` and then discarding it multiple times.  
