### PR TITLE
Avoid creating new Oscar group objects in `SubFPGroup`, `SubPcGroup`, `free_group`

### DIFF
--- a/src/Groups/group_constructors.jl
+++ b/src/Groups/group_constructors.jl
@@ -791,14 +791,18 @@ end
 # for the definition of group modulo relations, see the quo function in the sub.jl section
 
 function free_group(G::FPGroup)
+  isdefined(G, :free_group) && return G.free_group
   gapG = GapObj(G)::GapObj
   gapF = GAPWrap.FreeGroupOfFpGroup(gapG)
   if gapF === gapG
     # G is itself a free group
-    return G
+    res = G
   else
-    return FPGroup(gapF)
+    # we have not yet created the Oscar object
+    res = fp_group(gapF)
   end
+  G.free_group = res
+  return res
 end
 
 function underlying_word(g::FPGroupElem)

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -925,7 +925,7 @@ function isomorphism(T::Type{PcGroup}, G::GAPGroup; on_gens::Bool=false)
        # Create a group in `IsPcGroup` if `G` is finite,
        # and a group in `IsPcpGroup` otherwise.
        if is_finite(G)
-         fam = GAP.Globals.ElementsFamily(GAP.Globals.FamilyObj(GapObj(G)))::GapObj
+         fam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(GapObj(G)))
          Ggens = GapObj(gens(G); recursive = true)::GapObj
          Cpcgs = GAP.Globals.PcgsByPcSequence(fam, Ggens)::GapObj
          CC = GAP.Globals.PcGroupWithPcgs(Cpcgs)::GapObj

--- a/src/Groups/sub.jl
+++ b/src/Groups/sub.jl
@@ -756,7 +756,7 @@ false
 
 function quo(G::FPGroup, elements::Vector{FPGroupElem})
   elems_in_gap = GapObj(elements; recursive=true)
-  Q = FPGroup((GapObj(G)/elems_in_gap)::GapObj)
+  Q = fp_group((GapObj(G)/elems_in_gap)::GapObj, free_group(G))
   Ggens = GAPWrap.GeneratorsOfGroup(GapObj(G))
   Qgens = GAPWrap.GeneratorsOfGroup(GapObj(Q))
   if length(Ggens) == 0

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -298,7 +298,7 @@ const SubPcGroupElem = BasicGAPGroupElem{SubPcGroup}
     FPGroup
 
 Finitely presented group.
-Such groups can be constructed a factors of free groups,
+Such groups can be constructed as factors of free groups,
 see [`free_group`](@ref).
 
 For a group `G` of type `FPGroup`, the elements in `gens(G)` satisfy the
@@ -309,6 +309,7 @@ Functions that compute subgroups of `G` return groups of type `SubFPGroup`.
 @attributes mutable struct FPGroup <: GAPGroup
   X::GapObj
   as_sub_fp_group::GAPGroup  # we cannot prescribe `SubFPGroup`
+  free_group::GAPGroup  # we cannot prescribe `FPGroup`
 
   function FPGroup(G::GapObj)
     # Accept only full f.p. groups.
@@ -325,6 +326,21 @@ function fp_group(G::GapObj)
 
   f = GAP.Globals.IsomorphismFpGroup(G)::GapObj
   return FPGroup(GAPWrap.Range(f))
+end
+
+function fp_group(G::GapObj, F::FPGroup)
+  # We want to store `F` as the `free_group` value of the result.
+  # For that, `G` must be a full f.p. group on the GAP side
+  # (otherwise prescribing a known free group on the Oscar side
+  # does not make sense)
+  # and `GapObj(F)` must be identical with the free group on the GAP side
+  # that is stored in `G`
+  gapF = GapObj(F)
+  @assert GAPWrap.IsFpGroup(G)
+  @assert gapF === GAPWrap.FreeGroupOfFpGroup(G)
+  FG = FPGroup(G)
+  FG.free_group = F
+  return FG
 end
 
 # Return `true` if the generators of `G` fit

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -192,7 +192,7 @@ end
 
 function as_sub_pc_group(G::PcGroup)
   if !isdefined(G, :as_sub_pc_group)
-    G.as_sub_pc_group = sub_pc_group(G)
+    G.as_sub_pc_group = sub_pc_group(GapObj(G), G, check = false)
   end
   return G.as_sub_pc_group::SubPcGroup
 end
@@ -245,6 +245,7 @@ return groups of type `SubPcGroup`.
 #T better create an embedding!
 
   function SubPcGroup(G::GapObj)
+    # Create the `PcGroup` on the Oscar side anew.
     @assert GAPWrap.IsPcGroup(G) || GAPWrap.IsPcpGroup(G)
     if GAPWrap.IsPcGroup(G)
       full = GAPWrap.GroupOfPcgs(GAPWrap.FamilyPcgs(G))
@@ -254,9 +255,20 @@ return groups of type `SubPcGroup`.
     z = new(G, PcGroup(full))
     return z
   end
+
+  function SubPcGroup(G::GapObj, F::PcGroup; check::Bool=true)
+    # Keep object identity of the available `PcGroup` on the Oscar side.
+    if check
+      @assert (GAPWrap.IsPcGroup(G) || GAPWrap.IsPcpGroup(G)) &&
+              GAPWrap.FamilyObj(G) === GAPWrap.FamilyObj(F.X)
+    end
+    z = new(G, F)
+    return z
+  end
 end
 
 sub_pc_group(G::GapObj) = SubPcGroup(G)
+sub_pc_group(G::GapObj, F::PcGroup; check::Bool=true) = SubPcGroup(G, F; check=check)
 
 
 """
@@ -321,7 +333,7 @@ _is_full_fp_group(G::GapObj) = GAPWrap.IsFpGroup(G)
 
 function as_sub_fp_group(G::FPGroup)
   if !isdefined(G, :as_sub_fp_group)
-    G.as_sub_fp_group = sub_fp_group(G)
+    G.as_sub_fp_group = sub_fp_group(GapObj(G), G, check = false)
   end
   return G.as_sub_fp_group::SubFPGroup
 end
@@ -358,14 +370,26 @@ subgroups of a finitely presented group.
 #T better create an embedding!
 
   function SubFPGroup(G::GapObj)
+    # Create the `FPGroup` on the Oscar side anew.
     @assert GAPWrap.IsSubgroupFpGroup(G)
     full = GAP.getbangproperty(GAPWrap.FamilyObj(G), :wholeGroup)::GapObj
     z = new(G, FPGroup(full))
     return z
   end
+
+  function SubFPGroup(G::GapObj, F::FPGroup; check::Bool=true)
+    # Keep object identity of the available `FPGroup` on the Oscar side.
+    if check
+      @assert GAPWrap.IsSubgroupFpGroup(G) &&
+              GAPWrap.FamilyObj(G) === GAPWrap.FamilyObj(F.X)
+    end
+    z = new(G, F)
+    return z
+  end
 end
 
 sub_fp_group(G::GapObj) = SubFPGroup(G)
+sub_fp_group(G::GapObj, F::FPGroup; check::Bool=true) = SubFPGroup(G, F; check=check)
 
 
 """
@@ -473,7 +497,7 @@ sub_type(G::GAPGroup) = sub_type(typeof(G))
 # default: ignore `G` and `check`
 function _oscar_subgroup(obj::GapObj, G::GAPGroup; check::Bool = true)
   S = sub_type(G)(obj)
-  @assert GAP.Globals.FamilyObj(GapObj(S)) === GAP.Globals.FamilyObj(GapObj(G))
+  @assert GAPWrap.FamilyObj(GapObj(S)) === GAPWrap.FamilyObj(GapObj(G))
   return S
 end
 
@@ -490,6 +514,16 @@ function _oscar_subgroup(obj::GapObj, G::MatGroup; check::Bool = true)
   d = GAPWrap.DimensionOfMatrixGroup(obj)
   @req G.deg == d "requested dimension of matrices ($(G.deg)) does not match the given matrix dimension ($d)"
   return matrix_group(_ring_iso(G), obj; check = check)
+end
+
+# `FPGroup`: keep the object identity of `G`
+function _oscar_subgroup(obj::GapObj, G::FPGroup; check::Bool = true)
+  return SubFPGroup(obj, G; check = check)
+end
+
+# `PcGroup`: keep the object identity of `G`
+function _oscar_subgroup(obj::GapObj, G::PcGroup; check::Bool = true)
+  return SubPcGroup(obj, G; check = check)
 end
 
 

--- a/test/Groups/constructors.jl
+++ b/test/Groups/constructors.jl
@@ -55,6 +55,24 @@
   @test !is_isomorphic_to_symmetric_group(alternating_group(4))
 end
 
+@testset "Object identity for stored full group of subgroups" begin
+  G = free_group(2)
+  U, _ = sub(G, [gen(G, 2)])
+  @test full_group(U)[1] === G
+  Ux = GapObj(U)
+  @test full_group(SubFPGroup(Ux))[1] !== G
+  @test full_group(SubFPGroup(Ux, G))[1] === G
+  @test_throws AssertionError SubFPGroup(Ux, free_group(2))
+
+  G = small_group(24, 12)
+  U, _ = sub(G, [gen(G, 2)])
+  @test full_group(U)[1] === G
+  Ux = GapObj(U)
+  @test full_group(SubPcGroup(Ux))[1] !== G
+  @test full_group(SubPcGroup(Ux, G))[1] === G
+  @test_throws AssertionError SubPcGroup(Ux, small_group(24, 12))
+end
+
 @testset "Special Constructors" begin
 
   @test isa(symmetric_group(5), PermGroup)

--- a/test/Groups/constructors.jl
+++ b/test/Groups/constructors.jl
@@ -73,6 +73,14 @@ end
   @test_throws AssertionError SubPcGroup(Ux, small_group(24, 12))
 end
 
+@testset "Object identity for stored free group of f.p. groups" begin
+  G = free_group(2)
+  x, y = gens(G)
+  rels = [x^2, y^2]
+  Q, epi = quo(G, rels)
+  @test free_group(Q) === G
+end
+
 @testset "Special Constructors" begin
 
   @test isa(symmetric_group(5), PermGroup)

--- a/test/Groups/quotients.jl
+++ b/test/Groups/quotients.jl
@@ -185,6 +185,11 @@ end
    @test G([1 => 2, 2 => -3]) == G[1]^2 * G[2]^-3
    @test_throws MethodError S([1 => 2])
 
+   # quotient of non-free FPGroup by list of relators
+   rels = [gen(G, 1)^2]
+   G2, f2 = quo(G, rels)
+   @test free_group(G2) === free_group(G)
+
    S = symmetric_group(4)
    G,f = quo(S, [cperm(S,[1,3,2])])
    @test order(G) == 2


### PR DESCRIPTION
When creating a subgroup of the type `SubFPGroup` or `SubPcGroup` by wrapping a given group object from GAP,
use an existing Oscar group as the full group if possible.

Logically, two `SubFPGroup`s or `SubPcGroup`s are compatible if the underlying full groups on the GAP side are identical objects, in this the change does not affect the relations between group objects.

Similarly, `free_group` now tries to use an existing Oscar group where possible.

Avoiding different Oscar group objects representing the same full GAP group will be useful for the forthcoming changed serialization format of `SubFPGroup` and `SubPcGroup` objects.