### PR TITLE
Fix the stabilizer of a submodule of a torsion quadratic module

### DIFF
--- a/src/Groups/abelian_aut.jl
+++ b/src/Groups/abelian_aut.jl
@@ -773,6 +773,7 @@ function stabilizer(O::AutomorphismGroup{TorQuadModule}, i::TorQuadModuleMap)
     A = domain(i)
     C = codomain(i)
     S = O
+    iS = id_hom(O)
     pA = [i(p*x) for x in gens(A)]
     for k in 0:v
       # (A + p^k*C) / (p^(k+1)C + pA)
@@ -785,7 +786,10 @@ function stabilizer(O::AutomorphismGroup{TorQuadModule}, i::TorQuadModuleMap)
       B,j = sub(K, [iK(iD\(i(x))) for x in gens(A)])
       S,_ = stabilizer(SK,j)
       S,_ = preimage(toSK, S)
-      S,iS = preimage(iSD, S)
+      # `iS1` only maps into the stabilizer of the previous step, so we have to
+      # compose to keep an embedding into `O`
+      S,iS1 = preimage(iSD, S)
+      iS = iS1*iS
     end
     st = S,iS
     #@assert order(st[1])==order(st2[1])

--- a/test/Groups/abelian_aut.jl
+++ b/test/Groups/abelian_aut.jl
@@ -161,5 +161,18 @@ end
   OT = orthogonal_group(T)
   _, i = sub(T, [T[1]])
   @test_throws ArgumentError restrict_automorphism_group(OT, i)
+
+  # `stabilizer` must return an embedding into the group given in input, also
+  # for a submodule whose exponent is a proper prime power
+  L = direct_sum(root_lattice(:D, 5), root_lattice(:A, 3), root_lattice(:A, 3),
+                 root_lattice(:A, 3), root_lattice(:A, 1))[1]
+  T = discriminant_group(L)
+  OT = orthogonal_group(T)
+  _, i = sub(T, [T[2]])
+  @test order(domain(i)) == 4
+  S, j = stabilizer(OT, i)
+  @test codomain(j) === OT
+  @test is_subset(S, OT)
+  @test is_invariant(S, i)
 end
 


### PR DESCRIPTION
`stabilizer(::AutomorphismGroup{TorQuadModule}, ::TorQuadModuleMap)` is meant to
return the stabilizer together with its embedding into the group given in input.
For a submodule whose exponent is a proper prime power, the computation descends
along a chain of successively smaller groups, and the embedding of each step was
overwritten instead of composed with the previous ones. The returned map
therefore went into the stabilizer computed in the step before, not into the
group given in input.

Callers relying on the codomain of that map then worked with a group which is too
small. In `primitive_embeddings` this made the classifying group attached to a
gluing collapse to a stabilizer, so that splitting the corresponding orbit ended
in `AssertionError: K is not a subgroup of G`:

```julia
g = genus(ZZ[-2 -1 -1 1 1 -1 1 -1 0 0 0 0 0 0 0 0 0; -1 -2 -1 0 1 -1 0 0 0 0 0 0 0 0 0 0 0; -1 -1 -2 1 1 -1 1 -1 0 0 0 0 0 0 0 0 0; 1 0 1 -2 -1 0 -1 1 0 0 0 0 0 0 0 0 0; 1 1 1 -1 -2 1 -1 1 0 0 0 0 0 0 0 0 0; -1 -1 -1 0 1 -2 1 -1 0 0 0 0 0 0 0 0 0; 1 0 1 -1 -1 1 -2 1 0 0 0 0 0 0 0 0 0; -1 0 -1 1 1 -1 1 -2 0 0 0 0 0 0 0 0 0; 0 0 0 0 0 0 0 0 -2 1 -1 -1 1 -1 0 1 0; 0 0 0 0 0 0 0 0 1 -2 1 1 0 0 0 0 0; 0 0 0 0 0 0 0 0 -1 1 -2 0 0 0 0 0 0; 0 0 0 0 0 0 0 0 -1 1 0 -2 0 0 0 1 0; 0 0 0 0 0 0 0 0 1 0 0 0 -2 1 0 -1 0; 0 0 0 0 0 0 0 0 -1 0 0 0 1 -2 0 1 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 0 -2 1 0; 0 0 0 0 0 0 0 0 1 0 0 1 -1 1 1 -4 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 -4])

R = integer_lattice(gram=ZZ[-2 0 1 0 0 0 0 0 0 0 0 0 0 0 0; 0 -2 1 0 0 0 0 0 0 0 0 0 0 0 0; 1 1 -2 1 0 0 0 0 0 0 0 0 0 0 0; 0 0 1 -2 1 0 0 0 0 0 0 0 0 0 0; 0 0 0 1 -2 0 0 0 0 0 0 0 0 0 0; 0 0 0 0 0 -2 1 0 0 0 0 0 0 0 0; 0 0 0 0 0 1 -2 1 0 0 0 0 0 0 0; 0 0 0 0 0 0 1 -2 0 0 0 0 0 0 0; 0 0 0 0 0 0 0 0 -2 1 0 0 0 0 0; 0 0 0 0 0 0 0 0 1 -2 1 0 0 0 0; 0 0 0 0 0 0 0 0 0 1 -2 0 0 0 0; 0 0 0 0 0 0 0 0 0 0 0 -2 1 0 0; 0 0 0 0 0 0 0 0 0 0 0 1 -2 1 0; 0 0 0 0 0 0 0 0 0 0 0 0 1 -2 0; 0 0 0 0 0 0 0 0 0 0 0 0 0 0 -2])

primitive_embeddings(g, R)
```

Here the discriminant group of `R` is `Z/2 x (Z/4)^4` with `|O(q_R)| = 6144`, but
every local gluing along a glue group with a cyclic factor of order at least 4
came back with a stabilizer embedded into itself rather than into `O(q_R)`. With
this change the computation returns `true` together with 16 primitive embeddings.

The stabilizer itself is unchanged, only the codomain of the returned map, so no
other results are affected.

Besides the tests added here, the test suite in `test/NumberTheory/QuadFormAndIsom/`
and the doctests of `src/Groups/abelian_aut.jl` pass.

This pull request was written with the assistance of generative AI (Claude Code).