### PR TITLE
run tagbot on ubuntu-latest instead of slim

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:


### PR DESCRIPTION
Might help with this error:
```
Pull down action image 'ghcr.io/juliaregistries/tagbot:1.24.3'
  /usr/bin/docker pull ghcr.io/juliaregistries/tagbot:1.24.3
  failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
  Warning: Docker pull failed with exit code 1, back off 4.538 seconds before retry.
  /usr/bin/docker pull ghcr.io/juliaregistries/tagbot:1.24.3
  failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
  Warning: Docker pull failed with exit code 1, back off 4.223 seconds before retry.
  /usr/bin/docker pull ghcr.io/juliaregistries/tagbot:1.24.3
  failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Error: Docker pull failed with exit code 1
```
https://github.com/oscar-system/Oscar.jl/actions/runs/21988915929/job/63530336202#step:2:3
