### PR TITLE
Fix deserialization of `SMat` with trailing zero cols

### DIFF
--- a/src/Serialization/Rings.jl
+++ b/src/Serialization/Rings.jl
@@ -380,6 +380,8 @@ function load_object(s::DeserializerState, ::Type{<:SMat}, parent::SMatSpace{T})
     end
     push!(M, sparse_row(base, row_entries))
   end
+  M.c = parent.cols
+  @assert nrows(M) == parent.rows
   return M
 end
 

--- a/test/Serialization/Matrices.jl
+++ b/test/Serialization/Matrices.jl
@@ -14,6 +14,7 @@ cases = [
   (Fin, [d d^3; d^2 0]),
   (Frac, [1 // x x^2; 3 0]),
   (A, [(f^3 + g^2) f^2; g (a*f + 1)]),
+  (ZZ, [0 0 0; 0 0 0]), # issue #5849
 ]
 
 @testset "Matrices" begin


### PR DESCRIPTION
This fixes https://github.com/oscar-system/Oscar.jl/issues/5849.

However, what I add here seems more like a hack. I would prefer if the SMatSpace had some proper interface to do these things (or even to do them automatically), but this is an immediate fix to the issue that can be cleaned up eventually.