### PR TITLE
Remove some redundant Ideal methods

### DIFF
--- a/src/Rings/FractionalIdeal.jl
+++ b/src/Rings/FractionalIdeal.jl
@@ -1,4 +1,4 @@
-mutable struct FractionalIdeal{S <: Ideal, T <: RingElem}
+struct FractionalIdeal{S <: Ideal, T <: RingElem}
   num::S
   den::T
 end

--- a/src/Rings/FreeAssociativeAlgebraIdeal.jl
+++ b/src/Rings/FreeAssociativeAlgebraIdeal.jl
@@ -29,14 +29,6 @@ function Base.show(io::IO, a::FreeAssociativeAlgebraIdeal)
   print(io, "Ideal of ", base_ring(a), " with ", ItemQuantity(ngens(a), "generator"))
 end
 
-function Base.:(==)(I2::FreeAssociativeAlgebraIdeal, I1::FreeAssociativeAlgebraIdeal)
-  return is_subset(I1,I2) && is_subset(I2,I1)
-end
-
-function Base.hash(a::FreeAssociativeAlgebraIdeal, h::UInt)
-  return hash(base_ring(a), h)
-end
-
 @doc raw"""
     ideal(R::FreeAssociativeAlgebra, g::Vector{<:FreeAssociativeAlgebraElem})
 
@@ -69,12 +61,6 @@ end
 
 function gens(a::FreeAssociativeAlgebraIdeal{T}) where T
   return T[gen(a,i) for i in 1:ngens(a)]
-end
-
-function Base.:+(a::FreeAssociativeAlgebraIdeal{T}, b::FreeAssociativeAlgebraIdeal{T}) where T
-  R = base_ring(a)
-  @req R == base_ring(b) "parent mismatch"
-  return ideal(R, vcat(gens(a), gens(b)))
 end
 
 AbstractAlgebra.normal_form(f::FreeAssociativeAlgebraElem, I::FreeAssociativeAlgebraIdeal) = normal_form(f, gens(I))

--- a/src/Rings/MPolyQuo.jl
+++ b/src/Rings/MPolyQuo.jl
@@ -708,10 +708,6 @@ function is_subset(a::MPolyQuoIdeal{T}, b::MPolyQuoIdeal{T}) where T
   return Singular.iszero(Singular.reduce(singular_generators(a.gens), singular_groebner_generators(b)))
 end
 
-function Base.:(==)(a::MPolyQuoIdeal{T}, b::MPolyQuoIdeal{T}) where T
-  return issubset(a, b) && issubset(b, a)
-end
-
 @doc raw"""
     simplify(f::MPolyQuoRingElem)
 

--- a/src/Rings/PBWAlgebra.jl
+++ b/src/Rings/PBWAlgebra.jl
@@ -912,7 +912,7 @@ function is_subset(a::PBWAlgIdeal{D, T, S}, b::PBWAlgIdeal{D, T, S}) where {D, T
         # Ditto comment ideal_membership
         return Singular.is_zero(Singular.reduce(a.sdata, singular_groebner_basis(b)))
     else
-        return Singular.is_zero(Singular.reduce(a.sopdata, singular_opgroebner_basis(b)))
+        return Singular.is_zero(Singular.reduce(get_sopdata(a), singular_opgroebner_basis(b)))
     end
 end
 

--- a/src/Rings/PBWAlgebra.jl
+++ b/src/Rings/PBWAlgebra.jl
@@ -917,18 +917,6 @@ function is_subset(a::PBWAlgIdeal{D, T, S}, b::PBWAlgIdeal{D, T, S}) where {D, T
 end
 
 
-
-function Base.:(==)(a::PBWAlgIdeal{D, T, S}, b::PBWAlgIdeal{D, T, S}) where {D, T, S}
-  a === b && return true
-  gens(a) == gens(b) && return true
-  return is_subset(a, b) && is_subset(b, a)
-end
-
-function Base.hash(a::PBWAlgIdeal{D, T, S}, h::UInt) where {D, T, S}
-  b = 0x91c65dda1eed350f % UInt
-  return xor(hash(base_ring(a), hash(D, h)), b)
-end
-
 #### elimination
 
 function _depends_on_vars(p::Union{Singular.spoly, Singular.spluralg}, sigmaC::Vector{Int})


### PR DESCRIPTION
The removed methods are equivalent (or even inferior) to the default methods provided in AbstractAlgebra.

Also turn FractionalIdeal into a struct as a minor optimization.