### PR TITLE
Documentation on artifacts

### DIFF
--- a/docs/doc.main
+++ b/docs/doc.main
@@ -340,6 +340,7 @@
     "DeveloperDocumentation/debugging.md",
     "DeveloperDocumentation/caching.md",
     "DeveloperDocumentation/serialization.md",
+    "DeveloperDocumentation/artifacts.md",
     "DeveloperDocumentation/design_decisions.md",
     "DeveloperDocumentation/known_properties.md",
     "DeveloperDocumentation/gap_integration.md",

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -142,7 +142,7 @@ When debugging, contributors are encouraged to use temporary staging areas befor
 Data intended for querying may also be suitable for [OscarDB](https://docs.oscar-system.org/dev/Experimental/OscarDB/introduction/).
 
 
-### [Creating and Registering](@id artifact_registration)
+### [Registering](@id artifact_registration)
 
 Creating an artifact typically involves the following steps:
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -14,7 +14,7 @@ This page explains what artifacts are, when to use them, and how to work with th
 
 Artifacts are content-addressed bundles managed by [Julia's artifact system](https://pkgdocs.julialang.org/v1/artifacts/) and declared in `Oscar.jl/Artifacts.toml`. Artifacts are automatically downloaded, or updated when `Oscar.jl` is installed or updated, unless the required artifact is already present locally.
 
-Julia also supports [lazy artifacts](https://docs.julialang.org/en/v1/stdlib/LazyArtifacts/), which are installed only on demand. In the following, we shall ignore lazy artifacts.
+Julia also supports [lazy artifacts](https://docs.julialang.org/en/v1/stdlib/LazyArtifacts/), which are installed only on demand.
 
 Artifacts allow to:
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -189,7 +189,7 @@ Artifacts are immutable: To "update" an artifact, you are therefore required to 
 - create a new tarball with the updated data (we suggest appending a version tag to the artifact name _e.g._ `-v1`, `-v2` _etc._),
 - upload the tarball to a stable hosting location,
 - compute the `sha256` and `git-tree-sha1` of the tarball of the new version,
-- update the corresponding entry in `Oscar.jl/Artifacts.toml` (_i.e._ new filename, and the two new SHA hashes),
+- update the corresponding entry in `Artifacts.toml` (_i.e._ new filename, and the two new SHA hashes),
 - open a pull request with the changes to `Oscar.jl/Artifacts.toml`.
 
 Once the pull request is merged, the updated artifact becomes available.

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -90,7 +90,7 @@ println("git-tree-sha1: ", Tar.tree_hash(IOBuffer(inflate_gzip(filename))))
 
 Then add this information, together with the host location, to `Artifacts.toml`.
 
-In the case at hand, the corresponding entry to `Oscar.jl/Artifacts.toml` takes the following form:
+In the case at hand, the corresponding entry to `Artifacts.toml` takes the following form:
 
 ```toml
 [MyExample]

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -119,6 +119,8 @@ In `Oscar.jl` source files, the artifact string macro is already available and `
 
 Creating artifacts requires that the corresponding data be serialized locally first. Details are provided in the [Serialization page](https://docs.oscar-system.org/dev/DeveloperDocumentation/serialization/).
 
+We recommend the use of the `.mrdi` file format for serialization. However, this is not a strict requirement and you may use any file format that you see fit.
+
 
 ### [Hosting Artifacts](@id artifact_hosting)
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -65,7 +65,7 @@ save("example.mrdi", obj)
 Create a compressed tarball, for example `example_data_v1.tar.gz`, containing the file `example.mrdi`.
 
 !!! note
-    Do not introduce an intermediate directory inside the tarball. If multiple files are included, place them directly in the archive.
+    For simplicity, do not introduce an intermediate directory inside the tarball: if multiple files are included, just place them directly in the top level of the archive.
 
 We host this very example tarball at [https://martinbies.github.io/Materials/Data/example\_data\_v1.tar.gz](https://martinbies.github.io/Materials/Data/example_data_v1.tar.gz). 
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -12,7 +12,7 @@ This page explains what artifacts are, when to use them, and how to work with th
 
 ## What Artifacts Are and When to Use Them
 
-Artifacts are content-addressed bundles managed by [Julia's artifact system](https://pkgdocs.julialang.org/v1/artifacts/) and declared in the file `Artifacts.toml`.
+Artifacts are content-addressed bundles managed by [Julia's artifact system](https://pkgdocs.julialang.org/v1/artifacts/) and declared in the file `Artifacts.toml` located in the `Oscar.jl` root directory.
 Artifacts are automatically downloaded, or updated when `Oscar.jl` is installed or updated, unless the required artifact is already present locally.
 
 Julia also supports [lazy artifacts](https://docs.julialang.org/en/v1/stdlib/LazyArtifacts/), which are installed only on demand.

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -174,7 +174,7 @@ model_data_path = artifact"FTM-1511-03209/1511-03209.mrdi"
 model = load(model_data_path)
 ```
 
-The string passed to `artifact"..."` is determined by the corresponding entry in `Oscar.jl/Artifacts.toml`.
+The string passed to `artifact"..."` is determined by the corresponding entry in `Artifacts.toml`.
 
 In `Oscar.jl` source files, the artifact string macro is already available and `using LazyArtifacts` is typically not required.
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -155,7 +155,7 @@ Recall that creating an artifact typically involves the following steps:
 - packing these files into a compressed tarball (`.tar.gz`),
 - uploading the tarball to a stable hosting location,
 - adding a corresponding entry to `Artifacts.toml`,
-- opening a pull request with the change to `Oscar.jl/Artifacts.toml`.
+- opening a pull request with the change to `Artifacts.toml`.
 
 Registering refers to the final two steps. Once the change to `Oscar.jl/Artifacts.toml` is merged into the `Oscar.jl` repository, the artifact becomes publicly available.
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -71,7 +71,11 @@ We host this particular example tarball at <https://martinbies.github.io/Materia
 
 #### Registering the Artifact
 
-Register the artifact by adding an entry to `Oscar.jl/Artifacts.toml`; see also [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/). The package [`ArtifactUtils.jl`](https://github.com/JuliaPackaging/ArtifactUtils.jl) can help automate parts of this workflow. The following text demonstrates the manual workflow.
+Register the artifact by adding an entry to `Artifacts.toml`; see also
+[Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/).
+The package [`ArtifactUtils.jl`](https://github.com/JuliaPackaging/ArtifactUtils.jl)
+can help automate parts of this workflow. The following text demonstrates the
+manual workflow.
 
 First, compute the `sha256` and the `git-tree-sha1`:
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -154,7 +154,7 @@ Recall that creating an artifact typically involves the following steps:
 - collecting the relevant data files,
 - packing these files into a compressed tarball (`.tar.gz`),
 - uploading the tarball to a stable hosting location,
-- adding a corresponding entry to `Oscar.jl/Artifacts.toml`,
+- adding a corresponding entry to `Artifacts.toml`,
 - opening a pull request with the change to `Oscar.jl/Artifacts.toml`.
 
 Registering refers to the final two steps. Once the change to `Oscar.jl/Artifacts.toml` is merged into the `Oscar.jl` repository, the artifact becomes publicly available.

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -124,7 +124,7 @@ We recommend the use of the `.mrdi` file format for serialization. However, this
 
 ### [Hosting Artifacts](@id artifact_hosting)
 
-Artifacts should be hosted at stable and persistent locations.
+If you want create an artifact, the first decision is where it is to be safely stored: to ensure future accessibility, artifacts should be hosted at stable and persistent locations.
 
 Preferred options include:
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -111,7 +111,7 @@ obj_path = artifact"MyExample/example.mrdi"
 
 obj = load(obj_path)
 ```
-Note that an artifact may contain multiple files. We append `/example.mrdi` to the artifact name to specify which file in the artifact is to be loaded.
+Note that an artifact may contain multiple files and subdirectories. We append `/example.mrdi` (an absolute path inside the artifact tarball) to the artifact name to specify which file in the artifact is to be loaded.
 In `Oscar.jl` source files, the artifact string macro is already available and `using LazyArtifacts` is typically not required.
 
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -98,7 +98,7 @@ lazy = true
     url = "https://martinbies.github.io/Materials/Data/example_data_v1.tar.gz"
 ```
 
-You may of course replace `MyExample` in the above entry with any other string that you find descriptive.
+You may, of course, replace `MyExample` in the above entry with any other string that you find descriptive.
 
 #### Use the artifact
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -190,7 +190,7 @@ Artifacts are immutable: To "update" an artifact, you are therefore required to 
 - upload the tarball to a stable hosting location,
 - compute the `sha256` and `git-tree-sha1` of the tarball of the new version,
 - update the corresponding entry in `Artifacts.toml` (_i.e._ new filename, and the two new SHA hashes),
-- open a pull request with the changes to `Oscar.jl/Artifacts.toml`.
+- open a pull request with the changes to `Artifacts.toml`.
 
 Once the pull request is merged, the updated artifact becomes available.
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -190,7 +190,7 @@ Once the pull request is merged, the updated artifact becomes available in OSCAR
 Updating an artifact on a hosting platform alone, for example by uploading a new version to Zenodo, is not sufficient. Any change to the artifact contents changes its hashes and therefore requires a corresponding update of `Oscar.jl/Artifacts.toml`.
 
 !!! warning
-    Do not modify, rename, or delete files that are already referenced by existing OSCAR releases.
+    Any files referenced by the OSCAR master branch must not be modified, renamed, or deleted.
 
 When repeatedly debugging or refining artifacts, contributors are encouraged to use temporary staging areas before publishing long-term versions. In particular, publication-related Zenodo entries should typically not be cluttered with intermediate or broken artifact versions created during development.
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -6,7 +6,7 @@ DocTestSetup = Oscar.doctestsetup()
 
 # Artifacts
 
-This page explains what artifacts are, when to use them, and how to work with them in OSCAR.
+This page explains what artifacts are, when to use them, and how to work with them in `Oscar.jl`.
 
 
 
@@ -16,7 +16,7 @@ Artifacts are content-addressed bundles managed by [Julia's artifact system](htt
 
 Julia also supports [lazy artifacts](https://docs.julialang.org/en/v1/stdlib/LazyArtifacts/), which are installed only on demand. In the following, we ignore lazy artifacts.
 
-Artifacts allow OSCAR to:
+Artifacts allow to:
 
 - keep the `Oscar.jl` repository small,
 - distribute data reproducibly,
@@ -36,7 +36,7 @@ As a rule of thumb, data stored directly in the `Oscar.jl` repository should not
 
 This section describes how to create, host, register, and use artifacts in the `Oscar.jl` repository. The workflow typically proceeds as follows:
 
-- [ ] [Serialize data as `.mrdi` files](@ref data_preparation)
+- [ ] [Serialize data](@ref data_preparation)
 - [ ] [Upload the tarball to a stable hosting location](@ref artifact_hosting)
 - [ ] [Add an entry to `Oscar.jl/Artifacts.toml` and open a pull request](@ref artifact_registration)
 - [ ] [Use the artifact once the pull request has been merged](@ref artifact_usage)
@@ -46,7 +46,7 @@ We illustrate this workflow with an [end-to-end example](@ref end-to-end-artifac
 
 ### [End-to-End Example](@id end-to-end-artifact-example)
 
-The following example illustrates the complete workflow for creating, registering, and using an artifact.
+The following example illustrates the complete workflow for creating, registering, and using an artifact in `Oscar.jl`.
 
 #### Create data
 
@@ -71,7 +71,7 @@ Create a compressed tarball, for example `example_data_v1.tar.gz`, containing th
 
 #### Register the artifact
 
-Register the artifact by adding it to `Oscar.jl/Artifacts.toml`; see also [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/). The package [`ArtifactUtils.jl`](https://github.com/JuliaPackaging/ArtifactUtils.jl) can help automate parts of this workflow. The following example shows the manual workflow.
+Register the artifact by adding an entry to `Oscar.jl/Artifacts.toml`; see also [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/). The package [`ArtifactUtils.jl`](https://github.com/JuliaPackaging/ArtifactUtils.jl) can help automate parts of this workflow. The following text demonstrates the manual workflow.
 
 First, compute the `sha256` and the `git-tree-sha1`:
 
@@ -84,9 +84,7 @@ println("sha256: ", bytes2hex(open(sha256, filename)))
 println("git-tree-sha1: ", Tar.tree_hash(IOBuffer(inflate_gzip(filename))))
 ```
 
-Then add a corresponding entry to `Oscar.jl/Artifacts.toml`. We host this very example file at [https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-07-13/example_data_v1.tar.gz](https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-07-13/example_data_v1.tar.gz); for this particular artifact location, the corresponding entry takes the following form:
-
-HOST THIS FILE SOMEWHERE IN THE OSCAR UNIVERSE! E.g. https://github.com/oscar-system/Oscar.jl/releases/tag/archive-tag-1.
+Then add this information, together with the host location, to `Oscar.jl/Artifacts.toml`. This very example, we host at [https://martinbies.github.io/Materials/Data/example_data_v1.tar.gz](https://martinbies.github.io/Materials/Data/example_data_v1.tar.gz). Then, the corresponding entry to `Oscar.jl/Artifacts.toml` takes the following form:
 
 ```toml
 [MyExample]
@@ -102,7 +100,7 @@ You may of course replace `MyExample` in the above entry with any other string t
 
 #### Use the artifact
 
-The artifact string macro is exported by `LazyArtifacts`. In `Oscar.jl` source files this is already available; in a standalone Julia session, load it explicitly.
+The artifact string macro is exported by `LazyArtifacts`. In a standalone Julia session, load it explicitly.
 
 ```julia
 using LazyArtifacts
@@ -130,34 +128,34 @@ Preferred options include:
 - other stable hosting solutions agreed upon by the maintainers.
 
 For historical reasons, some artifacts are currently hosted via GitHub release assets, for example at
-[Oscar.jl/archive-tag-1](https://github.com/oscar-system/Oscar.jl/releases/tag/archive-tag-1). This approach should be used with care, as GitHub release assets are not intended to function as a long-term artifact registry. In particular, ensure that existing files are never removed or renamed, as they may be required by older OSCAR versions.
+[Oscar.jl/archive-tag-1](https://github.com/oscar-system/Oscar.jl/releases/tag/archive-tag-1). This approach should be used with care, as GitHub release assets are not intended to function as a long-term artifact registry.
 
-When debugging or repeatedly updating artifacts, contributors are encouraged to use temporary staging areas before publishing long-term artifact versions. In particular, publication-related Zenodo entries should typically not be cluttered with intermediate or broken artifact versions created during development.
+!!! warning
+    Ensure that existing files are never removed or renamed, as they may be required by older `Oscar.jl` releases.
+
+When debugging, contributors are encouraged to use temporary staging areas before publishing long-term artifact versions. In particular, publication-related Zenodo entries should typically not be cluttered with intermediate or broken artifact versions created during development.
 
 Data intended for querying may also be suitable for [OscarDB](https://docs.oscar-system.org/dev/Experimental/OscarDB/introduction/).
 
 
 ### [Creating and Registering](@id artifact_registration)
 
-Additional details on Julia artifacts are provided in [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/).
-
 Creating an artifact typically involves the following steps:
 
-- collecting the relevant files in a directory,
-- packing these files into a compressed tarball, such as `.tar.gz`,
-- uploading the tarball to a stable location,
-- adding a corresponding entry to `Oscar.jl/Artifacts.toml`.
+- collecting the relevant data files,
+- packing these files into a compressed tarball (`.tar.gz`),
+- uploading the tarball to a stable hosting location,
+- adding a corresponding entry to `Oscar.jl/Artifacts.toml`,
+- opening a pull request with the change to `Oscar.jl/Artifacts.toml`.
 
-The [end-to-end example](@ref end-to-end-artifact-example) explicitly demonstrates these steps.
+Once the change to `Oscar.jl/Artifacts.toml` is merged into the `Oscar.jl` repository, the artifact becomes available.
 
-Once the corresponding changes are merged into the `Oscar.jl` repository, the artifact becomes available to OSCAR and is downloaded automatically when first requested.
+The [end-to-end example](@ref end-to-end-artifact-example) explicitly demonstrates these steps. Additional information is available in [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/).
 
 
 ### [Using Artifacts in Oscar](@id artifact_usage)
 
-Artifacts can be accessed via Julia's artifact system through the `artifact"..."` string macro.
-
-For example:
+Artifacts can be accessed via Julia's artifact system through the `artifact"..."` string macro. For example:
 
 ```julia
 using LazyArtifacts
@@ -179,18 +177,18 @@ In `Oscar.jl` source files, the artifact string macro is already available and `
 
 Artifacts are immutable. Updating an artifact therefore requires:
 
-- creating a new tarball,
-- uploading it to a stable hosting location,
+- creating a new tarball with the updated data,
+- uploading the tarball to a stable hosting location,
 - recomputing the `sha256` and `git-tree-sha1`,
 - updating the corresponding entry in `Oscar.jl/Artifacts.toml`,
-- opening a pull request with these changes.
+- opening a pull request with the changes to `Oscar.jl/Artifacts.toml`.
 
-Once the pull request is merged, the updated artifact becomes available in OSCAR.
+Once the pull request is merged, the updated artifact becomes available.
 
 Updating an artifact on a hosting platform alone, for example by uploading a new version to Zenodo, is not sufficient. Any change to the artifact contents changes its hashes and therefore requires a corresponding update of `Oscar.jl/Artifacts.toml`.
 
 !!! warning
-    Any files referenced by the OSCAR master branch must not be modified, renamed, or deleted.
+    Any files referenced by the `Oscar.jl` master branch must not be modified, renamed, or deleted, as they may be required by earlier `Oscar.jl` releases.
 
 When repeatedly debugging or refining artifacts, contributors are encouraged to use temporary staging areas before publishing long-term versions. In particular, publication-related Zenodo entries should typically not be cluttered with intermediate or broken artifact versions created during development.
 
@@ -199,3 +197,11 @@ When repeatedly debugging or refining artifacts, contributors are encouraged to 
 The `.mrdi` file format is under active development and its standard evolves over time. Older files remain compatible with newer OSCAR versions; however, loading older artifacts may require upgrade steps during deserialization. For large artifacts, these upgrades may become time consuming. It is therefore recommended to use the most recent serialization standard when creating artifacts and to periodically upgrade older artifacts if appropriate.
 
 Additional details are provided in the [Serialization documentation](https://docs.oscar-system.org/stable/DeveloperDocumentation/serialization/#Upgrades).
+
+
+
+## Artifacts in Upstream Dependencies
+
+### GAP.jl
+
+`GAP.jl` uses artifacts to install [GAP](https://www.gap-system.org/) and GAP packages. Detailed maintainer information is provided in [`GAP.jl/README.maintainer.md`](https://github.com/oscar-system/GAP.jl/blob/master/README.maintainer.md).

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -69,7 +69,7 @@ Create a compressed tarball, for example `example_data_v1.tar.gz`, containing th
 !!! note
     For simplicity, do not introduce an intermediate directory inside the tarball: if multiple files are included, just place them directly in the top level of the archive.
 
-We host this particular example tarball at [https://martinbies.github.io/Materials/Data/example\_data\_v1.tar.gz](https://martinbies.github.io/Materials/Data/example_data_v1.tar.gz). 
+We host this particular example tarball at <https://martinbies.github.io/Materials/Data/example_data_v1.tar.gz>.
 
 #### Registering the Artifact
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -111,7 +111,7 @@ obj_path = artifact"MyExample/example.mrdi"
 
 obj = load(obj_path)
 ```
-
+Note that an artifact may contain multiple files. We use `/example.mrdi` to specify exactly which file to load.
 In `Oscar.jl` source files, the artifact string macro is already available and `using LazyArtifacts` is typically not required.
 
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -204,7 +204,7 @@ Additional details are provided in the [Serialization documentation](https://doc
 
 
 
-## Artifacts in Upstream Dependencies
+## Artifacts in Upstream Dependencies of `Oscar.jl`
 
 ### GAP.jl
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -208,4 +208,4 @@ Additional details are provided in the [Serialization documentation](https://doc
 
 ### GAP.jl
 
-`GAP.jl` uses artifacts to install [GAP](https://www.gap-system.org/) and GAP packages. Detailed maintainer information is provided in [`GAP.jl/README.maintainer.md`](https://github.com/oscar-system/GAP.jl/blob/master/README.maintainer.md).
+`GAP.jl` uses artifacts to install [GAP](https://www.gap-system.org/) packages. Detailed maintainer information is provided in [`GAP.jl/README.maintainer.md`](https://github.com/oscar-system/GAP.jl/blob/master/README.maintainer.md).

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -187,7 +187,7 @@ Artifacts are immutable: To "update" an artifact, you are therefore required to 
 
 - create a new tarball with the updated data (we suggest appending a version tag to the artifact name _e.g._ `-v1`, `-v2` _etc._),
 - upload the tarball to a stable hosting location,
-- recompute the `sha256` and `git-tree-sha1`,
+- compute the `sha256` and `git-tree-sha1` of the tarball of the new version,
 - update the corresponding entry in `Oscar.jl/Artifacts.toml`,
 - open a pull request with the changes to `Oscar.jl/Artifacts.toml`.
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -135,7 +135,7 @@ For historical reasons, some artifacts are currently hosted via GitHub release a
 [Oscar.jl/archive-tag-1](https://github.com/oscar-system/Oscar.jl/releases/tag/archive-tag-1). This approach should be used with care, as GitHub release assets are not intended to function as a long-term artifact registry.
 
 !!! warning
-    Ensure that existing files are never removed or renamed, as they may be required by older `Oscar.jl` releases.
+    Ensure that existing artifact files are never removed or renamed, as they may be required by older `Oscar.jl` releases.
 
 When debugging, contributors are encouraged to use temporary staging areas before publishing long-term artifact versions. In particular, publication-related Zenodo entries should typically not be cluttered with intermediate or broken artifact versions created during development.
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -135,7 +135,8 @@ Preferred options include:
 - other stable hosting solutions agreed upon by the maintainers.
 
 For historical reasons, some artifacts are currently hosted via GitHub release assets, for example at
-[Oscar.jl/archive-tag-1](https://github.com/oscar-system/Oscar.jl/releases/tag/archive-tag-1). This approach should be used with care, as GitHub release assets are not intended to function as a long-term artifact registry.
+[Oscar.jl/archive-tag-1](https://github.com/oscar-system/Oscar.jl/releases/tag/archive-tag-1).
+This approach should be used with care, as GitHub release assets are not intended to function as a long-term artifact registry.
 
 !!! warning
     Ensure that existing artifact files are never removed or renamed, as they may be required by older `Oscar.jl` releases.

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -1,0 +1,201 @@
+```@meta
+CurrentModule = Oscar
+CollapsedDocStrings = true
+DocTestSetup = Oscar.doctestsetup()
+```
+
+# Artifacts
+
+This page explains what artifacts are, when to use them, and how to work with them in OSCAR.
+
+
+
+## What Artifacts Are and When to Use Them
+
+Artifacts are content-addressed data bundles managed by [Julia's artifact system](https://pkgdocs.julialang.org/v1/artifacts/).
+They are declared in `Oscar.jl/Artifacts.toml` and are downloaded and unpacked on demand.
+
+Artifacts allow OSCAR to:
+
+- keep the `Oscar.jl` repository small,
+- distribute data reproducibly,
+- avoid duplication of large files across versions.
+
+Artifacts should be used for data that does not belong directly in the `Oscar.jl` repository, in particular:
+
+- generated data,
+- large datasets,
+- data not intended to be edited manually.
+
+As a rule of thumb, data stored directly in the `Oscar.jl` repository should not exceed the size of typical source files (around 100 KB). Small examples, test inputs, and simple hand-written data should remain in the `Oscar.jl` repository.
+
+
+
+
+## Creating, Hosting and Using Artifacts
+
+This section describes how to create, host, register, and use artifacts in the `Oscar.jl` repository. The workflow typically proceeds as follows:
+
+- [ ] [Serialize data as `.mrdi` files](@ref data_preparation)
+- [ ] [Upload the tarball to a stable hosting location](@ref artifact_hosting)
+- [ ] [Add an entry to `Oscar.jl/Artifacts.toml` and open a pull request](@ref artifact_registration)
+- [ ] [Use the artifact once the pull request has been merged](@ref artifact_usage)
+
+We illustrate this workflow with an [end-to-end example](@ref end-to-end-artifact-example).
+
+
+### [End-to-End Example](@id end-to-end-artifact-example)
+
+The following example illustrates the complete workflow for creating, registering, and using an artifact.
+
+#### Create data
+
+```julia
+using Oscar
+
+obj = ZZ(2)^10
+```
+
+#### Save data
+
+```julia
+save("example.mrdi", obj)
+```
+
+#### Pack into a tarball
+
+Create a compressed tarball, for example `example_data_v1.tar.gz`, containing the file `example.mrdi`.
+
+!!! note
+    Do not introduce an intermediate directory inside the tarball. If multiple files are included, place them directly in the archive.
+
+#### Register the artifact
+
+Register the artifact by adding it to `Oscar.jl/Artifacts.toml`; see also [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/). The package [`ArtifactUtils.jl`](https://github.com/JuliaPackaging/ArtifactUtils.jl) can help automate parts of this workflow. The following example shows the manual workflow.
+
+First, compute the `sha256` and the `git-tree-sha1`:
+
+```julia
+using Tar, Inflate, SHA
+
+filename = "/absolute/path/to/example_data_v1.tar.gz"
+
+println("sha256: ", bytes2hex(open(sha256, filename)))
+println("git-tree-sha1: ", Tar.tree_hash(IOBuffer(inflate_gzip(filename))))
+```
+
+Then add a corresponding entry to `Oscar.jl/Artifacts.toml`. We host this very example file at [https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-07-13/example_data_v1.tar.gz](https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-07-13/example_data_v1.tar.gz); for this particular artifact location, the corresponding entry takes the following form:
+
+HOST THIS FILE SOMEWHERE IN THE OSCAR UNIVERSE! E.g. https://github.com/oscar-system/Oscar.jl/releases/tag/archive-tag-1.
+
+```toml
+[MyExample]
+git-tree-sha1 = "ff2f21e623a130f47116d847ae54fd55232b42c1"
+lazy = true
+
+    [[MyExample.download]]
+    sha256 = "3bd5a20e84b2e579ecde7dc5d7d4606444daf08407eecc9d8e59be1e468ca5a1"
+    url = "https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-07-13/example_data_v1.tar.gz"
+```
+
+You may of course replace `MyExample` in the above entry with any other string that you find descriptive.
+
+#### Use the artifact
+
+The artifact string macro is exported by `LazyArtifacts`. In `Oscar.jl` source files this is already available; in a standalone Julia session, load it explicitly.
+
+```julia
+using LazyArtifacts
+
+obj_path = artifact"MyExample/example.mrdi"
+
+obj = load(obj_path)
+```
+
+In `Oscar.jl` source files, the artifact string macro is already available and `using LazyArtifacts` is typically not required.
+
+
+### [Preparing Data (Serialization)](@id data_preparation)
+
+Creating artifacts requires that the corresponding data be serialized locally first. Details are provided in the [Serialization page](https://docs.oscar-system.org/dev/DeveloperDocumentation/serialization/).
+
+
+### [Hosting Artifacts](@id artifact_hosting)
+
+Artifacts should be hosted at stable and persistent locations.
+
+Preferred options include:
+
+- archival services such as [Zenodo](https://zenodo.org/communities/oscar/records?q=&l=list&p=1&s=10&sort=newest), in particular for long-term or publication-related data,
+- other stable hosting solutions agreed upon by the maintainers.
+
+For historical reasons, some artifacts are currently hosted via GitHub release assets, for example at
+[Oscar.jl/archive-tag-1](https://github.com/oscar-system/Oscar.jl/releases/tag/archive-tag-1). This approach should be used with care, as GitHub release assets are not intended to function as a long-term artifact registry. In particular, ensure that existing files are never removed or renamed, as they may be required by older OSCAR versions.
+
+When debugging or repeatedly updating artifacts, contributors are encouraged to use temporary staging areas before publishing long-term artifact versions. In particular, publication-related Zenodo entries should typically not be cluttered with intermediate or broken artifact versions created during development.
+
+Data intended for querying may also be suitable for [OscarDB](https://docs.oscar-system.org/dev/Experimental/OscarDB/introduction/).
+
+
+### [Creating and Registering](@id artifact_registration)
+
+Additional details on Julia artifacts are provided in [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/).
+
+Creating an artifact typically involves the following steps:
+
+- collecting the relevant files in a directory,
+- packing these files into a compressed tarball, such as `.tar.gz`,
+- uploading the tarball to a stable location,
+- adding a corresponding entry to `Oscar.jl/Artifacts.toml`.
+
+The [end-to-end example](@ref end-to-end-artifact-example) explicitly demonstrates these steps.
+
+Once the corresponding changes are merged into the `Oscar.jl` repository, the artifact becomes available to OSCAR and is downloaded automatically when first requested.
+
+
+### [Using Artifacts in Oscar](@id artifact_usage)
+
+Artifacts can be accessed via Julia's artifact system through the `artifact"..."` string macro.
+
+For example:
+
+```julia
+using LazyArtifacts
+
+model_data_path = artifact"FTM-1511-03209/1511-03209.mrdi"
+
+model = load(model_data_path)
+```
+
+The string passed to `artifact"..."` is determined by the corresponding entry in `Oscar.jl/Artifacts.toml`.
+
+In `Oscar.jl` source files, the artifact string macro is already available and `using LazyArtifacts` is typically not required.
+
+
+
+## Updating Artifacts
+
+### General Rules
+
+Artifacts are immutable. Updating an artifact therefore requires:
+
+- creating a new tarball,
+- uploading it to a stable hosting location,
+- recomputing the `sha256` and `git-tree-sha1`,
+- updating the corresponding entry in `Oscar.jl/Artifacts.toml`,
+- opening a pull request with these changes.
+
+Once the pull request is merged, the updated artifact becomes available in OSCAR.
+
+Updating an artifact on a hosting platform alone, for example by uploading a new version to Zenodo, is not sufficient. Any change to the artifact contents changes its hashes and therefore requires a corresponding update of `Oscar.jl/Artifacts.toml`.
+
+!!! warning
+    Do not modify, rename, or delete files that are already referenced by existing OSCAR releases.
+
+When repeatedly debugging or refining artifacts, contributors are encouraged to use temporary staging areas before publishing long-term versions. In particular, publication-related Zenodo entries should typically not be cluttered with intermediate or broken artifact versions created during development.
+
+### Serialization Upgrades
+
+The `.mrdi` file format is under active development and its standard evolves over time. Older files remain compatible with newer OSCAR versions; however, loading older artifacts may require upgrade steps during deserialization. For large artifacts, these upgrades may become time consuming. It is therefore recommended to use the most recent serialization standard when creating artifacts and to periodically upgrade older artifacts if appropriate.
+
+Additional details are provided in the [Serialization documentation](https://docs.oscar-system.org/stable/DeveloperDocumentation/serialization/#Upgrades).

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -36,10 +36,10 @@ As a rule of thumb, data stored directly in the `Oscar.jl` repository should not
 
 This section describes how to create, host, register, and use artifacts in the `Oscar.jl` repository. The workflow typically proceeds as follows:
 
-- [ ] [Serialize data](@ref data_preparation)
-- [ ] [Upload the tarball to a stable hosting location](@ref artifact_hosting)
-- [ ] [Add an entry to `Oscar.jl/Artifacts.toml` and open a pull request](@ref artifact_registration)
-- [ ] [Use the artifact once the pull request has been merged](@ref artifact_usage)
+- [ ] [Serializing the Data](@ref data_preparation)
+- [ ] [Hosting the Data (zip the data as tarball and upload it to a stable location)](@ref artifact_hosting)
+- [ ] [Registering the Artifact (add an entry to `Oscar.jl/Artifacts.toml` and open a pull request)](@ref artifact_registration)
+- [ ] [Using the Artifact (once the pull request has been merged)](@ref artifact_usage)
 
 We illustrate this workflow with an [end-to-end example](@ref end-to-end-artifact-example).
 
@@ -48,30 +48,28 @@ We illustrate this workflow with an [end-to-end example](@ref end-to-end-artifac
 
 The following example illustrates the complete workflow for creating, registering, and using an artifact in `Oscar.jl`.
 
-#### Create data
+#### Serializing the Data
+
+Let us employ the [`.mrdi` file format to serialize our data](https://docs.oscar-system.org/dev/DeveloperDocumentation/serialization/) to serlialize the number $2^10$. (You may of course use the file format of your choice.)
 
 ```julia
 using Oscar
 
 obj = ZZ(2)^10
-```
 
-#### Save data
-
-Let us employ the  [`.mrdi` file format to serialize our data](https://docs.oscar-system.org/dev/DeveloperDocumentation/serialization/). (You may of course use the file format you prefer.)
-
-```julia
 save("example.mrdi", obj)
 ```
 
-#### Pack into a tarball
+#### Hosting the Data
 
 Create a compressed tarball, for example `example_data_v1.tar.gz`, containing the file `example.mrdi`.
 
 !!! note
     Do not introduce an intermediate directory inside the tarball. If multiple files are included, place them directly in the archive.
 
-#### Register the artifact
+We host this very example tarball at [https://martinbies.github.io/Materials/Data/example\_data\_v1.tar.gz](https://martinbies.github.io/Materials/Data/example_data_v1.tar.gz). 
+
+#### Registering the Artifact
 
 Register the artifact by adding an entry to `Oscar.jl/Artifacts.toml`; see also [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/). The package [`ArtifactUtils.jl`](https://github.com/JuliaPackaging/ArtifactUtils.jl) can help automate parts of this workflow. The following text demonstrates the manual workflow.
 
@@ -86,7 +84,9 @@ println("sha256: ", bytes2hex(open(sha256, filename)))
 println("git-tree-sha1: ", Tar.tree_hash(IOBuffer(inflate_gzip(filename))))
 ```
 
-Then add this information, together with the host location, to `Oscar.jl/Artifacts.toml`. This very example, we host at [https://martinbies.github.io/Materials/Data/example\_data\_v1.tar.gz](https://martinbies.github.io/Materials/Data/example_data_v1.tar.gz). Then, the corresponding entry to `Oscar.jl/Artifacts.toml` takes the following form:
+Then add this information, together with the host location, to `Oscar.jl/Artifacts.toml`.
+
+In the case at hand, the corresponding entry to `Oscar.jl/Artifacts.toml` takes the following form:
 
 ```toml
 [MyExample]
@@ -100,7 +100,7 @@ lazy = true
 
 You may, of course, replace `MyExample` in the above entry with any other string that you find descriptive.
 
-#### Use the artifact
+#### Using the Artifact
 
 The artifact string macro is exported by `LazyArtifacts`. In a standalone Julia session, load it explicitly.
 
@@ -115,14 +115,14 @@ obj = load(obj_path)
 In `Oscar.jl` source files, the artifact string macro is already available and `using LazyArtifacts` is typically not required.
 
 
-### [Preparing Data (Serialization)](@id data_preparation)
+### [Serializing the Data](@id data_preparation)
 
 Creating artifacts requires that the corresponding data be serialized locally first. Details are provided in the [Serialization page](https://docs.oscar-system.org/dev/DeveloperDocumentation/serialization/).
 
 We recommend the use of the `.mrdi` file format for serialization. However, this is not a strict requirement and you may use any file format that you see fit.
 
 
-### [Hosting Artifacts](@id artifact_hosting)
+### [Hosting the Data](@id artifact_hosting)
 
 If you want create an artifact, the first decision is where it is to be safely stored: to ensure future accessibility, artifacts should be hosted at stable and persistent locations.
 
@@ -142,7 +142,7 @@ When debugging, contributors are encouraged to use temporary staging areas befor
 Data intended for querying may also be suitable for [OscarDB](https://docs.oscar-system.org/dev/Experimental/OscarDB/introduction/).
 
 
-### [Registering](@id artifact_registration)
+### [Registering the Artifact](@id artifact_registration)
 
 Recall that creating an artifact typically involves the following steps:
 
@@ -157,7 +157,7 @@ Registering refers to the final two steps. Once the change to `Oscar.jl/Artifact
 The [end-to-end example](@ref end-to-end-artifact-example) explicitly demonstrates the required changes to `Oscar.jl/Artifacts.toml`. Additional information is available in [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/).
 
 
-### [Using Artifacts in Oscar](@id artifact_usage)
+### [Using the Artifact](@id artifact_usage)
 
 Artifacts can be accessed via Julia's artifact system through the `artifact"..."` string macro. For example:
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -159,7 +159,7 @@ Recall that creating an artifact typically involves the following steps:
 
 Registering refers to the final two steps. Once the change to `Artifacts.toml` is merged into the `Oscar.jl` repository, the artifact becomes publicly available.
 
-The [end-to-end example](@ref end-to-end-artifact-example) explicitly demonstrates the required changes to `Oscar.jl/Artifacts.toml`. Additional information is available in [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/).
+The [end-to-end example](@ref end-to-end-artifact-example) explicitly demonstrates the required changes to `Artifacts.toml`. Additional information is available in [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/).
 
 
 ### [Using the Artifact](@id artifact_usage)

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -14,7 +14,7 @@ This page explains what artifacts are, when to use them, and how to work with th
 
 Artifacts are content-addressed bundles managed by [Julia's artifact system](https://pkgdocs.julialang.org/v1/artifacts/) and declared in `Oscar.jl/Artifacts.toml`. Artifacts are automatically downloaded, or updated when `Oscar.jl` is installed or updated, unless the required artifact is already present locally.
 
-Julia also supports [lazy artifacts](https://docs.julialang.org/en/v1/stdlib/LazyArtifacts/), which are installed only on demand. In the following, we ignore lazy artifacts.
+Julia also supports [lazy artifacts](https://docs.julialang.org/en/v1/stdlib/LazyArtifacts/), which are installed only on demand. In the following, we shall ignore lazy artifacts.
 
 Artifacts allow to:
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -39,7 +39,7 @@ This section describes how to create, host, register, and use artifacts in the `
 
 - [ ] [Serializing the Data](@ref data_preparation)
 - [ ] [Hosting the Data (pack the data into a `gzip` compressed tarball, and upload it to a stable location)](@ref artifact_hosting)
-- [ ] [Registering the Artifact (add an entry to `Oscar.jl/Artifacts.toml` and open a pull request)](@ref artifact_registration)
+- [ ] [Registering the Artifact (add an entry to Oscar's `Artifacts.toml` and open a pull request)](@ref artifact_registration)
 - [ ] [Using the Artifact (once the pull request has been merged)](@ref artifact_usage)
 
 We illustrate this workflow with an [end-to-end example](@ref end-to-end-artifact-example).

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -194,7 +194,7 @@ Artifacts are immutable: To "update" an artifact, you are therefore required to 
 
 Once the pull request is merged, the updated artifact becomes available.
 
-Updating an artifact on a hosting platform alone, for example by uploading a new version to Zenodo, is not sufficient. Any change to the artifact contents changes its hashes and therefore requires a corresponding update of `Oscar.jl/Artifacts.toml`.
+Updating an artifact on a hosting platform alone, for example by uploading a new version to Zenodo, is not sufficient. Any change to the artifact contents changes its hashes and therefore requires a corresponding update of `Artifacts.toml`.
 
 !!! warning
     Any files referenced by the `Oscar.jl` master branch must not be modified, renamed, or deleted, as they may be required by earlier `Oscar.jl` releases.

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -198,7 +198,7 @@ When repeatedly debugging or refining artifacts, contributors are encouraged to 
 
 ### Serialization Upgrades
 
-The `.mrdi` file format is under active development and its standard evolves over time. Older files remain compatible with newer OSCAR versions; however, loading older artifacts may require upgrade steps during deserialization. For large artifacts, these upgrades may become time consuming. It is therefore recommended to use the most recent serialization standard when creating artifacts and to periodically upgrade older artifacts if appropriate.
+Note that the chosen file format for serialization may be subject to development. In particular, the `.mrdi` file format, which we recommend for serialization, is under active development. Consequently, its standard evolves over time. Older files remain compatible with newer OSCAR versions; however, loading older artifacts may require upgrade steps during deserialization. For large artifacts, these upgrades may become time consuming. It is therefore recommended to use the most recent serialization standard when creating artifacts and to periodically upgrade older artifacts if appropriate.
 
 Additional details are provided in the [Serialization documentation](https://docs.oscar-system.org/stable/DeveloperDocumentation/serialization/#Upgrades).
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -188,7 +188,7 @@ Artifacts are immutable: To "update" an artifact, you are therefore required to 
 - create a new tarball with the updated data (we suggest appending a version tag to the artifact name _e.g._ `-v1`, `-v2` _etc._),
 - upload the tarball to a stable hosting location,
 - compute the `sha256` and `git-tree-sha1` of the tarball of the new version,
-- update the corresponding entry in `Oscar.jl/Artifacts.toml`,
+- update the corresponding entry in `Oscar.jl/Artifacts.toml` (_i.e._ new filename, and the two new SHA hashes),
 - open a pull request with the changes to `Oscar.jl/Artifacts.toml`.
 
 Once the pull request is merged, the updated artifact becomes available.

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -154,7 +154,7 @@ Recall that creating an artifact typically involves the following steps:
 
 Registering refers to the final two steps. Once the change to `Oscar.jl/Artifacts.toml` is merged into the `Oscar.jl` repository, the artifact becomes available.
 
-The [end-to-end example](@ref end-to-end-artifact-example) explicitly demonstrates these steps. Additional information is available in [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/).
+The [end-to-end example](@ref end-to-end-artifact-example) explicitly demonstrates the required changes to `Oscar.jl/Artifacts.toml`. Additional information is available in [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/).
 
 
 ### [Using Artifacts in Oscar](@id artifact_usage)

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -20,7 +20,7 @@ or updated when `Oscar.jl` is installed or updated, unless the required artifact
 Julia also supports [lazy artifacts](https://docs.julialang.org/en/v1/stdlib/LazyArtifacts/), which are
 installed only on demand.
 
-Artifacts allow to:
+Artifacts allow us to:
 
 - keep the `Oscar.jl` repository small,
 - distribute data reproducibly,

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -50,7 +50,7 @@ The following example illustrates the complete workflow for creating, registerin
 
 #### Serializing the Data
 
-Let us employ the [`.mrdi` file format to serialize our data](https://docs.oscar-system.org/dev/DeveloperDocumentation/serialization/) to serlialize the number $2^10$. (You may of course use the file format of your choice.)
+Let us employ the [`.mrdi` file format to serialize our data](https://docs.oscar-system.org/dev/DeveloperDocumentation/serialization/) to serlialize the number $2^{10}$. (You may of course use the file format of your choice.)
 
 ```julia
 using Oscar

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -67,9 +67,6 @@ save("example.mrdi", obj)
 
 Create a compressed tarball, for example `example_data_v1.tar.gz`, containing the file `example.mrdi`.
 
-!!! note
-    For simplicity, do not introduce an intermediate directory inside the tarball: if multiple files are included, just place them directly in the top level of the archive.
-
 We host this particular example tarball at <https://martinbies.github.io/Materials/Data/example_data_v1.tar.gz>.
 
 #### Registering the Artifact

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -109,14 +109,19 @@ You may, of course, replace `MyExample` in the above entry with any other string
 The artifact string macro is exported by `LazyArtifacts`. In a standalone Julia session, load it explicitly.
 
 ```julia
-using LazyArtifacts
+using Pkg.Artifacts
 
 obj_path = artifact"MyExample/example.mrdi"
 
 obj = load(obj_path)
 ```
-Note that an artifact may contain multiple files and subdirectories. We append `/example.mrdi` (an absolute path inside the artifact tarball) to the artifact name to specify which file in the artifact is to be loaded.
-In `Oscar.jl` source files, the artifact string macro is already available and `using LazyArtifacts` is typically not required.
+
+Note that an artifact may contain multiple files and subdirectories. We append
+`/example.mrdi` (an absolute path inside the artifact tarball) to the artifact
+name to specify which file in the artifact is to be loaded.
+
+In `Oscar.jl` source files, the artifact string macro is already available and
+`using Pkg.Artifacts` is typically not required.
 
 
 ### [Serializing the Data](@id data_preparation)
@@ -164,19 +169,21 @@ The [end-to-end example](@ref end-to-end-artifact-example) explicitly demonstrat
 
 ### [Using the Artifact](@id artifact_usage)
 
-Artifacts can be accessed via Julia's artifact system through the `artifact"..."` string macro. For example:
+Artifacts are accessed via Julia's artifact system using the `artifact"..."` string macro.
+
+The string before the first `/` refers to the artifact name as defined in `Artifacts.toml`.
+Any remaining path components refer to files or subdirectories inside the unpacked artifact. For example,
 
 ```julia
-using LazyArtifacts
+using Pkg.Artifacts
 
-model_data_path = artifact"FTM-1511-03209/1511-03209.mrdi"
-
-model = load(model_data_path)
+artifact"MyArtifact/data/example.mrdi"
 ```
 
-The string passed to `artifact"..."` is determined by the corresponding entry in `Artifacts.toml`.
+refers to the file `data/example.mrdi` contained in the artifact `MyArtifact`.
 
-In `Oscar.jl` source files, the artifact string macro is already available and `using LazyArtifacts` is typically not required.
+In `Oscar.jl` source files, the artifact string macro is already available and
+`using Pkg.Artifacts` is typically not required.
 
 
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -95,7 +95,7 @@ lazy = true
 
     [[MyExample.download]]
     sha256 = "3bd5a20e84b2e579ecde7dc5d7d4606444daf08407eecc9d8e59be1e468ca5a1"
-    url = "https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-07-13/example_data_v1.tar.gz"
+    url = "https://martinbies.github.io/Materials/Data/example_data_v1.tar.gz"
 ```
 
 You may of course replace `MyExample` in the above entry with any other string that you find descriptive.

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -181,7 +181,7 @@ In `Oscar.jl` source files, the artifact string macro is already available and `
 
 Artifacts are immutable. Updating an artifact therefore requires:
 
-- creating a new tarball with the updated data (it may be reasonable at append a version tag like `-v1`, `-v2` etc.),
+- creating a new tarball with the updated data (we suggest appending a version tag to the artifact name _e.g._ `-v1`, `-v2` _etc._),
 - uploading the tarball to a stable hosting location,
 - recomputing the `sha256` and `git-tree-sha1`,
 - updating the corresponding entry in `Oscar.jl/Artifacts.toml`,

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -37,7 +37,7 @@ As a rule of thumb, data stored directly in the `Oscar.jl` repository should not
 This section describes how to create, host, register, and use artifacts in the `Oscar.jl` repository. The workflow typically proceeds as follows:
 
 - [ ] [Serializing the Data](@ref data_preparation)
-- [ ] [Hosting the Data (zip the data as tarball and upload it to a stable location)](@ref artifact_hosting)
+- [ ] [Hosting the Data (pack the data into a `gzip` compressed tarball, and upload it to a stable location)](@ref artifact_hosting)
 - [ ] [Registering the Artifact (add an entry to `Oscar.jl/Artifacts.toml` and open a pull request)](@ref artifact_registration)
 - [ ] [Using the Artifact (once the pull request has been merged)](@ref artifact_usage)
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -157,7 +157,7 @@ Recall that creating an artifact typically involves the following steps:
 - adding a corresponding entry to `Artifacts.toml`,
 - opening a pull request with the change to `Artifacts.toml`.
 
-Registering refers to the final two steps. Once the change to `Oscar.jl/Artifacts.toml` is merged into the `Oscar.jl` repository, the artifact becomes publicly available.
+Registering refers to the final two steps. Once the change to `Artifacts.toml` is merged into the `Oscar.jl` repository, the artifact becomes publicly available.
 
 The [end-to-end example](@ref end-to-end-artifact-example) explicitly demonstrates the required changes to `Oscar.jl/Artifacts.toml`. Additional information is available in [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/).
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -12,8 +12,9 @@ This page explains what artifacts are, when to use them, and how to work with th
 
 ## What Artifacts Are and When to Use Them
 
-Artifacts are content-addressed data bundles managed by [Julia's artifact system](https://pkgdocs.julialang.org/v1/artifacts/).
-They are declared in `Oscar.jl/Artifacts.toml` and are downloaded and unpacked on demand.
+Artifacts are content-addressed bundles managed by [Julia's artifact system](https://pkgdocs.julialang.org/v1/artifacts/) and declared in `Oscar.jl/Artifacts.toml`. Artifacts are automatically downloaded, or updated when `Oscar.jl` is installed or updated, unless the required artifact is already present locally.
+
+Julia also supports [lazy artifacts](https://docs.julialang.org/en/v1/stdlib/LazyArtifacts/), which are installed only on demand. In the following, we ignore lazy artifacts.
 
 Artifacts allow OSCAR to:
 
@@ -28,7 +29,6 @@ Artifacts should be used for data that does not belong directly in the `Oscar.jl
 - data not intended to be edited manually.
 
 As a rule of thumb, data stored directly in the `Oscar.jl` repository should not exceed the size of typical source files (around 100 KB). Small examples, test inputs, and simple hand-written data should remain in the `Oscar.jl` repository.
-
 
 
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -12,7 +12,8 @@ This page explains what artifacts are, when to use them, and how to work with th
 
 ## What Artifacts Are and When to Use Them
 
-Artifacts are content-addressed bundles managed by [Julia's artifact system](https://pkgdocs.julialang.org/v1/artifacts/) and declared in `Oscar.jl/Artifacts.toml`. Artifacts are automatically downloaded, or updated when `Oscar.jl` is installed or updated, unless the required artifact is already present locally.
+Artifacts are content-addressed bundles managed by [Julia's artifact system](https://pkgdocs.julialang.org/v1/artifacts/) and declared in the file `Artifacts.toml`.
+Artifacts are automatically downloaded, or updated when `Oscar.jl` is installed or updated, unless the required artifact is already present locally.
 
 Julia also supports [lazy artifacts](https://docs.julialang.org/en/v1/stdlib/LazyArtifacts/), which are installed only on demand.
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -208,7 +208,7 @@ Additional details are provided in the [Serialization documentation](https://doc
 
 
 
-## Artifacts in Upstream Dependencies of `Oscar.jl`
+## Places to look for Inspiration: Artifacts in Upstream Dependencies of `Oscar.jl`
 
 ### GAP.jl
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -50,7 +50,9 @@ The following example illustrates the complete workflow for creating, registerin
 
 #### Serializing the Data
 
-Let us employ the [`.mrdi` file format to serialize our data](https://docs.oscar-system.org/dev/DeveloperDocumentation/serialization/) to serlialize the number $2^{10}$. (You may of course use the file format of your choice.)
+For this example we will use the [`.mrdi` file format to serialize our data](https://docs.oscar-system.org/dev/DeveloperDocumentation/serialization/).
+(You may of course use the file format of your choice.)
+Here, the data is the number $2^{10}$.
 
 ```julia
 using Oscar

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -111,7 +111,7 @@ obj_path = artifact"MyExample/example.mrdi"
 
 obj = load(obj_path)
 ```
-Note that an artifact may contain multiple files. We use `/example.mrdi` to specify exactly which file to load.
+Note that an artifact may contain multiple files. We append `/example.mrdi` to the artifact name to specify which file in the artifact is to be loaded.
 In `Oscar.jl` source files, the artifact string macro is already available and `using LazyArtifacts` is typically not required.
 
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -181,7 +181,7 @@ In `Oscar.jl` source files, the artifact string macro is already available and `
 
 Artifacts are immutable. Updating an artifact therefore requires:
 
-- creating a new tarball with the updated data,
+- creating a new tarball with the updated data (it may be reasonable at append a version tag like `-v1`, `-v2` etc.),
 - uploading the tarball to a stable hosting location,
 - recomputing the `sha256` and `git-tree-sha1`,
 - updating the corresponding entry in `Oscar.jl/Artifacts.toml`,

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -14,9 +14,8 @@ This page explains what artifacts are, when to use them, and how to work with th
 
 Artifacts are content-addressed bundles managed by
 [Julia's artifact system](https://pkgdocs.julialang.org/v1/artifacts/) and declared in the file
-`Artifacts.toml` located in the `Oscar.jl` root directory. Artifacts are automatically downloaded,
+`Artifacts.toml` located in the `Oscar.jl` root directory. Normally, artifacts are downloaded automatically,
 or updated when `Oscar.jl` is installed or updated, unless the required artifact is already present locally.
-
 Julia also supports [lazy artifacts](https://docs.julialang.org/en/v1/stdlib/LazyArtifacts/), which are
 installed only on demand.
 
@@ -145,7 +144,6 @@ If you want create an artifact, the first decision is where it is to be safely s
 accessibility, artifacts should be hosted at stable and persistent locations.
 
 Preferred options include:
-
 - archival services such as [Zenodo](https://zenodo.org/communities/oscar/records?q=&l=list&p=1&s=10&sort=newest),
 in particular for long-term or publication-related data,
 - other stable hosting solutions agreed upon by the maintainers.

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -86,7 +86,7 @@ println("sha256: ", bytes2hex(open(sha256, filename)))
 println("git-tree-sha1: ", Tar.tree_hash(IOBuffer(inflate_gzip(filename))))
 ```
 
-Then add this information, together with the host location, to `Oscar.jl/Artifacts.toml`. This very example, we host at [https://martinbies.github.io/Materials/Data/example_data_v1.tar.gz](https://martinbies.github.io/Materials/Data/example_data_v1.tar.gz). Then, the corresponding entry to `Oscar.jl/Artifacts.toml` takes the following form:
+Then add this information, together with the host location, to `Oscar.jl/Artifacts.toml`. This very example, we host at [https://martinbies.github.io/Materials/Data/example\_data\_v1.tar.gz](https://martinbies.github.io/Materials/Data/example_data_v1.tar.gz). Then, the corresponding entry to `Oscar.jl/Artifacts.toml` takes the following form:
 
 ```toml
 [MyExample]

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -58,7 +58,7 @@ obj = ZZ(2)^10
 
 #### Save data
 
-Let us employ the `.mrdi` file format to serialize our data. (You may of course use the file format you prefer.)
+Let us employ the  [`.mrdi` file format to serialize our data](https://docs.oscar-system.org/dev/DeveloperDocumentation/serialization/). (You may of course use the file format you prefer.)
 
 ```julia
 save("example.mrdi", obj)

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -12,10 +12,13 @@ This page explains what artifacts are, when to use them, and how to work with th
 
 ## What Artifacts Are and When to Use Them
 
-Artifacts are content-addressed bundles managed by [Julia's artifact system](https://pkgdocs.julialang.org/v1/artifacts/) and declared in the file `Artifacts.toml` located in the `Oscar.jl` root directory.
-Artifacts are automatically downloaded, or updated when `Oscar.jl` is installed or updated, unless the required artifact is already present locally.
+Artifacts are content-addressed bundles managed by
+[Julia's artifact system](https://pkgdocs.julialang.org/v1/artifacts/) and declared in the file
+`Artifacts.toml` located in the `Oscar.jl` root directory. Artifacts are automatically downloaded,
+or updated when `Oscar.jl` is installed or updated, unless the required artifact is already present locally.
 
-Julia also supports [lazy artifacts](https://docs.julialang.org/en/v1/stdlib/LazyArtifacts/), which are installed only on demand.
+Julia also supports [lazy artifacts](https://docs.julialang.org/en/v1/stdlib/LazyArtifacts/), which are
+installed only on demand.
 
 Artifacts allow to:
 
@@ -29,18 +32,20 @@ Artifacts should be used for data that does not belong directly in the `Oscar.jl
 - large datasets,
 - data not intended to be edited manually.
 
-As a rule of thumb, data stored directly in the `Oscar.jl` repository should not exceed the size of typical source files (around 100 KB). Small examples, test inputs, and simple hand-written data should remain in the `Oscar.jl` repository.
+As a rule of thumb, data stored directly in the `Oscar.jl` repository should not exceed the size of typical source files
+(around 100 KB). Small examples, test inputs, and simple hand-written data should remain in the `Oscar.jl` repository.
 
 
 
 ## Creating, Hosting and Using Artifacts
 
-This section describes how to create, host, register, and use artifacts in the `Oscar.jl` repository. The workflow typically proceeds as follows:
+This section describes how to create, host, register, and use artifacts in the `Oscar.jl` repository. The workflow typically
+proceeds as follows:
 
-- [ ] [Serializing the Data](@ref data_preparation)
-- [ ] [Hosting the Data (pack the data into a `gzip` compressed tarball, and upload it to a stable location)](@ref artifact_hosting)
-- [ ] [Registering the Artifact (add an entry to Oscar's `Artifacts.toml` and open a pull request)](@ref artifact_registration)
-- [ ] [Using the Artifact (once the pull request has been merged)](@ref artifact_usage)
+- [ ] [Serialize the Data](@ref data_preparation)
+- [ ] [Host the Data (pack the data into a `gzip` compressed tarball, and upload it to a stable location)](@ref artifact_hosting)
+- [ ] [Register the Artifact (add an entry to Oscar's `Artifacts.toml` and open a pull request)](@ref artifact_registration)
+- [ ] [Use the Artifact (once the pull request has been merged)](@ref artifact_usage)
 
 We illustrate this workflow with an [end-to-end example](@ref end-to-end-artifact-example).
 
@@ -51,7 +56,8 @@ The following example illustrates the complete workflow for creating, registerin
 
 #### Serializing the Data
 
-For this example we will use the [`.mrdi` file format to serialize our data](https://docs.oscar-system.org/dev/DeveloperDocumentation/serialization/).
+For this example we will use the
+[`.mrdi` file format to serialize our data](https://docs.oscar-system.org/dev/DeveloperDocumentation/serialization/).
 (You may of course use the file format of your choice.)
 Here, the data is the number $2^{10}$.
 
@@ -126,28 +132,35 @@ In `Oscar.jl` source files, the artifact string macro is already available and
 
 ### [Serializing the Data](@id data_preparation)
 
-Creating artifacts requires that the corresponding data be serialized locally first. Details are provided in the [Serialization page](https://docs.oscar-system.org/dev/DeveloperDocumentation/serialization/).
+Creating artifacts requires that the corresponding data be serialized locally first. Details are
+provided in the [Serialization page](https://docs.oscar-system.org/dev/DeveloperDocumentation/serialization/).
 
-We recommend the use of the `.mrdi` file format for serialization. However, this is not a strict requirement and you may use any file format that you see fit.
+We recommend the use of the `.mrdi` file format for serialization. However, this is not a strict
+requirement and you may use any file format that you see fit.
 
 
 ### [Hosting the Data](@id artifact_hosting)
 
-If you want create an artifact, the first decision is where it is to be safely stored: to ensure future accessibility, artifacts should be hosted at stable and persistent locations.
+If you want create an artifact, the first decision is where it is to be safely stored: to ensure future
+accessibility, artifacts should be hosted at stable and persistent locations.
 
 Preferred options include:
 
-- archival services such as [Zenodo](https://zenodo.org/communities/oscar/records?q=&l=list&p=1&s=10&sort=newest), in particular for long-term or publication-related data,
+- archival services such as [Zenodo](https://zenodo.org/communities/oscar/records?q=&l=list&p=1&s=10&sort=newest),
+in particular for long-term or publication-related data,
 - other stable hosting solutions agreed upon by the maintainers.
 
 For historical reasons, some artifacts are currently hosted via GitHub release assets, for example at
 [Oscar.jl/archive-tag-1](https://github.com/oscar-system/Oscar.jl/releases/tag/archive-tag-1).
-This approach should be used with care, as GitHub release assets are not intended to function as a long-term artifact registry.
+This approach should be used with care, as GitHub release assets are not intended to function as a
+long-term artifact registry.
 
 !!! warning
     Ensure that existing artifact files are never removed or renamed, as they may be required by older `Oscar.jl` releases.
 
-When debugging, contributors are encouraged to use temporary staging areas before publishing long-term artifact versions. In particular, publication-related Zenodo entries should typically not be cluttered with intermediate or broken artifact versions created during development.
+When debugging, contributors are encouraged to use temporary staging areas before publishing long-term artifact versions.
+In particular, publication-related Zenodo entries should typically not be cluttered with intermediate or broken artifact
+versions created during development.
 
 Data intended for querying may also be suitable for [OscarDB](https://docs.oscar-system.org/dev/Experimental/OscarDB/introduction/).
 
@@ -162,9 +175,11 @@ Recall that creating an artifact typically involves the following steps:
 - adding a corresponding entry to `Artifacts.toml`,
 - opening a pull request with the change to `Artifacts.toml`.
 
-Registering refers to the final two steps. Once the change to `Artifacts.toml` is merged into the `Oscar.jl` repository, the artifact becomes publicly available.
+Registering refers to the final two steps. Once the change to `Artifacts.toml` is merged into the `Oscar.jl` repository,
+the artifact becomes publicly available.
 
-The [end-to-end example](@ref end-to-end-artifact-example) explicitly demonstrates the required changes to `Artifacts.toml`. Additional information is available in [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/).
+The [end-to-end example](@ref end-to-end-artifact-example) explicitly demonstrates the required changes to `Artifacts.toml`.
+Additional information is available in [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/).
 
 
 ### [Using the Artifact](@id artifact_usage)
@@ -191,7 +206,8 @@ In `Oscar.jl` source files, the artifact string macro is already available and
 
 ### General Rules
 
-Artifacts are immutable: To "update" an artifact, you are therefore required to make a new version. Here are the steps to follow:
+Artifacts are immutable: To "update" an artifact, you are therefore required to make a new version.
+Here are the steps to follow:
 
 - create a new tarball with the updated data (we suggest appending a version tag to the artifact name _e.g._ `-v1`, `-v2` _etc._),
 - upload the tarball to a stable hosting location,
@@ -201,18 +217,27 @@ Artifacts are immutable: To "update" an artifact, you are therefore required to 
 
 Once the pull request is merged, the updated artifact becomes available.
 
-Updating an artifact on a hosting platform alone, for example by uploading a new version to Zenodo, is not sufficient. Any change to the artifact contents changes its hashes and therefore requires a corresponding update of `Artifacts.toml`.
+Updating an artifact on a hosting platform alone, for example by uploading a new version to Zenodo, is not sufficient.
+Any change to the artifact contents changes its hashes and therefore requires a corresponding update of `Artifacts.toml`.
 
 !!! warning
-    Any files referenced by the `Oscar.jl` master branch must not be modified, renamed, or deleted, as they may be required by earlier `Oscar.jl` releases.
+    Any files referenced by the `Oscar.jl` master branch must not be modified, renamed, or deleted, as they may be required
+    by earlier `Oscar.jl` releases.
 
-When repeatedly debugging or refining artifacts, contributors are encouraged to use temporary staging areas before publishing long-term versions. In particular, publication-related Zenodo entries should typically not be cluttered with intermediate or broken artifact versions created during development.
+When repeatedly debugging or refining artifacts, contributors are encouraged to use temporary staging areas before publishing
+long-term versions. In particular, publication-related Zenodo entries should typically not be cluttered with intermediate or
+broken artifact versions created during development.
 
 ### Serialization Upgrades
 
-Note that the chosen file format for serialization may be subject to development. In particular, the `.mrdi` file format, which we recommend for serialization, is under active development. Consequently, its standard evolves over time. Older files remain compatible with newer OSCAR versions; however, loading older artifacts may require upgrade steps during deserialization. For large artifacts, these upgrades may become time consuming. It is therefore recommended to use the most recent serialization standard when creating artifacts and to periodically upgrade older artifacts if appropriate.
+Note that the chosen file format for serialization may be subject to development. In particular, the `.mrdi` file format, which
+we recommend for serialization, is under active development. Consequently, its standard evolves over time. Older files remain
+compatible with newer OSCAR versions; however, loading older artifacts may require upgrade steps during deserialization. For
+large artifacts, these upgrades may become time consuming. It is therefore recommended to use the most recent serialization
+standard when creating artifacts and to periodically upgrade older artifacts if appropriate.
 
-Additional details are provided in the [Serialization documentation](https://docs.oscar-system.org/stable/DeveloperDocumentation/serialization/#Upgrades).
+Additional details are provided in the
+[Serialization documentation](https://docs.oscar-system.org/stable/DeveloperDocumentation/serialization/#Upgrades).
 
 
 
@@ -220,4 +245,5 @@ Additional details are provided in the [Serialization documentation](https://doc
 
 ### GAP.jl
 
-`GAP.jl` uses artifacts to install [GAP](https://www.gap-system.org/) packages. Detailed maintainer information is provided in [`GAP.jl/README.maintainer.md`](https://github.com/oscar-system/GAP.jl/blob/master/README.maintainer.md).
+`GAP.jl` uses artifacts to install [GAP](https://www.gap-system.org/) packages. Detailed maintainer information is provided
+in [`GAP.jl/README.maintainer.md`](https://github.com/oscar-system/GAP.jl/blob/master/README.maintainer.md).

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -67,7 +67,7 @@ Create a compressed tarball, for example `example_data_v1.tar.gz`, containing th
 !!! note
     For simplicity, do not introduce an intermediate directory inside the tarball: if multiple files are included, just place them directly in the top level of the archive.
 
-We host this very example tarball at [https://martinbies.github.io/Materials/Data/example\_data\_v1.tar.gz](https://martinbies.github.io/Materials/Data/example_data_v1.tar.gz). 
+We host this particular example tarball at [https://martinbies.github.io/Materials/Data/example\_data\_v1.tar.gz](https://martinbies.github.io/Materials/Data/example_data_v1.tar.gz). 
 
 #### Registering the Artifact
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -58,6 +58,8 @@ obj = ZZ(2)^10
 
 #### Save data
 
+Let us employ the `.mrdi` file format to serialize our data. (You may of course use the file format you prefer.)
+
 ```julia
 save("example.mrdi", obj)
 ```

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -183,13 +183,13 @@ In `Oscar.jl` source files, the artifact string macro is already available and `
 
 ### General Rules
 
-Artifacts are immutable. Updating an artifact therefore requires:
+Artifacts are immutable: To "update" an artifact, you are therefore required to make a new version. Here are the steps to follow:
 
-- creating a new tarball with the updated data (we suggest appending a version tag to the artifact name _e.g._ `-v1`, `-v2` _etc._),
-- uploading the tarball to a stable hosting location,
-- recomputing the `sha256` and `git-tree-sha1`,
-- updating the corresponding entry in `Oscar.jl/Artifacts.toml`,
-- opening a pull request with the changes to `Oscar.jl/Artifacts.toml`.
+- create a new tarball with the updated data (we suggest appending a version tag to the artifact name _e.g._ `-v1`, `-v2` _etc._),
+- upload the tarball to a stable hosting location,
+- recompute the `sha256` and `git-tree-sha1`,
+- update the corresponding entry in `Oscar.jl/Artifacts.toml`,
+- open a pull request with the changes to `Oscar.jl/Artifacts.toml`.
 
 Once the pull request is merged, the updated artifact becomes available.
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -152,7 +152,7 @@ Recall that creating an artifact typically involves the following steps:
 - adding a corresponding entry to `Oscar.jl/Artifacts.toml`,
 - opening a pull request with the change to `Oscar.jl/Artifacts.toml`.
 
-Once the change to `Oscar.jl/Artifacts.toml` is merged into the `Oscar.jl` repository, the artifact becomes available.
+Registering refers to the final two steps. Once the change to `Oscar.jl/Artifacts.toml` is merged into the `Oscar.jl` repository, the artifact becomes available.
 
 The [end-to-end example](@ref end-to-end-artifact-example) explicitly demonstrates these steps. Additional information is available in [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/).
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -144,7 +144,7 @@ Data intended for querying may also be suitable for [OscarDB](https://docs.oscar
 
 ### [Registering](@id artifact_registration)
 
-Creating an artifact typically involves the following steps:
+Recall that creating an artifact typically involves the following steps:
 
 - collecting the relevant data files,
 - packing these files into a compressed tarball (`.tar.gz`),

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -156,7 +156,7 @@ Recall that creating an artifact typically involves the following steps:
 - adding a corresponding entry to `Oscar.jl/Artifacts.toml`,
 - opening a pull request with the change to `Oscar.jl/Artifacts.toml`.
 
-Registering refers to the final two steps. Once the change to `Oscar.jl/Artifacts.toml` is merged into the `Oscar.jl` repository, the artifact becomes available.
+Registering refers to the final two steps. Once the change to `Oscar.jl/Artifacts.toml` is merged into the `Oscar.jl` repository, the artifact becomes publicly available.
 
 The [end-to-end example](@ref end-to-end-artifact-example) explicitly demonstrates the required changes to `Oscar.jl/Artifacts.toml`. Additional information is available in [Julia's artifact documentation](https://pkgdocs.julialang.org/v1/artifacts/).
 

--- a/docs/src/DeveloperDocumentation/artifacts.md
+++ b/docs/src/DeveloperDocumentation/artifacts.md
@@ -88,7 +88,7 @@ println("sha256: ", bytes2hex(open(sha256, filename)))
 println("git-tree-sha1: ", Tar.tree_hash(IOBuffer(inflate_gzip(filename))))
 ```
 
-Then add this information, together with the host location, to `Oscar.jl/Artifacts.toml`.
+Then add this information, together with the host location, to `Artifacts.toml`.
 
 In the case at hand, the corresponding entry to `Oscar.jl/Artifacts.toml` takes the following form:
 


### PR DESCRIPTION
As requested in https://github.com/oscar-system/Oscar.jl/issues/4564, this PR adds developer documentation on creating, hosting, registering, updating, and using artifacts in `Oscar.jl`.

The documentation includes a complete end-to-end example together with the corresponding tarball artifact. At the moment, this example tarball is temporarily hosted at

https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-07-13/example_data_v1.tar.gz

This is explicitly stated in the documentation and should be updated once a final hosting location has been decided upon.

One possibility would be to place the example artifact under

https://github.com/oscar-system/Oscar.jl/releases/tag/archive-tag-1

as a proof of principle. Alternatively, we may prefer a different long-term location within the OSCAR ecosystem, e.g. zenodo?

cc @thofma
