### PR TITLE
Fix `rand` for graded polynomial rings

### DIFF
--- a/src/Rings/mpoly-graded.jl
+++ b/src/Rings/mpoly-graded.jl
@@ -2373,22 +2373,23 @@ end
 #create homogeneous polynomials in graded rings
 #TODO: make this work for non-standard gradings
 @doc raw"""
-    rand(S::MPolyDecRing, term_range, deg_range, v...)
+    rand([rng::Random.AbstractRNG,] S::MPolyDecRing, term_range::UnitRange{Int}, deg_range::UnitRange{Int}, v...)
 
 Create a random homogeneous polynomial with a random number of
 terms (`rand(term_range)`) and of random degree (`rand(deg_range)`)
 and random coefficients via `v...`.
 """
-function rand(S::MPolyDecRing, term_range, deg_range, v...)
+function rand(rng::Random.AbstractRNG, S::MPolyDecRing,
+              term_range::UnitRange{Int}, deg_range::UnitRange{Int}, v...)
   f = zero(forget_decoration(S))
-  d = rand(deg_range)
-  for i=1:rand(term_range)
-    t = forget_decoration(S)(rand(base_ring(S), v...))
+  d = rand(rng, deg_range)
+  for i=1:rand(rng, term_range)
+    t = forget_decoration(S)(rand(rng, base_ring(S), v...))
     if iszero(t)
       continue
     end
     for j=1:ngens(forget_decoration(S))-1
-      t *= gen(forget_decoration(S), j)^rand(0:(d-total_degree(t)))
+      t *= gen(forget_decoration(S), j)^rand(rng, 0:(d-total_degree(t)))
     end
     #the last exponent is deterministic...
     t *= gen(forget_decoration(S), ngens(forget_decoration(S)))^(d-total_degree(t))
@@ -2396,6 +2397,9 @@ function rand(S::MPolyDecRing, term_range, deg_range, v...)
   end
   return S(f)
 end
+
+rand(S::MPolyDecRing, term_range::UnitRange{Int}, deg_range::UnitRange{Int}, v...) =
+  rand(Random.default_rng(), S, term_range, deg_range, v...)
 
 ################################################################################
 #

--- a/test/Rings/mpoly-graded.jl
+++ b/test/Rings/mpoly-graded.jl
@@ -326,6 +326,14 @@ end
     for i in 1:100
       f = rand(R, 5:10, 1:10, 1:100)
       @test parent(f) === R
+
+      # a graded ring yields homogeneous polynomials, with or without an
+      # explicit rng
+      for g in (rand(S, 5:10, 1:10, 1:100),
+                rand(Random.default_rng(), S, 5:10, 1:10, 1:100))
+        @test parent(g) === S
+        @test is_homogeneous(g)
+      end
     end
   end
 end


### PR DESCRIPTION
AbstractAlgebra is typing the range parameters of its `rand` methods so that they no longer clash with the `rand(X, args...)` methods of Random and RandomExtensions, which leave `X` untyped; see Nemocas/AbstractAlgebra.jl#2509. Against that, `rand(::MPolyDecRing, ::UnitRange{Int}, ::UnitRange{Int}, ::UnitRange{Int})` is ambiguous, being more specific in `S` alone and less specific in the two ranges. Match `rand(::MPolyRing, ::UnitRange{Int}, ::UnitRange{Int}, ...)` exactly.

Independently of that, only the rng-less method was ever defined, so passing an rng fell through to `rand(::AbstractRNG, ::MPolyRing, ...)` in AbstractAlgebra, which knows nothing about the grading and reads the third argument as an exponent bound rather than a degree range. The result was silently inhomogeneous. Define the rng-taking method and let the rng-less one forward to it, as AbstractAlgebra does for its own ring types.

The existing testset built a graded ring but only ever drew from the underlying ungraded one, which is why this went unnoticed; it now covers both forms.

Assisted-by: Claude Code (Opus 5)

---

Needed to unblock https://github.com/Nemocas/AbstractAlgebra.jl/pull/2509 which in turn I'd like for a new breaking AA release.