### PR TITLE
Split notes for users of other systems into pages

### DIFF
--- a/docs/doc.main
+++ b/docs/doc.main
@@ -3,7 +3,14 @@
 
   "General" => [
      "General/architecture.md",
-     "General/other.md",
+     "Notes for users of other systems" => [
+        "General/other/intro.md",
+        "General/other/gap.md",
+        "General/other/magma.md",
+        "General/other/sage.md",
+        "General/other/singular.md",
+        "General/other/polymake.md",
+     ],
      "General/printing.md",
      "General/faq.md",
      "General/serialization.md",

--- a/docs/src/General/other/gap.md
+++ b/docs/src/General/other/gap.md
@@ -1,16 +1,6 @@
-# Notes for users of other computer algebra systems
+# Notes for GAP users
 
-## General differences
-
-- Julia evaluates `2^100` to `0` because `2` is regarded as a 64 bit integer.
-  Write `ZZRingElem(2)^100` to get a long.
-
-- OSCAR makes a subtle but important [distinction between `/` and `//`](@ref subtle_distinction_for_rings).
-
-
-## Notes for GAP users
-
-This section describes differences between GAP and Oscar.
+This page describes differences between GAP and Oscar.
 (Hints about using GAP in OSCAR can be found in the section about
 [GAP Integration](@ref).)
 
@@ -141,34 +131,3 @@ This section describes differences between GAP and Oscar.
   For the same reason, `transitive_group` in OSCAR supports degree 1,
   where the trivial group is the unique transitive group,
   whereas GAP's library of transitive groups starts at degree 2.
-
-
-## Notes for Polymake users
-
-- OSCAR (and Julia) is `1`-based, meaning that it counts from `1`, rather than
-  from `0` like polymake. For most properties we have taken care of the
-  translation but be aware that it might pop up at some point and generate
-  confusion.
-
-  For convenience, `Polymake.jl` provides `Polymake.to_one_based_indexing` and
-  `Polymake.to_zero_based_indexing`.
-
-- Polyhedra and polyhedral complexes in OSCAR are represented inhomogeneously,
-  i.e. without the leading `1` for vertices or `0` for rays. Hence constructors
-  take points, rays, and lineality generators separately.
-
-- `user_method`s cannot be accessed via Julia's dot syntax, i.e. something like
-
-  ```julia
-  c = Polymake.polytope.cube(3)
-  c.AMBIENT_DIM
-  ```
-
-  will not work. Instead `user_method`s are attached as Julia functions in
-  their respective application. They are always written in lowercase. In the
-  example the following works:
-
-  ```julia
-  c = Polymake.polytope.cube(3)
-  Polymake.polytope.ambient_dim(c)
-  ```

--- a/docs/src/General/other/intro.md
+++ b/docs/src/General/other/intro.md
@@ -1,0 +1,26 @@
+# Notes for users of other computer algebra systems
+
+This page collects differences that affect users of all such systems.
+Notes for users of specific systems follow on separate pages:
+
+- [Notes for GAP users](@ref)
+- [Notes for Magma users](@ref)
+- [Notes for SageMath users](@ref)
+- [Notes for Singular users](@ref)
+- [Notes for polymake users](@ref)
+
+!!! note "Help wanted"
+    These pages are far from complete.
+    If you are missing something here, or if a difference between OSCAR and
+    the system you know took you a while to understand,
+    please tell us about it, for example by opening an
+    [issue on GitHub](https://github.com/oscar-system/Oscar.jl/issues)
+    or on [Slack](https://oscar-system.org/slack).
+    Contributions to these pages are very welcome.
+
+## General differences
+
+- Julia evaluates `2^100` to `0` because `2` is regarded as a 64 bit integer.
+  Write `ZZRingElem(2)^100` to get a long.
+
+- OSCAR makes a subtle but important [distinction between `/` and `//`](@ref subtle_distinction_for_rings).

--- a/docs/src/General/other/magma.md
+++ b/docs/src/General/other/magma.md
@@ -1,0 +1,6 @@
+# Notes for Magma users
+
+!!! note "Help wanted"
+    There really should be more here.
+    Please tell us what is missing, see
+    [Notes for users of other computer algebra systems](@ref).

--- a/docs/src/General/other/polymake.md
+++ b/docs/src/General/other/polymake.md
@@ -1,0 +1,29 @@
+# Notes for polymake users
+
+- OSCAR (and Julia) is `1`-based, meaning that it counts from `1`, rather than
+  from `0` like polymake. For most properties we have taken care of the
+  translation but be aware that it might pop up at some point and generate
+  confusion.
+
+  For convenience, `Polymake.jl` provides `Polymake.to_one_based_indexing` and
+  `Polymake.to_zero_based_indexing`.
+
+- Polyhedra and polyhedral complexes in OSCAR are represented inhomogeneously,
+  i.e. without the leading `1` for vertices or `0` for rays. Hence constructors
+  take points, rays, and lineality generators separately.
+
+- `user_method`s cannot be accessed via Julia's dot syntax, i.e. something like
+
+  ```julia
+  c = Polymake.polytope.cube(3)
+  c.AMBIENT_DIM
+  ```
+
+  will not work. Instead `user_method`s are attached as Julia functions in
+  their respective application. They are always written in lowercase. In the
+  example the following works:
+
+  ```julia
+  c = Polymake.polytope.cube(3)
+  Polymake.polytope.ambient_dim(c)
+  ```

--- a/docs/src/General/other/sage.md
+++ b/docs/src/General/other/sage.md
@@ -1,0 +1,6 @@
+# Notes for SageMath users
+
+!!! note "Help wanted"
+    There really should be more here.
+    Please tell us what is missing, see
+    [Notes for users of other computer algebra systems](@ref).

--- a/docs/src/General/other/singular.md
+++ b/docs/src/General/other/singular.md
@@ -1,0 +1,6 @@
+# Notes for Singular users
+
+!!! note "Help wanted"
+    There really should be more here.
+    Please tell us what is missing, see
+    [Notes for users of other computer algebra systems](@ref).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,6 +29,9 @@ in OSCAR. While they offer a glimpse into OSCAR's powerful features, they only s
 For a deeper understanding, explore the detailed documentation you are reading now. Do not forget
 to use the search field (top left corner) to quickly find information on the features you need.
 
+If you already have experience with other computer algebra systems, have a look at our
+[notes for users of other computer algebra systems](@ref "Notes for users of other computer algebra systems").
+
 We would love your feedback on our tutorials! Whether it is suggestions for improving existing
 ones or ideas for new topics, your input helps us grow.
 


### PR DESCRIPTION
Turn the single page into a subsection with one page per system (GAP, Magma, SageMath, Singular, polymake) plus an intro page that keeps the general remarks and links to the system pages. The GAP and polymake pages carry the existing content, the other three are stubs asking for contributions. The front page now points to the notes.

This pull request was written with the assistance of generative AI (Claude Code).

First step towards resolving issue #5299 and beyond (more PRs are already in preparation)