### PR TITLE
Add graphs from group actions `graph_from_group_action([::Type{T},] G, L, act, adj) where {T <: Union{Directed, Undirected}}` and `graph_from_group_action([::Type{T},] Omega::GSet, adj) where {T <: Union{Directed, Undirected}}`

### DIFF
--- a/docs/src/Combinatorics/graphs.md
+++ b/docs/src/Combinatorics/graphs.md
@@ -39,6 +39,7 @@ dual_graph(p::Polyhedron)
 vertex_edge_graph(p::Polyhedron; modulo_lineality=false)
 graph_from_adjacency_matrix
 graph_from_edges
+graph_from_group_action
 graph_from_labeled_edges
 induced_subgraph
 ```

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -2220,12 +2220,12 @@ function _group_action_index_key(x)
     H = GapObj(x.H)
     r = GapObj(representative(x))
     if is_right(x)
-      canon = GAP.Globals.CanonicalRightCosetElement(H, r)
+      canon = GAPWrap.CanonicalRightCosetElement(H, r)
     else
       # A left coset x*H is determined by the right coset H*x^-1, and its
       # canonical representative is the inverse of the canonical
       # representative of that right coset.
-      canon = GAP.Globals.CanonicalRightCosetElement(H, GAPWrap.Inverse(r))
+      canon = GAPWrap.CanonicalRightCosetElement(H, GAPWrap.Inverse(r))
       canon = GAPWrap.Inverse(canon)
     end
     return group_element(x.G, canon)

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -2153,10 +2153,6 @@ function graph_from_edges(p::Polyhedron; modulo_lineality=false)
   return vertex_edge_graph(p; modulo_lineality=modulo_lineality)
 end
 
-################################################################################
-##  Graphs from group actions
-################################################################################
-
 @doc raw"""
     graph_from_group_action([::Type{T},] G, L, act, adj) where {T <: Union{Directed, Undirected}}
     graph_from_group_action([::Type{T},] Omega::GSet, adj) where {T <: Union{Directed, Undirected}}
@@ -2166,16 +2162,19 @@ if and only if `adj(L[i], L[j])` returns `true`.
 
 The group `G` must act on the list `L` via the action function `act`, i.e.
 `act(x, g)` is the image of `x in L` under `g in G`, and `L` must be invariant
-under this action. The elements of `L` must be pairwise distinct. The
-adjacency predicate `adj` must be invariant under the action of `G`, i.e.
-`adj(x, y) == adj(act(x, g), act(y, g))` holds for all `x, y in L` and all
-`g in G`.
+under this action. As for all group actions in Oscar and GAP, `act` must
+define a *right* action: `act(act(x, g1), g2) == act(x, g1*g2)` for all
+`x in L` and `g1, g2 in G`. (Left actions such as `(x, g) -> g*x` must be
+rewritten in the right-action form `(x, g) -> inv(g)*x`, as in the G-sets
+returned by `left_cosets`.) The elements of `L` must be pairwise distinct,
+and `adj` must be invariant under the action of `G`, i.e.
+`adj(x, y) == adj(act(x, g), act(y, g))` for all `x, y in L` and `g in G`.
 
-If a G-set `Omega` is passed instead of `G`, `L`, `act`, then the group, the
-vertex list and the action function are taken from `Omega`; the call is
-equivalent to `graph_from_group_action(T, acting_group(Omega), collect(Omega),
-action_function(Omega), adj)`. The vertices of the resulting graph are the
-elements of `collect(Omega)` in their given order.
+If a G-set `Omega` is passed instead of `G`, `L`, `act`, the group, the
+vertices and the action function are taken from `Omega`; the call is
+equivalent to `graph_from_group_action(T, acting_group(Omega),
+collect(Omega), action_function(Omega), adj)`, with the vertices in the
+order of `collect(Omega)`.
 
 If the first argument is omitted, or is `Directed`, then the returned graph is
 directed; if it is `Undirected`, then the returned graph is undirected and its
@@ -2212,27 +2211,6 @@ function graph_from_group_action(G::Union{Group, FinGenAbGroup}, L, act::Functio
   return graph_from_group_action(Directed, G, L, act, adj)
 end
 
-# Index key of a vertex element for the vertex lookup table. GAP-backed
-# cosets have a constant hash (a FIXME in Oscar) and expensive equality, so
-# the canonical representative of the coset is used instead.
-function _group_action_index_key(x)
-  if x isa GroupCoset
-    H = GapObj(x.H)
-    r = GapObj(representative(x))
-    if is_right(x)
-      canon = GAPWrap.CanonicalRightCosetElement(H, r)
-    else
-      # A left coset x*H is determined by the right coset H*x^-1, and its
-      # canonical representative is the inverse of the canonical
-      # representative of that right coset.
-      canon = GAPWrap.CanonicalRightCosetElement(H, GAPWrap.Inverse(r))
-      canon = GAPWrap.Inverse(canon)
-    end
-    return group_element(x.G, canon)
-  end
-  return x
-end
-
 function graph_from_group_action(::Type{T}, G::Union{Group, FinGenAbGroup}, L,
                                  act::Function,
                                  adj::Function) where {T <: Union{Directed, Undirected}}
@@ -2241,190 +2219,49 @@ function graph_from_group_action(::Type{T}, G::Union{Group, FinGenAbGroup}, L,
   verts = collect(L)
   n = length(verts)
   n == 0 && return graph(T, 0)
+  @req length(unique(verts)) == n "the elements of L must be pairwise distinct"
 
-  keys = [_group_action_index_key(x) for x in verts]
-  index = Dict{eltype(keys), Int}()
-  sizehint!(index, n)
-  for (i, k) in enumerate(keys)
-    @req !haskey(index, k) "the elements of L must be pairwise distinct"
-    index[k] = i
-  end
+  # L must be closed under the action of G; the closure of the seeds is
+  # larger than L exactly when L is not closed.
+  @req length(collect(gset(G, act, verts))) == n "L is not invariant under the action of G"
 
-  gens_list = gens(G)
-  m = length(gens_list)
-  invgens = [inv(g) for g in gens_list]
+  # Permutation image of the action of G on the vertices.
+  acthom = action_homomorphism(gset(G, act, verts; closed = true))
+  H = image(acthom)[1]          # PermGroup acting on 1:n
+  dom = 1:n
 
-  # Permutation of the vertex indices induced by each generator of G.
-  # Afterwards, all orbit and translation computations act on vertex indices
-  # only, so that the action function is not called in the inner loops.
-  gen_perm = Vector{Vector{Int}}(undef, m)
-  for h in 1:m
-    ph = Vector{Int}(undef, n)
-    for i in 1:n
-      v = get(index, _group_action_index_key(act(verts[i], gens_list[h])), 0)
-      @req v != 0 "L is not invariant under the action of G"
-      ph[i] = v
-    end
-    gen_perm[h] = ph
-  end
+  # Orbits of H on the vertices and their representatives.
+  orbs = orbits(gset(H, dom))
+  reps = [first(collect(o)) for o in orbs]
 
-  # Compute the orbits of G on the indices of verts by a breadth-first
-  # search. For every vertex the generator by which it was first reached and
-  # its predecessor in the search tree are stored; this is the Schreier
-  # vector of the orbit.
-  parent = zeros(Int, n)
-  gidx = zeros(Int, n)
-  reps = Int[]
-  orbs = Vector{Vector{Int}}()
-
-  for i in 1:n
-    parent[i] == 0 || continue
-    parent[i] = -1
-    orb = Int[i]
-    push!(reps, i)
-    k = 1
-    while k <= length(orb)
-      u = orb[k]
-      for h in 1:m
-        v = gen_perm[h][u]
-        if parent[v] == 0
-          parent[v] = u
-          gidx[v] = h
-          push!(orb, v)
-        end
-      end
-      k += 1
-    end
-    push!(orbs, orb)
-  end
-
-  # word in the generators from the orbit representative to the vertex v,
-  # together with the representative itself
-  function word_to_rep(v::Int)
-    word = Int[]
-    u = v
-    while parent[u] > 0
-      push!(word, gidx[u])
-      u = parent[u]
-    end
-    return reverse!(word), u
-  end
-
-  # Generators of the stabilizer of verts[r] in G. For GAP-backed groups
-  # Oscar's stabilizer is used, provided its generators indeed fix
-  # verts[r] (for exotic point types and Julia action functions the GAP
-  # stabilizer computation can be unreliable). Any subgroup of the true
-  # stabilizer is safe: it only refines the stabilizer orbits, and the
-  # adjacency predicate is invariant under the whole group. For other group
-  # types, or if the check fails, the Schreier generators of the orbit BFS
-  # tree are constructed as explicit group elements.
-  function stabilizer_generators(t::Int, r::Int)
-    if G isa GAPGroup
-      hgens = gens(stabilizer(G, verts[r], act)[1])
-      if all(hg -> act(verts[r], hg) == verts[r], hgens)
-        return hgens
-      end
-    end
-    result = typeof(one(G))[]
-    for u in orbs[t]
-      tau_u, _ = word_to_rep(u)
-      for h in 1:m
-        v = gen_perm[h][u]
-        tau_v, _ = word_to_rep(v)
-        # Schreier generators for a right action (tau_u * g_h * tau_v^-1)
-        # and for a left action (tau_v^-1 * g_h * tau_u). Which formula is
-        # correct depends on the orientation of the action, so we keep
-        # exactly those elements that fix the representative; the elements
-        # from the correct formula always fix it, hence their union still
-        # generates the stabilizer.
-        elt = one(G)
-        for e in tau_u
-          elt = elt * gens_list[e]
-        end
-        elt = elt * gens_list[h]
-        for e in reverse(tau_v)
-          elt = elt * invgens[e]
-        end
-        act(verts[r], elt) == verts[r] && push!(result, elt)
-        elt = one(G)
-        for e in reverse(tau_u)
-          elt = elt * invgens[e]
-        end
-        elt = elt * gens_list[h]
-        for e in tau_v
-          elt = elt * gens_list[e]
-        end
-        act(verts[r], elt) == verts[r] && push!(result, elt)
-      end
-    end
-    return result
-  end
-
-  reppos = Dict(reps[i] => i for i in eachindex(reps))
+  # Neighbours of each orbit representative: `adj` is constant on the
+  # orbits of the stabilizer of the representative, so one call to `adj`
+  # per stabilizer orbit suffices.
   rep_neighbors = Vector{Vector{Int}}(undef, length(reps))
-  hseen = falses(n)
-
-  for (t, r) in enumerate(reps)
-    # Permutation of the vertex indices induced by each generator of the
-    # stabilizer of verts[r].
-    hgens = stabilizer_generators(t, r)
-    hperm = Vector{Vector{Int}}(undef, length(hgens))
-    for (j, hg) in enumerate(hgens)
-      ph = Vector{Int}(undef, n)
-      for i in 1:n
-        ph[i] = index[_group_action_index_key(act(verts[i], hg))]
-      end
-      hperm[j] = ph
-    end
-
-    if isempty(hperm)
-      # trivial stabilizer
-      rep_neighbors[t] = [j for j in 1:n if adj(verts[r], verts[j])]
+  for (i, r) in enumerate(reps)
+    st = stabilizer(H, r)[1]
+    if order(st) == 1
+      rep_neighbors[i] = [j for j in dom if adj(verts[r], verts[j])]
     else
-      # Orbits of the stabilizer of verts[r] on the vertices: a vertex y is
-      # in the orbit of x if and only if it can be reached from x by
-      # applying the stabilizer generators. Since adj is invariant under the
-      # action, the whole stabilizer orbit of x is adjacent to verts[r] as
-      # soon as x is.
-      fill!(hseen, false)
       nb = Int[]
-      for j in 1:n
-        hseen[j] && continue
-        hseen[j] = true
-        ho = Int[j]
-        k = 1
-        while k <= length(ho)
-          u = ho[k]
-          for ph in hperm
-            q = ph[u]
-            if !hseen[q]
-              hseen[q] = true
-              push!(ho, q)
-            end
-          end
-          k += 1
-        end
-        if adj(verts[r], verts[ho[1]])
-          append!(nb, ho)
-        end
+      for o in orbits(gset(st, collect(orbs[i])))
+        oo = collect(o)
+        adj(verts[r], verts[oo[1]]) && append!(nb, oo)
       end
-      sort!(nb)
-      rep_neighbors[t] = nb
+      rep_neighbors[i] = sort!(nb)
     end
   end
 
-  # Translate the neighbour list of each representative along its orbit via
-  # the Schreier vector, and build the graph.
+  # Translate the neighbour lists along the orbits: for each vertex v,
+  # apply the element of H that maps the representative of its orbit to v.
   g = graph(T, n)
-  for v in 1:n
-    word, r = word_to_rep(v)
-    nb = rep_neighbors[reppos[r]]
-    for e in word
-      ph = gen_perm[e]
-      nb = [ph[x] for x in nb]
-    end
-    for w in sort!(nb)
-      add_edge!(g, v, w)
+  for (i, o) in enumerate(orbs)
+    r = reps[i]
+    for v in collect(o)
+      h = group_element(H, GAPWrap.RepresentativeAction(GapObj(H), r, v))
+      for w in sort!([h(x) for x in rep_neighbors[i]])
+        add_edge!(g, v, w)
+      end
     end
   end
   return g

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -2232,11 +2232,12 @@ function graph_from_group_action(::Type{T}, G::Union{Group, FinGenAbGroup}, L,
 
   # Orbits of H on the vertices and their representatives.
   orbs = orbits(gset(H, dom))
-  reps = [first(collect(o)) for o in orbs]
+  reps = representative.(orbs)
 
   # Neighbours of each orbit representative: `adj` is constant on the
-  # orbits of the stabilizer of the representative, so one call to `adj`
-  # per stabilizer orbit suffices.
+  # orbits of the stabilizer of the representative (on all vertices,
+  # including the other orbits of G), so one call to `adj` per such
+  # orbit suffices.
   rep_neighbors = Vector{Vector{Int}}(undef, length(reps))
   for (i, r) in enumerate(reps)
     st = stabilizer(H, r)[1]
@@ -2244,7 +2245,7 @@ function graph_from_group_action(::Type{T}, G::Union{Group, FinGenAbGroup}, L,
       rep_neighbors[i] = [j for j in dom if adj(verts[r], verts[j])]
     else
       nb = Int[]
-      for o in orbits(gset(st, collect(orbs[i])))
+      for o in orbits(gset(st, dom))
         oo = collect(o)
         adj(verts[r], verts[oo[1]]) && append!(nb, oo)
       end

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -2153,6 +2153,293 @@ function graph_from_edges(p::Polyhedron; modulo_lineality=false)
   return vertex_edge_graph(p; modulo_lineality=modulo_lineality)
 end
 
+################################################################################
+##  Graphs from group actions
+################################################################################
+
+@doc raw"""
+    graph_from_group_action([::Type{T},] G, L, act, adj) where {T <: Union{Directed, Undirected}}
+    graph_from_group_action([::Type{T},] Omega::GSet, adj) where {T <: Union{Directed, Undirected}}
+
+Return the graph on the vertices `1:length(L)` with a directed edge `(i, j)`
+if and only if `adj(L[i], L[j])` returns `true`.
+
+The group `G` must act on the list `L` via the action function `act`, i.e.
+`act(x, g)` is the image of `x in L` under `g in G`, and `L` must be invariant
+under this action. The elements of `L` must be pairwise distinct. The
+adjacency predicate `adj` must be invariant under the action of `G`, i.e.
+`adj(x, y) == adj(act(x, g), act(y, g))` holds for all `x, y in L` and all
+`g in G`.
+
+If a G-set `Omega` is passed instead of `G`, `L`, `act`, then the group, the
+vertex list and the action function are taken from `Omega`; the call is
+equivalent to `graph_from_group_action(T, acting_group(Omega), collect(Omega),
+action_function(Omega), adj)`. The vertices of the resulting graph are the
+elements of `collect(Omega)` in their given order.
+
+If the first argument is omitted, or is `Directed`, then the returned graph is
+directed; if it is `Undirected`, then the returned graph is undirected and its
+edges are obtained by symmetrizing the directed ones.
+
+# Examples
+```jldoctest
+julia> G = symmetric_group(5);
+
+julia> L = [[i, j] for i in 1:5 for j in i+1:5];
+
+julia> g = graph_from_group_action(G, L, on_sets,
+           (x, y) -> isempty(intersect(x, y)));
+
+julia> n_vertices(g), n_edges(g)
+(10, 30)
+
+julia> gu = graph_from_group_action(Undirected, G, L, on_sets,
+           (x, y) -> isempty(intersect(x, y)));
+
+julia> n_vertices(gu), n_edges(gu)
+(10, 15)
+
+julia> Omega = gset(symmetric_group(5), on_sets, [[1, 2]]);
+
+julia> g = graph_from_group_action(Omega, (x, y) -> isempty(intersect(x, y)));
+
+julia> n_vertices(g), n_edges(g)
+(10, 30)
+```
+"""
+function graph_from_group_action(G::Union{Group, FinGenAbGroup}, L, act::Function,
+                                 adj::Function)
+  return graph_from_group_action(Directed, G, L, act, adj)
+end
+
+# Index key of a vertex element for the vertex lookup table. GAP-backed
+# cosets have a constant hash (a FIXME in Oscar) and expensive equality, so
+# the canonical representative of the coset is used instead.
+function _group_action_index_key(x)
+  if x isa GroupCoset
+    H = GapObj(x.H)
+    r = GapObj(representative(x))
+    if is_right(x)
+      canon = GAP.Globals.CanonicalRightCosetElement(H, r)
+    else
+      # A left coset x*H is determined by the right coset H*x^-1, and its
+      # canonical representative is the inverse of the canonical
+      # representative of that right coset.
+      canon = GAP.Globals.CanonicalRightCosetElement(H, GAPWrap.Inverse(r))
+      canon = GAPWrap.Inverse(canon)
+    end
+    return group_element(x.G, canon)
+  end
+  return x
+end
+
+function graph_from_group_action(::Type{T}, G::Union{Group, FinGenAbGroup}, L,
+                                 act::Function,
+                                 adj::Function) where {T <: Union{Directed, Undirected}}
+  @req is_finite(G) "G must be finite"
+
+  verts = collect(L)
+  n = length(verts)
+  n == 0 && return graph(T, 0)
+
+  keys = [_group_action_index_key(x) for x in verts]
+  index = Dict{eltype(keys), Int}()
+  sizehint!(index, n)
+  for (i, k) in enumerate(keys)
+    @req !haskey(index, k) "the elements of L must be pairwise distinct"
+    index[k] = i
+  end
+
+  gens_list = gens(G)
+  m = length(gens_list)
+  invgens = [inv(g) for g in gens_list]
+
+  # Permutation of the vertex indices induced by each generator of G.
+  # Afterwards, all orbit and translation computations act on vertex indices
+  # only, so that the action function is not called in the inner loops.
+  gen_perm = Vector{Vector{Int}}(undef, m)
+  for h in 1:m
+    ph = Vector{Int}(undef, n)
+    for i in 1:n
+      v = get(index, _group_action_index_key(act(verts[i], gens_list[h])), 0)
+      @req v != 0 "L is not invariant under the action of G"
+      ph[i] = v
+    end
+    gen_perm[h] = ph
+  end
+
+  # Compute the orbits of G on the indices of verts by a breadth-first
+  # search. For every vertex the generator by which it was first reached and
+  # its predecessor in the search tree are stored; this is the Schreier
+  # vector of the orbit.
+  parent = zeros(Int, n)
+  gidx = zeros(Int, n)
+  reps = Int[]
+  orbs = Vector{Vector{Int}}()
+
+  for i in 1:n
+    parent[i] == 0 || continue
+    parent[i] = -1
+    orb = Int[i]
+    push!(reps, i)
+    k = 1
+    while k <= length(orb)
+      u = orb[k]
+      for h in 1:m
+        v = gen_perm[h][u]
+        if parent[v] == 0
+          parent[v] = u
+          gidx[v] = h
+          push!(orb, v)
+        end
+      end
+      k += 1
+    end
+    push!(orbs, orb)
+  end
+
+  # word in the generators from the orbit representative to the vertex v,
+  # together with the representative itself
+  function word_to_rep(v::Int)
+    word = Int[]
+    u = v
+    while parent[u] > 0
+      push!(word, gidx[u])
+      u = parent[u]
+    end
+    return reverse!(word), u
+  end
+
+  # Generators of the stabilizer of verts[r] in G. For GAP-backed groups
+  # Oscar's stabilizer is used, provided its generators indeed fix
+  # verts[r] (for exotic point types and Julia action functions the GAP
+  # stabilizer computation can be unreliable). Any subgroup of the true
+  # stabilizer is safe: it only refines the stabilizer orbits, and the
+  # adjacency predicate is invariant under the whole group. For other group
+  # types, or if the check fails, the Schreier generators of the orbit BFS
+  # tree are constructed as explicit group elements.
+  function stabilizer_generators(t::Int, r::Int)
+    if G isa GAPGroup
+      hgens = gens(stabilizer(G, verts[r], act)[1])
+      if all(hg -> act(verts[r], hg) == verts[r], hgens)
+        return hgens
+      end
+    end
+    result = typeof(one(G))[]
+    for u in orbs[t]
+      tau_u, _ = word_to_rep(u)
+      for h in 1:m
+        v = gen_perm[h][u]
+        tau_v, _ = word_to_rep(v)
+        # Schreier generators for a right action (tau_u * g_h * tau_v^-1)
+        # and for a left action (tau_v^-1 * g_h * tau_u). Which formula is
+        # correct depends on the orientation of the action, so we keep
+        # exactly those elements that fix the representative; the elements
+        # from the correct formula always fix it, hence their union still
+        # generates the stabilizer.
+        elt = one(G)
+        for e in tau_u
+          elt = elt * gens_list[e]
+        end
+        elt = elt * gens_list[h]
+        for e in reverse(tau_v)
+          elt = elt * invgens[e]
+        end
+        act(verts[r], elt) == verts[r] && push!(result, elt)
+        elt = one(G)
+        for e in reverse(tau_u)
+          elt = elt * invgens[e]
+        end
+        elt = elt * gens_list[h]
+        for e in tau_v
+          elt = elt * gens_list[e]
+        end
+        act(verts[r], elt) == verts[r] && push!(result, elt)
+      end
+    end
+    return result
+  end
+
+  reppos = Dict(reps[i] => i for i in eachindex(reps))
+  rep_neighbors = Vector{Vector{Int}}(undef, length(reps))
+  hseen = falses(n)
+
+  for (t, r) in enumerate(reps)
+    # Permutation of the vertex indices induced by each generator of the
+    # stabilizer of verts[r].
+    hgens = stabilizer_generators(t, r)
+    hperm = Vector{Vector{Int}}(undef, length(hgens))
+    for (j, hg) in enumerate(hgens)
+      ph = Vector{Int}(undef, n)
+      for i in 1:n
+        ph[i] = index[_group_action_index_key(act(verts[i], hg))]
+      end
+      hperm[j] = ph
+    end
+
+    if isempty(hperm)
+      # trivial stabilizer
+      rep_neighbors[t] = [j for j in 1:n if adj(verts[r], verts[j])]
+    else
+      # Orbits of the stabilizer of verts[r] on the vertices: a vertex y is
+      # in the orbit of x if and only if it can be reached from x by
+      # applying the stabilizer generators. Since adj is invariant under the
+      # action, the whole stabilizer orbit of x is adjacent to verts[r] as
+      # soon as x is.
+      fill!(hseen, false)
+      nb = Int[]
+      for j in 1:n
+        hseen[j] && continue
+        hseen[j] = true
+        ho = Int[j]
+        k = 1
+        while k <= length(ho)
+          u = ho[k]
+          for ph in hperm
+            q = ph[u]
+            if !hseen[q]
+              hseen[q] = true
+              push!(ho, q)
+            end
+          end
+          k += 1
+        end
+        if adj(verts[r], verts[ho[1]])
+          append!(nb, ho)
+        end
+      end
+      sort!(nb)
+      rep_neighbors[t] = nb
+    end
+  end
+
+  # Translate the neighbour list of each representative along its orbit via
+  # the Schreier vector, and build the graph.
+  g = graph(T, n)
+  for v in 1:n
+    word, r = word_to_rep(v)
+    nb = rep_neighbors[reppos[r]]
+    for e in word
+      ph = gen_perm[e]
+      nb = [ph[x] for x in nb]
+    end
+    for w in sort!(nb)
+      add_edge!(g, v, w)
+    end
+  end
+  return g
+end
+
+function graph_from_group_action(Omega::GSet, adj::Function)
+  return graph_from_group_action(Directed, Omega, adj)
+end
+
+function graph_from_group_action(::Type{T}, Omega::GSet,
+                                 adj::Function) where {T <: Union{Directed, Undirected}}
+  return graph_from_group_action(T, acting_group(Omega), collect(Omega),
+                                 action_function(Omega), adj)
+end
+
 @doc raw"""
     label!(G::Graph{T}, edge_labels::Union{Dict{Tuple{Int, Int}, Union{String, Int}}, Nothing}, vertex_labels::Union{Dict{Int, Union{String, Int}}, Nothing}=nothing; name::Symbol=:label) where {T <: Union{Directed, Undirected}}
 Given a graph `G`, add labels to the edges and optionally to the vertices with the given `name`.

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -29,6 +29,7 @@ GAP.@wrap Basis(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap BasisNC(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap BrauerCharacterValue(x::GapObj)::GAP.Obj
 GAP.@wrap CanonicalBasis(x::GapObj)::GapObj
+GAP.@wrap CanonicalRightCosetElement(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap CentralCharacter(x::GapObj)::GapObj
 GAP.@wrap Centralizer(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap CentreOfCharacter(x::GapObj, y::GapObj)::GapObj

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -383,6 +383,7 @@ GAP.@wrap RelativeOrders(x::GapObj)::GapObj
 GAP.@wrap RelatorsOfFpGroup(x::GapObj)::GapObj
 GAP.@wrap Representative(x::GapObj)::GAP.Obj
 GAP.@wrap RepresentativeAction(x::GapObj, y::GapObj, z::GapObj)::GapObj
+GAP.@wrap RepresentativeAction(x::GapObj, y::Int, z::Int)::GapObj
 GAP.@wrap RepresentativeTom(x::GapObj, y::Int)::GapObj
 GAP.@wrap RestrictedMapping(x::GapObj, y::GapObj)::GapObj
 GAP.@wrap RightCoset(x::GapObj, y::GapObj)::GapObj

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -740,6 +740,7 @@ export graph
 export graph_curve
 export graph_from_adjacency_matrix
 export graph_from_edges
+export graph_from_group_action
 export graph_from_labeled_edges
 export grassmann_pluecker_ideal
 export greatest_element

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -230,6 +230,118 @@
         @test is_isomorphic(G2, GG2)
     end
 
+    @testset "graph_from_group_action" begin
+      function naive_group_action_graph(::Type{T}, L, adj) where {T}
+        verts = collect(L)
+        n = length(verts)
+        g = graph(T, n)
+        for i in 1:n
+          for j in 1:n
+            adj(verts[i], verts[j]) && add_edge!(g, i, j)
+          end
+        end
+        return g
+      end
+
+      same_neighbors(a, b) =
+        n_vertices(a) == n_vertices(b) &&
+        all(Set(outneighbors(a, i)) == Set(outneighbors(b, i)) for i in 1:n_vertices(a))
+
+      S4 = symmetric_group(4)
+      pts = collect(1:4)
+
+      # natural action of S4, adjacency !=
+      adj_neq = (x, y) -> x != y
+      g1 = graph_from_group_action(S4, pts, ^, adj_neq)
+      h1 = naive_group_action_graph(Directed, pts, adj_neq)
+      @test same_neighbors(g1, h1)
+      @test n_edges(g1) == 12
+
+      # cyclic action with a non-trivial stabilizer
+      C4 = sub(S4, [cperm([1, 2, 3, 4])])[1]
+      adj_c4 = (x, y) -> mod(y - x, 4) in (1, 3)
+      g2 = graph_from_group_action(C4, pts, ^, adj_c4)
+      h2 = naive_group_action_graph(Directed, pts, adj_c4)
+      @test same_neighbors(g2, h2)
+      @test n_edges(g2) == 8
+
+      # S4 on all 2-subsets (non-trivial stabilizer)
+      pairs = [[i, j] for i in 1:4 for j in i+1:4]
+      disjoint = (x, y) -> isempty(intersect(x, y))
+      g3 = graph_from_group_action(S4, pairs, on_sets, disjoint)
+      h3 = naive_group_action_graph(Directed, pairs, disjoint)
+      @test same_neighbors(g3, h3)
+      @test n_edges(g3) == 6
+
+      # matrix group acting on the non-zero vectors of GF(2)^2
+      G2 = general_linear_group(2, 2)
+      V = free_module(GF(2), 2)
+      vecs = [v for v in collect(V) if !iszero(v)]
+      g4 = graph_from_group_action(G2, vecs, *, adj_neq)
+      h4 = naive_group_action_graph(Directed, vecs, adj_neq)
+      @test same_neighbors(g4, h4)
+      @test n_edges(g4) == 6
+      @test n_edges(graph_from_group_action(Undirected, G2, vecs, *, adj_neq)) == 3
+
+      # Petersen graph from the action of S5 on 2-subsets
+      S5 = symmetric_group(5)
+      two_subsets = [[i, j] for i in 1:5 for j in i+1:5]
+      g5 = graph_from_group_action(S5, two_subsets, on_sets, disjoint)
+      @test n_vertices(g5) == 10
+      @test n_edges(g5) == 30
+      gu5 = graph_from_group_action(Undirected, S5, two_subsets, on_sets, disjoint)
+      @test n_vertices(gu5) == 10
+      @test n_edges(gu5) == 15
+      @test is_isomorphic(gu5, petersen_graph())
+
+      # Cayley digraph of S3 with respect to its generators
+      S3 = symmetric_group(3)
+      elts = collect(S3)
+      gens3 = gens(S3)
+      g6 = graph_from_group_action(S3, elts, (x, g) -> x * g,
+                                   (x, y) -> inv(x) * y in gens3)
+      @test n_vertices(g6) == 6
+      @test n_edges(g6) == 6 * length(gens3)
+
+      # G-set signatures
+      Omega = gset(S5, on_sets, [[1, 2]])
+      g7 = graph_from_group_action(Omega, disjoint)
+      @test n_vertices(g7) == 10
+      @test n_edges(g7) == 30
+      @test same_neighbors(g7, graph_from_group_action(Directed, Omega, disjoint))
+      @test same_neighbors(g7,
+                           graph_from_group_action(S5, collect(Omega), on_sets, disjoint))
+      Omega4 = natural_gset(S4)
+      g8 = graph_from_group_action(Omega4, adj_neq)
+      @test n_vertices(g8) == 4
+      @test n_edges(g8) == 12
+
+      # right cosets with a double-coset adjacency predicate
+      H4 = stabilizer(S4, 1)[1]
+      rl = collect(right_cosets(S4, H4))
+      d = double_coset(H4, S4([2, 1, 3, 4]), H4)
+      g10 = graph_from_group_action(S4, rl, *,
+                                    (x, y) -> representative(x) / representative(y) in d)
+      @test n_vertices(g10) == 4
+      @test n_edges(g10) == 12
+
+      # left cosets with the left action
+      ll = collect(left_cosets(S4, H4))
+      g11 = graph_from_group_action(S4, ll, (x, g) -> g * x, adj_neq)
+      @test n_vertices(g11) == 4
+      @test n_edges(g11) == 12
+
+      # edge cases and errors
+      @test n_vertices(graph_from_group_action(S4, Int[], ^, (x, y) -> true)) == 0
+      trivial = trivial_subgroup(S4)[1]
+      g9 = graph_from_group_action(trivial, [1, 2, 3], ^, (x, y) -> x < y)
+      @test n_edges(g9) == 3
+      @test_throws ArgumentError graph_from_group_action(S4, [1, 2], ^, adj_neq)
+      @test_throws ArgumentError graph_from_group_action(S4, [1, 1, 2, 3], ^, adj_neq)
+      @test_throws ArgumentError graph_from_group_action(free_group(2), Int[], ^,
+                                                         (x, y) -> true)
+    end
+
       @testset "graph_from_labeled_edges" begin
         G1 = graph_from_edges([[1, 2], [3, 4]])
         vertex_labels = Dict(1 => 2, 3 => 4)

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -325,11 +325,13 @@
       @test n_vertices(g10) == 4
       @test n_edges(g10) == 12
 
-      # left cosets with the left action
+      # left cosets with the left action, expressed in its right-action
+      # form act(x, g) = inv(g)*x (as in the G-set of left cosets)
       ll = collect(left_cosets(S4, H4))
-      g11 = graph_from_group_action(S4, ll, (x, g) -> g * x, adj_neq)
+      g11 = graph_from_group_action(S4, ll, (x, g) -> inv(g) * x, adj_neq)
       @test n_vertices(g11) == 4
       @test n_edges(g11) == 12
+      @test same_neighbors(g11, graph_from_group_action(left_cosets(S4, H4), adj_neq))
 
       # edge cases and errors
       @test n_vertices(graph_from_group_action(S4, Int[], ^, (x, y) -> true)) == 0


### PR DESCRIPTION
    graph_from_group_action([::Type{T},] G, L, act, adj) where {T <: Union{Directed, Undirected}}
    graph_from_group_action([::Type{T},] Omega::GSet, adj) where {T <: Union{Directed, Undirected}}

Return the graph on the vertices `1:length(L)` with a directed edge `(i, j)`
if and only if `adj(L[i], L[j])` returns `true`.

The group `G` must act on the list `L` via the action function `act`, i.e.
`act(x, g)` is the image of `x in L` under `g in G`, and `L` must be invariant
under this action. The elements of `L` must be pairwise distinct. The
adjacency predicate `adj` must be invariant under the action of `G`, i.e.
`adj(x, y) == adj(act(x, g), act(y, g))` holds for all `x, y in L` and all
`g in G`.

If a G-set `Omega` is passed instead of `G`, `L`, `act`, then the group, the
vertex list and the action function are taken from `Omega`; the call is
equivalent to `graph_from_group_action(T, acting_group(Omega), collect(Omega),
action_function(Omega), adj)`. The vertices of the resulting graph are the
elements of `collect(Omega)` in their given order.

If the first argument is omitted, or is `Directed`, then the returned graph is
directed; if it is `Undirected`, then the returned graph is undirected and its
edges are obtained by symmetrizing the directed ones.

# Examples
```jldoctest
julia> G = symmetric_group(5);

julia> L = [[i, j] for i in 1:5 for j in i+1:5];

julia> g = graph_from_group_action(G, L, on_sets,
           (x, y) -> isempty(intersect(x, y)));

julia> n_vertices(g), n_edges(g)
(10, 30)

julia> gu = graph_from_group_action(Undirected, G, L, on_sets,
           (x, y) -> isempty(intersect(x, y)));

julia> n_vertices(gu), n_edges(gu)
(10, 15)

julia> Omega = gset(symmetric_group(5), on_sets, [[1, 2]]);

julia> g = graph_from_group_action(Omega, (x, y) -> isempty(intersect(x, y)));

julia> n_vertices(g), n_edges(g)
(10, 30)