### PR TITLE
Fix docs lookup for `matrix_repr(::LinearLieAlgebraElem)`

### DIFF
--- a/experimental/LieAlgebras/src/LinearLieAlgebra.jl
+++ b/experimental/LieAlgebras/src/LinearLieAlgebra.jl
@@ -158,7 +158,7 @@ end
 
 Return the Lie algebra element `x` in the underlying matrix representation.
 """
-function Generic.matrix_repr(x::LinearLieAlgebraElem)
+function Generic.matrix_repr(x::LinearLieAlgebraElem{C}) where {C<:FieldElem}
   L = parent(x)
   mat = zero_matrix(coefficient_ring(L), L.n, L.n)
   tmp = zero(mat)


### PR DESCRIPTION
The `@docs` entry in `lie_algebras.md` carries `where {C<:FieldElem}`, which Documenter never matched against the unbounded method. It fell back to AbstractAlgebra's `matrix_repr(::YoungTableau{T}) where T` docstring, so the rendered page showed the tableau docstring under this heading. Bound the method like `matrix_repr_basis` so the entry resolves to its own docstring.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>