### PR TITLE
Fix missing triple backticks in graphs documentation page

### DIFF
--- a/docs/src/Combinatorics/graphs.md
+++ b/docs/src/Combinatorics/graphs.md
@@ -81,6 +81,7 @@ complete_graph(n::Int64)
 complete_bipartite_graph(n::Int64, m::Int64)
 petersen_graph()
 clebsch_graph()
+```            
 
 ### Others
 ```@docs


### PR DESCRIPTION
Fixes missing closing triple backticks in documentation page, which broke code formatting.
<img width="1134" height="875" alt="image" src="https://github.com/user-attachments/assets/99af41ab-2e2b-47d8-8dff-8c1c63c0fb1b" />
