### PR TITLE
Use GenericCharacterTables 0.8.1 for book tests

### DIFF
--- a/test/book/cornerstones/groups/auxiliary_code/main.jl
+++ b/test/book/cornerstones/groups/auxiliary_code/main.jl
@@ -1,3 +1,3 @@
 import Pkg
-Pkg.add(name="GenericCharacterTables", version="0.8.0"; io=devnull)
+Pkg.add(name="GenericCharacterTables", version="0.8.1"; io=devnull)
 using GenericCharacterTables


### PR DESCRIPTION
Together with #5885 this should make Oscar.jl compatible with the recent changes in https://github.com/Nemocas/AbstractAlgebra.jl/pull/2274 changing internal field names.