### PR TITLE
First stub for modstd support for modules

### DIFF
--- a/src/Modules/ModuleTypes.jl
+++ b/src/Modules/ModuleTypes.jl
@@ -239,6 +239,8 @@ generate the submodule) (computed via `generator_matrix()`) are cached.
                         # So this field stores any gb for cases where the actual 
                         # ordering does not matter. Then this field here can be used. 
   any_gb_with_transition::ModuleGens{T} # The same but for one with transition matrix
+  dodgy_groebner_basis::Dict{ModuleOrdering, ModuleGens{T}} # Groebner bases computed with Singular's ModStd 
+                                                            # in case "dodgy_mode" is on. 
   matrix::MatElem
 
   function SubModuleOfFreeModule{R}(F::FreeMod{R}) where {R}

--- a/src/Modules/UngradedModules/FreeResolutions.jl
+++ b/src/Modules/UngradedModules/FreeResolutions.jl
@@ -550,7 +550,15 @@ function free_resolution(M::SubquoModule{T};
 
   #= This is the single computational hard part of this function =#
   if algorithm == :fres && T <: MPolyRingElem
-    gbpres = Singular.std(singular_kernel_entry)
+    # in case of dodgy mode take that shortcut
+    gbpres = (coefficient_type(T) === QQFieldElem && AbstractAlgebra.get_dodgy_mode()) ? 
+      begin
+        AbstractAlgebra.@RegisterDodgyStep(:free_resolution, Any[M])
+        gb = Singular.LibModstd.modStd(singular_kernel_entry)
+        gb.isGB = true #YOLO (dodgy)
+        gb
+      end : 
+      Singular.std(singular_kernel_entry)
     res = Singular.fres(gbpres, length, "complete")
   elseif algorithm == :lres
     error("LaScala's method is not yet available in Oscar.")

--- a/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
+++ b/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
@@ -177,8 +177,8 @@ function standard_basis(
   @req is_exact_type(elem_type(base_ring(submod))) "This functionality is only supported over exact fields."
 
   # In case of "dodgy_mode" over QQ we can take the cheap computation.
-  if base_ring(submod) isa QQMPolyRing && AbstractAlgebra.get_dodgy_mode()
-    return dodgy_groebner_basis(submod; ordering)
+  if base_ring(submod) <: MPolyRing{<:QQFieldElem} && AbstractAlgebra.get_dodgy_mode()
+    return dodgy_groebner_basis(submod; ordering, check=false)
   end
 
   gb = get!(submod.groebner_basis, ordering) do

--- a/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
+++ b/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
@@ -177,7 +177,7 @@ function standard_basis(
   @req is_exact_type(elem_type(base_ring(submod))) "This functionality is only supported over exact fields."
 
   # In case of "dodgy_mode" over QQ we can take the cheap computation.
-  if base_ring(submod) <: MPolyRing{<:QQFieldElem} && AbstractAlgebra.get_dodgy_mode()
+  if typeof(base_ring(submod)) <: MPolyRing{<:QQFieldElem} && AbstractAlgebra.get_dodgy_mode()
     return dodgy_groebner_basis(submod; ordering, check=false)
   end
 

--- a/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
+++ b/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
@@ -175,6 +175,12 @@ function standard_basis(
   end
 
   @req is_exact_type(elem_type(base_ring(submod))) "This functionality is only supported over exact fields."
+
+  # In case of "dodgy_mode" over QQ we can take the cheap computation.
+  if base_ring(submod) isa QQMPolyRing && AbstractAlgebra.get_dodgy_mode()
+    gb = dodgy_groebner_basis(submod; ordering)
+  end
+
   gb = get!(submod.groebner_basis, ordering) do
     compute_standard_basis(submod, ordering)
   end::ModuleGens

--- a/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
+++ b/src/Modules/UngradedModules/SubModuleOfFreeModule.jl
@@ -178,7 +178,7 @@ function standard_basis(
 
   # In case of "dodgy_mode" over QQ we can take the cheap computation.
   if base_ring(submod) isa QQMPolyRing && AbstractAlgebra.get_dodgy_mode()
-    gb = dodgy_groebner_basis(submod; ordering)
+    return dodgy_groebner_basis(submod; ordering)
   end
 
   gb = get!(submod.groebner_basis, ordering) do

--- a/src/Modules/UngradedModules/SubquoModule.jl
+++ b/src/Modules/UngradedModules/SubquoModule.jl
@@ -2150,7 +2150,6 @@ function compute_standard_basis_modular(
     ordering::ModuleOrdering=default_ordering(I),
     check::Bool=true
   ) where {T <: QQFieldElem}
-  @show "yes"
   sgens = singular_generators(I)
   gb = Singular.LibModstd.modStd(sgens, Int(check))
   gb.isGB = true # needs to be set manually, as it seems.

--- a/src/Modules/UngradedModules/SubquoModule.jl
+++ b/src/Modules/UngradedModules/SubquoModule.jl
@@ -2165,10 +2165,10 @@ end
 # takes care of caching the result of the above calls for 
 # computation for the specific use case of a "dodgy" object.
 function dodgy_groebner_basis(
-    I::SubModuleOfFreeModule{QQMPolyRingElem}; 
+    I::SubModuleOfFreeModule{T};
     ordering::ModuleOrdering=default_ordering(I), 
     check::Bool=true
-  )
+  ) where {T<:MPolyRingElem{QQFieldElem}}
   if !isdefined(I, :dogdy_groebner_basis)
     I.dodgy_groebner_basis = Dict{ModuleOrdering, ModuleGens{QQMPolyRingElem}}()
   end

--- a/src/Modules/UngradedModules/SubquoModule.jl
+++ b/src/Modules/UngradedModules/SubquoModule.jl
@@ -2128,33 +2128,47 @@ end
 # communicated to the user. 
 ########################################################################
 
-function standard_basis_modular(
+function compute_standard_basis_modular(
     I::SubquoModule{<:MPolyRingElem{T}}; 
     ordering::ModuleOrdering=default_ordering(I),
     check::Bool=true
   ) where {T <: QQFieldElem}
   @assert !isdefined(I, :quo) || is_zero(I.quo) "module must be a submodule of a free module"
-  return standard_basis_modular(I.sub; ordering, check)
+  return compute_standard_basis_modular(I.sub; ordering, check)
 end
 
-function standard_basis_modular(
+function compute_standard_basis_modular(
     I::SubModuleOfFreeModule{<:MPolyRingElem{T}}; 
     ordering::ModuleOrdering=default_ordering(I),
     check::Bool=true
   ) where {T <: QQFieldElem}
-  return standard_basis_modular(I.gens; ordering, check)
+  return compute_standard_basis_modular(I.gens; ordering, check)
 end
 
-function standard_basis_modular(
+function compute_standard_basis_modular(
     I::ModuleGens{<:MPolyRingElem{T}}; 
     ordering::ModuleOrdering=default_ordering(I),
     check::Bool=true
   ) where {T <: QQFieldElem}
   sgens = singular_generators(I)
   gb = Singular.LibModstd.modStd(sgens, Int(check))
+  gb.isGB = true # needs to be set manually, as it seems.
   res = ModuleGens(I.F, gb)
   res.isGB = true
   res.ordering = ordering
   return res
+end
+
+function dodgy_groebner_basis(
+    I::SubModuleOfFreeModule{QQMPolyRingElem}; 
+    ordering::ModuleOrdering=default_ordering(I)
+  )
+  if !isdefined(I, :dogdy_groebner_basis)
+    I.dodgy_groebner_basis = Dict{ModuleOrdering, ModuleGens{QQMPolyRingElem}}()
+  end
+  return get!(I.dodgy_groebner_basis, ordering) do
+    AbstractAlgebra.@RegisterDodgyStep(:standard_basis, Any[I])
+    compute_standard_basis_modular(I; ordering)
+  end
 end
 

--- a/src/Modules/UngradedModules/SubquoModule.jl
+++ b/src/Modules/UngradedModules/SubquoModule.jl
@@ -2159,6 +2159,11 @@ function compute_standard_basis_modular(
   return res
 end
 
+### get a dodgy groebner basis, i.e. one which has been 
+# computed via modular methods and is probably correct, 
+# but not verified. This is an internal function which 
+# takes care of caching the result of the above calls for 
+# computation for the specific use case of a "dodgy" object.
 function dodgy_groebner_basis(
     I::SubModuleOfFreeModule{QQMPolyRingElem}; 
     ordering::ModuleOrdering=default_ordering(I)

--- a/src/Modules/UngradedModules/SubquoModule.jl
+++ b/src/Modules/UngradedModules/SubquoModule.jl
@@ -2150,6 +2150,7 @@ function compute_standard_basis_modular(
     ordering::ModuleOrdering=default_ordering(I),
     check::Bool=true
   ) where {T <: QQFieldElem}
+  @show "yes"
   sgens = singular_generators(I)
   gb = Singular.LibModstd.modStd(sgens, Int(check))
   gb.isGB = true # needs to be set manually, as it seems.
@@ -2166,14 +2167,15 @@ end
 # computation for the specific use case of a "dodgy" object.
 function dodgy_groebner_basis(
     I::SubModuleOfFreeModule{QQMPolyRingElem}; 
-    ordering::ModuleOrdering=default_ordering(I)
+    ordering::ModuleOrdering=default_ordering(I), 
+    check::Bool=true
   )
   if !isdefined(I, :dogdy_groebner_basis)
     I.dodgy_groebner_basis = Dict{ModuleOrdering, ModuleGens{QQMPolyRingElem}}()
   end
   return get!(I.dodgy_groebner_basis, ordering) do
     AbstractAlgebra.@RegisterDodgyStep(:standard_basis, Any[I])
-    compute_standard_basis_modular(I; ordering)
+    compute_standard_basis_modular(I; ordering, check)
   end
 end
 

--- a/src/Modules/UngradedModules/SubquoModule.jl
+++ b/src/Modules/UngradedModules/SubquoModule.jl
@@ -2116,3 +2116,45 @@ end
   end
   return krull_dim(base_ring(F))
 end
+
+########################################################################
+# modular standard bases
+#
+# This is to wrap functionality from Singular's library ModStd 
+#     https://www.singular.uni-kl.de/hannes/sing_1410.htm#SEC1491
+# Unless the module put in is homogeneous or computations are done 
+# w.r.t a local ordering, the result is a Groebner basis only with 
+# high probability. Hence this functionality will not (yet) be 
+# communicated to the user. 
+########################################################################
+
+function standard_basis_modular(
+    I::SubquoModule{<:MPolyRingElem{T}}; 
+    ordering::ModuleOrdering=default_ordering(I),
+    check::Bool=true
+  ) where {T <: QQFieldElem}
+  @assert !isdefined(I, :quo) || is_zero(I.quo) "module must be a submodule of a free module"
+  return standard_basis_modular(I.sub; ordering, check)
+end
+
+function standard_basis_modular(
+    I::SubModuleOfFreeModule{<:MPolyRingElem{T}}; 
+    ordering::ModuleOrdering=default_ordering(I),
+    check::Bool=true
+  ) where {T <: QQFieldElem}
+  return standard_basis_modular(I.gens; ordering, check)
+end
+
+function standard_basis_modular(
+    I::ModuleGens{<:MPolyRingElem{T}}; 
+    ordering::ModuleOrdering=default_ordering(I),
+    check::Bool=true
+  ) where {T <: QQFieldElem}
+  sgens = singular_generators(I)
+  gb = Singular.LibModstd.modStd(sgens, Int(check))
+  res = ModuleGens(I.F, gb)
+  res.isGB = true
+  res.ordering = ordering
+  return res
+end
+

--- a/src/Modules/UngradedModules/SubquoModuleElem.jl
+++ b/src/Modules/UngradedModules/SubquoModuleElem.jl
@@ -914,6 +914,11 @@ end
     syzygy_module(F::ModuleGens; sub = FreeMod(base_ring(F.F), length(oscar_generators(F))))
 """
 function syzygy_module(F::ModuleGens{T}; sub = FreeMod(base_ring(F.F), length(oscar_generators(F)))) where {T <: MPolyRingElem}
+  # shortcut for dodgy mode over QQ
+  if T <: MPolyRingElem{<:QQFieldElem} && AbstractAlgebra.get_dodgy_mode()
+    AbstractAlgebra.@RegisterDodgyStep(:syzygy_module, Any[F])
+    return SubquoModule(sub, Singular.LibModstd.modSyz(singular_generators(F)))
+  end
   # TODO Obtain the Gröbner basis and cache it
   s = Singular.syz(singular_generators(F))
   return SubquoModule(sub, s)

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -2219,3 +2219,11 @@ end
   @test normal_form(v, SB) == -x*F[3]
   @test normal_form(w, SB) == zero(F)
 end
+
+@testset "modular standard bases" begin
+  R, (x, y) = QQ[:x, :y]
+  F = free_module(R, 1)
+  I, _ = sub(F, [x*F[1], y*F[1]])
+  @test Oscar.standard_basis_modular(I) isa Oscar.ModuleGens
+end
+

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -2232,6 +2232,9 @@ end
   M, _ = quo(F, I)
   @test !is_zero(M[1]) # triggers a dodgy GB computation
   @test !is_empty(AbstractAlgebra.dodgy_steps_get())
+  AbstractAlgebra.dodgy_steps_clear()
+  free_resolution(I)
+  @test length(AbstractAlgebra.dodgy_steps_get()) == 2 # dodgy syzygies for presentation and dodgy gb for resolution.
   AbstractAlgebra.set_dodgy_mode(false)
   AbstractAlgebra.dodgy_steps_clear()
   I, _ = sub(F, [x*F[1], y*F[1]])

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -2221,9 +2221,22 @@ end
 end
 
 @testset "modular standard bases" begin
+  AbstractAlgebra.set_dodgy_mode(true)
   R, (x, y) = QQ[:x, :y]
   F = free_module(R, 1)
   I, _ = sub(F, [x*F[1], y*F[1]])
-  @test Oscar.standard_basis_modular(I) isa Oscar.ModuleGens
+  @test Oscar.compute_standard_basis_modular(I) isa Oscar.ModuleGens
+  @test is_empty(AbstractAlgebra.dodgy_steps_get())
+  # start from scratch to avoid interferring caches
+  I, _ = sub(F, [x*F[1], y*F[1]])
+  M, _ = quo(F, I)
+  @test !is_zero(M[1]) # triggers a dodgy GB computation
+  @test !is_empty(AbstractAlgebra.dodgy_steps_get())
+  AbstractAlgebra.set_dodgy_mode(false)
+  AbstractAlgebra.dodgy_steps_clear()
+  I, _ = sub(F, [x*F[1], y*F[1]])
+  M, _ = quo(F, I)
+  @test !is_zero(M[1])
+  @test is_empty(AbstractAlgebra.dodgy_steps_get())
 end
 


### PR DESCRIPTION
I needed this for a project with @simonfelten, so this is an effort to bring Singular's ModStd to the `OFPModules` in Oscar. 
I will try to do everything in parallel to what we have for ideals. I think, it would be nice if throughout the next weeks we could discuss how such functionality could be integrated into Oscar, even if not user-facing for the moment. 

ping @jankoboehm , @wdecker 