### PR TITLE
Adds missing getter `gen(L::MPolyLocRing, i::Int)`

### DIFF
--- a/src/Rings/mpoly-localizations.jl
+++ b/src/Rings/mpoly-localizations.jl
@@ -907,6 +907,7 @@ inverted_set(W::MPolyLocRing) = W.S
 
 ### additional getter functions
 gens(W::MPolyLocRing) = W.(gens(base_ring(W)))
+gen(W::MPolyLocRing, i::Int) = W(gen(base_ring(W), i))
 number_of_generators(W::MPolyLocRing) = number_of_generators(base_ring(W))
 
 ### required extension of the localization function


### PR DESCRIPTION
While coding I found that the getter for the i-th generator of a `MPolyLocRing` is missing:
```
julia> R, (x,y,z) = QQ[:x,:y,:z]
(Multivariate polynomial ring in 3 variables over QQ, QQMPolyRingElem[x, y, z])

julia> Q,_ = quo(R, ideal(R, [x]))
(Quotient of multivariate polynomial ring by ideal (x), Map: R -> Q)

julia> L,_ = localization(R, complement_of_prime_ideal(ideal(R, [y])))
(Localization of multivariate polynomial ring in 3 variables over QQ at complement of prime ideal (y), Hom: R -> localized ring)

julia> LQ,_ =  quo(L, ideal(L, [x]))
(Localization of quotient of multivariate polynomial ring at complement of prime ideal, hom: Localized ring -> Localized quotient of multivariate polynomial ring)

julia> gen(R, 3)
z

julia> gen(Q, 3)
z

julia> gen(L, 3)
ERROR: MethodError: no method matching gen(::MPolyLocRing{QQField, QQFieldElem, QQMPolyRing, QQMPolyRingElem, MPolyComplementOfPrimeIdeal{…}}, ::Int64)
The function `gen` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  gen(::zzModMPolyRing, ::Int64)
   @ Nemo ~/.julia/packages/Nemo/xSaoQ/src/flint/nmod_mpoly.jl:55
  gen(::fqPolyRepMPolyRing, ::Int64)
   @ Nemo ~/.julia/packages/Nemo/xSaoQ/src/flint/fq_nmod_mpoly.jl:43
  gen(::ZZMPolyRing, ::Int64)
   @ Nemo ~/.julia/packages/Nemo/xSaoQ/src/flint/fmpz_mpoly.jl:42
  ...

Stacktrace:
 [1] top-level scope
   @ REPL[17]:1
Some type information was truncated. Use `show(err)` to see complete types.

julia> gen(LQ, 3)
z
```

This PR adds it in order to be coherent with all other `MPolyAnyRing` types.