### PR TITLE
Include `conjugate_group` docstring in markdown page

### DIFF
--- a/docs/src/Groups/subgroups.md
+++ b/docs/src/Groups/subgroups.md
@@ -83,6 +83,7 @@ subgroups(G::GAPGroup)
 ## Conjugation action of elements and subgroups
 
 ```@docs
+conjugate_group(G::GAPGroup, x::GAPGroupElem)
 is_conjugate(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)
 is_conjugate(G::GAPGroup, H::GAPGroup, K::GAPGroup)
 is_conjugate_with_data(G::GAPGroup, x::GAPGroupElem, y::GAPGroupElem)

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -1145,7 +1145,7 @@ julia> length(collect(low_index_subgroups(G, 6)))
 low_index_subgroups(G::T, n::Int) where T <: Union{GAPGroup, FinGenAbGroup} = Iterators.flatten(low_index_subgroup_classes(G, n))
 
 """
-    conjugate_group(G::T, x::GAPGroupElem) where T <: GAPGroup
+    conjugate_group(G::GAPGroup, x::GAPGroupElem)
 
 Return the group `G^x` that consists of the elements `g^x`, for `g` in `G`.
 
@@ -1161,7 +1161,7 @@ Permutation group of degree 4 and order 3
 
 ```
 """
-function conjugate_group(G::T, x::GAPGroupElem) where T <: GAPGroup
+function conjugate_group(G::GAPGroup, x::GAPGroupElem)
   P = Oscar._common_parent_group(G, parent(x))
   return _oscar_subgroup(GAPWrap.ConjugateSubgroup(GapObj(G), GapObj(x)), P)
 end


### PR DESCRIPTION
I was looking for this and this seems to be the correct place.