### PR TITLE
Rename `type_params` to `type_and_params`

### DIFF
--- a/docs/src/DeveloperDocumentation/serialization.md
+++ b/docs/src/DeveloperDocumentation/serialization.md
@@ -115,7 +115,7 @@ evaluation.
 There are three pairs of saving and loading functions that are used
 during serialization:
 1. `save_typed_object`, `load_typed_object`
-2. `save_type_params`, `load_type_params`
+2. `save_type_and_params`, `load_type_and_params`
 3. `save_object`, `load_object`
 
 
@@ -127,7 +127,7 @@ type information as well as its data. The data and type nodes are
 set in `save_typed_object` resulting in a "data branch" and "type branch".
 
 
-#### `save_type_params` / `load_type_params`
+#### `save_type_and_params` / `load_type_and_params`
 
 The serialization mechanism stores data in the format of a tree, with the
 exception that some nodes may point to a shared reference. The "data branch"

--- a/docs/src/DeveloperDocumentation/serialization.md
+++ b/docs/src/DeveloperDocumentation/serialization.md
@@ -135,11 +135,11 @@ is anything that is a child node of a data node, whereas the "type branch" is
 any information that is stored in a node that is a child of a type node.
 
 These functions should also not be touched, however they expect an implementation
-of `type_params` whenever saving a type `T`. By default `type_params` will return
-`nothing`. The `type_params` function does a shallow pass through an `obj` of type
+of `type_and_params` whenever saving a type `T`. By default `type_and_params` will return
+`nothing`. The `type_and_params` function does a shallow pass through an `obj` of type
 `T` gathering the necessary parameters for serializing `obj`.
 In most cases these parameters are the parameters of the `obj` that uses references.
-For example if `obj` is of type `RingElem` than it is expected that `type_params`
+For example if `obj` is of type `RingElem` than it is expected that `type_and_params`
 should contain at least `parent(obj)`.
 
 #### `save_object` / `load_object`

--- a/experimental/AlgebraicShifting/src/PartialShiftGraph.jl
+++ b/experimental/AlgebraicShifting/src/PartialShiftGraph.jl
@@ -222,7 +222,7 @@ function partial_shift_graph(F::Field, complexes::Vector{T},
     # this should be updated to use the parallel framework at some point?
     channels = [RemoteChannel(()->Channel{Any}(32), i) for i in workers()]
     # setup parents needed to be sent to each process
-    map(channel -> put_type_params(channel, codomain(phi)), channels)
+    map(channel -> put_type_and_params(channel, codomain(phi)), channels)
     map_function = pmap
   end
   try

--- a/experimental/AlgebraicStatistics/src/serialization.jl
+++ b/experimental/AlgebraicStatistics/src/serialization.jl
@@ -1,7 +1,7 @@
 import Oscar.Serialization: save_object, load_object,
   type_params, _convert_override_params, params, load_type_params, decode_type
 
-function _convert_override_params(tp::TypeParams{<:GraphicalModel, <:Tuple{Vararg{Pair}}})
+function _convert_override_params(tp::TypeAndParams{<:GraphicalModel, <:Tuple{Vararg{Pair}}})
   param_dict = Dict()
   for p in Oscar.Serialization.params(tp)
     if p.first == :graph_type 
@@ -13,7 +13,7 @@ function _convert_override_params(tp::TypeParams{<:GraphicalModel, <:Tuple{Varar
   return param_dict
 end
 
-function _convert_override_params(tp::TypeParams{T, <:Tuple{Vararg{Pair}}}) where T <: Union{GroupBasedPhylogeneticModel, PhylogeneticModel}
+function _convert_override_params(tp::TypeAndParams{T, <:Tuple{Vararg{Pair}}}) where T <: Union{GroupBasedPhylogeneticModel, PhylogeneticModel}
   param_dict = Dict()
   type_keys = [:transition_matrix_entry_type, :graph_type,
                :model_parameter_name_type, :root_distribution_entry_type]
@@ -35,7 +35,7 @@ end
 
 function type_params(obj::T) where T <: Union{GraphDict, GraphTransDict}
   if isempty(obj)
-    return TypeParams(
+    return TypeAndParams(
       T,
       nothing
     )
@@ -44,13 +44,13 @@ function type_params(obj::T) where T <: Union{GraphDict, GraphTransDict}
   value_params = type_params.(collect(values(obj)))
   @req allequal(value_params) "Not all params of values in $obj are the same"
   
-  return TypeParams(
+  return TypeAndParams(
     T,
     first(value_params)
   )
 end
 
-type_params(D::GenDict) = TypeParams(GenDict, params(type_params(D.d)))
+type_params(D::GenDict) = TypeAndParams(GenDict, params(type_params(D.d)))
 
 function save_object(s::SerializerState, e::Edge)
   save_data_array(s) do
@@ -137,8 +137,8 @@ end
 
 function type_params(GM::S) where {T, L, S <: GraphicalModel{T, L}}
   # this should only be the graph type not the whole graph
-  # need to make adjustments to TypeParams functionality
-  TypeParams(S, :graph_type => TypeParams(typeof(graph(GM)), nothing))
+  # need to make adjustments to TypeAndParams functionality
+  TypeAndParams(S, :graph_type => TypeAndParams(typeof(graph(GM)), nothing))
 end
 
 function save_object(s::SerializerState, M::GraphicalModel)
@@ -169,16 +169,16 @@ end
                                                         :model_ring,
                                                         :full_model_ring]
 
-type_params(pm::PhylogeneticModel) = TypeParams(
+type_params(pm::PhylogeneticModel) = TypeAndParams(
   PhylogeneticModel,
   :base_field => base_field(pm),
   # needed until serialization can handle types as parameters
-  :graph_type => TypeParams(typeof(graph(pm)), nothing), 
+  :graph_type => TypeAndParams(typeof(graph(pm)), nothing), 
   :graph_params => type_params(graph(pm)),
-  :model_parameter_name_type => TypeParams(typeof(varnames(pm)), nothing),
-  :transition_matrix_entry_type => TypeParams(eltype(transition_matrix(pm)), nothing),
+  :model_parameter_name_type => TypeAndParams(typeof(varnames(pm)), nothing),
+  :transition_matrix_entry_type => TypeAndParams(eltype(transition_matrix(pm)), nothing),
   :transition_matrix_params => type_params(transition_matrix(pm)),
-  :root_distribution_entry_type => TypeParams(eltype(root_distribution(pm)), nothing),
+  :root_distribution_entry_type => TypeAndParams(eltype(root_distribution(pm)), nothing),
   :root_distribution_params => type_params(root_distribution(pm))
 )
 
@@ -208,12 +208,12 @@ end
                                                                   :model_ring,
                                                                   :full_model_ring]
 
-type_params(pm::GroupBasedPhylogeneticModel) = TypeParams(
+type_params(pm::GroupBasedPhylogeneticModel) = TypeAndParams(
   GroupBasedPhylogeneticModel,
   :phylo_model => phylogenetic_model(pm),
   # see comment in GroupBasedPhylogeneticModel constructor about group
   :group => parent(first(group(pm))),
-  :model_parameter_name_type => TypeParams(typeof(varnames(pm)), nothing),
+  :model_parameter_name_type => TypeAndParams(typeof(varnames(pm)), nothing),
 )
 
 function save_object(s::SerializerState, pm::GroupBasedPhylogeneticModel)
@@ -238,11 +238,11 @@ end
 
 function type_params(IR::IndexedRing)
   if isempty(IR.gen_to_index)
-    return TypeParams(IndexedRing,
+    return TypeAndParams(IndexedRing,
                :ring => base_ring(IR),
-               :index_type => TypeParams(Int, nothing))
+               :index_type => TypeAndParams(Int, nothing))
   end
-  return TypeParams(IndexedRing,
+  return TypeAndParams(IndexedRing,
                     :ring => base_ring(IR),
                     :index_type => type_params(first(IR.gen_to_index).second))
 end

--- a/experimental/AlgebraicStatistics/src/serialization.jl
+++ b/experimental/AlgebraicStatistics/src/serialization.jl
@@ -1,5 +1,5 @@
 import Oscar.Serialization: save_object, load_object,
-  type_and_params, _convert_override_params, params, load_type_params, decode_type
+  type_and_params, _convert_override_params, params, load_type_and_params, decode_type
 
 function _convert_override_params(tp::TypeAndParams{<:GraphicalModel, <:Tuple{Vararg{Pair}}})
   param_dict = Dict()
@@ -109,15 +109,15 @@ function load_object(s::DeserializerState, ::Type{GraphTransDict}, R::Ring)
   return GraphTransDict{elem_type(R)}(graph_trans_dict)
 end
 
-function load_type_params(s::DeserializerState, T::Type{GenDict})
+function load_type_and_params(s::DeserializerState, T::Type{GenDict})
   subtype, params = load_node(s, :params) do obj
     S, key_params = load_node(s, :key_params) do params
       params isa String && return decode_type(s), nothing
-      load_type_params(s, decode_type(s))
+      load_type_and_params(s, decode_type(s))
     end
 
     _, value_params = load_node(s, :value_params) do _
-      load_type_params(s, decode_type(s))
+      load_type_and_params(s, decode_type(s))
     end
 
     return S, Dict(:key_params => key_params, :value_params => value_params)

--- a/experimental/AlgebraicStatistics/src/serialization.jl
+++ b/experimental/AlgebraicStatistics/src/serialization.jl
@@ -1,5 +1,5 @@
 import Oscar.Serialization: save_object, load_object,
-  type_params, _convert_override_params, params, load_type_params, decode_type
+  type_and_params, _convert_override_params, params, load_type_params, decode_type
 
 function _convert_override_params(tp::TypeAndParams{<:GraphicalModel, <:Tuple{Vararg{Pair}}})
   param_dict = Dict()
@@ -33,7 +33,7 @@ end
 @register_serialization_type GraphTransDict
 @register_serialization_type GenDict
 
-function type_params(obj::T) where T <: Union{GraphDict, GraphTransDict}
+function type_and_params(obj::T) where T <: Union{GraphDict, GraphTransDict}
   if isempty(obj)
     return TypeAndParams(
       T,
@@ -41,7 +41,7 @@ function type_params(obj::T) where T <: Union{GraphDict, GraphTransDict}
     )
   end
   
-  value_params = type_params.(collect(values(obj)))
+  value_params = type_and_params.(collect(values(obj)))
   @req allequal(value_params) "Not all params of values in $obj are the same"
   
   return TypeAndParams(
@@ -50,7 +50,7 @@ function type_params(obj::T) where T <: Union{GraphDict, GraphTransDict}
   )
 end
 
-type_params(D::GenDict) = TypeAndParams(GenDict, params(type_params(D.d)))
+type_and_params(D::GenDict) = TypeAndParams(GenDict, params(type_and_params(D.d)))
 
 function save_object(s::SerializerState, e::Edge)
   save_data_array(s) do
@@ -135,7 +135,7 @@ end
 @register_serialization_type GaussianGraphicalModel uses_id [:parameter_ring, :model_ring]
 @register_serialization_type DiscreteGraphicalModel uses_id [:parameter_ring, :model_ring]
 
-function type_params(GM::S) where {T, L, S <: GraphicalModel{T, L}}
+function type_and_params(GM::S) where {T, L, S <: GraphicalModel{T, L}}
   # this should only be the graph type not the whole graph
   # need to make adjustments to TypeAndParams functionality
   TypeAndParams(S, :graph_type => TypeAndParams(typeof(graph(GM)), nothing))
@@ -169,17 +169,17 @@ end
                                                         :model_ring,
                                                         :full_model_ring]
 
-type_params(pm::PhylogeneticModel) = TypeAndParams(
+type_and_params(pm::PhylogeneticModel) = TypeAndParams(
   PhylogeneticModel,
   :base_field => base_field(pm),
   # needed until serialization can handle types as parameters
   :graph_type => TypeAndParams(typeof(graph(pm)), nothing), 
-  :graph_params => type_params(graph(pm)),
+  :graph_params => type_and_params(graph(pm)),
   :model_parameter_name_type => TypeAndParams(typeof(varnames(pm)), nothing),
   :transition_matrix_entry_type => TypeAndParams(eltype(transition_matrix(pm)), nothing),
-  :transition_matrix_params => type_params(transition_matrix(pm)),
+  :transition_matrix_params => type_and_params(transition_matrix(pm)),
   :root_distribution_entry_type => TypeAndParams(eltype(root_distribution(pm)), nothing),
-  :root_distribution_params => type_params(root_distribution(pm))
+  :root_distribution_params => type_and_params(root_distribution(pm))
 )
 
 function save_object(s::SerializerState, pm::PhylogeneticModel)
@@ -208,7 +208,7 @@ end
                                                                   :model_ring,
                                                                   :full_model_ring]
 
-type_params(pm::GroupBasedPhylogeneticModel) = TypeAndParams(
+type_and_params(pm::GroupBasedPhylogeneticModel) = TypeAndParams(
   GroupBasedPhylogeneticModel,
   :phylo_model => phylogenetic_model(pm),
   # see comment in GroupBasedPhylogeneticModel constructor about group
@@ -236,7 +236,7 @@ end
 # IndexedRing
 @register_serialization_type IndexedRing
 
-function type_params(IR::IndexedRing)
+function type_and_params(IR::IndexedRing)
   if isempty(IR.gen_to_index)
     return TypeAndParams(IndexedRing,
                :ring => base_ring(IR),
@@ -244,7 +244,7 @@ function type_params(IR::IndexedRing)
   end
   return TypeAndParams(IndexedRing,
                     :ring => base_ring(IR),
-                    :index_type => type_params(first(IR.gen_to_index).second))
+                    :index_type => type_and_params(first(IR.gen_to_index).second))
 end
 
 save_object(s::SerializerState, R::IndexedRing) = save_object(s, R.gen_to_index)
@@ -266,7 +266,7 @@ end
 # Phylogenetic Networks
 @register_serialization_type PhylogeneticNetwork
 
-type_params(::PhylogeneticNetwork) = nothing
+type_and_params(::PhylogeneticNetwork) = nothing
 
 function save_object(s::SerializerState, pn::PhylogeneticNetwork)
   save_object(s, graph(pn))

--- a/experimental/FTheoryTools/src/serialization.jl
+++ b/experimental/FTheoryTools/src/serialization.jl
@@ -120,25 +120,25 @@ function _fmodel_params(m::Union{WeierstrassModel,GlobalTateModel,HypersurfaceMo
       nothing
     end,
     if !isempty(explicit_model_sections(m))
-      (:explicit_model_sections => type_params(explicit_model_sections(m)))
+      (:explicit_model_sections => type_and_params(explicit_model_sections(m)))
     else
       nothing
     end,
     if !isempty(defining_classes(m))
-      (:defining_classes => type_params(defining_classes(m)))
+      (:defining_classes => type_and_params(defining_classes(m)))
     else
       nothing
     end,
     if !isempty(model_section_parametrization(m))
-      (:model_section_parametrization => type_params(model_section_parametrization(m)))
+      (:model_section_parametrization => type_and_params(model_section_parametrization(m)))
     else
       nothing
     end]
   return filter(!isnothing, params)
 end
 
-type_params(m::T) where {T<:Union{WeierstrassModel,GlobalTateModel,HypersurfaceModel}} =
-  TypeParams(
+type_and_params(m::T) where {T<:Union{WeierstrassModel,GlobalTateModel,HypersurfaceModel}} =
+  TypeAndParams(
     T, _fmodel_params(m)...
   )
 

--- a/experimental/LieAlgebras/src/serialization.jl
+++ b/experimental/LieAlgebras/src/serialization.jl
@@ -19,7 +19,7 @@ const lie_algebra_serialization_attributes = [
 @register_serialization_type DirectSumLieAlgebra uses_id lie_algebra_serialization_attributes
 
 function type_and_params(L::T) where {T<:AbstractLieAlgebra}
-  TypeParams(
+  TypeAndParams(
     T,
     :base_ring => coefficient_ring(L),
     type_and_params_for_root_system(L)...,
@@ -44,7 +44,7 @@ function load_object(s::DeserializerState, ::Type{<:AbstractLieAlgebra}, d::Dict
 end
 
 function type_and_params(L::T) where {T<:LinearLieAlgebra}
-  TypeParams(
+  TypeAndParams(
     T,
     :base_ring => coefficient_ring(L),
     type_and_params_for_root_system(L)...,
@@ -73,7 +73,7 @@ function load_object(s::DeserializerState, ::Type{<:LinearLieAlgebra}, d::Dict)
 end
 
 function type_and_params(L::T) where {T<:DirectSumLieAlgebra}
-  TypeParams(
+  TypeAndParams(
     T,
     :base_ring => coefficient_ring(L),
     :summands => Tuple(L.summands),
@@ -144,7 +144,7 @@ end
 
 @register_serialization_type LieAlgebraModule uses_id
 
-type_and_params(V::LieAlgebraModule) = TypeParams(
+type_and_params(V::LieAlgebraModule) = TypeAndParams(
   LieAlgebraModule,
   :lie_algebra => base_lie_algebra(V),
   type_and_params_for_construction_data(V)...,

--- a/experimental/LieAlgebras/src/serialization.jl
+++ b/experimental/LieAlgebras/src/serialization.jl
@@ -5,7 +5,7 @@
 ###############################################################################
 
 using Oscar.Serialization
-import Oscar.Serialization: load_object, save_object, type_params
+import Oscar.Serialization: load_object, save_object, type_and_params
 
 const lie_algebra_serialization_attributes = [
   :is_abelian, :is_nilpotent, :is_perfect, :is_semisimple, :is_simple, :is_solvable
@@ -18,11 +18,11 @@ const lie_algebra_serialization_attributes = [
 ]
 @register_serialization_type DirectSumLieAlgebra uses_id lie_algebra_serialization_attributes
 
-function type_params(L::T) where {T<:AbstractLieAlgebra}
+function type_and_params(L::T) where {T<:AbstractLieAlgebra}
   TypeParams(
     T,
     :base_ring => coefficient_ring(L),
-    type_params_for_root_system(L)...,
+    type_and_params_for_root_system(L)...,
   )
 end
 
@@ -43,11 +43,11 @@ function load_object(s::DeserializerState, ::Type{<:AbstractLieAlgebra}, d::Dict
   return L
 end
 
-function type_params(L::T) where {T<:LinearLieAlgebra}
+function type_and_params(L::T) where {T<:LinearLieAlgebra}
   TypeParams(
     T,
     :base_ring => coefficient_ring(L),
-    type_params_for_root_system(L)...,
+    type_and_params_for_root_system(L)...,
   )
 end
 
@@ -72,12 +72,12 @@ function load_object(s::DeserializerState, ::Type{<:LinearLieAlgebra}, d::Dict)
   return L
 end
 
-function type_params(L::T) where {T<:DirectSumLieAlgebra}
+function type_and_params(L::T) where {T<:DirectSumLieAlgebra}
   TypeParams(
     T,
     :base_ring => coefficient_ring(L),
     :summands => Tuple(L.summands),
-    type_params_for_root_system(L)...,
+    type_and_params_for_root_system(L)...,
   )
 end
 
@@ -103,7 +103,7 @@ function save_root_system_data(s::SerializerState, L::LieAlgebra)
   end
 end
 
-function type_params_for_root_system(L::LieAlgebra)
+function type_and_params_for_root_system(L::LieAlgebra)
   if has_root_system(L)
     return (:root_system => root_system(L),)
   else
@@ -144,10 +144,10 @@ end
 
 @register_serialization_type LieAlgebraModule uses_id
 
-type_params(V::LieAlgebraModule) = TypeParams(
+type_and_params(V::LieAlgebraModule) = TypeParams(
   LieAlgebraModule,
   :lie_algebra => base_lie_algebra(V),
-  type_params_for_construction_data(V)...,
+  type_and_params_for_construction_data(V)...,
 )
 
 function save_object(s::SerializerState, V::LieAlgebraModule)
@@ -173,7 +173,7 @@ function load_object(s::DeserializerState, T::Type{<:LieAlgebraModule}, d::Dict)
   return V
 end
 
-function type_params_for_construction_data(V::LieAlgebraModule)
+function type_and_params_for_construction_data(V::LieAlgebraModule)
   if _is_standard_module(V)
     return (:_is_standard_module => true,)
   elseif ((fl, W) = _is_dual(V); fl)

--- a/experimental/MatroidRealizationSpaces/src/serialization.jl
+++ b/experimental/MatroidRealizationSpaces/src/serialization.jl
@@ -4,7 +4,7 @@ import Oscar.Serialization: save_object, load_object, type_and_params
 function type_and_params(M::MatroidRealizationSpace)
   mat = realization_matrix(M)
   p =  isnothing(mat) ? nothing : parent(mat)
-  return TypeParams(MatroidRealizationSpace,
+  return TypeAndParams(MatroidRealizationSpace,
                                       :matrix_space => p,
                                       :ideal_ring => base_ring(defining_ideal(M)),
                                       :ground_ring=>M.ground_ring)
@@ -48,7 +48,7 @@ end
 function type_and_params(M::MatroidRealizationSpaceSelfProjecting)
   mat = selfprojecting_realization_matrix(M)
   p =  isnothing(mat) ? nothing : parent(mat)
-  return TypeParams(MatroidRealizationSpaceSelfProjecting,
+  return TypeAndParams(MatroidRealizationSpaceSelfProjecting,
                                       :matrix_space => p,
                                       :ideal_ring => base_ring(defining_ideal(M)),
                                       :ground_ring=>M.ground_ring)

--- a/experimental/MatroidRealizationSpaces/src/serialization.jl
+++ b/experimental/MatroidRealizationSpaces/src/serialization.jl
@@ -1,7 +1,7 @@
-import Oscar.Serialization: save_object, load_object, type_params
+import Oscar.Serialization: save_object, load_object, type_and_params
 
 @register_serialization_type MatroidRealizationSpace uses_id
-function type_params(M::MatroidRealizationSpace)
+function type_and_params(M::MatroidRealizationSpace)
   mat = realization_matrix(M)
   p =  isnothing(mat) ? nothing : parent(mat)
   return TypeParams(MatroidRealizationSpace,
@@ -45,7 +45,7 @@ end
 
 
 @register_serialization_type MatroidRealizationSpaceSelfProjecting uses_id
-function type_params(M::MatroidRealizationSpaceSelfProjecting)
+function type_and_params(M::MatroidRealizationSpaceSelfProjecting)
   mat = selfprojecting_realization_matrix(M)
   p =  isnothing(mat) ? nothing : parent(mat)
   return TypeParams(MatroidRealizationSpaceSelfProjecting,
@@ -85,12 +85,12 @@ end
 
 
 @register_serialization_type SelfProjectingMatroidRealizations uses_id
-function type_params(M::SelfProjectingMatroidRealizations)
+function type_and_params(M::SelfProjectingMatroidRealizations)
   rs = realization_space(M)
   matrix_rs = isnothing(rs) ? nothing : realization_matrix(rs)
   sprs = selfprojecting_realization_space(M)
   matrix_sprs = isnothing(sprs) ? nothing : selfprojecting_realization_matrix(sprs)
-  TypeParams(SelfProjectingMatroidRealizations,
+  TypeAndParams(SelfProjectingMatroidRealizations,
              :matrix_space_mrs => isnothing(matrix_rs) ? nothing : parent(realization_matrix(rs)),
              :matrix_space_sp_mrs => isnothing(matrix_sprs) ? nothing : parent(selfprojecting_realization_matrix(sprs)),
              :ideal_ring_rs => isnothing(rs) ? nothing : base_ring(defining_ideal(rs)),

--- a/experimental/OscarDB/src/OscarDB.jl
+++ b/experimental/OscarDB/src/OscarDB.jl
@@ -3,7 +3,7 @@ module OscarDB
 using ..Oscar
 using ..Oscar.Serialization
 
-import Oscar.Serialization: load_object, save_object, type_params
+import Oscar.Serialization: load_object, save_object, type_and_params
 
 import Oscar:
   simplicial_complex,

--- a/experimental/OscarDB/src/serialization.jl
+++ b/experimental/OscarDB/src/serialization.jl
@@ -1,5 +1,5 @@
 @register_serialization_type LeechPair
-type_params(x::LeechPair) = TypeParams(LeechPair, group(x))
+type_and_params(x::LeechPair) = TypeParams(LeechPair, group(x))
 
 function save_object(s::SerializerState, LG::LeechPair)
   save_data_dict(s) do
@@ -39,7 +39,7 @@ end
 
 @register_serialization_type TransitiveSimplicialComplex
 
-type_params(tsc::TransitiveSimplicialComplex) = TypeParams(
+type_and_params(tsc::TransitiveSimplicialComplex) = TypeParams(
   TransitiveSimplicialComplex,
   automorphism_group(tsc)
 )
@@ -75,7 +75,7 @@ end
 
 @register_serialization_type SmallTreeModel
 
-type_params(stm::SmallTreeModel) = TypeParams(
+type_and_params(stm::SmallTreeModel) = TypeAndParams(
   SmallTreeModel,
   group_based_phylogenetic_model(stm)
 )

--- a/experimental/OscarDB/src/serialization.jl
+++ b/experimental/OscarDB/src/serialization.jl
@@ -1,5 +1,5 @@
 @register_serialization_type LeechPair
-type_and_params(x::LeechPair) = TypeParams(LeechPair, group(x))
+type_and_params(x::LeechPair) = TypeAndParams(LeechPair, group(x))
 
 function save_object(s::SerializerState, LG::LeechPair)
   save_data_dict(s) do
@@ -39,7 +39,7 @@ end
 
 @register_serialization_type TransitiveSimplicialComplex
 
-type_and_params(tsc::TransitiveSimplicialComplex) = TypeParams(
+type_and_params(tsc::TransitiveSimplicialComplex) = TypeAndParams(
   TransitiveSimplicialComplex,
   automorphism_group(tsc)
 )

--- a/experimental/Parallel/src/Parallel.jl
+++ b/experimental/Parallel/src/Parallel.jl
@@ -1,7 +1,7 @@
 using Distributed: RemoteChannel, Future, remotecall, @everywhere, WorkerPool, AbstractWorkerPool, addprocs, rmprocs, remotecall_eval, nworkers
 import Distributed: remotecall, workers, remotecall_fetch, pmap, ClusterManager
 
-import .Serialization: put_type_params
+import .Serialization: put_type_and_params
 
 @doc raw"""
      OscarWorkerPool
@@ -20,7 +20,7 @@ mutable struct OscarWorkerPool <: AbstractWorkerPool
   channel::Channel{Int} # required for the `AbstractWorkerPool` interface
   workers::Set{Int}     # same
   wids::Vector{Int}     # a list of the ids of all workers which are associated to this pool
-  oscar_channels::Dict{Int, <:RemoteChannel} # channels for sending `type_params` to the workers
+  oscar_channels::Dict{Int, <:RemoteChannel} # channels for sending `type_and_params` to the workers
 
   function OscarWorkerPool(n::Int; kw...)
     wids = addprocs(n; kw...)
@@ -136,9 +136,9 @@ end
 close!(wp::OscarWorkerPool) = rmprocs(workers(wp)...)
 
 # extend functionality so that `pmap` works with Oscar stuff
-function put_type_params(wp::OscarWorkerPool, a::Any)
+function put_type_and_params(wp::OscarWorkerPool, a::Any)
   asyncmap(wp.wids) do id
-    put_type_params(get_channel(wp, id), a)
+    put_type_and_params(get_channel(wp, id), a)
   end
 end
 
@@ -231,7 +231,7 @@ process_result!(ctx, id::Int, res) = ctx
 
 #=
 # Custom versions of `remotecall` and `remotecall_fetch` for `OscarWorkerPool`s.
-# The idea is to use this special type of worker pool to send the `type_params`
+# The idea is to use this special type of worker pool to send the `type_and_params`
 # of the arguments to the workers up front. Then hopefully, whenever an
 # `OscarWorkerPool` is being used, loads of other functionality like `pmap`
 # will run out of the box.
@@ -239,10 +239,10 @@ process_result!(ctx, id::Int, res) = ctx
 function remotecall(f::Any, wp::OscarWorkerPool, args...; kwargs...)
   wid = take!(wp)
   for a in args
-    put_type_params(get_channel(wp, wid), a)
+    put_type_and_params(get_channel(wp, wid), a)
   end
   for a in kwargs
-    put_type_params(get_channel(wp, wid), a)
+    put_type_and_params(get_channel(wp, wid), a)
   end
 
   # Copied from Distributed.jl/src/workerpool.jl.
@@ -272,10 +272,10 @@ function remotecall_fetch(f::Any, wp::OscarWorkerPool, args...; kwargs...)
   # TODO only send params when necessary
   # and/or figure out how to clear channels
   for a in args
-    put_type_params(get_channel(wp, wid), a)
+    put_type_and_params(get_channel(wp, wid), a)
   end
   for a in kwargs
-    put_type_params(get_channel(wp, wid), a)
+    put_type_and_params(get_channel(wp, wid), a)
   end
   result = remotecall_fetch(f, wid, args...; kwargs...)
   put!(wp, wid)
@@ -283,10 +283,10 @@ function remotecall_fetch(f::Any, wp::OscarWorkerPool, args...; kwargs...)
 end
 
 # this is here so that setting batchsize still works
-type_params(p::Base.Iterators.Zip) = type_params(first(p))
+type_and_params(p::Base.Iterators.Zip) = type_and_params(first(p))
   
 function pmap(f::Any, wp::OscarWorkerPool, c; kwargs...)
-  put_type_params(wp, c)
+  put_type_and_params(wp, c)
   pmap(f, wp.wp, c; kwargs...)
 end
 

--- a/gap/pkg/OscarInterface/gap/OscarInterface.gi
+++ b/gap/pkg/OscarInterface/gap/OscarInterface.gi
@@ -127,7 +127,7 @@ InstallMethod( GroupGeneratorsDefinePresentation,
 ############################################################################
 
 
-Perform( Oscar_jl.Serialization._GAP_type_params,
+Perform( Oscar_jl.Serialization._GAP_type_and_params,
          function( entry )
            InstallMethod( SerializationInOscarDependentObjects,
              [ JuliaToGAP( IsString, entry[1] ) ],

--- a/src/Serialization/Algebras.jl
+++ b/src/Serialization/Algebras.jl
@@ -4,7 +4,7 @@
 # Free associative algebra serialization
 @register_serialization_type FreeAssociativeAlgebra uses_id
 
-type_params(R::T) where T <: FreeAssociativeAlgebra = TypeParams(T, coefficient_ring(R))
+type_and_params(R::T) where T <: FreeAssociativeAlgebra = TypeParams(T, coefficient_ring(R))
 
 function save_object(s::SerializerState, A::FreeAssociativeAlgebra)
   save_data_dict(s) do
@@ -20,7 +20,7 @@ end
 # Free associative algebra element serialization
 @register_serialization_type FreeAssociativeAlgebraElem
 
-# see type_params in Rings
+# see type_and_params in Rings
 
 function save_object(s::SerializerState, f::FreeAssociativeAlgebraElem)
   save_data_array(s) do

--- a/src/Serialization/Algebras.jl
+++ b/src/Serialization/Algebras.jl
@@ -4,7 +4,7 @@
 # Free associative algebra serialization
 @register_serialization_type FreeAssociativeAlgebra uses_id
 
-type_and_params(R::T) where T <: FreeAssociativeAlgebra = TypeParams(T, coefficient_ring(R))
+type_and_params(R::T) where T <: FreeAssociativeAlgebra = TypeAndParams(T, coefficient_ring(R))
 
 function save_object(s::SerializerState, A::FreeAssociativeAlgebra)
   save_data_dict(s) do

--- a/src/Serialization/Combinatorics.jl
+++ b/src/Serialization/Combinatorics.jl
@@ -81,7 +81,7 @@ end
 ## Phylogenetic Trees
 ###############################################################################
 @register_serialization_type PhylogeneticTree 
-type_params(::PhylogeneticTree{T}) where T <: Union{QQFieldElem, Float64} = TypeParams(
+type_and_params(::PhylogeneticTree{T}) where T <: Union{QQFieldElem, Float64} = TypeAndParams(
   PhylogeneticTree, T == QQFieldElem ? QQ : AbstractAlgebra.Floats{Float64}())
 
 function save_object(s::SerializerState, PT::PhylogeneticTree)

--- a/src/Serialization/Fields.jl
+++ b/src/Serialization/Fields.jl
@@ -7,7 +7,7 @@
 @register_serialization_type QQField
 
 ################################################################################
-# type_params for field extension types
+# type_and_params for field extension types
 
 ################################################################################
 # non-ZZRingElem variant
@@ -70,7 +70,7 @@ end
 @register_serialization_type AbsSimpleNumField uses_id [:cyclo]
 const SimNumFieldTypeUnion = Union{AbsSimpleNumField, Hecke.RelSimpleNumField}
 
-type_params(obj::T) where T <: SimpleNumField = TypeParams(T, parent(defining_polynomial(obj)))
+type_and_params(obj::T) where T <: SimpleNumField = TypeParams(T, parent(defining_polynomial(obj)))
 
 function save_object(s::SerializerState, K::SimpleNumField)
   save_data_dict(s) do
@@ -90,7 +90,7 @@ end
 # FqNmodfinitefield
 @register_serialization_type fqPolyRepField uses_id
 
-type_params(K::fqPolyRepField) = TypeParams(fqPolyRepField, parent(defining_polynomial(K)))
+type_and_params(K::fqPolyRepField) = TypeParams(fqPolyRepField, parent(defining_polynomial(K)))
 
 function save_object(s::SerializerState, K::fqPolyRepField)
   save_object(s, defining_polynomial(K))
@@ -132,7 +132,7 @@ end
 @register_serialization_type FqField "FiniteField" uses_id default
 @register_serialization_type FqFieldElem
 
-function type_params(K::FqField)
+function type_and_params(K::FqField)
   absolute_degree(K) == 1 && return TypeParams(FqField, nothing)
   return TypeParams(FqField, parent(defining_polynomial(K)))
 end
@@ -184,7 +184,7 @@ end
 @register_serialization_type Hecke.RelNonSimpleNumField uses_id
 @register_serialization_type AbsNonSimpleNumField uses_id
 
-function type_params(K::T) where T <: Union{AbsNonSimpleNumField, RelNonSimpleNumField}
+function type_and_params(K::T) where T <: Union{AbsNonSimpleNumField, RelNonSimpleNumField}
   return TypeParams(T, parent(defining_polynomials(K)[1]))
 end
 
@@ -237,7 +237,7 @@ end
 
 @register_serialization_type FracField uses_id
 
-type_params(R::T) where T <: FracField = TypeParams(T, base_ring(R))
+type_and_params(R::T) where T <: FracField = TypeParams(T, base_ring(R))
 
 const FracUnionTypes = Union{MPolyRingElem, PolyRingElem, UniversalPolyRingElem}
 # we use the union to prevent QQField from using these save methods
@@ -277,7 +277,7 @@ end
 
 @register_serialization_type AbstractAlgebra.Generic.RationalFunctionField "RationalFunctionField" uses_id
 
-type_params(R::T) where T <: AbstractAlgebra.Generic.RationalFunctionField = TypeParams(T, base_ring(R))
+type_and_params(R::T) where T <: AbstractAlgebra.Generic.RationalFunctionField = TypeParams(T, base_ring(R))
 
 function save_object(s::SerializerState,
                      RF::AbstractAlgebra.Generic.RationalFunctionField{<: FieldElem, <: MPolyRingElem})
@@ -405,7 +405,7 @@ const FieldEmbeddingTypes = Union{
 @register_serialization_type Hecke.AbsSimpleNumFieldEmbedding uses_id
 @register_serialization_type Hecke.RelSimpleNumFieldEmbedding uses_id
 
-function type_params(E::T) where T <: FieldEmbeddingTypes
+function type_and_params(E::T) where T <: FieldEmbeddingTypes
   K = number_field(E)
   base_K = base_field(K)
   base_field(K) isa QQField && return TypeParams(T, K)
@@ -459,7 +459,7 @@ end
 
 @register_serialization_type EmbeddedNumField uses_id
 
-type_params(E::T) where T <: EmbeddedNumField = TypeParams(T, embedding(E))
+type_and_params(E::T) where T <: EmbeddedNumField = TypeAndParams(T, embedding(E))
 
 function save_object(s::SerializerState, E::EmbeddedNumField)
   save_data_array(s) do

--- a/src/Serialization/Fields.jl
+++ b/src/Serialization/Fields.jl
@@ -70,7 +70,7 @@ end
 @register_serialization_type AbsSimpleNumField uses_id [:cyclo]
 const SimNumFieldTypeUnion = Union{AbsSimpleNumField, Hecke.RelSimpleNumField}
 
-type_and_params(obj::T) where T <: SimpleNumField = TypeParams(T, parent(defining_polynomial(obj)))
+type_and_params(obj::T) where T <: SimpleNumField = TypeAndParams(T, parent(defining_polynomial(obj)))
 
 function save_object(s::SerializerState, K::SimpleNumField)
   save_data_dict(s) do
@@ -90,7 +90,7 @@ end
 # FqNmodfinitefield
 @register_serialization_type fqPolyRepField uses_id
 
-type_and_params(K::fqPolyRepField) = TypeParams(fqPolyRepField, parent(defining_polynomial(K)))
+type_and_params(K::fqPolyRepField) = TypeAndParams(fqPolyRepField, parent(defining_polynomial(K)))
 
 function save_object(s::SerializerState, K::fqPolyRepField)
   save_object(s, defining_polynomial(K))
@@ -133,8 +133,8 @@ end
 @register_serialization_type FqFieldElem
 
 function type_and_params(K::FqField)
-  absolute_degree(K) == 1 && return TypeParams(FqField, nothing)
-  return TypeParams(FqField, parent(defining_polynomial(K)))
+  absolute_degree(K) == 1 && return TypeAndParams(FqField, nothing)
+  return TypeAndParams(FqField, parent(defining_polynomial(K)))
 end
 
 function save_object(s::SerializerState, K::FqField)
@@ -185,7 +185,7 @@ end
 @register_serialization_type AbsNonSimpleNumField uses_id
 
 function type_and_params(K::T) where T <: Union{AbsNonSimpleNumField, RelNonSimpleNumField}
-  return TypeParams(T, parent(defining_polynomials(K)[1]))
+  return TypeAndParams(T, parent(defining_polynomials(K)[1]))
 end
 
 function save_object(s::SerializerState, K::NonSimpleNumField)
@@ -237,7 +237,7 @@ end
 
 @register_serialization_type FracField uses_id
 
-type_and_params(R::T) where T <: FracField = TypeParams(T, base_ring(R))
+type_and_params(R::T) where T <: FracField = TypeAndParams(T, base_ring(R))
 
 const FracUnionTypes = Union{MPolyRingElem, PolyRingElem, UniversalPolyRingElem}
 # we use the union to prevent QQField from using these save methods
@@ -277,7 +277,7 @@ end
 
 @register_serialization_type AbstractAlgebra.Generic.RationalFunctionField "RationalFunctionField" uses_id
 
-type_and_params(R::T) where T <: AbstractAlgebra.Generic.RationalFunctionField = TypeParams(T, base_ring(R))
+type_and_params(R::T) where T <: AbstractAlgebra.Generic.RationalFunctionField = TypeAndParams(T, base_ring(R))
 
 function save_object(s::SerializerState,
                      RF::AbstractAlgebra.Generic.RationalFunctionField{<: FieldElem, <: MPolyRingElem})
@@ -408,10 +408,10 @@ const FieldEmbeddingTypes = Union{
 function type_and_params(E::T) where T <: FieldEmbeddingTypes
   K = number_field(E)
   base_K = base_field(K)
-  base_field(K) isa QQField && return TypeParams(T, K)
+  base_field(K) isa QQField && return TypeAndParams(T, K)
 
   base_field_emb = restrict(E, base_K)
-  return TypeParams(
+  return TypeAndParams(
     T,
     :num_field => K,
     :base_field_emb => base_field_emb,

--- a/src/Serialization/GAP.jl
+++ b/src/Serialization/GAP.jl
@@ -42,9 +42,9 @@ end
 @register_serialization_type GapObj uses_id
 
 function type_and_params(X::GapObj)
-  params = GAP.Globals.SerializationInOscarDependentObjects(X)::Union{Nothing, TypeParams, GapObj}
-  params isa TypeParams && return params
-  return TypeParams(GapObj, params)
+  params = GAP.Globals.SerializationInOscarDependentObjects(X)::Union{Nothing, TypeAndParams, GapObj}
+  params isa TypeAndParams && return params
+  return TypeAndParams(GapObj, params)
 end
 
 function save_object(s::SerializerState, X::GapObj)
@@ -213,7 +213,7 @@ install_GAP_type_and_params(:IsSubgroupFpGroup,
     else
       F = GAP.getbangproperty(Xfam, :wholeGroup)::GapObj
     end
-    return TypeParams(GapObj, F)
+    return TypeAndParams(GapObj, F)
   end)
 
 install_GAP_serialization(:IsSubgroupFpGroup,

--- a/src/Serialization/GAP.jl
+++ b/src/Serialization/GAP.jl
@@ -16,12 +16,12 @@ import Oscar: GAPWrap
 #
 # utilities for installing methods depending on GAP filters
 #
-const _GAP_type_params = Pair{Symbol, Function}[]
+const _GAP_type_and_params = Pair{Symbol, Function}[]
 const _GAP_serializations = Pair{Symbol, Function}[]
 const _GAP_deserializations = Tuple{Symbol, Function, Bool}[]
 
-function install_GAP_type_params(filtsymbol::Symbol, meth::Function)
-  push!(_GAP_type_params, filtsymbol => meth)
+function install_GAP_type_and_params(filtsymbol::Symbol, meth::Function)
+  push!(_GAP_type_and_params, filtsymbol => meth)
   return
 end
 
@@ -41,7 +41,7 @@ end
 #
 @register_serialization_type GapObj uses_id
 
-function type_params(X::GapObj)
+function type_and_params(X::GapObj)
   params = GAP.Globals.SerializationInOscarDependentObjects(X)::Union{Nothing, TypeParams, GapObj}
   params isa TypeParams && return params
   return TypeParams(GapObj, params)
@@ -101,7 +101,7 @@ install_GAP_serialization(:IsFamily,
 #   full free group or subgroup of it,
 #   distinguished by type parameter `:freeGroup` and presence of `:gens`
 #   in case of a subgroup
-install_GAP_type_params(:IsFreeGroup,
+install_GAP_type_and_params(:IsFreeGroup,
   function(X::GapObj)
     if GAP.Globals.HasIsWholeFamily(X) && GAPWrap.IsWholeFamily(X)
       return nothing
@@ -204,7 +204,7 @@ install_GAP_deserialization(
 #   distinguished by type parameter `:freeGroup` and presence of `:relators`
 #   in case of a full group, or
 #   type parameter `:wholeGroup` and presence of `:gens` in case of a subgroup
-install_GAP_type_params(:IsSubgroupFpGroup,
+install_GAP_type_and_params(:IsSubgroupFpGroup,
   function(X::GapObj)
     Xfam = GAPWrap.FamilyObj(X)
     if GAP.Globals.HasIsWholeFamily(X) && GAPWrap.IsWholeFamily(X)
@@ -275,7 +275,7 @@ install_GAP_deserialization(
 #   we do not support (de)serialization of the stored rws,
 #   thus we need not (de)serialize its underlying free group etc.
 
-install_GAP_type_params(:IsPcGroup,
+install_GAP_type_and_params(:IsPcGroup,
   function(X::GapObj)
     elfam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(X))
     fullpcgs = GAP.getbangproperty(elfam, :DefiningPcgs)::GapObj

--- a/src/Serialization/Groups.jl
+++ b/src/Serialization/Groups.jl
@@ -171,7 +171,7 @@ end
 @register_serialization_type PcGroup uses_id
 @register_serialization_type SubPcGroup uses_id
 
-function type_params(G::T) where T <: Union{FPGroup, SubFPGroup, PcGroup, SubPcGroup}
+function type_and_params(G::T) where T <: Union{FPGroup, SubFPGroup, PcGroup, SubPcGroup}
   TypeParams(T, GapObj(G))
 end
 
@@ -277,7 +277,7 @@ end
 # homomorphisms
 @register_serialization_type FinGenAbGroupHom uses_id
 
-type_params(X::FinGenAbGroupHom) = TypeParams(
+type_and_params(X::FinGenAbGroupHom) = TypeParams(
   FinGenAbGroupHom,
   :domain => domain(X),
   :codomain => codomain(X)
@@ -297,9 +297,9 @@ end
 
 @register_serialization_type MatGroup uses_id
 
-type_params(G::MatGroup) = TypeParams(MatGroup,
-                                         :base_ring => base_ring(G),
-                                         :degree => degree(G))
+type_and_params(G::MatGroup) = TypeAndParams(MatGroup,
+                                             :base_ring => base_ring(G),
+                                             :degree => degree(G))
 
 function save_object(s::SerializerState, G::MatGroup)
   save_data_dict(s) do

--- a/src/Serialization/Groups.jl
+++ b/src/Serialization/Groups.jl
@@ -172,7 +172,7 @@ end
 @register_serialization_type SubPcGroup uses_id
 
 function type_and_params(G::T) where T <: Union{FPGroup, SubFPGroup, PcGroup, SubPcGroup}
-  TypeParams(T, GapObj(G))
+  TypeAndParams(T, GapObj(G))
 end
 
 function save_object(s::SerializerState,
@@ -277,7 +277,7 @@ end
 # homomorphisms
 @register_serialization_type FinGenAbGroupHom uses_id
 
-type_and_params(X::FinGenAbGroupHom) = TypeParams(
+type_and_params(X::FinGenAbGroupHom) = TypeAndParams(
   FinGenAbGroupHom,
   :domain => domain(X),
   :codomain => codomain(X)

--- a/src/Serialization/LieTheory.jl
+++ b/src/Serialization/LieTheory.jl
@@ -39,7 +39,7 @@ end
 @register_serialization_type RootSpaceElem
 @register_serialization_type DualRootSpaceElem
 
-type_params(e::T) where T <: Union{RootSpaceElem, DualRootSpaceElem} = TypeParams(T, root_system(e))
+type_and_params(e::T) where T <: Union{RootSpaceElem, DualRootSpaceElem} = TypeParams(T, root_system(e))
 
 function save_object(s::SerializerState, r::Union{RootSpaceElem,DualRootSpaceElem})
   save_object(s, _vec(coefficients(r)))
@@ -59,7 +59,7 @@ end
 
 @register_serialization_type WeightLattice uses_id
 
-type_params(P::WeightLattice) = TypeParams(WeightLattice, root_system(P))
+type_and_params(P::WeightLattice) = TypeParams(WeightLattice, root_system(P))
 
 function save_object(s::SerializerState, P::WeightLattice)
   save_data_dict(s) do
@@ -90,7 +90,7 @@ end
 
 @register_serialization_type WeylGroup uses_id
 
-type_params(W::WeylGroup) = TypeParams(WeylGroup, root_system(W))
+type_and_params(W::WeylGroup) = TypeAndParams(WeylGroup, root_system(W))
 
 function save_object(s::SerializerState, W::WeylGroup)
   save_data_dict(s) do

--- a/src/Serialization/LieTheory.jl
+++ b/src/Serialization/LieTheory.jl
@@ -39,7 +39,7 @@ end
 @register_serialization_type RootSpaceElem
 @register_serialization_type DualRootSpaceElem
 
-type_and_params(e::T) where T <: Union{RootSpaceElem, DualRootSpaceElem} = TypeParams(T, root_system(e))
+type_and_params(e::T) where T <: Union{RootSpaceElem, DualRootSpaceElem} = TypeAndParams(T, root_system(e))
 
 function save_object(s::SerializerState, r::Union{RootSpaceElem,DualRootSpaceElem})
   save_object(s, _vec(coefficients(r)))
@@ -59,7 +59,7 @@ end
 
 @register_serialization_type WeightLattice uses_id
 
-type_and_params(P::WeightLattice) = TypeParams(WeightLattice, root_system(P))
+type_and_params(P::WeightLattice) = TypeAndParams(WeightLattice, root_system(P))
 
 function save_object(s::SerializerState, P::WeightLattice)
   save_data_dict(s) do

--- a/src/Serialization/MPolyMap.jl
+++ b/src/Serialization/MPolyMap.jl
@@ -2,8 +2,8 @@ using Oscar: _images, coefficient_map
 
 @register_serialization_type MPolyAnyMap
 
-function type_params(phi::MPolyAnyMap{S, T, U, V}) where {S, T, U, V}
-  return TypeParams(
+function type_and_params(phi::MPolyAnyMap{S, T, U, V}) where {S, T, U, V}
+  return TypeAndParams(
     MPolyAnyMap,
     :domain => domain(phi),
     :codomain => codomain(phi)

--- a/src/Serialization/PolyhedralGeometry.jl
+++ b/src/Serialization/PolyhedralGeometry.jl
@@ -29,16 +29,16 @@ end
 ##############################################################################
 # Abstract Polyhedral Object
 
-type_and_params(obj::T) where {S <: Union{QQFieldElem, Float64}, T <: PolyhedralObject{S}} = TypeParams(T, coefficient_field(obj))
+type_and_params(obj::T) where {S <: Union{QQFieldElem, Float64}, T <: PolyhedralObject{S}} = TypeAndParams(T, coefficient_field(obj))
 
-type_and_params(obj::T) where {S <: Union{QQFieldElem, Float64}, T <: LinearProgram{S}} = TypeParams(T, coefficient_field(obj))
-type_and_params(obj::T) where {S <: Union{QQFieldElem, Float64}, T <: MixedIntegerLinearProgram{S}} = TypeParams(T, coefficient_field(obj))
+type_and_params(obj::T) where {S <: Union{QQFieldElem, Float64}, T <: LinearProgram{S}} = TypeAndParams(T, coefficient_field(obj))
+type_and_params(obj::T) where {S <: Union{QQFieldElem, Float64}, T <: MixedIntegerLinearProgram{S}} = TypeAndParams(T, coefficient_field(obj))
 
 function type_and_params(obj::T) where {S, T <: PolyhedralObject{S}}
   p_dict = _polyhedral_object_as_dict(obj)
   field = p_dict[:_coeff]
   delete!(p_dict, :_coeff)
-  return TypeParams(
+  return TypeAndParams(
     T,
     :field => field,
     :pm_params => type_and_params(p_dict))

--- a/src/Serialization/PolyhedralGeometry.jl
+++ b/src/Serialization/PolyhedralGeometry.jl
@@ -29,24 +29,24 @@ end
 ##############################################################################
 # Abstract Polyhedral Object
 
-type_params(obj::T) where {S <: Union{QQFieldElem, Float64}, T <: PolyhedralObject{S}} = TypeParams(T, coefficient_field(obj))
+type_and_params(obj::T) where {S <: Union{QQFieldElem, Float64}, T <: PolyhedralObject{S}} = TypeParams(T, coefficient_field(obj))
 
-type_params(obj::T) where {S <: Union{QQFieldElem, Float64}, T <: LinearProgram{S}} = TypeParams(T, coefficient_field(obj))
-type_params(obj::T) where {S <: Union{QQFieldElem, Float64}, T <: MixedIntegerLinearProgram{S}} = TypeParams(T, coefficient_field(obj))
+type_and_params(obj::T) where {S <: Union{QQFieldElem, Float64}, T <: LinearProgram{S}} = TypeParams(T, coefficient_field(obj))
+type_and_params(obj::T) where {S <: Union{QQFieldElem, Float64}, T <: MixedIntegerLinearProgram{S}} = TypeParams(T, coefficient_field(obj))
 
-function type_params(obj::T) where {S, T <: PolyhedralObject{S}}
+function type_and_params(obj::T) where {S, T <: PolyhedralObject{S}}
   p_dict = _polyhedral_object_as_dict(obj)
   field = p_dict[:_coeff]
   delete!(p_dict, :_coeff)
   return TypeParams(
     T,
     :field => field,
-    :pm_params => type_params(p_dict))
+    :pm_params => type_and_params(p_dict))
 end
 
-function type_params(obj::T) where {S, T <: Union{LinearProgram{S}, MixedIntegerLinearProgram{S}}}
-  par = params(type_params(feasible_region(obj)))
-  return TypeParams(
+function type_and_params(obj::T) where {S, T <: Union{LinearProgram{S}, MixedIntegerLinearProgram{S}}}
+  par = params(type_and_params(feasible_region(obj)))
+  return TypeAndParams(
     T,
     par...)
 end

--- a/src/Serialization/QuadForm.jl
+++ b/src/Serialization/QuadForm.jl
@@ -2,7 +2,7 @@
 # QuadSpace
 @register_serialization_type Hecke.QuadSpace uses_id
 
-type_params(V::Hecke.QuadSpace) = TypeParams(Hecke.QuadSpace, parent(gram_matrix(V)))
+type_and_params(V::Hecke.QuadSpace) = TypeParams(Hecke.QuadSpace, parent(gram_matrix(V)))
 
 function save_object(s::SerializerState, V::Hecke.QuadSpace)
   save_object(s, gram_matrix(V))
@@ -18,7 +18,7 @@ end
 # ZZLat
 @register_serialization_type ZZLat
 
-type_params(L::ZZLat) = TypeParams(
+type_and_params(L::ZZLat) = TypeParams(
   ZZLat,
   :basis => parent(basis_matrix(L)),
   :ambient_space => ambient_space(L)
@@ -37,7 +37,7 @@ end
 ############################################################
 # QuadSpaceWithIsom
 @register_serialization_type QuadSpaceWithIsom                                                                                    
-type_params(QS::QuadSpaceWithIsom) = TypeParams(
+type_and_params(QS::QuadSpaceWithIsom) = TypeParams(
   QuadSpaceWithIsom,
   :quad_space => space(QS),
   :isom => parent(isometry(QS)),
@@ -71,7 +71,7 @@ end
 # ZZLatWithIsom
 @register_serialization_type ZZLatWithIsom
 
-type_params(x::ZZLatWithIsom) = TypeParams(
+type_and_params(x::ZZLatWithIsom) = TypeAndParams(
   ZZLatWithIsom,
   :ambient_space => ambient_space(x),
   :basis => parent(basis_matrix(x))

--- a/src/Serialization/QuadForm.jl
+++ b/src/Serialization/QuadForm.jl
@@ -2,7 +2,7 @@
 # QuadSpace
 @register_serialization_type Hecke.QuadSpace uses_id
 
-type_and_params(V::Hecke.QuadSpace) = TypeParams(Hecke.QuadSpace, parent(gram_matrix(V)))
+type_and_params(V::Hecke.QuadSpace) = TypeAndParams(Hecke.QuadSpace, parent(gram_matrix(V)))
 
 function save_object(s::SerializerState, V::Hecke.QuadSpace)
   save_object(s, gram_matrix(V))
@@ -18,7 +18,7 @@ end
 # ZZLat
 @register_serialization_type ZZLat
 
-type_and_params(L::ZZLat) = TypeParams(
+type_and_params(L::ZZLat) = TypeAndParams(
   ZZLat,
   :basis => parent(basis_matrix(L)),
   :ambient_space => ambient_space(L)
@@ -37,11 +37,11 @@ end
 ############################################################
 # QuadSpaceWithIsom
 @register_serialization_type QuadSpaceWithIsom                                                                                    
-type_and_params(QS::QuadSpaceWithIsom) = TypeParams(
+type_and_params(QS::QuadSpaceWithIsom) = TypeAndParams(
   QuadSpaceWithIsom,
   :quad_space => space(QS),
   :isom => parent(isometry(QS)),
-  :order => TypeParams(typeof(order_of_isometry(QS)), nothing)
+  :order => TypeAndParams(typeof(order_of_isometry(QS)), nothing)
 )
 
 function save_object(s::SerializerState, QS::QuadSpaceWithIsom)

--- a/src/Serialization/Rings.jl
+++ b/src/Serialization/Rings.jl
@@ -27,19 +27,19 @@ const LaurentUnionType = Union{Generic.LaurentSeriesRing,
                                ZZLaurentSeriesRing}
 
 ################################################################################
-# type_params functions
+# type_and_params functions
 
 # element types by default use their parent as reference object
-type_params(x::T) where T <: SetElem = TypeParams(T, parent(x))
-type_params(x::T) where T <: SMat = TypeParams(T, parent(x))
+type_and_params(x::T) where T <: SetElem = TypeParams(T, parent(x))
+type_and_params(x::T) where T <: SMat = TypeParams(T, parent(x))
 
 # rings, groups etc. default have no reference object
-type_params(R::T) where T <: AbstractAlgebra.Set = TypeParams(T, nothing)
+type_and_params(R::T) where T <: AbstractAlgebra.Set = TypeParams(T, nothing)
 
 # ideals and matrix spaces have their base ring as reference object
-type_params(x::T) where T <: Ideal = TypeParams(T, base_ring(x))
-type_params(x::T) where T <: MatSpace = TypeParams(T, base_ring(x))
-type_params(x::T) where T <: SMatSpace = TypeParams(T, base_ring(x))
+type_and_params(x::T) where T <: Ideal = TypeParams(T, base_ring(x))
+type_and_params(x::T) where T <: MatSpace = TypeParams(T, base_ring(x))
+type_and_params(x::T) where T <: SMatSpace = TypeParams(T, base_ring(x))
 
 
 ################################################################################
@@ -88,7 +88,7 @@ end
 @register_serialization_type AbstractAlgebra.Generic.LaurentMPolyWrapRing uses_id
 
 # polynomial-like rings use their coefficient ring as reference object
-type_params(R::T) where T <: PolyRingUnionType = TypeParams(T, coefficient_ring(R))
+type_and_params(R::T) where T <: PolyRingUnionType = TypeParams(T, coefficient_ring(R))
 
 function save_object(s::SerializerState, R::PolyRingUnionType)
   save_data_dict(s) do
@@ -117,7 +117,7 @@ function load_object(s::DeserializerState, ::Type{<:AbstractAlgebra.Generic.Laur
 end
 
 # with grading
-type_params(R::MPolyDecRing) = TypeParams(
+type_and_params(R::MPolyDecRing) = TypeParams(
   MPolyDecRing,
   :grading_group => grading_group(R),
   :ring => forget_grading(R),
@@ -277,7 +277,7 @@ end
 
 @register_serialization_type IdealGens
 
-type_params(ig::IdealGens) = TypeParams(
+type_and_params(ig::IdealGens) = TypeParams(
   IdealGens,
   :base_ring => base_ring(ig),
   :ordering_type => TypeParams(typeof(ordering(ig)), nothing)
@@ -389,7 +389,7 @@ end
 # Power Series
 @register_serialization_type SeriesRing uses_id
 
-type_params(R::T) where T <: SeriesRing = TypeParams(T, base_ring(R))
+type_and_params(R::T) where T <: SeriesRing = TypeParams(T, base_ring(R))
 
 function save_object(s::SerializerState, R::RelPowerSeriesUnionType)
   save_data_dict(s) do
@@ -509,7 +509,7 @@ end
 @register_serialization_type Generic.LaurentSeriesField "LaurentSeriesField" uses_id
 @register_serialization_type ZZLaurentSeriesRing uses_id
 
-type_params(R::T) where T <: LaurentUnionType = TypeParams(T, base_ring(R))
+type_and_params(R::T) where T <: LaurentUnionType = TypeParams(T, base_ring(R))
 
 function save_object(s::SerializerState, R::LaurentUnionType)
   save_data_dict(s) do
@@ -593,7 +593,7 @@ end
 ### Affine algebras
 @register_serialization_type MPolyQuoRing uses_id
 
-type_params(A::MPolyQuoRing) = TypeParams(
+type_and_params(A::MPolyQuoRing) = TypeParams(
   MPolyQuoRing,
   :base_ring => base_ring(A),
   :ordering => typeof(ordering(A))
@@ -671,7 +671,7 @@ end
 # localizations of polynomial rings
 @register_serialization_type MPolyPowersOfElement uses_id
 
-type_params(U::T) where T <: MPolyPowersOfElement = TypeParams(T, ring(U))
+type_and_params(U::T) where T <: MPolyPowersOfElement = TypeParams(T, ring(U))
 
 function save_object(s::SerializerState, U::MPolyPowersOfElement)
   save_object(s, denominators(U))
@@ -685,7 +685,7 @@ end
 
 @register_serialization_type MPolyComplementOfPrimeIdeal uses_id
 
-type_params(U::MPolyComplementOfPrimeIdeal) = TypeParams(typeof(U), ring(U))
+type_and_params(U::MPolyComplementOfPrimeIdeal) = TypeParams(typeof(U), ring(U))
 
 function save_object(s::SerializerState, U::MPolyComplementOfPrimeIdeal)
   save_object(s, prime_ideal(U))
@@ -698,7 +698,7 @@ end
 
 @register_serialization_type MPolyLocRing uses_id
 
-type_params(W::T) where {T <: MPolyLocRing} = TypeParams(T, :base_ring => base_ring(W), :mult_set_type => TypeParams(typeof(inverted_set(W)), nothing)) # TODO: make this neater!
+type_and_params(W::T) where {T <: MPolyLocRing} = TypeParams(T, :base_ring => base_ring(W), :mult_set_type => TypeParams(typeof(inverted_set(W)), nothing)) # TODO: make this neater!
 
 function save_object(s::SerializerState, L::MPolyLocRing)
   save_object(s, inverted_set(L))
@@ -717,7 +717,7 @@ end
 @register_serialization_type MPolyLocRingElem
 
 function save_object(s::SerializerState, a::MPolyLocRingElem)
-  # `save_type_params` will store the output of type_params
+  # `save_type_and_params` will store the output of type_and_params
   # in this case the parent ring
   save_data_array(s) do
     save_object(s, numerator(a))
@@ -735,11 +735,11 @@ end
 
 @register_serialization_type MPolyQuoLocRing uses_id
 
-type_params(L::T) where {T <: MPolyQuoLocRing} = TypeParams(T, :base_ring=>base_ring(L), :loc_ring=>localized_ring(L), :quo_ring=>underlying_quotient(L))
+type_and_params(L::T) where {T <: MPolyQuoLocRing} = TypeParams(T, :base_ring=>base_ring(L), :loc_ring=>localized_ring(L), :quo_ring=>underlying_quotient(L))
 
 function save_object(s::SerializerState, L::MPolyQuoLocRing)
   save_data_dict(s) do
-    # Everything happens in the type_params.
+    # Everything happens in the type_and_params.
     # We still need to do something here, because otherwise 
     # we get an error. TODO: Make this better!
   end
@@ -768,7 +768,7 @@ end
 
 @register_serialization_type MPolyComplementOfKPointIdeal uses_id
 
-type_params(U::T) where {T<:MPolyComplementOfKPointIdeal} = TypeParams(T, ring(U))
+type_and_params(U::T) where {T<:MPolyComplementOfKPointIdeal} = TypeParams(T, ring(U))
 
 function save_object(s::SerializerState, U::MPolyComplementOfKPointIdeal)
   save_object(s, point_coordinates(U))
@@ -785,7 +785,7 @@ end
 
 @register_serialization_type MPolyLocalizedRingHom uses_id
 
-type_params(phi::T) where {T<:MPolyLocalizedRingHom} = TypeParams(T, :domain=>domain(phi), :codomain=>codomain(phi), :restricted_map_params=>type_params(restricted_map(phi)))
+type_and_params(phi::T) where {T<:MPolyLocalizedRingHom} = TypeParams(T, :domain=>domain(phi), :codomain=>codomain(phi), :restricted_map_params=>type_and_params(restricted_map(phi)))
 
 function save_object(s::SerializerState, phi::MPolyLocalizedRingHom)
   save_object(s, restricted_map(phi))
@@ -801,7 +801,7 @@ end
 
 @register_serialization_type MPolyQuoLocalizedRingHom uses_id
 
-type_params(phi::T) where {T<:MPolyQuoLocalizedRingHom} = TypeParams(T, :domain=>domain(phi), :codomain=>codomain(phi), :restricted_map_params=>type_params(restricted_map(phi)))
+type_and_params(phi::T) where {T<:MPolyQuoLocalizedRingHom} = TypeParams(T, :domain=>domain(phi), :codomain=>codomain(phi), :restricted_map_params=>type_and_params(restricted_map(phi)))
 
 function save_object(s::SerializerState, phi::MPolyQuoLocalizedRingHom)
   save_object(s, restricted_map(phi))

--- a/src/Serialization/Rings.jl
+++ b/src/Serialization/Rings.jl
@@ -30,16 +30,16 @@ const LaurentUnionType = Union{Generic.LaurentSeriesRing,
 # type_and_params functions
 
 # element types by default use their parent as reference object
-type_and_params(x::T) where T <: SetElem = TypeParams(T, parent(x))
-type_and_params(x::T) where T <: SMat = TypeParams(T, parent(x))
+type_and_params(x::T) where T <: SetElem = TypeAndParams(T, parent(x))
+type_and_params(x::T) where T <: SMat = TypeAndParams(T, parent(x))
 
 # rings, groups etc. default have no reference object
-type_and_params(R::T) where T <: AbstractAlgebra.Set = TypeParams(T, nothing)
+type_and_params(R::T) where T <: AbstractAlgebra.Set = TypeAndParams(T, nothing)
 
 # ideals and matrix spaces have their base ring as reference object
-type_and_params(x::T) where T <: Ideal = TypeParams(T, base_ring(x))
-type_and_params(x::T) where T <: MatSpace = TypeParams(T, base_ring(x))
-type_and_params(x::T) where T <: SMatSpace = TypeParams(T, base_ring(x))
+type_and_params(x::T) where T <: Ideal = TypeAndParams(T, base_ring(x))
+type_and_params(x::T) where T <: MatSpace = TypeAndParams(T, base_ring(x))
+type_and_params(x::T) where T <: SMatSpace = TypeAndParams(T, base_ring(x))
 
 
 ################################################################################
@@ -88,7 +88,7 @@ end
 @register_serialization_type AbstractAlgebra.Generic.LaurentMPolyWrapRing uses_id
 
 # polynomial-like rings use their coefficient ring as reference object
-type_and_params(R::T) where T <: PolyRingUnionType = TypeParams(T, coefficient_ring(R))
+type_and_params(R::T) where T <: PolyRingUnionType = TypeAndParams(T, coefficient_ring(R))
 
 function save_object(s::SerializerState, R::PolyRingUnionType)
   save_data_dict(s) do
@@ -117,7 +117,7 @@ function load_object(s::DeserializerState, ::Type{<:AbstractAlgebra.Generic.Laur
 end
 
 # with grading
-type_and_params(R::MPolyDecRing) = TypeParams(
+type_and_params(R::MPolyDecRing) = TypeAndParams(
   MPolyDecRing,
   :grading_group => grading_group(R),
   :ring => forget_grading(R),
@@ -277,10 +277,10 @@ end
 
 @register_serialization_type IdealGens
 
-type_and_params(ig::IdealGens) = TypeParams(
+type_and_params(ig::IdealGens) = TypeAndParams(
   IdealGens,
   :base_ring => base_ring(ig),
-  :ordering_type => TypeParams(typeof(ordering(ig)), nothing)
+  :ordering_type => TypeAndParams(typeof(ordering(ig)), nothing)
 )
 
 function save_object(s::SerializerState, obj::IdealGens)
@@ -389,7 +389,7 @@ end
 # Power Series
 @register_serialization_type SeriesRing uses_id
 
-type_and_params(R::T) where T <: SeriesRing = TypeParams(T, base_ring(R))
+type_and_params(R::T) where T <: SeriesRing = TypeAndParams(T, base_ring(R))
 
 function save_object(s::SerializerState, R::RelPowerSeriesUnionType)
   save_data_dict(s) do
@@ -509,7 +509,7 @@ end
 @register_serialization_type Generic.LaurentSeriesField "LaurentSeriesField" uses_id
 @register_serialization_type ZZLaurentSeriesRing uses_id
 
-type_and_params(R::T) where T <: LaurentUnionType = TypeParams(T, base_ring(R))
+type_and_params(R::T) where T <: LaurentUnionType = TypeAndParams(T, base_ring(R))
 
 function save_object(s::SerializerState, R::LaurentUnionType)
   save_data_dict(s) do
@@ -593,7 +593,7 @@ end
 ### Affine algebras
 @register_serialization_type MPolyQuoRing uses_id
 
-type_and_params(A::MPolyQuoRing) = TypeParams(
+type_and_params(A::MPolyQuoRing) = TypeAndParams(
   MPolyQuoRing,
   :base_ring => base_ring(A),
   :ordering => typeof(ordering(A))
@@ -671,7 +671,7 @@ end
 # localizations of polynomial rings
 @register_serialization_type MPolyPowersOfElement uses_id
 
-type_and_params(U::T) where T <: MPolyPowersOfElement = TypeParams(T, ring(U))
+type_and_params(U::T) where T <: MPolyPowersOfElement = TypeAndParams(T, ring(U))
 
 function save_object(s::SerializerState, U::MPolyPowersOfElement)
   save_object(s, denominators(U))
@@ -685,7 +685,7 @@ end
 
 @register_serialization_type MPolyComplementOfPrimeIdeal uses_id
 
-type_and_params(U::MPolyComplementOfPrimeIdeal) = TypeParams(typeof(U), ring(U))
+type_and_params(U::MPolyComplementOfPrimeIdeal) = TypeAndParams(typeof(U), ring(U))
 
 function save_object(s::SerializerState, U::MPolyComplementOfPrimeIdeal)
   save_object(s, prime_ideal(U))
@@ -698,7 +698,7 @@ end
 
 @register_serialization_type MPolyLocRing uses_id
 
-type_and_params(W::T) where {T <: MPolyLocRing} = TypeParams(T, :base_ring => base_ring(W), :mult_set_type => TypeParams(typeof(inverted_set(W)), nothing)) # TODO: make this neater!
+type_and_params(W::T) where {T <: MPolyLocRing} = TypeAndParams(T, :base_ring => base_ring(W), :mult_set_type => TypeAndParams(typeof(inverted_set(W)), nothing)) # TODO: make this neater!
 
 function save_object(s::SerializerState, L::MPolyLocRing)
   save_object(s, inverted_set(L))
@@ -735,7 +735,7 @@ end
 
 @register_serialization_type MPolyQuoLocRing uses_id
 
-type_and_params(L::T) where {T <: MPolyQuoLocRing} = TypeParams(T, :base_ring=>base_ring(L), :loc_ring=>localized_ring(L), :quo_ring=>underlying_quotient(L))
+type_and_params(L::T) where {T <: MPolyQuoLocRing} = TypeAndParams(T, :base_ring=>base_ring(L), :loc_ring=>localized_ring(L), :quo_ring=>underlying_quotient(L))
 
 function save_object(s::SerializerState, L::MPolyQuoLocRing)
   save_data_dict(s) do
@@ -768,7 +768,7 @@ end
 
 @register_serialization_type MPolyComplementOfKPointIdeal uses_id
 
-type_and_params(U::T) where {T<:MPolyComplementOfKPointIdeal} = TypeParams(T, ring(U))
+type_and_params(U::T) where {T<:MPolyComplementOfKPointIdeal} = TypeAndParams(T, ring(U))
 
 function save_object(s::SerializerState, U::MPolyComplementOfKPointIdeal)
   save_object(s, point_coordinates(U))
@@ -785,7 +785,7 @@ end
 
 @register_serialization_type MPolyLocalizedRingHom uses_id
 
-type_and_params(phi::T) where {T<:MPolyLocalizedRingHom} = TypeParams(T, :domain=>domain(phi), :codomain=>codomain(phi), :restricted_map_params=>type_and_params(restricted_map(phi)))
+type_and_params(phi::T) where {T<:MPolyLocalizedRingHom} = TypeAndParams(T, :domain=>domain(phi), :codomain=>codomain(phi), :restricted_map_params=>type_and_params(restricted_map(phi)))
 
 function save_object(s::SerializerState, phi::MPolyLocalizedRingHom)
   save_object(s, restricted_map(phi))
@@ -801,7 +801,7 @@ end
 
 @register_serialization_type MPolyQuoLocalizedRingHom uses_id
 
-type_and_params(phi::T) where {T<:MPolyQuoLocalizedRingHom} = TypeParams(T, :domain=>domain(phi), :codomain=>codomain(phi), :restricted_map_params=>type_and_params(restricted_map(phi)))
+type_and_params(phi::T) where {T<:MPolyQuoLocalizedRingHom} = TypeAndParams(T, :domain=>domain(phi), :codomain=>codomain(phi), :restricted_map_params=>type_and_params(restricted_map(phi)))
 
 function save_object(s::SerializerState, phi::MPolyQuoLocalizedRingHom)
   save_object(s, restricted_map(phi))

--- a/src/Serialization/ToricGeometry.jl
+++ b/src/Serialization/ToricGeometry.jl
@@ -28,7 +28,7 @@ end
 # Torus invariant divisors on toric varieties
 @register_serialization_type ToricDivisor
 
-type_and_params(obj::ToricDivisor) = TypeParams(ToricDivisor, toric_variety(obj))
+type_and_params(obj::ToricDivisor) = TypeAndParams(ToricDivisor, toric_variety(obj))
 
 function save_object(s::SerializerState, td::ToricDivisor)
   save_object(s, td.coeffs)
@@ -52,7 +52,7 @@ end
 # Torus invariant divisor classes on toric varieties
 @register_serialization_type ToricDivisorClass
 
-type_and_params(obj::ToricDivisorClass) = TypeParams(ToricDivisorClass, toric_variety(obj))
+type_and_params(obj::ToricDivisorClass) = TypeAndParams(ToricDivisorClass, toric_variety(obj))
 
 function save_object(s::SerializerState, tdc::ToricDivisorClass)
   save_object(s, toric_divisor(tdc).coeffs)

--- a/src/Serialization/ToricGeometry.jl
+++ b/src/Serialization/ToricGeometry.jl
@@ -28,7 +28,7 @@ end
 # Torus invariant divisors on toric varieties
 @register_serialization_type ToricDivisor
 
-type_params(obj::ToricDivisor) = TypeParams(ToricDivisor, toric_variety(obj))
+type_and_params(obj::ToricDivisor) = TypeParams(ToricDivisor, toric_variety(obj))
 
 function save_object(s::SerializerState, td::ToricDivisor)
   save_object(s, td.coeffs)
@@ -52,7 +52,7 @@ end
 # Torus invariant divisor classes on toric varieties
 @register_serialization_type ToricDivisorClass
 
-type_params(obj::ToricDivisorClass) = TypeParams(ToricDivisorClass, toric_variety(obj))
+type_and_params(obj::ToricDivisorClass) = TypeParams(ToricDivisorClass, toric_variety(obj))
 
 function save_object(s::SerializerState, tdc::ToricDivisorClass)
   save_object(s, toric_divisor(tdc).coeffs)
@@ -76,7 +76,7 @@ end
 # Cohomology classes on toric varieties
 @register_serialization_type CohomologyClass
 
-type_params(obj::CohomologyClass) = TypeParams(CohomologyClass, toric_variety(obj))
+type_and_params(obj::CohomologyClass) = TypeAndParams(CohomologyClass, toric_variety(obj))
 
 function save_object(s::SerializerState, cc::CohomologyClass)
   save_object(s, lift(polynomial(cc)))

--- a/src/Serialization/TropicalGeometry.jl
+++ b/src/Serialization/TropicalGeometry.jl
@@ -5,7 +5,7 @@
 ## elements
 @register_serialization_type TropicalSemiringElem
 
-type_params(obj::TropicalSemiringElem) = TypeParams(TropicalSemiringElem, parent(obj))
+type_and_params(obj::TropicalSemiringElem) = TypeParams(TropicalSemiringElem, parent(obj))
 
 function save_object(s::SerializerState, x::TropicalSemiringElem)
   str = string(x)
@@ -26,7 +26,7 @@ end
 # Tropical Hypersurfaces
 @register_serialization_type TropicalHypersurface
 
-type_params(t::T) where T <: TropicalHypersurface = TypeParams(T, parent(tropical_polynomial(t)))
+type_and_params(t::T) where T <: TropicalHypersurface = TypeParams(T, parent(tropical_polynomial(t)))
 
 function save_object(s::SerializerState, t::T) where T <: TropicalHypersurface
   save_object(s, tropical_polynomial(t))
@@ -41,10 +41,10 @@ end
 # Tropical Curves
 @register_serialization_type TropicalCurve uses_id
 
-type_params(t::TropicalCurve{M, true}) where M = TypeParams(TropicalCurve,
-                                                            params(type_params(polyhedral_complex(t))))
+type_and_params(t::TropicalCurve{M, true}) where M = TypeParams(TropicalCurve,
+                                                            params(type_and_params(polyhedral_complex(t))))
 # here to handle weird edge case
-type_params(t::TropicalCurve{M, false}) where M = TypeParams(TropicalCurve, "graph")
+type_and_params(t::TropicalCurve{M, false}) where M = TypeAndParams(TropicalCurve, "graph")
 
 function save_object(s::SerializerState, t::TropicalCurve{M, EMB}) where {M, EMB}
   save_data_dict(s) do

--- a/src/Serialization/TropicalGeometry.jl
+++ b/src/Serialization/TropicalGeometry.jl
@@ -5,7 +5,7 @@
 ## elements
 @register_serialization_type TropicalSemiringElem
 
-type_and_params(obj::TropicalSemiringElem) = TypeParams(TropicalSemiringElem, parent(obj))
+type_and_params(obj::TropicalSemiringElem) = TypeAndParams(TropicalSemiringElem, parent(obj))
 
 function save_object(s::SerializerState, x::TropicalSemiringElem)
   str = string(x)
@@ -26,7 +26,7 @@ end
 # Tropical Hypersurfaces
 @register_serialization_type TropicalHypersurface
 
-type_and_params(t::T) where T <: TropicalHypersurface = TypeParams(T, parent(tropical_polynomial(t)))
+type_and_params(t::T) where T <: TropicalHypersurface = TypeAndParams(T, parent(tropical_polynomial(t)))
 
 function save_object(s::SerializerState, t::T) where T <: TropicalHypersurface
   save_object(s, tropical_polynomial(t))
@@ -41,7 +41,7 @@ end
 # Tropical Curves
 @register_serialization_type TropicalCurve uses_id
 
-type_and_params(t::TropicalCurve{M, true}) where M = TypeParams(TropicalCurve,
+type_and_params(t::TropicalCurve{M, true}) where M = TypeAndParams(TropicalCurve,
                                                             params(type_and_params(polyhedral_complex(t))))
 # here to handle weird edge case
 type_and_params(t::TropicalCurve{M, false}) where M = TypeAndParams(TropicalCurve, "graph")

--- a/src/Serialization/containers.jl
+++ b/src/Serialization/containers.jl
@@ -2,21 +2,21 @@ const MatVecType{T} = Union{Matrix{T}, Vector{T}, SRow{T}} where T
 const ContainerTypes = Union{MatVecType, Set, Dict, Tuple, NamedTuple, Array}
 
 # handle Vector and Matrix instances, i.e. Array instances with 1 or 2 dimensions
-function type_params(obj::S) where {T, S <: MatVecType{T}}
+function type_and_params(obj::S) where {T, S <: MatVecType{T}}
   isempty(obj) && return TypeParams(S, TypeParams(T, nothing))
   
-  params = type_params.(obj)
+  params = type_and_params.(obj)
   @req allequal(params) "Not all params of the entries are the same, consider using a Tuple for serialization"
   return TypeParams(S, params[1])
 end
 
 # handle Array instances with >= 3 dimensions
-function type_params(obj::S) where {N, T, S <: Array{T, N}}
-  isempty(obj) && return TypeParams(S, :subtype_params => TypeParams(T, nothing), :dims => N)
+function type_and_params(obj::S) where {N, T, S <: Array{T, N}}
+  isempty(obj) && return TypeParams(S, :subtype_and_params => TypeParams(T, nothing), :dims => N)
   
-  params = type_params.(obj)
+  params = type_and_params.(obj)
   @req allequal(params) "Not all params of the entries are the same, consider using a Tuple for serialization"
-  return TypeParams(S, :subtype_params => params[1], :dims => N)
+  return TypeParams(S, :subtype_and_params => params[1], :dims => N)
 end
 
 has_empty_entries(obj) = false
@@ -24,21 +24,21 @@ has_empty_entries(obj) = false
 has_empty_entries(obj::ContainerTypes) = isempty(obj) || any(has_empty_entries, obj)
 
 # handle Vector and Matrix instances containing other containers
-function type_params(obj::S) where {T <: ContainerTypes, S <: MatVecType{T}}
+function type_and_params(obj::S) where {T <: ContainerTypes, S <: MatVecType{T}}
   isempty(obj) && return TypeParams(S, TypeParams(T, nothing))
 
   # empty entries can inherit params from the rest of the collection
   non_empty_entries = filter(!has_empty_entries, obj)
-  params = type_params.(non_empty_entries)
+  params = type_and_params.(non_empty_entries)
   @req allequal(params) "Not all params of the entries are the same, consider using a Tuple for serialization"
 
   # need to check if any of the inner containers are non empty, and if there is at least one
   # then we can use that one to get the type for the entire nested container
-  isempty(params) && return TypeParams(S, type_params(first(obj)))
+  isempty(params) && return TypeParams(S, type_and_params(first(obj)))
   return TypeParams(S, params[1])
 end
 
-function save_type_params(s::SerializerState,
+function save_type_and_params(s::SerializerState,
                           tp::TypeParams{T, <:Tuple{Vararg{Pair}}}) where {S, N,  T <: Array{S, N}}
   save_data_dict(s) do
     save_object(s, encode_type(T), :name)
@@ -47,7 +47,7 @@ function save_type_params(s::SerializerState,
         if k == :dims
           save_object(s, v, k)
         else
-          save_type_params(s, v, k)
+          save_type_and_params(s, v, k)
         end
       end
     end
@@ -55,19 +55,19 @@ function save_type_params(s::SerializerState,
 end
 
 # this function is forced to deal with all array types
-function load_type_params(s::DeserializerState, T::Type{<: Union{Array, MatVecType}})
+function load_type_and_params(s::DeserializerState, T::Type{<: Union{Array, MatVecType}})
   !haskey(s, :params) && return T, nothing
   subtype, params = load_node(s, :params) do _
     if haskey(s, :dims)
-      U = load_node(s, :subtype_params) do _
+      U = load_node(s, :subtype_and_params) do _
         return decode_type(s)
       end
        
       dims = load_object(s, Int, :dims)
-      subtype, params = load_type_params(s, U, :subtype_params)
+      subtype, params = load_type_and_params(s, U, :subtype_and_params)
       return T{subtype, dims}, params
     else
-      subtype, params = load_type_params(s, decode_type(s))
+      subtype, params = load_type_and_params(s, decode_type(s))
       return T{subtype}, params
     end
   end
@@ -87,7 +87,7 @@ end
 # Saving and loading vectors
 @register_serialization_type Vector
 
-# see Array above for load_type_params for general Arrays which include Matrix
+# see Array above for load_type_and_params for general Arrays which include Matrix
 # and Vector
 
 function save_object(s::SerializerState, x::AbstractVector{S}) where S
@@ -233,26 +233,26 @@ end
 # Saving and loading Tuple
 @register_serialization_type Tuple
 
-function type_params(obj::T) where T <: Tuple
-  return TypeParams(T, type_params.(obj))
+function type_and_params(obj::T) where T <: Tuple
+  return TypeParams(T, type_and_params.(obj))
 end
 
-function save_type_params(s::SerializerState, tp::TypeParams{T}) where T <: Tuple
+function save_type_and_params(s::SerializerState, tp::TypeParams{T}) where T <: Tuple
   save_data_dict(s) do
     save_object(s, encode_type(T), :name)
     save_data_array(s, :params) do
       for (i, param_tp) in enumerate(params(tp))
-        save_type_params(s, param_tp)
+        save_type_and_params(s, param_tp)
       end
     end
   end
 end
 
-function load_type_params(s::DeserializerState, T::Type{Tuple})
+function load_type_and_params(s::DeserializerState, T::Type{Tuple})
   !haskey(s, :params) && return T{}, nothing
   subtype, params = load_node(s, :params) do _
     tuple_params = load_array_node(s) do _
-      load_type_params(s, decode_type(s))
+      load_type_and_params(s, decode_type(s))
     end
     return Tuple([x[1] for x in tuple_params]), Tuple(x[2] for x in tuple_params)
   end
@@ -296,15 +296,15 @@ end
 # Saving and loading NamedTuple
 @register_serialization_type NamedTuple
 
-function type_params(obj::T) where T <: NamedTuple
+function type_and_params(obj::T) where T <: NamedTuple
   return TypeParams(
     T, 
-    NamedTuple(x.first => type_params(x.second) for x in pairs(obj))
+    NamedTuple(x.first => type_and_params(x.second) for x in pairs(obj))
   )
 end
 
 # Named Tuples need to preserve order so they are handled separate from Dict
-function save_type_params(s::SerializerState, tp::TypeParams{<:NamedTuple})
+function save_type_and_params(s::SerializerState, tp::TypeParams{<:NamedTuple})
   T = type(tp)
   save_data_dict(s) do
     save_object(s, encode_type(T), :name)
@@ -316,17 +316,17 @@ function save_type_params(s::SerializerState, tp::TypeParams{<:NamedTuple})
       end
       save_data_array(s, :tuple_params) do
         for (i, param_tp) in enumerate(values(params(tp)))
-          save_type_params(s, param_tp)
+          save_type_and_params(s, param_tp)
         end
       end
     end
   end
 end
 
-function load_type_params(s::DeserializerState, T::Type{NamedTuple})
+function load_type_and_params(s::DeserializerState, T::Type{NamedTuple})
   subtype, params = load_node(s, :params) do obj
     tuple_params = load_array_node(s, :tuple_params) do _
-      load_type_params(s, decode_type(s))
+      load_type_and_params(s, decode_type(s))
     end
     tuple_types, named_tuple_params = collect(zip(tuple_params...))
     names = load_object(s, Vector{Symbol}, :names)
@@ -347,16 +347,16 @@ end
 # Saving and loading dicts
 @register_serialization_type Dict
 
-function type_params(obj::T) where {S <: Union{Symbol, Int, String},
+function type_and_params(obj::T) where {S <: Union{Symbol, Int, String},
                                     T <: Dict{S, Any}}
   return TypeParams(
     T,
     :key_params => TypeParams(S, nothing),
-    (x.first => type_params(x.second) for x in pairs(obj))...
+    (x.first => type_and_params(x.second) for x in pairs(obj))...
   )
 end
 
-function type_params(obj::T) where {U, S, T <: Dict{S, U}}
+function type_and_params(obj::T) where {U, S, T <: Dict{S, U}}
   if isempty(obj)
     return TypeParams(
       T,
@@ -364,10 +364,10 @@ function type_params(obj::T) where {U, S, T <: Dict{S, U}}
       :value_params => TypeParams(U, nothing)
     )
   end
-  key_params = Oscar.type_params.(collect(keys(obj)))
+  key_params = Oscar.type_and_params.(collect(keys(obj)))
   @req allequal(key_params) "Not all type parameters of keys in $obj are the same"
 
-  value_params = type_params.(collect(values(obj)))
+  value_params = type_and_params.(collect(values(obj)))
   @req allequal(value_params) "Not all type parameters of values in $obj are the same"
 
   return TypeParams(
@@ -377,7 +377,7 @@ function type_params(obj::T) where {U, S, T <: Dict{S, U}}
   )
 end
 
-function save_type_params(
+function save_type_and_params(
   s::SerializerState,
   tp::TypeParams{Dict{S, T}, <:Tuple{Vararg{Pair}}}) where {T, S <: Union{Symbol, Int, String}}
   save_data_dict(s) do
@@ -385,22 +385,22 @@ function save_type_params(
     save_data_dict(s, :params) do
       isempty(params(tp)) && save_object(s, encode_type(T), :value_params)
       for (k, param_tp) in params(tp)
-        save_type_params(s, param_tp, Symbol(k))
+        save_type_and_params(s, param_tp, Symbol(k))
       end
     end
   end
 end
 
-function load_type_params(s::DeserializerState, T::Type{Dict})
+function load_type_and_params(s::DeserializerState, T::Type{Dict})
   subtype, params = load_node(s, :params) do obj
     if haskey(s, :value_params)
       S, key_params = load_node(s, :key_params) do params
         params isa String && return decode_type(s), nothing
-        load_type_params(s, decode_type(s))
+        load_type_and_params(s, decode_type(s))
       end
 
       U, value_params = load_node(s, :value_params) do _
-        load_type_params(s, decode_type(s))
+        load_type_and_params(s, decode_type(s))
       end
 
       return (S, U), Dict(:key_params => key_params, :value_params => value_params)
@@ -414,7 +414,7 @@ function load_type_params(s::DeserializerState, T::Type{Dict})
         k == :key_params && continue
         key = S <: Integer ? parse(Int, string(k)) : S(k)
         params_dict[key] = load_node(s, k) do _
-          return load_type_params(s, decode_type(s))
+          return load_type_and_params(s, decode_type(s))
         end
         push!(value_types, params_dict[key][1])
       end
@@ -546,7 +546,7 @@ function load_object(s::DeserializerState,
       push!(value_types, typeof(v))
     end
     isempty(value_types) && return T()
-    value_params = type_params.(collect(values(dict)))
+    value_params = type_and_params.(collect(values(dict)))
     value_type = allequal(value_params) ? typejoin(unique(value_types)...) : Any
     return Dict{S, value_type}(dict)
   end
@@ -568,15 +568,15 @@ end
 # Saving and loading sets
 @register_serialization_type Set
 
-function type_params(obj::T) where {S, T <: Set{S}}
+function type_and_params(obj::T) where {S, T <: Set{S}}
   isempty(obj) && return TypeParams(T, TypeParams(S, nothing))
-  return TypeParams(T, type_params(first(obj)))
+  return TypeParams(T, type_and_params(first(obj)))
 end
 
-function load_type_params(s::DeserializerState, T::Type{<: Set})
+function load_type_and_params(s::DeserializerState, T::Type{<: Set})
   !haskey(s, :params) && return T, nothing
   subtype, params = load_node(s, :params) do _
-    subtype, params = load_type_params(s, decode_type(s))
+    subtype, params = load_type_and_params(s, decode_type(s))
   end
   return T{subtype}, params
 end

--- a/src/Serialization/containers.jl
+++ b/src/Serialization/containers.jl
@@ -12,11 +12,11 @@ end
 
 # handle Array instances with >= 3 dimensions
 function type_and_params(obj::S) where {N, T, S <: Array{T, N}}
-  isempty(obj) && return TypeAndParams(S, :subtype_and_params => TypeAndParams(T, nothing), :dims => N)
+  isempty(obj) && return TypeAndParams(S, :subtype_params => TypeAndParams(T, nothing), :dims => N)
   
   params = type_and_params.(obj)
   @req allequal(params) "Not all params of the entries are the same, consider using a Tuple for serialization"
-  return TypeAndParams(S, :subtype_and_params => params[1], :dims => N)
+  return TypeAndParams(S, :subtype_params => params[1], :dims => N)
 end
 
 has_empty_entries(obj) = false
@@ -59,12 +59,12 @@ function load_type_and_params(s::DeserializerState, T::Type{<: Union{Array, MatV
   !haskey(s, :params) && return T, nothing
   subtype, params = load_node(s, :params) do _
     if haskey(s, :dims)
-      U = load_node(s, :subtype_and_params) do _
+      U = load_node(s, :subtype_params) do _
         return decode_type(s)
       end
        
       dims = load_object(s, Int, :dims)
-      subtype, params = load_type_and_params(s, U, :subtype_and_params)
+      subtype, params = load_type_and_params(s, U, :subtype_params)
       return T{subtype, dims}, params
     else
       subtype, params = load_type_and_params(s, decode_type(s))

--- a/src/Serialization/containers.jl
+++ b/src/Serialization/containers.jl
@@ -3,20 +3,20 @@ const ContainerTypes = Union{MatVecType, Set, Dict, Tuple, NamedTuple, Array}
 
 # handle Vector and Matrix instances, i.e. Array instances with 1 or 2 dimensions
 function type_and_params(obj::S) where {T, S <: MatVecType{T}}
-  isempty(obj) && return TypeParams(S, TypeParams(T, nothing))
+  isempty(obj) && return TypeAndParams(S, TypeAndParams(T, nothing))
   
   params = type_and_params.(obj)
   @req allequal(params) "Not all params of the entries are the same, consider using a Tuple for serialization"
-  return TypeParams(S, params[1])
+  return TypeAndParams(S, params[1])
 end
 
 # handle Array instances with >= 3 dimensions
 function type_and_params(obj::S) where {N, T, S <: Array{T, N}}
-  isempty(obj) && return TypeParams(S, :subtype_and_params => TypeParams(T, nothing), :dims => N)
+  isempty(obj) && return TypeAndParams(S, :subtype_and_params => TypeAndParams(T, nothing), :dims => N)
   
   params = type_and_params.(obj)
   @req allequal(params) "Not all params of the entries are the same, consider using a Tuple for serialization"
-  return TypeParams(S, :subtype_and_params => params[1], :dims => N)
+  return TypeAndParams(S, :subtype_and_params => params[1], :dims => N)
 end
 
 has_empty_entries(obj) = false
@@ -25,7 +25,7 @@ has_empty_entries(obj::ContainerTypes) = isempty(obj) || any(has_empty_entries, 
 
 # handle Vector and Matrix instances containing other containers
 function type_and_params(obj::S) where {T <: ContainerTypes, S <: MatVecType{T}}
-  isempty(obj) && return TypeParams(S, TypeParams(T, nothing))
+  isempty(obj) && return TypeAndParams(S, TypeAndParams(T, nothing))
 
   # empty entries can inherit params from the rest of the collection
   non_empty_entries = filter(!has_empty_entries, obj)
@@ -34,12 +34,12 @@ function type_and_params(obj::S) where {T <: ContainerTypes, S <: MatVecType{T}}
 
   # need to check if any of the inner containers are non empty, and if there is at least one
   # then we can use that one to get the type for the entire nested container
-  isempty(params) && return TypeParams(S, type_and_params(first(obj)))
-  return TypeParams(S, params[1])
+  isempty(params) && return TypeAndParams(S, type_and_params(first(obj)))
+  return TypeAndParams(S, params[1])
 end
 
 function save_type_and_params(s::SerializerState,
-                          tp::TypeParams{T, <:Tuple{Vararg{Pair}}}) where {S, N,  T <: Array{S, N}}
+                          tp::TypeAndParams{T, <:Tuple{Vararg{Pair}}}) where {S, N,  T <: Array{S, N}}
   save_data_dict(s) do
     save_object(s, encode_type(T), :name)
     save_data_dict(s, :params) do
@@ -234,10 +234,10 @@ end
 @register_serialization_type Tuple
 
 function type_and_params(obj::T) where T <: Tuple
-  return TypeParams(T, type_and_params.(obj))
+  return TypeAndParams(T, type_and_params.(obj))
 end
 
-function save_type_and_params(s::SerializerState, tp::TypeParams{T}) where T <: Tuple
+function save_type_and_params(s::SerializerState, tp::TypeAndParams{T}) where T <: Tuple
   save_data_dict(s) do
     save_object(s, encode_type(T), :name)
     save_data_array(s, :params) do
@@ -297,14 +297,14 @@ end
 @register_serialization_type NamedTuple
 
 function type_and_params(obj::T) where T <: NamedTuple
-  return TypeParams(
+  return TypeAndParams(
     T, 
     NamedTuple(x.first => type_and_params(x.second) for x in pairs(obj))
   )
 end
 
 # Named Tuples need to preserve order so they are handled separate from Dict
-function save_type_and_params(s::SerializerState, tp::TypeParams{<:NamedTuple})
+function save_type_and_params(s::SerializerState, tp::TypeAndParams{<:NamedTuple})
   T = type(tp)
   save_data_dict(s) do
     save_object(s, encode_type(T), :name)
@@ -349,19 +349,19 @@ end
 
 function type_and_params(obj::T) where {S <: Union{Symbol, Int, String},
                                     T <: Dict{S, Any}}
-  return TypeParams(
+  return TypeAndParams(
     T,
-    :key_params => TypeParams(S, nothing),
+    :key_params => TypeAndParams(S, nothing),
     (x.first => type_and_params(x.second) for x in pairs(obj))...
   )
 end
 
 function type_and_params(obj::T) where {U, S, T <: Dict{S, U}}
   if isempty(obj)
-    return TypeParams(
+    return TypeAndParams(
       T,
-      :key_params => TypeParams(S, nothing),
-      :value_params => TypeParams(U, nothing)
+      :key_params => TypeAndParams(S, nothing),
+      :value_params => TypeAndParams(U, nothing)
     )
   end
   key_params = Oscar.type_and_params.(collect(keys(obj)))
@@ -370,7 +370,7 @@ function type_and_params(obj::T) where {U, S, T <: Dict{S, U}}
   value_params = type_and_params.(collect(values(obj)))
   @req allequal(value_params) "Not all type parameters of values in $obj are the same"
 
-  return TypeParams(
+  return TypeAndParams(
     T, 
     :key_params => first(key_params),
     :value_params => first(value_params),
@@ -379,7 +379,7 @@ end
 
 function save_type_and_params(
   s::SerializerState,
-  tp::TypeParams{Dict{S, T}, <:Tuple{Vararg{Pair}}}) where {T, S <: Union{Symbol, Int, String}}
+  tp::TypeAndParams{Dict{S, T}, <:Tuple{Vararg{Pair}}}) where {T, S <: Union{Symbol, Int, String}}
   save_data_dict(s) do
     save_object(s, encode_type(Dict), :name)
     save_data_dict(s, :params) do
@@ -569,8 +569,8 @@ end
 @register_serialization_type Set
 
 function type_and_params(obj::T) where {S, T <: Set{S}}
-  isempty(obj) && return TypeParams(T, TypeParams(S, nothing))
-  return TypeParams(T, type_and_params(first(obj)))
+  isempty(obj) && return TypeAndParams(T, TypeAndParams(S, nothing))
+  return TypeAndParams(T, type_and_params(first(obj)))
 end
 
 function load_type_and_params(s::DeserializerState, T::Type{<: Set})

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -937,7 +937,7 @@ _convert_override_params(tp::TypeAndParams{T, <:Tuple{Vararg{Pair}}}) where T = 
 _convert_override_params(tp::TypeAndParams{T, S}) where {T <: MatVecType, S} = _convert_override_params(params(tp))
 _convert_override_params(tp::TypeAndParams{T, S}) where {T <: Set, S} = _convert_override_params(params(tp))
 _convert_override_params(tp::TypeAndParams{<: NamedTuple, S}) where S = _convert_override_params(values(params(tp)))
-_convert_override_params(tp::TypeAndParams{<:Array, <:Tuple{Vararg{Pair}}}) = Dict(_convert_override_params(params(tp)))[:subtype_and_params]
+_convert_override_params(tp::TypeAndParams{<:Array, <:Tuple{Vararg{Pair}}}) = Dict(_convert_override_params(params(tp)))[:subtype_params]
 
 function _convert_override_params(tp::TypeAndParams{Dict{S, Any}, <:Tuple{Vararg{Pair}}}) where S <: Union{Int, Symbol, String}
   return Dict(k => (type(v), _convert_override_params(v)) for (k, v) in params(tp))

--- a/src/Serialization/main.jl
+++ b/src/Serialization/main.jl
@@ -170,12 +170,12 @@ function decode_type(s::DeserializerState)
 end
 
 ################################################################################
-# TypeParams Struct
-struct TypeParams{T, S}
+# TypeAndParams Struct
+struct TypeAndParams{T, S}
   type::Type{T}
   params::S
 
-  function TypeParams(T::Type, params)
+  function TypeAndParams(T::Type, params)
     if Base.issingletontype(T)
       return new{T, Nothing}(T, nothing)
     else
@@ -184,14 +184,14 @@ struct TypeParams{T, S}
   end
 end
 
-TypeParams(T::Type, args::Pair...) = TypeParams(T, args)
+TypeAndParams(T::Type, args::Pair...) = TypeAndParams(T, args)
 
-params(tp::TypeParams) = tp.params
-type(tp::TypeParams) = tp.type
+params(tp::TypeAndParams) = tp.params
+type(tp::TypeAndParams) = tp.type
 
-type_params(obj::T) where T = TypeParams(T, nothing)
+type_and_params(obj::T) where T = TypeAndParams(T, nothing)
 
-function Base.show(io::IO, tp::TypeParams{T, Tuple}) where T
+function Base.show(io::IO, tp::TypeAndParams{T, Tuple}) where T
   if is_terse(io)
     print(io, "Type parameters for $T")
   else
@@ -204,7 +204,7 @@ function Base.show(io::IO, tp::TypeParams{T, Tuple}) where T
   end
 end
 
-function Base.show(io::IO, tp::TypeParams{T, S}) where {T, S}
+function Base.show(io::IO, tp::TypeAndParams{T, S}) where {T, S}
   if is_terse(io)
     print(io, "Type parameters for $T")
   else
@@ -247,7 +247,7 @@ function save_typed_object(s::SerializerState, x::T) where T
   if Base.issingletontype(T)
     save_object(s, encode_type(T), type_key)
   else
-    save_type_params(s, x, type_key)
+    save_type_and_params(s, x, type_key)
     save_object(s, x, :data)
   end
   if with_attrs(s)
@@ -270,18 +270,18 @@ function save_typed_object(s::SerializerState, x::T, key::Symbol) where T
 end
 
 ################################################################################
-# (save | load) TypeParams
+# (save | load) TypeAndParams
 
-function save_type_params(s::SerializerState, obj::Any, key::Symbol)
+function save_type_and_params(s::SerializerState, obj::Any, key::Symbol)
   set_key(s, key)
-  save_type_params(s, obj)
+  save_type_and_params(s, obj)
 end
 
-function save_type_params(s::SerializerState, obj::T) where T
-  save_type_params(s, type_params(obj))
+function save_type_and_params(s::SerializerState, obj::T) where T
+  save_type_and_params(s, type_and_params(obj))
 end
 
-function save_type_params(s::SerializerState, tp::TypeParams)
+function save_type_and_params(s::SerializerState, tp::TypeAndParams)
   save_data_dict(s) do
     T = type(tp)
     type_encoding = encode_type(T)
@@ -291,17 +291,17 @@ function save_type_params(s::SerializerState, tp::TypeParams)
     
     save_object(s, type_encoding, :name)
 
-    # params(tp) isa TypeParams if the type isa container type
-    if params(tp) isa TypeParams
-      save_type_params(s, params(tp), :params)
+    # params(tp) isa TypeAndParams if the type isa container type
+    if params(tp) isa TypeAndParams
+      save_type_and_params(s, params(tp), :params)
     else
       save_typed_object(s, params(tp), :params)
     end
   end
 end
 
-function save_type_params(s::SerializerState,
-                          ::TypeParams{T, Nothing}) where T
+function save_type_and_params(s::SerializerState,
+                          ::TypeAndParams{T, Nothing}) where T
   type_encoding = encode_type(T)
   if reverse_type_map[type_encoding] isa Dict
     save_data_dict(s) do
@@ -313,31 +313,31 @@ function save_type_params(s::SerializerState,
   end
 end
 
-function save_type_params(s::SerializerState,
-                          tp::TypeParams{<:TypeParams, <:Tuple{Vararg{Pair}}})
+function save_type_and_params(s::SerializerState,
+                          tp::TypeAndParams{<:TypeAndParams, <:Tuple{Vararg{Pair}}})
   for param in params(tp)
-    save_type_params(s, param.second, Symbol(param.first))
+    save_type_and_params(s, param.second, Symbol(param.first))
   end
 end
 
-function save_type_params(s::SerializerState,
-                          tp::TypeParams{<:TypeParams, <:Tuple})
+function save_type_and_params(s::SerializerState,
+                          tp::TypeAndParams{<:TypeAndParams, <:Tuple})
   save_data_array(s) do 
     for param in params(tp)
-      save_type_params(s, param)
+      save_type_and_params(s, param)
     end
   end
 end
 
-function save_type_params(s::SerializerState,
-                          tp::TypeParams{T, <:Tuple{Vararg{Pair}}}) where T
+function save_type_and_params(s::SerializerState,
+                          tp::TypeAndParams{T, <:Tuple{Vararg{Pair}}}) where T
   save_data_dict(s) do
     save_object(s, encode_type(T), :name)
     save_data_dict(s, :params) do
       for param in params(tp)
         if param.second isa Type
           save_object(s, encode_type(param.second), Symbol(param.first))
-        elseif !(param.second isa TypeParams)
+        elseif !(param.second isa TypeAndParams)
           if param.second isa Tuple
             save_data_array(s, Symbol(param.first)) do
               for entry in param.second
@@ -354,16 +354,16 @@ function save_type_params(s::SerializerState,
             save_typed_object(s, param.second, Symbol(param.first))
           end
         else
-          save_type_params(s, param.second, Symbol(param.first))
+          save_type_and_params(s, param.second, Symbol(param.first))
         end
       end
     end
   end
 end
 
-function load_type_params(s::DeserializerState, T::Type, key::Symbol)
+function load_type_and_params(s::DeserializerState, T::Type, key::Symbol)
   load_node(s, key) do _
-    load_type_params(s, T)
+    load_type_and_params(s, T)
   end
 end
 
@@ -374,11 +374,11 @@ function load_type_array_params(s::DeserializerState)
       !isnothing(tryparse(UUID, s.obj)) && return load_ref(s)
       return T
     end
-    return load_type_params(s, T)[2]
+    return load_type_and_params(s, T)[2]
   end
 end
 
-function load_type_params(s::DeserializerState, T::Type)
+function load_type_and_params(s::DeserializerState, T::Type)
   if s.obj isa String
     if !isnothing(tryparse(UUID, s.obj))
       return T, load_ref(s)
@@ -394,9 +394,9 @@ function load_type_params(s::DeserializerState, T::Type)
         if Base.issingletontype(U)
           params = U()
         else
-          params = load_type_params(s, U)[2]
+          params = load_type_and_params(s, U)[2]
         end
-      # handle cases where type_params is a dict of params
+      # handle cases where type_and_params is a dict of params
       elseif !haskey(obj, type_key) 
         params = Dict{Symbol, Any}()
         for (k, _) in obj
@@ -409,7 +409,7 @@ function load_type_params(s::DeserializerState, T::Type)
             if obj isa String && isnothing(tryparse(UUID, obj))
               return U
             end
-            return load_type_params(s, U)[2]
+            return load_type_and_params(s, U)[2]
           end
         end
       else
@@ -437,11 +437,11 @@ end
 function load_typed_object(s::DeserializerState; override_params::Any = nothing)
   T = decode_type(s)
   if !isnothing(override_params)
-    T, _ = load_type_params(s, T, type_key)
+    T, _ = load_type_and_params(s, T, type_key)
     params = override_params
   else
     s.obj isa String && !isnothing(tryparse(UUID, s.obj)) && return load_ref(s)
-    T, params = load_type_params(s, T, type_key)
+    T, params = load_type_and_params(s, T, type_key)
   end
   Base.issingletontype(T) && return T()
   obj = load_node(s, :data) do _
@@ -868,7 +868,7 @@ function load(io::IO; params::Any = nothing, type::Any = nothing,
   end
   
   try
-    if params isa TypeParams
+    if params isa TypeAndParams
       params = _convert_override_params(params)
     end
     if type !== nothing
@@ -887,7 +887,7 @@ function load(io::IO; params::Any = nothing, type::Any = nothing,
       Base.issingletontype(type) && return type()
       if isnothing(params)
         _, params = load_node(s, type_key) do _
-          load_type_params(s, U)
+          load_type_and_params(s, U)
         end
       end
       load_node(s, :data) do _
@@ -932,14 +932,14 @@ function load(filename::String; kwargs...)
   end
 end
 
-_convert_override_params(tp::TypeParams{T, S}) where {T, S} = _convert_override_params(params(tp))
-_convert_override_params(tp::TypeParams{T, <:Tuple{Vararg{Pair}}}) where T = Dict(_convert_override_params(params(tp)))
-_convert_override_params(tp::TypeParams{T, S}) where {T <: MatVecType, S} = _convert_override_params(params(tp))
-_convert_override_params(tp::TypeParams{T, S}) where {T <: Set, S} = _convert_override_params(params(tp))
-_convert_override_params(tp::TypeParams{<: NamedTuple, S}) where S = _convert_override_params(values(params(tp)))
-_convert_override_params(tp::TypeParams{<:Array, <:Tuple{Vararg{Pair}}}) = Dict(_convert_override_params(params(tp)))[:subtype_params]
+_convert_override_params(tp::TypeAndParams{T, S}) where {T, S} = _convert_override_params(params(tp))
+_convert_override_params(tp::TypeAndParams{T, <:Tuple{Vararg{Pair}}}) where T = Dict(_convert_override_params(params(tp)))
+_convert_override_params(tp::TypeAndParams{T, S}) where {T <: MatVecType, S} = _convert_override_params(params(tp))
+_convert_override_params(tp::TypeAndParams{T, S}) where {T <: Set, S} = _convert_override_params(params(tp))
+_convert_override_params(tp::TypeAndParams{<: NamedTuple, S}) where S = _convert_override_params(values(params(tp)))
+_convert_override_params(tp::TypeAndParams{<:Array, <:Tuple{Vararg{Pair}}}) = Dict(_convert_override_params(params(tp)))[:subtype_and_params]
 
-function _convert_override_params(tp::TypeParams{Dict{S, Any}, <:Tuple{Vararg{Pair}}}) where S <: Union{Int, Symbol, String}
+function _convert_override_params(tp::TypeAndParams{Dict{S, Any}, <:Tuple{Vararg{Pair}}}) where S <: Union{Int, Symbol, String}
   return Dict(k => (type(v), _convert_override_params(v)) for (k, v) in params(tp))
 end
 
@@ -948,14 +948,14 @@ _convert_override_params(obj::Any) = obj
 #handles empty tuple ambiguity
 _convert_override_params(obj::Tuple{}) = ()
 
-_convert_override_params(t::Tuple{Vararg{TypeParams}}) = map(_convert_override_params, t)
+_convert_override_params(t::Tuple{Vararg{TypeAndParams}}) = map(_convert_override_params, t)
 
 function _convert_override_params(t::Tuple{Vararg{Pair}})
   map(x -> x.first => _convert_override_params(x.second), t)
 end
 
 # handle special polyhedral case
-function _convert_override_params(tp::TypeParams{<:PolyhedralObject, <:Tuple{Vararg{Pair}}})
+function _convert_override_params(tp::TypeAndParams{<:PolyhedralObject, <:Tuple{Vararg{Pair}}})
   # special treatement for the polymake parameters
   poly_params = Dict()
   for (k, v) in params(tp)
@@ -972,7 +972,7 @@ function _convert_override_params(tp::TypeParams{<:PolyhedralObject, <:Tuple{Var
 end
 
 # handle monomial ordering
-_convert_override_params(tp::TypeParams{T, S}) where {T <: MonomialOrdering, S} = T
+_convert_override_params(tp::TypeAndParams{T, S}) where {T <: MonomialOrdering, S} = T
 
 
 export @register_serialization_type
@@ -995,14 +995,14 @@ export save_object
 export SerializerState
 export serialize_with_id
 export set_key
-export TypeParams
-export type_params
+export TypeAndParams
+export type_and_params
 export with_attrs
 
 end # module Serialization
 
 using Oscar.Serialization
-import Oscar.Serialization: load_object, save_object, type_params
+import Oscar.Serialization: load_object, save_object, type_and_params
 import Oscar.Serialization: reset_global_serializer_state
 
 # FIXME: the following functions are exported by us but undocumented

--- a/src/Serialization/parallel.jl
+++ b/src/Serialization/parallel.jl
@@ -1,17 +1,17 @@
 # Method for end of recursion.
 # TODO: there is probably a way to stop the code from getting here that will speed up the code
-function put_type_and_params(channel::RemoteChannel, ::TypeParams{T, Nothing}) where T
+function put_type_and_params(channel::RemoteChannel, ::TypeAndParams{T, Nothing}) where T
   return
 end
 
 function put_type_and_params(channel::RemoteChannel,
-                         ::TypeParams{T, Tuple{Vararg{Pair{Symbol, Nothing}}}}) where T
+                         ::TypeAndParams{T, Tuple{Vararg{Pair{Symbol, Nothing}}}}) where T
   return
 end
 
 # Recursive call. Send all subsequent parents on which this object is 
 # based and finally the object itself, if applicable. 
-function put_type_and_params(channel::RemoteChannel, tp::TypeParams)
+function put_type_and_params(channel::RemoteChannel, tp::TypeAndParams)
   # only  types that use ids need to be sent to the other processes
   put_type_and_params(channel, params(tp))
 end
@@ -22,7 +22,7 @@ function put_type_and_params(channel::RemoteChannel, tps::Tuple{Vararg{Pair}})
   end
 end
 
-function put_type_and_params(channel::RemoteChannel, tps::Tuple{Vararg{TypeParams}})
+function put_type_and_params(channel::RemoteChannel, tps::Tuple{Vararg{TypeAndParams}})
   for tp in tps
     put_type_and_params(channel, params(tp))
   end

--- a/src/Serialization/parallel.jl
+++ b/src/Serialization/parallel.jl
@@ -1,39 +1,39 @@
 # Method for end of recursion.
 # TODO: there is probably a way to stop the code from getting here that will speed up the code
-function put_type_params(channel::RemoteChannel, ::TypeParams{T, Nothing}) where T
+function put_type_and_params(channel::RemoteChannel, ::TypeParams{T, Nothing}) where T
   return
 end
 
-function put_type_params(channel::RemoteChannel,
+function put_type_and_params(channel::RemoteChannel,
                          ::TypeParams{T, Tuple{Vararg{Pair{Symbol, Nothing}}}}) where T
   return
 end
 
 # Recursive call. Send all subsequent parents on which this object is 
 # based and finally the object itself, if applicable. 
-function put_type_params(channel::RemoteChannel, tp::TypeParams)
+function put_type_and_params(channel::RemoteChannel, tp::TypeParams)
   # only  types that use ids need to be sent to the other processes
-  put_type_params(channel, params(tp))
+  put_type_and_params(channel, params(tp))
 end
 
-function put_type_params(channel::RemoteChannel, tps::Tuple{Vararg{Pair}})
+function put_type_and_params(channel::RemoteChannel, tps::Tuple{Vararg{Pair}})
   for tp in tps
-    put_type_params(channel, tp.second)
+    put_type_and_params(channel, tp.second)
   end
 end
 
-function put_type_params(channel::RemoteChannel, tps::Tuple{Vararg{TypeParams}})
+function put_type_and_params(channel::RemoteChannel, tps::Tuple{Vararg{TypeParams}})
   for tp in tps
-    put_type_params(channel, params(tp))
+    put_type_and_params(channel, params(tp))
   end
 end
 
-function put_type_params(channel::RemoteChannel, obj::T) where T
+function put_type_and_params(channel::RemoteChannel, obj::T) where T
   # only  types that use ids need to be sent to the other processes
   if serialize_with_id(T)
-    put_type_params(channel, type_params(obj))
+    put_type_and_params(channel, type_and_params(obj))
     put!(channel, obj)
   else
-    put_type_params(channel, type_params(obj))
+    put_type_and_params(channel, type_and_params(obj))
   end
 end

--- a/src/Serialization/serializers.jl
+++ b/src/Serialization/serializers.jl
@@ -264,7 +264,7 @@ end
 
 function deserializer_open(io::IO, serializer::IPCSerializer, with_attrs::Bool) 
   # Using a JSON3.Object from JSON3 version 1.13.2 causes
-  # put_type_params to hang
+  # put_type_and_params to hang
   #obj = JSON3.read(io)
   str = readuntil(io, '}'; keep=true)
   while !JSON.isvalidjson(str)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -242,3 +242,4 @@ Base.@deprecate_binding ModuleFPElem_dec OFPModuleElem_dec
 Base.@deprecate_binding ModuleFPHomDummy OFPModuleHomDummy
 
 @deprecate Serialization.type_params Serialization.type_and_params
+@deprecate Serialization.TypeParams Serialization.TypeAndParams

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -242,6 +242,6 @@ Base.@deprecate_binding ModuleFPElem_dec OFPModuleElem_dec
 Base.@deprecate_binding ModuleFPHomDummy OFPModuleHomDummy
 
 @eval Serialization begin
-  @deprecate Serialization.type_params Serialization.type_and_params
-  Base.@deprecate_binding Serialization.TypeParams Serialization.TypeAndParams
+  @deprecate type_params type_and_params
+  Base.@deprecate_binding TypeParams TypeAndParams
 end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -242,4 +242,4 @@ Base.@deprecate_binding ModuleFPElem_dec OFPModuleElem_dec
 Base.@deprecate_binding ModuleFPHomDummy OFPModuleHomDummy
 
 @deprecate Serialization.type_params Serialization.type_and_params
-@deprecate Serialization.TypeParams Serialization.TypeAndParams
+Base.@deprecate_binding Serialization.TypeParams Serialization.TypeAndParams

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -241,5 +241,7 @@ Base.@deprecate_binding ModuleFP_dec OFPModule_dec
 Base.@deprecate_binding ModuleFPElem_dec OFPModuleElem_dec
 Base.@deprecate_binding ModuleFPHomDummy OFPModuleHomDummy
 
-@deprecate Serialization.type_params Serialization.type_and_params
-Base.@deprecate_binding Serialization.TypeParams Serialization.TypeAndParams
+@eval Serialization begin
+  @deprecate Serialization.type_params Serialization.type_and_params
+  Base.@deprecate_binding Serialization.TypeParams Serialization.TypeAndParams
+end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -240,3 +240,5 @@ Base.@deprecate_binding AdmissibleModuleFPRingElem AdmissibleOFPModuleRingElem
 Base.@deprecate_binding ModuleFP_dec OFPModule_dec
 Base.@deprecate_binding ModuleFPElem_dec OFPModuleElem_dec
 Base.@deprecate_binding ModuleFPHomDummy OFPModuleHomDummy
+
+@deprecate Serialization.type_params Serialization.type_and_params

--- a/test/Serialization/PolyhedralGeometry.jl
+++ b/test/Serialization/PolyhedralGeometry.jl
@@ -74,7 +74,7 @@ using Oscar: _integer_variables
       f_vector(d_hedron)
       lattice_points(d_hedron)
 
-      # this type needs to be any since the values have different type_params
+      # this type needs to be any since the values have different type_and_params
       dict_ps = Dict{String, Any}(
         "unprecise" => polyhedron(
           Polymake.common.convert_to{Float64}(Oscar.pm_object(d_hedron))

--- a/test/Serialization/PolynomialsSeries.jl
+++ b/test/Serialization/PolynomialsSeries.jl
@@ -108,7 +108,7 @@ cases = [
             end
 
             # need a cleaner way to setup type params in general
-            params = Dict(Oscar.Serialization.params(Oscar.type_params(gb))...)
+            params = Dict(Oscar.Serialization.params(Oscar.type_and_params(gb))...)
             params[:ordering_type] = Oscar.Serialization.type(params[:ordering_type])
             test_save_load_roundtrip(path, gb; params=params) do loaded_gb
               @test gens(gb) == gens(loaded_gb)

--- a/test/Serialization/setup_tests.jl
+++ b/test/Serialization/setup_tests.jl
@@ -60,10 +60,10 @@ if !isdefined(Main, :test_save_load_roundtrip) || isinteractive()
     loaded = load(filename; params=params, kw...)
     @test loaded isa T
 
-    # test passing TypeParams
+    # test passing TypeAndParams
     save(filename, original; kw...)
     Oscar.reset_global_serializer_state()
-    loaded = load(filename; params=Oscar.type_params(original), kw...)
+    loaded = load(filename; params=Oscar.type_and_params(original), kw...)
     @test loaded isa T
 
     # test schema


### PR DESCRIPTION
Renames `type_params` and `TypeParams`.

Resolves https://github.com/oscar-system/Oscar.jl/issues/5129.