### PR TITLE
Fix deserialization of `MatGroup`

### DIFF
--- a/src/Serialization/Upgrades/1.4.0.jl
+++ b/src/Serialization/Upgrades/1.4.0.jl
@@ -473,7 +473,7 @@ push!(upgrade_scripts_set, UpgradeScript(
         if haskey(dict[:data], :graph)
           dict[:_type] = Dict{Symbol, Any}(
             :name => type_name,
-            :params => Dict{Symbol, Any}(:_type => String, :data => "graph")
+            :params => Dict{Symbol, Any}(:_type => "String", :data => "graph")
           )
           dict[:data][:graph] = dict[:data][:graph][:data]
         else

--- a/src/Serialization/Upgrades/1.7.0.jl
+++ b/src/Serialization/Upgrades/1.7.0.jl
@@ -14,10 +14,6 @@ push!(upgrade_scripts_set, UpgradeScript(
 
     upgraded_dict = rename_types(dict, renamings)
 
-    if haskey(dict, :data) && dict[:data] isa AbstractDict
-      upgraded_dict[:data] = upgrade_1_7_0(s, dict[:data])
-    end
-
     return upgraded_dict
   end
 ))

--- a/src/Serialization/Upgrades/1.7.0.jl
+++ b/src/Serialization/Upgrades/1.7.0.jl
@@ -1,0 +1,19 @@
+################################################################################
+# Upgrade Summary
+# 
+# `FreeAssAlgebra`: We renamed `FreeAssAlgebra` to `FreeAssociativeAlgebra`, 
+# as well as `FreeAssAlgElem` to `FreeAssociativeAlgebraElem` and this upgrade script takes care of this renaming.
+  
+push!(upgrade_scripts_set, UpgradeScript(
+  v"1.7.0",
+  function upgrade_1_7_0(s::UpgradeState, dict::AbstractDict{Symbol, Any})
+    renamings = Dict{String,String}([
+      ("MatrixGroup", "MatGroup"),
+      ("MatrixGroupElem", "MatGroupElem"),
+    ])
+
+    upgraded_dict = rename_types(dict, renamings)
+
+    return upgraded_dict
+  end
+))

--- a/src/Serialization/Upgrades/1.7.0.jl
+++ b/src/Serialization/Upgrades/1.7.0.jl
@@ -14,6 +14,10 @@ push!(upgrade_scripts_set, UpgradeScript(
 
     upgraded_dict = rename_types(dict, renamings)
 
+    if haskey(dict, :data) && dict[:data] isa AbstractDict
+      upgraded_dict[:data] = upgrade_1_7_0(s, dict[:data])
+    end
+
     return upgraded_dict
   end
 ))

--- a/src/Serialization/Upgrades/1.7.0.jl
+++ b/src/Serialization/Upgrades/1.7.0.jl
@@ -1,8 +1,8 @@
 ################################################################################
 # Upgrade Summary
 # 
-# `FreeAssAlgebra`: We renamed `FreeAssAlgebra` to `FreeAssociativeAlgebra`, 
-# as well as `FreeAssAlgElem` to `FreeAssociativeAlgebraElem` and this upgrade script takes care of this renaming.
+# We renamed `MatrixGroup` to `MatGroup`, as well as `MatrixGroupElem` to `MatGroupElem`
+# in https://github.com/oscar-system/Oscar.jl/pull/5704 and this upgrade script takes care of this renaming.
   
 push!(upgrade_scripts_set, UpgradeScript(
   v"1.7.0",

--- a/src/Serialization/Upgrades/main.jl
+++ b/src/Serialization/Upgrades/main.jl
@@ -118,16 +118,18 @@ function rename_types(dict::AbstractDict, renamings::Dict{String, String})
       return upg_d
     end
     
-    if d[:params] isa AbstractDict
-      if haskey(d[:params], :_type)
-        upg_d[:params][:_type] = upgrade_type(d[:params][:_type])
-      else
-        for (k, v) in d[:params]
-          upg_d[:params][k] = upgrade_type(d[:params][k])
+    if haskey(d, :params)
+      if d[:params] isa AbstractDict
+        if haskey(d[:params], :_type)
+          upg_d[:params][:_type] = upgrade_type(d[:params][:_type])
+        else
+          for (k, v) in d[:params]
+            upg_d[:params][k] = upgrade_type(d[:params][k])
+          end
         end
+      elseif d[:params] isa Vector
+        upg_d[:params] = upgrade_type(d[:params])
       end
-    elseif d[:params] isa Vector
-      upg_d[:params] = upgrade_type(d[:params])
     end
     return upg_d
   end

--- a/src/Serialization/Upgrades/main.jl
+++ b/src/Serialization/Upgrades/main.jl
@@ -304,6 +304,7 @@ include("1.3.0.jl")
 include("1.4.0.jl")
 include("1.6.0.jl")
 include("1.6.0+1.jl")
+include("1.7.0.jl")
 
 const upgrade_scripts = collect(upgrade_scripts_set)
 sort!(upgrade_scripts; by=version)

--- a/test/Serialization/upgrades/setup_tests.jl
+++ b/test/Serialization/upgrades/setup_tests.jl
@@ -8,7 +8,7 @@ if !isdefined(Main, :serialization_upgrade_test_path) ||
   !isdir(Main.serialization_upgrade_test_path) ||
   !isfile(joinpath(Main.serialization_upgrade_test_path, "LICENSE.md"))
 
-  serialization_upgrade_test_path = let commit_hash = "086fa620700151b36e94aa96ada8e34e5f4b314e"
+  serialization_upgrade_test_path = let commit_hash = "daf6ca1d4a8f80d2da7d506d4ddb593694dd92a2"
     tarball = Downloads.download("https://github.com/oscar-system/serialization-upgrade-tests/archive/$(commit_hash).tar.gz")
 
     destpath = open(CodecZlib.GzipDecompressorStream, tarball) do io

--- a/test/Serialization/upgrades/setup_tests.jl
+++ b/test/Serialization/upgrades/setup_tests.jl
@@ -8,7 +8,7 @@ if !isdefined(Main, :serialization_upgrade_test_path) ||
   !isdir(Main.serialization_upgrade_test_path) ||
   !isfile(joinpath(Main.serialization_upgrade_test_path, "LICENSE.md"))
 
-  serialization_upgrade_test_path = let commit_hash = "ce778d995ea63dd73307e7a9ecde1bf5b215ba22"
+  serialization_upgrade_test_path = let commit_hash = "47b74ddc8745be8693395af721ac2712d307abdb"
     tarball = Downloads.download("https://github.com/oscar-system/serialization-upgrade-tests/archive/$(commit_hash).tar.gz")
 
     destpath = open(CodecZlib.GzipDecompressorStream, tarball) do io

--- a/test/Serialization/upgrades/setup_tests.jl
+++ b/test/Serialization/upgrades/setup_tests.jl
@@ -8,7 +8,7 @@ if !isdefined(Main, :serialization_upgrade_test_path) ||
   !isdir(Main.serialization_upgrade_test_path) ||
   !isfile(joinpath(Main.serialization_upgrade_test_path, "LICENSE.md"))
 
-  serialization_upgrade_test_path = let commit_hash = "47b74ddc8745be8693395af721ac2712d307abdb"
+  serialization_upgrade_test_path = let commit_hash = "086fa620700151b36e94aa96ada8e34e5f4b314e"
     tarball = Downloads.download("https://github.com/oscar-system/serialization-upgrade-tests/archive/$(commit_hash).tar.gz")
 
     destpath = open(CodecZlib.GzipDecompressorStream, tarball) do io


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/5882 by adding an upgrade script.

I am not quite sure if I assembled the upgrade script in the right way, as there was no pure renaming since we have `upgrade_recursive`. In particular, I am not sure if `upgrade_recursive` needs to be called.

As the corresponding renaming was already released with Oscar 1.7.0, IMO we should backport this asap. (cc @benlorenz @aaruni96 )