### PR TITLE
Add `Combinatorics/intro.md` to the docs navigation

### DIFF
--- a/docs/doc.main
+++ b/docs/doc.main
@@ -11,6 +11,7 @@
   ],
 
   "Combinatorics" => [
+    "Combinatorics/intro.md",
     "Combinatorics/graphs.md",
     "Combinatorics/posets.md",
     "Combinatorics/matroids.md",


### PR DESCRIPTION
Just noticed that this page exists, but that it is not reachable via the nav bar