### PR TITLE
Schemes: Replace`x = vcat(x, y)` by `append!(x, y)` 

### DIFF
--- a/src/AlgebraicGeometry/Schemes/AffineSchemeOpenSubscheme/Rings/Constructors.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemeOpenSubscheme/Rings/Constructors.jl
@@ -261,7 +261,7 @@ function subscheme(U::AffineSchemeOpenSubscheme, g::Vector{T}) where {T<:AffineS
   X = ambient_scheme(U)
   gen_list = Vector{elem_type(OO(X))}()
   for f in g
-    gen_list = vcat(gen_list, OO(X).([lifted_numerator(f[i]) for i in 1:ngens(U)]))
+    append!(gen_list, OO(X).([lifted_numerator(f[i]) for i in 1:ngens(U)]))
   end
   Z = subscheme(X, gen_list)
   return AffineSchemeOpenSubscheme(Z, complement_equations(U))

--- a/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
+++ b/src/AlgebraicGeometry/Schemes/AffineSchemes/Objects/Attributes.jl
@@ -717,8 +717,7 @@ end
 
 # internal workhorse, not user-facing
 function _singular_locus_with_decomposition(X::AbsAffineScheme{<:Field, <:MPAnyQuoRing}, reduced::Bool=true)
-  empty = AbsAffineScheme[]
-  result = empty
+  result = AbsAffineScheme[]
   is_zero(ngens(OO(X))) && return result # Shortcut needed to avoid creating polynomial rings with zero variables
   I = saturated_ideal(modulus(OO(X)))
 
@@ -744,7 +743,7 @@ function _singular_locus_with_decomposition(X::AbsAffineScheme{<:Field, <:MPAnyQ
     minvec = minors(M, n-d)
     J = ideal(R, minvec)
     JX = ideal(OO(X),minvec)
-    one(OO(X)) in JX && return empty
+    one(OO(X)) in JX && return AbsAffineScheme[]
     return [subscheme(X, J)]
   else
 # if reducible, determine pairwise intersection loci
@@ -759,9 +758,9 @@ function _singular_locus_with_decomposition(X::AbsAffineScheme{<:Field, <:MPAnyQ
     end
 # and singular loci of components
     for Y in components
-      result = vcat(result, singular_locus(Y)[1])
+      push!(result, singular_locus(Y)[1])
     end
-  #one(OO(X)) in result && return empty
+  #one(OO(X)) in result && return AbsAffineScheme[]
   end
   return result
 end

--- a/src/AlgebraicGeometry/Schemes/CoveredSchemes/Morphisms/MorphismFromRationalFunctions/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/CoveredSchemes/Morphisms/MorphismFromRationalFunctions/Methods.jl
@@ -732,8 +732,8 @@ function _pullback(phi::MorphismFromRationalFunctions, I::PrimeIdealSheafFromCha
   U = affine_charts(X)
 
   cod_patches = AbsAffineScheme[V0]
-  cod_patches = vcat(cod_patches, [U for U in keys(object_cache(I)) if any(x->x===U, affine_charts(Y))])
-  cod_patches = vcat(cod_patches, [U for U in affine_charts(Y) if !any(x->x===U, cod_patches)])
+  append!(cod_patches, [U for U in keys(object_cache(I)) if any(x->x===U, affine_charts(Y))])
+  append!(cod_patches, [U for U in affine_charts(Y) if !any(x->x===U, cod_patches)])
   for U0 in U
     I_undef = ideal(OO(U0), elem_type(OO(U0))[])
     random_realizations = IdDict{AbsAffineScheme, AbsAffineSchemeMor}()

--- a/src/AlgebraicGeometry/Schemes/Covering/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/Covering/Objects/Methods.jl
@@ -177,7 +177,7 @@ function all_patches(C::Covering)
     push!(result, U)
     if haskey(affine_refinements(C), U)
       for (W, a) in affine_refinements(C)[U]
-        result = vcat(result, affine_patches(W))
+        append!(result, affine_patches(W))
       end
     end
   end

--- a/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
+++ b/src/AlgebraicGeometry/Schemes/ProjectiveSchemes/Objects/Methods.jl
@@ -290,7 +290,7 @@ function _homogenization_map(P::AbsProjectiveScheme{<:MPolyAnyRing, <:MPolyDecRi
   v = copy(gens(S))
   # prepare a vector of elements on which to evaluate the lifts
   popat!(v, i)
-  v = vcat(v, S.(gens(B)))
+  append!(v, S.(gens(B)))
   function my_dehom(a::RingElem)
     parent(a) === OO(U) || error("element does not belong to the correct ring")
     p = lifted_numerator(a)
@@ -335,7 +335,7 @@ function _homogenization_map(P::AbsProjectiveScheme{<:MPolyAnyRing, <:MPolyQuoRi
   v = copy(gens(S))
   # prepare a vector of elements on which to evaluate the lifts
   popat!(v, i)
-  v = vcat(v, S.(gens(B)))
+  append!(v, S.(gens(B)))
   function my_dehom(a::RingElem)
     parent(a) === OO(U) || error("element does not belong to the correct ring")
     p = lifted_numerator(a)

--- a/src/AlgebraicGeometry/Schemes/Sheaves/CoherentSheaves.jl
+++ b/src/AlgebraicGeometry/Schemes/Sheaves/CoherentSheaves.jl
@@ -1044,7 +1044,7 @@ end
   OOX = OO(X)
   patch_list = Vector{AbsAffineScheme}()
   for U in affine_charts(X)
-    patch_list = vcat(patch_list, _trivializing_covering(M, U))
+    append!(patch_list, _trivializing_covering(M, U))
   end
   C = Covering(patch_list)
   inherit_gluings!(C, default_covering(X))
@@ -1181,7 +1181,7 @@ function _trivializing_covering(M::AbsCoherentSheaf, U::AbsAffineScheme)
       MV, res = change_base_ring(rho, MU)
       add_incoming_restriction!(M, U, MV, res)
       object_cache(M)[V] = MV
-      return_patches = vcat(return_patches, _trivializing_covering(M, V))
+      append!(return_patches, _trivializing_covering(M, V))
     end
     return return_patches
   end
@@ -1261,7 +1261,7 @@ function _trivializing_covering(M::AbsCoherentSheaf, U::AbsAffineScheme)
       add_incoming_restriction!(M, U, MV, res)
       object_cache(M)[V] = MV
       set_attribute!(MV, :_presentation_matrix, Asub)
-      return_patches = vcat(return_patches, _trivializing_covering(M, V))
+      append!(return_patches, _trivializing_covering(M, V))
     end
   end
   return return_patches

--- a/src/AlgebraicGeometry/Schemes/Sheaves/IdealSheaves.jl
+++ b/src/AlgebraicGeometry/Schemes/Sheaves/IdealSheaves.jl
@@ -1440,7 +1440,7 @@ function _separate_disjoint_components(comp::Vector{<:AbsIdealSheaf}; covering::
     if isempty(cof)
       push!(new_patches, U)
     else
-      new_patches = vcat(new_patches, [PrincipalOpenSubset(U, a) for a in cof])
+      append!(new_patches, [PrincipalOpenSubset(U, a) for a in cof])
     end
   end
   new_cov = Covering(new_patches)


### PR DESCRIPTION
Rebinding `x = vcat(x, y)` inside a loop copies the whole list on every iteration. Where the accumulator is a freshly created vector, `append!` does the same job in place.

In `_singular_locus_with_decomposition` the appended value is a single scheme rather than a list, so `push!` applies there. Its result vector used to alias the local `empty`, which is now gone in favour of writing out the empty vector at the one place that returns it.

The two `product` methods keep their `vcat`: their accumulator may be `symbols(R)`, which is the polynomial ring's own vector, so appending in place would corrupt the ring.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>