### PR TITLE
Let `lies_in` for matrix groups error for non-matching base rings

### DIFF
--- a/src/Groups/matrices/MatGrp.jl
+++ b/src/Groups/matrices/MatGrp.jl
@@ -389,7 +389,8 @@ end
 # this saves the value of x.X
 # x_gap = x.X if this is already known, x_gap = nothing otherwise
 function lies_in(x::MatElem, G::MatGroup, x_gap)
-   if base_ring(x) != base_ring(G) || nrows(x) != degree(G) return false, x_gap end
+   AbstractAlgebra.check_base_ring(x, G)
+   if nrows(x) != degree(G) return false, x_gap end
    if isone(x) return true, x_gap end
    if isdefined(G,:gens)
       for g in gens(G)


### PR DESCRIPTION
So far, we have the following behaviour:
```
julia> K, _ = cyclotomic_field(4, :a);

julia> G = matrix_group(K[-1 0; 0 -1]);

julia> identity_matrix(QQ, 2) in G
false
```
That's maybe not wrong from a programming point of view, but seems mathematically odd. In my opinion, it is best to error here because presumably someone confused their base rings.
The same thing happens of course, if one creates two non-identical versions of the "same" field.
