### PR TITLE
Optimize `stabilizer(G, v, permuted)`

### DIFF
--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -672,11 +672,13 @@ function _stabilizer_generic(G::GAPGroup, pnt::Any, actfun::Function)
     GapObj(actfun)))
 end
 
+
 # natural stabilizers in permutation groups
 # Construct the arguments on the GAP side such that GAP's method selection
 # can choose the special method.
 # - stabilizer in a perm. group of an integer via `^`
 # - stabilizer in a perm. group of a vector of integers via `on_tuples`
+# - stabilizer in a perm. group of a vector of integers via `permuted`
 # - stabilizer in a perm. group of a set of integers via `on_sets`
 function stabilizer(G::PermGroup, pnt::T) where T <: IntegerUnion
   return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
@@ -688,6 +690,13 @@ function stabilizer(G::PermGroup, pnt::Union{Vector{T}, Tuple{T, Vararg{T}}}) wh
   return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
     GapObj(pnt, recursive = true),
     GAP.Globals.OnTuples))  # Do not use GAPWrap.OnTuples!
+end
+
+# with no group given, compute the stabilizer assuming we are acting by permuting entries
+function stabilizer_permuted(G::PermGroup, pnt::Union{Vector{T}, Tuple{T, Vararg{T}}}) where T <: Oscar.IntegerUnion
+  return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+    GapObj(pnt, recursive = true),
+    GAP.Globals.Permuted))  # Do not use GAPWrap.Permuted!
 end
 
 function stabilizer(G::PermGroup, pnt::AbstractSet{T}) where T <: Oscar.IntegerUnion
@@ -703,8 +712,15 @@ function stabilizer(G::PermGroup, pnt::T, actfun::Function) where T <: IntegerUn
 end
 
 function stabilizer(G::PermGroup, pnt::Union{Vector{T},Tuple{T,Vararg{T}}}, actfun::Function) where T <: IntegerUnion
-  return actfun == on_tuples ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
+  actfun == on_tuples && return stabilizer(G, pnt)
+  actfun == permuted && return  stabilizer_permuted(G, pnt)
+  return _stabilizer_generic(G, pnt, actfun)
 end
+
+
+
+
+
 
 function stabilizer(G::PermGroup, pnt::AbstractSet{T}, actfun::Function) where T <: IntegerUnion
   return actfun == on_sets ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -692,7 +692,7 @@ function stabilizer(G::PermGroup, pnt::Union{Vector{T}, Tuple{T, Vararg{T}}}) wh
     GAP.Globals.OnTuples))  # Do not use GAPWrap.OnTuples!
 end
 
-# with no group given, compute the stabilizer assuming we are acting by permuting entries
+# compute the stabilizer of a tuple acting by permuting entries
 function stabilizer_permuted(G::PermGroup, pnt::Union{Vector{T}, Tuple{T, Vararg{T}}}) where T <: Oscar.IntegerUnion
   return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
     GapObj(pnt, recursive = true),

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -732,23 +732,6 @@ function stabilizer(G::PermGroup, pnt::Union{Vector{T},Tuple{T,Vararg{T}}}, actf
 end
 
 
-"""
-    automorphism_group(v::Union{Vector,Tuple})
-
-Returns `S, emb` where `S` is the subgroup of `symmetric_group(length(v))`
-leaving `v` invariant under the permutation of the entries, and `emb` is
-the embedding of `S` into this symmetric group.
-This is shorthand for `stabilizer(symmetric_group(length(v)), v, permuted)`.
-
-# Examples
-```jldoctest
-julia> S = automorphism_group([1, 1, 2, 2, 3]);  order(S[1])
-4
-```
-"""
-automorphism_group(v::Union{Vector{T},Tuple{T,Vararg{T}}}) where T = stabilizer(symmetric_group(length(v)), v, permuted)
-
-
 function stabilizer(G::PermGroup, pnt::AbstractSet{T}, actfun::Function) where T <: IntegerUnion
   return actfun == on_sets ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
 end

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -699,6 +699,15 @@ function stabilizer_permuted(G::PermGroup, pnt::Union{Vector{T}, Tuple{T, Vararg
     GAP.Globals.Permuted))  # Do not use GAPWrap.Permuted!
 end
 
+# compute the stabilizer of a tuple acting by permuting entries
+function stabilizer_permuted(G::PermGroup, pnt::Union{Vector{T}, Tuple{T, Vararg{T}}}) where T
+  pnt2 = map( x -> findfirst(isequal(x), unique(pnt)), pnt)
+  return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
+    GapObj(pnt2, recursive = true),
+    GAP.Globals.Permuted))  # Do not use GAPWrap.Permuted!
+end
+
+
 function stabilizer(G::PermGroup, pnt::AbstractSet{T}) where T <: Oscar.IntegerUnion
   return Oscar._as_subgroup(G, GAPWrap.Stabilizer(GapObj(G),
     GapObj(pnt, recursive = true),
@@ -717,9 +726,10 @@ function stabilizer(G::PermGroup, pnt::Union{Vector{T},Tuple{T,Vararg{T}}}, actf
   return _stabilizer_generic(G, pnt, actfun)
 end
 
-
-
-
+function stabilizer(G::PermGroup, pnt::Union{Vector{T},Tuple{T,Vararg{T}}}, actfun::Function) where T
+  actfun == permuted && return  stabilizer_permuted(G, pnt)
+  return _stabilizer_generic(G, pnt, actfun)
+end
 
 
 function stabilizer(G::PermGroup, pnt::AbstractSet{T}, actfun::Function) where T <: IntegerUnion

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -732,6 +732,23 @@ function stabilizer(G::PermGroup, pnt::Union{Vector{T},Tuple{T,Vararg{T}}}, actf
 end
 
 
+"""
+    automorphism_group(v::Union{Vector,Tuple})
+
+Returns `S, emb` where `S` is the subgroup of `symmetric_group(length(v))`
+leaving `v` invariant under the permutation of the entries, and `emb` is
+the embedding of `S` into this symmetric group.
+This is shorthand for `stabilizer(symmetric_group(length(v)), v, permuted)`.
+
+# Examples
+```jldoctest
+julia> S = automorphism_group([1, 1, 2, 2, 3]);  order(S[1])
+4
+```
+"""
+automorphism_group(v::Union{Vector{T},Tuple{T,Vararg{T}}}) where T = stabilizer(symmetric_group(length(v)), v, permuted)
+
+
 function stabilizer(G::PermGroup, pnt::AbstractSet{T}, actfun::Function) where T <: IntegerUnion
   return actfun == on_sets ? stabilizer(G, pnt) : _stabilizer_generic(G, pnt, actfun)
 end

--- a/test/Groups/action.jl
+++ b/test/Groups/action.jl
@@ -26,6 +26,11 @@
   S = stabilizer(G, l, permuted)
   @test order(S[1]) == 4
 
+  # stabilizer under permutation action on vectors
+  l = ["a", "a", "b", "b", "c"]
+  S = stabilizer(G, l, permuted)
+  @test order(S[1]) == 4
+
   # a more complex example
   G = symmetric_group(14)
   gens = [ cperm([1,10], [2,12,13,7,8,14], [3,4,9,6,5,11]),


### PR DESCRIPTION
Closes #5977 

This adds an optimized call for calling `stabilizer` on a vector or tuple ~~of integers~~ using the `permuted` action.

~~I didn't add any tests, because I'm pretty sure this code is covered by already existing tests.~~

The timings now match what we would hope for:
```julia-repl
julia> v = [ 1, 1, 1, 3, 3, 4, 3, 4, 4, 4, 1, 3 ];

julia> G = symmetric_group(length(v));

julia> @benchmark stabilizer($G, $v, $permuted)
BenchmarkTools.Trial: 104 samples with 1 evaluation per sample.
 Range (min … max):  45.654 ms … 62.100 ms  ┊ GC (min … max): 0.00% … 20.04%
 Time  (median):     47.236 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   48.347 ms ±  3.670 ms  ┊ GC (mean ± σ):  2.29% ±  5.75%

     ▅█▁▂▅▁
  ▅▄▆██████▆▄▄▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▁▃▄▃▃▁▃▁▃▁▁▃ ▃
  45.7 ms         Histogram: frequency by time        60.8 ms <

 Memory estimate: 19.47 MiB, allocs estimate: 430244.
```