### PR TITLE
Allow loading files with a default type

### DIFF
--- a/src/Serialization/Fields.jl
+++ b/src/Serialization/Fields.jl
@@ -129,7 +129,7 @@ end
 ################################################################################
 # FqField
 
-@register_serialization_type FqField "FiniteField" uses_id
+@register_serialization_type FqField "FiniteField" uses_id default
 @register_serialization_type FqFieldElem
 
 function type_params(K::FqField)

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -498,6 +498,7 @@ function register_serialization_type(@nospecialize(T::Type), str::String, defaul
     end
     reverse_type_map[str] = merge(Dict{String, Type}(convert_type_to_string(T) => T), init)
     if default
+      "default" in reverse_type_map[str] && error("Attempting to overwrite registered default type $(reverse_type_map[str]["default"]) with $T") 
       reverse_type_map[str] = merge(Dict{String, Type}("default" => T), reverse_type_map[str])
     end
   elseif default

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -497,14 +497,18 @@ function register_serialization_type(@nospecialize(T::Type), str::String, defaul
       init = Dict{String, Type}(convert_type_to_string(init) => init)
     end
     reverse_type_map[str] = merge(Dict{String, Type}(convert_type_to_string(T) => T), init)
-    if default
-      "default" in reverse_type_map[str] && error("Attempting to overwrite registered default type $(reverse_type_map[str]["default"]) with $T") 
-      reverse_type_map[str] = merge(Dict{String, Type}("default" => T), reverse_type_map[str])
-    end
   elseif default
-    error("Keyword default used during Type registration when only one instance of type encoding")
+    reverse_type_map[str] = Dict{String, Type}(convert_type_to_string(T) => T)
   else
     reverse_type_map[str] = T
+  end
+
+  if default
+    if "default" in reverse_type_map[str]
+      S = reverse_type_map[str]["default"]
+      error("Attempting to overwrite registered default type $S with $T")
+    end
+    reverse_type_map[str] = merge(Dict{String, Type}("default" => T), reverse_type_map[str])
   end
 end
 

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -504,11 +504,11 @@ function register_serialization_type(@nospecialize(T::Type), str::String, defaul
   end
 
   if default
-    if "default" in reverse_type_map[str]
+    haskey(reverse_type_map[str], "default")
       S = reverse_type_map[str]["default"]
       error("Attempting to overwrite registered default type $S with $T")
     end
-    reverse_type_map[str] = merge(Dict{String, Type}("default" => T), reverse_type_map[str])
+    reverse_type_map[str]["default"] = T
   end
 end
 

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -504,7 +504,7 @@ function register_serialization_type(@nospecialize(T::Type), str::String, defaul
   end
 
   if default
-    haskey(reverse_type_map[str], "default")
+    if haskey(reverse_type_map[str], "default")
       S = reverse_type_map[str]["default"]
       error("Attempting to overwrite registered default type $S with $T")
     end

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -498,7 +498,7 @@ function register_serialization_type(@nospecialize(T::Type), str::String, defaul
     end
     reverse_type_map[str] = merge(Dict{String, Type}(convert_type_to_string(T) => T), init)
     if default
-      reverse_type_map[str] = merge(Dict{String, Type}("default" => T), init)
+      reverse_type_map[str] = merge(Dict{String, Type}("default" => T), reverse_type_map[str])
     end
   elseif default
     error("Keyword default used during Type registration when only one instance of type encoding")

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -140,12 +140,16 @@ function decode_type(s::DeserializerState)
       s.obj = obj
       return T
     end
-    return decode_type(s.obj)
+    obj = decode_type(s.obj)
+    obj isa AbstractDict && return obj["default"]
+    return obj
   end
 
   if type_key in keys(s.obj)
     return load_node(s, type_key) do _
-      decode_type(s)
+      obj = decode_type(s)
+      obj isa AbstractDict && return obj["default"]
+      return obj
     end
   end
 
@@ -157,7 +161,9 @@ function decode_type(s::DeserializerState)
       end
     else
       return load_node(s, :name) do _
-        decode_type(s)
+        obj = decode_type(s)
+        obj isa AbstractDict && return obj["default"]
+        return obj
       end
     end
   end

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -483,7 +483,7 @@ end
 
 ################################################################################
 # Type Registration
-function register_serialization_type(@nospecialize(T::Type), str::String)
+function register_serialization_type(@nospecialize(T::Type), str::String, default::Bool)
   if haskey(reverse_type_map, str) 
     init = reverse_type_map[str]
     # promote the value to a dictionary if necessary
@@ -491,6 +491,11 @@ function register_serialization_type(@nospecialize(T::Type), str::String)
       init = Dict{String, Type}(convert_type_to_string(init) => init)
     end
     reverse_type_map[str] = merge(Dict{String, Type}(convert_type_to_string(T) => T), init)
+    if default
+      reverse_type_map[str] = merge(Dict{String, Type}("default" => T), init)
+    end
+  elseif default
+    error("Keyword default used during Type registration when only one instance of type encoding")
   else
     reverse_type_map[str] = T
   end
@@ -514,10 +519,10 @@ import Distributed.AbstractSerializer
 serialize_with_id(::Type) = false
 serialize_with_id(obj::Any) = false
 
-function register_serialization_type(ex::Any, str::String, uses_id::Bool, attrs::Any)
+function register_serialization_type(ex::Any, str::String, uses_id::Bool, attrs::Any, default::Bool)
   return esc(
     quote
-      Oscar.Serialization.register_serialization_type($ex, $str)
+      Oscar.Serialization.register_serialization_type($ex, $str, $default)
       Oscar.Serialization.encode_type(::Type{<:$ex}) = $str
       # There exist types where equality cannot be discerned from the serialization
       # these types require an id so that equalities can be forced upon load.
@@ -553,7 +558,7 @@ function register_serialization_type(ex::Any, str::String, uses_id::Bool, attrs:
 end
 
 """
-    @register_serialization_type NewType "String Representation of type" uses_id uses_params [:attr1, :attr2]
+    @register_serialization_type NewType "String Representation of type" uses_id default [:attr1, :attr2]
 
 `@register_serialization_type` is a macro to ensure that the string we generate
 matches exactly the expression passed as first argument, and does not change
@@ -566,9 +571,7 @@ will be referred to throughout the serialization sessions using a `UUID`.
 This should typically only be used for types that do not have a fixed
 normal form for example `PolyRing` and `MPolyRing`.
 
-Using the `uses_params` flag will serialize the object with a more structured type
-description which will make the serialization more efficient see the discussion on
-`save_type_params` / `load_type_params` below.
+The `default` flag is used to decide a default amongst types that have the same encoding.
 
 Passing a vector of symbols that correspond to attributes of type
 indicates which attributes will be serialized when using save with `with_attrs=true`.
@@ -578,11 +581,14 @@ macro register_serialization_type(ex::Any, args...)
   uses_id = false
   str = nothing
   attrs = nothing
+  default = false
   for el in args
     if el isa String
       str = el
     elseif el == :uses_id
       uses_id = true
+    elseif el == :default
+      default = true
     else
       attrs = el
     end
@@ -594,7 +600,7 @@ macro register_serialization_type(ex::Any, args...)
     str = string(ex)
   end
 
-  return register_serialization_type(ex, str, uses_id, attrs)
+  return register_serialization_type(ex, str, uses_id, attrs, default)
 end
 
 ################################################################################

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -584,6 +584,7 @@ normal form for example `PolyRing` and `MPolyRing`.
 
 When registering a type with a "String representation" that is shared amonst more than one type, use the `default` flag to declare which type should be loaded by default, i.e. when the `_instance` is not used in the file to distinguish on load which type should be loaded.
 
+```
 {
   "_ns": {
     "Oscar": [
@@ -595,11 +596,11 @@ When registering a type with a "String representation" that is shared amonst mor
   "data": "2",
   "id": "7dc83bd8-4f11-4d30-9e4d-d96629c9a8f4"
 }
-
+```
 is loaded as a `FqField`
 
 where as 
-
+```
 {
   "_ns": {
     "Oscar": [
@@ -613,7 +614,8 @@ where as
   },
   "data": "2"
 }
-
+```
+is loaded as a `fpField`.
 Passing a vector of symbols that correspond to attributes of type
 indicates which attributes will be serialized when using save with `with_attrs=true`.
 

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -582,7 +582,37 @@ will be referred to throughout the serialization sessions using a `UUID`.
 This should typically only be used for types that do not have a fixed
 normal form for example `PolyRing` and `MPolyRing`.
 
-The `default` flag is used to decide a default amongst types that have the same encoding.
+When registering a type with a "String representation" that is shared amonst more than one type, use the `default` flag to declare which type should be loaded by default, i.e. when the `_instance` is not used in the file to distinguish on load which type should be loaded.
+
+{
+  "_ns": {
+    "Oscar": [
+      "https://github.com/oscar-system/Oscar.jl",
+      "1.8.0"
+    ]
+  },
+  "_type": "FiniteField",
+  "data": "2",
+  "id": "7dc83bd8-4f11-4d30-9e4d-d96629c9a8f4"
+}
+
+is loaded as a `FqField`
+
+where as 
+
+{
+  "_ns": {
+    "Oscar": [
+      "https://github.com/oscar-system/Oscar.jl",
+      "1.8.0"
+    ]
+  },
+  "_type": {
+    "_instance": "fpField",
+    "name": "FiniteField"
+  },
+  "data": "2"
+}
 
 Passing a vector of symbols that correspond to attributes of type
 indicates which attributes will be serialized when using save with `with_attrs=true`.

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -582,7 +582,8 @@ will be referred to throughout the serialization sessions using a `UUID`.
 This should typically only be used for types that do not have a fixed
 normal form for example `PolyRing` and `MPolyRing`.
 
-When registering a type with a "String representation" that is shared amonst more than one type, use the `default` flag to declare which type should be loaded by default, i.e. when the `_instance` is not used in the file to distinguish on load which type should be loaded.
+When registering a type with a "String representation of type" that is shared amongst more than one type, use the `default` flag to declare which type should be loaded by default.
+All other types with the same "String  representation of type" are stored with an additional `_instance` key describing their type. 
 
 ```
 {

--- a/test/Serialization/finite-field-default.mrdi
+++ b/test/Serialization/finite-field-default.mrdi
@@ -1,0 +1,1 @@
+{"_ns":{"Oscar":["https://github.com/oscar-system/Oscar.jl","1.8.0"]},"_type":{"name":"FqFieldElem","params":"53D8B336-D2B0-4439-9310-FF3B51AB6483"},"data":"3","_refs":{"53D8B336-D2B0-4439-9310-FF3B51AB6483":{"_type":"FiniteField","data":"11"}}}

--- a/test/Serialization/loading.jl
+++ b/test/Serialization/loading.jl
@@ -1,4 +1,9 @@
 @testset "loading" begin
+  @testset "Test Default Finite Field" begin
+    a = load(joinpath(@__DIR__, "finite-field-default.mrdi"))
+    @test a isa FqFieldElem
+  end
+
   @testset "loading file format paper example" begin
     F = GF(7, 2)
     o = gen(F)


### PR DESCRIPTION
For now there is only FiniteField types, but this type of functionality will help making the format slightly more language agnostic.

For example a Magma developer doesn't need to know what an FqField is to serialize a FiniteField.