### PR TITLE
Attempts at fixing regression for the `OFPModules`

### DIFF
--- a/src/Modules/UngradedModules/Presentation.jl
+++ b/src/Modules/UngradedModules/Presentation.jl
@@ -99,6 +99,7 @@ function _presentation_graded(SQ::SubquoModule)
   R = base_ring(SQ)
 
   F = ambient_free_module(SQ)
+  #=
   if ngens(SQ) == ngens(F) && all(repres(v) == g for (v, g) in zip(gens(SQ), gens(F)))
     rels = filter(!is_zero, relations(SQ))
     W = [degree(r) for r in rels]
@@ -114,6 +115,7 @@ function _presentation_graded(SQ::SubquoModule)
     set_attribute!(M, :show => Hecke.pres_show)
     return M
   end
+  =#
 
   # Create the free module for the presentation
   #


### PR DESCRIPTION
I do this PR to investigate #6088 and the aftermath of #6052. It seems that we need to tune the behavior of `presentation` and `_presentation_graded` further. The changes which I disable here, were introduced in #5990 in order for some surfaces code of @wdecker to work. However, in another project with Simon Felten this now led to a mysterious regression, which I do not fully understand. 

To reproduce our example, do the following:
```julia
P, (t,) = polynomial_ring(QQ, [:t])
S, (x, y, z, u, w) = graded_polynomial_ring(P, [:x, :y, :z, :u, :w])
F0 = graded_free_module(S, [2 for _ in 1:10])
e = gens(F0)
rels1 = FreeModElem{MPolyDecRingElem{QQMPolyRingElem, AbstractAlgebra.Generic.MPoly{QQMPolyRingElem}}}[u*e[1] - w*e[2] + 2*z*e[6] + t*z*e[7], u*e[4] - w*e[5] + 2*y*e[6] + t*y*e[7], y*e[1] + w*e[3] - z*e[4], y*e[2] + u*e[3] - z*e[5], z*e[3] - w*e[5] + y*e[6], u*e[1] + z*e[6] + t*y*e[8], z*e[1] + w*e[6] + t*y*e[9], z*e[2] - u*e[6] - t*u*e[7] + t*y*e[10], 2*x*e[6] + t*x*e[7] + u*e[9] - w*e[10], x*e[1] + w*e[8] - z*e[9], x*e[2] + u*e[8] - z*e[10], x*e[3] + z*e[7] - y*e[8], x*e[4] + w*e[7] - y*e[9], x*e[5] + u*e[7] - y*e[10], x*e[6] - z*e[8] + u*e[9], -y*z*e[3] + y*u*e[4] + y^2*e[6] + 1//3*x*z*e[7] + (1//3*x*y - t*z^2)*e[8] - t*w^2*e[9] - t*u^2*e[10], t*z^2*e[3] + t*w^2*e[4] + t*u^2*e[5] + 2//3*y*z*e[7] + (2*x*z - 1//3*y^2)*e[8] - x*u*e[9] - x*w*e[10], -t*w^2*e[1] - t*u^2*e[2] + t*y^2*e[3] + 1//3*z^2*e[7] + (t*x^2 - 2//3*y*z)*e[8], t*z^2*e[1] + t*y^2*e[4] - 2*t*u^2*e[6] + (1//3*z*w - t^2*u^2)*e[7] + 1//3*y*w*e[8] + (t*x^2 - y*z)*e[9], t*z^2*e[2] + t*y^2*e[5] + 2*t*w^2*e[6] + (1//3*z*u + t^2*w^2)*e[7] + 1//3*y*u*e[8] + (t*x^2 - y*z)*e[10], (-1//3*t*x*y*z - 1//3*z^3 + 1//3*z*w*u)*e[7] + (-1//3*t*x*y^2 - 1//3*y*z^2 + 1//3*y*w*u)*e[8]]
M = quo_object(F0, sub_object(F0, rels1));

G0 = graded_free_module(S, [0])
e = gens(G0)
rels2 = FreeModElem{MPolyDecRingElem{QQMPolyRingElem, AbstractAlgebra.Generic.MPoly{QQMPolyRingElem}}}[(-t*x^3 + x*y*z - t*y^3 - t*z^3 - t*w^3 - t*u^3)*e[1], (-t*x*y - z^2 + w*u)*e[1]]
N = quo_object(G0, sub_object(G0, rels2));

@time hom(M, N)
```
On the current master I did not see this code finish. With the changes in this PR it takes only about 40s. 

I tried to investigate this a bit and suspected that the denominators in the coefficients might be the cause for the difference in runtimes. But eliminating those denominators manually did not solve the problem. It seems that the seemingly redundant production of the presentation of an already presented module is leading to a significantly better choice of a generating set. And by significant I mean the difference between running for 40 seconds or running forever. That is odd to me and I wanted to put this out for other people to have a look and share their insights. @jankoboehm ? @wdecker ? 

It would be nice if we could complement this with @wdecker 's example and try to find the compromise which hopefully resolves both. 