### PR TITLE
Support sparse matrices for transformations in Groebner basis computations

### DIFF
--- a/experimental/InjectiveResolutions/src/ModuleFunctionality.jl
+++ b/experimental/InjectiveResolutions/src/ModuleFunctionality.jl
@@ -72,25 +72,10 @@ end
 =#
 function lift_std(M::ModuleGens{T}) where {T <: MonoidAlgebraElem}
   R = base_ring(M)
-  ### TODO: 
-  # We would like a new version of `lift_std` in Singular.jl which natively 
-  # returns a sparse matrix. This does not exist yet. 
-  # However, we already adapted the Oscar.jl code so that only sparse matrices
-  # are used for the modules. Thus the two nested `for`-loops below are a 
-  # temporary workaround which should be adapted, once a new version of 
-  # `lift_std` in Singular.jl becomes available. 
-  # In the meantime, this already provides an improvement in terms of 
-  # runtime and allocations.
-  G, Trans_mat = Singular.lift_std(singular_generators(M)) # When Singular supports reduction add it also here
-  A = sparse_matrix(R, 0, nrows(Trans_mat))
-  for i in 1:ncols(Trans_mat)
-    row_list = Vector{Tuple{Int, elem_type(R)}}()
-    for j in 1:nrows(Trans_mat)
-      c = Trans_mat[j, i]
-      is_zero(c) && continue
-      push!(row_list, (j, R(c)))
-    end
-    push!(A, sparse_row(R, row_list))
+  G, trans_mod = Singular.lift_std_sparse_transformation_matrix(singular_generators(M))
+  A = sparse_matrix(R, 0, ngens(trans_mod))
+  for v in gens(trans_mod)
+    push!(A, _build_sparse_row(R, v))
   end
   mg = ModuleGens(M.F, G)
   mg.isGB = true

--- a/experimental/InjectiveResolutions/src/ModuleFunctionality.jl
+++ b/experimental/InjectiveResolutions/src/ModuleFunctionality.jl
@@ -73,7 +73,7 @@ function lift_std(M::ModuleGens{T}) where {T <: MonoidAlgebraElem}
   mg.S.isGB = true
   mg.ordering = default_ordering(oscar_free_module(M))
   mat = map_entries(R, transpose(Trans_mat))
-  set_attribute!(mg, :transformation_matrix => mat)
+  set_attribute!(mg, :sparse_transformation_matrix => mat)
   return mg, mat
 end
 
@@ -85,7 +85,7 @@ function lift_std(M::ModuleGens{T}, ordering::ModuleOrdering) where {T <: Monoid
 end
 
 function coordinates_via_transform(a::FreeModElem{T}, generators::ModuleGens{T}) where {T <: MonoidAlgebraElem}
-  A = get_attribute(generators, :transformation_matrix)
+  A = get_attribute(generators, :sparse_transformation_matrix)
   A === nothing && error("No transformation matrix in the Gröbner basis.")
   if iszero(a)
     return sparse_row(base_ring(parent(a)))

--- a/experimental/InjectiveResolutions/src/ModuleFunctionality.jl
+++ b/experimental/InjectiveResolutions/src/ModuleFunctionality.jl
@@ -65,16 +65,39 @@ function coordinates_atomic(a::FreeModElem{T}, M::SubModuleOfFreeModule; task=:a
   return coordinates_via_transform(a, std)
 end
 
+#= The function's body is copied from `src/Modules`. 
+# We need to duplicate the method, because it needs te be made available for 
+# the type `MonoidAlgebraElem` which is from experimental. Therefore, we can 
+# not introduce a type union in `src`.
+=#
 function lift_std(M::ModuleGens{T}) where {T <: MonoidAlgebraElem}
   R = base_ring(M)
-  G,Trans_mat = Singular.lift_std(singular_generators(M)) # When Singular supports reduction add it also here
-  mg = ModuleGens(oscar_free_module(M), G)
+  ### TODO: 
+  # We would like a new version of `lift_std` in Singular.jl which natively 
+  # returns a sparse matrix. This does not exist yet. 
+  # However, we already adapted the Oscar.jl code so that only sparse matrices
+  # are used for the modules. Thus the two nested `for`-loops below are a 
+  # temporary workaround which should be adapted, once a new version of 
+  # `lift_std` in Singular.jl becomes available. 
+  # In the meantime, this already provides an improvement in terms of 
+  # runtime and allocations.
+  G, Trans_mat = Singular.lift_std(singular_generators(M)) # When Singular supports reduction add it also here
+  A = sparse_matrix(R, 0, nrows(Trans_mat))
+  for i in 1:ncols(Trans_mat)
+    row_list = Vector{Tuple{Int, elem_type(R)}}()
+    for j in 1:nrows(Trans_mat)
+      c = Trans_mat[j, i]
+      is_zero(c) && continue
+      push!(row_list, (j, R(c)))
+    end
+    push!(A, sparse_row(R, row_list))
+  end
+  mg = ModuleGens(M.F, G)
   mg.isGB = true
   mg.S.isGB = true
-  mg.ordering = default_ordering(oscar_free_module(M))
-  mat = map_entries(R, transpose(Trans_mat))
-  set_attribute!(mg, :sparse_transformation_matrix => mat)
-  return mg, mat
+  mg.ordering = default_ordering(M.F)
+  set_attribute!(mg, :sparse_transformation_matrix => A)
+  return mg, A
 end
 
 function lift_std(M::ModuleGens{T}, ordering::ModuleOrdering) where {T <: MonoidAlgebraElem}
@@ -103,7 +126,7 @@ function coordinates_via_transform(a::FreeModElem{T}, generators::ModuleGens{T})
   end
   Rx = base_ring(generators)
   coords_wrt_groebner_basis = sparse_row(Rx, s[1], 1:ngens(generators))
-  return coords_wrt_groebner_basis * sparse_matrix(A)
+  return coords_wrt_groebner_basis * A
 end
 
 function sparse_row(

--- a/src/Modules/UngradedModules/ModuleGens.jl
+++ b/src/Modules/UngradedModules/ModuleGens.jl
@@ -253,13 +253,14 @@ end
 Convert a free module element to the Singular side.
 """
 function (SF::Singular.FreeMod)(m::FreeModElem)
-  g = Singular.gens(SF)
-  e = SF()
+  is_zero(m) && return SF()
   Sx = base_ring(SF)
-  for (p,v) in coordinates(m)
-    e += Sx(v)*g[p]
+  c = coordinates(m)
+  if isone(length(c)) 
+    (p, v) = only(c)
+    return Sx(v)*gen(SF, p) 
   end
-  return e
+  return sum(Sx(v)*gen(SF, p) for (p, v) in c; init=SF())
 end
 
 @doc raw"""

--- a/src/Modules/UngradedModules/ModuleGens.jl
+++ b/src/Modules/UngradedModules/ModuleGens.jl
@@ -364,9 +364,7 @@ If no such `r` exists, an exception is thrown.
 function coordinates_via_transform(a::FreeModElem{T}, generators::ModuleGens{T}) where T
   iszero(a) && return sparse_row(base_ring(parent(a)))
   SA = get_attribute!(generators, :sparse_transformation_matrix) do
-    A = get_attribute(generators, :transformation_matrix)
-    A === nothing && error("No transformation matrix in the Gröbner basis.")
-    sparse_matrix(A)
+    error("No transformation matrix in the Gröbner basis.")
   end
 
   @assert generators.isGB

--- a/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
+++ b/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
@@ -455,9 +455,10 @@ function lift_std(M::SubModuleOfFreeModule)
     end
   end
   gb, transform = lift_std(M.gens, default_ordering(M))
-  M.groebner_basis[default_ordering(M)] = gb
   if !isdefined(M, :any_gb_with_transition)
     M.any_gb_with_transition = gb
+  else
+    M.groebner_basis[default_ordering(M)] = gb # this line spends a significant amount of time on hashing the ordering!
   end
   return gb, transform
 end

--- a/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
+++ b/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
@@ -183,7 +183,7 @@ function standard_basis(
   if !isdefined(submod, :any_gb)
     submod.any_gb = gb
   end
-  if !isdefined(submod, :any_gb_with_transition) && !isnothing(get_attribute(gb, :transformation_matrix))
+  if !isdefined(submod, :any_gb_with_transition) && !isnothing(get_attribute(gb, :sparse_transformation_matrix))
     submod.any_gb_with_transition = gb
   end
   return gb
@@ -216,7 +216,7 @@ function reduced_groebner_basis(submod::SubModuleOfFreeModule, ordering::ModuleO
   if !isdefined(submod, :any_gb)
     submod.any_gb = gb
   end
-  if !isdefined(submod, :any_gb_with_transition) && !isnothing(get_attribute(gb, :transformation_matrix))
+  if !isdefined(submod, :any_gb_with_transition) && !isnothing(get_attribute(gb, :sparse_transformation_matrix))
     submod.any_gb_with_transition = gb
   end
   return gb
@@ -445,11 +445,11 @@ Base.:+(M::SubModuleOfFreeModule, N::SubModuleOfFreeModule) = sum(M, N)
 
 function lift_std(M::SubModuleOfFreeModule)
   if isdefined(M, :any_gb_with_transition)
-    return M.any_gb_with_transition, get_attribute(M.any_gb_with_transition, :transformation_matrix)::MatrixElem
+    return M.any_gb_with_transition, get_attribute(M.any_gb_with_transition, :sparse_transformation_matrix)::SMat
   end
 
   for (ord, gb) in M.groebner_basis
-    transform = get_attribute(gb, :transformation_matrix)
+    transform = get_attribute(gb, :sparse_transformation_matrix)
     if transform !== nothing
       return gb, transform
     end

--- a/src/Modules/UngradedModules/SubquoModuleElem.jl
+++ b/src/Modules/UngradedModules/SubquoModuleElem.jl
@@ -251,18 +251,27 @@ end
     lift_std(M::ModuleGens{T}) where {T <: MPolyRingElem}
 
 Return a standard basis `G` of `F` as an object of type `ModuleGens` along with
-a transformation matrix `T` such that `T*matrix(M) = matrix(G)`.
+a sparse transformation matrix `T` such that `matrix(T)*matrix(M) = matrix(G)`.
 """
 function lift_std(M::ModuleGens{T}) where {T <: MPolyRingElem}
   R = base_ring(M)
-  G,Trans_mat = Singular.lift_std(singular_generators(M)) # When Singular supports reduction add it also here
+  G, Trans_mat = Singular.lift_std(singular_generators(M)) # When Singular supports reduction add it also here
+  A = sparse_matrix(R, 0, nrows(Trans_mat))
+  for i in 1:ncols(Trans_mat)
+    row_list = Vector{Tuple{Int, elem_type(R)}}()
+    for j in 1:nrows(Trans_mat)
+      c = Trans_mat[j, i]
+      is_zero(c) && continue
+      push!(row_list, (j, R(c)))
+    end
+    push!(A, sparse_row(R, row_list))
+  end
   mg = ModuleGens(M.F, G)
   mg.isGB = true
   mg.S.isGB = true
   mg.ordering = default_ordering(M.F)
-  mat = map_entries(R, transpose(Trans_mat))
-  set_attribute!(mg, :transformation_matrix => mat)
-  return mg, mat
+  set_attribute!(mg, :sparse_transformation_matrix => A)
+  return mg, A
 end
 
 @doc raw"""

--- a/src/Modules/UngradedModules/SubquoModuleElem.jl
+++ b/src/Modules/UngradedModules/SubquoModuleElem.jl
@@ -256,7 +256,7 @@ a sparse transformation matrix `T` such that `matrix(T)*matrix(M) = matrix(G)`.
 function lift_std(M::ModuleGens{T}) where {T <: MPolyRingElem}
   R = base_ring(M)
   G, trans_mod = Singular.lift_std_sparse_transformation_matrix(singular_generators(M))
-  A = sparse_matrix(R, 0, ngens(trans_mod))
+  A = sparse_matrix(R, 0, ngens(M))
   for v in gens(trans_mod)
     push!(A, _build_sparse_row(R, v))
   end

--- a/src/Modules/UngradedModules/SubquoModuleElem.jl
+++ b/src/Modules/UngradedModules/SubquoModuleElem.jl
@@ -255,6 +255,15 @@ a sparse transformation matrix `T` such that `matrix(T)*matrix(M) = matrix(G)`.
 """
 function lift_std(M::ModuleGens{T}) where {T <: MPolyRingElem}
   R = base_ring(M)
+  ### TODO: 
+  # We would like a new version of `lift_std` in Singular.jl which natively 
+  # returns a sparse matrix. This does not exist yet. 
+  # However, we already adapted the Oscar.jl code so that only sparse matrices
+  # are used for the modules. Thus the two nested `for`-loops below are a 
+  # temporary workaround which should be adapted, once a new version of 
+  # `lift_std` in Singular.jl becomes available. 
+  # In the meantime, this already provides an improvement in terms of 
+  # runtime and allocations.
   G, Trans_mat = Singular.lift_std(singular_generators(M)) # When Singular supports reduction add it also here
   A = sparse_matrix(R, 0, nrows(Trans_mat))
   for i in 1:ncols(Trans_mat)

--- a/src/Modules/UngradedModules/SubquoModuleElem.jl
+++ b/src/Modules/UngradedModules/SubquoModuleElem.jl
@@ -255,25 +255,10 @@ a sparse transformation matrix `T` such that `matrix(T)*matrix(M) = matrix(G)`.
 """
 function lift_std(M::ModuleGens{T}) where {T <: MPolyRingElem}
   R = base_ring(M)
-  ### TODO: 
-  # We would like a new version of `lift_std` in Singular.jl which natively 
-  # returns a sparse matrix. This does not exist yet. 
-  # However, we already adapted the Oscar.jl code so that only sparse matrices
-  # are used for the modules. Thus the two nested `for`-loops below are a 
-  # temporary workaround which should be adapted, once a new version of 
-  # `lift_std` in Singular.jl becomes available. 
-  # In the meantime, this already provides an improvement in terms of 
-  # runtime and allocations.
-  G, Trans_mat = Singular.lift_std(singular_generators(M)) # When Singular supports reduction add it also here
-  A = sparse_matrix(R, 0, nrows(Trans_mat))
-  for i in 1:ncols(Trans_mat)
-    row_list = Vector{Tuple{Int, elem_type(R)}}()
-    for j in 1:nrows(Trans_mat)
-      c = Trans_mat[j, i]
-      is_zero(c) && continue
-      push!(row_list, (j, R(c)))
-    end
-    push!(A, sparse_row(R, row_list))
+  G, trans_mod = Singular.lift_std_sparse_transformation_matrix(singular_generators(M))
+  A = sparse_matrix(R, 0, ngens(trans_mod))
+  for v in gens(trans_mod)
+    push!(A, _build_sparse_row(R, v))
   end
   mg = ModuleGens(M.F, G)
   mg.isGB = true

--- a/src/Rings/groebner/transformation-matrix.jl
+++ b/src/Rings/groebner/transformation-matrix.jl
@@ -66,7 +66,7 @@ true
 """
 function standard_basis_with_transformation_matrix(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool = false)
   G, A = standard_basis_with_sparse_transformation_matrix(I; ordering, complete_reduction)
-  return G, matrix(A)
+  return G, transpose(matrix(A))
 end
 
 # same as above, but returning a sparse matrix

--- a/src/Rings/groebner/transformation-matrix.jl
+++ b/src/Rings/groebner/transformation-matrix.jl
@@ -28,6 +28,17 @@ function _compute_standard_basis_with_transform(B::IdealGens, ordering::Monomial
   return IdealGens(R, istd), map_entries(R, m)
 end
 
+function _compute_standard_basis_with_sparse_transform(B::IdealGens, ordering::MonomialOrdering, complete_reduction::Bool = false)
+  istd, trans_mod = Singular.lift_std_sparse_transformation_matrix(singular_generators(B, ordering); 
+                                                           complete_reduction)
+  R = base_ring(B)
+  A = sparse_matrix(R, 0, ngens(trans_mod))
+  for v in gens(trans_mod)
+    push!(A, _build_sparse_row(R, v))
+  end
+  return IdealGens(R, istd), A
+end
+
 @doc raw"""
     standard_basis_with_transformation_matrix(I::MPolyIdeal;
       ordering::MonomialOrdering = default_ordering(base_ring(I)),

--- a/src/Rings/groebner/transformation-matrix.jl
+++ b/src/Rings/groebner/transformation-matrix.jl
@@ -33,7 +33,7 @@ function _compute_standard_basis_with_sparse_transform(B::IdealGens, ordering::M
   istd, trans_mod = Singular.lift_std_sparse_transformation_matrix(singular_generators(B, ordering); 
                                                            complete_reduction)
   R = base_ring(B)
-  A = sparse_matrix(R, 0, ngens(trans_mod))
+  A = sparse_matrix(R, 0, length(B))
   for v in gens(trans_mod)
     push!(A, _build_sparse_row(R, v))
   end
@@ -66,10 +66,36 @@ true
 """
 function standard_basis_with_transformation_matrix(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool = false)
   G, A = standard_basis_with_sparse_transformation_matrix(I; ordering, complete_reduction)
-  return G, matrix(A)
+  return G, transpose(matrix(A))
 end
 
-# same as above, but returning a sparse matrix
+@doc raw"""
+    standard_basis_with_sparse_transformation_matrix(I::MPolyIdeal;
+      ordering::MonomialOrdering = default_ordering(base_ring(I)),
+      complete_reduction::Bool=false)
+
+Return a pair `G`, `T`, say, where `G` is a standard basis of `I` with respect to `ordering`, and `T` 
+is a sparse transformation matrix from `gens(I)` to `G`. That is, `T*gens(I) == gens(G)`.
+
+!!! note 
+    The matrix `T` here is the transpose of what you would get for the non-sparse version. This is a deliberate choice made for efficiency and compatibility with the conventions for sparse modules. 
+
+!!! note
+    The returned Gröbner basis is reduced if `ordering` is a global monomial ordering and `complete_reduction = true`.
+
+# Examples
+```jldoctest
+julia> R,(x,y) = polynomial_ring(QQ,[:x,:y]);
+
+julia> I = ideal([x*y^2-1,x^3+y^2+x*y]);
+
+julia> G, T = standard_basis_with_sparse_transformation_matrix(I, ordering=neglex(R))
+(Standard basis with 1 element w.r.t. neglex([x, y]), [-1; 0])
+
+julia> gens(G) == [sum(c*gen(I, k) for (k, c) in v; init=zero(R)) for v in T]
+true
+```
+"""
 function standard_basis_with_sparse_transformation_matrix(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool = false)
   complete_reduction && @assert is_global(ordering)
   G, A = _compute_standard_basis_with_sparse_transform(I.gens, ordering, complete_reduction)

--- a/src/Rings/groebner/transformation-matrix.jl
+++ b/src/Rings/groebner/transformation-matrix.jl
@@ -66,7 +66,7 @@ true
 """
 function standard_basis_with_transformation_matrix(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool = false)
   G, A = standard_basis_with_sparse_transformation_matrix(I; ordering, complete_reduction)
-  return G, transpose(matrix(A))
+  return G, matrix(A)
 end
 
 # same as above, but returning a sparse matrix

--- a/src/Rings/groebner/transformation-matrix.jl
+++ b/src/Rings/groebner/transformation-matrix.jl
@@ -65,8 +65,11 @@ true
 ```
 """
 function standard_basis_with_transformation_matrix(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool = false)
-  G, A = standard_basis_with_sparse_transformation_matrix(I; ordering, complete_reduction)
-  return G, transpose(matrix(A))
+  complete_reduction && @assert is_global(ordering)
+  G, m = _compute_standard_basis_with_transform(I.gens, ordering, complete_reduction)
+  G.isGB = true
+  I.gb[ordering]  = G
+  return G, m
 end
 
 @doc raw"""

--- a/src/Rings/groebner/transformation-matrix.jl
+++ b/src/Rings/groebner/transformation-matrix.jl
@@ -90,7 +90,7 @@ julia> R,(x,y) = polynomial_ring(QQ,[:x,:y]);
 julia> I = ideal([x*y^2-1,x^3+y^2+x*y]);
 
 julia> G, T = Oscar.standard_basis_with_sparse_transformation_matrix(I, ordering=neglex(R))
-(Standard basis with 1 element w.r.t. neglex([x, y]), [-1; 0])
+(Standard basis with 1 element w.r.t. neglex([x, y]), Sparse 1 x 2 matrix with 1 non-zero entries)
 
 julia> gens(G) == [sum(c*gen(I, k) for (k, c) in v; init=zero(R)) for v in T]
 true

--- a/src/Rings/groebner/transformation-matrix.jl
+++ b/src/Rings/groebner/transformation-matrix.jl
@@ -28,6 +28,7 @@ function _compute_standard_basis_with_transform(B::IdealGens, ordering::Monomial
   return IdealGens(R, istd), map_entries(R, m)
 end
 
+# same as above, but using a sparse matrix 
 function _compute_standard_basis_with_sparse_transform(B::IdealGens, ordering::MonomialOrdering, complete_reduction::Bool = false)
   istd, trans_mod = Singular.lift_std_sparse_transformation_matrix(singular_generators(B, ordering); 
                                                            complete_reduction)
@@ -64,11 +65,17 @@ true
 ```
 """
 function standard_basis_with_transformation_matrix(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool = false)
+  G, A = standard_basis_with_sparse_transformation_matrix(I; ordering, complete_reduction)
+  return G, matrix(A)
+end
+
+# same as above, but returning a sparse matrix
+function standard_basis_with_sparse_transformation_matrix(I::MPolyIdeal; ordering::MonomialOrdering = default_ordering(base_ring(I)), complete_reduction::Bool = false)
   complete_reduction && @assert is_global(ordering)
-  G, m = _compute_standard_basis_with_transform(I.gens, ordering, complete_reduction)
+  G, A = _compute_standard_basis_with_sparse_transform(I.gens, ordering, complete_reduction)
   G.isGB = true
-  I.gb[ordering]  = G
-  return G, m
+  I.gb[ordering] = G
+  return G, A
 end
 
 @doc raw"""

--- a/src/Rings/groebner/transformation-matrix.jl
+++ b/src/Rings/groebner/transformation-matrix.jl
@@ -89,7 +89,7 @@ julia> R,(x,y) = polynomial_ring(QQ,[:x,:y]);
 
 julia> I = ideal([x*y^2-1,x^3+y^2+x*y]);
 
-julia> G, T = standard_basis_with_sparse_transformation_matrix(I, ordering=neglex(R))
+julia> G, T = Oscar.standard_basis_with_sparse_transformation_matrix(I, ordering=neglex(R))
 (Standard basis with 1 element w.r.t. neglex([x, y]), [-1; 0])
 
 julia> gens(G) == [sum(c*gen(I, k) for (k, c) in v; init=zero(R)) for v in T]


### PR DESCRIPTION
This is a first take on #4925 . The issue on the Singular side (that `lift_std` should return a sparse matrix directly) has not yet been addressed. But these are the changes necessary to use sparse data types on the Oscar side. 

@ederc : Maybe we want similar things for ideals? I think there `lift_std` still returns a dense matrix. But if we want this, I could work on those parallel changes, too. 

For comparison: 
```julia
julia> R, (x, y) = graded_polynomial_ring(QQ, [:x, :y]);

julia> F = free_module(R, 1000);

julia> I, _ = sub(F, [x*g for x in gens(R) for g in gens(F)]);

julia> @time coordinates(x*y*F[1], I)
  1.774690 seconds (16.61 M allocations: 386.731 MiB, 35.32% gc time)
Sparse row with positions [1001] and values MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}[x]
```

Update: With the changes to @ederc 's PR to Singular.jl I now get 
```julia
julia> @time coordinates(x*y*F[1], I)
  0.143819 seconds (2.61 M allocations: 111.929 MiB)
Sparse row with positions [1001] and values MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}[x]
```
which is much better. I did not do the work on the ideals, yet. But this PR is now also self-contained for merging, so that we could also just go ahead with it, once we have the corresponding Singular release. 

Update: With further small changes to avoid unnecessary allocations I now get down to 
```julia
julia> @time coordinates(x*y*F[1], I)
  0.117115 seconds (354.84 k allocations: 8.426 MiB)
```