### PR TITLE
Add missing argument assertion to `ideal_membership` and `radical_membership`

### DIFF
--- a/src/Rings/mpoly-ideals.jl
+++ b/src/Rings/mpoly-ideals.jl
@@ -1682,6 +1682,7 @@ false
 ```
 """
 function ideal_membership(f::T, I::MPolyIdeal{T}; ordering::MonomialOrdering = default_ordering(base_ring(I))) where T
+  @req parent(f) === base_ring(I) "Polynomial `f` and ideal `I` do not belong to the same polynomial ring."
   Sx = singular_polynomial_ring(I, ordering)
   return Singular.iszero(Singular.reduce(Sx(f), singular_groebner_generators(I, ordering)))
 end
@@ -1716,6 +1717,7 @@ false
 ```
 """
 function radical_membership(f::T, I::MPolyIdeal{T}) where T
+  @req parent(f) === base_ring(I) "Polynomial `f` and ideal `I` do not belong to the same polynomial ring."
   iszero(I) && return iszero(f)
   Sx = singular_polynomial_ring(I)
   return Singular.LibPolylib.rad_con(Sx(f), singular_generators(I)) == 1

--- a/test/Rings/mpoly.jl
+++ b/test/Rings/mpoly.jl
@@ -717,3 +717,17 @@ end
   @test all(is_zero(evaluate(g, [gen(parent(hg)), hg])) for hg in hg)
 end
 
+@testset "issue #5968" begin
+  R, (a,b,c) = QQ[:a,:b,:c]
+  Q, (d,e,f) = QQ[:d,:e,:f]
+  P, (u,v) = QQ[:u,:v]
+
+  I = ideal(R, [a,b,c])
+  J = ideal(P, [u,v])
+
+  @test_throws ArgumentError ideal_membership(d, I)
+  @test_throws ArgumentError ideal_membership(d, J)
+  @test_throws ArgumentError radical_membership(d, I)
+  @test_throws ArgumentError radical_membership(d, J)
+end
+


### PR DESCRIPTION
Fixes #5968 by adding the missing argument assertion  whether the polynomial `f` and ideal `I` belong to the same polynomial ring to the functions `ideal_membership(f, I)` and `radical_membership(f, I)` .