### PR TITLE
booktest: disable tab-complete hints on recent nightly

### DIFF
--- a/test/book/test.jl
+++ b/test/book/test.jl
@@ -155,6 +155,9 @@ isdefined(Main, :FakeTerminals) || include(joinpath(pkgdir(REPL),"test","FakeTer
       @static if VERSION > v"1.13.0-DEV.1328"
         # disable automatic bracket on recent nightly
         options.auto_insert_closing_bracket = false
+        @static if VERSION > v"1.14.0-DEV.2080"
+          options.hint_tab_completes = false
+        end
       end
       repl = REPL.LineEditREPL(FakeTerminals.FakeTerminal(input.out, out_stream, err.in, options.hascolor), options.hascolor, false)
       repl.options = options


### PR DESCRIPTION
Should work around recent booktest hangs with nightly (see #6013).
These are not needed anyway.

_Edit:_ I ran the nightly booktests twice on this PR, both runs succeeded, so this seems to work.