### PR TITLE
Improve `presentation` of a module over a `MPolyQuoLocRing`

### DIFF
--- a/src/Modules/UngradedModules/FreeResolutions.jl
+++ b/src/Modules/UngradedModules/FreeResolutions.jl
@@ -1041,8 +1041,8 @@ julia> I = ideal(AL, minors(M, 3));
 
 julia> FI = free_resolution(I, length = 3)
 Free resolution of I
-AL^4 <---- AL^7 <---- AL^4 <---- 0
-0          1          2          3
+AL^4 <---- AL^3 <---- 0
+0          1          2
 
 ```
 """

--- a/src/Modules/mpolyquo-localizations.jl
+++ b/src/Modules/mpolyquo-localizations.jl
@@ -35,8 +35,13 @@ end
 
 function syz(A::MatrixElem{<:MPolyQuoLocRingElem})
   B, D = clear_denominators(A)
-  L = syz(vcat(B, modulus_matrix(base_ring(A), ncols(B))))
-  return map_entries(base_ring(A), transpose(transpose(D) * transpose(L[:,1:nrows(D)])))
+  L = syz(vcat(B, modulus_matrix(base_ring(A), ncols(B))))[:,1:nrows(D)]
+  # remove zero rows in L
+  rows_L = [i for i in 1:nrows(L) if !iszero(L[i,:])]
+  S = map_entries(base_ring(A), transpose(transpose(D) * transpose(L[rows_L, :])))
+  # remove zero rows in S
+  rows_S = [i for i in 1:nrows(S) if !iszero(S[i,:])]
+  return S[rows_S, :]
 end
 
 function ann(b::MatrixType, A::MatrixType) where {T<:MPolyQuoLocRingElem, MatrixType<:MatrixElem{T}}

--- a/src/Modules/mpolyquo-localizations.jl
+++ b/src/Modules/mpolyquo-localizations.jl
@@ -123,7 +123,6 @@ function kernel(
   Kb, incb = kernel(ffb)
   Cb = representing_matrix(incb)
   C = change_base_ring(S, transpose(transpose(D) * transpose(Cb)))
-  C = change_base_ring(S, transpose(transpose(D) * transpose(Cb)))
   #C = change_base_ring(S, Cb*D)
   K, inc = sub(domain(f), C)
   return K, inc


### PR DESCRIPTION
While computing a `presentation` of a module over a `MPolyQuoLocRing` I noticed that the presentation can be "larger" than necessary, i.e. it can contain many trivial relations:

```
julia> R, (u,v,x,y,z) = QQ[:u,:v,:x,:y,:z];

julia> L, _ = localization(complement_of_point_ideal(R, [0,0,0,0,0]));

julia> M = L[u v x y; v x y z];

julia> LQ, _ = quo(L, ideal(minors(M, 2)));

julia> A = LQ[y   -z    0    x    0   -z    0    0;
              0    y   -z   -v    x    0    0    0;
              0    0    0    u   -v    0   -y    z;
             -v    0    y    0   -v    x    0    0;
              u   -v    0    0    u   -v    x   -y;
              0    u   -v    0    0    0   -v    x];

julia> presentation(image(A))
0 <---- M <---- LQ^6 <---- LQ^85

julia> present_as_cokernel(image(A))
Subquotient of submodule with 6 generators
  1: e[1]
  2: e[2]
  3: e[3]
  4: e[4]
  5: e[5]
  6: e[6]
by submodule with 85 generators
  1: x*e[1] + y*e[2] + z*e[4]
  2: x*e[2] + y*e[3] + y*e[4] + z*e[5]
  3: x*e[4] + y*e[5] + z*e[6]
  4: 0
     ⋮
  19: 0
  20: v*e[1] + x*e[2] + y*e[4]
  21: v*e[2] + x*e[3] - z*e[6]
  22: v*e[4] + x*e[5] + y*e[6]
  23: 0
     ⋮
  44: 0
  45: u*e[1] - x*e[3] + x*e[4] + z*e[6]
  46: u*e[2] + v*e[3] - v*e[4] - x*e[5] - 2*y*e[6]
  47: u*e[4] + v*e[5] + x*e[6]
  48: 0
     ⋮
  68: 0
  69: y^2*e[1] + y*z*e[2] + z^2*e[4]
  70: y^2*e[2] + y*z*e[3] + y*z*e[4] + z^2*e[5]
  71: 0
  72: y^2*e[4] + y*z*e[5] + z^2*e[6]
  73: 0
     ⋮
  85: 0
```

I traced this issue down to `syz(A::MatrixElem{<:MPolyQuoLocRingElem})` returning a matrix with potentially a lot of zero rows.
Removing these zero rows yields a `presentation` with fewer relations:
```
julia> presentation(image(A))
0 <---- M <---- LQ^6 <---- LQ^12
```

Ping @HechtiDerLachs 