### PR TITLE
fix project and remotes to allow building docs from a release version

### DIFF
--- a/docs/make_work.jl
+++ b/docs/make_work.jl
@@ -170,6 +170,7 @@ function doit(
   nemorev = get_rev(Base.PkgId(Oscar.Nemo).uuid)
   heckerev = get_rev(Base.PkgId(Oscar.Hecke).uuid)
   singularrev = get_rev(Base.PkgId(Oscar.Singular).uuid)
+  oscarrev = get_rev(Base.PkgId(Oscar).uuid)
 
   cd(joinpath(oscardir, "docs")) do
     DocMeta.setdocmeta!(Oscar, :DocTestSetup, Oscar.doctestsetup(); recursive=true, warn=false)
@@ -203,6 +204,7 @@ function doit(
         Base.pkgdir(Oscar.Nemo) => (Remotes.GitHub("Nemocas", "Nemo.jl"), nemorev),
         Base.pkgdir(Oscar.Hecke) => (Remotes.GitHub("thofma", "Hecke.jl"), heckerev),
         Base.pkgdir(Oscar.Singular) => (Remotes.GitHub("oscar-system", "Singular.jl"), singularrev),
+        Base.pkgdir(Oscar) => (Remotes.GitHub("oscar-system", "Oscar.jl"), oscarrev),
       ),
       plugins=[bib],
     )

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -46,7 +46,13 @@ end
 function doc_init(;path=mktempdir())
   global docsproject = path
   if !isfile(joinpath(docsproject,"Project.toml"))
-    cp(joinpath(oscardir, "docs", "Project.toml"), joinpath(docsproject,"Project.toml"))
+    target = joinpath(docsproject,"Project.toml")
+    cp(joinpath(oscardir, "docs", "Project.toml"), target)
+    # we need to make sure this tempfile is writable even
+    # when copied from a readonly pkg directory
+    if uperm(target) & 0o2 == 0
+      chmod(target, filemode(target) | 0o200)
+    end
   end
   Pkg.activate(docsproject) do
     # we dev all "our" packages with the paths from where they are currently


### PR DESCRIPTION
project file is readonly otherwise and documenter errors without the proper remote