### PR TITLE
Combinatorics: added copy(::Graph)

### DIFF
--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -5,6 +5,10 @@ function pm_object(G::Graph{T}) where {T <: Union{Directed, Undirected}}
   return G.pm_graph
 end
 
+function copy(G::Graph{T}) where {T <: Union{Directed, Undirected}}
+    return Graph{T}(copy(pm_object(G)))
+end
+
 _directed_component(G::MixedGraph) = G.directed_component
 @doc raw"""
     directed_component(G::MixedGraph)

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -5,6 +5,15 @@ function pm_object(G::Graph{T}) where {T <: Union{Directed, Undirected}}
   return G.pm_graph
 end
 
+function copy(G::Graph{T}) where {T <: Union{Directed, Undirected}}
+    copyG = Graph{T}(copy(pm_object(G)))
+    attrs = AbstractAlgebra._get_attributes(G)
+    if !isnothing(attrs)
+        copyG.__attrs = copy(attrs)
+    end
+    return copyG
+end
+
 _directed_component(G::MixedGraph) = G.directed_component
 @doc raw"""
     directed_component(G::MixedGraph)

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -5,13 +5,26 @@ function pm_object(G::Graph{T}) where {T <: Union{Directed, Undirected}}
   return G.pm_graph
 end
 
-function copy(G::Graph{T}) where {T <: Union{Directed, Undirected}}
-    copyG = Graph{T}(copy(pm_object(G)))
-    attrs = AbstractAlgebra._get_attributes(G)
-    if !isnothing(attrs)
-        copyG.__attrs = copy(attrs)
+function _copy_labels(G::Graph{T}, G_copy::Graph{T}, labels::Vector{Symbol}) where T <: Union{Directed, Undirected}
+  for label in labels
+    graph_map = _graph_maps(G)[label]
+    new_vertex_labels = nothing
+    new_edge_labels = nothing
+    if !isnothing(graph_map.vertex_map)
+      new_vertex_labels = Dict(v => graph_map.vertex_map[v] for v in 1:n_vertices(G))
     end
-    return copyG
+
+    if !isnothing(graph_map.edge_map)
+      new_edge_labels = Dict((src(e), dst(e)) => graph_map.edge_map[e] for e in edges(G))
+    end
+    label!(G_copy, new_edge_labels, new_vertex_labels; name=label)
+  end
+end
+
+function copy(G::Graph{T}) where {T <: Union{Directed, Undirected}}
+  copyG = Graph{T}(copy(pm_object(G)))
+  !isempty(labelings(G)) && _copy_labels(G, copyG, labelings(G))
+  return copyG
 end
 
 _directed_component(G::MixedGraph) = G.directed_component

--- a/src/TropicalGeometry/TropicalPolyhedron/constructors.jl
+++ b/src/TropicalGeometry/TropicalPolyhedron/constructors.jl
@@ -36,8 +36,6 @@ convention(::TropicalPolyhedron{typeof(max)}) = max
 convention(::TropicalPointConfiguration{typeof(min)}) = min
 convention(::TropicalPointConfiguration{typeof(max)}) = max
 
-visualize(P::TropicalPolyhedron) = Polymake.visual(pm_object(P))
-
 tropical_convex_hull(P::TropicalPointConfiguration{M}) where {M<:MinOrMax} = TropicalPolyhedron{M}(pm_object(P))
 tropical_point_configuration(P::TropicalPolyhedron{M}) where {M<:MinOrMax} = TropicalPointConfiguration{M}(pm_object(P))
 

--- a/src/TropicalGeometry/TropicalPolyhedron/constructors.jl
+++ b/src/TropicalGeometry/TropicalPolyhedron/constructors.jl
@@ -36,6 +36,8 @@ convention(::TropicalPolyhedron{typeof(max)}) = max
 convention(::TropicalPointConfiguration{typeof(min)}) = min
 convention(::TropicalPointConfiguration{typeof(max)}) = max
 
+visualize(P::TropicalPolyhedron) = Polymake.visual(pm_object(P))
+
 tropical_convex_hull(P::TropicalPointConfiguration{M}) where {M<:MinOrMax} = TropicalPolyhedron{M}(pm_object(P))
 tropical_point_configuration(P::TropicalPolyhedron{M}) where {M<:MinOrMax} = TropicalPointConfiguration{M}(pm_object(P))
 

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -7,12 +7,17 @@
         add_edge!(g, 1, 2)
         @test n_edges(g) == 1
         @test has_edge(g, 1, 2)
+        h = copy(g)
         rem_edge!(g, 1, 2)
         @test n_edges(g) == 0
+        @test n_edges(h) == 1
         @test !has_edge(g, 1, 2)
+        @test has_edge(h, 1, 2)
         @test add_vertex!(g)
         @test n_vertices(g) == 6
+        @test n_vertices(h) == 5
         @test has_vertex(g, 6)
+        @test !has_vertex(h, 6)
         rem_vertex!(g, 1)
         @test n_vertices(g) == 5
         @test has_vertex(g, 1)

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -479,5 +479,9 @@
       @test G.label[2, 1] == 10
       @test G.label[1, 3] == 20
       @test G.color[2] == "red"
+
+      H = copy(G)
+      permute_nodes!(H, p)
+      @test G.label[1, 3] == H.label[2, 3]
     end
 end


### PR DESCRIPTION
Many operations for graphs work inplace, so I think it would be nice if there was a `copy` command for graphs:

```
julia> G = graph_from_edges([[1,2]])
Undirected graph with 2 nodes and the following edges:
(2, 1)

julia> H = G
Undirected graph with 2 nodes and the following edges:
(2, 1)

julia> collect(edges(H))
1-element Vector{Edge}:
 Edge(2, 1)

julia> rem_edge!(G,1,2)
true

julia> collect(edges(H))
Edge[]
```
