### PR TITLE
Fix worldage problems in docs build

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, Oscar
 
 include("make_work.jl")
 
-Base.invokelatest(BuildDoc.doit, Oscar; warnonly=false, local_build=false, doctest=false)
+@invokelatest BuildDoc.doit(Oscar; warnonly=false, local_build=false, doctest=false)
 
 should_push_preview = true
 if get(ENV, "GITHUB_ACTOR", "") == "dependabot[bot]"

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -291,12 +291,11 @@ function build_doc(; doctest::Union{Symbol, Bool} = false, warnonly = true, open
   if !isdefined(Main, :BuildDoc)
     doc_init()
   end
+  BuildDoc = @invokelatest Main.BuildDoc
   withenv("COLUMNS"=>80, "LINES"=>24) do
     with_unicode(false) do
       Pkg.activate(docsproject) do
-        Base.invokelatest(
-          Main.BuildDoc.doit, Oscar; warnonly=warnonly, local_build=true, doctest=doctest
-        )
+        @invokelatest BuildDoc.doit(Oscar; warnonly=warnonly, local_build=true, doctest=doctest)
       end
     end
   end

--- a/test/book/test.jl
+++ b/test/book/test.jl
@@ -139,7 +139,7 @@ isdefined(Main, :FakeTerminals) || include(joinpath(pkgdir(REPL),"test","FakeTer
       mockdule = Module(sym)
       # make it accessible from Main
       @eval Main global $sym::Module
-      @invokelatest Main.sym = mockdule
+      invokelatest(setproperty!, Main, sym, mockdule)
       Core.eval(mockdule, :(eval(x) = Core.eval($(mockdule), x)))
       Core.eval(mockdule, :(include(x) = Base.include($(mockdule), abspath(x))))
 

--- a/test/book/test.jl
+++ b/test/book/test.jl
@@ -139,7 +139,7 @@ isdefined(Main, :FakeTerminals) || include(joinpath(pkgdir(REPL),"test","FakeTer
       mockdule = Module(sym)
       # make it accessible from Main
       @eval Main global $sym::Module
-      invokelatest(setproperty!, Main, sym, mockdule)
+      @invokelatest Main.sym = mockdule
       Core.eval(mockdule, :(eval(x) = Core.eval($(mockdule), x)))
       Core.eval(mockdule, :(include(x) = Base.include($(mockdule), abspath(x))))
 


### PR DESCRIPTION
by using `@invokelatest` to also apply the `invokelatest` to all `getproperty` and `setproperty` calls.

Resolves https://github.com/oscar-system/Oscar.jl/issues/5817.