### PR TITLE
Add type annotations to some `load_object` methods

### DIFF
--- a/src/Serialization/Combinatorics.jl
+++ b/src/Serialization/Combinatorics.jl
@@ -96,7 +96,7 @@ function load_object(s::DeserializerState, T::Type{<:PhylogeneticTree}, params::
     load_from_polymake(Polymake.BigObject, Dict(s.obj))
   end
   vertex_perm = load_object(s, Vector{Int}, :vertex_perm)
-  PhylogeneticTree{QQFieldElem}(inner_object, vertex_perm)
+  return PhylogeneticTree{QQFieldElem}(inner_object, vertex_perm)
 end
 
 function load_object(s::DeserializerState, T::Type{<:PhylogeneticTree}, params::AbstractAlgebra.Floats{Float64})
@@ -104,5 +104,5 @@ function load_object(s::DeserializerState, T::Type{<:PhylogeneticTree}, params::
     load_from_polymake(Polymake.BigObject, Dict(s.obj))
   end
   vertex_perm = load_object(s, Vector{Int}, :vertex_perm)
-  PhylogeneticTree{Float64}(inner_object, vertex_perm)
+  return PhylogeneticTree{Float64}(inner_object, vertex_perm)
 end

--- a/src/Serialization/Fields.jl
+++ b/src/Serialization/Fields.jl
@@ -20,7 +20,7 @@ end
 function load_object(s::DeserializerState, ::Type{fpField})
   load_node(s) do str
     return fpField(parse(UInt64, str))
-  end
+  end::fpField
 end
 
 # elements
@@ -33,7 +33,7 @@ end
 function load_object(s::DeserializerState, ::Type{fpFieldElem}, F::fpField)
   load_node(s) do str
     return F(parse(UInt64, str))
-  end
+  end::fpFieldElem
 end
 
 ################################################################################
@@ -47,7 +47,7 @@ end
 function load_object(s::DeserializerState, ::Type{FpField})
   load_node(s) do str
     FpField(parse(ZZRingElem, str))
-  end
+  end::FpField
 end
 
 # elements
@@ -60,7 +60,7 @@ end
 function load_object(s::DeserializerState, ::Type{FpFieldElem}, F::FpField)
   load_node(s) do str
     F(parse(ZZRingElem, str))
-  end
+  end::FpFieldElem
 end
 
 ################################################################################
@@ -145,12 +145,12 @@ function save_object(s::SerializerState, K::FqField)
   end
 end
 
-function load_object(s::DeserializerState, ::Type{<: FqField}, params::PolyRing)
-  finite_field(load_object(s, PolyRingElem, params), cached=false)[1]
+function load_object(s::DeserializerState, ::Type{FqField}, params::PolyRing)
+  return finite_field(load_object(s, PolyRingElem, params), cached=false)[1]::FqField
 end
 
-function load_object(s::DeserializerState, ::Type{<: FqField})
-  finite_field(load_object(s, ZZRingElem, ZZRing()))[1]
+function load_object(s::DeserializerState, ::Type{FqField})
+  return finite_field(load_object(s, ZZRingElem, ZZRing()))[1]::FqField
 end
 
 # elements
@@ -169,13 +169,13 @@ function save_object(s::SerializerState, k::FqFieldElem)
   end
 end
 
-function load_object(s::DeserializerState, ::Type{<: FqFieldElem}, K::FqField)
+function load_object(s::DeserializerState, ::Type{FqFieldElem}, K::FqField)
   load_node(s) do _
     if absolute_degree(K) != 1
       return K(load_object(s, PolyRingElem, parent(defining_polynomial(K))))
     end
     K(load_object(s, ZZRingElem, ZZRing()))
-  end
+  end::FqFieldElem
 end
 
 ################################################################################

--- a/src/Serialization/basic_types.jl
+++ b/src/Serialization/basic_types.jl
@@ -22,8 +22,8 @@ end
 
 function load_object(s::DeserializerState, ::Type{Bool})
   load_node(s) do val
-    return val::Bool
-  end
+    return val
+  end::Bool
 end
 
 
@@ -36,7 +36,7 @@ load_object(s::DeserializerState, T::Type{ZZRingElem}, ::ZZRing) = load_object(s
 function load_object(s::DeserializerState, ::Type{ZZRingElem})
   load_node(s) do str
     return ZZRingElem(str)
-  end
+  end::ZZRingElem
 end
 
 ################################################################################
@@ -53,7 +53,7 @@ function load_object(s::DeserializerState, ::Type{QQFieldElem})
     fraction_parts = parse.(ZZRingElem, fraction_parts)
     
     return QQFieldElem(fraction_parts...)
-  end
+  end::QQFieldElem
 end
 
 ################################################################################


### PR DESCRIPTION
Julia cannot infer the return type through a `load_object` call in general.