### PR TITLE
Remove obsolete pretty printing for IJulia notebooks, that errors with recent IJulia versions

### DIFF
--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -214,8 +214,6 @@ const PROJECT_UUID = Base.PkgId(@__MODULE__).uuid
 
 const is_dev = occursin("-dev", lowercase(string(VERSION_NUMBER)))
 
-const IJuliaMime = Union{MIME"text/latex", MIME"text/html"}
-
 const oscardir = Base.pkgdir(Oscar)
 
 function example(s::String)

--- a/src/Rings/mpoly.jl
+++ b/src/Rings/mpoly.jl
@@ -21,24 +21,6 @@ end
 _variables_for_singular(S::Vector{Symbol}) = _variables_for_singular(length(S))
 
 
-######################################################################
-# pretty printing for iJulia notebooks..
-#
-
-function Base.show(io::IO, mime::IJuliaMime, R::MPolyRing)
-  io = IOContext(io, :compact => true)
-  print(io, "\$")
-  math_html(io, R)
-  print(io, "\$")
-end
-
-function math_html(io::IO, R::MPolyRing)
-  print(io, "\\text{Multivariate Polynomial Ring in $(nvars(R)) variables:} ")
-  math_html(io, gens(R))
-  print(io, "\\text{ over }")
-  math_html(io, base_ring(R))
-end
-
 ###################################################
 
 using .Orderings


### PR DESCRIPTION
The removed code appears to not do anything (`math_html` is defined in https://github.com/thofma/Hecke.jl/blob/master/src/Misc/IJulia.jl , but not exported), but causes problems with newer IJulia :


```julia
MethodError: no method matching math_html(::IOContext{IOBuffer}, ::Vector{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}})
The function `math_html` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  math_html(::IO, ::MPolyRing)
   @ Oscar ~/Programs/git/Github/Oscar.jl/src/Rings/mpoly.jl:35


Stacktrace:
  [1] math_html(io::IOContext{IOBuffer}, R::MPolyDecRing{QQFieldElem, QQMPolyRing})
    @ Oscar ~/Programs/git/Github/Oscar.jl/src/Rings/mpoly.jl:37
  [2] show(io::IOContext{IOBuffer}, mime::MIME{Symbol("text/html")}, R::MPolyDecRing{QQFieldElem, QQMPolyRing})
    @ Oscar ~/Programs/git/Github/Oscar.jl/src/Rings/mpoly.jl:28
  [3] limitstringmime(mime::MIME{Symbol("text/html")}, x::Any, forcetext::Bool)
    @ IJulia ~/Programs/git/Github/TutorialTesterforOscar/.julia/packages/IJulia/Vl5w1/src/inline.jl:56
  [4] limitstringmime
    @ ~/Programs/git/Github/TutorialTesterforOscar/.julia/packages/IJulia/Vl5w1/src/inline.jl:51 [inlined]
  [5] display_mimestring(m::MIME{Symbol("text/html")}, x::Any)
    @ IJulia ~/Programs/git/Github/TutorialTesterforOscar/.julia/packages/IJulia/Vl5w1/src/display.jl:80
  [6] display_mimestring(mime_array::Vector{MIME}, x::Any)
    @ IJulia ~/Programs/git/Github/TutorialTesterforOscar/.julia/packages/IJulia/Vl5w1/src/display.jl:74
  [7] _display_dict(x::Any)
    @ IJulia ~/Programs/git/Github/TutorialTesterforOscar/.julia/packages/IJulia/Vl5w1/src/display.jl:109
  [8] display_dict(x::Any)
    @ IJulia ~/Programs/git/Github/TutorialTesterforOscar/.julia/packages/IJulia/Vl5w1/src/display.jl:133
  [9] execute_request(socket::ZMQ.Socket, kernel::IJulia.Kernel, msg::IJulia.Msg)
    @ IJulia ~/Programs/git/Github/TutorialTesterforOscar/.julia/packages/IJulia/Vl5w1/src/execute_request.jl:181
 [10] eventloop(socket::ZMQ.Socket, kernel::IJulia.Kernel)
    @ IJulia ~/Programs/git/Github/TutorialTesterforOscar/.julia/packages/IJulia/Vl5w1/src/eventloop.jl:26
 [11] (::IJulia.var"#waitloop##2#waitloop##3"{IJulia.Kernel})()
    @ IJulia ~/Programs/git/Github/TutorialTesterforOscar/.julia/packages/IJulia/Vl5w1/src/eventloop.jl:71

```