### PR TITLE
support `orbit(::MatGroup{E, M}, ::Vector{E})`

### DIFF
--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -253,18 +253,26 @@ function gset_by_type(G::PermGroup, Omega, ::Type{T}; closed::Bool = false) wher
   return GSetByElements(G, on_tuples_sets, Omega; closed = closed, check = false)
 end
 
-## action of permutations on vectors of positive integers
-## action of matrices on vectors via right multiplication
+## action of matrices on vectors via right multiplication,
+## where the entries of the matrices and the entries of the vectors
+## have the same type
+## (if the types do *not* match then we do not define a default action,
+## pointwise action on the entries of the vector might be a natural action)
+function gset_by_type(G::MatGroup{E, M}, Omega, ::Type{Vector{E}}; closed::Bool = false) where E where M
+  return GSetByElements(G, *, Omega; closed = closed, check = false)
+end
+
+## action of matrices on elements of free modules via right multiplication
 function gset_by_type(G::MatGroup{E, M}, Omega, ::Type{AbstractAlgebra.Generic.FreeModuleElem{E}}; closed::Bool = false) where E where M
   return GSetByElements(G, *, Omega; closed = closed, check = false)
 end
 
-## action of matrices on sets of vectors via right multiplication
+## action of matrices on sets of free module elements via right multiplication
 function gset_by_type(G::MatGroup{E, M}, Omega, ::Type{T}; closed::Bool = false) where T <: Set{AbstractAlgebra.Generic.FreeModuleElem{E}} where E where M
   return GSetByElements(G, on_sets, Omega; closed = closed, check = false)
 end
 
-## action of matrices on vectors of vectors via right multiplication
+## action of matrices on vectors of free module elements via right multiplication
 function gset_by_type(G::MatGroup{E, M}, Omega, ::Type{T}; closed::Bool = false) where T <: Vector{AbstractAlgebra.Generic.FreeModuleElem{E}} where E where M
   return GSetByElements(G, on_tuples, Omega; closed = closed, check = false)
 end

--- a/test/Groups/gsets.jl
+++ b/test/Groups/gsets.jl
@@ -345,6 +345,33 @@ end
 
 end
 
+@testset "G-sets of other matrix groups" begin
+  Z4, _ = residue_ring(ZZ, 4)
+  G = matrix_group(Z4[0 1; 1 0], Z4[0 1; -1 -1])
+
+  # action via (Julia vector) * (matrix group element)
+  v = [Z4(0), Z4(1)]
+  w = [Z4(1), Z4(1)]
+  Omega = orbit(G, v)
+  @test isa(Omega, GSet)
+  @test length(Omega) == 3
+  @test !(w in Omega)
+  C = collect(Omega)
+  @test order(stabilizer(Omega)[1]) * length(Omega) == order(G)
+  @test length(orbits(Omega)) == 1
+  @test is_transitive(Omega)
+  @test ! is_conjugate(Omega, v, w)
+  conj, M = is_conjugate_with_data(Omega, v, -w)
+  @test conj
+  @test v * M == -w
+  g = gen(G, 1)
+  pi = permutation(Omega, g)
+  @test order(pi) == order(g)
+  @test degree(parent(pi)) == length(Omega)
+  acthom = action_homomorphism(Omega)
+  @test pi == g^acthom
+end
+
 @testset "subspaces iterator" begin
 
   @testset for F in [ GF(2), GF(3), GF(2,2) ], n in 2:4


### PR DESCRIPTION
The point is to define `*` as the default action function for the `gset` construction in this case.

We do not define an analogous default for the action on vectors of vectors. Pointwise action with `*` would be a natural choice, but I am not sure whether we want to handle this and a collection of similar cases by explicitly providing defaults.
In the end, we would have to list them in the documentation, and it might be simpler to enter the intended action function as an argument (`orbit(::MatGroup{E, M}, *, ::Vector{E})` in the current case).

resolves #6209