### PR TITLE
Fix degree of rank-one toric line bundles

### DIFF
--- a/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles/attributes.jl
+++ b/src/AlgebraicGeometry/ToricVarieties/ToricLineBundles/attributes.jl
@@ -100,7 +100,10 @@ true
 @doc raw"""
     degree(l::ToricLineBundle)
 
-Return the degree of the toric line bundle `l`.
+Return the degree of the toric line bundle `l` when the Picard group of the
+underlying toric variety is free of rank one. The degree is the coefficient of
+the Picard class with respect to the chosen generator of the Picard group. An
+error is raised otherwise.
 
 # Examples
 ```jldoctest
@@ -114,7 +117,13 @@ julia> degree(l)
 2
 ```
 """
-@attr ZZRingElem degree(l::ToricLineBundle) = sum(coefficients(toric_divisor(l)))
+@attr ZZRingElem function degree(l::ToricLineBundle)
+  class = picard_class(l)
+  picard_group = parent(class)
+  has_degree = is_free(picard_group) && torsion_free_rank(picard_group) == 1
+  @req has_degree "The degree is only defined for toric line bundles whose Picard group is free of rank one"
+  return _coeff(class)[1]
+end
 
 #############################
 # 2. Basis of global sections

--- a/test/AlgebraicGeometry/ToricVarieties/line_bundles.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/line_bundles.jl
@@ -1,3 +1,4 @@
+# Test defining data, arithmetic, and representative-independent degree of toric line bundles.
 @testset "Line bundles" begin
   dP1 = del_pezzo_surface(NormalToricVariety, 1)
   dP3 = del_pezzo_surface(NormalToricVariety, 3)
@@ -7,6 +8,8 @@
   l3 = anticanonical_bundle(dP3)
   l4 = toric_line_bundle(dP3, trivial_divisor(dP3))
   l5 = toric_line_bundle(dP1, [ZZRingElem(1), ZZRingElem(2)])
+  P2 = projective_space(NormalToricVariety, 2)
+  l6 = toric_line_bundle(P2, [2])
 
   @testset "Should fail due to bad arguments (toric line bundles)" begin
     @test_throws ArgumentError l * l5
@@ -20,11 +23,21 @@
   end
 
   @testset "Basic attributes" begin
-    @test degree(l) == -6
-    @test degree(l^(-1)) == 6
-    @test degree(l * l) == -12
+    @test_throws ArgumentError degree(l)
+    @test degree(l6) == 2
+    @test degree(l6^(-1)) == -2
+    @test degree(l6 * l6) == 4
     @test picard_class(l).coeff == AbstractAlgebra.matrix(ZZ, [1 2 3 4])
     @test dim(toric_variety(l)) == 2
+  end
+
+  @testset "Degree is independent of the divisor representative" begin
+    WPS = weighted_projective_space(NormalToricVariety, [2, 3, 1])
+    principal_divisor = divisor_of_character(WPS, [1, 2])
+    principal_bundle = toric_line_bundle(principal_divisor)
+    trivial_bundle = trivial_line_bundle(WPS)
+    @test principal_bundle == trivial_bundle
+    @test degree(principal_bundle) == degree(trivial_bundle) == 0
   end
 
   @testset "Arithmetic" begin

--- a/test/AlgebraicGeometry/ToricVarieties/total_space.jl
+++ b/test/AlgebraicGeometry/ToricVarieties/total_space.jl
@@ -1,3 +1,4 @@
+# Test canonical bundles of total spaces without using a rank-dependent scalar degree.
 @testset "Total space of direct sum of line bundles on toric space" begin
   @testset "Test that some vector bundles on P1 are Calabi-Yau" begin
     P1 = projective_space(NormalToricVariety, 1)
@@ -25,7 +26,7 @@
         @test torsion_free_rank(picard_group_with_map(X)[1]) ==
           torsion_free_rank(picard_group_with_map(S)[1])
         @test dim(X) == 3
-        @test degree(canonical_bundle(X)) == 0
+        @test is_trivial(canonical_bundle(X))
       end
     end
 
@@ -38,7 +39,7 @@
         @test torsion_free_rank(picard_group_with_map(X)[1]) ==
           torsion_free_rank(picard_group_with_map(S)[1])
         @test dim(X) == 3
-        @test degree(canonical_bundle(X)) == 0
+        @test is_trivial(canonical_bundle(X))
       end
     end
   end


### PR DESCRIPTION
Currently, degree may differ between identical line bundles. Here is an example:

```julia
julia> X = hirzebruch_surface(NormalToricVariety, 1)
Normal toric variety

julia> D = divisor_of_character(X, [0, 1])
Torus-invariant, non-prime divisor on a normal toric variety

julia> L1 = toric_line_bundle(D)
Toric line bundle on a normal toric variety

julia> L2 = trivial_line_bundle(X)
Toric line bundle on a normal toric variety

julia> is_principal(toric_divisor(L1))
true

julia> is_principal(toric_divisor(L2))
true

julia> L1 == L2
true

julia> coefficients(toric_divisor(L1))
4-element Vector{ZZRingElem}:
  0
  1
  1
 -1

julia> degree(L1) # the sum of the coefficients
1

julia> coefficients(toric_divisor(L2))
4-element Vector{ZZRingElem}:
 0
 0
 0
 0

julia> degree(L2) # the sum of the coefficients
0
```

This PR aims to fix this as follows:
* Compute degree from the Picard-class coordinate when the Picard group is free of rank one.
* Reject higher-rank Picard-class cases (currently).