### PR TITLE
Add reduced characteristic vector sets to speed up canonical form for lattices with roots.

### DIFF
--- a/src/NumberTheory/ZLattices.jl
+++ b/src/NumberTheory/ZLattices.jl
@@ -212,6 +212,8 @@ function characteristic_vectors(L::ZZLat)
   return cvL
 end
 
+_get_canonical_form(A::ZZMatrix, char_vectors_set::Vector{Matrix{Int}}, canonical_ordering::Vector{Int}) = _get_canonical_form(A, [matrix(ZZ, v) for v in char_vectors_set], canonical_ordering)
+
 function _get_canonical_form(A::ZZMatrix, char_vectors_set::Vector{ZZMatrix}, canonical_ordering::Vector{Int})
   p = length(char_vectors_set)
   filter!(e->e!=p+1 && e!=p+2, canonical_ordering)
@@ -219,6 +221,45 @@ function _get_canonical_form(A::ZZMatrix, char_vectors_set::Vector{ZZMatrix}, ca
   _, U = hnf_with_transform(can_char_vectors_set) 
   U_inv = inv(U)
   return transpose(U_inv)*A*U_inv
+end
+
+function _reduce_characteristic_vectors(cv_set::Vector{ZZMatrix}, L::ZZLat)
+  R, _, _ = root_lattice_recognition_fundamental(L)
+  A = basis_matrix(R)
+  gram = matrix(ZZ, gram_matrix(L))
+  tmp = ZZ(0)
+  gram_int = Hecke._int_matrix_with_overflow(gram, tmp)
+  B_lat = basis_matrix(L)
+  A_lat = change_base_ring(ZZ, solve(B_lat, A))
+  v_i = Matrix{Int}(undef, 1, number_of_columns(gram))
+  t_i = Matrix{Int}(undef, number_of_rows(gram), 1)
+  w_i = Matrix{Int}(undef, 1, 1)
+  A_lat_int = Hecke._int_matrix_with_overflow(A_lat, tmp)
+  fundamental_roots = [reshape(A_lat_int[i, :], :, 1) for i in 1:number_of_rows(A_lat_int)]
+  res::Vector{Matrix{Int}} = []
+  for v in cv_set
+    v_int = Hecke._int_matrix_with_overflow(v, tmp)
+    AbstractAlgebra.LinearAlgebra.mul!(v_i, v_int, gram_int)
+    AbstractAlgebra.LinearAlgebra.mul!(w_i, v_i, AbstractAlgebra.LinearAlgebra.transpose!(t_i, v_int))
+    if w_i[1] == 1 || w_i[1] == 2
+      continue
+    end
+    in_chamber = true
+    for f_root in fundamental_roots
+      AbstractAlgebra.LinearAlgebra.mul!(w_i, v_i, f_root)
+      if w_i[1] < 0
+        in_chamber = false
+        break
+      end
+    end
+    if in_chamber
+      push!(res, v_int)
+    end
+  end
+  for f_root in fundamental_roots
+    push!(res, f_root')
+  end
+  return res
 end
 
 function _get_edge_labeled_graph(cv_set::Vector{ZZMatrix}, gram::ZZMatrix)
@@ -288,6 +329,7 @@ We follow ideas of Sikirić, Haensch, Voight and van Woerden [SHVW20](@cite).
 function canonical_form(L::ZZLat)
   gram = matrix(ZZ, gram_matrix(L))
   char_vectors_set = characteristic_vectors(L)
+  char_vectors_set = _reduce_characteristic_vectors(char_vectors_set, L)
   graph = _get_edge_labeled_graph(char_vectors_set, gram) # transform from adjenctcy matrix A to edge-vertex weighted graph Ga, then to edge weighted graph T1(Ga)
   can_order = _canonical_perm(graph; label=:edge) #_canonical_perm uses _edge_label_to_vertex_label themselfs
   return _get_canonical_form(gram, char_vectors_set, can_order)

--- a/src/NumberTheory/ZLattices.jl
+++ b/src/NumberTheory/ZLattices.jl
@@ -223,24 +223,24 @@ function _get_canonical_form(A::ZZMatrix, char_vectors_set::Vector{ZZMatrix}, ca
   return transpose(U_inv)*A*U_inv
 end
 
-function _reduce_characteristic_vectors(cv_set::Vector{ZZMatrix}, L::ZZLat)
+_reduce_characteristic_vectors(cv_set::Vector{ZZMatrix}, L::ZZLat) = _reduce_characteristic_vectors(_convert_cv_set_to_int(cv_set, matrix(ZZ, gram_matrix(L))), L)
+function _reduce_characteristic_vectors(cv_set::Vector{Matrix{Int}}, L::ZZLat)
   R, _, _ = root_lattice_recognition_fundamental(L)
   A = basis_matrix(R)
   gram = matrix(ZZ, gram_matrix(L))
-  tmp = ZZ(0)
-  gram_int = Hecke._int_matrix_with_overflow(gram, tmp)
   B_lat = basis_matrix(L)
   A_lat = change_base_ring(ZZ, solve(B_lat, A))
   v_i = Matrix{Int}(undef, 1, number_of_columns(gram))
   t_i = Matrix{Int}(undef, number_of_rows(gram), 1)
   w_i = Matrix{Int}(undef, 1, 1)
+  tmp = ZZ(0)
+  gram_int = Hecke._int_matrix_with_overflow(gram, tmp)
   A_lat_int = Hecke._int_matrix_with_overflow(A_lat, tmp)
   fundamental_roots = [reshape(A_lat_int[i, :], :, 1) for i in 1:number_of_rows(A_lat_int)]
   res::Vector{Matrix{Int}} = []
   for v in cv_set
-    v_int = Hecke._int_matrix_with_overflow(v, tmp)
-    AbstractAlgebra.LinearAlgebra.mul!(v_i, v_int, gram_int)
-    AbstractAlgebra.LinearAlgebra.mul!(w_i, v_i, AbstractAlgebra.LinearAlgebra.transpose!(t_i, v_int))
+    AbstractAlgebra.LinearAlgebra.mul!(v_i, v, gram_int)
+    AbstractAlgebra.LinearAlgebra.mul!(w_i, v_i, AbstractAlgebra.LinearAlgebra.transpose!(t_i, v))
     if w_i[1] == 1 || w_i[1] == 2
       continue
     end
@@ -253,7 +253,7 @@ function _reduce_characteristic_vectors(cv_set::Vector{ZZMatrix}, L::ZZLat)
       end
     end
     if in_chamber
-      push!(res, v_int)
+      push!(res, v)
     end
   end
   for f_root in fundamental_roots
@@ -262,7 +262,7 @@ function _reduce_characteristic_vectors(cv_set::Vector{ZZMatrix}, L::ZZLat)
   return res
 end
 
-function _get_edge_labeled_graph(cv_set::Vector{ZZMatrix}, gram::ZZMatrix)
+function _convert_cv_set_to_int(cv_set::Vector{ZZMatrix}, gram::ZZMatrix)
   tmp = ZZ(0)
   n = ZZ(0)
   tmp1 = zero_matrix(ZZ, 1, number_of_columns(gram))
@@ -278,7 +278,7 @@ function _get_edge_labeled_graph(cv_set::Vector{ZZMatrix}, gram::ZZMatrix)
   else 
     throw(OverflowError("The characteristic vectors have to large inner products to be converted to Int."))
   end
-  return _get_edge_labeled_graph(cv_set_int, Hecke._int_matrix_with_overflow(gram, tmp))
+  return cv_set_int
 end
 
 _get_edge_labeled_graph(cv_set::Vector{Matrix{Int}}, gram::ZZMatrix) = _get_edge_labeled_graph(cv_set, Hecke._int_matrix_with_overflow(gram, ZZ(0)))

--- a/test/NumberTheory/ZLattices.jl
+++ b/test/NumberTheory/ZLattices.jl
@@ -40,8 +40,8 @@ end
   L2 = integer_lattice(gram = G2)
   L3 = lattice_in_same_ambient_space(L1,U*basis_matrix(L1))
   can_form1 = canonical_form(L1)
-  # can_form2 =  canonical_form(L2) # too long time, circa 1 hour to calculate can form
+  can_form2 =  canonical_form(L2) # has 2400 char vectors, after reducing it has 18
   can_form3 =  canonical_form(L3)
-  # @test can_form1 != can_form2
+  @test can_form1 != can_form2
   @test can_form1 == can_form3
 end


### PR DESCRIPTION
Added `_reduce_characteristic_vectors` internal function, that reduces characteristic vectors to only vectors in fundamental chamber of lattice + fundamental root vectors. 

Renamed  `_get_edge_labeled_graph` dispatch function that I used to convert cv set to Int. Now it is `_convert_cv_set_to_int` and used in type dispatch for `_reduce_characteristic_vectors`. 

`_reduce_characteristic_vectors` function returns a vector of Matrix{Int}, so conversion in graph function is now not needed. 

Added re-conversion back for `_get_canonical_form` as it uses Oscar matricies for HNF computation. 

Uncommented second lattice in second test set, as it is now runs in short time. There is 2400+ cv set length, after reduction it is 18 => we can include this example in test set properly now.