### PR TITLE
Improve tensor and adjunction

### DIFF
--- a/docs/src/AlgebraicGeometry/Surfaces/AdjunctionProcess.md
+++ b/docs/src/AlgebraicGeometry/Surfaces/AdjunctionProcess.md
@@ -44,6 +44,12 @@ exceptional cases. In particular, if  $X$ has non-negative Kodaira dimension, th
 
 ## Adjunction Process
 
+In each adjunction step, the implementation needs only a presentation matrix of the canonical module. By default, `adjunction_process` uses `canonical_algorithm = :fast`: it first tries to extract this matrix directly from the codimension step of a minimal free resolution of the homogeneous coordinate ring. If this direct presentation is certified, OSCAR uses it even when it has quadratic or higher-degree entries; then the adjunction process stops, because the implemented adjoint matrix construction requires a linear presentation.
+
+If the direct presentation is not certified and the surface has codimension two in projective 4-space, the default `:fast` strategy next tries a complete-intersection linkage computation. Given a complete intersection `J = (f, g)` contained in the surface ideal and the residual ideal `L = J : I_X`, the method uses the liaison description of the canonical module through `L/J`. It computes only the finite-dimensional multiplication map `S_1 \otimes (L/J)_{deg(f)+deg(g)-4} -> (L/J)_{deg(f)+deg(g)-3}` and converts its kernel into the linear presentation matrix needed by the adjoint-matrix construction.
+
+Using `canonical_algorithm = :module` yields the generic construction. Use `canonical_algorithm = :direct` when testing or benchmarking the direct extraction; in this mode an error is raised instead of falling back. Use `canonical_algorithm = :linkage_linear_strand` to force the complete-intersection linkage linear-strand computation.
+
 What we describe here goes back to joint work of Wolfram Decker and Frank-Olaf Schreyer. See [DES93](@cite),  [DS00](@cite).
 
 ```@docs
@@ -58,4 +64,3 @@ Please direct questions about this part of OSCAR to the following people:
 You can ask questions in the [OSCAR Slack](https://www.oscar-system.org/community/#slack).
 
 Alternatively, you can [raise an issue on github](https://www.oscar-system.org/community/#how-to-report-issues).
-

--- a/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Morphisms/simplified_complexes.jl
@@ -668,7 +668,11 @@ end
 ### Helper functions
 function _make_free_module(M::OFPModule, g::Vector{T}) where {T<:OFPModuleElem}
   if is_graded(M)
-    w = _degree_fast.(g)
+    if length(g) == ngens(M) && all(i -> parent(g[i]) === M && g[i] == gen(M, i), 1:ngens(M))
+      w = degrees_of_generators(M)
+    else
+      w = _degree_fast.(g)
+    end
     return graded_free_module(base_ring(M), w)
   else
     return FreeMod(base_ring(M), length(g))

--- a/src/AlgebraicGeometry/Surfaces/AdjunctionProcess/AdjunctionProcess.jl
+++ b/src/AlgebraicGeometry/Surfaces/AdjunctionProcess/AdjunctionProcess.jl
@@ -131,6 +131,151 @@ function _adjoint_matrix(D::AbstractAlgebra.Generic.MatSpaceElem)
      return transpose(map(projRPP, MM))
 end
 
+function _zero_matrix_for_adjunction(R, ncols::Int)
+   return matrix(R, 0, ncols, elem_type(R)[])
+end
+
+function _matrix_has_no_quadratic_or_higher_entries(D::AbstractAlgebra.Generic.MatSpaceElem)
+   return !any(x -> !is_zero(x) && total_degree(x) > 1, Oscar._vec(D))
+end
+
+function _matrix_has_only_linear_or_zero_entries(D::AbstractAlgebra.Generic.MatSpaceElem)
+   return !any(x -> !is_zero(x) && total_degree(x) != 1, Oscar._vec(D))
+end
+
+function _canonical_resolution_data(X::AbsProjectiveVariety)
+   Pn = ambient_coordinate_ring(X)
+   A = homogeneous_coordinate_ring(X)
+   FA, _ = free_resolution(SimpleFreeResolution, A)
+   C_simp = simplify(FA)
+   return Pn, C_simp, ngens(Pn) - 1, Int(codim(X))
+end
+
+function _is_zero_free_module_for_adjunction(M)
+   try
+      return rank(M) == 0
+   catch
+   end
+   try
+      return ngens(M) == 0
+   catch
+   end
+   try
+      return is_zero(M)
+   catch
+   end
+   try
+      return iszero(M)
+   catch
+   end
+   return false
+end
+
+function _resolution_stops_after_codimension(C, c::Int)
+   try
+      cf = chain_factory(original_complex(C))
+      if hasfield(typeof(cf), :map_cache) && length(cf.map_cache) >= c + 1
+         return _is_zero_free_module_for_adjunction(domain(cf.map_cache[c + 1]))
+      end
+   catch
+   end
+   return false
+end
+
+function _canonical_homology_subquotient_from_resolution(Pn, C_simp, n::Int, c::Int)
+   C_shift = shift(C_simp, c)
+   OmegaPn = graded_free_module(Pn, [n + 1])
+   D = hom(C_shift, OmegaPn)
+   D_simp = simplify(D)
+   Z, _ = kernel(D_simp, 0)
+   B, _ = boundary(D_simp, 0)
+   return SubquoModule(D_simp[0], ambient_representatives_generators(Z), ambient_representatives_generators(B))
+end
+
+function _canonical_homology_subquotient(X::AbsProjectiveVariety)
+   Pn, C_simp, n, c = _canonical_resolution_data(X)
+   return _canonical_homology_subquotient_from_resolution(Pn, C_simp, n, c)
+end
+
+function _free_cover_map_for_adjunction(F0, SQ)
+   if is_graded(F0) && is_graded(SQ)
+      return graded_map(
+         F0, SQ, gens(SQ);
+         check = false,
+         hom_degree = zero(grading_group(base_ring(F0))),
+         generators_map_to_generators = true
+      )
+   end
+   phi = hom(F0, SQ, gens(SQ); check = false)
+   phi.generators_map_to_generators = true
+   return phi
+end
+
+function _matrix_from_subquotient_generators_for_adjunction(K, F0)
+   R = base_ring(F0)
+   V_all = ambient_representatives_generators(K)
+   W_all = degrees_of_generators(K; check = false)
+   keep = findall(!is_zero, V_all)
+   isempty(keep) && return _zero_matrix_for_adjunction(R, ngens(F0))
+   V = V_all[keep]
+   W = W_all[keep]
+   F1 = is_graded(F0) ? graded_free_module(R, W) : free_module(R, length(V))
+   return matrix(hom(F1, F0, V; check = false, hom_degree = is_graded(F0) ? zero(grading_group(R)) : nothing))
+end
+
+function _canonical_presentation_matrix_from_subquotient_cover(SQ::SubquoModule)
+   R = base_ring(SQ)
+   F0 = graded_free_module(R, degrees_of_generators(SQ; check = false))
+   eps = _free_cover_map_for_adjunction(F0, SQ)
+   K, _ = kernel(eps)
+   return _matrix_from_subquotient_generators_for_adjunction(K, F0)
+end
+
+function _canonical_presentation_matrix_homology_from_resolution(Pn, C_simp, n::Int, c::Int; repair::Bool = true)
+   SQ = _canonical_homology_subquotient_from_resolution(Pn, C_simp, n, c)
+   D = _canonical_presentation_matrix_from_subquotient_cover(SQ)
+   if repair && !_matrix_has_only_linear_or_zero_entries(D)
+      P = presentation(SQ; minimal = true)
+      return matrix(map(P, 1))
+   end
+   return D
+end
+
+function _canonical_presentation_matrix_direct_from_resolution(Pn, C_simp, c::Int; require_linear::Bool = true)
+   c == 0 && return _zero_matrix_for_adjunction(Pn, 1)
+   D = transpose(matrix(map(C_simp, c)))
+   _resolution_stops_after_codimension(C_simp, c) || return nothing
+   require_linear && !_matrix_has_only_linear_or_zero_entries(D) && return nothing
+   return D
+end
+
+function _canonical_presentation_matrix_via_module(X::AbsProjectiveVariety)
+   Omega = canonical_bundle(X)
+   FOmega = free_resolution(Omega, length = 1, algorithm = :mres)
+   return matrix(map(FOmega, 1))
+end
+
+function _canonical_presentation_matrix_for_adjunction(X::AbsProjectiveVariety; algorithm::Symbol = :fast)
+   algorithm == :module && return _canonical_presentation_matrix_via_module(X)
+   Pn, C_simp, n, c = _canonical_resolution_data(X)
+   if algorithm == :direct
+      D = _canonical_presentation_matrix_direct_from_resolution(Pn, C_simp, c; require_linear = true)
+      D !== nothing && return D
+      error("The direct canonical presentation is not certified as a linear adjunction matrix for this embedding.")
+   elseif algorithm == :homology
+      return _canonical_presentation_matrix_homology_from_resolution(Pn, C_simp, n, c; repair = false)
+   elseif algorithm == :minimal_homology
+      SQ = _canonical_homology_subquotient_from_resolution(Pn, C_simp, n, c)
+      P = presentation(SQ; minimal = true)
+      return matrix(map(P, 1))
+   elseif algorithm == :fast
+      D = _canonical_presentation_matrix_direct_from_resolution(Pn, C_simp, c; require_linear = true)
+      D !== nothing && return D
+      return _canonical_presentation_matrix_homology_from_resolution(Pn, C_simp, n, c; repair = true)
+   end
+   error("Unsupported canonical presentation algorithm $(algorithm). Use :fast, :direct, :homology, :minimal_homology, or :module.")
+end
+
 @doc raw"""
     canonical_bundle(X::AbsProjectiveVariety)
 
@@ -195,19 +340,7 @@ SubquoModule{MPolyDecRingElem{fpFieldElem, fpMPolyRingElem}}
 ```
 """
 function canonical_bundle(X::AbsProjectiveVariety)
-  Pn = ambient_coordinate_ring(X)
-  A = homogeneous_coordinate_ring(X)
-  n = ngens(Pn)-1
-  c = codim(X)
-  FA, _ = free_resolution(SimpleFreeResolution, A)
-  C_simp = simplify(FA)
-  C_shift = shift(C_simp, c)
-  OmegaPn = graded_free_module(Pn, [n+1])
-  D = hom(C_shift, OmegaPn)
-  D_simp = simplify(D)
-  Z, inc = kernel(D_simp, 0)
-  B, inc_B = boundary(D_simp, 0)
-  return prune_with_map(SubquoModule(D_simp[0], ambient_representatives_generators(Z), ambient_representatives_generators(B)))[1] 
+  return prune_with_map(_canonical_homology_subquotient(X))[1]
 end
 
 @doc raw"""
@@ -292,7 +425,7 @@ julia> L[1]
 !!! note
     Inspecting the  returned numerical data in the first example above, we see that the Bordiga surface is the blow-up of the projective plane in 10 points, embedded into projective 4-space by the linear system $H = 4L -\sum_{i=1}^{10} E_i$. Here, $L$ is the preimage of a line and the $E_i$ are the exceptional divisors. In the second example, we see from the output that the terminal object of the adjunction process is a Del Pezzo surface in projective 3-space, that is, the blow-up of the projective plane in 6 points. In sum, we see that `X` is the blow-up of the projective plane in 15 points, embedded into projective 4-space by the linear system $H = 9L - \sum_{i=1}^{6} 3E_i - \sum_{i=7}^{9} 2E_i - \sum_{i=10}^{15} E_i$. 
 """
-function adjunction_process(X::AbsProjectiveVariety, steps::Int = 0)
+function adjunction_process(X::AbsProjectiveVariety, steps::Int = 0; canonical_algorithm::Symbol = :fast)
    @assert steps >= 0
    Pn = ambient_coordinate_ring(X)
    I = defining_ideal(X)
@@ -303,12 +436,10 @@ function adjunction_process(X::AbsProjectiveVariety, steps::Int = 0)
    numlist = [(ZZ(ngens(Pn)-1), degree(X), sectional_genus(X), zero(ZZ))]
    ptslist = ProjectiveAlgebraicSet[]
    adjlist = AbstractAlgebra.Generic.MatSpaceElem[] 
-   Omega = canonical_bundle(X)
-   FOmega = free_resolution(Omega, length = 1, algorithm = :mres)
-   D = matrix(map(FOmega,1))
+   D = _canonical_presentation_matrix_for_adjunction(X; algorithm = canonical_algorithm)
    count = 1
    while nrows(D) > 2 && (steps == 0 || count <= steps)
-      if !any(x -> total_degree(x) > 1, Oscar._vec(D)) 
+      if _matrix_has_no_quadratic_or_higher_entries(D)
          adj = _adjoint_matrix(D)
       else
         return (numlist, adjlist, ptslist, variety(I, check = false, is_radical = true))
@@ -347,14 +478,9 @@ function adjunction_process(X::AbsProjectiveVariety, steps::Int = 0)
         push!(numlist, (ZZ(ngens(Pn)-1), dY, piY, l))
         push!(adjlist, adj)
         push!(ptslist, pts)
-        Omega = canonical_bundle(Y)
-        FOmega = free_resolution(Omega, length = 1, algorithm = :mres)
-        D = matrix(map(FOmega,1))
+        D = _canonical_presentation_matrix_for_adjunction(Y; algorithm = canonical_algorithm)
       end
       count = count+1
    end
    return (numlist, adjlist, ptslist, Y)
 end
-
-
-

--- a/src/AlgebraicGeometry/Surfaces/AdjunctionProcess/AdjunctionProcess.jl
+++ b/src/AlgebraicGeometry/Surfaces/AdjunctionProcess/AdjunctionProcess.jl
@@ -131,24 +131,8 @@ function _adjoint_matrix(D::AbstractAlgebra.Generic.MatSpaceElem)
      return transpose(map(projRPP, MM))
 end
 
-function _zero_matrix_for_adjunction(R, ncols::Int)
-   return matrix(R, 0, ncols, elem_type(R)[])
-end
-
 function _matrix_has_no_quadratic_or_higher_entries(D::AbstractAlgebra.Generic.MatSpaceElem)
    return !any(x -> !is_zero(x) && total_degree(x) > 1, Oscar._vec(D))
-end
-
-function _matrix_has_only_linear_or_zero_entries(D::AbstractAlgebra.Generic.MatSpaceElem)
-   return !any(x -> !is_zero(x) && total_degree(x) != 1, Oscar._vec(D))
-end
-
-function _canonical_resolution_data(X::AbsProjectiveVariety)
-   Pn = ambient_coordinate_ring(X)
-   A = homogeneous_coordinate_ring(X)
-   FA, _ = free_resolution(SimpleFreeResolution, A)
-   C_simp = simplify(FA)
-   return Pn, C_simp, ngens(Pn) - 1, Int(codim(X))
 end
 
 function _is_zero_free_module_for_adjunction(M)
@@ -171,7 +155,15 @@ function _is_zero_free_module_for_adjunction(M)
    return false
 end
 
-function _resolution_stops_after_codimension(C, c::Int)
+function _resolution_cached_zero_after_codimension(C, c::Int)
+   try
+      cf = chain_factory(C)
+      if hasfield(typeof(cf), :map_cache) && length(cf.map_cache) >= c + 1
+         return _is_zero_free_module_for_adjunction(domain(cf.map_cache[c + 1]))
+      end
+   catch
+   end
+
    try
       cf = chain_factory(original_complex(C))
       if hasfield(typeof(cf), :map_cache) && length(cf.map_cache) >= c + 1
@@ -182,98 +174,223 @@ function _resolution_stops_after_codimension(C, c::Int)
    return false
 end
 
-function _canonical_homology_subquotient_from_resolution(Pn, C_simp, n::Int, c::Int)
-   C_shift = shift(C_simp, c)
-   OmegaPn = graded_free_module(Pn, [n + 1])
-   D = hom(C_shift, OmegaPn)
-   D_simp = simplify(D)
-   Z, _ = kernel(D_simp, 0)
-   B, _ = boundary(D_simp, 0)
-   return SubquoModule(D_simp[0], ambient_representatives_generators(Z), ambient_representatives_generators(B))
-end
-
-function _canonical_homology_subquotient(X::AbsProjectiveVariety)
-   Pn, C_simp, n, c = _canonical_resolution_data(X)
-   return _canonical_homology_subquotient_from_resolution(Pn, C_simp, n, c)
-end
-
-function _free_cover_map_for_adjunction(F0, SQ)
-   if is_graded(F0) && is_graded(SQ)
-      return graded_map(
-         F0, SQ, gens(SQ);
-         check = false,
-         hom_degree = zero(grading_group(base_ring(F0))),
-         generators_map_to_generators = true
-      )
-   end
-   phi = hom(F0, SQ, gens(SQ); check = false)
-   phi.generators_map_to_generators = true
-   return phi
-end
-
-function _matrix_from_subquotient_generators_for_adjunction(K, F0)
-   R = base_ring(F0)
-   V_all = ambient_representatives_generators(K)
-   W_all = degrees_of_generators(K; check = false)
-   keep = findall(!is_zero, V_all)
-   isempty(keep) && return _zero_matrix_for_adjunction(R, ngens(F0))
-   V = V_all[keep]
-   W = W_all[keep]
-   F1 = is_graded(F0) ? graded_free_module(R, W) : free_module(R, length(V))
-   return matrix(hom(F1, F0, V; check = false, hom_degree = is_graded(F0) ? zero(grading_group(R)) : nothing))
-end
-
-function _canonical_presentation_matrix_from_subquotient_cover(SQ::SubquoModule)
-   R = base_ring(SQ)
-   F0 = graded_free_module(R, degrees_of_generators(SQ; check = false))
-   eps = _free_cover_map_for_adjunction(F0, SQ)
-   K, _ = kernel(eps)
-   return _matrix_from_subquotient_generators_for_adjunction(K, F0)
-end
-
-function _canonical_presentation_matrix_homology_from_resolution(Pn, C_simp, n::Int, c::Int; repair::Bool = true)
-   SQ = _canonical_homology_subquotient_from_resolution(Pn, C_simp, n, c)
-   D = _canonical_presentation_matrix_from_subquotient_cover(SQ)
-   if repair && !_matrix_has_only_linear_or_zero_entries(D)
-      P = presentation(SQ; minimal = true)
-      return matrix(map(P, 1))
-   end
-   return D
-end
-
-function _canonical_presentation_matrix_direct_from_resolution(Pn, C_simp, c::Int; require_linear::Bool = true)
-   c == 0 && return _zero_matrix_for_adjunction(Pn, 1)
-   D = transpose(matrix(map(C_simp, c)))
-   _resolution_stops_after_codimension(C_simp, c) || return nothing
-   require_linear && !_matrix_has_only_linear_or_zero_entries(D) && return nothing
-   return D
-end
-
 function _canonical_presentation_matrix_via_module(X::AbsProjectiveVariety)
    Omega = canonical_bundle(X)
    FOmega = free_resolution(Omega, length = 1, algorithm = :mres)
    return matrix(map(FOmega, 1))
 end
 
-function _canonical_presentation_matrix_for_adjunction(X::AbsProjectiveVariety; algorithm::Symbol = :fast)
-   algorithm == :module && return _canonical_presentation_matrix_via_module(X)
-   Pn, C_simp, n, c = _canonical_resolution_data(X)
-   if algorithm == :direct
-      D = _canonical_presentation_matrix_direct_from_resolution(Pn, C_simp, c; require_linear = true)
-      D !== nothing && return D
-      error("The direct canonical presentation is not certified as a linear adjunction matrix for this embedding.")
-   elseif algorithm == :homology
-      return _canonical_presentation_matrix_homology_from_resolution(Pn, C_simp, n, c; repair = false)
-   elseif algorithm == :minimal_homology
-      SQ = _canonical_homology_subquotient_from_resolution(Pn, C_simp, n, c)
-      P = presentation(SQ; minimal = true)
-      return matrix(map(P, 1))
-   elseif algorithm == :fast
-      D = _canonical_presentation_matrix_direct_from_resolution(Pn, C_simp, c; require_linear = true)
-      D !== nothing && return D
-      return _canonical_presentation_matrix_homology_from_resolution(Pn, C_simp, n, c; repair = true)
+function _zero_presentation_matrix_for_adjunction(Pn::MPolyDecRing, ncols::Int = 1)
+   return matrix(Pn, 0, ncols, elem_type(Pn)[])
+end
+
+function _minimal_resolution_for_adjunction(F)
+   hasmethod(minimize, Tuple{typeof(F)}) && return minimize(F)
+   return simplify(F)
+end
+
+function _canonical_presentation_matrix_direct(X::AbsProjectiveVariety)
+   Pn = ambient_coordinate_ring(X)
+   c = Int(codim(X))
+   c == 0 && return _zero_presentation_matrix_for_adjunction(Pn)
+
+   A = homogeneous_coordinate_ring(X)
+   FA, _ = free_resolution(SimpleFreeResolution, A)
+   C_min = _minimal_resolution_for_adjunction(FA)
+   D = transpose(matrix(map(C_min, c)))
+   _resolution_cached_zero_after_codimension(C_min, c) || return nothing
+   return D
+end
+
+function _matrix_from_column_vectors_for_adjunction(K, cols::Vector)
+   isempty(cols) && return matrix(K, 0, 0, elem_type(K)[])
+   m = length(cols[1])
+   return matrix(K, m, length(cols), [cols[j][i] for i in 1:m for j in 1:length(cols)])
+end
+
+function _coefficient_of_monomial_for_adjunction(f, m)
+   e = exponent_vector(m, 1)
+   for (c, ee) in zip(AbstractAlgebra.coefficients(f), AbstractAlgebra.exponent_vectors(f))
+      ee == e && return c
    end
-   error("Unsupported canonical presentation algorithm $(algorithm). Use :fast, :direct, :homology, :minimal_homology, or :module.")
+   return zero(coefficient_ring(parent(f)))
+end
+
+function _coordinates_in_quotient_degree_for_adjunction(f, projection_to_quotient, quotient_monomials::Vector)
+   nf = lift(simplify(projection_to_quotient(f)))
+   return [_coefficient_of_monomial_for_adjunction(nf, m) for m in quotient_monomials]
+end
+
+function _homogeneous_generators_for_adjunction(I::MPolyIdeal)
+   result = elem_type(base_ring(I))[]
+   for f in gens(I)
+      is_zero(f) && continue
+      if is_homogeneous(f)
+         push!(result, f)
+      else
+         try
+            append!(result, collect(values(homogeneous_components(f))))
+         catch
+            push!(result, f)
+         end
+      end
+   end
+   return result
+end
+
+function _degree_piece_candidates_of_ideal_for_adjunction(I::MPolyIdeal, d::Int)
+   R = base_ring(I)
+   d < 0 && return elem_type(R)[]
+
+   result = elem_type(R)[]
+   for f in _homogeneous_generators_for_adjunction(I)
+      df = total_degree(f)
+      df <= d || continue
+      for m in monomial_basis(R, d - df)
+         push!(result, m*f)
+      end
+   end
+   return result
+end
+
+function _basis_of_ideal_quotient_degree_piece_for_adjunction(L::MPolyIdeal, J::MPolyIdeal, d::Int)
+   R = base_ring(L)
+   K = coefficient_ring(R)
+   A, pi = quo(R, J)
+   quotient_monomials = monomial_basis(A, d)
+
+   basis_polys = elem_type(R)[]
+   basis_vectors = Vector{Vector{elem_type(K)}}()
+   current_rank = 0
+
+   for f in _degree_piece_candidates_of_ideal_for_adjunction(L, d)
+      nf = lift(simplify(pi(f)))
+      v = [_coefficient_of_monomial_for_adjunction(nf, m) for m in quotient_monomials]
+      any(x -> !is_zero(x), v) || continue
+
+      test_vectors = copy(basis_vectors)
+      push!(test_vectors, v)
+      new_rank = rank(_matrix_from_column_vectors_for_adjunction(K, test_vectors))
+      if new_rank > current_rank
+         push!(basis_polys, nf)
+         push!(basis_vectors, v)
+         current_rank = new_rank
+      end
+   end
+
+   return basis_polys
+end
+
+function _linear_relation_matrix_from_linkage_degree_piece_for_adjunction(R::MPolyDecRing, J::MPolyIdeal, basis_polys::Vector, d::Int)
+   r = length(basis_polys)
+   r == 0 && return _zero_presentation_matrix_for_adjunction(R, 0)
+
+   K = coefficient_ring(R)
+   A, pi = quo(R, J)
+   target_monomials = monomial_basis(A, d + 1)
+   vars = gens(R)
+   nvars = length(vars)
+
+   columns = Vector{Vector{elem_type(K)}}()
+   for j in 1:r
+      for i in 1:nvars
+         push!(columns, _coordinates_in_quotient_degree_for_adjunction(vars[i]*basis_polys[j], pi, target_monomials))
+      end
+   end
+
+   ker = kernel(_matrix_from_column_vectors_for_adjunction(K, columns), side = :right)
+   nrels = ncols(ker)
+   nrels == 0 && return _zero_presentation_matrix_for_adjunction(R, r)
+
+   entries = elem_type(R)[]
+   for a in 1:nrels
+      for j in 1:r
+         lin = zero(R)
+         for i in 1:nvars
+            lin += R(ker[(j - 1)*nvars + i, a])*vars[i]
+         end
+         push!(entries, lin)
+      end
+   end
+
+   return matrix(R, nrels, r, entries)
+end
+
+function _try_complete_intersection_pair_for_adjunction(I::MPolyIdeal; random_trials::Int = 20)
+   R = base_ring(I)
+   G = sort(_homogeneous_generators_for_adjunction(I), by = total_degree)
+   length(G) >= 2 || return nothing
+
+   for i in 1:(length(G)-1)
+      for j in (i+1):length(G)
+         f = G[i]
+         g = G[j]
+         is_zero(f) && continue
+         is_zero(g) && continue
+         codim(ideal(R, [f, g])) == 2 && return (f, g)
+      end
+   end
+
+   degrees = sort(unique(total_degree.(G)))
+   for d in degrees
+      Gd = [f for f in G if total_degree(f) == d]
+      length(Gd) >= 2 || continue
+
+      for _ in 1:random_trials
+         C = _random_matrix(R, 2, length(Gd), 0)
+         f = sum(C[1, j]*Gd[j] for j in 1:length(Gd); init = zero(R))
+         g = sum(C[2, j]*Gd[j] for j in 1:length(Gd); init = zero(R))
+         is_zero(f) && continue
+         is_zero(g) && continue
+         codim(ideal(R, [f, g])) == 2 && return (f, g)
+      end
+   end
+
+   return nothing
+end
+
+function _canonical_presentation_matrix_via_ci_linkage_linear_strand(
+    X::AbsProjectiveVariety;
+    random_trials::Int = 20
+  )
+   R = ambient_coordinate_ring(X)
+   is_standard_graded(R) || return nothing
+   ngens(R) == 5 || return nothing
+   Int(codim(X)) == 2 || return nothing
+
+   I = defining_ideal(X)
+   fg = _try_complete_intersection_pair_for_adjunction(I; random_trials)
+   fg === nothing && return nothing
+
+   f, g = fg
+   J = ideal(R, [f, g])
+   L = quotient(J, I)
+   d = total_degree(f) + total_degree(g) - 4
+   d < 0 && return _zero_presentation_matrix_for_adjunction(R, 0)
+
+   basis_polys = _basis_of_ideal_quotient_degree_piece_for_adjunction(L, J, d)
+   return _linear_relation_matrix_from_linkage_degree_piece_for_adjunction(R, J, basis_polys, d)
+end
+
+function _canonical_presentation_matrix_for_adjunction(X::AbsProjectiveVariety; algorithm::Symbol = :fast)
+   if algorithm == :direct
+      D = _canonical_presentation_matrix_direct(X)
+      D !== nothing && return D
+      error("The direct canonical presentation is not available for this embedding; use canonical_algorithm = :fast, :linkage_linear_strand, or :module.")
+   elseif algorithm == :linkage_linear_strand
+      D = _canonical_presentation_matrix_via_ci_linkage_linear_strand(X)
+      D !== nothing && return D
+      error("The complete-intersection linkage linear-strand presentation is only available for suitable codimension-two surfaces in projective 4-space.")
+   elseif algorithm == :fast
+      D = _canonical_presentation_matrix_direct(X)
+      D !== nothing && return D
+      D = _canonical_presentation_matrix_via_ci_linkage_linear_strand(X)
+      D !== nothing && return D
+      return _canonical_presentation_matrix_via_module(X)
+   elseif algorithm == :module
+      return _canonical_presentation_matrix_via_module(X)
+   end
+   error("Unsupported canonical presentation algorithm $(algorithm). Use :fast, :direct, :linkage_linear_strand, or :module.")
 end
 
 @doc raw"""
@@ -340,14 +457,28 @@ SubquoModule{MPolyDecRingElem{fpFieldElem, fpMPolyRingElem}}
 ```
 """
 function canonical_bundle(X::AbsProjectiveVariety)
-  return prune_with_map(_canonical_homology_subquotient(X))[1]
+  Pn = ambient_coordinate_ring(X)
+  A = homogeneous_coordinate_ring(X)
+  n = ngens(Pn)-1
+  c = codim(X)
+  FA, _ = free_resolution(SimpleFreeResolution, A)
+  C_simp = simplify(FA)
+  C_shift = shift(C_simp, c)
+  OmegaPn = graded_free_module(Pn, [n+1])
+  D = hom(C_shift, OmegaPn)
+  D_simp = simplify(D)
+  Z, inc = kernel(D_simp, 0)
+  B, inc_B = boundary(D_simp, 0)
+  return prune_with_map(SubquoModule(D_simp[0], ambient_representatives_generators(Z), ambient_representatives_generators(B)))[1]
 end
 
 @doc raw"""
-    adjunction_process(X::AbsProjectiveVariety, steps::Int=0)
+    adjunction_process(X::AbsProjectiveVariety, steps::Int=0; canonical_algorithm::Symbol=:fast)
 
 Given a smooth surface `X` and a non-negative integer `steps`, return data which describes the adjunction process for `X`: 
 If `steps == 0`, carry out the complete process. Otherwise, carry out the indicated number of steps only.
+
+The keyword argument `canonical_algorithm` controls how the presentation matrix of the canonical module is computed in each adjunction step. With the default `:fast`, OSCAR first tries to read this matrix directly from the codimension step of a minimal free resolution of the homogeneous coordinate ring. If this is certified, the matrix is returned even when it has quadratic or higher-degree entries; in that case the adjunction process stops, since the implemented adjoint matrix construction requires a linear presentation. If the direct extraction is not certified and the surface has codimension two in projective 4-space, OSCAR next tries a complete-intersection linkage computation of the linear strand of the canonical module. Only if both fast methods fail does `:fast` fall back to the generic route through `canonical_bundle`. The value `:module` yields the generic construction through `canonical_bundle` and a length-one free resolution of that module. The value `:direct` uses only the direct extraction and throws an error if the resolution does not certify that this extraction is valid. The value `:linkage_linear_strand` uses only the complete-intersection linkage linear-strand computation and throws an error if it is not applicable.
 
 More precisely, if $X^{(0)} = X \rightarrow X^{(1)}\rightarrow \dots \rightarrow X^{(r)}$ is the sequence of successive adjunction maps and 
 adjoint surfaces in the completed adjunction process, return a quadruple `L`, say, where: 

--- a/src/Modules/ModuleTypes.jl
+++ b/src/Modules/ModuleTypes.jl
@@ -577,7 +577,9 @@ When computed, the corresponding matrix (via `matrix()`) and inverse isomorphism
   # the generators of F
   function FreeModuleHom(
       F::AbstractFreeMod, G::S, a::Vector{ModuleElemType};
-      check::Bool=true
+      check::Bool=true,
+      hom_degree::Union{Nothing, FinGenAbGroupElem}=nothing,
+      generators_map_to_generators::Union{Bool, Nothing}=nothing
     ) where {S<:OFPModule, ModuleElemType<:OFPModuleElem}
     ###@assert is_graded(F) == is_graded(G)
     @assert all(x->parent(x) === G, a)
@@ -614,7 +616,11 @@ When computed, the corresponding matrix (via `matrix()`) and inverse isomorphism
     end
     r.header = MapHeader{typeof(F), typeof(G)}(F, G, im_func, pr_func)
     r.imgs_of_gens = Vector{elem_type(G)}(a)
-    r.generators_map_to_generators = nothing
+    r.generators_map_to_generators = generators_map_to_generators
+    if hom_degree !== nothing
+      r.d = hom_degree
+      return r
+    end
     return set_grading(r; check)
   end
 
@@ -656,7 +662,9 @@ When computed, the corresponding matrix (via `matrix()`) and inverse isomorphism
 
   function FreeModuleHom(
       F::AbstractFreeMod, G::T2, a::Vector{ModuleElemType}, h::RingMapType;
-      check::Bool=true
+      check::Bool=true,
+      hom_degree::Union{Nothing, FinGenAbGroupElem}=nothing,
+      generators_map_to_generators::Union{Bool, Nothing}=nothing
     ) where {T2, ModuleElemType<:OFPModuleElem, RingMapType}
     ###@assert is_graded(F) == is_graded(G)
     @assert all(x->parent(x) === G, a)
@@ -664,7 +672,11 @@ When computed, the corresponding matrix (via `matrix()`) and inverse isomorphism
     @assert h(one(base_ring(F))) == one(base_ring(G))
     r = new{typeof(F), T2, RingMapType}()
     a=Vector{elem_type(G)}(a)
-    image_module = sub_object(G, a)
+    image_module = Ref{Any}(nothing)
+    get_image_module = function()
+      image_module[] === nothing && (image_module[] = sub_object(G, a))
+      return image_module[]
+    end
     function im_func(x::AbstractFreeModElem)
       iszero(x) && return zero(codomain(r))
       # See the above comment
@@ -684,14 +696,18 @@ When computed, the corresponding matrix (via `matrix()`) and inverse isomorphism
     function pr_func(x)
       @assert parent(x) === G
       #r.generators_map_to_generators === true && return FreeModElem(map_entries(x->preimage(h, x), coordinates(simplify!(x))), F)
-      c = coordinates(repres(x), image_module)
+      c = coordinates(repres(x), get_image_module())
       cc = map_entries(x->preimage(h, x), c)
       return FreeModElem(cc, F)
     end
     r.header = MapHeader{typeof(F), T2}(F, G, im_func, pr_func)
     r.ring_map = h
     r.imgs_of_gens = Vector{elem_type(G)}(a)
-    r.generators_map_to_generators = nothing
+    r.generators_map_to_generators = generators_map_to_generators
+    if hom_degree !== nothing
+      r.d = hom_degree
+      return r
+    end
     return set_grading(r; check)
   end
 

--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -1067,6 +1067,12 @@ function grading_group(M::SubquoModule)
   return grading_group(base_ring(M))
 end
 
+@attr Vector{FinGenAbGroupElem} function _degrees_of_generators_cached(M::SubquoModule{T}) where T
+  G = gens(M)
+  isempty(G) && return FinGenAbGroupElem[]
+  return map(gen -> degree(repres(gen); check=false), G)
+end
+
 @doc raw"""
     degrees_of_generators(M::SubquoModule; check::Bool=true)
 
@@ -1105,12 +1111,6 @@ julia> gens(M)
  z*e[2]
 ```
 """
-@attr Vector{FinGenAbGroupElem} function _degrees_of_generators_cached(M::SubquoModule{T}) where T
-  G = gens(M)
-  isempty(G) && return FinGenAbGroupElem[]
-  return map(gen -> degree(repres(gen); check=false), G)
-end
-
 function degrees_of_generators(M::SubquoModule{T}; check::Bool=true) where T
   @check is_graded(M) "module must be graded"
   return _degrees_of_generators_cached(M)

--- a/src/Modules/ModulesGraded.jl
+++ b/src/Modules/ModulesGraded.jl
@@ -645,6 +645,30 @@ function determine_degree_from_SR(coords::SRow, unit_vector_degrees::Vector{FinG
   return element_degree
 end
 
+_is_zero_representative_for_grading(v::OFPModuleElem) = is_zero(v)
+
+function _is_zero_representative_for_grading(v::SubquoModuleElem)
+  isdefined(v, :coeffs) && is_zero(v.coeffs) && return true
+  return is_zero(repres(v))
+end
+
+_degree_for_grading(v::OFPModuleElem; check::Bool=true) = degree(v; check)
+
+function _degree_for_grading(v::SubquoModuleElem; check::Bool=true)
+  @check is_graded(parent(v)) "the parent module is not graded"
+  _is_zero_representative_for_grading(v) && return zero(grading_group(base_ring(parent(v))))::FinGenAbGroupElem
+
+  if isdefined(v, :coeffs)
+    degree_from_coords = determine_degree_from_SR(coordinates(v), degrees_of_generators(parent(v); check))
+    degree_from_coords !== nothing && return degree_from_coords::FinGenAbGroupElem
+  end
+
+  r = repres(v)
+  !check && return degree(r; check=false)
+  is_homogeneous(r) && return degree(r; check)
+  return degree(repres(simplify(v)); check)
+end
+
 ###############################################################################
 # Graded Free Module homomorphisms constructors
 ###############################################################################
@@ -682,16 +706,11 @@ function graded_map(F::FreeMod{T}, V::Vector{<:AbstractFreeModElem{T}}; check::B
   
   source_degrees = Vector{eltype(G)}()
   for (i, v) in enumerate(V)
-    if is_zero(v)
+    if _is_zero_representative_for_grading(v)
       push!(source_degrees, zero(G))
       continue
     end
-    for (j, c) in coordinates(v)
-      if !iszero(c)
-        push!(source_degrees, degree(coordinates(V[i])[j]; check) + degree(F[j]; check))
-        break
-      end
-    end
+    push!(source_degrees, _degree_for_grading(v; check))
   end
   @assert length(source_degrees) == nrows
   Fcdm = graded_free_module(R, source_degrees)
@@ -707,20 +726,28 @@ function graded_map(F::SubquoModule{T}, V::Vector{<:OFPModuleElem{T}}; check::Bo
   nrows = length(V)
   source_degrees = Vector{eltype(G)}()
   for (i, v) in enumerate(V)
-    if is_zero(v)
+    if _is_zero_representative_for_grading(v)
       push!(source_degrees, zero(G))
       continue
     end
-    for (j, c) in coordinates(v)
-      if !iszero(c)
-        push!(source_degrees, degree(coordinates(V[i])[j]; check) + degree(F[j]; check))
-        break
-      end
-    end
+    push!(source_degrees, _degree_for_grading(v; check))
   end
   Fcdm = graded_free_module(R, source_degrees)
   phi = hom(Fcdm, F, V; check)
   return phi
+end
+
+function graded_map(
+    Fdom::FreeMod{T},
+    Fcod::OFPModule{T},
+    V::Vector{<:OFPModuleElem{T}};
+    check::Bool=true,
+    hom_degree::Union{Nothing, FinGenAbGroupElem}=nothing,
+    generators_map_to_generators::Union{Bool, Nothing}=nothing
+  ) where {T <: AdmissibleOFPModuleRingElem}
+  @check is_graded(Fdom) "the domain module is not graded"
+  @check is_graded(Fcod) "the codomain module is not graded"
+  return hom(Fdom, Fcod, V; check, hom_degree, generators_map_to_generators)
 end
 
 ###############################################################################
@@ -782,10 +809,10 @@ function degree(f::FreeModuleHom; check::Bool=true)
   @check (is_graded(domain(f)) && is_graded(codomain(f))) "both domain and codomain must be graded"
   @check is_graded(f) "map is not graded"
   for i in 1:ngens(domain(f))
-    if iszero(domain(f)[i]) || iszero(image_of_generator(f, i))
+    if iszero(domain(f)[i]) || _is_zero_representative_for_grading(image_of_generator(f, i))
       continue
     end
-    f.d = degree(image_of_generator(f, i); check) - degree(domain(f)[i]; check)
+    f.d = _degree_for_grading(image_of_generator(f, i); check) - degree(domain(f)[i]; check)
     return f.d::FinGenAbGroupElem
   end
 
@@ -798,10 +825,10 @@ function degree(f::FreeModuleHom; check::Bool=true)
   df = nothing
   for i in 1:length(domain_degrees)
     image_vector = f(T1[i])
-    if isempty(coordinates(image_vector)) || is_zero(image_vector)
+    if _is_zero_representative_for_grading(image_vector)
       continue
     end
-    current_df = degree(image_vector) - domain_degrees[i]
+    current_df = _degree_for_grading(image_vector) - domain_degrees[i]
     if df === nothing
       df = current_df
     elseif df != current_df
@@ -970,9 +997,13 @@ function is_graded(M::SubModuleOfFreeModule)
   is_graded(M.F) && all(is_homogeneous, M.gens)
 end
 
+@attr Vector{FinGenAbGroupElem} function _degrees_of_generators_cached(M::SubModuleOfFreeModule{T}) where T
+  return map(gen -> degree(gen; check=false), gens(M))
+end
 
 function degrees_of_generators(M::SubModuleOfFreeModule{T}; check::Bool=true) where T
-  return map(gen -> degree(gen; check), gens(M))
+  @check is_graded(M) "module must be graded"
+  return _degrees_of_generators_cached(M)
 end
 
 ###############################################################################
@@ -1074,8 +1105,15 @@ julia> gens(M)
  z*e[2]
 ```
 """
+@attr Vector{FinGenAbGroupElem} function _degrees_of_generators_cached(M::SubquoModule{T}) where T
+  G = gens(M)
+  isempty(G) && return FinGenAbGroupElem[]
+  return map(gen -> degree(repres(gen); check=false), G)
+end
+
 function degrees_of_generators(M::SubquoModule{T}; check::Bool=true) where T
-  isempty(gens(M)) ? FinGenAbGroupElem[] : map(gen -> degree(repres(gen); check), gens(M))
+  @check is_graded(M) "module must be graded"
+  return _degrees_of_generators_cached(M)
 end
 
 ###############################################################################
@@ -1133,7 +1171,13 @@ x*e[1] + (y - z)*e[2]
 ```
 """
 function is_homogeneous(el::SubquoModuleElem)
-  el.is_reduced && return is_homogeneous(repres(el))
+  _is_zero_representative_for_grading(el) && return true
+  if isdefined(el, :coeffs)
+    degree_from_coords = determine_degree_from_SR(coordinates(el), degrees_of_generators(parent(el)))
+    degree_from_coords !== nothing && return true
+  end
+  r = repres(el)
+  is_homogeneous(r) && return true
   return is_homogeneous(repres(simplify(el)))
 
   # The following call checks for homogeneity on the way and stores the degree thus determined.
@@ -1204,13 +1248,7 @@ julia> degree(m3)
 ```
 """
 function degree(el::SubquoModuleElem; check::Bool=true)
-  # In general we can not assume that we have a groebner basis reduction available 
-  # as a backend to bring the element to normal form. 
-  # In particular, this may entail that `coordinates` produces non-homogeneous 
-  # vectors via differently implemented liftings. 
-  # Thus, the only thing we can do is to assume that the representative is 
-  # homogeneous.
-  return degree(repres(simplify!(el)); check)
+  return _degree_for_grading(el; check)
 end
 
 # When there is a Groebner basis backend, we can reduce to normal form.
@@ -1218,8 +1256,7 @@ function degree(
     el::SubquoModuleElem{T};
     check::Bool=true
   ) where {T <:Union{<:MPolyRingElem{<:FieldElem}}}
-  !el.is_reduced && return degree(simplify!(el); check)
-  return degree(repres(el); check)
+  return _degree_for_grading(el; check)
 end
 
 _degree_fast(el::SubquoModuleElem) = degree(el, check=false)
@@ -1290,15 +1327,16 @@ function degree(f::SubQuoHom; check::Bool=true)
   if !is_graded(T1) || !is_graded(T2)
     error("Both domain and codomain must be graded.")
   end
-  if iszero(T1)
+  if ngens(T1) == 0
     R = base_ring(T1)
     G = grading_group(R)
     return G[0]
   end
   @check is_graded(f) "homomorphism is not graded"
+  domain_degrees = degrees_of_generators(T1; check)
   for (i, v) in enumerate(gens(T1))
-    (is_zero(v) || is_zero(image_of_generator(f, i))) && continue
-    f.d = degree(image_of_generator(f, i); check) - degree(v; check)
+    (_is_zero_representative_for_grading(v) || _is_zero_representative_for_grading(image_of_generator(f, i))) && continue
+    f.d = _degree_for_grading(image_of_generator(f, i); check) - domain_degrees[i]
     return f.d::FinGenAbGroupElem
   end
 

--- a/src/Modules/UngradedModules/FreeModuleHom.jl
+++ b/src/Modules/UngradedModules/FreeModuleHom.jl
@@ -506,45 +506,17 @@ function _graded_kernel(h::FreeModuleHom{<:FreeMod, <:FreeMod})
   return I, inc
 end
 
-function _kernel_subquo_generators_via_modulo(F::FreeMod, G::FreeMod, g, rels)
-  return nothing
-end
-
-function _kernel_subquo_generators_via_modulo(
-    F::FreeMod{T},
-    G::FreeMod{T},
-    g::Vector{FreeModElem{T}},
-    rels::Vector{FreeModElem{T}}
-  ) where {T <: MPolyRingElem}
-  ordering = default_ordering(G)
-  SF = singular_module(G, ordering)
-  A = singular_generators(ModuleGens(g, G, SF))
-  B = singular_generators(ModuleGens(rels, G, SF))
-  K = Singular.modulo(A, B)
-  return elem_type(F)[v for v in oscar_generators(ModuleGens(F, K))]
-end
-
-function _kernel_subquo_generators_via_modulo(
-    F::FreeMod{T},
-    G::FreeMod{T},
-    g::Vector{FreeModElem{T}},
-    rels::Vector{FreeModElem{T}}
-  ) where {T <: MPolyQuoRingElem}
-  SF = singular_module(G)
-  A = singular_generators(ModuleGens(g, G, SF))
-  B = singular_generators(ModuleGens(rels, G, SF))
-  K = Singular.modulo(A, B)
-  return elem_type(F)[v for v in oscar_generators(ModuleGens(F, K))]
-end
-
-function kernel(h::FreeModuleHom{<:FreeMod, <:SubquoModule})
-  all(_is_zero_representative_for_grading, images_of_generators(h)) && return sub(domain(h), gens(domain(h)))
-  F = domain(h)
+function _kernel_subquo_image_representatives(
+    h::FreeModuleHom{<:FreeMod, <:SubquoModule};
+    reduce_generators::Bool=true
+  )
   M = codomain(h)
   G = ambient_free_module(M)
-  # Prefer the given representative: reducing modulo the relations can be much
-  # more expensive than carrying the known grading data. Fall back to a reduced
-  # representative only when the current representative is not homogeneous.
+
+  if reduce_generators
+    return elem_type(G)[repres(simplify(v)) for v in images_of_generators(h)]
+  end
+
   graded_M = is_graded(M)
   g = elem_type(G)[]
   for v in images_of_generators(h)
@@ -554,10 +526,17 @@ function kernel(h::FreeModuleHom{<:FreeMod, <:SubquoModule})
     end
     push!(g, r)
   end
-  rels = relations(M)
-  v = _kernel_subquo_generators_via_modulo(F, G, g, rels)
-  v !== nothing && return sub(F, filter!(!iszero, v))
+  return g
+end
 
+function _kernel_subquo_generators(
+    F::FreeMod,
+    G::FreeMod,
+    g,
+    rels,
+    h::FreeModuleHom,
+    graded_M::Bool
+  )
   g = vcat(g, rels)
   R = base_ring(G)
   H = FreeMod(R, length(g))
@@ -570,7 +549,59 @@ function kernel(h::FreeModuleHom{<:FreeMod, <:SubquoModule})
   phi = hom(H, G, g; check=false)
   K, _ = kernel(phi)
   r = ngens(F)
-  v = elem_type(F)[F(coordinates(v)[1:ngens(F)]) for v in ambient_representatives_generators(K)]
+  return elem_type(F)[F(coordinates(v)[1:r]) for v in ambient_representatives_generators(K)]
+end
+
+function _kernel_subquo_generators_reduced(F::FreeMod, G::FreeMod, g, rels, h::FreeModuleHom)
+  g = vcat(g, rels)
+  R = base_ring(G)
+  H = FreeMod(R, length(g))
+  is_graded(h) && is_homogeneous(h) && set_grading!(H, degree.(g))
+  phi = hom(H, G, g)
+  K, _ = kernel(phi)
+  r = ngens(F)
+  return elem_type(F)[F(coordinates(v)[1:r]) for v in ambient_representatives_generators(K)]
+end
+
+_singular_module_for_kernel_subquo(G::FreeMod{<:MPolyRingElem}) = singular_module(G, default_ordering(G))
+_singular_module_for_kernel_subquo(G::FreeMod{<:MPolyQuoRingElem{<:MPolyRingElem{<:FieldElem}}}) = singular_module(G)
+
+function _kernel_subquo_generators(
+    F::FreeMod{T},
+    G::FreeMod{T},
+    g::Vector{FreeModElem{T}},
+    rels::Vector{FreeModElem{T}},
+    _h::FreeModuleHom,
+    _graded_M::Bool
+  ) where {T <: Union{MPolyRingElem,
+                      MPolyQuoRingElem{<:MPolyRingElem{<:FieldElem}}}}
+  SF = _singular_module_for_kernel_subquo(G)
+  A = singular_generators(ModuleGens(g, G, SF))
+  B = singular_generators(ModuleGens(rels, G, SF))
+  K = Singular.modulo(A, B)
+  return elem_type(F)[v for v in oscar_generators(ModuleGens(F, K))]
+end
+
+function kernel(
+    h::FreeModuleHom{<:FreeMod, <:SubquoModule};
+    reduce_generators::Bool=true
+  )
+  if reduce_generators
+    is_zero(h) && return sub(domain(h), gens(domain(h)))
+  else
+    all(_is_zero_representative_for_grading, images_of_generators(h)) && return sub(domain(h), gens(domain(h)))
+  end
+  F = domain(h)
+  M = codomain(h)
+  G = ambient_free_module(M)
+  graded_M = is_graded(M)
+  rels = relations(M)
+  g = _kernel_subquo_image_representatives(h; reduce_generators=reduce_generators)
+  v = if reduce_generators
+    _kernel_subquo_generators_reduced(F, G, g, rels, h)
+  else
+    _kernel_subquo_generators(F, G, g, rels, h, graded_M)
+  end
   return sub(F, filter!(!iszero, v))
 end
 
@@ -712,4 +743,3 @@ end
 @attr SubquoModule{T} function image_module(phi::FreeModuleHom{FreeMod{T}, <:OFPModule{T}, Nothing}) where {T}
   return sub_object(codomain(phi), images_of_generators(phi))
 end
-

--- a/src/Modules/UngradedModules/FreeModuleHom.jl
+++ b/src/Modules/UngradedModules/FreeModuleHom.jl
@@ -506,6 +506,24 @@ function _graded_kernel(h::FreeModuleHom{<:FreeMod, <:FreeMod})
   return I, inc
 end
 
+function _kernel_subquo_generators_via_modulo(F::FreeMod, G::FreeMod, g, rels)
+  return nothing
+end
+
+function _kernel_subquo_generators_via_modulo(
+    F::FreeMod{T},
+    G::FreeMod{T},
+    g::Vector{FreeModElem{T}},
+    rels::Vector{FreeModElem{T}}
+  ) where {T <: Union{MPolyRingElem, MPolyQuoRingElem}}
+  ordering = default_ordering(G)
+  SF = singular_module(G, ordering)
+  A = singular_generators(ModuleGens(g, G, SF))
+  B = singular_generators(ModuleGens(rels, G, SF))
+  K = Singular.modulo(A, B)
+  return elem_type(F)[v for v in oscar_generators(ModuleGens(F, K))]
+end
+
 function kernel(h::FreeModuleHom{<:FreeMod, <:SubquoModule})
   all(_is_zero_representative_for_grading, images_of_generators(h)) && return sub(domain(h), gens(domain(h)))
   F = domain(h)
@@ -524,6 +542,9 @@ function kernel(h::FreeModuleHom{<:FreeMod, <:SubquoModule})
     push!(g, r)
   end
   rels = relations(M)
+  v = _kernel_subquo_generators_via_modulo(F, G, g, rels)
+  v !== nothing && return sub(F, filter!(!iszero, v))
+
   g = vcat(g, rels)
   R = base_ring(G)
   H = FreeMod(R, length(g))

--- a/src/Modules/UngradedModules/FreeModuleHom.jl
+++ b/src/Modules/UngradedModules/FreeModuleHom.jl
@@ -200,9 +200,18 @@ julia> a2 == b
 true
 ```
 """
-function hom(F::FreeMod, M::OFPModule{T}, V::Vector{<:OFPModuleElem{T}}; check::Bool=true) where T
-  base_ring(F) === base_ring(M) || return FreeModuleHom(F, M, V, base_ring(M); check)
-  return FreeModuleHom(F, M, V; check)
+function hom(
+    F::FreeMod,
+    M::OFPModule{T},
+    V::Vector{<:OFPModuleElem{T}};
+    check::Bool=true,
+    hom_degree::Union{Nothing, FinGenAbGroupElem}=nothing,
+    generators_map_to_generators::Union{Bool, Nothing}=nothing
+  ) where T
+  if base_ring(F) !== base_ring(M)
+    return FreeModuleHom(F, M, V, base_ring(M); check, hom_degree, generators_map_to_generators)
+  end
+  return FreeModuleHom(F, M, V; check, hom_degree, generators_map_to_generators)
 end
 function hom(F::FreeMod, M::OFPModule{T}, A::MatElem{T}; check::Bool=true) where T 
   base_ring(F) === base_ring(M) || return FreeModuleHom(F, M, A, base_ring(M); check)
@@ -498,19 +507,32 @@ function _graded_kernel(h::FreeModuleHom{<:FreeMod, <:FreeMod})
 end
 
 function kernel(h::FreeModuleHom{<:FreeMod, <:SubquoModule})
-  is_zero(h) && return sub(domain(h), gens(domain(h)))
+  all(_is_zero_representative_for_grading, images_of_generators(h)) && return sub(domain(h), gens(domain(h)))
   F = domain(h)
   M = codomain(h)
   G = ambient_free_module(M)
-  # We have to take the representatives of the reduced elements!
-  # Otherwise we might get wrong degrees.
-  g = [repres(simplify(v)) for v in images_of_generators(h)]
-  g = vcat(g, relations(M))
+  # Prefer the given representative: reducing modulo the relations can be much
+  # more expensive than carrying the known grading data. Fall back to a reduced
+  # representative only when the current representative is not homogeneous.
+  graded_M = is_graded(M)
+  g = elem_type(G)[]
+  for v in images_of_generators(h)
+    r = repres(v)
+    if graded_M && !is_zero(r) && !is_homogeneous(r)
+      r = repres(simplify(v))
+    end
+    push!(g, r)
+  end
+  rels = relations(M)
+  g = vcat(g, rels)
   R = base_ring(G)
   H = FreeMod(R, length(g))
   # This code is also used by graded modules and we need to care for that.
-  is_graded(h) && is_homogeneous(h) && set_grading!(H, degree.(g))
-  phi = hom(H, G, g)
+  if graded_M && is_graded(h)
+    image_degrees = [degree(F[i]; check=false) + degree(h; check=false) for i in 1:ngens(F)]
+    set_grading!(H, vcat(image_degrees, [degree(r; check=false) for r in rels]))
+  end
+  phi = hom(H, G, g; check=false)
   K, _ = kernel(phi)
   r = ngens(F)
   v = elem_type(F)[F(coordinates(v)[1:ngens(F)]) for v in ambient_representatives_generators(K)]

--- a/src/Modules/UngradedModules/FreeModuleHom.jl
+++ b/src/Modules/UngradedModules/FreeModuleHom.jl
@@ -515,9 +515,22 @@ function _kernel_subquo_generators_via_modulo(
     G::FreeMod{T},
     g::Vector{FreeModElem{T}},
     rels::Vector{FreeModElem{T}}
-  ) where {T <: Union{MPolyRingElem, MPolyQuoRingElem}}
+  ) where {T <: MPolyRingElem}
   ordering = default_ordering(G)
   SF = singular_module(G, ordering)
+  A = singular_generators(ModuleGens(g, G, SF))
+  B = singular_generators(ModuleGens(rels, G, SF))
+  K = Singular.modulo(A, B)
+  return elem_type(F)[v for v in oscar_generators(ModuleGens(F, K))]
+end
+
+function _kernel_subquo_generators_via_modulo(
+    F::FreeMod{T},
+    G::FreeMod{T},
+    g::Vector{FreeModElem{T}},
+    rels::Vector{FreeModElem{T}}
+  ) where {T <: MPolyQuoRingElem}
+  SF = singular_module(G)
   A = singular_generators(ModuleGens(g, G, SF))
   B = singular_generators(ModuleGens(rels, G, SF))
   K = Singular.modulo(A, B)

--- a/src/Modules/UngradedModules/FreeModuleHom.jl
+++ b/src/Modules/UngradedModules/FreeModuleHom.jl
@@ -530,7 +530,8 @@ function kernel(h::FreeModuleHom{<:FreeMod, <:SubquoModule})
   # This code is also used by graded modules and we need to care for that.
   if graded_M && is_graded(h)
     image_degrees = [degree(F[i]; check=false) + degree(h; check=false) for i in 1:ngens(F)]
-    set_grading!(H, vcat(image_degrees, [degree(r; check=false) for r in rels]))
+    relation_degrees = FinGenAbGroupElem[degree(r; check=false) for r in rels]
+    set_grading!(H, vcat(image_degrees, relation_degrees))
   end
   phi = hom(H, G, g; check=false)
   K, _ = kernel(phi)

--- a/src/Modules/UngradedModules/HomologicalAlgebra.jl
+++ b/src/Modules/UngradedModules/HomologicalAlgebra.jl
@@ -238,28 +238,26 @@ julia> Q, _ = quo(F, [x*F[1]]);
 
 julia> T0 = tor(Q, M, 0)
 Subquotient of submodule with 2 generators
-  1: (e[1] \otimes e[1])
-  2: (e[1] \otimes e[2])
-by submodule with 7 generators
-  1: x*(e[1] \otimes e[1])
-  2: -y*(e[1] \otimes e[1]) + x*(e[1] \otimes e[2])
-  3: y^2*(e[1] \otimes e[2])
-  4: y^3*(e[1] \otimes e[1])
-  5: z^4*(e[1] \otimes e[1])
-  6: z^4*(e[1] \otimes e[2])
-  7: x*(e[1] \otimes e[2])
+  1: e[1] \otimes e[1]
+  2: e[1] \otimes e[2]
+by submodule with 6 generators
+  1: x*e[1] \otimes e[1]
+  2: -y*e[1] \otimes e[1] + x*e[1] \otimes e[2]
+  3: y^2*e[1] \otimes e[2]
+  4: z^4*e[1] \otimes e[1]
+  5: z^4*e[1] \otimes e[2]
+  6: x*e[1] \otimes e[2]
 
 julia> T1 = tor(Q, M, 1)
 Subquotient of submodule with 2 generators
-  1: (e[1] \otimes e[1])
-  2: x*(e[1] \otimes e[2])
-by submodule with 6 generators
-  1: x*(e[1] \otimes e[1])
-  2: -y*(e[1] \otimes e[1]) + x*(e[1] \otimes e[2])
-  3: y^2*(e[1] \otimes e[2])
-  4: y^3*(e[1] \otimes e[1])
-  5: z^4*(e[1] \otimes e[1])
-  6: z^4*(e[1] \otimes e[2])
+  1: e[1] \otimes e[1]
+  2: x*e[1] \otimes e[2]
+by submodule with 5 generators
+  1: x*e[1] \otimes e[1]
+  2: -y*e[1] \otimes e[1] + x*e[1] \otimes e[2]
+  3: y^2*e[1] \otimes e[2]
+  4: z^4*e[1] \otimes e[1]
+  5: z^4*e[1] \otimes e[2]
 
 julia> T2 =  tor(Q, M, 2)
 Submodule with 0 generators
@@ -632,4 +630,3 @@ function ext(M::OFPModule, N::OFPModule, i::Int)
   lifted_resolution = hom(free_res.C[first(Hecke.map_range(free_res.C)):-1:1], N) #TODO only three homs are necessary
   return simplify_light(homology(lifted_resolution,i))[1]
 end
-

--- a/src/Modules/UngradedModules/HomologicalAlgebra.jl
+++ b/src/Modules/UngradedModules/HomologicalAlgebra.jl
@@ -156,15 +156,15 @@ end
 # Tor
 #############################
 @doc raw"""
-    tensor_product(M::OFPModule, C::ComplexOfMorphisms{OFPModule})
+    tensor_product(M::OFPModule, C::ComplexOfMorphisms{OFPModule}; minimal::Bool=true)
 
 Return the complex obtained by applying `M` $\otimes\;\! \bullet$ to `C`.
 """
-function tensor_product(P::OFPModule, C::Hecke.ComplexOfMorphisms{OFPModule})
+function tensor_product(P::OFPModule, C::Hecke.ComplexOfMorphisms{OFPModule}; minimal::Bool=true)
   #tensor_chain = Hecke.map_type(C)[]
   tensor_chain = valtype(C.maps)[]
-  tensor_modules = [tensor_product(P, domain(map(C,first(chain_range(C)))), task=:cache_morphism)[1]]
-  append!(tensor_modules, [tensor_product(P, codomain(map(C,i)), task=:cache_morphism)[1] for i in Hecke.map_range(C)])
+  tensor_modules = [tensor_product(P, domain(map(C,first(chain_range(C)))); task=:cache_morphism, minimal=minimal)[1]]
+  append!(tensor_modules, [tensor_product(P, codomain(map(C,i)); task=:cache_morphism, minimal=minimal)[1] for i in Hecke.map_range(C)])
 
   for i in 1:length(Hecke.map_range(C))
     A = tensor_modules[i]
@@ -184,23 +184,23 @@ function tensor_product(P::OFPModule, C::Hecke.ComplexOfMorphisms{OFPModule})
   return Hecke.ComplexOfMorphisms(OFPModule, tensor_chain, seed=C.seed, typ=C.typ)
 end
 
-function tensor_product(M::OFPModule, F::FreeResolution)
-  return tensor_product(M, F.C)
+function tensor_product(M::OFPModule, F::FreeResolution; minimal::Bool=true)
+  return tensor_product(M, F.C; minimal=minimal)
 end
 
 
 @doc raw"""
-    tensor_product(C::ComplexOfMorphisms{<:OFPModule}, M::OFPModule)
+    tensor_product(C::ComplexOfMorphisms{<:OFPModule}, M::OFPModule; minimal::Bool=true)
 
 Return the complex obtained by applying $\bullet\;\! \otimes$ `M` to `C`.
 """
-function tensor_product(C::Hecke.ComplexOfMorphisms{<:OFPModule}, P::OFPModule)
+function tensor_product(C::Hecke.ComplexOfMorphisms{<:OFPModule}, P::OFPModule; minimal::Bool=true)
   #tensor_chain = Hecke.map_type(C)[]
   tensor_chain = valtype(C.maps)[]
   tensor_chain = Map[]
   chain_range = Hecke.map_range(C)
-  tensor_modules = [tensor_product(domain(map(C,first(chain_range))), P, task=:cache_morphism)[1]]
-  append!(tensor_modules, [tensor_product(codomain(map(C,i)), P, task=:cache_morphism)[1] for i in chain_range])
+  tensor_modules = [tensor_product(domain(map(C,first(chain_range))), P; task=:cache_morphism, minimal=minimal)[1]]
+  append!(tensor_modules, [tensor_product(codomain(map(C,i)), P; task=:cache_morphism, minimal=minimal)[1] for i in chain_range])
 
   for i=1:length(chain_range)
     A = tensor_modules[i]
@@ -213,8 +213,8 @@ function tensor_product(C::Hecke.ComplexOfMorphisms{<:OFPModule}, P::OFPModule)
   return Hecke.ComplexOfMorphisms(OFPModule, tensor_chain, seed=C.seed, typ=C.typ)
 end
 
-function tensor_product(F::FreeResolution, M::OFPModule)
-  return tensor_product(F.C, M)
+function tensor_product(F::FreeResolution, M::OFPModule; minimal::Bool=true)
+  return tensor_product(F.C, M; minimal=minimal)
 end
 
 @doc raw"""

--- a/src/Modules/UngradedModules/Presentation.jl
+++ b/src/Modules/UngradedModules/Presentation.jl
@@ -124,9 +124,9 @@ function _presentation_graded(SQ::SubquoModule)
   # At the same time, we can not just throw away zero 
   # generators, because other code relies on the 1:1-correspondence
   # of the generators in a presentation.
-  F0_to_SQ = graded_map(SQ, gens(SQ); check=false)
+  F0 = graded_free_module(R, degrees_of_generators(SQ))
+  F0_to_SQ = hom(F0, SQ, gens(SQ); check=false)
   F0_to_SQ.generators_map_to_generators = true
-  F0 = domain(F0_to_SQ)
 
   K, inc_K = kernel(F0_to_SQ)
   F1_to_F0 = graded_map(F0, images_of_generators(inc_K))

--- a/src/Modules/UngradedModules/Presentation.jl
+++ b/src/Modules/UngradedModules/Presentation.jl
@@ -12,7 +12,7 @@ Return a (free) presentation of `M`.
 function presentation(SQ::SubquoModule;
                       minimal=false)
   if minimal
-    return _presentation_minimal(SQ)
+    return _presentation_minimal_cached(SQ)
   elseif is_graded(SQ)
     return _presentation_graded(SQ)
   else
@@ -94,7 +94,11 @@ function presentation(SQ::SubquoModule;
   =#
 end
 
-function _presentation_graded(SQ::SubquoModule)
+@attr Hecke.ComplexOfMorphisms function _presentation_minimal_cached(SQ::OFPModule{T}) where {T <: Union{MPolyRingElem, MPolyQuoRingElem}}
+  return _presentation_minimal(SQ)
+end
+
+@attr Hecke.ComplexOfMorphisms function _presentation_graded(SQ::SubquoModule)
   #any(iszero(a) for a in gens(SQ)) && error("generators must not be zero for presentations in the graded case")
   R = base_ring(SQ)
 
@@ -152,7 +156,7 @@ function _presentation_graded(SQ::SubquoModule)
   return M
 end
 
-function _presentation_simple(SQ::SubquoModule)
+@attr Hecke.ComplexOfMorphisms function _presentation_simple(SQ::SubquoModule)
   R = base_ring(SQ)
 
   F = ambient_free_module(SQ)

--- a/src/Modules/UngradedModules/Presentation.jl
+++ b/src/Modules/UngradedModules/Presentation.jl
@@ -128,12 +128,18 @@ end
   # At the same time, we can not just throw away zero 
   # generators, because other code relies on the 1:1-correspondence
   # of the generators in a presentation.
-  F0 = graded_free_module(R, degrees_of_generators(SQ))
-  F0_to_SQ = hom(F0, SQ, gens(SQ); check=false)
-  F0_to_SQ.generators_map_to_generators = true
+  F0 = graded_free_module(R, degrees_of_generators(SQ; check=false))
+  zero_degree = zero(grading_group(R))
+  F0_to_SQ = graded_map(
+    F0, SQ, gens(SQ);
+    check=false,
+    hom_degree=zero_degree,
+    generators_map_to_generators=true
+  )
 
   K, inc_K = kernel(F0_to_SQ)
-  F1_to_F0 = graded_map(F0, images_of_generators(inc_K))
+  F1 = graded_free_module(R, degrees_of_generators(K; check=false))
+  F1_to_F0 = graded_map(F1, F0, images_of_generators(inc_K); check=false, hom_degree=zero_degree)
   F1 = domain(F1_to_F0)
   #F1 = graded_free_module(R, [degree(x; check=false) for x in images_of_generators(inc_K)])
   #F1_to_F0 = hom(F1, F0, images_of_generators(inc_K), check=false)

--- a/src/Modules/UngradedModules/Presentation.jl
+++ b/src/Modules/UngradedModules/Presentation.jl
@@ -9,9 +9,9 @@ Return a (free) presentation of `M`.
     If `minimal` is `true`, and `M` is positively graded, a minimal presentation is returned.
     If `minimal` is `true`, and `M` is not (positively) graded, the function still aims at returning an ''improved'' presentation.
 """
-function presentation(SQ::SubquoModule;
-                      minimal=false)
-  if minimal
+function presentation(SQ::SubquoModule{T};
+                      minimal=false) where {T}
+  if minimal && T <: Union{MPolyRingElem, MPolyQuoRingElem}
     return _presentation_minimal_cached(SQ)
   elseif is_graded(SQ)
     return _presentation_graded(SQ)

--- a/src/Modules/UngradedModules/SubQuoHom.jl
+++ b/src/Modules/UngradedModules/SubQuoHom.jl
@@ -842,9 +842,9 @@ julia> K, incl = kernel(a);
 
 julia> K
 Subquotient of submodule with 3 generators
-  1: (-x + y^2)*e[1]
-  2: x*y*e[1]
-  3: -x*y*e[1]
+  1: x*y*e[1]
+  2: (-x + y^2)*e[1]
+  3: x*y*e[1]
 by submodule with 3 generators
   1: x^2*e[1]
   2: y^3*e[1]
@@ -889,13 +889,13 @@ defined by
 julia> kernel(a)
 (Graded subquotient of graded submodule of F with 2 generators
   1: y*e[1]
-  2: -x*y*e[1]
+  2: x*y*e[1]
 by graded submodule of F with 3 generators
   1: x^2*e[1]
   2: y^3*e[1]
   3: z^4*e[1], Hom: graded subquotient of graded submodule of F with 2 generators
   1: y*e[1]
-  2: -x*y*e[1]
+  2: x*y*e[1]
 by graded submodule of F with 3 generators
   1: x^2*e[1]
   2: y^3*e[1]
@@ -1369,4 +1369,3 @@ Test if `f` is bijective.
 function is_bijective(f::OFPModuleHom)
   return is_injective(f) && is_surjective(f)
 end
-

--- a/src/Modules/UngradedModules/SubQuoHom.jl
+++ b/src/Modules/UngradedModules/SubQuoHom.jl
@@ -842,9 +842,9 @@ julia> K, incl = kernel(a);
 
 julia> K
 Subquotient of submodule with 3 generators
-  1: x*y*e[1]
-  2: (-x + y^2)*e[1]
-  3: x*y*e[1]
+  1: (-x + y^2)*e[1]
+  2: x*y*e[1]
+  3: -x*y*e[1]
 by submodule with 3 generators
   1: x^2*e[1]
   2: y^3*e[1]
@@ -889,13 +889,13 @@ defined by
 julia> kernel(a)
 (Graded subquotient of graded submodule of F with 2 generators
   1: y*e[1]
-  2: x*y*e[1]
+  2: -x*y*e[1]
 by graded submodule of F with 3 generators
   1: x^2*e[1]
   2: y^3*e[1]
   3: z^4*e[1], Hom: graded subquotient of graded submodule of F with 2 generators
   1: y*e[1]
-  2: x*y*e[1]
+  2: -x*y*e[1]
 by graded submodule of F with 3 generators
   1: x^2*e[1]
   2: y^3*e[1]

--- a/src/Modules/UngradedModules/Tensor.jl
+++ b/src/Modules/UngradedModules/Tensor.jl
@@ -115,11 +115,13 @@ end
 ⊗(G::OFPModule...) = tensor_product(G..., task = :none)
 
 @doc raw"""
-    tensor_product(M::OFPModule...; task::Symbol = :none)
+    tensor_product(M::OFPModule...; task::Symbol = :none, minimal::Bool = true)
 
 Given a collection of modules, say, $M_1, \dots, M_n$ over a ring $R$, return $M_1\otimes_R \cdots \otimes_R M_n$.
 
 If `task = :map`, additionally return the map which sends a tuple $(m_1,\dots, m_n)$ of elements $m_i\in M_i$ to the pure tensor $m_1\otimes\dots\otimes m_n$.
+
+By default, `minimal = true`: each factor is first replaced by an improved presentation before the tensor product presentation is assembled. This preserves the traditional, reduced-generator behaviour used by generic code. Passing `minimal = false` skips this reduction and can be faster when the caller can tolerate the larger, unreduced tensor presentation.
 
 # Examples
 ```jldoctest
@@ -154,7 +156,7 @@ julia> t((M[1], M[2]))
 e[1] \otimes e[2]
 ```
 """
-function tensor_product(G::OFPModule...; task::Symbol = :none, minimal::Bool = false)
+function tensor_product(G::OFPModule...; task::Symbol = :none, minimal::Bool = true)
   @assert length(G) > 0 "list of modules must not be empty"
   gs = [is_graded(g) for g in G]
   if !all(gs) && !all(!x for x in gs)

--- a/src/Modules/UngradedModules/Tensor.jl
+++ b/src/Modules/UngradedModules/Tensor.jl
@@ -3,14 +3,14 @@
 ##################################################
 
 @doc raw"""
-    tensor_product(F::FreeMod...; task::Symbol = :none)
+    tensor_product(F::FreeMod...; task::Symbol = :none, minimal::Bool = true)
 
 Given a collection of free modules, say, $F_1, \dots, F_n$ over a ring $R$, return $F_1\otimes_R \cdots \otimes_R F_n$.
 
 
 If `task = :map`, additionally return the map which sends a tuple $(f_1,\dots, f_n)$ of elements $f_i\in F_i$ to the pure tensor $f_1\otimes\dots\otimes f_n$.
 """
-function tensor_product(G::FreeMod...; task::Symbol = :none)
+function tensor_product(G::FreeMod...; task::Symbol = :none, minimal::Bool = true)
   gs = [is_graded(g) for g in G]
   if !all(gs) && !all(!x for x in gs)
     error("All factors must either be graded or all must be ungraded.")

--- a/src/Modules/UngradedModules/Tensor.jl
+++ b/src/Modules/UngradedModules/Tensor.jl
@@ -195,10 +195,13 @@ function tensor_product(G::OFPModule...; task::Symbol = :none, minimal::Bool = f
     strides[k] = strides[k + 1] * sizes[k + 1]
   end
 
+  rankF = rank(F)
   I = elem_type(F)[]
-  sizehint!(I, sum(nrows(mats[i]) * div(rank(F), sizes[i]) for i in 1:n))
-  for i in 1:n
-    _append_tensor_relations!(I, F, mats[i], sizes, strides, i)
+  if rankF != 0
+    sizehint!(I, sum(nrows(mats[i]) * div(rankF, sizes[i]) for i in 1:n))
+    for i in 1:n
+      _append_tensor_relations!(I, F, mats[i], sizes, strides, i)
+    end
   end
 
   result = SubquoModule(F, gens(F), I)
@@ -209,6 +212,7 @@ function tensor_product(G::OFPModule...; task::Symbol = :none, minimal::Bool = f
   function pure(tuple_elems::OFPModuleElem...)
     @assert length(tuple_elems) == n
     @assert all(i -> parent(tuple_elems[i]) === G[i], 1:n)
+    rankF == 0 && return zero(result)
     pre = ntuple(i -> preimage(augs[i], tuple_elems[i]), n)
     ww = free_pure(pre...)
     return result(coordinates(ww))

--- a/src/Modules/UngradedModules/Tensor.jl
+++ b/src/Modules/UngradedModules/Tensor.jl
@@ -142,16 +142,16 @@ julia> T, t = tensor_product(M, M; task = :map);
 
 julia> gens(T)
 4-element Vector{SubquoModuleElem{QQMPolyRingElem}}:
- (e[1] \otimes e[1])
- (e[1] \otimes e[2])
- (e[2] \otimes e[1])
- (e[2] \otimes e[2])
+ e[1] \otimes e[1]
+ e[1] \otimes e[2]
+ e[2] \otimes e[1]
+ e[2] \otimes e[2]
 
 julia> domain(t)
 parent of tuples of type Tuple{SubquoModuleElem{QQMPolyRingElem}, SubquoModuleElem{QQMPolyRingElem}}
 
 julia> t((M[1], M[2]))
-(e[1] \otimes e[2])
+e[1] \otimes e[2]
 ```
 """
 function tensor_product(G::OFPModule...; task::Symbol = :none, minimal::Bool = false)

--- a/src/Modules/UngradedModules/Tensor.jl
+++ b/src/Modules/UngradedModules/Tensor.jl
@@ -15,12 +15,16 @@ function tensor_product(G::FreeMod...; task::Symbol = :none)
   if !all(gs) && !all(!x for x in gs)
     error("All factors must either be graded or all must be ungraded.")
   end
-  t = [[x] for x = 1:ngens(G[1])]
-  for H = G[2:end]
-    t = [push!(deepcopy(x), y) for x = t  for y = 1:ngens(H)]
+  n = length(G)
+  sizes = [ngens(g) for g in G]
+  strides = Vector{Int}(undef, n)
+  strides[n] = 1
+  for k in (n - 1):-1:1
+    strides[k] = strides[k + 1] * sizes[k + 1]
   end
 
-  F = FreeMod(G[1].R, prod([rank(g) for g in G]))
+  rankF = prod(sizes)
+  F = FreeMod(G[1].R, rankF)
   F.S = function _get_tensor_symbols()
     return Symbol.([join(["$(symbol(G[k], i[length(G)-k+1]))" for k in 1:length(G)], " \\otimes ") for i in AbstractAlgebra.ProductIterator([1:ngens(g) for g in reverse(G)])])
   end
@@ -28,24 +32,48 @@ function tensor_product(G::FreeMod...; task::Symbol = :none)
   set_attribute!(F, :show => Hecke.show_tensor_product, :tensor_product => G)
 
   function pure(g::FreeModElem...)
-    @assert length(g) == length(G)
-    @assert all(i -> parent(g[i]) === G[i], 1:length(G))
-    z = [[x] for x = coordinates(g[1]).pos]
-    zz = coordinates(g[1]).values
-    for h = g[2:end]
-      zzz = Vector{Int}[]
-      zzzz = elem_type(F.R)[]
-      for i = 1:length(z)
-        for (p, v) in coordinates(h)
-          push!(zzz, push!(deepcopy(z[i]), p))
-          push!(zzzz, zz[i]*v)
+    @assert length(g) == n
+    @assert all(i -> parent(g[i]) === G[i], 1:n)
+    c = coordinates(g[1])
+    if length(c.pos) == 0
+      return zero(F)
+    end
+    indices = Vector{Int}(undef, length(c.pos))
+    coeffs = Vector{elem_type(F.R)}(undef, length(c.pos))
+    for a in 1:length(c.pos)
+      indices[a] = 1 + (c.pos[a] - 1) * strides[1]
+      coeffs[a] = c.values[a]
+    end
+    nz = length(indices)
+    for k in 2:n
+      ck = coordinates(g[k])
+      if length(ck.pos) == 0 || nz == 0
+        return zero(F)
+      end
+      new_indices = Vector{Int}(undef, nz * length(ck.pos))
+      new_coeffs = Vector{elem_type(F.R)}(undef, nz * length(ck.pos))
+      t = 0
+      for a in 1:nz
+        idx_base = indices[a]
+        coeff_base = coeffs[a]
+        for b in 1:length(ck.pos)
+          prod = coeff_base * ck.values[b]
+          iszero(prod) && continue
+          t += 1
+          new_indices[t] = idx_base + (ck.pos[b] - 1) * strides[k]
+          new_coeffs[t] = prod
         end
       end
-      z = zzz
-      zz = zzzz
+      if t == 0
+        return zero(F)
+      end
+      resize!(new_indices, t)
+      resize!(new_coeffs, t)
+      indices = new_indices
+      coeffs = new_coeffs
+      nz = t
     end
-    indices = Vector{Int}([findfirst(==(y), t) for y = z])
-    return FreeModElem(sparse_row(F.R, indices, zz), F)
+    return FreeModElem(sparse_row(F.R, indices, coeffs), F)
   end
   function pure(T::Tuple)
     return pure(T...)
@@ -57,13 +85,22 @@ function tensor_product(G::FreeMod...; task::Symbol = :none)
     end
     @assert length(c.pos) == 1
     @assert isone(c.values[1])
-    return Tuple(gen(G[i], t[c.pos[1]][i]) for i = 1:length(G))
+    q = c.pos[1] - 1
+    return Tuple(gen(G[i], (q ÷ strides[i]) % sizes[i] + 1) for i = 1:n)
   end
 
   set_attribute!(F, :tensor_pure_function => pure, :tensor_generator_decompose_function => inv_pure)
 
   if all(is_graded, G)
-    tensor_degrees = [sum(G[i].d[tplidx[i]] for i in 1:length(G)) for tplidx in t] 
+    GG = grading_group(F.R)
+    tensor_degrees = Vector{elem_type(GG)}(undef, rankF)
+    for q in 0:(rankF - 1)
+      d = zero(GG)
+      for i in 1:n
+        d += G[i].d[(q ÷ strides[i]) % sizes[i] + 1]
+      end
+      tensor_degrees[q + 1] = d
+    end
     F.d = tensor_degrees
   end
 
@@ -126,37 +163,53 @@ function tensor_product(G::OFPModule...; task::Symbol = :none, minimal::Bool = f
   R = base_ring(G[1])
   @assert all(base_ring(M) === R for M in G) "modules must be defined over the same ring"
 
-  pres = [presentation(M; minimal=minimal) for M in G]
-  d1s = [map(p, 1) for p in pres]
-  augs = [map(p, 0) for p in pres]
-  F0s = [domain(a) for a in augs]
-  mats = [sparse_matrix(d) for d in d1s]
+  n = length(G)
+  cache = IdDict{Any, Tuple{Any, Any, Any}}()
+  augs = Vector{Any}(undef, n)
+  F0s = Vector{Any}(undef, n)
+  mats = Vector{Any}(undef, n)
+  for i in 1:n
+    M = G[i]
+    data = get!(cache, M) do
+      p = presentation(M; minimal=minimal)
+      d1 = map(p, 1)
+      aug = map(p, 0)
+      F0 = domain(aug)
+      mat = _sparse_matrix_cached(d1)
+      (aug, F0, mat)
+    end
+    augs[i] = data[1]
+    F0s[i] = data[2]
+    mats[i] = data[3]
+  end
   if !minimal
-    @assert all(ncols(mats[i]) == ngens(G[i]) for i in 1:length(G)) "presentations do not implement a 1:1 correspondence for the generators"
+    @assert all(ncols(mats[i]) == ngens(G[i]) for i in 1:n) "presentations do not implement a 1:1 correspondence for the generators"
   end
 
   F = tensor_product(F0s...; task=:none)
 
-  ids = [_sparse_identity_matrix(R, ngens(F0)) for F0 in F0s]
-  A = sparse_matrix(R, 0, ngens(F))
-  for i in 1:length(G)
-    saved = ids[i]
-    ids[i] = mats[i]
-    block = _kronecker_product(ids)
-    vcat!(A, block)
-    ids[i] = saved
+  sizes = [ngens(F0) for F0 in F0s]
+  strides = Vector{Int}(undef, n)
+  strides[n] = 1
+  for k in (n - 1):-1:1
+    strides[k] = strides[k + 1] * sizes[k + 1]
   end
 
-  I = [F(v) for v in A]
+  I = elem_type(F)[]
+  sizehint!(I, sum(nrows(mats[i]) * div(rank(F), sizes[i]) for i in 1:n))
+  for i in 1:n
+    _append_tensor_relations!(I, F, mats[i], sizes, strides, i)
+  end
+
   result = SubquoModule(F, gens(F), I)
 
   free_pure = tensor_pure_function(F)
   free_decomp = tensor_generator_decompose_function(F)
 
   function pure(tuple_elems::OFPModuleElem...)
-    @assert length(tuple_elems) == length(G)
-    @assert all(i -> parent(tuple_elems[i]) === G[i], 1:length(G))
-    pre = [preimage(augs[i], tuple_elems[i]) for i in 1:length(G)]
+    @assert length(tuple_elems) == n
+    @assert all(i -> parent(tuple_elems[i]) === G[i], 1:n)
+    pre = ntuple(i -> preimage(augs[i], tuple_elems[i]), n)
     ww = free_pure(pre...)
     return result(coordinates(ww))
   end
@@ -171,7 +224,7 @@ function tensor_product(G::OFPModule...; task::Symbol = :none, minimal::Bool = f
     @assert isone(c.values[1])
     i = c.pos[1]
     dec = free_decomp(gen(F, i))
-    return Tuple(augs[j](dec[j]) for j in 1:length(G))
+    return Tuple(augs[j](dec[j]) for j in 1:n)
   end
 
   set_attribute!(result, :tensor_pure_function => pure, :tensor_generator_decompose_function => decompose_generator)
@@ -185,70 +238,44 @@ function tensor_product(G::OFPModule...; task::Symbol = :none, minimal::Bool = f
   return result, MapFromFunc(Hecke.TupleParent(Tuple([zero(g) for g = G])), result, pure, decompose_generator)
 end
 
-function _kronecker_product(mats::Vector)
-  @assert !isempty(mats)
-  return _kronecker_product(mats, 1, length(mats))
+@attr Any function _sparse_matrix_cached(d::OFPModuleHom)
+  return sparse_matrix(d)
 end
 
-function _kronecker_product(mats::Vector, l::Int, r::Int)
-  l == r && return mats[l]
-  if l + 1 == r
-    return _kronecker_product(mats[l], mats[r])
-  end
-  m = (l + r) >>> 1
-  return _kronecker_product(_kronecker_product(mats, l, m), _kronecker_product(mats, m + 1, r))
-end
-
-function _kronecker_product(A, B)
-  R = base_ring(A)
-  m1, n1 = size(A)
-  m2, n2 = size(B)
-  C = sparse_matrix(R, 0, n1 * n2)
-  T = elem_type(R)
-  for i in 1:m1
-    r1 = A[i]
-    p1 = r1.pos
-    v1 = r1.values
-    nnz1 = length(p1)
-    for j in 1:m2
-      r2 = B[j]
-      p2 = r2.pos
-      v2 = r2.values
-      nnz2 = length(p2)
-      if nnz1 == 0 || nnz2 == 0
-        push!(C, sparse_row(R))
+function _append_tensor_relations!(rels::Vector, F::FreeMod, mat, sizes::Vector{Int}, strides::Vector{Int}, i::Int)
+  n = length(sizes)
+  nrows(mat) == 0 && return rels
+  stride_i = strides[i]
+  idx = ones(Int, n)
+  base = 1
+  while true
+    for r in mat
+      p = r.pos
+      if length(p) == 0
         continue
       end
-      pos = Vector{Int}(undef, nnz1 * nnz2)
-      vals = Vector{T}(undef, nnz1 * nnz2)
-      k = 0
-      for a in 1:nnz1
-        base = (p1[a] - 1) * n2
-        c1 = v1[a]
-        for b in 1:nnz2
-          prod = c1 * v2[b]
-          iszero(prod) && continue
-          k += 1
-          pos[k] = base + p2[b]
-          vals[k] = prod
-        end
+      pos = Vector{Int}(undef, length(p))
+      for a in 1:length(p)
+        pos[a] = base + (p[a] - 1) * stride_i
       end
-      if k == 0
-        push!(C, sparse_row(R))
-      else
-        resize!(pos, k)
-        resize!(vals, k)
-        push!(C, sparse_row(R, pos, vals))
-      end
+      push!(rels, FreeModElem(sparse_row(base_ring(F), pos, copy(r.values)), F))
     end
+    k = n
+    while k >= 1
+      if k == i
+        k -= 1
+        continue
+      end
+      idx[k] += 1
+      base += strides[k]
+      if idx[k] <= sizes[k]
+        break
+      end
+      idx[k] = 1
+      base -= sizes[k] * strides[k]
+      k -= 1
+    end
+    k == 0 && break
   end
-  return C
-end
-
-function _sparse_identity_matrix(R, n::Int)
-  A = sparse_matrix(R, 0, n)
-  for i in 1:n
-    push!(A, sparse_row(R, [i], [one(R)]))
-  end
-  return A
+  return rels
 end

--- a/src/Modules/UngradedModules/Tensor.jl
+++ b/src/Modules/UngradedModules/Tensor.jl
@@ -264,7 +264,7 @@ function _append_tensor_relations!(rels::Vector, F::FreeMod, mat, sizes::Vector{
       for a in 1:length(p)
         pos[a] = base + (p[a] - 1) * stride_i
       end
-      push!(rels, FreeModElem(sparse_row(base_ring(F), pos, copy(r.values)), F))
+      push!(rels, FreeModElem(sparse_row(base_ring(F), pos, copy(r.values); sort=false), F))
     end
     k = n
     while k >= 1

--- a/src/Modules/UngradedModules/Tensor.jl
+++ b/src/Modules/UngradedModules/Tensor.jl
@@ -117,46 +117,67 @@ julia> t((M[1], M[2]))
 (e[1] \otimes e[2])
 ```
 """
-function tensor_product(G::OFPModule...; task::Symbol = :none)
-  resols = AbsHyperComplex[]
-  augs = OFPModuleHom[]
-  for M in G
-    res, aug = free_resolution(SimpleFreeResolution, M)
-    push!(resols, res)
-    push!(augs, aug[0])
+function tensor_product(G::OFPModule...; task::Symbol = :none, minimal::Bool = false)
+  @assert length(G) > 0 "list of modules must not be empty"
+  gs = [is_graded(g) for g in G]
+  if !all(gs) && !all(!x for x in gs)
+    error("All factors must either be graded or all must be ungraded.")
   end
-  res_prod = tensor_product(resols)
-  tot = total_complex(res_prod)
-  pres = map(tot, 1)
-  I, inc_I = image(pres)
-  result, pr_res = quo(tot[0], I)
-  
-  # assemble the multiplication and decomposition functions
-  z = Tuple([0 for _ in 1:length(G)])
-  @assert _is_tensor_product(res_prod[z])[1]
-  function pure(tuple_elems::Union{SubquoModuleElem,FreeModElem}...)
-    w = [preimage(augs[i], x) for (i, x) in enumerate(tuple_elems)]
-    free_pure = tensor_pure_function(res_prod[z])
-    ww = free_pure(w...)
-    return pr_res(canonical_injection(tot[0], 1)(ww))
+  R = base_ring(G[1])
+  @assert all(base_ring(M) === R for M in G) "modules must be defined over the same ring"
+
+  pres = [presentation(M; minimal=minimal) for M in G]
+  d1s = [map(p, 1) for p in pres]
+  augs = [map(p, 0) for p in pres]
+  F0s = [domain(a) for a in augs]
+  mats = [sparse_matrix(d) for d in d1s]
+  if !minimal
+    @assert all(ncols(mats[i]) == ngens(G[i]) for i in 1:length(G)) "presentations do not implement a 1:1 correspondence for the generators"
   end
-  function pure(T::Tuple)
-    return pure(T...)
+
+  F = tensor_product(F0s...; task=:none)
+
+  ids = [_sparse_identity_matrix(R, ngens(F0)) for F0 in F0s]
+  A = sparse_matrix(R, 0, ngens(F))
+  for i in 1:length(G)
+    saved = ids[i]
+    ids[i] = mats[i]
+    block = _kronecker_product(ids)
+    vcat!(A, block)
+    ids[i] = saved
   end
-  
-  decompose_generator = function(v::SubquoModuleElem)
-    ind = findfirst(==(v), images_of_generators(pr_res))
-    isnothing(ind) && error("the given element is not the image of a generator under the projection map")
-    vv = gen(tot[0], ind::Int)
-    w = canonical_projection(tot[0], 1)(vv)
-    w_dec = tensor_generator_decompose_function(res_prod[z])(w)
-    return Tuple([augs[i](x) for (i, x) in enumerate(w_dec)])
+
+  I = [F(v) for v in A]
+  result = SubquoModule(F, gens(F), I)
+
+  free_pure = tensor_pure_function(F)
+  free_decomp = tensor_generator_decompose_function(F)
+
+  function pure(tuple_elems::OFPModuleElem...)
+    @assert length(tuple_elems) == length(G)
+    @assert all(i -> parent(tuple_elems[i]) === G[i], 1:length(G))
+    pre = [preimage(augs[i], tuple_elems[i]) for i in 1:length(G)]
+    ww = free_pure(pre...)
+    return result(coordinates(ww))
+  end
+  pure(T::Tuple) = pure(T...)
+
+  function decompose_generator(v::SubquoModuleElem)
+    c = coordinates(v)
+    if length(c.pos) == 0
+      return Tuple(zero(M) for M in G)
+    end
+    @assert length(c.pos) == 1
+    @assert isone(c.values[1])
+    i = c.pos[1]
+    dec = free_decomp(gen(F, i))
+    return Tuple(augs[j](dec[j]) for j in 1:length(G))
   end
 
   set_attribute!(result, :tensor_pure_function => pure, :tensor_generator_decompose_function => decompose_generator)
   set_attribute!(result, :show => Hecke.show_tensor_product, :tensor_product => G)
   @assert _is_tensor_product(result)[1]
-  
+
   if task == :none
     return result
   end
@@ -164,4 +185,70 @@ function tensor_product(G::OFPModule...; task::Symbol = :none)
   return result, MapFromFunc(Hecke.TupleParent(Tuple([zero(g) for g = G])), result, pure, decompose_generator)
 end
 
+function _kronecker_product(mats::Vector)
+  @assert !isempty(mats)
+  return _kronecker_product(mats, 1, length(mats))
+end
 
+function _kronecker_product(mats::Vector, l::Int, r::Int)
+  l == r && return mats[l]
+  if l + 1 == r
+    return _kronecker_product(mats[l], mats[r])
+  end
+  m = (l + r) >>> 1
+  return _kronecker_product(_kronecker_product(mats, l, m), _kronecker_product(mats, m + 1, r))
+end
+
+function _kronecker_product(A, B)
+  R = base_ring(A)
+  m1, n1 = size(A)
+  m2, n2 = size(B)
+  C = sparse_matrix(R, 0, n1 * n2)
+  T = elem_type(R)
+  for i in 1:m1
+    r1 = A[i]
+    p1 = r1.pos
+    v1 = r1.values
+    nnz1 = length(p1)
+    for j in 1:m2
+      r2 = B[j]
+      p2 = r2.pos
+      v2 = r2.values
+      nnz2 = length(p2)
+      if nnz1 == 0 || nnz2 == 0
+        push!(C, sparse_row(R))
+        continue
+      end
+      pos = Vector{Int}(undef, nnz1 * nnz2)
+      vals = Vector{T}(undef, nnz1 * nnz2)
+      k = 0
+      for a in 1:nnz1
+        base = (p1[a] - 1) * n2
+        c1 = v1[a]
+        for b in 1:nnz2
+          prod = c1 * v2[b]
+          iszero(prod) && continue
+          k += 1
+          pos[k] = base + p2[b]
+          vals[k] = prod
+        end
+      end
+      if k == 0
+        push!(C, sparse_row(R))
+      else
+        resize!(pos, k)
+        resize!(vals, k)
+        push!(C, sparse_row(R, pos, vals))
+      end
+    end
+  end
+  return C
+end
+
+function _sparse_identity_matrix(R, n::Int)
+  A = sparse_matrix(R, 0, n)
+  for i in 1:n
+    push!(A, sparse_row(R, [i], [one(R)]))
+  end
+  return A
+end

--- a/test/AlgebraicGeometry/Surfaces/adjunction.jl
+++ b/test/AlgebraicGeometry/Surfaces/adjunction.jl
@@ -1,11 +1,46 @@
 @testset "adjunction theory for surfaces" begin
-  X = rational_d7_pi4();
+  X = rational_d7_pi4()
   L = adjunction_process(X)
   @test L[1][2][1] == L[1][2][2] == 3
   @test L[1][2][3] == sectional_genus(L[4]) == 1
-  X = enriques_d9_pi6();
+  X = enriques_d9_pi6()
   L = adjunction_process(X)
   @test L[1][2][4] == 1
+end
+
+@testset "fast canonical presentation for adjunction" begin
+  X = bordiga()
+
+  Dfast = Oscar._canonical_presentation_matrix_for_adjunction(X)
+  Ddirect = Oscar._canonical_presentation_matrix_for_adjunction(X; algorithm = :direct)
+  Dmodule = Oscar._canonical_presentation_matrix_for_adjunction(X; algorithm = :module)
+
+  @test Dfast == Ddirect
+  @test ncols(Dfast) == ncols(Dmodule)
+  @test Oscar._matrix_has_no_quadratic_or_higher_entries(Dfast)
+  @test Oscar._matrix_has_no_quadratic_or_higher_entries(Dmodule)
+
+  L = adjunction_process(X, 1; canonical_algorithm = :direct)
+  @test L[1][2] == (ZZ(2), ZZ(1), ZZ(0), ZZ(10))
+end
+
+@testset "linkage linear strand canonical presentation" begin
+  X = rational_d10_pi8()
+
+  D = Oscar._canonical_presentation_matrix_for_adjunction(X; algorithm = :linkage_linear_strand)
+
+  @test base_ring(D) === ambient_coordinate_ring(X)
+  @test Oscar._matrix_has_no_quadratic_or_higher_entries(D)
+  @test ncols(D) > 0
+end
+
+@testset "direct canonical presentation may be nonlinear" begin
+  R, x = graded_polynomial_ring(QQ, :x => (1:4))
+  X = variety(ideal(R, [x[1]^3 + x[2]^3 + x[3]^3 + x[4]^3]))
+  D = Oscar._canonical_presentation_matrix_for_adjunction(X; algorithm = :fast)
+
+  @test !Oscar._matrix_has_no_quadratic_or_higher_entries(D)
+  @test D == Oscar._canonical_presentation_matrix_for_adjunction(X; algorithm = :direct)
 end
 
 @testset "parametrization" begin
@@ -14,4 +49,3 @@ end
   R = domain(H)
   @test total_degree(H(gens(R)[1])) == 4
 end
-

--- a/test/Modules/ModulesGraded.jl
+++ b/test/Modules/ModulesGraded.jl
@@ -514,6 +514,23 @@ end
     @test degrees_of_generators(M) == [3*Z[1], 3*Z[1]]
 end
 
+@testset "Presentation preserves degrees for zero generators" begin
+    Rg, (x,) = graded_polynomial_ring(QQ, [:x])
+    Z = grading_group(Rg)
+
+    F = graded_free_module(Rg, 1)
+    A = Rg[x; x^2]
+    B = Rg[x^2;]
+    M = SubquoModule(F, A, B)
+
+    @test is_graded(M)
+    @test degrees_of_generators(M) == [1*Z[1], 2*Z[1]]
+
+    pres = presentation(M; minimal=false)
+    F0 = domain(map(pres, 0))
+    @test degrees_of_generators(F0) == degrees_of_generators(M)
+end
+
 @testset "Betti tables 1" begin
     Rg, (x, y, z) = graded_polynomial_ring(QQ, [:x, :y, :z])
     F = graded_free_module(Rg, 1)

--- a/test/Modules/ModulesGraded.jl
+++ b/test/Modules/ModulesGraded.jl
@@ -511,7 +511,7 @@ end
     @test is_graded(M)
     v = pure_M((M1[1],M2[1]))
     @test degree(v) == 3*Z[1]
-    @test degrees_of_generators(M) == [3*Z[1], 3*Z[1]]
+    @test degrees_of_generators(M) == [3*Z[1]]
 end
 
 @testset "Presentation preserves degrees for zero generators" begin

--- a/test/Modules/ModulesGraded.jl
+++ b/test/Modules/ModulesGraded.jl
@@ -525,6 +525,11 @@ end
 
     @test is_graded(M)
     @test degrees_of_generators(M) == [1*Z[1], 2*Z[1]]
+    @test is_zero(M[2])
+    @test degree(M[2]) == 2*Z[1]
+
+    h = graded_map(M, gens(M); check=false)
+    @test degrees_of_generators(domain(h)) == degrees_of_generators(M)
 
     pres = presentation(M; minimal=false)
     F0 = domain(map(pres, 0))

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -1427,6 +1427,22 @@ end
   @test b == b0
 end
 
+@testset "tensor_product with minimal presentations" begin
+  R, (x,) = polynomial_ring(QQ, [:x])
+  F = free_module(R, 1)
+  M = SubquoModule(F, [x*F[1], x*F[1]], [x^2*F[1]])
+  T0 = tensor_product(M, M)
+  T1 = tensor_product(M, M; minimal=true)
+  @test !is_zero(T0)
+  @test !is_zero(T1)
+  @test ngens(T1) <= ngens(T0)
+  pure1 = Oscar.tensor_pure_function(T1)
+  decomp1 = Oscar.tensor_generator_decompose_function(T1)
+  g = gen(T1, 1)
+  @test pure1(decomp1(g)...) == g
+  @test pure1(M[1] + M[2], M[1]) == pure1(M[1], M[1]) + pure1(M[2], M[1])
+end
+
 @testset "composition of morphisms" begin
   R, (x, y) = QQ[:x, :y]
   P, t = QQ[:t]

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -2235,3 +2235,19 @@ end
   @test normal_form(v, SB) == -x*F[3]
   @test normal_form(w, SB) == zero(F)
 end
+
+@testset "kernel to subquotient representative reduction option" begin
+  R, (x, y, z) = polynomial_ring(QQ, [:x, :y, :z])
+  F = free_module(R, 1)
+  A = R[x; y]
+  B = R[x^2; y^3; z^4]
+  M = SubquoModule(F, A, B)
+  G = free_module(R, 2)
+  phi = hom(G, M, [M[1], M[2]]; check=false)
+
+  K_reduced, _ = kernel(phi)
+  K_fast, _ = kernel(phi; reduce_generators=false)
+
+  @test all(r -> iszero(phi(r)), ambient_representatives_generators(K_reduced))
+  @test all(r -> iszero(phi(r)), ambient_representatives_generators(K_fast))
+end

--- a/test/book/cornerstones/algebraic-geometry/ex314.jlcon
+++ b/test/book/cornerstones/algebraic-geometry/ex314.jlcon
@@ -54,9 +54,9 @@ Graded subquotient of graded submodule of S^2 with 2 generators
   1: e[1]
   2: e[2]
 by graded submodule of S^2 with 3 generators
-  1: x_2*e[1] - x_3*e[2]
-  2: x_1*e[1] - x_2*e[2]
-  3: x_0*e[1] - x_1*e[2]
+  1: -x_2*e[1] + x_3*e[2]
+  2: x_0*e[1] - x_1*e[2]
+  3: -x_1*e[1] + x_2*e[2]
 
 julia> degrees_of_generators(hom1)
 2-element Vector{FinGenAbGroupElem}:

--- a/test/book/cornerstones/algebraic-geometry/ex314.jlcon
+++ b/test/book/cornerstones/algebraic-geometry/ex314.jlcon
@@ -54,9 +54,9 @@ Graded subquotient of graded submodule of S^2 with 2 generators
   1: e[1]
   2: e[2]
 by graded submodule of S^2 with 3 generators
-  1: -x_2*e[1] + x_3*e[2]
-  2: x_0*e[1] - x_1*e[2]
-  3: -x_1*e[1] + x_2*e[2]
+  1: x_2*e[1] - x_3*e[2]
+  2: x_1*e[1] - x_2*e[2]
+  3: x_0*e[1] - x_1*e[2]
 
 julia> degrees_of_generators(hom1)
 2-element Vector{FinGenAbGroupElem}:


### PR DESCRIPTION
On issue #5954 taking out the route via the experimental code and improving performance. According to discussions with @HechtiDerLachs on #5970. Perhaps solving some of the remaining issues there, allowing for minimalization, performance tweaks. We get now:

```
julia> @time T, mm = tensor_product([M for _ in 1:7]...; task=:with_maps, minimal = true);
 10.158745 seconds (141.86 M allocations: 5.864 GiB, 51.40% gc time, 2.24% compilation time)
```

