### PR TITLE
Fix G4Flux hashing after hypersurface restriction

### DIFF
--- a/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
+++ b/experimental/FTheoryTools/src/G4Fluxes/constructors.jl
@@ -153,21 +153,22 @@ end
 # 2: Equality and hash
 ################################################
 
+function _hypersurface_class(m::AbstractFTheoryModel)
+  if !(m isa WeierstrassModel || m isa GlobalTateModel || m isa HypersurfaceModel)
+    error(
+      "Can currently only determine the hypersurface class for Weierstrass, global Tate and hypersurface models"
+    )
+  end
+  cl = toric_divisor_class(ambient_space(m), degree(hypersurface_equation(m)))
+  return cohomology_class(cl)
+end
+
 function Base.:(==)(gf1::G4Flux, gf2::G4Flux)
   # G4-fluxes can only be equal if they are defined for identically the same model
   model(gf1) !== model(gf2) && return false
 
-  # Currently, can only decide equality for Weierstrass, global Tate and hypersurface models
-  m = model(gf1)
-  if (m isa WeierstrassModel || m isa GlobalTateModel || m isa HypersurfaceModel) == false
-    error(
-      "Can currently only decide equality of G4-fluxes for Weierstrass, global Tate and hypersurface models"
-    )
-  end
-
   # Compute the cohomology class corresponding to the hypersurface equation
-  cl = toric_divisor_class(ambient_space(m), degree(hypersurface_equation(m)))
-  cy = cohomology_class(cl)
+  cy = _hypersurface_class(model(gf1))
 
   # Now can return the result
   return cy * cohomology_class(gf1) == cy * cohomology_class(gf2)
@@ -175,8 +176,9 @@ end
 
 function Base.hash(gf::G4Flux, h::UInt)
   b = 0x92bd6ac4f87d834e % UInt
-  h = hash(model(gf), h)
-  h = hash(cohomology_class(gf), h)
+  m = model(gf)
+  h = hash(m, h)
+  h = hash(_hypersurface_class(m) * cohomology_class(gf), h)
   return xor(h, b)
 end
 

--- a/experimental/FTheoryTools/test/weierstrass_models.jl
+++ b/experimental/FTheoryTools/test/weierstrass_models.jl
@@ -35,6 +35,30 @@ weierstrass_P3 = weierstrass_model(P3; completeness_check=false, rng=our_rng)
   @test isempty(exceptional_divisor_indices(weierstrass_P3))
 end
 
+# Equal G4-fluxes must have equal hashes after restriction to the hypersurface.
+@testset "Hashing G4-fluxes" begin
+  ambient = ambient_space(weierstrass_P3)
+  cohomology = cohomology_ring(ambient; completeness_check=false)
+  cy = cohomology_class(
+    toric_divisor_class(ambient, degree(hypersurface_equation(weierstrass_P3)));
+    completeness_check=false,
+  )
+  candidates = [
+    cohomology_class(ambient, x * y; completeness_check=false) for
+    (i, x) in enumerate(gens(cohomology)) for y in gens(cohomology)[i:end]
+  ]
+  kernel_index = findfirst(
+    c -> !iszero(polynomial(c)) && iszero(polynomial(cy * c)), candidates
+  )::Int
+  kernel_class = candidates[kernel_index]
+  zero_class = cohomology_class(ambient, zero(cohomology); completeness_check=false)
+  zero_flux = Oscar.G4Flux(weierstrass_P3, zero_class)
+  kernel_flux = Oscar.G4Flux(weierstrass_P3, kernel_class)
+  @test zero_flux == kernel_flux
+  @test hash(zero_flux) == hash(kernel_flux)
+  @test length(unique([zero_flux, kernel_flux])) == 1
+end
+
 # Check detailed display for a model carrying parameter metadata.
 set_attribute!(weierstrass_P3, :model_description, "Parameterized model")
 set_attribute!(weierstrass_P3, :model_parameters, Dict("z" => 2, "a" => 1))


### PR DESCRIPTION
Make G4Flux hashing use the same hypersurface-restricted cohomology class as equality, preserving Julia's hash contract for ambient classes that restrict identically.

Co-authored-by: Codex <codex@openai.com>