### PR TITLE
docs: fix building docs with julia 1.12

### DIFF
--- a/experimental/DrawingCurves/docs/doc.main
+++ b/experimental/DrawingCurves/docs/doc.main
@@ -3,4 +3,3 @@
       "introduction.md"
    ],
 ]
-


### PR DESCRIPTION
Julia 1.12 errors on this empty line when building the docs because the statement is complete in the previous line, see https://github.com/julialang/julia/issues/57345. We could switch to `Meta.parseall` but that is undocumented and not public.

cc: @lkastner 


<details>
<summary>Stacktrace</summary>

```
error while parsing experimental/DrawingCurves/docs/doc.main:
ERROR: ParseError("extra token after end of expression")
Stacktrace:
  [1] parse(str::String; filename::String, raise::Bool, depwarn::Bool)
    @ Base.Meta ./meta.jl:283
  [2] parse
    @ ./meta.jl:276 [inlined]
  [3] setup_experimental_package(Oscar::Module, package_name::String)
    @ Main.BuildDoc ~/software/polymake/julia/Oscar.jl/docs/make_work.jl:80
  [4] doit(Oscar::Module; warnonly::Bool, local_build::Bool, doctest::Bool)
    @ Main.BuildDoc ~/software/polymake/julia/Oscar.jl/docs/make_work.jl:114
  [5] #invokelatest_gr#232
    @ ./reflection.jl:1297 [inlined]
  [6] invokelatest_gr
    @ ./reflection.jl:1289 [inlined]
  [7] #50
    @ ~/software/polymake/julia/Oscar.jl/src/utils/docs.jl:304 [inlined]
  [8] activate(f::Oscar.var"#50#51"{Bool, Bool, Module}, new_project::String)
    @ Pkg.API ~/software/polymake/julia/julia/julia-1.12.5/share/julia/stdlib/v1.12/Pkg/src/API.jl:1489
  [9] (::Oscar.var"#48#49"{Bool, Bool, Module})()
    @ Oscar ~/software/polymake/julia/Oscar.jl/src/utils/docs.jl:303
 [10] with_unicode(f::Oscar.var"#48#49"{Bool, Bool, Module}, allowed::Bool)
    @ AbstractAlgebra.PrettyPrinting ~/.julia/packages/AbstractAlgebra/XwOtf/src/PrettyPrinting.jl:1858
 [11] #46
    @ ~/software/polymake/julia/Oscar.jl/src/utils/docs.jl:302 [inlined]
 [12] withenv(::Oscar.var"#46#47"{Bool, Bool, Module}, ::Pair{String, Int64}, ::Vararg{Pair{String, Int64}})
    @ Base ./env.jl:265
 [13] build_doc(; doctest::Bool, warnonly::Bool, open_browser::Bool, start_server::Bool)
    @ Oscar ~/software/polymake/julia/Oscar.jl/src/utils/docs.jl:301
 [14] top-level scope
    @ REPL[2]:1

```

</details>