### PR TITLE
Make `is_principal_with_data` booktest presentable

### DIFF
--- a/test/book/cornerstones/number-theory/intro-v1.13.jlcon
+++ b/test/book/cornerstones/number-theory/intro-v1.13.jlcon
@@ -69,8 +69,8 @@ with 2-normal generators [2, a + 1]
 julia> preimage(m, P)
 Abelian group element [3]
 
-julia> fl, gen = is_principal_with_data(P^2); (fl, gen in [2,-2])
-(true, true)
+julia> is_principal_with_data(P^2)
+(true, 2)
 
 julia> P^2 == 2*OK
 true

--- a/test/book/cornerstones/number-theory/intro-v1.13.jlcon
+++ b/test/book/cornerstones/number-theory/intro-v1.13.jlcon
@@ -69,10 +69,10 @@ with 2-normal generators [2, a + 1]
 julia> preimage(m, P)
 Abelian group element [3]
 
-julia> fl, gen = is_principal_with_data(P^2); (fl, gen in [2,-2])
-(true, true)
+julia> fl, gen = is_principal_with_data(P^2); fl
+true
 
-julia> P^2 == 2*OK
+julia> P^2 == gen*OK == 2*OK
 true
 
 julia> U, mU = unit_group(OK);

--- a/test/book/cornerstones/number-theory/intro-v1.14.jlcon
+++ b/test/book/cornerstones/number-theory/intro-v1.14.jlcon
@@ -69,8 +69,8 @@ with 2-normal generators [2, a + 1]
 julia> preimage(m, P)
 Abelian group element [3]
 
-julia> fl, gen = is_principal_with_data(P^2); (fl, gen in [2,-2])
-(true, true)
+julia> is_principal_with_data(P^2)
+(true, -2)
 
 julia> P^2 == 2*OK
 true

--- a/test/book/cornerstones/number-theory/intro-v1.14.jlcon
+++ b/test/book/cornerstones/number-theory/intro-v1.14.jlcon
@@ -69,10 +69,10 @@ with 2-normal generators [2, a + 1]
 julia> preimage(m, P)
 Abelian group element [3]
 
-julia> fl, gen = is_principal_with_data(P^2); (fl, gen in [2,-2])
-(true, true)
+julia> fl, gen = is_principal_with_data(P^2); fl
+true
 
-julia> P^2 == 2*OK
+julia> P^2 == gen*OK == 2*OK
 true
 
 julia> U, mU = unit_group(OK);

--- a/test/book/cornerstones/number-theory/intro.jlcon
+++ b/test/book/cornerstones/number-theory/intro.jlcon
@@ -69,8 +69,8 @@ with 2-normal generators [2, a + 1]
 julia> preimage(m, P)
 Abelian group element [3]
 
-julia> fl, gen = is_principal_with_data(P^2); (fl, gen in [2,-2])
-(true, true)
+julia> is_principal_with_data(P^2)
+(true, -2)
 
 julia> P^2 == 2*OK
 true

--- a/test/book/cornerstones/number-theory/intro.jlcon
+++ b/test/book/cornerstones/number-theory/intro.jlcon
@@ -69,10 +69,10 @@ with 2-normal generators [2, a + 1]
 julia> preimage(m, P)
 Abelian group element [3]
 
-julia> fl, gen = is_principal_with_data(P^2); (fl, gen in [2,-2])
-(true, true)
+julia> fl, gen = is_principal_with_data(P^2); fl
+true
 
-julia> P^2 == 2*OK
+julia> P^2 == gen*OK == 2*OK
 true
 
 julia> U, mU = unit_group(OK);


### PR DESCRIPTION
The sign of the generator returned by `is_principal_with_data(P^2)` is not reproducible: it is constant within one Julia process but differs between fresh processes with identical Julia and package versions, even with the fixed random seed used by the booktests. So neither a fixed expected output nor Julia-version-specific variants can pin it down.

Replace the `gen in [2,-2]` workaround with code that reads naturally on the book website: show the principality flag, then verify the returned generator against the known one.

See oscar-system/book.oscar-system.org#54 for background.

Written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
