### PR TITLE
include `in` docstring into markdown page

### DIFF
--- a/docs/src/Groups/subgroups.md
+++ b/docs/src/Groups/subgroups.md
@@ -10,6 +10,7 @@ The following functions are available in OSCAR for subgroup properties:
 
 ```@docs
 sub(G::GAPGroup, gens::AbstractVector{<:GAPGroupElem}; check::Bool = true)
+in(g::GAPGroupElem, G::GAPGroup)
 is_subset(H::GAPGroup, G::GAPGroup)
 is_subgroup(H::GAPGroup, G::GAPGroup)
 embedding(H::GAPGroup, G::GAPGroup)

--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -592,7 +592,7 @@ end
 Base.length(x::GAPGroup)::Int = order(Int, x)
 
 """
-    Base.in(g::GAPGroupElem, G::GAPGroup)
+    in(g::GAPGroupElem, G::GAPGroup)
 
 Return whether `g` is an element of `G`.
 The parent of `g` need not be equal to `G`.


### PR DESCRIPTION
I was looking for this and couldn't find it. There might be a good place to include it.