### PR TITLE
Account for an extra "_" in extra long tests

### DIFF
--- a/etc/testing-csv-to-json.jl
+++ b/etc/testing-csv-to-json.jl
@@ -8,6 +8,7 @@ injsonpath = "timing_summary.json"
 indict = isfile(injsonpath) ? JSON.parsefile(injsonpath) : JSON.parse("{}")
 filelist = readdir()
 filelist = filter(endswith("csv"), filelist)
+juliaVersion = join(split("$VERSION", ".")[1:2], ".")
 
 if isempty(indict)
     indict["jobs"] = Dict()
@@ -16,10 +17,6 @@ end
 for file in filelist
     (timestr, platform, juliaVersion, subset, commitHash) = split(file[1:end-4], "_")[2:end]
     # filenames on github must not contain colons so we convert to the correct timestamp format here
-    if "$(subset)_$(commitHash)" == "extra_long"
-        subset = "extra_long"
-        commitHash = split(file[1:end-4], "_")[end]
-    end
     timestamp = Dates.format(DateTime(timestr, dateformat"yyyy-mm-ddTHH-MM-SSZ"),
                              dateformat"yyyy-mm-ddTHH:MM:SS")
     if startswith(commitHash, "v")

--- a/etc/testing-csv-to-json.jl
+++ b/etc/testing-csv-to-json.jl
@@ -8,7 +8,6 @@ injsonpath = "timing_summary.json"
 indict = isfile(injsonpath) ? JSON.parsefile(injsonpath) : JSON.parse("{}")
 filelist = readdir()
 filelist = filter(endswith("csv"), filelist)
-juliaVersion = join(split("$VERSION", ".")[1:2], ".")
 
 if isempty(indict)
     indict["jobs"] = Dict()
@@ -17,6 +16,10 @@ end
 for file in filelist
     (timestr, platform, juliaVersion, subset, commitHash) = split(file[1:end-4], "_")[2:end]
     # filenames on github must not contain colons so we convert to the correct timestamp format here
+    if "$(subset)_$(commitHash)" == "extra_long"
+        subset = "extra_long"
+        commitHash = split(file[1:end-4], "_")[end]
+    end
     timestamp = Dates.format(DateTime(timestr, dateformat"yyyy-mm-ddTHH-MM-SSZ"),
                              dateformat"yyyy-mm-ddTHH:MM:SS")
     if startswith(commitHash, "v")

--- a/etc/testing-csv-to-json.jl
+++ b/etc/testing-csv-to-json.jl
@@ -8,7 +8,6 @@ injsonpath = "timing_summary.json"
 indict = isfile(injsonpath) ? JSON.parsefile(injsonpath) : JSON.parse("{}")
 filelist = readdir()
 filelist = filter(endswith("csv"), filelist)
-juliaVersion = join(split("$VERSION", ".")[1:2], ".")
 
 if isempty(indict)
     indict["jobs"] = Dict()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -215,7 +215,7 @@ if haskey(ENV, "GITHUB_ACTIONS") || haskey(ENV, "OSCAR_TEST_STATS")
   platform = Sys.islinux() ? "linux" : "macos"
   juliaVersion = join(split("$VERSION", ".")[1:2], ".")
   commitHash = metadata.commit
-  statsFileName = "test-stats_$(timestamp)_$(platform)_$(juliaVersion)_$(test_subset)_$(commitHash).csv"
+  statsFileName = "test-stats_$(timestamp)_$(platform)_$(juliaVersion)_$(replace("$test_subset", '_' => '-'))_$(commitHash).csv"
   open(joinpath(pkgdir(Oscar), statsFileName), "a") do io
     println(io, "path,time,ctime,rctime,gctime,alloc")
     DelimitedFiles.writedlm(io, ((k, v.time, v.ctime, v.rctime, v.gctime, v.alloc) for (k,v) in stats), ",")


### PR DESCRIPTION
This will allow us to add extra_long tests to the benchmarking setup.

In support for https://github.com/oscar-system/oscar-timing/issues/15

Removing line 11 is unrelated, but gets rid of an annoying warning.