### PR TITLE
allow disabling shuffling of tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,7 +92,11 @@ end
 
 # make sure we have the same list everywhere
 sort!(testlist)
-Random.shuffle!(Oscar.get_seeded_rng(), testlist)
+
+# allow disabling shuffle for speed tests
+if get(ENV, "OSCAR_TEST_SORTED", nothing) !== "true"
+  Random.shuffle!(Oscar.get_seeded_rng(), testlist)
+end
 
 # tests with the highest number of allocations / total time / compilation time
 # more or less sorted by allocations are in `long`


### PR DESCRIPTION
Should make timings more stable (since compilation time can vary a lot depending on the order) if `ENV["OSCAR_TEST_SORTED"] == "true"`. To be used on the dedicated runner at RPTU.

cc: @aaruni96 
x-ref: #697 