### PR TITLE
Add a modular algorithm for determinant of matrix over univariate polynomial rings over the integers

### DIFF
--- a/experimental/Parallel/src/Parallel.jl
+++ b/experimental/Parallel/src/Parallel.jl
@@ -290,4 +290,5 @@ function pmap(f::Any, wp::OscarWorkerPool, c; kwargs...)
   pmap(f, wp.wp, c; kwargs...)
 end
 
+include("determinants.jl")
 export oscar_worker_pool

--- a/experimental/Parallel/src/determinants.jl
+++ b/experimental/Parallel/src/determinants.jl
@@ -15,7 +15,7 @@ function modular_det(A::MatrixElem{T};
   # homogeneous parts of the rows of `A` for fixed degrees `dᵢ` 
   # per row. 
   bound = factorial(ZZ(m))*ZZ(maximum([maximum(abs.(coefficients(a)); init=0) for a in A]; init=0))^m
-  # Such determinants add up to the coefficient of tᵈwith as many 
+  # Such determinants add up to the coefficient of tᵈ with as many 
   # summands as there are possibilities for `Σᵢ dᵢ = d`. The following 
   # binomial coefficient is a significant overcount, but reliable 
   # bound of this.
@@ -24,7 +24,8 @@ function modular_det(A::MatrixElem{T};
   # Select primes until the above bound is reached. 
   primes = Int[next_prime(2^60)]
   primes_prod = one(ZZ)
-  while 2*primes_prod < bound
+  bound *= 2 # makes enough space on positive and negative axis
+  while primes_prod < bound
     p = next_prime(last(primes)+1)
     p in primes && continue
     push!(primes, p)

--- a/experimental/Parallel/src/determinants.jl
+++ b/experimental/Parallel/src/determinants.jl
@@ -23,11 +23,10 @@ function modular_det(A::MatrixElem{T};
 
   # Select primes until the above bound is reached. 
   primes = Int[next_prime(2^60)]
-  primes_prod = one(ZZ)
+  primes_prod = ZZ(only(primes))
   bound *= 2 # makes enough space on positive and negative axis
   while primes_prod < bound
     p = next_prime(last(primes)+1)
-    p in primes && continue
     push!(primes, p)
     primes_prod *= p
   end
@@ -40,10 +39,10 @@ function modular_det(A::MatrixElem{T};
   # Reconstruct the coefficients from chinese remaindering
   max_deg = maximum(degree(b) for b in dets; init=0)
   new_coeffs = sizehint!(ZZRingElem[], max_deg)
-  zz_primes = ZZ.(primes)
+  env = crt_env(ZZ.(primes))
   pp2 = div(primes_prod, 2)
   for i in 0:max_deg
-    c = crt([lift(ZZ, coeff(b, i)) for b in dets], zz_primes; check=false)
+    c = crt([lift(ZZ, coeff(b, i)) for b in dets], env)
     if c > pp2
       c -= primes_prod
     end

--- a/experimental/Parallel/src/determinants.jl
+++ b/experimental/Parallel/src/determinants.jl
@@ -1,7 +1,5 @@
 function modular_det(A::MatrixElem{T};
     wp::Union{OscarWorkerPool, Nothing}=nothing,
-    primes_bound=ZZ(1000)^6 # Experiments suggest that beyond this bound
-                            # modular arithmetic becomes slow again.
   ) where {T<:ZZPolyRingElem}
   m, n = size(A)
   m == n || error("matrix must be square")
@@ -23,26 +21,29 @@ function modular_det(A::MatrixElem{T};
   # bound of this.
   bound *= binomial(m-1+max_deg, max_deg)
 
-  # Select random primes until the above bound is reached. 
-  primes = ZZRingElem[]
+  # Select primes until the above bound is reached. 
+  primes = Int[next_prime(2^60)]
   primes_prod = one(ZZ)
   while 2*primes_prod < bound
-    p = next_prime(rand(ZZ, 0:primes_bound))
+    p = next_prime(last(primes)+1)
     p in primes && continue
     push!(primes, p)
     primes_prod *= p
   end
   
   # Compute determinants of the reduced matrices.
-  Bs = [map_entries(a->map_coefficients(GF(p), a)::FqPolyRingElem, A) for p in primes]
+  GFs = [Native.GF(p; cached=false) for p in primes]
+  Bs = [map_entries(a->map_coefficients(kk, a)::fpPolyRingElem, A) for kk in GFs]
   dets = isnothing(wp) ? [det(B) for B in Bs] : pmap(det, wp, Tuple(Bs))
 
   # Reconstruct the coefficients from chinese remaindering
   max_deg = maximum(degree(b) for b in dets; init=0)
   new_coeffs = sizehint!(ZZRingElem[], max_deg)
+  zz_primes = ZZ.(primes)
+  pp2 = div(primes_prod, 2)
   for i in 0:max_deg
-    c = crt([lift(ZZ, coeff(b, i)) for b in dets], primes; check=false)
-    if 2*c > primes_prod
+    c = crt([lift(ZZ, coeff(b, i)) for b in dets], zz_primes; check=false)
+    if c > pp2
       c -= primes_prod
     end
     push!(new_coeffs, c)

--- a/experimental/Parallel/src/determinants.jl
+++ b/experimental/Parallel/src/determinants.jl
@@ -1,0 +1,40 @@
+function modular_det(A::MatrixElem{T};
+    wp::Union{OscarWorkerPool, Nothing}=nothing,
+    primes_bound=1000000000
+  ) where {T<:ZZPolyRingElem}
+  m, n = size(A)
+  m == n || error("matrix must be square")
+  is_zero(m) && return one(ZZ)
+  is_one(m) && return A[1, 1]
+  bound = factorial(ZZ(m))*ZZ(maximum([maximum(abs.(coefficients(a)); init=0) for a in A]; init=0))^m
+  row_degs = [maximum([degree(a) for a in A[i, :]]; init=0) for i in 1:m]
+  max_deg = ZZ(sum(row_degs; init=0))
+  bound *= binomial(m-1+max_deg, max_deg)
+
+  primes = ZZRingElem[]
+  primes_prod = one(ZZ)
+  while 2*primes_prod < bound
+    p = next_prime(rand(ZZ, 0:primes_bound))
+    p in primes && continue
+    push!(primes, p)
+    primes_prod *= p
+  end
+  
+  Bs = [map_entries(a->map_coefficients(GF(p), a), A) for p in primes]
+  dets = isnothing(wp) ? [det(B) for B in Bs] : pmap(det, wp, Tuple(Bs))
+  # reconstruct the coefficients
+  max_deg = maximum(degree(b) for b in dets; init=0)
+  q = prod(primes; init=one(ZZ))
+  new_coeffs = sizehint!(ZZRingElem[], max_deg)
+  for i in 0:max_deg
+    c = crt([lift(ZZ, coeff(b, i)) for b in dets], primes; check=false)
+    if 2*c > q
+      c -= q
+    end
+    push!(new_coeffs, c)
+  end
+  P = base_ring(A)
+  return P(new_coeffs)
+end
+
+

--- a/experimental/Parallel/src/determinants.jl
+++ b/experimental/Parallel/src/determinants.jl
@@ -1,16 +1,29 @@
 function modular_det(A::MatrixElem{T};
     wp::Union{OscarWorkerPool, Nothing}=nothing,
-    primes_bound=1000000000
+    primes_bound=ZZ(1000)^6 # Experiments suggest that beyond this bound
+                            # modular arithmetic becomes slow again.
   ) where {T<:ZZPolyRingElem}
   m, n = size(A)
   m == n || error("matrix must be square")
   is_zero(m) && return one(ZZ)
   is_one(m) && return A[1, 1]
-  bound = factorial(ZZ(m))*ZZ(maximum([maximum(abs.(coefficients(a)); init=0) for a in A]; init=0))^m
+
+  # Determine a bound for the size of coefficients of the result.
   row_degs = [maximum([degree(a) for a in A[i, :]]; init=0) for i in 1:m]
   max_deg = ZZ(sum(row_degs; init=0))
+
+  # This first bound is for the size of the determinant over ZZ
+  # which arises for a single matrix `B` whose rows are the 
+  # homogeneous parts of the rows of `A` for fixed degrees `dᵢ` 
+  # per row. 
+  bound = factorial(ZZ(m))*ZZ(maximum([maximum(abs.(coefficients(a)); init=0) for a in A]; init=0))^m
+  # Such determinants add up to the coefficient of tᵈwith as many 
+  # summands as there are possibilities for `Σᵢ dᵢ = d`. The following 
+  # binomial coefficient is a significant overcount, but reliable 
+  # bound of this.
   bound *= binomial(m-1+max_deg, max_deg)
 
+  # Select random primes until the above bound is reached. 
   primes = ZZRingElem[]
   primes_prod = one(ZZ)
   while 2*primes_prod < bound
@@ -20,16 +33,17 @@ function modular_det(A::MatrixElem{T};
     primes_prod *= p
   end
   
-  Bs = [map_entries(a->map_coefficients(GF(p), a), A) for p in primes]
+  # Compute determinants of the reduced matrices.
+  Bs = [map_entries(a->map_coefficients(GF(p), a)::FqPolyRingElem, A) for p in primes]
   dets = isnothing(wp) ? [det(B) for B in Bs] : pmap(det, wp, Tuple(Bs))
-  # reconstruct the coefficients
+
+  # Reconstruct the coefficients from chinese remaindering
   max_deg = maximum(degree(b) for b in dets; init=0)
-  q = prod(primes; init=one(ZZ))
   new_coeffs = sizehint!(ZZRingElem[], max_deg)
   for i in 0:max_deg
     c = crt([lift(ZZ, coeff(b, i)) for b in dets], primes; check=false)
-    if 2*c > q
-      c -= q
+    if 2*c > primes_prod
+      c -= primes_prod
     end
     push!(new_coeffs, c)
   end

--- a/experimental/Parallel/src/determinants.jl
+++ b/experimental/Parallel/src/determinants.jl
@@ -1,16 +1,26 @@
+########################################################################
+# Code for computing determinants of matrices over ZZ[x].
+#
+# At the moment this is in experimental because of the option to use 
+# parallel methods. For the future we might want to port an 
+# implementation of this with the parallel methods stripped off to 
+# AbstractAlgebra. Comparison of timings and discussions where this 
+# can favourably be applied can be found on PR #5971. 
+########################################################################
 @doc raw"""
-    function modular_det(A::MatrixElem{T};
+    function det_modular_coeff_rec(A::MatrixElem{T};
         wp::Union{OscarWorkerPool, Nothing}=nothing,
         bound::Symbol=:GoldsteinGraham
       ) where {T<:ZZPolyRingElem}
 
-Compute the determinant of `A` by reducing `A` modulo primes and using the Chinese remainder theorem on the coefficients. 
+Compute the determinant of `A` via modular coefficient reconstruction, i.e. 
+by reducing `A` modulo primes and using the Chinese remainder theorem on the coefficients. 
 
 When `wp` is an `OscarWorkerPool`, the computation of determinants modulo primes is done in parallel on the workers
 The symbol `bound` can be set either to `:GoldsteinGraham`, or `:Naive` to select a way to compute a certified bound 
 for the selection of primes for reduction.
 """
-function modular_det(A::MatrixElem{T};
+function det_modular_coeff_rec(A::MatrixElem{T};
     wp::Union{OscarWorkerPool, Nothing}=nothing,
     bound::Symbol=:GoldsteinGraham
   ) where {T<:ZZPolyRingElem}

--- a/experimental/Parallel/src/determinants.jl
+++ b/experimental/Parallel/src/determinants.jl
@@ -1,26 +1,25 @@
+@doc raw"""
+    function modular_det(A::MatrixElem{T};
+        wp::Union{OscarWorkerPool, Nothing}=nothing,
+        bound::Symbol=:GoldsteinGraham
+      ) where {T<:ZZPolyRingElem}
+
+Compute the determinant of `A` by reducing `A` modulo primes and using the Chinese remainder theorem on the coefficients. 
+
+When `wp` is an `OscarWorkerPool`, the computation of determinants modulo primes is done in parallel on the workers
+The symbol `bound` can be set either to `:GoldsteinGraham`, or `:Naive` to select a way to compute a certified bound 
+for the selection of primes for reduction.
+"""
 function modular_det(A::MatrixElem{T};
     wp::Union{OscarWorkerPool, Nothing}=nothing,
+    bound::Symbol=:GoldsteinGraham
   ) where {T<:ZZPolyRingElem}
   m, n = size(A)
   m == n || error("matrix must be square")
   is_zero(m) && return one(ZZ)
   is_one(m) && return A[1, 1]
 
-  # Determine a bound for the size of coefficients of the result.
-  row_degs = [maximum([degree(a) for a in A[i, :]]; init=0) for i in 1:m]
-  max_deg = ZZ(sum(row_degs; init=0))
-
-  # This first bound is for the size of the determinant over ZZ
-  # which arises for a single matrix `B` whose rows are the 
-  # homogeneous parts of the rows of `A` for fixed degrees `dᵢ` 
-  # per row. 
-  bound = factorial(ZZ(m))*ZZ(maximum([maximum(abs.(coefficients(a)); init=0) for a in A]; init=0))^m
-  # Such determinants add up to the coefficient of tᵈ with as many 
-  # summands as there are possibilities for `Σᵢ dᵢ = d`. The following 
-  # binomial coefficient is a significant overcount, but reliable 
-  # bound of this.
-  bound *= binomial(m-1+max_deg, max_deg)
-
+  bound = _det_height_bound(Val{bound}, A)
   # Select primes until the above bound is reached. 
   primes = Int[next_prime(2^60)]
   primes_prod = ZZ(only(primes))
@@ -52,4 +51,39 @@ function modular_det(A::MatrixElem{T};
   return P(new_coeffs)
 end
 
+# Functionality for implementing the bound given in
+# https://doi.org/10.1137/1016065
+#
+# This could be more general but hadamard_bound2 is restricted to ZZPolyRingElem
+# To apply to a matrix containing QQPolyRingElem, one must clear denoms & convert to ZZPolyRingElem.
+function _det_height_bound(::Type{Val{:GoldsteinGraham}}, M::MatrixElem{ZZPolyRingElem})
+  is_square(M) || error("Matrix must be square");
+  is_empty(M)  &&  return one(base_ring(M));
+  M2 = map(_norm_1, M);
+  B2 = min(hadamard_bound2(M2), hadamard_bound2(transpose(M2)));
+  return 1+isqrt(B2);
+end
+
+function _norm_1(f::PolyRingElem)
+  return sum(abs(c) for c in coefficients(f); init=abs(zero(coefficient_ring(parent(f)))))
+end
+
+
+# A naive bound for the absolute value of the coefficients of `det(A)` for a matrix
+# over the ring of univariate polynomials
+function _det_height_bound(::Type{Val{:Naive}}, A::MatrixElem{ZZPolyRingElem})
+  row_degs = [maximum([degree(a) for a in A[i, :]]; init=0) for i in 1:m]
+  max_deg = ZZ(sum(row_degs; init=0))
+  # This first bound is for the size of the determinant over ZZ
+  # which arises for a single matrix `B` whose rows are the 
+  # homogeneous parts of the rows of `A` for fixed degrees `dᵢ` 
+  # per row. 
+  bound = factorial(ZZ(m))*ZZ(maximum([maximum(abs.(coefficients(a)); init=0) for a in A]; init=0))^m
+  # Such determinants add up to the coefficient of tᵈ with as many 
+  # summands as there are possibilities for `Σᵢ dᵢ = d`. The following 
+  # binomial coefficient is a significant overcount, but reliable 
+  # bound of this.
+  bound *= binomial(m-1+max_deg, max_deg)
+  return bound
+end
 

--- a/experimental/Parallel/src/determinants.jl
+++ b/experimental/Parallel/src/determinants.jl
@@ -8,7 +8,7 @@
 # can favourably be applied can be found on PR #5971. 
 ########################################################################
 @doc raw"""
-    function det_modular_coeff_rec(A::MatrixElem{T};
+    function det_modular_coeff_rec(A::MatElem{T};
         wp::Union{OscarWorkerPool, Nothing}=nothing,
         bound::Symbol=:GoldsteinGraham
       ) where {T<:ZZPolyRingElem}
@@ -20,7 +20,7 @@ When `wp` is an `OscarWorkerPool`, the computation of determinants modulo primes
 The symbol `bound` can be set either to `:GoldsteinGraham`, or `:Naive` to select a way to compute a certified bound 
 for the selection of primes for reduction.
 """
-function det_modular_coeff_rec(A::MatrixElem{T};
+function det_modular_coeff_rec(A::MatElem{T};
     wp::Union{OscarWorkerPool, Nothing}=nothing,
     bound::Symbol=:GoldsteinGraham
   ) where {T<:ZZPolyRingElem}
@@ -66,7 +66,7 @@ end
 #
 # This could be more general but hadamard_bound2 is restricted to ZZPolyRingElem
 # To apply to a matrix containing QQPolyRingElem, one must clear denoms & convert to ZZPolyRingElem.
-function _det_height_bound(::Type{Val{:GoldsteinGraham}}, M::MatrixElem{ZZPolyRingElem})
+function _det_height_bound(::Type{Val{:GoldsteinGraham}}, M::MatElem{ZZPolyRingElem})
   is_square(M) || error("Matrix must be square");
   is_empty(M)  &&  return one(base_ring(M));
   M2 = map(_norm_1, M);
@@ -81,7 +81,7 @@ end
 
 # A naive bound for the absolute value of the coefficients of `det(A)` for a matrix
 # over the ring of univariate polynomials
-function _det_height_bound(::Type{Val{:Naive}}, A::MatrixElem{ZZPolyRingElem})
+function _det_height_bound(::Type{Val{:Naive}}, A::MatElem{ZZPolyRingElem})
   row_degs = [maximum([degree(a) for a in A[i, :]]; init=0) for i in 1:m]
   max_deg = ZZ(sum(row_degs; init=0))
   # This first bound is for the size of the determinant over ZZ

--- a/experimental/Parallel/src/determinants.jl
+++ b/experimental/Parallel/src/determinants.jl
@@ -8,7 +8,7 @@
 # can favourably be applied can be found on PR #5971. 
 ########################################################################
 @doc raw"""
-    function det_modular_coeff_rec(A::MatElem{T};
+    det_modular_coeff_rec(A::MatElem{T};
         wp::Union{OscarWorkerPool, Nothing}=nothing,
         bound::Symbol=:GoldsteinGraham
       ) where {T<:ZZPolyRingElem}
@@ -25,8 +25,8 @@ function det_modular_coeff_rec(A::MatElem{T};
     bound::Symbol=:GoldsteinGraham
   ) where {T<:ZZPolyRingElem}
   m, n = size(A)
-  m == n || error("matrix must be square")
-  is_zero(m) && return one(ZZ)
+  @req is_square(A) "matrix must be square"
+  is_zero(m) && return one(base_ring(A))
   is_one(m) && return A[1, 1]
 
   bound = _det_height_bound(Val{bound}, A)
@@ -47,11 +47,16 @@ function det_modular_coeff_rec(A::MatElem{T};
 
   # Reconstruct the coefficients from chinese remaindering
   max_deg = maximum(degree(b) for b in dets; init=0)
-  new_coeffs = sizehint!(ZZRingElem[], max_deg)
+  max_deg < 0 && return zero(base_ring(A))
+  new_coeffs = sizehint!(ZZRingElem[], max_deg+1)
   env = crt_env(ZZ.(primes))
   pp2 = div(primes_prod, 2)
   for i in 0:max_deg
     c = crt([lift(ZZ, coeff(b, i)) for b in dets], env)
+    # TODO: We might want to use the `signed` option for `crt` here. 
+    # But that is not yet available in Hecke for this signature with 
+    # an `crt_env`, so we will postpone this until we have a new 
+    # version of Hecke to support this. 
     if c > pp2
       c -= primes_prod
     end
@@ -67,17 +72,13 @@ end
 # This could be more general but hadamard_bound2 is restricted to ZZPolyRingElem
 # To apply to a matrix containing QQPolyRingElem, one must clear denoms & convert to ZZPolyRingElem.
 function _det_height_bound(::Type{Val{:GoldsteinGraham}}, M::MatElem{ZZPolyRingElem})
-  is_square(M) || error("Matrix must be square");
-  is_empty(M)  &&  return one(base_ring(M));
-  M2 = map(_norm_1, M);
-  B2 = min(hadamard_bound2(M2), hadamard_bound2(transpose(M2)));
-  return 1+isqrt(B2);
+  is_square(M) || error("Matrix must be square")
+  is_empty(M)  &&  return one(base_ring(M))
+  # compute the matrix of 1-norms of the entries
+  M2 = map(f->sum(abs(c) for c in coefficients(f); init=zero(ZZ))::ZZRingElem, M)
+  B2 = min(hadamard_bound2(M2), hadamard_bound2(transpose(M2)))
+  return 1+isqrt(B2)
 end
-
-function _norm_1(f::PolyRingElem)
-  return sum(abs(c) for c in coefficients(f); init=abs(zero(coefficient_ring(parent(f)))))
-end
-
 
 # A naive bound for the absolute value of the coefficients of `det(A)` for a matrix
 # over the ring of univariate polynomials

--- a/experimental/Parallel/test/OscarWorkerPool.jl
+++ b/experimental/Parallel/test/OscarWorkerPool.jl
@@ -50,4 +50,17 @@
   yield()
 end
 
+@testset "modular determinants" begin
+  using Distributed
+  oscar_worker_pool(1) do wp
+    P, t = ZZ[:t]
+    m = 5 # from m = 12 it starts to get interesting in terms of timings
+    A = matrix_space(P, m, m)([rand(P, 1:100, -1000:1000) for _ in 1:m, _ in 1:m]);
+    @test det(A) == Oscar.modular_det(A)
+    @test det(A) == Oscar.modular_det(A; wp)
+  end
+  sleep(2)
+  yield()
+end
+
   

--- a/experimental/Parallel/test/OscarWorkerPool.jl
+++ b/experimental/Parallel/test/OscarWorkerPool.jl
@@ -56,8 +56,8 @@ end
     P, t = ZZ[:t]
     m = 5 # from m = 12 it starts to get interesting in terms of timings
     A = matrix_space(P, m, m)([rand(P, 1:100, -1000:1000) for _ in 1:m, _ in 1:m]);
-    @test det(A) == Oscar.modular_det(A)
-    @test det(A) == Oscar.modular_det(A; wp)
+    @test det(A) == Oscar.det_modular_coeff_rec(A)
+    @test det(A) == Oscar.det_modular_coeff_rec(A; wp)
   end
   sleep(2)
   yield()


### PR DESCRIPTION
Ping @antonydellavecchia , @JohnAAbbott 

As already mentioned in conversation with the two of you, I found the determinants of matrices over `ZZ[t]` to be rather slow. This is an experimental modular method which has proved rather useful in recent computations of discriminants. You can play around with `m` in the tests. From `m=12` and upwards the classical determinant has problems. Speedups for parallel methods become visible from `m=20`. 

Let me know what you think. 