### PR TITLE
Alternative interface to group libraries

### DIFF
--- a/experimental/GroupLibraries/docs/doc.main
+++ b/experimental/GroupLibraries/docs/doc.main
@@ -1,5 +1,5 @@
 [
-   "Group libraries" => [
+   "Group libraries (variant 1)" => [
       "introduction.md",
       "GroupLibraries.md",
    ],

--- a/experimental/GroupLibraries/docs/doc.main
+++ b/experimental/GroupLibraries/docs/doc.main
@@ -1,0 +1,7 @@
+[
+   "Group libraries" => [
+      "introduction.md",
+      "GroupLibraries.md",
+   ],
+]
+

--- a/experimental/GroupLibraries/docs/src/GroupLibraries.md
+++ b/experimental/GroupLibraries/docs/src/GroupLibraries.md
@@ -1,0 +1,55 @@
+```@meta
+CurrentModule = Oscar
+CollapsedDocStrings = true
+DocTestSetup = Oscar.doctestsetup()
+```
+
+# Group libraries
+
+Oscar provides access to several libraries of groups.
+There is a Julia module for each such library,
+the functions defined in this module are typically as follows,
+see the library of [Transitive permutation groups of small degree](@ref transgrp_section)
+for examples.
+(Not all of these functions are available for all group libraries,
+and some libraries provide also other functions.)
+
+- `get` returns the group from the library that is defined by the arguments,
+  if the library contains this group
+  (which can be checked via the `has` function)
+- `get_all` returns all groups from the library that have the properties
+  given by the arguments,
+  if the library contains these groups;
+  it depends on the library which equivalence relation is expressed by
+  "all" (up to abstract isomorphism, up to permutation isomorphism, etc.)
+- `get_one` returns one group from the library that has the properties
+  given by the arguments if the library contains the groups in question
+  and if such a group exists, and `nothing` otherwise
+- `has` returns `true` if the library contains all groups
+  given by the arguments
+- `has_count` returns `true` if the number of groups given by the arguments
+  is known, and `false` otherwise
+- `count` returns the number of groups given by the arguments,
+  if the library contains this information
+- `identification` takes a group `G` and returns a value
+  such that calling `get` with this value yields a group from the library
+  that corresponds to `G`,
+  if the library contains this information
+- `has_identification` returns `true` if there is such an `identification`
+  function, and `false` otherwise
+
+## [Transitive permutation groups of small degree](@id transgrp_section)
+
+```@docs
+TransitiveGroups
+```
+
+```@docs
+TransitiveGroups.get
+TransitiveGroups.get_all
+TransitiveGroups.has
+TransitiveGroups.has_count
+TransitiveGroups.count
+TransitiveGroups.has_identification
+TransitiveGroups.identification
+```

--- a/experimental/GroupLibraries/docs/src/GroupLibraries.md
+++ b/experimental/GroupLibraries/docs/src/GroupLibraries.md
@@ -53,3 +53,20 @@ TransitiveGroups.count
 TransitiveGroups.has_identification
 TransitiveGroups.identification
 ```
+
+## Perfect groups of small order
+
+```@docs
+PerfectGroups
+```
+
+```@docs
+PerfectGroups.get
+PerfectGroups.get_all
+PerfectGroups.has
+PerfectGroups.has_count
+PerfectGroups.count
+PerfectGroups.has_identification
+PerfectGroups.identification
+PerfectGroups.orders
+```

--- a/experimental/GroupLibraries/docs/src/GroupLibraries.md
+++ b/experimental/GroupLibraries/docs/src/GroupLibraries.md
@@ -4,7 +4,7 @@ CollapsedDocStrings = true
 DocTestSetup = Oscar.doctestsetup()
 ```
 
-# Group libraries
+# Group libraries (variant 1)
 
 Oscar provides access to several libraries of groups.
 There is a Julia module for each such library,

--- a/experimental/GroupLibraries/docs/src/introduction.md
+++ b/experimental/GroupLibraries/docs/src/introduction.md
@@ -1,0 +1,20 @@
+```@meta
+CurrentModule = Oscar
+CollapsedDocStrings = true
+DocTestSetup = Oscar.doctestsetup()
+```
+
+# Introduction
+
+The aim of `experimental/GroupLibraries` is
+to propose an alternative interface for accessing various group libraries.
+
+## Status
+
+This part of OSCAR is in an experimental state;
+please see [Adding new projects to experimental](@ref) for what this means.
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Thomas Breuer](https://www.math.rwth-aachen.de/~Thomas.Breuer/)

--- a/experimental/GroupLibraries/src/GroupLibraries.jl
+++ b/experimental/GroupLibraries/src/GroupLibraries.jl
@@ -8,11 +8,14 @@ using Oscar
 
 # The following code can be loaded at compile time.
 include("transitivegroups.jl")
+include("perfectgroups.jl")
 
 export TransitiveGroups
+export PerfectGroups
 
 end # module GroupLibraries
 
 using .GroupLibraries
 
 export TransitiveGroups
+export PerfectGroups

--- a/experimental/GroupLibraries/src/GroupLibraries.jl
+++ b/experimental/GroupLibraries/src/GroupLibraries.jl
@@ -1,0 +1,18 @@
+@doc """
+GroupLibraries.jl provides access to several libraries of groups.
+"""
+module GroupLibraries
+
+# the necessary Julia packages
+using Oscar
+
+# The following code can be loaded at compile time.
+include("transitivegroups.jl")
+
+export TransitiveGroups
+
+end # module GroupLibraries
+
+using .GroupLibraries
+
+export TransitiveGroups

--- a/experimental/GroupLibraries/src/perfectgroups.jl
+++ b/experimental/GroupLibraries/src/perfectgroups.jl
@@ -85,7 +85,7 @@ julia> PerfectGroups.has(2*10^6+1)
 false
 ```
 """
-function has(deg::Int)
+function has(n::Int)
   @req n >= 1 "order must be positive, not $n"
   return n <= 2_000_000
 end
@@ -198,8 +198,8 @@ These conditions may be of one of the following forms:
 - `!func` selects groups for which the function `func` returns `false`
 
 As a special case, the first argument may also be one of the following:
-- `intval` selects groups whose degree equals `intval`; this is equivalent to `degree => intval`
-- `intlist` selects groups whose degree is in `intlist`; this is equivalent to `degree => intlist`
+- `intval` selects groups whose order equals `intval`; this is equivalent to `order => intval`
+- `intlist` selects groups whose order is in `intlist`; this is equivalent to `order => intlist`
 
 The following functions are currently supported as values for `func`:
 - `is_quasisimple`

--- a/experimental/GroupLibraries/src/perfectgroups.jl
+++ b/experimental/GroupLibraries/src/perfectgroups.jl
@@ -1,0 +1,292 @@
+@doc raw"""
+The functions in this module are wrappers for the GAP library of
+finite perfect groups which provides, up to isomorphism,
+a list of all perfect groups whose sizes are less than $2 \cdot 10^6$.
+The groups of most orders up to $10^6$ have been
+enumerated by Derek Holt and Wilhelm Plesken, see [HP89](@cite). For orders
+86016, 368640, or 737280 this work only counted the groups (but did not
+explicitly list them), the groups of orders 61440, 122880, 172032,
+245760, 344064, 491520, 688128, or 983040 were omitted.
+
+Several additional groups omitted from the book [HP89](@cite) have also
+been included. Two groups -- one of order 450000 with a factor group of
+type $A_6$ and the one of order 962280 -- were found in 2005 by Jack Schmidt.
+Two groups of order 243000 and one each of orders 729000, 871200, 878460
+were found in 2020 by Alexander Hulpke.
+
+The perfect groups of size less than $2 \cdot 10^6$ which had not been
+classified in the work of Holt and Plesken have been enumerated by Alexander
+Hulpke, see [Hul22](@cite).
+They are stored directly and provide less construction information
+in their names.
+
+As all groups are stored by presentations, a permutation representation
+is obtained by coset enumeration. Note that some of the library groups do
+not have a faithful permutation representation of small degree.
+Computations in these groups may be rather time consuming.
+"""
+module PerfectGroups
+
+using Oscar
+import Oscar.GAPGroup
+import Oscar.IntegerUnion
+
+@doc raw"""
+    PerfectGroups.has_count(n::Int)
+
+Return whether the number of perfect groups of order `n` is available
+via `PerfectGroups.count(n)`.
+
+Currently the number of perfect groups is available up to order $2 \cdot 10^6$.
+
+# Examples
+```jldoctest
+julia> PerfectGroups.has_count(7200)
+true
+
+julia> PerfectGroups.has_count(2*10^6+1)
+false
+```
+"""
+has_count(n::Int) = has(n) # for now just an alias
+
+"""
+    PerfectGroups.has_identification(n::Int)
+
+Return whether identification of perfect groups of order `n` is available
+via `PerfectGroups.identification(G)`, where `G` is a group of order `n`.
+
+# Examples
+```jldoctest
+julia> PerfectGroups.has_identification(7200)
+true
+
+julia> PerfectGroups.has_identification(2*10^6+1)
+false
+```
+"""
+has_identification(n::Int) = has(n) # for now just an alias
+
+@doc raw"""
+    PerfectGroups.has(n::Int)
+
+Return whether the perfect groups of order `n` are available for
+use.  This function should be used to test for the scope of the library
+available.
+
+Currently all perfect groups up to order $2 \cdot 10^6$ are available.
+
+# Examples
+```jldoctest
+julia> PerfectGroups.has(7200)
+true
+
+julia> PerfectGroups.has(2*10^6+1)
+false
+```
+"""
+function has(deg::Int)
+  @req n >= 1 "order must be positive, not $n"
+  return n <= 2_000_000
+end
+
+"""
+    PerfectGroups.count(n::IntegerUnion)
+
+Return the number of perfect groups of order `n`, up to isomorphism.
+
+# Examples
+```jldoctest
+julia> PerfectGroups.count(60)
+1
+
+julia> PerfectGroups.count(1966080)
+7344
+```
+"""
+function count(n::IntegerUnion)
+   @req n >= 1 "group order must be positive, not $n"
+   res = GAP.Globals.NumberPerfectGroups(GAP.Obj(n))
+   @req (res !== GAP.Globals.fail) "the number of perfect groups of order $n is not available"
+   return res::Int
+end
+
+"""
+    PerfectGroups.get(::Type{T} = PermGroup, n::IntegerUnion, k::IntegerUnion)
+
+Return the `k`-th group of order `n` and type `T` in the catalogue of
+perfect groups in GAP's Perfect Groups Library.
+The type `T` can be either `PermGroup` or `FPGroup`.
+
+# Examples
+```jldoctest
+julia> PerfectGroups.get(60, 1)
+Permutation group of degree 5 and order 60
+
+julia> gens(ans)
+2-element Vector{PermGroupElem}:
+ (1,2)(4,5)
+ (2,3,4)
+
+julia> PerfectGroups.get(FPGroup, 60, 1)
+Finitely presented group of order 60
+
+julia> gens(ans)
+2-element Vector{FPGroupElem}:
+ a
+ b
+
+julia> PerfectGroups.get(60, 2)
+ERROR: ArgumentError: there are only 1 perfect groups of order 60
+[...]
+```
+"""
+function get(::Type{T}, n::IntegerUnion, k::IntegerUnion) where T <: GAPGroup
+   @req n >= 1 "group order must be positive, not $n"
+   @req k >= 1 "group index must be positive, not $k"
+   N = count(n)
+   @req k <= N "there are only $N perfect groups of order $n"
+   if T == PermGroup
+      G = T(GAP.Globals.PerfectGroup(GAP.Globals.IsPermGroup, GAP.Obj(n), GAP.Obj(k)))
+   elseif T == FPGroup
+      G = T(GAP.Globals.PerfectGroup(GAP.Globals.IsSubgroupFpGroup, GAP.Obj(n), GAP.Obj(k)))
+   else
+      throw(ArgumentError("unsupported type $T"))
+   end
+
+   return G
+end
+
+get(n::IntegerUnion, m::IntegerUnion) = get(PermGroup, n, m)
+
+"""
+    PerfectGroups.identification(G::GAPGroup)
+
+Return a pair `(n, m)` such that `G` is isomorphic with
+`PerfectGroups.get(n, m)`.
+If `G` is not perfect, an exception is thrown.
+
+# Examples
+```jldoctest
+julia> PerfectGroups.identification(alternating_group(5))
+(60, 1)
+
+julia> PerfectGroups.identification(SL(2,7))
+(336, 1)
+```
+"""
+function identification(G::GAPGroup)
+   @req is_perfect(G) "group is not perfect"
+   res = GAP.Globals.PerfectIdentification(GapObj(G))
+   @req (res !== GAP.Globals.fail) "identification is not available for groups of order $(order(G))"
+   return Tuple{Int,Int}(res)
+end
+
+"""
+    PerfectGroups.get_all(L...)
+    PerfectGroups.get_one(L...)
+
+`PerfectGroups.get_all` returns the list of all perfect groups
+(up to isomorphism) satisfying the conditions described by the arguments.
+`PerfectGroups.get_one` returns one perfect group satisfying
+the conditions if such a group exists, and `nothing` otherwise.
+These conditions may be of one of the following forms:
+
+- `func => intval` selects groups for which the function `func` returns `intval`
+- `func => list` selects groups for which the function `func` returns any element inside `list`
+- `func` selects groups for which the function `func` returns `true`
+- `!func` selects groups for which the function `func` returns `false`
+
+As a special case, the first argument may also be one of the following:
+- `intval` selects groups whose degree equals `intval`; this is equivalent to `degree => intval`
+- `intlist` selects groups whose degree is in `intlist`; this is equivalent to `degree => intlist`
+
+The following functions are currently supported as values for `func`:
+- `is_quasisimple`
+- `is_simple`
+- `is_sporadic_simple`
+- `number_of_conjugacy_classes`
+- `order`
+
+The type of the returned group(s) is `PermGroup`.
+
+# Examples
+```jldoctest
+julia> PerfectGroups.get_all(7200)
+2-element Vector{PermGroup}:
+ Permutation group of degree 29 and order 7200
+ Permutation group of degree 288 and order 7200
+
+julia> PerfectGroups.get_all(order => 1:200, !is_simple)
+2-element Vector{PermGroup}:
+ Permutation group of degree 1 and order 1
+ Permutation group of degree 24 and order 120
+
+julia> PerfectGroups.get_one(order => 1:200, !is_simple)
+Permutation group of degree 1 and order 1
+```
+"""
+get_all(L...) = _get_all_or_one(L, true)
+
+get_one(L...) = _get_all_or_one(L, false)
+@doc (@doc get_all) get_one
+
+function _get_all_or_one(L, all::Bool)
+   @req !isempty(L) "must specify at least one filter"
+   if L[1] isa IntegerUnion || L[1] isa AbstractVector{<:IntegerUnion}
+      L = (order => L[1], L[2:end]...)
+   end
+   # first get all order restrictions
+   ordsL = [x for x in L if x isa Pair && x[1] == order]
+   @req !isempty(ordsL) "must restrict the order"
+   conds = [x for x in L if !(x isa Pair && x[1] == order)]
+   orders = intersect([x[2] for x in ordsL]...)
+   @req has_perfect_groups(maximum(orders)) "only orders up to 2 million are supported"
+   res = PermGroup[]
+   for n in orders, i in 1:number_of_perfect_groups(n)
+      G = perfect_group(n, i)
+      ok = true
+      for c in conds
+         if c isa Pair
+            val = c[1](G)
+            ok = (val == c[2] || val in c[2])
+         elseif c isa Function
+            ok = c(G)
+         else
+            throw(ArgumentError("expected a function or a pair, got $arg"))
+         end
+         ok || break
+      end
+      !all && ok && return G
+      ok && push!(res, G)
+   end
+   return all ? res : nothing
+end
+
+@doc raw"""
+    PerfectGroups.orders()
+
+Return a sorted vector of all numbers to $2 \cdot 10^6$ that occur as orders
+of perfect groups.
+
+# Examples
+```jldoctest
+julia> PerfectGroups.orders()[1:10]
+10-element Vector{Int64}:
+   1
+  60
+ 120
+ 168
+ 336
+ 360
+ 504
+ 660
+ 720
+ 960
+```
+"""
+orders() = Vector{Int}(GAP.Globals.SizesPerfectGroups())
+
+end # module PerfectGroups
+
+export PerfectGroups

--- a/experimental/GroupLibraries/src/transitivegroups.jl
+++ b/experimental/GroupLibraries/src/transitivegroups.jl
@@ -27,12 +27,6 @@ import Oscar.IntegerUnion
 import Oscar._permgroup_filter_attrs
 import Oscar.translate_group_library_args
 
-# import Oscar.@req
-# import Oscar.GAP
-# import Oscar.GapObj
-# import Oscar.PermGroup
-# import Oscar.degree
-
 """
     TransitiveGroups.has_count(deg::Int)
 

--- a/experimental/GroupLibraries/src/transitivegroups.jl
+++ b/experimental/GroupLibraries/src/transitivegroups.jl
@@ -1,0 +1,280 @@
+"""
+The functions in this module are wrappers for
+the GAP library of transitive permutation groups up to degree 48,
+via the GAP package `TransGrp` [Hul23](@cite).
+
+(The groups of degrees 32 and 48 are currently not automatically
+available in OSCAR,
+one has to install additional data in order to access them.)
+
+The arrangement and the names of the groups of degree up to 15
+is the same as given in [CHM98](@cite).
+With the exception of the symmetric and alternating groups
+(which are represented as `symmetric_group` and `alternating_group`)
+the generators for these groups also conform to this paper
+with the only difference that 0 (which is not permitted in GAP
+for permutations to act on) is always replaced by the degree.
+
+The arrangement for all degrees is intended to be equal to
+the arrangement within the systems GAP and Magma,
+thus it should be safe to refer to particular (classes of) groups
+by their index numbers.
+"""
+module TransitiveGroups
+
+using Oscar
+import Oscar.IntegerUnion
+import Oscar._permgroup_filter_attrs
+import Oscar.translate_group_library_args
+
+# import Oscar.@req
+# import Oscar.GAP
+# import Oscar.GapObj
+# import Oscar.PermGroup
+# import Oscar.degree
+
+"""
+    TransitiveGroups.has_count(deg::Int)
+
+Return whether the number of transitive groups of degree `deg` is available for
+use via `TransitiveGroups.count(deg)`.
+
+# Examples
+```jldoctest
+julia> TransitiveGroups.has_count(30)
+true
+
+julia> TransitiveGroups.has_count(64)
+false
+```
+"""
+has_count(deg::Int) = has(deg)
+
+"""
+    TransitiveGroups.has_identification(deg::Int)
+
+Return whether identification of transitive groups of degree `deg` is available
+via `TransitiveGroups.identification(G)`, where `G` is a permutation group
+of degree `deg`.
+
+# Examples
+```jldoctest
+julia> TransitiveGroups.has_identification(30)
+true
+
+julia> TransitiveGroups.has_identification(64)
+false
+```
+"""
+has_identification(deg::Int) = has(deg)
+
+"""
+    TransitiveGroups.has(deg::Int)
+
+Return whether the transitive groups of degree `deg` are available for
+use. This function should be used to test for the scope of the library
+available.
+
+# Examples
+```jldoctest
+julia> TransitiveGroups.has(30)
+true
+
+julia> TransitiveGroups.has(64)
+false
+```
+"""
+function has(deg::Int)
+  @req deg >= 1 "degree must be positive, not $deg"
+  return deg == 1 || GAP.Globals.TransitiveGroupsAvailable(deg)::Bool
+end
+
+
+"""
+    TransitiveGroups.count(deg::Int)
+
+Return the number of transitive groups of degree `deg`,
+up to permutation isomorphism.
+
+# Examples
+```jldoctest
+julia> TransitiveGroups.count(30)
+5712
+
+julia> TransitiveGroups.count(64)
+ERROR: ArgumentError: the number of transitive groups of degree 64 is not available
+[...]
+```
+"""
+function count(deg::Int)
+  @req has_count(deg) "the number of transitive groups of degree $(deg) is not available"
+  return GAP.Globals.NrTransitiveGroups(deg)::Int
+end
+
+"""
+    TransitiveGroups.get(deg::Int, i::Int)
+
+Return the `i`-th group in the catalogue of transitive groups over the set
+`{1, ..., deg}` in GAP's Transitive Groups Library.
+The output is a group of type `PermGroup`.
+
+# Examples
+```jldoctest
+julia> TransitiveGroups.get(5, 4)
+Alternating group of degree 5
+
+julia> TransitiveGroups.get(5, 6)
+ERROR: ArgumentError: there are only 5 transitive groups of degree 5, not 6
+[...]
+```
+"""
+function get(deg::Int, i::Int)
+  @req has(deg) "transitive groups of degree $deg are not available"
+  N = count(deg)
+  @req i <= N "there are only $N transitive groups of degree $deg, not $i"
+  return PermGroup(GAP.Globals.TransitiveGroup(deg,i), deg)
+end
+
+"""
+    TransitiveGroups.identification(G::PermGroup)
+
+Return a pair `(d, n)` such that `G` is permutation isomorphic with
+`TransitiveGroups.get(d, n)`, where `G` acts transitively on `d` points.
+
+If `G` is not transitive on its moved points, or if the transitive groups of
+degree `d` are not available, an exception is thrown.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(7);  m = TransitiveGroups.identification(G)
+(7, 7)
+
+julia> order(TransitiveGroups.get(m...)) == order(G)
+true
+
+julia> S = sub(G, [perm([1, 3, 4, 5, 2])])[1]
+Permutation group of degree 7
+
+julia> is_transitive(S)
+false
+
+julia> is_transitive(S, moved_points(S))
+true
+
+julia> m = TransitiveGroups.identification(S)
+(4, 1)
+
+julia> order(TransitiveGroups.get(m...)) == order(S)
+true
+
+julia> TransitiveGroups.identification(symmetric_group(64))
+ERROR: ArgumentError: identification of transitive groups of degree 64 are not available
+[...]
+
+julia> S = sub(G, [perm([1, 3, 4, 5, 2, 7, 6])])[1];
+
+julia> TransitiveGroups.identification(S)
+ERROR: ArgumentError: group is not transitive on its moved points
+[...]
+```
+"""
+function identification(G::PermGroup)
+  moved = moved_points(G)
+  @req is_transitive(G, moved) "group is not transitive on its moved points"
+  deg = length(moved)
+  @req has(deg) "identification of transitive groups of degree $(deg) are not available"
+  res = GAP.Globals.TransitiveIdentification(GapObj(G))::Int
+  return deg, res
+end
+
+"""
+    TransitiveGroups.get_all(L...)
+    TransitiveGroups.get_one(L...)
+
+`TransitiveGroups.get_all` returns the list of all transitive groups
+(up to permutation isomorphism) satisfying the conditions described
+by the arguments.
+`TransitiveGroups.get_one` returns one transitive group satisfying
+the conditions if such a group exists, and `nothing` otherwise.
+These conditions may be of one of the following forms:
+
+- `func => intval` selects groups for which the function `func` returns `intval`
+- `func => list` selects groups for which the function `func` returns any element inside `list`
+- `func` selects groups for which the function `func` returns `true`
+- `!func` selects groups for which the function `func` returns `false`
+
+As a special case, the first argument may also be one of the following:
+- `intval` selects groups whose degree equals `intval`; this is equivalent to `degree => intval`
+- `intlist` selects groups whose degree is in `intlist`; this is equivalent to `degree => intlist`
+
+The following functions are currently supported as values for `func`:
+- `degree`
+- `is_abelian`
+- `is_almost_simple`
+- `is_cyclic`
+- `is_nilpotent`
+- `is_perfect`
+- `is_primitive`
+- `is_quasisimple`
+- `is_simple`
+- `is_sporadic_simple`
+- `is_solvable`
+- `is_supersolvable`
+- `is_transitive`
+- `number_of_conjugacy_classes`
+- `number_of_moved_points`
+- `order`
+- `transitivity`
+
+The type of the returned group(s) is `PermGroup`.
+
+# Examples
+```jldoctest
+julia> TransitiveGroups.get_all(4)
+5-element Vector{PermGroup}:
+ Permutation group of degree 4
+ Permutation group of degree 4
+ Permutation group of degree 4
+ Alternating group of degree 4
+ Symmetric group of degree 4
+
+julia> TransitiveGroups.get_one(4)
+Permutation group of degree 4
+
+julia> TransitiveGroups.get_all(degree => 3:5, is_abelian)
+4-element Vector{PermGroup}:
+ Alternating group of degree 3
+ Permutation group of degree 4
+ Permutation group of degree 4
+ Permutation group of degree 5
+
+julia> TransitiveGroups.get_one(degree => 3:5, is_abelian)
+Alternating group of degree 3
+```
+"""
+function get_all(L...)
+   @req !isempty(L) "must specify at least one filter"
+   if L[1] isa IntegerUnion || L[1] isa AbstractVector{<:IntegerUnion}
+      L = (degree => L[1], L[2:end]...)
+   end
+   gapargs = translate_group_library_args(L; filter_attrs = _permgroup_filter_attrs)
+   K = GAP.Globals.AllTransitiveGroups(gapargs...)::GapObj
+   return [PermGroup(x) for x in K]
+end
+# TODO: turn this into an iterator, perhaps using PrimitiveGroupsIterator
+
+function get_one(L...)
+   @req !isempty(L) "must specify at least one filter"
+   if L[1] isa IntegerUnion || L[1] isa AbstractVector{<:IntegerUnion}
+      L = (degree => L[1], L[2:end]...)
+   end
+   gapargs = translate_group_library_args(L; filter_attrs = _permgroup_filter_attrs)
+   K = GAP.Globals.OneTransitiveGroup(gapargs...)::GapObj
+   K === GAP.Globals.fail && return nothing
+   return PermGroup(K)
+end
+@doc (@doc get_all) get_one
+
+end # module TransitiveGroups
+
+export TransitiveGroups

--- a/experimental/GroupLibraries/test/perfect_groups.jl
+++ b/experimental/GroupLibraries/test/perfect_groups.jl
@@ -1,0 +1,44 @@
+@testset "Perfect groups" begin
+   G = alternating_group(5)
+   @test is_perfect(G)
+   @test !is_perfect(symmetric_group(5))
+
+   @test PerfectGroups.get(120, 1) isa PermGroup
+   @test PerfectGroups.get(PermGroup, 120, 1) isa PermGroup
+   @test PerfectGroups.get(FPGroup, 120, 1) isa FPGroup
+   @test_throws ArgumentError PerfectGroups.get(MatGroup, 120, 1)
+
+   @test_throws ArgumentError PerfectGroups.get(17, 0)
+   @test_throws ArgumentError PerfectGroups.get(17, 1)
+   @test_throws ArgumentError PerfectGroups.get(60, 0)
+   @test_throws ArgumentError PerfectGroups.get(60, 2)
+
+   @test is_isomorphic(PerfectGroups.get(60, 1), G)
+   @test [PerfectGroups.count(i) for i in 2:59] == [0 for i in 1:58]
+   x = PerfectGroups.identification(alternating_group(5))
+   @test is_isomorphic(PerfectGroups.get(x[1], x[2]), alternating_group(5))
+   @test_throws ArgumentError PerfectGroups.identification(symmetric_group(5))
+
+   @test sum(PerfectGroups.count, 1:59) == 1
+   @test PerfectGroups.count(ZZRingElem(60)^3) == 1
+   @test_throws ArgumentError PerfectGroups.count(0) # invalid argument
+   @test_throws ArgumentError PerfectGroups.count(ZZRingElem(60)^10)  # result not known
+
+   Gs = PerfectGroups.get_all(order => 1:200)
+   @test length(Gs) == sum(PerfectGroups.count, 1:200)
+   @test Gs == PerfectGroups.get_all(1:200)
+   @test length(PerfectGroups.get_all(7200)) == PerfectGroups.count(7200)
+
+   # all_perfect_groups with additional attributes
+   @test filter(G -> number_of_conjugacy_classes(G) in 5:8, Gs) == PerfectGroups.get_all(1:200, number_of_conjugacy_classes => 5:8)
+   @test filter(is_simple, Gs) == PerfectGroups.get_all(1:200, is_simple)
+   @test filter(is_simple, Gs) == PerfectGroups.get_all(1:200, is_simple => true)
+   @test filter(!is_simple, Gs) == PerfectGroups.get_all(1:200, !is_simple)
+   @test filter(!is_simple, Gs) == PerfectGroups.get_all(1:200, is_simple => false)
+
+   # all_perfect_groups with multiple order specifications
+   @test PerfectGroups.get_all(order => 1:5:200, order => 25:50) == PerfectGroups.get_all(order => intersect(1:5:200, 25:50))
+
+   # lazy artifact loading
+   @test PerfectGroups.get(1376256, 1) isa PermGroup
+end

--- a/experimental/GroupLibraries/test/transitive_groups.jl
+++ b/experimental/GroupLibraries/test/transitive_groups.jl
@@ -1,0 +1,76 @@
+@testset "Transitive groups" begin
+   @test TransitiveGroups.has(10)
+   @test !TransitiveGroups.has(60)
+
+   @test TransitiveGroups.has_count(10)
+   @test !TransitiveGroups.has_count(60)
+
+   @test TransitiveGroups.has_identification(10)
+   @test !TransitiveGroups.has_identification(60)
+
+   @test TransitiveGroups.count(4) == 5
+   @test TransitiveGroups.count(10) == 45
+   @test_throws ArgumentError TransitiveGroups.count(60)
+
+   for i in 1:10
+     @test TransitiveGroups.count(i) == length(TransitiveGroups.get_all(degree => i))
+   end
+
+   @test length(TransitiveGroups.get_all(degree => -1)) == 0
+   @test TransitiveGroups.get_one(degree => -1) == nothing
+
+   G = symmetric_group(4)
+   H1 = alternating_group(4)
+   H2 = sub(G, [G([2, 3, 4, 1])])[1]                   # cyclic
+   H3 = sub(G, [G([2, 3, 4, 1]), G([2, 1, 4, 3])])[1]  # dihedral
+   H4 = sub(G, [G([3, 4, 1, 2]), G([2, 1, 4, 3])])[1]  # Klein subgroup
+   L = [G, H1, H2, H3, H4]
+   grps = TransitiveGroups.get_all(degree => 4)
+   @test TransitiveGroups.get_one(degree => 4) in grps
+   for K in grps
+     @test count(l -> is_isomorphic(K, l), L) == 1
+   end
+   ids = [TransitiveGroups.identification(l) for l in L]
+   @test sort(ids) == [(4, i) for i in 1:5]
+   @test L == [TransitiveGroups.get(id...) for id in ids]
+   @test Set(L) == Set(TransitiveGroups.get_all(degree => 4))
+   @test [H2] == TransitiveGroups.get_all(degree => 4, is_cyclic)
+   @test [H4] == TransitiveGroups.get_all(degree => 4, !is_cyclic, is_abelian)
+
+   grps = TransitiveGroups.get_all(degree => 6)
+   @test length(grps) == 16
+   props = [
+      is_abelian,
+      is_almost_simple,
+      is_cyclic,
+      is_nilpotent,
+      is_perfect,
+      is_quasisimple,
+      is_simple,
+      is_sporadic_simple,
+      is_solvable,
+      is_supersolvable,
+      is_transitive,
+      is_primitive,
+   ]
+   @testset "get_all filtering for $(prop)" for prop in props
+     @test length(TransitiveGroups.get_all(degree => 6, prop => true)) == count(prop, grps)
+     @test length(TransitiveGroups.get_all(degree => 6, prop => false)) == count(!prop, grps)
+
+     @test length(TransitiveGroups.get_all(degree => 6, prop)) == count(prop, grps)
+     @test length(TransitiveGroups.get_all(degree => 6, !prop)) == count(!prop, grps)
+   end
+
+   @test length(TransitiveGroups.get_all(degree => 6, order => 1:12)) == count(g -> order(g) in 1:12, grps)
+
+   @test length(TransitiveGroups.get_all(degree => 1:6)) == sum([length(TransitiveGroups.get_all(degree => i)) for i in 1:6])
+
+   @test issetequal(TransitiveGroups.get_all(3:2:9), TransitiveGroups.get_all(degree => 3:2:9))
+   @test issetequal(TransitiveGroups.get_all(collect(3:2:9)), TransitiveGroups.get_all(3:2:9))
+   @test issetequal(reduce(vcat, (TransitiveGroups.get_all(i) for i in 3:2:9)), TransitiveGroups.get_all(3:2:9))
+
+   @test issetequal(TransitiveGroups.get_all(3:2:9, is_abelian), TransitiveGroups.get_all(degree => 3:2:9, is_abelian))
+   @test issetequal(TransitiveGroups.get_all(9, is_abelian), TransitiveGroups.get_all(degree => 9, is_abelian))
+
+   @test_throws ArgumentError TransitiveGroups.get(1, 2)
+end

--- a/experimental/GroupLibraries2/docs/doc.main
+++ b/experimental/GroupLibraries2/docs/doc.main
@@ -1,0 +1,7 @@
+[
+   "Group libraries (variant 2)" => [
+      "introduction.md",
+      "GroupLibraries2.md",
+   ],
+]
+

--- a/experimental/GroupLibraries2/docs/src/GroupLibraries2.md
+++ b/experimental/GroupLibraries2/docs/src/GroupLibraries2.md
@@ -1,0 +1,56 @@
+```@meta
+CurrentModule = Oscar
+CollapsedDocStrings = true
+DocTestSetup = Oscar.doctestsetup()
+```
+
+# Group libraries (variant 2)
+
+Oscar provides access to several libraries of groups.
+There is a Julia type for each such library,
+which can be used as the first argument of functions for accessing
+data of the library in question,
+see the library of [Transitive permutation groups of small degree](@ref transgrp_section2)
+for examples.
+(Not all of these functions are available for all group libraries,
+and some libraries provide also other functions.)
+
+- `get` returns the group from the library that is defined by the arguments,
+  if the library contains this group
+  (which can be checked via the `has` function)
+- `get_all` returns all groups from the library that have the properties
+  given by the arguments,
+  if the library contains these groups;
+  it depends on the library which equivalence relation is expressed by
+  "all" (up to abstract isomorphism, up to permutation isomorphism, etc.)
+- `get_one` returns one group from the library that has the properties
+  given by the arguments if the library contains the groups in question
+  and if such a group exists, and `nothing` otherwise
+- `has` returns `true` if the library contains all groups
+  given by the arguments
+- `has_count` returns `true` if the number of groups given by the arguments
+  is known, and `false` otherwise
+- `count` returns the number of groups given by the arguments,
+  if the library contains this information
+- `identification` takes a group `G` and returns a value
+  such that calling `get` with this value yields a group from the library
+  that corresponds to `G`,
+  if the library contains this information
+- `has_identification` returns `true` if there is such an `identification`
+  function, and `false` otherwise
+
+## [Transitive permutation groups of small degree](@id transgrp_section2)
+
+```@docs
+TransitiveGroupsLibrary
+```
+
+```@docs
+get(::Type{TransitiveGroupsLibrary}, deg::Int, i::Int)
+get_all(::Type{TransitiveGroupsLibrary}, L...)
+has(::Type{TransitiveGroupsLibrary}, deg::Int)
+has_count(T::Type{TransitiveGroupsLibrary}, deg::Int)
+count(::Type{TransitiveGroupsLibrary}, deg::Int)
+has_identification(T::Type{TransitiveGroupsLibrary}, deg::Int)
+identification(::Type{TransitiveGroupsLibrary}, G::PermGroup)
+```

--- a/experimental/GroupLibraries2/docs/src/introduction.md
+++ b/experimental/GroupLibraries2/docs/src/introduction.md
@@ -1,0 +1,20 @@
+```@meta
+CurrentModule = Oscar
+CollapsedDocStrings = true
+DocTestSetup = Oscar.doctestsetup()
+```
+
+# Introduction
+
+The aim of `experimental/GroupLibraries2` is
+to propose another alternative interface for accessing various group libraries.
+
+## Status
+
+This part of OSCAR is in an experimental state;
+please see [Adding new projects to experimental](@ref) for what this means.
+
+## Contact
+
+Please direct questions about this part of OSCAR to the following people:
+* [Thomas Breuer](https://www.math.rwth-aachen.de/~Thomas.Breuer/)

--- a/experimental/GroupLibraries2/src/GroupLibraries2.jl
+++ b/experimental/GroupLibraries2/src/GroupLibraries2.jl
@@ -1,0 +1,25 @@
+@doc """
+GroupLibraries2.jl provides access to several libraries of groups.
+"""
+module GroupLibraries2
+
+# the necessary Julia packages
+using Oscar
+import Oscar.GAPGroup
+import Oscar.IntegerUnion
+import Oscar._permgroup_filter_attrs
+import Oscar.translate_group_library_args
+import Base.count, Base.get
+
+# The following code can be loaded at compile time.
+include("transitivegroups.jl")
+
+export get, get_all, get_one, has, has_count, count, identification, has_identification
+export TransitiveGroupsLibrary
+
+end # module GroupLibraries2
+
+using .GroupLibraries2
+
+export get, get_all, get_one, has, has_count, count, identification, has_identification
+export TransitiveGroupsLibrary

--- a/experimental/GroupLibraries2/src/transitivegroups.jl
+++ b/experimental/GroupLibraries2/src/transitivegroups.jl
@@ -1,0 +1,270 @@
+"""
+    TransitiveGroupsLibrary
+
+This type is intended to be used as the first argument of functions
+such as `get`, `count`, `identification` in the context of
+GAP's library of transitive permutation groups.
+
+This library provides access to the transitive permutation groups
+up to degree 48, via the GAP package `TransGrp` [Hul23](@cite).
+
+(The groups of degrees 32 and 48 are currently not automatically
+available in OSCAR,
+one has to install additional data in order to access them.)
+
+The arrangement and the names of the groups of degree up to 15
+is the same as given in [CHM98](@cite).
+With the exception of the symmetric and alternating groups
+(which are represented as `symmetric_group` and `alternating_group`)
+the generators for these groups also conform to this paper
+with the only difference that 0 (which is not permitted in GAP
+for permutations to act on) is always replaced by the degree.
+
+The arrangement for all degrees is intended to be equal to
+the arrangement within the systems GAP and Magma,
+thus it should be safe to refer to particular (classes of) groups
+by their index numbers.
+"""
+struct TransitiveGroupsLibrary end
+
+"""
+    has_count(TransitiveGroupsLibrary, deg::Int)
+
+Return whether the number of transitive groups of degree `deg` is available for
+use via `count(TransitiveGroupsLibrary, deg)`.
+
+# Examples
+```jldoctest
+julia> has_count(TransitiveGroupsLibrary, 30)
+true
+
+julia> has_count(TransitiveGroupsLibrary, 64)
+false
+```
+"""
+has_count(T::Type{TransitiveGroupsLibrary}, deg::Int) = has(T, deg)
+
+"""
+    has_identification(TransitiveGroupsLibrary, deg::Int)
+
+Return whether identification of transitive groups of degree `deg` is available
+via `identification(TransitiveGroupsLibrary, G)`, where `G` is a permutation group
+of degree `deg`.
+
+# Examples
+```jldoctest
+julia> has_identification(TransitiveGroupsLibrary, 30)
+true
+
+julia> has_identification(TransitiveGroupsLibrary, 64)
+false
+```
+"""
+has_identification(T::Type{TransitiveGroupsLibrary}, deg::Int) = has(T, deg)
+
+"""
+    has(TransitiveGroupsLibrary, deg::Int)
+
+Return whether the transitive groups of degree `deg` are available for
+use. This function should be used to test for the scope of the library
+available.
+
+# Examples
+```jldoctest
+julia> has(TransitiveGroupsLibrary, 30)
+true
+
+julia> has(TransitiveGroupsLibrary, 64)
+false
+```
+"""
+function has(::Type{TransitiveGroupsLibrary}, deg::Int)
+  @req deg >= 1 "degree must be positive, not $deg"
+  return deg == 1 || GAP.Globals.TransitiveGroupsAvailable(deg)::Bool
+end
+
+
+"""
+    count(TransitiveGroupsLibrary, deg::Int)
+
+Return the number of transitive groups of degree `deg`,
+up to permutation isomorphism.
+
+# Examples
+```jldoctest
+julia> count(TransitiveGroupsLibrary, 30)
+5712
+
+julia> count(TransitiveGroupsLibrary, 64)
+ERROR: ArgumentError: the number of transitive groups of degree 64 is not available
+[...]
+```
+"""
+function Base.count(T::Type{TransitiveGroupsLibrary}, deg::Int)
+  @req has_count(T, deg) "the number of transitive groups of degree $(deg) is not available"
+  return GAP.Globals.NrTransitiveGroups(deg)::Int
+end
+
+"""
+    get(TransitiveGroupsLibrary, deg::Int, i::Int)
+
+Return the `i`-th group in the catalogue of transitive groups over the set
+`{1, ..., deg}` in GAP's Transitive Groups Library.
+The output is a group of type `PermGroup`.
+
+# Examples
+```jldoctest
+julia> get(TransitiveGroupsLibrary, 5, 4)
+Alternating group of degree 5
+
+julia> get(TransitiveGroupsLibrary, 5, 6)
+ERROR: ArgumentError: there are only 5 transitive groups of degree 5, not 6
+[...]
+```
+"""
+function Base.get(T::Type{TransitiveGroupsLibrary}, deg::Int, i::Int)
+  @req has(T, deg) "transitive groups of degree $deg are not available"
+  N = count(T, deg)
+  @req i <= N "there are only $N transitive groups of degree $deg, not $i"
+  return PermGroup(GAP.Globals.TransitiveGroup(deg,i), deg)
+end
+
+"""
+    identification(TransitiveGroupsLibrary, G::PermGroup)
+
+Return a pair `(d, n)` such that `G` is permutation isomorphic with
+`get(TransitiveGroupsLibrary, d, n)`, where `G` acts transitively on `d` points.
+
+If `G` is not transitive on its moved points, or if the transitive groups of
+degree `d` are not available, an exception is thrown.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(7);  m = identification(TransitiveGroupsLibrary, G)
+(7, 7)
+
+julia> order(get(TransitiveGroupsLibrary, m...)) == order(G)
+true
+
+julia> S = sub(G, [perm([1, 3, 4, 5, 2])])[1]
+Permutation group of degree 7
+
+julia> is_transitive(S)
+false
+
+julia> is_transitive(S, moved_points(S))
+true
+
+julia> m = identification(TransitiveGroupsLibrary, S)
+(4, 1)
+
+julia> order(get(TransitiveGroupsLibrary, m...)) == order(S)
+true
+
+julia> identification(TransitiveGroupsLibrary, symmetric_group(64))
+ERROR: ArgumentError: identification of transitive groups of degree 64 are not available
+[...]
+
+julia> S = sub(G, [perm([1, 3, 4, 5, 2, 7, 6])])[1];
+
+julia> identification(TransitiveGroupsLibrary, S)
+ERROR: ArgumentError: group is not transitive on its moved points
+[...]
+```
+"""
+function identification(T::Type{TransitiveGroupsLibrary}, G::PermGroup)
+  moved = moved_points(G)
+  @req is_transitive(G, moved) "group is not transitive on its moved points"
+  deg = length(moved)
+  @req has(T, deg) "identification of transitive groups of degree $(deg) are not available"
+  res = GAP.Globals.TransitiveIdentification(GapObj(G))::Int
+  return deg, res
+end
+
+@doc raw"""
+    get_all(TransitiveGroupsLibrary, L...)
+    get_one(TransitiveGroupsLibrary, L...)
+
+`get_all` returns the list of all transitive groups
+(up to permutation isomorphism) satisfying the conditions described
+by the arguments.
+
+`get_one` returns one transitive group satisfying
+the conditions if such a group exists, and `nothing` otherwise.
+These conditions may be of one of the following forms:
+
+- `func => intval` selects groups for which the function `func` returns `intval`
+- `func => list` selects groups for which the function `func` returns any element inside `list`
+- `func` selects groups for which the function `func` returns `true`
+- `!func` selects groups for which the function `func` returns `false`
+
+As a special case, the first argument may also be one of the following:
+- `intval` selects groups whose degree equals `intval`; this is equivalent to `degree => intval`
+- `intlist` selects groups whose degree is in `intlist`; this is equivalent to `degree => intlist`
+
+The following functions are currently supported as values for `func`:
+- `degree`
+- `is_abelian`
+- `is_almost_simple`
+- `is_cyclic`
+- `is_nilpotent`
+- `is_perfect`
+- `is_primitive`
+- `is_quasisimple`
+- `is_simple`
+- `is_sporadic_simple`
+- `is_solvable`
+- `is_supersolvable`
+- `is_transitive`
+- `number_of_conjugacy_classes`
+- `number_of_moved_points`
+- `order`
+- `transitivity`
+
+The type of the returned group(s) is `PermGroup`.
+
+# Examples
+```jldoctest
+julia> get_all(TransitiveGroupsLibrary, 4)
+5-element Vector{PermGroup}:
+ Permutation group of degree 4
+ Permutation group of degree 4
+ Permutation group of degree 4
+ Alternating group of degree 4
+ Symmetric group of degree 4
+
+julia> get_one(TransitiveGroupsLibrary, 4)
+Permutation group of degree 4
+
+julia> get_all(TransitiveGroupsLibrary, degree => 3:5, is_abelian)
+4-element Vector{PermGroup}:
+ Alternating group of degree 3
+ Permutation group of degree 4
+ Permutation group of degree 4
+ Permutation group of degree 5
+
+julia> get_one(TransitiveGroupsLibrary, degree => 3:5, is_abelian)
+Alternating group of degree 3
+```
+"""
+function get_all(::Type{TransitiveGroupsLibrary}, L...)
+   @req !isempty(L) "must specify at least one filter"
+   if L[1] isa IntegerUnion || L[1] isa AbstractVector{<:IntegerUnion}
+      L = (degree => L[1], L[2:end]...)
+   end
+   gapargs = translate_group_library_args(L; filter_attrs = _permgroup_filter_attrs)
+   K = GAP.Globals.AllTransitiveGroups(gapargs...)::GapObj
+   return [PermGroup(x) for x in K]
+end
+
+function get_one(::Type{TransitiveGroupsLibrary}, L...)
+   @req !isempty(L) "must specify at least one filter"
+   if L[1] isa IntegerUnion || L[1] isa AbstractVector{<:IntegerUnion}
+      L = (degree => L[1], L[2:end]...)
+   end
+   gapargs = translate_group_library_args(L; filter_attrs = _permgroup_filter_attrs)
+   K = GAP.Globals.OneTransitiveGroup(gapargs...)::GapObj
+   K === GAP.Globals.fail && return nothing
+   return PermGroup(K)
+end
+@doc (@doc get_all(::Type{TransitiveGroupsLibrary}, L...)) get_one(::Type{TransitiveGroupsLibrary}, L...)

--- a/experimental/GroupLibraries2/src/transitivegroups.jl
+++ b/experimental/GroupLibraries2/src/transitivegroups.jl
@@ -181,7 +181,7 @@ function identification(T::Type{TransitiveGroupsLibrary}, G::PermGroup)
   return deg, res
 end
 
-@doc raw"""
+_docstr = """
     get_all(TransitiveGroupsLibrary, L...)
     get_one(TransitiveGroupsLibrary, L...)
 
@@ -247,6 +247,8 @@ julia> get_one(TransitiveGroupsLibrary, degree => 3:5, is_abelian)
 Alternating group of degree 3
 ```
 """
+
+@doc _docstr
 function get_all(::Type{TransitiveGroupsLibrary}, L...)
    @req !isempty(L) "must specify at least one filter"
    if L[1] isa IntegerUnion || L[1] isa AbstractVector{<:IntegerUnion}
@@ -257,6 +259,7 @@ function get_all(::Type{TransitiveGroupsLibrary}, L...)
    return [PermGroup(x) for x in K]
 end
 
+@doc _docstr
 function get_one(::Type{TransitiveGroupsLibrary}, L...)
    @req !isempty(L) "must specify at least one filter"
    if L[1] isa IntegerUnion || L[1] isa AbstractVector{<:IntegerUnion}
@@ -267,4 +270,3 @@ function get_one(::Type{TransitiveGroupsLibrary}, L...)
    K === GAP.Globals.fail && return nothing
    return PermGroup(K)
 end
-@doc (@doc get_all(::Type{TransitiveGroupsLibrary}, L...)) get_one(::Type{TransitiveGroupsLibrary}, L...)

--- a/experimental/GroupLibraries2/test/transitive_groups.jl
+++ b/experimental/GroupLibraries2/test/transitive_groups.jl
@@ -1,0 +1,76 @@
+@testset "Transitive groups" begin
+   @test has(TransitiveGroupsLibrary, 10)
+   @test !has(TransitiveGroupsLibrary, 60)
+
+   @test has_count(TransitiveGroupsLibrary, 10)
+   @test !has_count(TransitiveGroupsLibrary, 60)
+
+   @test has_identification(TransitiveGroupsLibrary, 10)
+   @test !has_identification(TransitiveGroupsLibrary, 60)
+
+   @test count(TransitiveGroupsLibrary, 4) == 5
+   @test count(TransitiveGroupsLibrary, 10) == 45
+   @test_throws ArgumentError count(TransitiveGroupsLibrary, 60)
+
+   for i in 1:10
+     @test count(TransitiveGroupsLibrary, i) == length(get_all(TransitiveGroupsLibrary, degree => i))
+   end
+
+   @test length(get_all(TransitiveGroupsLibrary, degree => -1)) == 0
+   @test get_one(TransitiveGroupsLibrary, degree => -1) == nothing
+
+   G = symmetric_group(4)
+   H1 = alternating_group(4)
+   H2 = sub(G, [G([2, 3, 4, 1])])[1]                   # cyclic
+   H3 = sub(G, [G([2, 3, 4, 1]), G([2, 1, 4, 3])])[1]  # dihedral
+   H4 = sub(G, [G([3, 4, 1, 2]), G([2, 1, 4, 3])])[1]  # Klein subgroup
+   L = [G, H1, H2, H3, H4]
+   grps = get_all(TransitiveGroupsLibrary, degree => 4)
+   @test get_one(TransitiveGroupsLibrary, degree => 4) in grps
+   for K in grps
+     @test count(l -> is_isomorphic(K, l), L) == 1
+   end
+   ids = [identification(TransitiveGroupsLibrary, l) for l in L]
+   @test sort(ids) == [(4, i) for i in 1:5]
+   @test L == [get(TransitiveGroupsLibrary, id...) for id in ids]
+   @test Set(L) == Set(get_all(TransitiveGroupsLibrary, degree => 4))
+   @test [H2] == get_all(TransitiveGroupsLibrary, degree => 4, is_cyclic)
+   @test [H4] == get_all(TransitiveGroupsLibrary, degree => 4, !is_cyclic, is_abelian)
+
+   grps = get_all(TransitiveGroupsLibrary, degree => 6)
+   @test length(grps) == 16
+   props = [
+      is_abelian,
+      is_almost_simple,
+      is_cyclic,
+      is_nilpotent,
+      is_perfect,
+      is_quasisimple,
+      is_simple,
+      is_sporadic_simple,
+      is_solvable,
+      is_supersolvable,
+      is_transitive,
+      is_primitive,
+   ]
+   @testset "get_all filtering for $(prop)" for prop in props
+     @test length(get_all(TransitiveGroupsLibrary, degree => 6, prop => true)) == count(prop, grps)
+     @test length(get_all(TransitiveGroupsLibrary, degree => 6, prop => false)) == count(!prop, grps)
+
+     @test length(get_all(TransitiveGroupsLibrary, degree => 6, prop)) == count(prop, grps)
+     @test length(get_all(TransitiveGroupsLibrary, degree => 6, !prop)) == count(!prop, grps)
+   end
+
+   @test length(get_all(TransitiveGroupsLibrary, degree => 6, order => 1:12)) == count(g -> order(g) in 1:12, grps)
+
+   @test length(get_all(TransitiveGroupsLibrary, degree => 1:6)) == sum([length(get_all(TransitiveGroupsLibrary, degree => i)) for i in 1:6])
+
+   @test issetequal(get_all(TransitiveGroupsLibrary, 3:2:9), get_all(TransitiveGroupsLibrary, degree => 3:2:9))
+   @test issetequal(get_all(TransitiveGroupsLibrary, collect(3:2:9)), get_all(TransitiveGroupsLibrary, 3:2:9))
+   @test issetequal(reduce(vcat, (get_all(TransitiveGroupsLibrary, i) for i in 3:2:9)), get_all(TransitiveGroupsLibrary, 3:2:9))
+
+   @test issetequal(get_all(TransitiveGroupsLibrary, 3:2:9, is_abelian), get_all(TransitiveGroupsLibrary, degree => 3:2:9, is_abelian))
+   @test issetequal(get_all(TransitiveGroupsLibrary, 9, is_abelian), get_all(TransitiveGroupsLibrary, degree => 9, is_abelian))
+
+   @test_throws ArgumentError get(TransitiveGroupsLibrary, 1, 2)
+end


### PR DESCRIPTION
(first draft: for the transitive groups library only)

This approach is discussed in #1168.
For the moment, code and documentation are in `experimental`, independent of the already avaliable code and documentation.