### PR TITLE
fix and unify test stats filenames

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -180,7 +180,7 @@ jobs:
         uses: actions/upload-artifact@v6
         continue-on-error: true
         with:
-          name: stats-book-${{ join(matrix.os) }}-${{ matrix.julia-version }}
+          name: stats-book-${{ runner.os }}-${{ matrix.julia-version }}
           path: |
             test-stats_*.csv
       - name: "Process code coverage"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -127,7 +127,7 @@ jobs:
         with:
           name: stats-${{ matrix.group }}-${{ join(matrix.os) }}-${{ matrix.julia-version }}
           path: |
-            test-stats-*.csv
+            test-stats_*.csv
       - name: "Process code coverage"
         if: matrix.julia-version == '1.10' && matrix.depwarn != 'depwarn=error'
         uses: julia-actions/julia-processcoverage@v1
@@ -182,7 +182,7 @@ jobs:
         with:
           name: stats-book-${{ join(matrix.os) }}-${{ matrix.julia-version }}
           path: |
-            test-stats-*.csv
+            test-stats_*.csv
       - name: "Process code coverage"
         if: matrix.julia-version == '1.10'
         uses: julia-actions/julia-processcoverage@v1
@@ -289,7 +289,7 @@ jobs:
         with:
           name: stats-doctest-${{ join(matrix.os) }}-${{ matrix.julia-version }}
           path: |
-            test-stats-*.csv
+            test-stats_*.csv
       - name: "Process code coverage"
         if: matrix.julia-version == '1.10' && matrix.depwarn != 'depwarn=error'
         uses: julia-actions/julia-processcoverage@v1

--- a/docs/documenter_helpers.jl
+++ b/docs/documenter_helpers.jl
@@ -2,8 +2,14 @@ import DelimitedFiles
 
 const docstats = Dict{String,NamedTuple}()
 if haskey(ENV, "GITHUB_ACTION") || haskey(ENV, "OSCAR_TEST_STATS")
+  timestamp = readchomp(`git show --no-patch --pretty=format:"%ad" --date=format:"%Y-%m-%dT%H-%M-%S"`)
+  platform = Sys.islinux() ? "linux" : "macos"
+  juliaVersion = join(split("$VERSION", ".")[1:2], ".")
+  commitHash = readchomp(`git rev-parse --verify --short HEAD`)
+  statsFileName = "test-stats_$(timestamp)_$(platform)_$(juliaVersion)_doctests_$(commitHash).csv"
+
   Base.atexit() do
-    open("test-stats-doctests.csv", "a") do io
+    open(statsFileName, "a") do io
       @static if VERSION > v"1.11.0"
         println(io, "path,time,ctime,rctime,gctime,alloc")
         DelimitedFiles.writedlm(io, ((k, v.time, v.ctime, v.rctime, v.gctime, v.alloc) for (k,v) in docstats), ",")

--- a/etc/testing-csv-to-json.jl
+++ b/etc/testing-csv-to-json.jl
@@ -15,12 +15,10 @@ if isempty(indict)
 end
 
 for file in filelist
-    parts = split(file[1:end-4], "-")
-    timestamp = join(parts[3:5], "-")
-    platform = parts[6]
-    juliaVersion = parts[7]
-    subset = parts[8]    
-    commitHash = parts[9]
+    (timestr, platform, juliaVersion, subset, commitHash) = split(file[1:end-4], "_")[2:end]
+    # filenames on github must not contain colons so we convert to the correct timestamp format here
+    timestamp = Dates.format(DateTime(timestr, dateformat"yyyy-mm-ddTHH-MM-SSZ"),
+                             dateformat"yyyy-mm-ddTHH:MM:SS")
     commitAuthor = readchomp(`git show --no-patch --pretty=format:'%aN' $commitHash`)
     commitMessage = readchomp(`git show --no-patch --pretty=format:'%s' $commitHash`)
     if subset == "default"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -204,11 +204,11 @@ else
   print_stats(stdout, stats; max=10)
 end
 if haskey(ENV, "GITHUB_ACTIONS") || haskey(ENV, "OSCAR_TEST_STATS")
-  timestamp = readchomp(`git show --no-patch --pretty=format:"%ad" --date=format:"%Y-%m-%dT%H:%M:%S"`)
+  timestamp = readchomp(`git show --no-patch --pretty=format:"%ad" --date=format:"%Y-%m-%dT%H-%M-%S"`)
   platform = Sys.islinux() ? "linux" : "macos"
   juliaVersion = join(split("$VERSION", ".")[1:2], ".")
   commitHash = readchomp(`git rev-parse --verify --short HEAD`)
-  statsFileName = "test-stats-$(timestamp)-$(platform)-$(juliaVersion)-$(test_subset)-$(commitHash).csv"
+  statsFileName = "test-stats_$(timestamp)_$(platform)_$(juliaVersion)_$(test_subset)_$(commitHash).csv"
   open(joinpath(pkgdir(Oscar), statsFileName), "a") do io
     println(io, "path,time,ctime,rctime,gctime,alloc")
     DelimitedFiles.writedlm(io, ((k, v.time, v.ctime, v.rctime, v.gctime, v.alloc) for (k,v) in stats), ",")


### PR DESCRIPTION
Currently github refuses to archive the files since they contain a colon `:`.
Adjust doctests csv to use the same pattern.
Use underscore for splitting to simplify extracting metadata.
The parser then converts the timestamp back to the correct format.

```
The path for one of the files in artifact is not valid: /test-stats-2026-05-22T16:30:44-linux-1.13-short-0da2792aa.csv. Contains the following character:  Colon :
          
Invalid characters include:  Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?, Carriage return \r, Line feed \n
          
The following characters are not allowed in files that are uploaded due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.
```