### PR TITLE
CI: the NoExperimental CI job should not run whitelisted experimental tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,7 +83,7 @@ end
 
 testlist = Oscar._gather_tests("test")
 
-if !islink(joinpath(expdir, "NoExperimental_whitelist.jl")) # add no experimental tests in the NoExperimental CI job
+if !islink(joinpath(Oscar.expdir, "NoExperimental_whitelist.jl")) # add no experimental tests in the NoExperimental CI job
   for exp in Oscar.exppkgs
     path = joinpath(Oscar.oscardir, "experimental", exp, "test")
     if isdir(path) && exp != "Parallel"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,10 +83,12 @@ end
 
 testlist = Oscar._gather_tests("test")
 
-for exp in Oscar.exppkgs
-  path = joinpath(Oscar.oscardir, "experimental", exp, "test")
-  if isdir(path) && exp != "Parallel"
-    append!(testlist, Oscar._gather_tests(path))
+if !islink(joinpath(expdir, "NoExperimental_whitelist.jl")) # add no experimental tests in the NoExperimental CI job
+  for exp in Oscar.exppkgs
+    path = joinpath(Oscar.oscardir, "experimental", exp, "test")
+    if isdir(path) && exp != "Parallel"
+      append!(testlist, Oscar._gather_tests(path))
+    end
   end
 end
 


### PR DESCRIPTION
Implements point 2 of https://github.com/oscar-system/Oscar.jl/issues/6088#issuecomment-4913510865.