### PR TITLE
Fix two latent bugs found via closure box detection

### DIFF
--- a/experimental/GModule/src/Brueckner.jl
+++ b/experimental/GModule/src/Brueckner.jl
@@ -332,7 +332,7 @@ function lift(C::GModule, mp::Map; limit::Int = typemax(Int))
   end
 
   function _process(mu; is_trivial::Bool = false, limit::Int)
-    allG = typeof(mp)[]
+    res = typeof(mp)[]
     GG, GGinj, GGpro, GMtoGG = Oscar.GrpCoh.extension(PcGroup, mu)
     @assert isa(GG, PcGroup)
 
@@ -351,18 +351,18 @@ function lift(C::GModule, mp::Map; limit::Int = typemax(Int))
     end
     if !fl
 #      @show :no_sol
-      return allG
+      return res
     end
     k, mk = kernel(s)
     for x = k
       hm = hom(G, GG, [gns[i] * GGinj(pro[i](-pe +  mk(x))) for i=1:ngens(G)])
       if is_surjective(hm)
-        push!(allG, hm)
+        push!(res, hm)
       else
 #        @show :not_sur
       end
     end
-    return allG
+    return res
   end
 
 

--- a/src/AlgebraicGeometry/Schemes/Sheaves/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/Sheaves/Methods.jl
@@ -143,7 +143,7 @@ function produce_restriction_map(F::SheafOfModules, V::AbsAffineScheme, U::Princ
     # If the restriction was more complicated than what follows, then
     # it would have been cached earlier and this call would not have happened
     # This is the end of the recursion induced in the next elseif below.
-    res = hom(F(V), F(U), gens(F(U)), OO(X)(W, U))
+    res = hom(F(V), F(U), gens(F(U)), OO(X)(V, U))
     return res
   elseif has_ancestor(W->(W === V), U)
     W = ambient_scheme(U)


### PR DESCRIPTION
Two latent bugs found while running `Test.detect_closure_boxes` over Oscar. Both are cases where a local name is read where it is not (or no longer) the value the code means; both are independent of the refactoring that found them, so they come first and on their own.

**`produce_restriction_map` reads an undefined variable.** In the `SheafOfModules`/`PrincipalOpenSubset` method, the branch for `ambient_scheme(U) === V` restricts along `OO(X)(W, U)`, but `W` is only assigned in the `elseif` below it and further down. Reaching that branch raises an `UndefVarError`. The map wanted there is the one from `V`.

**`lift` drops all but its last batch of lifts.** `_process` is an inner function of `lift` and accumulated into `allG`, a name that is also a local of `lift`. Every call therefore rebound the outer `allG` to a fresh array, so in

```julia
append!(allG, _process(z(h); is_trivial = false, limit = limit - length(allG)))
```

the first argument was evaluated to the array `allG` referred to *before* the call, while `allG` afterwards names the array `_process` built. The appended results are unreachable, and `lift` returns only what the last `_process` call found. `_process` now uses its own name for the result.

This pull request was written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)