### PR TITLE
Fix incorrect Base.hash methods with default second argument

### DIFF
--- a/experimental/GModule/src/Cohomology.jl
+++ b/experimental/GModule/src/Cohomology.jl
@@ -68,7 +68,7 @@ import Base: ==, +, -, *
 -(a::MultGrpElem{T}, b::MultGrpElem{T}) where T = MultGrpElem{T}(a.data//b.data, parent(a))
 -(a::MultGrpElem{T}) where T = MultGrpElem{T}(inv(a.data), parent(a))
 ==(a::MultGrpElem{T}, b::MultGrpElem{T}) where T = a.data == b.data
-Base.hash(a::MultGrpElem, u::UInt = UInt(1235)) = hash(a.data. u)
+Base.hash(a::MultGrpElem, h::UInt) = hash(a.data, h)
 
 
 ##############################################################

--- a/src/AlgebraicGeometry/RationalPoint/ProjectiveRationalPoint.jl
+++ b/src/AlgebraicGeometry/RationalPoint/ProjectiveRationalPoint.jl
@@ -255,11 +255,11 @@ function normalize!(a::AbsProjectiveRationalPoint{ZZRingElem})
   return a
 end
 
-function Base.hash(a::AbsProjectiveRationalPoint, u::UInt=UInt(123432))
+function Base.hash(a::AbsProjectiveRationalPoint, h::UInt)
   w = weights(codomain(a))
   if any(!isone, w)
-    return u
+    return h
   end
   normalize!(a)
-  return hash(coordinates(a), u)
+  return hash(coordinates(a), h)
 end

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -618,8 +618,8 @@ Base.eltype(C::CycleType) = Pair{Int, Int}
 Base.getindex(C::CycleType, i::Int) = C.s[i]
 Base.size(C::CycleType) = size(C.s)
 
-function Base.hash(c::CycleType, u::UInt = UInt(121324))
-  return hash(c.s, u)
+function Base.hash(c::CycleType, h::UInt)
+  return hash(c.s, h)
 end
 
 function Base.show(io::IO, C::CycleType)


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

## Summary

Three `Base.hash` methods use a default value for the second `UInt` argument, which creates a spurious one-arg method. This causes the two-arg fallback `hash(x, h::UInt)` to use `objectid`-based hashing instead, leading to:

- **Correctness bugs**: equal objects may hash differently when used in `Dict` or `Set`
- **Performance issues**: excessive method invalidation across the ecosystem
- **Julia 1.13+ breakage**: the default hash seed is changing from `zero(UInt)` to a random value

### Changes
- `src/Groups/perm.jl`: `CycleType` — remove default arg
- `src/AlgebraicGeometry/RationalPoint/ProjectiveRationalPoint.jl`: `AbsProjectiveRationalPoint` — remove default arg
- `experimental/GModule/src/Cohomology.jl`: `MultGrpElem` — remove default arg, also fixes a typo (`.` → `,`)

## Test plan

- Verified the edits are syntactically correct and maintain the hash contract

---
This PR was generated with the assistance of generative AI.

Co-Authored-By: Claude <noreply@anthropic.com>