### PR TITLE
Warn when booktests change

### DIFF
--- a/.github/workflows/BooktestWarnings.yml
+++ b/.github/workflows/BooktestWarnings.yml
@@ -1,0 +1,88 @@
+name: Warn about booktest changes
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - '**.jlcon'
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  warn-booktest-changes:
+    name: Warn about changed booktests
+    runs-on: ubuntu-slim
+    timeout-minutes: 2
+    steps:
+      - name: Comment if booktests changed
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = "<!-- oscar-booktest-warning -->";
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const pull_number = context.payload.pull_request.number;
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100,
+            });
+
+            const booktestFiles = files
+              .filter((file) =>
+                file.filename.endsWith(".jlcon") ||
+                (file.previous_filename || "").endsWith(".jlcon"))
+              .map((file) => file.filename)
+              .sort();
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user.type === "Bot" && comment.body.includes(marker));
+
+            if (booktestFiles.length === 0) {
+              return;
+            }
+
+            const fileList = booktestFiles.map((file) => `- \`${file}\``).join("\n");
+            const body = [
+              marker,
+              "This pull request changes one or more `.jlcon` booktest files.",
+              "",
+              "These files are used by the OSCAR book website, so please take extra",
+              "care when editing them. In particular, check that the corresponding",
+              "book content still matches the transcript and that the website-facing",
+              "examples remain suitable.",
+              "",
+              "Changed `.jlcon` files:",
+              fileList,
+            ].join("\n");
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/BooktestWarnings.yml
+++ b/.github/workflows/BooktestWarnings.yml
@@ -3,8 +3,6 @@ name: Warn about booktest changes
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - '**.jlcon'
 
 permissions:
   contents: read
@@ -39,9 +37,13 @@ jobs:
 
             const booktestFiles = files
               .filter((file) =>
-                file.filename.endsWith(".jlcon") ||
-                (file.previous_filename || "").endsWith(".jlcon"))
-              .map((file) => file.filename)
+                file.filename.match(/^test\/book\/[^/]+\/[^/]+\/[^/]+\.jl(con)?$/) ||
+                (file.previous_filename || "").match(
+                  /^test\/book\/[^/]+\/[^/]+\/[^/]+\.jl(con)?$/))
+              .map((file) =>
+                file.previous_filename
+                  ? `${file.previous_filename} → ${file.filename}`
+                  : file.filename)
               .sort();
 
             const comments = await github.paginate(github.rest.issues.listComments, {
@@ -54,20 +56,27 @@ jobs:
               comment.user.type === "Bot" && comment.body.includes(marker));
 
             if (booktestFiles.length === 0) {
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                });
+              }
               return;
             }
 
             const fileList = booktestFiles.map((file) => `- \`${file}\``).join("\n");
             const body = [
               marker,
-              "This pull request changes one or more `.jlcon` booktest files.",
+              "This pull request changes one or more booktest files.",
               "",
               "These files are used by the OSCAR book website, so please take extra",
               "care when editing them. In particular, check that the corresponding",
               "book content still matches the transcript and that the website-facing",
               "examples remain suitable.",
               "",
-              "Changed `.jlcon` files:",
+              "Changed booktest files:",
               fileList,
             ].join("\n");
 

--- a/.github/workflows/BooktestWarnings.yml
+++ b/.github/workflows/BooktestWarnings.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Comment if booktests changed
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = "<!-- oscar-booktest-warning -->";


### PR DESCRIPTION
Add a pull_request_target workflow for .jlcon edits. It posts or updates one warning comment on matching PRs.

Resolves #6080.

Co-authored-by: Codex <codex@openai.com>

Unfortunately I don't think we can test this *before* it is merged, due to the way `pull_request_target` works (and we need that to support PRs from branches in forks of this repo)