### PR TITLE
Add generation of invariant polynomials via orbit sums for permutation groups

### DIFF
--- a/src/InvariantTheory/fundamental_invariants.jl
+++ b/src/InvariantTheory/fundamental_invariants.jl
@@ -87,7 +87,9 @@ function fundamental_invariants_via_king(RG::FinGroupInvarRing, beta::Int=0)
       GO = collect(G)
     end
 
-    # There are two possible strategies to find new candidates in degree d
+    # If G is of type PermGroup, we generate invariants via orbit sums.
+    # Otherwise, here are two possible strategies to find new candidates in
+    # degree d:
     # 1) apply the Reynolds operator to monomials of R of degree d which are
     #    not divisible by any leading monomial in G.S (this is what [Kin13]
     #    proposes)
@@ -110,7 +112,11 @@ function fundamental_invariants_via_king(RG::FinGroupInvarRing, beta::Int=0)
     time_lin_alg = ngens(group(RG)) * length(monomials_of_degree(R, d))^2
     X = 1 / 2 * order(Int, group(RG)) # magical extra factor (see above)
 
-    if X * time_rey < time_lin_alg
+    if group(RG) isa PermGroup
+      # Orbit sums
+      @vprintln :FundamentalInvariants "Generating invariants via orbit sums"
+      invs = (_cast_in_internal_poly_ring(RG, f) for f in iterate_basis(RG, d, :orbit_sums))
+    elseif X * time_rey < time_lin_alg
       # Reynolds approach
       @vprintln :FundamentalInvariants "Generating invariants via Reynolds operator"
       invs = (

--- a/src/InvariantTheory/fundamental_invariants.jl
+++ b/src/InvariantTheory/fundamental_invariants.jl
@@ -52,7 +52,7 @@ function fundamental_invariants_via_king(RG::FinGroupInvarRing, beta::Int=0)
   while d <= dmax
     @vprintln :FundamentalInvariants "--------------------------------------------------------------"
     @vprintln :FundamentalInvariants "Current maximal degree: $dmax"
-    @vprintln :FundamentalInvariants "Checking degree: $d"
+    @vprintln :FundamentalInvariants "Working in degree: $d"
     @vprintln :FundamentalInvariants "Number of invariants found: $(length(S))"
     if length(S) >= ngens(R) && total_degree(S[end]) == d - 2
       # We haven't added any invariants in the last round, so there is a chance
@@ -115,7 +115,9 @@ function fundamental_invariants_via_king(RG::FinGroupInvarRing, beta::Int=0)
     if group(RG) isa PermGroup
       # Orbit sums
       @vprintln :FundamentalInvariants "Generating invariants via orbit sums"
-      invs = (_cast_in_internal_poly_ring(RG, f) for f in iterate_basis(RG, d, :orbit_sums))
+      exps = [AbstractAlgebra.exponent_vector(m, 1) for m in mons]
+      mon_orbits = orbits(gset(group(RG), permuted, exps))
+      invs = (Rgraded([one(coefficient_ring(RG)) for _ in 1:length(orb)], elements(orb)) for orb in mon_orbits)
     elseif X * time_rey < time_lin_alg
       # Reynolds approach
       @vprintln :FundamentalInvariants "Generating invariants via Reynolds operator"

--- a/src/InvariantTheory/fundamental_invariants.jl
+++ b/src/InvariantTheory/fundamental_invariants.jl
@@ -50,6 +50,10 @@ function fundamental_invariants_via_king(RG::FinGroupInvarRing, beta::Int=0)
   d = 1
   gb_is_full = true # whether we have a full or truncated Gröbner basis
   while d <= dmax
+    @vprintln :FundamentalInvariants "--------------------------------------------------------------"
+    @vprintln :FundamentalInvariants "Current maximal degree: $dmax"
+    @vprintln :FundamentalInvariants "Checking degree: $d"
+    @vprintln :FundamentalInvariants "Number of invariants found: $(length(S))"
     if length(S) >= ngens(R) && total_degree(S[end]) == d - 2
       # We haven't added any invariants in the last round, so there is a chance
       # that we are done.
@@ -57,10 +61,13 @@ function fundamental_invariants_via_king(RG::FinGroupInvarRing, beta::Int=0)
       # can save many truncated Gröbner bases if we don't add any new invariants
       # in the following rounds.
       I = ideal(R, GO)
+      @vprint :FundamentalInvariants "Computing full Gröbner basis..."
       GO = gens(groebner_basis(I; ordering=ordR))
+      @vprintln :FundamentalInvariants " done."
       if is_zero(dim(I))
         mons = gens(ideal(R, Singular.kbase(I.gb[ordR].gensBiPolyArray.S)))
         dmax = maximum(total_degree(f) for f in mons)
+        @vprintln :FundamentalInvariants "Ideal is 0-dimensional! New maximal degree: $dmax"
         d > dmax ? break : nothing
       end
       G = I.gb[ordR]
@@ -74,7 +81,9 @@ function fundamental_invariants_via_king(RG::FinGroupInvarRing, beta::Int=0)
 
     if !gb_is_full
       # We don't have a full Gröbner basis, so we compute a degree truncated one.
+      @vprint :FundamentalInvariants "Computing truncated Gröbner basis up to degree $d..."
       G = _groebner_basis(ideal(R, GO), d; ordering=ordR)
+      @vprintln :FundamentalInvariants " done."
       GO = collect(G)
     end
 
@@ -103,6 +112,7 @@ function fundamental_invariants_via_king(RG::FinGroupInvarRing, beta::Int=0)
 
     if X * time_rey < time_lin_alg
       # Reynolds approach
+      @vprintln :FundamentalInvariants "Generating invariants via Reynolds operator"
       invs = (
         _cast_in_internal_poly_ring(
           RG, reynolds_operator(RG, _cast_in_external_poly_ring(RG, Rgraded(m)))
@@ -110,6 +120,7 @@ function fundamental_invariants_via_king(RG::FinGroupInvarRing, beta::Int=0)
       )
     else
       # Linear algebra approach
+      @vprintln :FundamentalInvariants "Generating invariants via linear algebra"
       invs = (
         _cast_in_internal_poly_ring(RG, f) for f in iterate_basis(RG, d, :linear_algebra)
       )
@@ -125,6 +136,8 @@ function fundamental_invariants_via_king(RG::FinGroupInvarRing, beta::Int=0)
       if is_zero(g)
         continue
       end
+
+      @vprintln :FundamentalInvariants "Adding an invariant of degree $d"
 
       push!(S, f)
       push!(GO, g)

--- a/src/InvariantTheory/fundamental_invariants.jl
+++ b/src/InvariantTheory/fundamental_invariants.jl
@@ -88,7 +88,7 @@ function fundamental_invariants_via_king(RG::FinGroupInvarRing, beta::Int=0)
     end
 
     # If G is of type PermGroup, we generate invariants via orbit sums.
-    # Otherwise, here are two possible strategies to find new candidates in
+    # Otherwise, there are two possible strategies to find new candidates in
     # degree d:
     # 1) apply the Reynolds operator to monomials of R of degree d which are
     #    not divisible by any leading monomial in G.S (this is what [Kin13]
@@ -117,7 +117,10 @@ function fundamental_invariants_via_king(RG::FinGroupInvarRing, beta::Int=0)
       @vprintln :FundamentalInvariants "Generating invariants via orbit sums"
       exps = [AbstractAlgebra.exponent_vector(m, 1) for m in mons]
       mon_orbits = orbits(gset(group(RG), permuted, exps))
-      invs = (Rgraded([one(coefficient_ring(RG)) for _ in 1:length(orb)], elements(orb)) for orb in mon_orbits)
+      invs = (
+        Rgraded([one(coefficient_ring(RG)) for _ in 1:length(orb)], elements(orb)) for
+        orb in mon_orbits
+      )
     elseif X * time_rey < time_lin_alg
       # Reynolds approach
       @vprintln :FundamentalInvariants "Generating invariants via Reynolds operator"

--- a/src/InvariantTheory/fundamental_invariants.jl
+++ b/src/InvariantTheory/fundamental_invariants.jl
@@ -100,17 +100,13 @@ function fundamental_invariants_via_king(RG::FinGroupInvarRing, beta::Int=0)
     # However, experience shows that we have to add a generous 1/2*|G| to the
     # Reynolds operator runtime to get closer to reality.
 
-    # Compute the monomials which would be input for the Reynolds operator
+    # Compute the monomials which would be input for the Reynolds operator or
+    # orbit sums
     # TODO: Properly wrap kbase (or reimplement it; an iterator would be lovely)
     mons = gens(ideal(R, Singular.kbase(singular_generators(G), d)))
     if isempty(mons) || (length(mons) == 1 && is_zero(mons[1]))
       break
     end
-
-    # Runtime estimates, see [KS99, Section17.2]
-    time_rey = length(mons) * d * order(group(RG))
-    time_lin_alg = ngens(group(RG)) * length(monomials_of_degree(R, d))^2
-    X = 1 / 2 * order(Int, group(RG)) # magical extra factor (see above)
 
     if group(RG) isa PermGroup
       # Orbit sums
@@ -121,20 +117,30 @@ function fundamental_invariants_via_king(RG::FinGroupInvarRing, beta::Int=0)
         Rgraded([one(coefficient_ring(RG)) for _ in 1:length(orb)], elements(orb)) for
         orb in mon_orbits
       )
-    elseif X * time_rey < time_lin_alg
-      # Reynolds approach
-      @vprintln :FundamentalInvariants "Generating invariants via Reynolds operator"
-      invs = (
-        _cast_in_internal_poly_ring(
-          RG, reynolds_operator(RG, _cast_in_external_poly_ring(RG, Rgraded(m)))
-        ) for m in mons
-      )
     else
-      # Linear algebra approach
-      @vprintln :FundamentalInvariants "Generating invariants via linear algebra"
-      invs = (
-        _cast_in_internal_poly_ring(RG, f) for f in iterate_basis(RG, d, :linear_algebra)
-      )
+      # We don't have a PermGroup, so we need to use either the Reynolds
+      # operator or linear algebra
+
+      # Runtime estimates, see [KS99, Section17.2]
+      time_rey = length(mons) * d * order(group(RG))
+      time_lin_alg = ngens(group(RG)) * length(monomials_of_degree(R, d))^2
+      X = 1 / 2 * order(Int, group(RG)) # magical extra factor (see above)
+
+      if X * time_rey < time_lin_alg
+        # Reynolds approach
+        @vprintln :FundamentalInvariants "Generating invariants via Reynolds operator"
+        invs = (
+                _cast_in_internal_poly_ring(
+                                            RG, reynolds_operator(RG, _cast_in_external_poly_ring(RG, Rgraded(m)))
+                                           ) for m in mons
+               )
+      else
+        # Linear algebra approach
+        @vprintln :FundamentalInvariants "Generating invariants via linear algebra"
+        invs = (
+                _cast_in_internal_poly_ring(RG, f) for f in iterate_basis(RG, d, :linear_algebra)
+               )
+      end
     end
 
     for m in invs

--- a/src/InvariantTheory/fundamental_invariants.jl
+++ b/src/InvariantTheory/fundamental_invariants.jl
@@ -130,16 +130,16 @@ function fundamental_invariants_via_king(RG::FinGroupInvarRing, beta::Int=0)
         # Reynolds approach
         @vprintln :FundamentalInvariants "Generating invariants via Reynolds operator"
         invs = (
-                _cast_in_internal_poly_ring(
-                                            RG, reynolds_operator(RG, _cast_in_external_poly_ring(RG, Rgraded(m)))
-                                           ) for m in mons
-               )
+          _cast_in_internal_poly_ring(
+            RG, reynolds_operator(RG, _cast_in_external_poly_ring(RG, Rgraded(m)))
+          ) for m in mons
+        )
       else
         # Linear algebra approach
         @vprintln :FundamentalInvariants "Generating invariants via linear algebra"
         invs = (
-                _cast_in_internal_poly_ring(RG, f) for f in iterate_basis(RG, d, :linear_algebra)
-               )
+          _cast_in_internal_poly_ring(RG, f) for f in iterate_basis(RG, d, :linear_algebra)
+        )
       end
     end
 

--- a/src/InvariantTheory/invariant_rings.jl
+++ b/src/InvariantTheory/invariant_rings.jl
@@ -431,6 +431,7 @@ Given an invariant ring `IR` and an integer `d`, return a basis for the invarian
 The optional argument `algorithm` specifies the algorithm to be used.
 If `algorithm = :reynolds`, the Reynolds operator is utilized (this method is only available in the non-modular case).
 Setting `algorithm = :linear_algebra` means that plain linear algebra is used.
+With `algorithm = :orbit_sums`, the invariants are constructed as sums of orbits of monomials; this is only possible if the underlying group is of type `PermGroup`.
 The default option `algorithm = :default` asks to select the heuristically best algorithm.
 
 See also [`iterate_basis`](@ref).

--- a/src/InvariantTheory/invariant_rings.jl
+++ b/src/InvariantTheory/invariant_rings.jl
@@ -637,7 +637,9 @@ end
 @doc raw"""
     molien_series([S::PolyRing], I::FinGroupInvarRing, [chi::GAPGroupClassFunction])
 
-In the non-modular case, return the Molien series of `I` as a rational function.
+Return the Molien series of `I` as a rational function.
+This function is implemented in the non-modular case or if `group(I)` is of type
+`PermGroup`.
 
 If a univariate polynomial ring with rational coefficients is specified by the
 optional argument `S::PolyRing`, then return the Molien series as an element
@@ -702,6 +704,10 @@ function molien_series(
 
   if characteristic(coefficient_ring(I)) == 0 && chi === nothing
     return _molien_series_char0(S, I)
+  elseif group(I) isa PermGroup && chi === nothing
+    # For a group permuting a basis, we can just pretend we are in characteristic 0
+    I0 = invariant_ring(QQ, group(I))
+    return _molien_series_char0(S, I0)
   else
     if !is_modular(I)
       return _molien_series_nonmodular_via_gap(S, I, chi)
@@ -728,8 +734,8 @@ end
 
 # There are some situations where one needs to know whether one can ask for the
 # Molien series without throwing an error.
-# And maybe some day we can also compute Molien series in some modular cases.
 is_molien_series_implemented(I::FinGroupInvarRing) = !is_modular(I)
+is_molien_series_implemented(I::FinGroupInvarRing{<:Any, <:PermGroup}) = true
 
 ################################################################################
 #

--- a/src/InvariantTheory/invariant_rings.jl
+++ b/src/InvariantTheory/invariant_rings.jl
@@ -735,7 +735,7 @@ end
 # There are some situations where one needs to know whether one can ask for the
 # Molien series without throwing an error.
 is_molien_series_implemented(I::FinGroupInvarRing) = !is_modular(I)
-is_molien_series_implemented(I::FinGroupInvarRing{<:Any, <:PermGroup}) = true
+is_molien_series_implemented(I::FinGroupInvarRing{<:Any,<:PermGroup}) = true
 
 ################################################################################
 #

--- a/src/InvariantTheory/invariant_rings.jl
+++ b/src/InvariantTheory/invariant_rings.jl
@@ -638,8 +638,8 @@ end
     molien_series([S::PolyRing], I::FinGroupInvarRing, [chi::GAPGroupClassFunction])
 
 Return the Molien series of `I` as a rational function.
-This function is implemented in the non-modular case or if `group(I)` is of type
-`PermGroup`.
+This function is implemented in the non-modular case or, if no `chi` is given,
+if `group(I)` is of type `PermGroup`.
 
 If a univariate polynomial ring with rational coefficients is specified by the
 optional argument `S::PolyRing`, then return the Molien series as an element

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -409,18 +409,19 @@ end
 function iterate_basis_orbit_sums(R::FinGroupInvarRing{T, <:PermGroup}, d::Int) where T
   @assert d >= 0 "Degree must be non-negative"
 
-  mons = monomials_of_degree(polynomial_ring(R), d)
-  exps = [AbstractAlgebra.exponent_vector(m, 1) for m in mons]
+  S = polynomial_ring(R)
+  # Generate all exponent vectors of monomials of degree d
+  exps = data.(collect(weak_compositions(d, ngens(S), inplace = false)))
 
   mon_orbits = orbits(gset(group(R), permuted, exps))
 
   k = length(mon_orbits)
-  N = zero_matrix(base_ring(polynomial_ring(R)), 0, 0)
+  N = zero_matrix(base_ring(S), 0, 0)
 
   return FinGroupInvarRingBasisIterator{
-                                        typeof(R),Nothing,typeof(mons),eltype(mons),typeof(N), typeof(mon_orbits)
+                                        typeof(R),Nothing,Nothing,elem_type(S),typeof(N), typeof(mon_orbits)
   }(
-    R, d, k, :orbit_sums, nothing, mons, Vector{eltype(mons)}(), N, mon_orbits
+    R, d, k, :orbit_sums, nothing, nothing, elem_type(S)[], N, mon_orbits
   )
 end
 

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -572,12 +572,10 @@ function iterate_orbit_sums(BI::FinGroupInvarRingBasisIterator, state::Union{Int
   end
 
   R = polynomial_ring(BI.R)
-  oneK = one(coefficient_ring(R))
-  F = MPolyBuildCtx(R)
-  for t in BI.orbits[s]
-    push_term!(F, oneK, t)
-  end
-  return finish(F), s + 1
+  K = coefficient_ring(R)
+  orb = elements(BI.orbits[s])
+  f = R([one(K) for _ in 1:length(orb)], orb)
+  return f, s + 1
 end
 
 ################################################################################

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -331,7 +331,7 @@ function iterate_basis_reynolds(
   return FinGroupInvarRingBasisIterator{
     typeof(R),typeof(reynolds),typeof(monomials),eltype(monomials),typeof(N)
   }(
-    R, d, k, true, reynolds, monomials, Vector{eltype(monomials)}(), N
+    R, d, k, :reynolds, reynolds, monomials, Vector{eltype(monomials)}(), N
   )
 end
 
@@ -349,7 +349,7 @@ function iterate_basis_linear_algebra(IR::FinGroupInvarRing, d::Int)
     return FinGroupInvarRingBasisIterator{
       typeof(IR),Nothing,typeof(dummy_mons),eltype(mons),typeof(N)
     }(
-      IR, d, k, false, nothing, dummy_mons, mons, N
+      IR, d, k, :linear_algebra, nothing, dummy_mons, mons, N
     )
   end
 
@@ -361,7 +361,7 @@ function iterate_basis_linear_algebra(IR::FinGroupInvarRing, d::Int)
     return FinGroupInvarRingBasisIterator{
       typeof(IR),Nothing,typeof(mons_iterator),eltype(mons),typeof(N)
     }(
-      IR, d, k, false, nothing, mons_iterator, mons, N
+      IR, d, k, :linear_algebra, nothing, mons_iterator, mons, N
     )
   end
 
@@ -397,7 +397,7 @@ function iterate_basis_linear_algebra(IR::FinGroupInvarRing, d::Int)
   return FinGroupInvarRingBasisIterator{
     typeof(IR),Nothing,typeof(mons_iterator),eltype(mons),typeof(N)
   }(
-    IR, d, ncols(N), false, nothing, mons_iterator, mons, N
+    IR, d, ncols(N), :linear_algebra, nothing, mons_iterator, mons, N
   )
 end
 
@@ -432,21 +432,21 @@ function Base.show(io::IO, BI::FinGroupInvarRingBasisIterator)
 end
 
 function Base.iterate(BI::FinGroupInvarRingBasisIterator)
-  if BI.reynolds
+  if BI.method === :reynolds
     return iterate_reynolds(BI)
   end
   return iterate_linear_algebra(BI)
 end
 
 function Base.iterate(BI::FinGroupInvarRingBasisIterator, state)
-  if BI.reynolds
+  if BI.method === :reynolds
     return iterate_reynolds(BI, state)
   end
   return iterate_linear_algebra(BI, state)
 end
 
 function iterate_reynolds(BI::FinGroupInvarRingBasisIterator)
-  @assert BI.reynolds
+  @assert BI.method === :reynolds
   if BI.dim == 0
     return nothing
   end
@@ -477,7 +477,7 @@ function iterate_reynolds(BI::FinGroupInvarRingBasisIterator)
 end
 
 function iterate_reynolds(BI::FinGroupInvarRingBasisIterator, state)
-  @assert BI.reynolds
+  @assert BI.method === :reynolds
 
   B = state[1]
   monomial_state = state[2]
@@ -511,7 +511,7 @@ function iterate_reynolds(BI::FinGroupInvarRingBasisIterator, state)
 end
 
 function iterate_linear_algebra(BI::FinGroupInvarRingBasisIterator)
-  @assert !BI.reynolds
+  @assert BI.method === :linear_algebra
   if BI.dim == 0
     return nothing
   end
@@ -533,7 +533,7 @@ function iterate_linear_algebra(BI::FinGroupInvarRingBasisIterator)
 end
 
 function iterate_linear_algebra(BI::FinGroupInvarRingBasisIterator, state::Int)
-  @assert !BI.reynolds
+  @assert BI.method === :linear_algebra
   if state > BI.dim
     return nothing
   end

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -143,10 +143,11 @@ for the invariants in degree `d`.
 The optional argument `algorithm` specifies the algorithm to be used.
 If `algorithm = :reynolds`, the Reynolds operator is utilized (this method is only available in the non-modular case).
 Setting `algorithm = :linear_algebra` means that plain linear algebra is used.
+With `algorithm = :orbit_sums`, the invariants are constructed as sums of orbits of monomials; this is only possible if the underlying group is of type `PermGroup`.
 The default option `algorithm = :default` asks to select the heuristically best algorithm.
 
 When using the Reynolds operator, the basis is constructed element-by-element.
-With linear algebra, this is not possible and the basis will be constructed
+With linear algebra or orbit sums, this is not possible and the basis will be constructed
 all at once when calling the function.
 
 See also [`basis`](@ref).

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -212,7 +212,9 @@ function iterate_basis(R::FinGroupInvarRing, d::Int, algorithm::Symbol=:default)
   @assert d >= 0 "Degree must be non-negative"
 
   if algorithm == :default
-    if is_modular(R)
+    if group(R) isa PermGroup
+      algorithm = :orbit_sums
+    elseif is_modular(R)
       algorithm = :linear_algebra
     else
       # Use the estimate in KS99, Section 17.2
@@ -236,10 +238,12 @@ function iterate_basis(R::FinGroupInvarRing, d::Int, algorithm::Symbol=:default)
     end
   end
 
-  if algorithm == :reynolds
+  if algorithm === :reynolds
     return iterate_basis_reynolds(R, d)
-  elseif algorithm == :linear_algebra
+  elseif algorithm === :linear_algebra
     return iterate_basis_linear_algebra(R, d)
+  elseif algorithm === :orbit_sums
+    return iterate_basis_orbit_sums(R, d)
   else
     error("Unsupported argument :$(algorithm) for algorithm")
   end
@@ -329,9 +333,9 @@ function iterate_basis_reynolds(
   N = zero_matrix(base_ring(polynomial_ring(R)), 0, 0)
 
   return FinGroupInvarRingBasisIterator{
-    typeof(R),typeof(reynolds),typeof(monomials),eltype(monomials),typeof(N)
+    typeof(R),typeof(reynolds),typeof(monomials),eltype(monomials),typeof(N), Nothing
   }(
-    R, d, k, :reynolds, reynolds, monomials, Vector{eltype(monomials)}(), N
+    R, d, k, :reynolds, reynolds, monomials, Vector{eltype(monomials)}(), N, nothing
   )
 end
 
@@ -347,9 +351,9 @@ function iterate_basis_linear_algebra(IR::FinGroupInvarRing, d::Int)
     mons = elem_type(R)[]
     dummy_mons = monomials_of_degree(R, 0)
     return FinGroupInvarRingBasisIterator{
-      typeof(IR),Nothing,typeof(dummy_mons),eltype(mons),typeof(N)
+      typeof(IR),Nothing,typeof(dummy_mons),eltype(mons),typeof(N),Nothing
     }(
-      IR, d, k, :linear_algebra, nothing, dummy_mons, mons, N
+      IR, d, k, :linear_algebra, nothing, dummy_mons, mons, N, nothing
     )
   end
 
@@ -359,9 +363,9 @@ function iterate_basis_linear_algebra(IR::FinGroupInvarRing, d::Int)
     N = identity_matrix(base_ring(R), 1)
     dummy_mons = monomials_of_degree(R, 0)
     return FinGroupInvarRingBasisIterator{
-      typeof(IR),Nothing,typeof(mons_iterator),eltype(mons),typeof(N)
+      typeof(IR),Nothing,typeof(mons_iterator),eltype(mons),typeof(N), Nothing
     }(
-      IR, d, k, :linear_algebra, nothing, mons_iterator, mons, N
+      IR, d, k, :linear_algebra, nothing, mons_iterator, mons, N, nothing
     )
   end
 
@@ -395,19 +399,38 @@ function iterate_basis_linear_algebra(IR::FinGroupInvarRing, d::Int)
   N = kernel(M; side=:right)
 
   return FinGroupInvarRingBasisIterator{
-    typeof(IR),Nothing,typeof(mons_iterator),eltype(mons),typeof(N)
+    typeof(IR),Nothing,typeof(mons_iterator),eltype(mons),typeof(N), Nothing
   }(
-    IR, d, ncols(N), :linear_algebra, nothing, mons_iterator, mons, N
+    IR, d, ncols(N), :linear_algebra, nothing, mons_iterator, mons, N, nothing
   )
 end
+
+function iterate_basis_orbit_sums(R::FinGroupInvarRing{T, <:PermGroup}, d::Int) where T
+  @assert d >= 0 "Degree must be non-negative"
+
+  mons = monomials_of_degree(polynomial_ring(R), d)
+  exps = [AbstractAlgebra.exponent_vector(m, 1) for m in mons]
+
+  mon_orbits = orbits(gset(group(R), permuted, exps))
+
+  k = length(mon_orbits)
+  N = zero_matrix(base_ring(polynomial_ring(R)), 0, 0)
+
+  return FinGroupInvarRingBasisIterator{
+                                        typeof(R),Nothing,typeof(mons),eltype(mons),typeof(N), typeof(mon_orbits)
+  }(
+    R, d, k, :orbit_sums, nothing, mons, Vector{eltype(mons)}(), N, mon_orbits
+  )
+end
+
 
 Base.eltype(
   ::Type{
     <:FinGroupInvarRingBasisIterator{
-      FinGroupInvarRingT,ReynoldsT,IteratorT,PolyRingElemT,MatrixT
+      FinGroupInvarRingT,ReynoldsT,IteratorT,PolyRingElemT
     },
   },
-) where {FinGroupInvarRingT,ReynoldsT,IteratorT,PolyRingElemT,MatrixT} = PolyRingElemT
+) where {FinGroupInvarRingT,ReynoldsT,IteratorT,PolyRingElemT} = PolyRingElemT
 
 Base.length(BI::FinGroupInvarRingBasisIterator) = BI.dim
 
@@ -434,15 +457,21 @@ end
 function Base.iterate(BI::FinGroupInvarRingBasisIterator)
   if BI.method === :reynolds
     return iterate_reynolds(BI)
+  elseif BI.method === :linear_algebra
+    return iterate_linear_algebra(BI)
+  else
+    return iterate_orbit_sums(BI)
   end
-  return iterate_linear_algebra(BI)
 end
 
 function Base.iterate(BI::FinGroupInvarRingBasisIterator, state)
   if BI.method === :reynolds
     return iterate_reynolds(BI, state)
+  elseif BI.method === :linear_algebra
+    return iterate_linear_algebra(BI, state)
+  else
+    return iterate_orbit_sums(BI, state)
   end
-  return iterate_linear_algebra(BI, state)
 end
 
 function iterate_reynolds(BI::FinGroupInvarRingBasisIterator)
@@ -549,6 +578,22 @@ function iterate_linear_algebra(BI::FinGroupInvarRingBasisIterator, state::Int)
   # Cancelling the leading coefficient is not mathematically necessary and
   # should be done with the ordering that is used for the printing
   return inv(AbstractAlgebra.leading_coefficient(f)) * f, state + 1
+end
+
+function iterate_orbit_sums(BI::FinGroupInvarRingBasisIterator, state::Union{Int, Nothing} = nothing)
+  @assert BI.method === :orbit_sums
+  s = isnothing(state) ? 1 : state
+  if s > BI.dim
+    return nothing
+  end
+
+  R = polynomial_ring(BI.R)
+  oneK = one(coefficient_ring(R))
+  F = MPolyBuildCtx(R)
+  for t in BI.orbits[s]
+    push_term!(F, oneK, t)
+  end
+  return finish(F), s + 1
 end
 
 ################################################################################

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -539,45 +539,27 @@ function iterate_reynolds(BI::FinGroupInvarRingBasisIterator, state)
   end
 end
 
-function iterate_linear_algebra(BI::FinGroupInvarRingBasisIterator)
+function iterate_linear_algebra(BI::FinGroupInvarRingBasisIterator, state::Union{Int, Nothing} = nothing)
   @assert BI.method === :linear_algebra
-  if BI.dim == 0
+  s = isnothing(state) ? 1 : state
+  if s > BI.dim
     return nothing
   end
 
   f = polynomial_ring(BI.R)()
   N = BI.kernel
   for i in 1:nrows(N)
-    if iszero(N[i, 1])
+    if iszero(N[i, s])
       continue
     end
-    f += N[i, 1] * BI.monomials_collected[i]
+    f += N[i, s] * BI.monomials_collected[i]
   end
   # Have to (should...) divide by the leading coefficient again:
   # The matrix was in echelon form, but the columns were not necessarily sorted
   # w.r.t. the monomial ordering.
   # Cancelling the leading coefficient is not mathematically necessary and
   # should be done with the ordering that is used for the printing
-  return inv(AbstractAlgebra.leading_coefficient(f)) * f, 2
-end
-
-function iterate_linear_algebra(BI::FinGroupInvarRingBasisIterator, state::Int)
-  @assert BI.method === :linear_algebra
-  if state > BI.dim
-    return nothing
-  end
-
-  f = polynomial_ring(BI.R)()
-  N = BI.kernel
-  for i in 1:nrows(N)
-    if iszero(N[i, state])
-      continue
-    end
-    f += N[i, state] * BI.monomials_collected[i]
-  end
-  # Cancelling the leading coefficient is not mathematically necessary and
-  # should be done with the ordering that is used for the printing
-  return inv(AbstractAlgebra.leading_coefficient(f)) * f, state + 1
+  return inv(AbstractAlgebra.leading_coefficient(f)) * f, s + 1
 end
 
 function iterate_orbit_sums(BI::FinGroupInvarRingBasisIterator, state::Union{Int, Nothing} = nothing)

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -334,7 +334,7 @@ function iterate_basis_reynolds(
   N = zero_matrix(base_ring(polynomial_ring(R)), 0, 0)
 
   return FinGroupInvarRingBasisIterator{
-    typeof(R),typeof(reynolds),typeof(monomials),eltype(monomials),typeof(N), Nothing
+    typeof(R),typeof(reynolds),typeof(monomials),eltype(monomials),typeof(N),Nothing
   }(
     R, d, k, :reynolds, reynolds, monomials, Vector{eltype(monomials)}(), N, nothing
   )
@@ -364,7 +364,7 @@ function iterate_basis_linear_algebra(IR::FinGroupInvarRing, d::Int)
     N = identity_matrix(base_ring(R), 1)
     dummy_mons = monomials_of_degree(R, 0)
     return FinGroupInvarRingBasisIterator{
-      typeof(IR),Nothing,typeof(mons_iterator),eltype(mons),typeof(N), Nothing
+      typeof(IR),Nothing,typeof(mons_iterator),eltype(mons),typeof(N),Nothing
     }(
       IR, d, k, :linear_algebra, nothing, mons_iterator, mons, N, nothing
     )
@@ -400,18 +400,18 @@ function iterate_basis_linear_algebra(IR::FinGroupInvarRing, d::Int)
   N = kernel(M; side=:right)
 
   return FinGroupInvarRingBasisIterator{
-    typeof(IR),Nothing,typeof(mons_iterator),eltype(mons),typeof(N), Nothing
+    typeof(IR),Nothing,typeof(mons_iterator),eltype(mons),typeof(N),Nothing
   }(
     IR, d, ncols(N), :linear_algebra, nothing, mons_iterator, mons, N, nothing
   )
 end
 
-function iterate_basis_orbit_sums(R::FinGroupInvarRing{T, <:PermGroup}, d::Int) where T
+function iterate_basis_orbit_sums(R::FinGroupInvarRing{T,<:PermGroup}, d::Int) where {T}
   @assert d >= 0 "Degree must be non-negative"
 
   S = polynomial_ring(R)
   # Generate all exponent vectors of monomials of degree d
-  exps = data.(collect(weak_compositions(d, ngens(S), inplace = false)))
+  exps = data.(collect(weak_compositions(d, ngens(S); inplace=false)))
 
   mon_orbits = orbits(gset(group(R), permuted, exps))
 
@@ -419,12 +419,11 @@ function iterate_basis_orbit_sums(R::FinGroupInvarRing{T, <:PermGroup}, d::Int) 
   N = zero_matrix(base_ring(S), 0, 0)
 
   return FinGroupInvarRingBasisIterator{
-                                        typeof(R),Nothing,Nothing,elem_type(S),typeof(N), typeof(mon_orbits)
+    typeof(R),Nothing,Nothing,elem_type(S),typeof(N),typeof(mon_orbits)
   }(
     R, d, k, :orbit_sums, nothing, nothing, elem_type(S)[], N, mon_orbits
   )
 end
-
 
 Base.eltype(
   ::Type{
@@ -541,7 +540,9 @@ function iterate_reynolds(BI::FinGroupInvarRingBasisIterator, state)
   end
 end
 
-function iterate_linear_algebra(BI::FinGroupInvarRingBasisIterator, state::Union{Int, Nothing} = nothing)
+function iterate_linear_algebra(
+  BI::FinGroupInvarRingBasisIterator, state::Union{Int,Nothing}=nothing
+)
   @assert BI.method === :linear_algebra
   s = isnothing(state) ? 1 : state
   if s > BI.dim
@@ -564,7 +565,9 @@ function iterate_linear_algebra(BI::FinGroupInvarRingBasisIterator, state::Union
   return inv(AbstractAlgebra.leading_coefficient(f)) * f, s + 1
 end
 
-function iterate_orbit_sums(BI::FinGroupInvarRingBasisIterator, state::Union{Int, Nothing} = nothing)
+function iterate_orbit_sums(
+  BI::FinGroupInvarRingBasisIterator, state::Union{Int,Nothing}=nothing
+)
   @assert BI.method === :orbit_sums
   s = isnothing(state) ? 1 : state
   if s > BI.dim

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -244,6 +244,7 @@ function iterate_basis(R::FinGroupInvarRing, d::Int, algorithm::Symbol=:default)
   elseif algorithm === :linear_algebra
     return iterate_basis_linear_algebra(R, d)
   elseif algorithm === :orbit_sums
+    @req group(R) isa PermGroup "The underlying group must be of type PermGroup for orbit sums"
     return iterate_basis_orbit_sums(R, d)
   else
     error("Unsupported argument :$(algorithm) for algorithm")

--- a/src/InvariantTheory/iterators.jl
+++ b/src/InvariantTheory/iterators.jl
@@ -413,6 +413,9 @@ function iterate_basis_orbit_sums(R::FinGroupInvarRing{T,<:PermGroup}, d::Int) w
   # Generate all exponent vectors of monomials of degree d
   exps = data.(collect(weak_compositions(d, ngens(S); inplace=false)))
 
+  # Make the output "more" deterministic by sorting; helps the book tests
+  sort!(exps; by=maximum)
+
   mon_orbits = orbits(gset(group(R), permuted, exps))
 
   k = length(mon_orbits)

--- a/src/InvariantTheory/types.jl
+++ b/src/InvariantTheory/types.jl
@@ -158,13 +158,13 @@ struct AllMonomials{PolyRingT}
 end
 
 struct FinGroupInvarRingBasisIterator{
-  FinGroupInvarRingT,ReynoldsT,IteratorT,PolyRingElemT,MatrixT
+  FinGroupInvarRingT,ReynoldsT,IteratorT,PolyRingElemT,MatrixT,OrbitsT
 }
   R::FinGroupInvarRingT
   degree::Int
   dim::Int
 
-  # method can be :reynolds or :linear_algebra
+  # method can be :reynolds, :linear_algebra or :orbit_sums
   method::Symbol
 
   # If we compute the basis twisted by a character, we cache the operator here
@@ -174,6 +174,8 @@ struct FinGroupInvarRingBasisIterator{
   monomials::IteratorT
   monomials_collected::Vector{PolyRingElemT}
   kernel::MatrixT # used if method == :linear_algebra
+
+  orbits::OrbitsT # used if method == :orbit_sums
 end
 
 abstract type VectorSpaceIterator{FieldT,IteratorT,ElemT} end

--- a/src/InvariantTheory/types.jl
+++ b/src/InvariantTheory/types.jl
@@ -163,7 +163,9 @@ struct FinGroupInvarRingBasisIterator{
   R::FinGroupInvarRingT
   degree::Int
   dim::Int
-  reynolds::Bool
+
+  # method can be :reynolds or :linear_algebra
+  method::Symbol
 
   # If we compute the basis twisted by a character, we cache the operator here
   # instead of in the invariant ring. Otherwise this is `nothing`.
@@ -171,7 +173,7 @@ struct FinGroupInvarRingBasisIterator{
 
   monomials::IteratorT
   monomials_collected::Vector{PolyRingElemT}
-  kernel::MatrixT # used iff reynolds == false
+  kernel::MatrixT # used if method == :linear_algebra
 end
 
 abstract type VectorSpaceIterator{FieldT,IteratorT,ElemT} end

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -183,6 +183,8 @@ function __init__()
 
   add_verbosity_scope(:f4ncgb)
 
+  add_verbosity_scope(:FundamentalInvariants)
+
   # Pkg.is_manifest_current() returns false if the manifest might be out of date
   # (but might return nothing when there is no project_hash)
   if is_dev && false === (VERSION < v"1.11.0-DEV.1135" ?

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -187,6 +187,8 @@ function __init__()
 
   add_verbosity_scope(:AlgebraicSolving)
 
+  add_verbosity_scope(:FundamentalInvariants)
+
   # Pkg.is_manifest_current() returns false if the manifest might be out of date
   # (but might return nothing when there is no project_hash)
   if is_dev && false === (VERSION < v"1.11.0-DEV.1135" ?

--- a/test/InvariantTheory/invariant_rings.jl
+++ b/test/InvariantTheory/invariant_rings.jl
@@ -163,19 +163,24 @@ end
   @test length(basis(RGK, 1)) == 1
   @test length(basis(RGK, 1, :reynolds)) == 1
   @test length(basis(RGK, 1, :linear_algebra)) == 1
+  @test length(basis(RGK, 1, :orbit_sums)) == 1
   @test length(basis(RGK, 3)) == 3
   @test length(basis(RGK, 3, :reynolds)) == 3
   @test length(basis(RGK, 3, :linear_algebra)) == 3
+  @test length(basis(RGK, 3, :orbit_sums)) == 3
 
   @test length(basis(RGF, 1)) == 1
   @test length(basis(RGF, 1, :reynolds)) == 1
   @test length(basis(RGF, 1, :linear_algebra)) == 1
+  @test length(basis(RGF, 1, :orbit_sums)) == 1
   @test length(basis(RGF, 3)) == 3
   @test length(basis(RGF, 3, :reynolds)) == 3
   @test length(basis(RGF, 3, :linear_algebra)) == 3
+  @test length(basis(RGF, 3, :orbit_sums)) == 3
 
   @test length(basis(RGM, 1)) == 1
   @test length(basis(RGM, 1, :linear_algebra)) == 1
+  @test length(basis(RGM, 1, :orbit_sums)) == 1
   @test_throws AssertionError basis(RGM, 1, :reynolds)
 
   mol = molien_series(RGK)

--- a/test/InvariantTheory/invariant_rings.jl
+++ b/test/InvariantTheory/invariant_rings.jl
@@ -193,6 +193,12 @@ end
   t = gens(base_ring(F))[1]
   @test mol == 1//((1 - t^3) * (1 - t^2) * (1 - t))
 
+  @test Oscar.is_molien_series_implemented(RGM)
+  mol = molien_series(RGM)
+  F = parent(mol)
+  t = gens(base_ring(F))[1]
+  @test mol == 1//((1 - t^3) * (1 - t^2) * (1 - t))
+
   # S4 (natural permutation module in characteristic 5)
   s4 = symmetric_group(4)
   S, t = QQ[:t]

--- a/test/book/specialized/decker-schmitt-invariant-theory/bertin.jlcon
+++ b/test/book/specialized/decker-schmitt-invariant-theory/bertin.jlcon
@@ -5,8 +5,8 @@ julia> RG = invariant_ring(GF(2), G);
 julia> primary_invariants(RG)
 4-element Vector{MPolyDecRingElem{FqFieldElem, FqMPolyRingElem}}:
  x[1] + x[2] + x[3] + x[4]
- x[1]*x[3] + x[2]*x[4]
  x[1]*x[2] + x[2]*x[3] + x[1]*x[4] + x[3]*x[4]
+ x[1]*x[3] + x[2]*x[4]
  x[1]*x[2]*x[3]*x[4]
 
 julia> secondary_invariants(RG)
@@ -27,4 +27,4 @@ Subquotient of submodule with 5 generators
   4: e[4]
   5: e[5]
 by submodule with 1 generator
-  1: t2*e[2] + (t2 + t3)*e[3] + t1*e[4]
+  1: t3*e[2] + (t2 + t3)*e[3] + t1*e[4]

--- a/test/book/specialized/decker-schmitt-invariant-theory/sym.jlcon
+++ b/test/book/specialized/decker-schmitt-invariant-theory/sym.jlcon
@@ -6,7 +6,7 @@ julia> L = fundamental_invariants(RS4)
 4-element Vector{MPolyDecRingElem{FqFieldElem, FqMPolyRingElem}}:
  x[1] + x[2] + x[3] + x[4]
  x[1]*x[2] + x[1]*x[3] + x[2]*x[3] + x[1]*x[4] + x[2]*x[4] + x[3]*x[4]
- x[1]^3 + x[2]^3 + x[3]^3 + x[4]^3
+ x[1]*x[2]*x[3] + x[1]*x[2]*x[4] + x[1]*x[3]*x[4] + x[2]*x[3]*x[4]
  x[1]*x[2]*x[3]*x[4]
 
 julia> is_algebraically_independent(L)

--- a/test/book/specialized/decker-schmitt-invariant-theory/sym.jlcon
+++ b/test/book/specialized/decker-schmitt-invariant-theory/sym.jlcon
@@ -6,7 +6,7 @@ julia> L = fundamental_invariants(RS4)
 4-element Vector{MPolyDecRingElem{FqFieldElem, FqMPolyRingElem}}:
  x[1] + x[2] + x[3] + x[4]
  x[1]*x[2] + x[1]*x[3] + x[2]*x[3] + x[1]*x[4] + x[2]*x[4] + x[3]*x[4]
- x[1]*x[2]*x[3] + x[1]*x[2]*x[4] + x[1]*x[3]*x[4] + x[2]*x[3]*x[4]
+ x[1]^3 + x[2]^3 + x[3]^3 + x[4]^3
  x[1]*x[2]*x[3]*x[4]
 
 julia> is_algebraically_independent(L)


### PR DESCRIPTION
See title. Orbits sums are faster than other methods and produce "nicer" polynomials (all coefficients are 1).

Also contains:
* Tune `fundamental_invariants_via_king` to use the new orbit sums
* Make `molien_series` work in all characteristics for permutation groups
* Add some optional verbose output

The main motivation for this is that some time ago I noticed timings in the Magma handbook against which OSCAR was pitiful. With this, we still don't match them, but at least we are getting closer.
I ran all timings on nenekiki for a comparison.
<details>

<summary>Magma</summary>

```
> d := 7;
> time for i := 1 to NumberOfTransitiveGroups(d) do
time|for> G := TransitiveGroup(d, i);
time|for> R := InvariantRing(G, RationalField());
time|for> F := FundamentalInvariants(R);
time|for> end for;
Time: 12.710
> time for i := 1 to NumberOfTransitiveGroups(d) do
time|for> G := TransitiveGroup(d, i);
time|for> p := rep{p: p in [2 .. #G] | IsPrime(p) and #G mod p ne 0};
time|for> R := InvariantRing(G, GF(p));
time|for> F := FundamentalInvariants(R);
time|for> end for;
Time: 2.370
> d := 8;
> time for i := 1 to NumberOfTransitiveGroups(d) do
time|for> G := TransitiveGroup(d, i);
time|for> p := rep{p: p in [2 .. #G] | IsPrime(p) and #G mod p ne 0};
time|for> R := InvariantRing(G, GF(p));
time|for> F := FundamentalInvariants(R);
time|for> end for;
Time: 439.700
```

</details>

<details>

<summary>OSCAR master</summary>

```
julia> d = 7;

julia> @time for i in 1:number_of_transitive_groups(d)
                G = transitive_group(d, i)
                R = invariant_ring(QQ, G)
                F = fundamental_invariants(R)
              end
237.920422 seconds (407.93 M allocations: 174.419 GiB, 9.84% gc time, 0.02% compilation time)

julia> @time for i in 1:number_of_transitive_groups(d)
                G = transitive_group(d, i)
                p = 2
                while is_divisible_by(order(G), p)
                  p = next_prime(p)
                end
                R = invariant_ring(GF(p), G)
                F = fundamental_invariants(R)
              end
100.385803 seconds (210.40 M allocations: 30.741 GiB, 7.53% gc time)

julia> d = 8;

julia> @time for i in 1:number_of_transitive_groups(d)
                G = transitive_group(d, i)
                p = 2
                while is_divisible_by(order(G), p)
                  p = next_prime(p)
                end
                R = invariant_ring(GF(p), G)
                F = fundamental_invariants(R)
              end
34962.131399 seconds (8.16 G allocations: 7.418 TiB, 1.47% gc time)
```
</details>

<details>

<summary>OSCAR with this pull request</summary>

```
julia> d = 7;

julia> @time for i in 1:number_of_transitive_groups(d)
         G = transitive_group(d, i)
         R = invariant_ring(QQ, G)
         F = fundamental_invariants(R)
       end
101.569851 seconds (236.04 M allocations: 147.231 GiB, 12.39% gc time, 0.04% compilation time)

julia> @time for i in 1:number_of_transitive_groups(d)
         G = transitive_group(d, i)
         p = 2
         while is_divisible_by(order(G), p)
           p = next_prime(p)
         end
         R = invariant_ring(GF(p), G)
         F = fundamental_invariants(R)
       end
  6.482528 seconds (8.98 M allocations: 815.234 MiB, 3.89% gc time, 0.12% compilation time)

julia> d = 8;

julia> @time for i in 1:number_of_transitive_groups(d)
         G = transitive_group(d, i)
         p = 2
         while is_divisible_by(order(G), p)
           p = next_prime(p)
         end
         R = invariant_ring(GF(p), G)
         F = fundamental_invariants(R)
       end
1124.512632 seconds (397.06 M allocations: 73.010 GiB, 2.39% gc time)
```

</details>

So in positive characteristic, the difference is now a factor of 3. In characteristic 0, there is still more difference. My impression is that most of the time is spent with the computation of Gröbner bases and divisions with remainder.
