### PR TITLE
Remove `eargmin`, and a micro-optimization

### DIFF
--- a/experimental/AlgebraicShifting/src/AlgebraicShifting.jl
+++ b/experimental/AlgebraicShifting/src/AlgebraicShifting.jl
@@ -32,22 +32,6 @@ function pivot_columns(A::MatElem)
 end
 
 """
-    eargmin(f, xs; filter=_->true, default=nothing, lt=Base.isless)
-
-Extended argmin function. Allows custom filter, default value and comparator.
-"""
-function eargmin(f, xs; filter=_->true, default=nothing, lt=Base.isless)
-  best = nothing
-  for x in xs
-    filter(x) || continue
-    if isnothing(best) || lt(f(x), best)
-      best = f(x)
-    end
-  end
-  return best
-end
-
-"""
     efindmin(f, xs; filter=_->true, default=nothing, lt=Base.isless)
 
 Extended findmin function. Allows custum filter, default value and comparator.

--- a/experimental/AlgebraicStatistics/src/MarkovProperties.jl
+++ b/experimental/AlgebraicStatistics/src/MarkovProperties.jl
@@ -181,7 +181,7 @@ function descendants(G::Graph{Directed}, i::Int)::Set{Int}
     C = Oscar.children(G, v)
     append!(queue, [c for c in C if !(c in visited)])
 
-    visited = union(visited, C)
+    union!(visited, C)
     current_index += 1
   end
   return Set(queue)


### PR DESCRIPTION
The switch to union! also avoids 'boxing' of 'visited'.