### PR TITLE
Propagate flux-family computation options consistently

### DIFF
--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/basic_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/basic_attributes.jl
@@ -137,39 +137,43 @@ end
 @attr QQMatrix function matrix_integral_quant_transverse(
   m::AbstractFTheoryModel;
   completeness_check::Bool=true,
+  algorithm::Symbol=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
   return matrix_integral(
-    special_flux_family(m; completeness_check=completeness_check, rng=rng)
+    special_flux_family(m; completeness_check, algorithm, rng)
   )
 end
 
 @attr QQMatrix function matrix_rational_quant_transverse(
   m::AbstractFTheoryModel;
   completeness_check::Bool=true,
+  algorithm::Symbol=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
   return matrix_rational(
-    special_flux_family(m; completeness_check=completeness_check, rng=rng)
+    special_flux_family(m; completeness_check, algorithm, rng)
   )
 end
 
 @attr Vector{QQFieldElem} function offset_quant_transverse(
   m::AbstractFTheoryModel;
   completeness_check::Bool=true,
+  algorithm::Symbol=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
-  return offset(special_flux_family(m; completeness_check=completeness_check, rng=rng))
+  return offset(special_flux_family(m; completeness_check, algorithm, rng))
 end
 
 @attr QQMatrix function matrix_integral_quant_transverse_nobreak(
   m::AbstractFTheoryModel;
   completeness_check::Bool=true,
+  algorithm::Symbol=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
   return matrix_integral(
     special_flux_family(
-      m; not_breaking=true, completeness_check=completeness_check, rng=rng
+      m; not_breaking=true, completeness_check, algorithm, rng
     ),
   )
 end
@@ -177,11 +181,12 @@ end
 @attr QQMatrix function matrix_rational_quant_transverse_nobreak(
   m::AbstractFTheoryModel;
   completeness_check::Bool=true,
+  algorithm::Symbol=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
   return matrix_rational(
     special_flux_family(
-      m; not_breaking=true, completeness_check=completeness_check, rng=rng
+      m; not_breaking=true, completeness_check, algorithm, rng
     ),
   )
 end
@@ -189,11 +194,12 @@ end
 @attr Vector{QQFieldElem} function offset_quant_transverse_nobreak(
   m::AbstractFTheoryModel;
   completeness_check::Bool=true,
+  algorithm::Symbol=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
   return offset(
     special_flux_family(
-      m; not_breaking=true, completeness_check=completeness_check, rng=rng
+      m; not_breaking=true, completeness_check, algorithm, rng
     ),
   )
 end

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/basic_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/basic_attributes.jl
@@ -134,10 +134,25 @@ end
 ### Attributes for flux families (not exported, rather for serialization overhaul)
 ######################################################################################
 
+function _normalize_flux_family_algorithm(
+  algorithm::Union{Symbol,String}, caller::Symbol
+)
+  normalized_algorithm = algorithm isa String ? Symbol(algorithm) : algorithm
+  normalized_algorithm in (:default, :special) ||
+    throw(ArgumentError("Unknown value for keyword `algorithm`: $algorithm"))
+  if algorithm isa String
+    Base.depwarn(
+      "Passing `algorithm=\"$algorithm\"` is deprecated; use `algorithm=:$algorithm` instead",
+      caller,
+    )
+  end
+  return normalized_algorithm
+end
+
 @attr QQMatrix function matrix_integral_quant_transverse(
   m::AbstractFTheoryModel;
   completeness_check::Bool=true,
-  algorithm::Symbol=:default,
+  algorithm::Union{Symbol,String}=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
   return matrix_integral(
@@ -148,7 +163,7 @@ end
 @attr QQMatrix function matrix_rational_quant_transverse(
   m::AbstractFTheoryModel;
   completeness_check::Bool=true,
-  algorithm::Symbol=:default,
+  algorithm::Union{Symbol,String}=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
   return matrix_rational(
@@ -159,7 +174,7 @@ end
 @attr Vector{QQFieldElem} function offset_quant_transverse(
   m::AbstractFTheoryModel;
   completeness_check::Bool=true,
-  algorithm::Symbol=:default,
+  algorithm::Union{Symbol,String}=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
   return offset(special_flux_family(m; completeness_check, algorithm, rng))
@@ -168,7 +183,7 @@ end
 @attr QQMatrix function matrix_integral_quant_transverse_nobreak(
   m::AbstractFTheoryModel;
   completeness_check::Bool=true,
-  algorithm::Symbol=:default,
+  algorithm::Union{Symbol,String}=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
   return matrix_integral(
@@ -181,7 +196,7 @@ end
 @attr QQMatrix function matrix_rational_quant_transverse_nobreak(
   m::AbstractFTheoryModel;
   completeness_check::Bool=true,
-  algorithm::Symbol=:default,
+  algorithm::Union{Symbol,String}=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
   return matrix_rational(
@@ -194,7 +209,7 @@ end
 @attr Vector{QQFieldElem} function offset_quant_transverse_nobreak(
   m::AbstractFTheoryModel;
   completeness_check::Bool=true,
-  algorithm::Symbol=:default,
+  algorithm::Union{Symbol,String}=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
   return offset(

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/analyze_fibers.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/analyze_fibers.jl
@@ -9,6 +9,9 @@ Determine the fiber of a (singular) global Tate model over a particular base loc
 
 !!! warning
     This method may run for very long time and is currently not tested as part of the regular OSCAR CI due to its excessive run times.
+
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
 """
 function analyze_fibers(
   model::GlobalTateModel,

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/put_over_concrete_base.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/put_over_concrete_base.jl
@@ -5,8 +5,10 @@ Put an F-theory model defined over a family of spaces over a concrete base.
 
 Currently, this functionality is limited to Tate and Weierstrass models.
 
-Internally, this function uses generic sections of line bundles. The random source
-used in the creation of said generic sections can be set with the optional argument `rng`.
+Internally, this function uses generic sections of line bundles.
+
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
 
 !!! note "Complete toric base"
     This function assumes that the toric base space is **complete**.

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/attributes.jl
@@ -168,6 +168,9 @@ the numerical coefficient values into this polynomial.
   consuming. To skip this check, pass the optional keyword argument 
   `completeness_check=false`.
 
+!!! note "Randomness"
+  The random source used for randomized computations can be set with the `rng` keyword.
+
 # Examples
 ```jldoctest; setup = :(Oscar.ensure_qsmdb_installed())
 julia> using Random;

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
@@ -215,7 +215,7 @@ Create a random element of a family of G4-fluxes.
   pass the optional keyword argument `consistency_check=false`.
 
 !!! note "Randomness"
-  The random source can be set with the optional argument `rng`
+  The random source used for randomized computations can be set with the `rng` keyword.
 
 # Examples
 ```jldoctest; setup = :(Oscar.ensure_qsmdb_installed())
@@ -290,7 +290,10 @@ Create a random ``G_4``-flux on a given F-theory model.
   pass the optional keyword argument `consistency_check=false`.
 
 !!! note "Randomness"
-  The random source can be set with the optional argument `rng`
+  The random source used for randomized computations can be set with the `rng` keyword.
+
+The `algorithm` keyword selects the algorithm used to construct the underlying flux family;
+see [`special_flux_family`](@ref).
 
 # Examples
 ```jldoctest; setup = :(Oscar.ensure_qsmdb_installed())
@@ -311,9 +314,10 @@ function random_flux(
   m::AbstractFTheoryModel;
   not_breaking::Bool=false,
   completeness_check::Bool=true,
+  algorithm::Symbol=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
-  family = special_flux_family(m; not_breaking, completeness_check, rng=rng)
+  family = special_flux_family(m; not_breaking, completeness_check, algorithm, rng)
   return random_flux_instance(
     family; completeness_check=completeness_check, consistency_check=false, rng=rng
   )

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/methods.jl
@@ -314,9 +314,10 @@ function random_flux(
   m::AbstractFTheoryModel;
   not_breaking::Bool=false,
   completeness_check::Bool=true,
-  algorithm::Symbol=:default,
+  algorithm::Union{Symbol,String}=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
+  algorithm = _normalize_flux_family_algorithm(algorithm, :random_flux)
   family = special_flux_family(m; not_breaking, completeness_check, algorithm, rng)
   return random_flux_instance(
     family; completeness_check=completeness_check, consistency_check=false, rng=rng

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
@@ -55,10 +55,10 @@ function special_flux_family(
   m::AbstractFTheoryModel;
   not_breaking::Bool=false,
   completeness_check::Bool=true,
-  algorithm::Symbol=:default,
+  algorithm::Union{Symbol,String}=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
-  @req algorithm in (:default, :special) "Unknown value for keyword `algorithm`: $algorithm"
+  algorithm = _normalize_flux_family_algorithm(algorithm, :special_flux_family)
 
   # (1) Is result known?
   if !not_breaking

--- a/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
+++ b/experimental/FTheoryTools/src/FamilyOfG4Fluxes/special_constructors.jl
@@ -10,6 +10,9 @@ Optional keyword arguments:
 - `completeness_check`: if `false`, skips completeness check of the ambient toric variety for improved performance.
 - `algorithm`: selects the computation method; the default uses Gröbner basis computations in the cohomology ring, while setting `algorithm = :special` activates a faster variant described in [BMT25](@cite BMT25).
 
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
+
 # Examples
 ```jldoctest; setup = :(Oscar.ensure_qsmdb_installed())
 julia> using Random;
@@ -55,6 +58,7 @@ function special_flux_family(
   algorithm::Symbol=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
+  @req algorithm in (:default, :special) "Unknown value for keyword `algorithm`: $algorithm"
 
   # (1) Is result known?
   if !not_breaking
@@ -62,13 +66,13 @@ function special_flux_family(
       has_attribute(m, :matrix_rational_quant_transverse) &&
       has_attribute(m, :offset_quant_transverse)
       fgs_m_int = matrix_integral_quant_transverse(
-        m; completeness_check=completeness_check, rng=rng
+        m; completeness_check, algorithm, rng
       )
       fgs_m_rat = matrix_rational_quant_transverse(
-        m; completeness_check=completeness_check, rng=rng
+        m; completeness_check, algorithm, rng
       )
       fgs_offset = offset_quant_transverse(
-        m; completeness_check=completeness_check, rng=rng
+        m; completeness_check, algorithm, rng
       )
       fgs = family_of_g4_fluxes(m, fgs_m_int, fgs_m_rat, fgs_offset; completeness_check)
       set_attribute!(fgs, :is_well_quantized, true)
@@ -80,13 +84,13 @@ function special_flux_family(
       has_attribute(m, :matrix_rational_quant_transverse_nobreak) &&
       has_attribute(m, :offset_quant_transverse_nobreak)
       fgs_m_int = matrix_integral_quant_transverse_nobreak(
-        m; completeness_check=completeness_check, rng=rng
+        m; completeness_check, algorithm, rng
       )
       fgs_m_rat = matrix_rational_quant_transverse_nobreak(
-        m; completeness_check=completeness_check, rng=rng
+        m; completeness_check, algorithm, rng
       )
       fgs_offset = offset_quant_transverse_nobreak(
-        m; completeness_check=completeness_check, rng=rng
+        m; completeness_check, algorithm, rng
       )
       fgs = family_of_g4_fluxes(m, fgs_m_int, fgs_m_rat, fgs_offset; completeness_check)
       set_attribute!(fgs, :is_well_quantized, true)

--- a/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
@@ -140,6 +140,12 @@ non-abelian gauge group.
   consuming. To skip this check, pass the optional keyword argument 
   `completeness_check=false`.
 
+!!! note "Randomness"
+  The random source used for randomized computations can be set with the `rng` keyword.
+
+The `algorithm` keyword selects the algorithm used to construct the flux family;
+see [`special_flux_family`](@ref).
+
 # Examples
 ```jldoctest; setup = :(Oscar.ensure_qsmdb_installed())
 julia> using Random;
@@ -161,10 +167,15 @@ Family of G4 fluxes:
   - Non-abelian gauge group: unbroken
 ```
 """
-@attr FamilyOfG4Fluxes function g4_flux_family(gf::G4Flux; completeness_check::Bool=true)
+@attr FamilyOfG4Fluxes function g4_flux_family(
+  gf::G4Flux;
+  completeness_check::Bool=true,
+  algorithm::Symbol=:default,
+  rng::AbstractRNG=Random.default_rng(),
+)
   nb = breaks_non_abelian_gauge_group(gf)
   gfs = special_flux_family(
-    model(gf); not_breaking=(!nb), completeness_check=completeness_check
+    model(gf); not_breaking=(!nb), completeness_check, algorithm, rng
   )
   return gfs
 end

--- a/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
@@ -167,17 +167,19 @@ Family of G4 fluxes:
   - Non-abelian gauge group: unbroken
 ```
 """
-@attr FamilyOfG4Fluxes function g4_flux_family(
+function g4_flux_family(
   gf::G4Flux;
   completeness_check::Bool=true,
   algorithm::Union{Symbol,String}=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
   algorithm = _normalize_flux_family_algorithm(algorithm, :g4_flux_family)
+  has_attribute(gf, :g4_flux_family) && return get_attribute(gf, :g4_flux_family)
   nb = breaks_non_abelian_gauge_group(gf)
   gfs = special_flux_family(
     model(gf); not_breaking=(!nb), completeness_check, algorithm, rng
   )
+  set_attribute!(gf, :g4_flux_family, gfs)
   return gfs
 end
 

--- a/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/attributes.jl
@@ -170,9 +170,10 @@ Family of G4 fluxes:
 @attr FamilyOfG4Fluxes function g4_flux_family(
   gf::G4Flux;
   completeness_check::Bool=true,
-  algorithm::Symbol=:default,
+  algorithm::Union{Symbol,String}=:default,
   rng::AbstractRNG=Random.default_rng(),
 )
+  algorithm = _normalize_flux_family_algorithm(algorithm, :g4_flux_family)
   nb = breaks_non_abelian_gauge_group(gf)
   gfs = special_flux_family(
     model(gf); not_breaking=(!nb), completeness_check, algorithm, rng

--- a/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/attributes.jl
@@ -56,9 +56,10 @@ hypersurface_equation_parametrization(h::HypersurfaceModel) =
 
 Return the Weierstrass model corresponding to the given hypersurface model, if known.
 
-If needed, this function constructs a literature model, the process of which may include the
-creation of generic sections. The random source used in the creation of said generic sections
-can be set with the optional argument `rng`.
+If needed, this function constructs a literature model, which may create generic sections.
+
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
 
 In the example below, we construct a hypersurface model and its corresponding Weierstrass
 model (see [BMT25](@cite BMT25) for background), and then establish the relationship
@@ -122,9 +123,10 @@ end
 
 Return the global Tate model corresponding to the given hypersurface model, if known.
 
-If needed, this function constructs a literature model, the process of which may include the
-creation of generic sections. The random source used in the creation of said generic sections
-can be set with the optional argument `rng`.
+If needed, this function constructs a literature model, which may create generic sections.
+
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
 
 In the example below, we construct a hypersurface model and its corresponding global
 Tate model (see [BMT25](@cite BMT25) for background), and then establish the relationship
@@ -251,7 +253,9 @@ model (see [BMT25](@cite BMT25) for background), in order to demonstrate this fu
 !!! warning
     The classification of singularities is performed using a Monte Carlo algorithm, involving randomized sampling.
     While reliable in practice, this probabilistic method may occasionally yield non-deterministic results.
-    The random source can be set with the optional argument `rng`.
+
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
 
 # Examples
 ```jldoctest

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -27,6 +27,9 @@ Some literature models require additional input to be uniquely determined and co
 * `completeness_check`: Set this to `false` to skip time consuming completeness checks of the base geometry to gain more performance.
 * `rng`: Set the random source used to create generic sections.
 
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
+
 See the [Literature Models](@ref literature_models) documentation page for a deeper discussion of these fields.
 
 First, notice how you can create the global Tate model from [Krause, Mayrhofer, Weigand 2011](@cite KMW12)

--- a/experimental/FTheoryTools/src/TateModels/attributes.jl
+++ b/experimental/FTheoryTools/src/TateModels/attributes.jl
@@ -316,7 +316,9 @@ refined Tate fiber type. See [`singular_loci(w::WeierstrassModel)`](@ref) for mo
 !!! warning
     The classification of singularities is performed using a Monte Carlo algorithm, involving randomized sampling.
     While reliable in practice, this probabilistic method may occasionally yield non-deterministic results.
-    The random source can be set with the optional argument `rng`.
+
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
 
 Below, we demonstrate this functionality by computing the singular loci of a Type ``III`` Tate model
 [KMSS11](@cite). In this case, the Tate sections are factored as follows:

--- a/experimental/FTheoryTools/src/TateModels/constructors.jl
+++ b/experimental/FTheoryTools/src/TateModels/constructors.jl
@@ -7,7 +7,9 @@
 
 This method constructs a global Tate model over a given toric base
 3-fold. The Tate sections ``a_i`` are taken with (pseudo) random coefficients.
-The random source used in their creation can be set with the optional argument `rng`.
+
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
 
 !!! note "Complete toric base"
     This function assumes that the toric base space is **complete**.
@@ -126,8 +128,10 @@ end
 
 Construct a global Tate model over the ``d``-dimensional projective space,
 represented as a toric variety. The Tate sections ``a_i`` are
-automatically generated with pseudorandom coefficients. The random
-source used in their creation can be set with the optional argument `rng`.
+automatically generated with pseudorandom coefficients.
+
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
 
 # Examples
 ```jldoctest
@@ -147,8 +151,10 @@ global_tate_model_over_projective_space(d::Int; rng::AbstractRNG=Random.default_
 
 Construct a global Tate model over the Hirzebruch surface ``F_r``,
 represented as a toric variety. The Tate sections ``a_i`` are
-automatically generated with pseudorandom coefficients. The random
-source used in their creation can be set with the optional argument `rng`.
+automatically generated with pseudorandom coefficients.
+
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
 
 # Examples
 ```jldoctest
@@ -168,8 +174,10 @@ global_tate_model_over_hirzebruch_surface(r::Int; rng::AbstractRNG=Random.defaul
 
 Construct a global Tate model over the del Pezzo surface ``\text{dP}_b``,
 represented as a toric variety. The Tate sections ``a_i`` are
-automatically generated with pseudorandom coefficients. The random
-source used in their creation can be set with the optional argument `rng`.
+automatically generated with pseudorandom coefficients.
+
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
 
 # Examples
 ```jldoctest

--- a/experimental/FTheoryTools/src/WeierstrassModels/attributes.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/attributes.jl
@@ -162,7 +162,9 @@ Advanced technical details are available in [BMT25](@cite BMT25).
 !!! warning
     The classification of singularities is based on a Monte Carlo algorithm, which involves random sampling.
     While reliable in practice, this probabilistic method may occasionally yield non-deterministic results.
-    The random source can be set with the optional argument `rng`.
+
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
 
 # Examples
 ```jldoctest

--- a/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
@@ -6,8 +6,10 @@
     weierstrass_model(base::NormalToricVariety; completeness_check::Bool = true, rng::AbstractRNG = Random.default_rng())
 
 Construct a Weierstrass model over a given toric base space. The Weierstrass sections
-``f`` and ``g`` are automatically generated with (pseudo)random coefficients. The random
-source used in their creation can be set with the optional argument `rng`.
+``f`` and ``g`` are automatically generated with (pseudo)random coefficients.
+
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
 
 !!! note "Complete toric base"
     This function assumes that the toric base space is **complete**.
@@ -114,8 +116,10 @@ end
 
 Construct a Weierstrass model over the ``d``-dimensional projective space,
 represented as a toric variety. The Weierstrass sections ``f`` and ``g`` are
-automatically generated with pseudorandom coefficients. The random
-source used in their creation can be set with the optional argument `rng`.
+automatically generated with pseudorandom coefficients.
+
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
 
 # Examples
 ```jldoctest
@@ -135,8 +139,10 @@ weierstrass_model_over_projective_space(d::Int; rng::AbstractRNG=Random.default_
 
 Construct a Weierstrass model over the Hirzebruch surface ``F_r``,
 represented as a toric variety. The Weierstrass sections ``f`` and ``g`` are
-automatically generated with pseudorandom coefficients. The random
-source used in their creation can be set with the optional argument `rng`.
+automatically generated with pseudorandom coefficients.
+
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
 
 # Examples
 ```jldoctest
@@ -156,8 +162,10 @@ weierstrass_model_over_hirzebruch_surface(r::Int; rng::AbstractRNG=Random.defaul
 
 Construct a Weierstrass model over the del Pezzo surface ``\text{dP}_b``,
 represented as a toric variety. The Weierstrass sections ``f`` and ``g`` are
-automatically generated with pseudorandom coefficients. The random
-source used in their creation can be set with the optional argument `rng`.
+automatically generated with pseudorandom coefficients.
+
+!!! note "Randomness"
+    The random source used for randomized computations can be set with the `rng` keyword.
 
 # Examples
 ```jldoctest

--- a/experimental/FTheoryTools/test/QSMs.jl
+++ b/experimental/FTheoryTools/test/QSMs.jl
@@ -56,39 +56,11 @@ end
   end
   qsm_g4_flux = qsm_flux(qsm_model)
 
-  # Check that flux-family wrappers normalize and forward algorithm selection and randomness.
-  @test_deprecated Oscar._normalize_flux_family_algorithm(
-    "default", :special_flux_family
-  ) ===
-    :default
+  # Check that string-valued algorithm names are deprecated.
   @test_deprecated Oscar._normalize_flux_family_algorithm(
     "special", :special_flux_family
   ) ===
     :special
-  @test_throws ArgumentError g4_flux_family(
-    qsm_g4_flux;
-    completeness_check=false,
-    algorithm=:unknown,
-    rng=Random.Xoshiro(1234),
-  )
-  @test_throws ArgumentError random_flux(
-    qsm_model;
-    completeness_check=false,
-    algorithm=:unknown,
-    rng=Random.Xoshiro(1234),
-  )
-  @test g4_flux_family(
-    qsm_g4_flux;
-    completeness_check=false,
-    algorithm=:special,
-    rng=Random.Xoshiro(1234),
-  ) isa FamilyOfG4Fluxes
-  @test_deprecated g4_flux_family(
-    qsm_g4_flux;
-    completeness_check=false,
-    algorithm="special",
-    rng=Random.Xoshiro(1234),
-  )
 
   h22_basis = gens_of_h22_hypersurface_indices(qsm_model; completeness_check=false)
   flux_poly_str = string(polynomial(cohomology_class(qsm_g4_flux)))

--- a/experimental/FTheoryTools/test/QSMs.jl
+++ b/experimental/FTheoryTools/test/QSMs.jl
@@ -56,7 +56,15 @@ end
   end
   qsm_g4_flux = qsm_flux(qsm_model)
 
-  # Check that flux-family wrappers forward algorithm selection and randomness.
+  # Check that flux-family wrappers normalize and forward algorithm selection and randomness.
+  @test_deprecated Oscar._normalize_flux_family_algorithm(
+    "default", :special_flux_family
+  ) ===
+    :default
+  @test_deprecated Oscar._normalize_flux_family_algorithm(
+    "special", :special_flux_family
+  ) ===
+    :special
   @test_throws ArgumentError g4_flux_family(
     qsm_g4_flux;
     completeness_check=false,
@@ -75,6 +83,12 @@ end
     algorithm=:special,
     rng=Random.Xoshiro(1234),
   ) isa FamilyOfG4Fluxes
+  @test_deprecated g4_flux_family(
+    qsm_g4_flux;
+    completeness_check=false,
+    algorithm="special",
+    rng=Random.Xoshiro(1234),
+  )
 
   h22_basis = gens_of_h22_hypersurface_indices(qsm_model; completeness_check=false)
   flux_poly_str = string(polynomial(cohomology_class(qsm_g4_flux)))

--- a/experimental/FTheoryTools/test/QSMs.jl
+++ b/experimental/FTheoryTools/test/QSMs.jl
@@ -55,6 +55,27 @@ end
     @test obj1 == obj2
   end
   qsm_g4_flux = qsm_flux(qsm_model)
+
+  # Check that flux-family wrappers forward algorithm selection and randomness.
+  @test_throws ArgumentError g4_flux_family(
+    qsm_g4_flux;
+    completeness_check=false,
+    algorithm=:unknown,
+    rng=Random.Xoshiro(1234),
+  )
+  @test_throws ArgumentError random_flux(
+    qsm_model;
+    completeness_check=false,
+    algorithm=:unknown,
+    rng=Random.Xoshiro(1234),
+  )
+  @test g4_flux_family(
+    qsm_g4_flux;
+    completeness_check=false,
+    algorithm=:special,
+    rng=Random.Xoshiro(1234),
+  ) isa FamilyOfG4Fluxes
+
   h22_basis = gens_of_h22_hypersurface_indices(qsm_model; completeness_check=false)
   flux_poly_str = string(polynomial(cohomology_class(qsm_g4_flux)))
   ring = base_ring(parent(polynomial(cohomology_class(qsm_g4_flux))))


### PR DESCRIPTION
* Document random-number generator keywords consistently across the `FTheoryTools` docu.
* Forward the flux-family algorithm and random source through wrapper functions and cached delegates.
* While symbols should be used by default to select algorithms, we used strings before (in our FTheoryTools paper for instance); restore support for algorithm selection via strings, but inform users about its deprecation.

Prepared with OpenAI Codex <codex@openai.com>.