### PR TITLE
Add information on OSCAR timing dashboard to developer documentation

### DIFF
--- a/docs/doc.main
+++ b/docs/doc.main
@@ -340,6 +340,7 @@
     "DeveloperDocumentation/documentation.md",
     "DeveloperDocumentation/printing_details.md",
     "DeveloperDocumentation/debugging.md",
+    "DeveloperDocumentation/timing-tool.md",
     "DeveloperDocumentation/caching.md",
     "DeveloperDocumentation/serialization.md",
     "DeveloperDocumentation/artifacts.md",

--- a/docs/src/DeveloperDocumentation/timing-tool.md
+++ b/docs/src/DeveloperDocumentation/timing-tool.md
@@ -1,0 +1,16 @@
+```@meta
+CurrentModule = Oscar
+CollapsedDocStrings = true
+DocTestSetup = Oscar.doctestsetup()
+```
+
+# Performance tools
+
+The OSCAR timing dashboard records and visualizes timing data of
+selected OSCAR benchmarks. It can be used to identify performance regressions,
+inspect benchmark runs, and compare timing results across OSCAR commits.
+
+The dashboard is available at <https://speed.oscar-system.org>.
+
+The source code for the dashboard is maintained in the `oscar-system/oscar-timing`
+repository at <https://github.com/oscar-system/oscar-timing>.

--- a/docs/src/DeveloperDocumentation/timing-tool.md
+++ b/docs/src/DeveloperDocumentation/timing-tool.md
@@ -7,10 +7,9 @@ DocTestSetup = Oscar.doctestsetup()
 # Performance tools
 
 The OSCAR timing dashboard records and visualizes timing data of
-selected OSCAR benchmarks. It can be used to identify performance regressions,
+existing OSCAR tests as benchmarks. It can be used to identify performance regressions,
 inspect benchmark runs, and compare timing results across OSCAR commits.
 
 The dashboard is available at <https://speed.oscar-system.org>.
 
-The source code for the dashboard is maintained in the `oscar-system/oscar-timing`
-repository at <https://github.com/oscar-system/oscar-timing>.
+The source code for the dashboard is maintained at [oscar-system/oscar-timing](https://github.com/oscar-system/oscar-timing).


### PR DESCRIPTION
Closes https://github.com/oscar-system/oscar-timing/issues/4.

Preview will become available at https://docs.oscar-system.org/previews/PR6121.

I suggest waiting for https://github.com/oscar-system/oscar-timing/pull/6 to be merged, before reviewing/merging this PR. Hence marked as draft for now.

cc @aaruni96 @fingolfin 