### PR TITLE
Fix the canonical form of a lattice depending on the chosen basis

### DIFF
--- a/src/NumberTheory/ZLattices.jl
+++ b/src/NumberTheory/ZLattices.jl
@@ -329,6 +329,10 @@ We follow ideas of Sikirić, Haensch, Voight and van Woerden [SHVW20](@cite).
 function canonical_form(L::ZZLat)
   gram = matrix(ZZ, gram_matrix(L))
   char_vectors_set = characteristic_vectors(L)
+  # `characteristic_vectors` returns the characteristic vectors only up to
+  # sign; reducing to the fundamental chamber does not commute with the choice
+  # of the signs, so we have to take all of them
+  char_vectors_set = unique!(append!(char_vectors_set, ZZMatrix[-v for v in char_vectors_set]))
   char_vectors_set = _reduce_characteristic_vectors(char_vectors_set, L)
   graph = _get_edge_labeled_graph(char_vectors_set, gram) # transform from adjenctcy matrix A to edge-vertex weighted graph Ga, then to edge weighted graph T1(Ga)
   can_order = _canonical_perm(graph; label=:edge) #_canonical_perm uses _edge_label_to_vertex_label themselfs

--- a/test/NumberTheory/ZLattices.jl
+++ b/test/NumberTheory/ZLattices.jl
@@ -44,4 +44,8 @@ end
   can_form3 =  canonical_form(L3)
   @test can_form1 != can_form2
   @test can_form1 == can_form3
+
+  G = matrix(QQ, 4, 4, [2,0,0,0, 0,3,1,1, 0,1,3,-1, 0,1,-1,5])
+  U = matrix(QQ, 4, 4, [0,1,1,0, 0,0,0,-1, 0,0,-1,1, 1,-1,-1,1])
+  @test canonical_form(integer_lattice(gram = G)) == canonical_form(integer_lattice(gram = U*G*transpose(U)))
 end


### PR DESCRIPTION
`characteristic_vectors` returns the characteristic vectors of a lattice only up to sign, and which of the two signs is returned depends on the basis. Reducing to the fundamental Weyl chamber does not commute with that choice, because the Weyl group acts only on the root part of a vector. Therefore the canonical form was not an invariant of the isometry class. We now reduce the set of characteristic vectors together with its negatives.

This pull request was written with the assistance of generative AI (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)