### PR TITLE
Shortcut for collecting exponent vectors for fine gradings

### DIFF
--- a/experimental/DoubleAndHyperComplexes/src/Morphisms/strand_functionality.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Morphisms/strand_functionality.jl
@@ -69,6 +69,11 @@ end
 
 # TODO: Code duplicated from `monomial_basis`. Clean this up!
 function all_exponents(W::MPolyDecRing, d::FinGenAbGroupElem; check::Bool=true)
+  if is_fine_graded(W) 
+    any(d[i] < 0 for i in 1:ngens(parent(d))) && return Vector{Int}[]
+    return Vector{Int}[[Int(d[i]) for i in 1:ngens(parent(d))]]
+  end
+
   D = W.D
   @check is_free(D) "Grading group must be free"
   h = hom(free_abelian_group(ngens(W)), D, W.d)

--- a/experimental/DoubleAndHyperComplexes/src/Morphisms/strand_functionality.jl
+++ b/experimental/DoubleAndHyperComplexes/src/Morphisms/strand_functionality.jl
@@ -67,11 +67,18 @@ function strand(c::AbsHyperComplex{T}, d::Union{Int, FinGenAbGroupElem}; check::
 end
 
 
+# allocation free getter and conversion in one go
+function _getindex(::Type{Int}, b::FinGenAbGroupElem, i::Int)
+  return unsafe_load(Nemo.mat_entry_ptr(b.coeff, 1, i))
+end
+
 # TODO: Code duplicated from `monomial_basis`. Clean this up!
 function all_exponents(W::MPolyDecRing, d::FinGenAbGroupElem; check::Bool=true)
   if is_fine_graded(W) 
-    any(d[i] < 0 for i in 1:ngens(parent(d))) && return Vector{Int}[]
-    return Vector{Int}[[Int(d[i]) for i in 1:ngens(parent(d))]]
+    n = ngens(parent(d))
+    res = Int[_getindex(Int, d, i) for i in 1:n]
+    any(<(0), res) && return Vector{Int}[]
+    return [res]
   end
 
   D = W.D

--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -4,6 +4,7 @@
   D::FinGenAbGroup
   d::Vector{FinGenAbGroupElem}
   lt::Any
+  is_fine_graded::Bool
   hilbert_series_parent::Generic.LaurentPolyWrapRing{ZZRingElem, ZZPolyRing}
   multi_hilbert_series_parent::Generic.LaurentMPolyWrapRing{ZZRingElem, ZZMPolyRing}
 
@@ -14,6 +15,7 @@
     r.R = R
     r.D = parent(d[1])
     r.d = d
+    r.is_fine_graded = is_free(parent(d[1])) && (rank(parent(d[1])) == ngens(R)) && (d == gens(parent(d[1])))
     return r
   end
   function MPolyDecRing(R::S, d::Vector{FinGenAbGroupElem}, lt) where {S}
@@ -24,11 +26,13 @@
     r.D = parent(d[1])
     r.d = d
     r.lt = lt
+    r.is_fine_graded = is_free(parent(d[1])) &&  (rank(parent(d[1])) == ngens(R)) && (d == gens(parent(d[1])))
     return r
   end
 end
 
 generator_degrees(S::MPolyDecRing) = S.d
+is_fine_graded(S::MPolyDecRing) = S.is_fine_graded
 
 @doc raw"""
     grading_group(R::MPolyDecRing)


### PR DESCRIPTION
Something else I encountered while working on direct images. Apparently the call to Polymake for collecting lattice points in a bounded polytope has some significant overhead. Hence I thought that it might make sense to catch some easy cases which will probably often be used. 

Timings to be added. 