### PR TITLE
Add `bergman_fan` function for matroids

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -83,6 +83,17 @@
   doi           = {10.4007/annals.2018.188.2.1}
 }
 
+@article {AK06,
+    AUTHOR = {Ardila, Federico and Klivans, Caroline J.},
+     TITLE = {The {B}ergman complex of a matroid and phylogenetic trees},
+   JOURNAL = {Journal of Combinatorial Theory. Series B},
+    VOLUME = {96},
+      YEAR = {2006},
+    NUMBER = {1},
+     PAGES = {38--49},
+       DOI = {10.1016/j.jctb.2005.06.004}
+}
+
 @Book{AL94,
   author        = {Adams, William W. and Loustaunau, Philippe},
   title         = {An Introduction to Gröbner Bases},

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -85,7 +85,7 @@
 
 @Article{AK06,
   author        = {Ardila, Federico and Klivans, Caroline J.},
-  title         = {The {B}ergman complex of a matroid and phylogenetic trees},
+  title         = {The Bergman complex of a matroid and phylogenetic trees},
   journal       = {Journal of Combinatorial Theory. Series B},
   volume        = {96},
   number        = {1},

--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -83,15 +83,15 @@
   doi           = {10.4007/annals.2018.188.2.1}
 }
 
-@article {AK06,
-    AUTHOR = {Ardila, Federico and Klivans, Caroline J.},
-     TITLE = {The {B}ergman complex of a matroid and phylogenetic trees},
-   JOURNAL = {Journal of Combinatorial Theory. Series B},
-    VOLUME = {96},
-      YEAR = {2006},
-    NUMBER = {1},
-     PAGES = {38--49},
-       DOI = {10.1016/j.jctb.2005.06.004}
+@Article{AK06,
+  author        = {Ardila, Federico and Klivans, Caroline J.},
+  title         = {The {B}ergman complex of a matroid and phylogenetic trees},
+  journal       = {Journal of Combinatorial Theory. Series B},
+  volume        = {96},
+  number        = {1},
+  pages         = {38--49},
+  year          = {2006},
+  doi           = {10.1016/j.jctb.2005.06.004}
 }
 
 @Book{AL94,

--- a/docs/src/Combinatorics/matroids.md
+++ b/docs/src/Combinatorics/matroids.md
@@ -118,7 +118,7 @@ is_minor(M::Matroid, N::Matroid)
 matroid_hex(M::Matroid)
 automorphism_group(M::Matroid)
 matroid_base_polytope(M::Matroid)
-bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Union{typeof(min),typeof(max)} = min)
+bergman_fan(M::Matroid; fan_structure::Symbol = :coarse, convention::Union{typeof(min),typeof(max)} = min)
 ```
 
 ### Tutte Group

--- a/docs/src/Combinatorics/matroids.md
+++ b/docs/src/Combinatorics/matroids.md
@@ -118,7 +118,7 @@ is_minor(M::Matroid, N::Matroid)
 matroid_hex(M::Matroid)
 automorphism_group(M::Matroid)
 matroid_base_polytope(M::Matroid)
-bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symbol = :min)
+bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Union{typeof(min),typeof(max)} = min)
 ```
 
 ### Tutte Group

--- a/docs/src/Combinatorics/matroids.md
+++ b/docs/src/Combinatorics/matroids.md
@@ -118,6 +118,7 @@ is_minor(M::Matroid, N::Matroid)
 matroid_hex(M::Matroid)
 automorphism_group(M::Matroid)
 matroid_base_polytope(M::Matroid)
+bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symbol = :min)
 ```
 
 ### Tutte Group

--- a/docs/src/Combinatorics/matroids.md
+++ b/docs/src/Combinatorics/matroids.md
@@ -118,7 +118,7 @@ is_minor(M::Matroid, N::Matroid)
 matroid_hex(M::Matroid)
 automorphism_group(M::Matroid)
 matroid_base_polytope(M::Matroid)
-bergman_fan(M::Matroid; fan_structure::Symbol = :coarse, convention::Union{typeof(min),typeof(max)} = min)
+bergman_fan(M::Matroid, convention::Union{typeof(min),typeof(max)} = min; fan_structure::Symbol = :coarse)
 ```
 
 ### Tutte Group

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1210,7 +1210,7 @@ which can be `:fine`, `:coarse` (the two structures discussed in [AK06](@cite)) 
 # Examples
 The Bergman fan of the complete graph on $n$ vertices is the space of phylogenetic trees, its coarse
 fan structure has $(2n-3)!!=(2n-3)\cdot(2n-5)\cdots 3\cdot 1$ maximal cones.
-```
+```jldoctest
 julia> M = cycle_matroid(complete_graph(5))
 Matroid of rank 4 on 10 elements
 

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1239,7 +1239,7 @@ function bergman_fan(M::Matroid, convention::Union{typeof(min),typeof(max)} = mi
         return polyhedral_fan(IM, R, [fill(1, length(M))])
         
     elseif fan_structure == :cyclic
-        pmTC = Polymake.tropical.matroid_fan{convention}(M.pm_matroid)
+        pmTC = Polymake.tropical.matroid_fan{convention}(pm_object(M))
         pmTC.FAN_DIM  # this forces polymake to compute the necessary properties
         
         i = findfirst(==([1; zeros(length(M))]), eachrow(pmTC.VERTICES))  # index of polymake's extra ray

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1211,14 +1211,14 @@ which can be `:fine`, `:coarse` (the two structures discussed in [AK06](@cite)) 
 The Bergman fan of the complete graph on $n$ vertices is the space of phylogenetic trees, its coarse
 fan structure has $(2n-3)!!=(2n-3)\cdot(2n-5)\cdot...\cdot 3\cdot 1$ maximal cones.
 ```
-julia> M = cycle_matroid(complete_graph(5))
-Matroid of rank 4 on 10 elements
+julia> M = cycle_matroid(complete_graph(4))
+Matroid of rank 3 on 6 elements
 
 julia> F = bergman_fan(M)
-Polyhedral fan in ambient dimension 10
+Polyhedral fan in ambient dimension 6
 
 julia> n_maximal_cones(F)
-105
+15
 ```
 """
 function bergman_fan(M::Matroid; fan_structure::Symbol = :coarse, convention::Union{typeof(min),typeof(max)} = min)

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1254,7 +1254,7 @@ function bergman_fan(M::Matroid, convention::Union{typeof(min),typeof(max)} = mi
         indices = findall(==(length(M) - rank(M) + 1), rank.(elements(FP)))
         
         V = vertices(P)
-        FF = [f.a[1, :] for f in facets(P)]
+        FF = normal_vector.(facets(P))
         
         IM = Vector{Int64}[]
         for i in indices

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1209,7 +1209,7 @@ which can be `:fine`, `:coarse` (the two structures discussed in [AK06](@cite)) 
 
 # Examples
 The Bergman fan of the complete graph on $n$ vertices is the space of phylogenetic trees, its coarse
-fan structure has $(2n-3)!!=(2n-3)\cdot(2n-5)\cdot...\cdot 3\cdot 1$ maximal cones.
+fan structure has $(2n-3)!!=(2n-3)\cdot(2n-5)\cdots 3\cdot 1$ maximal cones.
 ```
 julia> M = cycle_matroid(complete_graph(5))
 Matroid of rank 4 on 10 elements

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1224,7 +1224,7 @@ julia> n_maximal_cones(F)
 function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Union{typeof(min),typeof(max)} = min)
     conv = convention
     if !(conv in [min, max])
-        throw(ArgumentError("convention must be min or max."))
+        throw(ArgumentError("convention '$(conv)' is not supported"))
     end
     
     if !(fan_structure in [:fine, :cyclic, :coarse])
@@ -1255,7 +1255,7 @@ function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Unio
         NS = matrix(QQ, P.pm_polytope.AFFINE_HULL)[:, 2:end]
     
         FP = face_poset(P) 
-        DF = Polymake.graph.dual_faces(FP.pm_poset) #face-facet incidence
+        DF = Polymake.graph.dual_faces(FP.pm_poset)  # face-facet incidence
         indices = findall(==(length(M) - rank(M) + 1), rank.(elements(FP)))
         
         V = vertices(P)
@@ -1263,10 +1263,10 @@ function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Unio
         
         BC = Cone{QQFieldElem}[]
         for i in indices
-            verts = V[Vector(Oscar._get_decoration(FP, i)) .+ 1] #assumes the numbering of vertices used in decorations agrees with V
-            inM = matroid_from_bases([M.groundset[findall(==(1), v)] for v in verts], M.groundset) #initial matroid from vertices
+            verts = V[Vector(Oscar._get_decoration(FP, i)) .+ 1]  # assumes numbering of vertices used in decorations agrees with V
+            inM = matroid_from_bases([M.groundset[findall(==(1), v)] for v in verts], M.groundset)  # initial matroid from vertices
             if is_loopless(inM)
-                R = FF[Vector(DF[i]) .+ 1] #assumes the numbering of facets used in DF agrees with FF
+                R = FF[Vector(DF[i]) .+ 1]  # assumes the numbering of facets used in DF agrees with FF
                 push!(BC, cone(-conv(1, -1)*R, -conv(1, -1)*NS))
             end
         end

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1197,7 +1197,7 @@ function indicator_vector(S::Vector{Int}, n::Int)
 end
 
 @doc raw"""
-    bergman_fan(M::Matroid; fan_structure::Symbol = :coarse, convention::Union{typeof(min),typeof(max)} = min)
+    bergman_fan(M::Matroid, convention::Union{typeof(min),typeof(max)} = min; fan_structure::Symbol = :coarse)
 
 The Bergman fan of the matroid `M`. The desired fan structure is specified by `fan_structure`, 
 which can be `:fine`, `:coarse` (the two structures discussed in [AK06](@cite)) or `:cyclic` 

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1251,7 +1251,7 @@ function bergman_fan(M::Matroid, convention::Union{typeof(min),typeof(max)} = mi
     
         FP = face_poset(P) 
         DF = Polymake.graph.dual_faces(FP.pm_poset)  # face-facet incidence
-        indices = findall(==(length(M) - rank(M) + 1), rank.(elements(FP)))
+        elems = elements_of_rank(FP, length(M) - rank(M) + 1)
         
         V = vertices(P)
         FF = normal_vector.(facets(P))

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1197,7 +1197,7 @@ function indicator_vector(S::Vector{Int}, n::Int)
 end
 
 @doc raw"""
-    bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symbol = :min)
+    bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Union{typeof(min),typeof(max)} = min)
 
 The Bergman fan of the matroid `M`. The desired fan structure is specified by `fan_structure`, 
 which can be `:fine`, `:coarse` (the two structures discussed in [AK06](@cite)) or `:cyclic` 
@@ -1266,7 +1266,7 @@ function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Unio
             verts = V[Vector(Oscar._get_decoration(FP, i)) .+ 1]  # assumes numbering of vertices used in decorations agrees with V
             inM = matroid_from_bases([M.groundset[findall(==(1), v)] for v in verts], M.groundset)  # initial matroid from vertices
             if is_loopless(inM)
-                R = FF[Vector(DF[i]) .+ 1]  # assumes the numbering of facets used in DF agrees with FF
+                R = FF[Vector(DF[i]) .+ 1]  # assumes numbering of facets used in DF agrees with FF
                 push!(BC, cone(-conv(1, -1)*R, -conv(1, -1)*NS))
             end
         end

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1198,6 +1198,26 @@ end
 
 
 
+@doc raw"""
+    bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symbol = :min)
+
+The Bergman fan of the matroid `M`. The desired fan structure is specified by `fan_structure`, which can be `:fine`, `:coarse` (the two structures discussed in [AK06](@cite)) or `:cyclic` (as defined in [Rin13](@cite)). Convention `:min` or `:max` can be specified using the optional argument `convention`, where `:min` agrees with the aforecited papers. 
+
+!!! note
+Following the conventions in the above sources, the output has ambient dimension `length(M)` and dimension `rank(M)`. Therefore, its lineality dimension is always at least 1.
+
+# Examples
+```
+julia> M = cycle_matroid(complete_graph(5))
+Matroid of rank 4 on 10 elements
+
+julia> F = bergman_fan(M, fan_structure = :coarse) #this Bergman fan is the space of phylogenetic trees and has 7!! maximal cones
+Polyhedral fan in ambient dimension 10
+
+julia> n_maximal_cones(F)
+105
+```
+"""
 function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symbol = :min)
     if convention == :min
         conv = min
@@ -1221,7 +1241,7 @@ function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symb
         
     elseif fan_structure == :coarse
         P = matroid_base_polytope(M)
-        NS = matrix(QQ, P.pm_polytope.AFFINE_HULL)[:,2:end]
+        NS = matrix(QQ, P.pm_polytope.AFFINE_HULL)[:, 2:end]
     
         FP = face_poset(P) 
         DF = Polymake.graph.dual_faces(FP.pm_poset)

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1199,30 +1199,32 @@ end
 @doc raw"""
     bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symbol = :min)
 
-The Bergman fan of the matroid `M`. The desired fan structure is specified by `fan_structure`, which can be `:fine`, `:coarse` (the two structures discussed in [AK06](@cite)) or `:cyclic` (as defined in [Rin13](@cite)). Convention `:min` or `:max` can be chosen using the optional argument `convention`, where `:min` agrees with the aforecited papers. 
+The Bergman fan of the matroid `M`. The desired fan structure is specified by `fan_structure`, 
+which can be `:fine`, `:coarse` (the two structures discussed in [AK06](@cite)) or `:cyclic` 
+(as defined in [Rin13](@cite)). Convention `min` or `max` can be chosen using the optional argument 
+`convention`, where `min` agrees with the aforecited papers. 
 
 !!! note
     Via the conventions in the above sources, the output always has a lineality dimension of at least 1.
 
 # Examples
+The Bergman fan of the complete graph on $n$ vertices is the space of phylogenetic trees, its coarse
+fan structure has $(2n-3)!!=(2n-3)\cdot(2n-5)\cdot...\cdot 3\cdot 1$ maximal cones.
 ```
 julia> M = cycle_matroid(complete_graph(4))
 Matroid of rank 3 on 6 elements
 
-julia> F = bergman_fan(M, fan_structure = :coarse) #this Bergman fan is the space of phylogenetic trees with 5!! maximal cones
+julia> F = bergman_fan(M, fan_structure = :coarse)
 Polyhedral fan in ambient dimension 6
 
 julia> n_maximal_cones(F)
 15
 ```
 """
-function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symbol = :min)
-    if convention == :min
-        conv = min
-    elseif convention == :max
-        conv = max
-    else
-        throw(ArgumentError("convention must be :min or :max."))
+function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Union{typeof(min),typeof(max)} = min)
+    conv = convention
+    if !(conv in [min, max])
+        throw(ArgumentError("convention must be min or max."))
     end
     
     if !(fan_structure in [:fine, :cyclic, :coarse])

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1211,14 +1211,14 @@ which can be `:fine`, `:coarse` (the two structures discussed in [AK06](@cite)) 
 The Bergman fan of the complete graph on $n$ vertices is the space of phylogenetic trees, its coarse
 fan structure has $(2n-3)!!=(2n-3)\cdot(2n-5)\cdot...\cdot 3\cdot 1$ maximal cones.
 ```
-julia> M = cycle_matroid(complete_graph(4))
-Matroid of rank 3 on 6 elements
+julia> M = cycle_matroid(complete_graph(5))
+Matroid of rank 4 on 10 elements
 
-julia> F = bergman_fan(M, fan_structure = :coarse)
-Polyhedral fan in ambient dimension 6
+julia> F = bergman_fan(M)
+Polyhedral fan in ambient dimension 10
 
 julia> n_maximal_cones(F)
-15
+105
 ```
 """
 function bergman_fan(M::Matroid; fan_structure::Symbol = :coarse, convention::Union{typeof(min),typeof(max)} = min)
@@ -1250,7 +1250,6 @@ function bergman_fan(M::Matroid; fan_structure::Symbol = :coarse, convention::Un
         
     elseif fan_structure == :coarse
         P = matroid_base_polytope(M)
-        NS = matrix(QQ, P.pm_polytope.AFFINE_HULL)[:, 2:end]
     
         FP = face_poset(P) 
         DF = Polymake.graph.dual_faces(FP.pm_poset)  # face-facet incidence
@@ -1259,17 +1258,17 @@ function bergman_fan(M::Matroid; fan_structure::Symbol = :coarse, convention::Un
         V = vertices(P)
         FF = [f.a[1, :] for f in facets(P)]
         
-        BC = Cone{QQFieldElem}[]
+        IM = Vector{Int64}[]
         for i in indices
             verts = V[Vector(Oscar._get_decoration(FP, i)) .+ 1]  # assumes numbering of vertices used in decorations agrees with V
             inM = matroid_from_bases([M.groundset[findall(==(1), v)] for v in verts], M.groundset)  # initial matroid from vertices
             if is_loopless(inM)
-                R = FF[Vector(DF[i]) .+ 1]  # assumes numbering of facets used in DF agrees with FF
-                push!(BC, cone(-convention(1, -1)*R, -convention(1, -1)*NS))
+                push!(IM, Vector(DF[i]) .+ 1)  # assumes numbering of facets used in DF agrees with FF
             end
         end
                         
-        return polyhedral_fan(BC)
+        NS = matrix(QQ, P.pm_polytope.AFFINE_HULL)[:, 2:end]
+        return polyhedral_fan(IncidenceMatrix(IM), -convention(1, -1)*FF, NS)
     end
 end
         

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1266,7 +1266,7 @@ function bergman_fan(M::Matroid, convention::Union{typeof(min),typeof(max)} = mi
             end
         end
                         
-        NS = matrix(QQ, P.pm_polytope.AFFINE_HULL)[:, 2:end]
+        NS = normal_vector.(affine_hull(P))
         return polyhedral_fan(IncidenceMatrix(IM), -convention(1, -1)*FF, NS)
     end
 end

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1243,7 +1243,7 @@ function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symb
         
     elseif fan_structure == :cyclic
         pmTC = Polymake.tropical.matroid_fan{conv}(M.pm_matroid)
-        pmTC.FAN_DIM #this forces polymake to compute the necessary properties
+        pmTC.FAN_DIM  # this forces polymake to compute the necessary properties
         PC = polyhedral_complex(Polymake.fan.PolyhedralComplex(pmTC))
         BC = [cone(rays(mc), [fill(1, length(M))]) for mc in maximal_polyhedra(PC)]
         return polyhedral_fan(BC)

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1202,7 +1202,7 @@ end
 The Bergman fan of the matroid `M`. The desired fan structure is specified by `fan_structure`, which can be `:fine`, `:coarse` (the two structures discussed in [AK06](@cite)) or `:cyclic` (as defined in [Rin13](@cite)). Convention `:min` or `:max` can be chosen using the optional argument `convention`, where `:min` agrees with the aforecited papers. 
 
 !!! note
-Via the conventions in the above sources, the output always has a lineality dimension of at least 1.
+    Via the conventions in the above sources, the output always has a lineality dimension of at least 1.
 
 # Examples
 ```

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1226,7 +1226,7 @@ function bergman_fan(M::Matroid; fan_structure::Symbol = :coarse, convention::Un
     @req fan_structure in [:fine, :cyclic, :coarse] "fan structure '$(fan_structure)' is not supported"
     
     if rank(M) == 0
-        pt = cone(zeros(QQ, length(M)))
+        pt = cone(zeros(QQFieldElem, length(M)))
         return polyhedral_fan(pt)
     end
     

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1201,21 +1201,21 @@ end
 @doc raw"""
     bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symbol = :min)
 
-The Bergman fan of the matroid `M`. The desired fan structure is specified by `fan_structure`, which can be `:fine`, `:coarse` (the two structures discussed in [AK06](@cite)) or `:cyclic` (as defined in [Rin13](@cite)). Convention `:min` or `:max` can be specified using the optional argument `convention`, where `:min` agrees with the aforecited papers. 
+The Bergman fan of the matroid `M`. The desired fan structure is specified by `fan_structure`, which can be `:fine`, `:coarse` (the two structures discussed in [AK06](@cite)) or `:cyclic` (as defined in [Rin13](@cite)). Convention `:min` or `:max` can be chosen using the optional argument `convention`, where `:min` agrees with the aforecited papers. 
 
 !!! note
-Following the conventions in the above sources, the output has ambient dimension `length(M)` and dimension `rank(M)`. Therefore, its lineality dimension is always at least 1.
+Via the conventions in the above sources, the output always has a lineality dimension of at least 1.
 
 # Examples
 ```
-julia> M = cycle_matroid(complete_graph(5))
-Matroid of rank 4 on 10 elements
+julia> M = cycle_matroid(complete_graph(4))
+Matroid of rank 3 on 6 elements
 
-julia> F = bergman_fan(M, fan_structure = :coarse) #this Bergman fan is the space of phylogenetic trees and has 7!! maximal cones
-Polyhedral fan in ambient dimension 10
+julia> F = bergman_fan(M, fan_structure = :coarse) #this Bergman fan is the space of phylogenetic trees with 5!! maximal cones
+Polyhedral fan in ambient dimension 6
 
 julia> n_maximal_cones(F)
-105
+15
 ```
 """
 function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symbol = :min)

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1240,7 +1240,6 @@ function bergman_fan(M::Matroid, convention::Union{typeof(min),typeof(max)} = mi
         
     elseif fan_structure == :cyclic
         pmTC = Polymake.tropical.matroid_fan{convention}(pm_object(M))
-        pmTC.FAN_DIM  # this forces polymake to compute the necessary properties
         
         i = findfirst(==([1; zeros(length(M))]), eachrow(pmTC.VERTICES))  # index of polymake's extra ray
         IM = pmTC.MAXIMAL_POLYTOPES[:, [1:i-1; i+1:end]]  

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1196,8 +1196,6 @@ function indicator_vector(S::Vector{Int}, n::Int)
     return map(x -> x in S ? 1 : 0 , 1:n)
 end
 
-
-
 @doc raw"""
     bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symbol = :min)
 
@@ -1224,27 +1222,38 @@ function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symb
     elseif convention == :max
         conv = max
     else
-        error("Convention must be either :min or :max.")
+        throw(ArgumentError("convention must be :min or :max."))
+    end
+    
+    if !(fan_structure in [:fine, :cyclic, :coarse])
+        throw(ArgumentError("the supported fan structures are :fine, :cylcic and :coarse."))
+    end
+    
+    if rank(M) == 0
+        pt = cone(zeros(QQ, length(M)))
+        return polyhedral_fan(pt)
     end
     
     if fan_structure == :fine
-        PMTC = Polymake.tropical.matroid_fan_from_flats{conv}(M.pm_matroid)
-        PMTC.FAN_DIM #this forces polymake to compute the necessary properties
-        PC = polyhedral_complex(Polymake.fan.PolyhedralComplex(PMTC))
-        return polyhedral_fan([cone(rays(mc), [fill(1, length(M))]) for mc in maximal_polyhedra(PC)])
+        pmTC = Polymake.tropical.matroid_fan_from_flats{conv}(M.pm_matroid)
+        pmTC.FAN_DIM #this forces polymake to compute the necessary properties
+        PC = polyhedral_complex(Polymake.fan.PolyhedralComplex(pmTC))
+        BC = [cone(rays(mc), [fill(1, length(M))]) for mc in maximal_polyhedra(PC)]
+        return polyhedral_fan(BC)
         
     elseif fan_structure == :cyclic
-        PMTC = Polymake.tropical.matroid_fan{conv}(M.pm_matroid)
-        PMTC.FAN_DIM #this forces polymake to compute the necessary properties
-        PC = polyhedral_complex(Polymake.fan.PolyhedralComplex(PMTC))
-        return polyhedral_fan([cone(rays(mc), [fill(1, length(M))]) for mc in maximal_polyhedra(PC)])
+        pmTC = Polymake.tropical.matroid_fan{conv}(M.pm_matroid)
+        pmTC.FAN_DIM #this forces polymake to compute the necessary properties
+        PC = polyhedral_complex(Polymake.fan.PolyhedralComplex(pmTC))
+        BC = [cone(rays(mc), [fill(1, length(M))]) for mc in maximal_polyhedra(PC)]
+        return polyhedral_fan(BC)
         
     elseif fan_structure == :coarse
         P = matroid_base_polytope(M)
         NS = matrix(QQ, P.pm_polytope.AFFINE_HULL)[:, 2:end]
     
         FP = face_poset(P) 
-        DF = Polymake.graph.dual_faces(FP.pm_poset)
+        DF = Polymake.graph.dual_faces(FP.pm_poset) #face-facet incidence
         st = findfirst(==(length(M) - rank(M) + 1), rank.(elements(FP)))
         fi = findlast(==(length(M) - rank(M) + 1), rank.(elements(FP)))
         
@@ -1253,21 +1262,15 @@ function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symb
         
         BC = Cone{QQFieldElem}[]
         for i in st:fi #assumes elements of a given rank are consecutive in elements(FP)
-            f = elements(FP)[i]
-            if rank(f) == length(M) - rank(M) + 1
-                verts = V[Vector(Oscar._get_decoration(FP, i)) .+ 1] #assumes the numbering of vertices used in decorations agrees with V
-                inM = matroid_from_bases([M.groundset[findall(==(1), v)] for v in verts], M.groundset)
-                if is_loopless(inM)
-                    R = FF[Vector(DF[i]) .+ 1] #assumes the numbering of facets used in DF agrees with FF
-                    push!(BC, cone(-conv(1, -1)*R, -conv(1, -1)*NS))
-                end
+            verts = V[Vector(Oscar._get_decoration(FP, i)) .+ 1] #assumes the numbering of vertices used in decorations agrees with V
+            inM = matroid_from_bases([M.groundset[findall(==(1), v)] for v in verts], M.groundset) #initial matroid from vertices
+            if is_loopless(inM)
+                R = FF[Vector(DF[i]) .+ 1] #assumes the numbering of facets used in DF agrees with FF
+                push!(BC, cone(-conv(1, -1)*R, -conv(1, -1)*NS))
             end
         end
                         
         return polyhedral_fan(BC)
-        
-    else
-        error("The supported fan structures are :fine, :cylcic and :coarse.")
     end
 end
         

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1195,3 +1195,60 @@ end
 function indicator_vector(S::Vector{Int}, n::Int)
     return map(x -> x in S ? 1 : 0 , 1:n)
 end
+
+
+
+function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symbol = :min)
+    if convention == :min
+        conv = min
+    elseif convention == :max
+        conv = max
+    else
+        error("Convention must be either :min or :max.")
+    end
+    
+    if fan_structure == :fine
+        PMTC = Polymake.tropical.matroid_fan_from_flats{conv}(M.pm_matroid)
+        PMTC.FAN_DIM #this forces polymake to compute the necessary properties
+        PC = polyhedral_complex(Polymake.fan.PolyhedralComplex(PMTC))
+        return polyhedral_fan([cone(rays(mc), [fill(1, length(M))]) for mc in maximal_polyhedra(PC)])
+        
+    elseif fan_structure == :cyclic
+        PMTC = Polymake.tropical.matroid_fan{conv}(M.pm_matroid)
+        PMTC.FAN_DIM #this forces polymake to compute the necessary properties
+        PC = polyhedral_complex(Polymake.fan.PolyhedralComplex(PMTC))
+        return polyhedral_fan([cone(rays(mc), [fill(1, length(M))]) for mc in maximal_polyhedra(PC)])
+        
+    elseif fan_structure == :coarse
+        P = matroid_base_polytope(M)
+        NS = matrix(QQ, P.pm_polytope.AFFINE_HULL)[:,2:end]
+    
+        FP = face_poset(P) 
+        DF = Polymake.graph.dual_faces(FP.pm_poset)
+        st = findfirst(==(length(M) - rank(M) + 1), rank.(elements(FP)))
+        fi = findlast(==(length(M) - rank(M) + 1), rank.(elements(FP)))
+        
+        V = vertices(P)
+        FF = [f.a[1, :] for f in facets(P)]
+        
+        BC = Cone{QQFieldElem}[]
+        for i in st:fi #assumes elements of a given rank are consecutive in elements(FP)
+            f = elements(FP)[i]
+            if rank(f) == length(M) - rank(M) + 1
+                verts = V[Vector(Oscar._get_decoration(FP, i)) .+ 1] #assumes the numbering of vertices used in decorations agrees with V
+                inM = matroid_from_bases([M.groundset[findall(==(1), v)] for v in verts], M.groundset)
+                if is_loopless(inM)
+                    R = FF[Vector(DF[i]) .+ 1] #assumes the numbering of facets used in DF agrees with FF
+                    push!(BC, cone(-conv(1, -1)*R, -conv(1, -1)*NS))
+                end
+            end
+        end
+                        
+        return polyhedral_fan(BC)
+        
+    else
+        error("The supported fan structures are :fine, :cylcic and :coarse.")
+    end
+end
+        
+        

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1223,7 +1223,7 @@ julia> n_maximal_cones(F)
 """
 function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Union{typeof(min),typeof(max)} = min)
     @req convention in [min, max] "convention '$(convention)' is not supported"
-    @req fan_structure in [:fine, :cyclic, :coarse] "fan structure '$(fan_structure)' is not supported")
+    @req fan_structure in [:fine, :cyclic, :coarse] "fan structure '$(fan_structure)' is not supported"
     
     if rank(M) == 0
         pt = cone(zeros(QQ, length(M)))

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1226,7 +1226,7 @@ function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symb
     end
     
     if !(fan_structure in [:fine, :cyclic, :coarse])
-        throw(ArgumentError("the supported fan structures are :fine, :cylcic and :coarse."))
+        throw(ArgumentError("fan structure '$(fan_structure)' is not supported"))
     end
     
     if rank(M) == 0

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1254,14 +1254,13 @@ function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symb
     
         FP = face_poset(P) 
         DF = Polymake.graph.dual_faces(FP.pm_poset) #face-facet incidence
-        st = findfirst(==(length(M) - rank(M) + 1), rank.(elements(FP)))
-        fi = findlast(==(length(M) - rank(M) + 1), rank.(elements(FP)))
+        indices = findall(==(length(M) - rank(M) + 1), rank.(elements(FP)))
         
         V = vertices(P)
         FF = [f.a[1, :] for f in facets(P)]
         
         BC = Cone{QQFieldElem}[]
-        for i in st:fi #assumes elements of a given rank are consecutive in elements(FP)
+        for i in indices
             verts = V[Vector(Oscar._get_decoration(FP, i)) .+ 1] #assumes the numbering of vertices used in decorations agrees with V
             inM = matroid_from_bases([M.groundset[findall(==(1), v)] for v in verts], M.groundset) #initial matroid from vertices
             if is_loopless(inM)

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1222,14 +1222,8 @@ julia> n_maximal_cones(F)
 ```
 """
 function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Union{typeof(min),typeof(max)} = min)
-    conv = convention
-    if !(conv in [min, max])
-        throw(ArgumentError("convention '$(conv)' is not supported"))
-    end
-    
-    if !(fan_structure in [:fine, :cyclic, :coarse])
-        throw(ArgumentError("fan structure '$(fan_structure)' is not supported"))
-    end
+    @req convention in [min, max] "convention '$(convention)' is not supported"
+    @req fan_structure in [:fine, :cyclic, :coarse] "fan structure '$(fan_structure)' is not supported")
     
     if rank(M) == 0
         pt = cone(zeros(QQ, length(M)))
@@ -1237,14 +1231,14 @@ function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Unio
     end
     
     if fan_structure == :fine
-        pmTC = Polymake.tropical.matroid_fan_from_flats{conv}(M.pm_matroid)
+        pmTC = Polymake.tropical.matroid_fan_from_flats{convention}(M.pm_matroid)
         pmTC.FAN_DIM  # this forces polymake to compute the necessary properties
         PC = polyhedral_complex(Polymake.fan.PolyhedralComplex(pmTC))
         BC = [cone(rays(mc), [fill(1, length(M))]) for mc in maximal_polyhedra(PC)]
         return polyhedral_fan(BC)
         
     elseif fan_structure == :cyclic
-        pmTC = Polymake.tropical.matroid_fan{conv}(M.pm_matroid)
+        pmTC = Polymake.tropical.matroid_fan{convention}(M.pm_matroid)
         pmTC.FAN_DIM  # this forces polymake to compute the necessary properties
         PC = polyhedral_complex(Polymake.fan.PolyhedralComplex(pmTC))
         BC = [cone(rays(mc), [fill(1, length(M))]) for mc in maximal_polyhedra(PC)]
@@ -1267,7 +1261,7 @@ function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Unio
             inM = matroid_from_bases([M.groundset[findall(==(1), v)] for v in verts], M.groundset)  # initial matroid from vertices
             if is_loopless(inM)
                 R = FF[Vector(DF[i]) .+ 1]  # assumes numbering of facets used in DF agrees with FF
-                push!(BC, cone(-conv(1, -1)*R, -conv(1, -1)*NS))
+                push!(BC, cone(-convention(1, -1)*R, -convention(1, -1)*NS))
             end
         end
                         

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1236,7 +1236,7 @@ function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symb
     
     if fan_structure == :fine
         pmTC = Polymake.tropical.matroid_fan_from_flats{conv}(M.pm_matroid)
-        pmTC.FAN_DIM #this forces polymake to compute the necessary properties
+        pmTC.FAN_DIM  # this forces polymake to compute the necessary properties
         PC = polyhedral_complex(Polymake.fan.PolyhedralComplex(pmTC))
         BC = [cone(rays(mc), [fill(1, length(M))]) for mc in maximal_polyhedra(PC)]
         return polyhedral_fan(BC)

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1257,11 +1257,12 @@ function bergman_fan(M::Matroid, convention::Union{typeof(min),typeof(max)} = mi
         FF = normal_vector.(facets(P))
         
         IM = Vector{Int64}[]
-        for i in indices
-            verts = V[Vector(Oscar._get_decoration(FP, i)) .+ 1]  # assumes numbering of vertices used in decorations agrees with V
-            inM = matroid_from_bases([M.groundset[findall(==(1), v)] for v in verts], M.groundset)  # initial matroid from vertices
+        for pe in elems
+            verts = V[data(pe)]
+            # initial matroid from vertices
+            inM = matroid_from_bases([findall(isone, v) for v in verts], length(M); check=false)
             if is_loopless(inM)
-                push!(IM, Vector(DF[i]) .+ 1)  # assumes numbering of facets used in DF agrees with FF
+                push!(IM, Vector(Polymake.to_one_based_indexing(DF[node_id(pe)])))
             end
         end
                         

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1211,14 +1211,14 @@ which can be `:fine`, `:coarse` (the two structures discussed in [AK06](@cite)) 
 The Bergman fan of the complete graph on $n$ vertices is the space of phylogenetic trees, its coarse
 fan structure has $(2n-3)!!=(2n-3)\cdot(2n-5)\cdot...\cdot 3\cdot 1$ maximal cones.
 ```
-julia> M = cycle_matroid(complete_graph(4))
-Matroid of rank 3 on 6 elements
+julia> M = cycle_matroid(complete_graph(5))
+Matroid of rank 4 on 10 elements
 
 julia> F = bergman_fan(M)
-Polyhedral fan in ambient dimension 6
+Polyhedral fan in ambient dimension 10
 
 julia> n_maximal_cones(F)
-15
+105
 ```
 """
 function bergman_fan(M::Matroid; fan_structure::Symbol = :coarse, convention::Union{typeof(min),typeof(max)} = min)

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1250,7 +1250,7 @@ function bergman_fan(M::Matroid, convention::Union{typeof(min),typeof(max)} = mi
         P = matroid_base_polytope(M)
     
         FP = face_poset(P) 
-        DF = Polymake.graph.dual_faces(FP.pm_poset)  # face-facet incidence
+        DF = Polymake.graph.dual_faces(pm_object(FP))  # face-facet incidence
         elems = elements_of_rank(FP, length(M) - rank(M) + 1)
         
         V = vertices(P)

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1197,7 +1197,7 @@ function indicator_vector(S::Vector{Int}, n::Int)
 end
 
 @doc raw"""
-    bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Union{typeof(min),typeof(max)} = min)
+    bergman_fan(M::Matroid; fan_structure::Symbol = :coarse, convention::Union{typeof(min),typeof(max)} = min)
 
 The Bergman fan of the matroid `M`. The desired fan structure is specified by `fan_structure`, 
 which can be `:fine`, `:coarse` (the two structures discussed in [AK06](@cite)) or `:cyclic` 
@@ -1221,7 +1221,7 @@ julia> n_maximal_cones(F)
 15
 ```
 """
-function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Union{typeof(min),typeof(max)} = min)
+function bergman_fan(M::Matroid; fan_structure::Symbol = :coarse, convention::Union{typeof(min),typeof(max)} = min)
     @req convention in [min, max] "convention '$(convention)' is not supported"
     @req fan_structure in [:fine, :cyclic, :coarse] "fan structure '$(fan_structure)' is not supported"
     
@@ -1233,16 +1233,20 @@ function bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Unio
     if fan_structure == :fine
         pmTC = Polymake.tropical.matroid_fan_from_flats{convention}(M.pm_matroid)
         pmTC.FAN_DIM  # this forces polymake to compute the necessary properties
-        PC = polyhedral_complex(Polymake.fan.PolyhedralComplex(pmTC))
-        BC = [cone(rays(mc), [fill(1, length(M))]) for mc in maximal_polyhedra(PC)]
-        return polyhedral_fan(BC)
+        
+        i = findfirst(==([1; zeros(length(M))]), eachrow(pmTC.VERTICES))  # index of polymake's extra ray
+        IM = pmTC.MAXIMAL_POLYTOPES[:, [1:i-1; i+1:end]]  
+        R = eachrow(pmTC.VERTICES[[1:i-1; i+1:end], 2:end])  
+        return polyhedral_fan(IM, R, [fill(1, length(M))])
         
     elseif fan_structure == :cyclic
         pmTC = Polymake.tropical.matroid_fan{convention}(M.pm_matroid)
         pmTC.FAN_DIM  # this forces polymake to compute the necessary properties
-        PC = polyhedral_complex(Polymake.fan.PolyhedralComplex(pmTC))
-        BC = [cone(rays(mc), [fill(1, length(M))]) for mc in maximal_polyhedra(PC)]
-        return polyhedral_fan(BC)
+        
+        i = findfirst(==([1; zeros(length(M))]), eachrow(pmTC.VERTICES))  # index of polymake's extra ray
+        IM = pmTC.MAXIMAL_POLYTOPES[:, [1:i-1; i+1:end]]  
+        R = eachrow(pmTC.VERTICES[[1:i-1; i+1:end], 2:end])  
+        return polyhedral_fan(IM, R, [fill(1, length(M))])
         
     elseif fan_structure == :coarse
         P = matroid_base_polytope(M)

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1221,8 +1221,7 @@ julia> n_maximal_cones(F)
 105
 ```
 """
-function bergman_fan(M::Matroid; fan_structure::Symbol = :coarse, convention::Union{typeof(min),typeof(max)} = min)
-    @req convention in [min, max] "convention '$(convention)' is not supported"
+function bergman_fan(M::Matroid, convention::Union{typeof(min),typeof(max)} = min; fan_structure::Symbol = :coarse)
     @req fan_structure in [:fine, :cyclic, :coarse] "fan structure '$(fan_structure)' is not supported"
     
     if rank(M) == 0

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1230,7 +1230,7 @@ function bergman_fan(M::Matroid, convention::Union{typeof(min),typeof(max)} = mi
     end
     
     if fan_structure == :fine
-        pmTC = Polymake.tropical.matroid_fan_from_flats{convention}(M.pm_matroid)
+        pmTC = Polymake.tropical.matroid_fan_from_flats{convention}(pm_object(M))
         pmTC.FAN_DIM  # this forces polymake to compute the necessary properties
         
         i = findfirst(==([1; zeros(length(M))]), eachrow(pmTC.VERTICES))  # index of polymake's extra ray

--- a/src/Combinatorics/Matroids/properties.jl
+++ b/src/Combinatorics/Matroids/properties.jl
@@ -1231,7 +1231,6 @@ function bergman_fan(M::Matroid, convention::Union{typeof(min),typeof(max)} = mi
     
     if fan_structure == :fine
         pmTC = Polymake.tropical.matroid_fan_from_flats{convention}(pm_object(M))
-        pmTC.FAN_DIM  # this forces polymake to compute the necessary properties
         
         i = findfirst(==([1; zeros(length(M))]), eachrow(pmTC.VERTICES))  # index of polymake's extra ray
         IM = pmTC.MAXIMAL_POLYTOPES[:, [1:i-1; i+1:end]]  

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -334,6 +334,7 @@ export basis_of_global_sections_via_homogeneous_component
 export basis_of_global_sections_via_rational_functions
 export basis_of_h4
 export bell
+export bergman_fan
 export betti
 export betti_number
 export betti_numbers

--- a/test/Combinatorics/Matroids/Matroids.jl
+++ b/test/Combinatorics/Matroids/Matroids.jl
@@ -459,4 +459,27 @@
     @test !is_tutte_realizable(M)
     @test is_tutte_realizable(U)
   end
+    
+    @testset "bergman_fan" begin
+        M = cycle_matroid(complete_graph(4))
+        BF1 = bergman_fan(M, fan_structure = :fine)
+        BF2 = bergman_fan(M, fan_structure = :cyclic)
+        BF3 = bergman_fan(M, fan_structure = :coarse)
+    
+        @test n_maximal_cones(BF3) == 15
+        @test all(c in maximal_cones(BF2) for c in maximal_cones(BF3)) #BF2 and BF3 coincide
+        @test all(any(is_subset.(Ref(c), maximal_cones(BF3))) for c in maximal_cones(BF1)) #BF1 refines BF3
+            
+        M = direct_sum(uniform_matroid(2,3), uniform_matroid(2,3))
+        BF1 = bergman_fan(M, fan_structure = :fine)
+        BF2 = bergman_fan(M, fan_structure = :coarse)
+        BF3 = bergman_fan(M, fan_structure = :fine, convention = :max)   
+        BF4 = bergman_fan(M, fan_structure = :coarse, convention = :max)
+            
+        @test lineality_dim(BF1) == 1
+        @test lineality_dim(BF2) == 2
+        @test maximal_cones(BF1) == [cone(-rays_modulo_lineality(c)[1], lineality_space(c)) for c in maximal_cones(BF3)]
+        @test maximal_cones(BF2) == [cone(-rays_modulo_lineality(c)[1], lineality_space(c)) for c in maximal_cones(BF4)]
+    end
+>>>>>>> 8138c64f66 (wrote bergman_fan(), added tests for it, exported it)
 end

--- a/test/Combinatorics/Matroids/Matroids.jl
+++ b/test/Combinatorics/Matroids/Matroids.jl
@@ -473,8 +473,8 @@
         M = direct_sum(uniform_matroid(2, 4), uniform_matroid(2, 4))
         BF1 = bergman_fan(M, fan_structure = :fine)
         BF2 = bergman_fan(M)
-        BF3 = bergman_fan(M, fan_structure = :fine, convention = max)   
-        BF4 = bergman_fan(M, convention = max)
+        BF3 = bergman_fan(M, max, fan_structure = :fine)   
+        BF4 = bergman_fan(M, max)
             
         @test f_vector(BF1) == [0, 34, 120, 96]
         @test f_vector(BF2) == [0, 0, 8, 16]

--- a/test/Combinatorics/Matroids/Matroids.jl
+++ b/test/Combinatorics/Matroids/Matroids.jl
@@ -461,29 +461,28 @@
   end
     
     @testset "bergman_fan" begin
-        M = cycle_matroid(complete_graph(4))
+        M = cycle_matroid(complete_graph(5))
         BF1 = bergman_fan(M, fan_structure = :fine)
         BF2 = bergman_fan(M, fan_structure = :cyclic)
         BF3 = bergman_fan(M, fan_structure = :coarse)
     
-        @test n_maximal_cones(BF3) == 15
+        @test n_maximal_cones(BF3) == 105
         @test all(c in maximal_cones(BF2) for c in maximal_cones(BF3))  # BF2 and BF3 coincide
         @test all(any(is_subset.(Ref(c), maximal_cones(BF3))) for c in maximal_cones(BF1))  # BF1 refines BF3
             
-        M = direct_sum(uniform_matroid(2,3), uniform_matroid(2,3))
+        M = direct_sum(uniform_matroid(2, 4), uniform_matroid(2, 4))
         BF1 = bergman_fan(M, fan_structure = :fine)
-        BF2 = bergman_fan(M, fan_structure = :coarse)
+        BF2 = bergman_fan(M)
         BF3 = bergman_fan(M, fan_structure = :fine, convention = max)   
-        BF4 = bergman_fan(M, fan_structure = :coarse, convention = max)
+        BF4 = bergman_fan(M, convention = max)
             
-        @test lineality_dim(BF1) == 1
-        @test lineality_dim(BF2) == 2
+        @test f_vector(BF1) == [0, 34, 120, 96]
+        @test f_vector(BF2) == [0, 0, 8, 16]
         @test maximal_cones(BF1) == [cone(-rays_modulo_lineality(c)[1], lineality_space(c)) for c in maximal_cones(BF3)]
         @test maximal_cones(BF2) == [cone(-rays_modulo_lineality(c)[1], lineality_space(c)) for c in maximal_cones(BF4)]
         
         M = matroid_from_bases([[]], 4)
-        BF = bergman_fan(M, fan_structure = :coarse)
-        @test (dim(BF), n_maximal_cones(BF)) == (0, 1) 
+        @test bergman_fan(M) == polyhedral_fan(cone([0 0 0 0]))
     end
 >>>>>>> 8138c64f66 (wrote bergman_fan(), added tests for it, exported it)
 end

--- a/test/Combinatorics/Matroids/Matroids.jl
+++ b/test/Combinatorics/Matroids/Matroids.jl
@@ -480,6 +480,10 @@
         @test lineality_dim(BF2) == 2
         @test maximal_cones(BF1) == [cone(-rays_modulo_lineality(c)[1], lineality_space(c)) for c in maximal_cones(BF3)]
         @test maximal_cones(BF2) == [cone(-rays_modulo_lineality(c)[1], lineality_space(c)) for c in maximal_cones(BF4)]
+        
+        M = matroid_from_bases([[]], 4)
+        BF = bergman_fan(M, fan_structure = :coarse)
+        @test (dim(BF), n_maximal_cones(BF)) == (0, 1) 
     end
 >>>>>>> 8138c64f66 (wrote bergman_fan(), added tests for it, exported it)
 end

--- a/test/Combinatorics/Matroids/Matroids.jl
+++ b/test/Combinatorics/Matroids/Matroids.jl
@@ -461,12 +461,12 @@
   end
     
     @testset "bergman_fan" begin
-        M = cycle_matroid(complete_graph(5))
+        M = cycle_matroid(complete_graph(4))
         BF1 = bergman_fan(M, fan_structure = :fine)
         BF2 = bergman_fan(M, fan_structure = :cyclic)
         BF3 = bergman_fan(M, fan_structure = :coarse)
     
-        @test n_maximal_cones(BF3) == 105
+        @test n_maximal_cones(BF3) == 15
         @test all(c in maximal_cones(BF2) for c in maximal_cones(BF3))  # BF2 and BF3 coincide
         @test all(any(is_subset.(Ref(c), maximal_cones(BF3))) for c in maximal_cones(BF1))  # BF1 refines BF3
             
@@ -482,7 +482,7 @@
         @test maximal_cones(BF2) == [cone(-rays_modulo_lineality(c)[1], lineality_space(c)) for c in maximal_cones(BF4)]
         
         M = matroid_from_bases([[]], 4)
-        @test bergman_fan(M) == polyhedral_fan(cone([0 0 0 0]))
+        @test f_vector(bergman_fan(M)) == ZZRingElem[]
     end
 >>>>>>> 8138c64f66 (wrote bergman_fan(), added tests for it, exported it)
 end

--- a/test/Combinatorics/Matroids/Matroids.jl
+++ b/test/Combinatorics/Matroids/Matroids.jl
@@ -473,8 +473,8 @@
         M = direct_sum(uniform_matroid(2,3), uniform_matroid(2,3))
         BF1 = bergman_fan(M, fan_structure = :fine)
         BF2 = bergman_fan(M, fan_structure = :coarse)
-        BF3 = bergman_fan(M, fan_structure = :fine, convention = :max)   
-        BF4 = bergman_fan(M, fan_structure = :coarse, convention = :max)
+        BF3 = bergman_fan(M, fan_structure = :fine, convention = max)   
+        BF4 = bergman_fan(M, fan_structure = :coarse, convention = max)
             
         @test lineality_dim(BF1) == 1
         @test lineality_dim(BF2) == 2

--- a/test/Combinatorics/Matroids/Matroids.jl
+++ b/test/Combinatorics/Matroids/Matroids.jl
@@ -476,13 +476,12 @@
         BF3 = bergman_fan(M, max, fan_structure = :fine)   
         BF4 = bergman_fan(M, max)
             
-        @test f_vector(BF1) == [0, 34, 120, 96]
-        @test f_vector(BF2) == [0, 0, 8, 16]
+        @test f_vector(BF1) == [1, 34, 120, 96]
+        @test f_vector(BF2) == [0, 1, 8, 16]
         @test maximal_cones(BF1) == [cone(-rays_modulo_lineality(c)[1], lineality_space(c)) for c in maximal_cones(BF3)]
         @test maximal_cones(BF2) == [cone(-rays_modulo_lineality(c)[1], lineality_space(c)) for c in maximal_cones(BF4)]
         
         M = matroid_from_bases([[]], 4)
         @test f_vector(bergman_fan(M)) == ZZRingElem[]
     end
->>>>>>> 8138c64f66 (wrote bergman_fan(), added tests for it, exported it)
 end

--- a/test/Combinatorics/Matroids/Matroids.jl
+++ b/test/Combinatorics/Matroids/Matroids.jl
@@ -467,8 +467,8 @@
         BF3 = bergman_fan(M, fan_structure = :coarse)
     
         @test n_maximal_cones(BF3) == 15
-        @test all(c in maximal_cones(BF2) for c in maximal_cones(BF3)) #BF2 and BF3 coincide
-        @test all(any(is_subset.(Ref(c), maximal_cones(BF3))) for c in maximal_cones(BF1)) #BF1 refines BF3
+        @test all(c in maximal_cones(BF2) for c in maximal_cones(BF3))  # BF2 and BF3 coincide
+        @test all(any(is_subset.(Ref(c), maximal_cones(BF3))) for c in maximal_cones(BF1))  # BF1 refines BF3
             
         M = direct_sum(uniform_matroid(2,3), uniform_matroid(2,3))
         BF1 = bergman_fan(M, fan_structure = :fine)


### PR DESCRIPTION
This adds (and exports) the function `bergman_fan(M::Matroid; fan_structure::Symbol = :fine, convention::Symbol = :min)`, including docs and tests.