### PR TITLE
change `isomorphism(PermGroup, G)` for matrix groups `G`

### DIFF
--- a/gap/pkg/OscarInterface/gap/bugfix.gi
+++ b/gap/pkg/OscarInterface/gap/bugfix.gi
@@ -1,0 +1,68 @@
+##  `IsomorphismPermGroupForMatrixGroup` has been fixed in
+##  https://github.com/gap-system/gap/pull/5339,
+##  the function below makes this fix available to OSCAR.
+##
+##  Additionally, this function tries to improve the behaviour
+##  by avoiding `NicomorphismOfGeneralMatrixGroup` in the situation
+##  that a `NiceMonomorphism` was already stored
+##  whose image is *not* a permutation group.
+##  In this situation, we compute an `IsomorphismPermGroup` for the
+##  image of the stored map, and return the composition of the two maps.
+##
+##  So the idea is that we trust GAP that the stored `NiceMonomorphism`
+##  of `G` is really nice, in the sense that its image is better than `G`.
+##  A situation where this holds (in particular in OSCAR) is
+##  that a matrix group of cyclotomics knows a faithful reduction to
+##  a matrix group over a finite field.
+##  `NicomorphismOfGeneralMatrixGroup` is typically very expensive
+##  in this situation.
+BindGlobal( "IsomorphismPermGroupForMatrixGroup", function( G )
+  local map;
+
+  if HasNiceMonomorphism( G ) then
+    map:= NiceMonomorphism( G );
+    if not IsPermGroup( Range( map ) ) then
+      # Trust GAP that this map is still useful.
+      map:= CompositionMapping( IsomorphismPermGroup( Image( map ) ), map );
+    fi;
+  else
+    # We cannot be sure about `IsHandledByNiceMonomorphism` for `G`.
+    if not HasIsFinite( G ) then
+      Info( InfoWarning,1,
+            "IsomorphismPermGroup: The group is not known to be finite" );
+    fi;
+    map:= NicomorphismOfGeneralMatrixGroup( G, false, false );
+    SetNiceMonomorphism( G, map );
+  fi;
+  # Now `G` stores a `NiceMonomorphism`.
+  if IsPermGroup( Range( NiceMonomorphism( G ) ) ) then
+    # Set an attribute if available.
+    if IsAttribute( RestrictedNiceMonomorphism ) then
+      map:= RestrictedNiceMonomorphism( G );
+    else
+      map:= RestrictedNiceMonomorphism( NiceMonomorphism( G ), G );
+    fi;
+  fi;
+  if IsIdenticalObj( Source( map ), G ) and IsSurjective( map ) then
+    return map;
+  fi;
+  map:= GeneralRestrictedMapping( map, G, ImagesSet( map, G ) );
+  SetIsBijective( map, true );
+
+  return map;
+end );
+
+InstallMethod( IsomorphismPermGroup,
+    "matrix group",
+    [ IsMatrixGroup ],
+    IsomorphismPermGroupForMatrixGroup );
+
+InstallMethod( IsomorphismPermGroup,
+    "finite matrix group",
+    [ IsMatrixGroup and IsFinite and IsHandledByNiceMonomorphism ],
+    # We do not want the upranking via 'IsHandledByNiceMonomorphism',
+    # analogous to the situation with the method for
+    # 'IsGroup and IsFinite and IsHandledByNiceMonomorphism'in
+    # 'lib/grpnice.gi'.
+    [ [ IsMatrixGroup and IsFinite ], 1 ],
+    IsomorphismPermGroupForMatrixGroup );

--- a/gap/pkg/OscarInterface/read.g
+++ b/gap/pkg/OscarInterface/read.g
@@ -9,4 +9,6 @@ ReadPackage( "OscarInterface", "gap/alnuth.gi");
 ReadPackage( "OscarInterface", "gap/QQBar.gi");
 ReadPackage( "OscarInterface", "gap/hash.gi");
 
+RereadPackage( "OscarInterface", "gap/bugfix.gi");
+
 ReadPackage( "OscarInterface", "gap/ExperimentalMatrixGroups.g");

--- a/test/Groups/matrixgroups.jl
+++ b/test/Groups/matrixgroups.jl
@@ -149,6 +149,9 @@ end
      x = GAP.Globals.Product(GAP.Globals.GeneratorsOfGroup(Gap_G0))
      img = GAP.Globals.ImagesRepresentative(iso, x)
      @test x == GAP.Globals.PreImagesRepresentative(iso, img)
+
+     iso = isomorphism(PermGroup, G0)
+     @test order(codomain(iso)) == order(G0)
    end
 
    G = matrix_group(QQ, 2, dense_matrix_type(QQ)[])


### PR DESCRIPTION
If the GAP side knows already a `NiceMonomorphism` then trust GAP that this map is useful also if the image is not a permutation group.

resolves #5376