### PR TITLE
Improve FTheoryTools performance and model-data safety

### DIFF
--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/blowups.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/blowups.jl
@@ -505,16 +505,15 @@ function resolve(m::AbstractFTheoryModel, resolution_index::Int)
 
   # Resolve the model
   resolved_model = m
-  blow_up_chain = []
+  blow_up_chain = typeof(m)[]
   for k in 1:nr_blowups
 
     # Replace parameters in the blow_up_center with explicit_model_sections
     blow_up_center = copy(centers[k])
+    model_sections = explicit_model_sections(resolved_model)
     for l in 1:length(blow_up_center)
-      model_sections = explicit_model_sections(resolved_model)
       if haskey(model_sections, blow_up_center[l])
-        new_locus = string(explicit_model_sections(resolved_model)[blow_up_center[l]])
-        blow_up_center[l] = new_locus
+        blow_up_center[l] = string(model_sections[blow_up_center[l]])
       end
     end
 
@@ -546,7 +545,7 @@ function resolve(m::AbstractFTheoryModel, resolution_index::Int)
 
       # Compute strict transform of ideal sheaves appearing in blowup center
       exceptional_center = [c for c in blow_up_center if (c in exceptionals)]
-      positions = [findfirst(==(l), exceptionals) for l in exceptional_center]
+      positions = [findfirst(==(l), exceptionals)::Int for l in exceptional_center]
       exceptional_divisors = [
         exceptional_divisor(get_attribute(blow_up_chain[l], :blow_down_morphism)) for
         l in positions

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/put_over_concrete_base.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/put_over_concrete_base.jl
@@ -52,180 +52,80 @@ function put_over_concrete_base(
   # Conduct elementary entry checks
   @req base_space(m) isa FamilyOfSpaces "The model must be defined over a family of spaces"
   @req haskey(concrete_data, "base") "The base space must be specified"
-  @req (concrete_data["base"] isa NormalToricVariety) "Currently, models over families of spaces can only be put over toric bases"
-  @req ((m isa WeierstrassModel) || (m isa GlobalTateModel)) "Currently, only Tate or Weierstrass models can be put on a concrete base"
+  @req (
+    concrete_data["base"] isa NormalToricVariety
+  ) "Currently, models over families of spaces can only be put over toric bases"
+  @req (
+    m isa Union{WeierstrassModel,GlobalTateModel}
+  ) "Currently, only Tate or Weierstrass models can be put on a concrete base"
 
-  # Work out the Weierstrass/Tate sections
-  new_model_secs = Dict{String,MPolyRingElem}()
-  if is_empty(model_section_parametrization(m))
-
-    # No parametrization, so simply take generic sections
-
-    # Pick generic values
-    if m isa WeierstrassModel
-      new_model_secs["f"] = generic_section(
-        anticanonical_bundle(concrete_data["base"])^4; rng
-      )
-      new_model_secs["g"] = generic_section(
-        anticanonical_bundle(concrete_data["base"])^6; rng
-      )
-    else
-      new_model_secs["a1"] = generic_section(
-        anticanonical_bundle(concrete_data["base"]); rng
-      )
-      new_model_secs["a2"] = generic_section(
-        anticanonical_bundle(concrete_data["base"])^2; rng
-      )
-      new_model_secs["a3"] = generic_section(
-        anticanonical_bundle(concrete_data["base"])^3; rng
-      )
-      new_model_secs["a4"] = generic_section(
-        anticanonical_bundle(concrete_data["base"])^4; rng
-      )
-      new_model_secs["a6"] = generic_section(
-        anticanonical_bundle(concrete_data["base"])^6; rng
-      )
-    end
-
+  base = concrete_data["base"]::NormalToricVariety
+  parametrization = model_section_parametrization(m)
+  defining_sections = if m isa WeierstrassModel
+    (("f", 4), ("g", 6))
   else
+    (("a1", 1), ("a2", 2), ("a3", 3), ("a4", 4), ("a6", 6))
+  end
+  anticanonical = anticanonical_bundle(base)
+  new_model_sections = Dict{String,MPolyRingElem}()
 
-    # Parametrization for Weierstrass/Tate sections found
-
-    # Have all parametrizing sections been provided by the user?
-    polys = collect(values(model_section_parametrization(m)))
-    all_appearing_monomials = vcat([collect(monomials(p)) for p in polys]...)
-    all_appearing_exponents = hcat(
-      [collect(exponents(m))[1] for m in all_appearing_monomials]...
-    )
-    for k in 1:nrows(all_appearing_exponents)
-      if any(!is_zero, all_appearing_exponents[k, :])
-        gen_name = string(symbols(parent(polys[1]))[k])
-        @req haskey(concrete_data, gen_name) "Required base section $gen_name not specified"
-        @req parent(concrete_data[gen_name]) == coordinate_ring(concrete_data["base"]) "Specified sections must reside in Cox ring of given base"
-        new_model_secs[gen_name] = concrete_data[gen_name]
+  if isempty(parametrization)
+    for (name, power) in defining_sections
+      new_model_sections[name] = generic_section(anticanonical^power; rng)
+    end
+  else
+    parametrization_ring = parent(first(values(parametrization)))
+    parametrization_symbols = symbols(parametrization_ring)
+    used_generators = falses(ngens(parametrization_ring))
+    for polynomial in values(parametrization)
+      for index in eachindex(used_generators)
+        used_generators[index] |= degree(polynomial, index) > 0
       end
     end
 
-    # Create ring map to evaluate Weierstrass/Tate sections
-    parametrization = model_section_parametrization(m)
-    domain = parent(collect(values(parametrization))[1])
-    codomain = coordinate_ring(concrete_data["base"])
+    for index in eachindex(used_generators)
+      used_generators[index] || continue
+      name = string(parametrization_symbols[index])
+      @req haskey(concrete_data, name) "Required base section " * name * " not specified"
+      section = concrete_data[name]
+      @req (
+        parent(section) == coordinate_ring(base)
+      ) "Specified sections must reside in Cox ring of given base"
+      new_model_sections[name] = section
+    end
+
+    base_ring = coordinate_ring(base)
+    zero_section = zero(base_ring)
     images = [
-      haskey(new_model_secs, string(k)) ? new_model_secs[string(k)] : zero(codomain) for
-      k in gens(domain)
+      get(new_model_sections, string(generator), zero_section) for
+      generator in gens(parametrization_ring)
     ]
-    mapper = hom(domain, codomain, images)
+    evaluation_map = hom(parametrization_ring, base_ring, images)
 
-    # Compute defining sections
-    if m isa WeierstrassModel
-      if haskey(parametrization, "f")
-        new_sec = mapper(parametrization["f"])
-        if !is_zero(new_sec)
-          @req degree(new_sec) ==
-            degree(generic_section(anticanonical_bundle(concrete_data["base"])^4; rng)) "Degree mismatch"
+    for (name, power) in defining_sections
+      bundle = anticanonical^power
+      if haskey(parametrization, name)
+        section = evaluation_map(parametrization[name])
+        if !is_zero(section)
+          expected_degree = divisor_class(toric_divisor_class(bundle))
+          @req degree(section) == expected_degree "Degree mismatch"
         end
-        new_model_secs["f"] = new_sec
+        new_model_sections[name] = section
       else
-        new_model_secs["f"] = generic_section(
-          anticanonical_bundle(concrete_data["base"])^4; rng
-        )
-      end
-
-      if haskey(parametrization, "g")
-        new_sec = mapper(parametrization["g"])
-        if !is_zero(new_sec)
-          @req degree(new_sec) ==
-            degree(generic_section(anticanonical_bundle(concrete_data["base"])^6; rng)) "Degree mismatch"
-        end
-        new_model_secs["g"] = new_sec
-      else
-        new_model_secs["g"] = generic_section(
-          anticanonical_bundle(concrete_data["base"])^6; rng
-        )
-      end
-
-    else
-      if haskey(parametrization, "a1")
-        new_sec = mapper(parametrization["a1"])
-        if !is_zero(new_sec)
-          @req degree(new_sec) ==
-            degree(generic_section(anticanonical_bundle(concrete_data["base"]); rng)) "Degree mismatch"
-        end
-        new_model_secs["a1"] = new_sec
-      else
-        new_model_secs["a1"] = generic_section(
-          anticanonical_bundle(concrete_data["base"]); rng
-        )
-      end
-
-      if haskey(parametrization, "a2")
-        new_sec = mapper(parametrization["a2"])
-        if !is_zero(new_sec)
-          @req degree(new_sec) ==
-            degree(generic_section(anticanonical_bundle(concrete_data["base"])^2; rng)) "Degree mismatch"
-        end
-        new_model_secs["a2"] = new_sec
-      else
-        new_model_secs["a2"] = generic_section(
-          anticanonical_bundle(concrete_data["base"])^2; rng
-        )
-      end
-
-      if haskey(parametrization, "a3")
-        new_sec = mapper(parametrization["a3"])
-        if !is_zero(new_sec)
-          @req degree(new_sec) ==
-            degree(generic_section(anticanonical_bundle(concrete_data["base"])^3; rng)) "Degree mismatch"
-        end
-        new_model_secs["a3"] = new_sec
-      else
-        new_model_secs["a3"] = generic_section(
-          anticanonical_bundle(concrete_data["base"])^3; rng
-        )
-      end
-
-      if haskey(parametrization, "a4")
-        new_sec = mapper(parametrization["a4"])
-        if !is_zero(new_sec)
-          @req degree(new_sec) ==
-            degree(generic_section(anticanonical_bundle(concrete_data["base"])^4; rng)) "Degree mismatch"
-        end
-        new_model_secs["a4"] = new_sec
-      else
-        new_model_secs["a4"] = generic_section(
-          anticanonical_bundle(concrete_data["base"])^4; rng
-        )
-      end
-
-      if haskey(parametrization, "a6")
-        new_sec = mapper(parametrization["a6"])
-        if !is_zero(new_sec)
-          @req degree(new_sec) ==
-            degree(generic_section(anticanonical_bundle(concrete_data["base"])^6; rng)) "Degree mismatch"
-        end
-        new_model_secs["a6"] = new_sec
-      else
-        new_model_secs["a6"] = generic_section(
-          anticanonical_bundle(concrete_data["base"])^6; rng
-        )
+        new_model_sections[name] = generic_section(bundle; rng)
       end
     end
   end
 
-  # Compute the new model
-  if m isa WeierstrassModel
-    return weierstrass_model(
-      concrete_data["base"],
-      new_model_secs,
-      model_section_parametrization(m);
-      completeness_check,
+  result = if m isa WeierstrassModel
+    weierstrass_model(
+      base, new_model_sections, parametrization; completeness_check
     )
   else
-    return global_tate_model(
-      concrete_data["base"],
-      new_model_secs,
-      model_section_parametrization(m);
-      completeness_check,
+    global_tate_model(
+      base, new_model_sections, parametrization; completeness_check
     )
   end
+  _copy_model_metadata!(result, m)
+  return result
 end

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/put_over_concrete_base.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/put_over_concrete_base.jl
@@ -40,7 +40,7 @@ julia> a32 = generic_section(kbar^3 * w_bundle^(-2));
 julia> a43 = generic_section(kbar^4 * w_bundle^(-3));
 
 julia> t2 = put_over_concrete_base(t, Dict("base" => B3, "w" => w, "a21" => a21, "a32" => a32, "a43" => a43), completeness_check = false, rng = Random.Xoshiro(1234))
-Global Tate model over a concrete base
+Global Tate model over a concrete base -- SU(5)xU(1) restricted Tate model based on arXiv paper 1109.3454 Eq. (3.1)
 ```
 """
 function put_over_concrete_base(

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/attributes.jl
@@ -275,7 +275,7 @@ julia> d3_tadpole_constraint(fgs, rng = Random.Xoshiro(1234));
           val = gen1[l1] * gen2[l2]
           is_zero(val) && continue
 
-          my_tuple = Tuple(sort([basis_indices[l1]..., basis_indices[l2]...]))
+          my_tuple = _sorted_tuple(basis_indices[l1]..., basis_indices[l2]...)
 
           if arxiv_doi(m) == "10.48550/arXiv.1511.03209"
             change = sophisticated_intersection_product(

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special-intersection-theory.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special-intersection-theory.jl
@@ -13,7 +13,7 @@ function sophisticated_intersection_product(
 )
 
   # (A) Have we computed this intersection number in the past? If so, just use that result...
-  indices = Tuple(sort(collect(indices)))
+  indices = _sorted_tuple(indices...)
   if haskey(inter_dict, indices)
     return inter_dict[indices]
   end
@@ -26,16 +26,11 @@ function sophisticated_intersection_product(
     end
   end
 
-  # (C) Deal with self-intersection and should-never-happen case.
-  distinct_variables = Set(indices)
-  if length(distinct_variables) < 4 && length(distinct_variables) >= 1
+  # (C) Deal with self-intersections.
+  if !allunique(indices)
     return intersection_from_equivalent_cycle(
       v, indices, hypersurface_equation, inter_dict, s_inter_dict, data; rng
     )
-  end
-  if length(distinct_variables) == 0
-    println("WEIRD! THIS SHOULD NEVER HAPPEN! INFORM THE AUTHORS!")
-    println("")
   end
 
   # (D) Deal with transverse intersection...
@@ -44,17 +39,6 @@ function sophisticated_intersection_product(
   pt_reduced, gs_reduced, remaining_vars, reduced_scaling_relations = Oscar._reduce_hypersurface_equation(
     v, hypersurface_equation, indices, data
   )
-  if haskey(
-    s_inter_dict,
-    string([pt_reduced, gs_reduced, remaining_vars, reduced_scaling_relations]),
-  )
-    numb = s_inter_dict[string([
-      pt_reduced, gs_reduced, remaining_vars, reduced_scaling_relations
-    ])]
-    inter_dict[indices] = numb
-    return numb
-  end
-
   # D.2 If pt == 0, then we are not looking at a transverse intersection. So take an equivalent cycle and try again...
   if is_zero(pt_reduced)
     return intersection_from_equivalent_cycle(
@@ -154,7 +138,16 @@ function sophisticated_intersection_product(
     end
   end
 
-  # C.9 In all other cases, proceed via a rationally equivalent cycle
+  # C.9 In all other cases, proceed via a rationally equivalent cycle.
+  # Construct the serialization-compatible string key only for this expensive fallback.
+  reduction_key = string([
+    pt_reduced, gs_reduced, remaining_vars, reduced_scaling_relations
+  ])
+  if haskey(s_inter_dict, reduction_key)
+    numb = s_inter_dict[reduction_key]
+    inter_dict[indices] = numb
+    return numb
+  end
   #=
   println("")
   println("FOUND CASE THAT CANNOT YET BE DECIDED!")
@@ -169,9 +162,7 @@ function sophisticated_intersection_product(
   numb = intersection_from_equivalent_cycle(
     v, indices, hypersurface_equation, inter_dict, s_inter_dict, data; rng
   )
-  s_inter_dict[string([
-    pt_reduced, gs_reduced, remaining_vars, reduced_scaling_relations
-  ])] = numb
+  s_inter_dict[reduction_key] = numb
   return numb
 end
 
@@ -325,14 +316,14 @@ function _rationally_equivalent_cycle(
       new_tuple = (
         indices[1:(pos_power_variable - 1)]..., k, indices[(pos_power_variable + 1):end]...
       )
-      new_tuple = Tuple(sort(collect(new_tuple)))
+      new_tuple = _sorted_tuple(new_tuple...)
 
       pos = findfirst(==(new_tuple), tuples)
       if pos !== nothing
         coeffs[pos] += employed_relation[k]
       else
         push!(coeffs, employed_relation[k])
-        push!(tuples, Tuple(new_tuple))
+        push!(tuples, new_tuple)
       end
     end
   end

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
@@ -150,14 +150,9 @@ function special_flux_family_with_default_algorithm(
 )
 
   # (1) Are intersection numbers known?
-  # These instructions appear twice, once in the default and once in the special algorithnm. Code duplication? Improve it!
   inter_dict = get_attribute!(m, :inter_dict) do
     Dict{NTuple{4,Int64},ZZRingElem}()
   end::Dict{NTuple{4,Int64},ZZRingElem}
-  s_inter_dict = get_attribute!(m, :s_inter_dict) do
-    Dict{String,ZZRingElem}()
-  end::Dict{String,ZZRingElem}
-
   # (2) Obtain critical information - this may take significant time!
   ambient_space_flux_candidates_basis = gens_of_h22_hypersurface(m; completeness_check)
   list_of_base_divisor_pairs_to_be_considered = Oscar._ambient_space_base_divisor_pairs_to_be_considered(
@@ -169,11 +164,15 @@ function special_flux_family_with_default_algorithm(
   list_of_divisor_pairs_to_be_considered = Oscar._ambient_space_divisor_pairs_to_be_considered(
     m
   )
-  S = coordinate_ring(ambient_space(m))
   exceptional_divisor_positions = exceptional_divisor_indices(m)
-  tds = torusinvariant_prime_divisors(ambient_space(m))
+  ambient = ambient_space(m)
+  tds = torusinvariant_prime_divisors(ambient)
   cds = [cohomology_class(td) for td in tds]
-  pt_class = cohomology_class(anticanonical_divisor_class(ambient_space(m)))
+  pt_class = cohomology_class(anticanonical_divisor_class(ambient))
+  zsc = zero_section_class(m)
+  pos_zero_section = zero_section_index(m)
+  @req pos_zero_section !== nothing && pos_zero_section >= 1 "Could not establish position of the zero section"
+  number_of_base_rays = n_rays(base_space(m))
 
   # (3) Work out the relevant intersection numbers to tell if a flux passes the transversality constraints & (if desired) does not break the non-abelian gauge group.
   transversality_constraint_matrix = Vector{Vector{ZZRingElem}}()
@@ -182,11 +181,9 @@ function special_flux_family_with_default_algorithm(
 
     # Compute against pairs of base divisors
     for j in 1:length(list_of_base_divisor_pairs_to_be_considered)
-      my_tuple = Tuple(
-        sort([
-          ambient_space_flux_candidates_basis_indices[i]...,
-          list_of_base_divisor_pairs_to_be_considered[j]...,
-        ]),
+      my_tuple = _sorted_tuple(
+        ambient_space_flux_candidates_basis_indices[i]...,
+        list_of_base_divisor_pairs_to_be_considered[j]...,
       )
       push!(
         condition,
@@ -201,12 +198,9 @@ function special_flux_family_with_default_algorithm(
     end
 
     # Compute against zero section and base divisor
-    zsc = zero_section_class(m)
-    pos_zero_section = zero_section_index(m)
-    @req pos_zero_section !== nothing && pos_zero_section >= 1 "Could not establish position of the zero section"
-    for j in 1:n_rays(base_space(m))
-      my_tuple = Tuple(
-        sort([ambient_space_flux_candidates_basis_indices[i]..., [j, pos_zero_section]...])
+    for j in 1:number_of_base_rays
+      my_tuple = _sorted_tuple(
+        ambient_space_flux_candidates_basis_indices[i]..., j, pos_zero_section
       )
       push!(
         condition,
@@ -219,14 +213,12 @@ function special_flux_family_with_default_algorithm(
 
     # Compute against exceptional divisors
     if not_breaking
-      for j in 1:n_rays(base_space(m))
+      for j in 1:number_of_base_rays
         for k in 1:length(exceptional_divisor_positions)
-          my_tuple = Tuple(
-            sort([
-              ambient_space_flux_candidates_basis_indices[i]...,
-              j,
-              exceptional_divisor_positions[k]...,
-            ]),
+          my_tuple = _sorted_tuple(
+            ambient_space_flux_candidates_basis_indices[i]...,
+            j,
+            exceptional_divisor_positions[k],
           )
           push!(
             condition,
@@ -253,11 +245,9 @@ function special_flux_family_with_default_algorithm(
   for i in 1:length(ambient_space_flux_candidates_basis)
     condition = Vector{ZZRingElem}()
     for j in 1:length(list_of_divisor_pairs_to_be_considered)
-      my_tuple = Tuple(
-        sort([
-          ambient_space_flux_candidates_basis_indices[i]...,
-          list_of_divisor_pairs_to_be_considered[j]...,
-        ]),
+      my_tuple = _sorted_tuple(
+        ambient_space_flux_candidates_basis_indices[i]...,
+        list_of_divisor_pairs_to_be_considered[j]...,
       )
       push!(
         condition,
@@ -318,11 +308,13 @@ function special_flux_family_with_special_algorithm(
 )
 
   # (1) Compute data, that is frequently used by the sophisticated intersection product below
-  S = coordinate_ring(ambient_space(m))
-  gS = gens(coordinate_ring(ambient_space(m)))
-  linear_relations = matrix(ZZ, rays(ambient_space(m)))
+  ambient = ambient_space(m)
+  hypersurface = hypersurface_equation(m)
+  S = coordinate_ring(ambient)
+  gS = gens(S)
+  linear_relations = matrix(ZZ, rays(ambient))
   scalings = [c.coeff for c in S.d]
-  mnf = Oscar._minimal_nonfaces(ambient_space(m))
+  mnf = Oscar._minimal_nonfaces(ambient)
   sr_ideal_pos = [Vector{Int}(Polymake.row(mnf, i)) for i in 1:Polymake.nrows(mnf)]
   data = (
     S=S,
@@ -353,6 +345,9 @@ function special_flux_family_with_special_algorithm(
   )
   # TODO: This line is a bit fragile. Fix it!
   exceptional_divisor_positions = exceptional_divisor_indices(m)
+  pos_zero_section = zero_section_index(m)
+  @req pos_zero_section !== nothing && pos_zero_section >= 1 "Could not establish position of the zero section"
+  number_of_base_rays = n_rays(base_space(m))
 
   # (5) Work out the relevant intersection numbers to tell if a flux passes the transversality constraints & (if desired) if the flux is not breaking the gauge group.
   transversality_constraint_matrix = Vector{Vector{ZZRingElem}}()
@@ -361,18 +356,16 @@ function special_flux_family_with_special_algorithm(
 
     # Compute against pairs of base divisors
     for j in 1:length(list_of_base_divisor_pairs_to_be_considered)
-      my_tuple = Tuple(
-        sort([
-          ambient_space_flux_candidates_basis_indices[i]...,
-          list_of_base_divisor_pairs_to_be_considered[j]...,
-        ]),
+      my_tuple = _sorted_tuple(
+        ambient_space_flux_candidates_basis_indices[i]...,
+        list_of_base_divisor_pairs_to_be_considered[j]...,
       )
       push!(
         condition,
         sophisticated_intersection_product(
-          ambient_space(m),
+          ambient,
           my_tuple,
-          hypersurface_equation(m),
+          hypersurface,
           inter_dict,
           s_inter_dict,
           data;
@@ -382,17 +375,16 @@ function special_flux_family_with_special_algorithm(
     end
 
     # Compute against zero section and base divisor
-    pos_zero_section = zero_section_index(m)
-    for j in 1:n_rays(base_space(m))
-      my_tuple = Tuple(
-        sort([ambient_space_flux_candidates_basis_indices[i]..., [j, pos_zero_section]...])
+    for j in 1:number_of_base_rays
+      my_tuple = _sorted_tuple(
+        ambient_space_flux_candidates_basis_indices[i]..., j, pos_zero_section
       )
       push!(
         condition,
         sophisticated_intersection_product(
-          ambient_space(m),
+          ambient,
           my_tuple,
-          hypersurface_equation(m),
+          hypersurface,
           inter_dict,
           s_inter_dict,
           data;
@@ -403,20 +395,19 @@ function special_flux_family_with_special_algorithm(
 
     # Compute against exceptional divisors if desired
     if not_breaking
-      for j in 1:n_rays(base_space(m))
+      for j in 1:number_of_base_rays
         for k in 1:length(exceptional_divisor_positions)
-          my_tuple = Tuple(
-            sort([
-              ambient_space_flux_candidates_basis_indices[i]...,
-              [j, exceptional_divisor_positions[k]]...,
-            ]),
+          my_tuple = _sorted_tuple(
+            ambient_space_flux_candidates_basis_indices[i]...,
+            j,
+            exceptional_divisor_positions[k],
           )
           push!(
             condition,
             sophisticated_intersection_product(
-              ambient_space(m),
+              ambient,
               my_tuple,
-              hypersurface_equation(m),
+              hypersurface,
               inter_dict,
               s_inter_dict,
               data;
@@ -439,18 +430,16 @@ function special_flux_family_with_special_algorithm(
   for i in 1:length(ambient_space_flux_candidates_basis)
     condition = Vector{ZZRingElem}()
     for j in 1:length(list_of_divisor_pairs_to_be_considered)
-      my_tuple = Tuple(
-        sort([
-          ambient_space_flux_candidates_basis_indices[i]...,
-          list_of_divisor_pairs_to_be_considered[j]...,
-        ]),
+      my_tuple = _sorted_tuple(
+        ambient_space_flux_candidates_basis_indices[i]...,
+        list_of_divisor_pairs_to_be_considered[j]...,
       )
       push!(
         condition,
         sophisticated_intersection_product(
-          ambient_space(m),
+          ambient,
           my_tuple,
-          hypersurface_equation(m),
+          hypersurface,
           inter_dict,
           s_inter_dict,
           data;
@@ -474,14 +463,14 @@ function special_flux_family_with_special_algorithm(
   for j in 1:length(list_of_divisor_pairs_to_be_considered)
     inter_numb = QQ(0)
     for k in 1:length(non_zero_exponents)
-      my_tuple = Tuple(
-        sort([non_zero_exponents[k]..., list_of_divisor_pairs_to_be_considered[j]...])
+      my_tuple = _sorted_tuple(
+        non_zero_exponents[k]..., list_of_divisor_pairs_to_be_considered[j]...
       )
       inter_numb +=
         coeffs[k] * sophisticated_intersection_product(
-          ambient_space(m),
+          ambient,
           my_tuple,
-          hypersurface_equation(m),
+          hypersurface,
           inter_dict,
           s_inter_dict,
           data;

--- a/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
@@ -495,19 +495,10 @@ end
 
 # Detailed printing
 function Base.show(io::IO, ::MIME"text/plain", h::HypersurfaceModel)
-  io = pretty(io)
-  properties_string = String[]
-  if is_partially_resolved(h)
-    push!(properties_string, "Partially resolved hypersurface model over a")
-  else
-    push!(properties_string, "Hypersurface model over a")
-  end
-  if is_base_space_fully_specified(h)
-    push!(properties_string, "concrete base")
-  else
-    push!(properties_string, "not fully specified base")
-  end
-  join(io, properties_string, " ")
+  return _show_model_over_base(
+    io, h, "Hypersurface model"; show_literature_data=false,
+    partially_resolved_model_name="hypersurface model",
+  )
 end
 
 # Terse and one line printing

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -153,14 +153,14 @@ function literature_model(;
   equation::String="",
   type::String="",
   model_parameters::StringKeyedMapType=Dict{String,Any}(),
-  base_space::FTheorySpace=affine_space(NormalToricVariety, 0),
+  base_space::Union{Nothing,FTheorySpace}=nothing,
   model_sections::StringKeyedMapType=Dict{String,Any}(),
   defining_classes::StringKeyedMapType=Dict{String,Any}(),
   completeness_check::Bool=true,
   rng::AbstractRNG=Random.default_rng(),
 )
   model_dict = _find_model(doi, arxiv_id, version, equation, type)
-  return literature_model(
+  return _literature_model(
     model_dict;
     model_parameters=model_parameters,
     base_space=base_space,
@@ -174,14 +174,14 @@ end
 function literature_model(
   k::Int;
   model_parameters::StringKeyedMapType=Dict{String,Any}(),
-  base_space::FTheorySpace=affine_space(NormalToricVariety, 0),
+  base_space::Union{Nothing,FTheorySpace}=nothing,
   model_sections::StringKeyedMapType=Dict{String,Any}(),
   defining_classes::StringKeyedMapType=Dict{String,Any}(),
   completeness_check::Bool=true,
   rng::AbstractRNG=Random.default_rng(),
 )
   model_dict = _find_model(k)
-  return literature_model(
+  return _literature_model(
     model_dict;
     model_parameters=model_parameters,
     base_space=base_space,
@@ -195,12 +195,35 @@ end
 function literature_model(
   model_dict::StringKeyedMapType;
   model_parameters::StringKeyedMapType=Dict{String,Any}(),
-  base_space::FTheorySpace=affine_space(NormalToricVariety, 0),
+  base_space::Union{Nothing,FTheorySpace}=nothing,
   model_sections::StringKeyedMapType=Dict{String,Any}(),
   defining_classes::StringKeyedMapType=Dict{String,Any}(),
   completeness_check::Bool=true,
   rng::AbstractRNG=Random.default_rng(),
 )
+  Base.@nospecialize model_dict
+  return _literature_model(
+    deepcopy(model_dict);
+    model_parameters,
+    base_space,
+    model_sections,
+    defining_classes,
+    completeness_check,
+    rng,
+  )
+end
+
+function _literature_model(
+  model_dict::StringKeyedMapType;
+  model_parameters::StringKeyedMapType=Dict{String,Any}(),
+  base_space::Union{Nothing,FTheorySpace}=nothing,
+  model_sections::StringKeyedMapType=Dict{String,Any}(),
+  defining_classes::StringKeyedMapType=Dict{String,Any}(),
+  completeness_check::Bool=true,
+  rng::AbstractRNG=Random.default_rng(),
+)
+  Base.@nospecialize model_dict
+
   # (1) Deal with model parameters
   if haskey(model_dict, "model_parameters")
     needed_model_parameters = string.(model_dict["model_parameters"])
@@ -271,7 +294,7 @@ function literature_model(
   end
 
   # (3) Construct the model over concrete or arbitrary base
-  if dim(base_space) > 0
+  if !isnothing(base_space) && dim(base_space) > 0
 
     # Currently, support only for toric bases
     @req base_space isa NormalToricVariety "Construction of literature models over concrete bases currently limited to toric bases"
@@ -297,7 +320,7 @@ function literature_model(
       @req dim(base_space) == Int(model_dict["model_data"]["base_dim"]) "Model requires base dimension different from dimension of provided base"
     end
 
-    # Add additional information that is always known for weierstrass/tate 
+    # Add additional information that is always known for weierstrass/tate
     if (model_dict["model_descriptors"]["type"] == "weierstrass") ||
       (model_dict["model_descriptors"]["type"] == "tate")
       model_dict["model_data"]["zero_section_class"] = "z"
@@ -802,73 +825,88 @@ function _set_all_attributes(
     )
   end
 
-  R, _ = polynomial_ring(QQ, collect(keys(explicit_model_sections(model))); cached=false)
-  f = hom(
-    R, coordinate_ring(base_space(model)), collect(values(explicit_model_sections(model)))
+  model_data = model_dict["model_data"]
+  section_attributes = (
+    "resolution_generating_sections",
+    "resolution_zero_sections",
+    "weighted_resolution_generating_sections",
+    "weighted_resolution_zero_sections",
+    "zero_section",
+    "generating_sections",
+    "torsion_sections",
   )
-
-  if haskey(model_dict["model_data"], "resolution_generating_sections")
-    vs = [
-      [[string.(k) for k in sec] for sec in res] for
-      res in model_dict["model_data"]["resolution_generating_sections"]
-    ]
-    result = [[[[f(eval_poly(a, R)) for a in b] for b in c] for c in d] for d in vs]
-    set_attribute!(model, :resolution_generating_sections => result)
-  end
-
-  if haskey(model_dict["model_data"], "resolution_zero_sections")
-    vs = [
-      [string.(a) for a in b] for b in model_dict["model_data"]["resolution_zero_sections"]
-    ]
-    result = [[[f(eval_poly(a, R)) for a in b] for b in c] for c in vs]
-    set_attribute!(model, :resolution_zero_sections => result)
-  end
-
-  if haskey(model_dict["model_data"], "weighted_resolution_generating_sections")
-    vs = [
-      [[string.(k) for k in sec] for sec in res] for
-      res in model_dict["model_data"]["weighted_resolution_generating_sections"]
-    ]
-    result = [[[[f(eval_poly(a, R)) for a in b] for b in c] for c in d] for d in vs]
-    set_attribute!(model, :weighted_resolution_generating_sections => result)
-  end
-
-  if haskey(model_dict["model_data"], "weighted_resolution_zero_sections")
-    vs = [
-      [string.(a) for a in b] for
-      b in model_dict["model_data"]["weighted_resolution_zero_sections"]
-    ]
-    result = [[[f(eval_poly(a, R)) for a in b] for b in c] for c in vs]
-    set_attribute!(model, :weighted_resolution_zero_sections => result)
-  end
-
-  if haskey(model_dict["model_data"], "zero_section")
-    vs = string.(model_dict["model_data"]["zero_section"])
-    set_attribute!(model, :zero_section => [f(eval_poly(l, R)) for l in vs])
-  end
-
-  if haskey(model_dict["model_data"], "generating_sections")
-    vs = map(k -> string.(k), model_dict["model_data"]["generating_sections"])
-    set_attribute!(
-      model, :generating_sections => [[f(eval_poly(l, R)) for l in k] for k in vs]
+  if any(name -> haskey(model_data, name), section_attributes)
+    R, _ = polynomial_ring(QQ, collect(keys(explicit_model_sections(model))); cached=false)
+    f = hom(
+      R, coordinate_ring(base_space(model)), collect(values(explicit_model_sections(model)))
     )
+
+    if haskey(model_dict["model_data"], "resolution_generating_sections")
+      vs = [
+        [[string.(k) for k in sec] for sec in res] for
+        res in model_dict["model_data"]["resolution_generating_sections"]
+      ]
+      result = [[[[f(eval_poly(a, R)) for a in b] for b in c] for c in d] for d in vs]
+      set_attribute!(model, :resolution_generating_sections => result)
+    end
+
+    if haskey(model_dict["model_data"], "resolution_zero_sections")
+      vs = [
+        [string.(a) for a in b] for
+        b in model_dict["model_data"]["resolution_zero_sections"]
+      ]
+      result = [[[f(eval_poly(a, R)) for a in b] for b in c] for c in vs]
+      set_attribute!(model, :resolution_zero_sections => result)
+    end
+
+    if haskey(model_dict["model_data"], "weighted_resolution_generating_sections")
+      vs = [
+        [[string.(k) for k in sec] for sec in res] for
+        res in model_dict["model_data"]["weighted_resolution_generating_sections"]
+      ]
+      result = [[[[f(eval_poly(a, R)) for a in b] for b in c] for c in d] for d in vs]
+      set_attribute!(model, :weighted_resolution_generating_sections => result)
+    end
+
+    if haskey(model_dict["model_data"], "weighted_resolution_zero_sections")
+      vs = [
+        [string.(a) for a in b] for
+        b in model_dict["model_data"]["weighted_resolution_zero_sections"]
+      ]
+      result = [[[f(eval_poly(a, R)) for a in b] for b in c] for c in vs]
+      set_attribute!(model, :weighted_resolution_zero_sections => result)
+    end
+
+    if haskey(model_dict["model_data"], "zero_section")
+      vs = string.(model_dict["model_data"]["zero_section"])
+      set_attribute!(model, :zero_section => [f(eval_poly(l, R)) for l in vs])
+    end
+
+    if haskey(model_dict["model_data"], "generating_sections")
+      vs = map(k -> string.(k), model_dict["model_data"]["generating_sections"])
+      set_attribute!(
+        model, :generating_sections => [[f(eval_poly(l, R)) for l in k] for k in vs]
+      )
+    end
+
+    if haskey(model_dict["model_data"], "torsion_sections")
+      vs = map(k -> string.(k), model_dict["model_data"]["torsion_sections"])
+      set_attribute!(
+        model, :torsion_sections => [[f(eval_poly(l, R)) for l in k] for k in vs]
+      )
+    end
   end
 
-  if haskey(model_dict["model_data"], "torsion_sections")
-    vs = map(k -> string.(k), model_dict["model_data"]["torsion_sections"])
-    set_attribute!(
-      model, :torsion_sections => [[f(eval_poly(l, R)) for l in k] for k in vs]
-    )
-  end
+  has_toric_divisor_classes =
+    haskey(model_data, "zero_section_class") || haskey(model_data, "exceptional_classes")
+  if base_space(model) isa NormalToricVariety &&
+    ambient_space(model) isa NormalToricVariety && has_toric_divisor_classes
+    ambient = ambient_space(model)
+    divs = torusinvariant_prime_divisors(ambient)
+    cox_gens = symbols(coordinate_ring(ambient))
 
-  if base_space(model) isa NormalToricVariety && ambient_space(model) isa NormalToricVariety
-    divs = torusinvariant_prime_divisors(ambient_space(model))
-    cohomology_ring(ambient_space(model); completeness_check=false)
-    cox_gens = symbols(coordinate_ring(ambient_space(model)))
-
-    if haskey(model_dict["model_data"], "zero_section_class") &&
-      base_space(model) isa NormalToricVariety
-      desired_value = Symbol(string.(model_dict["model_data"]["zero_section_class"]))
+    if haskey(model_data, "zero_section_class")
+      desired_value = Symbol(string.(model_data["zero_section_class"]))
       @req desired_value in cox_gens "Specified zero section is invalid"
       index = findfirst(==(desired_value), cox_gens)
       set_attribute!(model, :zero_section_index => index::Int)
@@ -879,9 +917,8 @@ function _set_all_attributes(
       )
     end
 
-    if haskey(model_dict["model_data"], "exceptional_classes") &&
-      base_space(model) isa NormalToricVariety
-      desired_value = string.(model_dict["model_data"]["exceptional_classes"])
+    if haskey(model_data, "exceptional_classes")
+      desired_value = string.(model_data["exceptional_classes"])
       @req issubset(Symbol.(desired_value), cox_gens) "Specified exceptional classes are invalid"
       exceptional_divisor_indices = Vector{Int}()
       for class in desired_value
@@ -893,8 +930,10 @@ function _set_all_attributes(
       )
       set_attribute!(
         model,
-        :exceptional_classes =>
-          [cohomology_class(divs[index]) for index in exceptional_divisor_indices],
+        :exceptional_classes => [
+          cohomology_class(divs[index]; completeness_check=false) for
+          index in exceptional_divisor_indices
+        ],
       )
     end
   end

--- a/experimental/FTheoryTools/src/TateModels/attributes.jl
+++ b/experimental/FTheoryTools/src/TateModels/attributes.jl
@@ -191,80 +191,37 @@ Weierstrass model over a concrete base
   @req (base_space(t) isa NormalToricVariety || base_space(t) isa FamilyOfSpaces) "Conversion of global Tate model into Weierstrass model is currently only supported for toric varieties and family of spaces as base space"
 
   # Compute explicit Weierstrass sections
-  b2 = 4 * tate_section_a2(t) + tate_section_a1(t)^2
-  b4 = 2 * tate_section_a4(t) + tate_section_a1(t) * tate_section_a3(t)
-  b6 = 4 * tate_section_a6(t) + tate_section_a3(t)^2
-  f = -1//48 * (b2^2 - 24 * b4)
-  g = 1//864 * (b2^3 - 36 * b2 * b4 + 216 * b6)
+  f, g = _weierstrass_sections_from_tate(
+    tate_section_a1(t),
+    tate_section_a2(t),
+    tate_section_a3(t),
+    tate_section_a4(t),
+    tate_section_a6(t),
+  )
 
   # Compute explicit_model_sections
   new_explicit_model_sections = Dict("f" => f, "g" => g)
-  sections_t = collect(keys(explicit_model_sections(t)))
-  for section in sections_t
-    if !(section in ["a1", "a2", "a3", "a4", "a6"])
-      new_explicit_model_sections[section] = explicit_model_sections(t)[section]
-    end
+  tate_section_names = ("a1", "a2", "a3", "a4", "a6")
+  for (name, section) in explicit_model_sections(t)
+    name in tate_section_names || (new_explicit_model_sections[name] = section)
   end
 
   # Compute Weierstrass polynomial
-  S = coordinate_ring(ambient_space(t))
-  x, y, z = gens(S)[(ngens(S) - 2):ngens(S)]
-  ring_map = hom(parent(f), S, gens(S)[1:ngens(parent(f))])
-  pw = x^3 - y^2 + ring_map(f) * x * z^4 + ring_map(g) * z^6
+  pw = _weierstrass_polynomial(f, g, coordinate_ring(ambient_space(t)))
 
   # Compute parametrization of Weierstrass sections
   parametrization = model_section_parametrization(t)
-  param_keys = collect(keys(parametrization))
   new_model_section_parametrization = Dict{String,MPolyRingElem}()
-  if length(param_keys) > 0
-    # Find ring to evaluate polynomials into
-    R = parent(parametrization[param_keys[1]])
-
-    # Identify how we parametrize a1
-    if haskey(parametrization, "a1")
-      param_a1 = parametrization["a1"]
-    else
-      param_a1 = eval_poly("a1", R)
+  if !isempty(parametrization)
+    parametrization_ring = parent(first(values(parametrization)))
+    parametrized_tate_sections = map(tate_section_names) do name
+      if haskey(parametrization, name)
+        parametrization[name]
+      else
+        eval_poly(name, parametrization_ring)
+      end
     end
-
-    # Identify how we parametrize a2
-    if haskey(parametrization, "a2")
-      param_a2 = parametrization["a2"]
-    else
-      param_a2 = eval_poly("a2", R)
-    end
-
-    # Identify how we parametrize a3
-    if haskey(parametrization, "a3")
-      param_a3 = parametrization["a3"]
-    else
-      param_a3 = eval_poly("a3", R)
-    end
-
-    # Identify how we parametrize a4
-    if haskey(parametrization, "a4")
-      param_a4 = parametrization["a4"]
-    else
-      param_a4 = eval_poly("a4", R)
-    end
-
-    # Identify how we parametrize a6
-    if haskey(parametrization, "a6")
-      param_a6 = parametrization["a6"]
-    else
-      param_a6 = eval_poly("a6", R)
-    end
-
-    # Compute parametrization of b2, b4, b6
-    param_b2 = 4 * param_a2 + param_a1^2
-    param_b4 = 2 * param_a4 + param_a1 * param_a3
-    param_b6 = 4 * param_a6 + param_a3^2
-
-    # Compute parametrization of f, g
-    param_f = -1//48 * (param_b2^2 - 24 * param_b4)
-    param_g = 1//864 * (param_b2^3 - 36 * param_b2 * param_b4 + 216 * param_b6)
-
-    # Compute model_section_parametrization
+    param_f, param_g = _weierstrass_sections_from_tate(parametrized_tate_sections...)
     new_model_section_parametrization = Dict("f" => param_f, "g" => param_g)
   end
 
@@ -277,11 +234,10 @@ Weierstrass model over a concrete base
     ambient_space(t),
   )
 
-  # Copy attributes and return model
-  model_attributes = t.__attrs
-  for (key, value) in model_attributes
-    set_attribute!(model, key, value)
-  end
+  # Preserve model-independent provenance, but do not transfer computed geometry caches.
+  model.defining_classes = copy(defining_classes(t))
+  _copy_model_metadata!(model, t)
+  set_attribute!(model, :partially_resolved, is_partially_resolved(t))
   return model
 end
 

--- a/experimental/FTheoryTools/src/TateModels/constructors.jl
+++ b/experimental/FTheoryTools/src/TateModels/constructors.jl
@@ -306,35 +306,9 @@ end
 
 # Detailed printing
 function Base.show(io::IO, ::MIME"text/plain", t::GlobalTateModel)
-  io = pretty(io)
-  properties_string = String[]
-  if is_partially_resolved(t)
-    push!(properties_string, "Partially resolved global Tate model over a")
-  else
-    push!(properties_string, "Global Tate model over a")
-  end
-  if is_base_space_fully_specified(t)
-    push!(properties_string, "concrete base")
-  else
-    push!(properties_string, "not fully specified base")
-  end
-  if has_attribute(t, :model_description)
-    push!(properties_string, "-- " * model_description(t))
-    if has_attribute(t, :model_parameters)
-      push!(
-        properties_string,
-        "with parameter values (" *
-        join(["$key = $(string(val))" for (key, val) in model_parameters(t)], ", ") * ")",
-      )
-    end
-  end
-  if has_attribute(t, :arxiv_id)
-    push!(properties_string, "based on arXiv paper " * arxiv_id(t))
-  end
-  if has_attribute(t, :arxiv_model_equation_number)
-    push!(properties_string, "Eq. (" * arxiv_model_equation_number(t) * ")")
-  end
-  join(io, properties_string, " ")
+  return _show_model_over_base(
+    io, t, "Global Tate model"; partially_resolved_model_name="global Tate model"
+  )
 end
 
 # Terse and one line printing

--- a/experimental/FTheoryTools/src/TunedModels/constructors.jl
+++ b/experimental/FTheoryTools/src/TunedModels/constructors.jl
@@ -89,85 +89,8 @@ function tune(
   # Consistency checks
   @req base_space(w) isa NormalToricVariety "Currently, tuning is only supported for models over concrete toric bases"
   isempty(input_sections) && return w
-  secs_names = tunable_sections(w)
-  tuned_secs_names = collect(keys(input_sections))
-  @req all(in(secs_names), tuned_secs_names) "Provided section names are not among the tunable sections of the model"
 
-  # 0. Prepare for computation by setting up some information
-  explicit_secs = deepcopy(explicit_model_sections(w))
-  def_secs_param = deepcopy(model_section_parametrization(w))
-  weierstrass_sections = ["f", "g"]
-
-  # 1. Tune model sections different from Weierstrass sections
-  for x in setdiff(tuned_secs_names, weierstrass_sections)
-    @req parent(input_sections[x]) == parent(explicit_model_sections(w)[x]) "Parent mismatch between given and existing model section"
-    if is_zero(input_sections[x]) == false
-      @req degree(input_sections[x]) == divisor_class(classes_of_model_sections(w)[x]) "Degree mismatch between given and existing model section"
-    end
-    explicit_secs[x] = input_sections[x]
-  end
-
-  # 2. Use model sections to reevaluate the Weierstrass sections via their known parametrization
-  parametrization_keys = collect(keys(def_secs_param))
-  if !isempty(parametrization_keys) && !isempty(secs_names)
-    R = parent(def_secs_param[parametrization_keys[1]])
-    S = parent(explicit_secs[secs_names[1]])
-    vars = [string(k) for k in symbols(R)]
-    images = [
-      if k in secs_names
-        explicit_secs[k]
-      elseif k == "Kbar"
-        eval_poly("0", S)
-      else
-        eval_poly(k, S)
-      end for k in vars
-    ]
-    map = hom(R, S, images)
-    for section in weierstrass_sections
-      haskey(def_secs_param, section) &&
-        (explicit_secs[section] = map(eval_poly(string(def_secs_param[section]), R)))
-    end
-  end
-
-  # 3. Does the user want to set some Weierstrass sections? If so, overwrite existing choice with desired value.
-  for sec in weierstrass_sections
-    if haskey(input_sections, sec)
-      @req parent(input_sections[sec]) == parent(explicit_model_sections(w)[sec]) "Parent mismatch between given and existing Weierstrass section"
-      if is_zero(input_sections[sec]) == false
-        @req degree(input_sections[sec]) == divisor_class(classes_of_model_sections(w)[sec]) "Degree mismatch between given and existing Weierstrass section"
-      end
-      explicit_secs[sec] = input_sections[sec]
-      delete!(def_secs_param, sec)
-    end
-  end
-
-  # 4. There could be unused model sections...
-  if !isempty(parametrization_keys)
-    polys = [
-      eval_poly(string(def_secs_param[section]), R) for
-      section in weierstrass_sections if haskey(def_secs_param, section)
-    ]
-    all_appearing_monomials = vcat([collect(monomials(p)) for p in polys]...)
-    all_appearing_exponents = [collect(exponents(m))[1] for m in all_appearing_monomials]
-    potentially_redundant_sections = gens(R)
-    for k in 1:length(potentially_redundant_sections)
-      string(potentially_redundant_sections[k]) in weierstrass_sections && continue
-      is_used = any(
-        all_appearing_exponents[l][k] != 0 for l in 1:length(all_appearing_exponents)
-      )
-      is_used || delete!(explicit_secs, string(potentially_redundant_sections[k]))
-    end
-  end
-
-  # 5. After removing some sections, we must go over the parametrization again and adjust the ring in which the parametrization is given.
-  if !isempty(def_secs_param)
-    naive_vars = string.(gens(parent(first(values(def_secs_param)))))
-    filtered_vars = filter(x -> haskey(explicit_secs, x), naive_vars)
-    desired_ring, _ = polynomial_ring(QQ, filtered_vars; cached=false)
-    for (key, value) in def_secs_param
-      def_secs_param[key] = eval_poly(string(value), desired_ring)
-    end
-  end
+  explicit_secs, def_secs_param = _tuned_model_sections(w, input_sections, ["f", "g"])
 
   # 6. Build the new model
   resulting_model = weierstrass_model(
@@ -281,85 +204,10 @@ function tune(
   # Consistency checks
   @req base_space(t) isa NormalToricVariety "Currently, tuning is only supported for models over concrete toric bases"
   isempty(input_sections) && return t
-  secs_names = tunable_sections(t)
-  tuned_secs_names = collect(keys(input_sections))
-  @req all(in(secs_names), tuned_secs_names) "Provided section names are not among the tunable sections of the model"
 
-  # 0. Prepare for computation by setting up some information
-  explicit_secs = deepcopy(explicit_model_sections(t))
-  def_secs_param = deepcopy(model_section_parametrization(t))
-  tate_sections = ["a1", "a2", "a3", "a4", "a6"]
-
-  # 1. Tune model sections different from Tate sections
-  for x in setdiff(tuned_secs_names, tate_sections)
-    @req parent(input_sections[x]) == parent(explicit_model_sections(t)[x]) "Parent mismatch between given and existing model section"
-    if is_zero(input_sections[x]) == false
-      @req degree(input_sections[x]) == divisor_class(classes_of_model_sections(t)[x]) "Degree mismatch between given and existing model section"
-    end
-    explicit_secs[x] = input_sections[x]
-  end
-
-  # 2. Use model sections to reevaluate the Tate sections via their known parametrization
-  parametrization_keys = collect(keys(def_secs_param))
-  if !isempty(parametrization_keys) && !isempty(secs_names)
-    R = parent(def_secs_param[parametrization_keys[1]])
-    S = parent(explicit_secs[secs_names[1]])
-    vars = [string(k) for k in symbols(R)]
-    images = [
-      if k in secs_names
-        explicit_secs[k]
-      elseif k == "Kbar"
-        eval_poly("0", S)
-      else
-        eval_poly(k, S)
-      end for k in vars
-    ]
-    map = hom(R, S, images)
-    for section in tate_sections
-      haskey(def_secs_param, section) &&
-        (explicit_secs[section] = map(eval_poly(string(def_secs_param[section]), R)))
-    end
-  end
-
-  # 3. Does the user want to set some Tate sections? If so, overwrite existing choice with desired value.
-  for sec in tate_sections
-    if haskey(input_sections, sec)
-      @req parent(input_sections[sec]) == parent(explicit_model_sections(t)[sec]) "Parent mismatch between given and existing Tate section"
-      if is_zero(input_sections[sec]) == false
-        @req degree(input_sections[sec]) == divisor_class(classes_of_model_sections(t)[sec]) "Degree mismatch between given and existing Tate section"
-      end
-      explicit_secs[sec] = input_sections[sec]
-      delete!(def_secs_param, sec)
-    end
-  end
-
-  # 4. There could be unused model sections...
-  if !isempty(parametrization_keys)
-    polys = [
-      eval_poly(string(def_secs_param[section]), R) for
-      section in tate_sections if haskey(def_secs_param, section)
-    ]
-    all_appearing_monomials = vcat([collect(monomials(p)) for p in polys]...)
-    all_appearing_exponents = [collect(exponents(m))[1] for m in all_appearing_monomials]
-    potentially_redundant_sections = gens(R)
-    for k in 1:length(potentially_redundant_sections)
-      string(potentially_redundant_sections[k]) in tate_sections && continue
-      is_used = any(
-        all_appearing_exponents[l][k] != 0 for l in 1:length(all_appearing_exponents)
-      )
-      is_used || delete!(explicit_secs, string(potentially_redundant_sections[k]))
-    end
-  end
-
-  # 5. After removing some sections, we must go over the parametrization again and adjust the ring in which the parametrization is given.
-  if !isempty(def_secs_param)
-    naive_vars = string.(gens(parent(first(values(def_secs_param)))))
-    filtered_vars = filter(x -> haskey(explicit_secs, x), naive_vars)
-    desired_ring, _ = polynomial_ring(QQ, filtered_vars; cached=false)
-    for (key, value) in def_secs_param
-      def_secs_param[key] = eval_poly(string(value), desired_ring)
-    end
-  end
+  explicit_secs, def_secs_param = _tuned_model_sections(
+    t, input_sections, ["a1", "a2", "a3", "a4", "a6"]
+  )
 
   # 6. Build the new model
   resulting_model = global_tate_model(
@@ -474,7 +322,7 @@ function tune(
   end
 
   # 1. Tune model sections
-  explicit_secs = deepcopy(explicit_model_sections(h))
+  explicit_secs = copy(explicit_model_sections(h))
   for x in tuned_secs_names
     section_parent = parent(input_sections[x])
     @req section_parent == parent(explicit_model_sections(h)[x]) "Parent mismatch between given and existing model section"
@@ -523,6 +371,94 @@ function tune(
 
   # 5. Return the model
   return model
+end
+
+function _tuned_model_sections(
+  m::Union{WeierstrassModel,GlobalTateModel},
+  input_sections::Dict{String,<:Any},
+  defining_sections::Vector{String},
+)
+  section_names = tunable_sections(m)
+  tuned_section_names = collect(keys(input_sections))
+  @req all(in(section_names), tuned_section_names) "Provided section names are not among the tunable sections of the model"
+
+  source_sections = explicit_model_sections(m)
+  section_classes = classes_of_model_sections(m)
+  explicit_sections = copy(source_sections)
+  parametrizations = copy(model_section_parametrization(m))
+
+  for name in setdiff(tuned_section_names, defining_sections)
+    section = input_sections[name]
+    @req parent(section) == parent(source_sections[name]) "Parent mismatch between given and existing model section"
+    if !is_zero(section)
+      @req degree(section) == divisor_class(section_classes[name]) "Degree mismatch between given and existing model section"
+    end
+    explicit_sections[name] = section
+  end
+
+  if !isempty(parametrizations) && !isempty(section_names)
+    parametrization_ring = parent(first(values(parametrizations)))
+    section_ring = parent(explicit_sections[first(section_names)])
+    variables = string.(symbols(parametrization_ring))
+    images = [
+      if name in section_names
+        explicit_sections[name]
+      elseif name == "Kbar"
+        zero(section_ring)
+      else
+        eval_poly(name, section_ring)
+      end for name in variables
+    ]
+    evaluation_map = hom(parametrization_ring, section_ring, images)
+    for name in defining_sections
+      if haskey(parametrizations, name)
+        explicit_sections[name] = evaluation_map(parametrizations[name])
+      end
+    end
+  end
+
+  for name in defining_sections
+    if haskey(input_sections, name)
+      section = input_sections[name]
+      @req parent(section) == parent(source_sections[name]) "Parent mismatch between given and existing defining section"
+      if !is_zero(section)
+        @req degree(section) == divisor_class(section_classes[name]) "Degree mismatch between given and existing defining section"
+      end
+      explicit_sections[name] = section
+      delete!(parametrizations, name)
+    end
+  end
+
+  if !isempty(parametrizations)
+    parametrization_ring = parent(first(values(parametrizations)))
+    relevant_polynomials = [
+      parametrizations[name] for name in defining_sections if haskey(parametrizations, name)
+    ]
+    if !isempty(relevant_polynomials)
+      appearing_monomials = collect(
+        Iterators.flatten(monomials(p) for p in relevant_polynomials)
+      )
+      appearing_exponents = [first(exponents(monomial)) for monomial in appearing_monomials]
+      for (index, generator) in enumerate(gens(parametrization_ring))
+        name = string(generator)
+        name in defining_sections && continue
+        is_used = any(exponent[index] != 0 for exponent in appearing_exponents)
+        is_used || delete!(explicit_sections, name)
+      end
+    end
+  end
+
+  if !isempty(parametrizations)
+    parametrization_ring = parent(first(values(parametrizations)))
+    variables = string.(gens(parametrization_ring))
+    retained_variables = filter(name -> haskey(explicit_sections, name), variables)
+    desired_ring, _ = polynomial_ring(QQ, retained_variables; cached=false)
+    for (name, value) in parametrizations
+      parametrizations[name] = eval_poly(string(value), desired_ring)
+    end
+  end
+
+  return explicit_sections, parametrizations
 end
 
 # FIXME: The below tune function is not consistent with our other "tune" functions (it does not correspond mathematically to a tuning)

--- a/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
@@ -276,35 +276,7 @@ end
 
 # Detailed printing
 function Base.show(io::IO, ::MIME"text/plain", w::WeierstrassModel)
-  io = pretty(io)
-  properties_string = String[]
-  if is_partially_resolved(w)
-    push!(properties_string, "Partially resolved Weierstrass model over a")
-  else
-    push!(properties_string, "Weierstrass model over a")
-  end
-  if is_base_space_fully_specified(w)
-    push!(properties_string, "concrete base")
-  else
-    push!(properties_string, "not fully specified base")
-  end
-  if has_attribute(w, :model_description)
-    push!(properties_string, "-- " * model_description(w))
-    if has_attribute(w, :model_parameters)
-      push!(
-        properties_string,
-        "with parameter values (" *
-        join(["$key = $(string(val))" for (key, val) in model_parameters(t)], ", ") * ")",
-      )
-    end
-  end
-  if has_attribute(w, :arxiv_id)
-    push!(properties_string, "based on arXiv paper " * arxiv_id(w))
-  end
-  if has_attribute(w, :arxiv_model_equation_number)
-    push!(properties_string, "Eq. (" * arxiv_model_equation_number(w) * ")")
-  end
-  join(io, properties_string, " ")
+  return _show_model_over_base(io, w, "Weierstrass model")
 end
 
 # Terse and one line printing

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -193,6 +193,14 @@ function _kodaira_type(
       monodromy_poly, ["Non-split I^*_0", "Semi-split I^*_0", "Split I^*_0"]
     )
   else
+    is_multiplicative = f_ord == 0 && g_ord == 0
+    is_type_iv = d_ord == 4 && g_ord == 2 && f_ord >= 2
+    is_type_istar = f_ord == 2 && g_ord == 3 && d_ord >= 7
+    is_type_ivstar = d_ord == 8 && g_ord == 4 && f_ord >= 3
+    if !(is_multiplicative || is_type_iv || is_type_istar || is_type_ivstar)
+      return "Unrecognized"
+    end
+
     # If the base is arbitrary, we tune the model over projective space of the
     # appropriate dimension. This allows us to use the same algorithm for all
     # cases. The choice of projective space here is an attempt to minimize the
@@ -236,7 +244,7 @@ function _kodaira_type(
 
     f = weierstrass_section_f(w)
     g = weierstrass_section_g(w)
-    d = discriminant(w)
+    d = is_type_istar ? discriminant(w) : nothing
 
     # For now, we explicitly require that the gauge ideal is principal
     @req (ngens(id) == 1) "Gauge ideal is not principal"
@@ -246,22 +254,31 @@ function _kodaira_type(
     # could give an incorrect result (radical or not), so we actually try this
     # five times and see if we get agreement among all of the results
     num_gens = ngens(parent(f))
+    gauge = forget_decoration(gens(id)[1])
+    needs_f = is_multiplicative || is_type_istar
+    undecorated_f = needs_f ? forget_decoration(f) : nothing
+    undecorated_g = forget_decoration(g)
+    undecorated_d = is_type_istar ? forget_decoration(d) : nothing
     gauge2s, f2s, g2s, d2s = [], [], [], []
     for _ in 1:5
       coord_inds = randperm(rng, num_gens)[1:(end - 2)]
       rand_ints = rand(rng, -100:100, num_gens - 2)
 
-      push!(gauge2s, evaluate(forget_decoration(gens(id)[1]), coord_inds, rand_ints))
-      push!(f2s, evaluate(forget_decoration(f), coord_inds, rand_ints))
-      push!(g2s, evaluate(forget_decoration(g), coord_inds, rand_ints))
-      push!(d2s, evaluate(forget_decoration(d), coord_inds, rand_ints))
+      push!(gauge2s, evaluate(gauge, coord_inds, rand_ints))
+      if needs_f
+        push!(f2s, evaluate(undecorated_f, coord_inds, rand_ints))
+      end
+      push!(g2s, evaluate(undecorated_g, coord_inds, rand_ints))
+      if is_type_istar
+        push!(d2s, evaluate(undecorated_d, coord_inds, rand_ints))
+      end
     end
 
     # Check monodromy conditions for remaining cases.
     # Default to split when there is disagreement among the five attempts,
     # because this approach seems to skew toward accidentally identifying
     # a singularity as non-split
-    if f_ord == 0 && g_ord == 0
+    if is_multiplicative
       quotients = []
       for i in eachindex(gauge2s)
         push!(
@@ -275,7 +292,7 @@ function _kodaira_type(
       else
         "Split I_$d_ord"
       end
-    elseif d_ord == 4 && g_ord == 2 && f_ord >= 2
+    elseif is_type_iv
       quotients = []
       for i in eachindex(gauge2s)
         push!(
@@ -288,7 +305,7 @@ function _kodaira_type(
       else
         "Split IV"
       end
-    elseif f_ord == 2 && g_ord == 3 && d_ord >= 7
+    elseif is_type_istar
       quotients = []
       if d_ord % 2 == 0
         for i in eachindex(gauge2s)
@@ -317,7 +334,7 @@ function _kodaira_type(
       else
         "Split I^*_$(d_ord - 6)"
       end
-    elseif d_ord == 8 && g_ord == 4 && f_ord >= 3
+    else
       quotients = []
       for i in eachindex(gauge2s)
         push!(
@@ -330,8 +347,6 @@ function _kodaira_type(
       else
         "Split IV^*"
       end
-    else
-      kod_type = "Unrecognized"
     end
   end
 

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -329,6 +329,82 @@ function _kodaira_type(
   return kod_type
 end
 
+const _MODEL_METADATA_ATTRIBUTES = (
+  :associated_literature_models,
+  :arxiv_doi,
+  :arxiv_id,
+  :arxiv_link,
+  :arxiv_model_equation_number,
+  :arxiv_model_page,
+  :arxiv_model_section,
+  :arxiv_version,
+  :birational_literature_models,
+  :journal_doi,
+  :journal_link,
+  :journal_model_equation_number,
+  :journal_model_page,
+  :journal_model_section,
+  :journal_name,
+  :journal_pages,
+  :journal_report_numbers,
+  :journal_volume,
+  :journal_year,
+  :literature_identifier,
+  :model_description,
+  :model_parameters,
+  :paper_authors,
+  :paper_buzzwords,
+  :paper_description,
+  :paper_title,
+)
+
+function _copy_model_metadata!(target::AbstractFTheoryModel, source::AbstractFTheoryModel)
+  for name in _MODEL_METADATA_ATTRIBUTES
+    if has_attribute(source, name)
+      set_attribute!(target, name, deepcopy(get_attribute(source, name)))
+    end
+  end
+  return target
+end
+
+function _show_model_over_base(
+  io::IO,
+  model::AbstractFTheoryModel,
+  model_name::String;
+  show_literature_data::Bool=true,
+  partially_resolved_model_name::String=model_name,
+)
+  io = pretty(io)
+  properties = String[]
+  if is_partially_resolved(model)
+    push!(properties, "Partially resolved " * partially_resolved_model_name * " over a")
+  else
+    push!(properties, model_name * " over a")
+  end
+  if is_base_space_fully_specified(model)
+    push!(properties, "concrete base")
+  else
+    push!(properties, "not fully specified base")
+  end
+  if show_literature_data && has_attribute(model, :model_description)
+    push!(properties, "-- " * model_description(model))
+    if has_attribute(model, :model_parameters)
+      parameters = sort!(collect(model_parameters(model)); by=first)
+      parameter_text = join(
+        (string(key, " = ", value) for (key, value) in parameters), ", "
+      )
+      push!(properties, "with parameter values (" * parameter_text * ")")
+    end
+  end
+  if show_literature_data && has_attribute(model, :arxiv_id)
+    push!(properties, "based on arXiv paper " * arxiv_id(model))
+  end
+  if show_literature_data && has_attribute(model, :arxiv_model_equation_number)
+    push!(properties, "Eq. (" * arxiv_model_equation_number(model) * ")")
+  end
+  return join(io, properties, " ")
+end
+
 ###########################################################################
 # 5: Constructing a generic sample for models over not-fully specified spaces
 ###########################################################################

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -76,6 +76,15 @@ end
 # 2: Construct the Weierstrass polynomial
 ################################################################
 
+function _weierstrass_sections_from_tate(a1, a2, a3, a4, a6)
+  b2 = 4 * a2 + a1^2
+  b4 = 2 * a4 + a1 * a3
+  b6 = 4 * a6 + a3^2
+  f = -1//48 * (b2^2 - 24 * b4)
+  g = 1//864 * (b2^3 - 36 * b2 * b4 + 216 * b6)
+  return f, g
+end
+
 function _weierstrass_sections(
   base::NormalToricVariety; rng::AbstractRNG=Random.default_rng()
 )

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -391,6 +391,15 @@ function _copy_model_metadata!(target::AbstractFTheoryModel, source::AbstractFTh
   return target
 end
 
+function _sorted_tuple(a::Int, b::Int, c::Int, d::Int)
+  a, b = minmax(a, b)
+  c, d = minmax(c, d)
+  a, c = minmax(a, c)
+  b, d = minmax(b, d)
+  b, c = minmax(b, c)
+  return (a, b, c, d)
+end
+
 function _show_model_over_base(
   io::IO,
   model::AbstractFTheoryModel,

--- a/experimental/FTheoryTools/test/blowup.jl
+++ b/experimental/FTheoryTools/test/blowup.jl
@@ -31,8 +31,15 @@ add_resolution!(
   ["e1", "e4", "e2", "e3", "s"],
 )
 explicit_model_sections(t)["w"] = w
+
+# Ensure resolving a model does not mutate its stored resolution metadata.
+set_attribute!(t, :exceptional_divisor_indices, Int[])
+original_resolutions = deepcopy(resolutions(t))
+original_exceptional_indices = copy(exceptional_divisor_indices(t))
 t_res = resolve(t, 1)
 
 @testset "Custom blowup of a global Tate model" begin
   @test typeof(ambient_space(t_res)) == CoveredScheme{QQField}
+  @test resolutions(t) == original_resolutions
+  @test exceptional_divisor_indices(t) == original_exceptional_indices
 end

--- a/experimental/FTheoryTools/test/literature_models.jl
+++ b/experimental/FTheoryTools/test/literature_models.jl
@@ -5,6 +5,25 @@
 using Random
 our_rng = Random.Xoshiro(1234)
 
+# Ensure construction does not mutate caller-owned literature metadata.
+@testset "Literature model dictionary input" begin
+  model_dict = Oscar.JSON.parse(
+    raw"""
+    {
+      "model_parameters": ["k"],
+      "model_data": {"value": "k"},
+      "model_descriptors": {"description": "#k"},
+      "arxiv_data": {"id": "test"}
+    }
+    """,
+  )
+  original_model_dict = deepcopy(model_dict)
+  @test_throws ArgumentError literature_model(
+    model_dict; model_parameters=Dict("k" => 2)
+  )
+  @test isequal(model_dict, original_model_dict)
+end
+
 B3 = projective_space(NormalToricVariety, 3)
 Kbar = anticanonical_divisor_class(B3)
 w = torusinvariant_prime_divisors(B3)[1]

--- a/experimental/FTheoryTools/test/literature_models.jl
+++ b/experimental/FTheoryTools/test/literature_models.jl
@@ -272,6 +272,41 @@ end
   @test length(weighted_resolution_zero_sections(t3)) == 1
 end
 
+# Check specialization of an abstract Tate model and validation of its section data.
+tate_specialization_data = Dict{String,Any}("base" => B3)
+for name in ("w", "a21", "a32", "a43")
+  tate_specialization_data[name] = explicit_model_sections(t1)[name]
+end
+specialized_t3 = put_over_concrete_base(
+  t3, tate_specialization_data; completeness_check=false, rng=Random.Xoshiro(1234)
+)
+
+@testset "Putting a literature Tate model over a concrete base" begin
+  @test is_base_space_fully_specified(specialized_t3)
+  @test arxiv_id(specialized_t3) == arxiv_id(t3)
+  @test tate_section_a2(specialized_t3) == tate_section_a2(t1)
+  @test tate_section_a3(specialized_t3) == tate_section_a3(t1)
+  @test tate_section_a4(specialized_t3) == tate_section_a4(t1)
+
+  missing_section_data = copy(tate_specialization_data)
+  delete!(missing_section_data, "a43")
+  @test_throws ArgumentError put_over_concrete_base(
+    t3, missing_section_data; completeness_check=false
+  )
+
+  wrong_parent_data = copy(tate_specialization_data)
+  wrong_parent_data["a21"] = explicit_model_sections(t3)["a21"]
+  @test_throws ArgumentError put_over_concrete_base(
+    t3, wrong_parent_data; completeness_check=false
+  )
+
+  wrong_degree_data = copy(tate_specialization_data)
+  wrong_degree_data["a21"] = wrong_degree_data["w"]
+  @test_throws ArgumentError put_over_concrete_base(
+    t3, wrong_degree_data; completeness_check=false
+  )
+end
+
 @testset "Test error messages for literature Tate model over arbitrary base" begin
   @test_throws ArgumentError associated_literature_models(t3)
   @test_throws ArgumentError journal_report_numbers(t3)
@@ -423,6 +458,22 @@ end
   @test paper_description(w2) == "General construction of U(1) model"
   @test paper_title(w2) ==
     "F-Theory and the Mordell-Weil Group of Elliptically-Fibered Calabi-Yau Threefolds"
+end
+
+# Check specialization of the corresponding abstract Weierstrass model.
+weierstrass_specialization_data = Dict{String,Any}("base" => base_space(w1))
+for name in tunable_sections(w2)
+  weierstrass_specialization_data[name] = explicit_model_sections(w1)[name]
+end
+specialized_w2 = put_over_concrete_base(
+  w2, weierstrass_specialization_data; completeness_check=false, rng=Random.Xoshiro(1234)
+)
+
+@testset "Putting a literature Weierstrass model over a concrete base" begin
+  @test is_base_space_fully_specified(specialized_w2)
+  @test arxiv_id(specialized_w2) == arxiv_id(w2)
+  @test weierstrass_section_f(specialized_w2) == weierstrass_section_f(w1)
+  @test weierstrass_section_g(specialized_w2) == weierstrass_section_g(w1)
 end
 
 @testset "Test error messages for literature Weierstrass model over arbitrary base" begin

--- a/experimental/FTheoryTools/test/tate_models.jl
+++ b/experimental/FTheoryTools/test/tate_models.jl
@@ -18,6 +18,23 @@ section_a6 = generic_section(anticanonical_bundle(P3)^6; rng=our_rng)
 # Global Tate model over P3
 tate_P3 = global_tate_model(P3; completeness_check=false, rng=our_rng)
 
+# Check that conversion preserves source data without transferring model-dependent caches.
+source_hypersurface = calabi_yau_hypersurface(tate_P3)
+converted_model = weierstrass_model(tate_P3)
+converted_model_had_no_hypersurface =
+  !has_attribute(converted_model, :calabi_yau_hypersurface)
+converted_hypersurface = calabi_yau_hypersurface(converted_model)
+
+@testset "Tate-to-Weierstrass conversion cache ownership" begin
+  @test converted_model_had_no_hypersurface
+  @test converted_hypersurface !== source_hypersurface
+  @test defining_ideal(converted_hypersurface) ==
+    ideal([weierstrass_polynomial(converted_model)])
+  @test defining_ideal(converted_hypersurface) != ideal([tate_polynomial(tate_P3)])
+  @test defining_classes(converted_model) == defining_classes(tate_P3)
+  @test defining_classes(converted_model) !== defining_classes(tate_P3)
+end
+
 @testset "Attributes of global Tate models over concrete base space" begin
   @test parent(tate_section_a1(tate_P3)) == coordinate_ring(base_space(tate_P3))
   @test parent(tate_section_a2(tate_P3)) == coordinate_ring(base_space(tate_P3))

--- a/experimental/FTheoryTools/test/tuning.jl
+++ b/experimental/FTheoryTools/test/tuning.jl
@@ -35,6 +35,32 @@ w2 = tune(w, my_choice; completeness_check=false)
   # @test fiber_ambient_space(tuned_w3) == fiber_ambient_space(w3)
 end
 
+# Check that tuning a parametrized model recomputes its defining sections without changing its source.
+parametrized_base = projective_space(NormalToricVariety, 2)
+parametrized_divisor = torusinvariant_prime_divisors(parametrized_base)[1]
+parametrized_w = literature_model(;
+  arxiv_id="1208.2695",
+  equation="B.19",
+  base_space=parametrized_base,
+  defining_classes=Dict("b" => parametrized_divisor),
+  completeness_check=false,
+  rng=Random.Xoshiro(1234),
+)
+source_sections = copy(explicit_model_sections(parametrized_w))
+source_parametrization = copy(model_section_parametrization(parametrized_w))
+x1, x2, _ = gens(coordinate_ring(base_space(parametrized_w)))
+parametrized_w2 = tune(
+  parametrized_w, Dict("b" => x2, "c2" => x1^6); completeness_check=false
+)
+
+@testset "Tuning of a parametrized Weierstrass model" begin
+  @test explicit_model_sections(parametrized_w2)["c2"] == x1^6
+  @test weierstrass_section_f(parametrized_w2) != weierstrass_section_f(parametrized_w)
+  @test weierstrass_section_g(parametrized_w2) != weierstrass_section_g(parametrized_w)
+  @test explicit_model_sections(parametrized_w) == source_sections
+  @test model_section_parametrization(parametrized_w) == source_parametrization
+end
+
 other_Kbar = anticanonical_bundle(projective_space(NormalToricVariety, 3))
 
 @testset "Error messages from tuning Weierstrass models over concrete toric base" begin

--- a/experimental/FTheoryTools/test/weierstrass_models.jl
+++ b/experimental/FTheoryTools/test/weierstrass_models.jl
@@ -33,6 +33,15 @@ weierstrass_P3 = weierstrass_model(P3; completeness_check=false, rng=our_rng)
   @test is_partially_resolved(weierstrass_P3) == false
 end
 
+# Check detailed display for a model carrying parameter metadata.
+set_attribute!(weierstrass_P3, :model_description, "Parameterized model")
+set_attribute!(weierstrass_P3, :model_parameters, Dict("z" => 2, "a" => 1))
+
+@testset "Detailed display of a parameterized Weierstrass model" begin
+  displayed_model = sprint(show, MIME("text/plain"), weierstrass_P3)
+  @test occursin("Parameterized model with parameter values (a = 1, z = 2)", displayed_model)
+end
+
 @testset "Error messages in Weierstrass models over concrete base spaces" begin
   @test_throws ArgumentError weierstrass_model(
     P3, section_f, section_g; completeness_check=false

--- a/experimental/FTheoryTools/test/weierstrass_models.jl
+++ b/experimental/FTheoryTools/test/weierstrass_models.jl
@@ -39,7 +39,9 @@ set_attribute!(weierstrass_P3, :model_parameters, Dict("z" => 2, "a" => 1))
 
 @testset "Detailed display of a parameterized Weierstrass model" begin
   displayed_model = sprint(show, MIME("text/plain"), weierstrass_P3)
-  @test occursin("Parameterized model with parameter values (a = 1, z = 2)", displayed_model)
+  @test occursin(
+    "Parameterized model with parameter values (a = 1, z = 2)", displayed_model
+  )
 end
 
 @testset "Error messages in Weierstrass models over concrete base spaces" begin

--- a/experimental/FTheoryTools/test/weierstrass_models.jl
+++ b/experimental/FTheoryTools/test/weierstrass_models.jl
@@ -137,6 +137,8 @@ end
     completeness_check=false,
     rng=Random.Xoshiro(1234),
   )
+  @test isempty(model_section_parametrization(weierstrass_generic))
+  @test is_base_space_fully_specified(specialized_model)
   @test base_space(specialized_model) === P3
   @test parent(weierstrass_section_f(specialized_model)) === coordinate_ring(P3)
   @test parent(weierstrass_section_g(specialized_model)) === coordinate_ring(P3)


### PR DESCRIPTION
This PR simplifies and optimizes several central FTheoryTools code paths while fixing cases where mutable metadata or model-dependent caches could accidentally be shared between models.

  The main changes are:
  - avoid constructing an unnecessary dummy base for abstract literature models;
  - defer expensive literature-model attribute setup until the corresponding data is present;
  - centralize model metadata copying and detailed display;
  - simplify specialization of abstract Tate and Weierstrass models over concrete bases;
  - validate specialized sections directly through their parent rings and divisor classes;
  - share tuning logic between Tate and Weierstrass models and avoid unnecessary deep copies;
  - prevent Tate-to-Weierstrass conversion from transferring stale geometric caches;
  - ensure resolving a model does not mutate resolution metadata stored on the source model;
  - avoid unnecessary discriminant and polynomial computations during Kodaira classification;
  - reduce allocations and repeated work in G4-flux intersection calculations.

  Representative benchmarks:
  - concrete-base specialization: 96.7 ms / 20.40 MiB to 35.5 ms / 2.45 MiB;
  - representative singular-locus computation: 45.4 s / 7.58 GB to 15.5 s / 4.70 GB;
  - construction of 16 arbitrary-base literature models: 1.19 s to 0.51 s;
  - 20 Weierstrass tuning calls: 0.95 s to 0.56 s;
  - the advanced QSM/G4 section: approximately 12.3 s to 7.4 s.

The changes were developed with assistance from generative AI (OpenAI Codex).