### PR TITLE
Make `orbits` of G-sets faster (linear in the number of points, not quadratic in the number of orbits)

### DIFF
--- a/src/Groups/gsets.jl
+++ b/src/Groups/gsets.jl
@@ -604,11 +604,14 @@ julia> map(collect, orbs)
 """
 @attr Vector{GSetByElements{T,S}} function orbits(Omega::GSetByElements{T,S}) where {T <: Union{Group, FinGenAbGroup},S}
   orbs = GSetByElements{T,S}[]
+  # One shared set of seen points keeps this linear in the number of points.
+  seen = IndexedSet{S}()
   for p_ in Omega.seeds
     p = p_::S
-    if all(o -> !(p in o), orbs)
-      push!(orbs, orbit(Omega, p))
-    end
+    p in seen && continue
+    orb = orbit(Omega, p)
+    append!(seen, elements(orb))
+    push!(orbs, orb)
   end
   return orbs
 end


### PR DESCRIPTION
`orbits(::GSetByElements)` tested every seed against all orbits found so far, which is quadratic in the number of orbits. G-sets with many small orbits, e.g. a small permutation group acting on exponent vectors of monomials, took tens of seconds where a few milliseconds suffice. One shared `IndexedSet` of the points seen so far replaces the scan.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>