### PR TITLE
Improve performance of `in(..., ::GSetByElements)` in some cases

### DIFF
--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -385,7 +385,7 @@ function Base.in(omega::S, Omega::GSetByElements{T,S}) where {T,S}
   # in O(1) because seeds is an IndexedSet, but the look-up in elements(Omega)
   # takes linear time.
   elts = elements(Omega)
-  if length(Omega.seeds) == length(elts)
+  if length(Omega.seeds)::Int == length(elts)
     return is_in_seeds
   end
   return omega in elts

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -376,8 +376,16 @@ end
 #      using what is called `RepresentativeAction` in GAP.
 
 function Base.in(omega::S, Omega::GSetByElements{T,S}) where {T,S}
-    omega in Omega.seeds && return true
-    return omega in elements(Omega)
+  is_in_seeds = (omega in Omega.seeds)
+  # If all elements of Omega are seeds, we don't need to check everything again.
+  # This prominently happens if Omega was computed as an orbit. In that case,
+  # Omega already knows its elements, so the following length check is cheap.
+  # Further, looking up omega in Omega.seeds is in O(1) because seeds is an
+  # IndexedSet, but the look-up in elements(Omega) takes linear time.
+  if is_in_seeds || length(Omega.seeds) == length(elements(Omega))
+    return is_in_seeds
+  end
+  return omega in elements(Omega)
 end
 
 

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -376,18 +376,20 @@ end
 #      using what is called `RepresentativeAction` in GAP.
 
 function Base.in(omega::S, Omega::GSetByElements{T,S}) where {T,S}
-  is_in_seeds = (omega in Omega.seeds)
+  is_in_seeds = (omega in Omega.seeds)::Bool
+  is_in_seeds && return true
   # If all elements of Omega are seeds, we don't need to check everything again.
   # This prominently happens if Omega was computed as an orbit. In that case,
   # Omega already knows its elements, so the following length check is cheap.
-  # Further, looking up omega in Omega.seeds is in O(1) because seeds is an
-  # IndexedSet, but the look-up in elements(Omega) takes linear time.
-  if is_in_seeds || length(Omega.seeds) == length(elements(Omega))
+  # This is not just a micro-optimization: looking up omega in Omega.seeds is
+  # in O(1) because seeds is an IndexedSet, but the look-up in elements(Omega)
+  # takes linear time.
+  elts = elements(Omega)
+  if length(Omega.seeds) == length(elts)
     return is_in_seeds
   end
-  return omega in elements(Omega)
+  return omega in elts
 end
-
 
 #############################################################################
 ##


### PR DESCRIPTION
I noticed that (at least in some examples) `orbits` spends a lot of time checking containment via `in`: For every seed `p` of the G-set `Omega` it is tested whether `p` is in an already computed orbit `o`. Orbits are G-sets themselves and contain all their elements as seeds (at least that is my impression). Hence the current `in(p, o)` is checking everything twice, once whether `p` is in `o.seeds` and once whether `p` is in `elements(o)`. Worse, checking containment of `p` in `o.seeds` is constant (to my understanding) because `o.seeds` is an `IndexedSet`, but checking `p` in `elements(o)` is linear.

This optimization hence relies on the fact that for an orbit `o`, all elements are in the seeds `o.seeds`. I don't know this part of OSCAR very well, so maybe this is not the right way to go forward?

CC @fingolfin, @mjrodgers

~PS: Thinking about it, this is probably not the best/right way to do it. I might push an alternative later/in the next days.~

EDIT: I now pushed a version that does not rely on how orbits are represented internally for correctness.
Here is a timing:
```
julia> G = alternating_group(7);

julia> exp = data.(collect(weak_compositions(15, 7))); # These are all monomials in 7 variables of degree 15

# master
julia> @btime orbits(gset(G, permuted, exp));
  8.388 s (4380637 allocations: 85.14 MiB)

# this pull request
julia> @btime orbits(gset(G, permuted, exp));
  505.274 ms (5910641 allocations: 108.48 MiB)
```
I don't understand why the allocations go up in the second case, but I don't have time to investigate right now.

So feel free to chime in if you want, but it is probably too early for a review or anything.