### PR TITLE
FTheoryTools: Refresh zero-section class after toric blowups

### DIFF
--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/blowups.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Methods/blowups.jl
@@ -409,6 +409,19 @@ function blow_up(
       # Update exceptional classes and their indices
       divs = torusinvariant_prime_divisors(ambient_space(model))
 
+      # The ambient cohomology ring changes under a toric blowup. Recompute the
+      # zero-section class in the new ring rather than retaining the stale class
+      # copied from the pre-blowup model.
+      if has_attribute(model, :zero_section_index)
+        index = zero_section_index(model)
+        @req index <= length(divs) "Inconsistency encountered. Contact the authors"
+        set_attribute!(
+          model,
+          :zero_section_class =>
+            cohomology_class(divs[index]; completeness_check=false),
+        )
+      end
+
       indets = [
         lift(g) for
         g in gens(cohomology_ring(ambient_space(model); completeness_check=false))

--- a/experimental/FTheoryTools/test/literature_models.jl
+++ b/experimental/FTheoryTools/test/literature_models.jl
@@ -91,12 +91,31 @@ end
   @test_throws ArgumentError birational_literature_models(t1)
 end
 
-# Resolving a model must not mutate its stored resolution data or exceptional indices.
+# Resolving a toric model must refresh ambient-dependent data without mutating the input.
+zero_section_index_t1 =
+  findfirst(==(:z), symbols(coordinate_ring(ambient_space(t1))))::Int
+zero_section_divisor_t1 = torusinvariant_prime_divisors(ambient_space(t1))[zero_section_index_t1]
+set_attribute!(t1, :zero_section_index => zero_section_index_t1)
+set_attribute!(
+  t1,
+  :zero_section_class => cohomology_class(
+    zero_section_divisor_t1; completeness_check=false
+  ),
+)
+initial_zero_section_class = zero_section_class(t1)
 resolution_data = deepcopy(resolutions(t1))
 initial_exceptional_indices = copy(exceptional_divisor_indices(t1))
 t2 = resolve(t1, 1)
 
 @testset "Test resolving literature Tate model over concrete base" begin
+  @test zero_section_class(t1) === initial_zero_section_class
+  @test toric_variety(zero_section_class(t1)) === ambient_space(t1)
+  @test zero_section_index(t2) == zero_section_index_t1
+  @test toric_variety(zero_section_class(t2)) === ambient_space(t2)
+  @test zero_section_class(t2) == cohomology_class(
+    torusinvariant_prime_divisors(ambient_space(t2))[zero_section_index_t1];
+    completeness_check=false,
+  )
   @test resolutions(t1) == resolution_data
   @test exceptional_divisor_indices(t1) == initial_exceptional_indices
   @test is_smooth(ambient_space(t2)) == false


### PR DESCRIPTION
Prepared with Codex [codex@openai.com](mailto:codex@openai.com).