### PR TITLE
Add `dual` for roots and coroots

### DIFF
--- a/docs/src/LieTheory/root_systems.md
+++ b/docs/src/LieTheory/root_systems.md
@@ -113,6 +113,7 @@ RootSpaceElem(::RootSystem, ::Vector{<:RationalUnion})
 RootSpaceElem(::RootSystem, ::QQMatrix)
 RootSpaceElem(::WeightLatticeElem)
 zero(::Type{RootSpaceElem}, ::RootSystem)
+dual(::DualRootSpaceElem)
 ```
 
 ```@docs
@@ -158,6 +159,7 @@ reflect!(::RootSpaceElem, ::RootSpaceElem)
 DualRootSpaceElem(::RootSystem, ::Vector{<:RationalUnion})
 DualRootSpaceElem(::RootSystem, ::QQMatrix)
 zero(::Type{DualRootSpaceElem}, ::RootSystem)
+dual(::RootSpaceElem)
 ```
 
 ```@docs

--- a/src/LieTheory/RootSystem.jl
+++ b/src/LieTheory/RootSystem.jl
@@ -1375,7 +1375,8 @@ function dot(r1::DualRootSpaceElem, r2::DualRootSpaceElem)
 
   # return dot(coefficients(r1) * _bilinear_form_QQ_of_dual(root_system(r1)), coefficients(r2)) # currently the below is faster
   return only(
-    coefficients(r1) * _bilinear_form_QQ_of_dual(root_system(r1)) * transpose(coefficients(r2))
+    coefficients(r1) * _bilinear_form_QQ_of_dual(root_system(r1)) *
+    transpose(coefficients(r2)),
   )
 end
 
@@ -1573,7 +1574,7 @@ If `r` is a root, this is the coroot corresponding to `r`.
 function dual(r::RootSpaceElem)
   R = root_system(r)
   lr = dot(r, r)
-  coeffs = [dot(simple_root(R, i), simple_root(R, i))//lr * coeff(r,i) for i in 1:rank(R)]
+  coeffs = [dot(simple_root(R, i), simple_root(R, i))//lr * coeff(r, i) for i in 1:rank(R)]
   return DualRootSpaceElem(R, coeffs)
 end
 
@@ -1587,7 +1588,9 @@ If `r` is a coroot, this is the root corresponding to `r`.
 function dual(r::DualRootSpaceElem)
   R = root_system(r)
   lr = dot(r, r)
-  coeffs = [dot(simple_coroot(R, i), simple_coroot(R, i))//lr * coeff(r,i) for i in 1:rank(R)]
+  coeffs = [
+    dot(simple_coroot(R, i), simple_coroot(R, i))//lr * coeff(r, i) for i in 1:rank(R)
+  ]
   return RootSpaceElem(R, coeffs)
 end
 

--- a/src/LieTheory/RootSystem.jl
+++ b/src/LieTheory/RootSystem.jl
@@ -1566,7 +1566,9 @@ end
 @doc raw"""
     dual(r::RootSpaceElem) -> DualRootSpaceElem
 
-Return the coroot corresponding to `r` in the dual root space of its root system.
+Return the dual element to `r`.
+
+If `r` is a root, this is the coroot corresponding to `r`.
 """
 function dual(r::RootSpaceElem)
   R = root_system(r)
@@ -1578,7 +1580,9 @@ end
 @doc raw"""
     dual(r::DualRootSpaceElem) -> RootSpaceElem
 
-Return the root corresponding to the coroot `r` in the root space of its root system.
+Return the dual element to `r`, identified with an element in the root space instead of its bidual space.
+
+If `r` is a coroot, this is the root corresponding to `r`.
 """
 function dual(r::DualRootSpaceElem)
   R = root_system(r)

--- a/src/LieTheory/RootSystem.jl
+++ b/src/LieTheory/RootSystem.jl
@@ -142,6 +142,14 @@ end
   return QQMatrix(bilinear_form(R))
 end
 
+@attr ZZMatrix function bilinear_form_of_dual(R::RootSystem)
+  return cartan_bilinear_form(cartan_matrix_tr(R); check=false)
+end
+
+@attr QQMatrix function _bilinear_form_QQ_of_dual(R::RootSystem)
+  return QQMatrix(bilinear_form_of_dual(R))
+end
+
 @doc raw"""
     cartan_matrix(R::RootSystem) -> ZZMatrix
 
@@ -1362,6 +1370,15 @@ function Base.getindex(r::DualRootSpaceElem, i::Int)
   return coeff(r, i)
 end
 
+function dot(r1::DualRootSpaceElem, r2::DualRootSpaceElem)
+  @req root_system(r1) === root_system(r2) "parent root system mismatch"
+
+  # return dot(coefficients(r1) * _bilinear_form_QQ_of_dual(root_system(r1)), coefficients(r2)) # currently the below is faster
+  return only(
+    coefficients(r1) * _bilinear_form_QQ_of_dual(root_system(r1)) * transpose(coefficients(r2))
+  )
+end
+
 function expressify(r::DualRootSpaceElem; context=nothing)
   if is_unicode_allowed()
     return expressify(r, :α̌; context)
@@ -1544,6 +1561,30 @@ end
 
 function dot(w::WeightLatticeElem, r::RootSpaceElem)
   return dot(r, w)
+end
+
+@doc raw"""
+    dual(r::RootSpaceElem) -> DualRootSpaceElem
+
+Return the coroot corresponding to `r` in the dual root space of its root system.
+"""
+function dual(r::RootSpaceElem)
+  R = root_system(r)
+  lr = dot(r, r)
+  coeffs = [dot(simple_root(R, i), simple_root(R, i))//lr * coeff(r,i) for i in 1:rank(R)]
+  return DualRootSpaceElem(R, coeffs)
+end
+
+@doc raw"""
+    dual(r::DualRootSpaceElem) -> RootSpaceElem
+
+Return the root corresponding to the coroot `r` in the root space of its root system.
+"""
+function dual(r::DualRootSpaceElem)
+  R = root_system(r)
+  lr = dot(r, r)
+  coeffs = [dot(simple_coroot(R, i), simple_coroot(R, i))//lr * coeff(r,i) for i in 1:rank(R)]
+  return RootSpaceElem(R, coeffs)
 end
 
 ###############################################################################

--- a/test/LieTheory/RootSystem.jl
+++ b/test/LieTheory/RootSystem.jl
@@ -308,7 +308,7 @@
     end
   end
 
-  @testset "coroot" begin
+  @testset "dual" begin
     @testset "$Rname" for (Rname, R) in [
       ("A5", root_system(:A, 5)),
       ("B3", root_system(:B, 3)),
@@ -316,11 +316,14 @@
       ("F4", root_system(:F, 4)),
       ("G2", root_system(:G, 2)),
     ]
-      for i in 1:rank(R)
-        @test dual(simple_root(R,i)) == simple_coroot(R,i)
+      for i in 1:number_of_roots(R)
+        @test dual(root(R, i)) == coroot(R, i)
+        @test dual(coroot(R, i)) == root(R, i)
       end
-      for i in roots(R)
-        @test dual(dual(i)) == i
+
+      for _ in 1:10
+        r = RootSpaceElem(R, rand(-10:10, rank(R)))
+        @test dual(dual(r)) == r
       end
     end
   end

--- a/test/LieTheory/RootSystem.jl
+++ b/test/LieTheory/RootSystem.jl
@@ -307,4 +307,21 @@
       @test result == @inferred dot(RootSpaceElem(w1), RootSpaceElem(w2))
     end
   end
+
+  @testset "coroot" begin
+    @testset "$Rname" for (Rname, R) in [
+      ("A5", root_system(:A, 5)),
+      ("B3", root_system(:B, 3)),
+      ("D4", root_system(:D, 4)),
+      ("F4", root_system(:F, 4)),
+      ("G2", root_system(:G, 2)),
+    ]
+      for i in 1:rank(R)
+        @test dual(simple_root(R,i)) == simple_coroot(R,i)
+      end
+      for i in roots(R)
+        @test dual(dual(i)) == i
+      end
+    end
+  end
 end


### PR DESCRIPTION
add a function that dualizes a root to a coroot and vice versa and extend functionality of dot product to coroots