### PR TITLE
Change serialization format for subgroups of f.p. groups

### DIFF
--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -118,6 +118,7 @@ GAP.@wrap FieldOfMatrixGroup(x::GapObj)::GapObj
 GAP.@wrap Flat(x::GapObj)::GapObj
 GAP.@wrap FreeAbelianGroup(x::Int)::GapObj
 GAP.@wrap FreeGeneratorsOfFpGroup(x::GapObj)::GapObj
+GAP.@wrap FreeGroup(x::GapObj, y::GAP.Obj)::GapObj
 GAP.@wrap FreeGroupOfFpGroup(x::GapObj)::GapObj
 GAP.@wrap FusionCharTableTom(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap FusionConjugacyClasses(x::GapObj, y::GapObj)::GapObj

--- a/src/Serialization/Groups.jl
+++ b/src/Serialization/Groups.jl
@@ -126,17 +126,17 @@ end
 
 @register_serialization_type FPGroup uses_id
 
-function type_params(G::FPGroup)
+function type_and_params(G::FPGroup)
   F = free_group(G)
   if F === G
     # A full *free* group does not need type parameters.
-    return TypeParams(FPGroup, nothing)
+    return TypeAndParams(FPGroup, nothing)
   else
     # A group with relators needs the underlying free group
     # as a type parameter,
     # since the same free group object can be used for creating
     # several f.p. groups.
-    return TypeParams(FPGroup, F)
+    return TypeAndParams(FPGroup, F)
   end
 end
 
@@ -287,7 +287,7 @@ end
 
 function type_and_params(G::T) where T <: Union{SubFPGroup, SubPcGroup}
   # The subgroup needs a reference to its full group.
-  return TypeParams(T, G.full_group)
+  return TypeAndParams(T, G.full_group)
 end
 
 function save_object(s::SerializerState, G::SubFPGroup)

--- a/src/Serialization/Groups.jl
+++ b/src/Serialization/Groups.jl
@@ -2,7 +2,8 @@
 #
 # General ideas of the (de)serialization of groups and group elements:
 #
-# - Each `GAPGroupElem` object gets serialized together with its `parent`.
+# - Each `GAPGroupElem` object gets serialized together with its `parent`,
+#   via the `type_params(x::T)` method for `T <: SetElem`.
 #
 # - We request `uses_id` for the (de)serialization of group objects
 #   because parent references to the same group must point to the same object.
@@ -11,78 +12,38 @@
 #   deserializing the same group element twice may yield two nonidentical
 #   objects.
 #
-# - Not all subobjects of GAP objects get serialized, only the ones that are
+# - Not all subobjects of groups get serialized, only the ones that are
 #   needed to define the object.
-#   For example, we do not attempt to serialize the known properties and
+#   In particular, we do not attempt to serialize all known properties and
 #   attributes.
 #   (We may decide that some of them shall better get serialized because
 #   they are expensive to compute, such as finiteness and group order of
 #   finitely presented groups.)
-#   Moreover, some subobjects are intended just for "internal purposes".
-#   For example, a pc group in GAP stores (via its family object)
-#   a rewriting system in terms of elements of a free group.
-#   We do not serialize this information, it gets created anew when the
-#   pc group gets deserialized; this way, the original pc group and the
-#   deserialized one store nonidentical free group objects.
 #
-# - There are cases where the comparison of Oscar group elements relies on
-#   the comparison of underlying GAP elements,
+# - For Oscar objects that rely on underlying GAP objects,
+#   we do not implement the serialization recursively
+#   via a serialization of these GAP objects.
+#   For example, consider the situation that two groups in Oscar point to
+#   the same GAP object.
+#   Serializing and then deserializing these two groups may yield Oscar groups
+#   that point to different GAP objects.
+#
+#   There are cases where the equality check for Oscar group elements
+#   relies on the equality check for the underlying GAP elements,
 #   such that the object identity of the `GAPWrap.FamilyObj` values of these
-#   GAP elements is required.
-#   `FPGroupElem` and `PcGroupElem` are examples.
-#   In these cases, we install a (de)serialization of the GAP group object,
-#   with requirement `uses_id`.
-#   This way, we can (de)serialize Oscar group elements and Oscar groups
-#   as well as GAP groups.
+#   GAP elements is required for the equality of the elements.
+#   In these cases, we assume that the analogous object identity is satisfied
+#   also for the Oscar group objects in question.
+#   Thus the (de)serialization code for groups and group elements does not
+#   rely on a (de)serialization for the underlying GAP objects.
 #
-#   (Note that from GAP's viewpoint, it would look more logical
-#   to (de)serialize the `GAPWrap.FamilyObj` object,
-#   because the group element in GAP stores a reference to this object
-#   but not to a group object.
-#   However, technically the creation of the family objects in GAP
-#   is encapsulated inside functions such as `GAPWrap.FreeGroup`
-#   that create groups.
-#   Thus it would require extra code on the Oscar side if we would want to
-#   first deserialize some elements of a free group by creating the family
-#   object on the GAP side, and then later create a free group with prescribed
-#   elements family.
-#   In particular, we do not support the (de)serialization of GAP's
-#   family objects.)
+#   The type `FPGroupElem` and `PcGroupElem` are examples.
+#   Serializing a tuple containing several subgroups and quotients of a
+#   finitely presented group stores the information about the full group
+#   and the underlying full free group,
+#   such that the deserialization yields a tuple of groups which have the
+#   same relations to each other as the groups in the original tuple.
 #
-# - Currently it is not our aim to provide a (de)serialization of as many
-#   GAP objects as possible.
-#   We provide methods for those GAP objects that are needed for the
-#   (de)serialization of Oscar objects.
-#   For example, we need a serialization of free groups in GAP, because of
-#   the object identity requirements, but (de)serializing elements of
-#   free groups in Oscar is done by serializing the underlying word and
-#   the parent object, without serializing the underlying element in GAP.
-#
-# - Remark:
-#   In those cases where the object identity of `GAPWrap.FamilyObj`
-#   objects must be preserved in the deserialization, we cannot simply
-#   leave it to the (de)serialization of Oscar objects to deal with "their"
-#   underlying GAP objects.
-#
-#   For example, serialize two subgroups `H`, `K` of a finitely presented
-#   group `G` in Oscar.
-#   In order to achieve that the deserialized `H` and `K` in a new Julia
-#   session are compatible (that is, elements of `H` and elements of `K`
-#   can be multiplied with each other), we have to make sure that
-#   `GAPWrap.FamilyObj(GapObj(H)) === GAPWrap.FamilyObj(GapObj(K))`
-#   are identical.
-#   Since `H` and `K` know about these objects only via `GapObj(H)` and
-#   `GapObj(K)`,
-#   the mechanism that automatically takes care of object identity in the
-#   (de)serialization can be used only if (de)serialization methods for
-#   `GapObj(H)` and `GapObj(K)` are provided.
-#
-#   (The situation would be different if `H` and `K` would store references
-#   to the "full group" `G`.
-#   In this case, we could force that serializing `H` and `K` involves also
-#   a serialization of `G`, then deserializing `H` and `K` would recreate the
-#   common `G`, and the object identity of the GAP family object could be
-#   forced via `G`.)
 
 using Oscar: GAPGroup, _coeff
 
@@ -97,7 +58,7 @@ const GAPGroup_attributes = [
 ]
 
 function save_attrs(s::SerializerState, G::T) where T <: GAPGroup
-  save_data_dict(s, :attrs) do 
+  save_data_dict(s, :attrs) do
     for attr in attrs_list(T)
       func = Symbol(string("has_", attr))
       if @eval $func($G)
@@ -161,30 +122,218 @@ end
 
 
 ##############################################################################
-# FPGroup, SubFPGroup
-# PcGroup, SubPcGroup
-# We do the same for full free groups, subgroups of free groups,
-# full f.p. groups, and subgroups of f.p. groups.
+# FPGroup
 
 @register_serialization_type FPGroup uses_id
-@register_serialization_type SubFPGroup uses_id
+
+function type_params(G::FPGroup)
+  F = free_group(G)
+  if F === G
+    # A full *free* group does not need type parameters.
+    return TypeParams(FPGroup, nothing)
+  else
+    # A group with relators needs the underlying free group
+    # as a type parameter,
+    # since the same free group object can be used for creating
+    # several f.p. groups.
+    return TypeParams(FPGroup, F)
+  end
+end
+
+# There are several internal representations of elements of free groups in GAP.
+# Let the serialized data not depend on the names of the GAP filters.
+_word_filters = Dict(
+  :IsSyllableWordsFamily => :syllables,
+  :IsLetterWordsFamily => :letters,
+  :IsWLetterWordsFamily => :wletters,
+  :IsBLetterWordsFamily => :bletters,
+  )
+_word_filters_inv = Dict()
+for x in keys(_word_filters)
+  _word_filters_inv[_word_filters[x]] = x
+end
+
+function save_object(s::SerializerState, G::FPGroup)
+  F = free_group(G)
+  if F === G
+    # A full *free* group is represented by the names of the generators,
+    # and the information about the GAP filter that defines the internal
+    # representation of the elements; there are four such filters.
+    # (Currently we do not support free groups on infinitely many generators.)
+    X = GapObj(G)
+    elfam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(X))
+    @assert GAP.Globals.HasIsWholeFamily(X) && GAPWrap.IsWholeFamily(X)
+    save_data_dict(s) do
+      # (rank and) names of generators
+      Xnames = GAP.getbangproperty(elfam, :names)::GapObj
+      names = Vector{String}(Xnames)
+      save_object(s, names, :names)
+      # the internal representation of elements
+      if GAP.Globals.IsSyllableWordsFamily(elfam)::Bool
+        wfilt = :IsSyllableWordsFamily
+      elseif GAP.Globals.IsLetterWordsFamily(elfam)::Bool
+        wfilt = :IsLetterWordsFamily
+      elseif GAP.Globals.IsWLetterWordsFamily(elfam)::Bool
+        wfilt = :IsWLetterWordsFamily
+      elseif GAP.Globals.IsBLetterWordsFamily(elfam)::Bool
+        wfilt = :IsBLetterWordsFamily
+      else
+        error("not supported internal representation")
+      end
+      save_object(s, _word_filters[wfilt], :rep)
+    end
+  else
+    # A group with relators is represented by the underlying free group
+    # (via the type parameter) and a description of the relators.
+    X = GapObj(G)
+    elfam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(X))
+    relators = GAP.getbangproperty(elfam, :relators)::GapObj
+    save_data_dict(s) do
+      save_object(s, [Vector{Int}(GAPWrap.ExtRepOfObj(x)) for x in relators], :relators)
+    end
+  end
+end
+
+function load_object(s::DeserializerState, ::Type{FPGroup}, ::Nothing)
+  # Without type parameters, the object is a free group.
+  load_node(s) do d
+    # Create a new full free group.
+    wfilt = getproperty(GAP.Globals, _word_filters_inv[load_object(s, Symbol, :rep)])::GapObj
+
+    init = load_node(s, :names) do names
+      GapObj(names; recursive = true)
+    end
+    G = GAPWrap.FreeGroup(wfilt, init)
+    res = FPGroup(G)
+    res.free_group = res
+    return res
+  end
+end
+
+function load_object(s::DeserializerState, ::Type{FPGroup}, F::FPGroup)
+  # The object is a f.p. group, `F` is the underlying free group.
+  # Create a new full f.p. group.
+  FX = GapObj(F)
+  relators = load_object(s, Vector{Vector{Int}}, :relators)
+  elfreefam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(FX))
+  rels = [GAPWrap.ObjByExtRep(elfreefam, GapObj(x, true)) for x in relators]
+  G = FX / GapObj(rels)::GapObj
+  return fp_group(G, F)
+end
+
+
+##############################################################################
+# PcGroup
+# The full group is described by its collector, no type parameters are needed.
+
 @register_serialization_type PcGroup uses_id
+
+function save_object(s::SerializerState, G::PcGroup)
+  X = GapObj(G)
+  elfam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(X))
+  fullpcgs = GAP.getbangproperty(elfam, :DefiningPcgs)::GapObj
+  @assert fullpcgs === GAPWrap.Pcgs(X)
+  save_data_dict(s) do
+    # relative orders
+    relord = [GAPWrap.RelativeOrderOfPcElement(fullpcgs, x) for x in fullpcgs]
+    save_object(s, relord, :relord)
+    # power relators
+    rels = Tuple{Int, Vector{Int}}[]
+    for i in 1:length(relord)
+      ne = fullpcgs[i]^relord[i]
+      if ! GAPWrap.IsOne(ne)
+        push!(rels, (i, _free_group_extrep_from_exponents(
+          Vector{Int}(GAPWrap.ExponentsOfPcElement(fullpcgs, ne)))))
+      end
+    end
+    save_object(s, rels, :power_rels)
+    # commutator relators
+    rels = Tuple{Int, Int, Vector{Int}}[]
+    for i in 1:(length(relord)-1)
+      for j in (i+1):length(relord)
+        ne = GAP.Globals.Comm(fullpcgs[j], fullpcgs[i])::GapObj
+        if ! GAPWrap.IsOne(ne)
+          push!(rels, (j, i, _free_group_extrep_from_exponents(
+            Vector{Int}(GAPWrap.ExponentsOfPcElement(fullpcgs, ne)))))
+        end
+      end
+    end
+    save_object(s, rels, :comm_rels)
+  end
+end
+
+function load_object(s::DeserializerState, ::Type{PcGroup}, ::Nothing)
+  relord = load_object(s, Vector{Int}, :relord)
+  F = GAPWrap.FreeGroup(GAP.Globals.IsSyllableWordsFamily, length(relord))
+  fam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(F))
+  rws = GAP.Globals.SingleCollector(F, GapObj(relord))::GapObj
+  for (i, elm) in load_object(s, Vector{Tuple{Int, Vector{Int}}}, :power_rels)
+    GAP.Globals.SetPower(rws, i, GAPWrap.ObjByExtRep(fam, GapObj(elm)))
+  end
+  for (j, i, elm) in load_object(s, Vector{Tuple{Int, Int, Vector{Int}}}, :comm_rels)
+    GAP.Globals.SetCommutator(rws, j, i, GAPWrap.ObjByExtRep(fam, GapObj(elm)))
+  end
+  G = GAP.Globals.GroupByRwsNC(rws)::GapObj
+  return PcGroup(G)
+end
+
+
+##############################################################################
+# SubFPGroup, SubPcGroup
+# The group is described by full group (via a reference) and generators.
+
+@register_serialization_type SubFPGroup uses_id
 @register_serialization_type SubPcGroup uses_id
 
-function type_and_params(G::T) where T <: Union{FPGroup, SubFPGroup, PcGroup, SubPcGroup}
-  TypeAndParams(T, GapObj(G))
+function type_and_params(G::T) where T <: Union{SubFPGroup, SubPcGroup}
+  # The subgroup needs a reference to its full group.
+  return TypeParams(T, G.full_group)
 end
 
-function save_object(s::SerializerState,
-                     G::T) where T <: Union{FPGroup, SubFPGroup, PcGroup, SubPcGroup}
-  #needs place holder
-  save_data_array(() -> (),  s)
+function save_object(s::SerializerState, G::SubFPGroup)
+  save_data_dict(s) do
+    save_object(s, [Vector{Int}(GAPWrap.ExtRepOfObj(GapObj(x)::GapObj)::GapObj) for x in gens(G)], :gens)
+  end
 end
 
-function load_object(s::DeserializerState, ::Type{T},
-                     G::GapObj) where T <: Union{FPGroup, SubFPGroup, PcGroup, SubPcGroup}
-  return T(G)
+function save_object(s::SerializerState, G::SubPcGroup)
+  X = GapObj(G)
+  elfam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(X))
+  fullpcgs = GAP.getbangproperty(elfam, :DefiningPcgs)::GapObj
+
+  save_data_dict(s) do
+    save_object(s, [Vector{Int}(GAPWrap.ExponentsOfPcElement(fullpcgs, x))
+                    for x in GAP.Globals.InducedPcgsWrtHomePcgs(X)::GapObj], :gens)
+  end
 end
+
+function load_object(s::DeserializerState, ::Type{SubFPGroup}, F::FPGroup)
+  @assert haskey(s, :gens)
+  Ffam = GAPWrap.FamilyObj(F)
+  elfam = GAPWrap.ElementsFamily(Ffam)
+  freegroup = GAP.getbangproperty(elfam, :freeGroup)::GapObj
+  freefam = GAPWrap.FamilyObj(freegroup)
+  elfreefam = GAPWrap.ElementsFamily(freefam)
+  load_node(s) do d
+    generators = load_object(s, Vector{Vector{Int}}, :gens)
+    gens = [GAPWrap.ObjByExtRep(elfreefam, GapObj(x, true)) for x in generators]
+    Ggens = [Oscar.group_element(F, GAPWrap.ElementOfFpGroup(elfam, x)) for x in gens]
+    return sub(F, Ggens)[1]
+  end
+end
+
+function load_object(s::DeserializerState, ::Type{SubPcGroup}, parent_group::PcGroup)
+  X = GapObj(parent_group)
+  elfam = GAPWrap.ElementsFamily(GAPWrap.FamilyObj(X))
+  fullpcgs = GAP.getbangproperty(elfam, :DefiningPcgs)::GapObj
+  load_node(s) do d
+    generators = load_object(s, Vector{Vector{Int}}, :gens)
+    Ggens = [Oscar.group_element(parent_group, GAP.Globals.PcElementByExponentsNC(fullpcgs, GapObj(x, true))::GapObj)
+             for x in generators]
+    return sub(parent_group, Ggens)[1]
+  end
+end
+
 
 ##############################################################################
 # FPGroupElem, SubFPGroupElem

--- a/src/Serialization/Upgrades/1.8.0+2.jl
+++ b/src/Serialization/Upgrades/1.8.0+2.jl
@@ -1,0 +1,84 @@
+# Upgrades are to change the data format of
+# `FPGroup`, `SubFPGroup`, `PcGroup`, `SubPcGroup`
+# such that the underlying GAP objects are no longer part of
+# the serialized data.
+# After the upgrade, some serialized GAP objects may be no longer needed
+# (and no longer reachable) for the deserialization; the upgrade code does
+# not remove these unnecessary data.
+#
+push!(upgrade_scripts_set, UpgradeScript(
+  v"1.8.0+2",
+  function upgrade_1_8_0_2(s::UpgradeState, dict::AbstractDict{Symbol, Any})
+    haskey(dict, :_refs) || return dict
+    refs = dict[:_refs]
+
+    # Record the connections from Oscar groups to GAP groups.
+    pointers = Dict{String, String}()  # from GAP group to the corr. OSCAR group
+    for key in keys(refs)
+      ref = refs[key]
+      if ref[:_type] isa AbstractDict && haskey(dict[:_type], :name) &&
+         ref[:_type][:name] in ["FPGroup", "SubFPGroup", "PcGroup", "SubPcGroup"]
+        pointers[ref[:_type][:params]] = String(key)
+      end
+    end
+
+    # Rewrite the refs between GAP groups to refs between Oscar groups.
+    for (key, ref) in refs
+      if ref[:_type] isa AbstractDict && haskey(dict[:_type], :name)
+        name = ref[:_type][:name]
+        if name == "FPGroup"
+          gapref = refs[Symbol(ref[:_type][:params])]
+          data = gapref[:data]
+
+          if haskey(data, :names)
+            # full free group:
+            # transfer the names and the filter identifier.
+            ref[:data] = Dict{Symbol, Any}(
+                           :names => data[:names],
+                           :rep => Oscar.Serialization._word_filters[
+                                     Symbol(data[:wfilt])])
+
+            # no ref is needed anymore
+            ref[:_type] = "FPGroup"
+          else
+            # full f.p. group:
+            # transfer the relators
+            @assert haskey(data, :relators)
+            ref[:data] = Dict{Symbol, Any}(
+                           :relators => data[:relators])
+
+            # lift the ref to the full group from GAP to OSCAR
+            pointer = gapref[:_type][:params]
+            ref[:_type][:params] = pointers[pointer]
+          end
+        elseif name == "PcGroup"
+          gapref = refs[Symbol(ref[:_type][:params])]
+          data = gapref[:data]
+
+          # transfer the defining data of the collector
+          @assert haskey(data, :relord)
+          ref[:data] = Dict{Symbol, Any}(
+                         :relord => data[:relord],
+                         :power_rels => data[:power_rels],
+                         :comm_rels => data[:comm_rels])
+
+          # no ref is needed anymore
+          ref[:_type] = "PcGroup"
+        elseif name == "SubPcGroup" || name == "SubFPGroup"
+          gapref = refs[Symbol(ref[:_type][:params])]
+          data = gapref[:data]
+
+          # transfer generators
+          ref[:data] = Dict{Symbol, Any}(
+                         :gens => data[:gens])
+
+          # lift the ref to the full group from GAP to OSCAR
+          pointer = gapref[:_type][:params]
+          ref[:_type][:params] = pointers[pointer]
+        end
+      end
+    end
+    return dict
+  end
+))
+

--- a/src/Serialization/Upgrades/1.8.0+2.jl
+++ b/src/Serialization/Upgrades/1.8.0+2.jl
@@ -1,33 +1,144 @@
 # Upgrades are to change the data format of
-# `FPGroup`, `SubFPGroup`, `PcGroup`, `SubPcGroup`
+# the types `FPGroup`, `SubFPGroup`, `PcGroup`, `SubPcGroup`
 # such that the underlying GAP objects are no longer part of
 # the serialized data.
 # After the upgrade, some serialized GAP objects may be no longer needed
 # (and no longer reachable) for the deserialization; the upgrade code does
 # not remove these unnecessary data.
+# Distinguish two cases:
+# 1. The object in question is the only object in the file;
+#    In this case, it does not occur in the `_refs` part.
+# 2. The objects in question are part of bigger data,
+#    such as a (nested) container.
+#    In this case, all changes refer either to the `_refs` part
+#    or to `params` vectors of `_type` entries.
+#    In this case, we run over the `_refs` and adjust their contents.
+#    At the same time, we collect the necessary replacements that must be
+#    applied to the `_type` entries in the file.
+#    Finally, we run the recursion in order to adjust the `params` vectors
+#    in question.
 #
 push!(upgrade_scripts_set, UpgradeScript(
   v"1.8.0+2",
   function upgrade_1_8_0_2(s::UpgradeState, dict::AbstractDict{Symbol, Any})
-    haskey(dict, :_refs) || return dict
-    refs = dict[:_refs]
 
-    # Record the connections from Oscar groups to GAP groups.
-    pointers = Dict{String, String}()  # from GAP group to the corr. OSCAR group
+    # We want to run this upgrade only on the top level,
+    # and only if there is a `_refs` entry.
+    haskey(dict, :_refs) || return dict
+
+    # We are on the top level, prepare the global data for the recursion.
+    # We need the `_refs` and the connections between the Oscar groups
+    # and the corresponding GAP groups.
+
+    # Step 1: Deal with one top level object of one of our types.
+    refs = dict[:_refs]
+    if dict[:_type] isa AbstractDict && haskey(dict[:_type], :name) &&
+       dict[:_type][:name] in ["FPGroup", "SubFPGroup", "PcGroup", "SubPcGroup"]
+      refs = copy(refs)
+      refs[Symbol(dict[:id])] = Dict{Symbol, Any}(:_type => dict[:_type], :data => dict[:data])
+      toplevel = true
+    else
+      toplevel = false
+    end
+
+    # Step 2: Adjust the `_refs` part, and collect `params` replacements
+    #         (non-recursively).
+
+    # Collect pointers from GAP groups to corresponding OSCAR groups.
+    pointers = Dict{String, String}()
     for key in keys(refs)
       ref = refs[key]
-      if ref[:_type] isa AbstractDict && haskey(dict[:_type], :name) &&
+      if ref[:_type] isa AbstractDict && haskey(ref[:_type], :name) &&
          ref[:_type][:name] in ["FPGroup", "SubFPGroup", "PcGroup", "SubPcGroup"]
         pointers[ref[:_type][:params]] = String(key)
       end
     end
 
     # Rewrite the refs between GAP groups to refs between Oscar groups.
-    for (key, ref) in refs
-      if ref[:_type] isa AbstractDict && haskey(dict[:_type], :name)
+    replace_type = Dict()
+    pairs = collect(refs)
+
+    # auxiliary functions
+    insert_oscar_free_group = function(pointer, name)
+      # no Oscar free group was stored
+      oscaruuid = string(uuid4())
+      gapdata = refs[Symbol(pointer)][:data]
+      oscarobj = Dict{Symbol, Any}(
+                   :_type => "FPGroup",
+                   :data => Dict{Symbol, Any}(
+                     :names => gapdata[:names],
+                     :rep => Oscar.Serialization._word_filters[
+                               Symbol(gapdata[:wfilt])]))
+
+      dict[:_refs][Symbol(oscaruuid)] = oscarobj
+      push!(pairs, Symbol(oscaruuid) => oscarobj)
+      pointers[pointer] = oscaruuid
+
+      replace_type[Dict{Symbol, Any}(
+                     :name => name,
+                     :params => oscaruuid)] =
+                   Dict{Symbol, Any}(
+                     :name => name,
+                     :params => oscaruuid)
+    end
+
+    insert_oscar_full_group = function(pointer, name)
+      # no Oscar full group was stored
+      oscaruuid = string(uuid4())
+      gapdata = refs[Symbol(pointer)][:data]
+
+      if haskey(gapdata, :relators)
+        # subgroup of a f.p. group, and this points to a free group
+        oscarobj = Dict{Symbol, Any}(
+                     :_type => Dict{Symbol, Any}(
+                       :name => "FPGroup",
+                       :params => pointer),
+                     :data => Dict{Symbol, Any}(
+                       :relators => gapdata[:relators]))
+
+        dict[:_refs][Symbol(oscaruuid)] = oscarobj
+        push!(pairs, Symbol(oscaruuid) => oscarobj)
+        pointers[pointer] = oscaruuid
+
+        replace_type[Dict{Symbol, Any}(
+                       :name => name,
+                       :params => oscaruuid)] =
+                     Dict{Symbol, Any}(
+                       :name => name,
+                       :params => oscaruuid)
+
+        insert_oscar_free_group(gapdata[:freeGroup], "FPGroup")
+      elseif haskey(gapdata, :relord)
+        # subgroup of a pc group
+        oscarobj = Dict{Symbol, Any}(
+                     :_type => "PcGroup",
+                     :data => Dict{Symbol, Any}(
+                       :relord => gapdata[:relord],
+                       :power_rels => gapdata[:power_rels],
+                       :comm_rels => gapdata[:comm_rels]))
+
+        dict[:_refs][Symbol(oscaruuid)] = oscarobj
+        push!(pairs, Symbol(oscaruuid) => oscarobj)
+        pointers[pointer] = oscaruuid
+
+        replace_type[Dict{Symbol, Any}(
+                       :name => name,
+                       :params => oscaruuid)] =
+                     Dict{Symbol, Any}(
+                       :name => name,
+                       :params => oscaruuid)
+      else
+        # subgroup of a free group
+       insert_oscar_free_group(pointer, "SubFPGroup")
+      end
+    end
+
+    for (key, ref) in pairs
+      if ref[:_type] isa AbstractDict && haskey(ref[:_type], :name)
         name = ref[:_type][:name]
         if name == "FPGroup"
-          gapref = refs[Symbol(ref[:_type][:params])]
+          oldparams = ref[:_type][:params]
+          gapref = refs[Symbol(oldparams)]
           data = gapref[:data]
 
           if haskey(data, :names)
@@ -38,21 +149,36 @@ push!(upgrade_scripts_set, UpgradeScript(
                            :rep => Oscar.Serialization._word_filters[
                                      Symbol(data[:wfilt])])
 
+            replace_type[Dict{Symbol, Any}(:name => name,
+                              :params => oldparams)] = name
+
             # no ref is needed anymore
             ref[:_type] = "FPGroup"
-          else
+          elseif haskey(gapref, :_type) && gapref[:_type] isa AbstractDict &&
+                 haskey(gapref[:_type], :name) && gapref[:_type][:name] == "GapObj"
             # full f.p. group:
             # transfer the relators
             @assert haskey(data, :relators)
             ref[:data] = Dict{Symbol, Any}(
                            :relators => data[:relators])
 
-            # lift the ref to the full group from GAP to OSCAR
+            # lift the ref to the free group from GAP to OSCAR
             pointer = gapref[:_type][:params]
+
+            if !haskey(pointers, pointer)
+              insert_oscar_free_group(pointer, name)
+            end
+
+            replace_type[Dict{Symbol, Any}(:name => name,
+                              :params => oldparams)] =
+                         Dict{Symbol, Any}(:name => name,
+                              :params => pointers[pointer])
+
             ref[:_type][:params] = pointers[pointer]
           end
         elseif name == "PcGroup"
-          gapref = refs[Symbol(ref[:_type][:params])]
+          oldparams = ref[:_type][:params]
+          gapref = refs[Symbol(oldparams)]
           data = gapref[:data]
 
           # transfer the defining data of the collector
@@ -62,23 +188,62 @@ push!(upgrade_scripts_set, UpgradeScript(
                          :power_rels => data[:power_rels],
                          :comm_rels => data[:comm_rels])
 
+          replace_type[Dict{Symbol, Any}(:name => name,
+                            :params => oldparams)] = name
+
           # no ref is needed anymore
           ref[:_type] = "PcGroup"
         elseif name == "SubPcGroup" || name == "SubFPGroup"
-          gapref = refs[Symbol(ref[:_type][:params])]
-          data = gapref[:data]
+          oldparams = ref[:_type][:params]
+          gapref = refs[Symbol(oldparams)]
+          if haskey(gapref, :_type) && gapref[:_type] isa AbstractDict &&
+             haskey(gapref[:_type], :name) && gapref[:_type][:name] == "GapObj"
 
-          # transfer generators
-          ref[:data] = Dict{Symbol, Any}(
-                         :gens => data[:gens])
+            data = gapref[:data]
 
-          # lift the ref to the full group from GAP to OSCAR
-          pointer = gapref[:_type][:params]
-          ref[:_type][:params] = pointers[pointer]
+            # transfer generators
+            ref[:data] = Dict{Symbol, Any}(
+                           :gens => data[:gens])
+
+            # lift the ref to the full group from GAP to OSCAR
+            pointer = gapref[:_type][:params]
+            if !haskey(pointers, pointer)
+              insert_oscar_full_group(pointer, name)
+            end
+
+            replace_type[Dict{Symbol, Any}(:name => name,
+                              :params => oldparams)] =
+                         Dict{Symbol, Any}(:name => name,
+                              :params => pointers[pointer])
+
+            ref[:_type][:params] = pointers[pointer]
+          end
         end
       end
     end
+
+    # Step 3: Adjust `params` recursively,
+    #         using the precomputed replacements list.
+
+    if toplevel
+      # Replace the top level `:_type`.
+      dict[:_type] = replace_type[dict[:_type]]
+
+      # Replace the top level `:data`.
+      dict[:data] = refs[Symbol(dict[:id])][:data]
+    end
+
+    # Define a function that has access to `replace_type`.
+    recursion = function(s::UpgradeState, dict::AbstractDict{Symbol, Any})
+      if haskey(dict, :_type) && haskey(replace_type, dict[:_type])
+        dict[:_type] = replace_type[dict[:_type]]
+      end
+      return dict
+    end
+
+    # recurse upgrade on containers
+    upgrade_recursive(recursion, s, dict)
+
     return dict
   end
 ))
-

--- a/src/Serialization/Upgrades/main.jl
+++ b/src/Serialization/Upgrades/main.jl
@@ -310,6 +310,7 @@ include("1.6.0+1.jl")
 include("1.7.0.jl")
 include("1.8.0.jl")
 include("1.8.0+1.jl")
+include("1.8.0+2.jl")
 
 const upgrade_scripts = collect(upgrade_scripts_set)
 sort!(upgrade_scripts; by=version)

--- a/test/Serialization/Groups.jl
+++ b/test/Serialization/Groups.jl
@@ -228,6 +228,7 @@
         @test parent(loadedv[1]) === loadedv[3]
         @test parent(loadedv[2]) === loadedv[4]
         @test is_subgroup(loadedv[4], loadedv[3])[1]
+        @test full_group(v[4])[1] === v[3]
 
         loadedw = load(filenamew)
         @test parent(loadedv[1]) === parent(loadedw[2])
@@ -254,6 +255,24 @@
       test_save_load_roundtrip(path, g) do loaded
         @test loaded == g
       end
+    end
+
+    @testset "Object identity" begin
+      # Take two Oscar groups that (accidentally) point to the same GAP group.
+      # Serializing and then deserializing them may yield
+      # two Oscar groups that may point to different GAP groups.
+      G = free_group(2)
+      H = Oscar._oscar_group(GapObj(G))
+      @test GapObj(G) === GapObj(H)
+
+      v = (G, H)
+      filenamev = joinpath(path, "v")
+      save(filenamev, v)
+      loaded = load(filenamev)
+      @test loaded === (G, H)
+      Oscar.reset_global_serializer_state()
+      loaded = load(filenamev)
+      @test GapObj(loaded[1]) !== GapObj(loaded[2])
     end
   end
 end

--- a/test/Serialization/upgrades/runtests.jl
+++ b/test/Serialization/upgrades/runtests.jl
@@ -73,5 +73,23 @@
       # upgrading the following is tested in experimental/AlgebraicStatistics/test/serialization-upgrades.jl
       "GroupBasedPhylogeneticModel",
     ])
+
+    # The main point is to test the relation between loaded objects.
+    loaded = load(joinpath(Main.serialization_upgrade_test_path, "version_1_7_0", "FPGroup-3", "0.mrdi"))
+    @test length(loaded) == 6
+    (F, U, G, H, P, S) = map(parent, loaded)
+
+    @test full_group(F)[1] === F
+    @test full_group(U)[1] === F
+    @test free_group(G) === F
+    @test full_group(G)[1] === G
+    @test full_group(H)[1] === G
+
+    @test full_group(S)[1] === P
+
+    @test GAP.Globals.FamilyObj(GapObj(F)) === GAP.Globals.FamilyObj(GapObj(U))
+    @test GAP.Globals.FamilyObj(GapObj(G)) === GAP.Globals.FamilyObj(GapObj(H))
+    @test GAP.Globals.FamilyObj(GapObj(F)) !== GAP.Globals.FamilyObj(GapObj(G))
+    @test GAP.Globals.FamilyObj(GapObj(P)) === GAP.Globals.FamilyObj(GapObj(S))
   end
 end

--- a/test/Serialization/upgrades/runtests.jl
+++ b/test/Serialization/upgrades/runtests.jl
@@ -75,7 +75,7 @@
     ])
 
     # The main point is to test the relation between loaded objects.
-    loaded = load(joinpath(Main.serialization_upgrade_test_path, "version_1_7_0", "FPGroup-3", "0.mrdi"))
+    loaded = load(joinpath(Main.serialization_upgrade_test_path, "version_1_7_0", "Tuple-3", "0.mrdi"))
     @test length(loaded) == 6
     (F, U, G, H, P, S) = map(parent, loaded)
 

--- a/test/Serialization/upgrades/setup_tests.jl
+++ b/test/Serialization/upgrades/setup_tests.jl
@@ -9,7 +9,7 @@ if !isdefined(Main, :serialization_upgrade_test_path) ||
   !isfile(joinpath(Main.serialization_upgrade_test_path, "LICENSE.md"))
 
 
-  serialization_upgrade_test_path = let commit_hash = "e3473ad614217bc19fad7f809de2d863984be157"
+  serialization_upgrade_test_path = let commit_hash = "8dac84a1f4ae4913fe3fb44199621695573f81bc"
     tarball = Downloads.download("https://github.com/oscar-system/serialization-upgrade-tests/archive/$(commit_hash).tar.gz")
 
     destpath = open(CodecZlib.GzipDecompressorStream, tarball) do io


### PR DESCRIPTION
This affects the types `FPGroup`, `PcGroup`, `SubFPGroup`, `SubPcGroup`.

The idea is to keep the internal structure away form the data files, that is, we do no longer store GAP groups, see #5994.

(Logically, this abstraction means a loss of information in the sense that relations between underlying GAP objects may be different after deserialization.
On the other hand, one can argue that in situations where this causes problems, one should in fact better define a serialization for a larger object that makes the relations in question explicit.)