### PR TITLE
Call `CodePcgs` not `CodePcGroup` in `encode(G::PcGroup)`

### DIFF
--- a/docs/oscar_references.bib
+++ b/docs/oscar_references.bib
@@ -240,6 +240,19 @@
   doi           = {10.1016/0001-8708(91)90034-5}
 }
 
+@Article{BE99,
+  author        = {Besche, Hans Ulrich and Eick, Bettina},
+  title         = {Construction of finite groups},
+  mrnumber      = {1681346},
+  journal       = {J. Symbolic Comput.},
+  fjournal      = {Journal of Symbolic Computation},
+  volume        = {27},
+  number        = {4},
+  pages         = {387--404},
+  year          = {1999},
+  doi           = {10.1006/jsco.1998.0258}
+}
+
 @Misc{BEO23,
   author        = {Besche, Hans Ulrich and Eick, Bettina and O'Brien, Eamonn},
   title         = {SmallGrp, The GAP Small Groups Library, Version 1.5.3},

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -54,6 +54,7 @@ GAP.@wrap ClassPositionsOfDerivedSubgroup(x::GapObj)::GapObj
 GAP.@wrap ClassPositionsOfNormalSubgroups(x::GapObj)::GapObj
 GAP.@wrap ClassPositionsOfPCore(x::GapObj, y::GAP.Obj)::GapObj
 GAP.@wrap ClassPositionsOfSolvableResiduum(x::GapObj)::GapObj
+GAP.@wrap CodePcgs(x::GapObj)::GAP.Obj
 GAP.@wrap Coefficients(x::Any, y::Any)::GapObj
 GAP.@wrap CoefficientsFamily(x::GapObj)::GapObj
 GAP.@wrap CoefficientsOfUnivariatePolynomial(x::GapObj)::GapObj

--- a/src/Groups/pcgroup.jl
+++ b/src/Groups/pcgroup.jl
@@ -933,6 +933,12 @@ Return a `ZZRingElem` representing the polycyclic group `G`,
 using the same encoding as GAP's `CodePcGroup` and Magma's `SmallGroupEncoding`.
 Currently only defined for `PcGroup`, not `SubPcGroup`.
 
+For `n = order(G)` and `code = encode(G)`,
+`pc_group(n, code)` returns a `PcGroup` with the same defining presentation
+as `G`.
+
+The encoding is described in [BE99](@cite), Section 3.3.
+
 # Examples
 ```jldoctest
 julia> G = small_group(12, 2)
@@ -949,14 +955,17 @@ true
 ```
 """
 function encode(G::PcGroup)
-  return ZZ(GAP.Globals.CodePcGroup(GapObj(G))::GapInt)
+  return ZZ(GAPWrap.CodePcgs(GAPWrap.FamilyPcgs(GapObj(G))))
 end
 
 """
-    pc_group(order::IntegerUnion, code::IntegerUnion)
+    pc_group(n::IntegerUnion, code::IntegerUnion)
 
-Given an integer `order` and an integer `code`, return the polycyclic group it encodes.
-The accepted codes and resulting groups match those of GAP's `PcGroupCode` and Magma's `SmallGroupDecoding`.
+Return the polycyclic group encoded by `n` and `code`,
+in the sense of [`encode`](@ref).
+
+The accepted codes and resulting groups match those of GAP's `PcGroupCode`
+and Magma's `SmallGroupDecoding`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
- Make sure that the *defining* pcgs of the `PcGroup` is used in `encode`.

  (Many pc groups in GAP do not store the attribute `Pcgs` by construction. When `Pcgs` is called, the method that fetches `FamilyPcgs` has a quite low rank, and it gets called only because of an explicit `TryNextMethod` in the method of highest rank.
I do not know an example where the previous code was actually wrong, but calling `CodePcgs` instead of `CodePcGroup` is safer.)

- Document where the `encode` algorithm is defined.