### PR TITLE
Avoid redundant work when collecting monomial bases

### DIFF
--- a/src/AlgebraicGeometry/Schemes/Divisors/WeilDivisor.jl
+++ b/src/AlgebraicGeometry/Schemes/Divisors/WeilDivisor.jl
@@ -584,10 +584,7 @@ function _subsystem(L::LinearSystem, P::AbsIdealSheaf, n; covering::Covering=sim
     push!(images, normal_form(a, pPw))
   end
   # collect a monomial basis in which to represent the results
-  all_mons = elem_type(R)[]
-  for b in images
-    all_mons = vcat(all_mons, [m for m in monomials(b) if !(b in all_mons)])
-  end
+  all_mons = unique!(elem_type(R)[m for b in images for m in monomials(b)])
 
   kk = base_ring(X)
   A = zero_matrix(kk, ngens(L), length(all_mons))

--- a/src/Rings/mpolyquo-localizations.jl
+++ b/src/Rings/mpolyquo-localizations.jl
@@ -2395,7 +2395,7 @@ function vector_space(kk::Field, W::MPolyQuoLocRing{<:Field, <:FieldElem,
       done = true
       break
     end
-    V_gens = vcat(V_gens, [m for m in monomials_of_degree(R, d) if !(m in lead_I)])
+    append!(V_gens, inc)
     d = d + 1
   end
 


### PR DESCRIPTION
The duplicate filter in `_subsystem` tested the polynomial `b` for membership in the list of monomials collected so far, instead of the monomial `m`. It therefore practically never fired and `all_mons` accumulated duplicates. Results were unaffected, since the duplicate columns of the coefficient matrix are zero and thus do not contribute to its left kernel, but the matrix was wider than necessary and every lookup scanned a longer list.

In `vector_space` for an `MPolyQuoLocRing` the monomials outside the leading ideal were computed twice per degree, once for the emptiness test and once again for the concatenation.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


(Found this when we looked at "ridiculous" changes in PR #6238 -- I later realized that the `all_mons` example we looked was weird even before the changes in that PR 😂 )