### PR TITLE
document subtleties of `GAP.Globals` vs. `GAPWrap`

### DIFF
--- a/docs/src/DeveloperDocumentation/gap_integration.md
+++ b/docs/src/DeveloperDocumentation/gap_integration.md
@@ -59,6 +59,12 @@ GAP.jl cannot provide utility functions such as conversions to and from GAP.
   not inside GAP.jl is that we can extend the list without waiting for
   releases of GAP.jl.)
 
+  Note that `Oscar.GAPWrap` is intended only for *calling* the GAP function
+  in question.
+  In situations where a GAP function is used for other purposes,
+  usually as an argument in a function call,
+  one should access it via `GAP.Globals`.
+
 - In GAP code, global Julia variables can be accessed as members of
   `Julia`, relative to its `Main` module.
   For example, one can call `Julia.sqrt` and `Julia.typeof`


### PR DESCRIPTION
This arose from a discussion on slack.