### PR TITLE
fix serialization version in test

### DIFF
--- a/test/Serialization/loading.jl
+++ b/test/Serialization/loading.jl
@@ -61,7 +61,7 @@ end
     save(filename, [[1, 2], [3, 4], [5, 6]]; pretty_print=true)
     str = read(filename, String)
     version_info = Oscar.Serialization.get_oscar_serialization_version()[:Oscar][2]
-    cmp_str = "{\n  \"_ns\":{\n    \"Oscar\":[\n      \"https://github.com/oscar-system/Oscar.jl\",\n      \"" * version_info * "\"\n    ]\n  },\n  \"_type\":{\n    \"name\":\"Vector\",\n    \"params\":{\n      \"name\":\"Vector\",\n      \"params\":\"Base.Int\"\n    }\n  },\n  \"data\":[\n    [\n      \"1\",\n      \"2\"\n    ],\n    [\n      \"3\",\n      \"4\"\n    ],\n    [\n      \"5\",\n      \"6\"\n    ]\n  ]\n}"
+    cmp_str = "{\n  \"_ns\":{\n    \"Oscar\":[\n      \"https://github.com/oscar-system/Oscar.jl\",\n      \"" * string(version_info) * "\"\n    ]\n  },\n  \"_type\":{\n    \"name\":\"Vector\",\n    \"params\":{\n      \"name\":\"Vector\",\n      \"params\":\"Base.Int\"\n    }\n  },\n  \"data\":[\n    [\n      \"1\",\n      \"2\"\n    ],\n    [\n      \"3\",\n      \"4\"\n    ],\n    [\n      \"5\",\n      \"6\"\n    ]\n  ]\n}"
 
     @test str == cmp_str
   end

--- a/test/Serialization/loading.jl
+++ b/test/Serialization/loading.jl
@@ -61,8 +61,36 @@ end
     save(filename, [[1, 2], [3, 4], [5, 6]]; pretty_print=true)
     str = read(filename, String)
     version_info = Oscar.Serialization.get_oscar_serialization_version()[:Oscar][2]
-    cmp_str = "{\n  \"_ns\":{\n    \"Oscar\":[\n      \"https://github.com/oscar-system/Oscar.jl\",\n      \"" * string(version_info) * "\"\n    ]\n  },\n  \"_type\":{\n    \"name\":\"Vector\",\n    \"params\":{\n      \"name\":\"Vector\",\n      \"params\":\"Base.Int\"\n    }\n  },\n  \"data\":[\n    [\n      \"1\",\n      \"2\"\n    ],\n    [\n      \"3\",\n      \"4\"\n    ],\n    [\n      \"5\",\n      \"6\"\n    ]\n  ]\n}"
-
+    cmp_str = """
+{
+  "_ns":{
+    "Oscar":[
+      "https://github.com/oscar-system/Oscar.jl",
+      "$version_info"
+    ]
+  },
+  "_type":{
+    "name":"Vector",
+    "params":{
+      "name":"Vector",
+      "params":"Base.Int"
+    }
+  },
+  "data":[
+    [
+      "1",
+      "2"
+    ],
+    [
+      "3",
+      "4"
+    ],
+    [
+      "5",
+      "6"
+    ]
+  ]
+}"""
     @test str == cmp_str
   end
 


### PR DESCRIPTION
This only breaks on non-dev versions, ~~cherry-picked commit from release 1.8 branch.~~

Made sample string more readable by using multiline string and using interpolation which works with VersionNumber and String values.