### PR TITLE
docs: backtick two `@ref`s that name functions

### DIFF
--- a/experimental/InjectiveResolutions/docs/src/injective_resolutions.md
+++ b/experimental/InjectiveResolutions/docs/src/injective_resolutions.md
@@ -11,7 +11,7 @@ An *injective resolution* is an exact sequence
 
 $0 \to M \xhookrightarrow{\epsilon} J^0 \xrightarrow{d^0} J^1 \xrightarrow{d^1} \dots \xrightarrow{d^{i-1}} J^i \xrightarrow{d^i} \cdots.$
 
-The maps $d^j$ are given by monomial matrices. The function [injective_resolution](@ref) computes 
+The maps $d^j$ are given by monomial matrices. The function [`injective_resolution`](@ref) computes 
 an injective resolution up to some given cohomological degree. 
 This is an implementation of the algorithms in [HM05](@cite).
 

--- a/experimental/InjectiveResolutions/docs/src/local_cohomology.md
+++ b/experimental/InjectiveResolutions/docs/src/local_cohomology.md
@@ -56,7 +56,7 @@ $H^i_J(M)_\alpha \cong k^{\dim(H_S)} \text{ for } \alpha \in S.$
 
 For more details on sector partitions see, e.g., Chapter 13 of [MS05](@cite).
 
-The function [local_cohomology](@ref) computes a sector partition 
+The function [`local_cohomology`](@ref) computes a sector partition 
 of $H^i_I(M)$. For performance, multiple local cohomology modules $H^1_I(M),\dots,H^i_I(M)$ 
 should be computed at once using the function `local_cohomology_all`.
 


### PR DESCRIPTION
Plain link text is a header reference; a docstring needs backticks. These two resolved only thanks to a fallback that Documenter may be dropping, see JuliaDocs/Documenter.jl#2961.