### PR TITLE
Replace two uses of `MatrixElem` by `MatElem`

### DIFF
--- a/src/AlgebraicGeometry/Schemes/Sheaves/CoherentSheaves.jl
+++ b/src/AlgebraicGeometry/Schemes/Sheaves/CoherentSheaves.jl
@@ -1267,7 +1267,7 @@ function _trivializing_covering(M::AbsCoherentSheaf, U::AbsAffineScheme)
   return return_patches
 end
 
-@attr MatrixElem function _presentation_matrix(M::ModuleFP)
+@attr MatElem function _presentation_matrix(M::ModuleFP)
   return matrix(map(presentation(M), 1))
 end
 

--- a/test/Modules/MPolyQuo.jl
+++ b/test/Modules/MPolyQuo.jl
@@ -53,7 +53,7 @@ end
     F = FreeMod(R, 1)
     FF = FreeMod(Q, 1)
     f = hom(F, FF, gens(FF), phi)
-    @test matrix(f) isa MatrixElem
+    @test matrix(f) isa MatElem
 end
 
 @testset "Issues in #1806 part 3" begin


### PR DESCRIPTION
I suspect we can replace far more, but that should ideally be done
by people more familiar with the code.
