### PR TITLE
Use GenericCharacterTables 0.8.0 for book tests

### DIFF
--- a/test/book/cornerstones/groups/auxiliary_code/main.jl
+++ b/test/book/cornerstones/groups/auxiliary_code/main.jl
@@ -1,3 +1,3 @@
 import Pkg
-Pkg.add(name="GenericCharacterTables", version="0.7.2"; io=devnull)
+Pkg.add(name="GenericCharacterTables", version="0.8.0"; io=devnull)
 using GenericCharacterTables


### PR DESCRIPTION
As soon as the release of GenericCharacterTables.jl is done this should make the doctests compatible with https://github.com/Nemocas/AbstractAlgebra.jl/pull/2274.