### PR TITLE
Bump DocumenterCitations.jl to 1.4

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,7 +6,7 @@ Oscar = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
 
 [compat]
 Documenter = "1.16.0"
-DocumenterCitations = "~1.3.4"
+DocumenterCitations = "~1.4"
 JSON = "1.0.1"
 
 [sources]

--- a/docs/citation_style.jl
+++ b/docs/citation_style.jl
@@ -9,30 +9,29 @@ import DocumenterCitations
 
 const oscar_style = :oscar
 
+# This is the only difference to the :alpha style: the label is the citation key instead of a number.
+function DocumenterCitations.citation_label(style::Val{oscar_style}, entry, citations; _...)
+  return entry.id
+end
+
+# The type of html tag to use for the bibliography
+DocumenterCitations.bib_html_list_style(::Val{oscar_style}) = :dl
+
+# The order of entries in the bibliography
+DocumenterCitations.bib_sorting(::Val{oscar_style}) = :key  # sort by citation key
+
+# The label in the bibliography
+function DocumenterCitations.format_bibliography_label(::Val{oscar_style}, entry, citations)
+  label = DocumenterCitations.citation_label(Val(oscar_style), entry, citations)
+  return "[$label]"
+end
+
 # The long reference string in the bibliography
 function DocumenterCitations.format_bibliography_reference(style::Val{oscar_style}, entry)
   return DocumenterCitations.format_labeled_bibliography_reference(style, entry; article_link_doi_in_title=true)
 end
 
-# The label in the bibliography
-function DocumenterCitations.format_bibliography_label(::Val{oscar_style}, entry, citations)
-  return "[$(entry.id)]"
-end
-
-function DocumenterCitations.citation_label(style::Val{oscar_style}, entry, citations; _...)
-  return entry.id
-end
-
-# The order of entries in the bibliography
-DocumenterCitations.bib_sorting(::Val{oscar_style}) = :key  # sort by citation key
-
-# The type of html tag to use for the bibliography
-DocumenterCitations.bib_html_list_style(::Val{oscar_style}) = :dl
-
-function DocumenterCitations.format_citation(
-  style::Val{oscar_style}, cit, entries, citations
-)
-  # The only difference compared to `:alpha` is the citation label, which is
-  # picked up automatically by redefining `citation_label` above.
+# The in-text citation format
+function DocumenterCitations.format_citation(style::Val{oscar_style}, cit, entries, citations)
   return DocumenterCitations.format_labeled_citation(style, cit, entries, citations)
 end


### PR DESCRIPTION
The other changes are mostly re-ordering of methods to match the order the to-be-implemented functions are listed at https://juliadocs.org/DocumenterCitations.jl/v1.4/internals/#customization.
Furthermore, I simplified some implementations using a pre-defined helper.

I would prefer to keep the `~` specifier for the version as everything about custom styles is still marked as "internal" in DocumenterCitations.jl (and thus might break in a future minor release, as it did at some point in the past)