### PR TITLE
refactor(serialization): add load_json helper, replace JSON.parse calls

### DIFF
--- a/experimental/AlgebraicStatistics/src/serialization.jl
+++ b/experimental/AlgebraicStatistics/src/serialization.jl
@@ -1,5 +1,5 @@
 import Oscar.Serialization: save_object, load_object,
-  type_params, _convert_override_params, params, load_type_params, decode_type
+  type_params, _convert_override_params, params, load_type_params, decode_type, is_string
 
 function _convert_override_params(tp::TypeParams{<:GraphicalModel, <:Tuple{Vararg{Pair}}})
   param_dict = Dict()

--- a/src/Serialization/Combinatorics.jl
+++ b/src/Serialization/Combinatorics.jl
@@ -101,7 +101,7 @@ end
 
 function load_object(s::DeserializerState, T::Type{<:PhylogeneticTree}, params::AbstractAlgebra.Floats{Float64})
   inner_object = load_node(s, :pm_tree) do _
-    load_from_polymake(Polymake.BigObject, JSON.parse(s.obj, Dict{String, Any}))
+    load_from_polymake(Polymake.BigObject, load_json(s, Dict{String, Any}))
   end
   vertex_perm = load_object(s, Vector{Int}, :vertex_perm)
   PhylogeneticTree{Float64}(inner_object, vertex_perm)

--- a/src/Serialization/PolyhedralGeometry.jl
+++ b/src/Serialization/PolyhedralGeometry.jl
@@ -80,7 +80,7 @@ end
 
 function load_object(s::DeserializerState, T::Type{<:PolyhedralObject}, dict::Dict)
   field = dict[:field]
-  polymake_dict = load_object(s, Dict{String, Any}, dict[:pm_params])
+  polymake_dict = load_object(s, Dict{Symbol, Any}, dict[:pm_params])
   bigobject = _dict_to_bigobject(polymake_dict)
 
   return T{elem_type(field)}(bigobject, field)
@@ -89,7 +89,7 @@ end
 function load_object(s::DeserializerState, T::Type{<:PolyhedralObject{S}},
                      dict::Dict) where S <: FieldElem
   field = dict[:field]
-  polymake_dict = load_object(s, Dict{String, Any}, dict[:pm_params])
+  polymake_dict = load_object(s, Dict{Symbol, Any}, dict[:pm_params])
   bigobject = _dict_to_bigobject(polymake_dict)
 
   return T(bigobject, field)

--- a/src/Serialization/PolyhedralGeometry.jl
+++ b/src/Serialization/PolyhedralGeometry.jl
@@ -16,12 +16,12 @@ function save_object(s::SerializerState, p::Polymake.BigObject)
 end
 
 function load_object(s::DeserializerState, ::Type{Polymake.BigObjectAllocated})
-  dict = JSON.parse(s.obj, Dict{String, Any})
+  dict = load_json(s, Dict{String, Any})
   return load_from_polymake(dict)
 end
 
 function load_object(s::DeserializerState, ::Type{Polymake.BigObject})
-  dict = JSON.parse(s.obj, Dict{String, Any})
+  dict = load_json(s, Dict{String, Any})
   bigobject = Polymake.call_function(:common, :deserialize_json_string, JSON.json(dict))
   return bigobject
 end
@@ -70,12 +70,12 @@ end
 
 function load_object(s::DeserializerState, T::Type{<:PolyhedralObject},
                      field::U) where {U <: Union{QQField, AbstractAlgebra.Floats}}
-  return load_from_polymake(T{elem_type(field)}, JSON.parse(s.obj, Dict{String, Any}))
+  return load_from_polymake(T{elem_type(field)}, load_json(s, Dict{String, Any}))
 end
 
 function load_object(s::DeserializerState, T::Type{<:PolyhedralObject{S}},
     field::U) where {S <: Union{QQFieldElem, Float64}, U <: Union{QQField, AbstractAlgebra.Floats}}
-  return load_from_polymake(T, JSON.parse(s.obj, Dict{String, Any}))
+  return load_from_polymake(T, load_json(s, Dict{String, Any}))
 end
 
 function load_object(s::DeserializerState, T::Type{<:PolyhedralObject}, dict::Dict)

--- a/src/Serialization/basic_types.jl
+++ b/src/Serialization/basic_types.jl
@@ -22,7 +22,7 @@ end
 
 function load_object(s::DeserializerState, ::Type{Bool})
   load_node(s) do _
-    return s.obj[]::Bool
+    return JSON.parse(s.obj, Bool)
   end
 end
 

--- a/src/Serialization/basic_types.jl
+++ b/src/Serialization/basic_types.jl
@@ -78,7 +78,7 @@ end
 
 function load_object(s::DeserializerState, ::Type{T}) where {T<:Number}
   load_node(s) do _
-    parse(T, s.obj[])
+    JSON.parse(s.obj, T)
   end
 end
 
@@ -89,7 +89,7 @@ end
 @register_serialization_type String
 
 function load_object(s::DeserializerState, ::Type{String})
-  return s.obj[]
+  return JSON.parse(s.obj, String)
 end
 
 ################################################################################
@@ -98,7 +98,7 @@ end
 
 function load_object(s::DeserializerState, ::Type{Symbol})
   load_node(s) do _
-    Symbol(s.obj[])
+    Symbol(JSON.parse(s.obj, String))
   end
 end
 

--- a/src/Serialization/basic_types.jl
+++ b/src/Serialization/basic_types.jl
@@ -22,7 +22,7 @@ end
 
 function load_object(s::DeserializerState, ::Type{Bool})
   load_node(s) do _
-    return JSON.parse(s.obj, Bool)
+    return load_json(s, Bool)
   end
 end
 
@@ -35,7 +35,7 @@ load_object(s::DeserializerState, T::Type{ZZRingElem}, ::ZZRing) = load_object(s
 
 function load_object(s::DeserializerState, ::Type{ZZRingElem})
   load_node(s) do _
-    return ZZRingElem(JSON.parse(s.obj, String))
+    return ZZRingElem(load_json(s, String))
   end
 end
 
@@ -49,7 +49,7 @@ function load_object(s::DeserializerState, ::Type{QQFieldElem})
   # TODO: simplify the code below once https://github.com/Nemocas/Nemo.jl/pull/1375
   # is merged and in a Nemo release
   load_node(s) do _
-    fraction_parts = String.(split(JSON.parse(s.obj, String), "//"))
+    fraction_parts = String.(split(load_json(s, String), "//"))
     fraction_parts = parse.(ZZRingElem, fraction_parts)
 
     return QQFieldElem(fraction_parts...)
@@ -78,7 +78,7 @@ end
 
 function load_object(s::DeserializerState, ::Type{T}) where {T<:Number}
   load_node(s) do _
-    JSON.parse(s.obj, T)
+    load_json(s, T)
   end
 end
 
@@ -89,7 +89,7 @@ end
 @register_serialization_type String
 
 function load_object(s::DeserializerState, ::Type{String})
-  return JSON.parse(s.obj, String)
+  return load_json(s, String)
 end
 
 ################################################################################
@@ -98,7 +98,7 @@ end
 
 function load_object(s::DeserializerState, ::Type{Symbol})
   load_node(s) do _
-    Symbol(JSON.parse(s.obj, String))
+    Symbol(load_json(s, String))
   end
 end
 

--- a/src/Serialization/basic_types.jl
+++ b/src/Serialization/basic_types.jl
@@ -35,7 +35,7 @@ load_object(s::DeserializerState, T::Type{ZZRingElem}, ::ZZRing) = load_object(s
 
 function load_object(s::DeserializerState, ::Type{ZZRingElem})
   load_node(s) do _
-    return ZZRingElem(s.obj[])
+    return ZZRingElem(JSON.parse(s.obj, String))
   end
 end
 
@@ -49,7 +49,7 @@ function load_object(s::DeserializerState, ::Type{QQFieldElem})
   # TODO: simplify the code below once https://github.com/Nemocas/Nemo.jl/pull/1375
   # is merged and in a Nemo release
   load_node(s) do _
-    fraction_parts = String.(split(s.obj[], "//"))
+    fraction_parts = String.(split(JSON.parse(s.obj, String), "//"))
     fraction_parts = parse.(ZZRingElem, fraction_parts)
 
     return QQFieldElem(fraction_parts...)

--- a/src/Serialization/containers.jl
+++ b/src/Serialization/containers.jl
@@ -410,7 +410,7 @@ function load_type_params(s::DeserializerState, T::Type{Dict})
       end
       params_dict = Dict{S, Any}()
       value_types = Type[]
-      for (k, _) in obj
+      for k in propertynames(s.obj)
         k == "key_params" && continue
         key = S <: Integer ? parse(Int, string(k)) : S(k)
         params_dict[key] = load_node(s, Symbol(k)) do _

--- a/src/Serialization/containers.jl
+++ b/src/Serialization/containers.jl
@@ -411,7 +411,7 @@ function load_type_params(s::DeserializerState, T::Type{Dict})
       params_dict = Dict{S, Any}()
       value_types = Type[]
       for k in propertynames(s.obj)
-        k == "key_params" && continue
+        k == :key_params && continue
         key = S <: Integer ? parse(Int, string(k)) : S(k)
         params_dict[key] = load_node(s, Symbol(k)) do _
           return load_type_params(s, decode_type(s))

--- a/src/Serialization/containers.jl
+++ b/src/Serialization/containers.jl
@@ -158,7 +158,7 @@ function load_object(s::DeserializerState, T::Type{<:Matrix{S}}) where {S}
     if isempty(s)
       return T(undef, 0, 0)
     end
-    len = length(entries)
+    len = length(s.obj)
     m = stack([
       load_object(s, Vector{S}, i) for i in 1:len
         ]; dims=1)
@@ -173,7 +173,7 @@ function load_object(s::DeserializerState, T::Type{<:Matrix{S}}, params) where {
     if isempty(s)
       return T(undef, 0, 0)
     end
-    len = length(entries)
+    len = length(s.obj)
     m = stack([
       load_object(s, Vector{S}, params, i) for i in 1:len
         ]; dims=1)
@@ -200,11 +200,11 @@ function save_object(s::SerializerState, arr::AbstractArray{T, N}) where {T, N}
 end
 
 function load_object(s::DeserializerState, T::Type{Array{S, N}}) where {S, N}
-  load_node(s) do entries
-    if isempty(entries)
+  load_node(s) do _
+    if isempty(s)
       return T(undef, [0 for _ in 1:N]...)
     end
-    len = length(entries)
+    len = length(s.obj)
     m = [load_object(s, Array{S, N - 1}, i) for i in 1:len]
     return stack(m; dims=1)
   end
@@ -213,11 +213,11 @@ end
 load_object(s::DeserializerState, T::Type{Array{S, N}}, ::Nothing) where {S, N} = load_object(s, T)
 
 function load_object(s::DeserializerState, T::Type{Array{S, N}}, params::U) where {S, N, U}
-  load_node(s) do entries
-    if isempty(entries)
+  load_node(s) do _
+    if isempty(s)
       return T(undef, [0 for _ in 1:N]...)
     end
-    len = length(entries)
+    len = length(s.obj)
     m = [load_object(s, Array{S, N - 1}, params, i) for i in 1:len]
     return stack(m; dims=1)
   end

--- a/src/Serialization/containers.jl
+++ b/src/Serialization/containers.jl
@@ -154,8 +154,8 @@ end
 # this needs to be Matrix to avoid ambiguities, this is also ok
 # since types on load will be Matrix
 function load_object(s::DeserializerState, T::Type{<:Matrix{S}}) where {S}
-  load_node(s) do entries
-    if iszero(length(entries))
+  load_node(s) do _
+    if isempty(s)
       return T(undef, 0, 0)
     end
     len = length(entries)
@@ -169,8 +169,8 @@ end
 load_object(s::DeserializerState, T::Type{<:Matrix{S}}, ::Nothing) where {S} = load_object(s, T)
 
 function load_object(s::DeserializerState, T::Type{<:Matrix{S}}, params) where {S}
-  load_node(s) do entries
-    if isempty(entries)
+  load_node(s) do _
+    if isempty(s)
       return T(undef, 0, 0)
     end
     len = length(entries)

--- a/src/Serialization/containers.jl
+++ b/src/Serialization/containers.jl
@@ -540,9 +540,11 @@ function load_object(s::DeserializerState,
     value_types = Type[]
     for k in propertynames(s.obj)
       key = S <: Integer ? parse(S, string(k)) : S(k)
-      value_type, param = params[key]
+      # params may have been built with Symbol keys (from old files) even when S is String
+      param_key = haskey(params, key) ? key : Symbol(k)
+      value_type, param = params[param_key]
       v = load_object(s, value_type, param, k)
-      dict[key] = load_object(s, value_type, param, k)
+      dict[key] = v
       push!(value_types, typeof(v))
     end
     isempty(value_types) && return T()

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -136,7 +136,7 @@ end
 
 function decode_type(s::DeserializerState)
   if is_string(s)
-    obj = s.obj[]
+    obj = load_json(s, String)
     uuid = tryparse(UUID, obj)
     if !isnothing(uuid)
       if isnothing(s.refs)
@@ -160,8 +160,8 @@ function decode_type(s::DeserializerState)
 
   if haskey(s, :name)
     if haskey(s, :_instance)
-      name = load_node(s, :name) do _; s.obj[]; end
-      instance = load_node(s, :_instance) do _; s.obj[]; end
+      name = load_node(s, :name) do _; load_json(s, String); end
+      instance = load_node(s, :_instance) do _; load_json(s, String); end
       return get(reverse_type_map[name], instance) do
         error("unsupported instance '$instance' for decoding")
       end
@@ -375,7 +375,7 @@ function load_type_array_params(s::DeserializerState)
   load_array_node(s) do obj
     T = decode_type(s)
     if is_string(s)
-      !isnothing(tryparse(UUID, s.obj[])) && return load_ref(s)
+      !isnothing(tryparse(UUID, load_json(s, String))) && return load_ref(s)
       return T
     end
     return load_type_params(s, T)[2]
@@ -384,7 +384,7 @@ end
 
 function load_type_params(s::DeserializerState, T::Type)
   if is_string(s)
-    val = s.obj[]
+    val = load_json(s, String)
     !isnothing(tryparse(UUID, val)) && return T, load_ref(s)
     return T, nothing
   end
@@ -409,7 +409,7 @@ function load_type_params(s::DeserializerState, T::Type)
             end
 
             U = decode_type(s)
-            if is_string(s) && isnothing(tryparse(UUID, s.obj[]))
+            if is_string(s) && isnothing(tryparse(UUID, load_json(s, String)))
               return U
             end
             return load_type_params(s, U)[2]
@@ -443,7 +443,7 @@ function load_typed_object(s::DeserializerState; override_params::Any = nothing)
     T, _ = load_type_params(s, T, type_key)
     params = override_params
   else
-    is_string(s) && !isnothing(tryparse(UUID, s.obj[])) && return load_ref(s)
+    is_string(s) && !isnothing(tryparse(UUID, load_json(s, String))) && return load_ref(s)
     T, params = load_type_params(s, T, type_key)
   end
   Base.issingletontype(T) && return T()
@@ -856,7 +856,7 @@ function load(io::IO; params::Any = nothing, type::Any = nothing,
 
     if haskey(s, :id)
       load_node(s, :id) do _
-        id = s.obj[]
+        id = load_json(s, String)
         global_serializer_state.obj_to_id[loaded] = UUID(id)
         global_serializer_state.id_to_obj[UUID(id)] = loaded
       end

--- a/src/Serialization/polymake.jl
+++ b/src/Serialization/polymake.jl
@@ -155,16 +155,16 @@ function _load_bigobject_from_dict!(obj::Polymake.BigObject, dict::Dict, parent_
     end
   end
   for (k, v) in delay_loading
-    Polymake.take(obj, k, v)
+    Polymake.take(obj, Symbol(k), v)
   end
-  if haskey(dict, "_description")
-    Polymake.setdescription!(obj, dict["_description"])
+  if haskey(dict, :_description)
+    Polymake.setdescription!(obj, dict[:_description])
   end
   return obj
 end
 
-function _dict_to_bigobject(dict::Dict{String, Any})
-  obj = Polymake.BigObject(Polymake.BigObjectType(dict["_polymake_type"]))
+function _dict_to_bigobject(dict::Dict{Symbol, Any})
+  obj = Polymake.BigObject(Polymake.BigObjectType(dict[:_polymake_type]))
   _load_bigobject_from_dict!(obj, dict)
   return obj
 end

--- a/src/Serialization/serializers.jl
+++ b/src/Serialization/serializers.jl
@@ -190,10 +190,14 @@ mutable struct DeserializerState{T <: OscarSerializer}
   with_attrs::Bool
 end
 
+function load_json(s::DeserializerState, ::Type{T}) where T
+  return JSON.parse(s.obj, T)
+end
+
 # general loading of a reference
 
 function load_ref(s::DeserializerState)
-  id = s.obj[]
+  id = load_json(s, String)
   if haskey(global_serializer_state.id_to_obj, UUID(id))
     loaded_ref = global_serializer_state.id_to_obj[UUID(id)]
   else
@@ -223,7 +227,7 @@ end
 
 function load_node(f::Function, s::DeserializerState,
                    key::Union{Symbol, Int, Nothing} = nothing)
-  if is_string(s) && !isnothing(tryparse(UUID, s.obj[]))
+  if is_string(s) && !isnothing(tryparse(UUID, load_json(s, String)))
     return load_ref(s)
   end
 

--- a/src/Serialization/serializers.jl
+++ b/src/Serialization/serializers.jl
@@ -244,8 +244,8 @@ end
 
 function load_array_node(f::Function, s::DeserializerState,
                          key::Union{Symbol, Int, Nothing} = nothing)
-  load_node(s, key) do array
-    n = length(array)
+  load_node(s, key) do _
+    n = length(s.obj)
     [load_node(x -> f((i, x)), s, i) for i in 1:n]
   end
 end

--- a/src/Serialization/serializers.jl
+++ b/src/Serialization/serializers.jl
@@ -267,15 +267,12 @@ function deserializer_open(io::IO, serializer::OscarSerializer, with_attrs::Bool
   return DeserializerState(serializer, obj, nothing, refs, with_attrs)
 end
 
-function deserializer_open(io::IO, serializer::IPCSerializer, with_attrs::Bool) 
-  # Using a JSON3.Object from JSON3 version 1.13.2 causes
-  # put_type_params to hang
-  #obj = JSON3.read(io)
+function deserializer_open(io::IO, serializer::IPCSerializer, with_attrs::Bool)
   str = readuntil(io, '}'; keep=true)
   while !JSON.isvalidjson(str)
     str *= readuntil(io, '}'; keep=true)
   end
-  obj = JSON.parse(str; dicttype=Dict{Symbol, Any}) # TODO: investigate if JSON.Object is fine here
+  obj = JSON.lazy(str)
 
   return DeserializerState(serializer, obj, nothing, nothing, with_attrs)
 end


### PR DESCRIPTION
## Summary

- Add `load_json` helper to replace scattered `JSON.parse(s.obj, T)` calls
- Replace `s.obj[]` with `load_json` across Fields, Tropical, PolyhedralGeometry, GAP, basic_types
- Parse instead of materialize for Bool, Number, String, Symbol types
- Fix Symbol/String key mismatch in Dict params lookup
- Fix polymake-oscar file loading

Part 2 of stacked serialization refactor. Previous: `adv/serialization-laziness`. Next: `adv/serialization-typeparams-rename`.

## Test plan

- [ ] `julia --project=. -e 'using Oscar; include("test/Serialization/runtests.jl")'`
- [ ] Test polymake-oscar file loading if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)