### PR TITLE
Add `index_of_coset`

### DIFF
--- a/docs/src/Groups/subgroups.md
+++ b/docs/src/Groups/subgroups.md
@@ -131,6 +131,7 @@ group(T::SubgroupTransversal)
 subgroup(T::SubgroupTransversal)
 right_transversal(G::T1, H::T2; check::Bool=true) where T1 <: GAPGroup where T2 <: GAPGroup
 left_transversal(G::T1, H::T2; check::Bool=true) where T1 <: GAPGroup where T2 <: GAPGroup
+index_of_coset
 is_bicoset(C::GroupCoset)
 ```
 

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -357,6 +357,7 @@ GAP.@wrap Permuted(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap PolynomialByExtRep(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap PolynomialRing(x::GapObj)::GapObj
 GAP.@wrap PolynomialRing(x::GapObj, y::Int)::GapObj
+GAP.@wrap PositionCanonical(x::GapObj, y::GapObj)::GAP.Obj
 GAP.@wrap PossibleClassFusions(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap PossibleClassFusions(x::GapObj, y::GapObj, z::GapObj)::GapObj
 GAP.@wrap POW(x::GAP.Obj, y::GAP.Obj)::GAP.Obj

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -401,7 +401,7 @@ GAP.@install GapObj(T::SubgroupTransversal) = T.X
 
 function Base.show(io::IO, ::MIME"text/plain", x::SubgroupTransversal)
   side = is_left(x) ? "Left" : "Right"
-  println(io, "$side transversal of length $(length(x)) of")
+  println(io, "$side transversal of length $(length(ZZRingElem, x)) of")
   io = pretty(io)
   print(io, Indent())
   println(io, Lowercase(), x.H, " in")
@@ -428,8 +428,11 @@ Base.hash(x::SubgroupTransversal, h::UInt) = h # FIXME
 
 Base.length(T::SubgroupTransversal) = index(Int, T.G, T.H)
 
-function Base.getindex(T::SubgroupTransversal, i::Int)
-  res = group_element(T.G, GapObj(T)[i])
+Base.length(::Type{I}, T::SubgroupTransversal) where I <: IntegerUnion = index(I, T.G, T.H)
+
+function Base.getindex(T::SubgroupTransversal, i::IntegerUnion)
+  res = group_element(T.G, GAP.Globals.ELM_LIST(GapObj(T), GAP.Obj(i)))
+#TODO: As soon as `GapObj(T)[i]` works for large `i`, simplify the above line
   if is_left(T)
     res = inv(res)
   end
@@ -579,6 +582,50 @@ function left_transversal(G::T1, H::T2; check::Bool=true) where T1 <: GAPGroup w
               GAPWrap.RightTransversal(GapObj(G), GapObj(H)))
 end
 
+"""
+    index_of_coset(::Type{I} = ZZRingElem, T::SubgroupTransversal, g::GroupElem) where I <: IntegerUnion
+
+Return the position `i` in `T` such that
+`g` is an element of `subgroup(T)*T[i]` if `T` is a right transversal and
+`g` is an element of `T[i]*subgroup(T)` if `T` is a left transversal.
+
+The returned value has type `I`.
+
+`parent(g)` must be equal to `group(T)`.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(4);
+
+julia> H = symmetric_group(3);
+
+julia> Tr = right_transversal(G, H);
+
+julia> index_of_coset(Tr, G[1])
+2
+
+julia> Tl = left_transversal(G, H);
+
+julia> index_of_coset(Tl, G[1])
+4
+
+julia> G[1] in right_coset(H, Tr[2])
+true
+
+julia> G[1] in left_coset(H, Tl[4])
+true
+```
+"""
+index_of_coset(T::SubgroupTransversal, g::GroupElem) = index_of_coset(ZZRingElem, T::SubgroupTransversal, g::GroupElem)
+
+function index_of_coset(::Type{I}, T::SubgroupTransversal, g::GroupElem) where I <: IntegerUnion
+   @req parent(g) === group(T) "parent(g) differs from group(T)"
+   Gap_g = GapObj(g)
+   if is_left(T)
+     Gap_g = inv(Gap_g)
+   end
+   return I(GAPWrap.PositionCanonical(GapObj(T), Gap_g)::GapInt)
+end
 
 @doc raw"""
     GroupDoubleCoset{T<: Group, S <: GAPGroupElem}

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -826,6 +826,7 @@ export inclusion_morphism
 export indegree
 export independent_sets
 export index
+export index_of_coset
 export index_of_gen
 export index_of_leading_term
 export indicator

--- a/test/Groups/subgroups_and_cosets.jl
+++ b/test/Groups/subgroups_and_cosets.jl
@@ -292,6 +292,37 @@ end
    @test Set(intersect(lc,H))==Set(H)
    lc = left_coset(H,x)
    @test intersect(lc,H)==[]
+
+   @testset "index_of_coset" begin
+      G, _ = stabilizer(symmetric_group(6), 6)  # smaller than the natural parent
+      H = sylow_subgroup(G, 2)[1]
+      Tr = right_transversal(G, H)
+      @test all(i -> i == index_of_coset(Tr, G(H[1])*Tr[i]), 1:length(Tr))
+      Tl = left_transversal(G, H)
+      @test all(i -> i == index_of_coset(Tl, Tl[i]*G(H[1])), 1:length(Tl))
+      x = rand(G)
+      @test Tr[index_of_coset(Tr, x)] * inv(x) in H
+      @test inv(x) * Tl[index_of_coset(Tl, x)] in H
+
+      # special case that H is trivial
+      # (where we have a different type of transversal object on the GAP side)
+      G = symmetric_group(4)
+      H = trivial_subgroup(G)[1]
+      Tr = right_transversal(G, H)
+      @test all(i -> i == index_of_coset(Tr, Tr[i]), 1:length(Tr))
+
+      # a very long transversal
+      G = symmetric_group(21)
+      H = sub(G, [G[2]])[1]
+      T = right_transversal(G, H)
+      @test_throws InexactError length(T)
+      @test length(ZZRingElem, T) == divexact(factorial(ZZRingElem(21)), 2)
+      @test index_of_coset(T, T[1]) == 1
+      l = length(ZZRingElem, T)
+      @test index_of_coset(T, T[l]) == l
+
+      @test_throws ArgumentError index_of_coset(T, H[1])
+   end
 end
 
 @testset "Double cosets" begin


### PR DESCRIPTION
and improve the support for long transversals (length not an `Int`)