### PR TITLE
Overhaul linear algebra documentation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,7 +39,7 @@ HomotopyContinuation = "f213a82b-91d6-5c5d-acf7-10f1c761b327"
 HomotopyContinuationExt = "HomotopyContinuation"
 
 [compat]
-AbstractAlgebra = "0.50.1"
+AbstractAlgebra = "0.50.2"
 AlgebraicSolving = "0.10.6"
 CodecZlib = "0.7.8"
 Compat = "4.13.0"

--- a/docs/doc.main
+++ b/docs/doc.main
@@ -97,13 +97,17 @@
 
   "Linear Algebra" => [
      "LinearAlgebra/intro.md",
-     "AbstractAlgebra/matrix.md",
+     "Working with matrices" => [
+        "AbstractAlgebra/matrix_construction.md",
+        "AbstractAlgebra/matrix_manipulation.md",
+        "AbstractAlgebra/matrix_predicates.md",
+        "AbstractAlgebra/matrix_computed_quantities.md",
+        "AbstractAlgebra/linear_solving.md",
+        "AbstractAlgebra/matrix_normal_forms.md",
+        "LinearAlgebra/eigen.md",
+     ],
      "AbstractAlgebra/matrix_spaces.md",
-     "AbstractAlgebra/linear_solving.md",
-     "LinearAlgebra/eigen.md",
-     "Nemo/matrix.md",
      "AbstractAlgebra/matrix_algebras.md",
-     "Hecke/manual/misc/sparse.md",
      "Modules" => [
         "LinearAlgebra/module_introduction.md",
         "AbstractAlgebra/module.md",
@@ -113,7 +117,13 @@
         "AbstractAlgebra/direct_sum.md",
         "AbstractAlgebra/module_homomorphism.md",
      ],
-     "AbstractAlgebra/matrix_implementation.md",
+     "Specialized matrix types" => [
+        "Nemo/matrix.md",
+        "Hecke/manual/misc/sparse.md",
+     ],
+     "Developer documentation" => [
+        "AbstractAlgebra/matrix_implementation.md",
+     ]
   ],
 
   "Number Theory" => [

--- a/docs/doc.main
+++ b/docs/doc.main
@@ -97,13 +97,17 @@
 
   "Linear Algebra" => [
      "LinearAlgebra/intro.md",
-     "AbstractAlgebra/matrix.md",
+     "Working with matrices" => [
+        "AbstractAlgebra/matrix_construction.md",
+        "AbstractAlgebra/matrix_manipulation.md",
+        "AbstractAlgebra/matrix_predicates.md",
+        "AbstractAlgebra/matrix_properties.md",
+        "AbstractAlgebra/how_to_linear_solve.md", 
+        "AbstractAlgebra/matrix_normal_forms.md",
+        "LinearAlgebra/eigen.md",
+     ],
      "AbstractAlgebra/matrix_spaces.md",
-     "AbstractAlgebra/linear_solving.md",
-     "LinearAlgebra/eigen.md",
-     "Nemo/matrix.md",
      "AbstractAlgebra/matrix_algebras.md",
-     "Hecke/manual/misc/sparse.md",
      "Modules" => [
         "LinearAlgebra/module_introduction.md",
         "AbstractAlgebra/module.md",
@@ -113,7 +117,14 @@
         "AbstractAlgebra/direct_sum.md",
         "AbstractAlgebra/module_homomorphism.md",
      ],
-     "AbstractAlgebra/matrix_implementation.md",
+     "Specialized matrix types" => [
+        "Nemo/matrix.md",
+        "Hecke/manual/misc/sparse.md",
+     ],
+     "Developer documentation" => [
+        "AbstractAlgebra/matrix_implementation.md",
+        "AbstractAlgebra/linear_solving.md"
+     ]
   ],
 
   "Number Theory" => [

--- a/docs/src/LinearAlgebra/intro.md
+++ b/docs/src/LinearAlgebra/intro.md
@@ -51,15 +51,20 @@ types and Julia's native `Matrix` type is supported.
 ## Topics covered
 
 The main topics covered in this section are:
-- [Matrix functionality](@ref matrix_functionality_chapter)
-- [Matrix spaces](@ref "Matrix Spaces")
-- [Linear solving](@ref solving_chapter)
-- [Eigenvalues and -spaces](@ref "Eigenvalues and -spaces")
-- [Nemo matrices](@ref "Nemo matrices")
-- [Generic matrix algebras](@ref "Generic matrix algebras")
-- [Sparse linear algebra](@ref)
+- Working With Matrices
+  - [Constructing Algebraic Matrices](@ref matrix_construction)
+  - [Manipulating Algebraic Matrices](@ref matrix_manipulation)
+  - [Matrix Predicates](@ref matrix_predicates)
+  - [Matrix Computed Quantities](@ref matrix_computed_quantities)
+  - [Linear Solving](@ref solving_chapter)
+  - [Matrix Normal Forms](@ref matrix_normal_forms)
+  - [Eigenvalues And Eigenspaces](@ref "Eigenvalues and -spaces")
+- [Matrix Spaces](@ref "Matrix Spaces")
+- [Matrix Algebras](@ref "Generic matrix algebras")
 - [Modules](@ref "Finitely presented modules")
-
+- Specialized Matrix Types
+  - [Nemo Matrices](@ref "Nemo matrices")
+  - [Sparse Linear Algebra](@ref)
 
 ## For developers
 

--- a/docs/src/LinearAlgebra/intro.md
+++ b/docs/src/LinearAlgebra/intro.md
@@ -51,20 +51,25 @@ types and Julia's native `Matrix` type is supported.
 ## Topics covered
 
 The main topics covered in this section are:
-- [Matrix functionality](@ref matrix_functionality_chapter)
-- [Matrix spaces](@ref "Matrix Spaces")
-- [Linear solving](@ref solving_chapter)
-- [Eigenvalues and -spaces](@ref "Eigenvalues and -spaces")
-- [Nemo matrices](@ref "Nemo matrices")
-- [Generic matrix algebras](@ref "Generic matrix algebras")
-- [Sparse linear algebra](@ref)
+- Working With Matrices
+  - [Constructing Algebraic Matrices](@ref matrix_construction)
+  - [Manipulating Algebraic Matrices](@ref matrix_manipulation)
+  - [Matrix Predicates](@ref matrix_predicates)
+  - [Matrix Computed Quantities](@ref matrix_properties)
+  - [Solving Linear Systems](@ref solving_linear_systems)
+  - [Matrix Normal Forms](@ref matrix_normal_forms)
+  - [Eigenvalues And Eigenspaces](@ref "Eigenvalues and -spaces")
+- [Matrix Spaces](@ref "Matrix Spaces")
+- [Matrix Algebras](@ref "Generic matrix algebras")
 - [Modules](@ref "Finitely presented modules")
-
+- Specialized Matrix Types
+  - [Nemo Matrices](@ref "Nemo matrices")
+  - [Sparse Linear Algebra](@ref)
 
 ## For developers
 
-For developers interested in the implementation details of matrices, see
-[Matrix implementation](@ref "Matrix implementation").
+- [Matrix implementation](@ref "Matrix implementation")
+- [Linear Solving Interface](@ref solving_chapter)
 
 
 ## Tutorials


### PR DESCRIPTION
Follow-up to https://github.com/Nemocas/AbstractAlgebra.jl/pull/2448.

Must not be merged before https://github.com/Nemocas/AbstractAlgebra.jl/pull/2448 is merged, nor before an AA release has been made (here assumed to be 0.50.2 - as long as this release does not exist, this draft must fail).

Preview will eventually become available at https://docs.oscar-system.org/previews/PR6119/.

Ping @lgoettgens @JohnAAbbott 