### PR TITLE
Allow converting `fpMatrix` to GAP matrix

### DIFF
--- a/src/GAP/oscar_to_gap.jl
+++ b/src/GAP/oscar_to_gap.jl
@@ -28,9 +28,8 @@ GAP.@install function GapObj(obj::AbstractAlgebra.Generic.MatSpaceElem{AbsSimple
 end
 
 ## matrix of elements of a finite field (of prime order)
-GAP.@install function GapObj(obj::fpMatrix)
-    p = Int(characteristic(base_ring(obj)))
-    e = GAP.Globals.Z(p)
+GAP.@install function GapObj(obj::Union{fpMatrix, FpMatrix})
+    e = GAP.Globals.Z(GapObj(characteristic(base_ring(obj))))
     return GapObj(lift(obj)) * e
 end
 

--- a/src/GAP/oscar_to_gap.jl
+++ b/src/GAP/oscar_to_gap.jl
@@ -30,7 +30,7 @@ end
 ## matrix of elements of a finite field (of prime order)
 GAP.@install function GapObj(obj::fpMatrix)
     p = Int(characteristic(base_ring(obj)))
-    e = GAP.Globals.(p)
+    e = GAP.Globals.Z(p)
     return GapObj(lift(obj)) * e
 end
 

--- a/src/GAP/oscar_to_gap.jl
+++ b/src/GAP/oscar_to_gap.jl
@@ -27,6 +27,15 @@ GAP.@install function GapObj(obj::AbstractAlgebra.Generic.MatSpaceElem{AbsSimple
     return GapObj(mat)
 end
 
+## matrix of elements of a finite field (of prime order)
+GAP.@install function GapObj(obj::fpMatrix)
+    p = Int(characteristic(base_ring(obj)))
+    e = GAP.Globals.(p)
+    return GapObj(lift(obj)) * e
+end
+
+
+
 function has_GapObj_with_GapObj(input; recursive::Bool = false)
   try
     res = GapObj(input, recursive = recursive)

--- a/test/GAP/oscar_to_gap.jl
+++ b/test/GAP/oscar_to_gap.jl
@@ -21,6 +21,12 @@ end
     @test_throws ArgumentError GAP.Obj(matrix(F, 1, 1, [z]))
 end
 
+@testset "fpMatrices" begin
+    F = Native.GF(5)
+    m = matrix(F, 4, 4, 1:16)
+    @test GAP.Obj(m) == GAP.evalstr("[ [ Z(5), Z(5)^2, Z(5)^0, Z(5)^3 ], [ 0*Z(5), Z(5), Z(5)^2, Z(5)^0 ], [ Z(5)^3, 0*Z(5), Z(5), Z(5)^2 ], [ Z(5)^0, Z(5)^3, 0*Z(5), Z(5) ] ]")
+end
+
 @testset "GapGroup and GapGroupElem" begin
     # `GapGroup` to GAP group, Perm
     G = symmetric_group(5)

--- a/test/GAP/oscar_to_gap.jl
+++ b/test/GAP/oscar_to_gap.jl
@@ -21,8 +21,14 @@ end
     @test_throws ArgumentError GAP.Obj(matrix(F, 1, 1, [z]))
 end
 
-@testset "fpMatrices" begin
+@testset "fpMatrix" begin
     F = Native.GF(5)
+    m = matrix(F, 4, 4, 1:16)
+    @test GAP.Obj(m) == GAP.evalstr("[ [ Z(5), Z(5)^2, Z(5)^0, Z(5)^3 ], [ 0*Z(5), Z(5), Z(5)^2, Z(5)^0 ], [ Z(5)^3, 0*Z(5), Z(5), Z(5)^2 ], [ Z(5)^0, Z(5)^3, 0*Z(5), Z(5) ] ]")
+end
+
+@testset "FpMatrix" begin
+    F = Native.GF(ZZ(5))
     m = matrix(F, 4, 4, 1:16)
     @test GAP.Obj(m) == GAP.evalstr("[ [ Z(5), Z(5)^2, Z(5)^0, Z(5)^3 ], [ 0*Z(5), Z(5), Z(5)^2, Z(5)^0 ], [ Z(5)^3, 0*Z(5), Z(5), Z(5)^2 ], [ Z(5)^0, Z(5)^3, 0*Z(5), Z(5) ] ]")
 end


### PR DESCRIPTION
This is a small step to addressing #5298. For matrices over other finite fields, we need to make sure we have a corresponding field on the GAP side; this will be addressed in a future PR.