### PR TITLE
Fix test statistics outside Git checkouts

### DIFF
--- a/docs/documenter_helpers.jl
+++ b/docs/documenter_helpers.jl
@@ -1,11 +1,13 @@
 import DelimitedFiles
+import Oscar
 
 const docstats = Dict{String,NamedTuple}()
 if haskey(ENV, "GITHUB_ACTION") || haskey(ENV, "OSCAR_TEST_STATS")
-  timestamp = readchomp(`git show --no-patch --pretty=format:"%ad" --date=format:"%Y-%m-%dT%H-%M-%S"`)
+  metadata = Oscar._test_stats_metadata()
+  timestamp = metadata.timestamp
   platform = Sys.islinux() ? "linux" : "macos"
   juliaVersion = join(split("$VERSION", ".")[1:2], ".")
-  commitHash = readchomp(`git rev-parse --verify --short HEAD`)
+  commitHash = metadata.commit
   statsFileName = "test-stats_$(timestamp)_$(platform)_$(juliaVersion)_doctests_$(commitHash).csv"
 
   Base.atexit() do

--- a/etc/testing-csv-to-json.jl
+++ b/etc/testing-csv-to-json.jl
@@ -19,8 +19,14 @@ for file in filelist
     # filenames on github must not contain colons so we convert to the correct timestamp format here
     timestamp = Dates.format(DateTime(timestr, dateformat"yyyy-mm-ddTHH-MM-SSZ"),
                              dateformat"yyyy-mm-ddTHH:MM:SS")
-    commitAuthor = readchomp(`git show --no-patch --pretty=format:'%aN' $commitHash`)
-    commitMessage = readchomp(`git show --no-patch --pretty=format:'%s' $commitHash`)
+    commitAuthor, commitMessage = try
+        (readchomp(pipeline(`git show --no-patch --pretty=format:'%aN' $commitHash`;
+                            stderr=devnull)),
+         readchomp(pipeline(`git show --no-patch --pretty=format:'%s' $commitHash`;
+                            stderr=devnull)))
+    catch
+        ("unknown", "OSCAR $commitHash")
+    end
     if subset == "default"
         subset = "short"
     end

--- a/etc/testing-csv-to-json.jl
+++ b/etc/testing-csv-to-json.jl
@@ -19,13 +19,12 @@ for file in filelist
     # filenames on github must not contain colons so we convert to the correct timestamp format here
     timestamp = Dates.format(DateTime(timestr, dateformat"yyyy-mm-ddTHH-MM-SSZ"),
                              dateformat"yyyy-mm-ddTHH:MM:SS")
-    commitAuthor, commitMessage = try
-        (readchomp(pipeline(`git show --no-patch --pretty=format:'%aN' $commitHash`;
-                            stderr=devnull)),
-         readchomp(pipeline(`git show --no-patch --pretty=format:'%s' $commitHash`;
-                            stderr=devnull)))
-    catch
-        ("unknown", "OSCAR $commitHash")
+    if startswith(commitHash, "v")
+        commitAuthor = "unknown"
+        commitMessage = "OSCAR $commitHash"
+    else
+        commitAuthor = readchomp(`git show --no-patch --pretty=format:'%aN' $commitHash`)
+        commitMessage = readchomp(`git show --no-patch --pretty=format:'%s' $commitHash`)
     end
     if subset == "default"
         subset = "short"

--- a/src/utils/tests.jl
+++ b/src/utils/tests.jl
@@ -1,3 +1,32 @@
+function _test_stats_metadata(
+  dir::AbstractString=oscardir,
+  git_info::Union{Nothing,AbstractDict}=nothing,
+)
+  if Sys.which("git") !== nothing && ispath(joinpath(dir, ".git"))
+    try
+      timestamp = readchomp(
+        `git -C $dir show --no-patch --pretty=format:%ad --date=format:%Y-%m-%dT%H-%M-%S`,
+      )
+      commit = readchomp(`git -C $dir rev-parse --verify --short HEAD`)
+      return (; timestamp, commit)
+    catch
+    end
+  end
+
+  if isnothing(git_info)
+    git_info = _get_oscar_git_info()
+  end
+
+  if haskey(git_info, :commit) && haskey(git_info, :date)
+    timestamp = replace(git_info[:date][1:19], " " => "T", ":" => "-")
+    commit = git_info[:commit][1:7]
+    return (; timestamp, commit)
+  end
+
+  timestamp = Base.Libc.strftime("%Y-%m-%dT%H-%M-%S", time())
+  return (; timestamp, commit="v$(VERSION_NUMBER)")
+end
+
 function _timed_include(str::String, mod::Module=Main; has_ctime_stat=(VERSION > v"1.11.0"))
   has_ctime_stat || (compile_elapsedtimes = Base.cumulative_compile_time_ns())
   stats = @timed Base.include(identity, mod, str)

--- a/src/utils/tests.jl
+++ b/src/utils/tests.jl
@@ -1,22 +1,4 @@
-function _test_stats_metadata(
-  dir::AbstractString=oscardir,
-  git_info::Union{Nothing,AbstractDict}=nothing,
-)
-  if Sys.which("git") !== nothing && ispath(joinpath(dir, ".git"))
-    try
-      timestamp = readchomp(
-        `git -C $dir show --no-patch --pretty=format:%ad --date=format:%Y-%m-%dT%H-%M-%S`,
-      )
-      commit = readchomp(`git -C $dir rev-parse --verify --short HEAD`)
-      return (; timestamp, commit)
-    catch
-    end
-  end
-
-  if isnothing(git_info)
-    git_info = _get_oscar_git_info()
-  end
-
+function _test_stats_metadata(git_info::AbstractDict=_get_oscar_git_info())
   if haskey(git_info, :commit) && haskey(git_info, :date)
     timestamp = replace(git_info[:date][1:19], " " => "T", ":" => "-")
     commit = git_info[:commit][1:7]

--- a/test/printing.jl
+++ b/test/printing.jl
@@ -24,3 +24,17 @@
   # Restore old flag
   allow_unicode(old_flag; temporary=true)
 end
+
+# Test statistics metadata generation with and without Git information.
+@testset "Test statistics metadata" begin
+  metadata = Oscar._test_stats_metadata(Dict{Symbol,String}())
+  @test occursin(r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}$", metadata.timestamp)
+  @test metadata.commit == "v$(Oscar.VERSION_NUMBER)"
+
+  git_info = Dict(
+    :commit => "0123456789abcdef",
+    :date => "2026-07-24 12:17:12 +0200",
+  )
+  metadata = Oscar._test_stats_metadata(git_info)
+  @test metadata == (timestamp="2026-07-24T12-17-12", commit="0123456")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,22 @@ import DelimitedFiles
 using Dates
 using Oscar
 
+# Test statistics metadata generation without a Git checkout.
+@testset "test statistics metadata" begin
+  mktempdir() do dir
+    metadata = Oscar._test_stats_metadata(dir, Dict{Symbol,String}())
+    @test occursin(r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}$", metadata.timestamp)
+    @test metadata.commit == "v$(Oscar.VERSION_NUMBER)"
+
+    git_info = Dict(
+      :commit => "0123456789abcdef",
+      :date => "2026-07-24 12:17:12 +0200",
+    )
+    metadata = Oscar._test_stats_metadata(dir, git_info)
+    @test metadata == (timestamp="2026-07-24T12-17-12", commit="0123456")
+  end
+end
+
 numprocs_str = get(ENV, "NUMPROCS", "1")
 
 oldWorkingDirectory = pwd()
@@ -210,10 +226,11 @@ else
   print_stats(stdout, stats; max=10)
 end
 if haskey(ENV, "GITHUB_ACTIONS") || haskey(ENV, "OSCAR_TEST_STATS")
-  timestamp = readchomp(`git show --no-patch --pretty=format:"%ad" --date=format:"%Y-%m-%dT%H-%M-%S"`)
+  metadata = Oscar._test_stats_metadata()
+  timestamp = metadata.timestamp
   platform = Sys.islinux() ? "linux" : "macos"
   juliaVersion = join(split("$VERSION", ".")[1:2], ".")
-  commitHash = readchomp(`git rev-parse --verify --short HEAD`)
+  commitHash = metadata.commit
   statsFileName = "test-stats_$(timestamp)_$(platform)_$(juliaVersion)_$(test_subset)_$(commitHash).csv"
   open(joinpath(pkgdir(Oscar), statsFileName), "a") do io
     println(io, "path,time,ctime,rctime,gctime,alloc")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,22 +5,6 @@ import DelimitedFiles
 using Dates
 using Oscar
 
-# Test statistics metadata generation without a Git checkout.
-@testset "test statistics metadata" begin
-  mktempdir() do dir
-    metadata = Oscar._test_stats_metadata(dir, Dict{Symbol,String}())
-    @test occursin(r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}$", metadata.timestamp)
-    @test metadata.commit == "v$(Oscar.VERSION_NUMBER)"
-
-    git_info = Dict(
-      :commit => "0123456789abcdef",
-      :date => "2026-07-24 12:17:12 +0200",
-    )
-    metadata = Oscar._test_stats_metadata(dir, git_info)
-    @test metadata == (timestamp="2026-07-24T12-17-12", commit="0123456")
-  end
-end
-
 numprocs_str = get(ENV, "NUMPROCS", "1")
 
 oldWorkingDirectory = pwd()


### PR DESCRIPTION
Attempt to fix https://github.com/oscar-system/Oscar.jl/issues/6140.

Allow test and doctest statistics to obtain OSCAR revision metadata from package metadata when no Git checkout is available. Fall back to the OSCAR version when revision data cannot be recovered, and let the statistics converter handle that identifier gracefully.

 Co-authored-by: OpenAI Codex <codex@openai.com>