### PR TITLE
covector_decomposition: fix properties of output object

### DIFF
--- a/src/TropicalGeometry/TropicalPolyhedron/properties.jl
+++ b/src/TropicalGeometry/TropicalPolyhedron/properties.jl
@@ -300,7 +300,13 @@ julia> CD |> maximal_polyhedra
 ```
 """
 function covector_decomposition(P::TropicalPointConfiguration; dehomogenize_by=1)
-  return Polymake.tropical.torus_subdivision_as_complex(P.pm_tpolytope, dehomogenize_by-1)::Polymake.BigObject |> polyhedral_complex
+  tsc = Polymake.tropical.torus_subdivision_as_complex(P.pm_tpolytope, dehomogenize_by-1)::Polymake.BigObject
+  # workaround until a polymake bug is fixed:
+  # the torus_subdivision_as_complex client produces an empty lineality space matrix with the wrong number of
+  # columns which can cause subsequent computations to fail
+  # we copy the relevant properties to a new object and return that instead
+  tsc_fixed = Polymake.fan.PolyhedralComplex{Polymake.Rational}(VERTICES=tsc.VERTICES, MAXIMAL_POLYTOPES=tsc.MAXIMAL_POLYTOPES, FAN_AMBIENT_DIM=ncols(tsc.VERTICES))
+  return PolyhedralComplex{QQFieldElem}(tsc_fixed)
 end
 
 @doc raw"""

--- a/test/TropicalGeometry/tropical_polyhedra.jl
+++ b/test/TropicalGeometry/tropical_polyhedra.jl
@@ -220,6 +220,9 @@ end
      __sign*[-1, 0]
     ])
 
+  # issue 6095
+  @test f_vector(covector_decomposition(C2)) isa Vector{Int64}
+
   pts3 = TT[0 1__sign 4__sign; oo 0 2__sign; oo oo 0]
   C3 = tropical_point_configuration(pts3)
   @test issetequal(points(C3), eachrow(pts3))


### PR DESCRIPTION
fixes subsequent f_vector computation

cc: @KevinKuehn 
fixes: #6095 