### PR TITLE
Fix `deepcopy` of collectors

### DIFF
--- a/src/Groups/pcgroup.jl
+++ b/src/Groups/pcgroup.jl
@@ -333,10 +333,17 @@ end
 
 # Create a collector independent of `c`.
 function Base.deepcopy_internal(c::GAP_Collector{T}, dict::IdDict) where T <: IntegerUnion
+  haskey(dict, c) && return dict[c]
+
   cc = GAP_Collector{T}(c.ngens,
-         deepcopy_internal(c.relorders, dict::IdDict),
-         deepcopy_internal(c.powers, dict::IdDict), 
-         deepcopy_internal(c.conjugates, dict::IdDict))
+         deepcopy_internal(c.relorders, dict),
+         deepcopy_internal(c.powers, dict),
+         deepcopy_internal(c.conjugates, dict))
+  dict[c] = cc
+
+  # The free group belongs to `c.X`, hence it fits also to the copy of `c.X`;
+  # it is not mutated, thus it need not be copied.
+  isdefined(c, :F) && (cc.F = c.F)
 
   # If the GAP collector has already been created then copy it.
   if isdefined(c, :X)

--- a/src/Groups/types.jl
+++ b/src/Groups/types.jl
@@ -1237,6 +1237,12 @@ mutable struct GAP_Collector{T} <: Collector{T}
                repeat([Pair{Int, T}[]], n), # default powers are identity
                Matrix{Vector{Pair{Int, T}}}(undef, n, n)) # conjugates undefined
   end
+
+  function GAP_Collector{T}(n::Int, relorders::Vector{T},
+                            powers::Vector{Vector{Pair{Int, T}}},
+                            conjugates::Matrix{Vector{Pair{Int, T}}}) where T <: IntegerUnion
+    return new(n, relorders, powers, conjugates)
+  end
 end
 
 ################################################################################

--- a/test/Groups/pcgroup.jl
+++ b/test/Groups/pcgroup.jl
@@ -89,6 +89,43 @@ end
   @test_throws ArgumentError set_relative_order!(c, 2, 3)
 end
 
+@testset "deepcopy collectors" begin
+  # a copy of a collector is independent of the original,
+  # also when the GAP collector has already been created
+  for create_gap_collector in [false, true]
+    # finite case: `c.X` is a GAP single collector
+    c = collector(2, Int)
+    set_relative_orders!(c, [2, 3])
+    set_conjugate!(c, 2, 1, [2 => 2])
+    create_gap_collector && pc_group(c)
+
+    cc = deepcopy(c)
+    @test get_relative_orders(cc) == get_relative_orders(c)
+    @test get_conjugate(cc, 2, 1) == get_conjugate(c, 2, 1)
+    @test !isdefined(c, :X) || cc.X !== c.X
+
+    set_conjugate!(cc, 2, 1, [2 => 1])
+    set_power!(cc, 1, [2 => 1])
+    @test get_conjugate(c, 2, 1) == [2 => 2]
+    @test get_power(c, 1) == Pair{Int, Int}[]
+    @test describe(pc_group(c)) == "S3"
+    @test describe(pc_group(cc)) == "C6"
+
+    # infinite case: `c.X` is a collector from the left
+    c = collector(2, Int)
+    set_relative_orders!(c, [2, 0])
+    set_conjugate!(c, 2, 1, [2 => -1])
+    create_gap_collector && pc_group(c)
+
+    cc = deepcopy(c)
+    @test !isdefined(c, :X) || cc.X !== c.X
+
+    set_relative_orders!(cc, [3, 0])
+    @test get_relative_orders(c) == [2, 0]
+    @test describe(pc_group(c)) == "an infinite group"
+  end
+end
+
 @testset "create letters from polycyclic group elements" begin
 
   # finite polycyclic groups


### PR DESCRIPTION
`Base.deepcopy_internal` for `GAP_Collector` called a constructor that does not exist, so any `deepcopy` of a collector threw a `MethodError`. Add the missing inner constructor, carry over the free group belonging to a stored GAP single collector, and preserve object identity via the `IdDict`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>