### PR TITLE
Align FTheory model attribute names

### DIFF
--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/not_yet_computed_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/not_yet_computed_attributes.jl
@@ -10,7 +10,8 @@
   31
   ```
   """,
-  "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details.")
+  "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details."
+)
 
 @define_model_attribute_getter((hodge_h12, Int),
   """
@@ -24,7 +25,8 @@
   10
   ```
   """,
-  "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details.")
+  "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details."
+)
 
 @define_model_attribute_getter((hodge_h13, Int),
   """
@@ -38,7 +40,8 @@
   34
   ```
   """,
-  "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details.")
+  "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details."
+)
 
 @define_model_attribute_getter((hodge_h22, Int),
   """
@@ -52,7 +55,8 @@
   284
   ```
   """,
-  "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details.")
+  "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details."
+)
 
 @define_model_attribute_getter((kbar3, Int),
   """

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/not_yet_computed_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/not_yet_computed_attributes.jl
@@ -10,8 +10,7 @@
   31
   ```
   """,
-  "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details.",
-  h11)
+  "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details.")
 
 @define_model_attribute_getter((hodge_h12, Int),
   """
@@ -25,8 +24,7 @@
   10
   ```
   """,
-  "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details.",
-  h12)
+  "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details.")
 
 @define_model_attribute_getter((hodge_h13, Int),
   """
@@ -40,8 +38,7 @@
   34
   ```
   """,
-  "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details.",
-  h13)
+  "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details.")
 
 @define_model_attribute_getter((hodge_h22, Int),
   """
@@ -55,8 +52,7 @@
   284
   ```
   """,
-  "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details.",
-  h22)
+  "See [Advanced Mathematical Attributes](@ref non_yet_algorithmic_advanced_attributes) for more details.")
 
 @define_model_attribute_getter((kbar3, Int),
   """
@@ -69,4 +65,4 @@
   julia> kbar3(qsm_model)
   6
   ```
-  """, "See [Topological Data of a `QSM`](@ref base_top_data) for more details.", Kbar3)
+  """, "See [Topological Data of a `QSM`](@ref base_top_data) for more details.")

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/qsm_attributes.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Attributes/qsm_attributes.jl
@@ -30,7 +30,7 @@
   julia> polytope_index(qsm_model)
   4
   ```
-  """, "See [Underlying Polytope](@ref qsm_polytope) for more details.", poly_index)
+  """, "See [Underlying Polytope](@ref qsm_polytope) for more details.")
 
 @define_model_attribute_getter((has_quick_triangulation, Bool),
   """
@@ -43,7 +43,7 @@
   julia> has_quick_triangulation(qsm_model)
   true
   ```
-  """, "See [Underlying Polytope](@ref qsm_polytope) for more details.", triang_quick)
+  """, "See [Underlying Polytope](@ref qsm_polytope) for more details.")
 
 @define_model_attribute_getter((max_lattice_pts_in_facet, Int),
   """
@@ -87,7 +87,7 @@
   julia> typeof(genera_of_ci_curves(qsm_model))
   Dict{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}, Int64}
   ```
-  """, "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.", genus_ci)
+  """, "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.")
 
 @define_model_attribute_getter(
   (
@@ -104,8 +104,7 @@
   julia> typeof(degrees_of_kbar_restrictions_to_ci_curves(qsm_model))
   Dict{MPolyDecRingElem{QQFieldElem, QQMPolyRingElem}, Int64}
   ```
-  """, "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.",
-  degree_of_Kbar_of_tv_restricted_to_ci)
+  """, "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.")
 
 @define_model_attribute_getter(
   (topological_intersection_numbers_among_ci_curves, Matrix{Int64}),
@@ -119,8 +118,7 @@
   julia> size(topological_intersection_numbers_among_ci_curves(qsm_model))
   (29, 29)
   ```
-  """, "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.",
-  intersection_number_among_ci_cj)
+  """, "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.")
 
 @define_model_attribute_getter((indices_of_trivial_ci_curves, Vector{Int64}),
   """
@@ -143,8 +141,7 @@
    12
    15
   ```
-  """, "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.",
-  index_facet_interior_divisors)
+  """, "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.")
 
 @define_model_attribute_getter(
   (topological_intersection_numbers_among_nontrivial_ci_curves, Matrix{Int64}),
@@ -158,8 +155,7 @@
   julia> size(topological_intersection_numbers_among_nontrivial_ci_curves(qsm_model))
   (19, 19)
   ```
-  """, "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.",
-  intersection_number_among_nontrivial_ci_cj)
+  """, "See [The Nodal Curve](@ref qsm_nodal_curve) for more details.")
 
 ######################################################################
 # (3) Attributes regarding the dual graph
@@ -204,8 +200,7 @@
   julia> typeof(degrees_of_kbar_restrictions_to_components_of_dual_graph(qsm_model))
   Dict{String, Int64}
   ```
-  """, "See [The Dual Graph](@ref qsm_dual_graph) for more details.",
-  degree_of_Kbar_of_tv_restricted_to_components_of_dual_graph)
+  """, "See [The Dual Graph](@ref qsm_dual_graph) for more details.")
 
 @define_model_attribute_getter((genera_of_components_of_dual_graph, Dict{String,Int64}),
   """
@@ -218,8 +213,7 @@
   julia> typeof(genera_of_components_of_dual_graph(qsm_model))
   Dict{String, Int64}
   ```
-  """, "See [The Dual Graph](@ref qsm_dual_graph) for more details.",
-  genus_of_components_of_dual_graph)
+  """, "See [The Dual Graph](@ref qsm_dual_graph) for more details.")
 
 ######################################################################
 # (4) Attributes regarding the simplified dual graph
@@ -264,8 +258,7 @@
   julia> typeof(degrees_of_kbar_restrictions_to_components_of_simplified_dual_graph(qsm_model))
   Dict{String, Int64}
   ```
-  """, "See [The Simplified Dual Graph](@ref qsm_simple_dual_graph) for more details.",
-  degree_of_Kbar_of_tv_restricted_to_components_of_simplified_dual_graph)
+  """, "See [The Simplified Dual Graph](@ref qsm_simple_dual_graph) for more details.")
 
 @define_model_attribute_getter(
   (genera_of_components_of_simplified_dual_graph, Dict{String,Int64}),
@@ -279,5 +272,4 @@
   julia> typeof(genera_of_components_of_simplified_dual_graph(qsm_model))
   Dict{String, Int64}
   ```
-  """, "See [The Simplified Dual Graph](@ref qsm_simple_dual_graph) for more details.",
-  genus_of_components_of_simplified_dual_graph)
+  """, "See [The Simplified Dual Graph](@ref qsm_simple_dual_graph) for more details.")

--- a/experimental/FTheoryTools/src/AbstractFTheoryModels/Properties/properties.jl
+++ b/experimental/FTheoryTools/src/AbstractFTheoryModels/Properties/properties.jl
@@ -89,10 +89,10 @@ true
   @req ambient_space(m) isa NormalToricVariety "Verification of Euler characteristic of F-theory model currently supported only for toric ambient space"
   @req dim(base_space(m)) == 3 "Verification of Euler characteristic of F-theory model currently supported only for toric base spaces of dimension 3"
   @req dim(ambient_space(m)) == 5 "Verification of Euler characteristic of F-theory model currently supported only for toric ambient spaces of dimension 5"
-  @req has_attribute(m, :h11) "Verification of Euler characteristic of F-theory model requires h11"
-  @req has_attribute(m, :h12) "Verification of Euler characteristic of F-theory model requires h12"
-  @req has_attribute(m, :h13) "Verification of Euler characteristic of F-theory model requires h13"
-  @req has_attribute(m, :h22) "Verification of Euler characteristic of F-theory model requires h22"
+  @req has_attribute(m, :hodge_h11) "Verification of Euler characteristic of F-theory model requires hodge_h11"
+  @req has_attribute(m, :hodge_h12) "Verification of Euler characteristic of F-theory model requires hodge_h12"
+  @req has_attribute(m, :hodge_h13) "Verification of Euler characteristic of F-theory model requires hodge_h13"
+  @req has_attribute(m, :hodge_h22) "Verification of Euler characteristic of F-theory model requires hodge_h22"
 
   # Computer Euler characteristic from integrating c4
   ec = euler_characteristic(m; completeness_check)

--- a/experimental/FTheoryTools/src/auxiliary.jl
+++ b/experimental/FTheoryTools/src/auxiliary.jl
@@ -451,9 +451,7 @@ end
 # 8: Macro for function generation
 ###########################################################################
 
-macro define_model_attribute_getter(
-  arg_expr, doc_example="", doc_link="", attr_name=nothing
-)
+macro define_model_attribute_getter(arg_expr, doc_example="", doc_link="")
   if !(arg_expr isa Expr && arg_expr.head == :tuple && length(arg_expr.args) == 2)
     error("Expected input like: (function_name, ReturnType)")
   end
@@ -462,13 +460,7 @@ macro define_model_attribute_getter(
   rettype_expr = arg_expr.args[2]
   fname = fname_expr isa Symbol ? fname_expr : error("function_name is not a symbol")
 
-  # Determine attribute name symbol: use attr_name if provided, else function name
-  attr_sym = if attr_name === nothing
-    fname
-  else
-    (attr_name isa Symbol ? attr_name : error("attr_name must be a Symbol if provided"))
-  end
-  sym = QuoteNode(attr_sym)
+  sym = QuoteNode(fname)
 
   msg = "No $(replace(string(fname), '_' => ' ')) known for this model"
 

--- a/experimental/FTheoryTools/src/serialization.jl
+++ b/experimental/FTheoryTools/src/serialization.jl
@@ -3,7 +3,7 @@
 ###########################################################################
 
 const COMMON_FIELDS = [
-  :Kbar3,
+  :kbar3,
   :_ambient_space_base_divisor_pairs_to_be_considered,
   :_ambient_space_divisor_pairs_to_be_considered,
   :ambient_space_models_of_g4_fluxes,
@@ -21,9 +21,9 @@ const COMMON_FIELDS = [
   :components_of_simplified_dual_graph,
   :converter_dict_h22_ambient,
   :converter_dict_h22_hypersurface,
-  :degree_of_Kbar_of_tv_restricted_to_ci,
-  :degree_of_Kbar_of_tv_restricted_to_components_of_dual_graph,
-  :degree_of_Kbar_of_tv_restricted_to_components_of_simplified_dual_graph,
+  :degrees_of_kbar_restrictions_to_ci_curves,
+  :degrees_of_kbar_restrictions_to_components_of_dual_graph,
+  :degrees_of_kbar_restrictions_to_components_of_simplified_dual_graph,
   :dual_graph,
   :estimated_number_of_triangulations,
   :euler_characteristic,
@@ -32,18 +32,20 @@ const COMMON_FIELDS = [
   :g4_flux_tuple_list,
   :gauge_algebra,
   :generating_sections,
-  :genus_ci,
-  :genus_of_components_of_dual_graph,
-  :genus_of_components_of_simplified_dual_graph,
-  :global_gauge_group_quotients,
-  :h11,
-  :h12,
-  :h13,
-  :h22,
-  :index_facet_interior_divisors,
+  :genera_of_ci_curves,
+  :genera_of_components_of_dual_graph,
+  :genera_of_components_of_simplified_dual_graph,
+  :global_gauge_group_quotient,
+  :global_tate_model,
+  :has_quick_triangulation,
+  :hodge_h11,
+  :hodge_h12,
+  :hodge_h13,
+  :hodge_h22,
+  :indices_of_trivial_ci_curves,
   :inter_dict,
-  :intersection_number_among_ci_cj,
-  :intersection_number_among_nontrivial_ci_cj,
+  :topological_intersection_numbers_among_ci_curves,
+  :topological_intersection_numbers_among_nontrivial_ci_curves,
   :is_calabi_yau,
   :literature_identifier,
   :matrix_integral_quant_transverse,
@@ -56,14 +58,13 @@ const COMMON_FIELDS = [
   :offset_quant_transverse,
   :offset_quant_transverse_nobreak,
   :partially_resolved,
-  :poly_index,
+  :polytope_index,
   :resolutions,
   :resolution_generating_sections,
   :resolution_zero_sections,
   :s_inter_dict,
   :simplified_dual_graph,
   :torsion_sections,
-  :triang_quick,
   :tunable_sections,
   :vertices,
   :weierstrass_model,
@@ -101,6 +102,44 @@ const COMMON_FIELDS = [
 @register_serialization_type WeierstrassModel uses_id COMMON_FIELDS
 @register_serialization_type HypersurfaceModel uses_id COMMON_FIELDS
 @register_serialization_type GlobalTateModel uses_id COMMON_FIELDS
+
+const LEGACY_FTHEORY_MODEL_ATTRIBUTE_NAMES = Dict(
+  :Kbar3 => :kbar3,
+  :degree_of_Kbar_of_tv_restricted_to_ci => :degrees_of_kbar_restrictions_to_ci_curves,
+  :degree_of_Kbar_of_tv_restricted_to_components_of_dual_graph =>
+    :degrees_of_kbar_restrictions_to_components_of_dual_graph,
+  :degree_of_Kbar_of_tv_restricted_to_components_of_simplified_dual_graph =>
+    :degrees_of_kbar_restrictions_to_components_of_simplified_dual_graph,
+  :genus_ci => :genera_of_ci_curves,
+  :genus_of_components_of_dual_graph => :genera_of_components_of_dual_graph,
+  :genus_of_components_of_simplified_dual_graph => :genera_of_components_of_simplified_dual_graph,
+  :global_gauge_group_quotients => :global_gauge_group_quotient,
+  :h11 => :hodge_h11,
+  :h12 => :hodge_h12,
+  :h13 => :hodge_h13,
+  :h22 => :hodge_h22,
+  :index_facet_interior_divisors => :indices_of_trivial_ci_curves,
+  :intersection_number_among_ci_cj => :topological_intersection_numbers_among_ci_curves,
+  :intersection_number_among_nontrivial_ci_cj =>
+    :topological_intersection_numbers_among_nontrivial_ci_curves,
+  :poly_index => :polytope_index,
+  :triang_quick => :has_quick_triangulation,
+)
+
+function load_attrs(
+  s::DeserializerState, m::Union{WeierstrassModel,GlobalTateModel,HypersurfaceModel}
+)
+  !with_attrs(s) && return
+
+  haskey(s, :attrs) && load_node(s, :attrs) do d
+    serialized_attributes = keys(d)
+    for old_name in serialized_attributes
+      new_name = get(LEGACY_FTHEORY_MODEL_ATTRIBUTE_NAMES, old_name, old_name)
+      old_name != new_name && new_name in serialized_attributes && continue
+      set_attribute!(m, new_name, load_typed_object(s, old_name))
+    end
+  end
+end
 
 ###########################################################################
 # (2) Type parameters

--- a/experimental/FTheoryTools/src/serialization.jl
+++ b/experimental/FTheoryTools/src/serialization.jl
@@ -112,7 +112,8 @@ const LEGACY_FTHEORY_MODEL_ATTRIBUTE_NAMES = Dict(
     :degrees_of_kbar_restrictions_to_components_of_simplified_dual_graph,
   :genus_ci => :genera_of_ci_curves,
   :genus_of_components_of_dual_graph => :genera_of_components_of_dual_graph,
-  :genus_of_components_of_simplified_dual_graph => :genera_of_components_of_simplified_dual_graph,
+  :genus_of_components_of_simplified_dual_graph =>
+    :genera_of_components_of_simplified_dual_graph,
   :global_gauge_group_quotients => :global_gauge_group_quotient,
   :h11 => :hodge_h11,
   :h12 => :hodge_h12,
@@ -126,17 +127,17 @@ const LEGACY_FTHEORY_MODEL_ATTRIBUTE_NAMES = Dict(
   :triang_quick => :has_quick_triangulation,
 )
 
-function load_attrs(
+function Serialization.load_attrs(
   s::DeserializerState, m::Union{WeierstrassModel,GlobalTateModel,HypersurfaceModel}
 )
-  !with_attrs(s) && return
+  !with_attrs(s) && return nothing
 
   haskey(s, :attrs) && load_node(s, :attrs) do d
     serialized_attributes = keys(d)
     for old_name in serialized_attributes
       new_name = get(LEGACY_FTHEORY_MODEL_ATTRIBUTE_NAMES, old_name, old_name)
       old_name != new_name && new_name in serialized_attributes && continue
-      set_attribute!(m, new_name, load_typed_object(s, old_name))
+      set_attribute!(m, new_name, Serialization.load_typed_object(s, old_name))
     end
   end
 end

--- a/experimental/FTheoryTools/test/QSMs.jl
+++ b/experimental/FTheoryTools/test/QSMs.jl
@@ -31,6 +31,11 @@ fg_not_breaking = special_flux_family(
 g4_exp = flux_instance(fg_not_breaking, [3], [])
 
 @testset "Test properties of the QSM" begin
+  # Legacy QSM database attributes are canonicalized when the model is loaded.
+  @test has_attribute(qsm_model, :kbar3)
+  @test !has_attribute(qsm_model, :Kbar3)
+  @test has_attribute(qsm_model, :has_quick_triangulation)
+  @test !has_attribute(qsm_model, :triang_quick)
   @test H == U + E1 + E2 + E4 == V + E2 + E3
   @test chern_classes(qsm_model)[2] ==
     c2_B - 7 * E4^2 - E1 * Kbar - E2 * Kbar - E3 * Kbar - E4 * Kbar + 3 * H * Kbar

--- a/experimental/FTheoryTools/test/hypersurface_models.jl
+++ b/experimental/FTheoryTools/test/hypersurface_models.jl
@@ -48,6 +48,31 @@ end
   end
 end
 
+# Legacy serialized attribute names are upgraded to their public getter names on load.
+@testset "Loading legacy F-theory model attributes" begin
+  set_attribute!(h, :hodge_h11, 31)
+  set_attribute!(h, :global_gauge_group_quotient, [["-identity_matrix(C,2)"]])
+  mktempdir() do path
+    filename = joinpath(path, "legacy_attributes.mrdi")
+    save(filename, h)
+    serialized_model = read(filename, String)
+    @test contains(serialized_model, "\"hodge_h11\"")
+    @test contains(serialized_model, "\"global_gauge_group_quotient\"")
+    serialized_model = replace(
+      serialized_model,
+      "\"hodge_h11\"" => "\"h11\"",
+      "\"global_gauge_group_quotient\"" => "\"global_gauge_group_quotients\"",
+    )
+    write(filename, serialized_model)
+
+    loaded = load(filename)
+    @test hodge_h11(loaded) == 31
+    @test global_gauge_group_quotient(loaded) == [["-identity_matrix(C,2)"]]
+    @test !has_attribute(loaded, :h11)
+    @test !has_attribute(loaded, :global_gauge_group_quotients)
+  end
+end
+
 Kbar = anticanonical_divisor(B3)
 foah1_B3 = literature_model(;
   arxiv_id="1408.4808",
@@ -98,6 +123,17 @@ set_global_tate_model(h3, gt_model)
 @testset "Test assignment of Weierstrass and global Tate models to hypersurface models" begin
   @test weierstrass_model(h3) == w_model
   @test global_tate_model(h3) == gt_model
+end
+
+# Explicitly assigned related models are preserved by serialization.
+@testset "Saving related models of a hypersurface model" begin
+  mktempdir() do path
+    test_save_load_roundtrip(path, h3) do loaded
+      @test weierstrass_polynomial(weierstrass_model(loaded)) ==
+        weierstrass_polynomial(w_model)
+      @test tate_polynomial(global_tate_model(loaded)) == tate_polynomial(gt_model)
+    end
+  end
 end
 
 @testset "Attributes and properties of hypersurface literature models over concrete base space" begin


### PR DESCRIPTION
Use the public getter names as the canonical attribute names for FTheory models and migrate legacy serialized attributes while loading. Preserve explicitly assigned related models across serialization and prevent future getter-to-attribute name divergence.

Prepared with Codex [codex@openai.com](mailto:codex@openai.com).