### PR TITLE
TropicalGeometry: homogenize_pre_tropicalization, fix GB computation

### DIFF
--- a/src/TropicalGeometry/homogenization.jl
+++ b/src/TropicalGeometry/homogenization.jl
@@ -7,14 +7,12 @@
 ################################################################################
 
 function homogenize_pre_tropicalization(I::MPolyIdeal)
-    # Compute reduced Groebner basis
-    G = groebner_basis(I,complete_reduction=true)
-
-    # Construct polynomial ring for homogenization
+    # Compute reduced Groebner basis w.r.t. degrevlex
     Kx = base_ring(I)
-    Kxhx,_ = polynomial_ring(coefficient_ring(Kx),vcat([:xh],symbols(Kx)); cached=false)
+    G = groebner_basis(I, ordering=degrevlex(Kx), complete_reduction=true)
 
     # Construct homogenization
+    Kxhx,_ = polynomial_ring(coefficient_ring(Kx),vcat([:xh],symbols(Kx)); cached=false)
     Gh = Vector{elem_type(Kxhx)}(undef,length(G))
     for (i,g) in enumerate(G)
         gh = MPolyBuildCtx(Kxhx)


### PR DESCRIPTION
The old GB was computed with the default ordering, which could have been a weighted ordering in a some graded rings.  The resulting homogenization is then not with respect to the total degree, causing subsequent Singular code to crash. Fixes #5860.