### PR TITLE
Export `underlying_scheme`

### DIFF
--- a/src/AlgebraicGeometry/ToricVarieties/ToricSchemes/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricSchemes/attributes.jl
@@ -106,7 +106,7 @@ Polyhedral cone in ambient dimension 2
 julia> antv = affine_normal_toric_variety(C)
 Normal toric variety
 
-julia> Oscar.underlying_scheme(antv)
+julia> underlying_scheme(antv)
 Spectrum
   of quotient
     of multivariate polynomial ring in 2 variables x1, x2
@@ -229,7 +229,7 @@ its toric origin.
 julia> P2 = projective_space(NormalToricVariety, 2)
 Normal toric variety
 
-julia> Oscar.underlying_scheme(P2)
+julia> underlying_scheme(P2)
 Scheme
   over rational field
 with default covering

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1848,6 +1848,7 @@ export underlying_gluing
 export underlying_module
 export underlying_presheaf
 export underlying_quotient
+export underlying_scheme
 export underlying_word
 export undirected_component
 export uniform_matroid

--- a/test/AlgebraicGeometry/Schemes/CoveredScheme.jl
+++ b/test/AlgebraicGeometry/Schemes/CoveredScheme.jl
@@ -103,7 +103,7 @@
         return new{Oscar.base_ring_type(C)}(C)
       end
     end
-    underlying_scheme(D::DummyCoveredScheme) = D.C
+    Oscar.underlying_scheme(D::DummyCoveredScheme) = D.C
 
     D = DummyCoveredScheme(Ccov)
     @test coverings(D) == coverings(Ccov)

--- a/test/AlgebraicGeometry/Schemes/CoveredScheme.jl
+++ b/test/AlgebraicGeometry/Schemes/CoveredScheme.jl
@@ -103,7 +103,7 @@
         return new{Oscar.base_ring_type(C)}(C)
       end
     end
-    Oscar.underlying_scheme(D::DummyCoveredScheme) = D.C
+    underlying_scheme(D::DummyCoveredScheme) = D.C
 
     D = DummyCoveredScheme(Ccov)
     @test coverings(D) == coverings(Ccov)

--- a/test/AlgebraicGeometry/ToricVarieties/toric_schemes.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/toric_schemes.jl
@@ -3,8 +3,8 @@
   antv = affine_normal_toric_variety(C)
 
   @testset "A simplicial (and not smooth) affine toric scheme" begin
-    @test is_smooth(Oscar.underlying_scheme(antv)) == is_smooth(antv)
-    @test dim(Oscar.underlying_scheme(antv)) == dim(antv)
+    @test is_smooth(underlying_scheme(antv)) == is_smooth(antv)
+    @test dim(underlying_scheme(antv)) == dim(antv)
     @test polarize(cone(antv)) == weight_cone(antv)
     @test ngens(ambient_coordinate_ring(antv)) == nrows(hilbert_basis(antv)) == 3
   end
@@ -12,8 +12,8 @@
   X = hirzebruch_surface(NormalToricVariety, 3)
 
   @testset "Toric Scheme of Hirzebruch surface F3" begin
-    @test is_smooth(Oscar.underlying_scheme(X)) == is_smooth(X)
-    @test dim(Oscar.underlying_scheme(X)) == dim(X)
+    @test is_smooth(underlying_scheme(X)) == is_smooth(X)
+    @test dim(underlying_scheme(X)) == dim(X)
   end
 
   IP1 = projective_space(NormalToricVariety, 1)
@@ -21,7 +21,7 @@
   Y = IP1 * IP1
 
   @testset "Product of projective spaces" begin
-    @test is_smooth(Oscar.underlying_scheme(Y)) == is_smooth(Y)
+    @test is_smooth(underlying_scheme(Y)) == is_smooth(Y)
     @test length(values(gluings(default_covering(Y)))) == 16
   end
 
@@ -102,7 +102,7 @@ end
   )
   number_of_maximal_cones(f)
   ntv = normal_toric_variety(f)
-  X = Oscar.underlying_scheme(ntv)
+  X = underlying_scheme(ntv)
   for g in values(gluings(default_covering(X)))
     @test !(g isa Oscar.LazyGluing) || !isdefined(g, :G)
   end


### PR DESCRIPTION
While writing a docstring for #6003 I noticed that the well documented function `underlying_scheme`, see e.g. [here](https://docs.oscar-system.org/stable/AlgebraicGeometry/AlgebraicSets/AffineAlgebraicSet/#Relation-to-Schemes), is not exported.
```
julia> using Oscar
  ___   ___   ___    _    ____
 / _ \ / __\ / __\  / \  |  _ \  | Combining and extending ANTIC, GAP,
| |_| |\__ \| |__  / ^ \ |  ´ /  | Polymake and Singular
 \___/ \___/ \___//_/ \_\|_|\_\  | Type "?Oscar" for more information
o--------o-----o-----o--------o  | Documentation: https://docs.oscar-system.org
  S Y M B O L I C   T O O L S    | 1.8.0-DEV #master b4208f8 2026-05-21

help?> underlying_scheme
search: underlying_space_of_modules underlying_presheaf

Couldn't find underlying_scheme
Perhaps you meant underlying_module
  No documentation found.

  Binding underlying_scheme does not exist.
```
Ping @afkafkafk13 @HechtiDerLachs @simonbrandhorst