### PR TITLE
Avoid access to `p` field of universal ring elements

### DIFF
--- a/test/Serialization/PolynomialsSeries.jl
+++ b/test/Serialization/PolynomialsSeries.jl
@@ -124,7 +124,7 @@ cases = [
         p = z^2 + case[2] * z * w + case[3] * w^3
         test_save_load_roundtrip(path, p) do loaded
           test_p = z^2 + case[2] * z * w + case[3] * w^3
-          @test loaded.p == test_p.p
+          @test loaded == test_p
         end
 
         @testset "Load with params" begin


### PR DESCRIPTION
In https://github.com/Nemocas/AbstractAlgebra.jl/pull/2274 the field name of the underlying ordinary element of universal polynomials (and then also any universal ring element) is changed from `p` to `data`. But the exact name should actually be completely irrelevant for Oscar.jl. Somehow the field was access directly. This PR fixes this. I'll rerun the check over on AbstractAlgebra.jl's repo to check if I missed another direct access to `p`.

@antonydellavecchia I'm not sure why the equality was checked just for the underlying element. Do you know why?