### PR TITLE
Fix serialization of rigid matroid realization spaces

### DIFF
--- a/experimental/MatroidRealizationSpaces/src/serialization.jl
+++ b/experimental/MatroidRealizationSpaces/src/serialization.jl
@@ -29,7 +29,7 @@ function load_object(s::DeserializerState, ::Type{<:MatroidRealizationSpace}, di
   R = dict[:ideal_ring]
   GR = dict[:ground_ring]
   I = load_object(s, MPolyIdeal, R, :defining_ideal)
-  Ineqs = load_object(s, Vector{MPolyRingElem}, R, :inequations)
+  Ineqs = load_object(s, Vector{elem_type(R)}, R, :inequations)
   RMat = isnothing(MS) ? nothing : load_object(s, MatElem, MS, :realization_matrix)
   if R isa MPolyRing
     char = characteristic(coefficient_ring(R))
@@ -72,7 +72,7 @@ function load_object(s::DeserializerState, ::Type{<:MatroidRealizationSpaceSelfP
   R = dict[:ideal_ring]
   GR = dict[:ground_ring]
   I = load_object(s, MPolyIdeal, R, :defining_ideal)
-  Ineqs = load_object(s, Vector{MPolyRingElem}, R, :inequations)
+  Ineqs = load_object(s, Vector{elem_type(R)}, R, :inequations)
   RMat = isnothing(MS) ? nothing : load_object(s, MatElem, MS, :selfprojecting_realization_matrix)
   if R isa MPolyRing
     char = characteristic(coefficient_ring(R))

--- a/experimental/MatroidRealizationSpaces/test/runtests.jl
+++ b/experimental/MatroidRealizationSpaces/test/runtests.jl
@@ -237,3 +237,43 @@ end
         @test dimension(selfprojecting_realization_space(M6)) == -inf
     end
 end
+
+@testset "matroid realization space serialization" begin
+    # Regression: a fully reduced (rigid) chart has ambient ring ZZ, and the
+    # loader used to request the inequations as Vector{MPolyRingElem} over
+    # that ZZRing — a method that does not exist, so such charts could not be
+    # loaded in a fresh session. (In the session that saved them, the uses_id
+    # cache returned the object without running the loader, masking the bug.)
+    # The non-Fano matroid produces exactly such a chart: ambient ring ZZ,
+    # zero ideal, inequations [2].
+    RS = realization_space(non_fano_matroid(); saturate=true)
+    @test ambient_ring(RS) isa ZZRing        # precondition: chart is rigid
+    @test !isempty(inequations(RS))
+
+    io = IOBuffer()
+    save(io, RS)
+    Oscar.reset_global_serializer_state()    # simulate a fresh session
+    seekstart(io)
+    loaded = load(io)
+    @test loaded isa Oscar.MatroidRealizationSpace
+    @test ambient_ring(loaded) isa ZZRing
+    @test gens(defining_ideal(loaded)) == gens(defining_ideal(RS))
+    @test inequations(loaded) == inequations(RS)
+    @test realization_matrix(loaded) == realization_matrix(RS)
+
+    # ordinary polynomial-ambient chart: unaffected path stays intact.
+    # After the state reset the loaded ring is a distinct parent, so compare
+    # string representations rather than elements across parents.
+    RS2 = realization_space(pappus_matroid(); saturate=true)
+    @test !(ambient_ring(RS2) isa ZZRing)
+    io2 = IOBuffer()
+    save(io2, RS2)
+    Oscar.reset_global_serializer_state()
+    seekstart(io2)
+    loaded2 = load(io2)
+    @test loaded2 isa Oscar.MatroidRealizationSpace
+    @test symbols(ambient_ring(loaded2)) == symbols(ambient_ring(RS2))
+    @test string.(gens(defining_ideal(loaded2))) == string.(gens(defining_ideal(RS2)))
+    @test string.(inequations(loaded2)) == string.(inequations(RS2))
+    @test string(realization_matrix(loaded2)) == string(realization_matrix(RS2))
+end

--- a/src/Serialization/Rings.jl
+++ b/src/Serialization/Rings.jl
@@ -255,6 +255,23 @@ end
 @register_serialization_type MPolyQuoLocalizedIdeal
 @register_serialization_type MPolyQuoIdeal
 @register_serialization_type Hecke.PIDIdeal
+# ZZIdl is not a subtype of Ideal, so the generic Ideal
+# save/load below do not apply
+@register_serialization_type Hecke.ZZIdl
+
+save_object(s::SerializerState, I::Hecke.ZZIdl) = save_object(s, gens(I))
+
+function load_object(s::DeserializerState, ::Type{Hecke.ZZIdl}, ::ZZRing)
+  gens = ZZRingElem[]
+  load_array_node(s) do _
+    push!(gens, load_object(s, ZZRingElem, ZZ))
+  end
+  return ideal(ZZ, gens)
+end
+
+# the parent is always ZZ, so top-level loads need no params
+load_object(s::DeserializerState, ::Type{Hecke.ZZIdl}) =
+  load_object(s, Hecke.ZZIdl, ZZ)
 
 function save_object(s::SerializerState, I::Ideal)
   # we might want to serialize generating_system(I) and I.gb

--- a/test/Serialization/PolynomialsSeries.jl
+++ b/test/Serialization/PolynomialsSeries.jl
@@ -239,3 +239,13 @@ end
     end
   end
 end
+
+@testset "ZZIdl serialization" begin
+  mktempdir() do path
+    I = ideal(ZZ, [ZZ(3)])
+    test_save_load_roundtrip(path, I) do loaded
+      @test loaded == I
+      @test loaded == ideal(ZZ, ZZ(3))
+    end
+  end
+end


### PR DESCRIPTION
A fully reduced ("rigid") MatroidRealizationSpace has ambient ring ZZ and stores its defining ideal as a Hecke.ZZIdl. Two independent problems made these charts unserializable:  
1.. ZZIdl was never registered for serialization (and is not a subtype of Ideal, so the generic ideal methods don't apply) — save throws a MethodError.
2. The MatroidRealizationSpace loader hard-codes load_object(s, Vector{MPolyRingElem}, R, :inequations), which has no method for R::ZZRing — such charts cannot be loaded in a fresh session. 

This PR fixes both of these issues by adding save and load for ZZIdl and making the load of a MatroidRealizationSpace more liberal so that rigid spaces can also be loaded.

Includes regression tests: cold-session roundtrip of the non-Fano chart (via reset_global_serializer_state) that's the case that previously failed, a polynomial-ambient chart roundtrip, and a standalone ZZIdl roundtrip.