### PR TITLE
Add `on_graph` for acting on a graph with a `PermGroupElem`

### DIFF
--- a/docs/src/Combinatorics/graphs.md
+++ b/docs/src/Combinatorics/graphs.md
@@ -109,6 +109,7 @@ maximal_cliques(g::Graph{Undirected})
 labelings(G::Graph)
 has_disjoint_automorphisms(G::Graph)
 disjoint_automorphisms(G::Graph)
+on_graph
 ```
 
 ### Edges

--- a/docs/src/Combinatorics/graphs.md
+++ b/docs/src/Combinatorics/graphs.md
@@ -110,6 +110,7 @@ labelings(G::Graph)
 has_disjoint_automorphisms(G::Graph)
 disjoint_automorphisms(G::Graph)
 on_graph
+permute_nodes!
 ```
 
 ### Edges

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -1212,6 +1212,34 @@ function _canonical_perm(G::Graph; label::Union{Nothing, Symbol}=nothing,
   error("unimplemented for either indistinguishable vertex or edge labels")
 end
 
+@doc raw"""
+    permute_nodes!(G::Graph{T}, p::PermGroupElem) where T <: Union{Directed, Undirected}
+
+Permute the nodes of `G` in place according to the permutation `p`
+
+```jldoctest
+julia> G = graph_from_labeled_edges(Directed, Dict((1, 2) => 1, (2, 3) => 4); name=:color)
+Directed graph with 3 nodes and the following labeling(s):
+label: color
+(1, 2) -> 1
+(2, 3) -> 4
+
+julia> p = perm(3, [2, 1, 3])
+(1,2)
+
+julia> permute_nodes!(G, p)
+
+julia> G
+Directed graph with 3 nodes and the following labeling(s):
+label: color
+(1, 2) -> 1
+(2, 3) -> 4
+```
+"""
+function permute_nodes!(G::Graph{T}, p::PermGroupElem) where T <: Union{Directed, Undirected}
+  Polymake._permute_nodes!(pm_object(G), Polymake.Array{Int}(Polymake.to_zero_based_indexing(Vector(p))))
+end
+
 function _permute_nodes_and_labels(G::Graph{T}, p::Vector{Int}, labels::Vector{Symbol}) where T <: Union{Directed, Undirected}
   new_G = Graph{T}(Polymake._permute_nodes(pm_object(G), Polymake.Array{Int}(Polymake.to_zero_based_indexing(p))))
 
@@ -2563,6 +2591,8 @@ result. Any labelings on `g` are carried along accordingly.
 
 The permutation `p` must be an element of the symmetric group on
 `n_vertices(g)` letters.
+
+See [`permute_nodes!`](@ref) for an in place alternative.
 
 # Examples
 ```jldoctest

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -1227,7 +1227,7 @@ function _permute_nodes_and_labels(G::Graph{T}, p::Vector{Int}, labels::Vector{S
     if !isnothing(graph_map.edge_map)
       new_edge_labels = Dict((permute(src(e)), permute(dst(e))) => graph_map.edge_map[e] for e in edges(G))
     end
-    label!(new_G, new_edge_labels, new_vertex_labels)
+    label!(new_G, new_edge_labels, new_vertex_labels; name=label)
   end
   return new_G
 end

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -1212,25 +1212,32 @@ function _canonical_perm(G::Graph; label::Union{Nothing, Symbol}=nothing,
   error("unimplemented for either indistinguishable vertex or edge labels")
 end
 
+function _permute_nodes_and_labels(G::Graph{T}, p::PermGroupElem, labels::Vector{Symbol}) where T <: Union{Directed, Undirected}
+  @req "at least one label was not a labeling of $G" all(label in labelings(G), label)
+  new_G = Graph{T}(Polymake._permute_nodes(pm_object(G), Polymake.Array{Int}(Polymake.to_zero_based_indexing(p))))
+
+  for label in labels
+    graph_map = _graph_maps(G)[label]
+    new_vertex_labels = nothing
+    new_edge_labels = nothing
+    permute = inv(perm(p))
+    if !isnothing(graph_map.vertex_map)
+      new_vertex_labels = Dict(permute(v) => graph_map.vertex_map[v] for v in 1:n_vertices(G))
+    end
+
+    if !isnothing(graph_map.edge_map)
+      new_edge_labels = Dict((permute(src(e)), permute(dst(e))) => graph_map.edge_map[e] for e in edges(G))
+    end
+    label!(new_G, new_edge_labels, new_vertex_labels)
+  end
+  return new_G
+end
+
 function _canonical_form(G::Graph{T}; label::Union{Nothing, Symbol}=nothing, kwargs...) where T <: Union{Directed, Undirected}
   isnothing(label) && return Graph{T}(Polymake._canonical_form(pm_object(G)))
 
   p = _canonical_perm(G; label=label, kwargs...)
-  new_G = Graph{T}(Polymake._permute_nodes(pm_object(G), Polymake.Array{Int}(Polymake.to_zero_based_indexing(p))))
-
-  graph_map = _graph_maps(G)[label]
-  new_vertex_labels = nothing
-  new_edge_labels = nothing
-  permute = inv(perm(p))
-  if !isnothing(graph_map.vertex_map)
-    new_vertex_labels = Dict(permute(v) => graph_map.vertex_map[v] for v in 1:n_vertices(G))
-  end
-
-  if !isnothing(graph_map.edge_map)
-    new_edge_labels = Dict((permute(src(e)), permute(dst(e))) => graph_map.edge_map[e] for e in edges(G))
-  end
-  label!(new_G, new_edge_labels, new_vertex_labels)
-  return new_G
+  return _permute_nodes_and_label(G, p, [label])
 end
 
 
@@ -2547,3 +2554,7 @@ The canonical hash is an isomorphism invariant of a graph.
    The canonical hash depends on the version of Oscar.
 """
 canonical_hash(g::Graph{T}) where T<:Union{Directed,Undirected} = Polymake.graph.canonical_hash(Oscar.pm_object(g))
+function on_graph(g::Graph{T}, p::PermGroupElem) where T <: Union{Directed, Undirected}
+  @req degree(parent(p)) == n_vertices(g) "$p needs to be an element of the permutation group on the vertices"
+  return _permute_nodes_and_labels(g, p, labelings(g))
+end

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -1232,8 +1232,8 @@ julia> permute_nodes!(G, p)
 julia> G
 Directed graph with 3 nodes and the following labeling(s):
 label: color
-(1, 2) -> 1
-(2, 3) -> 4
+(1, 3) -> 4
+(2, 1) -> 1
 ```
 """
 function permute_nodes!(G::Graph{T}, p::PermGroupElem) where T <: Union{Directed, Undirected}

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -1212,8 +1212,7 @@ function _canonical_perm(G::Graph; label::Union{Nothing, Symbol}=nothing,
   error("unimplemented for either indistinguishable vertex or edge labels")
 end
 
-function _permute_nodes_and_labels(G::Graph{T}, p::PermGroupElem, labels::Vector{Symbol}) where T <: Union{Directed, Undirected}
-  @req "at least one label was not a labeling of $G" all(label in labelings(G), label)
+function _permute_nodes_and_labels(G::Graph{T}, p::Vector{Int}, labels::Vector{Symbol}) where T <: Union{Directed, Undirected}
   new_G = Graph{T}(Polymake._permute_nodes(pm_object(G), Polymake.Array{Int}(Polymake.to_zero_based_indexing(p))))
 
   for label in labels
@@ -2556,5 +2555,5 @@ The canonical hash is an isomorphism invariant of a graph.
 canonical_hash(g::Graph{T}) where T<:Union{Directed,Undirected} = Polymake.graph.canonical_hash(Oscar.pm_object(g))
 function on_graph(g::Graph{T}, p::PermGroupElem) where T <: Union{Directed, Undirected}
   @req degree(parent(p)) == n_vertices(g) "$p needs to be an element of the permutation group on the vertices"
-  return _permute_nodes_and_labels(g, p, labelings(g))
+  return _permute_nodes_and_labels(g, Vector(p), labelings(g))
 end

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -2553,6 +2553,48 @@ The canonical hash is an isomorphism invariant of a graph.
    The canonical hash depends on the version of Oscar.
 """
 canonical_hash(g::Graph{T}) where T<:Union{Directed,Undirected} = Polymake.graph.canonical_hash(Oscar.pm_object(g))
+
+@doc raw"""
+    on_graph(g::Graph{T}, p::PermGroupElem) where {T <: Union{Directed, Undirected}}
+
+Return the graph obtained from `g` by applying the permutation `p` to its
+vertices. An edge `(u, v)` in `g` becomes the edge `(p(u), p(v))` in the
+result. Any labelings on `g` are carried along accordingly.
+
+The permutation `p` must be an element of the symmetric group on
+`n_vertices(g)` letters.
+
+# Examples
+```jldoctest
+julia> G = graph_from_edges(Directed, [[1, 2], [2, 3]])
+Directed graph with 3 nodes and the following edges:
+(1, 2)(2, 3)
+
+julia> p = perm(symmetric_group(3), [2, 1, 3])
+(1,2)
+
+julia> on_graph(G, p)
+Directed graph with 3 nodes and the following edges:
+(1, 3)(2, 1)
+```
+
+```jldoctest
+julia> G = graph_from_labeled_edges(Directed, Dict((1, 2) => 1, (2, 3) => 2))
+Directed graph with 3 nodes and the following labeling(s):
+label: label
+(1, 2) -> 1
+(2, 3) -> 2
+
+julia> p = perm(symmetric_group(3), [2, 1, 3])
+(1,2)
+
+julia> on_graph(G, p)
+Directed graph with 3 nodes and the following labeling(s):
+label: label
+(1, 3) -> 2
+(2, 1) -> 1
+```
+"""
 function on_graph(g::Graph{T}, p::PermGroupElem) where T <: Union{Directed, Undirected}
   @req degree(parent(p)) == n_vertices(g) "$p needs to be an element of the permutation group on the vertices"
   return _permute_nodes_and_labels(g, Vector(p), labelings(g))

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1446,6 +1446,7 @@ export permutation_group
 export permutation_matrix
 export permutation_of_terms
 export permuted
+export permute_nodes!
 export petersen_graph
 export phylogenetic_tree
 export picard_class

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1381,6 +1381,7 @@ export numerical_lattice_of_K3_cover
 export objective_function
 export omega_group
 export on_echelon_form_mats
+export on_graph
 export on_indeterminates
 export on_lines
 export on_sets

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -462,7 +462,7 @@
       @test HL.color[2] == GL.color[1]
     end
 
-    @test "permute_nodes!" begin
+    @testset "permute_nodes!" begin
       p = perm(3, [2, 1, 3])  # (1,2)
       G = graph_from_edges(Directed, [[1, 2], [2, 3]])
       permute_nodes!(G, p)

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -462,7 +462,7 @@
       @test HL.color[2] == GL.color[1]
     end
 
-    @test "permuted_nodes!" begin
+    @test "permute_nodes!" begin
       G = graph_from_edges(Directed, [[1, 2], [2, 3]])
       Polymake.permuted_nodes!(G, [1, 2])
       @test collect(edges(G)) == [ Edge(1, 3),  Edge(2, 1)]

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -456,8 +456,10 @@
 
       # labels are carried along
       GL = graph_from_labeled_edges(Directed, Dict((1, 2) => 10, (2, 3) => 20))
+      label!(GL, nothing, Dict(1 => "red", 2 => "blue", 3 => "green"); name=:color)
       HL = on_graph(GL, p)
       @test HL.label[2, 1] == 10
       @test HL.label[1, 3] == 20
+      @test HL.color[2] == GL.color[1]
     end
 end

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -451,7 +451,7 @@
 
       # degree mismatch throws
       G2 = graph_from_edges(Directed, [[1, 2]])
-      @test_throws ArgumentError on_graph(G2, perm(S3, [2, 1, 3]))
+      @test_throws ArgumentError on_graph(G2, perm(3, [2, 1, 3]))
 
       # labels are carried along
       GL = graph_from_labeled_edges(Directed, Dict((1, 2) => 10, (2, 3) => 20))

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -427,15 +427,14 @@
     end
 
     @testset "on_graph" begin
-      S3 = symmetric_group(3)
-      id = perm(S3, [1, 2, 3])
+      id = perm(3, [1, 2, 3])
 
       # identity permutation gives equal graph
       G = graph_from_edges(Directed, [[1, 2], [2, 3]])
       @test on_graph(G, id) == G
 
       # applying a permutation relabels edges
-      p = perm(S3, [2, 1, 3])  # (1,2)
+      p = perm(3, [2, 1, 3])  # (1,2)
       H = on_graph(G, p)
       @test n_vertices(H) == n_vertices(G)
       @test n_edges(H) == n_edges(G)
@@ -461,5 +460,19 @@
       @test HL.label[2, 1] == 10
       @test HL.label[1, 3] == 20
       @test HL.color[2] == GL.color[1]
+    end
+
+    @test "permuted_nodes!" begin
+      G = graph_from_edges(Directed, [[1, 2], [2, 3]])
+      Polymake.permuted_nodes!(G, [1, 2])
+      @test collect(edges(G)) == [ Edge(1, 3),  Edge(2, 1)]
+
+      label!(G, Dict((1, 2) => 10, (2, 3) => 20), nothing)
+      label!(G, nothing, Dict(1 => "red", 2 => "blue", 3 => "green"); name=:color)
+      p = perm(3, [2, 1, 3])  # (1,2)
+      permute_nodes!(G, p)
+      @test G.label[2, 1] == 10
+      @test G.label[1, 3] == 20
+      @test G.color[2] == GL.color[1]
     end
 end

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -425,4 +425,39 @@
       @test Oscar._canonical_hash(G1; label=:label) == Oscar._canonical_hash(G2; label=:label)
       @test Oscar._canonical_hash(G1; label=:label) != Oscar._canonical_hash(G3; label=:label)
     end
+
+    @testset "on_graph" begin
+      S3 = symmetric_group(3)
+      id = perm(S3, [1, 2, 3])
+
+      # identity permutation gives equal graph
+      G = graph_from_edges(Directed, [[1, 2], [2, 3]])
+      @test on_graph(G, id) == G
+
+      # applying a permutation relabels edges
+      p = perm(S3, [2, 1, 3])  # (1,2)
+      H = on_graph(G, p)
+      @test n_vertices(H) == n_vertices(G)
+      @test n_edges(H) == n_edges(G)
+      @test has_edge(H, 2, 1)
+      @test has_edge(H, 1, 3)
+      @test !has_edge(H, 1, 2)
+      @test !has_edge(H, 2, 3)
+
+      # applying an automorphism gives an isomorphic graph
+      K4 = complete_graph(4)
+      S4 = symmetric_group(4)
+      q = perm(S4, [2, 3, 4, 1])
+      @test is_isomorphic(K4, on_graph(K4, q))
+
+      # degree mismatch throws
+      G2 = graph_from_edges(Directed, [[1, 2]])
+      @test_throws ArgumentError on_graph(G2, perm(S3, [2, 1, 3]))
+
+      # labels are carried along
+      GL = graph_from_labeled_edges(Directed, Dict((1, 2) => 10, (2, 3) => 20))
+      HL = on_graph(GL, p)
+      @test HL.label[2, 1] == 10
+      @test HL.label[1, 3] == 20
+    end
 end

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -462,17 +462,17 @@
       @test HL.color[2] == GL.color[1]
     end
 
-    @test "permuted_nodes!" begin
+    @test "permute_nodes!" begin
+      p = perm(3, [2, 1, 3])  # (1,2)
       G = graph_from_edges(Directed, [[1, 2], [2, 3]])
-      Polymake.permuted_nodes!(G, [1, 2])
+      permute_nodes!(G, p)
       @test collect(edges(G)) == [ Edge(1, 3),  Edge(2, 1)]
-
+      permute_nodes!(G, p)
       label!(G, Dict((1, 2) => 10, (2, 3) => 20), nothing)
       label!(G, nothing, Dict(1 => "red", 2 => "blue", 3 => "green"); name=:color)
-      p = perm(3, [2, 1, 3])  # (1,2)
       permute_nodes!(G, p)
       @test G.label[2, 1] == 10
       @test G.label[1, 3] == 20
-      @test G.color[2] == GL.color[1]
+      @test G.color[2] == "red"
     end
 end


### PR DESCRIPTION
acts on the graph while also permuting all the graph labels.
creates new graph.

Claude-code was used for the docs and the tests.

This code extracts the `_permute_nodes` code to be reusable.