### PR TITLE
Bump julia-actions/cache from 2 to 3; drop workarounds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,7 +88,7 @@ jobs:
         uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
         id: julia-cache
         if: runner.environment != 'self-hosted'
         with:
@@ -127,14 +127,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Save Julia depot cache on cancel or failure
-        id: julia-cache-save
-        if: (cancelled() || failure()) && runner.environment != 'self-hosted'
-        uses: actions/cache/save@v5
-        with: 
-          path: |
-            ${{ steps.julia-cache.outputs.cache-paths }}
-          key: ${{ steps.julia-cache.outputs.cache-key }}
 
   book-tests:
     runs-on: 'ubuntu-latest'
@@ -157,7 +149,7 @@ jobs:
         uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
         id: julia-cache
         if: runner.environment != 'self-hosted'
         with:
@@ -183,14 +175,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Save Julia depot cache on cancel or failure
-        id: julia-cache-save
-        if: (cancelled() || failure()) && runner.environment != 'self-hosted'
-        uses: actions/cache/save@v5
-        with: 
-          path: |
-            ${{ steps.julia-cache.outputs.cache-paths }}
-          key: ${{ steps.julia-cache.outputs.cache-key }}
 
   extra-long-test:
     # Extra long tests
@@ -249,7 +233,7 @@ jobs:
         uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
         id: julia-cache
         if: runner.environment != 'self-hosted'
         with:
@@ -290,14 +274,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Save Julia depot cache on cancel or failure
-        id: julia-cache-save
-        if: (cancelled() || failure()) && runner.environment != 'self-hosted'
-        uses: actions/cache/save@v5
-        with: 
-          path: |
-            ${{ steps.julia-cache.outputs.cache-paths }}
-          key: ${{ steps.julia-cache.outputs.cache-key }}
 
   test-mongodb:
     runs-on: ${{ matrix.os }}
@@ -335,7 +311,7 @@ jobs:
         uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
         with:
           cache-name: julia-cache;workflow=${{ github.workflow }};julia=${{ matrix.julia-version }};arch=${{ runner.arch }}
           include-matrix: false

--- a/.github/workflows/Docstrings.yml
+++ b/.github/workflows/Docstrings.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: julia-actions/setup-julia@v2
-    - uses: julia-actions/cache@v2
+    - uses: julia-actions/cache@v3
       id: julia-cache
     - name: Build package
       uses: julia-actions/julia-buildpkg@v1
@@ -39,11 +39,3 @@ jobs:
     - name: 'Check for markdown files with non-standard `@meta` blocks'
       run: |
         julia --color=yes -e 'include("etc/check_meta.jl")'
-    - name: Save Julia depot cache on cancel or failure
-      id: julia-cache-save
-      if: cancelled() || failure()
-      uses: actions/cache/save@v5
-      with: 
-        path: |
-          ${{ steps.julia-cache.outputs.cache-paths }}
-        key: ${{ steps.julia-cache.outputs.cache-key }}

--- a/.github/workflows/Docu.yml
+++ b/.github/workflows/Docu.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.10'
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Build package
         uses: julia-actions/julia-buildpkg@v1
       - name: Install dependencies

--- a/.github/workflows/JuliaFormatterCI.yml
+++ b/.github/workflows/JuliaFormatterCI.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: julia-actions/setup-julia@v2
-    - uses: julia-actions/cache@v2
+    - uses: julia-actions/cache@v3
     - name: 'Check format with JuliaFormatter'
       run: |
         julia etc/format_code.jl

--- a/.github/workflows/NoExperimental.yml
+++ b/.github/workflows/NoExperimental.yml
@@ -46,7 +46,7 @@ jobs:
         uses: julia-actions/setup-julia@v2
         with:
           version: '1.10'
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
         id: julia-cache
         with:
           cache-name: julia-cache;workflow=${{ github.workflow }};julia=1.10;arch=${{ runner.arch }}
@@ -59,15 +59,7 @@ jobs:
       - name: "Build package"
         uses: julia-actions/julia-buildpkg@v1
       - name: "Run tests"
-        uses: julia-actions/julia-runtest@latest
-      - name: Save Julia depot cache on cancel or failure
-        id: julia-cache-save
-        if: cancelled() || failure()
-        uses: actions/cache/save@v5
-        with: 
-          path: |
-            ${{ steps.julia-cache.outputs.cache-paths }}
-          key: ${{ steps.julia-cache.outputs.cache-key }}
+        uses: julia-actions/julia-runtest@v1
 
   doctest:
     runs-on: ubuntu-latest
@@ -79,7 +71,7 @@ jobs:
         uses: julia-actions/setup-julia@v2
         with:
           version: '1.10'
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
         id: julia-cache
         with:
           cache-name: julia-cache;workflow=${{ github.workflow }};julia=1.10;arch=${{ runner.arch }}
@@ -103,11 +95,3 @@ jobs:
               using Oscar
               DocMeta.setdocmeta!(Oscar, :DocTestSetup, Oscar.doctestsetup(); recursive = true)
               doctest(Oscar; doctestfilters=Oscar.doctestfilters())'
-      - name: Save Julia depot cache on cancel or failure
-        id: julia-cache-save
-        if: cancelled() || failure()
-        uses: actions/cache/save@v5
-        with: 
-          path: |
-            ${{ steps.julia-cache.outputs.cache-paths }}
-          key: ${{ steps.julia-cache.outputs.cache-key }}


### PR DESCRIPTION
the save-on-failure is now part of the `julia-actions/cache` action