### PR TITLE
Fix `dual(::RootSpaceElem)` for a zero input

### DIFF
--- a/src/LieTheory/RootSystem.jl
+++ b/src/LieTheory/RootSystem.jl
@@ -1573,6 +1573,7 @@ If `r` is a root, this is the coroot corresponding to `r`.
 """
 function dual(r::RootSpaceElem)
   R = root_system(r)
+  iszero(r) && return zero(DualRootSpaceElem, R)
   lr = dot(r, r)
   coeffs = [dot(simple_root(R, i), simple_root(R, i))//lr * coeff(r, i) for i in 1:rank(R)]
   return DualRootSpaceElem(R, coeffs)
@@ -1587,6 +1588,7 @@ If `r` is a coroot, this is the root corresponding to `r`.
 """
 function dual(r::DualRootSpaceElem)
   R = root_system(r)
+  iszero(r) && return zero(RootSpaceElem, R)
   lr = dot(r, r)
   coeffs = [
     dot(simple_coroot(R, i), simple_coroot(R, i))//lr * coeff(r, i) for i in 1:rank(R)

--- a/test/LieTheory/RootSystem.jl
+++ b/test/LieTheory/RootSystem.jl
@@ -316,7 +316,6 @@
       ("F4", root_system(:F, 4)),
       ("G2", root_system(:G, 2)),
     ]
-
       @test iszero(dual(zero(RootSpaceElem, R)))
       @test iszero(dual(zero(DualRootSpaceElem, R)))
 

--- a/test/LieTheory/RootSystem.jl
+++ b/test/LieTheory/RootSystem.jl
@@ -316,9 +316,13 @@
       ("F4", root_system(:F, 4)),
       ("G2", root_system(:G, 2)),
     ]
+
+      @test iszero(dual(zero(RootSpaceElem, R)))
+      @test iszero(dual(zero(DualRootSpaceElem, R)))
+
       for i in 1:number_of_roots(R)
-        @test dual(root(R, i)) == coroot(R, i)
-        @test dual(coroot(R, i)) == root(R, i)
+        @test (@inferred dual(root(R, i))) == coroot(R, i)
+        @test (@inferred dual(coroot(R, i))) == root(R, i)
       end
 
       for _ in 1:10


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/6146.