### PR TITLE
Add `graph_from_edge_orbits(::Type{T}, G::PermGroup, edges, n::Int=largest_moved_point(G)) where {T <: Union{Directed, Undirected}}`

### DIFF
--- a/docs/src/Combinatorics/graphs.md
+++ b/docs/src/Combinatorics/graphs.md
@@ -39,6 +39,7 @@ dual_graph(p::Polyhedron)
 vertex_edge_graph(p::Polyhedron; modulo_lineality=false)
 graph_from_adjacency_matrix
 graph_from_edges
+graph_from_edge_orbits
 graph_from_labeled_edges
 induced_subgraph
 ```

--- a/src/Combinatorics/Graphs/functions.jl
+++ b/src/Combinatorics/Graphs/functions.jl
@@ -2154,6 +2154,79 @@ function graph_from_edges(p::Polyhedron; modulo_lineality=false)
 end
 
 @doc raw"""
+    graph_from_edge_orbits(::Type{T}, G::PermGroup, edges, n::Int=largest_moved_point(G)) where {T <: Union{Directed, Undirected}}
+
+Return the graph of type `T` with vertex set `1:n` whose edge set is the union
+of the orbits of the edges in `edges` under the action of the permutation
+group `G` on ordered pairs, i.e. the set
+$\bigcup_{e \in edges} \{ [g(e_1), g(e_2)] : g \in G \}$.
+
+Here `edges` is either a single edge `[u, v]` or a list of edges
+`[[u, v], ...]`, where an edge is a pair of positive integers. The group `G`
+must fix the vertex set `1:n` setwise, and the vertices of the given edges
+must lie in `1:n`. In the undirected case, the pairs in the union of orbits
+are interpreted as undirected edges, and hence each edge occurs at most once.
+If `n` is not given, then the largest moved point of `G` is used.
+
+# Examples
+```jldoctest
+julia> G = @permutation_group(5, (1, 3), (1, 2)(3, 4));
+
+julia> D = graph_from_edge_orbits(Directed, G, [[1, 2], [4, 5]], 5)
+Directed graph with 5 nodes and the following edges:
+(1, 2)(1, 4)(1, 5)(2, 1)(2, 3)(2, 5)(3, 2)(3, 4)(3, 5)(4, 1)(4, 3)(4, 5)
+
+julia> outneighbors(D, 1)
+3-element Vector{Int64}:
+ 2
+ 4
+ 5
+
+julia> U = graph_from_edge_orbits(Undirected, G, [[1, 2], [4, 5]], 5)
+Undirected graph with 5 nodes and the following edges:
+(2, 1)(3, 2)(4, 1)(4, 3)(5, 1)(5, 2)(5, 3)(5, 4)
+
+julia> graph_from_edge_orbits(Directed, @permutation_group(3, ()), [3, 2])
+Directed graph with 0 nodes and no edges
+```
+"""
+function graph_from_edge_orbits(::Type{T},
+                                G::PermGroup,
+                                edges::Vector{Vector{Int}},
+                                n::Int=largest_moved_point(G)) where {T <: Union{Directed, Undirected}}
+  @req n >= 0 "n must be a non-negative integer"
+  n == 0 && return graph(T, 0)
+  @req !isempty(edges) "edges must be a nonempty list of pairs of positive integers"
+  @req all(e -> length(e) == 2 && all(>(0), e), edges) "edges must be a list of pairs of positive integers"
+  @req all(e -> all(<=(n), e), edges) "the vertices of the edges must be at most n"
+
+  Omega = gset(G, edges)
+  out = [Vector{Int}() for _ in 1:n]
+  for orb in orbits(Omega)
+    for e in orb
+      @req e[1] <= n && e[2] <= n "the orbit of the edge contains a vertex outside 1:$n"
+      push!(out[e[1]], e[2])
+    end
+  end
+
+  D = graph(T, n)
+  for i in 1:n
+    sort!(out[i])
+    for j in out[i]
+      add_edge!(D, i, j)
+    end
+  end
+  return D
+end
+
+function graph_from_edge_orbits(::Type{T},
+                                G::PermGroup,
+                                edge::Vector{Int},
+                                n::Int=largest_moved_point(G)) where {T <: Union{Directed, Undirected}}
+  return graph_from_edge_orbits(T, G, [edge], n)
+end
+
+@doc raw"""
     label!(G::Graph{T}, edge_labels::Union{Dict{Tuple{Int, Int}, Union{String, Int}}, Nothing}, vertex_labels::Union{Dict{Int, Union{String, Int}}, Nothing}=nothing; name::Symbol=:label) where {T <: Union{Directed, Undirected}}
 Given a graph `G`, add labels to the edges and optionally to the vertices with the given `name`.
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -739,6 +739,7 @@ export grading_group
 export graph
 export graph_curve
 export graph_from_adjacency_matrix
+export graph_from_edge_orbits
 export graph_from_edges
 export graph_from_labeled_edges
 export grassmann_pluecker_ideal

--- a/test/Combinatorics/Graph.jl
+++ b/test/Combinatorics/Graph.jl
@@ -496,4 +496,46 @@
       permute_nodes!(H, p)
       @test G.label[1, 3] == H.label[2, 3]
     end
+
+    @testset "graph_from_edge_orbits" begin
+      G = @permutation_group(5, (1, 3), (1, 2)(3, 4))
+      D = graph_from_edge_orbits(Directed, G, [[1, 2], [4, 5]], 5)
+      @test n_vertices(D) == 5
+      @test n_edges(D) == 12
+      @test [outneighbors(D, i) for i in 1:5] ==
+            [[2, 4, 5], [1, 3, 5], [2, 4, 5], [1, 3, 5], Int[]]
+
+      # the undirected version interprets the orbit pairs as undirected edges
+      U = graph_from_edge_orbits(Undirected, G, [[1, 2], [4, 5]], 5)
+      @test n_vertices(U) == 5
+      @test n_edges(U) == 8
+      @test has_edge(U, 1, 2) && has_edge(U, 2, 1)
+      @test has_edge(U, 4, 5)
+      @test !has_edge(U, 1, 3)
+
+      # a single edge is also accepted
+      D2 = graph_from_edge_orbits(Directed, @permutation_group(3, ()), [3, 2], 3)
+      @test n_vertices(D2) == 3
+      @test n_edges(D2) == 1
+      @test has_edge(D2, 3, 2)
+      @test !has_edge(D2, 2, 3)
+
+      # default n is the largest moved point
+      D3 = graph_from_edge_orbits(Directed, @permutation_group(3, ()), [3, 2])
+      @test n_vertices(D3) == 0
+      @test n_edges(D3) == 0
+
+      # the group may move points beyond n as long as 1:n is fixed setwise
+      G4 = @permutation_group(5, (1, 2), (2, 3), (4, 5))
+      D4 = graph_from_edge_orbits(Directed, G4, [[1, 2]], 3)
+      @test n_vertices(D4) == 3
+      @test n_edges(D4) == 6
+
+      # input checks
+      G5 = @permutation_group(3, ())
+      @test_throws ArgumentError graph_from_edge_orbits(Directed, G5, [[1, 2], [3, 6, 5]], 3)
+      @test_throws ArgumentError graph_from_edge_orbits(Directed, G5, [[1, 2], [3, -6]], 3)
+      @test_throws ArgumentError graph_from_edge_orbits(Directed, G5, [[1, 2], [3, 6]], -1)
+      @test_throws ArgumentError graph_from_edge_orbits(Directed, G5, [[1, 2], [3, 6]], 2)
+    end
 end


### PR DESCRIPTION
graph_from_edge_orbits(::Type{T}, G::PermGroup, edges, n::Int=largest_moved_point(G)) where {T <: Union{Directed, Undirected}}

Return the graph of type `T` with vertex set `1:n` whose edge set is the union
of the orbits of the edges in `edges` under the action of the permutation
group `G` on ordered pairs, i.e. the set
$\bigcup_{e \in edges} \{ [g(e_1), g(e_2)] : g \in G \}$.

Here `edges` is either a single edge `[u, v]` or a list of edges
`[[u, v], ...]`, where an edge is a pair of positive integers. The group `G`
must fix the vertex set `1:n` setwise, and the vertices of the given edges
must lie in `1:n`. In the undirected case, the pairs in the union of orbits
are interpreted as undirected edges, and hence each edge occurs at most once.
If `n` is not given, then the largest moved point of `G` is used.

# Examples
```jldoctest
julia> G = @permutation_group(5, (1, 3), (1, 2)(3, 4));

julia> D = graph_from_edge_orbits(Directed, G, [[1, 2], [4, 5]], 5)
Directed graph with 5 nodes and the following edges:
(1, 2)(1, 4)(1, 5)(2, 1)(2, 3)(2, 5)(3, 2)(3, 4)(3, 5)(4, 1)(4, 3)(4, 5)

julia> outneighbors(D, 1)
3-element Vector{Int64}:
 2
 4
 5

julia> U = graph_from_edge_orbits(Undirected, G, [[1, 2], [4, 5]], 5)
Undirected graph with 5 nodes and the following edges:
(2, 1)(3, 2)(4, 1)(4, 3)(5, 1)(5, 2)(5, 3)(5, 4)

julia> graph_from_edge_orbits(Directed, @permutation_group(3, ()), [3, 2])
Directed graph with 0 nodes and no edges
```