### PR TITLE
Add `regular_action_homomorphism` function for a finite group

### DIFF
--- a/docs/src/Groups/grouphom.md
+++ b/docs/src/Groups/grouphom.md
@@ -143,6 +143,7 @@ isomorphic_subgroups(H::GAPGroup, G::GAPGroup)
 ```@docs
 isomorphism(::Type{T}, G::Group) where T <: Group
 isomorphism(::Type{FinGenAbGroup}, G::GAPGroup)
+regular_action_homomorphism(G::GAPGroup)
 ```
 
 ## Technicalities

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -375,6 +375,7 @@ GAP.@wrap Random(x::GapObj, y::GapObj)::GAP.Obj
 GAP.@wrap Range(x::GapObj)::GapObj
 GAP.@wrap RecognizeGroup(x::GapObj)::GapObj
 GAP.@wrap ReduceCoeffs(x::GapObj, y::GapObj)
+GAP.@wrap RegularActionHomomorphism(x::GapObj)::GapObj
 GAP.@wrap RelativeOrder(x::GapObj)::GapInt
 GAP.@wrap RelativeOrderOfPcElement(x::GapObj, y::GapObj)::GapInt
 GAP.@wrap RelativeOrders(x::GapObj)::GapObj

--- a/src/Groups/action.jl
+++ b/src/Groups/action.jl
@@ -868,3 +868,29 @@ function right_coset_action(G::GAPGroup, U::GAPGroup)
   H = PermGroup(GAPWrap.Range(mp))
   return GAPGroupHomomorphism(G, H, mp)
 end
+
+@doc raw"""
+    regular_action_homomorphism(G::GAPGroup)
+
+Return an isomorphism from finite $G$ onto the regular permutation representation of $G$.
+
+# Examples
+```jldoctest
+julia> g = symmetric_group(5)
+Symmetric group of degree 5
+
+julia> hom = regular_action_homomorphism(g)
+Group homomorphism
+  from symmetric group of degree 5
+  to permutation group of degree 120 and order 120
+
+julia> number_of_moved_points(image(hom)[1]) == order(g)
+true
+```
+"""
+function regular_action_homomorphism(G::GAPGroup)
+  @req is_finite(G) "G must be a finite group."
+  hom = GAPWrap.RegularActionHomomorphism(GapObj(G))
+  H = PermGroup(GAPWrap.Image(hom))
+  return GAPGroupHomomorphism(G, H, hom)
+end

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1590,6 +1590,7 @@ export register_morphism!
 export regular_120_cell
 export regular_24_cell
 export regular_600_cell
+export regular_action_homomorphism
 export regular_character
 export regular_triangulation
 export regular_triangulations

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -934,3 +934,39 @@ end
    @test domain(comp) == domain(epi)
    @test codomain(comp) == codomain(iso)
 end
+
+@testset "regular_action_homomorphism" begin
+   @testset for G in [symmetric_group(4), dihedral_group(8), quaternion_group(8), alternating_group(5)]
+     hom = regular_action_homomorphism(G)
+     H = image(hom)[1]
+
+     @test hom isa Oscar.GAPGroupHomomorphism
+     @test domain(hom) === G
+     @test codomain(hom) == H
+     @test H isa PermGroup
+     @test degree(H) == order(G)
+     @test order(H) == order(G)
+     @test number_of_moved_points(H) == order(G)
+     @test is_injective(hom)
+     @test is_surjective(hom)
+     @test is_bijective(hom)
+
+     x = rand(G)
+     img = hom(x)
+     @test img in H
+     @test order(img) == order(x)
+     @test preimage(hom, img) == x
+   end
+
+   G = symmetric_group(5)
+   hom = regular_action_homomorphism(G)
+   H = image(hom)[1]
+   @test hom(gens(G)[1]) != one(H)
+
+   G = cyclic_group(6)
+   hom = regular_action_homomorphism(G)
+   H = image(hom)[1]
+   @test degree(H) == 6
+
+   @test_throws ArgumentError regular_action_homomorphism(free_group(2))
+end


### PR DESCRIPTION
    regular_action_homomorphism(G::GAPGroup)

Return an isomorphism from finite $G$ onto the regular permutation representation of $G$.

# Examples
```jldoctest
julia> g = symmetric_group(5)
Symmetric group of degree 5

julia> hom = regular_action_homomorphism(g)
Group homomorphism
  from symmetric group of degree 5
  to permutation group of degree 120 and order 120

julia> number_of_moved_points(image(hom)[1]) == order(g)
true
```