### PR TITLE
add membership test in `image` for `GAPGroupHomomorphism`

### DIFF
--- a/src/Groups/GAPGroups.jl
+++ b/src/Groups/GAPGroups.jl
@@ -597,7 +597,7 @@ Base.length(x::GAPGroup)::Int = order(Int, x)
 Return whether `g` is an element of `G`.
 The parent of `g` need not be equal to `G`.
 """
-Base.in(g::GAPGroupElem, G::GAPGroup) = GapObj(g) in GapObj(G)
+Base.in(g::GAPGroupElem, G::GAPGroup) = parent(g) === G || GapObj(g) in GapObj(G)
 
 """
     gens(G::Group)

--- a/src/Groups/homomorphisms.jl
+++ b/src/Groups/homomorphisms.jl
@@ -354,11 +354,15 @@ true
 ```
 """
 function image(f::GAPGroupHomomorphism, x::GAPGroupElem)
+  @req x in domain(f) "the element is not in the domain of f"
   return group_element(codomain(f), GAPWrap.ImagesRepresentative(GapObj(f), GapObj(x)))
 end
 
 # images under a `GAPGroupEmbedding` are computed by unwrapping and wrapping
-image(f::GAPGroupEmbedding, x::GAPGroupElem) = group_element(codomain(f), GapObj(x))
+function image(f::GAPGroupEmbedding, x::GAPGroupElem)
+  @req x in domain(f) "the element is not in the domain of f"
+  return group_element(codomain(f), GapObj(x))
+end
 
 (f::Union{GAPGroupHomomorphism, GAPGroupEmbedding})(x::GAPGroupElem) = image(f, x)
 Base.:^(x::GAPGroupElem,f::Union{GAPGroupHomomorphism, GAPGroupEmbedding}) = image(f,x)

--- a/test/Groups/homomorphisms.jl
+++ b/test/Groups/homomorphisms.jl
@@ -9,7 +9,16 @@
      @test id_hom(H) * emb == emb
      @test emb * id_hom(G) == emb
      @test is_trivial(ker)
+
+     @test_throws ArgumentError [image(emb, g) for g in gens(G)]
    end
+end
+
+@testset "image" begin
+  G = symmetric_group(3)
+  H, _ = trivial_subgroup(G)
+  f = hom(H, G, gens(H))
+  @test_throws ArgumentError f(gen(G, 1))
 end
 
 n = 6


### PR DESCRIPTION
(same for `GAPGroupEmbedding`)

And make the membership (hopefully) cheaper:
Do not ask GAP for a computation if the parent of the element fits.

resolves #6194