### PR TITLE
Fix bug in `diff_action` and provide convenience constructors

### DIFF
--- a/experimental/ActionPolyRing/docs/src/difference_polynomial_rings.md
+++ b/experimental/ActionPolyRing/docs/src/difference_polynomial_rings.md
@@ -11,7 +11,8 @@ A difference polynomial ring over the commutative ring ``R`` is an action polyno
 ## Construction
 
 ```@docs
-difference_polynomial_ring
+difference_polynomial_ring(R::Ring, n_elementary_symbols::Int, n_action_maps::Int; kwargs...)
+difference_polynomial_ring(R::Ring, x::Symbol, n_action_maps::Int; kwargs...)
 ```
 
 ## Action maps

--- a/experimental/ActionPolyRing/docs/src/differential_polynomial_rings.md
+++ b/experimental/ActionPolyRing/docs/src/differential_polynomial_rings.md
@@ -11,7 +11,8 @@ A differential polynomial ring over the commutative ring ``R`` is an action poly
 ## Construction
 
 ```@docs
-differential_polynomial_ring
+differential_polynomial_ring(R::Ring, n_elementary_symbols::Int, n_action_maps::Int; kwargs...)
+differential_polynomial_ring(R::Ring, x::Symbol, n_action_maps::Int; kwargs...)
 ```
 
 ## Action maps

--- a/experimental/ActionPolyRing/src/Content.jl
+++ b/experimental/ActionPolyRing/src/Content.jl
@@ -76,15 +76,16 @@ difference polynomial ring.
 
 # Examples
 
+This constructor is preferred when one only wants to have one elementary symbol:
 ```jldoctest
-# This constructor is preferred when one only wants to have one elementary symbol:
 julia> R, x = difference_polynomial_ring(ZZ, :x, 2)
 (Difference polynomial ring in 1 elementary symbols over ZZ, x[0,0])
 
 julia> x
 x[0,0]
-
-# If we instead construct this ring by passing the single elementary symbol as a vector, the variable x does not behave as intended:
+```
+If we instead construct this ring by passing the single elementary symbol as a vector, the variable x does not behave as intended:
+```jldoctest
 julia> R, x = difference_polynomial_ring(ZZ, [:x], 2)
 (Difference polynomial ring in 1 elementary symbols over ZZ, DifferencePolyRingElem{ZZRingElem}[x[0,0]])
 

--- a/experimental/ActionPolyRing/src/Content.jl
+++ b/experimental/ActionPolyRing/src/Content.jl
@@ -19,7 +19,7 @@ Construct the difference polynomial ring over the base ring `R` with the given e
 In both cases, the jet variables that are initially available are those with jet `[0,…,0]`, one for each elementary symbol.
 
 This method returns a tuple `(dpr, gens)` where `dpr` is the resulting difference polynomial ring and `gens` is the 
-vector of initial jet variables.  
+vector of initial jet variables.
 
 This constructor also accepts all keyword arguments of [`set_ranking!`](@ref) to control the ranking.
 
@@ -65,6 +65,37 @@ function difference_polynomial_ring(R::Ring, elementary_symbols::Vector{Symbol},
   dpr = DifferencePolyRing{elem_type(typeof(R))}(R, elementary_symbols, n_action_maps)
   set_ranking!(dpr; kwargs...)
   return (dpr, deepcopy.(__add_new_jetvar!(dpr, [(i, zeros(Int, n_action_maps)) for i in 1:length(elementary_symbols)])))
+end
+
+@doc raw"""
+    difference_polynomial_ring(R::Ring, x::Symbol, n_action_maps::Int) -> Tuple{DifferencePolyRing, DifferencePolyRingElem}
+
+This constructor behaves exactly like [`difference_polynomial_ring`](@ref difference_polynomial_ring(R::Ring, n_elementary_symbols::Int, n_action_maps::Int; kwargs...))
+but only allows for one elementary symbol `x` instead of a vector of these. Consequently, this method returns the tuple `(dpr, x[0,…,0])` where `dpr` is the resulting
+difference polynomial ring.
+
+# Examples
+
+```jldoctest
+# This constructor is preferred when one only wants to have one elementary symbol:
+julia> R, x = difference_polynomial_ring(ZZ, :x, 2)
+(Difference polynomial ring in 1 elementary symbols over ZZ, x[0,0])
+
+julia> x
+x[0,0]
+
+# If we instead construct this ring by passing the single elementary symbol as a vector, the variable x does not behave as intended:
+julia> R, x = difference_polynomial_ring(ZZ, [:x], 2)
+(Difference polynomial ring in 1 elementary symbols over ZZ, DifferencePolyRingElem{ZZRingElem}[x[0,0]])
+
+julia> x
+1-element Vector{DifferencePolyRingElem{ZZRingElem}}:
+ x[0,0]
+```
+"""
+function difference_polynomial_ring(R::Ring, elementary_symbol::Symbol, n_action_maps::Int; kwargs...)
+  tmp = difference_polynomial_ring(R, [elementary_symbol], n_action_maps; kwargs...)
+  return (tmp[1], tmp[2][1])
 end
 
 ### Differential ###
@@ -126,6 +157,37 @@ function differential_polynomial_ring(R::Ring, elementary_symbols::Vector{Symbol
   dpr = DifferentialPolyRing{elem_type(typeof(R))}(R, elementary_symbols, n_action_maps)
   set_ranking!(dpr; kwargs...)
   return (dpr, deepcopy.(__add_new_jetvar!(dpr, [(i, zeros(Int, n_action_maps)) for i in 1:length(elementary_symbols)])))
+end
+
+@doc raw"""
+    differential_polynomial_ring(R::Ring, x::Symbol, n_action_maps::Int) -> Tuple{DifferentialPolyRing, DifferentialPolyRingElem}
+
+This constructor behaves exactly like [`differential_polynomial_ring`](@ref differential_polynomial_ring(R::Ring, n_elementary_symbols::Int, n_action_maps::Int; kwargs...))
+but only allows for one elementary symbol `x` instead of a vector of these. Consequently, this method returns the tuple `(dpr, x[0,…,0])` where `dpr` is the resulting
+differential polynomial ring.
+
+# Examples
+
+```jldoctest
+# This constructor is preferred when one only wants to have one elementary symbol:
+julia> R, x = differential_polynomial_ring(ZZ, :x, 2)
+(Differential polynomial ring in 1 elementary symbols over ZZ, x[0,0])
+
+julia> x
+x[0,0]
+
+# If we instead construct this ring by passing the single elementary symbol as a vector, the variable x does not behave as intended:
+julia> R, x = differential_polynomial_ring(ZZ, [:x], 2)
+(Differential polynomial ring in 1 elementary symbols over ZZ, DifferentialPolyRingElem{ZZRingElem}[x[0,0]])
+
+julia> x
+1-element Vector{DifferentialPolyRingElem{ZZRingElem}}:
+ x[0,0]
+```
+"""
+function differential_polynomial_ring(R::Ring, elementary_symbol::Symbol, n_action_maps::Int; kwargs...)
+  tmp = differential_polynomial_ring(R, [elementary_symbol], n_action_maps; kwargs...)
+  return (tmp[1], tmp[2][1])
 end
 
 ##### Elements #####
@@ -773,16 +835,15 @@ function diff_action(dpre::DifferencePolyRingElem{T}, d::Vector{Int}) where {T}
     coeff_t = coeff(term, 1)
     vars_t = vars(term)
     ev = append!(exponent_vector(term, 1), fill(0, ngens(upr) - length(exponent_vector(term, 1))))
-    new_exp_vec = copy(ev)
+    new_exp_vec = fill(0, length(ev))
 
     for var in vars_t
       var_pos = findfirst(==(var), gens(upr))
       shifted_var_pos = old_to_new_pos[var_pos]
       
       new_exp_vec[shifted_var_pos] = ev[var_pos]
-      new_exp_vec[var_pos] = 0 
     end
-    
+
     push_term!(C, coeff_t , new_exp_vec)
   end
   return dpr(finish(C))

--- a/experimental/ActionPolyRing/src/Content.jl
+++ b/experimental/ActionPolyRing/src/Content.jl
@@ -169,15 +169,16 @@ differential polynomial ring.
 
 # Examples
 
+This constructor is preferred when one only wants to have one elementary symbol:
 ```jldoctest
-# This constructor is preferred when one only wants to have one elementary symbol:
 julia> R, x = differential_polynomial_ring(ZZ, :x, 2)
 (Differential polynomial ring in 1 elementary symbols over ZZ, x[0,0])
 
 julia> x
 x[0,0]
-
-# If we instead construct this ring by passing the single elementary symbol as a vector, the variable x does not behave as intended:
+```
+If we instead construct this ring by passing the single elementary symbol as a vector, the variable x does not behave as intended:
+```jldoctest
 julia> R, x = differential_polynomial_ring(ZZ, [:x], 2)
 (Differential polynomial ring in 1 elementary symbols over ZZ, DifferentialPolyRingElem{ZZRingElem}[x[0,0]])
 

--- a/experimental/ActionPolyRing/test/ActionPolyRing.jl
+++ b/experimental/ActionPolyRing/test/ActionPolyRing.jl
@@ -16,11 +16,13 @@ using Test
     @testset "DifferencePolyRing - conformance tests" begin
       ConformanceTests.test_Ring_interface(difference_polynomial_ring(residue_ring(ZZ, ZZ(18))[1], 2, 3)[1])
       ConformanceTests.test_Ring_interface(difference_polynomial_ring(ZZ, 5, 8)[1])
+      ConformanceTests.test_Ring_interface(difference_polynomial_ring(ZZ, :x, 2)[1])
     end
     
     @testset "DifferentialPolyRing - conformance tests" begin
       ConformanceTests.test_Ring_interface(differential_polynomial_ring(residue_ring(ZZ, ZZ(18))[1], 2, 3)[1])
       ConformanceTests.test_Ring_interface(differential_polynomial_ring(ZZ, 5, 8)[1])
+      ConformanceTests.test_Ring_interface(differential_polynomial_ring(ZZ, :x, 2)[1])
     end
 
   end
@@ -929,5 +931,14 @@ using Test
       end #End for loop
     end #End further constructions
   end #Construction and basic field access
+
+  @testset "Fixed bugs" begin
+    @testset "diff_action for difference wiping data" begin
+      R, (y_2, y_1) = difference_polynomial_ring(QQ, [:y2, :y1], 2; partition = [[1,1]], index_ordering_name=:degrevlex)
+      p = y_1^2 * diff_action(y_1, [0, 1]) - 1
+      @test diff_action(p, 2) == diff_action(p, [0, 1])
+      @test diff_action(p, 2) == R[2,[0,1]]^2*R[2,[0,2]] - 1
+    end
+  end
 
 end #All tests


### PR DESCRIPTION
This small PR fixes a bug in the `diff_action`-method for difference polynomial rings: After calculating the position of the new exponents the entries in the previous positions were killed, which caused an error if a new position coincided with an old one. This is now fixed and a test was added.

Additionally, we provide a new constructor for difference and differential polynomial rings respectively. It takes a single symbol instead of a vector of symbols. Using it is more convenient when one want to construct such a ring while storing its single jet variable at the same time. The docs were updated accordingly.