### PR TITLE
Fix error paths for right scalar multiplication

### DIFF
--- a/src/Modules/UngradedModules/FreeModElem.jl
+++ b/src/Modules/UngradedModules/FreeModElem.jl
@@ -263,7 +263,7 @@ function *(b::AbstractFreeModElem{T}, a::T) where {T <: AdmissibleOFPModuleRingE
   error("right multiplication is not supported at the moment")
 end
 
-function *(b::AbstractFreeModElem{T}, a::Any) where {T <: RingElem}
+function *(b::AbstractFreeModElem, a::Any)
   error("scalar multiplication from the right is not yet supported")
 end
 
@@ -275,11 +275,11 @@ is_left(M::OFPModule) = is_left(typeof(M))
 is_left(::Type{T}) where {RET<:RingElem, T<:OFPModule{RET}} = true
 is_left(::Type{T}) where {RET<:AdmissibleOFPModuleRingElem, T<:OFPModule{RET}} = true # Left multiplication is generically supported
 
-is_right(M::OFPModule) = is_right_module(typeof(M))
+is_right(M::OFPModule) = is_right(typeof(M))
 is_right(::Type{T}) where {RET<:RingElem, T<:OFPModule{RET}} = true
 is_right(::Type{T}) where {RET<:AdmissibleOFPModuleRingElem, T<:OFPModule{RET}} = false # Right multiplication is not supported by the generic code at the moment, but we plan to do so eventually. 
 
-is_two_sided(M::OFPModule) = is_right_module(typeof(M))
+is_two_sided(M::OFPModule) = is_two_sided(typeof(M))
 is_two_sided(::Type{T}) where {RET<:RingElem, T<:OFPModule{RET}} = true
 is_two_sided(::Type{T}) where {RET<:AdmissibleOFPModuleRingElem, T<:OFPModule{RET}} = false # see above
 

--- a/test/Modules/PBWModules.jl
+++ b/test/Modules/PBWModules.jl
@@ -58,3 +58,12 @@ end
     #@test !is_canonically_isomorphic(Q2,Q1)
     #simplify(Q[1])
 end
+
+@testset "right scalar multiplication is rejected" begin
+    # free modules over a PBW algebra are left modules only
+    E, x = exterior_algebra(QQ, 3)
+    M = FreeMod(E, 3)
+
+    @test !is_zero(x[1]*M[1])
+    @test_throws AssertionError M[1]*x[1]
+end

--- a/test/Modules/UngradedModules.jl
+++ b/test/Modules/UngradedModules.jl
@@ -2219,3 +2219,12 @@ end
   @test normal_form(v, SB) == -x*F[3]
   @test normal_form(w, SB) == zero(F)
 end
+
+@testset "right scalar multiplication is not supported" begin
+  # right multiplication is rejected by its own error, not by a dispatch ambiguity
+  R, (x, y) = polynomial_ring(QQ, [:x, :y])
+  F = free_module(R, 2)
+
+  @test_throws ErrorException F[1]*x
+  @test_throws ErrorException F[1]*2
+end


### PR DESCRIPTION
Right scalar multiplication on free module elements is meant to be refused with a clear message, but two defects got in the way.

The generic refusal was bounded by `RingElem`, which made it compete with the mirror of the left-hand `AdmissibleOFPModuleRingElem` method: each is more specific in one argument, so `M[1]*x` over a commutative base ring raised a dispatch ambiguity instead. Drop that bound so the signature mirrors the left-hand side and the more specific method wins.

`is_right` and `is_two_sided` dispatched to a non-existent `is_right_module`, so the sidedness check guarding that refusal raised `UndefVarError` instead of reporting that a module over a PBW algebra is not a right module.

Whether right multiplication should be supported over commutative base rings is deliberately left open here.

Assisted-By: Claude Opus 5 <noreply@anthropic.com>