### PR TITLE
CI: allow using pkg servers in oscardb workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -327,7 +327,6 @@ jobs:
           # Maps tcp port 27017 on service container to the host
           - 27017:27017
     env:
-      JULIA_PKG_SERVER: ""
       OSCARDB_TEST_URI: "mongodb://admin:admin@localhost:27017/?authSource=admin"
       OSCAR_TEST_SUBSET: "oscar_db"
     steps:


### PR DESCRIPTION
This was copied from some other rather old workflow and should not be necessary anymore. Allowing pkg servers might avoid some 502 errors during package installations from github that broke some tests recently.