### PR TITLE
fix token permissions for booktest-warning job

### DIFF
--- a/.github/workflows/BooktestWarnings.yml
+++ b/.github/workflows/BooktestWarnings.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Comment if booktests changed
         uses: actions/github-script@v9
         with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const marker = "<!-- oscar-booktest-warning -->";
             const { owner, repo } = context.repo;

--- a/.github/workflows/BooktestWarnings.yml
+++ b/.github/workflows/BooktestWarnings.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -22,7 +22,6 @@ jobs:
       - name: Comment if booktests changed
         uses: actions/github-script@v9
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const marker = "<!-- oscar-booktest-warning -->";
             const { owner, repo } = context.repo;

--- a/test/book/specialized/decker-schmitt-invariant-theory/sym.jlcon
+++ b/test/book/specialized/decker-schmitt-invariant-theory/sym.jlcon
@@ -6,7 +6,7 @@ julia> L = fundamental_invariants(RS4)
 4-element Vector{MPolyDecRingElem{FqFieldElem, FqMPolyRingElem}}:
  x[1] + x[2] + x[3] + x[4]
  x[1]*x[2] + x[1]*x[3] + x[2]*x[3] + x[1]*x[4] + x[2]*x[4] + x[3]*x[4]
- x[1]^3 + x[2]^3 + x[3]^3 + x[4]^3
+ x[1]*x[2]*x[3] + x[1]*x[2]*x[4] + x[1]*x[3]*x[4] + x[2]*x[3]*x[4]
  x[1]*x[2]*x[3]*x[4]
 
 julia> is_algebraically_independent(L)

--- a/test/book/specialized/decker-schmitt-invariant-theory/sym.jlcon
+++ b/test/book/specialized/decker-schmitt-invariant-theory/sym.jlcon
@@ -6,7 +6,7 @@ julia> L = fundamental_invariants(RS4)
 4-element Vector{MPolyDecRingElem{FqFieldElem, FqMPolyRingElem}}:
  x[1] + x[2] + x[3] + x[4]
  x[1]*x[2] + x[1]*x[3] + x[2]*x[3] + x[1]*x[4] + x[2]*x[4] + x[3]*x[4]
- x[1]*x[2]*x[3] + x[1]*x[2]*x[4] + x[1]*x[3]*x[4] + x[2]*x[3]*x[4]
+ x[1]^3 + x[2]^3 + x[3]^3 + x[4]^3
  x[1]*x[2]*x[3]*x[4]
 
 julia> is_algebraically_independent(L)


### PR DESCRIPTION
[skip ci]

Should fix the booktests warning part of #6168.

The latest change to this pull request was made with assistance from generative AI.