### PR TITLE
Remove incorrect `*` method for FreeAssociativeAlgebraIdeal

### DIFF
--- a/src/Rings/FreeAssociativeAlgebraIdeal.jl
+++ b/src/Rings/FreeAssociativeAlgebraIdeal.jl
@@ -77,11 +77,6 @@ function Base.:+(a::FreeAssociativeAlgebraIdeal{T}, b::FreeAssociativeAlgebraIde
   return ideal(R, vcat(gens(a), gens(b)))
 end
 
-function Base.:*(a::FreeAssociativeAlgebraIdeal{T}, b::FreeAssociativeAlgebraIdeal{T}) where T
-  # replace the generic implementation as it is incorrect in the non-commutative case.
-  throw(NotImplementedError(:*, a, b))
-end
-
 AbstractAlgebra.normal_form(f::FreeAssociativeAlgebraElem, I::FreeAssociativeAlgebraIdeal) = normal_form(f, gens(I))
 AbstractAlgebra.normal_form(f::FreeAssociativeAlgebraElem, I::IdealGens{<:FreeAssociativeAlgebraElem}) = normal_form(f, collect(I))
 

--- a/src/Rings/FreeAssociativeAlgebraIdeal.jl
+++ b/src/Rings/FreeAssociativeAlgebraIdeal.jl
@@ -78,9 +78,8 @@ function Base.:+(a::FreeAssociativeAlgebraIdeal{T}, b::FreeAssociativeAlgebraIde
 end
 
 function Base.:*(a::FreeAssociativeAlgebraIdeal{T}, b::FreeAssociativeAlgebraIdeal{T}) where T
-  R = base_ring(a)
-  @req R == base_ring(b) "parent mismatch"
-  return ideal(R, [i*j for i in gens(a) for j in gens(b)])
+  # replace the generic implementation as it is incorrect in the non-commutative case.
+  throw(NotImplementedError(:*, a, b))
 end
 
 AbstractAlgebra.normal_form(f::FreeAssociativeAlgebraElem, I::FreeAssociativeAlgebraIdeal) = normal_form(f, gens(I))

--- a/test/Rings/FreeAssociativeAlgebraIdeal.jl
+++ b/test/Rings/FreeAssociativeAlgebraIdeal.jl
@@ -30,7 +30,6 @@ end
   @test ideal_membership(f1, I2.gens)
   gb = groebner_basis(I2, 3; protocol=false)
   @test isdefined(I2, :gb)
-  @test length(gens(I * I2)) == 2
 end
 
 @testset "FreeAssociativeAlgebraIdeal.utils" begin


### PR DESCRIPTION
The product of two two-sided ideals over a non-commutative ring is in general *not* generated by the product of the generators. For example if the ring is free with generators `x, y, z`, then `<x>*<z>` contains `xyz`, but `<xz>` does not. In fact `<x>*<z>` is not even finitely generated.