### PR TITLE
read_metadata: use JSON for reading metadata to preserve order

### DIFF
--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -51,8 +51,8 @@ end
 # FIXME: this function is exported but undocumented
 function read_metadata(filename::String)
   open(filename) do io
-    obj = JSON3.read(io)
-    println(JSON.json(obj[:meta], 2))
+    obj = JSON.lazy(io)
+    println(JSON.json(JSON.parse(obj[:meta]), 2))
   end
 end
 


### PR DESCRIPTION
Fixes failing doctests with JSON.jl version 1.5.0 (which added a default sorting, for objects which are not native JSON Objects).

Adding a `sort_keys` keyword or changing the output would make it dependent on the JSON version, this way it should be independent.
Using lazy parsing to avoid materializing the whole file as an object.