### PR TITLE
Serialization upgrade fixes from #5812

### DIFF
--- a/src/Serialization/Upgrades/1.6.0+1.jl
+++ b/src/Serialization/Upgrades/1.6.0+1.jl
@@ -1,5 +1,5 @@
 push!(upgrade_scripts_set, UpgradeScript(
-  v"1.6.0-1",
+  v"1.6.0+1",
   function upgrade_1_6_0_1(s::UpgradeState, dict::AbstractDict{Symbol, Any})
     # recurse upgrade on containers
     upgrade_recursive(upgrade_1_6_0_1, s, dict)

--- a/src/Serialization/Upgrades/1.6.0-1.jl
+++ b/src/Serialization/Upgrades/1.6.0-1.jl
@@ -4,8 +4,14 @@ push!(upgrade_scripts_set, UpgradeScript(
     # recurse upgrade on containers
     upgrade_containers(upgrade_1_6_0_1, s, dict)
 
+    if dict[:_type] isa AbstractDict && haskey(dict[:_type], :name)
+      type_name = dict[:_type][:name]
+    else
+      type_name = dict[:_type]
+    end
+
     # Upgrades
-    if dict[:_type] isa AbstractDict && get(dict[:_type], :name, nothing) == "RationalFunctionField"
+    if type_name == "RationalFunctionField"
       if dict[:data][:symbols] isa String
         dict[:data][:symbol] = dict[:data][:symbols]
         delete!(dict[:data], :symbols)

--- a/src/Serialization/Upgrades/1.6.0-1.jl
+++ b/src/Serialization/Upgrades/1.6.0-1.jl
@@ -2,7 +2,7 @@ push!(upgrade_scripts_set, UpgradeScript(
   v"1.6.0-1",
   function upgrade_1_6_0_1(s::UpgradeState, dict::AbstractDict{Symbol, Any})
     # recurse upgrade on containers
-    upgrade_containers(upgrade_1_6_0_1, s, dict)
+    upgrade_recursive(upgrade_1_6_0_1, s, dict)
 
     if dict[:_type] isa AbstractDict && haskey(dict[:_type], :name)
       type_name = dict[:_type][:name]

--- a/src/Serialization/Upgrades/1.6.0.jl
+++ b/src/Serialization/Upgrades/1.6.0.jl
@@ -2,7 +2,7 @@ push!(upgrade_scripts_set, UpgradeScript(
   v"1.6.0",
   function upgrade_1_6_0(s::UpgradeState, dict::AbstractDict{Symbol, Any})
     # recurse upgrade on containers
-    upgrade_containers(upgrade_1_6_0, s, dict)
+    upgrade_recursive(upgrade_1_6_0, s, dict)
 
     # Upgrades 
     if dict[:_type] == "PhylogeneticTree"

--- a/src/Serialization/Upgrades/main.jl
+++ b/src/Serialization/Upgrades/main.jl
@@ -235,11 +235,12 @@ function upgrade_recursive(upgrade::Function, s::UpgradeState, dict::AbstractDic
         dict[:_type][:params][:value_params] = first_pair[2][:_type]
       end
     else
-      for entry in dict[:data]
-        upgraded_entry = upgrade(s, Dict{Symbol, Any}(:_type => dict[:_type][:params][entry.first],
-                                         :data => entry.second))
-        dict[:data][entry.first] = upgraded_entry[:data]
-        dict[:_type][:params][entry.first] = upgraded_entry[:_type]
+      for k in keys(dict[:_type][:params])
+        k === :key_params && continue
+        upgraded_entry = upgrade(s, Dict{Symbol, Any}(:_type => dict[:_type][:params][k],
+                                         :data => dict[:data][k]))
+        dict[:data][k] = upgraded_entry[:data]
+        dict[:_type][:params][k] = upgraded_entry[:_type]
       end
     end
   elseif type_name in ("Polyhedron", "Cone", "PolyhedralComplex", "PolyhedralFan", "SubdivisionOfPoints")

--- a/src/Serialization/Upgrades/main.jl
+++ b/src/Serialization/Upgrades/main.jl
@@ -303,7 +303,7 @@ include("1.2.0.jl")
 include("1.3.0.jl")
 include("1.4.0.jl")
 include("1.6.0.jl")
-include("1.6.0-1.jl")
+include("1.6.0+1.jl")
 
 const upgrade_scripts = collect(upgrade_scripts_set)
 sort!(upgrade_scripts; by=version)


### PR DESCRIPTION
This PR contains all of the fixes to upgrade scripts that I made in #5812.

Furthermore, I renamed `1.6.0-1.jl` to `1.6.0+1.jl`. This is to keep the intended ordering of upgrade scripts, as (unfortunately) `v"1.6.0-1" < v"1.6.0" < v"1.6.0+1"`. Aka later additions should get a build number increase and not a prerelease version increase to have the upgrade scripts applied in the expected order.