### PR TITLE
Initialize `isGB` and `is_reduced` in `ModuleGens` constructors as false

### DIFF
--- a/src/Modules/ModuleTypes.jl
+++ b/src/Modules/ModuleTypes.jl
@@ -188,6 +188,8 @@ Relative Gröbner / standard bases are also supported.
     r = new{T}()
     r.O = O
     r.F = F
+    r.isGB = false
+    r.is_reduced = false
     return r
   end
 
@@ -198,6 +200,8 @@ Relative Gröbner / standard bases are also supported.
     r.O = O
     r.SF = SF
     r.F = F
+    r.isGB = false
+    r.is_reduced = false
     return r
   end
 
@@ -211,6 +215,8 @@ Relative Gröbner / standard bases are also supported.
       r.SF = parent(s[1])
     end
     r.S = s
+    r.isGB = false
+    r.is_reduced = false
     return r
   end
 end


### PR DESCRIPTION
Fix #5935, by initializing the bitstype field `isGB` and `is_reduced` with false in all `ModuleGens` constructors.
