### PR TITLE
Actually enable serialization upgrade tests for 1.6.0 and 1.7.0 files

### DIFF
--- a/test/Serialization/upgrades/runtests.jl
+++ b/test/Serialization/upgrades/runtests.jl
@@ -71,7 +71,7 @@
   @testset "load files serialized with 1.7.0" begin
     test_upgrade_folder("version_1_7_0"; exclude=[
       # upgrading the following is tested in experimental/AlgebraicStatistics/test/serialization-upgrades.jl
-      "GroupbasedPhylogeneticModel",
+      "GroupBasedPhylogeneticModel",
     ])
   end
 end

--- a/test/Serialization/upgrades/runtests.jl
+++ b/test/Serialization/upgrades/runtests.jl
@@ -63,4 +63,15 @@
   @testset "load files serialized with 1.5.0" begin
     test_upgrade_folder("version_1_5_0")
   end
+
+  @testset "load files serialized with 1.6.0" begin
+    test_upgrade_folder("version_1_6_0")
+  end
+
+  @testset "load files serialized with 1.7.0" begin
+    test_upgrade_folder("version_1_7_0"; exclude=[
+      # upgrading the following is tested in experimental/AlgebraicStatistics/test/serialization-upgrades.jl
+      "GroupbasedPhylogeneticModel",
+    ])
+  end
 end

--- a/test/Serialization/upgrades/setup_tests.jl
+++ b/test/Serialization/upgrades/setup_tests.jl
@@ -8,7 +8,7 @@ if !isdefined(Main, :serialization_upgrade_test_path) ||
   !isdir(Main.serialization_upgrade_test_path) ||
   !isfile(joinpath(Main.serialization_upgrade_test_path, "LICENSE.md"))
 
-  serialization_upgrade_test_path = let commit_hash = "eb9f9dcd294e95c469c33ed8c588cdc6accc10c8"
+  serialization_upgrade_test_path = let commit_hash = "e3473ad614217bc19fad7f809de2d863984be157"
     tarball = Downloads.download("https://github.com/oscar-system/serialization-upgrade-tests/archive/$(commit_hash).tar.gz")
 
     destpath = open(CodecZlib.GzipDecompressorStream, tarball) do io


### PR DESCRIPTION
without this, the upgrade tests are never actually executed...