### PR TITLE
Prevent mutations during F-theory model transformations

### DIFF
--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/blowups.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/blowups.jl
@@ -396,7 +396,7 @@ function blow_up(
   if ambient_space(model) isa NormalToricVariety
     index = index_of_exceptional_ray(bd)
     @req index == ngens(coordinate_ring(ambient_space(model))) "Inconsistency encountered. Contact the authors"
-    indices = exceptional_divisor_indices(model)
+    indices = copy(exceptional_divisor_indices(model))
     push!(indices, index)
     set_attribute!(model, :exceptional_divisor_indices, indices)
 
@@ -505,7 +505,7 @@ function resolve(m::AbstractFTheoryModel, resolution_index::Int)
   for k in 1:nr_blowups
 
     # Replace parameters in the blow_up_center with explicit_model_sections
-    blow_up_center = centers[k]
+    blow_up_center = copy(centers[k])
     for l in 1:length(blow_up_center)
       model_sections = explicit_model_sections(resolved_model)
       if haskey(model_sections, blow_up_center[l])

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
@@ -134,12 +134,6 @@ function flux_instance(
   completeness_check::Bool=true,
   consistency_check::Bool=true,
 )
-  if length(int_coeffs) == 0 && length(rat_coeffs) == 0
-    m = model(fgs)
-    r = cohomology_ring(ambient_space(m); completeness_check)
-    tcc = cohomology_class(ambient_space(m), zero(r); completeness_check)
-    return g4_flux(m, tcc; completeness_check, consistency_check)
-  end
   @req all(x -> x isa Int, int_coeffs) "Provided integral coefficient is not an integer"
   @req all(x -> x isa Rational{Int64}, rat_coeffs) "Provided integral coefficient is not an integer"
 

--- a/experimental/FTheoryTools/test/QSMs.jl
+++ b/experimental/FTheoryTools/test/QSMs.jl
@@ -85,4 +85,19 @@ end
   @test is_integer(solution[1])
   reconstructed_flux = flux_instance(fg, matrix(ZZ, [[solution[1]]]), solution[2:end, :])
   @test cohomology_class(qsm_g4_flux) == cohomology_class(reconstructed_flux)
+
+  # Empty coefficient lists must retain the affine offset of a flux family.
+  shifted_offset = copy(offset(fg))
+  shifted_offset[1] = 1
+  shifted_fg = family_of_g4_fluxes(
+    qsm_model, M1, M2, shifted_offset; completeness_check=false
+  )
+  empty_coeff_flux = flux_instance(
+    shifted_fg, Int[], Rational{Int}[]; completeness_check=false, consistency_check=false
+  )
+  zero_matrix_flux = flux_instance(
+    shifted_fg, zero_matrix(ZZ, ncols(M1), 1), zero_matrix(QQ, ncols(M2), 1);
+    completeness_check=false, consistency_check=false,
+  )
+  @test cohomology_class(empty_coeff_flux) == cohomology_class(zero_matrix_flux)
 end

--- a/experimental/FTheoryTools/test/literature_models.jl
+++ b/experimental/FTheoryTools/test/literature_models.jl
@@ -91,9 +91,14 @@ end
   @test_throws ArgumentError birational_literature_models(t1)
 end
 
+# Resolving a model must not mutate its stored resolution data or exceptional indices.
+resolution_data = deepcopy(resolutions(t1))
+initial_exceptional_indices = copy(exceptional_divisor_indices(t1))
 t2 = resolve(t1, 1)
 
 @testset "Test resolving literature Tate model over concrete base" begin
+  @test resolutions(t1) == resolution_data
+  @test exceptional_divisor_indices(t1) == initial_exceptional_indices
   @test is_smooth(ambient_space(t2)) == false
   @test is_partially_resolved(t2) == true
   @test base_space(t1) == base_space(t2)


### PR DESCRIPTION
Keep resolution recipes and exceptional-divisor metadata isolated from derived models. Preserve affine offsets when constructing flux instances from empty coefficient lists.

Co-authored-by: OpenAI Codex <codex@openai.com>