### PR TITLE
Collect group theory related types in `Groups/types.jl`

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -753,16 +753,6 @@ end
 #
 ################################################################################
 
-@attributes mutable struct GAPGroupConjClass{T<:GAPGroup, S<:Union{GAPGroupElem,GAPGroup}} <: GroupConjClass{T, S}
-   X::T
-   repr::S
-   CC::GapObj
-
-   function GAPGroupConjClass(G::T, obj::S, C::GapObj) where T<:GAPGroup where S<:Union{GAPGroupElem, GAPGroup}
-     return new{T, S}(G, obj, C, Dict{Symbol,Any}())
-   end
-end
-
 GAP.@install GapObj(obj::GAPGroupConjClass) = obj.CC
 
 Base.eltype(::Type{GAPGroupConjClass{T,S}}) where {T,S} = S

--- a/src/Groups/GrpAb.jl
+++ b/src/Groups/GrpAb.jl
@@ -71,11 +71,6 @@ end
 #
 ################################################################################
 
-struct FinGenAbGroupConjClass{T<:FinGenAbGroup, S<:Union{FinGenAbGroupElem,FinGenAbGroup}} <: GroupConjClass{T, S}
-   X::T
-   repr::S
-end
-
 function Base.hash(C::FinGenAbGroupConjClass, h::UInt)
   return Base.hash(Representative(C), h)
 end

--- a/src/Groups/cosets.jl
+++ b/src/Groups/cosets.jl
@@ -1,38 +1,3 @@
-# T=type of the group, S=type of the element
-@doc raw"""
-    GroupCoset{TG <: GAPGroup, TH <: GAPGroup, S <: GAPGroupElem}
-
-Type of right and left cosets of subgroups in groups.
-
-For an element $g$ in a group $G$, and a subgroup $H$ of $G$,
-the set $Hg = \{ hg; h \in H \}$ is a right coset of $H$ in $G$,
-and the set $gH = \{ gh; h \in H \}$ is a left coset of $H$ in $G$.
-
-- [`group(C::GroupCoset)`](@ref) returns $G$.
-
-- [`acting_group(C::GroupCoset)`](@ref) returns $H$.
-
-- [`representative(C::GroupCoset)`](@ref) returns an element
-  (the same element for each call) of `C`.
-
-- [`is_right(C::GroupCoset)`](@ref) and [`is_left(C::GroupCoset)`](@ref)
-  return whether `C` is a right or left coset, respectively.
-
-Two cosets are equal if and only if they are both left or right, respectively,
-and they contain the same elements.
-"""
-struct GroupCoset{TG <: GAPGroup, TH <: GAPGroup, S <: GAPGroupElem}
-   G::TG                   # big group containing the subgroup and the element
-   H::TH                   # subgroup (may have a different type)
-   repr::S                 # element
-   side::Symbol            # says if the coset is left or right
-   X::Ref{GapObj}          # GapObj(H*repr)
-
-   function GroupCoset(G::TG, H::TH, representative::S, side::Symbol) where {TG <: GAPGroup, TH <: GAPGroup, S <:GAPGroupElem}
-     return new{TG, TH, S}(G, H, representative, side, Ref{GapObj}())
-   end
-end
-
 GAP.@install function GapObj(obj::GroupCoset)
   if !isassigned(obj.X)
     g = GapObj(representative(obj))
@@ -368,35 +333,6 @@ function left_cosets(G::GAPGroup, H::GAPGroup; check::Bool=true)
   return GSetBySubgroupTransversal(G, H, :left, check = check)
 end
 
-
-@doc raw"""
-    SubgroupTransversal{T<: GAPGroup, S<: GAPGroup, E<: GAPGroupElem}
-
-Type of left/right transversals of subgroups in groups.
-
-For a group $G$ and a subgroup $H$ of $G$, $T$ is a right
-(resp. left) transversal for $H$ in $G$ if $T$ contains
-precisely one element of each right (resp. left) cosets of $H$ in $G$.
-
-Objects of this type are created by [`right_transversal`](@ref) and
-[`left_transversal`](@ref).
-
-- [`group(T::SubgroupTransversal)`](@ref) returns $G$.
-
-- [`subgroup(T::SubgroupTransversal)`](@ref) returns $H$.
-
-# Note for developers
-
-The elements are encoded via a right transversal object in GAP.
-(Note that GAP does not support left transversals.)
-"""
-struct SubgroupTransversal{T<: GAPGroup, S<: GAPGroup, E<: GAPGroupElem} <: AbstractVector{E}
-   G::T                    # big group containing the subgroup
-   H::S                    # subgroup
-   side::Symbol            # says if the transversal is left or right
-   X::GapObj               # underlying *right* transversal in GAP
-end
-
 GAP.@install GapObj(T::SubgroupTransversal) = T.X
 
 function Base.show(io::IO, ::MIME"text/plain", x::SubgroupTransversal)
@@ -625,41 +561,6 @@ function index_of_coset(::Type{I}, T::SubgroupTransversal, g::GroupElem) where I
      Gap_g = inv(Gap_g)
    end
    return I(GAPWrap.PositionCanonical(GapObj(T), Gap_g)::GapInt)
-end
-
-@doc raw"""
-    GroupDoubleCoset{T<: Group, S <: GAPGroupElem}
-
-Type of double cosets of subgroups in groups.
-
-For an element $g$ in a group $G$, and two subgroups $H$, $K$ of $G$,
-the set $HgK = \{ hgk; h \in H, k \in K \}$ is a $H-K$-double coset in $G$.
-
-- [`group(C::GroupDoubleCoset)`](@ref) returns $G$.
-
-- [`left_acting_group(C::GroupDoubleCoset)`](@ref) returns $H$.
-
-- [`right_acting_group(C::GroupDoubleCoset)`](@ref) returns $K$.
-
-- [`representative(C::GroupDoubleCoset)`](@ref) returns an element
-  (the same element for each call) of `C`.
-
-Two double cosets are equal if and only if they contain the same elements.
-"""
-struct GroupDoubleCoset{T <: GAPGroup, S <: GAPGroupElem}
-# T=type of the group, S=type of the element
-   G::T
-   H::GAPGroup
-   K::GAPGroup
-   repr::S
-   X::Ref{GapObj}
-   size::Ref{ZZRingElem}
-   right_coset_reps::Ref{Dict{GAPGroupElem, Tuple{GAPGroupElem, GAPGroupElem}}}
-
-   function GroupDoubleCoset(G::T, H::GAPGroup, K::GAPGroup, representative::S) where {T<: GAPGroup, S<:GAPGroupElem}
-     return new{T, S}(G, H, K, representative, Ref{GapObj}(), Ref{ZZRingElem}(),
-                      Ref{Dict{GAPGroupElem, Tuple{GAPGroupElem, GAPGroupElem}}}())
-   end
 end
 
 GAP.@install function GapObj(C::GroupDoubleCoset)

--- a/src/Groups/group_characters.jl
+++ b/src/Groups/group_characters.jl
@@ -97,49 +97,6 @@ end
 ##
 ##  character tables
 ##
-abstract type GroupCharacterTable end
-
-"""
-    GAPGroupCharacterTable <: GroupCharacterTable
-
-This is the type of (ordinary or Brauer) character tables that can delegate
-tasks to an underlying character table object in the GAP system
-(field `GAPTable`).
-
-The value of the field `characteristic` determines whether the table
-is an ordinary one (value `0`) or a `p`-modular one (value `p`).
-
-A group can (but need not) be stored in the field `group`.
-If it is available then also the field `isomorphism` is available,
-its value is a bijective map from the `group` value to a group in GAP.
-
-Objects of type `GAPGroupCharacterTable` support [`get_attribute`](@ref),
-for example in order to store the already computed `p`-modular tables
-in an ordinary table, and to store the corresponding ordinary table
-in a `p`-modular table.
-"""
-@attributes mutable struct GAPGroupCharacterTable <: GroupCharacterTable
-    GAPTable::GapObj  # the GAP character table object
-    characteristic::T where T <: IntegerUnion
-    group::Union{GAPGroup, FinGenAbGroup}    # the underlying group, if any
-    isomorphism::Map  # isomorphism from `group` to a group in GAP
-
-    function GAPGroupCharacterTable(G::Union{GAPGroup, FinGenAbGroup}, tab::GapObj, iso::Map, char::T) where T <: IntegerUnion
-      return new(tab, char, G, iso)
-    end
-
-    function GAPGroupCharacterTable(tab::GapObj, char::T) where T <: IntegerUnion
-      # group and isomorphism are left undefined
-      return new(tab, char)
-    end
-end
-
-abstract type GroupClassFunction end
-
-struct GAPGroupClassFunction <: GroupClassFunction
-    table::GAPGroupCharacterTable
-    values::GapObj
-end
 
 # access to field values via functions
 GapObj(tbl::GAPGroupCharacterTable) = tbl.GAPTable
@@ -563,15 +520,6 @@ is_character_table_name(name::String) = GAPWrap.LibInfoCharacterTable(GapObj(nam
 ##############################################################################
 #
 # `print` and `show` character tables
-
-# Utility:
-# Create strings in length-lexicographical ordering w.r.t. the
-# alphabet 'alphabet'.
-# (If `alphabet` is `"ABCDEFGHIJKLMNOPQRSTUVWXYZ"` then the strings
-# have the form `"A", "B", ..., "Z", "AA", ...`.)
-mutable struct WordsIterator
-    alphabet::String
-end
 
 Base.iterate(wi::WordsIterator) = length(wi.alphabet) == 0 ? nothing : (string(wi.alphabet[1]), 2)
 
@@ -3907,30 +3855,6 @@ end
 ##
 ##  rational character tables
 ##
-"""
-    GAPGroupCharacterTableRational <: GroupCharacterTable
-
-This is the type of ordinary *rational* character tables
-that can delegate tasks to the underlying character table
-(field `character_table`).
-
-As a collection, a rational character table stores the *rational irreducible*
-characters of the underlying character table `t`, that is, the Galois sums of
-the irreducible characters of `t` (field `irr`).
-
-The norms of these characters (the lengths of the Galois orbits)
-are stored in the field `norms`.
-"""
-@attributes mutable struct GAPGroupCharacterTableRational <: GroupCharacterTable
-    character_table::GAPGroupCharacterTable
-    irr::Vector{GAPGroupClassFunction}
-    norms::Vector{Int}
-
-    function GAPGroupCharacterTableRational(tbl::GAPGroupCharacterTable)
-      # irr and norms are left undefined
-      return new(tbl)
-    end
-end
 
 """
     character_table_rational(tbl::GAPGroupCharacterTable)

--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -130,35 +130,6 @@ function ==(Omega1::GSet, Omega2::GSet)
   throw(NotImplementedError(:(==), (Omega1, Omega2)))
 end
 
-
-"""
-    GSetByElements{T,S} <: GSet{T,S}
-
-Objects of this type represent G-sets that are willing to write down
-orbits and elements lists as vectors.
-These G-sets are created by default by [`gset`](@ref).
-
-The fields are
-- the group that acts, of type `T`,
-- the Julia function (for example `on_tuples`) that describes the action,
-- the seeds (something iterable of eltype `S`) whose closure under the action is the G-set
-- the dictionary used to store attributes (orbits, elements, ...).
-"""
-@attributes mutable struct GSetByElements{T,S} <: GSet{T,S}
-    group::T
-    action_function::Function
-    seeds
-
-    function GSetByElements(G::T, fun::Function, seeds; closed::Bool = false, check::Bool = true) where {T<:Union{Group, FinGenAbGroup}}
-        @req !isempty(seeds) "seeds for G-set must be nonempty"
-        check && @req hasmethod(fun, (typeof(first(seeds)), elem_type(T))) "action function does not fit to seeds"
-        Omega = new{T,eltype(seeds)}(G, fun, seeds, Dict{Symbol,Any}())
-        closed && set_attribute!(Omega, :elements => unique!(collect(seeds)))
-        return Omega
-    end
-end
-#TODO: How can I specify that `seeds` should be an iterable object?
-
 function Base.show(io::IO, ::MIME"text/plain", x::GSetByElements)
   println(io, "G-set of")
   io = pretty(io)
@@ -460,19 +431,6 @@ function _induce(Omega::GSetByElements{T, S}, phi::Map{U, T}) where {T<:Union{Gr
 end
 
 #############################################################################
-##
-##  wrapper objects for elements of G-sets,
-##  with fields `gset` (the G-set) and `objects` (the unwrapped object)
-##
-##  These objects are optional ("syntactic sugar"), they can be used to
-##  - apply group elements via `^`,
-##    not via the action function stored in the G-set,
-##  - write something like `orbit(omega)`, `stabilizer(omega)`.
-
-struct ElementOfGSet{T, S, G <: GSet{T, S}}
-    gset::G
-    obj::S
-end
 
 function (Omega::GSet{T, S})(obj::S) where {T, S}
     return ElementOfGSet(Omega, obj)
@@ -807,46 +765,6 @@ function permutation(Omega::GSetByElements{T}, g::Union{GAPGroupElem, FinGenAbGr
     @req pi !== GAP.Globals.fail "no permutation is induced by $g"
 
     return group_element(action_range(Omega), pi)
-end
-
-
-@doc raw"""
-    GSetBySubgroupTransversal{T, S, E} <: GSet{T}
-
-Objects of this type represent G-sets that describe the left or right cosets
-of a subgroup $H$ in a group $G$.
-The group $G$ acts on the G-set by multiplication from the right or (after
-taking inverses) from the left.
-These G-sets store just transversals,
-see [`right_transversal`](@ref) and [`left_transversal`](@ref).
-The construction of explicit right or left cosets is not necessary in order
-to compute the permutation action of elements of $G$ on the cosets.
-
-The fields are
-- the group that acts, of type `T`, with elements of type `E`,
-- the subgroup whose cosets are the elements, of type `S`,
-- the side from which the group acts (`:right` or `:left`),
-- the (left or right) transversal, of type `SubgroupTransversal{T, S, E}`,
-- the dictionary used to store attributes (orbits, elements, ...).
-"""
-@attributes mutable struct GSetBySubgroupTransversal{T, S, E} <: GSet{T,GroupCoset{T, S, E}}
-    group::T
-    subgroup::S
-    side::Symbol
-    transversal::SubgroupTransversal{T, S, E}
-
-    function GSetBySubgroupTransversal(G::T, H::S, side::Symbol; check::Bool = true) where {T<:GAPGroup, S<:GAPGroup}
-        check && @req is_subgroup(H, G)[1] "H must be a subgroup of G"
-        E = eltype(G)
-        if side == :right
-          tr = right_transversal(G, H)
-        elseif side == :left
-          tr = left_transversal(G, H)
-        else
-          throw(ArgumentError("side must be :right or :left"))
-        end
-        return new{T, S, E}(G, H, side, tr, Dict{Symbol,Any}())
-    end
 end
 
 function Base.show(io::IO, ::MIME"text/plain", x::GSetBySubgroupTransversal)

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -1195,10 +1195,6 @@ function isomorphism(::Type{FPGroup}, A::FinGenAbGroup; on_gens::Bool=false)
 end
 
 ####
-mutable struct GroupIsomorphismFromFunc{R, T} <: Map{R, T, Hecke.HeckeMap, MapFromFunc}
-    map::MapFromFunc{R, T}
-end
-
 function GroupIsomorphismFromFunc{R, T}(D::R, C::T, f, g) where {R, T}
   return GroupIsomorphismFromFunc{R, T}(MapFromFunc(D, C, f, g))
 end

--- a/src/Groups/pcgroup.jl
+++ b/src/Groups/pcgroup.jl
@@ -15,23 +15,6 @@
 # we transfer changes in the Julia object to the GAP side
 # as soon as the GAP object exists.
 
-abstract type Collector{T} end
-
-mutable struct GAP_Collector{T} <: Collector{T}
-  ngens::Int
-  relorders::Vector{T}
-  powers::Vector{Vector{Pair{Int, T}}}
-  conjugates::Matrix{Vector{Pair{Int, T}}}
-  X::GapObj   # a collector in GAP, if defined
-  F::FPGroup  # the free group in Oscar that belongs to `X`, if defined
-
-  function GAP_Collector{T}(n::Int) where T <: IntegerUnion
-    return new(n, zeros(T, n), # relative orders undefined
-                  repeat([Pair{Int, T}[]], n), # default powers are identity
-                  Matrix{Vector{Pair{Int, T}}}(undef, n, n)) # conjugates undefined
-  end
-end
-
 """
     collector(n::Int, ::Type{T} = ZZRingElem) where T <: IntegerUnion
 

--- a/src/Groups/perm.jl
+++ b/src/Groups/perm.jl
@@ -590,26 +590,6 @@ Base.iseven(n::PermGroup) = !isodd(n)
 ##
 # cycle types and support
 ##
-struct CycleType <: AbstractVector{Pair{Int64, Int64}}
-  # pairs 'cycle length => number of times it occurs'
-  # so 'n => 1' is a single n-cycle and  '1 => n' is the identity on n points
-  s::Vector{Pair{Int, Int}}
-
-  # take a vector of cycle lengths
-  function CycleType(c::Vector{Int})
-    s = Vector{Pair{Int, Int}}()
-    for i = c
-      _push_cycle!(s, i)
-    end
-    sort!(s; by=first)
-    return new(s)
-  end
-  function CycleType(v::Vector{Pair{Int, Int}}; sorted::Bool = false)
-    sorted && return new(v)
-    return new(sort(v; by=first))
-#TODO: check that each cycle length is specified at most once?
-  end
-end
 
 Base.iterate(C::CycleType) = iterate(C.s)
 Base.iterate(C::CycleType, x) = iterate(C.s, x)

--- a/src/Groups/recog.jl
+++ b/src/Groups/recog.jl
@@ -1,14 +1,3 @@
-@attributes mutable struct GroupRecognitionTree{T <: GAPGroup}
-  input_group::T
-  gap_tree::GapObj
-
-  function GroupRecognitionTree{T}(G::GAPGroup, gap_tree::GapObj) where T
-     @req G isa PermGroup || G isa MatGroup "only matrix and permutation groups are supported"
-     res = new{T}(G, gap_tree)
-     return res
-  end
-end
-
 GapObj(tree::GroupRecognitionTree) = tree.gap_tree
 
 

--- a/src/Groups/subspaces.jl
+++ b/src/Groups/subspaces.jl
@@ -26,28 +26,6 @@ function bases_of_subspaces(V::AbstractAlgebra.Generic.FreeModule{T}, k::Int) wh
   return SubspacesIterator{T}(V, k)
 end
 
-# For an iterator of `k`-dimensional subspaces in an `n`-dimensional space
-# over the field with `q` elements,
-# the state is `(comb_iter, choice, prod_iter, values)`
-# where
-# - `comb_iter` is the iterator `combinations(1:n, k)`,
-# - `choice` is the current state of `comb_iter`,
-#   a vector that denotes the `k` pivot column positions in the matrix,
-# - `prod_iter` is an iterator of vectors, where the current vector
-#   corresponds to those entries in the not necessarily zero positions
-#   of the matrix that are not pivots, and
-# - `values` is the current state ot `prod_iter`.
-
-struct SubspacesIterator{T <: FinFieldElem}
-  V::AbstractAlgebra.Generic.AbstractAlgebra.Generic.FreeModule{T}
-  k::Int
-
-  function SubspacesIterator{T}(V, k) where T
-    @req 0 <= k <= vector_space_dim(V) "wrong dimension"
-    return new(V, k)
-  end
-end
-
 eltype(::SubspacesIterator{T}) where T = dense_matrix_type(T)
 
 function length(S::SubspacesIterator{T}) where T

--- a/src/Groups/tom.jl
+++ b/src/Groups/tom.jl
@@ -2,38 +2,6 @@
 ##
 ##  tables of marks in Oscar
 ##
-abstract type GroupTableOfMarks end
-
-"""
-    GAPGroupTableOfMarks <: GroupTableOfMarks
-
-This is the type of tables of marks that can delegate
-tasks to an underlying table of marks object in the GAP system
-(field `GAPTable`).
-
-A group can (but need not) be stored in the field `group`.
-If it is available then also the field `isomorphism` is available,
-its value is a bijective map from the `group` value to a group in GAP.
-
-Objects of type `GAPGroupTableOfMarks` support [`get_attribute`](@ref).
-"""
-@attributes mutable struct GAPGroupTableOfMarks <: GroupTableOfMarks
-  GAPTable::GapObj  # the GAP table of marks object
-  group::Union{GAPGroup, FinGenAbGroup}    # the underlying group, if any
-  isomorphism::Map  # isomorphism from `group` to a group in GAP
-
-  function GAPGroupTableOfMarks(G::Union{GAPGroup, FinGenAbGroup}, tom::GapObj, iso::Map)
-    @req GAPWrap.IsTableOfMarks(tom) "tom must be a GAP table of marks"
-    return new(tom, G, iso)
-  end
-
-  function GAPGroupTableOfMarks(tom::GapObj)
-    # group and isomorphism are left undefined
-    @req GAPWrap.IsTableOfMarks(tom) "tom must be a GAP table of marks"
-    return new(tom)
-  end
-end
-
 
 # If `tblid` is an admissible name for a library character table
 # then translate it to the GAP name of the corresponding
@@ -460,19 +428,6 @@ end
 ##
 ##  marks vectors
 ##
-##  In order to describe Burnside rings over the integers,
-##  we implement marks vectors as wrapped GAP vectors,
-##  with parent the table of marks in question.
-##  Note that marks vectors can be shorter than the number of columns
-##  of the table of marks,
-##  meaning that the values at larger positions are zero.
-##
-abstract type GroupMarksVector end
-
-struct GAPGroupMarksVector <: GroupMarksVector
-  table::GAPGroupTableOfMarks
-  values::GapObj
-end
 
 GAP.@install GapObj(chi::GAPGroupMarksVector) = chi.values
 

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -41,8 +41,8 @@ If $x$ is an element of the group `G` of type `T`,
 then the type of $x$ is `BasicGAPGroupElem{T}`.
 """
 struct BasicGAPGroupElem{T<:GAPGroup} <: GAPGroupElem{T}
-   parent::T
-   X::GapObj
+  parent::T
+  X::GapObj
 end
 
 function Base.deepcopy_internal(x::BasicGAPGroupElem, dict::IdDict)
@@ -101,27 +101,27 @@ Symmetric group of degree 6
 ```
 """
 @attributes mutable struct PermGroup <: GAPGroup
-   X::GapObj
-   deg::Int64       # G < Sym(deg)
-   
-   function PermGroup(G::GapObj)
-     @assert GAPWrap.IsPermGroup(G)
-     n = GAPWrap.LargestMovedPoint(G)::Int
-     if n == 0
-       # We support only positive degrees.
-       # (`symmetric_group(0)` yields an error,
-       # and `symmetric_group(1)` yields a GAP group with `n == 0`.)
-       n = 1
-     end
-     z = new(G, n)
-     return z
-   end
-   
-   function PermGroup(G::GapObj, deg::Int)
-     @assert GAPWrap.IsPermGroup(G) && deg > 0 && deg >= GAPWrap.LargestMovedPoint(G)::Int
-     z = new(G, deg)
-     return z
-   end
+  X::GapObj
+  deg::Int64       # G < Sym(deg)
+
+  function PermGroup(G::GapObj)
+    @assert GAPWrap.IsPermGroup(G)
+    n = GAPWrap.LargestMovedPoint(G)::Int
+    if n == 0
+      # We support only positive degrees.
+      # (`symmetric_group(0)` yields an error,
+      # and `symmetric_group(1)` yields a GAP group with `n == 0`.)
+      n = 1
+    end
+    z = new(G, n)
+    return z
+  end
+
+  function PermGroup(G::GapObj, deg::Int)
+    @assert GAPWrap.IsPermGroup(G) && deg > 0 && deg >= GAPWrap.LargestMovedPoint(G)::Int
+    z = new(G, deg)
+    return z
+  end
 end
 
 permutation_group(G::GapObj) = PermGroup(G)
@@ -242,7 +242,7 @@ return groups of type `SubPcGroup`.
 @attributes mutable struct SubPcGroup <: GAPGroup
   X::GapObj
   full_group::PcGroup
-#T better create an embedding!
+  #T better create an embedding!
 
   function SubPcGroup(G::GapObj)
     # Create the `PcGroup` on the Oscar side anew.
@@ -260,7 +260,7 @@ return groups of type `SubPcGroup`.
     # Keep object identity of the available `PcGroup` on the Oscar side.
     if check
       @assert (GAPWrap.IsPcGroup(G) || GAPWrap.IsPcpGroup(G)) &&
-              GAPWrap.FamilyObj(G) === GAPWrap.FamilyObj(F.X)
+      GAPWrap.FamilyObj(G) === GAPWrap.FamilyObj(F.X)
     end
     z = new(G, F)
     return z
@@ -383,7 +383,7 @@ subgroups of a finitely presented group.
 @attributes mutable struct SubFPGroup <: GAPGroup
   X::GapObj
   full_group::FPGroup
-#T better create an embedding!
+  #T better create an embedding!
 
   function SubFPGroup(G::GapObj)
     # Create the `FPGroup` on the Oscar side anew.
@@ -397,7 +397,7 @@ subgroups of a finitely presented group.
     # Keep object identity of the available `FPGroup` on the Oscar side.
     if check
       @assert GAPWrap.IsSubgroupFpGroup(G) &&
-              GAPWrap.FamilyObj(G) === GAPWrap.FamilyObj(F.X)
+      GAPWrap.FamilyObj(G) === GAPWrap.FamilyObj(F.X)
     end
     z = new(G, F)
     return z
@@ -428,19 +428,19 @@ abstract type AbstractMatGroupElem <: GAPGroupElem{GAPGroup} end
 Type of groups `G` of `n x n` matrices over the ring `R`, where `n = degree(G)` and `R = base_ring(G)`.
 """
 @attributes mutable struct MatGroup{RE<:RingElem, T<:MatElem{RE}} <: GAPGroup
-   deg::Int
-   ring::Ring
-   X::GapObj
-   gens::Vector{<:AbstractMatGroupElem}
-   descr::Symbol                       # e.g. GL, SL, symbols for isometry groups
-   ring_iso::MapFromFunc # Isomorphism from the Oscar base ring to the GAP base ring
+  deg::Int
+  ring::Ring
+  X::GapObj
+  gens::Vector{<:AbstractMatGroupElem}
+  descr::Symbol                       # e.g. GL, SL, symbols for isometry groups
+  ring_iso::MapFromFunc # Isomorphism from the Oscar base ring to the GAP base ring
 
-   function MatGroup{RE,T}(F::Ring, m::Int) where {RE,T}
-     G = new{RE, T}()
-     G.deg = m
-     G.ring = F
-     return G
-   end
+  function MatGroup{RE,T}(F::Ring, m::Int) where {RE,T}
+    G = new{RE, T}()
+    G.deg = m
+    G.ring = F
+    return G
+  end
 end
 
 # Construct an Oscar matrix group from a GAP matrix group,
@@ -479,22 +479,22 @@ end
 Type of elements of a group of type `MatGroup{RE, T}`.
 """
 mutable struct MatGroupElem{RE<:RingElem, T<:MatElem{RE}} <: AbstractMatGroupElem
-   parent::MatGroup{RE, T}
-   elm::T                         # Oscar matrix
-   X::GapObj                     # GAP matrix. If x isa MatGroupElem, then x.X = map_entries(x.parent.ring_iso, x.elm)
+  parent::MatGroup{RE, T}
+  elm::T                         # Oscar matrix
+  X::GapObj                     # GAP matrix. If x isa MatGroupElem, then x.X = map_entries(x.parent.ring_iso, x.elm)
 
-   # full constructor
-   MatGroupElem{RE,T}(G::MatGroup{RE,T}, x::T, x_gap::GapObj) where {RE, T} = new{RE,T}(G, x, x_gap)
+  # full constructor
+  MatGroupElem{RE,T}(G::MatGroup{RE,T}, x::T, x_gap::GapObj) where {RE, T} = new{RE,T}(G, x, x_gap)
 
-   # constructor which leaves `X` undefined
-   MatGroupElem{RE,T}(G::MatGroup{RE,T}, x::T) where {RE, T} = new{RE,T}(G, x)
+  # constructor which leaves `X` undefined
+  MatGroupElem{RE,T}(G::MatGroup{RE,T}, x::T) where {RE, T} = new{RE,T}(G, x)
 
-   # constructor which leaves `elm` undefined
-   function MatGroupElem{RE,T}(G::MatGroup{RE,T}, x_gap::GapObj) where {RE, T}
-      z = new{RE,T}(G)
-      z.X = x_gap
-      return z
-   end
+  # constructor which leaves `elm` undefined
+  function MatGroupElem{RE,T}(G::MatGroup{RE,T}, x_gap::GapObj) where {RE, T}
+    z = new{RE,T}(G)
+    z.X = x_gap
+    return z
+  end
 end
 
 
@@ -542,11 +542,196 @@ function _oscar_subgroup(obj::GapObj, G::PcGroup; check::Bool = true)
   return SubPcGroup(obj, G; check = check)
 end
 
+################################################################################
+#
+#  Cosets
+#
+################################################################################
 
+# T=type of the group, S=type of the element
+@doc raw"""
+    GroupCoset{TG <: GAPGroup, TH <: GAPGroup, S <: GAPGroupElem}
+
+Type of right and left cosets of subgroups in groups.
+
+For an element $g$ in a group $G$, and a subgroup $H$ of $G$,
+the set $Hg = \{ hg; h \in H \}$ is a right coset of $H$ in $G$,
+and the set $gH = \{ gh; h \in H \}$ is a left coset of $H$ in $G$.
+
+- [`group(C::GroupCoset)`](@ref) returns $G$.
+
+- [`acting_group(C::GroupCoset)`](@ref) returns $H$.
+
+- [`representative(C::GroupCoset)`](@ref) returns an element
+  (the same element for each call) of `C`.
+
+- [`is_right(C::GroupCoset)`](@ref) and [`is_left(C::GroupCoset)`](@ref)
+  return whether `C` is a right or left coset, respectively.
+
+Two cosets are equal if and only if they are both left or right, respectively,
+and they contain the same elements.
+"""
+struct GroupCoset{TG <: GAPGroup, TH <: GAPGroup, S <: GAPGroupElem}
+  G::TG                   # big group containing the subgroup and the element
+  H::TH                   # subgroup (may have a different type)
+  repr::S                 # element
+  side::Symbol            # says if the coset is left or right
+  X::Ref{GapObj}          # GapObj(H*repr)
+
+  function GroupCoset(G::TG, H::TH, representative::S, side::Symbol) where {TG <: GAPGroup, TH <: GAPGroup, S <:GAPGroupElem}
+    return new{TG, TH, S}(G, H, representative, side, Ref{GapObj}())
+  end
+end
+
+@doc raw"""
+    SubgroupTransversal{T<: GAPGroup, S<: GAPGroup, E<: GAPGroupElem}
+
+Type of left/right transversals of subgroups in groups.
+
+For a group $G$ and a subgroup $H$ of $G$, $T$ is a right
+(resp. left) transversal for $H$ in $G$ if $T$ contains
+precisely one element of each right (resp. left) cosets of $H$ in $G$.
+
+Objects of this type are created by [`right_transversal`](@ref) and
+[`left_transversal`](@ref).
+
+- [`group(T::SubgroupTransversal)`](@ref) returns $G$.
+
+- [`subgroup(T::SubgroupTransversal)`](@ref) returns $H$.
+
+# Note for developers
+
+The elements are encoded via a right transversal object in GAP.
+(Note that GAP does not support left transversals.)
+"""
+struct SubgroupTransversal{T<: GAPGroup, S<: GAPGroup, E<: GAPGroupElem} <: AbstractVector{E}
+  G::T                    # big group containing the subgroup
+  H::S                    # subgroup
+  side::Symbol            # says if the transversal is left or right
+  X::GapObj               # underlying *right* transversal in GAP
+end
+
+@doc raw"""
+    GroupDoubleCoset{T<: Group, S <: GAPGroupElem}
+
+Type of double cosets of subgroups in groups.
+
+For an element $g$ in a group $G$, and two subgroups $H$, $K$ of $G$,
+the set $HgK = \{ hgk; h \in H, k \in K \}$ is a $H-K$-double coset in $G$.
+
+- [`group(C::GroupDoubleCoset)`](@ref) returns $G$.
+
+- [`left_acting_group(C::GroupDoubleCoset)`](@ref) returns $H$.
+
+- [`right_acting_group(C::GroupDoubleCoset)`](@ref) returns $K$.
+
+- [`representative(C::GroupDoubleCoset)`](@ref) returns an element
+  (the same element for each call) of `C`.
+
+Two double cosets are equal if and only if they contain the same elements.
+"""
+struct GroupDoubleCoset{T <: GAPGroup, S <: GAPGroupElem}
+  # T=type of the group, S=type of the element
+  G::T
+  H::GAPGroup
+  K::GAPGroup
+  repr::S
+  X::Ref{GapObj}
+  size::Ref{ZZRingElem}
+  right_coset_reps::Ref{Dict{GAPGroupElem, Tuple{GAPGroupElem, GAPGroupElem}}}
+
+  function GroupDoubleCoset(G::T, H::GAPGroup, K::GAPGroup, representative::S) where {T<: GAPGroup, S<:GAPGroupElem}
+    return new{T, S}(G, H, K, representative, Ref{GapObj}(), Ref{ZZRingElem}(),
+                     Ref{Dict{GAPGroupElem, Tuple{GAPGroupElem, GAPGroupElem}}}())
+  end
+end
+
+################################################################################
+#
+#  G-Sets
+#
 ################################################################################
 
 abstract type GSet{T,S} end
 
+"""
+    GSetByElements{T,S} <: GSet{T,S}
+
+Objects of this type represent G-sets that are willing to write down
+orbits and elements lists as vectors.
+These G-sets are created by default by [`gset`](@ref).
+
+The fields are
+- the group that acts, of type `T`,
+- the Julia function (for example `on_tuples`) that describes the action,
+- the seeds (something iterable of eltype `S`) whose closure under the action is the G-set
+- the dictionary used to store attributes (orbits, elements, ...).
+"""
+@attributes mutable struct GSetByElements{T,S} <: GSet{T,S}
+  group::T
+  action_function::Function
+  seeds
+
+  function GSetByElements(G::T, fun::Function, seeds; closed::Bool = false, check::Bool = true) where {T<:Union{Group, FinGenAbGroup}}
+    @req !isempty(seeds) "seeds for G-set must be nonempty"
+    check && @req hasmethod(fun, (typeof(first(seeds)), elem_type(T))) "action function does not fit to seeds"
+    Omega = new{T,eltype(seeds)}(G, fun, seeds, Dict{Symbol,Any}())
+    closed && set_attribute!(Omega, :elements => unique!(collect(seeds)))
+    return Omega
+  end
+end
+#TODO: How can I specify that `seeds` should be an iterable object?
+
+##  wrapper objects for elements of G-sets,
+##  with fields `gset` (the G-set) and `objects` (the unwrapped object)
+##
+##  These objects are optional ("syntactic sugar"), they can be used to
+##  - apply group elements via `^`,
+##    not via the action function stored in the G-set,
+##  - write something like `orbit(omega)`, `stabilizer(omega)`.
+struct ElementOfGSet{T, S, G <: GSet{T, S}}
+  gset::G
+  obj::S
+end
+
+@doc raw"""
+    GSetBySubgroupTransversal{T, S, E} <: GSet{T}
+
+Objects of this type represent G-sets that describe the left or right cosets
+of a subgroup $H$ in a group $G$.
+The group $G$ acts on the G-set by multiplication from the right or (after
+taking inverses) from the left.
+These G-sets store just transversals,
+see [`right_transversal`](@ref) and [`left_transversal`](@ref).
+The construction of explicit right or left cosets is not necessary in order
+to compute the permutation action of elements of $G$ on the cosets.
+
+The fields are
+- the group that acts, of type `T`, with elements of type `E`,
+- the subgroup whose cosets are the elements, of type `S`,
+- the side from which the group acts (`:right` or `:left`),
+- the (left or right) transversal, of type `SubgroupTransversal{T, S, E}`,
+- the dictionary used to store attributes (orbits, elements, ...).
+"""
+@attributes mutable struct GSetBySubgroupTransversal{T, S, E} <: GSet{T,GroupCoset{T, S, E}}
+  group::T
+  subgroup::S
+  side::Symbol
+  transversal::SubgroupTransversal{T, S, E}
+
+  function GSetBySubgroupTransversal(G::T, H::S, side::Symbol; check::Bool = true) where {T<:GAPGroup, S<:GAPGroup}
+    check && @req is_subgroup(H, G)[1] "H must be a subgroup of G"
+    E = eltype(G)
+    if side == :right
+      tr = right_transversal(G, H)
+    elseif side == :left
+      tr = left_transversal(G, H)
+    else
+      throw(ArgumentError("side must be :right or :left"))
+    end
+    return new{T, S, E}(G, H, side, tr, Dict{Symbol,Any}())
+  end
+end
 
 ################################################################################
 #
@@ -562,6 +747,20 @@ in a group `G` of type `T`.
 """
 abstract type GroupConjClass{T,S} <: GSet{T,S} end
 
+@attributes mutable struct GAPGroupConjClass{T<:GAPGroup, S<:Union{GAPGroupElem,GAPGroup}} <: GroupConjClass{T, S}
+  X::T
+  repr::S
+  CC::GapObj
+
+  function GAPGroupConjClass(G::T, obj::S, C::GapObj) where T<:GAPGroup where S<:Union{GAPGroupElem, GAPGroup}
+    return new{T, S}(G, obj, C, Dict{Symbol,Any}())
+  end
+end
+
+struct FinGenAbGroupConjClass{T<:FinGenAbGroup, S<:Union{FinGenAbGroupElem,FinGenAbGroup}} <: GroupConjClass{T, S}
+  X::T
+  repr::S
+end
 
 ################################################################################
 #
@@ -580,13 +779,13 @@ An object of the type `GAPGroupHomomorphism` stores a homomorphism object
 as its `GapObj` value, and delegates all computations to it.
 """
 struct GAPGroupHomomorphism{S<: GAPGroup, T<: GAPGroup} <: Map{S,T,GAPMap,GAPGroupHomomorphism{S,T}}
-   domain::S
-   codomain::T
-   map::GapObj
+  domain::S
+  codomain::T
+  map::GapObj
 
-   function GAPGroupHomomorphism(G::S, H::T, mp::GapObj) where {S<: GAPGroup, T<: GAPGroup}
-     return new{S, T}(G, H, mp)
-   end
+  function GAPGroupHomomorphism(G::S, H::T, mp::GapObj) where {S<: GAPGroup, T<: GAPGroup}
+    return new{S, T}(G, H, mp)
+  end
 end
 
 """
@@ -603,13 +802,13 @@ Many natural embeddings between `GapGroup` objects are realized as
 `GAPGroupEmbedding` objects.
 """
 struct GAPGroupEmbedding{S<: GAPGroup, T<: GAPGroup} <: Map{S,T,GAPMap,GAPGroupEmbedding{S,T}}
-   domain::S
-   codomain::T
-   map::Ref{GapObj} # may be missing
+  domain::S
+  codomain::T
+  map::Ref{GapObj} # may be missing
 
-   function GAPGroupEmbedding(G::S, H::T) where {S<: GAPGroup, T<: GAPGroup}
-     return new{S, T}(G, H, Ref{GapObj}())
-   end
+  function GAPGroupEmbedding(G::S, H::T) where {S<: GAPGroup, T<: GAPGroup}
+    return new{S, T}(G, H, Ref{GapObj}())
+  end
 end
 
 GapObj(f::GAPGroupHomomorphism) = f.map
@@ -617,7 +816,7 @@ GapObj(f::GAPGroupHomomorphism) = f.map
 function GapObj(f::GAPGroupEmbedding)
   isassigned(f.map) && return f.map[]::GapObj
   mp = GAPWrap.GroupHomomorphismByFunction(GapObj(f.domain), GapObj(f.codomain),
-           GAP.Globals.IdFunc, false, GAP.Globals.IdFunc)
+                                           GAP.Globals.IdFunc, false, GAP.Globals.IdFunc)
   f.map[] = mp
   return mp
 end
@@ -661,6 +860,10 @@ end
 
 function Base.show(io::IO, f::AutomorphismGroupElem{FinGenAbGroup})
   print(io, matrix(f))
+end
+
+mutable struct GroupIsomorphismFromFunc{R, T} <: Map{R, T, Hecke.HeckeMap, MapFromFunc}
+  map::MapFromFunc{R, T}
 end
 
 ################################################################################
@@ -806,3 +1009,249 @@ end
 
 #TODO FinGenAbGroup: How do they behave?
 #     And does this question arise, since embeddings are used throughout?
+
+################################################################################
+#
+#  Character Tables
+#
+################################################################################
+
+abstract type GroupCharacterTable end
+
+"""
+    GAPGroupCharacterTable <: GroupCharacterTable
+
+This is the type of (ordinary or Brauer) character tables that can delegate
+tasks to an underlying character table object in the GAP system
+(field `GAPTable`).
+
+The value of the field `characteristic` determines whether the table
+is an ordinary one (value `0`) or a `p`-modular one (value `p`).
+
+A group can (but need not) be stored in the field `group`.
+If it is available then also the field `isomorphism` is available,
+its value is a bijective map from the `group` value to a group in GAP.
+
+Objects of type `GAPGroupCharacterTable` support [`get_attribute`](@ref),
+for example in order to store the already computed `p`-modular tables
+in an ordinary table, and to store the corresponding ordinary table
+in a `p`-modular table.
+"""
+@attributes mutable struct GAPGroupCharacterTable <: GroupCharacterTable
+  GAPTable::GapObj  # the GAP character table object
+  characteristic::T where T <: IntegerUnion
+  group::Union{GAPGroup, FinGenAbGroup}    # the underlying group, if any
+  isomorphism::Map  # isomorphism from `group` to a group in GAP
+
+  function GAPGroupCharacterTable(G::Union{GAPGroup, FinGenAbGroup}, tab::GapObj, iso::Map, char::T) where T <: IntegerUnion
+    return new(tab, char, G, iso)
+  end
+
+  function GAPGroupCharacterTable(tab::GapObj, char::T) where T <: IntegerUnion
+    # group and isomorphism are left undefined
+    return new(tab, char)
+  end
+end
+
+abstract type GroupClassFunction end
+
+struct GAPGroupClassFunction <: GroupClassFunction
+  table::GAPGroupCharacterTable
+  values::GapObj
+end
+
+"""
+    GAPGroupCharacterTableRational <: GroupCharacterTable
+
+This is the type of ordinary *rational* character tables
+that can delegate tasks to the underlying character table
+(field `character_table`).
+
+As a collection, a rational character table stores the *rational irreducible*
+characters of the underlying character table `t`, that is, the Galois sums of
+the irreducible characters of `t` (field `irr`).
+
+The norms of these characters (the lengths of the Galois orbits)
+are stored in the field `norms`.
+"""
+@attributes mutable struct GAPGroupCharacterTableRational <: GroupCharacterTable
+  character_table::GAPGroupCharacterTable
+  irr::Vector{GAPGroupClassFunction}
+  norms::Vector{Int}
+
+  function GAPGroupCharacterTableRational(tbl::GAPGroupCharacterTable)
+    # irr and norms are left undefined
+    return new(tbl)
+  end
+end
+
+################################################################################
+#
+#  Tables of marks
+#
+################################################################################
+
+abstract type GroupTableOfMarks end
+
+"""
+    GAPGroupTableOfMarks <: GroupTableOfMarks
+
+This is the type of tables of marks that can delegate
+tasks to an underlying table of marks object in the GAP system
+(field `GAPTable`).
+
+A group can (but need not) be stored in the field `group`.
+If it is available then also the field `isomorphism` is available,
+its value is a bijective map from the `group` value to a group in GAP.
+
+Objects of type `GAPGroupTableOfMarks` support [`get_attribute`](@ref).
+"""
+@attributes mutable struct GAPGroupTableOfMarks <: GroupTableOfMarks
+  GAPTable::GapObj  # the GAP table of marks object
+  group::Union{GAPGroup, FinGenAbGroup}    # the underlying group, if any
+  isomorphism::Map  # isomorphism from `group` to a group in GAP
+
+  function GAPGroupTableOfMarks(G::Union{GAPGroup, FinGenAbGroup}, tom::GapObj, iso::Map)
+    @req GAPWrap.IsTableOfMarks(tom) "tom must be a GAP table of marks"
+    return new(tom, G, iso)
+  end
+
+  function GAPGroupTableOfMarks(tom::GapObj)
+    # group and isomorphism are left undefined
+    @req GAPWrap.IsTableOfMarks(tom) "tom must be a GAP table of marks"
+    return new(tom)
+  end
+end
+
+################################################################################
+#
+#  Marks vectors
+#
+################################################################################
+
+#  In order to describe Burnside rings over the integers,
+#  we implement marks vectors as wrapped GAP vectors,
+#  with parent the table of marks in question.
+#  Note that marks vectors can be shorter than the number of columns
+#  of the table of marks,
+#  meaning that the values at larger positions are zero.
+
+abstract type GroupMarksVector end
+
+struct GAPGroupMarksVector <: GroupMarksVector
+  table::GAPGroupTableOfMarks
+  values::GapObj
+end
+
+################################################################################
+#
+#  Cycles
+#
+################################################################################
+
+struct CycleType <: AbstractVector{Pair{Int64, Int64}}
+  # pairs 'cycle length => number of times it occurs'
+  # so 'n => 1' is a single n-cycle and  '1 => n' is the identity on n points
+  s::Vector{Pair{Int, Int}}
+
+  # take a vector of cycle lengths
+  function CycleType(c::Vector{Int})
+    s = Vector{Pair{Int, Int}}()
+    for i = c
+      _push_cycle!(s, i)
+    end
+    sort!(s; by=first)
+    return new(s)
+  end
+  function CycleType(v::Vector{Pair{Int, Int}}; sorted::Bool = false)
+    sorted && return new(v)
+    return new(sort(v; by=first))
+    #TODO: check that each cycle length is specified at most once?
+  end
+end
+
+################################################################################
+#
+#  Subspaces iterator
+#
+################################################################################
+
+# For an iterator of `k`-dimensional subspaces in an `n`-dimensional space
+# over the field with `q` elements,
+# the state is `(comb_iter, choice, prod_iter, values)`
+# where
+# - `comb_iter` is the iterator `combinations(1:n, k)`,
+# - `choice` is the current state of `comb_iter`,
+#   a vector that denotes the `k` pivot column positions in the matrix,
+# - `prod_iter` is an iterator of vectors, where the current vector
+#   corresponds to those entries in the not necessarily zero positions
+#   of the matrix that are not pivots, and
+# - `values` is the current state ot `prod_iter`.
+
+struct SubspacesIterator{T <: FinFieldElem}
+  V::AbstractAlgebra.Generic.AbstractAlgebra.Generic.FreeModule{T}
+  k::Int
+
+  function SubspacesIterator{T}(V, k) where T
+    @req 0 <= k <= vector_space_dim(V) "wrong dimension"
+    return new(V, k)
+  end
+end
+
+################################################################################
+#
+#  Words iterator (for printing and showing character tables)
+#
+################################################################################
+
+# Utility:
+# Create strings in length-lexicographical ordering w.r.t. the
+# alphabet 'alphabet'.
+# (If `alphabet` is `"ABCDEFGHIJKLMNOPQRSTUVWXYZ"` then the strings
+# have the form `"A", "B", ..., "Z", "AA", ...`.)
+mutable struct WordsIterator
+  alphabet::String
+end
+
+################################################################################
+#
+#  Collector
+#
+################################################################################
+
+# Create an Oscar collector object, its type parameter `T` describes
+# the type of integers that occur as exponents.
+
+abstract type Collector{T} end
+
+mutable struct GAP_Collector{T} <: Collector{T}
+  ngens::Int
+  relorders::Vector{T}
+  powers::Vector{Vector{Pair{Int, T}}}
+  conjugates::Matrix{Vector{Pair{Int, T}}}
+  X::GapObj   # a collector in GAP, if defined
+  F::FPGroup  # the free group in Oscar that belongs to `X`, if defined
+
+  function GAP_Collector{T}(n::Int) where T <: IntegerUnion
+    return new(n, zeros(T, n), # relative orders undefined
+               repeat([Pair{Int, T}[]], n), # default powers are identity
+               Matrix{Vector{Pair{Int, T}}}(undef, n, n)) # conjugates undefined
+  end
+end
+
+################################################################################
+#
+#  Recognition
+#
+################################################################################
+
+@attributes mutable struct GroupRecognitionTree{T <: GAPGroup}
+  input_group::T
+  gap_tree::GapObj
+
+  function GroupRecognitionTree{T}(G::GAPGroup, gap_tree::GapObj) where T
+    @req G isa PermGroup || G isa MatGroup "only matrix and permutation groups are supported"
+    res = new{T}(G, gap_tree)
+    return res
+  end
+end

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -41,8 +41,8 @@ If $x$ is an element of the group `G` of type `T`,
 then the type of $x$ is `BasicGAPGroupElem{T}`.
 """
 struct BasicGAPGroupElem{T<:GAPGroup} <: GAPGroupElem{T}
-  parent::T
-  X::GapObj
+   parent::T
+   X::GapObj
 end
 
 function Base.deepcopy_internal(x::BasicGAPGroupElem, dict::IdDict)
@@ -101,27 +101,27 @@ Symmetric group of degree 6
 ```
 """
 @attributes mutable struct PermGroup <: GAPGroup
-  X::GapObj
-  deg::Int64       # G < Sym(deg)
-
-  function PermGroup(G::GapObj)
-    @assert GAPWrap.IsPermGroup(G)
-    n = GAPWrap.LargestMovedPoint(G)::Int
-    if n == 0
-      # We support only positive degrees.
-      # (`symmetric_group(0)` yields an error,
-      # and `symmetric_group(1)` yields a GAP group with `n == 0`.)
-      n = 1
-    end
-    z = new(G, n)
-    return z
-  end
-
-  function PermGroup(G::GapObj, deg::Int)
-    @assert GAPWrap.IsPermGroup(G) && deg > 0 && deg >= GAPWrap.LargestMovedPoint(G)::Int
-    z = new(G, deg)
-    return z
-  end
+   X::GapObj
+   deg::Int64       # G < Sym(deg)
+   
+   function PermGroup(G::GapObj)
+     @assert GAPWrap.IsPermGroup(G)
+     n = GAPWrap.LargestMovedPoint(G)::Int
+     if n == 0
+       # We support only positive degrees.
+       # (`symmetric_group(0)` yields an error,
+       # and `symmetric_group(1)` yields a GAP group with `n == 0`.)
+       n = 1
+     end
+     z = new(G, n)
+     return z
+   end
+   
+   function PermGroup(G::GapObj, deg::Int)
+     @assert GAPWrap.IsPermGroup(G) && deg > 0 && deg >= GAPWrap.LargestMovedPoint(G)::Int
+     z = new(G, deg)
+     return z
+   end
 end
 
 permutation_group(G::GapObj) = PermGroup(G)
@@ -242,7 +242,7 @@ return groups of type `SubPcGroup`.
 @attributes mutable struct SubPcGroup <: GAPGroup
   X::GapObj
   full_group::PcGroup
-  #T better create an embedding!
+#T better create an embedding!
 
   function SubPcGroup(G::GapObj)
     # Create the `PcGroup` on the Oscar side anew.
@@ -260,7 +260,7 @@ return groups of type `SubPcGroup`.
     # Keep object identity of the available `PcGroup` on the Oscar side.
     if check
       @assert (GAPWrap.IsPcGroup(G) || GAPWrap.IsPcpGroup(G)) &&
-      GAPWrap.FamilyObj(G) === GAPWrap.FamilyObj(F.X)
+              GAPWrap.FamilyObj(G) === GAPWrap.FamilyObj(F.X)
     end
     z = new(G, F)
     return z
@@ -383,7 +383,7 @@ subgroups of a finitely presented group.
 @attributes mutable struct SubFPGroup <: GAPGroup
   X::GapObj
   full_group::FPGroup
-  #T better create an embedding!
+#T better create an embedding!
 
   function SubFPGroup(G::GapObj)
     # Create the `FPGroup` on the Oscar side anew.
@@ -397,7 +397,7 @@ subgroups of a finitely presented group.
     # Keep object identity of the available `FPGroup` on the Oscar side.
     if check
       @assert GAPWrap.IsSubgroupFpGroup(G) &&
-      GAPWrap.FamilyObj(G) === GAPWrap.FamilyObj(F.X)
+              GAPWrap.FamilyObj(G) === GAPWrap.FamilyObj(F.X)
     end
     z = new(G, F)
     return z
@@ -428,19 +428,19 @@ abstract type AbstractMatGroupElem <: GAPGroupElem{GAPGroup} end
 Type of groups `G` of `n x n` matrices over the ring `R`, where `n = degree(G)` and `R = base_ring(G)`.
 """
 @attributes mutable struct MatGroup{RE<:RingElem, T<:MatElem{RE}} <: GAPGroup
-  deg::Int
-  ring::Ring
-  X::GapObj
-  gens::Vector{<:AbstractMatGroupElem}
-  descr::Symbol                       # e.g. GL, SL, symbols for isometry groups
-  ring_iso::MapFromFunc # Isomorphism from the Oscar base ring to the GAP base ring
+   deg::Int
+   ring::Ring
+   X::GapObj
+   gens::Vector{<:AbstractMatGroupElem}
+   descr::Symbol                       # e.g. GL, SL, symbols for isometry groups
+   ring_iso::MapFromFunc # Isomorphism from the Oscar base ring to the GAP base ring
 
-  function MatGroup{RE,T}(F::Ring, m::Int) where {RE,T}
-    G = new{RE, T}()
-    G.deg = m
-    G.ring = F
-    return G
-  end
+   function MatGroup{RE,T}(F::Ring, m::Int) where {RE,T}
+     G = new{RE, T}()
+     G.deg = m
+     G.ring = F
+     return G
+   end
 end
 
 # Construct an Oscar matrix group from a GAP matrix group,
@@ -479,22 +479,22 @@ end
 Type of elements of a group of type `MatGroup{RE, T}`.
 """
 mutable struct MatGroupElem{RE<:RingElem, T<:MatElem{RE}} <: AbstractMatGroupElem
-  parent::MatGroup{RE, T}
-  elm::T                         # Oscar matrix
-  X::GapObj                     # GAP matrix. If x isa MatGroupElem, then x.X = map_entries(x.parent.ring_iso, x.elm)
+   parent::MatGroup{RE, T}
+   elm::T                         # Oscar matrix
+   X::GapObj                     # GAP matrix. If x isa MatGroupElem, then x.X = map_entries(x.parent.ring_iso, x.elm)
 
-  # full constructor
-  MatGroupElem{RE,T}(G::MatGroup{RE,T}, x::T, x_gap::GapObj) where {RE, T} = new{RE,T}(G, x, x_gap)
+   # full constructor
+   MatGroupElem{RE,T}(G::MatGroup{RE,T}, x::T, x_gap::GapObj) where {RE, T} = new{RE,T}(G, x, x_gap)
 
-  # constructor which leaves `X` undefined
-  MatGroupElem{RE,T}(G::MatGroup{RE,T}, x::T) where {RE, T} = new{RE,T}(G, x)
+   # constructor which leaves `X` undefined
+   MatGroupElem{RE,T}(G::MatGroup{RE,T}, x::T) where {RE, T} = new{RE,T}(G, x)
 
-  # constructor which leaves `elm` undefined
-  function MatGroupElem{RE,T}(G::MatGroup{RE,T}, x_gap::GapObj) where {RE, T}
-    z = new{RE,T}(G)
-    z.X = x_gap
-    return z
-  end
+   # constructor which leaves `elm` undefined
+   function MatGroupElem{RE,T}(G::MatGroup{RE,T}, x_gap::GapObj) where {RE, T}
+      z = new{RE,T}(G)
+      z.X = x_gap
+      return z
+   end
 end
 
 
@@ -779,13 +779,13 @@ An object of the type `GAPGroupHomomorphism` stores a homomorphism object
 as its `GapObj` value, and delegates all computations to it.
 """
 struct GAPGroupHomomorphism{S<: GAPGroup, T<: GAPGroup} <: Map{S,T,GAPMap,GAPGroupHomomorphism{S,T}}
-  domain::S
-  codomain::T
-  map::GapObj
+   domain::S
+   codomain::T
+   map::GapObj
 
-  function GAPGroupHomomorphism(G::S, H::T, mp::GapObj) where {S<: GAPGroup, T<: GAPGroup}
-    return new{S, T}(G, H, mp)
-  end
+   function GAPGroupHomomorphism(G::S, H::T, mp::GapObj) where {S<: GAPGroup, T<: GAPGroup}
+     return new{S, T}(G, H, mp)
+   end
 end
 
 """
@@ -802,13 +802,13 @@ Many natural embeddings between `GapGroup` objects are realized as
 `GAPGroupEmbedding` objects.
 """
 struct GAPGroupEmbedding{S<: GAPGroup, T<: GAPGroup} <: Map{S,T,GAPMap,GAPGroupEmbedding{S,T}}
-  domain::S
-  codomain::T
-  map::Ref{GapObj} # may be missing
+   domain::S
+   codomain::T
+   map::Ref{GapObj} # may be missing
 
-  function GAPGroupEmbedding(G::S, H::T) where {S<: GAPGroup, T<: GAPGroup}
-    return new{S, T}(G, H, Ref{GapObj}())
-  end
+   function GAPGroupEmbedding(G::S, H::T) where {S<: GAPGroup, T<: GAPGroup}
+     return new{S, T}(G, H, Ref{GapObj}())
+   end
 end
 
 GapObj(f::GAPGroupHomomorphism) = f.map
@@ -816,7 +816,7 @@ GapObj(f::GAPGroupHomomorphism) = f.map
 function GapObj(f::GAPGroupEmbedding)
   isassigned(f.map) && return f.map[]::GapObj
   mp = GAPWrap.GroupHomomorphismByFunction(GapObj(f.domain), GapObj(f.codomain),
-                                           GAP.Globals.IdFunc, false, GAP.Globals.IdFunc)
+           GAP.Globals.IdFunc, false, GAP.Globals.IdFunc)
   f.map[] = mp
   return mp
 end


### PR DESCRIPTION
Recently I was working on the file `Groups/gsets.jl` and got frustrated because Revise doesn't work. So I started by moving some structs out of that file, which required more moving for the correct load order etc. 
In the end, I moved all the `struct`s in `Groups/*` into the file `Groups/types.jl`.

I don't know whether this is desired; it's the convention I 'grew up' with in Hecke.
It might also create some merge conflicts with other pull requests, so see this more as a "proposal" than a "request".

CC @fingolfin @ThomasBreuer
