### PR TITLE
Intersection Theory: add to PR #5656: use fglm for pushward (flag bundles)

### DIFF
--- a/experimental/IntersectionTheory/src/Main.jl
+++ b/experimental/IntersectionTheory/src/Main.jl
@@ -2933,7 +2933,9 @@ function flag_bundle(F::AbstractBundle, dims::Vector{Int}; symbol::String = "c")
   @assert all(>(0), ranks) && dims[end] <= n
   d = sum(ranks[i] * sum(dims[end]-dims[i]) for i in 1:l-1)
 
-  # construct the ring
+  # construct the (numerical) Chow-ring (Grothendieck, Seminaire Chevalley, tome 3 (1985))
+
+  # 1. implement the generators
 
   R = X.ring
   if R isa MPolyQuoRing
@@ -2945,21 +2947,20 @@ function flag_bundle(F::AbstractBundle, dims::Vector{Int}; symbol::String = "c")
   w = reduce(vcat, [1:r for r in ranks])
   append!(w, gradings(R))
   R1, gens_for_rels_R1, imgs_in_R1 = graded_polynomial_ring(X.base, syms, symbols(PR); weights = w)
-  pback = hom(PR, R1, imgs_in_R1)
-  pfwd = hom(R1, R, vcat(repeat([R()], n), gens(R)))
+  PRtoR1 = hom(PR, R1, imgs_in_R1)
 
-  # compute the relations
+  # 2. implement the relations
 
   c = [1+sum(gens_for_rels_R1[dims[i]+1:dims[i+1]]) for i in 1:l-1]
   pushfirst!(c, 1+sum(gens_for_rels_R1[1:dims[1]]))
   Rx, x = R1[:x]
-  fi = pback(total_chern_class(F).f)[0:n]
+  fi = PRtoR1(total_chern_class(F).f)[0:n]
   f = sum(fi[i+1].f * x^(n-i) for i in 0:n)
   gi = prod(c)[0:n]
   g = sum(gi[i+1].f * x^(n-i) for i in 0:n)
   rels = [R1(coeff(mod(f, g), i)) for i in 0:n-1]
   if R isa MPolyQuoRing
-    rels = vcat(pback.(gens(R.I)), rels)
+    rels = vcat(PRtoR1.(gens(R.I)), rels)
   end
   AFl = quo(R1, ideal(rels))[1]
   c = AFl.(c)
@@ -2968,17 +2969,19 @@ function flag_bundle(F::AbstractBundle, dims::Vector{Int}; symbol::String = "c")
 
   Fl = AbstractVariety(X.dim + d, AFl)
   Fl.bundles = [AbstractBundle(Fl, r, ci) for (r,ci) in zip(ranks, c)]
-  section = prod(top_chern_class(E)^sum(dims[i]) for (i, E) in enumerate(Fl.bundles[2:end]))### TODO skip when fglm is used
-  if isdefined(X, :point)
-    Fl.point = pback(X.point.f) * section ### TODO better when fglm is used (take section from _find_sect as second output
-  end
+
+  ### old approach to push forward
+  ### R1toR = hom(R1, R, vcat(repeat([R()], n), gens(R)))
+  ### section = prod(top_chern_class(E)^sum(dims[i]) for (i, E) in enumerate(Fl.bundles[2:end]))
+  ###pₓ = x -> (@warn("possibly wrong ans"); X(R1toR(div(simplify(x).f, simplify(section).f))))
+
+  # constructing the projection map
+
+  # 1. pullback
+
   pˣ = Fl.(imgs_in_R1)
 
-  ###pₓ = x -> (@warn("possibly wrong ans"); X(pfwd(div(simplify(x).f, simplify(section).f))))
-
-  ##################################
-  ##alternative approach
-  ##TODO: To be discussed. Use fglm in _find_sect as soon as fglm is fixed.
+  # 2. pushforward ([GSS22](@cite) Thm 2.15, Cor 5.3)
 
   ME = _matrix_of_exponents(ranks)
   nl = size(ME)[1]
@@ -2989,20 +2992,30 @@ function flag_bundle(F::AbstractBundle, dims::Vector{Int}; symbol::String = "c")
   gs = [RcstoR1(gs[i]) for i = 1:length(gs)]
   ds = [degree(Int, gs[i]) for i = 1:1:nl]
   dm = argmax(ds)
-  ### TODO find an return section
   fm = hom(R, AFl, pˣ)
   pₓ = x -> X(_find_sect(fm, gs)(simplify(x).f)[dm])
-  ##################################
-
   pₓ = MapFromFunc(Fl.ring, X.ring, pₓ)
+
   p = AbstractVarietyMap(Fl, X, pˣ, pₓ)
+  Fl.struct_map = p
+
+  ### old approach to point class
+  ### if isdefined(X, :point)
+  ###  Fl.point = PRtoR1(X.point.f) * section
+  ###end
+
+  if isdefined(X, :point)
+    Fl.point = PRtoR1(X.point.f) * gs[dm]
+  end
+
   p.O1 = simplify(sum((i-1)*chern_class(Fl.bundles[i], 1) for i in 1:l))
   Fl.O1 = p.O1
+
   p.T = sum(dual(Fl.bundles[i]) * sum([Fl.bundles[j] for j in i+1:l]) for i in 1:l-1)
   if isdefined(X, :T)
     Fl.T = pullback(p, X.T) + p.T
   end
-  Fl.struct_map = p
+
   set_attribute!(Fl, :description => "Relative flag abstract_variety Flag$(tuple(dims...)) for $F")
   set_attribute!(Fl, :section => section)
 
@@ -3020,7 +3033,7 @@ end
 #helper functions above
 ###########################################################
 
-function _matrix_of_exponents(ni::Vector{Int}) # [GSS22](@cite) Thm 2.15
+function _matrix_of_exponents(ni::Vector{Int})
  n = sum(ni)
  r = length(ni)
  A = zero_matrix(ZZ,n, n)
@@ -3080,9 +3093,8 @@ function  _find_sect(F::Oscar.AffAlgHom, gs::Vector) # see function present_fini
   if isdefined(A, :I) for g in gens(A.I) push!(Rels, ARtoR(g)) end end
   if isdefined(B, :I) for g in gens(B.I) push!(Rels, BRtoR(g)) end end
   J = ideal(R, Rels) # the ideal of the graph of F
-  V = groebner_basis(J) ###TODO replace by fglm below as soon as fglm is fixed
-  ###W = vcat(weights(Int, BR), weights(Int, AR)) ####
-  ###V = fglm(J, start_ordering = wdegrevlex(R, W), destination_ordering = default_ordering(R))
+  W = vcat(weights(Int, BR), weights(Int, AR))
+  V = fglm(J, start_ordering = wdegrevlex(R, W), destination_ordering = default_ordering(R))
 
   sect = x -> (y = reduce(BRtoR(x), gens(V), complete_reduction=true);
 	      ans = elem_type(AR)[];


### PR DESCRIPTION
@pbelmans This is an update of PR #5656 which implemented another way of computing pushforwards from flag bundles. It would be good to find relevant examples for testing this implementation.