### PR TITLE
BasisLieHighestWeight: Accept `LieAlgebra` instead of type and rank

### DIFF
--- a/experimental/BasisLieHighestWeight/src/MainAlgorithm.jl
+++ b/experimental/BasisLieHighestWeight/src/MainAlgorithm.jl
@@ -32,6 +32,7 @@ function basis_lie_highest_weight_compute(
   #     go through them one by one in monomial_ordering until basis is full
   #     return set_mon
 
+  @req characteristic(base_lie_algebra(V)) == 0 "This function only supports Lie algebras in characteristic 0"
   R = root_system(base_lie_algebra(V))
 
   birational_seq = birational_sequence(operators, root_system(base_lie_algebra(V)))
@@ -484,6 +485,7 @@ function add_by_hand(
 end
 
 function operators_asc_height(L::LieAlgebra)
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   return positive_roots(root_system(L))
 end
 
@@ -491,6 +493,7 @@ function operators_by_index(
   L::LieAlgebra,
   birational_seq::Vector{Int},
 )
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   return operators_asc_height(L)[birational_seq]
 end
 
@@ -498,6 +501,7 @@ function operators_by_simple_roots(
   L::LieAlgebra,
   birational_seq::Vector{Vector{Int}},
 )
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   R = root_system(L)
   operators = map(birational_seq) do whgt_alpha
     root = RootSpaceElem(R, whgt_alpha)
@@ -520,6 +524,7 @@ function operators_lusztig(L::LieAlgebra, reduced_expression::Vector{Int})
   # \beta_2 = \alpha_1 + \alpha_2
   # \beta_3 = \alpha_2
 
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   R = root_system(L)
   W = weyl_group(R)
   operators = map(1:length(reduced_expression)) do k

--- a/experimental/BasisLieHighestWeight/src/ModuleData.jl
+++ b/experimental/BasisLieHighestWeight/src/ModuleData.jl
@@ -22,6 +22,7 @@ mutable struct SimpleModuleData{C<:FieldElem,LieT<:LieAlgebraElem{C}} <: ModuleD
   function SimpleModuleData(
     L::LieAlgebra{C}, highest_weight::WeightLatticeElem
   ) where {C<:FieldElem}
+    @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
     return new{C,elem_type(L)}(L, highest_weight)
   end
 end
@@ -67,6 +68,7 @@ mutable struct DemazureModuleData{C<:FieldElem,LieT<:LieAlgebraElem{C}} <:
   function DemazureModuleData(
     L::LieAlgebra{C}, highest_weight::WeightLatticeElem, weyl_group_elem::WeylGroupElem
   ) where {C<:FieldElem}
+    @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
     return new{C,elem_type(L)}(L, highest_weight, weyl_group_elem)
   end
 end

--- a/experimental/BasisLieHighestWeight/src/UserFunctions.jl
+++ b/experimental/BasisLieHighestWeight/src/UserFunctions.jl
@@ -1,4 +1,5 @@
 @doc raw"""
+    basis_lie_highest_weight_operators(L::LieAlgebra)
     basis_lie_highest_weight_operators(type::Symbol, rank::Int)
 
 Lists the operators available for a given simple Lie algebra of type `type_rank`,
@@ -28,9 +29,12 @@ function basis_lie_highest_weight_operators(type::Symbol, rank::Int)
 end
 
 @doc raw"""
-    basis_lie_highest_weight(type::Symbol, rank::Int, highest_weight::Vector{Int}; monomial_ordering::Symbol=:degrevlex)
-    basis_lie_highest_weight(type::Symbol, rank::Int, highest_weight::Vector{Int}, birational_sequence::Vector{Int}; monomial_ordering::Symbol=:degrevlex)
-    basis_lie_highest_weight(type::Symbol, rank::Int, highest_weight::Vector{Int}, birational_sequence::Vector{Vector{Int}}; monomial_ordering::Symbol=:degrevlex)
+    basis_lie_highest_weight(L::LieAlgebra, highest_weight::Vector{Int}; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_lie_highest_weight(L::LieAlgebra, highest_weight::Vector{Int}, birational_sequence::Vector{Int}; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_lie_highest_weight(L::LieAlgebra, highest_weight::Vector{Int}, birational_sequence::Vector{Vector{Int}}; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_lie_highest_weight(type::Symbol, rank::Int, highest_weight::Vector{Int}; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_lie_highest_weight(type::Symbol, rank::Int, highest_weight::Vector{Int}, birational_sequence::Vector{Int}; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_lie_highest_weight(type::Symbol, rank::Int, highest_weight::Vector{Int}, birational_sequence::Vector{Vector{Int}}; monomial_ordering::Symbol=:degrevlex, kwargs...)
 
 Compute a monomial basis for the highest weight module with highest weight
 `highest_weight` (in terms of the fundamental weights $\omega_i$),
@@ -42,6 +46,9 @@ A birational sequence of type `Vector{Vector{Int}}` is a sequence of weights in 
 
 `monomial_ordering` describes the monomial ordering used for the basis.
 If this is a weighted ordering, the height of the corresponding root is used as weight.
+
+Further keyword arguments:
+- none at the moment (but this will probably change in the future)
 
 # Examples
 ```jldoctest
@@ -134,7 +141,8 @@ function basis_lie_highest_weight(type::Symbol, rank::Int, args...; kwargs...)
 end
 
 @doc raw"""
-    basis_lie_highest_weight_lusztig(type::Symbol, rank::Int, highest_weight::Vector{Int}, reduced_expression::Vector{Int})
+    basis_lie_highest_weight_lusztig(L::LieAlgebra, highest_weight::Vector{Int}, reduced_expression::Vector{Int}; kwargs...)
+    basis_lie_highest_weight_lusztig(type::Symbol, rank::Int, highest_weight::Vector{Int}, reduced_expression::Vector{Int}; kwargs...)
 
 Compute a monomial basis for the highest weight module with highest weight
 `highest_weight` (in terms of the fundamental weights $\omega_i$),
@@ -145,6 +153,8 @@ given as indices $[i_1, \dots, i_N]$ in `reduced_expression`.
 Then the birational sequence used consists of $\beta_1, \dots, \beta_N$ where $\beta_1 := \alpha_{i_1}$ and \beta_k := \alpha_{i_k} s_{i_{k-1}} \cdots s_{i_1}$ for $k = 2, \dots, N$.
 
 The monomial ordering is fixed to `wdegrevlex` (weighted degree reverse lexicographic order).
+
+For supported keyword arguments, see [`basis_lie_highest_weight`](@ref).
 
 # Examples
 ```jldoctest
@@ -174,7 +184,8 @@ function basis_lie_highest_weight_lusztig(type::Symbol, rank::Int, args...; kwar
 end
 
 @doc raw"""
-    basis_lie_highest_weight_string(type::Symbol, rank::Int, highest_weight::Vector{Int}, reduced_expression::Vector{Int})
+    basis_lie_highest_weight_string(L::LieAlgebra, highest_weight::Vector{Int}, reduced_expression::Vector{Int}; kwargs...)
+    basis_lie_highest_weight_string(type::Symbol, rank::Int, highest_weight::Vector{Int}, reduced_expression::Vector{Int}; kwargs...)
 
 Compute a monomial basis for the highest weight module with highest weight
 `highest_weight` (in terms of the fundamental weights $\omega_i$),
@@ -185,6 +196,8 @@ given as indices $[i_1, \dots, i_N]$ in `reduced_expression`.
 Then the birational sequence used consists of $\alpha_{i_1}, \dots, \alpha_{i_N}$.
 
 The monomial ordering is fixed to `neglex` (negative lexicographic order).      
+
+For supported keyword arguments, see [`basis_lie_highest_weight`](@ref).
 
 # Examples
 ```jldoctest
@@ -223,7 +236,8 @@ function basis_lie_highest_weight_string(type::Symbol, rank::Int, args...; kwarg
 end
 
 @doc raw"""
-    basis_lie_highest_weight_ffl(type::Symbol, rank::Int, highest_weight::Vector{Int})
+    basis_lie_highest_weight_ffl(L::LieAlgebra, highest_weight::Vector{Int}; kwargs...)
+    basis_lie_highest_weight_ffl(type::Symbol, rank::Int, highest_weight::Vector{Int}; kwargs...)
 
 Compute a monomial basis for the highest weight module with highest weight
 `highest_weight` (in terms of the fundamental weights $\omega_i$),
@@ -232,6 +246,8 @@ for a simple Lie algebra $L$ of type `type_rank`.
 Then the birational sequence used consists of all operators in descening height of the corresponding root.
 
 The monomial ordering is fixed to `degrevlex`.      
+
+For supported keyword arguments, see [`basis_lie_highest_weight`](@ref).
       
 # Examples
 ```jldoctest
@@ -261,7 +277,8 @@ function basis_lie_highest_weight_ffl(type::Symbol, rank::Int, args...; kwargs..
 end
 
 @doc raw"""
-    basis_lie_highest_weight_nz(type::Symbol, rank::Int, highest_weight::Vector{Int}, reduced_expression::Vector{Int})
+    basis_lie_highest_weight_nz(L::LieAlgebra, highest_weight::Vector{Int}, reduced_expression::Vector{Int}; kwargs...)
+    basis_lie_highest_weight_nz(type::Symbol, rank::Int, highest_weight::Vector{Int}, reduced_expression::Vector{Int}; kwargs...)
 
 Compute a monomial basis for the highest weight module with highest weight
 `highest_weight` (in terms of the fundamental weights $\omega_i$),
@@ -272,6 +289,8 @@ given as indices $[i_1, \dots, i_N]$ in `reduced_expression`.
 Then the birational sequence used consists of $\alpha_{i_1}, \dots, \alpha_{i_N}$.
 
 The monomial ordering is fixed to `degrevlex` (degree reverse lexicographic order).      
+
+For supported keyword arguments, see [`basis_lie_highest_weight`](@ref).
 
 # Examples
 ```jldoctest
@@ -310,9 +329,12 @@ function basis_lie_highest_weight_nz(type::Symbol, rank::Int, args...; kwargs...
 end
 
 @doc raw"""
-    basis_coordinate_ring_kodaira(type::Symbol, rank::Int, highest_weight::Vector{Int}, degree::Int; monomial_ordering::Symbol=:degrevlex)
-    basis_coordinate_ring_kodaira(type::Symbol, rank::Int, highest_weight::Vector{Int}, degree::Int, birational_sequence::Vector{Int}; monomial_ordering::Symbol=:degrevlex)
-    basis_coordinate_ring_kodaira(type::Symbol, rank::Int, highest_weight::Vector{Int}, degree::Int, birational_sequence::Vector{Vector{Int}}; monomial_ordering::Symbol=:degrevlex)
+    basis_coordinate_ring_kodaira(L::LieAlgebra, highest_weight::Vector{Int}, degree::Int; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_coordinate_ring_kodaira(L::LieAlgebra, highest_weight::Vector{Int}, degree::Int, birational_sequence::Vector{Int}; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_coordinate_ring_kodaira(L::LieAlgebra, highest_weight::Vector{Int}, degree::Int, birational_sequence::Vector{Vector{Int}}; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_coordinate_ring_kodaira(type::Symbol, rank::Int, highest_weight::Vector{Int}, degree::Int; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_coordinate_ring_kodaira(type::Symbol, rank::Int, highest_weight::Vector{Int}, degree::Int, birational_sequence::Vector{Int}; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_coordinate_ring_kodaira(type::Symbol, rank::Int, highest_weight::Vector{Int}, degree::Int, birational_sequence::Vector{Vector{Int}}; monomial_ordering::Symbol=:degrevlex, kwargs...)
 
 Compute monomial bases for the degree-truncated coordinate ring (for all degrees up to `degree`) 
 of the Kodaira embedding of the generalized flag variety into the projective space of the highest weight module
@@ -330,6 +352,8 @@ A birational sequence of type `Vector{Vector{Int}}` is a sequence of weights in 
 
 `monomial_ordering` describes the monomial ordering used for the basis.
 If this is a weighted ordering, the height of the corresponding root is used as weight.
+
+For supported keyword arguments, see [`basis_lie_highest_weight`](@ref).
 
 # Examples
 ```jldoctest
@@ -414,7 +438,8 @@ function basis_coordinate_ring_kodaira(type::Symbol, rank::Int, args...; kwargs.
 end
 
 @doc raw"""
-    basis_coordinate_ring_kodaira_ffl(type::Symbol, rank::Int, highest_weight::Vector{Int}, degree::Int)
+    basis_coordinate_ring_kodaira_ffl(L::LieAlgebra, highest_weight::Vector{Int}, degree::Int; kwargs...)
+    basis_coordinate_ring_kodaira_ffl(type::Symbol, rank::Int, highest_weight::Vector{Int}, degree::Int; kwargs...)
 
 Compute monomial bases for the degree-truncated coordinate ring (for all degrees up to `degree`) 
 of the Kodaira embedding of the generalized flag variety into the projective space of the highest weight module
@@ -429,6 +454,8 @@ of the bases of the lower degrees.
 The the birational sequence used consists of all operators in descening height of the corresponding root, i.e. a "good" ordering.
 
 The monomial ordering is fixed to `degrevlex`. 
+
+For supported keyword arguments, see [`basis_lie_highest_weight`](@ref).
 
 # Examples
 ```jldoctest
@@ -480,9 +507,12 @@ function basis_coordinate_ring_kodaira_ffl(type::Symbol, rank::Int, args...; kwa
 end
 
 @doc raw"""
-    basis_lie_demazure(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}; monomial_ordering::Symbol=:degrevlex)
-    basis_lie_demazure(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, birational_sequence::Vector{Int}; monomial_ordering::Symbol=:degrevlex)
-    basis_lie_demazure(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, birational_sequence::Vector{Vector{Int}}; monomial_ordering::Symbol=:degrevlex)
+    basis_lie_demazure(L::LieAlgebra, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_lie_demazure(L::LieAlgebra, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, birational_sequence::Vector{Int}; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_lie_demazure(L::LieAlgebra, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, birational_sequence::Vector{Vector{Int}}; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_lie_demazure(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_lie_demazure(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, birational_sequence::Vector{Int}; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_lie_demazure(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, birational_sequence::Vector{Vector{Int}}; monomial_ordering::Symbol=:degrevlex, kwargs...)
 
 Compute a monomial basis for the demazure module with extremal weight
 `highest_weight * weyl_group_elem` (in terms of the fundamental weights $\omega_i$),
@@ -494,6 +524,8 @@ A birational sequence of type `Vector{Vector{Int}}` is a sequence of weights in 
 
 `monomial_ordering` describes the monomial ordering used for the basis.
 If this is a weighted ordering, the height of the corresponding root is used as weight.
+
+For supported keyword arguments, see [`basis_lie_highest_weight`](@ref).
 
 # Examples
 ```jldoctest
@@ -554,7 +586,8 @@ function basis_lie_demazure(type::Symbol, rank::Int, args...; kwargs...)
 end
 
 @doc raw"""
-    basis_lie_demazure_lusztig(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, reduced_expression::Vector{Int})
+    basis_lie_demazure_lusztig(L::LieAlgebra, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, reduced_expression::Vector{Int}; kwargs...)
+    basis_lie_demazure_lusztig(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, reduced_expression::Vector{Int}; kwargs...)
 
 Compute a monomial basis for the demazure module with extremal weight
 `highest_weight * weyl_group_elem` (in terms of the fundamental weights $\omega_i$),
@@ -565,6 +598,8 @@ given as indices $[i_1, \dots, i_N]$ in `reduced_expression`.
 Then the birational sequence used consists of $\beta_1, \dots, \beta_N$ where $\beta_1 := \alpha_{i_1}$ and \beta_k := \alpha_{i_k} s_{i_{k-1}} \cdots s_{i_1}$ for $k = 2, \dots, N$.
 
 The monomial ordering is fixed to `wdegrevlex` (weighted degree reverse lexicographic order).
+
+For supported keyword arguments, see [`basis_lie_highest_weight`](@ref).
 
 # Examples
 ```jldoctest
@@ -595,7 +630,8 @@ function basis_lie_demazure_lusztig(type::Symbol, rank::Int, args...; kwargs...)
 end
 
 @doc raw"""
-    basis_lie_demazure_string(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, reduced_expression::Vector{Int})
+    basis_lie_demazure_string(L::LieAlgebra, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, reduced_expression::Vector{Int}; kwargs...)
+    basis_lie_demazure_string(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, reduced_expression::Vector{Int}; kwargs...)
 
 Compute a monomial basis for the demazure module with extremal weight
 `highest_weight * weyl_group_elem` (in terms of the fundamental weights $\omega_i$),
@@ -606,6 +642,8 @@ given as indices $[i_1, \dots, i_N]$ in `reduced_expression`.
 Then the birational sequence used consists of $\alpha_{i_1}, \dots, \alpha_{i_N}$.
 
 The monomial ordering is fixed to `neglex` (negative lexicographic order).
+
+For supported keyword arguments, see [`basis_lie_highest_weight`](@ref).
 
 # Examples
 ```jldoctest
@@ -636,7 +674,8 @@ function basis_lie_demazure_string(type::Symbol, rank::Int, args...; kwargs...)
 end
 
 @doc raw"""
-    basis_lie_demazure_ffl(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int})
+    basis_lie_demazure_ffl(L::LieAlgebra, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}; kwargs...)
+    basis_lie_demazure_ffl(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}; kwargs...)
 
 Compute a monomial basis for the demazure module with extremal weight
 `highest_weight * weyl_group_elem` (in terms of the fundamental weights $\omega_i$),
@@ -645,6 +684,8 @@ for a simple Lie algebra of type `type_rank`.
 Then the birational sequence used consists of all operators in descening height of the corresponding root.
 
 The monomial ordering is fixed to `degrevlex`.
+
+For supported keyword arguments, see [`basis_lie_highest_weight`](@ref).
       
 # Examples
 ```jldoctest
@@ -676,7 +717,8 @@ function basis_lie_demazure_ffl(type::Symbol, rank::Int, args...; kwargs...)
 end
 
 @doc raw"""
-    basis_lie_demazure_nz(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, reduced_expression::Vector{Int})
+    basis_lie_demazure_nz(L::LieAlgebra, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, reduced_expression::Vector{Int}; kwargs...)
+    basis_lie_demazure_nz(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, reduced_expression::Vector{Int}; kwargs...)
 
 Compute a monomial basis for the demazure module with extremal weight
 `highest_weight * weyl_group_elem` (in terms of the fundamental weights $\omega_i$),
@@ -687,6 +729,8 @@ given as indices $[i_1, \dots, i_N]$ in `reduced_expression`.
 Then the birational sequence used consists of $\alpha_{i_1}, \dots, \alpha_{i_N}$.
 
 The monomial ordering is fixed to `degrevlex` (degree reverse lexicographic order).     
+
+For supported keyword arguments, see [`basis_lie_highest_weight`](@ref).
 
 # Examples
 ```jldoctest
@@ -717,9 +761,12 @@ function basis_lie_demazure_nz(type::Symbol, rank::Int, args...; kwargs...)
 end
 
 @doc raw"""
-    basis_coordinate_ring_kodaira_demazure(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, degree::Int; monomial_ordering::Symbol=:degrevlex)
-    basis_coordinate_ring_kodaira_demazure(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, degree::Int, birational_sequence::Vector{Int}; monomial_ordering::Symbol=:degrevlex)
-    basis_coordinate_ring_kodaira_demazure(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, degree::Int, birational_sequence::Vector{Vector{Int}}; monomial_ordering::Symbol=:degrevlex)
+    basis_coordinate_ring_kodaira_demazure(L::LieAlgebra, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, degree::Int; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_coordinate_ring_kodaira_demazure(L::LieAlgebra, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, degree::Int, birational_sequence::Vector{Int}; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_coordinate_ring_kodaira_demazure(L::LieAlgebra, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, degree::Int, birational_sequence::Vector{Vector{Int}}; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_coordinate_ring_kodaira_demazure(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, degree::Int; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_coordinate_ring_kodaira_demazure(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, degree::Int, birational_sequence::Vector{Int}; monomial_ordering::Symbol=:degrevlex, kwargs...)
+    basis_coordinate_ring_kodaira_demazure(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, degree::Int, birational_sequence::Vector{Vector{Int}}; monomial_ordering::Symbol=:degrevlex, kwargs...)
 
 Compute monomial bases for the degree-truncated coordinate ring (for all degrees up to `degree`) 
 of the Kodaira embedding of a Schubert variety into the projective space of the Demazure module
@@ -737,6 +784,8 @@ A birational sequence of type `Vector{Vector{Int}}` is a sequence of weights in 
 
 `monomial_ordering` describes the monomial ordering used for the basis.
 If this is a weighted ordering, the height of the corresponding root is used as weight.
+
+For supported keyword arguments, see [`basis_lie_highest_weight`](@ref).
 
 # Examples
 ```jldoctest
@@ -815,7 +864,8 @@ function basis_coordinate_ring_kodaira_demazure(type::Symbol, rank::Int, args...
 end
 
 @doc raw"""
-    basis_coordinate_ring_kodaira_demazure_ffl(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, degree::Int)
+    basis_coordinate_ring_kodaira_demazure_ffl(L::LieAlgebra, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, degree::Int; kwargs...)
+    basis_coordinate_ring_kodaira_demazure_ffl(type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}, degree::Int; kwargs...)
 
 Compute monomial bases for the degree-truncated coordinate ring (for all degrees up to `degree`) 
 of the Kodaira embedding of a Schubert variety into the projective space of the Demazure module
@@ -830,6 +880,8 @@ of the bases of the lower degrees.
 The the birational sequence used consists of all operators in descening height of the corresponding root, i.e. a "good" ordering.
 
 The monomial ordering is fixed to `degrevlex`. 
+
+For supported keyword arguments, see [`basis_lie_highest_weight`](@ref).
 
 # Examples
 ```jldoctest

--- a/experimental/BasisLieHighestWeight/src/UserFunctions.jl
+++ b/experimental/BasisLieHighestWeight/src/UserFunctions.jl
@@ -16,9 +16,15 @@ julia> basis_lie_highest_weight_operators(:B, 2)
  (4, [1, 2])
 ```
 """
-function basis_lie_highest_weight_operators(type::Symbol, rank::Int)
-  R = root_system(type, rank)
+function basis_lie_highest_weight_operators(L::LieAlgebra)
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
+  R = root_system(L)
   return collect(enumerate(map(r -> Oscar._vec(coefficients(r)), positive_roots(R)))) # TODO: clean up
+end
+
+function basis_lie_highest_weight_operators(type::Symbol, rank::Int)
+  L = lie_algebra(QQ, type, rank)
+  return basis_lie_highest_weight_operators(L)
 end
 
 @doc raw"""
@@ -86,39 +92,45 @@ where the used birational sequence consists of the following roots:
 ```
 """
 function basis_lie_highest_weight(
-  type::Symbol, rank::Int, highest_weight::Vector{Int};
+  L::LieAlgebra, highest_weight::Vector{Int};
   monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
+  kwargs...,
 )
-  L = lie_algebra(QQ, type, rank)
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   V = SimpleModuleData(L, highest_weight)
   operators = operators_asc_height(L)
-  return basis_lie_highest_weight_compute(V, operators, monomial_ordering)
+  return basis_lie_highest_weight_compute(V, operators, monomial_ordering; kwargs...)
 end
 
 function basis_lie_highest_weight(
-  type::Symbol,
-  rank::Int,
+  L::LieAlgebra,
   highest_weight::Vector{Int},
   birational_sequence::Vector{Int};
   monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
+  kwargs...,
 )
-  L = lie_algebra(QQ, type, rank)
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   V = SimpleModuleData(L, highest_weight)
   operators = operators_by_index(L, birational_sequence)
-  return basis_lie_highest_weight_compute(V, operators, monomial_ordering)
+  return basis_lie_highest_weight_compute(V, operators, monomial_ordering; kwargs...)
 end
 
 function basis_lie_highest_weight(
-  type::Symbol,
-  rank::Int,
+  L::LieAlgebra,
   highest_weight::Vector{Int},
   birational_sequence::Vector{Vector{Int}};
   monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
+  kwargs...,
 )
-  L = lie_algebra(QQ, type, rank)
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   V = SimpleModuleData(L, highest_weight)
   operators = operators_by_simple_roots(L, birational_sequence)
-  return basis_lie_highest_weight_compute(V, operators, monomial_ordering)
+  return basis_lie_highest_weight_compute(V, operators, monomial_ordering; kwargs...)
+end
+
+function basis_lie_highest_weight(type::Symbol, rank::Int, args...; kwargs...)
+  L = lie_algebra(QQ, type, rank)
+  return basis_lie_highest_weight(L, args...; kwargs...)
 end
 
 @doc raw"""
@@ -147,13 +159,18 @@ where the used birational sequence consists of the following roots:
 ```
 """
 function basis_lie_highest_weight_lusztig(
-  type::Symbol, rank::Int, highest_weight::Vector{Int}, reduced_expression::Vector{Int}
+  L::LieAlgebra, highest_weight::Vector{Int}, reduced_expression::Vector{Int}; kwargs...
 )
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   monomial_ordering = :wdegrevlex
-  L = lie_algebra(QQ, type, rank)
   V = SimpleModuleData(L, highest_weight)
   operators = operators_lusztig(L, reduced_expression)
-  return basis_lie_highest_weight_compute(V, operators, monomial_ordering)
+  return basis_lie_highest_weight_compute(V, operators, monomial_ordering; kwargs...)
+end
+
+function basis_lie_highest_weight_lusztig(type::Symbol, rank::Int, args...; kwargs...)
+  L = lie_algebra(QQ, type, rank)
+  return basis_lie_highest_weight_lusztig(L, args...; kwargs...)
 end
 
 @doc raw"""
@@ -191,13 +208,18 @@ where the used birational sequence consists of the following roots:
 ```
 """
 function basis_lie_highest_weight_string(
-  type::Symbol, rank::Int, highest_weight::Vector{Int}, reduced_expression::Vector{Int}
+  L::LieAlgebra, highest_weight::Vector{Int}, reduced_expression::Vector{Int}; kwargs...
 )
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   monomial_ordering = :neglex
-  L = lie_algebra(QQ, type, rank)
   V = SimpleModuleData(L, highest_weight)
   operators = operators_by_index(L, reduced_expression)
-  return basis_lie_highest_weight_compute(V, operators, monomial_ordering)
+  return basis_lie_highest_weight_compute(V, operators, monomial_ordering; kwargs...)
+end
+
+function basis_lie_highest_weight_string(type::Symbol, rank::Int, args...; kwargs...)
+  L = lie_algebra(QQ, type, rank)
+  return basis_lie_highest_weight_string(L, args...; kwargs...)
 end
 
 @doc raw"""
@@ -223,14 +245,19 @@ where the used birational sequence consists of the following roots:
   [a_1 + a_2 + a_3, a_2 + a_3, a_1 + a_2, a_3, a_2, a_1]
 ```
 """
-function basis_lie_highest_weight_ffl(type::Symbol, rank::Int, highest_weight::Vector{Int})
+function basis_lie_highest_weight_ffl(L::LieAlgebra, highest_weight::Vector{Int}; kwargs...)
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   monomial_ordering = :degrevlex
-  L = lie_algebra(QQ, type, rank)
   V = SimpleModuleData(L, highest_weight)
   operators = reverse(operators_asc_height(L))
   # we reverse the order here to have simple roots at the right end, this is then a good ordering.
   # simple roots at the right end speed up the program very much
-  return basis_lie_highest_weight_compute(V, operators, monomial_ordering)
+  return basis_lie_highest_weight_compute(V, operators, monomial_ordering; kwargs...)
+end
+
+function basis_lie_highest_weight_ffl(type::Symbol, rank::Int, args...; kwargs...)
+  L = lie_algebra(QQ, type, rank)
+  return basis_lie_highest_weight_ffl(L, args...; kwargs...)
 end
 
 @doc raw"""
@@ -268,13 +295,18 @@ where the used birational sequence consists of the following roots:
 ```
 """
 function basis_lie_highest_weight_nz(
-  type::Symbol, rank::Int, highest_weight::Vector{Int}, reduced_expression::Vector{Int}
+  L::LieAlgebra, highest_weight::Vector{Int}, reduced_expression::Vector{Int}; kwargs...
 )
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   monomial_ordering = :degrevlex
-  L = lie_algebra(QQ, type, rank)
   V = SimpleModuleData(L, highest_weight)
   operators = operators_by_index(L, reduced_expression)
-  return basis_lie_highest_weight_compute(V, operators, monomial_ordering)
+  return basis_lie_highest_weight_compute(V, operators, monomial_ordering; kwargs...)
+end
+
+function basis_lie_highest_weight_nz(type::Symbol, rank::Int, args...; kwargs...)
+  L = lie_algebra(QQ, type, rank)
+  return basis_lie_highest_weight_nz(L, args...; kwargs...)
 end
 
 @doc raw"""
@@ -330,50 +362,55 @@ where the used birational sequence consists of the following roots:
 ```
 """
 function basis_coordinate_ring_kodaira(
-  type::Symbol,
-  rank::Int,
+  L::LieAlgebra,
   highest_weight::Vector{Int},
   degree::Int;
   monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
+  kwargs...,
 )
-  L = lie_algebra(QQ, type, rank)
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   V = SimpleModuleData(L, highest_weight)
   operators = operators_asc_height(L)
   return basis_coordinate_ring_kodaira_compute(
-    V, degree, operators, monomial_ordering
+    V, degree, operators, monomial_ordering; kwargs...
   )
 end
 
 function basis_coordinate_ring_kodaira(
-  type::Symbol,
-  rank::Int,
+  L::LieAlgebra,
   highest_weight::Vector{Int},
   degree::Int,
   birational_sequence::Vector{Int};
   monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
+  kwargs...,
 )
-  L = lie_algebra(QQ, type, rank)
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   V = SimpleModuleData(L, highest_weight)
   operators = operators_by_index(L, birational_sequence)
   return basis_coordinate_ring_kodaira_compute(
-    V, degree, operators, monomial_ordering
+    V, degree, operators, monomial_ordering; kwargs...
   )
 end
 
 function basis_coordinate_ring_kodaira(
-  type::Symbol,
-  rank::Int,
+  L::LieAlgebra,
   highest_weight::Vector{Int},
   degree::Int,
   birational_sequence::Vector{Vector{Int}};
   monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
+  kwargs...,
 )
-  L = lie_algebra(QQ, type, rank)
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   V = SimpleModuleData(L, highest_weight)
   operators = operators_by_simple_roots(L, birational_sequence)
   return basis_coordinate_ring_kodaira_compute(
-    V, degree, operators, monomial_ordering
+    V, degree, operators, monomial_ordering; kwargs...
   )
+end
+
+function basis_coordinate_ring_kodaira(type::Symbol, rank::Int, args...; kwargs...)
+  L = lie_algebra(QQ, type, rank)
+  return basis_coordinate_ring_kodaira(L, args...; kwargs...)
 end
 
 @doc raw"""
@@ -424,17 +461,22 @@ where the used birational sequence consists of the following roots:
 ```
 """
 function basis_coordinate_ring_kodaira_ffl(
-  type::Symbol, rank::Int, highest_weight::Vector{Int}, degree::Int
+  L::LieAlgebra, highest_weight::Vector{Int}, degree::Int; kwargs...
 )
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   monomial_ordering = :degrevlex
-  L = lie_algebra(QQ, type, rank)
   V = SimpleModuleData(L, highest_weight)
   operators = reverse(operators_asc_height(L))
   # we reverse the order here to have simple roots at the right end, this is then a good ordering.
   # simple roots at the right end speed up the program very much
   return basis_coordinate_ring_kodaira_compute(
-    V, degree, operators, monomial_ordering
+    V, degree, operators, monomial_ordering; kwargs...
   )
+end
+
+function basis_coordinate_ring_kodaira_ffl(type::Symbol, rank::Int, args...; kwargs...)
+  L = lie_algebra(QQ, type, rank)
+  return basis_coordinate_ring_kodaira_ffl(L, args...; kwargs...)
 end
 
 @doc raw"""
@@ -466,44 +508,49 @@ where the used birational sequence consists of the following roots:
 ```
 """
 function basis_lie_demazure(
-  type::Symbol,
-  rank::Int,
+  L::LieAlgebra,
   highest_weight::Vector{Int},
   weyl_group_elem::Vector{Int};
   monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
+  kwargs...,
 )
-  L = lie_algebra(QQ, type, rank)
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   V = DemazureModuleData(L, highest_weight, weyl_group_elem)
   operators = demazurify_operators(V, operators_asc_height(L))
-  return basis_lie_highest_weight_compute(V, operators, monomial_ordering)
+  return basis_lie_highest_weight_compute(V, operators, monomial_ordering; kwargs...)
 end
 
 function basis_lie_demazure(
-  type::Symbol,
-  rank::Int,
+  L::LieAlgebra,
   highest_weight::Vector{Int},
   weyl_group_elem::Vector{Int},
   birational_sequence::Vector{Int};
   monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
+  kwargs...,
 )
-  L = lie_algebra(QQ, type, rank)
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   V = DemazureModuleData(L, highest_weight, weyl_group_elem)
   operators = demazurify_operators(V, operators_by_index(L, birational_sequence))
-  return basis_lie_highest_weight_compute(V, operators, monomial_ordering)
+  return basis_lie_highest_weight_compute(V, operators, monomial_ordering; kwargs...)
 end
 
 function basis_lie_demazure(
-  type::Symbol,
-  rank::Int,
+  L::LieAlgebra,
   highest_weight::Vector{Int},
   weyl_group_elem::Vector{Int},
   birational_sequence::Vector{Vector{Int}};
   monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
+  kwargs...,
 )
-  L = lie_algebra(QQ, type, rank)
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   V = DemazureModuleData(L, highest_weight, weyl_group_elem)
   operators = demazurify_operators(V, operators_by_simple_roots(L, birational_sequence))
-  return basis_lie_highest_weight_compute(V, operators, monomial_ordering)
+  return basis_lie_highest_weight_compute(V, operators, monomial_ordering; kwargs...)
+end
+
+function basis_lie_demazure(type::Symbol, rank::Int, args...; kwargs...)
+  L = lie_algebra(QQ, type, rank)
+  return basis_lie_demazure(L, args...; kwargs...)
 end
 
 @doc raw"""
@@ -532,14 +579,19 @@ where the used birational sequence consists of the following roots:
 ```
 """
 function basis_lie_demazure_lusztig(
-  type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int},
-  reduced_expression::Vector{Int},
+  L::LieAlgebra, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int},
+  reduced_expression::Vector{Int}; kwargs...,
 )
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   monomial_ordering = :wdegrevlex
-  L = lie_algebra(QQ, type, rank)
   V = DemazureModuleData(L, highest_weight, weyl_group_elem)
   operators = demazurify_operators(V, operators_lusztig(L, reduced_expression))
-  return basis_lie_highest_weight_compute(V, operators, monomial_ordering)
+  return basis_lie_highest_weight_compute(V, operators, monomial_ordering; kwargs...)
+end
+
+function basis_lie_demazure_lusztig(type::Symbol, rank::Int, args...; kwargs...)
+  L = lie_algebra(QQ, type, rank)
+  return basis_lie_demazure_lusztig(L, args...; kwargs...)
 end
 
 @doc raw"""
@@ -568,14 +620,19 @@ where the used birational sequence consists of the following roots:
 ```
 """
 function basis_lie_demazure_string(
-  type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int},
-  reduced_expression::Vector{Int},
+  L::LieAlgebra, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int},
+  reduced_expression::Vector{Int}; kwargs...,
 )
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   monomial_ordering = :neglex
-  L = lie_algebra(QQ, type, rank)
   V = DemazureModuleData(L, highest_weight, weyl_group_elem)
   operators = demazurify_operators(V, operators_by_index(L, reduced_expression))
-  return basis_lie_highest_weight_compute(V, operators, monomial_ordering)
+  return basis_lie_highest_weight_compute(V, operators, monomial_ordering; kwargs...)
+end
+
+function basis_lie_demazure_string(type::Symbol, rank::Int, args...; kwargs...)
+  L = lie_algebra(QQ, type, rank)
+  return basis_lie_demazure_string(L, args...; kwargs...)
 end
 
 @doc raw"""
@@ -602,15 +659,20 @@ where the used birational sequence consists of the following roots:
 ```
 """
 function basis_lie_demazure_ffl(
-  type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}
+  L::LieAlgebra, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int}; kwargs...
 )
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   monomial_ordering = :degrevlex
-  L = lie_algebra(QQ, type, rank)
   V = DemazureModuleData(L, highest_weight, weyl_group_elem)
   operators = demazurify_operators(V, reverse(operators_asc_height(L)))
   # we reverse the order here to have simple roots at the right end, this is then a good ordering.
   # simple roots at the right end speed up the program very much
-  return basis_lie_highest_weight_compute(V, operators, monomial_ordering)
+  return basis_lie_highest_weight_compute(V, operators, monomial_ordering; kwargs...)
+end
+
+function basis_lie_demazure_ffl(type::Symbol, rank::Int, args...; kwargs...)
+  L = lie_algebra(QQ, type, rank)
+  return basis_lie_demazure_ffl(L, args...; kwargs...)
 end
 
 @doc raw"""
@@ -639,14 +701,19 @@ where the used birational sequence consists of the following roots:
 ```
 """
 function basis_lie_demazure_nz(
-  type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int},
-  reduced_expression::Vector{Int},
+  L::LieAlgebra, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int},
+  reduced_expression::Vector{Int}; kwargs...,
 )
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   monomial_ordering = :degrevlex
-  L = lie_algebra(QQ, type, rank)
   V = DemazureModuleData(L, highest_weight, weyl_group_elem)
   operators = demazurify_operators(V, operators_by_index(L, reduced_expression))
-  return basis_lie_highest_weight_compute(V, operators, monomial_ordering)
+  return basis_lie_highest_weight_compute(V, operators, monomial_ordering; kwargs...)
+end
+
+function basis_lie_demazure_nz(type::Symbol, rank::Int, args...; kwargs...)
+  L = lie_algebra(QQ, type, rank)
+  return basis_lie_demazure_nz(L, args...; kwargs...)
 end
 
 @doc raw"""
@@ -693,53 +760,58 @@ where the used birational sequence consists of the following roots:
 ```
 """
 function basis_coordinate_ring_kodaira_demazure(
-  type::Symbol,
-  rank::Int,
+  L::LieAlgebra,
   highest_weight::Vector{Int},
   weyl_group_elem::Vector{Int},
   degree::Int;
   monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
+  kwargs...,
 )
-  L = lie_algebra(QQ, type, rank)
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   V = DemazureModuleData(L, highest_weight, weyl_group_elem)
   operators = demazurify_operators(V, operators_asc_height(L))
   return basis_coordinate_ring_kodaira_compute(
-    V, degree, operators, monomial_ordering
+    V, degree, operators, monomial_ordering; kwargs...
   )
 end
 
 function basis_coordinate_ring_kodaira_demazure(
-  type::Symbol,
-  rank::Int,
+  L::LieAlgebra,
   highest_weight::Vector{Int},
   weyl_group_elem::Vector{Int},
   degree::Int,
   birational_sequence::Vector{Int};
   monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
+  kwargs...,
 )
-  L = lie_algebra(QQ, type, rank)
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   V = DemazureModuleData(L, highest_weight, weyl_group_elem)
   operators = demazurify_operators(V, operators_by_index(L, birational_sequence))
   return basis_coordinate_ring_kodaira_compute(
-    V, degree, operators, monomial_ordering
+    V, degree, operators, monomial_ordering; kwargs...
   )
 end
 
 function basis_coordinate_ring_kodaira_demazure(
-  type::Symbol,
-  rank::Int,
+  L::LieAlgebra,
   highest_weight::Vector{Int},
   weyl_group_elem::Vector{Int},
   degree::Int,
   birational_sequence::Vector{Vector{Int}};
   monomial_ordering::Union{AbsGenOrdering,Symbol}=:degrevlex,
+  kwargs...,
 )
-  L = lie_algebra(QQ, type, rank)
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   V = DemazureModuleData(L, highest_weight, weyl_group_elem)
   operators = demazurify_operators(V, operators_by_simple_roots(L, birational_sequence))
   return basis_coordinate_ring_kodaira_compute(
-    V, degree, operators, monomial_ordering
+    V, degree, operators, monomial_ordering; kwargs...
   )
+end
+
+function basis_coordinate_ring_kodaira_demazure(type::Symbol, rank::Int, args...; kwargs...)
+  L = lie_algebra(QQ, type, rank)
+  return basis_coordinate_ring_kodaira_demazure(L, args...; kwargs...)
 end
 
 @doc raw"""
@@ -781,16 +853,23 @@ where the used birational sequence consists of the following roots:
 ```
 """
 function basis_coordinate_ring_kodaira_demazure_ffl(
-  type::Symbol, rank::Int, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int},
-  degree::Int,
+  L::LieAlgebra, highest_weight::Vector{Int}, weyl_group_elem::Vector{Int},
+  degree::Int; kwargs...,
 )
+  @req characteristic(L) == 0 "This function only supports Lie algebras in characteristic 0"
   monomial_ordering = :degrevlex
-  L = lie_algebra(QQ, type, rank)
   V = DemazureModuleData(L, highest_weight, weyl_group_elem)
   operators = demazurify_operators(V, reverse(operators_asc_height(L)))
   # we reverse the order here to have simple roots at the right end, this is then a good ordering.
   # simple roots at the right end speed up the program very much
   return basis_coordinate_ring_kodaira_compute(
-    V, degree, operators, monomial_ordering
+    V, degree, operators, monomial_ordering; kwargs...
   )
+end
+
+function basis_coordinate_ring_kodaira_demazure_ffl(
+  type::Symbol, rank::Int, args...; kwargs...
+)
+  L = lie_algebra(QQ, type, rank)
+  return basis_coordinate_ring_kodaira_demazure_ffl(L, args...; kwargs...)
 end


### PR DESCRIPTION
with fallbacks that construct the Lie algebra for you (to not break any code).

@janikapeters this is what I mentioned at some point last week. Since my AI agent was touching all the user functions anyway, I also included the kwarg delegation that you need for https://github.com/oscar-system/Oscar.jl/pull/5597.