### PR TITLE
Fix parent of the generators of the ideal returned from `groebner_basis_f4` when used with `eliminate > 0`

### DIFF
--- a/experimental/AlgebraicStatistics/src/GraphicalModels.jl
+++ b/experimental/AlgebraicStatistics/src/GraphicalModels.jl
@@ -99,7 +99,6 @@ function generic_vanishing_ideal(GM::GraphicalModel; algorithm::Symbol = :elimin
       invariants = eliminate(I, elim_gens[1:ngens(R)])
     elseif algorithm == :f4
       invariants = ideal(groebner_basis_f4(I, eliminate=ngens(R)))
-      return invariants
     elseif algorithm == :markov
       o = lex(elim_ring)
       groebner_basis(I; ordering=o, algorithm=:markov)

--- a/experimental/AlgebraicStatistics/src/GraphicalModels.jl
+++ b/experimental/AlgebraicStatistics/src/GraphicalModels.jl
@@ -99,6 +99,7 @@ function generic_vanishing_ideal(GM::GraphicalModel; algorithm::Symbol = :elimin
       invariants = eliminate(I, elim_gens[1:ngens(R)])
     elseif algorithm == :f4
       invariants = ideal(groebner_basis_f4(I, eliminate=ngens(R)))
+      return invariants
     elseif algorithm == :markov
       o = lex(elim_ring)
       groebner_basis(I; ordering=o, algorithm=:markov)

--- a/src/Rings/groebner/f4.jl
+++ b/src/Rings/groebner/f4.jl
@@ -63,13 +63,15 @@ function groebner_basis_f4(
     AI   = AlgebraicSolving.Ideal(oscar_generators(I))
     if eliminate == 0
       AR = base_ring(I)
+      embedding = identity
     else
       vars = symbols(base_ring(I))[eliminate+1:end]
       AR,  = polynomial_ring(coefficient_ring(I), vars; cached=false)
+      embedding = hom(base_ring(I), AR, [repeat([zero(AR)], eliminate); gens(AR)])
     end
     ord  = degrevlex(AR)
     if length(AI.gens) == 0
-        GB = IdealGens(base_ring(I), singular_generators(I), complete_reduction)
+        GB = IdealGens(AR, [embedding(p) for p in singular_generators(I)], complete_reduction)
         GB.ord    = ord
         GB..isGB  = true
         GB.S.isGB = true
@@ -84,8 +86,8 @@ function groebner_basis_f4(
                     normalize = normalize,
                     truncate_lifting = truncate_lifting,
                     info_level = info_level)
-
-        GB = IdealGens(AR, AI.gb[eliminate], ord, keep_ordering = false,
+        
+        GB = IdealGens(AR, [embedding(p) for p in AI.gb[eliminate]], ord, keep_ordering = false,
                        isGB = true, isReduced = complete_reduction)
     end
     if eliminate == 0

--- a/src/Rings/groebner/f4.jl
+++ b/src/Rings/groebner/f4.jl
@@ -67,7 +67,7 @@ function groebner_basis_f4(
     else
       vars = symbols(base_ring(I))[eliminate+1:end]
       AR,  = polynomial_ring(coefficient_ring(I), vars; cached=false)
-      embedding = hom(base_ring(I), AR, [zeros(AR, eliminate); gens(AR)])
+      embedding = hom(base_ring(I), AR, [[zero(AR) for _ in 1:eliminate]; gens(AR)])
     end
     ord  = degrevlex(AR)
     if length(AI.gens) == 0

--- a/src/Rings/groebner/f4.jl
+++ b/src/Rings/groebner/f4.jl
@@ -67,7 +67,7 @@ function groebner_basis_f4(
     else
       vars = symbols(base_ring(I))[eliminate+1:end]
       AR,  = polynomial_ring(coefficient_ring(I), vars; cached=false)
-      embedding = hom(base_ring(I), AR, [repeat([zero(AR)], eliminate); gens(AR)])
+      embedding = hom(base_ring(I), AR, [zeros(AR, eliminate); gens(AR)])
     end
     ord  = degrevlex(AR)
     if length(AI.gens) == 0

--- a/test/Rings/groebner.jl
+++ b/test/Rings/groebner.jl
@@ -227,6 +227,7 @@ end
                 x3*x4^2 + 238609298*x4^3 + 14913081*x2*x4 + 56338306*x3*x4 + 129246702*x4^2 + 263464432*x2 + 260150414*x3 + 258493405*x4
                 x2*x4^2 + 89478486*x4^3 + 29826162*x2*x4 + 263464432*x3*x4 + 238609297*x4^2 + 141674270*x2 + 9942054*x3
                 x4^4 + 35851649*x4^3 + 232885084*x2*x4 + 251179133*x3*x4 + 231479137*x4^2 + 191484965*x2 + 85955250*x3 + 167408122*x4]
+
   @test elements(H) == G
   @test isdefined(I, :gb)
   @test Oscar.oscar_generators(I.gb[degrevlex(gens(base_ring(I)))]) == G
@@ -236,16 +237,19 @@ end
                 x3^3 + 156877866*x3*x4^2 + 59264971*x4^3 + 224858274*x3^2 + 183605206*x3*x4 + 130731555*x4^2 + 110395535*x3 + 158620953*x4
                 x4^4 + 167618101*x3*x4^2 + 102789335*x4^3 + 193931678*x3^2 + 156155981*x3*x4 + 60823186*x4^2 + 239040667*x3 + 127377432*x4
                 x3*x4^3 + 99215126*x3*x4^2 + 261328123*x4^3 + 132228634*x3^2 + 93598185*x3*x4 + 85654356*x4^2 + 3613010*x3 + 240673711*x4]
-  @test elements(H) == G
+
+  emb = hom(R, base_ring(H), [zeros(base_ring(H), 2); gens(base_ring(H))])
+
+  @test elements(H) == map(emb, G)
   @test length(I.gb) == 1
   # issue 5216
   R, (a,b,c,d,x,y,z,w) = polynomial_ring(QQ, ["a", "b", "c", "d", "x", "y", "z", "w"])
   I = ideal(R, [x - a*c, y - a*c*d, z - a*c^2 - b, w - a*c^2*d - b*d])
   H = groebner_basis_f4(I; eliminate=4);
-  H_x, H_y, H_z, H_w = gens(base_ring(H))
-  G = [-H_x * H_w + H_y * H_z]
-  @test elements(H) == G
-  @test parent(H_x) == base_ring(H)
+  G = [-x * w + y * z]
+  emb = hom(R, base_ring(H), [zeros(base_ring(H), 4); gens(base_ring(H))])
+  @test elements(H) == map(emb, G)
+  @test parent(first(gens(H))) == base_ring(H)
 
   I = ideal(R, [zero(R)])
   H = groebner_basis_f4(I; eliminate=4);

--- a/test/Rings/groebner.jl
+++ b/test/Rings/groebner.jl
@@ -242,8 +242,14 @@ end
   R, (a,b,c,d,x,y,z,w) = polynomial_ring(QQ, ["a", "b", "c", "d", "x", "y", "z", "w"])
   I = ideal(R, [x - a*c, y - a*c*d, z - a*c^2 - b, w - a*c^2*d - b*d])
   H = groebner_basis_f4(I; eliminate=4);
-  G= [-x*w + y*z]
+  H_x, H_y, H_z, H_w = gens(base_ring(H))
+  G = [-H_x * H_w + H_y * H_z]
   @test elements(H) == G
+  @test parent(H_x) == base_ring(H)
+
+  I = ideal(R, [zero(R)])
+  H = groebner_basis_f4(I; eliminate=4);
+  @test parent(first(gens(H))) == base_ring(H)
 end
 
 @testset "fglm" begin

--- a/test/Rings/groebner.jl
+++ b/test/Rings/groebner.jl
@@ -238,7 +238,7 @@ end
                 x4^4 + 167618101*x3*x4^2 + 102789335*x4^3 + 193931678*x3^2 + 156155981*x3*x4 + 60823186*x4^2 + 239040667*x3 + 127377432*x4
                 x3*x4^3 + 99215126*x3*x4^2 + 261328123*x4^3 + 132228634*x3^2 + 93598185*x3*x4 + 85654356*x4^2 + 3613010*x3 + 240673711*x4]
 
-  emb = hom(R, base_ring(H), [zeros(base_ring(H), 2); gens(base_ring(H))])
+  emb = hom(R, base_ring(H), [[zero(base_ring(H) for _ in 1:2)]; gens(base_ring(H))])
 
   @test elements(H) == map(emb, G)
   @test length(I.gb) == 1
@@ -247,7 +247,7 @@ end
   I = ideal(R, [x - a*c, y - a*c*d, z - a*c^2 - b, w - a*c^2*d - b*d])
   H = groebner_basis_f4(I; eliminate=4);
   G = [-x * w + y * z]
-  emb = hom(R, base_ring(H), [zeros(base_ring(H), 4); gens(base_ring(H))])
+  emb = hom(R, base_ring(H), [[zero(base_ring(H)) for _ in 1:4]; gens(base_ring(H))])
   @test elements(H) == map(emb, G)
   @test parent(first(gens(H))) == base_ring(H)
 

--- a/test/Rings/groebner.jl
+++ b/test/Rings/groebner.jl
@@ -238,7 +238,7 @@ end
                 x4^4 + 167618101*x3*x4^2 + 102789335*x4^3 + 193931678*x3^2 + 156155981*x3*x4 + 60823186*x4^2 + 239040667*x3 + 127377432*x4
                 x3*x4^3 + 99215126*x3*x4^2 + 261328123*x4^3 + 132228634*x3^2 + 93598185*x3*x4 + 85654356*x4^2 + 3613010*x3 + 240673711*x4]
 
-  emb = hom(R, base_ring(H), [[zero(base_ring(H) for _ in 1:2)]; gens(base_ring(H))])
+  emb = hom(R, base_ring(H), [[zero(base_ring(H)) for _ in 1:2]; gens(base_ring(H))])
 
   @test elements(H) == map(emb, G)
   @test length(I.gb) == 1


### PR DESCRIPTION
Adjustments so that the parent ring of the generators is the same as the base ring of the ideal after an f4 eliminate.