### PR TITLE
FTheoryTools: Exceptional divisors and classes

### DIFF
--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/precomputed_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/precomputed_attributes.jl
@@ -407,7 +407,8 @@ julia> exceptional_classes(foah11_B3)
 """
 function exceptional_classes(m::AbstractFTheoryModel)
   @req base_space(m) isa NormalToricVariety "Exceptional divisor classes are only supported for models over a concrete base"
-  return get_attribute(m, :exceptional_classes, Vector{CohomologyClass}())
+  @req has_attribute(m, :exceptional_classes) "Required exceptional divisor data is missing; please inform the FTheoryTools authors"
+  return get_attribute(m, :exceptional_classes)::Vector{CohomologyClass}
 end
 
 @doc raw"""
@@ -442,5 +443,6 @@ julia> exceptional_divisor_indices(foah11_B3)
 """
 @attr Vector{Int} function exceptional_divisor_indices(m::AbstractFTheoryModel)
   @req base_space(m) isa NormalToricVariety "Exceptional divisor indices are only supported for models over a concrete base"
-  return get_attribute(m, :exceptional_divisor_indices, Vector{Int64}())
+  @req has_attribute(m, :exceptional_divisor_indices) "Required exceptional divisor data is missing; please inform the FTheoryTools authors"
+  return get_attribute(m, :exceptional_divisor_indices)::Vector{Int}
 end

--- a/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
+++ b/experimental/FTheoryTools/src/HypersurfaceModels/constructors.jl
@@ -200,6 +200,7 @@ function _build_hypersurface_model(
     fiber_ambient_space,
   )
   set_attribute!(model, :partially_resolved, false)
+  _initialize_exceptional_divisor_attributes!(model)
   return model
 end
 

--- a/experimental/FTheoryTools/src/TateModels/constructors.jl
+++ b/experimental/FTheoryTools/src/TateModels/constructors.jl
@@ -120,6 +120,7 @@ function global_tate_model(base::NormalToricVariety,
     explicit_model_sections, model_section_parametrization, pt, base, ambient_space
   )
   set_attribute!(model, :partially_resolved, false)
+  _initialize_exceptional_divisor_attributes!(model)
   return model
 end
 

--- a/experimental/FTheoryTools/src/TunedModels/constructors.jl
+++ b/experimental/FTheoryTools/src/TunedModels/constructors.jl
@@ -520,6 +520,7 @@ function tune(
     new_classes_of_model_sections[key] = toric_divisor_class(base_space(model), m[1, :])
   end
   set_attribute!(model, :classes_of_model_sections => new_classes_of_model_sections)
+  _copy_exceptional_divisor_attributes!(model, h)
 
   # 5. Return the model
   return model

--- a/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
+++ b/experimental/FTheoryTools/src/WeierstrassModels/constructors.jl
@@ -108,6 +108,7 @@ function weierstrass_model(base::NormalToricVariety,
     explicit_model_sections, model_section_parametrization, pw, base, ambient_space
   )
   set_attribute!(model, :partially_resolved, false)
+  _initialize_exceptional_divisor_attributes!(model)
   return model
 end
 

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -448,7 +448,31 @@ function deepmap(f, x)
 end
 
 ###########################################################################
-# 8: Macro for function generation
+# 8: Exceptional divisor attributes
+###########################################################################
+
+function _initialize_exceptional_divisor_attributes!(model::AbstractFTheoryModel)
+  set_attribute!(
+    model,
+    :exceptional_classes => CohomologyClass[],
+    :exceptional_divisor_indices => Int[],
+  )
+  return model
+end
+
+function _copy_exceptional_divisor_attributes!(
+  target::AbstractFTheoryModel, source::AbstractFTheoryModel
+)
+  set_attribute!(
+    target,
+    :exceptional_classes => copy(exceptional_classes(source)),
+    :exceptional_divisor_indices => copy(exceptional_divisor_indices(source)),
+  )
+  return target
+end
+
+###########################################################################
+# 9: Macro for function generation
 ###########################################################################
 
 macro define_model_attribute_getter(

--- a/experimental/FTheoryTools/test/hypersurface_models.jl
+++ b/experimental/FTheoryTools/test/hypersurface_models.jl
@@ -24,6 +24,8 @@ h = hypersurface_model(
   @test symbols(coordinate_ring(fiber_ambient_space(h))) == [:x, :y, :z]
   @test toric_variety(calabi_yau_hypersurface(h)) == ambient_space(h)
   @test is_base_space_fully_specified(h) == true
+  @test isempty(exceptional_classes(h))
+  @test isempty(exceptional_divisor_indices(h))
 end
 
 @testset "Error messages in hypersurface models over concrete base spaces" begin

--- a/experimental/FTheoryTools/test/tate_models.jl
+++ b/experimental/FTheoryTools/test/tate_models.jl
@@ -34,6 +34,27 @@ tate_P3 = global_tate_model(P3; completeness_check=false, rng=our_rng)
   @test is_smooth(ambient_space(tate_P3)) == false
   @test toric_variety(calabi_yau_hypersurface(tate_P3)) == ambient_space(tate_P3)
   @test is_partially_resolved(tate_P3) == false
+  @test isempty(exceptional_classes(tate_P3))
+  @test isempty(exceptional_divisor_indices(tate_P3))
+end
+
+# Missing exceptional divisor attributes must expose inconsistent internal state.
+@testset "Missing exceptional divisor attributes" begin
+  message = "Required exceptional divisor data is missing; please inform the FTheoryTools authors"
+  for (getter, attribute) in (
+    (exceptional_classes, :exceptional_classes),
+    (exceptional_divisor_indices, :exceptional_divisor_indices),
+  )
+    broken_model = deepcopy(tate_P3)
+    delete!(broken_model.__attrs, attribute)
+    caught_error = try
+      getter(broken_model)
+      nothing
+    catch err
+      err
+    end
+    @test caught_error isa ArgumentError && caught_error.msg == message
+  end
 end
 
 @testset "Error messages in global Tate models over concrete base space" begin

--- a/experimental/FTheoryTools/test/tuning.jl
+++ b/experimental/FTheoryTools/test/tuning.jl
@@ -156,6 +156,29 @@ h = hypersurface_model(
   B3, ambient_space_of_fiber, [D1, D2, D3], p; completeness_check=false
 )
 
+# Hypersurface tuning must preserve exceptional divisor metadata.
+@testset "Exceptional divisor attributes after hypersurface tuning" begin
+  B2 = projective_space(NormalToricVariety, 2)
+  b = torusinvariant_prime_divisors(B2)[1]
+  tunable_hypersurface = literature_model(;
+    arxiv_id="1208.2695",
+    equation="B.5",
+    base_space=B2,
+    defining_classes=Dict("b" => b),
+    completeness_check=false,
+    rng=our_rng,
+  )
+  x1, x2, x3 = gens(coordinate_ring(B2))
+  tuned_hypersurface = tune(
+    tunable_hypersurface,
+    Dict("b" => x2, "c0" => zero(parent(x1)));
+    completeness_check=false,
+  )
+  @test exceptional_classes(tuned_hypersurface) == exceptional_classes(tunable_hypersurface)
+  @test exceptional_divisor_indices(tuned_hypersurface) ==
+    exceptional_divisor_indices(tunable_hypersurface)
+end
+
 # The tests below did not actually test the tune functionality of hypersurface models,
 # but instead the tune functionality of abstract F-theory models, inherited by hypersurface models
 # This functionality has been removed for the time being, because it did not correspond to a proper tuning

--- a/experimental/FTheoryTools/test/weierstrass_models.jl
+++ b/experimental/FTheoryTools/test/weierstrass_models.jl
@@ -31,6 +31,8 @@ weierstrass_P3 = weierstrass_model(P3; completeness_check=false, rng=our_rng)
   @test length(singular_loci(weierstrass_P3; rng=our_rng)) == 1
   @test is_base_space_fully_specified(weierstrass_P3) == true
   @test is_partially_resolved(weierstrass_P3) == false
+  @test isempty(exceptional_classes(weierstrass_P3))
+  @test isempty(exceptional_divisor_indices(weierstrass_P3))
 end
 
 @testset "Error messages in Weierstrass models over concrete base spaces" begin


### PR DESCRIPTION
Cautiously initialize and copy exceptional divisor and exceptional classes information. Also, do not return a default value when missing; rather raise an error.

Prepared with Codex [codex@openai.com](mailto:codex@openai.com).