### PR TITLE
Fixed unbound type parameters for Clifford algebras and orders

### DIFF
--- a/experimental/CliffordAlgOrd/src/CliffordAlgebra.jl
+++ b/experimental/CliffordAlgOrd/src/CliffordAlgebra.jl
@@ -68,6 +68,8 @@ Return the base ring of the Clifford algebra `C`.
 """
 base_ring(C::CliffordAlgebra) = C.base_ring::base_ring_type(typeof(C))
 
+coefficient_ring(C::CliffordAlgebra) = base_ring(C)
+
 @doc raw"""
     space(C::CliffordAlgebra) -> QuadSpace
 
@@ -112,6 +114,7 @@ coefficients(x::CliffordAlgebraElem) = x.coeffs
 ################################################################################
 
 base_ring_type(::Type{CliffordAlgebra{T, S}}) where {T, S} = parent_type(T)
+coefficient_ring_type(::Type{CliffordAlgebra{T, S}}) where {T, S} = parent_type(T)
 elem_type(::Type{CliffordAlgebra{T, S}}) where {T, S} = CliffordAlgebraElem{T, S}
 is_domain_type(::Type{CliffordAlgebraElem{T, S}}) where {T, S} = false
 is_exact_type(::Type{CliffordAlgebraElem{T, S}}) where {T, S} = true
@@ -445,13 +448,11 @@ is_odd(x::CliffordAlgebraElem) = (x == odd_part(x))
 #
 ################################################################################
 
-function AbstractAlgebra.promote_rule(::Type{CAE}, ::Type{V}) where
-        {T<:RingElement, S, CAE<:CliffordAlgebraElem{T, S}, V<:RingElement}
-    AbstractAlgebra.promote_rule(T, V) == T ? CAE : Union{}
+function AbstractAlgebra.promote_rule(::Type{CliffordAlgebraElem{T, S}}, ::Type{V}) where {T<:RingElement, S, V<:RingElement}
+  AbstractAlgebra.promote_rule(T, V) == T ? CliffordAlgebraElem{T, S} : Union{}
 end
 
-AbstractAlgebra.promote_rule(::Type{CAE}, ::Type{CAE}) where
-        {T<:RingElement, S, CAE<:CliffordAlgebraElem{T, S}} = CAE
+AbstractAlgebra.promote_rule(::Type{CliffordAlgebraElem{T, S}}, ::Type{CliffordAlgebraElem{T, S}}) where {T<:RingElement, S} = CliffordAlgebraElem{T, S}
 
 ################################################################################
 #

--- a/experimental/CliffordAlgOrd/src/CliffordOrder.jl
+++ b/experimental/CliffordAlgOrd/src/CliffordOrder.jl
@@ -14,6 +14,9 @@ parent_type(::Type{ZZCliffordOrderElem}) = ZZCliffordOrder
 base_ring_type(::Type{CliffordOrder{T, C}}) where {T, C} = parent_type(T)
 base_ring_type(::Type{ZZCliffordOrder}) = ZZRing
 
+coefficient_ring_type(::Type{CliffordOrder{T, C}}) where {T, C} = parent_type(T)
+coefficient_ring_type(::Type{ZZCliffordOrder}) = ZZRing
+
 is_domain_type(::Type{CliffordOrderElem{T, C, S}}) where {T, C, S} = false
 is_domain_type(::Type{ZZCliffordOrderElem}) = false
 
@@ -235,6 +238,9 @@ Return the base ring of the Clifford order `C`.
 """
 base_ring(C::CliffordOrder) = C.base_ring::base_ring_type(typeof(C))
 base_ring(C::ZZCliffordOrder) = C.base_ring::ZZRing
+
+coefficient_ring(C::CliffordOrder) = base_ring(C)
+coefficient_ring(C::ZZCliffordOrder) = base_ring(C)
 
 @doc raw"""
     ambient_algebra(C::Union{CliffordOrder, ZZCliffordOrder}) -> CliffordAlgebra
@@ -876,21 +882,19 @@ is_odd(x::Union{CliffordOrderElem, ZZCliffordOrderElem}) = (odd_part(x) == x)
 
 #############################################################
 #
-#  Promotion rules 
+#  Promotion rules
 #
 #############################################################
 
-function AbstractAlgebra.promote_rule(::Type{COE}, ::Type{V}) where
-        {T<:RingElement, S, COE<:CliffordOrderElem{T, S}, V<:RingElement}
-    AbstractAlgebra.promote_rule(T, V) == T ? COE : Union{}
+function AbstractAlgebra.promote_rule(::Type{CliffordOrderElem{T, S}}, ::Type{V}) where {T<:RingElement, S, V<:RingElement}
+  AbstractAlgebra.promote_rule(T, V) == T ? CliffordOrderElem{T, S} : Union{}
 end
 
-AbstractAlgebra.promote_rule(::Type{COE}, ::Type{COE}) where
-        {T<:RingElement, S, COE<:CliffordOrderElem{T, S}} = COE
+AbstractAlgebra.promote_rule(::Type{CliffordOrderElem{T, S}}, ::Type{CliffordOrderElem{T, S}}) where {T<:RingElement, S} = CliffordOrderElem{T, S}
 
 ### ZZ ###
 function AbstractAlgebra.promote_rule(::Type{ZZCliffordOrderElem}, ::Type{V}) where {V<:RingElement}
-    AbstractAlgebra.promote_rule(ZZRingElem, V) == ZZRingElem ? ZZCliffordOrderElem : Union{}
+  AbstractAlgebra.promote_rule(ZZRingElem, V) == ZZRingElem ? ZZCliffordOrderElem : Union{}
 end
 
 AbstractAlgebra.promote_rule(::Type{ZZCliffordOrderElem}, ::Type{ZZCliffordOrderElem}) = ZZCliffordOrderElem


### PR DESCRIPTION
The `promote_rule`-methods were flagged by the CI in other PRs for being susceptible to the creation of unbound type parameters. This PR fixes this and also adds the `coefficient_ring` and `coefficient_ring_type`-methods.