### PR TITLE
Simplify FTheoryTools keyword documentation

### DIFF
--- a/experimental/FTheoryTools/docs/src/literature.md
+++ b/experimental/FTheoryTools/docs/src/literature.md
@@ -74,7 +74,7 @@ We defer a detailed discussion of these technical inputs (and outputs) to the ne
 a high-level overview of how literature models are initialized in practice:
 
 ```@docs
-literature_model(; doi::String="", arxiv_id::String="", version::String="", equation::String="", model_parameters::Dict{String,<:Any} = Dict{String,Any}(), base_space::FTheorySpace = affine_space(NormalToricVariety, 0), model_sections::Dict{String, <:Any} = Dict{String,Any}(), defining_classes::Dict{String, <:Any} = Dict{String,Any}(), completeness_check::Bool = true)
+literature_model()
 ```
 
 It can be interesting to observe all currently supported literature models. This is possible via the following function:

--- a/experimental/FTheoryTools/docs/src/resolving_singularities.md
+++ b/experimental/FTheoryTools/docs/src/resolving_singularities.md
@@ -37,9 +37,9 @@ over the resolution process.
 You can execute individual blowups, whether toric or not, using the following methods:
 
 ```@docs
-blow_up(m::AbstractFTheoryModel, ideal_gens::Vector{String}; coordinate_name::String = "e")
-blow_up(m::AbstractFTheoryModel, I::MPolyIdeal; coordinate_name::String = "e")
-blow_up(m::AbstractFTheoryModel, I::AbsIdealSheaf; coordinate_name::String = "e")
+blow_up(m::AbstractFTheoryModel, ideal_gens::Vector{String})
+blow_up(m::AbstractFTheoryModel, I::MPolyIdeal)
+blow_up(m::AbstractFTheoryModel, I::AbsIdealSheaf)
 ```
 
 ### Data Format for Resolutions

--- a/experimental/FTheoryTools/docs/src/tate.md
+++ b/experimental/FTheoryTools/docs/src/tate.md
@@ -148,8 +148,8 @@ elliptic fibration structure.
 Users can construct global Tate models over such concrete toric bases with the following constructors:
 
 ```@docs
-global_tate_model(base::NormalToricVariety; completeness_check::Bool = true)
-global_tate_model(base::NormalToricVariety, ais::Vector{T}; completeness_check::Bool = true) where {T<:MPolyRingElem}
+global_tate_model(base::NormalToricVariety)
+global_tate_model(base::NormalToricVariety, ais::Vector{T}) where {T<:MPolyRingElem}
 ```
 
 For convenience—ideal for quick experiments and educational use—we also support constructors for global Tate models

--- a/experimental/FTheoryTools/docs/src/weierstrass.md
+++ b/experimental/FTheoryTools/docs/src/weierstrass.md
@@ -122,8 +122,8 @@ used in the F-theory literature, but it is guaranteed to be compatible with the 
 Users can construct Weierstrass models over such concrete toric bases with the following constructors:
 
 ```@docs
-weierstrass_model(base::NormalToricVariety; completeness_check::Bool = true)
-weierstrass_model(base::NormalToricVariety, f::MPolyRingElem, g::MPolyRingElem; completeness_check::Bool = true)
+weierstrass_model(base::NormalToricVariety)
+weierstrass_model(base::NormalToricVariety, f::MPolyRingElem, g::MPolyRingElem)
 ```
 
 For convenience—ideal for quick experiments and educational use—we also support constructors for Weierstrass

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/blowups.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/blowups.jl
@@ -6,9 +6,10 @@
 ###########################################################################
 
 @doc raw"""
-    _martins_desired_blowup(m::NormalToricVariety, I::ToricIdealSheafFromCoxRingIdeal; coordinate_name::String = "e")
+    _martins_desired_blowup(m::NormalToricVariety, I::ToricIdealSheafFromCoxRingIdeal; kwargs...)
 
 Blow up the toric variety along a toric ideal sheaf.
+Set `coordinate_name` to choose the name of the exceptional homogeneous coordinate; it defaults to `"e"`.
 
 !!! warning
     This function is type unstable. The type of the domain of the output `f` is always a subtype of `AbsCoveredScheme` (meaning that `domain(f) isa AbsCoveredScheme` is always true). 
@@ -58,7 +59,7 @@ function _martins_desired_blowup(
 end
 
 @doc raw"""
-    _martins_desired_blowup(v::NormalToricVariety, I::MPolyIdeal; coordinate_name::String = "e")
+    _martins_desired_blowup(v::NormalToricVariety, I::MPolyIdeal; kwargs...)
 
 Blow up the toric variety by subdividing the cone in the list
 of *all* cones of the fan of `v` which corresponds to the
@@ -117,9 +118,10 @@ end
 ##################################################################
 
 @doc raw"""
-    blow_up(m::AbstractFTheoryModel, ideal_gens::Vector{String}; coordinate_name::String = "e")
+    blow_up(m::AbstractFTheoryModel, ideal_gens::Vector{String}; kwargs...)
 
 Resolve an F-theory model by blowing up a locus in the ambient space.
+Set `coordinate_name` to choose the name of the exceptional homogeneous coordinate; it defaults to `"e"`.
 
 # Examples
 ```jldoctest
@@ -175,9 +177,10 @@ function blow_up(
 end
 
 @doc raw"""
-    blow_up(m::AbstractFTheoryModel, I::MPolyIdeal; coordinate_name::String = "e")
+    blow_up(m::AbstractFTheoryModel, I::MPolyIdeal; kwargs...)
 
 Resolve an F-theory model by blowing up a locus in the ambient space.
+Set `coordinate_name` to choose the name of the exceptional homogeneous coordinate; it defaults to `"e"`.
 
 # Examples
 ```jldoctest
@@ -245,10 +248,11 @@ function _ideal_sheaf_to_minimal_supercone_coordinates(
 end
 
 @doc raw"""
-    blow_up(m::AbstractFTheoryModel, I::AbsIdealSheaf; coordinate_name::String = "e")
+    blow_up(m::AbstractFTheoryModel, I::AbsIdealSheaf; kwargs...)
 
 Resolve an F-theory model by blowing up a locus in the ambient space.
 For this method, the blowup center is encoded by an ideal sheaf.
+Set `coordinate_name` to choose the name of the exceptional homogeneous coordinate; it defaults to `"e"`.
 
 # Examples
 ```jldoctest

--- a/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
+++ b/experimental/FTheoryTools/src/LiteratureModels/constructors.jl
@@ -3,7 +3,7 @@
 #######################################################
 
 @doc raw"""
-    literature_model(; doi::String="", arxiv_id::String="", version::String="", equation::String="", model_parameters::Dict{String,<:Any} = Dict{String,Any}(), base_space::FTheorySpace = affine_space(NormalToricVariety, 0), model_sections::Dict{String, <:Any} = Dict{String,Any}(), defining_classes::Dict{String, <:Any} = Dict{String,Any}(), completeness_check::Bool = true, rng::AbstractRNG = Random.default_rng())
+    literature_model(; kwargs...)
 
 Return a model from the F-theory literature identified by bibliographic metadata such as arXiv ID, DOI, or equation reference.
 Many such models are well-known in the field—e.g., the *U(1)-restricted SU(5)-GUT model
@@ -15,6 +15,7 @@ To identify and retrieve a model from the database, supply one or more of the fo
 * `arxiv_id`: A string specifying the arXiv identifier of the preprint version or the journal print version.
 * `version`: A string specifying the arXiv version (e.g. `"v1"`).
 * `equation`: A string indicating the equation label used to define the model within the source publication.
+* `type`: A string restricting the result to a model type such as `"tate"`, `"weierstrass"`, or `"hypersurface"`.
 
 The method attempts to match the given identifiers with a unique entry in the database. If no match is found, or if the information
 is ambiguous (i.e., multiple matches exist), an error is raised.
@@ -22,6 +23,7 @@ is ambiguous (i.e., multiple matches exist), an error is raised.
 Some literature models require additional input to be uniquely determined and constructed. For such cases, more optional arguments must be provided:
 
 * `model_parameters`: A dictionary specifying parameters needed to fix a model within a family, e.g. `Dict("k" => 5)`.
+* `model_sections`: A dictionary specifying model-section data required to construct certain models.
 * `defining_classes`: A dictionary specifying divisor classes necessary to fully define the geometry.
 * `base_space`: Optionally specify a concrete base over which the model should be constructed. Currently, only toric base spaces are supported.
 * `completeness_check`: Set this to `false` to skip time consuming completeness checks of the base geometry to gain more performance.

--- a/experimental/FTheoryTools/src/TateModels/constructors.jl
+++ b/experimental/FTheoryTools/src/TateModels/constructors.jl
@@ -3,7 +3,7 @@
 ################################################
 
 @doc raw"""
-    global_tate_model(base::NormalToricVariety; completeness_check::Bool = true, rng::AbstractRNG = Random.default_rng())
+    global_tate_model(base::NormalToricVariety; kwargs...)
 
 This method constructs a global Tate model over a given toric base
 3-fold. The Tate sections ``a_i`` are taken with (pseudo) random coefficients.
@@ -31,7 +31,7 @@ global_tate_model(
 )
 
 @doc raw"""
-    global_tate_model(base::NormalToricVariety, ais::Vector{T}; completeness_check::Bool = true) where {T<:MPolyRingElem}
+    global_tate_model(base::NormalToricVariety, ais::Vector{T}; kwargs...) where {T<:MPolyRingElem}
 
 This method operates analogously to `global_tate_model(base::NormalToricVarietyType)`.
 The only difference is that the Tate sections ``a_i`` can be specified with non-generic values.
@@ -122,7 +122,7 @@ function global_tate_model(base::NormalToricVariety,
 end
 
 @doc raw"""
-    global_tate_model_over_projective_space(d::Int; rng::AbstractRNG = Random.default_rng())
+    global_tate_model_over_projective_space(d::Int; kwargs...)
 
 Construct a global Tate model over the ``d``-dimensional projective space,
 represented as a toric variety. The Tate sections ``a_i`` are
@@ -143,7 +143,7 @@ global_tate_model_over_projective_space(d::Int; rng::AbstractRNG=Random.default_
   )
 
 @doc raw"""
-    global_tate_model_over_hirzebruch_surface(r::Int; rng::AbstractRNG = Random.default_rng())
+    global_tate_model_over_hirzebruch_surface(r::Int; kwargs...)
 
 Construct a global Tate model over the Hirzebruch surface ``F_r``,
 represented as a toric variety. The Tate sections ``a_i`` are
@@ -164,7 +164,7 @@ global_tate_model_over_hirzebruch_surface(r::Int; rng::AbstractRNG=Random.defaul
   )
 
 @doc raw"""
-    global_tate_model_over_del_pezzo_surface(b::Int; rng::AbstractRNG = Random.default_rng())
+    global_tate_model_over_del_pezzo_surface(b::Int; kwargs...)
 
 Construct a global Tate model over the del Pezzo surface ``\text{dP}_b``,
 represented as a toric variety. The Tate sections ``a_i`` are

--- a/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
@@ -3,7 +3,7 @@
 #####################################################################
 
 @doc raw"""
-    weierstrass_model(base::NormalToricVariety; completeness_check::Bool = true, rng::AbstractRNG = Random.default_rng())
+    weierstrass_model(base::NormalToricVariety; kwargs...)
 
 Construct a Weierstrass model over a given toric base space. The Weierstrass sections
 ``f`` and ``g`` are automatically generated with (pseudo)random coefficients. The random
@@ -32,7 +32,7 @@ function weierstrass_model(
 end
 
 @doc raw"""
-    weierstrass_model(base::NormalToricVariety, f::MPolyRingElem, g::MPolyRingElem; completeness_check::Bool = true)
+    weierstrass_model(base::NormalToricVariety, f::MPolyRingElem, g::MPolyRingElem; kwargs...)
 
 Construct a Weierstrass model over a given toric base space ``X``. The Weierstrass sections
 ``f`` and ``g`` are explicitly specified by the user as polynomials in the Cox ring of ``X``.
@@ -110,7 +110,7 @@ function weierstrass_model(base::NormalToricVariety,
 end
 
 @doc raw"""
-    weierstrass_model_over_projective_space(d::Int; rng::AbstractRNG = Random.default_rng())
+    weierstrass_model_over_projective_space(d::Int; kwargs...)
 
 Construct a Weierstrass model over the ``d``-dimensional projective space,
 represented as a toric variety. The Weierstrass sections ``f`` and ``g`` are
@@ -131,7 +131,7 @@ weierstrass_model_over_projective_space(d::Int; rng::AbstractRNG=Random.default_
   )
 
 @doc raw"""
-    weierstrass_model_over_hirzebruch_surface(r::Int; rng::AbstractRNG = Random.default_rng())
+    weierstrass_model_over_hirzebruch_surface(r::Int; kwargs...)
 
 Construct a Weierstrass model over the Hirzebruch surface ``F_r``,
 represented as a toric variety. The Weierstrass sections ``f`` and ``g`` are
@@ -152,7 +152,7 @@ weierstrass_model_over_hirzebruch_surface(r::Int; rng::AbstractRNG=Random.defaul
   )
 
 @doc raw"""
-    weierstrass_model_over_del_pezzo_surface(b::Int; rng::AbstractRNG = Random.default_rng())
+    weierstrass_model_over_del_pezzo_surface(b::Int; kwargs...)
 
 Construct a Weierstrass model over the del Pezzo surface ``\text{dP}_b``,
 represented as a toric variety. The Weierstrass sections ``f`` and ``g`` are


### PR DESCRIPTION
Keep docstring signatures concise and remove keyword arguments from Documenter method references, while retaining the keyword explanations within each function's doc string. This makes documentation references shorter and less likely to become stale.

Prepared with OpenAI Codex [codex@openai.com](mailto:codex@openai.com).