### PR TITLE
fix: minor improvements in HomotopyContinuationExt

### DIFF
--- a/ext/HomotopyContinuationExt.jl
+++ b/ext/HomotopyContinuationExt.jl
@@ -21,7 +21,7 @@ julia> p = x* y^2 + x^2
 x^2 + x*y^2
 
 julia> Expression(p)
-1.0*x*y^2 + 1.0*x^2
+x*y^2 + x^2
 ```
 """
 function Expression(f::QQMPolyRingElem)
@@ -53,15 +53,15 @@ julia> System(I)
 System of length 2
  2 variables: x, y
 
- -1.0*x*y + 1.0*x^2
- -1.0*x + 1.0*y^2
+ -x*y + x^2
+ -x + y^2
 
 julia> System(gens(I))
 System of length 2
  2 variables: x, y
 
- -1.0*x*y + 1.0*x^2
- -1.0*x + 1.0*y^2
+ -x*y + x^2
+ -x + y^2
 ```
 """
 function System(F::Vector{QQMPolyRingElem}; args...)

--- a/ext/HomotopyContinuationExt.jl
+++ b/ext/HomotopyContinuationExt.jl
@@ -103,8 +103,8 @@ julia> witness_set(I)
 Witness set for dimension 1 of degree 4
 ```
 """
-witness_set(I::Vector{QQMPolyRingElem}; show_progress=false, args...) = witness_set(System(I); show_progress, args...)
-witness_set(I::MPolyIdeal{QQMPolyRingElem}; show_progress=false, args...) = witness_set(gens(I); show_progress, args...)
+witness_set(F::Vector{QQMPolyRingElem}; show_progress=false, args...) = witness_set(System(F); show_progress, args...)
+witness_set(I::MPolyIdeal{QQMPolyRingElem}; show_progress=false, args...) = witness_set(System(I); show_progress, args...)
 
 # currently not working as expected
 #function Oscar.dim_numerical(I::Vector{QQMPolyRingElem})

--- a/ext/HomotopyContinuationExt.jl
+++ b/ext/HomotopyContinuationExt.jl
@@ -64,8 +64,13 @@ System of length 2
  -1.0*x + 1.0*y^2
 ```
 """
-System(I::Vector{QQMPolyRingElem}; args...) = System(Expression.(I); args...)
-System(I::MPolyIdeal{QQMPolyRingElem}; args...) = System(gens(I); args...)
+function System(F::Vector{QQMPolyRingElem}; args...)
+  R = parent(first(F))
+  all(f -> parent(f) === R, F) || throw(ArgumentError("All polynomials must have the same parent"))
+  return HomotopyContinuation.System(Expression.(F); variables=Variable.(symbols(R)), args...)
+end
+
+function System(I::MPolyIdeal{QQMPolyRingElem}; args...) = System(gens(I); args...)
 
 function Oscar.solve_numerical(I::Vector{QQMPolyRingElem}; show_progress=false, threading=false, args...)
   return HomotopyContinuation.solve(System(I); show_progress=show_progress, threading=threading, args...)

--- a/ext/HomotopyContinuationExt.jl
+++ b/ext/HomotopyContinuationExt.jl
@@ -29,7 +29,7 @@ function Expression(f::QQMPolyRingElem)
   # same as the ones in the Oscar polynomial f.
   v = Variable.(symbols(parent(f)))
   # Make the HomotopyContinuation expression
-  return sum(Float64(c) * prod(v[i]^e for (i,e) in enumerate(a)) for (c,a) in coefficients_and_exponents(f))
+  return sum(Rational{Int}(c) * prod(v[i]^e for (i,e) in enumerate(a)) for (c,a) in coefficients_and_exponents(f))
 end
 
 @doc raw"""

--- a/ext/HomotopyContinuationExt.jl
+++ b/ext/HomotopyContinuationExt.jl
@@ -29,7 +29,7 @@ function Expression(f::QQMPolyRingElem)
   # same as the ones in the Oscar polynomial f.
   v = Variable.(symbols(parent(f)))
   # Make the HomotopyContinuation expression
-  return sum(Rational{Int}(c) * prod(v[i]^e for (i,e) in enumerate(a)) for (c,a) in coefficients_and_exponents(f))
+  return sum(Rational{Int}(c) * prod(v[i]^e for (i,e) in enumerate(a)) for (c,a) in coefficients_and_exponents(f); init=Expression(0))
 end
 
 @doc raw"""

--- a/ext/HomotopyContinuationExt.jl
+++ b/ext/HomotopyContinuationExt.jl
@@ -70,7 +70,11 @@ function System(F::Vector{QQMPolyRingElem}; args...)
   return HomotopyContinuation.System(Expression.(F); variables=Variable.(symbols(R)), args...)
 end
 
-function System(I::MPolyIdeal{QQMPolyRingElem}; args...) = System(gens(I); args...)
+function System(I::MPolyIdeal{QQMPolyRingElem}; args...)
+  R = base_ring(I)
+  return HomotopyContinuation.System(Expression.(gens(I)); variables=Variable.(symbols(R)), args...)
+
+end
 
 function Oscar.solve_numerical(I::Vector{QQMPolyRingElem}; show_progress=false, threading=false, args...)
   return HomotopyContinuation.solve(System(I); show_progress=show_progress, threading=threading, args...)

--- a/ext/HomotopyContinuationExt.jl
+++ b/ext/HomotopyContinuationExt.jl
@@ -73,7 +73,6 @@ end
 function System(I::MPolyIdeal{QQMPolyRingElem}; args...)
   R = base_ring(I)
   return HomotopyContinuation.System(Expression.(gens(I)); variables=Variable.(symbols(R)), args...)
-
 end
 
 function Oscar.solve_numerical(I::Vector{QQMPolyRingElem}; show_progress=false, threading=false, args...)

--- a/ext/HomotopyContinuationExt.jl
+++ b/ext/HomotopyContinuationExt.jl
@@ -68,7 +68,7 @@ System(I::Vector{QQMPolyRingElem}; args...) = System(Expression.(I); args...)
 System(I::MPolyIdeal{QQMPolyRingElem}; args...) = System(gens(I); args...)
 
 function Oscar.solve_numerical(I::Vector{QQMPolyRingElem}; show_progress=false, threading=false, args...)
-  return HomotopyContinuation.solve(System(Expression.(I), args...), show_progress=show_progress, threading=threading)
+  return HomotopyContinuation.solve(System(I); show_progress=show_progress, threading=threading, args...)
 end
                                     
 function Oscar.solve_numerical(I::MPolyIdeal{QQMPolyRingElem}; args...)

--- a/ext/HomotopyContinuationExt.jl
+++ b/ext/HomotopyContinuationExt.jl
@@ -66,7 +66,7 @@ System of length 2
 """
 function System(F::Vector{QQMPolyRingElem}; args...)
   R = parent(first(F))
-  all(f -> parent(f) === R, F) || throw(ArgumentError("All polynomials must have the same parent"))
+  @req all(f -> parent(f) === R, F) "All polynomials must have the same parent"
   return HomotopyContinuation.System(Expression.(F); variables=Variable.(symbols(R)), args...)
 end
 

--- a/ext/HomotopyContinuationExt.jl
+++ b/ext/HomotopyContinuationExt.jl
@@ -29,7 +29,7 @@ function Expression(f::QQMPolyRingElem)
   # same as the ones in the Oscar polynomial f.
   v = Variable.(symbols(parent(f)))
   # Make the HomotopyContinuation expression
-  return sum(Rational{Int}(c) * prod(v[i]^e for (i,e) in enumerate(a)) for (c,a) in coefficients_and_exponents(f); init=Expression(0))
+  return sum(Rational(c) * prod(v[i]^e for (i,e) in enumerate(a)) for (c,a) in coefficients_and_exponents(f); init=Expression(0))
 end
 
 @doc raw"""


### PR DESCRIPTION
I recently played a bit with the new interface to `HomotopyContinuation.jl` and encountered a few minor bugs and behaviors that felt unexpected. Here's a quick attempt to fix these. Some points are a bit subjective, so feel free to revert things you don't like!

**Variables:** When constructing a HC.jl system of an ideal, I would expect all variables of the parent ring to appear as variables in the system. Example:

```julia
using Oscar, HomotopyContinuation
R, (x,y,z) = QQ[:x, :y, :z]
I = ideal(R, [x^2+y^2, 2*x+3*y-1])
```

Before:

```julia-repl
julia> System(I)
System of length 2
 2 variables: x, y

 1.0*x^2 + 1.0*y^2
 -1.0 + 2.0*x + 3.0*y
```

Now: 

```julia-repl
julia> System(I)
System of length 2
 3 variables: x, y, z

 1.0*x^2 + 1.0*y^2
 -1.0 + 2.0*x + 3.0*y
```
 
**Coefficients:** Rational coefficients are now kept rational, which makes it easier to visually inspect the HC.jl objects. In the above example, the output now looks like this:

```julia-repl
julia> System(I)
System of length 2
 3 variables: x, y, z

 x^2 + y^2
 -1 + 2*x + 3*y
```


**Keywords:**  The keywords for `solve_numerical` accidentally ended up in the System constructor before, which gave rise to errors like these:

```julia-repl
julia> I = ideal(R, [x^2+y^2, 2*x+3*y-1, z-2]);

julia> Oscar.solve_numerical(I, start_system = :total_degree)
ERROR: MethodError: no method matching System(::Vector{Expression}, ::Pair{Symbol, Symbol})
The type `System` exists, but no method is defined for this combination of argument types when trying to construct it.

Closest candidates are:
  System(::Vector{Expression}, ::Vector{Variable}, ::Vector{Variable})
   @ HomotopyContinuation ~/.julia/packages/HomotopyContinuation/lRShs/src/model_kit/symbolic.jl:1019
  System(::Vector{Expression}, ::Vector{Variable}, ::Vector{Variable}, ::Union{Nothing, Vector{Vector{Variable}}})
   @ HomotopyContinuation ~/.julia/packages/HomotopyContinuation/lRShs/src/model_kit/symbolic.jl:1019
  System(::AbstractVector, ::Vector{Variable}, ::Vector{Variable})
   @ HomotopyContinuation ~/.julia/packages/HomotopyContinuation/lRShs/src/model_kit/symbolic.jl:1084
  ...

Stacktrace:
 [1] solve_numerical(I::Vector{QQMPolyRingElem}; show_progress::Bool, threading::Bool, args::@Kwargs{start_system::Symbol})
   @ HomotopyContinuationExt ~/.julia/packages/Oscar/JAP9M/ext/HomotopyContinuationExt.jl:71
 [2] solve_numerical(I::MPolyIdeal{QQMPolyRingElem}; args::@Kwargs{start_system::Symbol})
   @ HomotopyContinuationExt ~/.julia/packages/Oscar/JAP9M/ext/HomotopyContinuationExt.jl:75
 [3] top-level scope
   @ REPL[107]:1


```

**Edge cases:** It's now possible to construct a HC.jl system from the zero ideal, and from ideals where zero appears as a generator. Before, this gave an error:

```julia-repl
julia> I = ideal(R, [x^2+y^2, 2*x+3*y-1, 0]);

julia> System(I)
ERROR: ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer
Stacktrace:
  [1] _empty_reduce_error()
    @ Base ./reduce.jl:311
  [2] mapreduce_empty(f::Function, op::Base.BottomRF{typeof(Base.add_sum)}, T::Type)
    @ Base ./reduce.jl:313
  [3] reduce_empty(op::Base.MappingRF{…}, ::Type{…})
    @ Base ./reduce.jl:350
  [4] reduce_empty_iter
    @ ./reduce.jl:373 [inlined]
  [5] reduce_empty_iter
    @ ./reduce.jl:372 [inlined]
  [6] foldl_impl
    @ ./reduce.jl:41 [inlined]
  [7] mapfoldl_impl
    @ ./reduce.jl:36 [inlined]
  [8] mapfoldl
    @ ./reduce.jl:167 [inlined]
  [9] mapreduce
    @ ./reduce.jl:299 [inlined]
 [10] sum
    @ ./reduce.jl:524 [inlined]
 [11] sum
    @ ./reduce.jl:553 [inlined]
 [12] Expression(f::QQMPolyRingElem)
    @ HomotopyContinuationExt ~/.julia/packages/Oscar/JAP9M/ext/HomotopyContinuationExt.jl:32
 [13] _broadcast_getindex_evalf
    @ ./broadcast.jl:699 [inlined]
 [14] _broadcast_getindex
    @ ./broadcast.jl:672 [inlined]
 [15] _getindex
    @ ./broadcast.jl:620 [inlined]
 [16] getindex
    @ ./broadcast.jl:616 [inlined]
 [17] macro expansion
    @ ./broadcast.jl:995 [inlined]
 [18] macro expansion
    @ ./simdloop.jl:77 [inlined]
 [19] copyto!
    @ ./broadcast.jl:994 [inlined]
 [20] copyto!
    @ ./broadcast.jl:947 [inlined]
 [21] copy
    @ ./broadcast.jl:919 [inlined]
 [22] materialize
    @ ./broadcast.jl:894 [inlined]
 [23] System(I::Vector{QQMPolyRingElem}; args::@Kwargs{})
    @ HomotopyContinuationExt ~/.julia/packages/Oscar/JAP9M/ext/HomotopyContinuationExt.jl:67
 [24] System
    @ ~/.julia/packages/Oscar/JAP9M/ext/HomotopyContinuationExt.jl:67 [inlined]
 [25] System(I::MPolyIdeal{QQMPolyRingElem})
    @ HomotopyContinuationExt ~/.julia/packages/Oscar/JAP9M/ext/HomotopyContinuationExt.jl:68
 [26] top-level scope
    @ REPL[100]:1
Some type information was truncated. Use `show(err)` to see complete types.
```