### PR TITLE
Add linear solving for matrices over multivariate polynomial and laurent rings

### DIFF
--- a/src/Rings/Rings.jl
+++ b/src/Rings/Rings.jl
@@ -44,3 +44,4 @@ include("resultant.jl")
 
 include("puiseux_wrapper.jl")
 
+include("linear_solving.jl")

--- a/src/Rings/linear_solving.jl
+++ b/src/Rings/linear_solving.jl
@@ -1,0 +1,48 @@
+struct ModuleSolveTrait <: AbstractAlgebra.Solve.MatrixNormalFormTrait end
+
+AbstractAlgebra.Solve.matrix_normal_form_type(::Union{MPolyRing, MPolyQuoRing, MPolyLocRing, MPolyQuoLocRing}) = ModuleSolveTrait()
+
+function AbstractAlgebra.Solve._can_solve_internal_no_check(::ModuleSolveTrait, A, b, task::Symbol; side::Symbol)
+  if side === :right
+    fl, _X, _K = AbstractAlgebra.Solve._can_solve_internal_no_check(ModuleSolveTrait(), transpose(A), transpose(b), task; side = :left)
+    return fl, transpose(_X), transpose(_K)
+  end
+
+  # we solve x * A = b
+  R = base_ring(A)
+
+  F = FreeModule(R, nrows(A); cached = false)
+  G = FreeModule(R, ncols(A); cached = false)
+  h = hom(F, G, A)
+  imh, = image(h)
+  sol = zero_matrix(R, nrows(b), nrows(A))
+  for i in 1:nrows(b)
+    c = G(b[i, :])
+    if !(c in imh)
+      return false
+    end
+    sol[i, :] = dense_row(coordinates(preimage(h, c)), nrows(A))
+  end
+  K, KtoF = kernel(h)
+  if ngens(K) == 0
+    Ke = zero_matrix(R, 0, nrows(A))
+  else
+    Ke = reduce(vcat, dense_row.(coordinates.(KtoF.(gens(K))), rank(F)))
+  end
+  return true, sol, Ke
+end
+
+struct LaurentSolveTrait <: AbstractAlgebra.Solve.MatrixNormalFormTrait end
+
+AbstractAlgebra.Solve.matrix_normal_form_type(::AbstractAlgebra.Generic.LaurentMPolyWrapRing) = LaurentSolveTrait()
+
+function AbstractAlgebra.Solve._can_solve_internal_no_check(::LaurentSolveTrait, A, b, task::Symbol; side::Symbol)
+  # just delegate to the underlying multivariate ring
+  R = base_ring(A)
+  f = Oscar._polyringquo(R)
+  RQ = codomain(f)
+  AA = map_entries(f, A)
+  bb = map_entries(f, b)
+  fl, xx, kk = can_solve_with_solution_and_kernel(AA, bb; side)
+  return fl, map_entries(f.inv, xx), map_entries(f.inv, kk)
+end

--- a/test/Rings/linear_solving.jl
+++ b/test/Rings/linear_solving.jl
@@ -1,0 +1,100 @@
+@testset "linear solving" begin
+  # MPolyRing
+  let
+    R, (x,y) = polynomial_ring(GF(3), [:x, :y])
+    r() = rand(R, 1:3, 1:5, 1:2)
+    n = rand(1:5)
+    m = rand(1:5)
+    l = rand(1:5)
+    A = matrix(R, n, m, [r() for i in 1:n, j in 1:m])
+    x = matrix(R, l, n, [r() for i in 1:l, j in 1:n])
+    b = x * A
+    @test can_solve(A, b)
+    fl, y = can_solve_with_solution(A, b)
+    @test fl && y * A == b
+    fl, y, K = can_solve_with_solution_and_kernel(A, b)
+    @test fl && y * A == b && is_zero(K * A)
+  end
+
+  # MPolyQuo
+  let
+    R, (x,y) = polynomial_ring(GF(3), [:x, :y])
+    f = y^2+y+x^2
+    C = ideal(R, [f])
+    Q, = quo(R, C)
+    r() = Q(rand(R, 1:2, 1:2, 1:2))
+    n = rand(1:5)
+    m = rand(1:5)
+    l = rand(1:5)
+    A = matrix(Q, n, m, [r() for i in 1:n, j in 1:m])
+    x = matrix(Q, l, n, [r() for i in 1:l, j in 1:n])
+    b = x * A
+    @test can_solve(A, b)
+    fl, y = can_solve_with_solution(A, b)
+    @test fl && y * A == b
+    fl, y, K = can_solve_with_solution_and_kernel(A, b)
+    @test fl && y * A == b && is_zero(K * A)
+  end
+
+  # MPolyQuoLoc
+  let
+    R, (x, y, u, v) = GF(3)[:x, :y, :u, :v]
+    f = x*v-y*u
+    I = ideal(R, f)
+    Q, p = quo(R, I)
+    S = Oscar.MPolyComplementOfKPointIdeal(R, [QQ(1), QQ(0), QQ(1), QQ(0)])
+    L, _ = localization(Q, S)
+    a, b, c, d = L.((x, y, u, v)) 
+    r() = L(Q(rand(R, 1:2, 1:2, 1:1)))
+    n = rand(1:4)
+    m = rand(1:4)
+    l = rand(1:4)
+    A = matrix(L, n, m, [r() for i in 1:n, j in 1:m])
+    x = matrix(L, l, n, [r() for i in 1:l, j in 1:n])
+    b = x * A
+    @test can_solve(A, b)
+    fl, y = can_solve_with_solution(A, b)
+    @test fl && y * A == b
+    fl, y, K = can_solve_with_solution_and_kernel(A, b)
+    @test fl && y * A == b && is_zero(K * A)
+  end
+
+  # MPolyLoc
+  let
+    R, (x, y) = GF(7)[:x, :y]
+    f = x^2+y^2-1
+    I = ideal(R, f)
+    S = Oscar.MPolyComplementOfPrimeIdeal(I)
+    V, _ = localization(S)
+    r() = V(rand(R, 1:2, 1:2, 1:1))
+    n = rand(1:4)
+    m = rand(1:4)
+    l = rand(1:4)
+    A = matrix(V, n, m, [r() for i in 1:n, j in 1:m])
+    x = matrix(V, l, n, [r() for i in 1:l, j in 1:n])
+    b = x * A
+    @test can_solve(A, b)
+    fl, y = can_solve_with_solution(A, b)
+    @test fl && y * A == b
+    fl, y, K = can_solve_with_solution_and_kernel(A, b)
+    @test fl && y * A == b && is_zero(K * A)
+  end
+
+  # Laurent
+  let
+    F = GF(2)
+    R, (x, y) = laurent_polynomial_ring(F, ["x", "y"])
+    r() = rand(R, 1:2, 1:2, 1:1)
+    n = rand(1:4)
+    m = rand(1:4)
+    l = rand(1:4)
+    A = matrix(R, n, m, [r() for i in 1:n, j in 1:m])
+    x = matrix(R, l, n, [r() for i in 1:l, j in 1:n])
+    b = x * A
+    @test can_solve(A, b)
+    fl, y = can_solve_with_solution(A, b)
+    @test fl && y * A == b
+    fl, y, K = can_solve_with_solution_and_kernel(A, b)
+    @test fl && y * A == b && is_zero(K * A)
+  end
+end


### PR DESCRIPTION
With this we get `can_solve`, `solve`, `can_solve_with_solution` and `can_solve_with_solution_and_kernel` for free.
```
julia> begin
         F = GF(2)
         R, (x, y, z) = laurent_polynomial_ring(F, ["x", "y", "z"])

         A = matrix(R, 3, 3, [
             x       y^-1   1;
             z      x^-1   y;
             1      z^-1   x*y^-1
         ])

         u = matrix(R, 3, 1, [x*y; z^-1; 1])
         b = A * u
       end;

julia> fl, x = can_solve_with_solution(A, b; side = :right);

julia> A * x == b
true

julia> x
[ x*y]
[z^-1]
[   1]
```

Closes #5673

CC: @nzy1997

Just need to add some tests.